### PR TITLE
feat(examples): Add image-preprocessing and realtime-video SDK examples

### DIFF
--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -447,6 +447,57 @@ func (c *Conversation) SendText(ctx context.Context, text string) error {
 	return c.duplexSession.SendText(ctx, text)
 }
 
+// SendFrame sends an image frame in duplex mode for realtime video scenarios.
+// Only available when the conversation was opened with OpenDuplex().
+//
+// Example:
+//
+//	frame := &session.ImageFrame{
+//	    Data:      jpegBytes,
+//	    MIMEType:  "image/jpeg",
+//	    Timestamp: time.Now(),
+//	}
+//	conv.SendFrame(ctx, frame)
+func (c *Conversation) SendFrame(ctx context.Context, frame *session.ImageFrame) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.mode != DuplexMode {
+		return fmt.Errorf(errDuplexModeRequired, "SendFrame()")
+	}
+	if c.closed {
+		return ErrConversationClosed
+	}
+
+	return c.duplexSession.SendFrame(ctx, frame)
+}
+
+// SendVideoChunk sends a video chunk in duplex mode for encoded video streaming.
+// Only available when the conversation was opened with OpenDuplex().
+//
+// Example:
+//
+//	chunk := &session.VideoChunk{
+//	    Data:       h264Data,
+//	    MIMEType:   "video/h264",
+//	    IsKeyFrame: true,
+//	    Timestamp:  time.Now(),
+//	}
+//	conv.SendVideoChunk(ctx, chunk)
+func (c *Conversation) SendVideoChunk(ctx context.Context, chunk *session.VideoChunk) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.mode != DuplexMode {
+		return fmt.Errorf(errDuplexModeRequired, "SendVideoChunk()")
+	}
+	if c.closed {
+		return ErrConversationClosed
+	}
+
+	return c.duplexSession.SendVideoChunk(ctx, chunk)
+}
+
 // TriggerStart sends a text message to make the model initiate the conversation.
 // Use this in ASM mode when you want the model to speak first (e.g., introducing itself).
 // Only available when the conversation was opened with OpenDuplex().

--- a/sdk/examples/README.md
+++ b/sdk/examples/README.md
@@ -27,6 +27,18 @@ Basic streaming example showing real-time LLM responses.
 ### 🎨 [multimodal](./multimodal/)
 Working with images, audio, and other media types.
 
+### 🖼️ [image-preprocessing](./image-preprocessing/)
+Automatic image resizing and optimization for vision models.
+- `WithAutoResize()` for simple size limits
+- `WithImagePreprocessing()` for full control
+- Quality optimization for API costs and latency
+
+### 🎥 [realtime-video](./realtime-video/)
+Realtime video/image streaming for duplex sessions.
+- `SendFrame()` for webcam-like scenarios
+- `WithStreamingVideo()` for frame rate limiting
+- Simulated frame capture example
+
 ### 🛠️ [tools](./tools/)
 Function calling and tool integration.
 

--- a/sdk/examples/image-preprocessing/README.md
+++ b/sdk/examples/image-preprocessing/README.md
@@ -1,0 +1,69 @@
+# Image Preprocessing Example
+
+This example demonstrates the image preprocessing capabilities of the PromptKit SDK for optimizing images before sending them to vision models.
+
+## Features Demonstrated
+
+- **WithAutoResize**: Simple option to automatically resize large images
+- **WithImagePreprocessing**: Full control over preprocessing configuration
+- **Quality optimization**: Configure JPEG quality for the best balance of size and clarity
+- **Streaming support**: Preprocessing works with both `Send()` and `Stream()`
+
+## Why Image Preprocessing?
+
+1. **Cost reduction**: Smaller images = fewer tokens = lower API costs
+2. **Faster responses**: Less data to transmit and process
+3. **Consistent quality**: Ensure images meet model requirements
+4. **Automatic handling**: No manual image manipulation needed
+
+## Usage
+
+```bash
+export GEMINI_API_KEY=your-key
+go run .
+```
+
+## Configuration Options
+
+### Simple: WithAutoResize
+
+```go
+conv, err := sdk.Open(
+    "./pack.json",
+    "vision",
+    sdk.WithAutoResize(1024, 1024), // Max dimensions
+)
+```
+
+### Advanced: WithImagePreprocessing
+
+```go
+conv, err := sdk.Open(
+    "./pack.json",
+    "vision",
+    sdk.WithImagePreprocessing(&stage.ImagePreprocessConfig{
+        Resize: stage.ImageResizeStageConfig{
+            MaxWidth:  800,
+            MaxHeight: 600,
+            Quality:   90,  // JPEG quality (1-100)
+        },
+        EnableResize: true,
+    }),
+)
+```
+
+## How It Works
+
+1. When you call `Send()` or `Stream()` with an image, the SDK:
+2. Downloads or reads the image data
+3. Checks if resizing is needed based on your configuration
+4. Resizes maintaining aspect ratio if the image exceeds limits
+5. Re-encodes as JPEG with the specified quality
+6. Sends the optimized image to the vision model
+
+## Best Practices
+
+- **1024x1024** is a good default for most vision models
+- **Quality 85** provides a good balance of size and clarity
+- For detailed analysis, use higher max dimensions (2048x2048)
+- For quick classification tasks, smaller sizes (512x512) work well

--- a/sdk/examples/image-preprocessing/image-preprocessing.pack.json
+++ b/sdk/examples/image-preprocessing/image-preprocessing.pack.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "image-preprocessing-example",
+  "name": "Image Preprocessing Example",
+  "version": "1.0.0",
+  "description": "Example demonstrating image preprocessing with automatic resizing and optimization",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "vision-analyst": {
+      "id": "vision-analyst",
+      "name": "Vision Analyst",
+      "version": "1.0.0",
+      "system_template": "You are an expert visual analyst. When shown images, provide detailed, accurate descriptions. Note any quality issues or artifacts you observe in the image.",
+      "parameters": {
+        "temperature": 0.7,
+        "max_tokens": 1024
+      }
+    }
+  }
+}

--- a/sdk/examples/image-preprocessing/main.go
+++ b/sdk/examples/image-preprocessing/main.go
@@ -1,0 +1,117 @@
+// Package main demonstrates image preprocessing capabilities with the PromptKit SDK.
+//
+// This example shows:
+//   - Automatic image resizing with WithAutoResize
+//   - Custom image preprocessing with WithImagePreprocessing
+//   - Quality optimization for LLM vision models
+//
+// Run with:
+//
+//	export GEMINI_API_KEY=your-key
+//	go run .
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Example 1: Using WithAutoResize for simple resizing
+	fmt.Println("=== Example 1: Auto-Resize (1024x1024 max) ===")
+	fmt.Println()
+
+	conv1, err := sdk.Open(
+		"./image-preprocessing.pack.json",
+		"vision-analyst",
+		sdk.WithAutoResize(1024, 1024), // Resize large images to max 1024x1024
+	)
+	if err != nil {
+		log.Fatalf("Failed to open pack: %v", err)
+	}
+	defer conv1.Close()
+
+	// Using a high-resolution image that will be automatically resized
+	imageURL := "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/1280px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg"
+
+	fmt.Println("Analyzing high-resolution image (will be auto-resized)...")
+	fmt.Println()
+
+	resp, err := conv1.Send(ctx, "Describe this famous painting. What artistic techniques do you notice?",
+		sdk.WithImageURL(imageURL),
+	)
+	if err != nil {
+		log.Printf("Error: %v", err)
+	} else {
+		fmt.Println(resp.Text())
+	}
+
+	// Example 2: Using WithImagePreprocessing for full control
+	fmt.Println("\n=== Example 2: Custom Preprocessing ===")
+	fmt.Println()
+
+	conv2, err := sdk.Open(
+		"./image-preprocessing.pack.json",
+		"vision-analyst",
+		sdk.WithImagePreprocessing(&stage.ImagePreprocessConfig{
+			Resize: stage.ImageResizeStageConfig{
+				MaxWidth:  800,
+				MaxHeight: 600,
+				Quality:   90, // Higher quality JPEG
+			},
+			EnableResize: true,
+		}),
+	)
+	if err != nil {
+		log.Fatalf("Failed to open pack: %v", err)
+	}
+	defer conv2.Close()
+
+	// Another high-resolution image
+	photoURL := "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Sunrise_over_the_sea.jpg/1280px-Sunrise_over_the_sea.jpg"
+
+	fmt.Println("Analyzing with custom preprocessing (800x600 max, 90% quality)...")
+	fmt.Println()
+
+	resp2, err := conv2.Send(ctx, "What time of day is shown in this photograph? Describe the lighting.",
+		sdk.WithImageURL(photoURL),
+	)
+	if err != nil {
+		log.Printf("Error: %v", err)
+	} else {
+		fmt.Println(resp2.Text())
+	}
+
+	// Example 3: Streaming with preprocessing
+	fmt.Println("\n=== Example 3: Streaming with Auto-Resize ===")
+	fmt.Println()
+
+	fmt.Println("Streaming analysis of preprocessed image...")
+	fmt.Println()
+
+	for chunk := range conv1.Stream(ctx, "What emotions does this artwork evoke? Be specific about visual elements that create those feelings.") {
+		if chunk.Error != nil {
+			log.Printf("Error: %v", chunk.Error)
+			break
+		}
+		if chunk.Type == sdk.ChunkDone {
+			fmt.Println("\n\n[Complete]")
+			break
+		}
+		fmt.Print(chunk.Text)
+	}
+
+	fmt.Println("\n=== Examples Complete ===")
+	fmt.Println()
+	fmt.Println("Image preprocessing automatically:")
+	fmt.Println("  - Resizes large images to reduce API costs and latency")
+	fmt.Println("  - Maintains aspect ratio during resizing")
+	fmt.Println("  - Optimizes JPEG quality for vision models")
+	fmt.Println("  - Works seamlessly with both Send() and Stream()")
+}

--- a/sdk/examples/realtime-video/README.md
+++ b/sdk/examples/realtime-video/README.md
@@ -1,0 +1,126 @@
+# Realtime Video Streaming Example
+
+This example demonstrates how to stream video frames to an LLM for real-time vision analysis using PromptKit's duplex session capabilities.
+
+## Features Demonstrated
+
+- **OpenDuplex with video**: Opening a bidirectional streaming session for video
+- **WithStreamingVideo**: Configuring frame rate limiting and preprocessing
+- **SendFrame()**: Sending individual image frames to the session
+- **Frame rate limiting**: Automatic dropping of excess frames to match LLM processing speed
+
+## Use Cases
+
+- **Webcam analysis**: Real-time description of what a webcam sees
+- **Screen sharing**: Analyzing screen content as it changes
+- **Security monitoring**: Continuous analysis of camera feeds
+- **Accessibility**: Describing visual content for users with visual impairments
+
+## Usage
+
+```bash
+export GEMINI_API_KEY=your-key
+go run .
+```
+
+## How It Works
+
+### 1. Open a Duplex Session with Video Config
+
+```go
+conv, err := sdk.OpenDuplex(
+    "./pack.json",
+    "vision-stream",
+    sdk.WithStreamingVideo(&sdk.VideoStreamConfig{
+        TargetFPS:    1.0,   // Process 1 frame per second
+        MaxWidth:     1024,  // Resize large frames
+        MaxHeight:    1024,
+        Quality:      85,    // JPEG quality
+        EnableResize: true,
+    }),
+)
+```
+
+### 2. Send Frames
+
+```go
+frame := &session.ImageFrame{
+    Data:      jpegBytes,
+    MIMEType:  "image/jpeg",
+    Width:     640,
+    Height:    480,
+    FrameNum:  frameCount,
+    Timestamp: time.Now(),
+}
+err = conv.SendFrame(ctx, frame)
+```
+
+### 3. Receive Responses
+
+```go
+for chunk := range conv.Response() {
+    if chunk.Content != "" {
+        fmt.Print(chunk.Content)
+    }
+}
+```
+
+## Frame Rate Limiting
+
+The `TargetFPS` setting automatically drops excess frames:
+
+- **Webcam at 30 FPS** → With `TargetFPS: 1.0`, only ~1 frame/second reaches the LLM
+- **No frame loss**: The most recent frame is kept, older frames are dropped
+- **Reduces costs**: Fewer frames = fewer tokens = lower API costs
+
+## Video Chunk Streaming
+
+For encoded video segments (H.264, VP8, etc.), use `SendVideoChunk()`:
+
+```go
+chunk := &session.VideoChunk{
+    Data:       h264Data,
+    MIMEType:   "video/h264",
+    ChunkIndex: 0,
+    IsKeyFrame: true,
+    Timestamp:  time.Now(),
+}
+err = conv.SendVideoChunk(ctx, chunk)
+```
+
+## Real-World Integration
+
+In a real application, replace the simulated frames with actual capture:
+
+### Using gocv (OpenCV for Go)
+
+```go
+import "gocv.io/x/gocv"
+
+webcam, _ := gocv.VideoCaptureDevice(0)
+defer webcam.Close()
+
+mat := gocv.NewMat()
+defer mat.Close()
+
+for webcam.Read(&mat) {
+    // Encode to JPEG
+    buf, _ := gocv.IMEncode(".jpg", mat)
+
+    frame := &session.ImageFrame{
+        Data:      buf.GetBytes(),
+        MIMEType:  "image/jpeg",
+        Timestamp: time.Now(),
+    }
+    conv.SendFrame(ctx, frame)
+}
+```
+
+## Provider Support
+
+Currently, realtime video streaming works best with providers that support bidirectional streaming:
+
+- **Gemini Live API**: Full support for real-time vision (when available)
+- **OpenAI Realtime**: Audio-focused, video support may be added later
+
+The SDK is provider-agnostic - video frames flow through when the provider supports them.

--- a/sdk/examples/realtime-video/main.go
+++ b/sdk/examples/realtime-video/main.go
@@ -1,0 +1,202 @@
+// Package main demonstrates realtime video/image streaming with the PromptKit SDK.
+//
+// This example shows:
+//   - Opening a duplex session with video streaming enabled
+//   - Sending image frames using SendFrame()
+//   - Frame rate limiting with WithStreamingVideo
+//   - Receiving streaming responses from vision models
+//
+// This simulates a webcam or screen capture scenario where frames are
+// continuously sent to an LLM for real-time analysis.
+//
+// Run with:
+//
+//	export GEMINI_API_KEY=your-key
+//	go run .
+//
+// Note: This example simulates frame capture. In a real application,
+// you would capture frames from a webcam, screen, or video file.
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"log"
+	"os"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+	"github.com/AltairaLabs/PromptKit/sdk/session"
+)
+
+func main() {
+	fmt.Println("🎥 Realtime Video Streaming Example")
+	fmt.Println("====================================")
+	fmt.Println()
+
+	// Check for API key
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		log.Fatal("GEMINI_API_KEY environment variable is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Open a duplex session with video streaming configuration
+	fmt.Println("Opening duplex session with video streaming...")
+	fmt.Println()
+
+	conv, err := sdk.OpenDuplex(
+		"./realtime-video.pack.json",
+		"vision-stream",
+		sdk.WithAPIKey(apiKey),
+		sdk.WithModel("gemini-2.0-flash-exp"),
+		// Configure video streaming: 1 FPS, auto-resize to 1024x1024
+		sdk.WithStreamingVideo(&sdk.VideoStreamConfig{
+			TargetFPS:    1.0,   // 1 frame per second for LLM processing
+			MaxWidth:     1024,
+			MaxHeight:    1024,
+			Quality:      85,
+			EnableResize: true,
+		}),
+	)
+	if err != nil {
+		log.Fatalf("Failed to open duplex session: %v", err)
+	}
+	defer conv.Close()
+
+	// Get the response channel
+	responseChan, err := conv.Response()
+	if err != nil {
+		log.Fatalf("Failed to get response channel: %v", err)
+	}
+
+	// Start receiving responses in a goroutine
+	go func() {
+		fmt.Println("Waiting for vision analysis responses...")
+		fmt.Println()
+		for chunk := range responseChan {
+			if chunk.Error != nil {
+				fmt.Printf("\n[Error: %v]\n", chunk.Error)
+				continue
+			}
+			if chunk.Content != "" {
+				fmt.Print(chunk.Content)
+			}
+			if chunk.FinishReason != nil && *chunk.FinishReason != "" {
+				fmt.Printf("\n[Response complete: %s]\n", *chunk.FinishReason)
+			}
+		}
+	}()
+
+	// Simulate sending frames (in a real app, these would come from a webcam)
+	fmt.Println("Simulating frame capture and sending...")
+	fmt.Println()
+
+	// Send a few simulated frames
+	for i := 1; i <= 3; i++ {
+		// Generate a simulated frame (in practice, capture from webcam)
+		frameData, err := generateSimulatedFrame(i)
+		if err != nil {
+			log.Printf("Failed to generate frame %d: %v", i, err)
+			continue
+		}
+
+		// Create an ImageFrame and send it
+		frame := &session.ImageFrame{
+			Data:      frameData,
+			MIMEType:  "image/jpeg",
+			Width:     320,
+			Height:    240,
+			FrameNum:  int64(i),
+			Timestamp: time.Now(),
+		}
+
+		fmt.Printf("Sending frame %d (%d bytes)...\n", i, len(frameData))
+
+		err = conv.SendFrame(ctx, frame)
+		if err != nil {
+			log.Printf("Failed to send frame %d: %v", i, err)
+			continue
+		}
+
+		// Wait between frames (simulating real-time capture)
+		time.Sleep(time.Second)
+	}
+
+	// Send a text prompt to trigger analysis
+	fmt.Println("\nSending analysis request...")
+	err = conv.SendText(ctx, "What did you observe in the frames I just sent?")
+	if err != nil {
+		log.Printf("Failed to send text: %v", err)
+	}
+
+	// Wait for responses
+	fmt.Println("\nWaiting for analysis...")
+	doneChan, err := conv.Done()
+	if err != nil {
+		log.Printf("Failed to get done channel: %v", err)
+	} else {
+		select {
+		case <-doneChan:
+			fmt.Println("\n[Session complete]")
+		case <-time.After(15 * time.Second):
+			fmt.Println("\n[Timeout waiting for response]")
+		}
+	}
+
+	fmt.Println("\n=== Example Complete ===")
+	fmt.Println()
+	fmt.Println("In a real application, you would:")
+	fmt.Println("  1. Capture frames from webcam using a library like gocv")
+	fmt.Println("  2. Encode frames as JPEG")
+	fmt.Println("  3. Send via conv.SendFrame() at your desired rate")
+	fmt.Println("  4. The SDK handles frame rate limiting automatically")
+}
+
+// generateSimulatedFrame creates a simple test image with frame number overlay.
+// In a real application, this would be replaced with actual webcam capture.
+func generateSimulatedFrame(frameNum int) ([]byte, error) {
+	// Create a simple colored image that changes each frame
+	width, height := 320, 240
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	// Fill with a color that varies by frame number
+	var bgColor color.RGBA
+	switch frameNum % 3 {
+	case 0:
+		bgColor = color.RGBA{100, 150, 200, 255} // Blue-ish
+	case 1:
+		bgColor = color.RGBA{150, 200, 100, 255} // Green-ish
+	case 2:
+		bgColor = color.RGBA{200, 100, 150, 255} // Pink-ish
+	}
+
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, bgColor)
+		}
+	}
+
+	// Draw a simple moving element (a white rectangle that moves)
+	rectX := (frameNum * 50) % (width - 50)
+	for y := height/2 - 25; y < height/2+25; y++ {
+		for x := rectX; x < rectX+50; x++ {
+			img.Set(x, y, color.White)
+		}
+	}
+
+	// Encode as JPEG
+	var buf bytes.Buffer
+	err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 85})
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/sdk/examples/realtime-video/realtime-video.pack.json
+++ b/sdk/examples/realtime-video/realtime-video.pack.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "realtime-video-example",
+  "name": "Realtime Video Streaming Example",
+  "version": "1.0.0",
+  "description": "Example demonstrating realtime video/image streaming for vision analysis",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "vision-stream": {
+      "id": "vision-stream",
+      "name": "Vision Stream Analyzer",
+      "version": "1.0.0",
+      "system_template": "You are a real-time vision analyst. You receive a stream of images and describe what you see. Be concise and focus on changes between frames. If you see movement or action, describe it.",
+      "parameters": {
+        "temperature": 0.7,
+        "max_tokens": 256
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add **image-preprocessing** example demonstrating `WithAutoResize` and `WithImagePreprocessing` options for optimizing images before LLM calls
- Add **realtime-video** example showing `SendFrame` with duplex sessions for webcam-like scenarios with frame rate limiting
- Expose `SendFrame` and `SendVideoChunk` methods on `Conversation` struct to allow video streaming in duplex mode
- Update examples README with new example entries
- Add tests for `SendFrame` and `SendVideoChunk` wrapper methods

## Test plan

- [x] Pre-commit hooks pass (lint, build, tests)
- [x] Coverage for `conversation.go` ≥80% (81.2%)
- [ ] CI passes
- [ ] Examples can be run manually with appropriate API keys