### PR TITLE
feat(providers): Add providers/all package for convenient registration

### DIFF
--- a/runtime/providers/all/all.go
+++ b/runtime/providers/all/all.go
@@ -1,0 +1,40 @@
+// Package all provides a convenient way to register all PromptKit providers
+// with a single import. Instead of importing each provider individually:
+//
+//	import (
+//	    _ "github.com/AltairaLabs/PromptKit/runtime/providers/claude"
+//	    _ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
+//	    _ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
+//	    _ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+//	)
+//
+// You can simply import this package:
+//
+//	import _ "github.com/AltairaLabs/PromptKit/runtime/providers/all"
+//
+// This registers all available providers with the provider registry,
+// making them available for use in your application.
+package all
+
+import (
+	// Register Claude provider
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/claude"
+
+	// Register Gemini provider
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
+
+	// Register Imagen provider (Google's image generation)
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/imagen"
+
+	// Register Mock provider (for testing)
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+
+	// Register Ollama provider (local models)
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
+
+	// Register OpenAI provider
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+
+	// Register Replay provider (for deterministic testing)
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/replay"
+)


### PR DESCRIPTION
## Summary

- Adds `providers/all` package that imports all available providers with a single blank import
- Simplifies consumer code by eliminating need to track and import each provider individually
- Future-proofs applications - new providers automatically available on upgrade

Closes #202

## Usage

Instead of:
```go
import (
    _ "github.com/AltairaLabs/PromptKit/runtime/providers/claude"
    _ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
    _ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
    _ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
)
```

Simply use:
```go
import _ "github.com/AltairaLabs/PromptKit/runtime/providers/all"
```

## Included Providers

- `claude` - Anthropic Claude
- `gemini` - Google Gemini
- `imagen` - Google Imagen (image generation)
- `mock` - Mock provider (testing)
- `ollama` - Ollama (local models)
- `openai` - OpenAI
- `replay` - Replay provider (deterministic testing)

## Test plan

- [x] Package compiles successfully
- [x] All provider tests pass
- [x] Pre-commit checks pass