### PR TITLE
feat(sdk): Add WithAudioData, WithVideoFile, and WithVideoData SendOptions

### DIFF
--- a/sdk/options.go
+++ b/sdk/options.go
@@ -929,6 +929,42 @@ func WithAudioFile(path string) SendOption {
 	}
 }
 
+// WithAudioData attaches audio from raw bytes.
+//
+//	resp, _ := conv.Send(ctx, "Transcribe this audio",
+//	    sdk.WithAudioData(audioBytes, "audio/mp3"),
+//	)
+func WithAudioData(data []byte, mimeType string) SendOption {
+	return func(c *sendConfig) error {
+		c.parts = append(c.parts, audioDataPart{data: data, mimeType: mimeType})
+		return nil
+	}
+}
+
+// WithVideoFile attaches a video from a file path.
+//
+//	resp, _ := conv.Send(ctx, "Describe this video",
+//	    sdk.WithVideoFile("/path/to/video.mp4"),
+//	)
+func WithVideoFile(path string) SendOption {
+	return func(c *sendConfig) error {
+		c.parts = append(c.parts, videoFilePart{path: path})
+		return nil
+	}
+}
+
+// WithVideoData attaches a video from raw bytes.
+//
+//	resp, _ := conv.Send(ctx, "Describe this video",
+//	    sdk.WithVideoData(videoBytes, "video/mp4"),
+//	)
+func WithVideoData(data []byte, mimeType string) SendOption {
+	return func(c *sendConfig) error {
+		c.parts = append(c.parts, videoDataPart{data: data, mimeType: mimeType})
+		return nil
+	}
+}
+
 // WithFile attaches a file with the given name and content.
 //
 //	resp, _ := conv.Send(ctx, "Analyze this data",
@@ -960,6 +996,20 @@ type imageDataPart struct {
 
 type audioFilePart struct {
 	path string
+}
+
+type audioDataPart struct {
+	data     []byte
+	mimeType string
+}
+
+type videoFilePart struct {
+	path string
+}
+
+type videoDataPart struct {
+	data     []byte
+	mimeType string
 }
 
 type filePart struct {

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -171,6 +171,18 @@ func (c *Conversation) addContentParts(msg *types.Message, parts []any) error {
 			if err := msg.AddAudioPart(p.path); err != nil {
 				return fmt.Errorf("failed to add audio from file: %w", err)
 			}
+		case audioDataPart:
+			base64Data := base64.StdEncoding.EncodeToString(p.data)
+			contentPart := types.NewAudioPartFromData(base64Data, p.mimeType)
+			msg.AddPart(contentPart)
+		case videoFilePart:
+			if err := msg.AddVideoPart(p.path); err != nil {
+				return fmt.Errorf("failed to add video from file: %w", err)
+			}
+		case videoDataPart:
+			base64Data := base64.StdEncoding.EncodeToString(p.data)
+			contentPart := types.NewVideoPartFromData(base64Data, p.mimeType)
+			msg.AddPart(contentPart)
 		case filePart:
 			msg.AddTextPart(fmt.Sprintf("[File: %s]\n%s", p.name, string(p.data)))
 		default:


### PR DESCRIPTION
## Summary

- Adds `WithAudioData(data, mimeType)` for in-memory audio attachments
- Adds `WithVideoFile(path)` for video file attachments
- Adds `WithVideoData(data, mimeType)` for in-memory video attachments

This makes the SDK API symmetric across media types:

| Content Type | File | URL | Data (bytes) |
|-------------|------|-----|--------------|
| Image | `WithImageFile` | `WithImageURL` | `WithImageData` |
| Audio | `WithAudioFile` | — | `WithAudioData` |
| Video | `WithVideoFile` | — | `WithVideoData` |

Closes #204

## Use Case

When audio/video arrives as base64/bytes (e.g., from browser uploads), consumers can now send it directly without writing to temp files:

```go
// Before: Required temp file
tmpFile, _ := os.CreateTemp("", "*.mp3")
tmpFile.Write(audioBytes)
resp, _ := conv.Send(ctx, "Transcribe", sdk.WithAudioFile(tmpFile.Name()))
os.Remove(tmpFile.Name())

// After: Direct from bytes
resp, _ := conv.Send(ctx, "Transcribe", sdk.WithAudioData(audioBytes, "audio/mp3"))
```

## Test plan

- [x] Unit tests for all new SendOptions
- [x] Unit tests for addContentParts handling
- [x] Error path tests for invalid file extensions
- [x] Pre-commit checks pass (100% coverage on options.go, 81.2% on streaming.go)