### PR TITLE
ci: use branch name for dependabot detection in quality gate

### DIFF
--- a/.github/workflows/dependabot-gate.yml
+++ b/.github/workflows/dependabot-gate.yml
@@ -12,7 +12,7 @@ jobs:
     # Job name must match the required status check context in the ruleset
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: startsWith(github.head_ref, 'dependabot/')
     steps:
       - name: Skip SonarCloud for Dependabot
         run: echo "SonarCloud analysis skipped — dependency-only change from Dependabot"


### PR DESCRIPTION
## Summary
- Fixes the dependabot quality gate workflow to use `github.head_ref` (branch name) instead of `github.actor` for detecting dependabot PRs

## Problem
The `github.actor` check (`dependabot[bot]`) fails when someone other than dependabot triggers a PR event — e.g. when using `gh pr update-branch` to sync the PR with main. This caused the mock SonarCloud Analysis check to be skipped instead of passing.

Using `startsWith(github.head_ref, 'dependabot/')` is more reliable since the branch name never changes regardless of who interacts with the PR.

## Test plan
- [ ] After merge, update the dependabot PR branches and verify the check passes as SUCCESS (not SKIPPED)