### PR TITLE
ci: use branch name for dependabot detection in quality gate

### DIFF
--- a/.github/workflows/dependabot-gate.yml
+++ b/.github/workflows/dependabot-gate.yml
@@ -12,7 +12,7 @@ jobs:
     # Job name must match the required status check context in the ruleset
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: startsWith(github.head_ref, 'dependabot/')
     steps:
       - name: Skip SonarCloud for Dependabot
         run: echo "SonarCloud analysis skipped — dependency-only change from Dependabot"


### PR DESCRIPTION
## Summary
- Fixes the dependabot quality gate workflow to use `github.head_ref` (branch name) instead of `github.actor`

## Problem
`github.actor` changes when someone other than dependabot triggers a PR event (e.g. `gh pr update-branch`), causing the mock check to be SKIPPED instead of SUCCESS. Branch name (`dependabot/...`) never changes.

## Test plan
- [ ] After merge, update dependabot PR branches → check passes as SUCCESS