### PR TITLE
feat(a2a): add HTTP client for calling external A2A agents (#261)

### DIFF
--- a/runtime/a2a/client.go
+++ b/runtime/a2a/client.go
@@ -1,0 +1,360 @@
+package a2a
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// RPCError represents a JSON-RPC error returned by an A2A agent.
+type RPCError struct {
+	Code    int
+	Message string
+}
+
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("a2a: rpc error %d: %s", e.Code, e.Message)
+}
+
+// StreamEvent represents a single event received during message streaming.
+// Exactly one field will be non-nil.
+type StreamEvent struct {
+	StatusUpdate   *TaskStatusUpdateEvent
+	ArtifactUpdate *TaskArtifactUpdateEvent
+}
+
+// ClientOption configures a [Client].
+type ClientOption func(*Client)
+
+// WithHTTPClient sets the underlying HTTP client.
+func WithHTTPClient(hc *http.Client) ClientOption {
+	return func(c *Client) { c.httpClient = hc }
+}
+
+// WithAuth sets the Authorization header on all requests.
+func WithAuth(scheme, token string) ClientOption {
+	return func(c *Client) {
+		c.authScheme = scheme
+		c.authToken = token
+	}
+}
+
+// Client is an HTTP client for discovering and calling external A2A agents.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	authScheme string
+	authToken  string
+	reqID      int64
+
+	mu        sync.RWMutex
+	agentCard *AgentCard
+}
+
+// NewClient creates a Client targeting baseURL.
+func NewClient(baseURL string, opts ...ClientOption) *Client {
+	c := &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *Client) setAuth(req *http.Request) {
+	if c.authToken != "" {
+		req.Header.Set("Authorization", c.authScheme+" "+c.authToken)
+	}
+}
+
+func (c *Client) nextID() int64 {
+	return atomic.AddInt64(&c.reqID, 1)
+}
+
+// Discover fetches the agent card from /.well-known/agent.json.
+// The card is cached after the first successful call.
+func (c *Client) Discover(ctx context.Context) (*AgentCard, error) {
+	c.mu.RLock()
+	if c.agentCard != nil {
+		card := c.agentCard
+		c.mu.RUnlock()
+		return card, nil
+	}
+	c.mu.RUnlock()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		c.baseURL+"/.well-known/agent.json", http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("a2a: discover: %w", err)
+	}
+	c.setAuth(httpReq)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("a2a: discover: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("a2a: discover: status %d", resp.StatusCode)
+	}
+
+	var card AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		return nil, fmt.Errorf("a2a: decode agent card: %w", err)
+	}
+
+	c.mu.Lock()
+	c.agentCard = &card
+	c.mu.Unlock()
+
+	return &card, nil
+}
+
+// rpcCall performs a JSON-RPC 2.0 POST to /a2a.
+func (c *Client) rpcCall(ctx context.Context, method string, params, result any) error {
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("a2a: marshal params: %w", err)
+	}
+
+	rpcReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      c.nextID(),
+		Method:  method,
+		Params:  paramsJSON,
+	}
+
+	body, err := json.Marshal(rpcReq)
+	if err != nil {
+		return fmt.Errorf("a2a: marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/a2a", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("a2a: %s: %w", method, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	c.setAuth(httpReq)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("a2a: %s: %w", method, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("a2a: %s: status %d", method, resp.StatusCode)
+	}
+
+	var rpcResp JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return fmt.Errorf("a2a: %s: decode response: %w", method, err)
+	}
+
+	if rpcResp.Error != nil {
+		return &RPCError{Code: rpcResp.Error.Code, Message: rpcResp.Error.Message}
+	}
+
+	if result != nil {
+		if err := json.Unmarshal(rpcResp.Result, result); err != nil {
+			return fmt.Errorf("a2a: %s: decode result: %w", method, err)
+		}
+	}
+
+	return nil
+}
+
+// SendMessage sends a message/send JSON-RPC request.
+func (c *Client) SendMessage(ctx context.Context, params *SendMessageRequest) (*Task, error) {
+	var task Task
+	if err := c.rpcCall(ctx, MethodSendMessage, params, &task); err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+// SendMessageStream sends a message/stream request and returns a channel of
+// streaming events. The channel is closed when the stream ends or the context
+// is canceled.
+func (c *Client) SendMessageStream(ctx context.Context, params *SendMessageRequest) (<-chan StreamEvent, error) {
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("a2a: marshal params: %w", err)
+	}
+
+	rpcReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      c.nextID(),
+		Method:  MethodSendStreamingMessage,
+		Params:  paramsJSON,
+	}
+
+	body, err := json.Marshal(rpcReq)
+	if err != nil {
+		return nil, fmt.Errorf("a2a: marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/a2a", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("a2a: stream: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	c.setAuth(httpReq)
+
+	resp, err := c.httpClient.Do(httpReq) //nolint:bodyclose // closed in goroutine below
+	if err != nil {
+		return nil, fmt.Errorf("a2a: stream: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("a2a: stream: status %d", resp.StatusCode)
+	}
+
+	ch := make(chan StreamEvent)
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+		readSSE(ctx, resp.Body, ch)
+	}()
+
+	return ch, nil
+}
+
+// GetTask retrieves a task by ID via tasks/get.
+func (c *Client) GetTask(ctx context.Context, taskID string) (*Task, error) {
+	var task Task
+	if err := c.rpcCall(ctx, MethodGetTask, GetTaskRequest{ID: taskID}, &task); err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+// CancelTask cancels a task by ID via tasks/cancel.
+func (c *Client) CancelTask(ctx context.Context, taskID string) error {
+	return c.rpcCall(ctx, MethodCancelTask, CancelTaskRequest{ID: taskID}, nil)
+}
+
+// ListTasks lists tasks via tasks/list.
+func (c *Client) ListTasks(ctx context.Context, params *ListTasksRequest) ([]*Task, error) {
+	var resp ListTasksResponse
+	if err := c.rpcCall(ctx, MethodListTasks, params, &resp); err != nil {
+		return nil, err
+	}
+	tasks := make([]*Task, len(resp.Tasks))
+	for i := range resp.Tasks {
+		tasks[i] = &resp.Tasks[i]
+	}
+	return tasks, nil
+}
+
+// readSSE reads SSE events from r and sends parsed StreamEvents to ch.
+func readSSE(ctx context.Context, r io.Reader, ch chan<- StreamEvent) {
+	scanner := bufio.NewScanner(r)
+	var buf strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, ":") {
+			continue // SSE comment
+		}
+
+		if strings.HasPrefix(line, "data:") {
+			appendDataLine(&buf, line)
+			continue
+		}
+
+		// Empty line terminates the current event.
+		if line == "" && buf.Len() > 0 {
+			if !emitEvent(ctx, buf.String(), ch) {
+				return
+			}
+			buf.Reset()
+		}
+	}
+
+	// Handle any remaining buffered data.
+	if buf.Len() > 0 {
+		emitEvent(ctx, buf.String(), ch)
+	}
+}
+
+// appendDataLine extracts the data payload from an SSE "data:" line and
+// appends it to buf, joining multiple data lines with newlines per the spec.
+func appendDataLine(buf *strings.Builder, line string) {
+	d := line[len("data:"):]
+	if d != "" && d[0] == ' ' {
+		d = d[1:]
+	}
+	if buf.Len() > 0 {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(d)
+}
+
+// emitEvent parses data as a stream event and sends it to ch.
+// Returns false if the context is canceled and the caller should stop.
+func emitEvent(ctx context.Context, data string, ch chan<- StreamEvent) bool {
+	evt, ok := parseStreamEvent(data)
+	if !ok {
+		return true
+	}
+	select {
+	case ch <- evt:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// parseStreamEvent parses a JSON payload into a StreamEvent.
+// It handles both raw event objects and JSON-RPC wrapped responses.
+func parseStreamEvent(data string) (StreamEvent, bool) {
+	raw := json.RawMessage(data)
+
+	// Unwrap JSON-RPC envelope if present.
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if json.Unmarshal(raw, &envelope) == nil && len(envelope.Result) > 0 {
+		raw = envelope.Result
+	}
+
+	// Discriminate by field presence.
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return StreamEvent{}, false
+	}
+
+	if _, ok := fields["artifact"]; ok {
+		var evt TaskArtifactUpdateEvent
+		if json.Unmarshal(raw, &evt) != nil {
+			return StreamEvent{}, false
+		}
+		return StreamEvent{ArtifactUpdate: &evt}, true
+	}
+
+	if _, ok := fields["status"]; ok {
+		var evt TaskStatusUpdateEvent
+		if json.Unmarshal(raw, &evt) != nil {
+			return StreamEvent{}, false
+		}
+		return StreamEvent{StatusUpdate: &evt}, true
+	}
+
+	return StreamEvent{}, false
+}

--- a/runtime/a2a/client_test.go
+++ b/runtime/a2a/client_test.go
@@ -1,0 +1,565 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- test helpers ---
+
+func rpcResult(w http.ResponseWriter, id any, result any) {
+	b, _ := json.Marshal(result)
+	_ = json.NewEncoder(w).Encode(JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  b,
+	})
+}
+
+func rpcErrorResp(w http.ResponseWriter, id any, code int, msg string) {
+	_ = json.NewEncoder(w).Encode(JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &JSONRPCError{Code: code, Message: msg},
+	})
+}
+
+func decodeRPC(r *http.Request) JSONRPCRequest {
+	var req JSONRPCRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	return req
+}
+
+func sseEvent(data any) string {
+	b, _ := json.Marshal(data)
+	return fmt.Sprintf("data: %s\n\n", b)
+}
+
+// --- unit tests ---
+
+func TestDiscover(t *testing.T) {
+	want := AgentCard{Name: "test-agent", Description: "A test agent"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/agent.json" {
+			t.Errorf("path = %q, want /.well-known/agent.json", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	got, err := c.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if got.Description != want.Description {
+		t.Errorf("Description = %q, want %q", got.Description, want.Description)
+	}
+}
+
+func TestDiscover_Caching(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_ = json.NewEncoder(w).Encode(AgentCard{Name: "cached"})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+
+	card1, err := c.Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	card2, err := c.Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", n)
+	}
+	if card1.Name != card2.Name {
+		t.Errorf("cached card mismatch: %q != %q", card1.Name, card2.Name)
+	}
+}
+
+func TestSendMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		if req.Method != MethodSendMessage {
+			t.Errorf("method = %q, want %q", req.Method, MethodSendMessage)
+		}
+		rpcResult(w, req.ID, Task{
+			ID:     "task-1",
+			Status: TaskStatus{State: TaskStateWorking},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	task, err := c.SendMessage(context.Background(), &SendMessageRequest{
+		Message: Message{
+			Role:  RoleUser,
+			Parts: []Part{{Text: ptr("hello")}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+	if task.ID != "task-1" {
+		t.Errorf("task.ID = %q, want 'task-1'", task.ID)
+	}
+	if task.Status.State != TaskStateWorking {
+		t.Errorf("state = %q, want %q", task.Status.State, TaskStateWorking)
+	}
+}
+
+func TestGetTask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		if req.Method != MethodGetTask {
+			t.Errorf("method = %q, want %q", req.Method, MethodGetTask)
+		}
+		var params GetTaskRequest
+		_ = json.Unmarshal(req.Params, &params)
+		rpcResult(w, req.ID, Task{
+			ID:     params.ID,
+			Status: TaskStatus{State: TaskStateCompleted},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	task, err := c.GetTask(context.Background(), "task-42")
+	if err != nil {
+		t.Fatalf("GetTask() error = %v", err)
+	}
+	if task.ID != "task-42" {
+		t.Errorf("task.ID = %q, want 'task-42'", task.ID)
+	}
+	if task.Status.State != TaskStateCompleted {
+		t.Errorf("state = %q, want %q", task.Status.State, TaskStateCompleted)
+	}
+}
+
+func TestCancelTask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		if req.Method != MethodCancelTask {
+			t.Errorf("method = %q, want %q", req.Method, MethodCancelTask)
+		}
+		rpcResult(w, req.ID, Task{
+			ID:     "task-1",
+			Status: TaskStatus{State: TaskStateCanceled},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.CancelTask(context.Background(), "task-1"); err != nil {
+		t.Fatalf("CancelTask() error = %v", err)
+	}
+}
+
+func TestListTasks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		if req.Method != MethodListTasks {
+			t.Errorf("method = %q, want %q", req.Method, MethodListTasks)
+		}
+		var params ListTasksRequest
+		_ = json.Unmarshal(req.Params, &params)
+		if params.ContextID != "ctx-1" {
+			t.Errorf("ContextID = %q, want 'ctx-1'", params.ContextID)
+		}
+		rpcResult(w, req.ID, ListTasksResponse{
+			Tasks: []Task{
+				{ID: "t1", Status: TaskStatus{State: TaskStateCompleted}},
+				{ID: "t2", Status: TaskStatus{State: TaskStateWorking}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	tasks, err := c.ListTasks(context.Background(), &ListTasksRequest{ContextID: "ctx-1"})
+	if err != nil {
+		t.Fatalf("ListTasks() error = %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("len(tasks) = %d, want 2", len(tasks))
+	}
+	if tasks[0].ID != "t1" {
+		t.Errorf("tasks[0].ID = %q, want 't1'", tasks[0].ID)
+	}
+	if tasks[1].ID != "t2" {
+		t.Errorf("tasks[1].ID = %q, want 't2'", tasks[1].ID)
+	}
+}
+
+func TestSendMessageStream(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f := w.(http.Flusher)
+
+		fmt.Fprint(w, sseEvent(TaskStatusUpdateEvent{
+			TaskID: "task-1",
+			Status: TaskStatus{State: TaskStateWorking},
+		}))
+		f.Flush()
+
+		fmt.Fprint(w, sseEvent(TaskArtifactUpdateEvent{
+			TaskID:   "task-1",
+			Artifact: Artifact{ArtifactID: "a1", Parts: []Part{{Text: ptr("result")}}},
+		}))
+		f.Flush()
+
+		fmt.Fprint(w, sseEvent(TaskStatusUpdateEvent{
+			TaskID: "task-1",
+			Status: TaskStatus{State: TaskStateCompleted},
+		}))
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	ch, err := c.SendMessageStream(context.Background(), &SendMessageRequest{
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("hello")}}},
+	})
+	if err != nil {
+		t.Fatalf("SendMessageStream() error = %v", err)
+	}
+
+	var events []StreamEvent
+	for evt := range ch {
+		events = append(events, evt)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	if events[0].StatusUpdate == nil || events[0].StatusUpdate.Status.State != TaskStateWorking {
+		t.Error("event 0: expected status=working")
+	}
+	if events[1].ArtifactUpdate == nil || events[1].ArtifactUpdate.Artifact.ArtifactID != "a1" {
+		t.Error("event 1: expected artifact a1")
+	}
+	if events[2].StatusUpdate == nil || events[2].StatusUpdate.Status.State != TaskStateCompleted {
+		t.Error("event 2: expected status=completed")
+	}
+}
+
+func TestSendMessageStream_JSONRPCWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f := w.(http.Flusher)
+
+		writeWrapped := func(result any) {
+			b, _ := json.Marshal(result)
+			envelope := JSONRPCResponse{JSONRPC: "2.0", ID: float64(1), Result: b}
+			fmt.Fprint(w, sseEvent(envelope))
+			f.Flush()
+		}
+
+		writeWrapped(TaskStatusUpdateEvent{
+			TaskID: "t1",
+			Status: TaskStatus{State: TaskStateWorking},
+		})
+		writeWrapped(TaskArtifactUpdateEvent{
+			TaskID:   "t1",
+			Artifact: Artifact{ArtifactID: "a1", Parts: []Part{{Text: ptr("chunk")}}},
+		})
+		writeWrapped(TaskStatusUpdateEvent{
+			TaskID: "t1",
+			Status: TaskStatus{State: TaskStateCompleted},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	ch, err := c.SendMessageStream(context.Background(), &SendMessageRequest{
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("go")}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var events []StreamEvent
+	for evt := range ch {
+		events = append(events, evt)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	if events[0].StatusUpdate == nil {
+		t.Error("event 0: expected StatusUpdate")
+	}
+	if events[1].ArtifactUpdate == nil {
+		t.Error("event 1: expected ArtifactUpdate")
+	}
+	if events[2].StatusUpdate == nil || events[2].StatusUpdate.Status.State != TaskStateCompleted {
+		t.Error("event 2: expected StatusUpdate completed")
+	}
+}
+
+func TestWithAuth(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(AgentCard{Name: "secure"})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, WithAuth("Bearer", "secret-token"))
+	_, err := c.Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer secret-token" {
+		t.Errorf("Authorization = %q, want 'Bearer secret-token'", gotAuth)
+	}
+}
+
+func TestRPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		rpcErrorResp(w, req.ID, -32600, "Invalid Request")
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	_, err := c.SendMessage(context.Background(), &SendMessageRequest{
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("hi")}}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var rpcErr *RPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("expected *RPCError, got %T: %v", err, err)
+	}
+	if rpcErr.Code != -32600 {
+		t.Errorf("Code = %d, want -32600", rpcErr.Code)
+	}
+	if rpcErr.Message != "Invalid Request" {
+		t.Errorf("Message = %q, want 'Invalid Request'", rpcErr.Message)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // block until client disconnects
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	c := NewClient(srv.URL)
+	_, err := c.Discover(ctx)
+	if err == nil {
+		t.Fatal("expected context deadline error")
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	custom := &http.Client{Timeout: 30 * time.Second}
+	c := NewClient("http://example.com", WithHTTPClient(custom))
+	if c.httpClient != custom {
+		t.Error("expected custom HTTP client")
+	}
+}
+
+func TestRPCError_ErrorString(t *testing.T) {
+	err := &RPCError{Code: -32600, Message: "bad request"}
+	got := err.Error()
+	if got != "a2a: rpc error -32600: bad request" {
+		t.Errorf("Error() = %q", got)
+	}
+}
+
+func TestDiscover_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	_, err := c.Discover(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSendMessageStream_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	_, err := c.SendMessageStream(context.Background(), &SendMessageRequest{
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("hi")}}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRPCCall_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	_, err := c.GetTask(context.Background(), "task-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- integration tests ---
+
+func TestHappyPath_DiscoverSendPollComplete(t *testing.T) {
+	var pollCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/agent.json":
+			_ = json.NewEncoder(w).Encode(AgentCard{Name: "agent"})
+		case "/a2a":
+			req := decodeRPC(r)
+			switch req.Method {
+			case MethodSendMessage:
+				rpcResult(w, req.ID, Task{
+					ID:        "task-1",
+					ContextID: "ctx-1",
+					Status:    TaskStatus{State: TaskStateWorking},
+				})
+			case MethodGetTask:
+				n := atomic.AddInt32(&pollCount, 1)
+				task := Task{ID: "task-1"}
+				if n >= 2 {
+					task.Status = TaskStatus{State: TaskStateCompleted}
+					task.Artifacts = []Artifact{{
+						ArtifactID: "a1",
+						Parts:      []Part{{Text: ptr("done")}},
+					}}
+				} else {
+					task.Status = TaskStatus{State: TaskStateWorking}
+				}
+				rpcResult(w, req.ID, task)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	c := NewClient(srv.URL)
+
+	// 1. Discover
+	card, err := c.Discover(ctx)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if card.Name != "agent" {
+		t.Errorf("agent name = %q", card.Name)
+	}
+
+	// 2. Send message
+	task, err := c.SendMessage(ctx, &SendMessageRequest{
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("solve this")}}},
+	})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if task.Status.State != TaskStateWorking {
+		t.Fatalf("expected working, got %s", task.Status.State)
+	}
+
+	// 3. Poll — first call: still working
+	task, err = c.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask(1): %v", err)
+	}
+	if task.Status.State != TaskStateWorking {
+		t.Fatalf("expected working, got %s", task.Status.State)
+	}
+
+	// 4. Poll — second call: completed with artifact
+	task, err = c.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask(2): %v", err)
+	}
+	if task.Status.State != TaskStateCompleted {
+		t.Fatalf("expected completed, got %s", task.Status.State)
+	}
+	if len(task.Artifacts) == 0 || *task.Artifacts[0].Parts[0].Text != "done" {
+		t.Error("expected artifact with text 'done'")
+	}
+}
+
+func TestErrorPath_DiscoverSendFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/agent.json":
+			_ = json.NewEncoder(w).Encode(AgentCard{Name: "agent"})
+		case "/a2a":
+			req := decodeRPC(r)
+			switch req.Method {
+			case MethodSendMessage:
+				rpcResult(w, req.ID, Task{
+					ID:     "task-1",
+					Status: TaskStatus{State: TaskStateWorking},
+				})
+			case MethodGetTask:
+				rpcResult(w, req.ID, Task{
+					ID:     "task-1",
+					Status: TaskStatus{State: TaskStateFailed},
+				})
+			}
+		}
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	c := NewClient(srv.URL)
+
+	_, err := c.Discover(ctx)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	task, err := c.SendMessage(ctx, &SendMessageRequest{
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("do something")}}},
+	})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if task.Status.State != TaskStateWorking {
+		t.Fatalf("expected working, got %s", task.Status.State)
+	}
+
+	task, err = c.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.Status.State != TaskStateFailed {
+		t.Errorf("expected failed, got %s", task.Status.State)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `runtime/a2a/client.go` with `Client` for discovering and calling external A2A agents over HTTP
- Supports agent card discovery (`GET /.well-known/agent.json`) with caching, JSON-RPC `message/send`, `tasks/get`, `tasks/cancel`, `tasks/list`, and SSE-based `message/stream`
- Includes `WithHTTPClient` and `WithAuth` functional options
- JSON-RPC errors parsed into `*RPCError` Go error type

## Test plan
- [x] Unit tests for each method: Discover, SendMessage, GetTask, CancelTask, ListTasks, SendMessageStream
- [x] Discover caching verified (single HTTP call on repeated Discover)
- [x] SSE stream: both raw and JSON-RPC wrapped events
- [x] Auth header propagation
- [x] JSON-RPC error parsing into `*RPCError`
- [x] Context cancellation stops in-flight requests
- [x] Integration: discover → send → poll until complete (happy path)
- [x] Integration: discover → send → task fails (error path)
- [x] All tests use `httptest.Server` — no real network calls
- [x] 84.6% file coverage, 89.4% package coverage

Closes #261