### PR TITLE
feat(a2a): add A2A HTTP server (#262)

### DIFF
--- a/runtime/a2a/server.go
+++ b/runtime/a2a/server.go
@@ -1,0 +1,393 @@
+package a2a
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+const (
+	// idBytes is the number of random bytes used to generate task/context IDs.
+	idBytes = 16
+
+	// defaultReadHeaderTimeout prevents Slowloris attacks.
+	defaultReadHeaderTimeout = 10 * time.Second
+
+	// defaultPageSize is used when ListTasksRequest.PageSize is 0.
+	defaultPageSize = 100
+
+	// sendSettleTime is how long handleSendMessage waits for fast calls
+	// to complete before returning the task in its current state.
+	sendSettleTime = 5 * time.Millisecond
+)
+
+// ConversationResult holds the outcome of a Send call.
+type ConversationResult struct {
+	Parts        []types.ContentPart
+	PendingTools bool
+}
+
+// Conversation abstracts a single conversation session.
+type Conversation interface {
+	Send(ctx context.Context, msg *types.Message) (*ConversationResult, error)
+	Close() error
+}
+
+// ConversationOpener creates or retrieves a Conversation for a context ID.
+type ConversationOpener func(contextID string) (Conversation, error)
+
+// ServerOption configures a [Server].
+type ServerOption func(*Server)
+
+// WithCard sets the agent card served at /.well-known/agent.json.
+func WithCard(card *AgentCard) ServerOption {
+	return func(s *Server) { s.card = *card }
+}
+
+// WithPort sets the TCP port for ListenAndServe.
+func WithPort(port int) ServerOption {
+	return func(s *Server) { s.port = port }
+}
+
+// WithTaskStore sets a custom task store. Defaults to an in-memory store.
+func WithTaskStore(store TaskStore) ServerOption {
+	return func(s *Server) { s.taskStore = store }
+}
+
+// Server is an HTTP server that exposes a PromptKit Conversation as an
+// A2A-compliant JSON-RPC endpoint.
+type Server struct {
+	opener    ConversationOpener
+	taskStore TaskStore
+	card      AgentCard
+	port      int
+	httpSrv   *http.Server
+
+	convsMu sync.RWMutex
+	convs   map[string]Conversation // context_id → Conversation
+
+	cancelsMu sync.Mutex
+	cancels   map[string]context.CancelFunc // task_id → cancel for in-flight Send
+}
+
+// NewServer creates a new A2A server.
+func NewServer(opener ConversationOpener, opts ...ServerOption) *Server {
+	s := &Server{
+		opener:  opener,
+		convs:   make(map[string]Conversation),
+		cancels: make(map[string]context.CancelFunc),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.taskStore == nil {
+		s.taskStore = NewInMemoryTaskStore()
+	}
+	return s
+}
+
+// Handler returns an http.Handler implementing the A2A protocol.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /.well-known/agent.json", s.handleAgentCard)
+	mux.HandleFunc("POST /a2a", s.handleRPC)
+	return mux
+}
+
+// ListenAndServe starts the HTTP server on the configured port.
+func (s *Server) ListenAndServe() error {
+	s.httpSrv = &http.Server{
+		Addr:              fmt.Sprintf(":%d", s.port),
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
+	}
+	return s.httpSrv.ListenAndServe()
+}
+
+// Shutdown gracefully shuts down the server: drains HTTP requests, cancels
+// in-flight tasks, and closes all conversations.
+func (s *Server) Shutdown(ctx context.Context) error {
+	var firstErr error
+
+	if s.httpSrv != nil {
+		firstErr = s.httpSrv.Shutdown(ctx)
+	}
+
+	// Cancel all in-flight tasks.
+	s.cancelsMu.Lock()
+	for _, cancel := range s.cancels {
+		cancel()
+	}
+	s.cancels = make(map[string]context.CancelFunc)
+	s.cancelsMu.Unlock()
+
+	// Close all conversations.
+	s.convsMu.Lock()
+	for id, conv := range s.convs {
+		if err := conv.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		delete(s.convs, id)
+	}
+	s.convsMu.Unlock()
+
+	return firstErr
+}
+
+// Serve starts the HTTP server on the given listener.
+func (s *Server) Serve(ln net.Listener) error {
+	s.httpSrv = &http.Server{
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
+	}
+	return s.httpSrv.Serve(ln)
+}
+
+// handleAgentCard serves the agent card as JSON.
+func (s *Server) handleAgentCard(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.card)
+}
+
+// handleRPC dispatches a JSON-RPC 2.0 request to the appropriate handler.
+func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
+	var req JSONRPCRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeRPCError(w, nil, -32700, "Parse error")
+		return
+	}
+
+	switch req.Method {
+	case MethodSendMessage:
+		s.handleSendMessage(w, &req)
+	case MethodGetTask:
+		s.handleGetTask(w, &req)
+	case MethodCancelTask:
+		s.handleCancelTask(w, &req)
+	case MethodListTasks:
+		s.handleListTasks(w, &req)
+	default:
+		writeRPCError(w, req.ID, -32601, "Method not found")
+	}
+}
+
+// handleSendMessage processes a message/send request.
+func (s *Server) handleSendMessage(w http.ResponseWriter, req *JSONRPCRequest) {
+	var params SendMessageRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeRPCError(w, req.ID, -32602, "Invalid params")
+		return
+	}
+
+	contextID := params.Message.ContextID
+	if contextID == "" {
+		contextID = generateID()
+	}
+
+	conv, err := s.getOrCreateConversation(contextID)
+	if err != nil {
+		writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to open conversation: %v", err))
+		return
+	}
+
+	pkMsg, err := MessageToMessage(&params.Message)
+	if err != nil {
+		writeRPCError(w, req.ID, -32602, fmt.Sprintf("Invalid message: %v", err))
+		return
+	}
+
+	taskID := generateID()
+	if _, err := s.taskStore.Create(taskID, contextID); err != nil {
+		writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to create task: %v", err))
+		return
+	}
+
+	done := s.runConversation(taskID, conv, pkMsg)
+
+	if params.Configuration != nil && params.Configuration.Blocking {
+		<-done
+	} else {
+		select {
+		case <-done:
+		case <-time.After(sendSettleTime):
+		}
+	}
+
+	task, _ := s.taskStore.Get(taskID)
+	writeRPCResult(w, req.ID, task)
+}
+
+// runConversation spawns a goroutine that drives the conversation for a task.
+// It returns a channel that is closed when the goroutine completes.
+func (s *Server) runConversation(taskID string, conv Conversation, pkMsg *types.Message) <-chan struct{} {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancelsMu.Lock()
+	s.cancels[taskID] = cancel
+	s.cancelsMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer cancel()
+
+		_ = s.taskStore.SetState(taskID, TaskStateWorking, nil)
+
+		result, sendErr := conv.Send(ctx, pkMsg)
+		if sendErr != nil {
+			errText := sendErr.Error()
+			_ = s.taskStore.SetState(taskID, TaskStateFailed, &Message{
+				Role:  RoleAgent,
+				Parts: []Part{{Text: &errText}},
+			})
+			return
+		}
+
+		if result.PendingTools {
+			_ = s.taskStore.SetState(taskID, TaskStateInputRequired, nil)
+			return
+		}
+
+		artifacts, convErr := ContentPartsToArtifacts(result.Parts)
+		if convErr == nil && len(artifacts) > 0 {
+			_ = s.taskStore.AddArtifacts(taskID, artifacts)
+		}
+		_ = s.taskStore.SetState(taskID, TaskStateCompleted, nil)
+	}()
+
+	return done
+}
+
+// handleGetTask processes a tasks/get request.
+func (s *Server) handleGetTask(w http.ResponseWriter, req *JSONRPCRequest) {
+	var params GetTaskRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeRPCError(w, req.ID, -32602, "Invalid params")
+		return
+	}
+
+	task, err := s.taskStore.Get(params.ID)
+	if err != nil {
+		writeRPCError(w, req.ID, -32001, fmt.Sprintf("Task not found: %v", err))
+		return
+	}
+
+	writeRPCResult(w, req.ID, task)
+}
+
+// handleCancelTask processes a tasks/cancel request.
+func (s *Server) handleCancelTask(w http.ResponseWriter, req *JSONRPCRequest) {
+	var params CancelTaskRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeRPCError(w, req.ID, -32602, "Invalid params")
+		return
+	}
+
+	// Cancel in-flight Send if running.
+	s.cancelsMu.Lock()
+	if cancel, ok := s.cancels[params.ID]; ok {
+		cancel()
+		delete(s.cancels, params.ID)
+	}
+	s.cancelsMu.Unlock()
+
+	if err := s.taskStore.Cancel(params.ID); err != nil {
+		writeRPCError(w, req.ID, -32001, fmt.Sprintf("Cancel failed: %v", err))
+		return
+	}
+
+	task, _ := s.taskStore.Get(params.ID)
+	writeRPCResult(w, req.ID, task)
+}
+
+// handleListTasks processes a tasks/list request.
+func (s *Server) handleListTasks(w http.ResponseWriter, req *JSONRPCRequest) {
+	var params ListTasksRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeRPCError(w, req.ID, -32602, "Invalid params")
+		return
+	}
+
+	limit := params.PageSize
+	if limit <= 0 {
+		limit = defaultPageSize
+	}
+
+	tasks, err := s.taskStore.List(params.ContextID, limit, 0)
+	if err != nil {
+		writeRPCError(w, req.ID, -32000, fmt.Sprintf("List failed: %v", err))
+		return
+	}
+
+	// Convert []*Task to []Task for the response.
+	taskList := make([]Task, len(tasks))
+	for i, t := range tasks {
+		taskList[i] = *t
+	}
+
+	writeRPCResult(w, req.ID, ListTasksResponse{
+		Tasks:    taskList,
+		PageSize: limit,
+	})
+}
+
+// getOrCreateConversation retrieves an existing conversation for the context ID
+// or creates a new one via the opener (double-check lock pattern).
+func (s *Server) getOrCreateConversation(contextID string) (Conversation, error) {
+	s.convsMu.RLock()
+	if conv, ok := s.convs[contextID]; ok {
+		s.convsMu.RUnlock()
+		return conv, nil
+	}
+	s.convsMu.RUnlock()
+
+	s.convsMu.Lock()
+	defer s.convsMu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if conv, ok := s.convs[contextID]; ok {
+		return conv, nil
+	}
+
+	conv, err := s.opener(contextID)
+	if err != nil {
+		return nil, err
+	}
+	s.convs[contextID] = conv
+	return conv, nil
+}
+
+// generateID returns a random hex string suitable for task and context IDs.
+func generateID() string {
+	b := make([]byte, idBytes)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// writeRPCResult writes a JSON-RPC 2.0 success response.
+func writeRPCResult(w http.ResponseWriter, id, result any) {
+	data, _ := json.Marshal(result)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  data,
+	})
+}
+
+// writeRPCError writes a JSON-RPC 2.0 error response.
+func writeRPCError(w http.ResponseWriter, id any, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &JSONRPCError{Code: code, Message: msg},
+	})
+}

--- a/runtime/a2a/server_test.go
+++ b/runtime/a2a/server_test.go
@@ -1,0 +1,557 @@
+package a2a
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// --- mock conversation ---
+
+type mockConversation struct {
+	sendFunc func(ctx context.Context, msg *types.Message) (*ConversationResult, error)
+	closed   atomic.Bool
+}
+
+func (m *mockConversation) Send(ctx context.Context, msg *types.Message) (*ConversationResult, error) {
+	return m.sendFunc(ctx, msg)
+}
+
+func (m *mockConversation) Close() error {
+	m.closed.Store(true)
+	return nil
+}
+
+// --- helpers ---
+
+func textPtr(s string) *string { return &s }
+
+func newTestServer(opener ConversationOpener, opts ...ServerOption) (*Server, *httptest.Server) {
+	srv := NewServer(opener, opts...)
+	ts := httptest.NewServer(srv.Handler())
+	return srv, ts
+}
+
+func rpcRequest(t *testing.T, ts *httptest.Server, method string, params any) *JSONRPCResponse {
+	t.Helper()
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	body, err := json.Marshal(JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  method,
+		Params:  paramsJSON,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	resp, err := http.Post(ts.URL+"/a2a", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /a2a: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var rpcResp JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return &rpcResp
+}
+
+func rpcRequestTask(t *testing.T, ts *httptest.Server, method string, params any) *Task {
+	t.Helper()
+	resp := rpcRequest(t, ts, method, params)
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %d %s", resp.Error.Code, resp.Error.Message)
+	}
+	var task Task
+	if err := json.Unmarshal(resp.Result, &task); err != nil {
+		t.Fatalf("unmarshal task: %v", err)
+	}
+	return &task
+}
+
+func sendMessage(t *testing.T, ts *httptest.Server, contextID, text string) *Task {
+	t.Helper()
+	return rpcRequestTask(t, ts, MethodSendMessage, SendMessageRequest{
+		Message: Message{
+			ContextID: contextID,
+			Role:      RoleUser,
+			Parts:     []Part{{Text: textPtr(text)}},
+		},
+		Configuration: &SendMessageConfiguration{Blocking: true},
+	})
+}
+
+func nopOpener(string) (Conversation, error) {
+	return nil, errors.New("should not be called")
+}
+
+func completingMock() *mockConversation {
+	return &mockConversation{
+		sendFunc: func(_ context.Context, _ *types.Message) (*ConversationResult, error) {
+			return &ConversationResult{
+				Parts: []types.ContentPart{types.NewTextPart("ok")},
+			}, nil
+		},
+	}
+}
+
+// --- tests ---
+
+func TestAgentCardDiscovery(t *testing.T) {
+	card := AgentCard{
+		Name:        "test-agent",
+		Description: "A test agent",
+		Version:     "1.0",
+	}
+	_, ts := newTestServer(nopOpener, WithCard(&card))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/agent.json")
+	if err != nil {
+		t.Fatalf("GET agent.json: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", ct)
+	}
+
+	var got AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Name != card.Name || got.Description != card.Description || got.Version != card.Version {
+		t.Fatalf("got %+v, want %+v", got, card)
+	}
+}
+
+func TestSendMessage_Completed(t *testing.T) {
+	replyText := "Hello from the agent"
+	mock := &mockConversation{
+		sendFunc: func(_ context.Context, _ *types.Message) (*ConversationResult, error) {
+			return &ConversationResult{
+				Parts: []types.ContentPart{types.NewTextPart(replyText)},
+			}, nil
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	task := sendMessage(t, ts, "ctx-1", "Hello")
+
+	if task.Status.State != TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", task.Status.State)
+	}
+	if len(task.Artifacts) == 0 {
+		t.Fatal("expected artifacts")
+	}
+	if task.Artifacts[0].Parts[0].Text == nil || *task.Artifacts[0].Parts[0].Text != replyText {
+		t.Fatalf("artifact text = %v, want %q", task.Artifacts[0].Parts[0].Text, replyText)
+	}
+}
+
+func TestSendMessage_Failed(t *testing.T) {
+	mock := &mockConversation{
+		sendFunc: func(_ context.Context, _ *types.Message) (*ConversationResult, error) {
+			return nil, errors.New("provider error")
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	task := sendMessage(t, ts, "ctx-fail", "Hello")
+
+	if task.Status.State != TaskStateFailed {
+		t.Fatalf("state = %q, want failed", task.Status.State)
+	}
+	if task.Status.Message == nil {
+		t.Fatal("expected status message on failure")
+	}
+}
+
+func TestSendMessage_InputRequired(t *testing.T) {
+	mock := &mockConversation{
+		sendFunc: func(_ context.Context, _ *types.Message) (*ConversationResult, error) {
+			return &ConversationResult{PendingTools: true}, nil
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	task := sendMessage(t, ts, "ctx-tools", "Hello")
+
+	if task.Status.State != TaskStateInputRequired {
+		t.Fatalf("state = %q, want input_required", task.Status.State)
+	}
+}
+
+func TestSendMessage_Multimodal(t *testing.T) {
+	mock := &mockConversation{
+		sendFunc: func(_ context.Context, msg *types.Message) (*ConversationResult, error) {
+			if len(msg.Parts) != 2 {
+				return nil, errors.New("expected 2 parts")
+			}
+			if msg.Parts[0].Type != types.ContentTypeText {
+				return nil, errors.New("expected text part first")
+			}
+			if msg.Parts[1].Type != types.ContentTypeImage {
+				return nil, errors.New("expected image part second")
+			}
+			return &ConversationResult{
+				Parts: []types.ContentPart{types.NewTextPart("got it")},
+			}, nil
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	imgURL := "https://example.com/image.png"
+	task := rpcRequestTask(t, ts, MethodSendMessage, SendMessageRequest{
+		Message: Message{
+			ContextID: "ctx-multi",
+			Role:      RoleUser,
+			Parts: []Part{
+				{Text: textPtr("Look at this image")},
+				{URL: &imgURL, MediaType: "image/png"},
+			},
+		},
+		Configuration: &SendMessageConfiguration{Blocking: true},
+	})
+
+	if task.Status.State != TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", task.Status.State)
+	}
+}
+
+func TestSendMessage_OpenerError(t *testing.T) {
+	_, ts := newTestServer(func(string) (Conversation, error) {
+		return nil, errors.New("opener failed")
+	})
+	defer ts.Close()
+
+	resp := rpcRequest(t, ts, MethodSendMessage, SendMessageRequest{
+		Message: Message{
+			ContextID: "ctx-err",
+			Role:      RoleUser,
+			Parts:     []Part{{Text: textPtr("Hello")}},
+		},
+	})
+	if resp.Error == nil {
+		t.Fatal("expected error when opener fails")
+	}
+	if resp.Error.Code != -32000 {
+		t.Fatalf("error code = %d, want -32000", resp.Error.Code)
+	}
+}
+
+func TestSendMessage_NoContextID(t *testing.T) {
+	mock := completingMock()
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	task := rpcRequestTask(t, ts, MethodSendMessage, SendMessageRequest{
+		Message: Message{
+			Role:  RoleUser,
+			Parts: []Part{{Text: textPtr("Hello")}},
+		},
+		Configuration: &SendMessageConfiguration{Blocking: true},
+	})
+
+	if task.ContextID == "" {
+		t.Fatal("expected server to generate a context ID")
+	}
+	if task.Status.State != TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", task.Status.State)
+	}
+}
+
+func TestServerGetTask(t *testing.T) {
+	mock := completingMock()
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	task := sendMessage(t, ts, "ctx-get", "Hello")
+
+	got := rpcRequestTask(t, ts, MethodGetTask, GetTaskRequest{ID: task.ID})
+
+	if got.ID != task.ID {
+		t.Fatalf("got task ID %q, want %q", got.ID, task.ID)
+	}
+	if got.Status.State != TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", got.Status.State)
+	}
+}
+
+func TestServerGetTask_NotFound(t *testing.T) {
+	_, ts := newTestServer(nopOpener)
+	defer ts.Close()
+
+	resp := rpcRequest(t, ts, MethodGetTask, GetTaskRequest{ID: "nonexistent"})
+	if resp.Error == nil {
+		t.Fatal("expected error for nonexistent task")
+	}
+	if resp.Error.Code != -32001 {
+		t.Fatalf("error code = %d, want -32001", resp.Error.Code)
+	}
+}
+
+func TestServerCancelTask(t *testing.T) {
+	sendStarted := make(chan struct{})
+	mock := &mockConversation{
+		sendFunc: func(ctx context.Context, _ *types.Message) (*ConversationResult, error) {
+			close(sendStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	resp := rpcRequest(t, ts, MethodSendMessage, SendMessageRequest{
+		Message: Message{
+			ContextID: "ctx-cancel",
+			Role:      RoleUser,
+			Parts:     []Part{{Text: textPtr("Hello")}},
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	var task Task
+	if err := json.Unmarshal(resp.Result, &task); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	<-sendStarted
+
+	cancelResp := rpcRequest(t, ts, MethodCancelTask, CancelTaskRequest{ID: task.ID})
+	if cancelResp.Error != nil {
+		t.Fatalf("cancel error: %d %s", cancelResp.Error.Code, cancelResp.Error.Message)
+	}
+
+	var cancelledTask Task
+	if err := json.Unmarshal(cancelResp.Result, &cancelledTask); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cancelledTask.Status.State != TaskStateCanceled {
+		t.Fatalf("state = %q, want canceled", cancelledTask.Status.State)
+	}
+}
+
+func TestServerCancelTask_NotFound(t *testing.T) {
+	_, ts := newTestServer(nopOpener)
+	defer ts.Close()
+
+	resp := rpcRequest(t, ts, MethodCancelTask, CancelTaskRequest{ID: "nonexistent"})
+	if resp.Error == nil {
+		t.Fatal("expected error for nonexistent task")
+	}
+	if resp.Error.Code != -32001 {
+		t.Fatalf("error code = %d, want -32001", resp.Error.Code)
+	}
+}
+
+func TestUnknownMethod(t *testing.T) {
+	_, ts := newTestServer(nopOpener)
+	defer ts.Close()
+
+	resp := rpcRequest(t, ts, "bogus/method", nil)
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown method")
+	}
+	if resp.Error.Code != -32601 {
+		t.Fatalf("error code = %d, want -32601", resp.Error.Code)
+	}
+}
+
+func TestInvalidJSON(t *testing.T) {
+	_, ts := newTestServer(nopOpener)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/a2a", "application/json", bytes.NewReader([]byte("not json")))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var rpcResp JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rpcResp.Error == nil {
+		t.Fatal("expected parse error")
+	}
+	if rpcResp.Error.Code != -32700 {
+		t.Fatalf("error code = %d, want -32700", rpcResp.Error.Code)
+	}
+}
+
+func TestConversationReuse(t *testing.T) {
+	var openCount atomic.Int32
+	mock := completingMock()
+
+	_, ts := newTestServer(func(string) (Conversation, error) {
+		openCount.Add(1)
+		return mock, nil
+	})
+	defer ts.Close()
+
+	sendMessage(t, ts, "ctx-reuse", "msg1")
+	sendMessage(t, ts, "ctx-reuse", "msg2")
+
+	if got := openCount.Load(); got != 1 {
+		t.Fatalf("opener called %d times, want 1", got)
+	}
+}
+
+func TestConcurrentRequests(t *testing.T) {
+	var openCount atomic.Int32
+	_, ts := newTestServer(func(string) (Conversation, error) {
+		openCount.Add(1)
+		return completingMock(), nil
+	})
+	defer ts.Close()
+
+	const n = 10
+	var wg sync.WaitGroup
+	wg.Add(n)
+	errs := make(chan error, n)
+
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			task := sendMessage(t, ts, "ctx-concurrent-"+string(rune('A'+i)), "Hello")
+			if task.Status.State != TaskStateCompleted {
+				errs <- errors.New("task not completed: " + string(task.Status.State))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+
+	if got := openCount.Load(); got != n {
+		t.Fatalf("opener called %d times, want %d", got, n)
+	}
+}
+
+func TestHITL(t *testing.T) {
+	var callCount atomic.Int32
+	mock := &mockConversation{
+		sendFunc: func(_ context.Context, _ *types.Message) (*ConversationResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return &ConversationResult{PendingTools: true}, nil
+			}
+			return &ConversationResult{
+				Parts: []types.ContentPart{types.NewTextPart("final answer")},
+			}, nil
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	task1 := sendMessage(t, ts, "ctx-hitl", "start")
+	if task1.Status.State != TaskStateInputRequired {
+		t.Fatalf("state = %q, want input_required", task1.Status.State)
+	}
+
+	task2 := sendMessage(t, ts, "ctx-hitl", "tool result")
+	if task2.Status.State != TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", task2.Status.State)
+	}
+}
+
+func TestServerListTasks(t *testing.T) {
+	mock := completingMock()
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	sendMessage(t, ts, "ctx-list", "msg1")
+	sendMessage(t, ts, "ctx-list", "msg2")
+
+	resp := rpcRequest(t, ts, MethodListTasks, ListTasksRequest{
+		ContextID: "ctx-list",
+	})
+	if resp.Error != nil {
+		t.Fatalf("list error: %d %s", resp.Error.Code, resp.Error.Message)
+	}
+
+	var listResp ListTasksResponse
+	if err := json.Unmarshal(resp.Result, &listResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(listResp.Tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2", len(listResp.Tasks))
+	}
+}
+
+func TestShutdown(t *testing.T) {
+	mock := completingMock()
+	srv, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	sendMessage(t, ts, "ctx-shutdown", "Hello")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	if !mock.closed.Load() {
+		t.Fatal("conversation was not closed during shutdown")
+	}
+}
+
+func TestWithTaskStore(t *testing.T) {
+	store := NewInMemoryTaskStore()
+	mock := completingMock()
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil }, WithTaskStore(store))
+	defer ts.Close()
+
+	task := sendMessage(t, ts, "ctx-store", "Hello")
+
+	got, err := store.Get(task.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got.Status.State != TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", got.Status.State)
+	}
+}
+
+func TestWithPort(t *testing.T) {
+	srv := NewServer(nopOpener, WithPort(0))
+	if srv.port != 0 {
+		t.Fatalf("port = %d, want 0", srv.port)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Server` that exposes a PromptKit `Conversation` as an A2A-compliant JSON-RPC endpoint, handling `message/send`, `tasks/get`, `tasks/cancel`, `tasks/list`, and agent card discovery (`GET /.well-known/agent.json`)
- Defines `Conversation` interface and `ConversationOpener` func type in `runtime/a2a` to avoid circular dependencies with the `sdk` package
- Builds on #258 (types), #259 (part translation), #260 (task store), and #261 (client)

## Test plan
- [x] 18 server tests covering: completed/failed/input_required flows, multimodal messages, opener errors, auto-generated context IDs, task get/cancel/list, unknown method (-32601), invalid JSON (-32700), conversation reuse, concurrent requests, HITL loop, shutdown, custom task store, agent card discovery
- [x] All 92 a2a package tests pass with `-race -count=1`
- [x] 88.3% package coverage, 86.4% on `server.go` (above 80% threshold)
- [x] Zero lint issues