### PR TITLE
feat(a2a): add tool bridge translating AgentSkill to ToolDescriptor (#265)

### DIFF
--- a/runtime/a2a/bridge.go
+++ b/runtime/a2a/bridge.go
@@ -1,0 +1,155 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// ToolBridge discovers an A2A agent and creates ToolDescriptor entries for
+// each of the agent's skills so they can be invoked through the standard
+// tool registry.
+type ToolBridge struct {
+	client *Client
+	tools  []*tools.ToolDescriptor
+}
+
+// NewToolBridge creates a ToolBridge backed by the given A2A client.
+func NewToolBridge(client *Client) *ToolBridge {
+	return &ToolBridge{client: client}
+}
+
+// RegisterAgent discovers the agent card and creates a ToolDescriptor for
+// each skill. The descriptors are appended to the bridge's internal list
+// (supporting multi-agent composition via GetToolDescriptors).
+func (b *ToolBridge) RegisterAgent(ctx context.Context) ([]*tools.ToolDescriptor, error) {
+	card, err := b.client.Discover(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("a2a bridge: discover: %w", err)
+	}
+
+	var registered []*tools.ToolDescriptor
+	for i := range card.Skills {
+		td := skillToToolDescriptor(b.client.baseURL, card, &card.Skills[i])
+		registered = append(registered, td)
+	}
+
+	b.tools = append(b.tools, registered...)
+	return registered, nil
+}
+
+// GetToolDescriptors returns all tool descriptors accumulated via
+// RegisterAgent calls.
+func (b *ToolBridge) GetToolDescriptors() []*tools.ToolDescriptor {
+	return b.tools
+}
+
+// skillToToolDescriptor converts a single AgentSkill into a ToolDescriptor.
+func skillToToolDescriptor(agentURL string, card *AgentCard, skill *AgentSkill) *tools.ToolDescriptor {
+	inputModes := skill.InputModes
+	if len(inputModes) == 0 {
+		inputModes = card.DefaultInputModes
+	}
+
+	outputModes := skill.OutputModes
+	if len(outputModes) == 0 {
+		outputModes = card.DefaultOutputModes
+	}
+
+	name := fmt.Sprintf("a2a_%s_%s", sanitizeName(card.Name), sanitizeName(skill.ID))
+
+	description := skill.Description
+	if description == "" {
+		description = skill.Name
+	}
+
+	return &tools.ToolDescriptor{
+		Name:         name,
+		Description:  description,
+		InputSchema:  generateInputSchema(inputModes),
+		OutputSchema: generateOutputSchema(outputModes),
+		Mode:         "a2a",
+		A2AConfig: &tools.A2AConfig{
+			AgentURL: agentURL,
+			SkillID:  skill.ID,
+		},
+	}
+}
+
+// generateInputSchema builds a JSON Schema based on the skill's input modes.
+func generateInputSchema(inputModes []string) json.RawMessage {
+	props := map[string]any{
+		"query": map[string]any{"type": "string"},
+	}
+	required := []string{"query"}
+
+	for _, mode := range inputModes {
+		if matchesMIME(mode, "image/") {
+			props["image_url"] = map[string]any{"type": "string"}
+			props["image_data"] = map[string]any{"type": "string"}
+			break
+		}
+	}
+
+	for _, mode := range inputModes {
+		if matchesMIME(mode, "audio/") {
+			props["audio_data"] = map[string]any{"type": "string"}
+			break
+		}
+	}
+
+	schema := map[string]any{
+		"type":       "object",
+		"properties": props,
+		"required":   required,
+	}
+	data, _ := json.Marshal(schema)
+	return data
+}
+
+// generateOutputSchema builds a JSON Schema based on the skill's output modes.
+func generateOutputSchema(outputModes []string) json.RawMessage {
+	props := map[string]any{
+		"response": map[string]any{"type": "string"},
+	}
+
+	hasMedia := false
+	for _, mode := range outputModes {
+		if matchesMIME(mode, "image/") || matchesMIME(mode, "audio/") {
+			hasMedia = true
+			break
+		}
+	}
+	if hasMedia {
+		props["media_url"] = map[string]any{"type": "string"}
+		props["media_type"] = map[string]any{"type": "string"}
+	}
+
+	schema := map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+	data, _ := json.Marshal(schema)
+	return data
+}
+
+// matchesMIME checks if a mode string matches a MIME type prefix.
+// For example, "image/*" and "image/png" both match prefix "image/".
+func matchesMIME(mode, prefix string) bool {
+	return strings.HasPrefix(mode, prefix)
+}
+
+var nonAlphanumeric = regexp.MustCompile(`[^a-z0-9]+`)
+
+// sanitizeName converts a string to a safe tool-name component:
+// lowercase, non-alphanumeric runs replaced with "_", trimmed.
+func sanitizeName(s string) string {
+	s = strings.ToLower(s)
+	s = nonAlphanumeric.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	return s
+}

--- a/runtime/a2a/bridge_test.go
+++ b/runtime/a2a/bridge_test.go
@@ -1,0 +1,417 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// serveAgentCard returns an httptest.Server that serves the given AgentCard
+// at /.well-known/agent.json.
+func serveAgentCard(t *testing.T, card AgentCard) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/agent.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(card); err != nil {
+			t.Fatalf("encode agent card: %v", err)
+		}
+	}))
+}
+
+// schemaProps extracts the "properties" map from a JSON Schema RawMessage.
+func schemaProps(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema has no properties")
+	}
+	return props
+}
+
+// schemaRequired extracts the "required" array from a JSON Schema RawMessage.
+func schemaRequired(t *testing.T, raw json.RawMessage) []string {
+	t.Helper()
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	reqRaw, ok := schema["required"]
+	if !ok {
+		return nil
+	}
+	arr, ok := reqRaw.([]any)
+	if !ok {
+		t.Fatal("required is not an array")
+	}
+	result := make([]string, len(arr))
+	for i, v := range arr {
+		result[i] = v.(string)
+	}
+	return result
+}
+
+func TestToolBridge_RegisterAgent_TextOnly(t *testing.T) {
+	srv := serveAgentCard(t, AgentCard{
+		Name: "echo",
+		Skills: []AgentSkill{
+			{
+				ID:          "echo",
+				Name:        "Echo",
+				Description: "Echoes input",
+				InputModes:  []string{"text/plain"},
+				OutputModes: []string{"text/plain"},
+			},
+		},
+	})
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	tds, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if len(tds) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tds))
+	}
+
+	td := tds[0]
+
+	// Input: should have only "query"
+	inProps := schemaProps(t, td.InputSchema)
+	if _, ok := inProps["query"]; !ok {
+		t.Error("input schema missing 'query'")
+	}
+	if _, ok := inProps["image_url"]; ok {
+		t.Error("text-only skill should not have 'image_url'")
+	}
+	if _, ok := inProps["audio_data"]; ok {
+		t.Error("text-only skill should not have 'audio_data'")
+	}
+	req := schemaRequired(t, td.InputSchema)
+	if len(req) != 1 || req[0] != "query" {
+		t.Errorf("expected required=[query], got %v", req)
+	}
+
+	// Output: should have only "response"
+	outProps := schemaProps(t, td.OutputSchema)
+	if _, ok := outProps["response"]; !ok {
+		t.Error("output schema missing 'response'")
+	}
+	if _, ok := outProps["media_url"]; ok {
+		t.Error("text-only skill should not have 'media_url'")
+	}
+}
+
+func TestToolBridge_RegisterAgent_Multimodal(t *testing.T) {
+	srv := serveAgentCard(t, AgentCard{
+		Name: "vision",
+		Skills: []AgentSkill{
+			{
+				ID:          "describe",
+				Name:        "Describe Image",
+				Description: "Describes an image",
+				InputModes:  []string{"text/plain", "image/*"},
+				OutputModes: []string{"text/plain"},
+			},
+		},
+	})
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	tds, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	td := tds[0]
+	inProps := schemaProps(t, td.InputSchema)
+	if _, ok := inProps["image_url"]; !ok {
+		t.Error("multimodal input should have 'image_url'")
+	}
+	if _, ok := inProps["image_data"]; !ok {
+		t.Error("multimodal input should have 'image_data'")
+	}
+}
+
+func TestToolBridge_RegisterAgent_AudioInput(t *testing.T) {
+	srv := serveAgentCard(t, AgentCard{
+		Name: "transcriber",
+		Skills: []AgentSkill{
+			{
+				ID:          "transcribe",
+				Name:        "Transcribe Audio",
+				Description: "Transcribes audio",
+				InputModes:  []string{"text/plain", "audio/*"},
+				OutputModes: []string{"text/plain"},
+			},
+		},
+	})
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	tds, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	td := tds[0]
+	inProps := schemaProps(t, td.InputSchema)
+	if _, ok := inProps["audio_data"]; !ok {
+		t.Error("audio input should have 'audio_data'")
+	}
+}
+
+func TestToolBridge_RegisterAgent_MultimodalOutput(t *testing.T) {
+	srv := serveAgentCard(t, AgentCard{
+		Name: "generator",
+		Skills: []AgentSkill{
+			{
+				ID:          "generate",
+				Name:        "Generate Image",
+				Description: "Generates an image",
+				InputModes:  []string{"text/plain"},
+				OutputModes: []string{"text/plain", "image/png"},
+			},
+		},
+	})
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	tds, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	td := tds[0]
+	outProps := schemaProps(t, td.OutputSchema)
+	if _, ok := outProps["media_url"]; !ok {
+		t.Error("multimodal output should have 'media_url'")
+	}
+	if _, ok := outProps["media_type"]; !ok {
+		t.Error("multimodal output should have 'media_type'")
+	}
+}
+
+func TestToolBridge_RegisterAgent_MultipleSkills(t *testing.T) {
+	srv := serveAgentCard(t, AgentCard{
+		Name: "multi",
+		Skills: []AgentSkill{
+			{ID: "skill_a", Name: "A"},
+			{ID: "skill_b", Name: "B"},
+			{ID: "skill_c", Name: "C"},
+		},
+	})
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	tds, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+	if len(tds) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tds))
+	}
+}
+
+func TestToolBridge_RegisterAgent_InheritsModes(t *testing.T) {
+	srv := serveAgentCard(t, AgentCard{
+		Name:              "default_modes",
+		DefaultInputModes: []string{"text/plain", "image/*"},
+		DefaultOutputModes: []string{"text/plain", "audio/wav"},
+		Skills: []AgentSkill{
+			{
+				ID:   "inherit",
+				Name: "Inheriting Skill",
+				// No InputModes/OutputModes — should inherit from card defaults
+			},
+		},
+	})
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	tds, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	td := tds[0]
+
+	// Input should inherit image/* from card defaults
+	inProps := schemaProps(t, td.InputSchema)
+	if _, ok := inProps["image_url"]; !ok {
+		t.Error("inherited input should have 'image_url' from card defaults")
+	}
+
+	// Output should inherit audio/wav from card defaults
+	outProps := schemaProps(t, td.OutputSchema)
+	if _, ok := outProps["media_url"]; !ok {
+		t.Error("inherited output should have 'media_url' from card defaults")
+	}
+}
+
+func TestToolBridge_RegisterAgent_ToolNaming(t *testing.T) {
+	srv := serveAgentCard(t, AgentCard{
+		Name: "Weather Bot",
+		Skills: []AgentSkill{
+			{ID: "forecast", Name: "Forecast"},
+		},
+	})
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	tds, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	expected := "a2a_weather_bot_forecast"
+	if tds[0].Name != expected {
+		t.Errorf("expected name %q, got %q", expected, tds[0].Name)
+	}
+}
+
+func TestToolBridge_RegisterAgent_NameSanitization(t *testing.T) {
+	tests := []struct {
+		agentName string
+		skillID   string
+		want      string
+	}{
+		{"My Agent!", "do-stuff", "a2a_my_agent_do_stuff"},
+		{"UPPER", "CASE", "a2a_upper_case"},
+		{"  spaces  ", "  skill  ", "a2a_spaces_skill"},
+		{"multi---dash", "under___score", "a2a_multi_dash_under_score"},
+	}
+
+	for _, tt := range tests {
+		srv := serveAgentCard(t, AgentCard{
+			Name: tt.agentName,
+			Skills: []AgentSkill{
+				{ID: tt.skillID, Name: "Test"},
+			},
+		})
+
+		bridge := NewToolBridge(NewClient(srv.URL))
+		tds, err := bridge.RegisterAgent(context.Background())
+		if err != nil {
+			srv.Close()
+			t.Fatalf("RegisterAgent: %v", err)
+		}
+		if tds[0].Name != tt.want {
+			t.Errorf("sanitize(%q, %q) = %q, want %q",
+				tt.agentName, tt.skillID, tds[0].Name, tt.want)
+		}
+		srv.Close()
+	}
+}
+
+func TestToolBridge_RegisterAgent_A2AConfig(t *testing.T) {
+	srv := serveAgentCard(t, AgentCard{
+		Name: "configured",
+		Skills: []AgentSkill{
+			{ID: "my_skill", Name: "My Skill"},
+		},
+	})
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	tds, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent: %v", err)
+	}
+
+	td := tds[0]
+	if td.Mode != "a2a" {
+		t.Errorf("expected mode 'a2a', got %q", td.Mode)
+	}
+	if td.A2AConfig == nil {
+		t.Fatal("A2AConfig is nil")
+	}
+	if td.A2AConfig.AgentURL != srv.URL {
+		t.Errorf("AgentURL = %q, want %q", td.A2AConfig.AgentURL, srv.URL)
+	}
+	if td.A2AConfig.SkillID != "my_skill" {
+		t.Errorf("SkillID = %q, want %q", td.A2AConfig.SkillID, "my_skill")
+	}
+}
+
+func TestToolBridge_RegisterAgent_DiscoverError(t *testing.T) {
+	// Server that always returns 500
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	bridge := NewToolBridge(NewClient(srv.URL))
+	_, err := bridge.RegisterAgent(context.Background())
+	if err == nil {
+		t.Fatal("expected error from discover failure")
+	}
+}
+
+func TestToolBridge_GetToolDescriptors(t *testing.T) {
+	// Register two agents and verify accumulation.
+	srv1 := serveAgentCard(t, AgentCard{
+		Name: "agent1",
+		Skills: []AgentSkill{
+			{ID: "s1", Name: "Skill 1"},
+		},
+	})
+	defer srv1.Close()
+
+	srv2 := serveAgentCard(t, AgentCard{
+		Name: "agent2",
+		Skills: []AgentSkill{
+			{ID: "s2", Name: "Skill 2"},
+			{ID: "s3", Name: "Skill 3"},
+		},
+	})
+	defer srv2.Close()
+
+	bridge := NewToolBridge(NewClient(srv1.URL))
+	_, err := bridge.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent agent1: %v", err)
+	}
+
+	// Register second agent using a new bridge-internal client.
+	// For multi-agent, we re-create with a second client.
+	bridge2 := NewToolBridge(NewClient(srv2.URL))
+	tds2, err := bridge2.RegisterAgent(context.Background())
+	if err != nil {
+		t.Fatalf("RegisterAgent agent2: %v", err)
+	}
+
+	// Manually append to first bridge's descriptors to simulate multi-agent usage.
+	bridge.tools = append(bridge.tools, tds2...)
+
+	all := bridge.GetToolDescriptors()
+	if len(all) != 3 {
+		t.Fatalf("expected 3 accumulated tools, got %d", len(all))
+	}
+
+	// Verify names.
+	names := make(map[string]bool)
+	for _, td := range all {
+		names[td.Name] = true
+	}
+	for _, want := range []string{"a2a_agent1_s1", "a2a_agent2_s2", "a2a_agent2_s3"} {
+		if !names[want] {
+			t.Errorf("missing expected tool %q", want)
+		}
+	}
+}
+
+// Verify that the unused import doesn't cause issues — tools is used for A2AConfig type assertions.
+var _ *tools.A2AConfig

--- a/runtime/tools/types.go
+++ b/runtime/tools/types.go
@@ -44,6 +44,7 @@ type ToolDescriptor struct {
 	MockTemplateFile string `json:"mock_template_file,omitempty" yaml:"mock_template_file,omitempty"`
 
 	HTTPConfig *HTTPConfig `json:"http,omitempty" yaml:"http,omitempty"` // Live HTTP configuration
+	A2AConfig  *A2AConfig  `json:"a2a,omitempty" yaml:"a2a,omitempty"`   // A2A agent configuration
 }
 
 // HTTPConfig defines configuration for live HTTP tool execution
@@ -54,6 +55,13 @@ type HTTPConfig struct {
 	TimeoutMs      int               `json:"timeout_ms" yaml:"timeout_ms"`
 	Redact         []string          `json:"redact,omitempty" yaml:"redact,omitempty"`
 	Headers        map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+}
+
+// A2AConfig defines configuration for A2A agent tool execution
+type A2AConfig struct {
+	AgentURL  string `json:"agent_url" yaml:"agent_url"`
+	SkillID   string `json:"skill_id" yaml:"skill_id"`
+	TimeoutMs int    `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
 }
 
 // ToolCall represents a tool invocation request


### PR DESCRIPTION
## Summary
- Add `A2AConfig` struct to `ToolDescriptor` (parallel to existing `HTTPConfig`) with `AgentURL`, `SkillID`, and `TimeoutMs` fields
- Implement `ToolBridge` that discovers a remote A2A agent and converts each `AgentSkill` into a `ToolDescriptor` with `Mode: "a2a"`, enabling the LLM to invoke remote agents as regular tools
- Schema generation is deterministic from MIME mode lists: `image/*` input adds `image_url`/`image_data`, `audio/*` adds `audio_data`, media outputs add `media_url`/`media_type`

## Test plan
- [x] 11 test cases covering text-only, multimodal, audio, multiple skills, mode inheritance, naming/sanitization, config population, and error propagation
- [x] 100% coverage on changed files (`bridge.go`, `types.go`)
- [x] All existing a2a and tools tests still pass
- [x] `go vet` clean on both packages