### PR TITLE
feat(a2a): add WithA2ATools SDK option and a2aExecutor (#266)

### DIFF
--- a/sdk/a2a_executor.go
+++ b/sdk/a2a_executor.go
@@ -1,0 +1,135 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// a2aExecutor implements tools.Executor for A2A agent tools.
+// It dispatches tool calls to remote A2A agents via the A2A client.
+type a2aExecutor struct {
+	mu      sync.RWMutex
+	clients map[string]*a2a.Client
+}
+
+// Name returns "a2a" to match the Mode on A2A tool descriptors.
+func (e *a2aExecutor) Name() string { return "a2a" }
+
+// Execute calls a remote A2A agent with the tool arguments and returns the response.
+func (e *a2aExecutor) Execute(descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+	if descriptor.A2AConfig == nil {
+		return nil, fmt.Errorf("a2a executor: tool %q has no A2AConfig", descriptor.Name)
+	}
+
+	cfg := descriptor.A2AConfig
+	client := e.getOrCreateClient(cfg.AgentURL)
+
+	// Parse arguments
+	var input struct {
+		Query     string `json:"query"`
+		ImageURL  string `json:"image_url,omitempty"`
+		ImageData string `json:"image_data,omitempty"`
+		AudioData string `json:"audio_data,omitempty"`
+	}
+	if err := json.Unmarshal(args, &input); err != nil {
+		return nil, fmt.Errorf("a2a executor: parse args: %w", err)
+	}
+
+	// Build message parts
+	text := input.Query
+	parts := []a2a.Part{{Text: &text}}
+
+	if input.ImageURL != "" {
+		parts = append(parts, a2a.Part{URL: &input.ImageURL, MediaType: "image/*"})
+	}
+	if input.ImageData != "" {
+		parts = append(parts, a2a.Part{Raw: []byte(input.ImageData), MediaType: "image/*"})
+	}
+	if input.AudioData != "" {
+		parts = append(parts, a2a.Part{Raw: []byte(input.AudioData), MediaType: "audio/*"})
+	}
+
+	req := &a2a.SendMessageRequest{
+		Message: a2a.Message{
+			Role:  a2a.RoleUser,
+			Parts: parts,
+		},
+	}
+
+	// Apply timeout
+	ctx := context.Background()
+	if cfg.TimeoutMs > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(cfg.TimeoutMs)*time.Millisecond)
+		defer cancel()
+	}
+
+	task, err := client.SendMessage(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("a2a executor: send message: %w", err)
+	}
+
+	// Extract response text from task
+	responseText := extractResponseText(task)
+
+	result := map[string]string{"response": responseText}
+	return json.Marshal(result)
+}
+
+// getOrCreateClient returns a cached client or creates a new one.
+func (e *a2aExecutor) getOrCreateClient(agentURL string) *a2a.Client {
+	e.mu.RLock()
+	if c, ok := e.clients[agentURL]; ok {
+		e.mu.RUnlock()
+		return c
+	}
+	e.mu.RUnlock()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Double-check after acquiring write lock
+	if c, ok := e.clients[agentURL]; ok {
+		return c
+	}
+	if e.clients == nil {
+		e.clients = make(map[string]*a2a.Client)
+	}
+	c := a2a.NewClient(agentURL)
+	e.clients[agentURL] = c
+	return c
+}
+
+// extractResponseText extracts text from a completed A2A task.
+// It checks the status message first, then artifacts.
+func extractResponseText(task *a2a.Task) string {
+	// Check status message
+	if task.Status.Message != nil {
+		for _, part := range task.Status.Message.Parts {
+			if part.Text != nil {
+				return *part.Text
+			}
+		}
+	}
+
+	// Check artifacts
+	var texts []string
+	for _, artifact := range task.Artifacts {
+		for _, part := range artifact.Parts {
+			if part.Text != nil {
+				texts = append(texts, *part.Text)
+			}
+		}
+	}
+	if len(texts) > 0 {
+		return strings.Join(texts, "\n")
+	}
+
+	return ""
+}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -242,6 +242,7 @@ func (c *Conversation) buildPipelineWithParams(
 	localExec := &localExecutor{handlers: c.handlers}
 	c.toolRegistry.RegisterExecutor(localExec)
 	c.registerMCPExecutors()
+	c.registerA2ATools()
 	toolRegistry := c.toolRegistry
 	c.handlersMu.RUnlock()
 
@@ -310,6 +311,7 @@ func (c *Conversation) buildStreamPipelineWithParams(
 	localExec := &localExecutor{handlers: c.handlers}
 	c.toolRegistry.RegisterExecutor(localExec)
 	c.registerMCPExecutors()
+	c.registerA2ATools()
 	toolRegistry := c.toolRegistry
 	c.handlersMu.RUnlock()
 

--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -374,6 +374,17 @@ func (c *Conversation) ToolRegistry() *tools.Registry {
 	return c.toolRegistry
 }
 
+// registerA2ATools registers tool descriptors and the executor for A2A tools.
+func (c *Conversation) registerA2ATools() {
+	if c.config.a2aBridge == nil {
+		return
+	}
+	for _, td := range c.config.a2aBridge.GetToolDescriptors() {
+		_ = c.toolRegistry.Register(td)
+	}
+	c.toolRegistry.RegisterExecutor(&a2aExecutor{})
+}
+
 // registerMCPExecutors registers executors for MCP tools.
 func (c *Conversation) registerMCPExecutors() {
 	if c.mcpRegistry == nil {

--- a/sdk/hitl_test.go
+++ b/sdk/hitl_test.go
@@ -208,6 +208,65 @@ func TestContinue(t *testing.T) {
 	})
 }
 
+func TestContinue_ResolutionBranches(t *testing.T) {
+	// These tests exercise the resolution-building branches in Continue().
+	// The minimal test pipeline processes messages without a provider, so
+	// Continue succeeds — we verify the code paths don't panic.
+
+	t.Run("builds rejected resolution message", func(t *testing.T) {
+		conv := newTestConversation()
+		conv.resolvedStore = sdktools.NewResolvedStore()
+		conv.resolvedStore.Add(&sdktools.ToolResolution{
+			ID:              "r1",
+			Rejected:        true,
+			RejectionReason: "not authorized",
+		})
+
+		resp, err := conv.Continue(context.Background())
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("builds error resolution message", func(t *testing.T) {
+		conv := newTestConversation()
+		conv.resolvedStore = sdktools.NewResolvedStore()
+		conv.resolvedStore.Add(&sdktools.ToolResolution{
+			ID:    "r2",
+			Error: assert.AnError,
+		})
+
+		resp, err := conv.Continue(context.Background())
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("builds resultJSON resolution message", func(t *testing.T) {
+		conv := newTestConversation()
+		conv.resolvedStore = sdktools.NewResolvedStore()
+		conv.resolvedStore.Add(&sdktools.ToolResolution{
+			ID:         "r3",
+			ResultJSON: []byte(`{"status":"ok"}`),
+		})
+
+		resp, err := conv.Continue(context.Background())
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("builds plain result resolution message", func(t *testing.T) {
+		conv := newTestConversation()
+		conv.resolvedStore = sdktools.NewResolvedStore()
+		conv.resolvedStore.Add(&sdktools.ToolResolution{
+			ID:     "r4",
+			Result: "plain value",
+		})
+
+		resp, err := conv.Continue(context.Background())
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+}
+
 func TestResolveToolStoresResolution(t *testing.T) {
 	t.Run("stores resolution for continue", func(t *testing.T) {
 		conv := newTestConversation()

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
@@ -66,6 +67,9 @@ type config struct {
 
 	// MCP configuration
 	mcpServers []mcp.ServerConfig
+
+	// A2A tool bridge for remote agent tools
+	a2aBridge *a2a.ToolBridge
 
 	// Variable providers for dynamic variable resolution
 	variableProviders []variables.Provider
@@ -650,6 +654,28 @@ func (b *MCPServerBuilder) Build() mcp.ServerConfig {
 func WithMCPServer(builder *MCPServerBuilder) Option {
 	return func(c *config) error {
 		c.mcpServers = append(c.mcpServers, builder.Build())
+		return nil
+	}
+}
+
+// WithA2ATools registers tools from an A2A [a2a.ToolBridge] so the LLM can
+// call remote A2A agents as tools.
+//
+// The bridge must have already discovered agents via [a2a.ToolBridge.RegisterAgent].
+// Each agent skill becomes a tool with Mode "a2a" in the tool registry.
+//
+// Example:
+//
+//	client := a2a.NewClient("https://agent.example.com")
+//	bridge := a2a.NewToolBridge(client)
+//	bridge.RegisterAgent(ctx)
+//
+//	conv, _ := sdk.Open("./assistant.pack.json", "assistant",
+//	    sdk.WithA2ATools(bridge),
+//	)
+func WithA2ATools(bridge *a2a.ToolBridge) Option {
+	return func(c *config) error {
+		c.a2aBridge = bridge
 		return nil
 	}
 }

--- a/sdk/sdk_a2a_test.go
+++ b/sdk/sdk_a2a_test.go
@@ -1,0 +1,292 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// a2aTestServer creates an httptest.Server that serves an agent card and
+// handles JSON-RPC message/send requests. It returns a completed task with
+// the given response text.
+func a2aTestServer(t *testing.T, agentName, skillID, responseText string) *httptest.Server {
+	t.Helper()
+	card := a2a.AgentCard{
+		Name: agentName,
+		Skills: []a2a.AgentSkill{
+			{ID: skillID, Name: skillID, Description: "Test skill"},
+		},
+		DefaultInputModes:  []string{"text/plain"},
+		DefaultOutputModes: []string{"text/plain"},
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/agent.json":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(card)
+
+		case "/a2a":
+			var rpcReq a2a.JSONRPCRequest
+			json.NewDecoder(r.Body).Decode(&rpcReq)
+
+			text := responseText
+			task := a2a.Task{
+				ID:        "task-1",
+				ContextID: "ctx-1",
+				Status: a2a.TaskStatus{
+					State: a2a.TaskStateCompleted,
+					Message: &a2a.Message{
+						Role:  a2a.RoleAgent,
+						Parts: []a2a.Part{{Text: &text}},
+					},
+				},
+			}
+
+			taskJSON, _ := json.Marshal(task)
+			resp := a2a.JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      rpcReq.ID,
+				Result:  taskJSON,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// setupA2ABridge creates a ToolBridge with a registered agent from the test server.
+func setupA2ABridge(t *testing.T, serverURL string) *a2a.ToolBridge {
+	t.Helper()
+	client := a2a.NewClient(serverURL)
+	bridge := a2a.NewToolBridge(client)
+	_, err := bridge.RegisterAgent(context.Background())
+	require.NoError(t, err)
+	return bridge
+}
+
+func TestA2AExecutor_Name(t *testing.T) {
+	exec := &a2aExecutor{}
+	assert.Equal(t, "a2a", exec.Name())
+}
+
+func TestA2AExecutor_Execute(t *testing.T) {
+	srv := a2aTestServer(t, "TestAgent", "greet", "Hello from remote agent!")
+	defer srv.Close()
+
+	exec := &a2aExecutor{}
+	desc := &tools.ToolDescriptor{
+		Name: "a2a_testagent_greet",
+		Mode: "a2a",
+		A2AConfig: &tools.A2AConfig{
+			AgentURL: srv.URL,
+			SkillID:  "greet",
+		},
+	}
+
+	args := json.RawMessage(`{"query":"Hi there"}`)
+	result, err := exec.Execute(desc, args)
+	require.NoError(t, err)
+
+	var parsed map[string]string
+	require.NoError(t, json.Unmarshal(result, &parsed))
+	assert.Equal(t, "Hello from remote agent!", parsed["response"])
+}
+
+func TestA2AExecutor_Execute_NoA2AConfig(t *testing.T) {
+	exec := &a2aExecutor{}
+	desc := &tools.ToolDescriptor{Name: "bad_tool", Mode: "a2a"}
+
+	_, err := exec.Execute(desc, json.RawMessage(`{"query":"test"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no A2AConfig")
+}
+
+func TestA2AExecutor_Execute_Timeout(t *testing.T) {
+	srv := a2aTestServer(t, "TestAgent", "greet", "ok")
+	defer srv.Close()
+
+	exec := &a2aExecutor{}
+	desc := &tools.ToolDescriptor{
+		Name: "a2a_testagent_greet",
+		Mode: "a2a",
+		A2AConfig: &tools.A2AConfig{
+			AgentURL:  srv.URL,
+			SkillID:   "greet",
+			TimeoutMs: 5000, // generous timeout for test
+		},
+	}
+
+	result, err := exec.Execute(desc, json.RawMessage(`{"query":"Hi"}`))
+	require.NoError(t, err)
+
+	var parsed map[string]string
+	require.NoError(t, json.Unmarshal(result, &parsed))
+	assert.Equal(t, "ok", parsed["response"])
+}
+
+func TestA2AExecutor_ClientCaching(t *testing.T) {
+	exec := &a2aExecutor{}
+
+	c1 := exec.getOrCreateClient("http://agent1.example.com")
+	c2 := exec.getOrCreateClient("http://agent1.example.com")
+	c3 := exec.getOrCreateClient("http://agent2.example.com")
+
+	assert.Same(t, c1, c2, "same URL should return same client")
+	assert.NotSame(t, c1, c3, "different URLs should return different clients")
+}
+
+func TestWithA2ATools_Option(t *testing.T) {
+	srv := a2aTestServer(t, "MyAgent", "do_stuff", "result")
+	defer srv.Close()
+
+	bridge := setupA2ABridge(t, srv.URL)
+
+	cfg := &config{}
+	opt := WithA2ATools(bridge)
+	err := opt(cfg)
+
+	require.NoError(t, err)
+	assert.Same(t, bridge, cfg.a2aBridge)
+}
+
+func TestWithA2ATools_NilBridge(t *testing.T) {
+	conv := newTestConversation()
+	conv.config.a2aBridge = nil
+
+	// registerA2ATools should be a no-op
+	conv.registerA2ATools()
+
+	// Verify no extra tools were registered
+	allTools := conv.toolRegistry.GetTools()
+	assert.Empty(t, allTools)
+}
+
+func TestWithA2ATools_ToolsRegistered(t *testing.T) {
+	srv := a2aTestServer(t, "MyAgent", "summarize", "summary")
+	defer srv.Close()
+
+	bridge := setupA2ABridge(t, srv.URL)
+	conv := newTestConversation()
+	conv.config.a2aBridge = bridge
+
+	conv.registerA2ATools()
+
+	// The tool name is "a2a_myagent_summarize" (sanitized)
+	tool, err := conv.toolRegistry.GetTool("a2a_myagent_summarize")
+	require.NoError(t, err)
+	assert.Equal(t, "a2a_myagent_summarize", tool.Name)
+	assert.Equal(t, "a2a", tool.Mode)
+	assert.NotNil(t, tool.A2AConfig)
+	assert.Equal(t, srv.URL, tool.A2AConfig.AgentURL)
+	assert.Equal(t, "summarize", tool.A2AConfig.SkillID)
+}
+
+func TestWithA2ATools_ExecutorRegistered(t *testing.T) {
+	srv := a2aTestServer(t, "MyAgent", "summarize", "summary")
+	defer srv.Close()
+
+	bridge := setupA2ABridge(t, srv.URL)
+	conv := newTestConversation()
+	conv.config.a2aBridge = bridge
+
+	conv.registerA2ATools()
+
+	// The registry should be able to resolve the "a2a" executor for this tool.
+	// We verify by calling Execute on the registry directly.
+	result, err := conv.toolRegistry.Execute("a2a_myagent_summarize", json.RawMessage(`{"query":"test"}`))
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result.Error)
+	assert.NotNil(t, result.Result)
+}
+
+func TestWithA2ATools_AlongsidePackTools(t *testing.T) {
+	srv := a2aTestServer(t, "RemoteAgent", "translate", "translated")
+	defer srv.Close()
+
+	bridge := setupA2ABridge(t, srv.URL)
+	conv := newTestConversation()
+	conv.config.a2aBridge = bridge
+
+	// Register a local tool handler
+	conv.OnTool("local_tool", func(args map[string]any) (any, error) {
+		return "local result", nil
+	})
+
+	// Register local executor + A2A tools
+	localExec := &localExecutor{handlers: conv.handlers}
+	conv.toolRegistry.RegisterExecutor(localExec)
+
+	// Also register the local tool descriptor
+	_ = conv.toolRegistry.Register(&tools.ToolDescriptor{
+		Name:        "local_tool",
+		Description: "A local tool",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Mode:        "local",
+	})
+
+	conv.registerA2ATools()
+
+	// Both should be present
+	_, err := conv.toolRegistry.GetTool("local_tool")
+	assert.NoError(t, err)
+
+	_, err = conv.toolRegistry.GetTool("a2a_remoteagent_translate")
+	assert.NoError(t, err)
+}
+
+func TestExtractResponseText(t *testing.T) {
+	t.Run("from status message", func(t *testing.T) {
+		text := "hello"
+		task := &a2a.Task{
+			Status: a2a.TaskStatus{
+				Message: &a2a.Message{
+					Parts: []a2a.Part{{Text: &text}},
+				},
+			},
+		}
+		assert.Equal(t, "hello", extractResponseText(task))
+	})
+
+	t.Run("from artifacts", func(t *testing.T) {
+		text := "artifact text"
+		task := &a2a.Task{
+			Artifacts: []a2a.Artifact{
+				{Parts: []a2a.Part{{Text: &text}}},
+			},
+		}
+		assert.Equal(t, "artifact text", extractResponseText(task))
+	})
+
+	t.Run("empty task", func(t *testing.T) {
+		task := &a2a.Task{}
+		assert.Equal(t, "", extractResponseText(task))
+	})
+
+	t.Run("status message preferred over artifacts", func(t *testing.T) {
+		statusText := "from status"
+		artifactText := "from artifact"
+		task := &a2a.Task{
+			Status: a2a.TaskStatus{
+				Message: &a2a.Message{
+					Parts: []a2a.Part{{Text: &statusText}},
+				},
+			},
+			Artifacts: []a2a.Artifact{
+				{Parts: []a2a.Part{{Text: &artifactText}}},
+			},
+		}
+		assert.Equal(t, "from status", extractResponseText(task))
+	})
+}


### PR DESCRIPTION
## Summary

- Add `a2aExecutor` implementing `tools.Executor` (Name → `"a2a"`) that dispatches tool calls to remote A2A agents via `a2a.Client`, with per-URL client caching and configurable timeouts
- Add `WithA2ATools(bridge)` SDK option that wires `ToolBridge` descriptors and executor into the conversation pipeline, mirroring the existing MCP integration pattern
- Add `registerA2ATools()` method called during pipeline building in both `buildPipelineWithParams` and `buildStreamPipelineWithParams`

## Test plan

- [x] `TestA2AExecutor_Name` — executor name is `"a2a"`
- [x] `TestA2AExecutor_Execute` — end-to-end call via mock httptest server returns expected response
- [x] `TestA2AExecutor_Execute_NoA2AConfig` — error when A2AConfig is missing
- [x] `TestA2AExecutor_Execute_Timeout` — timeout config applied via context
- [x] `TestA2AExecutor_ClientCaching` — same URL returns same client instance
- [x] `TestWithA2ATools_Option` — bridge stored in config
- [x] `TestWithA2ATools_NilBridge` — no-op when bridge is nil
- [x] `TestWithA2ATools_ToolsRegistered` — descriptors appear in tool registry with correct mode and A2AConfig
- [x] `TestWithA2ATools_ExecutorRegistered` — registry can execute a2a-mode tools end-to-end
- [x] `TestWithA2ATools_AlongsidePackTools` — A2A tools coexist with local pack tools
- [x] `TestExtractResponseText` — response extraction from status message, artifacts, empty task, and priority