### PR TITLE
feat(a2a): add configurable mock A2A server for Arena tests (#267)

### DIFF
--- a/runtime/a2a/mock/config.go
+++ b/runtime/a2a/mock/config.go
@@ -1,0 +1,111 @@
+package mock
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+)
+
+// AgentConfig is the YAML-friendly configuration for a mock agent.
+type AgentConfig struct {
+	Name      string        `json:"name" yaml:"name"`
+	Card      a2a.AgentCard `json:"card" yaml:"card"`
+	Responses []RuleConfig  `json:"responses" yaml:"responses"`
+}
+
+// RuleConfig describes a single response rule.
+type RuleConfig struct {
+	Skill    string          `json:"skill" yaml:"skill"`
+	Match    *MatchConfig    `json:"match,omitempty" yaml:"match,omitempty"`
+	Response *ResponseConfig `json:"response,omitempty" yaml:"response,omitempty"`
+	Error    string          `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+// MatchConfig describes how to match incoming messages.
+type MatchConfig struct {
+	Contains string `json:"contains,omitempty" yaml:"contains,omitempty"`
+	Regex    string `json:"regex,omitempty" yaml:"regex,omitempty"`
+}
+
+// ResponseConfig describes the response parts.
+type ResponseConfig struct {
+	Parts []PartConfig `json:"parts" yaml:"parts"`
+}
+
+// PartConfig describes a single response part.
+type PartConfig struct {
+	Text string `json:"text" yaml:"text"`
+}
+
+// OptionsFromConfig converts an AgentConfig's response rules into Options.
+func OptionsFromConfig(cfg *AgentConfig) []Option {
+	var opts []Option
+	for _, rule := range cfg.Responses {
+		if rule.Error != "" {
+			opts = append(opts, WithSkillError(rule.Skill, rule.Error))
+			continue
+		}
+		if rule.Response == nil {
+			continue
+		}
+
+		resp := configToResponse(rule.Response)
+		matcher := matcherFromConfig(rule.Match)
+
+		if matcher != nil {
+			opts = append(opts, WithInputMatcher(rule.Skill, matcher, resp))
+		} else {
+			opts = append(opts, WithSkillResponse(rule.Skill, resp))
+		}
+	}
+	return opts
+}
+
+// configToResponse converts a ResponseConfig to a Response.
+func configToResponse(cfg *ResponseConfig) Response {
+	var parts []a2a.Part
+	for _, p := range cfg.Parts {
+		text := p.Text
+		parts = append(parts, a2a.Part{Text: &text})
+	}
+	return Response{Parts: parts}
+}
+
+// matcherFromConfig builds a matcher function from a MatchConfig.
+// Returns nil if mc is nil (no matching required).
+func matcherFromConfig(mc *MatchConfig) func(a2a.Message) bool {
+	if mc == nil {
+		return nil
+	}
+
+	var checks []func(string) bool
+
+	if mc.Contains != "" {
+		lower := strings.ToLower(mc.Contains)
+		checks = append(checks, func(text string) bool {
+			return strings.Contains(strings.ToLower(text), lower)
+		})
+	}
+
+	if mc.Regex != "" {
+		re := regexp.MustCompile(mc.Regex)
+		checks = append(checks, func(text string) bool {
+			return re.MatchString(text)
+		})
+	}
+
+	if len(checks) == 0 {
+		return nil
+	}
+
+	return func(msg a2a.Message) bool {
+		text := messageText(&msg)
+		for _, check := range checks {
+			if !check(text) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/runtime/a2a/mock/mock.go
+++ b/runtime/a2a/mock/mock.go
@@ -1,0 +1,260 @@
+// Package mock provides a configurable mock A2A server for use in tests.
+//
+// It serves canned responses per skill with optional input matching,
+// latency injection, and error injection.
+package mock
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+)
+
+// Response holds the parts returned by a matched rule.
+type Response struct {
+	Parts []a2a.Part
+}
+
+// mockRule is an internal rule evaluated in order during message/send handling.
+type mockRule struct {
+	skillID  string
+	matcher  func(a2a.Message) bool
+	response *Response
+	errMsg   string
+}
+
+// A2AServer is a lightweight mock A2A server backed by httptest.Server.
+type A2AServer struct {
+	card    a2a.AgentCard
+	rules   []mockRule
+	latency time.Duration
+	taskSeq atomic.Int64
+	ts      *httptest.Server
+}
+
+// Option configures an A2AServer.
+type Option func(*A2AServer)
+
+// WithSkillResponse adds a rule that returns response for the given skill ID.
+func WithSkillResponse(skillID string, response Response) Option {
+	return func(m *A2AServer) {
+		m.rules = append(m.rules, mockRule{
+			skillID:  skillID,
+			response: &response,
+		})
+	}
+}
+
+// WithSkillError adds a rule that returns a failed task for the given skill ID.
+func WithSkillError(skillID, errMsg string) Option {
+	return func(m *A2AServer) {
+		m.rules = append(m.rules, mockRule{
+			skillID: skillID,
+			errMsg:  errMsg,
+		})
+	}
+}
+
+// WithLatency adds a delay before processing each message/send request.
+func WithLatency(d time.Duration) Option {
+	return func(m *A2AServer) {
+		m.latency = d
+	}
+}
+
+// WithInputMatcher adds a rule that fires when the matcher returns true for the
+// given skill ID. Rules are evaluated in order; first match wins.
+func WithInputMatcher(skillID string, fn func(a2a.Message) bool, response Response) Option {
+	return func(m *A2AServer) {
+		m.rules = append(m.rules, mockRule{
+			skillID:  skillID,
+			matcher:  fn,
+			response: &response,
+		})
+	}
+}
+
+// NewA2AServer creates a mock server with the given card and options.
+// Call Start to begin serving.
+func NewA2AServer(card *a2a.AgentCard, opts ...Option) *A2AServer {
+	m := &A2AServer{card: *card}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// Start starts the underlying httptest.Server and returns its URL.
+func (m *A2AServer) Start() (string, error) {
+	m.ts = httptest.NewServer(m.handler())
+	return m.ts.URL, nil
+}
+
+// Close shuts down the server.
+func (m *A2AServer) Close() {
+	if m.ts != nil {
+		m.ts.Close()
+	}
+}
+
+// URL returns the URL of the running server. Panics if not started.
+func (m *A2AServer) URL() string {
+	if m.ts == nil {
+		panic("mock: server not started")
+	}
+	return m.ts.URL
+}
+
+// handler builds the http.Handler for the mock server.
+func (m *A2AServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /.well-known/agent.json", m.handleAgentCard)
+	mux.HandleFunc("POST /a2a", m.handleRPC)
+	return mux
+}
+
+// handleAgentCard serves the agent card as JSON.
+func (m *A2AServer) handleAgentCard(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(m.card)
+}
+
+// handleRPC dispatches a JSON-RPC 2.0 request.
+func (m *A2AServer) handleRPC(w http.ResponseWriter, r *http.Request) {
+	var req a2a.JSONRPCRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeRPCError(w, nil, -32700, "Parse error")
+		return
+	}
+
+	switch req.Method {
+	case a2a.MethodSendMessage:
+		m.handleSendMessage(w, &req)
+	default:
+		writeRPCError(w, req.ID, -32601, "Method not found")
+	}
+}
+
+// handleSendMessage processes a message/send request.
+func (m *A2AServer) handleSendMessage(w http.ResponseWriter, req *a2a.JSONRPCRequest) {
+	var params a2a.SendMessageRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeRPCError(w, req.ID, -32602, "Invalid params")
+		return
+	}
+
+	if m.latency > 0 {
+		time.Sleep(m.latency)
+	}
+
+	skillID := extractSkillID(&params)
+	msg := params.Message
+
+	for _, rule := range m.rules {
+		if rule.skillID != "" && rule.skillID != skillID {
+			continue
+		}
+		if rule.matcher != nil && !rule.matcher(msg) {
+			continue
+		}
+
+		taskID := fmt.Sprintf("mock-task-%d", m.taskSeq.Add(1))
+
+		if rule.errMsg != "" {
+			writeRPCResult(w, req.ID, m.failedTask(taskID, rule.errMsg))
+			return
+		}
+
+		if rule.response != nil {
+			writeRPCResult(w, req.ID, m.completedTask(taskID, rule.response.Parts))
+			return
+		}
+	}
+
+	writeRPCError(w, req.ID, -32000, "no matching rule")
+}
+
+// extractSkillID pulls the skill ID from message metadata or request metadata.
+func extractSkillID(params *a2a.SendMessageRequest) string {
+	if v, ok := params.Message.Metadata["skillId"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	if v, ok := params.Metadata["skillId"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// completedTask builds a Task with completed status and the given parts as an artifact.
+func (m *A2AServer) completedTask(taskID string, parts []a2a.Part) *a2a.Task {
+	return &a2a.Task{
+		ID:        taskID,
+		ContextID: "mock-ctx",
+		Status: a2a.TaskStatus{
+			State: a2a.TaskStateCompleted,
+		},
+		Artifacts: []a2a.Artifact{
+			{
+				ArtifactID: "artifact-1",
+				Parts:      parts,
+			},
+		},
+	}
+}
+
+// failedTask builds a Task with failed status and an error message.
+func (m *A2AServer) failedTask(taskID, errMsg string) *a2a.Task {
+	return &a2a.Task{
+		ID:        taskID,
+		ContextID: "mock-ctx",
+		Status: a2a.TaskStatus{
+			State: a2a.TaskStateFailed,
+			Message: &a2a.Message{
+				Role:  a2a.RoleAgent,
+				Parts: []a2a.Part{{Text: &errMsg}},
+			},
+		},
+	}
+}
+
+// messageText concatenates all text parts in a message.
+func messageText(msg *a2a.Message) string {
+	var b strings.Builder
+	for _, p := range msg.Parts {
+		if p.Text != nil {
+			b.WriteString(*p.Text)
+		}
+	}
+	return b.String()
+}
+
+// writeRPCResult writes a JSON-RPC 2.0 success response.
+func writeRPCResult(w http.ResponseWriter, id, result any) {
+	data, _ := json.Marshal(result)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  data,
+	})
+}
+
+// writeRPCError writes a JSON-RPC 2.0 error response.
+func writeRPCError(w http.ResponseWriter, id any, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &a2a.JSONRPCError{Code: code, Message: msg},
+	})
+}

--- a/runtime/a2a/mock/mock_test.go
+++ b/runtime/a2a/mock/mock_test.go
@@ -1,0 +1,388 @@
+package mock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+)
+
+// textPtr returns a pointer to s.
+func textPtr(s string) *string { return &s }
+
+// testCard returns an AgentCard suitable for tests.
+func testCard() *a2a.AgentCard {
+	return &a2a.AgentCard{
+		Name:        "test-agent",
+		Description: "A mock agent for testing",
+		Skills: []a2a.AgentSkill{
+			{ID: "echo", Name: "Echo"},
+			{ID: "fail", Name: "Fail"},
+		},
+	}
+}
+
+// sendRPC is a test helper that performs a raw JSON-RPC POST.
+func sendRPC(t *testing.T, url, method string, params any) a2a.JSONRPCResponse {
+	t.Helper()
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	body, err := json.Marshal(a2a.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  method,
+		Params:  paramsJSON,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	resp, err := http.Post(url+"/a2a", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /a2a: %v", err)
+	}
+	defer resp.Body.Close()
+	var rpcResp a2a.JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return rpcResp
+}
+
+// decodeTask unmarshals a Task from a JSONRPCResponse result.
+func decodeTask(t *testing.T, resp a2a.JSONRPCResponse) a2a.Task {
+	t.Helper()
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %d %s", resp.Error.Code, resp.Error.Message)
+	}
+	var task a2a.Task
+	if err := json.Unmarshal(resp.Result, &task); err != nil {
+		t.Fatalf("unmarshal task: %v", err)
+	}
+	return task
+}
+
+// sendMsg builds a SendMessageRequest with the given skill ID and text.
+func sendMsg(skillID, text string) *a2a.SendMessageRequest {
+	req := &a2a.SendMessageRequest{
+		Message: a2a.Message{
+			Role:  a2a.RoleUser,
+			Parts: []a2a.Part{{Text: textPtr(text)}},
+		},
+	}
+	if skillID != "" {
+		req.Message.Metadata = map[string]any{"skillId": skillID}
+	}
+	return req
+}
+
+func TestMockServesAgentCard(t *testing.T) {
+	m := NewA2AServer(testCard())
+	m.Start()
+	defer m.Close()
+
+	resp, err := http.Get(m.URL() + "/.well-known/agent.json")
+	if err != nil {
+		t.Fatalf("GET agent.json: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var card a2a.AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if card.Name != "test-agent" {
+		t.Errorf("name = %q, want %q", card.Name, "test-agent")
+	}
+	if len(card.Skills) != 2 {
+		t.Errorf("skills = %d, want 2", len(card.Skills))
+	}
+}
+
+func TestMockReturnsSkillResponse(t *testing.T) {
+	m := NewA2AServer(testCard(),
+		WithSkillResponse("echo", Response{
+			Parts: []a2a.Part{{Text: textPtr("hello back")}},
+		}),
+	)
+	m.Start()
+	defer m.Close()
+
+	resp := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "hello"))
+	task := decodeTask(t, resp)
+
+	if task.Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", task.Status.State)
+	}
+	if len(task.Artifacts) == 0 || len(task.Artifacts[0].Parts) == 0 {
+		t.Fatal("no artifacts returned")
+	}
+	if got := task.Artifacts[0].Parts[0].Text; got == nil || *got != "hello back" {
+		t.Errorf("text = %v, want %q", got, "hello back")
+	}
+}
+
+func TestMockMatchesInputContains(t *testing.T) {
+	m := NewA2AServer(testCard(),
+		WithInputMatcher("echo", func(msg a2a.Message) bool {
+			return strings.Contains(messageText(&msg), "magic")
+		}, Response{
+			Parts: []a2a.Part{{Text: textPtr("found magic")}},
+		}),
+		WithSkillResponse("echo", Response{
+			Parts: []a2a.Part{{Text: textPtr("default echo")}},
+		}),
+	)
+	m.Start()
+	defer m.Close()
+
+	// Should match the input matcher.
+	resp := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "say the magic word"))
+	task := decodeTask(t, resp)
+	if got := *task.Artifacts[0].Parts[0].Text; got != "found magic" {
+		t.Errorf("text = %q, want %q", got, "found magic")
+	}
+
+	// Should fall through to default.
+	resp2 := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "ordinary message"))
+	task2 := decodeTask(t, resp2)
+	if got := *task2.Artifacts[0].Parts[0].Text; got != "default echo" {
+		t.Errorf("text = %q, want %q", got, "default echo")
+	}
+}
+
+func TestMockMatchesInputRegex(t *testing.T) {
+	mc := &MatchConfig{Regex: `\d{3}-\d{4}`}
+	fn := matcherFromConfig(mc)
+
+	msg := a2a.Message{Parts: []a2a.Part{{Text: textPtr("call 555-1234")}}}
+	if !fn(msg) {
+		t.Error("expected regex match")
+	}
+
+	msg2 := a2a.Message{Parts: []a2a.Part{{Text: textPtr("no numbers here")}}}
+	if fn(msg2) {
+		t.Error("expected no regex match")
+	}
+}
+
+func TestMockReturnsError(t *testing.T) {
+	m := NewA2AServer(testCard(),
+		WithSkillError("fail", "something broke"),
+	)
+	m.Start()
+	defer m.Close()
+
+	resp := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("fail", "do something"))
+	task := decodeTask(t, resp)
+
+	if task.Status.State != a2a.TaskStateFailed {
+		t.Fatalf("state = %q, want failed", task.Status.State)
+	}
+	if task.Status.Message == nil || len(task.Status.Message.Parts) == 0 {
+		t.Fatal("no error message in status")
+	}
+	if got := *task.Status.Message.Parts[0].Text; got != "something broke" {
+		t.Errorf("error = %q, want %q", got, "something broke")
+	}
+}
+
+func TestMockLatencyInjection(t *testing.T) {
+	delay := 50 * time.Millisecond
+	m := NewA2AServer(testCard(),
+		WithLatency(delay),
+		WithSkillResponse("echo", Response{
+			Parts: []a2a.Part{{Text: textPtr("delayed")}},
+		}),
+	)
+	m.Start()
+	defer m.Close()
+
+	start := time.Now()
+	resp := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "hi"))
+	elapsed := time.Since(start)
+
+	decodeTask(t, resp) // verify valid response
+
+	if elapsed < delay {
+		t.Errorf("elapsed %v < latency %v", elapsed, delay)
+	}
+}
+
+func TestMockDefaultResponse(t *testing.T) {
+	m := NewA2AServer(testCard(),
+		WithSkillResponse("echo", Response{
+			Parts: []a2a.Part{{Text: textPtr("default")}},
+		}),
+	)
+	m.Start()
+	defer m.Close()
+
+	// Any message with skill "echo" should match.
+	resp := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "anything"))
+	task := decodeTask(t, resp)
+
+	if got := *task.Artifacts[0].Parts[0].Text; got != "default" {
+		t.Errorf("text = %q, want %q", got, "default")
+	}
+}
+
+func TestMockRuleOrdering(t *testing.T) {
+	m := NewA2AServer(testCard(),
+		WithInputMatcher("echo", func(msg a2a.Message) bool {
+			return strings.Contains(messageText(&msg), "special")
+		}, Response{
+			Parts: []a2a.Part{{Text: textPtr("special response")}},
+		}),
+		WithSkillResponse("echo", Response{
+			Parts: []a2a.Part{{Text: textPtr("catch-all")}},
+		}),
+	)
+	m.Start()
+	defer m.Close()
+
+	// First rule should match.
+	resp1 := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "something special"))
+	task1 := decodeTask(t, resp1)
+	if got := *task1.Artifacts[0].Parts[0].Text; got != "special response" {
+		t.Errorf("text = %q, want %q", got, "special response")
+	}
+
+	// Second rule (catch-all) should match.
+	resp2 := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "normal"))
+	task2 := decodeTask(t, resp2)
+	if got := *task2.Artifacts[0].Parts[0].Text; got != "catch-all" {
+		t.Errorf("text = %q, want %q", got, "catch-all")
+	}
+}
+
+func TestMockUnknownMethod(t *testing.T) {
+	m := NewA2AServer(testCard())
+	m.Start()
+	defer m.Close()
+
+	resp := sendRPC(t, m.URL(), "tasks/get", map[string]string{"id": "nope"})
+	if resp.Error == nil {
+		t.Fatal("expected error response")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("code = %d, want -32601", resp.Error.Code)
+	}
+}
+
+func TestOptionsFromConfig(t *testing.T) {
+	cfg := &AgentConfig{
+		Name: "config-agent",
+		Card: *testCard(),
+		Responses: []RuleConfig{
+			{
+				Skill: "echo",
+				Match: &MatchConfig{Contains: "hello"},
+				Response: &ResponseConfig{
+					Parts: []PartConfig{{Text: "hello response"}},
+				},
+			},
+			{
+				Skill: "echo",
+				Response: &ResponseConfig{
+					Parts: []PartConfig{{Text: "default"}},
+				},
+			},
+			{
+				Skill: "fail",
+				Error: "config error",
+			},
+		},
+	}
+
+	opts := OptionsFromConfig(cfg)
+	m := NewA2AServer(&cfg.Card, opts...)
+	m.Start()
+	defer m.Close()
+
+	// Contains-match rule.
+	resp := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "hello world"))
+	task := decodeTask(t, resp)
+	if got := *task.Artifacts[0].Parts[0].Text; got != "hello response" {
+		t.Errorf("text = %q, want %q", got, "hello response")
+	}
+
+	// Default rule.
+	resp2 := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "other"))
+	task2 := decodeTask(t, resp2)
+	if got := *task2.Artifacts[0].Parts[0].Text; got != "default" {
+		t.Errorf("text = %q, want %q", got, "default")
+	}
+
+	// Error rule.
+	resp3 := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("fail", "x"))
+	task3 := decodeTask(t, resp3)
+	if task3.Status.State != a2a.TaskStateFailed {
+		t.Fatalf("state = %q, want failed", task3.Status.State)
+	}
+}
+
+func TestMockWithClient(t *testing.T) {
+	m := NewA2AServer(testCard(),
+		WithSkillResponse("echo", Response{
+			Parts: []a2a.Part{{Text: textPtr("client test")}},
+		}),
+	)
+	m.Start()
+	defer m.Close()
+
+	client := a2a.NewClient(m.URL())
+	ctx := context.Background()
+
+	// Discover.
+	card, err := client.Discover(ctx)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if card.Name != "test-agent" {
+		t.Errorf("card.Name = %q, want %q", card.Name, "test-agent")
+	}
+
+	// SendMessage.
+	task, err := client.SendMessage(ctx, sendMsg("echo", "via client"))
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if task.Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", task.Status.State)
+	}
+	if got := *task.Artifacts[0].Parts[0].Text; got != "client test" {
+		t.Errorf("text = %q, want %q", got, "client test")
+	}
+}
+
+func TestMockNoMatchingRule(t *testing.T) {
+	m := NewA2AServer(testCard(),
+		WithSkillResponse("other-skill", Response{
+			Parts: []a2a.Part{{Text: textPtr("nope")}},
+		}),
+	)
+	m.Start()
+	defer m.Close()
+
+	resp := sendRPC(t, m.URL(), a2a.MethodSendMessage, sendMsg("echo", "hi"))
+	if resp.Error == nil {
+		t.Fatal("expected error response")
+	}
+	if resp.Error.Code != -32000 {
+		t.Errorf("code = %d, want -32000", resp.Error.Code)
+	}
+	if !strings.Contains(resp.Error.Message, "no matching rule") {
+		t.Errorf("message = %q, want to contain 'no matching rule'", resp.Error.Message)
+	}
+}


### PR DESCRIPTION
## Summary
- Introduce `runtime/a2a/mock` package with a lightweight `httptest`-backed mock A2A server
- Supports canned responses per skill with functional options: `WithSkillResponse`, `WithSkillError`, `WithLatency`, `WithInputMatcher`
- Includes YAML-friendly config structs (`AgentConfig`, `RuleConfig`, `MatchConfig`) with `OptionsFromConfig` bridge for declarative test setup

## Test plan
- [x] 12 tests covering: agent card serving, skill responses, input matching (contains + regex), error injection, latency injection, default responses, rule ordering, unknown methods, config bridge, client integration, no-match error
- [x] All tests pass with `-race -count=1`
- [x] 89.9% coverage on mock package (above 80% threshold)
- [x] `go vet` and linter pass with 0 issues