### PR TITLE
feat(evals): add core eval types for RFC 0006

### DIFF
--- a/runtime/evals/types.go
+++ b/runtime/evals/types.go
@@ -1,0 +1,197 @@
+// Package evals provides the core evaluation framework for PromptPack.
+// Eval definitions travel with packs and can run both during Arena testing
+// and at runtime in production via the SDK.
+package evals
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// EvalTrigger determines when an eval fires.
+type EvalTrigger string
+
+const (
+	// TriggerEveryTurn fires the eval after every assistant turn.
+	TriggerEveryTurn EvalTrigger = "every_turn"
+	// TriggerOnSessionComplete fires the eval when a session ends.
+	TriggerOnSessionComplete EvalTrigger = "on_session_complete"
+	// TriggerSampleTurns fires the eval on a percentage of turns (hash-based).
+	TriggerSampleTurns EvalTrigger = "sample_turns"
+	// TriggerSampleSessions fires the eval on a percentage of sessions (hash-based).
+	TriggerSampleSessions EvalTrigger = "sample_sessions"
+)
+
+// DefaultSamplePercentage is the default sampling rate when not specified.
+const DefaultSamplePercentage = 5.0
+
+// ValidTriggers is the set of valid trigger values.
+var ValidTriggers = map[EvalTrigger]bool{
+	TriggerEveryTurn:         true,
+	TriggerOnSessionComplete: true,
+	TriggerSampleTurns:       true,
+	TriggerSampleSessions:    true,
+}
+
+// MetricType defines the Prometheus metric type for eval results.
+type MetricType string
+
+const (
+	// MetricGauge represents a gauge metric (set to a value).
+	MetricGauge MetricType = "gauge"
+	// MetricCounter represents a counter metric (increment only).
+	MetricCounter MetricType = "counter"
+	// MetricHistogram represents a histogram metric (observe values).
+	MetricHistogram MetricType = "histogram"
+	// MetricBoolean represents a boolean metric (0 or 1).
+	MetricBoolean MetricType = "boolean"
+)
+
+// ValidMetricTypes is the set of valid metric type values.
+var ValidMetricTypes = map[MetricType]bool{
+	MetricGauge:     true,
+	MetricCounter:   true,
+	MetricHistogram: true,
+	MetricBoolean:   true,
+}
+
+// EvalDef defines a single evaluation within a PromptPack.
+// Evals are defined at pack level and/or prompt level. Prompt-level
+// evals override pack-level evals by ID.
+type EvalDef struct {
+	ID               string         `json:"id" yaml:"id"`
+	Type             string         `json:"type" yaml:"type"`
+	Trigger          EvalTrigger    `json:"trigger" yaml:"trigger"`
+	Params           map[string]any `json:"params" yaml:"params"`
+	Description      string         `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled          *bool          `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	SamplePercentage *float64       `json:"sample_percentage,omitempty" yaml:"sample_percentage,omitempty"`
+	Metric           *MetricDef     `json:"metric,omitempty" yaml:"metric,omitempty"`
+}
+
+// IsEnabled returns whether this eval is enabled.
+// Defaults to true when Enabled is nil.
+func (e *EvalDef) IsEnabled() bool {
+	if e.Enabled == nil {
+		return true
+	}
+	return *e.Enabled
+}
+
+// GetSamplePercentage returns the sampling percentage.
+// Defaults to DefaultSamplePercentage when SamplePercentage is nil.
+func (e *EvalDef) GetSamplePercentage() float64 {
+	if e.SamplePercentage == nil {
+		return DefaultSamplePercentage
+	}
+	return *e.SamplePercentage
+}
+
+// Range defines the valid range for a metric value.
+type Range struct {
+	Min *float64 `json:"min,omitempty" yaml:"min,omitempty"`
+	Max *float64 `json:"max,omitempty" yaml:"max,omitempty"`
+}
+
+// MetricDef defines a Prometheus-style metric associated with an eval.
+// The Extra field captures additionalProperties from the schema.
+type MetricDef struct {
+	Name  string     `json:"name" yaml:"name"`
+	Type  MetricType `json:"type" yaml:"type"`
+	Range *Range     `json:"range,omitempty" yaml:"range,omitempty"`
+
+	// Extra holds additional properties beyond the defined schema fields.
+	// This supports the RFC's additionalProperties: true on metric.
+	Extra map[string]any `json:"-" yaml:"-"`
+}
+
+// MarshalJSON implements custom JSON marshaling to include Extra fields
+// as top-level properties alongside the known fields.
+func (m MetricDef) MarshalJSON() ([]byte, error) {
+	// Build a map with known fields
+	result := make(map[string]any)
+	result["name"] = m.Name
+	result["type"] = m.Type
+	if m.Range != nil {
+		result["range"] = m.Range
+	}
+	// Merge extra fields
+	for k, v := range m.Extra {
+		if k != "name" && k != "type" && k != "range" {
+			result[k] = v
+		}
+	}
+	return json.Marshal(result)
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling to capture
+// additional properties into the Extra field.
+func (m *MetricDef) UnmarshalJSON(data []byte) error {
+	// Unmarshal known fields via an alias to avoid recursion
+	type metricAlias MetricDef
+	var alias metricAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*m = MetricDef(alias)
+
+	// Capture all fields into a raw map
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Extract extra fields (anything not name, type, range)
+	knownFields := map[string]bool{"name": true, "type": true, "range": true}
+	for k, v := range raw {
+		if !knownFields[k] {
+			if m.Extra == nil {
+				m.Extra = make(map[string]any)
+			}
+			var val any
+			if err := json.Unmarshal(v, &val); err != nil {
+				return err
+			}
+			m.Extra[k] = val
+		}
+	}
+	return nil
+}
+
+// EvalResult captures the outcome of a single eval execution.
+type EvalResult struct {
+	EvalID      string   `json:"eval_id"`
+	Type        string   `json:"type"`
+	Passed      bool     `json:"passed"`
+	Score       *float64 `json:"score,omitempty"`
+	MetricValue *float64 `json:"metric_value,omitempty"`
+	Explanation string   `json:"explanation,omitempty"`
+	DurationMs  int64    `json:"duration_ms"`
+	Error       string   `json:"error,omitempty"`
+}
+
+// EvalContext provides data to eval handlers.
+// For turn-level evals: Messages contains history up to the current turn.
+// For session-level evals: Messages contains the full conversation.
+type EvalContext struct {
+	Messages      []types.Message  `json:"messages"`
+	TurnIndex     int              `json:"turn_index"`
+	CurrentOutput string           `json:"current_output"`
+	ToolCalls     []ToolCallRecord `json:"tool_calls,omitempty"`
+	SessionID     string           `json:"session_id"`
+	PromptID      string           `json:"prompt_id"`
+	Variables     map[string]any   `json:"variables,omitempty"`
+	Metadata      map[string]any   `json:"metadata,omitempty"`
+}
+
+// ToolCallRecord captures a single tool invocation for eval context.
+type ToolCallRecord struct {
+	TurnIndex int            `json:"turn_index"`
+	ToolName  string         `json:"tool_name"`
+	Arguments map[string]any `json:"arguments"`
+	Result    any            `json:"result,omitempty"`
+	Error     string         `json:"error,omitempty"`
+	Duration  time.Duration  `json:"duration,omitempty"`
+}

--- a/runtime/evals/types_test.go
+++ b/runtime/evals/types_test.go
@@ -1,0 +1,462 @@
+package evals
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestEvalDef_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled *bool
+		want    bool
+	}{
+		{"nil defaults to true", nil, true},
+		{"explicit true", ptr(true), true},
+		{"explicit false", ptr(false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EvalDef{Enabled: tt.enabled}
+			if got := e.IsEnabled(); got != tt.want {
+				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvalDef_GetSamplePercentage(t *testing.T) {
+	tests := []struct {
+		name string
+		pct  *float64
+		want float64
+	}{
+		{"nil defaults to 5.0", nil, DefaultSamplePercentage},
+		{"explicit 10", ptr(10.0), 10.0},
+		{"explicit 0", ptr(0.0), 0.0},
+		{"explicit 100", ptr(100.0), 100.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EvalDef{SamplePercentage: tt.pct}
+			if got := e.GetSamplePercentage(); got != tt.want {
+				t.Errorf("GetSamplePercentage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvalDef_JSONRoundTrip(t *testing.T) {
+	original := EvalDef{
+		ID:               "tone-check",
+		Type:             "llm_judge",
+		Trigger:          TriggerSampleTurns,
+		Params:           map[string]any{"criteria": "professional tone"},
+		Description:      "Check tone",
+		Enabled:          ptr(true),
+		SamplePercentage: ptr(10.0),
+		Metric: &MetricDef{
+			Name:  "promptpack_tone_score",
+			Type:  MetricGauge,
+			Range: &Range{Min: ptr(0.0), Max: ptr(1.0)},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var decoded EvalDef
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if decoded.ID != original.ID {
+		t.Errorf("ID = %q, want %q", decoded.ID, original.ID)
+	}
+	if decoded.Trigger != original.Trigger {
+		t.Errorf("Trigger = %q, want %q", decoded.Trigger, original.Trigger)
+	}
+	if decoded.Metric == nil {
+		t.Fatal("Metric is nil after round-trip")
+	}
+	if decoded.Metric.Name != original.Metric.Name {
+		t.Errorf("Metric.Name = %q, want %q", decoded.Metric.Name, original.Metric.Name)
+	}
+	if decoded.Metric.Type != original.Metric.Type {
+		t.Errorf("Metric.Type = %q, want %q", decoded.Metric.Type, original.Metric.Type)
+	}
+	if decoded.Metric.Range == nil {
+		t.Fatal("Metric.Range is nil after round-trip")
+	}
+	if *decoded.Metric.Range.Min != *original.Metric.Range.Min {
+		t.Errorf("Range.Min = %v, want %v", *decoded.Metric.Range.Min, *original.Metric.Range.Min)
+	}
+	if *decoded.Metric.Range.Max != *original.Metric.Range.Max {
+		t.Errorf("Range.Max = %v, want %v", *decoded.Metric.Range.Max, *original.Metric.Range.Max)
+	}
+}
+
+func TestEvalDef_JSONMinimal(t *testing.T) {
+	// Minimal required fields only
+	input := `{"id":"check","type":"contains","trigger":"every_turn","params":{"text":"hello"}}`
+	var e EvalDef
+	if err := json.Unmarshal([]byte(input), &e); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if e.ID != "check" {
+		t.Errorf("ID = %q, want %q", e.ID, "check")
+	}
+	if e.IsEnabled() != true {
+		t.Error("IsEnabled() should default to true")
+	}
+	if e.GetSamplePercentage() != DefaultSamplePercentage {
+		t.Errorf("GetSamplePercentage() = %v, want %v", e.GetSamplePercentage(), DefaultSamplePercentage)
+	}
+	if e.Metric != nil {
+		t.Error("Metric should be nil for minimal input")
+	}
+}
+
+func TestMetricDef_ExtraFieldsRoundTrip(t *testing.T) {
+	input := `{
+		"name": "my_metric",
+		"type": "gauge",
+		"range": {"min": 0, "max": 100},
+		"custom_field": "custom_value",
+		"another": 42
+	}`
+
+	var m MetricDef
+	if err := json.Unmarshal([]byte(input), &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if m.Name != "my_metric" {
+		t.Errorf("Name = %q, want %q", m.Name, "my_metric")
+	}
+	if m.Type != MetricGauge {
+		t.Errorf("Type = %q, want %q", m.Type, MetricGauge)
+	}
+	if m.Extra == nil {
+		t.Fatal("Extra is nil, expected custom fields")
+	}
+	if m.Extra["custom_field"] != "custom_value" {
+		t.Errorf("Extra[custom_field] = %v, want %q", m.Extra["custom_field"], "custom_value")
+	}
+	// JSON numbers unmarshal to float64
+	if m.Extra["another"] != float64(42) {
+		t.Errorf("Extra[another] = %v, want 42", m.Extra["another"])
+	}
+
+	// Round-trip
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var m2 MetricDef
+	if err := json.Unmarshal(data, &m2); err != nil {
+		t.Fatalf("Unmarshal round-trip: %v", err)
+	}
+	if m2.Extra["custom_field"] != "custom_value" {
+		t.Errorf("Round-trip Extra[custom_field] = %v, want %q", m2.Extra["custom_field"], "custom_value")
+	}
+	if m2.Extra["another"] != float64(42) {
+		t.Errorf("Round-trip Extra[another] = %v, want 42", m2.Extra["another"])
+	}
+	if m2.Name != "my_metric" {
+		t.Errorf("Round-trip Name = %q, want %q", m2.Name, "my_metric")
+	}
+}
+
+func TestMetricDef_NoExtra(t *testing.T) {
+	input := `{"name": "simple", "type": "counter"}`
+	var m MetricDef
+	if err := json.Unmarshal([]byte(input), &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if m.Extra != nil {
+		t.Errorf("Extra should be nil when no extra fields, got %v", m.Extra)
+	}
+}
+
+func TestMetricDef_ExtraDoesNotOverrideKnown(t *testing.T) {
+	// Extra fields named "name", "type", "range" should not be included in Extra
+	m := MetricDef{
+		Name: "test",
+		Type: MetricBoolean,
+		Extra: map[string]any{
+			"name":    "should_be_ignored",
+			"type":    "should_be_ignored",
+			"range":   "should_be_ignored",
+			"allowed": "yes",
+		},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw: %v", err)
+	}
+
+	// Known fields should use struct values, not Extra
+	if raw["name"] != "test" {
+		t.Errorf("name = %v, want %q (struct value should win)", raw["name"], "test")
+	}
+	if raw["type"] != string(MetricBoolean) {
+		t.Errorf("type = %v, want %q", raw["type"], MetricBoolean)
+	}
+	if raw["allowed"] != "yes" {
+		t.Errorf("allowed = %v, want %q", raw["allowed"], "yes")
+	}
+}
+
+func TestEvalResult_JSON(t *testing.T) {
+	r := EvalResult{
+		EvalID:      "tone-check",
+		Type:        "llm_judge",
+		Passed:      true,
+		Score:       ptr(0.95),
+		MetricValue: ptr(0.95),
+		Explanation: "Tone is professional",
+		DurationMs:  150,
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var decoded EvalResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.EvalID != r.EvalID {
+		t.Errorf("EvalID = %q, want %q", decoded.EvalID, r.EvalID)
+	}
+	if decoded.Passed != r.Passed {
+		t.Errorf("Passed = %v, want %v", decoded.Passed, r.Passed)
+	}
+	if decoded.Score == nil || *decoded.Score != *r.Score {
+		t.Errorf("Score = %v, want %v", decoded.Score, r.Score)
+	}
+}
+
+func TestEvalResult_ErrorField(t *testing.T) {
+	r := EvalResult{
+		EvalID:     "broken",
+		Type:       "contains",
+		Passed:     false,
+		DurationMs: 5,
+		Error:      "handler panicked",
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded EvalResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.Error != "handler panicked" {
+		t.Errorf("Error = %q, want %q", decoded.Error, "handler panicked")
+	}
+}
+
+func TestEvalResult_OmitsNilOptionals(t *testing.T) {
+	r := EvalResult{
+		EvalID:     "check",
+		Type:       "regex",
+		Passed:     true,
+		DurationMs: 3,
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw: %v", err)
+	}
+	if _, ok := raw["score"]; ok {
+		t.Error("score should be omitted when nil")
+	}
+	if _, ok := raw["metric_value"]; ok {
+		t.Error("metric_value should be omitted when nil")
+	}
+	if _, ok := raw["explanation"]; ok {
+		t.Error("explanation should be omitted when empty")
+	}
+	if _, ok := raw["error"]; ok {
+		t.Error("error should be omitted when empty")
+	}
+}
+
+func TestEvalContext_JSON(t *testing.T) {
+	ctx := EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "Hello"},
+			{Role: "assistant", Content: "Hi there"},
+		},
+		TurnIndex:     1,
+		CurrentOutput: "Hi there",
+		SessionID:     "sess-123",
+		PromptID:      "chat",
+		ToolCalls: []ToolCallRecord{
+			{
+				TurnIndex: 1,
+				ToolName:  "search",
+				Arguments: map[string]any{"query": "test"},
+			},
+		},
+		Variables: map[string]any{"user_name": "Alice"},
+		Metadata:  map[string]any{"source": "test"},
+	}
+
+	data, err := json.Marshal(ctx)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var decoded EvalContext
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if len(decoded.Messages) != 2 {
+		t.Errorf("Messages len = %d, want 2", len(decoded.Messages))
+	}
+	if decoded.TurnIndex != 1 {
+		t.Errorf("TurnIndex = %d, want 1", decoded.TurnIndex)
+	}
+	if decoded.CurrentOutput != "Hi there" {
+		t.Errorf("CurrentOutput = %q, want %q", decoded.CurrentOutput, "Hi there")
+	}
+	if decoded.SessionID != "sess-123" {
+		t.Errorf("SessionID = %q, want %q", decoded.SessionID, "sess-123")
+	}
+	if len(decoded.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls len = %d, want 1", len(decoded.ToolCalls))
+	}
+	if decoded.ToolCalls[0].ToolName != "search" {
+		t.Errorf("ToolCalls[0].ToolName = %q, want %q", decoded.ToolCalls[0].ToolName, "search")
+	}
+}
+
+func TestToolCallRecord_JSON(t *testing.T) {
+	tc := ToolCallRecord{
+		TurnIndex: 2,
+		ToolName:  "create_ticket",
+		Arguments: map[string]any{"title": "Bug fix", "priority": "high"},
+		Result:    map[string]any{"id": "T-123"},
+		Error:     "",
+	}
+	data, err := json.Marshal(tc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded ToolCallRecord
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.ToolName != "create_ticket" {
+		t.Errorf("ToolName = %q, want %q", decoded.ToolName, "create_ticket")
+	}
+	if decoded.TurnIndex != 2 {
+		t.Errorf("TurnIndex = %d, want 2", decoded.TurnIndex)
+	}
+}
+
+func TestValidTriggers(t *testing.T) {
+	expected := []EvalTrigger{
+		TriggerEveryTurn,
+		TriggerOnSessionComplete,
+		TriggerSampleTurns,
+		TriggerSampleSessions,
+	}
+	for _, trigger := range expected {
+		if !ValidTriggers[trigger] {
+			t.Errorf("ValidTriggers missing %q", trigger)
+		}
+	}
+	if ValidTriggers["invalid_trigger"] {
+		t.Error("ValidTriggers should not contain invalid trigger")
+	}
+}
+
+func TestValidMetricTypes(t *testing.T) {
+	expected := []MetricType{MetricGauge, MetricCounter, MetricHistogram, MetricBoolean}
+	for _, mt := range expected {
+		if !ValidMetricTypes[mt] {
+			t.Errorf("ValidMetricTypes missing %q", mt)
+		}
+	}
+	if ValidMetricTypes["invalid"] {
+		t.Error("ValidMetricTypes should not contain invalid type")
+	}
+}
+
+func TestEvalDef_DisabledExplicit(t *testing.T) {
+	input := `{"id":"x","type":"y","trigger":"every_turn","params":{},"enabled":false}`
+	var e EvalDef
+	if err := json.Unmarshal([]byte(input), &e); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if e.IsEnabled() {
+		t.Error("IsEnabled() should be false for explicit false")
+	}
+}
+
+func TestRange_JSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		min   *float64
+		max   *float64
+	}{
+		{"both min and max", `{"min":0,"max":1}`, ptr(0.0), ptr(1.0)},
+		{"only min", `{"min":-1}`, ptr(-1.0), nil},
+		{"only max", `{"max":100}`, nil, ptr(100.0)},
+		{"empty", `{}`, nil, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r Range
+			if err := json.Unmarshal([]byte(tt.input), &r); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if tt.min == nil && r.Min != nil {
+				t.Errorf("Min = %v, want nil", r.Min)
+			}
+			if tt.min != nil {
+				if r.Min == nil {
+					t.Fatal("Min is nil, want non-nil")
+				}
+				if *r.Min != *tt.min {
+					t.Errorf("Min = %v, want %v", *r.Min, *tt.min)
+				}
+			}
+			if tt.max == nil && r.Max != nil {
+				t.Errorf("Max = %v, want nil", r.Max)
+			}
+			if tt.max != nil {
+				if r.Max == nil {
+					t.Fatal("Max is nil, want non-nil")
+				}
+				if *r.Max != *tt.max {
+					t.Errorf("Max = %v, want %v", *r.Max, *tt.max)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces `runtime/evals/` package with foundational types for PromptPack evals (RFC 0006)
- `EvalDef`, `EvalTrigger`, `EvalResult`, `EvalContext`, `ToolCallRecord` types
- `MetricDef` with custom JSON marshal/unmarshal supporting `additionalProperties`
- Helper methods `IsEnabled()`, `GetSamplePercentage()` with RFC-specified defaults
- 90.9% test coverage

## Test plan
- [x] All types round-trip through JSON correctly
- [x] MetricDef.Extra fields survive JSON round-trip
- [x] IsEnabled() defaults to true; GetSamplePercentage() defaults to 5.0
- [x] Valid triggers and metric types validated
- [x] `go test -race` passes
- [x] Pre-commit hooks pass (lint, build, tests)

Closes #298