### PR TITLE
feat(evals): extend Pack and PackPrompt with evals field

### DIFF
--- a/runtime/prompt/pack.go
+++ b/runtime/prompt/pack.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
 // PromptPackSchemaURL is the JSON Schema URL for validating PromptPack files
@@ -90,6 +92,9 @@ type Pack struct {
 	// Metadata
 	Metadata    *Metadata        `json:"metadata,omitempty"`
 	Compilation *CompilationInfo `json:"compilation,omitempty"`
+
+	// Evals - Pack-level eval definitions (applied to all prompts unless overridden)
+	Evals []evals.EvalDef `json:"evals,omitempty"`
 }
 
 // PackTool represents a tool definition in the pack (per PromptPack spec Section 9)
@@ -129,6 +134,9 @@ type PackPrompt struct {
 
 	// Validators
 	Validators []ValidatorConfig `json:"validators,omitempty"`
+
+	// Evals - Prompt-level eval definitions (override pack-level evals by ID)
+	Evals []evals.EvalDef `json:"evals,omitempty"`
 
 	// Model Testing
 	TestedModels []ModelTestResultRef `json:"tested_models,omitempty"`

--- a/runtime/prompt/pack_evals_test.go
+++ b/runtime/prompt/pack_evals_test.go
@@ -1,0 +1,234 @@
+package prompt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boolPtr(b bool) *bool       { return &b }
+func float64Ptr(f float64) *float64 { return &f }
+
+func TestPack_BackwardCompatibility_NoEvals(t *testing.T) {
+	// A pack JSON without the "evals" field should still load correctly.
+	raw := `{
+		"id": "test-pack",
+		"name": "Test Pack",
+		"version": "v1.0.0",
+		"description": "A test pack",
+		"template_engine": {"version": "v1", "syntax": "handlebars"},
+		"prompts": {
+			"greeting": {
+				"id": "greeting",
+				"name": "Greeting",
+				"description": "Say hello",
+				"version": "1.0.0",
+				"system_template": "Hello {{name}}"
+			}
+		}
+	}`
+
+	var pack Pack
+	err := json.Unmarshal([]byte(raw), &pack)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-pack", pack.ID)
+	assert.Nil(t, pack.Evals)
+	assert.Nil(t, pack.Prompts["greeting"].Evals)
+}
+
+func TestPack_PackLevelEvals(t *testing.T) {
+	raw := `{
+		"id": "test-pack",
+		"name": "Test Pack",
+		"version": "v1.0.0",
+		"description": "A test pack",
+		"template_engine": {"version": "v1", "syntax": "handlebars"},
+		"prompts": {
+			"greeting": {
+				"id": "greeting",
+				"name": "Greeting",
+				"description": "Say hello",
+				"version": "1.0.0",
+				"system_template": "Hello {{name}}"
+			}
+		},
+		"evals": [
+			{
+				"id": "tone-check",
+				"type": "llm_judge",
+				"trigger": "every_turn",
+				"params": {"criteria": "professional tone"},
+				"description": "Check professional tone"
+			}
+		]
+	}`
+
+	var pack Pack
+	err := json.Unmarshal([]byte(raw), &pack)
+	require.NoError(t, err)
+
+	require.Len(t, pack.Evals, 1)
+	assert.Equal(t, "tone-check", pack.Evals[0].ID)
+	assert.Equal(t, "llm_judge", pack.Evals[0].Type)
+	assert.Equal(t, evals.TriggerEveryTurn, pack.Evals[0].Trigger)
+	assert.Equal(t, "professional tone", pack.Evals[0].Params["criteria"])
+	assert.Equal(t, "Check professional tone", pack.Evals[0].Description)
+}
+
+func TestPack_PromptLevelEvals(t *testing.T) {
+	raw := `{
+		"id": "test-pack",
+		"name": "Test Pack",
+		"version": "v1.0.0",
+		"description": "A test pack",
+		"template_engine": {"version": "v1", "syntax": "handlebars"},
+		"prompts": {
+			"greeting": {
+				"id": "greeting",
+				"name": "Greeting",
+				"description": "Say hello",
+				"version": "1.0.0",
+				"system_template": "Hello {{name}}",
+				"evals": [
+					{
+						"id": "length-check",
+						"type": "deterministic",
+						"trigger": "every_turn",
+						"params": {"max_length": 500},
+						"enabled": false,
+						"sample_percentage": 10.0
+					}
+				]
+			}
+		}
+	}`
+
+	var pack Pack
+	err := json.Unmarshal([]byte(raw), &pack)
+	require.NoError(t, err)
+
+	assert.Nil(t, pack.Evals)
+
+	prompt := pack.Prompts["greeting"]
+	require.NotNil(t, prompt)
+	require.Len(t, prompt.Evals, 1)
+
+	eval := prompt.Evals[0]
+	assert.Equal(t, "length-check", eval.ID)
+	assert.Equal(t, "deterministic", eval.Type)
+	assert.Equal(t, evals.TriggerEveryTurn, eval.Trigger)
+	assert.Equal(t, float64(500), eval.Params["max_length"])
+	assert.False(t, eval.IsEnabled())
+	assert.Equal(t, 10.0, eval.GetSamplePercentage())
+}
+
+func TestPack_EvalsRoundTrip(t *testing.T) {
+	original := &Pack{
+		ID:          "round-trip",
+		Name:        "Round Trip",
+		Version:     "v1.0.0",
+		Description: "Test round-trip",
+		TemplateEngine: &TemplateEngineInfo{
+			Version: "v1",
+			Syntax:  "handlebars",
+		},
+		Prompts: map[string]*PackPrompt{
+			"chat": {
+				ID:             "chat",
+				Name:           "Chat",
+				Description:    "Chat prompt",
+				Version:        "1.0.0",
+				SystemTemplate: "You are a helper",
+				Evals: []evals.EvalDef{
+					{
+						ID:      "prompt-eval",
+						Type:    "deterministic",
+						Trigger: evals.TriggerOnSessionComplete,
+						Params:  map[string]any{"threshold": 0.8},
+					},
+				},
+			},
+		},
+		Evals: []evals.EvalDef{
+			{
+				ID:               "pack-eval",
+				Type:             "llm_judge",
+				Trigger:          evals.TriggerSampleTurns,
+				Params:           map[string]any{"criteria": "helpful"},
+				Enabled:          boolPtr(true),
+				SamplePercentage: float64Ptr(25.0),
+				Metric: &evals.MetricDef{
+					Name: "helpfulness",
+					Type: evals.MetricGauge,
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored Pack
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	// Pack-level evals
+	require.Len(t, restored.Evals, 1)
+	assert.Equal(t, "pack-eval", restored.Evals[0].ID)
+	assert.Equal(t, "llm_judge", restored.Evals[0].Type)
+	assert.Equal(t, evals.TriggerSampleTurns, restored.Evals[0].Trigger)
+	assert.True(t, restored.Evals[0].IsEnabled())
+	assert.Equal(t, 25.0, restored.Evals[0].GetSamplePercentage())
+	require.NotNil(t, restored.Evals[0].Metric)
+	assert.Equal(t, "helpfulness", restored.Evals[0].Metric.Name)
+	assert.Equal(t, evals.MetricGauge, restored.Evals[0].Metric.Type)
+
+	// Prompt-level evals
+	chatPrompt := restored.Prompts["chat"]
+	require.NotNil(t, chatPrompt)
+	require.Len(t, chatPrompt.Evals, 1)
+	assert.Equal(t, "prompt-eval", chatPrompt.Evals[0].ID)
+	assert.Equal(t, evals.TriggerOnSessionComplete, chatPrompt.Evals[0].Trigger)
+}
+
+func TestPack_EvalsOmittedWhenEmpty(t *testing.T) {
+	pack := &Pack{
+		ID:      "no-evals",
+		Name:    "No Evals",
+		Version: "v1.0.0",
+		Prompts: map[string]*PackPrompt{
+			"basic": {
+				ID:             "basic",
+				Name:           "Basic",
+				Version:        "1.0.0",
+				SystemTemplate: "Hello",
+			},
+		},
+	}
+
+	data, err := json.Marshal(pack)
+	require.NoError(t, err)
+
+	// The "evals" key should not appear in the JSON output
+	var raw map[string]json.RawMessage
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	_, hasPackEvals := raw["evals"]
+	assert.False(t, hasPackEvals, "evals key should be omitted from pack JSON when nil")
+
+	var promptsRaw map[string]json.RawMessage
+	err = json.Unmarshal(raw["prompts"], &promptsRaw)
+	require.NoError(t, err)
+
+	var basicRaw map[string]json.RawMessage
+	err = json.Unmarshal(promptsRaw["basic"], &basicRaw)
+	require.NoError(t, err)
+
+	_, hasPromptEvals := basicRaw["evals"]
+	assert.False(t, hasPromptEvals, "evals key should be omitted from prompt JSON when nil")
+}

--- a/sdk/internal/pack/load.go
+++ b/sdk/internal/pack/load.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
@@ -37,6 +38,9 @@ type Pack struct {
 	// Fragments - Map of fragment name -> content
 	Fragments map[string]string `json:"fragments,omitempty"`
 
+	// Evals - Pack-level eval definitions (applied to all prompts unless overridden)
+	Evals []evals.EvalDef `json:"evals,omitempty"`
+
 	// FilePath is the path from which this pack was loaded.
 	FilePath string `json:"-"`
 }
@@ -54,6 +58,7 @@ type Prompt struct {
 	MediaConfig    *MediaConfig   `json:"media,omitempty"`
 	Parameters     *Parameters    `json:"parameters,omitempty"`
 	Validators     []Validator    `json:"validators,omitempty"`
+	Evals          []evals.EvalDef `json:"evals,omitempty"`
 	ModelOverrides map[string]any `json:"model_overrides,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Adds `Evals []evals.EvalDef` field to `Pack` struct (pack-level evals applied to all prompts unless overridden)
- Adds `Evals []evals.EvalDef` field to `PackPrompt` struct (prompt-level evals that override pack-level by ID)
- SDK-side `Pack` and `Prompt` types in `sdk/internal/pack/load.go` updated to match
- Backward compatible: existing packs without evals load unchanged (`json:"evals,omitempty"`)

## Test plan
- [x] Existing packs without evals load correctly (backward compatibility)
- [x] Pack JSON with pack-level evals deserializes correctly
- [x] Pack JSON with prompt-level evals deserializes correctly
- [x] Round-trip: marshal then unmarshal preserves evals
- [x] Evals field omitted from JSON when empty/nil
- [x] `go test -race` passes
- [x] `go vet` clean
- [x] Pre-commit hooks pass (lint, build, test, coverage)

Closes #299