### PR TITLE
feat(evals): add eval validation for packc

### DIFF
--- a/runtime/evals/validate.go
+++ b/runtime/evals/validate.go
@@ -1,0 +1,125 @@
+package evals
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// prometheusNameRe matches valid Prometheus metric names.
+var prometheusNameRe = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+
+// ValidateEvals validates a slice of EvalDef for correctness.
+// The scope parameter is used in error messages (e.g. "pack", "prompt:foo").
+// It checks:
+//   - IDs are non-empty and unique within the slice
+//   - Type is non-empty
+//   - Trigger is a valid value
+//   - sample_percentage (if set) is in [0, 100]
+//   - Metric name matches Prometheus naming regex
+//   - Metric type is one of gauge/counter/histogram/boolean
+func ValidateEvals(defs []EvalDef, scope string) []string {
+	var errs []string
+	seen := make(map[string]bool, len(defs))
+
+	for i, def := range defs {
+		prefix := fmt.Sprintf("%s evals[%d]", scope, i)
+		prefix, idErrs := validateEvalID(&def, prefix, scope, i, seen)
+		errs = append(errs, idErrs...)
+		errs = append(errs, validateEvalFields(&def, prefix)...)
+	}
+
+	return errs
+}
+
+// validateEvalID checks the eval ID for presence and uniqueness.
+// It returns the (possibly updated) prefix and any errors found.
+func validateEvalID(
+	def *EvalDef, prefix, scope string, idx int, seen map[string]bool,
+) (updatedPrefix string, errs []string) {
+	if def.ID == "" {
+		return prefix, []string{
+			fmt.Sprintf("%s: id is required", prefix),
+		}
+	}
+
+	updatedPrefix = fmt.Sprintf("%s evals[%d] (id=%q)", scope, idx, def.ID)
+	if seen[def.ID] {
+		errs = append(errs, fmt.Sprintf(
+			"%s: duplicate eval id %q", updatedPrefix, def.ID,
+		))
+	}
+	seen[def.ID] = true
+	return updatedPrefix, errs
+}
+
+// validateEvalFields checks type, trigger, sample_percentage, and metric.
+func validateEvalFields(def *EvalDef, prefix string) []string {
+	var errs []string
+
+	if def.Type == "" {
+		errs = append(errs, fmt.Sprintf("%s: type is required", prefix))
+	}
+
+	if def.Trigger == "" {
+		errs = append(errs, fmt.Sprintf(
+			"%s: trigger is required", prefix,
+		))
+	} else if !ValidTriggers[def.Trigger] {
+		errs = append(errs, fmt.Sprintf(
+			"%s: invalid trigger %q", prefix, def.Trigger,
+		))
+	}
+
+	if def.SamplePercentage != nil {
+		pct := *def.SamplePercentage
+		if pct < 0 || pct > 100 {
+			errs = append(errs, fmt.Sprintf(
+				"%s: sample_percentage must be between 0 and 100, got %g",
+				prefix, pct,
+			))
+		}
+	}
+
+	if def.Metric != nil {
+		errs = append(errs, validateMetric(def.Metric, prefix)...)
+	}
+
+	return errs
+}
+
+// validateMetric validates a MetricDef within an eval.
+func validateMetric(m *MetricDef, prefix string) []string {
+	var errs []string
+
+	if m.Name == "" {
+		errs = append(errs, fmt.Sprintf(
+			"%s: metric.name is required", prefix,
+		))
+	} else if !prometheusNameRe.MatchString(m.Name) {
+		errs = append(errs, fmt.Sprintf(
+			"%s: metric.name %q must match Prometheus naming: %s",
+			prefix, m.Name, prometheusNameRe.String(),
+		))
+	}
+
+	if m.Type == "" {
+		errs = append(errs, fmt.Sprintf(
+			"%s: metric.type is required", prefix,
+		))
+	} else if !ValidMetricTypes[m.Type] {
+		errs = append(errs, fmt.Sprintf(
+			"%s: invalid metric.type %q", prefix, m.Type,
+		))
+	}
+
+	if m.Range != nil && m.Range.Min != nil && m.Range.Max != nil {
+		if *m.Range.Min > *m.Range.Max {
+			errs = append(errs, fmt.Sprintf(
+				"%s: metric.range.min (%g) must be <= range.max (%g)",
+				prefix, *m.Range.Min, *m.Range.Max,
+			))
+		}
+	}
+
+	return errs
+}

--- a/runtime/evals/validate_test.go
+++ b/runtime/evals/validate_test.go
@@ -1,0 +1,310 @@
+package evals
+
+import (
+	"strings"
+	"testing"
+)
+
+func float64Ptr(f float64) *float64 { return &f }
+func boolPtr(b bool) *bool          { return &b }
+
+func TestValidateEvals(t *testing.T) {
+	tests := []struct {
+		name      string
+		defs      []EvalDef
+		scope     string
+		wantCount int
+		wantMsgs  []string // substrings that must appear in errors
+	}{
+		{
+			name:      "nil input returns no errors",
+			defs:      nil,
+			scope:     "pack",
+			wantCount: 0,
+		},
+		{
+			name:      "empty input returns no errors",
+			defs:      []EvalDef{},
+			scope:     "pack",
+			wantCount: 0,
+		},
+		{
+			name: "valid eval with all required fields",
+			defs: []EvalDef{
+				{ID: "tone-check", Type: "llm_judge", Trigger: TriggerEveryTurn},
+			},
+			scope:     "pack",
+			wantCount: 0,
+		},
+		{
+			name: "valid eval with metric",
+			defs: []EvalDef{
+				{
+					ID: "latency", Type: "custom", Trigger: TriggerEveryTurn,
+					Metric: &MetricDef{Name: "eval_latency_seconds", Type: MetricHistogram},
+				},
+			},
+			scope:     "pack",
+			wantCount: 0,
+		},
+		{
+			name: "valid eval with sample_percentage",
+			defs: []EvalDef{
+				{ID: "sampled", Type: "llm_judge", Trigger: TriggerSampleTurns, SamplePercentage: float64Ptr(10.0)},
+			},
+			scope:     "pack",
+			wantCount: 0,
+		},
+		{
+			name: "missing id",
+			defs: []EvalDef{
+				{Type: "llm_judge", Trigger: TriggerEveryTurn},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"id is required"},
+		},
+		{
+			name: "missing type",
+			defs: []EvalDef{
+				{ID: "tone-check", Trigger: TriggerEveryTurn},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"type is required"},
+		},
+		{
+			name: "missing trigger",
+			defs: []EvalDef{
+				{ID: "tone-check", Type: "llm_judge"},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"trigger is required"},
+		},
+		{
+			name: "invalid trigger",
+			defs: []EvalDef{
+				{ID: "tone-check", Type: "llm_judge", Trigger: "on_full_moon"},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"invalid trigger"},
+		},
+		{
+			name: "duplicate ids",
+			defs: []EvalDef{
+				{ID: "tone-check", Type: "llm_judge", Trigger: TriggerEveryTurn},
+				{ID: "tone-check", Type: "custom", Trigger: TriggerEveryTurn},
+			},
+			scope:     "prompt:greeting",
+			wantCount: 1,
+			wantMsgs:  []string{"duplicate eval id"},
+		},
+		{
+			name: "sample_percentage too low",
+			defs: []EvalDef{
+				{ID: "s", Type: "t", Trigger: TriggerSampleTurns, SamplePercentage: float64Ptr(-1)},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"sample_percentage must be between 0 and 100"},
+		},
+		{
+			name: "sample_percentage too high",
+			defs: []EvalDef{
+				{ID: "s", Type: "t", Trigger: TriggerSampleTurns, SamplePercentage: float64Ptr(101)},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"sample_percentage must be between 0 and 100"},
+		},
+		{
+			name: "sample_percentage at boundaries is valid",
+			defs: []EvalDef{
+				{ID: "a", Type: "t", Trigger: TriggerEveryTurn, SamplePercentage: float64Ptr(0)},
+				{ID: "b", Type: "t", Trigger: TriggerEveryTurn, SamplePercentage: float64Ptr(100)},
+			},
+			scope:     "pack",
+			wantCount: 0,
+		},
+		{
+			name: "metric missing name",
+			defs: []EvalDef{
+				{ID: "m", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Type: MetricGauge}},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"metric.name is required"},
+		},
+		{
+			name: "metric invalid name",
+			defs: []EvalDef{
+				{ID: "m", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Name: "123bad", Type: MetricGauge}},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"must match Prometheus naming"},
+		},
+		{
+			name: "metric name with spaces is invalid",
+			defs: []EvalDef{
+				{ID: "m", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Name: "has space", Type: MetricGauge}},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"must match Prometheus naming"},
+		},
+		{
+			name: "metric missing type",
+			defs: []EvalDef{
+				{ID: "m", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Name: "good_name"}},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"metric.type is required"},
+		},
+		{
+			name: "metric invalid type",
+			defs: []EvalDef{
+				{ID: "m", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Name: "good_name", Type: "summary"}},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"invalid metric.type"},
+		},
+		{
+			name: "metric range min > max",
+			defs: []EvalDef{
+				{
+					ID: "m", Type: "t", Trigger: TriggerEveryTurn,
+					Metric: &MetricDef{
+						Name:  "score",
+						Type:  MetricGauge,
+						Range: &Range{Min: float64Ptr(10), Max: float64Ptr(5)},
+					},
+				},
+			},
+			scope:     "pack",
+			wantCount: 1,
+			wantMsgs:  []string{"range.min", "must be <=", "range.max"},
+		},
+		{
+			name: "metric range valid",
+			defs: []EvalDef{
+				{
+					ID: "m", Type: "t", Trigger: TriggerEveryTurn,
+					Metric: &MetricDef{
+						Name:  "score",
+						Type:  MetricGauge,
+						Range: &Range{Min: float64Ptr(0), Max: float64Ptr(1)},
+					},
+				},
+			},
+			scope:     "pack",
+			wantCount: 0,
+		},
+		{
+			name: "metric range with only min is valid",
+			defs: []EvalDef{
+				{
+					ID: "m", Type: "t", Trigger: TriggerEveryTurn,
+					Metric: &MetricDef{
+						Name:  "score",
+						Type:  MetricGauge,
+						Range: &Range{Min: float64Ptr(0)},
+					},
+				},
+			},
+			scope:     "pack",
+			wantCount: 0,
+		},
+		{
+			name: "multiple errors accumulate",
+			defs: []EvalDef{
+				{}, // missing id, type, trigger
+			},
+			scope:     "pack",
+			wantCount: 3,
+			wantMsgs:  []string{"id is required", "type is required", "trigger is required"},
+		},
+		{
+			name: "scope appears in error messages",
+			defs: []EvalDef{
+				{Type: "t", Trigger: TriggerEveryTurn},
+			},
+			scope:     "prompt:greeting",
+			wantCount: 1,
+			wantMsgs:  []string{"prompt:greeting"},
+		},
+		{
+			name: "valid prometheus metric names",
+			defs: []EvalDef{
+				{ID: "a", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Name: "simple", Type: MetricGauge}},
+				{ID: "b", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Name: "_private", Type: MetricCounter}},
+				{ID: "c", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Name: "namespace:metric_name", Type: MetricHistogram}},
+				{ID: "d", Type: "t", Trigger: TriggerEveryTurn, Metric: &MetricDef{Name: "CamelCase123", Type: MetricBoolean}},
+			},
+			scope:     "pack",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateEvals(tt.defs, tt.scope)
+			if len(errs) != tt.wantCount {
+				t.Errorf("got %d errors, want %d:\n%s", len(errs), tt.wantCount, strings.Join(errs, "\n"))
+				return
+			}
+			for _, msg := range tt.wantMsgs {
+				found := false
+				for _, err := range errs {
+					if strings.Contains(err, msg) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected error containing %q, got:\n%s", msg, strings.Join(errs, "\n"))
+				}
+			}
+		})
+	}
+}
+
+func TestValidateEvals_ValidAllTriggerTypes(t *testing.T) {
+	for trigger := range ValidTriggers {
+		defs := []EvalDef{{ID: "test", Type: "custom", Trigger: trigger}}
+		errs := ValidateEvals(defs, "pack")
+		if len(errs) != 0 {
+			t.Errorf("trigger %q should be valid, got errors: %v", trigger, errs)
+		}
+	}
+}
+
+func TestValidateEvals_ValidAllMetricTypes(t *testing.T) {
+	for mt := range ValidMetricTypes {
+		defs := []EvalDef{{
+			ID: "test", Type: "custom", Trigger: TriggerEveryTurn,
+			Metric: &MetricDef{Name: "test_metric", Type: mt},
+		}}
+		errs := ValidateEvals(defs, "pack")
+		if len(errs) != 0 {
+			t.Errorf("metric type %q should be valid, got errors: %v", mt, errs)
+		}
+	}
+}
+
+func TestValidateEvals_DisabledEvalStillValidated(t *testing.T) {
+	defs := []EvalDef{{
+		ID:      "test",
+		Type:    "custom",
+		Trigger: "bogus",
+		Enabled: boolPtr(false),
+	}}
+	errs := ValidateEvals(defs, "pack")
+	if len(errs) != 1 {
+		t.Errorf("disabled eval should still be validated, got %d errors", len(errs))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ValidateEvals()` function in `runtime/evals/validate.go` for validating `[]EvalDef` slices
- Validates: unique IDs, required fields (id, type, trigger), valid trigger/metric type enums, sample_percentage in [0,100], Prometheus metric name regex, range min <= max
- Clear error messages with scope prefix (e.g. `pack evals[0] (id="tone-check"): ...`)

## Test plan
- [x] Nil and empty input return no errors
- [x] Valid evals with all field combinations pass
- [x] Missing required fields (id, type, trigger) detected
- [x] Invalid trigger values detected
- [x] Duplicate IDs within scope detected
- [x] sample_percentage boundary validation (0 and 100 valid, -1 and 101 invalid)
- [x] Prometheus metric name regex validation
- [x] Invalid metric types detected
- [x] Metric range min > max detected
- [x] Multiple errors accumulate correctly
- [x] Scope string appears in error messages
- [x] Disabled evals are still validated
- [x] All valid trigger types accepted
- [x] All valid metric types accepted
- [x] 100% coverage on validate.go, 96.0% package-wide
- [x] `go test -race` passes
- [x] Pre-commit hooks pass

Closes #301