### PR TITLE
feat(evals): add EvalTypeRegistry and JudgeProvider interface

### DIFF
--- a/runtime/evals/handlers/judge_provider.go
+++ b/runtime/evals/handlers/judge_provider.go
@@ -1,0 +1,53 @@
+// Package handlers provides eval type handler implementations.
+package handlers
+
+import "context"
+
+// JudgeProvider abstracts LLM access for judge-based evaluations.
+// Arena, SDK, and eval workers each provide their own implementation
+// wiring their respective provider infrastructure.
+type JudgeProvider interface {
+	// Judge sends the evaluation prompt to an LLM and returns
+	// the parsed verdict. Implementations handle provider selection,
+	// prompt formatting, and response parsing.
+	Judge(ctx context.Context, opts JudgeOpts) (*JudgeResult, error)
+}
+
+// JudgeOpts configures a judge evaluation request.
+type JudgeOpts struct {
+	// Content is the text being evaluated (assistant response or full conversation).
+	Content string
+
+	// Criteria describes what the judge should evaluate (e.g. "Is the response helpful?").
+	Criteria string
+
+	// Rubric provides detailed scoring guidance (optional).
+	Rubric string
+
+	// Model specifies which model to use for judging (optional, provider decides default).
+	Model string
+
+	// SystemPrompt overrides the default judge system prompt (optional).
+	SystemPrompt string
+
+	// MinScore is the minimum score threshold for passing (optional).
+	MinScore *float64
+
+	// Extra holds additional parameters for provider-specific features.
+	Extra map[string]any
+}
+
+// JudgeResult captures the output of an LLM judge evaluation.
+type JudgeResult struct {
+	// Passed indicates whether the content met the evaluation criteria.
+	Passed bool
+
+	// Score is the numerical score assigned by the judge (typically 0.0-1.0).
+	Score float64
+
+	// Reasoning explains the judge's evaluation.
+	Reasoning string
+
+	// Raw is the unprocessed LLM response text.
+	Raw string
+}

--- a/runtime/evals/handlers/judge_provider_test.go
+++ b/runtime/evals/handlers/judge_provider_test.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+)
+
+// mockJudgeProvider implements JudgeProvider for testing.
+type mockJudgeProvider struct {
+	result *JudgeResult
+	err    error
+}
+
+func (m *mockJudgeProvider) Judge(
+	_ context.Context, _ JudgeOpts,
+) (*JudgeResult, error) {
+	return m.result, m.err
+}
+
+func TestJudgeProviderInterface(t *testing.T) {
+	// Verify the interface can be implemented and used
+	var provider JudgeProvider = &mockJudgeProvider{
+		result: &JudgeResult{
+			Passed:    true,
+			Score:     0.95,
+			Reasoning: "Content is helpful and accurate",
+			Raw:       `{"passed": true, "score": 0.95}`,
+		},
+	}
+
+	result, err := provider.Judge(context.Background(), JudgeOpts{
+		Content:  "Hello, how can I help you?",
+		Criteria: "Is the response helpful?",
+		Model:    "claude-sonnet-4-5-20250929",
+	})
+
+	if err != nil {
+		t.Fatalf("Judge returned error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected Passed=true")
+	}
+	if result.Score != 0.95 {
+		t.Errorf("got score %f, want 0.95", result.Score)
+	}
+	if result.Reasoning == "" {
+		t.Error("expected non-empty reasoning")
+	}
+}
+
+func TestJudgeOptsFields(t *testing.T) {
+	minScore := 0.8
+	opts := JudgeOpts{
+		Content:      "test content",
+		Criteria:     "be helpful",
+		Rubric:       "detailed rubric",
+		Model:        "claude-sonnet-4-5-20250929",
+		SystemPrompt: "You are a judge",
+		MinScore:     &minScore,
+		Extra:        map[string]any{"temperature": 0.0},
+	}
+
+	if opts.Content != "test content" {
+		t.Error("Content not set correctly")
+	}
+	if opts.MinScore == nil || *opts.MinScore != 0.8 {
+		t.Error("MinScore not set correctly")
+	}
+	if opts.Extra["temperature"] != 0.0 {
+		t.Error("Extra not set correctly")
+	}
+}
+
+func TestJudgeProviderError(t *testing.T) {
+	provider := &mockJudgeProvider{
+		err: context.DeadlineExceeded,
+	}
+
+	_, err := provider.Judge(context.Background(), JudgeOpts{
+		Content:  "test",
+		Criteria: "test",
+	})
+
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected DeadlineExceeded, got %v", err)
+	}
+}

--- a/runtime/evals/helpers_test.go
+++ b/runtime/evals/helpers_test.go
@@ -1,0 +1,4 @@
+package evals
+
+func float64Ptr(f float64) *float64 { return &f }
+func boolPtr(b bool) *bool          { return &b }

--- a/runtime/evals/registry.go
+++ b/runtime/evals/registry.go
@@ -1,0 +1,84 @@
+package evals
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// EvalTypeHandler defines the interface for eval type implementations.
+// Each handler covers a single eval type (e.g. "contains", "llm_judge").
+// Handlers are stateless — params are passed per invocation.
+type EvalTypeHandler interface {
+	// Type returns the eval type identifier (e.g. "contains", "regex").
+	Type() string
+
+	// Eval executes the evaluation and returns a result.
+	// The EvalContext carries messages, tool calls, and metadata.
+	// Params come from the EvalDef.Params map.
+	Eval(ctx context.Context, evalCtx *EvalContext, params map[string]any) (*EvalResult, error)
+}
+
+// EvalTypeRegistry provides thread-safe registration and lookup of
+// EvalTypeHandler implementations by type name.
+type EvalTypeRegistry struct {
+	handlers map[string]EvalTypeHandler
+	mu       sync.RWMutex
+}
+
+// NewEmptyEvalTypeRegistry creates a registry with no handlers registered.
+// Use this in tests to control exactly which handlers are available.
+func NewEmptyEvalTypeRegistry() *EvalTypeRegistry {
+	return &EvalTypeRegistry{
+		handlers: make(map[string]EvalTypeHandler),
+	}
+}
+
+// NewEvalTypeRegistry creates a registry pre-populated with all
+// built-in eval handlers. Call this in production code.
+func NewEvalTypeRegistry() *EvalTypeRegistry {
+	r := NewEmptyEvalTypeRegistry()
+	// Built-in handlers will be registered here as they are implemented
+	// in subsequent issues (#303, #304, #305).
+	return r
+}
+
+// Register adds a handler to the registry. If a handler with the same
+// type is already registered, it is replaced.
+func (r *EvalTypeRegistry) Register(handler EvalTypeHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handlers[handler.Type()] = handler
+}
+
+// Get returns the handler for the given type, or an error if not found.
+func (r *EvalTypeRegistry) Get(evalType string) (EvalTypeHandler, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	h, ok := r.handlers[evalType]
+	if !ok {
+		return nil, fmt.Errorf("unknown eval type: %q", evalType)
+	}
+	return h, nil
+}
+
+// Has returns true if a handler is registered for the given type.
+func (r *EvalTypeRegistry) Has(evalType string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.handlers[evalType]
+	return ok
+}
+
+// Types returns a sorted list of all registered eval type names.
+func (r *EvalTypeRegistry) Types() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	types := make([]string, 0, len(r.handlers))
+	for t := range r.handlers {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
+}

--- a/runtime/evals/registry_test.go
+++ b/runtime/evals/registry_test.go
@@ -1,0 +1,158 @@
+package evals
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// stubHandler is a minimal EvalTypeHandler for testing.
+type stubHandler struct {
+	typeName string
+}
+
+func (s *stubHandler) Type() string { return s.typeName }
+
+func (s *stubHandler) Eval(
+	_ context.Context, _ *EvalContext, _ map[string]any,
+) (*EvalResult, error) {
+	return &EvalResult{EvalID: s.typeName, Passed: true}, nil
+}
+
+func TestNewEmptyEvalTypeRegistry(t *testing.T) {
+	r := NewEmptyEvalTypeRegistry()
+	if len(r.Types()) != 0 {
+		t.Errorf("empty registry should have 0 types, got %d", len(r.Types()))
+	}
+}
+
+func TestNewEvalTypeRegistry(t *testing.T) {
+	r := NewEvalTypeRegistry()
+	// Currently no built-in handlers, but should not panic
+	if r == nil {
+		t.Fatal("NewEvalTypeRegistry returned nil")
+	}
+}
+
+func TestRegisterAndGet(t *testing.T) {
+	r := NewEmptyEvalTypeRegistry()
+	h := &stubHandler{typeName: "contains"}
+	r.Register(h)
+
+	got, err := r.Get("contains")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got.Type() != "contains" {
+		t.Errorf("got type %q, want %q", got.Type(), "contains")
+	}
+}
+
+func TestGetUnknownType(t *testing.T) {
+	r := NewEmptyEvalTypeRegistry()
+	_, err := r.Get("nonexistent")
+	if err == nil {
+		t.Fatal("Get should return error for unknown type")
+	}
+}
+
+func TestHas(t *testing.T) {
+	r := NewEmptyEvalTypeRegistry()
+	r.Register(&stubHandler{typeName: "regex"})
+
+	if !r.Has("regex") {
+		t.Error("Has should return true for registered type")
+	}
+	if r.Has("unknown") {
+		t.Error("Has should return false for unregistered type")
+	}
+}
+
+func TestTypes(t *testing.T) {
+	r := NewEmptyEvalTypeRegistry()
+	r.Register(&stubHandler{typeName: "contains"})
+	r.Register(&stubHandler{typeName: "regex"})
+	r.Register(&stubHandler{typeName: "json_valid"})
+
+	types := r.Types()
+	want := []string{"contains", "json_valid", "regex"}
+	if len(types) != len(want) {
+		t.Fatalf("got %d types, want %d", len(types), len(want))
+	}
+	for i, w := range want {
+		if types[i] != w {
+			t.Errorf("types[%d] = %q, want %q", i, types[i], w)
+		}
+	}
+}
+
+func TestRegisterReplaces(t *testing.T) {
+	r := NewEmptyEvalTypeRegistry()
+	r.Register(&stubHandler{typeName: "contains"})
+
+	// Replace with a new handler of the same type
+	replacement := &stubHandler{typeName: "contains"}
+	r.Register(replacement)
+
+	got, err := r.Get("contains")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got != replacement {
+		t.Error("Register should replace existing handler")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	r := NewEmptyEvalTypeRegistry()
+	var wg sync.WaitGroup
+
+	// Concurrent registrations
+	for i := range 10 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			h := &stubHandler{typeName: "type_" + string(rune('a'+n))}
+			r.Register(h)
+		}(i)
+	}
+
+	// Concurrent reads
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.Has("type_a")
+			r.Types()
+			_, _ = r.Get("type_a")
+		}()
+	}
+
+	wg.Wait()
+
+	// Should have all 10 types registered
+	if len(r.Types()) != 10 {
+		t.Errorf("got %d types, want 10", len(r.Types()))
+	}
+}
+
+func TestHandlerEval(t *testing.T) {
+	r := NewEmptyEvalTypeRegistry()
+	r.Register(&stubHandler{typeName: "test"})
+
+	h, err := r.Get("test")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+
+	result, err := h.Eval(context.Background(), &EvalContext{}, nil)
+	if err != nil {
+		t.Fatalf("Eval returned error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected Passed=true")
+	}
+	if result.EvalID != "test" {
+		t.Errorf("got EvalID=%q, want %q", result.EvalID, "test")
+	}
+}

--- a/runtime/evals/resolve_test.go
+++ b/runtime/evals/resolve_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 )
 
-func boolPtr(b bool) *bool       { return &b }
-func float64Ptr(f float64) *float64 { return &f }
 
 func TestResolveEvals(t *testing.T) {
 	tests := []struct {

--- a/runtime/evals/validate_test.go
+++ b/runtime/evals/validate_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-func float64Ptr(f float64) *float64 { return &f }
-func boolPtr(b bool) *bool          { return &b }
 
 func TestValidateEvals(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Adds `EvalTypeHandler` interface — unified handler for both turn-level and session-level evals
- Adds thread-safe `EvalTypeRegistry` with `Register()`, `Get()`, `Has()`, `Types()`
- `NewEvalTypeRegistry()` for production (will be pre-populated as handlers are added)
- `NewEmptyEvalTypeRegistry()` for testing
- Adds `JudgeProvider` interface with `JudgeOpts`/`JudgeResult` in `runtime/evals/handlers/`
- Deduplicates test helpers (`float64Ptr`, `boolPtr`) into shared `helpers_test.go`

## Test plan
- [x] Empty registry has 0 types
- [x] Register and Get round-trip
- [x] Get unknown type returns error
- [x] Has returns true/false correctly
- [x] Types returns sorted list
- [x] Register replaces existing handler
- [x] Concurrent Register/Get/Has/Types safe (race detector)
- [x] Handler.Eval produces correct result
- [x] JudgeProvider interface can be implemented and used
- [x] JudgeOpts fields set correctly
- [x] JudgeProvider error propagation
- [x] 100% coverage on registry.go, 97.4% package-wide
- [x] Pre-commit hooks pass

Closes #302