### PR TITLE
feat(evals): migrate conversation-level assertions to session handlers

### DIFF
--- a/runtime/evals/handlers/contains.go
+++ b/runtime/evals/handlers/contains.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ContainsHandler checks if CurrentOutput contains all specified
+// patterns (case-insensitive). Params: patterns []string.
+type ContainsHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ContainsHandler) Type() string { return "contains" }
+
+// Eval checks that all patterns appear in the current output.
+func (h *ContainsHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	patterns := extractStringSlice(params, "patterns")
+	if len(patterns) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no patterns specified",
+		}, nil
+	}
+
+	contentLower := strings.ToLower(evalCtx.CurrentOutput)
+	missing := findMissingPatterns(contentLower, patterns)
+
+	passed := len(missing) == 0
+	explanation := "all patterns found in output"
+	if !passed {
+		explanation = fmt.Sprintf(
+			"missing patterns: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Explanation: explanation,
+	}, nil
+}
+
+// findMissingPatterns returns patterns not found in lowercased content.
+func findMissingPatterns(
+	contentLower string, patterns []string,
+) []string {
+	var missing []string
+	for _, p := range patterns {
+		if !strings.Contains(contentLower, strings.ToLower(p)) {
+			missing = append(missing, p)
+		}
+	}
+	return missing
+}

--- a/runtime/evals/handlers/contains_any.go
+++ b/runtime/evals/handlers/contains_any.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ContainsAnyHandler checks that at least one assistant message
+// contains at least one of the specified patterns.
+// Params: patterns []string (case-insensitive matching).
+type ContainsAnyHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ContainsAnyHandler) Type() string {
+	return "contains_any"
+}
+
+// Eval checks assistant messages for any matching pattern.
+func (h *ContainsAnyHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (_ *evals.EvalResult, _ error) {
+	patterns := extractStringSlice(params, "patterns")
+	if len(patterns) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no patterns specified",
+		}, nil
+	}
+
+	for i := range evalCtx.Messages {
+		msg := &evalCtx.Messages[i]
+		if !strings.EqualFold(msg.Role, roleAssistant) {
+			continue
+		}
+		content := msg.GetContent()
+		for _, p := range patterns {
+			if containsInsensitive(content, p) {
+				return &evals.EvalResult{
+					Type:   h.Type(),
+					Passed: true,
+					Explanation: fmt.Sprintf(
+						"turn %d contains pattern %q",
+						i, p,
+					),
+				}, nil
+			}
+		}
+	}
+
+	return &evals.EvalResult{
+		Type:   h.Type(),
+		Passed: false,
+		Explanation: fmt.Sprintf(
+			"no assistant message contained any of: %s",
+			strings.Join(patterns, ", "),
+		),
+	}, nil
+}

--- a/runtime/evals/handlers/content_excludes.go
+++ b/runtime/evals/handlers/content_excludes.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ContentExcludesHandler checks that NONE of the assistant messages
+// across the full conversation contain any of the forbidden patterns.
+// Params: patterns []string (case-insensitive matching).
+type ContentExcludesHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ContentExcludesHandler) Type() string {
+	return "content_excludes"
+}
+
+// Eval checks all assistant messages for forbidden patterns.
+func (h *ContentExcludesHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (_ *evals.EvalResult, _ error) {
+	patterns := extractStringSlice(params, "patterns")
+	if len(patterns) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no patterns to check",
+		}, nil
+	}
+
+	var found []string
+	for i := range evalCtx.Messages {
+		msg := &evalCtx.Messages[i]
+		if !strings.EqualFold(msg.Role, roleAssistant) {
+			continue
+		}
+		content := msg.GetContent()
+		for _, p := range patterns {
+			if containsInsensitive(content, p) {
+				found = append(found, fmt.Sprintf(
+					"turn %d contains %q", i, p,
+				))
+			}
+		}
+	}
+
+	if len(found) > 0 {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"forbidden content found: %s",
+				strings.Join(found, "; "),
+			),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: "no forbidden content detected",
+	}, nil
+}

--- a/runtime/evals/handlers/cosine_similarity.go
+++ b/runtime/evals/handlers/cosine_similarity.go
@@ -1,0 +1,142 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// CosineSimilarityHandler computes cosine similarity between
+// embeddings. Params: reference []float64, min_similarity float64.
+// Target embedding comes from Metadata["embedding"].
+type CosineSimilarityHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *CosineSimilarityHandler) Type() string {
+	return "cosine_similarity"
+}
+
+// Eval computes cosine similarity and checks against threshold.
+func (h *CosineSimilarityHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	reference, ok := extractFloat64Slice(params, "reference")
+	if !ok || len(reference) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no reference embedding specified",
+		}, nil
+	}
+
+	minSim, ok := extractFloat64(params, "min_similarity")
+	if !ok {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no min_similarity specified",
+		}, nil
+	}
+
+	target, ok := extractFloat64Slice(
+		evalCtx.Metadata, "embedding",
+	)
+	if !ok || len(target) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no embedding found in metadata",
+		}, nil
+	}
+
+	return h.computeAndCheck(reference, target, minSim)
+}
+
+// computeAndCheck calculates similarity and builds the result.
+func (h *CosineSimilarityHandler) computeAndCheck(
+	reference, target []float64, minSim float64,
+) (result *evals.EvalResult, err error) {
+	if len(reference) != len(target) {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"dimension mismatch: reference=%d, target=%d",
+				len(reference), len(target),
+			),
+		}, nil
+	}
+
+	similarity := cosineSimilarity(reference, target)
+	passed := similarity >= minSim
+	explanation := fmt.Sprintf(
+		"cosine similarity %.4f vs threshold %.4f",
+		similarity, minSim,
+	)
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Score:       &similarity,
+		Explanation: explanation,
+	}, nil
+}
+
+// cosineSimilarity computes the cosine similarity between two
+// vectors.
+func cosineSimilarity(a, b []float64) float64 {
+	var dot, normA, normB float64
+	for i := range a {
+		dot += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+	denom := math.Sqrt(normA) * math.Sqrt(normB)
+	if denom == 0 {
+		return 0
+	}
+	return dot / denom
+}
+
+// extractFloat64Slice extracts a []float64 from a map value.
+func extractFloat64Slice(
+	m map[string]any, key string,
+) (result []float64, ok bool) {
+	v, exists := m[key]
+	if !exists {
+		return nil, false
+	}
+
+	switch s := v.(type) {
+	case []float64:
+		return s, true
+	case []any:
+		return convertToFloat64Slice(s)
+	default:
+		return nil, false
+	}
+}
+
+// convertToFloat64Slice converts a []any to []float64.
+func convertToFloat64Slice(
+	s []any,
+) (result []float64, ok bool) {
+	out := make([]float64, 0, len(s))
+	for _, item := range s {
+		switch n := item.(type) {
+		case float64:
+			out = append(out, n)
+		case float32:
+			out = append(out, float64(n))
+		case int:
+			out = append(out, float64(n))
+		default:
+			return nil, false
+		}
+	}
+	return out, true
+}

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -1,0 +1,795 @@
+package handlers
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// --- Contains ---
+
+func TestContainsHandler_Type(t *testing.T) {
+	h := &ContainsHandler{}
+	if h.Type() != "contains" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestContainsHandler_AllFound(t *testing.T) {
+	h := &ContainsHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "Hello World, this is a Test",
+	}
+	params := map[string]any{
+		"patterns": []any{"hello", "world", "test"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestContainsHandler_Missing(t *testing.T) {
+	h := &ContainsHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "Hello World",
+	}
+	params := map[string]any{
+		"patterns": []any{"hello", "missing"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing pattern")
+	}
+}
+
+func TestContainsHandler_NoPatterns(t *testing.T) {
+	h := &ContainsHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no patterns")
+	}
+}
+
+// --- Regex ---
+
+func TestRegexHandler_Type(t *testing.T) {
+	h := &RegexHandler{}
+	if h.Type() != "regex" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestRegexHandler_Match(t *testing.T) {
+	h := &RegexHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "Order #12345 confirmed",
+	}
+	params := map[string]any{
+		"pattern": `#\d{5}`,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected match: %s", result.Explanation)
+	}
+}
+
+func TestRegexHandler_NoMatch(t *testing.T) {
+	h := &RegexHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "no numbers here",
+	}
+	params := map[string]any{"pattern": `\d+`}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected no match")
+	}
+}
+
+func TestRegexHandler_InvalidPattern(t *testing.T) {
+	h := &RegexHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{"pattern": `[invalid`}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Error == "" {
+		t.Fatal("expected error for invalid regex")
+	}
+}
+
+func TestRegexHandler_NoPattern(t *testing.T) {
+	h := &RegexHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no pattern")
+	}
+}
+
+// --- JSONValid ---
+
+func TestJSONValidHandler_Type(t *testing.T) {
+	h := &JSONValidHandler{}
+	if h.Type() != "json_valid" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestJSONValidHandler_Valid(t *testing.T) {
+	h := &JSONValidHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"key": "value", "num": 42}`,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestJSONValidHandler_Invalid(t *testing.T) {
+	h := &JSONValidHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `not json at all`,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for invalid JSON")
+	}
+}
+
+func TestJSONValidHandler_Array(t *testing.T) {
+	h := &JSONValidHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `[1, 2, 3]`,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatal("JSON array should be valid")
+	}
+}
+
+// --- JSONSchema ---
+
+func TestJSONSchemaHandler_Type(t *testing.T) {
+	h := &JSONSchemaHandler{}
+	if h.Type() != "json_schema" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestJSONSchemaHandler_Valid(t *testing.T) {
+	h := &JSONSchemaHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"name": "Alice", "age": 30}`,
+	}
+	params := map[string]any{
+		"schema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+				"age":  map[string]any{"type": "integer"},
+			},
+			"required": []any{"name", "age"},
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestJSONSchemaHandler_Invalid(t *testing.T) {
+	h := &JSONSchemaHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"name": 123}`,
+	}
+	params := map[string]any{
+		"schema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+			},
+			"required": []any{"name"},
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for schema violation")
+	}
+}
+
+func TestJSONSchemaHandler_NotJSON(t *testing.T) {
+	h := &JSONSchemaHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{CurrentOutput: "not json"}
+	params := map[string]any{
+		"schema": map[string]any{"type": "object"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for non-JSON")
+	}
+}
+
+func TestJSONSchemaHandler_NoSchema(t *testing.T) {
+	h := &JSONSchemaHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{CurrentOutput: `{}`}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no schema")
+	}
+}
+
+// --- ToolsCalled ---
+
+func TestToolsCalledHandler_Type(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	if h.Type() != "tools_called" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolsCalledHandler_AllCalled(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search"},
+			{ToolName: "fetch"},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"search", "fetch"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolsCalledHandler_Missing(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search"},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"search", "fetch"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing fetch")
+	}
+}
+
+func TestToolsCalledHandler_MinCalls(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search"},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"search"},
+		"min_calls":  float64(3),
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: only 1 call, need 3")
+	}
+}
+
+func TestToolsCalledHandler_NoToolNames(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no tool_names")
+	}
+}
+
+// --- ToolsNotCalled ---
+
+func TestToolsNotCalledHandler_Type(t *testing.T) {
+	h := &ToolsNotCalledHandler{}
+	if h.Type() != "tools_not_called" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolsNotCalledHandler_Pass(t *testing.T) {
+	h := &ToolsNotCalledHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search"},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"delete", "drop"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolsNotCalledHandler_Fail(t *testing.T) {
+	h := &ToolsNotCalledHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "delete"},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"delete"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: delete was called")
+	}
+}
+
+// --- ToolArgs ---
+
+func TestToolArgsHandler_Type(t *testing.T) {
+	h := &ToolArgsHandler{}
+	if h.Type() != "tool_args" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolArgsHandler_Match(t *testing.T) {
+	h := &ToolArgsHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "search",
+				Arguments: map[string]any{
+					"query": "golang",
+					"limit": "10",
+				},
+			},
+		},
+	}
+	params := map[string]any{
+		"tool_name": "search",
+		"expected_args": map[string]any{
+			"query": "golang",
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolArgsHandler_Mismatch(t *testing.T) {
+	h := &ToolArgsHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName:  "search",
+				Arguments: map[string]any{"query": "python"},
+			},
+		},
+	}
+	params := map[string]any{
+		"tool_name":     "search",
+		"expected_args": map[string]any{"query": "golang"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: args don't match")
+	}
+}
+
+func TestToolArgsHandler_ToolNotCalled(t *testing.T) {
+	h := &ToolArgsHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{ToolCalls: nil}
+	params := map[string]any{
+		"tool_name":     "search",
+		"expected_args": map[string]any{"q": "test"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: tool not called")
+	}
+}
+
+func TestToolArgsHandler_NoToolName(t *testing.T) {
+	h := &ToolArgsHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: no tool_name")
+	}
+}
+
+// --- LatencyBudget ---
+
+func TestLatencyBudgetHandler_Type(t *testing.T) {
+	h := &LatencyBudgetHandler{}
+	if h.Type() != "latency_budget" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestLatencyBudgetHandler_WithinBudget(t *testing.T) {
+	h := &LatencyBudgetHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{"latency_ms": 150.0},
+	}
+	params := map[string]any{"max_ms": 200.0}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+	if result.Score == nil || *result.Score != 1.0 {
+		t.Fatalf("expected score 1.0, got %v", result.Score)
+	}
+}
+
+func TestLatencyBudgetHandler_OverBudget(t *testing.T) {
+	h := &LatencyBudgetHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{"latency_ms": 500.0},
+	}
+	params := map[string]any{"max_ms": 200.0}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: over budget")
+	}
+	if result.Score == nil {
+		t.Fatal("expected score to be set")
+	}
+	if *result.Score >= 1.0 {
+		t.Fatalf("expected score < 1.0, got %f", *result.Score)
+	}
+}
+
+func TestLatencyBudgetHandler_NoMaxMs(t *testing.T) {
+	h := &LatencyBudgetHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{"latency_ms": 100.0},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: no max_ms")
+	}
+}
+
+func TestLatencyBudgetHandler_NoLatencyInMetadata(t *testing.T) {
+	h := &LatencyBudgetHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{},
+	}
+	params := map[string]any{"max_ms": 200.0}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: no latency_ms in metadata")
+	}
+}
+
+// --- CosineSimilarity ---
+
+func TestCosineSimilarityHandler_Type(t *testing.T) {
+	h := &CosineSimilarityHandler{}
+	if h.Type() != "cosine_similarity" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestCosineSimilarityHandler_Identical(t *testing.T) {
+	h := &CosineSimilarityHandler{}
+	ctx := context.Background()
+	ref := []float64{1.0, 0.0, 0.0}
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{
+			"embedding": []float64{1.0, 0.0, 0.0},
+		},
+	}
+	params := map[string]any{
+		"reference":      ref,
+		"min_similarity": 0.9,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+	if result.Score == nil {
+		t.Fatal("expected score")
+	}
+	if math.Abs(*result.Score-1.0) > 1e-9 {
+		t.Fatalf("expected score ~1.0, got %f", *result.Score)
+	}
+}
+
+func TestCosineSimilarityHandler_Orthogonal(t *testing.T) {
+	h := &CosineSimilarityHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{
+			"embedding": []float64{0.0, 1.0, 0.0},
+		},
+	}
+	params := map[string]any{
+		"reference":      []float64{1.0, 0.0, 0.0},
+		"min_similarity": 0.5,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: orthogonal vectors")
+	}
+}
+
+func TestCosineSimilarityHandler_DimensionMismatch(t *testing.T) {
+	h := &CosineSimilarityHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{
+			"embedding": []float64{1.0, 0.0},
+		},
+	}
+	params := map[string]any{
+		"reference":      []float64{1.0, 0.0, 0.0},
+		"min_similarity": 0.5,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: dimension mismatch")
+	}
+}
+
+func TestCosineSimilarityHandler_NoReference(t *testing.T) {
+	h := &CosineSimilarityHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{
+			"embedding": []float64{1.0},
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{
+		"min_similarity": 0.5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: no reference")
+	}
+}
+
+func TestCosineSimilarityHandler_NoEmbedding(t *testing.T) {
+	h := &CosineSimilarityHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{},
+	}
+	params := map[string]any{
+		"reference":      []float64{1.0, 0.0},
+		"min_similarity": 0.5,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: no embedding in metadata")
+	}
+}
+
+func TestCosineSimilarityHandler_AnySlice(t *testing.T) {
+	h := &CosineSimilarityHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{
+			"embedding": []any{1.0, 0.0, 0.0},
+		},
+	}
+	params := map[string]any{
+		"reference":      []any{1.0, 0.0, 0.0},
+		"min_similarity": 0.9,
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass with []any: %s", result.Explanation)
+	}
+}
+
+// --- Registration ---
+
+func TestRegisterInit(t *testing.T) {
+	// Verify that init() registered all handlers
+	expected := []string{
+		"contains",
+		"contains_any",
+		"content_excludes",
+		"cosine_similarity",
+		"json_schema",
+		"json_valid",
+		"latency_budget",
+		"regex",
+		"tool_args",
+		"tool_args_excluded_session",
+		"tool_args_session",
+		"tools_called",
+		"tools_called_session",
+		"tools_not_called",
+		"tools_not_called_session",
+	}
+
+	r := evals.NewEvalTypeRegistry()
+	types := r.Types()
+
+	if len(types) != len(expected) {
+		t.Fatalf(
+			"expected %d types, got %d: %v",
+			len(expected), len(types), types,
+		)
+	}
+
+	for _, e := range expected {
+		if !r.Has(e) {
+			t.Errorf("missing handler: %s", e)
+		}
+	}
+}

--- a/runtime/evals/handlers/helpers.go
+++ b/runtime/evals/handlers/helpers.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+)
+
+const roleAssistant = "assistant"
+
+// extractStringSlice safely extracts a string slice from params.
+func extractStringSlice(params map[string]any, key string) []string {
+	value, exists := params[key]
+	if !exists {
+		return nil
+	}
+
+	if strSlice, ok := value.([]string); ok {
+		return strSlice
+	}
+
+	if ifaceSlice, ok := value.([]any); ok {
+		result := make([]string, 0, len(ifaceSlice))
+		for _, item := range ifaceSlice {
+			if str, ok := item.(string); ok {
+				result = append(result, str)
+			}
+		}
+		return result
+	}
+
+	return nil
+}
+
+// containsInsensitive checks if text contains pattern
+// (case-insensitive).
+func containsInsensitive(text, pattern string) bool {
+	return strings.Contains(
+		strings.ToLower(text),
+		strings.ToLower(pattern),
+	)
+}
+
+// asString converts any value to its string representation.
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/runtime/evals/handlers/json_schema.go
+++ b/runtime/evals/handlers/json_schema.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// JSONSchemaHandler validates CurrentOutput against a JSON schema.
+// Params: schema map[string]any.
+type JSONSchemaHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *JSONSchemaHandler) Type() string { return "json_schema" }
+
+// Eval validates the current output against the provided JSON schema.
+func (h *JSONSchemaHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	schema, _ := params["schema"].(map[string]any)
+	if schema == nil {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no schema provided",
+		}, nil
+	}
+
+	// Validate the output is valid JSON first
+	var target any
+	if parseErr := json.Unmarshal(
+		[]byte(evalCtx.CurrentOutput), &target,
+	); parseErr != nil {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"output is not valid JSON: %v", parseErr,
+			),
+		}, nil
+	}
+
+	return h.validateSchema(evalCtx.CurrentOutput, schema)
+}
+
+// validateSchema performs the JSON schema validation.
+func (h *JSONSchemaHandler) validateSchema(
+	content string, schema map[string]any,
+) (result *evals.EvalResult, err error) {
+	schemaLoader := gojsonschema.NewGoLoader(schema)
+	docLoader := gojsonschema.NewStringLoader(content)
+
+	valResult, valErr := gojsonschema.Validate(
+		schemaLoader, docLoader,
+	)
+	if valErr != nil {
+		return &evals.EvalResult{
+			Type:  h.Type(),
+			Error: fmt.Sprintf("schema validation error: %v", valErr),
+		}, nil
+	}
+
+	if !valResult.Valid() {
+		errs := make([]string, 0, len(valResult.Errors()))
+		for _, e := range valResult.Errors() {
+			errs = append(errs, e.String())
+		}
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"schema violations: %s",
+				strings.Join(errs, "; "),
+			),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: "output matches JSON schema",
+	}, nil
+}

--- a/runtime/evals/handlers/json_valid.go
+++ b/runtime/evals/handlers/json_valid.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// JSONValidHandler checks if CurrentOutput is valid JSON.
+// No required params.
+type JSONValidHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *JSONValidHandler) Type() string { return "json_valid" }
+
+// Eval checks that the current output is parseable JSON.
+func (h *JSONValidHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	_ map[string]any,
+) (result *evals.EvalResult, err error) {
+	var target any
+	parseErr := json.Unmarshal(
+		[]byte(evalCtx.CurrentOutput), &target,
+	)
+
+	if parseErr != nil {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"invalid JSON: %v", parseErr,
+			),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: "output is valid JSON",
+	}, nil
+}

--- a/runtime/evals/handlers/latency_budget.go
+++ b/runtime/evals/handlers/latency_budget.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// LatencyBudgetHandler checks Metadata["latency_ms"] against a max.
+// Params: max_ms float64.
+type LatencyBudgetHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *LatencyBudgetHandler) Type() string {
+	return "latency_budget"
+}
+
+// Eval checks that the latency is within budget.
+func (h *LatencyBudgetHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	maxMs, ok := extractFloat64(params, "max_ms")
+	if !ok {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no max_ms specified",
+		}, nil
+	}
+
+	latencyMs, ok := extractFloat64(
+		evalCtx.Metadata, "latency_ms",
+	)
+	if !ok {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "latency_ms not found in metadata",
+		}, nil
+	}
+
+	passed := latencyMs <= maxMs
+	score := 1.0
+	if latencyMs > 0 {
+		score = maxMs / latencyMs
+		if score > 1.0 {
+			score = 1.0
+		}
+	}
+
+	explanation := fmt.Sprintf(
+		"latency %.1fms vs budget %.1fms", latencyMs, maxMs,
+	)
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Score:       &score,
+		Explanation: explanation,
+	}, nil
+}
+
+// extractFloat64 extracts a float64 from a map, handling int and
+// float types.
+func extractFloat64(
+	m map[string]any, key string,
+) (val float64, ok bool) {
+	v, exists := m[key]
+	if !exists {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}

--- a/runtime/evals/handlers/regex.go
+++ b/runtime/evals/handlers/regex.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// RegexHandler checks if CurrentOutput matches a regex pattern.
+// Params: pattern string.
+type RegexHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *RegexHandler) Type() string { return "regex" }
+
+// Eval checks that the current output matches the regex pattern.
+func (h *RegexHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	patternStr, _ := params["pattern"].(string)
+	if patternStr == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no pattern specified",
+		}, nil
+	}
+
+	re, compileErr := regexp.Compile(patternStr)
+	if compileErr != nil {
+		return &evals.EvalResult{
+			Type:  h.Type(),
+			Error: fmt.Sprintf("invalid regex: %v", compileErr),
+		}, nil
+	}
+
+	matched := re.MatchString(evalCtx.CurrentOutput)
+	explanation := fmt.Sprintf(
+		"pattern %q matched: %t", patternStr, matched,
+	)
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      matched,
+		Explanation: explanation,
+	}, nil
+}

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -1,0 +1,25 @@
+package handlers
+
+import "github.com/AltairaLabs/PromptKit/runtime/evals"
+
+//nolint:gochecknoinits // init registers handlers to avoid circular imports
+func init() {
+	// Turn-level deterministic handlers
+	evals.RegisterDefault(&ContainsHandler{})
+	evals.RegisterDefault(&RegexHandler{})
+	evals.RegisterDefault(&JSONValidHandler{})
+	evals.RegisterDefault(&JSONSchemaHandler{})
+	evals.RegisterDefault(&ToolsCalledHandler{})
+	evals.RegisterDefault(&ToolsNotCalledHandler{})
+	evals.RegisterDefault(&ToolArgsHandler{})
+	evals.RegisterDefault(&LatencyBudgetHandler{})
+	evals.RegisterDefault(&CosineSimilarityHandler{})
+
+	// Session-level deterministic handlers
+	evals.RegisterDefault(&ContainsAnyHandler{})
+	evals.RegisterDefault(&ContentExcludesHandler{})
+	evals.RegisterDefault(&ToolsCalledSessionHandler{})
+	evals.RegisterDefault(&ToolsNotCalledSessionHandler{})
+	evals.RegisterDefault(&ToolArgsSessionHandler{})
+	evals.RegisterDefault(&ToolArgsExcludedSessionHandler{})
+}

--- a/runtime/evals/handlers/session_handlers_test.go
+++ b/runtime/evals/handlers/session_handlers_test.go
@@ -1,0 +1,506 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func assistantMsg(content string) types.Message {
+	return types.Message{Role: "assistant", Content: content}
+}
+
+func userMsg(content string) types.Message {
+	return types.Message{Role: "user", Content: content}
+}
+
+func TestContentExcludesHandler_Pass(t *testing.T) {
+	h := &ContentExcludesHandler{}
+	if h.Type() != "content_excludes" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			userMsg("hello"),
+			assistantMsg("I can help with that"),
+			assistantMsg("Here is the answer"),
+		},
+	}
+	params := map[string]any{
+		"patterns": []any{"forbidden", "secret"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestContentExcludesHandler_Fail(t *testing.T) {
+	h := &ContentExcludesHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			userMsg("hello"),
+			assistantMsg("This is SECRET info"),
+		},
+	}
+	params := map[string]any{
+		"patterns": []any{"secret"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for forbidden content")
+	}
+}
+
+func TestContentExcludesHandler_IgnoresUserMessages(t *testing.T) {
+	h := &ContentExcludesHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			userMsg("secret"),
+			assistantMsg("I can help"),
+		},
+	}
+	params := map[string]any{
+		"patterns": []any{"secret"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatal("should ignore user messages")
+	}
+}
+
+func TestContentExcludesHandler_NoPatterns(t *testing.T) {
+	h := &ContentExcludesHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			assistantMsg("anything"),
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatal("no patterns should pass")
+	}
+}
+
+func TestContainsAnyHandler_Pass(t *testing.T) {
+	h := &ContainsAnyHandler{}
+	if h.Type() != "contains_any" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			userMsg("hi"),
+			assistantMsg("The weather is nice"),
+			assistantMsg("Have a good day"),
+		},
+	}
+	params := map[string]any{
+		"patterns": []any{"weather", "rain"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestContainsAnyHandler_Fail(t *testing.T) {
+	h := &ContainsAnyHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			userMsg("hi"),
+			assistantMsg("nothing relevant"),
+		},
+	}
+	params := map[string]any{
+		"patterns": []any{"weather", "rain"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail")
+	}
+}
+
+func TestContainsAnyHandler_CaseInsensitive(t *testing.T) {
+	h := &ContainsAnyHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			assistantMsg("The WEATHER is nice"),
+		},
+	}
+	params := map[string]any{
+		"patterns": []any{"weather"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatal("case-insensitive match should pass")
+	}
+}
+
+func TestContainsAnyHandler_NoPatterns(t *testing.T) {
+	h := &ContainsAnyHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			assistantMsg("anything"),
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("no patterns should fail")
+	}
+}
+
+func TestToolsCalledSessionHandler_Pass(t *testing.T) {
+	h := &ToolsCalledSessionHandler{}
+	if h.Type() != "tools_called_session" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", TurnIndex: 0},
+			{ToolName: "fetch", TurnIndex: 1},
+			{ToolName: "search", TurnIndex: 2},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"search", "fetch"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolsCalledSessionHandler_Fail(t *testing.T) {
+	h := &ToolsCalledSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", TurnIndex: 0},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"search", "fetch"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing fetch")
+	}
+}
+
+func TestToolsCalledSessionHandler_MinCalls(t *testing.T) {
+	h := &ToolsCalledSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", TurnIndex: 0},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"search"},
+		"min_calls":  float64(2),
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: only 1 call but need 2")
+	}
+}
+
+func TestToolsNotCalledSessionHandler_Pass(t *testing.T) {
+	h := &ToolsNotCalledSessionHandler{}
+	if h.Type() != "tools_not_called_session" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", TurnIndex: 0},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"delete", "drop"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolsNotCalledSessionHandler_Fail(t *testing.T) {
+	h := &ToolsNotCalledSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", TurnIndex: 0},
+			{ToolName: "delete", TurnIndex: 1},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"delete"},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: delete was called")
+	}
+}
+
+func TestToolArgsSessionHandler_Pass(t *testing.T) {
+	h := &ToolArgsSessionHandler{}
+	if h.Type() != "tool_args_session" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName:  "search",
+				TurnIndex: 0,
+				Arguments: map[string]any{
+					"query": "golang",
+					"limit": "10",
+				},
+			},
+		},
+	}
+	params := map[string]any{
+		"tool_name": "search",
+		"expected_args": map[string]any{
+			"query": "golang",
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolArgsSessionHandler_Fail(t *testing.T) {
+	h := &ToolArgsSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName:  "search",
+				TurnIndex: 0,
+				Arguments: map[string]any{
+					"query": "python",
+				},
+			},
+		},
+	}
+	params := map[string]any{
+		"tool_name": "search",
+		"expected_args": map[string]any{
+			"query": "golang",
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: args don't match")
+	}
+}
+
+func TestToolArgsSessionHandler_ToolNotCalled(t *testing.T) {
+	h := &ToolArgsSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{},
+	}
+	params := map[string]any{
+		"tool_name": "search",
+		"expected_args": map[string]any{
+			"query": "golang",
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: tool not called")
+	}
+}
+
+func TestToolArgsSessionHandler_NoToolName(t *testing.T) {
+	h := &ToolArgsSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: no tool_name")
+	}
+}
+
+func TestToolArgsExcludedSessionHandler_Pass(t *testing.T) {
+	h := &ToolArgsExcludedSessionHandler{}
+	if h.Type() != "tool_args_excluded_session" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName:  "search",
+				TurnIndex: 0,
+				Arguments: map[string]any{
+					"query": "golang",
+				},
+			},
+		},
+	}
+	params := map[string]any{
+		"tool_name": "search",
+		"excluded_args": map[string]any{
+			"query": "drop tables",
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolArgsExcludedSessionHandler_Fail(t *testing.T) {
+	h := &ToolArgsExcludedSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName:  "search",
+				TurnIndex: 0,
+				Arguments: map[string]any{
+					"query": "drop tables",
+				},
+			},
+		},
+	}
+	params := map[string]any{
+		"tool_name": "search",
+		"excluded_args": map[string]any{
+			"query": "drop tables",
+		},
+	}
+
+	result, err := h.Eval(ctx, evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: excluded args found")
+	}
+}
+
+func TestToolArgsExcludedSessionHandler_NoToolName(t *testing.T) {
+	h := &ToolArgsExcludedSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail: no tool_name")
+	}
+}
+
+func TestToolArgsExcludedSessionHandler_NoExcludedArgs(t *testing.T) {
+	h := &ToolArgsExcludedSessionHandler{}
+	ctx := context.Background()
+	evalCtx := &evals.EvalContext{}
+
+	result, err := h.Eval(ctx, evalCtx, map[string]any{
+		"tool_name": "search",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatal("no excluded_args should pass")
+	}
+}

--- a/runtime/evals/handlers/tool_args.go
+++ b/runtime/evals/handlers/tool_args.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolArgsHandler checks that a tool was called with specific args.
+// Params: tool_name string, expected_args map[string]any.
+type ToolArgsHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolArgsHandler) Type() string { return "tool_args" }
+
+// Eval checks that the specified tool was called with matching args.
+func (h *ToolArgsHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	toolName, _ := params["tool_name"].(string)
+	if toolName == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no tool_name specified",
+		}, nil
+	}
+
+	expectedArgs, _ := params["expected_args"].(map[string]any)
+	if len(expectedArgs) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no expected_args specified",
+		}, nil
+	}
+
+	matching := findMatchingCalls(evalCtx.ToolCalls, toolName)
+	if len(matching) == 0 {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"tool %q was not called", toolName,
+			),
+		}, nil
+	}
+
+	return h.checkArgs(matching, expectedArgs, toolName)
+}
+
+// checkArgs verifies at least one matching call has the expected
+// arguments.
+func (h *ToolArgsHandler) checkArgs(
+	matching []evals.ToolCallRecord,
+	expectedArgs map[string]any,
+	toolName string,
+) (result *evals.EvalResult, err error) {
+	for i := range matching {
+		if argsMatch(matching[i].Arguments, expectedArgs) {
+			return &evals.EvalResult{
+				Type:   h.Type(),
+				Passed: true,
+				Explanation: fmt.Sprintf(
+					"tool %q called with expected args",
+					toolName,
+				),
+			}, nil
+		}
+	}
+
+	violations := buildArgViolations(
+		matching[len(matching)-1], expectedArgs,
+	)
+
+	return &evals.EvalResult{
+		Type:   h.Type(),
+		Passed: false,
+		Explanation: fmt.Sprintf(
+			"tool %q args mismatch: %s",
+			toolName, strings.Join(violations, "; "),
+		),
+	}, nil
+}
+
+// buildArgViolations reports mismatches from a single tool call
+// against expected args.
+func buildArgViolations(
+	call evals.ToolCallRecord, expectedArgs map[string]any,
+) []string {
+	var violations []string
+	for k, expected := range expectedArgs {
+		actual, exists := call.Arguments[k]
+		if !exists {
+			violations = append(violations, fmt.Sprintf(
+				"missing arg %q", k,
+			))
+		} else if asString(actual) != asString(expected) {
+			violations = append(violations, fmt.Sprintf(
+				"arg %q: got %v, want %v",
+				k, actual, expected,
+			))
+		}
+	}
+	return violations
+}
+
+// findMatchingCalls returns tool call records matching the given
+// tool name.
+func findMatchingCalls(
+	toolCalls []evals.ToolCallRecord, toolName string,
+) []evals.ToolCallRecord {
+	var matching []evals.ToolCallRecord
+	for i := range toolCalls {
+		if toolCalls[i].ToolName == toolName {
+			matching = append(matching, toolCalls[i])
+		}
+	}
+	return matching
+}
+
+// argsMatch checks if actual arguments contain all expected args
+// with matching string representations.
+func argsMatch(
+	actual map[string]any, expected map[string]any,
+) bool {
+	for k, expectedVal := range expected {
+		actualVal, exists := actual[k]
+		if !exists {
+			return false
+		}
+		if asString(actualVal) != asString(expectedVal) {
+			return false
+		}
+	}
+	return true
+}

--- a/runtime/evals/handlers/tool_args_excluded_session.go
+++ b/runtime/evals/handlers/tool_args_excluded_session.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolArgsExcludedSessionHandler checks that a tool was NOT called
+// with specific argument values across the session.
+// Params: tool_name string, excluded_args map[string]any.
+type ToolArgsExcludedSessionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolArgsExcludedSessionHandler) Type() string {
+	return "tool_args_excluded_session"
+}
+
+// Eval ensures the tool was never called with excluded args.
+func (h *ToolArgsExcludedSessionHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (_ *evals.EvalResult, _ error) {
+	toolName, _ := params["tool_name"].(string)
+	excludedArgs, _ := params["excluded_args"].(map[string]any)
+
+	if toolName == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "tool_name parameter is required",
+		}, nil
+	}
+
+	if len(excludedArgs) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no excluded_args to check",
+		}, nil
+	}
+
+	var violations []string
+	for i := range evalCtx.ToolCalls {
+		tc := &evalCtx.ToolCalls[i]
+		if tc.ToolName != toolName {
+			continue
+		}
+		violations = append(
+			violations,
+			checkExcludedArgs(tc, excludedArgs)...,
+		)
+	}
+
+	if len(violations) > 0 {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"excluded args found: %s",
+				strings.Join(violations, "; "),
+			),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: "no excluded args detected",
+	}, nil
+}
+
+// checkExcludedArgs returns descriptions for each excluded arg match
+// found in a single tool call.
+func checkExcludedArgs(
+	tc *evals.ToolCallRecord,
+	excluded map[string]any,
+) []string {
+	var results []string
+	for k, ev := range excluded {
+		av, ok := tc.Arguments[k]
+		if !ok {
+			continue
+		}
+		if asString(av) == asString(ev) {
+			results = append(results, fmt.Sprintf(
+				"turn %d: %s=%v", tc.TurnIndex, k, av,
+			))
+		}
+	}
+	return results
+}

--- a/runtime/evals/handlers/tool_args_session.go
+++ b/runtime/evals/handlers/tool_args_session.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolArgsSessionHandler checks that a tool was called with specific
+// arguments across the session.
+// Params: tool_name string, expected_args map[string]any.
+type ToolArgsSessionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolArgsSessionHandler) Type() string {
+	return "tool_args_session"
+}
+
+// Eval checks tool calls for expected arguments.
+func (h *ToolArgsSessionHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (_ *evals.EvalResult, _ error) {
+	toolName, _ := params["tool_name"].(string)
+	expectedArgs, _ := params["expected_args"].(map[string]any)
+
+	if toolName == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "tool_name parameter is required",
+		}, nil
+	}
+
+	if len(expectedArgs) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no expected_args to check",
+		}, nil
+	}
+
+	matched := false
+	var mismatches []string
+	for i := range evalCtx.ToolCalls {
+		tc := &evalCtx.ToolCalls[i]
+		if tc.ToolName != toolName {
+			continue
+		}
+		if argsMatch(tc.Arguments, expectedArgs) {
+			matched = true
+			break
+		}
+		mismatches = append(mismatches, fmt.Sprintf(
+			"turn %d: args=%v", tc.TurnIndex, tc.Arguments,
+		))
+	}
+
+	if matched {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: true,
+			Explanation: fmt.Sprintf(
+				"%s was called with expected args", toolName,
+			),
+		}, nil
+	}
+
+	if len(mismatches) == 0 {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"tool %q was never called", toolName,
+			),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:   h.Type(),
+		Passed: false,
+		Explanation: fmt.Sprintf(
+			"%s called but args did not match: %s",
+			toolName, strings.Join(mismatches, "; "),
+		),
+	}, nil
+}

--- a/runtime/evals/handlers/tools_called.go
+++ b/runtime/evals/handlers/tools_called.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolsCalledHandler checks if specific tools were called.
+// Params: tool_names []string, optional min_calls int.
+type ToolsCalledHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolsCalledHandler) Type() string { return "tools_called" }
+
+// Eval checks that all expected tools were called.
+func (h *ToolsCalledHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	toolNames := extractStringSlice(params, "tool_names")
+	if len(toolNames) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no tool_names specified",
+		}, nil
+	}
+
+	minCalls := extractInt(params, "min_calls", 1)
+	callCounts := buildCallCounts(evalCtx.ToolCalls)
+
+	return h.checkToolCalls(toolNames, callCounts, minCalls)
+}
+
+// checkToolCalls verifies each tool was called the minimum number
+// of times.
+func (h *ToolsCalledHandler) checkToolCalls(
+	toolNames []string,
+	callCounts map[string]int,
+	minCalls int,
+) (result *evals.EvalResult, err error) {
+	var missing []string
+	for _, name := range toolNames {
+		if callCounts[name] < minCalls {
+			missing = append(missing, fmt.Sprintf(
+				"%s (called %d, need %d)",
+				name, callCounts[name], minCalls,
+			))
+		}
+	}
+
+	passed := len(missing) == 0
+	explanation := "all expected tools were called"
+	if !passed {
+		explanation = fmt.Sprintf(
+			"tools not called enough: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Explanation: explanation,
+	}, nil
+}
+
+// buildCallCounts counts how many times each tool was called.
+func buildCallCounts(
+	toolCalls []evals.ToolCallRecord,
+) map[string]int {
+	counts := make(map[string]int)
+	for i := range toolCalls {
+		counts[toolCalls[i].ToolName]++
+	}
+	return counts
+}
+
+// extractInt extracts an int from params with a default value.
+func extractInt(
+	params map[string]any, key string, defaultVal int,
+) int {
+	v, ok := params[key]
+	if !ok {
+		return defaultVal
+	}
+	switch val := v.(type) {
+	case int:
+		return val
+	case float64:
+		return int(val)
+	case int64:
+		return int(val)
+	default:
+		return defaultVal
+	}
+}

--- a/runtime/evals/handlers/tools_called_session.go
+++ b/runtime/evals/handlers/tools_called_session.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolsCalledSessionHandler checks that specific tools were called
+// across the full session.
+// Params: tool_names []string, min_calls int (optional, default 1).
+type ToolsCalledSessionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolsCalledSessionHandler) Type() string {
+	return "tools_called_session"
+}
+
+// Eval checks that all required tools were called at least
+// min_calls times.
+func (h *ToolsCalledSessionHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (_ *evals.EvalResult, _ error) {
+	required := extractStringSlice(params, "tool_names")
+	minCalls := 1
+	if m, ok := params["min_calls"].(int); ok && m > 0 {
+		minCalls = m
+	}
+	if mf, ok := params["min_calls"].(float64); ok && mf > 0 {
+		minCalls = int(mf)
+	}
+
+	counts := make(map[string]int)
+	for i := range evalCtx.ToolCalls {
+		counts[evalCtx.ToolCalls[i].ToolName]++
+	}
+
+	var missing []string
+	for _, name := range required {
+		if counts[name] < minCalls {
+			missing = append(missing, fmt.Sprintf(
+				"%s (got %d, need %d)",
+				name, counts[name], minCalls,
+			))
+		}
+	}
+
+	if len(missing) > 0 {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"missing required tools: %s",
+				strings.Join(missing, "; "),
+			),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: "all required tools were called",
+	}, nil
+}

--- a/runtime/evals/handlers/tools_not_called.go
+++ b/runtime/evals/handlers/tools_not_called.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolsNotCalledHandler checks that specific tools were NOT called.
+// Params: tool_names []string.
+type ToolsNotCalledHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolsNotCalledHandler) Type() string {
+	return "tools_not_called"
+}
+
+// Eval checks that none of the forbidden tools were called.
+func (h *ToolsNotCalledHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	toolNames := extractStringSlice(params, "tool_names")
+	if len(toolNames) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no tool_names specified",
+		}, nil
+	}
+
+	forbidden := make(map[string]bool, len(toolNames))
+	for _, name := range toolNames {
+		forbidden[name] = true
+	}
+
+	called := findForbiddenCalls(evalCtx.ToolCalls, forbidden)
+
+	passed := len(called) == 0
+	explanation := "none of the forbidden tools were called"
+	if !passed {
+		explanation = fmt.Sprintf(
+			"forbidden tools were called: %s",
+			strings.Join(called, ", "),
+		)
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Explanation: explanation,
+	}, nil
+}
+
+// findForbiddenCalls returns unique names of forbidden tools that
+// were called.
+func findForbiddenCalls(
+	toolCalls []evals.ToolCallRecord,
+	forbidden map[string]bool,
+) []string {
+	seen := make(map[string]bool)
+	var called []string
+	for i := range toolCalls {
+		name := toolCalls[i].ToolName
+		if forbidden[name] && !seen[name] {
+			called = append(called, name)
+			seen[name] = true
+		}
+	}
+	return called
+}

--- a/runtime/evals/handlers/tools_not_called_session.go
+++ b/runtime/evals/handlers/tools_not_called_session.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolsNotCalledSessionHandler checks that specific tools were NOT
+// called anywhere in the session.
+// Params: tool_names []string.
+type ToolsNotCalledSessionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolsNotCalledSessionHandler) Type() string {
+	return "tools_not_called_session"
+}
+
+// Eval ensures forbidden tools were never called across the session.
+func (h *ToolsNotCalledSessionHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (_ *evals.EvalResult, _ error) {
+	forbidden := extractStringSlice(params, "tool_names")
+	forbiddenSet := make(map[string]struct{}, len(forbidden))
+	for _, n := range forbidden {
+		forbiddenSet[n] = struct{}{}
+	}
+
+	var found []string
+	for i := range evalCtx.ToolCalls {
+		tc := &evalCtx.ToolCalls[i]
+		if _, bad := forbiddenSet[tc.ToolName]; bad {
+			found = append(found, fmt.Sprintf(
+				"%s at turn %d", tc.ToolName, tc.TurnIndex,
+			))
+		}
+	}
+
+	if len(found) > 0 {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"forbidden tools were called: %s",
+				strings.Join(found, "; "),
+			),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: "no forbidden tools called",
+	}, nil
+}

--- a/runtime/evals/registry.go
+++ b/runtime/evals/registry.go
@@ -37,11 +37,26 @@ func NewEmptyEvalTypeRegistry() *EvalTypeRegistry {
 
 // NewEvalTypeRegistry creates a registry pre-populated with all
 // built-in eval handlers. Call this in production code.
+// Handlers self-register via RegisterDefaults in the handlers package;
+// import _ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+// or call handlers.RegisterDefaults(r) explicitly.
 func NewEvalTypeRegistry() *EvalTypeRegistry {
 	r := NewEmptyEvalTypeRegistry()
-	// Built-in handlers will be registered here as they are implemented
-	// in subsequent issues (#303, #304, #305).
+	for _, h := range defaultHandlers {
+		r.Register(h)
+	}
 	return r
+}
+
+// defaultHandlers holds handlers registered via RegisterDefault.
+// This avoids a circular import between evals and handlers.
+var defaultHandlers []EvalTypeHandler
+
+// RegisterDefault adds a handler to the default set used by
+// NewEvalTypeRegistry. Call this from handler init() functions
+// or from handlers.RegisterDefaults().
+func RegisterDefault(h EvalTypeHandler) {
+	defaultHandlers = append(defaultHandlers, h)
 }
 
 // Register adds a handler to the registry. If a handler with the same


### PR DESCRIPTION
## Summary
- Add nine turn-level deterministic eval handlers migrated from Arena assertions: `contains`, `regex`, `json_valid`, `json_schema`, `tools_called`, `tools_not_called`, `tool_args`, `latency_budget`, `cosine_similarity`
- Add six session-scope eval handlers migrated from Arena's conversation-level assertions: `content_excludes`, `contains_any`, `tools_called_session`, `tools_not_called_session`, `tool_args_session`, `tool_args_excluded_session`
- Each handler implements `EvalTypeHandler`, and uses `init()`-based self-registration via `evals.RegisterDefault()` to avoid circular imports
- Includes helpers for string extraction, cosine similarity, argument matching, and float64 conversion

## Test plan
- [x] All handler tests pass with `-race -count=1`
- [x] `go vet` clean
- [x] Registration test verifies all 15 handlers are registered via `NewEvalTypeRegistry()`
- [ ] Verify handlers work end-to-end with Arena eval runner (future integration)

Closes #303
Closes #305