### PR TITLE
feat(evals): migrate LLM judge to runtime with JudgeProvider

### DIFF
--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -767,6 +767,8 @@ func TestRegisterInit(t *testing.T) {
 		"json_schema",
 		"json_valid",
 		"latency_budget",
+		"llm_judge",
+		"llm_judge_session",
 		"regex",
 		"tool_args",
 		"tool_args_excluded_session",

--- a/runtime/evals/handlers/llm_judge.go
+++ b/runtime/evals/handlers/llm_judge.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// LLMJudgeHandler evaluates a single assistant turn using an
+// LLM judge. The JudgeProvider must be supplied in
+// evalCtx.Metadata["judge_provider"].
+//
+// Params:
+//   - criteria (string, required): what to evaluate
+//   - rubric (string, optional): detailed scoring guidance
+//   - model (string, optional): model override for the judge
+//   - system_prompt (string, optional): override default system prompt
+//   - min_score (float64, optional): minimum score to pass
+type LLMJudgeHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *LLMJudgeHandler) Type() string { return "llm_judge" }
+
+// Eval runs the LLM judge on the current assistant output.
+func (h *LLMJudgeHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	provider, extractErr := extractJudgeProvider(evalCtx)
+	if extractErr != nil {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: extractErr.Error(),
+		}, nil
+	}
+
+	opts := buildJudgeOpts(evalCtx.CurrentOutput, params)
+
+	judgeResult, judgeErr := provider.Judge(ctx, opts)
+	if judgeErr != nil {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("judge error: %v", judgeErr),
+		}, nil
+	}
+
+	return buildEvalResult(h.Type(), judgeResult, params), nil
+}
+
+// extractJudgeProvider retrieves the JudgeProvider from eval
+// context metadata.
+func extractJudgeProvider(
+	evalCtx *evals.EvalContext,
+) (JudgeProvider, error) {
+	if evalCtx.Metadata == nil {
+		return nil, fmt.Errorf(
+			"judge_provider not found in metadata",
+		)
+	}
+
+	raw, ok := evalCtx.Metadata["judge_provider"]
+	if !ok {
+		return nil, fmt.Errorf(
+			"judge_provider not found in metadata",
+		)
+	}
+
+	provider, ok := raw.(JudgeProvider)
+	if !ok {
+		return nil, fmt.Errorf(
+			"judge_provider has wrong type: %T",
+			raw,
+		)
+	}
+
+	return provider, nil
+}
+
+// buildJudgeOpts constructs JudgeOpts from content and params.
+func buildJudgeOpts(
+	content string, params map[string]any,
+) JudgeOpts {
+	opts := JudgeOpts{Content: content}
+
+	if v, ok := params["criteria"].(string); ok {
+		opts.Criteria = v
+	}
+	if v, ok := params["rubric"].(string); ok {
+		opts.Rubric = v
+	}
+	if v, ok := params["model"].(string); ok {
+		opts.Model = v
+	}
+	if v, ok := params["system_prompt"].(string); ok {
+		opts.SystemPrompt = v
+	}
+	if v, ok := params["min_score"].(float64); ok {
+		opts.MinScore = &v
+	}
+
+	return opts
+}
+
+// buildEvalResult converts a JudgeResult into an EvalResult,
+// applying the min_score threshold when provided.
+func buildEvalResult(
+	evalType string,
+	jr *JudgeResult,
+	params map[string]any,
+) *evals.EvalResult {
+	score := jr.Score
+	passed := jr.Passed
+
+	if minScore, ok := params["min_score"].(float64); ok {
+		passed = score >= minScore
+	}
+
+	return &evals.EvalResult{
+		Type:        evalType,
+		Passed:      passed,
+		Score:       &score,
+		Explanation: jr.Reasoning,
+	}
+}

--- a/runtime/evals/handlers/llm_judge_session.go
+++ b/runtime/evals/handlers/llm_judge_session.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// LLMJudgeSessionHandler evaluates an entire conversation using
+// an LLM judge. It concatenates all assistant messages into a
+// single content string for evaluation.
+//
+// The JudgeProvider must be supplied in
+// evalCtx.Metadata["judge_provider"].
+//
+// Params:
+//   - criteria (string, required): what to evaluate
+//   - rubric (string, optional): detailed scoring guidance
+//   - model (string, optional): model override for the judge
+//   - system_prompt (string, optional): override default system prompt
+//   - min_score (float64, optional): minimum score to pass
+type LLMJudgeSessionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *LLMJudgeSessionHandler) Type() string {
+	return "llm_judge_session"
+}
+
+// Eval runs the LLM judge on all assistant messages in the session.
+func (h *LLMJudgeSessionHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (result *evals.EvalResult, err error) {
+	provider, extractErr := extractJudgeProvider(evalCtx)
+	if extractErr != nil {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: extractErr.Error(),
+		}, nil
+	}
+
+	content := collectAssistantContent(evalCtx)
+	opts := buildJudgeOpts(content, params)
+
+	judgeResult, judgeErr := provider.Judge(ctx, opts)
+	if judgeErr != nil {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("judge error: %v", judgeErr),
+		}, nil
+	}
+
+	return buildEvalResult(h.Type(), judgeResult, params), nil
+}
+
+// collectAssistantContent concatenates all assistant message
+// content from the eval context, separated by newlines.
+func collectAssistantContent(
+	evalCtx *evals.EvalContext,
+) string {
+	var parts []string
+	for i := range evalCtx.Messages {
+		msg := &evalCtx.Messages[i]
+		if strings.EqualFold(msg.Role, roleAssistant) {
+			parts = append(parts, msg.GetContent())
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/runtime/evals/handlers/llm_judge_test.go
+++ b/runtime/evals/handlers/llm_judge_test.go
@@ -1,0 +1,454 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// llmJudgeMock is a test double for JudgeProvider that captures
+// the opts passed to Judge.
+type llmJudgeMock struct {
+	result *JudgeResult
+	err    error
+	opts   JudgeOpts // captures last call
+}
+
+func (m *llmJudgeMock) Judge(
+	_ context.Context, opts JudgeOpts,
+) (*JudgeResult, error) {
+	m.opts = opts
+	return m.result, m.err
+}
+
+func TestLLMJudgeHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &LLMJudgeHandler{}
+	if h.Type() != "llm_judge" {
+		t.Errorf("got %q, want %q", h.Type(), "llm_judge")
+	}
+}
+
+func TestLLMJudgeHandler_PassingEval(t *testing.T) {
+	t.Parallel()
+	mock := &llmJudgeMock{
+		result: &JudgeResult{
+			Passed:    true,
+			Score:     0.9,
+			Reasoning: "good response",
+		},
+	}
+
+	h := &LLMJudgeHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "test output",
+		Metadata: map[string]any{
+			"judge_provider": mock,
+		},
+	}
+	params := map[string]any{
+		"criteria": "Is it helpful?",
+		"rubric":   "Score 1.0 for helpful",
+		"model":    "gpt-4",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected passed=true")
+	}
+	if result.Score == nil || *result.Score != 0.9 {
+		t.Errorf("expected score 0.9, got %v", result.Score)
+	}
+	if result.Explanation != "good response" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+
+	// Verify opts were forwarded
+	if mock.opts.Content != "test output" {
+		t.Errorf("content not forwarded: %s", mock.opts.Content)
+	}
+	if mock.opts.Criteria != "Is it helpful?" {
+		t.Errorf("criteria not forwarded: %s", mock.opts.Criteria)
+	}
+	if mock.opts.Rubric != "Score 1.0 for helpful" {
+		t.Errorf("rubric not forwarded: %s", mock.opts.Rubric)
+	}
+	if mock.opts.Model != "gpt-4" {
+		t.Errorf("model not forwarded: %s", mock.opts.Model)
+	}
+}
+
+func TestLLMJudgeHandler_MissingProvider(t *testing.T) {
+	t.Parallel()
+	h := &LLMJudgeHandler{}
+
+	// nil metadata
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	result, err := h.Eval(
+		context.Background(), evalCtx, map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected passed=false for missing provider")
+	}
+	if result.Explanation != "judge_provider not found in metadata" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+
+	// metadata without judge_provider
+	evalCtx.Metadata = map[string]any{"other": "value"}
+	result, err = h.Eval(
+		context.Background(), evalCtx, map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected passed=false for missing key")
+	}
+}
+
+func TestLLMJudgeHandler_WrongProviderType(t *testing.T) {
+	t.Parallel()
+	h := &LLMJudgeHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "test",
+		Metadata: map[string]any{
+			"judge_provider": "not-a-provider",
+		},
+	}
+
+	result, err := h.Eval(
+		context.Background(), evalCtx, map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected passed=false for wrong type")
+	}
+	if result.Explanation != "judge_provider has wrong type: string" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestLLMJudgeHandler_MinScoreThreshold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		score    float64
+		minScore float64
+		wantPass bool
+	}{
+		{"above threshold", 0.8, 0.7, true},
+		{"equal threshold", 0.7, 0.7, true},
+		{"below threshold", 0.6, 0.7, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &llmJudgeMock{
+				result: &JudgeResult{
+					Passed:    true,
+					Score:     tt.score,
+					Reasoning: "test",
+				},
+			}
+			h := &LLMJudgeHandler{}
+			evalCtx := &evals.EvalContext{
+				CurrentOutput: "output",
+				Metadata: map[string]any{
+					"judge_provider": mock,
+				},
+			}
+			params := map[string]any{
+				"criteria":  "test",
+				"min_score": tt.minScore,
+			}
+
+			result, err := h.Eval(
+				context.Background(), evalCtx, params,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Passed != tt.wantPass {
+				t.Errorf(
+					"passed=%v, want %v",
+					result.Passed, tt.wantPass,
+				)
+			}
+		})
+	}
+}
+
+func TestLLMJudgeHandler_JudgeError(t *testing.T) {
+	t.Parallel()
+	mock := &llmJudgeMock{
+		err: errors.New("LLM unavailable"),
+	}
+	h := &LLMJudgeHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "test",
+		Metadata: map[string]any{
+			"judge_provider": mock,
+		},
+	}
+
+	result, err := h.Eval(
+		context.Background(), evalCtx, map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected passed=false on judge error")
+	}
+	if result.Explanation != "judge error: LLM unavailable" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestLLMJudgeHandler_SystemPromptForwarded(t *testing.T) {
+	t.Parallel()
+	mock := &llmJudgeMock{
+		result: &JudgeResult{Passed: true, Score: 1.0},
+	}
+	h := &LLMJudgeHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "test",
+		Metadata: map[string]any{
+			"judge_provider": mock,
+		},
+	}
+	params := map[string]any{
+		"criteria":      "test",
+		"system_prompt": "You are a strict judge.",
+	}
+
+	_, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.opts.SystemPrompt != "You are a strict judge." {
+		t.Errorf(
+			"system_prompt not forwarded: %s",
+			mock.opts.SystemPrompt,
+		)
+	}
+}
+
+// --- Session handler tests ---
+
+func TestLLMJudgeSessionHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &LLMJudgeSessionHandler{}
+	if h.Type() != "llm_judge_session" {
+		t.Errorf(
+			"got %q, want %q", h.Type(), "llm_judge_session",
+		)
+	}
+}
+
+func TestLLMJudgeSessionHandler_ConcatenatesAssistant(t *testing.T) {
+	t.Parallel()
+	mock := &llmJudgeMock{
+		result: &JudgeResult{
+			Passed:    true,
+			Score:     0.85,
+			Reasoning: "coherent conversation",
+		},
+	}
+
+	h := &LLMJudgeSessionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "Hello"},
+			{Role: "assistant", Content: "Hi there!"},
+			{Role: "user", Content: "How are you?"},
+			{Role: "assistant", Content: "I'm doing great."},
+			{Role: "user", Content: "Bye"},
+			{Role: "assistant", Content: "Goodbye!"},
+		},
+		Metadata: map[string]any{
+			"judge_provider": mock,
+		},
+	}
+	params := map[string]any{
+		"criteria": "Is the conversation coherent?",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected passed=true")
+	}
+	if result.Type != "llm_judge_session" {
+		t.Errorf("unexpected type: %s", result.Type)
+	}
+
+	// Verify content is concatenated assistant messages
+	want := "Hi there!\nI'm doing great.\nGoodbye!"
+	if mock.opts.Content != want {
+		t.Errorf(
+			"content mismatch:\ngot:  %q\nwant: %q",
+			mock.opts.Content, want,
+		)
+	}
+}
+
+func TestLLMJudgeSessionHandler_MissingProvider(t *testing.T) {
+	t.Parallel()
+	h := &LLMJudgeSessionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "test"},
+		},
+	}
+
+	result, err := h.Eval(
+		context.Background(), evalCtx, map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected passed=false")
+	}
+}
+
+func TestLLMJudgeSessionHandler_JudgeError(t *testing.T) {
+	t.Parallel()
+	mock := &llmJudgeMock{
+		err: errors.New("timeout"),
+	}
+	h := &LLMJudgeSessionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "test"},
+		},
+		Metadata: map[string]any{
+			"judge_provider": mock,
+		},
+	}
+
+	result, err := h.Eval(
+		context.Background(), evalCtx, map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected passed=false on judge error")
+	}
+	if result.Explanation != "judge error: timeout" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestLLMJudgeSessionHandler_MinScore(t *testing.T) {
+	t.Parallel()
+	mock := &llmJudgeMock{
+		result: &JudgeResult{
+			Passed: true,
+			Score:  0.5,
+		},
+	}
+	h := &LLMJudgeSessionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "short answer"},
+		},
+		Metadata: map[string]any{
+			"judge_provider": mock,
+		},
+	}
+	params := map[string]any{
+		"criteria":  "quality",
+		"min_score": 0.7,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected passed=false (0.5 < 0.7)")
+	}
+}
+
+func TestLLMJudgeSessionHandler_NoAssistantMessages(t *testing.T) {
+	t.Parallel()
+	mock := &llmJudgeMock{
+		result: &JudgeResult{
+			Passed:    false,
+			Score:     0.0,
+			Reasoning: "no content to evaluate",
+		},
+	}
+	h := &LLMJudgeSessionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "Hello"},
+		},
+		Metadata: map[string]any{
+			"judge_provider": mock,
+		},
+	}
+
+	result, err := h.Eval(
+		context.Background(), evalCtx, map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Empty content is sent to the judge
+	if mock.opts.Content != "" {
+		t.Errorf(
+			"expected empty content, got: %q",
+			mock.opts.Content,
+		)
+	}
+	if result.Passed {
+		t.Error("expected passed=false")
+	}
+}
+
+func TestLLMJudgeSessionHandler_WrongProviderType(t *testing.T) {
+	t.Parallel()
+	h := &LLMJudgeSessionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "test"},
+		},
+		Metadata: map[string]any{
+			"judge_provider": 42,
+		},
+	}
+
+	result, err := h.Eval(
+		context.Background(), evalCtx, map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected passed=false for wrong type")
+	}
+	if result.Explanation != "judge_provider has wrong type: int" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -22,4 +22,8 @@ func init() {
 	evals.RegisterDefault(&ToolsNotCalledSessionHandler{})
 	evals.RegisterDefault(&ToolArgsSessionHandler{})
 	evals.RegisterDefault(&ToolArgsExcludedSessionHandler{})
+
+	// LLM judge handlers
+	evals.RegisterDefault(&LLMJudgeHandler{})
+	evals.RegisterDefault(&LLMJudgeSessionHandler{})
 }


### PR DESCRIPTION
## Summary
- Adds `LLMJudgeHandler` (type `"llm_judge"`) for turn-level LLM judge evaluations using the `JudgeProvider` interface from eval context metadata
- Adds `LLMJudgeSessionHandler` (type `"llm_judge_session"`) for session-level evaluation that concatenates all assistant messages
- Both handlers support `criteria`, `rubric`, `model`, `system_prompt`, and `min_score` threshold parameters
- Graceful error handling for missing/wrong-type `judge_provider` and judge invocation errors
- Registers both handlers via `init()` in `register.go`

## Test plan
- [x] Turn-level handler passes opts to JudgeProvider correctly
- [x] Session handler concatenates all assistant messages into content
- [x] Missing `judge_provider` in metadata returns failed result (not error)
- [x] Wrong type for `judge_provider` returns failed result with type info
- [x] `min_score` threshold: pass when `score >= min_score`, fail when below
- [x] Judge errors propagated as failed results with explanation
- [x] `system_prompt` forwarded to JudgeProvider
- [x] No assistant messages produces empty content for session handler
- [x] `TestRegisterInit` updated to expect 17 handler types
- [x] All tests pass with `-race -count=1`
- [x] `go vet` clean

Closes #304