### PR TITLE
feat(evals): add trigger system and EvalRunner (#306)

### DIFF
--- a/runtime/evals/runner.go
+++ b/runtime/evals/runner.go
@@ -1,0 +1,190 @@
+package evals
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// DefaultEvalTimeout is the per-eval execution timeout.
+const DefaultEvalTimeout = 30 * time.Second
+
+// EvalRunner executes evals in-process. It is the leaf execution unit
+// used by all dispatch modes (in-proc, event-driven, worker).
+type EvalRunner struct {
+	registry *EvalTypeRegistry
+	timeout  time.Duration
+}
+
+// RunnerOption configures an EvalRunner.
+type RunnerOption func(*EvalRunner)
+
+// WithTimeout sets the per-eval execution timeout.
+func WithTimeout(d time.Duration) RunnerOption {
+	return func(r *EvalRunner) { r.timeout = d }
+}
+
+// NewEvalRunner creates an EvalRunner with the given registry and options.
+func NewEvalRunner(
+	registry *EvalTypeRegistry, opts ...RunnerOption,
+) *EvalRunner {
+	r := &EvalRunner{
+		registry: registry,
+		timeout:  DefaultEvalTimeout,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// RunTurnEvals runs turn-level evals (every_turn and sample_turns triggers).
+// It filters by enabled state and trigger, then executes matching handlers.
+func (r *EvalRunner) RunTurnEvals(
+	ctx context.Context,
+	defs []EvalDef,
+	evalCtx *EvalContext,
+) []EvalResult {
+	trigCtx := &TriggerContext{
+		SessionID:         evalCtx.SessionID,
+		TurnIndex:         evalCtx.TurnIndex,
+		IsSessionComplete: false,
+	}
+	return r.runEvals(ctx, defs, evalCtx, trigCtx, turnTriggers)
+}
+
+// RunSessionEvals runs session-level evals (on_session_complete and
+// sample_sessions triggers). Call this when a session ends.
+func (r *EvalRunner) RunSessionEvals(
+	ctx context.Context,
+	defs []EvalDef,
+	evalCtx *EvalContext,
+) []EvalResult {
+	trigCtx := &TriggerContext{
+		SessionID:         evalCtx.SessionID,
+		TurnIndex:         evalCtx.TurnIndex,
+		IsSessionComplete: true,
+	}
+	return r.runEvals(ctx, defs, evalCtx, trigCtx, sessionTriggers)
+}
+
+// turnTriggers is the set of triggers that fire for turn-level evals.
+var turnTriggers = map[EvalTrigger]bool{
+	TriggerEveryTurn:   true,
+	TriggerSampleTurns: true,
+}
+
+// sessionTriggers is the set of triggers that fire for session-level evals.
+var sessionTriggers = map[EvalTrigger]bool{
+	TriggerOnSessionComplete: true,
+	TriggerSampleSessions:    true,
+}
+
+// runEvals is the shared implementation for both turn and session evals.
+func (r *EvalRunner) runEvals(
+	ctx context.Context,
+	defs []EvalDef,
+	evalCtx *EvalContext,
+	trigCtx *TriggerContext,
+	allowedTriggers map[EvalTrigger]bool,
+) []EvalResult {
+	var results []EvalResult
+	for i := range defs {
+		if ctx.Err() != nil {
+			break
+		}
+		result := r.runOne(ctx, &defs[i], evalCtx, trigCtx, allowedTriggers)
+		if result != nil {
+			results = append(results, *result)
+		}
+	}
+	return results
+}
+
+// runOne executes a single eval with filtering, timeout, and panic recovery.
+func (r *EvalRunner) runOne(
+	ctx context.Context,
+	def *EvalDef,
+	evalCtx *EvalContext,
+	trigCtx *TriggerContext,
+	allowedTriggers map[EvalTrigger]bool,
+) *EvalResult {
+	// Skip disabled evals
+	if !def.IsEnabled() {
+		return nil
+	}
+
+	// Skip evals whose trigger doesn't match this execution mode
+	if !allowedTriggers[def.Trigger] {
+		return nil
+	}
+
+	// Check sampling
+	if !ShouldRun(def.Trigger, def.GetSamplePercentage(), trigCtx) {
+		return nil
+	}
+
+	// Look up handler
+	handler, err := r.registry.Get(def.Type)
+	if err != nil {
+		return &EvalResult{
+			EvalID: def.ID,
+			Type:   def.Type,
+			Error:  fmt.Sprintf("handler not found: %v", err),
+		}
+	}
+
+	// Execute with timeout and panic recovery
+	return r.executeHandler(ctx, handler, def, evalCtx)
+}
+
+// executeHandler runs a handler with timeout and panic recovery.
+func (r *EvalRunner) executeHandler(
+	ctx context.Context,
+	handler EvalTypeHandler,
+	def *EvalDef,
+	evalCtx *EvalContext,
+) *EvalResult {
+	evalCtx2, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	start := time.Now()
+
+	// Panic recovery
+	var result *EvalResult
+	var evalErr error
+	func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				evalErr = fmt.Errorf("panic in eval %q: %v", def.ID, rec)
+			}
+		}()
+		result, evalErr = handler.Eval(evalCtx2, evalCtx, def.Params)
+	}()
+
+	durationMs := time.Since(start).Milliseconds()
+
+	if evalErr != nil {
+		return &EvalResult{
+			EvalID:     def.ID,
+			Type:       def.Type,
+			Error:      evalErr.Error(),
+			DurationMs: durationMs,
+		}
+	}
+
+	if result == nil {
+		return &EvalResult{
+			EvalID:     def.ID,
+			Type:       def.Type,
+			Error:      "handler returned nil result",
+			DurationMs: durationMs,
+		}
+	}
+
+	// Fill in metadata from the def
+	result.EvalID = def.ID
+	result.Type = def.Type
+	result.DurationMs = durationMs
+	return result
+}

--- a/runtime/evals/runner_test.go
+++ b/runtime/evals/runner_test.go
@@ -1,0 +1,406 @@
+package evals
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// panicHandler panics when Eval is called.
+type panicHandler struct{}
+
+func (p *panicHandler) Type() string { return "panic" }
+
+func (p *panicHandler) Eval(
+	_ context.Context, _ *EvalContext, _ map[string]any,
+) (*EvalResult, error) {
+	panic("boom")
+}
+
+// errorHandler returns an error.
+type errorHandler struct{}
+
+func (e *errorHandler) Type() string { return "error" }
+
+func (e *errorHandler) Eval(
+	_ context.Context, _ *EvalContext, _ map[string]any,
+) (*EvalResult, error) {
+	return nil, errors.New("eval failed")
+}
+
+// nilHandler returns nil result with nil error.
+type nilHandler struct{}
+
+func (n *nilHandler) Type() string { return "nil" }
+
+func (n *nilHandler) Eval(
+	_ context.Context, _ *EvalContext, _ map[string]any,
+) (*EvalResult, error) {
+	return nil, nil
+}
+
+// slowHandler blocks until context is cancelled.
+type slowHandler struct{}
+
+func (s *slowHandler) Type() string { return "slow" }
+
+func (s *slowHandler) Eval(
+	ctx context.Context, _ *EvalContext, _ map[string]any,
+) (*EvalResult, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func newTestRegistry(handlers ...EvalTypeHandler) *EvalTypeRegistry {
+	r := NewEmptyEvalTypeRegistry()
+	for _, h := range handlers {
+		r.Register(h)
+	}
+	return r
+}
+
+func TestNewEvalRunner_DefaultTimeout(t *testing.T) {
+	r := NewEvalRunner(newTestRegistry())
+	if r.timeout != DefaultEvalTimeout {
+		t.Errorf("got timeout %v, want %v", r.timeout, DefaultEvalTimeout)
+	}
+}
+
+func TestNewEvalRunner_WithTimeout(t *testing.T) {
+	r := NewEvalRunner(newTestRegistry(), WithTimeout(5*time.Second))
+	if r.timeout != 5*time.Second {
+		t.Errorf("got timeout %v, want %v", r.timeout, 5*time.Second)
+	}
+}
+
+func TestRunTurnEvals_Basic(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1", TurnIndex: 0}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].EvalID != "e1" {
+		t.Errorf("got EvalID %q, want %q", results[0].EvalID, "e1")
+	}
+	if !results[0].Passed {
+		t.Error("expected Passed=true")
+	}
+}
+
+func TestRunTurnEvals_SkipsSessionTrigger(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{
+			ID:      "session-only",
+			Type:    "test",
+			Trigger: TriggerOnSessionComplete,
+		},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 0 {
+		t.Errorf("turn evals should skip session triggers, got %d", len(results))
+	}
+}
+
+func TestRunSessionEvals_Basic(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{
+			ID:      "e1",
+			Type:    "test",
+			Trigger: TriggerOnSessionComplete,
+		},
+	}
+	evalCtx := &EvalContext{SessionID: "s1", TurnIndex: 3}
+
+	results := runner.RunSessionEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].EvalID != "e1" {
+		t.Errorf("got EvalID %q, want %q", results[0].EvalID, "e1")
+	}
+}
+
+func TestRunSessionEvals_SkipsTurnTrigger(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "turn-only", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunSessionEvals(context.Background(), defs, evalCtx)
+	if len(results) != 0 {
+		t.Errorf(
+			"session evals should skip turn triggers, got %d",
+			len(results),
+		)
+	}
+}
+
+func TestRunTurnEvals_SkipsDisabled(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{
+			ID:      "disabled",
+			Type:    "test",
+			Trigger: TriggerEveryTurn,
+			Enabled: boolPtr(false),
+		},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 0 {
+		t.Errorf("disabled evals should be skipped, got %d", len(results))
+	}
+}
+
+func TestRunTurnEvals_UnknownHandler(t *testing.T) {
+	reg := newTestRegistry() // empty registry
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "nonexistent", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Error == "" {
+		t.Error("expected error for unknown handler")
+	}
+}
+
+func TestRunTurnEvals_PanicRecovery(t *testing.T) {
+	reg := newTestRegistry(&panicHandler{})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "panicker", Type: "panic", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Error == "" {
+		t.Error("expected error from panic recovery")
+	}
+}
+
+func TestRunTurnEvals_ErrorHandler(t *testing.T) {
+	reg := newTestRegistry(&errorHandler{})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "error", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Error != "eval failed" {
+		t.Errorf("got error %q, want %q", results[0].Error, "eval failed")
+	}
+}
+
+func TestRunTurnEvals_NilResult(t *testing.T) {
+	reg := newTestRegistry(&nilHandler{})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "nil", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Error == "" {
+		t.Error("expected error for nil result")
+	}
+}
+
+func TestRunTurnEvals_DurationTracked(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].DurationMs < 0 {
+		t.Errorf("duration should be non-negative, got %d", results[0].DurationMs)
+	}
+}
+
+func TestRunTurnEvals_ContextCancelled(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+		{ID: "e2", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(ctx, defs, evalCtx)
+	if len(results) > 1 {
+		t.Errorf(
+			"cancelled context should stop early, got %d results",
+			len(results),
+		)
+	}
+}
+
+func TestRunTurnEvals_MultipleEvals(t *testing.T) {
+	reg := newTestRegistry(
+		&stubHandler{typeName: "test"},
+		&errorHandler{},
+	)
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+		{ID: "e2", Type: "error", Trigger: TriggerEveryTurn},
+		{ID: "e3", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+	if !results[0].Passed {
+		t.Error("e1 should pass")
+	}
+	if results[1].Error == "" {
+		t.Error("e2 should have error")
+	}
+	if !results[2].Passed {
+		t.Error("e3 should pass")
+	}
+}
+
+func TestRunTurnEvals_SampleTurns(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	// With 100% sampling, the eval should always run.
+	defs := []EvalDef{
+		{
+			ID:               "sampled",
+			Type:             "test",
+			Trigger:          TriggerSampleTurns,
+			SamplePercentage: float64Ptr(100),
+		},
+	}
+	evalCtx := &EvalContext{SessionID: "s1", TurnIndex: 0}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("100%% sample should always run, got %d results", len(results))
+	}
+}
+
+func TestRunTurnEvals_Timeout(t *testing.T) {
+	reg := newTestRegistry(&slowHandler{})
+	runner := NewEvalRunner(reg, WithTimeout(50*time.Millisecond))
+
+	defs := []EvalDef{
+		{ID: "slow", Type: "slow", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	start := time.Now()
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	elapsed := time.Since(start)
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Error == "" {
+		t.Error("expected timeout error")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("timeout took too long: %v", elapsed)
+	}
+}
+
+func TestRunSessionEvals_SampleSessions(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{
+			ID:               "sess-sample",
+			Type:             "test",
+			Trigger:          TriggerSampleSessions,
+			SamplePercentage: float64Ptr(100),
+		},
+	}
+	evalCtx := &EvalContext{SessionID: "s1", TurnIndex: 5}
+
+	results := runner.RunSessionEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf(
+			"100%% session sample should run, got %d results",
+			len(results),
+		)
+	}
+}
+
+func TestRunTurnEvals_MetadataFilled(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	defs := []EvalDef{
+		{ID: "meta-test", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.EvalID != "meta-test" {
+		t.Errorf("EvalID = %q, want %q", r.EvalID, "meta-test")
+	}
+	if r.Type != "test" {
+		t.Errorf("Type = %q, want %q", r.Type, "test")
+	}
+}

--- a/runtime/evals/trigger.go
+++ b/runtime/evals/trigger.go
@@ -1,0 +1,57 @@
+package evals
+
+import (
+	"hash/fnv"
+	"strconv"
+)
+
+// TriggerContext provides context for trigger evaluation decisions.
+type TriggerContext struct {
+	// SessionID identifies the current session (used for sampling).
+	SessionID string
+
+	// TurnIndex is the current turn number (used for sampling).
+	TurnIndex int
+
+	// IsSessionComplete indicates whether the session has ended.
+	IsSessionComplete bool
+}
+
+// ShouldRun determines whether an eval should fire given its trigger,
+// sampling percentage, and current context. Sampling is deterministic:
+// the same sessionID+turnIndex always produces the same decision.
+func ShouldRun(
+	trigger EvalTrigger, samplePct float64, ctx *TriggerContext,
+) bool {
+	switch trigger {
+	case TriggerEveryTurn:
+		return true
+	case TriggerOnSessionComplete:
+		return ctx.IsSessionComplete
+	case TriggerSampleTurns:
+		return sampleHit(ctx.SessionID, ctx.TurnIndex, samplePct)
+	case TriggerSampleSessions:
+		// Session sampling uses turnIndex=0 so every turn in the same
+		// session gets the same decision.
+		return sampleHit(ctx.SessionID, 0, samplePct)
+	default:
+		return false
+	}
+}
+
+// sampleModulus is the modulus used for percentage-based sampling.
+// pct (0–100) is multiplied by pctMultiplier so that integer comparison
+// against hash % sampleModulus yields the correct hit rate.
+const (
+	sampleModulus = 10000
+	pctMultiplier = 100
+)
+
+// sampleHit uses FNV-1a hashing for deterministic sampling.
+// Returns true when hash(sessionID+turnIndex) % sampleModulus < pct * pctMultiplier.
+func sampleHit(sessionID string, turnIndex int, pct float64) bool {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(sessionID))
+	_, _ = h.Write([]byte(strconv.Itoa(turnIndex)))
+	return h.Sum64()%sampleModulus < uint64(pct*pctMultiplier)
+}

--- a/runtime/evals/trigger_test.go
+++ b/runtime/evals/trigger_test.go
@@ -1,0 +1,114 @@
+package evals
+
+import "testing"
+
+func TestShouldRun_EveryTurn(t *testing.T) {
+	ctx := &TriggerContext{SessionID: "s1", TurnIndex: 0}
+	if !ShouldRun(TriggerEveryTurn, 0, ctx) {
+		t.Error("every_turn should always return true")
+	}
+}
+
+func TestShouldRun_OnSessionComplete(t *testing.T) {
+	tests := []struct {
+		name      string
+		complete  bool
+		wantRun   bool
+	}{
+		{"session complete", true, true},
+		{"session not complete", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &TriggerContext{
+				SessionID:         "s1",
+				IsSessionComplete: tt.complete,
+			}
+			got := ShouldRun(TriggerOnSessionComplete, 0, ctx)
+			if got != tt.wantRun {
+				t.Errorf("got %v, want %v", got, tt.wantRun)
+			}
+		})
+	}
+}
+
+func TestShouldRun_UnknownTrigger(t *testing.T) {
+	ctx := &TriggerContext{SessionID: "s1"}
+	if ShouldRun("bogus_trigger", 100, ctx) {
+		t.Error("unknown trigger should return false")
+	}
+}
+
+func TestShouldRun_SampleTurns_Deterministic(t *testing.T) {
+	ctx := &TriggerContext{SessionID: "session-abc", TurnIndex: 5}
+	// Same input must always produce the same result.
+	first := ShouldRun(TriggerSampleTurns, 50, ctx)
+	for range 100 {
+		if ShouldRun(TriggerSampleTurns, 50, ctx) != first {
+			t.Fatal("sampling should be deterministic")
+		}
+	}
+}
+
+func TestShouldRun_SampleTurns_DifferentTurns(t *testing.T) {
+	// With 50% sampling over many turns, we expect some true and some false.
+	trueCount := 0
+	for i := range 200 {
+		ctx := &TriggerContext{SessionID: "sess-x", TurnIndex: i}
+		if ShouldRun(TriggerSampleTurns, 50, ctx) {
+			trueCount++
+		}
+	}
+	// Expect roughly 100, but allow wide range to avoid flaky test.
+	if trueCount == 0 || trueCount == 200 {
+		t.Errorf(
+			"expected mixed results with 50%% sampling, got %d/200 true",
+			trueCount,
+		)
+	}
+}
+
+func TestShouldRun_SampleSessions_SameTurnDecision(t *testing.T) {
+	// Session sampling should give the same decision regardless of turn.
+	ctx0 := &TriggerContext{SessionID: "stable-session", TurnIndex: 0}
+	result := ShouldRun(TriggerSampleSessions, 50, ctx0)
+
+	for i := 1; i <= 20; i++ {
+		ctx := &TriggerContext{SessionID: "stable-session", TurnIndex: i}
+		if ShouldRun(TriggerSampleSessions, 50, ctx) != result {
+			t.Fatalf(
+				"session sampling should be same for all turns, "+
+					"turn 0=%v but turn %d differs",
+				result, i,
+			)
+		}
+	}
+}
+
+func TestShouldRun_SampleTurns_ZeroPercent(t *testing.T) {
+	for i := range 50 {
+		ctx := &TriggerContext{SessionID: "s", TurnIndex: i}
+		if ShouldRun(TriggerSampleTurns, 0, ctx) {
+			t.Fatal("0% sampling should never fire")
+		}
+	}
+}
+
+func TestShouldRun_SampleTurns_HundredPercent(t *testing.T) {
+	for i := range 50 {
+		ctx := &TriggerContext{SessionID: "s", TurnIndex: i}
+		if !ShouldRun(TriggerSampleTurns, 100, ctx) {
+			t.Fatal("100% sampling should always fire")
+		}
+	}
+}
+
+func TestSampleHit_Boundary(t *testing.T) {
+	// Directly test sampleHit at boundaries.
+	if sampleHit("x", 0, 0) {
+		t.Error("0% should never hit")
+	}
+	if !sampleHit("x", 0, 100) {
+		t.Error("100% should always hit")
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `TriggerContext` and `ShouldRun()` with FNV-1a hash-based deterministic sampling for `every_turn`, `on_session_complete`, `sample_turns`, and `sample_sessions` triggers
- Implements `EvalRunner` with per-eval timeout, panic recovery, context cancellation, and separate `RunTurnEvals`/`RunSessionEvals` entry points that filter by trigger type
- 100% coverage on trigger.go, 97.9% on runner.go

## Test plan
- [x] Turn-level evals fire for `every_turn` and `sample_turns`, skip session triggers
- [x] Session-level evals fire for `on_session_complete` and `sample_sessions`, skip turn triggers
- [x] Disabled evals are skipped
- [x] Unknown handler type returns error result
- [x] Panic in handler is recovered with error result
- [x] Handler error and nil result are handled gracefully
- [x] Duration is tracked on all results
- [x] Context cancellation stops eval loop early
- [x] Timeout fires for slow handlers
- [x] Deterministic sampling: same input always produces same decision
- [x] Session sampling gives same decision across all turns in a session
- [x] 0% never fires, 100% always fires

Closes #306