### PR TITLE
feat(evals): add EvalDispatcher, ResultWriter, and EvalWorker (#307)

### DIFF
--- a/runtime/evals/dispatcher.go
+++ b/runtime/evals/dispatcher.go
@@ -1,0 +1,161 @@
+package evals
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// EvalDispatcher controls WHERE evals execute. Implementations decide
+// whether evals run in-process, are published to an event bus for
+// async processing, or are skipped entirely.
+type EvalDispatcher interface {
+	// DispatchTurnEvals dispatches turn-level evals.
+	// Returns results synchronously (InProc) or nil (Event/NoOp).
+	DispatchTurnEvals(
+		ctx context.Context, defs []EvalDef, evalCtx *EvalContext,
+	) ([]EvalResult, error)
+
+	// DispatchSessionEvals dispatches session-level evals.
+	// Returns results synchronously (InProc) or nil (Event/NoOp).
+	DispatchSessionEvals(
+		ctx context.Context, defs []EvalDef, evalCtx *EvalContext,
+	) ([]EvalResult, error)
+}
+
+// EventPublisher publishes serialized eval payloads to an event bus.
+// PromptKit ships this interface only — platforms provide concrete
+// implementations backed by Redis Streams, NATS, Kafka, etc.
+type EventPublisher interface {
+	Publish(ctx context.Context, subject string, data []byte) error
+}
+
+// EventSubscriber subscribes to eval events from an event bus.
+// PromptKit ships this interface only — platforms provide concrete
+// implementations backed by Redis Streams, NATS, Kafka, etc.
+type EventSubscriber interface {
+	Subscribe(
+		ctx context.Context,
+		subject string,
+		handler func(event []byte) error,
+	) error
+}
+
+// InProcDispatcher runs evals directly via EvalRunner and writes
+// results via ResultWriter. Used by Arena (always) and SDK simple
+// deployments. Results are returned synchronously.
+type InProcDispatcher struct {
+	runner       *EvalRunner
+	resultWriter ResultWriter
+}
+
+// NewInProcDispatcher creates a dispatcher that runs evals in-process.
+// The resultWriter may be nil if no result writing is needed.
+func NewInProcDispatcher(
+	runner *EvalRunner, resultWriter ResultWriter,
+) *InProcDispatcher {
+	return &InProcDispatcher{
+		runner:       runner,
+		resultWriter: resultWriter,
+	}
+}
+
+// DispatchTurnEvals runs turn-level evals in-process.
+func (d *InProcDispatcher) DispatchTurnEvals(
+	ctx context.Context, defs []EvalDef, evalCtx *EvalContext,
+) ([]EvalResult, error) {
+	results := d.runner.RunTurnEvals(ctx, defs, evalCtx)
+	if err := d.writeResults(ctx, results); err != nil {
+		return results, err
+	}
+	return results, nil
+}
+
+// DispatchSessionEvals runs session-level evals in-process.
+func (d *InProcDispatcher) DispatchSessionEvals(
+	ctx context.Context, defs []EvalDef, evalCtx *EvalContext,
+) ([]EvalResult, error) {
+	results := d.runner.RunSessionEvals(ctx, defs, evalCtx)
+	if err := d.writeResults(ctx, results); err != nil {
+		return results, err
+	}
+	return results, nil
+}
+
+func (d *InProcDispatcher) writeResults(
+	ctx context.Context, results []EvalResult,
+) error {
+	if d.resultWriter == nil || len(results) == 0 {
+		return nil
+	}
+	return d.resultWriter.WriteResults(ctx, results)
+}
+
+// evalEventPayload is the JSON payload published by EventDispatcher.
+type evalEventPayload struct {
+	Defs    []EvalDef    `json:"defs"`
+	EvalCtx *EvalContext `json:"eval_ctx"`
+}
+
+// EventDispatcher publishes eval requests to an event bus for async
+// processing by an EvalWorker (Pattern B). Returns nil results since
+// evals run asynchronously in the worker.
+type EventDispatcher struct {
+	publisher EventPublisher
+}
+
+// NewEventDispatcher creates a dispatcher that publishes to an event bus.
+func NewEventDispatcher(publisher EventPublisher) *EventDispatcher {
+	return &EventDispatcher{publisher: publisher}
+}
+
+// DispatchTurnEvals publishes turn eval request to the event bus.
+// Subject: eval.turn.{session_id}
+func (d *EventDispatcher) DispatchTurnEvals(
+	ctx context.Context, defs []EvalDef, evalCtx *EvalContext,
+) ([]EvalResult, error) {
+	return nil, d.publish(ctx, "eval.turn", defs, evalCtx)
+}
+
+// DispatchSessionEvals publishes session eval request to the event bus.
+// Subject: eval.session.{session_id}
+func (d *EventDispatcher) DispatchSessionEvals(
+	ctx context.Context, defs []EvalDef, evalCtx *EvalContext,
+) ([]EvalResult, error) {
+	return nil, d.publish(ctx, "eval.session", defs, evalCtx)
+}
+
+func (d *EventDispatcher) publish(
+	ctx context.Context,
+	prefix string,
+	defs []EvalDef,
+	evalCtx *EvalContext,
+) error {
+	payload := evalEventPayload{Defs: defs, EvalCtx: evalCtx}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal eval event: %w", err)
+	}
+	subject := fmt.Sprintf("%s.%s", prefix, evalCtx.SessionID)
+	return d.publisher.Publish(ctx, subject, data)
+}
+
+// NoOpDispatcher is used when evals are disabled at the SDK dispatch
+// level. Returns nil results with no error. Used when the platform
+// handles evals externally (Pattern A) or via EventBusEvalListener
+// (Pattern C).
+type NoOpDispatcher struct{}
+
+// DispatchTurnEvals is a no-op that returns nil results.
+func (d *NoOpDispatcher) DispatchTurnEvals(
+	_ context.Context, _ []EvalDef, _ *EvalContext,
+) ([]EvalResult, error) {
+	return nil, nil
+}
+
+// DispatchSessionEvals is a no-op that returns nil results.
+func (d *NoOpDispatcher) DispatchSessionEvals(
+	_ context.Context, _ []EvalDef, _ *EvalContext,
+) ([]EvalResult, error) {
+	return nil, nil
+}

--- a/runtime/evals/dispatcher_test.go
+++ b/runtime/evals/dispatcher_test.go
@@ -1,0 +1,302 @@
+package evals
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// mockPublisher captures published events.
+type mockPublisher struct {
+	mu       sync.Mutex
+	events   []publishedEvent
+	publishErr error
+}
+
+type publishedEvent struct {
+	Subject string
+	Data    []byte
+}
+
+func (m *mockPublisher) Publish(
+	_ context.Context, subject string, data []byte,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.publishErr != nil {
+		return m.publishErr
+	}
+	m.events = append(m.events, publishedEvent{
+		Subject: subject,
+		Data:    data,
+	})
+	return nil
+}
+
+// recordingWriter captures results written.
+type recordingWriter struct {
+	mu      sync.Mutex
+	batches [][]EvalResult
+	err     error
+}
+
+func (w *recordingWriter) WriteResults(
+	_ context.Context, results []EvalResult,
+) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.batches = append(w.batches, results)
+	return w.err
+}
+
+func (w *recordingWriter) getBatches() [][]EvalResult {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	cp := make([][]EvalResult, len(w.batches))
+	copy(cp, w.batches)
+	return cp
+}
+
+func TestInProcDispatcher_TurnEvals(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	writer := &recordingWriter{}
+	disp := NewInProcDispatcher(runner, writer)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1", TurnIndex: 0}
+
+	results, err := disp.DispatchTurnEvals(
+		context.Background(), defs, evalCtx,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if !results[0].Passed {
+		t.Error("expected Passed=true")
+	}
+	if len(writer.batches) != 1 {
+		t.Errorf("expected 1 write batch, got %d", len(writer.batches))
+	}
+}
+
+func TestInProcDispatcher_SessionEvals(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	writer := &recordingWriter{}
+	disp := NewInProcDispatcher(runner, writer)
+
+	defs := []EvalDef{
+		{
+			ID:      "e1",
+			Type:    "test",
+			Trigger: TriggerOnSessionComplete,
+		},
+	}
+	evalCtx := &EvalContext{SessionID: "s1", TurnIndex: 3}
+
+	results, err := disp.DispatchSessionEvals(
+		context.Background(), defs, evalCtx,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+}
+
+func TestInProcDispatcher_NilWriter(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	disp := NewInProcDispatcher(runner, nil)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results, err := disp.DispatchTurnEvals(
+		context.Background(), defs, evalCtx,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+}
+
+func TestInProcDispatcher_WriterError(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	writer := &recordingWriter{err: errors.New("write failed")}
+	disp := NewInProcDispatcher(runner, writer)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	results, err := disp.DispatchTurnEvals(
+		context.Background(), defs, evalCtx,
+	)
+	if err == nil {
+		t.Fatal("expected error from writer")
+	}
+	// Results should still be returned even with writer error.
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+}
+
+func TestInProcDispatcher_NoResults_SkipsWrite(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	writer := &recordingWriter{}
+	disp := NewInProcDispatcher(runner, writer)
+
+	// No matching triggers → no results → no write.
+	defs := []EvalDef{
+		{
+			ID:      "e1",
+			Type:    "test",
+			Trigger: TriggerOnSessionComplete,
+		},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	_, err := disp.DispatchTurnEvals(
+		context.Background(), defs, evalCtx,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(writer.batches) != 0 {
+		t.Errorf("expected no writes, got %d", len(writer.batches))
+	}
+}
+
+func TestEventDispatcher_TurnEvals(t *testing.T) {
+	pub := &mockPublisher{}
+	disp := NewEventDispatcher(pub)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "session-123"}
+
+	results, err := disp.DispatchTurnEvals(
+		context.Background(), defs, evalCtx,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Error("event dispatcher should return nil results")
+	}
+	if len(pub.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(pub.events))
+	}
+	if pub.events[0].Subject != "eval.turn.session-123" {
+		t.Errorf(
+			"subject = %q, want %q",
+			pub.events[0].Subject, "eval.turn.session-123",
+		)
+	}
+
+	// Verify payload is valid JSON with expected structure.
+	var payload evalEventPayload
+	if err := json.Unmarshal(pub.events[0].Data, &payload); err != nil {
+		t.Fatalf("invalid payload JSON: %v", err)
+	}
+	if len(payload.Defs) != 1 {
+		t.Errorf("payload defs count = %d, want 1", len(payload.Defs))
+	}
+	if payload.EvalCtx.SessionID != "session-123" {
+		t.Errorf(
+			"payload session = %q, want %q",
+			payload.EvalCtx.SessionID, "session-123",
+		)
+	}
+}
+
+func TestEventDispatcher_SessionEvals(t *testing.T) {
+	pub := &mockPublisher{}
+	disp := NewEventDispatcher(pub)
+
+	defs := []EvalDef{
+		{
+			ID:      "e1",
+			Type:    "test",
+			Trigger: TriggerOnSessionComplete,
+		},
+	}
+	evalCtx := &EvalContext{SessionID: "sess-456"}
+
+	results, err := disp.DispatchSessionEvals(
+		context.Background(), defs, evalCtx,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Error("event dispatcher should return nil results")
+	}
+	if pub.events[0].Subject != "eval.session.sess-456" {
+		t.Errorf(
+			"subject = %q, want %q",
+			pub.events[0].Subject, "eval.session.sess-456",
+		)
+	}
+}
+
+func TestEventDispatcher_PublishError(t *testing.T) {
+	pub := &mockPublisher{publishErr: errors.New("bus down")}
+	disp := NewEventDispatcher(pub)
+
+	defs := []EvalDef{
+		{ID: "e1", Type: "test", Trigger: TriggerEveryTurn},
+	}
+	evalCtx := &EvalContext{SessionID: "s1"}
+
+	_, err := disp.DispatchTurnEvals(
+		context.Background(), defs, evalCtx,
+	)
+	if err == nil {
+		t.Fatal("expected publish error")
+	}
+}
+
+func TestNoOpDispatcher_Turn(t *testing.T) {
+	disp := &NoOpDispatcher{}
+	results, err := disp.DispatchTurnEvals(
+		context.Background(), nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Error("expected nil results")
+	}
+}
+
+func TestNoOpDispatcher_Session(t *testing.T) {
+	disp := &NoOpDispatcher{}
+	results, err := disp.DispatchSessionEvals(
+		context.Background(), nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Error("expected nil results")
+	}
+}

--- a/runtime/evals/result_writer.go
+++ b/runtime/evals/result_writer.go
@@ -1,0 +1,96 @@
+package evals
+
+import "context"
+
+// ResultWriter controls WHERE eval results go. Implementations may
+// write to Prometheus metrics, message metadata, telemetry spans,
+// databases, or external APIs. Platform-specific writers are
+// implemented outside PromptKit.
+type ResultWriter interface {
+	WriteResults(ctx context.Context, results []EvalResult) error
+}
+
+// MetricRecorder records eval results as metrics. This interface is
+// implemented by MetricCollector (defined in the metrics package) and
+// injected here to avoid circular dependencies.
+type MetricRecorder interface {
+	Record(result EvalResult, metric *MetricDef) error
+}
+
+// MetricResultWriter feeds eval results to a MetricRecorder for
+// Prometheus exposition. Only results whose corresponding EvalDef
+// has a Metric definition are recorded.
+type MetricResultWriter struct {
+	recorder MetricRecorder
+	// defs maps eval ID to its definition for metric lookup.
+	defs map[string]*EvalDef
+}
+
+// NewMetricResultWriter creates a writer that records metrics.
+// The defs slice provides the metric definitions keyed by eval ID.
+func NewMetricResultWriter(
+	recorder MetricRecorder, defs []EvalDef,
+) *MetricResultWriter {
+	m := make(map[string]*EvalDef, len(defs))
+	for i := range defs {
+		m[defs[i].ID] = &defs[i]
+	}
+	return &MetricResultWriter{recorder: recorder, defs: m}
+}
+
+// WriteResults records each result that has an associated metric.
+func (w *MetricResultWriter) WriteResults(
+	_ context.Context, results []EvalResult,
+) error {
+	for i := range results {
+		def, ok := w.defs[results[i].EvalID]
+		if !ok || def.Metric == nil {
+			continue
+		}
+		if err := w.recorder.Record(results[i], def.Metric); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MetadataResultWriter stores eval results in the EvalContext metadata
+// under the key "pack_evals". This is used by Arena and SDK to attach
+// results to message metadata for reporting.
+type MetadataResultWriter struct{}
+
+// WriteResults is a no-op placeholder. The actual metadata attachment
+// happens at the caller level since the writer doesn't have access to
+// the message being constructed. Callers use the returned results from
+// InProcDispatcher to populate msg.Meta["pack_evals"].
+func (w *MetadataResultWriter) WriteResults(
+	_ context.Context, _ []EvalResult,
+) error {
+	return nil
+}
+
+// CompositeResultWriter fans out WriteResults calls to multiple
+// writers. All writers are called; the first error encountered is
+// returned.
+type CompositeResultWriter struct {
+	writers []ResultWriter
+}
+
+// NewCompositeResultWriter creates a writer that delegates to multiple
+// writers. Writers are called in order.
+func NewCompositeResultWriter(writers ...ResultWriter) *CompositeResultWriter {
+	return &CompositeResultWriter{writers: writers}
+}
+
+// WriteResults calls WriteResults on each writer in order. Returns
+// the first error encountered.
+func (w *CompositeResultWriter) WriteResults(
+	ctx context.Context, results []EvalResult,
+) error {
+	for _, writer := range w.writers {
+		if err := writer.WriteResults(ctx, results); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/runtime/evals/result_writer_test.go
+++ b/runtime/evals/result_writer_test.go
@@ -1,0 +1,164 @@
+package evals
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockRecorder captures metric recordings.
+type mockRecorder struct {
+	recordings []recordedMetric
+	err        error
+}
+
+type recordedMetric struct {
+	Result EvalResult
+	Metric MetricDef
+}
+
+func (m *mockRecorder) Record(
+	result EvalResult, metric *MetricDef,
+) error {
+	m.recordings = append(m.recordings, recordedMetric{
+		Result: result,
+		Metric: *metric,
+	})
+	return m.err
+}
+
+func TestMetricResultWriter_RecordsMetrics(t *testing.T) {
+	rec := &mockRecorder{}
+	defs := []EvalDef{
+		{
+			ID:   "e1",
+			Type: "test",
+			Metric: &MetricDef{
+				Name: "test_metric",
+				Type: MetricGauge,
+			},
+		},
+		{ID: "e2", Type: "test"}, // no metric
+	}
+	writer := NewMetricResultWriter(rec, defs)
+
+	results := []EvalResult{
+		{EvalID: "e1", Passed: true},
+		{EvalID: "e2", Passed: true},
+	}
+	err := writer.WriteResults(context.Background(), results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only e1 has a metric, so only 1 recording.
+	if len(rec.recordings) != 1 {
+		t.Fatalf("got %d recordings, want 1", len(rec.recordings))
+	}
+	if rec.recordings[0].Metric.Name != "test_metric" {
+		t.Errorf(
+			"metric name = %q, want %q",
+			rec.recordings[0].Metric.Name, "test_metric",
+		)
+	}
+}
+
+func TestMetricResultWriter_UnknownEvalIDSkipped(t *testing.T) {
+	rec := &mockRecorder{}
+	defs := []EvalDef{
+		{
+			ID:     "e1",
+			Type:   "test",
+			Metric: &MetricDef{Name: "m", Type: MetricGauge},
+		},
+	}
+	writer := NewMetricResultWriter(rec, defs)
+
+	results := []EvalResult{
+		{EvalID: "unknown", Passed: true},
+	}
+	err := writer.WriteResults(context.Background(), results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.recordings) != 0 {
+		t.Errorf("expected no recordings, got %d", len(rec.recordings))
+	}
+}
+
+func TestMetricResultWriter_RecorderError(t *testing.T) {
+	rec := &mockRecorder{err: errors.New("record failed")}
+	defs := []EvalDef{
+		{
+			ID:     "e1",
+			Type:   "test",
+			Metric: &MetricDef{Name: "m", Type: MetricGauge},
+		},
+	}
+	writer := NewMetricResultWriter(rec, defs)
+
+	results := []EvalResult{
+		{EvalID: "e1", Passed: true},
+	}
+	err := writer.WriteResults(context.Background(), results)
+	if err == nil {
+		t.Fatal("expected recorder error")
+	}
+}
+
+func TestMetadataResultWriter_NoOp(t *testing.T) {
+	writer := &MetadataResultWriter{}
+	err := writer.WriteResults(context.Background(), []EvalResult{
+		{EvalID: "e1", Passed: true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompositeResultWriter_FansOut(t *testing.T) {
+	w1 := &recordingWriter{}
+	w2 := &recordingWriter{}
+	composite := NewCompositeResultWriter(w1, w2)
+
+	results := []EvalResult{
+		{EvalID: "e1", Passed: true},
+	}
+	err := composite.WriteResults(context.Background(), results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(w1.batches) != 1 {
+		t.Errorf("w1 got %d batches, want 1", len(w1.batches))
+	}
+	if len(w2.batches) != 1 {
+		t.Errorf("w2 got %d batches, want 1", len(w2.batches))
+	}
+}
+
+func TestCompositeResultWriter_StopsOnError(t *testing.T) {
+	w1 := &recordingWriter{err: errors.New("w1 failed")}
+	w2 := &recordingWriter{}
+	composite := NewCompositeResultWriter(w1, w2)
+
+	results := []EvalResult{
+		{EvalID: "e1", Passed: true},
+	}
+	err := composite.WriteResults(context.Background(), results)
+	if err == nil {
+		t.Fatal("expected error from w1")
+	}
+	// w2 should not have been called.
+	if len(w2.batches) != 0 {
+		t.Errorf("w2 should not be called after w1 error")
+	}
+}
+
+func TestCompositeResultWriter_Empty(t *testing.T) {
+	composite := NewCompositeResultWriter()
+	err := composite.WriteResults(context.Background(), []EvalResult{
+		{EvalID: "e1"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/runtime/evals/worker.go
+++ b/runtime/evals/worker.go
@@ -1,0 +1,132 @@
+package evals
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+// EvalWorker is a reusable worker loop for Pattern B event-driven
+// eval execution. It subscribes to eval events via EventSubscriber,
+// deserializes payloads, calls EvalRunner, and writes results via
+// ResultWriter. Platforms wire this with their own EventSubscriber
+// and ResultWriter implementations.
+type EvalWorker struct {
+	runner       *EvalRunner
+	subscriber   EventSubscriber
+	resultWriter ResultWriter
+	logger       Logger
+}
+
+// Logger is a minimal logging interface for EvalWorker.
+type Logger interface {
+	Printf(format string, v ...any)
+}
+
+// defaultLogger wraps the standard log package.
+type defaultLogger struct{}
+
+// Printf logs using the standard log package.
+func (defaultLogger) Printf(format string, v ...any) {
+	log.Printf(format, v...)
+}
+
+// WorkerOption configures an EvalWorker.
+type WorkerOption func(*EvalWorker)
+
+// WithLogger sets a custom logger for the worker.
+func WithLogger(l Logger) WorkerOption {
+	return func(w *EvalWorker) { w.logger = l }
+}
+
+// NewEvalWorker creates a worker that processes eval events.
+func NewEvalWorker(
+	runner *EvalRunner,
+	subscriber EventSubscriber,
+	resultWriter ResultWriter,
+	opts ...WorkerOption,
+) *EvalWorker {
+	w := &EvalWorker{
+		runner:       runner,
+		subscriber:   subscriber,
+		resultWriter: resultWriter,
+		logger:       defaultLogger{},
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
+}
+
+// Start subscribes to turn and session eval events and processes them.
+// It blocks until the context is canceled or a subscription error occurs.
+func (w *EvalWorker) Start(ctx context.Context) error {
+	turnErr := make(chan error, 1)
+	sessErr := make(chan error, 1)
+
+	go func() {
+		turnErr <- w.subscriber.Subscribe(
+			ctx, "eval.turn.*", w.handleTurnEvent,
+		)
+	}()
+
+	go func() {
+		sessErr <- w.subscriber.Subscribe(
+			ctx, "eval.session.*", w.handleSessionEvent,
+		)
+	}()
+
+	select {
+	case err := <-turnErr:
+		return fmt.Errorf("turn subscription: %w", err)
+	case err := <-sessErr:
+		return fmt.Errorf("session subscription: %w", err)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (w *EvalWorker) handleTurnEvent(event []byte) error {
+	payload, err := w.decode(event)
+	if err != nil {
+		return err
+	}
+	results := w.runner.RunTurnEvals(
+		context.Background(), payload.Defs, payload.EvalCtx,
+	)
+	return w.writeResults(results)
+}
+
+func (w *EvalWorker) handleSessionEvent(event []byte) error {
+	payload, err := w.decode(event)
+	if err != nil {
+		return err
+	}
+	results := w.runner.RunSessionEvals(
+		context.Background(), payload.Defs, payload.EvalCtx,
+	)
+	return w.writeResults(results)
+}
+
+func (w *EvalWorker) decode(event []byte) (*evalEventPayload, error) {
+	var payload evalEventPayload
+	if err := json.Unmarshal(event, &payload); err != nil {
+		w.logger.Printf("failed to decode eval event: %v", err)
+		return nil, fmt.Errorf("decode eval event: %w", err)
+	}
+	return &payload, nil
+}
+
+func (w *EvalWorker) writeResults(results []EvalResult) error {
+	if w.resultWriter == nil || len(results) == 0 {
+		return nil
+	}
+	if err := w.resultWriter.WriteResults(
+		context.Background(), results,
+	); err != nil {
+		w.logger.Printf("failed to write eval results: %v", err)
+		return err
+	}
+	return nil
+}

--- a/runtime/evals/worker_test.go
+++ b/runtime/evals/worker_test.go
@@ -1,0 +1,224 @@
+package evals
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// mockSubscriber calls handlers with pre-configured events.
+type mockSubscriber struct {
+	turnEvents    [][]byte
+	sessionEvents [][]byte
+	subErr        error
+}
+
+func (m *mockSubscriber) Subscribe(
+	ctx context.Context,
+	subject string,
+	handler func(event []byte) error,
+) error {
+	if m.subErr != nil {
+		return m.subErr
+	}
+
+	var events [][]byte
+	switch subject {
+	case "eval.turn.*":
+		events = m.turnEvents
+	case "eval.session.*":
+		events = m.sessionEvents
+	}
+
+	for _, e := range events {
+		if err := handler(e); err != nil {
+			return err
+		}
+	}
+
+	// Block until context is canceled to simulate long-running sub.
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// testLogger captures log output.
+type testLogger struct {
+	messages []string
+}
+
+func (l *testLogger) Printf(format string, _ ...any) {
+	l.messages = append(l.messages, format)
+}
+
+func makePayload(
+	t *testing.T, defs []EvalDef, evalCtx *EvalContext,
+) []byte {
+	t.Helper()
+	data, err := json.Marshal(evalEventPayload{
+		Defs:    defs,
+		EvalCtx: evalCtx,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return data
+}
+
+func TestEvalWorker_ProcessesTurnEvents(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	writer := &recordingWriter{}
+
+	payload := makePayload(t,
+		[]EvalDef{{ID: "e1", Type: "test", Trigger: TriggerEveryTurn}},
+		&EvalContext{SessionID: "s1", TurnIndex: 0},
+	)
+
+	sub := &mockSubscriber{turnEvents: [][]byte{payload}}
+	worker := NewEvalWorker(runner, sub, writer)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 500*time.Millisecond,
+	)
+	defer cancel()
+
+	_ = worker.Start(ctx)
+
+	batches := writer.getBatches()
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch, got %d", len(batches))
+	}
+	if len(batches[0]) != 1 {
+		t.Fatalf(
+			"expected 1 result in batch, got %d", len(batches[0]),
+		)
+	}
+	if !batches[0][0].Passed {
+		t.Error("expected Passed=true")
+	}
+}
+
+func TestEvalWorker_ProcessesSessionEvents(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	writer := &recordingWriter{}
+
+	payload := makePayload(t,
+		[]EvalDef{
+			{
+				ID:      "e1",
+				Type:    "test",
+				Trigger: TriggerOnSessionComplete,
+			},
+		},
+		&EvalContext{SessionID: "s1", TurnIndex: 5},
+	)
+
+	sub := &mockSubscriber{sessionEvents: [][]byte{payload}}
+	worker := NewEvalWorker(runner, sub, writer)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 500*time.Millisecond,
+	)
+	defer cancel()
+
+	_ = worker.Start(ctx)
+
+	batches := writer.getBatches()
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch, got %d", len(batches))
+	}
+}
+
+func TestEvalWorker_InvalidPayload(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	writer := &recordingWriter{}
+	logger := &testLogger{}
+
+	sub := &mockSubscriber{
+		turnEvents: [][]byte{[]byte("not json")},
+	}
+	worker := NewEvalWorker(runner, sub, writer, WithLogger(logger))
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 500*time.Millisecond,
+	)
+	defer cancel()
+
+	err := worker.Start(ctx)
+	// Should get an error from the failed decode propagating through
+	// the subscription.
+	if err == nil {
+		t.Fatal("expected error from invalid payload")
+	}
+	if len(logger.messages) == 0 {
+		t.Error("expected log message for decode failure")
+	}
+}
+
+func TestEvalWorker_SubscriptionError(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	sub := &mockSubscriber{subErr: errors.New("sub failed")}
+	worker := NewEvalWorker(runner, sub, nil)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 500*time.Millisecond,
+	)
+	defer cancel()
+
+	err := worker.Start(ctx)
+	if err == nil {
+		t.Fatal("expected subscription error")
+	}
+}
+
+func TestEvalWorker_NilResultWriter(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+
+	payload := makePayload(t,
+		[]EvalDef{{ID: "e1", Type: "test", Trigger: TriggerEveryTurn}},
+		&EvalContext{SessionID: "s1"},
+	)
+
+	sub := &mockSubscriber{turnEvents: [][]byte{payload}}
+	worker := NewEvalWorker(runner, sub, nil)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 500*time.Millisecond,
+	)
+	defer cancel()
+
+	// Should not panic with nil writer.
+	_ = worker.Start(ctx)
+}
+
+func TestEvalWorker_WriterError(t *testing.T) {
+	reg := newTestRegistry(&stubHandler{typeName: "test"})
+	runner := NewEvalRunner(reg)
+	writer := &recordingWriter{err: errors.New("write failed")}
+	logger := &testLogger{}
+
+	payload := makePayload(t,
+		[]EvalDef{{ID: "e1", Type: "test", Trigger: TriggerEveryTurn}},
+		&EvalContext{SessionID: "s1"},
+	)
+
+	sub := &mockSubscriber{turnEvents: [][]byte{payload}}
+	worker := NewEvalWorker(runner, sub, writer, WithLogger(logger))
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 500*time.Millisecond,
+	)
+	defer cancel()
+
+	err := worker.Start(ctx)
+	if err == nil {
+		t.Fatal("expected error from writer failure")
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `EvalDispatcher` interface with three built-in dispatchers: `InProcDispatcher` (synchronous via EvalRunner), `EventDispatcher` (async via EventPublisher), `NoOpDispatcher` (disabled)
- Implements `ResultWriter` interface with `MetricResultWriter`, `MetadataResultWriter`, and `CompositeResultWriter` for flexible result routing
- Implements `EvalWorker` for Pattern B event-driven eval processing with `EventSubscriber` interface
- Defines `EventPublisher` and `EventSubscriber` interfaces (PromptKit ships interfaces only)
- Event subjects follow `eval.turn.{session_id}` / `eval.session.{session_id}` pattern
- 91.3% coverage on dispatcher, 100% on result_writer, 94.7% on worker

## Test plan
- [x] InProcDispatcher produces same results as EvalRunner directly
- [x] InProcDispatcher writes results via ResultWriter
- [x] InProcDispatcher handles nil writer gracefully
- [x] InProcDispatcher returns results even when writer errors
- [x] InProcDispatcher skips write when no results
- [x] EventDispatcher serializes (defs, evalCtx) and publishes to correct subject
- [x] EventDispatcher propagates publish errors
- [x] NoOpDispatcher returns nil, nil for both turn and session
- [x] CompositeResultWriter fans out to multiple writers
- [x] CompositeResultWriter stops on first error
- [x] MetricResultWriter records only evals with metric definitions
- [x] MetricResultWriter skips unknown eval IDs
- [x] EvalWorker processes turn events end-to-end
- [x] EvalWorker processes session events end-to-end
- [x] EvalWorker handles invalid payloads with logging
- [x] EvalWorker handles subscription errors
- [x] EvalWorker handles nil writer and writer errors
- [x] All tests pass with -race

Closes #307