### PR TITLE
feat: RFC007 agents validation and multi-agent tool resolution

### DIFF
--- a/sdk/agent_resolver.go
+++ b/sdk/agent_resolver.go
@@ -1,17 +1,54 @@
 package sdk
 
 import (
+	"encoding/json"
+
 	"github.com/AltairaLabs/PromptKit/runtime/a2a"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt/agentcard"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 )
 
+// EndpointResolver determines the A2A endpoint URL for a given agent member.
+// Implementations can provide static URLs, service-discovery lookups, or
+// test-friendly mock endpoints.
+type EndpointResolver interface {
+	// Resolve returns the base URL (e.g. "http://localhost:9000") for the
+	// named agent member. An empty string means the agent has no reachable
+	// endpoint and should be skipped.
+	Resolve(agentName string) string
+}
+
+// StaticEndpointResolver returns the same base URL for every agent.
+// This is useful when all agents are behind a single gateway or when
+// developing locally against a single A2A server.
+type StaticEndpointResolver struct {
+	BaseURL string
+}
+
+// Resolve returns the static base URL for any agent name.
+func (r *StaticEndpointResolver) Resolve(_ string) string {
+	return r.BaseURL
+}
+
+// MapEndpointResolver maps each agent name to a specific endpoint URL.
+// Unknown agents return an empty string and are silently skipped.
+type MapEndpointResolver struct {
+	Endpoints map[string]string
+}
+
+// Resolve returns the endpoint URL for the given agent name, or empty string
+// if not found.
+func (r *MapEndpointResolver) Resolve(agentName string) string {
+	return r.Endpoints[agentName]
+}
+
 // AgentToolResolver resolves agent member references in tool lists
 // to A2A-compatible tool descriptors.
 type AgentToolResolver struct {
-	cards map[string]*a2a.AgentCard
-	pack  *prompt.Pack
+	cards    map[string]*a2a.AgentCard
+	pack     *prompt.Pack
+	resolver EndpointResolver
 }
 
 // NewAgentToolResolver creates a resolver from a compiled pack.
@@ -22,6 +59,16 @@ func NewAgentToolResolver(pack *prompt.Pack) *AgentToolResolver {
 		return nil
 	}
 	return &AgentToolResolver{cards: cards, pack: pack}
+}
+
+// SetEndpointResolver configures how agent URLs are resolved.
+// When nil, descriptors are created without an AgentURL (suitable for
+// testing or when endpoints are resolved later).
+func (r *AgentToolResolver) SetEndpointResolver(er EndpointResolver) {
+	if r == nil {
+		return
+	}
+	r.resolver = er
 }
 
 // IsAgentTool checks if a tool name refers to an agent member.
@@ -35,6 +82,8 @@ func (r *AgentToolResolver) IsAgentTool(toolName string) bool {
 
 // ResolveAgentTools returns tool descriptors for all agent members
 // that appear in the given tool names list.
+// Each descriptor has Mode "a2a", an input schema with a required "query"
+// field, and (if an EndpointResolver is set) an AgentURL in A2AConfig.
 func (r *AgentToolResolver) ResolveAgentTools(toolNames []string) []*tools.ToolDescriptor {
 	if r == nil {
 		return nil
@@ -46,16 +95,68 @@ func (r *AgentToolResolver) ResolveAgentTools(toolNames []string) []*tools.ToolD
 			continue
 		}
 		for i := range card.Skills {
+			agentURL := ""
+			if r.resolver != nil {
+				agentURL = r.resolver.Resolve(name)
+			}
+
 			desc := &tools.ToolDescriptor{
-				Name:        name,
-				Description: card.Skills[i].Description,
-				Mode:        "a2a",
+				Name:         name,
+				Description:  card.Skills[i].Description,
+				InputSchema:  agentInputSchema(),
+				OutputSchema: agentOutputSchema(),
+				Mode:         "a2a",
 				A2AConfig: &tools.A2AConfig{
-					SkillID: card.Skills[i].ID,
+					AgentURL: agentURL,
+					SkillID:  card.Skills[i].ID,
 				},
 			}
 			descriptors = append(descriptors, desc)
 		}
 	}
 	return descriptors
+}
+
+// MemberNames returns the names of all agent members known to this resolver.
+func (r *AgentToolResolver) MemberNames() []string {
+	if r == nil {
+		return nil
+	}
+	names := make([]string, 0, len(r.cards))
+	for name := range r.cards {
+		names = append(names, name)
+	}
+	return names
+}
+
+// agentInputSchema returns the JSON Schema for an agent tool's input.
+// Agent tools accept a "query" string that is forwarded as the A2A message.
+func agentInputSchema() json.RawMessage {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "The message to send to the agent",
+			},
+		},
+		"required": []string{"query"},
+	}
+	data, _ := json.Marshal(schema)
+	return data
+}
+
+// agentOutputSchema returns the JSON Schema for an agent tool's output.
+func agentOutputSchema() json.RawMessage {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"response": map[string]any{
+				"type":        "string",
+				"description": "The agent's response text",
+			},
+		},
+	}
+	data, _ := json.Marshal(schema)
+	return data
 }

--- a/sdk/agent_resolver_test.go
+++ b/sdk/agent_resolver_test.go
@@ -1,9 +1,11 @@
 package sdk
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -128,4 +130,280 @@ func TestAgentToolResolver_ResolveAgentTools_NilReceiver(t *testing.T) {
 	var r *AgentToolResolver
 	descriptors := r.ResolveAgentTools([]string{"anything"})
 	assert.Nil(t, descriptors)
+}
+
+// --- New tests for endpoint resolution, schemas, and wiring ---
+
+func TestAgentToolResolver_InputOutputSchemas(t *testing.T) {
+	pack := &prompt.Pack{
+		ID:      "test-pack",
+		Version: "1.0.0",
+		Prompts: map[string]*prompt.PackPrompt{
+			"summarizer": {
+				Name:        "Summarizer",
+				Description: "Summarizes text",
+			},
+		},
+		Agents: &prompt.AgentsConfig{
+			Entry: "summarizer",
+			Members: map[string]*prompt.AgentDef{
+				"summarizer": {Description: "Summarizes text"},
+			},
+		},
+	}
+
+	r := NewAgentToolResolver(pack)
+	require.NotNil(t, r)
+
+	descriptors := r.ResolveAgentTools([]string{"summarizer"})
+	require.Len(t, descriptors, 1)
+
+	d := descriptors[0]
+
+	// Verify input schema has "query" required field
+	var inputSchema map[string]any
+	require.NoError(t, json.Unmarshal(d.InputSchema, &inputSchema))
+	assert.Equal(t, "object", inputSchema["type"])
+
+	props, ok := inputSchema["properties"].(map[string]any)
+	require.True(t, ok)
+	queryProp, ok := props["query"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "string", queryProp["type"])
+
+	required, ok := inputSchema["required"].([]any)
+	require.True(t, ok)
+	assert.Contains(t, required, "query")
+
+	// Verify output schema has "response" field
+	var outputSchema map[string]any
+	require.NoError(t, json.Unmarshal(d.OutputSchema, &outputSchema))
+	assert.Equal(t, "object", outputSchema["type"])
+
+	outProps, ok := outputSchema["properties"].(map[string]any)
+	require.True(t, ok)
+	_, ok = outProps["response"].(map[string]any)
+	require.True(t, ok)
+}
+
+func TestStaticEndpointResolver(t *testing.T) {
+	r := &StaticEndpointResolver{BaseURL: "http://localhost:9000"}
+	assert.Equal(t, "http://localhost:9000", r.Resolve("any-agent"))
+	assert.Equal(t, "http://localhost:9000", r.Resolve("another-agent"))
+}
+
+func TestMapEndpointResolver(t *testing.T) {
+	r := &MapEndpointResolver{
+		Endpoints: map[string]string{
+			"summarizer": "http://summarizer:9001",
+			"translator": "http://translator:9002",
+		},
+	}
+	assert.Equal(t, "http://summarizer:9001", r.Resolve("summarizer"))
+	assert.Equal(t, "http://translator:9002", r.Resolve("translator"))
+	assert.Equal(t, "", r.Resolve("unknown"))
+}
+
+func TestAgentToolResolver_WithStaticEndpoint(t *testing.T) {
+	pack := &prompt.Pack{
+		ID:      "test-pack",
+		Version: "1.0.0",
+		Prompts: map[string]*prompt.PackPrompt{
+			"summarizer": {
+				Name:        "Summarizer",
+				Description: "Summarizes text",
+			},
+		},
+		Agents: &prompt.AgentsConfig{
+			Entry: "summarizer",
+			Members: map[string]*prompt.AgentDef{
+				"summarizer": {Description: "Summarizes text"},
+			},
+		},
+	}
+
+	r := NewAgentToolResolver(pack)
+	require.NotNil(t, r)
+
+	r.SetEndpointResolver(&StaticEndpointResolver{BaseURL: "http://localhost:8080"})
+
+	descriptors := r.ResolveAgentTools([]string{"summarizer"})
+	require.Len(t, descriptors, 1)
+
+	assert.Equal(t, "http://localhost:8080", descriptors[0].A2AConfig.AgentURL)
+	assert.Equal(t, "summarizer", descriptors[0].A2AConfig.SkillID)
+}
+
+func TestAgentToolResolver_WithMapEndpoints(t *testing.T) {
+	pack := &prompt.Pack{
+		ID:      "test-pack",
+		Version: "1.0.0",
+		Prompts: map[string]*prompt.PackPrompt{
+			"summarizer": {
+				Name:        "Summarizer",
+				Description: "Summarizes text",
+			},
+			"translator": {
+				Name:        "Translator",
+				Description: "Translates text",
+			},
+		},
+		Agents: &prompt.AgentsConfig{
+			Entry: "summarizer",
+			Members: map[string]*prompt.AgentDef{
+				"summarizer": {Description: "Summarizes text"},
+				"translator": {Description: "Translates text"},
+			},
+		},
+	}
+
+	r := NewAgentToolResolver(pack)
+	require.NotNil(t, r)
+
+	r.SetEndpointResolver(&MapEndpointResolver{
+		Endpoints: map[string]string{
+			"summarizer": "http://summarizer:9001",
+			"translator": "http://translator:9002",
+		},
+	})
+
+	descriptors := r.ResolveAgentTools([]string{"summarizer", "translator"})
+	require.Len(t, descriptors, 2)
+
+	byName := make(map[string]string)
+	for _, d := range descriptors {
+		byName[d.Name] = d.A2AConfig.AgentURL
+	}
+	assert.Equal(t, "http://summarizer:9001", byName["summarizer"])
+	assert.Equal(t, "http://translator:9002", byName["translator"])
+}
+
+func TestAgentToolResolver_NoEndpointResolver(t *testing.T) {
+	pack := &prompt.Pack{
+		ID:      "test-pack",
+		Version: "1.0.0",
+		Prompts: map[string]*prompt.PackPrompt{
+			"summarizer": {
+				Name:        "Summarizer",
+				Description: "Summarizes text",
+			},
+		},
+		Agents: &prompt.AgentsConfig{
+			Entry: "summarizer",
+			Members: map[string]*prompt.AgentDef{
+				"summarizer": {Description: "Summarizes text"},
+			},
+		},
+	}
+
+	r := NewAgentToolResolver(pack)
+	require.NotNil(t, r)
+
+	// No endpoint resolver set - AgentURL should be empty
+	descriptors := r.ResolveAgentTools([]string{"summarizer"})
+	require.Len(t, descriptors, 1)
+	assert.Equal(t, "", descriptors[0].A2AConfig.AgentURL)
+}
+
+func TestAgentToolResolver_SetEndpointResolver_NilReceiver(t *testing.T) {
+	var r *AgentToolResolver
+	// Should not panic
+	r.SetEndpointResolver(&StaticEndpointResolver{BaseURL: "http://localhost"})
+}
+
+func TestAgentToolResolver_MemberNames(t *testing.T) {
+	pack := &prompt.Pack{
+		ID:      "test-pack",
+		Version: "1.0.0",
+		Prompts: map[string]*prompt.PackPrompt{
+			"summarizer": {Name: "Summarizer"},
+			"translator": {Name: "Translator"},
+		},
+		Agents: &prompt.AgentsConfig{
+			Entry: "summarizer",
+			Members: map[string]*prompt.AgentDef{
+				"summarizer": {},
+				"translator": {},
+			},
+		},
+	}
+
+	r := NewAgentToolResolver(pack)
+	require.NotNil(t, r)
+
+	names := r.MemberNames()
+	assert.Len(t, names, 2)
+	assert.ElementsMatch(t, []string{"summarizer", "translator"}, names)
+}
+
+func TestAgentToolResolver_MemberNames_NilReceiver(t *testing.T) {
+	var r *AgentToolResolver
+	assert.Nil(t, r.MemberNames())
+}
+
+func TestAgentToolResolver_NonAgentToolsUnaffected(t *testing.T) {
+	// Verify that tool names NOT in agents.members are ignored by the resolver
+	pack := &prompt.Pack{
+		ID:      "test-pack",
+		Version: "1.0.0",
+		Prompts: map[string]*prompt.PackPrompt{
+			"summarizer": {Name: "Summarizer"},
+		},
+		Agents: &prompt.AgentsConfig{
+			Entry: "summarizer",
+			Members: map[string]*prompt.AgentDef{
+				"summarizer": {Description: "Summarizes text"},
+			},
+		},
+	}
+
+	r := NewAgentToolResolver(pack)
+	require.NotNil(t, r)
+
+	// These are regular tools, not agent members
+	assert.False(t, r.IsAgentTool("get_weather"))
+	assert.False(t, r.IsAgentTool("search_docs"))
+
+	// Only agent tools should be resolved
+	descriptors := r.ResolveAgentTools([]string{"get_weather", "search_docs"})
+	assert.Nil(t, descriptors)
+}
+
+func TestPackToRuntimePack(t *testing.T) {
+	// Test the internal conversion from sdk pack to runtime pack
+	sdkPack := &pack.Pack{
+		ID:      "test",
+		Version: "1.0.0",
+		Prompts: map[string]*pack.Prompt{
+			"chat": {
+				Name:        "Chat",
+				Description: "A chat prompt",
+			},
+		},
+		Agents: &pack.AgentsConfig{
+			Entry: "chat",
+			Members: map[string]*pack.AgentDef{
+				"chat": {
+					Description: "Chat agent",
+					Tags:        []string{"chat"},
+					InputModes:  []string{"text/plain"},
+					OutputModes: []string{"text/plain"},
+				},
+			},
+		},
+	}
+
+	rp := packToRuntimePack(sdkPack)
+	require.NotNil(t, rp)
+	assert.Equal(t, "test", rp.ID)
+	assert.Equal(t, "1.0.0", rp.Version)
+
+	require.Contains(t, rp.Prompts, "chat")
+	assert.Equal(t, "Chat", rp.Prompts["chat"].Name)
+
+	require.NotNil(t, rp.Agents)
+	assert.Equal(t, "chat", rp.Agents.Entry)
+	require.Contains(t, rp.Agents.Members, "chat")
+	assert.Equal(t, "Chat agent", rp.Agents.Members["chat"].Description)
+	assert.Equal(t, []string{"chat"}, rp.Agents.Members["chat"].Tags)
 }

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -105,6 +105,9 @@ type Conversation struct {
 	// MCP registry for managing MCP servers
 	mcpRegistry mcp.Registry
 
+	// Multi-agent tool resolver for routing tool calls to agent members
+	agentResolver *AgentToolResolver
+
 	// Eval middleware for dispatching evals after Send/Close
 	evalMW *evalMiddleware
 
@@ -248,6 +251,7 @@ func (c *Conversation) buildPipelineWithParams(
 	c.toolRegistry.RegisterExecutor(localExec)
 	c.registerMCPExecutors()
 	c.registerA2ATools()
+	c.registerAgentTools()
 	toolRegistry := c.toolRegistry
 	c.handlersMu.RUnlock()
 
@@ -317,6 +321,7 @@ func (c *Conversation) buildStreamPipelineWithParams(
 	c.toolRegistry.RegisterExecutor(localExec)
 	c.registerMCPExecutors()
 	c.registerA2ATools()
+	c.registerAgentTools()
 	toolRegistry := c.toolRegistry
 	c.handlersMu.RUnlock()
 

--- a/sdk/internal/pack/validate.go
+++ b/sdk/internal/pack/validate.go
@@ -55,3 +55,105 @@ func ValidateAgainstSchema(data []byte) error {
 
 	return nil
 }
+
+// AgentsValidationError represents an agents section validation error with details.
+type AgentsValidationError struct {
+	Errors []string
+}
+
+func (e *AgentsValidationError) Error() string {
+	if len(e.Errors) == 1 {
+		return fmt.Sprintf("agents validation failed: %s", e.Errors[0])
+	}
+	return fmt.Sprintf("agents validation failed with %d errors: %s",
+		len(e.Errors), e.Errors[0])
+}
+
+// ValidateAgents validates the agents section of a pack.
+// Returns nil if agents is nil (the section is optional) or if validation passes.
+func (p *Pack) ValidateAgents() error {
+	if p.Agents == nil {
+		return nil
+	}
+
+	var errs []string
+
+	errs = append(errs, validateAgentsStructure(p.Agents, p.Prompts)...)
+	errs = append(errs, validateAgentsModes(p.Agents.Members)...)
+
+	if len(errs) > 0 {
+		return &AgentsValidationError{Errors: errs}
+	}
+	return nil
+}
+
+// validateAgentsStructure checks members, entry, and prompt references.
+func validateAgentsStructure(agents *AgentsConfig, prompts map[string]*Prompt) []string {
+	var errs []string
+
+	if len(agents.Members) == 0 {
+		errs = append(errs, "agents.members must be non-empty")
+	}
+
+	if agents.Entry == "" {
+		errs = append(errs, "agents.entry is required")
+	}
+
+	if agents.Entry != "" && len(agents.Members) > 0 {
+		if _, ok := agents.Members[agents.Entry]; !ok {
+			errs = append(errs, fmt.Sprintf(
+				"agents.entry %q does not reference a key in agents.members", agents.Entry))
+		}
+	}
+
+	for key := range agents.Members {
+		if _, ok := prompts[key]; !ok {
+			errs = append(errs, fmt.Sprintf(
+				"agents.members key %q does not reference a valid prompt", key))
+		}
+	}
+
+	return errs
+}
+
+// validateAgentsModes checks input/output MIME type formats for all members.
+func validateAgentsModes(members map[string]*AgentDef) []string {
+	var errs []string
+	for key, def := range members {
+		for _, mode := range def.InputModes {
+			if !isValidMIMEFormat(mode) {
+				errs = append(errs, fmt.Sprintf(
+					"agents.members[%q].input_modes: %q is not a valid MIME type", key, mode))
+			}
+		}
+		for _, mode := range def.OutputModes {
+			if !isValidMIMEFormat(mode) {
+				errs = append(errs, fmt.Sprintf(
+					"agents.members[%q].output_modes: %q is not a valid MIME type", key, mode))
+			}
+		}
+	}
+	return errs
+}
+
+// isValidMIMEFormat checks if a string looks like a valid MIME type (type/subtype).
+// It performs a lightweight format check, not a full registry lookup.
+func isValidMIMEFormat(s string) bool {
+	if s == "" {
+		return false
+	}
+	// Must contain exactly one slash separating non-empty type and subtype
+	slashIdx := -1
+	for i, c := range s {
+		if c == '/' {
+			if slashIdx >= 0 {
+				return false // multiple slashes
+			}
+			slashIdx = i
+		}
+	}
+	if slashIdx <= 0 || slashIdx >= len(s)-1 {
+		return false
+	}
+	return true
+}

--- a/sdk/internal/pack/validate_test.go
+++ b/sdk/internal/pack/validate_test.go
@@ -2,6 +2,9 @@ package pack
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateAgainstSchema_Valid(t *testing.T) {
@@ -100,4 +103,304 @@ func TestLoad_SkipSchemaValidation(t *testing.T) {
 
 	// Skip if running in CI without setup
 	t.Skip("Requires temp file setup - run manually")
+}
+
+// --- Agents validation tests ---
+
+func TestValidateAgents_NilAgents(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{"chat": {ID: "chat"}},
+	}
+	err := p.ValidateAgents()
+	assert.NoError(t, err, "nil agents should pass validation")
+}
+
+func TestValidateAgents_Valid(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{
+			"chat":  {ID: "chat"},
+			"agent": {ID: "agent"},
+		},
+		Agents: &AgentsConfig{
+			Entry: "chat",
+			Members: map[string]*AgentDef{
+				"chat": {
+					Description: "Chat agent",
+					InputModes:  []string{"text/plain"},
+					OutputModes: []string{"text/plain", "application/json"},
+				},
+				"agent": {
+					Description: "Agent",
+					Tags:        []string{"helper"},
+				},
+			},
+		},
+	}
+	err := p.ValidateAgents()
+	assert.NoError(t, err)
+}
+
+func TestValidateAgents_EmptyMembers(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{"chat": {ID: "chat"}},
+		Agents: &AgentsConfig{
+			Entry:   "chat",
+			Members: map[string]*AgentDef{},
+		},
+	}
+	err := p.ValidateAgents()
+	require.Error(t, err)
+
+	agentsErr, ok := err.(*AgentsValidationError)
+	require.True(t, ok)
+	assert.Contains(t, agentsErr.Errors, "agents.members must be non-empty")
+}
+
+func TestValidateAgents_MissingEntry(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{"chat": {ID: "chat"}},
+		Agents: &AgentsConfig{
+			Members: map[string]*AgentDef{
+				"chat": {Description: "Chat agent"},
+			},
+		},
+	}
+	err := p.ValidateAgents()
+	require.Error(t, err)
+
+	agentsErr, ok := err.(*AgentsValidationError)
+	require.True(t, ok)
+	assert.Contains(t, agentsErr.Errors, "agents.entry is required")
+}
+
+func TestValidateAgents_EntryNotInMembers(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{
+			"chat":  {ID: "chat"},
+			"other": {ID: "other"},
+		},
+		Agents: &AgentsConfig{
+			Entry: "other",
+			Members: map[string]*AgentDef{
+				"chat": {Description: "Chat agent"},
+			},
+		},
+	}
+	err := p.ValidateAgents()
+	require.Error(t, err)
+
+	agentsErr, ok := err.(*AgentsValidationError)
+	require.True(t, ok)
+	found := false
+	for _, e := range agentsErr.Errors {
+		if assert.ObjectsAreEqual(e, `agents.entry "other" does not reference a key in agents.members`) {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected entry-not-in-members error, got: %v", agentsErr.Errors)
+}
+
+func TestValidateAgents_MemberNotInPrompts(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{
+			"chat": {ID: "chat"},
+		},
+		Agents: &AgentsConfig{
+			Entry: "chat",
+			Members: map[string]*AgentDef{
+				"chat":    {Description: "Chat agent"},
+				"missing": {Description: "Missing agent"},
+			},
+		},
+	}
+	err := p.ValidateAgents()
+	require.Error(t, err)
+
+	agentsErr, ok := err.(*AgentsValidationError)
+	require.True(t, ok)
+	found := false
+	for _, e := range agentsErr.Errors {
+		if assert.ObjectsAreEqual(e, `agents.members key "missing" does not reference a valid prompt`) {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected member-not-in-prompts error, got: %v", agentsErr.Errors)
+}
+
+func TestValidateAgents_InvalidInputMode(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{
+			"chat": {ID: "chat"},
+		},
+		Agents: &AgentsConfig{
+			Entry: "chat",
+			Members: map[string]*AgentDef{
+				"chat": {
+					InputModes: []string{"not-a-mime"},
+				},
+			},
+		},
+	}
+	err := p.ValidateAgents()
+	require.Error(t, err)
+
+	agentsErr, ok := err.(*AgentsValidationError)
+	require.True(t, ok)
+	found := false
+	for _, e := range agentsErr.Errors {
+		if assert.ObjectsAreEqual(e, `agents.members["chat"].input_modes: "not-a-mime" is not a valid MIME type`) {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected invalid MIME error, got: %v", agentsErr.Errors)
+}
+
+func TestValidateAgents_InvalidOutputMode(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{
+			"chat": {ID: "chat"},
+		},
+		Agents: &AgentsConfig{
+			Entry: "chat",
+			Members: map[string]*AgentDef{
+				"chat": {
+					OutputModes: []string{"plaintext"},
+				},
+			},
+		},
+	}
+	err := p.ValidateAgents()
+	require.Error(t, err)
+
+	agentsErr, ok := err.(*AgentsValidationError)
+	require.True(t, ok)
+	found := false
+	for _, e := range agentsErr.Errors {
+		if assert.ObjectsAreEqual(e, `agents.members["chat"].output_modes: "plaintext" is not a valid MIME type`) {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected invalid MIME error, got: %v", agentsErr.Errors)
+}
+
+func TestValidateAgents_MultipleErrors(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*Prompt{},
+		Agents: &AgentsConfig{
+			// Missing entry
+			Members: map[string]*AgentDef{},
+		},
+	}
+	err := p.ValidateAgents()
+	require.Error(t, err)
+
+	agentsErr, ok := err.(*AgentsValidationError)
+	require.True(t, ok)
+	assert.GreaterOrEqual(t, len(agentsErr.Errors), 2,
+		"expected multiple errors, got: %v", agentsErr.Errors)
+}
+
+func TestAgentsValidationError_Error(t *testing.T) {
+	// Single error
+	err := &AgentsValidationError{Errors: []string{"agents.entry is required"}}
+	assert.Equal(t, "agents validation failed: agents.entry is required", err.Error())
+
+	// Multiple errors
+	err = &AgentsValidationError{Errors: []string{"err1", "err2"}}
+	assert.Contains(t, err.Error(), "2 errors")
+}
+
+func TestIsValidMIMEFormat(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"text/plain", true},
+		{"application/json", true},
+		{"image/png", true},
+		{"text/html; charset=utf-8", true}, // subtype contains extra but still has slash
+		{"plaintext", false},
+		{"", false},
+		{"/plain", false},
+		{"text/", false},
+		{"a/b/c", false}, // multiple slashes
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isValidMIMEFormat(tt.input)
+			assert.Equal(t, tt.want, got, "isValidMIMEFormat(%q)", tt.input)
+		})
+	}
+}
+
+func TestParseWithAgents(t *testing.T) {
+	t.Run("valid agents section", func(t *testing.T) {
+		data := []byte(`{
+			"id": "agent-pack",
+			"prompts": {
+				"chat": {"id": "chat", "system_template": "Hello"},
+				"summarize": {"id": "summarize", "system_template": "Summarize"}
+			},
+			"agents": {
+				"entry": "chat",
+				"members": {
+					"chat": {
+						"description": "Chat agent",
+						"input_modes": ["text/plain"],
+						"output_modes": ["text/plain"]
+					},
+					"summarize": {
+						"description": "Summarize agent"
+					}
+				}
+			}
+		}`)
+
+		p, err := Parse(data)
+		require.NoError(t, err)
+		require.NotNil(t, p.Agents)
+		assert.Equal(t, "chat", p.Agents.Entry)
+		assert.Len(t, p.Agents.Members, 2)
+		assert.Equal(t, "Chat agent", p.Agents.Members["chat"].Description)
+		assert.Equal(t, []string{"text/plain"}, p.Agents.Members["chat"].InputModes)
+	})
+
+	t.Run("agents entry not in members", func(t *testing.T) {
+		data := []byte(`{
+			"id": "bad-pack",
+			"prompts": {
+				"chat": {"id": "chat", "system_template": "Hello"}
+			},
+			"agents": {
+				"entry": "nonexistent",
+				"members": {
+					"chat": {"description": "Chat agent"}
+				}
+			}
+		}`)
+
+		_, err := Parse(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "agents validation failed")
+	})
+
+	t.Run("agents member not in prompts", func(t *testing.T) {
+		data := []byte(`{
+			"id": "bad-pack",
+			"prompts": {
+				"chat": {"id": "chat", "system_template": "Hello"}
+			},
+			"agents": {
+				"entry": "chat",
+				"members": {
+					"chat": {"description": "Chat"},
+					"ghost": {"description": "Ghost agent"}
+				}
+			}
+		}`)
+
+		_, err := Parse(data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "agents validation failed")
+	})
 }

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -109,6 +109,9 @@ type config struct {
 	// When set, the provider will request responses in the specified format
 	responseFormat *providers.ResponseFormat
 
+	// Multi-agent endpoint resolution
+	agentEndpointResolver EndpointResolver
+
 	// Eval configuration
 	evalDispatcher    evals.EvalDispatcher
 	evalRegistry      *evals.EvalTypeRegistry
@@ -684,6 +687,37 @@ func WithMCPServer(builder *MCPServerBuilder) Option {
 func WithA2ATools(bridge *a2a.ToolBridge) Option {
 	return func(c *config) error {
 		c.a2aBridge = bridge
+		return nil
+	}
+}
+
+// WithAgentEndpoints configures endpoint resolution for multi-agent tool routing.
+//
+// When a pack has an agents section, prompts can reference other agent members
+// as tools. This option tells the SDK how to resolve agent names to A2A
+// endpoint URLs so that tool calls are routed to the correct agent.
+//
+// Example with a single gateway:
+//
+//	conv, _ := sdk.Open("./multiagent.pack.json", "orchestrator",
+//	    sdk.WithAgentEndpoints(&sdk.StaticEndpointResolver{
+//	        BaseURL: "http://localhost:9000",
+//	    }),
+//	)
+//
+// Example with per-agent endpoints:
+//
+//	conv, _ := sdk.Open("./multiagent.pack.json", "orchestrator",
+//	    sdk.WithAgentEndpoints(&sdk.MapEndpointResolver{
+//	        Endpoints: map[string]string{
+//	            "summarizer": "http://summarizer:9001",
+//	            "translator": "http://translator:9002",
+//	        },
+//	    }),
+//	)
+func WithAgentEndpoints(resolver EndpointResolver) Option {
+	return func(c *config) error {
+		c.agentEndpointResolver = resolver
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

- Add `ValidateAgents()` to runtime Pack with checks for member references, entry point, prompt existence, and MIME format validation
- Add mirrored `AgentsConfig`/`AgentDef` types to SDK internal pack with full validation wired into `Parse()`
- Enhance `AgentToolResolver` with `EndpointResolver` interface (Static and Map variants), input/output JSON schemas, and `MemberNames()` for discovery
- Add `WithAgentEndpoints()` SDK option and wire agent resolver into `Conversation` for automatic agent tool registration
- Add `packToRuntimePack()` helper for SDK-to-runtime pack conversion

## Test plan

- [x] Runtime `ValidateAgents()` — 8 test cases covering nil agents, empty members, invalid entry, missing prompts, invalid MIME modes, empty tags
- [x] SDK `ValidateAgents()` — 14 test functions covering all validation rules plus MIME format helper
- [x] `AgentToolResolver` — 16 tests covering endpoint resolvers, schemas, member names, nil safety, pack conversion
- [x] All pre-commit checks pass (linting, building, coverage ≥80%)

Closes #375, closes #376, closes #377