### PR TITLE
feat: RFC007 multi-agent orchestration, arena assertions, and deploy helpers

### DIFF
--- a/runtime/deploy/adaptersdk/agents.go
+++ b/runtime/deploy/adaptersdk/agents.go
@@ -1,0 +1,126 @@
+package adaptersdk
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt/agentcard"
+)
+
+// AgentInfo provides a simplified view of an agent member for deploy adapters.
+type AgentInfo struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	IsEntry     bool     `json:"is_entry"`
+	Tags        []string `json:"tags,omitempty"`
+	InputModes  []string `json:"input_modes"`
+	OutputModes []string `json:"output_modes"`
+}
+
+// IsMultiAgent returns true if the pack has an agents section with members.
+func IsMultiAgent(pack *prompt.Pack) bool {
+	return pack.Agents != nil && len(pack.Agents.Members) > 0
+}
+
+// ExtractAgents returns agent info for all members in the pack's agents section.
+// Returns nil if the pack is not multi-agent.
+// Defaults: text/plain for missing input/output modes, description falls back
+// to the corresponding prompt description.
+func ExtractAgents(pack *prompt.Pack) []AgentInfo {
+	if !IsMultiAgent(pack) {
+		return nil
+	}
+
+	agents := make([]AgentInfo, 0, len(pack.Agents.Members))
+
+	for name, def := range pack.Agents.Members {
+		info := AgentInfo{
+			Name:    name,
+			IsEntry: name == pack.Agents.Entry,
+			Tags:    def.Tags,
+		}
+
+		// Description: prefer agent def, fall back to prompt description.
+		info.Description = def.Description
+		if info.Description == "" {
+			if p, ok := pack.Prompts[name]; ok && p != nil {
+				info.Description = p.Description
+			}
+		}
+
+		// Default modes to text/plain when not specified.
+		info.InputModes = defaultModes(def.InputModes)
+		info.OutputModes = defaultModes(def.OutputModes)
+
+		agents = append(agents, info)
+	}
+
+	// Sort by name for deterministic output.
+	sort.Slice(agents, func(i, j int) bool {
+		return agents[i].Name < agents[j].Name
+	})
+
+	return agents
+}
+
+// GenerateAgentCards re-exports agentcard.GenerateAgentCards for adapter convenience.
+func GenerateAgentCards(pack *prompt.Pack) map[string]*a2a.AgentCard {
+	return agentcard.GenerateAgentCards(pack)
+}
+
+// GenerateAgentResourcePlan creates resource changes for deploying a multi-agent pack.
+// For each member it emits an agent_runtime and a2a_endpoint resource.
+// For the entry agent it also emits a gateway resource.
+// Returns nil if the pack is not multi-agent.
+func GenerateAgentResourcePlan(pack *prompt.Pack) []deploy.ResourceChange {
+	if !IsMultiAgent(pack) {
+		return nil
+	}
+
+	// Collect sorted member names for deterministic output.
+	names := make([]string, 0, len(pack.Agents.Members))
+	for name := range pack.Agents.Members {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var changes []deploy.ResourceChange
+
+	for _, name := range names {
+		changes = append(changes,
+			deploy.ResourceChange{
+				Type:   "agent_runtime",
+				Name:   name,
+				Action: deploy.ActionCreate,
+				Detail: fmt.Sprintf("Create agent runtime for %s", name),
+			},
+			deploy.ResourceChange{
+				Type:   "a2a_endpoint",
+				Name:   name + "_endpoint",
+				Action: deploy.ActionCreate,
+				Detail: fmt.Sprintf("Create A2A endpoint for %s", name),
+			},
+		)
+	}
+
+	// Gateway for the entry agent.
+	changes = append(changes, deploy.ResourceChange{
+		Type:   "gateway",
+		Name:   pack.Agents.Entry + "_gateway",
+		Action: deploy.ActionCreate,
+		Detail: fmt.Sprintf("Create gateway for entry agent %s", pack.Agents.Entry),
+	})
+
+	return changes
+}
+
+// defaultModes returns the given modes or a default of ["text/plain"] when empty.
+func defaultModes(modes []string) []string {
+	if len(modes) > 0 {
+		return modes
+	}
+	return []string{"text/plain"}
+}

--- a/runtime/deploy/adaptersdk/agents_test.go
+++ b/runtime/deploy/adaptersdk/agents_test.go
@@ -1,0 +1,255 @@
+package adaptersdk
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+)
+
+// multiAgentPack returns a two-member pack used across several tests.
+func multiAgentPack() *prompt.Pack {
+	return &prompt.Pack{
+		ID:      "test-pack",
+		Version: "v1.0.0",
+		Prompts: map[string]*prompt.PackPrompt{
+			"router": {
+				ID:          "router",
+				Name:        "Router",
+				Description: "Routes requests",
+			},
+			"worker": {
+				ID:          "worker",
+				Name:        "Worker",
+				Description: "Processes tasks",
+			},
+		},
+		Agents: &prompt.AgentsConfig{
+			Entry: "router",
+			Members: map[string]*prompt.AgentDef{
+				"router": {
+					Description: "Entry router agent",
+					Tags:        []string{"routing"},
+					InputModes:  []string{"text/plain", "application/json"},
+					OutputModes: []string{"text/plain"},
+				},
+				"worker": {
+					Tags: []string{"processing"},
+				},
+			},
+		},
+	}
+}
+
+func TestIsMultiAgent(t *testing.T) {
+	tests := []struct {
+		name string
+		pack *prompt.Pack
+		want bool
+	}{
+		{
+			name: "nil agents",
+			pack: &prompt.Pack{},
+			want: false,
+		},
+		{
+			name: "empty members",
+			pack: &prompt.Pack{
+				Agents: &prompt.AgentsConfig{
+					Members: map[string]*prompt.AgentDef{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "valid agents",
+			pack: multiAgentPack(),
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsMultiAgent(tc.pack)
+			if got != tc.want {
+				t.Errorf("IsMultiAgent() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractAgents(t *testing.T) {
+	t.Run("nil when not multi-agent", func(t *testing.T) {
+		pack := &prompt.Pack{}
+		agents := ExtractAgents(pack)
+		if agents != nil {
+			t.Fatalf("expected nil, got %v", agents)
+		}
+	})
+
+	t.Run("sorted output with correct fields", func(t *testing.T) {
+		pack := multiAgentPack()
+		agents := ExtractAgents(pack)
+
+		if len(agents) != 2 {
+			t.Fatalf("expected 2 agents, got %d", len(agents))
+		}
+
+		// Sorted alphabetically: router, worker
+		if agents[0].Name != "router" {
+			t.Errorf("expected first agent name 'router', got %q", agents[0].Name)
+		}
+		if agents[1].Name != "worker" {
+			t.Errorf("expected second agent name 'worker', got %q", agents[1].Name)
+		}
+	})
+
+	t.Run("entry agent marked correctly", func(t *testing.T) {
+		pack := multiAgentPack()
+		agents := ExtractAgents(pack)
+
+		for _, a := range agents {
+			if a.Name == "router" && !a.IsEntry {
+				t.Error("router should be marked as entry")
+			}
+			if a.Name == "worker" && a.IsEntry {
+				t.Error("worker should not be marked as entry")
+			}
+		}
+	})
+
+	t.Run("description falls back to prompt", func(t *testing.T) {
+		pack := multiAgentPack()
+		agents := ExtractAgents(pack)
+
+		// worker has no agent-level description; should fall back to prompt description.
+		for _, a := range agents {
+			if a.Name == "worker" {
+				if a.Description != "Processes tasks" {
+					t.Errorf("expected fallback description 'Processes tasks', got %q", a.Description)
+				}
+			}
+			if a.Name == "router" {
+				if a.Description != "Entry router agent" {
+					t.Errorf("expected agent description 'Entry router agent', got %q", a.Description)
+				}
+			}
+		}
+	})
+
+	t.Run("default modes applied when empty", func(t *testing.T) {
+		pack := multiAgentPack()
+		agents := ExtractAgents(pack)
+
+		for _, a := range agents {
+			if a.Name == "router" {
+				if len(a.InputModes) != 2 || a.InputModes[0] != "text/plain" {
+					t.Errorf("router input modes incorrect: %v", a.InputModes)
+				}
+			}
+			if a.Name == "worker" {
+				// Worker has no modes defined; should default to text/plain.
+				if len(a.InputModes) != 1 || a.InputModes[0] != "text/plain" {
+					t.Errorf("worker input modes should default to [text/plain], got %v", a.InputModes)
+				}
+				if len(a.OutputModes) != 1 || a.OutputModes[0] != "text/plain" {
+					t.Errorf("worker output modes should default to [text/plain], got %v", a.OutputModes)
+				}
+			}
+		}
+	})
+}
+
+func TestGenerateAgentCards(t *testing.T) {
+	t.Run("delegates to agentcard package", func(t *testing.T) {
+		pack := multiAgentPack()
+		cards := GenerateAgentCards(pack)
+
+		if cards == nil {
+			t.Fatal("expected non-nil cards")
+		}
+		if len(cards) != 2 {
+			t.Fatalf("expected 2 cards, got %d", len(cards))
+		}
+		if cards["router"] == nil {
+			t.Error("expected card for 'router'")
+		}
+		if cards["worker"] == nil {
+			t.Error("expected card for 'worker'")
+		}
+	})
+
+	t.Run("nil for non-multi-agent pack", func(t *testing.T) {
+		pack := &prompt.Pack{}
+		cards := GenerateAgentCards(pack)
+		if cards != nil {
+			t.Errorf("expected nil cards, got %v", cards)
+		}
+	})
+}
+
+func TestGenerateAgentResourcePlan(t *testing.T) {
+	t.Run("nil for non-multi-agent pack", func(t *testing.T) {
+		pack := &prompt.Pack{}
+		changes := GenerateAgentResourcePlan(pack)
+		if changes != nil {
+			t.Errorf("expected nil, got %v", changes)
+		}
+	})
+
+	t.Run("correct resources for multi-agent pack", func(t *testing.T) {
+		pack := multiAgentPack()
+		changes := GenerateAgentResourcePlan(pack)
+
+		// 2 members * 2 resources each + 1 gateway = 5
+		if len(changes) != 5 {
+			t.Fatalf("expected 5 resource changes, got %d", len(changes))
+		}
+
+		// Count resource types.
+		typeCounts := map[string]int{}
+		for _, c := range changes {
+			typeCounts[c.Type]++
+		}
+
+		if typeCounts["agent_runtime"] != 2 {
+			t.Errorf("expected 2 agent_runtime resources, got %d", typeCounts["agent_runtime"])
+		}
+		if typeCounts["a2a_endpoint"] != 2 {
+			t.Errorf("expected 2 a2a_endpoint resources, got %d", typeCounts["a2a_endpoint"])
+		}
+		if typeCounts["gateway"] != 1 {
+			t.Errorf("expected 1 gateway resource, got %d", typeCounts["gateway"])
+		}
+
+		// All actions should be CREATE.
+		for _, c := range changes {
+			if c.Action != deploy.ActionCreate {
+				t.Errorf("expected ActionCreate for %s/%s, got %s", c.Type, c.Name, c.Action)
+			}
+		}
+
+		// Gateway should be for the entry agent.
+		gateway := changes[len(changes)-1]
+		if gateway.Name != "router_gateway" {
+			t.Errorf("expected gateway name 'router_gateway', got %q", gateway.Name)
+		}
+	})
+
+	t.Run("deterministic ordering by name", func(t *testing.T) {
+		pack := multiAgentPack()
+
+		// Run multiple times to verify determinism.
+		for i := range 5 {
+			changes := GenerateAgentResourcePlan(pack)
+
+			// First two should be router resources (alphabetically before worker).
+			if changes[0].Name != "router" {
+				t.Errorf("iteration %d: expected first resource for 'router', got %q", i, changes[0].Name)
+			}
+			if changes[2].Name != "worker" {
+				t.Errorf("iteration %d: expected third resource for 'worker', got %q", i, changes[2].Name)
+			}
+		}
+	})
+}

--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -405,7 +405,11 @@ func (c *Conversation) registerAgentTools() {
 	}
 	// Ensure the A2A executor is registered so the registry can dispatch
 	// tool calls with Mode "a2a".
-	c.toolRegistry.RegisterExecutor(newA2AExecutor())
+	if c.config.localAgentExecutor != nil {
+		c.toolRegistry.RegisterExecutor(c.config.localAgentExecutor)
+	} else {
+		c.toolRegistry.RegisterExecutor(newA2AExecutor())
+	}
 }
 
 // registerMCPExecutors registers executors for MCP tools.

--- a/sdk/local_agent_executor.go
+++ b/sdk/local_agent_executor.go
@@ -1,0 +1,17 @@
+package sdk
+
+// LocalAgentExecutor routes A2A tool calls to in-process Conversations
+// instead of making remote HTTP calls. It implements tools.Executor.
+type LocalAgentExecutor struct {
+	members map[string]*Conversation
+}
+
+// NewLocalAgentExecutor creates an executor that routes tool calls to local conversations.
+func NewLocalAgentExecutor(members map[string]*Conversation) *LocalAgentExecutor {
+	return &LocalAgentExecutor{members: members}
+}
+
+// Name returns the executor name. Must be "a2a" to intercept A2A tool dispatches.
+func (e *LocalAgentExecutor) Name() string {
+	return "a2a"
+}

--- a/sdk/local_agent_executor_integration.go
+++ b/sdk/local_agent_executor_integration.go
@@ -1,0 +1,40 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// Execute routes a tool call to the corresponding member conversation.
+// It parses {"query":"..."} from args, calls member.Send(), and returns {"response":"..."}.
+func (e *LocalAgentExecutor) Execute(
+	descriptor *tools.ToolDescriptor,
+	args json.RawMessage,
+) (json.RawMessage, error) {
+	// Parse query from args
+	var input struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal(args, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse agent tool args: %w", err)
+	}
+
+	// Find the member conversation by tool name (which is the agent name)
+	conv, ok := e.members[descriptor.Name]
+	if !ok {
+		return nil, fmt.Errorf("unknown agent member: %s", descriptor.Name)
+	}
+
+	// Send the query to the member conversation
+	resp, err := conv.Send(context.Background(), input.Query)
+	if err != nil {
+		return nil, fmt.Errorf("agent %s failed: %w", descriptor.Name, err)
+	}
+
+	// Return the response
+	result := map[string]string{"response": resp.Text()}
+	return json.Marshal(result)
+}

--- a/sdk/local_agent_executor_test.go
+++ b/sdk/local_agent_executor_test.go
@@ -1,0 +1,39 @@
+package sdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalAgentExecutor_Name(t *testing.T) {
+	exec := NewLocalAgentExecutor(nil)
+	assert.Equal(t, "a2a", exec.Name())
+}
+
+func TestLocalAgentExecutor_Execute_UnknownMember(t *testing.T) {
+	exec := NewLocalAgentExecutor(map[string]*Conversation{})
+
+	desc := &tools.ToolDescriptor{Name: "nonexistent"}
+	args := json.RawMessage(`{"query":"hello"}`)
+
+	_, err := exec.Execute(desc, args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown agent member: nonexistent")
+}
+
+func TestLocalAgentExecutor_Execute_InvalidArgs(t *testing.T) {
+	exec := NewLocalAgentExecutor(map[string]*Conversation{
+		"agent1": {},
+	})
+
+	desc := &tools.ToolDescriptor{Name: "agent1"}
+	args := json.RawMessage(`{invalid json`)
+
+	_, err := exec.Execute(desc, args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse agent tool args")
+}

--- a/sdk/multi_agent.go
+++ b/sdk/multi_agent.go
@@ -1,0 +1,32 @@
+package sdk
+
+// MultiAgentSession manages a set of agent member conversations orchestrated
+// through an entry conversation. Tool calls from the entry agent to member
+// agents are routed in-process via LocalAgentExecutor.
+type MultiAgentSession struct {
+	entry   *Conversation
+	members map[string]*Conversation
+}
+
+// Entry returns the entry conversation.
+func (s *MultiAgentSession) Entry() *Conversation {
+	return s.entry
+}
+
+// Members returns the member conversations (excluding entry).
+func (s *MultiAgentSession) Members() map[string]*Conversation {
+	result := make(map[string]*Conversation, len(s.members))
+	for k, v := range s.members {
+		result[k] = v
+	}
+	return result
+}
+
+// Close closes all conversations (entry and members).
+func (s *MultiAgentSession) Close() error {
+	_ = s.entry.Close()
+	for _, c := range s.members {
+		_ = c.Close()
+	}
+	return nil
+}

--- a/sdk/multi_agent_integration.go
+++ b/sdk/multi_agent_integration.go
@@ -1,0 +1,113 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
+)
+
+// OpenMultiAgent loads a multi-agent pack and creates conversations for all
+// members and the entry agent. Agent-to-agent tool calls from the entry
+// conversation are routed in-process via LocalAgentExecutor.
+//
+// The pack must have an agents section with entry and members defined.
+// Options are applied to all conversations (entry and members).
+func OpenMultiAgent(packPath string, opts ...Option) (*MultiAgentSession, error) {
+	p, err := loadMultiAgentPack(packPath, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	members, err := openMembers(packPath, p, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	entry, err := openEntryAgent(packPath, p.Agents.Entry, members, opts)
+	if err != nil {
+		closeAll(members)
+		return nil, fmt.Errorf("failed to open entry agent %q: %w", p.Agents.Entry, err)
+	}
+
+	return &MultiAgentSession{entry: entry, members: members}, nil
+}
+
+// Send sends a message through the entry agent.
+func (s *MultiAgentSession) Send(
+	ctx context.Context,
+	message any,
+	opts ...SendOption,
+) (*Response, error) {
+	return s.entry.Send(ctx, message, opts...)
+}
+
+// loadMultiAgentPack resolves, loads, and validates a multi-agent pack.
+func loadMultiAgentPack(packPath string, opts []Option) (*pack.Pack, error) {
+	absPath, err := resolvePackPath(packPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve pack path: %w", err)
+	}
+
+	baseCfg, err := applyOptions("", opts)
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := pack.Load(absPath, pack.LoadOptions{
+		SkipSchemaValidation: baseCfg.skipSchemaValidation,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load pack: %w", err)
+	}
+
+	if p.Agents == nil || len(p.Agents.Members) == 0 {
+		return nil, fmt.Errorf("pack has no agents section")
+	}
+	if p.Agents.Entry == "" {
+		return nil, fmt.Errorf("pack agents section has no entry defined")
+	}
+
+	return p, nil
+}
+
+// openMembers opens conversations for all non-entry agent members.
+func openMembers(
+	packPath string,
+	p *pack.Pack,
+	opts []Option,
+) (map[string]*Conversation, error) {
+	members := make(map[string]*Conversation)
+	for name := range p.Agents.Members {
+		if name == p.Agents.Entry {
+			continue
+		}
+		conv, err := Open(packPath, name, opts...)
+		if err != nil {
+			closeAll(members)
+			return nil, fmt.Errorf("failed to open member agent %q: %w", name, err)
+		}
+		members[name] = conv
+	}
+	return members, nil
+}
+
+// openEntryAgent opens the entry conversation with a local agent executor.
+func openEntryAgent(
+	packPath, entryName string,
+	members map[string]*Conversation,
+	opts []Option,
+) (*Conversation, error) {
+	localExec := NewLocalAgentExecutor(members)
+	entryOpts := make([]Option, len(opts))
+	copy(entryOpts, opts)
+	entryOpts = append(entryOpts, withLocalAgentExecutor(localExec))
+	return Open(packPath, entryName, entryOpts...)
+}
+
+// closeAll closes all conversations in the map, ignoring errors.
+func closeAll(convs map[string]*Conversation) {
+	for _, c := range convs {
+		_ = c.Close()
+	}
+}

--- a/sdk/multi_agent_test.go
+++ b/sdk/multi_agent_test.go
@@ -1,0 +1,112 @@
+package sdk
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenMultiAgent_NonExistentPack(t *testing.T) {
+	_, err := OpenMultiAgent("/nonexistent/path/to/pack.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve pack path")
+}
+
+func TestOpenMultiAgent_NoAgentsSection(t *testing.T) {
+	// Create a minimal pack file without agents section
+	packPath := createTestPackFile(t, `{
+		"schema_version": "2025.1",
+		"id": "test-pack",
+		"version": "1.0.0",
+		"prompts": {
+			"chat": {
+				"name": "chat",
+				"messages": [{"role": "system", "content": "You are helpful."}]
+			}
+		}
+	}`)
+
+	_, err := OpenMultiAgent(packPath, WithSkipSchemaValidation())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pack has no agents section")
+}
+
+func TestOpenMultiAgent_NoEntryDefined(t *testing.T) {
+	packPath := createTestPackFile(t, `{
+		"schema_version": "2025.1",
+		"id": "test-pack",
+		"version": "1.0.0",
+		"prompts": {
+			"chat": {
+				"name": "chat",
+				"messages": [{"role": "system", "content": "You are helpful."}]
+			}
+		},
+		"agents": {
+			"entry": "",
+			"members": {
+				"chat": {
+					"description": "A chat agent"
+				}
+			}
+		}
+	}`)
+
+	_, err := OpenMultiAgent(packPath, WithSkipSchemaValidation())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entry is required")
+}
+
+func TestMultiAgentSession_Close_NilMembers(t *testing.T) {
+	// Test that Close handles empty members map gracefully
+	session := &MultiAgentSession{
+		entry:   &Conversation{config: &config{}},
+		members: map[string]*Conversation{},
+	}
+	// Close on a zero-value Conversation will just set closed=true
+	err := session.Close()
+	assert.NoError(t, err)
+}
+
+func TestMultiAgentSession_Members_ReturnsCopy(t *testing.T) {
+	conv1 := &Conversation{config: &config{}}
+	conv2 := &Conversation{config: &config{}}
+	session := &MultiAgentSession{
+		entry: &Conversation{config: &config{}},
+		members: map[string]*Conversation{
+			"a": conv1,
+			"b": conv2,
+		},
+	}
+
+	members := session.Members()
+	assert.Len(t, members, 2)
+	assert.Equal(t, conv1, members["a"])
+	assert.Equal(t, conv2, members["b"])
+
+	// Mutating the returned map should not affect the session
+	delete(members, "a")
+	assert.Len(t, session.members, 2)
+}
+
+func TestMultiAgentSession_Entry(t *testing.T) {
+	entry := &Conversation{config: &config{}}
+	session := &MultiAgentSession{
+		entry:   entry,
+		members: map[string]*Conversation{},
+	}
+	assert.Equal(t, entry, session.Entry())
+}
+
+// createTestPackFile creates a temporary pack JSON file for testing.
+func createTestPackFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.pack.json")
+	err := os.WriteFile(path, []byte(content), 0644)
+	require.NoError(t, err, "failed to create test pack file")
+	return path
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -112,6 +112,9 @@ type config struct {
 	// Multi-agent endpoint resolution
 	agentEndpointResolver EndpointResolver
 
+	// Local agent executor for in-process multi-agent routing
+	localAgentExecutor *LocalAgentExecutor
+
 	// Eval configuration
 	evalDispatcher    evals.EvalDispatcher
 	evalRegistry      *evals.EvalTypeRegistry
@@ -718,6 +721,15 @@ func WithA2ATools(bridge *a2a.ToolBridge) Option {
 func WithAgentEndpoints(resolver EndpointResolver) Option {
 	return func(c *config) error {
 		c.agentEndpointResolver = resolver
+		return nil
+	}
+}
+
+// withLocalAgentExecutor sets a local agent executor for in-process routing.
+// This is unexported because it's only used internally by OpenMultiAgent.
+func withLocalAgentExecutor(exec *LocalAgentExecutor) Option {
+	return func(c *config) error {
+		c.localAgentExecutor = exec
 		return nil
 	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,7 +32,8 @@ sonar.coverage.exclusions=**/examples/**,**/*example*/**,**/tools/arena/cmd/prom
 # GitHub Actions runner files have similar patterns across actions
 # Provider tool/streaming implementations share interface-mandated patterns
 # Persistence repository implementations share interface-mandated patterns (JSON/YAML/memory)
-sonar.cpd.exclusions=**/runtime/pipeline/stage/stages_video_frames.go,**/runtime/pipeline/stage/stages_media_compose.go,**/npm/**/lib/installer.js,**/npm/**/postinstall.js,**/runtime/providers/openai/openai_tools.go,**/runtime/providers/claude/claude_tools.go,**/runtime/providers/gemini/gemini_tools.go,**/runtime/providers/claude/claude_streaming.go,**/runtime/providers/gemini/gemini_streaming.go,**/.github/actions/**/src/runner.ts,**/runtime/persistence/yaml/yaml_tool.go,**/runtime/persistence/json/json.go
+# Arena assertion validators share interface-mandated patterns (turn + conversation level)
+sonar.cpd.exclusions=**/runtime/pipeline/stage/stages_video_frames.go,**/runtime/pipeline/stage/stages_media_compose.go,**/npm/**/lib/installer.js,**/npm/**/postinstall.js,**/runtime/providers/openai/openai_tools.go,**/runtime/providers/claude/claude_tools.go,**/runtime/providers/gemini/gemini_tools.go,**/runtime/providers/claude/claude_streaming.go,**/runtime/providers/gemini/gemini_streaming.go,**/.github/actions/**/src/runner.ts,**/runtime/persistence/yaml/yaml_tool.go,**/runtime/persistence/json/json.go,**/tools/arena/assertions/agent_*.go,**/tools/arena/assertions/tools_*.go
 
 # Function-level coverage exclusions using patterns
 # Exclude untestable interactive I/O functions in init.go (require terminal stdin/stdout)

--- a/tools/arena/assertions/agent_invoked.go
+++ b/tools/arena/assertions/agent_invoked.go
@@ -1,0 +1,37 @@
+// Package assertions provides turn-level and conversation-level validators
+// for Arena test scenarios.
+package assertions
+
+import (
+	runtimeValidators "github.com/AltairaLabs/PromptKit/runtime/validators"
+)
+
+// AgentInvokedValidator checks that expected agents were invoked as tools in the response.
+// In multi-agent packs, agent invocations appear as tool calls where the tool name
+// matches the agent member name.
+// Params: agents: []string - list of agent names that should have been called.
+type AgentInvokedValidator struct {
+	expectedAgents []string
+}
+
+// NewAgentInvokedValidator creates a new agent_invoked validator from params.
+func NewAgentInvokedValidator(params map[string]interface{}) runtimeValidators.Validator {
+	agents := extractStringSlice(params, "agents")
+	return &AgentInvokedValidator{expectedAgents: agents}
+}
+
+// Validate checks if expected agents were invoked as tool calls.
+func (v *AgentInvokedValidator) Validate(
+	content string,
+	params map[string]interface{},
+) runtimeValidators.ValidationResult {
+	toolCalls := resolveToolCalls(params)
+	missing := findMissing(toolCalls, v.expectedAgents)
+
+	return runtimeValidators.ValidationResult{
+		Passed: len(missing) == 0,
+		Details: map[string]interface{}{
+			"missing_agents": missing,
+		},
+	}
+}

--- a/tools/arena/assertions/agent_invoked_conversation.go
+++ b/tools/arena/assertions/agent_invoked_conversation.go
@@ -1,0 +1,80 @@
+package assertions
+
+import (
+	"context"
+	"strings"
+)
+
+// AgentInvokedConversationValidator checks that specific agents were invoked
+// at least a minimum number of times across the full conversation.
+// In multi-agent packs, agent invocations appear as tool calls where the tool name
+// matches the agent member name.
+// Params:
+//   - agent_names: []string required agent names
+//   - min_calls: int optional (default 1) minimum calls per agent
+//
+// Type: "agent_invoked"
+type AgentInvokedConversationValidator struct{}
+
+// Type returns the validator type name.
+func (v *AgentInvokedConversationValidator) Type() string { return "agent_invoked" }
+
+// NewAgentInvokedConversationValidator constructs a conversation-level agent_invoked validator.
+func NewAgentInvokedConversationValidator() ConversationValidator {
+	return &AgentInvokedConversationValidator{}
+}
+
+// ValidateConversation evaluates whether all required agents were invoked
+// at least the minimum number of times across the conversation.
+func (v *AgentInvokedConversationValidator) ValidateConversation(
+	ctx context.Context,
+	convCtx *ConversationContext,
+	params map[string]interface{},
+) ConversationValidationResult {
+	// Extract params
+	required := extractStringSlice(params, "agent_names")
+	minCalls := 1
+	if m, ok := params["min_calls"].(int); ok && m > 0 {
+		minCalls = m
+	}
+
+	// Count calls by tool name (agent invocations are tool calls)
+	counts := make(map[string]int)
+	for _, tc := range convCtx.ToolCalls {
+		counts[tc.ToolName]++
+	}
+
+	// Find missing agents w.r.t minCalls
+	var missing []string
+	requirements := make([]map[string]interface{}, 0, len(required))
+	for _, name := range required {
+		requirements = append(requirements, map[string]interface{}{
+			"agent":         name,
+			"calls":         counts[name],
+			"requiredCalls": minCalls,
+		})
+		if counts[name] < minCalls {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return ConversationValidationResult{
+			Passed:  false,
+			Message: "missing required agent invocations: " + strings.Join(missing, ", "),
+			Details: map[string]interface{}{
+				"requirements": requirements,
+				"counts":       counts,
+			},
+		}
+	}
+
+	return ConversationValidationResult{
+		Passed:  true,
+		Message: "all required agents were invoked",
+		Details: map[string]interface{}{
+			"requirements": requirements,
+			"counts":       counts,
+		},
+	}
+}

--- a/tools/arena/assertions/agent_invoked_conversation_test.go
+++ b/tools/arena/assertions/agent_invoked_conversation_test.go
@@ -1,0 +1,101 @@
+package assertions
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAgentInvokedConversationValidator(t *testing.T) {
+	v := NewAgentInvokedConversationValidator()
+	ctx := context.Background()
+
+	conv := &ConversationContext{
+		ToolCalls: []ToolCallRecord{
+			{TurnIndex: 1, ToolName: "researcher"},
+			{TurnIndex: 2, ToolName: "writer"},
+			{TurnIndex: 3, ToolName: "researcher"},
+		},
+	}
+
+	// All required agents present
+	params := map[string]interface{}{
+		"agent_names": []string{"researcher", "writer"},
+		"min_calls":   1,
+	}
+	res := v.ValidateConversation(ctx, conv, params)
+	if !res.Passed {
+		t.Fatalf("expected pass, got: %+v", res)
+	}
+
+	// Require at least 2 calls to researcher
+	params2 := map[string]interface{}{
+		"agent_names": []string{"researcher"},
+		"min_calls":   2,
+	}
+	res2 := v.ValidateConversation(ctx, conv, params2)
+	if !res2.Passed {
+		t.Fatalf("expected pass for min_calls=2, got: %+v", res2)
+	}
+
+	// Missing agent
+	params3 := map[string]interface{}{
+		"agent_names": []string{"editor"},
+	}
+	res3 := v.ValidateConversation(ctx, conv, params3)
+	if res3.Passed {
+		t.Fatalf("expected fail when required agent missing")
+	}
+
+	// min_calls not met
+	params4 := map[string]interface{}{
+		"agent_names": []string{"writer"},
+		"min_calls":   3,
+	}
+	res4 := v.ValidateConversation(ctx, conv, params4)
+	if res4.Passed {
+		t.Fatalf("expected fail when min_calls not met")
+	}
+}
+
+func TestAgentInvokedConversationValidator_Type(t *testing.T) {
+	v := NewAgentInvokedConversationValidator()
+	if v.Type() != "agent_invoked" {
+		t.Errorf("Type() = %q, want %q", v.Type(), "agent_invoked")
+	}
+}
+
+func TestAgentInvokedConversationValidator_EmptyConversation(t *testing.T) {
+	v := NewAgentInvokedConversationValidator()
+	ctx := context.Background()
+
+	conv := &ConversationContext{
+		ToolCalls: []ToolCallRecord{},
+	}
+
+	params := map[string]interface{}{
+		"agent_names": []string{"researcher"},
+	}
+	res := v.ValidateConversation(ctx, conv, params)
+	if res.Passed {
+		t.Fatalf("expected fail with empty conversation, got pass")
+	}
+}
+
+func TestAgentInvokedConversationValidator_NoRequiredAgents(t *testing.T) {
+	v := NewAgentInvokedConversationValidator()
+	ctx := context.Background()
+
+	conv := &ConversationContext{
+		ToolCalls: []ToolCallRecord{
+			{TurnIndex: 0, ToolName: "researcher"},
+		},
+	}
+
+	params := map[string]interface{}{
+		"agent_names": []string{},
+	}
+	res := v.ValidateConversation(ctx, conv, params)
+	if !res.Passed {
+		t.Fatalf("expected pass with no required agents, got fail")
+	}
+}

--- a/tools/arena/assertions/agent_invoked_test.go
+++ b/tools/arena/assertions/agent_invoked_test.go
@@ -1,0 +1,185 @@
+package assertions
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestAgentInvokedValidator(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedAgents []string
+		actualCalls    []types.MessageToolCall
+		wantPassed     bool
+		wantMissing    []string
+	}{
+		{
+			name:           "All expected agents invoked",
+			expectedAgents: []string{"researcher", "writer"},
+			actualCalls: []types.MessageToolCall{
+				{Name: "researcher"},
+				{Name: "writer"},
+			},
+			wantPassed:  true,
+			wantMissing: nil,
+		},
+		{
+			name:           "Missing one agent",
+			expectedAgents: []string{"researcher", "writer"},
+			actualCalls: []types.MessageToolCall{
+				{Name: "researcher"},
+			},
+			wantPassed:  false,
+			wantMissing: []string{"writer"},
+		},
+		{
+			name:           "Missing all agents",
+			expectedAgents: []string{"researcher", "writer"},
+			actualCalls:    []types.MessageToolCall{},
+			wantPassed:     false,
+			wantMissing:    []string{"researcher", "writer"},
+		},
+		{
+			name:           "Extra agents invoked is OK",
+			expectedAgents: []string{"researcher"},
+			actualCalls: []types.MessageToolCall{
+				{Name: "researcher"},
+				{Name: "editor"},
+			},
+			wantPassed:  true,
+			wantMissing: nil,
+		},
+		{
+			name:           "No expected agents",
+			expectedAgents: []string{},
+			actualCalls: []types.MessageToolCall{
+				{Name: "researcher"},
+			},
+			wantPassed:  true,
+			wantMissing: nil,
+		},
+		{
+			name:           "Agent invoked multiple times",
+			expectedAgents: []string{"researcher"},
+			actualCalls: []types.MessageToolCall{
+				{Name: "researcher"},
+				{Name: "researcher"},
+			},
+			wantPassed:  true,
+			wantMissing: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create validator with factory pattern
+			params := map[string]interface{}{
+				"agents": tt.expectedAgents,
+			}
+			validator := NewAgentInvokedValidator(params)
+
+			// Prepare enhanced params with tool calls
+			enhancedParams := map[string]interface{}{
+				"_message_tool_calls": tt.actualCalls,
+			}
+
+			// Validate
+			result := validator.Validate("", enhancedParams)
+
+			if result.Passed != tt.wantPassed {
+				t.Errorf("Validate() Passed = %v, want %v", result.Passed, tt.wantPassed)
+			}
+
+			// Check missing agents
+			if !result.Passed {
+				details, ok := result.Details.(map[string]interface{})
+				if !ok {
+					t.Fatalf("Expected details to be map[string]interface{}, got %T", result.Details)
+				}
+
+				missing, ok := details["missing_agents"].([]string)
+				if !ok {
+					t.Fatalf("Expected missing_agents to be []string, got %T", details["missing_agents"])
+				}
+
+				if len(missing) != len(tt.wantMissing) {
+					t.Errorf("Got %d missing agents, want %d: %v", len(missing), len(tt.wantMissing), missing)
+				}
+
+				for i, want := range tt.wantMissing {
+					if i >= len(missing) || missing[i] != want {
+						t.Errorf("Missing agent %d = %v, want %v", i, missing, tt.wantMissing)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAgentInvokedValidator_TurnMessages(t *testing.T) {
+	params := map[string]interface{}{
+		"agents": []string{"researcher"},
+	}
+	validator := NewAgentInvokedValidator(params)
+
+	// Test with _turn_messages (new approach)
+	enhancedParams := map[string]interface{}{
+		"_turn_messages": []types.Message{
+			{Role: "user", Content: "Find me some info"},
+			{
+				Role: "assistant",
+				ToolCalls: []types.MessageToolCall{
+					{ID: "call_1", Name: "researcher", Args: []byte(`{"query": "test"}`)},
+				},
+			},
+		},
+	}
+
+	result := validator.Validate("", enhancedParams)
+	if !result.Passed {
+		t.Errorf("Expected pass with turn messages, got fail")
+	}
+}
+
+func TestAgentInvokedValidator_FactoryWithSliceTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]interface{}
+		want   []string
+	}{
+		{
+			name: "String slice",
+			params: map[string]interface{}{
+				"agents": []string{"agent1", "agent2"},
+			},
+			want: []string{"agent1", "agent2"},
+		},
+		{
+			name: "Interface slice",
+			params: map[string]interface{}{
+				"agents": []interface{}{"agent1", "agent2"},
+			},
+			want: []string{"agent1", "agent2"},
+		},
+		{
+			name:   "Missing agents param",
+			params: map[string]interface{}{},
+			want:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := NewAgentInvokedValidator(tt.params)
+
+			result := validator.Validate("", map[string]interface{}{
+				"_message_tool_calls": []types.MessageToolCall{},
+			})
+
+			if len(tt.want) == 0 && !result.Passed {
+				t.Error("Expected Passed=true when no agents expected")
+			}
+		})
+	}
+}

--- a/tools/arena/assertions/agent_not_invoked.go
+++ b/tools/arena/assertions/agent_not_invoked.go
@@ -1,0 +1,35 @@
+package assertions
+
+import (
+	runtimeValidators "github.com/AltairaLabs/PromptKit/runtime/validators"
+)
+
+// AgentNotInvokedValidator checks that forbidden agents were NOT called in the response.
+// In multi-agent packs, agent invocations appear as tool calls where the tool name
+// matches the agent member name.
+// Params: agents: []string - agent names that should not have been called.
+type AgentNotInvokedValidator struct {
+	forbiddenAgents []string
+}
+
+// NewAgentNotInvokedValidator creates a new agent_not_invoked validator from params.
+func NewAgentNotInvokedValidator(params map[string]interface{}) runtimeValidators.Validator {
+	agents := extractStringSlice(params, "agents")
+	return &AgentNotInvokedValidator{forbiddenAgents: agents}
+}
+
+// Validate checks if any forbidden agents were invoked as tool calls.
+func (v *AgentNotInvokedValidator) Validate(
+	content string,
+	params map[string]interface{},
+) runtimeValidators.ValidationResult {
+	toolCalls := resolveToolCalls(params)
+	called := findForbiddenCalled(toolCalls, v.forbiddenAgents)
+
+	return runtimeValidators.ValidationResult{
+		Passed: len(called) == 0,
+		Details: map[string]interface{}{
+			"forbidden_agents_called": called,
+		},
+	}
+}

--- a/tools/arena/assertions/agent_not_invoked_conversation.go
+++ b/tools/arena/assertions/agent_not_invoked_conversation.go
@@ -1,0 +1,60 @@
+package assertions
+
+import (
+	"context"
+)
+
+// AgentNotInvokedConversationValidator checks that specific agents were NOT invoked
+// anywhere in the conversation.
+// In multi-agent packs, agent invocations appear as tool calls where the tool name
+// matches the agent member name.
+// Params:
+//   - agent_names: []string forbidden agent names
+//
+// Type: "agent_not_invoked"
+type AgentNotInvokedConversationValidator struct{}
+
+// Type returns the validator type name.
+func (v *AgentNotInvokedConversationValidator) Type() string { return "agent_not_invoked" }
+
+// NewAgentNotInvokedConversationValidator constructs a conversation-level agent_not_invoked validator.
+func NewAgentNotInvokedConversationValidator() ConversationValidator {
+	return &AgentNotInvokedConversationValidator{}
+}
+
+// ValidateConversation ensures forbidden agents were never invoked across the conversation.
+func (v *AgentNotInvokedConversationValidator) ValidateConversation(
+	ctx context.Context,
+	convCtx *ConversationContext,
+	params map[string]interface{},
+) ConversationValidationResult {
+	forbidden := extractStringSlice(params, "agent_names")
+	forbiddenSet := make(map[string]struct{}, len(forbidden))
+	for _, n := range forbidden {
+		forbiddenSet[n] = struct{}{}
+	}
+
+	var violations []ConversationViolation
+	for _, tc := range convCtx.ToolCalls {
+		if _, bad := forbiddenSet[tc.ToolName]; bad {
+			violations = append(violations, ConversationViolation{
+				TurnIndex:   tc.TurnIndex,
+				Description: "forbidden agent was invoked",
+				Evidence: map[string]interface{}{
+					"agent":     tc.ToolName,
+					"arguments": tc.Arguments,
+				},
+			})
+		}
+	}
+
+	if len(violations) > 0 {
+		return ConversationValidationResult{
+			Passed:     false,
+			Message:    "forbidden agents were invoked",
+			Violations: violations,
+		}
+	}
+
+	return ConversationValidationResult{Passed: true, Message: "no forbidden agents invoked"}
+}

--- a/tools/arena/assertions/agent_not_invoked_conversation_test.go
+++ b/tools/arena/assertions/agent_not_invoked_conversation_test.go
@@ -1,0 +1,92 @@
+package assertions
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAgentNotInvokedConversationValidator(t *testing.T) {
+	v := NewAgentNotInvokedConversationValidator()
+	ctx := context.Background()
+
+	conv := &ConversationContext{
+		ToolCalls: []ToolCallRecord{
+			{TurnIndex: 0, ToolName: "researcher"},
+			{TurnIndex: 1, ToolName: "writer"},
+		},
+	}
+
+	// No forbidden agents called
+	params := map[string]interface{}{
+		"agent_names": []string{"admin_agent", "delete_agent"},
+	}
+	res := v.ValidateConversation(ctx, conv, params)
+	if !res.Passed {
+		t.Fatalf("expected pass (no forbidden agents), got: %+v", res)
+	}
+
+	// Forbidden agent called
+	params2 := map[string]interface{}{
+		"agent_names": []string{"writer"},
+	}
+	res2 := v.ValidateConversation(ctx, conv, params2)
+	if res2.Passed {
+		t.Fatalf("expected fail (forbidden agent called), got pass")
+	}
+	if len(res2.Violations) == 0 {
+		t.Fatalf("expected violations to be reported")
+	}
+	if res2.Violations[0].Evidence["agent"] != "writer" {
+		t.Errorf("expected violation for 'writer', got: %v", res2.Violations[0].Evidence)
+	}
+}
+
+func TestAgentNotInvokedConversationValidator_Type(t *testing.T) {
+	v := NewAgentNotInvokedConversationValidator()
+	if v.Type() != "agent_not_invoked" {
+		t.Errorf("Type() = %q, want %q", v.Type(), "agent_not_invoked")
+	}
+}
+
+func TestAgentNotInvokedConversationValidator_EmptyConversation(t *testing.T) {
+	v := NewAgentNotInvokedConversationValidator()
+	ctx := context.Background()
+
+	conv := &ConversationContext{
+		ToolCalls: []ToolCallRecord{},
+	}
+
+	params := map[string]interface{}{
+		"agent_names": []string{"admin_agent"},
+	}
+	res := v.ValidateConversation(ctx, conv, params)
+	if !res.Passed {
+		t.Fatalf("expected pass with empty conversation, got fail")
+	}
+}
+
+func TestAgentNotInvokedConversationValidator_MultipleViolations(t *testing.T) {
+	v := NewAgentNotInvokedConversationValidator()
+	ctx := context.Background()
+
+	conv := &ConversationContext{
+		ToolCalls: []ToolCallRecord{
+			{TurnIndex: 0, ToolName: "admin_agent"},
+			{TurnIndex: 1, ToolName: "researcher"},
+			{TurnIndex: 2, ToolName: "admin_agent"},
+			{TurnIndex: 3, ToolName: "delete_agent"},
+		},
+	}
+
+	params := map[string]interface{}{
+		"agent_names": []string{"admin_agent", "delete_agent"},
+	}
+	res := v.ValidateConversation(ctx, conv, params)
+	if res.Passed {
+		t.Fatalf("expected fail with multiple violations, got pass")
+	}
+	// Should have 3 violations: admin_agent at turn 0, admin_agent at turn 2, delete_agent at turn 3
+	if len(res.Violations) != 3 {
+		t.Errorf("expected 3 violations, got %d", len(res.Violations))
+	}
+}

--- a/tools/arena/assertions/agent_not_invoked_test.go
+++ b/tools/arena/assertions/agent_not_invoked_test.go
@@ -1,0 +1,152 @@
+package assertions
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestAgentNotInvokedValidator(t *testing.T) {
+	tests := []struct {
+		name            string
+		forbiddenAgents []string
+		actualCalls     []types.MessageToolCall
+		wantPassed      bool
+		wantCalled      []string
+	}{
+		{
+			name:            "No forbidden agents called",
+			forbiddenAgents: []string{"admin_agent", "delete_agent"},
+			actualCalls: []types.MessageToolCall{
+				{Name: "researcher"},
+				{Name: "writer"},
+			},
+			wantPassed: true,
+			wantCalled: nil,
+		},
+		{
+			name:            "One forbidden agent called",
+			forbiddenAgents: []string{"admin_agent", "delete_agent"},
+			actualCalls: []types.MessageToolCall{
+				{Name: "researcher"},
+				{Name: "admin_agent"},
+			},
+			wantPassed: false,
+			wantCalled: []string{"admin_agent"},
+		},
+		{
+			name:            "Multiple forbidden agents called",
+			forbiddenAgents: []string{"admin_agent", "delete_agent"},
+			actualCalls: []types.MessageToolCall{
+				{Name: "admin_agent"},
+				{Name: "delete_agent"},
+			},
+			wantPassed: false,
+			wantCalled: []string{"admin_agent", "delete_agent"},
+		},
+		{
+			name:            "Forbidden agent called multiple times reports once",
+			forbiddenAgents: []string{"admin_agent"},
+			actualCalls: []types.MessageToolCall{
+				{Name: "admin_agent"},
+				{Name: "admin_agent"},
+			},
+			wantPassed: false,
+			wantCalled: []string{"admin_agent"},
+		},
+		{
+			name:            "No forbidden agents defined",
+			forbiddenAgents: []string{},
+			actualCalls: []types.MessageToolCall{
+				{Name: "researcher"},
+			},
+			wantPassed: true,
+			wantCalled: nil,
+		},
+		{
+			name:            "No calls at all",
+			forbiddenAgents: []string{"admin_agent"},
+			actualCalls:     []types.MessageToolCall{},
+			wantPassed:      true,
+			wantCalled:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]interface{}{
+				"agents": tt.forbiddenAgents,
+			}
+			validator := NewAgentNotInvokedValidator(params)
+
+			enhancedParams := map[string]interface{}{
+				"_message_tool_calls": tt.actualCalls,
+			}
+
+			result := validator.Validate("", enhancedParams)
+
+			if result.Passed != tt.wantPassed {
+				t.Errorf("Validate() Passed = %v, want %v", result.Passed, tt.wantPassed)
+			}
+
+			if !result.Passed {
+				details, ok := result.Details.(map[string]interface{})
+				if !ok {
+					t.Fatalf("Expected details to be map[string]interface{}, got %T", result.Details)
+				}
+
+				called, ok := details["forbidden_agents_called"].([]string)
+				if !ok {
+					t.Fatalf("Expected forbidden_agents_called to be []string, got %T", details["forbidden_agents_called"])
+				}
+
+				if len(called) != len(tt.wantCalled) {
+					t.Errorf("Got %d forbidden agents called, want %d: %v", len(called), len(tt.wantCalled), called)
+				}
+			}
+		})
+	}
+}
+
+func TestAgentNotInvokedValidator_TurnMessages(t *testing.T) {
+	params := map[string]interface{}{
+		"agents": []string{"admin_agent"},
+	}
+	validator := NewAgentNotInvokedValidator(params)
+
+	// Test with _turn_messages where forbidden agent is called
+	enhancedParams := map[string]interface{}{
+		"_turn_messages": []types.Message{
+			{Role: "user", Content: "Do something"},
+			{
+				Role: "assistant",
+				ToolCalls: []types.MessageToolCall{
+					{ID: "call_1", Name: "admin_agent", Args: []byte(`{}`)},
+				},
+			},
+		},
+	}
+
+	result := validator.Validate("", enhancedParams)
+	if result.Passed {
+		t.Errorf("Expected fail when forbidden agent is in turn messages, got pass")
+	}
+
+	// Test with _turn_messages where no forbidden agent is called
+	enhancedParams2 := map[string]interface{}{
+		"_turn_messages": []types.Message{
+			{Role: "user", Content: "Do something"},
+			{
+				Role: "assistant",
+				ToolCalls: []types.MessageToolCall{
+					{ID: "call_1", Name: "researcher", Args: []byte(`{}`)},
+				},
+			},
+		},
+	}
+
+	result2 := validator.Validate("", enhancedParams2)
+	if !result2.Passed {
+		t.Errorf("Expected pass when no forbidden agent in turn messages, got fail")
+	}
+}

--- a/tools/arena/assertions/agent_response_contains.go
+++ b/tools/arena/assertions/agent_response_contains.go
@@ -1,0 +1,67 @@
+package assertions
+
+import (
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	runtimeValidators "github.com/AltairaLabs/PromptKit/runtime/validators"
+)
+
+// AgentResponseContainsValidator checks that a specific agent's response contains expected text.
+// When an agent is invoked as a tool call, its response comes back as a tool result message
+// (Role="tool") with a ToolResult containing the agent name and content.
+// Params:
+//   - agent: string - the agent name whose response to check
+//   - contains: string - the substring to look for in the agent's response
+type AgentResponseContainsValidator struct {
+	agent    string
+	contains string
+}
+
+// NewAgentResponseContainsValidator creates a new agent_response_contains validator from params.
+func NewAgentResponseContainsValidator(params map[string]interface{}) runtimeValidators.Validator {
+	agent, _ := params["agent"].(string)
+	contains, _ := params["contains"].(string)
+	return &AgentResponseContainsValidator{agent: agent, contains: contains}
+}
+
+// Validate checks if the specified agent's tool result contains the expected text.
+func (v *AgentResponseContainsValidator) Validate(
+	content string,
+	params map[string]interface{},
+) runtimeValidators.ValidationResult {
+	// Look for tool result messages from the specified agent in turn messages
+	if messages, ok := params["_turn_messages"].([]types.Message); ok {
+		for i := range messages {
+			msg := &messages[i]
+			// Skip messages loaded from history
+			if msg.Source == sourceStatestore {
+				continue
+			}
+
+			// Tool result messages have Role="tool" and ToolResult containing the agent's response
+			if msg.Role == "tool" && msg.ToolResult != nil && msg.ToolResult.Name == v.agent {
+				if strings.Contains(msg.ToolResult.Content, v.contains) {
+					return runtimeValidators.ValidationResult{
+						Passed: true,
+						Details: map[string]interface{}{
+							"agent":         v.agent,
+							"found_content": msg.ToolResult.Content,
+						},
+					}
+				}
+			}
+		}
+	}
+
+	// Legacy: check _message_tool_calls for matching agent name
+	// Tool results are not available in legacy params, so we cannot check content
+	return runtimeValidators.ValidationResult{
+		Passed: false,
+		Details: map[string]interface{}{
+			"agent":           v.agent,
+			"expected_substr": v.contains,
+			"reason":          "no matching agent response found containing expected text",
+		},
+	}
+}

--- a/tools/arena/assertions/agent_response_contains_test.go
+++ b/tools/arena/assertions/agent_response_contains_test.go
@@ -1,0 +1,199 @@
+package assertions
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestAgentResponseContainsValidator(t *testing.T) {
+	tests := []struct {
+		name       string
+		agent      string
+		contains   string
+		messages   []types.Message
+		wantPassed bool
+	}{
+		{
+			name:     "Agent response contains expected text",
+			agent:    "researcher",
+			contains: "quantum computing",
+			messages: []types.Message{
+				{Role: "user", Content: "Research quantum computing"},
+				{
+					Role: "assistant",
+					ToolCalls: []types.MessageToolCall{
+						{ID: "call_1", Name: "researcher", Args: []byte(`{"query": "quantum computing"}`)},
+					},
+				},
+				{
+					Role: "tool",
+					ToolResult: &types.MessageToolResult{
+						ID:      "call_1",
+						Name:    "researcher",
+						Content: "Here are the results about quantum computing and its applications.",
+					},
+				},
+			},
+			wantPassed: true,
+		},
+		{
+			name:     "Agent response does not contain expected text",
+			agent:    "researcher",
+			contains: "machine learning",
+			messages: []types.Message{
+				{Role: "user", Content: "Research quantum computing"},
+				{
+					Role: "assistant",
+					ToolCalls: []types.MessageToolCall{
+						{ID: "call_1", Name: "researcher", Args: []byte(`{"query": "quantum computing"}`)},
+					},
+				},
+				{
+					Role: "tool",
+					ToolResult: &types.MessageToolResult{
+						ID:      "call_1",
+						Name:    "researcher",
+						Content: "Here are the results about quantum computing.",
+					},
+				},
+			},
+			wantPassed: false,
+		},
+		{
+			name:     "Agent not found in messages",
+			agent:    "writer",
+			contains: "some text",
+			messages: []types.Message{
+				{Role: "user", Content: "Do something"},
+				{
+					Role: "assistant",
+					ToolCalls: []types.MessageToolCall{
+						{ID: "call_1", Name: "researcher", Args: []byte(`{}`)},
+					},
+				},
+				{
+					Role: "tool",
+					ToolResult: &types.MessageToolResult{
+						ID:      "call_1",
+						Name:    "researcher",
+						Content: "Research results here.",
+					},
+				},
+			},
+			wantPassed: false,
+		},
+		{
+			name:       "No messages at all",
+			agent:      "researcher",
+			contains:   "anything",
+			messages:   []types.Message{},
+			wantPassed: false,
+		},
+		{
+			name:     "Skips statestore messages",
+			agent:    "researcher",
+			contains: "old result",
+			messages: []types.Message{
+				{
+					Role:   "tool",
+					Source: "statestore",
+					ToolResult: &types.MessageToolResult{
+						ID:      "old_call",
+						Name:    "researcher",
+						Content: "old result from previous turn",
+					},
+				},
+				{Role: "user", Content: "New query"},
+				{
+					Role: "assistant",
+					ToolCalls: []types.MessageToolCall{
+						{ID: "call_2", Name: "researcher", Args: []byte(`{}`)},
+					},
+				},
+				{
+					Role: "tool",
+					ToolResult: &types.MessageToolResult{
+						ID:      "call_2",
+						Name:    "researcher",
+						Content: "new result without the expected text",
+					},
+				},
+			},
+			wantPassed: false,
+		},
+		{
+			name:     "Multiple agents, correct one matched",
+			agent:    "writer",
+			contains: "draft complete",
+			messages: []types.Message{
+				{
+					Role: "assistant",
+					ToolCalls: []types.MessageToolCall{
+						{ID: "call_1", Name: "researcher", Args: []byte(`{}`)},
+						{ID: "call_2", Name: "writer", Args: []byte(`{}`)},
+					},
+				},
+				{
+					Role: "tool",
+					ToolResult: &types.MessageToolResult{
+						ID:      "call_1",
+						Name:    "researcher",
+						Content: "research findings here",
+					},
+				},
+				{
+					Role: "tool",
+					ToolResult: &types.MessageToolResult{
+						ID:      "call_2",
+						Name:    "writer",
+						Content: "The draft complete and ready for review.",
+					},
+				},
+			},
+			wantPassed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]interface{}{
+				"agent":    tt.agent,
+				"contains": tt.contains,
+			}
+			validator := NewAgentResponseContainsValidator(params)
+
+			enhancedParams := map[string]interface{}{
+				"_turn_messages": tt.messages,
+			}
+
+			result := validator.Validate("", enhancedParams)
+
+			if result.Passed != tt.wantPassed {
+				t.Errorf("Validate() Passed = %v, want %v, details: %v", result.Passed, tt.wantPassed, result.Details)
+			}
+		})
+	}
+}
+
+func TestAgentResponseContainsValidator_LegacyFallback(t *testing.T) {
+	// Without _turn_messages, the validator should fail gracefully
+	params := map[string]interface{}{
+		"agent":    "researcher",
+		"contains": "some text",
+	}
+	validator := NewAgentResponseContainsValidator(params)
+
+	result := validator.Validate("", map[string]interface{}{})
+	if result.Passed {
+		t.Errorf("Expected fail when no turn messages available, got pass")
+	}
+
+	details, ok := result.Details.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected details to be map[string]interface{}")
+	}
+	if details["reason"] == nil {
+		t.Errorf("Expected reason in details")
+	}
+}

--- a/tools/arena/assertions/conversation_registry.go
+++ b/tools/arena/assertions/conversation_registry.go
@@ -34,6 +34,10 @@ func NewConversationAssertionRegistry() *ConversationAssertionRegistry {
 	registry.Register("tool_calls_with_args", NewToolCallsWithArgsConversationValidator)
 	registry.Register("llm_judge_conversation", NewLLMJudgeConversationValidator)
 
+	// Register multi-agent conversation assertions
+	registry.Register("agent_invoked", NewAgentInvokedConversationValidator)
+	registry.Register("agent_not_invoked", NewAgentNotInvokedConversationValidator)
+
 	return registry
 }
 

--- a/tools/arena/assertions/registry.go
+++ b/tools/arena/assertions/registry.go
@@ -31,5 +31,10 @@ func NewArenaAssertionRegistry() *runtimeValidators.Registry {
 	registry.Register("llm_judge", NewLLMJudgeValidator)
 	// Note: conversation-level validator registered in conversation registry
 
+	// Register multi-agent assertion validators
+	registry.Register("agent_invoked", NewAgentInvokedValidator)
+	registry.Register("agent_not_invoked", NewAgentNotInvokedValidator)
+	registry.Register("agent_response_contains", NewAgentResponseContainsValidator)
+
 	return registry
 }

--- a/tools/arena/assertions/tool_calls_with_args.go
+++ b/tools/arena/assertions/tool_calls_with_args.go
@@ -38,13 +38,7 @@ func (v *ToolCallsWithArgsValidator) Validate(
 	content string, params map[string]interface{},
 ) runtimeValidators.ValidationResult {
 	// Extract tool calls from turn messages
-	var toolCalls []types.MessageToolCall
-
-	if messages, ok := params["_turn_messages"].([]types.Message); ok {
-		toolCalls = extractToolCallsFromTurnMessages(messages)
-	} else {
-		toolCalls = extractToolCalls(params)
-	}
+	toolCalls := resolveToolCalls(params)
 
 	// Find matching tool calls
 	var matchingCalls []types.MessageToolCall


### PR DESCRIPTION
## Summary
- **SDK** (#378): Add `OpenMultiAgent` session with `LocalAgentExecutor` for in-process agent-to-agent routing, eliminating the need for HTTP calls between co-located agents
- **Arena** (#379): Add `agent_invoked`, `agent_not_invoked`, `agent_response_contains` assertions at both turn and conversation level for testing multi-agent packs
- **Deploy** (#380): Add `IsMultiAgent`, `ExtractAgents`, `GenerateAgentCards`, `GenerateAgentResourcePlan` helpers for adapter authors working with multi-agent packs

## Test plan
- [x] `runtime/deploy/adaptersdk` — 12 tests passing (100% coverage on new code)
- [x] `sdk` — 9 new tests passing (all new files ≥80% coverage)
- [x] `tools/arena/assertions` — 20+ new tests passing (100% coverage on new assertion files)
- [x] All pre-commit checks pass (lint, build, test, coverage)