### PR TITLE
feat: add distributed trace context propagation to A2A boundaries

### DIFF
--- a/runtime/a2a/client.go
+++ b/runtime/a2a/client.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/AltairaLabs/PromptKit/runtime/telemetry"
 )
 
 // RPCError represents a JSON-RPC error returned by an A2A agent.
@@ -97,6 +99,7 @@ func (c *Client) Discover(ctx context.Context) (*AgentCard, error) {
 		return nil, fmt.Errorf("a2a: discover: %w", err)
 	}
 	c.setAuth(httpReq)
+	telemetry.InjectTraceHeaders(ctx, httpReq)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -146,6 +149,7 @@ func (c *Client) rpcCall(ctx context.Context, method string, params, result any)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	c.setAuth(httpReq)
+	telemetry.InjectTraceHeaders(ctx, httpReq)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -213,6 +217,7 @@ func (c *Client) SendMessageStream(ctx context.Context, params *SendMessageReque
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "text/event-stream")
 	c.setAuth(httpReq)
+	telemetry.InjectTraceHeaders(ctx, httpReq)
 
 	resp, err := c.httpClient.Do(httpReq) //nolint:bodyclose // closed in goroutine below
 	if err != nil {

--- a/runtime/telemetry/trace_context.go
+++ b/runtime/telemetry/trace_context.go
@@ -1,0 +1,81 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+)
+
+// traceContextKey is a private type for the trace context key to avoid collisions.
+type traceContextKey struct{}
+
+// traceparentRe validates the W3C Trace Context traceparent header format:
+// version-trace_id-parent_id-trace_flags (e.g., 00-<32 hex>-<16 hex>-<2 hex>).
+var traceparentRe = regexp.MustCompile(`^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$`)
+
+// TraceContext holds distributed trace headers extracted from an inbound HTTP request.
+type TraceContext struct {
+	Traceparent string // W3C traceparent header
+	Tracestate  string // W3C tracestate header
+	XRayTraceID string // AWS X-Ray X-Amzn-Trace-Id header
+}
+
+// IsEmpty returns true when no trace data is present.
+func (tc TraceContext) IsEmpty() bool {
+	return tc.Traceparent == "" && tc.Tracestate == "" && tc.XRayTraceID == ""
+}
+
+// ExtractTraceContext reads trace headers from an inbound HTTP request.
+// Invalid traceparent values are silently discarded.
+func ExtractTraceContext(r *http.Request) TraceContext {
+	tc := TraceContext{
+		Tracestate:  r.Header.Get("tracestate"),
+		XRayTraceID: r.Header.Get("X-Amzn-Trace-Id"),
+	}
+	if tp := r.Header.Get("traceparent"); traceparentRe.MatchString(tp) {
+		tc.Traceparent = tp
+	}
+	return tc
+}
+
+// ContextWithTrace stores a TraceContext in a Go context.
+func ContextWithTrace(ctx context.Context, tc TraceContext) context.Context {
+	return context.WithValue(ctx, traceContextKey{}, tc)
+}
+
+// TraceContextFromContext retrieves a TraceContext from a Go context.
+// Returns an empty TraceContext if none is stored.
+func TraceContextFromContext(ctx context.Context) TraceContext {
+	tc, _ := ctx.Value(traceContextKey{}).(TraceContext)
+	return tc
+}
+
+// TraceMiddleware extracts distributed trace headers from inbound requests
+// and stores them in the request context for downstream propagation.
+func TraceMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tc := ExtractTraceContext(r)
+		if !tc.IsEmpty() {
+			r = r.WithContext(ContextWithTrace(r.Context(), tc))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// InjectTraceHeaders writes trace headers from the context onto an outbound
+// HTTP request. It is a no-op if the context contains no trace data.
+func InjectTraceHeaders(ctx context.Context, req *http.Request) {
+	tc := TraceContextFromContext(ctx)
+	if tc.IsEmpty() {
+		return
+	}
+	if tc.Traceparent != "" {
+		req.Header.Set("traceparent", tc.Traceparent)
+	}
+	if tc.Tracestate != "" {
+		req.Header.Set("tracestate", tc.Tracestate)
+	}
+	if tc.XRayTraceID != "" {
+		req.Header.Set("X-Amzn-Trace-Id", tc.XRayTraceID)
+	}
+}

--- a/runtime/telemetry/trace_context_test.go
+++ b/runtime/telemetry/trace_context_test.go
@@ -1,0 +1,163 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExtractTraceContext_W3C(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	r.Header.Set("tracestate", "congo=t61rcWkgMzE")
+
+	tc := ExtractTraceContext(r)
+
+	if tc.Traceparent != "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" {
+		t.Errorf("Traceparent = %q", tc.Traceparent)
+	}
+	if tc.Tracestate != "congo=t61rcWkgMzE" {
+		t.Errorf("Tracestate = %q", tc.Tracestate)
+	}
+	if tc.XRayTraceID != "" {
+		t.Errorf("XRayTraceID = %q, want empty", tc.XRayTraceID)
+	}
+	if tc.IsEmpty() {
+		t.Error("expected non-empty TraceContext")
+	}
+}
+
+func TestExtractTraceContext_XRay(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.Header.Set("X-Amzn-Trace-Id", "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1")
+
+	tc := ExtractTraceContext(r)
+
+	if tc.XRayTraceID != "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1" {
+		t.Errorf("XRayTraceID = %q", tc.XRayTraceID)
+	}
+	if tc.Traceparent != "" {
+		t.Errorf("Traceparent = %q, want empty", tc.Traceparent)
+	}
+	if tc.IsEmpty() {
+		t.Error("expected non-empty TraceContext")
+	}
+}
+
+func TestExtractTraceContext_Both(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	r.Header.Set("tracestate", "congo=t61rcWkgMzE")
+	r.Header.Set("X-Amzn-Trace-Id", "Root=1-5759e988-bd862e3fe1be46a994272793")
+
+	tc := ExtractTraceContext(r)
+
+	if tc.Traceparent == "" {
+		t.Error("expected Traceparent")
+	}
+	if tc.Tracestate == "" {
+		t.Error("expected Tracestate")
+	}
+	if tc.XRayTraceID == "" {
+		t.Error("expected XRayTraceID")
+	}
+}
+
+func TestExtractTraceContext_None(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+
+	tc := ExtractTraceContext(r)
+
+	if !tc.IsEmpty() {
+		t.Errorf("expected empty TraceContext, got %+v", tc)
+	}
+}
+
+func TestExtractTraceContext_InvalidTraceparent(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.Header.Set("traceparent", "not-a-valid-traceparent")
+
+	tc := ExtractTraceContext(r)
+
+	if tc.Traceparent != "" {
+		t.Errorf("Traceparent = %q, want empty for invalid input", tc.Traceparent)
+	}
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	r.Header.Set("tracestate", "congo=t61rcWkgMzE")
+	r.Header.Set("X-Amzn-Trace-Id", "Root=1-5759e988-bd862e3fe1be46a994272793")
+
+	// Extract from inbound request.
+	tc := ExtractTraceContext(r)
+
+	// Store in context.
+	ctx := ContextWithTrace(context.Background(), tc)
+
+	// Inject into outbound request.
+	outReq := httptest.NewRequest(http.MethodPost, "/downstream", http.NoBody)
+	InjectTraceHeaders(ctx, outReq)
+
+	if got := outReq.Header.Get("traceparent"); got != tc.Traceparent {
+		t.Errorf("traceparent = %q, want %q", got, tc.Traceparent)
+	}
+	if got := outReq.Header.Get("tracestate"); got != tc.Tracestate {
+		t.Errorf("tracestate = %q, want %q", got, tc.Tracestate)
+	}
+	if got := outReq.Header.Get("X-Amzn-Trace-Id"); got != tc.XRayTraceID {
+		t.Errorf("X-Amzn-Trace-Id = %q, want %q", got, tc.XRayTraceID)
+	}
+}
+
+func TestTraceMiddleware(t *testing.T) {
+	wantTP := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+	var gotTC TraceContext
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotTC = TraceContextFromContext(r.Context())
+	})
+
+	handler := TraceMiddleware(inner)
+	r := httptest.NewRequest(http.MethodPost, "/a2a", http.NoBody)
+	r.Header.Set("traceparent", wantTP)
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+
+	if gotTC.Traceparent != wantTP {
+		t.Errorf("Traceparent = %q, want %q", gotTC.Traceparent, wantTP)
+	}
+}
+
+func TestTraceMiddleware_NoHeaders(t *testing.T) {
+	var gotTC TraceContext
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotTC = TraceContextFromContext(r.Context())
+	})
+
+	handler := TraceMiddleware(inner)
+	r := httptest.NewRequest(http.MethodPost, "/a2a", http.NoBody)
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+
+	if !gotTC.IsEmpty() {
+		t.Errorf("expected empty TraceContext, got %+v", gotTC)
+	}
+}
+
+func TestInjectTraceHeaders_NoOp(t *testing.T) {
+	ctx := context.Background() // no trace context stored
+
+	outReq := httptest.NewRequest(http.MethodPost, "/downstream", http.NoBody)
+	InjectTraceHeaders(ctx, outReq)
+
+	if got := outReq.Header.Get("traceparent"); got != "" {
+		t.Errorf("traceparent = %q, want empty", got)
+	}
+	if got := outReq.Header.Get("tracestate"); got != "" {
+		t.Errorf("tracestate = %q, want empty", got)
+	}
+	if got := outReq.Header.Get("X-Amzn-Trace-Id"); got != "" {
+		t.Errorf("X-Amzn-Trace-Id = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds W3C Trace Context (`traceparent`, `tracestate`) and AWS X-Ray (`X-Amzn-Trace-Id`) header propagation through A2A server and client HTTP boundaries
- New `TraceMiddleware` on the A2A server extracts inbound trace headers into the request context
- `handleSendMessage` propagates trace context to the background goroutine via a detached context
- A2A client injects trace headers from context onto outbound requests (`Discover`, `rpcCall`, `SendMessageStream`)

## Why this is safe

All changes are **additive and no-op by default**:

1. **No trace headers → no behavior change.** `TraceMiddleware` only calls `r.WithContext()` when headers are present; otherwise the original context passes through untouched. `InjectTraceHeaders` is a no-op on empty context.
2. **No signature changes on public API.** `A2AServer.Handler()`, `NewA2AServer()`, all client methods — signatures are unchanged. The only internal signature changes are `handleSendMessage` (added `*http.Request` param) and `runConversation` (added `context.Context` param).
3. **`runConversation` parent context preserves existing semantics.** Previously `context.Background()`; now `context.Background()` with an optional trace value attached. Cancellation behavior is identical — `context.WithCancel(parent)` still governs the goroutine lifecycle.
4. **Zero new dependencies.** Pure stdlib — `net/http`, `context`, `regexp`.

## Test plan

- [x] `runtime/telemetry`: 7 unit tests + 2 middleware tests (100% coverage on new code)
- [x] `runtime/a2a`: `TestClient_PropagatesTraceHeaders` — verifies Discover and SendMessage forward trace headers
- [x] `sdk`: `TestTraceContextPropagation_SendMessage` — verifies traceparent reaches `conv.Send()` context through middleware + detached context
- [x] `sdk`: `TestTraceContextPropagation_StreamMessage` — verifies traceparent reaches `Stream()` context via `r.Context()`
- [x] All pre-existing tests pass unchanged (90% coverage on a2a, 84% on sdk)
- [ ] CI (lint, build, full test suite, SonarCloud quality gate)