### PR TITLE
feat: add deploy plan serialization and state locking

### DIFF
--- a/runtime/deploy/lock.go
+++ b/runtime/deploy/lock.go
@@ -1,0 +1,84 @@
+package deploy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const lockFile = "deploy.lock"
+
+// Locker provides file-based locking for deploy operations.
+// It uses syscall.Flock to prevent concurrent deploys from
+// different processes targeting the same project directory.
+type Locker struct {
+	baseDir string
+	file    *os.File
+}
+
+// NewLocker creates a Locker for the given project directory.
+func NewLocker(baseDir string) *Locker {
+	return &Locker{baseDir: baseDir}
+}
+
+// lockPath returns the full path to the lock file.
+func (l *Locker) lockPath() string {
+	return filepath.Join(l.baseDir, stateDir, lockFile)
+}
+
+// Lock acquires an exclusive file lock. Returns an error if the lock
+// is already held by another process or if the locker already holds a lock.
+func (l *Locker) Lock() error {
+	if l.file != nil {
+		return fmt.Errorf("locker already holds a lock")
+	}
+
+	dir := filepath.Join(l.baseDir, stateDir)
+	if err := os.MkdirAll(dir, stateDirPerm); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	f, err := os.OpenFile(l.lockPath(), os.O_CREATE|os.O_RDWR, stateFilePerm)
+	if err != nil {
+		return fmt.Errorf("failed to open lock file: %w", err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return fmt.Errorf(
+				"deploy lock is held by another process; "+
+					"wait for the other deploy to finish or remove %s", l.lockPath())
+		}
+		return fmt.Errorf("failed to acquire deploy lock: %w", err)
+	}
+
+	l.file = f
+	return nil
+}
+
+// Unlock releases the lock and removes the lock file.
+// If no lock is held, Unlock is a no-op and returns nil.
+func (l *Locker) Unlock() error {
+	if l.file == nil {
+		return nil
+	}
+
+	fd := int(l.file.Fd())
+
+	if err := syscall.Flock(fd, syscall.LOCK_UN); err != nil {
+		return fmt.Errorf("failed to release deploy lock: %w", err)
+	}
+
+	if err := l.file.Close(); err != nil {
+		return fmt.Errorf("failed to close lock file: %w", err)
+	}
+
+	// Best-effort removal of the lock file.
+	_ = os.Remove(l.lockPath())
+
+	l.file = nil
+	return nil
+}

--- a/runtime/deploy/lock_test.go
+++ b/runtime/deploy/lock_test.go
@@ -1,0 +1,103 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocker_LockAndUnlock(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLocker(dir)
+
+	if err := l.Lock(); err != nil {
+		t.Fatalf("Lock() failed: %v", err)
+	}
+
+	// Lock file should exist.
+	if _, err := os.Stat(l.lockPath()); err != nil {
+		t.Fatalf("lock file does not exist after Lock(): %v", err)
+	}
+
+	if err := l.Unlock(); err != nil {
+		t.Fatalf("Unlock() failed: %v", err)
+	}
+
+	// Lock file should be removed after unlock.
+	if _, err := os.Stat(l.lockPath()); !os.IsNotExist(err) {
+		t.Fatalf("lock file still exists after Unlock()")
+	}
+}
+
+func TestLocker_DoubleLock(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLocker(dir)
+
+	if err := l.Lock(); err != nil {
+		t.Fatalf("first Lock() failed: %v", err)
+	}
+	defer func() { _ = l.Unlock() }()
+
+	err := l.Lock()
+	if err == nil {
+		t.Fatal("second Lock() should have returned an error")
+	}
+	if !strings.Contains(err.Error(), "already holds") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLocker_ConcurrentLock(t *testing.T) {
+	dir := t.TempDir()
+
+	l1 := NewLocker(dir)
+	l2 := NewLocker(dir)
+
+	if err := l1.Lock(); err != nil {
+		t.Fatalf("l1.Lock() failed: %v", err)
+	}
+	defer func() { _ = l1.Unlock() }()
+
+	err := l2.Lock()
+	if err == nil {
+		_ = l2.Unlock()
+		t.Fatal("l2.Lock() should have returned an error while l1 holds the lock")
+	}
+	if !strings.Contains(err.Error(), "held by another process") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLocker_UnlockWithoutLock(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLocker(dir)
+
+	if err := l.Unlock(); err != nil {
+		t.Fatalf("Unlock() without Lock() should be a no-op, got: %v", err)
+	}
+}
+
+func TestLocker_LockCreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, ".promptarena")
+
+	// Ensure the state directory does not exist yet.
+	if _, err := os.Stat(stateDir); !os.IsNotExist(err) {
+		t.Fatalf(".promptarena dir should not exist yet")
+	}
+
+	l := NewLocker(dir)
+	if err := l.Lock(); err != nil {
+		t.Fatalf("Lock() failed: %v", err)
+	}
+	defer func() { _ = l.Unlock() }()
+
+	info, err := os.Stat(stateDir)
+	if err != nil {
+		t.Fatalf(".promptarena dir was not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal(".promptarena should be a directory")
+	}
+}

--- a/runtime/deploy/state.go
+++ b/runtime/deploy/state.go
@@ -13,6 +13,7 @@ import (
 const (
 	stateDir      = ".promptarena"
 	stateFile     = "deploy.state"
+	planFile      = "deploy.plan"
 	stateVersion  = 1
 	stateDirPerm  = 0o750
 	stateFilePerm = 0o600
@@ -102,6 +103,87 @@ func (s *StateStore) Delete() error {
 func ComputePackChecksum(data []byte) string {
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("sha256:%x", h)
+}
+
+// SavedPlan is a serialized deployment plan that can be applied later.
+type SavedPlan struct {
+	Version      int           `json:"version"`
+	CreatedAt    string        `json:"created_at"`
+	Provider     string        `json:"provider"`
+	Environment  string        `json:"environment"`
+	PackChecksum string        `json:"pack_checksum"`
+	Plan         *PlanResponse `json:"plan"`
+	Request      *PlanRequest  `json:"request"`
+}
+
+// planPath returns the full path to the plan file.
+func (s *StateStore) planPath() string {
+	return filepath.Join(s.baseDir, stateDir, planFile)
+}
+
+// SavePlan persists a deployment plan to disk.
+func (s *StateStore) SavePlan(plan *SavedPlan) error {
+	if plan == nil {
+		return fmt.Errorf("plan cannot be nil")
+	}
+
+	plan.Version = stateVersion
+
+	dir := filepath.Join(s.baseDir, stateDir)
+	if err := os.MkdirAll(dir, stateDirPerm); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal plan: %w", err)
+	}
+
+	if err := os.WriteFile(s.planPath(), data, stateFilePerm); err != nil {
+		return fmt.Errorf("failed to write plan file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadPlan reads a saved plan from disk. Returns nil, nil if not found.
+func (s *StateStore) LoadPlan() (*SavedPlan, error) {
+	data, err := os.ReadFile(s.planPath())
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read plan file: %w", err)
+	}
+
+	var plan SavedPlan
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return nil, fmt.Errorf("failed to parse plan file: %w", err)
+	}
+
+	return &plan, nil
+}
+
+// DeletePlan removes the saved plan file. Returns nil if not found.
+func (s *StateStore) DeletePlan() error {
+	err := os.Remove(s.planPath())
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// NewSavedPlan creates a SavedPlan with current timestamp.
+func NewSavedPlan(provider, environment, packChecksum string, plan *PlanResponse, request *PlanRequest) *SavedPlan {
+	return &SavedPlan{
+		Version:      stateVersion,
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+		Provider:     provider,
+		Environment:  environment,
+		PackChecksum: packChecksum,
+		Plan:         plan,
+		Request:      request,
+	}
 }
 
 // NewState creates a new State with the given parameters and current timestamp.


### PR DESCRIPTION
## Summary

- Adds file-based exclusive locking (`syscall.Flock`) to prevent concurrent deploy operations targeting the same project directory
- Adds plan serialization (`SavedPlan` type) to support the `plan` → `apply` workflow pattern, with stale plan detection via pack checksum and environment validation
- Wires locking into `deploy`, `apply`, and `destroy` CLI commands; wires plan save/load into `plan` and `apply` commands

Closes #393

## Test plan

- [x] `runtime/deploy` tests pass (44 tests including 5 locking + 6 plan serialization tests)
- [x] `tools/arena/cmd/promptarena` builds and tests pass
- [x] Pre-commit hook passes (lint, build, tests, coverage ≥80%)
- [ ] CI passes