### PR TITLE
feat: add deploy refresh, drift detection, and resource import

### DIFF
--- a/runtime/deploy/adaptersdk/serve.go
+++ b/runtime/deploy/adaptersdk/serve.go
@@ -22,6 +22,7 @@ const (
 	MethodApply           = "apply"
 	MethodDestroy         = "destroy"
 	MethodStatus          = "status"
+	MethodImport          = "import"
 )
 
 // Standard JSON-RPC 2.0 error codes.
@@ -140,6 +141,8 @@ func dispatch(provider deploy.Provider, req *request) response {
 		return handleDestroy(ctx, provider, req)
 	case MethodStatus:
 		return handleStatus(ctx, provider, req)
+	case MethodImport:
+		return handleImport(ctx, provider, req)
 	default:
 		return response{
 			JSONRPC: jsonRPCVersion,
@@ -256,6 +259,23 @@ func handleStatus(
 		return errResponse(req.ID, CodeParseError, "invalid params: "+err.Error())
 	}
 	result, err := provider.Status(ctx, &params)
+	if err != nil {
+		return errResponse(req.ID, CodeInternalError, err.Error())
+	}
+	return okResponse(req.ID, result)
+}
+
+// handleImport handles the import method.
+func handleImport(
+	ctx context.Context,
+	provider deploy.Provider,
+	req *request,
+) response {
+	var params deploy.ImportRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errResponse(req.ID, CodeParseError, "invalid params: "+err.Error())
+	}
+	result, err := provider.Import(ctx, &params)
 	if err != nil {
 		return errResponse(req.ID, CodeInternalError, err.Error())
 	}

--- a/runtime/deploy/client.go
+++ b/runtime/deploy/client.go
@@ -32,6 +32,7 @@ const (
 	methodApply        = "apply"
 	methodDestroy      = "destroy"
 	methodStatus       = "status"
+	methodImport       = "import"
 )
 
 // rpcRequest is a JSON-RPC 2.0 request envelope.
@@ -240,6 +241,15 @@ func (c *AdapterClient) Destroy(ctx context.Context, req *DestroyRequest, callba
 func (c *AdapterClient) Status(ctx context.Context, req *StatusRequest) (*StatusResponse, error) {
 	var resp StatusResponse
 	if err := c.call(methodStatus, req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Import imports a pre-existing resource into the deployment state.
+func (c *AdapterClient) Import(ctx context.Context, req *ImportRequest) (*ImportResponse, error) {
+	var resp ImportResponse
+	if err := c.call(methodImport, req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/runtime/deploy/provider.go
+++ b/runtime/deploy/provider.go
@@ -11,6 +11,7 @@ const (
 	ActionUpdate   Action = "UPDATE"
 	ActionDelete   Action = "DELETE"
 	ActionNoChange Action = "NO_CHANGE"
+	ActionDrift    Action = "DRIFT"
 )
 
 // ProviderInfo describes a deploy adapter's capabilities.
@@ -112,6 +113,22 @@ type ApplyCallback func(event *ApplyEvent) error
 // DestroyCallback is called for each DestroyEvent during Destroy.
 type DestroyCallback func(event *DestroyEvent) error
 
+// ImportRequest is the input to Import.
+type ImportRequest struct {
+	ResourceType string `json:"resource_type"`
+	ResourceName string `json:"resource_name"`
+	Identifier   string `json:"identifier"`
+	DeployConfig string `json:"deploy_config"`
+	Environment  string `json:"environment,omitempty"`
+	PriorState   string `json:"prior_state,omitempty"`
+}
+
+// ImportResponse is the output of Import.
+type ImportResponse struct {
+	Resource ResourceStatus `json:"resource"`
+	State    string         `json:"state"`
+}
+
 // Provider defines the interface that deploy adapters must implement.
 type Provider interface {
 	GetProviderInfo(ctx context.Context) (*ProviderInfo, error)
@@ -120,4 +137,5 @@ type Provider interface {
 	Apply(ctx context.Context, req *PlanRequest, callback ApplyCallback) (adapterState string, err error)
 	Destroy(ctx context.Context, req *DestroyRequest, callback DestroyCallback) error
 	Status(ctx context.Context, req *StatusRequest) (*StatusResponse, error)
+	Import(ctx context.Context, req *ImportRequest) (*ImportResponse, error)
 }

--- a/runtime/deploy/provider_test.go
+++ b/runtime/deploy/provider_test.go
@@ -14,6 +14,7 @@ func TestActionConstants(t *testing.T) {
 		{ActionUpdate, "UPDATE"},
 		{ActionDelete, "DELETE"},
 		{ActionNoChange, "NO_CHANGE"},
+		{ActionDrift, "DRIFT"},
 	}
 
 	for _, tt := range tests {
@@ -173,6 +174,84 @@ func TestApplyEventTypes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestImportRequestJSONRoundtrip(t *testing.T) {
+	req := ImportRequest{
+		ResourceType: "agent_runtime",
+		ResourceName: "my-agent",
+		Identifier:   "container-abc123",
+		DeployConfig: `{"region":"us-east-1"}`,
+		Environment:  "production",
+		PriorState:   "prior-state-data",
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got ImportRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.ResourceType != req.ResourceType {
+		t.Errorf("ResourceType = %q, want %q", got.ResourceType, req.ResourceType)
+	}
+	if got.ResourceName != req.ResourceName {
+		t.Errorf("ResourceName = %q, want %q", got.ResourceName, req.ResourceName)
+	}
+	if got.Identifier != req.Identifier {
+		t.Errorf("Identifier = %q, want %q", got.Identifier, req.Identifier)
+	}
+	if got.DeployConfig != req.DeployConfig {
+		t.Errorf("DeployConfig = %q, want %q", got.DeployConfig, req.DeployConfig)
+	}
+	if got.Environment != req.Environment {
+		t.Errorf("Environment = %q, want %q", got.Environment, req.Environment)
+	}
+	if got.PriorState != req.PriorState {
+		t.Errorf("PriorState = %q, want %q", got.PriorState, req.PriorState)
+	}
+}
+
+func TestImportResponseJSONRoundtrip(t *testing.T) {
+	resp := ImportResponse{
+		Resource: ResourceStatus{
+			Type:   "agent_runtime",
+			Name:   "my-agent",
+			Status: "healthy",
+			Detail: "Running on port 8080",
+		},
+		State: "new-adapter-state",
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got ImportResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got.Resource.Type != resp.Resource.Type {
+		t.Errorf("Resource.Type = %q, want %q", got.Resource.Type, resp.Resource.Type)
+	}
+	if got.Resource.Name != resp.Resource.Name {
+		t.Errorf("Resource.Name = %q, want %q", got.Resource.Name, resp.Resource.Name)
+	}
+	if got.Resource.Status != resp.Resource.Status {
+		t.Errorf("Resource.Status = %q, want %q", got.Resource.Status, resp.Resource.Status)
+	}
+	if got.Resource.Detail != resp.Resource.Detail {
+		t.Errorf("Resource.Detail = %q, want %q", got.Resource.Detail, resp.Resource.Detail)
+	}
+	if got.State != resp.State {
+		t.Errorf("State = %q, want %q", got.State, resp.State)
 	}
 }
 

--- a/runtime/deploy/state.go
+++ b/runtime/deploy/state.go
@@ -28,6 +28,7 @@ type State struct {
 	PackVersion    string `json:"pack_version"`
 	PackChecksum   string `json:"pack_checksum"`
 	AdapterVersion string `json:"adapter_version"`
+	LastRefreshed  string `json:"last_refreshed,omitempty"`
 	State          string `json:"state,omitempty"` // Opaque base64 adapter state
 }
 


### PR DESCRIPTION
## Summary

- Add `ActionDrift` constant and `Import` RPC method to the deploy provider interface for detecting cloud resource drift and importing pre-existing resources
- Add `deploy refresh` CLI command that queries the adapter for live resource state and updates local state to match reality
- Add `deploy import <type> <name> <id>` CLI command to adopt pre-existing cloud resources into deployment state
- Add pre-plan state refresh in `deploy plan` and `deploy` commands so plans always reflect current cloud state (soft-fail: proceeds with cached state if refresh fails)
- Add `LastRefreshed` field to persisted deploy state for tracking freshness
- Add `!` symbol for drift actions in plan output display

Closes #394

## Test plan

- [x] `ActionDrift` constant verified in `TestActionConstants`
- [x] `ImportRequest`/`ImportResponse` JSON roundtrip tests
- [x] `TestClientImport` and `TestClientImport_Error` via mock server
- [x] `TestServeIO_Import` and `TestServeIO_Import_InvalidParams` for adapter SDK
- [x] `TestStateStore_LastRefreshedRoundtrip` and omitempty behavior
- [x] All 66 deploy tests pass with `-race -count=1`
- [x] All changed files meet ≥80% coverage threshold
- [x] `golangci-lint run ./deploy/...` — 0 issues
- [x] `go build ./tools/arena/cmd/promptarena/...` — success