### PR TITLE
feat: add deploy tool targets and gateway resource planning

### DIFF
--- a/runtime/deploy/adaptersdk/arena.go
+++ b/runtime/deploy/adaptersdk/arena.go
@@ -1,0 +1,182 @@
+package adaptersdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// arenaToolSpec mirrors the tool-relevant fields from config.ToolSpec.
+type arenaToolSpec struct {
+	Name        string      `json:"name,omitempty"`
+	Description string      `json:"description"`
+	InputSchema interface{} `json:"input_schema"`
+	Mode        string      `json:"mode"`
+	HTTP        *arenaHTTP  `json:"http,omitempty"`
+}
+
+type arenaHTTP struct {
+	URL    string `json:"url"`
+	Method string `json:"method"`
+}
+
+// arenaToolData mirrors config.ToolData for JSON deserialization.
+type arenaToolData struct {
+	FilePath string `json:"file_path,omitempty"`
+	Data     []byte `json:"data,omitempty"`
+}
+
+// arenaConfig is a lightweight subset of config.Config for adapter use.
+type arenaConfig struct {
+	LoadedTools []arenaToolData           `json:"loaded_tools,omitempty"`
+	ToolSpecs   map[string]*arenaToolSpec `json:"tool_specs,omitempty"`
+}
+
+// toolManifest represents the YAML structure of a .tool.yaml file.
+type toolManifest struct {
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec toolManifestSpec `yaml:"spec"`
+}
+
+type toolManifestSpec struct {
+	Name        string      `yaml:"name"`
+	Description string      `yaml:"description"`
+	InputSchema interface{} `yaml:"input_schema"`
+	Mode        string      `yaml:"mode"`
+	HTTP        *arenaHTTP  `yaml:"http,omitempty"`
+}
+
+// arenaScenario is a lightweight subset of config.Scenario.
+type arenaScenario struct {
+	ToolPolicy *arenaToolPolicy `json:"tool_policy,omitempty"`
+}
+
+type arenaToolPolicy struct {
+	Blocklist []string `json:"blocklist,omitempty"`
+}
+
+type arenaConfigWithScenarios struct {
+	LoadedScenarios map[string]*arenaScenario `json:"loaded_scenarios,omitempty"`
+}
+
+// ExtractToolInfo parses an ArenaConfig JSON string and returns tool info
+// for deploy planning. It reads from both inline ToolSpecs and loaded tool data.
+func ExtractToolInfo(arenaConfigJSON string) ([]ToolInfo, error) {
+	if arenaConfigJSON == "" {
+		return nil, nil
+	}
+	var cfg arenaConfig
+	if err := json.Unmarshal([]byte(arenaConfigJSON), &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse arena config: %w", err)
+	}
+	var tools []ToolInfo
+
+	// From ToolSpecs (inline specs — already structured)
+	for name, spec := range cfg.ToolSpecs {
+		tools = append(tools, ToolInfo{
+			Name:        name,
+			Description: spec.Description,
+			Mode:        spec.Mode,
+			HasSchema:   spec.InputSchema != nil,
+			InputSchema: spec.InputSchema,
+			HTTPURL:     httpURL(spec.HTTP),
+			HTTPMethod:  httpMethod(spec.HTTP),
+		})
+	}
+
+	// From LoadedTools (file-ref tools — need YAML parsing from Data bytes)
+	for _, td := range cfg.LoadedTools {
+		info, err := parseToolData(td)
+		if err != nil {
+			continue
+		}
+		if !containsTool(tools, info.Name) {
+			tools = append(tools, info)
+		}
+	}
+
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+	return tools, nil
+}
+
+// ExtractToolPolicies returns a merged ToolPolicyInfo from all scenarios in the ArenaConfig.
+func ExtractToolPolicies(arenaConfigJSON string) (*ToolPolicyInfo, error) {
+	if arenaConfigJSON == "" {
+		return nil, nil
+	}
+	var cfg arenaConfigWithScenarios
+	if err := json.Unmarshal([]byte(arenaConfigJSON), &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse arena config for policies: %w", err)
+	}
+	seen := map[string]bool{}
+	var blocklist []string
+	for _, sc := range cfg.LoadedScenarios {
+		if sc.ToolPolicy == nil {
+			continue
+		}
+		for _, b := range sc.ToolPolicy.Blocklist {
+			if !seen[b] {
+				seen[b] = true
+				blocklist = append(blocklist, b)
+			}
+		}
+	}
+	sort.Strings(blocklist)
+	if len(blocklist) == 0 {
+		return nil, nil
+	}
+	return &ToolPolicyInfo{Blocklist: blocklist}, nil
+}
+
+func parseToolData(td arenaToolData) (ToolInfo, error) {
+	if len(td.Data) == 0 {
+		return ToolInfo{}, fmt.Errorf("no data in tool entry")
+	}
+	var manifest toolManifest
+	if err := yaml.Unmarshal(td.Data, &manifest); err != nil {
+		return ToolInfo{}, fmt.Errorf("failed to parse tool manifest YAML: %w", err)
+	}
+	name := manifest.Spec.Name
+	if name == "" {
+		name = manifest.Metadata.Name
+	}
+	if name == "" {
+		return ToolInfo{}, fmt.Errorf("tool manifest has no name")
+	}
+	return ToolInfo{
+		Name:        name,
+		Description: manifest.Spec.Description,
+		Mode:        manifest.Spec.Mode,
+		HasSchema:   manifest.Spec.InputSchema != nil,
+		InputSchema: manifest.Spec.InputSchema,
+		HTTPURL:     httpURL(manifest.Spec.HTTP),
+		HTTPMethod:  httpMethod(manifest.Spec.HTTP),
+	}, nil
+}
+
+func httpURL(h *arenaHTTP) string {
+	if h == nil {
+		return ""
+	}
+	return h.URL
+}
+
+func httpMethod(h *arenaHTTP) string {
+	if h == nil {
+		return ""
+	}
+	return h.Method
+}
+
+func containsTool(tools []ToolInfo, name string) bool {
+	for _, t := range tools {
+		if t.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/runtime/deploy/adaptersdk/arena_test.go
+++ b/runtime/deploy/adaptersdk/arena_test.go
@@ -1,0 +1,374 @@
+package adaptersdk
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractToolInfo_FromToolSpecs(t *testing.T) {
+	arenaJSON := `{
+		"tool_specs": {
+			"get_weather": {
+				"description": "Get weather forecast",
+				"input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+				"mode": "live",
+				"http": {"url": "https://api.weather.com/v1", "method": "POST"}
+			},
+			"calculate": {
+				"description": "Perform calculations",
+				"input_schema": {"type": "object"},
+				"mode": "mock"
+			}
+		}
+	}`
+	tools, err := ExtractToolInfo(arenaJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+
+	// Tools should be sorted alphabetically
+	if tools[0].Name != "calculate" {
+		t.Errorf("expected first tool calculate, got %s", tools[0].Name)
+	}
+	if tools[1].Name != "get_weather" {
+		t.Errorf("expected second tool get_weather, got %s", tools[1].Name)
+	}
+
+	// Check get_weather details
+	weather := tools[1]
+	if weather.Description != "Get weather forecast" {
+		t.Errorf("unexpected description: %s", weather.Description)
+	}
+	if weather.Mode != "live" {
+		t.Errorf("unexpected mode: %s", weather.Mode)
+	}
+	if !weather.HasSchema {
+		t.Error("expected HasSchema to be true")
+	}
+	if weather.HTTPURL != "https://api.weather.com/v1" {
+		t.Errorf("unexpected HTTP URL: %s", weather.HTTPURL)
+	}
+	if weather.HTTPMethod != "POST" {
+		t.Errorf("unexpected HTTP method: %s", weather.HTTPMethod)
+	}
+
+	// Check calculate details
+	calc := tools[0]
+	if calc.Mode != "mock" {
+		t.Errorf("unexpected mode: %s", calc.Mode)
+	}
+	if calc.HTTPURL != "" {
+		t.Errorf("expected empty HTTP URL, got %s", calc.HTTPURL)
+	}
+}
+
+func TestExtractToolInfo_FromLoadedTools(t *testing.T) {
+	toolYAML := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: search_docs
+spec:
+  name: search_docs
+  description: Search documentation
+  input_schema:
+    type: object
+    properties:
+      query:
+        type: string
+  mode: live
+  http:
+    url: https://api.docs.com/search
+    method: GET`
+
+	arenaJSON, _ := json.Marshal(map[string]interface{}{
+		"loaded_tools": []map[string]interface{}{
+			{
+				"file_path": "tools/search.tool.yaml",
+				"data":      []byte(toolYAML),
+			},
+		},
+	})
+
+	tools, err := ExtractToolInfo(string(arenaJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	if tools[0].Name != "search_docs" {
+		t.Errorf("expected name search_docs, got %s", tools[0].Name)
+	}
+	if tools[0].Description != "Search documentation" {
+		t.Errorf("unexpected description: %s", tools[0].Description)
+	}
+	if tools[0].Mode != "live" {
+		t.Errorf("unexpected mode: %s", tools[0].Mode)
+	}
+	if !tools[0].HasSchema {
+		t.Error("expected HasSchema to be true")
+	}
+	if tools[0].HTTPURL != "https://api.docs.com/search" {
+		t.Errorf("unexpected HTTP URL: %s", tools[0].HTTPURL)
+	}
+}
+
+func TestExtractToolInfo_Empty(t *testing.T) {
+	tools, err := ExtractToolInfo("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tools != nil {
+		t.Errorf("expected nil, got %v", tools)
+	}
+}
+
+func TestExtractToolInfo_InvalidJSON(t *testing.T) {
+	_, err := ExtractToolInfo("{invalid}")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestExtractToolInfo_Deduplication(t *testing.T) {
+	toolYAML := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: get_weather
+spec:
+  name: get_weather
+  description: From loaded tools
+  mode: mock`
+
+	// Build JSON with both inline spec and loaded tool for same name
+	arenaJSON, _ := json.Marshal(map[string]interface{}{
+		"tool_specs": map[string]interface{}{
+			"get_weather": map[string]interface{}{
+				"description":  "From inline spec",
+				"input_schema": nil,
+				"mode":         "live",
+			},
+		},
+		"loaded_tools": []map[string]interface{}{
+			{
+				"file_path": "tools/weather.tool.yaml",
+				"data":      []byte(toolYAML),
+			},
+		},
+	})
+
+	tools, err := ExtractToolInfo(string(arenaJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool (deduplicated), got %d", len(tools))
+	}
+	// Inline spec takes precedence
+	if tools[0].Description != "From inline spec" {
+		t.Errorf("expected inline spec description, got %s", tools[0].Description)
+	}
+	if tools[0].Mode != "live" {
+		t.Errorf("expected inline spec mode, got %s", tools[0].Mode)
+	}
+}
+
+func TestExtractToolInfo_MetadataNameFallback(t *testing.T) {
+	// Tool with name only in metadata, not in spec
+	toolYAML := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: from_metadata
+spec:
+  description: Uses metadata name
+  mode: mock`
+
+	arenaJSON, _ := json.Marshal(map[string]interface{}{
+		"loaded_tools": []map[string]interface{}{
+			{
+				"data": []byte(toolYAML),
+			},
+		},
+	})
+
+	tools, err := ExtractToolInfo(string(arenaJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	if tools[0].Name != "from_metadata" {
+		t.Errorf("expected name from_metadata, got %s", tools[0].Name)
+	}
+}
+
+func TestExtractToolInfo_SkipsInvalidToolData(t *testing.T) {
+	arenaJSON, _ := json.Marshal(map[string]interface{}{
+		"loaded_tools": []map[string]interface{}{
+			{"data": []byte("not: valid: yaml: [")},
+			{"file_path": "empty.yaml"}, // no data
+		},
+		"tool_specs": map[string]interface{}{
+			"valid_tool": map[string]interface{}{
+				"description": "A valid tool",
+				"mode":        "mock",
+			},
+		},
+	})
+
+	tools, err := ExtractToolInfo(string(arenaJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool (skipped invalid), got %d", len(tools))
+	}
+	if tools[0].Name != "valid_tool" {
+		t.Errorf("expected valid_tool, got %s", tools[0].Name)
+	}
+}
+
+func TestExtractToolPolicies_BlocklistMerge(t *testing.T) {
+	arenaJSON := `{
+		"loaded_scenarios": {
+			"scenario1": {
+				"tool_policy": {
+					"blocklist": ["dangerous_tool", "admin_tool"]
+				}
+			},
+			"scenario2": {
+				"tool_policy": {
+					"blocklist": ["admin_tool", "debug_tool"]
+				}
+			}
+		}
+	}`
+	policy, err := ExtractToolPolicies(arenaJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy == nil {
+		t.Fatal("expected non-nil policy")
+	}
+	// Merged and sorted: admin_tool, dangerous_tool, debug_tool
+	if len(policy.Blocklist) != 3 {
+		t.Fatalf("expected 3 blocklist entries, got %d", len(policy.Blocklist))
+	}
+	expected := []string{"admin_tool", "dangerous_tool", "debug_tool"}
+	for i, e := range expected {
+		if policy.Blocklist[i] != e {
+			t.Errorf("blocklist[%d]: expected %s, got %s", i, e, policy.Blocklist[i])
+		}
+	}
+}
+
+func TestExtractToolPolicies_NoPolicies(t *testing.T) {
+	arenaJSON := `{
+		"loaded_scenarios": {
+			"scenario1": {},
+			"scenario2": {"tool_policy": {}}
+		}
+	}`
+	policy, err := ExtractToolPolicies(arenaJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy != nil {
+		t.Errorf("expected nil policy, got %v", policy)
+	}
+}
+
+func TestExtractToolPolicies_Empty(t *testing.T) {
+	policy, err := ExtractToolPolicies("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy != nil {
+		t.Errorf("expected nil, got %v", policy)
+	}
+}
+
+func TestExtractToolPolicies_InvalidJSON(t *testing.T) {
+	_, err := ExtractToolPolicies("{bad}")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestIntegration_EndToEndToolGatewayPlanning(t *testing.T) {
+	// Build ArenaConfig with tools
+	arenaJSON := `{
+		"tool_specs": {
+			"get_weather": {
+				"description": "Get weather",
+				"input_schema": {"type": "object"},
+				"mode": "live",
+				"http": {"url": "https://api.weather.com", "method": "POST"}
+			},
+			"search": {
+				"description": "Search docs",
+				"input_schema": {"type": "object"},
+				"mode": "live"
+			},
+			"mock_tool": {
+				"description": "A mock tool",
+				"mode": "mock"
+			}
+		}
+	}`
+
+	// Build deploy config with tool targets (only for some tools)
+	deployJSON := `{
+		"provider": "agentcore",
+		"tool_targets": {
+			"get_weather": {"lambda_arn": "arn:aws:lambda:us-east-1:123:function:weather"},
+			"search": {"lambda_arn": "arn:aws:lambda:us-east-1:123:function:search"}
+		}
+	}`
+
+	// Step 1: Extract tool info
+	tools, err := ExtractToolInfo(arenaJSON)
+	if err != nil {
+		t.Fatalf("ExtractToolInfo error: %v", err)
+	}
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+
+	// Step 2: Parse tool targets
+	targets, err := ParseDeployToolTargets(deployJSON)
+	if err != nil {
+		t.Fatalf("ParseDeployToolTargets error: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(targets))
+	}
+
+	// Step 3: Generate tool gateway plan
+	changes := GenerateToolGatewayPlan(tools, targets)
+	if len(changes) != 2 {
+		t.Fatalf("expected 2 tool_gateway changes, got %d", len(changes))
+	}
+
+	// Verify: only get_weather and search get gateway resources (not mock_tool)
+	names := map[string]bool{}
+	for _, c := range changes {
+		names[c.Name] = true
+		if c.Type != "tool_gateway" {
+			t.Errorf("expected type tool_gateway, got %s", c.Type)
+		}
+	}
+	if !names["get_weather"] {
+		t.Error("expected get_weather in changes")
+	}
+	if !names["search"] {
+		t.Error("expected search in changes")
+	}
+	if names["mock_tool"] {
+		t.Error("mock_tool should not be in changes")
+	}
+}

--- a/runtime/deploy/adaptersdk/tools.go
+++ b/runtime/deploy/adaptersdk/tools.go
@@ -1,0 +1,69 @@
+package adaptersdk
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+)
+
+// ToolInfo holds tool metadata extracted from ArenaConfig for deploy planning.
+type ToolInfo struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Mode        string      `json:"mode"` // "mock", "live", "mcp", "a2a"
+	HasSchema   bool        `json:"has_schema"`
+	InputSchema interface{} `json:"input_schema,omitempty"`
+	HTTPURL     string      `json:"http_url,omitempty"`
+	HTTPMethod  string      `json:"http_method,omitempty"`
+}
+
+// ToolTargetMap is an opaque map of tool name → adapter-specific target config.
+// Each adapter defines its own target schema; the SDK only tracks which tools have targets.
+type ToolTargetMap map[string]json.RawMessage
+
+// ToolPolicyInfo holds tool policy from scenarios for deploy planning.
+type ToolPolicyInfo struct {
+	Blocklist []string `json:"blocklist,omitempty"`
+}
+
+// ParseDeployToolTargets extracts the tool_targets map from the opaque deploy config JSON.
+// Returns raw JSON per tool so each adapter can unmarshal into its own target type.
+func ParseDeployToolTargets(deployConfigJSON string) (ToolTargetMap, error) {
+	if deployConfigJSON == "" {
+		return nil, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(deployConfigJSON), &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse deploy config: %w", err)
+	}
+	targetsRaw, ok := raw["tool_targets"]
+	if !ok {
+		return nil, nil
+	}
+	var targets ToolTargetMap
+	if err := json.Unmarshal(targetsRaw, &targets); err != nil {
+		return nil, fmt.Errorf("failed to parse tool_targets: %w", err)
+	}
+	return targets, nil
+}
+
+// GenerateToolGatewayPlan creates resource changes for tools that have target mappings.
+func GenerateToolGatewayPlan(tools []ToolInfo, targets ToolTargetMap) []deploy.ResourceChange {
+	if len(tools) == 0 || len(targets) == 0 {
+		return nil
+	}
+	var changes []deploy.ResourceChange
+	for _, tool := range tools {
+		if _, hasTarget := targets[tool.Name]; !hasTarget {
+			continue
+		}
+		changes = append(changes, deploy.ResourceChange{
+			Type:   "tool_gateway",
+			Name:   tool.Name,
+			Action: deploy.ActionCreate,
+			Detail: fmt.Sprintf("Create gateway target for tool %s", tool.Name),
+		})
+	}
+	return changes
+}

--- a/runtime/deploy/adaptersdk/tools_test.go
+++ b/runtime/deploy/adaptersdk/tools_test.go
@@ -1,0 +1,153 @@
+package adaptersdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+)
+
+func TestParseDeployToolTargets_ValidConfig(t *testing.T) {
+	configJSON := `{
+		"provider": "agentcore",
+		"tool_targets": {
+			"get_weather": {"lambda_arn": "arn:aws:lambda:us-east-1:123:function:weather"},
+			"search": {"lambda_arn": "arn:aws:lambda:us-east-1:123:function:search"}
+		}
+	}`
+	targets, err := ParseDeployToolTargets(configJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(targets))
+	}
+
+	// Verify raw JSON is preserved for adapter-specific unmarshaling
+	var weatherTarget struct {
+		LambdaARN string `json:"lambda_arn"`
+	}
+	if err := json.Unmarshal(targets["get_weather"], &weatherTarget); err != nil {
+		t.Fatalf("failed to unmarshal weather target: %v", err)
+	}
+	if weatherTarget.LambdaARN != "arn:aws:lambda:us-east-1:123:function:weather" {
+		t.Errorf("expected weather lambda ARN, got %s", weatherTarget.LambdaARN)
+	}
+}
+
+func TestParseDeployToolTargets_NoToolTargets(t *testing.T) {
+	configJSON := `{"provider": "agentcore"}`
+	targets, err := ParseDeployToolTargets(configJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if targets != nil {
+		t.Errorf("expected nil targets, got %v", targets)
+	}
+}
+
+func TestParseDeployToolTargets_EmptyString(t *testing.T) {
+	targets, err := ParseDeployToolTargets("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if targets != nil {
+		t.Errorf("expected nil targets, got %v", targets)
+	}
+}
+
+func TestParseDeployToolTargets_InvalidJSON(t *testing.T) {
+	_, err := ParseDeployToolTargets("{invalid}")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseDeployToolTargets_InvalidToolTargetsJSON(t *testing.T) {
+	configJSON := `{"tool_targets": "not-an-object"}`
+	_, err := ParseDeployToolTargets(configJSON)
+	if err == nil {
+		t.Fatal("expected error for invalid tool_targets JSON")
+	}
+}
+
+func TestGenerateToolGatewayPlan_ToolsWithTargets(t *testing.T) {
+	tools := []ToolInfo{
+		{Name: "get_weather", Description: "Get weather", Mode: "live"},
+		{Name: "search", Description: "Search", Mode: "live"},
+	}
+	targets := ToolTargetMap{
+		"get_weather": json.RawMessage(`{"lambda_arn": "arn:123"}`),
+		"search":      json.RawMessage(`{"lambda_arn": "arn:456"}`),
+	}
+
+	changes := GenerateToolGatewayPlan(tools, targets)
+	if len(changes) != 2 {
+		t.Fatalf("expected 2 changes, got %d", len(changes))
+	}
+	for i, c := range changes {
+		if c.Type != "tool_gateway" {
+			t.Errorf("change[%d]: expected type tool_gateway, got %s", i, c.Type)
+		}
+		if c.Action != deploy.ActionCreate {
+			t.Errorf("change[%d]: expected action CREATE, got %s", i, c.Action)
+		}
+	}
+	if changes[0].Name != "get_weather" {
+		t.Errorf("expected first change name get_weather, got %s", changes[0].Name)
+	}
+	if changes[1].Name != "search" {
+		t.Errorf("expected second change name search, got %s", changes[1].Name)
+	}
+}
+
+func TestGenerateToolGatewayPlan_ToolsWithoutTargets(t *testing.T) {
+	tools := []ToolInfo{
+		{Name: "get_weather", Description: "Get weather", Mode: "live"},
+		{Name: "search", Description: "Search", Mode: "mock"},
+	}
+	targets := ToolTargetMap{
+		"other_tool": json.RawMessage(`{"lambda_arn": "arn:789"}`),
+	}
+
+	changes := GenerateToolGatewayPlan(tools, targets)
+	if len(changes) != 0 {
+		t.Fatalf("expected 0 changes, got %d", len(changes))
+	}
+}
+
+func TestGenerateToolGatewayPlan_PartialMatch(t *testing.T) {
+	tools := []ToolInfo{
+		{Name: "get_weather", Description: "Get weather", Mode: "live"},
+		{Name: "search", Description: "Search", Mode: "live"},
+		{Name: "calculate", Description: "Calculate", Mode: "mock"},
+	}
+	targets := ToolTargetMap{
+		"search": json.RawMessage(`{"lambda_arn": "arn:456"}`),
+	}
+
+	changes := GenerateToolGatewayPlan(tools, targets)
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+	if changes[0].Name != "search" {
+		t.Errorf("expected change name search, got %s", changes[0].Name)
+	}
+}
+
+func TestGenerateToolGatewayPlan_EmptyInputs(t *testing.T) {
+	if changes := GenerateToolGatewayPlan(nil, nil); changes != nil {
+		t.Errorf("expected nil for nil inputs, got %v", changes)
+	}
+	if changes := GenerateToolGatewayPlan([]ToolInfo{}, ToolTargetMap{}); changes != nil {
+		t.Errorf("expected nil for empty inputs, got %v", changes)
+	}
+	tools := []ToolInfo{{Name: "a"}}
+	if changes := GenerateToolGatewayPlan(tools, nil); changes != nil {
+		t.Errorf("expected nil for nil targets, got %v", changes)
+	}
+	targets := ToolTargetMap{"a": json.RawMessage(`{}`)}
+	if changes := GenerateToolGatewayPlan(nil, targets); changes != nil {
+		t.Errorf("expected nil for nil tools, got %v", changes)
+	}
+}


### PR DESCRIPTION
## Summary
- Add adapter-agnostic tool target parsing (`ParseDeployToolTargets`) that extracts `tool_targets` as opaque JSON per tool, letting each adapter (AWS, GCP, etc.) define its own target schema
- Add lightweight ArenaConfig parsing helpers (`ExtractToolInfo`, `ExtractToolPolicies`) so adapters can extract tool metadata and blocklist info without importing heavy `pkg/config` dependencies
- Add per-tool gateway resource planning (`GenerateToolGatewayPlan`) that generates `tool_gateway` resource changes for tools with target mappings

## Test plan
- [x] `ParseDeployToolTargets` — valid config, no targets, empty string, invalid JSON, invalid targets JSON
- [x] `GenerateToolGatewayPlan` — tools with targets, without targets, partial match, empty inputs
- [x] `ExtractToolInfo` — from ToolSpecs, from LoadedTools YAML, empty, invalid JSON, deduplication, metadata name fallback, skips invalid data
- [x] `ExtractToolPolicies` — blocklist merge, no policies, empty, invalid JSON
- [x] End-to-end integration test: ArenaConfig + deploy config → correct resource plan
- [x] All existing adaptersdk tests still pass
- [x] Coverage: `tools.go` 100%, `arena.go` 98.2%