### PR TITLE
feat: add EmbeddingSelector for RAG-based skill selection

### DIFF
--- a/runtime/skills/selector_embedding.go
+++ b/runtime/skills/selector_embedding.go
@@ -1,0 +1,163 @@
+package skills
+
+import (
+	"context"
+	"math"
+	"sort"
+)
+
+// EmbeddingProvider generates vector embeddings for text inputs.
+// Implementations may wrap OpenAI, Anthropic, or local embedding models.
+type EmbeddingProvider interface {
+	// Embed returns embedding vectors for the given texts.
+	// Each text produces one vector. All vectors must have the same dimensionality.
+	Embed(ctx context.Context, texts []string) ([][]float64, error)
+}
+
+// embeddedSkill pairs a skill name with its precomputed embedding vector.
+type embeddedSkill struct {
+	name      string
+	embedding []float64
+}
+
+// EmbeddingSelector uses semantic similarity to select the most relevant skills
+// for a given query. It precomputes embeddings for all skill descriptions at
+// initialization and ranks skills by cosine similarity at selection time.
+//
+// Effective for large skill sets (50+) where showing all skills in the Phase 1
+// index would waste context. Returns the top-k most relevant skills.
+//
+// Safe for concurrent use after Build() completes.
+type EmbeddingSelector struct {
+	provider EmbeddingProvider
+	topK     int
+	index    []embeddedSkill
+}
+
+// NewEmbeddingSelector creates a new EmbeddingSelector with the given provider
+// and top-k count. If topK <= 0, it defaults to 10.
+func NewEmbeddingSelector(provider EmbeddingProvider, topK int) *EmbeddingSelector {
+	if topK <= 0 {
+		topK = 10
+	}
+	return &EmbeddingSelector{
+		provider: provider,
+		topK:     topK,
+	}
+}
+
+// Build precomputes embeddings for the given skills' descriptions.
+// Must be called before Select. Safe to call multiple times to rebuild the index.
+func (s *EmbeddingSelector) Build(ctx context.Context, skills []SkillMetadata) error {
+	if len(skills) == 0 {
+		s.index = nil
+		return nil
+	}
+
+	texts := make([]string, len(skills))
+	for i, sk := range skills {
+		texts[i] = sk.Name + ": " + sk.Description
+	}
+
+	embeddings, err := s.provider.Embed(ctx, texts)
+	if err != nil {
+		return err
+	}
+
+	index := make([]embeddedSkill, len(skills))
+	for i, sk := range skills {
+		index[i] = embeddedSkill{
+			name:      sk.Name,
+			embedding: embeddings[i],
+		}
+	}
+	s.index = index
+	return nil
+}
+
+// Select returns the top-k skill names most semantically similar to the query.
+// If the embedding provider fails, it falls back to returning all skill names
+// (equivalent to ModelDrivenSelector behavior).
+// If available skills differ from the built index, only indexed skills that
+// appear in available are considered.
+func (s *EmbeddingSelector) Select(
+	ctx context.Context,
+	query string,
+	available []SkillMetadata,
+) ([]string, error) {
+	// No index or no available skills — return all available
+	if len(s.index) == 0 || len(available) == 0 {
+		return allNames(available), nil
+	}
+
+	// Build set of currently available skill names
+	availableSet := make(map[string]bool, len(available))
+	for _, sk := range available {
+		availableSet[sk.Name] = true
+	}
+
+	// Embed the query
+	embeddings, err := s.provider.Embed(ctx, []string{query})
+	if err != nil {
+		// Graceful fallback: return all available skills
+		return allNames(available), nil
+	}
+	queryVec := embeddings[0]
+
+	// Score each indexed skill that is in the available set
+	type scored struct {
+		name  string
+		score float64
+	}
+	var candidates []scored
+	for _, es := range s.index {
+		if !availableSet[es.name] {
+			continue
+		}
+		sim := cosineSimilarity(queryVec, es.embedding)
+		candidates = append(candidates, scored{name: es.name, score: sim})
+	}
+
+	// Sort by descending similarity
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].score > candidates[j].score
+	})
+
+	// Return top-k
+	k := min(s.topK, len(candidates))
+	names := make([]string, k)
+	for i := 0; i < k; i++ {
+		names[i] = candidates[i].name
+	}
+	return names, nil
+}
+
+// allNames extracts skill names from metadata.
+func allNames(skills []SkillMetadata) []string {
+	names := make([]string, len(skills))
+	for i, sk := range skills {
+		names[i] = sk.Name
+	}
+	return names
+}
+
+// cosineSimilarity computes the cosine similarity between two vectors.
+// Returns 0 if either vector has zero magnitude.
+func cosineSimilarity(a, b []float64) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+
+	var dot, magA, magB float64
+	for i := range a {
+		dot += a[i] * b[i]
+		magA += a[i] * a[i]
+		magB += b[i] * b[i]
+	}
+
+	mag := math.Sqrt(magA) * math.Sqrt(magB)
+	if mag == 0 {
+		return 0
+	}
+	return dot / mag
+}

--- a/runtime/skills/selector_embedding_test.go
+++ b/runtime/skills/selector_embedding_test.go
@@ -1,0 +1,364 @@
+package skills
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+)
+
+// mockEmbeddingProvider returns preset embeddings for testing.
+type mockEmbeddingProvider struct {
+	embeddings map[string][]float64
+	callCount  int
+	err        error
+}
+
+func (m *mockEmbeddingProvider) Embed(_ context.Context, texts []string) ([][]float64, error) {
+	m.callCount++
+	if m.err != nil {
+		return nil, m.err
+	}
+	result := make([][]float64, len(texts))
+	for i, text := range texts {
+		if emb, ok := m.embeddings[text]; ok {
+			result[i] = emb
+		} else {
+			// Return zero vector for unknown texts
+			result[i] = make([]float64, 3)
+		}
+	}
+	return result, nil
+}
+
+func TestNewEmbeddingSelector(t *testing.T) {
+	provider := &mockEmbeddingProvider{}
+
+	s := NewEmbeddingSelector(provider, 5)
+	if s.topK != 5 {
+		t.Errorf("topK = %d, want 5", s.topK)
+	}
+	if s.provider != provider {
+		t.Error("provider not set")
+	}
+}
+
+func TestNewEmbeddingSelector_DefaultTopK(t *testing.T) {
+	s := NewEmbeddingSelector(&mockEmbeddingProvider{}, 0)
+	if s.topK != 10 {
+		t.Errorf("topK = %d, want 10 (default)", s.topK)
+	}
+
+	s2 := NewEmbeddingSelector(&mockEmbeddingProvider{}, -1)
+	if s2.topK != 10 {
+		t.Errorf("topK = %d, want 10 (default for negative)", s2.topK)
+	}
+}
+
+func TestEmbeddingSelector_Build(t *testing.T) {
+	provider := &mockEmbeddingProvider{
+		embeddings: map[string][]float64{
+			"billing: Handle billing inquiries":   {1, 0, 0},
+			"shipping: Handle shipping questions": {0, 1, 0},
+		},
+	}
+
+	s := NewEmbeddingSelector(provider, 5)
+	ctx := context.Background()
+
+	skills := []SkillMetadata{
+		{Name: "billing", Description: "Handle billing inquiries"},
+		{Name: "shipping", Description: "Handle shipping questions"},
+	}
+
+	err := s.Build(ctx, skills)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if len(s.index) != 2 {
+		t.Fatalf("index length = %d, want 2", len(s.index))
+	}
+	if s.index[0].name != "billing" {
+		t.Errorf("index[0].name = %q, want %q", s.index[0].name, "billing")
+	}
+	if provider.callCount != 1 {
+		t.Errorf("provider called %d times, want 1", provider.callCount)
+	}
+}
+
+func TestEmbeddingSelector_BuildEmpty(t *testing.T) {
+	s := NewEmbeddingSelector(&mockEmbeddingProvider{}, 5)
+	err := s.Build(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if s.index != nil {
+		t.Errorf("index should be nil for empty skills")
+	}
+}
+
+func TestEmbeddingSelector_BuildError(t *testing.T) {
+	provider := &mockEmbeddingProvider{err: errors.New("embedding service unavailable")}
+
+	s := NewEmbeddingSelector(provider, 5)
+	err := s.Build(context.Background(), []SkillMetadata{
+		{Name: "billing", Description: "Handle billing"},
+	})
+	if err == nil {
+		t.Fatal("Build() should return error")
+	}
+}
+
+func TestEmbeddingSelector_Select_TopK(t *testing.T) {
+	// Create embeddings where billing is closest to the query
+	provider := &mockEmbeddingProvider{
+		embeddings: map[string][]float64{
+			"billing: Handle billing inquiries":      {0.9, 0.1, 0.0},
+			"shipping: Handle shipping questions":    {0.1, 0.9, 0.0},
+			"returns: Handle return requests":        {0.8, 0.2, 0.0},
+			"escalation: Escalate to supervisor":     {0.0, 0.1, 0.9},
+			"I need help with my bill and a refund.": {0.95, 0.05, 0.0},
+		},
+	}
+
+	s := NewEmbeddingSelector(provider, 2)
+	ctx := context.Background()
+
+	skills := []SkillMetadata{
+		{Name: "billing", Description: "Handle billing inquiries"},
+		{Name: "shipping", Description: "Handle shipping questions"},
+		{Name: "returns", Description: "Handle return requests"},
+		{Name: "escalation", Description: "Escalate to supervisor"},
+	}
+
+	err := s.Build(ctx, skills)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	names, err := s.Select(ctx, "I need help with my bill and a refund.", skills)
+	if err != nil {
+		t.Fatalf("Select() error: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("got %d names, want 2", len(names))
+	}
+	// billing should be first (most similar), returns second
+	if names[0] != "billing" {
+		t.Errorf("names[0] = %q, want %q", names[0], "billing")
+	}
+	if names[1] != "returns" {
+		t.Errorf("names[1] = %q, want %q", names[1], "returns")
+	}
+}
+
+func TestEmbeddingSelector_Select_TopKLargerThanAvailable(t *testing.T) {
+	provider := &mockEmbeddingProvider{
+		embeddings: map[string][]float64{
+			"billing: Handle billing":  {1, 0, 0},
+			"shipping: Handle shipping": {0, 1, 0},
+			"query":                     {0.5, 0.5, 0},
+		},
+	}
+
+	s := NewEmbeddingSelector(provider, 10) // topK=10 but only 2 skills
+	ctx := context.Background()
+
+	skills := []SkillMetadata{
+		{Name: "billing", Description: "Handle billing"},
+		{Name: "shipping", Description: "Handle shipping"},
+	}
+	_ = s.Build(ctx, skills)
+
+	names, err := s.Select(ctx, "query", skills)
+	if err != nil {
+		t.Fatalf("Select() error: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("got %d names, want 2 (all available)", len(names))
+	}
+}
+
+func TestEmbeddingSelector_Select_EmptyIndex(t *testing.T) {
+	s := NewEmbeddingSelector(&mockEmbeddingProvider{}, 5)
+	// No Build() called
+
+	available := []SkillMetadata{
+		{Name: "billing", Description: "Handle billing"},
+	}
+
+	names, err := s.Select(context.Background(), "help", available)
+	if err != nil {
+		t.Fatalf("Select() error: %v", err)
+	}
+	if len(names) != 1 || names[0] != "billing" {
+		t.Errorf("expected fallback to all names, got %v", names)
+	}
+}
+
+func TestEmbeddingSelector_Select_EmptyAvailable(t *testing.T) {
+	s := NewEmbeddingSelector(&mockEmbeddingProvider{}, 5)
+
+	names, err := s.Select(context.Background(), "help", nil)
+	if err != nil {
+		t.Fatalf("Select() error: %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("expected empty names for nil available, got %v", names)
+	}
+}
+
+func TestEmbeddingSelector_Select_EmbedErrorFallback(t *testing.T) {
+	provider := &mockEmbeddingProvider{
+		embeddings: map[string][]float64{
+			"billing: Handle billing": {1, 0, 0},
+		},
+	}
+
+	s := NewEmbeddingSelector(provider, 5)
+	ctx := context.Background()
+
+	skills := []SkillMetadata{
+		{Name: "billing", Description: "Handle billing"},
+	}
+	_ = s.Build(ctx, skills)
+
+	// Now make provider fail for the query embedding
+	provider.err = errors.New("rate limited")
+
+	names, err := s.Select(ctx, "help with billing", skills)
+	if err != nil {
+		t.Fatalf("Select() should not return error on embed failure, got: %v", err)
+	}
+	// Should fall back to all available
+	if len(names) != 1 || names[0] != "billing" {
+		t.Errorf("expected fallback to all names, got %v", names)
+	}
+}
+
+func TestEmbeddingSelector_Select_FiltersByAvailable(t *testing.T) {
+	provider := &mockEmbeddingProvider{
+		embeddings: map[string][]float64{
+			"billing: Handle billing":   {0.9, 0.1, 0},
+			"shipping: Handle shipping": {0.1, 0.9, 0},
+			"returns: Handle returns":   {0.8, 0.2, 0},
+			"query":                     {0.95, 0.05, 0},
+		},
+	}
+
+	s := NewEmbeddingSelector(provider, 5)
+	ctx := context.Background()
+
+	allSkills := []SkillMetadata{
+		{Name: "billing", Description: "Handle billing"},
+		{Name: "shipping", Description: "Handle shipping"},
+		{Name: "returns", Description: "Handle returns"},
+	}
+	_ = s.Build(ctx, allSkills)
+
+	// Only billing and shipping are available (e.g., workflow state filter)
+	available := []SkillMetadata{
+		{Name: "billing", Description: "Handle billing"},
+		{Name: "shipping", Description: "Handle shipping"},
+	}
+
+	names, err := s.Select(ctx, "query", available)
+	if err != nil {
+		t.Fatalf("Select() error: %v", err)
+	}
+	// returns should not appear even though it's in the index
+	for _, n := range names {
+		if n == "returns" {
+			t.Error("returns should not be in results — not in available set")
+		}
+	}
+}
+
+func TestEmbeddingSelector_BuildRebuild(t *testing.T) {
+	provider := &mockEmbeddingProvider{
+		embeddings: map[string][]float64{
+			"billing: Handle billing":   {1, 0, 0},
+			"shipping: Handle shipping": {0, 1, 0},
+		},
+	}
+
+	s := NewEmbeddingSelector(provider, 5)
+	ctx := context.Background()
+
+	// Initial build
+	_ = s.Build(ctx, []SkillMetadata{
+		{Name: "billing", Description: "Handle billing"},
+	})
+	if len(s.index) != 1 {
+		t.Fatalf("index length = %d after first build, want 1", len(s.index))
+	}
+
+	// Rebuild with different skills
+	_ = s.Build(ctx, []SkillMetadata{
+		{Name: "billing", Description: "Handle billing"},
+		{Name: "shipping", Description: "Handle shipping"},
+	})
+	if len(s.index) != 2 {
+		t.Fatalf("index length = %d after rebuild, want 2", len(s.index))
+	}
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []float64
+		want float64
+	}{
+		{
+			name: "identical vectors",
+			a:    []float64{1, 0, 0},
+			b:    []float64{1, 0, 0},
+			want: 1.0,
+		},
+		{
+			name: "orthogonal vectors",
+			a:    []float64{1, 0, 0},
+			b:    []float64{0, 1, 0},
+			want: 0.0,
+		},
+		{
+			name: "opposite vectors",
+			a:    []float64{1, 0, 0},
+			b:    []float64{-1, 0, 0},
+			want: -1.0,
+		},
+		{
+			name: "similar vectors",
+			a:    []float64{0.9, 0.1, 0},
+			b:    []float64{0.8, 0.2, 0},
+			want: 0.9910,
+		},
+		{
+			name: "empty vectors",
+			a:    []float64{},
+			b:    []float64{},
+			want: 0.0,
+		},
+		{
+			name: "different lengths",
+			a:    []float64{1, 0},
+			b:    []float64{1, 0, 0},
+			want: 0.0,
+		},
+		{
+			name: "zero magnitude vector",
+			a:    []float64{0, 0, 0},
+			b:    []float64{1, 0, 0},
+			want: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cosineSimilarity(tt.a, tt.b)
+			if math.Abs(got-tt.want) > 0.001 {
+				t.Errorf("cosineSimilarity() = %f, want %f", got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime/skills/selector_test.go
+++ b/runtime/skills/selector_test.go
@@ -208,4 +208,5 @@ func TestNewTagSelector_Deduplicates(t *testing.T) {
 func TestInterfaceCompliance(t *testing.T) {
 	var _ SkillSelector = (*ModelDrivenSelector)(nil)
 	var _ SkillSelector = (*TagSelector)(nil)
+	var _ SkillSelector = (*EmbeddingSelector)(nil)
 }


### PR DESCRIPTION
## Summary
- Adds `EmbeddingSelector` implementing the `SkillSelector` interface for semantic similarity-based skill selection
- Pluggable `EmbeddingProvider` interface — adapters can wrap OpenAI, Voyage AI, or local embedding models
- Precomputes embeddings for skill descriptions via `Build()`, then ranks by cosine similarity on `Select()` returning top-k results
- Graceful fallback: if the embedding provider errors at query time, returns all available skills (equivalent to `ModelDrivenSelector`)
- Respects workflow state filtering: only scores skills in the `available` set, even if more are indexed
- Configurable top-k with default of 10

Closes #413

## Test plan
- [x] 12 unit tests with mock embedding provider
- [x] 100% coverage on `selector_embedding.go`
- [x] 7 cosine similarity unit tests (identical, orthogonal, opposite, similar, empty, mismatched, zero magnitude)
- [x] Interface compliance check added for `EmbeddingSelector`
- [x] All existing skills tests continue to pass (94.5% package coverage)