### PR TITLE
feat: update to PromptPack schema 1.3.1 with skills support

### DIFF
--- a/runtime/prompt/pack.go
+++ b/runtime/prompt/pack.go
@@ -111,7 +111,8 @@ type Pack struct {
 // SkillSourceConfig represents a skill source in the pack YAML.
 type SkillSourceConfig struct {
 	// Directory path for filesystem-based skills
-	Dir string `json:"dir,omitempty" yaml:"dir,omitempty"`
+	Dir  string `json:"dir,omitempty" yaml:"dir,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"` // schema alias for dir
 
 	// Inline skill fields
 	Name         string `json:"name,omitempty" yaml:"name,omitempty"`
@@ -120,6 +121,14 @@ type SkillSourceConfig struct {
 
 	// Options
 	Preload bool `json:"preload,omitempty" yaml:"preload,omitempty"`
+}
+
+// EffectiveDir returns the directory path, preferring Dir over Path.
+func (s *SkillSourceConfig) EffectiveDir() string {
+	if s.Dir != "" {
+		return s.Dir
+	}
+	return s.Path
 }
 
 // PackTool represents a tool definition in the pack (per PromptPack spec Section 9)

--- a/runtime/prompt/schema/promptpack.schema.json
+++ b/runtime/prompt/schema/promptpack.schema.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://promptpack.org/schema/latest/promptpack.schema.json",
   "title": "PromptPack Specification",
-  "description": "Schema for packaging, testing, and running multi-prompt conversational systems with multimodal, workflow, and agent support",
-  "version": "1.3.0",
+  "description": "Schema for packaging, testing, and running multi-prompt conversational systems with multimodal, workflow, agent, and skills support",
+  "version": "1.3.1",
   "type": "object",
   "required": ["id", "name", "version", "template_engine", "prompts"],
   "additionalProperties": false,
@@ -205,6 +205,14 @@
     "agents": {
       "$ref": "#/$defs/AgentsConfig",
       "description": "Agent configuration mapping prompts to A2A-compatible agent definitions. Enables multi-agent orchestration via the Agent-to-Agent protocol."
+    },
+
+    "skills": {
+      "type": "array",
+      "description": "Skill sources for progressive-disclosure knowledge loading. Each entry is either a string (path or package reference), a SkillPathSource object, or an InlineSkill object.",
+      "items": {
+        "$ref": "#/$defs/SkillSource"
+      }
     }
   },
   
@@ -1265,6 +1273,11 @@
           "type": "string",
           "description": "How this state is orchestrated: internal (runtime manages), external (caller manages), or hybrid.",
           "enum": ["internal", "external", "hybrid"]
+        },
+        "skills": {
+          "type": "string",
+          "description": "Skill filter for this workflow state. A path to a skill directory/file that scopes which skills are available in this state, or the literal 'none' to disable skills.",
+          "examples": ["./skills/billing", "none"]
         }
       }
     },
@@ -1325,6 +1338,69 @@
           },
           "default": ["text/plain"],
           "examples": [["text/plain"], ["text/plain", "application/json"]]
+        }
+      }
+    },
+
+    "SkillSource": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Path to a skill directory/file or a package reference (e.g., './skills', '@acme/billing-skills')."
+        },
+        {
+          "$ref": "#/$defs/SkillPathSource"
+        },
+        {
+          "$ref": "#/$defs/InlineSkill"
+        }
+      ],
+      "description": "A skill source for progressive-disclosure knowledge loading. Can be a simple string path, a path object with preload config, or an inline skill definition."
+    },
+
+    "SkillPathSource": {
+      "type": "object",
+      "description": "A skill source with a path and optional preload configuration.",
+      "required": ["path"],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to a skill directory, file, or package reference.",
+          "examples": ["./skills/billing", "@acme/billing-skills"]
+        },
+        "preload": {
+          "type": "boolean",
+          "description": "If true, load this skill source eagerly at pack initialization rather than on demand.",
+          "default": false,
+          "examples": [true, false]
+        }
+      }
+    },
+
+    "InlineSkill": {
+      "type": "object",
+      "description": "A skill defined inline within the pack. Useful for small, pack-specific skills that don't warrant a separate file.",
+      "required": ["name", "description", "instructions"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this skill.",
+          "minLength": 1,
+          "examples": ["escalation-protocol", "refund-policy"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief description of what this skill provides.",
+          "minLength": 1,
+          "examples": ["Steps for escalating unresolved customer issues"]
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The skill's instructions or knowledge content. Loaded into the agent's context when the skill is activated.",
+          "minLength": 1,
+          "examples": ["When a customer issue cannot be resolved within 3 exchanges:\n1. Acknowledge the complexity\n2. Collect case details\n3. Create an escalation ticket"]
         }
       }
     }

--- a/runtime/skills/registry.go
+++ b/runtime/skills/registry.go
@@ -41,9 +41,9 @@ func (r *Registry) Discover(sources []SkillSource) error {
 	defer r.mu.Unlock()
 
 	for _, src := range sources {
-		if src.Dir != "" {
+		if dir := src.EffectiveDir(); dir != "" {
 			if err := r.discoverDirectory(src); err != nil {
-				return fmt.Errorf("discovering skills in %s: %w", src.Dir, err)
+				return fmt.Errorf("discovering skills in %s: %w", dir, err)
 			}
 		} else if src.Name != "" {
 			r.registerInline(src)
@@ -55,7 +55,7 @@ func (r *Registry) Discover(sources []SkillSource) error {
 // discoverDirectory walks a directory looking for SKILL.md files and registers each skill found.
 // Must be called with r.mu held.
 func (r *Registry) discoverDirectory(src SkillSource) error {
-	absDir, err := filepath.Abs(src.Dir)
+	absDir, err := filepath.Abs(src.EffectiveDir())
 	if err != nil {
 		return fmt.Errorf("resolving directory path: %w", err)
 	}

--- a/runtime/skills/types.go
+++ b/runtime/skills/types.go
@@ -22,7 +22,8 @@ type Skill struct {
 // SkillSource represents a skill reference from the pack YAML.
 type SkillSource struct {
 	// For directory-based skills
-	Dir string `yaml:"dir,omitempty" json:"dir,omitempty"`
+	Dir  string `yaml:"dir,omitempty" json:"dir,omitempty"`
+	Path string `yaml:"path,omitempty" json:"path,omitempty"` // schema alias for dir
 
 	// For inline skills
 	Name         string `yaml:"name,omitempty" json:"name,omitempty"`
@@ -31,4 +32,12 @@ type SkillSource struct {
 
 	// Options
 	Preload bool `yaml:"preload,omitempty" json:"preload,omitempty"`
+}
+
+// EffectiveDir returns the directory path, preferring Dir over Path.
+func (s *SkillSource) EffectiveDir() string {
+	if s.Dir != "" {
+		return s.Dir
+	}
+	return s.Path
 }

--- a/runtime/workflow/types.go
+++ b/runtime/workflow/types.go
@@ -21,6 +21,7 @@ type State struct {
 	OnEvent       map[string]string `json:"on_event,omitempty"`
 	Persistence   Persistence       `json:"persistence,omitempty"`
 	Orchestration Orchestration     `json:"orchestration,omitempty"`
+	Skills        string            `json:"skills,omitempty"`
 }
 
 // Persistence is the storage hint for a workflow state.

--- a/sdk/capability.go
+++ b/sdk/capability.go
@@ -57,6 +57,7 @@ func convertSkillSources(configs []pack.SkillSourceConfig) []skills.SkillSource 
 	for i, cfg := range configs {
 		sources[i] = skills.SkillSource{
 			Dir:          cfg.Dir,
+			Path:         cfg.Path,
 			Name:         cfg.Name,
 			Description:  cfg.Description,
 			Instructions: cfg.Instructions,

--- a/sdk/internal/pack/load.go
+++ b/sdk/internal/pack/load.go
@@ -57,10 +57,19 @@ type Pack struct {
 // SkillSourceConfig represents a skill source in the pack.
 type SkillSourceConfig struct {
 	Dir          string `json:"dir,omitempty"`
+	Path         string `json:"path,omitempty"` // schema alias for dir
 	Name         string `json:"name,omitempty"`
 	Description  string `json:"description,omitempty"`
 	Instructions string `json:"instructions,omitempty"`
 	Preload      bool   `json:"preload,omitempty"`
+}
+
+// EffectiveDir returns the directory path, preferring Dir over Path.
+func (s *SkillSourceConfig) EffectiveDir() string {
+	if s.Dir != "" {
+		return s.Dir
+	}
+	return s.Path
 }
 
 // Prompt represents a prompt definition within a pack.

--- a/sdk/internal/pack/workflow.go
+++ b/sdk/internal/pack/workflow.go
@@ -17,4 +17,5 @@ type WorkflowState struct {
 	OnEvent       map[string]string `json:"on_event,omitempty"`
 	Persistence   string            `json:"persistence,omitempty"`
 	Orchestration string            `json:"orchestration,omitempty"`
+	Skills        string            `json:"skills,omitempty"`
 }

--- a/tools/packc/skills_validator.go
+++ b/tools/packc/skills_validator.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/skills"
+)
+
+const skillMDFilename = "SKILL.md"
+
+// ValidateSkillErrors returns blocking errors for skill configuration in the pack.
+func ValidateSkillErrors(pack *prompt.Pack, packDir string) []string {
+	var errs []string
+
+	seen := make(map[string]bool)
+
+	for i := range pack.Skills {
+		src := &pack.Skills[i]
+		dir := src.EffectiveDir()
+		if dir != "" {
+			errs = append(errs, validateSkillDirectory(dir, packDir, i, seen)...)
+		} else if src.Name != "" {
+			errs = append(errs, validateInlineSkill(src, i, seen)...)
+		}
+	}
+
+	// Validate workflow state skills paths
+	if pack.Workflow != nil {
+		errs = append(errs, validateWorkflowStateSkills(pack.Workflow, packDir)...)
+	}
+
+	return errs
+}
+
+// ValidateSkills returns non-blocking warnings for skill configuration in the pack.
+func ValidateSkills(pack *prompt.Pack, packDir string) []string {
+	var warnings []string
+
+	// Collect all pack tool names for cross-referencing
+	packToolNames := make(map[string]bool)
+	for name := range pack.Tools {
+		packToolNames[name] = true
+	}
+
+	// Check allowed-tools cross-references
+	for i := range pack.Skills {
+		dir := pack.Skills[i].EffectiveDir()
+		if dir == "" {
+			continue
+		}
+		absDir := dir
+		if !filepath.IsAbs(absDir) {
+			absDir = filepath.Join(packDir, absDir)
+		}
+
+		warnings = append(warnings, checkAllowedToolsCrossRef(absDir, packToolNames)...)
+	}
+
+	return warnings
+}
+
+// validateSkillDirectory validates a directory-based skill source.
+func validateSkillDirectory(dir, packDir string, idx int, seen map[string]bool) []string {
+	var errs []string
+
+	absDir := dir
+	if !filepath.IsAbs(absDir) {
+		absDir = filepath.Join(packDir, absDir)
+	}
+
+	info, err := os.Stat(absDir)
+	if err != nil || !info.IsDir() {
+		errs = append(errs, fmt.Sprintf("skills[%d]: directory %q does not exist", idx, dir))
+		return errs
+	}
+
+	// Walk directory for SKILL.md files
+	err = filepath.Walk(absDir, func(path string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if fi.IsDir() || fi.Name() != skillMDFilename {
+			return nil
+		}
+
+		meta, parseErr := skills.ParseSkillMetadata(path)
+		if parseErr != nil {
+			errs = append(errs, fmt.Sprintf("skills[%d]: failed to parse %s: %v", idx, path, parseErr))
+			return nil
+		}
+
+		if seen[meta.Name] {
+			errs = append(errs, fmt.Sprintf("skills[%d]: duplicate skill name %q", idx, meta.Name))
+		}
+		seen[meta.Name] = true
+
+		return nil
+	})
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("skills[%d]: error walking directory %q: %v", idx, dir, err))
+	}
+
+	return errs
+}
+
+// validateInlineSkill validates an inline skill definition.
+func validateInlineSkill(src *prompt.SkillSourceConfig, idx int, seen map[string]bool) []string {
+	var errs []string
+
+	if src.Name == "" {
+		errs = append(errs, fmt.Sprintf("skills[%d]: inline skill missing required field: name", idx))
+	}
+	if src.Description == "" {
+		errs = append(errs, fmt.Sprintf("skills[%d]: inline skill %q missing required field: description", idx, src.Name))
+	}
+	if src.Instructions == "" {
+		errs = append(errs, fmt.Sprintf("skills[%d]: inline skill %q missing required field: instructions", idx, src.Name))
+	}
+
+	if src.Name != "" {
+		if seen[src.Name] {
+			errs = append(errs, fmt.Sprintf("skills[%d]: duplicate skill name %q", idx, src.Name))
+		}
+		seen[src.Name] = true
+	}
+
+	return errs
+}
+
+// validateWorkflowStateSkills validates skill paths referenced by workflow states.
+func validateWorkflowStateSkills(wf *prompt.WorkflowConfig, packDir string) []string {
+	var errs []string
+
+	for name, state := range wf.States {
+		if state.Skills == "" || strings.EqualFold(state.Skills, "none") {
+			continue
+		}
+
+		absPath := state.Skills
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(packDir, absPath)
+		}
+
+		info, err := os.Stat(absPath)
+		if err != nil || !info.IsDir() {
+			errs = append(errs, fmt.Sprintf(
+				"workflow state %q: skills path %q does not exist", name, state.Skills))
+		}
+	}
+
+	return errs
+}
+
+// checkAllowedToolsCrossRef checks if skill allowed-tools reference tools defined in the pack.
+func checkAllowedToolsCrossRef(absDir string, packToolNames map[string]bool) []string {
+	var warnings []string
+
+	_ = filepath.Walk(absDir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() || fi.Name() != skillMDFilename {
+			return nil //nolint:nilerr // skip non-SKILL.md files
+		}
+
+		meta, parseErr := skills.ParseSkillMetadata(path)
+		if parseErr != nil || meta == nil {
+			return nil
+		}
+
+		for _, tool := range meta.AllowedTools {
+			if !packToolNames[tool] {
+				warnings = append(warnings, fmt.Sprintf(
+					"skill %q: allowed-tool %q is not defined in pack tools", meta.Name, tool))
+			}
+		}
+		return nil
+	})
+
+	return warnings
+}

--- a/tools/packc/skills_validator_test.go
+++ b/tools/packc/skills_validator_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSkillMD(t *testing.T, dir, name, desc string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	content := "---\nname: " + name + "\ndescription: " + desc + "\n---\nInstructions here."
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0644))
+}
+
+func writeSkillMDWithTools(t *testing.T, dir, name, desc string, tools []string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	content := "---\nname: " + name + "\ndescription: " + desc + "\nallowed-tools:\n"
+	for _, tool := range tools {
+		content += "  - " + tool + "\n"
+	}
+	content += "---\nInstructions here."
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0644))
+}
+
+func TestValidateSkillErrors_ValidDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "skills", "my-skill")
+	writeSkillMD(t, skillDir, "my-skill", "A test skill")
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	assert.Empty(t, errs)
+}
+
+func TestValidateSkillErrors_MissingDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "nonexistent-dir"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "does not exist")
+}
+
+func TestValidateSkillErrors_MissingSkillMD(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create an empty directory (no SKILL.md)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "skills", "empty-skill"), 0755))
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	// No error — a directory with no SKILL.md is simply not discovered as a skill
+	errs := ValidateSkillErrors(pack, tmpDir)
+	assert.Empty(t, errs)
+}
+
+func TestValidateSkillErrors_DuplicateNames(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeSkillMD(t, filepath.Join(tmpDir, "skills-a", "sk"), "dupe-skill", "Skill A")
+	writeSkillMD(t, filepath.Join(tmpDir, "skills-b", "sk"), "dupe-skill", "Skill B")
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills-a"},
+			{Dir: "skills-b"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "duplicate skill name")
+}
+
+func TestValidateSkillErrors_InlineComplete(t *testing.T) {
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Name: "inline-skill", Description: "An inline skill", Instructions: "Do the thing."},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, "/tmp")
+	assert.Empty(t, errs)
+}
+
+func TestValidateSkillErrors_InlineIncomplete(t *testing.T) {
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Name: "incomplete-skill"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, "/tmp")
+	require.Len(t, errs, 2)
+	assert.Contains(t, errs[0], "missing required field: description")
+	assert.Contains(t, errs[1], "missing required field: instructions")
+}
+
+func TestValidateSkillErrors_PathAlias(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "my-skills", "sk")
+	writeSkillMD(t, skillDir, "path-skill", "Uses path alias")
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Path: "my-skills"}, // using path instead of dir
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	assert.Empty(t, errs)
+}
+
+func TestValidateSkillErrors_DirTakesPrecedenceOverPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeSkillMD(t, filepath.Join(tmpDir, "dir-skills", "sk"), "dir-skill", "From dir")
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "dir-skills", Path: "nonexistent"}, // dir wins
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	assert.Empty(t, errs)
+}
+
+func TestValidateSkillErrors_WorkflowStateSkills_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "state-skills"), 0755))
+
+	pack := &prompt.Pack{
+		Workflow: &workflow.Spec{
+			Version: 1,
+			Entry:   "start",
+			States: map[string]*workflow.State{
+				"start": {
+					PromptTask: "p",
+					Skills:     "state-skills",
+				},
+			},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	assert.Empty(t, errs)
+}
+
+func TestValidateSkillErrors_WorkflowStateSkills_None(t *testing.T) {
+	pack := &prompt.Pack{
+		Workflow: &workflow.Spec{
+			Version: 1,
+			Entry:   "start",
+			States: map[string]*workflow.State{
+				"start": {
+					PromptTask: "p",
+					Skills:     "none",
+				},
+			},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, "/tmp")
+	assert.Empty(t, errs)
+}
+
+func TestValidateSkillErrors_WorkflowStateSkills_Missing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pack := &prompt.Pack{
+		Workflow: &workflow.Spec{
+			Version: 1,
+			Entry:   "start",
+			States: map[string]*workflow.State{
+				"start": {
+					PromptTask: "p",
+					Skills:     "nonexistent-skills-dir",
+				},
+			},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "does not exist")
+}
+
+func TestValidateSkills_AllowedToolsCrossRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "skills", "my-skill")
+	writeSkillMDWithTools(t, skillDir, "my-skill", "Skill with tools", []string{"existing_tool", "missing_tool"})
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills"},
+		},
+		Tools: map[string]*prompt.PackTool{
+			"existing_tool": {Name: "existing_tool", Description: "Exists"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	warnings := ValidateSkills(pack, tmpDir)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "missing_tool")
+	assert.Contains(t, warnings[0], "not defined in pack tools")
+}
+
+func TestValidateSkills_AllToolsExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "skills", "my-skill")
+	writeSkillMDWithTools(t, skillDir, "my-skill", "Skill with tools", []string{"tool_a"})
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills"},
+		},
+		Tools: map[string]*prompt.PackTool{
+			"tool_a": {Name: "tool_a", Description: "Tool A"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	warnings := ValidateSkills(pack, tmpDir)
+	assert.Empty(t, warnings)
+}
+
+func TestValidateSkillErrors_SkillMDMissingName(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "skills", "bad-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0755))
+	content := "---\ndescription: no name field\n---\nInstructions."
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0644))
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "name is required")
+}
+
+func TestValidateSkillErrors_SkillMDMissingDescription(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "skills", "bad-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0755))
+	content := "---\nname: no-desc\n---\nInstructions."
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0644))
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "description is required")
+}
+
+func TestValidateSkillErrors_DuplicateAcrossInlineAndDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeSkillMD(t, filepath.Join(tmpDir, "skills", "sk"), "shared-name", "Dir skill")
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills"},
+			{Name: "shared-name", Description: "Inline skill", Instructions: "Do stuff"},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "duplicate skill name")
+}
+
+func TestValidateSkillErrors_NoSkills(t *testing.T) {
+	pack := &prompt.Pack{
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, "/tmp")
+	assert.Empty(t, errs)
+}


### PR DESCRIPTION
## Summary

- **Schema 1.3.1**: Replace embedded `promptpack.schema.json` with v1.3.1, which adds official definitions for `skills` at pack level, `skills` on `WorkflowState`, and formalizes `agents`/`workflow`
- **Workflow state skills**: Add `Skills string` field to `workflow.State` (runtime) and `WorkflowState` (SDK mirror) for per-state skill scoping
- **`path` alias**: Add `Path` field + `EffectiveDir()` helper to `SkillSourceConfig` / `SkillSource` across runtime, skills, and SDK packages — supports both `dir` (existing) and `path` (schema) formats
- **Pack compiler skill validation**: New `ValidateSkillErrors()` / `ValidateSkills()` in packc with directory existence, SKILL.md parsing, duplicate detection, inline completeness, workflow state skills path, and allowed-tools cross-ref checks

Closes #410, #412

## Test plan

- [x] `go test ./runtime/... -count=1` — all pass
- [x] `go test ./sdk/... -count=1` — all pass
- [x] `go test ./tools/packc/... -count=1` — all pass (17 new skill validator tests)
- [x] `golangci-lint run --new-from-rev=HEAD` — 0 issues
- [x] Pre-commit hook passes (lint, build, tests, coverage ≥80% on all changed files)