### PR TITLE
feat: add pack-level assertions (#424)

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -54,7 +54,8 @@ type Config struct {
 	Scenarios     []ScenarioRef     `yaml:"scenarios,omitempty" json:"scenarios,omitempty"`
 	Evals         []EvalRef         `yaml:"evals,omitempty" json:"evals,omitempty"`
 	Tools         []ToolRef         `yaml:"tools,omitempty" json:"tools,omitempty"`
-	PackEvals     []evals.EvalDef   `yaml:"pack_evals,omitempty" json:"pack_evals,omitempty"`
+	PackEvals      []evals.EvalDef        `yaml:"pack_evals,omitempty" json:"pack_evals,omitempty"`
+	PackAssertions []asrt.AssertionConfig `yaml:"pack_assertions,omitempty" json:"pack_assertions,omitempty"`
 	Workflow      interface{}       `yaml:"workflow,omitempty" json:"workflow,omitempty"`
 	Agents        interface{}       `yaml:"agents,omitempty" json:"agents,omitempty"`
 	Deploy        *DeployConfig     `yaml:"deploy,omitempty" json:"deploy,omitempty"`

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -263,6 +263,12 @@
           },
           "type": "array"
         },
+        "pack_assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array"
+        },
         "workflow": true,
         "agents": true,
         "deploy": {

--- a/tools/arena/engine/duplex_executor_assertions_integration.go
+++ b/tools/arena/engine/duplex_executor_assertions_integration.go
@@ -186,25 +186,23 @@ func (de *DuplexConversationExecutor) countFailedAssertions(results []arenaasser
 	return count
 }
 
-// evaluateConversationAssertions evaluates scenario-level conversation assertions.
+// evaluateConversationAssertions evaluates pack + scenario conversation assertions.
 func (de *DuplexConversationExecutor) evaluateConversationAssertions(
 	req *ConversationRequest,
 	messages []types.Message,
 ) []arenaassertions.ConversationValidationResult {
-	if req.Scenario == nil || len(req.Scenario.ConversationAssertions) == 0 {
+	var scenarioAssertions []arenaassertions.AssertionConfig
+	if req.Scenario != nil {
+		scenarioAssertions = req.Scenario.ConversationAssertions
+	}
+	assertions := collectConversationAssertions(req.Config, scenarioAssertions)
+
+	if len(assertions) == 0 {
 		return nil
 	}
 
 	logger.Debug("Evaluating duplex conversation assertions",
-		"scenario", req.Scenario.ID,
-		"assertion_count", len(req.Scenario.ConversationAssertions))
-
-	// Convert scenario assertions to assertion format
-	var assertions []arenaassertions.ConversationAssertion
-	for i := range req.Scenario.ConversationAssertions {
-		a := req.Scenario.ConversationAssertions[i]
-		assertions = append(assertions, arenaassertions.ConversationAssertion(a))
-	}
+		"assertion_count", len(assertions))
 
 	// Build conversation context from messages
 	convCtx := de.buildConversationContext(req, messages)

--- a/tools/arena/engine/eval_conversation_executor.go
+++ b/tools/arena/engine/eval_conversation_executor.go
@@ -68,7 +68,8 @@ func (e *EvalConversationExecutor) ExecuteConversation(
 
 	convCtx := e.buildConversationContext(&req, messages, metadata)
 	e.applyAllTurnAssertions(req.Eval.Turns, messages, convCtx)
-	convResults := e.evaluateConversationAssertions(ctx, req.Eval.ConversationAssertions, convCtx)
+	mergedEvalAssertions := mergeAssertionConfigs(req.Config, req.Eval.ConversationAssertions)
+	convResults := e.evaluateConversationAssertions(ctx, mergedEvalAssertions, convCtx)
 
 	// Run pack eval session-level evals if configured
 	if e.packEvalHook != nil && e.packEvalHook.HasEvals() {


### PR DESCRIPTION
## Summary

- Adds `pack_assertions` field to `Config`, allowing pack authors to declare quality invariants (cost limits, tool ordering, anti-patterns) that apply to all scenarios and evals
- Introduces `collectConversationAssertions()` and `mergeAssertionConfigs()` helpers to merge pack + scenario/eval assertions
- Updates all four assertion evaluation call sites: conversation executor, duplex executor, workflow executor, and eval executor
- Regenerates JSON schemas to include the new field

## Test plan

- [x] Unit tests for `collectConversationAssertions` (pack+scenario, pack-only, nil config, empty)
- [x] Unit tests for `mergeAssertionConfigs` (ordering preserved)
- [x] Integration tests verifying pack assertions are evaluated via `evaluateConversationAssertions`
- [x] Integration test verifying pack + scenario assertions both produce results
- [x] All existing tests pass (`go test ./tools/arena/... ./pkg/...`)
- [x] Lint clean (`golangci-lint run --new-from-rev`)
- [x] Coverage ≥80% on changed files (types.go: 96.9%, conversation_executor.go: 91.0%, eval_conversation_executor.go: 96.4%)

Closes #424