### PR TITLE
fix: add text fallback when response Parts() is empty (#428)

### DIFF
--- a/sdk/a2a_server.go
+++ b/sdk/a2a_server.go
@@ -273,6 +273,12 @@ func (s *A2AServer) runConversation(parent context.Context, taskID string, conv 
 		artifacts, convErr := a2a.ContentPartsToArtifacts(resp.Parts())
 		if convErr == nil && len(artifacts) > 0 {
 			_ = s.taskStore.AddArtifacts(taskID, artifacts)
+		} else if text := resp.Text(); text != "" {
+			// Fallback: if Parts() is empty (see GH-428), use Text() content.
+			_ = s.taskStore.AddArtifacts(taskID, []a2a.Artifact{{
+				ArtifactID: "artifact-1",
+				Parts:      []a2a.Part{{Text: &text}},
+			}})
 		}
 		_ = s.taskStore.SetState(taskID, a2a.TaskStateCompleted, nil)
 	}()


### PR DESCRIPTION
## Summary
- When a provider returns text via the legacy `Content` field but `Parts()` is nil/empty, `ContentPartsToArtifacts` produces no artifacts and the A2A response silently loses the text
- Adds a fallback in `runConversation` that creates a text artifact from `resp.Text()` when `Parts()` is empty
- Adds the deferred `EmptyPartsTextFallback` test from the compliance suite PR (#431)

## Changes
- `sdk/a2a_server.go`: 6-line fallback in `runConversation` after `ContentPartsToArtifacts` returns empty
- `sdk/a2a_server_test.go`: `TestA2AServer_SendMessage_EmptyPartsTextFallback` — mock returns `Content` without `Parts`, verifies artifact is created

## Test plan
- [x] New test passes locally with `-race -count=1`
- [x] Pre-commit hook passes (89.4% coverage on `a2a_server.go`)