### PR TITLE
feat: add platform support to OpenAI and Gemini providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,13 @@ The repo has a pre-commit hook at `.git/hooks/pre-commit` that runs on every com
 - Lint changed files (`golangci-lint --new-from-rev=HEAD`)
 - Build changed modules
 - Run tests with coverage on changed packages (80% threshold on non-test files)
-- Skip with `[skip-pre-commit]` in commit message
+
+**NEVER use `--no-verify` or skip the pre-commit hook.** The pre-commit checks mirror what SonarCloud enforces in CI — if the hook fails, the PR will also fail. Fix all issues before committing, including pre-existing issues in files you've touched.
 
 ### Before committing
 1. Run `golangci-lint run ./...` and `go test ./... -count=1` first
 2. Fix ALL failures before attempting `git commit`
+3. If the pre-commit hook reports lint or coverage failures on pre-existing code in files you changed, fix those too — SonarCloud will flag them
 
 ## Project Structure
 

--- a/runtime/providers/claude/claude_bedrock_fallback_test.go
+++ b/runtime/providers/claude/claude_bedrock_fallback_test.go
@@ -1,0 +1,151 @@
+package claude
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// claudeAPIResponse is a minimal Claude API response for testing.
+const claudeAPIResponse = `{
+	"id": "msg_test",
+	"type": "message",
+	"role": "assistant",
+	"content": [{"type": "text", "text": "Hello from Bedrock"}],
+	"model": "anthropic.claude-3-5-haiku-20241022-v1:0",
+	"stop_reason": "end_turn",
+	"usage": {"input_tokens": 10, "output_tokens": 5}
+}`
+
+// claudeToolCallResponse is a Claude API response with tool calls.
+const claudeToolCallResponse = `{
+	"id": "msg_test",
+	"type": "message",
+	"role": "assistant",
+	"content": [
+		{"type": "text", "text": "Let me search"},
+		{"type": "tool_use", "id": "toolu_1", "name": "search", "input": {"q": "test"}}
+	],
+	"model": "anthropic.claude-3-5-haiku-20241022-v1:0",
+	"stop_reason": "tool_use",
+	"usage": {"input_tokens": 15, "output_tokens": 10}
+}`
+
+func newBedrockTestProvider(t *testing.T, response string) *Provider {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(server.Close)
+
+	return &Provider{
+		BaseProvider: providers.NewBaseProvider("test-bedrock", false, server.Client()),
+		model:        "anthropic.claude-3-5-haiku-20241022-v1:0",
+		baseURL:      server.URL,
+		apiKey:       "test-key",
+		platform:     "bedrock",
+		defaults:     providers.ProviderDefaults{MaxTokens: 1024},
+	}
+}
+
+func TestBedrockPredictStreamFallback(t *testing.T) {
+	provider := newBedrockTestProvider(t, claudeAPIResponse)
+
+	req := providers.PredictionRequest{
+		Messages:  []types.Message{{Role: "user", Content: "hello"}},
+		MaxTokens: 100,
+	}
+	ch, err := provider.bedrockPredictStreamFallback(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var chunks []providers.StreamChunk
+	for chunk := range ch {
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Content != "Hello from Bedrock" {
+		t.Errorf("expected content 'Hello from Bedrock', got %q", chunks[0].Content)
+	}
+	if chunks[0].FinishReason == nil || *chunks[0].FinishReason != "stop" {
+		t.Errorf("expected finish reason 'stop'")
+	}
+}
+
+func TestBedrockMultimodalStreamFallback(t *testing.T) {
+	provider := newBedrockTestProvider(t, claudeAPIResponse)
+
+	req := providers.PredictionRequest{
+		Messages:  []types.Message{{Role: "user", Content: "hello"}},
+		MaxTokens: 100,
+	}
+	ch, err := provider.bedrockMultimodalStreamFallback(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var chunks []providers.StreamChunk
+	for chunk := range ch {
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Content != "Hello from Bedrock" {
+		t.Errorf("expected content 'Hello from Bedrock', got %q", chunks[0].Content)
+	}
+}
+
+func TestBedrockToolStreamFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(claudeToolCallResponse))
+	}))
+	defer server.Close()
+
+	baseProvider := &Provider{
+		BaseProvider: providers.NewBaseProvider("test-bedrock", false, server.Client()),
+		model:        "anthropic.claude-3-5-haiku-20241022-v1:0",
+		baseURL:      server.URL,
+		apiKey:       "test-key",
+		platform:     "bedrock",
+		defaults:     providers.ProviderDefaults{MaxTokens: 1024},
+	}
+	toolProvider := &ToolProvider{Provider: baseProvider}
+
+	req := providers.PredictionRequest{
+		Messages:  []types.Message{{Role: "user", Content: "search for test"}},
+		MaxTokens: 100,
+	}
+	ch, err := toolProvider.bedrockStreamFallback(context.Background(), &req, nil, "auto")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var chunks []providers.StreamChunk
+	for chunk := range ch {
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if len(chunks[0].ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(chunks[0].ToolCalls))
+	}
+	if chunks[0].ToolCalls[0].Name != "search" {
+		t.Errorf("expected tool name 'search', got %q", chunks[0].ToolCalls[0].Name)
+	}
+}

--- a/runtime/providers/errors.go
+++ b/runtime/providers/errors.go
@@ -1,0 +1,24 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ParsePlatformHTTPError extracts a human-readable error from platform-specific
+// HTTP error responses (Bedrock, Vertex, Azure). These platforms return JSON
+// like {"message":"..."} on HTTP 4xx/5xx. Falls back to raw body if parsing fails.
+// When platform is empty, returns a generic error with the raw body.
+func ParsePlatformHTTPError(platform string, statusCode int, body []byte) error {
+	if platform == "" {
+		return fmt.Errorf("API error (HTTP %d): %s", statusCode, string(body))
+	}
+
+	var errResp struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Message != "" {
+		return fmt.Errorf("%s error (HTTP %d): %s", platform, statusCode, errResp.Message)
+	}
+	return fmt.Errorf("%s error (HTTP %d): %s", platform, statusCode, string(body))
+}

--- a/runtime/providers/errors_test.go
+++ b/runtime/providers/errors_test.go
@@ -1,0 +1,77 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePlatformHTTPError_BedrockJSON(t *testing.T) {
+	body := []byte(`{"message":"Invocation of model ID anthropic.claude-3-5-haiku with on-demand throughput isn't supported."}`)
+	err := ParsePlatformHTTPError("bedrock", 400, body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "bedrock error") {
+		t.Errorf("expected 'bedrock error' prefix, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "HTTP 400") {
+		t.Errorf("expected HTTP status code in message, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "on-demand throughput") {
+		t.Errorf("expected extracted message, got: %s", errMsg)
+	}
+}
+
+func TestParsePlatformHTTPError_RawFallback(t *testing.T) {
+	body := []byte(`not json`)
+	err := ParsePlatformHTTPError("bedrock", 500, body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not json") {
+		t.Errorf("should fall back to raw body, got: %s", err.Error())
+	}
+}
+
+func TestParsePlatformHTTPError_EmptyPlatform(t *testing.T) {
+	body := []byte(`{"error":"something went wrong"}`)
+	err := ParsePlatformHTTPError("", 403, body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "API error") {
+		t.Errorf("expected generic 'API error' prefix for empty platform, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "HTTP 403") {
+		t.Errorf("expected HTTP status code, got: %s", errMsg)
+	}
+}
+
+func TestParsePlatformHTTPError_AzurePlatform(t *testing.T) {
+	body := []byte(`{"message":"Rate limit exceeded"}`)
+	err := ParsePlatformHTTPError("azure", 429, body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "azure error") {
+		t.Errorf("expected 'azure error' prefix, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "Rate limit exceeded") {
+		t.Errorf("expected extracted message, got: %s", errMsg)
+	}
+}
+
+func TestParsePlatformHTTPError_EmptyMessage(t *testing.T) {
+	body := []byte(`{"message":""}`)
+	err := ParsePlatformHTTPError("vertex", 500, body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Empty message should fall back to raw body
+	if !strings.Contains(err.Error(), `{"message":""}`) {
+		t.Errorf("expected raw body fallback for empty message, got: %s", err.Error())
+	}
+}

--- a/runtime/providers/gemini/gemini_multimodal.go
+++ b/runtime/providers/gemini/gemini_multimodal.go
@@ -277,6 +277,9 @@ func (p *Provider) predictWithContents(ctx context.Context, contents []geminiCon
 	if resp.StatusCode != http.StatusOK {
 		predictResp.Latency = time.Since(start)
 		predictResp.Raw = respBody
+		if p.platform != "" {
+			return predictResp, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, respBody)
+		}
 		return predictResp, fmt.Errorf("API request to %s failed with status %d: %s",
 			logger.RedactSensitiveData(url), resp.StatusCode, string(respBody))
 	}
@@ -392,6 +395,9 @@ func (p *Provider) predictStreamWithContents(ctx context.Context, contents []gem
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
 		body, _ := io.ReadAll(resp.Body)
+		if p.platform != "" {
+			return nil, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, body)
+		}
 		return nil, fmt.Errorf("API request to %s failed with status %d: %s",
 			logger.RedactSensitiveData(url), resp.StatusCode, string(body))
 	}

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -452,6 +452,9 @@ func (p *Provider) predictWithResponses(
 	if resp.StatusCode != http.StatusOK {
 		predictResp.Latency = time.Since(start)
 		predictResp.Raw = respBody
+		if p.platform != "" {
+			return predictResp, nil, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, respBody)
+		}
 		return predictResp, nil, fmt.Errorf("API request to %s failed with status %d: %s",
 			url, resp.StatusCode, string(respBody))
 	}

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -33,9 +33,12 @@ func NewToolProvider(
 func NewToolProviderWithCredential(
 	id, model, baseURL string, defaults providers.ProviderDefaults,
 	includeRawOutput bool, additionalConfig map[string]any, cred providers.Credential,
+	platform string, platformConfig *providers.PlatformConfig,
 ) *ToolProvider {
 	return &ToolProvider{
-		Provider: NewProviderWithCredentialAndConfig(id, model, baseURL, defaults, includeRawOutput, cred, additionalConfig),
+		Provider: NewProviderWithCredentialAndConfig(
+			id, model, baseURL, defaults, includeRawOutput, cred, additionalConfig, platform, platformConfig,
+		),
 	}
 }
 
@@ -411,6 +414,7 @@ func init() {
 			return NewToolProviderWithCredential(
 				spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
 				spec.IncludeRawOutput, spec.AdditionalConfig, spec.Credential,
+				spec.Platform, spec.PlatformConfig,
 			), nil
 		}
 		// Fall back to env-var-based constructor

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -45,7 +45,7 @@ func TestNewToolProviderWithCredential(t *testing.T) {
 
 	t.Run("with credential", func(t *testing.T) {
 		cred := &mockCredential{credType: "api_key"}
-		provider := NewToolProviderWithCredential("test-openai", "gpt-4", "https://api.openai.com/v1", defaults, false, nil, cred)
+		provider := NewToolProviderWithCredential("test-openai", "gpt-4", "https://api.openai.com/v1", defaults, false, nil, cred, "", nil)
 
 		if provider == nil {
 			t.Fatal("Expected non-nil provider")
@@ -61,7 +61,7 @@ func TestNewToolProviderWithCredential(t *testing.T) {
 	})
 
 	t.Run("with nil credential", func(t *testing.T) {
-		provider := NewToolProviderWithCredential("test-openai", "gpt-4", "https://api.openai.com/v1", defaults, false, nil, nil)
+		provider := NewToolProviderWithCredential("test-openai", "gpt-4", "https://api.openai.com/v1", defaults, false, nil, nil, "", nil)
 
 		if provider == nil {
 			t.Fatal("Expected non-nil provider")
@@ -70,7 +70,7 @@ func TestNewToolProviderWithCredential(t *testing.T) {
 
 	t.Run("with additional config", func(t *testing.T) {
 		additionalConfig := map[string]any{"key": "value"}
-		provider := NewToolProviderWithCredential("test-openai", "gpt-4", "https://api.openai.com/v1", defaults, false, additionalConfig, nil)
+		provider := NewToolProviderWithCredential("test-openai", "gpt-4", "https://api.openai.com/v1", defaults, false, additionalConfig, nil, "", nil)
 
 		if provider == nil {
 			t.Fatal("Expected non-nil provider")


### PR DESCRIPTION
## Summary

- Add `platform` and `platformConfig` fields to OpenAI and Gemini providers so SDK-level `WithBedrock()`, `WithVertex()`, and `WithAzure()` options propagate through provider factories
- Extract shared `ParsePlatformHTTPError` into `runtime/providers/errors.go` — used by all three provider families (Claude, OpenAI, Gemini) for human-readable error messages from Bedrock/Azure/Vertex
- Fix 4 pre-existing `gocritic: hugeParam` lint issues in Claude provider by passing large structs by pointer
- Add tests for Bedrock fallback streaming, Gemini multimodal/media conversion, and platform error parsing
- Update `CLAUDE.md` to enforce pre-commit hook policy (never use `--no-verify`)

## Test plan

- [x] `golangci-lint run --new-from-rev=HEAD ./...` — 0 issues
- [x] `go test ./runtime/providers/... -count=1` — all pass
- [x] Per-file coverage ≥80% on all changed files (verified by pre-commit hook)
- [ ] CI passes (lint, build, test, SonarCloud quality gate)