### PR TITLE
feat: enrich OTLP exporter with conversation data

### DIFF
--- a/docs/src/content/docs/runtime/how-to/export-traces-otlp.md
+++ b/docs/src/content/docs/runtime/how-to/export-traces-otlp.md
@@ -1,0 +1,239 @@
+---
+title: Export Traces with OTLP
+sidebar:
+  order: 9
+---
+Send PromptKit session traces to any OpenTelemetry-compatible backend.
+
+## Prerequisites
+
+- A running OTLP-compatible collector or backend (e.g., [Jaeger](https://www.jaegertracing.io/), [Grafana Tempo](https://grafana.com/oss/tempo/), [Honeycomb](https://www.honeycomb.io/), or the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/))
+- PromptKit application using the SDK or runtime EventBus
+
+## Basic Setup
+
+### 1. Record events with the EventBus
+
+PromptKit's event system publishes lifecycle events as your pipeline runs. To capture them for OTLP export, attach a `FileEventStore` or accumulate events in memory:
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/AltairaLabs/PromptKit/runtime/events"
+    "github.com/AltairaLabs/PromptKit/runtime/telemetry"
+    "github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func main() {
+    // Open a conversation (events are published to the internal EventBus)
+    conv, err := sdk.Open("./app.pack.json", "chat")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer conv.Close()
+
+    // Collect events for export
+    var sessionEvents []events.Event
+    conv.EventBus().SubscribeAll(func(e *events.Event) {
+        sessionEvents = append(sessionEvents, *e)
+    })
+
+    // Run your conversation
+    ctx := context.Background()
+    resp, _ := conv.Send(ctx, "What's the weather in London?")
+    log.Println(resp.Text())
+
+    // Convert and export
+    converter := telemetry.NewEventConverter(nil)
+    spans, _ := converter.ConvertSession(conv.SessionID(), sessionEvents)
+
+    exporter := telemetry.NewOTLPExporter("http://localhost:4318/v1/traces")
+    defer exporter.Shutdown(ctx)
+
+    if err := exporter.Export(ctx, spans); err != nil {
+        log.Printf("OTLP export failed: %v", err)
+    }
+}
+```
+
+### 2. View in your backend
+
+Open your tracing UI (e.g., Jaeger at `http://localhost:16686`) and search for traces from `promptkit`. You'll see the full session trace with pipeline, provider, tool, and message spans.
+
+## Tag Traces with Pack ID
+
+Use `ResourceWithPackID` to identify which pack generated the trace:
+
+```go
+resource := telemetry.ResourceWithPackID("customer-support-v2")
+converter := telemetry.NewEventConverter(resource)
+```
+
+Or use `WithResource` on the exporter to set it globally:
+
+```go
+exporter := telemetry.NewOTLPExporter(
+    "http://localhost:4318/v1/traces",
+    telemetry.WithResource(telemetry.ResourceWithPackID("customer-support-v2")),
+)
+```
+
+This adds a `pack.id` attribute to the [OTLP resource](https://opentelemetry.io/docs/specs/semconv/resource/), making it easy to filter traces by pack in your backend.
+
+## Authenticate with Your Backend
+
+Most hosted backends require an API key or bearer token. Pass custom headers:
+
+```go
+exporter := telemetry.NewOTLPExporter(
+    "https://api.honeycomb.io/v1/traces",
+    telemetry.WithHeaders(map[string]string{
+        "x-honeycomb-team": os.Getenv("HONEYCOMB_API_KEY"),
+    }),
+)
+```
+
+For Grafana Cloud:
+
+```go
+exporter := telemetry.NewOTLPExporter(
+    "https://otlp-gateway-prod-us-east-0.grafana.net/otlp/v1/traces",
+    telemetry.WithHeaders(map[string]string{
+        "Authorization": "Basic " + base64.StdEncoding.EncodeToString(
+            []byte(os.Getenv("GRAFANA_INSTANCE_ID")+":"+os.Getenv("GRAFANA_API_KEY")),
+        ),
+    }),
+)
+```
+
+## Propagate Trace Context from Inbound Requests
+
+If your PromptKit application is called from another service that sends [W3C `traceparent`](https://www.w3.org/TR/trace-context/#traceparent-header) headers, you can link the PromptKit session trace to the caller's trace:
+
+### Using TraceMiddleware (recommended)
+
+```go
+import (
+    "net/http"
+    "github.com/AltairaLabs/PromptKit/runtime/telemetry"
+)
+
+// Wrap your HTTP handler
+mux := http.NewServeMux()
+mux.HandleFunc("/chat", handleChat)
+http.ListenAndServe(":8080", telemetry.TraceMiddleware(mux))
+
+func handleChat(w http.ResponseWriter, r *http.Request) {
+    // Extract trace context from the Go context
+    traceCtx := telemetry.TraceContextFromContext(r.Context())
+
+    // ... run your conversation and collect events ...
+
+    // Convert with parent trace
+    converter := telemetry.NewEventConverter(nil)
+    spans, _ := converter.ConvertSessionWithParent(sessionID, sessionEvents, &traceCtx)
+
+    exporter.Export(r.Context(), spans)
+}
+```
+
+### Manual extraction
+
+```go
+traceCtx := telemetry.ExtractTraceContext(r)
+spans, _ := converter.ConvertSessionWithParent(sessionID, sessionEvents, &traceCtx)
+```
+
+When a valid `traceparent` is provided, the session root span inherits the caller's trace ID and sets `ParentSpanID` to the caller's span ID. This makes the PromptKit session appear as a child in the caller's distributed trace.
+
+## What Gets Exported
+
+The converter handles these event types:
+
+| Runtime Event | OTLP Representation | Key Attributes |
+|---------------|---------------------|----------------|
+| `pipeline.started/completed/failed` | `pipeline` span | `pipeline.duration_ms`, `pipeline.total_cost`, token counts |
+| `provider.call.started/completed/failed` | `provider.<name>` span | `gen_ai.system`, `gen_ai.usage.*`, `gen_ai.response.finish_reason` |
+| `message.created` | Span event on provider span | `gen_ai.message.content`, `gen_ai.tool_calls` |
+| `tool.call.started/completed/failed` | `tool.<name>` span | `tool.args` (JSON), `tool.duration_ms`, `tool.status` |
+| `middleware.started/completed/failed` | `middleware.<name>` span | `middleware.duration_ms` |
+| `workflow.transitioned` | `workflow.transition` instant span | `workflow.from_state`, `workflow.to_state`, `workflow.event` |
+| `workflow.completed` | `workflow.completed` instant span | `workflow.final_state`, `workflow.transition_count` |
+
+### Semantic conventions
+
+Provider spans and message events follow the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
+
+- **Provider spans** use `gen_ai.system`, `gen_ai.operation`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, and `gen_ai.response.finish_reason`
+- **Message events** are named `gen_ai.<role>.message` (e.g., `gen_ai.user.message`, `gen_ai.assistant.message`) following the [GenAI span events spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/)
+- **Tool call arguments** are serialised as JSON in the `tool.args` attribute
+
+## Export to the OpenTelemetry Collector
+
+If you run an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), point the exporter at its OTLP HTTP receiver (default port 4318):
+
+```go
+exporter := telemetry.NewOTLPExporter("http://localhost:4318/v1/traces")
+```
+
+The Collector can then fan out to multiple backends. Example `otel-collector-config.yaml`:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "0.0.0.0:4318"
+
+exporters:
+  otlp/jaeger:
+    endpoint: "jaeger:4317"
+    tls:
+      insecure: true
+  otlp/tempo:
+    endpoint: "tempo:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/jaeger, otlp/tempo]
+```
+
+## Combine with Prometheus Metrics
+
+OTLP traces and Prometheus metrics are complementary. Use both for full observability:
+
+```go
+import (
+    "github.com/AltairaLabs/PromptKit/runtime/events"
+    "github.com/AltairaLabs/PromptKit/runtime/metrics/prometheus"
+    "github.com/AltairaLabs/PromptKit/runtime/telemetry"
+)
+
+// Metrics (real-time aggregation)
+metricsListener := prometheus.NewMetricsListener()
+eventBus.SubscribeAll(metricsListener.Listener())
+
+// Traces (per-request detail)
+var sessionEvents []events.Event
+eventBus.SubscribeAll(func(e *events.Event) {
+    sessionEvents = append(sessionEvents, *e)
+})
+```
+
+- **Prometheus** gives you dashboards, alerts, and aggregate metrics (p99 latency, error rates, token costs)
+- **OTLP traces** give you per-session drill-down (which tool was slow, what the LLM said, workflow path)
+
+## See Also
+
+- [Telemetry Reference](../reference/telemetry) — full API reference and attribute tables
+- [Prometheus Metrics](prometheus-metrics) — Prometheus-based monitoring
+- [SDK Observability](../../sdk/explanation/observability) — event system architecture
+- [Monitor Events](../../sdk/how-to/monitor-events) — SDK event hooks

--- a/docs/src/content/docs/runtime/how-to/index.md
+++ b/docs/src/content/docs/runtime/how-to/index.md
@@ -35,6 +35,7 @@ These guides show you how to accomplish specific tasks with the PromptKit Runtim
 
 ### Observability
 - [Prometheus Metrics](prometheus-metrics) - Monitor with Prometheus and Grafana
+- [Export Traces with OTLP](export-traces-otlp) - Send distributed traces to OpenTelemetry backends
 - [Monitor Costs](monitor-costs) - Cost tracking and optimization
 
 ### A2A (Agent-to-Agent)
@@ -55,6 +56,7 @@ These guides show you how to accomplish specific tasks with the PromptKit Runtim
 | Add MCP tools | [Integrate MCP](integrate-mcp) | 10 min |
 | Track costs | [Monitor Costs](monitor-costs) | 5 min |
 | Monitor with Prometheus | [Prometheus Metrics](prometheus-metrics) | 10 min |
+| Export OTLP traces | [Export Traces with OTLP](export-traces-otlp) | 10 min |
 | Handle errors | [Handle Errors](handle-errors) | 10 min |
 | Stream responses | [Streaming Responses](streaming-responses) | 10 min |
 | Persist conversations | [Manage State](manage-state) | 15 min |

--- a/docs/src/content/docs/runtime/reference/index.md
+++ b/docs/src/content/docs/runtime/reference/index.md
@@ -31,6 +31,7 @@ The PromptKit Runtime provides the core execution engine for LLM interactions. I
 | **Types** | Core data structures | [types.md](types) |
 | **A2A** | Client, types, tool bridge, mock | [a2a.md](a2a) |
 | **Logging** | Structured logging with context | [logging.md](logging) |
+| **Telemetry** | OpenTelemetry trace export | [telemetry.md](telemetry) |
 
 ### Import Paths
 
@@ -44,6 +45,7 @@ import (
     "github.com/AltairaLabs/PromptKit/runtime/validators"
     "github.com/AltairaLabs/PromptKit/runtime/types"
     "github.com/AltairaLabs/PromptKit/runtime/logger"
+    "github.com/AltairaLabs/PromptKit/runtime/telemetry"
 )
 ```
 

--- a/docs/src/content/docs/runtime/reference/logging.md
+++ b/docs/src/content/docs/runtime/reference/logging.md
@@ -445,6 +445,7 @@ logger.Info(fmt.Sprintf("User %s logged in from %s", userID, remoteAddr))
 
 ## See Also
 
+- [Telemetry Reference](telemetry) - OpenTelemetry trace export
 - [Pipeline Reference](pipeline) - Pipeline execution and middleware
 - [Providers Reference](providers) - LLM provider implementations
 - [Arena Config Reference](/arena/reference/config-schema) - Arena configuration including logging

--- a/docs/src/content/docs/runtime/reference/telemetry.md
+++ b/docs/src/content/docs/runtime/reference/telemetry.md
@@ -1,0 +1,294 @@
+---
+title: Telemetry
+sidebar:
+  order: 8
+---
+OpenTelemetry-compatible trace export for PromptKit sessions.
+
+## Overview
+
+The `runtime/telemetry` package converts PromptKit's EventBus events into [OpenTelemetry](https://opentelemetry.io/) spans and exports them over [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) to any compatible backend (Jaeger, Grafana Tempo, Datadog, Honeycomb, AWS X-Ray, etc.).
+
+The exporter follows the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) for LLM-specific attributes and the [W3C Trace Context](https://www.w3.org/TR/trace-context/) specification for distributed trace propagation.
+
+```go
+import "github.com/AltairaLabs/PromptKit/runtime/telemetry"
+```
+
+## Trace Structure
+
+Each session produces a single trace. The root span represents the session, with child spans for pipeline execution, provider calls, middleware, tool calls, and workflow transitions.
+
+```
+session (root, SpanKindServer)
+├── pipeline (SpanKindInternal)
+│   ├── middleware.auth (SpanKindInternal)
+│   ├── provider.openai (SpanKindClient)
+│   │   ├── [event] gen_ai.user.message
+│   │   └── [event] gen_ai.assistant.message
+│   ├── tool.search (SpanKindInternal)
+│   └── provider.openai (SpanKindClient)
+│       └── [event] gen_ai.assistant.message
+├── workflow.transition (SpanKindInternal, instant)
+├── workflow.transition (SpanKindInternal, instant)
+└── workflow.completed (SpanKindInternal, instant)
+```
+
+## EventConverter
+
+`EventConverter` transforms a slice of `events.Event` into OpenTelemetry `Span` objects.
+
+### Constructor
+
+```go
+func NewEventConverter(resource *Resource) *EventConverter
+```
+
+If `resource` is nil, `DefaultResource()` is used.
+
+### ConvertSession
+
+```go
+func (c *EventConverter) ConvertSession(
+    sessionID string, sessionEvents []events.Event,
+) ([]*Span, error)
+```
+
+Generates a trace ID deterministically from the session ID. The root span has no parent.
+
+### ConvertSessionWithParent
+
+```go
+func (c *EventConverter) ConvertSessionWithParent(
+    sessionID string, sessionEvents []events.Event, traceCtx *TraceContext,
+) ([]*Span, error)
+```
+
+Uses the provided [W3C `traceparent`](https://www.w3.org/TR/trace-context/#traceparent-header) header as the parent trace. The root session span's `TraceID` is taken from the inbound header and its `ParentSpanID` is set to the caller's span ID. Falls back to `ConvertSession` if `traceCtx` is nil or the `Traceparent` is empty/invalid.
+
+## Handled Event Types
+
+### Pipeline events
+
+| Event | Span |
+|-------|------|
+| `pipeline.started` / `pipeline.completed` / `pipeline.failed` | `pipeline` span (SpanKindInternal) |
+
+**Attributes:** `run.id`, `pipeline.duration_ms`, `pipeline.total_cost`, `pipeline.input_tokens`, `pipeline.output_tokens`
+
+### Provider events
+
+| Event | Span |
+|-------|------|
+| `provider.call.started` / `provider.call.completed` / `provider.call.failed` | `provider.<name>` span (SpanKindClient) |
+
+**Attributes** follow the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
+
+| Attribute | Source | Spec reference |
+|-----------|--------|---------------|
+| `gen_ai.system` | Provider name | [gen_ai.system](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/) |
+| `gen_ai.operation` | `"chat"` | [gen_ai.operation.name](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/) |
+| `gen_ai.usage.input_tokens` | Input token count | [gen_ai.usage.input_tokens](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/) |
+| `gen_ai.usage.output_tokens` | Output token count | [gen_ai.usage.output_tokens](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/) |
+| `gen_ai.response.finish_reason` | Finish reason | [gen_ai.response.finish_reasons](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/) |
+| `provider.name` | Provider identifier | PromptKit-specific |
+| `provider.model` | Model name | PromptKit-specific |
+| `provider.duration_ms` | Call duration | PromptKit-specific |
+| `provider.cost` | Estimated cost (USD) | PromptKit-specific |
+
+### Message events
+
+| Event | Behaviour |
+|-------|-----------|
+| `message.created` | Appended as a [SpanEvent](https://opentelemetry.io/docs/concepts/signals/traces/#span-events) on the active provider span |
+
+Messages are not separate spans. They are attached as **span events** on the currently active `provider.<name>` span, following the [GenAI Events conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/). If no provider span is active, the event is attached to the root session span.
+
+**Event name:** `gen_ai.<role>.message` (e.g., `gen_ai.user.message`, `gen_ai.assistant.message`)
+
+**Event attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `gen_ai.message.content` | string | Text content of the message |
+| `gen_ai.tool_calls` | string (JSON) | Tool calls requested by assistant (present only when non-empty) |
+| `gen_ai.tool_result` | string (JSON) | Tool result for tool-role messages (present only when non-nil) |
+
+### Tool events
+
+| Event | Span |
+|-------|------|
+| `tool.call.started` / `tool.call.completed` / `tool.call.failed` | `tool.<name>` span (SpanKindInternal) |
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `tool.name` | string | Tool name |
+| `tool.call_id` | string | Unique call identifier |
+| `tool.args` | string (JSON) | Serialised tool arguments (omitted when nil) |
+| `tool.duration_ms` | int64 | Execution time |
+| `tool.status` | string | Completion status |
+
+### Middleware events
+
+| Event | Span |
+|-------|------|
+| `middleware.started` / `middleware.completed` / `middleware.failed` | `middleware.<name>` span (SpanKindInternal) |
+
+**Attributes:** `middleware.name`, `middleware.index`, `middleware.duration_ms`
+
+### Workflow events
+
+| Event | Span |
+|-------|------|
+| `workflow.transitioned` | `workflow.transition` instant span (SpanKindInternal) |
+| `workflow.completed` | `workflow.completed` instant span (SpanKindInternal) |
+
+Workflow spans are **instant** — their start and end times are both set to the event timestamp.
+
+**Transition attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `workflow.from_state` | string | State before transition |
+| `workflow.to_state` | string | State after transition |
+| `workflow.event` | string | Trigger event |
+| `workflow.prompt_task` | string | Prompt task of the new state |
+
+**Completion attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `workflow.final_state` | string | Terminal state reached |
+| `workflow.transition_count` | int | Total number of transitions |
+
+## Resource
+
+The `Resource` identifies the entity producing telemetry, following the [OpenTelemetry Resource Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/resource/).
+
+### DefaultResource
+
+```go
+func DefaultResource() *Resource
+```
+
+Returns a resource with:
+- `service.name` = `"promptkit"`
+- `service.version` = `"1.0.0"`
+- `telemetry.sdk` = `"promptkit-telemetry"`
+
+### ResourceWithPackID
+
+```go
+func ResourceWithPackID(packID string) *Resource
+```
+
+Returns `DefaultResource()` plus a `pack.id` attribute. Use this to tag all spans from a specific pack:
+
+```go
+resource := telemetry.ResourceWithPackID("customer-support-v2")
+converter := telemetry.NewEventConverter(resource)
+```
+
+## OTLPExporter
+
+`OTLPExporter` sends spans to an [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) endpoint as JSON.
+
+```go
+func NewOTLPExporter(endpoint string, opts ...OTLPExporterOption) *OTLPExporter
+```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `WithHeaders(map[string]string)` | Custom HTTP headers (auth tokens, API keys) | none |
+| `WithResource(*Resource)` | Resource for exported spans | `DefaultResource()` |
+| `WithBatchSize(int)` | Max spans per export batch | 100 |
+| `WithHTTPClient(HTTPClient)` | Custom HTTP client (useful for testing) | `http.Client{Timeout: 30s}` |
+
+### Methods
+
+```go
+func (e *OTLPExporter) Export(ctx context.Context, spans []*Span) error
+func (e *OTLPExporter) Shutdown(ctx context.Context) error
+```
+
+`Export` sends spans immediately. `Shutdown` flushes any pending spans before returning.
+
+## TraceContext
+
+`TraceContext` holds distributed trace headers extracted from inbound requests, supporting [W3C Trace Context](https://www.w3.org/TR/trace-context/) and [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader).
+
+```go
+type TraceContext struct {
+    Traceparent string // W3C traceparent header
+    Tracestate  string // W3C tracestate header
+    XRayTraceID string // AWS X-Ray X-Amzn-Trace-Id header
+}
+```
+
+### Extracting from HTTP requests
+
+```go
+func ExtractTraceContext(r *http.Request) TraceContext
+```
+
+Reads `traceparent`, `tracestate`, and `X-Amzn-Trace-Id` headers. Invalid `traceparent` values are silently discarded.
+
+### Middleware
+
+```go
+func TraceMiddleware(next http.Handler) http.Handler
+```
+
+HTTP middleware that extracts trace context from inbound requests and stores it in the Go context for downstream propagation.
+
+### Injecting into outbound requests
+
+```go
+func InjectTraceHeaders(ctx context.Context, req *http.Request)
+```
+
+Writes trace headers from the context onto an outbound HTTP request.
+
+## OTLP Wire Format
+
+The exporter serialises spans as [OTLP/HTTP JSON](https://opentelemetry.io/docs/specs/otlp/#otlphttp-request). The payload structure matches the [OpenTelemetry protobuf schema](https://opentelemetry.io/docs/specs/otlp/#otlphttp-request):
+
+```json
+{
+  "resourceSpans": [{
+    "resource": {
+      "attributes": [
+        {"key": "service.name", "value": {"stringValue": "promptkit"}},
+        {"key": "pack.id", "value": {"stringValue": "my-pack"}}
+      ]
+    },
+    "scopeSpans": [{
+      "scope": {"name": "promptkit-telemetry", "version": "1.0.0"},
+      "spans": [...]
+    }]
+  }]
+}
+```
+
+Timestamps are serialised as Unix nanoseconds. Attribute values use the OTLP typed value encoding (`stringValue`, `intValue`, `doubleValue`, `boolValue`).
+
+## Relevant Specifications
+
+- [OpenTelemetry Specification](https://opentelemetry.io/docs/specs/otel/) — core concepts (traces, spans, resources)
+- [OTLP/HTTP Protocol](https://opentelemetry.io/docs/specs/otlp/#otlphttp) — wire format for trace export
+- [GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) — attribute naming for LLM workloads
+- [GenAI Span Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) — span event naming for chat completions
+- [Resource Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/resource/) — `service.name`, `service.version`
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/) — `traceparent` / `tracestate` headers
+- [AWS X-Ray Trace Header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) — `X-Amzn-Trace-Id`
+
+## See Also
+
+- [How-To: Export Traces with OTLP](../how-to/export-traces-otlp) — end-to-end setup guide
+- [How-To: Prometheus Metrics](../how-to/prometheus-metrics) — Prometheus-based monitoring
+- [Logging Reference](logging) — structured logging
+- [SDK Observability](../../sdk/explanation/observability) — event system overview

--- a/docs/src/content/docs/sdk/explanation/observability.md
+++ b/docs/src/content/docs/sdk/explanation/observability.md
@@ -327,6 +327,8 @@ Event handlers are called asynchronously in a separate goroutine (see `EventBus.
 ## See Also
 
 - [How-To: Monitor Events](../how-to/monitor-events)
+- [How-To: Export Traces with OTLP](/runtime/how-to/export-traces-otlp) — send session traces to OpenTelemetry backends
+- [Telemetry Reference](/runtime/reference/telemetry) — OTLP exporter API, span attributes, and semantic conventions
 - [Arena Eval Framework](/arena/explanation/eval-framework/)
 - [Session Recording](/arena/explanation/session-recording/)
 - [Tutorial 6: Observability](../tutorials/06-media-storage)


### PR DESCRIPTION
## Summary

Closes #425

- Handle `message.created` events as `gen_ai.<role>.message` span events on the active provider span (falls back to root span), following [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/)
- Serialize tool call arguments as `tool.args` JSON attribute on tool spans
- Create instant `workflow.transition` and `workflow.completed` spans for workflow events
- Add `ResourceWithPackID()` helper for tagging traces with pack identity
- Add `ConvertSessionWithParent()` for [W3C traceparent](https://www.w3.org/TR/trace-context/) propagation from inbound requests
- Add public docs: OTLP telemetry reference page and how-to guide with links to relevant OTel specs

## Test plan

- [x] `go test ./runtime/telemetry/... -v -race -count=1` — all 32 tests pass
- [x] `golangci-lint run ./runtime/telemetry/...` — 0 issues
- [x] Pre-commit hook passes (lint, build, tests, 90.4% coverage on exporter.go)
- [ ] CI passes