### PR TITLE
feat: add promptarena generate command with pluggable session source adapters

### DIFF
--- a/tools/arena/cmd/promptarena/generate.go
+++ b/tools/arena/cmd/promptarena/generate.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/generate"
+	"github.com/AltairaLabs/PromptKit/tools/arena/generate/sources"
+)
+
+// generateRegistry is the global registry for session source adapters.
+// External plugins can register adapters via init() functions.
+var generateRegistry = generate.NewRegistry()
+
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate scenario files from session data",
+	Long: `Generate Arena scenario YAML files from recorded sessions or external session sources.
+
+Uses pluggable SessionSourceAdapter implementations to load session data
+and convert it into reproducible test scenarios.
+
+Examples:
+  # Generate from local recording files
+  promptarena generate --from-recordings "recordings/*.recording.json"
+
+  # Generate from a named source adapter
+  promptarena generate --source omnia --filter-passed=false
+
+  # Generate workflow scenarios with a pack file
+  promptarena generate --from-recordings "recordings/*.recording.json" --pack pack.json
+
+  # Output to a specific directory
+  promptarena generate --from-recordings "*.recording.json" --output scenarios/`,
+	RunE: runGenerate,
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+
+	generateCmd.Flags().String("source", "", "Named session source adapter (e.g., omnia)")          // NOSONAR
+	generateCmd.Flags().String("from-recordings", "", "Glob path to local recording files")         // NOSONAR
+	generateCmd.Flags().String("filter-eval-type", "", "Filter sessions by assertion failure type") // NOSONAR
+	generateCmd.Flags().Bool("filter-passed", false, "Filter by pass/fail status")                  // NOSONAR
+	generateCmd.Flags().String("pack", "", "Pack file path (generates workflow scenarios)")         // NOSONAR
+	generateCmd.Flags().String("output", ".", "Output directory for generated scenario files")      // NOSONAR
+	generateCmd.Flags().Bool("dedup", true, "Deduplicate sessions by failure pattern")              // NOSONAR
+}
+
+func resolveAdapter(cmd *cobra.Command) (generate.SessionSourceAdapter, error) {
+	sourceName, _ := cmd.Flags().GetString("source")
+	fromRecordings, _ := cmd.Flags().GetString("from-recordings")
+
+	switch {
+	case fromRecordings != "":
+		return sources.NewRecordingsAdapter(fromRecordings), nil
+	case sourceName != "":
+		return generateRegistry.Get(sourceName)
+	default:
+		return nil, fmt.Errorf("specify either --source or --from-recordings")
+	}
+}
+
+func buildListOptions(cmd *cobra.Command) (generate.ListOptions, error) {
+	opts := generate.ListOptions{}
+
+	if cmd.Flags().Changed("filter-passed") {
+		val, err := cmd.Flags().GetBool("filter-passed")
+		if err != nil {
+			return opts, fmt.Errorf("invalid filter-passed value: %w", err)
+		}
+		opts.FilterPassed = &val
+	}
+
+	opts.FilterEvalType, _ = cmd.Flags().GetString("filter-eval-type")
+
+	return opts, nil
+}

--- a/tools/arena/cmd/promptarena/generate_integration.go
+++ b/tools/arena/cmd/promptarena/generate_integration.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/generate"
+)
+
+const (
+	dirPerms  = 0o700
+	filePerms = 0o600
+)
+
+func runGenerate(cmd *cobra.Command, _ []string) error {
+	adapter, err := resolveAdapter(cmd)
+	if err != nil {
+		return err
+	}
+
+	listOpts, err := buildListOptions(cmd)
+	if err != nil {
+		return err
+	}
+
+	sessions, err := fetchSessions(cmd, adapter, listOpts)
+	if err != nil {
+		return err
+	}
+	if sessions == nil {
+		return nil
+	}
+
+	return writeScenarios(cmd, sessions)
+}
+
+func fetchSessions(
+	cmd *cobra.Command,
+	adapter generate.SessionSourceAdapter,
+	listOpts generate.ListOptions,
+) ([]*generate.SessionDetail, error) {
+	ctx := context.Background()
+
+	summaries, err := adapter.List(ctx, listOpts)
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions: %w", err)
+	}
+
+	if len(summaries) == 0 {
+		fmt.Println("No sessions found matching the given filters.")
+		return nil, nil
+	}
+
+	var sessions []*generate.SessionDetail
+	for i := range summaries {
+		detail, getErr := adapter.Get(ctx, summaries[i].ID)
+		if getErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping session %s: %v\n", summaries[i].ID, getErr)
+			continue
+		}
+		sessions = append(sessions, detail)
+	}
+
+	dedup, _ := cmd.Flags().GetBool("dedup")
+	if dedup {
+		before := len(sessions)
+		sessions = generate.DeduplicateSessions(sessions)
+		if removed := before - len(sessions); removed > 0 {
+			fmt.Printf("Deduplicated: removed %d duplicate(s), %d session(s) remaining.\n", removed, len(sessions))
+		}
+	}
+
+	return sessions, nil
+}
+
+func writeScenarios(cmd *cobra.Command, sessions []*generate.SessionDetail) error {
+	packFile, _ := cmd.Flags().GetString("pack")
+	outputDir, _ := cmd.Flags().GetString("output")
+
+	if err := os.MkdirAll(outputDir, dirPerms); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	opts := generate.ConvertOptions{Pack: packFile}
+
+	for _, session := range sessions {
+		if err := writeSessionScenario(session, opts, outputDir); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("\nGenerated %d scenario file(s).\n", len(sessions))
+	return nil
+}
+
+func writeSessionScenario(
+	session *generate.SessionDetail,
+	opts generate.ConvertOptions,
+	outputDir string,
+) error {
+	sc, err := generate.ConvertSessionToScenario(session, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: skipping session %s: %v\n", session.ID, err)
+		return nil
+	}
+
+	data, err := yaml.Marshal(sc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: skipping session %s: marshal error: %v\n", session.ID, err)
+		return nil
+	}
+
+	filename := sc.Metadata.Name + ".scenario.yaml"
+	outPath := filepath.Join(outputDir, filename)
+
+	if err := os.WriteFile(outPath, data, filePerms); err != nil {
+		return fmt.Errorf("writing %s: %w", outPath, err)
+	}
+
+	fmt.Printf("Generated: %s\n", outPath)
+	return nil
+}

--- a/tools/arena/cmd/promptarena/generate_test.go
+++ b/tools/arena/cmd/promptarena/generate_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/generate"
+)
+
+func newGenerateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "generate", RunE: runGenerate}
+	cmd.Flags().String("source", "", "")
+	cmd.Flags().String("from-recordings", "", "")
+	cmd.Flags().String("filter-eval-type", "", "")
+	cmd.Flags().Bool("filter-passed", false, "")
+	cmd.Flags().String("pack", "", "")
+	cmd.Flags().String("output", ".", "")
+	cmd.Flags().Bool("dedup", true, "")
+	return cmd
+}
+
+func TestResolveAdapter_FromRecordings(t *testing.T) {
+	cmd := newGenerateTestCmd()
+	require.NoError(t, cmd.Flags().Set("from-recordings", "*.recording.json"))
+
+	adapter, err := resolveAdapter(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "recordings", adapter.Name())
+}
+
+func TestResolveAdapter_FromSource(t *testing.T) {
+	// Register a test adapter in the global registry.
+	generateRegistry.Register(&testSourceAdapter{name: "test-source"})
+
+	cmd := newGenerateTestCmd()
+	require.NoError(t, cmd.Flags().Set("source", "test-source"))
+
+	adapter, err := resolveAdapter(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "test-source", adapter.Name())
+}
+
+func TestResolveAdapter_NeitherFlag(t *testing.T) {
+	cmd := newGenerateTestCmd()
+	_, err := resolveAdapter(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "specify either --source or --from-recordings")
+}
+
+func TestBuildListOptions_Default(t *testing.T) {
+	cmd := newGenerateTestCmd()
+	opts, err := buildListOptions(cmd)
+	require.NoError(t, err)
+	assert.Nil(t, opts.FilterPassed, "FilterPassed should be nil when flag not changed")
+	assert.Empty(t, opts.FilterEvalType)
+}
+
+func TestBuildListOptions_WithFilterPassed(t *testing.T) {
+	cmd := newGenerateTestCmd()
+	require.NoError(t, cmd.Flags().Set("filter-passed", "false"))
+
+	opts, err := buildListOptions(cmd)
+	require.NoError(t, err)
+	require.NotNil(t, opts.FilterPassed)
+	assert.False(t, *opts.FilterPassed)
+}
+
+func TestBuildListOptions_WithFilterEvalType(t *testing.T) {
+	cmd := newGenerateTestCmd()
+	require.NoError(t, cmd.Flags().Set("filter-eval-type", "content_matches"))
+
+	opts, err := buildListOptions(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "content_matches", opts.FilterEvalType)
+}
+
+// testSourceAdapter is a minimal test double for the generate command tests.
+type testSourceAdapter struct {
+	name string
+}
+
+func (a *testSourceAdapter) Name() string { return a.name }
+
+func (a *testSourceAdapter) List(
+	_ context.Context,
+	_ generate.ListOptions,
+) ([]generate.SessionSummary, error) {
+	return nil, nil
+}
+
+func (a *testSourceAdapter) Get(
+	_ context.Context,
+	_ string,
+) (*generate.SessionDetail, error) {
+	return nil, nil
+}

--- a/tools/arena/generate/adapter.go
+++ b/tools/arena/generate/adapter.go
@@ -1,0 +1,68 @@
+// Package generate provides pluggable session source adapters for scenario generation.
+// It enables turning production session data (with failing assertions) into
+// reproducible test scenarios for PromptArena.
+package generate
+
+import (
+	"context"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+)
+
+// SessionSourceAdapter provides session data for scenario generation.
+// Implementations query external systems (e.g., session APIs, local recordings)
+// and return structured session data that can be converted into Arena scenarios.
+type SessionSourceAdapter interface {
+	// Name returns the adapter's unique identifier (e.g., "recordings", "omnia").
+	Name() string
+
+	// List returns session summaries matching the given options.
+	List(ctx context.Context, opts ListOptions) ([]SessionSummary, error)
+
+	// Get returns the full session detail including messages and eval results.
+	Get(ctx context.Context, sessionID string) (*SessionDetail, error)
+}
+
+// ListOptions controls which sessions are returned by List.
+type ListOptions struct {
+	// FilterPassed filters by pass/fail status: nil=all, *true=passed only, *false=failed only.
+	FilterPassed *bool
+	// FilterEvalType filters by assertion type (e.g., "content_matches").
+	FilterEvalType string
+	// Limit caps the number of results. 0 means unlimited.
+	Limit int
+}
+
+// SessionSummary is a lightweight representation of a session for listing.
+type SessionSummary struct {
+	ID          string
+	Source      string
+	ScenarioID  string
+	ProviderID  string
+	Timestamp   time.Time
+	TurnCount   int
+	HasFailures bool
+	Tags        []string
+	Metadata    map[string]interface{}
+}
+
+// SessionDetail contains the full session data needed for scenario generation.
+type SessionDetail struct {
+	SessionSummary
+	// Messages is the complete conversation history.
+	Messages []types.Message
+	// EvalResults contains conversation-level assertion results (nil for recordings).
+	EvalResults []assertions.ConversationValidationResult
+	// TurnEvalResults contains per-turn assertion results keyed by turn index.
+	TurnEvalResults map[int][]TurnEvalResult
+}
+
+// TurnEvalResult represents the result of a single turn-level assertion.
+type TurnEvalResult struct {
+	Type    string
+	Passed  bool
+	Message string
+	Params  map[string]interface{}
+}

--- a/tools/arena/generate/converter.go
+++ b/tools/arena/generate/converter.go
@@ -1,0 +1,199 @@
+package generate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+)
+
+const (
+	apiVersion   = "promptkit.altairalabs.ai/v1alpha1"
+	kindScenario = "Scenario"
+	maxIDLength  = 63
+	roleUser     = "user"
+)
+
+// ConvertOptions controls how a session is converted into a scenario.
+type ConvertOptions struct {
+	// Pack is the path to a .pack.json file. When set, the scenario is generated
+	// as a workflow scenario (with Steps) instead of a regular conversation scenario.
+	Pack string
+}
+
+// ConvertSessionToScenario converts a SessionDetail into a ScenarioConfig YAML document.
+func ConvertSessionToScenario(session *SessionDetail, opts ConvertOptions) (*config.ScenarioConfig, error) {
+	if session == nil {
+		return nil, fmt.Errorf("session is nil")
+	}
+
+	scenarioID := sanitizeID(session.ID)
+	description := buildDescription(session)
+
+	scenario := config.Scenario{
+		ID:          scenarioID,
+		Description: description,
+	}
+
+	if opts.Pack != "" {
+		scenario.Pack = opts.Pack
+		scenario.Steps = buildWorkflowSteps(session)
+	} else {
+		scenario.TaskType = "conversation"
+		scenario.Turns = buildTurns(session)
+	}
+
+	// Add conversation-level assertions from failed eval results.
+	scenario.ConversationAssertions = buildConversationAssertions(session.EvalResults)
+
+	// Add turn-level assertions from failed turn eval results.
+	applyTurnAssertions(&scenario, session.TurnEvalResults, opts.Pack != "")
+
+	return &config.ScenarioConfig{
+		APIVersion: apiVersion,
+		Kind:       kindScenario,
+		Metadata: config.ObjectMeta{
+			Name: scenarioID,
+		},
+		Spec: scenario,
+	}, nil
+}
+
+// sanitizeID produces a valid scenario ID: lowercase alphanumeric with hyphens, max 63 chars.
+func sanitizeID(raw string) string {
+	// Replace non-alphanumeric characters with hyphens.
+	re := regexp.MustCompile(`[^a-z0-9]+`)
+	id := re.ReplaceAllString(strings.ToLower(raw), "-")
+
+	// Trim leading/trailing hyphens.
+	id = strings.Trim(id, "-")
+
+	if id == "" {
+		id = "generated"
+	}
+
+	if len(id) > maxIDLength {
+		id = id[:maxIDLength]
+		// Don't end with a hyphen after truncation.
+		id = strings.TrimRight(id, "-")
+	}
+
+	return id
+}
+
+func buildDescription(session *SessionDetail) string {
+	parts := []string{fmt.Sprintf("Generated from session %s", session.ID)}
+	if !session.Timestamp.IsZero() {
+		parts = append(parts, fmt.Sprintf("recorded %s", session.Timestamp.Format(time.RFC3339)))
+	}
+	if session.HasFailures {
+		parts = append(parts, "contains assertion failures")
+	}
+	return strings.Join(parts, ", ")
+}
+
+func buildTurns(session *SessionDetail) []config.TurnDefinition {
+	var turns []config.TurnDefinition
+	for i := range session.Messages {
+		if session.Messages[i].Role != roleUser {
+			continue
+		}
+		turns = append(turns, config.TurnDefinition{
+			Role:    roleUser,
+			Content: session.Messages[i].GetContent(),
+		})
+	}
+	return turns
+}
+
+func buildWorkflowSteps(session *SessionDetail) []config.WorkflowStep {
+	var steps []config.WorkflowStep
+	for i := range session.Messages {
+		if session.Messages[i].Role != roleUser {
+			continue
+		}
+		steps = append(steps, config.WorkflowStep{
+			Type:    "input",
+			Content: session.Messages[i].GetContent(),
+		})
+	}
+	return steps
+}
+
+func buildConversationAssertions(
+	results []assertions.ConversationValidationResult,
+) []assertions.AssertionConfig {
+	var configs []assertions.AssertionConfig
+	for _, r := range results {
+		if r.Passed {
+			continue
+		}
+		ac := assertions.AssertionConfig{
+			Type:    r.Type,
+			Message: r.Message,
+		}
+		if r.Details != nil {
+			ac.Params = r.Details
+		}
+		configs = append(configs, ac)
+	}
+	return configs
+}
+
+// applyTurnAssertions attaches per-turn assertions from failed TurnEvalResults
+// to the appropriate turn or workflow step.
+func applyTurnAssertions(
+	scenario *config.Scenario,
+	turnResults map[int][]TurnEvalResult,
+	isWorkflow bool,
+) {
+	if len(turnResults) == 0 {
+		return
+	}
+
+	for turnIdx, results := range turnResults {
+		failedAssertions := collectFailedTurnAssertions(results)
+		if len(failedAssertions) == 0 {
+			continue
+		}
+		attachAssertions(scenario, turnIdx, failedAssertions, isWorkflow)
+	}
+}
+
+func collectFailedTurnAssertions(results []TurnEvalResult) []assertions.AssertionConfig {
+	var out []assertions.AssertionConfig
+	for _, r := range results {
+		if r.Passed {
+			continue
+		}
+		ac := assertions.AssertionConfig{
+			Type:    r.Type,
+			Message: r.Message,
+		}
+		if r.Params != nil {
+			ac.Params = r.Params
+		}
+		out = append(out, ac)
+	}
+	return out
+}
+
+func attachAssertions(
+	scenario *config.Scenario,
+	turnIdx int,
+	asrtConfigs []assertions.AssertionConfig,
+	isWorkflow bool,
+) {
+	if isWorkflow {
+		if turnIdx < len(scenario.Steps) {
+			scenario.Steps[turnIdx].Assertions = append(scenario.Steps[turnIdx].Assertions, asrtConfigs...)
+		}
+	} else {
+		if turnIdx < len(scenario.Turns) {
+			scenario.Turns[turnIdx].Assertions = append(scenario.Turns[turnIdx].Assertions, asrtConfigs...)
+		}
+	}
+}

--- a/tools/arena/generate/converter_test.go
+++ b/tools/arena/generate/converter_test.go
@@ -1,0 +1,160 @@
+package generate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+)
+
+func TestConvertSessionToScenario_Conversation(t *testing.T) {
+	session := &SessionDetail{
+		SessionSummary: SessionSummary{
+			ID:        "session-123",
+			Timestamp: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
+		},
+		Messages: []types.Message{
+			{Role: "user", Content: "Hello"},
+			{Role: "assistant", Content: "Hi there!"},
+			{Role: "user", Content: "How are you?"},
+			{Role: "assistant", Content: "I'm doing well!"},
+		},
+	}
+
+	sc, err := ConvertSessionToScenario(session, ConvertOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "promptkit.altairalabs.ai/v1alpha1", sc.APIVersion)
+	assert.Equal(t, "Scenario", sc.Kind)
+	assert.Equal(t, "session-123", sc.Metadata.Name)
+	assert.Equal(t, "conversation", sc.Spec.TaskType)
+	assert.Len(t, sc.Spec.Turns, 2)
+	assert.Equal(t, "Hello", sc.Spec.Turns[0].Content)
+	assert.Equal(t, "How are you?", sc.Spec.Turns[1].Content)
+	assert.Empty(t, sc.Spec.Steps)
+}
+
+func TestConvertSessionToScenario_Workflow(t *testing.T) {
+	session := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "wf-session"},
+		Messages: []types.Message{
+			{Role: "user", Content: "Start order"},
+			{Role: "assistant", Content: "Order started"},
+			{Role: "user", Content: "Add item"},
+		},
+	}
+
+	sc, err := ConvertSessionToScenario(session, ConvertOptions{Pack: "order.pack.json"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "order.pack.json", sc.Spec.Pack)
+	assert.Empty(t, sc.Spec.TaskType)
+	assert.Empty(t, sc.Spec.Turns)
+	assert.Len(t, sc.Spec.Steps, 2)
+	assert.Equal(t, "input", sc.Spec.Steps[0].Type)
+	assert.Equal(t, "Start order", sc.Spec.Steps[0].Content)
+}
+
+func TestConvertSessionToScenario_WithConversationAssertions(t *testing.T) {
+	session := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "eval-session", HasFailures: true},
+		Messages: []types.Message{
+			{Role: "user", Content: "Test"},
+			{Role: "assistant", Content: "Response"},
+		},
+		EvalResults: []assertions.ConversationValidationResult{
+			{
+				Type:    "content_matches",
+				Passed:  false,
+				Message: "Content did not match pattern",
+				Details: map[string]interface{}{"pattern": "expected.*"},
+			},
+			{
+				Type:    "tools_called",
+				Passed:  true,
+				Message: "Tools were called correctly",
+			},
+		},
+	}
+
+	sc, err := ConvertSessionToScenario(session, ConvertOptions{})
+	require.NoError(t, err)
+
+	// Only failed assertions should be included.
+	require.Len(t, sc.Spec.ConversationAssertions, 1)
+	assert.Equal(t, "content_matches", sc.Spec.ConversationAssertions[0].Type)
+	assert.Equal(t, "Content did not match pattern", sc.Spec.ConversationAssertions[0].Message)
+	assert.Equal(t, "expected.*", sc.Spec.ConversationAssertions[0].Params["pattern"])
+}
+
+func TestConvertSessionToScenario_WithTurnAssertions(t *testing.T) {
+	session := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "turn-eval-session"},
+		Messages: []types.Message{
+			{Role: "user", Content: "Q1"},
+			{Role: "assistant", Content: "A1"},
+			{Role: "user", Content: "Q2"},
+			{Role: "assistant", Content: "A2"},
+		},
+		TurnEvalResults: map[int][]TurnEvalResult{
+			0: {
+				{Type: "content_includes", Passed: false, Message: "Missing keyword", Params: map[string]interface{}{"text": "hello"}},
+			},
+			1: {
+				{Type: "content_includes", Passed: true, Message: "OK"},
+			},
+		},
+	}
+
+	sc, err := ConvertSessionToScenario(session, ConvertOptions{})
+	require.NoError(t, err)
+
+	// Turn 0 should have the failed assertion.
+	require.Len(t, sc.Spec.Turns, 2)
+	require.Len(t, sc.Spec.Turns[0].Assertions, 1)
+	assert.Equal(t, "content_includes", sc.Spec.Turns[0].Assertions[0].Type)
+
+	// Turn 1 should have no assertions (the one present passed).
+	assert.Empty(t, sc.Spec.Turns[1].Assertions)
+}
+
+func TestConvertSessionToScenario_NilSession(t *testing.T) {
+	_, err := ConvertSessionToScenario(nil, ConvertOptions{})
+	require.Error(t, err)
+}
+
+func TestSanitizeID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", "simple"},
+		{"Hello World!", "hello-world"},
+		{"UPPER_CASE", "upper-case"},
+		{"---leading-trailing---", "leading-trailing"},
+		{"", "generated"},
+		{"a" + string(make([]byte, 100)), "a"},
+		{"special@#$chars", "special-chars"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeID(tt.input)
+			assert.Equal(t, tt.expected, got)
+			assert.LessOrEqual(t, len(got), maxIDLength)
+		})
+	}
+}
+
+func TestSanitizeID_LongInput(t *testing.T) {
+	long := ""
+	for i := 0; i < 100; i++ {
+		long += "abcd"
+	}
+	got := sanitizeID(long)
+	assert.LessOrEqual(t, len(got), maxIDLength)
+}

--- a/tools/arena/generate/fingerprint.go
+++ b/tools/arena/generate/fingerprint.go
@@ -1,0 +1,89 @@
+package generate
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+)
+
+const fingerprintLength = 16
+
+// Fingerprint produces a stable hash for a session based on its failure pattern
+// and user message content. Sessions with the same fingerprint are considered
+// duplicates for deduplication purposes.
+func Fingerprint(session *SessionDetail) string {
+	h := sha256.New()
+
+	// Include sorted failure keys from conversation-level eval results.
+	var keys []string
+	for _, r := range session.EvalResults {
+		if !r.Passed {
+			keys = append(keys, failureKey(r))
+		}
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		_, _ = fmt.Fprintln(h, k)
+	}
+
+	// Include sorted failure keys from turn-level eval results.
+	var turnKeys []string
+	for idx, results := range session.TurnEvalResults {
+		for _, r := range results {
+			if !r.Passed {
+				turnKeys = append(turnKeys, fmt.Sprintf("turn:%d:%s", idx, r.Type))
+			}
+		}
+	}
+	sort.Strings(turnKeys)
+	for _, k := range turnKeys {
+		_, _ = fmt.Fprintln(h, k)
+	}
+
+	// Include user message content for content-based fingerprinting.
+	for i := range session.Messages {
+		if session.Messages[i].Role == "user" {
+			_, _ = fmt.Fprintln(h, session.Messages[i].GetContent())
+		}
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil))[:fingerprintLength]
+}
+
+// DeduplicateSessions keeps the first session per unique fingerprint.
+func DeduplicateSessions(sessions []*SessionDetail) []*SessionDetail {
+	seen := make(map[string]bool)
+	var result []*SessionDetail
+
+	for _, s := range sessions {
+		fp := Fingerprint(s)
+		if seen[fp] {
+			continue
+		}
+		seen[fp] = true
+		result = append(result, s)
+	}
+
+	return result
+}
+
+// failureKey returns a stable string representation of a failed assertion result,
+// composed of the assertion type and sorted detail keys.
+func failureKey(r assertions.ConversationValidationResult) string {
+	var parts []string
+	parts = append(parts, r.Type)
+
+	if r.Details != nil {
+		var detailKeys []string
+		for k := range r.Details {
+			detailKeys = append(detailKeys, k)
+		}
+		sort.Strings(detailKeys)
+		parts = append(parts, detailKeys...)
+	}
+
+	return strings.Join(parts, ":")
+}

--- a/tools/arena/generate/fingerprint_test.go
+++ b/tools/arena/generate/fingerprint_test.go
@@ -1,0 +1,135 @@
+package generate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+)
+
+func TestFingerprint_Stability(t *testing.T) {
+	session := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "s1"},
+		Messages: []types.Message{
+			{Role: "user", Content: "Hello"},
+			{Role: "assistant", Content: "Hi"},
+		},
+		EvalResults: []assertions.ConversationValidationResult{
+			{Type: "content_matches", Passed: false, Details: map[string]interface{}{"pattern": "x"}},
+		},
+	}
+
+	fp1 := Fingerprint(session)
+	fp2 := Fingerprint(session)
+	assert.Equal(t, fp1, fp2, "same input should produce same fingerprint")
+	assert.Len(t, fp1, fingerprintLength)
+}
+
+func TestFingerprint_DifferentFailures(t *testing.T) {
+	base := SessionDetail{
+		SessionSummary: SessionSummary{ID: "s1"},
+		Messages: []types.Message{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	s1 := base
+	s1.EvalResults = []assertions.ConversationValidationResult{
+		{Type: "content_matches", Passed: false},
+	}
+
+	s2 := base
+	s2.EvalResults = []assertions.ConversationValidationResult{
+		{Type: "tools_called", Passed: false},
+	}
+
+	assert.NotEqual(t, Fingerprint(&s1), Fingerprint(&s2))
+}
+
+func TestFingerprint_ContentOnly(t *testing.T) {
+	s1 := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "s1"},
+		Messages:       []types.Message{{Role: "user", Content: "Hello"}},
+	}
+	s2 := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "s2"},
+		Messages:       []types.Message{{Role: "user", Content: "Goodbye"}},
+	}
+
+	assert.NotEqual(t, Fingerprint(s1), Fingerprint(s2))
+}
+
+func TestFingerprint_EmptySession(t *testing.T) {
+	session := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "empty"},
+	}
+	fp := Fingerprint(session)
+	assert.Len(t, fp, fingerprintLength)
+}
+
+func TestDeduplicateSessions(t *testing.T) {
+	// Two sessions with identical content and failures should deduplicate.
+	makeSession := func(id string) *SessionDetail {
+		return &SessionDetail{
+			SessionSummary: SessionSummary{ID: id},
+			Messages:       []types.Message{{Role: "user", Content: "same message"}},
+			EvalResults: []assertions.ConversationValidationResult{
+				{Type: "content_matches", Passed: false},
+			},
+		}
+	}
+
+	sessions := []*SessionDetail{
+		makeSession("s1"),
+		makeSession("s2"),
+		makeSession("s3"),
+	}
+
+	result := DeduplicateSessions(sessions)
+	require.Len(t, result, 1, "duplicates should be removed")
+	assert.Equal(t, "s1", result[0].ID, "first session should be kept")
+}
+
+func TestDeduplicateSessions_Unique(t *testing.T) {
+	sessions := []*SessionDetail{
+		{
+			SessionSummary: SessionSummary{ID: "s1"},
+			Messages:       []types.Message{{Role: "user", Content: "message A"}},
+		},
+		{
+			SessionSummary: SessionSummary{ID: "s2"},
+			Messages:       []types.Message{{Role: "user", Content: "message B"}},
+		},
+	}
+
+	result := DeduplicateSessions(sessions)
+	assert.Len(t, result, 2, "unique sessions should all be kept")
+}
+
+func TestDeduplicateSessions_Empty(t *testing.T) {
+	result := DeduplicateSessions(nil)
+	assert.Nil(t, result)
+}
+
+func TestDeduplicateSessions_WithTurnEvalResults(t *testing.T) {
+	s1 := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "s1"},
+		Messages:       []types.Message{{Role: "user", Content: "same"}},
+		TurnEvalResults: map[int][]TurnEvalResult{
+			0: {{Type: "content_includes", Passed: false}},
+		},
+	}
+	s2 := &SessionDetail{
+		SessionSummary: SessionSummary{ID: "s2"},
+		Messages:       []types.Message{{Role: "user", Content: "same"}},
+		TurnEvalResults: map[int][]TurnEvalResult{
+			0: {{Type: "content_includes", Passed: false}},
+		},
+	}
+
+	result := DeduplicateSessions([]*SessionDetail{s1, s2})
+	assert.Len(t, result, 1)
+}

--- a/tools/arena/generate/registry.go
+++ b/tools/arena/generate/registry.go
@@ -1,0 +1,50 @@
+package generate
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Registry manages named SessionSourceAdapter instances.
+type Registry struct {
+	mu       sync.RWMutex
+	adapters map[string]SessionSourceAdapter
+}
+
+// NewRegistry creates a new empty adapter registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		adapters: make(map[string]SessionSourceAdapter),
+	}
+}
+
+// Register adds an adapter to the registry, keyed by its Name().
+func (r *Registry) Register(adapter SessionSourceAdapter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adapters[adapter.Name()] = adapter
+}
+
+// Get returns the adapter with the given name, or an error if not found.
+func (r *Registry) Get(name string) (SessionSourceAdapter, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	adapter, ok := r.adapters[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown session source adapter: %q", name)
+	}
+	return adapter, nil
+}
+
+// Names returns the sorted list of registered adapter names.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.adapters))
+	for name := range r.adapters {
+		names = append(names, name)
+	}
+	return names
+}

--- a/tools/arena/generate/registry_test.go
+++ b/tools/arena/generate/registry_test.go
@@ -1,0 +1,62 @@
+package generate
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockAdapter is a test double for SessionSourceAdapter.
+type mockAdapter struct {
+	name string
+}
+
+func (m *mockAdapter) Name() string { return m.name }
+
+func (m *mockAdapter) List(_ context.Context, _ ListOptions) ([]SessionSummary, error) {
+	return nil, nil
+}
+
+func (m *mockAdapter) Get(_ context.Context, _ string) (*SessionDetail, error) {
+	return nil, nil
+}
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+	adapter := &mockAdapter{name: "test"}
+	r.Register(adapter)
+
+	got, err := r.Get("test")
+	require.NoError(t, err)
+	assert.Equal(t, "test", got.Name())
+}
+
+func TestRegistry_GetUnknown(t *testing.T) {
+	r := NewRegistry()
+
+	_, err := r.Get("nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown session source adapter")
+}
+
+func TestRegistry_Names(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockAdapter{name: "beta"})
+	r.Register(&mockAdapter{name: "alpha"})
+
+	names := r.Names()
+	sort.Strings(names)
+	assert.Equal(t, []string{"alpha", "beta"}, names)
+}
+
+func TestRegistry_RegisterOverwrites(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockAdapter{name: "dup"})
+	r.Register(&mockAdapter{name: "dup"})
+
+	names := r.Names()
+	assert.Len(t, names, 1)
+}

--- a/tools/arena/generate/sources/recordings.go
+++ b/tools/arena/generate/sources/recordings.go
@@ -1,0 +1,111 @@
+// Package sources provides built-in SessionSourceAdapter implementations.
+package sources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/adapters"
+	"github.com/AltairaLabs/PromptKit/tools/arena/generate"
+)
+
+// RecordingsAdapter bridges existing recording adapters to the SessionSourceAdapter interface.
+// It uses the adapters.Registry to enumerate and load recording files.
+type RecordingsAdapter struct {
+	source   string
+	registry *adapters.Registry
+}
+
+// NewRecordingsAdapter creates a RecordingsAdapter that reads from the given source glob.
+func NewRecordingsAdapter(source string) *RecordingsAdapter {
+	return &RecordingsAdapter{
+		source:   source,
+		registry: adapters.NewRegistry(),
+	}
+}
+
+// Name returns "recordings".
+func (a *RecordingsAdapter) Name() string {
+	return "recordings"
+}
+
+// List enumerates recording files and returns a summary for each.
+func (a *RecordingsAdapter) List(
+	_ context.Context,
+	opts generate.ListOptions,
+) ([]generate.SessionSummary, error) {
+	refs, err := a.registry.Enumerate(a.source, "")
+	if err != nil {
+		return nil, fmt.Errorf("enumerating recordings: %w", err)
+	}
+
+	var summaries []generate.SessionSummary
+	for _, ref := range refs {
+		msgs, meta, loadErr := a.registry.Load(ref)
+		if loadErr != nil {
+			continue // skip unloadable recordings
+		}
+
+		summary := generate.SessionSummary{
+			ID:        ref.ID,
+			Source:    ref.Source,
+			TurnCount: len(msgs),
+		}
+		if meta != nil {
+			summary.Tags = meta.Tags
+			if meta.SessionID != "" {
+				summary.ID = meta.SessionID
+			}
+			if len(meta.Timestamps) > 0 {
+				summary.Timestamp = meta.Timestamps[0]
+			}
+		}
+
+		summaries = append(summaries, summary)
+
+		if opts.Limit > 0 && len(summaries) >= opts.Limit {
+			break
+		}
+	}
+
+	return summaries, nil
+}
+
+// Get loads a single recording by ID and returns its full session detail.
+func (a *RecordingsAdapter) Get(_ context.Context, sessionID string) (*generate.SessionDetail, error) {
+	ref := adapters.RecordingReference{
+		ID:     sessionID,
+		Source: sessionID,
+	}
+
+	msgs, meta, err := a.registry.Load(ref)
+	if err != nil {
+		return nil, fmt.Errorf("loading recording %q: %w", sessionID, err)
+	}
+
+	detail := &generate.SessionDetail{
+		SessionSummary: generate.SessionSummary{
+			ID:        sessionID,
+			Source:    sessionID,
+			TurnCount: len(msgs),
+			Timestamp: time.Now(),
+		},
+		Messages: msgs,
+		// Recordings don't carry eval data.
+		EvalResults:     nil,
+		TurnEvalResults: nil,
+	}
+
+	if meta != nil {
+		detail.Tags = meta.Tags
+		if meta.SessionID != "" {
+			detail.ID = meta.SessionID
+		}
+		if len(meta.Timestamps) > 0 {
+			detail.Timestamp = meta.Timestamps[0]
+		}
+	}
+
+	return detail, nil
+}

--- a/tools/arena/generate/sources/recordings_test.go
+++ b/tools/arena/generate/sources/recordings_test.go
@@ -1,0 +1,101 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/generate"
+)
+
+// sessionRecordingFixture creates a minimal .recording.json file for testing.
+func sessionRecordingFixture(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	data := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"session_id":  "sess-" + name,
+			"provider_id": "test-provider",
+			"tags":        []string{"test"},
+		},
+		"events": []map[string]interface{}{
+			{
+				"type":      "message",
+				"timestamp": time.Now().Format(time.RFC3339),
+				"message": map[string]interface{}{
+					"role":    "user",
+					"content": "Hello from " + name,
+				},
+			},
+			{
+				"type":      "message",
+				"timestamp": time.Now().Format(time.RFC3339),
+				"message": map[string]interface{}{
+					"role":    "assistant",
+					"content": "Hi back from " + name,
+				},
+			},
+		},
+	}
+
+	content, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, name+".recording.json")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+	return path
+}
+
+func TestRecordingsAdapter_Name(t *testing.T) {
+	adapter := NewRecordingsAdapter("*.recording.json")
+	assert.Equal(t, "recordings", adapter.Name())
+}
+
+func TestRecordingsAdapter_ListFromFixtures(t *testing.T) {
+	dir := t.TempDir()
+	sessionRecordingFixture(t, dir, "one")
+	sessionRecordingFixture(t, dir, "two")
+
+	adapter := NewRecordingsAdapter(filepath.Join(dir, "*.recording.json"))
+	summaries, err := adapter.List(context.Background(), generate.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, summaries, 2)
+}
+
+func TestRecordingsAdapter_ListWithLimit(t *testing.T) {
+	dir := t.TempDir()
+	sessionRecordingFixture(t, dir, "one")
+	sessionRecordingFixture(t, dir, "two")
+	sessionRecordingFixture(t, dir, "three")
+
+	adapter := NewRecordingsAdapter(filepath.Join(dir, "*.recording.json"))
+	summaries, err := adapter.List(context.Background(), generate.ListOptions{Limit: 2})
+	require.NoError(t, err)
+	assert.Len(t, summaries, 2)
+}
+
+func TestRecordingsAdapter_GetSession(t *testing.T) {
+	dir := t.TempDir()
+	path := sessionRecordingFixture(t, dir, "test")
+
+	adapter := NewRecordingsAdapter(filepath.Join(dir, "*.recording.json"))
+	detail, err := adapter.Get(context.Background(), path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "sess-test", detail.ID)
+	assert.Len(t, detail.Messages, 2)
+	assert.Equal(t, "user", detail.Messages[0].Role)
+	assert.Nil(t, detail.EvalResults, "recordings should not have eval results")
+}
+
+func TestRecordingsAdapter_GetMissingFile(t *testing.T) {
+	adapter := NewRecordingsAdapter("*.recording.json")
+	_, err := adapter.Get(context.Background(), "/nonexistent/file.recording.json")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Implements #426 — adds a `promptarena generate` command with a pluggable `SessionSourceAdapter` interface for converting session data into reproducible Arena scenario YAML files.

- **`SessionSourceAdapter` interface** (`tools/arena/generate/adapter.go`) — `Name()`, `List()`, `Get()` with `ListOptions` filtering, `SessionDetail` with messages + eval results
- **Name-keyed registry** (`tools/arena/generate/registry.go`) — thread-safe adapter registry for external plugins
- **Session-to-scenario converter** (`tools/arena/generate/converter.go`) — generates K8s-style `ScenarioConfig` YAML with conversation/workflow support, reconstructs failed assertions as conversation-level and turn-level assertions
- **Failure-pattern dedup** (`tools/arena/generate/fingerprint.go`) — SHA-256 fingerprinting of failure patterns + user content for deduplication
- **Built-in recordings adapter** (`tools/arena/generate/sources/recordings.go`) — bridges existing `adapters.Registry` to `SessionSourceAdapter`
- **Cobra command** (`tools/arena/cmd/promptarena/generate.go`) — `--source`, `--from-recordings`, `--filter-eval-type`, `--filter-passed`, `--pack`, `--output`, `--dedup` flags

## Test plan

- [x] `go build ./tools/arena/...` passes
- [x] `go test ./tools/arena/generate/... -v -race -count=1` — 26 tests pass (98.4%+ coverage)
- [x] `go test ./tools/arena/cmd/promptarena/... -run "TestResolveAdapter|TestBuildListOptions"` — 6 tests pass (95.5% coverage on generate.go)
- [x] `golangci-lint run ./tools/arena/generate/...` — 0 issues
- [x] Pre-commit hook passes (lint, build, test, coverage ≥80% on all changed files)