### PR TITLE
feat(evals): unified eval/assertion foundation (Phases 0-3)

### DIFF
--- a/runtime/evals/event_listener_test.go
+++ b/runtime/evals/event_listener_test.go
@@ -60,6 +60,12 @@ func (d *recordingDispatcher) DispatchSessionEvals(
 	return results, nil
 }
 
+func (d *recordingDispatcher) DispatchConversationEvals(
+	_ context.Context, _ []EvalDef, _ *EvalContext,
+) ([]EvalResult, error) {
+	return nil, nil
+}
+
 func (d *recordingDispatcher) TurnCalls() int {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/runtime/evals/handlers/agent_handlers_test.go
+++ b/runtime/evals/handlers/agent_handlers_test.go
@@ -1,0 +1,202 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// --- AgentInvoked ---
+
+func TestAgentInvokedHandler_Type(t *testing.T) {
+	h := &AgentInvokedHandler{}
+	if h.Type() != "agent_invoked" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestAgentInvokedHandler_Pass(t *testing.T) {
+	h := &AgentInvokedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "agent_a"},
+			{ToolName: "agent_b"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"agents": []any{"agent_a", "agent_b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestAgentInvokedHandler_Missing(t *testing.T) {
+	h := &AgentInvokedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "agent_a"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"agents": []any{"agent_a", "agent_c"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing agent")
+	}
+}
+
+func TestAgentInvokedHandler_NoAgents(t *testing.T) {
+	h := &AgentInvokedHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no agents")
+	}
+}
+
+// --- AgentNotInvoked ---
+
+func TestAgentNotInvokedHandler_Type(t *testing.T) {
+	h := &AgentNotInvokedHandler{}
+	if h.Type() != "agent_not_invoked" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestAgentNotInvokedHandler_Pass(t *testing.T) {
+	h := &AgentNotInvokedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "agent_a"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"agents": []any{"agent_b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestAgentNotInvokedHandler_Fail(t *testing.T) {
+	h := &AgentNotInvokedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "agent_a"},
+			{ToolName: "forbidden_agent"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"agents": []any{"forbidden_agent"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for forbidden agent called")
+	}
+}
+
+// --- AgentResponseContains ---
+
+func TestAgentResponseContainsHandler_Type(t *testing.T) {
+	h := &AgentResponseContainsHandler{}
+	if h.Type() != "agent_response_contains" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestAgentResponseContainsHandler_ViaToolCalls(t *testing.T) {
+	h := &AgentResponseContainsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "billing_agent", Result: "Your balance is $100"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"agent":    "billing_agent",
+		"contains": "balance",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestAgentResponseContainsHandler_ViaMessages(t *testing.T) {
+	h := &AgentResponseContainsHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{
+				Role: "tool",
+				ToolResult: &types.MessageToolResult{
+					Name:    "billing_agent",
+					Content: "Your balance is $100",
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"agent":    "billing_agent",
+		"contains": "balance",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass via messages: %s", result.Explanation)
+	}
+}
+
+func TestAgentResponseContainsHandler_NotFound(t *testing.T) {
+	h := &AgentResponseContainsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "billing_agent", Result: "some other response"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"agent":    "billing_agent",
+		"contains": "balance",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail when content not found")
+	}
+}
+
+func TestAgentResponseContainsHandler_NoAgent(t *testing.T) {
+	h := &AgentResponseContainsHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no agent")
+	}
+}

--- a/runtime/evals/handlers/agent_invoked.go
+++ b/runtime/evals/handlers/agent_invoked.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// AgentInvokedHandler checks that expected agents were invoked as tool calls.
+// Params: agents []string — list of agent names that should have been called.
+type AgentInvokedHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *AgentInvokedHandler) Type() string { return "agent_invoked" }
+
+// Eval checks if expected agents were invoked.
+func (h *AgentInvokedHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	agents := extractStringSlice(params, "agents")
+	if len(agents) == 0 {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "no agents specified",
+		}, nil
+	}
+
+	calledSet := make(map[string]bool)
+	for _, tc := range evalCtx.ToolCalls {
+		calledSet[tc.ToolName] = true
+	}
+
+	var missing []string
+	for _, agent := range agents {
+		if !calledSet[agent] {
+			missing = append(missing, agent)
+		}
+	}
+
+	if len(missing) > 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("missing agents: %s", strings.Join(missing, ", ")),
+			Details:     map[string]any{"missing_agents": missing},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type: h.Type(), Passed: true,
+		Explanation: "all expected agents were invoked",
+	}, nil
+}

--- a/runtime/evals/handlers/agent_not_invoked.go
+++ b/runtime/evals/handlers/agent_not_invoked.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// AgentNotInvokedHandler checks that forbidden agents were NOT called.
+// Params: agents []string — agent names that should not have been called.
+type AgentNotInvokedHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *AgentNotInvokedHandler) Type() string { return "agent_not_invoked" }
+
+// Eval checks if any forbidden agents were invoked.
+func (h *AgentNotInvokedHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	agents := extractStringSlice(params, "agents")
+	if len(agents) == 0 {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: true,
+			Explanation: "no agents specified to exclude",
+		}, nil
+	}
+
+	forbiddenSet := make(map[string]bool)
+	for _, a := range agents {
+		forbiddenSet[a] = true
+	}
+
+	var called []string
+	for _, tc := range evalCtx.ToolCalls {
+		if forbiddenSet[tc.ToolName] {
+			called = append(called, tc.ToolName)
+		}
+	}
+
+	if len(called) > 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("forbidden agents called: %s", strings.Join(called, ", ")),
+			Details:     map[string]any{"forbidden_agents_called": called},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type: h.Type(), Passed: true,
+		Explanation: "no forbidden agents were invoked",
+	}, nil
+}

--- a/runtime/evals/handlers/agent_response_contains.go
+++ b/runtime/evals/handlers/agent_response_contains.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// AgentResponseContainsHandler checks that a specific agent's response
+// contains expected text. Agent responses appear as tool-result messages
+// where the tool name matches the agent name.
+// Params: agent string, contains string.
+type AgentResponseContainsHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *AgentResponseContainsHandler) Type() string { return "agent_response_contains" }
+
+// Eval checks if the specified agent's tool result contains the expected text.
+func (h *AgentResponseContainsHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	agent, _ := params["agent"].(string)
+	contains, _ := params["contains"].(string)
+
+	if agent == "" {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "no agent specified",
+		}, nil
+	}
+
+	// Check tool call records for matching agent
+	for _, tc := range evalCtx.ToolCalls {
+		if tc.ToolName != agent {
+			continue
+		}
+		resultStr := asString(tc.Result)
+		if strings.Contains(resultStr, contains) {
+			return &evals.EvalResult{
+				Type: h.Type(), Passed: true,
+				Explanation: fmt.Sprintf("agent %q response contains expected text", agent),
+			}, nil
+		}
+	}
+
+	// Also check messages for tool result messages
+	for i := range evalCtx.Messages {
+		msg := &evalCtx.Messages[i]
+		if msg.Role == "tool" && msg.ToolResult != nil && msg.ToolResult.Name == agent {
+			if strings.Contains(msg.ToolResult.Content, contains) {
+				return &evals.EvalResult{
+					Type: h.Type(), Passed: true,
+					Explanation: fmt.Sprintf("agent %q response contains expected text", agent),
+				}, nil
+			}
+		}
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      false,
+		Explanation: fmt.Sprintf("no response from agent %q containing %q", agent, contains),
+		Details:     map[string]any{"agent": agent, "expected_substr": contains},
+	}, nil
+}

--- a/runtime/evals/handlers/audio_duration.go
+++ b/runtime/evals/handlers/audio_duration.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// AudioDurationHandler checks that audio duration is within range.
+// Params: min_seconds float64, max_seconds float64.
+type AudioDurationHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *AudioDurationHandler) Type() string { return "audio_duration" }
+
+// Eval checks audio duration constraints.
+func (h *AudioDurationHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return evalMediaDuration(h.Type(), evalCtx.Messages, types.ContentTypeAudio, errNoAudioFound, "audio_count", params)
+}

--- a/runtime/evals/handlers/audio_format.go
+++ b/runtime/evals/handlers/audio_format.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// AudioFormatHandler checks that audio content has allowed formats.
+// Params: formats []string.
+type AudioFormatHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *AudioFormatHandler) Type() string { return "audio_format" }
+
+// Eval checks audio formats against the allowed list.
+func (h *AudioFormatHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return evalMediaFormats(
+		h.Type(), evalCtx.Messages, types.ContentTypeAudio,
+		errNoAudioFound, "all audio has allowed formats", "some audio has disallowed formats",
+		params,
+	)
+}

--- a/runtime/evals/handlers/guardrail_triggered.go
+++ b/runtime/evals/handlers/guardrail_triggered.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// GuardrailTriggeredHandler checks if a specific guardrail validator
+// triggered (or didn't trigger) as expected.
+// Params: validator_type string, should_trigger bool (default true).
+type GuardrailTriggeredHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *GuardrailTriggeredHandler) Type() string { return "guardrail_triggered" }
+
+// Eval checks guardrail validation results from the last assistant message.
+func (h *GuardrailTriggeredHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	validatorType := extractValidatorType(params)
+	if validatorType == "" {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "validator_type parameter required",
+		}, nil
+	}
+
+	shouldTrigger := true
+	if v, ok := params["should_trigger"].(bool); ok {
+		shouldTrigger = v
+	}
+
+	found := findValidationResult(evalCtx.Messages, validatorType)
+	return h.evaluateResult(found, validatorType, shouldTrigger), nil
+}
+
+func extractValidatorType(params map[string]any) string {
+	if v, _ := params["validator_type"].(string); v != "" {
+		return v
+	}
+	v, _ := params["validator"].(string)
+	return v
+}
+
+func findValidationResult(messages []types.Message, validatorType string) *types.ValidationResult {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role != roleAssistant {
+			continue
+		}
+		for j := range messages[i].Validations {
+			if guardrailTypeMatches(messages[i].Validations[j].ValidatorType, validatorType) {
+				return &messages[i].Validations[j]
+			}
+		}
+		break
+	}
+	return nil
+}
+
+func (h *GuardrailTriggeredHandler) evaluateResult(
+	found *types.ValidationResult, validatorType string, shouldTrigger bool,
+) *evals.EvalResult {
+	if found == nil {
+		passed := !shouldTrigger
+		msg := fmt.Sprintf("expected validator %q to run but it did not", validatorType)
+		if passed {
+			msg = fmt.Sprintf("validator %q did not run (as expected)", validatorType)
+		}
+		return &evals.EvalResult{Type: h.Type(), Passed: passed, Explanation: msg}
+	}
+
+	triggered := !found.Passed
+	passed := shouldTrigger == triggered
+	if !passed {
+		action := "fail"
+		if !shouldTrigger {
+			action = "pass"
+		}
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: fmt.Sprintf("expected validator %q to %s but it did not", validatorType, action),
+		}
+	}
+
+	return &evals.EvalResult{
+		Type: h.Type(), Passed: true,
+		Explanation: fmt.Sprintf("validator %q behaved as expected", validatorType),
+		Details:     map[string]any{"validator": validatorType, "triggered": triggered},
+	}
+}
+
+// guardrailTypeMatches checks validator type with friendly name matching.
+func guardrailTypeMatches(validatorType, expectedName string) bool {
+	if validatorType == expectedName {
+		return true
+	}
+	friendlyName := snakeToPascal(expectedName)
+	if friendlyName == "" {
+		return false
+	}
+	return validatorType == friendlyName+"Validator" ||
+		validatorType == "*validators."+friendlyName+"Validator"
+}
+
+func snakeToPascal(s string) string {
+	if s == "" {
+		return ""
+	}
+	var result []byte
+	capitalizeNext := true
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' {
+			capitalizeNext = true
+			continue
+		}
+		if capitalizeNext && c >= 'a' && c <= 'z' {
+			result = append(result, c-('a'-'A'))
+			capitalizeNext = false
+		} else {
+			result = append(result, c)
+			capitalizeNext = false
+		}
+	}
+	return strings.TrimSpace(string(result))
+}

--- a/runtime/evals/handlers/guardrail_triggered_test.go
+++ b/runtime/evals/handlers/guardrail_triggered_test.go
@@ -1,0 +1,164 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestGuardrailTriggeredHandler_Type(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	if h.Type() != "guardrail_triggered" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestGuardrailTriggeredHandler_TriggeredAsExpected(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{
+				Role: "assistant",
+				Validations: []types.ValidationResult{
+					{ValidatorType: "banned_words", Passed: false},
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestGuardrailTriggeredHandler_NotTriggeredAsExpected(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{
+				Role: "assistant",
+				Validations: []types.ValidationResult{
+					{ValidatorType: "banned_words", Passed: true},
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestGuardrailTriggeredHandler_ExpectedTriggerButPassed(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{
+				Role: "assistant",
+				Validations: []types.ValidationResult{
+					{ValidatorType: "banned_words", Passed: true},
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail when trigger expected but validator passed")
+	}
+}
+
+func TestGuardrailTriggeredHandler_ValidatorNotFound(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "assistant"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail when validator not found but expected to trigger")
+	}
+}
+
+func TestGuardrailTriggeredHandler_FriendlyNameMatch(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{
+				Role: "assistant",
+				Validations: []types.ValidationResult{
+					{ValidatorType: "*validators.BannedWordsValidator", Passed: false},
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass with friendly name match: %s", result.Explanation)
+	}
+}
+
+func TestGuardrailTriggeredHandler_NoValidatorType(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no validator_type")
+	}
+}
+
+func TestSnakeToPascal(t *testing.T) {
+	tests := []struct {
+		input, expected string
+	}{
+		{"banned_words", "BannedWords"},
+		{"max_length", "MaxLength"},
+		{"simple", "Simple"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := snakeToPascal(tt.input)
+		if got != tt.expected {
+			t.Errorf("snakeToPascal(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -760,23 +760,60 @@ func TestCosineSimilarityHandler_AnySlice(t *testing.T) {
 func TestRegisterInit(t *testing.T) {
 	// Verify that init() registered all handlers
 	expected := []string{
+		// Turn-level deterministic
 		"contains",
+		"regex",
+		"json_valid",
+		"json_schema",
+		"tools_called",
+		"tools_not_called",
+		"tool_args",
+		"latency_budget",
+		"cosine_similarity",
+
+		// Session-level deterministic
 		"contains_any",
 		"content_excludes",
-		"cosine_similarity",
-		"json_schema",
-		"json_valid",
-		"latency_budget",
+		"tools_called_session",
+		"tools_not_called_session",
+		"tool_args_session",
+		"tool_args_excluded_session",
+
+		// Tool call handlers (Batch 1)
+		"no_tool_errors",
+		"tool_call_count",
+		"tool_result_includes",
+		"tool_result_matches",
+		"tool_call_sequence",
+		"tool_call_chain",
+		"tool_calls_with_args",
+
+		// JSON path, agent, guardrail handlers (Batch 2)
+		"json_path",
+		"agent_invoked",
+		"agent_not_invoked",
+		"agent_response_contains",
+		"guardrail_triggered",
+
+		// Workflow and skill handlers (Batch 3)
+		"workflow_complete",
+		"state_is",
+		"transitioned_to",
+		"skill_activated",
+		"skill_not_activated",
+
+		// Media handlers (Batch 4)
+		"image_format",
+		"image_dimensions",
+		"audio_format",
+		"audio_duration",
+		"video_duration",
+		"video_resolution",
+
+		// LLM judge handlers
 		"llm_judge",
 		"llm_judge_session",
-		"regex",
-		"tool_args",
-		"tool_args_excluded_session",
-		"tool_args_session",
-		"tools_called",
-		"tools_called_session",
-		"tools_not_called",
-		"tools_not_called_session",
+		"llm_judge_tool_calls",
 	}
 
 	r := evals.NewEvalTypeRegistry()

--- a/runtime/evals/handlers/helpers.go
+++ b/runtime/evals/handlers/helpers.go
@@ -47,3 +47,79 @@ func asString(v any) string {
 	}
 	return fmt.Sprintf("%v", v)
 }
+
+// extractFloat64Ptr extracts an optional float64 param, handling int->float64.
+func extractFloat64Ptr(params map[string]any, key string) *float64 {
+	val, ok := params[key]
+	if !ok {
+		return nil
+	}
+	switch v := val.(type) {
+	case float64:
+		return &v
+	case int:
+		f := float64(v)
+		return &f
+	default:
+		return nil
+	}
+}
+
+// extractIntPtr extracts an optional integer param.
+func extractIntPtr(params map[string]any, key string) *int {
+	val, ok := params[key]
+	if !ok {
+		return nil
+	}
+	switch v := val.(type) {
+	case int:
+		return &v
+	case float64:
+		i := int(v)
+		return &i
+	default:
+		return nil
+	}
+}
+
+// extractBool extracts a boolean param from a map.
+func extractBool(params map[string]any, key string) bool {
+	val, ok := params[key].(bool)
+	return ok && val
+}
+
+// extractMapStringString extracts a map[string]string from params.
+func extractMapStringString(params map[string]any, key string) map[string]string {
+	value, exists := params[key]
+	if !exists {
+		return nil
+	}
+
+	if m, ok := value.(map[string]any); ok {
+		result := make(map[string]string, len(m))
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				result[k] = s
+			}
+		}
+		return result
+	}
+
+	if m, ok := value.(map[string]string); ok {
+		return m
+	}
+
+	return nil
+}
+
+// extractMapAny extracts a map[string]any from params.
+func extractMapAny(params map[string]any, key string) map[string]any {
+	value, exists := params[key]
+	if !exists {
+		return nil
+	}
+	if m, ok := value.(map[string]any); ok {
+		return m
+	}
+	return nil
+}

--- a/runtime/evals/handlers/helpers_test.go
+++ b/runtime/evals/handlers/helpers_test.go
@@ -1,0 +1,172 @@
+package handlers
+
+import (
+	"testing"
+)
+
+func TestAsString_NonString(t *testing.T) {
+	// Cover the fmt.Sprintf branch for non-string values.
+	tests := []struct {
+		input    any
+		expected string
+	}{
+		{42, "42"},
+		{3.14, "3.14"},
+		{true, "true"},
+		{nil, "<nil>"},
+		{[]int{1, 2}, "[1 2]"},
+	}
+	for _, tt := range tests {
+		got := asString(tt.input)
+		if got != tt.expected {
+			t.Errorf("asString(%v) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestAsString_String(t *testing.T) {
+	got := asString("hello")
+	if got != "hello" {
+		t.Errorf("asString(\"hello\") = %q, want \"hello\"", got)
+	}
+}
+
+func TestExtractFloat64Ptr_Float64(t *testing.T) {
+	params := map[string]any{"val": 3.14}
+	result := extractFloat64Ptr(params, "val")
+	if result == nil || *result != 3.14 {
+		t.Fatalf("expected 3.14, got %v", result)
+	}
+}
+
+func TestExtractFloat64Ptr_Int(t *testing.T) {
+	params := map[string]any{"val": 42}
+	result := extractFloat64Ptr(params, "val")
+	if result == nil || *result != 42.0 {
+		t.Fatalf("expected 42.0, got %v", result)
+	}
+}
+
+func TestExtractFloat64Ptr_Missing(t *testing.T) {
+	params := map[string]any{}
+	result := extractFloat64Ptr(params, "val")
+	if result != nil {
+		t.Fatal("expected nil for missing key")
+	}
+}
+
+func TestExtractFloat64Ptr_UnsupportedType(t *testing.T) {
+	params := map[string]any{"val": "not a number"}
+	result := extractFloat64Ptr(params, "val")
+	if result != nil {
+		t.Fatal("expected nil for unsupported type")
+	}
+}
+
+func TestExtractIntPtr_Int(t *testing.T) {
+	params := map[string]any{"val": 42}
+	result := extractIntPtr(params, "val")
+	if result == nil || *result != 42 {
+		t.Fatalf("expected 42, got %v", result)
+	}
+}
+
+func TestExtractIntPtr_Float64(t *testing.T) {
+	params := map[string]any{"val": 3.7}
+	result := extractIntPtr(params, "val")
+	if result == nil || *result != 3 {
+		t.Fatalf("expected 3, got %v", result)
+	}
+}
+
+func TestExtractIntPtr_Missing(t *testing.T) {
+	params := map[string]any{}
+	result := extractIntPtr(params, "val")
+	if result != nil {
+		t.Fatal("expected nil for missing key")
+	}
+}
+
+func TestExtractIntPtr_UnsupportedType(t *testing.T) {
+	params := map[string]any{"val": "not a number"}
+	result := extractIntPtr(params, "val")
+	if result != nil {
+		t.Fatal("expected nil for unsupported type")
+	}
+}
+
+func TestExtractMapStringString_MapStringAny(t *testing.T) {
+	params := map[string]any{
+		"data": map[string]any{"key1": "val1", "key2": "val2"},
+	}
+	result := extractMapStringString(params, "data")
+	if result == nil || result["key1"] != "val1" || result["key2"] != "val2" {
+		t.Fatalf("unexpected result: %v", result)
+	}
+}
+
+func TestExtractMapStringString_MapStringString(t *testing.T) {
+	params := map[string]any{
+		"data": map[string]string{"key1": "val1"},
+	}
+	result := extractMapStringString(params, "data")
+	if result == nil || result["key1"] != "val1" {
+		t.Fatalf("unexpected result: %v", result)
+	}
+}
+
+func TestExtractMapStringString_Missing(t *testing.T) {
+	result := extractMapStringString(map[string]any{}, "data")
+	if result != nil {
+		t.Fatal("expected nil for missing key")
+	}
+}
+
+func TestExtractMapStringString_WrongType(t *testing.T) {
+	params := map[string]any{"data": "not a map"}
+	result := extractMapStringString(params, "data")
+	if result != nil {
+		t.Fatal("expected nil for wrong type")
+	}
+}
+
+func TestExtractMapStringString_NonStringValues(t *testing.T) {
+	// When map[string]any contains non-string values, they should be skipped.
+	params := map[string]any{
+		"data": map[string]any{"key1": "val1", "key2": 42},
+	}
+	result := extractMapStringString(params, "data")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result["key1"] != "val1" {
+		t.Errorf("expected key1=val1, got %q", result["key1"])
+	}
+	if _, exists := result["key2"]; exists {
+		t.Error("non-string value should not be in result")
+	}
+}
+
+func TestExtractMapAny_Present(t *testing.T) {
+	inner := map[string]any{"a": 1}
+	params := map[string]any{"data": inner}
+	result := extractMapAny(params, "data")
+	if result == nil || result["a"] != 1 {
+		t.Fatalf("unexpected result: %v", result)
+	}
+}
+
+func TestExtractMapAny_Missing(t *testing.T) {
+	result := extractMapAny(map[string]any{}, "data")
+	if result != nil {
+		t.Fatal("expected nil for missing key")
+	}
+}
+
+func TestExtractMapAny_WrongType(t *testing.T) {
+	params := map[string]any{"data": "not a map"}
+	result := extractMapAny(params, "data")
+	if result != nil {
+		t.Fatal("expected nil for wrong type")
+	}
+}

--- a/runtime/evals/handlers/image_dimensions.go
+++ b/runtime/evals/handlers/image_dimensions.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// ImageDimensionsHandler checks that images meet dimension requirements.
+// Params: min_width, max_width, min_height, max_height, width, height.
+type ImageDimensionsHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ImageDimensionsHandler) Type() string { return "image_dimensions" }
+
+// Eval checks image dimensions against constraints.
+func (h *ImageDimensionsHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	minWidth := extractIntPtr(params, "min_width")
+	maxWidth := extractIntPtr(params, "max_width")
+	minHeight := extractIntPtr(params, "min_height")
+	maxHeight := extractIntPtr(params, "max_height")
+	exactWidth := extractIntPtr(params, "width")
+	exactHeight := extractIntPtr(params, "height")
+
+	parts := extractMediaParts(evalCtx.Messages, types.ContentTypeImage)
+	if len(parts) == 0 {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: errNoImagesFound,
+		}, nil
+	}
+
+	var violations []string
+	for _, part := range parts {
+		if part.Media.Width == nil || part.Media.Height == nil {
+			violations = append(violations, errMissingDimensions)
+			continue
+		}
+		w, ht := *part.Media.Width, *part.Media.Height
+		if exactWidth != nil && w != *exactWidth {
+			violations = append(violations, fmt.Sprintf("width %d does not match required %d", w, *exactWidth))
+		}
+		if exactHeight != nil && ht != *exactHeight {
+			violations = append(violations, fmt.Sprintf("height %d does not match required %d", ht, *exactHeight))
+		}
+		violations = append(violations, checkWidthRange(w, minWidth, maxWidth)...)
+		violations = append(violations, checkHeightRange(ht, minHeight, maxHeight)...)
+	}
+
+	passed := len(violations) == 0
+	explanation := "all images meet dimension requirements"
+	if !passed {
+		explanation = "some images violate dimension requirements"
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Explanation: explanation,
+		Details: map[string]any{
+			"image_count": len(parts),
+			"violations":  violations,
+		},
+	}, nil
+}

--- a/runtime/evals/handlers/image_format.go
+++ b/runtime/evals/handlers/image_format.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// ImageFormatHandler checks that images in assistant messages have allowed formats.
+// Params: formats []string.
+type ImageFormatHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ImageFormatHandler) Type() string { return "image_format" }
+
+// Eval checks image formats against the allowed list.
+func (h *ImageFormatHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return evalMediaFormats(
+		h.Type(), evalCtx.Messages, types.ContentTypeImage,
+		errNoImagesFound, "all images have allowed formats", "some images have disallowed formats",
+		params,
+	)
+}

--- a/runtime/evals/handlers/json_path.go
+++ b/runtime/evals/handlers/json_path.go
@@ -1,0 +1,310 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// JSONPathHandler validates assistant output as JSON using JMESPath expressions.
+// Params:
+//   - expression string (JMESPath expression)
+//   - expected any (optional: exact match)
+//   - contains []any (optional: array contains check)
+//   - min_results int, max_results int (optional: array length bounds)
+//   - min float64, max float64 (optional: numeric range)
+//   - allow_wrapped bool (optional: extract JSON from code blocks)
+//   - extract_json bool (optional: extract JSON from mixed text)
+type JSONPathHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *JSONPathHandler) Type() string { return "json_path" }
+
+// Eval executes a JMESPath expression on the assistant output and validates the result.
+func (h *JSONPathHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	expression, _ := params["expression"].(string)
+	if expression == "" {
+		expression, _ = params["jmespath_expression"].(string)
+	}
+	if expression == "" {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "no expression specified",
+		}, nil
+	}
+
+	allowWrapped := extractBool(params, "allow_wrapped")
+	extractJSON := extractBool(params, "extract_json")
+
+	jsonContent := evalCtx.CurrentOutput
+	if allowWrapped || extractJSON {
+		if extracted := extractJSONFromContent(jsonContent, allowWrapped, extractJSON); extracted != "" {
+			jsonContent = extracted
+		}
+	}
+
+	var data any
+	if err := json.Unmarshal([]byte(jsonContent), &data); err != nil {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: fmt.Sprintf("invalid JSON: %v", err),
+		}, nil
+	}
+
+	result, err := jmespath.Search(expression, data)
+	if err != nil {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: fmt.Sprintf("JMESPath error: %v", err),
+			Details:     map[string]any{"expression": expression},
+		}, nil
+	}
+
+	return h.validateResult(result, params)
+}
+
+func (h *JSONPathHandler) validateResult(result any, params map[string]any) (*evals.EvalResult, error) {
+	if expected, ok := params["expected"]; ok {
+		if !jsonCompareValues(result, expected) {
+			return h.fail("result does not match expected value",
+				map[string]any{"expected": expected, "actual": result}), nil
+		}
+	}
+
+	if contains, ok := params["contains"]; ok {
+		if err := h.checkContains(result, contains); err != "" {
+			return h.fail(err, map[string]any{"result": result}), nil
+		}
+	}
+
+	if r := h.checkNumericRange(result, params); r != nil {
+		return r, nil
+	}
+
+	if r := h.checkArrayCount(result, params); r != nil {
+		return r, nil
+	}
+
+	return &evals.EvalResult{
+		Type: h.Type(), Passed: true,
+		Explanation: "JSON path validation passed",
+		Details:     map[string]any{"result": result},
+	}, nil
+}
+
+func (h *JSONPathHandler) fail(explanation string, details map[string]any) *evals.EvalResult {
+	return &evals.EvalResult{Type: h.Type(), Passed: false, Explanation: explanation, Details: details}
+}
+
+func (h *JSONPathHandler) checkNumericRange(result any, params map[string]any) *evals.EvalResult {
+	minVal := extractFloat64Ptr(params, "min")
+	maxVal := extractFloat64Ptr(params, "max")
+	if minVal == nil && maxVal == nil {
+		return nil
+	}
+
+	numValue, ok := jsonToFloat64(result)
+	if !ok {
+		return h.fail("result is not a number for range check", nil)
+	}
+	if minVal != nil && numValue < *minVal {
+		return h.fail(fmt.Sprintf("value %.2f is below minimum %.2f", numValue, *minVal), nil)
+	}
+	if maxVal != nil && numValue > *maxVal {
+		return h.fail(fmt.Sprintf("value %.2f exceeds maximum %.2f", numValue, *maxVal), nil)
+	}
+	return nil
+}
+
+func (h *JSONPathHandler) checkArrayCount(result any, params map[string]any) *evals.EvalResult {
+	minResults := extractInt(params, "min_results", 0)
+	maxResults := extractInt(params, "max_results", 0)
+	if minResults == 0 && maxResults == 0 {
+		return nil
+	}
+
+	arr, ok := result.([]any)
+	if !ok {
+		return h.fail("result is not an array for count check", nil)
+	}
+	count := len(arr)
+	if minResults > 0 && count < minResults {
+		return h.fail(fmt.Sprintf("array has %d items, minimum is %d", count, minResults), nil)
+	}
+	if maxResults > 0 && count > maxResults {
+		return h.fail(fmt.Sprintf("array has %d items, maximum is %d", count, maxResults), nil)
+	}
+	return nil
+}
+
+func (h *JSONPathHandler) checkContains(result, contains any) string {
+	resultArray, ok := result.([]any)
+	if !ok {
+		return "result is not an array, cannot check contains"
+	}
+	containsArray, ok := contains.([]any)
+	if !ok {
+		return "contains parameter must be an array"
+	}
+	for _, expected := range containsArray {
+		found := false
+		for _, item := range resultArray {
+			if jsonCompareValues(item, expected) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Sprintf("expected item %v not found in result", expected)
+		}
+	}
+	return ""
+}
+
+// extractJSONFromContent extracts JSON from mixed/wrapped content.
+func extractJSONFromContent(content string, allowWrapped, extractJSON bool) string {
+	if allowWrapped {
+		re := regexp.MustCompile("```(?:json)?\\s*\\n([\\s\\S]*?)\\n```")
+		matches := re.FindStringSubmatch(content)
+		if len(matches) > 1 {
+			return strings.TrimSpace(matches[1])
+		}
+	}
+
+	if extractJSON {
+		if idx := strings.Index(content, "{"); idx >= 0 {
+			if extracted := extractBalancedJSON(content[idx:], '{', '}'); extracted != "" {
+				return extracted
+			}
+		}
+		if idx := strings.Index(content, "["); idx >= 0 {
+			if extracted := extractBalancedJSON(content[idx:], '[', ']'); extracted != "" {
+				return extracted
+			}
+		}
+	}
+
+	return ""
+}
+
+func extractBalancedJSON(content string, openChar, closeChar byte) string {
+	if content == "" || content[0] != openChar {
+		return ""
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := range len(content) {
+		ch := content[i]
+		depth, inString, escaped = advanceJSONParser(ch, openChar, closeChar, depth, inString, escaped)
+		if depth == 0 && !inString && i > 0 {
+			return content[:i+1]
+		}
+	}
+	return ""
+}
+
+// advanceJSONParser advances the JSON parser state by one character.
+func advanceJSONParser(
+	ch, openChar, closeChar byte, depth int, inString, escaped bool,
+) (newDepth int, newInString, newEscaped bool) {
+	if escaped {
+		return depth, inString, false
+	}
+	switch {
+	case ch == '\\' && inString:
+		return depth, inString, true
+	case ch == '"':
+		return depth, !inString, false
+	case ch == openChar && !inString:
+		return depth + 1, inString, false
+	case ch == closeChar && !inString:
+		return depth - 1, inString, false
+	default:
+		return depth, inString, false
+	}
+}
+
+func jsonCompareValues(a, b any) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if ok, result := jsonCompareNumeric(a, b); ok {
+		return result
+	}
+	if ok, result := jsonCompareArrays(a, b); ok {
+		return result
+	}
+	if ok, result := jsonCompareMaps(a, b); ok {
+		return result
+	}
+	return a == b
+}
+
+func jsonCompareNumeric(a, b any) (handled, equal bool) {
+	aNum, aOK := jsonToFloat64(a)
+	bNum, bOK := jsonToFloat64(b)
+	if aOK && bOK {
+		return true, aNum == bNum
+	}
+	return false, false
+}
+
+func jsonCompareArrays(a, b any) (handled, equal bool) {
+	aArr, aIsArr := a.([]any)
+	bArr, bIsArr := b.([]any)
+	if !aIsArr || !bIsArr {
+		return false, false
+	}
+	if len(aArr) != len(bArr) {
+		return true, false
+	}
+	for i := range aArr {
+		if !jsonCompareValues(aArr[i], bArr[i]) {
+			return true, false
+		}
+	}
+	return true, true
+}
+
+func jsonCompareMaps(a, b any) (handled, equal bool) {
+	aMap, aIsMap := a.(map[string]any)
+	bMap, bIsMap := b.(map[string]any)
+	if !aIsMap || !bIsMap {
+		return false, false
+	}
+	if len(aMap) != len(bMap) {
+		return true, false
+	}
+	for k, v := range aMap {
+		if !jsonCompareValues(v, bMap[k]) {
+			return true, false
+		}
+	}
+	return true, true
+}
+
+func jsonToFloat64(v any) (float64, bool) {
+	switch val := v.(type) {
+	case float64:
+		return val, true
+	case float32:
+		return float64(val), true
+	case int:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	default:
+		return 0, false
+	}
+}

--- a/runtime/evals/handlers/json_path_test.go
+++ b/runtime/evals/handlers/json_path_test.go
@@ -1,0 +1,675 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+func TestJSONPathHandler_Type(t *testing.T) {
+	h := &JSONPathHandler{}
+	if h.Type() != "json_path" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestJSONPathHandler_Expected(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"name": "Alice", "age": 30}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "name",
+		"expected":   "Alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestJSONPathHandler_ExpectedMismatch(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"name": "Bob"}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "name",
+		"expected":   "Alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for mismatch")
+	}
+}
+
+func TestJSONPathHandler_NumericMin(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"score": 85}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "score",
+		"min":        50.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestJSONPathHandler_NumericMinFail(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"score": 30}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "score",
+		"min":        50.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail below min")
+	}
+}
+
+func TestJSONPathHandler_ArrayContains(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"items": ["a", "b", "c"]}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "items",
+		"contains":   []any{"a", "c"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestJSONPathHandler_MinResults(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"items": [1, 2, 3]}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression":  "items",
+		"min_results": 5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail below min_results")
+	}
+}
+
+func TestJSONPathHandler_InvalidJSON(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "not json",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "name",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for invalid JSON")
+	}
+}
+
+func TestJSONPathHandler_NoExpression(t *testing.T) {
+	h := &JSONPathHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no expression")
+	}
+}
+
+func TestJSONPathHandler_AllowWrapped(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "Here is the JSON:\n```json\n{\"name\": \"Alice\"}\n```\nDone.",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression":    "name",
+		"expected":      "Alice",
+		"allow_wrapped": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass with allow_wrapped: %s", result.Explanation)
+	}
+}
+
+func TestJSONPathHandler_ExtractJSON_Object(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `Here is the data: {"name": "Bob", "age": 25} and some trailing text.`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression":   "name",
+		"expected":     "Bob",
+		"extract_json": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass with extract_json: %s", result.Explanation)
+	}
+}
+
+func TestJSONPathHandler_ExtractJSON_Array(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `Results: [1, 2, 3] end`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression":   "[1]",
+		"expected":     float64(2),
+		"extract_json": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass extracting array: %s", result.Explanation)
+	}
+}
+
+func TestJSONPathHandler_ExtractJSON_NoJSON(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `No JSON content here at all`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression":   "name",
+		"extract_json": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for no extractable JSON")
+	}
+}
+
+func TestJSONPathHandler_JMESPathError(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"name": "Alice"}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "invalid..expression",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for invalid JMESPath")
+	}
+}
+
+func TestJSONPathHandler_JMESPathExpression(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"name": "Alice"}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"jmespath_expression": "name",
+		"expected":            "Alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass with jmespath_expression: %s", result.Explanation)
+	}
+}
+
+func TestJSONPathHandler_NumericMax(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"score": 95}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "score",
+		"max":        80.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail above max")
+	}
+}
+
+func TestJSONPathHandler_NumericRangeNonNumeric(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"value": "not a number"}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "value",
+		"min":        1.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for non-numeric range check")
+	}
+}
+
+func TestJSONPathHandler_MaxResults(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"items": [1, 2, 3, 4, 5]}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression":  "items",
+		"max_results": 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail above max_results")
+	}
+}
+
+func TestJSONPathHandler_ArrayCountNotArray(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"count": 5}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression":  "count",
+		"min_results": 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for non-array count check")
+	}
+}
+
+func TestJSONPathHandler_ContainsMissing(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"items": ["a", "b"]}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "items",
+		"contains":   []any{"a", "z"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing contains item")
+	}
+}
+
+func TestJSONPathHandler_ContainsNotArray(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"value": "hello"}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "value",
+		"contains":   []any{"hello"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for non-array contains check")
+	}
+}
+
+func TestJSONPathHandler_ContainsNotArrayParam(t *testing.T) {
+	h := &JSONPathHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: `{"items": [1, 2]}`,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expression": "items",
+		"contains":   "not an array",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for non-array contains param")
+	}
+}
+
+// --- extractBalancedJSON ---
+
+func TestExtractBalancedJSON_Object(t *testing.T) {
+	result := extractBalancedJSON(`{"key": "value"} trailing`, '{', '}')
+	if result != `{"key": "value"}` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractBalancedJSON_Nested(t *testing.T) {
+	result := extractBalancedJSON(`{"a": {"b": 1}} rest`, '{', '}')
+	if result != `{"a": {"b": 1}}` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractBalancedJSON_Array(t *testing.T) {
+	result := extractBalancedJSON(`[1, [2, 3]] rest`, '[', ']')
+	if result != `[1, [2, 3]]` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractBalancedJSON_Empty(t *testing.T) {
+	result := extractBalancedJSON("", '{', '}')
+	if result != "" {
+		t.Errorf("expected empty, got %q", result)
+	}
+}
+
+func TestExtractBalancedJSON_WrongStartChar(t *testing.T) {
+	result := extractBalancedJSON("abc", '{', '}')
+	if result != "" {
+		t.Errorf("expected empty, got %q", result)
+	}
+}
+
+func TestExtractBalancedJSON_UnbalancedBraces(t *testing.T) {
+	result := extractBalancedJSON(`{"key": "value"`, '{', '}')
+	if result != "" {
+		t.Errorf("expected empty for unbalanced, got %q", result)
+	}
+}
+
+func TestExtractBalancedJSON_StringsWithBraces(t *testing.T) {
+	result := extractBalancedJSON(`{"key": "val{ue}"}`, '{', '}')
+	if result != `{"key": "val{ue}"}` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractBalancedJSON_EscapedQuotes(t *testing.T) {
+	result := extractBalancedJSON(`{"key": "val\"ue"}`, '{', '}')
+	if result != `{"key": "val\"ue"}` {
+		t.Errorf("got %q", result)
+	}
+}
+
+// --- advanceJSONParser ---
+
+func TestAdvanceJSONParser_Escaped(t *testing.T) {
+	depth, inStr, esc := advanceJSONParser('"', '{', '}', 1, true, true)
+	if depth != 1 || !inStr || esc {
+		t.Errorf("escaped char should be skipped: depth=%d inStr=%v esc=%v", depth, inStr, esc)
+	}
+}
+
+func TestAdvanceJSONParser_Backslash(t *testing.T) {
+	depth, inStr, esc := advanceJSONParser('\\', '{', '}', 1, true, false)
+	if depth != 1 || !inStr || !esc {
+		t.Errorf("backslash should set escaped: depth=%d inStr=%v esc=%v", depth, inStr, esc)
+	}
+}
+
+func TestAdvanceJSONParser_Quote(t *testing.T) {
+	depth, inStr, esc := advanceJSONParser('"', '{', '}', 1, false, false)
+	if depth != 1 || !inStr || esc {
+		t.Errorf("quote should toggle inString: depth=%d inStr=%v esc=%v", depth, inStr, esc)
+	}
+}
+
+func TestAdvanceJSONParser_Open(t *testing.T) {
+	depth, inStr, esc := advanceJSONParser('{', '{', '}', 1, false, false)
+	if depth != 2 || inStr || esc {
+		t.Errorf("open should increment depth: depth=%d inStr=%v esc=%v", depth, inStr, esc)
+	}
+}
+
+func TestAdvanceJSONParser_Close(t *testing.T) {
+	depth, inStr, esc := advanceJSONParser('}', '{', '}', 2, false, false)
+	if depth != 1 || inStr || esc {
+		t.Errorf("close should decrement depth: depth=%d inStr=%v esc=%v", depth, inStr, esc)
+	}
+}
+
+func TestAdvanceJSONParser_DefaultChar(t *testing.T) {
+	depth, inStr, esc := advanceJSONParser('a', '{', '}', 1, false, false)
+	if depth != 1 || inStr || esc {
+		t.Errorf("default should not change state: depth=%d inStr=%v esc=%v", depth, inStr, esc)
+	}
+}
+
+// --- jsonCompareValues ---
+
+func TestJSONCompareValues_BothNil(t *testing.T) {
+	if !jsonCompareValues(nil, nil) {
+		t.Error("nil == nil should be true")
+	}
+}
+
+func TestJSONCompareValues_OneNil(t *testing.T) {
+	if jsonCompareValues(nil, "a") {
+		t.Error("nil != non-nil should be false")
+	}
+	if jsonCompareValues("a", nil) {
+		t.Error("non-nil != nil should be false")
+	}
+}
+
+func TestJSONCompareValues_Strings(t *testing.T) {
+	if !jsonCompareValues("hello", "hello") {
+		t.Error("same strings should be equal")
+	}
+	if jsonCompareValues("hello", "world") {
+		t.Error("different strings should not be equal")
+	}
+}
+
+func TestJSONCompareValues_NumericCrossType(t *testing.T) {
+	if !jsonCompareValues(float64(42), 42) {
+		t.Error("float64(42) should equal int(42)")
+	}
+	if !jsonCompareValues(int64(10), float64(10)) {
+		t.Error("int64(10) should equal float64(10)")
+	}
+}
+
+// --- jsonCompareArrays ---
+
+func TestJSONCompareArrays_Equal(t *testing.T) {
+	handled, equal := jsonCompareArrays([]any{1, "two"}, []any{1, "two"})
+	if !handled || !equal {
+		t.Errorf("expected handled=true equal=true, got %v %v", handled, equal)
+	}
+}
+
+func TestJSONCompareArrays_DifferentLength(t *testing.T) {
+	handled, equal := jsonCompareArrays([]any{1}, []any{1, 2})
+	if !handled || equal {
+		t.Errorf("expected handled=true equal=false, got %v %v", handled, equal)
+	}
+}
+
+func TestJSONCompareArrays_DifferentValues(t *testing.T) {
+	handled, equal := jsonCompareArrays([]any{1, 2}, []any{1, 3})
+	if !handled || equal {
+		t.Errorf("expected handled=true equal=false, got %v %v", handled, equal)
+	}
+}
+
+func TestJSONCompareArrays_NotArrays(t *testing.T) {
+	handled, _ := jsonCompareArrays("a", []any{1})
+	if handled {
+		t.Error("expected handled=false for non-array")
+	}
+}
+
+// --- jsonCompareMaps ---
+
+func TestJSONCompareMaps_Equal(t *testing.T) {
+	a := map[string]any{"k": "v"}
+	b := map[string]any{"k": "v"}
+	handled, equal := jsonCompareMaps(a, b)
+	if !handled || !equal {
+		t.Errorf("expected handled=true equal=true, got %v %v", handled, equal)
+	}
+}
+
+func TestJSONCompareMaps_DifferentLength(t *testing.T) {
+	a := map[string]any{"k": "v"}
+	b := map[string]any{"k": "v", "k2": "v2"}
+	handled, equal := jsonCompareMaps(a, b)
+	if !handled || equal {
+		t.Errorf("expected handled=true equal=false, got %v %v", handled, equal)
+	}
+}
+
+func TestJSONCompareMaps_DifferentValues(t *testing.T) {
+	a := map[string]any{"k": "v1"}
+	b := map[string]any{"k": "v2"}
+	handled, equal := jsonCompareMaps(a, b)
+	if !handled || equal {
+		t.Errorf("expected handled=true equal=false, got %v %v", handled, equal)
+	}
+}
+
+func TestJSONCompareMaps_NotMaps(t *testing.T) {
+	handled, _ := jsonCompareMaps("a", map[string]any{})
+	if handled {
+		t.Error("expected handled=false for non-map")
+	}
+}
+
+// --- jsonToFloat64 ---
+
+func TestJSONToFloat64_AllTypes(t *testing.T) {
+	tests := []struct {
+		input    any
+		expected float64
+		ok       bool
+	}{
+		{float64(1.5), 1.5, true},
+		{float32(2.5), 2.5, true},
+		{int(3), 3.0, true},
+		{int64(4), 4.0, true},
+		{"not a number", 0, false},
+		{true, 0, false},
+	}
+	for _, tt := range tests {
+		got, ok := jsonToFloat64(tt.input)
+		if ok != tt.ok {
+			t.Errorf("jsonToFloat64(%v): ok=%v, want %v", tt.input, ok, tt.ok)
+		}
+		if ok && got != tt.expected {
+			t.Errorf("jsonToFloat64(%v) = %v, want %v", tt.input, got, tt.expected)
+		}
+	}
+}
+
+// --- extractJSONFromContent ---
+
+func TestExtractJSONFromContent_WrappedCodeBlock(t *testing.T) {
+	content := "Some text\n```json\n{\"key\": \"value\"}\n```\nMore text"
+	result := extractJSONFromContent(content, true, false)
+	if result != `{"key": "value"}` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractJSONFromContent_ExtractObject(t *testing.T) {
+	content := `Leading text {"a": 1} trailing`
+	result := extractJSONFromContent(content, false, true)
+	if result != `{"a": 1}` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractJSONFromContent_ExtractArray(t *testing.T) {
+	content := `Leading text [1, 2, 3] trailing`
+	result := extractJSONFromContent(content, false, true)
+	if result != `[1, 2, 3]` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractJSONFromContent_NoMatch(t *testing.T) {
+	result := extractJSONFromContent("no json here", false, false)
+	if result != "" {
+		t.Errorf("expected empty, got %q", result)
+	}
+}
+
+func TestExtractJSONFromContent_BothFlags(t *testing.T) {
+	content := "Here is the JSON:\n```json\n{\"name\": \"Alice\"}\n```\nDone."
+	result := extractJSONFromContent(content, true, true)
+	if result != `{"name": "Alice"}` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractJSONFromContent_ExtractObjectNoArray(t *testing.T) {
+	// Test where content has only an object, no array bracket.
+	content := `Text before {"x": 1} text after`
+	result := extractJSONFromContent(content, false, true)
+	if result != `{"x": 1}` {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestExtractJSONFromContent_UnbalancedObjectFallsToArray(t *testing.T) {
+	// Object starts but never closes; array is present after.
+	content := `{unclosed but also [1, 2]`
+	result := extractJSONFromContent(content, false, true)
+	if result != `[1, 2]` {
+		t.Errorf("expected array extraction, got %q", result)
+	}
+}

--- a/runtime/evals/handlers/llm_judge_tool_calls.go
+++ b/runtime/evals/handlers/llm_judge_tool_calls.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// LLMJudgeToolCallsHandler evaluates tool call behavior via an LLM judge.
+// Instead of judging the assistant's text response, it feeds tool call data
+// (names, arguments, results) to the judge for evaluation.
+// Params:
+//   - tools []string (optional): filter to specific tool names
+//   - criteria string: what to evaluate
+//   - rubric string (optional): detailed scoring guidance
+//   - model string (optional): model override
+//   - min_score float64 (optional): minimum score to pass
+type LLMJudgeToolCallsHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *LLMJudgeToolCallsHandler) Type() string { return "llm_judge_tool_calls" }
+
+// Eval runs the LLM judge on formatted tool call data.
+func (h *LLMJudgeToolCallsHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	provider, extractErr := extractJudgeProvider(evalCtx)
+	if extractErr != nil {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: extractErr.Error(),
+		}, nil
+	}
+
+	filtered := filterToolCallViews(evalCtx.ToolCalls, extractStringSlice(params, "tools"))
+	if len(filtered) == 0 {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: true,
+			Explanation: "no matching tool calls to judge",
+			Skipped:     true,
+			SkipReason:  "no matching tool calls",
+		}, nil
+	}
+
+	opts := buildJudgeOpts(formatToolCallViews(filtered), params)
+	judgeResult, judgeErr := provider.Judge(ctx, opts)
+	if judgeErr != nil {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: fmt.Sprintf("judge error: %v", judgeErr),
+		}, nil
+	}
+
+	result := buildEvalResult(h.Type(), judgeResult, params)
+	result.Details = map[string]any{
+		"tool_calls_sent": len(filtered),
+	}
+	return result, nil
+}
+
+// filterToolCallViews converts records to views and optionally filters by tool names.
+func filterToolCallViews(records []evals.ToolCallRecord, toolNames []string) []toolCallView {
+	views := viewsFromRecords(records)
+	if len(toolNames) == 0 {
+		return views
+	}
+	toolSet := make(map[string]bool, len(toolNames))
+	for _, t := range toolNames {
+		toolSet[t] = true
+	}
+	var filtered []toolCallView
+	for _, v := range views {
+		if toolSet[v.Name] {
+			filtered = append(filtered, v)
+		}
+	}
+	return filtered
+}
+
+// formatToolCallViews formats tool call views as structured text for the judge prompt.
+func formatToolCallViews(calls []toolCallView) string {
+	var b strings.Builder
+	for i, tc := range calls {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "TOOL CALL %d (index %d):\n", i+1, tc.Index)
+		fmt.Fprintf(&b, "  Tool: %s\n", tc.Name)
+
+		argsJSON, err := json.Marshal(tc.Args)
+		if err != nil {
+			fmt.Fprintf(&b, "  Arguments: %v\n", tc.Args)
+		} else {
+			fmt.Fprintf(&b, "  Arguments: %s\n", string(argsJSON))
+		}
+
+		if tc.Result != "" {
+			fmt.Fprintf(&b, "  Result: %s\n", tc.Result)
+		} else {
+			b.WriteString("  Result: (none)\n")
+		}
+
+		if tc.Error != "" {
+			fmt.Fprintf(&b, "  Error: %s\n", tc.Error)
+		} else {
+			b.WriteString("  Error: (none)\n")
+		}
+	}
+	return b.String()
+}

--- a/runtime/evals/handlers/llm_judge_tool_calls_test.go
+++ b/runtime/evals/handlers/llm_judge_tool_calls_test.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+func TestLLMJudgeToolCallsHandler_Type(t *testing.T) {
+	h := &LLMJudgeToolCallsHandler{}
+	if h.Type() != "llm_judge_tool_calls" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestLLMJudgeToolCallsHandler_NoProvider(t *testing.T) {
+	h := &LLMJudgeToolCallsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", Result: "found"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"criteria": "check quality",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail when no judge provider")
+	}
+}
+
+func TestLLMJudgeToolCallsHandler_NoToolCalls(t *testing.T) {
+	h := &LLMJudgeToolCallsHandler{}
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{
+			"judge_provider": &mockJudgeProvider{
+				result: &JudgeResult{Score: 0.9, Passed: true},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"criteria": "check quality",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass (skip) with no tool calls: %s", result.Explanation)
+	}
+	if !result.Skipped {
+		t.Fatal("expected skipped=true")
+	}
+}
+
+func TestLLMJudgeToolCallsHandler_FilteredEmpty(t *testing.T) {
+	h := &LLMJudgeToolCallsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", Result: "found"},
+		},
+		Metadata: map[string]any{
+			"judge_provider": &mockJudgeProvider{
+				result: &JudgeResult{Score: 0.9, Passed: true},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"criteria": "check quality",
+		"tools":    []any{"nonexistent"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Skipped {
+		t.Fatal("expected skipped for no matching tools")
+	}
+}
+
+func TestLLMJudgeToolCallsHandler_WithProvider(t *testing.T) {
+	h := &LLMJudgeToolCallsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", Arguments: map[string]any{"q": "test"}, Result: "found 5 items"},
+		},
+		Metadata: map[string]any{
+			"judge_provider": &mockJudgeProvider{
+				result: &JudgeResult{Score: 0.85, Passed: true, Reasoning: "good tool usage"},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"criteria": "check tool usage quality",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestFormatToolCallViews(t *testing.T) {
+	views := []toolCallView{
+		{Name: "search", Args: map[string]any{"q": "test"}, Result: "found", Index: 0},
+		{Name: "fetch", Args: map[string]any{"id": "123"}, Error: "timeout", Index: 1},
+	}
+	text := formatToolCallViews(views)
+	if text == "" {
+		t.Fatal("expected non-empty output")
+	}
+	if !containsInsensitive(text, "search") || !containsInsensitive(text, "fetch") {
+		t.Fatal("expected both tool names in output")
+	}
+	if !containsInsensitive(text, "timeout") {
+		t.Fatal("expected error in output")
+	}
+}

--- a/runtime/evals/handlers/media_handlers_test.go
+++ b/runtime/evals/handlers/media_handlers_test.go
@@ -1,0 +1,512 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func intPtr(v int) *int       { return &v }
+func floatPtr(v float64) *float64 { return &v } //nolint:unparam // test helper
+
+func imageMsg(mime string, width, height *int) types.Message {
+	return types.Message{
+		Role: "assistant",
+		Parts: []types.ContentPart{
+			{
+				Type: types.ContentTypeImage,
+				Media: &types.MediaContent{
+					MIMEType: mime,
+					Width:    width,
+					Height:   height,
+				},
+			},
+		},
+	}
+}
+
+func audioMsg(mime string, duration *int) types.Message {
+	return types.Message{
+		Role: "assistant",
+		Parts: []types.ContentPart{
+			{
+				Type: types.ContentTypeAudio,
+				Media: &types.MediaContent{
+					MIMEType: mime,
+					Duration: duration,
+				},
+			},
+		},
+	}
+}
+
+func videoMsg(mime string, width, height *int, duration *int) types.Message {
+	return types.Message{
+		Role: "assistant",
+		Parts: []types.ContentPart{
+			{
+				Type: types.ContentTypeVideo,
+				Media: &types.MediaContent{
+					MIMEType: mime,
+					Width:    width,
+					Height:   height,
+					Duration: duration,
+				},
+			},
+		},
+	}
+}
+
+// --- ImageFormat ---
+
+func TestImageFormatHandler_Type(t *testing.T) {
+	h := &ImageFormatHandler{}
+	if h.Type() != "image_format" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestImageFormatHandler_Pass(t *testing.T) {
+	h := &ImageFormatHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{imageMsg("image/jpeg", intPtr(100), intPtr(100))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"formats": []any{"jpeg", "png"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestImageFormatHandler_InvalidFormat(t *testing.T) {
+	h := &ImageFormatHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{imageMsg("image/gif", intPtr(100), intPtr(100))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"formats": []any{"jpeg", "png"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for disallowed format")
+	}
+}
+
+func TestImageFormatHandler_NoImages(t *testing.T) {
+	h := &ImageFormatHandler{}
+	evalCtx := &evals.EvalContext{Messages: []types.Message{assistantMsg("hello")}}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"formats": []any{"jpeg"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for no images")
+	}
+}
+
+// --- ImageDimensions ---
+
+func TestImageDimensionsHandler_Type(t *testing.T) {
+	h := &ImageDimensionsHandler{}
+	if h.Type() != "image_dimensions" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestImageDimensionsHandler_Pass(t *testing.T) {
+	h := &ImageDimensionsHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{imageMsg("image/jpeg", intPtr(800), intPtr(600))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"min_width": 100, "max_width": 1000,
+		"min_height": 100, "max_height": 800,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestImageDimensionsHandler_ExactMatch(t *testing.T) {
+	h := &ImageDimensionsHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{imageMsg("image/jpeg", intPtr(800), intPtr(600))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"width": 800, "height": 600,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestImageDimensionsHandler_TooWide(t *testing.T) {
+	h := &ImageDimensionsHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{imageMsg("image/jpeg", intPtr(2000), intPtr(600))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"max_width": 1000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for exceeding max_width")
+	}
+}
+
+// --- AudioFormat ---
+
+func TestAudioFormatHandler_Type(t *testing.T) {
+	h := &AudioFormatHandler{}
+	if h.Type() != "audio_format" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestAudioFormatHandler_Pass(t *testing.T) {
+	h := &AudioFormatHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{audioMsg("audio/mpeg", intPtr(30))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"formats": []any{"mp3", "wav"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+// --- AudioDuration ---
+
+func TestAudioDurationHandler_Type(t *testing.T) {
+	h := &AudioDurationHandler{}
+	if h.Type() != "audio_duration" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestAudioDurationHandler_Pass(t *testing.T) {
+	h := &AudioDurationHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{audioMsg("audio/mpeg", intPtr(30))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"min_seconds": 10.0,
+		"max_seconds": 60.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestAudioDurationHandler_TooShort(t *testing.T) {
+	h := &AudioDurationHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{audioMsg("audio/mpeg", intPtr(5))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"min_seconds": 10.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for too short")
+	}
+}
+
+// --- VideoDuration ---
+
+func TestVideoDurationHandler_Type(t *testing.T) {
+	h := &VideoDurationHandler{}
+	if h.Type() != "video_duration" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestVideoDurationHandler_Pass(t *testing.T) {
+	h := &VideoDurationHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(1920), intPtr(1080), intPtr(60))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"min_seconds": 30.0,
+		"max_seconds": 120.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+// --- VideoResolution ---
+
+func TestVideoResolutionHandler_Type(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	if h.Type() != "video_resolution" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestVideoResolutionHandler_PresetMatch(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(1920), intPtr(1080), intPtr(60))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"presets": []any{"1080p", "720p"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestVideoResolutionHandler_PresetNoMatch(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(1920), intPtr(1080), intPtr(60))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"presets": []any{"720p"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for preset mismatch")
+	}
+}
+
+func TestVideoResolutionHandler_DimensionRange(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(1920), intPtr(1080), nil)},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"min_width": 1280, "min_height": 720,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestVideoResolutionHandler_NoVideos(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{assistantMsg("hello")},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"presets": []any{"1080p"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for no videos")
+	}
+}
+
+func TestVideoResolutionHandler_MissingMetadata(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", nil, nil, intPtr(60))},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"presets": []any{"1080p"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing width/height metadata")
+	}
+}
+
+func TestVideoResolutionHandler_AllPresets(t *testing.T) {
+	tests := []struct {
+		preset string
+		height int
+	}{
+		{"480p", 480},
+		{"sd", 480},
+		{"720p", 720},
+		{"hd", 720},
+		{"1080p", 1080},
+		{"fhd", 1080},
+		{"full_hd", 1080},
+		{"1440p", 1440},
+		{"2k", 1440},
+		{"qhd", 1440},
+		{"2160p", 2160},
+		{"4k", 2160},
+		{"uhd", 2160},
+		{"4320p", 4320},
+		{"8k", 4320},
+	}
+
+	h := &VideoResolutionHandler{}
+	for _, tt := range tests {
+		evalCtx := &evals.EvalContext{
+			Messages: []types.Message{videoMsg("video/mp4", intPtr(1920), intPtr(tt.height), nil)},
+		}
+		result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+			"presets": []any{tt.preset},
+		})
+		if err != nil {
+			t.Fatalf("preset %q: %v", tt.preset, err)
+		}
+		if !result.Passed {
+			t.Errorf("preset %q with height %d should pass: %s", tt.preset, tt.height, result.Explanation)
+		}
+	}
+}
+
+func TestVideoResolutionHandler_UnknownPreset(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(1920), intPtr(1080), nil)},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"presets": []any{"unknown_preset"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for unknown preset")
+	}
+}
+
+func TestVideoResolutionHandler_WidthRange(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(800), intPtr(600), nil)},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"min_width": 1280,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for width below min_width")
+	}
+}
+
+func TestVideoResolutionHandler_MaxWidth(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(3840), intPtr(2160), nil)},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"max_width": 1920,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for width above max_width")
+	}
+}
+
+func TestVideoResolutionHandler_HeightRange(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(1920), intPtr(400), nil)},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"min_height": 720,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for height below min_height")
+	}
+}
+
+func TestVideoResolutionHandler_MaxHeight(t *testing.T) {
+	h := &VideoResolutionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{videoMsg("video/mp4", intPtr(1920), intPtr(1440), nil)},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"max_height": 1080,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for height above max_height")
+	}
+}
+
+func TestExtractFormatFromMIMEType(t *testing.T) {
+	tests := []struct {
+		mime, expected string
+	}{
+		{"image/jpeg", "jpeg"},
+		{"image/png", "png"},
+		{"audio/mpeg", "mp3"},
+		{"video/mp4", "mp4"},
+		{"invalid", "invalid"},
+	}
+	for _, tt := range tests {
+		got := extractFormatFromMIMEType(tt.mime)
+		if got != tt.expected {
+			t.Errorf("extractFormatFromMIMEType(%q) = %q, want %q", tt.mime, got, tt.expected)
+		}
+	}
+}

--- a/runtime/evals/handlers/media_helpers.go
+++ b/runtime/evals/handlers/media_helpers.go
@@ -1,0 +1,215 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Media error messages.
+const (
+	errNoImagesFound     = "no images found in messages"
+	errNoAudioFound      = "no audio found in messages"
+	errNoVideoFound      = "no video found in messages"
+	errAtLeastOneFormat  = "at least one format must be specified"
+	errMissingDimensions = "missing width/height metadata"
+	errMissingDuration   = "missing duration metadata"
+)
+
+// Duration violation templates.
+const (
+	msgDurationBelowMin = "duration %.1fs below minimum %.1fs"
+	msgDurationAboveMax = "duration %.1fs exceeds maximum %.1fs"
+)
+
+// Dimension violation templates.
+const (
+	msgWidthBelowMin  = "width %d below minimum %d"
+	msgWidthAboveMax  = "width %d exceeds maximum %d"
+	msgHeightBelowMin = "height %d below minimum %d"
+	msgHeightAboveMax = "height %d exceeds maximum %d"
+)
+
+// extractMediaParts finds media content parts of the given type from assistant messages.
+func extractMediaParts(messages []types.Message, contentType string) []types.ContentPart {
+	var parts []types.ContentPart
+	for i := range messages {
+		if messages[i].Role != roleAssistant {
+			continue
+		}
+		for _, part := range messages[i].Parts {
+			if part.Type == contentType && part.Media != nil {
+				parts = append(parts, part)
+			}
+		}
+	}
+	return parts
+}
+
+// mimeTypeParts is the expected number of parts when splitting a MIME type by "/".
+const mimeTypeParts = 2
+
+// extractFormatFromMIMEType extracts the format from a MIME type string.
+func extractFormatFromMIMEType(mimeType string) string {
+	parts := strings.Split(mimeType, "/")
+	if len(parts) != mimeTypeParts {
+		return mimeType
+	}
+	format := parts[1]
+	if format == "mpeg" && strings.HasPrefix(mimeType, "audio/") {
+		return "mp3"
+	}
+	return format
+}
+
+// isAllowedFormat checks if a format is in the allowed list (case-insensitive).
+func isAllowedFormat(format string, allowed []string) bool {
+	for _, a := range allowed {
+		if strings.EqualFold(a, format) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkDuration checks duration constraints on a media content.
+func checkDuration(media *types.MediaContent, minSeconds, maxSeconds *float64) []string {
+	if media.Duration == nil {
+		return []string{errMissingDuration}
+	}
+	duration := float64(*media.Duration)
+	var violations []string
+	if minSeconds != nil && duration < *minSeconds {
+		violations = append(violations, fmt.Sprintf(msgDurationBelowMin, duration, *minSeconds))
+	}
+	if maxSeconds != nil && duration > *maxSeconds {
+		violations = append(violations, fmt.Sprintf(msgDurationAboveMax, duration, *maxSeconds))
+	}
+	return violations
+}
+
+// checkWidthRange checks width constraints.
+func checkWidthRange(width int, minWidth, maxWidth *int) []string {
+	var violations []string
+	if minWidth != nil && width < *minWidth {
+		violations = append(violations, fmt.Sprintf(msgWidthBelowMin, width, *minWidth))
+	}
+	if maxWidth != nil && width > *maxWidth {
+		violations = append(violations, fmt.Sprintf(msgWidthAboveMax, width, *maxWidth))
+	}
+	return violations
+}
+
+// checkHeightRange checks height constraints.
+func checkHeightRange(height int, minHeight, maxHeight *int) []string {
+	var violations []string
+	if minHeight != nil && height < *minHeight {
+		violations = append(violations, fmt.Sprintf(msgHeightBelowMin, height, *minHeight))
+	}
+	if maxHeight != nil && height > *maxHeight {
+		violations = append(violations, fmt.Sprintf(msgHeightAboveMax, height, *maxHeight))
+	}
+	return violations
+}
+
+// evalMediaDuration is a shared implementation for audio/video duration handlers.
+func evalMediaDuration(
+	typeName string,
+	messages []types.Message,
+	contentType string,
+	errNoMedia string,
+	countKey string,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	minSeconds := extractFloat64Ptr(params, "min_seconds")
+	maxSeconds := extractFloat64Ptr(params, "max_seconds")
+
+	parts := extractMediaParts(messages, contentType)
+	if len(parts) == 0 {
+		return &evals.EvalResult{
+			Type: typeName, Passed: false,
+			Explanation: errNoMedia,
+		}, nil
+	}
+
+	var violations []string
+	var foundDurations []float64
+	for _, part := range parts {
+		if part.Media.Duration != nil {
+			foundDurations = append(foundDurations, float64(*part.Media.Duration))
+		}
+		violations = append(violations, checkDuration(part.Media, minSeconds, maxSeconds)...)
+	}
+
+	passed := len(violations) == 0
+	explanation := fmt.Sprintf("all %s duration within range", contentType)
+	if !passed {
+		explanation = fmt.Sprintf("some %s duration violations", contentType)
+	}
+
+	return &evals.EvalResult{
+		Type:        typeName,
+		Passed:      passed,
+		Explanation: explanation,
+		Details: map[string]any{
+			countKey:          len(parts),
+			"found_durations": foundDurations,
+			"violations":      violations,
+		},
+	}, nil
+}
+
+// evalMediaFormats is a shared implementation for image/audio format handlers.
+func evalMediaFormats(
+	typeName string,
+	messages []types.Message,
+	contentType string,
+	errNoMedia string,
+	passMsg string,
+	failMsg string,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	formats := extractStringSlice(params, "formats")
+	if len(formats) == 0 {
+		return &evals.EvalResult{
+			Type: typeName, Passed: false,
+			Explanation: errAtLeastOneFormat,
+		}, nil
+	}
+
+	parts := extractMediaParts(messages, contentType)
+	if len(parts) == 0 {
+		return &evals.EvalResult{
+			Type: typeName, Passed: false,
+			Explanation: errNoMedia,
+		}, nil
+	}
+
+	var foundFormats, invalidFormats []string
+	for _, part := range parts {
+		format := extractFormatFromMIMEType(part.Media.MIMEType)
+		foundFormats = append(foundFormats, format)
+		if !isAllowedFormat(format, formats) {
+			invalidFormats = append(invalidFormats, format)
+		}
+	}
+
+	passed := len(invalidFormats) == 0
+	explanation := passMsg
+	if !passed {
+		explanation = failMsg
+	}
+
+	return &evals.EvalResult{
+		Type:        typeName,
+		Passed:      passed,
+		Explanation: explanation,
+		Details: map[string]any{
+			"found_formats":   foundFormats,
+			"invalid_formats": invalidFormats,
+			"allowed_formats": formats,
+		},
+	}, nil
+}

--- a/runtime/evals/handlers/no_tool_errors.go
+++ b/runtime/evals/handlers/no_tool_errors.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// NoToolErrorsHandler checks that no tool calls returned errors.
+// Params: tools []string (optional) — if set, only checks calls matching those tool names.
+type NoToolErrorsHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *NoToolErrorsHandler) Type() string { return "no_tool_errors" }
+
+// Eval checks for tool errors in the eval context's tool calls.
+func (h *NoToolErrorsHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	views := viewsFromRecords(evalCtx.ToolCalls)
+	tools := extractStringSlice(params, "tools")
+
+	errors := coreNoToolErrors(views, tools)
+
+	if len(errors) > 0 {
+		names := make([]string, len(errors))
+		for i, e := range errors {
+			names[i] = fmt.Sprintf("%s: %s", e["tool"], e["error"])
+		}
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("tool errors found: %s", strings.Join(names, "; ")),
+			Details:     map[string]any{"errors": errors},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: "no tool errors found",
+	}, nil
+}

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -23,7 +23,39 @@ func init() {
 	evals.RegisterDefault(&ToolArgsSessionHandler{})
 	evals.RegisterDefault(&ToolArgsExcludedSessionHandler{})
 
+	// Tool call handlers (Batch 1)
+	evals.RegisterDefault(&NoToolErrorsHandler{})
+	evals.RegisterDefault(&ToolCallCountHandler{})
+	evals.RegisterDefault(&ToolResultIncludesHandler{})
+	evals.RegisterDefault(&ToolResultMatchesHandler{})
+	evals.RegisterDefault(&ToolCallSequenceHandler{})
+	evals.RegisterDefault(&ToolCallChainHandler{})
+	evals.RegisterDefault(&ToolCallsWithArgsHandler{})
+
+	// JSON path, agent, and guardrail handlers (Batch 2)
+	evals.RegisterDefault(&JSONPathHandler{})
+	evals.RegisterDefault(&AgentInvokedHandler{})
+	evals.RegisterDefault(&AgentNotInvokedHandler{})
+	evals.RegisterDefault(&AgentResponseContainsHandler{})
+	evals.RegisterDefault(&GuardrailTriggeredHandler{})
+
+	// Workflow and skill handlers (Batch 3)
+	evals.RegisterDefault(&WorkflowCompleteHandler{})
+	evals.RegisterDefault(&WorkflowStateIsHandler{})
+	evals.RegisterDefault(&WorkflowTransitionedToHandler{})
+	evals.RegisterDefault(&SkillActivatedHandler{})
+	evals.RegisterDefault(&SkillNotActivatedHandler{})
+
+	// Media handlers (Batch 4)
+	evals.RegisterDefault(&ImageFormatHandler{})
+	evals.RegisterDefault(&ImageDimensionsHandler{})
+	evals.RegisterDefault(&AudioFormatHandler{})
+	evals.RegisterDefault(&AudioDurationHandler{})
+	evals.RegisterDefault(&VideoDurationHandler{})
+	evals.RegisterDefault(&VideoResolutionHandler{})
+
 	// LLM judge handlers
 	evals.RegisterDefault(&LLMJudgeHandler{})
 	evals.RegisterDefault(&LLMJudgeSessionHandler{})
+	evals.RegisterDefault(&LLMJudgeToolCallsHandler{})
 }

--- a/runtime/evals/handlers/skill_activated.go
+++ b/runtime/evals/handlers/skill_activated.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+const skillActivateToolName = "skill__activate"
+
+// SkillActivatedHandler checks that specific skills were activated.
+// Scans evalCtx.ToolCalls for "skill__activate" calls and extracts the "name" argument.
+// Params: skill_names []string, min_calls int (optional, default 1).
+type SkillActivatedHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *SkillActivatedHandler) Type() string { return "skill_activated" }
+
+// Eval checks that required skills were activated at least the minimum number of times.
+func (h *SkillActivatedHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	required := extractStringSlice(params, "skill_names")
+	minCalls := extractInt(params, "min_calls", 1)
+
+	counts := countSkillCalls(evalCtx.ToolCalls)
+
+	var missing []string
+	for _, name := range required {
+		if counts[name] < minCalls {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("missing skill activations: %s", strings.Join(missing, ", ")),
+			Details:     map[string]any{"counts": counts, "min_calls": minCalls},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type: h.Type(), Passed: true,
+		Explanation: "all required skills were activated",
+		Details:     map[string]any{"counts": counts},
+	}, nil
+}
+
+// countSkillCalls counts skill activations from skill__activate tool calls.
+func countSkillCalls(toolCalls []evals.ToolCallRecord) map[string]int {
+	counts := make(map[string]int)
+	for _, tc := range toolCalls {
+		if tc.ToolName != skillActivateToolName {
+			continue
+		}
+		if tc.Arguments == nil {
+			continue
+		}
+		if name, ok := tc.Arguments["name"].(string); ok && name != "" {
+			counts[name]++
+		}
+	}
+	return counts
+}

--- a/runtime/evals/handlers/skill_handlers_test.go
+++ b/runtime/evals/handlers/skill_handlers_test.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// --- SkillActivated ---
+
+func TestSkillActivatedHandler_Type(t *testing.T) {
+	h := &SkillActivatedHandler{}
+	if h.Type() != "skill_activated" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestSkillActivatedHandler_Pass(t *testing.T) {
+	h := &SkillActivatedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "skill__activate", Arguments: map[string]any{"name": "billing"}},
+			{ToolName: "skill__activate", Arguments: map[string]any{"name": "shipping"}},
+			{ToolName: "other_tool", Arguments: map[string]any{}},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"skill_names": []any{"billing", "shipping"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestSkillActivatedHandler_Missing(t *testing.T) {
+	h := &SkillActivatedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "skill__activate", Arguments: map[string]any{"name": "billing"}},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"skill_names": []any{"billing", "shipping"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing skill")
+	}
+}
+
+func TestSkillActivatedHandler_MinCalls(t *testing.T) {
+	h := &SkillActivatedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "skill__activate", Arguments: map[string]any{"name": "billing"}},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"skill_names": []any{"billing"},
+		"min_calls":   3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for insufficient calls")
+	}
+}
+
+// --- SkillNotActivated ---
+
+func TestSkillNotActivatedHandler_Type(t *testing.T) {
+	h := &SkillNotActivatedHandler{}
+	if h.Type() != "skill_not_activated" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestSkillNotActivatedHandler_Pass(t *testing.T) {
+	h := &SkillNotActivatedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "skill__activate", Arguments: map[string]any{"name": "billing"}},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"skill_names": []any{"dangerous_skill"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestSkillNotActivatedHandler_Fail(t *testing.T) {
+	h := &SkillNotActivatedHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "skill__activate", Arguments: map[string]any{"name": "dangerous_skill"}},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"skill_names": []any{"dangerous_skill"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for forbidden skill")
+	}
+	if len(result.Violations) == 0 {
+		t.Fatal("expected violations")
+	}
+}

--- a/runtime/evals/handlers/skill_not_activated.go
+++ b/runtime/evals/handlers/skill_not_activated.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// SkillNotActivatedHandler checks that specific skills were NOT activated.
+// Params: skill_names []string.
+type SkillNotActivatedHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *SkillNotActivatedHandler) Type() string { return "skill_not_activated" }
+
+// Eval ensures forbidden skills were never activated.
+func (h *SkillNotActivatedHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	forbidden := extractStringSlice(params, "skill_names")
+	forbiddenSet := make(map[string]struct{}, len(forbidden))
+	for _, n := range forbidden {
+		forbiddenSet[n] = struct{}{}
+	}
+
+	var violations []evals.EvalViolation
+	for _, tc := range evalCtx.ToolCalls {
+		if tc.ToolName != skillActivateToolName {
+			continue
+		}
+		if tc.Arguments == nil {
+			continue
+		}
+		skillName, _ := tc.Arguments["name"].(string)
+		if _, bad := forbiddenSet[skillName]; bad {
+			violations = append(violations, evals.EvalViolation{
+				TurnIndex:   tc.TurnIndex,
+				Description: fmt.Sprintf("forbidden skill %q was activated", skillName),
+				Evidence:    map[string]any{"skill": skillName},
+			})
+		}
+	}
+
+	if len(violations) > 0 {
+		names := make([]string, len(violations))
+		for i, v := range violations {
+			names[i] = v.Evidence["skill"].(string)
+		}
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("forbidden skills activated: %s", strings.Join(names, ", ")),
+			Violations:  violations,
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type: h.Type(), Passed: true,
+		Explanation: "no forbidden skills were activated",
+	}, nil
+}

--- a/runtime/evals/handlers/tool_call_chain.go
+++ b/runtime/evals/handlers/tool_call_chain.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolCallChainHandler checks a dependency chain of tool calls with per-step constraints.
+// Params: steps []map — each with tool, result_includes, result_matches, args_match, no_error.
+type ToolCallChainHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolCallChainHandler) Type() string { return "tool_call_chain" }
+
+// Eval checks that the chain of tool calls satisfies all step constraints in order.
+func (h *ToolCallChainHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	steps := parseChainSteps(params)
+
+	if len(steps) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "empty chain always passes",
+		}, nil
+	}
+
+	views := viewsFromRecords(evalCtx.ToolCalls)
+	completed, failure := coreToolCallChain(views, steps)
+
+	if failure != nil {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("%v", failure["message"]),
+			Details:     failure,
+		}, nil
+	}
+
+	if completed < len(steps) {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"chain incomplete: satisfied %d/%d steps, missing %q",
+				completed, len(steps), steps[completed].tool,
+			),
+			Details: map[string]any{
+				"completed_steps": completed,
+				"total_steps":     len(steps),
+			},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: "chain fully satisfied",
+		Details: map[string]any{
+			"completed_steps": len(steps),
+		},
+	}, nil
+}

--- a/runtime/evals/handlers/tool_call_count.go
+++ b/runtime/evals/handlers/tool_call_count.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolCallCountHandler checks the count of tool calls within bounds.
+// Params: tool string (optional), min int (optional), max int (optional).
+type ToolCallCountHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolCallCountHandler) Type() string { return "tool_call_count" }
+
+// Eval counts matching tool calls and checks min/max bounds.
+func (h *ToolCallCountHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	views := viewsFromRecords(evalCtx.ToolCalls)
+	tool, _ := params["tool"].(string)
+	minCount := extractInt(params, "min", countNotSet)
+	maxCount := extractInt(params, "max", countNotSet)
+
+	count, violation := coreToolCallCount(views, tool, minCount, maxCount)
+
+	if violation != "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: violation,
+			Details:     map[string]any{"tool": tool, "count": count},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: fmt.Sprintf("tool call count %d is within bounds", count),
+		Details:     map[string]any{"tool": tool, "count": count},
+	}, nil
+}

--- a/runtime/evals/handlers/tool_call_handlers_test.go
+++ b/runtime/evals/handlers/tool_call_handlers_test.go
@@ -1,0 +1,754 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func toolCall(name string, args map[string]any, result any, errStr string) types.ToolCallRecord {
+	return types.ToolCallRecord{
+		ToolName:  name,
+		Arguments: args,
+		Result:    result,
+		Error:     errStr,
+	}
+}
+
+// --- NoToolErrors ---
+
+func TestNoToolErrorsHandler_Type(t *testing.T) {
+	h := &NoToolErrorsHandler{}
+	if h.Type() != "no_tool_errors" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestNoToolErrorsHandler_Pass(t *testing.T) {
+	h := &NoToolErrorsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "result", ""),
+			toolCall("fetch", nil, "data", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestNoToolErrorsHandler_Fail(t *testing.T) {
+	h := &NoToolErrorsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "result", ""),
+			toolCall("fetch", nil, nil, "timeout error"),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for tool error")
+	}
+}
+
+func TestNoToolErrorsHandler_ScopedTools(t *testing.T) {
+	h := &NoToolErrorsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, nil, "error"),
+			toolCall("fetch", nil, "ok", ""),
+		},
+	}
+
+	// Only check "fetch" — should pass
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tools": []any{"fetch"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatal("expected pass when scoped to fetch")
+	}
+}
+
+// --- ToolCallCount ---
+
+func TestToolCallCountHandler_Type(t *testing.T) {
+	h := &ToolCallCountHandler{}
+	if h.Type() != "tool_call_count" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolCallCountHandler_Pass(t *testing.T) {
+	h := &ToolCallCountHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "r", ""),
+			toolCall("search", nil, "r", ""),
+			toolCall("fetch", nil, "r", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool": "search", "min": 1, "max": 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolCallCountHandler_BelowMin(t *testing.T) {
+	h := &ToolCallCountHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "r", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool": "search", "min": 5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail below min")
+	}
+}
+
+func TestToolCallCountHandler_AboveMax(t *testing.T) {
+	h := &ToolCallCountHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "r", ""),
+			toolCall("search", nil, "r", ""),
+			toolCall("search", nil, "r", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool": "search", "max": 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail above max")
+	}
+}
+
+// --- ToolResultIncludes ---
+
+func TestToolResultIncludesHandler_Type(t *testing.T) {
+	h := &ToolResultIncludesHandler{}
+	if h.Type() != "tool_result_includes" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolResultIncludesHandler_Pass(t *testing.T) {
+	h := &ToolResultIncludesHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "Found 3 results for query", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":     "search",
+		"patterns": []any{"found", "results"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolResultIncludesHandler_MissingPattern(t *testing.T) {
+	h := &ToolResultIncludesHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "no matches", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":     "search",
+		"patterns": []any{"results"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing pattern")
+	}
+}
+
+func TestToolResultIncludesHandler_NoPatterns(t *testing.T) {
+	h := &ToolResultIncludesHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no patterns")
+	}
+}
+
+// --- ToolResultMatches ---
+
+func TestToolResultMatchesHandler_Type(t *testing.T) {
+	h := &ToolResultMatchesHandler{}
+	if h.Type() != "tool_result_matches" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolResultMatchesHandler_Pass(t *testing.T) {
+	h := &ToolResultMatchesHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "Order #12345 confirmed", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":    "search",
+		"pattern": `#\d{5}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolResultMatchesHandler_NoMatch(t *testing.T) {
+	h := &ToolResultMatchesHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "no order", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":    "search",
+		"pattern": `#\d{5}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for no match")
+	}
+}
+
+func TestToolResultMatchesHandler_InvalidRegex(t *testing.T) {
+	h := &ToolResultMatchesHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
+		"pattern": `[invalid`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for invalid regex")
+	}
+}
+
+func TestToolResultMatchesHandler_NoPattern(t *testing.T) {
+	h := &ToolResultMatchesHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no pattern")
+	}
+}
+
+// --- ToolCallSequence ---
+
+func TestToolCallSequenceHandler_Type(t *testing.T) {
+	h := &ToolCallSequenceHandler{}
+	if h.Type() != "tool_call_sequence" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolCallSequenceHandler_Pass(t *testing.T) {
+	h := &ToolCallSequenceHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "", ""),
+			toolCall("fetch", nil, "", ""),
+			toolCall("process", nil, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"sequence": []any{"search", "process"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolCallSequenceHandler_Fail(t *testing.T) {
+	h := &ToolCallSequenceHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("process", nil, "", ""),
+			toolCall("search", nil, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"sequence": []any{"search", "process"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "process" appears before "search", so subsequence "search" → "process" only matches "search"
+	// but then "process" has already passed, so it can't match. Actually wait — subsequence check:
+	// we look for "search" first. tc[0] is "process" → no match. tc[1] is "search" → match (1/2).
+	// Then we look for "process" — no more calls. So matched=1 < 2, fail.
+	if result.Passed {
+		t.Fatal("expected fail for wrong order")
+	}
+}
+
+func TestToolCallSequenceHandler_EmptySequence(t *testing.T) {
+	h := &ToolCallSequenceHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatal("empty sequence should pass")
+	}
+}
+
+// --- ToolCallChain ---
+
+func TestToolCallChainHandler_Type(t *testing.T) {
+	h := &ToolCallChainHandler{}
+	if h.Type() != "tool_call_chain" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolCallChainHandler_Pass(t *testing.T) {
+	h := &ToolCallChainHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{"q": "test"}, "found items", ""),
+			toolCall("fetch", map[string]any{"id": "123"}, "item details", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"steps": []any{
+			map[string]any{"tool": "search", "result_includes": []any{"found"}},
+			map[string]any{"tool": "fetch", "no_error": true},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolCallChainHandler_IncompleteChain(t *testing.T) {
+	h := &ToolCallChainHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "found", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"steps": []any{
+			map[string]any{"tool": "search"},
+			map[string]any{"tool": "fetch"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for incomplete chain")
+	}
+}
+
+func TestToolCallChainHandler_StepViolation(t *testing.T) {
+	h := &ToolCallChainHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "nothing", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"steps": []any{
+			map[string]any{"tool": "search", "result_includes": []any{"found"}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for step constraint violation")
+	}
+}
+
+func TestToolCallChainHandler_EmptySteps(t *testing.T) {
+	h := &ToolCallChainHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatal("empty chain should pass")
+	}
+}
+
+// --- ToolCallsWithArgs ---
+
+func TestToolCallsWithArgsHandler_Type(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	if h.Type() != "tool_calls_with_args" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolCallsWithArgsHandler_ExactArgs(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{"query": "test", "limit": "10"}, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":     "search",
+		"expected_args": map[string]any{"query": "test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolCallsWithArgsHandler_ArgMismatch(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{"query": "wrong"}, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":     "search",
+		"expected_args": map[string]any{"query": "test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for arg mismatch")
+	}
+}
+
+func TestToolCallsWithArgsHandler_PatternArgs(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{"query": "hello world"}, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":  "search",
+		"args_match": map[string]any{"query": "hello.*"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolCallsWithArgsHandler_ToolNotCalled(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("other", nil, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name": "search",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail when tool not called")
+	}
+}
+
+func TestToolCallsWithArgsHandler_ResultConstraints(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "found 5 items", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":       "search",
+		"result_includes": []any{"found"},
+		"no_error":        true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolCallsWithArgsHandler_ErrorViolation(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "", "connection refused"),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name": "search",
+		"no_error":  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for tool error")
+	}
+}
+
+// --- validatePatternArgs additional coverage ---
+
+func TestToolCallsWithArgsHandler_PatternMissing(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{}, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":  "search",
+		"args_match": map[string]any{"query": "hello.*"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing argument in pattern match")
+	}
+}
+
+func TestToolCallsWithArgsHandler_PatternInvalid(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{"query": "test"}, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":  "search",
+		"args_match": map[string]any{"query": "[invalid"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for invalid pattern")
+	}
+}
+
+func TestToolCallsWithArgsHandler_PatternMismatch(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{"query": "goodbye"}, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":  "search",
+		"args_match": map[string]any{"query": "^hello"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for pattern mismatch")
+	}
+}
+
+// --- validateExactArgs additional coverage ---
+
+func TestToolCallsWithArgsHandler_ExactArgMissing(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{}, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":     "search",
+		"expected_args": map[string]any{"query": "test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing argument")
+	}
+}
+
+func TestToolCallsWithArgsHandler_ExactArgNilExpected(t *testing.T) {
+	// When expected value is nil, only existence matters.
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{"query": "anything"}, "", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":     "search",
+		"expected_args": map[string]any{"query": nil},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass when expected is nil (existence check): %s", result.Explanation)
+	}
+}
+
+// --- validateResultConstraints additional coverage ---
+
+func TestToolCallsWithArgsHandler_ResultIncludesMissing(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "some result", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":       "search",
+		"result_includes": []any{"missing_pattern"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing result pattern")
+	}
+}
+
+func TestToolCallsWithArgsHandler_ResultMatchesInvalid(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "result", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":      "search",
+		"result_matches": "[invalid",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for invalid result_matches regex")
+	}
+}
+
+func TestToolCallsWithArgsHandler_ResultMatchesMismatch(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", nil, "some result", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool_name":      "search",
+		"result_matches": "^no_match$",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for result_matches mismatch")
+	}
+}
+
+func TestToolCallsWithArgsHandler_NoToolNameMatchesAll(t *testing.T) {
+	h := &ToolCallsWithArgsHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			toolCall("search", map[string]any{"q": "test"}, "ok", ""),
+			toolCall("fetch", map[string]any{"q": "test"}, "ok", ""),
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"expected_args": map[string]any{"q": "test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass matching all tools: %s", result.Explanation)
+	}
+}

--- a/runtime/evals/handlers/tool_call_sequence.go
+++ b/runtime/evals/handlers/tool_call_sequence.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolCallSequenceHandler checks that tool calls appear in a specified subsequence order.
+// Params: sequence []string — the expected tool names in order.
+type ToolCallSequenceHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolCallSequenceHandler) Type() string { return "tool_call_sequence" }
+
+// Eval checks subsequence ordering of tool calls.
+func (h *ToolCallSequenceHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	views := viewsFromRecords(evalCtx.ToolCalls)
+	sequence := extractStringSlice(params, "sequence")
+
+	if len(sequence) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "empty sequence always passes",
+		}, nil
+	}
+
+	matched, actualTools := coreToolCallSequence(views, sequence)
+
+	if matched < len(sequence) {
+		return &evals.EvalResult{
+			Type:   h.Type(),
+			Passed: false,
+			Explanation: fmt.Sprintf(
+				"sequence incomplete: matched %d/%d, missing %q",
+				matched, len(sequence), sequence[matched],
+			),
+			Details: map[string]any{
+				"matched_steps": matched,
+				"total_steps":   len(sequence),
+				"actual_tools":  actualTools,
+			},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      true,
+		Explanation: fmt.Sprintf("sequence [%s] fully matched", strings.Join(sequence, " → ")),
+		Details: map[string]any{
+			"matched_steps": matched,
+			"actual_tools":  actualTools,
+		},
+	}, nil
+}

--- a/runtime/evals/handlers/tool_call_views.go
+++ b/runtime/evals/handlers/tool_call_views.go
@@ -1,0 +1,288 @@
+package handlers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// countNotSet is the sentinel value indicating a min/max count was not specified.
+const countNotSet = -1
+
+// toolCallView is a normalized view of a tool call for shared validation logic.
+type toolCallView struct {
+	Name   string
+	Args   map[string]any
+	Result string
+	Error  string
+	Index  int
+}
+
+// viewsFromRecords converts ToolCallRecords to normalized views.
+func viewsFromRecords(records []evals.ToolCallRecord) []toolCallView {
+	views := make([]toolCallView, len(records))
+	for i, r := range records {
+		views[i] = toolCallView{
+			Name:  r.ToolName,
+			Args:  r.Arguments,
+			Error: r.Error,
+			Index: r.TurnIndex,
+		}
+		if r.Result != nil {
+			views[i].Result = fmt.Sprintf("%v", r.Result)
+		}
+	}
+	return views
+}
+
+// coreNoToolErrors checks for tool errors in the given calls.
+// If tools is non-empty, only checks calls matching those tool names.
+func coreNoToolErrors(calls []toolCallView, tools []string) []map[string]any {
+	scopeSet := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		scopeSet[t] = true
+	}
+
+	var errors []map[string]any
+	for _, tc := range calls {
+		if len(scopeSet) > 0 && !scopeSet[tc.Name] {
+			continue
+		}
+		if tc.Error != "" {
+			errors = append(errors, map[string]any{
+				"tool":  tc.Name,
+				"error": tc.Error,
+				"index": tc.Index,
+			})
+		}
+	}
+	return errors
+}
+
+// coreToolCallCount counts matching calls and checks bounds.
+func coreToolCallCount(calls []toolCallView, tool string, minCount, maxCount int) (count int, violation string) {
+	for _, tc := range calls {
+		if tool == "" || tc.Name == tool {
+			count++
+		}
+	}
+
+	if minCount != countNotSet && count < minCount {
+		return count, fmt.Sprintf("expected at least %d call(s), got %d", minCount, count)
+	}
+	if maxCount != countNotSet && count > maxCount {
+		return count, fmt.Sprintf("expected at most %d call(s), got %d", maxCount, count)
+	}
+	return count, ""
+}
+
+// coreToolResultIncludes checks substring patterns in tool results.
+func coreToolResultIncludes(
+	calls []toolCallView, tool string, patterns []string,
+) (matchCount int, missingDetails []map[string]any) {
+	for _, tc := range calls {
+		if tool != "" && tc.Name != tool {
+			continue
+		}
+
+		resultLower := strings.ToLower(tc.Result)
+		allFound := true
+		var missing []string
+		for _, p := range patterns {
+			if !strings.Contains(resultLower, strings.ToLower(p)) {
+				allFound = false
+				missing = append(missing, p)
+			}
+		}
+
+		if allFound {
+			matchCount++
+		} else {
+			missingDetails = append(missingDetails, map[string]any{
+				"tool":             tc.Name,
+				"missing_patterns": missing,
+				"index":            tc.Index,
+			})
+		}
+	}
+	return matchCount, missingDetails
+}
+
+// coreToolResultMatches checks a regex pattern on tool results.
+func coreToolResultMatches(
+	calls []toolCallView, tool, pattern string,
+) (int, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return 0, err
+	}
+
+	matchCount := 0
+	for _, tc := range calls {
+		if tool != "" && tc.Name != tool {
+			continue
+		}
+		if re.MatchString(tc.Result) {
+			matchCount++
+		}
+	}
+	return matchCount, nil
+}
+
+// coreToolCallSequence checks subsequence ordering of tool calls.
+func coreToolCallSequence(calls []toolCallView, sequence []string) (matched int, actualTools []string) {
+	for _, tc := range calls {
+		if matched < len(sequence) && tc.Name == sequence[matched] {
+			matched++
+		}
+	}
+
+	actualTools = make([]string, len(calls))
+	for i, tc := range calls {
+		actualTools[i] = tc.Name
+	}
+	return matched, actualTools
+}
+
+// chainStep defines a single step in a tool call chain.
+type chainStep struct {
+	tool           string
+	resultIncludes []string
+	resultMatches  string
+	argsMatch      map[string]string
+	noError        bool
+}
+
+// parseChainSteps extracts chain steps from params.
+func parseChainSteps(params map[string]any) []chainStep {
+	stepsRaw, _ := params["steps"].([]any)
+	steps := make([]chainStep, 0, len(stepsRaw))
+
+	for _, raw := range stepsRaw {
+		stepMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		step := chainStep{
+			noError: extractBool(stepMap, "no_error"),
+		}
+		step.tool, _ = stepMap["tool"].(string)
+		step.resultIncludes = extractStringSlice(stepMap, "result_includes")
+		step.resultMatches, _ = stepMap["result_matches"].(string)
+		step.argsMatch = extractMapStringString(stepMap, "args_match")
+		steps = append(steps, step)
+	}
+
+	return steps
+}
+
+// coreToolCallChain checks a dependency chain with per-step constraints.
+func coreToolCallChain(
+	calls []toolCallView, steps []chainStep,
+) (completedSteps int, failure map[string]any) {
+	for _, tc := range calls {
+		if completedSteps >= len(steps) {
+			break
+		}
+		step := steps[completedSteps]
+		if tc.Name != step.tool {
+			continue
+		}
+
+		if violation := validateChainStepView(&tc, step, completedSteps); violation != nil {
+			return completedSteps, violation
+		}
+		completedSteps++
+	}
+	return completedSteps, nil
+}
+
+func validateChainStepView(tc *toolCallView, step chainStep, stepIndex int) map[string]any {
+	if step.noError && tc.Error != "" {
+		return chainStepFailure(stepIndex, step.tool, "unexpected error", map[string]any{
+			"error": tc.Error,
+		})
+	}
+
+	if f := checkChainResultIncludesView(tc, step, stepIndex); f != nil {
+		return f
+	}
+
+	if f := checkChainResultMatchesView(tc, step, stepIndex); f != nil {
+		return f
+	}
+
+	return checkChainArgsMatchView(tc, step, stepIndex)
+}
+
+func checkChainResultIncludesView(tc *toolCallView, step chainStep, stepIndex int) map[string]any {
+	if len(step.resultIncludes) == 0 {
+		return nil
+	}
+	resultLower := strings.ToLower(tc.Result)
+	for _, pattern := range step.resultIncludes {
+		if !strings.Contains(resultLower, strings.ToLower(pattern)) {
+			return chainStepFailure(stepIndex, step.tool,
+				fmt.Sprintf("result missing pattern %q", pattern),
+				map[string]any{"missing_pattern": pattern})
+		}
+	}
+	return nil
+}
+
+func checkChainResultMatchesView(tc *toolCallView, step chainStep, stepIndex int) map[string]any {
+	if step.resultMatches == "" {
+		return nil
+	}
+	re, err := regexp.Compile(step.resultMatches)
+	if err != nil {
+		return chainStepFailure(stepIndex, step.tool,
+			fmt.Sprintf("invalid regex %q", step.resultMatches),
+			map[string]any{"error": err.Error()})
+	}
+	if !re.MatchString(tc.Result) {
+		return chainStepFailure(stepIndex, step.tool,
+			"result does not match pattern",
+			map[string]any{"pattern": step.resultMatches})
+	}
+	return nil
+}
+
+func checkChainArgsMatchView(tc *toolCallView, step chainStep, stepIndex int) map[string]any {
+	for argName, pattern := range step.argsMatch {
+		argVal, exists := tc.Args[argName]
+		if !exists {
+			return chainStepFailure(stepIndex, step.tool,
+				fmt.Sprintf("missing argument %q", argName),
+				map[string]any{"argument": argName})
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return chainStepFailure(stepIndex, step.tool,
+				fmt.Sprintf("invalid arg regex %q", pattern),
+				map[string]any{"error": err.Error()})
+		}
+		if !re.MatchString(asString(argVal)) {
+			return chainStepFailure(stepIndex, step.tool,
+				fmt.Sprintf("argument %q does not match pattern", argName),
+				map[string]any{"argument": argName, "pattern": pattern, "actual": argVal})
+		}
+	}
+	return nil
+}
+
+func chainStepFailure(
+	stepIndex int, tool, reason string, extra map[string]any,
+) map[string]any {
+	result := map[string]any{
+		"message":    fmt.Sprintf("step %d (%s): %s", stepIndex, tool, reason),
+		"step_index": stepIndex,
+		"tool":       tool,
+	}
+	for k, v := range extra {
+		result[k] = v
+	}
+	return result
+}

--- a/runtime/evals/handlers/tool_calls_with_args.go
+++ b/runtime/evals/handlers/tool_calls_with_args.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolCallsWithArgsHandler checks that a tool was called with expected arguments.
+// Supports exact value matching (expected_args), regex pattern matching (args_match),
+// and result-level constraints (result_includes, result_matches, no_error).
+type ToolCallsWithArgsHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolCallsWithArgsHandler) Type() string { return "tool_calls_with_args" }
+
+// Eval checks tool calls for argument and result constraints.
+func (h *ToolCallsWithArgsHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	views := viewsFromRecords(evalCtx.ToolCalls)
+	toolName, _ := params["tool_name"].(string)
+	expectedArgs := extractMapAny(params, "expected_args")
+	argsMatch := extractMapStringString(params, "args_match")
+	resultIncludes := extractStringSlice(params, "result_includes")
+	resultMatches, _ := params["result_matches"].(string)
+	noError := extractBool(params, "no_error")
+
+	// Find matching tool calls
+	var matching []toolCallView
+	for _, v := range views {
+		if toolName == "" || v.Name == toolName {
+			matching = append(matching, v)
+		}
+	}
+
+	if toolName != "" && len(matching) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("tool %q was not called", toolName),
+			Details:     map[string]any{"tool_name": toolName},
+		}, nil
+	}
+
+	var violations []map[string]any
+
+	for _, tc := range matching {
+		violations = append(violations, validateExactArgs(tc, expectedArgs)...)
+		violations = append(violations, validatePatternArgs(tc, argsMatch)...)
+		violations = append(violations, validateResultConstraints(tc, resultIncludes, resultMatches, noError)...)
+	}
+
+	passed := len(violations) == 0
+	explanation := fmt.Sprintf("%d matching call(s), %d violation(s)", len(matching), len(violations))
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Explanation: explanation,
+		Details: map[string]any{
+			"violations":     violations,
+			"matching_calls": len(matching),
+		},
+	}, nil
+}
+
+func validateExactArgs(tc toolCallView, expectedArgs map[string]any) []map[string]any {
+	var violations []map[string]any
+	for argName, expectedValue := range expectedArgs {
+		actualValue, exists := tc.Args[argName]
+		if !exists {
+			violations = append(violations, map[string]any{
+				"type": "missing_argument", "tool": tc.Name, "argument": argName,
+			})
+			continue
+		}
+		if expectedValue != nil && asString(actualValue) != asString(expectedValue) {
+			violations = append(violations, map[string]any{
+				"type": "value_mismatch", "tool": tc.Name, "argument": argName,
+				"expected": expectedValue, "actual": actualValue,
+			})
+		}
+	}
+	return violations
+}
+
+func validatePatternArgs(tc toolCallView, argsMatch map[string]string) []map[string]any {
+	var violations []map[string]any
+	for argName, pattern := range argsMatch {
+		actualValue, exists := tc.Args[argName]
+		if !exists {
+			violations = append(violations, map[string]any{
+				"type": "missing_argument_for_pattern", "tool": tc.Name,
+				"argument": argName, "pattern": pattern,
+			})
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			violations = append(violations, map[string]any{
+				"type": "invalid_pattern", "tool": tc.Name, "argument": argName,
+				"pattern": pattern, "error": err.Error(),
+			})
+			continue
+		}
+		if !re.MatchString(asString(actualValue)) {
+			violations = append(violations, map[string]any{
+				"type": "pattern_mismatch", "tool": tc.Name, "argument": argName,
+				"pattern": pattern, "actual": actualValue,
+			})
+		}
+	}
+	return violations
+}
+
+func validateResultConstraints(
+	tc toolCallView, resultIncludes []string, resultMatches string, noError bool,
+) []map[string]any {
+	var violations []map[string]any
+
+	if noError && tc.Error != "" {
+		violations = append(violations, map[string]any{
+			"type": "tool_error", "tool": tc.Name, "error": tc.Error,
+		})
+	}
+
+	if len(resultIncludes) > 0 {
+		resultLower := strings.ToLower(tc.Result)
+		for _, pattern := range resultIncludes {
+			if !strings.Contains(resultLower, strings.ToLower(pattern)) {
+				violations = append(violations, map[string]any{
+					"type": "result_missing_pattern", "tool": tc.Name, "pattern": pattern,
+				})
+			}
+		}
+	}
+
+	if resultMatches != "" {
+		re, err := regexp.Compile(resultMatches)
+		if err != nil {
+			violations = append(violations, map[string]any{
+				"type": "invalid_result_pattern", "tool": tc.Name,
+				"pattern": resultMatches, "error": err.Error(),
+			})
+		} else if !re.MatchString(tc.Result) {
+			violations = append(violations, map[string]any{
+				"type": "result_pattern_mismatch", "tool": tc.Name, "pattern": resultMatches,
+			})
+		}
+	}
+
+	return violations
+}

--- a/runtime/evals/handlers/tool_result_includes.go
+++ b/runtime/evals/handlers/tool_result_includes.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolResultIncludesHandler checks that tool results contain expected substrings.
+// Params: tool string, patterns []string, occurrence int (optional, default 1).
+type ToolResultIncludesHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolResultIncludesHandler) Type() string { return "tool_result_includes" }
+
+// Eval checks substring patterns in tool results.
+func (h *ToolResultIncludesHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	views := viewsFromRecords(evalCtx.ToolCalls)
+	tool, _ := params["tool"].(string)
+	patterns := extractStringSlice(params, "patterns")
+	occurrence := extractInt(params, "occurrence", 1)
+
+	if len(patterns) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no patterns specified",
+		}, nil
+	}
+
+	matchCount, missingDetails := coreToolResultIncludes(views, tool, patterns)
+
+	passed := matchCount >= occurrence
+	explanation := fmt.Sprintf("%d call(s) matched all patterns (required: %d)", matchCount, occurrence)
+	if !passed {
+		explanation = fmt.Sprintf("only %d call(s) matched all patterns (required: %d)", matchCount, occurrence)
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Explanation: explanation,
+		Details: map[string]any{
+			"match_count":     matchCount,
+			"occurrence":      occurrence,
+			"missing_details": missingDetails,
+		},
+	}, nil
+}

--- a/runtime/evals/handlers/tool_result_matches.go
+++ b/runtime/evals/handlers/tool_result_matches.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ToolResultMatchesHandler checks that tool results match a regex pattern.
+// Params: tool string, pattern string, occurrence int (optional, default 1).
+type ToolResultMatchesHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolResultMatchesHandler) Type() string { return "tool_result_matches" }
+
+// Eval checks a regex pattern on tool results.
+func (h *ToolResultMatchesHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	views := viewsFromRecords(evalCtx.ToolCalls)
+	tool, _ := params["tool"].(string)
+	pattern, _ := params["pattern"].(string)
+	occurrence := extractInt(params, "occurrence", 1)
+
+	if pattern == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no pattern specified",
+		}, nil
+	}
+
+	matchCount, err := coreToolResultMatches(views, tool, pattern)
+	if err != nil {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("invalid regex: %v", err),
+		}, nil
+	}
+
+	passed := matchCount >= occurrence
+	explanation := fmt.Sprintf("%d call(s) matched pattern (required: %d)", matchCount, occurrence)
+	if !passed {
+		explanation = fmt.Sprintf("only %d call(s) matched pattern (required: %d)", matchCount, occurrence)
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Explanation: explanation,
+		Details: map[string]any{
+			"match_count": matchCount,
+			"occurrence":  occurrence,
+			"pattern":     pattern,
+		},
+	}, nil
+}

--- a/runtime/evals/handlers/video_duration.go
+++ b/runtime/evals/handlers/video_duration.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// VideoDurationHandler checks that video duration is within range.
+// Params: min_seconds float64, max_seconds float64.
+type VideoDurationHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *VideoDurationHandler) Type() string { return "video_duration" }
+
+// Eval checks video duration constraints.
+func (h *VideoDurationHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return evalMediaDuration(h.Type(), evalCtx.Messages, types.ContentTypeVideo, errNoVideoFound, "video_count", params)
+}

--- a/runtime/evals/handlers/video_resolution.go
+++ b/runtime/evals/handlers/video_resolution.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// VideoResolutionHandler checks that video resolution meets requirements.
+// Params: min_width, max_width, min_height, max_height, presets []string.
+type VideoResolutionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *VideoResolutionHandler) Type() string { return "video_resolution" }
+
+// Eval checks video resolution constraints.
+func (h *VideoResolutionHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	minWidth := extractIntPtr(params, "min_width")
+	maxWidth := extractIntPtr(params, "max_width")
+	minHeight := extractIntPtr(params, "min_height")
+	maxHeight := extractIntPtr(params, "max_height")
+	presets := extractStringSlice(params, "presets")
+
+	parts := extractMediaParts(evalCtx.Messages, types.ContentTypeVideo)
+	if len(parts) == 0 {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: errNoVideoFound,
+		}, nil
+	}
+
+	var violations []string
+	var foundResolutions []string
+	for _, part := range parts {
+		if part.Media.Width == nil || part.Media.Height == nil {
+			violations = append(violations, "video missing width/height metadata")
+			continue
+		}
+		w, ht := *part.Media.Width, *part.Media.Height
+		foundResolutions = append(foundResolutions, fmt.Sprintf("%dx%d", w, ht))
+
+		if len(presets) > 0 && !matchesAnyPreset(w, ht, presets) {
+			violations = append(violations,
+				fmt.Sprintf("resolution %dx%d does not match any preset: %v", w, ht, presets))
+		}
+
+		violations = append(violations, checkWidthRange(w, minWidth, maxWidth)...)
+		violations = append(violations, checkHeightRange(ht, minHeight, maxHeight)...)
+	}
+
+	passed := len(violations) == 0
+	explanation := "all videos meet resolution requirements"
+	if !passed {
+		explanation = "some videos violate resolution requirements"
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      passed,
+		Explanation: explanation,
+		Details: map[string]any{
+			"video_count":       len(parts),
+			"found_resolutions": foundResolutions,
+			"violations":        violations,
+		},
+	}, nil
+}
+
+func matchesAnyPreset(width, height int, presets []string) bool {
+	for _, preset := range presets {
+		if matchesResolutionPreset(width, height, preset) {
+			return true
+		}
+	}
+	return false
+}
+
+// Standard video resolution heights.
+const (
+	resHeight480p  = 480
+	resHeight720p  = 720
+	resHeight1080p = 1080
+	resHeight1440p = 1440
+	resHeight2160p = 2160
+	resHeight4320p = 4320
+)
+
+func matchesResolutionPreset(_, height int, preset string) bool {
+	switch strings.ToLower(preset) {
+	case "480p", "sd":
+		return height == resHeight480p
+	case "720p", "hd":
+		return height == resHeight720p
+	case "1080p", "fhd", "full_hd":
+		return height == resHeight1080p
+	case "1440p", "2k", "qhd":
+		return height == resHeight1440p
+	case "2160p", "4k", "uhd":
+		return height == resHeight2160p
+	case "4320p", "8k":
+		return height == resHeight4320p
+	default:
+		return false
+	}
+}

--- a/runtime/evals/handlers/workflow_complete.go
+++ b/runtime/evals/handlers/workflow_complete.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// WorkflowCompleteHandler checks that the workflow reached a terminal state.
+// Reads evalCtx.Extras["workflow_complete"] (bool) and ["workflow_current_state"] (string).
+type WorkflowCompleteHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *WorkflowCompleteHandler) Type() string { return "workflow_complete" }
+
+// Eval checks whether the workflow is in a terminal state.
+func (h *WorkflowCompleteHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	_ map[string]any,
+) (*evals.EvalResult, error) {
+	raw, ok := evalCtx.Extras["workflow_complete"]
+	if !ok {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "no workflow completion status in context",
+		}, nil
+	}
+
+	complete, ok := raw.(bool)
+	if !ok {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "invalid workflow completion status type",
+		}, nil
+	}
+
+	if complete {
+		state, _ := evalCtx.Extras["workflow_current_state"].(string)
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: true,
+			Explanation: fmt.Sprintf("workflow completed in terminal state %q", state),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type: h.Type(), Passed: false,
+		Explanation: "workflow has not reached a terminal state",
+	}, nil
+}

--- a/runtime/evals/handlers/workflow_handlers_test.go
+++ b/runtime/evals/handlers/workflow_handlers_test.go
@@ -1,0 +1,209 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// --- WorkflowComplete ---
+
+func TestWorkflowCompleteHandler_Type(t *testing.T) {
+	h := &WorkflowCompleteHandler{}
+	if h.Type() != "workflow_complete" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestWorkflowCompleteHandler_Complete(t *testing.T) {
+	h := &WorkflowCompleteHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_complete":      true,
+			"workflow_current_state": "resolved",
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestWorkflowCompleteHandler_NotComplete(t *testing.T) {
+	h := &WorkflowCompleteHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_complete": false,
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for incomplete workflow")
+	}
+}
+
+func TestWorkflowCompleteHandler_Missing(t *testing.T) {
+	h := &WorkflowCompleteHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing data")
+	}
+}
+
+// --- WorkflowStateIs ---
+
+func TestWorkflowStateIsHandler_Type(t *testing.T) {
+	h := &WorkflowStateIsHandler{}
+	if h.Type() != "state_is" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestWorkflowStateIsHandler_Match(t *testing.T) {
+	h := &WorkflowStateIsHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_current_state": "processing",
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"state": "processing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestWorkflowStateIsHandler_Mismatch(t *testing.T) {
+	h := &WorkflowStateIsHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_current_state": "pending",
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"state": "processing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for state mismatch")
+	}
+}
+
+func TestWorkflowStateIsHandler_NoState(t *testing.T) {
+	h := &WorkflowStateIsHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{
+		Extras: map[string]any{},
+	}, map[string]any{"state": "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail when no state available")
+	}
+}
+
+func TestWorkflowStateIsHandler_MissingParam(t *testing.T) {
+	h := &WorkflowStateIsHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{
+		Extras: map[string]any{},
+	}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with missing param")
+	}
+}
+
+// --- WorkflowTransitionedTo ---
+
+func TestWorkflowTransitionedToHandler_Type(t *testing.T) {
+	h := &WorkflowTransitionedToHandler{}
+	if h.Type() != "transitioned_to" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestWorkflowTransitionedToHandler_Found(t *testing.T) {
+	h := &WorkflowTransitionedToHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_transitions": []any{
+				map[string]any{"from": "new", "to": "processing"},
+				map[string]any{"from": "processing", "to": "resolved"},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"state": "resolved",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestWorkflowTransitionedToHandler_NotFound(t *testing.T) {
+	h := &WorkflowTransitionedToHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_transitions": []any{
+				map[string]any{"from": "new", "to": "processing"},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"state": "resolved",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for missing transition")
+	}
+}
+
+func TestWorkflowTransitionedToHandler_NoTransitions(t *testing.T) {
+	h := &WorkflowTransitionedToHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"state": "resolved",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for no transitions")
+	}
+}

--- a/runtime/evals/handlers/workflow_state_is.go
+++ b/runtime/evals/handlers/workflow_state_is.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// WorkflowStateIsHandler checks that the current workflow state matches an expected value.
+// Params: state string (required).
+type WorkflowStateIsHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *WorkflowStateIsHandler) Type() string { return "state_is" }
+
+// Eval checks if the current workflow state matches the expected value.
+func (h *WorkflowStateIsHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	expected, _ := params["state"].(string)
+	if expected == "" {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "missing required param 'state'",
+		}, nil
+	}
+
+	actual, ok := evalCtx.Extras["workflow_current_state"].(string)
+	if !ok {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "no workflow state available in context",
+		}, nil
+	}
+
+	if actual == expected {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: true,
+			Explanation: fmt.Sprintf("workflow is in expected state %q", expected),
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      false,
+		Explanation: fmt.Sprintf("expected state %q but got %q", expected, actual),
+		Details:     map[string]any{"expected": expected, "actual": actual},
+	}, nil
+}

--- a/runtime/evals/handlers/workflow_transitioned_to.go
+++ b/runtime/evals/handlers/workflow_transitioned_to.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// WorkflowTransitionedToHandler checks that a transition to a specific state occurred.
+// Params: state string (required).
+type WorkflowTransitionedToHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *WorkflowTransitionedToHandler) Type() string { return "transitioned_to" }
+
+// Eval checks if the workflow transitioned to the specified state.
+func (h *WorkflowTransitionedToHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	target, _ := params["state"].(string)
+	if target == "" {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "missing required param 'state'",
+		}, nil
+	}
+
+	raw, ok := evalCtx.Extras["workflow_transitions"]
+	if !ok {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "no workflow transitions available in context",
+		}, nil
+	}
+
+	transitions, ok := raw.([]any)
+	if !ok {
+		return &evals.EvalResult{
+			Type: h.Type(), Passed: false,
+			Explanation: "invalid transitions data in context",
+		}, nil
+	}
+
+	for _, t := range transitions {
+		tr, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		if to, _ := tr["to"].(string); to == target {
+			return &evals.EvalResult{
+				Type: h.Type(), Passed: true,
+				Explanation: fmt.Sprintf("workflow transitioned to %q", target),
+				Details:     map[string]any{"transition": tr},
+			}, nil
+		}
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      false,
+		Explanation: fmt.Sprintf("no transition to state %q found", target),
+		Details:     map[string]any{"target": target, "transitions": transitions},
+	}, nil
+}

--- a/runtime/evals/runner.go
+++ b/runtime/evals/runner.go
@@ -144,6 +144,19 @@ func (r *EvalRunner) runOne(
 		return nil
 	}
 
+	// Check when-conditions (tool call preconditions)
+	if def.When != nil {
+		if shouldRun, reason := ShouldRunWhen(def.When, evalCtx.ToolCalls); !shouldRun {
+			return &EvalResult{
+				EvalID:     def.ID,
+				Type:       def.Type,
+				Passed:     true,
+				Skipped:    true,
+				SkipReason: reason,
+			}
+		}
+	}
+
 	// Look up handler
 	handler, err := r.registry.Get(def.Type)
 	if err != nil {

--- a/runtime/evals/runner.go
+++ b/runtime/evals/runner.go
@@ -68,6 +68,21 @@ func (r *EvalRunner) RunSessionEvals(
 	return r.runEvals(ctx, defs, evalCtx, trigCtx, sessionTriggers)
 }
 
+// RunConversationEvals runs conversation-level evals (on_conversation_complete trigger).
+// Call this when a multi-turn conversation ends (e.g., Arena self-play completion).
+func (r *EvalRunner) RunConversationEvals(
+	ctx context.Context,
+	defs []EvalDef,
+	evalCtx *EvalContext,
+) []EvalResult {
+	trigCtx := &TriggerContext{
+		SessionID:         evalCtx.SessionID,
+		TurnIndex:         evalCtx.TurnIndex,
+		IsSessionComplete: true,
+	}
+	return r.runEvals(ctx, defs, evalCtx, trigCtx, conversationTriggers)
+}
+
 // turnTriggers is the set of triggers that fire for turn-level evals.
 var turnTriggers = map[EvalTrigger]bool{
 	TriggerEveryTurn:   true,
@@ -78,6 +93,11 @@ var turnTriggers = map[EvalTrigger]bool{
 var sessionTriggers = map[EvalTrigger]bool{
 	TriggerOnSessionComplete: true,
 	TriggerSampleSessions:    true,
+}
+
+// conversationTriggers is the set of triggers that fire for conversation-level evals.
+var conversationTriggers = map[EvalTrigger]bool{
+	TriggerOnConversationComplete: true,
 }
 
 // runEvals is the shared implementation for both turn and session evals.
@@ -186,5 +206,10 @@ func (r *EvalRunner) executeHandler(
 	result.EvalID = def.ID
 	result.Type = def.Type
 	result.DurationMs = durationMs
+
+	if def.Threshold != nil {
+		def.Threshold.Apply(result)
+	}
+
 	return result
 }

--- a/runtime/evals/trigger.go
+++ b/runtime/evals/trigger.go
@@ -24,9 +24,9 @@ func ShouldRun(
 	trigger EvalTrigger, samplePct float64, ctx *TriggerContext,
 ) bool {
 	switch trigger {
-	case TriggerEveryTurn:
+	case TriggerEveryTurn, TriggerOnWorkflowStep:
 		return true
-	case TriggerOnSessionComplete:
+	case TriggerOnSessionComplete, TriggerOnConversationComplete:
 		return ctx.IsSessionComplete
 	case TriggerSampleTurns:
 		return sampleHit(ctx.SessionID, ctx.TurnIndex, samplePct)

--- a/runtime/evals/when.go
+++ b/runtime/evals/when.go
@@ -1,0 +1,68 @@
+package evals
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// ShouldRunWhen evaluates EvalWhen preconditions against the current eval context's
+// tool call records. Returns whether the eval should run and a reason string if skipped.
+// When toolCalls is nil (e.g. duplex path), returns true to let the handler itself
+// decide how to handle the missing data.
+func ShouldRunWhen(when *EvalWhen, toolCalls []ToolCallRecord) (shouldRun bool, reason string) {
+	if when == nil {
+		return true, ""
+	}
+
+	if when.AnyToolCalled && len(toolCalls) == 0 {
+		return false, "no tool calls in turn"
+	}
+
+	if ok, msg := checkToolCalled(when.ToolCalled, toolCalls); !ok {
+		return false, msg
+	}
+
+	if ok, msg := checkToolCalledPattern(when.ToolCalledPattern, toolCalls); !ok {
+		return false, msg
+	}
+
+	if when.MinToolCalls > 0 && len(toolCalls) < when.MinToolCalls {
+		return false, fmt.Sprintf(
+			"only %d tool call(s), need %d", len(toolCalls), when.MinToolCalls,
+		)
+	}
+
+	return true, ""
+}
+
+// checkToolCalled checks if a specific tool name was called.
+func checkToolCalled(toolName string, toolCalls []ToolCallRecord) (ok bool, reason string) {
+	if toolName == "" {
+		return true, ""
+	}
+	for i := range toolCalls {
+		if toolCalls[i].ToolName == toolName {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("tool %q not called", toolName)
+}
+
+// checkToolCalledPattern checks if any tool name matches the regex pattern.
+func checkToolCalledPattern(pattern string, toolCalls []ToolCallRecord) (ok bool, reason string) {
+	if pattern == "" {
+		return true, ""
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false, fmt.Sprintf(
+			"invalid tool_called_pattern %q: %v", pattern, err,
+		)
+	}
+	for i := range toolCalls {
+		if re.MatchString(toolCalls[i].ToolName) {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("no tool matching pattern %q", pattern)
+}

--- a/runtime/evals/when_test.go
+++ b/runtime/evals/when_test.go
@@ -1,0 +1,151 @@
+package evals
+
+import "testing"
+
+func TestShouldRunWhen_NilWhen(t *testing.T) {
+	ok, reason := ShouldRunWhen(nil, nil)
+	if !ok {
+		t.Error("nil when should return true")
+	}
+	if reason != "" {
+		t.Errorf("expected empty reason, got %q", reason)
+	}
+}
+
+func TestShouldRunWhen_AnyToolCalled_NoTools(t *testing.T) {
+	when := &EvalWhen{AnyToolCalled: true}
+	ok, reason := ShouldRunWhen(when, nil)
+	if ok {
+		t.Error("should skip when no tool calls")
+	}
+	if reason != "no tool calls in turn" {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestShouldRunWhen_AnyToolCalled_WithTools(t *testing.T) {
+	when := &EvalWhen{AnyToolCalled: true}
+	calls := []ToolCallRecord{{ToolName: "search"}}
+	ok, _ := ShouldRunWhen(when, calls)
+	if !ok {
+		t.Error("should run when tool calls present")
+	}
+}
+
+func TestShouldRunWhen_ToolCalled_Match(t *testing.T) {
+	when := &EvalWhen{ToolCalled: "search"}
+	calls := []ToolCallRecord{
+		{ToolName: "format"},
+		{ToolName: "search"},
+	}
+	ok, _ := ShouldRunWhen(when, calls)
+	if !ok {
+		t.Error("should run when named tool was called")
+	}
+}
+
+func TestShouldRunWhen_ToolCalled_NoMatch(t *testing.T) {
+	when := &EvalWhen{ToolCalled: "search"}
+	calls := []ToolCallRecord{{ToolName: "format"}}
+	ok, reason := ShouldRunWhen(when, calls)
+	if ok {
+		t.Error("should skip when named tool not called")
+	}
+	if reason != `tool "search" not called` {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestShouldRunWhen_ToolCalledPattern_Match(t *testing.T) {
+	when := &EvalWhen{ToolCalledPattern: "workflow__.*"}
+	calls := []ToolCallRecord{{ToolName: "workflow__transition"}}
+	ok, _ := ShouldRunWhen(when, calls)
+	if !ok {
+		t.Error("should run when pattern matches")
+	}
+}
+
+func TestShouldRunWhen_ToolCalledPattern_NoMatch(t *testing.T) {
+	when := &EvalWhen{ToolCalledPattern: "workflow__.*"}
+	calls := []ToolCallRecord{{ToolName: "search"}}
+	ok, reason := ShouldRunWhen(when, calls)
+	if ok {
+		t.Error("should skip when pattern doesn't match")
+	}
+	if reason != `no tool matching pattern "workflow__.*"` {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestShouldRunWhen_ToolCalledPattern_InvalidRegex(t *testing.T) {
+	when := &EvalWhen{ToolCalledPattern: "[invalid"}
+	calls := []ToolCallRecord{{ToolName: "search"}}
+	ok, reason := ShouldRunWhen(when, calls)
+	if ok {
+		t.Error("should skip on invalid regex")
+	}
+	if reason == "" {
+		t.Error("expected reason for invalid regex")
+	}
+}
+
+func TestShouldRunWhen_MinToolCalls_Met(t *testing.T) {
+	when := &EvalWhen{MinToolCalls: 2}
+	calls := []ToolCallRecord{
+		{ToolName: "a"},
+		{ToolName: "b"},
+	}
+	ok, _ := ShouldRunWhen(when, calls)
+	if !ok {
+		t.Error("should run when min tool calls met")
+	}
+}
+
+func TestShouldRunWhen_MinToolCalls_NotMet(t *testing.T) {
+	when := &EvalWhen{MinToolCalls: 3}
+	calls := []ToolCallRecord{{ToolName: "a"}}
+	ok, reason := ShouldRunWhen(when, calls)
+	if ok {
+		t.Error("should skip when min tool calls not met")
+	}
+	if reason != "only 1 tool call(s), need 3" {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestShouldRunWhen_CombinedConditions(t *testing.T) {
+	when := &EvalWhen{
+		AnyToolCalled: true,
+		ToolCalled:    "search",
+		MinToolCalls:  2,
+	}
+	calls := []ToolCallRecord{
+		{ToolName: "search"},
+		{ToolName: "format"},
+	}
+	ok, _ := ShouldRunWhen(when, calls)
+	if !ok {
+		t.Error("should run when all conditions met")
+	}
+}
+
+func TestShouldRunWhen_CombinedConditions_PartialFail(t *testing.T) {
+	when := &EvalWhen{
+		AnyToolCalled: true,
+		ToolCalled:    "missing_tool",
+		MinToolCalls:  1,
+	}
+	calls := []ToolCallRecord{{ToolName: "search"}}
+	ok, _ := ShouldRunWhen(when, calls)
+	if ok {
+		t.Error("should skip when one condition fails")
+	}
+}
+
+func TestShouldRunWhen_EmptyWhen(t *testing.T) {
+	when := &EvalWhen{}
+	ok, _ := ShouldRunWhen(when, nil)
+	if !ok {
+		t.Error("empty when (no conditions) should return true")
+	}
+}

--- a/runtime/types/tool_call_record.go
+++ b/runtime/types/tool_call_record.go
@@ -1,0 +1,14 @@
+package types //nolint:revive // package name matches existing convention
+
+import "time"
+
+// ToolCallRecord captures a single tool invocation for eval/assertion context.
+// Shared between runtime/evals and tools/arena/assertions.
+type ToolCallRecord struct {
+	TurnIndex int            `json:"turn_index"`
+	ToolName  string         `json:"tool_name"`
+	Arguments map[string]any `json:"arguments"`
+	Result    any            `json:"result,omitempty"`
+	Error     string         `json:"error,omitempty"`
+	Duration  time.Duration  `json:"duration,omitempty"`
+}

--- a/runtime/types/tool_call_record_test.go
+++ b/runtime/types/tool_call_record_test.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestToolCallRecord_JSONRoundTrip(t *testing.T) {
+	original := ToolCallRecord{
+		TurnIndex: 2,
+		ToolName:  "create_ticket",
+		Arguments: map[string]any{"title": "Bug fix", "priority": "high"},
+		Result:    map[string]any{"id": "T-123"},
+		Error:     "",
+		Duration:  150 * time.Millisecond,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var decoded ToolCallRecord
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if decoded.ToolName != original.ToolName {
+		t.Errorf("ToolName = %q, want %q", decoded.ToolName, original.ToolName)
+	}
+	if decoded.TurnIndex != original.TurnIndex {
+		t.Errorf("TurnIndex = %d, want %d", decoded.TurnIndex, original.TurnIndex)
+	}
+	if decoded.Duration != original.Duration {
+		t.Errorf("Duration = %v, want %v", decoded.Duration, original.Duration)
+	}
+}
+
+func TestToolCallRecord_OmitsEmptyFields(t *testing.T) {
+	tc := ToolCallRecord{
+		TurnIndex: 0,
+		ToolName:  "search",
+		Arguments: map[string]any{"q": "test"},
+	}
+
+	data, err := json.Marshal(tc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw: %v", err)
+	}
+
+	if _, ok := raw["result"]; ok {
+		t.Error("result should be omitted when nil")
+	}
+	if _, ok := raw["error"]; ok {
+		t.Error("error should be omitted when empty")
+	}
+	if _, ok := raw["duration"]; ok {
+		t.Error("duration should be omitted when zero")
+	}
+}

--- a/sdk/eval_integration_test.go
+++ b/sdk/eval_integration_test.go
@@ -54,6 +54,12 @@ func (d *integrationDispatcher) DispatchSessionEvals(
 	}, nil
 }
 
+func (d *integrationDispatcher) DispatchConversationEvals(
+	_ context.Context, _ []evals.EvalDef, _ *evals.EvalContext,
+) ([]evals.EvalResult, error) {
+	return nil, nil
+}
+
 func float64Ptr(v float64) *float64 { return &v }
 
 // integrationResultWriter records results for assertion.

--- a/sdk/eval_middleware_test.go
+++ b/sdk/eval_middleware_test.go
@@ -49,6 +49,12 @@ func (d *testDispatcher) DispatchSessionEvals(
 	return nil, nil
 }
 
+func (d *testDispatcher) DispatchConversationEvals(
+	_ context.Context, _ []evals.EvalDef, _ *evals.EvalContext,
+) ([]evals.EvalResult, error) {
+	return nil, nil
+}
+
 func (d *testDispatcher) TurnCalls() int {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -515,6 +521,12 @@ func (d *errorDispatcher) DispatchSessionEvals(
 	return nil, d.sessionErr
 }
 
+func (d *errorDispatcher) DispatchConversationEvals(
+	_ context.Context, _ []evals.EvalDef, _ *evals.EvalContext,
+) ([]evals.EvalResult, error) {
+	return nil, nil
+}
+
 func TestEvalMiddleware_DispatchTurnEvalsError(t *testing.T) {
 	conv := &Conversation{
 		config: &config{
@@ -579,6 +591,12 @@ func (d *returningDispatcher) DispatchTurnEvals(
 }
 
 func (d *returningDispatcher) DispatchSessionEvals(
+	_ context.Context, _ []evals.EvalDef, _ *evals.EvalContext,
+) ([]evals.EvalResult, error) {
+	return d.results, nil
+}
+
+func (d *returningDispatcher) DispatchConversationEvals(
 	_ context.Context, _ []evals.EvalDef, _ *evals.EvalContext,
 ) ([]evals.EvalResult, error) {
 	return d.results, nil

--- a/tools/arena/assertions/conversation.go
+++ b/tools/arena/assertions/conversation.go
@@ -33,16 +33,9 @@ type ConversationContext struct {
 	Metadata ConversationMetadata
 }
 
-// ToolCallRecord captures a single tool invocation for assertion checking.
-// Records both the invocation parameters and the result for comprehensive validation.
-type ToolCallRecord struct {
-	TurnIndex int                    `json:"turn_index"` // Which turn (index in AllTurns) this call occurred in
-	ToolName  string                 `json:"tool_name"`  // Name of the tool called
-	Arguments map[string]interface{} `json:"arguments"`  // Arguments passed to the tool
-	Result    interface{}            `json:"result"`     // Tool's return value (nil if tool failed)
-	Error     string                 `json:"error"`      // Error message if tool failed (empty on success)
-	Duration  time.Duration          `json:"duration"`   // How long the tool took to execute
-}
+// ToolCallRecord is an alias for types.ToolCallRecord so existing code
+// referencing assertions.ToolCallRecord continues to compile unchanged.
+type ToolCallRecord = types.ToolCallRecord
 
 // ConversationMetadata provides context about the conversation execution.
 // Useful for conditional validation based on scenario characteristics.

--- a/tools/arena/assertions/eval_adapter.go
+++ b/tools/arena/assertions/eval_adapter.go
@@ -1,0 +1,55 @@
+package assertions
+
+import (
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// PackEvalTypePrefix is prepended to eval types when converting to assertion results.
+// Report renderers use this prefix to distinguish pack eval results from scenario assertions.
+const PackEvalTypePrefix = "pack_eval:"
+
+// ConvertEvalResults transforms a slice of EvalResult into ConversationValidationResult entries.
+// Each result is tagged with the PackEvalTypePrefix so renderers can group them separately.
+// This function is used by both the PackEvalAdapter (engine) and the statestore when
+// building AssertionsSummary from eval results.
+func ConvertEvalResults(results []evals.EvalResult) []ConversationValidationResult {
+	if len(results) == 0 {
+		return nil
+	}
+
+	converted := make([]ConversationValidationResult, 0, len(results))
+	for i := range results {
+		converted = append(converted, convertOneEvalResult(&results[i]))
+	}
+	return converted
+}
+
+// convertOneEvalResult converts a single EvalResult to ConversationValidationResult.
+func convertOneEvalResult(r *evals.EvalResult) ConversationValidationResult {
+	msg := r.Explanation
+	if !r.Passed && r.Error != "" {
+		msg = r.Error
+	}
+
+	details := make(map[string]interface{})
+	details["eval_id"] = r.EvalID
+	details["duration_ms"] = r.DurationMs
+	if r.Score != nil {
+		details["score"] = *r.Score
+	}
+	if r.MetricValue != nil {
+		details["metric_value"] = *r.MetricValue
+	}
+	if r.Error != "" {
+		details["error"] = r.Error
+	}
+
+	return ConversationValidationResult{
+		Type:    fmt.Sprintf("%s%s", PackEvalTypePrefix, r.Type),
+		Passed:  r.Passed,
+		Message: msg,
+		Details: details,
+	}
+}

--- a/tools/arena/assertions/eval_adapter_test.go
+++ b/tools/arena/assertions/eval_adapter_test.go
@@ -1,0 +1,109 @@
+package assertions_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+)
+
+func TestConvertEvalResults_Empty(t *testing.T) {
+	result := assertions.ConvertEvalResults(nil)
+	assert.Nil(t, result)
+
+	result = assertions.ConvertEvalResults([]evals.EvalResult{})
+	assert.Nil(t, result)
+}
+
+func TestConvertEvalResults_PassingResult(t *testing.T) {
+	score := 0.95
+	results := []evals.EvalResult{
+		{
+			EvalID:      "eval-1",
+			Type:        "contains",
+			Passed:      true,
+			Score:       &score,
+			Explanation: "Content contains expected text",
+			DurationMs:  42,
+		},
+	}
+
+	converted := assertions.ConvertEvalResults(results)
+	require.Len(t, converted, 1)
+
+	c := converted[0]
+	assert.Equal(t, "pack_eval:contains", c.Type)
+	assert.True(t, c.Passed)
+	assert.Equal(t, "Content contains expected text", c.Message)
+	assert.Equal(t, "eval-1", c.Details["eval_id"])
+	assert.Equal(t, int64(42), c.Details["duration_ms"])
+	assert.Equal(t, 0.95, c.Details["score"])
+	_, hasError := c.Details["error"]
+	assert.False(t, hasError)
+}
+
+func TestConvertEvalResults_FailingResultWithError(t *testing.T) {
+	results := []evals.EvalResult{
+		{
+			EvalID:      "eval-2",
+			Type:        "llm_judge",
+			Passed:      false,
+			Explanation: "Judge determined response is off-topic",
+			Error:       "provider timeout",
+			DurationMs:  5000,
+		},
+	}
+
+	converted := assertions.ConvertEvalResults(results)
+	require.Len(t, converted, 1)
+
+	c := converted[0]
+	assert.Equal(t, "pack_eval:llm_judge", c.Type)
+	assert.False(t, c.Passed)
+	// When failed and error is set, message should be the error
+	assert.Equal(t, "provider timeout", c.Message)
+	assert.Equal(t, "provider timeout", c.Details["error"])
+}
+
+func TestConvertEvalResults_MultipleResults(t *testing.T) {
+	metricVal := 0.87
+	results := []evals.EvalResult{
+		{
+			EvalID:      "eval-a",
+			Type:        "contains",
+			Passed:      true,
+			Explanation: "ok",
+			DurationMs:  10,
+		},
+		{
+			EvalID:      "eval-b",
+			Type:        "cosine_similarity",
+			Passed:      true,
+			MetricValue: &metricVal,
+			Explanation: "similarity check passed",
+			DurationMs:  20,
+		},
+		{
+			EvalID:      "eval-c",
+			Type:        "json_valid",
+			Passed:      false,
+			Explanation: "invalid JSON",
+			DurationMs:  5,
+		},
+	}
+
+	converted := assertions.ConvertEvalResults(results)
+	require.Len(t, converted, 3)
+
+	assert.Equal(t, "pack_eval:contains", converted[0].Type)
+	assert.True(t, converted[0].Passed)
+
+	assert.Equal(t, "pack_eval:cosine_similarity", converted[1].Type)
+	assert.Equal(t, 0.87, converted[1].Details["metric_value"])
+
+	assert.Equal(t, "pack_eval:json_valid", converted[2].Type)
+	assert.False(t, converted[2].Passed)
+}

--- a/tools/arena/assertions/types.go
+++ b/tools/arena/assertions/types.go
@@ -1,6 +1,9 @@
 package assertions
 
 import (
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	runtimeValidators "github.com/AltairaLabs/PromptKit/runtime/validators"
 )
 
@@ -48,3 +51,27 @@ func FromValidationResult(vr runtimeValidators.ValidationResult, message string)
 		Message: message,
 	}
 }
+
+// ToEvalDef converts an AssertionConfig to an evals.EvalDef.
+// This is the bridge for unifying arena assertions with runtime evals.
+func (a AssertionConfig) ToEvalDef(index int) evals.EvalDef {
+	def := evals.EvalDef{
+		ID:        fmt.Sprintf("assertion_%d_%s", index, a.Type),
+		Type:      a.Type,
+		Trigger:   evals.TriggerEveryTurn,
+		Params:    a.Params,
+		Message:   a.Message,
+		Threshold: &evals.Threshold{Passed: boolPtr(true)},
+	}
+	if a.When != nil {
+		def.When = &evals.EvalWhen{
+			ToolCalled:        a.When.ToolCalled,
+			ToolCalledPattern: a.When.ToolCalledPattern,
+			AnyToolCalled:     a.When.AnyToolCalled,
+			MinToolCalls:      a.When.MinToolCalls,
+		}
+	}
+	return def
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/tools/arena/assertions/types.go
+++ b/tools/arena/assertions/types.go
@@ -74,4 +74,12 @@ func (a AssertionConfig) ToEvalDef(index int) evals.EvalDef {
 	return def
 }
 
+// ToConversationEvalDef converts an AssertionConfig to an evals.EvalDef
+// with TriggerOnConversationComplete. Used for conversation-level assertions.
+func (a AssertionConfig) ToConversationEvalDef(index int) evals.EvalDef {
+	def := a.ToEvalDef(index)
+	def.Trigger = evals.TriggerOnConversationComplete
+	return def
+}
+
 func boolPtr(b bool) *bool { return &b }

--- a/tools/arena/assertions/types_test.go
+++ b/tools/arena/assertions/types_test.go
@@ -3,6 +3,7 @@ package assertions
 import (
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	runtimeValidators "github.com/AltairaLabs/PromptKit/runtime/validators"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,4 +28,60 @@ func TestFromValidationResult(t *testing.T) {
 	assert.True(t, ar.Passed)
 	assert.Equal(t, "test message", ar.Message)
 	assert.Equal(t, vr.Details, ar.Details)
+}
+
+func TestAssertionConfig_ToEvalDef_Basic(t *testing.T) {
+	cfg := AssertionConfig{
+		Type:    "content_includes",
+		Params:  map[string]interface{}{"patterns": []string{"hello"}},
+		Message: "should include hello",
+	}
+
+	def := cfg.ToEvalDef(0)
+
+	assert.Equal(t, "assertion_0_content_includes", def.ID)
+	assert.Equal(t, "content_includes", def.Type)
+	assert.Equal(t, evals.TriggerEveryTurn, def.Trigger)
+	assert.Equal(t, cfg.Params, def.Params)
+	assert.Equal(t, "should include hello", def.Message)
+	assert.NotNil(t, def.Threshold)
+	assert.NotNil(t, def.Threshold.Passed)
+	assert.True(t, *def.Threshold.Passed)
+	assert.Nil(t, def.When)
+}
+
+func TestAssertionConfig_ToEvalDef_WithWhen(t *testing.T) {
+	cfg := AssertionConfig{
+		Type:    "tools_called",
+		Params:  map[string]interface{}{"tools": []string{"search"}},
+		Message: "search should be called",
+		When: &AssertionWhen{
+			ToolCalled:        "search",
+			ToolCalledPattern: "search_.*",
+			AnyToolCalled:     true,
+			MinToolCalls:      2,
+		},
+	}
+
+	def := cfg.ToEvalDef(3)
+
+	assert.Equal(t, "assertion_3_tools_called", def.ID)
+	assert.NotNil(t, def.When)
+	assert.Equal(t, "search", def.When.ToolCalled)
+	assert.Equal(t, "search_.*", def.When.ToolCalledPattern)
+	assert.True(t, def.When.AnyToolCalled)
+	assert.Equal(t, 2, def.When.MinToolCalls)
+}
+
+func TestAssertionConfig_ToEvalDef_IndexInID(t *testing.T) {
+	cfg := AssertionConfig{
+		Type:   "content_matches",
+		Params: map[string]interface{}{},
+	}
+
+	def5 := cfg.ToEvalDef(5)
+	def10 := cfg.ToEvalDef(10)
+
+	assert.Equal(t, "assertion_5_content_matches", def5.ID)
+	assert.Equal(t, "assertion_10_content_matches", def10.ID)
 }

--- a/tools/arena/assertions/types_test.go
+++ b/tools/arena/assertions/types_test.go
@@ -85,3 +85,33 @@ func TestAssertionConfig_ToEvalDef_IndexInID(t *testing.T) {
 	assert.Equal(t, "assertion_5_content_matches", def5.ID)
 	assert.Equal(t, "assertion_10_content_matches", def10.ID)
 }
+
+func TestAssertionConfig_ToConversationEvalDef(t *testing.T) {
+	cfg := AssertionConfig{
+		Type:    "turn_count",
+		Params:  map[string]interface{}{"min": 3},
+		Message: "should have at least 3 turns",
+	}
+
+	def := cfg.ToConversationEvalDef(2)
+
+	assert.Equal(t, "assertion_2_turn_count", def.ID)
+	assert.Equal(t, "turn_count", def.Type)
+	assert.Equal(t, evals.TriggerOnConversationComplete, def.Trigger)
+	assert.Equal(t, cfg.Params, def.Params)
+}
+
+func TestAssertionConfig_ToConversationEvalDef_WithWhen(t *testing.T) {
+	cfg := AssertionConfig{
+		Type: "tools_called",
+		When: &AssertionWhen{
+			ToolCalled: "search",
+		},
+	}
+
+	def := cfg.ToConversationEvalDef(0)
+
+	assert.Equal(t, evals.TriggerOnConversationComplete, def.Trigger)
+	assert.NotNil(t, def.When)
+	assert.Equal(t, "search", def.When.ToolCalled)
+}

--- a/tools/arena/cmd/promptarena/run.go
+++ b/tools/arena/cmd/promptarena/run.go
@@ -423,6 +423,7 @@ func convertToEngineRunResult(sr *statestore.RunResult) engine.RunResult {
 			Results: sr.ConversationAssertions.Results,
 			Total:   sr.ConversationAssertions.Total,
 		},
+		EvalResults: sr.EvalResults,
 	}
 
 	// Convert A2AAgents

--- a/tools/arena/engine/conversation_executor_test.go
+++ b/tools/arena/engine/conversation_executor_test.go
@@ -23,7 +23,7 @@ func TestEvaluateConversationAssertions_NoAssertions(t *testing.T) {
 	req := ConversationRequest{Scenario: &config.Scenario{ID: "sc"}}
 	msgs := []types.Message{{Role: "assistant", Content: "hello"}}
 
-	res := ce.evaluateConversationAssertions(&req, msgs)
+	res, _ := ce.evaluateConversationAssertions(&req, msgs)
 	if res != nil {
 		t.Fatalf("expected nil results when no conversation assertions present, got %v", res)
 	}
@@ -86,7 +86,7 @@ func TestEvaluateConversationAssertions_WithContentNotIncludes(t *testing.T) {
 		{Role: "assistant", Content: "this has forbidden phrase"},
 	}
 
-	res := ce.evaluateConversationAssertions(&req, msgs)
+	res, _ := ce.evaluateConversationAssertions(&req, msgs)
 	if len(res) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(res))
 	}
@@ -868,7 +868,7 @@ func TestEvaluateConversationAssertions_PackAssertionsEvaluated(t *testing.T) {
 		{Role: "assistant", Content: "this has forbidden phrase"},
 	}
 
-	res := ce.evaluateConversationAssertions(&req, msgs)
+	res, _ := ce.evaluateConversationAssertions(&req, msgs)
 	if len(res) != 1 {
 		t.Fatalf("expected 1 result from pack assertion, got %d", len(res))
 	}
@@ -899,7 +899,7 @@ func TestEvaluateConversationAssertions_PackAndScenarioBothProduceResults(t *tes
 		{Role: "assistant", Content: "this has pack-bad and scenario-bad words"},
 	}
 
-	res := ce.evaluateConversationAssertions(&req, msgs)
+	res, _ := ce.evaluateConversationAssertions(&req, msgs)
 	if len(res) != 2 {
 		t.Fatalf("expected 2 results (pack + scenario), got %d", len(res))
 	}

--- a/tools/arena/engine/duplex_executor_results_integration.go
+++ b/tools/arena/engine/duplex_executor_results_integration.go
@@ -50,7 +50,7 @@ func (de *DuplexConversationExecutor) buildResultFromStateStore(
 	toolStats := de.calculateToolStats(messages)
 
 	// Evaluate conversation-level assertions
-	convAssertionResults := de.evaluateConversationAssertions(req, messages)
+	convAssertionResults, evalResults := de.evaluateConversationAssertions(req, messages)
 
 	// Run pack eval session-level evals if configured
 	if de.packEvalHook != nil && de.packEvalHook.HasEvals() {
@@ -67,6 +67,7 @@ func (de *DuplexConversationExecutor) buildResultFromStateStore(
 		SelfPlay:                     de.containsSelfPlay(req.Scenario),
 		PersonaID:                    de.findFirstSelfPlayPersona(req.Scenario),
 		ConversationAssertionResults: convAssertionResults,
+		EvalResults:                  evalResults,
 	}
 }
 

--- a/tools/arena/engine/eval_execution_test.go
+++ b/tools/arena/engine/eval_execution_test.go
@@ -193,7 +193,7 @@ func TestEvalConversationExecutor_EvaluateConversationAssertions(t *testing.T) {
 			},
 		}
 
-		results := executor.evaluateConversationAssertions(ctx, assertionConfigs, convCtx)
+		results, _ := executor.evaluateConversationAssertions(ctx, assertionConfigs, convCtx)
 		assert.Len(t, results, 1)
 		assert.True(t, results[0].Passed)
 		assert.Equal(t, "test_assertion", results[0].Type)
@@ -204,16 +204,18 @@ func TestEvalConversationExecutor_EvaluateConversationAssertions(t *testing.T) {
 			convAssertionReg: nil,
 		}
 
-		results := executor.evaluateConversationAssertions(ctx, []assertions.AssertionConfig{
+		results, evalResults := executor.evaluateConversationAssertions(ctx, []assertions.AssertionConfig{
 			{Type: "test"},
 		}, &assertions.ConversationContext{})
 
 		assert.Nil(t, results)
+		assert.Nil(t, evalResults)
 	})
 
 	t.Run("returns nil when no assertions", func(t *testing.T) {
-		results := executor.evaluateConversationAssertions(ctx, []assertions.AssertionConfig{}, &assertions.ConversationContext{})
+		results, evalResults := executor.evaluateConversationAssertions(ctx, []assertions.AssertionConfig{}, &assertions.ConversationContext{})
 		assert.Nil(t, results)
+		assert.Nil(t, evalResults)
 	})
 }
 

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -541,6 +541,7 @@ func (e *Engine) saveRunMetadata(
 		PersonaID:                    result.PersonaID,
 		RecordingPath:                e.GetRecordingPath(runID),
 		ConversationAssertionResults: result.ConversationAssertionResults,
+		EvalResults:                  result.EvalResults,
 		A2AAgents:                    e.getA2AAgentsFromConfig(),
 	}
 
@@ -548,6 +549,7 @@ func (e *Engine) saveRunMetadata(
 		"runID", runID,
 		"recording_path", metadata.RecordingPath,
 		"conv_assertions_count", len(result.ConversationAssertionResults),
+		"eval_results_count", len(result.EvalResults),
 		"conv_assertions_results", result.ConversationAssertionResults)
 
 	return store.SaveMetadata(ctx, runID, metadata)
@@ -685,6 +687,7 @@ func (e *Engine) saveEvalMetadata(
 		SelfPlay:                     convResult.SelfPlay,
 		PersonaID:                    convResult.PersonaID,
 		ConversationAssertionResults: convResult.ConversationAssertionResults,
+		EvalResults:                  convResult.EvalResults,
 		A2AAgents:                    e.getA2AAgentsFromConfig(),
 	}
 

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -95,6 +95,7 @@ func (e *Engine) executeWorkflowRun(
 		Error:                        convResult.Error,
 		RecordingPath:                e.GetRecordingPath(runID),
 		ConversationAssertionResults: assertionResults,
+		EvalResults:                  convResult.EvalResults,
 		A2AAgents:                    e.getA2AAgentsFromConfig(),
 	}
 

--- a/tools/arena/engine/interfaces.go
+++ b/tools/arena/engine/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -87,6 +88,10 @@ type ConversationResult struct {
 
 	// Conversation-level assertions
 	ConversationAssertionResults []assertions.ConversationValidationResult `json:"conv_assertions_results,omitempty"`
+
+	// Eval results from the new EvalRunner dual-write path (Phase 2).
+	// Stored alongside ConversationAssertionResults during the transition period.
+	EvalResults []evals.EvalResult `json:"eval_results,omitempty"`
 
 	// Self-play metadata
 	SelfPlay  bool   `json:"self_play,omitempty"`

--- a/tools/arena/engine/pack_eval_adapter.go
+++ b/tools/arena/engine/pack_eval_adapter.go
@@ -1,58 +1,19 @@
 package engine
 
 import (
-	"fmt"
-
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
 )
 
-// PackEvalTypePrefix is prepended to eval types when converting to assertion results.
-// Report renderers use this prefix to distinguish pack eval results from scenario assertions.
-const PackEvalTypePrefix = "pack_eval:"
-
 // PackEvalAdapter converts evals.EvalResult to assertions.ConversationValidationResult
 // so pack eval results flow through the existing Arena assertion reporting pipeline.
+//
+// Deprecated: The shared assertions.ConvertEvalResults() function should be preferred
+// for new code. PackEvalAdapter delegates to it and is kept for backward compatibility.
 type PackEvalAdapter struct{}
 
 // Convert transforms a slice of EvalResult into ConversationValidationResult entries.
-// Each result is tagged with the PackEvalTypePrefix so renderers can group them separately.
+// Each result is tagged with the assertions.PackEvalTypePrefix so renderers can group them separately.
 func (a *PackEvalAdapter) Convert(results []evals.EvalResult) []assertions.ConversationValidationResult {
-	if len(results) == 0 {
-		return nil
-	}
-
-	converted := make([]assertions.ConversationValidationResult, 0, len(results))
-	for i := range results {
-		converted = append(converted, a.convertOne(&results[i]))
-	}
-	return converted
-}
-
-// convertOne converts a single EvalResult to ConversationValidationResult.
-func (a *PackEvalAdapter) convertOne(r *evals.EvalResult) assertions.ConversationValidationResult {
-	msg := r.Explanation
-	if !r.Passed && r.Error != "" {
-		msg = r.Error
-	}
-
-	details := make(map[string]interface{})
-	details["eval_id"] = r.EvalID
-	details["duration_ms"] = r.DurationMs
-	if r.Score != nil {
-		details["score"] = *r.Score
-	}
-	if r.MetricValue != nil {
-		details["metric_value"] = *r.MetricValue
-	}
-	if r.Error != "" {
-		details["error"] = r.Error
-	}
-
-	return assertions.ConversationValidationResult{
-		Type:    fmt.Sprintf("%s%s", PackEvalTypePrefix, r.Type),
-		Passed:  r.Passed,
-		Message: msg,
-		Details: details,
-	}
+	return assertions.ConvertEvalResults(results)
 }

--- a/tools/arena/engine/pack_eval_adapter_test.go
+++ b/tools/arena/engine/pack_eval_adapter_test.go
@@ -75,37 +75,44 @@ func TestPackEvalAdapter_Convert_MultipleResults(t *testing.T) {
 	require.Len(t, converted, 3)
 }
 
-func TestPackEvalAdapter_convertOne_ScoreAndMetricValue(t *testing.T) {
+func TestPackEvalAdapter_Convert_ScoreAndMetricValue(t *testing.T) {
 	adapter := &PackEvalAdapter{}
 
-	r := &evals.EvalResult{
-		EvalID:      "eval-score",
-		Type:        "llm_judge",
-		Passed:      true,
-		Score:       floatPtr(0.95),
-		MetricValue: floatPtr(42.5),
-		Explanation: "high quality",
-		DurationMs:  100,
+	results := []evals.EvalResult{
+		{
+			EvalID:      "eval-score",
+			Type:        "llm_judge",
+			Passed:      true,
+			Score:       floatPtr(0.95),
+			MetricValue: floatPtr(42.5),
+			Explanation: "high quality",
+			DurationMs:  100,
+		},
 	}
 
-	result := adapter.convertOne(r)
+	converted := adapter.Convert(results)
+	require.Len(t, converted, 1)
 
+	result := converted[0]
 	assert.Equal(t, 0.95, result.Details["score"])
 	assert.Equal(t, 42.5, result.Details["metric_value"])
 	assert.Equal(t, "eval-score", result.Details["eval_id"])
 }
 
-func TestPackEvalAdapter_convertOne_DurationMs(t *testing.T) {
+func TestPackEvalAdapter_Convert_DurationMs(t *testing.T) {
 	adapter := &PackEvalAdapter{}
 
-	r := &evals.EvalResult{
-		EvalID:     "eval-dur",
-		Type:       "latency",
-		Passed:     true,
-		DurationMs: 250,
+	results := []evals.EvalResult{
+		{
+			EvalID:     "eval-dur",
+			Type:       "latency",
+			Passed:     true,
+			DurationMs: 250,
+		},
 	}
 
-	result := adapter.convertOne(r)
+	converted := adapter.Convert(results)
+	require.Len(t, converted, 1)
 
-	assert.Equal(t, int64(250), result.Details["duration_ms"])
+	assert.Equal(t, int64(250), converted[0].Details["duration_ms"])
 }

--- a/tools/arena/engine/pack_eval_hook.go
+++ b/tools/arena/engine/pack_eval_hook.go
@@ -50,6 +50,9 @@ func NewPackEvalHook(
 
 // HasEvals returns true if there are eval defs to execute.
 func (h *PackEvalHook) HasEvals() bool {
+	if h == nil {
+		return false
+	}
 	return len(h.defs) > 0
 }
 
@@ -61,7 +64,7 @@ func (h *PackEvalHook) RunTurnEvals(
 	turnIndex int,
 	sessionID string,
 ) []assertions.ConversationValidationResult {
-	if !h.HasEvals() {
+	if h == nil || !h.HasEvals() {
 		return nil
 	}
 
@@ -77,7 +80,7 @@ func (h *PackEvalHook) RunSessionEvals(
 	messages []types.Message,
 	sessionID string,
 ) []assertions.ConversationValidationResult {
-	if !h.HasEvals() {
+	if h == nil || !h.HasEvals() {
 		return nil
 	}
 
@@ -97,7 +100,7 @@ func (h *PackEvalHook) RunConversationEvals(
 	messages []types.Message,
 	sessionID string,
 ) []assertions.ConversationValidationResult {
-	if !h.HasEvals() {
+	if h == nil || !h.HasEvals() {
 		return nil
 	}
 
@@ -121,7 +124,7 @@ func (h *PackEvalHook) RunAssertionsAsEvals(
 	sessionID string,
 	trigger evals.EvalTrigger,
 ) []evals.EvalResult {
-	if len(assertionConfigs) == 0 {
+	if h == nil || len(assertionConfigs) == 0 {
 		return nil
 	}
 
@@ -159,6 +162,9 @@ func (h *PackEvalHook) RunAssertionsAsConversationResults(
 	sessionID string,
 	trigger evals.EvalTrigger,
 ) []assertions.ConversationValidationResult {
+	if h == nil {
+		return nil
+	}
 	results := h.RunAssertionsAsEvals(ctx, assertionConfigs, messages, turnIndex, sessionID, trigger)
 	return h.adapter.Convert(results)
 }

--- a/tools/arena/engine/pack_eval_hook.go
+++ b/tools/arena/engine/pack_eval_hook.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -89,6 +90,79 @@ func (h *PackEvalHook) RunSessionEvals(
 	return h.adapter.Convert(results)
 }
 
+// RunConversationEvals runs conversation-complete evals after all turns finish.
+// Returns converted ConversationValidationResult entries.
+func (h *PackEvalHook) RunConversationEvals(
+	ctx context.Context,
+	messages []types.Message,
+	sessionID string,
+) []assertions.ConversationValidationResult {
+	if !h.HasEvals() {
+		return nil
+	}
+
+	turnIndex := len(messages) - 1
+	if turnIndex < 0 {
+		turnIndex = 0
+	}
+	evalCtx := h.buildEvalContext(messages, turnIndex, sessionID)
+	results, _ := h.dispatcher.DispatchConversationEvals(ctx, h.defs, evalCtx)
+	return h.adapter.Convert(results)
+}
+
+// RunAssertionsAsEvals converts assertion configs to EvalDefs and runs them
+// through the dispatcher. Returns raw EvalResults (not converted to assertion format).
+// The trigger parameter overrides the default trigger on each converted def.
+func (h *PackEvalHook) RunAssertionsAsEvals(
+	ctx context.Context,
+	assertionConfigs []assertions.AssertionConfig,
+	messages []types.Message,
+	turnIndex int,
+	sessionID string,
+	trigger evals.EvalTrigger,
+) []evals.EvalResult {
+	if len(assertionConfigs) == 0 {
+		return nil
+	}
+
+	defs := make([]evals.EvalDef, len(assertionConfigs))
+	for i, cfg := range assertionConfigs {
+		defs[i] = cfg.ToEvalDef(i)
+		defs[i].Trigger = trigger
+	}
+
+	evalCtx := h.buildEvalContext(messages, turnIndex, sessionID)
+
+	var results []evals.EvalResult
+	var err error
+	switch trigger { //nolint:exhaustive // Only conversation and turn triggers are meaningful here
+	case evals.TriggerOnConversationComplete:
+		results, err = h.dispatcher.DispatchConversationEvals(ctx, defs, evalCtx)
+	case evals.TriggerEveryTurn:
+		results, err = h.dispatcher.DispatchTurnEvals(ctx, defs, evalCtx)
+	default:
+		results, err = h.dispatcher.DispatchTurnEvals(ctx, defs, evalCtx)
+	}
+	if err != nil {
+		return nil
+	}
+	return results
+}
+
+// RunAssertionsAsConversationResults converts assertion configs to EvalDefs,
+// runs them through the dispatcher, and wraps results in ConversationValidationResult.
+func (h *PackEvalHook) RunAssertionsAsConversationResults(
+	ctx context.Context,
+	assertionConfigs []assertions.AssertionConfig,
+	messages []types.Message,
+	turnIndex int,
+	sessionID string,
+	trigger evals.EvalTrigger,
+) []assertions.ConversationValidationResult {
+	results := h.RunAssertionsAsEvals(ctx, assertionConfigs, messages, turnIndex, sessionID, trigger)
+	return h.adapter.Convert(results)
+}
+
 // buildEvalContext constructs an EvalContext from Arena messages.
 func (h *PackEvalHook) buildEvalContext(
 	messages []types.Message,
@@ -97,21 +171,16 @@ func (h *PackEvalHook) buildEvalContext(
 ) *evals.EvalContext {
 	// Extract current output from the last assistant message
 	var currentOutput string
-	var toolCalls []evals.ToolCallRecord
+	toolCalls := extractToolCalls(messages)
 
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].Role == "assistant" {
 			currentOutput = messages[i].Content
-			// Extract tool calls
-			for _, tc := range messages[i].ToolCalls {
-				toolCalls = append(toolCalls, evals.ToolCallRecord{
-					TurnIndex: i,
-					ToolName:  tc.Name,
-				})
-			}
 			break
 		}
 	}
+
+	extras := extractWorkflowExtras(messages)
 
 	return &evals.EvalContext{
 		Messages:      convertToEvalMessages(messages),
@@ -120,7 +189,89 @@ func (h *PackEvalHook) buildEvalContext(
 		ToolCalls:     toolCalls,
 		SessionID:     sessionID,
 		PromptID:      h.taskType,
+		Extras:        extras,
 	}
+}
+
+// extractToolCalls builds a full ToolCallRecord list from assistant tool calls,
+// matching with tool-role result messages for Arguments, Result, and Error fields.
+func extractToolCalls(messages []types.Message) []evals.ToolCallRecord {
+	toolResults := buildToolResultMap(messages)
+
+	var toolCalls []evals.ToolCallRecord
+	for i := range messages {
+		if messages[i].Role != "assistant" {
+			continue
+		}
+		for _, tc := range messages[i].ToolCalls {
+			toolCalls = append(toolCalls, buildToolCallRecord(tc, i, toolResults))
+		}
+	}
+
+	return toolCalls
+}
+
+// buildToolResultMap creates a map of tool call ID → result message from tool-role messages.
+func buildToolResultMap(messages []types.Message) map[string]types.Message {
+	toolResults := make(map[string]types.Message)
+	for i := range messages {
+		if messages[i].Role == "tool" && messages[i].ToolResult != nil {
+			toolResults[messages[i].ToolResult.ID] = messages[i]
+		}
+	}
+	return toolResults
+}
+
+// buildToolCallRecord creates a ToolCallRecord from a tool call and its result.
+func buildToolCallRecord(
+	tc types.MessageToolCall, turnIndex int, toolResults map[string]types.Message,
+) evals.ToolCallRecord {
+	record := evals.ToolCallRecord{
+		TurnIndex: turnIndex,
+		ToolName:  tc.Name,
+	}
+	if len(tc.Args) > 0 {
+		record.Arguments = parseJSONArgs(tc.Args)
+	}
+	if resultMsg, ok := toolResults[tc.ID]; ok {
+		record.Result = resultMsg.Content
+		if resultMsg.ToolResult != nil && resultMsg.ToolResult.Error != "" {
+			record.Error = resultMsg.ToolResult.Error
+		}
+	}
+	return record
+}
+
+// parseJSONArgs parses JSON bytes into a map, returning nil on failure.
+func parseJSONArgs(data []byte) map[string]any {
+	var args map[string]any
+	if err := json.Unmarshal(data, &args); err != nil {
+		return nil
+	}
+	return args
+}
+
+// extractWorkflowExtras pulls workflow metadata from message Meta fields.
+func extractWorkflowExtras(messages []types.Message) map[string]any {
+	extras := make(map[string]any)
+	for i := range messages {
+		if messages[i].Meta == nil {
+			continue
+		}
+		if state, ok := messages[i].Meta["_workflow_state"]; ok {
+			extras["workflow_state"] = state
+		}
+		if transitions, ok := messages[i].Meta["_workflow_transitions"]; ok {
+			extras["workflow_transitions"] = transitions
+		}
+		if complete, ok := messages[i].Meta["_workflow_complete"]; ok {
+			extras["workflow_complete"] = complete
+		}
+	}
+	if len(extras) == 0 {
+		return nil
+	}
+	return extras
 }
 
 // convertToEvalMessages converts Arena types.Message to evals types.Message.

--- a/tools/arena/engine/pack_eval_hook_test.go
+++ b/tools/arena/engine/pack_eval_hook_test.go
@@ -407,3 +407,17 @@ func TestExtractWorkflowExtras_NilMeta(t *testing.T) {
 	extras := extractWorkflowExtras(messages)
 	assert.Nil(t, extras)
 }
+
+func TestPackEvalHook_NilReceiver(t *testing.T) {
+	var hook *PackEvalHook
+	ctx := context.Background()
+	msgs := []types.Message{{Role: "assistant", Content: "hello"}}
+	configs := []assertions.AssertionConfig{{Type: "contains", Params: map[string]interface{}{"value": "hello"}}}
+
+	assert.False(t, hook.HasEvals())
+	assert.Nil(t, hook.RunTurnEvals(ctx, msgs, 0, "s1"))
+	assert.Nil(t, hook.RunSessionEvals(ctx, msgs, "s1"))
+	assert.Nil(t, hook.RunConversationEvals(ctx, msgs, "s1"))
+	assert.Nil(t, hook.RunAssertionsAsEvals(ctx, configs, msgs, 0, "s1", evals.TriggerEveryTurn))
+	assert.Nil(t, hook.RunAssertionsAsConversationResults(ctx, configs, msgs, 0, "s1", evals.TriggerEveryTurn))
+}

--- a/tools/arena/engine/pack_eval_hook_test.go
+++ b/tools/arena/engine/pack_eval_hook_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -195,4 +196,214 @@ func TestRunSessionEvals_WithValidHandler(t *testing.T) {
 	results := hook.RunSessionEvals(context.Background(), messages, "session-1")
 	require.NotNil(t, results, "should return results when session evals are configured")
 	assert.Len(t, results, 1)
+}
+
+func TestRunConversationEvals_NoEvals(t *testing.T) {
+	hook := NewPackEvalHook(newTestRegistry(), nil, false, nil, "chat")
+	results := hook.RunConversationEvals(context.Background(), nil, "session-1")
+	assert.Nil(t, results)
+}
+
+func TestRunConversationEvals_WithValidHandler(t *testing.T) {
+	defs := []evals.EvalDef{
+		{ID: "eval-1", Type: "test_handler", Trigger: evals.TriggerOnConversationComplete},
+	}
+	hook := NewPackEvalHook(newTestRegistry(), defs, false, nil, "chat")
+
+	messages := []types.Message{
+		types.NewUserMessage("hello"),
+		types.NewAssistantMessage("goodbye"),
+	}
+
+	results := hook.RunConversationEvals(context.Background(), messages, "session-1")
+	require.NotNil(t, results)
+	assert.Len(t, results, 1)
+}
+
+func TestRunConversationEvals_EmptyMessages(t *testing.T) {
+	defs := []evals.EvalDef{
+		{ID: "eval-1", Type: "test_handler", Trigger: evals.TriggerOnConversationComplete},
+	}
+	hook := NewPackEvalHook(newTestRegistry(), defs, false, nil, "chat")
+
+	results := hook.RunConversationEvals(context.Background(), []types.Message{}, "session-1")
+	require.NotNil(t, results)
+	assert.Len(t, results, 1)
+}
+
+func TestRunAssertionsAsEvals_EmptyAssertions(t *testing.T) {
+	hook := NewPackEvalHook(newTestRegistry(), sampleDefs(), false, nil, "chat")
+	results := hook.RunAssertionsAsEvals(
+		context.Background(), nil, nil, 0, "session-1", evals.TriggerEveryTurn)
+	assert.Nil(t, results)
+}
+
+func TestRunAssertionsAsEvals_ConversationTrigger(t *testing.T) {
+	hook := NewPackEvalHook(newTestRegistry(), sampleDefs(), false, nil, "chat")
+
+	cfgs := []assertions.AssertionConfig{
+		{Type: "test_handler", Params: map[string]interface{}{}},
+	}
+	messages := []types.Message{
+		types.NewUserMessage("hi"),
+		types.NewAssistantMessage("hello"),
+	}
+
+	results := hook.RunAssertionsAsEvals(
+		context.Background(), cfgs, messages, 1, "session-1",
+		evals.TriggerOnConversationComplete)
+	require.NotNil(t, results)
+	assert.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+}
+
+func TestRunAssertionsAsEvals_TurnTrigger(t *testing.T) {
+	hook := NewPackEvalHook(newTestRegistry(), sampleDefs(), false, nil, "chat")
+
+	cfgs := []assertions.AssertionConfig{
+		{Type: "test_handler", Params: map[string]interface{}{}},
+	}
+	messages := []types.Message{
+		types.NewAssistantMessage("hello"),
+	}
+
+	results := hook.RunAssertionsAsEvals(
+		context.Background(), cfgs, messages, 0, "session-1",
+		evals.TriggerEveryTurn)
+	require.NotNil(t, results)
+	assert.Len(t, results, 1)
+}
+
+func TestRunAssertionsAsConversationResults(t *testing.T) {
+	hook := NewPackEvalHook(newTestRegistry(), sampleDefs(), false, nil, "chat")
+
+	cfgs := []assertions.AssertionConfig{
+		{Type: "test_handler", Params: map[string]interface{}{}},
+	}
+	messages := []types.Message{
+		types.NewAssistantMessage("hello"),
+	}
+
+	results := hook.RunAssertionsAsConversationResults(
+		context.Background(), cfgs, messages, 0, "session-1",
+		evals.TriggerEveryTurn)
+	require.NotNil(t, results)
+	assert.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+}
+
+func TestExtractToolCalls_WithResults(t *testing.T) {
+	messages := []types.Message{
+		types.NewUserMessage("search"),
+		{
+			Role:    "assistant",
+			Content: "searching...",
+			ToolCalls: []types.MessageToolCall{
+				{ID: "tc-1", Name: "search", Args: []byte(`{"q":"cats"}`)},
+			},
+		},
+		{
+			Role:    "tool",
+			Content: "found 3 results",
+			ToolResult: &types.MessageToolResult{
+				ID: "tc-1",
+			},
+		},
+	}
+
+	toolCalls := extractToolCalls(messages)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "search", toolCalls[0].ToolName)
+	assert.Equal(t, 1, toolCalls[0].TurnIndex)
+	assert.Equal(t, "cats", toolCalls[0].Arguments["q"])
+	assert.Equal(t, "found 3 results", toolCalls[0].Result)
+}
+
+func TestExtractToolCalls_WithError(t *testing.T) {
+	messages := []types.Message{
+		{
+			Role:    "assistant",
+			Content: "calling tool",
+			ToolCalls: []types.MessageToolCall{
+				{ID: "tc-1", Name: "fail_tool", Args: []byte(`{}`)},
+			},
+		},
+		{
+			Role:    "tool",
+			Content: "",
+			ToolResult: &types.MessageToolResult{
+				ID:    "tc-1",
+				Error: "tool failed",
+			},
+		},
+	}
+
+	toolCalls := extractToolCalls(messages)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "tool failed", toolCalls[0].Error)
+}
+
+func TestExtractToolCalls_NoMatchingResult(t *testing.T) {
+	messages := []types.Message{
+		{
+			Role:    "assistant",
+			Content: "calling",
+			ToolCalls: []types.MessageToolCall{
+				{ID: "tc-1", Name: "search"},
+			},
+		},
+	}
+
+	toolCalls := extractToolCalls(messages)
+	require.Len(t, toolCalls, 1)
+	assert.Empty(t, toolCalls[0].Result)
+}
+
+func TestParseJSONArgs_Valid(t *testing.T) {
+	result := parseJSONArgs([]byte(`{"key":"value","num":42}`))
+	assert.Equal(t, "value", result["key"])
+	assert.Equal(t, float64(42), result["num"])
+}
+
+func TestParseJSONArgs_Invalid(t *testing.T) {
+	result := parseJSONArgs([]byte(`not json`))
+	assert.Nil(t, result)
+}
+
+func TestExtractWorkflowExtras_AllFields(t *testing.T) {
+	messages := []types.Message{
+		{
+			Role: "assistant",
+			Meta: map[string]any{
+				"_workflow_state":       "greeting",
+				"_workflow_transitions": []string{"init", "greeting"},
+				"_workflow_complete":    true,
+			},
+		},
+	}
+
+	extras := extractWorkflowExtras(messages)
+	require.NotNil(t, extras)
+	assert.Equal(t, "greeting", extras["workflow_state"])
+	assert.Equal(t, []string{"init", "greeting"}, extras["workflow_transitions"])
+	assert.Equal(t, true, extras["workflow_complete"])
+}
+
+func TestExtractWorkflowExtras_NoWorkflowMeta(t *testing.T) {
+	messages := []types.Message{
+		{Role: "assistant", Meta: map[string]any{"other": "data"}},
+		{Role: "user"},
+	}
+
+	extras := extractWorkflowExtras(messages)
+	assert.Nil(t, extras)
+}
+
+func TestExtractWorkflowExtras_NilMeta(t *testing.T) {
+	messages := []types.Message{
+		{Role: "assistant"},
+	}
+
+	extras := extractWorkflowExtras(messages)
+	assert.Nil(t, extras)
 }

--- a/tools/arena/engine/types.go
+++ b/tools/arena/engine/types.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
 	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
@@ -55,6 +56,10 @@ type RunResult struct {
 
 	// Conversation-level assertions evaluated after the conversation completes (summary format)
 	ConversationAssertions AssertionsSummary `json:"conversation_assertions,omitempty"`
+
+	// Eval results from the unified eval pipeline (Phase 3).
+	// Carried through for downstream consumers.
+	EvalResults []evals.EvalResult `json:"eval_results,omitempty"`
 
 	// A2A agent metadata (populated from config for report rendering)
 	A2AAgents []A2AAgentInfo `json:"A2AAgents,omitempty"`

--- a/tools/arena/results/utils.go
+++ b/tools/arena/results/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
 )
 
@@ -140,6 +141,14 @@ func AllAssertionsPassed(result *engine.RunResult) bool {
 					return false
 				}
 			}
+			// Also check eval results (Phase 3 dual-write)
+			if evalResults, ok := meta["eval_results"].([]evals.EvalResult); ok {
+				for j := range evalResults {
+					if !evalResults[j].Passed {
+						return false
+					}
+				}
+			}
 		}
 	}
 
@@ -160,6 +169,10 @@ func HasAssertions(result *engine.RunResult) bool {
 	for i := range result.Messages {
 		if meta := result.Messages[i].Meta; meta != nil {
 			if _, ok := meta["assertions"].(map[string]interface{}); ok {
+				return true
+			}
+			// Also check eval results (Phase 3 dual-write)
+			if _, ok := meta["eval_results"]; ok {
 				return true
 			}
 		}

--- a/tools/arena/statestore/metadata.go
+++ b/tools/arena/statestore/metadata.go
@@ -7,6 +7,7 @@ import (
 
 	runtimestore "github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
 )
 
 // SaveMetadata stores Arena-specific metadata for a run
@@ -100,8 +101,17 @@ func (s *ArenaStateStore) GetResult(ctx context.Context, runID string) (*RunResu
 		RecordingPath: arenaState.RunMetadata.RecordingPath,
 		A2AAgents:     arenaState.RunMetadata.A2AAgents,
 
-		// Conversation-level assertions (summary)
-		ConversationAssertions: buildConversationAssertionsSummary(arenaState.RunMetadata.ConversationAssertionResults),
+		// Eval results (carried through for downstream consumers)
+		EvalResults: arenaState.RunMetadata.EvalResults,
+	}
+
+	// Prefer eval results when available (Phase 3), otherwise fall back to old assertions
+	if len(arenaState.RunMetadata.EvalResults) > 0 {
+		converted := assertions.ConvertEvalResults(arenaState.RunMetadata.EvalResults)
+		result.ConversationAssertions = buildConversationAssertionsSummary(converted)
+	} else {
+		result.ConversationAssertions = buildConversationAssertionsSummary(
+			arenaState.RunMetadata.ConversationAssertionResults)
 	}
 
 	return result, nil

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	runtimestore "github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -82,6 +83,11 @@ type RunMetadata struct {
 
 	// Conversation-level assertions (evaluated after conversation completes)
 	ConversationAssertionResults []ConversationValidationResult `json:"conv_assertions_results,omitempty"`
+
+	// Eval results from the new EvalRunner dual-write path (Phase 2).
+	// Phase 3: these flow through the full data pipeline and are preferred
+	// over ConversationAssertionResults when building AssertionsSummary.
+	EvalResults []evals.EvalResult `json:"eval_results,omitempty"`
 
 	// A2A agent metadata (populated from config for report rendering)
 	A2AAgents []A2AAgentInfo `json:"a2a_agents,omitempty"`
@@ -553,6 +559,11 @@ type RunResult struct {
 
 	// Conversation-level assertions evaluated after the conversation completes (summary format)
 	ConversationAssertions AssertionsSummary `json:"conversation_assertions,omitempty"`
+
+	// Eval results from the unified eval pipeline (Phase 3).
+	// Carried through for downstream consumers; used to build ConversationAssertions
+	// when available (preferred over old-format assertion results).
+	EvalResults []evals.EvalResult `json:"eval_results,omitempty"`
 
 	// A2A agent metadata (populated from config for report rendering)
 	A2AAgents []A2AAgentInfo `json:"A2AAgents,omitempty"`

--- a/tools/arena/turnexecutors/interfaces.go
+++ b/tools/arena/turnexecutors/interfaces.go
@@ -90,7 +90,8 @@ type TurnRequest struct {
 	SelfPlayPersona string                   // SelfPlayExecutor: the persona to use
 
 	// Assertions to validate after turn execution
-	Assertions []assertions.AssertionConfig
+	Assertions     []assertions.AssertionConfig
+	TurnEvalRunner interface{} // Optional stages.TurnEvalRunner for dual-write (Phase 2)
 
 	// Observability
 	EventBus *events.EventBus

--- a/tools/arena/turnexecutors/pipeline_executor.go
+++ b/tools/arena/turnexecutors/pipeline_executor.go
@@ -335,7 +335,11 @@ func (e *PipelineExecutor) buildStagePipeline(
 	// 9. Assertion stage - must run before state store save
 	if len(req.Assertions) > 0 {
 		assertionRegistry := arenaassertions.NewArenaAssertionRegistry()
-		stages = append(stages, arenastages.NewArenaAssertionStage(assertionRegistry, req.Assertions))
+		assertionStage := arenastages.NewArenaAssertionStage(assertionRegistry, req.Assertions)
+		if runner, ok := req.TurnEvalRunner.(arenastages.TurnEvalRunner); ok {
+			assertionStage.WithTurnEvalRunner(runner, req.ConversationID)
+		}
+		stages = append(stages, assertionStage)
 	}
 
 	// 10. Arena state store save - saves messages with assertion metadata

--- a/tools/arena/turnexecutors/scripted_executor.go
+++ b/tools/arena/turnexecutors/scripted_executor.go
@@ -257,7 +257,11 @@ func (e *ScriptedExecutor) buildStreamingStages(req *TurnRequest) (*stage.Stream
 	// Assertion stage - must run before state store save
 	if len(req.Assertions) > 0 {
 		assertionRegistry := arenaassertions.NewArenaAssertionRegistry()
-		stages = append(stages, arenastages.NewArenaAssertionStage(assertionRegistry, req.Assertions))
+		assertionStage := arenastages.NewArenaAssertionStage(assertionRegistry, req.Assertions)
+		if runner, ok := req.TurnEvalRunner.(arenastages.TurnEvalRunner); ok {
+			assertionStage.WithTurnEvalRunner(runner, req.ConversationID)
+		}
+		stages = append(stages, assertionStage)
 	}
 
 	// Arena state store save - saves messages with assertion metadata

--- a/tools/arena/turnexecutors/scripted_executor_test.go
+++ b/tools/arena/turnexecutors/scripted_executor_test.go
@@ -437,3 +437,33 @@ func TestScriptedExecutor_ExecuteTurn_SetsTimestamp(t *testing.T) {
 
 	mockProvider.AssertExpectations(t)
 }
+
+func TestExtractFinishReason_Nil(t *testing.T) {
+	assert.Nil(t, extractFinishReason(nil))
+}
+
+func TestExtractFinishReason_Present(t *testing.T) {
+	meta := map[string]interface{}{"finish_reason": "stop"}
+	result := extractFinishReason(meta)
+	require.NotNil(t, result)
+	assert.Equal(t, "stop", *result)
+}
+
+func TestExtractFinishReason_Missing(t *testing.T) {
+	meta := map[string]interface{}{"other": "value"}
+	assert.Nil(t, extractFinishReason(meta))
+}
+
+func TestExtractTokenCount_Nil(t *testing.T) {
+	assert.Equal(t, 0, extractTokenCount(nil))
+}
+
+func TestExtractTokenCount_Present(t *testing.T) {
+	meta := map[string]interface{}{"token_count": 42}
+	assert.Equal(t, 42, extractTokenCount(meta))
+}
+
+func TestExtractTokenCount_Missing(t *testing.T) {
+	meta := map[string]interface{}{"other": "value"}
+	assert.Equal(t, 0, extractTokenCount(meta))
+}


### PR DESCRIPTION
## Summary

- **Phase 0**: Shared types (`EvalDef`, `EvalResult`, `EvalContext`) in `runtime/evals/`
- **Phase 1**: Ported 24 arena assertion validators to eval handlers in `runtime/evals/handlers/`
- **Phase 2**: Dual-write — assertions produce both old-format (`ConversationAssertionResults`) and new-format (`EvalResults`) results
- **Phase 3**: Flow `EvalResults` through the full data pipeline (`ConversationResult` → `RunMetadata` → `RunResult` → renderers) and prefer them over old assertions when building `AssertionsSummary`

### Phase 3 changes (this PR's latest commit)

- Added `EvalResults` field to `RunMetadata`, `statestore.RunResult`, and `engine.RunResult`
- `GetResult()` now prefers `EvalResults` via `assertions.ConvertEvalResults()` when building the conversation assertions summary
- Turn-level utilities (`AllAssertionsPassed`, `HasAssertions`) also check `msg.Meta["eval_results"]`
- `PackEvalAdapter` delegates to shared `assertions.ConvertEvalResults()` to eliminate duplication
- Renderers unchanged — they continue reading `AssertionsSummary` (backward compatible)

## Test plan

- [x] New `assertions/eval_adapter_test.go` — tests conversion (empty, passing, failing, multiple)
- [x] New statestore tests — `GetResult` prefers eval results, falls back to old assertions
- [x] New results/utils tests — `AllAssertionsPassed` and `HasAssertions` with eval_results in meta
- [x] All 29 arena packages pass (`go test ./... -count=1`)
- [x] Lint clean on new code (`golangci-lint run --new-from-rev`)
- [x] All changed files meet ≥80% coverage threshold