### PR TITLE
fix(sdk): wire EventEmitter on pipeline builder for pipeline-level spans

### DIFF
--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -272,6 +272,11 @@ func buildStreamPipelineInternal(cfg *Config) (*stage.StreamPipeline, error) {
 		}
 	}
 
+	// Wire event emitter so the pipeline emits PipelineStarted/Completed events.
+	if cfg.EventEmitter != nil {
+		builder.WithEventEmitter(cfg.EventEmitter)
+	}
+
 	// Build and return the StreamPipeline directly
 	streamPipeline, err := builder.Chain(stages...).Build()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Wire `WithEventEmitter` on the pipeline builder so `PipelineStarted`/`PipelineCompleted` events are emitted, producing `promptkit.pipeline` OTel spans
- Update integration test to assert the pipeline span is present

## Test plan

- [x] `TestOTelIntegration_SpansFromConversation` now captures both `promptkit.pipeline` and `promptkit.provider.*` spans
- [x] All SDK tests pass with race detector
- [x] Pre-commit: lint clean, build clean, coverage ≥80%