### PR TITLE
refactor(config): collapse 7 identical schema validator functions into 1

### DIFF
--- a/pkg/config/schema_validator.go
+++ b/pkg/config/schema_validator.go
@@ -262,9 +262,10 @@ func validateJSONWithSchema(jsonData []byte, schema *gojsonschema.Schema) (*Sche
 	return validationResult, nil
 }
 
-// ValidateArenaConfig validates an Arena configuration against its schema
-func ValidateArenaConfig(yamlData []byte) error {
-	result, err := ValidateWithSchema(yamlData, ConfigTypeArena)
+// ValidateConfig validates YAML data against the JSON schema for the given ConfigType.
+// It returns a formatted error listing all schema violations, or nil if the data is valid.
+func ValidateConfig(configType ConfigType, yamlData []byte) error {
+	result, err := ValidateWithSchema(yamlData, configType)
 	if err != nil {
 		return err
 	}
@@ -274,119 +275,35 @@ func ValidateArenaConfig(yamlData []byte) error {
 		for _, e := range result.Errors {
 			errorMessages = append(errorMessages, fmt.Sprintf(errorFormat, e.Error()))
 		}
-		return fmt.Errorf("arena configuration does not match schema:\n%s", strings.Join(errorMessages, "\n"))
+		return fmt.Errorf("%s configuration does not match schema:\n%s",
+			string(configType), strings.Join(errorMessages, "\n"))
 	}
 
 	return nil
 }
 
-// ValidateScenario validates a Scenario configuration against its schema
-func ValidateScenario(yamlData []byte) error {
-	result, err := ValidateWithSchema(yamlData, ConfigTypeScenario)
-	if err != nil {
-		return err
-	}
+// ValidateArenaConfig validates an Arena configuration against its schema.
+func ValidateArenaConfig(yamlData []byte) error { return ValidateConfig(ConfigTypeArena, yamlData) }
 
-	if !result.Valid {
-		var errorMessages []string
-		for _, e := range result.Errors {
-			errorMessages = append(errorMessages, fmt.Sprintf(errorFormat, e.Error()))
-		}
-		return fmt.Errorf("scenario configuration does not match schema:\n%s", strings.Join(errorMessages, "\n"))
-	}
+// ValidateScenario validates a Scenario configuration against its schema.
+func ValidateScenario(yamlData []byte) error { return ValidateConfig(ConfigTypeScenario, yamlData) }
 
-	return nil
-}
+// ValidateEval validates an Eval configuration against its schema.
+func ValidateEval(yamlData []byte) error { return ValidateConfig(ConfigTypeEval, yamlData) }
 
-// ValidateEval validates an Eval configuration against its schema
-func ValidateEval(yamlData []byte) error {
-	result, err := ValidateWithSchema(yamlData, ConfigTypeEval)
-	if err != nil {
-		return err
-	}
+// ValidateProvider validates a Provider configuration against its schema.
+func ValidateProvider(yamlData []byte) error { return ValidateConfig(ConfigTypeProvider, yamlData) }
 
-	if !result.Valid {
-		var errorMessages []string
-		for _, e := range result.Errors {
-			errorMessages = append(errorMessages, fmt.Sprintf(errorFormat, e.Error()))
-		}
-		return fmt.Errorf("eval configuration does not match schema:\n%s", strings.Join(errorMessages, "\n"))
-	}
-
-	return nil
-}
-
-// ValidateProvider validates a Provider configuration against its schema
-func ValidateProvider(yamlData []byte) error {
-	result, err := ValidateWithSchema(yamlData, ConfigTypeProvider)
-	if err != nil {
-		return err
-	}
-
-	if !result.Valid {
-		var errorMessages []string
-		for _, e := range result.Errors {
-			errorMessages = append(errorMessages, fmt.Sprintf(errorFormat, e.Error()))
-		}
-		return fmt.Errorf("provider configuration does not match schema:\n%s", strings.Join(errorMessages, "\n"))
-	}
-
-	return nil
-}
-
-// ValidatePromptConfig validates a PromptConfig configuration against its schema
+// ValidatePromptConfig validates a PromptConfig configuration against its schema.
 func ValidatePromptConfig(yamlData []byte) error {
-	result, err := ValidateWithSchema(yamlData, ConfigTypePromptConfig)
-	if err != nil {
-		return err
-	}
-
-	if !result.Valid {
-		var errorMessages []string
-		for _, e := range result.Errors {
-			errorMessages = append(errorMessages, fmt.Sprintf(errorFormat, e.Error()))
-		}
-		return fmt.Errorf("promptconfig configuration does not match schema:\n%s", strings.Join(errorMessages, "\n"))
-	}
-
-	return nil
+	return ValidateConfig(ConfigTypePromptConfig, yamlData)
 }
 
-// ValidateTool validates a Tool configuration against its schema
-func ValidateTool(yamlData []byte) error {
-	result, err := ValidateWithSchema(yamlData, ConfigTypeTool)
-	if err != nil {
-		return err
-	}
+// ValidateTool validates a Tool configuration against its schema.
+func ValidateTool(yamlData []byte) error { return ValidateConfig(ConfigTypeTool, yamlData) }
 
-	if !result.Valid {
-		var errorMessages []string
-		for _, e := range result.Errors {
-			errorMessages = append(errorMessages, fmt.Sprintf(errorFormat, e.Error()))
-		}
-		return fmt.Errorf("tool configuration does not match schema:\n%s", strings.Join(errorMessages, "\n"))
-	}
-
-	return nil
-}
-
-// ValidatePersona validates a Persona configuration against its schema
-func ValidatePersona(yamlData []byte) error {
-	result, err := ValidateWithSchema(yamlData, ConfigTypePersona)
-	if err != nil {
-		return err
-	}
-
-	if !result.Valid {
-		var errorMessages []string
-		for _, e := range result.Errors {
-			errorMessages = append(errorMessages, fmt.Sprintf(errorFormat, e.Error()))
-		}
-		return fmt.Errorf("persona configuration does not match schema:\n%s", strings.Join(errorMessages, "\n"))
-	}
-
-	return nil
-}
+// ValidatePersona validates a Persona configuration against its schema.
+func ValidatePersona(yamlData []byte) error { return ValidateConfig(ConfigTypePersona, yamlData) }
 
 // DetectConfigType attempts to detect the configuration type from YAML data
 func DetectConfigType(yamlData []byte) (ConfigType, error) {


### PR DESCRIPTION
## Summary
- Extracts a single `ValidateConfig(configType ConfigType, yamlData []byte) error` function containing the shared validation-and-error-formatting logic that was duplicated across 7 functions.
- Retains all 7 original public functions (`ValidateArenaConfig`, `ValidateScenario`, `ValidateEval`, `ValidateProvider`, `ValidatePromptConfig`, `ValidateTool`, `ValidatePersona`) as thin one-liner wrappers, preserving full backward compatibility.
- Net reduction of ~83 lines of duplicated code.

Closes #472

## Test plan
- [x] Existing unit tests in `pkg/config/schema_validator_test.go` pass (88.4% coverage on changed file)
- [x] `golangci-lint run --new-from-rev=HEAD ./pkg/...` reports 0 issues
- [x] Pre-commit hook passes (lint, build, test, coverage)