### PR TITLE
perf(sdk): fix DuplexSession.Done() goroutine leak

### DIFF
--- a/sdk/session/duplex_session_test.go
+++ b/sdk/session/duplex_session_test.go
@@ -489,6 +489,27 @@ func TestDuplexSession_Done(t *testing.T) {
 	}
 }
 
+func TestDuplexSession_Done_ReturnsSameChannel(t *testing.T) {
+	provider := mock.NewStreamingProvider("mock-provider", "mock-model", false)
+	session, err := NewDuplexSession(context.Background(), &DuplexSessionConfig{
+		Provider:        provider,
+		Config:          &providers.StreamingInputConfig{},
+		PipelineBuilder: testPipelineBuilder,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	// Multiple calls to Done() must return the same channel (no goroutine leak)
+	done1 := session.Done()
+	done2 := session.Done()
+	done3 := session.Done()
+
+	assert.NotNil(t, done1)
+	// All calls must return the exact same channel instance
+	assert.Equal(t, done1, done2, "Done() should return the same channel on repeated calls")
+	assert.Equal(t, done1, done3, "Done() should return the same channel on repeated calls")
+}
+
 func TestDuplexSession_ExecutePipeline(t *testing.T) {
 	// Skip - executePipeline requires complex bidirectional streaming setup
 	t.Skip("executePipeline requires full pipeline and stream configuration")


### PR DESCRIPTION
## Summary
- Fixes #494: `DuplexSession.Done()` previously spawned a new goroutine on every call, creating a goroutine leak since each goroutine blocks on `select` waiting for stream closure
- Uses `sync.Once` to initialize the done channel once and returns the same channel on subsequent calls
- Refactors `streamChunkToStreamElement` to reduce cognitive complexity by extracting `applyVideoMetadata`, `applyImageMetadata`, and `convertMediaDelta` helper functions
- Removes stale `//nolint:unused` directive on `streamBufferSize`

## Test plan
- [x] Added `TestDuplexSession_Done_ReturnsSameChannel` test verifying multiple `Done()` calls return the same channel
- [x] All existing session tests pass with race detector (`go test ./sdk/session/... -count=1 -race`)
- [x] Coverage on changed file: 90.8% (threshold: 80%)
- [x] Lint passes: `golangci-lint run ./sdk/session/...` reports 0 issues