### PR TITLE
cleanup(sdk): remove dead code handlerAdapter, finalizeStreamHistory

### DIFF
--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -39,6 +39,12 @@ const (
 	errUnaryModeRequired  = "Send() only available in unary mode; use OpenDuplex() for duplex streaming"
 )
 
+// Role constants for message types.
+const roleAssistant = "assistant"
+
+// Content type constants.
+const contentTypeText = "text"
+
 // SessionMode represents the conversation's session mode.
 type SessionMode int
 
@@ -323,7 +329,6 @@ func (c *Conversation) buildPipelineWithParams(
 
 // buildStreamPipelineWithParams builds a stage pipeline directly for duplex sessions.
 // Returns *stage.StreamPipeline which DuplexSession uses directly without wrapping.
-//
 func (c *Conversation) buildStreamPipelineWithParams(
 	store statestore.Store,
 	conversationID string,
@@ -441,7 +446,7 @@ func (c *Conversation) buildResponse(result *rtpipeline.ExecutionResult, startTi
 	var assistantMsg *types.Message
 	if result.Response != nil {
 		assistantMsg = &types.Message{
-			Role:     "assistant",
+			Role:     roleAssistant,
 			Content:  result.Response.Content,
 			Parts:    result.Response.Parts,
 			CostInfo: &result.CostInfo,
@@ -468,7 +473,7 @@ func (c *Conversation) buildResponse(result *rtpipeline.ExecutionResult, startTi
 	// Extract validation results from the assistant message in history
 	// The DynamicValidatorMiddleware adds validations to the last assistant message
 	for i := len(result.Messages) - 1; i >= 0; i-- {
-		if result.Messages[i].Role == "assistant" && len(result.Messages[i].Validations) > 0 {
+		if result.Messages[i].Role == roleAssistant && len(result.Messages[i].Validations) > 0 {
 			resp.validations = result.Messages[i].Validations
 			break
 		}
@@ -795,7 +800,7 @@ func (c *Conversation) Fork() *Conversation {
 		asyncHandlers:  asyncHandlers,
 		pendingStore:   sdktools.NewPendingStore(),
 		resolvedStore:  sdktools.NewResolvedStore(),
-		mcpRegistry:    c.mcpRegistry, // Share MCP registry
+		mcpRegistry:    c.mcpRegistry,  // Share MCP registry
 		hookRegistry:   c.hookRegistry, // Share hook registry
 	}
 

--- a/sdk/conversation_test.go
+++ b/sdk/conversation_test.go
@@ -485,56 +485,6 @@ func TestGetVariables(t *testing.T) {
 	assert.Equal(t, "modified", val1)
 }
 
-func TestHandlerAdapter(t *testing.T) {
-	t.Run("name returns handler name", func(t *testing.T) {
-		adapter := &handlerAdapter{
-			name:    "test_handler",
-			handler: func(args map[string]any) (any, error) { return nil, nil },
-		}
-		assert.Equal(t, "test_handler", adapter.Name())
-	})
-
-	t.Run("execute calls handler", func(t *testing.T) {
-		called := false
-		adapter := &handlerAdapter{
-			name: "test",
-			handler: func(args map[string]any) (any, error) {
-				called = true
-				return map[string]string{"result": "success"}, nil
-			},
-		}
-
-		result, err := adapter.Execute(nil, []byte(`{"input": "test"}`))
-		assert.NoError(t, err)
-		assert.True(t, called)
-		assert.Contains(t, string(result), "success")
-	})
-
-	t.Run("execute returns handler error", func(t *testing.T) {
-		adapter := &handlerAdapter{
-			name: "test",
-			handler: func(args map[string]any) (any, error) {
-				return nil, errors.New("handler error")
-			},
-		}
-
-		_, err := adapter.Execute(nil, []byte(`{}`))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "handler error")
-	})
-
-	t.Run("execute returns parse error", func(t *testing.T) {
-		adapter := &handlerAdapter{
-			name:    "test",
-			handler: func(args map[string]any) (any, error) { return nil, nil },
-		}
-
-		_, err := adapter.Execute(nil, []byte(`invalid json`))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to parse")
-	})
-}
-
 func TestOnToolHTTP(t *testing.T) {
 	t.Run("registers HTTP handler", func(t *testing.T) {
 		conv := newTestConversation()
@@ -1808,9 +1758,8 @@ func TestBuildPipelineWithRAGContextOptions(t *testing.T) {
 				retrievalProvider: &mockEmbeddingProvider{},
 				retrievalTopK:     3,
 			},
-			mode:          UnaryMode,
-			handlers:      make(map[string]ToolHandler),
-
+			mode:     UnaryMode,
+			handlers: make(map[string]ToolHandler),
 		}
 
 		pipeline, err := conv.buildPipelineWithParams(store, "test-conv", nil, nil)
@@ -1833,9 +1782,8 @@ func TestBuildPipelineWithRAGContextOptions(t *testing.T) {
 				summarizeThreshold: 50,
 				summarizeBatchSize: 10,
 			},
-			mode:          UnaryMode,
-			handlers:      make(map[string]ToolHandler),
-
+			mode:     UnaryMode,
+			handlers: make(map[string]ToolHandler),
 		}
 
 		pipeline, err := conv.buildPipelineWithParams(store, "test-conv", nil, nil)
@@ -1855,14 +1803,13 @@ func TestBuildPipelineWithRAGContextOptions(t *testing.T) {
 				stateStore:         store,
 				contextWindow:      10,
 				retrievalProvider:  &mockEmbeddingProvider{},
-				retrievalTopK:     3,
+				retrievalTopK:      3,
 				summarizeProvider:  &mockSummarizeProvider{},
 				summarizeThreshold: 50,
 				summarizeBatchSize: 10,
 			},
-			mode:          UnaryMode,
-			handlers:      make(map[string]ToolHandler),
-
+			mode:     UnaryMode,
+			handlers: make(map[string]ToolHandler),
 		}
 
 		pipeline, err := conv.buildPipelineWithParams(store, "test-conv", nil, nil)

--- a/sdk/eval_middleware.go
+++ b/sdk/eval_middleware.go
@@ -112,7 +112,7 @@ func (em *evalMiddleware) buildEvalContext() *evals.EvalContext {
 		ctx.SessionID = em.conv.ID()
 
 		for i := len(ctx.Messages) - 1; i >= 0; i-- {
-			if ctx.Messages[i].Role == "assistant" {
+			if ctx.Messages[i].Role == roleAssistant {
 				ctx.CurrentOutput = ctx.Messages[i].GetContent()
 				break
 			}

--- a/sdk/internal/pack/load.go
+++ b/sdk/internal/pack/load.go
@@ -74,19 +74,19 @@ func (s *SkillSourceConfig) EffectiveDir() string {
 
 // Prompt represents a prompt definition within a pack.
 type Prompt struct {
-	ID             string         `json:"id"`
-	Name           string         `json:"name"`
-	Description    string         `json:"description"`
-	Version        string         `json:"version"`
-	SystemTemplate string         `json:"system_template"`
-	Variables      []Variable     `json:"variables,omitempty"`
-	Tools          []string       `json:"tools,omitempty"`
-	ToolPolicy     *ToolPolicy    `json:"tool_policy,omitempty"`
-	MediaConfig    *MediaConfig   `json:"media,omitempty"`
-	Parameters     *Parameters    `json:"parameters,omitempty"`
-	Validators     []Validator    `json:"validators,omitempty"`
+	ID             string          `json:"id"`
+	Name           string          `json:"name"`
+	Description    string          `json:"description"`
+	Version        string          `json:"version"`
+	SystemTemplate string          `json:"system_template"`
+	Variables      []Variable      `json:"variables,omitempty"`
+	Tools          []string        `json:"tools,omitempty"`
+	ToolPolicy     *ToolPolicy     `json:"tool_policy,omitempty"`
+	MediaConfig    *MediaConfig    `json:"media,omitempty"`
+	Parameters     *Parameters     `json:"parameters,omitempty"`
+	Validators     []Validator     `json:"validators,omitempty"`
 	Evals          []evals.EvalDef `json:"evals,omitempty"`
-	ModelOverrides map[string]any `json:"model_overrides,omitempty"`
+	ModelOverrides map[string]any  `json:"model_overrides,omitempty"`
 }
 
 // VariableBindingKind defines the type of resource a variable binds to.

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -158,6 +158,8 @@ func BuildStreamPipeline(cfg *Config) (*stage.StreamPipeline, error) {
 
 // buildStreamPipelineInternal creates a stage pipeline directly without wrapping.
 // Used by DuplexSession which handles streaming at the session level.
+//
+//nolint:gocognit // Complex pipeline construction logic
 func buildStreamPipelineInternal(cfg *Config) (*stage.StreamPipeline, error) {
 	logger.Info("Building stage-based pipeline",
 		"taskType", cfg.TaskType,

--- a/sdk/local_agent_executor.go
+++ b/sdk/local_agent_executor.go
@@ -13,5 +13,5 @@ func NewLocalAgentExecutor(members map[string]*Conversation) *LocalAgentExecutor
 
 // Name returns the executor name. Must be "a2a" to intercept A2A tool dispatches.
 func (e *LocalAgentExecutor) Name() string {
-	return "a2a"
+	return nsA2A
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -661,8 +661,8 @@ func Resume(conversationID, packPath, promptName string, opts ...Option) (*Conve
 
 	// Open conversation with the loaded state
 	// Add WithConversationID to preserve the original ID
-	optsWithID := append(opts, WithConversationID(conversationID))
-	conv, err := Open(packPath, promptName, optsWithID...)
+	opts = append(opts, WithConversationID(conversationID))
+	conv, err := Open(packPath, promptName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -679,7 +679,7 @@ func ensureA2ACapability(caps []Capability, cfg *config) []Capability {
 		return caps
 	}
 	for _, cap := range caps {
-		if cap.Name() == "a2a" {
+		if cap.Name() == nsA2A {
 			return caps
 		}
 	}

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -45,7 +45,6 @@ type duplexSession struct {
 	executionMu      sync.Mutex
 }
 
-//nolint:unused // Used by tests
 const streamBufferSize = 100 // Size of buffered channels for streaming
 
 // initConversationState initializes state for a new conversation if it doesn't exist.
@@ -429,6 +428,8 @@ func (s *duplexSession) ForkSession(
 // streamChunkToStreamElement converts a providers.StreamChunk to stage.StreamElement.
 // This is the boundary conversion for input data.
 // Routes media based on MIME type: video/* → VideoData, image/* → ImageData, audio/* → AudioData.
+//
+//nolint:gocognit // Complex media routing logic
 func streamChunkToStreamElement(chunk *providers.StreamChunk) stage.StreamElement {
 	elem := stage.StreamElement{
 		Metadata: make(map[string]interface{}),

--- a/sdk/tool_executors.go
+++ b/sdk/tool_executors.go
@@ -48,41 +48,6 @@ func (e *localExecutor) Execute(descriptor *tools.ToolDescriptor, args json.RawM
 	return resultJSON, nil
 }
 
-// handlerAdapter adapts an SDK ToolHandler to the runtime's tools.Executor interface.
-type handlerAdapter struct {
-	name    string
-	handler ToolHandler
-}
-
-// Name returns the tool name.
-func (a *handlerAdapter) Name() string {
-	return a.name
-}
-
-// Execute runs the handler with the given arguments.
-func (a *handlerAdapter) Execute(descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
-	// Parse args to map
-	var argsMap map[string]any
-	if err := json.Unmarshal(args, &argsMap); err != nil {
-		return nil, fmt.Errorf("failed to parse tool arguments: %w", err)
-	}
-
-	// Call handler
-	result, err := a.handler(argsMap)
-	if err != nil {
-		return nil, err
-	}
-
-	// Serialize result
-	resultJSON, err := json.Marshal(result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize tool result: %w", err)
-	}
-
-	return resultJSON, nil
-}
-
-// mcpHandlerAdapter adapts MCP tool calls to the runtime's tools.Executor interface.
 type mcpHandlerAdapter struct {
 	qualifiedName string // Namespaced name used as registry key (e.g. "mcp__fs__read_file")
 	rawName       string // Original MCP tool name sent to the server (e.g. "read_file")
@@ -121,7 +86,7 @@ func (a *mcpHandlerAdapter) Execute(descriptor *tools.ToolDescriptor, args json.
 
 	// Extract text content from response
 	var result any
-	if len(resp.Content) == 1 && resp.Content[0].Type == "text" {
+	if len(resp.Content) == 1 && resp.Content[0].Type == contentTypeText {
 		// Single text response - return as-is
 		result = resp.Content[0].Text
 	} else {


### PR DESCRIPTION
## Summary
- Remove unused `handlerAdapter` type and its methods from `sdk/tool_executors.go`
- Remove empty no-op `finalizeStreamHistory` method from `sdk/streaming.go` and its call site
- Remove corresponding `TestHandlerAdapter` test cases from `sdk/conversation_test.go`
- Fix pre-existing lint issues across sdk/ (goconst, gocritic, goimports, nolintlint, gocognit)

## Test plan
- [x] `golangci-lint run ./sdk/...` passes with 0 issues
- [x] `go test ./sdk/... -count=1` passes all tests
- [x] Pre-commit hook passes (lint, build, tests, coverage)
- [x] All changed files meet 80% coverage threshold

Closes #485