### PR TITLE
refactor(arena): extract schema-gen boilerplate into shared generator helper

### DIFF
--- a/tools/schema-gen/generators/arena.go
+++ b/tools/schema-gen/generators/arena.go
@@ -1,3 +1,4 @@
+// Package generators provides JSON schema generation functions for PromptKit configuration types.
 package generators
 
 import (
@@ -16,27 +17,13 @@ const (
 
 // GenerateArenaSchema generates the JSON Schema for Arena configuration
 func GenerateArenaSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties:  false,
-		ExpandedStruct:             true,
-		FieldNameTag:               "yaml",
-		RequiredFromJSONSchemaTags: false, // Use omitempty to determine required fields
-	}
-
-	schema := reflector.Reflect(&config.ArenaConfig{})
-
-	schema.Version = "https://json-schema.org/draft-07/schema"
-	schema.ID = schemaBaseURL + "/arena.json"
-	schema.Title = "PromptArena Configuration"
-	schema.Description = "Main configuration for PromptArena test suites"
-
-	// Allow the standard $schema field
-	allowSchemaField(schema)
-
-	// Add example
-	addArenaExample(schema)
-
-	return schema, nil
+	return Generate(&SchemaConfig{
+		Target:      &config.ArenaConfig{},
+		Filename:    "arena.json",
+		Title:       "PromptArena Configuration",
+		Description: "Main configuration for PromptArena test suites",
+		Customize:   addArenaExample,
+	})
 }
 
 func addArenaExample(schema *jsonschema.Schema) {

--- a/tools/schema-gen/generators/common.go
+++ b/tools/schema-gen/generators/common.go
@@ -7,14 +7,11 @@ import (
 
 // GenerateMetadataSchema generates the JSON Schema for Kubernetes ObjectMeta
 func GenerateMetadataSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		ExpandedStruct:            true,
-	}
+	reflector := newReflector("json")
 
 	schema := reflector.Reflect(&metav1.ObjectMeta{})
 
-	schema.ID = schemaBaseURL + "/common/metadata.json"
+	schema.ID = jsonschema.ID(schemaBaseURL + "/common/metadata.json")
 	schema.Title = "Kubernetes ObjectMeta"
 	schema.Description = "Kubernetes-style metadata for PromptKit resources"
 
@@ -24,7 +21,7 @@ func GenerateMetadataSchema() (interface{}, error) {
 // GenerateAssertionsSchema generates a placeholder for assertions schema
 func GenerateAssertionsSchema() (interface{}, error) {
 	schema := &jsonschema.Schema{
-		ID:          schemaBaseURL + "/common/assertions.json",
+		ID:          jsonschema.ID(schemaBaseURL + "/common/assertions.json"),
 		Title:       "PromptArena Assertions",
 		Description: "Assertion types for PromptArena scenarios",
 		Type:        "object",
@@ -36,7 +33,7 @@ func GenerateAssertionsSchema() (interface{}, error) {
 // GenerateMediaSchema generates a placeholder for media schema
 func GenerateMediaSchema() (interface{}, error) {
 	schema := &jsonschema.Schema{
-		ID:          schemaBaseURL + "/common/media.json",
+		ID:          jsonschema.ID(schemaBaseURL + "/common/media.json"),
 		Title:       "PromptKit Media Types",
 		Description: "Media content types for multimodal scenarios",
 		Type:        "object",

--- a/tools/schema-gen/generators/eval.go
+++ b/tools/schema-gen/generators/eval.go
@@ -8,25 +8,13 @@ import (
 
 // GenerateEvalSchema generates the JSON Schema for Eval configuration
 func GenerateEvalSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		ExpandedStruct:            true,
-		FieldNameTag:              "yaml",
-	}
-
-	schema := reflector.Reflect(&config.EvalConfig{})
-
-	schema.Version = "https://json-schema.org/draft-07/schema"
-	schema.ID = schemaBaseURL + "/eval.json"
-	schema.Title = "PromptArena Eval Configuration"
-	schema.Description = "Eval configuration for replaying and validating saved conversations"
-
-	// Allow the standard $schema field
-	allowSchemaField(schema)
-
-	addEvalExample(schema)
-
-	return schema, nil
+	return Generate(&SchemaConfig{
+		Target:      &config.EvalConfig{},
+		Filename:    "eval.json",
+		Title:       "PromptArena Eval Configuration",
+		Description: "Eval configuration for replaying and validating saved conversations",
+		Customize:   addEvalExample,
+	})
 }
 
 func addEvalExample(schema *jsonschema.Schema) {

--- a/tools/schema-gen/generators/helper.go
+++ b/tools/schema-gen/generators/helper.go
@@ -1,0 +1,60 @@
+package generators
+
+import (
+	"github.com/invopop/jsonschema"
+)
+
+// SchemaConfig holds the configuration for generating a JSON schema from a Go type.
+type SchemaConfig struct {
+	// Target is the Go struct instance to reflect (e.g., &config.ArenaConfig{}).
+	Target interface{}
+	// Filename is the schema output filename (e.g., "arena.json").
+	Filename string
+	// Title is the human-readable schema title.
+	Title string
+	// Description is the schema description.
+	Description string
+	// FieldNameTag overrides the struct tag used for field names.
+	// Defaults to "yaml" if empty.
+	FieldNameTag string
+	// Customize is an optional callback to apply additional modifications
+	// to the generated schema (e.g., adding examples or oneOf constraints).
+	Customize func(*jsonschema.Schema)
+}
+
+// newReflector creates a jsonschema.Reflector with the standard configuration
+// used across all schema generators.
+func newReflector(fieldNameTag string) jsonschema.Reflector {
+	if fieldNameTag == "" {
+		fieldNameTag = "yaml"
+	}
+	return jsonschema.Reflector{
+		AllowAdditionalProperties:  false,
+		ExpandedStruct:             true,
+		FieldNameTag:               fieldNameTag,
+		RequiredFromJSONSchemaTags: false,
+	}
+}
+
+// Generate produces a JSON schema for the given SchemaConfig. It creates
+// a reflector with standard settings, reflects the target type, sets the
+// schema metadata (version, ID, title, description), adds the $schema
+// property, and applies any custom modifications.
+func Generate(cfg *SchemaConfig) (interface{}, error) {
+	reflector := newReflector(cfg.FieldNameTag)
+
+	schema := reflector.Reflect(cfg.Target)
+
+	schema.Version = "https://json-schema.org/draft-07/schema"
+	schema.ID = jsonschema.ID(schemaBaseURL + "/" + cfg.Filename)
+	schema.Title = cfg.Title
+	schema.Description = cfg.Description
+
+	allowSchemaField(schema)
+
+	if cfg.Customize != nil {
+		cfg.Customize(schema)
+	}
+
+	return schema, nil
+}

--- a/tools/schema-gen/generators/logging.go
+++ b/tools/schema-gen/generators/logging.go
@@ -8,25 +8,13 @@ import (
 
 // GenerateLoggingSchema generates the JSON Schema for LoggingConfig configuration
 func GenerateLoggingSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		ExpandedStruct:            true,
-		FieldNameTag:              "yaml",
-	}
-
-	schema := reflector.Reflect(&config.LoggingConfig{})
-
-	schema.Version = "https://json-schema.org/draft-07/schema"
-	schema.ID = schemaBaseURL + "/logging.json"
-	schema.Title = "PromptKit Logging Configuration"
-	schema.Description = "Configuration for structured logging with per-module log levels"
-
-	// Allow the standard $schema field
-	allowSchemaField(schema)
-
-	addLoggingExample(schema)
-
-	return schema, nil
+	return Generate(&SchemaConfig{
+		Target:      &config.LoggingConfig{},
+		Filename:    "logging.json",
+		Title:       "PromptKit Logging Configuration",
+		Description: "Configuration for structured logging with per-module log levels",
+		Customize:   addLoggingExample,
+	})
 }
 
 func addLoggingExample(schema *jsonschema.Schema) {

--- a/tools/schema-gen/generators/persona.go
+++ b/tools/schema-gen/generators/persona.go
@@ -8,25 +8,13 @@ import (
 
 // GeneratePersonaSchema generates the JSON Schema for Persona configuration
 func GeneratePersonaSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		ExpandedStruct:            true,
-		FieldNameTag:              "yaml",
-	}
-
-	schema := reflector.Reflect(&config.PersonaConfigSchema{})
-
-	schema.Version = "https://json-schema.org/draft-07/schema"
-	schema.ID = schemaBaseURL + "/persona.json"
-	schema.Title = "PromptKit Persona Configuration"
-	schema.Description = "User persona configuration for self-play scenarios"
-
-	// Allow the standard $schema field
-	allowSchemaField(schema)
-
-	addPersonaExample(schema)
-
-	return schema, nil
+	return Generate(&SchemaConfig{
+		Target:      &config.PersonaConfigSchema{},
+		Filename:    "persona.json",
+		Title:       "PromptKit Persona Configuration",
+		Description: "User persona configuration for self-play scenarios",
+		Customize:   addPersonaExample,
+	})
 }
 
 func addPersonaExample(schema *jsonschema.Schema) {

--- a/tools/schema-gen/generators/promptconfig.go
+++ b/tools/schema-gen/generators/promptconfig.go
@@ -8,25 +8,13 @@ import (
 
 // GeneratePromptConfigSchema generates the JSON Schema for PromptConfig configuration
 func GeneratePromptConfigSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		ExpandedStruct:            true,
-		FieldNameTag:              "yaml",
-	}
-
-	schema := reflector.Reflect(&config.PromptConfigSchema{})
-
-	schema.Version = "https://json-schema.org/draft-07/schema"
-	schema.ID = schemaBaseURL + "/promptconfig.json"
-	schema.Title = "PromptKit Prompt Configuration"
-	schema.Description = "Prompt configuration for PromptKit"
-
-	// Allow the standard $schema field
-	allowSchemaField(schema)
-
-	addPromptConfigExample(schema)
-
-	return schema, nil
+	return Generate(&SchemaConfig{
+		Target:      &config.PromptConfigSchema{},
+		Filename:    "promptconfig.json",
+		Title:       "PromptKit Prompt Configuration",
+		Description: "Prompt configuration for PromptKit",
+		Customize:   addPromptConfigExample,
+	})
 }
 
 func addPromptConfigExample(schema *jsonschema.Schema) {

--- a/tools/schema-gen/generators/provider.go
+++ b/tools/schema-gen/generators/provider.go
@@ -8,25 +8,13 @@ import (
 
 // GenerateProviderSchema generates the JSON Schema for Provider configuration
 func GenerateProviderSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		ExpandedStruct:            true,
-		FieldNameTag:              "yaml",
-	}
-
-	schema := reflector.Reflect(&config.ProviderConfig{})
-
-	schema.Version = "https://json-schema.org/draft-07/schema"
-	schema.ID = schemaBaseURL + "/provider.json"
-	schema.Title = "PromptArena Provider Configuration"
-	schema.Description = "Provider configuration for PromptArena LLM connections"
-
-	// Allow the standard $schema field
-	allowSchemaField(schema)
-
-	addProviderExample(schema)
-
-	return schema, nil
+	return Generate(&SchemaConfig{
+		Target:      &config.ProviderConfig{},
+		Filename:    "provider.json",
+		Title:       "PromptArena Provider Configuration",
+		Description: "Provider configuration for PromptArena LLM connections",
+		Customize:   addProviderExample,
+	})
 }
 
 func addProviderExample(schema *jsonschema.Schema) {

--- a/tools/schema-gen/generators/scenario.go
+++ b/tools/schema-gen/generators/scenario.go
@@ -8,28 +8,16 @@ import (
 
 // GenerateScenarioSchema generates the JSON Schema for Scenario configuration
 func GenerateScenarioSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		ExpandedStruct:            true,
-		FieldNameTag:              "yaml",
-	}
-
-	schema := reflector.Reflect(&config.ScenarioConfig{})
-
-	schema.Version = "https://json-schema.org/draft-07/schema"
-	schema.ID = schemaBaseURL + "/scenario.json"
-	schema.Title = "PromptArena Scenario Configuration"
-	schema.Description = "Scenario configuration for PromptArena test cases"
-
-	// Allow the standard $schema field
-	allowSchemaField(schema)
-
-	// Add oneOf constraint: regular scenario (task_type + turns) or workflow scenario (pack + steps)
-	addScenarioOneOf(schema)
-
-	addScenarioExample(schema)
-
-	return schema, nil
+	return Generate(&SchemaConfig{
+		Target:      &config.ScenarioConfig{},
+		Filename:    "scenario.json",
+		Title:       "PromptArena Scenario Configuration",
+		Description: "Scenario configuration for PromptArena test cases",
+		Customize: func(schema *jsonschema.Schema) {
+			addScenarioOneOf(schema)
+			addScenarioExample(schema)
+		},
+	})
 }
 
 // addScenarioOneOf adds a oneOf constraint to the Scenario definition

--- a/tools/schema-gen/generators/tool.go
+++ b/tools/schema-gen/generators/tool.go
@@ -8,25 +8,13 @@ import (
 
 // GenerateToolSchema generates the JSON Schema for Tool configuration
 func GenerateToolSchema() (interface{}, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		ExpandedStruct:            true,
-		FieldNameTag:              "yaml",
-	}
-
-	schema := reflector.Reflect(&config.ToolConfigSchema{})
-
-	schema.Version = "https://json-schema.org/draft-07/schema"
-	schema.ID = schemaBaseURL + "/tool.json"
-	schema.Title = "PromptKit Tool Configuration"
-	schema.Description = "Tool/function configuration for PromptKit"
-
-	// Allow the standard $schema field
-	allowSchemaField(schema)
-
-	addToolExample(schema)
-
-	return schema, nil
+	return Generate(&SchemaConfig{
+		Target:      &config.ToolConfigSchema{},
+		Filename:    "tool.json",
+		Title:       "PromptKit Tool Configuration",
+		Description: "Tool/function configuration for PromptKit",
+		Customize:   addToolExample,
+	})
 }
 
 func addToolExample(schema *jsonschema.Schema) {

--- a/tools/schema-gen/main.go
+++ b/tools/schema-gen/main.go
@@ -1,3 +1,4 @@
+// Command schema-gen generates JSON schemas for PromptKit configuration types.
 package main
 
 import (


### PR DESCRIPTION
## Summary
- Extract duplicated schema generation boilerplate (reflector setup, metadata assignment, `allowSchemaField` call) into a shared `Generate()` helper function and `SchemaConfig` struct in `tools/schema-gen/generators/helper.go`
- Refactor all 8 schema generators (arena, scenario, eval, provider, promptconfig, tool, persona, logging) to use the shared helper
- Extract `newReflector()` helper used by both `Generate()` and `GenerateMetadataSchema()`
- Add package comments to fix pre-existing `revive` lint warnings
- Add unit tests for `Generate()`, `newReflector()`, and schema field injection

## Verification
- Generated schemas are byte-identical before and after refactoring (verified via MD5 checksums)
- `go run ./tools/schema-gen/... --check` confirms all schemas remain up to date
- `golangci-lint run ./...` passes with 0 issues
- All existing and new tests pass

Closes #484

## Test plan
- [x] `go test ./tools/schema-gen/... -count=1 -v` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `go run ./tools/schema-gen/... --check` confirms schemas unchanged
- [ ] CI passes (lint, build, test, SonarCloud)