### PR TITLE
perf(sdk): add PackTemplate to reduce per-conversation allocation overhead

### DIFF
--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -42,9 +42,6 @@ const (
 	errUnaryModeRequired  = "Send() only available in unary mode; use OpenDuplex() for duplex streaming"
 )
 
-// Role constants for message types.
-const roleAssistant = "assistant"
-
 // Content type constants.
 const contentTypeText = "text"
 

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -31,6 +31,9 @@ const (
 	defaultMaxTokens        = 4096
 	defaultTemperature      = 0.7
 	streamChannelBufferSize = 100 // Buffer size for streaming channels
+
+	// roleAssistant is the standard role string for assistant messages.
+	roleAssistant = "assistant"
 )
 
 // Error message templates for mode-specific operations.

--- a/sdk/template.go
+++ b/sdk/template.go
@@ -1,0 +1,237 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
+	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
+)
+
+// PackTemplate is a pre-loaded, immutable representation of a pack file.
+//
+// Use PackTemplate when creating many conversations from the same pack to
+// avoid redundant file I/O, JSON parsing, schema validation, prompt registry
+// construction, and tool repository construction on each Open() call.
+//
+// PackTemplate is safe for concurrent use. All cached artifacts are immutable
+// after construction.
+//
+// Usage:
+//
+//	tmpl, err := sdk.LoadTemplate("./assistant.pack.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Create conversations efficiently — pack is loaded once
+//	for req := range requests {
+//	    conv, err := tmpl.Open("chat", sdk.WithProvider(myProvider))
+//	    if err != nil {
+//	        log.Printf("open failed: %v", err)
+//	        continue
+//	    }
+//	    go handleConversation(conv, req)
+//	}
+type PackTemplate struct {
+	// pack is the immutable loaded pack (read-only after construction).
+	pack *pack.Pack
+
+	// promptRegistry is the shared prompt registry (thread-safe, read-only
+	// after construction via internal RWMutex caching).
+	promptRegistry *prompt.Registry
+
+	// toolRepository is the shared tool repository. Each conversation creates
+	// its own tools.Registry wrapping this shared repository, so tool
+	// descriptors are loaded once but executors remain per-conversation.
+	toolRepository *memory.ToolRepository
+}
+
+// LoadTemplate loads a pack file and pre-builds shared, immutable resources.
+//
+// The returned PackTemplate caches:
+//   - The parsed pack structure
+//   - The prompt registry (prompt configs, fragments)
+//   - The tool repository (tool descriptors)
+//
+// These are shared across all conversations created from this template.
+// Per-conversation resources (tool executors, state stores, sessions) are
+// still created fresh for each conversation.
+//
+// Options that affect pack loading can be passed:
+//   - WithSkipSchemaValidation() to skip JSON schema validation
+func LoadTemplate(packPath string, opts ...Option) (*PackTemplate, error) {
+	// Apply options only to extract pack-loading config
+	cfg := &config{}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return nil, fmt.Errorf("failed to apply option: %w", err)
+		}
+	}
+
+	absPath, err := resolvePackPath(packPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve pack path: %w", err)
+	}
+
+	loadOpts := pack.LoadOptions{
+		SkipSchemaValidation: cfg.skipSchemaValidation,
+	}
+
+	p, err := pack.Load(absPath, loadOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load pack: %w", err)
+	}
+
+	return &PackTemplate{
+		pack:           p,
+		promptRegistry: p.ToPromptRegistry(),
+		toolRepository: p.ToToolRepository(),
+	}, nil
+}
+
+// Open creates a new conversation from this template for the given prompt.
+//
+// This is equivalent to [sdk.Open] but reuses pre-loaded pack resources,
+// avoiding per-conversation file I/O and parsing overhead.
+//
+// Per-conversation resources are still created fresh:
+//   - Tool registry (with shared repository but per-conversation executors)
+//   - State store and session
+//   - Capabilities
+//   - Event bus and hooks
+func (t *PackTemplate) Open(promptName string, opts ...Option) (*Conversation, error) {
+	return t.openConversation(promptName, false, opts...)
+}
+
+// OpenDuplex creates a new duplex streaming conversation from this template.
+//
+// This is equivalent to [sdk.OpenDuplex] but reuses pre-loaded pack resources.
+func (t *PackTemplate) OpenDuplex(promptName string, opts ...Option) (*Conversation, error) {
+	return t.openConversation(promptName, true, opts...)
+}
+
+// Pack returns the loaded pack for inspection. The returned pack must not be modified.
+func (t *PackTemplate) Pack() *pack.Pack {
+	return t.pack
+}
+
+// openConversation is the shared implementation for Open and OpenDuplex on templates.
+func (t *PackTemplate) openConversation(
+	promptName string,
+	duplex bool,
+	opts ...Option,
+) (*Conversation, error) {
+	cfg, err := applyOptions(promptName, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	packPrompt, err := t.validatePrompt(promptName)
+	if err != nil {
+		return nil, err
+	}
+
+	prov, err := resolveProvider(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	conv := t.newConversation(promptName, packPrompt, cfg)
+
+	if err := t.initConversation(conv, packPrompt, cfg); err != nil {
+		return nil, err
+	}
+
+	if err := t.initSession(conv, cfg, prov, duplex); err != nil {
+		return nil, err
+	}
+
+	conv.evalMW = newEvalMiddleware(conv)
+
+	if err := initMCPRegistry(conv, cfg); err != nil {
+		return nil, err
+	}
+
+	conv.runSessionStart(context.Background())
+	return conv, nil
+}
+
+// validatePrompt checks that the named prompt exists in the cached pack.
+func (t *PackTemplate) validatePrompt(promptName string) (*pack.Prompt, error) {
+	packPrompt, ok := t.pack.Prompts[promptName]
+	if !ok {
+		available := make([]string, 0, len(t.pack.Prompts))
+		for name := range t.pack.Prompts {
+			available = append(available, name)
+		}
+		return nil, fmt.Errorf("prompt %q not found in pack (available: %v)", promptName, available)
+	}
+	return packPrompt, nil
+}
+
+// newConversation creates a Conversation struct with shared and per-conversation resources.
+func (t *PackTemplate) newConversation(
+	promptName string,
+	packPrompt *pack.Prompt,
+	cfg *config,
+) *Conversation {
+	return &Conversation{
+		pack:           t.pack,
+		prompt:         packPrompt,
+		promptName:     promptName,
+		promptRegistry: t.promptRegistry,
+		toolRegistry:   tools.NewRegistryWithRepository(t.toolRepository),
+		config:         cfg,
+		handlers:       make(map[string]ToolHandler),
+		asyncHandlers:  make(map[string]sdktools.AsyncToolHandler),
+		pendingStore:   sdktools.NewPendingStore(),
+		resolvedStore:  sdktools.NewResolvedStore(),
+	}
+}
+
+// initConversation sets up capabilities, hooks, and event bus on the conversation.
+func (t *PackTemplate) initConversation(conv *Conversation, packPrompt *pack.Prompt, cfg *config) error {
+	applyDefaultVariables(conv, packPrompt)
+	convertPackValidatorsToHooks(packPrompt, cfg)
+
+	allCaps := mergeCapabilities(cfg.capabilities, inferCapabilities(t.pack))
+	allCaps = ensureA2ACapability(allCaps, cfg)
+	allCaps = ensureSkillsCapability(allCaps, cfg)
+	wireA2AConfig(allCaps, cfg)
+	wireSkillsConfig(allCaps, cfg)
+	for _, cap := range allCaps {
+		if err := cap.Init(CapabilityContext{Pack: t.pack, PromptName: conv.promptName}); err != nil {
+			return fmt.Errorf("capability %q init failed: %w", cap.Name(), err)
+		}
+	}
+	conv.capabilities = allCaps
+
+	initEventBus(cfg)
+	conv.hookRegistry = cfg.buildHookRegistry()
+	return nil
+}
+
+// initSession initializes the appropriate session type (unary or duplex).
+func (t *PackTemplate) initSession(
+	conv *Conversation,
+	cfg *config,
+	prov providers.Provider,
+	duplex bool,
+) error {
+	if duplex {
+		streamProvider, ok := prov.(providers.StreamInputSupport)
+		if !ok {
+			return fmt.Errorf(
+				"provider %T does not support duplex streaming (must implement providers.StreamInputSupport)",
+				prov,
+			)
+		}
+		return initDuplexSession(conv, cfg, streamProvider)
+	}
+	return initInternalStateStore(conv, cfg)
+}

--- a/sdk/template_test.go
+++ b/sdk/template_test.go
@@ -1,0 +1,263 @@
+package sdk
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testPackJSON is a minimal valid pack for template tests.
+const testPackJSON = `{
+	"name": "template-test-pack",
+	"version": "v1",
+	"prompts": {
+		"chat": {
+			"system_template": "You are a helpful assistant."
+		},
+		"summarize": {
+			"system_template": "Summarize the following text."
+		}
+	}
+}`
+
+// writeTestPack writes a test pack file and returns its path.
+func writeTestPack(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	packFile := filepath.Join(dir, "test.pack.json")
+	err := os.WriteFile(packFile, []byte(testPackJSON), 0600)
+	require.NoError(t, err)
+	return packFile
+}
+
+func TestLoadTemplate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		packFile := writeTestPack(t)
+
+		tmpl, err := LoadTemplate(packFile, WithSkipSchemaValidation())
+		require.NoError(t, err)
+		require.NotNil(t, tmpl)
+
+		// Verify cached pack
+		assert.Equal(t, "template-test-pack", tmpl.Pack().Name)
+		assert.Contains(t, tmpl.Pack().Prompts, "chat")
+		assert.Contains(t, tmpl.Pack().Prompts, "summarize")
+
+		// Verify shared registries are populated
+		assert.NotNil(t, tmpl.promptRegistry)
+		assert.NotNil(t, tmpl.toolRepository)
+	})
+
+	t.Run("non-existent path", func(t *testing.T) {
+		_, err := LoadTemplate("/nonexistent/path/pack.json")
+		assert.Error(t, err)
+	})
+
+	t.Run("option error", func(t *testing.T) {
+		packFile := writeTestPack(t)
+		_, err := LoadTemplate(packFile, func(c *config) error {
+			return assert.AnError
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to apply option")
+	})
+}
+
+func TestPackTemplateOpen(t *testing.T) {
+	packFile := writeTestPack(t)
+	tmpl, err := LoadTemplate(packFile, WithSkipSchemaValidation())
+	require.NoError(t, err)
+
+	t.Run("success with mock provider", func(t *testing.T) {
+		provider := mock.NewProvider("mock", "mock-model", false)
+		conv, err := tmpl.Open("chat", WithProvider(provider))
+		require.NoError(t, err)
+		require.NotNil(t, conv)
+
+		assert.Equal(t, "chat", conv.promptName)
+		assert.NotNil(t, conv.toolRegistry)
+		defer conv.Close()
+	})
+
+	t.Run("prompt not found", func(t *testing.T) {
+		provider := mock.NewProvider("mock", "mock-model", false)
+		_, err := tmpl.Open("nonexistent", WithProvider(provider))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("no provider configured", func(t *testing.T) {
+		// Clear all API keys
+		os.Unsetenv("OPENAI_API_KEY")
+		os.Unsetenv("ANTHROPIC_API_KEY")
+		os.Unsetenv("GOOGLE_API_KEY")
+		os.Unsetenv("GEMINI_API_KEY")
+
+		_, err := tmpl.Open("chat")
+		assert.Error(t, err)
+	})
+
+	t.Run("option error", func(t *testing.T) {
+		_, err := tmpl.Open("chat", func(c *config) error {
+			return assert.AnError
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("multiple prompts same template", func(t *testing.T) {
+		provider := mock.NewProvider("mock", "mock-model", false)
+
+		conv1, err := tmpl.Open("chat", WithProvider(provider))
+		require.NoError(t, err)
+		defer conv1.Close()
+
+		conv2, err := tmpl.Open("summarize", WithProvider(provider))
+		require.NoError(t, err)
+		defer conv2.Close()
+
+		// Each conversation has its own state
+		assert.NotEqual(t, conv1.ID(), conv2.ID())
+		assert.Equal(t, "chat", conv1.promptName)
+		assert.Equal(t, "summarize", conv2.promptName)
+	})
+
+	t.Run("conversations share prompt registry", func(t *testing.T) {
+		provider := mock.NewProvider("mock", "mock-model", false)
+
+		conv1, err := tmpl.Open("chat", WithProvider(provider))
+		require.NoError(t, err)
+		defer conv1.Close()
+
+		conv2, err := tmpl.Open("chat", WithProvider(provider))
+		require.NoError(t, err)
+		defer conv2.Close()
+
+		// Both conversations reference the same prompt registry instance
+		assert.Same(t, conv1.promptRegistry, conv2.promptRegistry)
+	})
+
+	t.Run("conversations have isolated tool registries", func(t *testing.T) {
+		provider := mock.NewProvider("mock", "mock-model", false)
+
+		conv1, err := tmpl.Open("chat", WithProvider(provider))
+		require.NoError(t, err)
+		defer conv1.Close()
+
+		conv2, err := tmpl.Open("chat", WithProvider(provider))
+		require.NoError(t, err)
+		defer conv2.Close()
+
+		// Each conversation has its own tool registry
+		assert.NotSame(t, conv1.toolRegistry, conv2.toolRegistry)
+	})
+}
+
+func TestPackTemplateOpenConcurrent(t *testing.T) {
+	packFile := writeTestPack(t)
+	tmpl, err := LoadTemplate(packFile, WithSkipSchemaValidation())
+	require.NoError(t, err)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	convs := make(chan *Conversation, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			provider := mock.NewProvider("mock", "mock-model", false)
+			conv, err := tmpl.Open("chat", WithProvider(provider))
+			if err != nil {
+				errs <- err
+				return
+			}
+			convs <- conv
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	close(convs)
+
+	// No errors
+	for err := range errs {
+		t.Errorf("concurrent Open failed: %v", err)
+	}
+
+	// All conversations created successfully
+	var created []*Conversation
+	for conv := range convs {
+		created = append(created, conv)
+		defer conv.Close()
+	}
+	assert.Len(t, created, goroutines)
+
+	// All conversations have unique IDs
+	ids := make(map[string]bool, goroutines)
+	for _, conv := range created {
+		ids[conv.ID()] = true
+	}
+	assert.Len(t, ids, goroutines, "all conversation IDs should be unique")
+}
+
+func TestPackTemplateOpenSendReceive(t *testing.T) {
+	packFile := writeTestPack(t)
+	tmpl, err := LoadTemplate(packFile, WithSkipSchemaValidation())
+	require.NoError(t, err)
+
+	provider := mock.NewProvider("mock", "mock-model", false)
+	conv, err := tmpl.Open("chat", WithProvider(provider))
+	require.NoError(t, err)
+	defer conv.Close()
+
+	// Verify conversation is functional by sending a message
+	resp, err := conv.Send(context.Background(), "Hello")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Text())
+}
+
+func BenchmarkTemplateVsDirectOpen(b *testing.B) {
+	dir := b.TempDir()
+	packFile := filepath.Join(dir, "bench.pack.json")
+	err := os.WriteFile(packFile, []byte(testPackJSON), 0600)
+	require.NoError(b, err)
+
+	b.Run("Direct_Open", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			provider := mock.NewProvider("mock", "mock-model", false)
+			conv, err := Open(packFile, "chat",
+				WithSkipSchemaValidation(),
+				WithProvider(provider),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			conv.Close()
+		}
+	})
+
+	b.Run("Template_Open", func(b *testing.B) {
+		tmpl, err := LoadTemplate(packFile, WithSkipSchemaValidation())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			provider := mock.NewProvider("mock", "mock-model", false)
+			conv, err := tmpl.Open("chat", WithProvider(provider))
+			if err != nil {
+				b.Fatal(err)
+			}
+			conv.Close()
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #499

- Introduces `PackTemplate` type that pre-loads and caches immutable pack resources (parsed pack, prompt registry, tool repository) for sharing across conversations created from the same pack file
- `LoadTemplate()` loads a pack once; `PackTemplate.Open()` / `PackTemplate.OpenDuplex()` create conversations that reuse the shared resources while maintaining per-conversation isolation for mutable state (tool executors, sessions, capabilities)
- Fixes 10 pre-existing lint issues across the SDK: pipeline builder cognitive complexity, goconst violations, unused code, goimports formatting, and gocritic warnings

### Key design decisions
- **Shared**: pack struct, prompt registry (thread-safe via internal RWMutex), tool repository (read-only after construction)
- **Per-conversation**: tool registry (wraps shared repository but has per-conversation executors), session, capabilities, hook registry, event bus
- `PackTemplate` is safe for concurrent use from multiple goroutines

## Test plan
- [x] `TestLoadTemplate` - success, non-existent path, option error
- [x] `TestPackTemplateOpen` - success with mock provider, prompt not found, no provider, option error, multiple prompts from same template, shared prompt registry verification, isolated tool registries verification
- [x] `TestPackTemplateOpenConcurrent` - 20 concurrent goroutines creating conversations from same template
- [x] `TestPackTemplateOpenSendReceive` - functional test sending a message and receiving a response
- [x] `BenchmarkTemplateVsDirectOpen` - performance comparison
- [x] All existing SDK tests pass with race detection enabled
- [x] Coverage on all changed files >= 80% (template.go: 82.3%)
- [x] golangci-lint: 0 issues