### PR TITLE
refactor(events): consolidate lifecycle event data structs with type aliases

### DIFF
--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -313,6 +313,7 @@ func (e *Emitter) AudioInput(data *AudioInputData) {
 	if data == nil {
 		return
 	}
+	data.Direction = "input"
 	e.emit(EventAudioInput, data)
 }
 
@@ -321,6 +322,7 @@ func (e *Emitter) AudioOutput(data *AudioOutputData) {
 	if data == nil {
 		return
 	}
+	data.Direction = "output"
 	e.emit(EventAudioOutput, data)
 }
 

--- a/runtime/events/media_timeline.go
+++ b/runtime/events/media_timeline.go
@@ -129,22 +129,14 @@ func (mt *MediaTimeline) extractAudioSegments(eventType EventType, _ TrackType) 
 			continue
 		}
 
-		var payload *BinaryPayload
-		var metadata AudioMetadata
-		var chunkIndex int
-
-		switch data := event.Data.(type) {
-		case *AudioInputData:
-			payload = &data.Payload
-			metadata = data.Metadata
-			chunkIndex = data.ChunkIndex
-		case *AudioOutputData:
-			payload = &data.Payload
-			metadata = data.Metadata
-			chunkIndex = data.ChunkIndex
-		default:
+		data, ok := event.Data.(*AudioEventData)
+		if !ok {
 			continue
 		}
+
+		payload := &data.Payload
+		metadata := data.Metadata
+		chunkIndex := data.ChunkIndex
 
 		segment := &MediaSegment{
 			StartTime:  event.Timestamp.Sub(mt.SessionStart),

--- a/runtime/events/store.go
+++ b/runtime/events/store.go
@@ -115,31 +115,76 @@ func (se *SerializableEvent) toEvent() *Event {
 type eventDataFactory func() EventData
 
 // eventDataRegistry maps type names to factory functions for deserialization.
+// Entries for both canonical names (e.g., "*events.MiddlewareEventData") and
+// legacy alias names (e.g., "*events.MiddlewareStartedData") are included
+// so that old recordings can still be deserialized.
 var eventDataRegistry = map[string]eventDataFactory{
-	"*events.AudioInputData":          func() EventData { return &AudioInputData{} },
-	"*events.AudioOutputData":         func() EventData { return &AudioOutputData{} },
-	"*events.AudioTranscriptionData":  func() EventData { return &AudioTranscriptionData{} },
-	"*events.VideoFrameData":          func() EventData { return &VideoFrameData{} },
-	"*events.ScreenshotData":          func() EventData { return &ScreenshotData{} },
-	"*events.ImageInputData":          func() EventData { return &ImageInputData{} },
-	"*events.ImageOutputData":         func() EventData { return &ImageOutputData{} },
+	// Audio events (consolidated into AudioEventData)
+	"*events.AudioEventData":         func() EventData { return &AudioEventData{} },
+	"*events.AudioInputData":         func() EventData { return &AudioEventData{} },
+	"*events.AudioOutputData":        func() EventData { return &AudioEventData{} },
+	"*events.AudioTranscriptionData": func() EventData { return &AudioTranscriptionData{} },
+
+	// Video/Image events (ImageInputData/ImageOutputData consolidated into ImageEventData)
+	"*events.VideoFrameData":  func() EventData { return &VideoFrameData{} },
+	"*events.ScreenshotData":  func() EventData { return &ScreenshotData{} },
+	"*events.ImageEventData":  func() EventData { return &ImageEventData{} },
+	"*events.ImageInputData":  func() EventData { return &ImageEventData{} },
+	"*events.ImageOutputData": func() EventData { return &ImageEventData{} },
+
+	// Message events
 	"*events.MessageCreatedData":      func() EventData { return &MessageCreatedData{} },
 	"*events.MessageUpdatedData":      func() EventData { return &MessageUpdatedData{} },
 	"*events.ConversationStartedData": func() EventData { return &ConversationStartedData{} },
-	"*events.PipelineStartedData":     func() EventData { return &PipelineStartedData{} },
-	"*events.PipelineCompletedData":   func() EventData { return &PipelineCompletedData{} },
-	"*events.PipelineFailedData":      func() EventData { return &PipelineFailedData{} },
-	"*events.ProviderCallStartedData": func() EventData { return &ProviderCallStartedData{} },
-	"*events.ProviderCallCompletedData": func() EventData {
-		return &ProviderCallCompletedData{}
-	},
-	"*events.ProviderCallFailedData": func() EventData { return &ProviderCallFailedData{} },
-	"*events.ToolCallStartedData":    func() EventData { return &ToolCallStartedData{} },
-	"*events.ToolCallCompletedData":  func() EventData { return &ToolCallCompletedData{} },
-	"*events.ToolCallFailedData":     func() EventData { return &ToolCallFailedData{} },
-	"*events.CustomEventData":              func() EventData { return &CustomEventData{} },
-	"*events.WorkflowTransitionedData":    func() EventData { return &WorkflowTransitionedData{} },
-	"*events.WorkflowCompletedData":       func() EventData { return &WorkflowCompletedData{} },
+
+	// Pipeline events
+	"*events.PipelineStartedData":   func() EventData { return &PipelineStartedData{} },
+	"*events.PipelineCompletedData": func() EventData { return &PipelineCompletedData{} },
+	"*events.PipelineFailedData":    func() EventData { return &PipelineFailedData{} },
+
+	// Provider events
+	"*events.ProviderCallStartedData":   func() EventData { return &ProviderCallStartedData{} },
+	"*events.ProviderCallCompletedData": func() EventData { return &ProviderCallCompletedData{} },
+	"*events.ProviderCallFailedData":    func() EventData { return &ProviderCallFailedData{} },
+
+	// Tool events (consolidated into ToolCallEventData)
+	"*events.ToolCallEventData":     func() EventData { return &ToolCallEventData{} },
+	"*events.ToolCallStartedData":   func() EventData { return &ToolCallEventData{} },
+	"*events.ToolCallCompletedData": func() EventData { return &ToolCallEventData{} },
+	"*events.ToolCallFailedData":    func() EventData { return &ToolCallEventData{} },
+
+	// Custom events
+	"*events.CustomEventData": func() EventData { return &CustomEventData{} },
+
+	// Stage events (consolidated into StageEventData)
+	"*events.StageEventData":     func() EventData { return &StageEventData{} },
+	"*events.StageStartedData":   func() EventData { return &StageEventData{} },
+	"*events.StageCompletedData": func() EventData { return &StageEventData{} },
+	"*events.StageFailedData":    func() EventData { return &StageEventData{} },
+
+	// Middleware events (consolidated into MiddlewareEventData)
+	"*events.MiddlewareEventData":     func() EventData { return &MiddlewareEventData{} },
+	"*events.MiddlewareStartedData":   func() EventData { return &MiddlewareEventData{} },
+	"*events.MiddlewareCompletedData": func() EventData { return &MiddlewareEventData{} },
+	"*events.MiddlewareFailedData":    func() EventData { return &MiddlewareEventData{} },
+
+	// Validation events (consolidated into ValidationEventData)
+	"*events.ValidationEventData":   func() EventData { return &ValidationEventData{} },
+	"*events.ValidationStartedData": func() EventData { return &ValidationEventData{} },
+	"*events.ValidationPassedData":  func() EventData { return &ValidationEventData{} },
+	"*events.ValidationFailedData":  func() EventData { return &ValidationEventData{} },
+
+	// Context/State events (StateLoadedData/StateSavedData consolidated into StateEventData)
+	"*events.ContextBuiltData":        func() EventData { return &ContextBuiltData{} },
+	"*events.TokenBudgetExceededData": func() EventData { return &TokenBudgetExceededData{} },
+	"*events.StateEventData":          func() EventData { return &StateEventData{} },
+	"*events.StateLoadedData":         func() EventData { return &StateEventData{} },
+	"*events.StateSavedData":          func() EventData { return &StateEventData{} },
+	"*events.StreamInterruptedData":   func() EventData { return &StreamInterruptedData{} },
+
+	// Workflow events
+	"*events.WorkflowTransitionedData": func() EventData { return &WorkflowTransitionedData{} },
+	"*events.WorkflowCompletedData":    func() EventData { return &WorkflowCompletedData{} },
 }
 
 // deserializeEventData attempts to deserialize event data based on the type name.

--- a/runtime/events/store_test.go
+++ b/runtime/events/store_test.go
@@ -562,6 +562,83 @@ func TestDeserializeEventData(t *testing.T) {
 				assert.Equal(t, "test message", data.Message)
 			},
 		},
+		// Consolidated canonical type names
+		{
+			name:     "MiddlewareEventData canonical",
+			dataType: "*events.MiddlewareEventData",
+			data:     `{"Name":"auth","Index":0}`,
+			check: func(t *testing.T, result EventData) {
+				data, ok := result.(*MiddlewareEventData)
+				require.True(t, ok)
+				assert.Equal(t, "auth", data.Name)
+			},
+		},
+		{
+			name:     "StageEventData canonical",
+			dataType: "*events.StageEventData",
+			data:     `{"Name":"provider","Index":1,"StageType":"generate"}`,
+			check: func(t *testing.T, result EventData) {
+				data, ok := result.(*StageEventData)
+				require.True(t, ok)
+				assert.Equal(t, "provider", data.Name)
+				assert.Equal(t, "generate", data.StageType)
+			},
+		},
+		{
+			name:     "ToolCallEventData canonical",
+			dataType: "*events.ToolCallEventData",
+			data:     `{"ToolName":"search","CallID":"call-x"}`,
+			check: func(t *testing.T, result EventData) {
+				data, ok := result.(*ToolCallEventData)
+				require.True(t, ok)
+				assert.Equal(t, "search", data.ToolName)
+			},
+		},
+		{
+			name:     "ValidationEventData canonical",
+			dataType: "*events.ValidationEventData",
+			data:     `{"ValidatorName":"content_filter","ValidatorType":"output"}`,
+			check: func(t *testing.T, result EventData) {
+				data, ok := result.(*ValidationEventData)
+				require.True(t, ok)
+				assert.Equal(t, "content_filter", data.ValidatorName)
+				assert.Equal(t, "output", data.ValidatorType)
+			},
+		},
+		{
+			name:     "StateEventData canonical",
+			dataType: "*events.StateEventData",
+			data:     `{"ConversationID":"conv-1","MessageCount":5}`,
+			check: func(t *testing.T, result EventData) {
+				data, ok := result.(*StateEventData)
+				require.True(t, ok)
+				assert.Equal(t, "conv-1", data.ConversationID)
+				assert.Equal(t, 5, data.MessageCount)
+			},
+		},
+		{
+			name:     "AudioEventData canonical",
+			dataType: "*events.AudioEventData",
+			data:     `{"direction":"input","actor":"user","chunk_index":3}`,
+			check: func(t *testing.T, result EventData) {
+				data, ok := result.(*AudioEventData)
+				require.True(t, ok)
+				assert.Equal(t, "input", data.Direction)
+				assert.Equal(t, "user", data.Actor)
+				assert.Equal(t, 3, data.ChunkIndex)
+			},
+		},
+		{
+			name:     "ImageEventData canonical",
+			dataType: "*events.ImageEventData",
+			data:     `{"direction":"output","generated_from":"dalle"}`,
+			check: func(t *testing.T, result EventData) {
+				data, ok := result.(*ImageEventData)
+				require.True(t, ok)
+				assert.Equal(t, "output", data.Direction)
+				assert.Equal(t, "dalle", data.GeneratedFrom)
+			},
+		},
 		{
 			name:     "unknown type returns nil",
 			dataType: "*events.UnknownType",

--- a/runtime/events/types_test.go
+++ b/runtime/events/types_test.go
@@ -118,6 +118,62 @@ func TestEventTypes_Constants(t *testing.T) {
 	}
 }
 
+func TestConsolidatedTypes_Aliases(t *testing.T) {
+	// Verify that type aliases resolve to the canonical consolidated types.
+	// Because aliases are transparent, values constructed via old names
+	// can be asserted with the new canonical name and vice versa.
+	mw := &MiddlewareStartedData{Name: "auth", Index: 0}
+	var mwCanonical *MiddlewareEventData = mw // alias identity
+	if mwCanonical.Name != "auth" {
+		t.Errorf("MiddlewareEventData.Name = %v, want auth", mwCanonical.Name)
+	}
+
+	stage := &StageCompletedData{Name: "provider", Index: 1, StageType: "generate"}
+	var stCanonical *StageEventData = stage
+	if stCanonical.Name != "provider" {
+		t.Errorf("StageEventData.Name = %v, want provider", stCanonical.Name)
+	}
+
+	tc := &ToolCallFailedData{ToolName: "search", CallID: "c1"}
+	var tcCanonical *ToolCallEventData = tc
+	if tcCanonical.ToolName != "search" {
+		t.Errorf("ToolCallEventData.ToolName = %v, want search", tcCanonical.ToolName)
+	}
+
+	val := &ValidationPassedData{ValidatorName: "guard", ValidatorType: "output"}
+	var valCanonical *ValidationEventData = val
+	if valCanonical.ValidatorName != "guard" {
+		t.Errorf("ValidationEventData.ValidatorName = %v, want guard", valCanonical.ValidatorName)
+	}
+
+	st := &StateLoadedData{ConversationID: "conv", MessageCount: 3}
+	var stateCanonical *StateEventData = st
+	if stateCanonical.ConversationID != "conv" {
+		t.Errorf("StateEventData.ConversationID = %v, want conv", stateCanonical.ConversationID)
+	}
+
+	ai := &AudioInputData{Actor: "user", Direction: "input"}
+	var audioCanonical *AudioEventData = ai
+	if audioCanonical.Actor != "user" {
+		t.Errorf("AudioEventData.Actor = %v, want user", audioCanonical.Actor)
+	}
+
+	ii := &ImageOutputData{GeneratedFrom: "dalle", Direction: "output"}
+	var imgCanonical *ImageEventData = ii
+	if imgCanonical.GeneratedFrom != "dalle" {
+		t.Errorf("ImageEventData.GeneratedFrom = %v, want dalle", imgCanonical.GeneratedFrom)
+	}
+
+	// All consolidated types satisfy EventData
+	var _ EventData = &MiddlewareEventData{}
+	var _ EventData = &StageEventData{}
+	var _ EventData = &ToolCallEventData{}
+	var _ EventData = &ValidationEventData{}
+	var _ EventData = &StateEventData{}
+	var _ EventData = &AudioEventData{}
+	var _ EventData = &ImageEventData{}
+}
+
 func TestMessageCreatedData_Parts(t *testing.T) {
 	// Test that MessageCreatedData can store multimodal content parts
 	textContent := "Check out this image"

--- a/runtime/recording/recording.go
+++ b/runtime/recording/recording.go
@@ -27,24 +27,30 @@ const filePermissions = 0600
 
 // eventDataRegistry maps type names to factory functions for event data types.
 // This enables deserialization of recorded events back to their typed structs.
+// Entries for both canonical names and legacy alias names are included for
+// backward compatibility with old recordings.
 var eventDataRegistry = map[string]func() events.EventData{
-	// Audio events
-	"*events.AudioInputData":         func() events.EventData { return &events.AudioInputData{} },
-	"events.AudioInputData":          func() events.EventData { return &events.AudioInputData{} },
-	"*events.AudioOutputData":        func() events.EventData { return &events.AudioOutputData{} },
-	"events.AudioOutputData":         func() events.EventData { return &events.AudioOutputData{} },
+	// Audio events (consolidated into AudioEventData)
+	"*events.AudioEventData":         func() events.EventData { return &events.AudioEventData{} },
+	"events.AudioEventData":          func() events.EventData { return &events.AudioEventData{} },
+	"*events.AudioInputData":         func() events.EventData { return &events.AudioEventData{} },
+	"events.AudioInputData":          func() events.EventData { return &events.AudioEventData{} },
+	"*events.AudioOutputData":        func() events.EventData { return &events.AudioEventData{} },
+	"events.AudioOutputData":         func() events.EventData { return &events.AudioEventData{} },
 	"*events.AudioTranscriptionData": func() events.EventData { return &events.AudioTranscriptionData{} },
 	"events.AudioTranscriptionData":  func() events.EventData { return &events.AudioTranscriptionData{} },
 
-	// Video/Image events
+	// Video/Image events (ImageInputData/ImageOutputData consolidated into ImageEventData)
 	"*events.VideoFrameData":  func() events.EventData { return &events.VideoFrameData{} },
 	"events.VideoFrameData":   func() events.EventData { return &events.VideoFrameData{} },
 	"*events.ScreenshotData":  func() events.EventData { return &events.ScreenshotData{} },
 	"events.ScreenshotData":   func() events.EventData { return &events.ScreenshotData{} },
-	"*events.ImageInputData":  func() events.EventData { return &events.ImageInputData{} },
-	"events.ImageInputData":   func() events.EventData { return &events.ImageInputData{} },
-	"*events.ImageOutputData": func() events.EventData { return &events.ImageOutputData{} },
-	"events.ImageOutputData":  func() events.EventData { return &events.ImageOutputData{} },
+	"*events.ImageEventData":  func() events.EventData { return &events.ImageEventData{} },
+	"events.ImageEventData":   func() events.EventData { return &events.ImageEventData{} },
+	"*events.ImageInputData":  func() events.EventData { return &events.ImageEventData{} },
+	"events.ImageInputData":   func() events.EventData { return &events.ImageEventData{} },
+	"*events.ImageOutputData": func() events.EventData { return &events.ImageEventData{} },
+	"events.ImageOutputData":  func() events.EventData { return &events.ImageEventData{} },
 
 	// Message events
 	"*events.MessageCreatedData":      func() events.EventData { return &events.MessageCreatedData{} },
@@ -70,51 +76,61 @@ var eventDataRegistry = map[string]func() events.EventData{
 	"*events.ProviderCallFailedData":    func() events.EventData { return &events.ProviderCallFailedData{} },
 	"events.ProviderCallFailedData":     func() events.EventData { return &events.ProviderCallFailedData{} },
 
-	// Tool events
-	"*events.ToolCallStartedData":   func() events.EventData { return &events.ToolCallStartedData{} },
-	"events.ToolCallStartedData":    func() events.EventData { return &events.ToolCallStartedData{} },
-	"*events.ToolCallCompletedData": func() events.EventData { return &events.ToolCallCompletedData{} },
-	"events.ToolCallCompletedData":  func() events.EventData { return &events.ToolCallCompletedData{} },
-	"*events.ToolCallFailedData":    func() events.EventData { return &events.ToolCallFailedData{} },
-	"events.ToolCallFailedData":     func() events.EventData { return &events.ToolCallFailedData{} },
+	// Tool events (consolidated into ToolCallEventData)
+	"*events.ToolCallEventData":     func() events.EventData { return &events.ToolCallEventData{} },
+	"events.ToolCallEventData":      func() events.EventData { return &events.ToolCallEventData{} },
+	"*events.ToolCallStartedData":   func() events.EventData { return &events.ToolCallEventData{} },
+	"events.ToolCallStartedData":    func() events.EventData { return &events.ToolCallEventData{} },
+	"*events.ToolCallCompletedData": func() events.EventData { return &events.ToolCallEventData{} },
+	"events.ToolCallCompletedData":  func() events.EventData { return &events.ToolCallEventData{} },
+	"*events.ToolCallFailedData":    func() events.EventData { return &events.ToolCallEventData{} },
+	"events.ToolCallFailedData":     func() events.EventData { return &events.ToolCallEventData{} },
 
 	// Custom events
 	"*events.CustomEventData": func() events.EventData { return &events.CustomEventData{} },
 	"events.CustomEventData":  func() events.EventData { return &events.CustomEventData{} },
 
-	// Stage events
-	"*events.StageStartedData":   func() events.EventData { return &events.StageStartedData{} },
-	"events.StageStartedData":    func() events.EventData { return &events.StageStartedData{} },
-	"*events.StageCompletedData": func() events.EventData { return &events.StageCompletedData{} },
-	"events.StageCompletedData":  func() events.EventData { return &events.StageCompletedData{} },
-	"*events.StageFailedData":    func() events.EventData { return &events.StageFailedData{} },
-	"events.StageFailedData":     func() events.EventData { return &events.StageFailedData{} },
+	// Stage events (consolidated into StageEventData)
+	"*events.StageEventData":     func() events.EventData { return &events.StageEventData{} },
+	"events.StageEventData":      func() events.EventData { return &events.StageEventData{} },
+	"*events.StageStartedData":   func() events.EventData { return &events.StageEventData{} },
+	"events.StageStartedData":    func() events.EventData { return &events.StageEventData{} },
+	"*events.StageCompletedData": func() events.EventData { return &events.StageEventData{} },
+	"events.StageCompletedData":  func() events.EventData { return &events.StageEventData{} },
+	"*events.StageFailedData":    func() events.EventData { return &events.StageEventData{} },
+	"events.StageFailedData":     func() events.EventData { return &events.StageEventData{} },
 
-	// Middleware events
-	"*events.MiddlewareStartedData":   func() events.EventData { return &events.MiddlewareStartedData{} },
-	"events.MiddlewareStartedData":    func() events.EventData { return &events.MiddlewareStartedData{} },
-	"*events.MiddlewareCompletedData": func() events.EventData { return &events.MiddlewareCompletedData{} },
-	"events.MiddlewareCompletedData":  func() events.EventData { return &events.MiddlewareCompletedData{} },
-	"*events.MiddlewareFailedData":    func() events.EventData { return &events.MiddlewareFailedData{} },
-	"events.MiddlewareFailedData":     func() events.EventData { return &events.MiddlewareFailedData{} },
+	// Middleware events (consolidated into MiddlewareEventData)
+	"*events.MiddlewareEventData":     func() events.EventData { return &events.MiddlewareEventData{} },
+	"events.MiddlewareEventData":      func() events.EventData { return &events.MiddlewareEventData{} },
+	"*events.MiddlewareStartedData":   func() events.EventData { return &events.MiddlewareEventData{} },
+	"events.MiddlewareStartedData":    func() events.EventData { return &events.MiddlewareEventData{} },
+	"*events.MiddlewareCompletedData": func() events.EventData { return &events.MiddlewareEventData{} },
+	"events.MiddlewareCompletedData":  func() events.EventData { return &events.MiddlewareEventData{} },
+	"*events.MiddlewareFailedData":    func() events.EventData { return &events.MiddlewareEventData{} },
+	"events.MiddlewareFailedData":     func() events.EventData { return &events.MiddlewareEventData{} },
 
-	// Validation events
-	"*events.ValidationStartedData": func() events.EventData { return &events.ValidationStartedData{} },
-	"events.ValidationStartedData":  func() events.EventData { return &events.ValidationStartedData{} },
-	"*events.ValidationPassedData":  func() events.EventData { return &events.ValidationPassedData{} },
-	"events.ValidationPassedData":   func() events.EventData { return &events.ValidationPassedData{} },
-	"*events.ValidationFailedData":  func() events.EventData { return &events.ValidationFailedData{} },
-	"events.ValidationFailedData":   func() events.EventData { return &events.ValidationFailedData{} },
+	// Validation events (consolidated into ValidationEventData)
+	"*events.ValidationEventData":   func() events.EventData { return &events.ValidationEventData{} },
+	"events.ValidationEventData":    func() events.EventData { return &events.ValidationEventData{} },
+	"*events.ValidationStartedData": func() events.EventData { return &events.ValidationEventData{} },
+	"events.ValidationStartedData":  func() events.EventData { return &events.ValidationEventData{} },
+	"*events.ValidationPassedData":  func() events.EventData { return &events.ValidationEventData{} },
+	"events.ValidationPassedData":   func() events.EventData { return &events.ValidationEventData{} },
+	"*events.ValidationFailedData":  func() events.EventData { return &events.ValidationEventData{} },
+	"events.ValidationFailedData":   func() events.EventData { return &events.ValidationEventData{} },
 
-	// Context/State events
+	// Context/State events (StateLoadedData/StateSavedData consolidated into StateEventData)
 	"*events.ContextBuiltData":        func() events.EventData { return &events.ContextBuiltData{} },
 	"events.ContextBuiltData":         func() events.EventData { return &events.ContextBuiltData{} },
 	"*events.TokenBudgetExceededData": func() events.EventData { return &events.TokenBudgetExceededData{} },
 	"events.TokenBudgetExceededData":  func() events.EventData { return &events.TokenBudgetExceededData{} },
-	"*events.StateLoadedData":         func() events.EventData { return &events.StateLoadedData{} },
-	"events.StateLoadedData":          func() events.EventData { return &events.StateLoadedData{} },
-	"*events.StateSavedData":          func() events.EventData { return &events.StateSavedData{} },
-	"events.StateSavedData":           func() events.EventData { return &events.StateSavedData{} },
+	"*events.StateEventData":          func() events.EventData { return &events.StateEventData{} },
+	"events.StateEventData":           func() events.EventData { return &events.StateEventData{} },
+	"*events.StateLoadedData":         func() events.EventData { return &events.StateEventData{} },
+	"events.StateLoadedData":          func() events.EventData { return &events.StateEventData{} },
+	"*events.StateSavedData":          func() events.EventData { return &events.StateEventData{} },
+	"events.StateSavedData":           func() events.EventData { return &events.StateEventData{} },
 	"*events.StreamInterruptedData":   func() events.EventData { return &events.StreamInterruptedData{} },
 	"events.StreamInterruptedData":    func() events.EventData { return &events.StreamInterruptedData{} },
 }

--- a/tools/arena/tui/event_adapter.go
+++ b/tools/arena/tui/event_adapter.go
@@ -208,7 +208,7 @@ func (a *EventAdapter) handleConversationStarted(event *events.Event) tea.Msg {
 
 // handleArenaEvents handles arena-specific custom events.
 func (a *EventAdapter) handleArenaEvents(event *events.Event) tea.Msg {
-	switch event.Type {
+	switch event.Type { //nolint:exhaustive // Only arena-specific event types are handled here
 	case events.EventType("arena.run.started"):
 		return RunStartedMsg{
 			RunID:    event.RunID,
@@ -287,39 +287,30 @@ func providerModel(event *events.Event) string {
 }
 
 func middlewareName(event *events.Event) string {
-	if data, ok := event.Data.(events.MiddlewareStartedData); ok {
+	if data, ok := event.Data.(events.MiddlewareEventData); ok {
 		return data.Name
 	}
-	if data, ok := event.Data.(events.MiddlewareCompletedData); ok {
-		return data.Name
-	}
-	if data, ok := event.Data.(events.MiddlewareFailedData); ok {
+	if data, ok := event.Data.(*events.MiddlewareEventData); ok {
 		return data.Name
 	}
 	return ""
 }
 
 func toolName(event *events.Event) string {
-	if data, ok := event.Data.(events.ToolCallStartedData); ok {
+	if data, ok := event.Data.(events.ToolCallEventData); ok {
 		return data.ToolName
 	}
-	if data, ok := event.Data.(events.ToolCallCompletedData); ok {
-		return data.ToolName
-	}
-	if data, ok := event.Data.(events.ToolCallFailedData); ok {
+	if data, ok := event.Data.(*events.ToolCallEventData); ok {
 		return data.ToolName
 	}
 	return ""
 }
 
 func validationName(event *events.Event) string {
-	if data, ok := event.Data.(events.ValidationStartedData); ok {
+	if data, ok := event.Data.(events.ValidationEventData); ok {
 		return data.ValidatorName
 	}
-	if data, ok := event.Data.(events.ValidationPassedData); ok {
-		return data.ValidatorName
-	}
-	if data, ok := event.Data.(events.ValidationFailedData); ok {
+	if data, ok := event.Data.(*events.ValidationEventData); ok {
 		return data.ValidatorName
 	}
 	return ""
@@ -329,11 +320,11 @@ func eventError(event *events.Event) error {
 	switch data := event.Data.(type) {
 	case events.ProviderCallFailedData:
 		return data.Error
-	case events.MiddlewareFailedData:
+	case events.MiddlewareEventData:
 		return data.Error
-	case events.ToolCallFailedData:
+	case events.ToolCallEventData:
 		return data.Error
-	case events.ValidationFailedData:
+	case events.ValidationEventData:
 		return data.Error
 	default:
 		return nil

--- a/tools/arena/tui/logging/interceptor.go
+++ b/tools/arena/tui/logging/interceptor.go
@@ -155,7 +155,7 @@ func (l *Interceptor) FlushBuffer() {
 
 	for i := range l.logBuffer {
 		// Ignore errors during flush - best effort
-		// Use background context since original context may be cancelled
+		// Use background context since original context may be canceled
 		_ = l.originalHandler.Handle(context.Background(), l.logBuffer[i])
 	}
 

--- a/tools/arena/tui/pages/conversation.go
+++ b/tools/arena/tui/pages/conversation.go
@@ -2,10 +2,11 @@
 package pages
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
 	"github.com/AltairaLabs/PromptKit/tools/arena/tui/panels"
 	"github.com/AltairaLabs/PromptKit/tools/arena/tui/views"
-	tea "github.com/charmbracelet/bubbletea"
 )
 
 // ConversationPage renders the conversation view

--- a/tools/arena/tui/tui.go
+++ b/tools/arena/tui/tui.go
@@ -248,14 +248,15 @@ func (m *Model) handleRunStarted(msg *RunStartedMsg) {
 func (m *Model) handleRunCompleted(msg *RunCompletedMsg) {
 	// Find and update the run in activeRuns
 	for i := range m.activeRuns {
-		if m.activeRuns[i].RunID == msg.RunID {
-			m.activeRuns[i].Status = StatusCompleted
-			m.activeRuns[i].Duration = msg.Duration
-			m.activeRuns[i].Cost = msg.Cost
-			m.activeRuns[i].CurrentTurnRole = ""
-			m.activeRuns[i].CurrentTurnIndex = 0
-			break
+		if m.activeRuns[i].RunID != msg.RunID {
+			continue
 		}
+		m.activeRuns[i].Status = StatusCompleted
+		m.activeRuns[i].Duration = msg.Duration
+		m.activeRuns[i].Cost = msg.Cost
+		m.activeRuns[i].CurrentTurnRole = ""
+		m.activeRuns[i].CurrentTurnIndex = 0
+		break
 	}
 
 	// Update metrics
@@ -289,13 +290,14 @@ func (m *Model) handleRunCompleted(msg *RunCompletedMsg) {
 func (m *Model) handleRunFailed(msg *RunFailedMsg) {
 	// Find and update the run in activeRuns
 	for i := range m.activeRuns {
-		if m.activeRuns[i].RunID == msg.RunID {
-			m.activeRuns[i].Status = StatusFailed
-			m.activeRuns[i].Error = msg.Error.Error()
-			m.activeRuns[i].CurrentTurnRole = ""
-			m.activeRuns[i].CurrentTurnIndex = 0
-			break
+		if m.activeRuns[i].RunID != msg.RunID {
+			continue
 		}
+		m.activeRuns[i].Status = StatusFailed
+		m.activeRuns[i].Error = msg.Error.Error()
+		m.activeRuns[i].CurrentTurnRole = ""
+		m.activeRuns[i].CurrentTurnIndex = 0
+		break
 	}
 
 	// Update metrics
@@ -711,23 +713,6 @@ func (m *Model) convertToLogEntries() []panels.LogEntry {
 		}
 	}
 	return logs
-}
-
-func (m *Model) currentRunForDetail() *RunInfo {
-	if sel := m.selectedRun(); sel != nil {
-		return sel
-	}
-	if m.mainPage != nil {
-		table := m.mainPage.RunsPanel().Table()
-		idx := table.Cursor()
-		if idx >= 0 && idx < len(m.activeRuns) {
-			return &m.activeRuns[idx]
-		}
-	}
-	if len(m.activeRuns) > 0 {
-		return &m.activeRuns[0]
-	}
-	return nil
 }
 
 func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/tools/arena/tui/tui_test.go
+++ b/tools/arena/tui/tui_test.go
@@ -507,29 +507,6 @@ func TestConvertToLogEntries(t *testing.T) {
 	assert.Equal(t, "ERROR", logs[2].Level)
 }
 
-func TestCurrentRunForDetail(t *testing.T) {
-	m := NewModel("test.yaml", 2)
-
-	// No runs - returns nil
-	run := m.currentRunForDetail()
-	assert.Nil(t, run)
-
-	// With runs but no selection
-	m.activeRuns = []RunInfo{
-		{RunID: "run-1", Scenario: "scn1"},
-		{RunID: "run-2", Scenario: "scn2"},
-	}
-	run = m.currentRunForDetail()
-	// Should return first run when no selection
-	assert.NotNil(t, run)
-	assert.Equal(t, "run-1", run.RunID)
-
-	// With selected run
-	m.activeRuns[1].Selected = true
-	run = m.currentRunForDetail()
-	assert.NotNil(t, run)
-	assert.Equal(t, "run-2", run.RunID)
-}
 
 func TestRenderMainPage_NoStateStore(t *testing.T) {
 	m := NewModel("test.yaml", 1)

--- a/tools/arena/tui/views/logs.go
+++ b/tools/arena/tui/views/logs.go
@@ -13,6 +13,7 @@ import (
 const (
 	logsPaddingVertical   = 1
 	logsPaddingHorizontal = 1
+	logsPaddingSides      = 2 // both left and right
 )
 
 // LogEntry represents a single log line
@@ -50,8 +51,8 @@ func (v *LogsView) Render(vp *viewport.Model, ready bool, width int) string {
 		content = lipgloss.JoinVertical(lipgloss.Left, title, vp.View())
 	}
 
-	// Account for chrome: horizontal padding (2 * logsPaddingHorizontal) + 1 for border adjustment
-	chromeWidth := (2 * logsPaddingHorizontal) + 1
+	// Account for chrome: horizontal padding (both sides) + 1 for border adjustment
+	chromeWidth := (logsPaddingSides * logsPaddingHorizontal) + 1
 	innerWidth := width - chromeWidth
 	if innerWidth < 0 {
 		innerWidth = 0


### PR DESCRIPTION
## Summary

Closes #482

- Consolidated 20+ separate event data structs into 7 canonical types using Go type aliases for full backward compatibility:
  - `MiddlewareEventData` (replaces Started/Completed/Failed triplet)
  - `StageEventData` (replaces Started/Completed/Failed triplet)
  - `ToolCallEventData` (replaces Started/Completed/Failed triplet)
  - `ValidationEventData` (replaces Started/Passed/Failed triplet)
  - `StateEventData` (replaces Loaded/Saved pair)
  - `AudioEventData` (replaces Input/Output pair)
  - `ImageEventData` (replaces Input/Output pair)
- Updated deserialization registries in `events/store.go` and `recording/recording.go` to handle canonical type names (`fmt.Sprintf("%T")` on alias values produces the canonical name)
- Simplified `media_timeline.go` audio extraction to use single `*AudioEventData` assertion
- Simplified `tools/arena/tui/event_adapter.go` helper functions from 3 type checks to 2
- Fixed pre-existing lint issues in touched packages (goimports, misspell, magic numbers, unused code)
- Added comprehensive tests for all registry entries and consolidated type deserialization

## Test plan

- [x] All `runtime/...` tests pass (250+ tests)
- [x] All `sdk/...` tests pass
- [x] All `tools/arena/...` tests pass
- [x] `golangci-lint` passes on all touched packages
- [x] Per-file coverage >= 80% on all changed files
- [x] Backward compatibility verified: existing code using old type names (e.g., `MiddlewareStartedData`) continues to work unchanged