### PR TITLE
refactor(runtime): standardize Gemini provider field naming

### DIFF
--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -23,16 +23,22 @@ const (
 	httpClientTimeout = 60 * time.Second
 )
 
+// streamSessionFactory is the function signature for creating stream sessions.
+type streamSessionFactory func(
+	ctx context.Context, wsURL, apiKey string, config *StreamSessionConfig,
+) (*StreamSession, error)
+
 // Provider implements the Provider interface for Google Gemini
 type Provider struct {
 	providers.BaseProvider
-	model          string
-	baseURL        string
-	apiKey         string
-	credential     providers.Credential
-	defaults       providers.ProviderDefaults
-	platform       string
-	platformConfig *providers.PlatformConfig
+	model              string
+	baseURL            string
+	apiKey             string
+	credential         providers.Credential
+	defaults           providers.ProviderDefaults
+	platform           string
+	platformConfig     *providers.PlatformConfig
+	newStreamSessionFn streamSessionFactory // override for testing; nil means use NewStreamSession
 }
 
 // NewProvider creates a new Gemini provider

--- a/runtime/providers/gemini/gemini_helpers_test.go
+++ b/runtime/providers/gemini/gemini_helpers_test.go
@@ -168,7 +168,7 @@ func TestPrepareGeminiRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &Provider{
-				Defaults: tt.defaults,
+				defaults: tt.defaults,
 			}
 
 			contents, systemInstruction, temp, topP, maxTokens := provider.prepareGeminiRequest(tt.req)
@@ -301,7 +301,7 @@ func TestBuildGeminiRequest(t *testing.T) {
 func TestGeminiHelpers_Integration(t *testing.T) {
 	t.Run("Full request preparation flow", func(t *testing.T) {
 		provider := &Provider{
-			Defaults: providers.ProviderDefaults{
+			defaults: providers.ProviderDefaults{
 				Temperature: 0.7,
 				TopP:        0.95,
 				MaxTokens:   2000,

--- a/runtime/providers/gemini/gemini_multimodal.go
+++ b/runtime/providers/gemini/gemini_multimodal.go
@@ -209,15 +209,15 @@ func (p *Provider) predictWithContents(ctx context.Context, contents []geminiCon
 
 	// Apply provider defaults for zero values
 	if temperature == 0 {
-		temperature = p.Defaults.Temperature
+		temperature = p.defaults.Temperature
 	}
 
 	if topP == 0 {
-		topP = p.Defaults.TopP
+		topP = p.defaults.TopP
 	}
 
 	if maxTokens == 0 {
-		maxTokens = p.Defaults.MaxTokens
+		maxTokens = p.defaults.MaxTokens
 	}
 
 	// Create request
@@ -239,7 +239,7 @@ func (p *Provider) predictWithContents(ctx context.Context, contents []geminiCon
 	}
 
 	// Build URL with API key
-	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", p.BaseURL, p.modelName, p.ApiKey)
+	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", p.baseURL, p.model, p.apiKey)
 
 	// Debug log the request
 	headers := map[string]string{
@@ -355,15 +355,15 @@ func (p *Provider) parseGeminiResponse(respBody []byte) (*geminiResponse, error)
 func (p *Provider) predictStreamWithContents(ctx context.Context, contents []geminiContent, systemInstruction *geminiContent, temperature, topP float32, maxTokens int, seed *int) (<-chan providers.StreamChunk, error) {
 	// Apply provider defaults for zero values
 	if temperature == 0 {
-		temperature = p.Defaults.Temperature
+		temperature = p.defaults.Temperature
 	}
 
 	if topP == 0 {
-		topP = p.Defaults.TopP
+		topP = p.defaults.TopP
 	}
 
 	if maxTokens == 0 {
-		maxTokens = p.Defaults.MaxTokens
+		maxTokens = p.defaults.MaxTokens
 	}
 
 	// Create streaming request
@@ -377,7 +377,7 @@ func (p *Provider) predictStreamWithContents(ctx context.Context, contents []gem
 	}
 
 	// Build URL for streaming
-	url := fmt.Sprintf("%s/models/%s:streamGenerateContent?key=%s", p.BaseURL, p.modelName, p.ApiKey)
+	url := fmt.Sprintf("%s/models/%s:streamGenerateContent?key=%s", p.baseURL, p.model, p.apiKey)
 
 	// Make HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -22,7 +22,7 @@ func (p *Provider) PredictStream(
 	// Enrich context with provider and model info for logging
 	ctx = logger.WithLoggingContext(ctx, &logger.LoggingFields{
 		Provider: p.ID(),
-		Model:    p.modelName,
+		Model:    p.model,
 	})
 
 	// Convert messages to Gemini format and apply defaults
@@ -40,7 +40,7 @@ func (p *Provider) PredictStream(
 	}
 
 	// Make HTTP request
-	url := fmt.Sprintf("%s/models/%s:streamGenerateContent?key=%s", p.BaseURL, p.modelName, p.ApiKey)
+	url := fmt.Sprintf("%s/models/%s:streamGenerateContent?key=%s", p.baseURL, p.model, p.apiKey)
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/runtime/providers/gemini/gemini_test.go
+++ b/runtime/providers/gemini/gemini_test.go
@@ -34,11 +34,11 @@ func TestNewProvider(t *testing.T) {
 		t.Errorf("Expected model 'gemini-1.5-pro', got '%s'", provider.Model())
 	}
 
-	if provider.BaseURL != "https://generativelanguage.googleapis.com/v1beta" {
+	if provider.baseURL != "https://generativelanguage.googleapis.com/v1beta" {
 		t.Error("BaseURL mismatch")
 	}
 
-	if provider.Defaults.Temperature != 0.9 {
+	if provider.defaults.Temperature != 0.9 {
 		t.Error("Temperature default mismatch")
 	}
 }
@@ -66,8 +66,8 @@ func TestNewProviderWithCredential(t *testing.T) {
 			t.Errorf("Expected model 'gemini-1.5-pro', got '%s'", provider.Model())
 		}
 
-		if provider.ApiKey != "test-api-key" {
-			t.Errorf("Expected ApiKey 'test-api-key', got '%s'", provider.ApiKey)
+		if provider.apiKey != "test-api-key" {
+			t.Errorf("Expected ApiKey 'test-api-key', got '%s'", provider.apiKey)
 		}
 
 		if provider.credential == nil {
@@ -82,8 +82,8 @@ func TestNewProviderWithCredential(t *testing.T) {
 			t.Fatal("Expected non-nil provider")
 		}
 
-		if provider.ApiKey != "" {
-			t.Errorf("Expected empty ApiKey, got '%s'", provider.ApiKey)
+		if provider.apiKey != "" {
+			t.Errorf("Expected empty ApiKey, got '%s'", provider.apiKey)
 		}
 	})
 
@@ -96,8 +96,8 @@ func TestNewProviderWithCredential(t *testing.T) {
 		}
 
 		// Should not extract API key from non-api_key credential
-		if provider.ApiKey != "" {
-			t.Errorf("Expected empty ApiKey for non-APIKey credential, got '%s'", provider.ApiKey)
+		if provider.apiKey != "" {
+			t.Errorf("Expected empty ApiKey for non-APIKey credential, got '%s'", provider.apiKey)
 		}
 
 		if provider.credential == nil {

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -482,7 +482,7 @@ func (p *ToolProvider) makeRequest(ctx context.Context, request any) ([]byte, er
 	}
 
 	// Build URL with API key for Gemini
-	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", p.BaseURL, p.modelName, p.ApiKey)
+	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", p.baseURL, p.model, p.apiKey)
 
 	// Debug log the request
 	var requestObj any
@@ -547,7 +547,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 	// Use streamGenerateContent endpoint
 	url := fmt.Sprintf(
 		"%s/models/%s:streamGenerateContent?key=%s",
-		p.BaseURL, p.modelName, p.ApiKey,
+		p.baseURL, p.model, p.apiKey,
 	)
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestBytes))

--- a/runtime/providers/gemini/streaming_support.go
+++ b/runtime/providers/gemini/streaming_support.go
@@ -62,7 +62,12 @@ func (p *Provider) CreateStreamSession(
 		config.ResponseModalities = []string{"TEXT"}
 	}
 
-	session, err := NewStreamSession(ctx, geminiLiveAPIURL, p.apiKey, &config)
+	factory := p.newStreamSessionFn
+	if factory == nil {
+		factory = NewStreamSession
+	}
+
+	session, err := factory(ctx, geminiLiveAPIURL, p.apiKey, &config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create stream session: %w", err)
 	}

--- a/runtime/providers/gemini/streaming_support.go
+++ b/runtime/providers/gemini/streaming_support.go
@@ -62,7 +62,7 @@ func (p *Provider) CreateStreamSession(
 		config.ResponseModalities = []string{"TEXT"}
 	}
 
-	session, err := NewStreamSession(ctx, geminiLiveAPIURL, p.ApiKey, &config)
+	session, err := NewStreamSession(ctx, geminiLiveAPIURL, p.apiKey, &config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create stream session: %w", err)
 	}
@@ -95,7 +95,7 @@ func (p *Provider) validateStreamRequest(req *providers.StreamingInputConfig) er
 // buildStreamSessionConfig creates a base session configuration
 func (p *Provider) buildStreamSessionConfig(req *providers.StreamingInputConfig) StreamSessionConfig {
 	config := StreamSessionConfig{
-		Model:             p.modelName,
+		Model:             p.model,
 		SystemInstruction: req.SystemInstruction,
 		AutoReconnect:     true,
 		MaxReconnectTries: defaultMaxReconnectTries,
@@ -107,11 +107,11 @@ func (p *Provider) buildStreamSessionConfig(req *providers.StreamingInputConfig)
 
 // applyPricingConfig sets pricing from provider defaults or model-based defaults
 func (p *Provider) applyPricingConfig(config *StreamSessionConfig) {
-	if p.Defaults.Pricing.InputCostPer1K > 0 && p.Defaults.Pricing.OutputCostPer1K > 0 {
-		config.InputCostPer1K = p.Defaults.Pricing.InputCostPer1K
-		config.OutputCostPer1K = p.Defaults.Pricing.OutputCostPer1K
+	if p.defaults.Pricing.InputCostPer1K > 0 && p.defaults.Pricing.OutputCostPer1K > 0 {
+		config.InputCostPer1K = p.defaults.Pricing.InputCostPer1K
+		config.OutputCostPer1K = p.defaults.Pricing.OutputCostPer1K
 	} else {
-		config.InputCostPer1K, config.OutputCostPer1K, _ = geminiPricing(p.modelName)
+		config.InputCostPer1K, config.OutputCostPer1K, _ = geminiPricing(p.model)
 	}
 }
 

--- a/runtime/providers/gemini/streaming_support_test.go
+++ b/runtime/providers/gemini/streaming_support_test.go
@@ -211,7 +211,7 @@ func TestGeminiProvider_CreateStreamSession_InvalidConfig(t *testing.T) {
 func TestGeminiProvider_CreateStreamSession_ValidConfig(t *testing.T) {
 	// Skip if no API key available (for CI/CD)
 	provider := NewProvider("test", "gemini-2.0-flash-exp", "https://api.test.com", providers.ProviderDefaults{}, false)
-	if provider.ApiKey == "" {
+	if provider.apiKey == "" {
 		t.Skip("Skipping test: GEMINI_API_KEY not set")
 	}
 
@@ -348,7 +348,7 @@ func TestGeminiProvider_CreateStreamSession_WithTools(t *testing.T) {
 	provider := NewProvider("test", "gemini-2.0-flash-exp", "https://api.test.com", providers.ProviderDefaults{}, false)
 
 	// Skip if no API key available
-	if provider.ApiKey == "" {
+	if provider.apiKey == "" {
 		t.Skip("Skipping test: GEMINI_API_KEY not set")
 	}
 


### PR DESCRIPTION
## Summary
- Standardizes field naming conventions in Gemini provider for consistency
- Aligns with patterns used by other providers

Closes #486