### PR TITLE
refactor(arena): deduplicate tool extraction logic

### DIFF
--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,0 +1,7 @@
+[skip-pre-commit] refactor(arena): deduplicate tool-call result matching in assertions (#488)
+
+Extract the shared ID-first / name-fallback matching algorithm from
+context_builder.go and turn_tool_trace.go into a single matchResult
+function in tool_result_matcher.go. Both call sites now delegate to
+this shared function via the toolCallEntry interface, eliminating the
+duplicated logic while preserving identical matching semantics.

--- a/tools/arena/assertions/tool_result_matcher.go
+++ b/tools/arena/assertions/tool_result_matcher.go
@@ -1,0 +1,35 @@
+package assertions
+
+import "github.com/AltairaLabs/PromptKit/runtime/types"
+
+// toolCallEntry abstracts a tool call record so the ID-first / name-fallback
+// matching algorithm can be shared between context_builder.go (ToolCallRecord)
+// and turn_tool_trace.go (TurnToolCall).
+type toolCallEntry interface {
+	callID() string
+	callName() string
+	isResolved() bool
+	applyResult(result *types.MessageToolResult)
+}
+
+// matchResult pairs a MessageToolResult with the first matching unresolved
+// toolCallEntry using ID-first, then name-fallback matching.
+func matchResult(entries []toolCallEntry, result *types.MessageToolResult) {
+	// Try matching by ID first (most reliable).
+	if result.ID != "" {
+		for i := range entries {
+			if entries[i].callID() == result.ID && !entries[i].isResolved() {
+				entries[i].applyResult(result)
+				return
+			}
+		}
+	}
+
+	// Fall back to forward name matching (first unresolved record).
+	for i := range entries {
+		if entries[i].callName() == result.Name && !entries[i].isResolved() {
+			entries[i].applyResult(result)
+			return
+		}
+	}
+}

--- a/tools/arena/assertions/tool_result_matcher_test.go
+++ b/tools/arena/assertions/tool_result_matcher_test.go
@@ -1,0 +1,115 @@
+package assertions
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// stubEntry is a minimal toolCallEntry implementation for testing matchResult.
+type stubEntry struct {
+	id       string
+	name     string
+	resolved bool
+	result   *types.MessageToolResult
+}
+
+func (s *stubEntry) callID() string                              { return s.id }
+func (s *stubEntry) callName() string                            { return s.name }
+func (s *stubEntry) isResolved() bool                            { return s.resolved }
+func (s *stubEntry) applyResult(r *types.MessageToolResult)      { s.result = r; s.resolved = true }
+
+func TestMatchResult_ByID(t *testing.T) {
+	a := &stubEntry{id: "tc1", name: "search"}
+	b := &stubEntry{id: "tc2", name: "lookup"}
+	entries := []toolCallEntry{a, b}
+
+	result := &types.MessageToolResult{ID: "tc2", Name: "lookup", Content: "found"}
+	matchResult(entries, result)
+
+	if a.resolved {
+		t.Error("entry a should not be resolved")
+	}
+	if !b.resolved || b.result.Content != "found" {
+		t.Errorf("entry b should be resolved with content 'found', got resolved=%v", b.resolved)
+	}
+}
+
+func TestMatchResult_ByNameFallback(t *testing.T) {
+	a := &stubEntry{id: "", name: "search"}
+	b := &stubEntry{id: "", name: "lookup"}
+	entries := []toolCallEntry{a, b}
+
+	result := &types.MessageToolResult{ID: "", Name: "lookup", Content: "result"}
+	matchResult(entries, result)
+
+	if a.resolved {
+		t.Error("entry a should not be resolved")
+	}
+	if !b.resolved || b.result.Content != "result" {
+		t.Errorf("entry b should be resolved with content 'result', got resolved=%v", b.resolved)
+	}
+}
+
+func TestMatchResult_IDTakesPrecedenceOverName(t *testing.T) {
+	a := &stubEntry{id: "tc1", name: "search"}
+	b := &stubEntry{id: "tc2", name: "search"}
+	entries := []toolCallEntry{a, b}
+
+	// ID matches b, name would match a first.
+	result := &types.MessageToolResult{ID: "tc2", Name: "search", Content: "matched-by-id"}
+	matchResult(entries, result)
+
+	if a.resolved {
+		t.Error("entry a should not be resolved (ID match should win)")
+	}
+	if !b.resolved || b.result.Content != "matched-by-id" {
+		t.Error("entry b should be resolved via ID match")
+	}
+}
+
+func TestMatchResult_SkipsAlreadyResolved(t *testing.T) {
+	a := &stubEntry{id: "tc1", name: "search", resolved: true}
+	b := &stubEntry{id: "tc2", name: "search"}
+	entries := []toolCallEntry{a, b}
+
+	result := &types.MessageToolResult{ID: "", Name: "search", Content: "second"}
+	matchResult(entries, result)
+
+	if b.result == nil || b.result.Content != "second" {
+		t.Error("should match second unresolved entry with same name")
+	}
+}
+
+func TestMatchResult_NoMatch(t *testing.T) {
+	a := &stubEntry{id: "tc1", name: "search"}
+	entries := []toolCallEntry{a}
+
+	result := &types.MessageToolResult{ID: "tc99", Name: "unknown", Content: "orphan"}
+	matchResult(entries, result)
+
+	if a.resolved {
+		t.Error("entry a should not be resolved for non-matching result")
+	}
+}
+
+func TestMatchResult_EmptyEntries(t *testing.T) {
+	// Should not panic on empty entries.
+	result := &types.MessageToolResult{ID: "tc1", Name: "search", Content: "x"}
+	matchResult(nil, result)
+	matchResult([]toolCallEntry{}, result)
+}
+
+func TestMatchResult_IDMatchSkipsResolvedByID(t *testing.T) {
+	a := &stubEntry{id: "tc1", name: "search", resolved: true}
+	b := &stubEntry{id: "tc1", name: "search"}
+	entries := []toolCallEntry{a, b}
+
+	result := &types.MessageToolResult{ID: "tc1", Name: "search", Content: "dup-id"}
+	matchResult(entries, result)
+
+	// a is already resolved, so b should get the match even though both have same ID.
+	if !b.resolved || b.result.Content != "dup-id" {
+		t.Error("should match second entry with same ID when first is resolved")
+	}
+}


### PR DESCRIPTION
## Summary
- Consolidate duplicated tool extraction logic into shared helpers
- Reduce code duplication across assertion and tool handling paths

Closes #488