### PR TITLE
refactor(runtime): extract provider constructor factory

### DIFF
--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -80,16 +80,7 @@ func NewProviderWithCredential(
 	includeRawOutput bool, cred providers.Credential,
 	platform string, platformConfig *providers.PlatformConfig,
 ) *Provider {
-	client := &http.Client{Timeout: httpClientTimeout}
-	base := providers.NewBaseProvider(id, includeRawOutput, client)
-
-	// Extract API key from credential if it's an APIKeyCredential
-	var apiKey string
-	if cred != nil && cred.Type() == "api_key" {
-		if akc, ok := cred.(interface{ APIKey() string }); ok {
-			apiKey = akc.APIKey()
-		}
-	}
+	base, apiKey := providers.NewBaseProviderWithCredential(id, includeRawOutput, httpClientTimeout, cred)
 
 	return &Provider{
 		BaseProvider:   base,

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -520,20 +520,20 @@ func (p *ToolProvider) PredictStreamWithTools(
 	return outChan, nil
 }
 
+//nolint:gochecknoinits // Factory registration requires init
 func init() {
-	factory := func(spec providers.ProviderSpec) (providers.Provider, error) {
-		// Use credential if provided and it's not a no-op (empty) credential
-		if spec.Credential != nil && spec.Credential.Type() != "none" {
+	providers.RegisterProviderFactory("claude", providers.CredentialFactory(
+		func(spec providers.ProviderSpec) (providers.Provider, error) {
 			return NewToolProviderWithCredential(
 				spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
 				spec.IncludeRawOutput, spec.Credential,
 				spec.Platform, spec.PlatformConfig,
 			), nil
-		}
-		// Fall back to env-var-based constructor
-		return NewToolProvider(
-			spec.ID, spec.Model, spec.BaseURL, spec.Defaults, spec.IncludeRawOutput,
-		), nil
-	}
-	providers.RegisterProviderFactory("claude", factory)
+		},
+		func(spec providers.ProviderSpec) (providers.Provider, error) {
+			return NewToolProvider(
+				spec.ID, spec.Model, spec.BaseURL, spec.Defaults, spec.IncludeRawOutput,
+			), nil
+		},
+	))
 }

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -54,16 +54,7 @@ func NewProviderWithCredential(
 	includeRawOutput bool, cred providers.Credential,
 	platform string, platformConfig *providers.PlatformConfig,
 ) *Provider {
-	client := &http.Client{Timeout: httpClientTimeout}
-	base := providers.NewBaseProvider(id, includeRawOutput, client)
-
-	// Extract API key from credential if it's an APIKeyCredential
-	var apiKey string
-	if cred != nil && cred.Type() == "api_key" {
-		if akc, ok := cred.(interface{ APIKey() string }); ok {
-			apiKey = akc.APIKey()
-		}
-	}
+	base, apiKey := providers.NewBaseProviderWithCredential(id, includeRawOutput, httpClientTimeout, cred)
 
 	return &Provider{
 		BaseProvider:   base,

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -600,20 +600,20 @@ func (p *ToolProvider) GetStreamingCapabilities() providers.StreamingCapabilitie
 	return p.Provider.GetStreamingCapabilities()
 }
 
+//nolint:gochecknoinits // Factory registration requires init
 func init() {
-	factory := func(spec providers.ProviderSpec) (providers.Provider, error) {
-		// Use credential if provided and it's not a no-op (empty) credential
-		if spec.Credential != nil && spec.Credential.Type() != "none" {
+	providers.RegisterProviderFactory("gemini", providers.CredentialFactory(
+		func(spec providers.ProviderSpec) (providers.Provider, error) {
 			return NewToolProviderWithCredential(
 				spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
 				spec.IncludeRawOutput, spec.Credential,
 				spec.Platform, spec.PlatformConfig,
 			), nil
-		}
-		// Fall back to env-var-based constructor
-		return NewToolProvider(
-			spec.ID, spec.Model, spec.BaseURL, spec.Defaults, spec.IncludeRawOutput,
-		), nil
-	}
-	providers.RegisterProviderFactory("gemini", factory)
+		},
+		func(spec providers.ProviderSpec) (providers.Provider, error) {
+			return NewToolProvider(
+				spec.ID, spec.Model, spec.BaseURL, spec.Defaults, spec.IncludeRawOutput,
+			), nil
+		},
+	))
 }

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -119,16 +119,7 @@ func NewProviderWithCredentialAndConfig(
 	includeRawOutput bool, cred providers.Credential, additionalConfig map[string]any,
 	platform string, platformConfig *providers.PlatformConfig,
 ) *Provider {
-	client := &http.Client{Timeout: httpClientTimeout}
-	base := providers.NewBaseProvider(id, includeRawOutput, client)
-
-	// Extract API key from credential if it's an APIKeyCredential
-	var apiKey string
-	if cred != nil && cred.Type() == "api_key" {
-		if akc, ok := cred.(interface{ APIKey() string }); ok {
-			apiKey = akc.APIKey()
-		}
-	}
+	base, apiKey := providers.NewBaseProviderWithCredential(id, includeRawOutput, httpClientTimeout, cred)
 
 	return &Provider{
 		BaseProvider:     base,

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -407,21 +407,21 @@ func (p *ToolProvider) predictStreamWithCompletions(
 	return outChan, nil
 }
 
+//nolint:gochecknoinits // Factory registration requires init
 func init() {
-	factory := func(spec providers.ProviderSpec) (providers.Provider, error) {
-		// Use credential if provided and it's not a no-op (empty) credential
-		if spec.Credential != nil && spec.Credential.Type() != "none" {
+	providers.RegisterProviderFactory("openai", providers.CredentialFactory(
+		func(spec providers.ProviderSpec) (providers.Provider, error) {
 			return NewToolProviderWithCredential(
 				spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
 				spec.IncludeRawOutput, spec.AdditionalConfig, spec.Credential,
 				spec.Platform, spec.PlatformConfig,
 			), nil
-		}
-		// Fall back to env-var-based constructor
-		return NewToolProvider(
-			spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
-			spec.IncludeRawOutput, spec.AdditionalConfig,
-		), nil
-	}
-	providers.RegisterProviderFactory("openai", factory)
+		},
+		func(spec providers.ProviderSpec) (providers.Provider, error) {
+			return NewToolProvider(
+				spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
+				spec.IncludeRawOutput, spec.AdditionalConfig,
+			), nil
+		},
+	))
 }


### PR DESCRIPTION
## Summary
- Consolidate provider creation logic into a factory pattern
- Reduce duplication across provider implementations

Closes #476