### PR TITLE
fix(arena): disable schema validation in markdown result tests

### DIFF
--- a/tools/arena/results/markdown/init_test.go
+++ b/tools/arena/results/markdown/init_test.go
@@ -1,0 +1,14 @@
+package markdown
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+// init disables schema validation for tests since schemas may not be published yet.
+func init() {
+	if testing.Testing() {
+		config.SchemaValidationEnabled = false
+	}
+}


### PR DESCRIPTION
## Summary
- Add `init_test.go` to `tools/arena/results/markdown/` to disable schema validation during tests
- Fixes CI failure on main where `TestConfigurationIntegration` and `TestMarkdownConfigurationFromYAML` fail because `config.LoadConfig()` tries to validate against remote schemas that aren't available
- Matches the pattern used in `engine/init_test.go` and `cmd/promptarena/schema_disable_init_test.go`

## Test plan
- [x] `TestConfigurationIntegration` passes locally
- [x] `TestMarkdownConfigurationFromYAML` passes locally
- [ ] CI passes