### PR TITLE
refactor(sdk): extract duplex mode validation helpers

### DIFF
--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -95,14 +95,9 @@ func (c *Conversation) Stream(ctx context.Context, message any, opts ...SendOpti
 		startTime := time.Now()
 
 		c.mu.RLock()
-		if c.mode != UnaryMode {
+		if err := c.requireUnary("Stream()"); err != nil {
 			c.mu.RUnlock()
-			ch <- StreamChunk{Error: fmt.Errorf("Stream() only available in unary mode; use OpenDuplex() for duplex streaming")}
-			return
-		}
-		if c.closed {
-			c.mu.RUnlock()
-			ch <- StreamChunk{Error: ErrConversationClosed}
+			ch <- StreamChunk{Error: err}
 			return
 		}
 		c.mu.RUnlock()


### PR DESCRIPTION
## Summary
- Extract `requireDuplex(op string) error` and `requireUnary(op string) error` helpers on `Conversation` to replace repeated mode+closed guard blocks
- Replace 8 identical check patterns across `SendChunk`, `SendText`, `SendFrame`, `SendVideoChunk`, `TriggerStart`, `Response`, `Done`, `SessionError` with single-line `requireDuplex` calls
- Refactor `validateSendState` and `Stream` to use `requireUnary` helper
- Remove unused `errors` import from `conversation.go`

## Test plan
- [x] All existing SDK tests pass (`go test ./sdk/... -race -count=1`)
- [x] Pre-commit hook passes (lint, build, coverage >= 80%)
- [x] Error messages are unchanged (tests use `assert.Contains` matching)

Closes #471