### PR TITLE
refactor(sdk): extract session hook dispatcher from Conversation

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -199,6 +199,7 @@ func initConversation(
 
 	// Build hook registry BEFORE building pipeline so it can be wired into the provider stage
 	conv.hookRegistry = cfg.buildHookRegistry()
+	conv.sessionHooks = newSessionHookDispatcher(conv.hookRegistry, conv.sessionInfo)
 
 	return conv, prov, nil
 }
@@ -216,7 +217,7 @@ func finalizeConversation(conv *Conversation, cfg *config) error {
 	}
 
 	// Dispatch session start hooks
-	conv.runSessionStart(context.Background())
+	conv.sessionHooks.SessionStart(context.Background())
 
 	return nil
 }

--- a/sdk/session_hooks.go
+++ b/sdk/session_hooks.go
@@ -1,0 +1,105 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// sessionInfoFunc returns the dynamic session state needed to build a SessionEvent.
+// It is called at dispatch time so the event always reflects the latest state.
+type sessionInfoFunc func() (sessionID, conversationID string, messages []types.Message)
+
+// sessionHookDispatcher encapsulates session lifecycle hook dispatching.
+// It tracks the turn index and builds SessionEvent payloads via a callback,
+// keeping the dispatch mechanics separate from Conversation business logic.
+//
+// All public methods are nil-receiver safe: calling any method on a nil
+// *sessionHookDispatcher is a no-op (or returns a zero value).
+type sessionHookDispatcher struct {
+	registry *hooks.Registry
+	info     sessionInfoFunc
+	turns    int
+}
+
+// newSessionHookDispatcher creates a dispatcher that will call info() to gather
+// session metadata whenever it needs to build a hooks.SessionEvent.
+// Passing a nil registry is valid and produces a no-op dispatcher.
+func newSessionHookDispatcher(registry *hooks.Registry, info sessionInfoFunc) *sessionHookDispatcher {
+	return &sessionHookDispatcher{
+		registry: registry,
+		info:     info,
+	}
+}
+
+// SessionStart dispatches OnSessionStart to all registered session hooks.
+func (d *sessionHookDispatcher) SessionStart(ctx context.Context) {
+	if d == nil {
+		return
+	}
+	d.dispatch(ctx, func(ctx context.Context, e hooks.SessionEvent) error {
+		return d.registry.RunSessionStart(ctx, e)
+	})
+}
+
+// SessionUpdate dispatches OnSessionUpdate to all registered session hooks.
+func (d *sessionHookDispatcher) SessionUpdate(ctx context.Context) {
+	if d == nil {
+		return
+	}
+	d.dispatch(ctx, func(ctx context.Context, e hooks.SessionEvent) error {
+		return d.registry.RunSessionUpdate(ctx, e)
+	})
+}
+
+// SessionEnd dispatches OnSessionEnd to all registered session hooks.
+func (d *sessionHookDispatcher) SessionEnd(ctx context.Context) {
+	if d == nil {
+		return
+	}
+	d.dispatch(ctx, func(ctx context.Context, e hooks.SessionEvent) error {
+		return d.registry.RunSessionEnd(ctx, e)
+	})
+}
+
+// IncrementTurn advances the turn counter by one.
+func (d *sessionHookDispatcher) IncrementTurn() {
+	if d == nil {
+		return
+	}
+	d.turns++
+}
+
+// TurnIndex returns the current turn count.
+func (d *sessionHookDispatcher) TurnIndex() int {
+	if d == nil {
+		return 0
+	}
+	return d.turns
+}
+
+// dispatch builds a SessionEvent and calls fn. Errors from hooks are intentionally
+// discarded (they are logged inside the registry) so that hook failures never block
+// SDK operations.
+func (d *sessionHookDispatcher) dispatch(
+	ctx context.Context,
+	fn func(context.Context, hooks.SessionEvent) error,
+) {
+	if d.registry == nil {
+		return
+	}
+	_ = fn(ctx, d.buildEvent())
+}
+
+// buildEvent constructs a hooks.SessionEvent from the current dispatcher state
+// plus the dynamic info callback.
+func (d *sessionHookDispatcher) buildEvent() hooks.SessionEvent {
+	event := hooks.SessionEvent{
+		TurnIndex: d.turns,
+	}
+	if d.info != nil {
+		event.SessionID, event.ConversationID, event.Messages = d.info()
+	}
+	return event
+}

--- a/sdk/session_hooks_test.go
+++ b/sdk/session_hooks_test.go
@@ -1,0 +1,81 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionHookDispatcher_NilReceiver(t *testing.T) {
+	var d *sessionHookDispatcher
+
+	// All methods should be safe on a nil receiver.
+	d.SessionStart(context.Background())
+	d.SessionUpdate(context.Background())
+	d.SessionEnd(context.Background())
+	d.IncrementTurn()
+	assert.Equal(t, 0, d.TurnIndex())
+}
+
+func TestSessionHookDispatcher_NilRegistry(t *testing.T) {
+	d := newSessionHookDispatcher(nil, func() (string, string, []types.Message) {
+		return "s1", "c1", nil
+	})
+
+	// Should not panic — dispatch is a no-op.
+	d.SessionStart(context.Background())
+	d.SessionUpdate(context.Background())
+	d.SessionEnd(context.Background())
+}
+
+func TestSessionHookDispatcher_DispatchesAllLifecycleEvents(t *testing.T) {
+	hook := &recordingSessionHook{name: "lifecycle"}
+	reg := hooks.NewRegistry(hooks.WithSessionHook(hook))
+
+	d := newSessionHookDispatcher(reg, func() (string, string, []types.Message) {
+		return "sess-1", "conv-1", []types.Message{{Role: "user"}}
+	})
+
+	d.SessionStart(context.Background())
+	assert.True(t, hook.startCalled)
+	assert.Equal(t, "sess-1", hook.lastEvent.SessionID)
+	assert.Equal(t, "conv-1", hook.lastEvent.ConversationID)
+	assert.Equal(t, 0, hook.lastEvent.TurnIndex)
+	assert.Len(t, hook.lastEvent.Messages, 1)
+
+	d.IncrementTurn()
+	d.IncrementTurn()
+	d.SessionUpdate(context.Background())
+	assert.True(t, hook.updateCalled)
+	assert.Equal(t, 2, hook.lastEvent.TurnIndex)
+
+	d.SessionEnd(context.Background())
+	assert.True(t, hook.endCalled)
+}
+
+func TestSessionHookDispatcher_BuildEventNilInfo(t *testing.T) {
+	d := newSessionHookDispatcher(nil, nil)
+	d.turns = 5
+
+	event := d.buildEvent()
+
+	assert.Equal(t, 5, event.TurnIndex)
+	assert.Empty(t, event.SessionID)
+	assert.Empty(t, event.ConversationID)
+	assert.Nil(t, event.Messages)
+}
+
+func TestSessionHookDispatcher_TurnIndex(t *testing.T) {
+	d := newSessionHookDispatcher(nil, nil)
+	assert.Equal(t, 0, d.TurnIndex())
+
+	d.IncrementTurn()
+	assert.Equal(t, 1, d.TurnIndex())
+
+	d.IncrementTurn()
+	d.IncrementTurn()
+	assert.Equal(t, 3, d.TurnIndex())
+}

--- a/sdk/template.go
+++ b/sdk/template.go
@@ -157,7 +157,7 @@ func (t *PackTemplate) openConversation(
 		return nil, err
 	}
 
-	conv.runSessionStart(context.Background())
+	conv.sessionHooks.SessionStart(context.Background())
 	return conv, nil
 }
 


### PR DESCRIPTION
## Summary
- Extracts session lifecycle hook dispatching (start, update, end) from `Conversation` into a dedicated `sessionHookDispatcher` struct in `sdk/session_hooks.go`
- The dispatcher encapsulates the hook registry reference, turn counter, and event-building logic, keeping dispatch mechanics separate from conversation business logic
- All dispatcher methods are nil-receiver safe, matching the existing nil-safety pattern

## Test plan
- [x] New `sdk/session_hooks_test.go` with unit tests for the dispatcher (nil receiver, nil registry, full lifecycle, event building, turn tracking)
- [x] Updated existing session hook tests in `sdk/conversation_test.go` to use the dispatcher API
- [x] All SDK tests pass (`go test ./sdk/... -race -count=1`)
- [x] Lint clean on changed files (`golangci-lint run ./sdk/...`)
- [x] 100% coverage on `sdk/session_hooks.go`, 81% on `sdk/conversation.go`

Closes #474