### PR TITLE
feat(sdk): add TTL-based eviction for A2A tasks and conversations

### DIFF
--- a/sdk/a2a_eviction_test.go
+++ b/sdk/a2a_eviction_test.go
@@ -1,0 +1,288 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// --- eviction tests ---
+
+func TestA2AServer_EvictOnce_EvictsTerminalTasks(t *testing.T) {
+	store := NewInMemoryA2ATaskStore()
+
+	// Create a completed task with an old timestamp.
+	_, err := store.Create("old-task", "ctx-1")
+	require.NoError(t, err)
+	require.NoError(t, store.SetState("old-task", a2a.TaskStateWorking, nil))
+	require.NoError(t, store.SetState("old-task", a2a.TaskStateCompleted, nil))
+
+	// Backdate the task's timestamp to 2 hours ago.
+	task, _ := store.Get("old-task")
+	old := time.Now().Add(-2 * time.Hour)
+	task.Status.Timestamp = &old
+
+	// Create a recent completed task that should NOT be evicted.
+	_, err = store.Create("new-task", "ctx-1")
+	require.NoError(t, err)
+	require.NoError(t, store.SetState("new-task", a2a.TaskStateWorking, nil))
+	require.NoError(t, store.SetState("new-task", a2a.TaskStateCompleted, nil))
+
+	// Create a working task that should NOT be evicted.
+	_, err = store.Create("working-task", "ctx-1")
+	require.NoError(t, err)
+	require.NoError(t, store.SetState("working-task", a2a.TaskStateWorking, nil))
+
+	conv := &mockA2AConv{
+		sendFunc: func(_ context.Context, _ any, _ ...SendOption) (*Response, error) {
+			return &Response{
+					message: &types.Message{
+						Role:  "assistant",
+						Parts: []types.ContentPart{types.NewTextPart("ok")},
+					},
+				}, nil
+		},
+	}
+	opener := func(_ string) (a2aConv, error) { return conv, nil }
+
+	srv := NewA2AServer(opener,
+		WithA2ATaskStore(store),
+		WithA2ATaskTTL(1*time.Hour),
+		WithA2AConversationTTL(0), // disable conv eviction for this test
+	)
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	// Add a broadcaster for the old task to verify it gets cleaned up.
+	b := srv.getBroadcaster("old-task")
+	assert.NotNil(t, b)
+
+	// Run eviction.
+	srv.evictOnce()
+
+	// The old task should be evicted.
+	_, err = store.Get("old-task")
+	assert.ErrorIs(t, err, ErrTaskNotFound)
+
+	// The new and working tasks should still exist.
+	_, err = store.Get("new-task")
+	assert.NoError(t, err)
+
+	_, err = store.Get("working-task")
+	assert.NoError(t, err)
+
+	// The broadcaster for old-task should have been removed.
+	srv.subsMu.Lock()
+	_, hasBroadcaster := srv.subs["old-task"]
+	srv.subsMu.Unlock()
+	assert.False(t, hasBroadcaster, "broadcaster for evicted task should be removed")
+}
+
+func TestA2AServer_EvictOnce_EvictsIdleConversations(t *testing.T) {
+	opener := func(_ string) (a2aConv, error) {
+		return &mockA2AConv{
+			sendFunc: func(_ context.Context, _ any, _ ...SendOption) (*Response, error) {
+				return &Response{
+					message: &types.Message{
+						Role:  "assistant",
+						Parts: []types.ContentPart{types.NewTextPart("ok")},
+					},
+				}, nil
+			},
+		}, nil
+	}
+
+	srv := NewA2AServer(opener,
+		WithA2ATaskTTL(0), // disable task eviction
+		WithA2AConversationTTL(1*time.Hour),
+	)
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	// Manually add conversations with different last-use timestamps.
+	oldConv := &mockA2AConv{
+		sendFunc: func(_ context.Context, _ any, _ ...SendOption) (*Response, error) {
+			return &Response{
+					message: &types.Message{
+						Role:  "assistant",
+						Parts: []types.ContentPart{types.NewTextPart("ok")},
+					},
+				}, nil
+		},
+	}
+	newConv := &mockA2AConv{
+		sendFunc: func(_ context.Context, _ any, _ ...SendOption) (*Response, error) {
+			return &Response{
+					message: &types.Message{
+						Role:  "assistant",
+						Parts: []types.ContentPart{types.NewTextPart("ok")},
+					},
+				}, nil
+		},
+	}
+	srv.convsMu.Lock()
+	srv.convs["old-ctx"] = oldConv
+	srv.convLastUse["old-ctx"] = time.Now().Add(-2 * time.Hour)
+	srv.convs["new-ctx"] = newConv
+	srv.convLastUse["new-ctx"] = time.Now()
+	srv.convsMu.Unlock()
+
+	// Run eviction.
+	srv.evictOnce()
+
+	// The old conversation should be evicted and closed.
+	srv.convsMu.RLock()
+	_, hasOld := srv.convs["old-ctx"]
+	_, hasNew := srv.convs["new-ctx"]
+	srv.convsMu.RUnlock()
+
+	assert.False(t, hasOld, "idle conversation should be evicted")
+	assert.True(t, hasNew, "recent conversation should be kept")
+	assert.True(t, oldConv.closed.Load(), "evicted conversation should be closed")
+	assert.False(t, newConv.closed.Load(), "active conversation should not be closed")
+}
+
+func TestA2AServer_EvictOnce_EvictsClosedBroadcasters(t *testing.T) {
+	opener := func(_ string) (a2aConv, error) {
+		return &mockA2AConv{
+			sendFunc: func(_ context.Context, _ any, _ ...SendOption) (*Response, error) {
+				return &Response{
+					message: &types.Message{
+						Role:  "assistant",
+						Parts: []types.ContentPart{types.NewTextPart("ok")},
+					},
+				}, nil
+			},
+		}, nil
+	}
+
+	srv := NewA2AServer(opener,
+		WithA2ATaskTTL(0),
+		WithA2AConversationTTL(0),
+	)
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	// Add an open and a closed broadcaster.
+	openB := srv.getBroadcaster("open-task")
+	closedB := srv.getBroadcaster("closed-task")
+	closedB.close()
+
+	// Manually run eviction (TTLs are 0, so only broadcaster cleanup runs).
+	srv.evictOnce()
+
+	srv.subsMu.Lock()
+	_, hasOpen := srv.subs["open-task"]
+	_, hasClosed := srv.subs["closed-task"]
+	srv.subsMu.Unlock()
+
+	assert.True(t, hasOpen, "open broadcaster should be kept")
+	assert.False(t, hasClosed, "closed broadcaster should be evicted")
+	_ = openB // keep reference
+}
+
+func TestA2AServer_ShutdownStopsEviction(t *testing.T) {
+	opener := func(_ string) (a2aConv, error) {
+		return &mockA2AConv{
+			sendFunc: func(_ context.Context, _ any, _ ...SendOption) (*Response, error) {
+				return &Response{
+					message: &types.Message{
+						Role:  "assistant",
+						Parts: []types.ContentPart{types.NewTextPart("ok")},
+					},
+				}, nil
+			},
+		}, nil
+	}
+
+	srv := NewA2AServer(opener,
+		WithA2ATaskTTL(1*time.Hour),
+		WithA2AConversationTTL(1*time.Hour),
+	)
+
+	// Shutdown should close the stop channel.
+	err := srv.Shutdown(context.Background())
+	assert.NoError(t, err)
+
+	// Verify the stop channel is closed (non-blocking receive should succeed).
+	select {
+	case <-srv.stopCh:
+		// expected
+	default:
+		t.Fatal("stopCh should be closed after Shutdown")
+	}
+}
+
+func TestWithA2ATaskTTL(t *testing.T) {
+	opener := func(_ string) (a2aConv, error) { return nil, nil }
+
+	srv := NewA2AServer(opener, WithA2ATaskTTL(30*time.Minute))
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+	assert.Equal(t, 30*time.Minute, srv.taskTTL)
+}
+
+func TestWithA2AConversationTTL(t *testing.T) {
+	opener := func(_ string) (a2aConv, error) { return nil, nil }
+
+	srv := NewA2AServer(opener, WithA2AConversationTTL(45*time.Minute))
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+	assert.Equal(t, 45*time.Minute, srv.convTTL)
+}
+
+func TestA2AServer_DisabledEviction(t *testing.T) {
+	opener := func(_ string) (a2aConv, error) { return nil, nil }
+
+	// Both TTLs set to 0 should not start the eviction goroutine.
+	srv := NewA2AServer(opener,
+		WithA2ATaskTTL(0),
+		WithA2AConversationTTL(0),
+	)
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	// evictOnce should be safe to call even with TTLs disabled.
+	srv.evictOnce()
+}
+
+func TestA2AServer_ConversationLastUseUpdated(t *testing.T) {
+	conv := &mockA2AConv{
+		sendFunc: func(_ context.Context, _ any, _ ...SendOption) (*Response, error) {
+			return &Response{
+					message: &types.Message{
+						Role:  "assistant",
+						Parts: []types.ContentPart{types.NewTextPart("ok")},
+					},
+				}, nil
+		},
+	}
+	opener := func(_ string) (a2aConv, error) { return conv, nil }
+
+	srv := NewA2AServer(opener,
+		WithA2ATaskTTL(0),
+		WithA2AConversationTTL(1*time.Hour),
+	)
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	// First call creates the conversation and sets last-use.
+	_, err := srv.getOrCreateConversation("ctx-1")
+	require.NoError(t, err)
+
+	srv.convsMu.RLock()
+	firstUse := srv.convLastUse["ctx-1"]
+	srv.convsMu.RUnlock()
+	assert.False(t, firstUse.IsZero())
+
+	// Small sleep to ensure timestamp difference.
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call should update last-use.
+	_, err = srv.getOrCreateConversation("ctx-1")
+	require.NoError(t, err)
+
+	srv.convsMu.RLock()
+	secondUse := srv.convLastUse["ctx-1"]
+	srv.convsMu.RUnlock()
+	assert.True(t, secondUse.After(firstUse), "last-use should be updated on reuse")
+}


### PR DESCRIPTION
## Summary

Closes #491.

- Adds `WithA2ATaskTTL(d)` option to evict completed/failed/canceled tasks after a configurable duration (default: 1 hour)
- Adds `WithA2AConversationTTL(d)` option to evict idle conversations after a configurable duration (default: 1 hour)
- Background goroutine runs every minute to sweep expired tasks, idle conversations, and closed broadcasters
- Extends `TaskStore` interface with `EvictTerminal(cutoff time.Time) []string` method
- Setting either TTL to 0 disables that category of eviction

## Test plan

- [x] `TestA2AServer_EvictOnce_EvictsTerminalTasks` — verifies old completed tasks are removed, recent/working tasks are kept, and associated broadcasters are cleaned up
- [x] `TestA2AServer_EvictOnce_EvictsIdleConversations` — verifies idle conversations are closed and removed, recent ones are kept
- [x] `TestA2AServer_EvictOnce_EvictsClosedBroadcasters` — verifies closed broadcasters are swept, open ones are kept
- [x] `TestA2AServer_ShutdownStopsEviction` — verifies shutdown closes the stop channel
- [x] `TestWithA2ATaskTTL` / `TestWithA2AConversationTTL` — option wire-up
- [x] `TestA2AServer_DisabledEviction` — zero TTLs are safe
- [x] `TestA2AServer_ConversationLastUseUpdated` — last-use timestamp is updated on reuse
- [x] `TestInMemoryTaskStore_EvictTerminal` — store-level eviction logic (all terminal states, empty store)
- [x] Coverage: 94.4% on `a2a_server.go`, 100% on `task_store.go`
- [x] All existing tests pass, no regressions