### PR TITLE
fix: remove dead ValidationStage references

### DIFF
--- a/runtime/pipeline/stage/README.md
+++ b/runtime/pipeline/stage/README.md
@@ -145,22 +145,17 @@ result, err := pipeline.ExecuteSync(ctx, elements...)
    - Extracts validators from prompt configuration
    - Emits system prompt and allowed tools via metadata
 
-2. **ValidationStage** (`stages_core.go`)
-   - Dynamic validator execution from metadata
-   - Supports multiple validators in sequence
-   - Emits validation results with pass/fail status
-
-3. **StateStoreLoadStage** (`stages_core.go`)
+2. **StateStoreLoadStage** (`stages_core.go`)
    - Loads conversation history from state store
    - Marks historical messages with `from_history` flag
    - Prepends history to current messages
 
-4. **StateStoreSaveStage** (`stages_core.go`)
+3. **StateStoreSaveStage** (`stages_core.go`)
    - Saves conversation state after processing
    - Merges metadata from messages
    - Updates state store with new messages
 
-5. **ProviderStage** (`stages_provider.go`)
+4. **ProviderStage** (`stages_provider.go`)
    - Request/response LLM execution
    - Multi-round tool call support
    - Full tool execution via `toolRegistry.ExecuteAsync()`

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -142,8 +142,7 @@ type Config struct {
 //  3. PromptAssemblyStage - Load and assemble prompt from registry
 //  4. TemplateStage - Prepare system prompt for provider
 //  5. ProviderStage/DuplexProviderStage - LLM call with streaming support
-//  6. ValidationStage - Validate responses (if configured)
-//  7. StateStoreSaveStage - Save conversation state (if configured)
+//  6. StateStoreSaveStage - Save conversation state (if configured)
 //
 // This matches the runtime pipeline used by Arena.
 func Build(cfg *Config) (*stage.StreamPipeline, error) {

--- a/tools/arena/engine/duplex_executor_pipeline_integration.go
+++ b/tools/arena/engine/duplex_executor_pipeline_integration.go
@@ -297,11 +297,6 @@ func (de *DuplexConversationExecutor) buildDuplexPipeline(
 		stages = append(stages, stage.NewMediaExternalizerStage(mediaConfig))
 	}
 
-	// NOTE: ValidationStage is NOT included in the duplex pipeline.
-	// ValidationStage accumulates ALL elements before forwarding, which blocks
-	// the real-time element flow needed for duplex streaming. Turn assertions
-	// are handled separately by evaluateTurnAssertions() in the executor.
-
 	// 5. Arena state store save stage to capture conversation messages
 	// This stage handles system_prompt in metadata and prepends it as a system message
 	if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil {


### PR DESCRIPTION
## Summary
- Removed all remaining references to `ValidationStage` from pipeline comments and documentation
- Guardrails now run inside `ProviderStage` via hooks, making `ValidationStage` dead code
- The `ValidationStage` struct was already removed; this cleans up leftover references in:
  - `sdk/internal/pipeline/builder.go` (stage order comment)
  - `tools/arena/engine/duplex_executor_pipeline_integration.go` (explanatory comment)
  - `runtime/pipeline/stage/README.md` (phase 2 documentation)

Closes #458

## Test plan
- [x] `go test ./runtime/pipeline/... -v -race -count=1` passes
- [x] `go test ./sdk/... -v -race -count=1` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Pre-commit hook passes (lint, build, test, coverage)