### PR TITLE
refactor: standardize HTTP client setup and timeouts

### DIFF
--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -1,0 +1,28 @@
+// Package httputil provides shared HTTP client construction utilities
+// for the PromptKit project. It centralizes timeout defaults and client
+// creation so that every module uses consistent configuration.
+package httputil
+
+import (
+	"net/http"
+	"time"
+)
+
+// Standard timeout defaults used across the project.
+const (
+	// DefaultProviderTimeout is the HTTP timeout for LLM provider calls
+	// (e.g. OpenAI, Claude, Gemini). Provider requests can involve large
+	// payloads and long inference times, so they use a longer timeout.
+	DefaultProviderTimeout = 60 * time.Second
+
+	// DefaultToolTimeout is the HTTP timeout for tool / webhook calls
+	// made by the SDK HTTP executor. These are typically shorter-lived
+	// API requests.
+	DefaultToolTimeout = 30 * time.Second
+)
+
+// NewHTTPClient returns an *http.Client configured with the given timeout.
+// Pass one of the Default*Timeout constants, or a custom duration.
+func NewHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout}
+}

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -1,0 +1,41 @@
+package httputil_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/pkg/httputil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConstants(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 60*time.Second, httputil.DefaultProviderTimeout, "provider timeout should be 60s")
+	assert.Equal(t, 30*time.Second, httputil.DefaultToolTimeout, "tool timeout should be 30s")
+}
+
+func TestNewHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"provider timeout", httputil.DefaultProviderTimeout},
+		{"tool timeout", httputil.DefaultToolTimeout},
+		{"custom timeout", 5 * time.Second},
+		{"zero timeout", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := httputil.NewHTTPClient(tt.timeout)
+			require.NotNil(t, client, "returned client must not be nil")
+			assert.Equal(t, tt.timeout, client.Timeout, "client timeout must match requested value")
+		})
+	}
+}

--- a/runtime/providers/base_provider.go
+++ b/runtime/providers/base_provider.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/httputil"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 )
 
@@ -38,7 +39,7 @@ func NewBaseProviderWithAPIKey(id string, includeRawOutput bool, primaryKey, fal
 		apiKey = os.Getenv(fallbackKey)
 	}
 
-	client := &http.Client{Timeout: 60 * time.Second}
+	client := httputil.NewHTTPClient(httputil.DefaultProviderTimeout)
 	return NewBaseProvider(id, includeRawOutput, client), apiKey
 }
 

--- a/sdk/tools/http.go
+++ b/sdk/tools/http.go
@@ -16,15 +16,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/httputil"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 )
 
 // Default configuration values
 const (
-	defaultHTTPTimeout = 30 * time.Second
-	defaultHTTPMethod  = "POST"
-	maxResponseSize    = 10 * 1024 * 1024 // 10MB
-	envHeaderParts     = 2                // key=value split parts
+	defaultHTTPMethod = "POST"
+	maxResponseSize   = 10 * 1024 * 1024 // 10MB
+	envHeaderParts    = 2                // key=value split parts
 )
 
 // HTTPExecutor executes tools that make HTTP calls based on pack configuration.
@@ -36,9 +36,7 @@ type HTTPExecutor struct {
 // NewHTTPExecutor creates a new HTTP executor with the default HTTP client.
 func NewHTTPExecutor() *HTTPExecutor {
 	return &HTTPExecutor{
-		client: &http.Client{
-			Timeout: defaultHTTPTimeout,
-		},
+		client: httputil.NewHTTPClient(httputil.DefaultToolTimeout),
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #480

- Add `pkg/httputil` package with `NewHTTPClient(timeout)` factory and named constants (`DefaultProviderTimeout = 60s`, `DefaultToolTimeout = 30s`)
- Update `runtime/providers/base_provider.go` to use `httputil.NewHTTPClient(httputil.DefaultProviderTimeout)` instead of inline `&http.Client{Timeout: 60 * time.Second}`
- Update `sdk/tools/http.go` to use `httputil.NewHTTPClient(httputil.DefaultToolTimeout)` instead of inline client with a package-level `defaultHTTPTimeout` constant

## Test plan

- [x] New unit tests in `pkg/httputil/httputil_test.go` cover constants and factory (100% coverage)
- [x] Existing `runtime/providers` tests pass (no behavior change)
- [x] Existing `sdk/tools` tests pass (no behavior change)
- [x] Pre-commit lint, build, and coverage checks all pass