### PR TITLE
refactor: create shared Ptr[T] test utility

### DIFF
--- a/pkg/testutil/ptr.go
+++ b/pkg/testutil/ptr.go
@@ -1,0 +1,7 @@
+// Package testutil provides shared test helper utilities.
+package testutil
+
+// Ptr returns a pointer to v. It is a generic replacement for the various
+// typed pointer helpers (ptrString, ptrFloat32, boolPtr, etc.) that are
+// duplicated across test files.
+func Ptr[T any](v T) *T { return &v }

--- a/pkg/testutil/ptr_test.go
+++ b/pkg/testutil/ptr_test.go
@@ -1,0 +1,74 @@
+package testutil
+
+import "testing"
+
+func TestPtr(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		p := Ptr("hello")
+		if p == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *p != "hello" {
+			t.Fatalf("expected %q, got %q", "hello", *p)
+		}
+	})
+
+	t.Run("int", func(t *testing.T) {
+		p := Ptr(42)
+		if p == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *p != 42 {
+			t.Fatalf("expected %d, got %d", 42, *p)
+		}
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		p := Ptr(true)
+		if p == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *p != true {
+			t.Fatal("expected true")
+		}
+	})
+
+	t.Run("float32", func(t *testing.T) {
+		p := Ptr(float32(3.14))
+		if p == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *p != float32(3.14) {
+			t.Fatalf("expected %f, got %f", float32(3.14), *p)
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		p := Ptr(1.618)
+		if p == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *p != 1.618 {
+			t.Fatalf("expected %f, got %f", 1.618, *p)
+		}
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		type S struct{ X int }
+		p := Ptr(S{X: 7})
+		if p == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if p.X != 7 {
+			t.Fatalf("expected X=7, got X=%d", p.X)
+		}
+	})
+
+	t.Run("returns distinct pointers", func(t *testing.T) {
+		a := Ptr(1)
+		b := Ptr(1)
+		if a == b {
+			t.Fatal("expected distinct pointers for separate calls")
+		}
+	})
+}

--- a/runtime/a2a/client_test.go
+++ b/runtime/a2a/client_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
+	"github.com/AltairaLabs/PromptKit/runtime/telemetry"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
-
-	"github.com/AltairaLabs/PromptKit/runtime/telemetry"
 )
 
 // --- test helpers ---
@@ -121,7 +121,7 @@ func TestSendMessage(t *testing.T) {
 	task, err := c.SendMessage(context.Background(), &SendMessageRequest{
 		Message: Message{
 			Role:  RoleUser,
-			Parts: []Part{{Text: ptr("hello")}},
+			Parts: []Part{{Text: testutil.Ptr("hello")}},
 		},
 	})
 	if err != nil {
@@ -231,7 +231,7 @@ func TestSendMessageStream(t *testing.T) {
 
 		fmt.Fprint(w, sseEvent(TaskArtifactUpdateEvent{
 			TaskID:   "task-1",
-			Artifact: Artifact{ArtifactID: "a1", Parts: []Part{{Text: ptr("result")}}},
+			Artifact: Artifact{ArtifactID: "a1", Parts: []Part{{Text: testutil.Ptr("result")}}},
 		}))
 		f.Flush()
 
@@ -245,7 +245,7 @@ func TestSendMessageStream(t *testing.T) {
 
 	c := NewClient(srv.URL)
 	ch, err := c.SendMessageStream(context.Background(), &SendMessageRequest{
-		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("hello")}}},
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: testutil.Ptr("hello")}}},
 	})
 	if err != nil {
 		t.Fatalf("SendMessageStream() error = %v", err)
@@ -288,7 +288,7 @@ func TestSendMessageStream_JSONRPCWrapped(t *testing.T) {
 		})
 		writeWrapped(TaskArtifactUpdateEvent{
 			TaskID:   "t1",
-			Artifact: Artifact{ArtifactID: "a1", Parts: []Part{{Text: ptr("chunk")}}},
+			Artifact: Artifact{ArtifactID: "a1", Parts: []Part{{Text: testutil.Ptr("chunk")}}},
 		})
 		writeWrapped(TaskStatusUpdateEvent{
 			TaskID: "t1",
@@ -299,7 +299,7 @@ func TestSendMessageStream_JSONRPCWrapped(t *testing.T) {
 
 	c := NewClient(srv.URL)
 	ch, err := c.SendMessageStream(context.Background(), &SendMessageRequest{
-		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("go")}}},
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: testutil.Ptr("go")}}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -351,7 +351,7 @@ func TestRPCError(t *testing.T) {
 
 	c := NewClient(srv.URL)
 	_, err := c.SendMessage(context.Background(), &SendMessageRequest{
-		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("hi")}}},
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: testutil.Ptr("hi")}}},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -421,7 +421,7 @@ func TestSendMessageStream_HTTPError(t *testing.T) {
 
 	c := NewClient(srv.URL)
 	_, err := c.SendMessageStream(context.Background(), &SendMessageRequest{
-		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("hi")}}},
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: testutil.Ptr("hi")}}},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -465,7 +465,7 @@ func TestHappyPath_DiscoverSendPollComplete(t *testing.T) {
 					task.Status = TaskStatus{State: TaskStateCompleted}
 					task.Artifacts = []Artifact{{
 						ArtifactID: "a1",
-						Parts:      []Part{{Text: ptr("done")}},
+						Parts:      []Part{{Text: testutil.Ptr("done")}},
 					}}
 				} else {
 					task.Status = TaskStatus{State: TaskStateWorking}
@@ -490,7 +490,7 @@ func TestHappyPath_DiscoverSendPollComplete(t *testing.T) {
 
 	// 2. Send message
 	task, err := c.SendMessage(ctx, &SendMessageRequest{
-		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("solve this")}}},
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: testutil.Ptr("solve this")}}},
 	})
 	if err != nil {
 		t.Fatalf("SendMessage: %v", err)
@@ -553,7 +553,7 @@ func TestErrorPath_DiscoverSendFail(t *testing.T) {
 	}
 
 	task, err := c.SendMessage(ctx, &SendMessageRequest{
-		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("do something")}}},
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: testutil.Ptr("do something")}}},
 	})
 	if err != nil {
 		t.Fatalf("SendMessage: %v", err)
@@ -629,7 +629,7 @@ func TestClient_PropagatesTraceHeaders(t *testing.T) {
 
 	// Test SendMessage (rpcCall) propagates trace headers.
 	_, err = c.SendMessage(ctx, &SendMessageRequest{
-		Message: Message{Role: RoleUser, Parts: []Part{{Text: ptr("hi")}}},
+		Message: Message{Role: RoleUser, Parts: []Part{{Text: testutil.Ptr("hi")}}},
 	})
 	if err != nil {
 		t.Fatalf("SendMessage: %v", err)

--- a/runtime/a2a/mock/mock_test.go
+++ b/runtime/a2a/mock/mock_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/a2a"
 )
-
-// textPtr returns a pointer to s.
-func textPtr(s string) *string { return &s }
 
 // testCard returns an AgentCard suitable for tests.
 func testCard() *a2a.AgentCard {
@@ -73,7 +71,7 @@ func sendMsg(skillID, text string) *a2a.SendMessageRequest {
 	req := &a2a.SendMessageRequest{
 		Message: a2a.Message{
 			Role:  a2a.RoleUser,
-			Parts: []a2a.Part{{Text: textPtr(text)}},
+			Parts: []a2a.Part{{Text: testutil.Ptr(text)}},
 		},
 	}
 	if skillID != "" {
@@ -112,7 +110,7 @@ func TestMockServesAgentCard(t *testing.T) {
 func TestMockReturnsSkillResponse(t *testing.T) {
 	m := NewA2AServer(testCard(),
 		WithSkillResponse("echo", Response{
-			Parts: []a2a.Part{{Text: textPtr("hello back")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("hello back")}},
 		}),
 	)
 	m.Start()
@@ -137,10 +135,10 @@ func TestMockMatchesInputContains(t *testing.T) {
 		WithInputMatcher("echo", func(msg a2a.Message) bool {
 			return strings.Contains(messageText(&msg), "magic")
 		}, Response{
-			Parts: []a2a.Part{{Text: textPtr("found magic")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("found magic")}},
 		}),
 		WithSkillResponse("echo", Response{
-			Parts: []a2a.Part{{Text: textPtr("default echo")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("default echo")}},
 		}),
 	)
 	m.Start()
@@ -165,12 +163,12 @@ func TestMockMatchesInputRegex(t *testing.T) {
 	mc := &MatchConfig{Regex: `\d{3}-\d{4}`}
 	fn := matcherFromConfig(mc)
 
-	msg := a2a.Message{Parts: []a2a.Part{{Text: textPtr("call 555-1234")}}}
+	msg := a2a.Message{Parts: []a2a.Part{{Text: testutil.Ptr("call 555-1234")}}}
 	if !fn(msg) {
 		t.Error("expected regex match")
 	}
 
-	msg2 := a2a.Message{Parts: []a2a.Part{{Text: textPtr("no numbers here")}}}
+	msg2 := a2a.Message{Parts: []a2a.Part{{Text: testutil.Ptr("no numbers here")}}}
 	if fn(msg2) {
 		t.Error("expected no regex match")
 	}
@@ -202,7 +200,7 @@ func TestMockLatencyInjection(t *testing.T) {
 	m := NewA2AServer(testCard(),
 		WithLatency(delay),
 		WithSkillResponse("echo", Response{
-			Parts: []a2a.Part{{Text: textPtr("delayed")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("delayed")}},
 		}),
 	)
 	m.Start()
@@ -222,7 +220,7 @@ func TestMockLatencyInjection(t *testing.T) {
 func TestMockDefaultResponse(t *testing.T) {
 	m := NewA2AServer(testCard(),
 		WithSkillResponse("echo", Response{
-			Parts: []a2a.Part{{Text: textPtr("default")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("default")}},
 		}),
 	)
 	m.Start()
@@ -242,10 +240,10 @@ func TestMockRuleOrdering(t *testing.T) {
 		WithInputMatcher("echo", func(msg a2a.Message) bool {
 			return strings.Contains(messageText(&msg), "special")
 		}, Response{
-			Parts: []a2a.Part{{Text: textPtr("special response")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("special response")}},
 		}),
 		WithSkillResponse("echo", Response{
-			Parts: []a2a.Part{{Text: textPtr("catch-all")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("catch-all")}},
 		}),
 	)
 	m.Start()
@@ -335,7 +333,7 @@ func TestOptionsFromConfig(t *testing.T) {
 func TestMockWithClient(t *testing.T) {
 	m := NewA2AServer(testCard(),
 		WithSkillResponse("echo", Response{
-			Parts: []a2a.Part{{Text: textPtr("client test")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("client test")}},
 		}),
 	)
 	m.Start()
@@ -369,7 +367,7 @@ func TestMockWithClient(t *testing.T) {
 func TestMockNoMatchingRule(t *testing.T) {
 	m := NewA2AServer(testCard(),
 		WithSkillResponse("other-skill", Response{
-			Parts: []a2a.Part{{Text: textPtr("nope")}},
+			Parts: []a2a.Part{{Text: testutil.Ptr("nope")}},
 		}),
 	)
 	m.Start()

--- a/runtime/a2a/parts_test.go
+++ b/runtime/a2a/parts_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -46,8 +47,8 @@ func TestPartToContentPart(t *testing.T) {
 	}{
 		{
 			name: "text part",
-			part: Part{Text: ptr("hello")},
-			want: types.ContentPart{Type: "text", Text: ptr("hello")},
+			part: Part{Text: testutil.Ptr("hello")},
+			want: types.ContentPart{Type: "text", Text: testutil.Ptr("hello")},
 		},
 		{
 			name: "raw+image",
@@ -84,11 +85,11 @@ func TestPartToContentPart(t *testing.T) {
 		},
 		{
 			name: "url+image",
-			part: Part{URL: ptr("https://example.com/img.png"), MediaType: "image/png"},
+			part: Part{URL: testutil.Ptr("https://example.com/img.png"), MediaType: "image/png"},
 			want: types.ContentPart{
 				Type: "image",
 				Media: &types.MediaContent{
-					URL:      ptr("https://example.com/img.png"),
+					URL:      testutil.Ptr("https://example.com/img.png"),
 					MIMEType: "image/png",
 				},
 			},
@@ -155,7 +156,7 @@ func TestContentPartToA2APart(t *testing.T) {
 	}{
 		{
 			name: "text",
-			part: types.ContentPart{Type: "text", Text: ptr("hello")},
+			part: types.ContentPart{Type: "text", Text: testutil.Ptr("hello")},
 			check: func(t *testing.T, got Part) {
 				if got.Text == nil || *got.Text != "hello" {
 					t.Errorf("Text = %v, want 'hello'", got.Text)
@@ -188,7 +189,7 @@ func TestContentPartToA2APart(t *testing.T) {
 			part: types.ContentPart{
 				Type: "image",
 				Media: &types.MediaContent{
-					URL:      ptr("https://example.com/img.png"),
+					URL:      testutil.Ptr("https://example.com/img.png"),
 					MIMEType: "image/png",
 				},
 			},
@@ -226,8 +227,8 @@ func TestMessageToMessage(t *testing.T) {
 	msg := Message{
 		Role: RoleAgent,
 		Parts: []Part{
-			{Text: ptr("Hello ")},
-			{Text: ptr("world")},
+			{Text: testutil.Ptr("Hello ")},
+			{Text: testutil.Ptr("world")},
 			{Raw: []byte("img"), MediaType: "image/png"},
 		},
 		Metadata: map[string]any{"key": "value"},
@@ -264,7 +265,7 @@ func TestMessageToMessage(t *testing.T) {
 func TestMessageToMessage_UserRole(t *testing.T) {
 	msg := Message{
 		Role:  RoleUser,
-		Parts: []Part{{Text: ptr("hi")}},
+		Parts: []Part{{Text: testutil.Ptr("hi")}},
 	}
 	got, err := MessageToMessage(&msg)
 	if err != nil {
@@ -279,7 +280,7 @@ func TestContentPartsToArtifacts(t *testing.T) {
 	b64 := base64.StdEncoding.EncodeToString([]byte("img"))
 
 	parts := []types.ContentPart{
-		{Type: "text", Text: ptr("result text")},
+		{Type: "text", Text: testutil.Ptr("result text")},
 		{
 			Type: "image",
 			Media: &types.MediaContent{
@@ -327,14 +328,14 @@ func TestRoundTrip(t *testing.T) {
 	}{
 		{
 			name: "text",
-			orig: types.ContentPart{Type: "text", Text: ptr("round trip text")},
+			orig: types.ContentPart{Type: "text", Text: testutil.Ptr("round trip text")},
 		},
 		{
 			name: "image data",
 			orig: types.ContentPart{
 				Type: "image",
 				Media: &types.MediaContent{
-					Data:     ptr(base64.StdEncoding.EncodeToString([]byte("pixel data"))),
+					Data:     testutil.Ptr(base64.StdEncoding.EncodeToString([]byte("pixel data"))),
 					MIMEType: "image/png",
 				},
 			},
@@ -344,7 +345,7 @@ func TestRoundTrip(t *testing.T) {
 			orig: types.ContentPart{
 				Type: "image",
 				Media: &types.MediaContent{
-					URL:      ptr("https://example.com/photo.jpg"),
+					URL:      testutil.Ptr("https://example.com/photo.jpg"),
 					MIMEType: "image/jpeg",
 				},
 			},

--- a/runtime/a2a/types_test.go
+++ b/runtime/a2a/types_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func ptr[T any](v T) *T { return &v }
 
 func TestTaskState_JSON(t *testing.T) {
 	tests := []struct {
@@ -52,7 +51,7 @@ func TestTaskState_InvalidJSON(t *testing.T) {
 }
 
 func TestPart_TextRoundTrip(t *testing.T) {
-	p := Part{Text: ptr("hello world")}
+	p := Part{Text: testutil.Ptr("hello world")}
 
 	data, err := json.Marshal(p)
 	require.NoError(t, err)
@@ -85,7 +84,7 @@ func TestPart_RawRoundTrip(t *testing.T) {
 
 func TestPart_URLRoundTrip(t *testing.T) {
 	p := Part{
-		URL:       ptr("https://example.com/file.pdf"),
+		URL:       testutil.Ptr("https://example.com/file.pdf"),
 		MediaType: "application/pdf",
 	}
 
@@ -122,7 +121,7 @@ func TestMessage_RoundTrip(t *testing.T) {
 		ContextID: "ctx-1",
 		TaskID:    "task-1",
 		Role:      RoleUser,
-		Parts:     []Part{{Text: ptr("What is the weather?")}},
+		Parts:     []Part{{Text: testutil.Ptr("What is the weather?")}},
 		Metadata:  map[string]any{"source": "test"},
 	}
 
@@ -144,7 +143,7 @@ func TestArtifact_RoundTrip(t *testing.T) {
 		ArtifactID:  "art-1",
 		Name:        "result",
 		Description: "The generated output",
-		Parts:       []Part{{Text: ptr("Generated text")}},
+		Parts:       []Part{{Text: testutil.Ptr("Generated text")}},
 	}
 
 	data, err := json.Marshal(a)
@@ -169,21 +168,21 @@ func TestTask_RoundTrip(t *testing.T) {
 			Message: &Message{
 				MessageID: "status-msg",
 				Role:      RoleAgent,
-				Parts:     []Part{{Text: ptr("Processing your request")}},
+				Parts:     []Part{{Text: testutil.Ptr("Processing your request")}},
 			},
 		},
 		Artifacts: []Artifact{
 			{
 				ArtifactID: "art-1",
 				Name:       "output",
-				Parts:      []Part{{Text: ptr("Result data")}},
+				Parts:      []Part{{Text: testutil.Ptr("Result data")}},
 			},
 		},
 		History: []Message{
 			{
 				MessageID: "msg-1",
 				Role:      RoleUser,
-				Parts:     []Part{{Text: ptr("Do something")}},
+				Parts:     []Part{{Text: testutil.Ptr("Do something")}},
 			},
 		},
 	}
@@ -326,11 +325,11 @@ func TestSendMessageRequest_RoundTrip(t *testing.T) {
 		Message: Message{
 			MessageID: "msg-1",
 			Role:      RoleUser,
-			Parts:     []Part{{Text: ptr("hello")}},
+			Parts:     []Part{{Text: testutil.Ptr("hello")}},
 		},
 		Configuration: &SendMessageConfiguration{
 			AcceptedOutputModes: []string{"text"},
-			HistoryLength:       ptr(10),
+			HistoryLength:       testutil.Ptr(10),
 			Blocking:            true,
 		},
 	}
@@ -397,7 +396,7 @@ func TestStreamingEvents_RoundTrip(t *testing.T) {
 			ContextID: "ctx-1",
 			Artifact: Artifact{
 				ArtifactID: "art-1",
-				Parts:      []Part{{Text: ptr("chunk")}},
+				Parts:      []Part{{Text: testutil.Ptr("chunk")}},
 			},
 			Append:    true,
 			LastChunk: false,

--- a/runtime/evals/handlers/media_handlers_test.go
+++ b/runtime/evals/handlers/media_handlers_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
-func intPtr(v int) *int       { return &v }
-func floatPtr(v float64) *float64 { return &v } //nolint:unparam // test helper
+var intPtr = testutil.Ptr[int]
 
 func imageMsg(mime string, width, height *int) types.Message {
 	return types.Message{

--- a/runtime/evals/helpers_test.go
+++ b/runtime/evals/helpers_test.go
@@ -1,4 +1,8 @@
 package evals
 
-func float64Ptr(f float64) *float64 { return &f }
-func boolPtr(b bool) *bool          { return &b }
+import "github.com/AltairaLabs/PromptKit/pkg/testutil"
+
+var (
+	float64Ptr = testutil.Ptr[float64]
+	boolPtr    = testutil.Ptr[bool]
+)

--- a/runtime/evals/types_test.go
+++ b/runtime/evals/types_test.go
@@ -4,12 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
-
-func ptr[T any](v T) *T {
-	return &v
-}
 
 func TestEvalDef_IsEnabled(t *testing.T) {
 	tests := []struct {
@@ -18,8 +15,8 @@ func TestEvalDef_IsEnabled(t *testing.T) {
 		want    bool
 	}{
 		{"nil defaults to true", nil, true},
-		{"explicit true", ptr(true), true},
-		{"explicit false", ptr(false), false},
+		{"explicit true", testutil.Ptr(true), true},
+		{"explicit false", testutil.Ptr(false), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -38,9 +35,9 @@ func TestEvalDef_GetSamplePercentage(t *testing.T) {
 		want float64
 	}{
 		{"nil defaults to 5.0", nil, DefaultSamplePercentage},
-		{"explicit 10", ptr(10.0), 10.0},
-		{"explicit 0", ptr(0.0), 0.0},
-		{"explicit 100", ptr(100.0), 100.0},
+		{"explicit 10", testutil.Ptr(10.0), 10.0},
+		{"explicit 0", testutil.Ptr(0.0), 0.0},
+		{"explicit 100", testutil.Ptr(100.0), 100.0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -59,12 +56,12 @@ func TestEvalDef_JSONRoundTrip(t *testing.T) {
 		Trigger:          TriggerSampleTurns,
 		Params:           map[string]any{"criteria": "professional tone"},
 		Description:      "Check tone",
-		Enabled:          ptr(true),
-		SamplePercentage: ptr(10.0),
+		Enabled:          testutil.Ptr(true),
+		SamplePercentage: testutil.Ptr(10.0),
 		Metric: &MetricDef{
 			Name:  "promptpack_tone_score",
 			Type:  MetricGauge,
-			Range: &Range{Min: ptr(0.0), Max: ptr(1.0)},
+			Range: &Range{Min: testutil.Ptr(0.0), Max: testutil.Ptr(1.0)},
 		},
 	}
 
@@ -227,8 +224,8 @@ func TestEvalResult_JSON(t *testing.T) {
 		EvalID:      "tone-check",
 		Type:        "llm_judge",
 		Passed:      true,
-		Score:       ptr(0.95),
-		MetricValue: ptr(0.95),
+		Score:       testutil.Ptr(0.95),
+		MetricValue: testutil.Ptr(0.95),
 		Explanation: "Tone is professional",
 		DurationMs:  150,
 	}
@@ -427,42 +424,42 @@ func TestThreshold_Apply(t *testing.T) {
 		{
 			name:       "nil threshold is no-op",
 			threshold:  nil,
-			result:     EvalResult{Passed: true, Score: ptr(0.5)},
+			result:     EvalResult{Passed: true, Score: testutil.Ptr(0.5)},
 			wantPassed: true,
 		},
 		{
 			name:       "passed required but result failed",
-			threshold:  &Threshold{Passed: ptr(true)},
-			result:     EvalResult{Passed: false, Score: ptr(0.9)},
+			threshold:  &Threshold{Passed: testutil.Ptr(true)},
+			result:     EvalResult{Passed: false, Score: testutil.Ptr(0.9)},
 			wantPassed: false,
 		},
 		{
 			name:       "min_score met",
-			threshold:  &Threshold{MinScore: ptr(0.7)},
-			result:     EvalResult{Passed: true, Score: ptr(0.8)},
+			threshold:  &Threshold{MinScore: testutil.Ptr(0.7)},
+			result:     EvalResult{Passed: true, Score: testutil.Ptr(0.8)},
 			wantPassed: true,
 		},
 		{
 			name:       "min_score not met",
-			threshold:  &Threshold{MinScore: ptr(0.7)},
-			result:     EvalResult{Passed: true, Score: ptr(0.5)},
+			threshold:  &Threshold{MinScore: testutil.Ptr(0.7)},
+			result:     EvalResult{Passed: true, Score: testutil.Ptr(0.5)},
 			wantPassed: false,
 		},
 		{
 			name:       "max_score met",
-			threshold:  &Threshold{MaxScore: ptr(0.9)},
-			result:     EvalResult{Passed: true, Score: ptr(0.8)},
+			threshold:  &Threshold{MaxScore: testutil.Ptr(0.9)},
+			result:     EvalResult{Passed: true, Score: testutil.Ptr(0.8)},
 			wantPassed: true,
 		},
 		{
 			name:       "max_score exceeded",
-			threshold:  &Threshold{MaxScore: ptr(0.9)},
-			result:     EvalResult{Passed: true, Score: ptr(0.95)},
+			threshold:  &Threshold{MaxScore: testutil.Ptr(0.9)},
+			result:     EvalResult{Passed: true, Score: testutil.Ptr(0.95)},
 			wantPassed: false,
 		},
 		{
 			name:       "nil score with min_score is no-op",
-			threshold:  &Threshold{MinScore: ptr(0.7)},
+			threshold:  &Threshold{MinScore: testutil.Ptr(0.7)},
 			result:     EvalResult{Passed: true},
 			wantPassed: true,
 		},
@@ -480,9 +477,9 @@ func TestThreshold_Apply(t *testing.T) {
 
 func TestThreshold_JSON(t *testing.T) {
 	th := Threshold{
-		Passed:   ptr(true),
-		MinScore: ptr(0.7),
-		MaxScore: ptr(0.95),
+		Passed:   testutil.Ptr(true),
+		MinScore: testutil.Ptr(0.7),
+		MaxScore: testutil.Ptr(0.95),
 	}
 	data, err := json.Marshal(th)
 	if err != nil {
@@ -652,7 +649,7 @@ func TestEvalDef_ExtendedFieldsJSON(t *testing.T) {
 		Params:  map[string]any{"text": "hello"},
 		Message: "should contain hello",
 		Threshold: &Threshold{
-			Passed: ptr(true),
+			Passed: testutil.Ptr(true),
 		},
 		When: &EvalWhen{
 			ToolCalled: "search",
@@ -724,9 +721,9 @@ func TestRange_JSON(t *testing.T) {
 		min   *float64
 		max   *float64
 	}{
-		{"both min and max", `{"min":0,"max":1}`, ptr(0.0), ptr(1.0)},
-		{"only min", `{"min":-1}`, ptr(-1.0), nil},
-		{"only max", `{"max":100}`, nil, ptr(100.0)},
+		{"both min and max", `{"min":0,"max":1}`, testutil.Ptr(0.0), testutil.Ptr(1.0)},
+		{"only min", `{"min":-1}`, testutil.Ptr(-1.0), nil},
+		{"only max", `{"max":100}`, nil, testutil.Ptr(100.0)},
 		{"empty", `{}`, nil, nil},
 	}
 	for _, tt := range tests {

--- a/runtime/pipeline/stage/element_pool_test.go
+++ b/runtime/pipeline/stage/element_pool_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -27,7 +28,7 @@ func TestPutElement(t *testing.T) {
 
 	// Test that element is reset after put
 	elem := GetElement()
-	elem.Text = ptrString("test")
+	elem.Text = testutil.Ptr("test")
 	elem.Sequence = 42
 	elem.Source = "test-source"
 	elem.Metadata["key"] = "value"
@@ -55,7 +56,7 @@ func TestPutElement(t *testing.T) {
 
 func TestReset(t *testing.T) {
 	elem := &StreamElement{
-		Text:        ptrString("test text"),
+		Text:        testutil.Ptr("test text"),
 		Audio:       &AudioData{Samples: []byte{1, 2, 3}},
 		Video:       &VideoData{Data: []byte{4, 5, 6}},
 		Image:       &ImageData{Data: []byte{7, 8, 9}},
@@ -246,7 +247,7 @@ func TestPoolConcurrency(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < numOperations; j++ {
 				elem := GetElement()
-				elem.Text = ptrString("test")
+				elem.Text = testutil.Ptr("test")
 				elem.Sequence = int64(id*numOperations + j)
 				elem.Metadata["id"] = id
 				elem.Metadata["op"] = j
@@ -283,11 +284,6 @@ func TestPoolReuse(t *testing.T) {
 	}
 }
 
-// ptrString returns a pointer to the given string.
-func ptrString(s string) *string {
-	return &s
-}
-
 // BenchmarkGetElement benchmarks getting an element from the pool.
 func BenchmarkGetElement(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -316,7 +312,7 @@ func BenchmarkPoolParallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			elem := GetElement()
-			elem.Text = ptrString("test")
+			elem.Text = testutil.Ptr("test")
 			elem.Metadata["key"] = "value"
 			PutElement(elem)
 		}

--- a/runtime/pipeline/stage/router_strategies_test.go
+++ b/runtime/pipeline/stage/router_strategies_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 )
 
 func TestContentRouter_RoutesBasedOnPredicate(t *testing.T) {
@@ -117,12 +119,12 @@ func TestRouteContentType(t *testing.T) {
 		element     StreamElement
 		shouldMatch bool
 	}{
-		{"text matches text", ContentTypeText, StreamElement{Text: ptrString("hello")}, true},
+		{"text matches text", ContentTypeText, StreamElement{Text: testutil.Ptr("hello")}, true},
 		{"text doesn't match audio", ContentTypeText, StreamElement{Audio: &AudioData{}}, false},
 		{"audio matches audio", ContentTypeAudio, StreamElement{Audio: &AudioData{}}, true},
 		{"video matches video", ContentTypeVideo, StreamElement{Video: &VideoData{}}, true},
 		{"image matches image", ContentTypeImage, StreamElement{Image: &ImageData{}}, true},
-		{"any matches everything", ContentTypeAny, StreamElement{Text: ptrString("x")}, true},
+		{"any matches everything", ContentTypeAny, StreamElement{Text: testutil.Ptr("x")}, true},
 	}
 
 	for _, tt := range tests {

--- a/runtime/prompt/pack_evals_test.go
+++ b/runtime/prompt/pack_evals_test.go
@@ -4,13 +4,16 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func boolPtr(b bool) *bool       { return &b }
-func float64Ptr(f float64) *float64 { return &f }
+var (
+	boolPtr    = testutil.Ptr[bool]
+	float64Ptr = testutil.Ptr[float64]
+)
 
 func TestPack_BackwardCompatibility_NoEvals(t *testing.T) {
 	// A pack JSON without the "evals" field should still load correctly.

--- a/runtime/providers/imagen/imagen_test.go
+++ b/runtime/providers/imagen/imagen_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -313,7 +314,7 @@ func TestExtractPrompt(t *testing.T) {
 						Role:    "user",
 						Content: "",
 						Parts: []types.ContentPart{
-							{Type: "text", Text: stringPtr("Generate a red square")},
+							{Type: "text", Text: testutil.Ptr("Generate a red square")},
 						},
 					},
 				},
@@ -357,7 +358,7 @@ func TestExtractPrompt(t *testing.T) {
 						Role: "user",
 						Parts: []types.ContentPart{
 							{Type: "image", Text: nil},
-							{Type: "text", Text: stringPtr("This should be found")},
+							{Type: "text", Text: testutil.Ptr("This should be found")},
 						},
 					},
 				},
@@ -439,11 +440,6 @@ func TestClose(t *testing.T) {
 	if err != nil {
 		t.Errorf("Close() returned unexpected error: %v", err)
 	}
-}
-
-// Helper function for tests
-func stringPtr(s string) *string {
-	return &s
 }
 
 // TestPredictErrorCases tests error handling in Predict method

--- a/runtime/providers/mock/mock.go
+++ b/runtime/providers/mock/mock.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/AltairaLabs/PromptKit/runtime/providers"
-
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -273,7 +273,7 @@ func (m *Provider) createStreamChunk(responseText string, parts []types.ContentP
 		Delta:        responseText,
 		TokenCount:   outputTokens,
 		DeltaTokens:  outputTokens,
-		FinishReason: ptr("stop"),
+		FinishReason: testutil.Ptr("stop"),
 		CostInfo:     costInfo,
 		FinalResult: &providers.PredictionResponse{
 			Content:  responseText,
@@ -319,11 +319,6 @@ func (m *Provider) CalculateCost(inputTokens, outputTokens, cachedTokens int) ty
 		CachedCostUSD: cachedCost,
 		TotalCost:     inputCost + cachedCost + outputCost,
 	}
-}
-
-// ptr is a helper function to create a pointer to a value
-func ptr[T any](v T) *T {
-	return &v
 }
 
 // generateContentSummary creates a human-readable summary from content parts

--- a/runtime/providers/streaming_test.go
+++ b/runtime/providers/streaming_test.go
@@ -7,17 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/claude"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/openai"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
-
-// ptr is a helper function to create a pointer to a string
-func ptr(s string) *string {
-	return &s
-}
 
 func TestOpenAIStreaming(t *testing.T) {
 	// Only run live streaming tests when explicitly enabled to avoid CI flakiness
@@ -303,7 +299,7 @@ func TestStreamChunk_WithError(t *testing.T) {
 	chunk := providers.StreamChunk{
 		Content:      "Partial content",
 		Error:        testErr,
-		FinishReason: ptr("validation_failed"),
+		FinishReason: testutil.Ptr("validation_failed"),
 	}
 
 	if chunk.Error == nil {
@@ -452,22 +448,22 @@ func TestIsValidationAbort(t *testing.T) {
 
 func TestPtr(t *testing.T) {
 	s := "test"
-	p := ptr(s)
+	p := testutil.Ptr(s)
 
 	if p == nil {
-		t.Fatal("ptr() returned nil")
+		t.Fatal("testutil.Ptr() returned nil")
 	}
 
 	if *p != s {
-		t.Errorf("ptr() = %q, want %q", *p, s)
+		t.Errorf("testutil.Ptr() = %q, want %q", *p, s)
 	}
 
 	// Verify it's a different address
 	s2 := "test"
-	p2 := ptr(s2)
+	p2 := testutil.Ptr(s2)
 
 	if p == p2 {
-		t.Error("ptr() should return different pointers")
+		t.Error("testutil.Ptr() should return different pointers")
 	}
 }
 

--- a/runtime/providers/vllm/vllm_multimodal_test.go
+++ b/runtime/providers/vllm/vllm_multimodal_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -265,7 +266,7 @@ func TestBuildMultimodalContent_UnsupportedType(t *testing.T) {
 		Type: types.ContentTypeAudio,
 		Media: &types.MediaContent{
 			MIMEType: "audio/mp3",
-			Data:     stringPtr("base64data"),
+			Data:     testutil.Ptr("base64data"),
 		},
 	}
 	msg.Parts = []types.ContentPart{audioPart}
@@ -371,8 +372,4 @@ func TestPrepareMultimodalMessages_WithSystem(t *testing.T) {
 	if messages[0].Role != "system" {
 		t.Errorf("Expected first message to be system, got %s", messages[0].Role)
 	}
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/runtime/types/content_test.go
+++ b/runtime/types/content_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 )
 
 func TestNewTextPart(t *testing.T) {
@@ -112,7 +114,7 @@ func TestContentPartValidate(t *testing.T) {
 			name: "valid text part",
 			part: ContentPart{
 				Type: ContentTypeText,
-				Text: stringPtr("Hello"),
+				Text: testutil.Ptr("Hello"),
 			},
 			wantErr: false,
 		},
@@ -120,7 +122,7 @@ func TestContentPartValidate(t *testing.T) {
 			name: "invalid text part - empty text",
 			part: ContentPart{
 				Type: ContentTypeText,
-				Text: stringPtr(""),
+				Text: testutil.Ptr(""),
 			},
 			wantErr: true,
 		},
@@ -137,7 +139,7 @@ func TestContentPartValidate(t *testing.T) {
 			part: ContentPart{
 				Type: ContentTypeImage,
 				Media: &MediaContent{
-					Data:     stringPtr("base64data"),
+					Data:     testutil.Ptr("base64data"),
 					MIMEType: MIMETypeImageJPEG,
 				},
 			},
@@ -155,7 +157,7 @@ func TestContentPartValidate(t *testing.T) {
 			name: "invalid type",
 			part: ContentPart{
 				Type: "invalid",
-				Text: stringPtr("test"),
+				Text: testutil.Ptr("test"),
 			},
 			wantErr: true,
 		},
@@ -180,7 +182,7 @@ func TestMediaContentValidate(t *testing.T) {
 		{
 			name: "valid with data",
 			media: MediaContent{
-				Data:     stringPtr("base64data"),
+				Data:     testutil.Ptr("base64data"),
 				MIMEType: MIMETypeImageJPEG,
 			},
 			wantErr: false,
@@ -188,7 +190,7 @@ func TestMediaContentValidate(t *testing.T) {
 		{
 			name: "valid with file path",
 			media: MediaContent{
-				FilePath: stringPtr("/path/to/image.jpg"),
+				FilePath: testutil.Ptr("/path/to/image.jpg"),
 				MIMEType: MIMETypeImageJPEG,
 			},
 			wantErr: false,
@@ -196,7 +198,7 @@ func TestMediaContentValidate(t *testing.T) {
 		{
 			name: "valid with URL",
 			media: MediaContent{
-				URL:      stringPtr("https://example.com/image.jpg"),
+				URL:      testutil.Ptr("https://example.com/image.jpg"),
 				MIMEType: MIMETypeImageJPEG,
 			},
 			wantErr: false,
@@ -211,8 +213,8 @@ func TestMediaContentValidate(t *testing.T) {
 		{
 			name: "invalid - multiple data sources",
 			media: MediaContent{
-				Data:     stringPtr("base64data"),
-				FilePath: stringPtr("/path/to/image.jpg"),
+				Data:     testutil.Ptr("base64data"),
+				FilePath: testutil.Ptr("/path/to/image.jpg"),
 				MIMEType: MIMETypeImageJPEG,
 			},
 			wantErr: true,
@@ -220,7 +222,7 @@ func TestMediaContentValidate(t *testing.T) {
 		{
 			name: "invalid - no MIME type",
 			media: MediaContent{
-				Data: stringPtr("base64data"),
+				Data: testutil.Ptr("base64data"),
 			},
 			wantErr: true,
 		},
@@ -396,11 +398,6 @@ func TestInferMIMEType(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Helper function
-func stringPtr(s string) *string {
-	return &s
 }
 
 func TestNewImagePart_ErrorPath(t *testing.T) {

--- a/runtime/types/migration_test.go
+++ b/runtime/types/migration_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 )
 
 func TestMigrateToMultimodal(t *testing.T) {
@@ -245,7 +247,7 @@ func TestCloneMessage(t *testing.T) {
 
 	// Modify clone and verify original unchanged
 	clone.Content = "Modified"
-	clone.Parts[0].Text = stringPtr("Modified text")
+	clone.Parts[0].Text = testutil.Ptr("Modified text")
 	clone.Meta["key"] = "modified"
 
 	if original.Content == "Modified" {

--- a/sdk/eval_integration_test.go
+++ b/sdk/eval_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
 )
@@ -37,7 +38,7 @@ func (d *integrationDispatcher) DispatchTurnEvals(
 	d.mu.Unlock()
 	d.turnCh <- struct{}{}
 	return []evals.EvalResult{
-		{EvalID: "e1", Passed: true, Score: float64Ptr(0.9)},
+		{EvalID: "e1", Passed: true, Score: testutil.Ptr(0.9)},
 	}, nil
 }
 
@@ -60,7 +61,6 @@ func (d *integrationDispatcher) DispatchConversationEvals(
 	return nil, nil
 }
 
-func float64Ptr(v float64) *float64 { return &v }
 
 // integrationResultWriter records results for assertion.
 type integrationResultWriter struct {

--- a/tools/arena/adapters/arena_output_test.go
+++ b/tools/arena/adapters/arena_output_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -308,7 +309,7 @@ func TestConvertParts(t *testing.T) {
 			parts: []ArenaContentPart{
 				{
 					Type: "text",
-					Text: stringPtr("Hello"),
+					Text: testutil.Ptr("Hello"),
 				},
 			},
 			want: 1,
@@ -318,7 +319,7 @@ func TestConvertParts(t *testing.T) {
 			parts: []ArenaContentPart{
 				{
 					Type: "text",
-					Text: stringPtr("Check this image:"),
+					Text: testutil.Ptr("Check this image:"),
 				},
 				{
 					Type: "image",

--- a/tools/arena/adapters/session_recording_test.go
+++ b/tools/arena/adapters/session_recording_test.go
@@ -7,18 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
-
-// Helper function to create string pointers
-func stringPtr(s string) *string {
-	return &s
-}
-
-// Helper function to create int pointers
-func intPtr(i int) *int {
-	return &i
-}
 
 func TestSessionRecordingAdapter_CanHandle(t *testing.T) {
 	adapter := NewSessionRecordingAdapter()
@@ -114,7 +105,7 @@ func TestSessionRecordingAdapter_Load(t *testing.T) {
 					Parts: []RecordedContentPart{
 						{
 							Type: "text",
-							Text: stringPtr("I have a billing question"),
+							Text: testutil.Ptr("I have a billing question"),
 						},
 					},
 				},
@@ -278,7 +269,7 @@ func TestSessionRecordingAdapter_Load_WithMultimodal(t *testing.T) {
 					Parts: []RecordedContentPart{
 						{
 							Type: "text",
-							Text: stringPtr("What's in this image?"),
+							Text: testutil.Ptr("What's in this image?"),
 						},
 						{
 							Type: "image",
@@ -379,7 +370,7 @@ func TestConvertContentPart(t *testing.T) {
 			name: "text part",
 			part: RecordedContentPart{
 				Type: "text",
-				Text: stringPtr("Hello"),
+				Text: testutil.Ptr("Hello"),
 			},
 			check: func(t *testing.T, cp types.ContentPart) {
 				if cp.Type != "text" {

--- a/tools/arena/adapters/transcript_test.go
+++ b/tools/arena/adapters/transcript_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -226,7 +227,7 @@ func TestTranscriptAdapter_Load_WithMultimodal(t *testing.T) {
 				Parts: []TranscriptContentPart{
 					{
 						Type: "text",
-						Text: stringPtr("Analyze this image"),
+						Text: testutil.Ptr("Analyze this image"),
 					},
 					{
 						Type: "image",
@@ -323,7 +324,7 @@ func TestTranscriptConvertContentPart(t *testing.T) {
 			name: "text part",
 			part: TranscriptContentPart{
 				Type: "text",
-				Text: stringPtr("Hello world"),
+				Text: testutil.Ptr("Hello world"),
 			},
 			want: "text",
 		},

--- a/tools/arena/assertions/types.go
+++ b/tools/arena/assertions/types.go
@@ -3,6 +3,7 @@ package assertions
 import (
 	"fmt"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
@@ -43,7 +44,7 @@ func (a AssertionConfig) ToEvalDef(index int) evals.EvalDef {
 		Trigger:   evals.TriggerEveryTurn,
 		Params:    a.Params,
 		Message:   a.Message,
-		Threshold: &evals.Threshold{Passed: boolPtr(true)},
+		Threshold: &evals.Threshold{Passed: testutil.Ptr(true)},
 	}
 	if a.When != nil {
 		def.When = &evals.EvalWhen{
@@ -63,5 +64,3 @@ func (a AssertionConfig) ToConversationEvalDef(index int) evals.EvalDef {
 	def.Trigger = evals.TriggerOnConversationComplete
 	return def
 }
-
-func boolPtr(b bool) *bool { return &b }

--- a/tools/arena/engine/conversation_executor_selfplay_multiturn_test.go
+++ b/tools/arena/engine/conversation_executor_selfplay_multiturn_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -216,7 +217,7 @@ func TestExecuteConversation_SelfPlayMultiTurnStreaming(t *testing.T) {
 		TaskType: "assistant",
 		Turns: []config.TurnDefinition{
 			{Role: "user", Content: "Start conversation."},
-			{Role: "attacker", Persona: "attacker", Turns: 3, Streaming: boolPtr(true)},
+			{Role: "attacker", Persona: "attacker", Turns: 3, Streaming: testutil.Ptr(true)},
 		},
 	}
 
@@ -352,14 +353,6 @@ func saveMessagesToStateStore(ctx context.Context, req turnexecutors.TurnRequest
 	return store.Save(ctx, state)
 }
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func ptrFloat32(f float32) *float32 {
-	return &f
-}
-
 // createTestSelfPlayRegistry creates a minimal self-play registry for testing
 func createTestSelfPlayRegistry(t *testing.T) *selfplay.Registry {
 	t.Helper()
@@ -390,21 +383,21 @@ func createTestSelfPlayRegistry(t *testing.T) *selfplay.Registry {
 			ID:           "curious-learner",
 			SystemPrompt: "You are a curious learner asking questions.",
 			Defaults: config.PersonaDefaults{
-				Temperature: ptrFloat32(0.7),
+				Temperature: testutil.Ptr[float32](0.7),
 			},
 		},
 		"attacker": {
 			ID:           "attacker",
 			SystemPrompt: "You are testing security.",
 			Defaults: config.PersonaDefaults{
-				Temperature: ptrFloat32(0.8),
+				Temperature: testutil.Ptr[float32](0.8),
 			},
 		},
 		"test": {
 			ID:           "test",
 			SystemPrompt: "You are a test persona.",
 			Defaults: config.PersonaDefaults{
-				Temperature: ptrFloat32(0.7),
+				Temperature: testutil.Ptr[float32](0.7),
 			},
 		},
 	}

--- a/tools/arena/engine/conversation_executor_streaming_test.go
+++ b/tools/arena/engine/conversation_executor_streaming_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -531,7 +532,7 @@ func TestExecuteConversation_SelfPlayTurnNonStreaming(t *testing.T) {
 			ID:           "plant-operator",
 			SystemPrompt: "You are an operator.",
 			Defaults: config.PersonaDefaults{
-				Temperature: ptrFloat32Streaming(0.7),
+				Temperature: testutil.Ptr[float32](0.7),
 			},
 		},
 	}
@@ -601,7 +602,7 @@ func TestExecuteConversation_SelfPlayTurnStreaming(t *testing.T) {
 			ID:           "plant-operator",
 			SystemPrompt: "You are an operator.",
 			Defaults: config.PersonaDefaults{
-				Temperature: ptrFloat32Streaming(0.7),
+				Temperature: testutil.Ptr[float32](0.7),
 			},
 		},
 	}
@@ -647,8 +648,4 @@ func TestExecuteConversation_SelfPlayTurnStreaming(t *testing.T) {
 	require.False(t, result.Failed)
 	require.Equal(t, 0, selfPlayExec.execCalls)
 	require.Equal(t, 1, selfPlayExec.streamCalls)
-}
-
-func ptrFloat32Streaming(f float32) *float32 {
-	return &f
 }

--- a/tools/arena/engine/conversation_executor_vars_test.go
+++ b/tools/arena/engine/conversation_executor_vars_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -256,7 +257,7 @@ func TestBuildTurnRequest_TemperatureAndMaxTokens(t *testing.T) {
 			name:              "override temperature",
 			configTemp:        0.7,
 			configMax:         1000,
-			reqTemp:           float64Ptr(0.9),
+			reqTemp:           testutil.Ptr(0.9),
 			reqMax:            nil,
 			expectedTemp:      0.9,
 			expectedMaxTokens: 1000,
@@ -266,7 +267,7 @@ func TestBuildTurnRequest_TemperatureAndMaxTokens(t *testing.T) {
 			configTemp:        0.7,
 			configMax:         1000,
 			reqTemp:           nil,
-			reqMax:            intPtr(2000),
+			reqMax:            testutil.Ptr(2000),
 			expectedTemp:      0.7,
 			expectedMaxTokens: 2000,
 		},
@@ -274,8 +275,8 @@ func TestBuildTurnRequest_TemperatureAndMaxTokens(t *testing.T) {
 			name:              "override both",
 			configTemp:        0.7,
 			configMax:         1000,
-			reqTemp:           float64Ptr(0.5),
-			reqMax:            intPtr(500),
+			reqTemp:           testutil.Ptr(0.5),
+			reqMax:            testutil.Ptr(500),
 			expectedTemp:      0.5,
 			expectedMaxTokens: 500,
 		},
@@ -377,15 +378,6 @@ func TestBuildTurnRequest_StateStoreConfig(t *testing.T) {
 	if turnReq.ConversationID != "conv-456" {
 		t.Errorf("Expected ConversationID conv-456, got %s", turnReq.ConversationID)
 	}
-}
-
-// Helper functions
-func float64Ptr(f float64) *float64 {
-	return &f
-}
-
-func intPtr(i int) *int {
-	return &i
 }
 
 // MockProvider for testing (reuse from conversation_executor_test.go)

--- a/tools/arena/engine/duplex_conversation_executor_test.go
+++ b/tools/arena/engine/duplex_conversation_executor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/streaming"
@@ -663,7 +664,7 @@ func TestProcessResponseElement(t *testing.T) {
 			elem: &stage.StreamElement{
 				EndOfStream: true,
 				Message: &types.Message{
-					Parts: []types.ContentPart{{Text: stringPtr("text")}},
+					Parts: []types.ContentPart{{Text: testutil.Ptr("text")}},
 				},
 			},
 			expectedAction: streaming.ResponseActionComplete,
@@ -672,7 +673,7 @@ func TestProcessResponseElement(t *testing.T) {
 		{
 			name: "streaming chunk continues",
 			elem: &stage.StreamElement{
-				Text: stringPtr("chunk"),
+				Text: testutil.Ptr("chunk"),
 			},
 			expectedAction: streaming.ResponseActionContinue,
 			expectedErr:    false,
@@ -691,8 +692,4 @@ func TestProcessResponseElement(t *testing.T) {
 			}
 		})
 	}
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/tools/arena/render/media_test.go
+++ b/tools/arena/render/media_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
 )
@@ -297,14 +298,14 @@ func TestRenderMessageWithMedia(t *testing.T) {
 				Parts: []types.ContentPart{
 					{
 						Type: types.ContentTypeText,
-						Text: stringPtr("Analyze this image"),
+						Text: testutil.Ptr("Analyze this image"),
 					},
 					{
 						Type: types.ContentTypeImage,
 						Media: &types.MediaContent{
 							MIMEType: "image/jpeg",
-							FilePath: stringPtr("test.jpg"),
-							Data:     stringPtr("base64data"),
+							FilePath: testutil.Ptr("test.jpg"),
+							Data:     testutil.Ptr("base64data"),
 						},
 					},
 				},
@@ -321,7 +322,7 @@ func TestRenderMessageWithMedia(t *testing.T) {
 				Parts: []types.ContentPart{
 					{
 						Type: types.ContentTypeText,
-						Text: stringPtr("Generate a short audio clip"),
+						Text: testutil.Ptr("Generate a short audio clip"),
 					},
 				},
 			},
@@ -337,16 +338,16 @@ func TestRenderMessageWithMedia(t *testing.T) {
 						Type: types.ContentTypeImage,
 						Media: &types.MediaContent{
 							MIMEType: "image/png",
-							FilePath: stringPtr("chart.png"),
-							Data:     stringPtr("data"),
+							FilePath: testutil.Ptr("chart.png"),
+							Data:     testutil.Ptr("data"),
 						},
 					},
 					{
 						Type: types.ContentTypeAudio,
 						Media: &types.MediaContent{
 							MIMEType: "audio/wav",
-							FilePath: stringPtr("voice.wav"),
-							Data:     stringPtr("data"),
+							FilePath: testutil.Ptr("voice.wav"),
+							Data:     testutil.Ptr("data"),
 						},
 					},
 				},
@@ -389,8 +390,8 @@ func TestRenderInlineImage(t *testing.T) {
 				Type: types.ContentTypeImage,
 				Media: &types.MediaContent{
 					MIMEType: "image/jpeg",
-					FilePath: stringPtr("/path/to/image.jpg"),
-					Data:     stringPtr("SGVsbG8gV29ybGQ="),
+					FilePath: testutil.Ptr("/path/to/image.jpg"),
+					Data:     testutil.Ptr("SGVsbG8gV29ybGQ="),
 				},
 			},
 			want:    []string{"inline-image", "data:image/jpeg;base64,", "SGVsbG8gV29ybGQ=", "image.jpg"},
@@ -402,7 +403,7 @@ func TestRenderInlineImage(t *testing.T) {
 				Type: types.ContentTypeImage,
 				Media: &types.MediaContent{
 					MIMEType: "image/png",
-					URL:      stringPtr("https://example.com/image.png"),
+					URL:      testutil.Ptr("https://example.com/image.png"),
 				},
 			},
 			want:    []string{"inline-image", "https://example.com/image.png"},
@@ -414,7 +415,7 @@ func TestRenderInlineImage(t *testing.T) {
 				Type: types.ContentTypeImage,
 				Media: &types.MediaContent{
 					MIMEType: "image/gif",
-					FilePath: stringPtr("missing.gif"),
+					FilePath: testutil.Ptr("missing.gif"),
 				},
 			},
 			want:    []string{"inline-image-placeholder", "🖼️", "missing.gif"},
@@ -435,8 +436,8 @@ func TestRenderInlineImage(t *testing.T) {
 				Type: types.ContentTypeImage,
 				Media: &types.MediaContent{
 					MIMEType: "image/png",
-					FilePath: stringPtr("large.png"),
-					SizeKB:   int64Ptr(1024),
+					FilePath: testutil.Ptr("large.png"),
+					SizeKB:   testutil.Ptr[int64](1024),
 				},
 			},
 			want:    []string{"inline-image-placeholder", "1.0 MB"},
@@ -482,7 +483,7 @@ func TestGetMediaSummaryFromParts(t *testing.T) {
 		{
 			name: "text only",
 			parts: []types.ContentPart{
-				{Type: types.ContentTypeText, Text: stringPtr("hello")},
+				{Type: types.ContentTypeText, Text: testutil.Ptr("hello")},
 			},
 			want: &types.MediaSummary{
 				TotalParts: 1,
@@ -493,19 +494,19 @@ func TestGetMediaSummaryFromParts(t *testing.T) {
 		{
 			name: "mixed content",
 			parts: []types.ContentPart{
-				{Type: types.ContentTypeText, Text: stringPtr("text")},
+				{Type: types.ContentTypeText, Text: testutil.Ptr("text")},
 				{
 					Type: types.ContentTypeImage,
 					Media: &types.MediaContent{
 						MIMEType: "image/jpeg",
-						FilePath: stringPtr("test.jpg"),
+						FilePath: testutil.Ptr("test.jpg"),
 					},
 				},
 				{
 					Type: types.ContentTypeAudio,
 					Media: &types.MediaContent{
 						MIMEType: "audio/wav",
-						URL:      stringPtr("http://example.com/audio.wav"),
+						URL:      testutil.Ptr("http://example.com/audio.wav"),
 					},
 				},
 			},
@@ -583,7 +584,7 @@ func TestGetMediaItemSummaryFromPart(t *testing.T) {
 				Type: types.ContentTypeImage,
 				Media: &types.MediaContent{
 					MIMEType: "image/png",
-					FilePath: stringPtr("/path/to/image.png"),
+					FilePath: testutil.Ptr("/path/to/image.png"),
 				},
 			},
 			want: types.MediaItemSummary{
@@ -599,7 +600,7 @@ func TestGetMediaItemSummaryFromPart(t *testing.T) {
 				Type: types.ContentTypeAudio,
 				Media: &types.MediaContent{
 					MIMEType: "audio/mp3",
-					URL:      stringPtr("https://example.com/audio.mp3"),
+					URL:      testutil.Ptr("https://example.com/audio.mp3"),
 				},
 			},
 			want: types.MediaItemSummary{
@@ -615,7 +616,7 @@ func TestGetMediaItemSummaryFromPart(t *testing.T) {
 				Type: types.ContentTypeImage,
 				Media: &types.MediaContent{
 					MIMEType: "image/jpeg",
-					Data:     stringPtr("aGVsbG8gd29ybGQ="), // 16 chars base64
+					Data:     testutil.Ptr("aGVsbG8gd29ybGQ="), // 16 chars base64
 				},
 			},
 			want: types.MediaItemSummary{
@@ -632,8 +633,8 @@ func TestGetMediaItemSummaryFromPart(t *testing.T) {
 				Type: types.ContentTypeVideo,
 				Media: &types.MediaContent{
 					MIMEType: "video/mp4",
-					FilePath: stringPtr("video.mp4"),
-					SizeKB:   int64Ptr(1024),
+					FilePath: testutil.Ptr("video.mp4"),
+					SizeKB:   testutil.Ptr[int64](1024),
 				},
 			},
 			want: types.MediaItemSummary{
@@ -672,15 +673,6 @@ func TestGetMediaItemSummaryFromPart(t *testing.T) {
 	}
 }
 
-// Helper functions for tests
-func stringPtr(s string) *string {
-	return &s
-}
-
-func int64Ptr(i int64) *int64 {
-	return &i
-}
-
 func TestCalculateMediaStats(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -716,9 +708,9 @@ func TestCalculateMediaStats(t *testing.T) {
 									Type: types.ContentTypeImage,
 									Media: &types.MediaContent{
 										MIMEType: "image/jpeg",
-										FilePath: stringPtr("test.jpg"),
-										Data:     stringPtr("data"),
-										SizeKB:   int64Ptr(50),
+										FilePath: testutil.Ptr("test.jpg"),
+										Data:     testutil.Ptr("data"),
+										SizeKB:   testutil.Ptr[int64](50),
 									},
 								},
 							},
@@ -744,16 +736,16 @@ func TestCalculateMediaStats(t *testing.T) {
 									Type: types.ContentTypeImage,
 									Media: &types.MediaContent{
 										MIMEType: "image/png",
-										FilePath: stringPtr("loaded.png"),
-										Data:     stringPtr("data"),
-										SizeKB:   int64Ptr(100),
+										FilePath: testutil.Ptr("loaded.png"),
+										Data:     testutil.Ptr("data"),
+										SizeKB:   testutil.Ptr[int64](100),
 									},
 								},
 								{
 									Type: types.ContentTypeImage,
 									Media: &types.MediaContent{
 										MIMEType: "image/jpeg",
-										FilePath: stringPtr("missing.jpg"),
+										FilePath: testutil.Ptr("missing.jpg"),
 										// No Data = not loaded, triggers error path
 									},
 								},
@@ -761,9 +753,9 @@ func TestCalculateMediaStats(t *testing.T) {
 									Type: types.ContentTypeAudio,
 									Media: &types.MediaContent{
 										MIMEType: "audio/wav",
-										FilePath: stringPtr("audio.wav"),
-										Data:     stringPtr("audiodata"),
-										SizeKB:   int64Ptr(256),
+										FilePath: testutil.Ptr("audio.wav"),
+										Data:     testutil.Ptr("audiodata"),
+										SizeKB:   testutil.Ptr[int64](256),
 									},
 								},
 							},
@@ -790,9 +782,9 @@ func TestCalculateMediaStats(t *testing.T) {
 									Type: types.ContentTypeImage,
 									Media: &types.MediaContent{
 										MIMEType: "image/jpeg",
-										FilePath: stringPtr("img1.jpg"),
-										Data:     stringPtr("data1"),
-										SizeKB:   int64Ptr(50),
+										FilePath: testutil.Ptr("img1.jpg"),
+										Data:     testutil.Ptr("data1"),
+										SizeKB:   testutil.Ptr[int64](50),
 									},
 								},
 							},
@@ -808,9 +800,9 @@ func TestCalculateMediaStats(t *testing.T) {
 									Type: types.ContentTypeVideo,
 									Media: &types.MediaContent{
 										MIMEType: "video/mp4",
-										FilePath: stringPtr("video.mp4"),
-										Data:     stringPtr("videodata"),
-										SizeKB:   int64Ptr(1024),
+										FilePath: testutil.Ptr("video.mp4"),
+										Data:     testutil.Ptr("videodata"),
+										SizeKB:   testutil.Ptr[int64](1024),
 									},
 								},
 							},

--- a/tools/arena/results/junit/junit_media_test.go
+++ b/tools/arena/results/junit/junit_media_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
 )
@@ -37,7 +38,7 @@ func TestCalculateMediaStats(t *testing.T) {
 								{
 									Type: types.ContentTypeImage,
 									Media: &types.MediaContent{
-										Data:     ptrString("base64data"),
+										Data:     testutil.Ptr("base64data"),
 										MIMEType: "image/jpeg",
 									},
 								},
@@ -66,21 +67,21 @@ func TestCalculateMediaStats(t *testing.T) {
 								{
 									Type: types.ContentTypeImage,
 									Media: &types.MediaContent{
-										Data:     ptrString("img123"),
+										Data:     testutil.Ptr("img123"),
 										MIMEType: "image/png",
 									},
 								},
 								{
 									Type: types.ContentTypeAudio,
 									Media: &types.MediaContent{
-										FilePath: ptrString("/path/to/audio.mp3"),
+										FilePath: testutil.Ptr("/path/to/audio.mp3"),
 										MIMEType: "audio/mpeg",
 									},
 								},
 								{
 									Type: types.ContentTypeVideo,
 									Media: &types.MediaContent{
-										URL:      ptrString("https://example.com/video.mp4"),
+										URL:      testutil.Ptr("https://example.com/video.mp4"),
 										MIMEType: "video/mp4",
 									},
 								},
@@ -116,7 +117,7 @@ func TestCalculateMediaStats(t *testing.T) {
 								{
 									Type: types.ContentTypeAudio,
 									Media: &types.MediaContent{
-										Data:     ptrString(""), // Empty data
+										Data:     testutil.Ptr(""), // Empty data
 										MIMEType: "audio/mp3",
 									},
 								},
@@ -165,7 +166,7 @@ func TestCalculateMediaStats(t *testing.T) {
 							Parts: []types.ContentPart{
 								{
 									Type: types.ContentTypeText,
-									Text: ptrString("Hello world"),
+									Text: testutil.Ptr("Hello world"),
 								},
 								{
 									Type: types.ContentTypeImage,
@@ -196,7 +197,7 @@ func TestCalculateMediaStats(t *testing.T) {
 								{
 									Type: types.ContentTypeImage,
 									Media: &types.MediaContent{
-										Data:     ptrString("abc"),
+										Data:     testutil.Ptr("abc"),
 										MIMEType: "image/png",
 									},
 								},
@@ -212,14 +213,14 @@ func TestCalculateMediaStats(t *testing.T) {
 								{
 									Type: types.ContentTypeImage,
 									Media: &types.MediaContent{
-										Data:     ptrString("def"),
+										Data:     testutil.Ptr("def"),
 										MIMEType: "image/jpeg",
 									},
 								},
 								{
 									Type: types.ContentTypeAudio,
 									Media: &types.MediaContent{
-										Data:     ptrString("audio123"),
+										Data:     testutil.Ptr("audio123"),
 										MIMEType: "audio/wav",
 									},
 								},
@@ -396,12 +397,12 @@ func TestMediaStatsIntegration(t *testing.T) {
 					Parts: []types.ContentPart{
 						{
 							Type: types.ContentTypeText,
-							Text: ptrString("Analyze this image"),
+							Text: testutil.Ptr("Analyze this image"),
 						},
 						{
 							Type: types.ContentTypeImage,
 							Media: &types.MediaContent{
-								Data:     ptrString("image_base64_data_here"),
+								Data:     testutil.Ptr("image_base64_data_here"),
 								MIMEType: "image/jpeg",
 							},
 						},
@@ -427,7 +428,7 @@ func TestMediaStatsIntegration(t *testing.T) {
 						{
 							Type: types.ContentTypeAudio,
 							Media: &types.MediaContent{
-								FilePath: ptrString("/path/to/audio.mp3"),
+								FilePath: testutil.Ptr("/path/to/audio.mp3"),
 								MIMEType: "audio/mpeg",
 							},
 						},
@@ -471,9 +472,4 @@ func TestMediaStatsIntegration(t *testing.T) {
 			t.Error("property has empty value")
 		}
 	}
-}
-
-// Helper function to create string pointers
-func ptrString(s string) *string {
-	return &s
 }

--- a/tools/arena/results/markdown/markdown_media_test.go
+++ b/tools/arena/results/markdown/markdown_media_test.go
@@ -3,6 +3,7 @@ package markdown
 import (
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
 )
@@ -12,7 +13,7 @@ func TestMarkdownRepository_MediaHelpers(t *testing.T) {
 
 	t.Run("mediaHasData with data", func(t *testing.T) {
 		media := &types.MediaContent{
-			Data:     ptrString("base64data"),
+			Data:     testutil.Ptr("base64data"),
 			MIMEType: "image/jpeg",
 		}
 		if !repo.mediaHasData(media) {
@@ -22,7 +23,7 @@ func TestMarkdownRepository_MediaHelpers(t *testing.T) {
 
 	t.Run("mediaHasData with filepath", func(t *testing.T) {
 		media := &types.MediaContent{
-			FilePath: ptrString("/path/to/file.jpg"),
+			FilePath: testutil.Ptr("/path/to/file.jpg"),
 			MIMEType: "image/jpeg",
 		}
 		if !repo.mediaHasData(media) {
@@ -32,7 +33,7 @@ func TestMarkdownRepository_MediaHelpers(t *testing.T) {
 
 	t.Run("mediaHasData with URL", func(t *testing.T) {
 		media := &types.MediaContent{
-			URL:      ptrString("https://example.com/image.jpg"),
+			URL:      testutil.Ptr("https://example.com/image.jpg"),
 			MIMEType: "image/jpeg",
 		}
 		if !repo.mediaHasData(media) {
@@ -51,7 +52,7 @@ func TestMarkdownRepository_MediaHelpers(t *testing.T) {
 
 	t.Run("calculateMediaSize with data", func(t *testing.T) {
 		media := &types.MediaContent{
-			Data:     ptrString("base64encodeddata"),
+			Data:     testutil.Ptr("base64encodeddata"),
 			MIMEType: "image/jpeg",
 		}
 		size := repo.calculateMediaSize(media)
@@ -62,7 +63,7 @@ func TestMarkdownRepository_MediaHelpers(t *testing.T) {
 
 	t.Run("calculateMediaSize without data", func(t *testing.T) {
 		media := &types.MediaContent{
-			FilePath: ptrString("/path"),
+			FilePath: testutil.Ptr("/path"),
 			MIMEType: "image/jpeg",
 		}
 		size := repo.calculateMediaSize(media)
@@ -124,7 +125,7 @@ func TestMarkdownRepository_ProcessMediaPart(t *testing.T) {
 			part: types.ContentPart{
 				Type: "image",
 				Media: &types.MediaContent{
-					Data:     ptrString("imgdata"),
+					Data:     testutil.Ptr("imgdata"),
 					MIMEType: "image/png",
 				},
 			},
@@ -137,7 +138,7 @@ func TestMarkdownRepository_ProcessMediaPart(t *testing.T) {
 			part: types.ContentPart{
 				Type: "audio",
 				Media: &types.MediaContent{
-					FilePath: ptrString("/path/audio.mp3"),
+					FilePath: testutil.Ptr("/path/audio.mp3"),
 					MIMEType: "audio/mpeg",
 				},
 			},
@@ -150,7 +151,7 @@ func TestMarkdownRepository_ProcessMediaPart(t *testing.T) {
 			part: types.ContentPart{
 				Type: "video",
 				Media: &types.MediaContent{
-					URL:      ptrString("https://example.com/video.mp4"),
+					URL:      testutil.Ptr("https://example.com/video.mp4"),
 					MIMEType: "video/mp4",
 				},
 			},
@@ -230,7 +231,7 @@ func TestMarkdownRepository_AddMediaStats(t *testing.T) {
 							{
 								Type: "image",
 								Media: &types.MediaContent{
-									Data:     ptrString("imagedata"),
+									Data:     testutil.Ptr("imagedata"),
 									MIMEType: "image/jpeg",
 								},
 							},
@@ -252,14 +253,14 @@ func TestMarkdownRepository_AddMediaStats(t *testing.T) {
 							{
 								Type: "image",
 								Media: &types.MediaContent{
-									Data:     ptrString("img"),
+									Data:     testutil.Ptr("img"),
 									MIMEType: "image/png",
 								},
 							},
 							{
 								Type: "audio",
 								Media: &types.MediaContent{
-									FilePath: ptrString("/audio.mp3"),
+									FilePath: testutil.Ptr("/audio.mp3"),
 									MIMEType: "audio/mpeg",
 								},
 							},
@@ -299,8 +300,4 @@ func TestMarkdownRepository_AddMediaStats(t *testing.T) {
 			}
 		})
 	}
-}
-
-func ptrString(s string) *string {
-	return &s
 }

--- a/tools/arena/results/markdown/markdown_repository_test.go
+++ b/tools/arena/results/markdown/markdown_repository_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
 	"github.com/stretchr/testify/assert"
@@ -614,32 +615,32 @@ func TestMarkdownResultRepository_MediaOutputs(t *testing.T) {
 					Type:      "image",
 					MIMEType:  "image/png",
 					SizeBytes: 102400,
-					Width:     ptr(800),
-					Height:    ptr(600),
+					Width:     testutil.Ptr(800),
+					Height:    testutil.Ptr(600),
 					FilePath:  "/tmp/output1.png",
 				},
 				{
 					Type:      "image",
 					MIMEType:  "image/jpeg",
 					SizeBytes: 204800,
-					Width:     ptr(1920),
-					Height:    ptr(1080),
+					Width:     testutil.Ptr(1920),
+					Height:    testutil.Ptr(1080),
 					FilePath:  "/tmp/output2.jpg",
 				},
 				{
 					Type:      "audio",
 					MIMEType:  "audio/wav",
 					SizeBytes: 512000,
-					Duration:  ptr(30), // seconds as int
+					Duration:  testutil.Ptr(30), // seconds as int
 					FilePath:  "/tmp/audio.wav",
 				},
 				{
 					Type:      "video",
 					MIMEType:  "video/mp4",
 					SizeBytes: 2048000,
-					Duration:  ptr(60), // seconds as int
-					Width:     ptr(1280),
-					Height:    ptr(720),
+					Duration:  testutil.Ptr(60), // seconds as int
+					Width:     testutil.Ptr(1280),
+					Height:    testutil.Ptr(720),
 					FilePath:  "/tmp/video.mp4",
 				},
 			},
@@ -879,8 +880,4 @@ func TestHasFailedAssertionInMap(t *testing.T) {
 	t.Run("empty assertions", func(t *testing.T) {
 		assert.False(t, repo.hasFailedAssertionInMap(map[string]interface{}{}))
 	})
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/tools/arena/stages/assertions_test.go
+++ b/tools/arena/stages/assertions_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/pkg/testutil"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -28,7 +29,6 @@ func (m *mockTurnEvalRunner) RunAssertionsAsEvals(
 	return m.results
 }
 
-func float64Ptr(v float64) *float64 { return &v }
 
 func TestArenaAssertionStage_NoAssertions(t *testing.T) {
 	s := NewArenaAssertionStage(nil)
@@ -72,7 +72,7 @@ func TestArenaAssertionStage_WithPassingAssertion(t *testing.T) {
 			{
 				Type:    "always_pass",
 				Passed:  true,
-				Score:   float64Ptr(1.0),
+				Score:   testutil.Ptr(1.0),
 				Message: "Should always pass",
 				Details: map[string]any{"status": "passed"},
 			},
@@ -111,7 +111,7 @@ func TestArenaAssertionStage_WithFailingAssertion(t *testing.T) {
 			{
 				Type:    "always_fail",
 				Passed:  false,
-				Score:   float64Ptr(0.0),
+				Score:   testutil.Ptr(0.0),
 				Message: "Should always fail",
 				Details: map[string]any{"status": "failed", "reason": "always fails"},
 			},
@@ -147,7 +147,7 @@ func TestArenaAssertionStage_NoAssistantMessage(t *testing.T) {
 
 	runner := &mockTurnEvalRunner{
 		results: []evals.EvalResult{
-			{Type: "always_pass", Passed: true, Score: float64Ptr(1.0)},
+			{Type: "always_pass", Passed: true, Score: testutil.Ptr(1.0)},
 		},
 	}
 
@@ -352,14 +352,14 @@ func TestArenaAssertionStage_MultipleAssertions(t *testing.T) {
 			{
 				Type:    "pass1",
 				Passed:  true,
-				Score:   float64Ptr(1.0),
+				Score:   testutil.Ptr(1.0),
 				Message: "First assertion",
 				Details: map[string]any{"status": "passed"},
 			},
 			{
 				Type:    "pass2",
 				Passed:  true,
-				Score:   float64Ptr(1.0),
+				Score:   testutil.Ptr(1.0),
 				Message: "Second assertion",
 				Details: map[string]any{"status": "passed"},
 			},
@@ -395,14 +395,14 @@ func TestArenaAssertionStage_AllAssertionsRunOnFailure(t *testing.T) {
 			{
 				Type:    "fail_first",
 				Passed:  false,
-				Score:   float64Ptr(0.0),
+				Score:   testutil.Ptr(0.0),
 				Message: "Will fail",
 				Details: map[string]any{"status": "failed"},
 			},
 			{
 				Type:    "also_runs",
 				Passed:  true,
-				Score:   float64Ptr(1.0),
+				Score:   testutil.Ptr(1.0),
 				Message: "Also runs",
 				Details: map[string]any{"status": "passed"},
 			},


### PR DESCRIPTION
## Summary

- Create `pkg/testutil.Ptr[T]` as a shared generic pointer helper that returns `*T` from a value of type `T`
- Replace **all** local pointer helper redeclarations across 30 files in `runtime/`, `sdk/`, and `tools/arena/`
- Eliminated helpers: `ptr[T]`, `textPtr`, `stringPtr`, `ptrString`, `boolPtr`, `float64Ptr`, `ptrFloat32`, `ptrFloat32Streaming`, `intPtr`, `int64Ptr`, `floatPtr`

Closes #473

## Test plan

- [x] `pkg/testutil` has full test coverage (100%)
- [x] All existing tests pass across `runtime`, `sdk`, and `tools/arena` modules
- [x] `golangci-lint` reports 0 issues on changed code
- [x] Pre-commit hook passes (lint, build, test with coverage)