### PR TITLE
fix: configure HTTP connection pooling for providers

### DIFF
--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -656,14 +656,12 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 		return predictResp, fmt.Errorf("failed to apply authentication: %w", authErr)
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
-
 	logger.APIRequest("OpenAI", "POST", p.baseURL+openAIPredictCompletionsPath, map[string]string{
 		contentTypeHeader:   applicationJSON,
 		authorizationHeader: "***",
 	}, openAIReq)
 
-	resp, err := client.Do(httpReq)
+	resp, err := p.GetHTTPClient().Do(httpReq)
 	if err != nil {
 		predictResp.Latency = time.Since(start)
 		return predictResp, fmt.Errorf("failed to send request: %w", err)

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -494,7 +494,7 @@ func TestPredict_Integration(t *testing.T) {
 		defer server.Close()
 
 		provider := &Provider{
-			BaseProvider: providers.NewBaseProvider("test", false, nil),
+			BaseProvider: providers.NewBaseProvider("test", false, &http.Client{Timeout: 30 * time.Second}),
 			model:        "gpt-4",
 			baseURL:      server.URL,
 			apiKey:       "test-key",
@@ -548,7 +548,7 @@ func TestPredict_Integration(t *testing.T) {
 		defer server.Close()
 
 		provider := &Provider{
-			BaseProvider: providers.NewBaseProvider("test", false, nil),
+			BaseProvider: providers.NewBaseProvider("test", false, &http.Client{Timeout: 30 * time.Second}),
 			model:        "gpt-4",
 			baseURL:      server.URL,
 			apiKey:       "test-key",
@@ -584,7 +584,7 @@ func TestPredict_Integration(t *testing.T) {
 		defer server.Close()
 
 		provider := &Provider{
-			BaseProvider: providers.NewBaseProvider("test", false, nil),
+			BaseProvider: providers.NewBaseProvider("test", false, &http.Client{Timeout: 30 * time.Second}),
 			model:        "gpt-4",
 			baseURL:      server.URL,
 			apiKey:       "test-key",
@@ -625,7 +625,7 @@ func TestPredict_Integration(t *testing.T) {
 		defer server.Close()
 
 		provider := &Provider{
-			BaseProvider: providers.NewBaseProvider("test", false, nil),
+			BaseProvider: providers.NewBaseProvider("test", false, &http.Client{Timeout: 30 * time.Second}),
 			model:        "gpt-4",
 			baseURL:      server.URL,
 			apiKey:       "test-key",
@@ -880,7 +880,7 @@ func TestExtractContentString(t *testing.T) {
 
 func TestSupportsStreaming(t *testing.T) {
 	provider := &Provider{
-		BaseProvider: providers.NewBaseProvider("test", false, nil),
+		BaseProvider: providers.NewBaseProvider("test", false, &http.Client{Timeout: 30 * time.Second}),
 	}
 
 	if !provider.SupportsStreaming() {


### PR DESCRIPTION
## Summary
- **Fix OpenAI `Predict()` using throwaway `http.Client`**: Replaced `&http.Client{Timeout: 30 * time.Second}` with `p.GetHTTPClient()` so non-streaming predictions reuse the provider's shared HTTP client and its connection pool.
- **Add connection pooling to provider HTTP transports**: Introduced `NewPooledTransport()` in `base_provider.go` with tuned settings (MaxIdleConns: 1000, MaxIdleConnsPerHost: 100, MaxConnsPerHost: 100, IdleConnTimeout: 90s, TLS 1.2+, HTTP/2). Wired into `NewBaseProviderWithAPIKey` and `NewBaseProviderWithCredential`.
- **Fix A2A client using `http.DefaultClient`**: Replaced with a dedicated client configured with timeout (60s) and connection pooling, preventing resource contention with other packages sharing the default client.

Closes #490

## Test plan
- [x] New unit tests for `NewPooledTransport()` verifying all pool settings
- [x] New tests verifying `NewBaseProviderWithAPIKey` and `NewBaseProviderWithCredential` produce clients with pooled transports
- [x] New tests for A2A `NewClient` verifying default client is not `http.DefaultClient`, has correct timeout and transport settings
- [x] Test that `WithHTTPClient` option still overrides the default
- [x] Updated existing OpenAI tests that passed `nil` client (previously masked by per-call client creation)
- [x] All pre-commit checks pass (lint, build, tests with 80%+ coverage)