### PR TITLE
fix: propagate context instead of context.Background()

### DIFF
--- a/runtime/a2a/executor.go
+++ b/runtime/a2a/executor.go
@@ -27,7 +27,9 @@ func NewExecutor() *Executor {
 func (e *Executor) Name() string { return "a2a" }
 
 // Execute calls a remote A2A agent with the tool arguments and returns the response.
-func (e *Executor) Execute(descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (e *Executor) Execute(
+	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
 	if descriptor.A2AConfig == nil {
 		return nil, fmt.Errorf("a2a executor: tool %q has no A2AConfig", descriptor.Name)
 	}
@@ -74,8 +76,7 @@ func (e *Executor) Execute(descriptor *tools.ToolDescriptor, args json.RawMessag
 		},
 	}
 
-	// Apply timeout
-	ctx := context.Background()
+	// Apply timeout on top of the caller's context
 	if cfg.TimeoutMs > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(cfg.TimeoutMs)*time.Millisecond)

--- a/runtime/a2a/executor_test.go
+++ b/runtime/a2a/executor_test.go
@@ -1,6 +1,7 @@
 package a2a
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +20,7 @@ func TestExecutor_Name(t *testing.T) {
 func TestExecutor_Execute_NoA2AConfig(t *testing.T) {
 	e := NewExecutor()
 	desc := &tools.ToolDescriptor{Name: "test-tool"}
-	_, err := e.Execute(desc, json.RawMessage(`{"query":"hello"}`))
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"hello"}`))
 	if err == nil {
 		t.Fatal("expected error for missing A2AConfig")
 	}
@@ -56,7 +57,7 @@ func TestExecutor_Execute_BasicTextQuery(t *testing.T) {
 		},
 	}
 
-	result, err := e.Execute(desc, json.RawMessage(`{"query":"search for papers"}`))
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"search for papers"}`))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -96,7 +97,7 @@ func TestExecutor_Execute_ArtifactFallback(t *testing.T) {
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
 	}
 
-	result, err := e.Execute(desc, json.RawMessage(`{"query":"test"}`))
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"test"}`))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -130,7 +131,7 @@ func TestExecutor_Execute_EmptyResponse(t *testing.T) {
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
 	}
 
-	result, err := e.Execute(desc, json.RawMessage(`{"query":"test"}`))
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"test"}`))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -151,7 +152,7 @@ func TestExecutor_Execute_InvalidArgs(t *testing.T) {
 		A2AConfig: &tools.A2AConfig{AgentURL: "http://localhost:1"},
 	}
 
-	_, err := e.Execute(desc, json.RawMessage(`not-json`))
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`not-json`))
 	if err == nil {
 		t.Fatal("expected error for invalid args")
 	}
@@ -188,7 +189,7 @@ func TestExecutor_Execute_WithSkillIDMetadata(t *testing.T) {
 		},
 	}
 
-	_, err := e.Execute(desc, json.RawMessage(`{"query":"hello"}`))
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"hello"}`))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -229,7 +230,7 @@ func TestExecutor_Execute_NoSkillIDMetadata(t *testing.T) {
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
 	}
 
-	_, err := e.Execute(desc, json.RawMessage(`{"query":"hello"}`))
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"hello"}`))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -268,7 +269,7 @@ func TestExecutor_Execute_WithMediaParts(t *testing.T) {
 	}
 
 	args := `{"query":"analyze","image_url":"http://example.com/img.png","image_data":"base64data","audio_data":"audiodata"}`
-	_, err := e.Execute(desc, json.RawMessage(args))
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(args))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -315,8 +316,8 @@ func TestExecutor_ClientCaching(t *testing.T) {
 	}
 
 	// Execute twice with same URL - should reuse client
-	_, _ = e.Execute(desc, json.RawMessage(`{"query":"first"}`))
-	_, _ = e.Execute(desc, json.RawMessage(`{"query":"second"}`))
+	_, _ = e.Execute(context.Background(), desc, json.RawMessage(`{"query":"first"}`))
+	_, _ = e.Execute(context.Background(), desc, json.RawMessage(`{"query":"second"}`))
 
 	if callCount != 2 {
 		t.Errorf("server received %d calls, want 2", callCount)
@@ -344,7 +345,7 @@ func TestExecutor_Execute_ServerError(t *testing.T) {
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
 	}
 
-	_, err := e.Execute(desc, json.RawMessage(`{"query":"test"}`))
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"test"}`))
 	if err == nil {
 		t.Fatal("expected error from server error response")
 	}

--- a/runtime/evals/event_listener_test.go
+++ b/runtime/evals/event_listener_test.go
@@ -204,7 +204,7 @@ func TestEventBusEvalListener_CloseSessionFiresSessionEvals(t *testing.T) {
 	dispatcher.sessionResults = []EvalResult{{EvalID: "e1", Passed: true}}
 	dispatcher.mu.Unlock()
 
-	listener.CloseSession("s1")
+	listener.CloseSession(context.Background(), "s1")
 
 	select {
 	case <-dispatcher.sessionCh:

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -777,7 +777,7 @@ func (s *ProviderStage) executeToolCalls(
 
 		// Execute tool via registry (handles both sync and async tools)
 		startTime := time.Now()
-		asyncResult, err := s.toolRegistry.ExecuteAsync(toolCall.Name, toolCall.Args)
+		asyncResult, err := s.toolRegistry.ExecuteAsync(ctx, toolCall.Name, toolCall.Args)
 		if err != nil {
 			// Tool not found or execution setup failed
 			results = append(results, types.NewToolResultMessage(types.MessageToolResult{

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -1080,14 +1080,14 @@ func (m *mockAsyncExecutor) Name() string {
 	return m.name
 }
 
-func (m *mockAsyncExecutor) Execute(descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (m *mockAsyncExecutor) Execute(_ context.Context, descriptor *tools.ToolDescriptor, _ json.RawMessage) (json.RawMessage, error) {
 	if m.status == tools.ToolStatusFailed {
 		return nil, fmt.Errorf("%s", m.errorMsg)
 	}
 	return m.content, nil
 }
 
-func (m *mockAsyncExecutor) ExecuteAsync(descriptor *tools.ToolDescriptor, args json.RawMessage) (*tools.ToolExecutionResult, error) {
+func (m *mockAsyncExecutor) ExecuteAsync(_ context.Context, descriptor *tools.ToolDescriptor, _ json.RawMessage) (*tools.ToolExecutionResult, error) {
 	result := &tools.ToolExecutionResult{
 		Status:  m.status,
 		Content: m.content,

--- a/runtime/skills/tool_executor.go
+++ b/runtime/skills/tool_executor.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -141,7 +142,7 @@ func (e *ToolExecutor) Name() string { return SkillExecutorName }
 
 // Execute dispatches a skill tool call to the appropriate executor method.
 func (e *ToolExecutor) Execute(
-	tool *tools.ToolDescriptor, args json.RawMessage,
+	_ context.Context, tool *tools.ToolDescriptor, args json.RawMessage,
 ) (json.RawMessage, error) {
 	switch tool.Name {
 	case SkillActivateTool:

--- a/runtime/skills/tool_executor_test.go
+++ b/runtime/skills/tool_executor_test.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -78,7 +79,7 @@ func TestToolExecutor_Activate(t *testing.T) {
 	}}
 	_, toolReg := newTestToolExecutor(t, sources)
 
-	result, err := toolReg.Execute(SkillActivateTool, []byte(`{"name":"test-skill"}`))
+	result, err := toolReg.Execute(context.Background(), SkillActivateTool, []byte(`{"name":"test-skill"}`))
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Result)
 	assert.Empty(t, result.Error)
@@ -97,11 +98,11 @@ func TestToolExecutor_Deactivate(t *testing.T) {
 	_, toolReg := newTestToolExecutor(t, sources)
 
 	// Activate first
-	_, err := toolReg.Execute(SkillActivateTool, []byte(`{"name":"test-skill"}`))
+	_, err := toolReg.Execute(context.Background(), SkillActivateTool, []byte(`{"name":"test-skill"}`))
 	require.NoError(t, err)
 
 	// Then deactivate
-	result, err := toolReg.Execute(SkillDeactivateTool, []byte(`{"name":"test-skill"}`))
+	result, err := toolReg.Execute(context.Background(), SkillDeactivateTool, []byte(`{"name":"test-skill"}`))
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Result)
 	assert.Empty(t, result.Error)
@@ -128,6 +129,7 @@ Instructions.`
 	_, toolReg := newTestToolExecutor(t, sources)
 
 	result, err := toolReg.Execute(
+		context.Background(),
 		SkillReadResourceTool,
 		[]byte(`{"skill_name":"res-skill","path":"data.txt"}`),
 	)
@@ -144,7 +146,7 @@ func TestToolExecutor_ActivateUnknownSkill(t *testing.T) {
 	}}
 	_, toolReg := newTestToolExecutor(t, sources)
 
-	result, err := toolReg.Execute(SkillActivateTool, []byte(`{"name":"nonexistent"}`))
+	result, err := toolReg.Execute(context.Background(), SkillActivateTool, []byte(`{"name":"nonexistent"}`))
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Error)
 }
@@ -157,7 +159,7 @@ func TestToolExecutor_DeactivateInactive(t *testing.T) {
 	}}
 	_, toolReg := newTestToolExecutor(t, sources)
 
-	result, err := toolReg.Execute(SkillDeactivateTool, []byte(`{"name":"test-skill"}`))
+	result, err := toolReg.Execute(context.Background(), SkillDeactivateTool, []byte(`{"name":"test-skill"}`))
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Error)
 }
@@ -171,7 +173,7 @@ func TestToolExecutor_InvalidArgs(t *testing.T) {
 	_, toolReg := newTestToolExecutor(t, sources)
 
 	// Registry validates JSON before passing to executor, so error may come from either layer
-	result, err := toolReg.Execute(SkillActivateTool, []byte(`{invalid`))
+	result, err := toolReg.Execute(context.Background(), SkillActivateTool, []byte(`{invalid`))
 	if err != nil {
 		assert.Contains(t, err.Error(), "invalid")
 	} else {
@@ -182,7 +184,7 @@ func TestToolExecutor_InvalidArgs(t *testing.T) {
 func TestToolExecutor_UnknownTool(t *testing.T) {
 	exec := NewToolExecutor(nil)
 	desc := &tools.ToolDescriptor{Name: "skill__unknown", Mode: SkillExecutorName}
-	_, err := exec.Execute(desc, nil)
+	_, err := exec.Execute(context.Background(), desc, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown skill tool")
 }

--- a/runtime/tools/executors.go
+++ b/runtime/tools/executors.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -31,7 +32,9 @@ func (e *MockStaticExecutor) Name() string {
 }
 
 // Execute executes a tool using static mock data
-func (e *MockStaticExecutor) Execute(descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (e *MockStaticExecutor) Execute(
+	_ context.Context, descriptor *ToolDescriptor, _ json.RawMessage,
+) (json.RawMessage, error) {
 	if descriptor.Mode != modeMock {
 		return nil, ErrMockExecutorOnly
 	}
@@ -68,7 +71,9 @@ func (e *MockScriptedExecutor) Name() string {
 }
 
 // Execute executes a tool using templated mock data
-func (e *MockScriptedExecutor) Execute(descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (e *MockScriptedExecutor) Execute(
+	_ context.Context, descriptor *ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
 	if descriptor.Mode != modeMock {
 		return nil, ErrMockExecutorOnly
 	}

--- a/runtime/tools/mcp_executor_test.go
+++ b/runtime/tools/mcp_executor_test.go
@@ -115,7 +115,7 @@ func TestMCPExecutor_Execute_Success(t *testing.T) {
 	}
 	args := json.RawMessage(`{"key":"value"}`)
 
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 	if err != nil {
 		t.Fatalf("Execute() failed: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestMCPExecutor_Execute_WrongMode(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	_, err := executor.Execute(descriptor, args)
+	_, err := executor.Execute(context.Background(), descriptor, args)
 	if err == nil {
 		t.Error("Execute() with wrong mode should return error")
 	}
@@ -158,7 +158,7 @@ func TestMCPExecutor_Execute_ClientNotFound(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	_, err := executor.Execute(descriptor, args)
+	_, err := executor.Execute(context.Background(), descriptor, args)
 	if err == nil {
 		t.Error("Execute() with nonexistent client should return error")
 	}
@@ -182,7 +182,7 @@ func TestMCPExecutor_Execute_ToolCallFailed(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	_, err := executor.Execute(descriptor, args)
+	_, err := executor.Execute(context.Background(), descriptor, args)
 	if err == nil {
 		t.Error("Execute() with failing tool should return error")
 	}
@@ -211,7 +211,7 @@ func TestMCPExecutor_Execute_ErrorResponse(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	_, err := executor.Execute(descriptor, args)
+	_, err := executor.Execute(context.Background(), descriptor, args)
 	if err == nil {
 		t.Error("Execute() with error response should return error")
 	}
@@ -238,7 +238,7 @@ func TestMCPExecutor_Execute_EmptyResponse(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 	if err != nil {
 		t.Fatalf("Execute() failed: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestMCPExecutor_Execute_MultipleContentParts(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 	if err != nil {
 		t.Fatalf("Execute() failed: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestMCPExecutor_Execute_StructuredResponse(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 	if err != nil {
 		t.Fatalf("Execute() failed: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestMCPExecutor_Execute_ErrorWithMultipleMessages(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	_, err := executor.Execute(descriptor, args)
+	_, err := executor.Execute(context.Background(), descriptor, args)
 	if err == nil {
 		t.Error("Execute() with multiple error messages should return error")
 	}
@@ -387,7 +387,7 @@ func TestMCPExecutor_Execute_ErrorWithEmptyContent(t *testing.T) {
 	}
 	args := json.RawMessage(`{}`)
 
-	_, err := executor.Execute(descriptor, args)
+	_, err := executor.Execute(context.Background(), descriptor, args)
 	if err == nil {
 		t.Error("Execute() with empty error should return error")
 	}
@@ -425,7 +425,7 @@ func TestMCPExecutor_Execute_Timeout(t *testing.T) {
 	args := json.RawMessage(`{}`)
 
 	// This should not timeout (default is 30s)
-	_, err := executor.Execute(descriptor, args)
+	_, err := executor.Execute(context.Background(), descriptor, args)
 	if err != nil {
 		t.Fatalf("Execute() failed unexpectedly: %v", err)
 	}

--- a/runtime/tools/registry_async_test.go
+++ b/runtime/tools/registry_async_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -18,12 +19,12 @@ func (m *mockRegistryAsyncExecutor) Name() string {
 	return "mock-async"
 }
 
-func (m *mockRegistryAsyncExecutor) Execute(descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (m *mockRegistryAsyncExecutor) Execute(_ context.Context, _ *ToolDescriptor, _ json.RawMessage) (json.RawMessage, error) {
 	// Fallback to sync execution
 	return json.RawMessage(`{"result": "sync"}`), nil
 }
 
-func (m *mockRegistryAsyncExecutor) ExecuteAsync(descriptor *ToolDescriptor, args json.RawMessage) (*ToolExecutionResult, error) {
+func (m *mockRegistryAsyncExecutor) ExecuteAsync(_ context.Context, descriptor *ToolDescriptor, args json.RawMessage) (*ToolExecutionResult, error) {
 	if m.shouldFail {
 		return &ToolExecutionResult{
 			Status: ToolStatusFailed,
@@ -73,7 +74,7 @@ func TestRegistry_ExecuteAsync_Complete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute with ExecuteAsync
-	result, err := registry.ExecuteAsync("test_async_tool", json.RawMessage(`{"name": "test"}`))
+	result, err := registry.ExecuteAsync(context.Background(),"test_async_tool", json.RawMessage(`{"name": "test"}`))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -105,7 +106,7 @@ func TestRegistry_ExecuteAsync_Pending(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute with ExecuteAsync
-	result, err := registry.ExecuteAsync("test_pending_tool", json.RawMessage(`{"name": "test"}`))
+	result, err := registry.ExecuteAsync(context.Background(),"test_pending_tool", json.RawMessage(`{"name": "test"}`))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -140,7 +141,7 @@ func TestRegistry_ExecuteAsync_Failed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute with ExecuteAsync
-	result, err := registry.ExecuteAsync("test_failing_tool", json.RawMessage(`{"name": "test"}`))
+	result, err := registry.ExecuteAsync(context.Background(),"test_failing_tool", json.RawMessage(`{"name": "test"}`))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -168,7 +169,7 @@ func TestRegistry_ExecuteAsync_FallbackToSync(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute with ExecuteAsync - should fall back to sync execution
-	result, err := registry.ExecuteAsync("test_sync_tool", json.RawMessage(`{"name": "test"}`))
+	result, err := registry.ExecuteAsync(context.Background(),"test_sync_tool", json.RawMessage(`{"name": "test"}`))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/runtime/tools/repository_executor.go
+++ b/runtime/tools/repository_executor.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -39,7 +40,9 @@ func (e *RepositoryToolExecutor) Name() string {
 // Execute executes a tool, first checking the repository for mock responses.
 // If a matching response is found in the repository, it returns that response.
 // Otherwise, it falls back to the base executor for real execution.
-func (e *RepositoryToolExecutor) Execute(descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (e *RepositoryToolExecutor) Execute(
+	ctx context.Context, descriptor *ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
 	logger.Debug("RepositoryToolExecutor Execute",
 		"tool_name", descriptor.Name,
 		"context_key", e.contextKey,
@@ -51,7 +54,7 @@ func (e *RepositoryToolExecutor) Execute(descriptor *ToolDescriptor, args json.R
 		logger.Debug("RepositoryToolExecutor failed to parse args, falling back to base executor",
 			"tool_name", descriptor.Name,
 			"error", err)
-		return e.baseExecutor.Execute(descriptor, args)
+		return e.baseExecutor.Execute(ctx, descriptor, args)
 	}
 
 	// Check if we have a repository response for this tool call
@@ -72,7 +75,7 @@ func (e *RepositoryToolExecutor) Execute(descriptor *ToolDescriptor, args json.R
 			logger.Debug("RepositoryToolExecutor failed to marshal repository response",
 				"tool_name", descriptor.Name,
 				"error", err)
-			return e.baseExecutor.Execute(descriptor, args)
+			return e.baseExecutor.Execute(ctx, descriptor, args)
 		}
 
 		return result, nil
@@ -83,7 +86,7 @@ func (e *RepositoryToolExecutor) Execute(descriptor *ToolDescriptor, args json.R
 		"tool_name", descriptor.Name,
 		"context_key", e.contextKey)
 
-	return e.baseExecutor.Execute(descriptor, args)
+	return e.baseExecutor.Execute(ctx, descriptor, args)
 }
 
 // getRepositoryResponse attempts to get a mock response from the repository.

--- a/runtime/tools/repository_executor_test.go
+++ b/runtime/tools/repository_executor_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -47,7 +48,7 @@ func TestRepositoryToolExecutor_Execute_RepositoryResponse(t *testing.T) {
 	args := json.RawMessage(`{"location": "San Francisco"}`)
 
 	// Execute - should use repository response
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 
 	require.NoError(t, err)
 
@@ -79,7 +80,7 @@ func TestRepositoryToolExecutor_Execute_FallbackToBase(t *testing.T) {
 	args := json.RawMessage(`{"location": "San Francisco"}`)
 
 	// Execute - should fall back to base executor since no repository response
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 
 	require.NoError(t, err)
 
@@ -114,7 +115,7 @@ func TestRepositoryToolExecutor_Execute_RepositoryError(t *testing.T) {
 	args := json.RawMessage(`{"id": "123"}`)
 
 	// Execute - should return repository error
-	_, err := executor.Execute(descriptor, args)
+	_, err := executor.Execute(context.Background(), descriptor, args)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "NotFound: Resource not found")
@@ -142,7 +143,7 @@ func TestRepositoryToolExecutor_Execute_WrongContext(t *testing.T) {
 	args := json.RawMessage(`{"test": "value"}`)
 
 	// Execute - should fall back to base executor due to context mismatch
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 
 	require.NoError(t, err)
 
@@ -172,7 +173,7 @@ func TestRepositoryToolExecutor_Execute_InvalidJSON(t *testing.T) {
 	args := json.RawMessage(`{invalid json}`)
 
 	// Execute - should fall back to base executor due to JSON parse error
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 
 	require.NoError(t, err)
 

--- a/runtime/tools/tools_test.go
+++ b/runtime/tools/tools_test.go
@@ -1,6 +1,7 @@
 package tools_test
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -61,7 +62,7 @@ func TestMockExecutors(t *testing.T) {
 	}
 
 	args := json.RawMessage(`{"input": "test"}`)
-	result, err := staticExec.Execute(desc, args)
+	result, err := staticExec.Execute(context.Background(), desc, args)
 	if err != nil {
 		t.Fatalf("Static execution failed: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestMockExecutors(t *testing.T) {
 		Mode:           "mock",
 		MockResultFile: file,
 	}
-	result, err = staticExec.Execute(descFile, args)
+	result, err = staticExec.Execute(context.Background(), descFile, args)
 	if err != nil {
 		t.Fatalf("Static file execution failed: %v", err)
 	}
@@ -107,7 +108,7 @@ func TestMockExecutors(t *testing.T) {
 		MockTemplateFile: tmplFile,
 	}
 	scriptedArgs := json.RawMessage(`{"name":"Alice"}`)
-	result, err = scriptedExec.Execute(descTmpl, scriptedArgs)
+	result, err = scriptedExec.Execute(context.Background(), descTmpl, scriptedArgs)
 	if err != nil {
 		t.Fatalf("Scripted file execution failed: %v", err)
 	}
@@ -129,7 +130,7 @@ func TestMockExecutors(t *testing.T) {
 			MockTemplate:     `{"greeting":"Hello {{.name}} from inline"}`,
 			MockTemplateFile: file,
 		}
-		result, err := scriptedExec.Execute(descInline, scriptedArgs)
+		result, err := scriptedExec.Execute(context.Background(), descInline, scriptedArgs)
 		if err != nil {
 			t.Fatalf("Inline template execution failed: %v", err)
 		}
@@ -147,7 +148,7 @@ func TestMockExecutors(t *testing.T) {
 			Mode:         "mock",
 			MockTemplate: "hello {{.name}}",
 		}
-		result, err := scriptedExec.Execute(descText, scriptedArgs)
+		result, err := scriptedExec.Execute(context.Background(), descText, scriptedArgs)
 		if err != nil {
 			t.Fatalf("Text template execution failed: %v", err)
 		}
@@ -166,7 +167,7 @@ func TestMockExecutorErrors(t *testing.T) {
 
 	t.Run("missing template", func(t *testing.T) {
 		desc := &tools.ToolDescriptor{Name: "noTemplate", Mode: "mock"}
-		if _, err := scriptedExec.Execute(desc, args); err == nil {
+		if _, err := scriptedExec.Execute(context.Background(), desc, args); err == nil {
 			t.Fatalf("expected error for missing template")
 		}
 	})
@@ -177,7 +178,7 @@ func TestMockExecutorErrors(t *testing.T) {
 			Mode:         "mock",
 			MockTemplate: "{{ .name ", // malformed
 		}
-		if _, err := scriptedExec.Execute(desc, args); err == nil {
+		if _, err := scriptedExec.Execute(context.Background(), desc, args); err == nil {
 			t.Fatalf("expected template parse error")
 		}
 	})
@@ -188,7 +189,7 @@ func TestMockExecutorErrors(t *testing.T) {
 			Mode:             "mock",
 			MockTemplateFile: "/does/not/exist.tmpl",
 		}
-		if _, err := scriptedExec.Execute(desc, args); err == nil {
+		if _, err := scriptedExec.Execute(context.Background(), desc, args); err == nil {
 			t.Fatalf("expected file read error")
 		}
 	})
@@ -199,7 +200,7 @@ func TestMockExecutorErrors(t *testing.T) {
 			Mode:         "mock",
 			MockTemplate: `{"hello":"{{.name}}"}`,
 		}
-		if _, err := scriptedExec.Execute(desc, json.RawMessage(`{"name":`)); err == nil {
+		if _, err := scriptedExec.Execute(context.Background(), desc, json.RawMessage(`{"name":`)); err == nil {
 			t.Fatalf("expected arg parse error")
 		}
 	})
@@ -211,7 +212,7 @@ func TestMockExecutorErrors(t *testing.T) {
 			Mode:           "mock",
 			MockResultFile: "/does/not/exist.json",
 		}
-		if _, err := staticExec.Execute(desc, nil); err == nil {
+		if _, err := staticExec.Execute(context.Background(), desc, nil); err == nil {
 			t.Fatalf("expected missing file error")
 		}
 	})

--- a/runtime/tools/types.go
+++ b/runtime/tools/types.go
@@ -12,6 +12,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -196,7 +197,7 @@ func (e *ValidationError) Error() string {
 
 // Executor interface defines how tools are executed
 type Executor interface {
-	Execute(descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error)
+	Execute(ctx context.Context, descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error)
 	Name() string
 }
 
@@ -206,7 +207,7 @@ type AsyncToolExecutor interface {
 	Executor // Still implements the basic Executor interface
 
 	// ExecuteAsync may return immediately with a pending status
-	ExecuteAsync(descriptor *ToolDescriptor, args json.RawMessage) (*ToolExecutionResult, error)
+	ExecuteAsync(ctx context.Context, descriptor *ToolDescriptor, args json.RawMessage) (*ToolExecutionResult, error)
 }
 
 // PredictionRequest represents a predict request (extending existing type)

--- a/runtime/tools/types_test.go
+++ b/runtime/tools/types_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -230,8 +231,8 @@ func (m *mockAsyncExecutor) Name() string {
 	return m.name
 }
 
-func (m *mockAsyncExecutor) Execute(descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
-	result, err := m.ExecuteAsync(descriptor, args)
+func (m *mockAsyncExecutor) Execute(ctx context.Context, descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+	result, err := m.ExecuteAsync(ctx, descriptor, args)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +242,7 @@ func (m *mockAsyncExecutor) Execute(descriptor *ToolDescriptor, args json.RawMes
 	return result.Content, nil
 }
 
-func (m *mockAsyncExecutor) ExecuteAsync(descriptor *ToolDescriptor, args json.RawMessage) (*ToolExecutionResult, error) {
+func (m *mockAsyncExecutor) ExecuteAsync(_ context.Context, _ *ToolDescriptor, _ json.RawMessage) (*ToolExecutionResult, error) {
 	return m.result, m.err
 }
 
@@ -264,13 +265,13 @@ func TestAsyncToolExecutor_Interface(t *testing.T) {
 	}
 
 	// Test ExecuteAsync
-	result, err := executor.ExecuteAsync(&ToolDescriptor{Name: "test"}, json.RawMessage(`{}`))
+	result, err := executor.ExecuteAsync(context.Background(), &ToolDescriptor{Name: "test"}, json.RawMessage(`{}`))
 	require.NoError(t, err)
 	assert.Equal(t, ToolStatusPending, result.Status)
 	assert.NotNil(t, result.PendingInfo)
 
 	// Test Execute falls back correctly
-	_, err = executor.Execute(&ToolDescriptor{Name: "test"}, json.RawMessage(`{}`))
+	_, err = executor.Execute(context.Background(), &ToolDescriptor{Name: "test"}, json.RawMessage(`{}`))
 	assert.Error(t, err) // Should error because result is pending
 }
 
@@ -284,7 +285,7 @@ func TestAsyncToolExecutor_CompleteResult(t *testing.T) {
 	}
 
 	// Test Execute with complete result
-	result, err := executor.Execute(&ToolDescriptor{Name: "test"}, json.RawMessage(`{}`))
+	result, err := executor.Execute(context.Background(), &ToolDescriptor{Name: "test"}, json.RawMessage(`{}`))
 	require.NoError(t, err)
 	assert.Equal(t, `{"result": "success"}`, string(result))
 }

--- a/sdk/capability_skills_test.go
+++ b/sdk/capability_skills_test.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -216,7 +217,7 @@ func TestSkillsCapability_SkillExecutor_Activate(t *testing.T) {
 	cap.RegisterTools(registry)
 
 	// Execute the activate tool
-	result, err := registry.Execute(skills.SkillActivateTool, []byte(`{"name":"test-skill"}`))
+	result, err := registry.Execute(context.Background(), skills.SkillActivateTool, []byte(`{"name":"test-skill"}`))
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Result)
 	assert.Empty(t, result.Error)
@@ -242,10 +243,10 @@ func TestSkillsCapability_SkillExecutor_Deactivate(t *testing.T) {
 	cap.RegisterTools(registry)
 
 	// First activate, then deactivate
-	_, err := registry.Execute(skills.SkillActivateTool, []byte(`{"name":"test-skill"}`))
+	_, err := registry.Execute(context.Background(), skills.SkillActivateTool, []byte(`{"name":"test-skill"}`))
 	require.NoError(t, err)
 
-	result, err := registry.Execute(skills.SkillDeactivateTool, []byte(`{"name":"test-skill"}`))
+	result, err := registry.Execute(context.Background(), skills.SkillDeactivateTool, []byte(`{"name":"test-skill"}`))
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Result)
 	assert.Empty(t, result.Error)
@@ -281,6 +282,7 @@ Instructions.`
 	cap.RegisterTools(registry)
 
 	result, err := registry.Execute(
+		context.Background(),
 		skills.SkillReadResourceTool,
 		[]byte(`{"skill_name":"res-skill","path":"data.txt"}`),
 	)

--- a/sdk/concurrency_test.go
+++ b/sdk/concurrency_test.go
@@ -111,7 +111,7 @@ func TestForkIsolation(t *testing.T) {
 		return "original", nil
 	})
 
-	forked := original.Fork(context.Background())
+	forked := original.Fork()
 
 	// Both should start with the same variable
 	origVal, _ := original.GetVar("branch")
@@ -154,7 +154,7 @@ func TestConcurrentFork(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			forks[idx] = original.Fork(context.Background())
+			forks[idx] = original.Fork()
 			forks[idx].SetVar("fork_id", string(rune('A'+idx)))
 		}(i)
 	}

--- a/sdk/concurrency_test.go
+++ b/sdk/concurrency_test.go
@@ -111,7 +111,7 @@ func TestForkIsolation(t *testing.T) {
 		return "original", nil
 	})
 
-	forked := original.Fork()
+	forked := original.Fork(context.Background())
 
 	// Both should start with the same variable
 	origVal, _ := original.GetVar("branch")
@@ -154,7 +154,7 @@ func TestConcurrentFork(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			forks[idx] = original.Fork()
+			forks[idx] = original.Fork(context.Background())
 			forks[idx].SetVar("fork_id", string(rune('A'+idx)))
 		}(i)
 	}

--- a/sdk/conversation_test.go
+++ b/sdk/conversation_test.go
@@ -565,7 +565,7 @@ type mockExecutor struct {
 
 func (m *mockExecutor) Name() string { return m.name }
 
-func (m *mockExecutor) Execute(descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (m *mockExecutor) Execute(_ context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
 	return m.result, m.err
 }
 
@@ -586,7 +586,7 @@ func TestLocalExecutorExecute(t *testing.T) {
 		descriptor := &tools.ToolDescriptor{Name: "add"}
 		args := json.RawMessage(`{"a": 1, "b": 2}`)
 
-		result, err := executor.Execute(descriptor, args)
+		result, err := executor.Execute(context.Background(), descriptor, args)
 		assert.NoError(t, err)
 
 		var parsed map[string]float64
@@ -603,7 +603,7 @@ func TestLocalExecutorExecute(t *testing.T) {
 		descriptor := &tools.ToolDescriptor{Name: "unknown"}
 		args := json.RawMessage(`{}`)
 
-		_, err := executor.Execute(descriptor, args)
+		_, err := executor.Execute(context.Background(), descriptor, args)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no handler registered")
 	})
@@ -621,7 +621,7 @@ func TestLocalExecutorExecute(t *testing.T) {
 		descriptor := &tools.ToolDescriptor{Name: "test"}
 		args := json.RawMessage(`{invalid json}`)
 
-		_, err := executor.Execute(descriptor, args)
+		_, err := executor.Execute(context.Background(), descriptor, args)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse tool arguments")
 	})
@@ -639,7 +639,7 @@ func TestLocalExecutorExecute(t *testing.T) {
 		descriptor := &tools.ToolDescriptor{Name: "failing"}
 		args := json.RawMessage(`{}`)
 
-		_, err := executor.Execute(descriptor, args)
+		_, err := executor.Execute(context.Background(), descriptor, args)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "handler failed")
 	})

--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -123,7 +123,8 @@ func (c *Conversation) OnToolExecutor(name string, executor tools.Executor) {
 		}
 
 		// Execute
-		result, err := executor.Execute(desc, argsJSON)
+		// TODO: propagate context from ToolHandler once the handler signature supports it.
+		result, err := executor.Execute(context.TODO(), desc, argsJSON)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/eval_middleware_test.go
+++ b/sdk/eval_middleware_test.go
@@ -298,7 +298,7 @@ func TestEvalMiddleware_BuildEvalContext_NoSession(t *testing.T) {
 	}
 
 	mw.turnIndex = 3
-	ctx := mw.buildEvalContext()
+	ctx := mw.buildEvalContext(context.Background())
 
 	if ctx.TurnIndex != 3 {
 		t.Errorf("expected TurnIndex 3, got %d", ctx.TurnIndex)

--- a/sdk/hitl_test.go
+++ b/sdk/hitl_test.go
@@ -341,7 +341,7 @@ func TestForkWithAsyncHandlers(t *testing.T) {
 	conv.CheckPending("async_tool", map[string]any{})
 
 	// Fork
-	forked := conv.Fork()
+	forked := conv.Fork(context.Background())
 
 	// Verify async handlers are copied
 	forked.asyncHandlersMu.RLock()

--- a/sdk/hitl_test.go
+++ b/sdk/hitl_test.go
@@ -341,7 +341,7 @@ func TestForkWithAsyncHandlers(t *testing.T) {
 	conv.CheckPending("async_tool", map[string]any{})
 
 	// Fork
-	forked := conv.Fork(context.Background())
+	forked := conv.Fork()
 
 	// Verify async handlers are copied
 	forked.asyncHandlersMu.RLock()

--- a/sdk/local_agent_executor_integration.go
+++ b/sdk/local_agent_executor_integration.go
@@ -11,6 +11,7 @@ import (
 // Execute routes a tool call to the corresponding member conversation.
 // It parses {"query":"..."} from args, calls member.Send(), and returns {"response":"..."}.
 func (e *LocalAgentExecutor) Execute(
+	ctx context.Context,
 	descriptor *tools.ToolDescriptor,
 	args json.RawMessage,
 ) (json.RawMessage, error) {
@@ -28,8 +29,8 @@ func (e *LocalAgentExecutor) Execute(
 		return nil, fmt.Errorf("unknown agent member: %s", descriptor.Name)
 	}
 
-	// Send the query to the member conversation
-	resp, err := conv.Send(context.Background(), input.Query)
+	// Send the query to the member conversation using the caller's context.
+	resp, err := conv.Send(ctx, input.Query)
 	if err != nil {
 		return nil, fmt.Errorf("agent %s failed: %w", descriptor.Name, err)
 	}

--- a/sdk/local_agent_executor_test.go
+++ b/sdk/local_agent_executor_test.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -20,7 +21,7 @@ func TestLocalAgentExecutor_Execute_UnknownMember(t *testing.T) {
 	desc := &tools.ToolDescriptor{Name: "nonexistent"}
 	args := json.RawMessage(`{"query":"hello"}`)
 
-	_, err := exec.Execute(desc, args)
+	_, err := exec.Execute(context.Background(), desc, args)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown agent member: nonexistent")
 }
@@ -33,7 +34,7 @@ func TestLocalAgentExecutor_Execute_InvalidArgs(t *testing.T) {
 	desc := &tools.ToolDescriptor{Name: "agent1"}
 	args := json.RawMessage(`{invalid json`)
 
-	_, err := exec.Execute(desc, args)
+	_, err := exec.Execute(context.Background(), desc, args)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse agent tool args")
 }

--- a/sdk/mcp_test.go
+++ b/sdk/mcp_test.go
@@ -189,7 +189,7 @@ func TestMCPHandlerAdapter(t *testing.T) {
 			registry:      registry,
 		}
 
-		result, err := adapter.Execute(&tools.ToolDescriptor{}, json.RawMessage(`{"path":"/tmp/test"}`))
+		result, err := adapter.Execute(context.Background(), &tools.ToolDescriptor{}, json.RawMessage(`{"path":"/tmp/test"}`))
 		require.NoError(t, err)
 		assert.Contains(t, string(result), "file contents")
 	})
@@ -209,7 +209,7 @@ func TestMCPHandlerAdapter(t *testing.T) {
 			registry:      registry,
 		}
 
-		_, err := adapter.Execute(&tools.ToolDescriptor{}, json.RawMessage(`{}`))
+		_, err := adapter.Execute(context.Background(), &tools.ToolDescriptor{}, json.RawMessage(`{}`))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "file not found")
 	})
@@ -231,7 +231,7 @@ func TestMCPHandlerAdapter(t *testing.T) {
 			registry:      registry,
 		}
 
-		result, err := adapter.Execute(&tools.ToolDescriptor{}, json.RawMessage(`{}`))
+		result, err := adapter.Execute(context.Background(), &tools.ToolDescriptor{}, json.RawMessage(`{}`))
 		require.NoError(t, err)
 		// Multiple content items are returned as array
 		var content []mcp.Content

--- a/sdk/sdk_a2a_test.go
+++ b/sdk/sdk_a2a_test.go
@@ -95,7 +95,7 @@ func TestA2AExecutor_Execute(t *testing.T) {
 	}
 
 	args := json.RawMessage(`{"query":"Hi there"}`)
-	result, err := exec.Execute(desc, args)
+	result, err := exec.Execute(context.Background(), desc, args)
 	require.NoError(t, err)
 
 	var parsed map[string]string
@@ -107,7 +107,7 @@ func TestA2AExecutor_Execute_NoA2AConfig(t *testing.T) {
 	exec := a2a.NewExecutor()
 	desc := &tools.ToolDescriptor{Name: "bad_tool", Mode: "a2a"}
 
-	_, err := exec.Execute(desc, json.RawMessage(`{"query":"test"}`))
+	_, err := exec.Execute(context.Background(), desc, json.RawMessage(`{"query":"test"}`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no A2AConfig")
 }
@@ -127,7 +127,7 @@ func TestA2AExecutor_Execute_Timeout(t *testing.T) {
 		},
 	}
 
-	result, err := exec.Execute(desc, json.RawMessage(`{"query":"Hi"}`))
+	result, err := exec.Execute(context.Background(), desc, json.RawMessage(`{"query":"Hi"}`))
 	require.NoError(t, err)
 
 	var parsed map[string]string
@@ -193,7 +193,7 @@ func TestWithA2ATools_ExecutorRegistered(t *testing.T) {
 
 	// The registry should be able to resolve the "a2a" executor for this tool.
 	// We verify by calling Execute on the registry directly.
-	result, err := registry.Execute("a2a__myagent__summarize", json.RawMessage(`{"query":"test"}`))
+	result, err := registry.Execute(context.Background(), "a2a__myagent__summarize", json.RawMessage(`{"query":"test"}`))
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Empty(t, result.Error)

--- a/sdk/tool_executors.go
+++ b/sdk/tool_executors.go
@@ -21,7 +21,9 @@ func (e *localExecutor) Name() string {
 }
 
 // Execute dispatches to the appropriate handler based on tool name.
-func (e *localExecutor) Execute(descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (e *localExecutor) Execute(
+	_ context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
 	handler, ok := e.handlers[descriptor.Name]
 	if !ok {
 		return nil, fmt.Errorf("no handler registered for tool: %s", descriptor.Name)
@@ -61,9 +63,9 @@ func (a *mcpHandlerAdapter) Name() string {
 }
 
 // Execute runs the MCP tool with the given arguments.
-func (a *mcpHandlerAdapter) Execute(descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
-	ctx := context.Background()
-
+func (a *mcpHandlerAdapter) Execute(
+	ctx context.Context, _ *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
 	// Use the raw MCP name for server communication
 	client, err := a.registry.GetClientForTool(ctx, a.rawName)
 	if err != nil {

--- a/sdk/tools/http.go
+++ b/sdk/tools/http.go
@@ -56,10 +56,11 @@ func (e *HTTPExecutor) Name() string {
 // Execute performs an HTTP request based on the tool descriptor's HTTPConfig.
 // The args are serialized to JSON and sent as the request body.
 func (e *HTTPExecutor) Execute(
+	ctx context.Context,
 	descriptor *tools.ToolDescriptor,
 	args json.RawMessage,
 ) (json.RawMessage, error) {
-	return e.ExecuteWithContext(context.Background(), descriptor, args)
+	return e.ExecuteWithContext(ctx, descriptor, args)
 }
 
 // ExecuteWithContext performs an HTTP request with context support for cancellation.
@@ -338,7 +339,8 @@ func (c *HTTPToolConfig) executeHandler(executor *HTTPExecutor, args map[string]
 	}
 
 	// Execute the HTTP request
-	result, err := executor.Execute(descriptor, argsJSON)
+	// TODO: propagate context from ToolHandler once the handler signature supports it.
+	result, err := executor.Execute(context.TODO(), descriptor, argsJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/tools/http_test.go
+++ b/sdk/tools/http_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +46,7 @@ func TestHTTPExecutor_Execute_Success(t *testing.T) {
 	}
 
 	args := json.RawMessage(`{"query": "test"}`)
-	result, err := executor.Execute(descriptor, args)
+	result, err := executor.Execute(context.Background(), descriptor, args)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -70,7 +71,7 @@ func TestHTTPExecutor_Execute_NoConfig(t *testing.T) {
 		// No HTTPConfig
 	}
 
-	_, err := executor.Execute(descriptor, json.RawMessage(`{}`))
+	_, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
 	if err == nil {
 		t.Error("Execute() expected error for missing HTTPConfig")
 	}
@@ -92,7 +93,7 @@ func TestHTTPExecutor_Execute_HTTPError(t *testing.T) {
 		},
 	}
 
-	_, err := executor.Execute(descriptor, json.RawMessage(`{}`))
+	_, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
 	if err == nil {
 		t.Error("Execute() expected error for HTTP 400")
 	}
@@ -117,7 +118,7 @@ func TestHTTPExecutor_Execute_GetMethod(t *testing.T) {
 		},
 	}
 
-	_, err := executor.Execute(descriptor, nil)
+	_, err := executor.Execute(context.Background(), descriptor, nil)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -149,7 +150,7 @@ func TestHTTPExecutor_Execute_CustomHeaders(t *testing.T) {
 		},
 	}
 
-	_, err := executor.Execute(descriptor, json.RawMessage(`{}`))
+	_, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -179,7 +180,7 @@ func TestHTTPExecutor_Execute_HeadersFromEnv(t *testing.T) {
 		},
 	}
 
-	_, err := executor.Execute(descriptor, json.RawMessage(`{}`))
+	_, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -202,7 +203,7 @@ func TestHTTPExecutor_Execute_Redact(t *testing.T) {
 		},
 	}
 
-	result, err := executor.Execute(descriptor, nil)
+	result, err := executor.Execute(context.Background(), descriptor, nil)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -239,7 +240,7 @@ func TestHTTPExecutor_Execute_NonJSONResponse(t *testing.T) {
 		},
 	}
 
-	result, err := executor.Execute(descriptor, nil)
+	result, err := executor.Execute(context.Background(), descriptor, nil)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -273,7 +274,7 @@ func TestHTTPExecutor_Execute_Timeout(t *testing.T) {
 	}
 
 	// This should succeed since server responds quickly
-	_, err := executor.Execute(descriptor, nil)
+	_, err := executor.Execute(context.Background(), descriptor, nil)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -505,13 +506,13 @@ func TestEmptyArgs(t *testing.T) {
 	}
 
 	// Test with null args
-	_, err := executor.Execute(descriptor, json.RawMessage(`null`))
+	_, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`null`))
 	if err != nil {
 		t.Fatalf("Execute() with null error = %v", err)
 	}
 
 	// Test with empty object
-	_, err = executor.Execute(descriptor, json.RawMessage(`{}`))
+	_, err = executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute() with empty object error = %v", err)
 	}

--- a/sdk/tools/typed.go
+++ b/sdk/tools/typed.go
@@ -29,6 +29,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -184,7 +185,9 @@ func (a *HandlerAdapter) Name() string {
 }
 
 // Execute runs the handler with the given arguments.
-func (a *HandlerAdapter) Execute(descriptor *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+func (a *HandlerAdapter) Execute(
+	_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
 	// Parse args to map
 	var argsMap map[string]any
 	if err := json.Unmarshal(args, &argsMap); err != nil {

--- a/sdk/tools/typed_test.go
+++ b/sdk/tools/typed_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -144,7 +145,7 @@ func TestHandlerAdapter(t *testing.T) {
 
 		assert.Equal(t, "test_tool", adapter.Name())
 
-		result, err := adapter.Execute(&tools.ToolDescriptor{
+		result, err := adapter.Execute(context.Background(), &tools.ToolDescriptor{
 			Name: "test_tool",
 		}, json.RawMessage(`{"input": "hello"}`))
 
@@ -162,7 +163,7 @@ func TestHandlerAdapter(t *testing.T) {
 			return nil, nil
 		})
 
-		_, err := adapter.Execute(&tools.ToolDescriptor{}, json.RawMessage(`invalid`))
+		_, err := adapter.Execute(context.Background(), &tools.ToolDescriptor{}, json.RawMessage(`invalid`))
 		assert.Error(t, err)
 	})
 
@@ -171,7 +172,7 @@ func TestHandlerAdapter(t *testing.T) {
 			return nil, assert.AnError
 		})
 
-		_, err := adapter.Execute(&tools.ToolDescriptor{}, json.RawMessage(`{}`))
+		_, err := adapter.Execute(context.Background(), &tools.ToolDescriptor{}, json.RawMessage(`{}`))
 		assert.Error(t, err)
 	})
 }

--- a/tools/arena/engine/duplex_executor_tools_integration.go
+++ b/tools/arena/engine/duplex_executor_tools_integration.go
@@ -43,7 +43,7 @@ func (e *arenaToolExecutor) Execute(
 			"args", string(tc.Args))
 
 		// Execute tool using registry - args are already json.RawMessage
-		toolResult, err := e.registry.Execute(tc.Name, tc.Args)
+		toolResult, err := e.registry.Execute(ctx, tc.Name, tc.Args)
 		if err != nil {
 			logger.Error("arenaToolExecutor: tool execution failed",
 				"name", tc.Name, "error", err)

--- a/tools/arena/engine/workflow_driver_integration.go
+++ b/tools/arena/engine/workflow_driver_integration.go
@@ -174,7 +174,7 @@ func (d *arenaWorkflowDriver) Send(ctx context.Context, message string) (string,
 
 		// Execute non-workflow tool calls (skill__activate, a2a__, etc.) via the tool registry
 		if d.toolRegistry != nil {
-			result, execErr := d.toolRegistry.Execute(tc.Name, tc.Args)
+			result, execErr := d.toolRegistry.Execute(ctx, tc.Name, tc.Args)
 			var content string
 			if execErr != nil {
 				content = fmt.Sprintf(`{"error":%q}`, execErr.Error())


### PR DESCRIPTION
## Summary

Closes #495

- **CRITICAL**: A2A executor (`runtime/a2a/executor.go`) now uses caller's context instead of `context.Background()`, enabling proper cancellation and deadline propagation for agent-to-agent calls
- **HIGH**: Eval event listener (`runtime/evals/event_listener.go`) uses lifecycle context for turn dispatches and accepts `ctx` in `CloseSession()` instead of creating detached contexts
- **MEDIUM**: SDK `Conversation.Clear()` and `Fork()` now accept `ctx`; `Close()` uses a bounded 5-second timeout context

### Breaking change: `tools.Executor` interface

The `Execute` method on `tools.Executor` and `ExecuteAsync` on `AsyncToolExecutor` now require a `context.Context` parameter. All 14 executor implementations and all callers (registry, pipeline stages, arena engine) have been updated.

## Test plan

- [x] All existing tests updated to pass `context.Background()` to changed method signatures
- [x] `golangci-lint run` passes with zero new issues on changed files
- [x] All tests pass across runtime, sdk, and arena modules (`go test ./... -count=1`)
- [x] Pre-commit hook passes: lint, build, test, and coverage (>=80% on all changed files)