### PR TITLE
feat(evals): add rest_eval and a2a_eval external evaluation handlers

### DIFF
--- a/docs/src/content/docs/arena/explanation/eval-framework.md
+++ b/docs/src/content/docs/arena/explanation/eval-framework.md
@@ -20,7 +20,7 @@ PromptKit offers two complementary evaluation mechanisms:
 | **Defined in** | Pack file (`evals` array) | Arena scenario YAML |
 | **Scope** | Any conversation using the pack | Specific test scenarios |
 | **When** | Production + testing | Testing only |
-| **Types** | Deterministic + LLM judge | Content matching + LLM judge |
+| **Types** | Deterministic + LLM judge + External | Content matching + LLM judge + External |
 | **Trigger** | Configurable (every turn, sampling) | Every turn / conversation end |
 
 **Pack evals** travel with your pack — they run in production, in Arena tests, and anywhere the pack is used. Think of them as built-in quality monitors.
@@ -70,6 +70,19 @@ Use an LLM to evaluate quality when deterministic checks aren't sufficient:
 | `llm_judge_session` | LLM evaluates full session | `criteria` (string) |
 
 LLM judge evals require a judge provider configured in the eval context metadata.
+
+### External Evals
+
+Delegate evaluation to an external service — a REST endpoint or an A2A agent:
+
+| Type | Description | Key Params |
+|------|-------------|------------|
+| `rest_eval` | POST turn to an HTTP endpoint | `url` (string), `criteria` (string) |
+| `rest_eval_session` | POST full session to an HTTP endpoint | `url` (string), `criteria` (string) |
+| `a2a_eval` | Send turn to an A2A eval agent | `agent_url` (string), `criteria` (string) |
+| `a2a_eval_session` | Send full session to an A2A eval agent | `agent_url` (string), `criteria` (string) |
+
+External eval handlers send conversation context (messages, tool calls, variables) to the external service and expect a `{passed, score, reasoning}` JSON response. They support `${ENV_VAR}` interpolation for authentication headers and tokens, configurable timeouts, and a `min_score` threshold. REST evals use standard HTTP; A2A evals use the A2A protocol's `message/send` method.
 
 ## Triggers
 

--- a/docs/src/content/docs/arena/explanation/validation-strategies.md
+++ b/docs/src/content/docs/arena/explanation/validation-strategies.md
@@ -539,6 +539,16 @@ assertions:
       criteria: "Response follows business rules and policies"
       judge_provider: "openai/gpt-4o-mini"
       message: "Must follow business rules"
+
+  # Level 6: External evaluation
+  - type: rest_eval
+    params:
+      url: "https://eval-service.example.com/evaluate"
+      headers:
+        Authorization: "Bearer ${EVAL_API_KEY}"
+      criteria: "Response meets domain-specific compliance requirements"
+      min_score: 0.9
+      message: "Must pass external compliance check"
 ```
 
 **Benefits:**
@@ -546,6 +556,7 @@ assertions:
 - Detailed validation only if basics pass
 - Clear failure diagnostics
 - Efficient test execution
+- External services can apply specialized evaluation logic
 
 ### The Specificity Spectrum
 

--- a/docs/src/content/docs/arena/how-to/validate-outputs.md
+++ b/docs/src/content/docs/arena/how-to/validate-outputs.md
@@ -250,6 +250,16 @@ Start with basic assertions, add complexity:
     criteria: "Response complies with brand guidelines"
     judge_provider: "openai/gpt-4o-mini"
     message: "Must meet brand compliance"
+
+# Level 5: External evaluation service
+- type: rest_eval
+  params:
+    url: "https://eval-service.example.com/evaluate"
+    headers:
+      Authorization: "Bearer ${EVAL_API_KEY}"
+    criteria: "Response meets compliance requirements"
+    min_score: 0.9
+    message: "External compliance check"
 ```
 
 ### Quality Gates

--- a/docs/src/content/docs/arena/reference/scenario-format.md
+++ b/docs/src/content/docs/arena/reference/scenario-format.md
@@ -125,6 +125,10 @@ assertions:
   # LLM Judge
   - type: llm_judge
 
+  # External Evals
+  - type: rest_eval
+  - type: a2a_eval
+
 # Conversation-level assertions (in conversation_assertions field)
 conversation_assertions:
   - type: tools_called

--- a/runtime/evals/handlers/a2a_eval.go
+++ b/runtime/evals/handlers/a2a_eval.go
@@ -1,0 +1,189 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+const defaultA2AEvalTimeout = 60 * time.Second
+
+// A2AEvalHandler evaluates a single assistant turn by sending
+// conversation context to an A2A agent and interpreting the agent's
+// response as a structured eval result.
+//
+// Params:
+//   - agent_url (string, required): A2A agent endpoint URL
+//   - auth_token (string, optional): auth token, supports ${ENV_VAR}
+//   - timeout (string, optional): request timeout, default 60s
+//   - criteria (string, optional): evaluation criteria
+//   - include_messages (bool, optional): include conversation history, default true
+//   - include_tool_calls (bool, optional): include tool call records, default false
+//   - min_score (float64, optional): minimum score threshold
+//   - extra (map[string]any, optional): arbitrary data forwarded in request
+type A2AEvalHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *A2AEvalHandler) Type() string { return "a2a_eval" }
+
+// Eval sends the current assistant output to the configured A2A agent.
+func (h *A2AEvalHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return executeA2AEval(ctx, evalCtx, params, h.Type(), evalCtx.CurrentOutput)
+}
+
+// A2AEvalSessionHandler evaluates an entire conversation by sending
+// all assistant messages to an A2A agent.
+//
+// Params: same as A2AEvalHandler.
+type A2AEvalSessionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *A2AEvalSessionHandler) Type() string { return "a2a_eval_session" }
+
+// Eval sends all assistant messages to the configured A2A agent.
+func (h *A2AEvalSessionHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	content := collectAssistantContent(evalCtx)
+	return executeA2AEval(ctx, evalCtx, params, h.Type(), content)
+}
+
+// executeA2AEval is the shared implementation for both A2A eval handlers.
+func executeA2AEval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+	evalType string,
+	content string,
+) (*evals.EvalResult, error) {
+	agentURL, ok := params["agent_url"].(string)
+	if !ok || agentURL == "" {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: "a2a_eval requires an 'agent_url' param",
+		}, nil
+	}
+
+	timeout := parseDuration(params, "timeout", defaultA2AEvalTimeout)
+	minScore := extractFloat64Ptr(params, "min_score")
+
+	// Build A2A client with optional auth.
+	var clientOpts []a2a.ClientOption
+	if token, ok := params["auth_token"].(string); ok && token != "" {
+		expanded := expandEnvVars(token)
+		if expanded != "" {
+			clientOpts = append(clientOpts, a2a.WithAuth("Bearer", expanded))
+		}
+	}
+	client := a2a.NewClient(agentURL, clientOpts...)
+
+	// Build the message content: criteria as text + request context as JSON.
+	reqBody := buildExternalRequest(evalCtx, params, content)
+	reqJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: fmt.Sprintf("failed to marshal request: %v", err),
+		}, nil
+	}
+
+	messageText := buildA2AMessageText(reqBody.Criteria, string(reqJSON))
+	textPtr := messageText
+
+	// Set timeout on context.
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Send synchronous message to the A2A agent.
+	task, err := client.SendMessage(ctx, &a2a.SendMessageRequest{
+		Message: a2a.Message{
+			Role:  a2a.RoleUser,
+			Parts: []a2a.Part{{Text: &textPtr}},
+		},
+		Configuration: &a2a.SendMessageConfiguration{
+			Blocking: true,
+		},
+	})
+	if err != nil {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: fmt.Sprintf("a2a agent error: %v", err),
+		}, nil
+	}
+
+	// Extract text response from the task.
+	responseText := extractA2AResponseText(task)
+	if responseText == "" {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: "a2a agent returned no text response",
+		}, nil
+	}
+
+	result := parseExternalResponse([]byte(responseText), minScore)
+	result.Type = evalType
+	return result, nil
+}
+
+// buildA2AMessageText creates the user message text sent to the eval agent.
+func buildA2AMessageText(criteria, requestJSON string) string {
+	var sb strings.Builder
+	sb.WriteString("You are an evaluation judge. Evaluate the following content and respond with a JSON object ")
+	sb.WriteString("containing: \"passed\" (boolean), \"score\" (float 0-1), and \"reasoning\" (string).\n\n")
+
+	if criteria != "" {
+		sb.WriteString("Criteria: ")
+		sb.WriteString(criteria)
+		sb.WriteString("\n\n")
+	}
+
+	sb.WriteString("Context:\n")
+	sb.WriteString(requestJSON)
+	return sb.String()
+}
+
+// extractA2AResponseText extracts text content from an A2A task response.
+// It checks the status message first, then artifacts.
+func extractA2AResponseText(task *a2a.Task) string {
+	// Check status message first.
+	if task.Status.Message != nil {
+		if text := extractPartsText(task.Status.Message.Parts); text != "" {
+			return text
+		}
+	}
+
+	// Check artifacts.
+	for i := range task.Artifacts {
+		if text := extractPartsText(task.Artifacts[i].Parts); text != "" {
+			return text
+		}
+	}
+
+	return ""
+}
+
+// extractPartsText concatenates text parts from A2A message parts.
+func extractPartsText(parts []a2a.Part) string {
+	var texts []string
+	for i := range parts {
+		if parts[i].Text != nil {
+			texts = append(texts, *parts[i].Text)
+		}
+	}
+	return strings.Join(texts, "\n")
+}

--- a/runtime/evals/handlers/a2a_eval_test.go
+++ b/runtime/evals/handlers/a2a_eval_test.go
@@ -1,0 +1,507 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestA2AEvalHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &A2AEvalHandler{}
+	if h.Type() != "a2a_eval" {
+		t.Errorf("got %q, want %q", h.Type(), "a2a_eval")
+	}
+}
+
+func TestA2AEvalSessionHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &A2AEvalSessionHandler{}
+	if h.Type() != "a2a_eval_session" {
+		t.Errorf("got %q, want %q", h.Type(), "a2a_eval_session")
+	}
+}
+
+func TestA2AEvalHandler_MissingAgentURL(t *testing.T) {
+	t.Parallel()
+	h := &A2AEvalHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false for missing agent_url")
+	}
+	if result.Explanation != "a2a_eval requires an 'agent_url' param" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+// mockA2AServer creates a test server that responds to A2A JSON-RPC requests.
+func mockA2AServer(t *testing.T, responseText string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a" {
+			http.NotFound(w, r)
+			return
+		}
+
+		var rpcReq struct {
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+			ID     int64           `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&rpcReq); err != nil {
+			t.Errorf("failed to decode rpc request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		text := responseText
+		task := a2a.Task{
+			ID: "test-task-1",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+				Message: &a2a.Message{
+					Role:  a2a.RoleAgent,
+					Parts: []a2a.Part{{Text: &text}},
+				},
+			},
+		}
+
+		taskJSON, _ := json.Marshal(task)
+		rpcResp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      rpcReq.ID,
+			"result":  json.RawMessage(taskJSON),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(rpcResp)
+	}))
+}
+
+func TestA2AEvalHandler_SuccessfulEval(t *testing.T) {
+	t.Parallel()
+	server := mockA2AServer(t, `{"passed": true, "score": 0.9, "reasoning": "Good response"}`)
+	defer server.Close()
+
+	h := &A2AEvalHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "helpful answer",
+		Messages: []types.Message{
+			{Role: "user", Content: "help me"},
+			{Role: "assistant", Content: "helpful answer"},
+		},
+	}
+	params := map[string]any{
+		"agent_url": server.URL,
+		"criteria":  "Is it helpful?",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected Passed=true, got explanation: %s", result.Explanation)
+	}
+	if result.Score == nil || *result.Score != 0.9 {
+		t.Errorf("expected score 0.9, got %v", result.Score)
+	}
+	if result.Type != "a2a_eval" {
+		t.Errorf("expected type a2a_eval, got %s", result.Type)
+	}
+}
+
+func TestA2AEvalHandler_FailedEval(t *testing.T) {
+	t.Parallel()
+	server := mockA2AServer(t, `{"passed": false, "score": 0.2, "reasoning": "Poor response"}`)
+	defer server.Close()
+
+	h := &A2AEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "bad answer"}
+	params := map[string]any{"agent_url": server.URL}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false")
+	}
+	if result.Score == nil || *result.Score != 0.2 {
+		t.Errorf("expected score 0.2, got %v", result.Score)
+	}
+}
+
+func TestA2AEvalHandler_AgentError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a" {
+			http.NotFound(w, r)
+			return
+		}
+		var rpcReq struct {
+			ID int64 `json:"id"`
+		}
+		json.NewDecoder(r.Body).Decode(&rpcReq)
+
+		rpcResp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      rpcReq.ID,
+			"error": map[string]any{
+				"code":    -32000,
+				"message": "agent processing failed",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(rpcResp)
+	}))
+	defer server.Close()
+
+	h := &A2AEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{"agent_url": server.URL}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false for agent error")
+	}
+}
+
+func TestA2AEvalHandler_Timeout(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	h := &A2AEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{
+		"agent_url": server.URL,
+		"timeout":   "100ms",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false for timeout")
+	}
+}
+
+func TestA2AEvalHandler_AuthToken(t *testing.T) {
+	t.Setenv("A2A_EVAL_TEST_TOKEN", "my-secret-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a" {
+			http.NotFound(w, r)
+			return
+		}
+
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer my-secret-token" {
+			t.Errorf("expected auth 'Bearer my-secret-token', got %q", auth)
+		}
+
+		var rpcReq struct {
+			ID int64 `json:"id"`
+		}
+		json.NewDecoder(r.Body).Decode(&rpcReq)
+
+		text := `{"passed": true, "score": 1.0}`
+		task := a2a.Task{
+			ID: "test-task",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+				Message: &a2a.Message{
+					Role:  a2a.RoleAgent,
+					Parts: []a2a.Part{{Text: &text}},
+				},
+			},
+		}
+		taskJSON, _ := json.Marshal(task)
+		rpcResp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      rpcReq.ID,
+			"result":  json.RawMessage(taskJSON),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(rpcResp)
+	}))
+	defer server.Close()
+
+	h := &A2AEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{
+		"agent_url":  server.URL,
+		"auth_token": "${A2A_EVAL_TEST_TOKEN}",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected Passed=true, got explanation: %s", result.Explanation)
+	}
+}
+
+func TestA2AEvalSessionHandler_AggregatesContent(t *testing.T) {
+	t.Parallel()
+	var receivedReq ExternalEvalRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a" {
+			http.NotFound(w, r)
+			return
+		}
+
+		var rpcReq struct {
+			Params json.RawMessage `json:"params"`
+			ID     int64           `json:"id"`
+		}
+		json.NewDecoder(r.Body).Decode(&rpcReq)
+
+		// Parse the SendMessageRequest to extract the message text
+		var smr a2a.SendMessageRequest
+		json.Unmarshal(rpcReq.Params, &smr)
+
+		// The message text contains the JSON context — parse it to verify
+		if len(smr.Message.Parts) > 0 && smr.Message.Parts[0].Text != nil {
+			msgText := *smr.Message.Parts[0].Text
+			// Extract the JSON from the context section
+			if idx := len("Context:\n"); idx > 0 {
+				ctxStart := len(msgText) - 1
+				for i := 0; i < len(msgText); i++ {
+					if msgText[i:] == "Context:\n"[:min(9, len(msgText)-i)] {
+						ctxStart = i + 9
+						break
+					}
+				}
+				if ctxStart < len(msgText) {
+					json.Unmarshal([]byte(msgText[ctxStart:]), &receivedReq)
+				}
+			}
+		}
+
+		text := `{"passed": true, "score": 0.85, "reasoning": "good session"}`
+		task := a2a.Task{
+			ID: "test-task",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+				Message: &a2a.Message{
+					Role:  a2a.RoleAgent,
+					Parts: []a2a.Part{{Text: &text}},
+				},
+			},
+		}
+		taskJSON, _ := json.Marshal(task)
+		rpcResp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      rpcReq.ID,
+			"result":  json.RawMessage(taskJSON),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(rpcResp)
+	}))
+	defer server.Close()
+
+	h := &A2AEvalSessionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "question 1"},
+			{Role: "assistant", Content: "answer 1"},
+			{Role: "user", Content: "question 2"},
+			{Role: "assistant", Content: "answer 2"},
+		},
+	}
+	params := map[string]any{"agent_url": server.URL}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected Passed=true, got explanation: %s", result.Explanation)
+	}
+	if result.Type != "a2a_eval_session" {
+		t.Errorf("expected type a2a_eval_session, got %s", result.Type)
+	}
+}
+
+func TestA2AEvalHandler_NoTextResponse(t *testing.T) {
+	t.Parallel()
+	// Server returns a task with no text parts
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a" {
+			http.NotFound(w, r)
+			return
+		}
+		var rpcReq struct {
+			ID int64 `json:"id"`
+		}
+		json.NewDecoder(r.Body).Decode(&rpcReq)
+
+		task := a2a.Task{
+			ID: "test-task",
+			Status: a2a.TaskStatus{
+				State: a2a.TaskStateCompleted,
+			},
+		}
+		taskJSON, _ := json.Marshal(task)
+		rpcResp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      rpcReq.ID,
+			"result":  json.RawMessage(taskJSON),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(rpcResp)
+	}))
+	defer server.Close()
+
+	h := &A2AEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{"agent_url": server.URL}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false for no text response")
+	}
+	if result.Explanation != "a2a agent returned no text response" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestA2AEvalHandler_MinScore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passes with lower threshold", func(t *testing.T) {
+		t.Parallel()
+		server := mockA2AServer(t, `{"score": 0.7, "reasoning": "decent"}`)
+		defer server.Close()
+
+		h := &A2AEvalHandler{}
+		evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+		params := map[string]any{
+			"agent_url": server.URL,
+			"min_score": 0.6,
+		}
+		result, err := h.Eval(context.Background(), evalCtx, params)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Passed {
+			t.Errorf("expected Passed=true with min_score=0.6, explanation=%s", result.Explanation)
+		}
+	})
+
+	t.Run("fails with higher threshold", func(t *testing.T) {
+		t.Parallel()
+		server := mockA2AServer(t, `{"score": 0.7, "reasoning": "decent"}`)
+		defer server.Close()
+
+		h := &A2AEvalHandler{}
+		evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+		params := map[string]any{
+			"agent_url": server.URL,
+			"min_score": 0.8,
+		}
+		result, err := h.Eval(context.Background(), evalCtx, params)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Passed {
+			t.Error("expected Passed=false with min_score=0.8")
+		}
+	})
+}
+
+func TestExtractA2AResponseText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("from status message", func(t *testing.T) {
+		t.Parallel()
+		text := "hello world"
+		task := &a2a.Task{
+			Status: a2a.TaskStatus{
+				Message: &a2a.Message{
+					Parts: []a2a.Part{{Text: &text}},
+				},
+			},
+		}
+		got := extractA2AResponseText(task)
+		if got != "hello world" {
+			t.Errorf("got %q, want %q", got, "hello world")
+		}
+	})
+
+	t.Run("from artifacts", func(t *testing.T) {
+		t.Parallel()
+		text := "artifact text"
+		task := &a2a.Task{
+			Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+			Artifacts: []a2a.Artifact{
+				{Parts: []a2a.Part{{Text: &text}}},
+			},
+		}
+		got := extractA2AResponseText(task)
+		if got != "artifact text" {
+			t.Errorf("got %q, want %q", got, "artifact text")
+		}
+	})
+
+	t.Run("empty task", func(t *testing.T) {
+		t.Parallel()
+		task := &a2a.Task{
+			Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+		}
+		got := extractA2AResponseText(task)
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+}
+
+func TestBuildA2AMessageText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with criteria", func(t *testing.T) {
+		t.Parallel()
+		text := buildA2AMessageText("Be helpful", `{"current_output": "test"}`)
+		if text == "" {
+			t.Error("expected non-empty text")
+		}
+		// Should contain criteria and context
+		if !containsInsensitive(text, "Be helpful") {
+			t.Error("expected text to contain criteria")
+		}
+		if !containsInsensitive(text, "current_output") {
+			t.Error("expected text to contain request JSON")
+		}
+	})
+
+	t.Run("without criteria", func(t *testing.T) {
+		t.Parallel()
+		text := buildA2AMessageText("", `{"current_output": "test"}`)
+		if containsInsensitive(text, "Criteria:") {
+			t.Error("expected no criteria section when empty")
+		}
+	})
+}

--- a/runtime/evals/handlers/external_eval.go
+++ b/runtime/evals/handlers/external_eval.go
@@ -1,0 +1,162 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+const defaultExternalTimeout = 30 * time.Second
+
+// envVarPattern matches ${VAR_NAME} for environment variable interpolation.
+var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// ExternalEvalRequest is the standard request body sent to external
+// eval endpoints (REST) and formatted as context for A2A eval agents.
+type ExternalEvalRequest struct {
+	CurrentOutput string         `json:"current_output"`
+	Messages      []messageView  `json:"messages,omitempty"`
+	ToolCalls     []toolCallView `json:"tool_calls,omitempty"`
+	Criteria      string         `json:"criteria,omitempty"`
+	Variables     map[string]any `json:"variables,omitempty"`
+	Extra         map[string]any `json:"extra,omitempty"`
+}
+
+// messageView is a simplified message representation for external eval requests.
+type messageView struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// externalEvalResponse is the standard response expected from external
+// eval endpoints and A2A eval agents.
+type externalEvalResponse struct {
+	Passed    *bool   `json:"passed"`
+	Score     float64 `json:"score"`
+	Reasoning string  `json:"reasoning"`
+}
+
+// expandEnvVars replaces ${VAR} patterns with their environment variable values.
+func expandEnvVars(s string) string {
+	return envVarPattern.ReplaceAllStringFunc(s, func(match string) string {
+		varName := match[2 : len(match)-1]
+		return os.Getenv(varName)
+	})
+}
+
+// buildExternalRequest constructs an ExternalEvalRequest from the eval context and params.
+func buildExternalRequest(
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+	content string,
+) *ExternalEvalRequest {
+	req := &ExternalEvalRequest{
+		CurrentOutput: content,
+		Variables:     evalCtx.Variables,
+	}
+
+	if v, ok := params["criteria"].(string); ok {
+		req.Criteria = v
+	}
+
+	req.Extra = extractMapAny(params, "extra")
+
+	includeMessages := true
+	if v, ok := params["include_messages"].(bool); ok {
+		includeMessages = v
+	}
+	if includeMessages {
+		req.Messages = buildMessageViews(evalCtx)
+	}
+
+	if extractBool(params, "include_tool_calls") {
+		req.ToolCalls = buildToolCallViews(evalCtx)
+	}
+
+	return req
+}
+
+// buildMessageViews converts eval context messages to simplified message views.
+func buildMessageViews(evalCtx *evals.EvalContext) []messageView {
+	views := make([]messageView, 0, len(evalCtx.Messages))
+	for i := range evalCtx.Messages {
+		msg := &evalCtx.Messages[i]
+		views = append(views, messageView{
+			Role:    msg.Role,
+			Content: msg.GetContent(),
+		})
+	}
+	return views
+}
+
+// buildToolCallViews converts eval context tool calls to simplified views.
+func buildToolCallViews(evalCtx *evals.EvalContext) []toolCallView {
+	views := make([]toolCallView, 0, len(evalCtx.ToolCalls))
+	for i := range evalCtx.ToolCalls {
+		tc := &evalCtx.ToolCalls[i]
+		views = append(views, toolCallView{
+			Index:  tc.TurnIndex,
+			Name:   tc.ToolName,
+			Args:   tc.Arguments,
+			Result: fmt.Sprintf("%v", tc.Result),
+			Error:  tc.Error,
+		})
+	}
+	return views
+}
+
+// parseExternalResponse parses the standard {passed, score, reasoning}
+// response from an external eval endpoint. Uses the same pass-determination
+// logic as parseJudgeResponse.
+func parseExternalResponse(body []byte, minScore *float64) *evals.EvalResult {
+	var resp externalEvalResponse
+
+	// Extract JSON from response (might be wrapped in text/markdown)
+	jsonStr := string(body)
+	if idx := strings.Index(jsonStr, "{"); idx >= 0 {
+		if end := strings.LastIndex(jsonStr, "}"); end >= idx {
+			jsonStr = jsonStr[idx : end+1]
+		}
+	}
+
+	if err := json.Unmarshal([]byte(jsonStr), &resp); err != nil {
+		return &evals.EvalResult{
+			Passed:      false,
+			Explanation: fmt.Sprintf("failed to parse response: %v", err),
+		}
+	}
+
+	score := resp.Score
+	var passed bool
+	if resp.Passed != nil {
+		passed = *resp.Passed
+	} else if minScore != nil {
+		passed = score >= *minScore
+	} else {
+		passed = score >= defaultPassThreshold
+	}
+
+	return &evals.EvalResult{
+		Passed:      passed,
+		Score:       &score,
+		Explanation: resp.Reasoning,
+	}
+}
+
+// parseDuration extracts a duration param with a default value.
+func parseDuration(params map[string]any, key string, defaultVal time.Duration) time.Duration {
+	v, ok := params[key].(string)
+	if !ok || v == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return defaultVal
+	}
+	return d
+}

--- a/runtime/evals/handlers/external_eval_test.go
+++ b/runtime/evals/handlers/external_eval_test.go
@@ -1,0 +1,236 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestExpandEnvVars(t *testing.T) {
+	t.Setenv("TEST_VAR_1", "hello")
+	t.Setenv("TEST_VAR_2", "world")
+
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{"no vars", "plain text", "plain text"},
+		{"single var", "Bearer ${TEST_VAR_1}", "Bearer hello"},
+		{"multiple vars", "${TEST_VAR_1} ${TEST_VAR_2}", "hello world"},
+		{"missing var", "${NONEXISTENT_VAR_XYZ}", ""},
+		{"empty string", "", ""},
+		{"adjacent vars", "${TEST_VAR_1}${TEST_VAR_2}", "helloworld"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := expandEnvVars(tt.input)
+			if got != tt.expect {
+				t.Errorf("expandEnvVars(%q) = %q, want %q", tt.input, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestBuildExternalRequest(t *testing.T) {
+	t.Parallel()
+
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "test output",
+		Messages: []types.Message{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi there"},
+		},
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", Arguments: map[string]any{"q": "test"}},
+		},
+		Variables: map[string]any{"lang": "en"},
+	}
+
+	t.Run("default includes messages", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{
+			"criteria": "be helpful",
+		}
+		req := buildExternalRequest(evalCtx, params, "test output")
+		if req.CurrentOutput != "test output" {
+			t.Errorf("CurrentOutput = %q, want %q", req.CurrentOutput, "test output")
+		}
+		if req.Criteria != "be helpful" {
+			t.Errorf("Criteria = %q, want %q", req.Criteria, "be helpful")
+		}
+		if len(req.Messages) != 2 {
+			t.Errorf("Messages length = %d, want 2", len(req.Messages))
+		}
+		if len(req.ToolCalls) != 0 {
+			t.Errorf("ToolCalls length = %d, want 0 (not included by default)", len(req.ToolCalls))
+		}
+	})
+
+	t.Run("include_tool_calls", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{
+			"include_tool_calls": true,
+		}
+		req := buildExternalRequest(evalCtx, params, "test output")
+		if len(req.ToolCalls) != 1 {
+			t.Errorf("ToolCalls length = %d, want 1", len(req.ToolCalls))
+		}
+	})
+
+	t.Run("exclude messages", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{
+			"include_messages": false,
+		}
+		req := buildExternalRequest(evalCtx, params, "test output")
+		if len(req.Messages) != 0 {
+			t.Errorf("Messages length = %d, want 0", len(req.Messages))
+		}
+	})
+
+	t.Run("extra forwarded", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{
+			"extra": map[string]any{"scenario_id": "test-1"},
+		}
+		req := buildExternalRequest(evalCtx, params, "test output")
+		if req.Extra == nil {
+			t.Fatal("Extra is nil")
+		}
+		if req.Extra["scenario_id"] != "test-1" {
+			t.Errorf("Extra[scenario_id] = %v, want test-1", req.Extra["scenario_id"])
+		}
+	})
+
+	t.Run("variables forwarded", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{}
+		req := buildExternalRequest(evalCtx, params, "test output")
+		if req.Variables["lang"] != "en" {
+			t.Errorf("Variables[lang] = %v, want en", req.Variables["lang"])
+		}
+	})
+}
+
+func TestParseExternalResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		minScore *float64
+		passed   bool
+		hasScore bool
+		score    float64
+	}{
+		{
+			name:     "passed true with score",
+			body:     `{"passed": true, "score": 0.9, "reasoning": "good"}`,
+			passed:   true,
+			hasScore: true,
+			score:    0.9,
+		},
+		{
+			name:     "passed false",
+			body:     `{"passed": false, "score": 0.3, "reasoning": "bad"}`,
+			passed:   false,
+			hasScore: true,
+			score:    0.3,
+		},
+		{
+			name:     "no passed field score above default threshold",
+			body:     `{"score": 0.7, "reasoning": "ok"}`,
+			passed:   true,
+			hasScore: true,
+			score:    0.7,
+		},
+		{
+			name:     "no passed field score below default threshold",
+			body:     `{"score": 0.3, "reasoning": "bad"}`,
+			passed:   false,
+			hasScore: true,
+			score:    0.3,
+		},
+		{
+			name:     "min_score override pass",
+			body:     `{"score": 0.8, "reasoning": "ok"}`,
+			minScore: float64Ptr(0.7),
+			passed:   true,
+			hasScore: true,
+			score:    0.8,
+		},
+		{
+			name:     "min_score override fail",
+			body:     `{"score": 0.6, "reasoning": "ok"}`,
+			minScore: float64Ptr(0.7),
+			passed:   false,
+			hasScore: true,
+			score:    0.6,
+		},
+		{
+			name:   "invalid JSON",
+			body:   "not json at all",
+			passed: false,
+		},
+		{
+			name:     "JSON in markdown",
+			body:     "```json\n{\"passed\": true, \"score\": 0.95, \"reasoning\": \"great\"}\n```",
+			passed:   true,
+			hasScore: true,
+			score:    0.95,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseExternalResponse([]byte(tt.body), tt.minScore)
+			if result.Passed != tt.passed {
+				t.Errorf("Passed = %v, want %v", result.Passed, tt.passed)
+			}
+			if tt.hasScore && (result.Score == nil || *result.Score != tt.score) {
+				var gotScore float64
+				if result.Score != nil {
+					gotScore = *result.Score
+				}
+				t.Errorf("Score = %v, want %v", gotScore, tt.score)
+			}
+		})
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		params   map[string]any
+		key      string
+		defVal   string
+		expected string
+	}{
+		{"valid duration", map[string]any{"timeout": "10s"}, "timeout", "30s", "10s"},
+		{"missing key", map[string]any{}, "timeout", "30s", "30s"},
+		{"invalid duration", map[string]any{"timeout": "bad"}, "timeout", "30s", "30s"},
+		{"wrong type", map[string]any{"timeout": 123}, "timeout", "30s", "30s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseDuration(tt.params, tt.key, defaultExternalTimeout)
+			if tt.expected == "30s" && got != defaultExternalTimeout {
+				t.Errorf("got %v, want default %v", got, defaultExternalTimeout)
+			}
+			if tt.expected == "10s" && got.Seconds() != 10 {
+				t.Errorf("got %v, want 10s", got)
+			}
+		})
+	}
+}
+
+func float64Ptr(v float64) *float64 { return &v }

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -814,6 +814,12 @@ func TestRegisterInit(t *testing.T) {
 		"llm_judge",
 		"llm_judge_session",
 		"llm_judge_tool_calls",
+
+		// External eval handlers
+		"rest_eval",
+		"rest_eval_session",
+		"a2a_eval",
+		"a2a_eval_session",
 	}
 
 	r := evals.NewEvalTypeRegistry()

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -58,4 +58,10 @@ func init() {
 	evals.RegisterDefault(&LLMJudgeHandler{})
 	evals.RegisterDefault(&LLMJudgeSessionHandler{})
 	evals.RegisterDefault(&LLMJudgeToolCallsHandler{})
+
+	// External eval handlers
+	evals.RegisterDefault(&RestEvalHandler{})
+	evals.RegisterDefault(&RestEvalSessionHandler{})
+	evals.RegisterDefault(&A2AEvalHandler{})
+	evals.RegisterDefault(&A2AEvalSessionHandler{})
 }

--- a/runtime/evals/handlers/rest_eval.go
+++ b/runtime/evals/handlers/rest_eval.go
@@ -1,0 +1,143 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// RestEvalHandler evaluates a single assistant turn by POSTing
+// conversation context to an external HTTP endpoint and interpreting
+// the structured JSON response.
+//
+// Params:
+//   - url (string, required): endpoint URL
+//   - method (string, optional): HTTP method, default POST
+//   - headers (map[string]string, optional): request headers, supports ${ENV_VAR}
+//   - timeout (string, optional): request timeout, default 30s
+//   - include_messages (bool, optional): include conversation history, default true
+//   - include_tool_calls (bool, optional): include tool call records, default false
+//   - criteria (string, optional): evaluation criteria forwarded in request
+//   - min_score (float64, optional): minimum score threshold
+//   - extra (map[string]any, optional): arbitrary data forwarded in request
+type RestEvalHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *RestEvalHandler) Type() string { return "rest_eval" }
+
+// Eval sends the current assistant output to the configured REST endpoint.
+func (h *RestEvalHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return executeRestEval(ctx, evalCtx, params, h.Type(), evalCtx.CurrentOutput)
+}
+
+// RestEvalSessionHandler evaluates an entire conversation by POSTing
+// all assistant messages to an external HTTP endpoint.
+//
+// Params: same as RestEvalHandler.
+type RestEvalSessionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *RestEvalSessionHandler) Type() string { return "rest_eval_session" }
+
+// Eval sends all assistant messages to the configured REST endpoint.
+func (h *RestEvalSessionHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	content := collectAssistantContent(evalCtx)
+	return executeRestEval(ctx, evalCtx, params, h.Type(), content)
+}
+
+// executeRestEval is the shared implementation for both REST eval handlers.
+func executeRestEval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+	evalType string,
+	content string,
+) (*evals.EvalResult, error) {
+	url, ok := params["url"].(string)
+	if !ok || url == "" {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: "rest_eval requires a 'url' param",
+		}, nil
+	}
+
+	method := "POST"
+	if v, ok := params["method"].(string); ok && v != "" {
+		method = v
+	}
+
+	timeout := parseDuration(params, "timeout", defaultExternalTimeout)
+	minScore := extractFloat64Ptr(params, "min_score")
+
+	reqBody := buildExternalRequest(evalCtx, params, content)
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: fmt.Sprintf("failed to marshal request: %v", err),
+		}, nil
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: fmt.Sprintf("failed to create request: %v", err),
+		}, nil
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Apply custom headers with env var interpolation.
+	headers := extractMapStringString(params, "headers")
+	for k, v := range headers {
+		httpReq.Header.Set(k, expandEnvVars(v))
+	}
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: fmt.Sprintf("request failed: %v", err),
+		}, nil
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: fmt.Sprintf("failed to read response: %v", err),
+		}, nil
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: fmt.Sprintf("endpoint returned status %d: %s", resp.StatusCode, string(respBody)),
+		}, nil
+	}
+
+	result := parseExternalResponse(respBody, minScore)
+	result.Type = evalType
+	return result, nil
+}

--- a/runtime/evals/handlers/rest_eval_test.go
+++ b/runtime/evals/handlers/rest_eval_test.go
@@ -1,0 +1,396 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestRestEvalHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &RestEvalHandler{}
+	if h.Type() != "rest_eval" {
+		t.Errorf("got %q, want %q", h.Type(), "rest_eval")
+	}
+}
+
+func TestRestEvalSessionHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &RestEvalSessionHandler{}
+	if h.Type() != "rest_eval_session" {
+		t.Errorf("got %q, want %q", h.Type(), "rest_eval_session")
+	}
+}
+
+func TestRestEvalHandler_MissingURL(t *testing.T) {
+	t.Parallel()
+	h := &RestEvalHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false for missing URL")
+	}
+	if result.Explanation != "rest_eval requires a 'url' param" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestRestEvalHandler_SuccessfulEval(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected application/json content type")
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req ExternalEvalRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("failed to unmarshal request: %v", err)
+		}
+		if req.CurrentOutput != "great answer" {
+			t.Errorf("expected current_output='great answer', got %q", req.CurrentOutput)
+		}
+		if req.Criteria != "Is it helpful?" {
+			t.Errorf("expected criteria='Is it helpful?', got %q", req.Criteria)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"passed":    true,
+			"score":     0.95,
+			"reasoning": "Very helpful response",
+		})
+	}))
+	defer server.Close()
+
+	h := &RestEvalHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "great answer",
+		Messages: []types.Message{
+			{Role: "user", Content: "help me"},
+			{Role: "assistant", Content: "great answer"},
+		},
+	}
+	params := map[string]any{
+		"url":      server.URL,
+		"criteria": "Is it helpful?",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected Passed=true")
+	}
+	if result.Score == nil || *result.Score != 0.95 {
+		t.Errorf("expected score 0.95, got %v", result.Score)
+	}
+	if result.Explanation != "Very helpful response" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+	if result.Type != "rest_eval" {
+		t.Errorf("expected type rest_eval, got %s", result.Type)
+	}
+}
+
+func TestRestEvalHandler_FailedEval(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"passed":    false,
+			"score":     0.2,
+			"reasoning": "Not helpful at all",
+		})
+	}))
+	defer server.Close()
+
+	h := &RestEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "bad answer"}
+	params := map[string]any{"url": server.URL}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false")
+	}
+	if result.Score == nil || *result.Score != 0.2 {
+		t.Errorf("expected score 0.2, got %v", result.Score)
+	}
+}
+
+func TestRestEvalHandler_NonOKStatus(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	h := &RestEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{"url": server.URL}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false for 500 status")
+	}
+	if result.Type != "rest_eval" {
+		t.Errorf("expected type rest_eval, got %s", result.Type)
+	}
+}
+
+func TestRestEvalHandler_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("not valid json"))
+	}))
+	defer server.Close()
+
+	h := &RestEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{"url": server.URL}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false for invalid JSON")
+	}
+}
+
+func TestRestEvalHandler_Timeout(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.Write([]byte(`{"passed": true, "score": 1.0}`))
+	}))
+	defer server.Close()
+
+	h := &RestEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{
+		"url":     server.URL,
+		"timeout": "100ms",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected Passed=false for timeout")
+	}
+}
+
+func TestRestEvalHandler_EnvVarHeaders(t *testing.T) {
+	t.Setenv("REST_EVAL_TEST_TOKEN", "secret-token-123")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer secret-token-123" {
+			t.Errorf("expected auth header 'Bearer secret-token-123', got %q", auth)
+		}
+		custom := r.Header.Get("X-Custom")
+		if custom != "value" {
+			t.Errorf("expected X-Custom header 'value', got %q", custom)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"passed": true, "score": 1.0})
+	}))
+	defer server.Close()
+
+	h := &RestEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{
+		"url": server.URL,
+		"headers": map[string]any{
+			"Authorization": "Bearer ${REST_EVAL_TEST_TOKEN}",
+			"X-Custom":      "value",
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected Passed=true, got explanation: %s", result.Explanation)
+	}
+}
+
+func newScoreServer(score float64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"score":     score,
+			"reasoning": "decent",
+		})
+	}))
+}
+
+func TestRestEvalHandler_MinScoreOverride(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passes with lower threshold", func(t *testing.T) {
+		t.Parallel()
+		server := newScoreServer(0.7)
+		defer server.Close()
+
+		h := &RestEvalHandler{}
+		evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+		params := map[string]any{
+			"url":       server.URL,
+			"min_score": 0.6,
+		}
+		result, err := h.Eval(context.Background(), evalCtx, params)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Passed {
+			t.Errorf("expected Passed=true with min_score=0.6, score=%v, explanation=%s",
+				result.Score, result.Explanation)
+		}
+	})
+
+	t.Run("fails with higher threshold", func(t *testing.T) {
+		t.Parallel()
+		server := newScoreServer(0.7)
+		defer server.Close()
+
+		h := &RestEvalHandler{}
+		evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+		params := map[string]any{
+			"url":       server.URL,
+			"min_score": 0.8,
+		}
+		result, err := h.Eval(context.Background(), evalCtx, params)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Passed {
+			t.Error("expected Passed=false with min_score=0.8")
+		}
+	})
+}
+
+func TestRestEvalSessionHandler_AggregatesContent(t *testing.T) {
+	t.Parallel()
+	var receivedOutput string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req ExternalEvalRequest
+		json.Unmarshal(body, &req)
+		receivedOutput = req.CurrentOutput
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"passed": true, "score": 0.9})
+	}))
+	defer server.Close()
+
+	h := &RestEvalSessionHandler{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "question 1"},
+			{Role: "assistant", Content: "answer 1"},
+			{Role: "user", Content: "question 2"},
+			{Role: "assistant", Content: "answer 2"},
+		},
+	}
+	params := map[string]any{"url": server.URL}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected Passed=true")
+	}
+	if result.Type != "rest_eval_session" {
+		t.Errorf("expected type rest_eval_session, got %s", result.Type)
+	}
+	if receivedOutput != "answer 1\nanswer 2" {
+		t.Errorf("expected aggregated assistant content, got %q", receivedOutput)
+	}
+}
+
+func TestRestEvalHandler_CustomMethod(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"passed": true, "score": 1.0})
+	}))
+	defer server.Close()
+
+	h := &RestEvalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "test"}
+	params := map[string]any{
+		"url":    server.URL,
+		"method": "PUT",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected Passed=true")
+	}
+}
+
+func TestRestEvalHandler_IncludeToolCalls(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req ExternalEvalRequest
+		json.Unmarshal(body, &req)
+
+		if len(req.ToolCalls) != 1 {
+			t.Errorf("expected 1 tool call, got %d", len(req.ToolCalls))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"passed": true, "score": 1.0})
+	}))
+	defer server.Close()
+
+	h := &RestEvalHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "test",
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search", Arguments: map[string]any{"q": "test"}},
+		},
+	}
+	params := map[string]any{
+		"url":                server.URL,
+		"include_tool_calls": true,
+	}
+
+	_, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add four new eval type handlers (`rest_eval`, `rest_eval_session`, `a2a_eval`, `a2a_eval_session`) that delegate evaluation to external services
- REST handlers POST conversation context to any HTTP endpoint and interpret the structured `{passed, score, reasoning}` JSON response
- A2A handlers send context to an A2A agent via `message/send` and parse the agent's text response for a JSON eval result
- Shared utilities: `${ENV_VAR}` interpolation for headers/tokens, standard request/response types, response parsing with configurable `min_score` threshold
- Starlight docs updated across assertions reference, eval-framework explanation, scenario-format reference, and how-to/explanation guides

## New files

| File | Purpose |
|------|---------|
| `runtime/evals/handlers/external_eval.go` | Shared types and helpers |
| `runtime/evals/handlers/rest_eval.go` | `RestEvalHandler` + `RestEvalSessionHandler` |
| `runtime/evals/handlers/a2a_eval.go` | `A2AEvalHandler` + `A2AEvalSessionHandler` |
| `*_test.go` (3 files) | Tests with httptest mock servers |

## Test plan

- [x] All existing handler tests pass (`go test ./runtime/evals/handlers/...`)
- [x] New tests cover: success, failure, non-2xx, invalid JSON, timeout, env var interpolation, session aggregation, min_score override, missing required params, A2A agent error, no text response
- [x] Coverage: `a2a_eval.go` 98.2%, `external_eval.go` 100%, `rest_eval.go` 91.9%
- [x] `golangci-lint run ./runtime/evals/handlers/...` — 0 issues
- [x] Pre-commit hook passes (lint, build, tests, coverage ≥80%)