### PR TITLE
chore(schemas): regenerate JSON schemas for Prometheus labels field

### DIFF
--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1057,6 +1057,12 @@
         },
         "range": {
           "$ref": "#/$defs/Range"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/promptconfig.json
+++ b/schemas/v1alpha1/promptconfig.json
@@ -306,6 +306,12 @@
         },
         "range": {
           "$ref": "#/$defs/Range"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

- Regenerate `arena.json` and `promptconfig.json` schemas that were out of date after the Prometheus labels field was added in #564
- Adds the `labels` property (map of string) to the metric collector schema

## Test plan

- [x] `make schemas-check` passes locally
- [x] Schema validation CI pipeline should now pass on main