### PR TITLE
fix(release): add server/a2a module to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,19 @@ jobs:
           echo "✓ Tagged pkg/$VERSION"
         fi
     
+    - name: Tag server/a2a
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        echo "Tagging server/a2a/$VERSION"
+        if git rev-parse "server/a2a/$VERSION" >/dev/null 2>&1; then
+          echo "⚠ Tag server/a2a/$VERSION already exists, skipping"
+        else
+          git tag -a "server/a2a/$VERSION" -m "Release server/a2a $VERSION"
+          git push origin "server/a2a/$VERSION"
+          echo "✓ Tagged server/a2a/$VERSION"
+        fi
+
     - name: Tag sdk
       env:
         VERSION: ${{ needs.validate.outputs.version }}
@@ -220,28 +233,34 @@ jobs:
           return 1
         }
         
-        # Check all three modules
+        # Check all modules
         check_module "runtime" "$VERSION" &
         PID_RUNTIME=$!
-        
+
         check_module "pkg" "$VERSION" &
         PID_PKG=$!
-        
+
+        check_module "server/a2a" "$VERSION" &
+        PID_SERVER_A2A=$!
+
         check_module "sdk" "$VERSION" &
         PID_SDK=$!
-        
+
         # Wait for all checks to complete
         wait $PID_RUNTIME
         RESULT_RUNTIME=$?
-        
+
         wait $PID_PKG
         RESULT_PKG=$?
-        
+
+        wait $PID_SERVER_A2A
+        RESULT_SERVER_A2A=$?
+
         wait $PID_SDK
         RESULT_SDK=$?
-        
+
         # Report overall status (non-blocking - Go proxy can take time to propagate)
-        if [ $RESULT_RUNTIME -eq 0 ] && [ $RESULT_PKG -eq 0 ] && [ $RESULT_SDK -eq 0 ]; then
+        if [ $RESULT_RUNTIME -eq 0 ] && [ $RESULT_PKG -eq 0 ] && [ $RESULT_SERVER_A2A -eq 0 ] && [ $RESULT_SDK -eq 0 ]; then
           echo "✓ All modules are available on Go proxy"
         else
           echo "⚠ Some modules may need more time to propagate"
@@ -290,6 +309,43 @@ jobs:
           echo "✓ Created branch $BRANCH"
         fi
     
+    - name: Update server/a2a dependencies
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        echo "Updating server/a2a to use $VERSION..."
+        cd server/a2a
+
+        # Update go.mod to require new versions
+        echo "Setting required versions to $VERSION..."
+        go mod edit -require="github.com/AltairaLabs/PromptKit/runtime@$VERSION"
+
+        # Remove local replace directives
+        go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/runtime
+
+        cd ../..
+        echo "✓ Updated server/a2a go.mod to $VERSION"
+
+    - name: Update sdk dependencies
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        echo "Updating sdk to use $VERSION..."
+        cd sdk
+
+        # Update go.mod to require new versions
+        echo "Setting required versions to $VERSION..."
+        go mod edit -require="github.com/AltairaLabs/PromptKit/runtime@$VERSION"
+        go mod edit -require="github.com/AltairaLabs/PromptKit/pkg@$VERSION"
+        go mod edit -require="github.com/AltairaLabs/PromptKit/server/a2a@$VERSION"
+
+        # Remove local replace directives
+        go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/runtime
+        go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/server/a2a
+
+        cd ..
+        echo "✓ Updated sdk go.mod to $VERSION"
+
     - name: Update arena dependencies
       env:
         VERSION: ${{ needs.validate.outputs.version }}
@@ -335,12 +391,14 @@ jobs:
         BRANCH="release/tools/$VERSION"
         
         # Check if there are changes to commit
-        if git diff --quiet tools/arena/go.mod tools/arena/go.sum tools/packc/go.mod tools/packc/go.sum; then
+        if git diff --quiet server/a2a/go.mod server/a2a/go.sum sdk/go.mod sdk/go.sum tools/arena/go.mod tools/arena/go.sum tools/packc/go.mod tools/packc/go.sum; then
           echo "⚠ No changes to commit (already up to date)"
         else
+          git add server/a2a/go.mod server/a2a/go.sum
+          git add sdk/go.mod sdk/go.sum
           git add tools/arena/go.mod tools/arena/go.sum
           git add tools/packc/go.mod tools/packc/go.sum
-          git commit -m "release: update tools to $VERSION"
+          git commit -m "release: update modules to $VERSION"
           git push origin "$BRANCH"
           echo "✓ Pushed $BRANCH"
         fi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -135,6 +135,7 @@ release:
     **Libraries:**
     - `runtime/{{.Version}}` - Core runtime components
     - `pkg/{{.Version}}` - Shared packages
+    - `server/a2a/{{.Version}}` - A2A server module
     - `sdk/{{.Version}}` - Production SDK library
     
     **Tools:**


### PR DESCRIPTION
## Summary

- Add `server/a2a` sub-module to the release workflow — it was completely missing, meaning it was never tagged or had its dependencies updated during releases
- The SDK imports `server/a2a` but it was pinned at `v0.0.0` with a `replace` directive, which breaks external consumers doing `go get github.com/AltairaLabs/PromptKit/sdk@<version>`
- Also created and pushed `server/a2a/v1.3.3` tag for the current release

### Changes to release workflow:
1. **Tag server/a2a** — new step in `tag-dependencies` job (ordered after pkg, before sdk)
2. **Update server/a2a deps** — new step in `update-tools` job to drop replace directive and set runtime version
3. **Update sdk deps** — new step in `update-tools` job to drop server/a2a replace directive and set proper version
4. **Go proxy verification** — added server/a2a to the parallel proxy check
5. **Commit step** — includes server/a2a and sdk go.mod/go.sum files
6. **GoReleaser footer** — lists server/a2a in released components

## Test plan

- [ ] Verify the release workflow YAML is valid (CI will check syntax)
- [ ] Next release (v1.3.4+) should tag server/a2a automatically
- [ ] Verify `server/a2a/v1.3.3` tag exists on remote