### PR TITLE
fix(telemetry): parent OTel spans under caller context

### DIFF
--- a/runtime/telemetry/listener.go
+++ b/runtime/telemetry/listener.go
@@ -56,14 +56,23 @@ func NewOTelEventListener(tracer trace.Tracer) *OTelEventListener {
 
 // StartSession creates a root span for the given session, optionally parented
 // under the span context in parentCtx.
+// It is idempotent: if a session already exists for the given ID, the previous
+// session span is ended before creating a new one. This allows callers to call
+// StartSession on every Send/Stream with a fresh parent context.
 func (l *OTelEventListener) StartSession(parentCtx context.Context, sessionID string) {
 	ctx, span := l.tracer.Start(parentCtx, "promptkit.session",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(attribute.String("session.id", sessionID)),
 	)
 	l.mu.Lock()
+	prev, hadPrev := l.sessions[sessionID]
 	l.sessions[sessionID] = &sessionState{span: span, ctx: ctx}
 	l.mu.Unlock()
+
+	// End previous session span outside the lock to avoid holding it during span.End().
+	if hadPrev {
+		prev.span.End()
+	}
 }
 
 // EndSession ends the root span for the given session.

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -203,6 +203,8 @@ func (c *Conversation) Send(ctx context.Context, message any, opts ...SendOption
 		return nil, err
 	}
 
+	c.startOTelSession(ctx)
+
 	// Build user message from input
 	userMsg, err := c.buildUserMessage(message)
 	if err != nil {
@@ -773,6 +775,14 @@ func (c *Conversation) Fork() *Conversation {
 	return fork
 }
 
+// startOTelSession registers (or re-registers) the caller's context with the
+// OTel event listener so that pipeline spans are parented under the caller's span.
+func (c *Conversation) startOTelSession(ctx context.Context) {
+	if c.config != nil && c.config.otelListener != nil {
+		c.config.otelListener.StartSession(ctx, c.ID())
+	}
+}
+
 // Close releases resources associated with the conversation.
 //
 // After Close is called, Send and Stream will return [ErrConversationClosed].
@@ -785,6 +795,12 @@ func (c *Conversation) Close() error {
 		return nil
 	}
 	c.closed = true
+
+	// End the OTel session span (deferred to Close so late-arriving async events
+	// from the EventBus still have a parent context).
+	if c.config != nil && c.config.otelListener != nil {
+		c.config.otelListener.EndSession(c.ID())
+	}
 
 	// Run session end hooks before cleanup
 	c.sessionHooks.SessionEnd(context.Background())

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -19,6 +19,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/skills"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/stt"
+	"github.com/AltairaLabs/PromptKit/runtime/telemetry"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/tts"
 	"github.com/AltairaLabs/PromptKit/runtime/variables"
@@ -157,6 +158,10 @@ type config struct {
 
 	// Telemetry: OTel TracerProvider for distributed tracing
 	tracerProvider trace.TracerProvider
+
+	// OTel event listener reference (set by initEventBus when tracerProvider is configured).
+	// Used by Send/Stream to call StartSession so pipeline spans are parented under the caller's context.
+	otelListener *telemetry.OTelEventListener
 
 	// Custom logger for SDK consumers
 	logger *slog.Logger

--- a/sdk/otel_integration_test.go
+++ b/sdk/otel_integration_test.go
@@ -42,6 +42,11 @@ func TestOTelIntegration_SpansFromConversation(t *testing.T) {
 		t.Fatal("initEventBus should create an event bus")
 	}
 
+	// Verify that initEventBus stores the listener reference in config.
+	if cfg.otelListener == nil {
+		t.Fatal("initEventBus should store otelListener in config when tracerProvider is set")
+	}
+
 	// Track events for debug visibility.
 	var eventTypes []events.EventType
 	var eventMu sync.Mutex
@@ -175,6 +180,75 @@ func TestOTelIntegration_SpansParentedUnderSession(t *testing.T) {
 				s.Name, s.SpanContext.TraceID(), sessionTraceID)
 		}
 	}
+}
+
+// TestOTelIntegration_SpansParentedUnderCallerContext verifies the fix for #588:
+// when Send() is called with a context carrying a parent span, all PromptKit
+// spans share the same trace ID as the caller's span (not orphaned).
+func TestOTelIntegration_SpansParentedUnderCallerContext(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	// Wire via initEventBus so otelListener is stored — this is the production path.
+	cfg := &config{tracerProvider: tp}
+	initEventBus(cfg)
+
+	conv := buildOTelTestConversation(t, cfg)
+
+	// Create a parent span simulating an HTTP handler or gRPC interceptor.
+	tracer := tp.Tracer("test-caller")
+	parentCtx, parentSpan := tracer.Start(context.Background(), "caller-request")
+	parentTraceID := parentSpan.SpanContext().TraceID()
+
+	// Send() should call StartSession with parentCtx, parenting all pipeline spans.
+	resp, err := conv.Send(parentCtx, "Hello from caller context")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if resp == nil || resp.Text() == "" {
+		t.Fatal("expected non-empty response")
+	}
+	parentSpan.End()
+
+	// Allow async event processing to complete.
+	time.Sleep(200 * time.Millisecond)
+
+	// Close ends the OTel session span so it appears in the exporter.
+	conv.Close()
+
+	if err := tp.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("ForceFlush: %v", err)
+	}
+
+	spans := exp.GetSpans()
+
+	// Every span emitted by PromptKit (session, pipeline, provider, middleware)
+	// must share the same trace ID as the caller's parent span.
+	for _, s := range spans {
+		if s.Name == "caller-request" {
+			continue // skip the caller's own span
+		}
+		if s.SpanContext.TraceID() != parentTraceID {
+			t.Errorf("span %q has trace ID %v, want %v (same as caller)",
+				s.Name, s.SpanContext.TraceID(), parentTraceID)
+		}
+	}
+
+	// Verify we got at least the session and pipeline spans.
+	spanNames := make(map[string]bool)
+	for _, s := range spans {
+		spanNames[s.Name] = true
+	}
+	if !spanNames["promptkit.session"] {
+		t.Errorf("missing promptkit.session span; got: %v", spanNameList(spans))
+	}
+	if !spanNames["promptkit.pipeline"] {
+		t.Errorf("missing promptkit.pipeline span; got: %v", spanNameList(spans))
+	}
+
+	t.Logf("captured %d span(s) all under trace %v: %v",
+		len(spans), parentTraceID, spanNameList(spans))
 }
 
 // TestOTelIntegration_NoTracerProvider verifies that conversations work

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -436,6 +436,7 @@ func initEventBus(cfg *config) {
 		tracer := telemetry.Tracer(cfg.tracerProvider)
 		listener := telemetry.NewOTelEventListener(tracer)
 		cfg.eventBus.SubscribeAll(listener.OnEvent)
+		cfg.otelListener = listener
 	}
 }
 

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -90,6 +90,10 @@ type streamState struct {
 func (c *Conversation) Stream(ctx context.Context, message any, opts ...SendOption) <-chan StreamChunk {
 	ch := make(chan StreamChunk, streamChannelBufferSize)
 
+	// Register the caller's context with the OTel listener before launching the
+	// goroutine so the session exists when pipeline events start arriving.
+	c.startOTelSession(ctx)
+
 	go func() {
 		defer close(ch)
 		startTime := time.Now()


### PR DESCRIPTION
## Summary

Fixes #588

- OTel spans were orphaned because `StartSession()` was never called with the caller's context. `Send(ctx)`/`Stream(ctx)` carry a parent span from the caller, but the listener's `sessionCtx()` returned `context.Background()` since no session was registered.
- Store the `OTelEventListener` reference in config, call `StartSession(ctx, id)` at the top of each `Send()`/`Stream()`, and `EndSession(id)` in `Close()`.
- Make `StartSession` idempotent so repeated `Send()` calls safely update the parent context.
- `EndSession` is deferred to `Close()` (not per-call) because the EventBus delivers events asynchronously—ending the session immediately after `Send()` returns would cause late-arriving events to lose their parent context.

## Changes

| File | Change |
|------|--------|
| `sdk/options.go` | Add `otelListener` field to config |
| `sdk/sdk.go` | Store listener ref in `initEventBus()` |
| `runtime/telemetry/listener.go` | Make `StartSession` idempotent (end previous span first) |
| `sdk/conversation.go` | Add `startOTelSession` helper; wire into `Send()` and `Close()` |
| `sdk/streaming.go` | Wire `startOTelSession` into `Stream()` before goroutine launch |
| `sdk/otel_integration_test.go` | Add regression test + verify `otelListener` is stored |

## Test plan

- [x] `TestOTelIntegration_SpansParentedUnderCallerContext` — creates a parent span, calls `Send()`, verifies all PromptKit spans share the caller's trace ID
- [x] `TestOTelIntegration_SpansFromConversation` — updated to verify `cfg.otelListener` is set
- [x] All existing OTel integration tests pass
- [x] Full SDK test suite passes with race detector
- [x] Pre-commit hooks pass (lint, build, coverage ≥80%)