### PR TITLE
fix(sdk): expose WithExecutionTimeout and propagate context to tool handlers

### DIFF
--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -119,8 +119,9 @@ type Conversation struct {
 	duplexSession session.DuplexSession
 
 	// Tool handlers
-	handlers   map[string]ToolHandler
-	handlersMu sync.RWMutex
+	handlers    map[string]ToolHandler
+	ctxHandlers map[string]ToolHandlerCtx
+	handlersMu  sync.RWMutex
 
 	// Async tool handlers for HITL
 	asyncHandlers   map[string]sdktools.AsyncToolHandler
@@ -282,7 +283,7 @@ func (c *Conversation) buildPipelineConfig(
 
 	// Build tool registry
 	c.handlersMu.RLock()
-	localExec := &localExecutor{handlers: c.handlers}
+	localExec := &localExecutor{handlers: c.handlers, ctxHandlers: c.ctxHandlers}
 	c.toolRegistry.RegisterExecutor(localExec)
 	c.registerMCPExecutors()
 	// Register capability tools (includes A2A)
@@ -323,6 +324,7 @@ func (c *Conversation) buildPipelineConfig(
 		SummarizeThreshold:    c.config.summarizeThreshold,
 		SummarizeBatchSize:    c.config.summarizeBatchSize,
 		HookRegistry:          c.hookRegistry,
+		ExecutionTimeout:      c.config.executionTimeout,
 	}
 
 	// Wire up RAG context components from SDK options

--- a/sdk/conversation_test.go
+++ b/sdk/conversation_test.go
@@ -170,16 +170,21 @@ func TestConversationOnToolCtx(t *testing.T) {
 		return "ctx_result", nil
 	})
 
-	// Verify handler was registered (wrapped)
+	// Verify handler was stored in ctxHandlers (not wrapped in handlers)
 	conv.handlersMu.RLock()
-	handler, ok := conv.handlers["ctx_tool"]
+	ctxHandler, ok := conv.ctxHandlers["ctx_tool"]
+	_, inPlain := conv.handlers["ctx_tool"]
 	conv.handlersMu.RUnlock()
 
 	assert.True(t, ok)
-	result, err := handler(map[string]any{})
+	assert.False(t, inPlain, "OnToolCtx should not store in plain handlers map")
+
+	// Call the ctx handler directly with a real context
+	testCtx := context.WithValue(context.Background(), struct{ k string }{"test"}, "value")
+	result, err := ctxHandler(testCtx, map[string]any{})
 	assert.NoError(t, err)
 	assert.Equal(t, "ctx_result", result)
-	assert.NotNil(t, receivedCtx)
+	assert.Equal(t, testCtx, receivedCtx)
 }
 
 func TestConversationOnTools(t *testing.T) {
@@ -494,7 +499,7 @@ func TestOnToolHTTP(t *testing.T) {
 		conv.OnToolHTTP("http_tool", cfg)
 
 		conv.handlersMu.RLock()
-		_, exists := conv.handlers["http_tool"]
+		_, exists := conv.ctxHandlers["http_tool"]
 		conv.handlersMu.RUnlock()
 
 		assert.True(t, exists)
@@ -525,13 +530,13 @@ func TestOnToolExecutor(t *testing.T) {
 		conv.OnToolExecutor("custom_tool", executor)
 
 		conv.handlersMu.RLock()
-		handler, exists := conv.handlers["custom_tool"]
+		handler, exists := conv.ctxHandlers["custom_tool"]
 		conv.handlersMu.RUnlock()
 
 		assert.True(t, exists)
 
-		// Test the handler
-		result, err := handler(map[string]any{"input": "test"})
+		// Test the handler — context is now propagated
+		result, err := handler(context.Background(), map[string]any{"input": "test"})
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 	})
@@ -547,10 +552,10 @@ func TestOnToolExecutor(t *testing.T) {
 		conv.OnToolExecutor("missing_tool", executor)
 
 		conv.handlersMu.RLock()
-		handler := conv.handlers["missing_tool"]
+		handler := conv.ctxHandlers["missing_tool"]
 		conv.handlersMu.RUnlock()
 
-		_, err := handler(map[string]any{})
+		_, err := handler(context.Background(), map[string]any{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in pack")
 	})
@@ -643,6 +648,93 @@ func TestLocalExecutorExecute(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "handler failed")
 	})
+}
+
+func TestLocalExecutorCtxHandler(t *testing.T) {
+	t.Run("context-aware handler receives pipeline context", func(t *testing.T) {
+		type ctxKey string
+		var receivedCtx context.Context
+
+		executor := &localExecutor{
+			handlers: make(map[string]ToolHandler),
+			ctxHandlers: map[string]ToolHandlerCtx{
+				"search": func(ctx context.Context, args map[string]any) (any, error) {
+					receivedCtx = ctx
+					return "found", nil
+				},
+			},
+		}
+
+		pipelineCtx := context.WithValue(context.Background(), ctxKey("trace"), "abc123")
+		descriptor := &tools.ToolDescriptor{Name: "search"}
+		result, err := executor.Execute(pipelineCtx, descriptor, json.RawMessage(`{}`))
+
+		assert.NoError(t, err)
+		assert.Equal(t, `"found"`, string(result))
+		assert.Equal(t, "abc123", receivedCtx.Value(ctxKey("trace")))
+	})
+
+	t.Run("ctxHandler takes priority over plain handler", func(t *testing.T) {
+		executor := &localExecutor{
+			handlers: map[string]ToolHandler{
+				"search": func(args map[string]any) (any, error) {
+					return "plain", nil
+				},
+			},
+			ctxHandlers: map[string]ToolHandlerCtx{
+				"search": func(ctx context.Context, args map[string]any) (any, error) {
+					return "ctx-aware", nil
+				},
+			},
+		}
+
+		descriptor := &tools.ToolDescriptor{Name: "search"}
+		result, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
+
+		assert.NoError(t, err)
+		assert.Equal(t, `"ctx-aware"`, string(result))
+	})
+
+	t.Run("falls back to plain handler when no ctxHandler", func(t *testing.T) {
+		executor := &localExecutor{
+			handlers: map[string]ToolHandler{
+				"search": func(args map[string]any) (any, error) {
+					return "plain", nil
+				},
+			},
+			ctxHandlers: make(map[string]ToolHandlerCtx),
+		}
+
+		descriptor := &tools.ToolDescriptor{Name: "search"}
+		result, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
+
+		assert.NoError(t, err)
+		assert.Equal(t, `"plain"`, string(result))
+	})
+}
+
+func TestOnToolCtxStoresCtxHandler(t *testing.T) {
+	conv := newTestConversation()
+
+	var receivedCtx context.Context
+	conv.OnToolCtx("search", func(ctx context.Context, args map[string]any) (any, error) {
+		receivedCtx = ctx
+		return "ok", nil
+	})
+
+	// ctxHandlers should have the handler, handlers should not
+	assert.NotNil(t, conv.ctxHandlers["search"])
+	assert.Nil(t, conv.handlers["search"])
+
+	// Execute through localExecutor to verify context propagation
+	type ctxKey string
+	pipelineCtx := context.WithValue(context.Background(), ctxKey("span"), "test-span")
+	executor := &localExecutor{handlers: conv.handlers, ctxHandlers: conv.ctxHandlers}
+	result, err := executor.Execute(pipelineCtx, &tools.ToolDescriptor{Name: "search"}, json.RawMessage(`{}`))
+
+	assert.NoError(t, err)
+	assert.Equal(t, `"ok"`, string(result))
+	assert.Equal(t, "test-span", receivedCtx.Value(ctxKey("span")))
 }
 
 // =============================================================================

--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -44,12 +44,10 @@ func (c *Conversation) OnTool(name string, handler ToolHandler) {
 func (c *Conversation) OnToolCtx(name string, handler ToolHandlerCtx) {
 	c.handlersMu.Lock()
 	defer c.handlersMu.Unlock()
-	// Wrap ToolHandlerCtx as ToolHandler (context will be injected at call time)
-	c.handlers[name] = func(args map[string]any) (any, error) {
-		// Note: This wrapper will be replaced with proper context injection
-		// when the pipeline is built
-		return handler(context.Background(), args)
+	if c.ctxHandlers == nil {
+		c.ctxHandlers = make(map[string]ToolHandlerCtx)
 	}
+	c.ctxHandlers[name] = handler
 }
 
 // OnTools registers multiple tool handlers at once.
@@ -83,7 +81,10 @@ func (c *Conversation) OnTools(handlers map[string]ToolHandler) {
 func (c *Conversation) OnToolHTTP(name string, config *sdktools.HTTPToolConfig) {
 	c.handlersMu.Lock()
 	defer c.handlersMu.Unlock()
-	c.handlers[name] = config.Handler()
+	if c.ctxHandlers == nil {
+		c.ctxHandlers = make(map[string]ToolHandlerCtx)
+	}
+	c.ctxHandlers[name] = config.HandlerCtx()
 }
 
 // OnToolExecutor registers a custom executor for tools.
@@ -98,7 +99,10 @@ func (c *Conversation) OnToolHTTP(name string, config *sdktools.HTTPToolConfig) 
 func (c *Conversation) OnToolExecutor(name string, executor tools.Executor) {
 	c.handlersMu.Lock()
 	defer c.handlersMu.Unlock()
-	c.handlers[name] = func(args map[string]any) (any, error) {
+	if c.ctxHandlers == nil {
+		c.ctxHandlers = make(map[string]ToolHandlerCtx)
+	}
+	c.ctxHandlers[name] = func(ctx context.Context, args map[string]any) (any, error) {
 		// Convert args to JSON for the executor
 		argsJSON, err := json.Marshal(args)
 		if err != nil {
@@ -122,9 +126,8 @@ func (c *Conversation) OnToolExecutor(name string, executor tools.Executor) {
 			InputSchema: paramsJSON,
 		}
 
-		// Execute
-		// TODO: propagate context from ToolHandler once the handler signature supports it.
-		result, err := executor.Execute(context.TODO(), desc, argsJSON)
+		// Execute with pipeline context for tracing and cancellation
+		result, err := executor.Execute(ctx, desc, argsJSON)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -3,6 +3,7 @@ package pipeline
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -132,6 +133,11 @@ type Config struct {
 	// HookRegistry for policy enforcement hooks (optional)
 	// When provided, ProviderStage will use hooks for provider call, chunk, and tool interception
 	HookRegistry *hooks.Registry
+
+	// ExecutionTimeout overrides the default pipeline execution timeout.
+	// When non-nil, the pointed-to duration is used instead of the default 30s.
+	// A zero value disables timeout entirely.
+	ExecutionTimeout *time.Duration
 }
 
 // Build creates a stage-based streaming pipeline.
@@ -196,6 +202,11 @@ func newPipelineBuilder(cfg *Config) *stage.PipelineBuilder {
 		// since the session runs indefinitely until user ends it
 		pipelineConfig := stage.DefaultPipelineConfig()
 		pipelineConfig.ExecutionTimeout = 0 // Disable timeout for duplex
+		return stage.NewPipelineBuilderWithConfig(pipelineConfig)
+	}
+	if cfg.ExecutionTimeout != nil {
+		pipelineConfig := stage.DefaultPipelineConfig()
+		pipelineConfig.ExecutionTimeout = *cfg.ExecutionTimeout
 		return stage.NewPipelineBuilderWithConfig(pipelineConfig)
 	}
 	return stage.NewPipelineBuilder()

--- a/sdk/internal/pipeline/builder_test.go
+++ b/sdk/internal/pipeline/builder_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
@@ -907,6 +908,42 @@ func TestBuildWithHookRegistry(t *testing.T) {
 }
 
 // testVariableProvider implements variables.Provider for testing
+func TestNewPipelineBuilderWithExecutionTimeout(t *testing.T) {
+	t.Run("uses default timeout when ExecutionTimeout is nil", func(t *testing.T) {
+		cfg := &Config{}
+		builder := newPipelineBuilder(cfg)
+		assert.NotNil(t, builder)
+	})
+
+	t.Run("uses custom timeout when ExecutionTimeout is set", func(t *testing.T) {
+		timeout := 120 * time.Second
+		registry := createTestRegistry("chat")
+		cfg := &Config{
+			PromptRegistry:   registry,
+			TaskType:         "chat",
+			ExecutionTimeout: &timeout,
+		}
+
+		pipe, err := Build(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, pipe)
+	})
+
+	t.Run("disables timeout when ExecutionTimeout is zero", func(t *testing.T) {
+		timeout := time.Duration(0)
+		registry := createTestRegistry("chat")
+		cfg := &Config{
+			PromptRegistry:   registry,
+			TaskType:         "chat",
+			ExecutionTimeout: &timeout,
+		}
+
+		pipe, err := Build(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, pipe)
+	})
+}
+
 type testVariableProvider struct {
 	vars map[string]string
 	err  error

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -163,6 +163,11 @@ type config struct {
 	// Used by Send/Stream to call StartSession so pipeline spans are parented under the caller's context.
 	otelListener *telemetry.OTelEventListener
 
+	// Pipeline execution timeout override.
+	// When non-nil, overrides the default 30s execution timeout.
+	// Use 0 to disable timeout entirely (useful for long-running tool-calling pipelines).
+	executionTimeout *time.Duration
+
 	// Custom logger for SDK consumers
 	logger *slog.Logger
 }
@@ -518,6 +523,20 @@ func WithTracerProvider(tp trace.TracerProvider) Option {
 func WithLogger(l *slog.Logger) Option {
 	return func(c *config) error {
 		c.logger = l
+		return nil
+	}
+}
+
+// WithExecutionTimeout overrides the default pipeline execution timeout (30s).
+// Use this for pipelines that need more time, such as multi-round tool-calling
+// with slower providers like Ollama. Pass 0 to disable the timeout entirely.
+//
+//	conv, _ := sdk.Open("./chat.pack.json", "assistant",
+//	    sdk.WithExecutionTimeout(120 * time.Second),
+//	)
+func WithExecutionTimeout(d time.Duration) Option {
+	return func(c *config) error {
+		c.executionTimeout = &d
 		return nil
 	}
 }

--- a/sdk/options_test.go
+++ b/sdk/options_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,26 @@ func TestWithConversationID(t *testing.T) {
 	err := opt(cfg)
 	assert.NoError(t, err)
 	assert.Equal(t, "conv-123", cfg.conversationID)
+}
+
+func TestWithExecutionTimeout(t *testing.T) {
+	t.Run("sets timeout", func(t *testing.T) {
+		opt := WithExecutionTimeout(120 * time.Second)
+		cfg := &config{}
+		err := opt(cfg)
+		assert.NoError(t, err)
+		require.NotNil(t, cfg.executionTimeout)
+		assert.Equal(t, 120*time.Second, *cfg.executionTimeout)
+	})
+
+	t.Run("zero disables timeout", func(t *testing.T) {
+		opt := WithExecutionTimeout(0)
+		cfg := &config{}
+		err := opt(cfg)
+		assert.NoError(t, err)
+		require.NotNil(t, cfg.executionTimeout)
+		assert.Equal(t, time.Duration(0), *cfg.executionTimeout)
+	})
 }
 
 func TestWithTokenBudget(t *testing.T) {

--- a/sdk/tool_executors.go
+++ b/sdk/tool_executors.go
@@ -11,8 +11,11 @@ import (
 
 // localExecutor is a tool executor for locally-handled tools (Mode: "local").
 // It dispatches to the appropriate ToolHandler based on the tool name.
+// Context-aware handlers (ctxHandlers) are preferred over plain handlers
+// so that pipeline context (tracing, cancellation) propagates to tool calls.
 type localExecutor struct {
-	handlers map[string]ToolHandler
+	handlers    map[string]ToolHandler
+	ctxHandlers map[string]ToolHandlerCtx
 }
 
 // Name returns "local" to match the Mode on tools in the pack.
@@ -21,22 +24,26 @@ func (e *localExecutor) Name() string {
 }
 
 // Execute dispatches to the appropriate handler based on tool name.
+// Context-aware handlers are preferred so that tracing and cancellation propagate.
 func (e *localExecutor) Execute(
-	_ context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
 ) (json.RawMessage, error) {
-	handler, ok := e.handlers[descriptor.Name]
-	if !ok {
-		return nil, fmt.Errorf("no handler registered for tool: %s", descriptor.Name)
-	}
-
 	// Parse args to map
 	var argsMap map[string]any
 	if err := json.Unmarshal(args, &argsMap); err != nil {
 		return nil, fmt.Errorf("failed to parse tool arguments: %w", err)
 	}
 
-	// Call handler
-	result, err := handler(argsMap)
+	// Prefer context-aware handler
+	var result any
+	var err error
+	if ctxHandler, ok := e.ctxHandlers[descriptor.Name]; ok {
+		result, err = ctxHandler(ctx, argsMap)
+	} else if handler, ok := e.handlers[descriptor.Name]; ok {
+		result, err = handler(argsMap)
+	} else {
+		return nil, fmt.Errorf("no handler registered for tool: %s", descriptor.Name)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/tools/http.go
+++ b/sdk/tools/http.go
@@ -308,15 +308,26 @@ func (c *HTTPToolConfig) ToDescriptorConfig() *tools.HTTPConfig {
 // Handler returns a tool handler function that makes the HTTP request.
 // This is used with OnTool to register an HTTP-based tool.
 func (c *HTTPToolConfig) Handler() func(args map[string]any) (any, error) {
+	ctxHandler := c.HandlerCtx()
+	return func(args map[string]any) (any, error) {
+		return ctxHandler(context.Background(), args)
+	}
+}
+
+// HandlerCtx returns a context-aware tool handler function that makes the HTTP request.
+// The context is propagated to the underlying HTTP executor for tracing and cancellation.
+func (c *HTTPToolConfig) HandlerCtx() func(ctx context.Context, args map[string]any) (any, error) {
 	executor := NewHTTPExecutor()
 
-	return func(args map[string]any) (any, error) {
-		return c.executeHandler(executor, args)
+	return func(ctx context.Context, args map[string]any) (any, error) {
+		return c.executeHandler(ctx, executor, args)
 	}
 }
 
 // executeHandler performs the HTTP request with transforms and post-processing.
-func (c *HTTPToolConfig) executeHandler(executor *HTTPExecutor, args map[string]any) (any, error) {
+func (c *HTTPToolConfig) executeHandler(
+	ctx context.Context, executor *HTTPExecutor, args map[string]any,
+) (any, error) {
 	// Apply transform if configured
 	if c.transform != nil {
 		var err error
@@ -338,9 +349,8 @@ func (c *HTTPToolConfig) executeHandler(executor *HTTPExecutor, args map[string]
 		return nil, fmt.Errorf("failed to serialize arguments: %w", err)
 	}
 
-	// Execute the HTTP request
-	// TODO: propagate context from ToolHandler once the handler signature supports it.
-	result, err := executor.Execute(context.TODO(), descriptor, argsJSON)
+	// Execute the HTTP request with pipeline context for tracing and cancellation
+	result, err := executor.Execute(ctx, descriptor, argsJSON)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- **#590**: Add `sdk.WithExecutionTimeout(d time.Duration)` option so consumers can override the default 30s pipeline execution timeout. Pass `0` to disable entirely — useful for multi-round tool-calling with slower providers like Ollama.
- **#591**: Propagate pipeline context through all tool handler paths (`OnToolCtx`, `OnToolExecutor`, `OnToolHTTP`) so trace spans, cancellation, and deadlines flow to tool execution instead of being dropped via `context.Background()`/`context.TODO()`.

### Changes

**Execution timeout (#590):**
- Add `executionTimeout *time.Duration` to `sdk.config` and `WithExecutionTimeout()` option
- Add `ExecutionTimeout *time.Duration` to `sdk/internal/pipeline.Config`
- Thread through `newPipelineBuilder()` and `buildPipelineConfig()`

**Context propagation (#591):**
- Add `ctxHandlers map[string]ToolHandlerCtx` to `localExecutor` and `Conversation`
- `OnToolCtx` stores directly in `ctxHandlers` instead of wrapping with `context.Background()`
- `OnToolExecutor` stores as `ctxHandler`, passes pipeline `ctx` to executor
- `OnToolHTTP` uses new `HTTPToolConfig.HandlerCtx()` that propagates context to HTTP executor
- `localExecutor.Execute` prefers `ctxHandlers` over plain `handlers`

### Usage

```go
conv, _ := sdk.Open("./chat.pack.json", "assistant",
    sdk.WithExecutionTimeout(120 * time.Second), // or 0 to disable
)
```

Closes #590
Closes #591

## Test plan

- [x] `TestWithExecutionTimeout` — option sets config field correctly (including zero)
- [x] `TestNewPipelineBuilderWithExecutionTimeout` — builder uses custom/zero/nil timeout
- [x] `TestLocalExecutorCtxHandler` — context propagation, priority over plain handlers, fallback
- [x] `TestOnToolCtxStoresCtxHandler` — end-to-end context flow through localExecutor
- [x] `TestConversationOnToolCtx` — stores in ctxHandlers, not handlers
- [x] `TestOnToolHTTP` — stores in ctxHandlers
- [x] `TestOnToolExecutor` — stores in ctxHandlers with context propagation
- [x] All existing SDK tests pass, lint clean, coverage ≥80% on changed files