### PR TITLE
fix(ollama,sdk): streaming token counts and ctxHandlers initialization (#594)

### DIFF
--- a/examples/ollama-local/config.arena.yaml
+++ b/examples/ollama-local/config.arena.yaml
@@ -5,9 +5,16 @@ metadata:
   annotations:
     description: "Example demonstrating local LLM inference with Ollama"
 spec:
+  # Tool definitions (mock implementations for testing)
+  tools:
+    - file: tools/get_weather.tool.yaml
+    - file: tools/get_time.tool.yaml
+
   prompt_configs:
     - id: assistant
       file: prompts/assistant.yaml
+    - id: tool-assistant
+      file: prompts/tool-assistant.yaml
     - id: vision-assistant
       file: prompts/vision-assistant.yaml
 
@@ -20,6 +27,9 @@ spec:
     # Basic functionality tests
     - file: scenarios/basic-chat.scenario.yaml
     - file: scenarios/code-generation.scenario.yaml
+    # Tool calling tests
+    - file: scenarios/tool-calling.scenario.yaml
+    - file: scenarios/tool-calling-streaming.scenario.yaml
     # Streaming verification tests
     - file: scenarios/streaming-verification.scenario.yaml
     # Uncomment for multimodal testing (requires vision provider)

--- a/examples/ollama-local/prompts/tool-assistant.yaml
+++ b/examples/ollama-local/prompts/tool-assistant.yaml
@@ -1,0 +1,26 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: tool-assistant
+  annotations:
+    description: "AI assistant with tool calling capabilities for local Ollama models"
+spec:
+  task_type: "tool-assistant"
+  version: "v1.0.0"
+  description: "An assistant that can use tools to answer questions"
+
+  system_template: |
+    You are a helpful AI assistant with access to tools. When a user asks a question
+    that can be answered using one of your available tools, you MUST call the tool
+    to get accurate information rather than guessing.
+
+    Available Tools:
+    - get_weather: Get current weather conditions for any location
+    - get_time: Get the current date and time for a given timezone
+
+    Always use tools when the user asks about weather or time.
+    After receiving tool results, incorporate them into a natural response.
+
+  allowed_tools:
+    - get_weather
+    - get_time

--- a/examples/ollama-local/providers/ollama-llama.provider.yaml
+++ b/examples/ollama-local/providers/ollama-llama.provider.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   id: "ollama-llama"
   type: ollama
-  model: llama3.2:1b
+  model: llama3.2:3b
   base_url: "http://localhost:11434"
   additional_config:
     # Keep the model loaded in memory for 5 minutes between requests

--- a/examples/ollama-local/scenarios/tool-calling-streaming.scenario.yaml
+++ b/examples/ollama-local/scenarios/tool-calling-streaming.scenario.yaml
@@ -1,0 +1,47 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: tool-calling-streaming
+  annotations:
+    description: "Verify tool calling works correctly with streaming enabled"
+spec:
+  id: tool-calling-streaming
+  description: "Test tool calling with streaming responses from local Ollama models"
+  task_type: tool-assistant
+  streaming: true
+
+  tool_policy:
+    tool_choice: auto
+    max_tool_calls_per_turn: 3
+    max_total_tool_calls: 5
+
+  turns:
+    - role: user
+      content: "What's the weather like in Tokyo right now?"
+      assertions:
+        - type: min_length
+          params:
+            min_chars: 20
+            message: "Response should describe the weather"
+
+    - role: user
+      content: "And what time is it there?"
+      assertions:
+        - type: min_length
+          params:
+            min_chars: 10
+            message: "Response should include time information"
+
+  conversation_assertions:
+    - type: tools_called
+      params:
+        tool_names:
+          - get_weather
+        min_calls: 1
+        message: "Should call get_weather tool for weather query"
+    - type: tools_called
+      params:
+        tool_names:
+          - get_time
+        min_calls: 1
+        message: "Should call get_time tool for time query"

--- a/examples/ollama-local/scenarios/tool-calling.scenario.yaml
+++ b/examples/ollama-local/scenarios/tool-calling.scenario.yaml
@@ -1,0 +1,46 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: tool-calling
+  annotations:
+    description: "Verify that Ollama models can use tools via function calling"
+spec:
+  id: tool-calling
+  description: "Test tool calling capabilities with local Ollama models"
+  task_type: tool-assistant
+
+  tool_policy:
+    tool_choice: auto
+    max_tool_calls_per_turn: 3
+    max_total_tool_calls: 5
+
+  turns:
+    - role: user
+      content: "What's the weather like in San Francisco?"
+      assertions:
+        - type: min_length
+          params:
+            min_chars: 20
+            message: "Response should describe the weather"
+
+    - role: user
+      content: "What time is it in New York?"
+      assertions:
+        - type: min_length
+          params:
+            min_chars: 10
+            message: "Response should include time information"
+
+  conversation_assertions:
+    - type: tools_called
+      params:
+        tool_names:
+          - get_weather
+        min_calls: 1
+        message: "Should call get_weather tool for weather query"
+    - type: tools_called
+      params:
+        tool_names:
+          - get_time
+        min_calls: 1
+        message: "Should call get_time tool for time query"

--- a/examples/ollama-local/tools/get_time.tool.yaml
+++ b/examples/ollama-local/tools/get_time.tool.yaml
@@ -1,0 +1,29 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: get_time
+spec:
+  name: get_time
+  description: Get the current date and time for a given timezone
+  input_schema:
+    type: object
+    properties:
+      timezone:
+        type: string
+        description: "Timezone identifier (e.g., 'America/New_York', 'Europe/London', 'UTC')"
+    required:
+      - timezone
+  output_schema:
+    type: object
+    properties:
+      datetime:
+        type: string
+        description: Current date and time in ISO 8601 format
+      timezone:
+        type: string
+        description: The timezone used
+  mode: mock
+  timeout_ms: 1000
+  mock_result:
+    datetime: "2026-03-03T14:30:00-05:00"
+    timezone: "America/New_York"

--- a/examples/ollama-local/tools/get_weather.tool.yaml
+++ b/examples/ollama-local/tools/get_weather.tool.yaml
@@ -1,0 +1,33 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: get_weather
+spec:
+  name: get_weather
+  description: Get current weather conditions for a location
+  input_schema:
+    type: object
+    properties:
+      location:
+        type: string
+        description: City name or location
+    required:
+      - location
+  output_schema:
+    type: object
+    properties:
+      temperature:
+        type: number
+        description: Temperature in degrees Fahrenheit
+      conditions:
+        type: string
+        description: Weather conditions (sunny, cloudy, rainy, etc.)
+      humidity:
+        type: number
+        description: Humidity percentage
+  mode: mock
+  timeout_ms: 2000
+  mock_result:
+    temperature: 72
+    conditions: sunny with light clouds
+    humidity: 45

--- a/runtime/providers/ollama/ollama.go
+++ b/runtime/providers/ollama/ollama.go
@@ -271,6 +271,7 @@ func (p *Provider) createFinalStreamChunk(
 	if usage != nil {
 		costBreakdown := p.CalculateCost(usage.PromptTokens, usage.CompletionTokens, 0)
 		finalChunk.CostInfo = &costBreakdown
+		finalChunk.TokenCount = usage.PromptTokens + usage.CompletionTokens
 	}
 
 	return finalChunk
@@ -289,6 +290,8 @@ func (p *Provider) streamResponse(
 	accumulated := ""
 	totalTokens := 0
 	var accumulatedToolCalls []types.MessageToolCall
+	var lastUsage *ollamaUsage
+	var finishReason *string
 
 	for scanner.Scan() {
 		if p.handleContextCancellation(ctx, accumulated, accumulatedToolCalls, outChan) {
@@ -297,22 +300,30 @@ func (p *Provider) streamResponse(
 
 		data := scanner.Data()
 		if data == "[DONE]" {
-			p.sendDoneChunk(accumulated, accumulatedToolCalls, totalTokens, outChan)
-			return
+			break
 		}
 
 		chunk, ok := p.parseStreamChunk(data)
-		if !ok || len(chunk.Choices) == 0 {
+		if !ok {
+			continue
+		}
+
+		// Track usage from any chunk (may arrive in a usage-only chunk after finish)
+		if chunk.Usage != nil {
+			lastUsage = chunk.Usage
+		}
+
+		if len(chunk.Choices) == 0 {
 			continue
 		}
 
 		choice := chunk.Choices[0]
 		accumulated, totalTokens = p.processStreamChoice(
 			choice, accumulated, totalTokens,
-			&accumulatedToolCalls, chunk.Usage, outChan,
+			&accumulatedToolCalls, outChan,
 		)
 		if choice.FinishReason != nil {
-			return
+			finishReason = choice.FinishReason
 		}
 	}
 
@@ -323,7 +334,16 @@ func (p *Provider) streamResponse(
 			Error:        err,
 			FinishReason: providers.StringPtr("error"),
 		}
+		return
 	}
+
+	// Send final chunk with usage data (collected from usage-only chunk after finish)
+	if finishReason == nil {
+		finishReason = providers.StringPtr("stop")
+	}
+	outChan <- p.createFinalStreamChunk(
+		accumulated, accumulatedToolCalls, totalTokens, finishReason, lastUsage,
+	)
 }
 
 // handleContextCancellation checks for context cancellation and sends appropriate chunk
@@ -352,14 +372,13 @@ func (p *Provider) sendDoneChunk(
 	accumulated string,
 	accumulatedToolCalls []types.MessageToolCall,
 	totalTokens int,
+	usage *ollamaUsage,
 	outChan chan<- providers.StreamChunk,
 ) {
-	outChan <- providers.StreamChunk{
-		Content:      accumulated,
-		ToolCalls:    accumulatedToolCalls,
-		TokenCount:   totalTokens,
-		FinishReason: providers.StringPtr("stop"),
-	}
+	finalChunk := p.createFinalStreamChunk(
+		accumulated, accumulatedToolCalls, totalTokens, providers.StringPtr("stop"), usage,
+	)
+	outChan <- finalChunk
 }
 
 // parseStreamChunk parses a stream chunk from JSON
@@ -371,13 +390,14 @@ func (p *Provider) parseStreamChunk(data string) (ollamaStreamChunk, bool) {
 	return chunk, true
 }
 
-// processStreamChoice processes a single stream choice and returns updated state
+// processStreamChoice processes a single stream choice and returns updated state.
+// It sends intermediate delta chunks but NOT the final chunk — the caller handles that
+// after collecting usage data from the post-finish usage-only chunk.
 func (p *Provider) processStreamChoice(
 	choice ollamaStreamChoice,
 	accumulated string,
 	totalTokens int,
 	accumulatedToolCalls *[]types.MessageToolCall,
-	usage *ollamaUsage,
 	outChan chan<- providers.StreamChunk,
 ) (newAccumulated string, newTotalTokens int) {
 	// Handle content delta
@@ -403,14 +423,6 @@ func (p *Provider) processStreamChoice(
 			TokenCount:  totalTokens,
 			DeltaTokens: 0,
 		}
-	}
-
-	// Handle finish reason
-	if choice.FinishReason != nil {
-		finalChunk := p.createFinalStreamChunk(
-			accumulated, *accumulatedToolCalls, totalTokens, choice.FinishReason, usage,
-		)
-		outChan <- finalChunk
 	}
 
 	return accumulated, totalTokens
@@ -598,7 +610,8 @@ func (p *Provider) predictStreamWithMessages(
 		"temperature": temperature,
 		"top_p":       topP,
 		"max_tokens":  maxTokens,
-		"stream":      true,
+		"stream":         true,
+		"stream_options": map[string]any{"include_usage": true},
 	}
 	if req.Seed != nil {
 		ollamaReq["seed"] = *req.Seed

--- a/runtime/providers/ollama/ollama_test.go
+++ b/runtime/providers/ollama/ollama_test.go
@@ -952,7 +952,8 @@ func TestSendDoneChunk(t *testing.T) {
 	outChan := make(chan providers.StreamChunk, 1)
 	toolCalls := []types.MessageToolCall{{ID: "call_1"}}
 
-	provider.sendDoneChunk("content", toolCalls, 10, outChan)
+	// Test without usage
+	provider.sendDoneChunk("content", toolCalls, 10, nil, outChan)
 
 	chunk := <-outChan
 
@@ -966,6 +967,20 @@ func TestSendDoneChunk(t *testing.T) {
 
 	if chunk.FinishReason == nil || *chunk.FinishReason != "stop" {
 		t.Error("Expected stop finish reason")
+	}
+
+	// Test with usage - should override estimated token count
+	usage := &ollamaUsage{PromptTokens: 50, CompletionTokens: 25, TotalTokens: 75}
+	provider.sendDoneChunk("content", toolCalls, 10, usage, outChan)
+
+	chunk = <-outChan
+
+	if chunk.TokenCount != 75 {
+		t.Errorf("Expected TokenCount 75 from usage, got %d", chunk.TokenCount)
+	}
+
+	if chunk.CostInfo == nil {
+		t.Error("Expected CostInfo to be set when usage is provided")
 	}
 }
 
@@ -983,7 +998,7 @@ func TestProcessStreamChoice(t *testing.T) {
 	}
 
 	newAccum, newTokens := provider.processStreamChoice(
-		choice, "", 0, &toolCalls, nil, outChan,
+		choice, "", 0, &toolCalls, outChan,
 	)
 
 	if newAccum != "Hello" {

--- a/runtime/providers/ollama/ollama_tools.go
+++ b/runtime/providers/ollama/ollama_tools.go
@@ -327,6 +327,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 
 	// Add streaming options
 	ollamaReq["stream"] = true
+	ollamaReq["stream_options"] = map[string]any{"include_usage": true}
 
 	reqBody, err := json.Marshal(ollamaReq)
 	if err != nil {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -174,6 +174,7 @@ func initConversation(
 		toolRegistry:   tools.NewRegistryWithRepository(p.ToToolRepository()), // Create registry with pack tools
 		config:         cfg,
 		handlers:       make(map[string]ToolHandler),
+		ctxHandlers:    make(map[string]ToolHandlerCtx),
 		asyncHandlers:  make(map[string]sdktools.AsyncToolHandler),
 		pendingStore:   sdktools.NewPendingStore(),
 		resolvedStore:  sdktools.NewResolvedStore(),

--- a/sdk/template.go
+++ b/sdk/template.go
@@ -188,6 +188,7 @@ func (t *PackTemplate) newConversation(
 		toolRegistry:   tools.NewRegistryWithRepository(t.toolRepository),
 		config:         cfg,
 		handlers:       make(map[string]ToolHandler),
+		ctxHandlers:    make(map[string]ToolHandlerCtx),
 		asyncHandlers:  make(map[string]sdktools.AsyncToolHandler),
 		pendingStore:   sdktools.NewPendingStore(),
 		resolvedStore:  sdktools.NewResolvedStore(),


### PR DESCRIPTION
## Summary
- Fix Ollama streaming provider returning 0 token counts by adding `stream_options: {include_usage: true}` and refactoring the stream reader to collect usage data from the post-finish chunk
- Fix `ctxHandlers` not initialized in `Conversation` constructors, causing `OnToolCtx` handlers to silently fail to dispatch (#594)
- Add tool-calling example scenarios (streaming and non-streaming) to the `ollama-local` example

## Ollama streaming token counts
The Ollama OpenAI-compatible API only includes usage data in streaming responses when `stream_options.include_usage` is explicitly set. Additionally, usage arrives in a separate chunk (empty `choices`) **after** the `finish_reason` chunk. The previous code returned immediately on `finish_reason`, never seeing the usage chunk.

### Changes
- Add `stream_options: {include_usage: true}` to streaming requests in `predictStreamWithMessages()` and `PredictStreamWithTools()`
- Refactor `streamResponse()` to continue reading after `finish_reason` to collect usage
- Update `createFinalStreamChunk()` to use actual token counts from usage data

## SDK ctxHandlers fix (#594)
The `Conversation` constructors in `sdk.go` and `template.go` initialized `handlers` and `asyncHandlers` but not `ctxHandlers`. The `localExecutor` captured a nil reference during pipeline construction. When `OnToolCtx` later created a new map, the executor and Conversation held disconnected references.

### Changes
- Initialize `ctxHandlers` with `make()` in both `sdk.go` and `template.go` constructors

## Test plan
- [x] All Ollama provider unit tests pass (88.5% coverage)
- [x] All SDK tests pass (84.6% coverage)
- [x] Pre-commit hooks pass for both commits
- [x] Verified against live Ollama (`llama3.2:3b`) — token counts now reported correctly
- [x] Non-tool streaming scenario still works

Fixes #594