### PR TITLE
feat(tools): add client mode for client-side tool execution

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1065,11 +1065,28 @@ type ToolSpec struct {
 	Description  string      `json:"description" yaml:"description"`
 	InputSchema  interface{} `json:"input_schema" yaml:"input_schema"`   // JSON Schema Draft-07
 	OutputSchema interface{} `json:"output_schema" yaml:"output_schema"` // JSON Schema Draft-07
-	Mode         string      `json:"mode" yaml:"mode"`                   // "mock" | "live"
+	Mode         string      `json:"mode" yaml:"mode"`                   // "mock" | "live" | "client"
 	TimeoutMs    int         `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
 	MockResult   interface{} `json:"mock_result,omitempty" yaml:"mock_result,omitempty"`     // Static mock data
 	MockTemplate string      `json:"mock_template,omitempty" yaml:"mock_template,omitempty"` // Template for dynamic mocks
 	HTTPConfig   *HTTPConfig `json:"http,omitempty" yaml:"http,omitempty"`                   // Live HTTP configuration
+	// Client-side execution configuration
+	ClientConfig *ToolClientConfig `json:"client,omitempty" yaml:"client,omitempty"`
+}
+
+// ToolClientConfig defines configuration for client-side tool execution (schema generation)
+type ToolClientConfig struct {
+	Consent        *ToolConsentConfig `json:"consent,omitempty" yaml:"consent,omitempty"`
+	TimeoutMs      int                `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+	Categories     []string           `json:"categories,omitempty" yaml:"categories,omitempty"`
+	ValidateOutput bool               `json:"validate_output,omitempty" yaml:"validate_output,omitempty"`
+}
+
+// ToolConsentConfig defines consent requirements for client-side tools (schema generation)
+type ToolConsentConfig struct {
+	Required        bool   `json:"required" yaml:"required"`
+	Message         string `json:"message,omitempty" yaml:"message,omitempty"`
+	DeclineStrategy string `json:"decline_strategy,omitempty" yaml:"decline_strategy,omitempty"`
 }
 
 // HTTPConfig defines configuration for live HTTP tool execution

--- a/runtime/tools/errors.go
+++ b/runtime/tools/errors.go
@@ -20,7 +20,7 @@ var (
 	ErrOutputSchemaRequired = errors.New("output schema is required")
 
 	// ErrInvalidToolMode is returned when a tool has an invalid mode.
-	ErrInvalidToolMode = errors.New("mode must be 'mock', 'live', 'mcp', or a registered executor name")
+	ErrInvalidToolMode = errors.New("mode must be 'mock', 'live', 'mcp', 'client', or a registered executor name")
 
 	// ErrMockExecutorOnly is returned when a non-mock tool is passed to a mock executor.
 	ErrMockExecutorOnly = errors.New("executor can only execute mock tools")

--- a/runtime/tools/executors.go
+++ b/runtime/tools/executors.go
@@ -14,6 +14,7 @@ const (
 	modeMock             = "mock"
 	modeLive             = "live"
 	modeMCP              = "mcp"
+	modeClient           = "client"
 	executorMockStatic   = "mock-static"
 	executorMockScripted = "mock-scripted"
 )
@@ -35,7 +36,7 @@ func (e *MockStaticExecutor) Name() string {
 func (e *MockStaticExecutor) Execute(
 	_ context.Context, descriptor *ToolDescriptor, _ json.RawMessage,
 ) (json.RawMessage, error) {
-	if descriptor.Mode != modeMock {
+	if descriptor.Mode != modeMock && descriptor.Mode != modeClient {
 		return nil, ErrMockExecutorOnly
 	}
 
@@ -74,7 +75,7 @@ func (e *MockScriptedExecutor) Name() string {
 func (e *MockScriptedExecutor) Execute(
 	_ context.Context, descriptor *ToolDescriptor, args json.RawMessage,
 ) (json.RawMessage, error) {
-	if descriptor.Mode != modeMock {
+	if descriptor.Mode != modeMock && descriptor.Mode != modeClient {
 		return nil, ErrMockExecutorOnly
 	}
 

--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -359,7 +359,7 @@ func (r *Registry) getExecutorForTool(tool *ToolDescriptor) (Executor, error) {
 
 	// First, handle built-in modes with their established mappings
 	switch tool.Mode {
-	case modeMock, "": // Empty mode defaults to mock behavior
+	case modeMock, modeClient, "": // Empty/mock/client modes use mock executors
 		// Check for templated mock first
 		if tool.MockTemplate != "" || tool.MockTemplateFile != "" {
 			executorName = executorMockScripted
@@ -476,7 +476,8 @@ func (r *Registry) validateDescriptor(descriptor *ToolDescriptor) error {
 
 	// Mode must be empty (defaults to mock), a built-in mode, or a registered executor name
 	isBuiltinMode := descriptor.Mode == "" || descriptor.Mode == modeMock ||
-		descriptor.Mode == modeLive || descriptor.Mode == modeMCP
+		descriptor.Mode == modeLive || descriptor.Mode == modeMCP ||
+		descriptor.Mode == modeClient
 	_, isRegisteredExecutor := r.executors[descriptor.Mode]
 	if !isBuiltinMode && !isRegisteredExecutor {
 		return ErrInvalidToolMode

--- a/runtime/tools/registry_test.go
+++ b/runtime/tools/registry_test.go
@@ -596,6 +596,16 @@ func TestGetExecutorForTool_BuiltInModes(t *testing.T) {
 			mode:        "mcp",
 			expectError: true, // mcp executor not registered by default
 		},
+		{
+			name:       "client mode with static result",
+			mode:       "client",
+			mockResult: json.RawMessage(`{"result": "client_data"}`),
+		},
+		{
+			name:         "client mode with template",
+			mode:         "client",
+			mockTemplate: `{"result": "client_templated"}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/runtime/tools/tools_test.go
+++ b/runtime/tools/tools_test.go
@@ -218,6 +218,141 @@ func TestMockExecutorErrors(t *testing.T) {
 	})
 }
 
+func TestClientModeTool_StaticExecution(t *testing.T) {
+	staticExec := tools.NewMockStaticExecutor()
+
+	desc := &tools.ToolDescriptor{
+		Name:       "get_location",
+		Mode:       "client",
+		MockResult: json.RawMessage(`{"lat": 37.7749, "lng": -122.4194}`),
+	}
+
+	result, err := staticExec.Execute(context.Background(), desc, json.RawMessage(`{"accuracy": "fine"}`))
+	if err != nil {
+		t.Fatalf("Client mode static execution failed: %v", err)
+	}
+
+	var resultMap map[string]interface{}
+	if err := json.Unmarshal(result, &resultMap); err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	if resultMap["lat"] != 37.7749 {
+		t.Errorf("Expected lat 37.7749, got %v", resultMap["lat"])
+	}
+}
+
+func TestClientModeTool_ScriptedExecution(t *testing.T) {
+	scriptedExec := tools.NewMockScriptedExecutor()
+
+	desc := &tools.ToolDescriptor{
+		Name:         "get_location",
+		Mode:         "client",
+		MockTemplate: `{"lat": 37.7749, "accuracy": "{{.accuracy}}"}`,
+	}
+
+	result, err := scriptedExec.Execute(context.Background(), desc, json.RawMessage(`{"accuracy": "fine"}`))
+	if err != nil {
+		t.Fatalf("Client mode scripted execution failed: %v", err)
+	}
+
+	var resultMap map[string]interface{}
+	if err := json.Unmarshal(result, &resultMap); err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	if resultMap["accuracy"] != "fine" {
+		t.Errorf("Expected accuracy 'fine', got %v", resultMap["accuracy"])
+	}
+}
+
+func TestClientModeTool_RegistryExecution(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	descriptor := &tools.ToolDescriptor{
+		Name:         "get_location",
+		Description:  "Get GPS coordinates",
+		InputSchema:  json.RawMessage(`{"type": "object", "properties": {"accuracy": {"type": "string"}}}`),
+		OutputSchema: json.RawMessage(`{"type": "object", "properties": {"lat": {"type": "number"}, "lng": {"type": "number"}}}`),
+		Mode:         "client",
+		MockResult:   json.RawMessage(`{"lat": 37.7749, "lng": -122.4194}`),
+		TimeoutMs:    5000,
+	}
+
+	if err := registry.Register(descriptor); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	result, err := registry.Execute(context.Background(), "get_location", json.RawMessage(`{"accuracy": "fine"}`))
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if result.Error != "" {
+		t.Errorf("Expected no error, got '%s'", result.Error)
+	}
+
+	var resultData map[string]interface{}
+	if err := json.Unmarshal(result.Result, &resultData); err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	if resultData["lat"] != 37.7749 {
+		t.Errorf("Expected lat 37.7749, got %v", resultData["lat"])
+	}
+}
+
+func TestClientModeTool_YAMLLoad(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	yamlTool := `
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: get_location
+spec:
+  description: "Get GPS coordinates"
+  mode: client
+  input_schema:
+    type: object
+    properties:
+      accuracy:
+        type: string
+  output_schema:
+    type: object
+    properties:
+      lat:
+        type: number
+      lng:
+        type: number
+  mock_result:
+    lat: 37.7749
+    lng: -122.4194
+`
+
+	if err := registry.LoadToolFromBytes("get_location.tool.yaml", []byte(yamlTool)); err != nil {
+		t.Fatalf("LoadToolFromBytes failed: %v", err)
+	}
+
+	tool := registry.Get("get_location")
+	if tool == nil {
+		t.Fatal("Tool not found after loading")
+	}
+
+	if tool.Mode != "client" {
+		t.Errorf("Expected mode 'client', got '%s'", tool.Mode)
+	}
+
+	result, err := registry.Execute(context.Background(), "get_location", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if result.Error != "" {
+		t.Errorf("Expected no error, got '%s'", result.Error)
+	}
+}
+
 func TestSchemaValidator(t *testing.T) {
 	validator := tools.NewSchemaValidator()
 

--- a/runtime/tools/types.go
+++ b/runtime/tools/types.go
@@ -87,8 +87,9 @@ type ToolDescriptor struct {
 	MockResultFile   string `json:"mock_result_file,omitempty" yaml:"mock_result_file,omitempty"`
 	MockTemplateFile string `json:"mock_template_file,omitempty" yaml:"mock_template_file,omitempty"`
 
-	HTTPConfig *HTTPConfig `json:"http,omitempty" yaml:"http,omitempty"` // Live HTTP configuration
-	A2AConfig  *A2AConfig  `json:"a2a,omitempty" yaml:"a2a,omitempty"`   // A2A agent configuration
+	HTTPConfig   *HTTPConfig   `json:"http,omitempty" yaml:"http,omitempty"`     // Live HTTP configuration
+	A2AConfig    *A2AConfig    `json:"a2a,omitempty" yaml:"a2a,omitempty"`       // A2A agent configuration
+	ClientConfig *ClientConfig `json:"client,omitempty" yaml:"client,omitempty"` // Client-side execution configuration
 }
 
 // HTTPConfig defines configuration for live HTTP tool execution
@@ -107,6 +108,31 @@ type A2AConfig struct {
 	SkillID   string `json:"skill_id" yaml:"skill_id"`
 	TimeoutMs int    `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
 }
+
+// ClientConfig defines configuration for client-side tool execution.
+// Tools with mode "client" are fulfilled by the SDK caller's device
+// (e.g., GPS, camera, contacts, biometrics).
+type ClientConfig struct {
+	Consent        *ConsentConfig `json:"consent,omitempty" yaml:"consent,omitempty"`
+	TimeoutMs      int            `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+	Categories     []string       `json:"categories,omitempty" yaml:"categories,omitempty"`
+	ValidateOutput bool           `json:"validate_output,omitempty" yaml:"validate_output,omitempty"`
+}
+
+// ConsentConfig defines consent requirements for client-side tools.
+type ConsentConfig struct {
+	Required bool   `json:"required" yaml:"required"`
+	Message  string `json:"message,omitempty" yaml:"message,omitempty"`
+	// DeclineStrategy: "fallback" | "error" | "retry"
+	DeclineStrategy string `json:"decline_strategy,omitempty" yaml:"decline_strategy,omitempty"`
+}
+
+// Decline strategy constants for ConsentConfig.DeclineStrategy.
+const (
+	DeclineStrategyFallback = "fallback"
+	DeclineStrategyError    = "error"
+	DeclineStrategyRetry    = "retry"
+)
 
 // ToolCall represents a tool invocation request
 type ToolCall struct {

--- a/runtime/tools/types_test.go
+++ b/runtime/tools/types_test.go
@@ -220,6 +220,100 @@ func TestParseToolName_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestClientConfig_MarshalJSON(t *testing.T) {
+	cfg := ClientConfig{
+		Consent: &ConsentConfig{
+			Required:        true,
+			Message:         "This app wants to access your location.",
+			DeclineStrategy: DeclineStrategyFallback,
+		},
+		TimeoutMs:      30000,
+		Categories:     []string{"location", "sensors"},
+		ValidateOutput: true,
+	}
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var decoded ClientConfig
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, cfg.TimeoutMs, decoded.TimeoutMs)
+	assert.Equal(t, cfg.Categories, decoded.Categories)
+	assert.Equal(t, cfg.ValidateOutput, decoded.ValidateOutput)
+	require.NotNil(t, decoded.Consent)
+	assert.True(t, decoded.Consent.Required)
+	assert.Equal(t, "This app wants to access your location.", decoded.Consent.Message)
+	assert.Equal(t, DeclineStrategyFallback, decoded.Consent.DeclineStrategy)
+}
+
+func TestClientConfig_OptionalFields(t *testing.T) {
+	cfg := ClientConfig{}
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var decoded ClientConfig
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Nil(t, decoded.Consent)
+	assert.Zero(t, decoded.TimeoutMs)
+	assert.Nil(t, decoded.Categories)
+	assert.False(t, decoded.ValidateOutput)
+}
+
+func TestConsentConfig_DeclineStrategies(t *testing.T) {
+	strategies := []string{
+		DeclineStrategyFallback,
+		DeclineStrategyError,
+		DeclineStrategyRetry,
+	}
+	assert.Equal(t, "fallback", strategies[0])
+	assert.Equal(t, "error", strategies[1])
+	assert.Equal(t, "retry", strategies[2])
+}
+
+func TestToolDescriptor_WithClientConfig(t *testing.T) {
+	descriptor := ToolDescriptor{
+		Name:         "get_location",
+		Description:  "Get GPS coordinates",
+		InputSchema:  json.RawMessage(`{"type":"object"}`),
+		OutputSchema: json.RawMessage(`{"type":"object","properties":{"lat":{"type":"number"},"lng":{"type":"number"}}}`),
+		Mode:         "client",
+		ClientConfig: &ClientConfig{
+			Consent: &ConsentConfig{
+				Required:        true,
+				Message:         "Allow location access?",
+				DeclineStrategy: DeclineStrategyError,
+			},
+			TimeoutMs:      15000,
+			Categories:     []string{"location"},
+			ValidateOutput: true,
+		},
+		MockResult: json.RawMessage(`{"lat":37.7749,"lng":-122.4194}`),
+	}
+
+	data, err := json.Marshal(descriptor)
+	require.NoError(t, err)
+
+	var decoded ToolDescriptor
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "client", decoded.Mode)
+	require.NotNil(t, decoded.ClientConfig)
+	require.NotNil(t, decoded.ClientConfig.Consent)
+	assert.True(t, decoded.ClientConfig.Consent.Required)
+	assert.Equal(t, "Allow location access?", decoded.ClientConfig.Consent.Message)
+	assert.Equal(t, DeclineStrategyError, decoded.ClientConfig.Consent.DeclineStrategy)
+	assert.Equal(t, 15000, decoded.ClientConfig.TimeoutMs)
+	assert.Equal(t, []string{"location"}, decoded.ClientConfig.Categories)
+	assert.True(t, decoded.ClientConfig.ValidateOutput)
+	assert.NotEmpty(t, decoded.MockResult)
+}
+
 // Mock executor for testing AsyncToolExecutor interface
 type mockAsyncExecutor struct {
 	name   string

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1882,6 +1882,45 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ToolClientConfig": {
+      "properties": {
+        "consent": {
+          "$ref": "#/$defs/ToolConsentConfig"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "categories": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "validate_output": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolConsentConfig": {
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "decline_strategy": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "required"
+      ]
+    },
     "ToolPolicy": {
       "properties": {
         "tool_choice": {
@@ -1963,6 +2002,9 @@
         },
         "http": {
           "$ref": "#/$defs/HTTPConfig"
+        },
+        "client": {
+          "$ref": "#/$defs/ToolClientConfig"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/tool.json
+++ b/schemas/v1alpha1/tool.json
@@ -72,6 +72,45 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ToolClientConfig": {
+      "properties": {
+        "consent": {
+          "$ref": "#/$defs/ToolConsentConfig"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "categories": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "validate_output": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolConsentConfig": {
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "decline_strategy": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "required"
+      ]
+    },
     "ToolSpec": {
       "properties": {
         "name": {
@@ -94,6 +133,9 @@
         },
         "http": {
           "$ref": "#/$defs/HTTPConfig"
+        },
+        "client": {
+          "$ref": "#/$defs/ToolClientConfig"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

- Adds `mode: client` tool definition for tools that must execute on the caller's device (GPS, camera, contacts, biometrics)
- Adds `ClientConfig` and `ConsentConfig` types with consent requirements and decline strategies (`fallback`, `error`, `retry`)
- Client tools reuse existing mock executors (`MockStaticExecutor`, `MockScriptedExecutor`) — no new execution paths
- Regenerated JSON schemas (`tool.json`, `arena.json`) to include the `client` block

Closes #595

## Design

Full proposal: `docs/local-backlog/CLIENT_SIDE_TOOL_EXECUTION_PROPOSAL.md` (gitignored, local only)

This is Phase 1 of 6 — core infrastructure types and tool routing. Subsequent phases:
- #596 SDK synchronous handlers (`OnClientTool`)
- #597 Pipeline suspension and deferred mode
- #598 Streaming support
- #599 PromptArena consent simulation
- #600 A2A integration (`input_required`)

## Test plan

- [x] `ClientConfig` / `ConsentConfig` JSON round-trip serialization
- [x] `mode: client` accepted in `validateDescriptor`
- [x] Client tools route to `MockStaticExecutor` and `MockScriptedExecutor`
- [x] Full registry `Execute()` with client mode tool
- [x] YAML loading of client tool via `LoadToolFromBytes`
- [x] Client mode added to `TestGetExecutorForTool_BuiltInModes` table
- [x] All pre-commit checks pass (lint, build, tests, coverage >= 80%)