### PR TITLE
feat(sdk): add OnClientTool handler and clientExecutor for client-side tools

### DIFF
--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -359,7 +359,16 @@ func (r *Registry) getExecutorForTool(tool *ToolDescriptor) (Executor, error) {
 
 	// First, handle built-in modes with their established mappings
 	switch tool.Mode {
-	case modeMock, modeClient, "": // Empty/mock/client modes use mock executors
+	case modeClient:
+		// Prefer registered "client" executor (SDK); fall back to mock
+		if _, ok := r.executors["client"]; ok {
+			executorName = "client"
+		} else if tool.MockTemplate != "" || tool.MockTemplateFile != "" {
+			executorName = executorMockScripted
+		} else {
+			executorName = executorMockStatic
+		}
+	case modeMock, "": // Empty/mock modes use mock executors
 		// Check for templated mock first
 		if tool.MockTemplate != "" || tool.MockTemplateFile != "" {
 			executorName = executorMockScripted

--- a/runtime/tools/registry_test.go
+++ b/runtime/tools/registry_test.go
@@ -894,3 +894,84 @@ func TestGetByNamespace(t *testing.T) {
 		t.Errorf("expected 0 workflow tools, got %d", len(noneTools))
 	}
 }
+
+// TestGetExecutorForTool_ClientModePreference verifies that a registered
+// "client" executor takes priority over mock fallback for mode: "client".
+func TestGetExecutorForTool_ClientModePreference(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	// Register a custom executor named "client"
+	customExec := &mockCustomExecutor{
+		name:   "client",
+		result: json.RawMessage(`{"source": "client_executor"}`),
+	}
+	registry.RegisterExecutor(customExec)
+
+	descriptor := &tools.ToolDescriptor{
+		Name:         "get_location",
+		Description:  "Get GPS coordinates",
+		InputSchema:  json.RawMessage(`{"type": "object"}`),
+		OutputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:         "client",
+		MockResult:   json.RawMessage(`{"source": "mock"}`),
+		TimeoutMs:    1000,
+	}
+
+	if err := registry.Register(descriptor); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	result, err := registry.Execute(
+		context.Background(), "get_location", json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Result, &data); err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// Should come from custom executor, not mock
+	if data["source"] != "client_executor" {
+		t.Errorf("Expected client_executor, got %v", data["source"])
+	}
+}
+
+// TestGetExecutorForTool_ClientModeFallsBackToMock verifies that without
+// a registered "client" executor, client mode falls back to mock.
+func TestGetExecutorForTool_ClientModeFallsBackToMock(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	descriptor := &tools.ToolDescriptor{
+		Name:         "get_location_mock",
+		Description:  "Get GPS coordinates",
+		InputSchema:  json.RawMessage(`{"type": "object"}`),
+		OutputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:         "client",
+		MockResult:   json.RawMessage(`{"source": "mock"}`),
+		TimeoutMs:    1000,
+	}
+
+	if err := registry.Register(descriptor); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	result, err := registry.Execute(
+		context.Background(), "get_location_mock", json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Result, &data); err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// Should come from mock since no client executor is registered
+	if data["source"] != "mock" {
+		t.Errorf("Expected mock, got %v", data["source"])
+	}
+}

--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -1,0 +1,156 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// ClientToolRequest contains information about a client-side tool invocation.
+// It is passed to handlers registered via [Conversation.OnClientTool].
+type ClientToolRequest struct {
+	// ToolName is the tool's name as defined in the pack.
+	ToolName string
+
+	// CallID is the provider-assigned ID for this particular invocation.
+	CallID string
+
+	// Args contains the parsed arguments from the LLM.
+	Args map[string]any
+
+	// ConsentMsg is the human-readable consent message from the pack's
+	// client.consent.message field. Empty when no consent is configured.
+	ConsentMsg string
+
+	// Categories are the semantic consent categories (e.g., ["location"]).
+	Categories []string
+
+	// Descriptor provides the full tool descriptor for advanced use cases.
+	Descriptor *tools.ToolDescriptor
+}
+
+// ClientToolHandler is a function that fulfills a client-side tool call.
+// It receives a context (carrying the tool timeout from ClientConfig.TimeoutMs)
+// and a [ClientToolRequest] with the invocation details.
+//
+// The return value should be JSON-serializable and will be sent back to the
+// LLM as the tool result.
+type ClientToolHandler func(ctx context.Context, req ClientToolRequest) (any, error)
+
+// OnClientTool registers a handler for a client-side tool.
+//
+// Client tools (mode: "client") are tools that must be fulfilled on the
+// caller's device — for example GPS, camera, or biometric sensors. The
+// handler is invoked synchronously when the LLM calls the tool.
+//
+// Example:
+//
+//	conv.OnClientTool("get_location", func(ctx context.Context, req sdk.ClientToolRequest) (any, error) {
+//	    coords, err := deviceGPS(ctx, req.Args["accuracy"].(string))
+//	    if err != nil {
+//	        return nil, err
+//	    }
+//	    return map[string]any{"lat": coords.Lat, "lng": coords.Lng}, nil
+//	})
+func (c *Conversation) OnClientTool(name string, handler ClientToolHandler) {
+	c.clientHandlersMu.Lock()
+	defer c.clientHandlersMu.Unlock()
+	if c.clientHandlers == nil {
+		c.clientHandlers = make(map[string]ClientToolHandler)
+	}
+	c.clientHandlers[name] = handler
+}
+
+// OnClientTools registers multiple client tool handlers at once.
+//
+//	conv.OnClientTools(map[string]sdk.ClientToolHandler{
+//	    "get_location": locationHandler,
+//	    "read_contacts": contactsHandler,
+//	})
+func (c *Conversation) OnClientTools(handlers map[string]ClientToolHandler) {
+	c.clientHandlersMu.Lock()
+	defer c.clientHandlersMu.Unlock()
+	if c.clientHandlers == nil {
+		c.clientHandlers = make(map[string]ClientToolHandler)
+	}
+	for name, handler := range handlers {
+		c.clientHandlers[name] = handler
+	}
+}
+
+// clientExecutor dispatches client-mode tool calls to registered
+// ClientToolHandler functions. It implements tools.Executor.
+type clientExecutor struct {
+	handlers   map[string]ClientToolHandler
+	handlersMu *clientHandlersMuAccessor
+}
+
+// clientHandlersMuAccessor provides read access to the conversation's
+// client handlers under its mutex. This avoids exposing the full
+// Conversation to the executor.
+type clientHandlersMuAccessor struct {
+	conv *Conversation
+}
+
+func (a *clientHandlersMuAccessor) getHandler(name string) (ClientToolHandler, bool) {
+	a.conv.clientHandlersMu.RLock()
+	defer a.conv.clientHandlersMu.RUnlock()
+	h, ok := a.conv.clientHandlers[name]
+	return h, ok
+}
+
+// Name returns "client" to match mode: "client" tools.
+func (e *clientExecutor) Name() string {
+	return "client"
+}
+
+// Execute dispatches to the registered ClientToolHandler for the tool.
+func (e *clientExecutor) Execute(
+	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
+	// Parse args
+	var argsMap map[string]any
+	if err := json.Unmarshal(args, &argsMap); err != nil {
+		return nil, fmt.Errorf("failed to parse client tool arguments: %w", err)
+	}
+
+	// Look up handler — first from snapshot, then live via mutex accessor
+	handler, ok := e.handlers[descriptor.Name]
+	if !ok && e.handlersMu != nil {
+		handler, ok = e.handlersMu.getHandler(descriptor.Name)
+	}
+	if !ok {
+		return nil, fmt.Errorf("no client handler registered for tool: %s", descriptor.Name)
+	}
+
+	// Build request
+	req := ClientToolRequest{
+		ToolName:   descriptor.Name,
+		Args:       argsMap,
+		Descriptor: descriptor,
+	}
+
+	// Populate consent fields from ClientConfig
+	if descriptor.ClientConfig != nil {
+		if descriptor.ClientConfig.Consent != nil {
+			req.ConsentMsg = descriptor.ClientConfig.Consent.Message
+		}
+		req.Categories = descriptor.ClientConfig.Categories
+	}
+
+	// Execute handler
+	result, err := handler(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Serialize result
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize client tool result: %w", err)
+	}
+
+	return resultJSON, nil
+}

--- a/sdk/client_tools_test.go
+++ b/sdk/client_tools_test.go
@@ -1,0 +1,206 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnClientTool_RegistersHandler(t *testing.T) {
+	conv := newTestConversation()
+
+	conv.OnClientTool("get_location", func(_ context.Context, req ClientToolRequest) (any, error) {
+		assert.Equal(t, "get_location", req.ToolName)
+		return map[string]any{"lat": 37.7749, "lng": -122.4194}, nil
+	})
+
+	conv.clientHandlersMu.RLock()
+	_, ok := conv.clientHandlers["get_location"]
+	conv.clientHandlersMu.RUnlock()
+	assert.True(t, ok, "handler should be registered")
+}
+
+func TestOnClientTools_RegistersMultiple(t *testing.T) {
+	conv := newTestConversation()
+
+	conv.OnClientTools(map[string]ClientToolHandler{
+		"get_location": func(_ context.Context, _ ClientToolRequest) (any, error) {
+			return nil, nil
+		},
+		"read_contacts": func(_ context.Context, _ ClientToolRequest) (any, error) {
+			return nil, nil
+		},
+	})
+
+	conv.clientHandlersMu.RLock()
+	assert.Len(t, conv.clientHandlers, 2)
+	conv.clientHandlersMu.RUnlock()
+}
+
+func TestClientExecutor_Name(t *testing.T) {
+	exec := &clientExecutor{}
+	assert.Equal(t, "client", exec.Name())
+}
+
+func TestClientExecutor_Execute(t *testing.T) {
+	conv := newTestConversation()
+
+	conv.OnClientTool("get_location", func(_ context.Context, req ClientToolRequest) (any, error) {
+		assert.Equal(t, "get_location", req.ToolName)
+		lat := req.Args["accuracy"]
+		return map[string]any{"lat": 37.7749, "accuracy": lat}, nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{
+		Name: "get_location",
+		Mode: "client",
+	}
+	args := json.RawMessage(`{"accuracy": "fine"}`)
+
+	result, err := exec.Execute(context.Background(), desc, args)
+	require.NoError(t, err)
+
+	var resultMap map[string]any
+	require.NoError(t, json.Unmarshal(result, &resultMap))
+	assert.Equal(t, 37.7749, resultMap["lat"])
+	assert.Equal(t, "fine", resultMap["accuracy"])
+}
+
+func TestClientExecutor_WithConsentInfo(t *testing.T) {
+	conv := newTestConversation()
+
+	var capturedReq ClientToolRequest
+	conv.OnClientTool("get_location", func(_ context.Context, req ClientToolRequest) (any, error) {
+		capturedReq = req
+		return map[string]any{"lat": 0.0}, nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{
+		Name: "get_location",
+		Mode: "client",
+		ClientConfig: &tools.ClientConfig{
+			Consent: &tools.ConsentConfig{
+				Required: true,
+				Message:  "Allow location access?",
+			},
+			Categories: []string{"location", "sensors"},
+		},
+	}
+
+	_, err := exec.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Allow location access?", capturedReq.ConsentMsg)
+	assert.Equal(t, []string{"location", "sensors"}, capturedReq.Categories)
+	assert.NotNil(t, capturedReq.Descriptor)
+}
+
+func TestClientExecutor_NoHandler(t *testing.T) {
+	exec := &clientExecutor{
+		handlers: make(map[string]ClientToolHandler),
+	}
+
+	desc := &tools.ToolDescriptor{
+		Name: "unknown_tool",
+		Mode: "client",
+	}
+
+	_, err := exec.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no client handler registered")
+}
+
+func TestClientExecutor_InvalidArgs(t *testing.T) {
+	conv := newTestConversation()
+	conv.OnClientTool("test", func(_ context.Context, _ ClientToolRequest) (any, error) {
+		return nil, nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{Name: "test", Mode: "client"}
+	_, err := exec.Execute(context.Background(), desc, json.RawMessage(`{invalid`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse client tool arguments")
+}
+
+func TestClientExecutor_HandlerError(t *testing.T) {
+	conv := newTestConversation()
+	conv.OnClientTool("failing", func(_ context.Context, _ ClientToolRequest) (any, error) {
+		return nil, assert.AnError
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{Name: "failing", Mode: "client"}
+	_, err := exec.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.Equal(t, assert.AnError, err)
+}
+
+func TestClientExecutor_NoClientConfig(t *testing.T) {
+	conv := newTestConversation()
+
+	var capturedReq ClientToolRequest
+	conv.OnClientTool("simple", func(_ context.Context, req ClientToolRequest) (any, error) {
+		capturedReq = req
+		return "ok", nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	// No ClientConfig at all
+	desc := &tools.ToolDescriptor{Name: "simple", Mode: "client"}
+	_, err := exec.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	assert.Empty(t, capturedReq.ConsentMsg)
+	assert.Nil(t, capturedReq.Categories)
+}
+
+func TestClientExecutor_LateRegistration(t *testing.T) {
+	// Test that handlers registered after executor creation are found
+	// via the mutex accessor
+	conv := newTestConversation()
+
+	exec := &clientExecutor{
+		handlers:   make(map[string]ClientToolHandler), // Empty snapshot
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	// Register handler after executor is created
+	conv.OnClientTool("late_tool", func(_ context.Context, _ ClientToolRequest) (any, error) {
+		return "found", nil
+	})
+
+	desc := &tools.ToolDescriptor{Name: "late_tool", Mode: "client"}
+	result, err := exec.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	var val string
+	require.NoError(t, json.Unmarshal(result, &val))
+	assert.Equal(t, "found", val)
+}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -123,6 +123,10 @@ type Conversation struct {
 	ctxHandlers map[string]ToolHandlerCtx
 	handlersMu  sync.RWMutex
 
+	// Client tool handlers (mode: "client")
+	clientHandlers   map[string]ClientToolHandler
+	clientHandlersMu sync.RWMutex
+
 	// Async tool handlers for HITL
 	asyncHandlers   map[string]sdktools.AsyncToolHandler
 	asyncHandlersMu sync.RWMutex
@@ -285,6 +289,16 @@ func (c *Conversation) buildPipelineConfig(
 	c.handlersMu.RLock()
 	localExec := &localExecutor{handlers: c.handlers, ctxHandlers: c.ctxHandlers}
 	c.toolRegistry.RegisterExecutor(localExec)
+
+	// Register client executor for mode: "client" tools
+	c.clientHandlersMu.RLock()
+	clientExec := &clientExecutor{
+		handlers:   c.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: c},
+	}
+	c.clientHandlersMu.RUnlock()
+	c.toolRegistry.RegisterExecutor(clientExec)
+
 	c.registerMCPExecutors()
 	// Register capability tools (includes A2A)
 	for _, cap := range c.capabilities {
@@ -707,6 +721,14 @@ func (c *Conversation) Fork() *Conversation {
 	}
 	c.asyncHandlersMu.RUnlock()
 
+	c.clientHandlersMu.RLock()
+	// Copy client handlers
+	clientHandlers := make(map[string]ClientToolHandler, len(c.clientHandlers))
+	for k, v := range c.clientHandlers {
+		clientHandlers[k] = v
+	}
+	c.clientHandlersMu.RUnlock()
+
 	// Create fork with new ID
 	sess := c.getBaseSession()
 	forkID := sess.ID() + "-fork"
@@ -736,6 +758,7 @@ func (c *Conversation) Fork() *Conversation {
 		config:         c.config,
 		mode:           c.mode,
 		handlers:       handlers,
+		clientHandlers: clientHandlers,
 		asyncHandlers:  asyncHandlers,
 		pendingStore:   sdktools.NewPendingStore(),
 		resolvedStore:  sdktools.NewResolvedStore(),


### PR DESCRIPTION
## Summary
- Adds `ClientToolRequest` struct and `ClientToolHandler` type for client-side tool invocations
- Adds `OnClientTool()` and `OnClientTools()` methods on `Conversation` for registering handlers
- Implements `clientExecutor` (tools.Executor) that dispatches to registered handlers with consent info
- Updates `getExecutorForTool` in the registry to prefer a registered `"client"` executor over mock fallback
- Copies client handlers in `Fork()` for conversation branching

Closes #596

## Test plan
- [x] `TestOnClientTool_RegistersHandler` — single handler registration
- [x] `TestOnClientTools_RegistersMultiple` — batch registration
- [x] `TestClientExecutor_Execute` — basic execution with args
- [x] `TestClientExecutor_WithConsentInfo` — consent message and categories propagation
- [x] `TestClientExecutor_NoHandler` — error for missing handler
- [x] `TestClientExecutor_InvalidArgs` — error for malformed JSON args
- [x] `TestClientExecutor_HandlerError` — handler error propagation
- [x] `TestClientExecutor_NoClientConfig` — tools without ClientConfig
- [x] `TestClientExecutor_LateRegistration` — handlers registered after executor creation
- [x] `TestGetExecutorForTool_ClientModePreference` — "client" executor takes priority
- [x] `TestGetExecutorForTool_ClientModeFallsBackToMock` — mock fallback when no client executor