### PR TITLE
feat(sdk): pipeline suspension and deferred client tool mode

### DIFF
--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -184,6 +184,25 @@ func (s *ProviderStage) executeAndEmit(
 	}
 
 	if err != nil {
+		// If tools are pending, emit collected messages and propagate pending
+		// info as metadata so the SDK can surface them to the caller.
+		if ep, ok := tools.IsErrToolsPending(err); ok {
+			if emitErr := s.emitResponseMessages(ctx, responseMessages, acc.metadata, output); emitErr != nil {
+				return emitErr
+			}
+			// Send a marker element with pending tool info in metadata
+			pendingElem := StreamElement{
+				Metadata: map[string]interface{}{
+					"pending_tools": ep.Pending,
+				},
+			}
+			select {
+			case output <- pendingElem:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			return nil
+		}
 		output <- NewErrorElement(err)
 		return err
 	}
@@ -242,6 +261,11 @@ func (s *ProviderStage) executeMultiRound(
 
 		toolResults, err := s.executeToolCalls(ctx, response.ToolCalls)
 		if err != nil {
+			// If tools are pending, append completed results and propagate
+			if _, ok := tools.IsErrToolsPending(err); ok {
+				messages = append(messages, toolResults...)
+				return messages, err
+			}
 			return messages, fmt.Errorf("provider stage: tool execution failed: %w", err)
 		}
 
@@ -299,6 +323,11 @@ func (s *ProviderStage) executeStreamingMultiRound(
 
 		toolResults, err := s.executeToolCalls(ctx, response.ToolCalls)
 		if err != nil {
+			// If tools are pending, append completed results and propagate
+			if _, ok := tools.IsErrToolsPending(err); ok {
+				messages = append(messages, toolResults...)
+				return messages, err
+			}
 			return messages, fmt.Errorf("provider stage: tool execution failed: %w", err)
 		}
 
@@ -742,6 +771,7 @@ func (s *ProviderStage) executeToolCalls(
 	}
 
 	results := make([]types.Message, 0, len(toolCalls))
+	var pendingTools []tools.PendingToolExecution
 
 	for _, toolCall := range toolCalls {
 		// Check if tool is blocked by policy
@@ -789,6 +819,23 @@ func (s *ProviderStage) executeToolCalls(
 			continue
 		}
 
+		// Check for pending status — collect for pipeline suspension
+		if asyncResult.Status == tools.ToolStatusPending {
+			var argsMap map[string]any
+			if toolCall.Args != nil {
+				_ = json.Unmarshal(toolCall.Args, &argsMap)
+			}
+			toolResult := s.handleToolResult(toolCall, asyncResult)
+			pendingTools = append(pendingTools, tools.PendingToolExecution{
+				CallID:      toolCall.ID,
+				ToolName:    toolCall.Name,
+				Args:        argsMap,
+				PendingInfo: asyncResult.PendingInfo,
+				ToolResult:  toolResult,
+			})
+			continue
+		}
+
 		// Convert tool execution result to message
 		result := s.handleToolResult(toolCall, asyncResult)
 		results = append(results, types.NewToolResultMessage(result))
@@ -809,6 +856,10 @@ func (s *ProviderStage) executeToolCalls(
 			}
 			s.hookRegistry.RunAfterToolExecution(ctx, toolReq, toolResp)
 		}
+	}
+
+	if len(pendingTools) > 0 {
+		return results, &tools.ErrToolsPending{Pending: pendingTools}
 	}
 
 	return results, nil

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -1228,11 +1228,17 @@ func TestProviderStage_ExecuteToolCalls_Pending(t *testing.T) {
 
 	results, err := stage.executeToolCalls(context.Background(), toolCalls)
 
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "tool", results[0].Role)
-	assert.Contains(t, results[0].ToolResult.Content, "requires")
-	assert.Empty(t, results[0].ToolResult.Error)
+	// Pending tools now return ErrToolsPending
+	require.Error(t, err)
+	ep, ok := tools.IsErrToolsPending(err)
+	require.True(t, ok, "error should be *ErrToolsPending")
+	require.Len(t, ep.Pending, 1)
+	assert.Equal(t, "call-1", ep.Pending[0].CallID)
+	assert.Equal(t, "pending_tool", ep.Pending[0].ToolName)
+	assert.Contains(t, ep.Pending[0].ToolResult.Content, "requires")
+
+	// No completed results since only tool was pending
+	assert.Empty(t, results)
 }
 
 func TestProviderStage_ExecuteToolCalls_Failed(t *testing.T) {
@@ -1586,4 +1592,52 @@ func TestProviderStage_EmitsBothStartAndCompletedEvents(t *testing.T) {
 	assert.Len(t, receivedTypes, 2, "should receive both Started and Completed events")
 	assert.Contains(t, receivedTypes, events.EventProviderCallStarted)
 	assert.Contains(t, receivedTypes, events.EventProviderCallCompleted)
+}
+
+func TestProviderStage_ExecuteToolCalls_PendingSuspends(t *testing.T) {
+	// When a tool returns ToolStatusPending, executeToolCalls should return
+	// an ErrToolsPending error alongside completed tool results.
+	registry := tools.NewRegistry()
+	_ = registry.Register(&tools.ToolDescriptor{
+		Name:        "normal_tool",
+		Description: "A normal tool",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Mode:        "mock",
+		MockResult:  json.RawMessage(`"ok"`),
+	})
+	_ = registry.Register(&tools.ToolDescriptor{
+		Name:        "pending_tool",
+		Description: "A pending tool",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Mode:        "client",
+	})
+
+	// Register an async executor that returns pending for client tools
+	pendingExec := &mockAsyncExecutor{
+		name:       "client",
+		status:     tools.ToolStatusPending,
+		pendingMsg: "awaiting caller",
+	}
+	registry.RegisterExecutor(pendingExec)
+
+	provider := mock.NewProvider("test", "model", false)
+	s := NewProviderStage(provider, registry, nil, nil)
+
+	toolCalls := []types.MessageToolCall{
+		{ID: "call-1", Name: "normal_tool", Args: json.RawMessage(`{}`)},
+		{ID: "call-2", Name: "pending_tool", Args: json.RawMessage(`{}`)},
+	}
+
+	results, err := s.executeToolCalls(context.Background(), toolCalls)
+
+	// Should return ErrToolsPending
+	require.Error(t, err)
+	ep, ok := tools.IsErrToolsPending(err)
+	require.True(t, ok, "error should be *ErrToolsPending")
+	require.Len(t, ep.Pending, 1)
+	assert.Equal(t, "call-2", ep.Pending[0].CallID)
+	assert.Equal(t, "pending_tool", ep.Pending[0].ToolName)
+
+	// Completed results should still be returned
+	require.Len(t, results, 1, "completed tool results should be returned")
 }

--- a/runtime/pipeline/types.go
+++ b/runtime/pipeline/types.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -133,9 +134,10 @@ type Response struct {
 
 // ExecutionResult is the output of a pipeline execution.
 type ExecutionResult struct {
-	Messages []types.Message        `json:"messages"`  // All messages including history and responses
-	Response *Response              `json:"response"`  // The final response
-	Trace    ExecutionTrace         `json:"trace"`     // Complete execution trace with all LLM calls
-	CostInfo types.CostInfo         `json:"cost_info"` // Aggregate cost across all LLM calls
-	Metadata map[string]interface{} `json:"metadata"`  // Metadata populated by stages
+	Messages     []types.Message              `json:"messages"`
+	Response     *Response                    `json:"response"`
+	Trace        ExecutionTrace               `json:"trace"`
+	CostInfo     types.CostInfo               `json:"cost_info"`
+	Metadata     map[string]interface{}       `json:"metadata"`
+	PendingTools []tools.PendingToolExecution `json:"pending_tools,omitempty"`
 }

--- a/runtime/tools/errors.go
+++ b/runtime/tools/errors.go
@@ -1,6 +1,12 @@
 package tools
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
 
 // Sentinel errors for tool operations.
 var (
@@ -28,3 +34,37 @@ var (
 	// ErrMCPExecutorOnly is returned when a non-mcp tool is passed to an MCP executor.
 	ErrMCPExecutorOnly = errors.New("MCP executor can only execute mcp tools")
 )
+
+// PendingToolExecution captures a single tool call that returned ToolStatusPending.
+type PendingToolExecution struct {
+	CallID      string                  `json:"call_id"`
+	ToolName    string                  `json:"tool_name"`
+	Args        map[string]any          `json:"args"`
+	PendingInfo *PendingToolInfo        `json:"pending_info,omitempty"`
+	ToolResult  types.MessageToolResult `json:"tool_result"`
+}
+
+// ErrToolsPending is returned by executeToolCalls when one or more tool calls
+// returned ToolStatusPending. The pipeline should suspend: completed tool
+// results are still returned alongside this error so they can be appended to
+// the message history.
+type ErrToolsPending struct {
+	Pending []PendingToolExecution
+}
+
+func (e *ErrToolsPending) Error() string {
+	names := make([]string, len(e.Pending))
+	for i, p := range e.Pending {
+		names[i] = p.ToolName
+	}
+	return fmt.Sprintf("tools pending: %s", strings.Join(names, ", "))
+}
+
+// IsErrToolsPending checks whether err is or wraps an *ErrToolsPending.
+func IsErrToolsPending(err error) (*ErrToolsPending, bool) {
+	var ep *ErrToolsPending
+	if errors.As(err, &ep) {
+		return ep, true
+	}
+	return nil, false
+}

--- a/runtime/tools/errors_test.go
+++ b/runtime/tools/errors_test.go
@@ -1,0 +1,71 @@
+package tools
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrToolsPending_Error(t *testing.T) {
+	t.Run("single pending tool", func(t *testing.T) {
+		err := &ErrToolsPending{
+			Pending: []PendingToolExecution{
+				{ToolName: "get_location"},
+			},
+		}
+		assert.Equal(t, "tools pending: get_location", err.Error())
+	})
+
+	t.Run("multiple pending tools", func(t *testing.T) {
+		err := &ErrToolsPending{
+			Pending: []PendingToolExecution{
+				{ToolName: "get_location"},
+				{ToolName: "read_contacts"},
+			},
+		}
+		assert.Equal(t, "tools pending: get_location, read_contacts", err.Error())
+	})
+
+	t.Run("no pending tools", func(t *testing.T) {
+		err := &ErrToolsPending{}
+		assert.Equal(t, "tools pending: ", err.Error())
+	})
+}
+
+func TestIsErrToolsPending(t *testing.T) {
+	t.Run("matches ErrToolsPending", func(t *testing.T) {
+		original := &ErrToolsPending{
+			Pending: []PendingToolExecution{
+				{CallID: "c1", ToolName: "get_location"},
+			},
+		}
+		ep, ok := IsErrToolsPending(original)
+		require.True(t, ok)
+		assert.Len(t, ep.Pending, 1)
+		assert.Equal(t, "get_location", ep.Pending[0].ToolName)
+	})
+
+	t.Run("matches wrapped ErrToolsPending", func(t *testing.T) {
+		original := &ErrToolsPending{
+			Pending: []PendingToolExecution{{ToolName: "tool_a"}},
+		}
+		wrapped := fmt.Errorf("outer: %w", original)
+		ep, ok := IsErrToolsPending(wrapped)
+		require.True(t, ok)
+		assert.Equal(t, "tool_a", ep.Pending[0].ToolName)
+	})
+
+	t.Run("does not match other errors", func(t *testing.T) {
+		ep, ok := IsErrToolsPending(fmt.Errorf("some other error"))
+		assert.False(t, ok)
+		assert.Nil(t, ep)
+	})
+
+	t.Run("does not match nil", func(t *testing.T) {
+		ep, ok := IsErrToolsPending(nil)
+		assert.False(t, ok)
+		assert.Nil(t, ep)
+	})
+}

--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
 )
 
 // ClientToolRequest contains information about a client-side tool invocation.
@@ -31,7 +34,7 @@ type ClientToolRequest struct {
 	Descriptor *tools.ToolDescriptor
 }
 
-// ClientToolHandler is a function that fulfills a client-side tool call.
+// ClientToolHandler is a function that fulfillls a client-side tool call.
 // It receives a context (carrying the tool timeout from ClientConfig.TimeoutMs)
 // and a [ClientToolRequest] with the invocation details.
 //
@@ -41,7 +44,7 @@ type ClientToolHandler func(ctx context.Context, req ClientToolRequest) (any, er
 
 // OnClientTool registers a handler for a client-side tool.
 //
-// Client tools (mode: "client") are tools that must be fulfilled on the
+// Client tools (mode: "client") are tools that must be fulfillled on the
 // caller's device — for example GPS, camera, or biometric sensors. The
 // handler is invoked synchronously when the LLM calls the tool.
 //
@@ -107,6 +110,7 @@ func (e *clientExecutor) Name() string {
 }
 
 // Execute dispatches to the registered ClientToolHandler for the tool.
+// Returns an error if no handler is registered (sync fallback path).
 func (e *clientExecutor) Execute(
 	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
 ) (json.RawMessage, error) {
@@ -125,7 +129,144 @@ func (e *clientExecutor) Execute(
 		return nil, fmt.Errorf("no client handler registered for tool: %s", descriptor.Name)
 	}
 
-	// Build request
+	return e.executeHandler(ctx, handler, descriptor, argsMap)
+}
+
+// ExecuteAsync checks for a registered handler. If one exists it executes
+// synchronously and returns ToolStatusComplete. If no handler is registered
+// the tool is deferred: a ToolStatusPending result is returned so the
+// pipeline suspends and the caller can fulfill the tool via SendToolResult.
+func (e *clientExecutor) ExecuteAsync(
+	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (*tools.ToolExecutionResult, error) {
+	// Parse args
+	var argsMap map[string]any
+	if err := json.Unmarshal(args, &argsMap); err != nil {
+		return nil, fmt.Errorf("failed to parse client tool arguments: %w", err)
+	}
+
+	// Look up handler — first from snapshot, then live via mutex accessor
+	handler, ok := e.handlers[descriptor.Name]
+	if !ok && e.handlersMu != nil {
+		handler, ok = e.handlersMu.getHandler(descriptor.Name)
+	}
+
+	// No handler → deferred mode: return Pending
+	if !ok {
+		info := &tools.PendingToolInfo{
+			Reason:   "client_tool_deferred",
+			Message:  fmt.Sprintf("Client tool %q awaiting caller fulfillment", descriptor.Name),
+			ToolName: descriptor.Name,
+			Args:     args,
+		}
+		if descriptor.ClientConfig != nil {
+			if descriptor.ClientConfig.Consent != nil {
+				info.Message = descriptor.ClientConfig.Consent.Message
+			}
+			info.Metadata = map[string]any{
+				"categories": descriptor.ClientConfig.Categories,
+			}
+		}
+		return &tools.ToolExecutionResult{
+			Status:      tools.ToolStatusPending,
+			PendingInfo: info,
+		}, nil
+	}
+
+	// Handler present → execute synchronously
+	resultJSON, err := e.executeHandler(ctx, handler, descriptor, argsMap)
+	if err != nil {
+		return nil, err
+	}
+	return &tools.ToolExecutionResult{
+		Status:  tools.ToolStatusComplete,
+		Content: resultJSON,
+	}, nil
+}
+
+// SendToolResult provides the result for a deferred client tool.
+//
+// callID must match one of the [PendingClientTool.CallID] values returned in
+// the [Response]. result should be JSON-serializable.
+//
+// After all pending tools have been resolved (via SendToolResult or
+// RejectClientTool), call [Conversation.Resume] to continue the pipeline.
+func (c *Conversation) SendToolResult(_ context.Context, callID string, result any) error {
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to serialize client tool result: %w", err)
+	}
+	c.resolvedStore.Add(&sdktools.ToolResolution{
+		ID:         callID,
+		ResultJSON: resultJSON,
+	})
+	return nil
+}
+
+// RejectClientTool rejects a deferred client tool with a human-readable reason.
+//
+// callID must match one of the [PendingClientTool.CallID] values returned in
+// the [Response]. The rejection reason is sent to the LLM as the tool result.
+func (c *Conversation) RejectClientTool(_ context.Context, callID, reason string) {
+	c.resolvedStore.Add(&sdktools.ToolResolution{
+		ID:              callID,
+		Rejected:        true,
+		RejectionReason: reason,
+	})
+}
+
+// Resume continues pipeline execution after all deferred client tools have
+// been resolved via [Conversation.SendToolResult] or [Conversation.RejectClientTool].
+//
+// The resolved tool results are injected as tool-result messages and a new
+// LLM round is triggered. The returned Response contains the assistant's reply.
+func (c *Conversation) Resume(ctx context.Context) (*Response, error) {
+	startTime := time.Now()
+
+	if err := c.validateSendState(); err != nil {
+		return nil, err
+	}
+
+	// Pop all resolved tool results
+	resolutions := c.resolvedStore.PopAll()
+	if len(resolutions) == 0 {
+		return nil, fmt.Errorf("no resolved tool results to resume with")
+	}
+
+	// Build tool result messages from resolutions
+	var toolMsgs []types.Message
+	for _, res := range resolutions {
+		var content string
+		if res.Rejected {
+			content = fmt.Sprintf("Tool rejected: %s", res.RejectionReason)
+		} else if res.Error != nil {
+			content = fmt.Sprintf("Tool error: %v", res.Error)
+		} else {
+			content = string(res.ResultJSON)
+		}
+		toolMsgs = append(toolMsgs, types.NewToolResultMessage(types.MessageToolResult{
+			ID:      res.ID,
+			Content: content,
+		}))
+	}
+
+	// Inject tool results into session history and re-execute
+	result, err := c.unarySession.ResumeWithToolResults(ctx, toolMsgs)
+	if err != nil {
+		return nil, fmt.Errorf("resume failed: %w", err)
+	}
+
+	resp := c.buildResponse(result, startTime)
+	c.sessionHooks.IncrementTurn()
+	c.sessionHooks.SessionUpdate(ctx)
+	return resp, nil
+}
+
+// executeHandler runs a ClientToolHandler and returns serialized JSON.
+func (e *clientExecutor) executeHandler(
+	ctx context.Context, handler ClientToolHandler,
+	descriptor *tools.ToolDescriptor, argsMap map[string]any,
+) (json.RawMessage, error) {
 	req := ClientToolRequest{
 		ToolName:   descriptor.Name,
 		Args:       argsMap,

--- a/sdk/client_tools_test.go
+++ b/sdk/client_tools_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
+	rtpipeline "github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -203,4 +207,278 @@ func TestClientExecutor_LateRegistration(t *testing.T) {
 	var val string
 	require.NoError(t, json.Unmarshal(result, &val))
 	assert.Equal(t, "found", val)
+}
+
+// --- Phase 3: Deferred mode tests ---
+
+func TestClientExecutor_DeferredMode_NoPendingWhenHandlerExists(t *testing.T) {
+	conv := newTestConversation()
+	conv.OnClientTool("get_location", func(_ context.Context, _ ClientToolRequest) (any, error) {
+		return map[string]any{"lat": 1.0}, nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{Name: "get_location", Mode: "client"}
+	result, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, tools.ToolStatusComplete, result.Status)
+	assert.NotEmpty(t, result.Content)
+	assert.Nil(t, result.PendingInfo)
+}
+
+func TestClientExecutor_DeferredMode_PendingWhenNoHandler(t *testing.T) {
+	exec := &clientExecutor{
+		handlers: make(map[string]ClientToolHandler),
+	}
+
+	desc := &tools.ToolDescriptor{
+		Name: "get_location",
+		Mode: "client",
+		ClientConfig: &tools.ClientConfig{
+			Consent: &tools.ConsentConfig{
+				Required: true,
+				Message:  "Allow location?",
+			},
+			Categories: []string{"location"},
+		},
+	}
+
+	result, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{"accuracy":"fine"}`))
+	require.NoError(t, err)
+	assert.Equal(t, tools.ToolStatusPending, result.Status)
+	require.NotNil(t, result.PendingInfo)
+	assert.Equal(t, "client_tool_deferred", result.PendingInfo.Reason)
+	assert.Equal(t, "Allow location?", result.PendingInfo.Message)
+	assert.Equal(t, "get_location", result.PendingInfo.ToolName)
+	assert.NotEmpty(t, result.PendingInfo.Args)
+}
+
+func TestClientExecutor_DeferredMode_PendingNoClientConfig(t *testing.T) {
+	exec := &clientExecutor{
+		handlers: make(map[string]ClientToolHandler),
+	}
+
+	desc := &tools.ToolDescriptor{Name: "simple_tool", Mode: "client"}
+	result, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, tools.ToolStatusPending, result.Status)
+	require.NotNil(t, result.PendingInfo)
+	assert.Contains(t, result.PendingInfo.Message, "simple_tool")
+}
+
+func TestClientExecutor_DeferredMode_InvalidArgs(t *testing.T) {
+	exec := &clientExecutor{
+		handlers: make(map[string]ClientToolHandler),
+	}
+
+	desc := &tools.ToolDescriptor{Name: "test", Mode: "client"}
+	_, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{invalid`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse client tool arguments")
+}
+
+func TestPendingClientTool_ResponseMethods(t *testing.T) {
+	t.Run("no pending client tools", func(t *testing.T) {
+		resp := &Response{}
+		assert.False(t, resp.HasPendingClientTools())
+		assert.Empty(t, resp.ClientTools())
+	})
+
+	t.Run("with pending client tools", func(t *testing.T) {
+		resp := &Response{
+			clientTools: []PendingClientTool{
+				{CallID: "call-1", ToolName: "get_location", Args: map[string]any{"accuracy": "fine"}},
+				{CallID: "call-2", ToolName: "read_contacts"},
+			},
+		}
+		assert.True(t, resp.HasPendingClientTools())
+		assert.Len(t, resp.ClientTools(), 2)
+		assert.Equal(t, "call-1", resp.ClientTools()[0].CallID)
+		assert.Equal(t, "read_contacts", resp.ClientTools()[1].ToolName)
+	})
+}
+
+func TestBuildResponse_PopulatesPendingClientTools(t *testing.T) {
+	conv := newTestConversation()
+
+	result := &rtpipeline.ExecutionResult{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "I need your location"},
+		},
+		Response: &rtpipeline.Response{
+			Role:    "assistant",
+			Content: "I need your location",
+		},
+		Metadata: make(map[string]any),
+		PendingTools: []tools.PendingToolExecution{
+			{
+				CallID:   "call-1",
+				ToolName: "get_location",
+				Args:     map[string]any{"accuracy": "fine"},
+				PendingInfo: &tools.PendingToolInfo{
+					Reason:  "client_tool_deferred",
+					Message: "Allow location?",
+					Metadata: map[string]any{
+						"categories": []string{"location"},
+					},
+				},
+			},
+		},
+	}
+
+	resp := conv.buildResponse(result, time.Now())
+	require.True(t, resp.HasPendingClientTools())
+	require.Len(t, resp.ClientTools(), 1)
+
+	ct := resp.ClientTools()[0]
+	assert.Equal(t, "call-1", ct.CallID)
+	assert.Equal(t, "get_location", ct.ToolName)
+	assert.Equal(t, map[string]any{"accuracy": "fine"}, ct.Args)
+	assert.Equal(t, "Allow location?", ct.ConsentMsg)
+	assert.Equal(t, []string{"location"}, ct.Categories)
+}
+
+func TestSendToolResult(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	err := conv.SendToolResult(context.Background(), "call-1", map[string]any{"lat": 37.7})
+	require.NoError(t, err)
+
+	resolutions := conv.resolvedStore.PopAll()
+	require.Len(t, resolutions, 1)
+	assert.Equal(t, "call-1", resolutions[0].ID)
+	assert.False(t, resolutions[0].Rejected)
+	assert.NotEmpty(t, resolutions[0].ResultJSON)
+
+	var resultMap map[string]any
+	require.NoError(t, json.Unmarshal(resolutions[0].ResultJSON, &resultMap))
+	assert.Equal(t, 37.7, resultMap["lat"])
+}
+
+func TestSendToolResult_InvalidJSON(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	// Functions can't be JSON-serialized
+	err := conv.SendToolResult(context.Background(), "call-1", func() {})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to serialize")
+}
+
+func TestRejectClientTool(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	conv.RejectClientTool(context.Background(), "call-2", "user declined")
+
+	resolutions := conv.resolvedStore.PopAll()
+	require.Len(t, resolutions, 1)
+	assert.Equal(t, "call-2", resolutions[0].ID)
+	assert.True(t, resolutions[0].Rejected)
+	assert.Equal(t, "user declined", resolutions[0].RejectionReason)
+}
+
+func TestResume_NoResolutions(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	_, err := conv.Resume(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no resolved tool results")
+}
+
+func TestClientExecutor_ExecuteAsync_HandlerError(t *testing.T) {
+	conv := newTestConversation()
+	conv.OnClientTool("failing", func(_ context.Context, _ ClientToolRequest) (any, error) {
+		return nil, assert.AnError
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{Name: "failing", Mode: "client"}
+	_, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.Equal(t, assert.AnError, err)
+}
+
+func TestClientExecutor_ExecuteAsync_LateRegistration(t *testing.T) {
+	conv := newTestConversation()
+
+	exec := &clientExecutor{
+		handlers:   make(map[string]ClientToolHandler),
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	// Register handler after executor is created
+	conv.OnClientTool("late_tool", func(_ context.Context, _ ClientToolRequest) (any, error) {
+		return "found_async", nil
+	})
+
+	desc := &tools.ToolDescriptor{Name: "late_tool", Mode: "client"}
+	result, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, tools.ToolStatusComplete, result.Status)
+
+	var val string
+	require.NoError(t, json.Unmarshal(result.Content, &val))
+	assert.Equal(t, "found_async", val)
+}
+
+func TestClientExecutor_ExecuteAsync_WithConsent(t *testing.T) {
+	conv := newTestConversation()
+
+	var capturedReq ClientToolRequest
+	conv.OnClientTool("sensor", func(_ context.Context, req ClientToolRequest) (any, error) {
+		capturedReq = req
+		return "ok", nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{
+		Name: "sensor",
+		Mode: "client",
+		ClientConfig: &tools.ClientConfig{
+			Consent: &tools.ConsentConfig{
+				Required: true,
+				Message:  "Allow sensor access?",
+			},
+			Categories: []string{"sensors"},
+		},
+	}
+
+	result, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{"type":"gyro"}`))
+	require.NoError(t, err)
+	assert.Equal(t, tools.ToolStatusComplete, result.Status)
+	assert.Equal(t, "Allow sensor access?", capturedReq.ConsentMsg)
+	assert.Equal(t, []string{"sensors"}, capturedReq.Categories)
+}
+
+func TestResume_BuildsToolMessages(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	// Add a rejected resolution to cover that branch
+	conv.RejectClientTool(context.Background(), "call-reject", "user declined")
+
+	// Add a successful resolution
+	err := conv.SendToolResult(context.Background(), "call-ok", map[string]any{"data": "result"})
+	require.NoError(t, err)
+
+	// Resume sends tool result messages through the pipeline.
+	// The mock pipeline processes them and returns a response.
+	resp, err := conv.Resume(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
 }

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -456,6 +456,24 @@ func (c *Conversation) buildResponse(result *rtpipeline.ExecutionResult, startTi
 		}
 	}
 
+	// Populate pending client tools from pipeline result
+	for _, pt := range result.PendingTools {
+		pct := PendingClientTool{
+			CallID:   pt.CallID,
+			ToolName: pt.ToolName,
+			Args:     pt.Args,
+		}
+		if pt.PendingInfo != nil {
+			pct.ConsentMsg = pt.PendingInfo.Message
+			if cats, ok := pt.PendingInfo.Metadata["categories"]; ok {
+				if catSlice, ok := cats.([]string); ok {
+					pct.Categories = catSlice
+				}
+			}
+		}
+		resp.clientTools = append(resp.clientTools, pct)
+	}
+
 	return resp
 }
 

--- a/sdk/response.go
+++ b/sdk/response.go
@@ -42,6 +42,9 @@ type Response struct {
 
 	// HITL state - tools awaiting approval
 	pendingTools []PendingTool
+
+	// Client tools awaiting caller fulfillment (deferred mode)
+	clientTools []PendingClientTool
 }
 
 // Text returns the text content of the response.
@@ -166,4 +169,42 @@ type PendingTool struct {
 
 	// Human-readable message about why approval is needed
 	Message string
+}
+
+// ClientTools returns client tools awaiting fulfillment by the caller.
+//
+// When no [Conversation.OnClientTool] handler is registered for a tool,
+// the pipeline suspends and the pending client tools are returned here.
+// The caller should fulfillthem via [Conversation.SendToolResult] or
+// [Conversation.RejectClientTool], then call [Conversation.Resume].
+func (r *Response) ClientTools() []PendingClientTool {
+	return r.clientTools
+}
+
+// HasPendingClientTools returns true if the response contains client tools
+// that the caller must fulfillbefore the conversation can continue.
+func (r *Response) HasPendingClientTools() bool {
+	return len(r.clientTools) > 0
+}
+
+// PendingClientTool represents a client-mode tool call that was deferred
+// because no OnClientTool handler was registered. The caller must supply a
+// result via [Conversation.SendToolResult] or reject it via
+// [Conversation.RejectClientTool] and then call [Conversation.Resume].
+type PendingClientTool struct {
+	// CallID is the provider-assigned ID for this tool invocation.
+	CallID string
+
+	// ToolName is the tool's name as defined in the pack.
+	ToolName string
+
+	// Args contains the parsed arguments from the LLM.
+	Args map[string]any
+
+	// ConsentMsg is the human-readable consent message from the pack's
+	// client.consent.message field. Empty when no consent is configured.
+	ConsentMsg string
+
+	// Categories are the semantic consent categories (e.g., ["location"]).
+	Categories []string
 }

--- a/sdk/session/session.go
+++ b/sdk/session/session.go
@@ -35,6 +35,10 @@ type UnarySession interface {
 	ExecuteStream(ctx context.Context, role, content string) (<-chan providers.StreamChunk, error)
 	ExecuteStreamWithMessage(ctx context.Context, message types.Message) (<-chan providers.StreamChunk, error)
 
+	// ResumeWithToolResults injects tool result messages into the session
+	// history and re-executes the pipeline so the LLM can continue.
+	ResumeWithToolResults(ctx context.Context, toolResults []types.Message) (*pipeline.ExecutionResult, error)
+
 	// ForkSession creates a new session that is a fork of this one.
 	// The new session will have an independent copy of the conversation state.
 	ForkSession(ctx context.Context, forkID string, pipeline *stage.StreamPipeline) (UnarySession, error)

--- a/sdk/session/unary_session.go
+++ b/sdk/session/unary_session.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -110,6 +111,31 @@ func (s *unarySession) ExecuteWithMessage(
 	}
 
 	// Convert stage.ExecutionResult to pipeline.ExecutionResult
+	return convertExecutionResult(result), nil
+}
+
+// ResumeWithToolResults injects tool result messages and re-executes the pipeline.
+func (s *unarySession) ResumeWithToolResults(
+	ctx context.Context,
+	toolResults []types.Message,
+) (*pipeline.ExecutionResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Build input elements: one per tool result message
+	inputElems := make([]stage.StreamElement, 0, len(toolResults))
+	for i := range toolResults {
+		inputElems = append(inputElems, stage.StreamElement{
+			Message:  &toolResults[i],
+			Metadata: map[string]interface{}{"variables": s.variables},
+		})
+	}
+
+	result, err := s.pipeline.ExecuteSync(ctx, inputElems...)
+	if err != nil {
+		return nil, err
+	}
+
 	return convertExecutionResult(result), nil
 }
 
@@ -268,6 +294,13 @@ func convertExecutionResult(result *stage.ExecutionResult) *pipeline.ExecutionRe
 			Content:   result.Response.Content,
 			Parts:     result.Response.Parts,
 			ToolCalls: result.Response.ToolCalls,
+		}
+	}
+
+	// Propagate pending tools from stage metadata
+	if pt, ok := result.Metadata["pending_tools"]; ok {
+		if pending, ok := pt.([]tools.PendingToolExecution); ok {
+			pipelineResult.PendingTools = pending
 		}
 	}
 

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -331,6 +331,35 @@ func TestUnarySession_ExecuteStreamWithMessage(t *testing.T) {
 	assert.NotEmpty(t, chunks)
 }
 
+func TestUnarySession_ResumeWithToolResults(t *testing.T) {
+	pipe := createTestPipeline(t)
+
+	cfg := UnarySessionConfig{
+		ConversationID: "resume-session",
+		Pipeline:       pipe,
+	}
+
+	sess, err := NewUnarySession(cfg)
+	require.NoError(t, err)
+
+	// First execute to get the conversation started
+	_, err = sess.Execute(context.Background(), "user", "Hello")
+	require.NoError(t, err)
+
+	// Resume with tool results — sends tool result messages through pipeline
+	toolResults := []types.Message{
+		types.NewToolResultMessage(types.MessageToolResult{
+			ID:      "call-1",
+			Content: `{"lat": 37.7749}`,
+		}),
+	}
+
+	result, err := sess.ResumeWithToolResults(context.Background(), toolResults)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotNil(t, result.Response)
+}
+
 func TestUnarySession_ForkSession(t *testing.T) {
 	pipe := createTestPipeline(t)
 


### PR DESCRIPTION
## Summary

- When no `OnClientTool` handler is registered for a client-mode tool, the pipeline now **suspends** instead of erroring, returning pending client tools in the `Response`
- The caller can fulfill deferred tools via `SendToolResult` / `RejectClientTool`, then call `Resume()` to continue the conversation
- `clientExecutor` now implements `AsyncToolExecutor` with `ExecuteAsync()` for async/deferred dispatch
- Added `ErrToolsPending` sentinel error for pipeline suspension signaling through `executeToolCalls` → `executeMultiRound`
- Added `PendingTools` field to `pipeline.ExecutionResult` for propagating pending state

## Test plan

- [x] Unit tests for `ErrToolsPending.Error()` and `IsErrToolsPending()` (runtime/tools)
- [x] Unit tests for `ExecuteAsync` deferred mode — pending when no handler, complete when handler exists
- [x] Unit tests for `PendingClientTool` response methods — `ClientTools()`, `HasPendingClientTools()`
- [x] Unit tests for `SendToolResult`, `RejectClientTool`, `Resume`
- [x] Unit tests for `buildResponse` populating pending client tools
- [x] Unit tests for `ResumeWithToolResults` on `UnarySession`
- [x] Pipeline suspension test in `stages_provider_test.go`
- [x] All pre-commit checks pass (lint, build, tests, 80%+ coverage)

Closes #597