### PR TITLE
feat(sdk): streaming support for client-side tool execution (#598)

### DIFF
--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -326,6 +326,14 @@ func (e *Emitter) AudioOutput(data *AudioOutputData) {
 	e.emit(EventAudioOutput, data)
 }
 
+// ClientToolRequest emits the tool.client.request event.
+func (e *Emitter) ClientToolRequest(data *ClientToolRequestData) {
+	if data == nil {
+		return
+	}
+	e.emit(EventClientToolRequest, data)
+}
+
 // WorkflowTransitioned emits the workflow.transitioned event.
 func (e *Emitter) WorkflowTransitioned(fromState, toState, event, promptTask string) {
 	e.emit(EventWorkflowTransitioned, &WorkflowTransitionedData{

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -98,6 +98,11 @@ func TestEmitterPublishesVariousEvents(t *testing.T) {
 		},
 		func() { emitter.WorkflowTransitioned("s1", "s2", "Next", "p2") },
 		func() { emitter.WorkflowCompleted("done", 1) },
+		func() {
+			emitter.ClientToolRequest(&ClientToolRequestData{
+				CallID: "call-1", ToolName: "test_tool",
+			})
+		},
 	}
 
 	wg.Add(len(tests))
@@ -485,4 +490,61 @@ func TestEmitter_WorkflowCompleted(t *testing.T) {
 	if data.FinalState != "done" || data.TransitionCount != 3 {
 		t.Fatalf("unexpected data: state=%s count=%d", data.FinalState, data.TransitionCount)
 	}
+}
+
+func TestEmitter_ClientToolRequest(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctr", "session-ctr", "conv-ctr")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	bus.Subscribe(EventClientToolRequest, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	emitter.ClientToolRequest(&ClientToolRequestData{
+		CallID:     "call-1",
+		ToolName:   "get_location",
+		Args:       map[string]any{"accuracy": "fine"},
+		ConsentMsg: "Allow location access?",
+		Categories: []string{"location", "sensors"},
+	})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for tool.client.request event")
+	}
+
+	if got.RunID != "run-ctr" || got.SessionID != "session-ctr" || got.ConversationID != "conv-ctr" {
+		t.Fatalf("unexpected context: %+v", got)
+	}
+
+	data, ok := got.Data.(*ClientToolRequestData)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", got.Data)
+	}
+
+	if data.CallID != "call-1" || data.ToolName != "get_location" {
+		t.Fatalf("unexpected data: %+v", data)
+	}
+	if data.ConsentMsg != "Allow location access?" {
+		t.Fatalf("unexpected consent msg: %s", data.ConsentMsg)
+	}
+	if len(data.Categories) != 2 || data.Categories[0] != "location" {
+		t.Fatalf("unexpected categories: %v", data.Categories)
+	}
+}
+
+func TestEmitter_ClientToolRequest_NilData(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctrn", "session-ctrn", "conv-ctrn")
+
+	// Should not panic when data is nil
+	emitter.ClientToolRequest(nil)
 }

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -93,6 +93,9 @@ const (
 	EventWorkflowTransitioned EventType = "workflow.transitioned"
 	// EventWorkflowCompleted marks a workflow reaching a terminal state.
 	EventWorkflowCompleted EventType = "workflow.completed"
+
+	// EventClientToolRequest marks a client-mode tool request awaiting caller fulfillment.
+	EventClientToolRequest EventType = "tool.client.request"
 )
 
 // EventData is a marker interface for event payloads.
@@ -520,6 +523,21 @@ type (
 	// ImageOutputData is an alias for ImageEventData (backward compatibility).
 	ImageOutputData = ImageEventData
 )
+
+// ClientToolRequestData contains data for client tool request events.
+type ClientToolRequestData struct {
+	baseEventData
+	// CallID is the provider-assigned ID for this tool invocation.
+	CallID string `json:"call_id"`
+	// ToolName is the tool's name as defined in the pack.
+	ToolName string `json:"tool_name"`
+	// Args contains the parsed arguments from the LLM.
+	Args map[string]any `json:"args,omitempty"`
+	// ConsentMsg is the human-readable consent message.
+	ConsentMsg string `json:"consent_msg,omitempty"`
+	// Categories are the semantic consent categories.
+	Categories []string `json:"categories,omitempty"`
+}
 
 // WorkflowTransitionedData contains data for workflow state transition events.
 type WorkflowTransitionedData struct {

--- a/runtime/providers/streaming.go
+++ b/runtime/providers/streaming.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -49,6 +50,10 @@ type StreamChunk struct {
 
 	// CostInfo contains cost breakdown (only present in final chunk when FinishReason != nil)
 	CostInfo *types.CostInfo `json:"cost_info,omitempty"`
+
+	// PendingTools contains client-mode tools awaiting caller fulfillment.
+	// Only set when FinishReason is "pending_tools".
+	PendingTools []tools.PendingToolExecution `json:"pending_tools,omitempty"`
 }
 
 // StreamEvent is sent to observers for monitoring

--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -227,14 +227,88 @@ func (c *Conversation) Resume(ctx context.Context) (*Response, error) {
 		return nil, err
 	}
 
-	// Pop all resolved tool results
+	toolMsgs, err := c.buildToolResultMessages()
+	if err != nil {
+		return nil, err
+	}
+
+	// Inject tool results into session history and re-execute
+	result, err := c.unarySession.ResumeWithToolResults(ctx, toolMsgs)
+	if err != nil {
+		return nil, fmt.Errorf("resume failed: %w", err)
+	}
+
+	resp := c.buildResponse(result, startTime)
+	c.sessionHooks.IncrementTurn()
+	c.sessionHooks.SessionUpdate(ctx)
+	return resp, nil
+}
+
+// ResumeStream is the streaming equivalent of [Conversation.Resume].
+//
+// It continues pipeline execution after deferred client tools have been resolved,
+// returning a channel of [StreamChunk] values. The final chunk (Type == ChunkDone)
+// contains the complete Response.
+//
+// Example:
+//
+//	conv.SendToolResult(ctx, "call-1", locationData)
+//	for chunk := range conv.ResumeStream(ctx) {
+//	    if chunk.Error != nil { break }
+//	    fmt.Print(chunk.Text)
+//	}
+func (c *Conversation) ResumeStream(ctx context.Context) <-chan StreamChunk {
+	ch := make(chan StreamChunk, streamChannelBufferSize)
+
+	c.startOTelSession(ctx)
+
+	go func() {
+		defer close(ch)
+		startTime := time.Now()
+
+		if err := c.validateSendState(); err != nil {
+			ch <- StreamChunk{Error: err}
+			return
+		}
+
+		toolMsgs, err := c.buildToolResultMessages()
+		if err != nil {
+			ch <- StreamChunk{Error: err}
+			return
+		}
+
+		streamCh, err := c.unarySession.ResumeStreamWithToolResults(ctx, toolMsgs)
+		if err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("resume stream failed: %w", err)}
+			return
+		}
+
+		state := &streamState{}
+		if err := c.processAndFinalizeStreamWithState(streamCh, ch, startTime, state); err != nil {
+			ch <- StreamChunk{Error: err}
+			return
+		}
+
+		// Skip lifecycle hooks when pipeline is suspended for pending tools
+		if len(state.pendingTools) == 0 {
+			c.sessionHooks.IncrementTurn()
+			c.sessionHooks.SessionUpdate(ctx)
+			c.evalMW.dispatchTurnEvals(ctx)
+		}
+	}()
+
+	return ch
+}
+
+// buildToolResultMessages pops all resolved tool results and builds
+// tool-result messages. Shared by Resume() and ResumeStream().
+func (c *Conversation) buildToolResultMessages() ([]types.Message, error) {
 	resolutions := c.resolvedStore.PopAll()
 	if len(resolutions) == 0 {
 		return nil, fmt.Errorf("no resolved tool results to resume with")
 	}
 
-	// Build tool result messages from resolutions
-	var toolMsgs []types.Message
+	toolMsgs := make([]types.Message, 0, len(resolutions))
 	for _, res := range resolutions {
 		var content string
 		if res.Rejected {
@@ -250,16 +324,7 @@ func (c *Conversation) Resume(ctx context.Context) (*Response, error) {
 		}))
 	}
 
-	// Inject tool results into session history and re-execute
-	result, err := c.unarySession.ResumeWithToolResults(ctx, toolMsgs)
-	if err != nil {
-		return nil, fmt.Errorf("resume failed: %w", err)
-	}
-
-	resp := c.buildResponse(result, startTime)
-	c.sessionHooks.IncrementTurn()
-	c.sessionHooks.SessionUpdate(ctx)
-	return resp, nil
+	return toolMsgs, nil
 }
 
 // executeHandler runs a ClientToolHandler and returns serialized JSON.

--- a/sdk/client_tools_test.go
+++ b/sdk/client_tools_test.go
@@ -482,3 +482,51 @@ func TestResume_BuildsToolMessages(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 }
+
+func TestResumeStream_NoResolutions(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	ch := conv.ResumeStream(context.Background())
+	chunk := <-ch
+	require.Error(t, chunk.Error)
+	assert.Contains(t, chunk.Error.Error(), "no resolved tool results")
+}
+
+func TestResumeStream_WithResolutions(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	err := conv.SendToolResult(context.Background(), "call-1", map[string]any{"lat": 37.7})
+	require.NoError(t, err)
+
+	ch := conv.ResumeStream(context.Background())
+
+	var chunks []StreamChunk
+	for chunk := range ch {
+		chunks = append(chunks, chunk)
+	}
+
+	// Should get at least a ChunkDone
+	require.NotEmpty(t, chunks)
+	lastChunk := chunks[len(chunks)-1]
+	assert.Equal(t, ChunkDone, lastChunk.Type)
+	assert.NotNil(t, lastChunk.Message)
+}
+
+func TestBuildToolResultMessages_ErrorBranch(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	// Add a resolution with error
+	conv.resolvedStore.Add(&sdktools.ToolResolution{
+		ID:    "call-err",
+		Error: assert.AnError,
+	})
+
+	msgs, err := conv.buildToolResultMessages()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	// The message content should contain "Tool error"
+	assert.Contains(t, msgs[0].GetContent(), "Tool error")
+}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -152,6 +152,9 @@ type Conversation struct {
 	// Eval middleware for dispatching evals after Send/Close
 	evalMW *evalMiddleware
 
+	// Stream event handler for StreamWithCallback
+	streamEventHandler StreamEventHandler
+
 	// Closed flag
 	closed bool
 	mu     sync.RWMutex
@@ -457,21 +460,8 @@ func (c *Conversation) buildResponse(result *rtpipeline.ExecutionResult, startTi
 	}
 
 	// Populate pending client tools from pipeline result
-	for _, pt := range result.PendingTools {
-		pct := PendingClientTool{
-			CallID:   pt.CallID,
-			ToolName: pt.ToolName,
-			Args:     pt.Args,
-		}
-		if pt.PendingInfo != nil {
-			pct.ConsentMsg = pt.PendingInfo.Message
-			if cats, ok := pt.PendingInfo.Metadata["categories"]; ok {
-				if catSlice, ok := cats.([]string); ok {
-					pct.Categories = catSlice
-				}
-			}
-		}
-		resp.clientTools = append(resp.clientTools, pct)
+	for i := range result.PendingTools {
+		resp.clientTools = append(resp.clientTools, buildPendingClientToolFromExecution(&result.PendingTools[i]))
 	}
 
 	return resp

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -567,6 +568,14 @@ func streamElementToStreamChunk(elem *stage.StreamElement) providers.StreamChunk
 	// Copy metadata
 	if elem.Metadata != nil {
 		chunk.Metadata = elem.Metadata
+
+		// Detect pending client tools (pipeline suspended)
+		if pt, ok := elem.Metadata["pending_tools"]; ok {
+			if pending, ok := pt.([]tools.PendingToolExecution); ok && len(pending) > 0 {
+				chunk.PendingTools = pending
+				chunk.FinishReason = strPtr("pending_tools")
+			}
+		}
 	}
 
 	return chunk

--- a/sdk/session/session.go
+++ b/sdk/session/session.go
@@ -39,6 +39,10 @@ type UnarySession interface {
 	// history and re-executes the pipeline so the LLM can continue.
 	ResumeWithToolResults(ctx context.Context, toolResults []types.Message) (*pipeline.ExecutionResult, error)
 
+	// ResumeStreamWithToolResults is the streaming equivalent of ResumeWithToolResults.
+	// It injects tool result messages and returns a streaming channel.
+	ResumeStreamWithToolResults(ctx context.Context, toolResults []types.Message) (<-chan providers.StreamChunk, error)
+
 	// ForkSession creates a new session that is a fork of this one.
 	// The new session will have an independent copy of the conversation state.
 	ForkSession(ctx context.Context, forkID string, pipeline *stage.StreamPipeline) (UnarySession, error)

--- a/sdk/session/unary_session.go
+++ b/sdk/session/unary_session.go
@@ -202,6 +202,39 @@ func (s *unarySession) ExecuteStreamWithMessage(
 	return convertStreamOutput(outputChan), nil
 }
 
+// ResumeStreamWithToolResults injects tool result messages and returns a streaming channel.
+func (s *unarySession) ResumeStreamWithToolResults(
+	ctx context.Context,
+	toolResults []types.Message,
+) (<-chan providers.StreamChunk, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Build input elements: one per tool result message
+	inputElems := make([]stage.StreamElement, 0, len(toolResults))
+	for i := range toolResults {
+		inputElems = append(inputElems, stage.StreamElement{
+			Message:  &toolResults[i],
+			Metadata: map[string]interface{}{"variables": s.variables},
+		})
+	}
+
+	// Create input channel from tool result messages
+	inputChan := make(chan stage.StreamElement, len(inputElems))
+	for i := range inputElems {
+		inputChan <- inputElems[i]
+	}
+	close(inputChan)
+
+	// Execute as stream
+	outputChan, err := s.pipeline.Execute(ctx, inputChan)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertStreamOutput(outputChan), nil
+}
+
 // SetVar sets a template variable that will be available for substitution.
 func (s *unarySession) SetVar(name, value string) {
 	s.mu.Lock()
@@ -325,6 +358,7 @@ func convertStreamOutput(stageChan <-chan stage.StreamElement) <-chan providers.
 func processStreamElements(stageChan <-chan stage.StreamElement, chunkChan chan<- providers.StreamChunk) {
 	var accumulatedContent string
 	var finalResult *pipeline.ExecutionResult
+	var pendingToolsEmitted bool
 
 	for elem := range stageChan {
 		// Handle errors
@@ -350,14 +384,28 @@ func processStreamElements(stageChan <-chan stage.StreamElement, chunkChan chan<
 			if stageResult, ok := elem.Metadata["__final_result__"].(*stage.ExecutionResult); ok {
 				finalResult = convertExecutionResult(stageResult)
 			}
+
+			// Check for pending client tools (pipeline suspended)
+			if pt, ok := elem.Metadata["pending_tools"]; ok {
+				if pending, ok := pt.([]tools.PendingToolExecution); ok && len(pending) > 0 {
+					chunkChan <- providers.StreamChunk{
+						FinishReason: strPtr("pending_tools"),
+						PendingTools: pending,
+						FinalResult:  finalResult,
+					}
+					pendingToolsEmitted = true
+				}
+			}
 		}
 	}
 
-	// Send final chunk
-	finishReason := "stop"
-	chunkChan <- providers.StreamChunk{
-		FinishReason: &finishReason,
-		FinalResult:  finalResult,
+	// Send final chunk only if we didn't already emit a pending_tools chunk
+	if !pendingToolsEmitted {
+		finishReason := "stop"
+		chunkChan <- providers.StreamChunk{
+			FinishReason: &finishReason,
+			FinalResult:  finalResult,
+		}
 	}
 }
 

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pipeline"
 )
@@ -73,7 +74,7 @@ func TestNewUnarySession(t *testing.T) {
 		cfg := UnarySessionConfig{
 			Pipeline: pipe,
 			UserID:   "user123",
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"key": "value",
 			},
 		}
@@ -358,6 +359,111 @@ func TestUnarySession_ResumeWithToolResults(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.NotNil(t, result.Response)
+}
+
+func TestProcessStreamElements_PropagatesPendingTools(t *testing.T) {
+	stageChan := make(chan stage.StreamElement, 5)
+
+	pendingTools := []tools.PendingToolExecution{
+		{
+			CallID:   "call-1",
+			ToolName: "get_location",
+			Args:     map[string]any{"accuracy": "fine"},
+			PendingInfo: &tools.PendingToolInfo{
+				Message: "Allow location?",
+			},
+		},
+	}
+
+	// Send a text element, then a pending_tools element
+	text := "I need your location."
+	stageChan <- stage.StreamElement{Text: &text}
+	stageChan <- stage.StreamElement{
+		Metadata: map[string]any{
+			"pending_tools": pendingTools,
+		},
+	}
+	close(stageChan)
+
+	// Use convertStreamOutput which properly wraps processStreamElements with close
+	chunkChan := convertStreamOutput(stageChan)
+
+	var chunks []providers.StreamChunk
+	for chunk := range chunkChan {
+		chunks = append(chunks, chunk)
+	}
+
+	// Should have text chunk + pending_tools chunk (no "stop" chunk)
+	require.Len(t, chunks, 2)
+
+	// First: text delta
+	assert.Equal(t, "I need your location.", chunks[0].Delta)
+	assert.Nil(t, chunks[0].FinishReason)
+
+	// Second: pending_tools
+	require.NotNil(t, chunks[1].FinishReason)
+	assert.Equal(t, "pending_tools", *chunks[1].FinishReason)
+	require.Len(t, chunks[1].PendingTools, 1)
+	assert.Equal(t, "call-1", chunks[1].PendingTools[0].CallID)
+	assert.Equal(t, "get_location", chunks[1].PendingTools[0].ToolName)
+}
+
+func TestProcessStreamElements_NoPendingTools(t *testing.T) {
+	stageChan := make(chan stage.StreamElement, 5)
+
+	text := "Hello world"
+	stageChan <- stage.StreamElement{Text: &text}
+	close(stageChan)
+
+	chunkChan := convertStreamOutput(stageChan)
+
+	var chunks []providers.StreamChunk
+	for chunk := range chunkChan {
+		chunks = append(chunks, chunk)
+	}
+
+	// Should have text chunk + "stop" final chunk
+	require.Len(t, chunks, 2)
+	assert.Equal(t, "Hello world", chunks[0].Delta)
+	require.NotNil(t, chunks[1].FinishReason)
+	assert.Equal(t, "stop", *chunks[1].FinishReason)
+	assert.Empty(t, chunks[1].PendingTools)
+}
+
+func TestUnarySession_ResumeStreamWithToolResults(t *testing.T) {
+	pipe := createTestPipeline(t)
+
+	cfg := UnarySessionConfig{
+		ConversationID: "resume-stream-session",
+		Pipeline:       pipe,
+	}
+
+	sess, err := NewUnarySession(cfg)
+	require.NoError(t, err)
+
+	// First execute to get the conversation started
+	_, err = sess.Execute(context.Background(), "user", "Hello")
+	require.NoError(t, err)
+
+	// Resume with tool results in streaming mode
+	toolResults := []types.Message{
+		types.NewToolResultMessage(types.MessageToolResult{
+			ID:      "call-1",
+			Content: `{"lat": 37.7749}`,
+		}),
+	}
+
+	stream, err := sess.ResumeStreamWithToolResults(context.Background(), toolResults)
+	require.NoError(t, err)
+	assert.NotNil(t, stream)
+
+	// Consume stream
+	var chunks []providers.StreamChunk
+	for chunk := range stream {
+		chunks = append(chunks, chunk)
+	}
+
+	assert.NotEmpty(t, chunks)
 }
 
 func TestUnarySession_ForkSession(t *testing.T) {

--- a/sdk/stream_events.go
+++ b/sdk/stream_events.go
@@ -1,0 +1,123 @@
+package sdk
+
+import "context"
+
+// StreamEvent is the interface for all stream event types.
+// Use a type switch to handle specific events.
+type StreamEvent interface {
+	streamEvent() // marker method
+}
+
+// TextDeltaEvent is emitted for each text delta during streaming.
+type TextDeltaEvent struct {
+	// Delta is the new text content in this chunk.
+	Delta string
+}
+
+func (TextDeltaEvent) streamEvent() {}
+
+// ClientToolRequestEvent is emitted when the pipeline encounters a client tool
+// that needs caller fulfillment.
+type ClientToolRequestEvent struct {
+	// CallID is the provider-assigned ID for this tool invocation.
+	CallID string
+
+	// ToolName is the tool's name as defined in the pack.
+	ToolName string
+
+	// Args contains the parsed arguments from the LLM.
+	Args map[string]any
+
+	// ConsentMsg is the human-readable consent message.
+	ConsentMsg string
+
+	// Categories are the semantic consent categories.
+	Categories []string
+}
+
+func (ClientToolRequestEvent) streamEvent() {}
+
+// StreamDoneEvent is emitted when the stream completes.
+type StreamDoneEvent struct {
+	// Response contains the complete response with metadata.
+	Response *Response
+}
+
+func (StreamDoneEvent) streamEvent() {}
+
+// StreamEventHandler is called for each event during streaming.
+type StreamEventHandler func(event StreamEvent)
+
+// OnStreamEvent registers a handler that will be called for each stream event
+// during [Conversation.StreamWithCallback].
+//
+// Example:
+//
+//	conv.OnStreamEvent(func(event sdk.StreamEvent) {
+//	    switch e := event.(type) {
+//	    case sdk.TextDeltaEvent:
+//	        fmt.Print(e.Delta)
+//	    case sdk.ClientToolRequestEvent:
+//	        fmt.Printf("Tool %s needs fulfillment\n", e.ToolName)
+//	    case sdk.StreamDoneEvent:
+//	        fmt.Println("\nDone!")
+//	    }
+//	})
+func (c *Conversation) OnStreamEvent(handler StreamEventHandler) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.streamEventHandler = handler
+}
+
+// StreamWithCallback sends a message and invokes the registered [StreamEventHandler]
+// for each chunk. This is a convenience wrapper around [Conversation.Stream] that
+// translates chunks into typed events.
+//
+// If no handler has been registered via [Conversation.OnStreamEvent], this behaves
+// like Stream() but discards all chunks and returns the final response.
+//
+// Returns the complete Response or an error.
+func (c *Conversation) StreamWithCallback(ctx context.Context, message any, opts ...SendOption) (*Response, error) {
+	c.mu.RLock()
+	handler := c.streamEventHandler
+	c.mu.RUnlock()
+
+	var finalResp *Response
+
+	for chunk := range c.Stream(ctx, message, opts...) {
+		if chunk.Error != nil {
+			return nil, chunk.Error
+		}
+
+		if handler == nil {
+			if chunk.Type == ChunkDone {
+				finalResp = chunk.Message
+			}
+			continue
+		}
+
+		switch chunk.Type {
+		case ChunkText:
+			handler(TextDeltaEvent{Delta: chunk.Text})
+		case ChunkClientTool:
+			if chunk.ClientTool != nil {
+				handler(ClientToolRequestEvent{
+					CallID:     chunk.ClientTool.CallID,
+					ToolName:   chunk.ClientTool.ToolName,
+					Args:       chunk.ClientTool.Args,
+					ConsentMsg: chunk.ClientTool.ConsentMsg,
+					Categories: chunk.ClientTool.Categories,
+				})
+			}
+		case ChunkToolCall, ChunkMedia:
+			// Pass through without event emission
+		case ChunkDone:
+			finalResp = chunk.Message
+			handler(StreamDoneEvent{Response: chunk.Message})
+		default:
+			// ChunkToolCall, ChunkMedia — no event type defined yet
+		}
+	}
+
+	return finalResp, nil
+}

--- a/sdk/stream_events_test.go
+++ b/sdk/stream_events_test.go
@@ -1,0 +1,168 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	mock "github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
+	"github.com/AltairaLabs/PromptKit/sdk/session"
+	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnStreamEvent_TextDelta(t *testing.T) {
+	ctx := context.Background()
+	repo := mock.NewInMemoryMockRepository("Hello world")
+	mockProv := mock.NewProviderWithRepository("test-mock", "test-model", false, repo)
+	store := statestore.NewMemoryStore()
+
+	p := &pack.Pack{
+		ID: "test-pack",
+		Prompts: map[string]*pack.Prompt{
+			"chat": {ID: "chat", SystemTemplate: "System"},
+		},
+	}
+
+	conv := &Conversation{
+		pack:           p,
+		prompt:         p.Prompts["chat"],
+		promptName:     "chat",
+		promptRegistry: p.ToPromptRegistry(),
+		toolRegistry:   tools.NewRegistry(),
+		config:         &config{provider: mockProv},
+		mode:           UnaryMode,
+		handlers:       make(map[string]ToolHandler),
+		asyncHandlers:  make(map[string]sdktools.AsyncToolHandler),
+		pendingStore:   sdktools.NewPendingStore(),
+	}
+
+	pipeline, err := conv.buildPipelineWithParams(store, "test-conv", nil, nil)
+	require.NoError(t, err)
+
+	unarySession, err := session.NewUnarySession(session.UnarySessionConfig{
+		ConversationID: "test-conv",
+		StateStore:     store,
+		Pipeline:       pipeline,
+	})
+	require.NoError(t, err)
+	conv.unarySession = unarySession
+
+	var textDeltas []string
+	var doneReceived bool
+
+	conv.OnStreamEvent(func(event StreamEvent) {
+		switch e := event.(type) {
+		case TextDeltaEvent:
+			textDeltas = append(textDeltas, e.Delta)
+		case StreamDoneEvent:
+			doneReceived = true
+			assert.NotNil(t, e.Response)
+		}
+	})
+
+	resp, err := conv.StreamWithCallback(ctx, "Hello")
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.True(t, doneReceived, "should receive StreamDoneEvent")
+	// Mock provider returns text, so we should get text deltas
+	assert.NotEmpty(t, textDeltas)
+}
+
+func TestStreamWithCallback_NoHandler(t *testing.T) {
+	ctx := context.Background()
+	repo := mock.NewInMemoryMockRepository("Response text")
+	mockProv := mock.NewProviderWithRepository("test-mock", "test-model", false, repo)
+	store := statestore.NewMemoryStore()
+
+	p := &pack.Pack{
+		ID: "test-pack",
+		Prompts: map[string]*pack.Prompt{
+			"chat": {ID: "chat", SystemTemplate: "System"},
+		},
+	}
+
+	conv := &Conversation{
+		pack:           p,
+		prompt:         p.Prompts["chat"],
+		promptName:     "chat",
+		promptRegistry: p.ToPromptRegistry(),
+		toolRegistry:   tools.NewRegistry(),
+		config:         &config{provider: mockProv},
+		mode:           UnaryMode,
+		handlers:       make(map[string]ToolHandler),
+		asyncHandlers:  make(map[string]sdktools.AsyncToolHandler),
+		pendingStore:   sdktools.NewPendingStore(),
+	}
+
+	pipeline, err := conv.buildPipelineWithParams(store, "test-conv-nh", nil, nil)
+	require.NoError(t, err)
+
+	unarySession, err := session.NewUnarySession(session.UnarySessionConfig{
+		ConversationID: "test-conv-nh",
+		StateStore:     store,
+		Pipeline:       pipeline,
+	})
+	require.NoError(t, err)
+	conv.unarySession = unarySession
+
+	// No handler registered — should still work
+	resp, err := conv.StreamWithCallback(ctx, "Hello")
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestStreamWithCallback_ClientToolRequest(t *testing.T) {
+	conv := newTestConversation()
+
+	// Simulate a stream with client tool chunks
+	outCh := make(chan StreamChunk, 10)
+	state := &streamState{}
+
+	// Simulate emitStreamChunk with pending tools
+	finishReason := "pending_tools"
+	providerChunk := &providers.StreamChunk{
+		FinishReason: &finishReason,
+		PendingTools: []tools.PendingToolExecution{
+			{
+				CallID:   "call-1",
+				ToolName: "get_location",
+				Args:     map[string]any{"accuracy": "fine"},
+				PendingInfo: &tools.PendingToolInfo{
+					Message: "Allow location access?",
+					Metadata: map[string]any{
+						"categories": []string{"location"},
+					},
+				},
+			},
+		},
+	}
+
+	conv.emitStreamChunk(providerChunk, outCh, state)
+	close(outCh)
+
+	// Verify ChunkClientTool was emitted
+	var clientToolChunks []StreamChunk
+	for chunk := range outCh {
+		clientToolChunks = append(clientToolChunks, chunk)
+	}
+
+	require.Len(t, clientToolChunks, 1)
+	assert.Equal(t, ChunkClientTool, clientToolChunks[0].Type)
+	assert.NotNil(t, clientToolChunks[0].ClientTool)
+	assert.Equal(t, "call-1", clientToolChunks[0].ClientTool.CallID)
+	assert.Equal(t, "get_location", clientToolChunks[0].ClientTool.ToolName)
+	assert.Equal(t, "Allow location access?", clientToolChunks[0].ClientTool.ConsentMsg)
+	assert.Equal(t, []string{"location"}, clientToolChunks[0].ClientTool.Categories)
+}
+
+func TestStreamEventInterface(t *testing.T) {
+	// Verify all event types implement StreamEvent
+	var _ StreamEvent = TextDeltaEvent{}
+	var _ StreamEvent = ClientToolRequestEvent{}
+	var _ StreamEvent = StreamDoneEvent{}
+}

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -8,6 +8,7 @@ import (
 
 	rtpipeline "github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	streamPkg "github.com/AltairaLabs/PromptKit/sdk/stream"
 )
@@ -25,6 +26,10 @@ type StreamChunk struct {
 
 	// Media content (for ChunkMedia type)
 	Media *types.MediaContent
+
+	// ClientTool contains a pending client tool request (for ChunkClientTool type).
+	// The caller should fulfill it via SendToolResult/RejectClientTool, then call ResumeStream.
+	ClientTool *PendingClientTool
 
 	// Complete response (for ChunkDone type)
 	Message *Response
@@ -48,6 +53,9 @@ const (
 
 	// ChunkDone indicates streaming is complete.
 	ChunkDone
+
+	// ChunkClientTool indicates a client tool request that needs caller fulfillment.
+	ChunkClientTool
 )
 
 // String returns the string representation of the chunk type.
@@ -61,6 +69,8 @@ func (t ChunkType) String() string {
 		return "media"
 	case ChunkDone:
 		return "done"
+	case ChunkClientTool:
+		return "client_tool"
 	default:
 		return "unknown"
 	}
@@ -71,6 +81,7 @@ type streamState struct {
 	accumulatedContent string
 	lastToolCalls      []types.MessageToolCall
 	finalResult        *rtpipeline.ExecutionResult
+	pendingTools       []PendingClientTool
 }
 
 // Stream sends a message and returns a channel of response chunks.
@@ -215,14 +226,17 @@ func (c *Conversation) executeStreamingPipeline(
 	}
 
 	// Process stream and finalize
-	if err := c.processAndFinalizeStream(streamCh, outCh, startTime); err != nil {
+	state := &streamState{}
+	if err := c.processAndFinalizeStreamWithState(streamCh, outCh, startTime, state); err != nil {
 		return err
 	}
 
-	// Dispatch turn-level evals (mirrors Send() behavior)
-	c.sessionHooks.IncrementTurn()
-	c.sessionHooks.SessionUpdate(ctx)
-	c.evalMW.dispatchTurnEvals(ctx)
+	// Skip lifecycle hooks when pipeline is suspended for pending tools
+	if len(state.pendingTools) == 0 {
+		c.sessionHooks.IncrementTurn()
+		c.sessionHooks.SessionUpdate(ctx)
+		c.evalMW.dispatchTurnEvals(ctx)
+	}
 
 	return nil
 }
@@ -233,15 +247,24 @@ func (c *Conversation) processAndFinalizeStream(
 	outCh chan<- StreamChunk,
 	startTime time.Time,
 ) error {
-	state := &streamState{}
+	return c.processAndFinalizeStreamWithState(streamCh, outCh, startTime, &streamState{})
+}
 
+// processAndFinalizeStreamWithState is like processAndFinalizeStream but uses a caller-provided state
+// so the caller can inspect pendingTools after the stream completes.
+func (c *Conversation) processAndFinalizeStreamWithState(
+	streamCh <-chan providers.StreamChunk,
+	outCh chan<- StreamChunk,
+	startTime time.Time,
+	state *streamState,
+) error {
 	// Process all stream chunks
 	if err := c.processStreamChunks(streamCh, outCh, state); err != nil {
 		return err
 	}
 
 	// Build response from accumulated data
-	resp := c.buildStreamingResponse(state.finalResult, state.accumulatedContent, state.lastToolCalls, startTime)
+	resp := c.buildStreamingResponse(state, startTime)
 
 	// Emit final ChunkDone with complete response
 	outCh <- StreamChunk{
@@ -293,6 +316,19 @@ func (c *Conversation) emitStreamChunk(
 		state.lastToolCalls = chunk.ToolCalls
 	}
 
+	// Handle pending client tools
+	if chunk.FinishReason != nil && *chunk.FinishReason == "pending_tools" && len(chunk.PendingTools) > 0 {
+		for i := range chunk.PendingTools {
+			pct := buildPendingClientToolFromExecution(&chunk.PendingTools[i])
+			state.pendingTools = append(state.pendingTools, pct)
+			outCh <- StreamChunk{Type: ChunkClientTool, ClientTool: &pct}
+		}
+		if result, ok := chunk.FinalResult.(*rtpipeline.ExecutionResult); ok {
+			state.finalResult = result
+		}
+		return
+	}
+
 	// Capture final result
 	if chunk.FinishReason != nil {
 		if result, ok := chunk.FinalResult.(*rtpipeline.ExecutionResult); ok {
@@ -301,16 +337,34 @@ func (c *Conversation) emitStreamChunk(
 	}
 }
 
+// buildPendingClientToolFromExecution converts a tools.PendingToolExecution to a PendingClientTool.
+func buildPendingClientToolFromExecution(pt *tools.PendingToolExecution) PendingClientTool {
+	pct := PendingClientTool{
+		CallID:   pt.CallID,
+		ToolName: pt.ToolName,
+		Args:     pt.Args,
+	}
+	if pt.PendingInfo != nil {
+		pct.ConsentMsg = pt.PendingInfo.Message
+		if cats, ok := pt.PendingInfo.Metadata["categories"]; ok {
+			if catSlice, ok := cats.([]string); ok {
+				pct.Categories = catSlice
+			}
+		}
+	}
+	return pct
+}
+
 // buildStreamingResponse creates a Response from streaming data.
 func (c *Conversation) buildStreamingResponse(
-	result *rtpipeline.ExecutionResult,
-	content string,
-	toolCalls []types.MessageToolCall,
+	state *streamState,
 	startTime time.Time,
 ) *Response {
 	resp := &Response{
 		duration: time.Since(startTime),
 	}
+
+	result := state.finalResult
 
 	// Use result data if available
 	if result != nil && result.Response != nil {
@@ -336,11 +390,16 @@ func (c *Conversation) buildStreamingResponse(
 		// Build from accumulated streaming data
 		resp.message = &types.Message{
 			Role:    roleAssistant,
-			Content: content,
+			Content: state.accumulatedContent,
 		}
-		if len(toolCalls) > 0 {
-			resp.toolCalls = toolCalls
+		if len(state.lastToolCalls) > 0 {
+			resp.toolCalls = state.lastToolCalls
 		}
+	}
+
+	// Populate pending client tools from stream state
+	if len(state.pendingTools) > 0 {
+		resp.clientTools = state.pendingTools
 	}
 
 	return resp
@@ -378,6 +437,9 @@ func (c *Conversation) StreamRaw(ctx context.Context, message any) (<-chan strea
 			case ChunkMedia:
 				chunk.Type = streamPkg.ChunkMedia
 				chunk.Media = sdkChunk.Media
+			case ChunkClientTool:
+				// Client tool requests are SDK-level; skip in raw stream
+				continue
 			case ChunkDone:
 				chunk.Done = true
 			}

--- a/sdk/streaming_test.go
+++ b/sdk/streaming_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	mock "github.com/AltairaLabs/PromptKit/runtime/providers/mock"
@@ -575,6 +576,114 @@ func TestAddContentPartsAudioFileError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to add audio from file")
+}
+
+func TestChunkClientToolType_String(t *testing.T) {
+	assert.Equal(t, "client_tool", ChunkClientTool.String())
+}
+
+func TestEmitStreamChunk_ClientTool(t *testing.T) {
+	conv := newTestConversation()
+	outCh := make(chan StreamChunk, 10)
+	state := &streamState{}
+
+	finishReason := "pending_tools"
+	providerChunk := &providers.StreamChunk{
+		FinishReason: &finishReason,
+		PendingTools: []tools.PendingToolExecution{
+			{
+				CallID:   "call-1",
+				ToolName: "get_location",
+				Args:     map[string]any{"accuracy": "fine"},
+				PendingInfo: &tools.PendingToolInfo{
+					Message: "Allow location?",
+					Metadata: map[string]any{
+						"categories": []string{"location"},
+					},
+				},
+			},
+			{
+				CallID:   "call-2",
+				ToolName: "read_contacts",
+				Args:     map[string]any{},
+			},
+		},
+	}
+
+	conv.emitStreamChunk(providerChunk, outCh, state)
+	close(outCh)
+
+	var chunks []StreamChunk
+	for chunk := range outCh {
+		chunks = append(chunks, chunk)
+	}
+
+	// Should emit one ChunkClientTool per pending tool
+	require.Len(t, chunks, 2)
+	assert.Equal(t, ChunkClientTool, chunks[0].Type)
+	assert.Equal(t, "call-1", chunks[0].ClientTool.CallID)
+	assert.Equal(t, "get_location", chunks[0].ClientTool.ToolName)
+	assert.Equal(t, "Allow location?", chunks[0].ClientTool.ConsentMsg)
+	assert.Equal(t, []string{"location"}, chunks[0].ClientTool.Categories)
+
+	assert.Equal(t, ChunkClientTool, chunks[1].Type)
+	assert.Equal(t, "call-2", chunks[1].ClientTool.CallID)
+	assert.Equal(t, "read_contacts", chunks[1].ClientTool.ToolName)
+	assert.Empty(t, chunks[1].ClientTool.ConsentMsg)
+
+	// State should have pending tools recorded
+	assert.Len(t, state.pendingTools, 2)
+}
+
+func TestBuildStreamingResponse_WithPendingTools(t *testing.T) {
+	conv := newTestConversation()
+
+	state := &streamState{
+		accumulatedContent: "I need your location.",
+		pendingTools: []PendingClientTool{
+			{
+				CallID:     "call-1",
+				ToolName:   "get_location",
+				Args:       map[string]any{"accuracy": "fine"},
+				ConsentMsg: "Allow location?",
+				Categories: []string{"location"},
+			},
+		},
+	}
+
+	resp := conv.buildStreamingResponse(state, time.Now())
+	require.NotNil(t, resp)
+	assert.True(t, resp.HasPendingClientTools())
+	require.Len(t, resp.ClientTools(), 1)
+	assert.Equal(t, "call-1", resp.ClientTools()[0].CallID)
+	assert.Equal(t, "get_location", resp.ClientTools()[0].ToolName)
+}
+
+func TestEmitStreamChunk_NormalFinish(t *testing.T) {
+	// Verify that a normal "stop" finish reason doesn't emit ChunkClientTool
+	conv := newTestConversation()
+	outCh := make(chan StreamChunk, 10)
+	state := &streamState{}
+
+	finishReason := "stop"
+	providerChunk := &providers.StreamChunk{
+		Delta:        "Hello",
+		Content:      "Hello",
+		FinishReason: &finishReason,
+	}
+
+	conv.emitStreamChunk(providerChunk, outCh, state)
+	close(outCh)
+
+	var chunks []StreamChunk
+	for chunk := range outCh {
+		chunks = append(chunks, chunk)
+	}
+
+	// Should only emit text, no client tool
+	require.Len(t, chunks, 1)
+	assert.Equal(t, ChunkText, chunks[0].Type)
+	assert.Empty(t, state.pendingTools)
 }
 
 func TestStreamingError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Propagate pending client tools through the streaming pipeline (`processStreamElements`, `streamElementToStreamChunk`) so they are no longer silently dropped
- Add `ChunkClientTool` stream chunk type with `PendingClientTool` data for client-side tool requests during streaming
- Add callback-based `StreamEvent` API (`OnStreamEvent` + `StreamWithCallback`) for event-driven stream consumption
- Add `ResumeStream` for streaming resumption after client tool resolution
- Add `ResumeStreamWithToolResults` to `UnarySession` interface
- Add `EventClientToolRequest` event type for observability via the event bus
- Extract shared helpers (`buildPendingClientToolFromExecution`, `buildToolResultMessages`) to reduce duplication

## Test plan
- [x] `TestProcessStreamElements_PropagatesPendingTools` — pending tools forwarded through stream conversion
- [x] `TestProcessStreamElements_NoPendingTools` — normal stream finishes with "stop"
- [x] `TestUnarySession_ResumeStreamWithToolResults` — session-level streaming resumption
- [x] `TestEmitStreamChunk_ClientTool` — SDK chunk emission for client tools
- [x] `TestBuildStreamingResponse_WithPendingTools` — response includes pending tools from stream state
- [x] `TestOnStreamEvent_TextDelta` — full integration: stream events fire for text deltas and done
- [x] `TestStreamWithCallback_ClientToolRequest` — client tool request events emitted
- [x] `TestStreamWithCallback_NoHandler` — works without event handler
- [x] `TestResumeStream_WithResolutions` / `_NoResolutions` — streaming resume path
- [x] `TestEmitter_ClientToolRequest` — event bus emission
- [x] All pre-existing tests pass, coverage ≥80% on all changed files