### PR TITLE
feat(arena): add consent simulation for client-side tools

### DIFF
--- a/examples/client-tools/config.arena.yaml
+++ b/examples/client-tools/config.arena.yaml
@@ -1,0 +1,28 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: client-tools-consent
+spec:
+  prompt_configs:
+    - id: chat
+      file: prompts/chat.yaml
+
+  providers:
+    - file: providers/mock-provider.yaml
+
+  scenarios:
+    - file: scenarios/consent-grant.scenario.yaml
+    - file: scenarios/consent-deny.scenario.yaml
+
+  tools:
+    - file: tools/get_location.tool.yaml
+
+  defaults:
+    temperature: 0.0
+    max_tokens: 500
+    seed: 42
+    output:
+      dir: out
+      formats: ["json", "html"]
+    fail_on:
+      - provider_error

--- a/examples/client-tools/mock-responses.yaml
+++ b/examples/client-tools/mock-responses.yaml
@@ -1,0 +1,24 @@
+# Mock responses for client-tools consent simulation example
+
+defaultResponse: "I can help you with that."
+
+scenarios:
+  consent-grant:
+    defaultResponse: "Here is your location information."
+    turns:
+      1:
+        tool_calls:
+          - name: "get_location"
+            arguments:
+              accuracy: "high"
+      2: "Based on your location at latitude 37.7749, longitude -122.4194, you appear to be in San Francisco, California."
+
+  consent-deny:
+    defaultResponse: "I'm unable to access your location."
+    turns:
+      1:
+        tool_calls:
+          - name: "get_location"
+            arguments:
+              accuracy: "high"
+      2: "I'm sorry, I was unable to access your location because the request was denied. Could you please provide your location manually so I can assist you?"

--- a/examples/client-tools/prompts/chat.yaml
+++ b/examples/client-tools/prompts/chat.yaml
@@ -1,0 +1,21 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: chat
+spec:
+  task_type: "chat"
+  version: "v1.0.0"
+  description: "Chat assistant with client-side tool access"
+
+  system_template: |
+    You are a helpful assistant with access to the user's device capabilities.
+
+    Available tools:
+    - get_location: Get the user's GPS coordinates (requires user consent)
+
+    When the user asks about their location, use the get_location tool.
+    If the tool is unavailable or denied, politely inform the user that
+    you are unable to access their location and suggest they provide it manually.
+
+  allowed_tools:
+    - get_location

--- a/examples/client-tools/providers/mock-provider.yaml
+++ b/examples/client-tools/providers/mock-provider.yaml
@@ -1,0 +1,10 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-client-tools
+spec:
+  id: mock-client-tools
+  type: mock
+  model: mock-model
+  additional_config:
+    mock_config: mock-responses.yaml

--- a/examples/client-tools/scenarios/consent-deny.scenario.yaml
+++ b/examples/client-tools/scenarios/consent-deny.scenario.yaml
@@ -1,0 +1,27 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: consent-deny
+spec:
+  id: consent-deny
+  task_type: chat
+  description: "Verifies that the LLM handles consent denial gracefully"
+
+  turns:
+    - role: user
+      content: "Where am I right now?"
+      consent_overrides:
+        get_location: deny
+      assertions:
+        - type: tool_called
+          params:
+            tool_name: get_location
+            message: "Should attempt to call get_location tool"
+
+    - role: user
+      content: "Can you try again?"
+      assertions:
+        - type: content_matches
+          params:
+            pattern: "(?i)(unable|denied|provide|manually|sorry)"
+            message: "Should explain that location access was denied and suggest alternatives"

--- a/examples/client-tools/scenarios/consent-grant.scenario.yaml
+++ b/examples/client-tools/scenarios/consent-grant.scenario.yaml
@@ -1,0 +1,25 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: consent-grant
+spec:
+  id: consent-grant
+  task_type: chat
+  description: "Verifies that a client tool executes when consent is granted (default)"
+
+  turns:
+    - role: user
+      content: "Where am I right now?"
+      assertions:
+        - type: tool_called
+          params:
+            tool_name: get_location
+            message: "Should call get_location tool when user asks for location"
+
+    - role: user
+      content: "Tell me more about this area"
+      assertions:
+        - type: content_matches
+          params:
+            pattern: "(?i)(san francisco|37\\.77|location)"
+            message: "Should reference the location data from the tool result"

--- a/examples/client-tools/tools/get_location.tool.yaml
+++ b/examples/client-tools/tools/get_location.tool.yaml
@@ -1,0 +1,32 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: get_location
+spec:
+  description: "Get the user's current GPS coordinates"
+  mode: client
+  timeout_ms: 5000
+  input_schema:
+    type: object
+    properties:
+      accuracy:
+        type: string
+        enum: ["high", "low"]
+        description: "Desired accuracy level"
+  output_schema:
+    type: object
+    properties:
+      lat:
+        type: number
+      lng:
+        type: number
+  mock_result:
+    lat: 37.7749
+    lng: -122.4194
+  client:
+    consent:
+      required: true
+      message: "Allow location access?"
+      decline_strategy: error
+    categories:
+      - location

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -939,6 +939,10 @@ type TurnDefinition struct {
 	// Streaming control - if nil, uses scenario-level streaming setting
 	Streaming *bool `json:"streaming,omitempty" yaml:"streaming,omitempty"` // Override streaming for this turn
 
+	// ConsentOverrides controls consent simulation for client-side tools.
+	// Keys are tool names, values are "grant", "deny", or "timeout".
+	ConsentOverrides map[string]string `json:"consent_overrides,omitempty" yaml:"consent_overrides,omitempty"`
+
 	// Turn-level assertions (for testing only)
 	Assertions []asrt.AssertionConfig `json:"assertions,omitempty" yaml:"assertions,omitempty"`
 }

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2069,6 +2069,12 @@
         "streaming": {
           "type": "boolean"
         },
+        "consent_overrides": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
         "assertions": {
           "items": {
             "$ref": "#/$defs/AssertionConfig"

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -396,6 +396,12 @@
         "streaming": {
           "type": "boolean"
         },
+        "consent_overrides": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
         "assertions": {
           "items": {
             "$ref": "#/$defs/AssertionConfig"

--- a/tools/arena/consent/hook.go
+++ b/tools/arena/consent/hook.go
@@ -1,0 +1,115 @@
+// Package consent provides consent simulation for PromptArena scenarios.
+// It implements a hooks.ToolHook that intercepts client-side tool execution
+// and simulates consent grant, denial, or timeout based on scenario overrides.
+package consent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+type contextKey int
+
+const (
+	consentOverridesKey contextKey = iota
+	toolRegistryKey
+)
+
+// SimulationHook implements hooks.ToolHook to simulate consent decisions
+// for client-side tools during PromptArena scenario execution.
+type SimulationHook struct{}
+
+// NewSimulationHook creates a new consent simulation hook.
+func NewSimulationHook() *SimulationHook {
+	return &SimulationHook{}
+}
+
+// Name returns the hook name.
+func (h *SimulationHook) Name() string {
+	return "consent-simulation"
+}
+
+// BeforeExecution checks consent overrides and blocks denied/timed-out tools.
+func (h *SimulationHook) BeforeExecution(ctx context.Context, req hooks.ToolRequest) hooks.Decision {
+	overrides := OverridesFromContext(ctx)
+	if overrides == nil {
+		return hooks.Allow
+	}
+
+	action, ok := overrides[req.Name]
+	if !ok {
+		return hooks.Allow
+	}
+
+	switch action {
+	case "deny":
+		reason := buildDenyMessage(req.Name, h.lookupDeclineStrategy(ctx, req.Name))
+		return hooks.Decision{Allow: false, Reason: reason}
+
+	case "timeout":
+		return hooks.Decision{
+			Allow:  false,
+			Reason: fmt.Sprintf("Tool %s timed out waiting for user consent", req.Name),
+		}
+
+	default: // "grant" or any other value
+		return hooks.Allow
+	}
+}
+
+// AfterExecution is a no-op — always allows.
+func (h *SimulationHook) AfterExecution(_ context.Context, _ hooks.ToolRequest, _ hooks.ToolResponse) hooks.Decision {
+	return hooks.Allow
+}
+
+// lookupDeclineStrategy retrieves the decline strategy from the tool descriptor.
+func (h *SimulationHook) lookupDeclineStrategy(ctx context.Context, toolName string) string {
+	registry := ToolRegistryFromContext(ctx)
+	if registry == nil {
+		return ""
+	}
+
+	descriptor := registry.Get(toolName)
+	if descriptor == nil || descriptor.ClientConfig == nil || descriptor.ClientConfig.Consent == nil {
+		return ""
+	}
+
+	return descriptor.ClientConfig.Consent.DeclineStrategy
+}
+
+// buildDenyMessage returns the appropriate denial message based on decline strategy.
+func buildDenyMessage(toolName, strategy string) string {
+	switch strategy {
+	case tools.DeclineStrategyFallback:
+		return fmt.Sprintf("Tool %s unavailable: user declined consent. Use alternative approach.", toolName)
+	case tools.DeclineStrategyRetry:
+		return fmt.Sprintf("Tool %s denied: user declined consent. Try a different approach.", toolName)
+	default: // "error" or unset
+		return fmt.Sprintf("Tool %s denied: user declined consent", toolName)
+	}
+}
+
+// WithConsentOverrides stores consent overrides in the context.
+func WithConsentOverrides(ctx context.Context, overrides map[string]string) context.Context {
+	return context.WithValue(ctx, consentOverridesKey, overrides)
+}
+
+// OverridesFromContext retrieves consent overrides from the context.
+func OverridesFromContext(ctx context.Context) map[string]string {
+	v, _ := ctx.Value(consentOverridesKey).(map[string]string)
+	return v
+}
+
+// WithToolRegistry stores a tool registry in the context.
+func WithToolRegistry(ctx context.Context, registry *tools.Registry) context.Context {
+	return context.WithValue(ctx, toolRegistryKey, registry)
+}
+
+// ToolRegistryFromContext retrieves a tool registry from the context.
+func ToolRegistryFromContext(ctx context.Context) *tools.Registry {
+	v, _ := ctx.Value(toolRegistryKey).(*tools.Registry)
+	return v
+}

--- a/tools/arena/consent/hook_test.go
+++ b/tools/arena/consent/hook_test.go
@@ -1,0 +1,224 @@
+package consent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+func init() {
+	if testing.Testing() {
+		config.SchemaValidationEnabled = false
+	}
+}
+
+func TestSimulationHook_Name(t *testing.T) {
+	h := NewSimulationHook()
+	if h.Name() != "consent-simulation" {
+		t.Errorf("expected name 'consent-simulation', got %q", h.Name())
+	}
+}
+
+func TestSimulationHook_Grant(t *testing.T) {
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "grant",
+	})
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if !d.Allow {
+		t.Errorf("expected Allow=true for grant override, got Allow=false, reason=%q", d.Reason)
+	}
+}
+
+func TestSimulationHook_Deny_ErrorStrategy(t *testing.T) {
+	registry := tools.NewRegistry()
+	_ = registry.Register(&tools.ToolDescriptor{
+		Name: "get_location",
+		Mode: "client",
+		ClientConfig: &tools.ClientConfig{
+			Consent: &tools.ConsentConfig{
+				Required:        true,
+				DeclineStrategy: tools.DeclineStrategyError,
+			},
+		},
+	})
+
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "deny",
+	})
+	ctx = WithToolRegistry(ctx, registry)
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if d.Allow {
+		t.Fatal("expected Allow=false for deny override")
+	}
+	expected := "Tool get_location denied: user declined consent"
+	if d.Reason != expected {
+		t.Errorf("expected reason %q, got %q", expected, d.Reason)
+	}
+}
+
+func TestSimulationHook_Deny_FallbackStrategy(t *testing.T) {
+	registry := tools.NewRegistry()
+	_ = registry.Register(&tools.ToolDescriptor{
+		Name: "get_location",
+		Mode: "client",
+		ClientConfig: &tools.ClientConfig{
+			Consent: &tools.ConsentConfig{
+				Required:        true,
+				DeclineStrategy: tools.DeclineStrategyFallback,
+			},
+		},
+	})
+
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "deny",
+	})
+	ctx = WithToolRegistry(ctx, registry)
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if d.Allow {
+		t.Fatal("expected Allow=false for deny override")
+	}
+	expected := "Tool get_location unavailable: user declined consent. Use alternative approach."
+	if d.Reason != expected {
+		t.Errorf("expected reason %q, got %q", expected, d.Reason)
+	}
+}
+
+func TestSimulationHook_Deny_RetryStrategy(t *testing.T) {
+	registry := tools.NewRegistry()
+	_ = registry.Register(&tools.ToolDescriptor{
+		Name: "get_location",
+		Mode: "client",
+		ClientConfig: &tools.ClientConfig{
+			Consent: &tools.ConsentConfig{
+				Required:        true,
+				DeclineStrategy: tools.DeclineStrategyRetry,
+			},
+		},
+	})
+
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "deny",
+	})
+	ctx = WithToolRegistry(ctx, registry)
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if d.Allow {
+		t.Fatal("expected Allow=false for deny override")
+	}
+	expected := "Tool get_location denied: user declined consent. Try a different approach."
+	if d.Reason != expected {
+		t.Errorf("expected reason %q, got %q", expected, d.Reason)
+	}
+}
+
+func TestSimulationHook_Deny_DefaultStrategy(t *testing.T) {
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "deny",
+	})
+	// No registry — should fall back to default (error) message
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if d.Allow {
+		t.Fatal("expected Allow=false for deny override")
+	}
+	expected := "Tool get_location denied: user declined consent"
+	if d.Reason != expected {
+		t.Errorf("expected reason %q, got %q", expected, d.Reason)
+	}
+}
+
+func TestSimulationHook_Timeout(t *testing.T) {
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "timeout",
+	})
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if d.Allow {
+		t.Fatal("expected Allow=false for timeout override")
+	}
+	expected := "Tool get_location timed out waiting for user consent"
+	if d.Reason != expected {
+		t.Errorf("expected reason %q, got %q", expected, d.Reason)
+	}
+}
+
+func TestSimulationHook_NoOverride(t *testing.T) {
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"other_tool": "deny",
+	})
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if !d.Allow {
+		t.Errorf("expected Allow=true for tool not in overrides, got Allow=false")
+	}
+}
+
+func TestSimulationHook_NoContext(t *testing.T) {
+	h := NewSimulationHook()
+	d := h.BeforeExecution(context.Background(), hooks.ToolRequest{Name: "get_location"})
+	if !d.Allow {
+		t.Errorf("expected Allow=true with no overrides in context, got Allow=false")
+	}
+}
+
+func TestSimulationHook_AfterExecution(t *testing.T) {
+	h := NewSimulationHook()
+	d := h.AfterExecution(context.Background(), hooks.ToolRequest{Name: "get_location"}, hooks.ToolResponse{})
+	if !d.Allow {
+		t.Errorf("expected AfterExecution to always return Allow=true")
+	}
+}
+
+func TestContextRoundTrip_ConsentOverrides(t *testing.T) {
+	overrides := map[string]string{
+		"tool_a": "grant",
+		"tool_b": "deny",
+	}
+	ctx := WithConsentOverrides(context.Background(), overrides)
+	got := OverridesFromContext(ctx)
+
+	if len(got) != len(overrides) {
+		t.Fatalf("expected %d overrides, got %d", len(overrides), len(got))
+	}
+	for k, v := range overrides {
+		if got[k] != v {
+			t.Errorf("expected override[%q]=%q, got %q", k, v, got[k])
+		}
+	}
+}
+
+func TestContextRoundTrip_ToolRegistry(t *testing.T) {
+	registry := tools.NewRegistry()
+	ctx := WithToolRegistry(context.Background(), registry)
+	got := ToolRegistryFromContext(ctx)
+	if got != registry {
+		t.Error("expected same registry instance from context")
+	}
+}
+
+func TestOverridesFromContext_Empty(t *testing.T) {
+	got := OverridesFromContext(context.Background())
+	if got != nil {
+		t.Errorf("expected nil from empty context, got %v", got)
+	}
+}
+
+func TestToolRegistryFromContext_Empty(t *testing.T) {
+	got := ToolRegistryFromContext(context.Background())
+	if got != nil {
+		t.Errorf("expected nil from empty context, got %v", got)
+	}
+}

--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -312,6 +312,7 @@ func (ce *DefaultConversationExecutor) buildTurnRequest(req ConversationRequest,
 		EventBus:         req.EventBus,
 		ScriptedContent:  scenarioTurn.Content, // Legacy text content (for backward compatibility)
 		ScriptedParts:    scenarioTurn.Parts,   // Multimodal content parts (takes precedence over ScriptedContent)
+		ConsentOverrides: scenarioTurn.ConsentOverrides,
 		Assertions:       scenarioTurn.Assertions,
 		TurnEvalRunner:   ce.packEvalHook,
 		Metadata:         metadata,

--- a/tools/arena/turnexecutors/interfaces.go
+++ b/tools/arena/turnexecutors/interfaces.go
@@ -89,6 +89,10 @@ type TurnRequest struct {
 	SelfPlayRole    string                   // SelfPlayExecutor: the self-play role
 	SelfPlayPersona string                   // SelfPlayExecutor: the persona to use
 
+	// ConsentOverrides controls consent simulation for client-side tools.
+	// Keys are tool names, values are "grant", "deny", or "timeout".
+	ConsentOverrides map[string]string
+
 	// Assertions to validate after turn execution
 	Assertions     []assertions.AssertionConfig
 	TurnEvalRunner interface{} // Optional stages.TurnEvalRunner for dual-write (Phase 2)

--- a/tools/arena/turnexecutors/pipeline_executor.go
+++ b/tools/arena/turnexecutors/pipeline_executor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/media"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
@@ -17,6 +18,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/storage"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/consent"
 	arenastages "github.com/AltairaLabs/PromptKit/tools/arena/stages"
 )
 
@@ -313,17 +315,10 @@ func (e *PipelineExecutor) buildStagePipeline(
 		stages = append(stages, stage.NewMediaConvertStage(mediaConvertConfig))
 	}
 
-	// 6. Provider stage
-	providerConfig := buildProviderConfig(req)
-	stages = append(stages, stage.NewProviderStage(
-		req.Provider,
-		e.toolRegistry,
-		buildToolPolicy(req.Scenario),
-		providerConfig,
-	))
-
+	// 6. Provider stage (with consent simulation hook if overrides are present)
 	// 7. Guardrail evaluation (evaluative, not enforcement — records pass/fail for assertions)
-	stages = append(stages, arenastages.NewGuardrailEvalStage())
+	providerConfig := buildProviderConfig(req)
+	stages = append(stages, e.buildProviderStage(req, providerConfig), arenastages.NewGuardrailEvalStage())
 
 	// 7a. Media externalization (if configured)
 	if mediaConfig := buildMediaConfig(req.ConversationID, e.mediaStorage); mediaConfig != nil {
@@ -360,6 +355,16 @@ func (e *PipelineExecutor) handleExecutionError(provider providers.Provider, err
 	return fmt.Errorf("pipeline execution failed: %w", err)
 }
 
+// buildProviderStage creates a provider stage, attaching a consent simulation hook if overrides are present.
+func (e *PipelineExecutor) buildProviderStage(req *TurnRequest, providerConfig *stage.ProviderConfig) stage.Stage {
+	toolPolicy := buildToolPolicy(req.Scenario)
+	if len(req.ConsentOverrides) > 0 {
+		hookReg := hooks.NewRegistry(hooks.WithToolHook(consent.NewSimulationHook()))
+		return stage.NewProviderStageWithHooks(req.Provider, e.toolRegistry, toolPolicy, providerConfig, nil, hookReg)
+	}
+	return stage.NewProviderStage(req.Provider, e.toolRegistry, toolPolicy, providerConfig)
+}
+
 // Execute runs the conversation through the pipeline and returns the new messages generated.
 // This is the new flattened API that works directly with message lists.
 //
@@ -370,6 +375,12 @@ func (e *PipelineExecutor) Execute(
 	req *TurnRequest,
 	userMessage *types.Message,
 ) error {
+	// Inject consent overrides into context if present
+	if len(req.ConsentOverrides) > 0 {
+		ctx = consent.WithConsentOverrides(ctx, req.ConsentOverrides)
+		ctx = consent.WithToolRegistry(ctx, e.toolRegistry)
+	}
+
 	// Build base variables and stage pipeline
 	baseVariables := buildBaseVariables(req.Region)
 	p, err := e.buildStagePipeline(req, baseVariables)

--- a/tools/arena/turnexecutors/selfplay_executor.go
+++ b/tools/arena/turnexecutors/selfplay_executor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/consent"
 	"github.com/AltairaLabs/PromptKit/tools/arena/selfplay"
 	arenastages "github.com/AltairaLabs/PromptKit/tools/arena/stages"
 )
@@ -321,6 +322,12 @@ func (e *SelfPlayExecutor) executeStreamingPipeline(
 ) {
 	messages := []types.Message{*userMessage}
 
+	// Inject consent overrides into context if present
+	if len(req.ConsentOverrides) > 0 {
+		ctx = consent.WithConsentOverrides(ctx, req.ConsentOverrides)
+		ctx = consent.WithToolRegistry(ctx, e.pipelineExecutor.toolRegistry)
+	}
+
 	// Build and execute stage pipeline
 	pl, err := e.buildStreamingStages(req)
 	if err != nil {
@@ -406,9 +413,7 @@ func (e *SelfPlayExecutor) buildStreamingStages(req *TurnRequest) (*stage.Stream
 		Seed:        req.Seed,
 	}
 
-	stages = append(stages,
-		stage.NewProviderStage(req.Provider, e.pipelineExecutor.toolRegistry, buildToolPolicy(req.Scenario), providerConfig),
-	)
+	stages = append(stages, e.pipelineExecutor.buildProviderStage(req, providerConfig))
 
 	// StateStore Save stage
 	if req.StateStoreConfig != nil && req.ConversationID != "" {


### PR DESCRIPTION
## Summary
- Add `consent_overrides` per-turn field to Arena scenario definitions, enabling scenario authors to simulate consent grant, denial, or timeout for client-side tools
- Implement `ConsentSimulationHook` (via `hooks.ToolHook`) that intercepts tool execution and returns strategy-appropriate error messages based on the tool's `decline_strategy` (error/fallback/retry)
- Wire hook into `PipelineExecutor` and `SelfPlayExecutor` pipeline construction with context-based override/registry injection
- Add example `client-tools/` scenario demonstrating consent grant and denial flows

## Test plan
- [x] 14 unit tests in `tools/arena/consent/` covering all override actions, decline strategies, context round-trips, and edge cases (96.8% coverage)
- [x] All existing arena tests pass (`go test ./tools/arena/... -count=1`)
- [x] All pkg tests pass (`go test ./pkg/... -count=1`)
- [x] No new lint issues (`golangci-lint run --new-from-rev=HEAD`)
- [x] Pre-commit hook passes (lint, build, test, coverage ≥80%)
- [x] Schema regenerated and verified (`consent_overrides` in scenario.json)
- [ ] CI checks