### PR TITLE
feat(sdk): WithRecording option, binary stripping, and tool call events

### DIFF
--- a/docs/src/content/docs/arena/explanation/session-recording.md
+++ b/docs/src/content/docs/arena/explanation/session-recording.md
@@ -26,19 +26,25 @@ Session recording provides a complete audit trail of LLM interactions. Unlike si
 
 ### Event Emitter
 
-The `Emitter` is the heart of session recording. It captures events as they occur:
+The `Emitter` captures events as they occur during a conversation:
 
 ```go
 emitter := events.NewEmitter(eventBus, runID, scenarioID, conversationID)
 
 // Events are emitted automatically during conversation
 emitter.ConversationStarted(systemPrompt)
-emitter.MessageCreated(role, content)
+emitter.MessageCreated(role, content, index, parts, toolCalls, toolResult)
 emitter.AudioInput(audioData)
 emitter.ProviderCallStarted(provider, model)
 emitter.ToolCallStarted(toolName, args)
 // ...
 ```
+
+:::note[Binary data handling]
+The emitter's `MessageCreated()` automatically strips binary data (base64 `Data` and `FilePath`) from content parts, emitting only metadata (MIMEType, SizeKB, dimensions). This keeps observability events lightweight.
+
+**RecordingStage** bypasses the emitter and publishes events directly to the EventBus with full binary data intact. Use `sdk.WithRecording()` to enable this in SDK pipelines, or insert RecordingStages manually in Arena pipelines.
+:::
 
 Events flow through an EventBus to registered subscribers:
 

--- a/docs/src/content/docs/arena/how-to/session-recording.md
+++ b/docs/src/content/docs/arena/how-to/session-recording.md
@@ -56,19 +56,62 @@ Each recording is a JSONL file containing:
 
 ## Captured Events
 
-Session recordings capture a comprehensive event stream:
+Session recordings capture a comprehensive event stream covering all runtime activity:
 
-| Event Type | Description |
-|------------|-------------|
-| `conversation.started` | Session initialization with system prompt |
-| `message.created` | User and assistant messages |
-| `audio.input` | User audio chunks (voice conversations) |
-| `audio.output` | Assistant audio chunks (voice responses) |
-| `provider.call.started` | LLM API call initiation |
-| `provider.call.completed` | LLM API call completion with tokens/cost |
-| `tool.call.started` | Tool/function call initiation |
-| `tool.call.completed` | Tool result with timing |
-| `validation.*` | Validator execution and results |
+| Category | Event Type | Description |
+|----------|------------|-------------|
+| **Conversation** | `conversation.started` | Session initialization with system prompt |
+| **Messages** | `message.created` | User and assistant messages with multimodal content parts |
+| | `message.updated` | Metadata updates (latency, token counts, cost) |
+| **Pipeline** | `pipeline.started` | Pipeline execution start with middleware count |
+| | `pipeline.completed` | Pipeline completion with total cost/tokens |
+| | `pipeline.failed` | Pipeline failure with error |
+| **Stages** | `stage.started` | Streaming stage start with type info |
+| | `stage.completed` | Stage completion with duration |
+| | `stage.failed` | Stage failure with error and duration |
+| **Middleware** | `middleware.started` | Middleware execution start |
+| | `middleware.completed` | Middleware completion with duration |
+| | `middleware.failed` | Middleware failure with error |
+| **Provider** | `provider.call.started` | LLM API call initiation (provider, model, message count) |
+| | `provider.call.completed` | LLM API call completion (tokens, cost, cached tokens) |
+| | `provider.call.failed` | LLM API call failure with error |
+| **Tools** | `tool.call.started` | Tool execution start with arguments |
+| | `tool.call.completed` | Tool completion with duration and status |
+| | `tool.call.failed` | Tool failure with error and duration |
+| **Client Tools** | `tool.client.request` | Client-side tool request with consent message and categories |
+| **Validation** | `validation.started` | Validator execution start |
+| | `validation.passed` | Validation success with duration |
+| | `validation.failed` | Validation failure with violations |
+| **Context** | `context.built` | Context window assembly (token count, budget, truncation) |
+| | `context.token_budget_exceeded` | Token budget overflow (required vs. budget) |
+| **State** | `state.loaded` | Conversation state loaded from store |
+| | `state.saved` | Conversation state persisted |
+| **Streaming** | `stream.interrupted` | Stream interruption with reason |
+| **Workflow** | `workflow.transitioned` | Workflow state transition (from/to states, event, prompt task) |
+| | `workflow.completed` | Workflow reached terminal state (final state, transition count) |
+| **Audio** | `audio.input` | User/environment audio chunks |
+| | `audio.output` | Assistant audio chunks |
+| | `audio.transcription` | Speech-to-text transcription result |
+| **Video** | `video.frame` | Video frame capture |
+| **Images** | `image.input` | Image input from user/environment |
+| | `image.output` | Image output from agent |
+| | `screenshot` | Screenshot capture |
+
+### Multimodal Content in Events
+
+The `message.created` event includes a `Parts` field (`[]ContentPart`) for multimodal messages. Each `ContentPart` has a `Type` field indicating the content kind:
+
+- **`text`** — Text content with a `Text` field
+- **`image`** — Image content with a `Media` field containing MIME type, URL, or inline data
+- **`audio`** — Audio content with a `Media` field
+- **`video`** — Video content with a `Media` field
+
+Audio, video, and image events use `BinaryPayload` for content storage:
+- `InlineData` — Raw bytes for small payloads
+- `StorageReference` — Backend-specific storage reference for externalized content
+- `MIMEType` — Content type (e.g., `audio/pcm`, `image/png`)
+
+Audio events include `AudioMetadata` (sample rate, channels, encoding, duration) and video events include `VideoMetadata` (width, height, frame rate) for media reconstruction.
 
 ## Working with Recordings
 
@@ -352,9 +395,12 @@ Save recordings as artifacts for debugging failed tests:
 ### Captured in Recordings
 - Complete event stream with precise timestamps
 - Audio chunks for voice conversations
-- Message content and metadata
-- Tool calls with arguments and results
+- Message content and metadata, including multimodal content parts
+- Tool calls with arguments, results, and timing
+- Client tool requests with consent information
 - Provider call timing and token usage
+- Stage and middleware execution lifecycle
+- Workflow state transitions and completion
 - Validation results
 
 ### Not Captured (stored separately)

--- a/docs/src/content/docs/arena/tutorials/08-client-tools.md
+++ b/docs/src/content/docs/arena/tutorials/08-client-tools.md
@@ -1,0 +1,241 @@
+---
+title: 'Tutorial 8: Client-Side Tools'
+---
+Learn how to test tools that execute on the caller's device, including consent simulation for grant and deny scenarios.
+
+## What You'll Learn
+
+- Define client-mode tools that run on the user's device
+- Use `mock_result` to provide deterministic test data
+- Configure consent simulation for client-side tools
+- Test both consent grant and consent deny scenarios
+
+## Prerequisites
+
+- Completed [Tutorials 1-3](01-first-test)
+- Understanding of tool calling in LLMs (see [Tutorial 4](04-mcp-tools))
+
+## What are Client-Side Tools?
+
+Most tools execute server-side -- the LLM calls them, and the server runs the logic. **Client-side tools** are different: they execute on the caller's device. Think GPS location, camera access, biometric sensors, or local file pickers. The LLM requests the tool call, but the actual execution happens on the end user's client.
+
+Because these tools access sensitive device capabilities, they typically require **user consent** before executing. PromptArena lets you simulate this consent flow so you can test how your LLM handles both granted and denied permissions.
+
+## Step 1: Define a Client-Mode Tool
+
+Create a tool definition file at `tools/get_location.tool.yaml`:
+
+```yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: get_location
+spec:
+  description: "Get the user's current GPS coordinates"
+  mode: client
+  timeout_ms: 5000
+  input_schema:
+    type: object
+    properties:
+      accuracy:
+        type: string
+        enum: ["high", "low"]
+        description: "Desired accuracy level"
+  output_schema:
+    type: object
+    properties:
+      lat:
+        type: number
+      lng:
+        type: number
+  mock_result:
+    lat: 37.7749
+    lng: -122.4194
+  client:
+    consent:
+      required: true
+      message: "Allow location access?"
+      decline_strategy: error
+    categories:
+      - location
+```
+
+Key fields to note:
+
+- **`mode: client`** -- marks this tool as client-side rather than server-executed.
+- **`mock_result`** -- provides a fixed response when running in test mode. This is the data the LLM receives as if the device returned it.
+- **`client.consent.required: true`** -- indicates the tool needs user permission before executing.
+- **`client.consent.decline_strategy: error`** -- controls what happens when consent is denied. With `error`, the tool returns an error to the LLM so it can respond accordingly.
+
+## Step 2: Create a Prompt Configuration
+
+Create `prompts/chat.yaml` to tell the LLM about the available tool:
+
+```yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: chat
+spec:
+  task_type: "chat"
+  version: "v1.0.0"
+  description: "Chat assistant with client-side tool access"
+
+  system_template: |
+    You are a helpful assistant with access to the user's device capabilities.
+
+    Available tools:
+    - get_location: Get the user's GPS coordinates (requires user consent)
+
+    When the user asks about their location, use the get_location tool.
+    If the tool is unavailable or denied, politely inform the user that
+    you are unable to access their location and suggest they provide it manually.
+
+  allowed_tools:
+    - get_location
+```
+
+## Step 3: Write Scenarios
+
+You need two scenarios: one where the user grants consent and one where they deny it.
+
+### Consent Grant Scenario
+
+Create `scenarios/consent-grant.scenario.yaml`:
+
+```yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: consent-grant
+spec:
+  id: consent-grant
+  task_type: chat
+  description: "Verifies that a client tool executes when consent is granted (default)"
+
+  turns:
+    - role: user
+      content: "Where am I right now?"
+      assertions:
+        - type: tool_called
+          params:
+            tool_name: get_location
+            message: "Should call get_location tool when user asks for location"
+
+    - role: user
+      content: "Tell me more about this area"
+      assertions:
+        - type: content_matches
+          params:
+            pattern: "(?i)(san francisco|37\\.77|location)"
+            message: "Should reference the location data from the tool result"
+```
+
+When no `consent_overrides` are specified, consent defaults to **grant**. The LLM calls `get_location`, receives the `mock_result` data, and uses it in its response.
+
+### Consent Deny Scenario
+
+Create `scenarios/consent-deny.scenario.yaml`:
+
+```yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: consent-deny
+spec:
+  id: consent-deny
+  task_type: chat
+  description: "Verifies that the LLM handles consent denial gracefully"
+
+  turns:
+    - role: user
+      content: "Where am I right now?"
+      consent_overrides:
+        get_location: deny
+      assertions:
+        - type: tool_called
+          params:
+            tool_name: get_location
+            message: "Should attempt to call get_location tool"
+
+    - role: user
+      content: "Can you try again?"
+      assertions:
+        - type: content_matches
+          params:
+            pattern: "(?i)(unable|denied|provide|manually|sorry)"
+            message: "Should explain that location access was denied and suggest alternatives"
+```
+
+The key line is `consent_overrides: { get_location: deny }`. This simulates the user declining the consent prompt. The LLM should detect the denial and respond gracefully rather than crashing or ignoring the error.
+
+## Step 4: Configure Arena
+
+Create `config.arena.yaml` to tie everything together:
+
+```yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: client-tools-consent
+spec:
+  prompt_configs:
+    - id: chat
+      file: prompts/chat.yaml
+
+  providers:
+    - file: providers/mock-provider.yaml
+
+  scenarios:
+    - file: scenarios/consent-grant.scenario.yaml
+    - file: scenarios/consent-deny.scenario.yaml
+
+  tools:
+    - file: tools/get_location.tool.yaml
+
+  defaults:
+    temperature: 0.0
+    max_tokens: 500
+    seed: 42
+    output:
+      dir: out
+      formats: ["json", "html"]
+    fail_on:
+      - provider_error
+```
+
+The `tools` section references the client-mode tool file. Arena registers the tool with the pipeline and handles consent simulation automatically based on your scenario overrides.
+
+## Step 5: Run the Tests
+
+Run the tests from your project directory:
+
+```bash
+PROMPTKIT_SCHEMA_SOURCE=local promptarena run --ci --format html
+```
+
+You should see output indicating both scenarios were executed:
+
+- **consent-grant** -- the tool is called, `mock_result` is returned, and the LLM uses the coordinates in its response.
+- **consent-deny** -- the tool call is attempted, consent is denied, and the LLM responds with a helpful fallback message.
+
+Open `out/report.html` in a browser to view the full results.
+
+## Summary
+
+In this tutorial you learned how to:
+
+1. Define a **client-mode tool** with `mode: client` that represents device-side functionality
+2. Use **`mock_result`** to provide deterministic data during testing without a real device
+3. Configure **consent simulation** with `client.consent` settings on the tool
+4. Test the **consent grant** path (default behavior) to verify the tool executes correctly
+5. Test the **consent deny** path using `consent_overrides` to verify graceful degradation
+
+Testing consent flows is important because real users will sometimes deny permissions. Your LLM should always handle denial gracefully -- offering alternatives rather than failing silently.
+
+For a complete working example, see the [`examples/client-tools/`](https://github.com/AltairaLabs/PromptKit/tree/main/examples/client-tools) directory in the PromptKit repository.
+
+## Next Steps
+
+- **[Tutorial 5: CI Integration](05-ci-integration)** -- automate client-tool tests in your CI/CD pipeline
+- **[Tutorial 4: MCP Tools](04-mcp-tools)** -- learn about server-side tool testing for comparison

--- a/docs/src/content/docs/sdk/explanation/observability.md
+++ b/docs/src/content/docs/sdk/explanation/observability.md
@@ -157,7 +157,19 @@ type BlobStore interface {
 }
 ```
 
-**RecordingStage** is a pipeline stage that publishes content-carrying events (like `message.created`) to the EventBus as elements flow through the pipeline. It observes without modifying data, making it safe to insert at any position:
+**Binary stripping in events**: The `Emitter.MessageCreated()` method automatically strips binary data (base64 `Data` and `FilePath`) from content parts, keeping only metadata (MIMEType, SizeKB, dimensions, URL references). This prevents large binary payloads from flowing through observability events when recording is not enabled.
+
+**RecordingStage** is a pipeline stage that publishes content-carrying events (like `message.created`) directly to the EventBus, bypassing the emitter's binary stripping. This ensures that full binary data is captured for session replay. RecordingStages observe without modifying data, making them safe to insert at any position.
+
+To enable RecordingStages via the SDK, use `WithRecording()`:
+
+```go
+conv, _ := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithRecording(nil), // defaults: audio=true, video=false, images=true
+)
+```
+
+This inserts an input RecordingStage (after template assembly) and an output RecordingStage (before state store save). For manual pipeline construction:
 
 ```go
 pipeline := stage.NewPipelineBuilder().

--- a/docs/src/content/docs/sdk/how-to/client-tools.md
+++ b/docs/src/content/docs/sdk/how-to/client-tools.md
@@ -1,0 +1,163 @@
+---
+title: Client-Side Tools
+sidebar:
+  order: 5
+---
+Tools that execute on the client rather than the server -- GPS, camera, biometrics, local file access, etc. Defined with `mode: client` in your tool YAML.
+
+## Define a Client Tool
+
+```yaml
+tools:
+  get_location:
+    name: get_location
+    description: Get the user's current GPS location
+    mode: client
+    client:
+      consent:
+        required: true
+        message: "This app wants to access your location"
+        decline_strategy: reject
+    parameters:
+      type: object
+      properties: {}
+```
+
+## Synchronous Handler (OnClientTool)
+
+Register a handler that runs immediately when the LLM invokes the tool:
+
+```go
+conv.OnClientTool("get_location", func(ctx context.Context, req sdk.ClientToolRequest) (any, error) {
+    return map[string]any{"lat": 40.7128, "lon": -74.0060}, nil
+})
+
+resp, _ := conv.Send(ctx, "Where am I?")
+fmt.Println(resp.Text()) // "You're in New York City!"
+```
+
+The pipeline handles the tool call automatically -- the LLM receives the result and continues generating.
+
+## Deferred Mode
+
+When no handler is registered, the pipeline suspends and returns pending tool calls to the caller:
+
+```go
+resp, _ := conv.Send(ctx, "Where am I?")
+
+if resp.HasPendingClientTools() {
+    for _, tool := range resp.ClientTools() {
+        fmt.Printf("Tool: %s (consent: %s)\n", tool.ToolName, tool.ConsentMsg)
+
+        // Fulfill the tool call
+        conv.SendToolResult(ctx, tool.CallID, map[string]any{
+            "lat": 40.7128,
+            "lon": -74.0060,
+        })
+
+        // Or reject it
+        // conv.RejectClientTool(ctx, tool.CallID, "User denied location access")
+    }
+
+    // Resume to get the final response
+    resp, _ = conv.Resume(ctx)
+    fmt.Println(resp.Text())
+}
+```
+
+## Streaming Deferred Mode
+
+Use `ResumeStream` after fulfilling tool calls during streaming:
+
+```go
+for chunk := range conv.Stream(ctx, "Where am I?") {
+    if chunk.Type == sdk.ChunkClientTool {
+        // Fulfill the tool call
+        conv.SendToolResult(ctx, chunk.ClientTool.CallID, map[string]any{
+            "lat": 40.7128,
+            "lon": -74.0060,
+        })
+
+        // Resume streaming for the final response
+        for resumeChunk := range conv.ResumeStream(ctx) {
+            fmt.Print(resumeChunk.Text)
+        }
+        break
+    }
+    fmt.Print(chunk.Text)
+}
+```
+
+## Consent Configuration
+
+Control consent prompts in the tool YAML:
+
+| Field | Description |
+|-------|-------------|
+| `client.consent.required` | If `true`, consent metadata is surfaced before execution |
+| `client.consent.message` | Message to display to the user |
+| `client.consent.decline_strategy` | What happens if declined: `reject` (return error) or `skip` (omit tool result) |
+
+## A2A Integration
+
+When serving via an A2A server, client tool suspension surfaces as an `input_required` task state. Tool metadata appears in the status message parts:
+
+```json
+{
+  "status": {
+    "state": "input_required",
+    "message": {
+      "role": "agent",
+      "parts": [
+        {
+          "text": "Client tool required: get_location",
+          "metadata": {
+            "tool_call_id": "call_abc123",
+            "tool_name": "get_location",
+            "tool_args": { "accuracy": "high" },
+            "consent_message": "This app wants to access your location"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+The A2A client sends tool results back via `message/send` with `tool_call_id` and `tool_result` in part metadata:
+
+```json
+{
+  "method": "message/send",
+  "params": {
+    "message": {
+      "contextId": "original-context-id",
+      "role": "user",
+      "parts": [
+        {
+          "metadata": {
+            "tool_call_id": "call_abc123",
+            "tool_result": { "lat": 40.7128, "lon": -74.0060 }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+To reject a tool, use `"rejected": "reason"` instead of `"tool_result"`:
+
+```json
+{
+  "metadata": {
+    "tool_call_id": "call_abc123",
+    "rejected": "User denied location access"
+  }
+}
+```
+
+## See Also
+
+- [Register Tools](register-tools)
+- [Send Messages](send-messages)

--- a/docs/src/content/docs/sdk/reference/index.md
+++ b/docs/src/content/docs/sdk/reference/index.md
@@ -123,6 +123,28 @@ Attach a video file.
 sdk.WithVideoFile("/path/to/video.mp4")
 ```
 
+### WithRecording
+
+Enable session recording by inserting RecordingStages into the pipeline. These stages capture full binary content (images, audio, video) and publish events directly to the EventBus for session replay.
+
+If `cfg` is nil, default settings are used (audio=true, video=false, images=true). An EventBus is automatically created if none was provided via `WithEventBus`.
+
+```go
+// Use defaults
+sdk.WithRecording(nil)
+
+// Custom config
+sdk.WithRecording(&sdk.RecordingConfig{
+    IncludeAudio:  true,
+    IncludeVideo:  true,
+    IncludeImages: true,
+})
+```
+
+:::note
+Without `WithRecording`, the emitter's `MessageCreated` events strip binary data from content parts (keeping only metadata like MIMEType, SizeKB, dimensions). RecordingStages bypass the emitter and publish full binary data directly to the EventBus.
+:::
+
 ## Conversation Type
 
 ### Send

--- a/examples/client-tools/scenarios/consent-grant.scenario.yaml
+++ b/examples/client-tools/scenarios/consent-grant.scenario.yaml
@@ -10,6 +10,8 @@ spec:
   turns:
     - role: user
       content: "Where am I right now?"
+      consent_overrides:
+        get_location: grant
       assertions:
         - type: tool_called
           params:

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -1,6 +1,10 @@
 package events
 
-import "time"
+import (
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
 
 // Emitter provides helpers for publishing runtime events with shared metadata.
 type Emitter struct {
@@ -275,9 +279,13 @@ func (e *Emitter) EmitCustom(
 }
 
 // MessageCreated emits the message.created event.
+// Binary data (base64 Data, FilePath) is stripped from content parts to avoid
+// large payloads in observability events. RecordingStage bypasses the emitter
+// and publishes directly to the EventBus with full binary data.
 func (e *Emitter) MessageCreated(
 	role, content string,
 	index int,
+	parts []types.ContentPart,
 	toolCalls []MessageToolCall,
 	toolResult *MessageToolResult,
 ) {
@@ -285,6 +293,7 @@ func (e *Emitter) MessageCreated(
 		Role:       role,
 		Content:    content,
 		Index:      index,
+		Parts:      types.MetadataOnlyParts(parts),
 		ToolCalls:  toolCalls,
 		ToolResult: toolResult,
 	})

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 func TestEmitterPublishesSharedContext(t *testing.T) {
@@ -133,7 +135,7 @@ func TestEmitterHandlesNilEmitter(t *testing.T) {
 	var emitter *Emitter
 	// Should not panic when emitter is nil
 	emitter.PipelineStarted(1)
-	emitter.MessageCreated("user", "hello", 0, nil, nil)
+	emitter.MessageCreated("user", "hello", 0, nil, nil, nil)
 	emitter.MessageUpdated(0, 100, 10, 20, 0.001)
 	emitter.ConversationStarted("system prompt")
 	emitter.AudioInput(&AudioInputData{Actor: "user"})
@@ -158,7 +160,7 @@ func TestEmitter_MessageCreated(t *testing.T) {
 	toolCalls := []MessageToolCall{
 		{Name: "test_tool", Args: `{"key":"value"}`},
 	}
-	emitter.MessageCreated("assistant", "Hello!", 1, toolCalls, nil)
+	emitter.MessageCreated("assistant", "Hello!", 1, nil, toolCalls, nil)
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for message.created event")
@@ -200,7 +202,7 @@ func TestEmitter_MessageCreated_WithToolResult(t *testing.T) {
 		Name:    "weather_tool",
 		Content: `{"temp": 72}`,
 	}
-	emitter.MessageCreated("tool", "", 2, nil, toolResult)
+	emitter.MessageCreated("tool", "", 2, nil, nil, toolResult)
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for message.created event with tool result")
@@ -216,6 +218,125 @@ func TestEmitter_MessageCreated_WithToolResult(t *testing.T) {
 	}
 	if data.ToolResult == nil || data.ToolResult.Name != "weather_tool" {
 		t.Fatalf("unexpected tool result: %+v", data.ToolResult)
+	}
+}
+
+func TestEmitter_MessageCreated_WithParts(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-mp", "session-mp", "conv-mp")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	bus.Subscribe(EventMessageCreated, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	textVal := "Hello with image"
+	imgURL := "https://example.com/img.png"
+	parts := []types.ContentPart{
+		{Type: "text", Text: &textVal},
+		{Type: "image", Media: &types.MediaContent{MIMEType: "image/png", URL: &imgURL}},
+	}
+	emitter.MessageCreated("user", "Hello with image", 0, parts, nil, nil)
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for message.created event with parts")
+	}
+
+	data, ok := got.Data.(MessageCreatedData)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", got.Data)
+	}
+
+	if len(data.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(data.Parts))
+	}
+	if data.Parts[0].Type != "text" || data.Parts[1].Type != "image" {
+		t.Fatalf("unexpected part types: %v, %v", data.Parts[0].Type, data.Parts[1].Type)
+	}
+}
+
+func TestEmitter_MessageCreated_StripsBinaryData(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-sb", "session-sb", "conv-sb")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	bus.Subscribe(EventMessageCreated, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	base64Data := "aGVsbG8gd29ybGQ=" // "hello world" in base64
+	filePath := "/tmp/audio.mp3"
+	sizeKB := int64(500)
+	textVal := "Check this out"
+	parts := []types.ContentPart{
+		{Type: "text", Text: &textVal},
+		{
+			Type: "image",
+			Media: &types.MediaContent{
+				Data:     &base64Data,
+				MIMEType: "image/jpeg",
+				SizeKB:   &sizeKB,
+			},
+		},
+		{
+			Type: "audio",
+			Media: &types.MediaContent{
+				FilePath: &filePath,
+				MIMEType: "audio/mp3",
+			},
+		},
+	}
+	emitter.MessageCreated("user", "Check this out", 0, parts, nil, nil)
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for message.created event")
+	}
+
+	data, ok := got.Data.(MessageCreatedData)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", got.Data)
+	}
+
+	if len(data.Parts) != 3 {
+		t.Fatalf("expected 3 parts, got %d", len(data.Parts))
+	}
+
+	// Text part should be unchanged
+	if data.Parts[0].Type != "text" || *data.Parts[0].Text != textVal {
+		t.Fatal("text part was modified")
+	}
+
+	// Image: Data should be stripped, metadata preserved
+	imgPart := data.Parts[1]
+	if imgPart.Media.Data != nil {
+		t.Error("expected Data to be stripped from image part")
+	}
+	if imgPart.Media.MIMEType != "image/jpeg" {
+		t.Errorf("expected MIMEType image/jpeg, got %s", imgPart.Media.MIMEType)
+	}
+	if imgPart.Media.SizeKB == nil || *imgPart.Media.SizeKB != sizeKB {
+		t.Error("SizeKB metadata was not preserved")
+	}
+
+	// Audio: FilePath should be stripped
+	audPart := data.Parts[2]
+	if audPart.Media.FilePath != nil {
+		t.Error("expected FilePath to be stripped from audio part")
+	}
+	if audPart.Media.MIMEType != "audio/mp3" {
+		t.Errorf("expected MIMEType audio/mp3, got %s", audPart.Media.MIMEType)
 	}
 }
 

--- a/runtime/hooks/registry.go
+++ b/runtime/hooks/registry.go
@@ -119,12 +119,18 @@ func (r *Registry) RunBeforeToolExecution(ctx context.Context, req ToolRequest) 
 	if r == nil {
 		return Allow
 	}
+	var lastAllow Decision
+	lastAllow.Allow = true
 	for _, h := range r.toolHooks {
-		if d := h.BeforeExecution(ctx, req); !d.Allow {
+		d := h.BeforeExecution(ctx, req)
+		if !d.Allow {
 			return d
 		}
+		if d.Metadata != nil {
+			lastAllow = d
+		}
 	}
-	return Allow
+	return lastAllow
 }
 
 // RunAfterToolExecution executes all tool hooks' AfterExecution in order.

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -811,10 +811,23 @@ func (s *ProviderStage) executeToolCalls(
 			}
 		}
 
+		// Emit tool call started event
+		if s.emitter != nil {
+			var argsMap map[string]interface{}
+			if toolCall.Args != nil {
+				_ = json.Unmarshal(toolCall.Args, &argsMap)
+			}
+			s.emitter.ToolCallStarted(toolCall.Name, toolCall.ID, argsMap)
+		}
+
 		// Execute tool via registry (handles both sync and async tools)
 		startTime := time.Now()
 		asyncResult, err := s.toolRegistry.ExecuteAsync(ctx, toolCall.Name, toolCall.Args)
 		if err != nil {
+			// Emit tool call failed event
+			if s.emitter != nil {
+				s.emitter.ToolCallFailed(toolCall.Name, toolCall.ID, err, time.Since(startTime))
+			}
 			// Tool not found or execution setup failed
 			results = append(results, types.NewToolResultMessage(types.MessageToolResult{
 				ID:      toolCall.ID,
@@ -840,6 +853,12 @@ func (s *ProviderStage) executeToolCalls(
 				ToolResult:  toolResult,
 			})
 			continue
+		}
+
+		// Emit tool call completed event
+		if s.emitter != nil {
+			status := string(asyncResult.Status)
+			s.emitter.ToolCallCompleted(toolCall.Name, toolCall.ID, time.Since(startTime), status)
 		}
 
 		// Convert tool execution result to message

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -787,20 +787,26 @@ func (s *ProviderStage) executeToolCalls(
 		}
 
 		// Run BeforeExecution tool hooks
+		var hookDecision hooks.Decision
 		if s.hookRegistry != nil {
 			toolReq := hooks.ToolRequest{
 				Name:   toolCall.Name,
 				Args:   toolCall.Args,
 				CallID: toolCall.ID,
 			}
-			if d := s.hookRegistry.RunBeforeToolExecution(ctx, toolReq); !d.Allow {
-				errMsg := fmt.Sprintf("Tool %s blocked by hook: %s", toolCall.Name, d.Reason)
-				results = append(results, types.NewToolResultMessage(types.MessageToolResult{
+			hookDecision = s.hookRegistry.RunBeforeToolExecution(ctx, toolReq)
+			if !hookDecision.Allow {
+				errMsg := fmt.Sprintf("Tool %s blocked by hook: %s", toolCall.Name, hookDecision.Reason)
+				msg := types.NewToolResultMessage(types.MessageToolResult{
 					ID:      toolCall.ID,
 					Name:    toolCall.Name,
 					Content: errMsg,
 					Error:   errMsg,
-				}))
+				})
+				if hookDecision.Metadata != nil {
+					msg.Meta = hookDecision.Metadata
+				}
+				results = append(results, msg)
 				continue
 			}
 		}
@@ -838,7 +844,11 @@ func (s *ProviderStage) executeToolCalls(
 
 		// Convert tool execution result to message
 		result := s.handleToolResult(toolCall, asyncResult)
-		results = append(results, types.NewToolResultMessage(result))
+		resultMsg := types.NewToolResultMessage(result)
+		if hookDecision.Metadata != nil {
+			resultMsg.Meta = hookDecision.Metadata
+		}
+		results = append(results, resultMsg)
 
 		// Run AfterExecution tool hooks
 		if s.hookRegistry != nil {

--- a/runtime/pipeline/stage/stages_provider_hooks_test.go
+++ b/runtime/pipeline/stage/stages_provider_hooks_test.go
@@ -393,6 +393,131 @@ func TestProviderStage_ToolHook_AfterExecution_Records(t *testing.T) {
 }
 
 // =============================================================================
+// Tool hook metadata threading tests
+// =============================================================================
+
+// denyToolHookWithMetadata blocks tools and includes metadata in the decision.
+type denyToolHookWithMetadata struct {
+	blockedTool string
+	reason      string
+	metadata    map[string]any
+}
+
+func (h *denyToolHookWithMetadata) Name() string { return "deny_tool_meta" }
+
+func (h *denyToolHookWithMetadata) BeforeExecution(
+	_ context.Context, req hooks.ToolRequest,
+) hooks.Decision {
+	if req.Name == h.blockedTool {
+		return hooks.DenyWithMetadata(h.reason, h.metadata)
+	}
+	return hooks.Allow
+}
+
+func (h *denyToolHookWithMetadata) AfterExecution(
+	_ context.Context, _ hooks.ToolRequest, _ hooks.ToolResponse,
+) hooks.Decision {
+	return hooks.Allow
+}
+
+// allowToolHookWithMetadata allows execution but includes metadata in the decision.
+type allowToolHookWithMetadata struct {
+	metadata map[string]any
+}
+
+func (h *allowToolHookWithMetadata) Name() string { return "allow_tool_meta" }
+
+func (h *allowToolHookWithMetadata) BeforeExecution(
+	_ context.Context, _ hooks.ToolRequest,
+) hooks.Decision {
+	return hooks.Decision{Allow: true, Metadata: h.metadata}
+}
+
+func (h *allowToolHookWithMetadata) AfterExecution(
+	_ context.Context, _ hooks.ToolRequest, _ hooks.ToolResponse,
+) hooks.Decision {
+	return hooks.Allow
+}
+
+func TestProviderStage_ToolHook_DenyMetadataThreaded(t *testing.T) {
+	provider := mock.NewProvider("p", "m", false)
+	toolReg := tools.NewRegistry()
+
+	executor := &mockAsyncExecutor{
+		name:    "meta-deny-executor",
+		status:  tools.ToolStatusComplete,
+		content: []byte(`{"ok":true}`),
+	}
+	toolReg.RegisterExecutor(executor)
+	toolReg.Register(&tools.ToolDescriptor{
+		Name:        "consent_tool",
+		Description: "test",
+		Mode:        "meta-deny-executor",
+		InputSchema: []byte(`{"type":"object"}`),
+	})
+
+	hookReg := hooks.NewRegistry(hooks.WithToolHook(&denyToolHookWithMetadata{
+		blockedTool: "consent_tool",
+		reason:      "user declined consent",
+		metadata:    map[string]any{"consent_status": "denied"},
+	}))
+
+	stage := NewProviderStageWithHooks(
+		provider, toolReg, nil, nil, nil, hookReg,
+	)
+
+	calls := []types.MessageToolCall{
+		{ID: "c1", Name: "consent_tool", Args: json.RawMessage(`{}`)},
+	}
+
+	results, err := stage.executeToolCalls(context.Background(), calls)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].ToolResult.Error, "blocked by hook")
+	assert.NotNil(t, results[0].Meta, "expected Meta to be populated from hook decision")
+	assert.Equal(t, "denied", results[0].Meta["consent_status"])
+}
+
+func TestProviderStage_ToolHook_AllowMetadataThreaded(t *testing.T) {
+	provider := mock.NewProvider("p", "m", false)
+	toolReg := tools.NewRegistry()
+
+	executor := &mockAsyncExecutor{
+		name:    "meta-allow-executor",
+		status:  tools.ToolStatusComplete,
+		content: []byte(`{"ok":true}`),
+	}
+	toolReg.RegisterExecutor(executor)
+	toolReg.Register(&tools.ToolDescriptor{
+		Name:        "consent_tool",
+		Description: "test",
+		Mode:        "meta-allow-executor",
+		InputSchema: []byte(`{"type":"object"}`),
+	})
+
+	hookReg := hooks.NewRegistry(hooks.WithToolHook(&allowToolHookWithMetadata{
+		metadata: map[string]any{"consent_status": "granted"},
+	}))
+
+	stage := NewProviderStageWithHooks(
+		provider, toolReg, nil, nil, nil, hookReg,
+	)
+
+	calls := []types.MessageToolCall{
+		{ID: "c1", Name: "consent_tool", Args: json.RawMessage(`{}`)},
+	}
+
+	results, err := stage.executeToolCalls(context.Background(), calls)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].ToolResult.Error)
+	assert.NotNil(t, results[0].Meta, "expected Meta to be populated from hook decision")
+	assert.Equal(t, "granted", results[0].Meta["consent_status"])
+}
+
+// =============================================================================
 // Constructor chaining
 // =============================================================================
 

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -1641,3 +1641,167 @@ func TestProviderStage_ExecuteToolCalls_PendingSuspends(t *testing.T) {
 	// Completed results should still be returned
 	require.Len(t, results, 1, "completed tool results should be returned")
 }
+
+func TestProviderStage_ExecuteToolCalls_EmitsStartedCompleted(t *testing.T) {
+	provider := mock.NewProvider("test", "model", false)
+	registry := tools.NewRegistry()
+
+	executor := &mockAsyncExecutor{
+		name:    "test-executor",
+		status:  tools.ToolStatusComplete,
+		content: []byte(`{"result": "ok"}`),
+	}
+	registry.RegisterExecutor(executor)
+	registry.Register(&tools.ToolDescriptor{
+		Name:        "emit_tool",
+		Description: "A tool for testing event emission",
+		Mode:        "test-executor",
+		InputSchema: []byte(`{"type": "object"}`),
+	})
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run-1", "session-1", "conv-1")
+
+	var captured []*events.Event
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(2) // expect started + completed
+
+	bus.SubscribeAll(func(e *events.Event) {
+		mu.Lock()
+		captured = append(captured, e)
+		mu.Unlock()
+		wg.Done()
+	})
+
+	stage := NewProviderStageWithEmitter(provider, registry, nil, nil, emitter)
+
+	toolCalls := []types.MessageToolCall{
+		{ID: "call-1", Name: "emit_tool", Args: json.RawMessage(`{"key":"value"}`)},
+	}
+
+	results, err := stage.executeToolCalls(context.Background(), toolCalls)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, captured, 2)
+	assert.Equal(t, events.EventToolCallStarted, captured[0].Type)
+	assert.Equal(t, events.EventToolCallCompleted, captured[1].Type)
+
+	startedData, ok := captured[0].Data.(events.ToolCallStartedData)
+	require.True(t, ok)
+	assert.Equal(t, "emit_tool", startedData.ToolName)
+	assert.Equal(t, "call-1", startedData.CallID)
+	assert.Equal(t, "value", startedData.Args["key"])
+
+	completedData, ok := captured[1].Data.(events.ToolCallCompletedData)
+	require.True(t, ok)
+	assert.Equal(t, "emit_tool", completedData.ToolName)
+	assert.Equal(t, "call-1", completedData.CallID)
+	assert.Equal(t, "complete", completedData.Status)
+}
+
+func TestProviderStage_ExecuteToolCalls_EmitsFailed(t *testing.T) {
+	provider := mock.NewProvider("test", "model", false)
+	registry := tools.NewRegistry()
+	// Don't register any tool — ExecuteAsync will return "tool not found" error
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run-1", "session-1", "conv-1")
+
+	var captured []*events.Event
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(2) // expect started + failed
+
+	bus.SubscribeAll(func(e *events.Event) {
+		mu.Lock()
+		captured = append(captured, e)
+		mu.Unlock()
+		wg.Done()
+	})
+
+	stage := NewProviderStageWithEmitter(provider, registry, nil, nil, emitter)
+
+	toolCalls := []types.MessageToolCall{
+		{ID: "call-1", Name: "nonexistent_tool", Args: json.RawMessage(`{}`)},
+	}
+
+	results, err := stage.executeToolCalls(context.Background(), toolCalls)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].ToolResult.Error, "nonexistent_tool")
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, captured, 2)
+
+	// Events may arrive in any order from async bus — find by type
+	var startedEvent, failedEvent *events.Event
+	for _, e := range captured {
+		switch e.Type {
+		case events.EventToolCallStarted:
+			startedEvent = e
+		case events.EventToolCallFailed:
+			failedEvent = e
+		}
+	}
+	require.NotNil(t, startedEvent, "expected tool.call.started event")
+	require.NotNil(t, failedEvent, "expected tool.call.failed event")
+
+	failedData, ok := failedEvent.Data.(events.ToolCallFailedData)
+	require.True(t, ok)
+	assert.Equal(t, "nonexistent_tool", failedData.ToolName)
+	assert.Equal(t, "call-1", failedData.CallID)
+	assert.Error(t, failedData.Error)
+}
+
+func TestProviderStage_ExecuteToolCalls_BlockedNoEvents(t *testing.T) {
+	provider := mock.NewProvider("test", "model", false)
+	registry := tools.NewRegistry()
+	registry.Register(&tools.ToolDescriptor{
+		Name:        "blocked_tool",
+		Description: "A blocked tool",
+		InputSchema: []byte(`{"type": "object"}`),
+	})
+
+	toolPolicy := &pipeline.ToolPolicy{
+		Blocklist: []string{"blocked_tool"},
+	}
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run-1", "session-1", "conv-1")
+
+	var captured []*events.Event
+	var mu sync.Mutex
+
+	bus.SubscribeAll(func(e *events.Event) {
+		mu.Lock()
+		captured = append(captured, e)
+		mu.Unlock()
+	})
+
+	stage := NewProviderStageWithEmitter(provider, registry, toolPolicy, nil, emitter)
+
+	toolCalls := []types.MessageToolCall{
+		{ID: "call-1", Name: "blocked_tool", Args: json.RawMessage(`{}`)},
+	}
+
+	results, err := stage.executeToolCalls(context.Background(), toolCalls)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0].ToolResult.Content, "blocked by policy")
+
+	// Give the event bus a moment to process any events
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, captured, "blocked tools should not emit any tool call events")
+}

--- a/runtime/pipeline/stage/stages_recording.go
+++ b/runtime/pipeline/stage/stages_recording.go
@@ -160,6 +160,7 @@ func (rs *RecordingStage) recordMessageElement(elem *StreamElement) {
 	data := &events.MessageCreatedData{
 		Role:    msg.Role,
 		Content: msg.Content,
+		Parts:   msg.Parts,
 	}
 
 	// Convert tool calls if present

--- a/runtime/prompt/schema/promptpack.schema.json
+++ b/runtime/prompt/schema/promptpack.schema.json
@@ -419,7 +419,7 @@
       "type": "object",
       "description": "A tool definition following OpenAI's function calling format. Tools enable the LLM to call external functions to retrieve data or perform actions.",
       "required": ["name", "description"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "name": {
           "type": "string",

--- a/runtime/types/content.go
+++ b/runtime/types/content.go
@@ -319,6 +319,39 @@ func (mc *MediaContent) ReadData() (io.ReadCloser, error) {
 	return nil, fmt.Errorf("no data source available")
 }
 
+// MetadataOnlyParts returns a copy of parts with binary data stripped.
+// Text parts are preserved as-is. Media parts keep metadata (MIMEType, SizeKB,
+// Width, Height, Duration, etc.) and URL references, but Data and FilePath
+// are set to nil. This is useful for event emission where binary payloads
+// are unnecessary overhead.
+func MetadataOnlyParts(parts []ContentPart) []ContentPart {
+	if len(parts) == 0 {
+		return parts
+	}
+
+	result := make([]ContentPart, len(parts))
+	for i, p := range parts {
+		if p.Media == nil {
+			// Text parts and parts without media pass through unchanged
+			result[i] = p
+			continue
+		}
+
+		// Copy the media content, stripping binary sources
+		stripped := *p.Media
+		stripped.Data = nil
+		stripped.FilePath = nil
+
+		result[i] = ContentPart{
+			Type:  p.Type,
+			Text:  p.Text,
+			Media: &stripped,
+		}
+	}
+
+	return result
+}
+
 // inferMIMEType infers the MIME type from a file path based on extension
 func inferMIMEType(filePath string) (string, error) {
 	ext := strings.ToLower(filepath.Ext(filePath))

--- a/runtime/types/content_test.go
+++ b/runtime/types/content_test.go
@@ -465,6 +465,134 @@ func TestGetBase64Data_URL(t *testing.T) {
 	}
 }
 
+func TestMetadataOnlyParts(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		result := MetadataOnlyParts(nil)
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		result := MetadataOnlyParts([]ContentPart{})
+		if len(result) != 0 {
+			t.Errorf("expected empty, got %d parts", len(result))
+		}
+	})
+
+	t.Run("text parts are preserved", func(t *testing.T) {
+		text := "Hello, world!"
+		parts := []ContentPart{
+			{Type: ContentTypeText, Text: &text},
+		}
+		result := MetadataOnlyParts(parts)
+		if len(result) != 1 {
+			t.Fatalf("expected 1 part, got %d", len(result))
+		}
+		if result[0].Type != ContentTypeText || result[0].Text == nil || *result[0].Text != text {
+			t.Errorf("text part not preserved: %+v", result[0])
+		}
+	})
+
+	t.Run("binary data is stripped from media parts", func(t *testing.T) {
+		data := "base64encodedimagedata"
+		filePath := "/path/to/image.jpg"
+		sizeKB := int64(150)
+		width := 800
+		height := 600
+		parts := []ContentPart{
+			{
+				Type: ContentTypeImage,
+				Media: &MediaContent{
+					Data:     &data,
+					MIMEType: MIMETypeImageJPEG,
+					SizeKB:   &sizeKB,
+					Width:    &width,
+					Height:   &height,
+				},
+			},
+			{
+				Type: ContentTypeAudio,
+				Media: &MediaContent{
+					FilePath: &filePath,
+					MIMEType: MIMETypeAudioMP3,
+					SizeKB:   &sizeKB,
+				},
+			},
+		}
+
+		result := MetadataOnlyParts(parts)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 parts, got %d", len(result))
+		}
+
+		// Image: Data should be nil, metadata preserved
+		img := result[0]
+		if img.Media.Data != nil {
+			t.Error("expected Data to be nil")
+		}
+		if img.Media.MIMEType != MIMETypeImageJPEG {
+			t.Errorf("expected MIMEType %s, got %s", MIMETypeImageJPEG, img.Media.MIMEType)
+		}
+		if img.Media.SizeKB == nil || *img.Media.SizeKB != sizeKB {
+			t.Error("SizeKB not preserved")
+		}
+		if img.Media.Width == nil || *img.Media.Width != width {
+			t.Error("Width not preserved")
+		}
+		if img.Media.Height == nil || *img.Media.Height != height {
+			t.Error("Height not preserved")
+		}
+
+		// Audio: FilePath should be nil, metadata preserved
+		aud := result[1]
+		if aud.Media.FilePath != nil {
+			t.Error("expected FilePath to be nil")
+		}
+		if aud.Media.MIMEType != MIMETypeAudioMP3 {
+			t.Errorf("expected MIMEType %s, got %s", MIMETypeAudioMP3, aud.Media.MIMEType)
+		}
+	})
+
+	t.Run("URL is preserved", func(t *testing.T) {
+		url := "https://example.com/image.png"
+		parts := []ContentPart{
+			{
+				Type: ContentTypeImage,
+				Media: &MediaContent{
+					URL:      &url,
+					MIMEType: MIMETypeImagePNG,
+				},
+			},
+		}
+
+		result := MetadataOnlyParts(parts)
+		if result[0].Media.URL == nil || *result[0].Media.URL != url {
+			t.Error("URL should be preserved")
+		}
+	})
+
+	t.Run("original parts are not mutated", func(t *testing.T) {
+		data := "base64data"
+		parts := []ContentPart{
+			{
+				Type: ContentTypeImage,
+				Media: &MediaContent{
+					Data:     &data,
+					MIMEType: MIMETypeImageJPEG,
+				},
+			},
+		}
+
+		_ = MetadataOnlyParts(parts)
+
+		// Original should still have data
+		if parts[0].Media.Data == nil || *parts[0].Media.Data != data {
+			t.Error("original part was mutated")
+		}
+	})
+}
+
 func TestInferMIMETypeFromURL_Fallback(t *testing.T) {
 	// URL with no extension should default to JPEG
 	result := inferMIMETypeFromURL("https://example.com/image")

--- a/sdk/a2a_server_adapter.go
+++ b/sdk/a2a_server_adapter.go
@@ -11,7 +11,33 @@ import (
 type responseAdapter struct{ r *Response }
 
 // HasPendingTools implements a2aserver.SendResult.
-func (a *responseAdapter) HasPendingTools() bool { return len(a.r.PendingTools()) > 0 }
+// Returns true when HITL tools or client-side tools are pending.
+func (a *responseAdapter) HasPendingTools() bool {
+	return len(a.r.PendingTools()) > 0 || a.r.HasPendingClientTools()
+}
+
+// HasPendingClientTools implements a2aserver.SendResult.
+func (a *responseAdapter) HasPendingClientTools() bool {
+	return a.r.HasPendingClientTools()
+}
+
+// PendingClientTools implements a2aserver.SendResult.
+func (a *responseAdapter) PendingClientTools() []a2aserver.PendingClientToolInfo {
+	sdkTools := a.r.ClientTools()
+	if len(sdkTools) == 0 {
+		return nil
+	}
+	out := make([]a2aserver.PendingClientToolInfo, len(sdkTools))
+	for i, t := range sdkTools {
+		out[i] = a2aserver.PendingClientToolInfo{
+			CallID:     t.CallID,
+			ToolName:   t.ToolName,
+			Args:       t.Args,
+			ConsentMsg: t.ConsentMsg,
+		}
+	}
+	return out
+}
 
 // Parts implements a2aserver.SendResult.
 func (a *responseAdapter) Parts() []types.ContentPart { return a.r.Parts() }
@@ -19,8 +45,21 @@ func (a *responseAdapter) Parts() []types.ContentPart { return a.r.Parts() }
 // Text implements a2aserver.SendResult.
 func (a *responseAdapter) Text() string { return a.r.Text() }
 
-// convAdapter wraps *Conversation to satisfy a2aserver.Conversation.
-type convAdapter struct{ c *Conversation }
+// conversationBackend is the subset of *Conversation that convAdapter needs.
+// This enables unit testing without a fully initialized Conversation.
+type conversationBackend interface {
+	Send(ctx context.Context, message any, opts ...SendOption) (*Response, error)
+	Close() error
+	SendToolResult(ctx context.Context, callID string, result any) error
+	RejectClientTool(ctx context.Context, callID, reason string)
+	Resume(ctx context.Context) (*Response, error)
+	ResumeStream(ctx context.Context) <-chan StreamChunk
+	Stream(ctx context.Context, message any, opts ...SendOption) <-chan StreamChunk
+}
+
+// convAdapter wraps a conversationBackend to satisfy a2aserver.Conversation.
+// It also implements a2aserver.ResumableConversation for client tool support.
+type convAdapter struct{ c conversationBackend }
 
 // Send implements a2aserver.Conversation.
 func (a *convAdapter) Send(ctx context.Context, message any) (a2aserver.SendResult, error) {
@@ -33,6 +72,38 @@ func (a *convAdapter) Send(ctx context.Context, message any) (a2aserver.SendResu
 
 // Close implements a2aserver.Conversation.
 func (a *convAdapter) Close() error { return a.c.Close() }
+
+// SendToolResult implements a2aserver.ResumableConversation.
+func (a *convAdapter) SendToolResult(callID string, result any) error {
+	return a.c.SendToolResult(context.Background(), callID, result)
+}
+
+// RejectClientTool implements a2aserver.ResumableConversation.
+func (a *convAdapter) RejectClientTool(callID, reason string) {
+	a.c.RejectClientTool(context.Background(), callID, reason)
+}
+
+// Resume implements a2aserver.ResumableConversation.
+func (a *convAdapter) Resume(ctx context.Context) (a2aserver.SendResult, error) {
+	resp, err := a.c.Resume(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &responseAdapter{r: resp}, nil
+}
+
+// ResumeStream implements a2aserver.ResumableConversation.
+func (a *convAdapter) ResumeStream(ctx context.Context) <-chan a2aserver.StreamEvent {
+	chunks := a.c.ResumeStream(ctx)
+	out := make(chan a2aserver.StreamEvent)
+	go func() {
+		defer close(out)
+		for chunk := range chunks {
+			out <- chunkToEvent(chunk)
+		}
+	}()
+	return out
+}
 
 // streamConvAdapter extends convAdapter with streaming support.
 type streamConvAdapter struct{ convAdapter }
@@ -62,6 +133,16 @@ func chunkToEvent(c StreamChunk) a2aserver.StreamEvent {
 		return a2aserver.StreamEvent{Kind: a2aserver.EventMedia, Media: c.Media}
 	case ChunkToolCall:
 		return a2aserver.StreamEvent{Kind: a2aserver.EventToolCall}
+	case ChunkClientTool:
+		return a2aserver.StreamEvent{
+			Kind: a2aserver.EventClientTool,
+			ClientTool: &a2aserver.PendingClientToolInfo{
+				CallID:     c.ClientTool.CallID,
+				ToolName:   c.ClientTool.ToolName,
+				Args:       c.ClientTool.Args,
+				ConsentMsg: c.ClientTool.ConsentMsg,
+			},
+		}
 	case ChunkDone:
 		return a2aserver.StreamEvent{Kind: a2aserver.EventDone}
 	default:

--- a/sdk/a2a_server_adapter_test.go
+++ b/sdk/a2a_server_adapter_test.go
@@ -1,0 +1,319 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	a2aserver "github.com/AltairaLabs/PromptKit/server/a2a"
+)
+
+// --- mock SDK response for adapter tests ---
+
+type mockSDKResponse struct {
+	text              string
+	parts             []types.ContentPart
+	pendingTools      []PendingTool
+	pendingClientBool bool
+	clientTools       []PendingClientTool
+}
+
+func (r *mockSDKResponse) Text() string                    { return r.text }
+func (r *mockSDKResponse) Parts() []types.ContentPart      { return r.parts }
+func (r *mockSDKResponse) PendingTools() []PendingTool      { return r.pendingTools }
+func (r *mockSDKResponse) HasPendingClientTools() bool      { return r.pendingClientBool }
+func (r *mockSDKResponse) ClientTools() []PendingClientTool { return r.clientTools }
+
+// --- mock conversationBackend ---
+
+type mockConvBackend struct {
+	sendFunc            func(ctx context.Context, message any, opts ...SendOption) (*Response, error)
+	closeFunc           func() error
+	sendToolResultFunc  func(ctx context.Context, callID string, result any) error
+	rejectClientFunc    func(ctx context.Context, callID, reason string)
+	resumeFunc          func(ctx context.Context) (*Response, error)
+	resumeStreamFunc    func(ctx context.Context) <-chan StreamChunk
+	streamFunc          func(ctx context.Context, message any, opts ...SendOption) <-chan StreamChunk
+}
+
+func (m *mockConvBackend) Send(ctx context.Context, message any, opts ...SendOption) (*Response, error) {
+	return m.sendFunc(ctx, message, opts...)
+}
+
+func (m *mockConvBackend) Close() error {
+	if m.closeFunc != nil {
+		return m.closeFunc()
+	}
+	return nil
+}
+
+func (m *mockConvBackend) SendToolResult(ctx context.Context, callID string, result any) error {
+	return m.sendToolResultFunc(ctx, callID, result)
+}
+
+func (m *mockConvBackend) RejectClientTool(ctx context.Context, callID, reason string) {
+	m.rejectClientFunc(ctx, callID, reason)
+}
+
+func (m *mockConvBackend) Resume(ctx context.Context) (*Response, error) {
+	return m.resumeFunc(ctx)
+}
+
+func (m *mockConvBackend) ResumeStream(ctx context.Context) <-chan StreamChunk {
+	return m.resumeStreamFunc(ctx)
+}
+
+func (m *mockConvBackend) Stream(ctx context.Context, message any, opts ...SendOption) <-chan StreamChunk {
+	return m.streamFunc(ctx, message, opts...)
+}
+
+// --- responseAdapter tests ---
+
+func TestResponseAdapter_HasPendingTools_IncludesClientTools(t *testing.T) {
+	resp := &Response{}
+	adapter := &responseAdapter{r: resp}
+	if adapter.HasPendingTools() {
+		t.Error("expected false when no tools pending")
+	}
+
+	resp = &Response{
+		clientTools: []PendingClientTool{
+			{CallID: "c1", ToolName: "gps"},
+		},
+	}
+	adapter = &responseAdapter{r: resp}
+	if !adapter.HasPendingTools() {
+		t.Error("expected true when client tools pending")
+	}
+}
+
+func TestResponseAdapter_HasPendingClientTools(t *testing.T) {
+	resp := &Response{}
+	adapter := &responseAdapter{r: resp}
+	if adapter.HasPendingClientTools() {
+		t.Error("expected false when no client tools")
+	}
+
+	resp = &Response{
+		clientTools: []PendingClientTool{
+			{CallID: "c1", ToolName: "camera"},
+		},
+	}
+	adapter = &responseAdapter{r: resp}
+	if !adapter.HasPendingClientTools() {
+		t.Error("expected true when client tools present")
+	}
+}
+
+func TestResponseAdapter_PendingClientTools(t *testing.T) {
+	resp := &Response{
+		clientTools: []PendingClientTool{
+			{CallID: "c1", ToolName: "gps", Args: map[string]any{"accuracy": "high"}, ConsentMsg: "Allow GPS?"},
+			{CallID: "c2", ToolName: "camera"},
+		},
+	}
+	adapter := &responseAdapter{r: resp}
+	tools := adapter.PendingClientTools()
+
+	if len(tools) != 2 {
+		t.Fatalf("tools = %d, want 2", len(tools))
+	}
+	if tools[0].CallID != "c1" || tools[0].ToolName != "gps" {
+		t.Errorf("tool[0] = %+v, want {c1 gps ...}", tools[0])
+	}
+	if tools[0].ConsentMsg != "Allow GPS?" {
+		t.Errorf("consent = %q, want 'Allow GPS?'", tools[0].ConsentMsg)
+	}
+	if tools[1].CallID != "c2" || tools[1].ToolName != "camera" {
+		t.Errorf("tool[1] = %+v, want {c2 camera}", tools[1])
+	}
+}
+
+func TestResponseAdapter_PendingClientTools_Empty(t *testing.T) {
+	resp := &Response{}
+	adapter := &responseAdapter{r: resp}
+	tools := adapter.PendingClientTools()
+	if tools != nil {
+		t.Errorf("expected nil, got %+v", tools)
+	}
+}
+
+// --- chunkToEvent tests ---
+
+func TestChunkToEvent_ClientTool(t *testing.T) {
+	chunk := StreamChunk{
+		Type: ChunkClientTool,
+		ClientTool: &PendingClientTool{
+			CallID:     "call-1",
+			ToolName:   "get_location",
+			Args:       map[string]any{"accuracy": "high"},
+			ConsentMsg: "Allow location?",
+		},
+	}
+
+	evt := chunkToEvent(chunk)
+	if evt.Kind != a2aserver.EventClientTool {
+		t.Fatalf("kind = %d, want EventClientTool", evt.Kind)
+	}
+	if evt.ClientTool == nil {
+		t.Fatal("expected non-nil ClientTool")
+	}
+	if evt.ClientTool.CallID != "call-1" {
+		t.Errorf("call ID = %q, want call-1", evt.ClientTool.CallID)
+	}
+	if evt.ClientTool.ToolName != "get_location" {
+		t.Errorf("tool name = %q, want get_location", evt.ClientTool.ToolName)
+	}
+	if evt.ClientTool.ConsentMsg != "Allow location?" {
+		t.Errorf("consent = %q, want 'Allow location?'", evt.ClientTool.ConsentMsg)
+	}
+}
+
+func TestChunkToEvent_ExistingTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   StreamChunk
+		want a2aserver.EventKind
+	}{
+		{"text", StreamChunk{Type: ChunkText, Text: "hi"}, a2aserver.EventText},
+		{"tool_call", StreamChunk{Type: ChunkToolCall}, a2aserver.EventToolCall},
+		{"done", StreamChunk{Type: ChunkDone}, a2aserver.EventDone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evt := chunkToEvent(tt.in)
+			if evt.Kind != tt.want {
+				t.Errorf("kind = %d, want %d", evt.Kind, tt.want)
+			}
+		})
+	}
+}
+
+// --- convAdapter tests ---
+
+func TestConvAdapter_SendToolResult(t *testing.T) {
+	var capturedCallID string
+	var capturedResult any
+	mock := &mockConvBackend{
+		sendToolResultFunc: func(_ context.Context, callID string, result any) error {
+			capturedCallID = callID
+			capturedResult = result
+			return nil
+		},
+	}
+	adapter := &convAdapter{c: mock}
+
+	err := adapter.SendToolResult("call-1", map[string]any{"lat": 40.7})
+	if err != nil {
+		t.Fatalf("SendToolResult error: %v", err)
+	}
+	if capturedCallID != "call-1" {
+		t.Errorf("callID = %q, want call-1", capturedCallID)
+	}
+	if capturedResult == nil {
+		t.Error("expected non-nil result")
+	}
+}
+
+func TestConvAdapter_SendToolResult_Error(t *testing.T) {
+	wantErr := errors.New("serialize error")
+	mock := &mockConvBackend{
+		sendToolResultFunc: func(_ context.Context, _ string, _ any) error {
+			return wantErr
+		},
+	}
+	adapter := &convAdapter{c: mock}
+
+	err := adapter.SendToolResult("call-1", "data")
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestConvAdapter_RejectClientTool(t *testing.T) {
+	var capturedCallID, capturedReason string
+	mock := &mockConvBackend{
+		rejectClientFunc: func(_ context.Context, callID, reason string) {
+			capturedCallID = callID
+			capturedReason = reason
+		},
+	}
+	adapter := &convAdapter{c: mock}
+
+	adapter.RejectClientTool("call-2", "denied by user")
+	if capturedCallID != "call-2" {
+		t.Errorf("callID = %q, want call-2", capturedCallID)
+	}
+	if capturedReason != "denied by user" {
+		t.Errorf("reason = %q, want 'denied by user'", capturedReason)
+	}
+}
+
+func TestConvAdapter_Resume(t *testing.T) {
+	mock := &mockConvBackend{
+		resumeFunc: func(_ context.Context) (*Response, error) {
+			return &Response{
+				message: &types.Message{Parts: []types.ContentPart{types.NewTextPart("resumed")}},
+			}, nil
+		},
+	}
+	adapter := &convAdapter{c: mock}
+
+	result, err := adapter.Resume(context.Background())
+	if err != nil {
+		t.Fatalf("Resume error: %v", err)
+	}
+	if result.Text() != "resumed" {
+		t.Errorf("text = %q, want 'resumed'", result.Text())
+	}
+}
+
+func TestConvAdapter_Resume_Error(t *testing.T) {
+	wantErr := errors.New("resume failed")
+	mock := &mockConvBackend{
+		resumeFunc: func(_ context.Context) (*Response, error) {
+			return nil, wantErr
+		},
+	}
+	adapter := &convAdapter{c: mock}
+
+	_, err := adapter.Resume(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestConvAdapter_ResumeStream(t *testing.T) {
+	mock := &mockConvBackend{
+		resumeStreamFunc: func(_ context.Context) <-chan StreamChunk {
+			ch := make(chan StreamChunk, 3)
+			ch <- StreamChunk{Type: ChunkText, Text: "resumed text"}
+			ch <- StreamChunk{Type: ChunkDone}
+			close(ch)
+			return ch
+		},
+	}
+	adapter := &convAdapter{c: mock}
+
+	var events []a2aserver.StreamEvent
+	for evt := range adapter.ResumeStream(context.Background()) {
+		events = append(events, evt)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+	if events[0].Kind != a2aserver.EventText || events[0].Text != "resumed text" {
+		t.Errorf("event[0] = %+v, want text='resumed text'", events[0])
+	}
+	if events[1].Kind != a2aserver.EventDone {
+		t.Errorf("event[1] kind = %d, want EventDone", events[1].Kind)
+	}
+}
+
+// Verify convAdapter implements ResumableConversation at compile time.
+var _ a2aserver.ResumableConversation = (*convAdapter)(nil)
+
+// Verify streamConvAdapter also implements ResumableConversation.
+var _ a2aserver.ResumableConversation = (*streamConvAdapter)(nil)

--- a/sdk/a2a_test.go
+++ b/sdk/a2a_test.go
@@ -314,8 +314,10 @@ func (m *a2aTestConv) Close() error { return nil }
 
 type a2aTestResult struct{}
 
-func (r *a2aTestResult) HasPendingTools() bool       { return false }
-func (r *a2aTestResult) Parts() []types.ContentPart { return []types.ContentPart{types.NewTextPart("mock response")} }
-func (r *a2aTestResult) Text() string               { return "mock response" }
+func (r *a2aTestResult) HasPendingTools() bool                                 { return false }
+func (r *a2aTestResult) HasPendingClientTools() bool                           { return false }
+func (r *a2aTestResult) PendingClientTools() []a2aserver.PendingClientToolInfo { return nil }
+func (r *a2aTestResult) Parts() []types.ContentPart                            { return []types.ContentPart{types.NewTextPart("mock response")} }
+func (r *a2aTestResult) Text() string                                          { return "mock response" }
 
 func a2aTextPtr(s string) *string { return &s }

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -344,6 +344,18 @@ func (c *Conversation) buildPipelineConfig(
 		ExecutionTimeout:      c.config.executionTimeout,
 	}
 
+	// Wire recording config if enabled
+	if c.config.recordingConfig != nil && c.config.eventBus != nil {
+		pipelineCfg.RecordingConfig = &stage.RecordingStageConfig{
+			SessionID:      conversationID,
+			ConversationID: conversationID,
+			IncludeAudio:   c.config.recordingConfig.IncludeAudio,
+			IncludeVideo:   c.config.recordingConfig.IncludeVideo,
+			IncludeImages:  c.config.recordingConfig.IncludeImages,
+		}
+		pipelineCfg.RecordingEventBus = c.config.eventBus
+	}
+
 	// Wire up RAG context components from SDK options
 	if c.config.retrievalProvider != nil {
 		pipelineCfg.MessageIndex = statestore.NewInMemoryIndex(c.config.retrievalProvider)

--- a/sdk/examples/client-tools/client-tools.pack.json
+++ b/sdk/examples/client-tools/client-tools.pack.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "client-tools-example",
+  "name": "Client Tools Example",
+  "version": "1.0.0",
+  "description": "Example demonstrating client-side tool execution",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "assistant": {
+      "id": "assistant",
+      "name": "Location Assistant",
+      "version": "1.0.0",
+      "system_template": "You are a helpful assistant. When asked about the user's location, use the get_location tool to get their GPS coordinates.",
+      "tools": ["get_location"]
+    }
+  },
+  "tools": {
+    "get_location": {
+      "name": "get_location",
+      "description": "Get the user's current GPS location",
+      "mode": "client",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "accuracy": {
+            "type": "string",
+            "enum": ["high", "low"],
+            "description": "GPS accuracy level"
+          }
+        }
+      },
+      "client": {
+        "consent": {
+          "required": true,
+          "message": "This app wants to access your location",
+          "decline_strategy": "graceful"
+        }
+      }
+    }
+  }
+}

--- a/sdk/examples/client-tools/main_interactive.go
+++ b/sdk/examples/client-tools/main_interactive.go
@@ -1,0 +1,136 @@
+// Package main demonstrates client-side tool execution with the PromptKit SDK.
+//
+// This example shows two modes:
+//   - Synchronous: OnClientTool handler runs immediately when the LLM invokes the tool
+//   - Deferred: No handler registered; pipeline suspends, caller provides result, then resumes
+//
+// Run with:
+//
+//	export OPENAI_API_KEY=your-key
+//	go run .
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func main() {
+	// --- Mode 1: Synchronous handler ---
+	fmt.Println("=== Synchronous Mode ===")
+	syncExample()
+
+	// --- Mode 2: Deferred (no handler) ---
+	fmt.Println("\n=== Deferred Mode ===")
+	deferredExample()
+
+	// --- Mode 3: Streaming deferred ---
+	fmt.Println("\n=== Streaming Deferred Mode ===")
+	streamDeferredExample()
+}
+
+func syncExample() {
+	conv, err := sdk.Open("./client-tools.pack.json", "assistant")
+	if err != nil {
+		log.Fatalf("Failed to open pack: %v", err)
+	}
+	defer conv.Close()
+
+	// Register a synchronous client tool handler.
+	conv.OnClientTool("get_location", func(_ context.Context, req sdk.ClientToolRequest) (any, error) {
+		fmt.Printf("  [Client] Location requested (accuracy: %v)\n", req.Args["accuracy"])
+		return map[string]any{"lat": 40.7128, "lon": -74.0060, "city": "New York"}, nil
+	})
+
+	resp, err := conv.Send(context.Background(), "Where am I right now?")
+	if err != nil {
+		log.Fatalf("Send failed: %v", err)
+	}
+	fmt.Printf("  Assistant: %s\n", resp.Text())
+}
+
+func deferredExample() {
+	conv, err := sdk.Open("./client-tools.pack.json", "assistant")
+	if err != nil {
+		log.Fatalf("Failed to open pack: %v", err)
+	}
+	defer conv.Close()
+
+	// No OnClientTool handler — pipeline will suspend.
+	ctx := context.Background()
+
+	resp, err := conv.Send(ctx, "Where am I right now?")
+	if err != nil {
+		log.Fatalf("Send failed: %v", err)
+	}
+
+	if resp.HasPendingClientTools() {
+		for _, tool := range resp.ClientTools() {
+			fmt.Printf("  [Client] Tool requested: %s\n", tool.ToolName)
+			fmt.Printf("  [Client] Consent message: %s\n", tool.ConsentMsg)
+
+			// Simulate user granting consent and providing data.
+			err := conv.SendToolResult(ctx, tool.CallID, map[string]any{
+				"lat": 37.7749, "lon": -122.4194, "city": "San Francisco",
+			})
+			if err != nil {
+				log.Fatalf("SendToolResult failed: %v", err)
+			}
+		}
+
+		// Resume the pipeline with the provided results.
+		resp, err = conv.Resume(ctx)
+		if err != nil {
+			log.Fatalf("Resume failed: %v", err)
+		}
+	}
+
+	fmt.Printf("  Assistant: %s\n", resp.Text())
+}
+
+func streamDeferredExample() {
+	conv, err := sdk.Open("./client-tools.pack.json", "assistant")
+	if err != nil {
+		log.Fatalf("Failed to open pack: %v", err)
+	}
+	defer conv.Close()
+
+	ctx := context.Background()
+
+	for chunk := range conv.Stream(ctx, "Where am I right now?") {
+		if chunk.Error != nil {
+			log.Fatalf("Stream error: %v", chunk.Error)
+		}
+
+		switch chunk.Type {
+		case sdk.ChunkText:
+			fmt.Print(chunk.Text)
+		case sdk.ChunkClientTool:
+			fmt.Printf("\n  [Client] Tool requested: %s\n", chunk.ClientTool.ToolName)
+
+			err := conv.SendToolResult(ctx, chunk.ClientTool.CallID, map[string]any{
+				"lat": 51.5074, "lon": -0.1278, "city": "London",
+			})
+			if err != nil {
+				log.Fatalf("SendToolResult failed: %v", err)
+			}
+
+			// Resume streaming.
+			fmt.Print("  Assistant: ")
+			for resumeChunk := range conv.ResumeStream(ctx) {
+				if resumeChunk.Error != nil {
+					log.Fatalf("ResumeStream error: %v", resumeChunk.Error)
+				}
+				if resumeChunk.Type == sdk.ChunkText {
+					fmt.Print(resumeChunk.Text)
+				}
+			}
+			fmt.Println()
+			return
+		}
+	}
+	fmt.Println()
+}

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -138,6 +138,15 @@ type Config struct {
 	// When non-nil, the pointed-to duration is used instead of the default 30s.
 	// A zero value disables timeout entirely.
 	ExecutionTimeout *time.Duration
+
+	// RecordingConfig enables recording stages in the pipeline.
+	// When set, input and output RecordingStages are inserted to capture
+	// full binary content for session replay.
+	RecordingConfig *stage.RecordingStageConfig
+
+	// RecordingEventBus is the event bus used by recording stages.
+	// Required when RecordingConfig is set.
+	RecordingEventBus *events.EventBus
 }
 
 // Build creates a stage-based streaming pipeline.
@@ -247,6 +256,13 @@ func collectPipelineStages(
 		stage.NewTemplateStage(),
 	)
 
+	// 4.1 Input recording stage - captures user input with full binary data
+	if cfg.RecordingConfig != nil && cfg.RecordingEventBus != nil {
+		inputCfg := *cfg.RecordingConfig
+		inputCfg.Position = stage.RecordingPositionInput
+		stages = append(stages, stage.NewRecordingStage(cfg.RecordingEventBus, inputCfg))
+	}
+
 	// 4.5 Context builder stage - manages token budget and truncation
 	if cfg.TokenBudget > 0 {
 		contextPolicy := buildContextBuilderPolicy(cfg)
@@ -264,6 +280,13 @@ func collectPipelineStages(
 		return nil, err
 	}
 	stages = append(stages, providerStages...)
+
+	// 5.5 Output recording stage - captures assistant output with full binary data
+	if cfg.RecordingConfig != nil && cfg.RecordingEventBus != nil {
+		outputCfg := *cfg.RecordingConfig
+		outputCfg.Position = stage.RecordingPositionOutput
+		stages = append(stages, stage.NewRecordingStage(cfg.RecordingEventBus, outputCfg))
+	}
 
 	// 6. State store save stage - saves conversation state LAST
 	stages = appendStateStoreSaveStages(stages, cfg, stateStoreConfig, useRAGContext)

--- a/sdk/internal/pipeline/builder_test.go
+++ b/sdk/internal/pipeline/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
 	rtpipeline "github.com/AltairaLabs/PromptKit/runtime/pipeline"
@@ -899,6 +900,101 @@ func TestBuildWithHookRegistry(t *testing.T) {
 			TaskType:       "chat",
 			Provider:       provider,
 			HookRegistry:   nil,
+		}
+
+		pipeline, err := Build(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, pipeline)
+	})
+}
+
+func TestBuildWithRecordingConfig(t *testing.T) {
+	t.Run("builds with recording stages", func(t *testing.T) {
+		registry := createTestRegistry("chat")
+		provider := mock.NewProvider("test", "test-model", false)
+		bus := events.NewEventBus()
+
+		cfg := &Config{
+			PromptRegistry: registry,
+			TaskType:       "chat",
+			Provider:       provider,
+			RecordingConfig: &stage.RecordingStageConfig{
+				SessionID:      "test-session",
+				ConversationID: "test-conv",
+				IncludeAudio:   true,
+				IncludeVideo:   false,
+				IncludeImages:  true,
+			},
+			RecordingEventBus: bus,
+		}
+
+		pipeline, err := Build(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, pipeline)
+	})
+
+	t.Run("recording stages execute successfully", func(t *testing.T) {
+		registry := createTestRegistry("chat")
+		provider := mock.NewProvider("test", "test-model", false)
+		bus := events.NewEventBus()
+
+		cfg := &Config{
+			PromptRegistry: registry,
+			TaskType:       "chat",
+			Provider:       provider,
+			RecordingConfig: &stage.RecordingStageConfig{
+				SessionID:      "test-session",
+				ConversationID: "test-conv",
+				IncludeAudio:   true,
+				IncludeImages:  true,
+			},
+			RecordingEventBus: bus,
+		}
+
+		pipe, err := Build(cfg)
+		require.NoError(t, err)
+
+		userMsg := types.Message{Role: "user"}
+		userMsg.AddTextPart("Hello with recording!")
+
+		elem := stage.StreamElement{
+			Message:  &userMsg,
+			Metadata: map[string]interface{}{"conversation_id": "test-conv"},
+		}
+
+		result, err := pipe.ExecuteSync(context.Background(), elem)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.Response)
+	})
+
+	t.Run("no recording stages without config", func(t *testing.T) {
+		registry := createTestRegistry("chat")
+		provider := mock.NewProvider("test", "test-model", false)
+
+		cfg := &Config{
+			PromptRegistry: registry,
+			TaskType:       "chat",
+			Provider:       provider,
+		}
+
+		pipeline, err := Build(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, pipeline)
+	})
+
+	t.Run("no recording stages without event bus", func(t *testing.T) {
+		registry := createTestRegistry("chat")
+		provider := mock.NewProvider("test", "test-model", false)
+
+		cfg := &Config{
+			PromptRegistry: registry,
+			TaskType:       "chat",
+			Provider:       provider,
+			RecordingConfig: &stage.RecordingStageConfig{
+				IncludeAudio: true,
+			},
+			// RecordingEventBus is nil — stages should not be added
 		}
 
 		pipeline, err := Build(cfg)

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -168,6 +168,11 @@ type config struct {
 	// Use 0 to disable timeout entirely (useful for long-running tool-calling pipelines).
 	executionTimeout *time.Duration
 
+	// Recording configuration for session recording via RecordingStage.
+	// When set, RecordingStages are inserted into the pipeline to capture
+	// full message content (including binary data) for session replay.
+	recordingConfig *RecordingConfig
+
 	// Custom logger for SDK consumers
 	logger *slog.Logger
 }
@@ -486,6 +491,63 @@ func WithEventBus(bus *events.EventBus) Option {
 func WithEventStore(store events.EventStore) Option {
 	return func(c *config) error {
 		c.eventStore = store
+		return nil
+	}
+}
+
+// RecordingConfig configures session recording via RecordingStage.
+// RecordingStages capture full message content (including binary data)
+// and publish directly to the EventBus for session replay.
+type RecordingConfig struct {
+	// IncludeAudio records audio data (may be large). Default: true.
+	IncludeAudio bool
+
+	// IncludeVideo records video data (may be large). Default: false.
+	IncludeVideo bool
+
+	// IncludeImages records image data. Default: true.
+	IncludeImages bool
+}
+
+// DefaultRecordingConfig returns a RecordingConfig with sensible defaults.
+func DefaultRecordingConfig() RecordingConfig {
+	return RecordingConfig{
+		IncludeAudio:  true,
+		IncludeVideo:  false,
+		IncludeImages: true,
+	}
+}
+
+// WithRecording enables session recording by inserting RecordingStages
+// into the pipeline. These stages capture full binary content and publish
+// events directly to the EventBus, bypassing the emitter's binary stripping.
+//
+// If cfg is nil, default settings are used (audio=true, video=false, images=true).
+// An EventBus is automatically created if none was provided via WithEventBus.
+//
+//	conv, _ := sdk.Open("./chat.pack.json", "assistant",
+//	    sdk.WithRecording(nil), // use defaults
+//	)
+//
+//	// Or with custom config:
+//	conv, _ := sdk.Open("./chat.pack.json", "assistant",
+//	    sdk.WithRecording(&sdk.RecordingConfig{
+//	        IncludeAudio:  true,
+//	        IncludeVideo:  true,
+//	        IncludeImages: true,
+//	    }),
+//	)
+func WithRecording(cfg *RecordingConfig) Option {
+	return func(c *config) error {
+		if cfg == nil {
+			defaults := DefaultRecordingConfig()
+			cfg = &defaults
+		}
+		c.recordingConfig = cfg
+		// Ensure an event bus exists for recording stages
+		if c.eventBus == nil {
+			c.eventBus = events.NewEventBus()
+		}
 		return nil
 	}
 }

--- a/sdk/options_test.go
+++ b/sdk/options_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -966,3 +967,45 @@ func (h *testSessionHook) OnSessionUpdate(_ context.Context, _ hooks.SessionEven
 	return nil
 }
 func (h *testSessionHook) OnSessionEnd(_ context.Context, _ hooks.SessionEvent) error { return nil }
+
+func TestWithRecording(t *testing.T) {
+	t.Run("nil config uses defaults", func(t *testing.T) {
+		cfg := &config{}
+		err := WithRecording(nil)(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.recordingConfig)
+		assert.True(t, cfg.recordingConfig.IncludeAudio)
+		assert.False(t, cfg.recordingConfig.IncludeVideo)
+		assert.True(t, cfg.recordingConfig.IncludeImages)
+		assert.NotNil(t, cfg.eventBus, "should auto-create event bus")
+	})
+
+	t.Run("custom config is used", func(t *testing.T) {
+		cfg := &config{}
+		err := WithRecording(&RecordingConfig{
+			IncludeAudio:  false,
+			IncludeVideo:  true,
+			IncludeImages: false,
+		})(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.recordingConfig)
+		assert.False(t, cfg.recordingConfig.IncludeAudio)
+		assert.True(t, cfg.recordingConfig.IncludeVideo)
+		assert.False(t, cfg.recordingConfig.IncludeImages)
+	})
+
+	t.Run("does not overwrite existing event bus", func(t *testing.T) {
+		bus := &events.EventBus{}
+		cfg := &config{eventBus: bus}
+		err := WithRecording(nil)(cfg)
+		require.NoError(t, err)
+		assert.Same(t, bus, cfg.eventBus, "should not overwrite existing event bus")
+	})
+}
+
+func TestDefaultRecordingConfig(t *testing.T) {
+	cfg := DefaultRecordingConfig()
+	assert.True(t, cfg.IncludeAudio)
+	assert.False(t, cfg.IncludeVideo)
+	assert.True(t, cfg.IncludeImages)
+}

--- a/sdk/otel_integration_test.go
+++ b/sdk/otel_integration_test.go
@@ -419,8 +419,10 @@ func (m *otelMockConv) Close() error { return nil }
 
 type otelMockResult struct{}
 
-func (r *otelMockResult) HasPendingTools() bool       { return false }
-func (r *otelMockResult) Parts() []types.ContentPart { return []types.ContentPart{types.NewTextPart("ok")} }
-func (r *otelMockResult) Text() string               { return "ok" }
+func (r *otelMockResult) HasPendingTools() bool                                 { return false }
+func (r *otelMockResult) HasPendingClientTools() bool                           { return false }
+func (r *otelMockResult) PendingClientTools() []a2aserver.PendingClientToolInfo { return nil }
+func (r *otelMockResult) Parts() []types.ContentPart                            { return []types.ContentPart{types.NewTextPart("ok")} }
+func (r *otelMockResult) Text() string                                          { return "ok" }
 
 func ptrStr(s string) *string { return &s }

--- a/server/a2a/conversation.go
+++ b/server/a2a/conversation.go
@@ -11,9 +11,16 @@ import (
 
 // SendResult is what the server needs from a completed conversation turn.
 type SendResult interface {
-	// HasPendingTools reports whether there are tools awaiting approval.
-	// When true the task transitions to input_required.
+	// HasPendingTools reports whether there are tools awaiting approval
+	// (HITL or client-side). When true the task transitions to input_required.
 	HasPendingTools() bool
+
+	// HasPendingClientTools reports whether there are client-side tools
+	// awaiting fulfillment by the caller.
+	HasPendingClientTools() bool
+
+	// PendingClientTools returns metadata for each pending client tool.
+	PendingClientTools() []PendingClientToolInfo
 
 	// Parts returns the content parts of the response.
 	Parts() []types.ContentPart
@@ -21,6 +28,14 @@ type SendResult interface {
 	// Text returns the text content of the response as a fallback
 	// when Parts() is empty.
 	Text() string
+}
+
+// PendingClientToolInfo describes a client-side tool call awaiting fulfillment.
+type PendingClientToolInfo struct {
+	CallID     string         `json:"call_id"`
+	ToolName   string         `json:"tool_name"`
+	Args       map[string]any `json:"args,omitempty"`
+	ConsentMsg string         `json:"consent_message,omitempty"`
 }
 
 // EventKind discriminates the payload of a StreamEvent.
@@ -38,14 +53,18 @@ const (
 
 	// EventDone indicates the stream is complete.
 	EventDone
+
+	// EventClientTool indicates a client tool request awaiting fulfillment.
+	EventClientTool
 )
 
 // StreamEvent is a single event on a streaming channel.
 type StreamEvent struct {
-	Kind  EventKind
-	Text  string
-	Media *types.MediaContent
-	Error error
+	Kind       EventKind
+	Text       string
+	Media      *types.MediaContent
+	ClientTool *PendingClientToolInfo
+	Error      error
 }
 
 // Conversation is the non-streaming conversation interface the server uses.
@@ -58,6 +77,16 @@ type Conversation interface {
 type StreamingConversation interface {
 	Conversation
 	Stream(ctx context.Context, message any) <-chan StreamEvent
+}
+
+// ResumableConversation extends Conversation with the ability to submit
+// client-side tool results and resume pipeline execution.
+type ResumableConversation interface {
+	Conversation
+	SendToolResult(callID string, result any) error
+	RejectClientTool(callID string, reason string)
+	Resume(ctx context.Context) (SendResult, error)
+	ResumeStream(ctx context.Context) <-chan StreamEvent
 }
 
 // ConversationOpener creates or retrieves a conversation for a given context ID.

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -361,6 +361,12 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request, req *
 		return
 	}
 
+	// Check if this is a tool-result message for a resumable conversation.
+	if toolResults := extractToolResults(params.Message.Parts); len(toolResults) > 0 {
+		s.handleToolResultMessage(w, req, conv, contextID, toolResults, params.Configuration)
+		return
+	}
+
 	pkMsg, err := a2a.MessageToMessage(&params.Message)
 	if err != nil {
 		writeRPCError(w, req.ID, -32602, fmt.Sprintf("Invalid message: %v", err))
@@ -393,6 +399,112 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request, req *
 	writeRPCResult(w, req.ID, task)
 }
 
+// toolResultEntry represents a single client tool result extracted from an A2A message.
+type toolResultEntry struct {
+	CallID   string
+	Result   any
+	Rejected bool
+	Reason   string
+}
+
+// extractToolResults inspects message parts for client tool results.
+// Parts with metadata containing "tool_call_id" are treated as tool results.
+func extractToolResults(parts []a2a.Part) []toolResultEntry {
+	var results []toolResultEntry
+	for _, p := range parts {
+		callID, ok := p.Metadata["tool_call_id"].(string)
+		if !ok || callID == "" {
+			continue
+		}
+		entry := toolResultEntry{CallID: callID}
+		if reason, rejected := p.Metadata["rejected"].(string); rejected {
+			entry.Rejected = true
+			entry.Reason = reason
+		} else {
+			entry.Result = p.Metadata["tool_result"]
+		}
+		results = append(results, entry)
+	}
+	return results
+}
+
+// handleToolResultMessage processes a message/send that carries client tool results.
+// It submits each result to the ResumableConversation and resumes execution.
+func (s *Server) handleToolResultMessage(
+	w http.ResponseWriter, req *a2a.JSONRPCRequest,
+	conv Conversation, contextID string,
+	results []toolResultEntry, cfg *a2a.SendMessageConfiguration,
+) {
+	resumable, ok := conv.(ResumableConversation)
+	if !ok {
+		writeRPCError(w, req.ID, -32000, "Conversation does not support client tool results")
+		return
+	}
+
+	for _, r := range results {
+		if r.Rejected {
+			resumable.RejectClientTool(r.CallID, r.Reason)
+		} else {
+			if err := resumable.SendToolResult(r.CallID, r.Result); err != nil {
+				writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to submit tool result: %v", err))
+				return
+			}
+		}
+	}
+
+	taskID := generateID()
+	if _, err := s.taskStore.Create(taskID, contextID); err != nil {
+		writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to create task: %v", err))
+		return
+	}
+
+	done := s.runResume(context.Background(), taskID, resumable)
+
+	if cfg != nil && cfg.Blocking {
+		<-done
+	} else {
+		select {
+		case <-done:
+		case <-time.After(sendSettleTime):
+		}
+	}
+
+	task, _ := s.taskStore.Get(taskID)
+	writeRPCResult(w, req.ID, task)
+}
+
+// runResume spawns a goroutine that calls Resume on a ResumableConversation.
+func (s *Server) runResume(parent context.Context, taskID string, conv ResumableConversation) <-chan struct{} {
+	ctx, cancel := context.WithCancel(parent)
+	s.cancelsMu.Lock()
+	s.cancels[taskID] = cancel
+	s.cancelsMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer cancel()
+
+		_ = s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil)
+
+		resp, err := conv.Resume(ctx)
+		if err != nil {
+			if ctx.Err() == nil {
+				errText := err.Error()
+				_ = s.taskStore.SetState(taskID, a2a.TaskStateFailed, &a2a.Message{
+					Role:  a2a.RoleAgent,
+					Parts: []a2a.Part{{Text: &errText}},
+				})
+			}
+			return
+		}
+
+		s.finalizeTask(taskID, resp)
+	}()
+
+	return done
+}
+
 // runConversation spawns a goroutine that drives the conversation for a task.
 // It returns a channel that is closed when the goroutine completes.
 func (s *Server) runConversation(parent context.Context, taskID string, conv Conversation, pkMsg any) <-chan struct{} {
@@ -423,25 +535,62 @@ func (s *Server) runConversation(parent context.Context, taskID string, conv Con
 			return
 		}
 
-		if resp.HasPendingTools() {
-			_ = s.taskStore.SetState(taskID, a2a.TaskStateInputRequired, nil)
-			return
-		}
-
-		artifacts, convErr := a2a.ContentPartsToArtifacts(resp.Parts())
-		if convErr == nil && len(artifacts) > 0 {
-			_ = s.taskStore.AddArtifacts(taskID, artifacts)
-		} else if text := resp.Text(); text != "" {
-			// Fallback: if Parts() is empty (see GH-428), use Text() content.
-			_ = s.taskStore.AddArtifacts(taskID, []a2a.Artifact{{
-				ArtifactID: "artifact-1",
-				Parts:      []a2a.Part{{Text: &text}},
-			}})
-		}
-		_ = s.taskStore.SetState(taskID, a2a.TaskStateCompleted, nil)
+		s.finalizeTask(taskID, resp)
 	}()
 
 	return done
+}
+
+// finalizeTask handles the terminal state of a task based on the SendResult.
+// If client tools are pending, it sets input_required with tool metadata.
+// Otherwise it stores artifacts and marks the task completed.
+func (s *Server) finalizeTask(taskID string, resp SendResult) {
+	if resp.HasPendingTools() {
+		msg := buildPendingToolsMessage(resp)
+		_ = s.taskStore.SetState(taskID, a2a.TaskStateInputRequired, msg)
+		return
+	}
+
+	artifacts, convErr := a2a.ContentPartsToArtifacts(resp.Parts())
+	if convErr == nil && len(artifacts) > 0 {
+		_ = s.taskStore.AddArtifacts(taskID, artifacts)
+	} else if text := resp.Text(); text != "" {
+		// Fallback: if Parts() is empty (see GH-428), use Text() content.
+		_ = s.taskStore.AddArtifacts(taskID, []a2a.Artifact{{
+			ArtifactID: "artifact-1",
+			Parts:      []a2a.Part{{Text: &text}},
+		}})
+	}
+	_ = s.taskStore.SetState(taskID, a2a.TaskStateCompleted, nil)
+}
+
+// buildPendingToolsMessage creates an A2A message describing pending tools.
+// For client tools, it includes tool metadata (call ID, name, args, consent)
+// in the message parts so the A2A client can fulfill them.
+func buildPendingToolsMessage(resp SendResult) *a2a.Message {
+	clientTools := resp.PendingClientTools()
+	if len(clientTools) == 0 {
+		// HITL-only pending tools — no metadata needed.
+		return nil
+	}
+
+	parts := make([]a2a.Part, len(clientTools))
+	for i, t := range clientTools {
+		text := fmt.Sprintf("Client tool required: %s", t.ToolName)
+		parts[i] = a2a.Part{
+			Text: &text,
+			Metadata: map[string]any{
+				"tool_call_id":    t.CallID,
+				"tool_name":       t.ToolName,
+				"tool_args":       t.Args,
+				"consent_message": t.ConsentMsg,
+			},
+		}
+	}
+	return &a2a.Message{
+		Role:  a2a.RoleAgent,
+		Parts: parts,
+	}
 }
 
 // handleGetTask processes a tasks/get request.

--- a/server/a2a/server_stream.go
+++ b/server/a2a/server_stream.go
@@ -213,6 +213,12 @@ func (s *Server) handleStreamMessage(
 		return
 	}
 
+	// Check if this is a tool-result message for a resumable conversation.
+	if toolResults := extractToolResults(params.Message.Parts); len(toolResults) > 0 {
+		s.handleStreamToolResultMessage(w, r, req, streamConv, contextID, toolResults)
+		return
+	}
+
 	pkMsg, err := a2a.MessageToMessage(&params.Message)
 	if err != nil {
 		writeRPCError(w, req.ID, -32602,
@@ -266,6 +272,73 @@ func (s *Server) handleStreamMessage(
 
 	events := streamConv.Stream(ctx, pkMsg)
 
+	sc.processEvents(ctx, events)
+}
+
+// handleStreamToolResultMessage processes a streaming message/send that carries
+// client tool results. It submits results, then resumes via ResumeStream.
+func (s *Server) handleStreamToolResultMessage(
+	w http.ResponseWriter, r *http.Request, req *a2a.JSONRPCRequest,
+	conv StreamingConversation, contextID string, results []toolResultEntry,
+) {
+	resumable, ok := conv.(ResumableConversation)
+	if !ok {
+		writeRPCError(w, req.ID, -32000, "Conversation does not support client tool results")
+		return
+	}
+
+	for _, tr := range results {
+		if tr.Rejected {
+			resumable.RejectClientTool(tr.CallID, tr.Reason)
+		} else {
+			if err := resumable.SendToolResult(tr.CallID, tr.Result); err != nil {
+				writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to submit tool result: %v", err))
+				return
+			}
+		}
+	}
+
+	taskID := generateID()
+	if _, err := s.taskStore.Create(taskID, contextID); err != nil {
+		writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to create task: %v", err))
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeRPCError(w, req.ID, -32000, "Streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	sc := &streamCtx{
+		srv:       s,
+		w:         w,
+		flusher:   flusher,
+		b:         s.getBroadcaster(taskID),
+		rpcID:     req.ID,
+		taskID:    taskID,
+		contextID: contextID,
+	}
+
+	_ = s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil)
+	sc.emit(a2a.TaskStatusUpdateEvent{
+		TaskID:    taskID,
+		ContextID: contextID,
+		Status:    a2a.TaskStatus{State: a2a.TaskStateWorking},
+	})
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	s.cancelsMu.Lock()
+	s.cancels[taskID] = cancel
+	s.cancelsMu.Unlock()
+
+	events := resumable.ResumeStream(ctx)
 	sc.processEvents(ctx, events)
 }
 
@@ -331,6 +404,10 @@ func (sc *streamCtx) handleEvent(evt StreamEvent, artifactIdx int) (done bool, n
 		// Suppressed — agent opacity. Task stays working.
 		return false, artifactIdx
 
+	case EventClientTool:
+		sc.emitInputRequired(evt)
+		return true, artifactIdx
+
 	case EventDone:
 		sc.complete()
 		return true, artifactIdx
@@ -338,6 +415,38 @@ func (sc *streamCtx) handleEvent(evt StreamEvent, artifactIdx int) (done bool, n
 	default:
 		return false, artifactIdx
 	}
+}
+
+// emitInputRequired emits a task status update with input_required state
+// and client tool metadata so the A2A client can fulfill the tool request.
+func (sc *streamCtx) emitInputRequired(evt StreamEvent) {
+	var msg *a2a.Message
+	if evt.ClientTool != nil {
+		text := fmt.Sprintf("Client tool required: %s", evt.ClientTool.ToolName)
+		msg = &a2a.Message{
+			Role: a2a.RoleAgent,
+			Parts: []a2a.Part{{
+				Text: &text,
+				Metadata: map[string]any{
+					"tool_call_id":    evt.ClientTool.CallID,
+					"tool_name":       evt.ClientTool.ToolName,
+					"tool_args":       evt.ClientTool.Args,
+					"consent_message": evt.ClientTool.ConsentMsg,
+				},
+			}},
+		}
+	}
+	_ = sc.srv.taskStore.SetState(sc.taskID, a2a.TaskStateInputRequired, msg)
+	sc.emit(a2a.TaskStatusUpdateEvent{
+		TaskID:    sc.taskID,
+		ContextID: sc.contextID,
+		Status: a2a.TaskStatus{
+			State:   a2a.TaskStateInputRequired,
+			Message: msg,
+		},
+	})
+	sc.b.close()
+	sc.srv.removeBroadcaster(sc.taskID)
 }
 
 // emitArtifact emits a single artifact update event.

--- a/server/a2a/server_stream_test.go
+++ b/server/a2a/server_stream_test.go
@@ -968,3 +968,178 @@ func TestServer_StreamMessage_TaskStoreAfterStream(t *testing.T) {
 		t.Fatalf("task ID = %q, want %q", got.ID, taskID)
 	}
 }
+
+func TestServer_StreamMessage_ClientTool_InputRequired(t *testing.T) {
+	mock := &mockStreamConv{
+		mockConv: mockConv{
+			sendFunc: func(_ context.Context, _ any) (SendResult, error) {
+				return &mockSendResult{}, nil
+			},
+		},
+		streamFunc: func(_ context.Context, _ any) <-chan StreamEvent {
+			ch := make(chan StreamEvent, 3)
+			ch <- StreamEvent{Kind: EventText, Text: "Looking up..."}
+			ch <- StreamEvent{
+				Kind: EventClientTool,
+				ClientTool: &PendingClientToolInfo{
+					CallID:     "call-loc",
+					ToolName:   "get_location",
+					Args:       map[string]any{"accuracy": "high"},
+					ConsentMsg: "Allow location?",
+				},
+			}
+			close(ch)
+			return ch
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	events := readSSEEvents(t, ts, a2a.MethodSendStreamingMessage, a2a.SendMessageRequest{
+		Message: a2a.Message{
+			ContextID: "ctx-stream-client",
+			Role:      a2a.RoleUser,
+			Parts:     []a2a.Part{{Text: serverTextPtr("Where am I?")}},
+		},
+	})
+
+	// Expect: working status, artifact (text), input_required status.
+	var foundInputRequired bool
+	for _, evt := range events {
+		if evt.StatusUpdate != nil && evt.StatusUpdate.Status.State == a2a.TaskStateInputRequired {
+			foundInputRequired = true
+			if evt.StatusUpdate.Status.Message == nil {
+				t.Error("expected status message with tool metadata")
+			} else if len(evt.StatusUpdate.Status.Message.Parts) == 0 {
+				t.Error("expected message parts with tool metadata")
+			} else {
+				meta := evt.StatusUpdate.Status.Message.Parts[0].Metadata
+				if meta["tool_call_id"] != "call-loc" {
+					t.Errorf("tool_call_id = %v, want call-loc", meta["tool_call_id"])
+				}
+				if meta["tool_name"] != "get_location" {
+					t.Errorf("tool_name = %v, want get_location", meta["tool_name"])
+				}
+			}
+		}
+	}
+	if !foundInputRequired {
+		t.Fatal("no input_required event found in stream")
+	}
+}
+
+// mockResumableStreamConv is a streaming conversation that also implements ResumableConversation.
+type mockResumableStreamConv struct {
+	mockStreamConv
+	toolResults    []toolResultEntry
+	rejected       []toolResultEntry
+	resumeStreamFn func(ctx context.Context) <-chan StreamEvent
+	mu             sync.Mutex
+}
+
+func (m *mockResumableStreamConv) SendToolResult(callID string, result any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.toolResults = append(m.toolResults, toolResultEntry{CallID: callID, Result: result})
+	return nil
+}
+
+func (m *mockResumableStreamConv) RejectClientTool(callID string, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rejected = append(m.rejected, toolResultEntry{CallID: callID, Rejected: true, Reason: reason})
+}
+
+func (m *mockResumableStreamConv) Resume(_ context.Context) (SendResult, error) {
+	return &mockSendResult{parts: []types.ContentPart{types.NewTextPart("resumed")}}, nil
+}
+
+func (m *mockResumableStreamConv) ResumeStream(ctx context.Context) <-chan StreamEvent {
+	return m.resumeStreamFn(ctx)
+}
+
+func TestServer_StreamMessage_ClientTool_ResumeStream(t *testing.T) {
+	mock := &mockResumableStreamConv{
+		mockStreamConv: mockStreamConv{
+			mockConv: mockConv{
+				sendFunc: func(_ context.Context, _ any) (SendResult, error) {
+					return &mockSendResult{}, nil
+				},
+			},
+			streamFunc: func(_ context.Context, _ any) <-chan StreamEvent {
+				ch := make(chan StreamEvent, 2)
+				ch <- StreamEvent{
+					Kind: EventClientTool,
+					ClientTool: &PendingClientToolInfo{
+						CallID:   "call-1",
+						ToolName: "get_location",
+					},
+				}
+				close(ch)
+				return ch
+			},
+		},
+		resumeStreamFn: func(_ context.Context) <-chan StreamEvent {
+			ch := make(chan StreamEvent, 2)
+			ch <- StreamEvent{Kind: EventText, Text: "You are in NYC"}
+			ch <- StreamEvent{Kind: EventDone}
+			close(ch)
+			return ch
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	// Step 1: stream triggers input_required.
+	events1 := readSSEEvents(t, ts, a2a.MethodSendStreamingMessage, a2a.SendMessageRequest{
+		Message: a2a.Message{
+			ContextID: "ctx-stream-resume",
+			Role:      a2a.RoleUser,
+			Parts:     []a2a.Part{{Text: serverTextPtr("Where am I?")}},
+		},
+	})
+
+	var foundInputRequired bool
+	for _, evt := range events1 {
+		if evt.StatusUpdate != nil && evt.StatusUpdate.Status.State == a2a.TaskStateInputRequired {
+			foundInputRequired = true
+		}
+	}
+	if !foundInputRequired {
+		t.Fatal("expected input_required in first stream")
+	}
+
+	// Step 2: send tool results via streaming, triggering ResumeStream.
+	events2 := readSSEEvents(t, ts, a2a.MethodSendStreamingMessage, a2a.SendMessageRequest{
+		Message: a2a.Message{
+			ContextID: "ctx-stream-resume",
+			Role:      a2a.RoleUser,
+			Parts: []a2a.Part{
+				{
+					Metadata: map[string]any{
+						"tool_call_id": "call-1",
+						"tool_result":  map[string]any{"lat": 40.7, "lon": -74.0},
+					},
+				},
+			},
+		},
+	})
+
+	var foundCompleted bool
+	for _, evt := range events2 {
+		if evt.StatusUpdate != nil && evt.StatusUpdate.Status.State == a2a.TaskStateCompleted {
+			foundCompleted = true
+		}
+	}
+	if !foundCompleted {
+		t.Fatal("expected completed in resume stream")
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.toolResults) != 1 || mock.toolResults[0].CallID != "call-1" {
+		t.Errorf("tool results = %+v, want [{call-1 ...}]", mock.toolResults)
+	}
+}

--- a/server/a2a/server_test.go
+++ b/server/a2a/server_test.go
@@ -29,14 +29,18 @@ import (
 // --- mock SendResult ---
 
 type mockSendResult struct {
-	parts      []types.ContentPart
-	text       string
-	hasPending bool
+	parts              []types.ContentPart
+	text               string
+	hasPending         bool
+	hasPendingClient   bool
+	pendingClientTools []PendingClientToolInfo
 }
 
-func (r *mockSendResult) HasPendingTools() bool       { return r.hasPending }
-func (r *mockSendResult) Parts() []types.ContentPart { return r.parts }
-func (r *mockSendResult) Text() string               { return r.text }
+func (r *mockSendResult) HasPendingTools() bool                    { return r.hasPending }
+func (r *mockSendResult) HasPendingClientTools() bool              { return r.hasPendingClient }
+func (r *mockSendResult) PendingClientTools() []PendingClientToolInfo { return r.pendingClientTools }
+func (r *mockSendResult) Parts() []types.ContentPart               { return r.parts }
+func (r *mockSendResult) Text() string                             { return r.text }
 
 // --- mock conversation for server tests ---
 
@@ -1827,5 +1831,297 @@ func TestServerShutdownConvCloseError(t *testing.T) {
 	err := srv.Shutdown(ctx)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Shutdown error = %v, want %v", err, wantErr)
+	}
+}
+
+// --- mock resumable conversation ---
+
+type mockResumableConv struct {
+	mockConv
+	toolResults    []toolResultEntry
+	rejected       []toolResultEntry
+	resumeFunc     func(ctx context.Context) (SendResult, error)
+	resumeStreamFn func(ctx context.Context) <-chan StreamEvent
+	mu             sync.Mutex
+}
+
+func (m *mockResumableConv) SendToolResult(callID string, result any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.toolResults = append(m.toolResults, toolResultEntry{CallID: callID, Result: result})
+	return nil
+}
+
+func (m *mockResumableConv) RejectClientTool(callID string, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rejected = append(m.rejected, toolResultEntry{CallID: callID, Rejected: true, Reason: reason})
+}
+
+func (m *mockResumableConv) Resume(ctx context.Context) (SendResult, error) {
+	return m.resumeFunc(ctx)
+}
+
+func (m *mockResumableConv) ResumeStream(ctx context.Context) <-chan StreamEvent {
+	if m.resumeStreamFn != nil {
+		return m.resumeStreamFn(ctx)
+	}
+	ch := make(chan StreamEvent)
+	close(ch)
+	return ch
+}
+
+// --- client tool tests ---
+
+func TestServer_ClientTool_InputRequired(t *testing.T) {
+	mock := &mockConv{
+		sendFunc: func(_ context.Context, _ any) (SendResult, error) {
+			return &mockSendResult{
+				hasPending:       true,
+				hasPendingClient: true,
+				pendingClientTools: []PendingClientToolInfo{
+					{CallID: "call-1", ToolName: "get_location", Args: map[string]any{"accuracy": "high"}, ConsentMsg: "Allow location access?"},
+				},
+			}, nil
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	task := a2aSendMessage(t, ts, "ctx-client-tool", "Where am I?")
+
+	if task.Status.State != a2a.TaskStateInputRequired {
+		t.Fatalf("state = %q, want input_required", task.Status.State)
+	}
+	if task.Status.Message == nil {
+		t.Fatal("expected status message with tool metadata")
+	}
+	if len(task.Status.Message.Parts) != 1 {
+		t.Fatalf("parts = %d, want 1", len(task.Status.Message.Parts))
+	}
+	part := task.Status.Message.Parts[0]
+	if part.Metadata["tool_call_id"] != "call-1" {
+		t.Errorf("tool_call_id = %v, want call-1", part.Metadata["tool_call_id"])
+	}
+	if part.Metadata["tool_name"] != "get_location" {
+		t.Errorf("tool_name = %v, want get_location", part.Metadata["tool_name"])
+	}
+}
+
+func TestServer_ClientTool_ResumeCompleted(t *testing.T) {
+	mock := &mockResumableConv{
+		mockConv: mockConv{
+			sendFunc: func(_ context.Context, _ any) (SendResult, error) {
+				return &mockSendResult{
+					hasPending:       true,
+					hasPendingClient: true,
+					pendingClientTools: []PendingClientToolInfo{
+						{CallID: "call-1", ToolName: "get_location"},
+					},
+				}, nil
+			},
+		},
+		resumeFunc: func(_ context.Context) (SendResult, error) {
+			return &mockSendResult{
+				parts: []types.ContentPart{types.NewTextPart("You are in NYC")},
+				text:  "You are in NYC",
+			}, nil
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	// First: trigger client tool suspension.
+	task1 := a2aSendMessage(t, ts, "ctx-resume", "Where am I?")
+	if task1.Status.State != a2a.TaskStateInputRequired {
+		t.Fatalf("state = %q, want input_required", task1.Status.State)
+	}
+
+	// Second: send tool result on same context ID.
+	task2 := a2aRPCRequestTask(t, ts, a2a.MethodSendMessage, a2a.SendMessageRequest{
+		Message: a2a.Message{
+			ContextID: "ctx-resume",
+			Role:      a2a.RoleUser,
+			Parts: []a2a.Part{
+				{
+					Metadata: map[string]any{
+						"tool_call_id": "call-1",
+						"tool_result":  map[string]any{"lat": 40.7, "lon": -74.0},
+					},
+				},
+			},
+		},
+		Configuration: &a2a.SendMessageConfiguration{Blocking: true},
+	})
+
+	if task2.Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", task2.Status.State)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.toolResults) != 1 {
+		t.Fatalf("tool results = %d, want 1", len(mock.toolResults))
+	}
+	if mock.toolResults[0].CallID != "call-1" {
+		t.Errorf("call ID = %q, want call-1", mock.toolResults[0].CallID)
+	}
+}
+
+func TestServer_ClientTool_Reject(t *testing.T) {
+	mock := &mockResumableConv{
+		mockConv: mockConv{
+			sendFunc: func(_ context.Context, _ any) (SendResult, error) {
+				return &mockSendResult{
+					hasPending:       true,
+					hasPendingClient: true,
+					pendingClientTools: []PendingClientToolInfo{
+						{CallID: "call-1", ToolName: "get_location"},
+					},
+				}, nil
+			},
+		},
+		resumeFunc: func(_ context.Context) (SendResult, error) {
+			return &mockSendResult{
+				parts: []types.ContentPart{types.NewTextPart("Location denied")},
+				text:  "Location denied",
+			}, nil
+		},
+	}
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	// Trigger suspension.
+	a2aSendMessage(t, ts, "ctx-reject", "Where am I?")
+
+	// Reject the tool.
+	task := a2aRPCRequestTask(t, ts, a2a.MethodSendMessage, a2a.SendMessageRequest{
+		Message: a2a.Message{
+			ContextID: "ctx-reject",
+			Role:      a2a.RoleUser,
+			Parts: []a2a.Part{
+				{
+					Metadata: map[string]any{
+						"tool_call_id": "call-1",
+						"rejected":     "user declined location access",
+					},
+				},
+			},
+		},
+		Configuration: &a2a.SendMessageConfiguration{Blocking: true},
+	})
+
+	if task.Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("state = %q, want completed", task.Status.State)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.rejected) != 1 {
+		t.Fatalf("rejected = %d, want 1", len(mock.rejected))
+	}
+	if mock.rejected[0].Reason != "user declined location access" {
+		t.Errorf("reason = %q, want 'user declined location access'", mock.rejected[0].Reason)
+	}
+}
+
+func TestServer_ClientTool_NonResumable(t *testing.T) {
+	// A regular (non-resumable) conversation should return an error
+	// when tool results are sent.
+	mock := completingMock()
+
+	_, ts := newTestServer(func(string) (Conversation, error) { return mock, nil })
+	defer ts.Close()
+
+	// Send an initial message to create the conversation.
+	a2aSendMessage(t, ts, "ctx-nonresumable", "Hello")
+
+	// Try to send tool results to a non-resumable conversation.
+	resp := a2aRPCRequest(t, ts, a2a.MethodSendMessage, a2a.SendMessageRequest{
+		Message: a2a.Message{
+			ContextID: "ctx-nonresumable",
+			Role:      a2a.RoleUser,
+			Parts: []a2a.Part{
+				{
+					Metadata: map[string]any{
+						"tool_call_id": "call-1",
+						"tool_result":  "some result",
+					},
+				},
+			},
+		},
+		Configuration: &a2a.SendMessageConfiguration{Blocking: true},
+	})
+
+	if resp.Error == nil {
+		t.Fatal("expected RPC error for non-resumable conversation")
+	}
+	if resp.Error.Code != -32000 {
+		t.Errorf("error code = %d, want -32000", resp.Error.Code)
+	}
+}
+
+func TestExtractToolResults(t *testing.T) {
+	parts := []a2a.Part{
+		{Text: serverTextPtr("just text")},
+		{
+			Metadata: map[string]any{
+				"tool_call_id": "call-1",
+				"tool_result":  map[string]any{"lat": 40.7},
+			},
+		},
+		{
+			Metadata: map[string]any{
+				"tool_call_id": "call-2",
+				"rejected":     "user denied",
+			},
+		},
+	}
+
+	results := extractToolResults(parts)
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+
+	if results[0].CallID != "call-1" || results[0].Rejected {
+		t.Errorf("result[0] = %+v, want call-1 non-rejected", results[0])
+	}
+	if results[1].CallID != "call-2" || !results[1].Rejected || results[1].Reason != "user denied" {
+		t.Errorf("result[1] = %+v, want call-2 rejected with reason", results[1])
+	}
+}
+
+func TestBuildPendingToolsMessage(t *testing.T) {
+	resp := &mockSendResult{
+		hasPending:       true,
+		hasPendingClient: true,
+		pendingClientTools: []PendingClientToolInfo{
+			{CallID: "c1", ToolName: "camera", Args: map[string]any{"mode": "photo"}, ConsentMsg: "Allow camera?"},
+		},
+	}
+
+	msg := buildPendingToolsMessage(resp)
+	if msg == nil {
+		t.Fatal("expected non-nil message")
+	}
+	if len(msg.Parts) != 1 {
+		t.Fatalf("parts = %d, want 1", len(msg.Parts))
+	}
+	if msg.Parts[0].Metadata["tool_call_id"] != "c1" {
+		t.Errorf("tool_call_id = %v, want c1", msg.Parts[0].Metadata["tool_call_id"])
+	}
+	if msg.Parts[0].Metadata["tool_name"] != "camera" {
+		t.Errorf("tool_name = %v, want camera", msg.Parts[0].Metadata["tool_name"])
+	}
+}
+
+func TestBuildPendingToolsMessage_HITLOnly(t *testing.T) {
+	resp := &mockSendResult{hasPending: true}
+	msg := buildPendingToolsMessage(resp)
+	if msg != nil {
+		t.Fatalf("expected nil message for HITL-only pending, got %+v", msg)
 	}
 }

--- a/tools/arena/consent/hook.go
+++ b/tools/arena/consent/hook.go
@@ -47,16 +47,20 @@ func (h *SimulationHook) BeforeExecution(ctx context.Context, req hooks.ToolRequ
 	switch action {
 	case "deny":
 		reason := buildDenyMessage(req.Name, h.lookupDeclineStrategy(ctx, req.Name))
-		return hooks.Decision{Allow: false, Reason: reason}
+		return hooks.DenyWithMetadata(reason, map[string]any{
+			"consent_status": "denied",
+		})
 
 	case "timeout":
-		return hooks.Decision{
-			Allow:  false,
-			Reason: fmt.Sprintf("Tool %s timed out waiting for user consent", req.Name),
-		}
+		return hooks.DenyWithMetadata(
+			fmt.Sprintf("Tool %s timed out waiting for user consent", req.Name),
+			map[string]any{"consent_status": "timeout"},
+		)
 
 	default: // "grant" or any other value
-		return hooks.Allow
+		return hooks.Decision{Allow: true, Metadata: map[string]any{
+			"consent_status": "granted",
+		}}
 	}
 }
 

--- a/tools/arena/consent/hook_test.go
+++ b/tools/arena/consent/hook_test.go
@@ -34,6 +34,60 @@ func TestSimulationHook_Grant(t *testing.T) {
 	}
 }
 
+func TestSimulationHook_GrantMetadata(t *testing.T) {
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "grant",
+	})
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if !d.Allow {
+		t.Fatal("expected Allow=true for grant override")
+	}
+	if d.Metadata == nil {
+		t.Fatal("expected non-nil Metadata for grant decision")
+	}
+	if status, ok := d.Metadata["consent_status"].(string); !ok || status != "granted" {
+		t.Errorf("expected consent_status='granted', got %v", d.Metadata["consent_status"])
+	}
+}
+
+func TestSimulationHook_DenyMetadata(t *testing.T) {
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "deny",
+	})
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if d.Allow {
+		t.Fatal("expected Allow=false for deny override")
+	}
+	if d.Metadata == nil {
+		t.Fatal("expected non-nil Metadata for deny decision")
+	}
+	if status, ok := d.Metadata["consent_status"].(string); !ok || status != "denied" {
+		t.Errorf("expected consent_status='denied', got %v", d.Metadata["consent_status"])
+	}
+}
+
+func TestSimulationHook_TimeoutMetadata(t *testing.T) {
+	h := NewSimulationHook()
+	ctx := WithConsentOverrides(context.Background(), map[string]string{
+		"get_location": "timeout",
+	})
+
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "get_location"})
+	if d.Allow {
+		t.Fatal("expected Allow=false for timeout override")
+	}
+	if d.Metadata == nil {
+		t.Fatal("expected non-nil Metadata for timeout decision")
+	}
+	if status, ok := d.Metadata["consent_status"].(string); !ok || status != "timeout" {
+		t.Errorf("expected consent_status='timeout', got %v", d.Metadata["consent_status"])
+	}
+}
+
 func TestSimulationHook_Deny_ErrorStrategy(t *testing.T) {
 	registry := tools.NewRegistry()
 	_ = registry.Register(&tools.ToolDescriptor{

--- a/tools/arena/render/html.go
+++ b/tools/arena/render/html.go
@@ -373,6 +373,7 @@ func generateHTML(data HTMLReportData) (string, error) {
 		"isWorkflowTool":      isWorkflowTool,
 		"hasA2AAgents":        hasA2AAgents,
 		"renderA2AAgentCards": renderA2AAgentCards,
+		"consentStatus":       consentStatus,
 	}).Parse(reportTemplate))
 
 	var buf strings.Builder
@@ -1085,6 +1086,20 @@ func renderConversationDetails(result assertions.ConversationValidationResult) s
 	}
 	b.WriteString(`</details>`)
 	return b.String()
+}
+
+// consentStatus extracts consent status from a message's Meta field.
+// Returns "granted", "denied", "timeout", or "" if no consent metadata.
+//
+//nolint:gocritic // hugeParam: template functions can't use pointers
+func consentStatus(msg types.Message) string {
+	if msg.Meta == nil {
+		return ""
+	}
+	if status, ok := msg.Meta["consent_status"].(string); ok {
+		return status
+	}
+	return ""
 }
 
 // isAgentTool returns true if the tool name is an A2A agent tool.

--- a/tools/arena/render/html_test.go
+++ b/tools/arena/render/html_test.go
@@ -2818,3 +2818,57 @@ func TestRenderA2AAgentCards(t *testing.T) {
 		}
 	})
 }
+
+func TestConsentStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		meta     map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "granted",
+			meta:     map[string]interface{}{"consent_status": "granted"},
+			expected: "granted",
+		},
+		{
+			name:     "denied",
+			meta:     map[string]interface{}{"consent_status": "denied"},
+			expected: "denied",
+		},
+		{
+			name:     "timeout",
+			meta:     map[string]interface{}{"consent_status": "timeout"},
+			expected: "timeout",
+		},
+		{
+			name:     "nil meta",
+			meta:     nil,
+			expected: "",
+		},
+		{
+			name:     "empty meta",
+			meta:     map[string]interface{}{},
+			expected: "",
+		},
+		{
+			name:     "wrong type in meta",
+			meta:     map[string]interface{}{"consent_status": 42},
+			expected: "",
+		},
+		{
+			name:     "other meta keys only",
+			meta:     map[string]interface{}{"some_key": "some_value"},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := types.Message{Role: "tool", Meta: tt.meta}
+			got := consentStatus(msg)
+			if got != tt.expected {
+				t.Errorf("consentStatus() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/tools/arena/render/templates/report.html.tmpl
+++ b/tools/arena/render/templates/report.html.tmpl
@@ -923,6 +923,18 @@
             display: none;
         }
         
+        .devtools-consent-badge {
+            display: inline-block;
+            padding: 1px 6px;
+            border-radius: 3px;
+            font-size: 0.65rem;
+            font-weight: 600;
+            margin-left: auto;
+        }
+        .devtools-consent-granted { background: #166534; color: #dcfce7; }
+        .devtools-consent-denied { background: #991b1b; color: #fecaca; }
+        .devtools-consent-timeout { background: #92400e; color: #fef3c7; }
+
         .turn-error {
             background: #fed7d7;
             border: 1px solid #fc8181;
@@ -2109,7 +2121,8 @@
                                     </div>
                                     {{end}}
                                     {{if eq $msg.Role "tool"}}
-                                    <div class="tool-response">
+                                    {{$consent := consentStatus $msg}}
+                                    <div class="tool-response"{{if and $consent $msg.ToolResult}} data-consent-status="{{$consent}}" data-tool-call-id="{{$msg.ToolResult.ID}}"{{end}}>
                                         <div class="tool-response-header" onclick="toggleToolResponse(this)">
                                             {{if $msg.ToolResult}}
                                             <span class="tool-response-name{{if isAgentTool $msg.ToolResult.Name}} agent{{else if isWorkflowTool $msg.ToolResult.Name}} workflow{{end}}">{{if isAgentTool $msg.ToolResult.Name}}<span class="agent-icon">🤖</span>{{else if isWorkflowTool $msg.ToolResult.Name}}<span class="workflow-icon">⚡</span>{{end}}{{$msg.ToolResult.Name}}</span>
@@ -2532,6 +2545,16 @@
 
                 // Tool calls made in this turn
                 if (toolcallsEl) {
+                    // Build consent status map from tool-response elements in the same result
+                    var consentMap = {};
+                    var resultContainer = data.closest('.result-card') || data.parentElement;
+                    if (resultContainer) {
+                        resultContainer.querySelectorAll('.tool-response[data-consent-status]').forEach(function(el) {
+                            var callId = el.getAttribute('data-tool-call-id');
+                            var status = el.getAttribute('data-consent-status');
+                            if (callId && status) consentMap[callId] = status;
+                        });
+                    }
                     html += '<div class="devtools-section"><div class="devtools-section-title">Tool Calls Made</div>';
                     try {
                         var calls = JSON.parse(toolcallsEl.textContent);
@@ -2543,11 +2566,16 @@
                                 else if (tc.name && tc.name.startsWith('a2a__')) { badge = 'a2a'; badgeLabel = 'a2a'; }
                                 else if (tc.name && tc.name.startsWith('mcp__')) { badge = 'a2a'; badgeLabel = 'mcp'; }
                                 else if (tc.name && tc.name.startsWith('memory__')) { badge = 'skill'; badgeLabel = 'mem'; }
+                                var consentStatus = tc.id ? (consentMap[tc.id] || '') : '';
                                 html += '<div style="margin-bottom:0.75rem;border:1px solid #313244;border-radius:4px;overflow:hidden;">';
                                 html += '<div style="display:flex;align-items:center;gap:0.5rem;padding:0.4rem 0.5rem;background:#181825;border-bottom:1px solid #313244;">';
                                 html += '<span class="devtools-tool-badge ' + badge + '">' + badgeLabel + '</span>';
                                 html += '<span style="font-family:monospace;font-size:0.8rem;color:#89b4fa;">' + escapeHtml(stripToolNamespace(tc.name || 'unknown')) + '</span>';
-                                if (tc.id) html += '<span style="margin-left:auto;font-size:0.65rem;color:#585b70;">' + tc.id + '</span>';
+                                if (consentStatus) {
+                                    var cLabel = consentStatus === 'granted' ? '✓ granted' : consentStatus === 'denied' ? '✗ denied' : '⏱ timeout';
+                                    html += '<span class="devtools-consent-badge devtools-consent-' + consentStatus + '">' + cLabel + '</span>';
+                                }
+                                if (tc.id) html += '<span style="' + (consentStatus ? '' : 'margin-left:auto;') + 'font-size:0.65rem;color:#585b70;">' + tc.id + '</span>';
                                 html += '</div>';
                                 if (tc.args) {
                                     var argsStr = typeof tc.args === 'string' ? tc.args : JSON.stringify(tc.args, null, 2);


### PR DESCRIPTION
## Summary

- **Strip binary from emitter events**: `Emitter.MessageCreated()` now calls `types.MetadataOnlyParts()` to strip `Data` and `FilePath` from content parts, keeping only metadata (MIMEType, SizeKB, dimensions, URL). This keeps observability events lightweight.
- **Add `WithRecording()` SDK option**: Inserts input/output `RecordingStage`s into the pipeline that bypass the emitter and publish full binary data directly to the EventBus for session replay.
- **Emit tool call events from ProviderStage**: `ToolCallStarted`, `ToolCallCompleted`, and `ToolCallFailed` events are now emitted during tool execution in the pipeline.
- **Documentation updates**: Updated SDK reference, observability explanation, and session recording architecture docs.

Closes #602, closes #604, closes #607

## Test plan

- [x] `MetadataOnlyParts` strips binary, preserves metadata/URL, doesn't mutate originals
- [x] `Emitter.MessageCreated` strips binary data from parts in emitted events
- [x] Pipeline builder inserts RecordingStages when `RecordingConfig` + `RecordingEventBus` are set
- [x] Pipeline builder skips RecordingStages when config or bus is nil
- [x] Pipeline with recording stages executes successfully end-to-end
- [x] ProviderStage emits tool call started/completed/failed events
- [x] All pre-commit checks pass (lint, build, tests, ≥80% coverage)