### PR TITLE
fix(runtime): fix flaky tool call event ordering test

### DIFF
--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -1689,16 +1689,28 @@ func TestProviderStage_ExecuteToolCalls_EmitsStartedCompleted(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	require.Len(t, captured, 2)
-	assert.Equal(t, events.EventToolCallStarted, captured[0].Type)
-	assert.Equal(t, events.EventToolCallCompleted, captured[1].Type)
 
-	startedData, ok := captured[0].Data.(events.ToolCallStartedData)
+	// Find events by type (event bus delivery order is non-deterministic under -race)
+	var startedEvt, completedEvt *events.Event
+	for _, e := range captured {
+		switch e.Type {
+		case events.EventToolCallStarted:
+			startedEvt = e
+		case events.EventToolCallCompleted:
+			completedEvt = e
+		}
+	}
+
+	require.NotNil(t, startedEvt, "expected a tool.call.started event")
+	require.NotNil(t, completedEvt, "expected a tool.call.completed event")
+
+	startedData, ok := startedEvt.Data.(events.ToolCallStartedData)
 	require.True(t, ok)
 	assert.Equal(t, "emit_tool", startedData.ToolName)
 	assert.Equal(t, "call-1", startedData.CallID)
 	assert.Equal(t, "value", startedData.Args["key"])
 
-	completedData, ok := captured[1].Data.(events.ToolCallCompletedData)
+	completedData, ok := completedEvt.Data.(events.ToolCallCompletedData)
 	require.True(t, ok)
 	assert.Equal(t, "emit_tool", completedData.ToolName)
 	assert.Equal(t, "call-1", completedData.CallID)


### PR DESCRIPTION
## Summary

- Fix `TestProviderStage_ExecuteToolCalls_EmitsStartedCompleted` which fails intermittently in CI with `-race`
- The event bus delivers events via goroutines, so `started` and `completed` can arrive in either order
- Changed assertions to look up events by type instead of assuming index order

## Test plan

- [x] Ran the test 5x with `-race -count=5` — all pass
- [x] Pre-commit hook passes (lint, build, tests)