### PR TITLE
fix(telemetry): nest provider/tool/middleware spans under pipeline span

### DIFF
--- a/runtime/telemetry/listener.go
+++ b/runtime/telemetry/listener.go
@@ -137,13 +137,28 @@ func (l *OTelEventListener) sessionCtx(sessionID string) context.Context {
 	return context.Background()
 }
 
-// startSpan starts a span parented under the session root and stores it in inflight.
+// parentCtxForRun returns the context of the inflight pipeline span for the
+// given runID, falling back to the session root span context if no pipeline
+// span is active. This ensures provider, tool, and middleware spans are nested
+// under their pipeline span in trace viewers.
+func (l *OTelEventListener) parentCtxForRun(sessionID, runID string) context.Context {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if entry, ok := l.inflight["pipeline:"+runID]; ok {
+		return entry.ctx
+	}
+	if ss, ok := l.sessions[sessionID]; ok {
+		return ss.ctx
+	}
+	return context.Background()
+}
+
+// startSpan starts a span parented under the given parent context and stores it in inflight.
 // If a completion was already buffered (out-of-order delivery), the span is
 // immediately ended.
 func (l *OTelEventListener) startSpan(
-	sessionID, key, name string, kind trace.SpanKind, attrs ...attribute.KeyValue,
+	parentCtx context.Context, key, name string, kind trace.SpanKind, attrs ...attribute.KeyValue,
 ) {
-	parentCtx := l.sessionCtx(sessionID)
 	ctx, span := l.tracer.Start(parentCtx, name,
 		trace.WithSpanKind(kind),
 		trace.WithAttributes(attrs...),
@@ -223,7 +238,7 @@ func asPtr[T any](data any) (*T, bool) {
 // --- Pipeline ---
 
 func (l *OTelEventListener) startPipeline(evt *events.Event) {
-	l.startSpan(evt.SessionID, "pipeline:"+evt.RunID, "promptkit.pipeline",
+	l.startSpan(l.sessionCtx(evt.SessionID), "pipeline:"+evt.RunID, "promptkit.pipeline",
 		trace.SpanKindInternal,
 		attribute.String("run.id", evt.RunID),
 	)
@@ -259,7 +274,7 @@ func (l *OTelEventListener) startProvider(evt *events.Event) {
 	if !ok {
 		return
 	}
-	l.startSpan(evt.SessionID, "provider:"+evt.RunID, "promptkit.provider."+data.Provider,
+	l.startSpan(l.parentCtxForRun(evt.SessionID, evt.RunID), "provider:"+evt.RunID, "promptkit.provider."+data.Provider,
 		trace.SpanKindClient,
 		attribute.String("gen_ai.system", data.Provider),
 		attribute.String("gen_ai.request.model", data.Model),
@@ -308,7 +323,7 @@ func (l *OTelEventListener) startTool(evt *events.Event) {
 			attrs = append(attrs, attribute.String("tool.args", string(argsJSON)))
 		}
 	}
-	l.startSpan(evt.SessionID, "tool:"+data.CallID, "promptkit.tool."+data.ToolName,
+	l.startSpan(l.parentCtxForRun(evt.SessionID, evt.RunID), "tool:"+data.CallID, "promptkit.tool."+data.ToolName,
 		trace.SpanKindInternal,
 		attrs...,
 	)
@@ -342,7 +357,7 @@ func (l *OTelEventListener) startMiddleware(evt *events.Event) {
 	if !ok {
 		return
 	}
-	l.startSpan(evt.SessionID, "middleware:"+data.Name, "promptkit.middleware."+data.Name,
+	l.startSpan(l.parentCtxForRun(evt.SessionID, evt.RunID), "middleware:"+data.Name, "promptkit.middleware."+data.Name,
 		trace.SpanKindInternal,
 		attribute.String("middleware.name", data.Name),
 		attribute.Int("middleware.index", data.Index),

--- a/runtime/telemetry/listener_test.go
+++ b/runtime/telemetry/listener_test.go
@@ -91,6 +91,45 @@ func TestOTelEventListener_PipelineSpan(t *testing.T) {
 		SessionID: "sess-1", RunID: "run-1",
 		Data: &events.PipelineStartedData{MiddlewareCount: 2},
 	})
+
+	// Emit provider, tool, and middleware spans inside the pipeline.
+	listener.OnEvent(&events.Event{
+		Type: events.EventMiddlewareStarted, Timestamp: now.Add(10 * time.Millisecond),
+		SessionID: "sess-1", RunID: "run-1",
+		Data: &events.MiddlewareStartedData{Name: "guard", Index: 0},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventMiddlewareCompleted, Timestamp: now.Add(20 * time.Millisecond),
+		SessionID: "sess-1", RunID: "run-1",
+		Data: &events.MiddlewareCompletedData{Name: "guard", Index: 0, Duration: 10 * time.Millisecond},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventProviderCallStarted, Timestamp: now.Add(50 * time.Millisecond),
+		SessionID: "sess-1", RunID: "run-1",
+		Data: &events.ProviderCallStartedData{Provider: "openai", Model: "gpt-4"},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventProviderCallCompleted, Timestamp: now.Add(200 * time.Millisecond),
+		SessionID: "sess-1", RunID: "run-1",
+		Data: &events.ProviderCallCompletedData{
+			Provider: "openai", Model: "gpt-4",
+			Duration: 150 * time.Millisecond, FinishReason: "stop",
+		},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventToolCallStarted, Timestamp: now.Add(300 * time.Millisecond),
+		SessionID: "sess-1", RunID: "run-1",
+		Data: &events.ToolCallStartedData{ToolName: "search", CallID: "call-h1"},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventToolCallCompleted, Timestamp: now.Add(400 * time.Millisecond),
+		SessionID: "sess-1", RunID: "run-1",
+		Data: &events.ToolCallCompletedData{
+			ToolName: "search", CallID: "call-h1",
+			Duration: 100 * time.Millisecond, Status: "success",
+		},
+	})
+
 	listener.OnEvent(&events.Event{
 		Type: events.EventPipelineCompleted, Timestamp: now.Add(time.Second),
 		SessionID: "sess-1", RunID: "run-1",
@@ -108,10 +147,28 @@ func TestOTelEventListener_PipelineSpan(t *testing.T) {
 		t.Errorf("expected Ok status, got %v", pipelineSpan.Status.Code)
 	}
 
-	// Verify parent relationship.
+	// Pipeline should be child of session.
 	sessionSpan := findSpan(t, spans, "promptkit.session")
 	if pipelineSpan.Parent.SpanID() != sessionSpan.SpanContext.SpanID() {
 		t.Error("pipeline span should be child of session span")
+	}
+
+	// Provider, tool, and middleware should be children of pipeline (not session).
+	pipelineSpanID := pipelineSpan.SpanContext.SpanID()
+
+	providerSpan := findSpan(t, spans, "promptkit.provider.openai")
+	if providerSpan.Parent.SpanID() != pipelineSpanID {
+		t.Error("provider span should be child of pipeline span")
+	}
+
+	toolSpan := findSpan(t, spans, "promptkit.tool.search")
+	if toolSpan.Parent.SpanID() != pipelineSpanID {
+		t.Error("tool span should be child of pipeline span")
+	}
+
+	mwSpan := findSpan(t, spans, "promptkit.middleware.guard")
+	if mwSpan.Parent.SpanID() != pipelineSpanID {
+		t.Error("middleware span should be child of pipeline span")
 	}
 }
 
@@ -684,6 +741,39 @@ func TestOTelEventListener_OutOfOrderDelivery(t *testing.T) {
 	}
 	if v, ok := attrMap["pipeline.total_cost"]; !ok || v.AsFloat64() != 0.01 {
 		t.Errorf("expected pipeline.total_cost=0.01, got %v", attrMap["pipeline.total_cost"])
+	}
+}
+
+func TestOTelEventListener_SpanHierarchy_NoPipeline_FallsBackToSession(t *testing.T) {
+	listener, exp, tp := newTestListener(t)
+	now := time.Now()
+
+	listener.StartSession(context.Background(), "sess-1")
+
+	// Start a provider span without a pipeline span inflight.
+	listener.OnEvent(&events.Event{
+		Type: events.EventProviderCallStarted, Timestamp: now,
+		SessionID: "sess-1", RunID: "run-1",
+		Data: &events.ProviderCallStartedData{Provider: "openai", Model: "gpt-4"},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventProviderCallCompleted, Timestamp: now.Add(100 * time.Millisecond),
+		SessionID: "sess-1", RunID: "run-1",
+		Data: &events.ProviderCallCompletedData{
+			Provider: "openai", Model: "gpt-4",
+			Duration: 100 * time.Millisecond, FinishReason: "stop",
+		},
+	})
+
+	listener.EndSession("sess-1")
+	spans := flushAndGetSpans(t, tp, exp)
+
+	sessionSpan := findSpan(t, spans, "promptkit.session")
+	providerSpan := findSpan(t, spans, "promptkit.provider.openai")
+
+	// Without a pipeline, provider should fall back to being a child of the session.
+	if providerSpan.Parent.SpanID() != sessionSpan.SpanContext.SpanID() {
+		t.Error("provider span should be child of session span when no pipeline is active")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Provider, tool, and middleware OTel spans were all parented under the session root span, making traces flat in viewers like Grafana Tempo
- Added `parentCtxForRun()` helper that looks up the inflight pipeline span context for a given runID, falling back to the session root
- Changed `startSpan()` to accept an explicit parent context instead of always using the session context
- Updated all callers: pipeline → session parent, provider/tool/middleware → pipeline parent

Closes #614

## Test plan
- [x] Updated `TestOTelEventListener_PipelineSpan` to verify provider, tool, and middleware spans are children of the pipeline span
- [x] Added `TestOTelEventListener_SpanHierarchy_NoPipeline_FallsBackToSession` for graceful fallback when no pipeline is active
- [x] All 25 telemetry tests pass with `-race`
- [x] `golangci-lint` clean
- [x] Pre-commit hook passes (87.7% coverage on changed file)