### PR TITLE
feat(events): add Result field to ToolCallCompleted event

### DIFF
--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -169,12 +169,13 @@ func (e *Emitter) ToolCallStarted(toolName, callID string, args map[string]inter
 }
 
 // ToolCallCompleted emits the tool.call.completed event.
-func (e *Emitter) ToolCallCompleted(toolName, callID string, duration time.Duration, status string) {
+func (e *Emitter) ToolCallCompleted(toolName, callID string, duration time.Duration, status, result string) {
 	e.emit(EventToolCallCompleted, ToolCallCompletedData{
 		ToolName: toolName,
 		CallID:   callID,
 		Duration: duration,
 		Status:   status,
+		Result:   result,
 	})
 }
 

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -83,7 +83,7 @@ func TestEmitterPublishesVariousEvents(t *testing.T) {
 		},
 		func() { emitter.ProviderCallFailed("provider", "model", errors.New("fail"), time.Millisecond) },
 		func() { emitter.ToolCallStarted("tool", "call", map[string]interface{}{"k": "v"}) },
-		func() { emitter.ToolCallCompleted("tool", "call", time.Millisecond, "success") },
+		func() { emitter.ToolCallCompleted("tool", "call", time.Millisecond, "success", "tool result") },
 		func() { emitter.ToolCallFailed("tool", "call", errors.New("fail"), time.Millisecond) },
 		func() { emitter.ValidationStarted("validator", "input") },
 		func() { emitter.ValidationPassed("validator", "input", time.Millisecond) },

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -237,6 +237,7 @@ type ToolCallEventData struct {
 	Args     map[string]interface{} // Set on started
 	Duration time.Duration          // Set on completed/failed
 	Status   string                 // Set on completed (e.g. "success", "error", "pending")
+	Result   string                 // Set on completed — tool result content
 	Error    error                  // Set on failed
 }
 

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -855,14 +855,14 @@ func (s *ProviderStage) executeToolCalls(
 			continue
 		}
 
+		// Convert tool execution result to message
+		result := s.handleToolResult(toolCall, asyncResult)
+
 		// Emit tool call completed event
 		if s.emitter != nil {
 			status := string(asyncResult.Status)
-			s.emitter.ToolCallCompleted(toolCall.Name, toolCall.ID, time.Since(startTime), status)
+			s.emitter.ToolCallCompleted(toolCall.Name, toolCall.ID, time.Since(startTime), status, result.Content)
 		}
-
-		// Convert tool execution result to message
-		result := s.handleToolResult(toolCall, asyncResult)
 		resultMsg := types.NewToolResultMessage(result)
 		if hookDecision.Metadata != nil {
 			resultMsg.Meta = hookDecision.Metadata


### PR DESCRIPTION
## Summary
- Adds `Result string` field to `ToolCallEventData` carrying the processed tool result content
- SDK hosts that rely on events (without the Recording stage) can now capture tool results directly from the `tool.call.completed` event
- Reorders `stages_provider.go` so `handleToolResult` runs before event emission, making the result available

## Test plan
- [x] All existing tests in `runtime/events/`, `runtime/pipeline/stage/`, `runtime/telemetry/`, `runtime/metrics/`, and `runtime/recording/` pass
- [x] Pre-commit hook passes (lint, build, tests, coverage)
- [ ] CI passes