### PR TITLE
perf: remaining scalability fixes (low-priority, K8s, audio)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,19 @@ promptarena run --ci --format html
 - The `--mock-provider` flag replaces all providers with a generic mock that does NOT load scenario-specific response files
 - Mock responses support `tool_calls` for simulating LLM-initiated tool use (e.g., `workflow__transition`)
 
+## Concurrent Agents and Worktrees
+
+When running in a worktree or when concurrent agents may operate on the repo, **always use `git -C <path>` instead of `cd <path> && git ...`**. Compound `cd && git` commands require extra approval to prevent bare repository attacks, whereas `git -C` is safe and non-interactive.
+
+```bash
+# Good — works in worktrees and concurrent agents
+git -C /Users/chaholl/repos/altairalabs/promptkit push
+git -C /Users/chaholl/repos/altairalabs/promptkit log --oneline -5
+
+# Bad — requires approval, breaks in some worktree contexts
+cd /Users/chaholl/repos/altairalabs/promptkit && git push
+```
+
 ## Go Code Standards
 
 - **golangci-lint** config in `.golangci.yml` — line length 120, linters include errcheck, gocritic, gosec, govet, revive, staticcheck, unused

--- a/docs/local-backlog/05-mar-scalability-review.md
+++ b/docs/local-backlog/05-mar-scalability-review.md
@@ -22,8 +22,9 @@ Comprehensive review of limits, bottlenecks, and scalability concerns across the
 - ~~Every `Load()` and `Save()` deep-copies the entire state including all messages, content parts, and media.~~
 - **Fixed in `feat/scalability-medium-priority-fixes`**: Optimized `deepCopyMessages` with slab allocation (`batchCopyStringPtrs`/`batchCopyIntPtrs`) to reduce per-pointer heap allocations. Added fast paths for text-only content parts and simple messages (single text part, no metadata) that avoid reflection-heavy generic copy. Reduces GC pressure significantly for typical conversation workloads.
 
-### 1.5 Redis state store serializes monolithically (MEDIUM)
-- **runtime/statestore/redis.go:96-131** — `Save` serializes the entire `ConversationState` as a single JSON blob. For conversations with thousands of messages or embedded media, this creates very large Redis values. An incremental `AppendMessages` path exists but isn't the default.
+### 1.5 ~~Redis state store serializes monolithically~~ RESOLVED
+- ~~**runtime/statestore/redis.go:96-131** — `Save` serializes the entire `ConversationState` as a single JSON blob.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Decomposed storage into 3 separate Redis keys: meta (small JSON), messages list (per-message entries), and summaries list. `Save()` only serializes metadata fully; messages/summaries use Redis lists. `Load()` falls back to legacy monolithic format for backward compatibility.
 
 ---
 
@@ -66,8 +67,9 @@ Comprehensive review of limits, bottlenecks, and scalability concerns across the
 - ~~**runtime/providers/openai/openai.go:799** and **claude/claude_streaming.go:115** — Create unbuffered `chan StreamChunk`. A slow consumer causes the streaming goroutine to block on every send, which can idle the HTTP connection long enough for proxy timeouts.~~
 - **Fixed in `feat/scalability-remaining-fixes`**: All 17 stream channel allocations across all providers now use `DefaultStreamBufferSize = 32` elements. Reduces backpressure-induced stalls.
 
-### 3.5 No idle timeout between stream chunks (MEDIUM)
-- If a provider stops sending data mid-stream, the only protection is the HTTP client timeout (60s). No heartbeat or inactivity detection between chunks.
+### 3.5 ~~No idle timeout between stream chunks~~ RESOLVED
+- ~~If a provider stops sending data mid-stream, the only protection is the HTTP client timeout (60s). No heartbeat or inactivity detection between chunks.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `IdleTimeoutReader` that wraps response bodies with `DefaultStreamIdleTimeout = 30s`. Timer resets on each successful read. If no data arrives within the timeout, the body is closed and `ErrStreamIdleTimeout` is returned. Applied to all 6 providers.
 
 ### 3.6 ~~Context cancellation doesn't unblock scanner~~ RESOLVED
 - ~~**runtime/providers/openai/openai.go:445-545** — The streaming goroutine checks `ctx.Done()` via select/default, but if blocked on `scanner.Scan()` (I/O), it stays blocked until the HTTP connection times out. The response body needs to be closed to unblock the scanner.~~
@@ -85,11 +87,13 @@ Comprehensive review of limits, bottlenecks, and scalability concerns across the
 - ~~`dispatch()` calls listeners synchronously. A slow listener blocks the worker.~~
 - **Fixed in `feat/scalability-medium-priority-fixes`**: Added `invokeWithTimeout()` that wraps subscriber calls with a configurable timeout (default 5s via `WithSubscriberTimeout()`). Slow subscribers are interrupted and logged rather than blocking workers indefinitely.
 
-### 4.3 Synchronous event store in publish path (MEDIUM)
-- **runtime/events/bus.go:197-199** — When an event store is configured, `store.Append()` is called synchronously *before* queuing. If backed by a database, this adds latency to every `Publish()` on the critical path.
+### 4.3 ~~Synchronous event store in publish path~~ RESOLVED
+- ~~**runtime/events/bus.go:197-199** — When an event store is configured, `store.Append()` is called synchronously *before* queuing.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Moved `store.Append()` from `Publish()` to `dispatch()` worker goroutine. Store writes are now asynchronous relative to the publisher.
 
-### 4.4 Event bus always created (LOW)
-- **sdk/sdk.go:427-442** — `initEventBus()` creates an `EventBus` and spawns 10 worker goroutines even when no one subscribes.
+### 4.4 ~~Event bus always created~~ RESOLVED
+- ~~**sdk/sdk.go:427-442** — `initEventBus()` creates an `EventBus` and spawns 10 worker goroutines even when no one subscribes.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Workers are now started lazily via `ensureStarted()` (atomic CAS) on first `Subscribe()`, `SubscribeAll()`, or `WithStore()` call.
 
 ---
 
@@ -135,15 +139,17 @@ Comprehensive review of limits, bottlenecks, and scalability concerns across the
 - ~~`getMediaData` uses `io.ReadAll` with no size limit.~~
 - **Fixed in `feat/scalability-high-priority-fixes`**: Read paths now use `io.LimitReader` capped at `MaxFileSize`. File reads check `os.Stat` before reading.
 
-### 6.5 Dedup index fully in memory (MEDIUM)
-- **runtime/storage/local/filestore.go:56-62, 450-479** — `dedupIndex` is a `map[string]string` re-serialized to JSON on every store. O(N) writes for N stored files.
+### 6.5 ~~Dedup index fully in memory~~ RESOLVED
+- ~~**runtime/storage/local/filestore.go:56-62, 450-479** — `dedupIndex` is a `map[string]string` re-serialized to JSON on every store. O(N) writes for N stored files.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `dedupDirty` flag — index is only written when actually modified. Dedup hits skip writes entirely. Added `Flush()` method for explicit persistence.
 
 ### 6.6 ~~No policy enforcement started by default~~ RESOLVED
 - ~~`StartEnforcement` is never called automatically. Media files with retention policies are never cleaned up.~~
 - **Fixed in `feat/scalability-medium-priority-fixes`**: Added `WithAutoStart(bool)` and `WithBaseDir(string)` functional options. When `autoStart=true`, enforcement starts automatically on construction. `StartEnforcement` and `Stop` are now idempotent.
 
-### 6.7 Policy enforcement walks entire directory tree (MEDIUM)
-- **runtime/storage/policy/time_based.go:77-115** — Uses `filepath.Walk` to scan the entire media directory on every enforcement tick. No index of expiring files.
+### 6.7 ~~Policy enforcement walks entire directory tree~~ RESOLVED
+- ~~**runtime/storage/policy/time_based.go:77-115** — Uses `filepath.Walk` to scan the entire media directory on every enforcement tick. No index of expiring files.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `expiryIndex` map with `BuildExpiryIndex()` (scans once on startup). Subsequent ticks only check files whose expiry has passed — O(expired) instead of O(total). `TrackFile()`/`UntrackFile()` maintain index incrementally.
 
 ---
 
@@ -197,15 +203,17 @@ Comprehensive review of limits, bottlenecks, and scalability concerns across the
 
 ## 10. MCP Client
 
-### 10.1 No reconnection on process death (MEDIUM)
-- **runtime/mcp/client.go:309-327** — `checkHealth` detects `ErrProcessDied` but has no reconnection logic. The registry's `GetClient` does check `IsAlive()` and creates new clients, but the dead client's pending requests leak until context timeout.
+### 10.1 ~~No reconnection on process death~~ RESOLVED
+- ~~**runtime/mcp/client.go:309-327** — `checkHealth` detects `ErrProcessDied` but has no reconnection logic. Dead client's pending requests leak until context timeout.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: `checkHealth()` now attempts auto-reconnection via `reconnect()` with configurable `MaxReconnectAttempts` (default 3). `failPendingRequests()` sends error responses to all pending RPC channels before reconnecting. `cleanupDeadProcess()` properly releases pipes and waits for goroutines.
 
 ### 10.2 ~~Sleep while holding mutex during init retry~~ RESOLVED
 - ~~`time.Sleep(delay)` during init retry blocks `c.mu`, preventing all other operations during retry delays.~~
 - **Fixed in `feat/scalability-medium-priority-fixes`**: Extracted `startProcessWithRetry()` that releases the mutex before sleeping. Sleep is now cancellable via `select` on `time.After`/`ctx.Done()` instead of blocking `time.Sleep`.
 
-### 10.3 No limit on concurrent MCP processes (MEDIUM)
-- **runtime/mcp/registry.go** — Each MCP server is a child process. No limit on concurrent processes — can exhaust OS process/FD limits.
+### 10.3 ~~No limit on concurrent MCP processes~~ RESOLVED
+- ~~**runtime/mcp/registry.go** — Each MCP server is a child process. No limit on concurrent processes — can exhaust OS process/FD limits.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `RegistryOptions` with `MaxProcesses` field. Non-blocking counting semaphore via buffered channel. Returns `ErrMaxProcessesReached` when limit is hit. `ActiveProcessCount()` exposes current usage.
 
 ---
 
@@ -277,24 +285,19 @@ Comprehensive review of limits, bottlenecks, and scalability concerns across the
 
 ## Recommended Next Steps
 
-All critical, high, medium, and most low-priority items have been addressed. Remaining work:
+Nearly all code-level scalability issues have been addressed across 4 PRs (#630, #631, #632, #634). Remaining work is primarily architectural/infrastructure:
 
-### Remaining Items (not yet addressed)
+### Remaining Code Items
 1. **Integrate tiktoken-go** — replace heuristic token counter for accurate context window management (currently improved but still heuristic).
-2. **No idle timeout between stream chunks** (3.5) — if a provider stops sending data mid-stream, the only protection is the HTTP client timeout.
-3. **Synchronous event store in publish path** (4.3) — `store.Append()` is called synchronously before queuing.
-4. **Event bus always created** (4.4) — `initEventBus()` creates an EventBus even when no one subscribes.
-5. **Dedup index fully in memory** (6.5) — re-serialized to JSON on every store.
-6. **Policy enforcement walks entire directory tree** (6.7) — `filepath.Walk` on every tick.
-7. **Redis state store serializes monolithically** (1.5) — entire state as single JSON blob.
-8. **MCP no reconnection on process death** (10.1) — dead client's pending requests leak.
-9. **No limit on concurrent MCP processes** (10.3) — can exhaust OS process/FD limits.
+2. **StreamChunk carries accumulated content** (3.3) — O(N²) memory for all chunks in the channel.
+3. **Hardcoded HTTP client timeout** (2.4) — 60s covers entire request lifecycle including streaming.
+4. **Full response body read into memory** (2.5) — non-streaming responses use `io.ReadAll` with no size limit.
 
 ### K8s / Production Deployment (infrastructure gaps)
-10. **Share MCP registry across conversations** — prevent O(N) child processes.
-11. **Cloud storage backend** — replace `FileStore` with S3/GCS for persistent media storage.
-12. **Share provider instances** — avoid per-conversation HTTP connection pools.
-13. **External pub/sub for cross-pod events** — EventBus is in-process only.
+5. **Share MCP registry across conversations** — prevent O(N) child processes.
+6. **Cloud storage backend** — replace `FileStore` with S3/GCS for persistent media storage.
+7. **Share provider instances** — avoid per-conversation HTTP connection pools.
+8. **External pub/sub for cross-pod events** — EventBus is in-process only.
 
 ---
 

--- a/docs/local-backlog/05-mar-scalability-review.md
+++ b/docs/local-backlog/05-mar-scalability-review.md
@@ -1,0 +1,450 @@
+# PromptKit Scalability Review — 5 March 2026
+
+Comprehensive review of limits, bottlenecks, and scalability concerns across the PromptKit codebase.
+
+---
+
+## 1. Message History & Context Window Management
+
+### 1.1 ~~Unbounded message accumulation~~ RESOLVED
+- ~~By default, the entire conversation history is sent to the provider with no limit or warning.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: `ContextAssemblyStage` now has `DefaultMaxMessages = 200` hard cap. When no explicit context window is set and messages exceed this, automatically truncates to most recent 200 messages (preserving system messages). Logs a warning at `DefaultWarningThreshold = 100` messages when no token budget or context window is configured. Both thresholds are configurable via `ContextAssemblyConfig`.
+
+### 1.2 ~~Heuristic-only token counting~~ PARTIALLY RESOLVED
+- ~~Only token counter is heuristic-based (word count × ratio of 1.3–1.4). No concept of multimodal token costs.~~
+- **Improved in `feat/scalability-critical-fixes`**: Added content-aware ratio detection (code-heavy → 1.55x, CJK-heavy → 1.15x). Added `CountMessageTokens()` for multimodal messages handling image tokens by detail level (low=85, high=170K, auto=1024), audio/video captions, tool calls, and per-message overhead. Still heuristic-based — tiktoken-go integration remains a future improvement.
+
+### 1.3 ~~No pre-flight token budget enforcement~~ RESOLVED
+- ~~No pipeline stage validates total token count before sending to the provider.~~
+- **Fixed in `feat/scalability-critical-fixes`**: New `TokenBudgetStage` pipeline stage enforces token limits before provider calls. Configurable `MaxTokens` budget with `ReserveTokens` for response. Truncation preserves system messages and fills from most recent messages backward. Warns when conversations exceed configurable threshold (default 100 messages) without a budget set.
+
+### 1.4 ~~Deep-copy cost on state operations~~ RESOLVED
+- ~~Every `Load()` and `Save()` deep-copies the entire state including all messages, content parts, and media.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Optimized `deepCopyMessages` with slab allocation (`batchCopyStringPtrs`/`batchCopyIntPtrs`) to reduce per-pointer heap allocations. Added fast paths for text-only content parts and simple messages (single text part, no metadata) that avoid reflection-heavy generic copy. Reduces GC pressure significantly for typical conversation workloads.
+
+### 1.5 Redis state store serializes monolithically (MEDIUM)
+- **runtime/statestore/redis.go:96-131** — `Save` serializes the entire `ConversationState` as a single JSON blob. For conversations with thousands of messages or embedded media, this creates very large Redis values. An incremental `AppendMessages` path exists but isn't the default.
+
+---
+
+## 2. Provider API Limits
+
+### 2.1 ~~No retry logic~~ RESOLVED
+- ~~`RetryPolicy` type is defined (`runtime/pipeline/types.go:35-39`) but **never implemented**.~~
+- **Fixed in `feat/scalability-critical-fixes`**: `runtime/providers/retry.go` implements `DoWithRetry()` with exponential backoff, jitter, and Retry-After header support. Handles 429/502/503/504 and network errors. Default: 3 retries, 500ms initial delay. Wired into `BaseProvider.MakeRawRequest()`.
+
+### 2.2 ~~No rate limiting~~ RESOLVED
+- ~~No rate limiter exists anywhere.~~
+- **Fixed in `feat/scalability-critical-fixes`**: `BaseProvider` now has a `rateLimiter *rate.Limiter` field using `golang.org/x/time/rate`. Configurable via `SetRateLimit(rps float64, burst int)`. `WaitForRateLimit()` is called before every HTTP request in `MakeRawRequest()`.
+
+### 2.3 ~~No request payload size validation~~ RESOLVED
+- ~~No provider validates total request payload size before sending.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: `BaseProvider` now has `maxRequestPayloadSize` (default 100MB). `MakeRawRequest` checks `len(body)` and returns `ErrPayloadTooLarge` when exceeded. Logs warning for payloads > 10MB. Configurable via `SetMaxPayloadSize()`.
+
+### 2.4 Hardcoded HTTP client timeout (MEDIUM)
+- **runtime/providers/openai/openai.go:25** and **claude/claude.go:28** — Both use `60 * time.Second` as HTTP client timeout, which covers the entire request lifecycle including streaming. Long streaming responses may be aborted.
+
+### 2.5 Full response body read into memory (MEDIUM)
+- Non-streaming responses use `io.ReadAll(resp.Body)` with no size limit. A malformed or unexpectedly large response could consume significant memory.
+
+---
+
+## 3. Streaming & Throughput
+
+### 3.1 ~~Gemini streaming reads entire body into memory~~ RESOLVED
+- ~~`streamResponse` calls `io.ReadAll(body)` then unmarshals the entire JSON array.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: Replaced with incremental `json.NewDecoder` parsing. Uses `dec.Token()` to read `[`, `dec.More()` + `dec.Decode()` loop to parse each response object as it arrives, emitting chunks immediately.
+
+### 3.2 ~~O(N²) string concatenation in streaming~~ RESOLVED
+- ~~All providers and SDK streaming code used `accumulated += delta` string concatenation in hot loops, which is O(N²) due to Go's immutable strings.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Replaced with `strings.Builder` across all 5 providers (OpenAI, Claude, Gemini, Ollama, vLLM), SDK `streaming.go`, `stream/stream.go`, and `session/unary_session.go`. Now O(N) amortized.
+
+### 3.3 StreamChunk carries accumulated content (MEDIUM)
+- **runtime/providers/streaming.go:14-19** — Every `StreamChunk` carries the full accumulated `Content` string, not just the delta. Total memory for all chunks in the channel is O(N²) in response length.
+
+### 3.4 ~~Unbuffered stream channels~~ RESOLVED
+- ~~**runtime/providers/openai/openai.go:799** and **claude/claude_streaming.go:115** — Create unbuffered `chan StreamChunk`. A slow consumer causes the streaming goroutine to block on every send, which can idle the HTTP connection long enough for proxy timeouts.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: All 17 stream channel allocations across all providers now use `DefaultStreamBufferSize = 32` elements. Reduces backpressure-induced stalls.
+
+### 3.5 No idle timeout between stream chunks (MEDIUM)
+- If a provider stops sending data mid-stream, the only protection is the HTTP client timeout (60s). No heartbeat or inactivity detection between chunks.
+
+### 3.6 ~~Context cancellation doesn't unblock scanner~~ RESOLVED
+- ~~**runtime/providers/openai/openai.go:445-545** — The streaming goroutine checks `ctx.Done()` via select/default, but if blocked on `scanner.Scan()` (I/O), it stays blocked until the HTTP connection times out. The response body needs to be closed to unblock the scanner.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: All 6 provider `streamResponse` functions now launch a context-cancel watcher goroutine that closes the response body when the context is done, unblocking the scanner immediately.
+
+---
+
+## 4. Event Bus
+
+### 4.1 ~~Silent event drops under load~~ RESOLVED
+- ~~`Publish()` silently drops events when the buffer is full with no indication.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Added `droppedCount atomic.Int64` counter with `DroppedCount()` accessor. Rate-limited drop logging (every 100th drop) to avoid log flooding. Enables monitoring dropped events via metrics.
+
+### 4.2 ~~Slow subscriber blocks worker~~ RESOLVED
+- ~~`dispatch()` calls listeners synchronously. A slow listener blocks the worker.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Added `invokeWithTimeout()` that wraps subscriber calls with a configurable timeout (default 5s via `WithSubscriberTimeout()`). Slow subscribers are interrupted and logged rather than blocking workers indefinitely.
+
+### 4.3 Synchronous event store in publish path (MEDIUM)
+- **runtime/events/bus.go:197-199** — When an event store is configured, `store.Append()` is called synchronously *before* queuing. If backed by a database, this adds latency to every `Publish()` on the critical path.
+
+### 4.4 Event bus always created (LOW)
+- **sdk/sdk.go:427-442** — `initEventBus()` creates an `EventBus` and spawns 10 worker goroutines even when no one subscribes.
+
+---
+
+## 5. Tool Execution
+
+### 5.1 ~~Sequential tool call execution~~ RESOLVED
+- ~~`executeToolCalls()` runs tool calls sequentially in a `for` loop.~~
+- **Fixed in `feat/scalability-critical-fixes`**: `executeToolCalls()` now uses `errgroup.Group` with `SetLimit()` for bounded parallel execution. Default max concurrency: 10. Configurable via `ToolPolicy.MaxParallelToolCalls`. Pre-allocated result slots preserve ordering.
+
+### 5.2 ~~Tool timeout declared but not enforced~~ RESOLVED
+- ~~Tool descriptors have `TimeoutMs` but `Execute()` and `ExecuteAsync()` never create a `context.WithTimeout`.~~
+- **Fixed in `feat/scalability-critical-fixes`**: `Execute()` and `ExecuteAsync()` now wrap execution with `context.WithTimeout` using the tool's `TimeoutMs`. Default timeout raised to 30s (`DefaultToolTimeout`). Returns `ErrToolTimeout` sentinel error on timeout. `NewRegistry()` accepts `WithDefaultTimeout()` option.
+
+### 5.3 ~~No limit on tool result size~~ RESOLVED
+- ~~**runtime/pipeline/stage/stages_provider.go:898-952** — Tool results are JSON-marshaled and included in message history without any size limit. A tool returning a large result (e.g., thousands of database rows) would be sent verbatim to the LLM.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `DefaultMaxToolResultSize = 1MB` to registry. `enforceResultSizeLimit()` truncates oversized results with a `[truncated]` suffix. Configurable via `WithMaxToolResultSize()`.
+
+### 5.4 ~~Tool registry maps have no mutex~~ RESOLVED
+- ~~**runtime/tools/registry.go:27-32** — `tools` and `executors` maps have no lock. Concurrent registration during initialization could cause a data race.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `sync.RWMutex` to `Registry`. All map reads use `RLock`, all writes use `Lock`. Concurrent registration is now safe.
+
+### 5.5 ~~PendingStore grows unbounded~~ RESOLVED
+- ~~**sdk/tools/pending.go:74-131** — Simple map with no TTL or max size. If async tools are registered but never resolved, the map grows without bound.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `DefaultPendingTTL = 5min` and `DefaultMaxPending = 1000`. Background cleanup goroutine runs periodically. `Close()` method for lifecycle management, called from `Conversation.Close()`.
+
+---
+
+## 6. Memory & Media
+
+### 6.1 Base64 encoding triples media memory (HIGH — partially mitigated)
+- Media is still base64-encoded in memory (inherent to LLM API requirements), but large files now trigger warnings.
+- **Improved in `feat/scalability-high-priority-fixes`**: `MediaLoader` now logs warnings for files > 5MB about base64 memory overhead. Aggregate and per-item limits prevent runaway loading.
+
+### 6.2 ~~No aggregate media size limit~~ RESOLVED
+- ~~No aggregate limit. A message with 10 images could require 500MB+.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: Added `MaxAggregateMediaSize = 100MB` and `MaxMediaItems = 20` limits to `MediaLoader`. Both enforced per-loader instance. Uses `io.LimitReader` for per-file reads.
+
+### 6.3 ~~Storage: no file size limit~~ RESOLVED
+- ~~No `MaxFileSize` configuration and no size check before writing.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: `FileStore` now has `MaxFileSize` field (default 50MB via `DefaultMaxFileSize`). Configurable via `WithMaxFileSize()` option. Returns `ErrFileTooLarge` sentinel error. Size checked before writes and reads.
+
+### 6.4 ~~Storage: entire file read into memory~~ RESOLVED
+- ~~`getMediaData` uses `io.ReadAll` with no size limit.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: Read paths now use `io.LimitReader` capped at `MaxFileSize`. File reads check `os.Stat` before reading.
+
+### 6.5 Dedup index fully in memory (MEDIUM)
+- **runtime/storage/local/filestore.go:56-62, 450-479** — `dedupIndex` is a `map[string]string` re-serialized to JSON on every store. O(N) writes for N stored files.
+
+### 6.6 ~~No policy enforcement started by default~~ RESOLVED
+- ~~`StartEnforcement` is never called automatically. Media files with retention policies are never cleaned up.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Added `WithAutoStart(bool)` and `WithBaseDir(string)` functional options. When `autoStart=true`, enforcement starts automatically on construction. `StartEnforcement` and `Stop` are now idempotent.
+
+### 6.7 Policy enforcement walks entire directory tree (MEDIUM)
+- **runtime/storage/policy/time_based.go:77-115** — Uses `filepath.Walk` to scan the entire media directory on every enforcement tick. No index of expiring files.
+
+---
+
+## 7. State Store
+
+### 7.1 ~~MemoryStore has no default TTL or max entries~~ RESOLVED
+- ~~`NewMemoryStore()` defaults to no TTL and no max entries. Memory grows unbounded.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Added `DefaultTTL = 1 hour` and `DefaultMaxEntries = 10,000`. Opt-out via `WithNoTTL()` and `WithNoMaxEntries()` options. Internal `ttlSet`/`maxEntriesSet` bools track whether defaults were explicitly overridden.
+
+### 7.2 ~~LRU eviction is O(N) scan~~ RESOLVED
+- ~~**runtime/statestore/memory.go:467-485** — `evictLRULocked()` iterates all entries to find the oldest. For thousands of entries, this linear scan is a bottleneck.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Replaced linear scan with `container/heap`-based `accessHeap`. `touchLRULocked()` maintains heap invariant on every access. Eviction is now O(log N). Benchmarked at 40x speedup at 10K entries.
+
+### 7.3 ~~Background eviction blocks all operations~~ RESOLVED
+- ~~**runtime/statestore/memory.go:487-512** — `evictExpiredLocked()` iterates all entries under a write lock, blocking concurrent read/write.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Two-phase expiration: `collectExpiredKeys()` scans under `RLock`, then `deleteExpiredKeys()` deletes under `Lock`. Read operations are no longer blocked during expiration scans.
+
+---
+
+## 8. Eval Middleware
+
+### 8.1 ~~Goroutine leak risk in turn evals~~ RESOLVED
+- ~~`dispatchTurnEvals()` launches a `go func()` with no tracking, no WaitGroup, no cancellation.~~
+- **Fixed in `feat/scalability-critical-fixes`**: `evalMiddleware` now has `sync.WaitGroup` for goroutine tracking and `context.WithCancel` for lifecycle management. New `wait()` blocks until all in-flight goroutines complete. New `close()` cancels context and waits. `Conversation.Close()` sequences: `wait()` → `dispatchSessionEvals()` → `close()`.
+
+### 8.2 ~~No concurrency limit on eval goroutines~~ RESOLVED
+- ~~Each `Send()` spawns a new goroutine without a semaphore or pool.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Added buffered channel semaphore (`sem chan struct{}`) with `DefaultMaxConcurrentEvals = 10`. Non-blocking acquire: if semaphore is full, the eval dispatch is skipped with a warning log. Configurable via `WithMaxConcurrentEvals(n int)` SDK option.
+
+---
+
+## 9. A2A Protocol
+
+### 9.1 ~~SSE scanner default 64KB buffer~~ RESOLVED
+- ~~`ReadSSE` uses `bufio.NewScanner` with default 64KB max token size.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: SSE scanner now uses `sseMaxTokenSize = 1MB` buffer via `scanner.Buffer()`.
+
+### 9.2 ~~HTTP client timeout kills SSE streams~~ RESOLVED
+- ~~`defaultClientTimeout` of 60s applies to SSE streaming.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: Added separate `sseClient` with `sseClientTimeout = 30 minutes`. `SendMessageStream` uses the SSE client; regular JSON-RPC requests keep the 60s timeout.
+
+### 9.3 ~~Client cache grows unbounded~~ RESOLVED
+- ~~**runtime/a2a/executor.go:97-117** — `getOrCreateClient` caches clients in an unbounded map with no TTL, no eviction, no `Close()` on Executor.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `clientEntry` with `lastUsed` tracking. `DefaultClientTTL = 30min`, `DefaultMaxClients = 100`. Background `cleanupLoop` runs periodic eviction (`evictStale` + `evictLRU`). `Close()` method shuts down cleanup and clears cache. Configurable via `WithClientTTL()`/`WithMaxClients()`.
+
+### 9.4 ~~No retry logic for A2A calls~~ RESOLVED
+- ~~Zero retry logic. Transient network errors cause immediate failure.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Added `RetryPolicy` struct with `sendWithRetry()` implementing exponential backoff with jitter. Retries on 429, 502, 503, 504, and network errors via `isA2ARetryableError()`. Added `HTTPStatusError` type for structured status code errors. Configurable via `WithRetryPolicy()`/`WithNoRetry()` options. Default: 3 retries, 500ms initial delay.
+
+---
+
+## 10. MCP Client
+
+### 10.1 No reconnection on process death (MEDIUM)
+- **runtime/mcp/client.go:309-327** — `checkHealth` detects `ErrProcessDied` but has no reconnection logic. The registry's `GetClient` does check `IsAlive()` and creates new clients, but the dead client's pending requests leak until context timeout.
+
+### 10.2 ~~Sleep while holding mutex during init retry~~ RESOLVED
+- ~~`time.Sleep(delay)` during init retry blocks `c.mu`, preventing all other operations during retry delays.~~
+- **Fixed in `feat/scalability-medium-priority-fixes`**: Extracted `startProcessWithRetry()` that releases the mutex before sleeping. Sleep is now cancellable via `select` on `time.After`/`ctx.Done()` instead of blocking `time.Sleep`.
+
+### 10.3 No limit on concurrent MCP processes (MEDIUM)
+- **runtime/mcp/registry.go** — Each MCP server is a child process. No limit on concurrent processes — can exhaust OS process/FD limits.
+
+---
+
+## 11. Workflow Engine
+
+### 11.1 ~~No mutex on StateMachine~~ RESOLVED
+- ~~`ProcessEvent` reads/writes `sm.context` without synchronization.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: Added `sync.RWMutex` to `StateMachine`. `RLock` for read-only methods, `Lock` for mutating methods. Concurrent access tests pass with `-race`.
+
+### 11.2 ~~Unbounded history growth~~ RESOLVED
+- ~~Every state transition appends to `History` with no cap.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: Added `MaxHistoryLength = 1000` constant. `RecordTransition()` trims oldest entries when cap is exceeded.
+
+### 11.3 ~~Metadata deep copy is shallow~~ RESOLVED
+- ~~`Clone()` uses `maps.Copy` which is shallow.~~
+- **Fixed in `feat/scalability-high-priority-fixes`**: Implemented recursive `deepCopyMap()`/`deepCopyValue()` for proper deep copy of nested maps and slices.
+
+---
+
+## 12. Arena Engine
+
+### 12.1 ~~All goroutines spawned eagerly~~ RESOLVED
+- ~~**tools/arena/engine/engine.go:417-433** — All run combinations launch goroutines immediately, blocking on a semaphore. For 1000+ combinations, this creates 1000 goroutines waiting on the semaphore with no context check before acquisition.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Semaphore acquire now uses `select` on both `sem` channel and `ctx.Done()`, so goroutines exit immediately on context cancellation instead of waiting indefinitely.
+
+### 12.2 ~~No per-run timeout~~ RESOLVED
+- ~~**tools/arena/engine/execution.go:386** — `ExecuteConversation` is called without a per-run deadline. A hanging provider blocks a semaphore slot indefinitely.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `DefaultRunTimeout = 5min`. `resolveRunTimeout()` checks scenario `Defaults.RunTimeout`, then config override. `context.WithTimeout` wraps execution. `RunTimeout` field added to `pkg/config.Defaults`.
+
+---
+
+## Priority Summary
+
+### Critical (address before production scale)
+| # | Issue | Area | Status |
+|---|-------|------|--------|
+| 1 | ~~Unbounded message history~~ | Pipeline / StateStore | **RESOLVED** |
+| 2 | ~~No retry logic despite RetryPolicy type~~ | All providers | **RESOLVED** |
+| 3 | ~~No rate limiting~~ | All providers | **RESOLVED** |
+| 4 | ~~Sequential tool execution~~ | Pipeline | **RESOLVED** |
+| 5 | ~~Tool timeout not enforced~~ | Tool registry | **RESOLVED** |
+| 6 | ~~Goroutine leak in eval middleware~~ | SDK | **RESOLVED** |
+| 7 | ~~Heuristic-only token counting~~ | Tokenizer | **IMPROVED** |
+| 8 | ~~No pre-flight token budget enforcement~~ | Pipeline | **RESOLVED** |
+
+### High (will cause issues at moderate scale)
+| # | Issue | Area | Status |
+|---|-------|------|--------|
+| 9 | ~~Gemini streaming reads entire body~~ | Providers | **RESOLVED** |
+| 10 | ~~A2A SSE buffer too small; timeout kills streams~~ | A2A | **RESOLVED** |
+| 11 | ~~No file size limit in storage~~ | Storage | **RESOLVED** |
+| 12 | Base64 encoding triples media memory | Media loader | **MITIGATED** |
+| 13 | ~~Workflow StateMachine has no mutex~~ | Workflow | **RESOLVED** |
+| 14 | ~~No request payload validation~~ | Providers | **RESOLVED** |
+
+### Medium (will cause issues at high scale)
+| # | Issue | Area | Status |
+|---|-------|------|--------|
+| 15 | ~~O(N²) string concat in streaming~~ | Streaming | **RESOLVED** |
+| 16 | ~~Silent event drops under load~~ | Event bus | **RESOLVED** |
+| 17 | ~~Deep-copy cost on state operations~~ | StateStore | **RESOLVED** |
+| 18 | ~~MCP sleep while holding mutex~~ | MCP | **RESOLVED** |
+| 19 | ~~No policy enforcement by default~~ | Storage | **RESOLVED** |
+| 20 | ~~Eval goroutine concurrency unbounded~~ | SDK | **RESOLVED** |
+| 21 | ~~A2A/MCP no retry logic~~ | A2A / MCP | **RESOLVED** |
+| 22 | ~~MemoryStore no default limits~~ | StateStore | **RESOLVED** |
+
+---
+
+## Recommended Next Steps
+
+All critical, high, medium, and most low-priority items have been addressed. Remaining work:
+
+### Remaining Items (not yet addressed)
+1. **Integrate tiktoken-go** — replace heuristic token counter for accurate context window management (currently improved but still heuristic).
+2. **No idle timeout between stream chunks** (3.5) — if a provider stops sending data mid-stream, the only protection is the HTTP client timeout.
+3. **Synchronous event store in publish path** (4.3) — `store.Append()` is called synchronously before queuing.
+4. **Event bus always created** (4.4) — `initEventBus()` creates an EventBus even when no one subscribes.
+5. **Dedup index fully in memory** (6.5) — re-serialized to JSON on every store.
+6. **Policy enforcement walks entire directory tree** (6.7) — `filepath.Walk` on every tick.
+7. **Redis state store serializes monolithically** (1.5) — entire state as single JSON blob.
+8. **MCP no reconnection on process death** (10.1) — dead client's pending requests leak.
+9. **No limit on concurrent MCP processes** (10.3) — can exhaust OS process/FD limits.
+
+### K8s / Production Deployment (infrastructure gaps)
+10. **Share MCP registry across conversations** — prevent O(N) child processes.
+11. **Cloud storage backend** — replace `FileStore` with S3/GCS for persistent media storage.
+12. **Share provider instances** — avoid per-conversation HTTP connection pools.
+13. **External pub/sub for cross-pod events** — EventBus is in-process only.
+
+---
+
+## 13. Kubernetes at 10,000 Concurrent Connections
+
+Assumes horizontal scaling across pods with load balancer. Pods can scale out to meet demand.
+
+### 13.1 State affinity — MemoryStore is process-local (CRITICAL)
+- **sdk/sdk.go:451-457** — Default path creates a per-conversation `MemoryStore`. If a user's second request hits a different pod, the state is gone. `Resume()` returns `ErrConversationNotFound`.
+- **Mitigation available**: `RedisStore` at `runtime/statestore/redis.go` implements full `Store`, `MessageReader`, `MessageAppender`, `SummaryAccessor` interfaces with pipelining and TTL. Wire via `sdk.WithStateStore(redisStore)`.
+- **Gap**: No auto-detection of clustered environments. Deployers must explicitly wire Redis.
+
+### 13.2 Event bus is purely in-process (CRITICAL)
+- **runtime/events/bus.go:54-64** — `EventBus` is local pub/sub. Subscribers are function references that cannot span pods. Any observability or side-effect logic (OTel, eval results) is invisible to other pods.
+- At 10K connections with default per-conversation buses: 10 workers × 10K = **100,000 goroutines** just for event dispatching.
+- Should share a single `EventBus` across conversations via `sdk.WithEventBus()`, reducing to 10 workers total per pod.
+
+### 13.3 MCP processes do not pool (CRITICAL)
+- **runtime/mcp/client.go:267-306** — Each `StdioClient` runs `exec.Command()` to launch a child process. 2 background goroutines per client (`readLoop`, `logStderr`).
+- **sdk/sdk.go:560** — MCP registry is created per-conversation.
+- At 10K connections with 3 MCP servers: **30,000 child processes**, **60,000 goroutines** on a single pod. This will exhaust OS process/FD limits.
+- Need shared MCP registry across conversations, or sidecar pattern.
+- MCP PATH is hardcoded to `/usr/local/bin:/usr/bin:/bin` (`client.go:271`), may miss container-specific binary locations.
+
+### 13.4 File-based storage lost on pod restart (HIGH)
+- `FileStore` writes to configurable `BaseDir`, maintains in-memory dedup index. All lost with ephemeral storage.
+- `FileEventStore` stores events as JSONL files — purely local filesystem.
+- Need PersistentVolumes or cloud storage (S3/GCS) backends for production.
+
+### 13.5 ~~No health/readiness endpoints~~ RESOLVED
+- ~~No `/healthz` or `/readyz` endpoints exist anywhere in the codebase.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `GET /healthz` (liveness) and `GET /readyz` (readiness) endpoints to A2A server. `HealthChecker` interface allows custom readiness checks (e.g., Redis connection, provider availability). `isReady` atomic bool tracks server readiness state. Configurable via `WithHealthCheck()` option.
+
+### 13.6 ~~No graceful shutdown orchestration~~ RESOLVED
+- ~~A2A `Server.Shutdown()` is well-implemented (drains HTTP, cancels tasks, closes conversations). But the SDK itself has no shutdown manager.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `ShutdownManager` to SDK with `Register`/`Deregister`/`Shutdown`/`Len` methods. Conversations auto-register via `WithShutdownManager()` option and auto-deregister on `Close()`. `GracefulShutdown()` listens for SIGTERM/SIGINT and closes all tracked conversations with configurable timeout.
+
+### 13.7 HTTP client pooling is good but per-conversation (LOW)
+- **runtime/providers/base_provider.go:20-46** — Well-configured `http.Transport` with `MaxIdleConns=1000`, `MaxConnsPerHost=100`, HTTP/2, TLS 1.2+.
+- But each conversation creates its own provider → own `http.Client` → own connection pool. With 10K conversations targeting the same LLM endpoint: theoretical 1M connections.
+- Should share provider instances via `sdk.WithProvider()`.
+
+### K8s Deployment Checklist
+
+| Item | Status | Action |
+|------|--------|--------|
+| State store | Available | Wire `RedisStore` via `WithStateStore()` |
+| Event bus | Gap | Share single bus via `WithEventBus()`; consider external pub/sub for cross-pod |
+| MCP processes | Gap | Share registry; consider sidecar or remote MCP pattern |
+| Storage | Gap | Replace `FileStore` with cloud storage backend |
+| Health probes | **RESOLVED** | `/healthz` and `/readyz` endpoints added to A2A server |
+| Graceful shutdown | **RESOLVED** | `ShutdownManager` tracks and closes all conversations on SIGTERM |
+| Provider sharing | Available | Share via `WithProvider()` |
+| Goroutine budget | Monitor | Expect ~12-22 goroutines per conversation (with shared EventBus) |
+
+---
+
+## 14. 10,000 Concurrent Duplex Audio Connections
+
+### 14.1 Per-connection resource footprint
+
+Each `OpenDuplex` session creates:
+
+| Component | Goroutines | Memory |
+|-----------|-----------|--------|
+| `duplexSession.executePipeline` | 1 | — |
+| Pipeline stage runners | 3-8 (per stage) | — |
+| Pipeline bookkeeping (output collection, error closer, timeout) | 2-3 | — |
+| `DuplexProviderStage` (input forwarder, response merger) | 2 | — |
+| WebSocket heartbeat + receive loop | 2 | — |
+| Streaming session receive loop | 1 | — |
+| EventBus workers | 10 (per bus) or 0 (shared) | — |
+| `stageInput` channel (buffer 100) | — | ~180 KB |
+| `streamOutput` channel (buffer 100) | — | ~180 KB |
+| Inter-stage channels (4-8 stages × buffer 16) | — | ~115 KB |
+| Provider response channel (buffer 10) | — | ~18 KB |
+| WebSocket buffers | — | ~64 KB |
+| Misc (mutexes, contexts, maps) | — | ~5 KB |
+
+**Totals per connection:**
+- **ASM mode** (provider-side VAD): ~20-22 goroutines, ~600 KB - 1 MB memory
+- **VAD mode** (local VAD + STT + TTS): ~23-26 goroutines, ~1-3 MB memory (depends on utterance length)
+
+### 14.2 Aggregate resource requirements at 10K connections
+
+| Resource | ASM mode | VAD mode |
+|----------|----------|----------|
+| Goroutines (shared EventBus) | ~120K-140K | ~150K-180K |
+| Goroutines (per-connection EventBus) | ~220K-240K | ~250K-280K |
+| Goroutine stack memory | 400 MB - 1.6 GB | 500 MB - 2 GB |
+| Channel buffer memory | 6-10 GB | 10-30 GB |
+| WebSocket connections to providers | 10,000 | 10,000 |
+| OS file descriptors | 20,000+ | 20,000+ |
+
+### 14.3 ~~Unbounded audio buffer in VAD mode~~ RESOLVED
+- ~~**runtime/audio/silence.go:46-51** — `SilenceDetector.audioBuffer` grows via `append` with no cap.~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `DefaultMaxAudioBufferSize = 10MB` cap. Buffer is truncated (keeping most recent data) when cap is exceeded. Prevents unbounded memory growth for long utterances.
+
+### 14.4 Network bandwidth (HIGH)
+- PCM 16kHz/16-bit/mono: **32 KB/s per direction per connection**
+- Bidirectional at 10K connections: **640 MB/s** aggregate PCM bandwidth
+- OpenAI base64-encodes audio: add 33% → **853 MB/s** outbound
+- Plus provider response audio flowing back at similar rates
+- Requires multi-gigabit network links between pods and LLM providers
+
+### 14.5 VAD CPU cost is manageable (LOW)
+- **runtime/audio/simple_vad.go:63-85** — `SimpleVAD.Analyze()` does RMS calculation: O(N) per chunk where N = samples (320 at 20ms/16kHz).
+- 10K connections × 50 chunks/sec = 500K VAD invocations/sec → ~1-3 CPU cores
+- `SimpleVAD` is energy-based (RMS), not ML-based. Lightweight but less accurate.
+
+### 14.6 ~~Resampling GC pressure~~ RESOLVED
+- ~~**runtime/audio/resample.go:18-86** — `ResamplePCM16()` allocates 3 slices per invocation (~3 KB per chunk).~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Added `sync.Pool` for `[]int16` resample buffers. Reused across invocations, significantly reducing GC pressure at high throughput.
+
+### 14.7 ~~Channel backpressure at 320ms~~ RESOLVED
+- ~~Inter-stage channels buffer only 16 elements (`DefaultChannelBufferSize = 16`).~~
+- **Fixed in `feat/scalability-remaining-fixes`**: Increased `DefaultChannelBufferSize` from 16 to 32, and added `DefaultAudioChannelBufferSize = 64` for audio pipeline stages (~1.3s of buffering at 50 chunks/sec).
+
+### 14.8 Provider WebSocket limits (MEDIUM)
+- Each duplex session opens its own WebSocket to the provider. No connection pooling for WebSockets.
+- OpenAI and Gemini both have per-account concurrent connection limits (typically 100-1000).
+- 10K connections would require multiple API keys or enterprise tier agreements.
+
+### 14.9 No connection draining for audio (MEDIUM)
+- When a pod receives SIGTERM, active audio streams need graceful completion (at minimum, flush current utterance and send final response).
+- No mechanism exists to drain duplex sessions before shutdown.
+
+### Audio at Scale — Key Numbers
+
+| Metric | Value |
+|--------|-------|
+| Memory per connection (ASM) | 600 KB - 1 MB |
+| Memory per connection (VAD, 10s utterance) | 1 - 1.5 MB |
+| Memory per connection (VAD, 60s utterance) | 2 - 3 MB |
+| Total memory at 10K (ASM) | 6 - 10 GB |
+| Total memory at 10K (VAD) | 10 - 30 GB |
+| Goroutines at 10K (shared EventBus) | 120K - 180K |
+| CPU for VAD at 10K | 1 - 3 cores |
+| CPU for resampling at 10K | 1 - 3 cores |
+| Network bandwidth at 10K (PCM) | 640 MB/s bidirectional |
+| Network bandwidth at 10K (base64) | 853 MB/s outbound |
+| Provider WebSocket connections | 10K (likely exceeds provider limits) |
+
+### Audio-Specific Recommendations
+
+1. ~~**Cap `SilenceDetector.audioBuffer`**~~ — **RESOLVED**: `DefaultMaxAudioBufferSize = 10MB` cap added.
+2. ~~**Pool audio buffers**~~ — **RESOLVED**: `sync.Pool` for resample `[]int16` slices.
+3. ~~**Increase inter-stage channel buffers for audio**~~ — **RESOLVED**: `DefaultAudioChannelBufferSize = 64`.
+4. **Share provider connections** — multiplex audio streams over fewer WebSocket connections where provider APIs allow.
+5. **Add connection draining** — on SIGTERM, stop accepting new audio, flush current utterances, send final responses.
+6. **OS tuning for K8s nodes** — `ulimit -n 65536`, `net.core.somaxconn=32768`, `net.ipv4.tcp_tw_reuse=1`.
+7. **Monitor goroutine count** — expose `runtime.NumGoroutine()` as a Prometheus metric; alert at 200K+.
+8. **Consider audio codec compression** — Opus at 32kbps would reduce bandwidth from 32KB/s to 4KB/s per direction (8x reduction).

--- a/docs/local-backlog/capacity-planning-guide.md
+++ b/docs/local-backlog/capacity-planning-guide.md
@@ -1,0 +1,306 @@
+# PromptKit Capacity Planning Guide
+
+Practical guidance for estimating resource requirements when deploying PromptKit at scale.
+
+---
+
+## 1. Per-Conversation Memory Footprint
+
+Each active conversation allocates several runtime objects. The table below summarizes the major components.
+
+| Component | Memory Estimate | Notes |
+|-----------|----------------|-------|
+| **ConversationState** (statestore) | 2-50 KB | Scales with message count. Each `types.Message` is ~200-500 bytes for text. At the 200-message default cap (`DefaultMaxMessages`), expect ~40-100 KB. |
+| **Conversation struct** (sdk) | ~2 KB | Fixed overhead: config pointers, handler maps, mutexes, mode union. |
+| **EventBus** (per-conversation) | ~80 KB | 10 worker goroutines (8 KB stack each) + 1000-element buffered channel. **Strongly recommend sharing** a single bus via `WithEventBus()`. |
+| **EventBus** (shared) | ~0 KB per conversation | Amortized across all conversations. Single bus: 10 workers total. |
+| **Provider HTTP client** (per-conversation) | ~50-100 KB | Connection pool (`MaxIdleConns=1000`, `MaxConnsPerHost=100`), TLS state. **Recommend sharing** via `WithProvider()`. |
+| **Provider HTTP client** (shared) | ~0 KB per conversation | Pool shared across all conversations to the same endpoint. |
+| **Tool registry** | ~1-5 KB | Map of tool descriptors and executors. |
+| **Streaming channel buffer** | ~6 KB (active only) | `DefaultStreamBufferSize = 32` elements, allocated only during active streaming. |
+| **MCP client** (per-server) | ~500 KB-1 MB | Child process + 2 goroutines (readLoop, logStderr) + pipe buffers. See section on MCP below. |
+| **Eval middleware** | ~1 KB | Semaphore channel (`DefaultMaxConcurrentEvals = 10`), WaitGroup. |
+
+### Summary by Configuration
+
+| Configuration | Memory per Conversation |
+|---------------|------------------------|
+| Shared EventBus + shared provider (recommended) | **5-60 KB** |
+| Per-conversation EventBus, shared provider | **85-160 KB** |
+| Per-conversation EventBus + per-conversation provider | **135-260 KB** |
+| With 3 MCP servers (per-conversation registry) | **add 1.5-3 MB** |
+
+---
+
+## 2. Workload Profiles
+
+### Chat-Only (text-based, no tools)
+
+Typical use case: customer support bots, FAQ systems, simple Q&A.
+
+| Resource | Per Conversation | At 1,000 | At 10,000 |
+|----------|-----------------|----------|-----------|
+| Memory (shared bus/provider) | 5-60 KB | 50-600 MB | 500 MB-6 GB |
+| Goroutines | 2-5 | 2,000-5,000 | 20,000-50,000 |
+| Provider API calls | 1 per turn | — | — |
+| State store entries | 1 | 1,000 | 10,000 |
+| CPU (steady state) | negligible | 0.5-1 core | 2-5 cores |
+
+**Key constraint**: Provider rate limits (see section 5). At 10K concurrent, you need provider capacity for burst request rates during peak activity.
+
+### Tool-Heavy (MCP tools, A2A agents)
+
+Typical use case: agentic workflows, multi-step reasoning with external tools.
+
+| Resource | Per Conversation | At 1,000 | At 10,000 |
+|----------|-----------------|----------|-----------|
+| Memory (shared bus/provider) | 50-200 KB | 500 MB-2 GB | 5-20 GB |
+| Memory (with 3 MCP servers, shared registry) | 50-200 KB + 1.5 MB fixed | 500 MB-2 GB + 1.5 MB | 5-20 GB + 1.5 MB |
+| Memory (with 3 MCP servers, per-conversation) | 1.5-3.2 MB | 15-32 GB | **150-320 GB** |
+| Goroutines (shared MCP registry) | 5-15 | 5,000-15,000 | 50,000-150,000 |
+| Tool calls per turn | 1-10 (parallel, max 10) | — | — |
+| A2A client cache | 30 min TTL, max 100 clients | — | — |
+| CPU per turn | moderate (tool execution) | 2-5 cores | 10-30 cores |
+
+**Critical**: Share the MCP registry across conversations. Per-conversation MCP processes will exhaust OS process and file descriptor limits. At 10K conversations with 3 MCP servers each, that would be 30,000 child processes.
+
+### Audio/Video (real-time streaming with media)
+
+Typical use case: voice assistants, real-time audio agents.
+
+| Resource | Per Connection (ASM) | Per Connection (VAD) | At 1,000 (ASM) | At 10,000 (ASM) |
+|----------|---------------------|---------------------|-----------------|------------------|
+| Memory | 600 KB-1 MB | 1-3 MB | 6-10 GB | 60-100 GB |
+| Goroutines (shared bus) | 12-14 | 15-18 | 12,000-14,000 | 120,000-140,000 |
+| Network bandwidth | 32 KB/s per direction | 32 KB/s per direction | 64 MB/s bidir | 640 MB/s bidir |
+| WebSocket connections | 1 to provider | 1 to provider | 1,000 | 10,000 |
+| Audio buffer (VAD max) | 10 MB cap | 10 MB cap | — | — |
+| CPU (VAD + resample) | — | ~0.3 ms/chunk | — | 2-6 cores |
+
+**Key constraints**: Provider WebSocket connection limits (typically 100-1000 per account), network bandwidth (multi-gigabit links needed at 10K), and base64 encoding overhead (33% increase for OpenAI).
+
+Channel buffer sizes for audio pipelines: `DefaultAudioChannelBufferSize = 64` elements (~1.3s of buffering at 50 chunks/sec).
+
+---
+
+## 3. Scaling Formulas
+
+### Basic Instance Sizing
+
+```
+conversations_per_instance = available_memory / memory_per_conversation
+instances = ceil(target_conversations / conversations_per_instance)
+```
+
+**Example (chat-only, shared bus/provider):**
+- Pod memory: 4 GB available (after Go runtime, OS overhead)
+- Memory per conversation: ~60 KB (upper bound for 200-message conversations)
+- conversations_per_instance = 4 GB / 60 KB = ~68,000
+- For 10,000 target conversations: 1 instance
+
+**Example (tool-heavy, shared MCP):**
+- Pod memory: 8 GB available
+- Memory per conversation: ~200 KB
+- conversations_per_instance = 8 GB / 200 KB = ~40,000
+- For 10,000 target conversations: 1 instance
+
+**Example (audio/ASM):**
+- Pod memory: 16 GB available
+- Memory per conversation: ~1 MB
+- conversations_per_instance = 16 GB / 1 MB = ~16,000
+- For 10,000 target connections: 1 instance (but see constraints below)
+
+### Goroutine Budget
+
+Go handles goroutines efficiently, but each has a minimum 8 KB stack that can grow. Plan for:
+
+```
+goroutine_memory = goroutine_count * avg_stack_size
+```
+
+Conservative estimate: 16 KB average stack per goroutine.
+
+| Goroutine Count | Estimated Stack Memory |
+|----------------|----------------------|
+| 50,000 | 800 MB |
+| 150,000 | 2.4 GB |
+| 250,000 | 4 GB |
+
+Alert threshold: 200,000+ goroutines. Expose `runtime.NumGoroutine()` as a Prometheus metric.
+
+### CPU Sizing
+
+For text workloads, CPU is rarely the bottleneck (most time is spent waiting on provider API responses). Key CPU consumers:
+
+- **Token counting** (heuristic): negligible
+- **State deep-copy**: ~0.1 ms per operation for typical conversations
+- **JSON serialization** (Redis state store): ~0.5-2 ms per save for 200 messages
+- **VAD processing**: ~0.3 ms per 20ms audio chunk
+- **Audio resampling**: ~0.2 ms per chunk (pooled buffers)
+
+Rule of thumb:
+```
+cpu_cores = base_cores + (audio_connections * 0.0005) + (tool_calls_per_second * 0.001)
+```
+
+Where `base_cores = 1-2` for the Go runtime, GC, and HTTP handling.
+
+---
+
+## 4. Storage Planning
+
+### MemoryStore (In-Process)
+
+Default limits:
+- `DefaultMaxEntries = 10,000` conversations
+- `DefaultTTL = 1 hour` (entries expire after last access)
+- LRU eviction when max entries reached (O(log N) via heap)
+
+Memory consumption: number of entries * average state size. For 10,000 conversations at 50 KB each = ~500 MB.
+
+**Not suitable for production multi-pod deployments** -- state is process-local.
+
+### Redis State Store
+
+Decomposed storage (3 keys per conversation after scalability fixes):
+- `{prefix}:{id}:meta` -- small JSON (~200-500 bytes): ID, UserID, SystemPrompt, TokenCount, timestamps
+- `{prefix}:{id}:messages` -- Redis list, one entry per message (~200-500 bytes each)
+- `{prefix}:{id}:summaries` -- Redis list, one entry per summary (~200-1000 bytes each)
+
+Default TTL: 24 hours.
+
+| Conversations | Avg Messages | Redis Memory Estimate |
+|--------------|-------------|----------------------|
+| 1,000 | 50 | ~25-50 MB |
+| 10,000 | 50 | ~250-500 MB |
+| 10,000 | 200 | ~1-2 GB |
+| 100,000 | 50 | ~2.5-5 GB |
+
+Growth rate depends on conversation creation rate and TTL. With 24-hour TTL, Redis memory is bounded by:
+
+```
+peak_redis_memory = max_daily_conversations * avg_messages * 500 bytes
+```
+
+**Recommendations:**
+- Set Redis `maxmemory` with `allkeys-lru` eviction policy as a safety net.
+- Monitor Redis memory usage and key count.
+- Tune TTL based on conversation patterns (`WithTTL()` option on Redis store).
+
+### FileStore (Local Disk)
+
+Used for media files (images, audio, documents).
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| Max file size | 50 MB (`DefaultMaxFileSize`) | Per-file limit |
+| Max aggregate media | 100 MB (`MaxAggregateMediaSize`) | Per-loader instance |
+| Max media items | 20 (`MaxMediaItems`) | Per-loader instance |
+| Dedup index | In-memory map | Written to disk only when dirty |
+
+Disk growth rate:
+```
+daily_disk_growth = new_media_files_per_day * avg_file_size
+```
+
+**Recommendations:**
+- Enable retention policy enforcement (`WithAutoStart(true)`) to automatically clean expired media.
+- For production, replace `FileStore` with a cloud storage backend (S3/GCS).
+- Set `TimeBasedPolicy` with appropriate retention (e.g., 24-48 hours for transient media).
+
+---
+
+## 5. Provider Rate Limits
+
+### Typical Provider Limits
+
+| Provider | RPM (Requests/Min) | TPM (Tokens/Min) | Concurrent Connections |
+|----------|--------------------|--------------------|----------------------|
+| OpenAI GPT-4 | 500-10,000 | 30K-800K | No hard limit (HTTP) |
+| OpenAI Realtime | — | — | 100-1,000 WebSocket |
+| Anthropic Claude | 1,000-4,000 | 80K-400K | No hard limit (HTTP) |
+| Google Gemini | 360-1,000 | 120K-4M | No hard limit (HTTP) |
+
+*Limits vary by tier and account. Check your provider dashboard for exact numbers.*
+
+### How Rate Limits Affect Capacity
+
+The effective conversation throughput is bounded by:
+
+```
+max_turns_per_minute = provider_RPM
+max_concurrent_active = provider_RPM * avg_response_time_seconds / 60
+```
+
+**Example:** OpenAI GPT-4 at 500 RPM with 3-second average response time:
+- max_concurrent_active = 500 * 3 / 60 = 25 conversations actively generating at once
+- The other conversations are idle (waiting for user input)
+
+For a chat application where users send a message every 30 seconds on average:
+```
+sustainable_conversations = provider_RPM * avg_user_think_time / 60
+                          = 500 * 30 / 60 = 250 concurrent conversations
+```
+
+### Built-In Rate Limiting
+
+PromptKit has built-in rate limiting on `BaseProvider`:
+- Configurable via `SetRateLimit(rps float64, burst int)`
+- Uses `golang.org/x/time/rate` token bucket algorithm
+- Set this below your provider's limit to avoid 429 errors
+
+### Connection Pooling
+
+Default HTTP transport settings (per provider instance):
+- `MaxIdleConns = 1000`
+- `MaxIdleConnsPerHost = 100`
+- `MaxConnsPerHost = 100`
+- `IdleConnTimeout = 90s`
+- HTTP/2 enabled (multiplexing multiple requests over fewer TCP connections)
+
+**Recommendation:** Share provider instances across conversations via `WithProvider()`. This shares the connection pool and rate limiter, preventing per-conversation connection overhead and ensuring rate limits are enforced globally.
+
+### Retry Behavior
+
+Built-in retry with exponential backoff:
+- Default: 3 retries, 500ms initial delay
+- Retries on 429, 502, 503, 504, and network errors
+- Respects `Retry-After` headers from providers
+- Budget for retry overhead: ~2x provider calls during degraded conditions
+
+---
+
+## Quick Reference: Deployment Sizing
+
+| Deployment Size | Conversations | Recommended Pod Spec | Pods | Key Settings |
+|----------------|--------------|---------------------|------|--------------|
+| Small | Up to 500 | 2 CPU, 4 GB RAM | 1-2 | MemoryStore OK for single-pod |
+| Medium | 500-5,000 | 4 CPU, 8 GB RAM | 2-4 | Redis state store, shared EventBus + provider |
+| Large | 5,000-50,000 | 8 CPU, 16 GB RAM | 4-10 | Redis state store, shared everything, cloud storage |
+| Audio (ASM) | Up to 5,000 | 8 CPU, 32 GB RAM | 4-8 | Multi-gigabit network, shared EventBus |
+| Audio (VAD) | Up to 2,000 | 8 CPU, 32 GB RAM | 4-10 | Higher CPU for VAD/resample, shared EventBus |
+
+### OS Tuning for Large Deployments
+
+```bash
+ulimit -n 65536            # file descriptors
+sysctl net.core.somaxconn=32768
+sysctl net.ipv4.tcp_tw_reuse=1
+```
+
+### Key SDK Options for Production
+
+```go
+// Share resources across conversations
+sharedBus := events.NewBus()
+sharedProvider := openai.New(apiKey)
+sharedStateStore := statestore.NewRedisStore(redisClient)
+shutdownMgr := sdk.NewShutdownManager()
+
+conv, _ := sdk.Open(pack,
+    sdk.WithEventBus(sharedBus),
+    sdk.WithProvider(sharedProvider),
+    sdk.WithStateStore(sharedStateStore),
+    sdk.WithShutdownManager(shutdownMgr),
+)
+```

--- a/docs/local-backlog/horizontal-scaling-guide.md
+++ b/docs/local-backlog/horizontal-scaling-guide.md
@@ -1,0 +1,445 @@
+# Horizontal Scaling and Resource Planning Guide
+
+This guide covers how to deploy PromptKit across multiple instances, extract state to shared stores, and size resources for different workloads. It references the scalability work completed in the `feat/scalability-*` branches (see `docs/local-backlog/05-mar-scalability-review.md` for the full audit).
+
+---
+
+## 1. Extracting State to External Stores
+
+### The Problem
+
+By default, `sdk.Open()` creates a per-conversation `MemoryStore` (`runtime/statestore/memory.go`). This store is process-local: if a user's next request lands on a different pod, the conversation state is gone and `Resume()` returns `ErrConversationNotFound`.
+
+### Solution: Wire a RedisStore
+
+PromptKit ships a production-ready Redis-backed state store at `runtime/statestore/redis.go`. It implements the full set of interfaces:
+
+- `Store` (Load/Save/Fork)
+- `MessageReader` (LoadRecentMessages/MessageCount)
+- `MessageAppender` (AppendMessages)
+- `MetadataAccessor` (LoadMetadata)
+- `SummaryAccessor` (LoadSummaries/SaveSummary)
+
+These interfaces are defined in `runtime/statestore/interface.go`.
+
+#### Basic Setup
+
+```go
+import (
+    "github.com/redis/go-redis/v9"
+    "github.com/AltairaLabs/PromptKit/runtime/statestore"
+    "github.com/AltairaLabs/PromptKit/sdk"
+)
+
+redisClient := redis.NewClient(&redis.Options{
+    Addr:     "redis:6379",
+    Password: os.Getenv("REDIS_PASSWORD"),
+    DB:       0,
+})
+
+store := statestore.NewRedisStore(
+    redisClient,
+    statestore.WithTTL(24 * time.Hour),  // Default is 24h
+    statestore.WithPrefix("myapp"),       // Default is "promptkit"
+)
+
+conv, err := sdk.Open("./chat.pack.json", "assistant",
+    sdk.WithStateStore(store),
+)
+```
+
+#### How It Works
+
+The `RedisStore` uses a decomposed key layout for efficient partial reads:
+
+| Key Pattern | Content | Purpose |
+|---|---|---|
+| `{prefix}:conversation:{id}:meta` | Small JSON (ID, UserID, SystemPrompt, TokenCount, LastAccessedAt, Metadata) | Fast metadata reads without deserializing messages |
+| `{prefix}:conversation:{id}:messages` | Redis list, one JSON entry per message | Supports `LRANGE` for partial reads, `RPUSH` for appends |
+| `{prefix}:conversation:{id}:summaries` | Redis list, one JSON entry per summary | Append-only summary storage |
+| `{prefix}:user:{userId}:conversations` | Redis set of conversation IDs | O(1) user-scoped lookups |
+
+`Save()` uses Redis pipelining to write meta, messages, and summaries in a single round-trip. `AppendMessages()` uses `RPUSH` to add messages incrementally without rewriting the full list. `LoadRecentMessages()` uses `LRANGE` with negative indices to fetch only the last N messages.
+
+The store automatically migrates data from the legacy monolithic format (a single JSON blob per conversation) to the decomposed format on first access. All TTLs are applied to every key in the pipeline.
+
+#### Redis Configuration Recommendations
+
+For production deployments:
+
+```
+# redis.conf recommendations
+maxmemory-policy allkeys-lru    # Evict oldest keys when memory is full
+tcp-keepalive 60                # Detect dead connections
+timeout 300                     # Close idle connections after 5 min
+
+# For Redis Cluster (10K+ conversations)
+cluster-enabled yes
+cluster-node-timeout 5000
+```
+
+Use Redis Sentinel or Redis Cluster for high availability. A single Redis instance can typically handle 10K-50K concurrent conversations depending on message volume and average conversation size.
+
+### MemoryStore Defaults (Single-Instance)
+
+If you intentionally run a single instance, the `MemoryStore` now has safe defaults:
+
+- `DefaultTTL = 1 hour` -- entries expire after 1 hour of inactivity
+- `DefaultMaxEntries = 10,000` -- LRU eviction when limit is reached (O(log N) via min-heap)
+- Background eviction configurable via `WithMemoryEvictionInterval()`
+- Opt out explicitly with `WithNoTTL()` or `WithNoMaxEntries()`
+
+---
+
+## 2. Event Bus Considerations
+
+### Current Architecture
+
+The `EventBus` (`runtime/events/bus.go`) is an in-process pub/sub system:
+
+- Fixed worker pool (default `DefaultWorkerPoolSize = 10` goroutines)
+- Buffered event channel (default `DefaultEventBufferSize = 1000`)
+- Subscriber timeout protection (default `DefaultSubscriberTimeout = 5s`)
+- Lazy worker startup -- goroutines only spawn on first `Subscribe()`/`SubscribeAll()` call
+- Dropped event counter (`DroppedCount()`) for monitoring
+
+### Multi-Instance Gap
+
+The EventBus is purely in-process. Subscribers on pod A cannot receive events published on pod B. This affects:
+
+- **Observability**: OTel/metrics listeners only see events from their local pod
+- **Eval results**: Evaluation middleware results are local to the pod that handled the request
+- **Side effects**: Any event-driven side effects (notifications, logging) are incomplete
+
+### Recommended: Share a Single Bus Per Pod
+
+Even within a single pod, create one `EventBus` and share it across all conversations:
+
+```go
+bus := events.NewEventBus(
+    events.WithWorkerPoolSize(20),       // Scale with expected concurrency
+    events.WithEventBufferSize(5000),    // Larger buffer for bursty workloads
+    events.WithSubscriberTimeout(10*time.Second),
+)
+defer bus.Close()
+
+// All conversations share the same bus
+conv1, _ := sdk.Open("./chat.pack.json", "assistant",
+    sdk.WithEventBus(bus),
+    sdk.WithStateStore(store),
+)
+conv2, _ := sdk.Open("./chat.pack.json", "assistant",
+    sdk.WithEventBus(bus),
+    sdk.WithStateStore(store),
+)
+```
+
+This reduces goroutine overhead from 10 workers per conversation to 10-20 workers total per pod.
+
+### Future: Cross-Instance Event Distribution
+
+For cross-pod event visibility, the EventBus would need an external transport layer. Candidate technologies:
+
+| Technology | Pros | Cons | Best For |
+|---|---|---|---|
+| **NATS** | Lightweight, low latency, built-in clustering | Less durable than Kafka | Real-time event fanout, metrics |
+| **Redis Pub/Sub** | Already deployed if using RedisStore, simple | No persistence, at-most-once delivery | Lightweight notifications |
+| **Kafka** | Durable, exactly-once semantics, replay capability | Higher operational complexity, higher latency | Audit logs, eval result aggregation |
+
+A future implementation would wrap the `EventBus` with a bridge that publishes events to the external transport and subscribes to events from other pods. The existing `EventStore` interface (`runtime/events/store.go`) provides a natural hook for persistent event storage.
+
+**This is not yet implemented.** For now, accept that event subscribers are pod-local, and use external observability (e.g., OpenTelemetry exported to a collector) for cross-pod visibility.
+
+---
+
+## 3. Session Affinity
+
+### When You Need Sticky Sessions
+
+If you use the in-memory `MemoryStore` (the default), you **must** configure session affinity (sticky sessions) in your load balancer so that all requests for a given conversation route to the same pod. Without it, the second request for a conversation will hit a different pod and fail with `ErrConversationNotFound`.
+
+Common approaches:
+
+- **Kubernetes**: Use `sessionAffinity: ClientIP` on the Service, or use an Ingress controller with cookie-based affinity
+- **NGINX**: `ip_hash` directive or `sticky cookie`
+- **AWS ALB**: Stickiness enabled on the target group
+
+### How to Avoid Needing Sticky Sessions
+
+Use `RedisStore` (Section 1). When conversation state lives in Redis, any pod can serve any request. This is the recommended approach for production:
+
+```yaml
+# Kubernetes Service -- no session affinity needed with Redis
+apiVersion: v1
+kind: Service
+metadata:
+  name: promptkit
+spec:
+  type: ClusterIP
+  # No sessionAffinity needed
+  ports:
+    - port: 8080
+```
+
+Additional considerations:
+
+- **MCP processes** are pod-local (child processes). If a conversation uses MCP tools, switching pods means re-spawning MCP servers. This adds latency but not correctness issues, since MCP servers are stateless tool executors.
+- **Provider instances** are pod-local (HTTP connection pools). Switching pods means establishing new connections, but `BaseProvider` configures aggressive connection pooling (`MaxIdleConns=1000`, `MaxConnsPerHost=100`) that makes this fast.
+- **EventBus** is pod-local. Event subscribers on the original pod will not fire for requests that land on a different pod. Use external observability for cross-pod visibility.
+
+---
+
+## 4. Resource Limit Recommendations
+
+### Key Constants in the Codebase
+
+| Constant | Location | Default | Purpose |
+|---|---|---|---|
+| `DefaultStreamBufferSize` | `runtime/providers/streaming.go` | 32 | Buffered channel for stream chunks |
+| `DefaultStreamIdleTimeout` | `runtime/providers/streaming.go` | 30s | Max wait between stream chunks |
+| `DefaultChannelBufferSize` | `runtime/pipeline/stage/config.go` | 32 | Inter-stage pipeline channel buffer |
+| `DefaultAudioChannelBufferSize` | `runtime/pipeline/stage/config.go` | 64 | Audio pipeline channel buffer (~1.3s at 50 chunks/sec) |
+| `DefaultMaxAudioBufferSize` | `runtime/audio/silence.go` | 10 MB | Max VAD audio buffer per connection |
+| `DefaultToolTimeout` | `runtime/tools/registry.go` | 30,000 ms | Per-tool execution timeout |
+| `DefaultMaxToolResultSize` | `runtime/tools/registry.go` | 1 MB | Max tool result payload |
+| `defaultMaxParallelToolCalls` | `runtime/pipeline/stage/stages_provider.go` | 10 | Concurrent tool executions per turn |
+| `DefaultMaxProcesses` | `runtime/mcp/registry.go` | 0 (unlimited) | Max concurrent MCP child processes |
+| `defaultMaxReconnectAttempts` | `runtime/mcp/client.go` | 3 | MCP process reconnection attempts |
+| `DefaultMaxClients` | `runtime/a2a/executor.go` | 100 | Max cached A2A clients |
+| `DefaultClientTTL` | `runtime/a2a/executor.go` | 30 min | A2A client cache TTL |
+| `DefaultTTL` (MemoryStore) | `runtime/statestore/memory.go` | 1 hour | In-memory state expiration |
+| `DefaultMaxEntries` | `runtime/statestore/memory.go` | 10,000 | In-memory state max entries |
+| `DefaultWorkerPoolSize` | `runtime/events/bus.go` | 10 | EventBus worker goroutines |
+| `DefaultEventBufferSize` | `runtime/events/bus.go` | 1,000 | EventBus channel buffer |
+| `DefaultMaxIdleConns` | `runtime/providers/base_provider.go` | 1,000 | HTTP transport idle connections |
+| `DefaultMaxConnsPerHost` | `runtime/providers/base_provider.go` | 100 | HTTP transport max per host |
+
+### Per-Connection Resource Footprint
+
+| Workload | Goroutines (shared EventBus) | Memory per Connection | Notes |
+|---|---|---|---|
+| **Chat-only (text)** | ~12-15 | 200-500 KB | Pipeline stages + state |
+| **Chat with tools** | ~15-20 | 300 KB - 1 MB | Add tool execution goroutines (up to `defaultMaxParallelToolCalls`) |
+| **Audio ASM** (provider-side VAD) | ~20-22 | 600 KB - 1 MB | WebSocket + pipeline + streaming |
+| **Audio VAD** (local VAD + STT/TTS) | ~23-26 | 1-3 MB | Depends on utterance length; `DefaultMaxAudioBufferSize = 10MB` caps worst case |
+| **With MCP tools** | +2 per MCP server | +~50 KB per server | `readLoop` + `logStderr` goroutines per child process |
+
+### Sizing Guidance
+
+#### Chat-Only Workloads (e.g., customer support bot)
+
+```yaml
+resources:
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
+  limits:
+    cpu: "2"
+    memory: "2Gi"
+```
+
+- Supports ~1,000-2,000 concurrent conversations per pod
+- CPU is dominated by JSON serialization and HTTP I/O
+- Set `MaxProcesses` on MCP registry if MCP tools are used
+
+#### Tool-Heavy Workloads (e.g., agent with database/API tools)
+
+```yaml
+resources:
+  requests:
+    cpu: "1"
+    memory: "1Gi"
+  limits:
+    cpu: "4"
+    memory: "4Gi"
+```
+
+- Each tool call fan-out creates up to 10 goroutines (`defaultMaxParallelToolCalls`)
+- Tool result size capped at `DefaultMaxToolResultSize = 1MB`
+- Set `RegistryOptions{MaxProcesses: 20}` on MCP registry to bound child processes:
+
+```go
+mcpRegistry := mcp.NewRegistryWithOptions(mcp.RegistryOptions{
+    MaxProcesses: 20,
+})
+```
+
+#### Audio/Video Workloads (duplex streaming)
+
+```yaml
+resources:
+  requests:
+    cpu: "2"
+    memory: "4Gi"
+  limits:
+    cpu: "8"
+    memory: "16Gi"
+```
+
+- Memory dominated by audio buffers: each connection uses up to 10MB for VAD buffer
+- Network bandwidth is the primary bottleneck: ~32 KB/s per direction per connection (PCM 16kHz/16-bit/mono)
+- At 1,000 connections: ~64 MB/s bidirectional PCM bandwidth
+- Provider WebSocket limits may be the real ceiling (typically 100-1000 per API key)
+
+#### OS-Level Tuning for K8s Nodes
+
+For any workload above 1,000 concurrent connections:
+
+```bash
+# /etc/security/limits.conf or K8s securityContext
+ulimit -n 65536                    # File descriptors
+
+# sysctl (node-level)
+net.core.somaxconn = 32768
+net.ipv4.tcp_tw_reuse = 1
+net.ipv4.ip_local_port_range = 1024 65535
+```
+
+---
+
+## 5. Auto-Scaling Policy Guidance
+
+### Metrics to Monitor
+
+Expose these via Prometheus and use them for HPA scaling decisions:
+
+| Metric | Source | Why |
+|---|---|---|
+| **Active conversations** | Application counter (increment on `Open()`, decrement on `Close()`) | Primary demand signal |
+| **Goroutine count** | `runtime.NumGoroutine()` | Proxy for overall load; alert at 200K+ |
+| **Event bus dropped count** | `bus.DroppedCount()` | Indicates backpressure; scale out if consistently > 0 |
+| **MCP active processes** | `registry.ActiveProcessCount()` | OS resource pressure |
+| **Response latency (p95/p99)** | OTel or application middleware | User-facing quality signal |
+| **Redis operation latency** | Redis client metrics | State store becoming a bottleneck |
+| **Provider rate limit 429s** | Provider retry metrics | May need to spread load across API keys |
+
+### Kubernetes HPA Configuration
+
+#### Chat Workloads
+
+Scale on a custom metric for active conversations per pod:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: promptkit-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: promptkit
+  minReplicas: 2
+  maxReplicas: 20
+  metrics:
+    # Primary: active conversations per pod
+    - type: Pods
+      pods:
+        metric:
+          name: promptkit_active_conversations
+        target:
+          type: AverageValue
+          averageValue: "500"    # Target 500 active conversations per pod
+    # Secondary: CPU as a safety net
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300   # 5 min cooldown before scaling down
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+```
+
+#### Audio Workloads
+
+Scale on memory (audio buffers) and connection count:
+
+```yaml
+metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: promptkit_active_duplex_sessions
+      target:
+        type: AverageValue
+        averageValue: "200"     # Conservative: 200 audio sessions per pod
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 60  # Audio buffers consume memory rapidly
+```
+
+### Graceful Shutdown
+
+PromptKit includes a `ShutdownManager` (`sdk/shutdown.go`) for coordinated shutdown:
+
+```go
+mgr := sdk.NewShutdownManager()
+
+// Conversations auto-register when WithShutdownManager is used
+conv, _ := sdk.Open("./chat.pack.json", "assistant",
+    sdk.WithStateStore(store),
+    sdk.WithShutdownManager(mgr),
+)
+
+// In your main() or signal handler:
+// Listens for SIGTERM/SIGINT, closes all tracked conversations
+sdk.GracefulShutdown(mgr, 30*time.Second)
+```
+
+For Kubernetes, set `terminationGracePeriodSeconds` in your pod spec to match or exceed your shutdown timeout:
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 45   # > GracefulShutdown timeout (30s)
+  containers:
+    - name: promptkit
+      # ...
+```
+
+The A2A server also exposes health endpoints:
+
+- `GET /healthz` -- liveness probe (always 200 when server is running)
+- `GET /readyz` -- readiness probe (200 when ready to accept traffic)
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+```
+
+### Scaling Checklist
+
+| Item | Single Instance | Multi-Instance |
+|---|---|---|
+| State store | `MemoryStore` (default) | `RedisStore` via `WithStateStore()` |
+| Event bus | One per conversation (default) | Shared via `WithEventBus()` |
+| Session affinity | Not needed | Not needed with Redis; required with MemoryStore |
+| Provider instances | One per conversation (default) | Share via `WithProvider()` to reduce connection pools |
+| MCP registry | Per-conversation (default) | Share across conversations; set `MaxProcesses` |
+| Graceful shutdown | `Conversation.Close()` | `ShutdownManager` + `GracefulShutdown()` |
+| Health probes | N/A | `/healthz` + `/readyz` on A2A server |
+| Goroutine monitoring | Optional | Expose `runtime.NumGoroutine()` as Prometheus metric |

--- a/docs/local-backlog/performance-tuning-runbook.md
+++ b/docs/local-backlog/performance-tuning-runbook.md
@@ -1,0 +1,348 @@
+# PromptKit Performance Tuning Runbook
+
+Practical guide to tuning PromptKit's runtime parameters for throughput, latency, and memory. All values reference code constants and configuration options introduced in the scalability work (March 2026).
+
+---
+
+## 1. EventBus Tuning
+
+**Source**: `runtime/events/bus.go`
+
+| Parameter | Default | Option | Effect |
+|-----------|---------|--------|--------|
+| Worker pool size | `DefaultWorkerPoolSize = 10` | `WithWorkerPoolSize(n)` | Number of goroutines dispatching events to subscribers |
+| Event buffer | `DefaultEventBufferSize = 1000` | `WithEventBufferSize(n)` | Buffered channel capacity between `Publish()` and workers |
+| Subscriber timeout | `DefaultSubscriberTimeout = 5s` | `WithSubscriberTimeout(d)` | Max time a listener may run before being skipped |
+
+### When to adjust
+
+- **Increase worker pool size** when `DroppedCount()` rises while subscriber callbacks are fast (workers cannot keep up with dispatch volume). Start with 20, measure, and go up to 50. Beyond that, contention on the subscriber list `RLock` becomes the bottleneck.
+- **Increase event buffer** when `DroppedCount()` rises in short bursts but workers catch up during steady state. A buffer of 5000-10000 absorbs spikes without adding goroutines.
+- **Decrease worker pool size** when running many conversations per process with a shared `EventBus` (via `sdk.WithEventBus()`). A shared bus with 10 workers serves all conversations; per-conversation buses waste 10 goroutines each.
+- **Increase subscriber timeout** when listeners perform I/O (e.g., writing to an external telemetry sink). Set to 10-15s. Avoid going above 30s as a slow subscriber holds a worker.
+- **Decrease subscriber timeout** when all listeners are in-process and fast (e.g., metrics counters). Set to 1-2s to detect stuck subscribers quickly.
+
+### Symptoms of misconfiguration
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `DroppedCount()` increasing steadily | Buffer too small or workers too few for the event rate |
+| Log: `"event dropped: buffer full"` (rate-limited, every 100th drop) | Same as above |
+| Log: `"event subscriber timed out"` | Subscriber is slow or the timeout is too short |
+| High goroutine count from event bus | Per-conversation buses instead of shared; or pool size too large |
+
+### Lazy startup
+
+Workers are started lazily on the first `Subscribe()`, `SubscribeAll()`, or `WithStore()` call. If no one subscribes, zero goroutines are spawned. Event store writes happen inside the worker goroutine (asynchronous to the publisher).
+
+### Recommended production config
+
+```go
+bus := events.NewEventBus(
+    events.WithWorkerPoolSize(20),
+    events.WithEventBufferSize(5000),
+    events.WithSubscriberTimeout(10 * time.Second),
+)
+// Share across all conversations:
+conv, _ := sdk.Open(pack, sdk.WithEventBus(bus))
+```
+
+---
+
+## 2. State Store Tuning
+
+### MemoryStore
+
+**Source**: `runtime/statestore/memory.go`
+
+| Parameter | Default | Option | Effect |
+|-----------|---------|--------|--------|
+| TTL | `DefaultTTL = 1 hour` | `WithMemoryTTL(d)` / `WithNoTTL()` | Time since last access before entry is eligible for eviction |
+| Max entries | `DefaultMaxEntries = 10,000` | `WithMemoryMaxEntries(n)` / `WithNoMaxEntries()` | Hard cap; LRU eviction when exceeded |
+| Eviction interval | 0 (disabled) | `WithMemoryEvictionInterval(d)` | Background goroutine tick for TTL cleanup |
+
+### When to adjust
+
+- **Increase TTL** for long-lived conversations (e.g., support tickets that span hours). Set to 4-8h.
+- **Decrease TTL** for high-throughput stateless workloads (e.g., one-shot API calls). Set to 5-15min to free memory quickly.
+- **Increase max entries** if you expect more than 10K concurrent conversations on a single process. Each entry costs ~1-50 KB depending on message history length.
+- **Enable eviction interval** in server deployments to proactively reclaim memory. Recommended: `WithMemoryEvictionInterval(1 * time.Minute)`. Without this, expired entries are only cleaned on access (lazy eviction).
+
+### LRU eviction performance
+
+Eviction uses a `container/heap`-based min-heap (`accessHeap`), giving O(log N) eviction instead of the previous O(N) scan. The two-phase expiration approach (`collectExpiredKeys` under `RLock`, then `deleteExpiredKeys` under `Lock`) avoids blocking reads during background cleanup.
+
+### RedisStore
+
+**Source**: `runtime/statestore/redis.go`
+
+| Parameter | Default | Option | Effect |
+|-----------|---------|--------|--------|
+| TTL | 24 hours | `WithTTL(d)` | Redis key expiration |
+| Key prefix | `"promptkit"` | `WithPrefix(s)` | Namespace isolation |
+
+Redis connection pooling is configured through the `go-redis` client options:
+
+```go
+client := redis.NewClient(&redis.Options{
+    Addr:         "localhost:6379",
+    PoolSize:     50,         // max connections (default: 10 * GOMAXPROCS)
+    MinIdleConns: 10,         // keep warm connections ready
+    PoolTimeout:  30 * time.Second,
+    ReadTimeout:  5 * time.Second,
+    WriteTimeout: 5 * time.Second,
+})
+store := statestore.NewRedisStore(client, statestore.WithTTL(2 * time.Hour))
+```
+
+### When to switch from MemoryStore to RedisStore
+
+- Multi-pod Kubernetes deployments (state must survive pod restarts and be accessible from any pod)
+- Memory pressure on the application pod (offload state to dedicated Redis)
+- Conversations exceeding 10K concurrent on a single process
+- Need for durable state across deploys
+
+The RedisStore uses decomposed storage: metadata, messages, and summaries are stored as separate Redis keys/lists. `Save()` only serializes metadata fully; messages use Redis lists for incremental append. The store falls back to legacy monolithic format for backward compatibility.
+
+---
+
+## 3. Provider / Streaming Tuning
+
+**Source**: `runtime/providers/streaming.go`, `runtime/providers/idle_timeout.go`, `runtime/providers/base_provider.go`, `runtime/providers/retry.go`
+
+| Parameter | Default | Source | Effect |
+|-----------|---------|--------|--------|
+| Stream buffer size | `DefaultStreamBufferSize = 32` | `streaming.go` | Channel buffer for `StreamChunk` between provider goroutine and consumer |
+| Stream idle timeout | `DefaultStreamIdleTimeout = 30s` | `idle_timeout.go` | Max time between stream data reads before closing the connection |
+| Max payload size | `DefaultMaxPayloadSize = 100 MB` | `base_provider.go` | Request body size limit; returns `ErrPayloadTooLarge` when exceeded |
+| Retry attempts | `DefaultMaxRetries = 3` | `retry.go` | Retries on 429/502/503/504 and network errors |
+| Retry initial delay | `DefaultInitialDelayMs = 500` | `retry.go` | Exponential backoff base (with jitter) |
+| Rate limiter | Not set by default | `BaseProvider.SetRateLimit(rps, burst)` | Token bucket rate limiter for outbound requests |
+
+### Stream buffer size
+
+The buffer of 32 prevents the streaming goroutine from blocking on every chunk send when the consumer is slow. For audio pipelines with high chunk rates (~50 chunks/sec), consider the inter-stage buffer sizes instead (see section below).
+
+- **Increase to 64-128** if you see streaming stalls in logs and the consumer processes chunks in batches.
+- **Decrease to 8-16** if memory is constrained and each `StreamChunk` carries large accumulated content strings.
+
+### Stream idle timeout
+
+The `IdleTimeoutReader` wraps the HTTP response body. The timer resets on each successful read. If no data arrives within 30s, the body is closed and `ErrStreamIdleTimeout` is returned.
+
+- **Increase to 60-120s** for providers that have long "thinking" pauses (e.g., complex reasoning models).
+- **Decrease to 10-15s** for latency-sensitive applications where a stalled stream should fail fast.
+
+### Rate limiting
+
+```go
+provider.SetRateLimit(10.0, 5)  // 10 requests/sec, burst of 5
+```
+
+Set this based on your provider's rate limit tier. `WaitForRateLimit()` is called before every HTTP request in `MakeRawRequest()`.
+
+### Audio pipeline buffer sizes
+
+**Source**: `runtime/pipeline/stage/config.go`, `runtime/audio/silence.go`
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| Inter-stage channel buffer | `DefaultChannelBufferSize = 32` | Buffer between pipeline stages |
+| Audio channel buffer | `DefaultAudioChannelBufferSize = 64` | ~1.3s of buffering at 50 chunks/sec |
+| Audio buffer cap | `DefaultMaxAudioBufferSize = 10 MB` | Max size of `SilenceDetector.audioBuffer`; truncated when exceeded |
+
+For duplex audio at scale, use `DefaultAudioChannelBufferSize` for audio pipeline stages to avoid backpressure stalls. The audio buffer cap prevents unbounded memory growth during long utterances.
+
+---
+
+## 4. MCP Tuning
+
+**Source**: `runtime/mcp/registry.go`, `runtime/mcp/client.go`
+
+| Parameter | Default | Option/Field | Effect |
+|-----------|---------|-------------|--------|
+| Max processes | `DefaultMaxProcesses = 0` (unlimited) | `RegistryOptions.MaxProcesses` | Semaphore-based limit on concurrent child processes |
+| Request timeout | 30s | `ClientOptions.RequestTimeout` | Per-RPC request timeout |
+| Init timeout | 10s | `ClientOptions.InitTimeout` | Initialization handshake timeout |
+| Max retries | 3 | `ClientOptions.MaxRetries` | RPC request retries with exponential backoff |
+| Retry delay | 100ms | `ClientOptions.RetryDelay` | Initial backoff delay |
+| Max reconnect attempts | 3 | `ClientOptions.MaxReconnectAttempts` | Auto-reconnection attempts on process death |
+
+### When to adjust
+
+- **Set MaxProcesses** in production to prevent OS resource exhaustion. Each MCP server is a child process with 2+ background goroutines (`readLoop`, `logStderr`). Recommended: set to 2-3x the number of distinct MCP servers you expect to run concurrently.
+
+```go
+registry := mcp.NewRegistryWithOptions(mcp.RegistryOptions{
+    MaxProcesses: 20,
+})
+```
+
+- **Increase request timeout** for MCP tools that perform heavy computation (e.g., code execution sandboxes). Set to 60-120s.
+- **Decrease reconnect attempts** to 0 if you want fail-fast behavior (the caller handles restart logic).
+- **Increase reconnect attempts** to 5 for flaky MCP servers that crash intermittently.
+
+### Symptoms of misconfiguration
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `ErrMaxProcessesReached` errors | `MaxProcesses` too low for workload; increase or share registry across conversations |
+| Goroutine count growing with `readLoop`/`logStderr` stacks | Dead MCP processes not cleaned up; check `MaxReconnectAttempts` |
+| Tool execution timeouts | `RequestTimeout` too short for the tool's workload |
+
+### Sharing MCP registry
+
+In server deployments, create one registry and share it across conversations to avoid O(N) child processes:
+
+```go
+registry, _ := mcp.NewRegistryWithServers(serverConfigs)
+// Pass to each conversation via SDK options
+```
+
+---
+
+## 5. Storage Tuning
+
+### FileStore
+
+**Source**: `runtime/storage/local/filestore.go`
+
+| Parameter | Default | Option | Effect |
+|-----------|---------|--------|--------|
+| Max file size | `DefaultMaxFileSize = 50 MB` | `WithMaxFileSize(n)` | Per-file size limit; returns `ErrFileTooLarge` |
+| Dedup enabled | Configurable | `FileStoreConfig.EnableDeduplication` | SHA-256 content-based deduplication |
+
+### Dedup dirty flag optimization
+
+The `dedupDirty` flag ensures the dedup index is only written to disk when actually modified. Dedup cache hits skip writes entirely. Call `Flush()` explicitly to persist the index before a graceful shutdown.
+
+- For high-throughput media storage, enable dedup to reduce disk usage for duplicate content (e.g., repeated audio chunks).
+- For workloads with unique content, disable dedup to avoid the SHA-256 hashing overhead.
+
+### Policy enforcement
+
+**Source**: `runtime/storage/policy/time_based.go`
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| Enforcement interval | Configurable at construction | Tick interval for background cleanup |
+| Auto-start | `false` | `WithAutoStart(true)` starts enforcement on construction |
+| Base dir | Required for auto-start | `WithBaseDir(dir)` sets the scan directory |
+
+The expiry index (`expiryIndex` map) is built once at startup via `BuildExpiryIndex()` and maintained incrementally via `TrackFile()`/`UntrackFile()`. Subsequent enforcement ticks only check files whose expiry has passed (O(expired) instead of O(total)).
+
+### Recommended config
+
+```go
+handler := policy.NewTimeBasedPolicyHandler(
+    5 * time.Minute,               // enforcement interval
+    policy.WithAutoStart(true),
+    policy.WithBaseDir("/data/media"),
+)
+```
+
+- **Decrease enforcement interval** (to 1 min) for storage-constrained environments where expired files should be cleaned quickly.
+- **Increase enforcement interval** (to 15-30 min) for low-churn environments to reduce disk I/O.
+
+---
+
+## 6. Monitoring Checklist
+
+### Key metrics to expose
+
+| Metric | Source | What it tells you |
+|--------|--------|-------------------|
+| Event bus dropped count | `EventBus.DroppedCount()` | Events lost due to full buffer — indicates undersized buffer or workers |
+| Subscriber timeout count | Log: `"event subscriber timed out"` | Slow subscribers blocking workers |
+| Memory store entry count | `MemoryStore.Len()` | Current state store size; watch for approaching `MaxEntries` |
+| MCP active processes | `RegistryImpl.ActiveProcessCount()` | Current child process count; watch for approaching `MaxProcesses` |
+| Goroutine count | `runtime.NumGoroutine()` | Overall goroutine pressure; alert at 200K+ |
+| Provider retry count | Log: retry attempts from `DoWithRetry()` | Rate limit pressure or provider instability |
+| Stream idle timeouts | Log: `ErrStreamIdleTimeout` occurrences | Provider stalls or network issues |
+| Tool execution timeouts | Log: `ErrToolTimeout` occurrences | Tools exceeding their deadline |
+| Pending tool store size | `PendingStore` count | Unresolved async tool calls; leaks if growing unbounded |
+| Policy expiry index size | `TimeBasedPolicyHandler.ExpiryIndexLen()` | Files tracked for cleanup |
+
+### Prometheus integration pattern
+
+PromptKit does not ship a built-in Prometheus exporter, but metrics can be exposed by subscribing to the event bus and maintaining counters:
+
+```go
+bus := events.NewEventBus()
+
+// Track event throughput
+var eventCount prometheus.Counter
+bus.SubscribeAll(func(e *events.Event) {
+    eventCount.Inc()
+})
+
+// Periodic metric collection
+go func() {
+    ticker := time.NewTicker(15 * time.Second)
+    for range ticker.C {
+        droppedGauge.Set(float64(bus.DroppedCount()))
+        storeEntriesGauge.Set(float64(memStore.Len()))
+        mcpProcessGauge.Set(float64(mcpRegistry.ActiveProcessCount()))
+        goroutineGauge.Set(float64(runtime.NumGoroutine()))
+    }
+}()
+```
+
+---
+
+## 7. Common Issues and Fixes
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Events silently disappearing | Event buffer full, events dropped | Increase `WithEventBufferSize()` to 5000+ or add more workers |
+| `"event subscriber timed out"` warnings | Subscriber doing I/O in callback | Increase `WithSubscriberTimeout()` or make the subscriber async |
+| Memory growing unbounded in long-running process | MemoryStore with no TTL or no eviction interval | Enable `WithMemoryEvictionInterval(1*time.Minute)` and verify TTL is set |
+| `ErrNotFound` on `Resume()` across pods | Using MemoryStore in multi-pod deployment | Switch to `RedisStore` with `sdk.WithStateStore()` |
+| `ErrMaxProcessesReached` on tool calls | MCP process limit too low | Increase `MaxProcesses` or share registry across conversations |
+| Streaming responses cut off mid-way | HTTP client timeout (60s) too short for long responses | Increase provider HTTP client timeout |
+| `ErrStreamIdleTimeout` during long pauses | Provider thinking time exceeds 30s idle timeout | Increase `DefaultStreamIdleTimeout` (requires code change) or use a provider-specific timeout |
+| `ErrPayloadTooLarge` on send | Request body exceeds 100 MB | Reduce message history or media; or increase via `SetMaxPayloadSize()` |
+| `ErrFileTooLarge` on media store | File exceeds 50 MB limit | Increase via `WithMaxFileSize()` or compress before storing |
+| High GC pressure with audio workloads | Frequent `[]int16` allocations in resampling | Already mitigated with `sync.Pool`; verify pool is being used |
+| 429 errors from provider | Missing rate limiter | Configure `provider.SetRateLimit(rps, burst)` based on provider tier |
+| Tool calls running sequentially | `MaxParallelToolCalls` set to 1 | Increase `ToolPolicy.MaxParallelToolCalls` (default 10) |
+| Eval goroutines piling up | More evals dispatched than semaphore allows | Increase `WithMaxConcurrentEvals(n)` (default 10); evals exceeding the limit are skipped with a warning |
+| Conversation history growing without bound | No token budget or context window configured | Set `ContextAssemblyConfig.MaxMessages` (default 200) or configure `TokenBudgetStage` |
+| Disk filling up with expired media | Policy enforcement not running | Use `WithAutoStart(true)` and `WithBaseDir(dir)` on `TimeBasedPolicyHandler` |
+| Full directory walk on every enforcement tick | Expiry index not built | Ensure `BuildExpiryIndex()` is called at startup (automatic with `StartEnforcement()`) |
+
+---
+
+## Quick Reference: All Defaults
+
+| Component | Parameter | Default Value | Code Location |
+|-----------|-----------|---------------|---------------|
+| EventBus | Worker pool size | 10 | `runtime/events/bus.go:15` |
+| EventBus | Event buffer size | 1000 | `runtime/events/bus.go:16` |
+| EventBus | Subscriber timeout | 5s | `runtime/events/bus.go:17` |
+| MemoryStore | TTL | 1 hour | `runtime/statestore/memory.go:54` |
+| MemoryStore | Max entries | 10,000 | `runtime/statestore/memory.go:59` |
+| RedisStore | TTL | 24 hours | `runtime/statestore/redis.go:58` |
+| Streaming | Buffer size | 32 | `runtime/providers/streaming.go:13` |
+| Streaming | Idle timeout | 30s | `runtime/providers/streaming.go:18` |
+| Provider | Max payload | 100 MB | `runtime/providers/base_provider.go:37` |
+| Provider | Max retries | 3 | `runtime/providers/retry.go:20` |
+| Provider | Initial retry delay | 500ms | `runtime/providers/retry.go:21` |
+| MCP | Max processes | 0 (unlimited) | `runtime/mcp/registry.go:14` |
+| MCP | Request timeout | 30s | `runtime/mcp/client.go:38` |
+| MCP | Init timeout | 10s | `runtime/mcp/client.go:39` |
+| MCP | Max reconnect attempts | 3 | `runtime/mcp/client.go:49` |
+| Storage | Max file size | 50 MB | `runtime/storage/local/filestore.go:36` |
+| Tools | Default timeout | 30s (30000ms) | `runtime/tools/registry.go:22` |
+| Tools | Max result size | 1 MB | `runtime/tools/registry.go:26` |
+| Tools | Max parallel tool calls | 10 | `runtime/pipeline/stage/stages_provider.go:24` |
+| Pipeline | Max messages | 200 | `runtime/pipeline/stage/stages_context.go:18` |
+| Pipeline | Warning threshold | 100 messages | `runtime/pipeline/stage/stages_context.go:22` |
+| Pipeline | Channel buffer | 32 | `runtime/pipeline/stage/config.go:11` |
+| Pipeline | Audio channel buffer | 64 | `runtime/pipeline/stage/config.go:14` |
+| Audio | Max audio buffer | 10 MB | `runtime/audio/silence.go:12` |
+| Eval | Max concurrent evals | 10 | `sdk/eval_middleware.go:13` |
+| Pending tools | TTL | 5 min | `sdk/tools/pending.go:15` |
+| Pending tools | Max pending | 1000 | `sdk/tools/pending.go:19` |
+| A2A | Client cache TTL | 30 min | `runtime/a2a/executor.go:29` |
+| A2A | Max cached clients | 100 | `runtime/a2a/executor.go:33` |

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -47,24 +47,24 @@ type ArenaConfigK8s struct {
 // Config represents the main configuration structure
 type Config struct {
 	// File references for YAML serialization
-	PromptConfigs []PromptConfigRef `yaml:"prompt_configs,omitempty" json:"prompt_configs,omitempty"`
-	Providers     []ProviderRef     `yaml:"providers" json:"providers"`
-	Judges        []JudgeRef        `yaml:"judges,omitempty" json:"judges,omitempty"`
-	JudgeDefaults *JudgeDefaults    `yaml:"judge_defaults,omitempty" json:"judge_defaults,omitempty"`
-	Scenarios     []ScenarioRef     `yaml:"scenarios,omitempty" json:"scenarios,omitempty"`
-	Evals         []EvalRef         `yaml:"evals,omitempty" json:"evals,omitempty"`
-	Tools         []ToolRef         `yaml:"tools,omitempty" json:"tools,omitempty"`
+	PromptConfigs  []PromptConfigRef      `yaml:"prompt_configs,omitempty" json:"prompt_configs,omitempty"`
+	Providers      []ProviderRef          `yaml:"providers" json:"providers"`
+	Judges         []JudgeRef             `yaml:"judges,omitempty" json:"judges,omitempty"`
+	JudgeDefaults  *JudgeDefaults         `yaml:"judge_defaults,omitempty" json:"judge_defaults,omitempty"`
+	Scenarios      []ScenarioRef          `yaml:"scenarios,omitempty" json:"scenarios,omitempty"`
+	Evals          []EvalRef              `yaml:"evals,omitempty" json:"evals,omitempty"`
+	Tools          []ToolRef              `yaml:"tools,omitempty" json:"tools,omitempty"`
 	PackEvals      []evals.EvalDef        `yaml:"pack_evals,omitempty" json:"pack_evals,omitempty"`
 	PackAssertions []asrt.AssertionConfig `yaml:"pack_assertions,omitempty" json:"pack_assertions,omitempty"`
-	Workflow      interface{}       `yaml:"workflow,omitempty" json:"workflow,omitempty"`
-	Agents        interface{}       `yaml:"agents,omitempty" json:"agents,omitempty"`
-	Deploy        *DeployConfig     `yaml:"deploy,omitempty" json:"deploy,omitempty"`
-	MCPServers    []MCPServerConfig `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
-	A2AAgents     []A2AAgentConfig  `yaml:"a2a_agents,omitempty" json:"a2a_agents,omitempty"`
-	StateStore    *StateStoreConfig `yaml:"state_store,omitempty" json:"state_store,omitempty"`
-	Defaults      Defaults          `yaml:"defaults" json:"defaults"`
-	SelfPlay      *SelfPlayConfig   `yaml:"self_play,omitempty" json:"self_play,omitempty"`
-	PackFile      string            `yaml:"pack_file,omitempty" json:"pack_file,omitempty"`
+	Workflow       interface{}            `yaml:"workflow,omitempty" json:"workflow,omitempty"`
+	Agents         interface{}            `yaml:"agents,omitempty" json:"agents,omitempty"`
+	Deploy         *DeployConfig          `yaml:"deploy,omitempty" json:"deploy,omitempty"`
+	MCPServers     []MCPServerConfig      `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
+	A2AAgents      []A2AAgentConfig       `yaml:"a2a_agents,omitempty" json:"a2a_agents,omitempty"`
+	StateStore     *StateStoreConfig      `yaml:"state_store,omitempty" json:"state_store,omitempty"`
+	Defaults       Defaults               `yaml:"defaults" json:"defaults"`
+	SelfPlay       *SelfPlayConfig        `yaml:"self_play,omitempty" json:"self_play,omitempty"`
+	PackFile       string                 `yaml:"pack_file,omitempty" json:"pack_file,omitempty"`
 
 	// Inline resource specs (alternative to file refs, merged into LoadedX during load)
 	ProviderSpecs map[string]*Provider    `yaml:"provider_specs,omitempty" json:"provider_specs,omitempty"`
@@ -300,11 +300,13 @@ type SelfPlayRoleGroup struct {
 
 // Defaults contains default configuration values
 type Defaults struct {
-	Temperature float32      `yaml:"temperature,omitempty" json:"temperature,omitempty"`
-	MaxTokens   int          `yaml:"max_tokens,omitempty" json:"max_tokens,omitempty"`
-	Seed        int          `yaml:"seed,omitempty" json:"seed,omitempty"`
-	Concurrency int          `yaml:"concurrency,omitempty" json:"concurrency,omitempty"`
-	Output      OutputConfig `yaml:"output,omitempty" json:"output,omitempty"`
+	Temperature float32 `yaml:"temperature,omitempty" json:"temperature,omitempty"`
+	MaxTokens   int     `yaml:"max_tokens,omitempty" json:"max_tokens,omitempty"`
+	Seed        int     `yaml:"seed,omitempty" json:"seed,omitempty"`
+	Concurrency int     `yaml:"concurrency,omitempty" json:"concurrency,omitempty"`
+	// RunTimeout is the per-run timeout duration (e.g. "5m", "30s"). Defaults to 5m.
+	RunTimeout string       `yaml:"run_timeout,omitempty" json:"run_timeout,omitempty"`
+	Output     OutputConfig `yaml:"output,omitempty" json:"output,omitempty"`
 	// ConfigDir is the base directory for all config files (prompts, providers, scenarios, tools).
 	// If not set, defaults to the directory containing the main config file.
 	// If the main config file path is not known, defaults to current working directory.

--- a/runtime/a2a/executor.go
+++ b/runtime/a2a/executor.go
@@ -24,11 +24,28 @@ const (
 	DefaultA2AInitialDelay = 500 * time.Millisecond
 	DefaultA2AMaxDelay     = 30 * time.Second
 
+	// DefaultClientTTL is the default time-to-live for cached A2A clients.
+	// Clients not used within this duration are evicted from the cache.
+	DefaultClientTTL = 30 * time.Minute
+
+	// DefaultMaxClients is the default maximum number of cached A2A clients.
+	// When exceeded, the least recently used client is evicted.
+	DefaultMaxClients = 100
+
+	// defaultCleanupInterval is the interval between cache cleanup sweeps.
+	defaultCleanupInterval = 5 * time.Minute
+
 	a2aExponentialBase   = 2
 	a2aMaxJitterFraction = 0.5
 	a2aFloat64MantBits   = 53
 	a2aUint64Bits        = 64
 )
+
+// clientEntry wraps a cached Client with usage metadata for TTL-based eviction.
+type clientEntry struct {
+	client   *Client
+	lastUsed time.Time
+}
 
 // RetryPolicy configures retry behavior for the A2A executor.
 type RetryPolicy struct {
@@ -59,22 +76,52 @@ func WithNoRetry() ExecutorOption {
 	return func(e *Executor) { e.retryPolicy = RetryPolicy{MaxRetries: 0} }
 }
 
+// WithClientTTL sets the time-to-live for cached A2A clients.
+// Clients not used within this duration are evicted from the cache.
+func WithClientTTL(d time.Duration) ExecutorOption {
+	return func(e *Executor) { e.clientTTL = d }
+}
+
+// WithMaxClients sets the maximum number of cached A2A clients.
+// When exceeded, the least recently used client is evicted.
+func WithMaxClients(n int) ExecutorOption {
+	return func(e *Executor) { e.maxClients = n }
+}
+
 // Executor implements tools.Executor for A2A agent tools.
 // It dispatches tool calls to remote A2A agents via the A2A client.
+// The executor maintains a cache of A2A clients with TTL-based eviction.
+// Call Close when the executor is no longer needed to release resources.
 type Executor struct {
 	mu          sync.RWMutex
-	clients     map[string]*Client
+	clients     map[string]*clientEntry
 	retryPolicy RetryPolicy
+	clientTTL   time.Duration
+	maxClients  int
+	stopCleanup chan struct{}
+	cleanupDone chan struct{}
+	closed      bool
+
+	// nowFunc is used for testing to control time. Defaults to time.Now.
+	nowFunc func() time.Time
 }
 
 // NewExecutor creates a new A2A executor with optional configuration.
+// The executor starts a background goroutine for cache cleanup.
+// Call Close when the executor is no longer needed.
 func NewExecutor(opts ...ExecutorOption) *Executor {
 	e := &Executor{
 		retryPolicy: DefaultRetryPolicy(),
+		clientTTL:   DefaultClientTTL,
+		maxClients:  DefaultMaxClients,
+		stopCleanup: make(chan struct{}),
+		cleanupDone: make(chan struct{}),
+		nowFunc:     time.Now,
 	}
 	for _, opt := range opts {
 		opt(e)
 	}
+	go e.cleanupLoop(defaultCleanupInterval)
 	return e
 }
 
@@ -293,26 +340,107 @@ func a2aCryptoRandFloat64() float64 {
 	return float64(n) / float64(maxMantissa)
 }
 
+// Close stops the background cleanup goroutine and clears the client cache.
+func (e *Executor) Close() error {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return nil
+	}
+	e.closed = true
+	e.mu.Unlock()
+
+	close(e.stopCleanup)
+	<-e.cleanupDone
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.clients = nil
+	return nil
+}
+
+// cleanupLoop periodically removes stale clients from the cache.
+func (e *Executor) cleanupLoop(interval time.Duration) {
+	defer close(e.cleanupDone)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-e.stopCleanup:
+			return
+		case <-ticker.C:
+			e.evictStale()
+		}
+	}
+}
+
+// evictStale removes clients that have not been used within the TTL.
+func (e *Executor) evictStale() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	now := e.nowFunc()
+	for url, entry := range e.clients {
+		if now.Sub(entry.lastUsed) > e.clientTTL {
+			delete(e.clients, url)
+		}
+	}
+}
+
+// evictLRU removes the least recently used client from the cache.
+// Must be called with e.mu held for writing.
+func (e *Executor) evictLRU() {
+	var oldestURL string
+	var oldestTime time.Time
+
+	for url, entry := range e.clients {
+		if oldestURL == "" || entry.lastUsed.Before(oldestTime) {
+			oldestURL = url
+			oldestTime = entry.lastUsed
+		}
+	}
+
+	if oldestURL != "" {
+		delete(e.clients, oldestURL)
+	}
+}
+
 // getOrCreateClient returns a cached client or creates a new one.
+// It updates the lastUsed timestamp on cache hits and enforces
+// the maximum client count by evicting the least recently used entry.
 func (e *Executor) getOrCreateClient(agentURL string) *Client {
+	now := e.nowFunc()
+
 	e.mu.RLock()
-	if c, ok := e.clients[agentURL]; ok {
+	if entry, ok := e.clients[agentURL]; ok {
 		e.mu.RUnlock()
-		return c
+		// Update lastUsed under write lock.
+		e.mu.Lock()
+		entry.lastUsed = now
+		e.mu.Unlock()
+		return entry.client
 	}
 	e.mu.RUnlock()
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	// Double-check after acquiring write lock
-	if c, ok := e.clients[agentURL]; ok {
-		return c
+	if entry, ok := e.clients[agentURL]; ok {
+		entry.lastUsed = now
+		return entry.client
 	}
 	if e.clients == nil {
-		e.clients = make(map[string]*Client)
+		e.clients = make(map[string]*clientEntry)
 	}
+
+	// Evict LRU if at capacity.
+	if len(e.clients) >= e.maxClients {
+		e.evictLRU()
+	}
+
 	c := NewClient(agentURL)
-	e.clients[agentURL] = c
+	e.clients[agentURL] = &clientEntry{client: c, lastUsed: now}
 	return c
 }
 

--- a/runtime/a2a/executor_cache_test.go
+++ b/runtime/a2a/executor_cache_test.go
@@ -1,0 +1,425 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// newTestExecutor creates an executor with short TTL/intervals for testing.
+// The caller must call Close on the returned executor.
+func newTestExecutor(opts ...ExecutorOption) *Executor {
+	defaults := []ExecutorOption{
+		WithClientTTL(50 * time.Millisecond),
+		WithMaxClients(DefaultMaxClients),
+	}
+	return NewExecutor(append(defaults, opts...)...)
+}
+
+func TestExecutor_Close_StopsCleanup(t *testing.T) {
+	e := NewExecutor()
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// Double close should be safe.
+	if err := e.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestExecutor_Close_ClearsCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		rpcResult(w, req.ID, okTask("task-close"))
+	}))
+	defer srv.Close()
+
+	e := NewExecutor()
+	desc := &tools.ToolDescriptor{
+		Name:      "test-tool",
+		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
+	}
+
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"hello"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	// Verify client is cached.
+	e.mu.RLock()
+	count := len(e.clients)
+	e.mu.RUnlock()
+	if count != 1 {
+		t.Fatalf("cached %d clients before Close, want 1", count)
+	}
+
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// Verify cache is cleared.
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.clients != nil {
+		t.Errorf("clients map should be nil after Close, got %v", e.clients)
+	}
+}
+
+func TestExecutor_TTLEviction(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		rpcResult(w, req.ID, okTask("task-ttl"))
+	}))
+	defer srv.Close()
+
+	// Use a controllable clock.
+	now := time.Now()
+	mu := sync.Mutex{}
+
+	getNow := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	setNow := func(t time.Time) {
+		mu.Lock()
+		defer mu.Unlock()
+		now = t
+	}
+
+	e := NewExecutor(
+		WithClientTTL(10*time.Minute),
+		WithNoRetry(),
+	)
+	e.nowFunc = getNow
+	defer e.Close()
+
+	desc := &tools.ToolDescriptor{
+		Name:      "test-tool",
+		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
+	}
+
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"hello"}`))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	// Client should be cached.
+	e.mu.RLock()
+	count := len(e.clients)
+	e.mu.RUnlock()
+	if count != 1 {
+		t.Fatalf("cached %d clients, want 1", count)
+	}
+
+	// Advance time past TTL and trigger eviction.
+	setNow(now.Add(11 * time.Minute))
+	e.evictStale()
+
+	// Client should be evicted.
+	e.mu.RLock()
+	count = len(e.clients)
+	e.mu.RUnlock()
+	if count != 0 {
+		t.Errorf("cached %d clients after TTL expiry, want 0", count)
+	}
+}
+
+func TestExecutor_TTLEviction_PreservesRecentClients(t *testing.T) {
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		rpcResult(w, req.ID, okTask("task-1"))
+	}))
+	defer srv1.Close()
+
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		rpcResult(w, req.ID, okTask("task-2"))
+	}))
+	defer srv2.Close()
+
+	start := time.Now()
+	now := start
+	mu := sync.Mutex{}
+
+	getNow := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	setNow := func(t time.Time) {
+		mu.Lock()
+		defer mu.Unlock()
+		now = t
+	}
+
+	e := NewExecutor(
+		WithClientTTL(10*time.Minute),
+		WithNoRetry(),
+	)
+	e.nowFunc = getNow
+	defer e.Close()
+
+	desc1 := &tools.ToolDescriptor{
+		Name:      "tool-1",
+		A2AConfig: &tools.A2AConfig{AgentURL: srv1.URL},
+	}
+	desc2 := &tools.ToolDescriptor{
+		Name:      "tool-2",
+		A2AConfig: &tools.A2AConfig{AgentURL: srv2.URL},
+	}
+
+	// Create first client at t=0.
+	_, _ = e.Execute(context.Background(), desc1, json.RawMessage(`{"query":"hello"}`))
+
+	// Advance time by 6 minutes, then create second client.
+	setNow(start.Add(6 * time.Minute))
+	_, _ = e.Execute(context.Background(), desc2, json.RawMessage(`{"query":"hello"}`))
+
+	// Advance to 11 minutes from start — first client is stale (11min > 10min TTL),
+	// second is fresh (5min < 10min TTL).
+	setNow(start.Add(11 * time.Minute))
+	e.evictStale()
+
+	e.mu.RLock()
+	count := len(e.clients)
+	_, hasSrv1 := e.clients[srv1.URL]
+	_, hasSrv2 := e.clients[srv2.URL]
+	e.mu.RUnlock()
+
+	if count != 1 {
+		t.Errorf("cached %d clients, want 1", count)
+	}
+	if hasSrv1 {
+		t.Error("stale client for srv1 should have been evicted")
+	}
+	if !hasSrv2 {
+		t.Error("recent client for srv2 should still be cached")
+	}
+}
+
+func TestExecutor_MaxClientsEvictsLRU(t *testing.T) {
+	servers := make([]*httptest.Server, 3)
+	for i := range servers {
+		servers[i] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			req := decodeRPC(r)
+			rpcResult(w, req.ID, okTask("task-max"))
+		}))
+		defer servers[i].Close()
+	}
+
+	now := time.Now()
+	mu := sync.Mutex{}
+
+	getNow := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	advance := func(d time.Duration) {
+		mu.Lock()
+		defer mu.Unlock()
+		now = now.Add(d)
+	}
+
+	e := NewExecutor(
+		WithMaxClients(2),
+		WithClientTTL(1*time.Hour),
+		WithNoRetry(),
+	)
+	e.nowFunc = getNow
+	defer e.Close()
+
+	// Add first two clients at different times.
+	desc0 := &tools.ToolDescriptor{
+		Name:      "tool-0",
+		A2AConfig: &tools.A2AConfig{AgentURL: servers[0].URL},
+	}
+	_, _ = e.Execute(context.Background(), desc0, json.RawMessage(`{"query":"hello"}`))
+	advance(1 * time.Minute)
+
+	desc1 := &tools.ToolDescriptor{
+		Name:      "tool-1",
+		A2AConfig: &tools.A2AConfig{AgentURL: servers[1].URL},
+	}
+	_, _ = e.Execute(context.Background(), desc1, json.RawMessage(`{"query":"hello"}`))
+	advance(1 * time.Minute)
+
+	// Adding a third client should evict the LRU (servers[0]).
+	desc2 := &tools.ToolDescriptor{
+		Name:      "tool-2",
+		A2AConfig: &tools.A2AConfig{AgentURL: servers[2].URL},
+	}
+	_, _ = e.Execute(context.Background(), desc2, json.RawMessage(`{"query":"hello"}`))
+
+	e.mu.RLock()
+	count := len(e.clients)
+	_, has0 := e.clients[servers[0].URL]
+	_, has1 := e.clients[servers[1].URL]
+	_, has2 := e.clients[servers[2].URL]
+	e.mu.RUnlock()
+
+	if count != 2 {
+		t.Errorf("cached %d clients, want 2", count)
+	}
+	if has0 {
+		t.Error("LRU client for server[0] should have been evicted")
+	}
+	if !has1 {
+		t.Error("client for server[1] should still be cached")
+	}
+	if !has2 {
+		t.Error("new client for server[2] should be cached")
+	}
+}
+
+func TestExecutor_MaxClientsEvictsLRU_WithRecentAccess(t *testing.T) {
+	servers := make([]*httptest.Server, 3)
+	for i := range servers {
+		servers[i] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			req := decodeRPC(r)
+			rpcResult(w, req.ID, okTask("task-lru"))
+		}))
+		defer servers[i].Close()
+	}
+
+	now := time.Now()
+	mu := sync.Mutex{}
+
+	getNow := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	advance := func(d time.Duration) {
+		mu.Lock()
+		defer mu.Unlock()
+		now = now.Add(d)
+	}
+
+	e := NewExecutor(
+		WithMaxClients(2),
+		WithClientTTL(1*time.Hour),
+		WithNoRetry(),
+	)
+	e.nowFunc = getNow
+	defer e.Close()
+
+	desc0 := &tools.ToolDescriptor{
+		Name:      "tool-0",
+		A2AConfig: &tools.A2AConfig{AgentURL: servers[0].URL},
+	}
+	desc1 := &tools.ToolDescriptor{
+		Name:      "tool-1",
+		A2AConfig: &tools.A2AConfig{AgentURL: servers[1].URL},
+	}
+
+	// Add two clients.
+	_, _ = e.Execute(context.Background(), desc0, json.RawMessage(`{"query":"hello"}`))
+	advance(1 * time.Minute)
+	_, _ = e.Execute(context.Background(), desc1, json.RawMessage(`{"query":"hello"}`))
+	advance(1 * time.Minute)
+
+	// Re-access server[0] so it becomes more recent than server[1].
+	_, _ = e.Execute(context.Background(), desc0, json.RawMessage(`{"query":"hello"}`))
+	advance(1 * time.Minute)
+
+	// Adding a third client should evict server[1] (the actual LRU).
+	desc2 := &tools.ToolDescriptor{
+		Name:      "tool-2",
+		A2AConfig: &tools.A2AConfig{AgentURL: servers[2].URL},
+	}
+	_, _ = e.Execute(context.Background(), desc2, json.RawMessage(`{"query":"hello"}`))
+
+	e.mu.RLock()
+	_, has0 := e.clients[servers[0].URL]
+	_, has1 := e.clients[servers[1].URL]
+	_, has2 := e.clients[servers[2].URL]
+	e.mu.RUnlock()
+
+	if !has0 {
+		t.Error("recently accessed client for server[0] should still be cached")
+	}
+	if has1 {
+		t.Error("LRU client for server[1] should have been evicted")
+	}
+	if !has2 {
+		t.Error("new client for server[2] should be cached")
+	}
+}
+
+func TestExecutor_WithClientTTL(t *testing.T) {
+	e := NewExecutor(WithClientTTL(5 * time.Minute))
+	defer e.Close()
+	if e.clientTTL != 5*time.Minute {
+		t.Errorf("clientTTL = %v, want 5m", e.clientTTL)
+	}
+}
+
+func TestExecutor_WithMaxClients(t *testing.T) {
+	e := NewExecutor(WithMaxClients(50))
+	defer e.Close()
+	if e.maxClients != 50 {
+		t.Errorf("maxClients = %d, want 50", e.maxClients)
+	}
+}
+
+func TestExecutor_DefaultCacheSettings(t *testing.T) {
+	e := NewExecutor()
+	defer e.Close()
+	if e.clientTTL != DefaultClientTTL {
+		t.Errorf("clientTTL = %v, want %v", e.clientTTL, DefaultClientTTL)
+	}
+	if e.maxClients != DefaultMaxClients {
+		t.Errorf("maxClients = %d, want %d", e.maxClients, DefaultMaxClients)
+	}
+}
+
+func TestExecutor_GetOrCreateClient_UpdatesLastUsed(t *testing.T) {
+	now := time.Now()
+	mu := sync.Mutex{}
+
+	getNow := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	e := NewExecutor(WithNoRetry())
+	e.nowFunc = getNow
+	defer e.Close()
+
+	// Create a client.
+	_ = e.getOrCreateClient("http://example.com")
+
+	e.mu.RLock()
+	entry := e.clients["http://example.com"]
+	initialTime := entry.lastUsed
+	e.mu.RUnlock()
+
+	// Advance time and access again.
+	mu.Lock()
+	now = now.Add(5 * time.Minute)
+	mu.Unlock()
+
+	_ = e.getOrCreateClient("http://example.com")
+
+	e.mu.RLock()
+	updatedTime := e.clients["http://example.com"].lastUsed
+	e.mu.RUnlock()
+
+	if !updatedTime.After(initialTime) {
+		t.Errorf("lastUsed was not updated: initial=%v, updated=%v", initialTime, updatedTime)
+	}
+}

--- a/runtime/a2a/executor_retry_test.go
+++ b/runtime/a2a/executor_retry_test.go
@@ -44,6 +44,7 @@ func TestExecutor_RetryOn502(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -84,6 +85,7 @@ func TestExecutor_RetryOn503(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -116,6 +118,7 @@ func TestExecutor_RetryOn504(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -143,6 +146,7 @@ func TestExecutor_NoRetryOn400(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -171,6 +175,7 @@ func TestExecutor_NoRetryOnRPCError(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -198,6 +203,7 @@ func TestExecutor_RetryExhausted(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -229,6 +235,7 @@ func TestExecutor_NoRetryOnContextCanceled(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -249,6 +256,7 @@ func TestExecutor_WithNoRetry(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor(WithNoRetry())
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -277,6 +285,7 @@ func TestExecutor_RetryOnConnectionRefused(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: "http://" + addr},
@@ -408,6 +417,7 @@ func TestExecutor_RetryOn429(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -436,6 +446,7 @@ func TestExecutor_RetrySucceedsFirstAttempt(t *testing.T) {
 		InitialDelay: 1 * time.Millisecond,
 		MaxDelay:     10 * time.Millisecond,
 	}))
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},

--- a/runtime/a2a/executor_test.go
+++ b/runtime/a2a/executor_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestExecutor_Name(t *testing.T) {
 	e := NewExecutor()
+	defer e.Close()
 	if got := e.Name(); got != "a2a" {
 		t.Errorf("Name() = %q, want %q", got, "a2a")
 	}
@@ -19,6 +20,7 @@ func TestExecutor_Name(t *testing.T) {
 
 func TestExecutor_Execute_NoA2AConfig(t *testing.T) {
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{Name: "test-tool"}
 	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"hello"}`))
 	if err == nil {
@@ -49,6 +51,7 @@ func TestExecutor_Execute_BasicTextQuery(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name: "a2a__research_agent__search",
 		A2AConfig: &tools.A2AConfig{
@@ -92,6 +95,7 @@ func TestExecutor_Execute_ArtifactFallback(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -126,6 +130,7 @@ func TestExecutor_Execute_EmptyResponse(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -147,6 +152,7 @@ func TestExecutor_Execute_EmptyResponse(t *testing.T) {
 
 func TestExecutor_Execute_InvalidArgs(t *testing.T) {
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: "http://localhost:1"},
@@ -181,6 +187,7 @@ func TestExecutor_Execute_WithSkillIDMetadata(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name: "test-tool",
 		A2AConfig: &tools.A2AConfig{
@@ -225,6 +232,7 @@ func TestExecutor_Execute_NoSkillIDMetadata(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -263,6 +271,7 @@ func TestExecutor_Execute_WithMediaParts(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -310,6 +319,7 @@ func TestExecutor_ClientCaching(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
@@ -340,6 +350,7 @@ func TestExecutor_Execute_ServerError(t *testing.T) {
 	defer srv.Close()
 
 	e := NewExecutor()
+	defer e.Close()
 	desc := &tools.ToolDescriptor{
 		Name:      "test-tool",
 		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},

--- a/runtime/audio/resample.go
+++ b/runtime/audio/resample.go
@@ -4,7 +4,38 @@ package audio
 import (
 	"encoding/binary"
 	"fmt"
+	"sync"
 )
+
+// defaultPoolSliceCap is the default capacity for pooled sample slices.
+// 4096 samples covers ~170ms at 24kHz, a reasonable default for typical audio chunks.
+const defaultPoolSliceCap = 4096
+
+// resamplePool provides pooled []int16 slices for resampling to reduce GC pressure.
+var resamplePool = sync.Pool{
+	New: func() any {
+		s := make([]int16, 0, defaultPoolSliceCap)
+		return &s
+	},
+}
+
+// getInt16Slice retrieves a pooled []int16 slice and resets it to the requested size.
+func getInt16Slice(size int) *[]int16 {
+	sp := resamplePool.Get().(*[]int16)
+	if cap(*sp) < size {
+		*sp = make([]int16, size)
+	} else {
+		*sp = (*sp)[:size]
+	}
+	return sp
+}
+
+// putInt16Slice returns a []int16 slice to the pool after clearing it.
+func putInt16Slice(sp *[]int16) {
+	// Reset length to zero but keep capacity
+	*sp = (*sp)[:0]
+	resamplePool.Put(sp)
+}
 
 // Standard audio sample rates for common use cases.
 const (
@@ -44,16 +75,22 @@ func ResamplePCM16(input []byte, fromRate, toRate int) ([]byte, error) {
 		return []byte{}, nil
 	}
 
-	// Convert input bytes to samples
+	// Convert input bytes to samples using pooled slices to reduce GC pressure.
 	// Note: The uint16->int16 conversion is safe because PCM16 audio uses
 	// the full int16 range (-32768 to 32767) stored as unsigned bytes.
-	inputSamples := make([]int16, numInputSamples)
+	inputSamplesPtr := getInt16Slice(numInputSamples)
+	defer putInt16Slice(inputSamplesPtr)
+	inputSamples := *inputSamplesPtr
+
 	for i := 0; i < numInputSamples; i++ {
 		inputSamples[i] = int16(binary.LittleEndian.Uint16(input[i*bytesPerSample:])) //nolint:gosec // Safe PCM16 conversion
 	}
 
 	// Resample using linear interpolation
-	outputSamples := make([]int16, numOutputSamples)
+	outputSamplesPtr := getInt16Slice(numOutputSamples)
+	defer putInt16Slice(outputSamplesPtr)
+	outputSamples := *outputSamplesPtr
+
 	ratio := float64(fromRate) / float64(toRate)
 
 	for i := 0; i < numOutputSamples; i++ {

--- a/runtime/audio/resample_test.go
+++ b/runtime/audio/resample_test.go
@@ -2,8 +2,83 @@ package audio
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 )
+
+// BenchmarkResamplePCM16_Pooled benchmarks resampling with pooled buffers (current implementation).
+func BenchmarkResamplePCM16_Pooled(b *testing.B) {
+	// 20ms of audio at 24kHz = 480 samples = 960 bytes (typical real-time chunk)
+	numSamples := 480
+	input := make([]byte, numSamples*2)
+	for i := 0; i < numSamples; i++ {
+		binary.LittleEndian.PutUint16(input[i*2:], uint16(i%32768))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := ResamplePCM16(input, SampleRate24kHz, SampleRate16kHz)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkResamplePCM16_LargeChunk benchmarks resampling a larger audio chunk.
+func BenchmarkResamplePCM16_LargeChunk(b *testing.B) {
+	// 1 second of audio at 24kHz = 24000 samples = 48000 bytes
+	numSamples := 24000
+	input := make([]byte, numSamples*2)
+	for i := 0; i < numSamples; i++ {
+		binary.LittleEndian.PutUint16(input[i*2:], uint16(i%32768))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := ResamplePCM16(input, SampleRate24kHz, SampleRate16kHz)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestResamplePCM16_ConcurrentPoolSafety(t *testing.T) {
+	// Verify that pooled buffers don't cause data corruption under concurrent use
+	numSamples := 100
+	input := make([]byte, numSamples*2)
+	for i := 0; i < numSamples; i++ {
+		binary.LittleEndian.PutUint16(input[i*2:], uint16(i*100))
+	}
+
+	const goroutines = 10
+	errs := make(chan error, goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			for i := 0; i < 50; i++ {
+				output, err := ResamplePCM16(input, SampleRate24kHz, SampleRate16kHz)
+				if err != nil {
+					errs <- err
+					return
+				}
+				expectedSamples := int(float64(numSamples) * float64(SampleRate16kHz) / float64(SampleRate24kHz))
+				if len(output)/2 != expectedSamples {
+					errs <- fmt.Errorf("unexpected output samples: got %d, want %d", len(output)/2, expectedSamples)
+					return
+				}
+			}
+			errs <- nil
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent resample failed: %v", err)
+		}
+	}
+}
 
 func TestResamplePCM16_SameRate(t *testing.T) {
 	// Create a simple sine wave pattern

--- a/runtime/audio/silence.go
+++ b/runtime/audio/silence.go
@@ -2,15 +2,25 @@ package audio
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 )
+
+// DefaultMaxAudioBufferSize is the maximum size of the audio buffer in bytes.
+// At 16kHz/16-bit mono (32KB/s), 10MB holds approximately 5 minutes of audio.
+const DefaultMaxAudioBufferSize = 10 * 1024 * 1024
 
 // SilenceDetector detects turn boundaries based on silence duration.
 // It triggers end-of-turn when silence exceeds a configurable threshold.
 type SilenceDetector struct {
 	// Threshold is the silence duration required to trigger turn end.
 	Threshold time.Duration
+
+	// MaxBufferSize is the maximum audio buffer size in bytes.
+	// When exceeded, the oldest audio data is discarded to stay within the limit.
+	// Default: DefaultMaxAudioBufferSize (10MB).
+	MaxBufferSize int
 
 	mu           sync.RWMutex
 	silenceStart time.Time
@@ -23,15 +33,31 @@ type SilenceDetector struct {
 	hadSpeech    bool // Track if we've had any speech this turn
 }
 
+// SilenceDetectorOption configures a SilenceDetector.
+type SilenceDetectorOption func(*SilenceDetector)
+
+// WithMaxAudioBufferSize sets the maximum audio buffer size in bytes.
+// When the buffer exceeds this limit, the oldest data is trimmed.
+func WithMaxAudioBufferSize(size int) SilenceDetectorOption {
+	return func(d *SilenceDetector) {
+		d.MaxBufferSize = size
+	}
+}
+
 // NewSilenceDetector creates a SilenceDetector with the given threshold.
 // threshold is the duration of silence required to trigger end-of-turn.
-func NewSilenceDetector(threshold time.Duration) *SilenceDetector {
-	return &SilenceDetector{
-		Threshold:    threshold,
-		silenceStart: time.Now(),
-		inSilence:    true,
-		lastVADState: VADStateQuiet,
+func NewSilenceDetector(threshold time.Duration, opts ...SilenceDetectorOption) *SilenceDetector {
+	d := &SilenceDetector{
+		Threshold:     threshold,
+		MaxBufferSize: DefaultMaxAudioBufferSize,
+		silenceStart:  time.Now(),
+		inSilence:     true,
+		lastVADState:  VADStateQuiet,
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
 }
 
 // Name returns the detector identifier.
@@ -47,6 +73,17 @@ func (d *SilenceDetector) ProcessAudio(ctx context.Context, audio []byte) (bool,
 	// Accumulate audio if we're tracking a turn
 	if d.userSpeaking || d.hadSpeech {
 		d.audioBuffer = append(d.audioBuffer, audio...)
+
+		// Cap the buffer to MaxBufferSize, keeping the most recent data
+		if d.MaxBufferSize > 0 && len(d.audioBuffer) > d.MaxBufferSize {
+			excess := len(d.audioBuffer) - d.MaxBufferSize
+			copy(d.audioBuffer, d.audioBuffer[excess:])
+			d.audioBuffer = d.audioBuffer[:d.MaxBufferSize]
+			slog.Warn("audio buffer exceeded max size, trimmed oldest data",
+				"excess_bytes", excess,
+				"max_buffer_size", d.MaxBufferSize,
+			)
+		}
 	}
 	d.mu.Unlock()
 

--- a/runtime/audio/silence_test.go
+++ b/runtime/audio/silence_test.go
@@ -184,6 +184,93 @@ func TestSilenceDetector_SetTranscript(t *testing.T) {
 	}
 }
 
+func TestSilenceDetector_WithMaxAudioBufferSize(t *testing.T) {
+	d := NewSilenceDetector(500*time.Millisecond, WithMaxAudioBufferSize(1024))
+	if d.MaxBufferSize != 1024 {
+		t.Errorf("MaxBufferSize = %d, want 1024", d.MaxBufferSize)
+	}
+}
+
+func TestSilenceDetector_DefaultMaxBufferSize(t *testing.T) {
+	d := NewSilenceDetector(500 * time.Millisecond)
+	if d.MaxBufferSize != DefaultMaxAudioBufferSize {
+		t.Errorf("MaxBufferSize = %d, want %d", d.MaxBufferSize, DefaultMaxAudioBufferSize)
+	}
+}
+
+func TestSilenceDetector_BufferCapTruncation(t *testing.T) {
+	maxSize := 10
+	d := NewSilenceDetector(500*time.Millisecond, WithMaxAudioBufferSize(maxSize))
+
+	// Start speaking so audio accumulates
+	d.ProcessVADState(context.Background(), VADStateSpeaking)
+
+	// Add data that will exceed the cap
+	chunk1 := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	chunk2 := []byte{9, 10, 11, 12, 13}
+	d.ProcessAudio(context.Background(), chunk1)
+	d.ProcessAudio(context.Background(), chunk2)
+
+	// Total would be 13 bytes, but max is 10. Should keep the most recent 10 bytes.
+	audio := d.GetAccumulatedAudio()
+	if len(audio) != maxSize {
+		t.Fatalf("buffer length = %d, want %d", len(audio), maxSize)
+	}
+
+	// Should contain the last 10 bytes: [4,5,6,7,8,9,10,11,12,13]
+	expected := []byte{4, 5, 6, 7, 8, 9, 10, 11, 12, 13}
+	for i, v := range expected {
+		if audio[i] != v {
+			t.Errorf("audio[%d] = %d, want %d", i, audio[i], v)
+		}
+	}
+}
+
+func TestSilenceDetector_BufferCapMultipleOverflows(t *testing.T) {
+	maxSize := 5
+	d := NewSilenceDetector(500*time.Millisecond, WithMaxAudioBufferSize(maxSize))
+
+	d.ProcessVADState(context.Background(), VADStateSpeaking)
+
+	// Overflow multiple times
+	for i := 0; i < 10; i++ {
+		d.ProcessAudio(context.Background(), []byte{byte(i), byte(i + 10)})
+	}
+
+	audio := d.GetAccumulatedAudio()
+	if len(audio) != maxSize {
+		t.Fatalf("buffer length = %d, want %d", len(audio), maxSize)
+	}
+}
+
+func TestSilenceDetector_BufferCapExactFit(t *testing.T) {
+	maxSize := 8
+	d := NewSilenceDetector(500*time.Millisecond, WithMaxAudioBufferSize(maxSize))
+
+	d.ProcessVADState(context.Background(), VADStateSpeaking)
+
+	// Add exactly maxSize bytes -- should not trigger trimming
+	d.ProcessAudio(context.Background(), make([]byte, maxSize))
+
+	audio := d.GetAccumulatedAudio()
+	if len(audio) != maxSize {
+		t.Fatalf("buffer length = %d, want %d", len(audio), maxSize)
+	}
+}
+
+func TestSilenceDetector_BufferCapUnderLimit(t *testing.T) {
+	maxSize := 100
+	d := NewSilenceDetector(500*time.Millisecond, WithMaxAudioBufferSize(maxSize))
+
+	d.ProcessVADState(context.Background(), VADStateSpeaking)
+	d.ProcessAudio(context.Background(), []byte{1, 2, 3})
+
+	audio := d.GetAccumulatedAudio()
+	if len(audio) != 3 {
+		t.Fatalf("buffer length = %d, want 3", len(audio))
+	}
+}
+
 func TestSilenceDetector_Reset(t *testing.T) {
 	d := NewSilenceDetector(500 * time.Millisecond)
 

--- a/runtime/events/bus.go
+++ b/runtime/events/bus.go
@@ -67,6 +67,8 @@ type listenerEntry struct {
 }
 
 // EventBus manages event distribution to listeners via a fixed-size worker pool.
+// Workers are started lazily on the first Subscribe/SubscribeAll call to avoid
+// spawning goroutines when no one is listening.
 type EventBus struct {
 	mu              sync.RWMutex
 	listeners       map[EventType][]listenerEntry
@@ -77,13 +79,20 @@ type EventBus struct {
 	eventCh           chan *Event
 	wg                sync.WaitGroup
 	closed            atomic.Bool
+	started           atomic.Bool // true once workers have been launched
 	droppedCount      atomic.Int64
 	subscriberTimeout time.Duration
+
+	// Saved config for lazy worker startup.
+	workerPoolSize int
 }
 
 // NewEventBus creates a new event bus with a worker pool.
 // Options can be provided to configure pool size and buffer capacity.
 // The zero-argument form uses sensible defaults and is fully backward-compatible.
+//
+// Workers are started lazily: goroutines are only spawned when the first
+// subscriber is added via Subscribe or SubscribeAll.
 func NewEventBus(opts ...BusOption) *EventBus {
 	cfg := &busConfig{
 		workerPoolSize:    DefaultWorkerPoolSize,
@@ -98,14 +107,21 @@ func NewEventBus(opts ...BusOption) *EventBus {
 		listeners:         make(map[EventType][]listenerEntry),
 		eventCh:           make(chan *Event, cfg.eventBufferSize),
 		subscriberTimeout: cfg.subscriberTimeout,
-	}
-
-	eb.wg.Add(cfg.workerPoolSize)
-	for range cfg.workerPoolSize {
-		go eb.worker()
+		workerPoolSize:    cfg.workerPoolSize,
 	}
 
 	return eb
+}
+
+// ensureStarted launches workers if they haven't been started yet.
+// Caller must NOT hold eb.mu (this method is lock-free via atomic CAS).
+func (eb *EventBus) ensureStarted() {
+	if eb.started.CompareAndSwap(false, true) {
+		eb.wg.Add(eb.workerPoolSize)
+		for range eb.workerPoolSize {
+			go eb.worker()
+		}
+	}
 }
 
 // worker processes events from the buffered channel.
@@ -117,9 +133,27 @@ func (eb *EventBus) worker() {
 }
 
 // dispatch delivers an event to all matching listeners.
+// If an event store is configured, the event is persisted asynchronously here
+// (in the worker goroutine) rather than in the Publish() caller's goroutine,
+// keeping the publish path fast.
 // Each listener is invoked with a timeout; if a listener exceeds the subscriber
 // timeout it is skipped and a warning is logged.
 func (eb *EventBus) dispatch(event *Event) {
+	// Persist to store if configured (asynchronous — runs in worker goroutine)
+	eb.mu.RLock()
+	store := eb.store
+	eb.mu.RUnlock()
+
+	if store != nil && event.SessionID != "" {
+		if err := store.Append(context.Background(), event); err != nil {
+			logger.Warn("event store append failed",
+				"event_type", string(event.Type),
+				"session_id", event.SessionID,
+				"error", err,
+			)
+		}
+	}
+
 	eb.mu.RLock()
 	typeListeners := eb.listeners[event.Type]
 
@@ -159,10 +193,16 @@ func (eb *EventBus) invokeWithTimeout(listener Listener, event *Event) {
 }
 
 // WithStore returns the event bus configured with the given store for persistence.
+// If a non-nil store is provided, workers are started immediately since store
+// writes happen in the dispatch worker goroutine.
 func (eb *EventBus) WithStore(store EventStore) *EventBus {
 	eb.mu.Lock()
-	defer eb.mu.Unlock()
 	eb.store = store
+	eb.mu.Unlock()
+
+	if store != nil {
+		eb.ensureStarted()
+	}
 	return eb
 }
 
@@ -175,7 +215,10 @@ func (eb *EventBus) Store() EventStore {
 
 // Subscribe registers a listener for a specific event type and returns
 // an unsubscribe function that removes the listener when called.
+// On the first call, workers are started lazily.
 func (eb *EventBus) Subscribe(eventType EventType, listener Listener) func() {
+	eb.ensureStarted()
+
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
 
@@ -200,7 +243,10 @@ func (eb *EventBus) Subscribe(eventType EventType, listener Listener) func() {
 
 // SubscribeAll registers a listener for all event types and returns
 // an unsubscribe function that removes the listener when called.
+// On the first call, workers are started lazily.
 func (eb *EventBus) SubscribeAll(listener Listener) func() {
+	eb.ensureStarted()
+
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
 
@@ -224,21 +270,11 @@ func (eb *EventBus) SubscribeAll(listener Listener) func() {
 
 // Publish sends an event to the worker pool for asynchronous delivery to all
 // registered listeners. If a store is configured, the event is persisted
-// synchronously before being queued for dispatch.
+// asynchronously in the dispatch worker (not in the caller's goroutine).
 // Returns false if the bus has been closed.
 func (eb *EventBus) Publish(event *Event) bool {
 	if eb.closed.Load() {
 		return false
-	}
-
-	eb.mu.RLock()
-	store := eb.store
-	eb.mu.RUnlock()
-
-	// Persist to store if configured (synchronous to ensure ordering)
-	if store != nil && event.SessionID != "" {
-		// Use background context for persistence - don't block on caller context
-		_ = store.Append(context.Background(), event)
 	}
 
 	// Non-blocking send: if the buffer is full, drop the event rather than blocking
@@ -266,10 +302,19 @@ func (eb *EventBus) DroppedCount() int64 {
 // Close shuts down the event bus gracefully. It closes the event channel and
 // waits for all workers to finish processing remaining events.
 // After Close returns, Publish calls will return false.
+// If no workers were ever started (no subscribers), Close simply marks the bus
+// as closed and drains any buffered events.
 func (eb *EventBus) Close() {
 	if eb.closed.CompareAndSwap(false, true) {
 		close(eb.eventCh)
-		eb.wg.Wait()
+		if eb.started.Load() {
+			eb.wg.Wait()
+		} else {
+			// Drain any buffered events that were published before Close
+			// when no workers were started.
+			for range eb.eventCh { //nolint:revive // intentional drain
+			}
+		}
 	}
 }
 

--- a/runtime/events/bus_test.go
+++ b/runtime/events/bus_test.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -537,6 +539,242 @@ func TestEventBusDroppedCountRateLimitedLogging(t *testing.T) {
 
 	close(blockCh)
 }
+
+func TestEventBusLazyWorkerStartup(t *testing.T) {
+	t.Parallel()
+
+	// NewEventBus should NOT start workers immediately.
+	bus := NewEventBus()
+	defer bus.Close()
+
+	if bus.started.Load() {
+		t.Fatal("expected workers to NOT be started before any subscription")
+	}
+
+	// Subscribe should trigger worker startup.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventPipelineStarted, func(*Event) {
+		wg.Done()
+	})
+
+	if !bus.started.Load() {
+		t.Fatal("expected workers to be started after Subscribe")
+	}
+
+	bus.Publish(&Event{Type: EventPipelineStarted})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event after lazy start")
+	}
+}
+
+func TestEventBusLazyWorkerStartupViaSubscribeAll(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	defer bus.Close()
+
+	if bus.started.Load() {
+		t.Fatal("expected workers to NOT be started before any subscription")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.SubscribeAll(func(*Event) {
+		wg.Done()
+	})
+
+	if !bus.started.Load() {
+		t.Fatal("expected workers to be started after SubscribeAll")
+	}
+
+	bus.Publish(&Event{Type: EventPipelineStarted})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event after lazy start via SubscribeAll")
+	}
+}
+
+func TestEventBusCloseWithoutSubscribers(t *testing.T) {
+	t.Parallel()
+
+	// Create bus, publish events, close — no subscribers ever added.
+	bus := NewEventBus()
+
+	bus.Publish(&Event{Type: EventPipelineStarted})
+	bus.Publish(&Event{Type: EventPipelineStarted})
+
+	// Close should not hang even though no workers were started.
+	done := make(chan struct{})
+	go func() {
+		bus.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() hung when no subscribers were ever added")
+	}
+
+	if !bus.closed.Load() {
+		t.Fatal("expected bus to be closed")
+	}
+}
+
+func TestEventBusStoreWriteInDispatchWorker(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus(WithWorkerPoolSize(1))
+	defer bus.Close()
+
+	// Use a mock store that records which goroutine Append runs on.
+	store := &goroutineTrackingStore{}
+	bus.WithStore(store)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventPipelineStarted, func(*Event) {
+		wg.Done()
+	})
+
+	// Publish from the test goroutine.
+	bus.Publish(&Event{Type: EventPipelineStarted, SessionID: "test-session"})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event")
+	}
+
+	// Verify store.Append was called.
+	if store.appendCount.Load() != 1 {
+		t.Fatalf("expected 1 store append, got %d", store.appendCount.Load())
+	}
+}
+
+func TestEventBusStoreWriteSkipsEmptySessionID(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus(WithWorkerPoolSize(1))
+	defer bus.Close()
+
+	store := &goroutineTrackingStore{}
+	bus.WithStore(store)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventPipelineStarted, func(*Event) {
+		wg.Done()
+	})
+
+	// Publish event without SessionID — store should NOT be called.
+	bus.Publish(&Event{Type: EventPipelineStarted})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event")
+	}
+
+	if store.appendCount.Load() != 0 {
+		t.Fatalf("expected 0 store appends for empty session ID, got %d", store.appendCount.Load())
+	}
+}
+
+func TestEventBusStoreAppendErrorLogged(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus(WithWorkerPoolSize(1))
+	defer bus.Close()
+
+	store := &failingStore{}
+	bus.WithStore(store)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventPipelineStarted, func(*Event) {
+		wg.Done()
+	})
+
+	// Even though store.Append fails, the event should still be dispatched to listeners.
+	bus.Publish(&Event{Type: EventPipelineStarted, SessionID: "test-session"})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("listener should fire even when store.Append fails")
+	}
+}
+
+func TestEventBusEnsureStartedIdempotent(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus(WithWorkerPoolSize(2))
+	defer bus.Close()
+
+	// Call ensureStarted multiple times — should only start workers once.
+	bus.ensureStarted()
+	bus.ensureStarted()
+	bus.ensureStarted()
+
+	if !bus.started.Load() {
+		t.Fatal("expected started to be true after ensureStarted")
+	}
+
+	// Verify bus still works correctly.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventPipelineStarted, func(*Event) {
+		wg.Done()
+	})
+
+	bus.Publish(&Event{Type: EventPipelineStarted})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event after multiple ensureStarted calls")
+	}
+}
+
+// goroutineTrackingStore is a mock EventStore that counts Append calls.
+type goroutineTrackingStore struct {
+	appendCount atomic.Int32
+}
+
+func (s *goroutineTrackingStore) Append(_ context.Context, _ *Event) error {
+	s.appendCount.Add(1)
+	return nil
+}
+
+func (s *goroutineTrackingStore) Query(context.Context, *EventFilter) ([]*Event, error) {
+	return nil, nil
+}
+
+func (s *goroutineTrackingStore) QueryRaw(context.Context, *EventFilter) ([]*StoredEvent, error) {
+	return nil, nil
+}
+
+func (s *goroutineTrackingStore) Stream(context.Context, string) (<-chan *Event, error) {
+	ch := make(chan *Event)
+	close(ch)
+	return ch, nil
+}
+
+func (s *goroutineTrackingStore) Close() error { return nil }
+
+// failingStore is a mock EventStore whose Append always returns an error.
+type failingStore struct{}
+
+func (s *failingStore) Append(context.Context, *Event) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (s *failingStore) Query(context.Context, *EventFilter) ([]*Event, error) { return nil, nil }
+
+func (s *failingStore) QueryRaw(context.Context, *EventFilter) ([]*StoredEvent, error) {
+	return nil, nil
+}
+
+func (s *failingStore) Stream(context.Context, string) (<-chan *Event, error) {
+	ch := make(chan *Event)
+	close(ch)
+	return ch, nil
+}
+
+func (s *failingStore) Close() error { return nil }
 
 func waitForWG(wg *sync.WaitGroup, timeout time.Duration) bool {
 	done := make(chan struct{})

--- a/runtime/events/store_test.go
+++ b/runtime/events/store_test.go
@@ -297,6 +297,10 @@ func TestEventBus_WithStore(t *testing.T) {
 	}
 	bus.Publish(event)
 
+	// Close the bus to ensure the worker finishes processing the event
+	// (store writes are now asynchronous in the dispatch worker).
+	bus.Close()
+
 	// Sync to disk
 	require.NoError(t, store.Sync())
 

--- a/runtime/mcp/client.go
+++ b/runtime/mcp/client.go
@@ -27,6 +27,9 @@ type ClientOptions struct {
 	RetryDelay time.Duration
 	// EnableGracefulDegradation allows operations to continue even if MCP is unavailable
 	EnableGracefulDegradation bool
+	// MaxReconnectAttempts is the maximum number of times to attempt reconnection
+	// when a process death is detected. 0 disables auto-reconnection.
+	MaxReconnectAttempts int
 }
 
 // DefaultClientOptions returns sensible defaults
@@ -37,8 +40,18 @@ func DefaultClientOptions() ClientOptions {
 		MaxRetries:                3,
 		RetryDelay:                100 * time.Millisecond,
 		EnableGracefulDegradation: true,
+		MaxReconnectAttempts:      defaultMaxReconnectAttempts,
 	}
 }
+
+const (
+	// defaultMaxReconnectAttempts is the default number of reconnection attempts.
+	defaultMaxReconnectAttempts = 3
+	// reconnectPollInterval is the polling interval when waiting for a concurrent reconnection.
+	reconnectPollInterval = 100 * time.Millisecond
+	// reconnectPollMaxIterations is the max iterations to poll for concurrent reconnection.
+	reconnectPollMaxIterations = 50
+)
 
 var (
 	// ErrClientNotInitialized is returned when attempting operations on uninitialized client
@@ -72,6 +85,9 @@ type StdioClient struct {
 
 	// Health monitoring
 	lastActivity atomic.Int64 // Unix timestamp of last successful RPC
+
+	// Reconnection state
+	reconnecting bool
 
 	// Background goroutine management
 	ctx    context.Context
@@ -325,25 +341,231 @@ func (c *StdioClient) startProcess() error {
 	return nil
 }
 
-// checkHealth verifies the client is in a healthy state
+// checkHealth verifies the client is in a healthy state.
+// If the process has died and auto-reconnection is configured, it attempts to reconnect.
 func (c *StdioClient) checkHealth() error {
 	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	if c.closed {
+		c.mu.RUnlock()
 		return ErrClientClosed
 	}
 
 	if !c.started {
+		c.mu.RUnlock()
 		return ErrClientNotInitialized
 	}
 
 	// Check if process is still alive
-	if c.cmd == nil || c.cmd.Process == nil {
+	if c.cmd != nil && c.cmd.Process != nil {
+		c.mu.RUnlock()
+		return nil
+	}
+
+	// Process is dead — attempt reconnection if configured
+	reconnectAttempts := c.options.MaxReconnectAttempts
+	c.mu.RUnlock()
+
+	if reconnectAttempts <= 0 {
 		return ErrProcessDied
 	}
 
+	return c.reconnect()
+}
+
+// reconnect attempts to restart the MCP server process and re-initialize the connection.
+// It fails all pending requests on the dead client before attempting to restart.
+func (c *StdioClient) reconnect() error {
+	c.mu.Lock()
+
+	// Another goroutine may have already reconnected
+	if c.cmd != nil && c.cmd.Process != nil {
+		c.mu.Unlock()
+		return nil
+	}
+
+	// If already reconnecting, wait and re-check
+	if c.reconnecting {
+		c.mu.Unlock()
+		return c.waitForReconnect()
+	}
+
+	if c.closed {
+		c.mu.Unlock()
+		return ErrClientClosed
+	}
+
+	c.reconnecting = true
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		c.reconnecting = false
+		c.mu.Unlock()
+	}()
+
+	// Fail all pending requests so callers don't hang until context timeout
+	c.failPendingRequests()
+
+	// Clean up old process resources
+	c.cleanupDeadProcess()
+
+	// Attempt to restart with retries
+	logger.Warn("MCP process died, attempting reconnection", "server", c.config.Name)
+
+	// Use a background-derived context so we're not affected by the old process's canceled context
+	totalTimeout := c.options.InitTimeout * time.Duration(c.options.MaxReconnectAttempts+1)
+	ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
+	defer cancel()
+
+	var lastErr error
+	for attempt := 0; attempt < c.options.MaxReconnectAttempts; attempt++ {
+		if attempt > 0 {
+			delay := c.options.RetryDelay * time.Duration(1<<uint(attempt-1)) //nolint:gosec // bounded
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return fmt.Errorf("reconnection canceled: %w", ctx.Err())
+			}
+		}
+
+		err := c.attemptReconnect(ctx, attempt+1)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, ErrClientClosed) {
+			return err
+		}
+		lastErr = err
+	}
+
+	return fmt.Errorf("reconnection failed after %d attempts: %w", c.options.MaxReconnectAttempts, lastErr)
+}
+
+// attemptReconnect performs a single reconnection attempt: restarts the process and re-initializes.
+func (c *StdioClient) attemptReconnect(ctx context.Context, attemptNum int) error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return ErrClientClosed
+	}
+
+	// Reset the context/cancel for the new process
+	c.cancel()
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+
+	err := c.startProcess()
+	if err != nil {
+		c.mu.Unlock()
+		logger.Warn("MCP reconnection attempt failed to start process",
+			"server", c.config.Name, "attempt", attemptNum, "error", err)
+		return err
+	}
+
+	// Start background reader
+	c.wg.Add(1)
+	go c.readLoop()
+	c.mu.Unlock()
+
+	// Re-initialize the MCP handshake
+	initCtx, initCancel := context.WithTimeout(ctx, c.options.InitTimeout)
+	defer initCancel()
+
+	req := InitializeRequest{
+		ProtocolVersion: ProtocolVersion,
+		Capabilities:    ClientCapabilities{Elicitation: &ElicitationCapability{}},
+		ClientInfo:      Implementation{Name: "promptkit", Version: "0.1.0"},
+	}
+
+	var resp InitializeResponse
+	if err = c.sendRequestWithRetry(initCtx, "initialize", req, &resp); err != nil {
+		logger.Warn("MCP reconnection attempt failed handshake",
+			"server", c.config.Name, "attempt", attemptNum, "error", err)
+		return err
+	}
+
+	// Send initialized notification (non-fatal)
+	if notifyErr := c.sendNotification("notifications/initialized", nil); notifyErr != nil {
+		logger.Warn("MCP initialized notification failed after reconnect",
+			"server", c.config.Name, "error", notifyErr)
+	}
+
+	c.mu.Lock()
+	c.serverInfo = &resp
+	c.mu.Unlock()
+	c.updateActivity()
+
+	logger.Info("MCP reconnection successful", "server", c.config.Name, "attempt", attemptNum)
 	return nil
+}
+
+// waitForReconnect waits for an in-progress reconnection to complete, then re-checks health.
+func (c *StdioClient) waitForReconnect() error {
+	// Poll briefly for the reconnecting flag to clear
+	for i := 0; i < reconnectPollMaxIterations; i++ {
+		time.Sleep(reconnectPollInterval)
+		c.mu.RLock()
+		reconnecting := c.reconnecting
+		alive := c.cmd != nil && c.cmd.Process != nil
+		closed := c.closed
+		c.mu.RUnlock()
+
+		if closed {
+			return ErrClientClosed
+		}
+		if !reconnecting {
+			if alive {
+				return nil
+			}
+			return ErrProcessDied
+		}
+	}
+	return fmt.Errorf("timed out waiting for reconnection")
+}
+
+// failPendingRequests sends an error response to all pending requests so they don't
+// hang until their context timeout.
+func (c *StdioClient) failPendingRequests() {
+	c.pendingReqs.Range(func(key, value interface{}) bool {
+		ch := value.(chan *JSONRPCMessage)
+		errMsg := &JSONRPCMessage{
+			JSONRPC: "2.0",
+			ID:      key,
+			Error: &JSONRPCError{
+				Code:    -32000,
+				Message: "server process died",
+			},
+		}
+		select {
+		case ch <- errMsg:
+		default:
+		}
+		c.pendingReqs.Delete(key)
+		return true
+	})
+}
+
+// cleanupDeadProcess releases resources from a dead process without marking the client as closed.
+func (c *StdioClient) cleanupDeadProcess() {
+	// Close pipes (safe to call on already-closed pipes; errors are non-actionable)
+	if c.stdin != nil {
+		_ = c.stdin.Close()
+	}
+	if c.stdout != nil {
+		_ = c.stdout.Close()
+	}
+	if c.stderr != nil {
+		_ = c.stderr.Close()
+	}
+
+	// Clean up zombie process
+	if c.cmd != nil && c.cmd.Process != nil {
+		_ = c.cmd.Process.Kill()
+		_ = c.cmd.Wait()
+	}
+
+	// Wait for background goroutines from the old process to finish
+	c.wg.Wait()
 }
 
 // updateActivity records the timestamp of the last successful operation

--- a/runtime/mcp/client_test.go
+++ b/runtime/mcp/client_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -23,6 +24,7 @@ func TestDefaultClientOptions(t *testing.T) {
 	assert.Equal(t, 3, opts.MaxRetries)
 	assert.Equal(t, 100*time.Millisecond, opts.RetryDelay)
 	assert.True(t, opts.EnableGracefulDegradation)
+	assert.Equal(t, 3, opts.MaxReconnectAttempts)
 }
 
 func TestClientErrors(t *testing.T) {
@@ -98,11 +100,27 @@ func TestCheckHealth(t *testing.T) {
 		assert.Equal(t, ErrClientClosed, err)
 	})
 
-	t.Run("started but no process", func(t *testing.T) {
-		client := NewStdioClient(config)
+	t.Run("started but no process with reconnect disabled", func(t *testing.T) {
+		opts := DefaultClientOptions()
+		opts.MaxReconnectAttempts = 0
+		client := NewStdioClientWithOptions(config, opts)
 		client.started = true
 		err := client.checkHealth()
 		assert.Equal(t, ErrProcessDied, err)
+	})
+
+	t.Run("started but no process with reconnect enabled fails", func(t *testing.T) {
+		opts := DefaultClientOptions()
+		opts.MaxReconnectAttempts = 1
+		opts.RetryDelay = 10 * time.Millisecond
+		opts.InitTimeout = 100 * time.Millisecond
+		client := NewStdioClientWithOptions(config, opts)
+		client.started = true
+		// cmd is nil and command is "echo" which won't work as MCP server
+		err := client.checkHealth()
+		assert.Error(t, err)
+		// Should attempt reconnection and fail
+		assert.Contains(t, err.Error(), "reconnection failed")
 	})
 }
 
@@ -1258,6 +1276,278 @@ func TestInitialize_ProcessStartsHandshakeSucceeds(t *testing.T) {
 	_ = client2.cmd.Process.Kill()
 	_ = client2.cmd.Wait()
 	client2.wg.Wait()
+}
+
+func TestCheckHealth_ReconnectionDisabled(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "echo",
+	}
+
+	opts := DefaultClientOptions()
+	opts.MaxReconnectAttempts = 0 // Disable auto-reconnection
+	client := NewStdioClientWithOptions(config, opts)
+	client.started = true
+	// cmd is nil — process is dead
+
+	err := client.checkHealth()
+	assert.Equal(t, ErrProcessDied, err)
+}
+
+func TestCheckHealth_HealthyProcess(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "sleep",
+	}
+	client := NewStdioClient(config)
+	client.started = true
+	client.cmd = exec.Command("sleep", "60")
+	require.NoError(t, client.cmd.Start())
+	t.Cleanup(func() {
+		if client.cmd.Process != nil {
+			_ = client.cmd.Process.Kill()
+			_ = client.cmd.Wait()
+		}
+	})
+
+	err := client.checkHealth()
+	assert.NoError(t, err)
+}
+
+func TestFailPendingRequests(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "echo",
+	}
+	client := NewStdioClient(config)
+
+	// Add some pending requests
+	ch1 := make(chan *JSONRPCMessage, 1)
+	ch2 := make(chan *JSONRPCMessage, 1)
+	ch3 := make(chan *JSONRPCMessage, 1)
+	client.pendingReqs.Store(int64(1), ch1)
+	client.pendingReqs.Store(int64(2), ch2)
+	client.pendingReqs.Store(int64(3), ch3)
+
+	client.failPendingRequests()
+
+	// All channels should have received error messages
+	for i, ch := range []chan *JSONRPCMessage{ch1, ch2, ch3} {
+		select {
+		case msg := <-ch:
+			require.NotNil(t, msg, "channel %d should have a message", i+1)
+			assert.NotNil(t, msg.Error, "channel %d should have an error", i+1)
+			assert.Equal(t, -32000, msg.Error.Code)
+			assert.Contains(t, msg.Error.Message, "process died")
+		default:
+			t.Fatalf("channel %d should have received an error message", i+1)
+		}
+	}
+
+	// Pending requests should be cleared
+	count := 0
+	client.pendingReqs.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 0, count, "pending requests should be cleared")
+}
+
+func TestFailPendingRequests_FullChannel(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "echo",
+	}
+	client := NewStdioClient(config)
+
+	// Add a pending request with a channel that's already full
+	ch := make(chan *JSONRPCMessage, 1)
+	ch <- &JSONRPCMessage{} // Fill the channel
+	client.pendingReqs.Store(int64(1), ch)
+
+	// Should not panic when channel is full
+	client.failPendingRequests()
+
+	count := 0
+	client.pendingReqs.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 0, count, "pending requests should be cleared even if channel was full")
+}
+
+func TestCleanupDeadProcess(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "sleep",
+	}
+	client := NewStdioClient(config)
+
+	// Start a real process
+	client.cmd = exec.Command("sleep", "60")
+	var err error
+	client.stdin, err = client.cmd.StdinPipe()
+	require.NoError(t, err)
+	client.stdout, err = client.cmd.StdoutPipe()
+	require.NoError(t, err)
+	client.stderr, err = client.cmd.StderrPipe()
+	require.NoError(t, err)
+	require.NoError(t, client.cmd.Start())
+
+	// cleanupDeadProcess should not panic
+	client.cleanupDeadProcess()
+}
+
+func TestReconnect_ClientClosed(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "echo",
+	}
+	client := NewStdioClient(config)
+	client.started = true
+	client.closed = true
+
+	err := client.reconnect()
+	assert.ErrorIs(t, err, ErrClientClosed)
+}
+
+func TestReconnect_AlreadyAlive(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "sleep",
+	}
+	client := NewStdioClient(config)
+	client.started = true
+	client.cmd = exec.Command("sleep", "60")
+	require.NoError(t, client.cmd.Start())
+	t.Cleanup(func() {
+		if client.cmd.Process != nil {
+			_ = client.cmd.Process.Kill()
+			_ = client.cmd.Wait()
+		}
+	})
+
+	// reconnect should return nil since process is alive
+	err := client.reconnect()
+	assert.NoError(t, err)
+}
+
+func TestReconnect_FailsWithBadCommand(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "/nonexistent/command",
+	}
+
+	opts := DefaultClientOptions()
+	opts.MaxReconnectAttempts = 2
+	opts.RetryDelay = 10 * time.Millisecond
+	opts.InitTimeout = 100 * time.Millisecond
+	client := NewStdioClientWithOptions(config, opts)
+	client.started = true
+	// cmd is nil — process is dead
+
+	err := client.reconnect()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reconnection failed after 2 attempts")
+}
+
+func TestReconnect_ClosedDuringAttempt(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "/nonexistent/command",
+	}
+
+	opts := DefaultClientOptions()
+	opts.MaxReconnectAttempts = 5
+	opts.RetryDelay = 200 * time.Millisecond
+	opts.InitTimeout = 100 * time.Millisecond
+	client := NewStdioClientWithOptions(config, opts)
+	client.started = true
+
+	// Close the client during reconnection
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		client.mu.Lock()
+		client.closed = true
+		client.mu.Unlock()
+	}()
+
+	err := client.reconnect()
+	assert.Error(t, err)
+	// Should detect closed state
+	assert.True(t,
+		errors.Is(err, ErrClientClosed) ||
+			strings.Contains(err.Error(), "reconnection failed"),
+		"expected closed or failed error, got: %s", err.Error())
+}
+
+func TestWaitForReconnect_Success(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "sleep",
+	}
+	client := NewStdioClient(config)
+	client.started = true
+	client.reconnecting = true
+
+	// Simulate reconnection completing
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		client.mu.Lock()
+		client.reconnecting = false
+		client.cmd = exec.Command("sleep", "60")
+		_ = client.cmd.Start()
+		client.mu.Unlock()
+	}()
+	t.Cleanup(func() {
+		if client.cmd != nil && client.cmd.Process != nil {
+			_ = client.cmd.Process.Kill()
+			_ = client.cmd.Wait()
+		}
+	})
+
+	err := client.waitForReconnect()
+	assert.NoError(t, err)
+}
+
+func TestWaitForReconnect_ClosedDuringWait(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "echo",
+	}
+	client := NewStdioClient(config)
+	client.reconnecting = true
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		client.mu.Lock()
+		client.closed = true
+		client.reconnecting = false
+		client.mu.Unlock()
+	}()
+
+	err := client.waitForReconnect()
+	assert.ErrorIs(t, err, ErrClientClosed)
+}
+
+func TestWaitForReconnect_ReconnectFailed(t *testing.T) {
+	config := ServerConfig{
+		Name:    "test-server",
+		Command: "echo",
+	}
+	client := NewStdioClient(config)
+	client.reconnecting = true
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		client.mu.Lock()
+		client.reconnecting = false
+		// cmd stays nil — reconnect failed
+		client.mu.Unlock()
+	}()
+
+	err := client.waitForReconnect()
+	assert.Equal(t, ErrProcessDied, err)
 }
 
 func TestSendRequest_UnmarshalResultError(t *testing.T) {

--- a/runtime/mcp/registry.go
+++ b/runtime/mcp/registry.go
@@ -2,11 +2,28 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 )
+
+// DefaultMaxProcesses is the default maximum number of concurrent MCP processes.
+// 0 means unlimited.
+const DefaultMaxProcesses = 0
+
+var (
+	// ErrMaxProcessesReached is returned when the concurrent process limit has been reached.
+	ErrMaxProcessesReached = errors.New("mcp: maximum concurrent processes reached")
+)
+
+// RegistryOptions configures the MCP registry behavior.
+type RegistryOptions struct {
+	// MaxProcesses limits the number of concurrent MCP server processes.
+	// 0 means unlimited (no limit enforced).
+	MaxProcesses int
+}
 
 // RegistryImpl implements the Registry interface
 type RegistryImpl struct {
@@ -23,15 +40,42 @@ type RegistryImpl struct {
 
 	// Lifecycle
 	closed bool
+
+	// Options
+	options RegistryOptions
+
+	// Process limiter — buffered channel used as a counting semaphore.
+	// nil when MaxProcesses is 0 (unlimited).
+	processSem chan struct{}
+
+	// newClientFunc creates a new MCP client. Defaults to newStdioClientAdapter.
+	// Can be overridden in tests to inject mock clients.
+	newClientFunc func(config ServerConfig) Client
 }
 
-// NewRegistry creates a new MCP server registry
+// NewRegistry creates a new MCP server registry with default options (unlimited processes).
 func NewRegistry() *RegistryImpl {
-	return &RegistryImpl{
-		servers:   make(map[string]ServerConfig),
-		clients:   make(map[string]Client),
-		toolIndex: make(map[string]string),
+	return NewRegistryWithOptions(RegistryOptions{MaxProcesses: DefaultMaxProcesses})
+}
+
+// newStdioClientAdapter wraps NewStdioClient to return the Client interface.
+func newStdioClientAdapter(config ServerConfig) Client {
+	return NewStdioClient(config)
+}
+
+// NewRegistryWithOptions creates a new MCP server registry with custom options.
+func NewRegistryWithOptions(opts RegistryOptions) *RegistryImpl {
+	r := &RegistryImpl{
+		servers:       make(map[string]ServerConfig),
+		clients:       make(map[string]Client),
+		toolIndex:     make(map[string]string),
+		options:       opts,
+		newClientFunc: newStdioClientAdapter,
 	}
+	if opts.MaxProcesses > 0 {
+		r.processSem = make(chan struct{}, opts.MaxProcesses)
+	}
+	return r
 }
 
 // RegisterServer adds a new MCP server configuration
@@ -92,24 +136,48 @@ func (r *RegistryImpl) tryGetExistingClient(serverName string) (Client, error) {
 	return nil, nil // No existing client, need to create new one
 }
 
-// createNewClient creates and initializes a new client
+// createNewClient creates and initializes a new client.
+// If a process limit is configured, it acquires a semaphore slot before creating the process.
 func (r *RegistryImpl) createNewClient(ctx context.Context, serverName string) (Client, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	// Acquire process semaphore before creating a new process
+	if err := r.acquireProcessSlot(); err != nil {
+		return nil, fmt.Errorf("failed to acquire process slot for %s: %w", serverName, err)
+	}
 
-	// Double-check after acquiring write lock
+	r.mu.Lock()
+
+	// Double-check after acquiring write lock — another goroutine may have created it
 	if client, exists := r.clients[serverName]; exists && client.IsAlive() {
+		r.mu.Unlock()
+		r.releaseProcessSlot() // We didn't need the slot after all
 		return client, nil
 	}
 
-	config := r.servers[serverName]
+	// If we're replacing a dead client, release its slot conceptually
+	// (the dead client's slot is already consumed; we acquired a new one above)
+	if _, exists := r.clients[serverName]; exists {
+		// Old client was dead — release the extra slot since we're replacing, not adding
+		r.releaseProcessSlot()
+	}
 
-	// Create and initialize new client
-	newClient := NewStdioClient(config)
+	config := r.servers[serverName]
+	r.mu.Unlock()
+
+	// Create and initialize new client (outside the lock to avoid holding it during I/O)
+	newClient := r.newClientFunc(config)
 	if _, err := newClient.Initialize(ctx); err != nil {
+		r.releaseProcessSlot()
 		return nil, fmt.Errorf("failed to initialize MCP server %s: %w", serverName, err)
 	}
 
+	r.mu.Lock()
+	// Final check — if someone else beat us, close our client and use theirs
+	if client, exists := r.clients[serverName]; exists && client.IsAlive() {
+		r.mu.Unlock()
+		_ = newClient.Close()
+		r.releaseProcessSlot()
+		return client, nil
+	}
 	r.clients[serverName] = newClient
 
 	// Refresh tool index for this server
@@ -117,8 +185,51 @@ func (r *RegistryImpl) createNewClient(ctx context.Context, serverName string) (
 		// Log error but don't fail - client is still usable
 		logger.Warn("Failed to refresh tool index", "server", serverName, "error", err)
 	}
+	r.mu.Unlock()
 
 	return newClient, nil
+}
+
+// acquireProcessSlot attempts to acquire a process slot from the semaphore.
+// Returns nil immediately if no process limit is configured.
+// Returns ErrMaxProcessesReached if all slots are occupied.
+func (r *RegistryImpl) acquireProcessSlot() error {
+	if r.processSem == nil {
+		return nil // No limit configured
+	}
+
+	select {
+	case r.processSem <- struct{}{}:
+		return nil
+	default:
+		// Semaphore is full — return error immediately instead of blocking
+		return ErrMaxProcessesReached
+	}
+}
+
+// releaseProcessSlot releases a process slot back to the semaphore.
+// No-op if no process limit is configured.
+func (r *RegistryImpl) releaseProcessSlot() {
+	if r.processSem == nil {
+		return
+	}
+	select {
+	case <-r.processSem:
+	default:
+		// Should not happen, but don't block
+	}
+}
+
+// ActiveProcessCount returns the number of active MCP processes.
+// Returns -1 if no process limit is configured.
+func (r *RegistryImpl) ActiveProcessCount() int {
+	if r.processSem == nil {
+		r.mu.RLock()
+		count := len(r.clients)
+		r.mu.RUnlock()
+		return count
+	}
+	return len(r.processSem)
 }
 
 // GetClientForTool returns the client that provides the specified tool
@@ -250,10 +361,16 @@ func (r *RegistryImpl) Close() error {
 	r.closed = true
 
 	var firstErr error
+	clientCount := len(r.clients)
 	for name, client := range r.clients {
 		if err := client.Close(); err != nil && firstErr == nil {
 			firstErr = fmt.Errorf("failed to close client %s: %w", name, err)
 		}
+	}
+
+	// Release all process slots
+	for i := 0; i < clientCount; i++ {
+		r.releaseProcessSlot()
 	}
 
 	// Clear all state

--- a/runtime/mcp/registry_test.go
+++ b/runtime/mcp/registry_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 
@@ -429,4 +431,351 @@ func TestRegistry_ToolIndexSynchronization(t *testing.T) {
 		assert.NotContains(t, registry.toolIndex, "tool2")
 		assert.Equal(t, "server2", registry.toolIndex["tool3"])
 	})
+}
+
+// --- Process limiter tests ---
+
+func TestNewRegistryWithOptions_Unlimited(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 0})
+	assert.NotNil(t, registry)
+	assert.Nil(t, registry.processSem)
+	assert.Equal(t, 0, registry.options.MaxProcesses)
+}
+
+func TestNewRegistryWithOptions_WithLimit(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 5})
+	assert.NotNil(t, registry)
+	assert.NotNil(t, registry.processSem)
+	assert.Equal(t, 5, cap(registry.processSem))
+	assert.Equal(t, 5, registry.options.MaxProcesses)
+}
+
+func TestNewRegistry_DefaultUnlimited(t *testing.T) {
+	registry := NewRegistry()
+	assert.Nil(t, registry.processSem, "default registry should have no process limit")
+}
+
+func TestRegistry_AcquireProcessSlot_Unlimited(t *testing.T) {
+	registry := NewRegistry()
+	// Should always succeed with no limit
+	err := registry.acquireProcessSlot()
+	assert.NoError(t, err)
+}
+
+func TestRegistry_AcquireProcessSlot_WithCapacity(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 2})
+
+	// Acquire first slot
+	err := registry.acquireProcessSlot()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(registry.processSem))
+
+	// Acquire second slot
+	err = registry.acquireProcessSlot()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(registry.processSem))
+
+	// Third should fail immediately
+	err = registry.acquireProcessSlot()
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMaxProcessesReached))
+}
+
+func TestRegistry_ReleaseProcessSlot(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 2})
+
+	// Acquire both slots
+	_ = registry.acquireProcessSlot()
+	_ = registry.acquireProcessSlot()
+	assert.Equal(t, 2, len(registry.processSem))
+
+	// Release one
+	registry.releaseProcessSlot()
+	assert.Equal(t, 1, len(registry.processSem))
+
+	// Should be able to acquire again
+	err := registry.acquireProcessSlot()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(registry.processSem))
+}
+
+func TestRegistry_ReleaseProcessSlot_Unlimited(t *testing.T) {
+	registry := NewRegistry()
+	// Should not panic
+	registry.releaseProcessSlot()
+}
+
+func TestRegistry_ReleaseProcessSlot_Empty(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 2})
+	// Should not block when semaphore is empty
+	registry.releaseProcessSlot()
+}
+
+func TestRegistry_ActiveProcessCount_Unlimited(t *testing.T) {
+	registry := NewRegistry()
+	assert.Equal(t, 0, registry.ActiveProcessCount())
+}
+
+func TestRegistry_ActiveProcessCount_WithLimit(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 5})
+	assert.Equal(t, 0, registry.ActiveProcessCount())
+
+	_ = registry.acquireProcessSlot()
+	assert.Equal(t, 1, registry.ActiveProcessCount())
+
+	_ = registry.acquireProcessSlot()
+	assert.Equal(t, 2, registry.ActiveProcessCount())
+
+	registry.releaseProcessSlot()
+	assert.Equal(t, 1, registry.ActiveProcessCount())
+}
+
+func TestRegistry_ProcessLimit_CreateNewClientFails(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 1})
+
+	// Register two servers
+	_ = registry.RegisterServer(ServerConfig{Name: "server1", Command: "/nonexistent/cmd1"})
+	_ = registry.RegisterServer(ServerConfig{Name: "server2", Command: "/nonexistent/cmd2"})
+
+	// First client creation should acquire a slot (then fail on init, releasing the slot)
+	_, err := registry.GetClient(context.Background(), "server1")
+	assert.Error(t, err) // Init fails
+
+	// Slot should have been released, so another attempt should be possible
+	_, err = registry.GetClient(context.Background(), "server2")
+	assert.Error(t, err) // Init fails too, but slot was acquired
+}
+
+func TestRegistry_ProcessLimit_ExhaustedSlots(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 1})
+
+	// Manually consume the semaphore slot
+	registry.processSem <- struct{}{}
+
+	_ = registry.RegisterServer(ServerConfig{Name: "server1", Command: "echo"})
+
+	// Should fail immediately because semaphore is full
+	_, err := registry.GetClient(context.Background(), "server1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to acquire process slot")
+}
+
+func TestRegistry_Close_ReleasesSlots(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 3})
+
+	// Simulate active clients by consuming semaphore slots
+	_ = registry.acquireProcessSlot()
+	_ = registry.acquireProcessSlot()
+
+	// Create mock clients in the registry
+	mockClient1 := &mockClient{}
+	mockClient2 := &mockClient{}
+	registry.clients["server1"] = mockClient1
+	registry.clients["server2"] = mockClient2
+
+	err := registry.Close()
+	assert.NoError(t, err)
+
+	// After close, the semaphore should have released the 2 slots
+	assert.Equal(t, 0, len(registry.processSem))
+}
+
+func TestRegistry_CreateNewClient_DoubleCheckReturnsAlive(t *testing.T) {
+	// Test the double-check path: if a client was created by another goroutine
+	// between tryGetExistingClient and createNewClient
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 2})
+
+	_ = registry.RegisterServer(ServerConfig{Name: "server1", Command: "/nonexistent"})
+
+	// Pre-populate with an alive mock client
+	aliveClient := &mockClient{alive: true}
+	registry.clients["server1"] = aliveClient
+
+	// GetClient should find the alive client via tryGetExistingClient
+	client, err := registry.GetClient(context.Background(), "server1")
+	assert.NoError(t, err)
+	assert.Equal(t, aliveClient, client)
+}
+
+func TestRegistry_CreateNewClient_ReplacesDeadClient(t *testing.T) {
+	// Test the path where an existing dead client is replaced
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 3})
+
+	_ = registry.RegisterServer(ServerConfig{Name: "server1", Command: "/nonexistent"})
+
+	// Pre-populate with a dead client (simulate a slot already consumed for it)
+	deadClient := &mockClient{alive: false}
+	registry.clients["server1"] = deadClient
+	_ = registry.acquireProcessSlot() // simulate the slot for the dead client
+
+	// Before GetClient: 1 slot in use
+	assert.Equal(t, 1, len(registry.processSem))
+
+	// tryGetExistingClient will return nil,nil (client exists but not alive)
+	// createNewClient will:
+	//   1. acquireProcessSlot (sem=2)
+	//   2. detect dead client, releaseProcessSlot (sem=1, replacing the dead one's slot)
+	//   3. Init fails, releaseProcessSlot (sem=0)
+	_, err := registry.GetClient(context.Background(), "server1")
+	assert.Error(t, err) // Init will fail (bad command)
+
+	// Both slots were released (the dead client's and the new attempt's)
+	assert.Equal(t, 0, len(registry.processSem))
+}
+
+func TestRegistry_CreateNewClient_InitFailsReleasesSlot(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 3})
+
+	_ = registry.RegisterServer(ServerConfig{Name: "server1", Command: "/nonexistent"})
+
+	// Before GetClient, no slots are used
+	assert.Equal(t, 0, len(registry.processSem))
+
+	_, err := registry.GetClient(context.Background(), "server1")
+	assert.Error(t, err)
+
+	// After failed init, slot should be released
+	assert.Equal(t, 0, len(registry.processSem))
+}
+
+func TestRegistry_CreateNewClient_SemaphoreAcquireFails(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 1})
+
+	_ = registry.RegisterServer(ServerConfig{Name: "server1", Command: "/nonexistent"})
+
+	// Fill the semaphore
+	registry.processSem <- struct{}{}
+
+	_, err := registry.GetClient(context.Background(), "server1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to acquire process slot")
+	assert.ErrorIs(t, err, ErrMaxProcessesReached)
+}
+
+func TestErrMaxProcessesReached(t *testing.T) {
+	assert.NotNil(t, ErrMaxProcessesReached)
+	assert.Contains(t, ErrMaxProcessesReached.Error(), "maximum concurrent processes")
+}
+
+func TestRegistryOptions_Defaults(t *testing.T) {
+	assert.Equal(t, 0, DefaultMaxProcesses, "default should be unlimited (0)")
+}
+
+// mockClient implements the Client interface for testing
+type mockClient struct {
+	alive    bool
+	closed   bool
+	initErr  error
+	tools    []Tool
+	toolsErr error
+}
+
+func (m *mockClient) Initialize(_ context.Context) (*InitializeResponse, error) {
+	if m.initErr != nil {
+		return nil, m.initErr
+	}
+	m.alive = true
+	return &InitializeResponse{ProtocolVersion: ProtocolVersion}, nil
+}
+
+func (m *mockClient) ListTools(_ context.Context) ([]Tool, error) {
+	return m.tools, m.toolsErr
+}
+
+func (m *mockClient) CallTool(_ context.Context, _ string, _ json.RawMessage) (*ToolCallResponse, error) {
+	return nil, nil
+}
+func (m *mockClient) Close() error  { m.closed = true; m.alive = false; return nil }
+func (m *mockClient) IsAlive() bool { return m.alive }
+
+func TestRegistry_CreateNewClient_SuccessWithMock(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 3})
+
+	// Override client factory to return a mock
+	registry.newClientFunc = func(_ ServerConfig) Client {
+		return &mockClient{tools: []Tool{{Name: "tool1"}}}
+	}
+
+	_ = registry.RegisterServer(ServerConfig{Name: "server1", Command: "mock"})
+
+	client, err := registry.GetClient(context.Background(), "server1")
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.True(t, client.IsAlive())
+
+	// Should use 1 process slot
+	assert.Equal(t, 1, registry.ActiveProcessCount())
+}
+
+func TestRegistry_CreateNewClient_DoubleCheckRace(t *testing.T) {
+	// Test the final race-check path: if someone else created the client
+	// while we were initializing ours.
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 5})
+
+	callCount := 0
+	registry.newClientFunc = func(_ ServerConfig) Client {
+		callCount++
+		// On the first call, simulate another goroutine inserting a client
+		if callCount == 1 {
+			aliveClient := &mockClient{alive: true, tools: []Tool{{Name: "tool2"}}}
+			registry.mu.Lock()
+			registry.clients["server1"] = aliveClient
+			registry.mu.Unlock()
+		}
+		return &mockClient{tools: []Tool{{Name: "tool1"}}}
+	}
+
+	_ = registry.RegisterServer(ServerConfig{Name: "server1", Command: "mock"})
+
+	client, err := registry.GetClient(context.Background(), "server1")
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	// Should have gotten the pre-existing alive client, not the one we just created
+	assert.True(t, client.IsAlive())
+}
+
+func TestRegistry_CreateNewClient_WithSemaphoreSuccess(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 2})
+
+	registry.newClientFunc = func(_ ServerConfig) Client {
+		return &mockClient{tools: []Tool{{Name: "tool-a"}}}
+	}
+
+	_ = registry.RegisterServer(ServerConfig{Name: "s1", Command: "mock"})
+	_ = registry.RegisterServer(ServerConfig{Name: "s2", Command: "mock"})
+
+	c1, err := registry.GetClient(context.Background(), "s1")
+	require.NoError(t, err)
+	assert.NotNil(t, c1)
+
+	c2, err := registry.GetClient(context.Background(), "s2")
+	require.NoError(t, err)
+	assert.NotNil(t, c2)
+
+	assert.Equal(t, 2, registry.ActiveProcessCount())
+
+	// Close releases slots
+	err = registry.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(registry.processSem))
+}
+
+func TestRegistry_Close_WithMockClients(t *testing.T) {
+	registry := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 3})
+
+	registry.newClientFunc = func(_ ServerConfig) Client {
+		return &mockClient{}
+	}
+
+	_ = registry.RegisterServer(ServerConfig{Name: "s1", Command: "mock"})
+	_ = registry.RegisterServer(ServerConfig{Name: "s2", Command: "mock"})
+
+	_, _ = registry.GetClient(context.Background(), "s1")
+	_, _ = registry.GetClient(context.Background(), "s2")
+
+	assert.Equal(t, 2, registry.ActiveProcessCount())
+
+	err := registry.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(registry.processSem))
 }

--- a/runtime/pipeline/stage/capabilities_validation.go
+++ b/runtime/pipeline/stage/capabilities_validation.go
@@ -2,6 +2,8 @@
 package stage
 
 import (
+	"strings"
+
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 )
 
@@ -217,27 +219,15 @@ func joinContentTypes(types []ContentType) string {
 	for i, ct := range types {
 		strs[i] = ct.String()
 	}
-	return joinStrings(strs, "|")
+	return strings.Join(strs, "|")
 }
 
 func describeAudioCapability(audio *AudioCapability) string {
 	if audio == nil {
 		return ""
 	}
-	result := ""
 	if len(audio.Formats) > 0 {
-		result = joinStrings(audioFormatsToStrings(audio.Formats), "|")
+		return strings.Join(audioFormatsToStrings(audio.Formats), "|")
 	}
-	return result
-}
-
-func joinStrings(strs []string, sep string) string {
-	if len(strs) == 0 {
-		return ""
-	}
-	result := strs[0]
-	for i := 1; i < len(strs); i++ {
-		result += sep + strs[i]
-	}
-	return result
+	return ""
 }

--- a/runtime/pipeline/stage/capabilities_validation_test.go
+++ b/runtime/pipeline/stage/capabilities_validation_test.go
@@ -244,28 +244,6 @@ func TestIntsOverlap(t *testing.T) {
 	}
 }
 
-func TestJoinStrings(t *testing.T) {
-	tests := []struct {
-		name   string
-		strs   []string
-		sep    string
-		expect string
-	}{
-		{"empty", []string{}, "|", ""},
-		{"single", []string{"a"}, "|", "a"},
-		{"multiple", []string{"a", "b", "c"}, "|", "a|b|c"},
-		{"different sep", []string{"x", "y"}, ",", "x,y"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := joinStrings(tt.strs, tt.sep); got != tt.expect {
-				t.Errorf("joinStrings() = %q, want %q", got, tt.expect)
-			}
-		})
-	}
-}
-
 func TestDescribeAudioCapability(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/runtime/pipeline/stage/config.go
+++ b/runtime/pipeline/stage/config.go
@@ -6,7 +6,12 @@ import (
 
 const (
 	// DefaultChannelBufferSize is the default buffer size for channels between stages.
-	DefaultChannelBufferSize = 16
+	// For text pipelines, 16 provides adequate buffering.
+	// For audio pipelines at ~50 chunks/sec, consider using DefaultAudioChannelBufferSize.
+	DefaultChannelBufferSize = 32
+	// DefaultAudioChannelBufferSize is the recommended buffer size for audio pipelines.
+	// At 50 chunks/sec, 64 buffers provide ~1.3 seconds of buffering to absorb jitter.
+	DefaultAudioChannelBufferSize = 64
 	// DefaultMaxConcurrentPipelines is the default maximum number of concurrent pipeline executions.
 	DefaultMaxConcurrentPipelines = 100
 	// DefaultExecutionTimeoutSeconds is the default execution timeout in seconds.

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1021,6 +1021,9 @@ func (s *ProviderStage) handleToolResult(
 			content = formatToolResult(resultValue)
 		}
 
+		// Enforce tool result size limit
+		content = s.enforceResultSizeLimit(call.Name, content)
+
 		return types.MessageToolResult{
 			ID:      call.ID,
 			Name:    call.Name,
@@ -1036,6 +1039,32 @@ func (s *ProviderStage) handleToolResult(
 			Error:   fmt.Sprintf("Unknown tool status: %v", asyncResult.Status),
 		}
 	}
+}
+
+// enforceResultSizeLimit truncates the tool result content if it exceeds the
+// configured maximum size from the tool registry.
+func (s *ProviderStage) enforceResultSizeLimit(toolName, content string) string {
+	if s.toolRegistry == nil {
+		return content
+	}
+	maxSize := s.toolRegistry.MaxToolResultSize()
+	if maxSize <= 0 {
+		return content
+	}
+	size := len(content)
+	if size <= maxSize {
+		return content
+	}
+	logger.Warn("Tool result truncated",
+		"tool", toolName,
+		"size", size,
+		"limit", maxSize,
+	)
+	truncated := content[:maxSize]
+	return fmt.Sprintf(
+		"%s\n... [truncated, %d bytes exceeded limit of %d bytes]",
+		truncated, size, maxSize,
+	)
 }
 
 // isToolBlocked checks if a tool is in the blocklist

--- a/runtime/pipeline/stage/stages_provider_truncate_test.go
+++ b/runtime/pipeline/stage/stages_provider_truncate_test.go
@@ -1,0 +1,68 @@
+package stage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnforceResultSizeLimit(t *testing.T) {
+	t.Run("no truncation when within limit", func(t *testing.T) {
+		reg := tools.NewRegistry(tools.WithMaxToolResultSize(100))
+		s := &ProviderStage{toolRegistry: reg}
+
+		content := "short result"
+		result := s.enforceResultSizeLimit("test_tool", content)
+		assert.Equal(t, content, result)
+	})
+
+	t.Run("truncates when exceeding limit", func(t *testing.T) {
+		reg := tools.NewRegistry(tools.WithMaxToolResultSize(10))
+		s := &ProviderStage{toolRegistry: reg}
+
+		content := "this is a long result that exceeds the limit"
+		result := s.enforceResultSizeLimit("test_tool", content)
+
+		assert.True(t, strings.HasPrefix(result, content[:10]))
+		assert.Contains(t, result, "[truncated,")
+		assert.Contains(t, result, "bytes exceeded limit of 10 bytes]")
+	})
+
+	t.Run("no truncation when limit is zero", func(t *testing.T) {
+		reg := tools.NewRegistry(tools.WithMaxToolResultSize(0))
+		s := &ProviderStage{toolRegistry: reg}
+
+		content := strings.Repeat("x", 10000)
+		result := s.enforceResultSizeLimit("test_tool", content)
+		assert.Equal(t, content, result)
+	})
+
+	t.Run("no truncation when no registry", func(t *testing.T) {
+		s := &ProviderStage{toolRegistry: nil}
+
+		content := "some result"
+		result := s.enforceResultSizeLimit("test_tool", content)
+		assert.Equal(t, content, result)
+	})
+
+	t.Run("exact limit is not truncated", func(t *testing.T) {
+		reg := tools.NewRegistry(tools.WithMaxToolResultSize(5))
+		s := &ProviderStage{toolRegistry: reg}
+
+		content := "12345"
+		result := s.enforceResultSizeLimit("test_tool", content)
+		assert.Equal(t, content, result)
+	})
+
+	t.Run("one byte over limit is truncated", func(t *testing.T) {
+		reg := tools.NewRegistry(tools.WithMaxToolResultSize(5))
+		s := &ProviderStage{toolRegistry: reg}
+
+		content := "123456"
+		result := s.enforceResultSizeLimit("test_tool", content)
+		assert.True(t, strings.HasPrefix(result, "12345"))
+		assert.Contains(t, result, "[truncated,")
+	})
+}

--- a/runtime/pipeline/stage/stages_video_frames.go
+++ b/runtime/pipeline/stage/stages_video_frames.go
@@ -8,6 +8,7 @@ import (
 	_ "image/jpeg" // Register JPEG decoder
 	_ "image/png"  // Register PNG decoder
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -284,14 +285,7 @@ func (s *VideoToFramesStage) buildFFmpegArgs(inputPath, outputPattern string) []
 
 // ffmpegJoinFilters joins FFmpeg video filters with comma separator.
 func ffmpegJoinFilters(filters []string) string {
-	if len(filters) == 0 {
-		return ""
-	}
-	result := filters[0]
-	for i := 1; i < len(filters); i++ {
-		result += "," + filters[i]
-	}
-	return result
+	return strings.Join(filters, ",")
 }
 
 // generateVideoID creates a unique identifier for video correlation.

--- a/runtime/providers/claude/claude_multimodal.go
+++ b/runtime/providers/claude/claude_multimodal.go
@@ -457,8 +457,9 @@ func (p *Provider) predictStreamWithContentsMultimodal(ctx context.Context, mess
 		if err != nil {
 			return nil, err
 		}
+		idleBody := providers.NewIdleTimeoutReader(body, providers.DefaultStreamIdleTimeout)
 		outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-		go p.streamResponseMultimodal(ctx, body, scanner, outChan)
+		go p.streamResponseMultimodal(ctx, idleBody, scanner, outChan)
 		return outChan, nil
 	}
 
@@ -492,9 +493,10 @@ func (p *Provider) predictStreamWithContentsMultimodal(ctx context.Context, mess
 	}
 
 	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-	scanner := providers.NewSSEScanner(resp.Body)
+	idleBody := providers.NewIdleTimeoutReader(resp.Body, providers.DefaultStreamIdleTimeout)
+	scanner := providers.NewSSEScanner(idleBody)
 
-	go p.streamResponseMultimodal(ctx, resp.Body, scanner, outChan)
+	go p.streamResponseMultimodal(ctx, idleBody, scanner, outChan)
 
 	return outChan, nil
 }

--- a/runtime/providers/claude/claude_multimodal.go
+++ b/runtime/providers/claude/claude_multimodal.go
@@ -457,7 +457,7 @@ func (p *Provider) predictStreamWithContentsMultimodal(ctx context.Context, mess
 		if err != nil {
 			return nil, err
 		}
-		outChan := make(chan providers.StreamChunk)
+		outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 		go p.streamResponseMultimodal(ctx, body, scanner, outChan)
 		return outChan, nil
 	}
@@ -491,7 +491,7 @@ func (p *Provider) predictStreamWithContentsMultimodal(ctx context.Context, mess
 		return nil, fmt.Errorf("claude api error (status %d): %s", resp.StatusCode, string(body))
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 	scanner := providers.NewSSEScanner(resp.Body)
 
 	go p.streamResponseMultimodal(ctx, resp.Body, scanner, outChan)

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -77,7 +77,7 @@ func (p *Provider) PredictStream(
 		if err != nil {
 			return nil, err
 		}
-		outChan := make(chan providers.StreamChunk)
+		outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 		go p.streamResponse(ctx, body, scanner, outChan)
 		return outChan, nil
 	}
@@ -113,7 +113,7 @@ func (p *Provider) PredictStream(
 		return nil, err
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 	scanner := providers.NewSSEScanner(resp.Body)
 
 	go p.streamResponse(ctx, resp.Body, scanner, outChan)
@@ -242,6 +242,12 @@ func (p *Provider) streamResponse(
 ) {
 	defer close(outChan)
 	defer body.Close()
+
+	// Close the response body when context is canceled to unblock scanner.Scan()
+	go func() {
+		<-ctx.Done()
+		_ = body.Close()
+	}()
 	var sb strings.Builder
 	totalTokens := 0
 

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -77,8 +77,9 @@ func (p *Provider) PredictStream(
 		if err != nil {
 			return nil, err
 		}
+		idleBody := providers.NewIdleTimeoutReader(body, providers.DefaultStreamIdleTimeout)
 		outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-		go p.streamResponse(ctx, body, scanner, outChan)
+		go p.streamResponse(ctx, idleBody, scanner, outChan)
 		return outChan, nil
 	}
 
@@ -114,9 +115,10 @@ func (p *Provider) PredictStream(
 	}
 
 	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-	scanner := providers.NewSSEScanner(resp.Body)
+	idleBody := providers.NewIdleTimeoutReader(resp.Body, providers.DefaultStreamIdleTimeout)
+	scanner := providers.NewSSEScanner(idleBody)
 
-	go p.streamResponse(ctx, resp.Body, scanner, outChan)
+	go p.streamResponse(ctx, idleBody, scanner, outChan)
 
 	return outChan, nil
 }
@@ -241,6 +243,7 @@ func (p *Provider) streamResponse(
 	ctx context.Context, body io.ReadCloser, scanner providers.StreamScanner, outChan chan<- providers.StreamChunk,
 ) {
 	defer close(outChan)
+
 	defer body.Close()
 
 	// Close the response body when context is canceled to unblock scanner.Scan()

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -480,8 +480,9 @@ func (p *ToolProvider) PredictStreamWithTools(
 		if err != nil {
 			return nil, err
 		}
+		idleBody := providers.NewIdleTimeoutReader(body, providers.DefaultStreamIdleTimeout)
 		outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-		go p.streamResponse(ctx, body, scanner, outChan)
+		go p.streamResponse(ctx, idleBody, scanner, outChan)
 		return outChan, nil
 	}
 
@@ -514,8 +515,9 @@ func (p *ToolProvider) PredictStreamWithTools(
 	}
 
 	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-	scanner := providers.NewSSEScanner(resp.Body)
-	go p.streamResponse(ctx, resp.Body, scanner, outChan)
+	idleBody := providers.NewIdleTimeoutReader(resp.Body, providers.DefaultStreamIdleTimeout)
+	scanner := providers.NewSSEScanner(idleBody)
+	go p.streamResponse(ctx, idleBody, scanner, outChan)
 
 	return outChan, nil
 }

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -480,7 +480,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 		if err != nil {
 			return nil, err
 		}
-		outChan := make(chan providers.StreamChunk)
+		outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 		go p.streamResponse(ctx, body, scanner, outChan)
 		return outChan, nil
 	}
@@ -513,7 +513,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 		return nil, fmt.Errorf("API request to %s failed with status %d: %s", url, resp.StatusCode, string(body))
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 	scanner := providers.NewSSEScanner(resp.Body)
 	go p.streamResponse(ctx, resp.Body, scanner, outChan)
 

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -324,25 +324,28 @@ func (p *Provider) handleNoCandidatesError(geminiResp geminiResponse, predictRes
 
 	// Check if prompt was blocked
 	if geminiResp.PromptFeedback != nil && geminiResp.PromptFeedback.BlockReason != "" {
-		errorMsg := fmt.Sprintf("no candidates in response - prompt blocked: %s", geminiResp.PromptFeedback.BlockReason)
+		var b strings.Builder
+		fmt.Fprintf(&b, "no candidates in response - prompt blocked: %s", geminiResp.PromptFeedback.BlockReason)
 		if len(geminiResp.PromptFeedback.SafetyRatings) > 0 {
-			errorMsg += " (safety ratings:"
+			b.WriteString(" (safety ratings:")
 			for _, rating := range geminiResp.PromptFeedback.SafetyRatings {
-				errorMsg += fmt.Sprintf(" %s=%s", rating.Category, rating.Probability)
+				fmt.Fprintf(&b, " %s=%s", rating.Category, rating.Probability)
 			}
-			errorMsg += ")"
+			b.WriteString(")")
 		}
-		errorMsg += " - consider adjusting safety settings or prompt content"
-		return predictResp, errors.New(errorMsg)
+		b.WriteString(" - consider adjusting safety settings or prompt content")
+		return predictResp, errors.New(b.String())
 	}
 
 	// No candidates but also no explicit block reason
-	errorMsg := "no candidates in response (prompt consumed tokens but generated no output)"
+	var b strings.Builder
+	b.WriteString("no candidates in response (prompt consumed tokens but generated no output)")
 	if geminiResp.UsageMetadata != nil {
-		errorMsg += fmt.Sprintf(" - used %d prompt tokens", geminiResp.UsageMetadata.PromptTokenCount)
+		fmt.Fprintf(&b, " - used %d prompt tokens", geminiResp.UsageMetadata.PromptTokenCount)
 	}
-	errorMsg += " - this may indicate the model refused to generate content, try rephrasing the prompt or checking system instructions"
-	return predictResp, errors.New(errorMsg)
+	b.WriteString(" - this may indicate the model refused to generate content, " +
+		"try rephrasing the prompt or checking system instructions")
+	return predictResp, errors.New(b.String())
 }
 
 // makeGeminiHTTPRequest sends the HTTP request to Gemini API

--- a/runtime/providers/gemini/gemini_multimodal.go
+++ b/runtime/providers/gemini/gemini_multimodal.go
@@ -402,7 +402,7 @@ func (p *Provider) predictStreamWithContents(ctx context.Context, contents []gem
 			logger.RedactSensitiveData(url), resp.StatusCode, string(body))
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	go p.streamResponse(ctx, resp.Body, outChan)
 

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -59,7 +59,7 @@ func (p *Provider) PredictStream(
 		return nil, err
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	go p.streamResponse(ctx, resp.Body, outChan)
 
@@ -143,6 +143,12 @@ func (p *Provider) processGeminiStreamChunk(
 func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
 	defer close(outChan)
 	defer body.Close()
+
+	// Close the response body when context is canceled to unblock decoder reads
+	go func() {
+		<-ctx.Done()
+		_ = body.Close()
+	}()
 
 	dec := json.NewDecoder(body)
 

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -142,7 +142,6 @@ func (p *Provider) processGeminiStreamChunk(
 // as it arrives, preserving the streaming benefit.
 func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
 	defer close(outChan)
-	defer body.Close()
 
 	// Close the response body when context is canceled to unblock decoder reads
 	go func() {
@@ -150,7 +149,11 @@ func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outCh
 		_ = body.Close()
 	}()
 
-	dec := json.NewDecoder(body)
+	// Wrap body with idle timeout detection to guard against stalled streams
+	idleBody := providers.NewIdleTimeoutReader(body, providers.DefaultStreamIdleTimeout)
+	defer idleBody.Close()
+
+	dec := json.NewDecoder(idleBody)
 
 	// Read the opening '[' token of the JSON array
 	tok, err := dec.Token()

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -572,7 +572,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 			logger.RedactSensitiveData(url), resp.StatusCode, string(body))
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 	go p.streamResponse(ctx, resp.Body, outChan)
 
 	return outChan, nil

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -432,13 +433,13 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte, predictResp providers
 	}
 
 	// Extract text content and tool calls
-	var textContent string
+	var textBuilder strings.Builder
 	var toolCalls []types.MessageToolCall
 
 	for i, part := range candidate.Content.Parts {
 		// Check for text content
 		if part.Text != "" {
-			textContent += part.Text
+			textBuilder.WriteString(part.Text)
 		}
 
 		// Check for function call
@@ -466,7 +467,7 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte, predictResp providers
 	// Calculate cost breakdown (Gemini doesn't support cached tokens yet)
 	costBreakdown := p.Provider.CalculateCost(tokensIn, tokensOut, 0)
 
-	predictResp.Content = textContent
+	predictResp.Content = textBuilder.String()
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = time.Since(start)
 	predictResp.Raw = respBytes

--- a/runtime/providers/gemini/stream_session_reconnect_test.go
+++ b/runtime/providers/gemini/stream_session_reconnect_test.go
@@ -17,18 +17,30 @@ import (
 // This simulates Gemini's behavior of dropping connections mid-conversation.
 func TestStreamSession_ReconnectOnUnexpectedClose(t *testing.T) {
 	var connectionCount atomic.Int32
+	// Use a done channel to prevent t.Log calls after test completion (avoids data race).
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+
+	logf := func(format string, args ...interface{}) {
+		select {
+		case <-done:
+			return
+		default:
+			t.Logf(format, args...)
+		}
+	}
 
 	server := newMockWebSocketServer(func(conn *websocket.Conn) {
 		count := connectionCount.Add(1)
-		t.Logf("Server: connection #%d established", count)
+		logf("Server: connection #%d established", count)
 
 		// Read setup message
 		_, data, err := conn.ReadMessage()
 		if err != nil {
-			t.Logf("Server: error reading setup: %v", err)
+			logf("Server: error reading setup: %v", err)
 			return
 		}
-		t.Logf("Server: received setup message: %s", string(data))
+		logf("Server: received setup message: %s", string(data))
 
 		// Send setup_complete response
 		setupResponse := ServerMessage{
@@ -36,26 +48,26 @@ func TestStreamSession_ReconnectOnUnexpectedClose(t *testing.T) {
 		}
 		setupData, _ := json.Marshal(setupResponse)
 		if err := conn.WriteMessage(websocket.TextMessage, setupData); err != nil {
-			t.Logf("Server: error sending setup_complete: %v", err)
+			logf("Server: error sending setup_complete: %v", err)
 			return
 		}
-		t.Logf("Server: sent setup_complete")
+		logf("Server: sent setup_complete")
 
 		if count == 1 {
 			// First connection: close unexpectedly after a short delay
 			// This simulates Gemini closing the connection mid-conversation
 			time.Sleep(100 * time.Millisecond)
-			t.Log("Server: closing connection unexpectedly (simulating Gemini behavior)")
+			logf("Server: closing connection unexpectedly (simulating Gemini behavior)")
 			conn.Close()
 			return
 		}
 
 		// Second connection: stay alive and handle messages
-		t.Log("Server: second connection - staying alive")
+		logf("Server: second connection - staying alive")
 		for {
 			_, _, err := conn.ReadMessage()
 			if err != nil {
-				t.Logf("Server: connection #%d closed: %v", count, err)
+				logf("Server: connection #%d closed: %v", count, err)
 				return
 			}
 		}

--- a/runtime/providers/idle_timeout.go
+++ b/runtime/providers/idle_timeout.go
@@ -1,0 +1,71 @@
+package providers
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"time"
+)
+
+// ErrStreamIdleTimeout is returned when no data is received within the idle timeout.
+var ErrStreamIdleTimeout = errors.New("stream idle timeout: no data received")
+
+// IdleTimeoutReader wraps an io.ReadCloser with idle timeout detection.
+// If no data is read within the configured timeout, the underlying reader
+// is closed, causing any blocking Read to return an error.
+type IdleTimeoutReader struct {
+	inner   io.ReadCloser
+	timeout time.Duration
+	timer   *time.Timer
+
+	mu     sync.Mutex
+	closed bool
+}
+
+// NewIdleTimeoutReader wraps the given reader with idle timeout detection.
+// The timeout is reset on every successful Read that returns data.
+// If the timeout fires, the underlying reader is closed to unblock any
+// pending Read calls.
+func NewIdleTimeoutReader(r io.ReadCloser, timeout time.Duration) *IdleTimeoutReader {
+	itr := &IdleTimeoutReader{
+		inner:   r,
+		timeout: timeout,
+	}
+
+	itr.timer = time.AfterFunc(timeout, func() {
+		itr.mu.Lock()
+		defer itr.mu.Unlock()
+		if !itr.closed {
+			itr.closed = true
+			itr.inner.Close()
+		}
+	})
+
+	return itr
+}
+
+// Read reads from the underlying reader and resets the idle timer on success.
+func (r *IdleTimeoutReader) Read(p []byte) (int, error) {
+	n, err := r.inner.Read(p)
+	if n > 0 {
+		r.timer.Reset(r.timeout)
+	}
+	return n, err
+}
+
+// Close stops the idle timer and closes the underlying reader.
+func (r *IdleTimeoutReader) Close() error {
+	r.timer.Stop()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.closed {
+		r.closed = true
+		return r.inner.Close()
+	}
+	return nil
+}
+
+// IsStreamIdleTimeout checks if an error is (or wraps) a stream idle timeout.
+func IsStreamIdleTimeout(err error) bool {
+	return errors.Is(err, ErrStreamIdleTimeout)
+}

--- a/runtime/providers/idle_timeout_test.go
+++ b/runtime/providers/idle_timeout_test.go
@@ -1,0 +1,252 @@
+package providers
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// nopCloser wraps a reader with a no-op Close method.
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+// slowReader blocks on Read until the provided channel is closed or a value is sent.
+type slowReader struct {
+	dataCh chan []byte
+	mu     sync.Mutex
+	closed bool
+}
+
+func newSlowReader() *slowReader {
+	return &slowReader{dataCh: make(chan []byte, 10)}
+}
+
+func (r *slowReader) Read(p []byte) (int, error) {
+	data, ok := <-r.dataCh
+	if !ok {
+		return 0, io.EOF
+	}
+	n := copy(p, data)
+	return n, nil
+}
+
+func (r *slowReader) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.closed {
+		r.closed = true
+		close(r.dataCh)
+	}
+	return nil
+}
+
+func TestIdleTimeoutReader_NormalRead(t *testing.T) {
+	data := "hello world"
+	inner := nopCloser{strings.NewReader(data)}
+	reader := NewIdleTimeoutReader(inner, 5*time.Second)
+	defer reader.Close()
+
+	buf := make([]byte, len(data))
+	n, err := reader.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("expected %d bytes, got %d", len(data), n)
+	}
+	if string(buf[:n]) != data {
+		t.Fatalf("expected %q, got %q", data, string(buf[:n]))
+	}
+}
+
+func TestIdleTimeoutReader_TimeoutClosesBody(t *testing.T) {
+	sr := newSlowReader()
+	reader := NewIdleTimeoutReader(sr, 50*time.Millisecond)
+	defer reader.Close()
+
+	// Read should block and then fail when idle timeout fires and closes the body
+	buf := make([]byte, 1024)
+	_, err := reader.Read(buf)
+	if err == nil {
+		t.Fatal("expected error from idle timeout, got nil")
+	}
+}
+
+func TestIdleTimeoutReader_ResetOnData(t *testing.T) {
+	sr := newSlowReader()
+	reader := NewIdleTimeoutReader(sr, 100*time.Millisecond)
+	defer reader.Close()
+
+	// Send data before timeout fires - this should reset the timer
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		sr.dataCh <- []byte("chunk1")
+		time.Sleep(50 * time.Millisecond)
+		sr.dataCh <- []byte("chunk2")
+		time.Sleep(50 * time.Millisecond)
+		sr.dataCh <- []byte("chunk3")
+		time.Sleep(50 * time.Millisecond)
+		sr.Close()
+	}()
+
+	var chunks []string
+	buf := make([]byte, 1024)
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			chunks = append(chunks, string(buf[:n]))
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	// Should have received all 3 chunks because each arrived within timeout
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d: %v", len(chunks), chunks)
+	}
+	if chunks[0] != "chunk1" || chunks[1] != "chunk2" || chunks[2] != "chunk3" {
+		t.Fatalf("unexpected chunks: %v", chunks)
+	}
+}
+
+func TestIdleTimeoutReader_CloseStopsTimer(t *testing.T) {
+	inner := nopCloser{strings.NewReader("data")}
+	reader := NewIdleTimeoutReader(inner, 5*time.Second)
+
+	// Close should not panic and should stop the timer
+	err := reader.Close()
+	if err != nil {
+		t.Fatalf("unexpected error on close: %v", err)
+	}
+
+	// Double close should not panic
+	err = reader.Close()
+	if err != nil {
+		t.Fatalf("unexpected error on double close: %v", err)
+	}
+}
+
+func TestIdleTimeoutReader_MultipleReads(t *testing.T) {
+	data := "abcdefghijklmnop"
+	inner := nopCloser{bytes.NewReader([]byte(data))}
+	reader := NewIdleTimeoutReader(inner, 5*time.Second)
+	defer reader.Close()
+
+	// Read in small chunks
+	var result []byte
+	buf := make([]byte, 4)
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			result = append(result, buf[:n]...)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if string(result) != data {
+		t.Fatalf("expected %q, got %q", data, string(result))
+	}
+}
+
+func TestIdleTimeoutReader_ZeroBytesDoNotReset(t *testing.T) {
+	// A reader that returns 0 bytes should not reset the timer
+	sr := newSlowReader()
+	reader := NewIdleTimeoutReader(sr, 50*time.Millisecond)
+	defer reader.Close()
+
+	// Don't send any data - the timer should fire
+	buf := make([]byte, 1024)
+	start := time.Now()
+	_, err := reader.Read(buf)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from idle timeout, got nil")
+	}
+	// Should have timed out around 50ms
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("timeout took too long: %v", elapsed)
+	}
+}
+
+func TestDefaultStreamIdleTimeout(t *testing.T) {
+	if DefaultStreamIdleTimeout != 30*time.Second {
+		t.Fatalf("expected DefaultStreamIdleTimeout to be 30s, got %v", DefaultStreamIdleTimeout)
+	}
+}
+
+func TestIsStreamIdleTimeout(t *testing.T) {
+	if !IsStreamIdleTimeout(ErrStreamIdleTimeout) {
+		t.Fatal("IsStreamIdleTimeout should return true for ErrStreamIdleTimeout")
+	}
+
+	wrapped := errors.New("wrapped: " + ErrStreamIdleTimeout.Error())
+	if IsStreamIdleTimeout(wrapped) {
+		// Not wrapped with %w, so should not match
+	}
+
+	if IsStreamIdleTimeout(errors.New("other error")) {
+		t.Fatal("IsStreamIdleTimeout should return false for other errors")
+	}
+
+	if IsStreamIdleTimeout(nil) {
+		t.Fatal("IsStreamIdleTimeout should return false for nil")
+	}
+}
+
+// closerTracker tracks whether Close was called
+type closerTracker struct {
+	io.Reader
+	closed bool
+}
+
+func (c *closerTracker) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestIdleTimeoutReader_InnerCloseCalledOnTimeout(t *testing.T) {
+	sr := newSlowReader()
+	reader := NewIdleTimeoutReader(sr, 50*time.Millisecond)
+
+	// Wait for timeout to fire
+	time.Sleep(100 * time.Millisecond)
+
+	// The inner reader should have been closed by the timer
+	sr.mu.Lock()
+	closed := sr.closed
+	sr.mu.Unlock()
+	if !closed {
+		t.Fatal("expected inner reader to be closed after idle timeout")
+	}
+
+	// Explicit close should not panic (double close)
+	reader.Close()
+}
+
+func TestIdleTimeoutReader_InnerCloseCalledOnExplicitClose(t *testing.T) {
+	tracker := &closerTracker{Reader: strings.NewReader("data")}
+	reader := NewIdleTimeoutReader(tracker, 5*time.Second)
+
+	err := reader.Close()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !tracker.closed {
+		t.Fatal("expected inner reader Close to be called")
+	}
+}

--- a/runtime/providers/mock/mock_tool_provider_interactive.go
+++ b/runtime/providers/mock/mock_tool_provider_interactive.go
@@ -305,7 +305,7 @@ func (m *ToolProvider) PredictStreamWithTools(
 	}
 
 	// Create a channel and send the response as chunks
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	go func() {
 		defer close(outChan)

--- a/runtime/providers/ollama/ollama.go
+++ b/runtime/providers/ollama/ollama.go
@@ -287,6 +287,12 @@ func (p *Provider) streamResponse(
 	defer close(outChan)
 	defer body.Close()
 
+	// Close the response body when context is canceled to unblock scanner.Scan()
+	go func() {
+		<-ctx.Done()
+		_ = body.Close()
+	}()
+
 	scanner := providers.NewSSEScanner(body)
 	var sb strings.Builder
 	totalTokens := 0
@@ -646,7 +652,7 @@ func (p *Provider) predictStreamWithMessages(
 		return nil, err
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	go p.streamResponse(ctx, resp.Body, outChan)
 

--- a/runtime/providers/ollama/ollama.go
+++ b/runtime/providers/ollama/ollama.go
@@ -285,7 +285,6 @@ func (p *Provider) streamResponse(
 	outChan chan<- providers.StreamChunk,
 ) {
 	defer close(outChan)
-	defer body.Close()
 
 	// Close the response body when context is canceled to unblock scanner.Scan()
 	go func() {
@@ -293,7 +292,11 @@ func (p *Provider) streamResponse(
 		_ = body.Close()
 	}()
 
-	scanner := providers.NewSSEScanner(body)
+	// Wrap body with idle timeout detection to guard against stalled streams
+	idleBody := providers.NewIdleTimeoutReader(body, providers.DefaultStreamIdleTimeout)
+	defer idleBody.Close()
+
+	scanner := providers.NewSSEScanner(idleBody)
 	var sb strings.Builder
 	totalTokens := 0
 	var accumulatedToolCalls []types.MessageToolCall

--- a/runtime/providers/ollama/ollama_tools.go
+++ b/runtime/providers/ollama/ollama_tools.go
@@ -355,7 +355,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 		return nil, err
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	go p.streamResponse(ctx, resp.Body, outChan)
 

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -447,6 +447,12 @@ func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outCh
 	defer close(outChan)
 	defer body.Close()
 
+	// Close the response body when context is canceled to unblock scanner.Scan()
+	go func() {
+		<-ctx.Done()
+		_ = body.Close()
+	}()
+
 	scanner := providers.NewSSEScanner(body)
 	var sb strings.Builder
 	totalTokens := 0
@@ -797,7 +803,7 @@ func (p *Provider) predictStreamWithMessages(ctx context.Context, req providers.
 		return nil, err
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	go p.streamResponse(ctx, resp.Body, outChan)
 

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -445,7 +445,6 @@ func (p *Provider) createFinalStreamChunk(accumulated string, accumulatedToolCal
 // streamResponse reads SSE stream from OpenAI and sends chunks
 func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
 	defer close(outChan)
-	defer body.Close()
 
 	// Close the response body when context is canceled to unblock scanner.Scan()
 	go func() {
@@ -453,7 +452,11 @@ func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outCh
 		_ = body.Close()
 	}()
 
-	scanner := providers.NewSSEScanner(body)
+	// Wrap body with idle timeout detection to guard against stalled streams
+	idleBody := providers.NewIdleTimeoutReader(body, providers.DefaultStreamIdleTimeout)
+	defer idleBody.Close()
+
+	scanner := providers.NewSSEScanner(idleBody)
 	var sb strings.Builder
 	totalTokens := 0
 	var accumulatedToolCalls []types.MessageToolCall

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -766,7 +766,6 @@ func (p *Provider) streamResponsesResponse(
 	outChan chan<- providers.StreamChunk,
 ) {
 	defer close(outChan)
-	defer body.Close()
 
 	// Close the response body when context is canceled to unblock scanner.Scan()
 	go func() {
@@ -774,7 +773,11 @@ func (p *Provider) streamResponsesResponse(
 		_ = body.Close()
 	}()
 
-	scanner := bufio.NewScanner(body)
+	// Wrap body with idle timeout detection to guard against stalled streams
+	idleBody := providers.NewIdleTimeoutReader(body, providers.DefaultStreamIdleTimeout)
+	defer idleBody.Close()
+
+	scanner := bufio.NewScanner(idleBody)
 	var sb strings.Builder
 	totalTokens := 0
 	var accumulatedToolCalls []types.MessageToolCall

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -568,7 +568,7 @@ func (p *Provider) predictStreamWithResponses(
 		return nil, err
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 	go p.streamResponsesResponse(ctx, resp.Body, outChan)
 
 	return outChan, nil
@@ -767,6 +767,12 @@ func (p *Provider) streamResponsesResponse(
 ) {
 	defer close(outChan)
 	defer body.Close()
+
+	// Close the response body when context is canceled to unblock scanner.Scan()
+	go func() {
+		<-ctx.Done()
+		_ = body.Close()
+	}()
 
 	scanner := bufio.NewScanner(body)
 	var sb strings.Builder

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -400,7 +400,7 @@ func (p *ToolProvider) predictStreamWithCompletions(
 		return nil, err
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	go p.streamResponse(ctx, resp.Body, outChan)
 

--- a/runtime/providers/streaming.go
+++ b/runtime/providers/streaming.go
@@ -12,6 +12,11 @@ import (
 // when the consumer is slow, while keeping memory usage reasonable.
 const DefaultStreamBufferSize = 32
 
+// DefaultStreamIdleTimeout is the maximum time to wait between stream chunks
+// before considering the stream stalled. If no data is received within this
+// duration, the response body is closed to unblock the reader.
+const DefaultStreamIdleTimeout = 30 * time.Second
+
 // ExecutionResult is a forward declaration to avoid circular import.
 type ExecutionResult interface{}
 

--- a/runtime/providers/streaming.go
+++ b/runtime/providers/streaming.go
@@ -7,6 +7,11 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// DefaultStreamBufferSize is the default buffer size for streaming channels.
+// A buffer of 32 prevents the streaming goroutine from blocking on every send
+// when the consumer is slow, while keeping memory usage reasonable.
+const DefaultStreamBufferSize = 32
+
 // ExecutionResult is a forward declaration to avoid circular import.
 type ExecutionResult interface{}
 

--- a/runtime/providers/streaming_mock_test.go
+++ b/runtime/providers/streaming_mock_test.go
@@ -418,3 +418,114 @@ func TestIsValidationAbortWithNil(t *testing.T) {
 		t.Error("providers.IsValidationAbort(nil) should return false")
 	}
 }
+
+func TestContextCancelUnblocksScannerOpenAI(t *testing.T) {
+	// Create a server that holds the connection open indefinitely (simulating a slow/stalled stream)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		// Hold connection open until client disconnects
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	provider := openai.NewProvider(
+		"test", "gpt-4o-mini", server.URL,
+		providers.ProviderDefaults{MaxTokens: 100}, false,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stream, err := provider.PredictStream(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "test"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream failed: %v", err)
+	}
+
+	// Read the first chunk to confirm streaming is working
+	chunk, ok := <-stream
+	if !ok {
+		t.Fatal("expected at least one chunk")
+	}
+	if chunk.Content != "hi" {
+		t.Errorf("expected content 'hi', got %q", chunk.Content)
+	}
+
+	// Cancel context - the body-close watcher should unblock the scanner
+	cancel()
+
+	// The channel should close promptly (within 2 seconds).
+	// Without the body-close fix, this would hang indefinitely.
+	done := make(chan struct{})
+	go func() {
+		for range stream {
+			// drain remaining chunks
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success - stream closed promptly after cancel
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not close within 2s after context cancellation; scanner may be stuck on I/O")
+	}
+}
+
+func TestContextCancelUnblocksScannerClaude(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	provider := claude.NewProvider(
+		"test", "claude-3-5-haiku-20241022", server.URL,
+		providers.ProviderDefaults{MaxTokens: 100}, false,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stream, err := provider.PredictStream(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "test"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream failed: %v", err)
+	}
+
+	// Read the first chunk
+	_, ok := <-stream
+	if !ok {
+		t.Fatal("expected at least one chunk")
+	}
+
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		for range stream {
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not close within 2s after context cancellation")
+	}
+}

--- a/runtime/providers/streaming_test.go
+++ b/runtime/providers/streaming_test.go
@@ -543,6 +543,38 @@ func (m *mockStreamObserver) OnError(err error) {
 	m.errors = append(m.errors, err)
 }
 
+func TestDefaultStreamBufferSize(t *testing.T) {
+	if providers.DefaultStreamBufferSize != 32 {
+		t.Errorf("DefaultStreamBufferSize: got %d, want 32", providers.DefaultStreamBufferSize)
+	}
+}
+
+func TestStreamChannelBufferCapacity(t *testing.T) {
+	ch := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
+
+	if cap(ch) != 32 {
+		t.Errorf("channel capacity: got %d, want 32", cap(ch))
+	}
+
+	// Verify we can send DefaultStreamBufferSize chunks without blocking
+	for i := 0; i < providers.DefaultStreamBufferSize; i++ {
+		select {
+		case ch <- providers.StreamChunk{Delta: "chunk"}:
+			// ok
+		default:
+			t.Fatalf("channel blocked on send %d, expected buffer of %d", i, providers.DefaultStreamBufferSize)
+		}
+	}
+
+	// The next send should block (buffer full)
+	select {
+	case ch <- providers.StreamChunk{Delta: "overflow"}:
+		t.Fatal("channel should block when buffer is full")
+	default:
+		// expected
+	}
+}
+
 func TestMockObserver(t *testing.T) {
 	observer := &mockStreamObserver{}
 

--- a/runtime/providers/vllm/vllm.go
+++ b/runtime/providers/vllm/vllm.go
@@ -477,7 +477,7 @@ func (p *Provider) predictStreamWithMessages(
 		return nil, err
 	}
 
-	outChan := make(chan providers.StreamChunk)
+	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	go p.streamResponse(ctx, resp.Body, outChan)
 
@@ -492,6 +492,12 @@ func (p *Provider) streamResponse(
 ) {
 	defer close(outChan)
 	defer body.Close()
+
+	// Close the response body when context is canceled to unblock scanner.Scan()
+	go func() {
+		<-ctx.Done()
+		_ = body.Close()
+	}()
 
 	scanner := providers.NewSSEScanner(body)
 	var sb strings.Builder // Track accumulated content

--- a/runtime/providers/vllm/vllm.go
+++ b/runtime/providers/vllm/vllm.go
@@ -491,7 +491,6 @@ func (p *Provider) streamResponse(
 	outChan chan<- providers.StreamChunk,
 ) {
 	defer close(outChan)
-	defer body.Close()
 
 	// Close the response body when context is canceled to unblock scanner.Scan()
 	go func() {
@@ -499,7 +498,11 @@ func (p *Provider) streamResponse(
 		_ = body.Close()
 	}()
 
-	scanner := providers.NewSSEScanner(body)
+	// Wrap body with idle timeout detection to guard against stalled streams
+	idleBody := providers.NewIdleTimeoutReader(body, providers.DefaultStreamIdleTimeout)
+	defer idleBody.Close()
+
+	scanner := providers.NewSSEScanner(idleBody)
 	var sb strings.Builder // Track accumulated content
 
 	for scanner.Scan() {

--- a/runtime/providers/vllm/vllm_tools.go
+++ b/runtime/providers/vllm/vllm_tools.go
@@ -22,7 +22,6 @@ const (
 	toolChoiceNone     = "none"
 	toolChoiceAuto     = "auto"
 	sseDoneMessage     = "[DONE]"
-	streamBufferSize   = 10
 )
 
 // vLLM-specific tool structures (OpenAI-compatible format)
@@ -255,7 +254,7 @@ func (p *Provider) PredictStreamWithTools(
 	}
 
 	// Create output channel
-	chunks := make(chan providers.StreamChunk, streamBufferSize)
+	chunks := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
 
 	// Start goroutine to process SSE stream
 	go p.streamToolResponse(ctx, httpResp.Body, chunks)
@@ -350,6 +349,12 @@ func (p *Provider) buildToolRequest(
 func (p *Provider) streamToolResponse(ctx context.Context, body io.ReadCloser, chunks chan<- providers.StreamChunk) {
 	defer close(chunks)
 	defer body.Close()
+
+	// Close the response body when context is canceled to unblock scanner.Scan()
+	go func() {
+		<-ctx.Done()
+		_ = body.Close()
+	}()
 
 	scanner := bufio.NewScanner(body)
 	var accumulated strings.Builder

--- a/runtime/statestore/interface.go
+++ b/runtime/statestore/interface.go
@@ -65,6 +65,17 @@ type MessageAppender interface {
 	AppendMessages(ctx context.Context, id string, messages []types.Message) error
 }
 
+// MetadataAccessor allows reading metadata without loading the full state.
+// This is an optional interface — stores that implement it enable efficient
+// metadata reads without the cost of deep-copying the message history.
+// Pipeline stages type-assert for this interface and fall back to Store.Load when unavailable.
+type MetadataAccessor interface {
+	// LoadMetadata returns just the metadata map for the given conversation.
+	// Returns ErrNotFound if the conversation doesn't exist.
+	// The returned map is a deep copy safe for mutation by the caller.
+	LoadMetadata(ctx context.Context, id string) (map[string]interface{}, error)
+}
+
 // SummaryAccessor allows reading and writing summaries independently of the full state.
 // This is an optional interface for stores that support efficient summary operations.
 type SummaryAccessor interface {

--- a/runtime/statestore/memory.go
+++ b/runtime/statestore/memory.go
@@ -411,14 +411,16 @@ func (s *MemoryStore) LoadRecentMessages(ctx context.Context, id string, n int) 
 }
 
 // MessageCount returns the total number of messages in the conversation.
-// Expired entries return ErrNotFound.
+// Uses a read lock since it only needs the message count, not a mutable reference.
+// Expired entries return ErrNotFound but are not eagerly evicted under RLock;
+// they will be cleaned up on the next write operation or background eviction.
 func (s *MemoryStore) MessageCount(ctx context.Context, id string) (int, error) {
 	if id == "" {
 		return 0, ErrInvalidID
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	state, exists := s.states[id]
 	if !exists {
@@ -426,15 +428,40 @@ func (s *MemoryStore) MessageCount(ctx context.Context, id string) (int, error) 
 	}
 
 	if s.isExpired(state) {
-		s.deleteStateLocked(id, state)
 		return 0, ErrNotFound
+	}
+
+	return len(state.Messages), nil
+}
+
+// LoadMetadata returns just the metadata map for the given conversation.
+// This avoids the cost of deep-copying the entire message history, making it
+// significantly cheaper than Load() for callers that only need metadata.
+// Expired entries are lazily evicted and return ErrNotFound.
+func (s *MemoryStore) LoadMetadata(ctx context.Context, id string) (map[string]interface{}, error) {
+	if id == "" {
+		return nil, ErrInvalidID
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, exists := s.states[id]
+	if !exists {
+		return nil, ErrNotFound
+	}
+
+	if s.isExpired(state) {
+		s.deleteStateLocked(id, state)
+		return nil, ErrNotFound
 	}
 
 	now := time.Now()
 	state.LastAccessedAt = now
 	s.touchLRULocked(id, now)
 
-	return len(state.Messages), nil
+	// Only deep copy the metadata map, not the entire state
+	return cloneMapStringInterface(state.Metadata), nil
 }
 
 // AppendMessages appends messages to the conversation's message history.
@@ -476,14 +503,16 @@ func (s *MemoryStore) AppendMessages(ctx context.Context, id string, messages []
 }
 
 // LoadSummaries returns all summaries for the given conversation.
-// Expired entries return nil.
+// Uses a read lock since summaries contain only value types and cloning
+// is a simple slice copy that doesn't benefit from write-lock protection.
+// Expired entries return nil but are not eagerly evicted under RLock.
 func (s *MemoryStore) LoadSummaries(ctx context.Context, id string) ([]Summary, error) {
 	if id == "" {
 		return nil, ErrInvalidID
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	state, exists := s.states[id]
 	if !exists {
@@ -491,19 +520,15 @@ func (s *MemoryStore) LoadSummaries(ctx context.Context, id string) ([]Summary, 
 	}
 
 	if s.isExpired(state) {
-		s.deleteStateLocked(id, state)
 		return nil, nil
 	}
-
-	now := time.Now()
-	state.LastAccessedAt = now
-	s.touchLRULocked(id, now)
 
 	if len(state.Summaries) == 0 {
 		return nil, nil
 	}
 
-	// Deep copy summaries using structural cloning
+	// Summary contains only value types (int, string, time.Time),
+	// so a simple slice copy suffices for isolation.
 	return cloneSummaries(state.Summaries), nil
 }
 

--- a/runtime/statestore/memory.go
+++ b/runtime/statestore/memory.go
@@ -1,6 +1,7 @@
 package statestore
 
 import (
+	"container/heap"
 	"context"
 	"encoding/json"
 	"sort"
@@ -10,6 +11,42 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// =============================================================================
+// Min-heap for O(log N) LRU eviction
+// =============================================================================
+
+// accessEntry tracks a key's last access time for the LRU heap.
+type accessEntry struct {
+	key        string
+	lastAccess time.Time
+	index      int // position in the heap, maintained by heap.Interface
+}
+
+// accessHeap is a min-heap of accessEntry ordered by lastAccess (oldest first).
+type accessHeap []*accessEntry
+
+func (h accessHeap) Len() int           { return len(h) }
+func (h accessHeap) Less(i, j int) bool { return h[i].lastAccess.Before(h[j].lastAccess) }
+func (h accessHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i]; h[i].index = i; h[j].index = j }
+
+// Push adds an element to the heap. Required by heap.Interface.
+func (h *accessHeap) Push(x interface{}) {
+	entry := x.(*accessEntry)
+	entry.index = len(*h)
+	*h = append(*h, entry)
+}
+
+// Pop removes and returns the minimum element from the heap. Required by heap.Interface.
+func (h *accessHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	entry := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	entry.index = -1
+	*h = old[:n-1]
+	return entry
+}
 
 // DefaultTTL is the default time-to-live for conversation states in a MemoryStore.
 // Entries that have not been accessed within the TTL are considered expired and
@@ -93,6 +130,10 @@ type MemoryStore struct {
 	// Index for efficient user-based lookups
 	userIndex map[string]map[string]struct{} // userID -> set of conversationIDs
 
+	// LRU eviction heap (min-heap ordered by lastAccess)
+	lruHeap   accessHeap
+	heapIndex map[string]*accessEntry // key -> heap entry for O(log N) updates
+
 	// TTL and eviction settings
 	ttl              time.Duration // zero means no expiry
 	maxEntries       int           // zero means no limit
@@ -112,6 +153,7 @@ func NewMemoryStore(opts ...MemoryStoreOption) *MemoryStore {
 	s := &MemoryStore{
 		states:    make(map[string]*ConversationState),
 		userIndex: make(map[string]map[string]struct{}),
+		heapIndex: make(map[string]*accessEntry),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -164,7 +206,9 @@ func (s *MemoryStore) Load(ctx context.Context, id string) (*ConversationState, 
 		return nil, ErrNotFound
 	}
 
-	state.LastAccessedAt = time.Now()
+	now := time.Now()
+	state.LastAccessedAt = now
+	s.touchLRULocked(id, now)
 
 	// Return a deep copy to prevent external mutations
 	return deepCopyState(state), nil
@@ -194,10 +238,12 @@ func (s *MemoryStore) Save(ctx context.Context, state *ConversationState) error 
 
 	// Store a deep copy to prevent external mutations
 	stateCopy := deepCopyState(state)
-	stateCopy.LastAccessedAt = time.Now()
+	now := time.Now()
+	stateCopy.LastAccessedAt = now
 
 	// Update main storage
 	s.states[state.ID] = stateCopy
+	s.touchLRULocked(state.ID, now)
 
 	// Update user index if UserID is set
 	if state.UserID != "" {
@@ -238,10 +284,12 @@ func (s *MemoryStore) Fork(ctx context.Context, sourceID, newID string) error {
 	// Deep copy the state
 	forked := deepCopyState(source)
 	forked.ID = newID
-	forked.LastAccessedAt = time.Now()
+	now := time.Now()
+	forked.LastAccessedAt = now
 
 	// Store the forked state
 	s.states[newID] = forked
+	s.touchLRULocked(newID, now)
 
 	// Update user index if UserID is set
 	if forked.UserID != "" {
@@ -348,7 +396,9 @@ func (s *MemoryStore) LoadRecentMessages(ctx context.Context, id string, n int) 
 		return nil, ErrNotFound
 	}
 
-	state.LastAccessedAt = time.Now()
+	now := time.Now()
+	state.LastAccessedAt = now
+	s.touchLRULocked(id, now)
 
 	msgs := state.Messages
 	if n >= len(msgs) {
@@ -380,7 +430,9 @@ func (s *MemoryStore) MessageCount(ctx context.Context, id string) (int, error) 
 		return 0, ErrNotFound
 	}
 
-	state.LastAccessedAt = time.Now()
+	now := time.Now()
+	state.LastAccessedAt = now
+	s.touchLRULocked(id, now)
 
 	return len(state.Messages), nil
 }
@@ -416,7 +468,9 @@ func (s *MemoryStore) AppendMessages(ctx context.Context, id string, messages []
 
 	// Deep copy new messages before appending using structural cloning
 	state.Messages = append(state.Messages, cloneMessages(messages)...)
-	state.LastAccessedAt = time.Now()
+	now := time.Now()
+	state.LastAccessedAt = now
+	s.touchLRULocked(id, now)
 
 	return nil
 }
@@ -441,7 +495,9 @@ func (s *MemoryStore) LoadSummaries(ctx context.Context, id string) ([]Summary, 
 		return nil, nil
 	}
 
-	state.LastAccessedAt = time.Now()
+	now := time.Now()
+	state.LastAccessedAt = now
+	s.touchLRULocked(id, now)
 
 	if len(state.Summaries) == 0 {
 		return nil, nil
@@ -472,7 +528,9 @@ func (s *MemoryStore) SaveSummary(ctx context.Context, id string, summary Summar
 	}
 
 	state.Summaries = append(state.Summaries, summary)
-	state.LastAccessedAt = time.Now()
+	now := time.Now()
+	state.LastAccessedAt = now
+	s.touchLRULocked(id, now)
 
 	return nil
 }
@@ -505,41 +563,81 @@ func (s *MemoryStore) deleteStateLocked(id string, state *ConversationState) {
 		s.removeFromUserIndex(state.UserID, id)
 	}
 	delete(s.states, id)
+
+	// Remove from LRU heap
+	if entry, ok := s.heapIndex[id]; ok {
+		heap.Remove(&s.lruHeap, entry.index)
+		delete(s.heapIndex, id)
+	}
+}
+
+// touchLRULocked updates or inserts a key in the LRU heap with the given access time.
+// Must be called with the write lock held.
+func (s *MemoryStore) touchLRULocked(key string, accessTime time.Time) {
+	if entry, ok := s.heapIndex[key]; ok {
+		entry.lastAccess = accessTime
+		heap.Fix(&s.lruHeap, entry.index)
+	} else {
+		entry = &accessEntry{key: key, lastAccess: accessTime}
+		heap.Push(&s.lruHeap, entry)
+		s.heapIndex[key] = entry
+	}
 }
 
 // evictLRULocked removes the least-recently-accessed entry from the store.
+// Uses a min-heap for O(log N) eviction instead of O(N) full scan.
 // Must be called with the write lock held.
 func (s *MemoryStore) evictLRULocked() {
-	var oldestID string
-	var oldestTime time.Time
-	first := true
+	for s.lruHeap.Len() > 0 {
+		entry := heap.Pop(&s.lruHeap).(*accessEntry)
+		delete(s.heapIndex, entry.key)
 
-	for id, state := range s.states {
-		if first || state.LastAccessedAt.Before(oldestTime) {
-			oldestID = id
-			oldestTime = state.LastAccessedAt
-			first = false
+		if state, ok := s.states[entry.key]; ok {
+			if state.UserID != "" {
+				s.removeFromUserIndex(state.UserID, entry.key)
+			}
+			delete(s.states, entry.key)
+			return
 		}
-	}
-
-	if !first {
-		if state, ok := s.states[oldestID]; ok {
-			s.deleteStateLocked(oldestID, state)
-		}
+		// Entry was already deleted from states (e.g., by TTL expiry); pop next.
 	}
 }
 
-// evictExpiredLocked removes all expired entries from the store.
-// Must be called with the write lock held.
-func (s *MemoryStore) evictExpiredLocked() {
+// collectExpiredKeys scans under RLock and returns the IDs of all expired entries.
+func (s *MemoryStore) collectExpiredKeys() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var expired []string
 	for id, state := range s.states {
 		if s.isExpired(state) {
+			expired = append(expired, id)
+		}
+	}
+	return expired
+}
+
+// deleteExpiredKeys takes a write lock and deletes the given keys if they are still expired.
+// Keys that were refreshed between the scan and delete phases are skipped.
+func (s *MemoryStore) deleteExpiredKeys(keys []string) {
+	if len(keys) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, id := range keys {
+		state, ok := s.states[id]
+		if ok && s.isExpired(state) {
 			s.deleteStateLocked(id, state)
 		}
 	}
 }
 
 // backgroundEviction runs periodic cleanup of expired entries.
+// Uses a two-phase approach: RLock scan to collect expired keys, then write lock to delete.
+// This allows concurrent reads during the scan phase.
 func (s *MemoryStore) backgroundEviction() {
 	ticker := time.NewTicker(s.evictionInterval)
 	defer ticker.Stop()
@@ -549,9 +647,8 @@ func (s *MemoryStore) backgroundEviction() {
 		case <-s.stopCh:
 			return
 		case <-ticker.C:
-			s.mu.Lock()
-			s.evictExpiredLocked()
-			s.mu.Unlock()
+			expired := s.collectExpiredKeys()
+			s.deleteExpiredKeys(expired)
 		}
 	}
 }

--- a/runtime/statestore/memory_bench_test.go
+++ b/runtime/statestore/memory_bench_test.go
@@ -414,6 +414,88 @@ func BenchmarkCloneMessage_WithMeta(b *testing.B) {
 }
 
 // =============================================================================
+// LoadMetadata vs Load benchmarks — shows savings from avoiding message deep copy
+// =============================================================================
+
+func BenchmarkLoad_Medium(b *testing.B) {
+	store := NewMemoryStore(WithNoTTL(), WithNoMaxEntries())
+	ctx := context.Background()
+	state := buildMediumState()
+	_ = store.Save(ctx, state)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = store.Load(ctx, state.ID)
+	}
+}
+
+func BenchmarkLoadMetadata_Medium(b *testing.B) {
+	store := NewMemoryStore(WithNoTTL(), WithNoMaxEntries())
+	ctx := context.Background()
+	state := buildMediumState()
+	_ = store.Save(ctx, state)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = store.LoadMetadata(ctx, state.ID)
+	}
+}
+
+func BenchmarkLoad_Large(b *testing.B) {
+	store := NewMemoryStore(WithNoTTL(), WithNoMaxEntries())
+	ctx := context.Background()
+	state := buildLargeState()
+	_ = store.Save(ctx, state)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = store.Load(ctx, state.ID)
+	}
+}
+
+func BenchmarkLoadMetadata_Large(b *testing.B) {
+	store := NewMemoryStore(WithNoTTL(), WithNoMaxEntries())
+	ctx := context.Background()
+	state := buildLargeState()
+	_ = store.Save(ctx, state)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = store.LoadMetadata(ctx, state.ID)
+	}
+}
+
+func BenchmarkMessageCount_RLock(b *testing.B) {
+	store := NewMemoryStore(WithNoTTL(), WithNoMaxEntries())
+	ctx := context.Background()
+	state := buildLargeState()
+	_ = store.Save(ctx, state)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = store.MessageCount(ctx, state.ID)
+	}
+}
+
+func BenchmarkLoadSummaries_RLock(b *testing.B) {
+	store := NewMemoryStore(WithNoTTL(), WithNoMaxEntries())
+	ctx := context.Background()
+	state := buildMediumState() // has summaries
+	_ = store.Save(ctx, state)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = store.LoadSummaries(ctx, state.ID)
+	}
+}
+
+// =============================================================================
 // LRU eviction benchmarks — heap-based vs linear scan
 // =============================================================================
 

--- a/runtime/statestore/memory_bench_test.go
+++ b/runtime/statestore/memory_bench_test.go
@@ -1,6 +1,7 @@
 package statestore
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -409,5 +410,190 @@ func BenchmarkCloneMessage_WithMeta(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		cloneMessage(msg)
+	}
+}
+
+// =============================================================================
+// LRU eviction benchmarks — heap-based vs linear scan
+// =============================================================================
+
+// linearEvictLRU is the old O(N) implementation kept for benchmarking comparison.
+func linearEvictLRU(states map[string]*ConversationState) string {
+	var oldestID string
+	var oldestTime time.Time
+	first := true
+
+	for id, state := range states {
+		if first || state.LastAccessedAt.Before(oldestTime) {
+			oldestID = id
+			oldestTime = state.LastAccessedAt
+			first = false
+		}
+	}
+	return oldestID
+}
+
+// setupStoreForEviction creates a MemoryStore with n entries for eviction benchmarking.
+func setupStoreForEviction(n int) *MemoryStore {
+	store := NewMemoryStore(WithNoTTL(), WithMemoryMaxEntries(n+1))
+	ctx := context.Background()
+	base := time.Now()
+	for i := 0; i < n; i++ {
+		state := &ConversationState{
+			ID:             "conv-" + string(rune(i)),
+			LastAccessedAt: base.Add(time.Duration(i) * time.Millisecond),
+		}
+		_ = store.Save(ctx, state)
+	}
+	return store
+}
+
+func BenchmarkEvictLRU_Heap_100(b *testing.B) {
+	benchmarkHeapEvict(b, 100)
+}
+
+func BenchmarkEvictLRU_Heap_1000(b *testing.B) {
+	benchmarkHeapEvict(b, 1000)
+}
+
+func BenchmarkEvictLRU_Heap_10000(b *testing.B) {
+	benchmarkHeapEvict(b, 10000)
+}
+
+func BenchmarkEvictLRU_Linear_100(b *testing.B) {
+	benchmarkLinearEvict(b, 100)
+}
+
+func BenchmarkEvictLRU_Linear_1000(b *testing.B) {
+	benchmarkLinearEvict(b, 1000)
+}
+
+func BenchmarkEvictLRU_Linear_10000(b *testing.B) {
+	benchmarkLinearEvict(b, 10000)
+}
+
+func benchmarkHeapEvict(b *testing.B, n int) {
+	b.Helper()
+	store := setupStoreForEviction(n)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		// Pop from heap (O(log N))
+		store.mu.Lock()
+		store.evictLRULocked()
+		store.mu.Unlock()
+
+		// Re-add an entry to keep the store at size n
+		store.mu.Lock()
+		now := time.Now()
+		id := "refill"
+		state := &ConversationState{ID: id, LastAccessedAt: now}
+		store.states[id] = state
+		store.touchLRULocked(id, now)
+		store.mu.Unlock()
+	}
+}
+
+func benchmarkLinearEvict(b *testing.B, n int) {
+	b.Helper()
+	store := setupStoreForEviction(n)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		// Linear scan (O(N))
+		store.mu.Lock()
+		oldestID := linearEvictLRU(store.states)
+		if state, ok := store.states[oldestID]; ok {
+			store.deleteStateLocked(oldestID, state)
+		}
+		store.mu.Unlock()
+
+		// Re-add an entry to keep the store at size n
+		store.mu.Lock()
+		now := time.Now()
+		id := "refill"
+		state := &ConversationState{ID: id, LastAccessedAt: now}
+		store.states[id] = state
+		store.touchLRULocked(id, now)
+		store.mu.Unlock()
+	}
+}
+
+// =============================================================================
+// Background expiration benchmarks — two-phase RLock vs single write lock
+// =============================================================================
+
+// setupStoreForExpiration creates a MemoryStore with n entries, half of which are expired.
+func setupStoreForExpiration(n int) *MemoryStore {
+	store := NewMemoryStore(WithMemoryTTL(50*time.Millisecond), WithNoMaxEntries())
+	now := time.Now()
+	store.mu.Lock()
+	for i := 0; i < n; i++ {
+		id := "conv-" + string(rune(i))
+		accessTime := now
+		if i%2 == 0 {
+			// Make half of the entries expired
+			accessTime = now.Add(-1 * time.Second)
+		}
+		state := &ConversationState{
+			ID:             id,
+			LastAccessedAt: accessTime,
+		}
+		store.states[id] = state
+		store.touchLRULocked(id, accessTime)
+	}
+	store.mu.Unlock()
+	return store
+}
+
+func BenchmarkExpiration_TwoPhase_1000(b *testing.B) {
+	benchmarkTwoPhaseExpire(b, 1000)
+}
+
+func BenchmarkExpiration_TwoPhase_10000(b *testing.B) {
+	benchmarkTwoPhaseExpire(b, 10000)
+}
+
+func BenchmarkExpiration_WriteLock_1000(b *testing.B) {
+	benchmarkWriteLockExpire(b, 1000)
+}
+
+func BenchmarkExpiration_WriteLock_10000(b *testing.B) {
+	benchmarkWriteLockExpire(b, 10000)
+}
+
+func benchmarkTwoPhaseExpire(b *testing.B, n int) {
+	b.Helper()
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		store := setupStoreForExpiration(n)
+		b.StartTimer()
+
+		expired := store.collectExpiredKeys()
+		store.deleteExpiredKeys(expired)
+	}
+}
+
+// evictExpiredWriteLocked is the old single-lock implementation kept for benchmarking comparison.
+func evictExpiredWriteLocked(s *MemoryStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, state := range s.states {
+		if s.isExpired(state) {
+			s.deleteStateLocked(id, state)
+		}
+	}
+}
+
+func benchmarkWriteLockExpire(b *testing.B, n int) {
+	b.Helper()
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		store := setupStoreForExpiration(n)
+		b.StartTimer()
+
+		evictExpiredWriteLocked(store)
 	}
 }

--- a/runtime/statestore/memory_test.go
+++ b/runtime/statestore/memory_test.go
@@ -1210,6 +1210,147 @@ func TestMemoryStore_DeepCloneMultimodalAndToolCalls(t *testing.T) {
 	assert.Equal(t, int64(250), toolMsg.ToolResult.LatencyMs)
 }
 
+func TestMemoryStore_LoadMetadata(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Save a conversation with metadata and messages
+	state := &ConversationState{
+		ID:     "conv-meta",
+		UserID: "user-alice",
+		Messages: []types.Message{
+			{Role: "user", Content: "Hello", Timestamp: time.Now()},
+			{Role: "assistant", Content: "Hi there!", Timestamp: time.Now()},
+			{Role: "user", Content: "How are you?", Timestamp: time.Now()},
+		},
+		Metadata: map[string]interface{}{
+			"topic":  "greetings",
+			"nested": map[string]interface{}{"key": "value"},
+		},
+	}
+	err := store.Save(ctx, state)
+	require.NoError(t, err)
+
+	// LoadMetadata should return only the metadata, not messages
+	metadata, err := store.LoadMetadata(ctx, "conv-meta")
+	require.NoError(t, err)
+	assert.Equal(t, "greetings", metadata["topic"])
+	nested, ok := metadata["nested"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "value", nested["key"])
+
+	// Mutating the returned metadata should not affect the store
+	metadata["topic"] = "mutated"
+	nested["key"] = "mutated"
+
+	metadata2, err := store.LoadMetadata(ctx, "conv-meta")
+	require.NoError(t, err)
+	assert.Equal(t, "greetings", metadata2["topic"])
+	nested2 := metadata2["nested"].(map[string]interface{})
+	assert.Equal(t, "value", nested2["key"])
+
+	// Not found
+	_, err = store.LoadMetadata(ctx, "nonexistent")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	// Invalid ID
+	_, err = store.LoadMetadata(ctx, "")
+	assert.ErrorIs(t, err, ErrInvalidID)
+
+	// Nil metadata
+	noMetaState := &ConversationState{
+		ID:     "conv-no-meta",
+		UserID: "user-alice",
+	}
+	err = store.Save(ctx, noMetaState)
+	require.NoError(t, err)
+
+	metadata, err = store.LoadMetadata(ctx, "conv-no-meta")
+	require.NoError(t, err)
+	assert.Nil(t, metadata)
+}
+
+func TestMemoryStore_LoadMetadata_Expired(t *testing.T) {
+	store := NewMemoryStore(WithMemoryTTL(10 * time.Millisecond))
+	ctx := context.Background()
+
+	state := &ConversationState{
+		ID:       "conv-expire",
+		UserID:   "user-alice",
+		Metadata: map[string]interface{}{"key": "value"},
+	}
+	err := store.Save(ctx, state)
+	require.NoError(t, err)
+
+	// Wait for TTL to expire
+	time.Sleep(20 * time.Millisecond)
+
+	_, err = store.LoadMetadata(ctx, "conv-expire")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestMemoryStore_MessageCount_ReadOnly(t *testing.T) {
+	// Verify MessageCount works correctly with RLock (no LRU touch)
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	state := &ConversationState{
+		ID:     "conv-count-ro",
+		UserID: "user-alice",
+		Messages: []types.Message{
+			{Role: "user", Content: "Hello", Timestamp: time.Now()},
+			{Role: "assistant", Content: "Hi", Timestamp: time.Now()},
+		},
+	}
+	err := store.Save(ctx, state)
+	require.NoError(t, err)
+
+	// MessageCount should work with concurrent reads
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			count, err := store.MessageCount(ctx, "conv-count-ro")
+			assert.NoError(t, err)
+			assert.Equal(t, 2, count)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestMemoryStore_LoadSummaries_ReadOnly(t *testing.T) {
+	// Verify LoadSummaries works correctly with RLock
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	now := time.Now()
+	state := &ConversationState{
+		ID:     "conv-sum-ro",
+		UserID: "user-alice",
+		Summaries: []Summary{
+			{StartTurn: 0, EndTurn: 5, Content: "Summary 1", TokenCount: 20, CreatedAt: now},
+			{StartTurn: 6, EndTurn: 10, Content: "Summary 2", TokenCount: 25, CreatedAt: now},
+		},
+	}
+	err := store.Save(ctx, state)
+	require.NoError(t, err)
+
+	// Concurrent reads should not race
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			summaries, err := store.LoadSummaries(ctx, "conv-sum-ro")
+			assert.NoError(t, err)
+			assert.Len(t, summaries, 2)
+			assert.Equal(t, "Summary 1", summaries[0].Content)
+		}()
+	}
+	wg.Wait()
+}
+
 func TestDeepCopyState_Nil(t *testing.T) {
 	result := deepCopyState(nil)
 	assert.Nil(t, result)

--- a/runtime/statestore/memory_ttl_test.go
+++ b/runtime/statestore/memory_ttl_test.go
@@ -490,7 +490,7 @@ func TestMemoryStore_UserIndexSetBehavior(t *testing.T) {
 	assert.Len(t, ids, 1)
 }
 
-func TestMemoryStore_EvictExpiredLocked(t *testing.T) {
+func TestMemoryStore_EvictExpiredTwoPhase(t *testing.T) {
 	store := NewMemoryStore(WithMemoryTTL(50 * time.Millisecond))
 	ctx := context.Background()
 
@@ -505,10 +505,10 @@ func TestMemoryStore_EvictExpiredLocked(t *testing.T) {
 
 	time.Sleep(80 * time.Millisecond)
 
-	// Trigger eviction manually via internal method
-	store.mu.Lock()
-	store.evictExpiredLocked()
-	store.mu.Unlock()
+	// Trigger two-phase eviction manually
+	expired := store.collectExpiredKeys()
+	assert.Len(t, expired, 5)
+	store.deleteExpiredKeys(expired)
 
 	assert.Equal(t, 0, store.Len())
 }

--- a/runtime/statestore/redis.go
+++ b/runtime/statestore/redis.go
@@ -499,6 +499,30 @@ func (s *RedisStore) summariesKey(id string) string {
 	return fmt.Sprintf("%s:conversation:%s:summaries", s.prefix, id)
 }
 
+// LoadMetadata returns just the metadata map for the given conversation.
+// This only loads the meta key, avoiding deserialization of the messages and summaries lists.
+func (s *RedisStore) LoadMetadata(ctx context.Context, id string) (map[string]interface{}, error) {
+	if id == "" {
+		return nil, ErrInvalidID
+	}
+
+	// Try decomposed meta key first
+	meta, err := s.loadMeta(ctx, id)
+	if err == nil {
+		return meta.Metadata, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
+
+	// Fall back to monolithic key (loads full state, but this is the legacy path)
+	state, err := s.loadMonolithic(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return state.Metadata, nil
+}
+
 // LoadRecentMessages returns the last n messages using LRANGE on the messages list.
 // Falls back to loading from the monolithic key if the list doesn't exist.
 func (s *RedisStore) LoadRecentMessages(ctx context.Context, id string, n int) ([]types.Message, error) {

--- a/runtime/statestore/redis.go
+++ b/runtime/statestore/redis.go
@@ -66,12 +66,128 @@ func NewRedisStore(client *redis.Client, opts ...RedisOption) *RedisStore {
 	return store
 }
 
+// redisStateMeta holds the non-message, non-summary fields of a ConversationState.
+// It is stored as a single JSON value in the meta key, keeping it small and fast to serialize.
+type redisStateMeta struct {
+	ID             string                 `json:"id"`
+	UserID         string                 `json:"user_id"`
+	SystemPrompt   string                 `json:"system_prompt,omitempty"`
+	TokenCount     int                    `json:"token_count,omitempty"`
+	LastAccessedAt time.Time              `json:"last_accessed_at"`
+	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+}
+
 // Load retrieves a conversation state by ID from Redis.
+// Tries the decomposed format (meta key + messages list + summaries list) first,
+// then falls back to the legacy monolithic JSON string for backward compatibility.
 func (s *RedisStore) Load(ctx context.Context, id string) (*ConversationState, error) {
 	if id == "" {
 		return nil, ErrInvalidID
 	}
 
+	// Try decomposed format first
+	state, err := s.loadDecomposed(ctx, id)
+	if err == nil {
+		return state, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
+
+	// Fall back to legacy monolithic format
+	return s.loadMonolithic(ctx, id)
+}
+
+// loadDecomposed loads a conversation state from decomposed keys (meta + messages list + summaries list).
+func (s *RedisStore) loadDecomposed(ctx context.Context, id string) (*ConversationState, error) {
+	meta, err := s.loadMeta(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	state := metaToState(meta)
+
+	state.Messages, err = s.loadMessagesList(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	state.Summaries, err = s.loadSummariesList(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return state, nil
+}
+
+// loadMeta loads and unmarshals the meta key for a conversation.
+func (s *RedisStore) loadMeta(ctx context.Context, id string) (*redisStateMeta, error) {
+	data, err := s.client.Get(ctx, s.metaKey(id)).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("redis get meta failed: %w", err)
+	}
+
+	var meta redisStateMeta
+	if unmarshalErr := json.Unmarshal(data, &meta); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal meta: %w", unmarshalErr)
+	}
+	return &meta, nil
+}
+
+// metaToState converts a redisStateMeta to a ConversationState (without messages/summaries).
+func metaToState(meta *redisStateMeta) *ConversationState {
+	return &ConversationState{
+		ID:             meta.ID,
+		UserID:         meta.UserID,
+		SystemPrompt:   meta.SystemPrompt,
+		TokenCount:     meta.TokenCount,
+		LastAccessedAt: meta.LastAccessedAt,
+		Metadata:       meta.Metadata,
+	}
+}
+
+// loadMessagesList loads messages from a Redis list key.
+func (s *RedisStore) loadMessagesList(ctx context.Context, id string) ([]types.Message, error) {
+	vals, err := s.client.LRange(ctx, s.messagesKey(id), 0, -1).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("redis lrange messages failed: %w", err)
+	}
+	messages := make([]types.Message, 0, len(vals))
+	for _, v := range vals {
+		var msg types.Message
+		if unmarshalErr := json.Unmarshal([]byte(v), &msg); unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to unmarshal message: %w", unmarshalErr)
+		}
+		messages = append(messages, msg)
+	}
+	return messages, nil
+}
+
+// loadSummariesList loads summaries from a Redis list key.
+func (s *RedisStore) loadSummariesList(ctx context.Context, id string) ([]Summary, error) {
+	vals, err := s.client.LRange(ctx, s.summariesKey(id), 0, -1).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("redis lrange summaries failed: %w", err)
+	}
+	if len(vals) == 0 {
+		return nil, nil
+	}
+	summaries := make([]Summary, 0, len(vals))
+	for _, v := range vals {
+		var sm Summary
+		if unmarshalErr := json.Unmarshal([]byte(v), &sm); unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to unmarshal summary: %w", unmarshalErr)
+		}
+		summaries = append(summaries, sm)
+	}
+	return summaries, nil
+}
+
+// loadMonolithic loads a conversation state from the legacy monolithic JSON string.
+func (s *RedisStore) loadMonolithic(ctx context.Context, id string) (*ConversationState, error) {
 	key := s.conversationKey(id)
 	data, err := s.client.Get(ctx, key).Bytes()
 	if err != nil {
@@ -89,8 +205,11 @@ func (s *RedisStore) Load(ctx context.Context, id string) (*ConversationState, e
 	return &state, nil
 }
 
-// Save persists a conversation state to Redis with TTL.
-// Uses a pipeline to batch the SET and optional user index update into a single round-trip.
+// Save persists a conversation state to Redis using decomposed keys.
+// Metadata is stored in a meta key, messages in a Redis list, and summaries in a separate list.
+// This avoids serializing the entire state as one monolithic JSON blob, significantly reducing
+// serialization cost for conversations with many messages since only the meta (small) is
+// fully rewritten, while messages and summaries are replaced in their list keys.
 func (s *RedisStore) Save(ctx context.Context, state *ConversationState) error {
 	if state == nil {
 		return ErrInvalidState
@@ -102,30 +221,105 @@ func (s *RedisStore) Save(ctx context.Context, state *ConversationState) error {
 	// Update timestamp
 	state.LastAccessedAt = time.Now()
 
-	// Serialize to JSON
-	data, err := json.Marshal(state)
+	// Serialize metadata (small — excludes messages and summaries)
+	metaData, err := json.Marshal(stateToMeta(state))
 	if err != nil {
-		return fmt.Errorf("failed to marshal state: %w", err)
+		return fmt.Errorf("failed to marshal meta: %w", err)
 	}
 
-	// Pipeline: SET conversation + optional SAdd/Expire for user index
-	key := s.conversationKey(state.ID)
+	// Build pipeline: write meta, replace messages/summaries lists, cleanup legacy key, update index
 	pipe := s.client.Pipeline()
-	pipe.Set(ctx, key, data, s.ttl)
+	pipe.Set(ctx, s.metaKey(state.ID), metaData, s.ttl)
 
-	if state.UserID != "" {
-		indexKey := s.userIndexKey(state.UserID)
-		pipe.SAdd(ctx, indexKey, state.ID)
-		if s.ttl > 0 {
-			pipe.Expire(ctx, indexKey, s.ttl)
-		}
+	if err := s.pipeReplaceList(ctx, pipe, s.messagesKey(state.ID), marshalMessages(state.Messages)); err != nil {
+		return err
 	}
+	if err := s.pipeReplaceList(ctx, pipe, s.summariesKey(state.ID), marshalSummaries(state.Summaries)); err != nil {
+		return err
+	}
+
+	// Remove legacy monolithic key if it exists
+	pipe.Del(ctx, s.conversationKey(state.ID))
+
+	s.pipeUpdateUserIndex(ctx, pipe, state.UserID, state.ID)
 
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("redis pipeline failed: %w", err)
 	}
 
 	return nil
+}
+
+// stateToMeta extracts the metadata fields from a ConversationState.
+func stateToMeta(state *ConversationState) redisStateMeta {
+	return redisStateMeta{
+		ID:             state.ID,
+		UserID:         state.UserID,
+		SystemPrompt:   state.SystemPrompt,
+		TokenCount:     state.TokenCount,
+		LastAccessedAt: state.LastAccessedAt,
+		Metadata:       state.Metadata,
+	}
+}
+
+// marshalMessages serializes messages to a list of JSON byte slices.
+// Returns a marshalResult that is evaluated lazily when added to the pipeline.
+func marshalMessages(msgs []types.Message) func() ([]interface{}, error) {
+	return func() ([]interface{}, error) {
+		vals := make([]interface{}, 0, len(msgs))
+		for i := range msgs {
+			data, err := json.Marshal(&msgs[i])
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal message: %w", err)
+			}
+			vals = append(vals, data)
+		}
+		return vals, nil
+	}
+}
+
+// marshalSummaries serializes summaries to a list of JSON byte slices.
+func marshalSummaries(sums []Summary) func() ([]interface{}, error) {
+	return func() ([]interface{}, error) {
+		vals := make([]interface{}, 0, len(sums))
+		for i := range sums {
+			data, err := json.Marshal(&sums[i])
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal summary: %w", err)
+			}
+			vals = append(vals, data)
+		}
+		return vals, nil
+	}
+}
+
+// pipeReplaceList deletes a list key and re-populates it via RPUSH in the given pipeline.
+func (s *RedisStore) pipeReplaceList(
+	ctx context.Context, pipe redis.Pipeliner, key string, marshalFn func() ([]interface{}, error),
+) error {
+	pipe.Del(ctx, key)
+	vals, err := marshalFn()
+	if err != nil {
+		return err
+	}
+	if len(vals) > 0 {
+		pipe.RPush(ctx, key, vals...)
+		if s.ttl > 0 {
+			pipe.Expire(ctx, key, s.ttl)
+		}
+	}
+	return nil
+}
+
+// pipeUpdateUserIndex adds commands to the pipeline to update the user conversation index.
+func (s *RedisStore) pipeUpdateUserIndex(ctx context.Context, pipe redis.Pipeliner, userID, convID string) {
+	if userID != "" {
+		indexKey := s.userIndexKey(userID)
+		pipe.SAdd(ctx, indexKey, convID)
+		if s.ttl > 0 {
+			pipe.Expire(ctx, indexKey, s.ttl)
+		}
+	}
 }
 
 // Fork creates a copy of an existing conversation state with a new ID.
@@ -149,7 +343,8 @@ func (s *RedisStore) Fork(ctx context.Context, sourceID, newID string) error {
 }
 
 // Delete removes a conversation state from Redis.
-// Uses a pipeline to batch the DEL and optional user index cleanup.
+// Removes both decomposed keys (meta, messages, summaries) and legacy monolithic key.
+// Uses a pipeline to batch all DEL commands and optional user index cleanup.
 func (s *RedisStore) Delete(ctx context.Context, id string) error {
 	if id == "" {
 		return ErrInvalidID
@@ -161,10 +356,14 @@ func (s *RedisStore) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	// Pipeline: DEL conversation key + optional SRem from user index
-	key := s.conversationKey(id)
+	// Pipeline: DEL all keys for this conversation + optional SRem from user index
 	pipe := s.client.Pipeline()
-	delCmd := pipe.Del(ctx, key)
+	delCmd := pipe.Del(ctx,
+		s.conversationKey(id), // legacy monolithic key
+		s.metaKey(id),         // decomposed meta
+		s.messagesKey(id),     // decomposed messages list
+		s.summariesKey(id),    // decomposed summaries list
+	)
 
 	if state.UserID != "" {
 		indexKey := s.userIndexKey(state.UserID)
@@ -217,20 +416,42 @@ func (s *RedisStore) fetchUserConversations(ctx context.Context, userID string) 
 	return members, nil
 }
 
-// scanAllConversations scans all conversation keys in Redis
+// scanAllConversations scans all conversation keys in Redis.
+// Scans both legacy monolithic keys and decomposed meta keys to find all conversations.
 func (s *RedisStore) scanAllConversations(ctx context.Context) ([]string, error) {
-	var ids []string
+	seen := make(map[string]struct{})
+
+	// Scan legacy monolithic keys: prefix:conversation:ID
 	pattern := s.conversationKey("*")
 	iter := s.client.Scan(ctx, 0, pattern, 0).Iterator()
 	for iter.Next(ctx) {
 		key := iter.Val()
 		id := s.extractIDFromKey(key)
-		if id != "" {
-			ids = append(ids, id)
+		if id != "" && !s.isSubKey(id) {
+			seen[id] = struct{}{}
 		}
 	}
 	if err := iter.Err(); err != nil {
 		return nil, fmt.Errorf("redis scan failed: %w", err)
+	}
+
+	// Scan decomposed meta keys: prefix:conversation:ID:meta
+	metaPattern := fmt.Sprintf("%s:conversation:*:meta", s.prefix)
+	iter = s.client.Scan(ctx, 0, metaPattern, 0).Iterator()
+	for iter.Next(ctx) {
+		key := iter.Val()
+		id := s.extractIDFromMetaKey(key)
+		if id != "" {
+			seen[id] = struct{}{}
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("redis scan meta failed: %w", err)
+	}
+
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
 	}
 	return ids, nil
 }
@@ -408,16 +629,35 @@ func (s *RedisStore) rpushMessages(ctx context.Context, key string, messages []t
 	return nil
 }
 
-// updateMetaTTL updates TTL and last accessed time.
-// Uses a pipeline to batch EXPIRE and SET meta into a single round-trip.
-func (s *RedisStore) updateMetaTTL(ctx context.Context, id, key string) error {
+// updateMetaTTL updates TTL and last accessed time on the meta key.
+// Loads the existing meta, updates the timestamp, and writes it back to preserve all fields.
+// Uses a pipeline for the EXPIRE + SET to minimize round-trips.
+func (s *RedisStore) updateMetaTTL(ctx context.Context, id, msgKey string) error {
 	metaKey := s.metaKey(id)
-	meta := map[string]any{"last_accessed_at": time.Now()}
-	metaData, _ := json.Marshal(meta)
+
+	// Load existing meta to preserve all fields
+	var meta redisStateMeta
+	data, err := s.client.Get(ctx, metaKey).Bytes()
+	if err == nil {
+		// Existing meta found — update timestamp
+		if unmarshalErr := json.Unmarshal(data, &meta); unmarshalErr != nil {
+			return fmt.Errorf("failed to unmarshal meta: %w", unmarshalErr)
+		}
+	} else if !errors.Is(err, redis.Nil) {
+		return fmt.Errorf("redis get meta failed: %w", err)
+	}
+	// If meta doesn't exist, we create a minimal one with just the ID and timestamp
+	meta.ID = id
+	meta.LastAccessedAt = time.Now()
+
+	metaData, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal meta: %w", err)
+	}
 
 	pipe := s.client.Pipeline()
 	if s.ttl > 0 {
-		pipe.Expire(ctx, key, s.ttl)
+		pipe.Expire(ctx, msgKey, s.ttl)
 	}
 	pipe.Set(ctx, metaKey, metaData, s.ttl)
 
@@ -565,6 +805,25 @@ func (s *RedisStore) extractIDFromKey(key string) string {
 	return ""
 }
 
+// isSubKey returns true if the extracted ID contains a colon suffix, indicating
+// it is a sub-key (e.g., :messages, :meta, :summaries) rather than a conversation ID.
+func (s *RedisStore) isSubKey(id string) bool {
+	return strings.Contains(id, ":")
+}
+
+// extractIDFromMetaKey extracts the conversation ID from a meta key.
+// Meta keys have the format: prefix:conversation:ID:meta
+func (s *RedisStore) extractIDFromMetaKey(key string) string {
+	prefix := s.conversationKey("")
+	suffix := ":meta"
+	if strings.HasPrefix(key, prefix) && strings.HasSuffix(key, suffix) {
+		id := strings.TrimPrefix(key, prefix)
+		id = strings.TrimSuffix(id, suffix)
+		return id
+	}
+	return ""
+}
+
 // sortConversations sorts conversation IDs using pipelined GET to fetch all states
 // in a single round-trip, then sorts in memory.
 func (s *RedisStore) sortConversations(ctx context.Context, ids []string, sortBy, sortOrder string) error {
@@ -594,33 +853,65 @@ type stateWithID struct {
 	state *ConversationState
 }
 
-// pipelinedLoadStates fetches multiple conversation states using a single pipelined GET.
+// pipelinedLoadStates fetches multiple conversation states using pipelined GETs.
+// Tries decomposed meta keys first, then falls back to legacy monolithic keys.
 func (s *RedisStore) pipelinedLoadStates(ctx context.Context, ids []string) ([]stateWithID, error) {
+	// Pipeline: GET meta key and GET monolithic key for each ID
 	pipe := s.client.Pipeline()
-	cmds := make([]*redis.StringCmd, len(ids))
+	metaCmds := make([]*redis.StringCmd, len(ids))
+	monoCmds := make([]*redis.StringCmd, len(ids))
 	for i, id := range ids {
-		cmds[i] = pipe.Get(ctx, s.conversationKey(id))
+		metaCmds[i] = pipe.Get(ctx, s.metaKey(id))
+		monoCmds[i] = pipe.Get(ctx, s.conversationKey(id))
 	}
 	if _, err := pipe.Exec(ctx); err != nil && !errors.Is(err, redis.Nil) {
 		return nil, fmt.Errorf("redis pipeline failed: %w", err)
 	}
 
 	states := make([]stateWithID, 0, len(ids))
-	for i, cmd := range cmds {
-		data, err := cmd.Bytes()
+	for i := range ids {
+		st, err := s.resolveStateFromCmds(ids[i], metaCmds[i], monoCmds[i])
 		if err != nil {
-			if errors.Is(err, redis.Nil) {
-				continue
-			}
-			return nil, fmt.Errorf("redis get failed: %w", err)
+			return nil, err
 		}
-		var state ConversationState
-		if err := json.Unmarshal(data, &state); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal state: %w", err)
+		if st != nil {
+			states = append(states, stateWithID{id: ids[i], state: st})
 		}
-		states = append(states, stateWithID{id: ids[i], state: &state})
 	}
 	return states, nil
+}
+
+// resolveStateFromCmds tries the decomposed meta command first, falls back to monolithic.
+// Returns nil state (no error) if neither key exists.
+func (s *RedisStore) resolveStateFromCmds(
+	id string, metaCmd, monoCmd *redis.StringCmd,
+) (*ConversationState, error) {
+	// Try decomposed meta first
+	data, err := metaCmd.Bytes()
+	if err == nil {
+		var meta redisStateMeta
+		if unmarshalErr := json.Unmarshal(data, &meta); unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to unmarshal meta for %s: %w", id, unmarshalErr)
+		}
+		return metaToState(&meta), nil
+	}
+	if !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("redis get meta failed: %w", err)
+	}
+
+	// Fall back to monolithic key
+	data, err = monoCmd.Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("redis get failed: %w", err)
+	}
+	var state ConversationState
+	if unmarshalErr := json.Unmarshal(data, &state); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal state: %w", unmarshalErr)
+	}
+	return &state, nil
 }
 
 // sortStatesByField sorts a slice of stateWithID entries by the given field and direction.

--- a/runtime/statestore/redis.go
+++ b/runtime/statestore/redis.go
@@ -14,8 +14,6 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
-
-
 // RedisStore provides a Redis-backed implementation of the Store interface.
 // It uses JSON serialization for state storage and supports automatic TTL-based cleanup.
 // This implementation is suitable for distributed systems and production deployments.

--- a/runtime/statestore/redis_test.go
+++ b/runtime/statestore/redis_test.go
@@ -2,6 +2,7 @@ package statestore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -355,9 +356,9 @@ func TestRedisStore_CustomPrefix(t *testing.T) {
 	err := store.Save(ctx, state)
 	require.NoError(t, err)
 
-	// Check Redis directly for key with custom prefix
+	// Check Redis directly for keys with custom prefix (decomposed format)
 	keys := mr.Keys()
-	assert.Contains(t, keys, "myapp:conversation:conv-123")
+	assert.Contains(t, keys, "myapp:conversation:conv-123:meta")
 	assert.Contains(t, keys, "myapp:user:user-alice:conversations")
 }
 
@@ -1265,4 +1266,788 @@ func TestRedisStore_SaveSummary_WithTTL(t *testing.T) {
 		assert.Equal(t, "First", summaries[0].Content)
 		assert.Equal(t, "Second", summaries[1].Content)
 	})
+}
+
+func TestRedisStore_DecomposedFormat(t *testing.T) {
+	t.Run("save uses decomposed keys instead of monolithic", func(t *testing.T) {
+		store, mr := setupRedisStore(t)
+		ctx := context.Background()
+
+		state := &ConversationState{
+			ID:           "conv-decomposed",
+			UserID:       "user-alice",
+			SystemPrompt: "Be helpful",
+			Messages: []types.Message{
+				{Role: "user", Content: "Hello"},
+				{Role: "assistant", Content: "Hi there"},
+			},
+			Summaries: []Summary{
+				{StartTurn: 0, EndTurn: 5, Content: "A summary", TokenCount: 10},
+			},
+			TokenCount: 42,
+			Metadata:   map[string]interface{}{"key": "value"},
+		}
+		err := store.Save(ctx, state)
+		require.NoError(t, err)
+
+		keys := mr.Keys()
+		// Decomposed keys should exist
+		assert.Contains(t, keys, store.metaKey("conv-decomposed"))
+		assert.Contains(t, keys, store.messagesKey("conv-decomposed"))
+		assert.Contains(t, keys, store.summariesKey("conv-decomposed"))
+		// Monolithic key should NOT exist
+		assert.NotContains(t, keys, store.conversationKey("conv-decomposed"))
+	})
+
+	t.Run("load reconstructs state from decomposed keys", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		original := &ConversationState{
+			ID:           "conv-reconstruct",
+			UserID:       "user-bob",
+			SystemPrompt: "System prompt",
+			Messages: []types.Message{
+				{Role: "user", Content: "msg1"},
+				{Role: "assistant", Content: "msg2"},
+				{Role: "user", Content: "msg3"},
+			},
+			Summaries: []Summary{
+				{StartTurn: 0, EndTurn: 3, Content: "Summary text", TokenCount: 15},
+			},
+			TokenCount: 100,
+			Metadata:   map[string]interface{}{"nested": map[string]interface{}{"a": "b"}},
+		}
+		err := store.Save(ctx, original)
+		require.NoError(t, err)
+
+		loaded, err := store.Load(ctx, "conv-reconstruct")
+		require.NoError(t, err)
+
+		assert.Equal(t, original.ID, loaded.ID)
+		assert.Equal(t, original.UserID, loaded.UserID)
+		assert.Equal(t, original.SystemPrompt, loaded.SystemPrompt)
+		assert.Equal(t, original.TokenCount, loaded.TokenCount)
+		assert.Len(t, loaded.Messages, 3)
+		assert.Equal(t, "msg1", loaded.Messages[0].Content)
+		assert.Equal(t, "msg3", loaded.Messages[2].Content)
+		assert.Len(t, loaded.Summaries, 1)
+		assert.Equal(t, "Summary text", loaded.Summaries[0].Content)
+	})
+
+	t.Run("backward compat: loads legacy monolithic format", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		// Write a monolithic key directly (simulating legacy data)
+		legacyState := &ConversationState{
+			ID:           "conv-legacy",
+			UserID:       "user-legacy",
+			SystemPrompt: "Legacy prompt",
+			Messages: []types.Message{
+				{Role: "user", Content: "legacy msg"},
+			},
+			TokenCount: 5,
+		}
+		data, err := json.Marshal(legacyState)
+		require.NoError(t, err)
+		err = store.client.Set(ctx, store.conversationKey("conv-legacy"), data, 0).Err()
+		require.NoError(t, err)
+
+		// Load should fall back to monolithic
+		loaded, err := store.Load(ctx, "conv-legacy")
+		require.NoError(t, err)
+		assert.Equal(t, "conv-legacy", loaded.ID)
+		assert.Equal(t, "Legacy prompt", loaded.SystemPrompt)
+		assert.Len(t, loaded.Messages, 1)
+		assert.Equal(t, "legacy msg", loaded.Messages[0].Content)
+	})
+
+	t.Run("save removes legacy monolithic key", func(t *testing.T) {
+		store, mr := setupRedisStore(t)
+		ctx := context.Background()
+
+		// Write a monolithic key directly (simulating legacy data)
+		legacyState := &ConversationState{
+			ID:     "conv-cleanup",
+			UserID: "user-cleanup",
+		}
+		data, err := json.Marshal(legacyState)
+		require.NoError(t, err)
+		err = store.client.Set(ctx, store.conversationKey("conv-cleanup"), data, 0).Err()
+		require.NoError(t, err)
+		assert.True(t, mr.Exists(store.conversationKey("conv-cleanup")))
+
+		// Save with new format should remove monolithic key
+		err = store.Save(ctx, legacyState)
+		require.NoError(t, err)
+		assert.False(t, mr.Exists(store.conversationKey("conv-cleanup")))
+		assert.True(t, mr.Exists(store.metaKey("conv-cleanup")))
+	})
+
+	t.Run("save with no messages creates meta but no messages key", func(t *testing.T) {
+		store, mr := setupRedisStore(t)
+		ctx := context.Background()
+
+		state := &ConversationState{
+			ID:     "conv-empty-msgs",
+			UserID: "user-empty",
+		}
+		err := store.Save(ctx, state)
+		require.NoError(t, err)
+
+		assert.True(t, mr.Exists(store.metaKey("conv-empty-msgs")))
+		// Messages key should not exist since there are no messages
+		assert.False(t, mr.Exists(store.messagesKey("conv-empty-msgs")))
+	})
+
+	t.Run("TTL applied to all decomposed keys", func(t *testing.T) {
+		store, mr := setupRedisStore(t, WithTTL(10*time.Minute))
+		ctx := context.Background()
+
+		state := &ConversationState{
+			ID:     "conv-ttl-decomposed",
+			UserID: "user-ttl",
+			Messages: []types.Message{
+				{Role: "user", Content: "msg"},
+			},
+			Summaries: []Summary{
+				{StartTurn: 0, EndTurn: 1, Content: "sum", TokenCount: 5},
+			},
+		}
+		err := store.Save(ctx, state)
+		require.NoError(t, err)
+
+		// All keys should have TTL
+		assert.True(t, mr.TTL(store.metaKey("conv-ttl-decomposed")) > 0)
+		assert.True(t, mr.TTL(store.messagesKey("conv-ttl-decomposed")) > 0)
+		assert.True(t, mr.TTL(store.summariesKey("conv-ttl-decomposed")) > 0)
+
+		// Fast-forward past TTL
+		mr.FastForward(11 * time.Minute)
+
+		_, err = store.Load(ctx, "conv-ttl-decomposed")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("delete removes all decomposed keys", func(t *testing.T) {
+		store, mr := setupRedisStore(t)
+		ctx := context.Background()
+
+		state := &ConversationState{
+			ID:     "conv-del-decomposed",
+			UserID: "user-del",
+			Messages: []types.Message{
+				{Role: "user", Content: "msg"},
+			},
+			Summaries: []Summary{
+				{StartTurn: 0, EndTurn: 1, Content: "sum", TokenCount: 5},
+			},
+		}
+		err := store.Save(ctx, state)
+		require.NoError(t, err)
+
+		err = store.Delete(ctx, "conv-del-decomposed")
+		require.NoError(t, err)
+
+		assert.False(t, mr.Exists(store.metaKey("conv-del-decomposed")))
+		assert.False(t, mr.Exists(store.messagesKey("conv-del-decomposed")))
+		assert.False(t, mr.Exists(store.summariesKey("conv-del-decomposed")))
+	})
+
+	t.Run("list finds decomposed-format conversations", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		for i := 0; i < 3; i++ {
+			state := &ConversationState{
+				ID:     fmt.Sprintf("conv-list-%d", i),
+				UserID: "user-list",
+			}
+			err := store.Save(ctx, state)
+			require.NoError(t, err)
+		}
+
+		ids, err := store.List(ctx, ListOptions{UserID: "user-list"})
+		require.NoError(t, err)
+		assert.Len(t, ids, 3)
+	})
+
+	t.Run("list all finds decomposed-format conversations via scan", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		for i := 0; i < 3; i++ {
+			state := &ConversationState{
+				ID: fmt.Sprintf("conv-scan-%d", i),
+			}
+			err := store.Save(ctx, state)
+			require.NoError(t, err)
+		}
+
+		ids, err := store.List(ctx, ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, ids, 3)
+	})
+
+	t.Run("AppendMessages preserves meta fields", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		state := &ConversationState{
+			ID:           "conv-append-meta",
+			UserID:       "user-append",
+			SystemPrompt: "Keep this prompt",
+			Messages: []types.Message{
+				{Role: "user", Content: "initial"},
+			},
+			TokenCount: 50,
+			Metadata:   map[string]interface{}{"important": "data"},
+		}
+		err := store.Save(ctx, state)
+		require.NoError(t, err)
+
+		// AppendMessages should preserve meta fields
+		err = store.AppendMessages(ctx, "conv-append-meta", []types.Message{
+			{Role: "assistant", Content: "appended"},
+		})
+		require.NoError(t, err)
+
+		// Reload and verify meta is preserved
+		loaded, err := store.Load(ctx, "conv-append-meta")
+		require.NoError(t, err)
+		assert.Equal(t, "user-append", loaded.UserID)
+		assert.Equal(t, "Keep this prompt", loaded.SystemPrompt)
+		assert.Equal(t, 50, loaded.TokenCount)
+		assert.Equal(t, "data", loaded.Metadata["important"])
+		assert.Len(t, loaded.Messages, 2)
+		assert.Equal(t, "appended", loaded.Messages[1].Content)
+	})
+}
+
+// saveMonolithicLegacy writes a ConversationState directly as a monolithic JSON key,
+// simulating legacy data that predates the decomposed format.
+func saveMonolithicLegacy(t *testing.T, store *RedisStore, state *ConversationState) {
+	t.Helper()
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	err = store.client.Set(context.Background(), store.conversationKey(state.ID), data, 0).Err()
+	require.NoError(t, err)
+}
+
+func TestRedisStore_MigrateToListFormat(t *testing.T) {
+	t.Run("migrates monolithic messages to list format", func(t *testing.T) {
+		store, mr := setupRedisStore(t)
+		ctx := context.Background()
+
+		// Write legacy monolithic key directly (no decomposed keys)
+		legacyState := &ConversationState{
+			ID:     "conv-migrate-legacy",
+			UserID: "user-alice",
+			Messages: []types.Message{
+				{Role: "user", Content: "legacy msg 1"},
+				{Role: "assistant", Content: "legacy msg 2"},
+			},
+		}
+		saveMonolithicLegacy(t, store, legacyState)
+
+		// Verify only monolithic key exists
+		assert.True(t, mr.Exists(store.conversationKey("conv-migrate-legacy")))
+		assert.False(t, mr.Exists(store.messagesKey("conv-migrate-legacy")))
+
+		// AppendMessages triggers ensureListFormat -> migrateToListFormat
+		err := store.AppendMessages(ctx, "conv-migrate-legacy", []types.Message{
+			{Role: "user", Content: "new msg 3"},
+		})
+		require.NoError(t, err)
+
+		// Verify messages were migrated + appended
+		msgs, err := store.LoadRecentMessages(ctx, "conv-migrate-legacy", 10)
+		require.NoError(t, err)
+		assert.Len(t, msgs, 3)
+		assert.Equal(t, "legacy msg 1", msgs[0].Content)
+		assert.Equal(t, "legacy msg 2", msgs[1].Content)
+		assert.Equal(t, "new msg 3", msgs[2].Content)
+	})
+
+	t.Run("migrates monolithic with summaries to list format", func(t *testing.T) {
+		store, mr := setupRedisStore(t)
+		ctx := context.Background()
+
+		legacyState := &ConversationState{
+			ID:     "conv-migrate-with-sums",
+			UserID: "user-alice",
+			Messages: []types.Message{
+				{Role: "user", Content: "msg1"},
+			},
+			Summaries: []Summary{
+				{StartTurn: 0, EndTurn: 5, Content: "Legacy summary", TokenCount: 20},
+			},
+		}
+		saveMonolithicLegacy(t, store, legacyState)
+
+		// Verify only monolithic key exists
+		assert.False(t, mr.Exists(store.summariesKey("conv-migrate-with-sums")))
+
+		// AppendMessages triggers full migration
+		err := store.AppendMessages(ctx, "conv-migrate-with-sums", []types.Message{
+			{Role: "assistant", Content: "msg2"},
+		})
+		require.NoError(t, err)
+
+		// Verify summaries were migrated
+		assert.True(t, mr.Exists(store.summariesKey("conv-migrate-with-sums")))
+		summaries, err := store.LoadSummaries(ctx, "conv-migrate-with-sums")
+		require.NoError(t, err)
+		assert.Len(t, summaries, 1)
+		assert.Equal(t, "Legacy summary", summaries[0].Content)
+	})
+
+	t.Run("migration with TTL sets expiry on migrated keys", func(t *testing.T) {
+		store, mr := setupRedisStore(t, WithTTL(10*time.Minute))
+		ctx := context.Background()
+
+		legacyState := &ConversationState{
+			ID:     "conv-migrate-ttl-legacy",
+			UserID: "user-alice",
+			Messages: []types.Message{
+				{Role: "user", Content: "msg1"},
+			},
+			Summaries: []Summary{
+				{StartTurn: 0, EndTurn: 3, Content: "Summary", TokenCount: 10},
+			},
+		}
+		saveMonolithicLegacy(t, store, legacyState)
+
+		err := store.AppendMessages(ctx, "conv-migrate-ttl-legacy", []types.Message{
+			{Role: "assistant", Content: "msg2"},
+		})
+		require.NoError(t, err)
+
+		// Verify migrated keys have TTL
+		msgKey := store.messagesKey("conv-migrate-ttl-legacy")
+		sumKey := store.summariesKey("conv-migrate-ttl-legacy")
+		assert.True(t, mr.TTL(msgKey) > 0, "migrated messages key should have TTL")
+		assert.True(t, mr.TTL(sumKey) > 0, "migrated summaries key should have TTL")
+	})
+
+	t.Run("migration with no TTL skips expiry", func(t *testing.T) {
+		store, mr := setupRedisStore(t, WithTTL(0))
+		ctx := context.Background()
+
+		legacyState := &ConversationState{
+			ID:     "conv-migrate-no-ttl",
+			UserID: "user-alice",
+			Messages: []types.Message{
+				{Role: "user", Content: "msg1"},
+			},
+			Summaries: []Summary{
+				{StartTurn: 0, EndTurn: 3, Content: "Summary", TokenCount: 10},
+			},
+		}
+		saveMonolithicLegacy(t, store, legacyState)
+
+		err := store.AppendMessages(ctx, "conv-migrate-no-ttl", []types.Message{
+			{Role: "assistant", Content: "msg2"},
+		})
+		require.NoError(t, err)
+
+		// Verify no TTL on migrated keys
+		msgKey := store.messagesKey("conv-migrate-no-ttl")
+		sumKey := store.summariesKey("conv-migrate-no-ttl")
+		assert.Equal(t, time.Duration(0), mr.TTL(msgKey), "migrated messages key should have no TTL")
+		assert.Equal(t, time.Duration(0), mr.TTL(sumKey), "migrated summaries key should have no TTL")
+	})
+}
+
+func TestRedisStore_ResolveStateFromCmds(t *testing.T) {
+	t.Run("resolves from monolithic when meta is missing", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		// Write only a monolithic key
+		legacyState := &ConversationState{
+			ID:           "conv-resolve-mono",
+			UserID:       "user-alice",
+			SystemPrompt: "Mono prompt",
+			TokenCount:   42,
+		}
+		saveMonolithicLegacy(t, store, legacyState)
+
+		// List with sorting triggers pipelinedLoadStates -> resolveStateFromCmds
+		ids, err := store.List(ctx, ListOptions{
+			SortBy:    SortByUpdatedAt,
+			SortOrder: "asc",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, ids, "conv-resolve-mono")
+	})
+
+	t.Run("returns nil when neither key exists", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		// Add ghost IDs to the user index (no actual data behind them)
+		err := store.client.SAdd(ctx, store.userIndexKey("user-ghost"), "conv-ghost-1", "conv-ghost-2").Err()
+		require.NoError(t, err)
+
+		// List with sorting — resolveStateFromCmds returns nil for both,
+		// pipelinedLoadStates skips them
+		ids, err := store.List(ctx, ListOptions{
+			UserID:    "user-ghost",
+			SortBy:    SortByUpdatedAt,
+			SortOrder: "desc",
+		})
+		require.NoError(t, err)
+		// The IDs list comes from SMembers (2 entries), but sorting overwrites
+		// only positions with real states (0 states found), so we still get the original 2 IDs back
+		assert.Len(t, ids, 2)
+	})
+}
+
+func TestRedisStore_SortStatesByField(t *testing.T) {
+	t.Run("sort by created_at ascending", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		// Save conversations with metadata containing created_at
+		for i, id := range []string{"conv-sort-a", "conv-sort-b", "conv-sort-c"} {
+			state := &ConversationState{
+				ID:     id,
+				UserID: "user-sort",
+				Metadata: map[string]interface{}{
+					"created_at": time.Date(2025, 1, 1+i, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+				},
+			}
+			err := store.Save(ctx, state)
+			require.NoError(t, err)
+		}
+
+		// Sort by created_at ascending
+		ids, err := store.List(ctx, ListOptions{
+			UserID:    "user-sort",
+			SortBy:    SortByCreatedAt,
+			SortOrder: "asc",
+		})
+		require.NoError(t, err)
+		assert.Len(t, ids, 3)
+		assert.Equal(t, "conv-sort-a", ids[0])
+		assert.Equal(t, "conv-sort-c", ids[2])
+	})
+
+	t.Run("sort by created_at descending", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		for i, id := range []string{"conv-sort-d", "conv-sort-e", "conv-sort-f"} {
+			state := &ConversationState{
+				ID:     id,
+				UserID: "user-sort-desc",
+				Metadata: map[string]interface{}{
+					"created_at": time.Date(2025, 1, 1+i, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+				},
+			}
+			err := store.Save(ctx, state)
+			require.NoError(t, err)
+		}
+
+		ids, err := store.List(ctx, ListOptions{
+			UserID:    "user-sort-desc",
+			SortBy:    SortByCreatedAt,
+			SortOrder: "desc",
+		})
+		require.NoError(t, err)
+		assert.Len(t, ids, 3)
+		assert.Equal(t, "conv-sort-f", ids[0])
+		assert.Equal(t, "conv-sort-d", ids[2])
+	})
+
+	t.Run("sort by unknown field preserves order", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		for _, id := range []string{"conv-unk-a", "conv-unk-b"} {
+			state := &ConversationState{
+				ID:     id,
+				UserID: "user-unk-sort",
+			}
+			err := store.Save(ctx, state)
+			require.NoError(t, err)
+		}
+
+		ids, err := store.List(ctx, ListOptions{
+			UserID:    "user-unk-sort",
+			SortBy:    "nonexistent_field",
+			SortOrder: "asc",
+		})
+		require.NoError(t, err)
+		assert.Len(t, ids, 2)
+	})
+}
+
+func TestRedisStore_ExtractIDFromKey_Variations(t *testing.T) {
+	store, _ := setupRedisStore(t)
+
+	// Valid conversation key
+	assert.Equal(t, "conv-123", store.extractIDFromKey("promptkit:conversation:conv-123"))
+	// Key with wrong prefix returns empty
+	assert.Equal(t, "", store.extractIDFromKey("other:prefix:conv-123"))
+	// Empty key returns empty
+	assert.Equal(t, "", store.extractIDFromKey(""))
+}
+
+func TestRedisStore_LoadMeta_InvalidJSON(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Write invalid JSON to the meta key
+	metaKey := store.metaKey("conv-bad-json")
+	err := store.client.Set(ctx, metaKey, "not valid json{{{", 0).Err()
+	require.NoError(t, err)
+
+	_, err = store.Load(ctx, "conv-bad-json")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal meta")
+}
+
+func TestRedisStore_LoadRecentFromMonolithic_NGreaterThanTotal(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Write monolithic key with messages
+	legacyState := &ConversationState{
+		ID:     "conv-mono-recent",
+		UserID: "user-alice",
+		Messages: []types.Message{
+			{Role: "user", Content: "msg1"},
+			{Role: "assistant", Content: "msg2"},
+		},
+	}
+	saveMonolithicLegacy(t, store, legacyState)
+
+	// Request more messages than exist — should return all
+	msgs, err := store.LoadRecentMessages(ctx, "conv-mono-recent", 100)
+	require.NoError(t, err)
+	assert.Len(t, msgs, 2)
+	assert.Equal(t, "msg1", msgs[0].Content)
+}
+
+func TestRedisStore_LoadRecentFromMonolithic_SliceLast(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Write monolithic key with messages
+	legacyState := &ConversationState{
+		ID:     "conv-mono-slice",
+		UserID: "user-alice",
+		Messages: []types.Message{
+			{Role: "user", Content: "msg1"},
+			{Role: "assistant", Content: "msg2"},
+			{Role: "user", Content: "msg3"},
+			{Role: "assistant", Content: "msg4"},
+		},
+	}
+	saveMonolithicLegacy(t, store, legacyState)
+
+	// Request last 2 — should slice from monolithic
+	msgs, err := store.LoadRecentMessages(ctx, "conv-mono-slice", 2)
+	require.NoError(t, err)
+	assert.Len(t, msgs, 2)
+	assert.Equal(t, "msg3", msgs[0].Content)
+	assert.Equal(t, "msg4", msgs[1].Content)
+}
+
+func TestRedisStore_MessageCount_MonolithicFallback(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Write monolithic key directly
+	legacyState := &ConversationState{
+		ID:     "conv-count-mono-legacy",
+		UserID: "user-alice",
+		Messages: []types.Message{
+			{Role: "user", Content: "a"},
+			{Role: "assistant", Content: "b"},
+			{Role: "user", Content: "c"},
+		},
+	}
+	saveMonolithicLegacy(t, store, legacyState)
+
+	count, err := store.MessageCount(ctx, "conv-count-mono-legacy")
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
+func TestRedisStore_AppendMessages_EmptySlice(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Append empty messages — rpushMessages returns nil early
+	err := store.AppendMessages(ctx, "conv-empty-append", []types.Message{})
+	require.NoError(t, err)
+}
+
+func TestRedisStore_List_SortError(t *testing.T) {
+	// This test validates that List with sorting on empty result returns gracefully
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	ids, err := store.List(ctx, ListOptions{
+		UserID:    "nonexistent-user",
+		SortBy:    SortByUpdatedAt,
+		SortOrder: "desc",
+	})
+	require.NoError(t, err)
+	assert.Len(t, ids, 0)
+}
+
+func TestRedisStore_SaveWithNoUserID(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Save with empty UserID — pipeUpdateUserIndex should skip
+	state := &ConversationState{
+		ID: "conv-no-user",
+		Messages: []types.Message{
+			{Role: "user", Content: "msg"},
+		},
+	}
+	err := store.Save(ctx, state)
+	require.NoError(t, err)
+
+	loaded, err := store.Load(ctx, "conv-no-user")
+	require.NoError(t, err)
+	assert.Equal(t, "", loaded.UserID)
+}
+
+func TestRedisStore_ResolveStateFromCmds_MonolithicFallback(t *testing.T) {
+	t.Run("sorts conversations from monolithic format", func(t *testing.T) {
+		store, _ := setupRedisStore(t)
+		ctx := context.Background()
+
+		// Write two monolithic-only conversations with different timestamps
+		state1 := &ConversationState{
+			ID:             "conv-mono-sort-1",
+			UserID:         "user-mono-sort",
+			LastAccessedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		saveMonolithicLegacy(t, store, state1)
+
+		state2 := &ConversationState{
+			ID:             "conv-mono-sort-2",
+			UserID:         "user-mono-sort",
+			LastAccessedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		}
+		saveMonolithicLegacy(t, store, state2)
+
+		// Add both to user index manually (since saveMonolithicLegacy doesn't)
+		indexKey := store.userIndexKey("user-mono-sort")
+		err := store.client.SAdd(ctx, indexKey, "conv-mono-sort-1", "conv-mono-sort-2").Err()
+		require.NoError(t, err)
+
+		// List with sorting — resolveStateFromCmds should fall back to monolithic
+		ids, err := store.List(ctx, ListOptions{
+			UserID:    "user-mono-sort",
+			SortBy:    SortByUpdatedAt,
+			SortOrder: "asc",
+		})
+		require.NoError(t, err)
+		assert.Len(t, ids, 2)
+		assert.Equal(t, "conv-mono-sort-1", ids[0])
+		assert.Equal(t, "conv-mono-sort-2", ids[1])
+	})
+}
+
+func TestRedisStore_LoadDecomposed_MessageListError(t *testing.T) {
+	// This covers the loadDecomposed error path when messages list has bad data
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Write valid meta
+	meta := redisStateMeta{
+		ID:     "conv-bad-msgs",
+		UserID: "user-alice",
+	}
+	metaData, err := json.Marshal(meta)
+	require.NoError(t, err)
+	err = store.client.Set(ctx, store.metaKey("conv-bad-msgs"), metaData, 0).Err()
+	require.NoError(t, err)
+
+	// Write invalid JSON to messages list
+	err = store.client.RPush(ctx, store.messagesKey("conv-bad-msgs"), "not-valid-json{{{").Err()
+	require.NoError(t, err)
+
+	_, loadErr := store.Load(ctx, "conv-bad-msgs")
+	assert.Error(t, loadErr)
+	assert.Contains(t, loadErr.Error(), "failed to unmarshal message")
+}
+
+func TestRedisStore_LoadSummariesList_Error(t *testing.T) {
+	// This covers the loadSummariesList error path when summaries list has bad data
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Write valid meta and messages
+	meta := redisStateMeta{
+		ID:     "conv-bad-sums",
+		UserID: "user-alice",
+	}
+	metaData, err := json.Marshal(meta)
+	require.NoError(t, err)
+	err = store.client.Set(ctx, store.metaKey("conv-bad-sums"), metaData, 0).Err()
+	require.NoError(t, err)
+
+	// Write invalid JSON to summaries list
+	err = store.client.RPush(ctx, store.summariesKey("conv-bad-sums"), "not-valid-json{{{").Err()
+	require.NoError(t, err)
+
+	_, loadErr := store.Load(ctx, "conv-bad-sums")
+	assert.Error(t, loadErr)
+	assert.Contains(t, loadErr.Error(), "failed to unmarshal summary")
+}
+
+func TestRedisStore_LoadSummaries_UnmarshalError(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Write invalid JSON to summaries list key
+	sumKey := store.summariesKey("conv-bad-sum-load")
+	err := store.client.RPush(ctx, sumKey, "invalid-json{").Err()
+	require.NoError(t, err)
+
+	_, loadErr := store.LoadSummaries(ctx, "conv-bad-sum-load")
+	assert.Error(t, loadErr)
+	assert.Contains(t, loadErr.Error(), "failed to unmarshal summary")
+}
+
+func TestRedisStore_LoadRecentMessages_UnmarshalError(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Write invalid JSON to messages list key
+	msgKey := store.messagesKey("conv-bad-msg-load")
+	err := store.client.RPush(ctx, msgKey, "invalid-json{").Err()
+	require.NoError(t, err)
+
+	_, loadErr := store.LoadRecentMessages(ctx, "conv-bad-msg-load", 5)
+	assert.Error(t, loadErr)
+	assert.Contains(t, loadErr.Error(), "failed to unmarshal message")
+}
+
+func TestRedisStore_IsSubKey(t *testing.T) {
+	store, _ := setupRedisStore(t)
+
+	assert.False(t, store.isSubKey("conv-123"))
+	assert.True(t, store.isSubKey("conv-123:messages"))
+	assert.True(t, store.isSubKey("conv-123:meta"))
+	assert.True(t, store.isSubKey("conv-123:summaries"))
+}
+
+func TestRedisStore_ExtractIDFromMetaKey(t *testing.T) {
+	store, _ := setupRedisStore(t)
+
+	assert.Equal(t, "conv-123", store.extractIDFromMetaKey("promptkit:conversation:conv-123:meta"))
+	assert.Equal(t, "", store.extractIDFromMetaKey("promptkit:conversation:conv-123:messages"))
+	assert.Equal(t, "", store.extractIDFromMetaKey("other:conversation:conv-123:meta"))
+	assert.Equal(t, "", store.extractIDFromMetaKey(""))
 }

--- a/runtime/storage/local/filestore.go
+++ b/runtime/storage/local/filestore.go
@@ -34,6 +34,9 @@ const (
 
 	// DefaultMaxFileSize is the default maximum file size (50 MB).
 	DefaultMaxFileSize = 50 * 1024 * 1024
+
+	// filePermissions is the default file permission mode for created files.
+	filePermissions = 0600
 )
 
 // ErrFileTooLarge is returned when data exceeds the configured MaxFileSize.
@@ -76,6 +79,7 @@ type FileStore struct {
 
 	// dedupIndex maps content hashes to file paths for deduplication
 	dedupIndex map[string]string
+	dedupDirty bool // tracks whether the in-memory index has unsaved changes
 	dedupMu    sync.RWMutex
 
 	// refCounts tracks how many references exist for each deduplicated file
@@ -237,13 +241,14 @@ func (fs *FileStore) StoreMedia(ctx context.Context, content *types.MediaContent
 	if fs.config.EnableDeduplication && hash != "" {
 		fs.dedupMu.Lock()
 		fs.dedupIndex[hash] = filePath
+		fs.dedupDirty = true
 		fs.dedupMu.Unlock()
 
 		fs.refMu.Lock()
 		fs.refCounts[filePath] = 1
 		fs.refMu.Unlock()
 
-		// Persist index
+		// Persist index (skips write if not dirty)
 		_ = fs.saveDedupIndex()
 	}
 
@@ -338,10 +343,13 @@ func (fs *FileStore) DeleteMedia(ctx context.Context, reference storage.Referenc
 		for hash, path := range fs.dedupIndex {
 			if path == filePath {
 				delete(fs.dedupIndex, hash)
+				fs.dedupDirty = true
 				break
 			}
 		}
 		fs.dedupMu.Unlock()
+
+		// Persist index (skips write if not dirty)
 		_ = fs.saveDedupIndex()
 	}
 
@@ -552,6 +560,11 @@ func (fs *FileStore) saveDedupIndex() error {
 	indexPath := filepath.Join(fs.config.BaseDir, ".dedup_index.json")
 
 	fs.dedupMu.RLock()
+	dirty := fs.dedupDirty
+	if !dirty {
+		fs.dedupMu.RUnlock()
+		return nil
+	}
 	data, err := json.MarshalIndent(fs.dedupIndex, "", "  ")
 	fs.dedupMu.RUnlock()
 
@@ -559,7 +572,24 @@ func (fs *FileStore) saveDedupIndex() error {
 		return err
 	}
 
-	return os.WriteFile(indexPath, data, 0600)
+	if err := os.WriteFile(indexPath, data, filePermissions); err != nil {
+		return err
+	}
+
+	fs.dedupMu.Lock()
+	fs.dedupDirty = false
+	fs.dedupMu.Unlock()
+
+	return nil
+}
+
+// Flush persists any pending dedup index changes to disk.
+// Call this periodically or before shutting down to ensure the index is saved.
+func (fs *FileStore) Flush() error {
+	if !fs.config.EnableDeduplication {
+		return nil
+	}
+	return fs.saveDedupIndex()
 }
 
 func (fs *FileStore) cleanupEmptyDirs(dir string) {

--- a/runtime/storage/local/filestore_test.go
+++ b/runtime/storage/local/filestore_test.go
@@ -1150,3 +1150,142 @@ func TestFileStore_SpecialCases(t *testing.T) {
 		assert.Nil(t, retrieved.PolicyName)
 	})
 }
+
+func TestFileStore_Flush(t *testing.T) {
+	t.Run("flush persists dedup index", func(t *testing.T) {
+		tempDir := t.TempDir()
+		fs1, err := local.NewFileStore(local.FileStoreConfig{
+			BaseDir:             tempDir,
+			Organization:        storage.OrganizationByRun,
+			EnableDeduplication: true,
+		})
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		testData := []byte("flush test data")
+		base64Data := base64.StdEncoding.EncodeToString(testData)
+		content := &types.MediaContent{
+			Data:     &base64Data,
+			MIMEType: "image/jpeg",
+		}
+		metadata := storage.MediaMetadata{
+			RunID:      "run-flush",
+			MessageIdx: 0,
+			PartIdx:    0,
+			MIMEType:   "image/jpeg",
+			SizeBytes:  int64(len(testData)),
+			Timestamp:  time.Now(),
+		}
+
+		ref1, err := fs1.StoreMedia(ctx, content, &metadata)
+		require.NoError(t, err)
+
+		// Flush should succeed
+		err = fs1.Flush()
+		assert.NoError(t, err)
+
+		// Create new instance - should load persisted index
+		fs2, err := local.NewFileStore(local.FileStoreConfig{
+			BaseDir:             tempDir,
+			Organization:        storage.OrganizationByRun,
+			EnableDeduplication: true,
+		})
+		require.NoError(t, err)
+
+		metadata2 := metadata
+		metadata2.RunID = "run-flush-2"
+		metadata2.MessageIdx = 1
+		ref2, err := fs2.StoreMedia(ctx, content, &metadata2)
+		require.NoError(t, err)
+
+		// Should deduplicate using loaded index
+		assert.Equal(t, ref1, ref2)
+	})
+
+	t.Run("flush is no-op when dedup disabled", func(t *testing.T) {
+		tempDir := t.TempDir()
+		fs, err := local.NewFileStore(local.FileStoreConfig{
+			BaseDir:      tempDir,
+			Organization: storage.OrganizationByRun,
+		})
+		require.NoError(t, err)
+
+		err = fs.Flush()
+		assert.NoError(t, err)
+	})
+
+	t.Run("flush is no-op when index unchanged", func(t *testing.T) {
+		tempDir := t.TempDir()
+		fs, err := local.NewFileStore(local.FileStoreConfig{
+			BaseDir:             tempDir,
+			Organization:        storage.OrganizationByRun,
+			EnableDeduplication: true,
+		})
+		require.NoError(t, err)
+
+		// Flush without any stores - should be no-op
+		err = fs.Flush()
+		assert.NoError(t, err)
+
+		// Dedup index file should not exist (nothing written)
+		indexPath := filepath.Join(tempDir, ".dedup_index.json")
+		assert.NoFileExists(t, indexPath)
+	})
+}
+
+func TestFileStore_DedupSkipsWriteOnHit(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	fs, err := local.NewFileStore(local.FileStoreConfig{
+		BaseDir:             tempDir,
+		Organization:        storage.OrganizationByRun,
+		EnableDeduplication: true,
+	})
+	require.NoError(t, err)
+
+	testData := []byte("dedup hit test data")
+	base64Data := base64.StdEncoding.EncodeToString(testData)
+	content := &types.MediaContent{
+		Data:     &base64Data,
+		MIMEType: "image/jpeg",
+	}
+
+	// Store first copy
+	metadata1 := storage.MediaMetadata{
+		RunID:      "run-hit-1",
+		MessageIdx: 0,
+		PartIdx:    0,
+		MIMEType:   "image/jpeg",
+		SizeBytes:  int64(len(testData)),
+		Timestamp:  time.Now(),
+	}
+	ref1, err := fs.StoreMedia(ctx, content, &metadata1)
+	require.NoError(t, err)
+
+	// Record modification time of dedup index file
+	indexPath := filepath.Join(tempDir, ".dedup_index.json")
+	info1, err := os.Stat(indexPath)
+	require.NoError(t, err)
+	modTime1 := info1.ModTime()
+
+	// Small delay to ensure filesystem timestamp granularity
+	time.Sleep(10 * time.Millisecond)
+
+	// Store duplicate - should be a dedup hit (no index write needed)
+	metadata2 := storage.MediaMetadata{
+		RunID:      "run-hit-2",
+		MessageIdx: 1,
+		PartIdx:    0,
+		MIMEType:   "image/jpeg",
+		SizeBytes:  int64(len(testData)),
+		Timestamp:  time.Now(),
+	}
+	ref2, err := fs.StoreMedia(ctx, content, &metadata2)
+	require.NoError(t, err)
+	assert.Equal(t, ref1, ref2)
+
+	// Verify index file was not rewritten (mod time unchanged)
+	info2, err := os.Stat(indexPath)
+	require.NoError(t, err)
+	assert.Equal(t, modTime1, info2.ModTime(), "dedup index should not be rewritten on dedup hit")
+}

--- a/runtime/storage/policy/time_based.go
+++ b/runtime/storage/policy/time_based.go
@@ -35,9 +35,19 @@ func WithBaseDir(baseDir string) Option {
 	}
 }
 
+// expiryEntry tracks a file and its expiration time in the in-memory index.
+type expiryEntry struct {
+	metaPath  string
+	expiresAt time.Time
+}
+
 // TimeBasedPolicyHandler implements PolicyHandler for time-based retention policies.
 // It applies expiration times to media based on policy names and enforces deletion
 // of expired media through background scanning.
+//
+// When an expiry index is built (via buildExpiryIndex or TrackFile), enforcement
+// uses the index to check only files whose expiry time has passed, avoiding a
+// full directory walk on every tick.
 type TimeBasedPolicyHandler struct {
 	// policies maps policy names to their configurations
 	policies map[string]Config
@@ -66,6 +76,15 @@ type TimeBasedPolicyHandler struct {
 	// mu protects started and stopped fields
 	mu sync.Mutex
 
+	// expiryIndex holds files with their expiry times, keyed by meta path.
+	// When populated, EnforcePolicy uses this index instead of walking the
+	// entire directory tree.
+	expiryIndex map[string]expiryEntry
+	expiryMu    sync.RWMutex
+
+	// indexBuilt indicates whether the expiry index has been populated
+	indexBuilt bool
+
 	// ctx is the context used for auto-started enforcement
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -80,6 +99,7 @@ func NewTimeBasedPolicyHandler(enforcementInterval time.Duration, opts ...Option
 		enforcementInterval: enforcementInterval,
 		stopCh:              make(chan struct{}),
 		doneCh:              make(chan struct{}),
+		expiryIndex:         make(map[string]expiryEntry),
 	}
 
 	for _, opt := range opts {
@@ -126,8 +146,60 @@ func (h *TimeBasedPolicyHandler) ApplyPolicy(ctx context.Context, metadata *stor
 	return nil
 }
 
-// EnforcePolicy implements storage.PolicyHandler.EnforcePolicy
+// EnforcePolicy implements storage.PolicyHandler.EnforcePolicy.
+// When an expiry index has been built (via BuildExpiryIndex or TrackFile),
+// this method only checks files whose expiry time has passed, avoiding a
+// full directory walk. Otherwise it falls back to walking the directory tree.
 func (h *TimeBasedPolicyHandler) EnforcePolicy(ctx context.Context, baseDir string) error {
+	h.expiryMu.RLock()
+	indexed := h.indexBuilt
+	h.expiryMu.RUnlock()
+
+	if indexed {
+		return h.enforceFromIndex(ctx)
+	}
+	return h.enforceFromWalk(ctx, baseDir)
+}
+
+// enforceFromIndex checks only files in the expiry index whose time has passed.
+func (h *TimeBasedPolicyHandler) enforceFromIndex(_ context.Context) error {
+	now := time.Now()
+	deleted := 0
+	errors := 0
+
+	// Collect expired entries under read lock
+	h.expiryMu.RLock()
+	var expired []expiryEntry
+	for _, entry := range h.expiryIndex {
+		if entry.expiresAt.Before(now) {
+			expired = append(expired, entry)
+		}
+	}
+	h.expiryMu.RUnlock()
+
+	// Process expired entries
+	for _, entry := range expired {
+		if h.processMetaFile(entry.metaPath, now) {
+			// Remove from index after successful deletion
+			h.expiryMu.Lock()
+			delete(h.expiryIndex, entry.metaPath)
+			h.expiryMu.Unlock()
+			deleted++
+		} else {
+			errors++
+		}
+	}
+
+	if deleted > 0 || errors > 0 {
+		logger.Info("Policy enforcement completed (indexed)", "deleted", deleted, "errors", errors)
+	}
+
+	return nil
+}
+
+// enforceFromWalk is the original full directory walk implementation, used
+// when no expiry index has been built.
+func (h *TimeBasedPolicyHandler) enforceFromWalk(_ context.Context, baseDir string) error {
 	now := time.Now()
 	deleted := 0
 	errors := 0
@@ -198,6 +270,8 @@ func (h *TimeBasedPolicyHandler) processMetaFile(metaPath string, now time.Time)
 }
 
 // StartEnforcement starts a background goroutine that periodically enforces policies.
+// On the first call it builds an in-memory expiry index by scanning the base directory
+// once, then uses that index on subsequent ticks to avoid repeated full directory walks.
 func (h *TimeBasedPolicyHandler) StartEnforcement(ctx context.Context, baseDir string) {
 	h.mu.Lock()
 	if h.started {
@@ -206,6 +280,11 @@ func (h *TimeBasedPolicyHandler) StartEnforcement(ctx context.Context, baseDir s
 	}
 	h.started = true
 	h.mu.Unlock()
+
+	// Build the expiry index once at startup
+	if err := h.BuildExpiryIndex(baseDir); err != nil {
+		logger.Warn("Failed to build expiry index, falling back to directory walk", "error", err)
+	}
 
 	go func() {
 		defer close(h.doneCh)
@@ -248,6 +327,80 @@ func (h *TimeBasedPolicyHandler) Stop() {
 	if wasStarted {
 		<-h.doneCh
 	}
+}
+
+// BuildExpiryIndex scans the base directory once and builds an in-memory
+// index of files with their expiry times. Subsequent calls to EnforcePolicy
+// will use this index instead of walking the directory tree.
+func (h *TimeBasedPolicyHandler) BuildExpiryIndex(baseDir string) error {
+	index := make(map[string]expiryEntry)
+
+	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // skip errors
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".meta") {
+			return nil
+		}
+
+		meta, loadErr := h.loadPolicyMetadata(path)
+		if loadErr != nil {
+			return nil // skip unreadable files
+		}
+
+		if meta.ExpiresAt != nil {
+			index[path] = expiryEntry{
+				metaPath:  path,
+				expiresAt: *meta.ExpiresAt,
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to build expiry index: %w", err)
+	}
+
+	h.expiryMu.Lock()
+	h.expiryIndex = index
+	h.indexBuilt = true
+	h.expiryMu.Unlock()
+
+	return nil
+}
+
+// TrackFile adds a file to the in-memory expiry index. This should be called
+// when a new file with a retention policy is stored, to keep the index current
+// without requiring a full directory scan.
+func (h *TimeBasedPolicyHandler) TrackFile(metaPath string, expiresAt time.Time) {
+	h.expiryMu.Lock()
+	defer h.expiryMu.Unlock()
+
+	h.expiryIndex[metaPath] = expiryEntry{
+		metaPath:  metaPath,
+		expiresAt: expiresAt,
+	}
+	// Mark index as built if this is the first tracked file,
+	// enabling index-based enforcement going forward.
+	h.indexBuilt = true
+}
+
+// UntrackFile removes a file from the in-memory expiry index. This should be
+// called when a file is explicitly deleted, to keep the index current.
+func (h *TimeBasedPolicyHandler) UntrackFile(metaPath string) {
+	h.expiryMu.Lock()
+	defer h.expiryMu.Unlock()
+
+	delete(h.expiryIndex, metaPath)
+}
+
+// ExpiryIndexLen returns the number of entries in the expiry index.
+// This is primarily useful for testing.
+func (h *TimeBasedPolicyHandler) ExpiryIndexLen() int {
+	h.expiryMu.RLock()
+	defer h.expiryMu.RUnlock()
+	return len(h.expiryIndex)
 }
 
 // loadPolicyMetadata loads policy metadata from a .meta file.

--- a/runtime/storage/policy/time_based_test.go
+++ b/runtime/storage/policy/time_based_test.go
@@ -3,6 +3,7 @@ package policy_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -336,4 +337,232 @@ func TestTimeBasedPolicyHandler_StartEnforcementIdempotent(t *testing.T) {
 	handler.StartEnforcement(ctx, tempDir)
 
 	handler.Stop()
+}
+
+func TestTimeBasedPolicyHandler_BuildExpiryIndex(t *testing.T) {
+	t.Run("builds index from existing meta files", func(t *testing.T) {
+		tempDir := t.TempDir()
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+
+		// Create 3 meta files: 2 expired, 1 active
+		for i, offset := range []time.Duration{-6, -10, -1} {
+			mediaPath := filepath.Join(tempDir, fmt.Sprintf("file%d.jpg", i))
+			err := os.WriteFile(mediaPath, []byte("data"), 0600)
+			require.NoError(t, err)
+
+			meta := storage.MediaMetadata{
+				PolicyName: "delete-after-5min",
+				Timestamp:  time.Now().Add(offset * time.Minute),
+				MIMEType:   "image/jpeg",
+			}
+			metaData, err := json.Marshal(meta)
+			require.NoError(t, err)
+			err = os.WriteFile(mediaPath+".meta", metaData, 0600)
+			require.NoError(t, err)
+		}
+
+		err := handler.BuildExpiryIndex(tempDir)
+		require.NoError(t, err)
+
+		// All 3 files should be in the index (they all have policies)
+		assert.Equal(t, 3, handler.ExpiryIndexLen())
+	})
+
+	t.Run("skips files without policy", func(t *testing.T) {
+		tempDir := t.TempDir()
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+
+		// Create a meta file without a policy name
+		metaPath := filepath.Join(tempDir, "nopolicy.jpg.meta")
+		meta := storage.MediaMetadata{
+			MIMEType:  "image/jpeg",
+			Timestamp: time.Now(),
+		}
+		metaData, err := json.Marshal(meta)
+		require.NoError(t, err)
+		err = os.WriteFile(metaPath, metaData, 0600)
+		require.NoError(t, err)
+
+		err = handler.BuildExpiryIndex(tempDir)
+		require.NoError(t, err)
+		assert.Equal(t, 0, handler.ExpiryIndexLen())
+	})
+
+	t.Run("handles corrupt meta files gracefully", func(t *testing.T) {
+		tempDir := t.TempDir()
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+
+		metaPath := filepath.Join(tempDir, "corrupt.jpg.meta")
+		err := os.WriteFile(metaPath, []byte("not json"), 0600)
+		require.NoError(t, err)
+
+		err = handler.BuildExpiryIndex(tempDir)
+		require.NoError(t, err)
+		assert.Equal(t, 0, handler.ExpiryIndexLen())
+	})
+}
+
+func TestTimeBasedPolicyHandler_TrackFile(t *testing.T) {
+	t.Run("adds file to expiry index", func(t *testing.T) {
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+
+		expiresAt := time.Now().Add(5 * time.Minute)
+		handler.TrackFile("/tmp/test.jpg.meta", expiresAt)
+
+		assert.Equal(t, 1, handler.ExpiryIndexLen())
+	})
+
+	t.Run("updates existing entry", func(t *testing.T) {
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+
+		handler.TrackFile("/tmp/test.jpg.meta", time.Now().Add(5*time.Minute))
+		handler.TrackFile("/tmp/test.jpg.meta", time.Now().Add(10*time.Minute))
+
+		assert.Equal(t, 1, handler.ExpiryIndexLen())
+	})
+}
+
+func TestTimeBasedPolicyHandler_UntrackFile(t *testing.T) {
+	t.Run("removes file from expiry index", func(t *testing.T) {
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+
+		handler.TrackFile("/tmp/test.jpg.meta", time.Now().Add(5*time.Minute))
+		assert.Equal(t, 1, handler.ExpiryIndexLen())
+
+		handler.UntrackFile("/tmp/test.jpg.meta")
+		assert.Equal(t, 0, handler.ExpiryIndexLen())
+	})
+
+	t.Run("no-op for unknown file", func(t *testing.T) {
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+		handler.UntrackFile("/tmp/nonexistent.meta") // should not panic
+		assert.Equal(t, 0, handler.ExpiryIndexLen())
+	})
+}
+
+func TestTimeBasedPolicyHandler_IndexedEnforcement(t *testing.T) {
+	t.Run("deletes only expired files using index", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+
+		// Create expired file
+		expiredMedia := filepath.Join(tempDir, "expired.jpg")
+		err := os.WriteFile(expiredMedia, []byte("expired"), 0600)
+		require.NoError(t, err)
+
+		expiredMeta := storage.MediaMetadata{
+			PolicyName: "delete-after-5min",
+			Timestamp:  time.Now().Add(-6 * time.Minute),
+			MIMEType:   "image/jpeg",
+		}
+		expiredMetaData, err := json.Marshal(expiredMeta)
+		require.NoError(t, err)
+		expiredMetaPath := expiredMedia + ".meta"
+		err = os.WriteFile(expiredMetaPath, expiredMetaData, 0600)
+		require.NoError(t, err)
+
+		// Create active file
+		activeMedia := filepath.Join(tempDir, "active.jpg")
+		err = os.WriteFile(activeMedia, []byte("active"), 0600)
+		require.NoError(t, err)
+
+		activeMeta := storage.MediaMetadata{
+			PolicyName: "delete-after-5min",
+			Timestamp:  time.Now().Add(-1 * time.Minute),
+			MIMEType:   "image/jpeg",
+		}
+		activeMetaData, err := json.Marshal(activeMeta)
+		require.NoError(t, err)
+		activeMetaPath := activeMedia + ".meta"
+		err = os.WriteFile(activeMetaPath, activeMetaData, 0600)
+		require.NoError(t, err)
+
+		// Build index
+		err = handler.BuildExpiryIndex(tempDir)
+		require.NoError(t, err)
+		assert.Equal(t, 2, handler.ExpiryIndexLen())
+
+		// Enforce using index
+		err = handler.EnforcePolicy(ctx, tempDir)
+		assert.NoError(t, err)
+
+		// Expired file should be deleted, active file should remain
+		assert.NoFileExists(t, expiredMedia)
+		assert.NoFileExists(t, expiredMetaPath)
+		assert.FileExists(t, activeMedia)
+		assert.FileExists(t, activeMetaPath)
+
+		// Index should have removed the expired entry
+		assert.Equal(t, 1, handler.ExpiryIndexLen())
+	})
+
+	t.Run("enforcement with tracked files deletes expired", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		handler := policy.NewTimeBasedPolicyHandler(1 * time.Minute)
+
+		// Create a media file
+		mediaPath := filepath.Join(tempDir, "tracked.jpg")
+		err := os.WriteFile(mediaPath, []byte("data"), 0600)
+		require.NoError(t, err)
+
+		meta := storage.MediaMetadata{
+			PolicyName: "delete-after-5min",
+			Timestamp:  time.Now().Add(-6 * time.Minute),
+			MIMEType:   "image/jpeg",
+		}
+		metaData, err := json.Marshal(meta)
+		require.NoError(t, err)
+		metaPath := mediaPath + ".meta"
+		err = os.WriteFile(metaPath, metaData, 0600)
+		require.NoError(t, err)
+
+		// Track the file manually (as would happen during store)
+		handler.TrackFile(metaPath, time.Now().Add(-1*time.Minute)) // already expired
+
+		// Enforce
+		err = handler.EnforcePolicy(ctx, tempDir)
+		assert.NoError(t, err)
+
+		assert.NoFileExists(t, mediaPath)
+		assert.NoFileExists(t, metaPath)
+		assert.Equal(t, 0, handler.ExpiryIndexLen())
+	})
+
+	t.Run("StartEnforcement builds index and uses it", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		tempDir := t.TempDir()
+		handler := policy.NewTimeBasedPolicyHandler(100 * time.Millisecond)
+
+		// Create an expired file
+		mediaPath := filepath.Join(tempDir, "indexed-expire.jpg")
+		err := os.WriteFile(mediaPath, []byte("data"), 0600)
+		require.NoError(t, err)
+
+		meta := storage.MediaMetadata{
+			PolicyName: "delete-after-5min",
+			Timestamp:  time.Now().Add(-6 * time.Minute),
+			MIMEType:   "image/jpeg",
+		}
+		metaData, err := json.Marshal(meta)
+		require.NoError(t, err)
+		metaPath := mediaPath + ".meta"
+		err = os.WriteFile(metaPath, metaData, 0600)
+		require.NoError(t, err)
+
+		// Start enforcement - should build index on startup
+		handler.StartEnforcement(ctx, tempDir)
+
+		// Wait for enforcement to run
+		time.Sleep(250 * time.Millisecond)
+
+		// File should be deleted
+		assert.NoFileExists(t, mediaPath)
+		assert.NoFileExists(t, metaPath)
+
+		handler.Stop()
+	})
 }

--- a/runtime/tools/mcp_executor.go
+++ b/runtime/tools/mcp_executor.go
@@ -108,21 +108,17 @@ func (e *MCPExecutor) extractErrorMessage(content []mcp.Content) string {
 		return mcpToolReturnedErr
 	}
 
-	var errorMsg string
-	for i, item := range content {
+	var parts []string
+	for _, item := range content {
 		if item.Text != "" {
-			if i == 0 {
-				errorMsg = item.Text
-			} else {
-				errorMsg += "; " + item.Text
-			}
+			parts = append(parts, item.Text)
 		}
 	}
 
-	if errorMsg == "" {
+	if len(parts) == 0 {
 		return mcpToolReturnedErr
 	}
-	return errorMsg
+	return strings.Join(parts, "; ")
 }
 
 func (e *MCPExecutor) formatSuccessResponse(toolName string, response *mcp.ToolCallResponse) (json.RawMessage, error) {

--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -19,6 +20,10 @@ const (
 	// that don't specify their own TimeoutMs. 30 seconds accommodates HTTP-calling
 	// tools and other network-dependent operations.
 	DefaultToolTimeout = 30000
+
+	// DefaultMaxToolResultSize is the maximum allowed size (in bytes) of a
+	// JSON-marshaled tool result. Results exceeding this limit are truncated.
+	DefaultMaxToolResultSize = 1 * 1024 * 1024 // 1 MB
 )
 
 // ToolRepository provides abstract access to tool descriptors (local interface to avoid import cycles)
@@ -39,13 +44,24 @@ func WithDefaultTimeout(ms int) RegistryOption {
 	}
 }
 
-// Registry manages tool descriptors and provides access to executors
+// WithMaxToolResultSize sets the maximum allowed size (in bytes) of a
+// JSON-marshaled tool result. Pass 0 to disable size checking.
+func WithMaxToolResultSize(bytes int) RegistryOption {
+	return func(r *Registry) {
+		r.maxToolResultSize = bytes
+	}
+}
+
+// Registry manages tool descriptors and provides access to executors.
+// All map access is protected by mu (RWMutex) for safe concurrent use.
 type Registry struct {
-	repository       ToolRepository             // Optional repository for loading tools
-	tools            map[string]*ToolDescriptor // Cache of loaded tool descriptors
-	validator        *SchemaValidator           // Schema validator for tool arguments
-	executors        map[string]Executor        // Registered tool executors
-	defaultTimeoutMs int                        // Default timeout for tools without explicit TimeoutMs
+	mu                sync.RWMutex
+	repository        ToolRepository             // Optional repository for loading tools
+	tools             map[string]*ToolDescriptor // Cache of loaded tool descriptors
+	validator         *SchemaValidator           // Schema validator for tool arguments
+	executors         map[string]Executor        // Registered tool executors
+	defaultTimeoutMs  int                        // Default timeout for tools without explicit TimeoutMs
+	maxToolResultSize int                        // Max result size in bytes (0 = unlimited)
 }
 
 // NewRegistry creates a new tool registry without a repository backend (legacy mode)
@@ -61,11 +77,12 @@ func NewRegistryWithRepository(repo ToolRepository, opts ...RegistryOption) *Reg
 // newRegistry is the internal constructor for creating registries
 func newRegistry(repository ToolRepository, opts ...RegistryOption) *Registry {
 	registry := &Registry{
-		repository:       repository,
-		tools:            make(map[string]*ToolDescriptor),
-		validator:        NewSchemaValidator(),
-		executors:        make(map[string]Executor),
-		defaultTimeoutMs: DefaultToolTimeout,
+		repository:        repository,
+		tools:             make(map[string]*ToolDescriptor),
+		validator:         NewSchemaValidator(),
+		executors:         make(map[string]Executor),
+		defaultTimeoutMs:  DefaultToolTimeout,
+		maxToolResultSize: DefaultMaxToolResultSize,
 	}
 
 	for _, opt := range opts {
@@ -90,7 +107,7 @@ func newRegistry(repository ToolRepository, opts ...RegistryOption) *Registry {
 	return registry
 }
 
-// Register adds a tool descriptor to the registry with validation
+// Register adds a tool descriptor to the registry with validation.
 func (r *Registry) Register(descriptor *ToolDescriptor) error {
 	// Test validation setup (errors here indicate schema compilation issues, which are acceptable during registration)
 	_ = r.validator.ValidateArgs(descriptor, []byte("{}"))
@@ -106,21 +123,28 @@ func (r *Registry) Register(descriptor *ToolDescriptor) error {
 	descriptor.Namespace, _ = ParseToolName(descriptor.Name)
 
 	// Cache the descriptor
+	r.mu.Lock()
 	r.tools[descriptor.Name] = descriptor
+	r.mu.Unlock()
 	return nil
 }
 
-// Get retrieves a tool descriptor by name with repository fallback
+// Get retrieves a tool descriptor by name with repository fallback.
 func (r *Registry) Get(name string) *ToolDescriptor {
 	// Check cache first
-	if tool, ok := r.tools[name]; ok {
+	r.mu.RLock()
+	tool, ok := r.tools[name]
+	r.mu.RUnlock()
+	if ok {
 		return tool
 	}
 
 	// Try loading from repository if available
 	if r.repository != nil {
 		if tool, _ := r.repository.LoadTool(name); tool != nil {
+			r.mu.Lock()
 			r.tools[name] = tool // Cache the loaded tool
+			r.mu.Unlock()
 			return tool
 		}
 	}
@@ -128,7 +152,7 @@ func (r *Registry) Get(name string) *ToolDescriptor {
 	return nil // Not found
 }
 
-// List returns all tool names from repository or cache
+// List returns all tool names from repository or cache.
 func (r *Registry) List() []string {
 	// Try repository first for complete list
 	if r.repository != nil {
@@ -138,6 +162,8 @@ func (r *Registry) List() []string {
 	}
 
 	// Fallback to cache
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	names := make([]string, 0, len(r.tools))
 	for name := range r.tools {
 		names = append(names, name)
@@ -203,7 +229,9 @@ func (r *Registry) loadK8sManifest(filename string, temp any) error {
 	}
 
 	toolConfig.Spec.Namespace, _ = ParseToolName(toolConfig.Spec.Name)
+	r.mu.Lock()
 	r.tools[toolConfig.Spec.Name] = &toolConfig.Spec
+	r.mu.Unlock()
 	return nil
 }
 
@@ -233,23 +261,29 @@ func (r *Registry) loadJSONTool(filename string, data []byte) error {
 	}
 
 	descriptor.Namespace, _ = ParseToolName(descriptor.Name)
+	r.mu.Lock()
 	r.tools[descriptor.Name] = &descriptor
+	r.mu.Unlock()
 	return nil
 }
 
-// GetTool retrieves a tool descriptor by name
+// GetTool retrieves a tool descriptor by name.
 func (r *Registry) GetTool(name string) (*ToolDescriptor, error) {
+	r.mu.RLock()
 	tool, exists := r.tools[name]
+	r.mu.RUnlock()
 	if !exists {
 		return nil, fmt.Errorf("%w: %s", ErrToolNotFound, name)
 	}
 	return tool, nil
 }
 
-// GetTools returns all loaded tool descriptors
+// GetTools returns all loaded tool descriptors.
 func (r *Registry) GetTools() map[string]*ToolDescriptor {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	// Return a copy to prevent external modification
-	result := make(map[string]*ToolDescriptor)
+	result := make(map[string]*ToolDescriptor, len(r.tools))
 	for name, tool := range r.tools {
 		result[name] = tool
 	}
@@ -271,6 +305,8 @@ func (r *Registry) GetToolsByNames(names []string) ([]*ToolDescriptor, error) {
 
 // GetByNamespace returns all tool descriptors in the given namespace.
 func (r *Registry) GetByNamespace(ns string) []*ToolDescriptor {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	var result []*ToolDescriptor
 	for _, tool := range r.tools {
 		if tool.Namespace == ns {
@@ -280,9 +316,18 @@ func (r *Registry) GetByNamespace(ns string) []*ToolDescriptor {
 	return result
 }
 
-// RegisterExecutor registers a tool executor
+// RegisterExecutor registers a tool executor.
 func (r *Registry) RegisterExecutor(executor Executor) {
+	r.mu.Lock()
 	r.executors[executor.Name()] = executor
+	r.mu.Unlock()
+}
+
+// MaxToolResultSize returns the configured maximum tool result size in bytes.
+func (r *Registry) MaxToolResultSize() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.maxToolResultSize
 }
 
 // withTimeout wraps ctx with a deadline derived from the tool's TimeoutMs.
@@ -409,6 +454,9 @@ func (r *Registry) ExecuteAsync(
 // 1. Built-in mode mapping (mock, live, mcp) for backwards compatibility
 // 2. If tool.Mode matches a registered executor name, use it (enables custom executors)
 func (r *Registry) getExecutorForTool(tool *ToolDescriptor) (Executor, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	var executorName string
 
 	// First, handle built-in modes with their established mappings
@@ -557,7 +605,9 @@ func (r *Registry) validateDescriptor(descriptor *ToolDescriptor) error {
 	isBuiltinMode := descriptor.Mode == "" || descriptor.Mode == modeMock ||
 		descriptor.Mode == modeLive || descriptor.Mode == modeMCP ||
 		descriptor.Mode == modeClient
+	r.mu.RLock()
 	_, isRegisteredExecutor := r.executors[descriptor.Mode]
+	r.mu.RUnlock()
 	if !isBuiltinMode && !isRegisteredExecutor {
 		return ErrInvalidToolMode
 	}

--- a/runtime/tools/registry_concurrency_test.go
+++ b/runtime/tools/registry_concurrency_test.go
@@ -1,0 +1,96 @@
+package tools_test
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// TestRegistryConcurrentRegisterAndGet verifies that concurrent Register and Get
+// calls do not race (protected by the internal RWMutex).
+func TestRegistryConcurrentRegisterAndGet(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+
+	// Concurrently register tools
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			name := "tool_" + string(rune('A'+idx%26)) + string(rune('0'+idx/26))
+			desc := &tools.ToolDescriptor{
+				Name:         name,
+				Description:  "Test tool",
+				InputSchema:  json.RawMessage(`{"type":"object"}`),
+				OutputSchema: json.RawMessage(`{"type":"object"}`),
+			}
+			_ = registry.Register(desc)
+		}(i)
+	}
+
+	// Concurrently read tools
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			name := "tool_" + string(rune('A'+idx%26)) + string(rune('0'+idx/26))
+			_ = registry.Get(name)
+			_ = registry.List()
+			_ = registry.GetTools()
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify at least some tools were registered
+	if len(registry.List()) == 0 {
+		t.Error("expected some tools to be registered")
+	}
+}
+
+// TestRegistryConcurrentRegisterExecutor verifies concurrent executor registration.
+func TestRegistryConcurrentRegisterExecutor(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			// Re-registering the same executors concurrently should be safe
+			registry.RegisterExecutor(tools.NewMockStaticExecutor())
+			registry.RegisterExecutor(tools.NewMockScriptedExecutor())
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestMaxToolResultSizeOption verifies the WithMaxToolResultSize option.
+func TestMaxToolResultSizeOption(t *testing.T) {
+	t.Run("default is 1MB", func(t *testing.T) {
+		registry := tools.NewRegistry()
+		if registry.MaxToolResultSize() != tools.DefaultMaxToolResultSize {
+			t.Errorf("expected %d, got %d", tools.DefaultMaxToolResultSize, registry.MaxToolResultSize())
+		}
+	})
+
+	t.Run("custom value", func(t *testing.T) {
+		registry := tools.NewRegistry(tools.WithMaxToolResultSize(512))
+		if registry.MaxToolResultSize() != 512 {
+			t.Errorf("expected 512, got %d", registry.MaxToolResultSize())
+		}
+	})
+
+	t.Run("zero disables limit", func(t *testing.T) {
+		registry := tools.NewRegistry(tools.WithMaxToolResultSize(0))
+		if registry.MaxToolResultSize() != 0 {
+			t.Errorf("expected 0, got %d", registry.MaxToolResultSize())
+		}
+	})
+}

--- a/runtime/variables/state.go
+++ b/runtime/variables/state.go
@@ -2,6 +2,7 @@ package variables
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -69,18 +70,20 @@ func (p *StateProvider) Provide(ctx context.Context) (map[string]string, error) 
 		return nil, nil
 	}
 
-	state, err := p.store.Load(ctx, p.conversationID)
+	// Use MetadataAccessor if available to avoid deep-copying the entire message
+	// history. This is significantly cheaper for conversations with many messages.
+	metadata, err := p.loadMetadata(ctx)
 	if err != nil {
 		// Conversation not found is not an error - just return no variables
 		return nil, nil
 	}
 
-	if state == nil || state.Metadata == nil {
+	if metadata == nil {
 		return nil, nil
 	}
 
 	result := make(map[string]string)
-	for k, v := range state.Metadata {
+	for k, v := range metadata {
 		// Apply prefix filter if configured
 		if p.KeyPrefix != "" && !strings.HasPrefix(k, p.KeyPrefix) {
 			continue
@@ -97,4 +100,31 @@ func (p *StateProvider) Provide(ctx context.Context) (map[string]string, error) 
 	}
 
 	return result, nil
+}
+
+// loadMetadata returns the metadata map for the current conversation.
+// It uses MetadataAccessor if available to avoid deep-copying the full state,
+// otherwise falls back to Store.Load.
+func (p *StateProvider) loadMetadata(ctx context.Context) (map[string]interface{}, error) {
+	// Try MetadataAccessor first (avoids deep-copying messages)
+	if accessor, ok := p.store.(statestore.MetadataAccessor); ok {
+		metadata, err := accessor.LoadMetadata(ctx, p.conversationID)
+		if err != nil {
+			if errors.Is(err, statestore.ErrNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return metadata, nil
+	}
+
+	// Fall back to full Load
+	state, err := p.store.Load(ctx, p.conversationID)
+	if err != nil {
+		return nil, err
+	}
+	if state == nil {
+		return nil, nil
+	}
+	return state.Metadata, nil
 }

--- a/runtime/variables/state_test.go
+++ b/runtime/variables/state_test.go
@@ -25,6 +25,26 @@ func (m *mockStateStore) Fork(_ context.Context, _, _ string) error {
 	return nil
 }
 
+// mockMetadataStore implements both statestore.Store and statestore.MetadataAccessor.
+// It tracks whether LoadMetadata was called to verify the fast path is used.
+type mockMetadataStore struct {
+	mockStateStore
+	metadata         map[string]interface{}
+	metadataErr      error
+	loadMetaCalled   bool
+	loadStateCalled  bool
+}
+
+func (m *mockMetadataStore) Load(_ context.Context, _ string) (*statestore.ConversationState, error) {
+	m.loadStateCalled = true
+	return m.mockStateStore.Load(nil, "")
+}
+
+func (m *mockMetadataStore) LoadMetadata(_ context.Context, _ string) (map[string]interface{}, error) {
+	m.loadMetaCalled = true
+	return m.metadata, m.metadataErr
+}
+
 func TestStateProvider_Name(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -173,5 +193,76 @@ func TestStateProvider_Provide(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestStateProvider_UsesMetadataAccessor(t *testing.T) {
+	// Verify that when the store implements MetadataAccessor,
+	// the provider uses LoadMetadata instead of Load (avoids deep-copying messages).
+	store := &mockMetadataStore{
+		metadata: map[string]interface{}{
+			"user_name": "Alice",
+			"count":     42,
+		},
+	}
+
+	provider := NewStateProvider(store, "test-conv")
+	got, err := provider.Provide(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have used LoadMetadata, not Load
+	if !store.loadMetaCalled {
+		t.Error("expected LoadMetadata to be called")
+	}
+	if store.loadStateCalled {
+		t.Error("Load should not be called when MetadataAccessor is available")
+	}
+
+	// Verify the values
+	if got["user_name"] != "Alice" {
+		t.Errorf("user_name = %v, want Alice", got["user_name"])
+	}
+	if got["count"] != "42" {
+		t.Errorf("count = %v, want 42", got["count"])
+	}
+}
+
+func TestStateProvider_FallsBackToLoad(t *testing.T) {
+	// Verify that when MetadataAccessor is NOT implemented,
+	// the provider falls back to Load.
+	store := &mockStateStore{
+		state: &statestore.ConversationState{
+			Metadata: map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	provider := NewStateProvider(store, "test-conv")
+	got, err := provider.Provide(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got["key"] != "value" {
+		t.Errorf("key = %v, want value", got["key"])
+	}
+}
+
+func TestStateProvider_MetadataAccessorNotFound(t *testing.T) {
+	// Verify that ErrNotFound from MetadataAccessor returns nil (not error).
+	store := &mockMetadataStore{
+		metadataErr: statestore.ErrNotFound,
+	}
+
+	provider := NewStateProvider(store, "test-conv")
+	got, err := provider.Provide(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
 	}
 }

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -448,6 +448,9 @@
         "concurrency": {
           "type": "integer"
         },
+        "run_timeout": {
+          "type": "string"
+        },
         "output": {
           "$ref": "#/$defs/OutputConfig"
         },

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -879,6 +879,11 @@ func (c *Conversation) Close() error {
 		}
 	}
 
+	// Stop the pending store cleanup goroutine
+	if c.pendingStore != nil {
+		c.pendingStore.Close()
+	}
+
 	// State is automatically persisted by the StateStore middleware in the pipeline
 	// No explicit save needed here
 

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -841,6 +841,9 @@ func (c *Conversation) Close() error {
 	}
 	c.closed = true
 
+	// Deregister from shutdown manager if configured
+	c.deregisterFromShutdownManager()
+
 	// End the OTel session span (deferred to Close so late-arriving async events
 	// from the EventBus still have a parent context).
 	if c.config != nil && c.config.otelListener != nil {
@@ -888,6 +891,14 @@ func (c *Conversation) Close() error {
 	// No explicit save needed here
 
 	return nil
+}
+
+// deregisterFromShutdownManager removes the conversation from its shutdown
+// manager, if one is configured. Must be called while c.mu is held.
+func (c *Conversation) deregisterFromShutdownManager() {
+	if c.config != nil && c.config.shutdownManager != nil {
+		c.config.shutdownManager.Deregister(c.ID())
+	}
 }
 
 // ID returns the conversation's unique identifier.

--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -359,7 +359,9 @@ func (c *Conversation) CheckPending(
 	}
 
 	// Store it
-	c.pendingStore.Add(pending)
+	if err := c.pendingStore.Add(pending); err != nil {
+		return nil, false
+	}
 
 	return pending, true
 }

--- a/sdk/eval_middleware_test.go
+++ b/sdk/eval_middleware_test.go
@@ -655,18 +655,29 @@ func TestEvalMiddleware_EmitResults_WithBus(t *testing.T) {
 		{EvalID: "e2", Type: "regex", Passed: false},
 	})
 
-	// Check we got 2 events
-	e1 := <-received
-	e2 := <-received
+	// Check we got 2 events (order is non-deterministic).
+	ev1 := <-received
+	ev2 := <-received
 
-	if e1.Type != events.EventEvalCompleted {
-		t.Errorf("expected eval.completed, got %s", e1.Type)
-	}
-	if e2.Type != events.EventEvalFailed {
-		t.Errorf("expected eval.failed, got %s", e2.Type)
+	got := []*events.Event{ev1, ev2}
+	var completed, failed *events.Event
+	for _, e := range got {
+		switch e.Type {
+		case events.EventEvalCompleted:
+			completed = e
+		case events.EventEvalFailed:
+			failed = e
+		}
 	}
 
-	data1, ok := e1.Data.(*events.EvalCompletedData)
+	if completed == nil {
+		t.Fatal("expected an eval.completed event")
+	}
+	if failed == nil {
+		t.Fatal("expected an eval.failed event")
+	}
+
+	data1, ok := completed.Data.(*events.EvalCompletedData)
 	if !ok {
 		t.Fatal("expected *EvalCompletedData")
 	}

--- a/sdk/eval_middleware_test.go
+++ b/sdk/eval_middleware_test.go
@@ -626,7 +626,10 @@ func (h *gatedEvalHandler) Eval(
 }
 
 func TestEvalMiddleware_EmitResults_WithBus(t *testing.T) {
-	bus := events.NewEventBus()
+	// Use a single worker to guarantee ordered dispatch of events.
+	bus := events.NewEventBus(events.WithWorkerPoolSize(1))
+	defer bus.Close()
+
 	received := make(chan *events.Event, 10)
 	bus.Subscribe(events.EventEvalCompleted, func(e *events.Event) {
 		received <- e
@@ -655,33 +658,40 @@ func TestEvalMiddleware_EmitResults_WithBus(t *testing.T) {
 		{EvalID: "e2", Type: "regex", Passed: false},
 	})
 
-	// Check we got 2 events (order is non-deterministic).
-	ev1 := <-received
-	ev2 := <-received
-
-	got := []*events.Event{ev1, ev2}
-	var completed, failed *events.Event
-	for _, e := range got {
-		switch e.Type {
-		case events.EventEvalCompleted:
-			completed = e
-		case events.EventEvalFailed:
-			failed = e
+	// Collect 2 events (order may vary with multiple workers, so use maps).
+	var got []*events.Event
+	for range 2 {
+		select {
+		case e := <-received:
+			got = append(got, e)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for eval events")
 		}
 	}
 
-	if completed == nil {
-		t.Fatal("expected an eval.completed event")
-	}
-	if failed == nil {
-		t.Fatal("expected an eval.failed event")
+	// Verify we received one completed and one failed event.
+	typeCount := map[events.EventType]int{}
+	for _, e := range got {
+		typeCount[e.Type]++
 	}
 
-	data1, ok := completed.Data.(*events.EvalCompletedData)
-	if !ok {
-		t.Fatal("expected *EvalCompletedData")
+	if typeCount[events.EventEvalCompleted] != 1 {
+		t.Errorf("expected 1 eval.completed, got %d", typeCount[events.EventEvalCompleted])
 	}
-	if data1.EvalID != "e1" {
-		t.Errorf("expected eval ID e1, got %q", data1.EvalID)
+	if typeCount[events.EventEvalFailed] != 1 {
+		t.Errorf("expected 1 eval.failed, got %d", typeCount[events.EventEvalFailed])
+	}
+
+	// Verify eval IDs are present.
+	for _, e := range got {
+		if e.Type == events.EventEvalCompleted {
+			data, ok := e.Data.(*events.EvalCompletedData)
+			if !ok {
+				t.Fatal("expected *EvalCompletedData")
+			}
+			if data.EvalID != "e1" {
+				t.Errorf("expected eval ID e1, got %q", data.EvalID)
+			}
+		}
 	}
 }

--- a/sdk/hitl_test.go
+++ b/sdk/hitl_test.go
@@ -126,6 +126,7 @@ func TestResolveTool(t *testing.T) {
 	t.Run("returns error for non-existent id", func(t *testing.T) {
 		conv := newTestConversation()
 		conv.pendingStore = sdktools.NewPendingStore()
+		defer conv.pendingStore.Close()
 
 		_, err := conv.ResolveTool("non-existent")
 		assert.Error(t, err)
@@ -144,10 +145,11 @@ func TestRejectTool(t *testing.T) {
 	t.Run("rejects pending tool", func(t *testing.T) {
 		conv := newTestConversation()
 		conv.pendingStore = sdktools.NewPendingStore()
-		conv.pendingStore.Add(&sdktools.PendingToolCall{
+		defer conv.pendingStore.Close()
+		require.NoError(t, conv.pendingStore.Add(&sdktools.PendingToolCall{
 			ID:   "test-id",
 			Name: "test_tool",
-		})
+		}))
 
 		resolution, err := conv.RejectTool("test-id", "not authorized")
 		require.NoError(t, err)
@@ -172,8 +174,9 @@ func TestPendingTools(t *testing.T) {
 	t.Run("returns pending tools", func(t *testing.T) {
 		conv := newTestConversation()
 		conv.pendingStore = sdktools.NewPendingStore()
-		conv.pendingStore.Add(&sdktools.PendingToolCall{ID: "1", Name: "tool1"})
-		conv.pendingStore.Add(&sdktools.PendingToolCall{ID: "2", Name: "tool2"})
+		defer conv.pendingStore.Close()
+		require.NoError(t, conv.pendingStore.Add(&sdktools.PendingToolCall{ID: "1", Name: "tool1"}))
+		require.NoError(t, conv.pendingStore.Add(&sdktools.PendingToolCall{ID: "2", Name: "tool2"}))
 
 		pending := conv.PendingTools()
 		assert.Len(t, pending, 2)
@@ -302,13 +305,14 @@ func TestRejectToolStoresResolution(t *testing.T) {
 	t.Run("stores rejection for continue", func(t *testing.T) {
 		conv := newTestConversation()
 		conv.pendingStore = sdktools.NewPendingStore()
+		defer conv.pendingStore.Close()
 		conv.resolvedStore = sdktools.NewResolvedStore()
 
 		// Add a pending tool
-		conv.pendingStore.Add(&sdktools.PendingToolCall{
+		require.NoError(t, conv.pendingStore.Add(&sdktools.PendingToolCall{
 			ID:   "test-id",
 			Name: "test_tool",
-		})
+		}))
 
 		// Reject it
 		resolution, err := conv.RejectTool("test-id", "not allowed")

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -176,6 +176,9 @@ type config struct {
 
 	// Custom logger for SDK consumers
 	logger *slog.Logger
+
+	// Shutdown manager for graceful conversation cleanup
+	shutdownManager *ShutdownManager
 }
 
 // buildHookRegistry creates a hooks.Registry from the configured hooks.
@@ -1738,6 +1741,24 @@ func WithMaxActiveSkillsOption(n int) Option {
 			return fmt.Errorf("WithMaxActiveSkillsOption: n must be positive, got %d", n)
 		}
 		c.maxActiveSkills = n
+		return nil
+	}
+}
+
+// WithShutdownManager attaches a [ShutdownManager] to the conversation.
+// When set, [Open] and [OpenDuplex] automatically register the conversation
+// with the manager, and [Conversation.Close] automatically deregisters it.
+//
+//	mgr := sdk.NewShutdownManager()
+//	go sdk.GracefulShutdown(mgr, 30*time.Second)
+//
+//	conv, _ := sdk.Open("./chat.pack.json", "assistant",
+//	    sdk.WithShutdownManager(mgr),
+//	)
+//	defer conv.Close()
+func WithShutdownManager(mgr *ShutdownManager) Option {
+	return func(c *config) error {
+		c.shutdownManager = mgr
 		return nil
 	}
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -77,6 +77,14 @@ func Open(packPath, promptName string, opts ...Option) (*Conversation, error) {
 		return nil, err
 	}
 
+	// Register with shutdown manager if configured
+	if conv.config.shutdownManager != nil {
+		if err := conv.config.shutdownManager.Register(conv.ID(), conv); err != nil {
+			_ = conv.Close()
+			return nil, fmt.Errorf("failed to register with shutdown manager: %w", err)
+		}
+	}
+
 	return conv, nil
 }
 
@@ -130,6 +138,14 @@ func OpenDuplex(packPath, promptName string, opts ...Option) (*Conversation, err
 	// Finalize conversation (eval middleware, MCP, session start hooks)
 	if err := finalizeConversation(conv, conv.config); err != nil {
 		return nil, err
+	}
+
+	// Register with shutdown manager if configured
+	if conv.config.shutdownManager != nil {
+		if err := conv.config.shutdownManager.Register(conv.ID(), conv); err != nil {
+			_ = conv.Close()
+			return nil, fmt.Errorf("failed to register with shutdown manager: %w", err)
+		}
 	}
 
 	return conv, nil

--- a/sdk/shutdown.go
+++ b/sdk/shutdown.go
@@ -1,0 +1,151 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+)
+
+// ErrShutdownManagerClosed is returned when Register is called after Shutdown.
+var ErrShutdownManagerClosed = errors.New("shutdown manager is closed; cannot register new conversations")
+
+// ShutdownManager tracks active conversations and closes them all on shutdown.
+// It is safe for concurrent use.
+//
+// Use [NewShutdownManager] to create an instance and [WithShutdownManager] to
+// wire it into [Open] / [OpenDuplex] so that conversations are automatically
+// registered and deregistered.
+//
+// Example:
+//
+//	mgr := sdk.NewShutdownManager()
+//	go sdk.GracefulShutdown(mgr, 30*time.Second)
+//
+//	conv, _ := sdk.Open("./chat.pack.json", "assistant",
+//	    sdk.WithShutdownManager(mgr),
+//	)
+//	defer conv.Close() // automatically deregisters
+type ShutdownManager struct {
+	mu     sync.Mutex
+	convs  map[string]io.Closer // conversation ID -> conversation
+	closed bool
+}
+
+// NewShutdownManager creates a new ShutdownManager.
+func NewShutdownManager() *ShutdownManager {
+	return &ShutdownManager{
+		convs: make(map[string]io.Closer),
+	}
+}
+
+// Register tracks a conversation for shutdown. If the manager has already
+// been shut down, it returns [ErrShutdownManagerClosed].
+func (m *ShutdownManager) Register(id string, conv io.Closer) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.closed {
+		return ErrShutdownManagerClosed
+	}
+	m.convs[id] = conv
+	return nil
+}
+
+// Deregister removes a conversation from tracking. It is safe to call with
+// an ID that was never registered or was already deregistered.
+func (m *ShutdownManager) Deregister(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.convs, id)
+}
+
+// Shutdown closes all tracked conversations. It respects the context deadline,
+// returning a context error if the deadline is exceeded before all conversations
+// are closed. After Shutdown returns, new registrations are rejected.
+//
+// Errors from individual Close calls are collected and returned as a combined
+// error using [errors.Join].
+func (m *ShutdownManager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	m.closed = true
+	// Snapshot and clear so we don't hold the lock during Close calls.
+	snapshot := make(map[string]io.Closer, len(m.convs))
+	for id, c := range m.convs {
+		snapshot[id] = c
+	}
+	m.convs = make(map[string]io.Closer)
+	m.mu.Unlock()
+
+	if len(snapshot) == 0 {
+		return nil
+	}
+
+	type result struct {
+		id  string
+		err error
+	}
+
+	results := make(chan result, len(snapshot))
+	for id, conv := range snapshot {
+		go func(id string, conv io.Closer) {
+			results <- result{id: id, err: conv.Close()}
+		}(id, conv)
+	}
+
+	var errs []error
+	for range len(snapshot) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case r := <-results:
+			if r.err != nil {
+				errs = append(errs, r.err)
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Len returns the number of currently tracked conversations.
+func (m *ShutdownManager) Len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.convs)
+}
+
+// GracefulShutdown listens for SIGTERM and SIGINT, then calls
+// mgr.Shutdown with the given timeout. It is designed to be called
+// as a goroutine:
+//
+//	go sdk.GracefulShutdown(mgr, 30*time.Second)
+func GracefulShutdown(mgr *ShutdownManager, timeout time.Duration) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	gracefulShutdownOnSignal(mgr, timeout, sigCh)
+}
+
+// gracefulShutdownOnSignal waits for a signal on sigCh and then shuts down
+// the manager with the given timeout. Extracted for testability.
+func gracefulShutdownOnSignal(mgr *ShutdownManager, timeout time.Duration, sigCh <-chan os.Signal) {
+	sig := <-sigCh
+	logger.Info("Received signal, shutting down conversations", "signal", sig.String())
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := mgr.Shutdown(ctx); err != nil {
+		logger.Error("Shutdown completed with errors", "error", err)
+	} else {
+		logger.Info("All conversations closed successfully")
+	}
+}

--- a/sdk/shutdown_test.go
+++ b/sdk/shutdown_test.go
@@ -1,0 +1,254 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// mockCloser is a minimal io.Closer for testing shutdown behavior.
+type mockCloser struct {
+	closed    atomic.Bool
+	closeFunc func() error
+}
+
+func (m *mockCloser) Close() error {
+	m.closed.Store(true)
+	if m.closeFunc != nil {
+		return m.closeFunc()
+	}
+	return nil
+}
+
+func TestShutdownManager_RegisterAndDeregister(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	c1 := &mockCloser{}
+	c2 := &mockCloser{}
+
+	if err := mgr.Register("conv-1", c1); err != nil {
+		t.Fatalf("Register conv-1: %v", err)
+	}
+	if err := mgr.Register("conv-2", c2); err != nil {
+		t.Fatalf("Register conv-2: %v", err)
+	}
+
+	if mgr.Len() != 2 {
+		t.Fatalf("expected 2 tracked, got %d", mgr.Len())
+	}
+
+	mgr.Deregister("conv-1")
+	if mgr.Len() != 1 {
+		t.Fatalf("expected 1 tracked after deregister, got %d", mgr.Len())
+	}
+
+	// Deregistering a non-existent ID is a no-op.
+	mgr.Deregister("does-not-exist")
+	if mgr.Len() != 1 {
+		t.Fatalf("expected 1 tracked after no-op deregister, got %d", mgr.Len())
+	}
+}
+
+func TestShutdownManager_ShutdownClosesAll(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	closers := make([]*mockCloser, 5)
+	for i := range closers {
+		closers[i] = &mockCloser{}
+		if err := mgr.Register(idFromIndex(i), closers[i]); err != nil {
+			t.Fatalf("Register %d: %v", i, err)
+		}
+	}
+
+	ctx := context.Background()
+	if err := mgr.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	for i, c := range closers {
+		if !c.closed.Load() {
+			t.Errorf("closer %d was not closed", i)
+		}
+	}
+
+	if mgr.Len() != 0 {
+		t.Errorf("expected 0 tracked after shutdown, got %d", mgr.Len())
+	}
+}
+
+func TestShutdownManager_ShutdownAggregatesErrors(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	errA := errors.New("close error A")
+	errB := errors.New("close error B")
+
+	_ = mgr.Register("ok", &mockCloser{})
+	_ = mgr.Register("err-a", &mockCloser{closeFunc: func() error { return errA }})
+	_ = mgr.Register("err-b", &mockCloser{closeFunc: func() error { return errB }})
+
+	err := mgr.Shutdown(context.Background())
+	if err == nil {
+		t.Fatal("expected aggregated error, got nil")
+	}
+
+	if !errors.Is(err, errA) {
+		t.Errorf("expected error to contain errA, got: %v", err)
+	}
+	if !errors.Is(err, errB) {
+		t.Errorf("expected error to contain errB, got: %v", err)
+	}
+}
+
+func TestShutdownManager_ShutdownRespectsTimeout(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	// Register a closer that blocks until cancelled.
+	blocker := &mockCloser{
+		closeFunc: func() error {
+			time.Sleep(5 * time.Second)
+			return nil
+		},
+	}
+	_ = mgr.Register("blocking", blocker)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := mgr.Shutdown(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got: %v", err)
+	}
+}
+
+func TestShutdownManager_RejectAfterClosed(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	_ = mgr.Shutdown(context.Background())
+
+	err := mgr.Register("late", &mockCloser{})
+	if !errors.Is(err, ErrShutdownManagerClosed) {
+		t.Fatalf("expected ErrShutdownManagerClosed, got: %v", err)
+	}
+}
+
+func TestShutdownManager_ShutdownEmpty(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown on empty manager: %v", err)
+	}
+}
+
+func TestShutdownManager_ConcurrentRegisterDeregister(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	var wg sync.WaitGroup
+	const n = 100
+
+	// Concurrently register.
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = mgr.Register(idFromIndex(i), &mockCloser{})
+		}(i)
+	}
+	wg.Wait()
+
+	if mgr.Len() != n {
+		t.Fatalf("expected %d tracked, got %d", n, mgr.Len())
+	}
+
+	// Concurrently deregister half.
+	for i := range n / 2 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			mgr.Deregister(idFromIndex(i))
+		}(i)
+	}
+	wg.Wait()
+
+	if mgr.Len() != n/2 {
+		t.Fatalf("expected %d tracked, got %d", n/2, mgr.Len())
+	}
+
+	// Shutdown the remainder.
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestShutdownManager_DoubleShutdown(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	_ = mgr.Register("conv-1", &mockCloser{})
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("first Shutdown: %v", err)
+	}
+
+	// Second shutdown should be a no-op (no conversations left).
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second Shutdown: %v", err)
+	}
+}
+
+func TestGracefulShutdownOnSignal(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	c := &mockCloser{}
+	_ = mgr.Register("conv-1", c)
+
+	sigCh := make(chan os.Signal, 1)
+
+	done := make(chan struct{})
+	go func() {
+		gracefulShutdownOnSignal(mgr, 5*time.Second, sigCh)
+		close(done)
+	}()
+
+	// Send signal to trigger shutdown.
+	sigCh <- syscall.SIGTERM
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("gracefulShutdownOnSignal did not return in time")
+	}
+
+	if !c.closed.Load() {
+		t.Error("expected closer to be closed after signal")
+	}
+	if mgr.Len() != 0 {
+		t.Errorf("expected 0 tracked, got %d", mgr.Len())
+	}
+}
+
+func TestGracefulShutdownOnSignal_WithErrors(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	_ = mgr.Register("err", &mockCloser{closeFunc: func() error {
+		return errors.New("close failed")
+	}})
+
+	sigCh := make(chan os.Signal, 1)
+	sigCh <- syscall.SIGINT
+
+	// Should complete without panicking even with close errors.
+	gracefulShutdownOnSignal(mgr, 5*time.Second, sigCh)
+
+	if mgr.Len() != 0 {
+		t.Errorf("expected 0 tracked, got %d", mgr.Len())
+	}
+}
+
+// idFromIndex is a helper that converts an integer index to a string ID.
+func idFromIndex(i int) string {
+	return "conv-" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+}

--- a/sdk/tools/pending.go
+++ b/sdk/tools/pending.go
@@ -3,9 +3,27 @@ package tools
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 )
+
+const (
+	// DefaultPendingTTL is the default time-to-live for pending tool calls.
+	// Entries older than this are automatically removed by the cleanup goroutine.
+	DefaultPendingTTL = 5 * time.Minute
+
+	// DefaultMaxPending is the default maximum number of pending tool calls
+	// that can be stored simultaneously. New adds are rejected when full.
+	DefaultMaxPending = 1000
+
+	// pendingCleanupInterval is the interval between TTL cleanup sweeps.
+	pendingCleanupInterval = 30 * time.Second
+)
+
+// ErrPendingStoreFull is returned when the store has reached its maximum capacity.
+var ErrPendingStoreFull = errors.New("pending store is full")
 
 // PendingResult is returned by async tool handlers to indicate
 // that the tool execution requires external approval.
@@ -62,6 +80,9 @@ type PendingToolCall struct {
 
 	// The underlying handler to execute if approved
 	handler func(args map[string]any) (any, error)
+
+	// createdAt tracks when this entry was added for TTL expiration.
+	createdAt time.Time
 }
 
 // SetHandler sets the execution handler for this pending call.
@@ -70,24 +91,107 @@ func (p *PendingToolCall) SetHandler(h func(args map[string]any) (any, error)) {
 	p.handler = h
 }
 
-// PendingStore manages pending tool calls for a conversation.
-type PendingStore struct {
-	pending map[string]*PendingToolCall
-	mu      sync.RWMutex
-}
+// PendingStoreOption configures a PendingStore during construction.
+type PendingStoreOption func(*PendingStore)
 
-// NewPendingStore creates a new pending tool store.
-func NewPendingStore() *PendingStore {
-	return &PendingStore{
-		pending: make(map[string]*PendingToolCall),
+// WithPendingTTL sets the time-to-live for pending tool calls.
+// Entries older than this are removed during periodic cleanup.
+func WithPendingTTL(ttl time.Duration) PendingStoreOption {
+	return func(s *PendingStore) {
+		s.ttl = ttl
 	}
 }
 
-// Add stores a pending tool call.
-func (s *PendingStore) Add(call *PendingToolCall) {
+// WithMaxPending sets the maximum number of pending tool calls allowed.
+func WithMaxPending(limit int) PendingStoreOption {
+	return func(s *PendingStore) {
+		s.maxPending = limit
+	}
+}
+
+// PendingStore manages pending tool calls for a conversation.
+type PendingStore struct {
+	pending    map[string]*PendingToolCall
+	mu         sync.RWMutex
+	ttl        time.Duration
+	maxPending int
+	stopCh     chan struct{}
+	stopped    chan struct{}
+	nowFunc    func() time.Time // for testing
+}
+
+// NewPendingStore creates a new pending tool store with TTL-based cleanup.
+// Call Close() when the store is no longer needed to stop the cleanup goroutine.
+func NewPendingStore(opts ...PendingStoreOption) *PendingStore {
+	s := &PendingStore{
+		pending:    make(map[string]*PendingToolCall),
+		ttl:        DefaultPendingTTL,
+		maxPending: DefaultMaxPending,
+		stopCh:     make(chan struct{}),
+		stopped:    make(chan struct{}),
+		nowFunc:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	go s.cleanupLoop()
+	return s
+}
+
+// cleanupLoop periodically removes expired entries.
+func (s *PendingStore) cleanupLoop() {
+	defer close(s.stopped)
+	ticker := time.NewTicker(pendingCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			s.removeExpired()
+		}
+	}
+}
+
+// removeExpired removes all entries that have exceeded the TTL.
+func (s *PendingStore) removeExpired() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	now := s.nowFunc()
+	for id, call := range s.pending {
+		if now.Sub(call.createdAt) > s.ttl {
+			delete(s.pending, id)
+		}
+	}
+}
+
+// Close stops the background cleanup goroutine and waits for it to finish.
+func (s *PendingStore) Close() {
+	select {
+	case <-s.stopCh:
+		// Already closed
+		return
+	default:
+		close(s.stopCh)
+	}
+	<-s.stopped
+}
+
+// Add stores a pending tool call. Returns ErrPendingStoreFull if the store
+// has reached its maximum capacity.
+func (s *PendingStore) Add(call *PendingToolCall) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.pending) >= s.maxPending {
+		return ErrPendingStoreFull
+	}
+
+	call.createdAt = s.nowFunc()
 	s.pending[call.ID] = call
+	return nil
 }
 
 // Get retrieves a pending tool call by ID.

--- a/sdk/tools/pending_test.go
+++ b/sdk/tools/pending_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,7 @@ func TestPendingResult(t *testing.T) {
 func TestPendingStore(t *testing.T) {
 	t.Run("add and get", func(t *testing.T) {
 		store := NewPendingStore()
+		defer store.Close()
 		call := &PendingToolCall{
 			ID:        "call-1",
 			Name:      "test_tool",
@@ -42,7 +44,8 @@ func TestPendingStore(t *testing.T) {
 			Reason:    "test",
 		}
 
-		store.Add(call)
+		err := store.Add(call)
+		require.NoError(t, err)
 
 		retrieved, ok := store.Get("call-1")
 		assert.True(t, ok)
@@ -52,14 +55,16 @@ func TestPendingStore(t *testing.T) {
 
 	t.Run("get non-existent", func(t *testing.T) {
 		store := NewPendingStore()
+		defer store.Close()
 		_, ok := store.Get("non-existent")
 		assert.False(t, ok)
 	})
 
 	t.Run("remove", func(t *testing.T) {
 		store := NewPendingStore()
-		store.Add(&PendingToolCall{ID: "call-1", Name: "tool1"})
-		store.Add(&PendingToolCall{ID: "call-2", Name: "tool2"})
+		defer store.Close()
+		require.NoError(t, store.Add(&PendingToolCall{ID: "call-1", Name: "tool1"}))
+		require.NoError(t, store.Add(&PendingToolCall{ID: "call-2", Name: "tool2"}))
 
 		assert.Equal(t, 2, store.Len())
 
@@ -72,8 +77,9 @@ func TestPendingStore(t *testing.T) {
 
 	t.Run("list", func(t *testing.T) {
 		store := NewPendingStore()
-		store.Add(&PendingToolCall{ID: "call-1", Name: "tool1"})
-		store.Add(&PendingToolCall{ID: "call-2", Name: "tool2"})
+		defer store.Close()
+		require.NoError(t, store.Add(&PendingToolCall{ID: "call-1", Name: "tool1"}))
+		require.NoError(t, store.Add(&PendingToolCall{ID: "call-2", Name: "tool2"}))
 
 		calls := store.List()
 		assert.Len(t, calls, 2)
@@ -81,8 +87,9 @@ func TestPendingStore(t *testing.T) {
 
 	t.Run("clear", func(t *testing.T) {
 		store := NewPendingStore()
-		store.Add(&PendingToolCall{ID: "call-1", Name: "tool1"})
-		store.Add(&PendingToolCall{ID: "call-2", Name: "tool2"})
+		defer store.Close()
+		require.NoError(t, store.Add(&PendingToolCall{ID: "call-1", Name: "tool1"}))
+		require.NoError(t, store.Add(&PendingToolCall{ID: "call-2", Name: "tool2"}))
 
 		store.Clear()
 		assert.Equal(t, 0, store.Len())
@@ -92,6 +99,7 @@ func TestPendingStore(t *testing.T) {
 func TestPendingStoreResolve(t *testing.T) {
 	t.Run("resolve successful", func(t *testing.T) {
 		store := NewPendingStore()
+		defer store.Close()
 		call := &PendingToolCall{
 			ID:        "call-1",
 			Name:      "test_tool",
@@ -101,7 +109,7 @@ func TestPendingStoreResolve(t *testing.T) {
 				return map[string]any{"result": x * 2}, nil
 			},
 		}
-		store.Add(call)
+		require.NoError(t, store.Add(call))
 
 		resolution, err := store.Resolve("call-1")
 		require.NoError(t, err)
@@ -117,12 +125,14 @@ func TestPendingStoreResolve(t *testing.T) {
 
 	t.Run("resolve non-existent", func(t *testing.T) {
 		store := NewPendingStore()
+		defer store.Close()
 		_, err := store.Resolve("non-existent")
 		assert.Error(t, err)
 	})
 
 	t.Run("resolve handler error", func(t *testing.T) {
 		store := NewPendingStore()
+		defer store.Close()
 		call := &PendingToolCall{
 			ID:   "call-1",
 			Name: "failing_tool",
@@ -130,7 +140,7 @@ func TestPendingStoreResolve(t *testing.T) {
 				return nil, assert.AnError
 			},
 		}
-		store.Add(call)
+		require.NoError(t, store.Add(call))
 
 		resolution, err := store.Resolve("call-1")
 		require.NoError(t, err) // Resolution itself succeeds
@@ -141,7 +151,8 @@ func TestPendingStoreResolve(t *testing.T) {
 func TestPendingStoreReject(t *testing.T) {
 	t.Run("reject successful", func(t *testing.T) {
 		store := NewPendingStore()
-		store.Add(&PendingToolCall{ID: "call-1", Name: "test_tool"})
+		defer store.Close()
+		require.NoError(t, store.Add(&PendingToolCall{ID: "call-1", Name: "test_tool"}))
 
 		resolution, err := store.Reject("call-1", "not authorized")
 		require.NoError(t, err)
@@ -156,6 +167,7 @@ func TestPendingStoreReject(t *testing.T) {
 
 	t.Run("reject non-existent", func(t *testing.T) {
 		store := NewPendingStore()
+		defer store.Close()
 		_, err := store.Reject("non-existent", "reason")
 		assert.Error(t, err)
 	})
@@ -188,6 +200,7 @@ func TestAsyncToolHandler(t *testing.T) {
 func TestPendingToolCall_SetHandler(t *testing.T) {
 	t.Run("sets handler and can resolve", func(t *testing.T) {
 		store := NewPendingStore()
+		defer store.Close()
 		call := &PendingToolCall{
 			ID:        "call-1",
 			Name:      "test_tool",
@@ -200,7 +213,7 @@ func TestPendingToolCall_SetHandler(t *testing.T) {
 			return map[string]any{"result": x * 2}, nil
 		})
 
-		store.Add(call)
+		require.NoError(t, store.Add(call))
 
 		resolution, err := store.Resolve("call-1")
 		assert.NoError(t, err)
@@ -275,5 +288,120 @@ func TestResolvedStore(t *testing.T) {
 
 		store.PopAll()
 		assert.Equal(t, 0, store.Len())
+	})
+}
+
+func TestPendingStoreMaxEntries(t *testing.T) {
+	t.Run("rejects when full", func(t *testing.T) {
+		store := NewPendingStore(WithMaxPending(2))
+		defer store.Close()
+
+		require.NoError(t, store.Add(&PendingToolCall{ID: "1", Name: "t1"}))
+		require.NoError(t, store.Add(&PendingToolCall{ID: "2", Name: "t2"}))
+
+		err := store.Add(&PendingToolCall{ID: "3", Name: "t3"})
+		assert.ErrorIs(t, err, ErrPendingStoreFull)
+		assert.Equal(t, 2, store.Len())
+	})
+
+	t.Run("accepts after removal frees space", func(t *testing.T) {
+		store := NewPendingStore(WithMaxPending(2))
+		defer store.Close()
+
+		require.NoError(t, store.Add(&PendingToolCall{ID: "1", Name: "t1"}))
+		require.NoError(t, store.Add(&PendingToolCall{ID: "2", Name: "t2"}))
+
+		store.Remove("1")
+		require.NoError(t, store.Add(&PendingToolCall{ID: "3", Name: "t3"}))
+		assert.Equal(t, 2, store.Len())
+	})
+}
+
+func TestPendingStoreTTL(t *testing.T) {
+	t.Run("expired entries are removed", func(t *testing.T) {
+		now := time.Now()
+		store := NewPendingStore(WithPendingTTL(1 * time.Minute))
+		store.nowFunc = func() time.Time { return now }
+		defer store.Close()
+
+		require.NoError(t, store.Add(&PendingToolCall{ID: "old", Name: "t1"}))
+		require.NoError(t, store.Add(&PendingToolCall{ID: "new", Name: "t2"}))
+
+		// Advance time past TTL for "old" entry
+		store.nowFunc = func() time.Time { return now.Add(2 * time.Minute) }
+
+		// Add a fresh entry so its createdAt is after TTL
+		require.NoError(t, store.Add(&PendingToolCall{ID: "fresh", Name: "t3"}))
+
+		// Run cleanup
+		store.removeExpired()
+
+		// "old" and "new" should be gone, "fresh" should remain
+		_, oldOk := store.Get("old")
+		assert.False(t, oldOk, "expired entry 'old' should be removed")
+
+		_, newOk := store.Get("new")
+		assert.False(t, newOk, "expired entry 'new' should be removed")
+
+		_, freshOk := store.Get("fresh")
+		assert.True(t, freshOk, "fresh entry should remain")
+	})
+
+	t.Run("non-expired entries are kept", func(t *testing.T) {
+		now := time.Now()
+		store := NewPendingStore(WithPendingTTL(10 * time.Minute))
+		store.nowFunc = func() time.Time { return now }
+		defer store.Close()
+
+		require.NoError(t, store.Add(&PendingToolCall{ID: "1", Name: "t1"}))
+
+		// Advance only slightly
+		store.nowFunc = func() time.Time { return now.Add(1 * time.Minute) }
+		store.removeExpired()
+
+		assert.Equal(t, 1, store.Len())
+	})
+}
+
+func TestPendingStoreClose(t *testing.T) {
+	t.Run("close stops cleanup goroutine", func(t *testing.T) {
+		store := NewPendingStore()
+		store.Close()
+
+		// Double close should not panic
+		store.Close()
+	})
+
+	t.Run("close waits for goroutine", func(t *testing.T) {
+		store := NewPendingStore()
+		store.Close()
+		// After Close, the stopped channel should be closed
+		select {
+		case <-store.stopped:
+			// expected
+		default:
+			t.Error("stopped channel should be closed after Close()")
+		}
+	})
+}
+
+func TestPendingStoreOptions(t *testing.T) {
+	t.Run("custom TTL", func(t *testing.T) {
+		store := NewPendingStore(WithPendingTTL(10 * time.Second))
+		defer store.Close()
+		assert.Equal(t, 10*time.Second, store.ttl)
+	})
+
+	t.Run("custom max pending", func(t *testing.T) {
+		store := NewPendingStore(WithMaxPending(50))
+		defer store.Close()
+		assert.Equal(t, 50, store.maxPending)
+	})
+
+	t.Run("defaults", func(t *testing.T) {
+		store := NewPendingStore()
+		defer store.Close()
+		assert.Equal(t, DefaultPendingTTL, store.ttl)
+		assert.Equal(t, DefaultMaxPending, store.maxPending)
 	})
 }

--- a/server/a2a/health_test.go
+++ b/server/a2a/health_test.go
@@ -1,0 +1,201 @@
+package a2aserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingChecker is a HealthChecker that always returns an error.
+type failingChecker struct{ err error }
+
+func (c *failingChecker) Check(context.Context) error { return c.err }
+
+// passingChecker is a HealthChecker that always succeeds.
+type passingChecker struct{}
+
+func (*passingChecker) Check(context.Context) error { return nil }
+
+func TestHealthz_ReturnsOK(t *testing.T) {
+	t.Parallel()
+
+	opener := func(string) (Conversation, error) { return nil, nil }
+	srv := NewServer(opener)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/healthz") //nolint:noctx // test helper
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "ok", body["status"])
+}
+
+func TestReadyz_ReadyAfterInit(t *testing.T) {
+	t.Parallel()
+
+	opener := func(string) (Conversation, error) { return nil, nil }
+	srv := NewServer(opener)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/readyz") //nolint:noctx // test helper
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "ready", body["status"])
+}
+
+func TestReadyz_NotReadyDuringShutdown(t *testing.T) {
+	t.Parallel()
+
+	opener := func(string) (Conversation, error) { return nil, nil }
+	srv := NewServer(opener)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// Simulate shutdown: mark server not ready.
+	require.NoError(t, srv.Shutdown(context.Background()))
+
+	resp, err := http.Get(ts.URL + "/readyz") //nolint:noctx // test helper
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "not_ready", body["status"])
+	assert.Contains(t, body["reason"], "shutting down")
+}
+
+func TestReadyz_FailingHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	opener := func(string) (Conversation, error) { return nil, nil }
+	srv := NewServer(opener, WithHealthCheck("db", &failingChecker{err: errors.New("connection refused")}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/readyz") //nolint:noctx // test helper
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "not_ready", body["status"])
+
+	checks, ok := body["checks"].(map[string]any)
+	require.True(t, ok, "expected checks map in response")
+	dbCheck, ok := checks["db"].(map[string]any)
+	require.True(t, ok, "expected db check in response")
+	assert.Equal(t, "fail", dbCheck["status"])
+	assert.Equal(t, "connection refused", dbCheck["error"])
+}
+
+func TestReadyz_PassingHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	opener := func(string) (Conversation, error) { return nil, nil }
+	srv := NewServer(opener, WithHealthCheck("cache", &passingChecker{}))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/readyz") //nolint:noctx // test helper
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "ready", body["status"])
+
+	checks, ok := body["checks"].(map[string]any)
+	require.True(t, ok, "expected checks map in response")
+	cacheCheck, ok := checks["cache"].(map[string]any)
+	require.True(t, ok, "expected cache check in response")
+	assert.Equal(t, "pass", cacheCheck["status"])
+}
+
+func TestReadyz_MultipleCheckers_MixedResults(t *testing.T) {
+	t.Parallel()
+
+	opener := func(string) (Conversation, error) { return nil, nil }
+	srv := NewServer(opener,
+		WithHealthCheck("ok-check", &passingChecker{}),
+		WithHealthCheck("bad-check", &failingChecker{err: errors.New("timeout")}),
+	)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/readyz") //nolint:noctx // test helper
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	checks := body["checks"].(map[string]any)
+	okCheck := checks["ok-check"].(map[string]any)
+	assert.Equal(t, "pass", okCheck["status"])
+
+	badCheck := checks["bad-check"].(map[string]any)
+	assert.Equal(t, "fail", badCheck["status"])
+	assert.Equal(t, "timeout", badCheck["error"])
+}
+
+func TestHealthCheckerFunc(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	f := HealthCheckerFunc(func(context.Context) error {
+		called = true
+		return nil
+	})
+
+	err := f.Check(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestReadyz_NotReadyBeforeInit(t *testing.T) {
+	t.Parallel()
+
+	// Manually construct a server without calling NewServer to simulate
+	// the isReady flag being false (zero value).
+	s := &Server{
+		convs:       make(map[string]Conversation),
+		convLastUse: make(map[string]time.Time),
+		cancels:     make(map[string]context.CancelFunc),
+		subs:        make(map[string]*taskBroadcaster),
+		stopCh:      make(chan struct{}),
+	}
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/readyz") //nolint:noctx // test helper
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -143,6 +144,33 @@ func WithAuthenticator(auth Authenticator) Option {
 	return func(s *Server) { s.authenticator = auth }
 }
 
+// HealthChecker performs a named health check. Implementations should return
+// nil when healthy and a non-nil error describing the problem otherwise.
+type HealthChecker interface {
+	Check(ctx context.Context) error
+}
+
+// HealthCheckerFunc adapts an ordinary function to the [HealthChecker] interface.
+type HealthCheckerFunc func(ctx context.Context) error
+
+// Check calls f(ctx).
+func (f HealthCheckerFunc) Check(ctx context.Context) error { return f(ctx) }
+
+// WithHealthCheck registers a named health checker that is evaluated by the
+// /readyz endpoint. Multiple checkers can be registered; each is reported
+// individually in the response body.
+func WithHealthCheck(name string, checker HealthChecker) Option {
+	return func(s *Server) {
+		s.healthChecks = append(s.healthChecks, namedChecker{name: name, checker: checker})
+	}
+}
+
+// namedChecker pairs a human-readable name with a [HealthChecker].
+type namedChecker struct {
+	name    string
+	checker HealthChecker
+}
+
 // Server is an HTTP server that exposes a Conversation as an
 // A2A-compliant JSON-RPC endpoint.
 type Server struct {
@@ -158,6 +186,12 @@ type Server struct {
 	writeTimeout time.Duration
 	idleTimeout  time.Duration
 	maxBodySize  int64
+
+	// Readiness flag: set to true after NewServer completes, false on Shutdown.
+	isReady atomic.Bool
+
+	// Optional health checkers evaluated by /readyz.
+	healthChecks []namedChecker
 
 	// TTL-based eviction configuration.
 	taskTTL  time.Duration // 0 disables task eviction
@@ -204,6 +238,8 @@ func NewServer(opener ConversationOpener, opts ...Option) *Server {
 		go s.evictionLoop()
 	}
 
+	s.isReady.Store(true)
+
 	return s
 }
 
@@ -212,6 +248,8 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /.well-known/agent.json", s.handleAgentCard)
 	mux.HandleFunc("POST /a2a", s.handleRPC)
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+	mux.HandleFunc("GET /readyz", s.handleReadyz)
 	return otelhttp.NewHandler(mux, "a2a-server")
 }
 
@@ -236,6 +274,9 @@ func (s *Server) ListenAndServe() error {
 // Shutdown gracefully shuts down the server: stops the eviction goroutine,
 // drains HTTP requests, cancels in-flight tasks, and closes all conversations.
 func (s *Server) Shutdown(ctx context.Context) error {
+	// Mark as not ready so /readyz returns 503 immediately.
+	s.isReady.Store(false)
+
 	// Stop the eviction goroutine.
 	s.stopOnce.Do(func() { close(s.stopCh) })
 
@@ -288,6 +329,61 @@ func (s *Server) Serve(ln net.Listener) error {
 	s.httpSrvMu.Unlock()
 
 	return srv.Serve(ln)
+}
+
+// handleHealthz is a liveness probe: it returns 200 whenever the HTTP server
+// is accepting connections.
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// handleReadyz is a readiness probe: it returns 200 when the server is ready
+// to accept traffic and 503 otherwise. It checks the isReady flag and all
+// registered health checkers.
+func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if !s.isReady.Load() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"status": "not_ready",
+			"reason": "server is shutting down or not yet initialized",
+		})
+		return
+	}
+
+	// Run registered health checks.
+	type checkResult struct {
+		Status string `json:"status"`
+		Error  string `json:"error,omitempty"`
+	}
+	checks := make(map[string]checkResult, len(s.healthChecks))
+	allOK := true
+	for _, nc := range s.healthChecks {
+		if err := nc.checker.Check(r.Context()); err != nil {
+			checks[nc.name] = checkResult{Status: "fail", Error: err.Error()}
+			allOK = false
+		} else {
+			checks[nc.name] = checkResult{Status: "pass"}
+		}
+	}
+
+	if !allOK {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "not_ready",
+			"reason": "one or more health checks failed",
+			"checks": checks,
+		})
+		return
+	}
+
+	resp := map[string]any{"status": "ready"}
+	if len(checks) > 0 {
+		resp["checks"] = checks
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleAgentCard serves the agent card as JSON.

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -419,8 +419,19 @@ func (e *Engine) ExecuteRuns(ctx context.Context, plan *RunPlan, concurrency int
 		go func(idx int, combo RunCombination) {
 			defer wg.Done()
 
-			// Acquire semaphore
-			semaphore <- struct{}{}
+			// Check if context is already canceled before blocking on semaphore.
+			// This prevents canceled runs from wastefully occupying goroutines
+			// waiting on an already-exhausted semaphore.
+			select {
+			case <-ctx.Done():
+				mu.Lock()
+				runIDs[idx] = ""
+				errors[idx] = ctx.Err()
+				mu.Unlock()
+				return
+			case semaphore <- struct{}{}:
+				// acquired
+			}
 			defer func() { <-semaphore }()
 
 			runID, err := e.executeRun(ctx, combo)

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -14,6 +14,11 @@ import (
 	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
 )
 
+// DefaultRunTimeout is the default maximum duration for a single run execution.
+// If a provider call hangs, the run will be canceled after this timeout,
+// freeing up the semaphore slot for other runs.
+const DefaultRunTimeout = 5 * time.Minute
+
 // GenerateRunPlan creates a comprehensive test execution plan from filter criteria.
 // The plan contains all combinations of regions × providers × scenarios OR evals that match
 // the provided filters. Scenarios and evals are mutually exclusive.
@@ -322,6 +327,11 @@ func (e *Engine) intersectProviders(scenarioProviders, providerFilter []string) 
 // Handles errors gracefully, always returning a RunID (with Error saved in StateStore if failed).
 // Returns the RunID. Results can be retrieved from StateStore using GetRunResult().
 func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, error) {
+	// Apply per-run timeout to prevent hanging provider calls from blocking indefinitely
+	runTimeout := e.resolveRunTimeout()
+	runCtx, cancel := context.WithTimeout(ctx, runTimeout)
+	defer cancel()
+
 	startTime := time.Now()
 	runID := generateRunID(combo)
 	runEmitter := e.createRunEmitter(runID, combo)
@@ -339,7 +349,7 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 
 	// Check if this is an eval run
 	if combo.EvalID != "" {
-		return e.executeEvalRun(ctx, combo, runID, startTime, arenaStore, runEmitter, saveError)
+		return e.executeEvalRun(runCtx, combo, runID, startTime, arenaStore, runEmitter, saveError)
 	}
 
 	// Otherwise it's a scenario run
@@ -351,7 +361,7 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 
 	// Route workflow scenarios to the workflow executor
 	if scenario.IsWorkflow() {
-		return e.executeWorkflowRun(ctx, &combo, runID, startTime, arenaStore, runEmitter, saveError)
+		return e.executeWorkflowRun(runCtx, &combo, runID, startTime, arenaStore, runEmitter, saveError)
 	}
 
 	// Get provider
@@ -383,17 +393,26 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 	// Use RunID as ConversationID for Arena executions
 	req.ConversationID = runID
 
-	convResult := e.conversationExecutor.ExecuteConversation(ctx, req)
+	convResult := e.conversationExecutor.ExecuteConversation(runCtx, req)
+
+	// Check if the run was canceled due to timeout
+	if runCtx.Err() != nil {
+		timeoutMsg := fmt.Sprintf("run timed out after %s", runTimeout)
+		if convResult != nil && convResult.Error != "" {
+			timeoutMsg = fmt.Sprintf("%s: %s", timeoutMsg, convResult.Error)
+		}
+		return saveError(timeoutMsg)
+	}
 
 	// Enrich conversation messages with tool descriptor metadata for reports
-	e.enrichMessagesWithToolDescriptors(ctx, arenaStore, runID)
+	e.enrichMessagesWithToolDescriptors(runCtx, arenaStore, runID)
 
 	// Calculate duration and cost
 	duration := time.Since(startTime)
 	cost := convResult.Cost.TotalCost
 
 	// Save run metadata to StateStore
-	if err := e.saveRunMetadata(ctx, arenaStore, combo, convResult, runID, startTime, duration); err != nil {
+	if err := e.saveRunMetadata(runCtx, arenaStore, combo, convResult, runID, startTime, duration); err != nil {
 		return runID, fmt.Errorf("failed to save run metadata: %w", err)
 	}
 
@@ -728,6 +747,20 @@ func convertA2AAgentsFromConfig(agents []config.A2AAgentConfig) []statestore.A2A
 		result[i] = info
 	}
 	return result
+}
+
+// resolveRunTimeout returns the per-run timeout from config, or DefaultRunTimeout if not set.
+func (e *Engine) resolveRunTimeout() time.Duration {
+	if e.config != nil && e.config.Defaults.RunTimeout != "" {
+		d, err := time.ParseDuration(e.config.Defaults.RunTimeout)
+		if err == nil && d > 0 {
+			return d
+		}
+		logger.Warn("Invalid run_timeout in config, using default",
+			"configured", e.config.Defaults.RunTimeout,
+			"default", DefaultRunTimeout)
+	}
+	return DefaultRunTimeout
 }
 
 // generateRunID creates a unique run ID for a combination

--- a/tools/arena/engine/run_timeout_test.go
+++ b/tools/arena/engine/run_timeout_test.go
@@ -1,0 +1,291 @@
+package engine
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
+)
+
+// hangingConversationExecutor blocks until ctx is cancelled, simulating a hanging provider.
+type hangingConversationExecutor struct {
+	callCount atomic.Int32
+}
+
+func (h *hangingConversationExecutor) ExecuteConversation(
+	ctx context.Context,
+	_ ConversationRequest,
+) *ConversationResult {
+	h.callCount.Add(1)
+	<-ctx.Done()
+	return &ConversationResult{
+		Error:  "context cancelled",
+		Failed: true,
+	}
+}
+
+func (h *hangingConversationExecutor) ExecuteConversationStream(
+	_ context.Context,
+	_ ConversationRequest,
+) (<-chan ConversationStreamChunk, error) {
+	return nil, nil
+}
+
+// fastConversationExecutor returns immediately with a successful result.
+type fastConversationExecutor struct {
+	callCount atomic.Int32
+}
+
+func (f *fastConversationExecutor) ExecuteConversation(
+	_ context.Context,
+	_ ConversationRequest,
+) *ConversationResult {
+	f.callCount.Add(1)
+	return &ConversationResult{
+		Messages: []types.Message{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi"},
+		},
+	}
+}
+
+func (f *fastConversationExecutor) ExecuteConversationStream(
+	_ context.Context,
+	_ ConversationRequest,
+) (<-chan ConversationStreamChunk, error) {
+	return nil, nil
+}
+
+// newMockProviderRegistry creates a provider registry with a single mock provider.
+func newMockProviderRegistry(providerID string) *providers.Registry {
+	registry := providers.NewRegistry()
+	repo := mock.NewInMemoryMockRepository("mock response")
+	mockProvider := mock.NewToolProviderWithRepository(providerID, "mock-model", false, repo)
+	registry.Register(mockProvider)
+	return registry
+}
+
+func TestResolveRunTimeout(t *testing.T) {
+	t.Run("returns default when config is nil", func(t *testing.T) {
+		e := &Engine{}
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+	})
+
+	t.Run("returns default when run_timeout is empty", func(t *testing.T) {
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "",
+				},
+			},
+		}
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+	})
+
+	t.Run("parses valid duration", func(t *testing.T) {
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "30s",
+				},
+			},
+		}
+		assert.Equal(t, 30*time.Second, e.resolveRunTimeout())
+	})
+
+	t.Run("parses minutes", func(t *testing.T) {
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "10m",
+				},
+			},
+		}
+		assert.Equal(t, 10*time.Minute, e.resolveRunTimeout())
+	})
+
+	t.Run("returns default for invalid duration", func(t *testing.T) {
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "not-a-duration",
+				},
+			},
+		}
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+	})
+
+	t.Run("returns default for zero duration", func(t *testing.T) {
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "0s",
+				},
+			},
+		}
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+	})
+
+	t.Run("returns default for negative duration", func(t *testing.T) {
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "-5s",
+				},
+			},
+		}
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+	})
+}
+
+func TestExecuteRun_Timeout(t *testing.T) {
+	t.Run("hanging provider is cancelled by timeout", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		executor := &hangingConversationExecutor{}
+
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "200ms", // Short timeout for test
+				},
+			},
+			stateStore:           store,
+			conversationExecutor: executor,
+			providerRegistry:     newMockProviderRegistry("mock-provider"),
+			scenarios: map[string]*config.Scenario{
+				"test-scenario": {ID: "test-scenario", TaskType: "support"},
+			},
+			providers: map[string]*config.Provider{
+				"mock-provider": {ID: "mock-provider"},
+			},
+		}
+
+		combo := RunCombination{
+			Region:     "default",
+			ScenarioID: "test-scenario",
+			ProviderID: "mock-provider",
+		}
+
+		ctx := context.Background()
+		start := time.Now()
+		runID, err := e.executeRun(ctx, combo)
+		elapsed := time.Since(start)
+
+		// Should complete within a reasonable time (timeout + overhead)
+		assert.Less(t, elapsed, 2*time.Second, "run should complete quickly after timeout")
+		require.NoError(t, err) // executeRun saves error in statestore, returns nil
+
+		// Verify the run was recorded with a timeout error
+		result, err := store.GetRunResult(ctx, runID)
+		require.NoError(t, err)
+		assert.Contains(t, result.Error, "run timed out after 200ms")
+
+		// Verify the executor was actually called
+		assert.Equal(t, int32(1), executor.callCount.Load())
+	})
+
+	t.Run("fast provider completes before timeout", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		executor := &fastConversationExecutor{}
+
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "10s", // Long timeout
+				},
+			},
+			stateStore:           store,
+			conversationExecutor: executor,
+			providerRegistry:     newMockProviderRegistry("mock-provider"),
+			scenarios: map[string]*config.Scenario{
+				"test-scenario": {ID: "test-scenario", TaskType: "support"},
+			},
+			providers: map[string]*config.Provider{
+				"mock-provider": {ID: "mock-provider"},
+			},
+		}
+
+		combo := RunCombination{
+			Region:     "default",
+			ScenarioID: "test-scenario",
+			ProviderID: "mock-provider",
+		}
+
+		ctx := context.Background()
+		runID, err := e.executeRun(ctx, combo)
+		require.NoError(t, err)
+
+		// Verify the run succeeded without timeout error
+		result, err := store.GetRunResult(ctx, runID)
+		require.NoError(t, err)
+		assert.Empty(t, result.Error, "successful run should have no error")
+
+		// Verify the executor was called
+		assert.Equal(t, int32(1), executor.callCount.Load())
+	})
+}
+
+func TestExecuteRuns_ContextAwareSemaphore(t *testing.T) {
+	t.Run("cancelled context skips semaphore acquisition", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		executor := &fastConversationExecutor{}
+
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "10s",
+				},
+			},
+			stateStore:           store,
+			conversationExecutor: executor,
+			providerRegistry:     newMockProviderRegistry("p1"),
+			scenarios: map[string]*config.Scenario{
+				"s1": {ID: "s1", TaskType: "support"},
+			},
+			providers: map[string]*config.Provider{
+				"p1": {ID: "p1"},
+			},
+		}
+
+		plan := &RunPlan{
+			Combinations: []RunCombination{
+				{Region: "default", ScenarioID: "s1", ProviderID: "p1"},
+				{Region: "us", ScenarioID: "s1", ProviderID: "p1"},
+				{Region: "eu", ScenarioID: "s1", ProviderID: "p1"},
+			},
+		}
+
+		// Cancel context immediately
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		runIDs, err := e.ExecuteRuns(ctx, plan, 1)
+		// Some or all runs may fail due to cancelled context
+		assert.Len(t, runIDs, 3)
+
+		// At least some runs should have failed with context error
+		hasContextErr := false
+		if err != nil {
+			hasContextErr = true
+		}
+		for _, id := range runIDs {
+			if id == "" {
+				hasContextErr = true
+			}
+		}
+		assert.True(t, hasContextErr, "cancelled context should cause errors")
+	})
+}
+
+func TestDefaultRunTimeout_Value(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, DefaultRunTimeout)
+}


### PR DESCRIPTION
## Summary

Completes all remaining scalability items from the comprehensive review (#632, #631, #630). This PR addresses low-priority, K8s deployment, audio, and remaining medium-priority items.

### Streaming & Throughput
- **Buffered stream channels**: All 17 provider stream channels now use `DefaultStreamBufferSize = 32`
- **Context-cancel unblocks scanner**: All 6 provider `streamResponse` functions close body on ctx cancel
- **Stream idle timeout**: `IdleTimeoutReader` with `DefaultStreamIdleTimeout = 30s` wraps all provider response bodies

### Event Bus
- **Async store writes**: `store.Append()` moved from `Publish()` to dispatch workers
- **Lazy worker startup**: Workers only start on first `Subscribe()`/`SubscribeAll()`/`WithStore()` call

### State Store
- **Heap-based LRU eviction**: O(log N) via `container/heap` (40x speedup at 10K entries)
- **Non-blocking expiration**: Two-phase scan (RLock collect, Lock delete)
- **Redis decomposed storage**: Separate keys for meta, messages list, and summaries list instead of monolithic JSON

### Tool Execution
- **Result size limits**: `DefaultMaxToolResultSize = 1MB` with truncation
- **Registry mutex**: `sync.RWMutex` for concurrent-safe registration
- **PendingStore lifecycle**: TTL, max entries, background cleanup, `Close()`

### Storage
- **Dedup index optimization**: Dirty flag skips unnecessary writes; dedup hits avoid I/O entirely
- **Policy enforcement indexing**: `expiryIndex` scans once on startup, O(expired) on subsequent ticks

### MCP
- **Process reconnection**: Auto-reconnect on process death with `MaxReconnectAttempts` (default 3)
- **Process limiting**: `MaxProcesses` option with non-blocking semaphore, `ErrMaxProcessesReached`

### Arena Engine
- **Per-run timeout**: `DefaultRunTimeout = 5min` with `context.WithTimeout`
- **Context-aware semaphore**: Goroutines exit on context cancel

### A2A Protocol
- **Client cache eviction**: TTL-based with `DefaultClientTTL = 30min`, `DefaultMaxClients = 100`

### Audio
- **Audio buffer cap**: `DefaultMaxAudioBufferSize = 10MB`
- **sync.Pool for resampling**: Pools `[]int16` slices
- **Increased channel buffers**: `DefaultAudioChannelBufferSize = 64`

### K8s Deployment
- **Health endpoints**: `GET /healthz` and `GET /readyz` with `HealthChecker` interface
- **Shutdown manager**: `ShutdownManager` with SIGTERM/SIGINT handling

## Test plan
- [x] All runtime tests pass
- [x] All SDK tests pass  
- [x] All arena tests pass
- [x] All server tests pass
- [x] Pre-commit hooks pass on all commits
- [ ] CI green