### PR TITLE
feat: replace MessageToolResult.Content with Parts []ContentPart

### DIFF
--- a/runtime/evals/handlers/agent_handlers_test.go
+++ b/runtime/evals/handlers/agent_handlers_test.go
@@ -150,10 +150,10 @@ func TestAgentResponseContainsHandler_ViaMessages(t *testing.T) {
 		Messages: []types.Message{
 			{
 				Role: "tool",
-				ToolResult: &types.MessageToolResult{
-					Name:    "billing_agent",
-					Content: "Your balance is $100",
-				},
+				ToolResult: func() *types.MessageToolResult {
+					r := types.NewTextToolResult("", "billing_agent", "Your balance is $100")
+					return &r
+				}(),
 			},
 		},
 	}

--- a/runtime/evals/handlers/agent_response_contains.go
+++ b/runtime/evals/handlers/agent_response_contains.go
@@ -51,7 +51,7 @@ func (h *AgentResponseContainsHandler) Eval(
 	for i := range evalCtx.Messages {
 		msg := &evalCtx.Messages[i]
 		if msg.Role == "tool" && msg.ToolResult != nil && msg.ToolResult.Name == agent {
-			if strings.Contains(msg.ToolResult.Content, contains) {
+			if strings.Contains(msg.ToolResult.GetTextContent(), contains) {
 				return &evals.EvalResult{
 					Type: h.Type(), Passed: true,
 					Explanation: fmt.Sprintf("agent %q response contains expected text", agent),

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -169,13 +169,18 @@ func (e *Emitter) ToolCallStarted(toolName, callID string, args map[string]inter
 }
 
 // ToolCallCompleted emits the tool.call.completed event.
-func (e *Emitter) ToolCallCompleted(toolName, callID string, duration time.Duration, status, result string) {
+func (e *Emitter) ToolCallCompleted(
+	toolName, callID string,
+	duration time.Duration,
+	status string,
+	parts []types.ContentPart,
+) {
 	e.emit(EventToolCallCompleted, ToolCallCompletedData{
 		ToolName: toolName,
 		CallID:   callID,
 		Duration: duration,
 		Status:   status,
-		Result:   result,
+		Parts:    types.MetadataOnlyParts(parts),
 	})
 }
 

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -83,7 +83,9 @@ func TestEmitterPublishesVariousEvents(t *testing.T) {
 		},
 		func() { emitter.ProviderCallFailed("provider", "model", errors.New("fail"), time.Millisecond) },
 		func() { emitter.ToolCallStarted("tool", "call", map[string]interface{}{"k": "v"}) },
-		func() { emitter.ToolCallCompleted("tool", "call", time.Millisecond, "success", "tool result") },
+		func() {
+			emitter.ToolCallCompleted("tool", "call", time.Millisecond, "success", []types.ContentPart{types.NewTextPart("tool result")})
+		},
 		func() { emitter.ToolCallFailed("tool", "call", errors.New("fail"), time.Millisecond) },
 		func() { emitter.ValidationStarted("validator", "input") },
 		func() { emitter.ValidationPassed("validator", "input", time.Millisecond) },
@@ -199,8 +201,8 @@ func TestEmitter_MessageCreated_WithToolResult(t *testing.T) {
 	})
 
 	toolResult := &MessageToolResult{
-		Name:    "weather_tool",
-		Content: `{"temp": 72}`,
+		Name:  "weather_tool",
+		Parts: []types.ContentPart{types.NewTextPart(`{"temp": 72}`)},
 	}
 	emitter.MessageCreated("tool", "", 2, nil, nil, toolResult)
 

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -242,7 +242,7 @@ type ToolCallEventData struct {
 	Args     map[string]interface{} // Set on started
 	Duration time.Duration          // Set on completed/failed
 	Status   string                 // Set on completed (e.g. "success", "error", "pending")
-	Result   string                 // Set on completed — tool result content
+	Parts    []types.ContentPart    // Set on completed — tool result content parts
 	Error    error                  // Set on failed
 }
 
@@ -335,11 +335,11 @@ type MessageToolCall struct {
 
 // MessageToolResult represents a tool result in a message event (mirrors runtime/types.MessageToolResult).
 type MessageToolResult struct {
-	ID        string `json:"id"`                   // References the MessageToolCall.ID
-	Name      string `json:"name"`                 // Tool name that was executed
-	Content   string `json:"content"`              // Result content
-	Error     string `json:"error,omitempty"`      // Error message if tool failed
-	LatencyMs int64  `json:"latency_ms,omitempty"` // Tool execution latency
+	ID        string              `json:"id"`                   // References the MessageToolCall.ID
+	Name      string              `json:"name"`                 // Tool name that was executed
+	Parts     []types.ContentPart `json:"parts,omitempty"`      // Multimodal result content
+	Error     string              `json:"error,omitempty"`      // Error message if tool failed
+	LatencyMs int64               `json:"latency_ms,omitempty"` // Tool execution latency
 }
 
 // MessageCreatedData contains data for message creation events.

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -843,10 +843,10 @@ func (s *ProviderStage) preExecCheck(
 ) (hooks.Decision, toolCallResult, bool) {
 	if s.toolPolicy != nil && isToolBlocked(toolCall.Name, s.toolPolicy.Blocklist) {
 		errMsg := fmt.Sprintf("Tool %s is blocked by policy", toolCall.Name)
+		result := types.NewTextToolResult(toolCall.ID, toolCall.Name, errMsg)
+		result.Error = errMsg
 		return hooks.Decision{}, toolCallResult{
-			message: types.NewToolResultMessage(types.MessageToolResult{
-				ID: toolCall.ID, Name: toolCall.Name, Content: errMsg, Error: errMsg,
-			}),
+			message: types.NewToolResultMessage(result),
 		}, true
 	}
 
@@ -860,9 +860,9 @@ func (s *ProviderStage) preExecCheck(
 			errMsg := fmt.Sprintf(
 				"Tool %s blocked by hook: %s", toolCall.Name, hookDecision.Reason,
 			)
-			msg := types.NewToolResultMessage(types.MessageToolResult{
-				ID: toolCall.ID, Name: toolCall.Name, Content: errMsg, Error: errMsg,
-			})
+			hookResult := types.NewTextToolResult(toolCall.ID, toolCall.Name, errMsg)
+			hookResult.Error = errMsg
+			msg := types.NewToolResultMessage(hookResult)
 			if hookDecision.Metadata != nil {
 				msg.Meta = hookDecision.Metadata
 			}
@@ -895,13 +895,10 @@ func (s *ProviderStage) executeSingleToolCall(
 				toolCall.Name, toolCall.ID, err, time.Since(startTime),
 			)
 		}
+		errResult := types.NewTextToolResult(toolCall.ID, toolCall.Name, fmt.Sprintf("Error: %v", err))
+		errResult.Error = err.Error()
 		return toolCallResult{
-			message: types.NewToolResultMessage(types.MessageToolResult{
-				ID:      toolCall.ID,
-				Name:    toolCall.Name,
-				Content: fmt.Sprintf("Error: %v", err),
-				Error:   err.Error(),
-			}),
+			message: types.NewToolResultMessage(errResult),
 		}
 	}
 
@@ -913,7 +910,7 @@ func (s *ProviderStage) executeSingleToolCall(
 	if s.emitter != nil {
 		status := string(asyncResult.Status)
 		s.emitter.ToolCallCompleted(
-			toolCall.Name, toolCall.ID, time.Since(startTime), status, result.Content,
+			toolCall.Name, toolCall.ID, time.Since(startTime), status, result.Parts,
 		)
 	}
 	resultMsg := types.NewToolResultMessage(result)
@@ -974,7 +971,7 @@ func (s *ProviderStage) runAfterToolHooks(
 	toolResp := hooks.ToolResponse{
 		Name:      toolCall.Name,
 		CallID:    toolCall.ID,
-		Content:   result.Content,
+		Content:   result.GetTextContent(),
 		Error:     result.Error,
 		LatencyMs: time.Since(startTime).Milliseconds(),
 	}
@@ -996,20 +993,18 @@ func (s *ProviderStage) handleToolResult(
 		}
 		logger.Warn("Tool requires approval in ProviderStage - pending tool support not yet implemented",
 			"tool", call.Name, "call_id", call.ID)
-		return types.MessageToolResult{
-			ID:      call.ID,
-			Name:    call.Name,
-			Content: pendingMsg + " (Note: Async tool approval workflows not yet implemented in stages)",
-			Error:   "",
-		}
+		return types.NewTextToolResult(
+			call.ID, call.Name,
+			pendingMsg+" (Note: Async tool approval workflows not yet implemented in stages)",
+		)
 
 	case tools.ToolStatusFailed:
-		return types.MessageToolResult{
-			ID:      call.ID,
-			Name:    call.Name,
-			Content: fmt.Sprintf("Tool execution failed: %s", asyncResult.Error),
-			Error:   asyncResult.Error,
-		}
+		failResult := types.NewTextToolResult(
+			call.ID, call.Name,
+			fmt.Sprintf("Tool execution failed: %s", asyncResult.Error),
+		)
+		failResult.Error = asyncResult.Error
+		return failResult
 
 	case tools.ToolStatusComplete:
 		// Tool completed successfully
@@ -1024,20 +1019,13 @@ func (s *ProviderStage) handleToolResult(
 		// Enforce tool result size limit
 		content = s.enforceResultSizeLimit(call.Name, content)
 
-		return types.MessageToolResult{
-			ID:      call.ID,
-			Name:    call.Name,
-			Content: content,
-			Error:   "",
-		}
+		return types.NewTextToolResult(call.ID, call.Name, content)
 
 	default:
-		return types.MessageToolResult{
-			ID:      call.ID,
-			Name:    call.Name,
-			Content: fmt.Sprintf("Unknown tool status: %v", asyncResult.Status),
-			Error:   fmt.Sprintf("Unknown tool status: %v", asyncResult.Status),
-		}
+		unknownMsg := fmt.Sprintf("Unknown tool status: %v", asyncResult.Status)
+		unknownResult := types.NewTextToolResult(call.ID, call.Name, unknownMsg)
+		unknownResult.Error = unknownMsg
+		return unknownResult
 	}
 }
 

--- a/runtime/pipeline/stage/stages_provider_hooks_test.go
+++ b/runtime/pipeline/stage/stages_provider_hooks_test.go
@@ -348,7 +348,7 @@ func TestProviderStage_ToolHook_BlocksToolExecution(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Contains(t, results[0].ToolResult.Error, "blocked by hook")
-	assert.Contains(t, results[0].ToolResult.Content, "policy forbids this tool")
+	assert.Contains(t, results[0].ToolResult.GetTextContent(), "policy forbids this tool")
 }
 
 func TestProviderStage_ToolHook_AfterExecution_Records(t *testing.T) {

--- a/runtime/pipeline/stage/stages_provider_parallel_test.go
+++ b/runtime/pipeline/stage/stages_provider_parallel_test.go
@@ -255,15 +255,15 @@ func TestParallelToolCalls_OneFailureDoesNotCancelOthers(t *testing.T) {
 
 	// First tool succeeded.
 	assert.Empty(t, results[0].ToolResult.Error)
-	assert.Contains(t, results[0].ToolResult.Content, "ok")
+	assert.Contains(t, results[0].ToolResult.GetTextContent(), "ok")
 
 	// Second tool failed but is still in results.
 	assert.NotEmpty(t, results[1].ToolResult.Error)
-	assert.Contains(t, results[1].ToolResult.Content, "failed")
+	assert.Contains(t, results[1].ToolResult.GetTextContent(), "failed")
 
 	// Third tool succeeded despite failure in the second.
 	assert.Empty(t, results[2].ToolResult.Error)
-	assert.Contains(t, results[2].ToolResult.Content, "ok")
+	assert.Contains(t, results[2].ToolResult.GetTextContent(), "ok")
 }
 
 func TestParallelToolCalls_MixedBlockedAndExecuted(t *testing.T) {
@@ -410,7 +410,7 @@ func TestParallelToolCalls_SingleToolCall(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "c1", results[0].ToolResult.ID)
-	assert.Contains(t, results[0].ToolResult.Content, "hello")
+	assert.Contains(t, results[0].ToolResult.GetTextContent(), "hello")
 }
 
 func TestParallelToolCalls_EmptyToolCalls(t *testing.T) {

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -1143,7 +1143,7 @@ func TestProviderStage_ExecuteToolCalls_BlockedTool(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "tool", results[0].Role)
-	assert.Contains(t, results[0].ToolResult.Content, "blocked by policy")
+	assert.Contains(t, results[0].ToolResult.GetTextContent(), "blocked by policy")
 	assert.Contains(t, results[0].ToolResult.Error, "blocked by policy")
 }
 
@@ -1161,7 +1161,7 @@ func TestProviderStage_ExecuteToolCalls_ToolNotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "tool", results[0].Role)
-	assert.Contains(t, results[0].ToolResult.Content, "Error:")
+	assert.Contains(t, results[0].ToolResult.GetTextContent(), "Error:")
 	assert.NotEmpty(t, results[0].ToolResult.Error)
 }
 
@@ -1198,7 +1198,7 @@ func TestProviderStage_ExecuteToolCalls_Complete(t *testing.T) {
 	assert.Equal(t, "tool", results[0].Role)
 	assert.NotNil(t, results[0].ToolResult)
 	assert.Empty(t, results[0].ToolResult.Error)
-	assert.Contains(t, results[0].ToolResult.Content, "result")
+	assert.Contains(t, results[0].ToolResult.GetTextContent(), "result")
 }
 
 func TestProviderStage_ExecuteToolCalls_Pending(t *testing.T) {
@@ -1235,7 +1235,7 @@ func TestProviderStage_ExecuteToolCalls_Pending(t *testing.T) {
 	require.Len(t, ep.Pending, 1)
 	assert.Equal(t, "call-1", ep.Pending[0].CallID)
 	assert.Equal(t, "pending_tool", ep.Pending[0].ToolName)
-	assert.Contains(t, ep.Pending[0].ToolResult.Content, "requires")
+	assert.Contains(t, ep.Pending[0].ToolResult.GetTextContent(), "requires")
 
 	// No completed results since only tool was pending
 	assert.Empty(t, results)
@@ -1271,7 +1271,7 @@ func TestProviderStage_ExecuteToolCalls_Failed(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "tool", results[0].Role)
-	assert.Contains(t, results[0].ToolResult.Content, "failed")
+	assert.Contains(t, results[0].ToolResult.GetTextContent(), "failed")
 	assert.NotEmpty(t, results[0].ToolResult.Error)
 }
 
@@ -1521,7 +1521,7 @@ func TestProviderStage_HandleToolResult_AllStatuses(t *testing.T) {
 
 			assert.Equal(t, "test-call-id", result.ID)
 			assert.Equal(t, "test_tool", result.Name)
-			assert.Contains(t, result.Content, tc.contentContain)
+			assert.Contains(t, result.GetTextContent(), tc.contentContain)
 			if tc.expectError {
 				assert.NotEmpty(t, result.Error)
 			}
@@ -1808,7 +1808,7 @@ func TestProviderStage_ExecuteToolCalls_BlockedNoEvents(t *testing.T) {
 	results, err := stage.executeToolCalls(context.Background(), toolCalls)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Contains(t, results[0].ToolResult.Content, "blocked by policy")
+	assert.Contains(t, results[0].ToolResult.GetTextContent(), "blocked by policy")
 
 	// Give the event bus a moment to process any events
 	time.Sleep(50 * time.Millisecond)

--- a/runtime/pipeline/stage/stages_recording.go
+++ b/runtime/pipeline/stage/stages_recording.go
@@ -178,9 +178,9 @@ func (rs *RecordingStage) recordMessageElement(elem *StreamElement) {
 	// Convert tool result if present
 	if msg.ToolResult != nil {
 		data.ToolResult = &events.MessageToolResult{
-			ID:      msg.ToolResult.ID,
-			Name:    msg.ToolResult.Name,
-			Content: msg.ToolResult.Content,
+			ID:    msg.ToolResult.ID,
+			Name:  msg.ToolResult.Name,
+			Parts: msg.ToolResult.Parts,
 		}
 	}
 

--- a/runtime/pipeline/stage/stages_recording_test.go
+++ b/runtime/pipeline/stage/stages_recording_test.go
@@ -597,14 +597,11 @@ func TestRecordingStage_MessageWithToolResult(t *testing.T) {
 	input := make(chan StreamElement, 1)
 	output := make(chan StreamElement, 1)
 
+	toolResult := types.NewTextToolResult("call_123", "get_weather", "Sunny, 72°F")
 	msg := &types.Message{
-		Role:    "tool",
-		Content: "Weather result",
-		ToolResult: &types.MessageToolResult{
-			ID:      "call_123",
-			Name:    "get_weather",
-			Content: "Sunny, 72°F",
-		},
+		Role:       "tool",
+		Content:    "Weather result",
+		ToolResult: &toolResult,
 	}
 	input <- StreamElement{Message: msg, Timestamp: time.Now()}
 	close(input)

--- a/runtime/providers/claude/claude_tool_results_test.go
+++ b/runtime/providers/claude/claude_tool_results_test.go
@@ -64,11 +64,10 @@ func TestToolProvider_BuildRequestWithToolMessages(t *testing.T) {
 		{
 			Role:    "tool",
 			Content: `{"temperature": 72, "condition": "sunny"}`,
-			ToolResult: &types.MessageToolResult{
-				ID:      "toolu_123",
-				Name:    "get_weather",
-				Content: `{"temperature": 72, "condition": "sunny"}`,
-			},
+			ToolResult: func() *types.MessageToolResult {
+				r := types.NewTextToolResult("toolu_123", "get_weather", `{"temperature": 72, "condition": "sunny"}`)
+				return &r
+			}(),
 		},
 		{Role: "user", Content: "Thanks! Now check NYC."},
 	}
@@ -200,20 +199,18 @@ func TestToolProvider_MultipleToolResultsGrouped(t *testing.T) {
 		{
 			Role:    "tool",
 			Content: `{"temperature": 72, "condition": "sunny"}`,
-			ToolResult: &types.MessageToolResult{
-				ID:      "toolu_sf",
-				Name:    "get_weather",
-				Content: `{"temperature": 72, "condition": "sunny"}`,
-			},
+			ToolResult: func() *types.MessageToolResult {
+				r := types.NewTextToolResult("toolu_sf", "get_weather", `{"temperature": 72, "condition": "sunny"}`)
+				return &r
+			}(),
 		},
 		{
 			Role:    "tool",
 			Content: `{"temperature": 65, "condition": "cloudy"}`,
-			ToolResult: &types.MessageToolResult{
-				ID:      "toolu_nyc",
-				Name:    "get_weather",
-				Content: `{"temperature": 65, "condition": "cloudy"}`,
-			},
+			ToolResult: func() *types.MessageToolResult {
+				r := types.NewTextToolResult("toolu_nyc", "get_weather", `{"temperature": 65, "condition": "cloudy"}`)
+				return &r
+			}(),
 		},
 	}
 
@@ -286,12 +283,10 @@ func TestProcessClaudeToolResult_UsesToolResultContent(t *testing.T) {
 	toolResultMsg := types.Message{
 		Role: "tool",
 		// Content is intentionally empty - this is how the SDK creates tool result messages
-		ToolResult: &types.MessageToolResult{
-			ID:      "toolu_abc123",
-			Name:    "weather",
-			Content: `{"temperature": 73, "conditions": "sunny"}`,
-			Error:   "",
-		},
+		ToolResult: func() *types.MessageToolResult {
+			r := types.NewTextToolResult("toolu_abc123", "weather", `{"temperature": 73, "conditions": "sunny"}`)
+			return &r
+		}(),
 	}
 
 	// Process the tool result

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -132,8 +132,8 @@ func processClaudeToolResult(msg types.Message) claudeToolResult {
 	return claudeToolResult{
 		Type:      "tool_result",
 		ToolUseID: msg.ToolResult.ID,
-		// Use ToolResult.Content (not msg.Content which is empty)
-		Content: msg.ToolResult.Content,
+		// Use ToolResult.GetTextContent() (not msg.Content which is empty)
+		Content: msg.ToolResult.GetTextContent(),
 	}
 }
 

--- a/runtime/providers/gemini/gemini_tool_loop_test.go
+++ b/runtime/providers/gemini/gemini_tool_loop_test.go
@@ -167,7 +167,8 @@ func TestToolProvider_ToolLoopDetection(t *testing.T) {
 	// Add assistant message with tool calls to history
 	messages = append(messages, types.Message{
 		Role:      "assistant",
-		Content:   resp1.Content,
+		Parts:     []types.ContentPart{types.NewTextPart(resp1.Content)},
+
 		ToolCalls: toolCalls1,
 	})
 
@@ -175,11 +176,13 @@ func TestToolProvider_ToolLoopDetection(t *testing.T) {
 	resultContent := `{"status":"active","next_billing":"2025-11-01"}`
 	messages = append(messages, types.Message{
 		Role:    "tool",
-		Content: resultContent,
+		Parts:     []types.ContentPart{types.NewTextPart(resultContent)},
+
 		ToolResult: &types.MessageToolResult{
 			ID:      toolCalls1[0].ID,
 			Name:    toolCalls1[0].Name,
-			Content: resultContent,
+			Parts:     []types.ContentPart{types.NewTextPart(resultContent)},
+
 		},
 	})
 

--- a/runtime/providers/gemini/gemini_tool_results_test.go
+++ b/runtime/providers/gemini/gemini_tool_results_test.go
@@ -65,18 +65,21 @@ func TestToolProvider_BuildRequestWithToolMessages(t *testing.T) {
 		{Role: "user", Content: "What's the weather?"},
 		{
 			Role:    "assistant",
-			Content: "Let me check the weather for you.",
+			Parts:     []types.ContentPart{types.NewTextPart("Let me check the weather for you.")},
+
 			ToolCalls: []types.MessageToolCall{
 				{ID: "call_123", Name: "get_weather", Args: json.RawMessage(`{"location":"SF"}`)},
 			},
 		},
 		{
 			Role:    "tool",
-			Content: `{"temperature": 72, "condition": "sunny"}`,
+			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
+
 			ToolResult: &types.MessageToolResult{
 				ID:      "call_123",
 				Name:    "get_weather",
-				Content: `{"temperature": 72, "condition": "sunny"}`,
+				Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
+
 			},
 		},
 		{Role: "user", Content: "Thanks! Now check NYC."},
@@ -217,20 +220,24 @@ func TestToolProvider_MultipleToolResultsGrouped(t *testing.T) {
 		},
 		{
 			Role:    "tool",
-			Content: `{"temperature": 72, "condition": "sunny"}`,
+			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
+
 			ToolResult: &types.MessageToolResult{
 				ID:      "call_sf",
 				Name:    "get_weather",
-				Content: `{"temperature": 72, "condition": "sunny"}`,
+				Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
+
 			},
 		},
 		{
 			Role:    "tool",
-			Content: `{"temperature": 65, "condition": "cloudy"}`,
+			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 65, "condition": "cloudy"}`)},
+
 			ToolResult: &types.MessageToolResult{
 				ID:      "call_nyc",
 				Name:    "get_weather",
-				Content: `{"temperature": 65, "condition": "cloudy"}`,
+				Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 65, "condition": "cloudy"}`)},
+
 			},
 		},
 	}
@@ -300,14 +307,15 @@ func TestToolProvider_MultipleToolResultsGrouped(t *testing.T) {
 func TestProcessToolMessage_UsesToolResultContent(t *testing.T) {
 	// Create a tool result message as the SDK creates them:
 	// - msg.Content is NOT set (empty)
-	// - msg.ToolResult.Content has the actual data
+	// - msg.ToolResult.GetTextContent() has the actual data
 	toolResultMsg := types.Message{
 		Role: "tool",
 		// Content is intentionally empty - this is how the SDK creates tool result messages
 		ToolResult: &types.MessageToolResult{
 			ID:      "call_abc123",
 			Name:    "weather",
-			Content: `{"temperature": 73, "conditions": "sunny"}`,
+			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 73, "conditions": "sunny"}`)},
+
 			Error:   "",
 		},
 	}

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -148,8 +148,8 @@ func (p *ToolProvider) PredictWithTools(
 //
 //nolint:gocritic // hugeParam: types.Message is part of established API
 func processToolMessage(msg types.Message) map[string]any {
-	// Use ToolResult.Content (not msg.Content which is empty for tool result messages)
-	content := msg.ToolResult.Content
+	// Use ToolResult.GetTextContent() (not msg.Content which is empty for tool result messages)
+	content := msg.ToolResult.GetTextContent()
 
 	var response any
 	if err := json.Unmarshal([]byte(content), &response); err != nil {

--- a/runtime/providers/gemini/gemini_tools_edge_cases_test.go
+++ b/runtime/providers/gemini/gemini_tools_edge_cases_test.go
@@ -12,7 +12,8 @@ import (
 func TestToolProvider_BuildMessageParts_EmptyToolResults(t *testing.T) {
 	msg := types.Message{
 		Role:    "user",
-		Content: "Hello",
+		Parts:     []types.ContentPart{types.NewTextPart("Hello")},
+
 	}
 
 	parts := buildMessageParts(msg, []map[string]interface{}{})
@@ -24,7 +25,8 @@ func TestToolProvider_BuildMessageParts_EmptyToolResults(t *testing.T) {
 func TestToolProvider_BuildMessageParts_WithToolResults(t *testing.T) {
 	msg := types.Message{
 		Role:    "user",
-		Content: "Process result",
+		Parts:     []types.ContentPart{types.NewTextPart("Process result")},
+
 	}
 
 	toolResults := []map[string]interface{}{
@@ -46,7 +48,8 @@ func TestToolProvider_BuildMessageParts_WithToolResults(t *testing.T) {
 func TestToolProvider_BuildMessageParts_WithToolCalls(t *testing.T) {
 	msg := types.Message{
 		Role:    "assistant",
-		Content: "Let me check that",
+		Parts:     []types.ContentPart{types.NewTextPart("Let me check that")},
+
 		ToolCalls: []types.MessageToolCall{
 			{
 				ID:   "call_1",
@@ -66,11 +69,13 @@ func TestToolProvider_BuildMessageParts_WithToolCalls(t *testing.T) {
 func TestToolProvider_ProcessToolMessage_EmptyName(t *testing.T) {
 	msg := types.Message{
 		Role:    "tool",
-		Content: `{"result": "success"}`,
+		Parts:     []types.ContentPart{types.NewTextPart(`{"result": "success"}`)},
+
 		ToolResult: &types.MessageToolResult{
 			ID:      "call_1",
 			Name:    "", // Empty name
-			Content: `{"result": "success"}`,
+			Parts:     []types.ContentPart{types.NewTextPart(`{"result": "success"}`)},
+
 		},
 	}
 
@@ -94,11 +99,13 @@ func TestToolProvider_ProcessToolMessage_EmptyName(t *testing.T) {
 func TestToolProvider_ProcessToolMessage_StringContent(t *testing.T) {
 	msg := types.Message{
 		Role:    "tool",
-		Content: "plain string result",
+		Parts:     []types.ContentPart{types.NewTextPart("plain string result")},
+
 		ToolResult: &types.MessageToolResult{
 			ID:      "call_1",
 			Name:    "test_tool",
-			Content: "plain string result",
+			Parts:     []types.ContentPart{types.NewTextPart("plain string result")},
+
 		},
 	}
 
@@ -119,7 +126,8 @@ func TestToolProvider_ProcessToolMessage_PrimitiveContent(t *testing.T) {
 		ToolResult: &types.MessageToolResult{
 			ID:      "call_1",
 			Name:    "get_number",
-			Content: "42",
+			Parts:     []types.ContentPart{types.NewTextPart("42")},
+
 		},
 	}
 

--- a/runtime/providers/ollama/ollama_tools_test.go
+++ b/runtime/providers/ollama/ollama_tools_test.go
@@ -340,14 +340,11 @@ func TestToolProvider_ConvertSingleMessageForTools(t *testing.T) {
 	})
 
 	t.Run("tool result message", func(t *testing.T) {
+		toolResult := types.NewTextToolResult("call_1", "test", "result")
 		msg := &types.Message{
-			Role: "tool",
-			ToolResult: &types.MessageToolResult{
-				ID:      "call_1",
-				Name:    "test",
-				Content: "result",
-			},
-			Content: "result",
+			Role:       "tool",
+			Content:    "result",
+			ToolResult: &toolResult,
 		}
 
 		result := provider.convertSingleMessageForTools(msg)

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -230,7 +230,7 @@ func (p *Provider) convertSingleMessageToResponsesInput(msg *types.Message) []ma
 		return []map[string]any{{
 			"type":    "function_call_output",
 			"call_id": callID,
-			"output":  msg.ToolResult.Content,
+			"output":  msg.ToolResult.GetTextContent(),
 		}}
 	}
 

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -229,8 +229,8 @@ func (p *ToolProvider) convertSingleMessageForTools(msg types.Message) map[strin
 	if msg.Role == "tool" && msg.ToolResult != nil {
 		openaiMsg["tool_call_id"] = msg.ToolResult.ID
 		openaiMsg["name"] = msg.ToolResult.Name
-		// Use ToolResult.Content as the message content (not msg.Content which is empty)
-		openaiMsg["content"] = msg.ToolResult.Content
+		// Use ToolResult.GetTextContent() as the message content (not msg.Content which is empty)
+		openaiMsg["content"] = msg.ToolResult.GetTextContent()
 	}
 
 	return openaiMsg

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -979,7 +979,8 @@ func TestToolProvider_ConvertToolResultMessage_ContentIsSet(t *testing.T) {
 		ToolResult: &types.MessageToolResult{
 			ID:      "call_123",
 			Name:    "weather",
-			Content: `{"temperature": 73, "conditions": "sunny"}`,
+			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 73, "conditions": "sunny"}`)},
+
 			Error:   "",
 		},
 	}
@@ -1028,7 +1029,8 @@ func TestToolProvider_ConvertRequestMessages_ToolResultHasContent(t *testing.T) 
 				ToolResult: &types.MessageToolResult{
 					ID:      "call_abc",
 					Name:    "weather",
-					Content: `{"temp": 75, "conditions": "partly cloudy"}`,
+					Parts:     []types.ContentPart{types.NewTextPart(`{"temp": 75, "conditions": "partly cloudy"}`)},
+
 				},
 			},
 		},

--- a/runtime/providers/provider_test.go
+++ b/runtime/providers/provider_test.go
@@ -72,15 +72,8 @@ func TestPredictMessage_WithToolCalls(t *testing.T) {
 }
 
 func TestPredictMessage_ToolResult(t *testing.T) {
-	msg := types.Message{
-		Role:    "tool",
-		Content: `{"result": "found"}`,
-		ToolResult: &types.MessageToolResult{
-			ID:      "call-123",
-			Name:    "search",
-			Content: `{"result": "found"}`,
-		},
-	}
+	result := types.NewTextToolResult("call-123", "search", `{"result": "found"}`)
+	msg := types.NewToolResultMessage(result)
 
 	if msg.Role != "tool" {
 		t.Error("Expected role 'tool'")
@@ -333,13 +326,8 @@ func TestToolDescriptor_Structure(t *testing.T) {
 
 func TestToolResult_Structure(t *testing.T) {
 	resultContent := `{"results": ["item1", "item2"]}`
-	result := ToolResult{
-		Name:      "search",
-		ID:        "call-789",
-		Content:   resultContent,
-		LatencyMs: 250,
-		Error:     "",
-	}
+	result := types.NewTextToolResult("call-789", "search", resultContent)
+	result.LatencyMs = 250
 
 	if result.Name != "search" {
 		t.Error("Name mismatch")
@@ -359,13 +347,9 @@ func TestToolResult_Structure(t *testing.T) {
 }
 
 func TestToolResult_WithError(t *testing.T) {
-	result := ToolResult{
-		Name:      "failing_tool",
-		ID:        "call-error",
-		Content:   "",
-		LatencyMs: 100,
-		Error:     "tool execution failed",
-	}
+	result := types.NewTextToolResult("call-error", "failing_tool", "")
+	result.LatencyMs = 100
+	result.Error = "tool execution failed"
 
 	if result.Error == "" {
 		t.Error("Expected error message")

--- a/runtime/statestore/memory_test.go
+++ b/runtime/statestore/memory_test.go
@@ -1119,12 +1119,11 @@ func TestMemoryStore_DeepCloneMultimodalAndToolCalls(t *testing.T) {
 			{
 				Role:    "tool",
 				Content: "Analysis complete",
-				ToolResult: &types.MessageToolResult{
-					ID:        "call-1",
-					Name:      "analyze_image",
-					Content:   "Analysis complete",
-					LatencyMs: 250,
-				},
+				ToolResult: func() *types.MessageToolResult {
+					r := types.NewTextToolResult("call-1", "analyze_image", "Analysis complete")
+					r.LatencyMs = 250
+					return &r
+				}(),
 				Timestamp: time.Now(),
 			},
 		},
@@ -1153,7 +1152,7 @@ func TestMemoryStore_DeepCloneMultimodalAndToolCalls(t *testing.T) {
 	*state.Messages[0].Parts[3].Media.StorageReference = "MUTATED"
 	state.Messages[1].ToolCalls[0].Args = json.RawMessage(`{"mutated":true}`)
 	state.Messages[1].ToolCalls[0].Name = "MUTATED"
-	state.Messages[2].ToolResult.Content = "MUTATED"
+	state.Messages[2].ToolResult.Parts = []types.ContentPart{types.NewTextPart("MUTATED")}
 
 	// Load and verify original values are preserved
 	loaded, err := store.Load(ctx, "conv-multimodal")
@@ -1205,7 +1204,7 @@ func TestMemoryStore_DeepCloneMultimodalAndToolCalls(t *testing.T) {
 	// Verify tool result preserved
 	toolMsg := loaded.Messages[2]
 	require.NotNil(t, toolMsg.ToolResult)
-	assert.Equal(t, "Analysis complete", toolMsg.ToolResult.Content)
+	assert.Equal(t, "Analysis complete", toolMsg.ToolResult.GetTextContent())
 	assert.Equal(t, "call-1", toolMsg.ToolResult.ID)
 	assert.Equal(t, int64(250), toolMsg.ToolResult.LatencyMs)
 }

--- a/runtime/tokenizer/tokenizer_test.go
+++ b/runtime/tokenizer/tokenizer_test.go
@@ -511,7 +511,8 @@ func TestCountMessageTokens_ToolCalls(t *testing.T) {
 	messages := []types.Message{
 		{
 			Role:    "assistant",
-			Content: "Let me check that for you.",
+			Parts:     []types.ContentPart{types.NewTextPart("Let me check that for you.")},
+
 			ToolCalls: []types.MessageToolCall{
 				{
 					ID:   "call_1",
@@ -533,7 +534,8 @@ func TestCountMessageTokens_ToolResult(t *testing.T) {
 			ToolResult: &types.MessageToolResult{
 				ID:      "call_1",
 				Name:    "get_weather",
-				Content: "The temperature in San Francisco is 18C",
+				Parts:     []types.ContentPart{types.NewTextPart("The temperature in San Francisco is 18C")},
+
 			},
 		},
 	}
@@ -571,7 +573,8 @@ func TestCountMessageTokens_LargeConversation(t *testing.T) {
 		}
 		messages[i] = types.Message{
 			Role:    role,
-			Content: "This is a test message with some content for counting tokens.",
+			Parts:     []types.ContentPart{types.NewTextPart("This is a test message with some content for counting tokens.")},
+
 		}
 	}
 	tokens := counter.CountMessageTokens(messages)

--- a/runtime/tools/types.go
+++ b/runtime/tools/types.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // NamespaceSep is the separator used in qualified tool names.
@@ -143,11 +145,12 @@ type ToolCall struct {
 
 // ToolResult represents the result of a tool execution
 type ToolResult struct {
-	Name      string          `json:"name"`
-	ID        string          `json:"id"` // Matches ToolCall.ID
-	Result    json.RawMessage `json:"result"`
-	LatencyMs int64           `json:"latency_ms"`
-	Error     string          `json:"error,omitempty"`
+	Name      string              `json:"name"`
+	ID        string              `json:"id"` // Matches ToolCall.ID
+	Result    json.RawMessage     `json:"result"`
+	Parts     []types.ContentPart `json:"parts,omitempty"`
+	LatencyMs int64               `json:"latency_ms"`
+	Error     string              `json:"error,omitempty"`
 }
 
 // ToolExecutionStatus represents whether a tool completed or needs external input
@@ -166,6 +169,7 @@ const (
 type ToolExecutionResult struct {
 	Status  ToolExecutionStatus `json:"status"`
 	Content json.RawMessage     `json:"content,omitempty"`
+	Parts   []types.ContentPart `json:"parts,omitempty"`
 	Error   string              `json:"error,omitempty"`
 
 	// Present when Status == ToolStatusPending

--- a/runtime/types/message.go
+++ b/runtime/types/message.go
@@ -50,11 +50,48 @@ type MessageToolCall struct {
 // MessageToolResult represents the result of a tool execution in a Message.
 // When embedded in Message, the Message.Role should be "tool".
 type MessageToolResult struct {
-	ID        string `json:"id"`              // References the MessageToolCall.ID that triggered this result
-	Name      string `json:"name"`            // Tool name that was executed
-	Content   string `json:"content"`         // Result content or error message
-	Error     string `json:"error,omitempty"` // Error message if tool execution failed
-	LatencyMs int64  `json:"latency_ms"`      // Tool execution latency in milliseconds
+	ID    string `json:"id"`              // References the MessageToolCall.ID that triggered this result
+	Name  string `json:"name"`            // Tool name that was executed
+	Error string `json:"error,omitempty"` // Error message if tool execution failed
+
+	// Parts contains the multimodal result content (text, images, etc.).
+	Parts     []ContentPart `json:"parts,omitempty" yaml:"parts,omitempty"`
+	LatencyMs int64         `json:"latency_ms"` // Tool execution latency in milliseconds
+}
+
+// GetTextContent returns concatenated text from all text parts.
+// This is the recommended way to access tool result content as text.
+func (r *MessageToolResult) GetTextContent() string {
+	var sb strings.Builder
+	for _, part := range r.Parts {
+		if part.Type == ContentTypeText && part.Text != nil {
+			sb.WriteString(*part.Text)
+		}
+	}
+	return sb.String()
+}
+
+// HasMedia returns true if any non-text parts exist in the tool result.
+func (r *MessageToolResult) HasMedia() bool {
+	for _, part := range r.Parts {
+		if part.Type != ContentTypeText {
+			return true
+		}
+	}
+	return false
+}
+
+// NewTextToolResult creates a MessageToolResult with text-only content.
+// This is the most common case and should be used everywhere that previously
+// set a text string Content.
+func NewTextToolResult(id, name, text string) MessageToolResult {
+	return MessageToolResult{
+		ID:   id,
+		Name: name,
+		Parts: []ContentPart{
+			NewTextPart(text),
+		},
+	}
 }
 
 // ToolDef represents a tool definition that can be provided to an LLM.
@@ -108,10 +145,10 @@ type ValidationResult struct {
 // 2. For multimodal messages: returns concatenated text parts
 // 3. For legacy messages: returns the Content field
 func (m *Message) GetContent() string {
-	// Tool messages: ToolResult.Content is the authoritative source
-	// This handles the case where Content field may be empty but ToolResult.Content is set
+	// Tool messages: ToolResult.Parts is the authoritative source
+	// This handles the case where Content field may be empty but ToolResult.Parts is set
 	if m.Role == "tool" && m.ToolResult != nil {
-		return m.ToolResult.Content
+		return m.ToolResult.GetTextContent()
 	}
 
 	// Multimodal messages: extract text from parts
@@ -249,16 +286,16 @@ func NewSystemMessage(content string) Message {
 }
 
 // NewToolResultMessage creates a properly normalized tool result message.
-// This ensures Content and ToolResult.Content are always synchronized,
+// This ensures Content and ToolResult.Parts are always synchronized,
 // which is required for provider compatibility and consistent behavior.
 //
 // IMPORTANT: Always use this constructor instead of directly creating
-// Message{Role: "tool", ToolResult: ...} to avoid Content/ToolResult.Content
+// Message{Role: "tool", ToolResult: ...} to avoid Content/ToolResult.Parts
 // synchronization issues.
 func NewToolResultMessage(result MessageToolResult) Message {
 	return Message{
 		Role:       "tool",
-		Content:    result.Content, // Sync Content for backward compatibility
+		Content:    result.GetTextContent(), // Sync Content for backward compatibility
 		ToolResult: &result,
 	}
 }
@@ -342,9 +379,9 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
-	// If tool result is present but Content is empty, copy from ToolResult
+	// If tool result is present but Content is empty, copy text from ToolResult.Parts
 	if m.ToolResult != nil && m.Content == "" {
-		m.Content = m.ToolResult.Content
+		m.Content = m.ToolResult.GetTextContent()
 	}
 	return nil
 }

--- a/runtime/types/message_integration_test.go
+++ b/runtime/types/message_integration_test.go
@@ -11,15 +11,11 @@ import (
 // 3. Unmarshal from JSON (should restore Content from ToolResult)
 func TestMessage_Integration_ToolResultHandling(t *testing.T) {
 	// Step 1: Create a tool result message with Content set
+	result := NewTextToolResult("call_123", "get_weather", "The weather is sunny")
 	originalMsg := &Message{
-		Role:    "tool",
-		Content: "The weather is sunny",
-		ToolResult: &MessageToolResult{
-			ID:      "call_123",
-			Name:    "get_weather",
-			Content: "The weather is sunny",
-			Error:   "",
-		},
+		Role:       "tool",
+		Content:    "The weather is sunny",
+		ToolResult: &result,
 	}
 
 	// Verify Content is set initially
@@ -43,13 +39,22 @@ func TestMessage_Integration_ToolResultHandling(t *testing.T) {
 		t.Errorf("JSON should NOT contain 'content' field when ToolResult is present\nJSON: %s", string(jsonData))
 	}
 
-	// Verify tool_result.content is present
+	// Verify tool_result.parts is present
 	toolResult, ok := rawJSON["tool_result"].(map[string]interface{})
 	if !ok {
 		t.Fatal("tool_result field missing or wrong type")
 	}
-	if toolResult["content"] != "The weather is sunny" {
-		t.Errorf("tool_result.content = %v, want 'The weather is sunny'", toolResult["content"])
+	parts, hasParts := toolResult["parts"]
+	if !hasParts {
+		t.Fatal("tool_result.parts missing")
+	}
+	partsArr := parts.([]interface{})
+	if len(partsArr) != 1 {
+		t.Fatalf("Expected 1 part, got %d", len(partsArr))
+	}
+	partMap := partsArr[0].(map[string]interface{})
+	if partMap["text"] != "The weather is sunny" {
+		t.Errorf("tool_result.parts[0].text = %v, want 'The weather is sunny'", partMap["text"])
 	}
 
 	// Step 3: Unmarshal back from JSON
@@ -60,7 +65,7 @@ func TestMessage_Integration_ToolResultHandling(t *testing.T) {
 
 	// Verify Content field is restored for provider compatibility
 	if restoredMsg.Content != "The weather is sunny" {
-		t.Errorf("Content should be restored from ToolResult.Content\nGot: %q\nWant: %q",
+		t.Errorf("Content should be restored from ToolResult.GetTextContent()\nGot: %q\nWant: %q",
 			restoredMsg.Content, "The weather is sunny")
 	}
 
@@ -68,7 +73,8 @@ func TestMessage_Integration_ToolResultHandling(t *testing.T) {
 	if restoredMsg.ToolResult == nil {
 		t.Fatal("ToolResult should not be nil")
 	}
-	if restoredMsg.ToolResult.Content != "The weather is sunny" {
-		t.Errorf("ToolResult.Content = %q, want 'The weather is sunny'", restoredMsg.ToolResult.Content)
+	if restoredMsg.ToolResult.GetTextContent() != "The weather is sunny" {
+		t.Errorf("ToolResult.GetTextContent() = %q, want 'The weather is sunny'",
+			restoredMsg.ToolResult.GetTextContent())
 	}
 }

--- a/runtime/types/message_json_test.go
+++ b/runtime/types/message_json_test.go
@@ -11,14 +11,11 @@ import (
 // TestMessage_JSONMarshal_ToolResultOmitsContent tests that when a message has a ToolResult,
 // the Content field is omitted from JSON to avoid duplication
 func TestMessage_JSONMarshal_ToolResultOmitsContent(t *testing.T) {
+	result := NewTextToolResult("call_123", "test_tool", `{"result": "success"}`)
 	msg := Message{
-		Role:    "tool",
-		Content: `{"result": "success"}`,
-		ToolResult: &MessageToolResult{
-			ID:      "call_123",
-			Name:    "test_tool",
-			Content: `{"result": "success"}`,
-		},
+		Role:       "tool",
+		Content:    `{"result": "success"}`,
+		ToolResult: &result,
 	}
 
 	data, err := json.Marshal(msg)
@@ -37,10 +34,15 @@ func TestMessage_JSONMarshal_ToolResultOmitsContent(t *testing.T) {
 	toolResult, hasToolResult := parsed["tool_result"]
 	assert.True(t, hasToolResult, "ToolResult should be present")
 
-	// ToolResult.Content should have the content
+	// ToolResult.Parts should have the content
 	if hasToolResult {
 		toolResultMap := toolResult.(map[string]interface{})
-		assert.Equal(t, `{"result": "success"}`, toolResultMap["content"])
+		parts, hasParts := toolResultMap["parts"]
+		assert.True(t, hasParts, "ToolResult should have parts")
+		partsArr := parts.([]interface{})
+		assert.Len(t, partsArr, 1)
+		partMap := partsArr[0].(map[string]interface{})
+		assert.Equal(t, `{"result": "success"}`, partMap["text"])
 	}
 }
 
@@ -72,7 +74,7 @@ func TestMessage_JSONUnmarshal_ToolResult(t *testing.T) {
 		"tool_result": {
 			"id": "call_123",
 			"name": "test_tool",
-			"content": "{\"result\": \"success\"}"
+			"parts": [{"type": "text", "text": "{\"result\": \"success\"}"}]
 		}
 	}`
 
@@ -84,8 +86,8 @@ func TestMessage_JSONUnmarshal_ToolResult(t *testing.T) {
 	require.NotNil(t, msg.ToolResult)
 	assert.Equal(t, "call_123", msg.ToolResult.ID)
 	assert.Equal(t, "test_tool", msg.ToolResult.Name)
-	assert.Equal(t, `{"result": "success"}`, msg.ToolResult.Content)
+	assert.Equal(t, `{"result": "success"}`, msg.ToolResult.GetTextContent())
 
-	// After unmarshaling, Content should be set from ToolResult for provider compatibility
+	// After unmarshaling, Content should be set from ToolResult.GetTextContent() for provider compatibility
 	assert.Equal(t, `{"result": "success"}`, msg.Content)
 }

--- a/runtime/types/message_test.go
+++ b/runtime/types/message_test.go
@@ -110,7 +110,7 @@ func TestMessage_WithToolResult(t *testing.T) {
 		ToolResult: &MessageToolResult{
 			ID:        "call_123",
 			Name:      "get_weather",
-			Content:   `{"temp":72,"condition":"sunny"}`,
+			Parts:     []ContentPart{NewTextPart(`{"temp":72,"condition":"sunny"}`)},
 			LatencyMs: 250,
 		},
 	}
@@ -146,10 +146,9 @@ func TestMessage_WithToolError(t *testing.T) {
 		Role:    "tool",
 		Content: "",
 		ToolResult: &MessageToolResult{
-			ID:      "call_456",
-			Name:    "invalid_tool",
-			Content: "",
-			Error:   "Tool not found",
+			ID:    "call_456",
+			Name:  "invalid_tool",
+			Error: "Tool not found",
 		},
 	}
 
@@ -559,12 +558,8 @@ func TestNewSystemMessage(t *testing.T) {
 }
 
 func TestNewToolResultMessage(t *testing.T) {
-	result := MessageToolResult{
-		ID:        "call_123",
-		Name:      "get_weather",
-		Content:   `{"temp": 72, "condition": "sunny"}`,
-		LatencyMs: 150,
-	}
+	result := NewTextToolResult("call_123", "get_weather", `{"temp": 72, "condition": "sunny"}`)
+	result.LatencyMs = 150
 
 	msg := NewToolResultMessage(result)
 
@@ -580,26 +575,22 @@ func TestNewToolResultMessage(t *testing.T) {
 	if msg.ToolResult.Name != "get_weather" {
 		t.Errorf("ToolResult.Name mismatch: got %q, want %q", msg.ToolResult.Name, "get_weather")
 	}
-	// Content should be synced from ToolResult.Content
-	if msg.Content != result.Content {
-		t.Errorf("Content not synced: got %q, want %q", msg.Content, result.Content)
+	// Content should be synced from ToolResult.GetTextContent()
+	if msg.Content != result.GetTextContent() {
+		t.Errorf("Content not synced: got %q, want %q", msg.Content, result.GetTextContent())
 	}
 }
 
 func TestNewToolResultMessage_ContentSync(t *testing.T) {
-	// Verify that Content and ToolResult.Content are synchronized
-	result := MessageToolResult{
-		ID:      "call_456",
-		Name:    "calculator",
-		Content: "42",
-	}
+	// Verify that Content and ToolResult.GetTextContent() are synchronized
+	result := NewTextToolResult("call_456", "calculator", "42")
 
 	msg := NewToolResultMessage(result)
 
 	// Both should have the same content
-	if msg.Content != msg.ToolResult.Content {
-		t.Errorf("Content not synced with ToolResult.Content: Content=%q, ToolResult.Content=%q",
-			msg.Content, msg.ToolResult.Content)
+	if msg.Content != msg.ToolResult.GetTextContent() {
+		t.Errorf("Content not synced with ToolResult.GetTextContent(): Content=%q, GetTextContent()=%q",
+			msg.Content, msg.ToolResult.GetTextContent())
 	}
 
 	// GetContent should return the content
@@ -609,12 +600,8 @@ func TestNewToolResultMessage_ContentSync(t *testing.T) {
 }
 
 func TestNewToolResultMessage_WithError(t *testing.T) {
-	result := MessageToolResult{
-		ID:      "call_789",
-		Name:    "invalid_tool",
-		Content: "Tool execution failed",
-		Error:   "Tool not found",
-	}
+	result := NewTextToolResult("call_789", "invalid_tool", "Tool execution failed")
+	result.Error = "Tool not found"
 
 	msg := NewToolResultMessage(result)
 

--- a/sdk/agui/convert.go
+++ b/sdk/agui/convert.go
@@ -44,7 +44,7 @@ func MessageToAGUI(msg *types.Message) aguitypes.Message {
 	// Handle tool result messages
 	if msg.Role == "tool" && msg.ToolResult != nil {
 		aguiMsg.ToolCallID = msg.ToolResult.ID
-		aguiMsg.Content = msg.ToolResult.Content
+		aguiMsg.Content = msg.ToolResult.GetTextContent()
 		return aguiMsg
 	}
 
@@ -74,10 +74,8 @@ func MessageFromAGUI(msg *aguitypes.Message) types.Message {
 	if msg.Role == aguitypes.RoleTool {
 		content := contentString(msg)
 		pkMsg.Content = content
-		pkMsg.ToolResult = &types.MessageToolResult{
-			ID:      msg.ToolCallID,
-			Content: content,
-		}
+		result := types.NewTextToolResult(msg.ToolCallID, "", content)
+		pkMsg.ToolResult = &result
 		return pkMsg
 	}
 

--- a/sdk/agui/convert_test.go
+++ b/sdk/agui/convert_test.go
@@ -80,11 +80,9 @@ func TestMessageToAGUI_AssistantWithToolCalls(t *testing.T) {
 }
 
 func TestMessageToAGUI_ToolResultMessage(t *testing.T) {
-	msg := types.NewToolResultMessage(types.MessageToolResult{
-		ID:      "call-123",
-		Name:    "get_weather",
-		Content: `{"temperature":72,"condition":"sunny"}`,
-	})
+	msg := types.NewToolResultMessage(
+		types.NewTextToolResult("call-123", "get_weather", `{"temperature":72,"condition":"sunny"}`),
+	)
 
 	result := MessageToAGUI(&msg)
 
@@ -219,7 +217,7 @@ func TestMessageFromAGUI_ToolResultMessage(t *testing.T) {
 	assert.Equal(t, `{"result":"success"}`, result.Content)
 	require.NotNil(t, result.ToolResult)
 	assert.Equal(t, "call-789", result.ToolResult.ID)
-	assert.Equal(t, `{"result":"success"}`, result.ToolResult.Content)
+	assert.Equal(t, `{"result":"success"}`, result.ToolResult.GetTextContent())
 }
 
 func TestMessageFromAGUI_AssistantWithToolCalls(t *testing.T) {
@@ -333,11 +331,9 @@ func TestRoundTrip_AssistantWithToolCalls(t *testing.T) {
 }
 
 func TestRoundTrip_ToolResultMessage(t *testing.T) {
-	original := types.NewToolResultMessage(types.MessageToolResult{
-		ID:      "call-rt2",
-		Name:    "fetch",
-		Content: "result data",
-	})
+	original := types.NewToolResultMessage(
+		types.NewTextToolResult("call-rt2", "fetch", "result data"),
+	)
 
 	aguiMsg := MessageToAGUI(&original)
 	roundTripped := MessageFromAGUI(&aguiMsg)
@@ -345,7 +341,7 @@ func TestRoundTrip_ToolResultMessage(t *testing.T) {
 	assert.Equal(t, "tool", roundTripped.Role)
 	require.NotNil(t, roundTripped.ToolResult)
 	assert.Equal(t, "call-rt2", roundTripped.ToolResult.ID)
-	assert.Equal(t, "result data", roundTripped.ToolResult.Content)
+	assert.Equal(t, "result data", roundTripped.ToolResult.GetTextContent())
 }
 
 func TestRoundTrip_MultimodalImageURL(t *testing.T) {

--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -318,10 +318,9 @@ func (c *Conversation) buildToolResultMessages() ([]types.Message, error) {
 		} else {
 			content = string(res.ResultJSON)
 		}
-		toolMsgs = append(toolMsgs, types.NewToolResultMessage(types.MessageToolResult{
-			ID:      res.ID,
-			Content: content,
-		}))
+		toolMsgs = append(toolMsgs, types.NewToolResultMessage(
+			types.NewTextToolResult(res.ID, "", content),
+		))
 	}
 
 	return toolMsgs, nil

--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -283,11 +283,8 @@ func (c *Conversation) Continue(ctx context.Context) (*Response, error) {
 			content = fmt.Sprintf("%v", res.Result)
 		}
 
-		toolResult := types.MessageToolResult{
-			ID:      res.ID,
-			Content: content,
-			Error:   errStr,
-		}
+		toolResult := types.NewTextToolResult(res.ID, "", content)
+		toolResult.Error = errStr
 		toolMsgs = append(toolMsgs, types.NewToolResultMessage(toolResult))
 	}
 

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -349,10 +349,9 @@ func TestUnarySession_ResumeWithToolResults(t *testing.T) {
 
 	// Resume with tool results — sends tool result messages through pipeline
 	toolResults := []types.Message{
-		types.NewToolResultMessage(types.MessageToolResult{
-			ID:      "call-1",
-			Content: `{"lat": 37.7749}`,
-		}),
+		types.NewToolResultMessage(
+			types.NewTextToolResult("call-1", "", `{"lat": 37.7749}`),
+		),
 	}
 
 	result, err := sess.ResumeWithToolResults(context.Background(), toolResults)
@@ -447,10 +446,9 @@ func TestUnarySession_ResumeStreamWithToolResults(t *testing.T) {
 
 	// Resume with tool results in streaming mode
 	toolResults := []types.Message{
-		types.NewToolResultMessage(types.MessageToolResult{
-			ID:      "call-1",
-			Content: `{"lat": 37.7749}`,
-		}),
+		types.NewToolResultMessage(
+			types.NewTextToolResult("call-1", "", `{"lat": 37.7749}`),
+		),
 	}
 
 	stream, err := sess.ResumeStreamWithToolResults(context.Background(), toolResults)

--- a/tools/arena/adapters/arena_output.go
+++ b/tools/arena/adapters/arena_output.go
@@ -91,13 +91,8 @@ func (a *ArenaOutputAdapter) convertToMessages(output *ArenaOutputFile) ([]types
 
 		// Add tool result messages
 		for _, toolResult := range turn.ToolResults {
-			msg := types.Message{
-				Role: "tool",
-				ToolResult: &types.MessageToolResult{
-					ID:      toolResult.ToolCallID,
-					Content: toolResult.Content,
-				},
-			}
+			result := types.NewTextToolResult(toolResult.ToolCallID, "", toolResult.Content)
+			msg := types.NewToolResultMessage(result)
 			messages = append(messages, msg)
 			timestamps = append(timestamps, turn.Timestamp)
 		}

--- a/tools/arena/adapters/arena_output_test.go
+++ b/tools/arena/adapters/arena_output_test.go
@@ -216,8 +216,8 @@ func TestArenaOutputAdapter_Load_WithToolResults(t *testing.T) {
 	if messages[2].ToolResult == nil || messages[2].ToolResult.ID != "call_123" {
 		t.Errorf("messages[2].ToolResult.ID = %v, want call_123", messages[2].ToolResult)
 	}
-	if messages[2].ToolResult.Content != "Sunny, 72°F" {
-		t.Errorf("messages[2].ToolResult.Content = %s, want 'Sunny, 72°F'", messages[2].ToolResult.Content)
+	if messages[2].ToolResult.GetTextContent() != "Sunny, 72°F" {
+		t.Errorf("messages[2].ToolResult.GetTextContent() = %s, want 'Sunny, 72°F'", messages[2].ToolResult.GetTextContent())
 	}
 }
 

--- a/tools/arena/adapters/session_recording.go
+++ b/tools/arena/adapters/session_recording.go
@@ -117,10 +117,8 @@ func (a *SessionRecordingAdapter) buildMessage(recordedMsg *RecordedMsg) types.M
 
 	// Set tool result for tool role messages
 	if recordedMsg.ToolCallID != "" {
-		msg.ToolResult = &types.MessageToolResult{
-			ID:      recordedMsg.ToolCallID,
-			Content: recordedMsg.Content,
-		}
+		result := types.NewTextToolResult(recordedMsg.ToolCallID, "", recordedMsg.Content)
+		msg.ToolResult = &result
 	}
 
 	return msg

--- a/tools/arena/adapters/transcript.go
+++ b/tools/arena/adapters/transcript.go
@@ -136,10 +136,8 @@ func (a *TranscriptAdapter) buildMessage(msg *TranscriptMessage) types.Message {
 
 	// Set tool result for tool role messages
 	if msg.ToolCallID != "" {
-		result.ToolResult = &types.MessageToolResult{
-			ID:      msg.ToolCallID,
-			Content: msg.Content,
-		}
+		toolResult := types.NewTextToolResult(msg.ToolCallID, "", msg.Content)
+		result.ToolResult = &toolResult
 	}
 
 	return result

--- a/tools/arena/assertions/context_builder.go
+++ b/tools/arena/assertions/context_builder.go
@@ -102,7 +102,7 @@ func (e *toolCallRecordEntry) isResolved() bool {
 }
 
 func (e *toolCallRecordEntry) applyResult(result *types.MessageToolResult) {
-	e.rec.Result = result.Content
+	e.rec.Result = result.GetTextContent()
 	e.rec.Error = result.Error
 	e.rec.Duration = time.Duration(result.LatencyMs) * time.Millisecond
 }

--- a/tools/arena/assertions/context_builder_test.go
+++ b/tools/arena/assertions/context_builder_test.go
@@ -13,8 +13,9 @@ func TestBuildConversationContextFromMessages_Basic(t *testing.T) {
 		{Role: "system", Content: "You are a helpful assistant."},
 		{Role: "user", Content: "Hello"},
 		{
-			Role:    "assistant",
-			Content: "Let me look that up.",
+			Role:  "assistant",
+			Parts: []types.ContentPart{types.NewTextPart("Let me look that up.")},
+
 			ToolCalls: []types.MessageToolCall{
 				{ID: "tc1", Name: "search", Args: json.RawMessage(`{"query":"hello"}`)},
 			},
@@ -54,9 +55,10 @@ func TestBuildConversationContextFromMessages_ToolResults(t *testing.T) {
 		{
 			Role: "tool",
 			ToolResult: &types.MessageToolResult{
-				ID:        "tc1",
-				Name:      "search",
-				Content:   "found 3 results",
+				ID:    "tc1",
+				Name:  "search",
+				Parts: []types.ContentPart{types.NewTextPart("found 3 results")},
+
 				Error:     "",
 				LatencyMs: 150,
 			},
@@ -92,9 +94,9 @@ func TestBuildConversationContextFromMessages_ToolResultWithError(t *testing.T) 
 		{
 			Role: "tool",
 			ToolResult: &types.MessageToolResult{
-				ID:        "tc1",
-				Name:      "db_query",
-				Content:   "",
+				ID:   "tc1",
+				Name: "db_query",
+
 				Error:     "connection refused",
 				LatencyMs: 50,
 			},
@@ -124,13 +126,13 @@ func TestBuildConversationContextFromMessages_MultipleToolCalls(t *testing.T) {
 		{
 			Role: "tool",
 			ToolResult: &types.MessageToolResult{
-				ID: "tc1", Name: "search", Content: "result-a", LatencyMs: 10,
+				ID: "tc1", Name: "search", Parts: []types.ContentPart{types.NewTextPart("result-a")}, LatencyMs: 10,
 			},
 		},
 		{
 			Role: "tool",
 			ToolResult: &types.MessageToolResult{
-				ID: "tc2", Name: "lookup", Content: "result-b", LatencyMs: 20,
+				ID: "tc2", Name: "lookup", Parts: []types.ContentPart{types.NewTextPart("result-b")}, LatencyMs: 20,
 			},
 		},
 		{
@@ -142,7 +144,7 @@ func TestBuildConversationContextFromMessages_MultipleToolCalls(t *testing.T) {
 		{
 			Role: "tool",
 			ToolResult: &types.MessageToolResult{
-				ID: "tc3", Name: "search", Content: "result-c", LatencyMs: 30,
+				ID: "tc3", Name: "search", Parts: []types.ContentPart{types.NewTextPart("result-c")}, LatencyMs: 30,
 			},
 		},
 	}
@@ -170,16 +172,18 @@ func TestBuildConversationContextFromMessages_MultipleToolCalls(t *testing.T) {
 func TestBuildConversationContextFromMessages_WorkflowMetadata(t *testing.T) {
 	messages := []types.Message{
 		{
-			Role:    "assistant",
-			Content: "Transitioning...",
+			Role:  "assistant",
+			Parts: []types.ContentPart{types.NewTextPart("Transitioning...")},
+
 			Meta: map[string]interface{}{
 				"_workflow_state":       "greeting",
 				"_workflow_transitions": []string{"init->greeting"},
 			},
 		},
 		{
-			Role:    "assistant",
-			Content: "Done.",
+			Role:  "assistant",
+			Parts: []types.ContentPart{types.NewTextPart("Done.")},
+
 			Meta: map[string]interface{}{
 				"_workflow_state":    "complete",
 				"_workflow_complete": true,

--- a/tools/arena/assertions/tool_result_matcher_test.go
+++ b/tools/arena/assertions/tool_result_matcher_test.go
@@ -14,23 +14,23 @@ type stubEntry struct {
 	result   *types.MessageToolResult
 }
 
-func (s *stubEntry) callID() string                              { return s.id }
-func (s *stubEntry) callName() string                            { return s.name }
-func (s *stubEntry) isResolved() bool                            { return s.resolved }
-func (s *stubEntry) applyResult(r *types.MessageToolResult)      { s.result = r; s.resolved = true }
+func (s *stubEntry) callID() string                         { return s.id }
+func (s *stubEntry) callName() string                       { return s.name }
+func (s *stubEntry) isResolved() bool                       { return s.resolved }
+func (s *stubEntry) applyResult(r *types.MessageToolResult) { s.result = r; s.resolved = true }
 
 func TestMatchResult_ByID(t *testing.T) {
 	a := &stubEntry{id: "tc1", name: "search"}
 	b := &stubEntry{id: "tc2", name: "lookup"}
 	entries := []toolCallEntry{a, b}
 
-	result := &types.MessageToolResult{ID: "tc2", Name: "lookup", Content: "found"}
+	result := &types.MessageToolResult{ID: "tc2", Name: "lookup", Parts: []types.ContentPart{types.NewTextPart("found")}}
 	matchResult(entries, result)
 
 	if a.resolved {
 		t.Error("entry a should not be resolved")
 	}
-	if !b.resolved || b.result.Content != "found" {
+	if !b.resolved || b.result.GetTextContent() != "found" {
 		t.Errorf("entry b should be resolved with content 'found', got resolved=%v", b.resolved)
 	}
 }
@@ -40,13 +40,13 @@ func TestMatchResult_ByNameFallback(t *testing.T) {
 	b := &stubEntry{id: "", name: "lookup"}
 	entries := []toolCallEntry{a, b}
 
-	result := &types.MessageToolResult{ID: "", Name: "lookup", Content: "result"}
+	result := &types.MessageToolResult{ID: "", Name: "lookup", Parts: []types.ContentPart{types.NewTextPart("result")}}
 	matchResult(entries, result)
 
 	if a.resolved {
 		t.Error("entry a should not be resolved")
 	}
-	if !b.resolved || b.result.Content != "result" {
+	if !b.resolved || b.result.GetTextContent() != "result" {
 		t.Errorf("entry b should be resolved with content 'result', got resolved=%v", b.resolved)
 	}
 }
@@ -57,13 +57,13 @@ func TestMatchResult_IDTakesPrecedenceOverName(t *testing.T) {
 	entries := []toolCallEntry{a, b}
 
 	// ID matches b, name would match a first.
-	result := &types.MessageToolResult{ID: "tc2", Name: "search", Content: "matched-by-id"}
+	result := &types.MessageToolResult{ID: "tc2", Name: "search", Parts: []types.ContentPart{types.NewTextPart("matched-by-id")}}
 	matchResult(entries, result)
 
 	if a.resolved {
 		t.Error("entry a should not be resolved (ID match should win)")
 	}
-	if !b.resolved || b.result.Content != "matched-by-id" {
+	if !b.resolved || b.result.GetTextContent() != "matched-by-id" {
 		t.Error("entry b should be resolved via ID match")
 	}
 }
@@ -73,10 +73,10 @@ func TestMatchResult_SkipsAlreadyResolved(t *testing.T) {
 	b := &stubEntry{id: "tc2", name: "search"}
 	entries := []toolCallEntry{a, b}
 
-	result := &types.MessageToolResult{ID: "", Name: "search", Content: "second"}
+	result := &types.MessageToolResult{ID: "", Name: "search", Parts: []types.ContentPart{types.NewTextPart("second")}}
 	matchResult(entries, result)
 
-	if b.result == nil || b.result.Content != "second" {
+	if b.result == nil || b.result.GetTextContent() != "second" {
 		t.Error("should match second unresolved entry with same name")
 	}
 }
@@ -85,7 +85,7 @@ func TestMatchResult_NoMatch(t *testing.T) {
 	a := &stubEntry{id: "tc1", name: "search"}
 	entries := []toolCallEntry{a}
 
-	result := &types.MessageToolResult{ID: "tc99", Name: "unknown", Content: "orphan"}
+	result := &types.MessageToolResult{ID: "tc99", Name: "unknown", Parts: []types.ContentPart{types.NewTextPart("orphan")}}
 	matchResult(entries, result)
 
 	if a.resolved {
@@ -95,7 +95,7 @@ func TestMatchResult_NoMatch(t *testing.T) {
 
 func TestMatchResult_EmptyEntries(t *testing.T) {
 	// Should not panic on empty entries.
-	result := &types.MessageToolResult{ID: "tc1", Name: "search", Content: "x"}
+	result := &types.MessageToolResult{ID: "tc1", Name: "search", Parts: []types.ContentPart{types.NewTextPart("x")}}
 	matchResult(nil, result)
 	matchResult([]toolCallEntry{}, result)
 }
@@ -105,11 +105,11 @@ func TestMatchResult_IDMatchSkipsResolvedByID(t *testing.T) {
 	b := &stubEntry{id: "tc1", name: "search"}
 	entries := []toolCallEntry{a, b}
 
-	result := &types.MessageToolResult{ID: "tc1", Name: "search", Content: "dup-id"}
+	result := &types.MessageToolResult{ID: "tc1", Name: "search", Parts: []types.ContentPart{types.NewTextPart("dup-id")}}
 	matchResult(entries, result)
 
 	// a is already resolved, so b should get the match even though both have same ID.
-	if !b.resolved || b.result.Content != "dup-id" {
+	if !b.resolved || b.result.GetTextContent() != "dup-id" {
 		t.Error("should match second entry with same ID when first is resolved")
 	}
 }

--- a/tools/arena/assertions/turn_tool_trace.go
+++ b/tools/arena/assertions/turn_tool_trace.go
@@ -116,7 +116,7 @@ func (e *turnToolCallEntry) isResolved() bool {
 }
 
 func (e *turnToolCallEntry) applyResult(result *types.MessageToolResult) {
-	e.tc.Result = result.Content
+	e.tc.Result = result.GetTextContent()
 	e.tc.Error = result.Error
 	e.tc.LatencyMs = result.LatencyMs
 	e.tc.resolved = true

--- a/tools/arena/assertions/when_test.go
+++ b/tools/arena/assertions/when_test.go
@@ -26,12 +26,11 @@ func buildWhenParams(toolCalls ...TurnToolCall) map[string]interface{} {
 		for _, tc := range toolCalls {
 			msgs = append(msgs, types.Message{
 				Role: "tool",
-				ToolResult: &types.MessageToolResult{
-					ID:      tc.CallID,
-					Name:    tc.Name,
-					Content: tc.Result,
-					Error:   tc.Error,
-				},
+				ToolResult: func() *types.MessageToolResult {
+					r := types.NewTextToolResult(tc.CallID, tc.Name, tc.Result)
+					r.Error = tc.Error
+					return &r
+				}(),
 			})
 		}
 	} else {

--- a/tools/arena/engine/duplex_executor_tools_integration.go
+++ b/tools/arena/engine/duplex_executor_tools_integration.go
@@ -53,12 +53,9 @@ func (e *arenaToolExecutor) Execute(
 				Result:     fmt.Sprintf(`{"error": %q}`, errMsg),
 				IsError:    true,
 			})
-			result.ResultMessages = append(result.ResultMessages, types.NewToolResultMessage(types.MessageToolResult{
-				ID:      tc.ID,
-				Name:    tc.Name,
-				Content: errMsg,
-				Error:   errMsg,
-			}))
+			errResult := types.NewTextToolResult(tc.ID, tc.Name, errMsg)
+			errResult.Error = errMsg
+			result.ResultMessages = append(result.ResultMessages, types.NewToolResultMessage(errResult))
 			continue
 		}
 
@@ -71,13 +68,10 @@ func (e *arenaToolExecutor) Execute(
 				Result:     fmt.Sprintf(`{"error": %q}`, toolResult.Error),
 				IsError:    true,
 			})
-			result.ResultMessages = append(result.ResultMessages, types.NewToolResultMessage(types.MessageToolResult{
-				ID:        tc.ID,
-				Name:      tc.Name,
-				Content:   toolResult.Error,
-				Error:     toolResult.Error,
-				LatencyMs: toolResult.LatencyMs,
-			}))
+			toolErrResult := types.NewTextToolResult(tc.ID, tc.Name, toolResult.Error)
+			toolErrResult.Error = toolResult.Error
+			toolErrResult.LatencyMs = toolResult.LatencyMs
+			result.ResultMessages = append(result.ResultMessages, types.NewToolResultMessage(toolErrResult))
 			continue
 		}
 
@@ -94,12 +88,9 @@ func (e *arenaToolExecutor) Execute(
 			Result:     resultStr,
 			IsError:    false,
 		})
-		result.ResultMessages = append(result.ResultMessages, types.NewToolResultMessage(types.MessageToolResult{
-			ID:        tc.ID,
-			Name:      tc.Name,
-			Content:   resultStr,
-			LatencyMs: toolResult.LatencyMs,
-		}))
+		successResult := types.NewTextToolResult(tc.ID, tc.Name, resultStr)
+		successResult.LatencyMs = toolResult.LatencyMs
+		result.ResultMessages = append(result.ResultMessages, types.NewToolResultMessage(successResult))
 	}
 
 	return result, nil

--- a/tools/arena/engine/workflow_driver_integration.go
+++ b/tools/arena/engine/workflow_driver_integration.go
@@ -183,11 +183,9 @@ func (d *arenaWorkflowDriver) Send(ctx context.Context, message string) (string,
 			} else {
 				content = string(result.Result)
 			}
-			toolResultMsg := types.NewToolResultMessage(types.MessageToolResult{
-				ID:      tc.ID,
-				Name:    tc.Name,
-				Content: content,
-			})
+			toolResultMsg := types.NewToolResultMessage(
+				types.NewTextToolResult(tc.ID, tc.Name, content),
+			)
 			// Only append to trace, not to d.messages — tool results in d.messages
 			// cause the mock provider to inflate the turn number (turn skew).
 			d.messageTrace = append(d.messageTrace, toolResultMsg)
@@ -229,11 +227,9 @@ func (d *arenaWorkflowDriver) processTransitionToolCall(tc types.MessageToolCall
 		NewState: toState,
 		Event:    args.Event,
 	})
-	toolResultMsg := types.NewToolResultMessage(types.MessageToolResult{
-		ID:      tc.ID,
-		Name:    workflowTransitionTool,
-		Content: string(resultJSON),
-	})
+	toolResultMsg := types.NewToolResultMessage(
+		types.NewTextToolResult(tc.ID, workflowTransitionTool, string(resultJSON)),
+	)
 	d.messageTrace = append(d.messageTrace, toolResultMsg)
 
 	// Append new state's system prompt to trace with full diagnostics

--- a/tools/arena/stages/stages_test.go
+++ b/tools/arena/stages/stages_test.go
@@ -678,11 +678,10 @@ func TestDeepCloneMessages_WithToolResult(t *testing.T) {
 	original := []types.Message{
 		{
 			Role: "tool",
-			ToolResult: &types.MessageToolResult{
-				ID:      "call1",
-				Name:    "tool1",
-				Content: "result",
-			},
+			ToolResult: func() *types.MessageToolResult {
+				r := types.NewTextToolResult("call1", "tool1", "result")
+				return &r
+			}(),
 		},
 	}
 
@@ -693,8 +692,8 @@ func TestDeepCloneMessages_WithToolResult(t *testing.T) {
 	assert.Equal(t, "call1", cloned[0].ToolResult.ID)
 
 	// Modify original should not affect clone
-	original[0].ToolResult.Content = "modified"
-	assert.Equal(t, "result", cloned[0].ToolResult.Content)
+	original[0].ToolResult.Parts = []types.ContentPart{types.NewTextPart("modified")}
+	assert.Equal(t, "result", cloned[0].ToolResult.GetTextContent())
 }
 
 func TestDeepCloneMessages_WithCostInfo(t *testing.T) {

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -370,10 +370,12 @@ func (s *ArenaStateStore) cloneMessageToolCalls(cloned *types.Message, msg *type
 // cloneMessageToolResult clones the ToolResult
 func (s *ArenaStateStore) cloneMessageToolResult(cloned *types.Message, msg *types.Message) {
 	if msg.ToolResult != nil {
+		partsCopy := make([]types.ContentPart, len(msg.ToolResult.Parts))
+		copy(partsCopy, msg.ToolResult.Parts)
 		cloned.ToolResult = &types.MessageToolResult{
 			ID:        msg.ToolResult.ID,
 			Name:      msg.ToolResult.Name,
-			Content:   msg.ToolResult.Content,
+			Parts:     partsCopy,
 			Error:     msg.ToolResult.Error,
 			LatencyMs: msg.ToolResult.LatencyMs,
 		}

--- a/tools/arena/tui/event_adapter_test.go
+++ b/tools/arena/tui/event_adapter_test.go
@@ -628,7 +628,7 @@ func TestEventAdapter_HandleMessageCreated(t *testing.T) {
 				ToolResult: &events.MessageToolResult{
 					ID:        "call-1",
 					Name:      "get_weather",
-					Content:   `{"temp": 72, "conditions": "sunny"}`,
+					Parts:     []types.ContentPart{types.NewTextPart(`{"temp": 72, "conditions": "sunny"}`)},
 					LatencyMs: 150,
 				},
 			},

--- a/tools/arena/tui/panels/conversation.go
+++ b/tools/arena/tui/panels/conversation.go
@@ -635,9 +635,9 @@ func (c *ConversationPanel) appendToolResultMarkdown(md *strings.Builder, msg *t
 	}
 
 	fmt.Fprintf(md, "## ✅ Tool Result: %s\n\n", msg.ToolResult.Name)
-	if msg.ToolResult.Content != "" {
+	if textContent := msg.ToolResult.GetTextContent(); textContent != "" {
 		md.WriteString("```json\n")
-		md.WriteString(formatJSON(msg.ToolResult.Content))
+		md.WriteString(formatJSON(textContent))
 		md.WriteString("\n```\n\n")
 	}
 	if msg.ToolResult.Error != "" {

--- a/tools/arena/tui/panels/conversation_test.go
+++ b/tools/arena/tui/panels/conversation_test.go
@@ -501,11 +501,9 @@ func TestConversationPanel_AppendToolResultMarkdown(t *testing.T) {
 	panel := NewConversationPanel()
 	var md strings.Builder
 
+	toolResult := types.NewTextToolResult("", "test_tool", `{"result":"success"}`)
 	msg := &types.Message{
-		ToolResult: &types.MessageToolResult{
-			Name:    "test_tool",
-			Content: `{"result":"success"}`,
-		},
+		ToolResult: &toolResult,
 	}
 
 	panel.appendToolResultMarkdown(&md, msg)

--- a/tools/arena/tui/panels/panels_test.go
+++ b/tools/arena/tui/panels/panels_test.go
@@ -25,10 +25,10 @@ func TestConversationPanel_ViewAndNavigation(t *testing.T) {
 				ToolCalls: []types.MessageToolCall{
 					{Name: "list_devices", Args: []byte(`{"customer_id":"acme"}`)},
 				},
-				ToolResult: &types.MessageToolResult{
-					Name:    "list_devices",
-					Content: `{"devices":[1,2]}`,
-				},
+				ToolResult: func() *types.MessageToolResult {
+					r := types.NewTextToolResult("", "list_devices", `{"devices":[1,2]}`)
+					return &r
+				}(),
 				CostInfo: &types.CostInfo{
 					InputTokens:  50,
 					OutputTokens: 100,

--- a/tools/arena/tui/tui.go
+++ b/tools/arena/tui/tui.go
@@ -386,10 +386,12 @@ func (m *Model) handleMessageCreated(msg *MessageCreatedMsg) {
 	}
 	var toolResult *types.MessageToolResult
 	if msg.ToolResult != nil {
+		partsCopy := make([]types.ContentPart, len(msg.ToolResult.Parts))
+		copy(partsCopy, msg.ToolResult.Parts)
 		toolResult = &types.MessageToolResult{
 			ID:        msg.ToolResult.ID,
 			Name:      msg.ToolResult.Name,
-			Content:   msg.ToolResult.Content,
+			Parts:     partsCopy,
 			Error:     msg.ToolResult.Error,
 			LatencyMs: msg.ToolResult.LatencyMs,
 		}
@@ -714,7 +716,6 @@ func (m *Model) convertToLogEntries() []panels.LogEntry {
 	}
 	return logs
 }
-
 
 //nolint:unused // used by tests (golangci-lint runs with tests:false)
 func (m *Model) currentRunForDetail() *RunInfo {

--- a/tools/arena/tui/tui_test.go
+++ b/tools/arena/tui/tui_test.go
@@ -507,7 +507,6 @@ func TestConvertToLogEntries(t *testing.T) {
 	assert.Equal(t, "ERROR", logs[2].Level)
 }
 
-
 func TestRenderMainPage_NoStateStore(t *testing.T) {
 	m := NewModel("test.yaml", 1)
 	m.width = 100
@@ -1176,7 +1175,7 @@ func TestHandleMessageCreated_WithToolResult(t *testing.T) {
 		ToolResult: &MessageToolResult{
 			ID:        "call-1",
 			Name:      "get_weather",
-			Content:   `{"temp": 72}`,
+			Parts:     []types.ContentPart{types.NewTextPart(`{"temp": 72}`)},
 			LatencyMs: 100,
 		},
 		Time: time.Now(),


### PR DESCRIPTION
## Summary

Closes #617

Replace the text-only `Content string` field on `MessageToolResult` with a multimodal `Parts []ContentPart` slice, reusing the existing `ContentPart` type. This is a breaking change that enables tool results to carry images, audio, video, and documents alongside text.

### Changes

- **`runtime/types/message.go`**: Remove `Content string`, add `Parts []ContentPart`. Add helper methods `GetTextContent()`, `HasMedia()`, and constructor `NewTextToolResult()`. Update `NewToolResultMessage()`, `GetContent()`, `MarshalJSON()`, and `UnmarshalJSON()`.
- **`runtime/events/`**: Update `ToolCallEventData.Result` to `Parts []ContentPart`, update `events.MessageToolResult` mirror type, change `ToolCallCompleted` emitter signature to accept `[]types.ContentPart`.
- **`runtime/tools/types.go`**: Add `Parts []ContentPart` to `ToolResult` and `ToolExecutionResult` (existing fields retained for backward compat).
- **Provider files** (Claude, OpenAI, Gemini, Ollama): Replace `.Content` access with `.GetTextContent()`.
- **Pipeline stages**: Update tool result construction and recording to use `Parts`.
- **SDK**: Update `conversation_tools.go`, `client_tools.go`, `agui/convert.go` to use `NewTextToolResult()` and `GetTextContent()`.
- **Arena**: Update adapters, assertions, TUI, and state store across ~15 files.
- **53 files changed** across runtime, sdk, and tools/arena modules. All tests pass with >80% coverage on changed lines.

## Test plan

- [x] All existing tests updated and passing (53 files, 377 insertions, 382 deletions)
- [x] `golangci-lint run --new-from-rev=HEAD` clean (0 issues)
- [x] Pre-commit hook passes (lint, build, test, coverage)
- [x] Coverage >= 80% on all changed non-test files