### PR TITLE
feat: Gemini provider multimodal tool result serialization

### DIFF
--- a/runtime/providers/gemini/gemini_tool_results_test.go
+++ b/runtime/providers/gemini/gemini_tool_results_test.go
@@ -64,22 +64,21 @@ func TestToolProvider_BuildRequestWithToolMessages(t *testing.T) {
 	messages := []types.Message{
 		{Role: "user", Content: "What's the weather?"},
 		{
-			Role:    "assistant",
-			Parts:     []types.ContentPart{types.NewTextPart("Let me check the weather for you.")},
+			Role:  "assistant",
+			Parts: []types.ContentPart{types.NewTextPart("Let me check the weather for you.")},
 
 			ToolCalls: []types.MessageToolCall{
 				{ID: "call_123", Name: "get_weather", Args: json.RawMessage(`{"location":"SF"}`)},
 			},
 		},
 		{
-			Role:    "tool",
-			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
+			Role:  "tool",
+			Parts: []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
 
 			ToolResult: &types.MessageToolResult{
-				ID:      "call_123",
-				Name:    "get_weather",
-				Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
-
+				ID:    "call_123",
+				Name:  "get_weather",
+				Parts: []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
 			},
 		},
 		{Role: "user", Content: "Thanks! Now check NYC."},
@@ -219,25 +218,23 @@ func TestToolProvider_MultipleToolResultsGrouped(t *testing.T) {
 			},
 		},
 		{
-			Role:    "tool",
-			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
+			Role:  "tool",
+			Parts: []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
 
 			ToolResult: &types.MessageToolResult{
-				ID:      "call_sf",
-				Name:    "get_weather",
-				Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
-
+				ID:    "call_sf",
+				Name:  "get_weather",
+				Parts: []types.ContentPart{types.NewTextPart(`{"temperature": 72, "condition": "sunny"}`)},
 			},
 		},
 		{
-			Role:    "tool",
-			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 65, "condition": "cloudy"}`)},
+			Role:  "tool",
+			Parts: []types.ContentPart{types.NewTextPart(`{"temperature": 65, "condition": "cloudy"}`)},
 
 			ToolResult: &types.MessageToolResult{
-				ID:      "call_nyc",
-				Name:    "get_weather",
-				Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 65, "condition": "cloudy"}`)},
-
+				ID:    "call_nyc",
+				Name:  "get_weather",
+				Parts: []types.ContentPart{types.NewTextPart(`{"temperature": 65, "condition": "cloudy"}`)},
 			},
 		},
 	}
@@ -301,6 +298,249 @@ func TestToolProvider_MultipleToolResultsGrouped(t *testing.T) {
 	t.Logf("✅ Multiple tool results properly grouped in single user content")
 }
 
+// TestProcessToolMessage_TextOnly verifies that text-only tool results serialize correctly (regression).
+func TestProcessToolMessage_TextOnly(t *testing.T) {
+	msg := types.Message{
+		Role: "tool",
+		ToolResult: &types.MessageToolResult{
+			ID:   "call_1",
+			Name: "lookup",
+			Parts: []types.ContentPart{
+				types.NewTextPart(`{"status": "ok", "count": 42}`),
+			},
+		},
+	}
+
+	result := processToolMessage(msg)
+	funcResp, ok := result["functionResponse"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected functionResponse map, got %T", result["functionResponse"])
+	}
+
+	if funcResp["name"] != "lookup" {
+		t.Errorf("Expected name 'lookup', got '%v'", funcResp["name"])
+	}
+
+	response, ok := funcResp["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected response to be map, got %T", funcResp["response"])
+	}
+
+	// JSON object should be used directly (not wrapped in "result")
+	if response["status"] != "ok" {
+		t.Errorf("Expected status 'ok', got %v", response["status"])
+	}
+	if response["count"] != float64(42) {
+		t.Errorf("Expected count 42, got %v", response["count"])
+	}
+
+	// Should NOT have inlineData for text-only results
+	if _, hasInlineData := response["inlineData"]; hasInlineData {
+		t.Error("Text-only tool result should not have inlineData")
+	}
+}
+
+// TestProcessToolMessage_ImagePart verifies that tool results with image parts
+// emit inlineData with the correct mimeType.
+func TestProcessToolMessage_ImagePart(t *testing.T) {
+	imageData := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+	msg := types.Message{
+		Role: "tool",
+		ToolResult: &types.MessageToolResult{
+			ID:   "call_chart",
+			Name: "generate_chart",
+			Parts: []types.ContentPart{
+				types.NewTextPart("Chart generated successfully"),
+				{
+					Type: types.ContentTypeImage,
+					Media: &types.MediaContent{
+						MIMEType: "image/png",
+						Data:     &imageData,
+					},
+				},
+			},
+		},
+	}
+
+	result := processToolMessage(msg)
+	funcResp := result["functionResponse"].(map[string]any)
+
+	if funcResp["name"] != "generate_chart" {
+		t.Errorf("Expected name 'generate_chart', got '%v'", funcResp["name"])
+	}
+
+	response, ok := funcResp["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected response to be map, got %T", funcResp["response"])
+	}
+
+	// Should have text
+	if response["text"] != "Chart generated successfully" {
+		t.Errorf("Expected text 'Chart generated successfully', got '%v'", response["text"])
+	}
+
+	// Should have inlineData
+	inlineData, ok := response["inlineData"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected inlineData map, got %T", response["inlineData"])
+	}
+
+	if inlineData["mimeType"] != "image/png" {
+		t.Errorf("Expected mimeType 'image/png', got '%v'", inlineData["mimeType"])
+	}
+
+	if inlineData["data"] != imageData {
+		t.Errorf("Expected base64 data to match, got '%v'", inlineData["data"])
+	}
+}
+
+// TestProcessToolMessage_MixedContent tests tool results with text and media parts.
+func TestProcessToolMessage_MixedContent(t *testing.T) {
+	audioData := "AAABAAAAAAEAAQBFAAEAAQBF"
+	msg := types.Message{
+		Role: "tool",
+		ToolResult: &types.MessageToolResult{
+			ID:   "call_tts",
+			Name: "text_to_speech",
+			Parts: []types.ContentPart{
+				types.NewTextPart("Audio generated"),
+				{
+					Type: types.ContentTypeAudio,
+					Media: &types.MediaContent{
+						MIMEType: "audio/wav",
+						Data:     &audioData,
+					},
+				},
+			},
+		},
+	}
+
+	result := processToolMessage(msg)
+	funcResp := result["functionResponse"].(map[string]any)
+	response := funcResp["response"].(map[string]any)
+
+	// Should have both text and inlineData
+	if response["text"] != "Audio generated" {
+		t.Errorf("Expected text 'Audio generated', got '%v'", response["text"])
+	}
+
+	inlineData := response["inlineData"].(map[string]any)
+	if inlineData["mimeType"] != "audio/wav" {
+		t.Errorf("Expected mimeType 'audio/wav', got '%v'", inlineData["mimeType"])
+	}
+}
+
+// TestProcessToolMessage_ImageOnlyNoText tests tool results with only an image and no text.
+func TestProcessToolMessage_ImageOnlyNoText(t *testing.T) {
+	imageData := "iVBORw0KGgoAAAANSUhEUg"
+	msg := types.Message{
+		Role: "tool",
+		ToolResult: &types.MessageToolResult{
+			ID:   "call_screenshot",
+			Name: "take_screenshot",
+			Parts: []types.ContentPart{
+				{
+					Type: types.ContentTypeImage,
+					Media: &types.MediaContent{
+						MIMEType: "image/jpeg",
+						Data:     &imageData,
+					},
+				},
+			},
+		},
+	}
+
+	result := processToolMessage(msg)
+	funcResp := result["functionResponse"].(map[string]any)
+	response := funcResp["response"].(map[string]any)
+
+	// Should NOT have text key
+	if _, hasText := response["text"]; hasText {
+		t.Error("Image-only tool result should not have text key")
+	}
+
+	// Should have inlineData
+	inlineData := response["inlineData"].(map[string]any)
+	if inlineData["mimeType"] != "image/jpeg" {
+		t.Errorf("Expected mimeType 'image/jpeg', got '%v'", inlineData["mimeType"])
+	}
+	if inlineData["data"] != imageData {
+		t.Error("Expected base64 data to match")
+	}
+}
+
+// TestBuildTextToolResponse_JSONObject tests that JSON objects are used directly.
+func TestBuildTextToolResponse_JSONObject(t *testing.T) {
+	response := buildTextToolResponse(`{"key": "value"}`)
+	respMap, ok := response.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected map, got %T", response)
+	}
+	if respMap["key"] != "value" {
+		t.Errorf("Expected key 'value', got '%v'", respMap["key"])
+	}
+}
+
+// TestBuildTextToolResponse_PlainString tests that plain strings get wrapped.
+func TestBuildTextToolResponse_PlainString(t *testing.T) {
+	response := buildTextToolResponse("hello world")
+	respMap, ok := response.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected map, got %T", response)
+	}
+	if respMap["result"] != "hello world" {
+		t.Errorf("Expected result 'hello world', got '%v'", respMap["result"])
+	}
+}
+
+// TestBuildTextToolResponse_Primitive tests that primitives get wrapped.
+func TestBuildTextToolResponse_Primitive(t *testing.T) {
+	response := buildTextToolResponse("42")
+	respMap, ok := response.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected map, got %T", response)
+	}
+	if respMap["result"] != float64(42) {
+		t.Errorf("Expected result 42, got '%v'", respMap["result"])
+	}
+}
+
+// TestBuildMultimodalToolResponse tests the multimodal response builder directly.
+func TestBuildMultimodalToolResponse(t *testing.T) {
+	imgData := "base64data"
+	result := &types.MessageToolResult{
+		ID:   "call_1",
+		Name: "gen_image",
+		Parts: []types.ContentPart{
+			types.NewTextPart("Image ready"),
+			{
+				Type: types.ContentTypeImage,
+				Media: &types.MediaContent{
+					MIMEType: "image/png",
+					Data:     &imgData,
+				},
+			},
+		},
+	}
+
+	response := buildMultimodalToolResponse(result)
+
+	if response["text"] != "Image ready" {
+		t.Errorf("Expected text 'Image ready', got '%v'", response["text"])
+	}
+
+	inlineData, ok := response["inlineData"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected inlineData map, got %T", response["inlineData"])
+	}
+	if inlineData["mimeType"] != "image/png" {
+		t.Errorf("Expected mimeType 'image/png', got '%v'", inlineData["mimeType"])
+	}
+	if inlineData["data"] != imgData {
+		t.Error("Expected data to match")
+	}
+}
+
 // TestProcessToolMessage_UsesToolResultContent verifies that processToolMessage
 // uses ToolResult.Content (not msg.Content) for the tool response.
 // This is critical for streaming with tools to work correctly.
@@ -312,11 +552,11 @@ func TestProcessToolMessage_UsesToolResultContent(t *testing.T) {
 		Role: "tool",
 		// Content is intentionally empty - this is how the SDK creates tool result messages
 		ToolResult: &types.MessageToolResult{
-			ID:      "call_abc123",
-			Name:    "weather",
-			Parts:     []types.ContentPart{types.NewTextPart(`{"temperature": 73, "conditions": "sunny"}`)},
+			ID:    "call_abc123",
+			Name:  "weather",
+			Parts: []types.ContentPart{types.NewTextPart(`{"temperature": 73, "conditions": "sunny"}`)},
 
-			Error:   "",
+			Error: "",
 		},
 	}
 

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -144,36 +144,28 @@ func (p *ToolProvider) PredictWithTools(
 	return p.parseToolResponse(respBytes, predictResp)
 }
 
-// processToolMessage converts a tool result message to Gemini's functionResponse format
+// processToolMessage converts a tool result message to Gemini's functionResponse format.
+// For multimodal tool results (containing images, audio, etc.), it builds a response
+// with text and inlineData entries per Gemini's multimodal function response format.
 //
 //nolint:gocritic // hugeParam: types.Message is part of established API
 func processToolMessage(msg types.Message) map[string]any {
-	// Use ToolResult.GetTextContent() (not msg.Content which is empty for tool result messages)
-	content := msg.ToolResult.GetTextContent()
-
-	var response any
-	if err := json.Unmarshal([]byte(content), &response); err != nil {
-		// If unmarshal fails, wrap the content in an object
-		response = map[string]any{
-			"result": content,
-		}
-	} else {
-		// Successfully unmarshaled, but check if it's a map (object) or primitive
-		if _, isMap := response.(map[string]any); !isMap {
-			response = map[string]any{
-				"result": response,
-			}
-		}
-	}
-
 	// Debug: log tool message details
 	logger.Debug("Processing tool message",
 		"name", msg.ToolResult.Name,
-		"content_length", len(content),
+		"has_media", msg.ToolResult.HasMedia(),
 		"tool_result_id", msg.ToolResult.ID)
 
 	if msg.ToolResult.Name == "" {
 		logger.Warn("Tool message has empty Name field - functionResponse will be invalid")
+	}
+
+	var response any
+
+	if msg.ToolResult.HasMedia() {
+		response = buildMultimodalToolResponse(msg.ToolResult)
+	} else {
+		response = buildTextToolResponse(msg.ToolResult.GetTextContent())
 	}
 
 	return map[string]any{
@@ -182,6 +174,60 @@ func processToolMessage(msg types.Message) map[string]any {
 			"response": response,
 		},
 	}
+}
+
+// buildTextToolResponse creates a response object from text-only tool result content.
+// It attempts to parse the content as JSON; if successful and it's a JSON object,
+// it uses it directly. Otherwise, it wraps the content in a {"result": ...} object.
+func buildTextToolResponse(content string) any {
+	var response any
+	if err := json.Unmarshal([]byte(content), &response); err != nil {
+		return map[string]any{
+			"result": content,
+		}
+	}
+	// Successfully unmarshaled, but check if it's a map (object) or primitive
+	if _, isMap := response.(map[string]any); !isMap {
+		return map[string]any{
+			"result": response,
+		}
+	}
+	return response
+}
+
+// buildMultimodalToolResponse creates a response object from a multimodal tool result.
+// It emits text fields and inlineData entries for media parts, matching Gemini's format:
+//
+//	{
+//	  "text": "Chart generated successfully",
+//	  "inlineData": { "mimeType": "image/png", "data": "..." }
+//	}
+func buildMultimodalToolResponse(result *types.MessageToolResult) map[string]any {
+	response := make(map[string]any)
+
+	// Collect text content from all text parts
+	textContent := result.GetTextContent()
+	if textContent != "" {
+		response["text"] = textContent
+	}
+
+	// Find the first media part and add it as inlineData.
+	// Gemini's functionResponse.response is a flat object, so we use the first media part.
+	for _, part := range result.Parts {
+		if part.Type == types.ContentTypeText || part.Media == nil {
+			continue
+		}
+		mediaMap := convertMediaPartToMap(part)
+		if mediaMap != nil {
+			// mediaMap is {"inlineData": {"mimeType": ..., "data": ...}}
+			if inlineData, ok := mediaMap["inlineData"]; ok {
+				response["inlineData"] = inlineData
+				break
+			}
+		}
+	}
+
+	return response
 }
 
 // buildMessageParts creates parts array for a message including text, images, and tool calls


### PR DESCRIPTION
## Summary

Closes #620

- Updated `processToolMessage` in `runtime/providers/gemini/gemini_tools.go` to handle multimodal tool results (images, audio, etc.) by emitting `inlineData` entries in the `functionResponse` response object
- Extracted `buildTextToolResponse` and `buildMultimodalToolResponse` helper functions for clarity
- Text-only tool results continue to use the existing JSON parsing path (regression-safe)

## Changes

**`runtime/providers/gemini/gemini_tools.go`**:
- `processToolMessage` now checks `msg.ToolResult.HasMedia()` to decide between text-only and multimodal paths
- `buildTextToolResponse`: handles JSON parsing for text content (extracted from original function)
- `buildMultimodalToolResponse`: builds response with `text` and `inlineData` fields for multimodal results

**`runtime/providers/gemini/gemini_tool_results_test.go`**:
- `TestProcessToolMessage_TextOnly` - text-only regression test
- `TestProcessToolMessage_ImagePart` - image with text
- `TestProcessToolMessage_MixedContent` - audio with text
- `TestProcessToolMessage_ImageOnlyNoText` - image without text
- `TestBuildTextToolResponse_*` - unit tests for text response builder
- `TestBuildMultimodalToolResponse` - unit test for multimodal response builder

## Test plan

- [x] All existing Gemini tests pass (`go test ./runtime/providers/gemini/... -count=1`)
- [x] New tests cover text-only, image, audio, and mixed content cases
- [x] Coverage on changed file: 88.3% (threshold: 80%)
- [x] No new lint issues (`golangci-lint run --new-from-rev=HEAD`)