### PR TITLE
feat: SDK deferred tool resolution with multimodal Parts

### DIFF
--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -173,15 +173,8 @@ func (e *clientExecutor) ExecuteAsync(
 		}, nil
 	}
 
-	// Handler present → execute synchronously
-	resultJSON, err := e.executeHandler(ctx, handler, descriptor, argsMap)
-	if err != nil {
-		return nil, err
-	}
-	return &tools.ToolExecutionResult{
-		Status:  tools.ToolStatusComplete,
-		Content: resultJSON,
-	}, nil
+	// Handler present → execute synchronously (with multimodal support)
+	return e.executeHandlerAsync(ctx, handler, descriptor, argsMap)
 }
 
 // SendToolResult provides the result for a deferred client tool.
@@ -199,6 +192,26 @@ func (c *Conversation) SendToolResult(_ context.Context, callID string, result a
 	c.resolvedStore.Add(&sdktools.ToolResolution{
 		ID:         callID,
 		ResultJSON: resultJSON,
+	})
+	return nil
+}
+
+// SendToolResultMultimodal provides a multimodal result for a deferred client tool.
+//
+// callID must match one of the [PendingClientTool.CallID] values returned in
+// the [Response]. parts should contain one or more [types.ContentPart] values
+// (text, images, audio, etc.) that will be sent directly to the LLM.
+//
+// After all pending tools have been resolved (via SendToolResult,
+// SendToolResultMultimodal, or RejectClientTool), call [Conversation.Resume]
+// to continue the pipeline.
+func (c *Conversation) SendToolResultMultimodal(_ context.Context, callID string, parts []types.ContentPart) error {
+	if len(parts) == 0 {
+		return fmt.Errorf("parts must not be empty")
+	}
+	c.resolvedStore.Add(&sdktools.ToolResolution{
+		ID:    callID,
+		Parts: parts,
 	})
 	return nil
 }
@@ -310,17 +323,25 @@ func (c *Conversation) buildToolResultMessages() ([]types.Message, error) {
 
 	toolMsgs := make([]types.Message, 0, len(resolutions))
 	for _, res := range resolutions {
-		var content string
-		if res.Rejected {
-			content = fmt.Sprintf("Tool rejected: %s", res.RejectionReason)
-		} else if res.Error != nil {
-			content = fmt.Sprintf("Tool error: %v", res.Error)
-		} else {
-			content = string(res.ResultJSON)
+		var toolResult types.MessageToolResult
+
+		switch {
+		case res.Rejected:
+			toolResult = types.NewTextToolResult(res.ID, "",
+				fmt.Sprintf("Tool rejected: %s", res.RejectionReason))
+		case res.Error != nil:
+			toolResult = types.NewTextToolResult(res.ID, "",
+				fmt.Sprintf("Tool error: %v", res.Error))
+		case len(res.Parts) > 0:
+			toolResult = types.MessageToolResult{
+				ID:    res.ID,
+				Parts: res.Parts,
+			}
+		default:
+			toolResult = types.NewTextToolResult(res.ID, "", string(res.ResultJSON))
 		}
-		toolMsgs = append(toolMsgs, types.NewToolResultMessage(
-			types.NewTextToolResult(res.ID, "", content),
-		))
+
+		toolMsgs = append(toolMsgs, types.NewToolResultMessage(toolResult))
 	}
 
 	return toolMsgs, nil
@@ -358,4 +379,49 @@ func (e *clientExecutor) executeHandler(
 	}
 
 	return resultJSON, nil
+}
+
+// executeHandlerAsync runs a ClientToolHandler and returns a ToolExecutionResult.
+// If the handler returns []types.ContentPart, the parts are stored directly
+// instead of being JSON-serialized. Other return types are JSON-serialized as usual.
+func (e *clientExecutor) executeHandlerAsync(
+	ctx context.Context, handler ClientToolHandler,
+	descriptor *tools.ToolDescriptor, argsMap map[string]any,
+) (*tools.ToolExecutionResult, error) {
+	req := ClientToolRequest{
+		ToolName:   descriptor.Name,
+		Args:       argsMap,
+		Descriptor: descriptor,
+	}
+
+	if descriptor.ClientConfig != nil {
+		if descriptor.ClientConfig.Consent != nil {
+			req.ConsentMsg = descriptor.ClientConfig.Consent.Message
+		}
+		req.Categories = descriptor.ClientConfig.Categories
+	}
+
+	result, err := handler(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for multimodal content parts
+	if parts, ok := result.([]types.ContentPart); ok {
+		return &tools.ToolExecutionResult{
+			Status: tools.ToolStatusComplete,
+			Parts:  parts,
+		}, nil
+	}
+
+	// Default: JSON-serialize result
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize client tool result: %w", err)
+	}
+
+	return &tools.ToolExecutionResult{
+		Status:  tools.ToolStatusComplete,
+		Content: resultJSON,
+	}, nil
 }

--- a/sdk/client_tools_test.go
+++ b/sdk/client_tools_test.go
@@ -514,6 +514,151 @@ func TestResumeStream_WithResolutions(t *testing.T) {
 	assert.NotNil(t, lastChunk.Message)
 }
 
+func TestSendToolResultMultimodal(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	text := "screenshot of the result"
+	imgData := "base64data"
+	parts := []types.ContentPart{
+		types.NewTextPart(text),
+		types.NewImagePartFromData(imgData, "image/png", nil),
+	}
+
+	err := conv.SendToolResultMultimodal(context.Background(), "call-mm", parts)
+	require.NoError(t, err)
+
+	resolutions := conv.resolvedStore.PopAll()
+	require.Len(t, resolutions, 1)
+	assert.Equal(t, "call-mm", resolutions[0].ID)
+	require.Len(t, resolutions[0].Parts, 2)
+	assert.Equal(t, "text", resolutions[0].Parts[0].Type)
+	assert.Equal(t, "image", resolutions[0].Parts[1].Type)
+}
+
+func TestSendToolResultMultimodal_EmptyParts(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	err := conv.SendToolResultMultimodal(context.Background(), "call-mm", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parts must not be empty")
+
+	err = conv.SendToolResultMultimodal(context.Background(), "call-mm", []types.ContentPart{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parts must not be empty")
+}
+
+func TestBuildToolResultMessages_MultimodalParts(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	text := "here is the image"
+	imgData := "base64imagedata"
+	parts := []types.ContentPart{
+		types.NewTextPart(text),
+		types.NewImagePartFromData(imgData, "image/jpeg", nil),
+	}
+
+	conv.resolvedStore.Add(&sdktools.ToolResolution{
+		ID:    "call-mm",
+		Parts: parts,
+	})
+
+	msgs, err := conv.buildToolResultMessages()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	toolResult := msgs[0].ToolResult
+	require.NotNil(t, toolResult)
+	require.Len(t, toolResult.Parts, 2)
+	assert.Equal(t, "text", toolResult.Parts[0].Type)
+	assert.Equal(t, &text, toolResult.Parts[0].Text)
+	assert.Equal(t, "image", toolResult.Parts[1].Type)
+	assert.Equal(t, "image/jpeg", toolResult.Parts[1].Media.MIMEType)
+}
+
+func TestBuildToolResultMessages_TextOnlyWrapsAsContentPart(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	err := conv.SendToolResult(context.Background(), "call-text", map[string]any{"status": "ok"})
+	require.NoError(t, err)
+
+	msgs, err := conv.buildToolResultMessages()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	toolResult := msgs[0].ToolResult
+	require.NotNil(t, toolResult)
+	require.Len(t, toolResult.Parts, 1)
+	assert.Equal(t, "text", toolResult.Parts[0].Type)
+	assert.Contains(t, *toolResult.Parts[0].Text, "status")
+}
+
+func TestBuildToolResultMessages_RejectionWrapsAsContentPart(t *testing.T) {
+	conv := newTestConversation()
+	conv.resolvedStore = sdktools.NewResolvedStore()
+
+	conv.RejectClientTool(context.Background(), "call-rej", "not allowed")
+
+	msgs, err := conv.buildToolResultMessages()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	toolResult := msgs[0].ToolResult
+	require.NotNil(t, toolResult)
+	require.Len(t, toolResult.Parts, 1)
+	assert.Equal(t, "text", toolResult.Parts[0].Type)
+	assert.Contains(t, *toolResult.Parts[0].Text, "Tool rejected: not allowed")
+}
+
+func TestClientExecutor_ExecuteAsync_ReturnsContentParts(t *testing.T) {
+	conv := newTestConversation()
+
+	text := "captured image"
+	conv.OnClientTool("camera", func(_ context.Context, _ ClientToolRequest) (any, error) {
+		return []types.ContentPart{
+			types.NewTextPart(text),
+			types.NewImagePartFromData("base64img", "image/png", nil),
+		}, nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{Name: "camera", Mode: "client"}
+	result, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, tools.ToolStatusComplete, result.Status)
+	require.Len(t, result.Parts, 2)
+	assert.Equal(t, "text", result.Parts[0].Type)
+	assert.Equal(t, "image", result.Parts[1].Type)
+	// Content should be empty since parts take precedence
+	assert.Empty(t, result.Content)
+}
+
+func TestClientExecutor_ExecuteAsync_NonContentPartsJSON(t *testing.T) {
+	conv := newTestConversation()
+	conv.OnClientTool("simple", func(_ context.Context, _ ClientToolRequest) (any, error) {
+		return map[string]any{"result": "ok"}, nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{Name: "simple", Mode: "client"}
+	result, err := exec.ExecuteAsync(context.Background(), desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, tools.ToolStatusComplete, result.Status)
+	assert.NotEmpty(t, result.Content)
+	assert.Empty(t, result.Parts)
+}
+
 func TestBuildToolResultMessages_ErrorBranch(t *testing.T) {
 	conv := newTestConversation()
 	conv.resolvedStore = sdktools.NewResolvedStore()

--- a/sdk/tools/pending.go
+++ b/sdk/tools/pending.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 const (
@@ -244,6 +246,11 @@ type ToolResolution struct {
 
 	// ResultJSON is the JSON-encoded result
 	ResultJSON json.RawMessage
+
+	// Parts contains multimodal content parts for the tool result.
+	// When set, these are used directly as MessageToolResult.Parts,
+	// taking precedence over ResultJSON.
+	Parts []types.ContentPart
 
 	// Error if execution failed
 	Error error

--- a/sdk/tools/pending_test.go
+++ b/sdk/tools/pending_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -288,6 +289,32 @@ func TestResolvedStore(t *testing.T) {
 
 		store.PopAll()
 		assert.Equal(t, 0, store.Len())
+	})
+}
+
+func TestToolResolution_PartsField(t *testing.T) {
+	t.Run("parts field stores multimodal content", func(t *testing.T) {
+		text := "result text"
+		imgData := "base64data"
+		res := &ToolResolution{
+			ID: "call-1",
+			Parts: []types.ContentPart{
+				types.NewTextPart(text),
+				types.NewImagePartFromData(imgData, "image/png", nil),
+			},
+		}
+
+		assert.Equal(t, "call-1", res.ID)
+		require.Len(t, res.Parts, 2)
+		assert.Equal(t, "text", res.Parts[0].Type)
+		assert.Equal(t, &text, res.Parts[0].Text)
+		assert.Equal(t, "image", res.Parts[1].Type)
+		assert.Equal(t, "image/png", res.Parts[1].Media.MIMEType)
+	})
+
+	t.Run("nil parts by default", func(t *testing.T) {
+		res := &ToolResolution{ID: "call-2"}
+		assert.Nil(t, res.Parts)
 	})
 }
 


### PR DESCRIPTION
## Summary

Closes #623

- Adds `Parts []types.ContentPart` field to `ToolResolution` for multimodal content
- Adds `SendToolResultMultimodal()` method on `Conversation` for submitting multimodal deferred tool results
- Updates `buildToolResultMessages()` to propagate `Parts` directly to `MessageToolResult` when populated; text-only, rejection, and error resolutions continue to wrap as text `ContentPart`s via `NewTextToolResult`
- Adds `executeHandlerAsync()` on `clientExecutor` that detects `[]types.ContentPart` returns via type assertion and populates `ToolExecutionResult.Parts` instead of JSON-serializing
- `ClientToolHandler` signature (`func(ctx, req) (any, error)`) is unchanged -- handlers returning `[]ContentPart` get multimodal support automatically

## Test plan

- [x] `ToolResolution` has `Parts` field (unit test)
- [x] `SendToolResultMultimodal` stores parts on resolution
- [x] `SendToolResultMultimodal` rejects empty parts
- [x] `buildToolResultMessages` propagates Parts to `MessageToolResult`
- [x] `buildToolResultMessages` wraps text-only `ResultJSON` as text `ContentPart`
- [x] `buildToolResultMessages` wraps rejection as text `ContentPart`
- [x] `ClientToolHandler` returning `[]ContentPart` populates `ToolExecutionResult.Parts`
- [x] Non-`ContentPart` return types continue JSON serialization
- [x] Existing `SendToolResult` continues working
- [x] Coverage: 92.1% on `client_tools.go`, 97.7% on `pending.go`