### PR TITLE
feat: tool_result_has_media and tool_result_media_type assertions

### DIFF
--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -784,6 +784,8 @@ func TestRegisterInit(t *testing.T) {
 		"tool_call_count",
 		"tool_result_includes",
 		"tool_result_matches",
+		"tool_result_has_media",
+		"tool_result_media_type",
 		"tool_call_sequence",
 		"tool_call_chain",
 		"tool_calls_with_args",

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -28,6 +28,8 @@ func init() {
 	evals.RegisterDefault(&ToolCallCountHandler{})
 	evals.RegisterDefault(&ToolResultIncludesHandler{})
 	evals.RegisterDefault(&ToolResultMatchesHandler{})
+	evals.RegisterDefault(&ToolResultHasMediaHandler{})
+	evals.RegisterDefault(&ToolResultMediaTypeHandler{})
 	evals.RegisterDefault(&ToolCallSequenceHandler{})
 	evals.RegisterDefault(&ToolCallChainHandler{})
 	evals.RegisterDefault(&ToolCallsWithArgsHandler{})

--- a/runtime/evals/handlers/tool_result_media.go
+++ b/runtime/evals/handlers/tool_result_media.go
@@ -1,0 +1,196 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// ToolResultHasMediaHandler asserts that a named tool call returned media content of a given type.
+// Params: tool string, media_type string ("image", "audio", "video", "document").
+type ToolResultHasMediaHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolResultHasMediaHandler) Type() string { return "tool_result_has_media" }
+
+// Eval checks that a tool result contains ContentPart entries with the specified media type.
+func (h *ToolResultHasMediaHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	tool, _ := params["tool"].(string)
+	mediaType, _ := params["media_type"].(string)
+
+	if mediaType == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no media_type specified",
+		}, nil
+	}
+
+	for _, tc := range evalCtx.ToolCalls {
+		if tool != "" && tc.ToolName != tool {
+			continue
+		}
+		parts := extractContentParts(tc.Result)
+		for _, p := range parts {
+			if strings.EqualFold(p.Type, mediaType) {
+				return &evals.EvalResult{
+					Type:        h.Type(),
+					Passed:      true,
+					Explanation: fmt.Sprintf("tool %q returned media of type %q", tc.ToolName, mediaType),
+					Details: map[string]any{
+						"tool":       tc.ToolName,
+						"media_type": mediaType,
+					},
+				}, nil
+			}
+		}
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      false,
+		Explanation: fmt.Sprintf("no tool result contains media of type %q", mediaType),
+		Details: map[string]any{
+			"tool":       tool,
+			"media_type": mediaType,
+		},
+	}, nil
+}
+
+// ToolResultMediaTypeHandler asserts the MIME type of media in a tool result.
+// Params: tool string, mime_type string.
+type ToolResultMediaTypeHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolResultMediaTypeHandler) Type() string { return "tool_result_media_type" }
+
+// Eval checks that a tool result contains a non-text ContentPart with the specified MIME type.
+func (h *ToolResultMediaTypeHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	tool, _ := params["tool"].(string)
+	mimeType, _ := params["mime_type"].(string)
+
+	if mimeType == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "no mime_type specified",
+		}, nil
+	}
+
+	for _, tc := range evalCtx.ToolCalls {
+		if tool != "" && tc.ToolName != tool {
+			continue
+		}
+		parts := extractContentParts(tc.Result)
+		for _, p := range parts {
+			if p.Type == types.ContentTypeText {
+				continue
+			}
+			if p.Media != nil && strings.EqualFold(p.Media.MIMEType, mimeType) {
+				return &evals.EvalResult{
+					Type:        h.Type(),
+					Passed:      true,
+					Explanation: fmt.Sprintf("tool %q returned media with MIME type %q", tc.ToolName, mimeType),
+					Details: map[string]any{
+						"tool":      tc.ToolName,
+						"mime_type": mimeType,
+					},
+				}, nil
+			}
+		}
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      false,
+		Explanation: fmt.Sprintf("no tool result contains media with MIME type %q", mimeType),
+		Details: map[string]any{
+			"tool":      tool,
+			"mime_type": mimeType,
+		},
+	}, nil
+}
+
+// extractContentParts attempts to extract []types.ContentPart from a tool result.
+// The Result field is typed as `any`, so we try direct type assertion first,
+// then fall back to []any with map-based extraction.
+func extractContentParts(result any) []types.ContentPart {
+	if result == nil {
+		return nil
+	}
+
+	// Direct type assertion for []types.ContentPart
+	if parts, ok := result.([]types.ContentPart); ok {
+		return parts
+	}
+
+	// Try []any (e.g., from JSON deserialization)
+	slice, ok := result.([]any)
+	if !ok {
+		return nil
+	}
+
+	var parts []types.ContentPart
+	for _, item := range slice {
+		if part, ok := parseContentPartFromMap(item); ok {
+			parts = append(parts, part)
+		}
+	}
+
+	return parts
+}
+
+// parseContentPartFromMap converts a map[string]any to a ContentPart.
+// Returns false if the item is not a valid content part map.
+func parseContentPartFromMap(item any) (types.ContentPart, bool) {
+	m, ok := item.(map[string]any)
+	if !ok {
+		return types.ContentPart{}, false
+	}
+
+	partType, _ := m["type"].(string)
+	if partType == "" {
+		return types.ContentPart{}, false
+	}
+
+	part := types.ContentPart{Type: partType}
+
+	if text, ok := m["text"].(string); ok {
+		part.Text = &text
+	}
+
+	if mediaMap, ok := m["media"].(map[string]any); ok {
+		part.Media = parseMediaFromMap(mediaMap)
+	}
+
+	return part, true
+}
+
+// parseMediaFromMap converts a map[string]any to a MediaContent.
+func parseMediaFromMap(mediaMap map[string]any) *types.MediaContent {
+	media := &types.MediaContent{}
+	media.MIMEType, _ = mediaMap["mime_type"].(string)
+
+	if data, ok := mediaMap["data"].(string); ok {
+		media.Data = &data
+	}
+	if fp, ok := mediaMap["file_path"].(string); ok {
+		media.FilePath = &fp
+	}
+	if u, ok := mediaMap["url"].(string); ok {
+		media.URL = &u
+	}
+
+	return media
+}

--- a/runtime/evals/handlers/tool_result_media_test.go
+++ b/runtime/evals/handlers/tool_result_media_test.go
@@ -1,0 +1,509 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// --- ToolResultHasMedia ---
+
+func TestToolResultHasMediaHandler_Type(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	if h.Type() != "tool_result_has_media" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolResultHasMediaHandler_Pass(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "generate_chart",
+				Result: []types.ContentPart{
+					types.NewImagePartFromData("abc123", "image/png", nil),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":       "generate_chart",
+		"media_type": "image",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolResultHasMediaHandler_PassAudio(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "synthesize_speech",
+				Result: []types.ContentPart{
+					types.NewAudioPartFromData("audiodata", "audio/mp3"),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":       "synthesize_speech",
+		"media_type": "audio",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolResultHasMediaHandler_FailWrongType(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "generate_chart",
+				Result: []types.ContentPart{
+					types.NewImagePartFromData("abc123", "image/png", nil),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":       "generate_chart",
+		"media_type": "audio",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for wrong media type")
+	}
+}
+
+func TestToolResultHasMediaHandler_FailWrongTool(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "other_tool",
+				Result: []types.ContentPart{
+					types.NewImagePartFromData("abc123", "image/png", nil),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":       "generate_chart",
+		"media_type": "image",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for wrong tool name")
+	}
+}
+
+func TestToolResultHasMediaHandler_NoMediaType(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no media_type")
+	}
+}
+
+func TestToolResultHasMediaHandler_NilResult(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "generate_chart", Result: nil},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":       "generate_chart",
+		"media_type": "image",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for nil result")
+	}
+}
+
+func TestToolResultHasMediaHandler_StringResult(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "generate_chart", Result: "plain string result"},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":       "generate_chart",
+		"media_type": "image",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for string result")
+	}
+}
+
+func TestToolResultHasMediaHandler_NoToolFilter(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "any_tool",
+				Result: []types.ContentPart{
+					types.NewVideoPartFromData("videodata", "video/mp4"),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"media_type": "video",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass without tool filter: %s", result.Explanation)
+	}
+}
+
+func TestToolResultHasMediaHandler_CaseInsensitive(t *testing.T) {
+	h := &ToolResultHasMediaHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "gen",
+				Result: []types.ContentPart{
+					types.NewImagePartFromData("data", "image/png", nil),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":       "gen",
+		"media_type": "Image",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass with case-insensitive media_type: %s", result.Explanation)
+	}
+}
+
+// --- ToolResultMediaType ---
+
+func TestToolResultMediaTypeHandler_Type(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	if h.Type() != "tool_result_media_type" {
+		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestToolResultMediaTypeHandler_Pass(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "generate_chart",
+				Result: []types.ContentPart{
+					types.NewImagePartFromData("abc123", "image/png", nil),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":      "generate_chart",
+		"mime_type": "image/png",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestToolResultMediaTypeHandler_FailWrongMIME(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "generate_chart",
+				Result: []types.ContentPart{
+					types.NewImagePartFromData("abc123", "image/png", nil),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":      "generate_chart",
+		"mime_type": "image/jpeg",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for wrong MIME type")
+	}
+}
+
+func TestToolResultMediaTypeHandler_NoMIMEType(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail with no mime_type")
+	}
+}
+
+func TestToolResultMediaTypeHandler_SkipsTextParts(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "generate_chart",
+				Result: []types.ContentPart{
+					types.NewTextPart("chart description"),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":      "generate_chart",
+		"mime_type": "image/png",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail when only text parts exist")
+	}
+}
+
+func TestToolResultMediaTypeHandler_NilResult(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "generate_chart", Result: nil},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":      "generate_chart",
+		"mime_type": "image/png",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for nil result")
+	}
+}
+
+func TestToolResultMediaTypeHandler_NoToolFilter(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "any_tool",
+				Result: []types.ContentPart{
+					types.NewAudioPartFromData("audio", "audio/mpeg"),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"mime_type": "audio/mpeg",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass without tool filter: %s", result.Explanation)
+	}
+}
+
+func TestToolResultMediaTypeHandler_CaseInsensitive(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "gen",
+				Result: []types.ContentPart{
+					types.NewImagePartFromData("data", "image/png", nil),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":      "gen",
+		"mime_type": "Image/PNG",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Passed {
+		t.Fatalf("expected pass with case-insensitive mime_type: %s", result.Explanation)
+	}
+}
+
+func TestToolResultMediaTypeHandler_WrongTool(t *testing.T) {
+	h := &ToolResultMediaTypeHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				ToolName: "other_tool",
+				Result: []types.ContentPart{
+					types.NewImagePartFromData("data", "image/png", nil),
+				},
+			},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"tool":      "generate_chart",
+		"mime_type": "image/png",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Passed {
+		t.Fatal("expected fail for wrong tool name")
+	}
+}
+
+// --- extractContentParts ---
+
+func TestExtractContentParts_MapBased(t *testing.T) {
+	// Simulate JSON-deserialized result ([]any with map[string]any)
+	result := []any{
+		map[string]any{
+			"type": "image",
+			"media": map[string]any{
+				"mime_type": "image/png",
+				"data":      "base64data",
+			},
+		},
+		map[string]any{
+			"type": "text",
+			"text": "a caption",
+		},
+	}
+
+	parts := extractContentParts(result)
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+
+	if parts[0].Type != "image" {
+		t.Fatalf("expected image type, got %s", parts[0].Type)
+	}
+	if parts[0].Media == nil || parts[0].Media.MIMEType != "image/png" {
+		t.Fatal("expected media with MIME type image/png")
+	}
+
+	if parts[1].Type != "text" || parts[1].Text == nil || *parts[1].Text != "a caption" {
+		t.Fatal("expected text part with 'a caption'")
+	}
+}
+
+func TestExtractContentParts_MapWithURLAndFilePath(t *testing.T) {
+	result := []any{
+		map[string]any{
+			"type": "document",
+			"media": map[string]any{
+				"mime_type": "application/pdf",
+				"file_path": "/tmp/doc.pdf",
+			},
+		},
+		map[string]any{
+			"type": "image",
+			"media": map[string]any{
+				"mime_type": "image/jpeg",
+				"url":       "https://example.com/img.jpg",
+			},
+		},
+	}
+
+	parts := extractContentParts(result)
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	if parts[0].Media == nil || parts[0].Media.FilePath == nil || *parts[0].Media.FilePath != "/tmp/doc.pdf" {
+		t.Fatal("expected file_path on first part")
+	}
+	if parts[1].Media == nil || parts[1].Media.URL == nil || *parts[1].Media.URL != "https://example.com/img.jpg" {
+		t.Fatal("expected url on second part")
+	}
+}
+
+func TestExtractContentParts_InvalidSliceItems(t *testing.T) {
+	// Non-map items and maps without type should be skipped
+	result := []any{
+		"not a map",
+		42,
+		map[string]any{"no_type": "value"},
+		map[string]any{"type": "image", "media": map[string]any{"mime_type": "image/png"}},
+	}
+
+	parts := extractContentParts(result)
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 valid part, got %d", len(parts))
+	}
+}
+
+func TestExtractContentParts_NonSlice(t *testing.T) {
+	parts := extractContentParts("just a string")
+	if len(parts) != 0 {
+		t.Fatalf("expected 0 parts for string input, got %d", len(parts))
+	}
+}
+
+// --- Registration ---
+
+func TestToolResultMediaHandlersRegistered(t *testing.T) {
+	registry := evals.NewEvalTypeRegistry()
+	registry.Register(&ToolResultHasMediaHandler{})
+	registry.Register(&ToolResultMediaTypeHandler{})
+
+	if _, err := registry.Get("tool_result_has_media"); err != nil {
+		t.Fatalf("tool_result_has_media not registered: %v", err)
+	}
+	if _, err := registry.Get("tool_result_media_type"); err != nil {
+		t.Fatalf("tool_result_media_type not registered: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `tool_result_has_media` eval handler that asserts a tool call returned media content of a given type (image, audio, video, document)
- Adds `tool_result_media_type` eval handler that asserts the MIME type of media in a tool result
- Both handlers inspect `ToolCallRecord.Result` (typed as `any`) with type assertion to `[]types.ContentPart` and fallback to map-based extraction for JSON-deserialized results

Closes #625

## Test plan
- [x] 24 new unit tests covering pass/fail paths, edge cases (nil result, string result, wrong tool, no filter, case insensitivity), and map-based extraction
- [x] Both handlers registered in default registry (TestRegisterInit updated from 45 to 47)
- [x] 100% coverage on new code (`tool_result_media.go`)
- [x] `golangci-lint` passes with zero issues
- [x] Full `runtime/evals/handlers` test suite passes