### PR TITLE
feat: A2A executor ExtractResponseParts and MultimodalExecutor

### DIFF
--- a/runtime/a2a/executor.go
+++ b/runtime/a2a/executor.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // Default retry constants for A2A executor.
@@ -88,7 +89,13 @@ func WithMaxClients(n int) ExecutorOption {
 	return func(e *Executor) { e.maxClients = n }
 }
 
-// Executor implements tools.Executor for A2A agent tools.
+// Compile-time interface checks.
+var (
+	_ tools.Executor           = (*Executor)(nil)
+	_ tools.MultimodalExecutor = (*Executor)(nil)
+)
+
+// Executor implements tools.Executor and tools.MultimodalExecutor for A2A agent tools.
 // It dispatches tool calls to remote A2A agents via the A2A client.
 // The executor maintains a cache of A2A clients with TTL-based eviction.
 // Call Close when the executor is no longer needed to release resources.
@@ -128,26 +135,28 @@ func NewExecutor(opts ...ExecutorOption) *Executor {
 // Name returns "a2a" to match the Mode on A2A tool descriptors.
 func (e *Executor) Name() string { return "a2a" }
 
-// Execute calls a remote A2A agent with the tool arguments and returns the response.
-func (e *Executor) Execute(
-	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
-) (json.RawMessage, error) {
+// a2aInput holds parsed arguments for an A2A tool call.
+type a2aInput struct {
+	Query     string `json:"query"`
+	ImageURL  string `json:"image_url,omitempty"`
+	ImageData string `json:"image_data,omitempty"`
+	AudioData string `json:"audio_data,omitempty"`
+}
+
+// buildRequest validates the descriptor, parses args, and constructs a SendMessageRequest.
+// It returns the A2A config and the request, or an error.
+func buildRequest(
+	descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (*tools.A2AConfig, *SendMessageRequest, error) {
 	if descriptor.A2AConfig == nil {
-		return nil, fmt.Errorf("a2a executor: tool %q has no A2AConfig", descriptor.Name)
+		return nil, nil, fmt.Errorf("a2a executor: tool %q has no A2AConfig", descriptor.Name)
 	}
 
 	cfg := descriptor.A2AConfig
-	client := e.getOrCreateClient(cfg.AgentURL)
 
-	// Parse arguments
-	var input struct {
-		Query     string `json:"query"`
-		ImageURL  string `json:"image_url,omitempty"`
-		ImageData string `json:"image_data,omitempty"`
-		AudioData string `json:"audio_data,omitempty"`
-	}
+	var input a2aInput
 	if err := json.Unmarshal(args, &input); err != nil {
-		return nil, fmt.Errorf("a2a executor: parse args: %w", err)
+		return nil, nil, fmt.Errorf("a2a executor: parse args: %w", err)
 	}
 
 	// Build message parts
@@ -178,7 +187,15 @@ func (e *Executor) Execute(
 		},
 	}
 
-	// Apply timeout on top of the caller's context
+	return cfg, req, nil
+}
+
+// executeRequest sends an A2A request with timeout and retry, returning the completed task.
+func (e *Executor) executeRequest(
+	ctx context.Context, cfg *tools.A2AConfig, req *SendMessageRequest,
+) (*Task, error) {
+	client := e.getOrCreateClient(cfg.AgentURL)
+
 	if cfg.TimeoutMs > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(cfg.TimeoutMs)*time.Millisecond)
@@ -189,10 +206,51 @@ func (e *Executor) Execute(
 	if err != nil {
 		return nil, fmt.Errorf("a2a executor: send message: %w", err)
 	}
+	return task, nil
+}
+
+// Execute calls a remote A2A agent with the tool arguments and returns the response.
+func (e *Executor) Execute(
+	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
+	cfg, req, err := buildRequest(descriptor, args)
+	if err != nil {
+		return nil, err
+	}
+
+	task, err := e.executeRequest(ctx, cfg, req)
+	if err != nil {
+		return nil, err
+	}
 
 	responseText := ExtractResponseText(task)
 	result := map[string]string{"response": responseText}
 	return json.Marshal(result)
+}
+
+// ExecuteMultimodal calls a remote A2A agent and returns both JSON result and multimodal content parts.
+// It implements [tools.MultimodalExecutor].
+func (e *Executor) ExecuteMultimodal(
+	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, []types.ContentPart, error) {
+	cfg, req, err := buildRequest(descriptor, args)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	task, err := e.executeRequest(ctx, cfg, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	parts := ExtractResponseParts(task)
+	responseText := ExtractResponseText(task)
+	result := map[string]string{"response": responseText}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return nil, nil, fmt.Errorf("a2a executor: marshal result: %w", err)
+	}
+	return raw, parts, nil
 }
 
 // sendWithRetry wraps client.SendMessage with exponential backoff retry logic.
@@ -442,6 +500,35 @@ func (e *Executor) getOrCreateClient(agentURL string) *Client {
 	c := NewClient(agentURL)
 	e.clients[agentURL] = &clientEntry{client: c, lastUsed: now}
 	return c
+}
+
+// ExtractResponseParts converts all A2A Parts from a completed task into PromptKit ContentParts.
+// It collects parts from the status message (if present) and all artifacts.
+// Parts that fail conversion (e.g., structured data) are silently skipped.
+func ExtractResponseParts(task *Task) []types.ContentPart {
+	var result []types.ContentPart
+
+	if task.Status.Message != nil {
+		for i := range task.Status.Message.Parts {
+			cp, err := PartToContentPart(&task.Status.Message.Parts[i])
+			if err != nil {
+				continue
+			}
+			result = append(result, cp)
+		}
+	}
+
+	for _, artifact := range task.Artifacts {
+		for i := range artifact.Parts {
+			cp, err := PartToContentPart(&artifact.Parts[i])
+			if err != nil {
+				continue
+			}
+			result = append(result, cp)
+		}
+	}
+
+	return result
 }
 
 // ExtractResponseText extracts text from a completed A2A task.

--- a/runtime/a2a/executor_test.go
+++ b/runtime/a2a/executor_test.go
@@ -8,7 +8,11 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// Compile-time interface check.
+var _ tools.MultimodalExecutor = (*Executor)(nil)
 
 func TestExecutor_Name(t *testing.T) {
 	e := NewExecutor()
@@ -416,5 +420,280 @@ func TestExtractResponseText_StatusPrecedence(t *testing.T) {
 	// Status message text takes precedence over artifacts
 	if got := ExtractResponseText(task); got != "from status" {
 		t.Errorf("got %q, want %q", got, "from status")
+	}
+}
+
+func TestExtractResponseParts_TextOnly(t *testing.T) {
+	text := "hello world"
+	task := &Task{
+		Status: TaskStatus{
+			Message: &Message{
+				Parts: []Part{{Text: &text}},
+			},
+		},
+	}
+	parts := ExtractResponseParts(task)
+	if len(parts) != 1 {
+		t.Fatalf("got %d parts, want 1", len(parts))
+	}
+	if parts[0].Type != types.ContentTypeText {
+		t.Errorf("type = %q, want %q", parts[0].Type, types.ContentTypeText)
+	}
+	if parts[0].Text == nil || *parts[0].Text != "hello world" {
+		t.Errorf("text = %v, want %q", parts[0].Text, "hello world")
+	}
+}
+
+func TestExtractResponseParts_ImageBase64(t *testing.T) {
+	task := &Task{
+		Status: TaskStatus{
+			Message: &Message{
+				Parts: []Part{
+					{Raw: []byte("raw-image-bytes"), MediaType: "image/png"},
+				},
+			},
+		},
+	}
+	parts := ExtractResponseParts(task)
+	if len(parts) != 1 {
+		t.Fatalf("got %d parts, want 1", len(parts))
+	}
+	if parts[0].Type != types.ContentTypeImage {
+		t.Errorf("type = %q, want %q", parts[0].Type, types.ContentTypeImage)
+	}
+	if parts[0].Media == nil || parts[0].Media.Data == nil {
+		t.Fatal("expected media with data")
+	}
+}
+
+func TestExtractResponseParts_URLPart(t *testing.T) {
+	url := "https://example.com/image.png"
+	task := &Task{
+		Status: TaskStatus{
+			Message: &Message{
+				Parts: []Part{
+					{URL: &url, MediaType: "image/png"},
+				},
+			},
+		},
+	}
+	parts := ExtractResponseParts(task)
+	if len(parts) != 1 {
+		t.Fatalf("got %d parts, want 1", len(parts))
+	}
+	if parts[0].Media == nil || parts[0].Media.URL == nil || *parts[0].Media.URL != url {
+		t.Errorf("expected URL %q in media", url)
+	}
+}
+
+func TestExtractResponseParts_Artifacts(t *testing.T) {
+	text := "artifact text"
+	task := &Task{
+		Status: TaskStatus{State: TaskStateCompleted},
+		Artifacts: []Artifact{
+			{Parts: []Part{{Text: &text}}},
+			{Parts: []Part{{Raw: []byte("img"), MediaType: "image/jpeg"}}},
+		},
+	}
+	parts := ExtractResponseParts(task)
+	if len(parts) != 2 {
+		t.Fatalf("got %d parts, want 2", len(parts))
+	}
+	if parts[0].Type != types.ContentTypeText {
+		t.Errorf("part 0 type = %q, want %q", parts[0].Type, types.ContentTypeText)
+	}
+	if parts[1].Type != types.ContentTypeImage {
+		t.Errorf("part 1 type = %q, want %q", parts[1].Type, types.ContentTypeImage)
+	}
+}
+
+func TestExtractResponseParts_Empty(t *testing.T) {
+	task := &Task{
+		Status: TaskStatus{State: TaskStateCompleted},
+	}
+	parts := ExtractResponseParts(task)
+	if len(parts) != 0 {
+		t.Errorf("got %d parts, want 0", len(parts))
+	}
+}
+
+func TestExtractResponseParts_SkipsUnsupported(t *testing.T) {
+	text := "ok"
+	task := &Task{
+		Status: TaskStatus{
+			Message: &Message{
+				Parts: []Part{
+					{Text: &text},
+					{Data: map[string]any{"key": "value"}}, // structured data — unsupported
+				},
+			},
+		},
+	}
+	parts := ExtractResponseParts(task)
+	if len(parts) != 1 {
+		t.Fatalf("got %d parts, want 1 (structured data should be skipped)", len(parts))
+	}
+}
+
+func TestExtractResponseParts_StatusAndArtifacts(t *testing.T) {
+	statusText := "status"
+	artifactText := "artifact"
+	task := &Task{
+		Status: TaskStatus{
+			Message: &Message{
+				Parts: []Part{{Text: &statusText}},
+			},
+		},
+		Artifacts: []Artifact{
+			{Parts: []Part{{Text: &artifactText}}},
+		},
+	}
+	parts := ExtractResponseParts(task)
+	// Should include both status and artifact parts
+	if len(parts) != 2 {
+		t.Fatalf("got %d parts, want 2", len(parts))
+	}
+	if *parts[0].Text != "status" {
+		t.Errorf("part 0 = %q, want %q", *parts[0].Text, "status")
+	}
+	if *parts[1].Text != "artifact" {
+		t.Errorf("part 1 = %q, want %q", *parts[1].Text, "artifact")
+	}
+}
+
+func TestExecutor_ExecuteMultimodal_BasicFlow(t *testing.T) {
+	text := "multimodal response"
+	task := &Task{
+		ID: "task-mm-1",
+		Status: TaskStatus{
+			State: TaskStateCompleted,
+			Message: &Message{
+				Role: RoleAgent,
+				Parts: []Part{
+					{Text: &text},
+					{Raw: []byte("image-data"), MediaType: "image/png"},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		rpcResult(w, req.ID, task)
+	}))
+	defer srv.Close()
+
+	e := NewExecutor(WithNoRetry())
+	defer e.Close()
+	desc := &tools.ToolDescriptor{
+		Name:      "a2a__agent__skill",
+		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
+	}
+
+	result, parts, err := e.ExecuteMultimodal(
+		context.Background(), desc, json.RawMessage(`{"query":"analyze image"}`),
+	)
+	if err != nil {
+		t.Fatalf("ExecuteMultimodal() error = %v", err)
+	}
+
+	// Check JSON result
+	var out map[string]string
+	if err := json.Unmarshal(result, &out); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if out["response"] != "multimodal response" {
+		t.Errorf("response = %q, want %q", out["response"], "multimodal response")
+	}
+
+	// Check content parts
+	if len(parts) != 2 {
+		t.Fatalf("got %d parts, want 2", len(parts))
+	}
+	if parts[0].Type != types.ContentTypeText {
+		t.Errorf("part 0 type = %q, want %q", parts[0].Type, types.ContentTypeText)
+	}
+	if parts[1].Type != types.ContentTypeImage {
+		t.Errorf("part 1 type = %q, want %q", parts[1].Type, types.ContentTypeImage)
+	}
+}
+
+func TestExecutor_ExecuteMultimodal_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		rpcErrorResp(w, req.ID, -32600, "bad request")
+	}))
+	defer srv.Close()
+
+	e := NewExecutor(WithNoRetry())
+	defer e.Close()
+	desc := &tools.ToolDescriptor{
+		Name:      "test-tool",
+		A2AConfig: &tools.A2AConfig{AgentURL: srv.URL},
+	}
+
+	_, _, err := e.ExecuteMultimodal(
+		context.Background(), desc, json.RawMessage(`{"query":"test"}`),
+	)
+	if err == nil {
+		t.Fatal("expected error from server error response")
+	}
+}
+
+func TestExecutor_ExecuteMultimodal_NoA2AConfig(t *testing.T) {
+	e := NewExecutor(WithNoRetry())
+	defer e.Close()
+	desc := &tools.ToolDescriptor{Name: "test-tool"}
+
+	_, _, err := e.ExecuteMultimodal(
+		context.Background(), desc, json.RawMessage(`{"query":"hello"}`),
+	)
+	if err == nil {
+		t.Fatal("expected error for missing A2AConfig")
+	}
+}
+
+func TestExecutor_ExecuteMultimodal_WithTimeout(t *testing.T) {
+	text := "ok"
+	task := &Task{
+		ID: "task-mm-t",
+		Status: TaskStatus{
+			State:   TaskStateCompleted,
+			Message: &Message{Role: RoleAgent, Parts: []Part{{Text: &text}}},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		rpcResult(w, req.ID, task)
+	}))
+	defer srv.Close()
+
+	e := NewExecutor(WithNoRetry())
+	defer e.Close()
+	desc := &tools.ToolDescriptor{
+		Name: "test-tool",
+		A2AConfig: &tools.A2AConfig{
+			AgentURL:  srv.URL,
+			TimeoutMs: 5000,
+		},
+	}
+
+	result, parts, err := e.ExecuteMultimodal(
+		context.Background(), desc, json.RawMessage(`{"query":"hello"}`),
+	)
+	if err != nil {
+		t.Fatalf("ExecuteMultimodal() error = %v", err)
+	}
+
+	var out map[string]string
+	if err := json.Unmarshal(result, &out); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if out["response"] != "ok" {
+		t.Errorf("response = %q, want %q", out["response"], "ok")
+	}
+	if len(parts) != 1 {
+		t.Fatalf("got %d parts, want 1", len(parts))
 	}
 }


### PR DESCRIPTION
## Summary

Closes #621

- Add `ExtractResponseParts()` function that converts all A2A Parts (from status message and artifacts) to PromptKit `ContentPart` values using the existing `PartToContentPart()` helper. Unsupported parts (e.g., structured data) are silently skipped.
- Add `ExecuteMultimodal()` method on `Executor` implementing `tools.MultimodalExecutor` — calls the remote A2A agent and returns both the JSON result and multimodal content parts.
- Extract shared `buildRequest()` and `executeRequest()` helpers to eliminate duplication between `Execute` and `ExecuteMultimodal` (SonarCloud ≤3% duplication).
- Add compile-time interface checks for `tools.Executor` and `tools.MultimodalExecutor`.

## Test plan

- [x] `TestExtractResponseParts_TextOnly` — text part conversion
- [x] `TestExtractResponseParts_ImageBase64` — base64 image part
- [x] `TestExtractResponseParts_URLPart` — URL-based media part
- [x] `TestExtractResponseParts_Artifacts` — parts from artifacts
- [x] `TestExtractResponseParts_Empty` — empty task returns no parts
- [x] `TestExtractResponseParts_SkipsUnsupported` — structured data parts skipped
- [x] `TestExtractResponseParts_StatusAndArtifacts` — both status and artifact parts collected
- [x] `TestExecutor_ExecuteMultimodal_BasicFlow` — text + image response
- [x] `TestExecutor_ExecuteMultimodal_ServerError` — error propagation
- [x] `TestExecutor_ExecuteMultimodal_NoA2AConfig` — missing config error
- [x] `TestExecutor_ExecuteMultimodal_WithTimeout` — timeout config applied
- [x] Coverage: 93.7% on `executor.go`, 91.5% on package