### PR TITLE
feat: PromptArena HTML report media thumbnails in DevTools panel

### DIFF
--- a/tools/arena/render/html.go
+++ b/tools/arena/render/html.go
@@ -369,11 +369,12 @@ func generateHTML(data HTMLReportData) (string, error) {
 		"getConversationAssertionResults": func(r engine.RunResult) []assertions.ConversationValidationResult {
 			return r.ConversationAssertions.Results
 		},
-		"isAgentTool":         isAgentTool,
-		"isWorkflowTool":      isWorkflowTool,
-		"hasA2AAgents":        hasA2AAgents,
-		"renderA2AAgentCards": renderA2AAgentCards,
-		"consentStatus":       consentStatus,
+		"renderToolResultMediaBadges": renderToolResultMediaBadges,
+		"isAgentTool":                 isAgentTool,
+		"isWorkflowTool":              isWorkflowTool,
+		"hasA2AAgents":                hasA2AAgents,
+		"renderA2AAgentCards":         renderA2AAgentCards,
+		"consentStatus":               consentStatus,
 	}).Parse(reportTemplate))
 
 	var buf strings.Builder

--- a/tools/arena/render/media.go
+++ b/tools/arena/render/media.go
@@ -477,6 +477,70 @@ const (
 	maxSourceLength = 40
 )
 
+// renderToolResultMediaBadges creates HTML metadata badges for media parts in tool results.
+// Since binary data is stripped via MetadataOnlyParts(), this renders metadata-only indicators
+// showing content type, MIME type, dimensions, and file size.
+// Returns empty template.HTML if no media parts exist.
+func renderToolResultMediaBadges(result *types.MessageToolResult) template.HTML {
+	if result == nil || !result.HasMedia() {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(`<div class="tool-result-media-badges">`)
+
+	for _, part := range result.Parts {
+		if part.Type == types.ContentTypeText {
+			continue
+		}
+		renderToolResultMediaBadge(&b, part)
+	}
+
+	b.WriteString(divCloseTag)
+	//nolint:gosec // G203: HTML generation is intentional for template rendering
+	return template.HTML(b.String())
+}
+
+// renderToolResultMediaBadge writes a single media metadata badge for a content part.
+func renderToolResultMediaBadge(b *strings.Builder, part types.ContentPart) {
+	b.WriteString(`<div class="tool-result-media-badge">`)
+
+	// Type icon and label
+	icon := getMediaTypeIcon(part.Type)
+	fmt.Fprintf(b, `<span class="trmb-icon">%s</span>`, icon)
+	fmt.Fprintf(b, `<span class="trmb-type">%s</span>`, part.Type)
+
+	if part.Media != nil {
+		renderToolResultMediaMeta(b, part.Media)
+	}
+
+	b.WriteString(divCloseTag)
+}
+
+// renderToolResultMediaMeta writes the metadata spans (MIME, dimensions, size, duration).
+func renderToolResultMediaMeta(b *strings.Builder, media *types.MediaContent) {
+	if media.MIMEType != "" {
+		fmt.Fprintf(b, `<span class="trmb-mime">%s</span>`,
+			template.HTMLEscapeString(media.MIMEType))
+	}
+
+	if media.Width != nil && media.Height != nil &&
+		*media.Width > 0 && *media.Height > 0 {
+		fmt.Fprintf(b, `<span class="trmb-dimensions">%d×%d</span>`,
+			*media.Width, *media.Height)
+	}
+
+	if media.SizeKB != nil && *media.SizeKB > 0 {
+		fmt.Fprintf(b, `<span class="trmb-size">%s</span>`,
+			formatBytes(int(*media.SizeKB*bytesPerKB)))
+	}
+
+	if media.Duration != nil && *media.Duration > 0 {
+		fmt.Fprintf(b, `<span class="trmb-duration">%ds</span>`,
+			*media.Duration)
+	}
+}
+
 // MediaStats holds aggregate media statistics across multiple run results.
 type MediaStats struct {
 	TotalImages      int

--- a/tools/arena/render/media_test.go
+++ b/tools/arena/render/media_test.go
@@ -9,6 +9,145 @@ import (
 	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
 )
 
+func TestRenderToolResultMediaBadges(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *types.MessageToolResult
+		want    []string // Strings that should appear in output
+		wantNot []string // Strings that should NOT appear
+	}{
+		{
+			name:   "nil result",
+			result: nil,
+			want:   []string{},
+		},
+		{
+			name: "text-only result unchanged",
+			result: &types.MessageToolResult{
+				ID:   "call_1",
+				Name: "get_weather",
+				Parts: []types.ContentPart{
+					{Type: types.ContentTypeText, Text: testutil.Ptr("sunny")},
+				},
+			},
+			want:    []string{},
+			wantNot: []string{"tool-result-media-badge"},
+		},
+		{
+			name: "image part shows metadata badge",
+			result: &types.MessageToolResult{
+				ID:   "call_2",
+				Name: "generate_image",
+				Parts: []types.ContentPart{
+					{Type: types.ContentTypeText, Text: testutil.Ptr("Generated image")},
+					{
+						Type: types.ContentTypeImage,
+						Media: &types.MediaContent{
+							MIMEType: "image/png",
+							Width:    testutil.Ptr(1024),
+							Height:   testutil.Ptr(768),
+							SizeKB:   testutil.Ptr[int64](245),
+						},
+					},
+				},
+			},
+			want: []string{
+				"tool-result-media-badges",
+				"tool-result-media-badge",
+				"trmb-type", "image",
+				"trmb-mime", "image/png",
+				"trmb-dimensions", "1024×768",
+				"trmb-size", "245.0 KB",
+			},
+			wantNot: []string{"audio", "video", "document"},
+		},
+		{
+			name: "document part shows metadata badge",
+			result: &types.MessageToolResult{
+				ID:   "call_3",
+				Name: "read_file",
+				Parts: []types.ContentPart{
+					{
+						Type: types.ContentTypeDocument,
+						Media: &types.MediaContent{
+							MIMEType: "application/pdf",
+							SizeKB:   testutil.Ptr[int64](512),
+						},
+					},
+				},
+			},
+			want: []string{
+				"tool-result-media-badge",
+				"trmb-type", "document",
+				"trmb-mime", "application/pdf",
+				"trmb-size", "512.0 KB",
+			},
+			wantNot: []string{"trmb-dimensions"},
+		},
+		{
+			name: "mixed text and media shows both text unaffected and badge",
+			result: &types.MessageToolResult{
+				ID:   "call_4",
+				Name: "analyze",
+				Parts: []types.ContentPart{
+					{Type: types.ContentTypeText, Text: testutil.Ptr("Analysis complete")},
+					{
+						Type: types.ContentTypeImage,
+						Media: &types.MediaContent{
+							MIMEType: "image/jpeg",
+							Width:    testutil.Ptr(800),
+							Height:   testutil.Ptr(600),
+						},
+					},
+					{
+						Type: types.ContentTypeAudio,
+						Media: &types.MediaContent{
+							MIMEType: "audio/wav",
+							Duration: testutil.Ptr(30),
+							SizeKB:   testutil.Ptr[int64](1024),
+						},
+					},
+				},
+			},
+			want: []string{
+				"tool-result-media-badges",
+				"image/jpeg", "800×600",
+				"audio/wav", "30s", "1.0 MB",
+			},
+		},
+		{
+			name: "media part without media content",
+			result: &types.MessageToolResult{
+				ID:   "call_5",
+				Name: "broken_tool",
+				Parts: []types.ContentPart{
+					{Type: types.ContentTypeImage, Media: nil},
+				},
+			},
+			want:    []string{"tool-result-media-badge", "trmb-type", "image"},
+			wantNot: []string{"trmb-mime", "trmb-dimensions", "trmb-size"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(renderToolResultMediaBadges(tt.result))
+
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("renderToolResultMediaBadges() missing expected string %q\nGot: %s", want, got)
+				}
+			}
+
+			for _, wantNot := range tt.wantNot {
+				if strings.Contains(got, wantNot) {
+					t.Errorf("renderToolResultMediaBadges() contains unexpected string %q\nGot: %s", wantNot, got)
+				}
+			}
+		})
+	}
+}
+
 func TestRenderMediaSummaryBadge(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/tools/arena/render/templates/report.html.tmpl
+++ b/tools/arena/render/templates/report.html.tmpl
@@ -615,7 +615,50 @@
             margin-bottom: 0.5rem;
             font-weight: 600;
         }
-        
+
+        .tool-result-media-badges {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 0.75rem;
+        }
+
+        .tool-result-media-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            background: #edf2f7;
+            border: 1px solid #cbd5e0;
+            border-radius: 6px;
+            padding: 0.3rem 0.6rem;
+            font-size: 0.8rem;
+            color: #2d3748;
+        }
+
+        .trmb-icon {
+            font-size: 1rem;
+        }
+
+        .trmb-type {
+            font-weight: 600;
+            text-transform: capitalize;
+        }
+
+        .trmb-mime {
+            color: #718096;
+            font-family: 'Courier New', monospace;
+            font-size: 0.75rem;
+        }
+
+        .trmb-dimensions,
+        .trmb-size,
+        .trmb-duration {
+            color: #4a5568;
+            font-size: 0.75rem;
+            padding-left: 0.25rem;
+            border-left: 1px solid #cbd5e0;
+        }
+
         .raw-request-content {
             display: none;
             margin-top: 0.75rem;
@@ -2135,6 +2178,7 @@
                                         <div class="tool-response-content">
                                             <div class="tool-response-label">Response:</div>
                                             <div class="json-content">{{prettyJSON $msg.Content}}</div>
+                                            {{if $msg.ToolResult}}{{renderToolResultMediaBadges $msg.ToolResult}}{{end}}
                                         </div>
                                     </div>
                                     {{if $msg.ToolResult}}


### PR DESCRIPTION
## Summary
- Adds media metadata badges to tool results in the HTML report's DevTools panel
- When a tool result contains media parts (image, audio, video, document), compact badges show content type icon, MIME type, dimensions, and file size
- Since binary data is stripped via `MetadataOnlyParts()`, badges display metadata only — no actual images rendered
- Text-only tool results are unaffected (regression-safe)

Closes #626

## Test plan
- [x] Tool results with image parts show image metadata badge (type icon, MIME, dimensions, size)
- [x] Tool results with document parts show document metadata badge
- [x] Text-only tool results display unchanged (regression test)
- [x] Mixed content (text + media) shows both text and metadata badges
- [x] Media part with nil Media field renders gracefully (type badge only)
- [x] All existing arena tests pass (`go test ./tools/arena/... -count=1`)
- [x] Lint clean (`golangci-lint --new-from-rev=HEAD`)
- [x] Pre-commit hook passes (lint, build, tests, coverage >= 80%)