### PR TITLE
docs: update documentation for multimodal tool results

### DIFF
--- a/docs/src/content/docs/arena/reference/assertions.md
+++ b/docs/src/content/docs/arena/reference/assertions.md
@@ -1088,6 +1088,99 @@ assertions:
 
 ---
 
+#### `tool_result_has_media`
+
+Asserts that a tool result contains multimodal media content (images, audio, video, or documents).
+
+**Use Cases**:
+- Verify that a chart generation tool returns an image
+- Confirm audio synthesis tools produce audio output
+- Validate that document tools return file attachments
+
+**Parameters**:
+- `tool` (string, required): Name of the tool to check
+- `media_type` (string, optional): Required media type — `"image"`, `"audio"`, `"video"`, or `"document"`. If omitted, passes for any non-text content.
+
+**Example**:
+```yaml
+- role: user
+  content: "Generate a bar chart of Q1 sales"
+  assertions:
+    - type: tool_result_has_media
+      params:
+        tool: generate_chart
+        media_type: image
+      message: "Chart tool should return an image"
+```
+
+**Without media_type filter** (any media passes):
+```yaml
+assertions:
+  - type: tool_result_has_media
+    params:
+      tool: generate_report
+    message: "Report tool should return some media"
+```
+
+**Failure Details**:
+```json
+{
+  "passed": false,
+  "details": {
+    "message": "tool 'generate_chart' result has no media parts matching type 'image'",
+    "tool": "generate_chart",
+    "expected_media_type": "image",
+    "actual_part_types": ["text"]
+  }
+}
+```
+
+**Conversation-Level**: Also available in `conversation_assertions`.
+
+---
+
+#### `tool_result_media_type`
+
+Asserts that a tool result contains media with a specific MIME type.
+
+**Use Cases**:
+- Verify exact output format (e.g., PNG vs JPEG)
+- Check audio encoding (e.g., `audio/wav` vs `audio/mp3`)
+- Validate document format (e.g., `application/pdf`)
+
+**Parameters**:
+- `tool` (string, required): Name of the tool to check
+- `mime_type` (string, required): Expected MIME type (e.g., `"image/png"`, `"audio/wav"`, `"application/pdf"`)
+
+**Example**:
+```yaml
+- role: user
+  content: "Export the dashboard as a PNG"
+  assertions:
+    - type: tool_result_media_type
+      params:
+        tool: export_dashboard
+        mime_type: "image/png"
+      message: "Dashboard export should be PNG format"
+```
+
+**Failure Details**:
+```json
+{
+  "passed": false,
+  "details": {
+    "message": "tool 'export_dashboard' result has no media matching MIME type 'image/png'",
+    "tool": "export_dashboard",
+    "expected_mime_type": "image/png",
+    "actual_mime_types": ["image/jpeg"]
+  }
+}
+```
+
+**Conversation-Level**: Also available in `conversation_assertions`.
+
+---
+
 #### `tool_call_chain`
 
 Asserts a **dependency chain**: tool calls must appear in order (subsequence matching), and each step can have additional per-call constraints on arguments, result content, regex matching, and error presence.

--- a/docs/src/content/docs/runtime/reference/types.md
+++ b/docs/src/content/docs/runtime/reference/types.md
@@ -109,22 +109,67 @@ toolCall := types.MessageToolCall{
 
 ```go
 type MessageToolResult struct {
-    ID      string
-    Name    string
-    Content json.RawMessage
-    IsError bool
+    ID        string           `json:"id"`
+    Name      string           `json:"name"`
+    Parts     []ContentPart    `json:"parts,omitempty"`
+    Error     string           `json:"error,omitempty"`
+    LatencyMs int64            `json:"latency_ms,omitempty"`
 }
 ```
 
-Result of tool execution.
+Result of tool execution. Supports multimodal content through the `Parts` field, allowing tools to return text, images, audio, video, and documents in a single result.
 
-**Example**:
+**Fields:**
+
+- **ID**: The tool call ID this result corresponds to
+- **Name**: The tool name
+- **Parts**: Multimodal content parts (text, images, audio, video, documents). A result can contain multiple parts of different types.
+- **Error**: Error message if the tool call failed (empty on success)
+- **LatencyMs**: Execution time in milliseconds
+
+**Methods:**
+
+- `GetTextContent() string` — Concatenates text from all text parts into a single string. Useful when you only need the textual portion of a multimodal result.
+- `HasMedia() bool` — Returns `true` if any non-text parts are present (images, audio, video, documents).
+- `NewTextToolResult(id, name, text string) MessageToolResult` — Constructor for creating a simple text-only tool result.
+
+**Examples:**
+
+Text-only result (using constructor):
+```go
+result := types.NewTextToolResult("call_123", "get_weather", `{"temp": 72, "conditions": "sunny"}`)
+```
+
+Multimodal result with text and an image:
 ```go
 result := types.MessageToolResult{
-    ID:      "call_123",
-    Name:    "get_weather",
-    Content: json.RawMessage(`{"temp": 72, "conditions": "sunny"}`),
-    IsError: false,
+    ID:   "call_456",
+    Name: "generate_chart",
+    Parts: []types.ContentPart{
+        {Type: "text", Text: "Here is the requested chart:"},
+        {
+            Type:     "image",
+            ImageURL: &types.ImageURL{
+                URL: "data:image/png;base64,iVBORw0KGgo...",
+            },
+        },
+    },
+    LatencyMs: 230,
+}
+
+// Access just the text
+fmt.Println(result.GetTextContent()) // "Here is the requested chart:"
+
+// Check for media
+fmt.Println(result.HasMedia()) // true
+```
+
+Error result:
+```go
+result := types.MessageToolResult{
+    ID:    "call_789",
+    Name:  "fetch_data",
+    Error: "connection timeout after 30s",
 }
 ```
 
@@ -526,15 +571,27 @@ func ValidateMessage(msg types.Message) error {
 ### 2. Safe Type Assertions
 
 ```go
-// Safe JSON unmarshaling
+// Extract text from a multimodal tool result
+text := toolResult.GetTextContent()
+
+// Parse structured text content
 var result map[string]interface{}
-if err := json.Unmarshal(toolResult.Content, &result); err != nil {
+if err := json.Unmarshal([]byte(text), &result); err != nil {
     return fmt.Errorf("invalid tool result: %w", err)
 }
 
 // Safe type assertion with check
 if temp, ok := result["temperature"].(float64); ok {
     fmt.Printf("Temperature: %.0f\n", temp)
+}
+
+// Check for media content
+if toolResult.HasMedia() {
+    for _, part := range toolResult.Parts {
+        if part.Type == "image" {
+            fmt.Printf("Image: %s\n", part.ImageURL.URL)
+        }
+    }
 }
 ```
 

--- a/docs/src/content/docs/sdk/how-to/client-tools.md
+++ b/docs/src/content/docs/sdk/how-to/client-tools.md
@@ -157,6 +157,58 @@ To reject a tool, use `"rejected": "reason"` instead of `"tool_result"`:
 }
 ```
 
+## Multimodal Tool Results
+
+Use `SendToolResultMultimodal()` to return rich content (images, audio, etc.) from client tools alongside text.
+
+### Returning an Image with Text
+
+```go
+resp, _ := conv.Send(ctx, "Generate a chart of monthly sales")
+
+if resp.HasPendingClientTools() {
+    for _, tool := range resp.ClientTools() {
+        // Generate the chart image
+        chartPNG, _ := generateChart(tool.Arguments)
+
+        // Return multimodal result with text and image
+        conv.SendToolResultMultimodal(ctx, tool.CallID, []types.ContentPart{
+            {Type: "text", Text: "Monthly sales chart for Q1 2026"},
+            {
+                Type: "image",
+                ImageURL: &types.ImageURL{
+                    URL: "data:image/png;base64," + base64.StdEncoding.EncodeToString(chartPNG),
+                },
+            },
+        })
+    }
+
+    resp, _ = conv.Resume(ctx)
+    fmt.Println(resp.Text()) // LLM describes the chart
+}
+```
+
+### Synchronous Multimodal Handler
+
+For synchronous handlers, return `[]types.ContentPart` directly:
+
+```go
+conv.OnClientTool("capture_photo", func(ctx context.Context, req sdk.ClientToolRequest) (any, error) {
+    photoBytes, _ := capturePhoto()
+    return []types.ContentPart{
+        {Type: "text", Text: "Photo captured at entrance"},
+        {
+            Type: "image",
+            ImageURL: &types.ImageURL{
+                URL: "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(photoBytes),
+            },
+        },
+    }, nil
+})
+```
+
+When the handler returns `[]types.ContentPart`, the SDK automatically constructs a multimodal `MessageToolResult`. For any other return type, the result is serialized as JSON text.
+
 ## See Also
 
 - [Register Tools](register-tools)


### PR DESCRIPTION
## Summary

- Updated `MessageToolResult` struct definition in types reference to reflect new multimodal API (`Parts`, `Error`, `LatencyMs` fields) with method documentation (`GetTextContent()`, `HasMedia()`, `NewTextToolResult()`)
- Added `SendToolResultMultimodal()` section to client-tools how-to with examples for deferred and synchronous multimodal handlers
- Added `tool_result_has_media` and `tool_result_media_type` assertion types to the Arena assertions reference

## Test plan

- [ ] Verify docs site builds without errors (`npm run build` in `docs/`)
- [ ] Review types.md renders correctly with new struct definition and examples
- [ ] Review client-tools.md multimodal section flows naturally after existing content
- [ ] Review assertions.md new entries match the style of surrounding assertion docs