### PR TITLE
fix: server/a2a and pkg reliability improvements

### DIFF
--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 // LoggingConfig represents logging configuration in K8s-style manifest format.
 // This is used for schema generation and external configuration files.
 type LoggingConfig struct {
@@ -100,7 +102,7 @@ func (c *LoggingConfigSpec) Validate() error {
 	for i, mod := range c.Modules {
 		if mod.Name == "" {
 			return &ValidationError{
-				Field:   "modules[" + string(rune('0'+i)) + "].name",
+				Field:   fmt.Sprintf("modules[%d].name", i),
 				Message: "module name is required",
 			}
 		}

--- a/pkg/config/logging_test.go
+++ b/pkg/config/logging_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -149,6 +150,52 @@ func TestIsValidLogLevel(t *testing.T) {
 		if isValidLogLevel(level) {
 			t.Errorf("expected %s to be invalid", level)
 		}
+	}
+}
+
+func TestLoggingConfigSpec_Validate_ModuleIndexFormat(t *testing.T) {
+	// Verify that the module index in the error field uses numeric format
+	// (e.g. "modules[0].name") not ASCII rune conversion.
+	cfg := LoggingConfigSpec{
+		Modules: []ModuleLoggingConfig{
+			{Name: "valid", Level: LogLevelDebug},
+			{Name: "", Level: LogLevelDebug}, // index 1 has empty name
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty module name")
+	}
+
+	ve, ok := err.(*ValidationError)
+	if !ok {
+		t.Fatalf("expected *ValidationError, got %T", err)
+	}
+	if ve.Field != "modules[1].name" {
+		t.Errorf("expected field 'modules[1].name', got %q", ve.Field)
+	}
+}
+
+func TestLoggingConfigSpec_Validate_HighModuleIndex(t *testing.T) {
+	// For indices >= 10, the old string(rune('0'+i)) would produce wrong characters.
+	modules := make([]ModuleLoggingConfig, 11)
+	for i := range 10 {
+		modules[i] = ModuleLoggingConfig{Name: fmt.Sprintf("mod%d", i), Level: LogLevelInfo}
+	}
+	modules[10] = ModuleLoggingConfig{Name: "", Level: LogLevelInfo} // empty at index 10
+
+	cfg := LoggingConfigSpec{Modules: modules}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty module name at index 10")
+	}
+	ve, ok := err.(*ValidationError)
+	if !ok {
+		t.Fatalf("expected *ValidationError, got %T", err)
+	}
+	if ve.Field != "modules[10].name" {
+		t.Errorf("expected field 'modules[10].name', got %q", ve.Field)
 	}
 }
 

--- a/pkg/config/schema_validator.go
+++ b/pkg/config/schema_validator.go
@@ -45,28 +45,66 @@ func localSchemaDirIfRequested() string {
 	return SchemaLocalPath
 }
 
+// maxSchemaCacheSize is the maximum number of schemas that can be cached.
+// When this limit is reached, the least recently used entry is evicted.
+const maxSchemaCacheSize = 64
+
+type schemaCacheEntry struct {
+	key    string
+	schema *gojsonschema.Schema
+}
+
 type schemaCacheStore struct {
-	mu      sync.RWMutex
-	schemas map[string]*gojsonschema.Schema
+	mu      sync.Mutex
+	schemas map[string]*schemaCacheEntry
+	order   []string // LRU order: most recently used at the end
 }
 
 // schemaCache caches compiled JSON schemas to avoid repeated HTTP requests
 var schemaCache = &schemaCacheStore{
-	schemas: make(map[string]*gojsonschema.Schema),
+	schemas: make(map[string]*schemaCacheEntry),
 }
 
-// get retrieves a schema from the cache
+// get retrieves a schema from the cache and marks it as recently used.
 func (c *schemaCacheStore) get(key string) *gojsonschema.Schema {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.schemas[key]
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.schemas[key]
+	if !ok {
+		return nil
+	}
+	c.touchLocked(key)
+	return entry.schema
 }
 
-// set stores a schema in the cache
+// set stores a schema in the cache, evicting the LRU entry if at capacity.
 func (c *schemaCacheStore) set(key string, schema *gojsonschema.Schema) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.schemas[key] = schema
+	if _, ok := c.schemas[key]; ok {
+		c.schemas[key].schema = schema
+		c.touchLocked(key)
+		return
+	}
+	// Evict LRU if at capacity.
+	if len(c.order) >= maxSchemaCacheSize {
+		oldest := c.order[0]
+		c.order = c.order[1:]
+		delete(c.schemas, oldest)
+	}
+	c.schemas[key] = &schemaCacheEntry{key: key, schema: schema}
+	c.order = append(c.order, key)
+}
+
+// touchLocked moves key to the end of the LRU order. Must be called with mu held.
+func (c *schemaCacheStore) touchLocked(key string) {
+	for i, k := range c.order {
+		if k == key {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			break
+		}
+	}
+	c.order = append(c.order, key)
 }
 
 // findLocalSchemaPath searches for a local schema file in common locations
@@ -182,6 +220,9 @@ func buildSchemaKey(configType ConfigType, schemaDir string) string {
 	return fmt.Sprintf("%s/%s.json", SchemaBaseURL, configType)
 }
 
+// TODO: Use golang.org/x/sync/singleflight to deduplicate concurrent schema loads
+// for the same key. Currently, multiple goroutines requesting the same uncached
+// schema will each perform an independent load (thundering herd).
 func loadOrGetCachedSchema(schemaKey string, configType ConfigType, schemaDir string) (*gojsonschema.Schema, error) {
 	// Check cache first
 	schema := schemaCache.get(schemaKey)

--- a/pkg/config/schema_validator_test.go
+++ b/pkg/config/schema_validator_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,7 +82,8 @@ spec:
 func TestSchemaCaching(t *testing.T) {
 	// Clear cache before test
 	schemaCache.mu.Lock()
-	schemaCache.schemas = make(map[string]*gojsonschema.Schema)
+	schemaCache.schemas = make(map[string]*schemaCacheEntry)
+	schemaCache.order = nil
 	schemaCache.mu.Unlock()
 
 	validConfig := []byte(`
@@ -130,10 +132,8 @@ spec:
 	require.NoError(t, err)
 
 	// Check that schema was cached
-	schemaCache.mu.RLock()
 	schemaKey := "file://" + schemaDir + "/arena.json"
-	cachedSchema := schemaCache.schemas[schemaKey]
-	schemaCache.mu.RUnlock()
+	cachedSchema := schemaCache.get(schemaKey)
 	assert.NotNil(t, cachedSchema, "Schema should be cached after first validation")
 
 	// Second validation - should use cached schema
@@ -141,9 +141,7 @@ spec:
 	require.NoError(t, err)
 
 	// Verify same schema instance is used (pointer equality)
-	schemaCache.mu.RLock()
-	cachedSchema2 := schemaCache.schemas[schemaKey]
-	schemaCache.mu.RUnlock()
+	cachedSchema2 := schemaCache.get(schemaKey)
 	assert.Same(t, cachedSchema, cachedSchema2, "Should reuse cached schema instance")
 }
 
@@ -653,4 +651,74 @@ spec:
 	err := ValidatePersona(invalidPersona)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persona configuration does not match schema")
+}
+
+// --- M32: Schema cache LRU eviction ---
+
+func TestSchemaCacheStore_LRUEviction(t *testing.T) {
+	cache := &schemaCacheStore{
+		schemas: make(map[string]*schemaCacheEntry),
+	}
+
+	// Create a dummy schema for testing.
+	loader := gojsonschema.NewStringLoader(`{"type": "object"}`)
+	dummySchema, err := gojsonschema.NewSchema(loader)
+	require.NoError(t, err)
+
+	// Fill cache to capacity.
+	for i := range maxSchemaCacheSize {
+		cache.set(fmt.Sprintf("key-%d", i), dummySchema)
+	}
+	assert.Equal(t, maxSchemaCacheSize, len(cache.schemas))
+
+	// Adding one more should evict the oldest (key-0).
+	cache.set("key-new", dummySchema)
+	assert.Equal(t, maxSchemaCacheSize, len(cache.schemas))
+	assert.Nil(t, cache.get("key-0"), "oldest entry should be evicted")
+	assert.NotNil(t, cache.get("key-new"), "new entry should be present")
+}
+
+func TestSchemaCacheStore_LRUTouchPromotes(t *testing.T) {
+	cache := &schemaCacheStore{
+		schemas: make(map[string]*schemaCacheEntry),
+	}
+
+	loader := gojsonschema.NewStringLoader(`{"type": "object"}`)
+	dummySchema, err := gojsonschema.NewSchema(loader)
+	require.NoError(t, err)
+
+	// Fill cache to capacity.
+	for i := range maxSchemaCacheSize {
+		cache.set(fmt.Sprintf("key-%d", i), dummySchema)
+	}
+
+	// Touch key-0 to promote it.
+	cache.get("key-0")
+
+	// Adding a new entry should evict key-1 (the new oldest) instead of key-0.
+	cache.set("key-new", dummySchema)
+	assert.NotNil(t, cache.get("key-0"), "touched entry should not be evicted")
+	assert.Nil(t, cache.get("key-1"), "second oldest should be evicted")
+}
+
+func TestSchemaCacheStore_SetExistingKey(t *testing.T) {
+	cache := &schemaCacheStore{
+		schemas: make(map[string]*schemaCacheEntry),
+	}
+
+	loader := gojsonschema.NewStringLoader(`{"type": "object"}`)
+	dummySchema, err := gojsonschema.NewSchema(loader)
+	require.NoError(t, err)
+
+	cache.set("key-1", dummySchema)
+	cache.set("key-1", dummySchema) // update existing
+	assert.Equal(t, 1, len(cache.schemas))
+	assert.NotNil(t, cache.get("key-1"))
+}
+
+func TestSchemaCacheStore_GetMiss(t *testing.T) {
+	cache := &schemaCacheStore{
+		schemas: make(map[string]*schemaCacheEntry),
+	}
+	assert.Nil(t, cache.get("nonexistent"))
 }

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -298,22 +298,21 @@ func (v *ConfigValidator) validateJudgeDefaults() {
 	}
 }
 
-// validateCrossReferences validates references between components
+// validateCrossReferences validates references between components.
+// It uses already-loaded scenarios from v.config.LoadedScenarios to avoid
+// redundant file I/O.
 func (v *ConfigValidator) validateCrossReferences() {
 	taskTypes := v.getPromptTaskTypes()
 
-	// Validate scenario task_type references
-	for _, scenarioConfig := range v.config.Scenarios {
-		scenario, err := LoadScenario(scenarioConfig.File)
-		if err != nil {
-			// Already reported in validateScenarios
+	// Validate scenario task_type references using already-loaded scenarios.
+	for id, scenario := range v.config.LoadedScenarios {
+		if scenario == nil {
 			continue
 		}
-
 		// Check task_type exists in loaded prompt configs
 		if scenario.TaskType != "" && !taskTypes[scenario.TaskType] {
 			err := fmt.Errorf("scenario %s references unknown task_type: %s",
-				scenarioConfig.File, scenario.TaskType)
+				id, scenario.TaskType)
 			v.errors = append(v.errors, err)
 		}
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -60,13 +60,13 @@ func (e *ContextualError) Unwrap() error {
 	return e.Cause
 }
 
-// WithStatusCode returns a copy of the error with the given status code set.
+// WithStatusCode sets the status code on this error and returns it for chaining.
 func (e *ContextualError) WithStatusCode(code int) *ContextualError {
 	e.StatusCode = code
 	return e
 }
 
-// WithDetails returns a copy of the error with the given details map set.
+// WithDetails sets the details map on this error and returns it for chaining.
 func (e *ContextualError) WithDetails(details map[string]any) *ContextualError {
 	e.Details = details
 	return e

--- a/server/a2a/eviction_test.go
+++ b/server/a2a/eviction_test.go
@@ -24,9 +24,8 @@ func TestServer_EvictOnce_EvictsTerminalTasks(t *testing.T) {
 	require.NoError(t, store.SetState("old-task", a2a.TaskStateCompleted, nil))
 
 	// Backdate the task's timestamp to 2 hours ago.
-	task, _ := store.Get("old-task")
 	old := time.Now().Add(-2 * time.Hour)
-	task.Status.Timestamp = &old
+	setTaskTimestamp(store, "old-task", old)
 
 	// Create a recent completed task that should NOT be evicted.
 	_, err = store.Create("new-task", "ctx-1")

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -6,8 +6,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -250,17 +252,37 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /a2a", s.handleRPC)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	mux.HandleFunc("GET /readyz", s.handleReadyz)
-	return otelhttp.NewHandler(mux, "a2a-server")
+	return otelhttp.NewHandler(recoveryMiddleware(mux), "a2a-server")
+}
+
+// recoveryMiddleware wraps an http.Handler with panic recovery.
+// On panic it logs the stack trace and returns a 500 JSON-RPC error response.
+func recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				stack := debug.Stack()
+				log.Printf("a2a: panic recovered: %v\n%s", rec, stack)
+				writeRPCError(w, nil, -32603, "Internal error")
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
 }
 
 // ListenAndServe starts the HTTP server on the configured port.
+//
+// WriteTimeout is set to 0 (disabled) because SSE streaming endpoints
+// (message/stream, tasks/subscribe) hold the connection open indefinitely.
+// A non-zero WriteTimeout would kill long-lived SSE connections. Non-streaming
+// endpoints rely on the request context deadline for timeout enforcement.
 func (s *Server) ListenAndServe() error {
 	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.port),
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: defaultReadHeaderTimeout,
 		ReadTimeout:       s.readTimeout,
-		WriteTimeout:      s.writeTimeout,
+		WriteTimeout:      0, // disabled for SSE streaming compatibility
 		IdleTimeout:       s.idleTimeout,
 	}
 
@@ -315,12 +337,13 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 // Serve starts the HTTP server on the given listener.
+// See ListenAndServe for the rationale behind WriteTimeout: 0.
 func (s *Server) Serve(ln net.Listener) error {
 	srv := &http.Server{
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: defaultReadHeaderTimeout,
 		ReadTimeout:       s.readTimeout,
-		WriteTimeout:      s.writeTimeout,
+		WriteTimeout:      0, // disabled for SSE streaming compatibility
 		IdleTimeout:       s.idleTimeout,
 	}
 
@@ -395,7 +418,8 @@ func (s *Server) handleAgentCard(w http.ResponseWriter, r *http.Request) {
 	}
 	card, err := s.cardProvider.AgentCard(r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Printf("a2a: failed to get agent card: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -407,7 +431,8 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 	// Authenticate if configured.
 	if s.authenticator != nil {
 		if err := s.authenticator.Authenticate(r); err != nil {
-			writeRPCError(w, nil, -32000, fmt.Sprintf("Authentication failed: %v", err))
+			log.Printf("a2a: authentication failed: %v", err)
+			writeRPCError(w, nil, -32000, "Authentication failed")
 			return
 		}
 	}
@@ -804,7 +829,12 @@ func generateID() string {
 
 // writeRPCResult writes a JSON-RPC 2.0 success response.
 func writeRPCResult(w http.ResponseWriter, id, result any) {
-	data, _ := json.Marshal(result)
+	data, err := json.Marshal(result)
+	if err != nil {
+		log.Printf("a2a: failed to marshal RPC result: %v", err)
+		writeRPCError(w, id, -32603, "Internal error: failed to encode result")
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",

--- a/server/a2a/server_stream.go
+++ b/server/a2a/server_stream.go
@@ -14,6 +14,12 @@ import (
 // subscriberBuffer is the channel buffer size for broadcast subscribers.
 const subscriberBuffer = 64
 
+// maxSubscribers is the maximum number of concurrent subscribers per broadcaster.
+const maxSubscribers = 1000
+
+// ErrTooManySubscribers is returned when a broadcaster has reached its subscriber limit.
+var ErrTooManySubscribers = fmt.Errorf("a2a: too many subscribers")
+
 // ssePayload is a single SSE payload ready to be broadcast.
 type ssePayload struct {
 	Data []byte // JSON-encoded JSON-RPC response
@@ -27,16 +33,20 @@ type taskBroadcaster struct {
 }
 
 // subscribe adds a new subscriber and returns its channel.
-func (b *taskBroadcaster) subscribe() <-chan ssePayload {
+// Returns nil if the broadcaster is at capacity.
+func (b *taskBroadcaster) subscribe() (<-chan ssePayload, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	ch := make(chan ssePayload, subscriberBuffer)
 	if b.closed {
 		close(ch)
-		return ch
+		return ch, nil
+	}
+	if len(b.subs) >= maxSubscribers {
+		return nil, ErrTooManySubscribers
 	}
 	b.subs = append(b.subs, ch)
-	return ch
+	return ch, nil
 }
 
 // unsubscribe removes a subscriber channel.
@@ -512,7 +522,11 @@ func (s *Server) handleTaskSubscribe(w http.ResponseWriter, r *http.Request, req
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	ch := broadcaster.subscribe()
+	ch, subErr := broadcaster.subscribe()
+	if subErr != nil {
+		writeRPCError(w, req.ID, -32000, "Too many subscribers")
+		return
+	}
 	defer broadcaster.unsubscribe(ch)
 
 	ctx := r.Context()

--- a/server/a2a/server_stream_test.go
+++ b/server/a2a/server_stream_test.go
@@ -1143,3 +1143,58 @@ func TestServer_StreamMessage_ClientTool_ResumeStream(t *testing.T) {
 		t.Errorf("tool results = %+v, want [{call-1 ...}]", mock.toolResults)
 	}
 }
+
+// --- L23: Broadcaster subscriber limit ---
+
+func TestBroadcaster_SubscriberLimit(t *testing.T) {
+	b := &taskBroadcaster{}
+
+	// Fill up to maxSubscribers.
+	for i := 0; i < maxSubscribers; i++ {
+		ch, err := b.subscribe()
+		if err != nil {
+			t.Fatalf("subscribe %d failed: %v", i, err)
+		}
+		if ch == nil {
+			t.Fatalf("subscribe %d returned nil channel", i)
+		}
+	}
+
+	// Next subscribe should fail.
+	ch, err := b.subscribe()
+	if !errors.Is(err, ErrTooManySubscribers) {
+		t.Errorf("expected ErrTooManySubscribers, got %v", err)
+	}
+	if ch != nil {
+		t.Error("expected nil channel on error")
+	}
+
+	// After unsubscribing one, should be able to subscribe again.
+	b.mu.Lock()
+	firstCh := b.subs[0]
+	b.mu.Unlock()
+	b.unsubscribe(firstCh)
+
+	ch, err = b.subscribe()
+	if err != nil {
+		t.Errorf("subscribe after unsubscribe failed: %v", err)
+	}
+	if ch == nil {
+		t.Error("expected non-nil channel after unsubscribe")
+	}
+}
+
+func TestBroadcaster_SubscribeClosed(t *testing.T) {
+	b := &taskBroadcaster{}
+	b.close()
+
+	ch, err := b.subscribe()
+	if err != nil {
+		t.Errorf("unexpected error subscribing to closed broadcaster: %v", err)
+	}
+	// Channel should be closed immediately.
+	_, ok := <-ch
+	if ok {
+		t.Error("expected closed channel from closed broadcaster")
+	}
+}

--- a/server/a2a/server_test.go
+++ b/server/a2a/server_test.go
@@ -36,11 +36,11 @@ type mockSendResult struct {
 	pendingClientTools []PendingClientToolInfo
 }
 
-func (r *mockSendResult) HasPendingTools() bool                    { return r.hasPending }
-func (r *mockSendResult) HasPendingClientTools() bool              { return r.hasPendingClient }
+func (r *mockSendResult) HasPendingTools() bool                       { return r.hasPending }
+func (r *mockSendResult) HasPendingClientTools() bool                 { return r.hasPendingClient }
 func (r *mockSendResult) PendingClientTools() []PendingClientToolInfo { return r.pendingClientTools }
-func (r *mockSendResult) Parts() []types.ContentPart               { return r.parts }
-func (r *mockSendResult) Text() string                             { return r.text }
+func (r *mockSendResult) Parts() []types.ContentPart                  { return r.parts }
+func (r *mockSendResult) Text() string                                { return r.text }
 
 // --- mock conversation for server tests ---
 
@@ -2123,5 +2123,114 @@ func TestBuildPendingToolsMessage_HITLOnly(t *testing.T) {
 	msg := buildPendingToolsMessage(resp)
 	if msg != nil {
 		t.Fatalf("expected nil message for HITL-only pending, got %+v", msg)
+	}
+}
+
+// --- H8: Panic recovery middleware ---
+
+func TestServer_PanicRecovery(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /panic", func(_ http.ResponseWriter, _ *http.Request) {
+		panic("test panic")
+	})
+	handler := recoveryMiddleware(mux)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/panic")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Should get a 200 with a JSON-RPC error body (not a 5xx crash).
+	var rpcResp a2a.JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if rpcResp.Error == nil {
+		t.Fatal("expected JSON-RPC error response")
+	}
+	if rpcResp.Error.Code != -32603 {
+		t.Errorf("expected code -32603, got %d", rpcResp.Error.Code)
+	}
+	if rpcResp.Error.Message != "Internal error" {
+		t.Errorf("expected 'Internal error', got %q", rpcResp.Error.Message)
+	}
+}
+
+func TestServer_PanicRecovery_NoPanic(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /ok", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := recoveryMiddleware(mux)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/ok")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// --- M31: Authentication error does not leak internals ---
+
+type mockAuthenticator struct {
+	err error
+}
+
+func (m *mockAuthenticator) Authenticate(_ *http.Request) error {
+	return m.err
+}
+
+func TestServer_AuthErrorNoLeak(t *testing.T) {
+	secretErr := fmt.Errorf("invalid token: abc123-secret-key")
+	_, ts := newTestServer(nopOpener, WithAuthenticator(&mockAuthenticator{err: secretErr}))
+	defer ts.Close()
+
+	resp := a2aRPCRequest(t, ts, a2a.MethodGetTask, a2a.GetTaskRequest{ID: "t1"})
+	if resp.Error == nil {
+		t.Fatal("expected error response")
+	}
+	if resp.Error.Message != "Authentication failed" {
+		t.Errorf("expected generic message, got %q", resp.Error.Message)
+	}
+	// The secret key must NOT appear in the response.
+	if bytes.Contains(resp.Result, []byte("abc123-secret-key")) {
+		t.Error("secret key leaked in response")
+	}
+}
+
+// --- L25: Agent card error does not leak internals ---
+
+type failingCardProvider struct{}
+
+func (f *failingCardProvider) AgentCard(_ *http.Request) (*a2a.AgentCard, error) {
+	return nil, fmt.Errorf("database connection failed: host=db.internal password=secret")
+}
+
+func TestServer_AgentCardErrorNoLeak(t *testing.T) {
+	_, ts := newTestServer(nopOpener, WithCardProvider(&failingCardProvider{}))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/agent.json")
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+
+	var body bytes.Buffer
+	_, _ = body.ReadFrom(resp.Body)
+	if bytes.Contains(body.Bytes(), []byte("password=secret")) {
+		t.Error("internal error details leaked in agent card response")
 	}
 }

--- a/server/a2a/task_store.go
+++ b/server/a2a/task_store.go
@@ -3,6 +3,7 @@ package a2aserver
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -99,7 +100,8 @@ func (s *InMemoryTaskStore) Create(taskID, contextID string) (*a2a.Task, error) 
 	return task, nil
 }
 
-// Get retrieves a task by ID.
+// Get retrieves a deep copy of a task by ID. The returned task is safe to
+// read/modify without holding the store lock.
 func (s *InMemoryTaskStore) Get(taskID string) (*a2a.Task, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -108,7 +110,7 @@ func (s *InMemoryTaskStore) Get(taskID string) (*a2a.Task, error) {
 	if !ok {
 		return nil, ErrTaskNotFound
 	}
-	return task, nil
+	return cloneTask(task), nil
 }
 
 // SetState transitions the task to a new state with an optional status message.
@@ -195,8 +197,9 @@ func (s *InMemoryTaskStore) EvictTerminal(cutoff time.Time) []string {
 	return evicted
 }
 
-// List returns tasks matching the given contextID with pagination.
-// If contextID is empty, all tasks are returned. Offset and limit control pagination.
+// List returns deep copies of tasks matching the given contextID with pagination.
+// If contextID is empty, all tasks are returned. Results are sorted by ID for
+// deterministic pagination. Offset and limit control pagination.
 func (s *InMemoryTaskStore) List(contextID string, limit, offset int) ([]*a2a.Task, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -207,6 +210,11 @@ func (s *InMemoryTaskStore) List(contextID string, limit, offset int) ([]*a2a.Ta
 			matched = append(matched, task)
 		}
 	}
+
+	// Sort by ID for deterministic pagination.
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].ID < matched[j].ID
+	})
 
 	// Apply offset.
 	if offset >= len(matched) {
@@ -219,5 +227,106 @@ func (s *InMemoryTaskStore) List(contextID string, limit, offset int) ([]*a2a.Ta
 		matched = matched[:limit]
 	}
 
-	return matched, nil
+	// Return deep copies so callers cannot mutate the store.
+	result := make([]*a2a.Task, len(matched))
+	for i, t := range matched {
+		result[i] = cloneTask(t)
+	}
+	return result, nil
+}
+
+// cloneTask returns a deep copy of a Task.
+func cloneTask(t *a2a.Task) *a2a.Task {
+	cp := *t
+
+	// Clone Status.
+	if t.Status.Timestamp != nil {
+		ts := *t.Status.Timestamp
+		cp.Status.Timestamp = &ts
+	}
+	if t.Status.Message != nil {
+		cp.Status.Message = cloneMessage(t.Status.Message)
+	}
+
+	// Clone History.
+	if len(t.History) > 0 {
+		cp.History = make([]a2a.Message, len(t.History))
+		for i := range t.History {
+			cp.History[i] = *cloneMessage(&t.History[i])
+		}
+	}
+
+	// Clone Artifacts.
+	if len(t.Artifacts) > 0 {
+		cp.Artifacts = make([]a2a.Artifact, len(t.Artifacts))
+		for i := range t.Artifacts {
+			cp.Artifacts[i] = cloneArtifact(&t.Artifacts[i])
+		}
+	}
+
+	// Clone Metadata.
+	if len(t.Metadata) > 0 {
+		cp.Metadata = make(map[string]any, len(t.Metadata))
+		for k, v := range t.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+
+	return &cp
+}
+
+// cloneMessage returns a deep copy of a Message.
+func cloneMessage(m *a2a.Message) *a2a.Message {
+	cp := *m
+	if len(m.Parts) > 0 {
+		cp.Parts = make([]a2a.Part, len(m.Parts))
+		for i := range m.Parts {
+			cp.Parts[i] = clonePart(&m.Parts[i])
+		}
+	}
+	if len(m.Metadata) > 0 {
+		cp.Metadata = make(map[string]any, len(m.Metadata))
+		for k, v := range m.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	return &cp
+}
+
+// cloneArtifact returns a deep copy of an Artifact.
+func cloneArtifact(art *a2a.Artifact) a2a.Artifact {
+	cp := *art
+	if len(art.Parts) > 0 {
+		cp.Parts = make([]a2a.Part, len(art.Parts))
+		for i := range art.Parts {
+			cp.Parts[i] = clonePart(&art.Parts[i])
+		}
+	}
+	if len(art.Metadata) > 0 {
+		cp.Metadata = make(map[string]any, len(art.Metadata))
+		for k, v := range art.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	return cp
+}
+
+// clonePart returns a deep copy of a Part.
+func clonePart(p *a2a.Part) a2a.Part {
+	cp := *p
+	if p.Text != nil {
+		s := *p.Text
+		cp.Text = &s
+	}
+	if p.URL != nil {
+		s := *p.URL
+		cp.URL = &s
+	}
+	if len(p.Metadata) > 0 {
+		cp.Metadata = make(map[string]any, len(p.Metadata))
+		for k, v := range p.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	return cp
 }

--- a/server/a2a/task_store_test.go
+++ b/server/a2a/task_store_test.go
@@ -360,6 +360,16 @@ func TestInMemoryTaskStore_Concurrent(t *testing.T) {
 	}
 }
 
+// setTaskTimestamp directly sets the timestamp on the live task in the store.
+// This is needed because Get() returns deep copies.
+func setTaskTimestamp(store *InMemoryTaskStore, taskID string, ts time.Time) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if task, ok := store.tasks[taskID]; ok {
+		task.Status.Timestamp = &ts
+	}
+}
+
 func TestInMemoryTaskStore_EvictTerminal(t *testing.T) {
 	store := NewInMemoryTaskStore()
 
@@ -368,9 +378,8 @@ func TestInMemoryTaskStore_EvictTerminal(t *testing.T) {
 	require.NoError(t, store.SetState("old-completed", a2a.TaskStateWorking, nil))
 	require.NoError(t, store.SetState("old-completed", a2a.TaskStateCompleted, nil))
 
-	task, _ := store.Get("old-completed")
 	old := time.Now().Add(-2 * time.Hour)
-	task.Status.Timestamp = &old
+	setTaskTimestamp(store, "old-completed", old)
 
 	_, err = store.Create("new-completed", "ctx")
 	require.NoError(t, err)
@@ -380,15 +389,13 @@ func TestInMemoryTaskStore_EvictTerminal(t *testing.T) {
 	_, err = store.Create("old-working", "ctx")
 	require.NoError(t, err)
 	require.NoError(t, store.SetState("old-working", a2a.TaskStateWorking, nil))
-	workingTask, _ := store.Get("old-working")
-	workingTask.Status.Timestamp = &old
+	setTaskTimestamp(store, "old-working", old)
 
 	_, err = store.Create("old-failed", "ctx")
 	require.NoError(t, err)
 	require.NoError(t, store.SetState("old-failed", a2a.TaskStateWorking, nil))
 	require.NoError(t, store.SetState("old-failed", a2a.TaskStateFailed, nil))
-	failedTask, _ := store.Get("old-failed")
-	failedTask.Status.Timestamp = &old
+	setTaskTimestamp(store, "old-failed", old)
 
 	cutoff := time.Now().Add(-1 * time.Hour)
 	evicted := store.EvictTerminal(cutoff)
@@ -406,6 +413,67 @@ func TestInMemoryTaskStore_EvictTerminal(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = store.Get("old-working")
 	assert.NoError(t, err)
+}
+
+func TestInMemoryTaskStore_GetReturnsDeepCopy(t *testing.T) {
+	store := NewInMemoryTaskStore()
+	_, err := store.Create("t", "c")
+	require.NoError(t, err)
+
+	msg := &a2a.Message{
+		Role:  a2a.RoleAgent,
+		Parts: []a2a.Part{{Text: taskStoreTextPtr("hello")}},
+	}
+	require.NoError(t, store.SetState("t", a2a.TaskStateWorking, msg))
+
+	task1, err := store.Get("t")
+	require.NoError(t, err)
+	task2, err := store.Get("t")
+	require.NoError(t, err)
+
+	// Mutating the returned copy must not affect the stored task.
+	*task1.Status.Message.Parts[0].Text = "mutated"
+	assert.Equal(t, "hello", *task2.Status.Message.Parts[0].Text,
+		"Get must return independent deep copies")
+
+	// Verify the pointers are different.
+	assert.NotSame(t, task1, task2)
+	assert.NotSame(t, task1.Status.Timestamp, task2.Status.Timestamp)
+}
+
+func TestInMemoryTaskStore_ListReturnsDeepCopies(t *testing.T) {
+	store := NewInMemoryTaskStore()
+	_, err := store.Create("t1", "ctx")
+	require.NoError(t, err)
+
+	tasks, err := store.List("ctx", 0, 0)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	// Mutating the returned task must not affect the store.
+	tasks[0].ContextID = "mutated"
+	task, err := store.Get("t1")
+	require.NoError(t, err)
+	assert.Equal(t, "ctx", task.ContextID)
+}
+
+func TestInMemoryTaskStore_ListDeterministicOrder(t *testing.T) {
+	store := NewInMemoryTaskStore()
+	ids := []string{"c", "a", "b", "e", "d"}
+	for _, id := range ids {
+		_, err := store.Create(id, "ctx")
+		require.NoError(t, err)
+	}
+
+	tasks, err := store.List("ctx", 0, 0)
+	require.NoError(t, err)
+	require.Len(t, tasks, 5)
+
+	// Results must be sorted by ID.
+	for i := 1; i < len(tasks); i++ {
+		assert.True(t, tasks[i-1].ID < tasks[i].ID,
+			"expected %s < %s", tasks[i-1].ID, tasks[i].ID)
+	}
 }
 
 func TestInMemoryTaskStore_EvictTerminal_Empty(t *testing.T) {
@@ -430,9 +498,8 @@ func TestInMemoryTaskStore_EvictTerminal_AllTerminalStates(t *testing.T) {
 			require.NoError(t, store.SetState("t", a2a.TaskStateWorking, nil))
 			require.NoError(t, store.SetState("t", terminal, nil))
 
-			task, _ := store.Get("t")
 			old := time.Now().Add(-2 * time.Hour)
-			task.Status.Timestamp = &old
+			setTaskTimestamp(store, "t", old)
 
 			evicted := store.EvictTerminal(time.Now().Add(-1 * time.Hour))
 			assert.Equal(t, []string{"t"}, evicted)


### PR DESCRIPTION
## Summary
- **H8**: Add panic recovery middleware to A2A HTTP server, returns JSON-RPC error instead of crashing
- **H9**: `InMemoryTaskStore.Get()` and `List()` now return deep copies, preventing callers from mutating store internals
- **M30**: Set `WriteTimeout` to 0 for SSE streaming compatibility, with documented trade-off
- **M31**: Authentication errors no longer leak internal details to clients (logged server-side)
- **M32**: Schema cache now has LRU eviction with max size 64
- **M33**: `validateCrossReferences` uses already-loaded `LoadedScenarios` instead of re-reading files
- **M34**: Fixed module index bug in `LoggingConfigSpec.Validate` (was using `rune('0'+i)` instead of `fmt.Sprintf`)
- **L22**: Task list pagination is now deterministic (sorted by ID)
- **L23**: Broadcaster subscriber count capped at 1000 per task
- **L24**: `writeRPCResult` now checks `json.Marshal` errors and returns JSON-RPC error
- **L25**: Agent card errors no longer leak internal details
- **L26**: Added TODO for singleflight deduplication (golang.org/x/sync not in pkg/ deps)
- **L28**: Clarified `WithStatusCode`/`WithDetails` doc comments to reflect mutate-receiver semantics

## Test plan
- [x] All server/a2a tests pass (coverage 89.7%)
- [x] All pkg tests pass (coverage 90.2%)
- [x] Pre-commit hooks pass (lint, build, test, coverage >=80%)
- [x] New tests for: panic recovery, deep copy isolation, deterministic sort, subscriber limits, LRU cache eviction, module index formatting, auth/card error redaction