### PR TITLE
perf: pipeline, tools, and misc runtime performance fixes

### DIFF
--- a/runtime/pipeline/stage/builder.go
+++ b/runtime/pipeline/stage/builder.go
@@ -118,11 +118,14 @@ func (b *PipelineBuilder) Build() (*StreamPipeline, error) {
 		return nil, err
 	}
 
-	// Precompute root stages (stages with no incoming edges) for O(1) lookup.
+	// Precompute root stages (stages with no incoming edges) and
+	// reverse-edge adjacency map for O(1) upstream lookup.
+	reverseEdges := make(map[string]string)
 	hasIncoming := make(map[string]struct{})
-	for _, toStages := range b.edges {
+	for fromStage, toStages := range b.edges {
 		for _, toStage := range toStages {
 			hasIncoming[toStage] = struct{}{}
+			reverseEdges[toStage] = fromStage
 		}
 	}
 	rootStages := make(map[string]struct{})
@@ -136,6 +139,7 @@ func (b *PipelineBuilder) Build() (*StreamPipeline, error) {
 	return &StreamPipeline{
 		stages:       b.stages,
 		edges:        b.edges,
+		reverseEdges: reverseEdges,
 		rootStages:   rootStages,
 		config:       b.config,
 		eventEmitter: b.eventEmitter,

--- a/runtime/pipeline/stage/element_pool.go
+++ b/runtime/pipeline/stage/element_pool.go
@@ -10,6 +10,11 @@ import (
 
 // elementPool is a sync.Pool for reusing StreamElement instances.
 // This reduces GC pressure in high-throughput pipeline scenarios.
+//
+// TODO: Wire elementPool into hot paths (e.g. collectOutput, runStage,
+// ProviderStage streaming loops) so that elements are obtained via
+// GetElement/PutElement instead of direct allocation. The pool is defined
+// and ready to use but currently unused by the pipeline internals.
 var elementPool = sync.Pool{
 	New: func() interface{} {
 		return &StreamElement{

--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -17,6 +17,7 @@ import (
 type StreamPipeline struct {
 	stages       []Stage
 	edges        map[string][]string // stage name -> downstream stage names
+	reverseEdges map[string]string   // stage name -> upstream stage name (O(1) lookup)
 	rootStages   map[string]struct{} // precomputed set of stages with no incoming edges
 	config       *PipelineConfig
 	eventEmitter *events.Emitter
@@ -211,11 +212,16 @@ func (p *StreamPipeline) isRootStage(stageName string) bool {
 	return ok
 }
 
-// findUpstreamStage finds the stage that feeds into the given stage.
+// findUpstreamStage finds the stage that feeds into the given stage using a
+// precomputed reverse-edge map for O(1) lookup.
 // Note: Fan-in (multiple stages feeding into one) is a Phase 5 enhancement.
 // Current implementation supports single upstream stage per stage (sufficient for linear chains and fan-out).
 // For fan-in/merge patterns, a dedicated MergeStage will be implemented in Phase 5.
 func (p *StreamPipeline) findUpstreamStage(stageName string) string {
+	if p.reverseEdges != nil {
+		return p.reverseEdges[stageName]
+	}
+	// Fallback to linear scan (should not happen with properly built pipelines).
 	for fromStage, toStages := range p.edges {
 		for _, toStage := range toStages {
 			if toStage == stageName {
@@ -269,18 +275,40 @@ func (p *StreamPipeline) runStage(
 	}
 }
 
-// collectOutput collects output from all leaf stages into the pipeline output channel.
+// collectOutput collects output from all leaf stages into the pipeline output
+// channel. Leaf stages are read concurrently so that a slow leaf does not
+// block faster ones.
 func (p *StreamPipeline) collectOutput(channels map[string]chan StreamElement, output chan<- StreamElement) {
-	// Find leaf stages (stages with no outgoing edges)
+	// Identify leaf stages (stages with no outgoing edges).
+	var leafChans []<-chan StreamElement
 	for _, stage := range p.stages {
 		if len(p.edges[stage.Name()]) == 0 {
-			// This is a leaf stage - collect its output
-			stageChan := channels[stage.Name()]
-			for elem := range stageChan {
+			leafChans = append(leafChans, channels[stage.Name()])
+		}
+	}
+
+	if len(leafChans) <= 1 {
+		// Fast path: single leaf — no extra goroutines needed.
+		for _, ch := range leafChans {
+			for elem := range ch {
 				output <- elem
 			}
 		}
+		return
 	}
+
+	// Fan-in: one goroutine per leaf forwards to the shared output channel.
+	var wg sync.WaitGroup
+	wg.Add(len(leafChans))
+	for _, ch := range leafChans {
+		go func(src <-chan StreamElement) {
+			defer wg.Done()
+			for elem := range src {
+				output <- elem
+			}
+		}(ch)
+	}
+	wg.Wait()
 }
 
 // ExecuteSync runs the pipeline synchronously and returns the accumulated result.

--- a/runtime/pipeline/stage/pipeline_internal_test.go
+++ b/runtime/pipeline/stage/pipeline_internal_test.go
@@ -42,8 +42,8 @@ type testPassthroughStage struct {
 	name string
 }
 
-func (s *testPassthroughStage) Name() string      { return s.name }
-func (s *testPassthroughStage) Type() StageType   { return StageTypeTransform }
+func (s *testPassthroughStage) Name() string    { return s.name }
+func (s *testPassthroughStage) Type() StageType { return StageTypeTransform }
 func (s *testPassthroughStage) Process(_ context.Context, in <-chan StreamElement, out chan<- StreamElement) error {
 	defer close(out)
 	for elem := range in {
@@ -166,6 +166,112 @@ func TestWaitForStageErrors(t *testing.T) {
 			t.Errorf("expected %v, got %v", testErr, result)
 		}
 	})
+}
+
+// TestFindUpstreamStage_ReverseEdges verifies O(1) lookup via precomputed reverseEdges.
+func TestFindUpstreamStage_ReverseEdges(t *testing.T) {
+	stageA := &testPassthroughStage{name: "stageA"}
+	stageB := &testPassthroughStage{name: "stageB"}
+	stageC := &testPassthroughStage{name: "stageC"}
+
+	pipeline, err := NewPipelineBuilder().
+		Chain(stageA, stageB, stageC).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// reverseEdges should be populated by Build.
+	if pipeline.reverseEdges == nil {
+		t.Fatal("reverseEdges should not be nil")
+	}
+
+	if upstream := pipeline.findUpstreamStage("stageB"); upstream != "stageA" {
+		t.Errorf("expected stageA upstream of stageB, got %q", upstream)
+	}
+	if upstream := pipeline.findUpstreamStage("stageC"); upstream != "stageB" {
+		t.Errorf("expected stageB upstream of stageC, got %q", upstream)
+	}
+	if upstream := pipeline.findUpstreamStage("stageA"); upstream != "" {
+		t.Errorf("expected empty upstream for root stageA, got %q", upstream)
+	}
+	if upstream := pipeline.findUpstreamStage("nonexistent"); upstream != "" {
+		t.Errorf("expected empty upstream for nonexistent, got %q", upstream)
+	}
+}
+
+// TestFindUpstreamStage_FallbackNilReverseEdges tests the fallback linear scan
+// when reverseEdges is nil (should not happen in practice).
+func TestFindUpstreamStage_FallbackNilReverseEdges(t *testing.T) {
+	pipeline := &StreamPipeline{
+		edges: map[string][]string{
+			"A": {"B"},
+			"B": {"C"},
+		},
+		reverseEdges: nil, // force fallback
+	}
+
+	if upstream := pipeline.findUpstreamStage("B"); upstream != "A" {
+		t.Errorf("fallback: expected A upstream of B, got %q", upstream)
+	}
+	if upstream := pipeline.findUpstreamStage("X"); upstream != "" {
+		t.Errorf("fallback: expected empty for X, got %q", upstream)
+	}
+}
+
+// TestCollectOutput_ConcurrentLeafStages verifies that collectOutput fans
+// in from multiple leaf stages concurrently.
+func TestCollectOutput_ConcurrentLeafStages(t *testing.T) {
+	// Build a fan-out pipeline: A -> B, A -> C (B and C are leaves)
+	stageA := &testPassthroughStage{name: "stageA"}
+	stageB := &testPassthroughStage{name: "stageB"}
+	stageC := &testPassthroughStage{name: "stageC"}
+
+	pipeline, err := NewPipelineBuilder().
+		AddStage(stageA).
+		AddStage(stageB).
+		AddStage(stageC).
+		Connect("stageA", "stageB").
+		Connect("stageA", "stageC").
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Create channels mimicking the stage output channels.
+	channels := map[string]chan StreamElement{
+		"stageA": make(chan StreamElement, 10),
+		"stageB": make(chan StreamElement, 10),
+		"stageC": make(chan StreamElement, 10),
+	}
+
+	// stageA is not a leaf (has outgoing edges), close its channel.
+	close(channels["stageA"])
+
+	// stageB and stageC are leaves; push test elements.
+	text1 := "from-B"
+	text2 := "from-C"
+	channels["stageB"] <- StreamElement{Text: &text1}
+	close(channels["stageB"])
+	channels["stageC"] <- StreamElement{Text: &text2}
+	close(channels["stageC"])
+
+	output := make(chan StreamElement, 10)
+	go func() {
+		pipeline.collectOutput(channels, output)
+		close(output)
+	}()
+
+	var collected []string
+	for elem := range output {
+		if elem.Text != nil {
+			collected = append(collected, *elem.Text)
+		}
+	}
+
+	if len(collected) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(collected))
+	}
 }
 
 // TestEmitCompletionEvent tests the emitCompletionEvent helper function.

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1099,6 +1099,9 @@ func formatToolResult(value interface{}) string {
 	}
 }
 
+// buildProviderTools constructs the tool descriptors sent to the provider.
+// It is called once at the start of each multi-round execution (not per round)
+// so the resulting snapshot is reused across all tool-call rounds.
 func (s *ProviderStage) buildProviderTools(allowedTools []string) (interface{}, string, error) {
 	if s.toolRegistry == nil {
 		return nil, "", nil
@@ -1131,16 +1134,17 @@ func (s *ProviderStage) buildProviderTools(allowedTools []string) (interface{}, 
 
 	// 2. Add capability tools (system-namespaced: skill__, a2a__, workflow__, mcp__, memory__)
 	//    These are registered by capabilities and are always available to the LLM.
-	for name, tool := range s.toolRegistry.GetTools() {
+	//    Uses IterateTools to avoid a full map copy from GetTools.
+	s.toolRegistry.IterateTools(func(name string, tool *tools.ToolDescriptor) {
 		if seen[name] || !tools.IsSystemTool(name) {
-			continue
+			return
 		}
 		descriptors = append(descriptors, &providers.ToolDescriptor{
 			Name:        tool.Name,
 			Description: tool.Description,
 			InputSchema: tool.InputSchema,
 		})
-	}
+	})
 
 	if len(descriptors) == 0 {
 		return nil, "", nil

--- a/runtime/pipeline/stage/stages_token_budget.go
+++ b/runtime/pipeline/stage/stages_token_budget.go
@@ -188,40 +188,50 @@ func (s *TokenBudgetStage) enforceTokenBudget(
 // truncateMessages removes old non-system messages to fit within the budget.
 // It keeps system messages at the start and fills from the most recent
 // messages backward until the budget is exhausted.
+//
+// Token counts are pre-computed once per message and reused via a running
+// sum to avoid re-counting during selection.
 func (s *TokenBudgetStage) truncateMessages(
 	messages []types.Message,
 	systemPrompt string,
 	budget int,
 ) []types.Message {
-	// Separate system messages (at the start) from conversation messages
+	// Pre-compute per-message token counts once.
+	tokenCounts := s.precomputeTokenCounts(messages)
+
+	// Separate system messages from conversation messages, tracking
+	// token totals via the precomputed counts.
 	var systemMsgs []types.Message
 	var conversationMsgs []types.Message
+	var conversationTokens []int
 
+	systemTokens := 0
 	for i := range messages {
 		if messages[i].Role == roleSystem {
 			systemMsgs = append(systemMsgs, messages[i])
+			systemTokens += tokenCounts[i]
 		} else {
 			conversationMsgs = append(conversationMsgs, messages[i])
+			conversationTokens = append(conversationTokens, tokenCounts[i])
 		}
 	}
 
-	// Calculate tokens used by system messages and prompt
-	usedTokens := s.config.TokenCounter.CountMessageTokens(systemMsgs)
+	// Account for system prompt tokens.
 	if systemPrompt != "" {
-		usedTokens += s.config.TokenCounter.CountTokensContentAware(systemPrompt)
+		systemTokens += s.config.TokenCounter.CountTokensContentAware(systemPrompt)
 	}
 
-	remainingBudget := budget - usedTokens
+	remainingBudget := budget - systemTokens
 	if remainingBudget <= 0 {
 		// System messages alone exceed the budget; return them anyway
 		logger.Warn("System messages exceed token budget",
-			"system_tokens", usedTokens,
+			"system_tokens", systemTokens,
 			"budget", budget)
 		return systemMsgs
 	}
 
-	// Fill from most recent messages backward
-	kept := s.selectRecentMessages(conversationMsgs, remainingBudget)
+	// Fill from most recent messages backward using precomputed counts.
+	kept := s.selectRecentMessagesPrecomputed(conversationMsgs, conversationTokens, remainingBudget)
 
 	originalCount := len(messages)
 	truncatedCount := originalCount - len(systemMsgs) - len(kept)
@@ -238,23 +248,41 @@ func (s *TokenBudgetStage) truncateMessages(
 	return result
 }
 
+// precomputeTokenCounts returns per-message token counts so that subsequent
+// logic can use a running sum instead of re-counting.
+func (s *TokenBudgetStage) precomputeTokenCounts(messages []types.Message) []int {
+	counts := make([]int, len(messages))
+	for i := range messages {
+		counts[i] = s.config.TokenCounter.CountMessageTokens(messages[i : i+1])
+	}
+	return counts
+}
+
 // selectRecentMessages picks the most recent messages that fit within
 // the given token budget, working backward from the end.
 func (s *TokenBudgetStage) selectRecentMessages(
 	messages []types.Message,
 	budget int,
 ) []types.Message {
+	counts := s.precomputeTokenCounts(messages)
+	return s.selectRecentMessagesPrecomputed(messages, counts, budget)
+}
+
+// selectRecentMessagesPrecomputed picks the most recent messages using
+// precomputed per-message token counts, avoiding redundant counting.
+func (s *TokenBudgetStage) selectRecentMessagesPrecomputed(
+	messages []types.Message,
+	tokenCounts []int,
+	budget int,
+) []types.Message {
 	usedTokens := 0
 	startIdx := len(messages)
 
 	for i := len(messages) - 1; i >= 0; i-- {
-		msgTokens := s.config.TokenCounter.CountMessageTokens(
-			messages[i : i+1],
-		)
-		if usedTokens+msgTokens > budget {
+		if usedTokens+tokenCounts[i] > budget {
 			break
 		}
-		usedTokens += msgTokens
+		usedTokens += tokenCounts[i]
 		startIdx = i
 	}
 

--- a/runtime/skills/executor.go
+++ b/runtime/skills/executor.go
@@ -14,6 +14,7 @@ type Executor struct {
 	selector  SkillSelector
 	active    map[string]*Skill // currently active skills, keyed by name
 	packTools []string          // all tools declared in the pack (the ceiling)
+	packSet   map[string]bool   // pre-built set from packTools for O(1) membership checks
 	maxActive int               // max concurrent active skills (0 = unlimited)
 	mu        sync.RWMutex
 }
@@ -33,11 +34,18 @@ func NewExecutor(cfg ExecutorConfig) *Executor {
 	if sel == nil {
 		sel = NewModelDrivenSelector()
 	}
+	// Pre-build the packSet map once so intersectPackTools avoids
+	// rebuilding it on every call.
+	packSet := make(map[string]bool, len(cfg.PackTools))
+	for _, t := range cfg.PackTools {
+		packSet[t] = true
+	}
 	return &Executor{
 		registry:  cfg.Registry,
 		selector:  sel,
 		active:    make(map[string]*Skill),
 		packTools: cfg.PackTools,
+		packSet:   packSet,
 		maxActive: cfg.MaxActive,
 	}
 }
@@ -181,20 +189,17 @@ func (e *Executor) ActiveTools() []string {
 }
 
 // intersectPackTools returns elements of skillTools that also appear in packTools.
+// Uses the pre-built packSet for O(1) membership checks instead of rebuilding
+// the map on every call.
 // Must be called with e.mu held (read or write).
 func (e *Executor) intersectPackTools(skillTools []string) []string {
-	if len(e.packTools) == 0 || len(skillTools) == 0 {
+	if len(e.packSet) == 0 || len(skillTools) == 0 {
 		return nil
-	}
-
-	packSet := make(map[string]bool, len(e.packTools))
-	for _, t := range e.packTools {
-		packSet[t] = true
 	}
 
 	var result []string
 	for _, t := range skillTools {
-		if packSet[t] {
+		if e.packSet[t] {
 			result = append(result, t)
 		}
 	}

--- a/runtime/tools/executors.go
+++ b/runtime/tools/executors.go
@@ -8,10 +8,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"text/template"
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// templateCache caches compiled Go text/templates keyed by the raw template
+// string. This avoids re-parsing the same template on every mock call.
+var templateCache sync.Map // map[string]*template.Template
 
 const (
 	modeMock             = "mock"
@@ -185,8 +190,10 @@ func (e *MockScriptedExecutor) Execute(
 }
 
 // processTemplate renders a Go text/template with provided arguments.
+// Compiled templates are cached by template string via templateCache (sync.Map)
+// so that repeated calls with the same template skip the parse step.
 func (e *MockScriptedExecutor) processTemplate(tmpl string, args map[string]any) (string, error) {
-	t, err := template.New("mock").Option("missingkey=zero").Parse(tmpl)
+	t, err := getOrParseTemplate(tmpl)
 	if err != nil {
 		return "", err
 	}
@@ -195,4 +202,20 @@ func (e *MockScriptedExecutor) processTemplate(tmpl string, args map[string]any)
 		return "", err
 	}
 	return out.String(), nil
+}
+
+// getOrParseTemplate returns a cached compiled template or parses and caches it.
+func getOrParseTemplate(tmpl string) (*template.Template, error) {
+	if cached, ok := templateCache.Load(tmpl); ok {
+		return cached.(*template.Template), nil
+	}
+
+	t, err := template.New("mock").Option("missingkey=zero").Parse(tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store and return (race-safe: if another goroutine stored first, we use theirs).
+	actual, _ := templateCache.LoadOrStore(tmpl, t)
+	return actual.(*template.Template), nil
 }

--- a/runtime/tools/executors_test.go
+++ b/runtime/tools/executors_test.go
@@ -1,0 +1,89 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessTemplate_CachesCompiledTemplates(t *testing.T) {
+	executor := &MockScriptedExecutor{}
+	tmpl := `{"greeting": "hello {{.name}}"}`
+	args := map[string]any{"name": "world"}
+
+	// First call: compiles and caches.
+	result1, err := executor.processTemplate(tmpl, args)
+	require.NoError(t, err)
+	assert.Contains(t, result1, "hello world")
+
+	// Second call: should hit cache; result identical.
+	result2, err := executor.processTemplate(tmpl, args)
+	require.NoError(t, err)
+	assert.Equal(t, result1, result2)
+
+	// Verify the template is actually in the cache.
+	cached, ok := templateCache.Load(tmpl)
+	assert.True(t, ok, "template should be in cache")
+	assert.NotNil(t, cached)
+}
+
+func TestProcessTemplate_InvalidTemplate(t *testing.T) {
+	executor := &MockScriptedExecutor{}
+	_, err := executor.processTemplate(`{{.invalid`, nil)
+	assert.Error(t, err)
+}
+
+func TestProcessTemplate_DifferentTemplatesCached(t *testing.T) {
+	executor := &MockScriptedExecutor{}
+	tmplA := `{"a": "{{.x}}"}`
+	tmplB := `{"b": "{{.y}}"}`
+
+	_, err := executor.processTemplate(tmplA, map[string]any{"x": "1"})
+	require.NoError(t, err)
+	_, err = executor.processTemplate(tmplB, map[string]any{"y": "2"})
+	require.NoError(t, err)
+
+	_, okA := templateCache.Load(tmplA)
+	_, okB := templateCache.Load(tmplB)
+	assert.True(t, okA)
+	assert.True(t, okB)
+}
+
+func TestMockScriptedExecutor_Execute(t *testing.T) {
+	executor := NewMockScriptedExecutor()
+
+	t.Run("renders template from descriptor", func(t *testing.T) {
+		descriptor := &ToolDescriptor{
+			Name:         "test-scripted",
+			Mode:         modeMock,
+			MockTemplate: `{"result": "{{.input}}"}`,
+		}
+		args := json.RawMessage(`{"input": "hello"}`)
+		result, err := executor.Execute(context.Background(), descriptor, args)
+		require.NoError(t, err)
+		assert.Contains(t, string(result), "hello")
+	})
+
+	t.Run("rejects non-mock mode", func(t *testing.T) {
+		descriptor := &ToolDescriptor{
+			Name:         "test-live",
+			Mode:         modeLive,
+			MockTemplate: `{"result": "nope"}`,
+		}
+		_, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
+		assert.ErrorIs(t, err, ErrMockExecutorOnly)
+	})
+
+	t.Run("error when no template", func(t *testing.T) {
+		descriptor := &ToolDescriptor{
+			Name: "test-empty",
+			Mode: modeMock,
+		}
+		_, err := executor.Execute(context.Background(), descriptor, json.RawMessage(`{}`))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no mock template")
+	})
+}

--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -280,7 +280,9 @@ func (r *Registry) GetTool(name string) (*ToolDescriptor, error) {
 	return tool, nil
 }
 
-// GetTools returns all loaded tool descriptors.
+// GetTools returns all loaded tool descriptors. The returned map is a shallow
+// copy (safe to iterate/delete keys), but the *ToolDescriptor pointers are
+// shared with the registry. Callers MUST NOT mutate the returned descriptors.
 func (r *Registry) GetTools() map[string]*ToolDescriptor {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -290,6 +292,19 @@ func (r *Registry) GetTools() map[string]*ToolDescriptor {
 		result[name] = tool
 	}
 	return result
+}
+
+// IterateTools calls fn for each loaded tool descriptor while holding the
+// read lock. This avoids the map copy that GetTools performs, which matters
+// when the registry is large and the caller only needs to inspect each tool
+// once (e.g. building a provider tool list).
+// The callback MUST NOT call back into the Registry (deadlock).
+func (r *Registry) IterateTools(fn func(name string, tool *ToolDescriptor)) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for name, tool := range r.tools {
+		fn(name, tool)
+	}
 }
 
 // GetToolsByNames returns tool descriptors for the specified names

--- a/runtime/tools/registry_test.go
+++ b/runtime/tools/registry_test.go
@@ -270,7 +270,7 @@ func TestExecute_MockStatic(t *testing.T) {
 	_ = registry.Register(descriptor)
 
 	args := json.RawMessage(`{"input": "test"}`)
-	result, err := registry.Execute(context.Background(),"static_tool", args)
+	result, err := registry.Execute(context.Background(), "static_tool", args)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestExecute_MockScripted(t *testing.T) {
 	_ = registry.Register(descriptor)
 
 	args := json.RawMessage(`{"name": "World"}`)
-	result, err := registry.Execute(context.Background(),"scripted_tool", args)
+	result, err := registry.Execute(context.Background(), "scripted_tool", args)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestExecute_NonExistentTool(t *testing.T) {
 	registry := tools.NewRegistry()
 
 	args := json.RawMessage(`{}`)
-	_, err := registry.Execute(context.Background(),"nonexistent", args)
+	_, err := registry.Execute(context.Background(), "nonexistent", args)
 	if err == nil {
 		t.Error("Execute should fail for non-existent tool")
 	}
@@ -370,14 +370,14 @@ func TestExecute_InvalidArgs(t *testing.T) {
 
 	// Missing required field
 	invalidArgs := json.RawMessage(`{}`)
-	_, err := registry.Execute(context.Background(),"validate_tool", invalidArgs)
+	_, err := registry.Execute(context.Background(), "validate_tool", invalidArgs)
 	if err == nil {
 		t.Error("Execute should fail with invalid args")
 	}
 
 	// Empty required field
 	invalidArgs2 := json.RawMessage(`{"required_field": ""}`)
-	_, err = registry.Execute(context.Background(),"validate_tool", invalidArgs2)
+	_, err = registry.Execute(context.Background(), "validate_tool", invalidArgs2)
 	if err == nil {
 		t.Error("Execute should fail with empty required field")
 	}
@@ -406,7 +406,7 @@ func TestExecute_ResultValidation(t *testing.T) {
 	_ = registry.Register(descriptor)
 
 	args := json.RawMessage(`{}`)
-	result, err := registry.Execute(context.Background(),"output_validate", args)
+	result, err := registry.Execute(context.Background(), "output_validate", args)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestExecute_LatencyTracking(t *testing.T) {
 	_ = registry.Register(descriptor)
 
 	args := json.RawMessage(`{}`)
-	result, err := registry.Execute(context.Background(),"latency_tool", args)
+	result, err := registry.Execute(context.Background(), "latency_tool", args)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -540,7 +540,7 @@ func TestGetExecutorForTool_CustomExecutor(t *testing.T) {
 	}
 
 	// Execute should route to our custom executor
-	result, err := registry.Execute(context.Background(),"custom_tool", json.RawMessage(`{"input": "test"}`))
+	result, err := registry.Execute(context.Background(), "custom_tool", json.RawMessage(`{"input": "test"}`))
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -626,7 +626,7 @@ func TestGetExecutorForTool_BuiltInModes(t *testing.T) {
 				t.Fatalf("Register failed: %v", err)
 			}
 
-			_, err = registry.Execute(context.Background(),descriptor.Name, json.RawMessage(`{}`))
+			_, err = registry.Execute(context.Background(), descriptor.Name, json.RawMessage(`{}`))
 			if tt.expectError && err == nil {
 				t.Error("Expected error but got none")
 			}
@@ -658,7 +658,7 @@ func TestGetExecutorForTool_UnknownModeNoExecutor(t *testing.T) {
 	}
 
 	// Execution should fail because no executor matches the mode
-	_, err = registry.Execute(context.Background(),"unknown_mode_tool", json.RawMessage(`{}`))
+	_, err = registry.Execute(context.Background(), "unknown_mode_tool", json.RawMessage(`{}`))
 	if err == nil {
 		t.Fatal("Expected error when executing tool with unknown mode")
 	}
@@ -697,7 +697,7 @@ func TestExecuteAsync_CustomExecutor(t *testing.T) {
 	}
 
 	// ExecuteAsync should route to our custom executor
-	result, err := registry.ExecuteAsync(context.Background(),"async_custom_tool", json.RawMessage(`{}`))
+	result, err := registry.ExecuteAsync(context.Background(), "async_custom_tool", json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("ExecuteAsync failed: %v", err)
 	}
@@ -828,9 +828,9 @@ func TestRegister_PopulatesNamespace(t *testing.T) {
 	registry := tools.NewRegistry()
 
 	tests := []struct {
-		name    string
-		toolNm  string
-		wantNS  string
+		name   string
+		toolNm string
+		wantNS string
 	}{
 		{"plain tool", "get_weather", ""},
 		{"a2a namespaced", "a2a__weather__forecast", "a2a"},
@@ -973,5 +973,36 @@ func TestGetExecutorForTool_ClientModeFallsBackToMock(t *testing.T) {
 	// Should come from mock since no client executor is registered
 	if data["source"] != "mock" {
 		t.Errorf("Expected mock, got %v", data["source"])
+	}
+}
+
+// TestIterateTools verifies IterateTools visits all registered tools without
+// producing a map copy.
+func TestIterateTools(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	descs := []tools.ToolDescriptor{
+		{Name: "tool_a", Description: "A", InputSchema: json.RawMessage(`{"type":"object"}`), OutputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "tool_b", Description: "B", InputSchema: json.RawMessage(`{"type":"object"}`), OutputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	for i := range descs {
+		if err := registry.Register(&descs[i]); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+	}
+
+	visited := make(map[string]bool)
+	registry.IterateTools(func(name string, tool *tools.ToolDescriptor) {
+		visited[name] = true
+		if tool == nil {
+			t.Errorf("nil tool for name %q", name)
+		}
+	})
+
+	if len(visited) != 2 {
+		t.Errorf("expected 2 tools visited, got %d", len(visited))
+	}
+	if !visited["tool_a"] || !visited["tool_b"] {
+		t.Errorf("expected both tools visited, got %v", visited)
 	}
 }

--- a/runtime/tools/validator.go
+++ b/runtime/tools/validator.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"container/list"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -8,16 +9,41 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// SchemaValidator handles JSON schema validation for tool inputs and outputs
-type SchemaValidator struct {
-	cache map[string]*gojsonschema.Schema
-	mu    sync.RWMutex
+// DefaultMaxSchemaCacheSize is the maximum number of compiled JSON schemas
+// held in the validator cache. When full the least-recently-used entry is
+// evicted.
+const DefaultMaxSchemaCacheSize = 128
+
+// schemaEntry is a single entry in the LRU schema cache.
+type schemaEntry struct {
+	key    string
+	schema *gojsonschema.Schema
 }
 
-// NewSchemaValidator creates a new schema validator
+// SchemaValidator handles JSON schema validation for tool inputs and outputs.
+// It maintains an LRU cache of compiled schemas bounded by maxCacheSize.
+type SchemaValidator struct {
+	cache   map[string]*list.Element
+	order   *list.List // front = most recently used
+	maxSize int
+	mu      sync.RWMutex
+}
+
+// NewSchemaValidator creates a new schema validator with the default cache size.
 func NewSchemaValidator() *SchemaValidator {
+	return NewSchemaValidatorWithSize(DefaultMaxSchemaCacheSize)
+}
+
+// NewSchemaValidatorWithSize creates a new schema validator with the given
+// maximum cache size. If maxSize <= 0 it defaults to DefaultMaxSchemaCacheSize.
+func NewSchemaValidatorWithSize(maxSize int) *SchemaValidator {
+	if maxSize <= 0 {
+		maxSize = DefaultMaxSchemaCacheSize
+	}
 	return &SchemaValidator{
-		cache: make(map[string]*gojsonschema.Schema),
+		cache:   make(map[string]*list.Element, maxSize),
+		order:   list.New(),
+		maxSize: maxSize,
 	}
 }
 
@@ -87,33 +113,60 @@ func (sv *SchemaValidator) ValidateResult(descriptor *ToolDescriptor, result jso
 	return nil
 }
 
-// getSchema retrieves or compiles a JSON schema
+// getSchema retrieves or compiles a JSON schema. Compiled schemas are cached
+// in an LRU cache bounded by maxSize; when full the least-recently-used entry
+// is evicted.
 func (sv *SchemaValidator) getSchema(schemaJSON string) (*gojsonschema.Schema, error) {
-	// First check with read lock
+	// Fast path: read lock lookup + promote to front.
 	sv.mu.RLock()
-	if schema, exists := sv.cache[schemaJSON]; exists {
+	if elem, exists := sv.cache[schemaJSON]; exists {
 		sv.mu.RUnlock()
-		return schema, nil
+		// Promote requires write lock.
+		sv.mu.Lock()
+		sv.order.MoveToFront(elem)
+		sv.mu.Unlock()
+		return elem.Value.(*schemaEntry).schema, nil
 	}
 	sv.mu.RUnlock()
 
-	// Compile schema outside of lock
+	// Compile schema outside of lock.
 	schemaLoader := gojsonschema.NewStringLoader(schemaJSON)
 	schema, err := gojsonschema.NewSchema(schemaLoader)
 	if err != nil {
 		return nil, err
 	}
 
-	// Write to cache with write lock
+	// Write to cache with write lock.
 	sv.mu.Lock()
-	// Double-check in case another goroutine added it
-	if existing, exists := sv.cache[schemaJSON]; exists {
+	// Double-check in case another goroutine added it.
+	if elem, exists := sv.cache[schemaJSON]; exists {
+		sv.order.MoveToFront(elem)
 		sv.mu.Unlock()
-		return existing, nil
+		return elem.Value.(*schemaEntry).schema, nil
 	}
-	sv.cache[schemaJSON] = schema
+
+	// Evict LRU if at capacity.
+	if sv.order.Len() >= sv.maxSize {
+		oldest := sv.order.Back()
+		if oldest != nil {
+			sv.order.Remove(oldest)
+			delete(sv.cache, oldest.Value.(*schemaEntry).key)
+		}
+	}
+
+	entry := &schemaEntry{key: schemaJSON, schema: schema}
+	elem := sv.order.PushFront(entry)
+	sv.cache[schemaJSON] = elem
 	sv.mu.Unlock()
 	return schema, nil
+}
+
+// CacheLen returns the number of entries currently in the schema cache.
+// Exported for testing and monitoring.
+func (sv *SchemaValidator) CacheLen() int {
+	sv.mu.RLock()
+	defer sv.mu.RUnlock()
+	return sv.order.Len()
 }
 
 // CoerceResult attempts to coerce simple type mismatches in tool results

--- a/runtime/tools/validator_test.go
+++ b/runtime/tools/validator_test.go
@@ -70,10 +70,8 @@ func TestSchemaValidator_ValidateArgs(t *testing.T) {
 		err = validator.ValidateArgs(descriptor, args)
 		assert.NoError(t, err)
 
-		// Verify cache contains the schema
-		schemaKey := string(descriptor.InputSchema)
-		_, exists := validator.cache[schemaKey]
-		assert.True(t, exists)
+		// Verify cache contains the schema (via CacheLen)
+		assert.Greater(t, validator.CacheLen(), 0)
 	})
 }
 
@@ -237,6 +235,52 @@ func TestSchemaValidator_CoerceResult(t *testing.T) {
 		assert.Nil(t, coerced)
 		assert.Nil(t, coercions)
 	})
+}
+
+func TestSchemaValidator_LRUEviction(t *testing.T) {
+	// Create a validator with a tiny cache (size 2) to test eviction.
+	validator := NewSchemaValidatorWithSize(2)
+
+	schema1 := `{"type":"object","properties":{"a":{"type":"string"}}}`
+	schema2 := `{"type":"object","properties":{"b":{"type":"string"}}}`
+	schema3 := `{"type":"object","properties":{"c":{"type":"string"}}}`
+
+	// Fill the cache with 2 entries.
+	_, err := validator.getSchema(schema1)
+	require.NoError(t, err)
+	_, err = validator.getSchema(schema2)
+	require.NoError(t, err)
+	assert.Equal(t, 2, validator.CacheLen())
+
+	// Adding a 3rd should evict the LRU (schema1).
+	_, err = validator.getSchema(schema3)
+	require.NoError(t, err)
+	assert.Equal(t, 2, validator.CacheLen())
+
+	// schema1 should have been evicted (re-add will not increase size beyond 2).
+	// Access schema2 to make it MRU, then add schema1 — schema3 should be evicted.
+	_, err = validator.getSchema(schema2)
+	require.NoError(t, err)
+	_, err = validator.getSchema(schema1)
+	require.NoError(t, err)
+	assert.Equal(t, 2, validator.CacheLen())
+
+	// schema3 was LRU and should be evicted; schema2 and schema1 remain.
+	// Re-access schema2 and schema1 to confirm they are still cached.
+	_, err = validator.getSchema(schema2)
+	assert.NoError(t, err)
+	_, err = validator.getSchema(schema1)
+	assert.NoError(t, err)
+}
+
+func TestSchemaValidator_DefaultCacheSize(t *testing.T) {
+	v := NewSchemaValidator()
+	assert.Equal(t, DefaultMaxSchemaCacheSize, v.maxSize)
+}
+
+func TestSchemaValidatorWithSize_ZeroDefaults(t *testing.T) {
+	v := NewSchemaValidatorWithSize(0)
+	assert.Equal(t, DefaultMaxSchemaCacheSize, v.maxSize)
 }
 
 func TestSchemaValidator_coerceValue(t *testing.T) {


### PR DESCRIPTION
## Summary

Medium and low-priority performance fixes from the scalability review (items M4-M7, L3-L6, L11):

- **M4**: Bounded LRU schema validator cache (128 entries, evicts LRU) replacing unbounded map
- **M5**: Concurrent fan-in for leaf stage output collection (goroutine per leaf via WaitGroup)
- **M6**: Zero-copy `IterateTools()` method on Registry; replaces `GetTools()` map copy in `buildProviderTools`
- **M7**: Pre-compute per-message token counts once in token budget stage; running sum during selection
- **L3**: Cache compiled Go text/templates via `sync.Map` in mock scripted executor
- **L4**: Doc comment on `GetTools()` clarifying returned descriptors must not be mutated
- **L5**: Reverse-edge adjacency map built at pipeline construction for O(1) upstream lookup
- **L6**: TODO comment on `element_pool.go` noting pool is ready but not yet wired into hot paths
- **L11**: Pre-built `packSet` map in skills `NewExecutor` avoids rebuild on every `intersectPackTools` call

## Test plan

- [x] All existing runtime tests pass (`go test ./... -count=1`)
- [x] New tests for LRU cache eviction, reverse-edge lookup, concurrent leaf fan-in, template caching, IterateTools
- [x] Pre-commit hooks pass (lint, build, coverage >= 80% on all changed files)
- [x] Zero new lint issues (`golangci-lint run --new-from-rev=HEAD`)