### PR TITLE
fix: SDK reliability and performance improvements

### DIFF
--- a/sdk/agui/adapter.go
+++ b/sdk/agui/adapter.go
@@ -8,6 +8,7 @@ import (
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/sdk"
 )
@@ -422,7 +423,8 @@ func (a *EventAdapter) emit(event aguievents.Event) {
 	select {
 	case a.events <- event:
 	default:
-		// Drop event if buffer is full to prevent blocking
+		// Drop event if buffer is full to prevent blocking.
+		logger.Warn("AG-UI event dropped: channel buffer full", "event_type", event.Type())
 	}
 }
 

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -142,7 +142,8 @@ type Conversation struct {
 	mcpRegistry mcp.Registry
 
 	// Platform capabilities (workflow, a2a, memory, etc.)
-	capabilities []Capability
+	capabilities           []Capability
+	capabilitiesRegistered bool // guards against re-registering capability tools on every pipeline build
 
 	// Hook registry for policy enforcement (nil = no hooks)
 	hookRegistry *hooks.Registry
@@ -289,8 +290,8 @@ func (c *Conversation) buildPipelineConfig(
 		}
 	}
 
-	// Build tool registry
-	c.handlersMu.RLock()
+	// Build tool registry — uses write lock because RegisterExecutor/RegisterTools mutate state
+	c.handlersMu.Lock()
 	localExec := &localExecutor{handlers: c.handlers, ctxHandlers: c.ctxHandlers}
 	c.toolRegistry.RegisterExecutor(localExec)
 
@@ -304,12 +305,15 @@ func (c *Conversation) buildPipelineConfig(
 	c.toolRegistry.RegisterExecutor(clientExec)
 
 	c.registerMCPExecutors()
-	// Register capability tools (includes A2A)
-	for _, cap := range c.capabilities {
-		cap.RegisterTools(c.toolRegistry)
+	// Register capability tools (includes A2A) — only on first build
+	if !c.capabilitiesRegistered {
+		for _, cap := range c.capabilities {
+			cap.RegisterTools(c.toolRegistry)
+		}
+		c.capabilitiesRegistered = true
 	}
 	toolRegistry := c.toolRegistry
-	c.handlersMu.RUnlock()
+	c.handlersMu.Unlock()
 
 	// Create event emitter if event bus is configured
 	var eventEmitter *events.Emitter
@@ -655,6 +659,9 @@ func (c *Conversation) SetVars(vars map[string]any) {
 //	conv.SetVarsFromEnv("PROMPTKIT_")
 //	// Sets variable "customer_name" = "Alice"
 func (c *Conversation) SetVarsFromEnv(prefix string) {
+	// O(N) scan of all env vars is acceptable here — os.Environ() is called
+	// infrequently (typically once at startup) and the alternative (os.LookupEnv
+	// per variable) would require knowing variable names in advance.
 	const envKeyValueParts = 2 // key=value split parts
 	for _, env := range os.Environ() {
 		parts := strings.SplitN(env, "=", envKeyValueParts)
@@ -769,13 +776,26 @@ func (c *Conversation) Fork() *Conversation {
 		return nil
 	}
 
+	// Create a new tool registry for the fork, copying tool descriptors from the original.
+	// This prevents mutations in the fork from affecting the parent's registry.
+	forkRegistry := tools.NewRegistry()
+	for _, desc := range c.toolRegistry.GetTools() {
+		_ = forkRegistry.Register(&tools.ToolDescriptor{
+			Name:        desc.Name,
+			Description: desc.Description,
+			InputSchema: desc.InputSchema,
+			Mode:        desc.Mode,
+			Namespace:   desc.Namespace,
+		})
+	}
+
 	// Create the forked conversation
 	fork := &Conversation{
 		pack:           c.pack,
 		prompt:         c.prompt,
 		promptName:     c.promptName,
 		promptRegistry: c.promptRegistry,
-		toolRegistry:   c.toolRegistry,
+		toolRegistry:   forkRegistry,
 		config:         c.config,
 		mode:           c.mode,
 		handlers:       handlers,

--- a/sdk/conversation_test.go
+++ b/sdk/conversation_test.go
@@ -1850,9 +1850,8 @@ func TestBuildPipelineWithRAGContextOptions(t *testing.T) {
 				retrievalProvider: &mockEmbeddingProvider{},
 				retrievalTopK:     3,
 			},
-			mode:          UnaryMode,
-			handlers:      make(map[string]ToolHandler),
-
+			mode:     UnaryMode,
+			handlers: make(map[string]ToolHandler),
 		}
 
 		pipeline, err := conv.buildPipelineWithParams(store, "test-conv", nil, nil)
@@ -1875,9 +1874,8 @@ func TestBuildPipelineWithRAGContextOptions(t *testing.T) {
 				summarizeThreshold: 50,
 				summarizeBatchSize: 10,
 			},
-			mode:          UnaryMode,
-			handlers:      make(map[string]ToolHandler),
-
+			mode:     UnaryMode,
+			handlers: make(map[string]ToolHandler),
 		}
 
 		pipeline, err := conv.buildPipelineWithParams(store, "test-conv", nil, nil)
@@ -1897,14 +1895,13 @@ func TestBuildPipelineWithRAGContextOptions(t *testing.T) {
 				stateStore:         store,
 				contextWindow:      10,
 				retrievalProvider:  &mockEmbeddingProvider{},
-				retrievalTopK:     3,
+				retrievalTopK:      3,
 				summarizeProvider:  &mockSummarizeProvider{},
 				summarizeThreshold: 50,
 				summarizeBatchSize: 10,
 			},
-			mode:          UnaryMode,
-			handlers:      make(map[string]ToolHandler),
-
+			mode:     UnaryMode,
+			handlers: make(map[string]ToolHandler),
 		}
 
 		pipeline, err := conv.buildPipelineWithParams(store, "test-conv", nil, nil)
@@ -1986,10 +1983,50 @@ type closeErrorCapability struct {
 	closeErr error
 }
 
-func (c *closeErrorCapability) Name() string                        { return c.name }
-func (c *closeErrorCapability) Init(_ CapabilityContext) error      { return nil }
-func (c *closeErrorCapability) RegisterTools(_ *tools.Registry)     {}
-func (c *closeErrorCapability) Close() error                        { return c.closeErr }
+func (c *closeErrorCapability) Name() string                    { return c.name }
+func (c *closeErrorCapability) Init(_ CapabilityContext) error  { return nil }
+func (c *closeErrorCapability) RegisterTools(_ *tools.Registry) {}
+func (c *closeErrorCapability) Close() error                    { return c.closeErr }
+
+func TestForkRegistryIsolation(t *testing.T) {
+	conv := newTestConversation()
+
+	// Register a tool in the original
+	schema := json.RawMessage(`{"type":"object","properties":{}}`)
+	_ = conv.toolRegistry.Register(&tools.ToolDescriptor{
+		Name:        "original_tool",
+		Description: "A tool in the original conversation",
+		InputSchema: schema,
+	})
+
+	fork := conv.Fork()
+	require.NotNil(t, fork)
+
+	// Fork should have the original tool
+	forkTools := fork.toolRegistry.GetTools()
+	foundOriginal := false
+	for _, td := range forkTools {
+		if td.Name == "original_tool" {
+			foundOriginal = true
+			break
+		}
+	}
+	assert.True(t, foundOriginal, "fork should have copied original_tool")
+
+	// Register a new tool in the fork — should NOT appear in original
+	_ = fork.toolRegistry.Register(&tools.ToolDescriptor{
+		Name:        "fork_only_tool",
+		Description: "A tool only in the fork",
+		InputSchema: schema,
+	})
+
+	origTools := conv.toolRegistry.GetTools()
+	for _, td := range origTools {
+		if td.Name == "fork_only_tool" {
+			t.Error("fork_only_tool should NOT appear in original registry")
+		}
+	}
+}
 
 func TestForkErrorHandling(t *testing.T) {
 	t.Run("fork preserves handlers", func(t *testing.T) {

--- a/sdk/conversation_test.go
+++ b/sdk/conversation_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -2222,4 +2223,11 @@ func TestForkPreservesHookRegistry(t *testing.T) {
 	require.NotNil(t, forked)
 	assert.Equal(t, reg, forked.hookRegistry)
 	assert.NotNil(t, forked.sessionHooks)
+}
+
+func TestSetLoggerOnce(t *testing.T) {
+	l := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Should not panic even if called multiple times.
+	setLoggerOnce(l)
+	setLoggerOnce(l)
 }

--- a/sdk/eval_integration_test.go
+++ b/sdk/eval_integration_test.go
@@ -177,8 +177,8 @@ func TestE2E_EvalMiddleware_TurnIndexIncrements(t *testing.T) {
 		}
 	}
 
-	if mw.turnIndex != 3 {
-		t.Errorf("expected turnIndex 3, got %d", mw.turnIndex)
+	if mw.turnIndex.Load() != 3 {
+		t.Errorf("expected turnIndex 3, got %d", mw.turnIndex.Load())
 	}
 
 	mu.Lock()

--- a/sdk/eval_middleware.go
+++ b/sdk/eval_middleware.go
@@ -3,10 +3,12 @@ package sdk
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // DefaultMaxConcurrentEvals is the default maximum number of concurrent eval goroutines.
@@ -18,7 +20,7 @@ type evalMiddleware struct {
 	defs      []evals.EvalDef
 	emitter   *events.Emitter // nil-safe (bus may not be configured)
 	conv      *Conversation
-	turnIndex int
+	turnIndex atomic.Int32 // atomic for thread safety across concurrent Send() calls
 
 	// Goroutine lifecycle management for async turn evals.
 	wg     sync.WaitGroup     // tracks in-flight turn eval goroutines
@@ -27,6 +29,12 @@ type evalMiddleware struct {
 
 	// Bounded concurrency: sem limits how many eval goroutines run simultaneously.
 	sem chan struct{}
+
+	// Cached messages to avoid reloading on every dispatch.
+	cachedMessages   []types.Message
+	cachedTurnIndex  int32
+	cachedSessionID  string
+	cachedLastOutput string
 }
 
 // newEvalMiddleware creates eval middleware for a conversation.
@@ -102,7 +110,7 @@ func (em *evalMiddleware) dispatchTurnEvals(ctx context.Context) {
 		return
 	}
 
-	em.turnIndex++
+	turn := em.turnIndex.Add(1)
 
 	// Try to acquire the semaphore without blocking. If all slots are taken,
 	// skip this eval dispatch to prevent unbounded goroutine growth.
@@ -111,7 +119,7 @@ func (em *evalMiddleware) dispatchTurnEvals(ctx context.Context) {
 		// Acquired — proceed
 	default:
 		logger.Warn("evals: semaphore full, skipping turn eval dispatch",
-			"turn", em.turnIndex, "capacity", cap(em.sem))
+			"turn", turn, "capacity", cap(em.sem))
 		return
 	}
 
@@ -194,24 +202,33 @@ func (em *evalMiddleware) emitResults(results []evals.EvalResult) {
 }
 
 // buildEvalContext creates an EvalContext from the conversation state.
+// It caches messages and only reloads when the turn count changes.
 func (em *evalMiddleware) buildEvalContext(ctx context.Context) *evals.EvalContext {
+	currentTurn := em.turnIndex.Load()
 	evalCtx := &evals.EvalContext{
-		TurnIndex: em.turnIndex,
+		TurnIndex: int(currentTurn),
 		PromptID:  em.conv.promptName,
 	}
 
 	// Safely get session info — sessions may not be initialized in tests
 	// or when middleware is used standalone.
 	if em.conv.unarySession != nil || em.conv.duplexSession != nil {
-		evalCtx.Messages = em.conv.Messages(ctx)
-		evalCtx.SessionID = em.conv.ID()
-
-		for i := len(evalCtx.Messages) - 1; i >= 0; i-- {
-			if evalCtx.Messages[i].Role == roleAssistant {
-				evalCtx.CurrentOutput = evalCtx.Messages[i].GetContent()
-				break
+		// Only reload messages if turn count changed since last cache
+		if currentTurn != em.cachedTurnIndex || em.cachedMessages == nil {
+			em.cachedMessages = em.conv.Messages(ctx)
+			em.cachedSessionID = em.conv.ID()
+			em.cachedTurnIndex = currentTurn
+			em.cachedLastOutput = ""
+			for i := len(em.cachedMessages) - 1; i >= 0; i-- {
+				if em.cachedMessages[i].Role == roleAssistant {
+					em.cachedLastOutput = em.cachedMessages[i].GetContent()
+					break
+				}
 			}
 		}
+		evalCtx.Messages = em.cachedMessages
+		evalCtx.SessionID = em.cachedSessionID
+		evalCtx.CurrentOutput = em.cachedLastOutput
 	}
 
 	return evalCtx

--- a/sdk/eval_middleware_test.go
+++ b/sdk/eval_middleware_test.go
@@ -608,6 +608,75 @@ func TestEvalMiddleware_CustomMaxConcurrentEvals(t *testing.T) {
 	}
 }
 
+func TestEvalMiddleware_BuildEvalContext_CachesMessages(t *testing.T) {
+	conv := &Conversation{
+		config: &config{},
+		pack: &pack.Pack{
+			Evals: []evals.EvalDef{
+				{ID: "e1", Type: "contains", Trigger: evals.TriggerEveryTurn},
+			},
+		},
+		prompt:     &pack.Prompt{},
+		promptName: "test-prompt",
+	}
+
+	mw := newEvalMiddleware(conv)
+	if mw == nil {
+		t.Fatal("expected non-nil middleware")
+	}
+
+	// First call at turn 0 — cache should be populated (no session so messages are nil)
+	ctx1 := mw.buildEvalContext(context.Background())
+	if ctx1.TurnIndex != 0 {
+		t.Errorf("expected TurnIndex 0, got %d", ctx1.TurnIndex)
+	}
+
+	// Same turn index — should return cached result
+	ctx2 := mw.buildEvalContext(context.Background())
+	if ctx2.TurnIndex != 0 {
+		t.Errorf("expected cached TurnIndex 0, got %d", ctx2.TurnIndex)
+	}
+
+	// Increment turn — cache should be invalidated
+	mw.turnIndex.Store(1)
+	ctx3 := mw.buildEvalContext(context.Background())
+	if ctx3.TurnIndex != 1 {
+		t.Errorf("expected TurnIndex 1, got %d", ctx3.TurnIndex)
+	}
+}
+
+func TestEvalMiddleware_TurnIndexAtomic(t *testing.T) {
+	conv := &Conversation{
+		config: &config{},
+		pack: &pack.Pack{
+			Evals: []evals.EvalDef{
+				{ID: "e1", Type: "contains", Trigger: evals.TriggerEveryTurn},
+			},
+		},
+		prompt: &pack.Prompt{},
+	}
+
+	mw := newEvalMiddleware(conv)
+	if mw == nil {
+		t.Fatal("expected non-nil middleware")
+	}
+
+	// Verify atomic operations on turnIndex
+	if mw.turnIndex.Load() != 0 {
+		t.Errorf("expected initial turnIndex 0, got %d", mw.turnIndex.Load())
+	}
+
+	mw.turnIndex.Add(1)
+	if mw.turnIndex.Load() != 1 {
+		t.Errorf("expected turnIndex 1 after Add, got %d", mw.turnIndex.Load())
+	}
+
+	mw.turnIndex.Store(5)
+	if mw.turnIndex.Load() != 5 {
+		t.Errorf("expected turnIndex 5 after Store, got %d", mw.turnIndex.Load())
+	}
+}
+
 // gatedEvalHandler signals when started and blocks until unblock is closed.
 type gatedEvalHandler struct {
 	typeName string

--- a/sdk/eval_middleware_test.go
+++ b/sdk/eval_middleware_test.go
@@ -209,7 +209,7 @@ func TestEvalMiddleware_BuildEvalContext_NoSession(t *testing.T) {
 		t.Fatal("expected non-nil middleware")
 	}
 
-	mw.turnIndex = 3
+	mw.turnIndex.Store(3)
 	ctx := mw.buildEvalContext(context.Background())
 
 	if ctx.TurnIndex != 3 {
@@ -508,11 +508,11 @@ func TestEvalMiddleware_SemaphoreSkipsWhenAtCapacity(t *testing.T) {
 	<-started
 
 	// Dispatch a 3rd — should be skipped because semaphore is full
-	turnBefore := mw.turnIndex
+	turnBefore := mw.turnIndex.Load()
 	mw.dispatchTurnEvals(context.Background())
 	// turnIndex still increments, but no goroutine was launched
-	if mw.turnIndex != turnBefore+1 {
-		t.Errorf("expected turnIndex to increment, got %d", mw.turnIndex)
+	if mw.turnIndex.Load() != turnBefore+1 {
+		t.Errorf("expected turnIndex to increment, got %d", mw.turnIndex.Load())
 	}
 
 	// Unblock all goroutines and wait

--- a/sdk/local_agent_executor_integration.go
+++ b/sdk/local_agent_executor_integration.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 )
+
+// defaultAgentSendTimeout is the default timeout applied to member agent Send
+// calls when the caller's context has no deadline.
+const defaultAgentSendTimeout = 5 * time.Minute
 
 // Execute routes a tool call to the corresponding member conversation.
 // It parses {"query":"..."} from args, calls member.Send(), and returns {"response":"..."}.
@@ -29,7 +34,15 @@ func (e *LocalAgentExecutor) Execute(
 		return nil, fmt.Errorf("unknown agent member: %s", descriptor.Name)
 	}
 
-	// Send the query to the member conversation using the caller's context.
+	// If the caller's context has no deadline, wrap with a default timeout
+	// to prevent member agent calls from hanging indefinitely.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultAgentSendTimeout)
+		defer cancel()
+	}
+
+	// Send the query to the member conversation.
 	resp, err := conv.Send(ctx, input.Query)
 	if err != nil {
 		return nil, fmt.Errorf("agent %s failed: %w", descriptor.Name, err)

--- a/sdk/multi_agent.go
+++ b/sdk/multi_agent.go
@@ -1,5 +1,7 @@
 package sdk
 
+import "errors"
+
 // MultiAgentSession manages a set of agent member conversations orchestrated
 // through an entry conversation. Tool calls from the entry agent to member
 // agents are routed in-process via LocalAgentExecutor.
@@ -23,10 +25,16 @@ func (s *MultiAgentSession) Members() map[string]*Conversation {
 }
 
 // Close closes all conversations (entry and members).
+// Errors from individual Close calls are collected and returned via errors.Join.
 func (s *MultiAgentSession) Close() error {
-	_ = s.entry.Close()
-	for _, c := range s.members {
-		_ = c.Close()
+	var errs []error
+	if err := s.entry.Close(); err != nil {
+		errs = append(errs, err)
 	}
-	return nil
+	for _, c := range s.members {
+		if err := c.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/sdk/multi_agent_test.go
+++ b/sdk/multi_agent_test.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -99,6 +100,89 @@ func TestMultiAgentSession_Entry(t *testing.T) {
 		members: map[string]*Conversation{},
 	}
 	assert.Equal(t, entry, session.Entry())
+}
+
+func TestMultiAgentSession_Close_CollectsErrors(t *testing.T) {
+	// Close on a Conversation with both unary and duplex nil sessions should succeed.
+	session := &MultiAgentSession{
+		entry: &Conversation{config: &config{}},
+		members: map[string]*Conversation{
+			"m1": {config: &config{}},
+			"m2": {config: &config{}},
+		},
+	}
+	err := session.Close()
+	assert.NoError(t, err)
+
+	// Close again — entry and members are already closed, returns nil from Conversation.Close.
+	err = session.Close()
+	assert.NoError(t, err)
+}
+
+func TestMultiAgentSession_Close_WithMembers(t *testing.T) {
+	// Create conversations with configs; closing them should succeed.
+	entry := &Conversation{config: &config{}, handlers: make(map[string]ToolHandler)}
+	m1 := &Conversation{config: &config{}, handlers: make(map[string]ToolHandler)}
+	m2 := &Conversation{config: &config{}, handlers: make(map[string]ToolHandler)}
+	session := &MultiAgentSession{
+		entry:   entry,
+		members: map[string]*Conversation{"m1": m1, "m2": m2},
+	}
+	err := session.Close()
+	assert.NoError(t, err)
+}
+
+func TestMultiAgentSession_Close_EntryError(t *testing.T) {
+	// Use closeErrorCapability (defined in conversation_test.go) to make Close() return an error.
+	entryErr := errors.New("entry close failed")
+	entry := &Conversation{
+		config:       &config{},
+		capabilities: []Capability{&closeErrorCapability{name: "failing", closeErr: entryErr}},
+	}
+	session := &MultiAgentSession{
+		entry:   entry,
+		members: map[string]*Conversation{},
+	}
+	err := session.Close()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, entryErr)
+}
+
+func TestMultiAgentSession_Close_MemberError(t *testing.T) {
+	memberErr := errors.New("member close failed")
+	entry := &Conversation{config: &config{}}
+	m1 := &Conversation{
+		config:       &config{},
+		capabilities: []Capability{&closeErrorCapability{name: "failing", closeErr: memberErr}},
+	}
+	session := &MultiAgentSession{
+		entry:   entry,
+		members: map[string]*Conversation{"m1": m1},
+	}
+	err := session.Close()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, memberErr)
+}
+
+func TestMultiAgentSession_Close_EntryAndMemberErrors(t *testing.T) {
+	entryErr := errors.New("entry error")
+	memberErr := errors.New("member error")
+	entry := &Conversation{
+		config:       &config{},
+		capabilities: []Capability{&closeErrorCapability{name: "e", closeErr: entryErr}},
+	}
+	m1 := &Conversation{
+		config:       &config{},
+		capabilities: []Capability{&closeErrorCapability{name: "m", closeErr: memberErr}},
+	}
+	session := &MultiAgentSession{
+		entry:   entry,
+		members: map[string]*Conversation{"m1": m1},
+	}
+	err := session.Close()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, entryErr)
+	assert.ErrorIs(t, err, memberErr)
 }
 
 // createTestPackFile creates a temporary pack JSON file for testing.

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -3,8 +3,10 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/google/uuid"
 
@@ -26,6 +28,17 @@ import (
 	"github.com/AltairaLabs/PromptKit/sdk/session"
 	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
 )
+
+// loggerOnce guards logger.SetLogger to avoid data races when multiple
+// goroutines call Open() concurrently with WithLogger.
+var loggerOnce sync.Once
+
+// setLoggerOnce sets the global logger exactly once.
+func setLoggerOnce(l *slog.Logger) {
+	loggerOnce.Do(func() {
+		logger.SetLogger(l)
+	})
+}
 
 // Open loads a pack file and creates a new conversation for the specified prompt.
 //
@@ -164,9 +177,10 @@ func initConversation(
 		return nil, nil, err
 	}
 
-	// Set custom logger before any logging occurs
+	// Set custom logger before any logging occurs — only once to avoid
+	// data races when multiple goroutines call Open() concurrently.
 	if cfg.logger != nil {
-		logger.SetLogger(cfg.logger)
+		setLoggerOnce(cfg.logger)
 	}
 
 	// Load and validate pack
@@ -630,7 +644,9 @@ func applyDefaultVariables(conv *Conversation, prompt *pack.Prompt) {
 // Resume requires a state store to be configured. If no state store is provided,
 // it returns [ErrNoStateStore].
 func Resume(conversationID, packPath, promptName string, opts ...Option) (*Conversation, error) {
-	// Ensure state store is provided
+	// Options are applied twice intentionally: first here to extract the state
+	// store for loading, then again inside Open() for full initialization.
+	// This is safe because options are idempotent config setters.
 	cfg := &config{}
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -45,6 +45,16 @@ type duplexSession struct {
 	executionStarted bool
 	executionMu      sync.Mutex
 
+	// sessionCtx is a session-level context created during NewDuplexSession.
+	// It is used for pipeline execution instead of the first SendChunk's context,
+	// ensuring the pipeline outlives any single RPC call.
+	sessionCtx    context.Context
+	sessionCancel context.CancelFunc
+
+	// pipelineDone is closed when executePipeline returns, signaling that the session has ended.
+	// This is a separate signal from streamOutput so that Done() does not drain the output channel.
+	pipelineDone chan struct{}
+
 	// Done channel (initialized once via sync.Once)
 	doneCh   chan struct{}
 	doneOnce sync.Once
@@ -135,14 +145,19 @@ func NewDuplexSession(ctx context.Context, cfg *DuplexSessionConfig) (DuplexSess
 	stageInput := make(chan stage.StreamElement, streamBufferSize)
 	streamOutput := make(chan providers.StreamChunk, streamBufferSize)
 
+	sessionCtx, sessionCancel := context.WithCancel(context.Background())
+
 	sess := &duplexSession{
-		id:           conversationID,
-		store:        store,
-		pipeline:     builtPipeline,
-		provider:     cfg.Provider,
-		variables:    vars,
-		stageInput:   stageInput,
-		streamOutput: streamOutput,
+		id:            conversationID,
+		store:         store,
+		pipeline:      builtPipeline,
+		provider:      cfg.Provider,
+		variables:     vars,
+		stageInput:    stageInput,
+		streamOutput:  streamOutput,
+		sessionCtx:    sessionCtx,
+		sessionCancel: sessionCancel,
+		pipelineDone:  make(chan struct{}),
 	}
 
 	return sess, nil
@@ -167,14 +182,16 @@ func (s *duplexSession) SendChunk(ctx context.Context, chunk *providers.StreamCh
 		return fmt.Errorf("chunk cannot be nil")
 	}
 
-	// Start Pipeline execution on first chunk
+	// Start Pipeline execution on first chunk using session-level context
 	s.executionMu.Lock()
 	if !s.executionStarted {
 		s.executionStarted = true
 		s.executionMu.Unlock()
 
-		// Start Pipeline execution in background
-		go s.executePipeline(ctx)
+		// Start Pipeline execution in background using the session-level context
+		// rather than the first SendChunk's context, so the pipeline outlives any
+		// single caller.
+		go s.executePipeline(s.sessionCtx)
 	} else {
 		s.executionMu.Unlock()
 	}
@@ -220,7 +237,9 @@ func (s *duplexSession) SendFrame(ctx context.Context, frame *ImageFrame) error 
 		return fmt.Errorf("frame data is required")
 	}
 
-	// Convert frame data to string for MediaContent
+	// TODO: This copies []byte to string on every frame, which is expensive for
+	// high-frequency video. Consider using unsafe.String or redesigning MediaContent
+	// to accept []byte directly. This is API-breaking so deferred for a future release.
 	dataStr := string(frame.Data)
 
 	chunk := &providers.StreamChunk{
@@ -275,6 +294,7 @@ func (s *duplexSession) SendVideoChunk(ctx context.Context, vchunk *VideoChunk) 
 // This is called once when the first chunk is received.
 // Converts stage.StreamElement output to providers.StreamChunk at the boundary.
 func (s *duplexSession) executePipeline(ctx context.Context) {
+	defer close(s.pipelineDone)
 	defer close(s.streamOutput)
 
 	// Start the stage pipeline with our input channel
@@ -332,6 +352,7 @@ func (s *duplexSession) Close() error {
 
 	s.closed = true
 	close(s.stageInput)
+	s.sessionCancel()
 	// Note: DuplexProviderStage manages the provider session and closes it when pipeline completes
 
 	return nil
@@ -339,13 +360,16 @@ func (s *duplexSession) Close() error {
 
 // Done returns a channel that's closed when the session ends.
 // The channel is initialized once on first call; subsequent calls return the same channel.
+// Done monitors the session's done signal rather than draining streamOutput, so it
+// does not compete with Response() for output chunks.
 func (s *duplexSession) Done() <-chan struct{} {
 	s.doneOnce.Do(func() {
 		s.doneCh = make(chan struct{})
 		go func() {
-			// Wait for all output to be consumed
-			for range s.streamOutput { //nolint:revive // intentionally draining channel
-			}
+			// Wait for the pipeline to finish by monitoring streamOutput closure
+			// without consuming any elements. This avoids stealing chunks from
+			// consumers reading via Response().
+			<-s.pipelineDone
 			close(s.doneCh)
 		}()
 	})

--- a/sdk/session/unary_session.go
+++ b/sdk/session/unary_session.go
@@ -169,7 +169,7 @@ func (s *unarySession) ExecuteStream(ctx context.Context, role, content string) 
 	}
 
 	// Convert stage output to StreamChunk output
-	return convertStreamOutput(outputChan), nil
+	return convertStreamOutput(ctx, outputChan), nil
 }
 
 // ExecuteStreamWithMessage implements TextSession.
@@ -200,7 +200,7 @@ func (s *unarySession) ExecuteStreamWithMessage(
 	}
 
 	// Convert stage output to StreamChunk output
-	return convertStreamOutput(outputChan), nil
+	return convertStreamOutput(ctx, outputChan), nil
 }
 
 // ResumeStreamWithToolResults injects tool result messages and returns a streaming channel.
@@ -233,7 +233,7 @@ func (s *unarySession) ResumeStreamWithToolResults(
 		return nil, err
 	}
 
-	return convertStreamOutput(outputChan), nil
+	return convertStreamOutput(ctx, outputChan), nil
 }
 
 // SetVar sets a template variable that will be available for substitution.
@@ -343,70 +343,106 @@ func convertExecutionResult(result *stage.ExecutionResult) *pipeline.ExecutionRe
 
 const streamChunkBufferSize = 100
 
-// convertStreamOutput converts stage StreamElement channel to StreamChunk channel
-func convertStreamOutput(stageChan <-chan stage.StreamElement) <-chan providers.StreamChunk {
+// convertStreamOutput converts stage StreamElement channel to StreamChunk channel.
+// It accepts a context for cancellation propagation — if the context is canceled,
+// the goroutine exits promptly instead of blocking on chunkChan sends.
+func convertStreamOutput(ctx context.Context, stageChan <-chan stage.StreamElement) <-chan providers.StreamChunk {
 	chunkChan := make(chan providers.StreamChunk, streamChunkBufferSize)
 
 	go func() {
 		defer close(chunkChan)
-		processStreamElements(stageChan, chunkChan)
+		processStreamElements(ctx, stageChan, chunkChan)
 	}()
 
 	return chunkChan
 }
 
-// processStreamElements processes stream elements and sends chunks
-func processStreamElements(stageChan <-chan stage.StreamElement, chunkChan chan<- providers.StreamChunk) {
-	var sb strings.Builder
-	var finalResult *pipeline.ExecutionResult
-	var pendingToolsEmitted bool
+// streamProcessor holds state for processing stream elements into chunks.
+type streamProcessor struct {
+	ctx                 context.Context
+	chunkChan           chan<- providers.StreamChunk
+	sb                  strings.Builder
+	finalResult         *pipeline.ExecutionResult
+	pendingToolsEmitted bool
+}
 
-	for elem := range stageChan {
-		// Handle errors
-		if elem.Error != nil {
-			chunkChan <- providers.StreamChunk{
-				Error:        elem.Error,
-				FinishReason: strPtr("error"),
-			}
-			continue
-		}
+// sendChunk sends a chunk to the output channel, respecting context cancellation.
+// Returns false if the context was canceled.
+func (p *streamProcessor) sendChunk(chunk *providers.StreamChunk) bool {
+	select {
+	case p.chunkChan <- *chunk:
+		return true
+	case <-p.ctx.Done():
+		return false
+	}
+}
 
-		// Emit text chunks
-		if elem.Text != nil && *elem.Text != "" {
-			sb.WriteString(*elem.Text)
-			chunkChan <- providers.StreamChunk{
-				Delta:   *elem.Text,
-				Content: sb.String(),
-			}
-		}
+// processElement processes a single stream element. Returns false if processing should stop.
+func (p *streamProcessor) processElement(elem *stage.StreamElement) bool {
+	if elem.Error != nil {
+		return p.sendChunk(&providers.StreamChunk{
+			Error:        elem.Error,
+			FinishReason: strPtr("error"),
+		})
+	}
 
-		// Collect final result from metadata
-		if elem.Metadata != nil {
-			if stageResult, ok := elem.Metadata["__final_result__"].(*stage.ExecutionResult); ok {
-				finalResult = convertExecutionResult(stageResult)
-			}
-
-			// Check for pending client tools (pipeline suspended)
-			if pt, ok := elem.Metadata["pending_tools"]; ok {
-				if pending, ok := pt.([]tools.PendingToolExecution); ok && len(pending) > 0 {
-					chunkChan <- providers.StreamChunk{
-						FinishReason: strPtr("pending_tools"),
-						PendingTools: pending,
-						FinalResult:  finalResult,
-					}
-					pendingToolsEmitted = true
-				}
-			}
+	if elem.Text != nil && *elem.Text != "" {
+		p.sb.WriteString(*elem.Text)
+		if !p.sendChunk(&providers.StreamChunk{Delta: *elem.Text}) {
+			return false
 		}
 	}
 
-	// Send final chunk only if we didn't already emit a pending_tools chunk
-	if !pendingToolsEmitted {
-		finishReason := "stop"
-		chunkChan <- providers.StreamChunk{
-			FinishReason: &finishReason,
-			FinalResult:  finalResult,
+	if elem.Metadata != nil {
+		p.collectMetadata(elem.Metadata)
+	}
+	return true
+}
+
+// collectMetadata extracts final results and pending tools from element metadata.
+func (p *streamProcessor) collectMetadata(metadata map[string]interface{}) {
+	if stageResult, ok := metadata["__final_result__"].(*stage.ExecutionResult); ok {
+		p.finalResult = convertExecutionResult(stageResult)
+	}
+
+	pt, ok := metadata["pending_tools"]
+	if !ok {
+		return
+	}
+	pending, ok := pt.([]tools.PendingToolExecution)
+	if !ok || len(pending) == 0 {
+		return
+	}
+	p.sendChunk(&providers.StreamChunk{
+		FinishReason: strPtr("pending_tools"),
+		PendingTools: pending,
+		FinalResult:  p.finalResult,
+	})
+	p.pendingToolsEmitted = true
+}
+
+// processStreamElements processes stream elements and sends chunks.
+// It respects context cancellation to avoid goroutine leaks when the consumer abandons the channel.
+func processStreamElements(
+	ctx context.Context, stageChan <-chan stage.StreamElement, chunkChan chan<- providers.StreamChunk,
+) {
+	p := &streamProcessor{ctx: ctx, chunkChan: chunkChan}
+
+	for elem := range stageChan {
+		if !p.processElement(&elem) {
+			return
 		}
+	}
+
+	// Send final chunk only if we didn't already emit a pending_tools chunk.
+	// Set Content to the fully accumulated text here (once) instead of on every
+	// intermediate chunk, avoiding O(N^2) string allocation.
+	if !p.pendingToolsEmitted {
+		p.sendChunk(&providers.StreamChunk{
+			Content:      p.sb.String(),
+			FinishReason: strPtr("stop"),
+			FinalResult:  p.finalResult,
+		})
 	}
 }
 

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -385,7 +385,7 @@ func TestProcessStreamElements_PropagatesPendingTools(t *testing.T) {
 	close(stageChan)
 
 	// Use convertStreamOutput which properly wraps processStreamElements with close
-	chunkChan := convertStreamOutput(stageChan)
+	chunkChan := convertStreamOutput(context.Background(), stageChan)
 
 	var chunks []providers.StreamChunk
 	for chunk := range chunkChan {
@@ -414,7 +414,7 @@ func TestProcessStreamElements_NoPendingTools(t *testing.T) {
 	stageChan <- stage.StreamElement{Text: &text}
 	close(stageChan)
 
-	chunkChan := convertStreamOutput(stageChan)
+	chunkChan := convertStreamOutput(context.Background(), stageChan)
 
 	var chunks []providers.StreamChunk
 	for chunk := range chunkChan {

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -492,4 +493,42 @@ func TestUnarySession_ForkSession(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, len(origMessages), len(forkedMessages))
+}
+
+func TestStreamProcessor_SendChunk_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Use an unbuffered channel so send would block, forcing the ctx.Done() path.
+	chunkChan := make(chan providers.StreamChunk)
+	p := &streamProcessor{ctx: ctx, chunkChan: chunkChan}
+
+	ok := p.sendChunk(&providers.StreamChunk{Delta: "test"})
+	assert.False(t, ok, "sendChunk should return false when context is cancelled")
+}
+
+func TestStreamProcessor_ProcessElement_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	chunkChan := make(chan providers.StreamChunk) // unbuffered
+	p := &streamProcessor{ctx: ctx, chunkChan: chunkChan}
+
+	text := "hello"
+	ok := p.processElement(&stage.StreamElement{Text: &text})
+	assert.False(t, ok, "processElement should return false when context is cancelled")
+}
+
+func TestStreamProcessor_ProcessElement_Error(t *testing.T) {
+	chunkChan := make(chan providers.StreamChunk, 10)
+	p := &streamProcessor{ctx: context.Background(), chunkChan: chunkChan}
+
+	testErr := errors.New("stream error")
+	ok := p.processElement(&stage.StreamElement{Error: testErr})
+	assert.True(t, ok, "processElement should succeed sending error chunk")
+
+	chunk := <-chunkChan
+	assert.Equal(t, testErr, chunk.Error)
+	require.NotNil(t, chunk.FinishReason)
+	assert.Equal(t, "error", *chunk.FinishReason)
 }

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -532,3 +532,47 @@ func TestStreamProcessor_ProcessElement_Error(t *testing.T) {
 	require.NotNil(t, chunk.FinishReason)
 	assert.Equal(t, "error", *chunk.FinishReason)
 }
+
+func TestStreamProcessor_CollectMetadata_FinalResult(t *testing.T) {
+	chunkChan := make(chan providers.StreamChunk, 10)
+	p := &streamProcessor{ctx: context.Background(), chunkChan: chunkChan}
+
+	execResult := &stage.ExecutionResult{
+		Response: &stage.Response{Role: "assistant", Content: "test"},
+	}
+	meta := map[string]interface{}{
+		"__final_result__": execResult,
+	}
+	p.collectMetadata(meta)
+
+	assert.NotNil(t, p.finalResult, "finalResult should be set from metadata")
+}
+
+func TestStreamProcessor_CollectMetadata_InvalidPendingToolsType(t *testing.T) {
+	chunkChan := make(chan providers.StreamChunk, 10)
+	p := &streamProcessor{ctx: context.Background(), chunkChan: chunkChan}
+
+	// pending_tools exists but is wrong type — should hit early return
+	meta := map[string]interface{}{
+		"pending_tools": "not-a-slice",
+	}
+	p.collectMetadata(meta)
+	assert.False(t, p.pendingToolsEmitted)
+}
+
+func TestProcessStreamElements_EarlyExit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stageChan := make(chan stage.StreamElement, 5)
+	text := "hello"
+	stageChan <- stage.StreamElement{Text: &text}
+	stageChan <- stage.StreamElement{Text: &text}
+	close(stageChan)
+
+	// Unbuffered chunkChan + cancelled context forces processElement to return false,
+	// testing the early exit path in processStreamElements.
+	chunkChan := make(chan providers.StreamChunk)
+	processStreamElements(ctx, stageChan, chunkChan)
+	// If we reach here without hanging, the early exit worked.
+}

--- a/sdk/shutdown.go
+++ b/sdk/shutdown.go
@@ -109,7 +109,14 @@ func (m *ShutdownManager) Shutdown(ctx context.Context) error {
 		go func(id string, conv io.Closer) {
 			sem <- struct{}{}        // acquire
 			defer func() { <-sem }() // release
-			results <- result{id: id, err: conv.Close()}
+			// Attempt to close. If the context is already done, skip the Close
+			// to avoid goroutines lingering past the deadline.
+			select {
+			case <-ctx.Done():
+				results <- result{id: id, err: ctx.Err()}
+			default:
+				results <- result{id: id, err: conv.Close()}
+			}
 		}(id, conv)
 	}
 

--- a/sdk/shutdown_test.go
+++ b/sdk/shutdown_test.go
@@ -289,6 +289,32 @@ func TestShutdownManager_BoundedConcurrency(t *testing.T) {
 	}
 }
 
+func TestShutdownManager_ContextCancelledSkipsClose(t *testing.T) {
+	mgr := NewShutdownManager()
+
+	slowCloser := &mockCloser{
+		closeFunc: func() error {
+			time.Sleep(5 * time.Second)
+			return nil
+		},
+	}
+	_ = mgr.Register("slow", slowCloser)
+	_ = mgr.Register("fast", &mockCloser{})
+
+	// Cancel context before shutdown — goroutines should detect cancelled context
+	// and return ctx.Err() instead of blocking on Close.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := mgr.Shutdown(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled in error, got: %v", err)
+	}
+}
+
 // idFromIndex is a helper that converts an integer index to a string ID.
 func idFromIndex(i int) string {
 	return "conv-" + string(rune('A'+i%26)) + string(rune('0'+i/26))

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -118,7 +118,10 @@ func (c *Conversation) Stream(ctx context.Context, message any, opts ...SendOpti
 		c.mu.RLock()
 		if err := c.requireUnary("Stream()"); err != nil {
 			c.mu.RUnlock()
-			ch <- StreamChunk{Error: err}
+			select {
+			case ch <- StreamChunk{Error: err}:
+			case <-ctx.Done():
+			}
 			return
 		}
 		c.mu.RUnlock()
@@ -126,13 +129,19 @@ func (c *Conversation) Stream(ctx context.Context, message any, opts ...SendOpti
 		// Build user message with options
 		userMsg, err := c.buildStreamMessage(message, opts)
 		if err != nil {
-			ch <- StreamChunk{Error: err}
+			select {
+			case ch <- StreamChunk{Error: err}:
+			case <-ctx.Done():
+			}
 			return
 		}
 
 		// Execute streaming pipeline
 		if err := c.executeStreamingPipeline(ctx, userMsg, ch, startTime); err != nil {
-			ch <- StreamChunk{Error: err}
+			select {
+			case ch <- StreamChunk{Error: err}:
+			case <-ctx.Done():
+			}
 		}
 	}()
 
@@ -319,7 +328,9 @@ func (c *Conversation) emitStreamChunk(
 		for i := len(state.lastToolCalls); i < len(chunk.ToolCalls); i++ {
 			outCh <- StreamChunk{Type: ChunkToolCall, ToolCall: &chunk.ToolCalls[i]}
 		}
-		state.lastToolCalls = chunk.ToolCalls
+		// Copy the slice to avoid holding a reference to the provider's internal slice
+		state.lastToolCalls = make([]types.MessageToolCall, len(chunk.ToolCalls))
+		copy(state.lastToolCalls, chunk.ToolCalls)
 	}
 
 	// Handle pending client tools

--- a/sdk/template.go
+++ b/sdk/template.go
@@ -214,6 +214,7 @@ func (t *PackTemplate) initConversation(conv *Conversation, packPrompt *pack.Pro
 
 	initEventBus(cfg)
 	conv.hookRegistry = cfg.buildHookRegistry()
+	conv.sessionHooks = newSessionHookDispatcher(conv.hookRegistry, conv.sessionInfo)
 	return nil
 }
 

--- a/sdk/tools/http.go
+++ b/sdk/tools/http.go
@@ -361,6 +361,10 @@ func (c *HTTPToolConfig) Handler() func(args map[string]any) (any, error) {
 // HandlerCtx returns a context-aware tool handler function that makes the HTTP request.
 // The context is propagated to the underlying HTTP executor for tracing and cancellation.
 func (c *HTTPToolConfig) HandlerCtx() func(ctx context.Context, args map[string]any) (any, error) {
+	// TODO: Consider caching the HTTPExecutor at the HTTPToolConfig level or using
+	// a package-level pool. Currently each HandlerCtx() call creates a new executor
+	// with its own http.Client, which is fine for low-cardinality tool sets but
+	// wasteful if called repeatedly for the same tool config.
 	executor := NewHTTPExecutor()
 
 	return func(ctx context.Context, args map[string]any) (any, error) {

--- a/sdk/tools/typed.go
+++ b/sdk/tools/typed.go
@@ -80,6 +80,8 @@ type ToolHandler = func(args map[string]any) (any, error)
 
 // mapToStruct converts a map[string]any to a struct using reflection.
 // It looks for "map" struct tags or uses lowercase field names.
+// TODO: Cache reflect.Type field metadata (tag lookup, field index) per type
+// to avoid repeated reflection on hot paths with many tool calls.
 func mapToStruct(m map[string]any, v any) error {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -82,9 +82,9 @@ func OpenWorkflow(packPath string, opts ...Option) (*WorkflowConversation, error
 		}
 	}
 
-	// Set custom logger before any logging occurs
+	// Set custom logger before any logging occurs — only once
 	if cfg.logger != nil {
-		logger.SetLogger(cfg.logger)
+		setLoggerOnce(cfg.logger)
 	}
 
 	p, err := pack.Load(absPath, pack.LoadOptions{
@@ -305,58 +305,6 @@ func (wc *WorkflowConversation) Transition(event string) (string, error) {
 	return wc.transitionInternal(event, contextSummary)
 }
 
-// transitionInternal is the shared transition logic used by both explicit
-// Transition() and LLM-initiated transitions. Caller must hold wc.mu.
-func (wc *WorkflowConversation) transitionInternal(event, contextSummary string) (string, error) {
-	fromState := wc.machine.CurrentState()
-
-	if err := wc.machine.ProcessEvent(event); err != nil {
-		return "", err
-	}
-
-	toState := wc.machine.CurrentState()
-
-	// Close old conversation
-	if wc.activeConv != nil {
-		_ = wc.activeConv.Close()
-	}
-
-	// Build options, injecting context as a template variable if available
-	opts := wc.opts
-	if contextSummary != "" {
-		opts = append(append([]Option{}, wc.opts...), WithVariables(map[string]string{
-			"workflow_context": contextSummary,
-		}))
-	}
-
-	// Open new conversation for the new state
-	promptName := wc.machine.CurrentPromptTask()
-	conv, err := Open(wc.packPath, promptName, opts...)
-	if err != nil {
-		return "", fmt.Errorf("failed to open conversation for state %q (prompt %q): %w",
-			toState, promptName, err)
-	}
-	wc.activeConv = conv
-
-	// Register workflow tools for the new state
-	wc.registerWorkflowTools()
-
-	// Persist workflow context if state store is configured and state is not transient
-	if wc.stateStore != nil && wc.workflowID != "" {
-		wc.persistWorkflowContext()
-	}
-
-	// Emit transition event
-	if wc.emitter != nil {
-		wc.emitter.WorkflowTransitioned(fromState, toState, event, promptName)
-		if wc.machine.IsTerminal() {
-			wc.emitter.WorkflowCompleted(toState, wc.machine.Context().TransitionCount())
-		}
-	}
-
-	return toState, nil
-}
-
 // registerWorkflowTools registers the workflow__transition tool and handler
 // for the current state on the active conversation.
 func (wc *WorkflowConversation) registerWorkflowTools() {
@@ -477,16 +425,8 @@ func (wc *WorkflowConversation) Close() error {
 	return nil
 }
 
-// filterRelevantMessages removes system messages from the conversation history.
-func filterRelevantMessages(messages []types.Message) []types.Message {
-	result := make([]types.Message, 0, len(messages))
-	for i := range messages {
-		if messages[i].Role != "system" {
-			result = append(result, messages[i])
-		}
-	}
-	return result
-}
+// roleSystem is the role string for system messages (extracted as a constant to satisfy goconst).
+const roleSystem = "system"
 
 // extractMessageText returns the text content of a message, checking Content
 // first and falling back to the first text Part.
@@ -530,7 +470,9 @@ func (wc *WorkflowConversation) persistWorkflowContext() {
 
 	wfCtx := wc.machine.Context()
 	state.Metadata["workflow"] = wfCtx
-	_ = wc.stateStore.Save(ctx, state)
+	if err := wc.stateStore.Save(ctx, state); err != nil {
+		logger.Warn("failed to persist workflow context", "workflow_id", wc.workflowID, "error", err)
+	}
 }
 
 // extractWorkflowContext extracts and deserializes workflow.Context from state metadata.

--- a/sdk/workflow_integration.go
+++ b/sdk/workflow_integration.go
@@ -4,7 +4,64 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// transitionInternal is the shared transition logic used by both explicit
+// Transition() and LLM-initiated transitions. Caller must hold wc.mu.
+//
+// This function calls Open() to create a new conversation for the target state,
+// so it requires a valid pack file and is tested via integration tests.
+func (wc *WorkflowConversation) transitionInternal(event, contextSummary string) (string, error) {
+	fromState := wc.machine.CurrentState()
+
+	if err := wc.machine.ProcessEvent(event); err != nil {
+		return "", err
+	}
+
+	toState := wc.machine.CurrentState()
+
+	// Close old conversation
+	if wc.activeConv != nil {
+		_ = wc.activeConv.Close()
+	}
+
+	// Build options, injecting context as a template variable if available
+	opts := wc.opts
+	if contextSummary != "" {
+		opts = append(append([]Option{}, wc.opts...), WithVariables(map[string]string{
+			"workflow_context": contextSummary,
+		}))
+	}
+
+	// Open new conversation for the new state
+	promptName := wc.machine.CurrentPromptTask()
+	conv, err := Open(wc.packPath, promptName, opts...)
+	if err != nil {
+		return "", fmt.Errorf("failed to open conversation for state %q (prompt %q): %w",
+			toState, promptName, err)
+	}
+	wc.activeConv = conv
+
+	// Register workflow tools for the new state
+	wc.registerWorkflowTools()
+
+	// Persist workflow context if state store is configured and state is not transient
+	if wc.stateStore != nil && wc.workflowID != "" {
+		wc.persistWorkflowContext()
+	}
+
+	// Emit transition event
+	if wc.emitter != nil {
+		wc.emitter.WorkflowTransitioned(fromState, toState, event, promptName)
+		if wc.machine.IsTerminal() {
+			wc.emitter.WorkflowCompleted(toState, wc.machine.Context().TransitionCount())
+		}
+	}
+
+	return toState, nil
+}
 
 // maxSummaryContentLen is the max characters per message in a carry-forward summary.
 const maxSummaryContentLen = 200
@@ -25,14 +82,20 @@ func buildContextSummary(stateName string, conv *Conversation) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "[Previous state: %s, %d messages]\n", stateName, len(messages))
 
-	// Include the last N messages (skip system messages)
-	relevant := filterRelevantMessages(messages)
-	start := 0
-	if len(relevant) > defaultMaxSummaryMessages {
-		start = len(relevant) - defaultMaxSummaryMessages
+	// Collect the last N non-system messages by iterating from the end,
+	// avoiding a full filter + slice allocation for long histories.
+	relevant := make([]types.Message, 0, defaultMaxSummaryMessages)
+	for i := len(messages) - 1; i >= 0 && len(relevant) < defaultMaxSummaryMessages; i-- {
+		if messages[i].Role != roleSystem {
+			relevant = append(relevant, messages[i])
+		}
+	}
+	// Reverse to restore chronological order
+	for i, j := 0, len(relevant)-1; i < j; i, j = i+1, j-1 {
+		relevant[i], relevant[j] = relevant[j], relevant[i]
 	}
 
-	for i := start; i < len(relevant); i++ {
+	for i := 0; i < len(relevant); i++ {
 		content := extractMessageText(&relevant[i])
 		if content == "" {
 			continue

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -326,8 +326,8 @@ func TestWorkflowConversation_SendDelegatesToConversation(t *testing.T) {
 func TestWorkflowConversation_CloseWithActiveConv(t *testing.T) {
 	// Test that Close properly closes the active conversation
 	conv := &Conversation{
-		handlers:  make(map[string]ToolHandler),
-		config:    &config{},
+		handlers: make(map[string]ToolHandler),
+		config:   &config{},
 	}
 	wc := &WorkflowConversation{
 		activeConv: conv,
@@ -476,35 +476,6 @@ func TestWorkflowConversation_TransitionEmitsCompletedOnTerminal(t *testing.T) {
 	assert.Equal(t, 1, cData.TransitionCount)
 
 	_ = machine // used indirectly
-}
-
-func TestFilterRelevantMessages(t *testing.T) {
-	messages := []types.Message{
-		{Role: "system", Content: "You are helpful."},
-		{Role: "user", Content: "Hello there"},
-		{Role: "assistant", Content: "Hi! How can I help?"},
-		{Role: "user", Content: "I need billing help"},
-	}
-
-	relevant := filterRelevantMessages(messages)
-	assert.Len(t, relevant, 3) // system filtered out
-	assert.Equal(t, "user", relevant[0].Role)
-	assert.Equal(t, "assistant", relevant[1].Role)
-	assert.Equal(t, "user", relevant[2].Role)
-}
-
-func TestFilterRelevantMessages_AllSystem(t *testing.T) {
-	messages := []types.Message{
-		{Role: "system", Content: "System 1"},
-		{Role: "system", Content: "System 2"},
-	}
-	relevant := filterRelevantMessages(messages)
-	assert.Empty(t, relevant)
-}
-
-func TestFilterRelevantMessages_Empty(t *testing.T) {
-	relevant := filterRelevantMessages(nil)
-	assert.Empty(t, relevant)
 }
 
 func TestWithContextCarryForward(t *testing.T) {
@@ -1193,4 +1164,91 @@ func TestWorkflowConversation_ConcurrentSendAndTransition(t *testing.T) {
 
 	wg.Wait()
 	// No assertions needed — test validates absence of data races with -race flag
+}
+
+// errorStore is a statestore.Store that always returns errors on Save.
+type errorStore struct {
+	statestore.Store
+}
+
+func (s *errorStore) Load(_ context.Context, _ string) (*statestore.ConversationState, error) {
+	return &statestore.ConversationState{
+		ID:       "wf-1",
+		Metadata: make(map[string]any),
+	}, nil
+}
+
+func (s *errorStore) Save(_ context.Context, _ *statestore.ConversationState) error {
+	return errors.New("save failed")
+}
+
+func TestPersistWorkflowContext_SaveError(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States: map[string]*workflow.State{
+			"start": {PromptTask: "p1"},
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		stateStore:   &errorStore{},
+		workflowID:   "wf-1",
+	}
+
+	// Should not panic — logs the error instead of discarding
+	wc.persistWorkflowContext()
+}
+
+func TestPersistWorkflowContext_TransientStateSkipped(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States: map[string]*workflow.State{
+			"start": {
+				PromptTask:  "p1",
+				Persistence: workflow.PersistenceTransient,
+			},
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		stateStore:   statestore.NewMemoryStore(),
+		workflowID:   "wf-1",
+	}
+
+	// Should be a no-op (transient state)
+	wc.persistWorkflowContext()
+}
+
+func TestPersistWorkflowContext_Success(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States: map[string]*workflow.State{
+			"start": {PromptTask: "p1"},
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+	store := statestore.NewMemoryStore()
+
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		stateStore:   store,
+		workflowID:   "wf-1",
+	}
+
+	wc.persistWorkflowContext()
+
+	// Verify the workflow context was saved
+	state, err := store.Load(context.Background(), "wf-1")
+	require.NoError(t, err)
+	require.NotNil(t, state.Metadata["workflow"])
 }


### PR DESCRIPTION
## Summary

Addresses 22 findings from the SDK scalability review (H5-H7, M18-M28, L12-L21):

**High Priority:**
- **H5**: Fix `RLock` to `Lock` for `buildPipelineConfig` tool registration (write operation under read lock)
- **H6**: Isolate tool registry on `Fork()` to prevent cross-conversation tool leaks
- **H7**: Add `pipelineDone` channel to avoid draining `streamOutput` in `Done()`

**Medium Priority:**
- **M18**: Guard capability tool registration with `capabilitiesRegistered` flag
- **M19**: Use `sync.Once` for `logger.SetLogger` to prevent data race
- **M20**: Add session-scoped context for duplex pipeline execution
- **M21**: Remove O(N^2) string allocation from intermediate stream chunks
- **M22**: Add TODO for `SendFrame` byte-to-string copy
- **M23**: Use `atomic.Int32` for eval middleware `turnIndex`
- **M24**: Add message caching for eval middleware
- **M25**: Initialize `sessionHooks` in `initConversation`
- **M26**: Log `persistWorkflowContext` save errors instead of discarding
- **M27**: Add default 5-minute timeout for agent executor calls
- **M28**: Log AG-UI event drops when channel buffer is full

**Low Priority:**
- **L12-L18**: Documentation/TODO comments for known limitations
- **L19**: Rewrite `filterRelevantMessages` to iterate from end (inlined, O(1) extra space)
- **L20**: Collect errors in `MultiAgentSession.Close` via `errors.Join`
- **L21**: Check context before `Close` in shutdown goroutines

## Test plan

- [x] All existing SDK tests pass (`go test ./sdk/... -count=1`)
- [x] All session tests pass (`go test ./sdk/session -count=1`)
- [x] Added tests for `MultiAgentSession.Close` error collection (entry, member, combined)
- [x] Added tests for `persistWorkflowContext` (save error, transient state, success)
- [x] Lint clean via `golangci-lint run ./sdk/...`
- [x] All changed files meet 80% coverage threshold
- [x] Pre-commit hook passes