### PR TITLE
fix: security hardening and config validation improvements

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -252,9 +252,12 @@ func LoadConfig(filename string) (*Config, error) {
 		}
 	}
 
-	// Validate the loaded configuration (warnings only, doesn't fail)
+	// Validate the loaded configuration (warnings only, doesn't fail).
+	// TODO: propagate validation warnings to the caller or log them. Currently the
+	// validator result and any warnings are discarded because the config package has
+	// no logger and LoadConfig's signature does not surface warnings.
 	validator := NewConfigValidatorWithPath(cfg, filename)
-	_ = validator.Validate() // Intentionally ignored - validation warnings accessible via validator.GetWarnings()
+	_ = validator.Validate()
 
 	return cfg, nil
 }
@@ -446,6 +449,9 @@ func (c *Config) loadTools(configPath string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read tool file %s: %w", ref.File, err)
 		}
+		// TODO: validate tool files against a schema. Note that ValidateTool expects
+		// K8s-style manifests (apiVersion/kind/spec), but tool files referenced here
+		// may use raw OpenAI function format. A format-aware validator is needed.
 		c.LoadedTools = append(c.LoadedTools, ToolData{
 			FilePath: ref.File,
 			Data:     data,

--- a/pkg/config/persona.go
+++ b/pkg/config/persona.go
@@ -313,6 +313,8 @@ func (p *UserPersonaPack) buildTemplatedPrompt(region string, contextVars map[st
 		// The actual fragment loading will be handled when needed
 		// This is a temporary approach - proper fragment loading through repository
 		// should be implemented when persona system is refactored further
+		// TODO: reject fragment configs at validation time (in ConfigValidator) so that
+		// callers get a clear error during config loading rather than at render time.
 		return "", fmt.Errorf("fragment loading for personas not yet fully implemented in config-first pattern for persona %s", p.ID)
 	}
 
@@ -333,7 +335,9 @@ func (p *UserPersonaPack) buildTemplatedPrompt(region string, contextVars map[st
 }
 
 // convertFragmentRefs converts config.FragmentRef to prompt.FragmentRef
-// (they're the same structure, but different types for package separation)
+// (they're the same structure, but different types for package separation).
+// TODO: this function is currently unreachable because fragment loading returns an error
+// above. It will become reachable once fragment loading is implemented.
 func convertFragmentRefs(refs []FragmentRef) []prompt.FragmentRef {
 	result := make([]prompt.FragmentRef, len(refs))
 	for i, ref := range refs {

--- a/pkg/config/schema_validator.go
+++ b/pkg/config/schema_validator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/xeipuuv/gojsonschema"
 	"gopkg.in/yaml.v3"
@@ -19,12 +20,15 @@ const SchemaBaseURL = "https://promptkit.altairalabs.ai/schemas/v1alpha1"
 
 const errorFormat = "  - %s"
 
-// SchemaFallbackEnabled controls whether to fall back to local schemas when remote fetch fails
-var SchemaFallbackEnabled = true
+// SchemaFallbackDisabled controls whether local schema fallback is suppressed.
+// When true (non-default), the loader will not fall back to local schemas on remote fetch failure.
+// Uses atomic.Bool for safe concurrent access across goroutines and test init functions.
+var SchemaFallbackDisabled atomic.Bool
 
-// SchemaValidationEnabled controls whether schema validation is performed
-// Can be disabled for testing or when schemas are not yet published
-var SchemaValidationEnabled = true
+// SchemaValidationDisabled controls whether schema validation is skipped.
+// When true (non-default), schema validation is bypassed (useful for testing or unpublished schemas).
+// Uses atomic.Bool for safe concurrent access across goroutines and test init functions.
+var SchemaValidationDisabled atomic.Bool
 
 // SchemaLocalPath is the path to local schema files (relative to repo root)
 const SchemaLocalPath = "schemas/v1alpha1"
@@ -176,7 +180,7 @@ func ValidateWithLocalSchema(yamlData []byte, configType ConfigType, schemaDir s
 
 func validateWithSchemaSource(yamlData []byte, configType ConfigType, schemaDir string) (*SchemaValidationResult, error) {
 	// Skip validation if disabled (for testing or when schemas not yet published)
-	if !SchemaValidationEnabled {
+	if SchemaValidationDisabled.Load() {
 		return &SchemaValidationResult{Valid: true, Errors: []SchemaValidationError{}}, nil
 	}
 
@@ -256,7 +260,7 @@ func loadSchema(schemaKey string, configType ConfigType, schemaDir string) (*goj
 	}
 
 	// Try fallback to local schema if remote fetch failed
-	if SchemaFallbackEnabled && schemaDir == "" {
+	if !SchemaFallbackDisabled.Load() && schemaDir == "" {
 		localSchema, fallbackErr := tryLocalSchemaFallback(configType)
 		if fallbackErr == nil {
 			return localSchema, nil

--- a/pkg/config/schema_validator_test.go
+++ b/pkg/config/schema_validator_test.go
@@ -499,9 +499,9 @@ func TestTryLocalSchemaFallback(t *testing.T) {
 
 func TestLoadSchema_WithFallback(t *testing.T) {
 	// Enable fallback for this test
-	originalFallbackSetting := SchemaFallbackEnabled
-	SchemaFallbackEnabled = true
-	defer func() { SchemaFallbackEnabled = originalFallbackSetting }()
+	originalFallbackSetting := SchemaFallbackDisabled.Load()
+	SchemaFallbackDisabled.Store(false)
+	defer func() { SchemaFallbackDisabled.Store(originalFallbackSetting) }()
 
 	// Test with an invalid remote schema URL (should trigger fallback)
 	schema, err := loadSchema("http://invalid-url-that-does-not-exist.com/schema.json", ConfigTypeArena, "")
@@ -517,9 +517,9 @@ func TestLoadSchema_WithFallback(t *testing.T) {
 
 func TestLoadSchema_WithoutFallback(t *testing.T) {
 	// Disable fallback for this test
-	originalFallbackSetting := SchemaFallbackEnabled
-	SchemaFallbackEnabled = false
-	defer func() { SchemaFallbackEnabled = originalFallbackSetting }()
+	originalFallbackSetting := SchemaFallbackDisabled.Load()
+	SchemaFallbackDisabled.Store(true)
+	defer func() { SchemaFallbackDisabled.Store(originalFallbackSetting) }()
 
 	// Test with a malformed schema reference that will fail
 	_, err := loadSchema("file:///nonexistent/path/to/schema.json", ConfigTypeArena, "")

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1007,7 +1007,8 @@ type Provider struct {
 // Resolution order: api_key → credential_file → credential_env → default env vars.
 type CredentialConfig struct {
 	// APIKey is an explicit API key value (not recommended for production).
-	APIKey string `json:"api_key,omitempty" yaml:"api_key,omitempty"`
+	// Excluded from JSON serialization to prevent accidental credential leakage.
+	APIKey string `json:"-" yaml:"api_key,omitempty"`
 	// CredentialFile is a path to a file containing the API key.
 	CredentialFile string `json:"credential_file,omitempty" yaml:"credential_file,omitempty"`
 	// CredentialEnv is the name of an environment variable containing the API key.

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -319,6 +319,8 @@ func (v *ConfigValidator) validateCrossReferences() {
 }
 
 // Helper methods to build ID sets
+
+// getPromptConfigIDs is currently only used by tests (validator_test.go).
 func (v *ConfigValidator) getPromptConfigIDs() map[string]bool {
 	ids := make(map[string]bool)
 	for _, pc := range v.config.PromptConfigs {

--- a/sdk/tools/http.go
+++ b/sdk/tools/http.go
@@ -173,7 +173,13 @@ func (e *HTTPExecutor) applyHeaders(req *http.Request, cfg *tools.HTTPConfig) {
 		req.Header.Set(key, value)
 	}
 
-	// Apply headers from environment variables
+	// Apply headers from environment variables.
+	// Security consideration: headers_from_env allows pack authors to inject arbitrary
+	// environment variable values into HTTP requests. A malicious pack could exfiltrate
+	// sensitive environment variables (e.g., AWS_SECRET_ACCESS_KEY) by directing requests
+	// to an attacker-controlled endpoint.
+	// TODO: implement an allowlist of permitted environment variable names or patterns
+	// to limit which variables can be read via headers_from_env.
 	for _, envHeader := range cfg.HeadersFromEnv {
 		// Format: "Header-Name=ENV_VAR_NAME"
 		parts := strings.SplitN(envHeader, "=", envHeaderParts)

--- a/tools/arena/cmd/promptarena/schema_disable_init_test.go
+++ b/tools/arena/cmd/promptarena/schema_disable_init_test.go
@@ -11,6 +11,6 @@ import (
 func init() {
 	// Disable schema validation when running tests
 	if testing.Testing() {
-		config.SchemaValidationEnabled = false
+		config.SchemaValidationDisabled.Store(true)
 	}
 }

--- a/tools/arena/consent/hook_test.go
+++ b/tools/arena/consent/hook_test.go
@@ -11,7 +11,7 @@ import (
 
 func init() {
 	if testing.Testing() {
-		config.SchemaValidationEnabled = false
+		config.SchemaValidationDisabled.Store(true)
 	}
 }
 

--- a/tools/arena/engine/init_test.go
+++ b/tools/arena/engine/init_test.go
@@ -11,6 +11,6 @@ import (
 func init() {
 	// Disable schema validation when running tests
 	if testing.Testing() {
-		config.SchemaValidationEnabled = false
+		config.SchemaValidationDisabled.Store(true)
 	}
 }

--- a/tools/arena/results/markdown/init_test.go
+++ b/tools/arena/results/markdown/init_test.go
@@ -9,6 +9,6 @@ import (
 // init disables schema validation for tests since schemas may not be published yet.
 func init() {
 	if testing.Testing() {
-		config.SchemaValidationEnabled = false
+		config.SchemaValidationDisabled.Store(true)
 	}
 }


### PR DESCRIPTION
## Summary
- **H9**: Prevent API key serialization in JSON by adding `json:"-"` tag to `CredentialConfig.APIKey`
- **M28**: Replace mutable `bool` schema validation flags with `atomic.Bool` to prevent data races
- **M15**: Document env variable exfiltration risk in `headers_from_env` with TODO for allowlist
- **M29, M34**: Add TODO comments for missing tool validation and discarded config warnings
- **L42-L44**: Document dead code and unimplemented fragment loading

## Test plan
- [x] `go test ./... -count=1` passes in pkg/
- [x] `golangci-lint run ./...` passes in pkg/
- [x] Arena test init files updated for new `atomic.Bool` API