### PR TITLE
fix: SDK concurrency, reliability, and safety improvements

### DIFF
--- a/sdk/a2a_server_adapter.go
+++ b/sdk/a2a_server_adapter.go
@@ -134,6 +134,9 @@ func chunkToEvent(c StreamChunk) a2aserver.StreamEvent {
 	case ChunkToolCall:
 		return a2aserver.StreamEvent{Kind: a2aserver.EventToolCall}
 	case ChunkClientTool:
+		if c.ClientTool == nil {
+			return a2aserver.StreamEvent{Kind: a2aserver.EventClientTool}
+		}
 		return a2aserver.StreamEvent{
 			Kind: a2aserver.EventClientTool,
 			ClientTool: &a2aserver.PendingClientToolInfo{

--- a/sdk/a2a_server_adapter_test.go
+++ b/sdk/a2a_server_adapter_test.go
@@ -19,8 +19,8 @@ type mockSDKResponse struct {
 	clientTools       []PendingClientTool
 }
 
-func (r *mockSDKResponse) Text() string                    { return r.text }
-func (r *mockSDKResponse) Parts() []types.ContentPart      { return r.parts }
+func (r *mockSDKResponse) Text() string                     { return r.text }
+func (r *mockSDKResponse) Parts() []types.ContentPart       { return r.parts }
 func (r *mockSDKResponse) PendingTools() []PendingTool      { return r.pendingTools }
 func (r *mockSDKResponse) HasPendingClientTools() bool      { return r.pendingClientBool }
 func (r *mockSDKResponse) ClientTools() []PendingClientTool { return r.clientTools }
@@ -28,13 +28,13 @@ func (r *mockSDKResponse) ClientTools() []PendingClientTool { return r.clientToo
 // --- mock conversationBackend ---
 
 type mockConvBackend struct {
-	sendFunc            func(ctx context.Context, message any, opts ...SendOption) (*Response, error)
-	closeFunc           func() error
-	sendToolResultFunc  func(ctx context.Context, callID string, result any) error
-	rejectClientFunc    func(ctx context.Context, callID, reason string)
-	resumeFunc          func(ctx context.Context) (*Response, error)
-	resumeStreamFunc    func(ctx context.Context) <-chan StreamChunk
-	streamFunc          func(ctx context.Context, message any, opts ...SendOption) <-chan StreamChunk
+	sendFunc           func(ctx context.Context, message any, opts ...SendOption) (*Response, error)
+	closeFunc          func() error
+	sendToolResultFunc func(ctx context.Context, callID string, result any) error
+	rejectClientFunc   func(ctx context.Context, callID, reason string)
+	resumeFunc         func(ctx context.Context) (*Response, error)
+	resumeStreamFunc   func(ctx context.Context) <-chan StreamChunk
+	streamFunc         func(ctx context.Context, message any, opts ...SendOption) <-chan StreamChunk
 }
 
 func (m *mockConvBackend) Send(ctx context.Context, message any, opts ...SendOption) (*Response, error) {
@@ -167,6 +167,20 @@ func TestChunkToEvent_ClientTool(t *testing.T) {
 	}
 	if evt.ClientTool.ConsentMsg != "Allow location?" {
 		t.Errorf("consent = %q, want 'Allow location?'", evt.ClientTool.ConsentMsg)
+	}
+}
+
+func TestChunkToEvent_ClientTool_Nil(t *testing.T) {
+	chunk := StreamChunk{
+		Type:       ChunkClientTool,
+		ClientTool: nil,
+	}
+	evt := chunkToEvent(chunk)
+	if evt.Kind != a2aserver.EventClientTool {
+		t.Fatalf("kind = %d, want EventClientTool", evt.Kind)
+	}
+	if evt.ClientTool != nil {
+		t.Error("expected nil ClientTool for nil input")
 	}
 }
 

--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -185,6 +185,12 @@ func (e *clientExecutor) ExecuteAsync(
 // After all pending tools have been resolved (via SendToolResult or
 // RejectClientTool), call [Conversation.Resume] to continue the pipeline.
 func (c *Conversation) SendToolResult(_ context.Context, callID string, result any) error {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return ErrConversationClosed
+	}
 	resultJSON, err := json.Marshal(result)
 	if err != nil {
 		return fmt.Errorf("failed to serialize client tool result: %w", err)
@@ -206,6 +212,12 @@ func (c *Conversation) SendToolResult(_ context.Context, callID string, result a
 // SendToolResultMultimodal, or RejectClientTool), call [Conversation.Resume]
 // to continue the pipeline.
 func (c *Conversation) SendToolResultMultimodal(_ context.Context, callID string, parts []types.ContentPart) error {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return ErrConversationClosed
+	}
 	if len(parts) == 0 {
 		return fmt.Errorf("parts must not be empty")
 	}
@@ -221,6 +233,12 @@ func (c *Conversation) SendToolResultMultimodal(_ context.Context, callID string
 // callID must match one of the [PendingClientTool.CallID] values returned in
 // the [Response]. The rejection reason is sent to the LLM as the tool result.
 func (c *Conversation) RejectClientTool(_ context.Context, callID, reason string) {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return
+	}
 	c.resolvedStore.Add(&sdktools.ToolResolution{
 		ID:              callID,
 		Rejected:        true,
@@ -297,7 +315,7 @@ func (c *Conversation) ResumeStream(ctx context.Context) <-chan StreamChunk {
 		}
 
 		state := &streamState{}
-		if err := c.processAndFinalizeStreamWithState(streamCh, ch, startTime, state); err != nil {
+		if err := c.processAndFinalizeStreamWithState(ctx, streamCh, ch, startTime, state); err != nil {
 			ch <- StreamChunk{Error: err}
 			return
 		}

--- a/sdk/client_tools_test.go
+++ b/sdk/client_tools_test.go
@@ -483,6 +483,43 @@ func TestResume_BuildsToolMessages(t *testing.T) {
 	assert.NotNil(t, resp)
 }
 
+func TestSendToolResult_WhenClosed(t *testing.T) {
+	conv := newTestConversation()
+	conv.ctxHandlers = make(map[string]ToolHandlerCtx)
+	conv.clientHandlers = make(map[string]ClientToolHandler)
+	conv.resolvedStore = sdktools.NewResolvedStore()
+	_ = conv.Close()
+
+	err := conv.SendToolResult(context.Background(), "call-1", map[string]any{"data": "x"})
+	assert.Equal(t, ErrConversationClosed, err)
+}
+
+func TestSendToolResultMultimodal_WhenClosed(t *testing.T) {
+	conv := newTestConversation()
+	conv.ctxHandlers = make(map[string]ToolHandlerCtx)
+	conv.clientHandlers = make(map[string]ClientToolHandler)
+	conv.resolvedStore = sdktools.NewResolvedStore()
+	_ = conv.Close()
+
+	err := conv.SendToolResultMultimodal(context.Background(), "call-1", []types.ContentPart{types.NewTextPart("hi")})
+	assert.Equal(t, ErrConversationClosed, err)
+}
+
+func TestRejectClientTool_WhenClosed(t *testing.T) {
+	conv := newTestConversation()
+	conv.ctxHandlers = make(map[string]ToolHandlerCtx)
+	conv.clientHandlers = make(map[string]ClientToolHandler)
+	conv.resolvedStore = sdktools.NewResolvedStore()
+	_ = conv.Close()
+
+	// Should not panic; silently returns
+	conv.RejectClientTool(context.Background(), "call-1", "denied")
+
+	// Verify nothing was added to the resolved store
+	resolutions := conv.resolvedStore.PopAll()
+	assert.Empty(t, resolutions)
+}
+
 func TestResumeStream_NoResolutions(t *testing.T) {
 	conv := newTestConversation()
 	conv.resolvedStore = sdktools.NewResolvedStore()

--- a/sdk/concurrency_test.go
+++ b/sdk/concurrency_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestConcurrentConversations verifies that multiple conversations
@@ -111,7 +112,8 @@ func TestForkIsolation(t *testing.T) {
 		return "original", nil
 	})
 
-	forked := original.Fork()
+	forked, err := original.Fork()
+	require.NoError(t, err)
 
 	// Both should start with the same variable
 	origVal, _ := original.GetVar("branch")
@@ -154,7 +156,9 @@ func TestConcurrentFork(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			forks[idx] = original.Fork()
+			fork, forkErr := original.Fork()
+			require.NoError(t, forkErr)
+			forks[idx] = fork
 			forks[idx].SetVar("fork_id", string(rune('A'+idx)))
 		}(i)
 	}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -139,7 +139,8 @@ type Conversation struct {
 	resolvedStore *sdktools.ResolvedStore
 
 	// MCP registry for managing MCP servers
-	mcpRegistry mcp.Registry
+	mcpRegistry            mcp.Registry
+	mcpExecutorsRegistered bool // guards against re-registering MCP executors on every pipeline build
 
 	// Platform capabilities (workflow, a2a, memory, etc.)
 	capabilities           []Capability
@@ -290,18 +291,35 @@ func (c *Conversation) buildPipelineConfig(
 		}
 	}
 
-	// Build tool registry — uses write lock because RegisterExecutor/RegisterTools mutate state
+	// Snapshot handler maps under lock to avoid races, then release before I/O.
 	c.handlersMu.Lock()
-	localExec := &localExecutor{handlers: c.handlers, ctxHandlers: c.ctxHandlers}
-	c.toolRegistry.RegisterExecutor(localExec)
+	handlersCopy := make(map[string]ToolHandler, len(c.handlers))
+	for k, v := range c.handlers {
+		handlersCopy[k] = v
+	}
+	ctxHandlersCopy := make(map[string]ToolHandlerCtx, len(c.ctxHandlers))
+	for k, v := range c.ctxHandlers {
+		ctxHandlersCopy[k] = v
+	}
+	c.handlersMu.Unlock()
 
-	// Register client executor for mode: "client" tools
 	c.clientHandlersMu.RLock()
-	clientExec := &clientExecutor{
-		handlers:   c.clientHandlers,
-		handlersMu: &clientHandlersMuAccessor{conv: c},
+	clientHandlersCopy := make(map[string]ClientToolHandler, len(c.clientHandlers))
+	for k, v := range c.clientHandlers {
+		clientHandlersCopy[k] = v
 	}
 	c.clientHandlersMu.RUnlock()
+
+	// Build tool registry — uses write lock because RegisterExecutor/RegisterTools mutate state.
+	// Handler map copies are used so the executor doesn't alias the Conversation's live maps.
+	c.handlersMu.Lock()
+	localExec := &localExecutor{handlers: handlersCopy, ctxHandlers: ctxHandlersCopy}
+	c.toolRegistry.RegisterExecutor(localExec)
+
+	clientExec := &clientExecutor{
+		handlers:   clientHandlersCopy,
+		handlersMu: &clientHandlersMuAccessor{conv: c},
+	}
 	c.toolRegistry.RegisterExecutor(clientExec)
 
 	c.registerMCPExecutors()
@@ -633,6 +651,12 @@ func (c *Conversation) SessionError() error {
 //	// Template: "You are helping {{customer_name}}"
 //	// Becomes: "You are helping Alice"
 func (c *Conversation) SetVar(name, value string) {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return
+	}
 	c.getBaseSession().SetVar(name, value)
 }
 
@@ -644,6 +668,12 @@ func (c *Conversation) SetVar(name, value string) {
 //	    "max_discount": 20,
 //	})
 func (c *Conversation) SetVars(vars map[string]any) {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return
+	}
 	sess := c.getBaseSession()
 	for k, v := range vars {
 		sess.SetVar(k, fmt.Sprintf("%v", v))
@@ -659,6 +689,12 @@ func (c *Conversation) SetVars(vars map[string]any) {
 //	conv.SetVarsFromEnv("PROMPTKIT_")
 //	// Sets variable "customer_name" = "Alice"
 func (c *Conversation) SetVarsFromEnv(prefix string) {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return
+	}
 	// O(N) scan of all env vars is acceptable here — os.Environ() is called
 	// infrequently (typically once at startup) and the alternative (os.LookupEnv
 	// per variable) would require knowing variable names in advance.
@@ -679,6 +715,12 @@ func (c *Conversation) SetVarsFromEnv(prefix string) {
 // GetVar returns the current value of a template variable.
 // Returns empty string and false if the variable is not set.
 func (c *Conversation) GetVar(name string) (string, bool) {
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return "", false
+	}
 	return c.getBaseSession().GetVar(name)
 }
 
@@ -703,6 +745,15 @@ func (c *Conversation) Messages(ctx context.Context) []types.Message {
 // messages. Useful for starting fresh within the same conversation session.
 // In duplex mode, this will close the session first if actively streaming.
 func (c *Conversation) Clear() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return ErrConversationClosed
+	}
+
+	// TODO: Clear should accept a context parameter in a future API revision
+	// instead of using context.Background().
 	ctx := context.Background()
 
 	// For duplex mode, close the session first
@@ -721,14 +772,14 @@ func (c *Conversation) Clear() error {
 //	conv.Send(ctx, "What cities should I visit?")
 //
 //	// Fork to explore different paths
-//	branch := conv.Fork()
+//	branch, err := conv.Fork()
 //
 //	conv.Send(ctx, "Tell me about Tokyo")     // Original path
 //	branch.Send(ctx, "Tell me about Kyoto")   // Branch path
 //
 // The forked conversation is completely independent - changes to one
 // do not affect the other.
-func (c *Conversation) Fork() *Conversation {
+func (c *Conversation) Fork() (*Conversation, error) {
 	// Need write lock because buildPipelineWithParams mutates shared tool registry
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -773,7 +824,7 @@ func (c *Conversation) Fork() *Conversation {
 	ctx := context.Background()
 	pipeline, err := c.buildPipelineWithParams(store, forkID, nil, nil)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("fork: failed to build pipeline: %w", err)
 	}
 
 	// Create a new tool registry for the fork, copying tool descriptors from the original.
@@ -813,7 +864,7 @@ func (c *Conversation) Fork() *Conversation {
 	case UnaryMode:
 		forkSession, err := c.unarySession.ForkSession(ctx, forkID, pipeline)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("fork: failed to fork unary session: %w", err)
 		}
 		fork.unarySession = forkSession
 
@@ -833,12 +884,12 @@ func (c *Conversation) Fork() *Conversation {
 
 		forkSession, err := c.duplexSession.ForkSession(ctx, forkID, pipelineBuilder)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("fork: failed to fork duplex session: %w", err)
 		}
 		fork.duplexSession = forkSession
 	}
 
-	return fork
+	return fork, nil
 }
 
 // startOTelSession registers (or re-registers) the caller's context with the

--- a/sdk/conversation_test.go
+++ b/sdk/conversation_test.go
@@ -385,6 +385,34 @@ func TestConversationSendWhenClosed(t *testing.T) {
 	assert.Equal(t, ErrConversationClosed, err)
 }
 
+func TestConversationVarsWhenClosed(t *testing.T) {
+	conv := newTestConversation()
+	conv.ctxHandlers = make(map[string]ToolHandlerCtx)
+	conv.clientHandlers = make(map[string]ClientToolHandler)
+	_ = conv.Close()
+
+	// SetVar should silently return on closed conversation
+	conv.SetVar("key", "value")
+	// SetVars should silently return on closed conversation
+	conv.SetVars(map[string]any{"key": "value"})
+	// SetVarsFromEnv should silently return on closed conversation
+	conv.SetVarsFromEnv("TEST_PREFIX_")
+	// GetVar should return empty on closed conversation
+	val, ok := conv.GetVar("key")
+	assert.False(t, ok)
+	assert.Empty(t, val)
+}
+
+func TestConversationClearWhenClosed(t *testing.T) {
+	conv := newTestConversation()
+	conv.ctxHandlers = make(map[string]ToolHandlerCtx)
+	conv.clientHandlers = make(map[string]ClientToolHandler)
+	_ = conv.Close()
+
+	err := conv.Clear()
+	assert.Error(t, err)
+}
+
 func TestConversationSendMessageTypes(t *testing.T) {
 	t.Skip("Skipping: Send now requires full Open() initialization with textSession")
 	conv := newTestConversation()

--- a/sdk/conversation_test.go
+++ b/sdk/conversation_test.go
@@ -338,7 +338,8 @@ func TestConversationFork(t *testing.T) {
 	err = store.Save(ctx, state)
 	require.NoError(t, err)
 
-	fork := conv.Fork()
+	fork, err := conv.Fork()
+	require.NoError(t, err)
 
 	// Verify fork has same data
 	forkVal, ok := fork.GetVar("name")
@@ -2000,8 +2001,8 @@ func TestForkRegistryIsolation(t *testing.T) {
 		InputSchema: schema,
 	})
 
-	fork := conv.Fork()
-	require.NotNil(t, fork)
+	fork, err := conv.Fork()
+	require.NoError(t, err)
 
 	// Fork should have the original tool
 	forkTools := fork.toolRegistry.GetTools()
@@ -2036,7 +2037,8 @@ func TestForkErrorHandling(t *testing.T) {
 			return "result", nil
 		})
 
-		forked := conv.Fork()
+		forked, err := conv.Fork()
+		require.NoError(t, err)
 
 		conv.handlersMu.RLock()
 		_, origHas := conv.handlers["test_tool"]
@@ -2114,7 +2116,7 @@ func TestSessionHookDispatcher_SessionUpdate(t *testing.T) {
 		conv := newTestConversation()
 		conv.hookRegistry = reg
 		conv.sessionHooks = newSessionHookDispatcher(reg, conv.sessionInfo)
-		conv.sessionHooks.turns = 3
+		conv.sessionHooks.turns.Store(3)
 
 		conv.sessionHooks.SessionUpdate(context.Background())
 
@@ -2137,7 +2139,7 @@ func TestSessionHookDispatcher_SessionEnd(t *testing.T) {
 		conv := newTestConversation()
 		conv.hookRegistry = reg
 		conv.sessionHooks = newSessionHookDispatcher(reg, conv.sessionInfo)
-		conv.sessionHooks.turns = 5
+		conv.sessionHooks.turns.Store(5)
 
 		conv.sessionHooks.SessionEnd(context.Background())
 
@@ -2157,7 +2159,7 @@ func TestSessionHookDispatcher_BuildEvent(t *testing.T) {
 		conv := newTestConversation()
 		conv.config.conversationID = "conv-456"
 		conv.sessionHooks = newSessionHookDispatcher(nil, conv.sessionInfo)
-		conv.sessionHooks.turns = 7
+		conv.sessionHooks.turns.Store(7)
 
 		event := conv.sessionHooks.buildEvent()
 
@@ -2172,7 +2174,7 @@ func TestSessionHookDispatcher_BuildEvent(t *testing.T) {
 			config: &config{conversationID: "conv-789"},
 		}
 		conv.sessionHooks = newSessionHookDispatcher(nil, conv.sessionInfo)
-		conv.sessionHooks.turns = 2
+		conv.sessionHooks.turns.Store(2)
 
 		event := conv.sessionHooks.buildEvent()
 
@@ -2201,7 +2203,7 @@ func TestCloseRunsSessionEndHook(t *testing.T) {
 	conv := newTestConversation()
 	conv.hookRegistry = reg
 	conv.sessionHooks = newSessionHookDispatcher(reg, conv.sessionInfo)
-	conv.sessionHooks.turns = 2
+	conv.sessionHooks.turns.Store(2)
 
 	err := conv.Close()
 	require.NoError(t, err)
@@ -2219,8 +2221,8 @@ func TestForkPreservesHookRegistry(t *testing.T) {
 	conv.sessionHooks = newSessionHookDispatcher(reg, conv.sessionInfo)
 	conv.asyncHandlers = make(map[string]sdktools.AsyncToolHandler)
 
-	forked := conv.Fork()
-	require.NotNil(t, forked)
+	forked, err := conv.Fork()
+	require.NoError(t, err)
 	assert.Equal(t, reg, forked.hookRegistry)
 	assert.NotNil(t, forked.sessionHooks)
 }

--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -161,6 +161,9 @@ func (c *Conversation) OnToolExecutor(name string, executor tools.Executor) {
 //	})
 //
 // The first function checks if approval is needed, the second executes the action.
+//
+// Lock ordering contract: asyncHandlersMu is acquired first, then handlersMu.
+// All code paths that acquire both locks must follow this order to avoid deadlock.
 func (c *Conversation) OnToolAsync(
 	name string,
 	checkFunc func(args map[string]any) sdktools.PendingResult,
@@ -182,7 +185,7 @@ func (c *Conversation) OnToolAsync(
 
 	c.asyncHandlers[name] = checkFunc
 
-	// Register the execution handler
+	// Register the execution handler (handlersMu acquired after asyncHandlersMu per lock ordering)
 	c.handlersMu.Lock()
 	c.handlers[name] = execFunc
 	c.handlersMu.Unlock()
@@ -378,10 +381,12 @@ func (c *Conversation) ToolRegistry() *tools.Registry {
 }
 
 // registerMCPExecutors registers executors for MCP tools.
+// Guarded by mcpExecutorsRegistered to avoid redundant ListAllTools I/O on every pipeline build (e.g. Fork).
 func (c *Conversation) registerMCPExecutors() {
-	if c.mcpRegistry == nil {
+	if c.mcpRegistry == nil || c.mcpExecutorsRegistered {
 		return
 	}
+	c.mcpExecutorsRegistered = true
 
 	ctx := context.Background()
 	mcpTools, err := c.mcpRegistry.ListAllTools(ctx)

--- a/sdk/eval_middleware.go
+++ b/sdk/eval_middleware.go
@@ -30,7 +30,9 @@ type evalMiddleware struct {
 	// Bounded concurrency: sem limits how many eval goroutines run simultaneously.
 	sem chan struct{}
 
-	// Cached messages to avoid reloading on every dispatch.
+	// cacheMu protects the cached fields below from concurrent access
+	// across multiple dispatchTurnEvals goroutines.
+	cacheMu          sync.Mutex
 	cachedMessages   []types.Message
 	cachedTurnIndex  int32
 	cachedSessionID  string
@@ -204,6 +206,9 @@ func (em *evalMiddleware) emitResults(results []evals.EvalResult) {
 // buildEvalContext creates an EvalContext from the conversation state.
 // It caches messages and only reloads when the turn count changes.
 func (em *evalMiddleware) buildEvalContext(ctx context.Context) *evals.EvalContext {
+	em.cacheMu.Lock()
+	defer em.cacheMu.Unlock()
+
 	currentTurn := em.turnIndex.Load()
 	evalCtx := &evals.EvalContext{
 		TurnIndex: int(currentTurn),

--- a/sdk/hitl_test.go
+++ b/sdk/hitl_test.go
@@ -345,7 +345,8 @@ func TestForkWithAsyncHandlers(t *testing.T) {
 	conv.CheckPending("async_tool", map[string]any{})
 
 	// Fork
-	forked := conv.Fork()
+	forked, err := conv.Fork()
+	require.NoError(t, err)
 
 	// Verify async handlers are copied
 	forked.asyncHandlersMu.RLock()

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -586,6 +586,9 @@ func WithTracerProvider(tp trace.TracerProvider) Option {
 //	conv, _ := sdk.Open("./chat.pack.json", "assistant",
 //	    sdk.WithLogger(slog.New(slog.NewJSONHandler(os.Stdout, nil))),
 //	)
+//
+// Note: only the first logger set via WithLogger takes effect process-wide.
+// Subsequent calls are silently ignored due to sync.Once in setLoggerOnce.
 func WithLogger(l *slog.Logger) Option {
 	return func(c *config) error {
 		c.logger = l

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -430,7 +430,10 @@ func platformBaseURL(pc *platformConfig, provType string) string {
 	case platformTypeVertex:
 		return vertexBaseURL(pc, provType)
 	case platformTypeAzure:
-		return pc.endpoint // Azure requires an explicit endpoint
+		// Azure always requires an explicit endpoint via WithPlatformEndpoint.
+		// When none is set, pc.endpoint is empty and provider creation will fail
+		// with a clear error from the Azure credential/provider layer.
+		return pc.endpoint
 	default:
 		return ""
 	}

--- a/sdk/session_hooks.go
+++ b/sdk/session_hooks.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -20,7 +21,7 @@ type sessionInfoFunc func() (sessionID, conversationID string, messages []types.
 type sessionHookDispatcher struct {
 	registry *hooks.Registry
 	info     sessionInfoFunc
-	turns    int
+	turns    atomic.Int32
 }
 
 // newSessionHookDispatcher creates a dispatcher that will call info() to gather
@@ -63,20 +64,20 @@ func (d *sessionHookDispatcher) SessionEnd(ctx context.Context) {
 	})
 }
 
-// IncrementTurn advances the turn counter by one.
+// IncrementTurn advances the turn counter by one. Safe for concurrent use.
 func (d *sessionHookDispatcher) IncrementTurn() {
 	if d == nil {
 		return
 	}
-	d.turns++
+	d.turns.Add(1)
 }
 
-// TurnIndex returns the current turn count.
+// TurnIndex returns the current turn count. Safe for concurrent use.
 func (d *sessionHookDispatcher) TurnIndex() int {
 	if d == nil {
 		return 0
 	}
-	return d.turns
+	return int(d.turns.Load())
 }
 
 // dispatch builds a SessionEvent and calls fn. Errors from hooks are intentionally
@@ -96,7 +97,7 @@ func (d *sessionHookDispatcher) dispatch(
 // plus the dynamic info callback.
 func (d *sessionHookDispatcher) buildEvent() hooks.SessionEvent {
 	event := hooks.SessionEvent{
-		TurnIndex: d.turns,
+		TurnIndex: int(d.turns.Load()),
 	}
 	if d.info != nil {
 		event.SessionID, event.ConversationID, event.Messages = d.info()

--- a/sdk/session_hooks_test.go
+++ b/sdk/session_hooks_test.go
@@ -58,7 +58,7 @@ func TestSessionHookDispatcher_DispatchesAllLifecycleEvents(t *testing.T) {
 
 func TestSessionHookDispatcher_BuildEventNilInfo(t *testing.T) {
 	d := newSessionHookDispatcher(nil, nil)
-	d.turns = 5
+	d.turns.Store(5)
 
 	event := d.buildEvent()
 

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -242,7 +242,7 @@ func (c *Conversation) executeStreamingPipeline(
 
 	// Process stream and finalize
 	state := &streamState{}
-	if err := c.processAndFinalizeStreamWithState(streamCh, outCh, startTime, state); err != nil {
+	if err := c.processAndFinalizeStreamWithState(ctx, streamCh, outCh, startTime, state); err != nil {
 		return err
 	}
 
@@ -256,18 +256,11 @@ func (c *Conversation) executeStreamingPipeline(
 	return nil
 }
 
-// processAndFinalizeStream handles the streaming response and emits the final chunk.
-func (c *Conversation) processAndFinalizeStream(
-	streamCh <-chan providers.StreamChunk,
-	outCh chan<- StreamChunk,
-	startTime time.Time,
-) error {
-	return c.processAndFinalizeStreamWithState(streamCh, outCh, startTime, &streamState{})
-}
-
-// processAndFinalizeStreamWithState is like processAndFinalizeStream but uses a caller-provided state
+// processAndFinalizeStreamWithState processes the streaming response, emits chunks, and sends
+// the final ChunkDone. Uses a caller-provided state
 // so the caller can inspect pendingTools after the stream completes.
 func (c *Conversation) processAndFinalizeStreamWithState(
+	ctx context.Context,
 	streamCh <-chan providers.StreamChunk,
 	outCh chan<- StreamChunk,
 	startTime time.Time,
@@ -281,10 +274,12 @@ func (c *Conversation) processAndFinalizeStreamWithState(
 	// Build response from accumulated data
 	resp := c.buildStreamingResponse(state, startTime)
 
-	// Emit final ChunkDone with complete response
-	outCh <- StreamChunk{
-		Type:    ChunkDone,
-		Message: resp,
+	// Emit final ChunkDone with complete response, respecting context cancellation
+	// to avoid blocking indefinitely when the consumer has gone away.
+	select {
+	case outCh <- StreamChunk{Type: ChunkDone, Message: resp}:
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
 	return nil

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -265,6 +265,10 @@ func (wc *WorkflowConversation) Send(ctx context.Context, message any, opts ...S
 	// Process pending transition from tool call
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
+	// Re-check closed after re-acquiring lock; Close() may have run while Send was in progress.
+	if wc.closed {
+		return nil, ErrWorkflowClosed
+	}
 	if wc.pendingTransition != nil {
 		pt := wc.pendingTransition
 		wc.pendingTransition = nil
@@ -457,8 +461,12 @@ func (wc *WorkflowConversation) persistWorkflowContext() {
 
 	ctx := context.Background()
 	state, err := wc.stateStore.Load(ctx, wc.workflowID)
+	if err != nil {
+		logger.Warn("failed to load workflow state, creating fresh state",
+			"workflow_id", wc.workflowID, "error", err)
+	}
 	if err != nil || state == nil {
-		// Create new state if not found
+		// Create new state if not found or on load error
 		state = &statestore.ConversationState{
 			ID:       wc.workflowID,
 			Metadata: make(map[string]any),


### PR DESCRIPTION
## Summary
Addresses 17 code review findings in the SDK module:

**HIGH:**
- **H1**: Fix data race in `buildEvalContext` cached fields (added `cacheMu sync.Mutex`)
- **H2**: Fix handler map race in `buildPipelineConfig` (snapshot maps under lock)
- **H3**: Fix `Clear()` race with `Close()`/`Send()` (added mutex + closed check)
- **H8**: `Fork()` now returns `(*Conversation, error)` instead of silently returning nil

**MEDIUM:**
- **M11**: `sessionHookDispatcher.turns` changed to `atomic.Int32`
- **M12**: `WorkflowConversation.Send()` re-checks `wc.closed` after re-acquiring lock
- **M13**: Added `mcpExecutorsRegistered` guard to prevent redundant MCP re-registration
- **M14**: Documented `WithLogger` single-set limitation
- **M22**: Added `c.closed` checks to `SetVar`, `SetVars`, `SetVarsFromEnv`, `GetVar`
- **M23**: Restructured `buildPipelineConfig` to minimize critical section
- **M24**: Added nil check for `ClientTool` in `chunkToEvent`
- **M25**: Log error in `persistWorkflowContext` instead of silently swallowing

**LOW:** L35, L36, L37, L39, L40

## Breaking Changes
- `Fork()` signature changed from `Fork() *Conversation` to `Fork() (*Conversation, error)`

## Test plan
- [x] All SDK tests pass with `-race` flag
- [x] `golangci-lint run ./...` passes
- [x] Pre-commit hook passes (lint, build, tests, coverage)
- [x] All Fork() callers in tests updated