### PR TITLE
fix: A2A server reliability, security, and observability

### DIFF
--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -282,8 +282,11 @@ func (s *Server) ListenAndServe() error {
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: defaultReadHeaderTimeout,
 		ReadTimeout:       s.readTimeout,
-		WriteTimeout:      0, // disabled for SSE streaming compatibility
-		IdleTimeout:       s.idleTimeout,
+		// TODO: WriteTimeout: 0 disables write timeouts on all endpoints, not
+		// just SSE. Consider per-handler timeouts via http.TimeoutHandler for
+		// non-streaming endpoints.
+		WriteTimeout: 0,
+		IdleTimeout:  s.idleTimeout,
 	}
 
 	s.httpSrvMu.Lock()
@@ -343,8 +346,11 @@ func (s *Server) Serve(ln net.Listener) error {
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: defaultReadHeaderTimeout,
 		ReadTimeout:       s.readTimeout,
-		WriteTimeout:      0, // disabled for SSE streaming compatibility
-		IdleTimeout:       s.idleTimeout,
+		// TODO: WriteTimeout: 0 disables write timeouts on all endpoints, not
+		// just SSE. Consider per-handler timeouts via http.TimeoutHandler for
+		// non-streaming endpoints.
+		WriteTimeout: 0,
+		IdleTimeout:  s.idleTimeout,
 	}
 
 	s.httpSrvMu.Lock()
@@ -432,7 +438,7 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 	if s.authenticator != nil {
 		if err := s.authenticator.Authenticate(r); err != nil {
 			log.Printf("a2a: authentication failed: %v", err)
-			writeRPCError(w, nil, -32000, "Authentication failed")
+			writeRPCErrorWithStatus(w, http.StatusUnauthorized, nil, -32000, "Authentication failed")
 			return
 		}
 	}
@@ -478,25 +484,28 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request, req *
 
 	conv, err := s.getOrCreateConversation(contextID)
 	if err != nil {
-		writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to open conversation: %v", err))
+		log.Printf("a2a: failed to open conversation for context %s: %v", contextID, err)
+		writeRPCError(w, req.ID, -32000, "internal server error")
 		return
 	}
 
 	// Check if this is a tool-result message for a resumable conversation.
 	if toolResults := extractToolResults(params.Message.Parts); len(toolResults) > 0 {
-		s.handleToolResultMessage(w, req, conv, contextID, toolResults, params.Configuration)
+		s.handleToolResultMessage(w, r, req, conv, contextID, toolResults, params.Configuration)
 		return
 	}
 
 	pkMsg, err := a2a.MessageToMessage(&params.Message)
 	if err != nil {
-		writeRPCError(w, req.ID, -32602, fmt.Sprintf("Invalid message: %v", err))
+		log.Printf("a2a: invalid message in context %s: %v", contextID, err)
+		writeRPCError(w, req.ID, -32602, "Invalid message")
 		return
 	}
 
 	taskID := generateID()
 	if _, err := s.taskStore.Create(taskID, contextID); err != nil {
-		writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to create task: %v", err))
+		log.Printf("a2a: failed to create task for context %s: %v", contextID, err)
+		writeRPCError(w, req.ID, -32000, "internal server error")
 		return
 	}
 
@@ -552,7 +561,7 @@ func extractToolResults(parts []a2a.Part) []toolResultEntry {
 // handleToolResultMessage processes a message/send that carries client tool results.
 // It submits each result to the ResumableConversation and resumes execution.
 func (s *Server) handleToolResultMessage(
-	w http.ResponseWriter, req *a2a.JSONRPCRequest,
+	w http.ResponseWriter, r *http.Request, req *a2a.JSONRPCRequest,
 	conv Conversation, contextID string,
 	results []toolResultEntry, cfg *a2a.SendMessageConfiguration,
 ) {
@@ -562,12 +571,13 @@ func (s *Server) handleToolResultMessage(
 		return
 	}
 
-	for _, r := range results {
-		if r.Rejected {
-			resumable.RejectClientTool(r.CallID, r.Reason)
+	for _, tr := range results {
+		if tr.Rejected {
+			resumable.RejectClientTool(tr.CallID, tr.Reason)
 		} else {
-			if err := resumable.SendToolResult(r.CallID, r.Result); err != nil {
-				writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to submit tool result: %v", err))
+			if err := resumable.SendToolResult(tr.CallID, tr.Result); err != nil {
+				log.Printf("a2a: failed to submit tool result %s: %v", tr.CallID, err)
+				writeRPCError(w, req.ID, -32000, "internal server error")
 				return
 			}
 		}
@@ -575,11 +585,16 @@ func (s *Server) handleToolResultMessage(
 
 	taskID := generateID()
 	if _, err := s.taskStore.Create(taskID, contextID); err != nil {
-		writeRPCError(w, req.ID, -32000, fmt.Sprintf("Failed to create task: %v", err))
+		log.Printf("a2a: failed to create task for context %s: %v", contextID, err)
+		writeRPCError(w, req.ID, -32000, "internal server error")
 		return
 	}
 
-	done := s.runResume(context.Background(), taskID, resumable)
+	// Propagate trace context to the background goroutine so downstream
+	// spans nest under the inbound trace.
+	bgCtx := trace.ContextWithSpanContext(context.Background(),
+		trace.SpanContextFromContext(r.Context()))
+	done := s.runResume(bgCtx, taskID, resumable)
 
 	if cfg != nil && cfg.Blocking {
 		<-done
@@ -605,17 +620,26 @@ func (s *Server) runResume(parent context.Context, taskID string, conv Resumable
 	go func() {
 		defer close(done)
 		defer cancel()
+		defer func() {
+			s.cancelsMu.Lock()
+			delete(s.cancels, taskID)
+			s.cancelsMu.Unlock()
+		}()
 
-		_ = s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil)
+		if err := s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil); err != nil {
+			log.Printf("a2a: task %s: failed to set working state: %v", taskID, err)
+		}
 
 		resp, err := conv.Resume(ctx)
 		if err != nil {
 			if ctx.Err() == nil {
 				errText := err.Error()
-				_ = s.taskStore.SetState(taskID, a2a.TaskStateFailed, &a2a.Message{
+				if storeErr := s.taskStore.SetState(taskID, a2a.TaskStateFailed, &a2a.Message{
 					Role:  a2a.RoleAgent,
 					Parts: []a2a.Part{{Text: &errText}},
-				})
+				}); storeErr != nil {
+					log.Printf("a2a: task %s: failed to set failed state: %v", taskID, storeErr)
+				}
 			}
 			return
 		}
@@ -638,8 +662,15 @@ func (s *Server) runConversation(parent context.Context, taskID string, conv Con
 	go func() {
 		defer close(done)
 		defer cancel()
+		defer func() {
+			s.cancelsMu.Lock()
+			delete(s.cancels, taskID)
+			s.cancelsMu.Unlock()
+		}()
 
-		_ = s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil)
+		if err := s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil); err != nil {
+			log.Printf("a2a: task %s: failed to set working state: %v", taskID, err)
+		}
 
 		resp, sendErr := conv.Send(ctx, pkMsg)
 		if sendErr != nil {
@@ -648,10 +679,12 @@ func (s *Server) runConversation(parent context.Context, taskID string, conv Con
 			// "canceled". Only mark as failed for genuine errors.
 			if ctx.Err() == nil {
 				errText := sendErr.Error()
-				_ = s.taskStore.SetState(taskID, a2a.TaskStateFailed, &a2a.Message{
+				if storeErr := s.taskStore.SetState(taskID, a2a.TaskStateFailed, &a2a.Message{
 					Role:  a2a.RoleAgent,
 					Parts: []a2a.Part{{Text: &errText}},
-				})
+				}); storeErr != nil {
+					log.Printf("a2a: task %s: failed to set failed state: %v", taskID, storeErr)
+				}
 			}
 			return
 		}
@@ -668,21 +701,29 @@ func (s *Server) runConversation(parent context.Context, taskID string, conv Con
 func (s *Server) finalizeTask(taskID string, resp SendResult) {
 	if resp.HasPendingTools() {
 		msg := buildPendingToolsMessage(resp)
-		_ = s.taskStore.SetState(taskID, a2a.TaskStateInputRequired, msg)
+		if err := s.taskStore.SetState(taskID, a2a.TaskStateInputRequired, msg); err != nil {
+			log.Printf("a2a: task %s: failed to set input_required state: %v", taskID, err)
+		}
 		return
 	}
 
 	artifacts, convErr := a2a.ContentPartsToArtifacts(resp.Parts())
 	if convErr == nil && len(artifacts) > 0 {
-		_ = s.taskStore.AddArtifacts(taskID, artifacts)
+		if err := s.taskStore.AddArtifacts(taskID, artifacts); err != nil {
+			log.Printf("a2a: task %s: failed to add artifacts: %v", taskID, err)
+		}
 	} else if text := resp.Text(); text != "" {
 		// Fallback: if Parts() is empty (see GH-428), use Text() content.
-		_ = s.taskStore.AddArtifacts(taskID, []a2a.Artifact{{
+		if err := s.taskStore.AddArtifacts(taskID, []a2a.Artifact{{
 			ArtifactID: "artifact-1",
 			Parts:      []a2a.Part{{Text: &text}},
-		}})
+		}}); err != nil {
+			log.Printf("a2a: task %s: failed to add text artifact: %v", taskID, err)
+		}
 	}
-	_ = s.taskStore.SetState(taskID, a2a.TaskStateCompleted, nil)
+	if err := s.taskStore.SetState(taskID, a2a.TaskStateCompleted, nil); err != nil {
+		log.Printf("a2a: task %s: failed to set completed state: %v", taskID, err)
+	}
 }
 
 // buildPendingToolsMessage creates an A2A message describing pending tools.
@@ -791,21 +832,11 @@ func (s *Server) handleListTasks(w http.ResponseWriter, req *a2a.JSONRPCRequest)
 // or creates a new one via the opener (double-check lock pattern).
 // It also updates the last-use timestamp for conversation TTL tracking.
 func (s *Server) getOrCreateConversation(contextID string) (Conversation, error) {
-	s.convsMu.RLock()
-	if conv, ok := s.convs[contextID]; ok {
-		s.convsMu.RUnlock()
-		// Upgrade to write lock to update last-use timestamp.
-		s.convsMu.Lock()
-		s.convLastUse[contextID] = time.Now()
-		s.convsMu.Unlock()
-		return conv, nil
-	}
-	s.convsMu.RUnlock()
-
+	// Acquire write lock directly to avoid a TOCTOU gap between RUnlock and
+	// Lock that could allow duplicate conversation creation.
 	s.convsMu.Lock()
 	defer s.convsMu.Unlock()
 
-	// Double-check after acquiring write lock.
 	if conv, ok := s.convs[contextID]; ok {
 		s.convLastUse[contextID] = time.Now()
 		return conv, nil
@@ -846,6 +877,17 @@ func writeRPCResult(w http.ResponseWriter, id, result any) {
 // writeRPCError writes a JSON-RPC 2.0 error response.
 func writeRPCError(w http.ResponseWriter, id any, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &a2a.JSONRPCError{Code: code, Message: msg},
+	})
+}
+
+// writeRPCErrorWithStatus writes a JSON-RPC 2.0 error response with a specific HTTP status code.
+func writeRPCErrorWithStatus(w http.ResponseWriter, status int, id any, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,

--- a/server/a2a/server_stream.go
+++ b/server/a2a/server_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"sync"
 
@@ -26,39 +27,40 @@ type ssePayload struct {
 }
 
 // taskBroadcaster fans out SSE events to multiple subscribers for a single task.
+// Subscribers are stored in a map keyed by auto-incrementing ID for O(1) removal.
 type taskBroadcaster struct {
 	mu     sync.Mutex
-	subs   []chan ssePayload
+	subs   map[uint64]chan ssePayload
+	nextID uint64
 	closed bool
 }
 
-// subscribe adds a new subscriber and returns its channel.
-// Returns nil if the broadcaster is at capacity.
-func (b *taskBroadcaster) subscribe() (<-chan ssePayload, error) {
+// subscribe adds a new subscriber and returns its receive channel and an ID for unsubscription.
+func (b *taskBroadcaster) subscribe() (_ <-chan ssePayload, subID uint64, _ error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	ch := make(chan ssePayload, subscriberBuffer)
 	if b.closed {
 		close(ch)
-		return ch, nil
+		return ch, 0, nil
+	}
+	if b.subs == nil {
+		b.subs = make(map[uint64]chan ssePayload)
 	}
 	if len(b.subs) >= maxSubscribers {
-		return nil, ErrTooManySubscribers
+		return nil, 0, ErrTooManySubscribers
 	}
-	b.subs = append(b.subs, ch)
-	return ch, nil
+	id := b.nextID
+	b.nextID++
+	b.subs[id] = ch
+	return ch, id, nil
 }
 
-// unsubscribe removes a subscriber channel.
-func (b *taskBroadcaster) unsubscribe(ch <-chan ssePayload) {
+// unsubscribe removes a subscriber by ID.
+func (b *taskBroadcaster) unsubscribe(id uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	for i, s := range b.subs {
-		if s == ch {
-			b.subs = append(b.subs[:i], b.subs[i+1:]...)
-			return
-		}
-	}
+	delete(b.subs, id)
 }
 
 // send broadcasts an event to all subscribers.
@@ -72,7 +74,7 @@ func (b *taskBroadcaster) send(evt ssePayload) {
 		select {
 		case ch <- evt:
 		default:
-			// slow subscriber — drop event to avoid blocking
+			log.Printf("a2a: broadcaster: dropped event for slow subscriber (buffer full)")
 		}
 	}
 }
@@ -120,30 +122,51 @@ func (s *Server) closeAllBroadcasters() {
 	}
 }
 
-// marshalRaw marshals v to json.RawMessage.
-func marshalRaw(v any) json.RawMessage {
-	data, _ := json.Marshal(v)
-	return data
+// marshalRaw marshals v to json.RawMessage, returning an error if serialization fails.
+func marshalRaw(v any) (json.RawMessage, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshalRaw: %w", err)
+	}
+	return data, nil
 }
 
 // writeSSE writes a single SSE event to the response.
 func writeSSE(w http.ResponseWriter, flusher http.Flusher, id, event any) {
-	data, _ := json.Marshal(a2a.JSONRPCResponse{
+	raw, err := marshalRaw(event)
+	if err != nil {
+		log.Printf("a2a: writeSSE: failed to marshal event: %v", err)
+		return
+	}
+	data, err := json.Marshal(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
-		Result:  marshalRaw(event),
+		Result:  raw,
 	})
+	if err != nil {
+		log.Printf("a2a: writeSSE: failed to marshal response: %v", err)
+		return
+	}
 	_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 	flusher.Flush()
 }
 
 // broadcastEvent builds an ssePayload and sends it to the broadcaster.
 func broadcastEvent(b *taskBroadcaster, rpcID, event any) {
-	data, _ := json.Marshal(a2a.JSONRPCResponse{
+	raw, err := marshalRaw(event)
+	if err != nil {
+		log.Printf("a2a: broadcastEvent: failed to marshal event: %v", err)
+		return
+	}
+	data, err := json.Marshal(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      rpcID,
-		Result:  marshalRaw(event),
+		Result:  raw,
 	})
+	if err != nil {
+		log.Printf("a2a: broadcastEvent: failed to marshal response: %v", err)
+		return
+	}
 	b.send(ssePayload{Data: data})
 }
 
@@ -166,10 +189,12 @@ func (sc *streamCtx) emit(event any) {
 
 // fail records a task failure in the store and emits the failed status event.
 func (sc *streamCtx) fail(errText string) {
-	_ = sc.srv.taskStore.SetState(sc.taskID, a2a.TaskStateFailed, &a2a.Message{
+	if err := sc.srv.taskStore.SetState(sc.taskID, a2a.TaskStateFailed, &a2a.Message{
 		Role:  a2a.RoleAgent,
 		Parts: []a2a.Part{{Text: &errText}},
-	})
+	}); err != nil {
+		log.Printf("a2a: task %s: failed to set failed state: %v", sc.taskID, err)
+	}
 	sc.emit(a2a.TaskStatusUpdateEvent{
 		TaskID:    sc.taskID,
 		ContextID: sc.contextID,
@@ -184,7 +209,9 @@ func (sc *streamCtx) fail(errText string) {
 
 // complete records a task completion and emits the completed status event.
 func (sc *streamCtx) complete() {
-	_ = sc.srv.taskStore.SetState(sc.taskID, a2a.TaskStateCompleted, nil)
+	if err := sc.srv.taskStore.SetState(sc.taskID, a2a.TaskStateCompleted, nil); err != nil {
+		log.Printf("a2a: task %s: failed to set completed state: %v", sc.taskID, err)
+	}
 	sc.emit(a2a.TaskStatusUpdateEvent{
 		TaskID:    sc.taskID,
 		ContextID: sc.contextID,
@@ -265,7 +292,9 @@ func (s *Server) handleStreamMessage(
 	}
 
 	// Set task to working.
-	_ = s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil)
+	if err := s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil); err != nil {
+		log.Printf("a2a: task %s: failed to set working state: %v", taskID, err)
+	}
 	sc.emit(a2a.TaskStatusUpdateEvent{
 		TaskID:    taskID,
 		ContextID: contextID,
@@ -334,7 +363,9 @@ func (s *Server) handleStreamToolResultMessage(
 		contextID: contextID,
 	}
 
-	_ = s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil)
+	if err := s.taskStore.SetState(taskID, a2a.TaskStateWorking, nil); err != nil {
+		log.Printf("a2a: task %s: failed to set working state: %v", taskID, err)
+	}
 	sc.emit(a2a.TaskStatusUpdateEvent{
 		TaskID:    taskID,
 		ContextID: contextID,
@@ -446,7 +477,9 @@ func (sc *streamCtx) emitInputRequired(evt StreamEvent) {
 			}},
 		}
 	}
-	_ = sc.srv.taskStore.SetState(sc.taskID, a2a.TaskStateInputRequired, msg)
+	if err := sc.srv.taskStore.SetState(sc.taskID, a2a.TaskStateInputRequired, msg); err != nil {
+		log.Printf("a2a: task %s: failed to set input_required state: %v", sc.taskID, err)
+	}
 	sc.emit(a2a.TaskStatusUpdateEvent{
 		TaskID:    sc.taskID,
 		ContextID: sc.contextID,
@@ -522,12 +555,12 @@ func (s *Server) handleTaskSubscribe(w http.ResponseWriter, r *http.Request, req
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	ch, subErr := broadcaster.subscribe()
+	ch, subID, subErr := broadcaster.subscribe()
 	if subErr != nil {
 		writeRPCError(w, req.ID, -32000, "Too many subscribers")
 		return
 	}
-	defer broadcaster.unsubscribe(ch)
+	defer broadcaster.unsubscribe(subID)
 
 	ctx := r.Context()
 	for {

--- a/server/a2a/server_stream_test.go
+++ b/server/a2a/server_stream_test.go
@@ -1149,19 +1149,23 @@ func TestServer_StreamMessage_ClientTool_ResumeStream(t *testing.T) {
 func TestBroadcaster_SubscriberLimit(t *testing.T) {
 	b := &taskBroadcaster{}
 
-	// Fill up to maxSubscribers.
+	// Fill up to maxSubscribers and track the first subscriber ID.
+	var firstSubID uint64
 	for i := 0; i < maxSubscribers; i++ {
-		ch, err := b.subscribe()
+		ch, subID, err := b.subscribe()
 		if err != nil {
 			t.Fatalf("subscribe %d failed: %v", i, err)
 		}
 		if ch == nil {
 			t.Fatalf("subscribe %d returned nil channel", i)
 		}
+		if i == 0 {
+			firstSubID = subID
+		}
 	}
 
 	// Next subscribe should fail.
-	ch, err := b.subscribe()
+	ch, _, err := b.subscribe()
 	if !errors.Is(err, ErrTooManySubscribers) {
 		t.Errorf("expected ErrTooManySubscribers, got %v", err)
 	}
@@ -1170,12 +1174,9 @@ func TestBroadcaster_SubscriberLimit(t *testing.T) {
 	}
 
 	// After unsubscribing one, should be able to subscribe again.
-	b.mu.Lock()
-	firstCh := b.subs[0]
-	b.mu.Unlock()
-	b.unsubscribe(firstCh)
+	b.unsubscribe(firstSubID)
 
-	ch, err = b.subscribe()
+	ch, _, err = b.subscribe()
 	if err != nil {
 		t.Errorf("subscribe after unsubscribe failed: %v", err)
 	}
@@ -1188,7 +1189,7 @@ func TestBroadcaster_SubscribeClosed(t *testing.T) {
 	b := &taskBroadcaster{}
 	b.close()
 
-	ch, err := b.subscribe()
+	ch, _, err := b.subscribe()
 	if err != nil {
 		t.Errorf("unexpected error subscribing to closed broadcaster: %v", err)
 	}


### PR DESCRIPTION
## Summary
Addresses 10 code review findings in the server/a2a module:

**HIGH:**
- **H10**: `marshalRaw` now returns `(json.RawMessage, error)` — propagated to all callers

**MEDIUM:**
- **M1**: Fix race in `getOrCreateConversation` — single write lock instead of RLock/RUnlock/Lock
- **M2**: OTel span context propagation in `handleToolResultMessage`
- **M3**: Cleanup stale `s.cancels` entries via deferred delete
- **M4**: Sanitize error messages to clients, log full errors server-side
- **M5**: O(1) broadcaster unsubscribe via map with auto-incrementing IDs
- **M6**: Log warnings on dropped events for slow subscribers
- **M31**: 13 instances of silent task store errors now logged
- **M32**: Auth failures return HTTP 401 instead of 200

**LOW:** L47 (TODO for global WriteTimeout)

## Test plan
- [x] `go test ./... -count=1 -race` passes (87% coverage)
- [x] `golangci-lint run ./...` passes