### PR TITLE
fix: wire mock_parts through Arena executor and update schemas

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1068,17 +1068,35 @@ type ToolConfigSchema struct {
 
 // ToolSpec represents a tool descriptor (re-exported from runtime/tools for schema generation)
 type ToolSpec struct {
-	Name         string      `json:"name,omitempty" yaml:"name,omitempty"`
-	Description  string      `json:"description" yaml:"description"`
-	InputSchema  interface{} `json:"input_schema" yaml:"input_schema"`   // JSON Schema Draft-07
-	OutputSchema interface{} `json:"output_schema" yaml:"output_schema"` // JSON Schema Draft-07
-	Mode         string      `json:"mode" yaml:"mode"`                   // "mock" | "live" | "client"
-	TimeoutMs    int         `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
-	MockResult   interface{} `json:"mock_result,omitempty" yaml:"mock_result,omitempty"`     // Static mock data
-	MockTemplate string      `json:"mock_template,omitempty" yaml:"mock_template,omitempty"` // Template for dynamic mocks
-	HTTPConfig   *HTTPConfig `json:"http,omitempty" yaml:"http,omitempty"`                   // Live HTTP configuration
+	Name         string         `json:"name,omitempty" yaml:"name,omitempty"`
+	Description  string         `json:"description" yaml:"description"`
+	InputSchema  interface{}    `json:"input_schema" yaml:"input_schema"`   // JSON Schema Draft-07
+	OutputSchema interface{}    `json:"output_schema" yaml:"output_schema"` // JSON Schema Draft-07
+	Mode         string         `json:"mode" yaml:"mode"`                   // "mock" | "live" | "client"
+	TimeoutMs    int            `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+	MockResult   interface{}    `json:"mock_result,omitempty" yaml:"mock_result,omitempty"`
+	MockTemplate string         `json:"mock_template,omitempty" yaml:"mock_template,omitempty"`
+	MockParts    []MockPartSpec `json:"mock_parts,omitempty" yaml:"mock_parts,omitempty"`
+	HTTPConfig   *HTTPConfig    `json:"http,omitempty" yaml:"http,omitempty"`
 	// Client-side execution configuration
 	ClientConfig *ToolClientConfig `json:"client,omitempty" yaml:"client,omitempty"`
+}
+
+// MockPartSpec describes a single multimodal content part in mock_parts (schema generation).
+type MockPartSpec struct {
+	Type  string         `json:"type" yaml:"type"`                     // "text", "image", "audio", "video", "document"
+	Text  string         `json:"text,omitempty" yaml:"text,omitempty"` // For type=text
+	Media *MockMediaSpec `json:"media,omitempty" yaml:"media,omitempty"`
+}
+
+// MockMediaSpec describes media content in a mock part (schema generation).
+type MockMediaSpec struct {
+	FilePath string `json:"file_path,omitempty" yaml:"file_path,omitempty"` // Local file path (resolved at execution)
+	URL      string `json:"url,omitempty" yaml:"url,omitempty"`             // External URL
+	MIMEType string `json:"mime_type" yaml:"mime_type"`
+	Width    *int   `json:"width,omitempty" yaml:"width,omitempty"`
+	Height   *int   `json:"height,omitempty" yaml:"height,omitempty"`
+	Caption  string `json:"caption,omitempty" yaml:"caption,omitempty"`
 }
 
 // ToolClientConfig defines configuration for client-side tool execution (schema generation)

--- a/runtime/providers/gemini/stream_session_tools_integration.go
+++ b/runtime/providers/gemini/stream_session_tools_integration.go
@@ -35,6 +35,10 @@ func (s *StreamSession) SendToolResponse(ctx context.Context, toolCallID, result
 // SendToolResponses sends multiple tool execution results back to Gemini.
 // This is used when the model makes parallel tool calls.
 // After receiving the tool responses, Gemini will continue generating.
+//
+// NOTE: The streaming BidiGenerateContent API only supports text-based tool results.
+// Multimodal tool results (images, audio) are not supported in this path.
+// Use the non-streaming PredictWithTools API for multimodal tool result support.
 func (s *StreamSession) SendToolResponses(ctx context.Context, responses []providers.ToolResponse) error {
 	s.mu.Lock()
 	if s.closed {

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -224,6 +224,9 @@ func (p *Provider) convertMessagesToResponsesInput(messages []types.Message) []a
 // Returns a slice because assistant messages with tool calls become multiple items
 func (p *Provider) convertSingleMessageToResponsesInput(msg *types.Message) []map[string]any {
 	// Handle tool results - these are function_call_output items
+	// NOTE: The Responses API only supports text output for function_call_output.
+	// Multimodal tool results (images, audio) are reduced to text here.
+	// Use the Chat Completions API for full multimodal tool result support.
 	if msg.Role == roleToolResult && msg.ToolResult != nil {
 		// Transform call ID to Responses API format (must start with 'fc_')
 		callID := transformToResponsesCallID(msg.ToolResult.ID)

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1075,6 +1075,51 @@
         "type"
       ]
     },
+    "MockMediaSpec": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "MockPartSpec": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/MockMediaSpec"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
     "ModelOverride": {
       "properties": {
         "system_template": {
@@ -2002,6 +2047,12 @@
         "mock_result": true,
         "mock_template": {
           "type": "string"
+        },
+        "mock_parts": {
+          "items": {
+            "$ref": "#/$defs/MockPartSpec"
+          },
+          "type": "array"
         },
         "http": {
           "$ref": "#/$defs/HTTPConfig"

--- a/schemas/v1alpha1/tool.json
+++ b/schemas/v1alpha1/tool.json
@@ -40,6 +40,51 @@
         "timeout_ms"
       ]
     },
+    "MockMediaSpec": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "MockPartSpec": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/MockMediaSpec"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
     "ObjectMeta": {
       "properties": {
         "name": {
@@ -130,6 +175,12 @@
         "mock_result": true,
         "mock_template": {
           "type": "string"
+        },
+        "mock_parts": {
+          "items": {
+            "$ref": "#/$defs/MockPartSpec"
+          },
+          "type": "array"
         },
         "http": {
           "$ref": "#/$defs/HTTPConfig"

--- a/tools/arena/engine/duplex_conversation_executor_test.go
+++ b/tools/arena/engine/duplex_conversation_executor_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -10,7 +11,10 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/streaming"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDuplexConversationExecutor_RequiresDuplexConfig(t *testing.T) {
@@ -589,6 +593,46 @@ func TestArenaToolExecutor_NilRegistry(t *testing.T) {
 	if executor != nil {
 		t.Errorf("newArenaToolExecutor(nil) should return nil, got %v", executor)
 	}
+}
+
+func TestArenaToolExecutor_PropagatesMultimodalParts(t *testing.T) {
+	// Register a mock tool that returns multimodal parts via ExecuteMultimodal
+	registry := tools.NewRegistry()
+	text := "chart generated"
+	imgData := "iVBORw0KGgo="
+	imgMime := "image/png"
+
+	mockParts := []types.ContentPart{
+		{Type: types.ContentTypeText, Text: &text},
+		{Type: types.ContentTypeImage, Media: &types.MediaContent{Data: &imgData, MIMEType: imgMime}},
+	}
+
+	desc := &tools.ToolDescriptor{
+		Name:        "chart_tool",
+		Description: "generates charts",
+		Mode:        "mock",
+		MockResult:  json.RawMessage(`{"ok":true}`),
+		MockParts:   mockParts,
+	}
+	require.NoError(t, registry.Register(desc))
+
+	executor := newArenaToolExecutor(registry)
+	require.NotNil(t, executor)
+
+	toolCalls := []types.MessageToolCall{
+		{ID: "call-1", Name: "chart_tool", Args: json.RawMessage(`{}`)},
+	}
+
+	result, err := executor.Execute(context.Background(), toolCalls)
+	require.NoError(t, err)
+	require.Len(t, result.ResultMessages, 1)
+
+	msg := result.ResultMessages[0]
+	require.NotNil(t, msg.ToolResult)
+	require.True(t, msg.ToolResult.HasMedia(), "tool result should contain media parts")
+	assert.Len(t, msg.ToolResult.Parts, 2)
+	assert.Equal(t, types.ContentTypeText, msg.ToolResult.Parts[0].Type)
+	assert.Equal(t, types.ContentTypeImage, msg.ToolResult.Parts[1].Type)
 }
 
 func TestProcessResponseElement(t *testing.T) {

--- a/tools/arena/engine/duplex_executor_tools_integration.go
+++ b/tools/arena/engine/duplex_executor_tools_integration.go
@@ -90,6 +90,10 @@ func (e *arenaToolExecutor) Execute(
 		})
 		successResult := types.NewTextToolResult(tc.ID, tc.Name, resultStr)
 		successResult.LatencyMs = toolResult.LatencyMs
+		// Propagate multimodal parts (e.g. from mock_parts) if present
+		if len(toolResult.Parts) > 0 {
+			successResult.Parts = toolResult.Parts
+		}
 		result.ResultMessages = append(result.ResultMessages, types.NewToolResultMessage(successResult))
 	}
 


### PR DESCRIPTION
## Summary
- **Arena tool executor**: Propagate `toolResult.Parts` (multimodal content from `mock_parts`) to `MessageToolResult` so multimodal tool results flow end-to-end through PromptArena
- **Config types & schemas**: Add `MockPartSpec`, `MockMediaSpec` types and `mock_parts` field to `ToolSpec`; regenerate JSON schemas
- **Provider docs**: Document text-only limitations for OpenAI Responses API and Gemini streaming tool results
- **A2A server**: Reliability, security, and observability improvements (from prior commit)

Closes gaps identified in `MULTIMODAL_TOOL_RESULTS_PROPOSAL.md` items #624 (Arena integration) and #626 (example pack).

## Test plan
- [x] Unit test for multimodal parts propagation in `duplex_conversation_executor_test.go`
- [x] Pre-commit checks pass (lint, build, tests with 80% coverage)
- [ ] CI green
- [ ] Verify `examples/multimodal-tool-results/` works with `mock_parts` after merge