### PR TITLE
fix: resolve LOW code review findings

### DIFF
--- a/pkg/config/persona.go
+++ b/pkg/config/persona.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/template"
 )
 
@@ -332,20 +331,4 @@ func (p *UserPersonaPack) buildTemplatedPrompt(region string, contextVars map[st
 	}
 
 	return result, nil
-}
-
-// convertFragmentRefs converts config.FragmentRef to prompt.FragmentRef
-// (they're the same structure, but different types for package separation).
-// TODO: this function is currently unreachable because fragment loading returns an error
-// above. It will become reachable once fragment loading is implemented.
-func convertFragmentRefs(refs []FragmentRef) []prompt.FragmentRef {
-	result := make([]prompt.FragmentRef, len(refs))
-	for i, ref := range refs {
-		result[i] = prompt.FragmentRef{
-			Name:     ref.Name,
-			Path:     ref.Path,
-			Required: ref.Required,
-		}
-	}
-	return result
 }

--- a/pkg/config/persona_test.go
+++ b/pkg/config/persona_test.go
@@ -582,24 +582,3 @@ func TestUserPersonaPack_BuildTemplatedPrompt_WithFragments(t *testing.T) {
 		t.Errorf("Expected fragment error message, got: %v", err)
 	}
 }
-
-func TestConvertFragmentRefs(t *testing.T) {
-	configRefs := []FragmentRef{
-		{Name: "frag1", Path: "path1", Required: true},
-		{Name: "frag2", Path: "path2", Required: false},
-	}
-
-	promptRefs := convertFragmentRefs(configRefs)
-
-	if len(promptRefs) != 2 {
-		t.Errorf("Expected 2 refs, got %d", len(promptRefs))
-	}
-
-	if promptRefs[0].Name != "frag1" || promptRefs[0].Path != "path1" || !promptRefs[0].Required {
-		t.Error("First ref conversion incorrect")
-	}
-
-	if promptRefs[1].Name != "frag2" || promptRefs[1].Path != "path2" || promptRefs[1].Required {
-		t.Error("Second ref conversion incorrect")
-	}
-}

--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -114,20 +114,22 @@ func (r *Registry) Register(descriptor *ToolDescriptor) error {
 	// Test validation setup (errors here indicate schema compilation issues, which are acceptable during registration)
 	_ = r.validator.ValidateArgs(descriptor, []byte("{}"))
 
-	// Persist to repository if available
+	// Auto-populate namespace from name before persisting
+	descriptor.Namespace, _ = ParseToolName(descriptor.Name)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Persist to repository if available (under lock to prevent concurrent
+	// Register calls for the same tool from both persisting)
 	if r.repository != nil {
 		if err := r.repository.SaveTool(descriptor); err != nil {
 			return fmt.Errorf("failed to save tool to repository: %w", err)
 		}
 	}
 
-	// Auto-populate namespace from name
-	descriptor.Namespace, _ = ParseToolName(descriptor.Name)
-
 	// Cache the descriptor
-	r.mu.Lock()
 	r.tools[descriptor.Name] = descriptor
-	r.mu.Unlock()
 	return nil
 }
 

--- a/sdk/capability_skills.go
+++ b/sdk/capability_skills.go
@@ -71,7 +71,9 @@ func (c *SkillsCapability) Init(ctx CapabilityContext) error {
 	}
 	c.executor = skills.NewExecutor(cfg)
 
-	// Preload skills marked with preload: true
+	// Preload skills marked with preload: true.
+	// Errors are intentionally ignored: preloading is best-effort and the skill
+	// will be activated on first use if preloading fails.
 	for _, sk := range reg.PreloadedSkills() {
 		_, _, _ = c.executor.Activate(sk.Name)
 	}

--- a/tools/arena/render/assertion_message_test.go
+++ b/tools/arena/render/assertion_message_test.go
@@ -36,7 +36,7 @@ func TestAssertionMessageRendering(t *testing.T) {
 	)
 
 	data := prepareReportData([]engine.RunResult{result})
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf("generateHTML() error = %v", err)
 	}

--- a/tools/arena/render/badge_semantics_test.go
+++ b/tools/arena/render/badge_semantics_test.go
@@ -46,7 +46,7 @@ func TestBadgeSemantics_GuardrailTriggeredExpected(t *testing.T) {
 	}
 
 	data := prepareReportData([]engine.RunResult{result})
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf("generateHTML() error = %v", err)
 	}
@@ -106,7 +106,7 @@ func TestBadgeSemantics_GuardrailNotTriggeredGood(t *testing.T) {
 	}
 
 	data := prepareReportData([]engine.RunResult{result})
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf("generateHTML() error = %v", err)
 	}
@@ -165,7 +165,7 @@ func TestBadgeSemantics_GuardrailTriggeredNotExpected(t *testing.T) {
 	}
 
 	data := prepareReportData([]engine.RunResult{result})
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf("generateHTML() error = %v", err)
 	}

--- a/tools/arena/render/badge_test.go
+++ b/tools/arena/render/badge_test.go
@@ -58,7 +58,7 @@ func TestValidatorBadgeDisplay(t *testing.T) {
 			}
 
 			data := prepareReportData([]engine.RunResult{result})
-			html, err := generateHTML(data)
+			html, err := generateHTML(&data)
 			if err != nil {
 				t.Fatalf("generateHTML() error = %v", err)
 			}
@@ -148,7 +148,7 @@ func TestAssertionBadgeDisplay(t *testing.T) {
 			}
 
 			data := prepareReportData([]engine.RunResult{result})
-			html, err := generateHTML(data)
+			html, err := generateHTML(&data)
 			if err != nil {
 				t.Fatalf("generateHTML() error = %v", err)
 			}
@@ -241,7 +241,7 @@ func TestMultipleValidatorsBadgeDisplay(t *testing.T) {
 			}
 
 			data := prepareReportData([]engine.RunResult{result})
-			html, err := generateHTML(data)
+			html, err := generateHTML(&data)
 			if err != nil {
 				t.Fatalf("generateHTML() error = %v", err)
 			}
@@ -314,7 +314,7 @@ func TestValidatorAndAssertionBadgesTogether(t *testing.T) {
 	}
 
 	data := prepareReportData([]engine.RunResult{result})
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf("generateHTML() error = %v", err)
 	}

--- a/tools/arena/render/conversation_assertions_test.go
+++ b/tools/arena/render/conversation_assertions_test.go
@@ -166,7 +166,7 @@ func TestConversationAssertionsRendering(t *testing.T) {
 			}
 
 			// Generate HTML
-			html, err := generateHTML(data)
+			html, err := generateHTML(&data)
 			if err != nil {
 				t.Fatalf("generateHTML() error = %v", err)
 			}

--- a/tools/arena/render/html.go
+++ b/tools/arena/render/html.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/microcosm-cc/bluemonday"
@@ -95,7 +96,7 @@ func GenerateHTMLReport(results []engine.RunResult, outputPath string) error {
 	data := prepareReportData(results)
 
 	// Generate HTML
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		return fmt.Errorf("failed to generate HTML: %w", err)
 	}
@@ -343,48 +344,58 @@ func generateScenarioGroups(results []engine.RunResult, scenarios []string) []Sc
 	return groups
 }
 
-func generateHTML(data HTMLReportData) (string, error) {
-	tmpl := template.Must(template.New("report").Funcs(template.FuncMap{
-		"formatCost":                   formatCost,
-		"formatDuration":               formatDuration,
-		"formatPercent":                formatPercent,
-		"statusClass":                  getStatusClass,
-		"prettyJSON":                   prettyJSON,
-		"renderMarkdown":               renderMarkdown,
-		"renderMessageContent":         renderMessageContent,
-		"formatBytes":                  formatBytesHTML,
-		"json":                         convertToJS,
-		"add":                          func(a, b int) int { return a + b },
-		"getAssertions":                getAssertions,
-		"getValidators":                getValidatorsFromMessage,
-		"assertionsPassed":             checkAssertionsPassed,
-		"validatorsPassed":             checkValidatorsPassed,
-		"hasAssertions":                hasAssertions,
-		"hasValidators":                hasValidatorsInMessage,
-		"getOK":                        getOKFromResult,
-		"getDetails":                   getDetailsFromResult,
-		"getMessage":                   getMessage,
-		"hasMediaOutputs":              hasMediaOutputs,
-		"renderMediaOutputs":           renderMediaOutputs,
-		"hasAssertionResults":          hasAssertionResults,
-		"getAssertionResults":          getAssertionResults,
-		"getAssertionType":             getAssertionType,
-		"hasConversationAssertions":    hasConversationAssertions,
-		"conversationAssertionsPassed": conversationAssertionsPassed,
-		"renderConversationAssertions": renderConversationAssertions,
-		"getConversationAssertionResults": func(r engine.RunResult) []assertions.ConversationValidationResult {
-			return r.ConversationAssertions.Results
-		},
-		"renderToolResultMediaBadges": renderToolResultMediaBadges,
-		"isAgentTool":                 isAgentTool,
-		"isWorkflowTool":              isWorkflowTool,
-		"hasA2AAgents":                hasA2AAgents,
-		"renderA2AAgentCards":         renderA2AAgentCards,
-		"consentStatus":               consentStatus,
-	}).Parse(reportTemplate))
+var (
+	reportTmplOnce sync.Once
+	reportTmpl     *template.Template
+)
 
+func getReportTemplate() *template.Template {
+	reportTmplOnce.Do(func() {
+		reportTmpl = template.Must(template.New("report").Funcs(template.FuncMap{
+			"formatCost":                   formatCost,
+			"formatDuration":               formatDuration,
+			"formatPercent":                formatPercent,
+			"statusClass":                  getStatusClass,
+			"prettyJSON":                   prettyJSON,
+			"renderMarkdown":               renderMarkdown,
+			"renderMessageContent":         renderMessageContent,
+			"formatBytes":                  formatBytesHTML,
+			"json":                         convertToJS,
+			"add":                          func(a, b int) int { return a + b },
+			"getAssertions":                getAssertions,
+			"getValidators":                getValidatorsFromMessage,
+			"assertionsPassed":             checkAssertionsPassed,
+			"validatorsPassed":             checkValidatorsPassed,
+			"hasAssertions":                hasAssertions,
+			"hasValidators":                hasValidatorsInMessage,
+			"getOK":                        getOKFromResult,
+			"getDetails":                   getDetailsFromResult,
+			"getMessage":                   getMessage,
+			"hasMediaOutputs":              hasMediaOutputs,
+			"renderMediaOutputs":           renderMediaOutputs,
+			"hasAssertionResults":          hasAssertionResults,
+			"getAssertionResults":          getAssertionResults,
+			"getAssertionType":             getAssertionType,
+			"hasConversationAssertions":    hasConversationAssertions,
+			"conversationAssertionsPassed": conversationAssertionsPassed,
+			"renderConversationAssertions": renderConversationAssertions,
+			"getConversationAssertionResults": func(r engine.RunResult) []assertions.ConversationValidationResult {
+				return r.ConversationAssertions.Results
+			},
+			"renderToolResultMediaBadges": renderToolResultMediaBadges,
+			"isAgentTool":                 isAgentTool,
+			"isWorkflowTool":              isWorkflowTool,
+			"hasA2AAgents":                hasA2AAgents,
+			"renderA2AAgentCards":         renderA2AAgentCards,
+			"consentStatus":               consentStatus,
+		}).Parse(reportTemplate))
+	})
+	return reportTmpl
+}
+
+func generateHTML(data *HTMLReportData) (string, error) {
 	var buf strings.Builder
-	if err := tmpl.Execute(&buf, data); err != nil {
+	if err := getReportTemplate().Execute(&buf, data); err != nil {
 		return "", err
 	}
 

--- a/tools/arena/render/html_test.go
+++ b/tools/arena/render/html_test.go
@@ -380,7 +380,7 @@ func TestGenerateHTML_ValidData(t *testing.T) {
 		Matrix:    [][]MatrixCell{},
 	}
 
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf(testFailedGenerateHTML, err)
 	}
@@ -423,7 +423,7 @@ func TestGenerateHTML_TemplateFunctions(t *testing.T) {
 		},
 	}
 
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf(testFailedGenerateHTML, err)
 	}
@@ -784,7 +784,7 @@ func TestGetValidationsForTurn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Get the actual function from the template generation
 			data := HTMLReportData{}
-			html, _ := generateHTML(data)
+			html, _ := generateHTML(&data)
 			_ = html // Ensure the function is created
 
 			// Call our test implementation
@@ -1155,7 +1155,7 @@ func TestGenerateHTML_WithMessageCostInfo(t *testing.T) {
 
 	// This should not panic or error - specifically tests that the template
 	// can access $msg.CostInfo.TotalCost (not TotalCostUSD)
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf("Failed to generate HTML with message CostInfo: %v", err)
 	}
@@ -1258,7 +1258,7 @@ func TestGenerateHTML_UserMessageWithCostInfo(t *testing.T) {
 	// Use prepareReportData to properly populate ScenarioGroups
 	data := prepareReportData([]engine.RunResult{result})
 
-	html, err := generateHTML(data)
+	html, err := generateHTML(&data)
 	if err != nil {
 		t.Fatalf(testFailedGenerateHTML, err)
 	}
@@ -1398,7 +1398,7 @@ func TestGenerateHTML_MessageCostInfoEdgeCases(t *testing.T) {
 				Matrix:    [][]MatrixCell{},
 			}
 
-			html, err := generateHTML(data)
+			html, err := generateHTML(&data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("generateHTML() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1450,7 +1450,7 @@ func TestHasValidators_WithMessageValidations(t *testing.T) {
 			result.Messages = []types.Message{tt.message}
 
 			data := prepareReportData([]engine.RunResult{result})
-			html, err := generateHTML(data)
+			html, err := generateHTML(&data)
 			if err != nil {
 				t.Fatalf("generateHTML() error = %v", err)
 			}

--- a/tools/schema-gen/generators/arena.go
+++ b/tools/schema-gen/generators/arena.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	schemaBaseURL            = "https://promptkit.altairalabs.ai/schemas/v1alpha1"
+	schemaBaseURL            = config.SchemaBaseURL
 	defaultTemperature       = 0.7
 	defaultMaxTokens         = 1000
 	defaultProviderMaxTokens = 2000


### PR DESCRIPTION
## Summary
- **L49**: Fix `Register()` race in tool registry — move `SaveTool` and `descriptor.Namespace` mutation inside mutex lock
- **L44**: Remove unreachable `convertFragmentRefs` dead code and its test
- **L46**: Use `config.SchemaBaseURL` constant instead of duplicated string in schema-gen
- **L9**: Cache parsed HTML report template with `sync.Once` instead of re-parsing on every `generateHTML` call; pass `*HTMLReportData` by pointer
- **L32**: Document intentional error suppression in skills preload

### Also verified as already fixed
- L11 (regex caching) — already cached in `WhenEvaluator`
- L13 (audio I/O errors) — already checks `io.EOF` specifically
- L37 (closed check) — already checks `c.closed`
- L39 (goroutine leak) — already uses `select` with `ctx.Done()`
- L45 (regex recompilation) — already pre-compiled at package level
- L48 (deep copy) — `cloneToolResult` already deep-copies Parts
- L52 (misleading name) — already renamed to `shallowCopyMap`

## Test plan
- [x] All pre-commit checks pass (lint, build, tests, coverage)
- [x] `golangci-lint run --new-from-rev=HEAD` reports 0 issues
- [x] Arena render tests pass with cached template
- [x] Runtime tools registry tests pass with reordered locking