### PR TITLE
test: add coverage for code review LOW findings

### DIFF
--- a/tools/arena/engine/conversation_executor_test.go
+++ b/tools/arena/engine/conversation_executor_test.go
@@ -14,6 +14,7 @@ import (
 	arenaassertions "github.com/AltairaLabs/PromptKit/tools/arena/assertions"
 	"github.com/AltairaLabs/PromptKit/tools/arena/selfplay"
 	"github.com/AltairaLabs/PromptKit/tools/arena/turnexecutors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -352,6 +353,25 @@ func createTestPromptRegistry(t *testing.T) *prompt.Registry {
 	registry := prompt.NewRegistryWithRepository(memRepo)
 
 	return registry
+}
+
+func TestExecuteConversation_NilScenario(t *testing.T) {
+	executor := NewDefaultConversationExecutor(
+		&MockTurnExecutor{},
+		nil,
+		nil,
+		createTestPromptRegistry(t),
+		nil,
+	)
+
+	req := ConversationRequest{
+		ConversationID: "conv-nil",
+		Scenario:       nil, // nil scenario should not panic
+	}
+
+	result := executor.ExecuteConversation(context.Background(), req)
+	assert.True(t, result.Failed)
+	assert.Contains(t, result.Error, "scenario is nil")
 }
 
 func TestExecuteConversation_BasicScriptedScenario(t *testing.T) {

--- a/tools/arena/statestore/store_unit_test.go
+++ b/tools/arena/statestore/store_unit_test.go
@@ -487,3 +487,44 @@ func TestCloneHelpers(t *testing.T) {
 		}
 	})
 }
+
+func TestExtractValidations_TurnIndexCountsUserMessages(t *testing.T) {
+	store := NewArenaStateStore()
+
+	// Simulate a conversation with tool-call messages breaking strict alternation:
+	// user(0), assistant(1), tool(2), assistant(3), user(4), assistant(5)
+	state := &ArenaConversationState{
+		ConversationState: runtimestore.ConversationState{Messages: []types.Message{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi", Validations: []types.ValidationResult{
+				{ValidatorType: "v1", Passed: true},
+			}},
+			{Role: "tool", Content: "tool result"},
+			{Role: "assistant", Content: "here you go", Validations: []types.ValidationResult{
+				{ValidatorType: "v2", Passed: false},
+			}},
+			{Role: "user", Content: "thanks"},
+			{Role: "assistant", Content: "bye", Validations: []types.ValidationResult{
+				{ValidatorType: "v3", Passed: true},
+			}},
+		}},
+	}
+
+	validations := store.extractValidations(state)
+	if len(validations) != 3 {
+		t.Fatalf("expected 3 validations, got %d", len(validations))
+	}
+
+	// After first user message (userTurns=1), assistant at index 1 should have turnIndex=1
+	if validations[0].TurnIndex != 1 {
+		t.Errorf("expected turnIndex 1 for first validation, got %d", validations[0].TurnIndex)
+	}
+	// Tool message doesn't increment userTurns; assistant at index 3 still has turnIndex=1
+	if validations[1].TurnIndex != 1 {
+		t.Errorf("expected turnIndex 1 for second validation (after tool msg), got %d", validations[1].TurnIndex)
+	}
+	// After second user message (userTurns=2), assistant at index 5 should have turnIndex=2
+	if validations[2].TurnIndex != 2 {
+		t.Errorf("expected turnIndex 2 for third validation, got %d", validations[2].TurnIndex)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `TestExecuteConversation_NilScenario` covering the nil-scenario guard in `conversation_executor.go`
- Add `TestExtractValidations_TurnIndexCountsUserMessages` covering the user-message-based turn indexing in `telemetry.go`

These tests were intended for PR #667 but the push landed after auto-merge completed.

## Test plan
- [x] Both tests pass locally
- [x] Pre-commit hooks pass