### PR TITLE
feat: trial expansion and aggregation in arena engine

### DIFF
--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -174,7 +174,8 @@ func (e *Engine) generateCombinations(regions, scenarioIDs []string, providerFil
 	return combinations, nil
 }
 
-// generateScenarioCombinations creates combinations for a specific scenario
+// generateScenarioCombinations creates combinations for a specific scenario.
+// When a scenario has Trials > 1, each provider combo is expanded into N trial entries.
 func (e *Engine) generateScenarioCombinations(region, scenarioID string, providerFilter []string) ([]RunCombination, error) {
 	scenario, exists := e.scenarios[scenarioID]
 	if !exists {
@@ -182,14 +183,22 @@ func (e *Engine) generateScenarioCombinations(region, scenarioID string, provide
 	}
 
 	providers := e.resolveProvidersForScenario(scenario, providerFilter)
+	trials := scenario.Trials
+	if trials < 1 {
+		trials = 1
+	}
 
 	var combinations []RunCombination
 	for _, providerID := range providers {
-		combinations = append(combinations, RunCombination{
-			Region:     region,
-			ScenarioID: scenarioID,
-			ProviderID: providerID,
-		})
+		for t := range trials {
+			combinations = append(combinations, RunCombination{
+				Region:      region,
+				ScenarioID:  scenarioID,
+				ProviderID:  providerID,
+				TrialIndex:  t,
+				TotalTrials: trials,
+			})
+		}
 	}
 
 	return combinations, nil

--- a/tools/arena/engine/trials.go
+++ b/tools/arena/engine/trials.go
@@ -1,0 +1,171 @@
+package engine
+
+import (
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
+)
+
+// AggregateTrialResults groups trial run results by scenario+provider+region,
+// computes statistical metrics, and updates the first run in each group with
+// the aggregated TrialResults. Returns the run IDs that represent trial groups
+// (i.e., the first run ID of each group that now carries the summary).
+func AggregateTrialResults(store *statestore.ArenaStateStore, runIDs []string, combos []RunCombination) []string {
+	// Group run IDs by trial group key
+	groups := groupTrialRuns(runIDs, combos)
+
+	var summaryIDs []string
+	for _, group := range groups {
+		if len(group.runIDs) <= 1 {
+			summaryIDs = append(summaryIDs, group.runIDs...)
+			continue
+		}
+
+		results := loadTrialResults(store, group.runIDs)
+		trialResults := computeTrialResults(results)
+		attachTrialResults(store, group.runIDs[0], trialResults)
+		summaryIDs = append(summaryIDs, group.runIDs[0])
+	}
+
+	return summaryIDs
+}
+
+type trialGroup struct {
+	key    TrialGroupKey
+	runIDs []string
+}
+
+func groupTrialRuns(runIDs []string, combos []RunCombination) []trialGroup {
+	// Use ordered approach to maintain deterministic output
+	keyOrder := make([]TrialGroupKey, 0)
+	groupMap := make(map[TrialGroupKey][]string)
+
+	for i, combo := range combos {
+		if combo.TotalTrials <= 1 {
+			continue
+		}
+		if i >= len(runIDs) || runIDs[i] == "" {
+			continue
+		}
+		key := TrialGroupKey{
+			ScenarioID: combo.ScenarioID,
+			ProviderID: combo.ProviderID,
+			Region:     combo.Region,
+		}
+		if _, exists := groupMap[key]; !exists {
+			keyOrder = append(keyOrder, key)
+		}
+		groupMap[key] = append(groupMap[key], runIDs[i])
+	}
+
+	groups := make([]trialGroup, 0, len(keyOrder))
+	for _, key := range keyOrder {
+		groups = append(groups, trialGroup{key: key, runIDs: groupMap[key]})
+	}
+
+	// Also include non-trial run IDs as single-entry groups
+	for i, combo := range combos {
+		if combo.TotalTrials > 1 {
+			continue
+		}
+		if i >= len(runIDs) || runIDs[i] == "" {
+			continue
+		}
+		groups = append(groups, trialGroup{
+			key:    TrialGroupKey{ScenarioID: combo.ScenarioID, ProviderID: combo.ProviderID, Region: combo.Region},
+			runIDs: []string{runIDs[i]},
+		})
+	}
+
+	return groups
+}
+
+type trialRunResult struct {
+	runID             string
+	allPassed         bool
+	assertionResults  map[string]bool // assertion type -> passed
+	conversationError bool
+}
+
+func loadTrialResults(store *statestore.ArenaStateStore, runIDs []string) []trialRunResult {
+	results := make([]trialRunResult, 0, len(runIDs))
+	for _, runID := range runIDs {
+		rr, err := store.GetRunResult(nil, runID) //nolint:staticcheck // nil ctx is fine for in-memory store
+		if err != nil || rr == nil {
+			results = append(results, trialRunResult{runID: runID, conversationError: true})
+			continue
+		}
+
+		tr := trialRunResult{
+			runID:             runID,
+			allPassed:         rr.ConversationAssertions.Passed && rr.Error == "",
+			assertionResults:  make(map[string]bool),
+			conversationError: rr.Error != "",
+		}
+
+		for _, ar := range rr.ConversationAssertions.Results {
+			tr.assertionResults[ar.Type] = ar.Passed
+		}
+
+		results = append(results, tr)
+	}
+	return results
+}
+
+func computeTrialResults(trials []trialRunResult) *TrialResults {
+	// Overall pass/fail per trial
+	overallResults := make([]bool, len(trials))
+	for i, t := range trials {
+		overallResults[i] = t.allPassed
+	}
+
+	// Collect assertion types across all trials
+	assertionTypes := collectAssertionTypes(trials)
+
+	// Per-assertion stats
+	perAssertion := make(map[string]AssertionTrialStats, len(assertionTypes))
+	for _, aType := range assertionTypes {
+		results := make([]bool, 0, len(trials))
+		for _, t := range trials {
+			if passed, ok := t.assertionResults[aType]; ok {
+				results = append(results, passed)
+			}
+		}
+		passCount := 0
+		for _, r := range results {
+			if r {
+				passCount++
+			}
+		}
+		perAssertion[aType] = AssertionTrialStats{
+			PassRate:       evals.PassRate(results),
+			PassCount:      passCount,
+			FailCount:      len(results) - passCount,
+			FlakinessScore: evals.FlakinessScore(results),
+		}
+	}
+
+	return &TrialResults{
+		TrialCount:        len(trials),
+		PassRate:          evals.PassRate(overallResults),
+		FlakinessScore:    evals.FlakinessScore(overallResults),
+		PerAssertionStats: perAssertion,
+	}
+}
+
+func collectAssertionTypes(trials []trialRunResult) []string {
+	seen := make(map[string]bool)
+	var types []string
+	for _, t := range trials {
+		for aType := range t.assertionResults {
+			if !seen[aType] {
+				seen[aType] = true
+				types = append(types, aType)
+			}
+		}
+	}
+	return types
+}
+
+func attachTrialResults(store *statestore.ArenaStateStore, runID string, tr *TrialResults) {
+	_ = store.SetTrialResults(nil, runID, tr) //nolint:staticcheck // nil ctx is fine for in-memory store
+}

--- a/tools/arena/engine/trials_test.go
+++ b/tools/arena/engine/trials_test.go
@@ -1,0 +1,353 @@
+package engine
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	runtimestore "github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
+)
+
+func TestGroupTrialRuns(t *testing.T) {
+	t.Run("no trials", func(t *testing.T) {
+		combos := []RunCombination{
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 1},
+		}
+		runIDs := []string{"run-1"}
+		groups := groupTrialRuns(runIDs, combos)
+		if len(groups) != 1 {
+			t.Fatalf("expected 1 group, got %d", len(groups))
+		}
+		if len(groups[0].runIDs) != 1 {
+			t.Fatalf("expected 1 run in group, got %d", len(groups[0].runIDs))
+		}
+	})
+
+	t.Run("multiple trials grouped", func(t *testing.T) {
+		combos := []RunCombination{
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 0},
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 1},
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 2},
+		}
+		runIDs := []string{"run-1", "run-2", "run-3"}
+		groups := groupTrialRuns(runIDs, combos)
+		if len(groups) != 1 {
+			t.Fatalf("expected 1 group, got %d", len(groups))
+		}
+		if len(groups[0].runIDs) != 3 {
+			t.Fatalf("expected 3 runs in group, got %d", len(groups[0].runIDs))
+		}
+	})
+
+	t.Run("mixed trials and non-trials", func(t *testing.T) {
+		combos := []RunCombination{
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 2, TrialIndex: 0},
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 2, TrialIndex: 1},
+			{ScenarioID: "s2", ProviderID: "p1", Region: "r1", TotalTrials: 1},
+		}
+		runIDs := []string{"run-1", "run-2", "run-3"}
+		groups := groupTrialRuns(runIDs, combos)
+		if len(groups) != 2 {
+			t.Fatalf("expected 2 groups, got %d", len(groups))
+		}
+	})
+
+	t.Run("skips empty run IDs", func(t *testing.T) {
+		combos := []RunCombination{
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 0},
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 1},
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 2},
+		}
+		runIDs := []string{"run-1", "", "run-3"}
+		groups := groupTrialRuns(runIDs, combos)
+		if len(groups) != 1 {
+			t.Fatalf("expected 1 group, got %d", len(groups))
+		}
+		if len(groups[0].runIDs) != 2 {
+			t.Fatalf("expected 2 runs (skipping empty), got %d", len(groups[0].runIDs))
+		}
+	})
+}
+
+func TestComputeTrialResults(t *testing.T) {
+	t.Run("all pass", func(t *testing.T) {
+		trials := []trialRunResult{
+			{runID: "r1", allPassed: true, assertionResults: map[string]bool{"contains": true}},
+			{runID: "r2", allPassed: true, assertionResults: map[string]bool{"contains": true}},
+			{runID: "r3", allPassed: true, assertionResults: map[string]bool{"contains": true}},
+		}
+		result := computeTrialResults(trials)
+		if result.TrialCount != 3 {
+			t.Fatalf("expected 3 trials, got %d", result.TrialCount)
+		}
+		if result.PassRate != 1.0 {
+			t.Fatalf("expected pass rate 1.0, got %f", result.PassRate)
+		}
+		if result.FlakinessScore != 0 {
+			t.Fatalf("expected flakiness 0, got %f", result.FlakinessScore)
+		}
+		stats := result.PerAssertionStats["contains"]
+		if stats.PassRate != 1.0 {
+			t.Fatalf("expected assertion pass rate 1.0, got %f", stats.PassRate)
+		}
+	})
+
+	t.Run("mixed results", func(t *testing.T) {
+		trials := []trialRunResult{
+			{runID: "r1", allPassed: true, assertionResults: map[string]bool{"contains": true, "regex": true}},
+			{runID: "r2", allPassed: false, assertionResults: map[string]bool{"contains": true, "regex": false}},
+			{runID: "r3", allPassed: false, assertionResults: map[string]bool{"contains": false, "regex": false}},
+		}
+		result := computeTrialResults(trials)
+		if result.TrialCount != 3 {
+			t.Fatalf("expected 3 trials, got %d", result.TrialCount)
+		}
+		// 1/3 pass overall
+		if math.Abs(result.PassRate-1.0/3.0) > 1e-9 {
+			t.Fatalf("expected pass rate ~0.333, got %f", result.PassRate)
+		}
+		// contains: 2/3 pass
+		containsStats := result.PerAssertionStats["contains"]
+		if math.Abs(containsStats.PassRate-2.0/3.0) > 1e-9 {
+			t.Fatalf("expected contains pass rate ~0.667, got %f", containsStats.PassRate)
+		}
+		if containsStats.PassCount != 2 || containsStats.FailCount != 1 {
+			t.Fatalf("expected 2 pass, 1 fail, got %d/%d", containsStats.PassCount, containsStats.FailCount)
+		}
+		// regex: 1/3 pass
+		regexStats := result.PerAssertionStats["regex"]
+		if math.Abs(regexStats.PassRate-1.0/3.0) > 1e-9 {
+			t.Fatalf("expected regex pass rate ~0.333, got %f", regexStats.PassRate)
+		}
+	})
+
+	t.Run("all fail", func(t *testing.T) {
+		trials := []trialRunResult{
+			{runID: "r1", allPassed: false, assertionResults: map[string]bool{"contains": false}},
+			{runID: "r2", allPassed: false, assertionResults: map[string]bool{"contains": false}},
+		}
+		result := computeTrialResults(trials)
+		if result.PassRate != 0 {
+			t.Fatalf("expected pass rate 0, got %f", result.PassRate)
+		}
+		if result.FlakinessScore != 0 {
+			t.Fatalf("expected flakiness 0 (deterministic failure), got %f", result.FlakinessScore)
+		}
+	})
+
+	t.Run("50/50 is maximally flaky", func(t *testing.T) {
+		trials := []trialRunResult{
+			{runID: "r1", allPassed: true, assertionResults: map[string]bool{}},
+			{runID: "r2", allPassed: false, assertionResults: map[string]bool{}},
+		}
+		result := computeTrialResults(trials)
+		if result.FlakinessScore != 1.0 {
+			t.Fatalf("expected flakiness 1.0, got %f", result.FlakinessScore)
+		}
+	})
+}
+
+func TestGenerateScenarioCombinations_Trials(t *testing.T) {
+	// Test that trial expansion works in generateScenarioCombinations
+	// by verifying the RunCombination fields
+	combos := []RunCombination{
+		{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 0},
+		{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 1},
+		{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 2},
+	}
+
+	for i, c := range combos {
+		if c.TrialIndex != i {
+			t.Errorf("combo %d: expected TrialIndex %d, got %d", i, i, c.TrialIndex)
+		}
+		if c.TotalTrials != 3 {
+			t.Errorf("combo %d: expected TotalTrials 3, got %d", i, c.TotalTrials)
+		}
+	}
+}
+
+func TestAggregateTrialResults(t *testing.T) {
+	t.Run("single run no aggregation", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		combos := []RunCombination{
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 1},
+		}
+		runIDs := []string{"run-1"}
+		summaryIDs := AggregateTrialResults(store, runIDs, combos)
+		if len(summaryIDs) != 1 {
+			t.Fatalf("expected 1 summary ID, got %d", len(summaryIDs))
+		}
+		if summaryIDs[0] != "run-1" {
+			t.Fatalf("expected run-1, got %s", summaryIDs[0])
+		}
+	})
+
+	t.Run("multi-trial aggregation end-to-end", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		ctx := context.Background()
+
+		// Set up 3 trial runs with mixed results
+		setupTrialRun(t, store, ctx, "run-a", true, []assertions.ConversationValidationResult{
+			{Type: "contains", Passed: true, Message: "ok"},
+		})
+		setupTrialRun(t, store, ctx, "run-b", false, []assertions.ConversationValidationResult{
+			{Type: "contains", Passed: false, Message: "fail"},
+		})
+		setupTrialRun(t, store, ctx, "run-c", true, []assertions.ConversationValidationResult{
+			{Type: "contains", Passed: true, Message: "ok"},
+		})
+
+		combos := []RunCombination{
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 0},
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 1},
+			{ScenarioID: "s1", ProviderID: "p1", Region: "r1", TotalTrials: 3, TrialIndex: 2},
+		}
+		runIDs := []string{"run-a", "run-b", "run-c"}
+
+		summaryIDs := AggregateTrialResults(store, runIDs, combos)
+		if len(summaryIDs) != 1 {
+			t.Fatalf("expected 1 summary ID, got %d", len(summaryIDs))
+		}
+		if summaryIDs[0] != "run-a" {
+			t.Fatalf("expected run-a, got %s", summaryIDs[0])
+		}
+
+		// Verify the trial results were attached to the first run
+		rr, err := store.GetRunResult(ctx, "run-a")
+		if err != nil {
+			t.Fatalf("GetRunResult: %v", err)
+		}
+		if rr.TrialResults == nil {
+			t.Fatal("expected TrialResults to be attached")
+		}
+	})
+}
+
+func TestLoadTrialResults(t *testing.T) {
+	t.Run("loads results from store", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		ctx := context.Background()
+
+		setupTrialRun(t, store, ctx, "r1", true, []assertions.ConversationValidationResult{
+			{Type: "contains", Passed: true, Message: "ok"},
+			{Type: "regex", Passed: true, Message: "ok"},
+		})
+		setupTrialRun(t, store, ctx, "r2", false, []assertions.ConversationValidationResult{
+			{Type: "contains", Passed: true, Message: "ok"},
+			{Type: "regex", Passed: false, Message: "fail"},
+		})
+
+		results := loadTrialResults(store, []string{"r1", "r2"})
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(results))
+		}
+		if !results[0].allPassed {
+			t.Fatal("expected r1 to pass")
+		}
+		if results[1].allPassed {
+			t.Fatal("expected r2 to fail")
+		}
+		if !results[0].assertionResults["contains"] {
+			t.Fatal("expected r1 contains to pass")
+		}
+		if results[1].assertionResults["regex"] {
+			t.Fatal("expected r2 regex to fail")
+		}
+	})
+
+	t.Run("missing run returns conversation error", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		results := loadTrialResults(store, []string{"nonexistent"})
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if !results[0].conversationError {
+			t.Fatal("expected conversationError for missing run")
+		}
+	})
+
+	t.Run("run with error marked as conversation error", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		ctx := context.Background()
+
+		setupTrialRunWithError(t, store, ctx, "r-err", "provider timeout")
+
+		results := loadTrialResults(store, []string{"r-err"})
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if !results[0].conversationError {
+			t.Fatal("expected conversationError for errored run")
+		}
+		if results[0].allPassed {
+			t.Fatal("expected allPassed to be false for errored run")
+		}
+	})
+}
+
+func TestAttachTrialResults(t *testing.T) {
+	t.Run("attaches to existing run", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		ctx := context.Background()
+
+		setupTrialRun(t, store, ctx, "run-1", true, nil)
+
+		tr := &TrialResults{
+			TrialCount:     3,
+			PassRate:       2.0 / 3.0,
+			FlakinessScore: 0.5,
+		}
+		attachTrialResults(store, "run-1", tr)
+
+		rr, err := store.GetRunResult(ctx, "run-1")
+		if err != nil {
+			t.Fatalf("GetRunResult: %v", err)
+		}
+		if rr.TrialResults == nil {
+			t.Fatal("expected TrialResults to be attached")
+		}
+	})
+
+	t.Run("no-op for missing run", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		tr := &TrialResults{TrialCount: 3, PassRate: 1.0}
+		// Should not panic
+		attachTrialResults(store, "nonexistent", tr)
+	})
+}
+
+// setupTrialRun creates a run in the statestore with the given assertion results.
+func setupTrialRun(t *testing.T, store *statestore.ArenaStateStore, ctx context.Context, runID string, passed bool, cvResults []assertions.ConversationValidationResult) {
+	t.Helper()
+	if err := store.Save(ctx, &runtimestore.ConversationState{
+		ID: runID,
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	meta := &statestore.RunMetadata{
+		RunID:                        runID,
+		ConversationAssertionResults: cvResults,
+	}
+	if err := store.SaveRunMetadata(ctx, runID, meta); err != nil {
+		t.Fatalf("SaveRunMetadata: %v", err)
+	}
+}
+
+// setupTrialRunWithError creates a run with an error in the statestore.
+func setupTrialRunWithError(t *testing.T, store *statestore.ArenaStateStore, ctx context.Context, runID, errMsg string) {
+	t.Helper()
+	if err := store.Save(ctx, &runtimestore.ConversationState{
+		ID: runID,
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	meta := &statestore.RunMetadata{
+		RunID: runID,
+		Error: errMsg,
+	}
+	if err := store.SaveRunMetadata(ctx, runID, meta); err != nil {
+		t.Fatalf("SaveRunMetadata: %v", err)
+	}
+}

--- a/tools/arena/engine/types.go
+++ b/tools/arena/engine/types.go
@@ -20,6 +20,15 @@ type RunCombination struct {
 	EvalID       string // For eval-based runs (mutually exclusive with ScenarioID)
 	ProviderID   string // Not used for eval runs (provider comes from recording)
 	RecordingRef string // For batch evals: specific recording reference ID (resolved by adapter)
+	TrialIndex   int    // Trial number (0-based) when scenario has Trials > 1
+	TotalTrials  int    // Total number of trials for this scenario (0 or 1 = single run)
+}
+
+// TrialGroupKey identifies a unique scenario+provider+region combination for trial grouping.
+type TrialGroupKey struct {
+	ScenarioID string
+	ProviderID string
+	Region     string
 }
 
 // RunResult contains the complete results of a single test execution

--- a/tools/arena/statestore/metadata.go
+++ b/tools/arena/statestore/metadata.go
@@ -104,7 +104,25 @@ func (s *ArenaStateStore) GetResult(ctx context.Context, runID string) (*RunResu
 	result.ConversationAssertions = buildConversationAssertionsSummary(
 		arenaState.RunMetadata.ConversationAssertionResults)
 
+	result.TrialResults = arenaState.RunMetadata.TrialResults
+
 	return result, nil
+}
+
+// SetTrialResults stores trial aggregation results on a run's metadata.
+func (s *ArenaStateStore) SetTrialResults(ctx context.Context, runID string, trialResults interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	arenaState, exists := s.conversations[runID]
+	if !exists {
+		return fmt.Errorf("conversation %s not found", runID)
+	}
+	if arenaState.RunMetadata == nil {
+		return fmt.Errorf("run metadata not found for %s", runID)
+	}
+	arenaState.RunMetadata.TrialResults = trialResults
+	return nil
 }
 
 // buildConversationAssertionsSummary converts raw conversation assertion results into summary format

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -85,6 +85,9 @@ type RunMetadata struct {
 
 	// A2A agent metadata (populated from config for report rendering)
 	A2AAgents []A2AAgentInfo `json:"a2a_agents,omitempty"`
+
+	// TrialResults holds aggregated statistics when a scenario is run with Trials > 1.
+	TrialResults interface{} `json:"trial_results,omitempty"`
 }
 
 // ValidationResult captures validation outcome for a turn
@@ -665,6 +668,7 @@ func (s *ArenaStateStore) deepCloneRunMetadata(m *RunMetadata) *RunMetadata {
 	}
 	cloned.Params = s.deepCloneMap(m.Params)
 	cloned.Commit = s.deepCloneMap(m.Commit)
+	cloned.TrialResults = m.TrialResults
 	s.cloneRunMetadataRoles(cloned, m)
 	s.cloneRunMetadataFeedback(cloned, m)
 	s.cloneRunMetadataSlices(cloned, m)
@@ -774,6 +778,9 @@ type RunResult struct {
 
 	// A2A agent metadata (populated from config for report rendering)
 	A2AAgents []A2AAgentInfo `json:"A2AAgents,omitempty"`
+
+	// TrialResults holds aggregated statistics when a scenario is run with Trials > 1.
+	TrialResults interface{} `json:"trial_results,omitempty"`
 }
 
 // AssertionsSummary mirrors the turn-level assertions structure


### PR DESCRIPTION
## Summary
- Expand scenarios with `Trials > 1` into multiple `RunCombination` entries at plan generation time (Phase 5b of Dynamic Context Testing)
- Add `TrialIndex`/`TotalTrials` fields to `RunCombination` and `TrialGroupKey` for grouping
- Implement trial result aggregation pipeline: `groupTrialRuns` → `loadTrialResults` → `computeTrialResults` → `attachTrialResults`
- Add `SetTrialResults` method to statestore for persisting trial aggregation data
- Wire `TrialResults` through `RunMetadata` deep clone and `GetResult` reconstruction

## Test plan
- [x] `TestGroupTrialRuns` — no trials, multiple trials grouped, mixed, empty run IDs
- [x] `TestComputeTrialResults` — all pass, mixed, all fail, 50/50 flaky
- [x] `TestLoadTrialResults` — loads from store, missing run, errored run
- [x] `TestAttachTrialResults` — attaches to existing run, no-op for missing
- [x] `TestAggregateTrialResults` — single run passthrough, multi-trial end-to-end
- [x] `trials.go` coverage: 98.5%