### PR TITLE
feat: Phase 6 behavioral testing — perturbations, outcome equivalence, directional assertions

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -979,6 +979,11 @@ type TurnDefinition struct {
 	// Keys are tool names, values are "grant", "deny", or "timeout".
 	ConsentOverrides map[string]string `json:"consent_overrides,omitempty" yaml:"consent_overrides,omitempty"`
 
+	// Perturbations define variable substitutions for behavioral testing.
+	// Each key is a placeholder name (e.g., "city") and the value is a list of variants.
+	// The engine expands each variant into a separate trial, substituting {key} in Content.
+	Perturbations map[string][]string `json:"perturbations,omitempty" yaml:"perturbations,omitempty"`
+
 	// Turn-level assertions (for testing only)
 	Assertions []AssertionConfig `json:"assertions,omitempty" yaml:"assertions,omitempty"`
 }

--- a/runtime/evals/handlers/behavioral_helpers.go
+++ b/runtime/evals/handlers/behavioral_helpers.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// compareToolSets checks if the actual tool calls match the expected set and returns an EvalResult.
+func compareToolSets(
+	evalType string,
+	evalCtx *evals.EvalContext,
+	expectedTools []string,
+	expectedLabel string,
+) *evals.EvalResult {
+	actual := uniqueToolNames(evalCtx.ToolCalls)
+	expected := toSortedSet(expectedTools)
+
+	if setsEqual(actual, expected) {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      true,
+			Explanation: fmt.Sprintf("tool calls match %s: [%s]", expectedLabel, strings.Join(expected, ", ")),
+			Details:     map[string]any{"actual": actual, expectedLabel: expected},
+		}
+	}
+
+	return &evals.EvalResult{
+		Type:   evalType,
+		Passed: false,
+		Explanation: fmt.Sprintf(
+			"tool calls differ from %s: got [%s], %s [%s]",
+			expectedLabel, strings.Join(actual, ", "), expectedLabel, strings.Join(expected, ", "),
+		),
+		Details: map[string]any{"actual": actual, expectedLabel: expected},
+	}
+}
+
+// compareWorkflowState checks if the actual workflow state matches the expected value.
+func compareWorkflowState(
+	evalType string,
+	evalCtx *evals.EvalContext,
+	expectedState string,
+	expectedLabel string,
+) *evals.EvalResult {
+	raw, ok := evalCtx.Extras["workflow_state"]
+	if !ok {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      false,
+			Explanation: "workflow_state not found in eval context extras",
+		}
+	}
+
+	actualState := asString(raw)
+	if actualState == expectedState {
+		return &evals.EvalResult{
+			Type:        evalType,
+			Passed:      true,
+			Explanation: fmt.Sprintf("state matches %s: %q", expectedLabel, expectedState),
+			Details:     map[string]any{"actual": actualState, expectedLabel: expectedState},
+		}
+	}
+
+	return &evals.EvalResult{
+		Type:        evalType,
+		Passed:      false,
+		Explanation: fmt.Sprintf("state %q does not match %s %q", actualState, expectedLabel, expectedState),
+		Details:     map[string]any{"actual": actualState, expectedLabel: expectedState},
+	}
+}
+
+// uniqueToolNames extracts a sorted, deduplicated list of tool names from tool calls.
+func uniqueToolNames(calls []evals.ToolCallRecord) []string {
+	seen := make(map[string]struct{}, len(calls))
+	for _, tc := range calls {
+		seen[tc.ToolName] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// toSortedSet returns a sorted, deduplicated copy of the input slice.
+func toSortedSet(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		seen[item] = struct{}{}
+	}
+	result := make([]string, 0, len(seen))
+	for item := range seen {
+		result = append(result, item)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// setsEqual checks if two sorted string slices are identical.
+func setsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/runtime/evals/handlers/directional.go
+++ b/runtime/evals/handlers/directional.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// DirectionalHandler compares a run's output against a baseline expectation.
+// Used in behavioral testing (Phase 6) to verify perturbation-invariant behavior.
+// Params:
+//   - check (string, required): "same_tool_calls", "same_outcome", or "similar_content"
+//   - baseline_tools ([]string, optional): expected tool names for same_tool_calls
+//   - baseline_state (string, optional): expected workflow state for same_outcome
+//   - baseline_content (string, optional): expected content substring for similar_content
+//   - threshold (float64, optional): minimum overlap ratio for similar_content (default 0.5)
+type DirectionalHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *DirectionalHandler) Type() string { return "directional" }
+
+// Eval checks that the run's output matches the baseline for the given check type.
+func (h *DirectionalHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	check, _ := params["check"].(string)
+	if check == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "missing required param 'check'",
+		}, nil
+	}
+
+	switch check {
+	case "same_tool_calls":
+		return h.checkSameToolCalls(evalCtx, params)
+	case "same_outcome":
+		return h.checkSameOutcome(evalCtx, params)
+	case "similar_content":
+		return h.checkSimilarContent(evalCtx, params)
+	default:
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("unknown check %q; must be same_tool_calls, same_outcome, or similar_content", check),
+		}, nil
+	}
+}
+
+func (h *DirectionalHandler) checkSameToolCalls(
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	tools := extractStringSlice(params, "baseline_tools")
+	if len(tools) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no baseline_tools specified; skipping comparison",
+		}, nil
+	}
+	return compareToolSets(h.Type(), evalCtx, tools, "baseline"), nil
+}
+
+func (h *DirectionalHandler) checkSameOutcome(
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	state, _ := params["baseline_state"].(string)
+	if state == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no baseline_state specified; skipping comparison",
+		}, nil
+	}
+	return compareWorkflowState(h.Type(), evalCtx, state, "baseline"), nil
+}
+
+func (h *DirectionalHandler) checkSimilarContent(
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	baselineContent, _ := params["baseline_content"].(string)
+	if baselineContent == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no baseline_content specified; skipping comparison",
+		}, nil
+	}
+
+	threshold := 0.5
+	if t, ok := extractFloat64(params, "threshold"); ok {
+		threshold = t
+	}
+
+	actual := evalCtx.CurrentOutput
+	score := wordOverlap(actual, baselineContent)
+	passed := score >= threshold
+
+	result := &evals.EvalResult{
+		Type:   h.Type(),
+		Passed: passed,
+		Score:  &score,
+		Details: map[string]any{
+			"overlap_score": score,
+			"threshold":     threshold,
+		},
+	}
+
+	if passed {
+		result.Explanation = fmt.Sprintf("content similarity %.2f >= threshold %.2f", score, threshold)
+	} else {
+		result.Explanation = fmt.Sprintf("content similarity %.2f < threshold %.2f", score, threshold)
+	}
+
+	return result, nil
+}
+
+// wordOverlap computes the Jaccard similarity of word sets between two strings.
+func wordOverlap(a, b string) float64 {
+	wordsA := wordSet(a)
+	wordsB := wordSet(b)
+
+	if len(wordsA) == 0 && len(wordsB) == 0 {
+		return 1.0
+	}
+	if len(wordsA) == 0 || len(wordsB) == 0 {
+		return 0.0
+	}
+
+	intersection := 0
+	for w := range wordsA {
+		if wordsB[w] {
+			intersection++
+		}
+	}
+
+	union := len(wordsA)
+	for w := range wordsB {
+		if !wordsA[w] {
+			union++
+		}
+	}
+
+	if union == 0 {
+		return 0.0
+	}
+
+	return float64(intersection) / float64(union)
+}
+
+// wordSet splits a string into lowercase words and returns the unique set.
+func wordSet(s string) map[string]bool {
+	words := strings.Fields(strings.ToLower(s))
+	set := make(map[string]bool, len(words))
+	for _, w := range words {
+		set[w] = true
+	}
+	return set
+}

--- a/runtime/evals/handlers/directional_test.go
+++ b/runtime/evals/handlers/directional_test.go
@@ -1,0 +1,319 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestDirectional_Type(t *testing.T) {
+	h := &DirectionalHandler{}
+	if h.Type() != "directional" {
+		t.Errorf("expected type %q, got %q", "directional", h.Type())
+	}
+}
+
+func TestDirectional_MissingCheck(t *testing.T) {
+	h := &DirectionalHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when check is missing")
+	}
+}
+
+func TestDirectional_UnknownCheck(t *testing.T) {
+	h := &DirectionalHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
+		"check": "bogus",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail for unknown check")
+	}
+}
+
+func TestDirectional_SameToolCalls_Match(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []types.ToolCallRecord{
+			{ToolName: "search"},
+			{ToolName: "lookup"},
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":          "same_tool_calls",
+		"baseline_tools": []any{"lookup", "search"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestDirectional_SameToolCalls_Mismatch(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []types.ToolCallRecord{
+			{ToolName: "search"},
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":          "same_tool_calls",
+		"baseline_tools": []any{"search", "lookup"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when tool sets differ")
+	}
+}
+
+func TestDirectional_SameToolCalls_NoBaseline(t *testing.T) {
+	h := &DirectionalHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
+		"check": "same_tool_calls",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass when no baseline: %s", result.Explanation)
+	}
+}
+
+func TestDirectional_SameOutcome_Match(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{"workflow_state": "completed"},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":          "same_outcome",
+		"baseline_state": "completed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestDirectional_SameOutcome_Mismatch(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{"workflow_state": "pending"},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":          "same_outcome",
+		"baseline_state": "completed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when states differ")
+	}
+}
+
+func TestDirectional_SameOutcome_NoBaseline(t *testing.T) {
+	h := &DirectionalHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
+		"check": "same_outcome",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass when no baseline: %s", result.Explanation)
+	}
+}
+
+func TestDirectional_SameOutcome_MissingExtras(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{Extras: map[string]any{}}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":          "same_outcome",
+		"baseline_state": "completed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when workflow_state missing")
+	}
+}
+
+func TestDirectional_SameOutcome_NilExtras(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":          "same_outcome",
+		"baseline_state": "completed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when extras is nil")
+	}
+}
+
+func TestDirectional_SimilarContent_AboveThreshold(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "The quick brown fox jumps over the lazy dog",
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":            "similar_content",
+		"baseline_content": "The quick brown fox leaps over the lazy dog",
+		"threshold":        0.5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass: %s", result.Explanation)
+	}
+	if result.Score == nil {
+		t.Fatal("expected score to be set")
+	}
+}
+
+func TestDirectional_SimilarContent_BelowThreshold(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "completely different output here",
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":            "similar_content",
+		"baseline_content": "The quick brown fox jumps over the lazy dog",
+		"threshold":        0.9,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when content is very different")
+	}
+}
+
+func TestDirectional_SimilarContent_NoBaseline(t *testing.T) {
+	h := &DirectionalHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
+		"check": "similar_content",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass when no baseline: %s", result.Explanation)
+	}
+}
+
+func TestDirectional_SimilarContent_DefaultThreshold(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "hello world foo bar baz",
+	}
+	// 3 shared words out of 7 union = ~0.43 < default 0.5
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":            "similar_content",
+		"baseline_content": "hello world qux quux corge",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With default threshold 0.5, low overlap should fail
+	if result.Passed {
+		t.Errorf("expected fail with default threshold: score=%v", result.Score)
+	}
+}
+
+func TestDirectional_SimilarContent_IdenticalContent(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "exact same content",
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":            "similar_content",
+		"baseline_content": "exact same content",
+		"threshold":        1.0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass for identical content: %s", result.Explanation)
+	}
+	if result.Score == nil || *result.Score != 1.0 {
+		t.Errorf("expected score 1.0, got %v", result.Score)
+	}
+}
+
+func TestDirectional_SimilarContent_EmptyBoth(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: ""}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":            "similar_content",
+		"baseline_content": " ", // whitespace-only becomes empty word set
+		"threshold":        0.5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Both empty word sets → score 1.0
+	if !result.Passed {
+		t.Errorf("expected pass for empty content: %s", result.Explanation)
+	}
+}
+
+func TestDirectional_SameToolCalls_StringSliceParam(t *testing.T) {
+	h := &DirectionalHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []types.ToolCallRecord{
+			{ToolName: "search"},
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"check":          "same_tool_calls",
+		"baseline_tools": []string{"search"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass with []string param: %s", result.Explanation)
+	}
+}
+
+func TestWordOverlap(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     string
+		expected float64
+	}{
+		{"identical", "hello world", "hello world", 1.0},
+		{"no overlap", "foo bar", "baz qux", 0.0},
+		{"partial", "a b c", "b c d", 0.5}, // intersection=2, union=4
+		{"both empty", "", "", 1.0},
+		{"one empty", "hello", "", 0.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := wordOverlap(tt.a, tt.b)
+			if score < tt.expected-0.01 || score > tt.expected+0.01 {
+				t.Errorf("wordOverlap(%q, %q) = %f, want %f", tt.a, tt.b, score, tt.expected)
+			}
+		})
+	}
+}

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -834,6 +834,10 @@ func TestRegisterInit(t *testing.T) {
 		"rest_eval_session",
 		"a2a_eval",
 		"a2a_eval_session",
+
+		// Behavioral testing handlers (Phase 6)
+		"outcome_equivalent",
+		"directional",
 	}
 
 	r := evals.NewEvalTypeRegistry()

--- a/runtime/evals/handlers/outcome_equivalent.go
+++ b/runtime/evals/handlers/outcome_equivalent.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// OutcomeEquivalentHandler checks that a single run's outcome matches an expected value.
+// Used in behavioral testing (Phase 6) to verify perturbation-invariant outcomes.
+// Params:
+//   - metric (string, required): "tool_calls", "final_state", or "content_hash"
+//   - expected_tools ([]string, optional): for tool_calls metric
+//   - expected_state (string, optional): for final_state metric
+//   - expected_content (string, optional): for content_hash metric
+type OutcomeEquivalentHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *OutcomeEquivalentHandler) Type() string { return "outcome_equivalent" }
+
+// Eval checks that the run's outcome matches the expected value for the given metric.
+func (h *OutcomeEquivalentHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	metric, _ := params["metric"].(string)
+	if metric == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: "missing required param 'metric'",
+		}, nil
+	}
+
+	switch metric {
+	case "tool_calls":
+		return h.evalToolCalls(evalCtx, params)
+	case "final_state":
+		return h.evalFinalState(evalCtx, params)
+	case "content_hash":
+		return h.evalContentHash(evalCtx, params)
+	default:
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      false,
+			Explanation: fmt.Sprintf("unknown metric %q; must be tool_calls, final_state, or content_hash", metric),
+		}, nil
+	}
+}
+
+func (h *OutcomeEquivalentHandler) evalToolCalls(
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	tools := extractStringSlice(params, "expected_tools")
+	if len(tools) == 0 {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no expected_tools specified; skipping single-run comparison",
+		}, nil
+	}
+	return compareToolSets(h.Type(), evalCtx, tools, "expected"), nil
+}
+
+func (h *OutcomeEquivalentHandler) evalFinalState(
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	state, _ := params["expected_state"].(string)
+	if state == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no expected_state specified; skipping single-run comparison",
+		}, nil
+	}
+	return compareWorkflowState(h.Type(), evalCtx, state, "expected"), nil
+}
+
+func (h *OutcomeEquivalentHandler) evalContentHash(
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	expectedContent, _ := params["expected_content"].(string)
+	if expectedContent == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "no expected_content specified; skipping single-run comparison",
+		}, nil
+	}
+
+	actual := evalCtx.CurrentOutput
+	if actual == expectedContent {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Passed:      true,
+			Explanation: "content matches expected output",
+			Details:     map[string]any{"length": len(actual)},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Passed:      false,
+		Explanation: "content does not match expected output",
+		Details:     map[string]any{"actual_length": len(actual), "expected_length": len(expectedContent)},
+	}, nil
+}

--- a/runtime/evals/handlers/outcome_equivalent_test.go
+++ b/runtime/evals/handlers/outcome_equivalent_test.go
@@ -1,0 +1,315 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestOutcomeEquivalent_Type(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	if h.Type() != "outcome_equivalent" {
+		t.Errorf("expected type %q, got %q", "outcome_equivalent", h.Type())
+	}
+}
+
+func TestOutcomeEquivalent_MissingMetric(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when metric is missing")
+	}
+	if result.Explanation != "missing required param 'metric'" {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_UnknownMetric(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	result, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
+		"metric": "unknown_metric",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail for unknown metric")
+	}
+	if result.Explanation == "" {
+		t.Error("expected non-empty explanation")
+	}
+}
+
+func TestOutcomeEquivalent_ToolCalls_Match(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []types.ToolCallRecord{
+			{ToolName: "search"},
+			{ToolName: "lookup"},
+			{ToolName: "search"}, // duplicate — should be deduplicated
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "tool_calls",
+		"expected_tools": []any{"lookup", "search"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass, got fail: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_ToolCalls_Mismatch(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []types.ToolCallRecord{
+			{ToolName: "search"},
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "tool_calls",
+		"expected_tools": []any{"search", "lookup"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when tool sets differ")
+	}
+}
+
+func TestOutcomeEquivalent_ToolCalls_NoExpected(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []types.ToolCallRecord{
+			{ToolName: "search"},
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric": "tool_calls",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass when no expected_tools: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_ToolCalls_OrderIndependent(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []types.ToolCallRecord{
+			{ToolName: "beta"},
+			{ToolName: "alpha"},
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "tool_calls",
+		"expected_tools": []any{"alpha", "beta"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass (order independent): %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_FinalState_Match(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_state": "completed",
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "final_state",
+		"expected_state": "completed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_FinalState_Mismatch(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_state": "pending",
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "final_state",
+		"expected_state": "completed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when states differ")
+	}
+}
+
+func TestOutcomeEquivalent_FinalState_NoExpected(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{
+			"workflow_state": "completed",
+		},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric": "final_state",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass when no expected_state: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_FinalState_MissingExtras(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		Extras: map[string]any{},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "final_state",
+		"expected_state": "completed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when workflow_state is missing from extras")
+	}
+}
+
+func TestOutcomeEquivalent_FinalState_NilExtras(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "final_state",
+		"expected_state": "completed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when extras is nil")
+	}
+}
+
+func TestOutcomeEquivalent_ContentHash_Match(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "Hello, world!",
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":           "content_hash",
+		"expected_content": "Hello, world!",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_ContentHash_Mismatch(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "Hello, world!",
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":           "content_hash",
+		"expected_content": "Goodbye, world!",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when content differs")
+	}
+}
+
+func TestOutcomeEquivalent_ContentHash_NoExpected(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "Hello, world!",
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric": "content_hash",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass when no expected_content: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_ToolCalls_EmptyActualAndExpected(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "tool_calls",
+		"expected_tools": []any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Empty expected_tools slice has length 0, so treated as "no expected"
+	if !result.Passed {
+		t.Errorf("expected pass for empty expected_tools: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_ToolCalls_StringSliceParam(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []types.ToolCallRecord{
+			{ToolName: "search"},
+		},
+	}
+	// Test with []string (extractStringSlice handles both []string and []any)
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":         "tool_calls",
+		"expected_tools": []string{"search"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("expected pass with []string param: %s", result.Explanation)
+	}
+}
+
+func TestOutcomeEquivalent_ContentHash_EmptyContent(t *testing.T) {
+	h := &OutcomeEquivalentHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "",
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"metric":           "content_hash",
+		"expected_content": "something",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected fail when actual is empty but expected is not")
+	}
+}

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -78,4 +78,8 @@ func init() {
 	evals.RegisterDefault(&RestEvalSessionHandler{})
 	evals.RegisterDefault(&A2AEvalHandler{})
 	evals.RegisterDefault(&A2AEvalSessionHandler{})
+
+	// Behavioral testing handlers (Phase 6)
+	evals.RegisterDefault(&OutcomeEquivalentHandler{})
+	evals.RegisterDefault(&DirectionalHandler{})
 }

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2136,6 +2136,15 @@
           },
           "type": "object"
         },
+        "perturbations": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
         "assertions": {
           "items": {
             "$ref": "#/$defs/AssertionConfig"

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -409,6 +409,15 @@
           },
           "type": "object"
         },
+        "perturbations": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
         "assertions": {
           "items": {
             "$ref": "#/$defs/AssertionConfig"

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -188,15 +188,26 @@ func (e *Engine) generateScenarioCombinations(region, scenarioID string, provide
 		trials = 1
 	}
 
+	// Compute perturbation variants (if any)
+	perturbationVariants := ExpandPerturbations(scenario)
+	perturbationCount := len(perturbationVariants)
+	if perturbationCount == 0 {
+		perturbationCount = 1 // No perturbations = single run
+	}
+
+	// Total trials = explicit trials × perturbation variants
+	totalTrials := trials * perturbationCount
+
 	var combinations []RunCombination
 	for _, providerID := range providers {
-		for t := range trials {
+		for t := range totalTrials {
 			combinations = append(combinations, RunCombination{
-				Region:      region,
-				ScenarioID:  scenarioID,
-				ProviderID:  providerID,
-				TrialIndex:  t,
-				TotalTrials: trials,
+				Region:            region,
+				ScenarioID:        scenarioID,
+				ProviderID:        providerID,
+				TrialIndex:        t,
+				TotalTrials:       totalTrials,
+				PerturbationIndex: perturbationIndexForTrial(t, perturbationCount),
 			})
 		}
 	}
@@ -385,10 +396,21 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 		return saveError(fmt.Sprintf("provider not found: %s", combo.ProviderID))
 	}
 
+	// Apply perturbation substitutions if this run has a perturbation variant
+	execScenario := scenario
+	if combo.PerturbationIndex >= 0 {
+		variants := ExpandPerturbations(scenario)
+		if combo.PerturbationIndex < len(variants) {
+			perturbed := *scenario
+			perturbed.Turns = ApplyPerturbation(scenario.Turns, variants[combo.PerturbationIndex])
+			execScenario = &perturbed
+		}
+	}
+
 	// Execute conversation
 	req := ConversationRequest{
 		Provider: provider,
-		Scenario: scenario,
+		Scenario: execScenario,
 		Config:   e.config,
 		Region:   combo.Region,
 		RunID:    runID,

--- a/tools/arena/engine/perturbations.go
+++ b/tools/arena/engine/perturbations.go
@@ -1,0 +1,139 @@
+package engine
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+// PerturbationVariant represents a single set of variable substitutions.
+type PerturbationVariant struct {
+	// Substitutions maps placeholder names to their values for this variant.
+	Substitutions map[string]string
+}
+
+// ExpandPerturbations computes all perturbation variants for a scenario.
+// It collects all perturbation maps across turns and computes the Cartesian product.
+// Returns nil if no perturbations are defined.
+func ExpandPerturbations(scenario *config.Scenario) []PerturbationVariant {
+	allPerturbations := collectPerturbations(scenario.Turns)
+	if len(allPerturbations) == 0 {
+		return nil
+	}
+	return cartesianProduct(allPerturbations)
+}
+
+// collectPerturbations merges perturbation maps from all turns into a single map.
+// If the same key appears in multiple turns, the values are merged (union).
+func collectPerturbations(turns []config.TurnDefinition) map[string][]string {
+	merged := make(map[string][]string)
+	for i := range turns {
+		for key, values := range turns[i].Perturbations {
+			if len(values) == 0 {
+				continue
+			}
+			merged[key] = mergeUnique(merged[key], values)
+		}
+	}
+	return merged
+}
+
+// mergeUnique appends values from src to dst, skipping duplicates already in dst.
+func mergeUnique(dst, src []string) []string {
+	if len(dst) == 0 {
+		return append([]string{}, src...)
+	}
+	seen := make(map[string]bool, len(dst))
+	for _, v := range dst {
+		seen[v] = true
+	}
+	for _, v := range src {
+		if !seen[v] {
+			dst = append(dst, v)
+		}
+	}
+	return dst
+}
+
+// cartesianProduct computes all combinations of perturbation values.
+// For example, {city: [NYC, LA], tone: [formal, casual]} produces 4 variants.
+func cartesianProduct(perturbations map[string][]string) []PerturbationVariant {
+	keys := sortedKeys(perturbations)
+	if len(keys) == 0 {
+		return nil
+	}
+
+	variants := []PerturbationVariant{{Substitutions: make(map[string]string)}}
+
+	for _, key := range keys {
+		values := perturbations[key]
+		var expanded []PerturbationVariant
+		for _, variant := range variants {
+			for _, val := range values {
+				newSubs := make(map[string]string, len(variant.Substitutions)+1)
+				for k, v := range variant.Substitutions {
+					newSubs[k] = v
+				}
+				newSubs[key] = val
+				expanded = append(expanded, PerturbationVariant{Substitutions: newSubs})
+			}
+		}
+		variants = expanded
+	}
+
+	return variants
+}
+
+// sortedKeys returns map keys in sorted order.
+func sortedKeys(m map[string][]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// ApplyPerturbation substitutes perturbation variables in turn content.
+// Placeholders use {key} syntax (e.g., "Book a flight from {city}" with city=NYC
+// becomes "Book a flight from NYC").
+func ApplyPerturbation(turns []config.TurnDefinition, variant PerturbationVariant) []config.TurnDefinition {
+	if len(variant.Substitutions) == 0 {
+		return turns
+	}
+
+	result := make([]config.TurnDefinition, len(turns))
+	for i := range turns {
+		result[i] = turns[i]
+		result[i].Content = substituteVars(turns[i].Content, variant.Substitutions)
+		if len(turns[i].Parts) > 0 {
+			result[i].Parts = make([]config.TurnContentPart, len(turns[i].Parts))
+			for j := range turns[i].Parts {
+				result[i].Parts[j] = turns[i].Parts[j]
+				if turns[i].Parts[j].Type == "text" {
+					result[i].Parts[j].Text = substituteVars(turns[i].Parts[j].Text, variant.Substitutions)
+				}
+			}
+		}
+	}
+	return result
+}
+
+// perturbationIndexForTrial returns the perturbation variant index for a given trial.
+// When perturbations are combined with trials, the trial index cycles through perturbation variants.
+// Returns -1 if perturbationCount <= 1 (no perturbations).
+func perturbationIndexForTrial(trialIndex, perturbationCount int) int {
+	if perturbationCount <= 1 {
+		return -1
+	}
+	return trialIndex % perturbationCount
+}
+
+// substituteVars replaces {key} placeholders with their values.
+func substituteVars(content string, subs map[string]string) string {
+	for key, val := range subs {
+		content = strings.ReplaceAll(content, "{"+key+"}", val)
+	}
+	return content
+}

--- a/tools/arena/engine/perturbations_test.go
+++ b/tools/arena/engine/perturbations_test.go
@@ -1,0 +1,211 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+func TestExpandPerturbations(t *testing.T) {
+	t.Run("no perturbations", func(t *testing.T) {
+		scenario := &config.Scenario{
+			Turns: []config.TurnDefinition{
+				{Role: "user", Content: "Hello"},
+			},
+		}
+		variants := ExpandPerturbations(scenario)
+		if variants != nil {
+			t.Fatalf("expected nil, got %d variants", len(variants))
+		}
+	})
+
+	t.Run("single key single value", func(t *testing.T) {
+		scenario := &config.Scenario{
+			Turns: []config.TurnDefinition{
+				{Role: "user", Content: "Go to {city}", Perturbations: map[string][]string{
+					"city": {"NYC"},
+				}},
+			},
+		}
+		variants := ExpandPerturbations(scenario)
+		if len(variants) != 1 {
+			t.Fatalf("expected 1 variant, got %d", len(variants))
+		}
+		if variants[0].Substitutions["city"] != "NYC" {
+			t.Fatalf("expected NYC, got %s", variants[0].Substitutions["city"])
+		}
+	})
+
+	t.Run("single key multiple values", func(t *testing.T) {
+		scenario := &config.Scenario{
+			Turns: []config.TurnDefinition{
+				{Role: "user", Content: "Go to {city}", Perturbations: map[string][]string{
+					"city": {"NYC", "LA", "Tokyo"},
+				}},
+			},
+		}
+		variants := ExpandPerturbations(scenario)
+		if len(variants) != 3 {
+			t.Fatalf("expected 3 variants, got %d", len(variants))
+		}
+	})
+
+	t.Run("cartesian product of two keys", func(t *testing.T) {
+		scenario := &config.Scenario{
+			Turns: []config.TurnDefinition{
+				{Role: "user", Content: "Fly from {city} {tone}", Perturbations: map[string][]string{
+					"city": {"NYC", "LA"},
+					"tone": {"formal", "casual"},
+				}},
+			},
+		}
+		variants := ExpandPerturbations(scenario)
+		if len(variants) != 4 {
+			t.Fatalf("expected 4 variants (2x2), got %d", len(variants))
+		}
+		// Verify all combinations exist
+		seen := make(map[string]bool)
+		for _, v := range variants {
+			key := v.Substitutions["city"] + "+" + v.Substitutions["tone"]
+			seen[key] = true
+		}
+		expected := []string{"NYC+casual", "NYC+formal", "LA+casual", "LA+formal"}
+		for _, e := range expected {
+			if !seen[e] {
+				t.Errorf("missing combination: %s", e)
+			}
+		}
+	})
+
+	t.Run("perturbations across turns merged", func(t *testing.T) {
+		scenario := &config.Scenario{
+			Turns: []config.TurnDefinition{
+				{Role: "user", Content: "Go to {city}", Perturbations: map[string][]string{
+					"city": {"NYC", "LA"},
+				}},
+				{Role: "user", Content: "In {city} do {action}", Perturbations: map[string][]string{
+					"city":   {"NYC", "Tokyo"}, // NYC is duplicate, Tokyo is new
+					"action": {"eat", "shop"},
+				}},
+			},
+		}
+		variants := ExpandPerturbations(scenario)
+		// city: [NYC, LA, Tokyo] (3) × action: [eat, shop] (2) = 6
+		if len(variants) != 6 {
+			t.Fatalf("expected 6 variants (3x2), got %d", len(variants))
+		}
+	})
+
+	t.Run("empty values ignored", func(t *testing.T) {
+		scenario := &config.Scenario{
+			Turns: []config.TurnDefinition{
+				{Role: "user", Content: "Go to {city}", Perturbations: map[string][]string{
+					"city":  {"NYC"},
+					"empty": {},
+				}},
+			},
+		}
+		variants := ExpandPerturbations(scenario)
+		if len(variants) != 1 {
+			t.Fatalf("expected 1 variant, got %d", len(variants))
+		}
+	})
+}
+
+func TestApplyPerturbation(t *testing.T) {
+	t.Run("substitutes in content", func(t *testing.T) {
+		turns := []config.TurnDefinition{
+			{Role: "user", Content: "Book a flight from {city} to London"},
+		}
+		variant := PerturbationVariant{Substitutions: map[string]string{"city": "NYC"}}
+		result := ApplyPerturbation(turns, variant)
+		if result[0].Content != "Book a flight from NYC to London" {
+			t.Fatalf("expected substituted content, got %q", result[0].Content)
+		}
+	})
+
+	t.Run("substitutes in text parts", func(t *testing.T) {
+		turns := []config.TurnDefinition{
+			{Role: "user", Parts: []config.TurnContentPart{
+				{Type: "text", Text: "Hello {name}"},
+				{Type: "image"},
+			}},
+		}
+		variant := PerturbationVariant{Substitutions: map[string]string{"name": "Alice"}}
+		result := ApplyPerturbation(turns, variant)
+		if result[0].Parts[0].Text != "Hello Alice" {
+			t.Fatalf("expected substituted text part, got %q", result[0].Parts[0].Text)
+		}
+	})
+
+	t.Run("empty substitutions returns original", func(t *testing.T) {
+		turns := []config.TurnDefinition{
+			{Role: "user", Content: "Hello {name}"},
+		}
+		variant := PerturbationVariant{Substitutions: map[string]string{}}
+		result := ApplyPerturbation(turns, variant)
+		if result[0].Content != "Hello {name}" {
+			t.Fatalf("expected unchanged content, got %q", result[0].Content)
+		}
+	})
+
+	t.Run("multiple substitutions", func(t *testing.T) {
+		turns := []config.TurnDefinition{
+			{Role: "user", Content: "Fly from {city} to {dest}"},
+		}
+		variant := PerturbationVariant{Substitutions: map[string]string{
+			"city": "NYC",
+			"dest": "London",
+		}}
+		result := ApplyPerturbation(turns, variant)
+		if result[0].Content != "Fly from NYC to London" {
+			t.Fatalf("expected substituted content, got %q", result[0].Content)
+		}
+	})
+
+	t.Run("does not modify original turns", func(t *testing.T) {
+		turns := []config.TurnDefinition{
+			{Role: "user", Content: "Hello {name}"},
+		}
+		variant := PerturbationVariant{Substitutions: map[string]string{"name": "Alice"}}
+		_ = ApplyPerturbation(turns, variant)
+		if turns[0].Content != "Hello {name}" {
+			t.Fatal("original turns should not be modified")
+		}
+	})
+}
+
+func TestCollectPerturbations(t *testing.T) {
+	t.Run("deduplicates values", func(t *testing.T) {
+		turns := []config.TurnDefinition{
+			{Perturbations: map[string][]string{"city": {"NYC", "LA"}}},
+			{Perturbations: map[string][]string{"city": {"NYC", "Tokyo"}}},
+		}
+		merged := collectPerturbations(turns)
+		cities := merged["city"]
+		if len(cities) != 3 {
+			t.Fatalf("expected 3 unique cities, got %d: %v", len(cities), cities)
+		}
+	})
+}
+
+func TestCartesianProduct(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		result := cartesianProduct(map[string][]string{})
+		if result != nil {
+			t.Fatalf("expected nil, got %d variants", len(result))
+		}
+	})
+
+	t.Run("three keys", func(t *testing.T) {
+		result := cartesianProduct(map[string][]string{
+			"a": {"1", "2"},
+			"b": {"x"},
+			"c": {"p", "q", "r"},
+		})
+		// 2 × 1 × 3 = 6
+		if len(result) != 6 {
+			t.Fatalf("expected 6 variants, got %d", len(result))
+		}
+	})
+}

--- a/tools/arena/engine/types.go
+++ b/tools/arena/engine/types.go
@@ -22,6 +22,9 @@ type RunCombination struct {
 	RecordingRef string // For batch evals: specific recording reference ID (resolved by adapter)
 	TrialIndex   int    // Trial number (0-based) when scenario has Trials > 1
 	TotalTrials  int    // Total number of trials for this scenario (0 or 1 = single run)
+
+	// PerturbationIndex identifies which perturbation variant this run uses (-1 = no perturbation).
+	PerturbationIndex int
 }
 
 // TrialGroupKey identifies a unique scenario+provider+region combination for trial grouping.


### PR DESCRIPTION
## Summary

- **Perturbation expansion infrastructure**: Cartesian product of `{key}` variable substitutions across scenario turns, multiplied with trial count. Wired into `generateScenarioCombinations` and `executeRun` for automatic variable substitution.
- **`outcome_equivalent` eval handler**: Verifies that tool_calls, final_state, or content_hash match expected values — used for perturbation-invariant outcome validation.
- **`directional` eval handler**: Compares runs against baselines using `same_tool_calls`, `same_outcome`, or `similar_content` (Jaccard word overlap with configurable threshold).
- Shared comparison helpers extracted to `behavioral_helpers.go` to avoid duplication between handlers.
- `Perturbations` field added to `TurnDefinition`, `PerturbationIndex` added to `RunCombination`.
- JSON schemas regenerated. 57 registered eval handlers total.

## Test plan

- [x] 14 perturbation tests: expansion, Cartesian product, cross-turn merge, deduplication, substitution, immutability
- [x] 16 outcome_equivalent tests: all metrics, match/mismatch, missing params, edge cases
- [x] 22 directional tests: all check types, word overlap, thresholds, empty content
- [x] Registration test updated (57 handlers)
- [x] All coverage thresholds met (97-100% on new files)
- [x] Pre-commit hooks pass (lint, build, test, coverage)