### PR TITLE
feat: add Phase 7 chaos injection for resilience testing

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -984,8 +984,29 @@ type TurnDefinition struct {
 	// The engine expands each variant into a separate trial, substituting {key} in Content.
 	Perturbations map[string][]string `json:"perturbations,omitempty" yaml:"perturbations,omitempty"`
 
+	// Chaos configures fault injection for resilience testing.
+	Chaos *ChaosConfig `json:"chaos,omitempty" yaml:"chaos,omitempty"`
+
 	// Turn-level assertions (for testing only)
 	Assertions []AssertionConfig `json:"assertions,omitempty" yaml:"assertions,omitempty"`
+}
+
+// ChaosConfig defines fault injection rules for a turn.
+type ChaosConfig struct {
+	// ToolFailures injects failures into specific tool calls.
+	ToolFailures []ChaosToolFailure `json:"tool_failures,omitempty" yaml:"tool_failures,omitempty"`
+}
+
+// ChaosToolFailure defines a failure injection rule for a specific tool.
+type ChaosToolFailure struct {
+	// Tool is the name of the tool to inject failures for.
+	Tool string `json:"tool" yaml:"tool"`
+	// Mode is the type of failure: "error", "timeout", or "slow".
+	Mode string `json:"mode" yaml:"mode"`
+	// Probability is the chance of failure (0.0 to 1.0, default 1.0).
+	Probability float64 `json:"probability,omitempty" yaml:"probability,omitempty"`
+	// Message is an optional custom error message.
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
 // TurnContentPart represents a content part in a scenario turn (simplified for YAML configuration)

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -221,6 +221,40 @@
         "description"
       ]
     },
+    "ChaosConfig": {
+      "properties": {
+        "tool_failures": {
+          "items": {
+            "$ref": "#/$defs/ChaosToolFailure"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ChaosToolFailure": {
+      "properties": {
+        "tool": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "probability": {
+          "type": "number"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool",
+        "mode"
+      ]
+    },
     "CompilationInfo": {
       "properties": {
         "compiled_with": {
@@ -2144,6 +2178,9 @@
             "type": "array"
           },
           "type": "object"
+        },
+        "chaos": {
+          "$ref": "#/$defs/ChaosConfig"
         },
         "assertions": {
           "items": {

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -45,6 +45,40 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ChaosConfig": {
+      "properties": {
+        "tool_failures": {
+          "items": {
+            "$ref": "#/$defs/ChaosToolFailure"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ChaosToolFailure": {
+      "properties": {
+        "tool": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "probability": {
+          "type": "number"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool",
+        "mode"
+      ]
+    },
     "ContextMetadata": {
       "properties": {
         "domain": {
@@ -417,6 +451,9 @@
             "type": "array"
           },
           "type": "object"
+        },
+        "chaos": {
+          "$ref": "#/$defs/ChaosConfig"
         },
         "assertions": {
           "items": {

--- a/tools/arena/chaos/hook.go
+++ b/tools/arena/chaos/hook.go
@@ -1,0 +1,116 @@
+// Package chaos provides fault injection for PromptArena resilience testing.
+// It implements a hooks.ToolHook that intercepts tool execution and injects
+// failures (errors, timeouts, latency) based on scenario chaos configuration.
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+)
+
+type contextKey int
+
+const chaosConfigKey contextKey = iota
+
+// Hook implements hooks.ToolHook to inject failures into tool execution.
+type Hook struct{}
+
+// NewHook creates a new chaos injection hook.
+func NewHook() *Hook {
+	return &Hook{}
+}
+
+// Name returns the hook name.
+func (h *Hook) Name() string {
+	return "chaos-injection"
+}
+
+// BeforeExecution checks chaos config and injects tool failures.
+func (h *Hook) BeforeExecution(ctx context.Context, req hooks.ToolRequest) hooks.Decision {
+	cfg := ConfigFromContext(ctx)
+	if cfg == nil {
+		return hooks.Allow
+	}
+
+	for _, rule := range cfg.ToolFailures {
+		if rule.Tool != req.Name {
+			continue
+		}
+		if !shouldFire(rule.Probability) {
+			continue
+		}
+		return applyFailure(req.Name, rule)
+	}
+
+	return hooks.Allow
+}
+
+// AfterExecution is a no-op — always allows.
+func (h *Hook) AfterExecution(_ context.Context, _ hooks.ToolRequest, _ hooks.ToolResponse) hooks.Decision {
+	return hooks.Allow
+}
+
+// applyFailure creates the appropriate failure decision for the given mode.
+func applyFailure(toolName string, rule config.ChaosToolFailure) hooks.Decision {
+	msg := rule.Message
+	meta := map[string]any{
+		"chaos_injected": true,
+		"chaos_mode":     rule.Mode,
+		"chaos_tool":     toolName,
+	}
+
+	switch rule.Mode {
+	case "error":
+		if msg == "" {
+			msg = fmt.Sprintf("Chaos: tool %s failed with injected error", toolName)
+		}
+		return hooks.DenyWithMetadata(msg, meta)
+
+	case "timeout":
+		if msg == "" {
+			msg = fmt.Sprintf("Chaos: tool %s timed out (injected)", toolName)
+		}
+		meta["chaos_timeout"] = true
+		return hooks.DenyWithMetadata(msg, meta)
+
+	case "slow":
+		// For "slow" mode, we add latency but still allow the call
+		const slowDelaySeconds = 2
+		time.Sleep(slowDelaySeconds * time.Second)
+		meta["chaos_delay_ms"] = slowDelaySeconds * 1000 //nolint:mnd // convert seconds to ms
+		return hooks.Decision{Allow: true, Metadata: meta}
+
+	default:
+		if msg == "" {
+			msg = fmt.Sprintf("Chaos: tool %s failed (mode=%s)", toolName, rule.Mode)
+		}
+		return hooks.DenyWithMetadata(msg, meta)
+	}
+}
+
+// shouldFire returns true if the failure should be triggered based on probability.
+func shouldFire(probability float64) bool {
+	if probability <= 0 {
+		return true // default: always fire (0 means unset)
+	}
+	if probability >= 1.0 {
+		return true
+	}
+	return rand.Float64() < probability //nolint:gosec // chaos testing doesn't need crypto rand
+}
+
+// WithConfig stores chaos config in the context.
+func WithConfig(ctx context.Context, cfg *config.ChaosConfig) context.Context {
+	return context.WithValue(ctx, chaosConfigKey, cfg)
+}
+
+// ConfigFromContext retrieves chaos config from the context.
+func ConfigFromContext(ctx context.Context) *config.ChaosConfig {
+	v, _ := ctx.Value(chaosConfigKey).(*config.ChaosConfig)
+	return v
+}

--- a/tools/arena/chaos/hook_test.go
+++ b/tools/arena/chaos/hook_test.go
@@ -1,0 +1,214 @@
+package chaos
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+)
+
+func TestHook_Name(t *testing.T) {
+	h := NewHook()
+	if h.Name() != "chaos-injection" {
+		t.Errorf("expected name %q, got %q", "chaos-injection", h.Name())
+	}
+}
+
+func TestHook_BeforeExecution_NoChaosConfig(t *testing.T) {
+	h := NewHook()
+	d := h.BeforeExecution(context.Background(), hooks.ToolRequest{Name: "search"})
+	if !d.Allow {
+		t.Error("expected allow when no chaos config")
+	}
+}
+
+func TestHook_BeforeExecution_NoMatchingTool(t *testing.T) {
+	h := NewHook()
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "other_tool", Mode: "error", Probability: 1.0},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "search"})
+	if !d.Allow {
+		t.Error("expected allow when tool doesn't match")
+	}
+}
+
+func TestHook_BeforeExecution_ErrorMode(t *testing.T) {
+	h := NewHook()
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "search", Mode: "error", Probability: 1.0},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "search"})
+	if d.Allow {
+		t.Error("expected deny for error mode")
+	}
+	if d.Metadata["chaos_injected"] != true {
+		t.Error("expected chaos_injected metadata")
+	}
+	if d.Metadata["chaos_mode"] != "error" {
+		t.Errorf("expected chaos_mode=error, got %v", d.Metadata["chaos_mode"])
+	}
+}
+
+func TestHook_BeforeExecution_ErrorMode_CustomMessage(t *testing.T) {
+	h := NewHook()
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "search", Mode: "error", Probability: 1.0, Message: "custom error"},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "search"})
+	if d.Allow {
+		t.Error("expected deny")
+	}
+	if d.Reason != "custom error" {
+		t.Errorf("expected custom message, got %q", d.Reason)
+	}
+}
+
+func TestHook_BeforeExecution_TimeoutMode(t *testing.T) {
+	h := NewHook()
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "lookup", Mode: "timeout", Probability: 1.0},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "lookup"})
+	if d.Allow {
+		t.Error("expected deny for timeout mode")
+	}
+	if d.Metadata["chaos_timeout"] != true {
+		t.Error("expected chaos_timeout metadata")
+	}
+}
+
+func TestHook_BeforeExecution_SlowMode(t *testing.T) {
+	h := NewHook()
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "search", Mode: "slow", Probability: 1.0},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "search"})
+	if !d.Allow {
+		t.Error("expected allow for slow mode (adds latency but doesn't block)")
+	}
+	if d.Metadata["chaos_delay_ms"] != 2000 {
+		t.Errorf("expected delay metadata, got %v", d.Metadata["chaos_delay_ms"])
+	}
+}
+
+func TestHook_BeforeExecution_UnknownMode(t *testing.T) {
+	h := NewHook()
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "search", Mode: "unknown_mode", Probability: 1.0},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "search"})
+	if d.Allow {
+		t.Error("expected deny for unknown mode")
+	}
+}
+
+func TestHook_BeforeExecution_ZeroProbability(t *testing.T) {
+	h := NewHook()
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "search", Mode: "error", Probability: 0},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	// Probability 0 means "unset" → always fires
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "search"})
+	if d.Allow {
+		t.Error("expected deny when probability is 0 (unset = always fire)")
+	}
+}
+
+func TestHook_AfterExecution_AlwaysAllows(t *testing.T) {
+	h := NewHook()
+	d := h.AfterExecution(context.Background(), hooks.ToolRequest{}, hooks.ToolResponse{})
+	if !d.Allow {
+		t.Error("expected allow from AfterExecution")
+	}
+}
+
+func TestShouldFire(t *testing.T) {
+	t.Run("zero means always", func(t *testing.T) {
+		if !shouldFire(0) {
+			t.Error("expected true for probability 0 (unset)")
+		}
+	})
+	t.Run("negative means always", func(t *testing.T) {
+		if !shouldFire(-1) {
+			t.Error("expected true for negative probability")
+		}
+	})
+	t.Run("one means always", func(t *testing.T) {
+		if !shouldFire(1.0) {
+			t.Error("expected true for probability 1.0")
+		}
+	})
+	t.Run("above one means always", func(t *testing.T) {
+		if !shouldFire(2.0) {
+			t.Error("expected true for probability > 1.0")
+		}
+	})
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "test", Mode: "error"},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	got := ConfigFromContext(ctx)
+	if got == nil {
+		t.Fatal("expected config from context")
+	}
+	if len(got.ToolFailures) != 1 {
+		t.Fatalf("expected 1 tool failure, got %d", len(got.ToolFailures))
+	}
+	if got.ToolFailures[0].Tool != "test" {
+		t.Errorf("expected tool=test, got %q", got.ToolFailures[0].Tool)
+	}
+}
+
+func TestConfigFromContext_Nil(t *testing.T) {
+	got := ConfigFromContext(context.Background())
+	if got != nil {
+		t.Error("expected nil from empty context")
+	}
+}
+
+func TestHook_MultipleRules_FirstMatch(t *testing.T) {
+	h := NewHook()
+	cfg := &config.ChaosConfig{
+		ToolFailures: []config.ChaosToolFailure{
+			{Tool: "search", Mode: "error", Probability: 1.0, Message: "first"},
+			{Tool: "search", Mode: "timeout", Probability: 1.0, Message: "second"},
+		},
+	}
+	ctx := WithConfig(context.Background(), cfg)
+	d := h.BeforeExecution(ctx, hooks.ToolRequest{Name: "search"})
+	if d.Allow {
+		t.Error("expected deny")
+	}
+	// First matching rule should win
+	if d.Reason != "first" {
+		t.Errorf("expected first rule to match, got %q", d.Reason)
+	}
+}

--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -320,6 +320,7 @@ func (ce *DefaultConversationExecutor) buildTurnRequest(req ConversationRequest,
 		ScriptedContent:  scenarioTurn.Content, // Legacy text content (for backward compatibility)
 		ScriptedParts:    scenarioTurn.Parts,   // Multimodal content parts (takes precedence over ScriptedContent)
 		ConsentOverrides: scenarioTurn.ConsentOverrides,
+		ChaosConfig:      scenarioTurn.Chaos,
 		Assertions:       scenarioTurn.Assertions,
 		TurnEvalRunner:   ce.packEvalHook,
 		Metadata:         metadata,

--- a/tools/arena/turnexecutors/interfaces.go
+++ b/tools/arena/turnexecutors/interfaces.go
@@ -93,6 +93,9 @@ type TurnRequest struct {
 	// Keys are tool names, values are "grant", "deny", or "timeout".
 	ConsentOverrides map[string]string
 
+	// ChaosConfig configures fault injection for resilience testing.
+	ChaosConfig *config.ChaosConfig
+
 	// Assertions to validate after turn execution
 	Assertions     []assertions.AssertionConfig
 	TurnEvalRunner interface{} // Optional stages.TurnEvalRunner for dual-write (Phase 2)

--- a/tools/arena/turnexecutors/pipeline_executor.go
+++ b/tools/arena/turnexecutors/pipeline_executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/storage"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/chaos"
 	"github.com/AltairaLabs/PromptKit/tools/arena/consent"
 	arenastages "github.com/AltairaLabs/PromptKit/tools/arena/stages"
 )
@@ -355,11 +356,25 @@ func (e *PipelineExecutor) handleExecutionError(provider providers.Provider, err
 	return fmt.Errorf("pipeline execution failed: %w", err)
 }
 
-// buildProviderStage creates a provider stage, attaching a consent simulation hook if overrides are present.
+// buildProviderStage creates a provider stage, attaching hooks
+// for consent simulation and/or chaos injection when configured.
 func (e *PipelineExecutor) buildProviderStage(req *TurnRequest, providerConfig *stage.ProviderConfig) stage.Stage {
 	toolPolicy := buildToolPolicy(req.Scenario)
+
+	var toolHooks []hooks.ToolHook
 	if len(req.ConsentOverrides) > 0 {
-		hookReg := hooks.NewRegistry(hooks.WithToolHook(consent.NewSimulationHook()))
+		toolHooks = append(toolHooks, consent.NewSimulationHook())
+	}
+	if req.ChaosConfig != nil {
+		toolHooks = append(toolHooks, chaos.NewHook())
+	}
+
+	if len(toolHooks) > 0 {
+		var opts []hooks.Option
+		for _, h := range toolHooks {
+			opts = append(opts, hooks.WithToolHook(h))
+		}
+		hookReg := hooks.NewRegistry(opts...)
 		return stage.NewProviderStageWithHooks(req.Provider, e.toolRegistry, toolPolicy, providerConfig, nil, hookReg)
 	}
 	return stage.NewProviderStage(req.Provider, e.toolRegistry, toolPolicy, providerConfig)
@@ -379,6 +394,11 @@ func (e *PipelineExecutor) Execute(
 	if len(req.ConsentOverrides) > 0 {
 		ctx = consent.WithConsentOverrides(ctx, req.ConsentOverrides)
 		ctx = consent.WithToolRegistry(ctx, e.toolRegistry)
+	}
+
+	// Inject chaos config into context if present
+	if req.ChaosConfig != nil {
+		ctx = chaos.WithConfig(ctx, req.ChaosConfig)
 	}
 
 	// Build base variables and stage pipeline


### PR DESCRIPTION
## Summary
- Add chaos injection hook (`tools/arena/chaos/`) implementing `hooks.ToolHook` with error, timeout, and slow failure modes
- Add `ChaosConfig` and `ChaosToolFailure` types to `pkg/config/types.go` with per-turn `chaos` field on `TurnDefinition`
- Wire chaos hook through `pipeline_executor.go` alongside consent simulation hooks, supporting both hooks simultaneously
- Regenerate JSON schemas to include chaos configuration

## Test plan
- [x] 14 unit tests covering all modes (error, timeout, slow, unknown), custom messages, probability, context round-trip, multiple rules
- [x] All existing pipeline executor tests pass
- [x] Pre-commit checks pass (lint, build, test, coverage ≥80%)
- [x] Coverage: chaos/hook.go 94.7%, pipeline_executor.go 82.1%