### PR TITLE
feat: structured logging and OTel trace propagation across runtime and SDK

### DIFF
--- a/runtime/a2a/executor.go
+++ b/runtime/a2a/executor.go
@@ -222,7 +222,7 @@ func buildRequest(
 
 // executeRequest sends an A2A request with timeout and retry, returning the completed task.
 func (e *Executor) executeRequest(
-	ctx context.Context, cfg *tools.A2AConfig, req *SendMessageRequest,
+	ctx context.Context, toolName string, cfg *tools.A2AConfig, req *SendMessageRequest,
 ) (*Task, error) {
 	client := e.getOrCreateClient(cfg.AgentURL)
 
@@ -232,10 +232,20 @@ func (e *Executor) executeRequest(
 		defer cancel()
 	}
 
+	logger.Info("A2A tool call",
+		"tool", toolName, "agent_url", cfg.AgentURL, "skill_id", cfg.SkillID)
+
 	task, err := e.sendWithRetry(ctx, client, req, cfg.AgentURL)
 	if err != nil {
+		logger.Error("A2A tool call failed",
+			"tool", toolName, "agent_url", cfg.AgentURL, "error", err)
 		return nil, fmt.Errorf("a2a executor: send message: %w", err)
 	}
+
+	logger.Info("A2A tool call completed",
+		"tool", toolName, "agent_url", cfg.AgentURL,
+		"task_state", string(task.Status.State))
+
 	return task, nil
 }
 
@@ -245,10 +255,12 @@ func (e *Executor) Execute(
 ) (json.RawMessage, error) {
 	cfg, req, err := buildRequest(descriptor, args)
 	if err != nil {
+		logger.Error("A2A tool request build failed",
+			"tool", descriptor.Name, "error", err)
 		return nil, err
 	}
 
-	task, err := e.executeRequest(ctx, cfg, req)
+	task, err := e.executeRequest(ctx, descriptor.Name, cfg, req)
 	if err != nil {
 		return nil, err
 	}
@@ -265,10 +277,12 @@ func (e *Executor) ExecuteMultimodal(
 ) (json.RawMessage, []types.ContentPart, error) {
 	cfg, req, err := buildRequest(descriptor, args)
 	if err != nil {
+		logger.Error("A2A multimodal tool request build failed",
+			"tool", descriptor.Name, "error", err)
 		return nil, nil, err
 	}
 
-	task, err := e.executeRequest(ctx, cfg, req)
+	task, err := e.executeRequest(ctx, descriptor.Name, cfg, req)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/runtime/credentials/resolver.go
+++ b/runtime/credentials/resolver.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 )
 
 // Platform type constants.
@@ -86,6 +88,8 @@ func resolveAPIKeyCredential(cfg ResolverConfig) (Credential, error) {
 func findAPIKey(cfg ResolverConfig) (string, error) {
 	// 1. Try explicit api_key
 	if cfg.CredentialConfig != nil && cfg.CredentialConfig.APIKey != "" {
+		logger.Debug("credential resolved via explicit api_key",
+			"provider", cfg.ProviderType)
 		return cfg.CredentialConfig.APIKey, nil
 	}
 
@@ -95,6 +99,8 @@ func findAPIKey(cfg ResolverConfig) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("failed to read credential file: %w", err)
 		}
+		logger.Debug("credential resolved via credential_file",
+			"provider", cfg.ProviderType)
 		return key, nil
 	}
 
@@ -104,11 +110,21 @@ func findAPIKey(cfg ResolverConfig) (string, error) {
 		if key == "" {
 			return "", fmt.Errorf("environment variable %s is not set", cfg.CredentialConfig.CredentialEnv)
 		}
+		logger.Debug("credential resolved via credential_env",
+			"provider", cfg.ProviderType, "env_var", cfg.CredentialConfig.CredentialEnv)
 		return key, nil
 	}
 
 	// 4. Try default env vars for provider type
-	return findDefaultEnvKey(cfg.ProviderType), nil
+	key := findDefaultEnvKey(cfg.ProviderType)
+	if key != "" {
+		logger.Debug("credential resolved via default env var",
+			"provider", cfg.ProviderType)
+	} else {
+		logger.Debug("no credential found, using NoOp",
+			"provider", cfg.ProviderType)
+	}
+	return key, nil
 }
 
 // findDefaultEnvKey looks for API keys in default environment variables.

--- a/runtime/hooks/registry.go
+++ b/runtime/hooks/registry.go
@@ -2,7 +2,9 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
@@ -69,6 +71,8 @@ func (r *Registry) RunBeforeProviderCall(ctx context.Context, req *ProviderReque
 	}
 	for _, h := range r.providerHooks {
 		if d := h.BeforeCall(ctx, req); !d.Allow {
+			logger.Warn("provider hook denied before-call",
+				"hook", fmt.Sprintf("%T", h), "reason", d.Reason)
 			return d
 		}
 	}
@@ -83,6 +87,8 @@ func (r *Registry) RunAfterProviderCall(ctx context.Context, req *ProviderReques
 	}
 	for _, h := range r.providerHooks {
 		if d := h.AfterCall(ctx, req, resp); !d.Allow {
+			logger.Warn("provider hook denied after-call",
+				"hook", fmt.Sprintf("%T", h), "reason", d.Reason)
 			return d
 		}
 	}
@@ -105,6 +111,8 @@ func (r *Registry) RunOnChunk(ctx context.Context, chunk *providers.StreamChunk)
 	}
 	for _, ci := range r.chunkInterceptors {
 		if d := ci.OnChunk(ctx, chunk); !d.Allow {
+			logger.Warn("chunk interceptor denied",
+				"interceptor", fmt.Sprintf("%T", ci), "reason", d.Reason)
 			return d
 		}
 	}
@@ -124,6 +132,8 @@ func (r *Registry) RunBeforeToolExecution(ctx context.Context, req ToolRequest) 
 	for _, h := range r.toolHooks {
 		d := h.BeforeExecution(ctx, req)
 		if !d.Allow {
+			logger.Warn("tool hook denied before-execution",
+				"hook", fmt.Sprintf("%T", h), "tool", req.Name, "reason", d.Reason)
 			return d
 		}
 		if d.Metadata != nil {
@@ -141,6 +151,8 @@ func (r *Registry) RunAfterToolExecution(ctx context.Context, req ToolRequest, r
 	}
 	for _, h := range r.toolHooks {
 		if d := h.AfterExecution(ctx, req, resp); !d.Allow {
+			logger.Warn("tool hook denied after-execution",
+				"hook", fmt.Sprintf("%T", h), "tool", req.Name, "reason", d.Reason)
 			return d
 		}
 	}

--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -271,7 +271,14 @@ func (p *StreamPipeline) runStage(
 
 	// Report error
 	if err != nil {
+		logger.Debug("pipeline stage failed",
+			"stage", stage.Name(), "type", stage.Type(),
+			"duration", duration, "error", err)
 		errors <- NewStageError(stage.Name(), stage.Type(), err)
+	} else {
+		logger.Debug("pipeline stage completed",
+			"stage", stage.Name(), "type", stage.Type(),
+			"duration", duration)
 	}
 }
 

--- a/runtime/providers/retry.go
+++ b/runtime/providers/retry.go
@@ -209,19 +209,33 @@ func DoWithRetry(
 
 		retryAfter, shouldRetry := state.classify(resp, err)
 		if !shouldRetry {
+			if err != nil {
+				logger.Debug("provider request failed (non-retryable)",
+					"provider", providerName,
+					"error", err)
+			}
 			return resp, err
 		}
 
 		if attempt >= maxAttempts-1 {
+			logger.Warn("provider request failed after all retries",
+				"provider", providerName,
+				"attempts", maxAttempts,
+				"error", state.lastErr)
 			break
 		}
 
 		delay := calculateBackoff(policy, attempt, retryAfter)
+		statusInfo := ""
+		if resp != nil {
+			statusInfo = resp.Status
+		}
 		logger.Warn("retrying provider request",
 			"provider", providerName,
 			"attempt", attempt+1,
 			"max_retries", policy.MaxRetries,
 			"delay", delay.String(),
+			"status", statusInfo,
 			"error", state.lastErr,
 		)
 

--- a/runtime/statestore/memory.go
+++ b/runtime/statestore/memory.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -620,6 +621,9 @@ func (s *MemoryStore) evictLRULocked() {
 				s.removeFromUserIndex(state.UserID, entry.key)
 			}
 			delete(s.states, entry.key)
+			logger.Debug("state store LRU eviction",
+				"conversation_id", entry.key,
+				"store_size", len(s.states))
 			return
 		}
 		// Entry was already deleted from states (e.g., by TTL expiry); pop next.
@@ -650,11 +654,17 @@ func (s *MemoryStore) deleteExpiredKeys(keys []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	evicted := 0
 	for _, id := range keys {
 		state, ok := s.states[id]
 		if ok && s.isExpired(state) {
 			s.deleteStateLocked(id, state)
+			evicted++
 		}
+	}
+	if evicted > 0 {
+		logger.Debug("state store TTL eviction",
+			"evicted", evicted, "store_size", len(s.states))
 	}
 }
 

--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -373,6 +374,8 @@ func (r *Registry) Execute(
 
 	// Validate arguments
 	if valErr := r.validator.ValidateArgs(tool, args); valErr != nil {
+		logger.Debug("tool argument validation failed",
+			"tool", toolName, "error", valErr)
 		return nil, valErr
 	}
 
@@ -381,6 +384,10 @@ func (r *Registry) Execute(
 	if err != nil {
 		return nil, err
 	}
+
+	logger.Debug("tool execution started",
+		"tool", toolName, "mode", tool.Mode, "executor", executor.Name(),
+		"timeout_ms", tool.TimeoutMs)
 
 	// Apply timeout from tool descriptor
 	execCtx, cancel := r.withTimeout(ctx, tool)
@@ -409,6 +416,12 @@ func (r *Registry) Execute(
 				"%s: %s exceeded %dms timeout",
 				ErrToolTimeout, toolName, tool.TimeoutMs,
 			)
+			logger.Warn("tool execution timed out",
+				"tool", toolName, "timeout_ms", tool.TimeoutMs,
+				"latency_ms", latency)
+		} else {
+			logger.Debug("tool execution failed",
+				"tool", toolName, "latency_ms", latency, "error", err)
 		}
 		return &ToolResult{
 			Name:      toolName,

--- a/runtime/workflow/machine.go
+++ b/runtime/workflow/machine.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"sync"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 )
 
 var (
@@ -91,7 +93,10 @@ func (sm *StateMachine) ProcessEvent(event string) error {
 			ErrInvalidEvent, event, sm.context.CurrentState, sm.availableEventsLocked())
 	}
 
-	sm.context.RecordTransition(sm.context.CurrentState, target, event, sm.now())
+	fromState := sm.context.CurrentState
+	sm.context.RecordTransition(fromState, target, event, sm.now())
+	logger.Info("workflow state transition",
+		"from", fromState, "to", target, "event", event)
 	return nil
 }
 

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	rtpipeline "github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
@@ -918,6 +919,10 @@ func (c *Conversation) Close() error {
 		return nil
 	}
 	c.closed = true
+	var convID string
+	if (c.mode == UnaryMode && c.unarySession != nil) || (c.mode == DuplexMode && c.duplexSession != nil) {
+		convID = c.ID()
+	}
 
 	// Deregister from shutdown manager if configured
 	c.deregisterFromShutdownManager()
@@ -925,7 +930,7 @@ func (c *Conversation) Close() error {
 	// End the OTel session span (deferred to Close so late-arriving async events
 	// from the EventBus still have a parent context).
 	if c.config != nil && c.config.otelListener != nil {
-		c.config.otelListener.EndSession(c.ID())
+		c.config.otelListener.EndSession(convID)
 	}
 
 	// Run session end hooks before cleanup
@@ -973,13 +978,17 @@ func (c *Conversation) Close() error {
 	// State is automatically persisted by the StateStore middleware in the pipeline
 	// No explicit save needed here
 
+	logger.Info("conversation closed", "id", convID)
 	return errors.Join(errs...)
 }
 
 // deregisterFromShutdownManager removes the conversation from its shutdown
 // manager, if one is configured. Must be called while c.mu is held.
 func (c *Conversation) deregisterFromShutdownManager() {
-	if c.config != nil && c.config.shutdownManager != nil {
+	if c.config == nil || c.config.shutdownManager == nil {
+		return
+	}
+	if (c.mode == UnaryMode && c.unarySession != nil) || (c.mode == DuplexMode && c.duplexSession != nil) {
 		c.config.shutdownManager.Deregister(c.ID())
 	}
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -79,6 +79,8 @@ func setLoggerOnce(l *slog.Logger) {
 func Open(packPath, promptName string, opts ...Option) (*Conversation, error) {
 	conv, _, err := initConversation(packPath, promptName, opts)
 	if err != nil {
+		logger.Error("conversation open failed",
+			"pack", packPath, "prompt", promptName, "error", err)
 		return nil, err
 	}
 
@@ -101,6 +103,8 @@ func Open(packPath, promptName string, opts ...Option) (*Conversation, error) {
 		}
 	}
 
+	logger.Info("conversation opened",
+		"id", conv.ID(), "pack", packPath, "prompt", promptName)
 	return conv, nil
 }
 

--- a/sdk/tools/http.go
+++ b/sdk/tools/http.go
@@ -17,7 +17,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+
 	"github.com/AltairaLabs/PromptKit/runtime/httputil"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 )
 
@@ -109,8 +113,13 @@ func (e *HTTPExecutor) ExecuteWithContext(
 	// Create the request
 	req, err := e.buildRequest(ctx, cfg, args)
 	if err != nil {
+		logger.Error("HTTP tool request build failed",
+			"tool", descriptor.Name, "url", cfg.URL, "error", err)
 		return nil, err
 	}
+
+	// Inject OTel trace context into outbound request headers.
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
 	// Apply timeout if configured
 	if cfg.TimeoutMs > 0 {
@@ -120,15 +129,32 @@ func (e *HTTPExecutor) ExecuteWithContext(
 		req = req.WithContext(ctx)
 	}
 
+	method := req.Method
+	logger.Info("HTTP tool call",
+		"tool", descriptor.Name, "method", method, "url", cfg.URL)
+
 	// Execute the request
 	resp, err := e.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("HTTP request failed: %w", err)
+		logger.Error("HTTP tool call failed",
+			"tool", descriptor.Name, "method", method, "url", cfg.URL, "error", err)
+		return nil, fmt.Errorf("HTTP request to %s %s failed: %w", method, cfg.URL, err)
 	}
 	defer resp.Body.Close()
 
 	// Process the response
-	return e.processResponse(resp, cfg)
+	result, err := e.processResponse(resp, cfg)
+	if err != nil {
+		logger.Error("HTTP tool response error",
+			"tool", descriptor.Name, "method", method, "url", cfg.URL,
+			"status", resp.StatusCode, "error", err)
+		return nil, err
+	}
+
+	logger.Info("HTTP tool call completed",
+		"tool", descriptor.Name, "method", method, "url", cfg.URL,
+		"status", resp.StatusCode, "response_bytes", len(result))
+	return result, nil
 }
 
 // buildRequest creates an HTTP request from the config and args.


### PR DESCRIPTION
## Summary

- Add structured logging with OTel trace propagation to HTTP and A2A tool executors
- Add structured logging across the entire runtime and SDK for observability:
  - **Provider retry** (`runtime/providers/retry.go`): Warn on retries with backoff details, warn on exhausted attempts, debug non-retryable failures
  - **Tool registry** (`runtime/tools/registry.go`): Debug tool execution start/completion, warn on timeouts
  - **Workflow machine** (`runtime/workflow/machine.go`): Info on state transitions
  - **Hooks registry** (`runtime/hooks/registry.go`): Warn on deny decisions from provider/tool/chunk hooks
  - **Credential resolver** (`runtime/credentials/resolver.go`): Debug which resolution path was taken (explicit key, file, env, default, NoOp)
  - **State store** (`runtime/statestore/memory.go`): Debug LRU and TTL eviction events
  - **Pipeline stages** (`runtime/pipeline/stage/pipeline.go`): Debug stage completion/failure with duration
  - **SDK conversation** (`sdk/sdk.go`, `sdk/conversation.go`): Info on conversation open/close lifecycle, error on open failures

## Log level strategy
- **Debug**: Internal operations (cache lookups, executor selection, credential resolution, stage lifecycle)
- **Info**: Lifecycle events (conversation open/close, workflow transitions)
- **Warn**: Retries, hook denials, evictions, timeouts
- **Error**: Failures (conversation open failed)

## Test plan
- [x] All runtime tests pass
- [x] All SDK tests pass (including `TestCloseWithErrors/duplex_mode_close` fix)
- [x] golangci-lint clean on changed files
- [x] All changed files meet ≥80% coverage threshold
- [x] Pre-commit hooks pass