### PR TITLE
docs: MCP and A2A how-to guides

### DIFF
--- a/docs/src/content/docs/arena/how-to/index.md
+++ b/docs/src/content/docs/arena/how-to/index.md
@@ -70,6 +70,18 @@ Capture detailed session recordings for debugging, replay, and analysis. Export 
 Configure context management and truncation strategies for long conversations, including embedding-based relevance truncation.
 </div>
 
+## Tool Integrations
+
+<div class="code-example" markdown="1">
+### [Test MCP Tools](test-mcp-tools)
+Configure MCP servers in Arena for integration testing with tool filtering, timeouts, and environment variables.
+</div>
+
+<div class="code-example" markdown="1">
+### [Test A2A Agents](test-a2a-agents)
+Test agent-to-agent delegation with mock or remote A2A agents, including authentication, headers, and skill filtering.
+</div>
+
 ## Automation
 
 <div class="code-example" markdown="1">

--- a/docs/src/content/docs/arena/how-to/test-a2a-agents.md
+++ b/docs/src/content/docs/arena/how-to/test-a2a-agents.md
@@ -295,6 +295,115 @@ conversation_assertions:
 
 ---
 
+## Remote A2A Agents
+
+Instead of mock agents, you can test against real remote A2A servers. Set `url` on the agent config — Arena discovers the agent's skills from its `/.well-known/agent.json` endpoint.
+
+### Basic Remote Agent
+
+```yaml
+a2a_agents:
+  - name: echo_agent
+    url: "http://localhost:9877"
+```
+
+When `url` is set, `card` and `responses` are ignored — the agent card is fetched from the remote server.
+
+### Authentication
+
+Use `auth` to send credentials with every request:
+
+```yaml
+a2a_agents:
+  - name: echo_agent
+    url: "http://localhost:9877"
+    auth:
+      scheme: Bearer
+      token: "test-token-123"
+```
+
+To keep tokens out of config files, use `token_env` to read from an environment variable:
+
+```yaml
+a2a_agents:
+  - name: echo_agent
+    url: "https://agent.example.com"
+    auth:
+      scheme: Bearer
+      token_env: AGENT_TOKEN
+```
+
+### Headers
+
+Add static headers or headers resolved from environment variables:
+
+```yaml
+a2a_agents:
+  - name: echo_agent
+    url: "https://agent.example.com"
+    headers:
+      X-Tenant-ID: acme
+      X-Request-Source: arena
+    headers_from_env:
+      - "X-API-Key=API_KEY_ENV"
+```
+
+`headers_from_env` entries use the format `Header-Name=ENV_VAR_NAME`. If the env var is unset, the header is silently skipped.
+
+### Skill Filtering
+
+Limit which skills from the remote agent are exposed as tools:
+
+```yaml
+a2a_agents:
+  - name: echo_agent
+    url: "http://localhost:9877"
+    skill_filter:
+      allowlist:
+        - echo
+```
+
+Use `blocklist` to exclude specific skills instead:
+
+```yaml
+    skill_filter:
+      blocklist:
+        - debug
+        - admin
+```
+
+### Timeout
+
+Set a per-request timeout in milliseconds:
+
+```yaml
+a2a_agents:
+  - name: echo_agent
+    url: "http://localhost:9877"
+    timeout_ms: 5000
+```
+
+### Complete Remote Agent Config
+
+```yaml
+a2a_agents:
+  - name: echo_agent
+    url: "http://localhost:9877"
+    auth:
+      scheme: Bearer
+      token: "test-token-123"
+    headers:
+      X-Tenant-ID: acme
+    headers_from_env:
+      - "X-API-Key=API_KEY_ENV"
+    timeout_ms: 5000
+    skill_filter:
+      allowlist:
+        - echo
+```
+
+---
+
 ## Response Rules Reference
 
 ### Match Config

--- a/docs/src/content/docs/arena/how-to/test-mcp-tools.md
+++ b/docs/src/content/docs/arena/how-to/test-mcp-tools.md
@@ -1,0 +1,254 @@
+---
+title: Test MCP Tools
+description: Configure MCP servers in Arena scenarios for integration testing
+sidebar:
+  order: 12
+---
+
+Test MCP tool integrations in Arena by connecting real MCP servers and verifying tool calls in your scenarios.
+
+---
+
+## Configure MCP Servers
+
+Add an `mcp_servers` block to your Arena config:
+
+```yaml
+# config.arena.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: mcp-test
+spec:
+  mcp_servers:
+    - name: everything
+      command: npx
+      args:
+        - "-y"
+        - "@modelcontextprotocol/server-everything"
+
+  prompt_configs:
+    - id: assistant
+      file: prompts/assistant.yaml
+  scenarios:
+    - file: scenarios/echo-test.yaml
+  providers:
+    - file: providers/mock-provider.yaml
+```
+
+Arena starts the MCP server, discovers its tools, and registers them for use in scenarios.
+
+---
+
+## Tool Filtering
+
+MCP servers often expose many tools. Use `tool_filter` to limit which tools are available:
+
+### Allowlist
+
+```yaml
+mcp_servers:
+  - name: everything
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-everything"]
+    tool_filter:
+      allowlist:
+        - echo
+        - get-sum
+```
+
+### Blocklist
+
+```yaml
+mcp_servers:
+  - name: database
+    command: python
+    args: ["mcp_db_server.py"]
+    tool_filter:
+      blocklist:
+        - drop_table
+        - truncate_table
+```
+
+---
+
+## Server Configuration
+
+### Environment Variables
+
+Pass environment variables to the server process:
+
+```yaml
+mcp_servers:
+  - name: github
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_TOKEN: "${GITHUB_TOKEN}"
+```
+
+### Working Directory
+
+```yaml
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "./data"]
+    working_dir: /path/to/project
+```
+
+### Timeout
+
+Set a per-request timeout in milliseconds:
+
+```yaml
+mcp_servers:
+  - name: everything
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-everything"]
+    timeout_ms: 10000
+```
+
+---
+
+## Prompt Config
+
+Enable MCP tools in your prompt config with `allowed_tools`. MCP tools follow the naming pattern `mcp__{serverName}__{toolName}`:
+
+```yaml
+# prompts/assistant.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+spec:
+  task_type: assistant
+  version: v1.0.0
+  description: Assistant with MCP tools
+  allowed_tools:
+    - mcp__everything__echo
+    - mcp__everything__get-sum
+  system_template: |
+    You are a helpful assistant with access to echo and math tools.
+```
+
+---
+
+## Mock LLM Responses
+
+Configure the mock LLM to issue tool calls against MCP tools:
+
+```yaml
+# mock-responses.yaml
+scenarios:
+  echo-test:
+    turns:
+      1:
+        tool_calls:
+          - name: "mcp__everything__echo"
+            arguments:
+              message: "Hello from Arena!"
+      2:
+        response: "The echo tool returned: Hello from Arena!"
+```
+
+---
+
+## Scenario with Assertions
+
+```yaml
+# scenarios/echo-test.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: echo-test
+spec:
+  id: echo-test
+  task_type: assistant
+  description: Test MCP echo tool
+  tool_policy:
+    tool_choice: auto
+    max_tool_calls_per_turn: 3
+  turns:
+    - role: user
+      content: "Echo the message: Hello from Arena!"
+      assertions:
+        - type: tools_called
+          params:
+            tools:
+              - mcp__everything__echo
+        - type: content_includes
+          params:
+            patterns:
+              - "Hello from Arena"
+```
+
+---
+
+## Multiple MCP Servers
+
+Register multiple servers in the same config:
+
+```yaml
+mcp_servers:
+  - name: everything
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-everything"]
+    tool_filter:
+      allowlist: [echo, get-sum]
+
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "./data"]
+    tool_filter:
+      allowlist: [read_file, list_directory]
+```
+
+---
+
+## Complete Example
+
+```yaml
+# config.arena.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: mcp-everything-test
+spec:
+  mcp_servers:
+    - name: everything
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-everything"]
+      timeout_ms: 10000
+      tool_filter:
+        allowlist: [echo, get-sum]
+
+  prompt_configs:
+    - id: mcp-assistant
+      file: prompts/mcp-assistant.yaml
+  scenarios:
+    - file: scenarios/echo-and-add.scenario.yaml
+  providers:
+    - file: providers/mock-provider.yaml
+  defaults:
+    temperature: 0.7
+    max_tokens: 500
+    concurrency: 1
+    output:
+      dir: out
+      formats: ["json", "html"]
+```
+
+Run it:
+
+```bash
+cd examples/mcp-everything-test
+promptarena run -c config.arena.yaml
+```
+
+---
+
+## Next Steps
+
+- [Configure MCP Servers (SDK)](/sdk/how-to/configure-mcp/) — use MCP servers in the Go SDK
+- [Integrate MCP (Runtime)](/runtime/how-to/integrate-mcp/) — low-level MCP registry API
+- [Test A2A Agents](/arena/how-to/test-a2a-agents/) — test agent-to-agent delegation
+- [Write Scenarios](/arena/how-to/write-scenarios/) — general scenario authoring

--- a/docs/src/content/docs/sdk/how-to/configure-mcp.md
+++ b/docs/src/content/docs/sdk/how-to/configure-mcp.md
@@ -1,0 +1,185 @@
+---
+title: Configure MCP Servers
+description: Connect MCP tool servers to your conversation using the SDK builder pattern
+sidebar:
+  order: 6
+---
+
+Add [Model Context Protocol](https://modelcontextprotocol.io) servers to a conversation so the LLM can call their tools.
+
+---
+
+## Quick Start
+
+```go
+import "github.com/AltairaLabs/PromptKit/sdk"
+
+conv, err := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithMCP("filesystem", "npx", "-y", "@modelcontextprotocol/server-filesystem", "/data"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer conv.Close()
+```
+
+`WithMCP` registers all tools from the server. For finer control, use the builder pattern.
+
+---
+
+## Builder Pattern
+
+Use `NewMCPServer` when you need environment variables, timeouts, working directories, or tool filtering.
+
+```go
+import (
+    "github.com/AltairaLabs/PromptKit/runtime/mcp"
+    "github.com/AltairaLabs/PromptKit/sdk"
+)
+
+server := sdk.NewMCPServer("github", "npx", "@modelcontextprotocol/server-github").
+    WithEnv("GITHUB_TOKEN", os.Getenv("GITHUB_TOKEN")).
+    WithTimeout(10000).
+    WithToolFilter(&mcp.ToolFilter{
+        Allowlist: []string{"search_repositories", "get_file_contents"},
+    })
+
+conv, err := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithMCPServer(server),
+)
+```
+
+### Builder Methods
+
+| Method | Description |
+|--------|-------------|
+| `WithEnv(key, value)` | Add an environment variable to the server process |
+| `WithArgs(args...)` | Append additional command arguments |
+| `WithWorkingDir(dir)` | Set the working directory for the server process |
+| `WithTimeout(ms)` | Set per-request timeout in milliseconds |
+| `WithToolFilter(filter)` | Control which tools are exposed to the LLM |
+
+---
+
+## Tool Filtering
+
+Use `ToolFilter` to limit which tools the LLM can see. This is useful when a server exposes many tools but you only need a few.
+
+### Allowlist
+
+Only expose specific tools:
+
+```go
+server := sdk.NewMCPServer("everything", "npx", "@modelcontextprotocol/server-everything").
+    WithToolFilter(&mcp.ToolFilter{
+        Allowlist: []string{"echo", "get-sum"},
+    })
+```
+
+### Blocklist
+
+Expose all tools except specific ones:
+
+```go
+server := sdk.NewMCPServer("db", "python", "mcp_server.py").
+    WithToolFilter(&mcp.ToolFilter{
+        Blocklist: []string{"drop_table", "truncate_table"},
+    })
+```
+
+If both are set, allowlist takes precedence.
+
+---
+
+## Multiple Servers
+
+Register multiple MCP servers in a single conversation:
+
+```go
+github := sdk.NewMCPServer("github", "npx", "@modelcontextprotocol/server-github").
+    WithEnv("GITHUB_TOKEN", os.Getenv("GITHUB_TOKEN"))
+
+filesystem := sdk.NewMCPServer("fs", "npx",
+    "-y", "@modelcontextprotocol/server-filesystem", "/data")
+
+conv, err := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithMCPServer(github),
+    sdk.WithMCPServer(filesystem),
+)
+```
+
+Tool names are namespaced as `mcp__{serverName}__{toolName}` to avoid collisions.
+
+---
+
+## Tool Naming
+
+MCP tools registered through the SDK follow this naming pattern:
+
+```
+mcp__{serverName}__{toolName}
+```
+
+| Server Name | Tool Name | Registered As |
+|-------------|-----------|---------------|
+| `github` | `search_repositories` | `mcp__github__search_repositories` |
+| `filesystem` | `read_file` | `mcp__filesystem__read_file` |
+
+Reference these names in your prompt config's `allowed_tools` if you want to restrict which tools are available:
+
+```yaml
+spec:
+  allowed_tools:
+    - mcp__github__search_repositories
+    - mcp__github__get_file_contents
+```
+
+---
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/AltairaLabs/PromptKit/runtime/mcp"
+    "github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func main() {
+    server := sdk.NewMCPServer("everything", "npx",
+        "@modelcontextprotocol/server-everything").
+        WithTimeout(10000).
+        WithToolFilter(&mcp.ToolFilter{
+            Allowlist: []string{"echo", "get-sum"},
+        })
+
+    conv, err := sdk.Open("./app.pack.json", "assistant",
+        sdk.WithMCPServer(server),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer conv.Close()
+
+    ctx := context.Background()
+    resp, err := conv.Send(ctx, "What is 17 + 25?")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(resp.Text())
+}
+```
+
+---
+
+## Next Steps
+
+- [Integrate MCP (Runtime)](/runtime/how-to/integrate-mcp/) — low-level MCP registry and pipeline integration
+- [Register Tools](/sdk/how-to/register-tools/) — add custom Go tools alongside MCP tools
+- [HTTP Tools](/sdk/how-to/http-tools/) — call REST APIs as tools

--- a/docs/src/content/docs/sdk/how-to/connect-a2a-agents.md
+++ b/docs/src/content/docs/sdk/how-to/connect-a2a-agents.md
@@ -1,0 +1,246 @@
+---
+title: Connect A2A Agents
+description: Register remote A2A agents as tools with authentication, headers, and skill filtering
+sidebar:
+  order: 7
+---
+
+Connect to remote [A2A](https://google.github.io/A2A/) agents so the LLM can delegate tasks to them. The SDK discovers the agent's skills at startup and registers each skill as a tool.
+
+---
+
+## Quick Start
+
+```go
+import "github.com/AltairaLabs/PromptKit/sdk"
+
+agent := sdk.NewA2AAgent("https://agent.example.com").
+    WithAuth("Bearer", os.Getenv("AGENT_TOKEN"))
+
+conv, err := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithA2AAgent(agent),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer conv.Close()
+```
+
+The SDK calls `/.well-known/agent.json` to discover the agent's skills, then registers each skill as a callable tool.
+
+---
+
+## Builder Pattern
+
+`NewA2AAgent` provides a fluent API for configuring authentication, headers, timeouts, retry policies, and skill filtering.
+
+```go
+import (
+    "github.com/AltairaLabs/PromptKit/runtime/tools"
+    "github.com/AltairaLabs/PromptKit/sdk"
+)
+
+agent := sdk.NewA2AAgent("https://agent.example.com").
+    WithAuth("Bearer", os.Getenv("AGENT_TOKEN")).
+    WithHeader("X-Tenant-ID", "acme").
+    WithTimeout(5000).
+    WithRetryPolicy(3, 100, 2000).
+    WithSkillFilter(&tools.A2ASkillFilter{
+        Allowlist: []string{"forecast", "alerts"},
+    })
+
+conv, err := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithA2AAgent(agent),
+)
+```
+
+### Builder Methods
+
+| Method | Description |
+|--------|-------------|
+| `WithAuth(scheme, token)` | Set auth credentials (e.g. `"Bearer"`, `"my-token"`) |
+| `WithAuthFromEnv(scheme, envVar)` | Read the token from an environment variable |
+| `WithHeader(key, value)` | Add a static header to every request |
+| `WithHeaderFromEnv(spec)` | Add a header from an env var (`"X-Key=ENV_VAR"`) |
+| `WithTimeout(ms)` | Per-request timeout in milliseconds |
+| `WithRetryPolicy(max, initialMs, maxMs)` | Retry with exponential backoff |
+| `WithSkillFilter(filter)` | Control which skills are exposed |
+
+---
+
+## Authentication
+
+### Direct Token
+
+```go
+agent := sdk.NewA2AAgent("https://agent.example.com").
+    WithAuth("Bearer", "my-secret-token")
+```
+
+### Token from Environment Variable
+
+Keep secrets out of code:
+
+```go
+agent := sdk.NewA2AAgent("https://agent.example.com").
+    WithAuthFromEnv("Bearer", "AGENT_TOKEN")
+```
+
+At startup, the SDK reads `os.Getenv("AGENT_TOKEN")`. If the variable is unset, the agent connects without auth.
+
+---
+
+## Custom Headers
+
+Add static headers or headers resolved from environment variables:
+
+```go
+agent := sdk.NewA2AAgent("https://agent.example.com").
+    WithHeader("X-Tenant-ID", "acme").
+    WithHeader("X-Request-Source", "promptkit").
+    WithHeaderFromEnv("X-API-Key=API_KEY_ENV")
+```
+
+`WithHeaderFromEnv` uses the format `"Header-Name=ENV_VAR_NAME"`. If the env var is unset, the header is silently skipped.
+
+---
+
+## Skill Filtering
+
+When an agent exposes many skills but you only need a few, use a skill filter.
+
+### Allowlist
+
+```go
+agent := sdk.NewA2AAgent("https://weather.example.com").
+    WithSkillFilter(&tools.A2ASkillFilter{
+        Allowlist: []string{"forecast", "alerts"},
+    })
+```
+
+### Blocklist
+
+```go
+agent := sdk.NewA2AAgent("https://agent.example.com").
+    WithSkillFilter(&tools.A2ASkillFilter{
+        Blocklist: []string{"debug", "admin"},
+    })
+```
+
+If both are set, allowlist takes precedence.
+
+---
+
+## Multiple Agents
+
+Register multiple A2A agents in a single conversation:
+
+```go
+research := sdk.NewA2AAgent("https://research.example.com").
+    WithAuth("Bearer", os.Getenv("RESEARCH_TOKEN"))
+
+translation := sdk.NewA2AAgent("https://translate.example.com").
+    WithAuth("Bearer", os.Getenv("TRANSLATE_TOKEN"))
+
+conv, err := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithA2AAgent(research),
+    sdk.WithA2AAgent(translation),
+)
+```
+
+---
+
+## Tool Naming
+
+Each agent skill becomes a tool named:
+
+```
+a2a__{agentName}__{skillId}
+```
+
+Names are sanitized: lowercased, with non-alphanumeric runs replaced by underscores.
+
+| Agent Name | Skill ID | Tool Name |
+|------------|----------|-----------|
+| `Research Agent` | `search_papers` | `a2a__research_agent__search_papers` |
+| `Weather Bot` | `forecast` | `a2a__weather_bot__forecast` |
+
+Reference these in `allowed_tools` to control LLM access:
+
+```yaml
+spec:
+  allowed_tools:
+    - a2a__research_agent__search_papers
+```
+
+---
+
+## Legacy Bridge Pattern
+
+For lower-level control, you can create a `ToolBridge` manually:
+
+```go
+import "github.com/AltairaLabs/PromptKit/runtime/a2a"
+
+client := a2a.NewClient("https://agent.example.com")
+bridge := a2a.NewToolBridge(client)
+bridge.RegisterAgent(ctx)
+
+conv, err := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithA2ATools(bridge),
+)
+```
+
+The builder pattern (`NewA2AAgent`) is preferred for new code — it handles auth, headers, retries, and skill filtering automatically.
+
+---
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/AltairaLabs/PromptKit/runtime/tools"
+    "github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func main() {
+    agent := sdk.NewA2AAgent("http://localhost:9877").
+        WithAuth("Bearer", os.Getenv("ECHO_AGENT_TOKEN")).
+        WithHeader("X-Request-Source", "sdk-example").
+        WithTimeout(5000).
+        WithRetryPolicy(3, 100, 2000).
+        WithSkillFilter(&tools.A2ASkillFilter{
+            Allowlist: []string{"echo"},
+        })
+
+    conv, err := sdk.Open("./app.pack.json", "assistant",
+        sdk.WithA2AAgent(agent),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer conv.Close()
+
+    ctx := context.Background()
+    resp, err := conv.Send(ctx, "Echo: Hello from the SDK!")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(resp.Text())
+}
+```
+
+---
+
+## Next Steps
+
+- [Use Tool Bridge (Runtime)](/runtime/how-to/use-a2a-tool-bridge/) — low-level bridge API
+- [Test A2A Agents (Arena)](/arena/how-to/test-a2a-agents/) — end-to-end testing with mock agents
+- [Register Tools](/sdk/how-to/register-tools/) — add custom Go tools alongside A2A tools

--- a/docs/src/content/docs/sdk/how-to/index.md
+++ b/docs/src/content/docs/sdk/how-to/index.md
@@ -16,6 +16,11 @@ Practical, task-focused guides for common SDK operations.
 - **[HTTP Tools](http-tools)** - External API calls with `OnToolHTTP()`
 - **[HITL Workflows](hitl-workflows)** - Approval with `OnToolAsync()`
 
+## Integrations
+
+- **[Configure MCP Servers](configure-mcp)** - Connect MCP tool servers with `NewMCPServer()` and `WithMCPServer()`
+- **[Connect A2A Agents](connect-a2a-agents)** - Register remote A2A agents with `NewA2AAgent()` and `WithA2AAgent()`
+
 ## Variables & Templates
 
 - **[Manage Variables](manage-state)** - Use `SetVar()` and `GetVar()`
@@ -100,6 +105,12 @@ hooks.On(conv, events.EventProviderCallCompleted, func(e *events.Event) {
 
 1. [Register Tools](register-tools)
 2. [HTTP Tools](http-tools) (for external APIs)
+3. [Configure MCP Servers](configure-mcp) (for MCP tools)
+
+### Connecting External Agents
+
+1. [Connect A2A Agents](connect-a2a-agents)
+2. [Configure MCP Servers](configure-mcp)
 
 ### Building Safe AI Agents
 


### PR DESCRIPTION
## Summary

- **SDK: Configure MCP Servers** — builder pattern with `NewMCPServer()`, tool filtering, multiple servers, tool naming conventions
- **SDK: Connect A2A Agents** — `NewA2AAgent()` builder with auth, headers, retry, skill filtering, legacy bridge comparison
- **Arena: Test MCP Tools** — `mcp_servers` config with tool filtering, env vars, timeouts, mock LLM responses, assertions
- **Arena: Test A2A Agents (updated)** — remote agents with `url`, `auth`, `headers`, `headers_from_env`, `skill_filter`, `timeout_ms`
- **Index updates** — SDK and Arena how-to index pages link to new guides

## Test plan

- [x] `npm run build` in `docs/` succeeds (208 pages built)
- [ ] Visual review of rendered pages
