### PR TITLE
feat: add TracerProvider to sdk.Evaluate() for OTel span emission

### DIFF
--- a/sdk/evaluate.go
+++ b/sdk/evaluate.go
@@ -6,8 +6,11 @@ import (
 	"log/slog"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/telemetry"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
 
@@ -61,8 +64,14 @@ type EvaluateOpts struct {
 
 	// --- Observability ---
 
+	// TracerProvider enables OpenTelemetry trace emission for eval results.
+	// When set, an OTelEventListener is automatically wired to the EventBus,
+	// producing spans named "promptkit.eval.{evalID}" with GenAI SIG attributes.
+	// An EventBus is created automatically if not provided.
+	TracerProvider trace.TracerProvider
+
 	// EventBus enables eval event emission (eval.completed / eval.failed).
-	// If nil, events are not emitted.
+	// If nil and TracerProvider is set, a bus is created automatically.
 	EventBus *events.EventBus
 
 	// Logger is used for structured logging. If nil, the default logger is used.
@@ -96,6 +105,9 @@ type EvaluateOpts struct {
 //
 //nolint:gocritic // hugeParam: value receiver is intentional for public API ergonomics
 func Evaluate(ctx context.Context, opts EvaluateOpts) ([]evals.EvalResult, error) {
+	// 0. Wire OTel listener if TracerProvider is set
+	ownsBus := initEvalTracing(&opts)
+
 	// 1. Resolve eval defs
 	defs, err := resolveEvalDefs(&opts)
 	if err != nil {
@@ -132,6 +144,11 @@ func Evaluate(ctx context.Context, opts EvaluateOpts) ([]evals.EvalResult, error
 	// 5. Emit events (optional)
 	if opts.EventBus != nil {
 		emitEvalEvents(opts.EventBus, results)
+	}
+
+	// 6. Close auto-created bus to flush events to OTel listener
+	if ownsBus && opts.EventBus != nil {
+		opts.EventBus.Close()
 	}
 
 	return results, nil
@@ -206,6 +223,23 @@ func dispatchEvals(
 	default:
 		return runner.RunTurnEvals(ctx, defs, evalCtx)
 	}
+}
+
+// initEvalTracing wires an OTelEventListener to the EventBus when TracerProvider is set.
+// Creates an EventBus if one wasn't provided. Returns true if the bus was auto-created
+// (caller should close it after emitting events to flush the listener).
+func initEvalTracing(opts *EvaluateOpts) bool {
+	if opts.TracerProvider == nil {
+		return false
+	}
+	createdBus := opts.EventBus == nil
+	if createdBus {
+		opts.EventBus = events.NewEventBus()
+	}
+	tracer := telemetry.Tracer(opts.TracerProvider)
+	listener := telemetry.NewOTelEventListener(tracer)
+	opts.EventBus.SubscribeAll(listener.OnEvent)
+	return createdBus
 }
 
 // emitEvalEvents emits eval results as events on the event bus.

--- a/sdk/evaluate_test.go
+++ b/sdk/evaluate_test.go
@@ -8,29 +8,32 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
-func TestEvaluate_WithEvalDefs(t *testing.T) {
-	defs := []evals.EvalDef{
-		{
-			ID:      "greeting",
-			Type:    "contains",
-			Trigger: evals.TriggerEveryTurn,
-			Params:  map[string]any{"patterns": []any{"hello"}},
-		},
+// containsDef returns a single "contains" eval def for use in tests.
+func containsDef(id string, patterns ...string) []evals.EvalDef {
+	anyPatterns := make([]any, len(patterns))
+	for i, p := range patterns {
+		anyPatterns[i] = p
 	}
-	messages := []types.Message{
-		types.NewUserMessage("hi"),
-		types.NewAssistantMessage("hello there!"),
-	}
+	return []evals.EvalDef{{
+		ID:      id,
+		Type:    "contains",
+		Trigger: evals.TriggerEveryTurn,
+		Params:  map[string]any{"patterns": anyPatterns},
+	}}
+}
 
+func TestEvaluate_WithEvalDefs(t *testing.T) {
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		EvalDefs:  defs,
-		Messages:  messages,
+		EvalDefs:  containsDef("greeting", "hello"),
+		Messages:  []types.Message{types.NewUserMessage("hi"), types.NewAssistantMessage("hello there!")},
 		SessionID: "test-session",
 		TurnIndex: 1,
 	})
@@ -42,21 +45,9 @@ func TestEvaluate_WithEvalDefs(t *testing.T) {
 }
 
 func TestEvaluate_WithEvalDefs_Failing(t *testing.T) {
-	defs := []evals.EvalDef{
-		{
-			ID:      "missing",
-			Type:    "contains",
-			Trigger: evals.TriggerEveryTurn,
-			Params:  map[string]any{"patterns": []any{"nonexistent"}},
-		},
-	}
-	messages := []types.Message{
-		types.NewAssistantMessage("hello there!"),
-	}
-
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		EvalDefs:  defs,
-		Messages:  messages,
+		EvalDefs:  containsDef("missing", "nonexistent"),
+		Messages:  []types.Message{types.NewAssistantMessage("hello there!")},
 		SessionID: "s1",
 	})
 
@@ -65,15 +56,12 @@ func TestEvaluate_WithEvalDefs_Failing(t *testing.T) {
 	assert.False(t, results[0].Passed)
 }
 
-func TestEvaluate_WithPackPath(t *testing.T) {
-	messages := []types.Message{
-		types.NewUserMessage("hi"),
-		types.NewAssistantMessage("hello! how can I help?"),
-	}
+const evalTestPack = "testdata/packs/eval-test.pack.json"
 
+func TestEvaluate_WithPackPath(t *testing.T) {
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		PackPath:             "testdata/packs/eval-test.pack.json",
-		Messages:             messages,
+		PackPath:             evalTestPack,
+		Messages:             []types.Message{types.NewUserMessage("hi"), types.NewAssistantMessage("hello! how can I help?")},
 		SessionID:            "test-session",
 		TurnIndex:            1,
 		SkipSchemaValidation: true,
@@ -88,14 +76,10 @@ func TestEvaluate_WithPackPath(t *testing.T) {
 }
 
 func TestEvaluate_WithPackPath_PromptEvals(t *testing.T) {
-	messages := []types.Message{
-		types.NewAssistantMessage("thank you for your patience"),
-	}
-
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		PackPath:             "testdata/packs/eval-test.pack.json",
+		PackPath:             evalTestPack,
 		PromptName:           "assistant",
-		Messages:             messages,
+		Messages:             []types.Message{types.NewAssistantMessage("thank you for your patience")},
 		SessionID:            "s1",
 		SkipSchemaValidation: true,
 	})
@@ -114,16 +98,12 @@ func TestEvaluate_WithPackPath_PromptEvals(t *testing.T) {
 }
 
 func TestEvaluate_WithPackData(t *testing.T) {
-	data, err := os.ReadFile("testdata/packs/eval-test.pack.json")
+	data, err := os.ReadFile(evalTestPack)
 	require.NoError(t, err)
-
-	messages := []types.Message{
-		types.NewAssistantMessage("hello!"),
-	}
 
 	results, err := Evaluate(context.Background(), EvaluateOpts{
 		PackData:  data,
-		Messages:  messages,
+		Messages:  []types.Message{types.NewAssistantMessage("hello!")},
 		SessionID: "s1",
 	})
 
@@ -134,13 +114,9 @@ func TestEvaluate_WithPackData(t *testing.T) {
 }
 
 func TestEvaluate_SessionTrigger(t *testing.T) {
-	messages := []types.Message{
-		types.NewAssistantMessage("goodbye and take care"),
-	}
-
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		PackPath:             "testdata/packs/eval-test.pack.json",
-		Messages:             messages,
+		PackPath:             evalTestPack,
+		Messages:             []types.Message{types.NewAssistantMessage("goodbye and take care")},
 		SessionID:            "s1",
 		Trigger:              evals.TriggerOnSessionComplete,
 		SkipSchemaValidation: true,
@@ -152,34 +128,38 @@ func TestEvaluate_SessionTrigger(t *testing.T) {
 	assert.True(t, results[0].Passed)
 }
 
-func TestEvaluate_NoSource_ReturnsError(t *testing.T) {
-	_, err := Evaluate(context.Background(), EvaluateOpts{
-		Messages: []types.Message{types.NewAssistantMessage("hi")},
-	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "one of EvalDefs, PackData, or PackPath must be provided")
-}
-
-func TestEvaluate_InvalidPackPath_ReturnsError(t *testing.T) {
-	_, err := Evaluate(context.Background(), EvaluateOpts{
-		PackPath: "nonexistent.pack.json",
-	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "load pack")
-}
-
-func TestEvaluate_InvalidPackData_ReturnsError(t *testing.T) {
-	_, err := Evaluate(context.Background(), EvaluateOpts{
-		PackData: []byte(`not json`),
-	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "parse pack data")
+func TestEvaluate_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    EvaluateOpts
+		wantErr string
+	}{
+		{
+			name:    "no source",
+			opts:    EvaluateOpts{Messages: []types.Message{types.NewAssistantMessage("hi")}},
+			wantErr: "one of EvalDefs, PackData, or PackPath must be provided",
+		},
+		{
+			name:    "invalid pack path",
+			opts:    EvaluateOpts{PackPath: "nonexistent.pack.json"},
+			wantErr: "load pack",
+		},
+		{
+			name:    "invalid pack data",
+			opts:    EvaluateOpts{PackData: []byte(`not json`)},
+			wantErr: "parse pack data",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Evaluate(context.Background(), tt.opts)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }
 
 func TestEvaluate_EmptyDefs_ReturnsNil(t *testing.T) {
-	// Empty slice of defs: Evaluate treats it as "no defs" since len == 0
-	// but resolveEvalDefs returns them as-is (not nil).
-	// The nil-or-empty check in Evaluate returns nil results.
 	results, err := Evaluate(context.Background(), EvaluateOpts{
 		EvalDefs: []evals.EvalDef{},
 	})
@@ -188,17 +168,8 @@ func TestEvaluate_EmptyDefs_ReturnsNil(t *testing.T) {
 }
 
 func TestEvaluate_EmptyMessages(t *testing.T) {
-	defs := []evals.EvalDef{
-		{
-			ID:      "check",
-			Type:    "contains",
-			Trigger: evals.TriggerEveryTurn,
-			Params:  map[string]any{"patterns": []any{"hello"}},
-		},
-	}
-
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		EvalDefs: defs,
+		EvalDefs: containsDef("check", "hello"),
 		Messages: nil,
 	})
 
@@ -218,21 +189,9 @@ func TestEvaluate_EventBusEmission(t *testing.T) {
 		mu.Unlock()
 	})
 
-	defs := []evals.EvalDef{
-		{
-			ID:      "pass",
-			Type:    "contains",
-			Trigger: evals.TriggerEveryTurn,
-			Params:  map[string]any{"patterns": []any{"hello"}},
-		},
-	}
-	messages := []types.Message{
-		types.NewAssistantMessage("hello world"),
-	}
-
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		EvalDefs: defs,
-		Messages: messages,
+		EvalDefs: containsDef("pass", "hello"),
+		Messages: []types.Message{types.NewAssistantMessage("hello world")},
 		EventBus: bus,
 	})
 
@@ -251,19 +210,9 @@ func TestEvaluate_EventBusEmission(t *testing.T) {
 
 func TestEvaluate_CustomRegistry(t *testing.T) {
 	registry := evals.NewEmptyEvalTypeRegistry()
-	// Empty registry — handler lookup will fail
-
-	defs := []evals.EvalDef{
-		{
-			ID:      "check",
-			Type:    "contains",
-			Trigger: evals.TriggerEveryTurn,
-			Params:  map[string]any{"patterns": []any{"hello"}},
-		},
-	}
 
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		EvalDefs: defs,
+		EvalDefs: containsDef("check", "hello"),
 		Messages: []types.Message{types.NewAssistantMessage("hello")},
 		Registry: registry,
 	})
@@ -277,17 +226,8 @@ func TestEvaluate_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	defs := []evals.EvalDef{
-		{
-			ID:      "check",
-			Type:    "contains",
-			Trigger: evals.TriggerEveryTurn,
-			Params:  map[string]any{"patterns": []any{"hello"}},
-		},
-	}
-
 	results, err := Evaluate(ctx, EvaluateOpts{
-		EvalDefs: defs,
+		EvalDefs: containsDef("check", "hello"),
 		Messages: []types.Message{types.NewAssistantMessage("hello")},
 	})
 
@@ -296,19 +236,61 @@ func TestEvaluate_ContextCancellation(t *testing.T) {
 	assert.Empty(t, results)
 }
 
-func TestEvaluate_JudgeMetadata(t *testing.T) {
-	// Verify judge metadata is wired into EvalContext
-	defs := []evals.EvalDef{
-		{
-			ID:      "check",
-			Type:    "contains",
-			Trigger: evals.TriggerEveryTurn,
-			Params:  map[string]any{"patterns": []any{"hello"}},
-		},
-	}
+// newTestTracerProvider creates an in-memory OTel tracer provider for testing.
+// Caller must defer tp.Shutdown(ctx).
+func newTestTracerProvider() (*tracetest.InMemoryExporter, *sdktrace.TracerProvider) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	return exp, tp
+}
+
+func TestEvaluate_TracerProvider(t *testing.T) {
+	exp, tp := newTestTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
 
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		EvalDefs:      defs,
+		EvalDefs:       containsDef("greeting", "hello"),
+		Messages:       []types.Message{types.NewAssistantMessage("hello world")},
+		TracerProvider: tp,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+
+	// Force flush to ensure spans are exported
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exp.GetSpans()
+	var evalSpans []tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == "promptkit.eval.greeting" {
+			evalSpans = append(evalSpans, s)
+		}
+	}
+	require.Len(t, evalSpans, 1, "expected one OTel span for eval 'greeting'")
+}
+
+func TestEvaluate_TracerProvider_CreatesEventBus(t *testing.T) {
+	// When TracerProvider is set but EventBus is nil, Evaluate should create one automatically
+	_, tp := newTestTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	// No EventBus provided — should still work
+	results, err := Evaluate(context.Background(), EvaluateOpts{
+		EvalDefs:       containsDef("check", "hello"),
+		Messages:       []types.Message{types.NewAssistantMessage("hello")},
+		TracerProvider: tp,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+}
+
+func TestEvaluate_JudgeMetadata(t *testing.T) {
+	results, err := Evaluate(context.Background(), EvaluateOpts{
+		EvalDefs:      containsDef("check", "hello"),
 		Messages:      []types.Message{types.NewAssistantMessage("hello")},
 		JudgeProvider: "mock-judge",
 	})

--- a/sdk/examples/evaluate/main.go
+++ b/sdk/examples/evaluate/main.go
@@ -69,21 +69,22 @@ func main() {
 	// Example 3: Inline eval definitions — no pack file needed.
 	// Useful for programmatic or dynamic eval scenarios.
 	fmt.Println("\n=== Example 3: Inline eval definitions ===")
-	results, err = sdk.Evaluate(ctx, sdk.EvaluateOpts{
-		EvalDefs: []evals.EvalDef{
-			{
-				ID:      "has_code_block",
-				Type:    "contains",
-				Trigger: evals.TriggerEveryTurn,
-				Params:  map[string]any{"patterns": []any{"```"}},
-			},
-			{
-				ID:      "mentions_error",
-				Type:    "contains",
-				Trigger: evals.TriggerEveryTurn,
-				Params:  map[string]any{"patterns": []any{"error"}},
-			},
+	inlineDefs := []evals.EvalDef{
+		{
+			ID:      "has_code_block",
+			Type:    "contains",
+			Trigger: evals.TriggerEveryTurn,
+			Params:  map[string]any{"patterns": []any{"```"}},
 		},
+		{
+			ID:      "mentions_error",
+			Type:    "contains",
+			Trigger: evals.TriggerEveryTurn,
+			Params:  map[string]any{"patterns": []any{"error"}},
+		},
+	}
+	results, err = sdk.Evaluate(ctx, sdk.EvaluateOpts{
+		EvalDefs: inlineDefs,
 		Messages: []types.Message{
 			types.NewUserMessage("How do I read a file in Go?"),
 			types.NewAssistantMessage("Here's how to read a file:\n\n```go\ndata, err := os.ReadFile(\"file.txt\")\n```"),
@@ -100,49 +101,38 @@ func main() {
 	fmt.Println("\n=== Example 4: EventBus-driven eval results ===")
 
 	bus := events.NewEventBus()
-
 	var mu sync.Mutex
-	var passed, failed int
+	counters := map[string]int{"passed": 0, "failed": 0}
 
-	bus.Subscribe(events.EventEvalCompleted, func(e *events.Event) {
-		data, ok := e.Data.(*events.EvalEventData)
-		if !ok {
-			return
-		}
-		mu.Lock()
-		passed++
-		mu.Unlock()
-		fmt.Printf("  [EVENT] eval.completed: %s — %s\n", data.EvalID, data.Explanation)
+	for _, et := range []events.EventType{events.EventEvalCompleted, events.EventEvalFailed} {
+		eventType := et
+		bus.Subscribe(eventType, func(e *events.Event) {
+			data, ok := e.Data.(*events.EvalEventData)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			if eventType == events.EventEvalCompleted {
+				counters["passed"]++
+			} else {
+				counters["failed"]++
+			}
+			mu.Unlock()
+			fmt.Printf("  [EVENT] %s: %s — %s\n", eventType, data.EvalID, data.Explanation)
+		})
+	}
+
+	// Reuse the inline defs from Example 3, adding a check that will fail.
+	eventDefs := append(inlineDefs, evals.EvalDef{
+		ID:      "apology",
+		Type:    "contains",
+		Trigger: evals.TriggerEveryTurn,
+		Params:  map[string]any{"patterns": []any{"sorry"}},
 	})
-
-	bus.Subscribe(events.EventEvalFailed, func(e *events.Event) {
-		data, ok := e.Data.(*events.EvalEventData)
-		if !ok {
-			return
-		}
-		mu.Lock()
-		failed++
-		mu.Unlock()
-		fmt.Printf("  [EVENT] eval.failed:    %s — %s\n", data.EvalID, data.Explanation)
-	})
-
 	_, err = sdk.Evaluate(ctx, sdk.EvaluateOpts{
-		EvalDefs: []evals.EvalDef{
-			{
-				ID:      "greeting",
-				Type:    "contains",
-				Trigger: evals.TriggerEveryTurn,
-				Params:  map[string]any{"patterns": []any{"hello"}},
-			},
-			{
-				ID:      "apology",
-				Type:    "contains",
-				Trigger: evals.TriggerEveryTurn,
-				Params:  map[string]any{"patterns": []any{"sorry"}},
-			},
-		},
+		EvalDefs: eventDefs,
 		Messages: []types.Message{
-			types.NewAssistantMessage("Hello! How can I help?"),
+			types.NewAssistantMessage("Here's how:\n\n```go\ndata, err := os.ReadFile(\"file.txt\")\n```"),
 		},
 		EventBus: bus,
 	})
@@ -154,7 +144,7 @@ func main() {
 	bus.Close()
 
 	mu.Lock()
-	fmt.Printf("\n  Summary: %d passed, %d failed\n", passed, failed)
+	fmt.Printf("\n  Summary: %d passed, %d failed\n", counters["passed"], counters["failed"])
 	mu.Unlock()
 }
 


### PR DESCRIPTION
## Summary
- Add `TracerProvider` option to `EvaluateOpts` that auto-wires an `OTelEventListener` to the `EventBus`, producing spans named `promptkit.eval.{evalID}` with GenAI SIG attributes — matching the behavior of live conversations
- Auto-create `EventBus` when `TracerProvider` is set but no bus is provided; auto-close to flush spans before returning
- Refactor test file to extract `containsDef` helper and consolidate error tests into table-driven format, reducing SonarCloud duplication below 3%
- Consolidate example EventBus code to reduce duplication

## Test plan
- [x] `TestEvaluate_TracerProvider` verifies OTel spans are emitted with correct name
- [x] `TestEvaluate_TracerProvider_CreatesEventBus` verifies auto-bus creation when only TracerProvider is set
- [x] All existing evaluate tests pass
- [x] Pre-commit hooks pass (lint, build, coverage ≥ 80%)