### PR TITLE
fix: populate sessionID in eval/workflow event emitters

### DIFF
--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -514,6 +514,20 @@ func (c *Conversation) getBaseSession() session.BaseSession {
 	return c.duplexSession
 }
 
+// newEmitter creates an events.Emitter for this conversation, populating
+// the sessionID from the active session. Returns nil if the event bus is not
+// configured.
+func (c *Conversation) newEmitter(bus *events.EventBus) *events.Emitter {
+	if bus == nil {
+		return nil
+	}
+	sessionID := ""
+	if s := c.getBaseSession(); s != nil {
+		sessionID = s.ID()
+	}
+	return events.NewEmitter(bus, "", sessionID, "")
+}
+
 // SendChunk sends a streaming chunk in duplex mode.
 // Only available when the conversation was opened with OpenDuplex().
 func (c *Conversation) SendChunk(ctx context.Context, chunk *providers.StreamChunk) error {

--- a/sdk/eval_middleware.go
+++ b/sdk/eval_middleware.go
@@ -78,11 +78,8 @@ func newEvalMiddleware(conv *Conversation) *evalMiddleware {
 		runner = evals.NewEvalRunner(registry)
 	}
 
-	// Build emitter from event bus (nil-safe)
-	var emitter *events.Emitter
-	if conv.config.eventBus != nil {
-		emitter = events.NewEmitter(conv.config.eventBus, "", "", "")
-	}
+	// Build emitter from event bus (nil-safe), populating session ID if available.
+	emitter := conv.newEmitter(conv.config.eventBus)
 
 	maxConcurrent := DefaultMaxConcurrentEvals
 	if conv.config.maxConcurrentEvals > 0 {

--- a/sdk/eval_middleware.go
+++ b/sdk/eval_middleware.go
@@ -175,29 +175,7 @@ func (em *evalMiddleware) emitResults(results []evals.EvalResult) {
 	if em.emitter == nil {
 		return
 	}
-	for i := range results {
-		r := &results[i]
-		data := events.EvalEventData{
-			EvalID:      r.EvalID,
-			EvalType:    r.Type,
-			Passed:      r.Passed,
-			Score:       r.Score,
-			Explanation: r.Explanation,
-			DurationMs:  r.DurationMs,
-			Error:       r.Error,
-			Message:     r.Message,
-			Skipped:     r.Skipped,
-			SkipReason:  r.SkipReason,
-		}
-		for _, v := range r.Violations {
-			data.Violations = append(data.Violations, v.Description)
-		}
-		if r.Passed {
-			em.emitter.EvalCompleted(&data)
-		} else {
-			em.emitter.EvalFailed(&data)
-		}
-	}
+	emitEvalResultsTo(em.emitter, results)
 }
 
 // buildEvalContext creates an EvalContext from the conversation state.

--- a/sdk/eval_middleware_test.go
+++ b/sdk/eval_middleware_test.go
@@ -764,3 +764,43 @@ func TestEvalMiddleware_EmitResults_WithBus(t *testing.T) {
 		}
 	}
 }
+
+func TestEvalMiddleware_EmitResults_IncludesSessionID(t *testing.T) {
+	bus := events.NewEventBus(events.WithWorkerPoolSize(1))
+	defer bus.Close()
+
+	received := make(chan *events.Event, 10)
+	bus.Subscribe(events.EventEvalCompleted, func(e *events.Event) {
+		received <- e
+	})
+
+	// Create a conversation with a real unary session that has a known ID.
+	conv := newTestConversation()
+	conv.config.eventBus = bus
+	conv.pack.Evals = []evals.EvalDef{
+		{ID: "e1", Type: "contains", Trigger: evals.TriggerEveryTurn},
+	}
+
+	mw := newEvalMiddleware(conv)
+	if mw == nil {
+		t.Fatal("expected non-nil middleware")
+	}
+
+	mw.emitResults([]evals.EvalResult{
+		{EvalID: "e1", Type: "contains", Passed: true},
+	})
+
+	select {
+	case e := <-received:
+		// The session ID should match the conversation's session ID.
+		expectedID := conv.ID()
+		if e.SessionID != expectedID {
+			t.Errorf("expected SessionID %q on eval event, got %q", expectedID, e.SessionID)
+		}
+		if e.SessionID == "" {
+			t.Error("eval event SessionID must not be empty when session is available")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for eval event")
+	}
+}

--- a/sdk/evaluate.go
+++ b/sdk/evaluate.go
@@ -282,6 +282,12 @@ func registerExecEvalHandlers(registry *evals.EvalTypeRegistry, path string) err
 // emitEvalEvents emits eval results as events on the event bus.
 func emitEvalEvents(bus *events.EventBus, sessionID string, results []evals.EvalResult) {
 	emitter := events.NewEmitter(bus, "", sessionID, "")
+	emitEvalResultsTo(emitter, results)
+}
+
+// emitEvalResultsTo emits eval results through the given emitter.
+// Shared by the standalone Evaluate() path and the eval middleware.
+func emitEvalResultsTo(emitter *events.Emitter, results []evals.EvalResult) {
 	for i := range results {
 		r := &results[i]
 		data := events.EvalEventData{

--- a/sdk/evaluate.go
+++ b/sdk/evaluate.go
@@ -157,7 +157,7 @@ func Evaluate(ctx context.Context, opts EvaluateOpts) ([]evals.EvalResult, error
 
 	// 5. Emit events (optional)
 	if opts.EventBus != nil {
-		emitEvalEvents(opts.EventBus, results)
+		emitEvalEvents(opts.EventBus, opts.SessionID, results)
 	}
 
 	// 6. Close auto-created bus to flush events to OTel listener
@@ -280,8 +280,8 @@ func registerExecEvalHandlers(registry *evals.EvalTypeRegistry, path string) err
 }
 
 // emitEvalEvents emits eval results as events on the event bus.
-func emitEvalEvents(bus *events.EventBus, results []evals.EvalResult) {
-	emitter := events.NewEmitter(bus, "", "", "")
+func emitEvalEvents(bus *events.EventBus, sessionID string, results []evals.EvalResult) {
+	emitter := events.NewEmitter(bus, "", sessionID, "")
 	for i := range results {
 		r := &results[i]
 		data := events.EvalEventData{

--- a/sdk/evaluate_test.go
+++ b/sdk/evaluate_test.go
@@ -208,6 +208,37 @@ func TestEvaluate_EventBusEmission(t *testing.T) {
 	assert.Equal(t, events.EventEvalCompleted, received[0].Type)
 }
 
+func TestEvaluate_EventBusIncludesSessionID(t *testing.T) {
+	bus := events.NewEventBus()
+
+	var mu sync.Mutex
+	var received []*events.Event
+	bus.Subscribe(events.EventEvalCompleted, func(e *events.Event) {
+		mu.Lock()
+		received = append(received, e)
+		mu.Unlock()
+	})
+
+	results, err := Evaluate(context.Background(), EvaluateOpts{
+		EvalDefs:  containsDef("pass", "hello"),
+		Messages:  []types.Message{types.NewAssistantMessage("hello world")},
+		EventBus:  bus,
+		SessionID: "eval-session-456",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+
+	bus.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(received), 1)
+	assert.Equal(t, "eval-session-456", received[0].SessionID,
+		"eval events from Evaluate() should include the SessionID from opts")
+}
+
 func TestEvaluate_CustomRegistry(t *testing.T) {
 	registry := evals.NewEmptyEvalTypeRegistry()
 

--- a/sdk/evaluate_test.go
+++ b/sdk/evaluate_test.go
@@ -190,9 +190,10 @@ func TestEvaluate_EventBusEmission(t *testing.T) {
 	})
 
 	results, err := Evaluate(context.Background(), EvaluateOpts{
-		EvalDefs: containsDef("pass", "hello"),
-		Messages: []types.Message{types.NewAssistantMessage("hello world")},
-		EventBus: bus,
+		EvalDefs:  containsDef("pass", "hello"),
+		Messages:  []types.Message{types.NewAssistantMessage("hello world")},
+		EventBus:  bus,
+		SessionID: "eval-session-456",
 	})
 
 	require.NoError(t, err)
@@ -206,35 +207,6 @@ func TestEvaluate_EventBusEmission(t *testing.T) {
 	defer mu.Unlock()
 	require.GreaterOrEqual(t, len(received), 1)
 	assert.Equal(t, events.EventEvalCompleted, received[0].Type)
-}
-
-func TestEvaluate_EventBusIncludesSessionID(t *testing.T) {
-	bus := events.NewEventBus()
-
-	var mu sync.Mutex
-	var received []*events.Event
-	bus.Subscribe(events.EventEvalCompleted, func(e *events.Event) {
-		mu.Lock()
-		received = append(received, e)
-		mu.Unlock()
-	})
-
-	results, err := Evaluate(context.Background(), EvaluateOpts{
-		EvalDefs:  containsDef("pass", "hello"),
-		Messages:  []types.Message{types.NewAssistantMessage("hello world")},
-		EventBus:  bus,
-		SessionID: "eval-session-456",
-	})
-
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.True(t, results[0].Passed)
-
-	bus.Close()
-
-	mu.Lock()
-	defer mu.Unlock()
-	require.GreaterOrEqual(t, len(received), 1)
 	assert.Equal(t, "eval-session-456", received[0].SessionID,
 		"eval events from Evaluate() should include the SessionID from opts")
 }

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -217,12 +217,12 @@ func ResumeWorkflow(workflowID, packPath string, opts ...Option) (*WorkflowConve
 		sdkPack:             p,
 		activeConv:          conv,
 		opts:                opts,
-		emitter:             conv.newEmitter(cfg.eventBus),
 		stateStore:          cfg.stateStore,
 		workflowID:          workflowID,
 		contextCarryForward: cfg.contextCarryForward,
 		workflowCap:         wfCap,
 	}
+	wc.emitter = conv.newEmitter(cfg.eventBus)
 
 	// Register workflow tools for the current state
 	wc.registerWorkflowTools()

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -110,12 +110,6 @@ func OpenWorkflow(packPath string, opts ...Option) (*WorkflowConversation, error
 			machine.CurrentState(), promptName, err)
 	}
 
-	// Create emitter from event bus if configured
-	var emitter *events.Emitter
-	if cfg.eventBus != nil {
-		emitter = events.NewEmitter(cfg.eventBus, "", "", "")
-	}
-
 	// Create and init WorkflowCapability
 	wfCap := NewWorkflowCapability()
 	if err := wfCap.Init(CapabilityContext{Pack: p, PromptName: promptName}); err != nil {
@@ -130,7 +124,7 @@ func OpenWorkflow(packPath string, opts ...Option) (*WorkflowConversation, error
 		sdkPack:             p,
 		activeConv:          conv,
 		opts:                opts,
-		emitter:             emitter,
+		emitter:             conv.newEmitter(cfg.eventBus),
 		stateStore:          cfg.stateStore,
 		workflowID:          cfg.conversationID,
 		contextCarryForward: cfg.contextCarryForward,
@@ -209,11 +203,6 @@ func ResumeWorkflow(workflowID, packPath string, opts ...Option) (*WorkflowConve
 			machine.CurrentState(), promptName, err)
 	}
 
-	var emitter *events.Emitter
-	if cfg.eventBus != nil {
-		emitter = events.NewEmitter(cfg.eventBus, "", "", "")
-	}
-
 	// Create and init WorkflowCapability
 	wfCap := NewWorkflowCapability()
 	if err := wfCap.Init(CapabilityContext{Pack: p, PromptName: promptName}); err != nil {
@@ -228,7 +217,7 @@ func ResumeWorkflow(workflowID, packPath string, opts ...Option) (*WorkflowConve
 		sdkPack:             p,
 		activeConv:          conv,
 		opts:                opts,
-		emitter:             emitter,
+		emitter:             conv.newEmitter(cfg.eventBus),
 		stateStore:          cfg.stateStore,
 		workflowID:          workflowID,
 		contextCarryForward: cfg.contextCarryForward,


### PR DESCRIPTION
## Summary

Fixes #705.

- `events.NewEmitter()` was called with empty `sessionID` in eval middleware, standalone `Evaluate()`, and workflow transitions, causing event stores that filter on SessionID to silently drop eval/workflow events.
- Added `Conversation.newEmitter()` helper that reads sessionID from the active session (nil-safe).
- Used the helper in `eval_middleware.go` and `workflow.go` (2 sites).
- Passed `opts.SessionID` through to `emitEvalEvents` in `evaluate.go`.

## Test plan

- [x] `TestEvalMiddleware_EmitResults_IncludesSessionID` — verifies eval events from middleware carry the session ID
- [x] `TestEvaluate_EventBusIncludesSessionID` — verifies standalone `Evaluate()` events carry the caller-provided session ID
- [x] Full SDK test suite passes with race detector (`go test -race ./sdk/...`)
- [x] All changed files meet 80% coverage threshold