### PR TITLE
feat: add MetricRecorder and ValidateEvalTypes to sdk.Evaluate

### DIFF
--- a/sdk/evaluate.go
+++ b/sdk/evaluate.go
@@ -84,6 +84,13 @@ type EvaluateOpts struct {
 	// If Registry is also provided, the exec handlers are registered into it.
 	RuntimeConfigPath string
 
+	// --- Metrics ---
+
+	// MetricRecorder records eval results as metrics (e.g. Prometheus gauges,
+	// counters, histograms) based on Metric definitions in each EvalDef.
+	// If nil, no metrics are recorded.
+	MetricRecorder evals.MetricRecorder
+
 	// --- Eval execution ---
 
 	// Registry overrides the default eval type registry.
@@ -160,7 +167,15 @@ func Evaluate(ctx context.Context, opts EvaluateOpts) ([]evals.EvalResult, error
 		emitEvalEvents(opts.EventBus, opts.SessionID, results)
 	}
 
-	// 6. Close auto-created bus to flush events to OTel listener
+	// 6. Record metrics (optional)
+	if opts.MetricRecorder != nil {
+		writer := evals.NewMetricResultWriter(opts.MetricRecorder, defs)
+		if err := writer.WriteResults(ctx, results); err != nil {
+			return results, fmt.Errorf("record metrics: %w", err)
+		}
+	}
+
+	// 7. Close auto-created bus to flush OTel listener
 	if ownsBus && opts.EventBus != nil {
 		opts.EventBus.Close()
 	}
@@ -277,6 +292,79 @@ func registerExecEvalHandlers(registry *evals.EvalTypeRegistry, path string) err
 		registry.Register(handler)
 	}
 	return nil
+}
+
+// ValidateEvalTypesOpts configures eval type validation.
+type ValidateEvalTypesOpts struct {
+	// --- Pack source (use one of PackPath, PackData, or EvalDefs) ---
+
+	// PackPath loads a PromptPack from the filesystem.
+	PackPath string
+
+	// PackData parses a PromptPack from raw JSON bytes.
+	PackData []byte
+
+	// EvalDefs provides pre-resolved eval definitions directly.
+	EvalDefs []evals.EvalDef
+
+	// PromptName selects which prompt's evals to merge with pack-level evals.
+	// Only used with PackPath or PackData. If empty, only pack-level evals are checked.
+	PromptName string
+
+	// --- Extensibility ---
+
+	// RuntimeConfigPath registers exec eval handlers from a RuntimeConfig YAML file
+	// before validation, so custom eval types are recognized.
+	RuntimeConfigPath string
+
+	// Registry overrides the default eval type registry.
+	// If nil, a registry with all built-in handlers is created.
+	Registry *evals.EvalTypeRegistry
+
+	// SkipSchemaValidation disables JSON schema validation when loading from PackPath.
+	SkipSchemaValidation bool
+}
+
+// ValidateEvalTypes checks that every eval type referenced in the resolved
+// eval definitions has a registered handler in the EvalTypeRegistry.
+// Returns a list of eval IDs whose types are missing, or nil if all are valid.
+//
+// This is useful as a preflight check — e.g. at startup or in CI — to catch
+// configuration errors (typos, missing RuntimeConfig bindings) before evals
+// are actually executed.
+//
+//nolint:gocritic // hugeParam: value receiver is intentional for public API ergonomics
+func ValidateEvalTypes(opts ValidateEvalTypesOpts) ([]evals.EvalDef, error) {
+	// Reuse the same resolution logic as Evaluate().
+	resolveOpts := &EvaluateOpts{
+		PackPath:             opts.PackPath,
+		PackData:             opts.PackData,
+		EvalDefs:             opts.EvalDefs,
+		PromptName:           opts.PromptName,
+		SkipSchemaValidation: opts.SkipSchemaValidation,
+	}
+	defs, err := resolveEvalDefs(resolveOpts)
+	if err != nil {
+		return nil, fmt.Errorf("resolve eval defs: %w", err)
+	}
+
+	registry := opts.Registry
+	if registry == nil {
+		registry = evals.NewEvalTypeRegistry()
+	}
+	if opts.RuntimeConfigPath != "" {
+		if err := registerExecEvalHandlers(registry, opts.RuntimeConfigPath); err != nil {
+			return nil, fmt.Errorf("load runtime config evals: %w", err)
+		}
+	}
+
+	var missing []evals.EvalDef
+	for _, def := range defs {
+		if !registry.Has(def.Type) {
+			missing = append(missing, def)
+		}
+	}
+	return missing, nil
 }
 
 // emitEvalEvents emits eval results as events on the event bus.

--- a/sdk/evaluate_test.go
+++ b/sdk/evaluate_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -348,6 +349,134 @@ func TestEvaluate_RuntimeConfigPath_InvalidPath(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "load runtime config evals")
+}
+
+func TestEvaluate_MetricRecorder(t *testing.T) {
+	defs := []evals.EvalDef{{
+		ID:      "scored-eval",
+		Type:    "contains",
+		Trigger: evals.TriggerEveryTurn,
+		Params:  map[string]any{"patterns": []any{"hello"}},
+		Metric: &evals.MetricDef{
+			Name: "greeting_score",
+			Type: evals.MetricGauge,
+		},
+	}}
+
+	collector := evals.NewMetricCollector(evals.WithNamespace("test"))
+
+	results, err := Evaluate(context.Background(), EvaluateOpts{
+		EvalDefs:       defs,
+		Messages:       []types.Message{types.NewAssistantMessage("hello world")},
+		MetricRecorder: collector,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+
+	// Verify metric was recorded by writing Prometheus output
+	var buf strings.Builder
+	require.NoError(t, collector.WritePrometheus(&buf))
+	output := buf.String()
+	assert.Contains(t, output, "# TYPE test_greeting_score gauge", "metric should have correct Prometheus type")
+	assert.Contains(t, output, "test_greeting_score ", "metric should be recorded with namespace prefix")
+}
+
+func TestEvaluate_MetricRecorder_NoMetricDef(t *testing.T) {
+	// Evals without Metric defs should not cause errors when MetricRecorder is set
+	collector := evals.NewMetricCollector()
+
+	results, err := Evaluate(context.Background(), EvaluateOpts{
+		EvalDefs:       containsDef("simple", "hello"),
+		Messages:       []types.Message{types.NewAssistantMessage("hello")},
+		MetricRecorder: collector,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Passed)
+
+	// No metrics should have been recorded
+	var buf strings.Builder
+	require.NoError(t, collector.WritePrometheus(&buf))
+	assert.Empty(t, buf.String(), "no metrics should be recorded for evals without MetricDef")
+}
+
+func TestValidateEvalTypes_AllRegistered(t *testing.T) {
+	missing, err := ValidateEvalTypes(ValidateEvalTypesOpts{
+		EvalDefs: containsDef("check", "hello"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, missing, "all built-in types should be registered")
+}
+
+func TestValidateEvalTypes_MissingType(t *testing.T) {
+	missing, err := ValidateEvalTypes(ValidateEvalTypesOpts{
+		EvalDefs: []evals.EvalDef{
+			{ID: "good", Type: "contains", Trigger: evals.TriggerEveryTurn},
+			{ID: "bad", Type: "nonexistent_eval_type", Trigger: evals.TriggerEveryTurn},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, missing, 1)
+	assert.Equal(t, "bad", missing[0].ID)
+	assert.Equal(t, "nonexistent_eval_type", missing[0].Type)
+}
+
+func TestValidateEvalTypes_FromPackPath(t *testing.T) {
+	missing, err := ValidateEvalTypes(ValidateEvalTypesOpts{
+		PackPath:             evalTestPack,
+		SkipSchemaValidation: true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, missing, "pack eval types should all be registered")
+}
+
+func TestValidateEvalTypes_RuntimeConfigRegistersHandler(t *testing.T) {
+	script := writeTestScript(t, "#!/bin/sh\necho '{}'")
+	rcYAML := []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: RuntimeConfig
+metadata:
+  name: test
+spec:
+  evals:
+    custom_type:
+      command: ` + script + `
+`)
+	rcPath := t.TempDir() + "/runtime.yaml"
+	require.NoError(t, os.WriteFile(rcPath, rcYAML, 0o644))
+
+	// Without RuntimeConfig, custom_type is missing
+	missing, err := ValidateEvalTypes(ValidateEvalTypesOpts{
+		EvalDefs: []evals.EvalDef{{ID: "ext", Type: "custom_type"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, missing, 1, "custom_type should be missing without RuntimeConfig")
+
+	// With RuntimeConfig, custom_type is registered
+	missing, err = ValidateEvalTypes(ValidateEvalTypesOpts{
+		EvalDefs:          []evals.EvalDef{{ID: "ext", Type: "custom_type"}},
+		RuntimeConfigPath: rcPath,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, missing, "custom_type should be registered via RuntimeConfig")
+}
+
+func TestValidateEvalTypes_EmptyDefs(t *testing.T) {
+	missing, err := ValidateEvalTypes(ValidateEvalTypesOpts{
+		EvalDefs: []evals.EvalDef{},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+}
+
+func TestValidateEvalTypes_InvalidPackPath(t *testing.T) {
+	_, err := ValidateEvalTypes(ValidateEvalTypesOpts{
+		PackPath: "nonexistent.pack.json",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve eval defs")
 }
 
 // writeTestScript creates a temporary executable shell script for tests.

--- a/sdk/examples/evaluate/evaluate.pack.json
+++ b/sdk/examples/evaluate/evaluate.pack.json
@@ -15,6 +15,10 @@
       "trigger": "every_turn",
       "params": {
         "patterns": ["hello"]
+      },
+      "metric": {
+        "name": "greeting_present",
+        "type": "boolean"
       }
     },
     {
@@ -23,6 +27,11 @@
       "trigger": "every_turn",
       "params": {
         "patterns": ["please", "thank"]
+      },
+      "metric": {
+        "name": "politeness",
+        "type": "counter",
+        "labels": { "category": "tone" }
       }
     },
     {
@@ -31,6 +40,10 @@
       "trigger": "on_session_complete",
       "params": {
         "patterns": ["goodbye"]
+      },
+      "metric": {
+        "name": "farewell_present",
+        "type": "gauge"
       }
     }
   ],

--- a/sdk/examples/evaluate/main.go
+++ b/sdk/examples/evaluate/main.go
@@ -6,6 +6,9 @@
 //   - Filtering evals by trigger (every_turn vs on_session_complete)
 //   - Running evals from inline definitions (no pack file needed)
 //   - Receiving eval results via the EventBus for reactive workflows
+//   - Recording eval results as Prometheus metrics via MetricRecorder
+//   - Validating that all eval types are registered before execution
+//   - Extending the eval registry with custom exec handlers via RuntimeConfig
 //
 // Run with:
 //
@@ -16,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
@@ -146,6 +150,109 @@ func main() {
 	mu.Lock()
 	fmt.Printf("\n  Summary: %d passed, %d failed\n", counters["passed"], counters["failed"])
 	mu.Unlock()
+
+	// Example 5: Metrics — record eval results as Prometheus metrics.
+	// Each eval in the pack has a "metric" definition that specifies the
+	// Prometheus metric name and type (boolean, counter, gauge, histogram).
+	// Pass a MetricCollector to Evaluate() to automatically record results.
+	fmt.Println("\n=== Example 5: Prometheus metrics from eval results ===")
+
+	collector := evals.NewMetricCollector(
+		evals.WithNamespace("myapp"),
+		evals.WithLabels(map[string]string{"env": "production"}),
+	)
+
+	results, err = sdk.Evaluate(ctx, sdk.EvaluateOpts{
+		PackPath:             "./evaluate.pack.json",
+		SkipSchemaValidation: true,
+		MetricRecorder:       collector,
+		Messages: []types.Message{
+			types.NewUserMessage("Hi there!"),
+			types.NewAssistantMessage("Hello! How can I help you today?"),
+		},
+		SessionID: "metrics-session",
+		TurnIndex: 1,
+	})
+	if err != nil {
+		log.Fatalf("Evaluate failed: %v", err)
+	}
+	printResults(results)
+
+	fmt.Println("\n  Prometheus output:")
+	if err := collector.WritePrometheus(os.Stdout); err != nil {
+		log.Fatalf("WritePrometheus failed: %v", err)
+	}
+
+	// Example 6: Validate eval types before execution.
+	// ValidateEvalTypes checks that every eval type referenced in the pack
+	// has a registered handler. This is a preflight check — useful at startup
+	// or in CI to catch typos or missing RuntimeConfig bindings early.
+	fmt.Println("\n=== Example 6: Validate eval types (preflight check) ===")
+
+	// All built-in types should be valid.
+	missing, err := sdk.ValidateEvalTypes(sdk.ValidateEvalTypesOpts{
+		PackPath:             "./evaluate.pack.json",
+		SkipSchemaValidation: true,
+	})
+	if err != nil {
+		log.Fatalf("ValidateEvalTypes failed: %v", err)
+	}
+	if len(missing) == 0 {
+		fmt.Println("  All eval types are registered.")
+	}
+
+	// Demonstrate a missing type: "sentiment" is not a built-in handler.
+	missing, err = sdk.ValidateEvalTypes(sdk.ValidateEvalTypesOpts{
+		EvalDefs: []evals.EvalDef{
+			{ID: "tone", Type: "contains"},
+			{ID: "mood", Type: "sentiment"},
+		},
+	})
+	if err != nil {
+		log.Fatalf("ValidateEvalTypes failed: %v", err)
+	}
+	for _, def := range missing {
+		fmt.Printf("  Missing handler: eval %q requires type %q\n", def.ID, def.Type)
+	}
+
+	// Example 7: RuntimeConfig — extend the registry with custom exec handlers.
+	// A RuntimeConfig YAML file can bind eval type names to external commands
+	// (Python scripts, Node.js, shell scripts, etc.). These bindings are
+	// registered into the eval registry so custom types work seamlessly.
+	//
+	// Example runtime-config.yaml:
+	//
+	//   apiVersion: promptkit.altairalabs.ai/v1alpha1
+	//   kind: RuntimeConfig
+	//   metadata:
+	//     name: my-app
+	//   spec:
+	//     evals:
+	//       sentiment:                         # registers "sentiment" eval type
+	//         command: python3
+	//         args: [scripts/sentiment.py]
+	//         timeout_ms: 10000
+	//       toxicity:                          # registers "toxicity" eval type
+	//         command: node
+	//         args: [scripts/toxicity.js]
+	//
+	// With a RuntimeConfig, the "sentiment" type above would pass validation:
+	//
+	//   missing, err := sdk.ValidateEvalTypes(sdk.ValidateEvalTypesOpts{
+	//       EvalDefs:          defs,
+	//       RuntimeConfigPath: "runtime-config.yaml",
+	//   })
+	//
+	// And Evaluate() would run the external command for that eval type:
+	//
+	//   results, err := sdk.Evaluate(ctx, sdk.EvaluateOpts{
+	//       EvalDefs:          defs,
+	//       RuntimeConfigPath: "runtime-config.yaml",
+	//       Messages:          messages,
+	//   })
+	fmt.Println("\n=== Example 7: RuntimeConfig (exec eval handlers) ===")
+	fmt.Println("  (See source code comments for RuntimeConfig YAML format)")
+	fmt.Println("  RuntimeConfigPath can be passed to both Evaluate() and ValidateEvalTypes()")
 }
 
 func printResults(results []evals.EvalResult) {


### PR DESCRIPTION
## Summary
- Add `MetricRecorder` field to `EvaluateOpts` so eval results are automatically recorded as Prometheus metrics (gauge, counter, histogram, boolean) based on `EvalDef.Metric` definitions
- Add `ValidateEvalTypes()` preflight function that checks all eval types in a pack have registered handlers, including custom exec handlers from `RuntimeConfig`
- Update the evaluate SDK example with new demos for metrics recording, type validation, and RuntimeConfig extensibility
- Add metric definitions to the example pack (boolean, counter, gauge)

## Test plan
- [x] `TestEvaluate_MetricRecorder` — verifies metrics are recorded with correct Prometheus type
- [x] `TestEvaluate_MetricRecorder_NoMetricDef` — verifies no errors when evals lack metric defs
- [x] `TestValidateEvalTypes_AllRegistered` — all built-in types pass
- [x] `TestValidateEvalTypes_MissingType` — unknown type is reported
- [x] `TestValidateEvalTypes_FromPackPath` — pack-based resolution works
- [x] `TestValidateEvalTypes_RuntimeConfigRegistersHandler` — exec handlers from RuntimeConfig are recognized
- [x] `TestValidateEvalTypes_EmptyDefs` — empty defs return nil
- [x] `TestValidateEvalTypes_InvalidPackPath` — invalid path returns error
- [x] Pre-commit: lint clean, 93.3% coverage on evaluate.go