### PR TITLE
fix(sdk): correct client tools lifecycle hooks, call ID propagation, and tool call preservation

### DIFF
--- a/docs/src/content/docs/architecture/runtime-events.md
+++ b/docs/src/content/docs/architecture/runtime-events.md
@@ -102,8 +102,25 @@ Events are organized into several categories:
 #### Tool Execution
 
 - `tool.call.started` - Tool execution begins
-- `tool.call.completed` - Tool execution succeeds
+- `tool.call.completed` - Tool execution succeeds (status: `"complete"`, `"pending"`, etc.)
 - `tool.call.failed` - Tool execution fails
+
+#### Client Tool Lifecycle
+
+Client-mode tools (fulfilled on the caller's device) emit additional events to track the deferred execution lifecycle:
+
+- `tool.client.request` - Client tool awaiting caller fulfillment (emitted when the tool returns `ToolStatusPending`)
+- `tool.client.resolved` - Client tool resolved by the caller (emitted during `Resume`/`ResumeStream`)
+
+The full lifecycle for a deferred client tool:
+
+1. `tool.call.started` — tool execution begins
+2. `tool.client.request` — tool is pending, awaiting caller (includes consent message, categories)
+3. `tool.call.completed` (status: `"pending"`) — matches the started event
+4. *(Caller fulfills via `SendToolResult` / `RejectClientTool`)*
+5. `tool.client.resolved` (status: `"fulfilled"` | `"rejected"` | `"error"`) — emitted during `Resume`
+
+For synchronous client tools (handler registered via `OnClientTool`), only `tool.call.started` and `tool.call.completed` (status: `"complete"`) are emitted — no client-specific events.
 
 #### Validation
 

--- a/docs/src/content/docs/sdk/how-to/monitor-events.md
+++ b/docs/src/content/docs/sdk/how-to/monitor-events.md
@@ -77,6 +77,10 @@ EventImageOutput        EventType = "image.output"
 EventEvalCompleted EventType = "eval.completed"  // eval finished (any score)
 EventEvalFailed    EventType = "eval.failed"      // eval errored (not low score)
 
+// Client tool lifecycle
+EventClientToolRequest  EventType = "tool.client.request"   // client tool awaiting fulfillment
+EventClientToolResolved EventType = "tool.client.resolved"  // client tool resolved by caller
+
 // Stream control
 EventStreamInterrupted EventType = "stream.interrupted"
 ```

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -376,6 +376,14 @@ func (e *Emitter) ClientToolRequest(data *ClientToolRequestData) {
 	e.emit(EventClientToolRequest, data)
 }
 
+// ClientToolResolved emits the tool.client.resolved event.
+func (e *Emitter) ClientToolResolved(data *ClientToolResolvedData) {
+	if data == nil {
+		return
+	}
+	e.emit(EventClientToolResolved, data)
+}
+
 // EvalCompleted emits the eval.completed event for a passed eval.
 func (e *Emitter) EvalCompleted(data *EvalCompletedData) {
 	e.emit(EventEvalCompleted, data)

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -121,6 +121,11 @@ func TestEmitterPublishesVariousEvents(t *testing.T) {
 				ValidatorType: "length",
 			})
 		},
+		func() {
+			emitter.ClientToolResolved(&ClientToolResolvedData{
+				CallID: "call-1", Status: "fulfilled",
+			})
+		},
 	}
 
 	wg.Add(len(tests))
@@ -743,4 +748,80 @@ func TestEmitter_ClientToolRequest_NilData(t *testing.T) {
 
 	// Should not panic when data is nil
 	emitter.ClientToolRequest(nil)
+}
+
+func TestEmitter_ClientToolResolved(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctr2", "session-ctr2", "conv-ctr2")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	bus.Subscribe(EventClientToolResolved, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	emitter.ClientToolResolved(&ClientToolResolvedData{
+		CallID:   "call-42",
+		ToolName: "get_location",
+		Status:   "fulfilled",
+	})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for tool.client.resolved event")
+	}
+
+	data, ok := got.Data.(*ClientToolResolvedData)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", got.Data)
+	}
+
+	if data.CallID != "call-42" || data.ToolName != "get_location" || data.Status != "fulfilled" {
+		t.Fatalf("unexpected data: %+v", data)
+	}
+}
+
+func TestEmitter_ClientToolResolved_Rejected(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctr3", "session-ctr3", "conv-ctr3")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	bus.Subscribe(EventClientToolResolved, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	emitter.ClientToolResolved(&ClientToolResolvedData{
+		CallID:          "call-99",
+		Status:          "rejected",
+		RejectionReason: "user denied",
+	})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for tool.client.resolved event")
+	}
+
+	data := got.Data.(*ClientToolResolvedData)
+	if data.Status != "rejected" || data.RejectionReason != "user denied" {
+		t.Fatalf("unexpected rejection data: %+v", data)
+	}
+}
+
+func TestEmitter_ClientToolResolved_NilData(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctr4", "session-ctr4", "conv-ctr4")
+
+	// Should not panic when data is nil
+	emitter.ClientToolResolved(nil)
 }

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -101,6 +101,8 @@ const (
 
 	// EventClientToolRequest marks a client-mode tool request awaiting caller fulfillment.
 	EventClientToolRequest EventType = "tool.client.request"
+	// EventClientToolResolved marks a client-mode tool that has been resolved by the caller.
+	EventClientToolResolved EventType = "tool.client.resolved"
 )
 
 // EventData is a marker interface for event payloads.
@@ -550,6 +552,19 @@ type ClientToolRequestData struct {
 	ConsentMsg string `json:"consent_msg,omitempty"`
 	// Categories are the semantic consent categories.
 	Categories []string `json:"categories,omitempty"`
+}
+
+// ClientToolResolvedData contains data for client tool resolution events.
+type ClientToolResolvedData struct {
+	baseEventData
+	// CallID is the provider-assigned ID for this tool invocation.
+	CallID string `json:"call_id"`
+	// ToolName is the tool's name (empty for deferred resolutions where name is unknown).
+	ToolName string `json:"tool_name,omitempty"`
+	// Status is the resolution outcome: "fulfilled", "rejected", or "error".
+	Status string `json:"status"`
+	// RejectionReason is set when Status is "rejected".
+	RejectionReason string `json:"rejection_reason,omitempty"`
 }
 
 // --- Eval events (consolidated) ---

--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -385,9 +385,10 @@ func (p *StreamPipeline) accumulateResult(output <-chan StreamElement) (*Executi
 			// Set response to last assistant message
 			if elem.Message.Role == roleAssistant {
 				result.Response = &Response{
-					Role:    elem.Message.Role,
-					Content: elem.Message.Content,
-					Parts:   elem.Message.Parts,
+					Role:      elem.Message.Role,
+					Content:   elem.Message.Content,
+					Parts:     elem.Message.Parts,
+					ToolCalls: elem.Message.ToolCalls,
 				}
 				// Propagate cost info from provider response to result
 				if elem.Message.CostInfo != nil {

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -929,6 +929,7 @@ func (s *ProviderStage) executeSingleToolCall(
 	s.emitToolStarted(toolCall, labels)
 
 	startTime := time.Now()
+	ctx = tools.WithCallID(ctx, toolCall.ID)
 	asyncResult, err := s.toolRegistry.ExecuteAsync(ctx, toolCall.Name, toolCall.Args)
 	if err != nil {
 		if s.emitter != nil {

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1000,6 +1000,9 @@ func (s *ProviderStage) emitGuardrailEvent(d hooks.Decision, duration time.Durat
 }
 
 // buildPendingResult creates a toolCallResult for a pending tool execution.
+// It emits a tool.client.request event so observers know a client tool is
+// awaiting fulfillment, and a tool.call.completed with status "pending" so
+// every tool.call.started has a matching completion.
 func (s *ProviderStage) buildPendingResult(
 	toolCall types.MessageToolCall, asyncResult *tools.ToolExecutionResult,
 ) toolCallResult {
@@ -1007,6 +1010,29 @@ func (s *ProviderStage) buildPendingResult(
 	if toolCall.Args != nil {
 		_ = json.Unmarshal(toolCall.Args, &argsMap)
 	}
+
+	// Emit client tool request event with consent/category metadata
+	if s.emitter != nil {
+		reqData := &events.ClientToolRequestData{
+			CallID:   toolCall.ID,
+			ToolName: toolCall.Name,
+			Args:     argsMap,
+		}
+		if asyncResult.PendingInfo != nil {
+			reqData.ConsentMsg = asyncResult.PendingInfo.Message
+			if cats, ok := asyncResult.PendingInfo.Metadata["categories"].([]string); ok {
+				reqData.Categories = cats
+			}
+		}
+		s.emitter.ClientToolRequest(reqData)
+	}
+
+	// Emit tool.call.completed with status "pending" so the started event is paired
+	if s.emitter != nil {
+		labels := s.toolLabels(toolCall.Name)
+		s.emitter.ToolCallCompleted(toolCall.Name, toolCall.ID, 0, "pending", nil, labels)
+	}
+
 	toolResult := s.handleToolResult(toolCall, asyncResult)
 	return toolCallResult{
 		pending: &tools.PendingToolExecution{

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -1776,6 +1776,86 @@ func TestProviderStage_ExecuteToolCalls_EmitsFailed(t *testing.T) {
 	assert.Error(t, failedData.Error)
 }
 
+func TestProviderStage_ExecuteToolCalls_PendingEmitsRequestAndCompleted(t *testing.T) {
+	// When a tool returns ToolStatusPending, buildPendingResult should emit:
+	//   1. tool.client.request — so observers know a client tool awaits fulfillment
+	//   2. tool.call.completed with status "pending" — so every started has a matching completion
+	registry := tools.NewRegistry()
+	_ = registry.Register(&tools.ToolDescriptor{
+		Name:        "location_tool",
+		Description: "Gets user location",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Mode:        "client",
+	})
+
+	pendingExec := &mockAsyncExecutor{
+		name:       "client",
+		status:     tools.ToolStatusPending,
+		pendingMsg: "Allow location access?",
+	}
+	registry.RegisterExecutor(pendingExec)
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run-pe", "session-pe", "conv-pe")
+
+	var captured []*events.Event
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(3) // started + client.request + completed(pending)
+
+	bus.SubscribeAll(func(e *events.Event) {
+		mu.Lock()
+		captured = append(captured, e)
+		mu.Unlock()
+		wg.Done()
+	})
+
+	provider := mock.NewProvider("test", "model", false)
+	stage := NewProviderStageWithEmitter(provider, registry, nil, nil, emitter)
+
+	toolCalls := []types.MessageToolCall{
+		{ID: "call-loc", Name: "location_tool", Args: json.RawMessage(`{"accuracy":"fine"}`)},
+	}
+
+	_, err := stage.executeToolCalls(context.Background(), toolCalls)
+	require.Error(t, err, "should return ErrToolsPending")
+
+	wg.Wait()
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Classify captured events
+	var startedEvt, clientReqEvt, completedEvt *events.Event
+	for _, e := range captured {
+		switch e.Type {
+		case events.EventToolCallStarted:
+			startedEvt = e
+		case events.EventClientToolRequest:
+			clientReqEvt = e
+		case events.EventToolCallCompleted:
+			completedEvt = e
+		}
+	}
+
+	require.NotNil(t, startedEvt, "expected tool.call.started event")
+	require.NotNil(t, clientReqEvt, "expected tool.client.request event")
+	require.NotNil(t, completedEvt, "expected tool.call.completed event")
+
+	// Verify client request data
+	reqData, ok := clientReqEvt.Data.(*events.ClientToolRequestData)
+	require.True(t, ok)
+	assert.Equal(t, "call-loc", reqData.CallID)
+	assert.Equal(t, "location_tool", reqData.ToolName)
+	assert.Equal(t, "Allow location access?", reqData.ConsentMsg)
+
+	// Verify completed has status "pending"
+	compData, ok := completedEvt.Data.(*events.ToolCallCompletedData)
+	require.True(t, ok)
+	assert.Equal(t, "location_tool", compData.ToolName)
+	assert.Equal(t, "call-loc", compData.CallID)
+	assert.Equal(t, "pending", compData.Status)
+}
+
 func TestProviderStage_ExecuteToolCalls_BlockedNoEvents(t *testing.T) {
 	provider := mock.NewProvider("test", "model", false)
 	registry := tools.NewRegistry()

--- a/runtime/pipeline/stage/stages_utilities_test.go
+++ b/runtime/pipeline/stage/stages_utilities_test.go
@@ -1066,6 +1066,29 @@ func TestStreamPipeline_ExecuteSync(t *testing.T) {
 		assert.Error(t, err)
 		assert.NotNil(t, result)
 	})
+
+	t.Run("preserves tool calls on assistant messages", func(t *testing.T) {
+		passthrough := NewPassthroughStage("passthrough")
+		builder := NewPipelineBuilder().AddStage(passthrough)
+		pipeline, err := builder.Build()
+		require.NoError(t, err)
+
+		msg := &types.Message{
+			Role:    "assistant",
+			Content: "Let me check the weather",
+			ToolCalls: []types.MessageToolCall{
+				{ID: "call-1", Name: "get_weather", Args: []byte(`{"city":"London"}`)},
+			},
+		}
+		input := NewMessageElement(msg)
+
+		result, err := pipeline.ExecuteSync(context.Background(), input)
+		require.NoError(t, err)
+		require.NotNil(t, result.Response)
+		assert.Len(t, result.Response.ToolCalls, 1,
+			"accumulateResult should preserve ToolCalls from assistant messages")
+		assert.Equal(t, "get_weather", result.Response.ToolCalls[0].Name)
+	})
 }
 
 // =============================================================================

--- a/runtime/tools/context.go
+++ b/runtime/tools/context.go
@@ -1,0 +1,23 @@
+package tools
+
+import "context"
+
+type callIDKeyType struct{}
+
+var callIDKey = callIDKeyType{}
+
+// WithCallID returns a new context that carries the tool call ID.
+// This is set by the pipeline before executing a tool so that
+// executors can access the provider-assigned call ID.
+func WithCallID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, callIDKey, id)
+}
+
+// CallIDFromContext extracts the tool call ID from the context.
+// Returns an empty string if no call ID is set.
+func CallIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(callIDKey).(string); ok {
+		return id
+	}
+	return ""
+}

--- a/runtime/tools/context_test.go
+++ b/runtime/tools/context_test.go
@@ -1,0 +1,19 @@
+package tools_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithCallID_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ctx = tools.WithCallID(ctx, "call-abc-123")
+	assert.Equal(t, "call-abc-123", tools.CallIDFromContext(ctx))
+}
+
+func TestCallIDFromContext_Missing(t *testing.T) {
+	assert.Equal(t, "", tools.CallIDFromContext(context.Background()))
+}

--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
@@ -338,6 +339,7 @@ func (c *Conversation) ResumeStream(ctx context.Context) <-chan StreamChunk {
 
 // buildToolResultMessages pops all resolved tool results and builds
 // tool-result messages. Shared by Resume() and ResumeStream().
+// It also emits tool.client.resolved events for each resolution.
 func (c *Conversation) buildToolResultMessages() ([]types.Message, error) {
 	resolutions := c.resolvedStore.PopAll()
 	if len(resolutions) == 0 {
@@ -367,7 +369,33 @@ func (c *Conversation) buildToolResultMessages() ([]types.Message, error) {
 		toolMsgs = append(toolMsgs, types.NewToolResultMessage(toolResult))
 	}
 
+	c.emitClientToolResolvedEvents(resolutions)
+
 	return toolMsgs, nil
+}
+
+// emitClientToolResolvedEvents emits a tool.client.resolved event for each
+// resolution so that observers see the full request → resolved lifecycle.
+func (c *Conversation) emitClientToolResolvedEvents(resolutions []*sdktools.ToolResolution) {
+	if c.config.eventBus == nil {
+		return
+	}
+	emitter := events.NewEmitter(c.config.eventBus, "", "", "")
+	for _, res := range resolutions {
+		status := "fulfilled"
+		reason := ""
+		if res.Rejected {
+			status = "rejected"
+			reason = res.RejectionReason
+		} else if res.Error != nil {
+			status = "error"
+		}
+		emitter.ClientToolResolved(&events.ClientToolResolvedData{
+			CallID:          res.ID,
+			Status:          status,
+			RejectionReason: reason,
+		})
+	}
 }
 
 // executeHandler runs a ClientToolHandler and returns serialized JSON.

--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -270,8 +270,13 @@ func (c *Conversation) Resume(ctx context.Context) (*Response, error) {
 	}
 
 	resp := c.buildResponse(result, startTime)
-	c.sessionHooks.IncrementTurn()
-	c.sessionHooks.SessionUpdate(ctx)
+
+	// Skip lifecycle hooks when the resumed pipeline returns more pending tools.
+	if !resp.HasPendingClientTools() {
+		c.sessionHooks.IncrementTurn()
+		c.sessionHooks.SessionUpdate(ctx)
+		c.evalMW.dispatchTurnEvals(ctx)
+	}
 	return resp, nil
 }
 
@@ -372,6 +377,7 @@ func (e *clientExecutor) executeHandler(
 ) (json.RawMessage, error) {
 	req := ClientToolRequest{
 		ToolName:   descriptor.Name,
+		CallID:     tools.CallIDFromContext(ctx),
 		Args:       argsMap,
 		Descriptor: descriptor,
 	}
@@ -408,6 +414,7 @@ func (e *clientExecutor) executeHandlerAsync(
 ) (*tools.ToolExecutionResult, error) {
 	req := ClientToolRequest{
 		ToolName:   descriptor.Name,
+		CallID:     tools.CallIDFromContext(ctx),
 		Args:       argsMap,
 		Descriptor: descriptor,
 	}

--- a/sdk/client_tools_lifecycle_test.go
+++ b/sdk/client_tools_lifecycle_test.go
@@ -1,0 +1,220 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	rtpipeline "github.com/AltairaLabs/PromptKit/runtime/pipeline"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/sdk/session"
+	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockUnarySession is a controllable UnarySession for testing lifecycle behavior.
+type mockUnarySession struct {
+	executeResult *rtpipeline.ExecutionResult
+	executeErr    error
+	resumeResult  *rtpipeline.ExecutionResult
+	resumeErr     error
+
+	// Track calls
+	resumeCalled        bool
+	resumeStreamCalled  bool
+	resumeToolResults   []types.Message
+	executeStreamResult chan providers.StreamChunk
+	executeStreamErr    error
+}
+
+func (m *mockUnarySession) ID() string                                          { return "mock-session" }
+func (m *mockUnarySession) Variables() map[string]string                        { return nil }
+func (m *mockUnarySession) SetVar(_, _ string)                                  {}
+func (m *mockUnarySession) GetVar(_ string) (string, bool)                      { return "", false }
+func (m *mockUnarySession) Messages(_ context.Context) ([]types.Message, error) { return nil, nil }
+func (m *mockUnarySession) Clear(_ context.Context) error                       { return nil }
+
+func (m *mockUnarySession) Execute(_ context.Context, _, _ string) (*rtpipeline.ExecutionResult, error) {
+	return m.executeResult, m.executeErr
+}
+
+//nolint:gocritic
+func (m *mockUnarySession) ExecuteWithMessage(_ context.Context, _ types.Message) (*rtpipeline.ExecutionResult, error) {
+	return m.executeResult, m.executeErr
+}
+
+func (m *mockUnarySession) ExecuteStream(_ context.Context, _, _ string) (<-chan providers.StreamChunk, error) {
+	return m.executeStreamResult, m.executeStreamErr
+}
+
+//nolint:gocritic
+func (m *mockUnarySession) ExecuteStreamWithMessage(_ context.Context, _ types.Message) (<-chan providers.StreamChunk, error) {
+	return m.executeStreamResult, m.executeStreamErr
+}
+
+func (m *mockUnarySession) ResumeWithToolResults(_ context.Context, toolResults []types.Message) (*rtpipeline.ExecutionResult, error) {
+	m.resumeCalled = true
+	m.resumeToolResults = toolResults
+	return m.resumeResult, m.resumeErr
+}
+
+func (m *mockUnarySession) ResumeStreamWithToolResults(_ context.Context, toolResults []types.Message) (<-chan providers.StreamChunk, error) {
+	m.resumeStreamCalled = true
+	m.resumeToolResults = toolResults
+	ch := make(chan providers.StreamChunk, 1)
+	if m.resumeResult != nil {
+		fin := "stop"
+		ch <- providers.StreamChunk{
+			Content:      m.resumeResult.Response.Content,
+			FinishReason: &fin,
+			FinalResult:  &stage.ExecutionResult{Response: &stage.Response{Role: "assistant", Content: m.resumeResult.Response.Content}},
+		}
+	}
+	close(ch)
+	return ch, m.resumeErr
+}
+
+func (m *mockUnarySession) ForkSession(_ context.Context, _ string, _ *stage.StreamPipeline) (session.UnarySession, error) {
+	return nil, nil
+}
+
+// newTestConvWithMockSession creates a Conversation wired to a mock session
+// for precise control of pipeline results.
+func newTestConvWithMockSession(sess *mockUnarySession) *Conversation {
+	return &Conversation{
+		config:         &config{},
+		handlers:       make(map[string]ToolHandler),
+		ctxHandlers:    make(map[string]ToolHandlerCtx),
+		clientHandlers: make(map[string]ClientToolHandler),
+		mode:           UnaryMode,
+		unarySession:   sess,
+		toolRegistry:   tools.NewRegistry(),
+		resolvedStore:  sdktools.NewResolvedStore(),
+		sessionHooks:   newSessionHookDispatcher(nil, nil),
+	}
+}
+
+// resultWithPendingTools builds an ExecutionResult that contains pending client tools.
+func resultWithPendingTools() *rtpipeline.ExecutionResult {
+	return &rtpipeline.ExecutionResult{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "I need your location"},
+		},
+		Response: &rtpipeline.Response{
+			Role:    "assistant",
+			Content: "I need your location",
+		},
+		PendingTools: []tools.PendingToolExecution{
+			{
+				CallID:   "call-1",
+				ToolName: "get_location",
+				Args:     map[string]any{"accuracy": "fine"},
+				PendingInfo: &tools.PendingToolInfo{
+					Reason:   "client_tool_deferred",
+					Message:  "Allow location?",
+					ToolName: "get_location",
+					Args:     json.RawMessage(`{"accuracy":"fine"}`),
+					Metadata: map[string]any{
+						"categories": []string{"location"},
+					},
+				},
+			},
+		},
+		Metadata: make(map[string]any),
+	}
+}
+
+// resultWithoutPendingTools builds a normal ExecutionResult.
+func resultWithoutPendingTools() *rtpipeline.ExecutionResult {
+	return &rtpipeline.ExecutionResult{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "Your location is San Francisco"},
+		},
+		Response: &rtpipeline.Response{
+			Role:    "assistant",
+			Content: "Your location is San Francisco",
+		},
+		Metadata: make(map[string]any),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1: Send() should not fire lifecycle hooks when pending tools exist
+// ---------------------------------------------------------------------------
+
+func TestSend_SkipsHooksWhenPendingClientTools(t *testing.T) {
+	sess := &mockUnarySession{
+		executeResult: resultWithPendingTools(),
+	}
+	conv := newTestConvWithMockSession(sess)
+
+	resp, err := conv.Send(context.Background(), "Where am I?")
+	require.NoError(t, err)
+	require.True(t, resp.HasPendingClientTools(), "response should have pending client tools")
+
+	// Turn counter should NOT have been incremented
+	assert.Equal(t, 0, conv.sessionHooks.TurnIndex(),
+		"IncrementTurn should not fire when pending client tools exist")
+}
+
+func TestSend_FiresHooksWhenNoPendingClientTools(t *testing.T) {
+	sess := &mockUnarySession{
+		executeResult: resultWithoutPendingTools(),
+	}
+	conv := newTestConvWithMockSession(sess)
+
+	resp, err := conv.Send(context.Background(), "Hello")
+	require.NoError(t, err)
+	require.False(t, resp.HasPendingClientTools())
+
+	// Turn counter SHOULD have been incremented
+	assert.Equal(t, 1, conv.sessionHooks.TurnIndex(),
+		"IncrementTurn should fire for normal responses")
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2a: Resume() should call dispatchTurnEvals
+// Bug 2b: Resume() should skip hooks when nested pending tools exist
+// ---------------------------------------------------------------------------
+
+func TestResume_SkipsHooksWhenNestedPendingTools(t *testing.T) {
+	sess := &mockUnarySession{
+		// Resume returns MORE pending tools (nested)
+		resumeResult: resultWithPendingTools(),
+	}
+	conv := newTestConvWithMockSession(sess)
+
+	// Supply a tool result so Resume has something to work with
+	err := conv.SendToolResult(context.Background(), "call-prev", map[string]any{"data": "ok"})
+	require.NoError(t, err)
+
+	resp, err := conv.Resume(context.Background())
+	require.NoError(t, err)
+	require.True(t, resp.HasPendingClientTools(), "resume should return nested pending tools")
+
+	// Turn counter should NOT have been incremented
+	assert.Equal(t, 0, conv.sessionHooks.TurnIndex(),
+		"IncrementTurn should not fire when resume returns pending tools")
+}
+
+func TestResume_FiresHooksWhenNoPendingTools(t *testing.T) {
+	sess := &mockUnarySession{
+		resumeResult: resultWithoutPendingTools(),
+	}
+	conv := newTestConvWithMockSession(sess)
+
+	err := conv.SendToolResult(context.Background(), "call-1", map[string]any{"lat": 37.7})
+	require.NoError(t, err)
+
+	resp, err := conv.Resume(context.Background())
+	require.NoError(t, err)
+	require.False(t, resp.HasPendingClientTools())
+
+	// Turn counter SHOULD have been incremented
+	assert.Equal(t, 1, conv.sessionHooks.TurnIndex(),
+		"IncrementTurn should fire when resume completes normally")
+}

--- a/sdk/client_tools_test.go
+++ b/sdk/client_tools_test.go
@@ -696,6 +696,54 @@ func TestClientExecutor_ExecuteAsync_NonContentPartsJSON(t *testing.T) {
 	assert.Empty(t, result.Parts)
 }
 
+func TestClientExecutor_Execute_PopulatesCallID(t *testing.T) {
+	conv := newTestConversation()
+
+	var capturedReq ClientToolRequest
+	conv.OnClientTool("get_location", func(_ context.Context, req ClientToolRequest) (any, error) {
+		capturedReq = req
+		return map[string]any{"lat": 37.7749}, nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{Name: "get_location", Mode: "client"}
+	ctx := tools.WithCallID(context.Background(), "call-xyz-789")
+
+	_, err := exec.Execute(ctx, desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "call-xyz-789", capturedReq.CallID,
+		"CallID should be populated from context")
+}
+
+func TestClientExecutor_ExecuteAsync_PopulatesCallID(t *testing.T) {
+	conv := newTestConversation()
+
+	var capturedReq ClientToolRequest
+	conv.OnClientTool("sensor", func(_ context.Context, req ClientToolRequest) (any, error) {
+		capturedReq = req
+		return "ok", nil
+	})
+
+	exec := &clientExecutor{
+		handlers:   conv.clientHandlers,
+		handlersMu: &clientHandlersMuAccessor{conv: conv},
+	}
+
+	desc := &tools.ToolDescriptor{Name: "sensor", Mode: "client"}
+	ctx := tools.WithCallID(context.Background(), "call-async-456")
+
+	result, err := exec.ExecuteAsync(ctx, desc, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, tools.ToolStatusComplete, result.Status)
+	assert.Equal(t, "call-async-456", capturedReq.CallID,
+		"CallID should be populated from context in async path")
+}
+
 func TestBuildToolResultMessages_ErrorBranch(t *testing.T) {
 	conv := newTestConversation()
 	conv.resolvedStore = sdktools.NewResolvedStore()

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -237,9 +237,14 @@ func (c *Conversation) Send(ctx context.Context, message any, opts ...SendOption
 	}
 
 	resp := c.buildResponse(result, startTime)
-	c.sessionHooks.IncrementTurn()
-	c.sessionHooks.SessionUpdate(ctx)
-	c.evalMW.dispatchTurnEvals(ctx) // nil-safe, no-op if middleware is nil
+
+	// Skip lifecycle hooks when pipeline is suspended for pending client tools.
+	// The hooks will fire when Resume() completes the turn instead.
+	if !resp.HasPendingClientTools() {
+		c.sessionHooks.IncrementTurn()
+		c.sessionHooks.SessionUpdate(ctx)
+		c.evalMW.dispatchTurnEvals(ctx) // nil-safe, no-op if middleware is nil
+	}
 	return resp, nil
 }
 

--- a/sdk/integration/client_tools_test.go
+++ b/sdk/integration/client_tools_test.go
@@ -1,0 +1,242 @@
+package integration
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// patchToolMode updates a tool descriptor's mode in the conversation's registry.
+// The pack parser currently hardcodes mode: "local" for all tools, so this is
+// needed to test client-mode tools in integration tests.
+func patchToolMode(t *testing.T, conv *sdk.Conversation, toolName, mode string) {
+	t.Helper()
+	desc, err := conv.ToolRegistry().GetTool(toolName)
+	require.NoError(t, err, "tool %q should exist in registry", toolName)
+	desc.Mode = mode
+	if mode == "client" {
+		desc.ClientConfig = &tools.ClientConfig{
+			Consent: &tools.ConsentConfig{
+				Required: true,
+				Message:  "Allow access?",
+			},
+			Categories: []string{"location"},
+		}
+	}
+}
+
+// clientToolsPackJSON defines a pack with a client-mode tool.
+const clientToolsPackJSON = `{
+	"id": "integration-test-client-tools",
+	"version": "1.0.0",
+	"description": "Pack with client tools for SDK integration tests",
+	"prompts": {
+		"chat": {
+			"id": "chat",
+			"name": "Chat",
+			"system_template": "You are a helpful assistant with client tools.",
+			"tools": ["get_location"]
+		}
+	},
+	"tools": {
+		"get_location": {
+			"name": "get_location",
+			"description": "Get the user's GPS location",
+			"mode": "client",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"accuracy": {"type": "string"}
+				},
+				"required": ["accuracy"]
+			},
+			"client": {
+				"consent": {
+					"required": true,
+					"message": "Allow location access?"
+				},
+				"categories": ["location"]
+			}
+		}
+	}
+}`
+
+// ---------------------------------------------------------------------------
+// 5.1 — Client tool deferred mode: Send → pending → SendToolResult → Resume
+// ---------------------------------------------------------------------------
+
+func TestClientTools_DeferredRoundTrip(t *testing.T) {
+	repo := newTestTurnRepository()
+	// Turn 1: LLM calls the client tool
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+	// Turn 2: LLM responds with location-aware answer
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "You are in San Francisco.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	// Patch the tool descriptor to set mode to "client".
+	// The pack parser currently hardcodes mode: "local" for all tools,
+	// so we patch the registry after opening.
+	patchToolMode(t, conv, "get_location", "client")
+
+	// No handler registered — tool should be deferred
+	ctx := context.Background()
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err)
+
+	// Response should have pending client tools
+	require.True(t, resp.HasPendingClientTools(),
+		"response should have pending client tools when no handler is registered")
+
+	clientTools := resp.ClientTools()
+	require.Len(t, clientTools, 1)
+	assert.Equal(t, "get_location", clientTools[0].ToolName)
+	assert.Equal(t, map[string]any{"accuracy": "fine"}, clientTools[0].Args)
+	assert.NotEmpty(t, clientTools[0].CallID, "CallID should be populated")
+
+	// Provide the tool result
+	err = conv.SendToolResult(ctx, clientTools[0].CallID, map[string]any{
+		"lat": 37.7749,
+		"lng": -122.4194,
+	})
+	require.NoError(t, err)
+
+	// Resume to get final response
+	resp, err = conv.Resume(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Text(), "response after resume should have text")
+	assert.False(t, resp.HasPendingClientTools(), "no more pending tools after resume")
+}
+
+// ---------------------------------------------------------------------------
+// 5.2 — Client tool with sync handler (immediate execution)
+// ---------------------------------------------------------------------------
+
+func TestClientTools_SyncHandlerExecution(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "coarse"},
+		}},
+	})
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "You are in San Francisco.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	// Register a sync handler
+	var handlerCalled atomic.Bool
+	var capturedArgs map[string]any
+	var mu sync.Mutex
+
+	conv.OnClientTool("get_location", func(_ context.Context, req sdk.ClientToolRequest) (any, error) {
+		handlerCalled.Store(true)
+		mu.Lock()
+		capturedArgs = req.Args
+		mu.Unlock()
+		return map[string]any{"lat": 37.7749, "lng": -122.4194}, nil
+	})
+
+	ctx := context.Background()
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err)
+
+	// Should NOT have pending tools — handler ran synchronously
+	assert.False(t, resp.HasPendingClientTools(),
+		"should not have pending tools when handler is registered")
+	assert.True(t, handlerCalled.Load(), "sync handler should have been called")
+
+	mu.Lock()
+	assert.Equal(t, "coarse", capturedArgs["accuracy"])
+	mu.Unlock()
+
+	assert.NotEmpty(t, resp.Text(), "response should have text content")
+}
+
+// ---------------------------------------------------------------------------
+// 5.3 — Client tool rejection
+// ---------------------------------------------------------------------------
+
+func TestClientTools_Rejection(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "I understand you declined location access.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	ctx := context.Background()
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err)
+	require.True(t, resp.HasPendingClientTools())
+
+	// Reject the tool
+	clientTools := resp.ClientTools()
+	conv.RejectClientTool(ctx, clientTools[0].CallID, "user declined location access")
+
+	// Resume after rejection
+	resp, err = conv.Resume(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Text(), "response after rejection should have text")
+	assert.False(t, resp.HasPendingClientTools())
+}

--- a/sdk/integration/client_tools_test.go
+++ b/sdk/integration/client_tools_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/sdk"
@@ -609,4 +610,137 @@ func TestClientTools_StreamingRejection(t *testing.T) {
 	require.NotNil(t, resumeDone)
 	assert.NotEmpty(t, resumeText, "resumed stream should produce text after rejection")
 	assert.False(t, resumeDone.Message.HasPendingClientTools())
+}
+
+// ---------------------------------------------------------------------------
+// 5.10 — Event lifecycle: request → pending completion → resolved
+// ---------------------------------------------------------------------------
+
+func TestClientTools_EventLifecycle(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "You are in San Francisco.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	bus := events.NewEventBus()
+	collector := newEventCollector(bus)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+		sdk.WithEventBus(bus),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	ctx := context.Background()
+
+	// Send — should produce pending tool
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err)
+	require.True(t, resp.HasPendingClientTools())
+
+	// Verify: tool.call.started, tool.client.request, tool.call.completed(pending)
+	startedEvents := collector.ofType(events.EventToolCallStarted)
+	requestEvents := collector.ofType(events.EventClientToolRequest)
+	completedEvents := collector.ofType(events.EventToolCallCompleted)
+
+	require.NotEmpty(t, startedEvents, "expected tool.call.started event")
+	require.NotEmpty(t, requestEvents, "expected tool.client.request event")
+	require.NotEmpty(t, completedEvents, "expected tool.call.completed event")
+
+	// Verify client request data
+	reqData := requestEvents[0].Data.(*events.ClientToolRequestData)
+	assert.Equal(t, "get_location", reqData.ToolName)
+	assert.NotEmpty(t, reqData.CallID)
+
+	// Verify completed has status "pending"
+	compData := completedEvents[0].Data.(*events.ToolCallCompletedData)
+	assert.Equal(t, "pending", compData.Status)
+
+	// Resolve and resume
+	pending := resp.ClientTools()
+	require.Len(t, pending, 1)
+
+	err = conv.SendToolResult(ctx, pending[0].CallID, map[string]any{"lat": 37.7, "lng": -122.4})
+	require.NoError(t, err)
+
+	resp2, err := conv.Resume(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp2.Text())
+
+	// Verify: tool.client.resolved event emitted during Resume
+	resolvedEvents := collector.ofType(events.EventClientToolResolved)
+	require.NotEmpty(t, resolvedEvents, "expected tool.client.resolved event after Resume")
+
+	resData := resolvedEvents[0].Data.(*events.ClientToolResolvedData)
+	assert.Equal(t, pending[0].CallID, resData.CallID)
+	assert.Equal(t, "fulfilled", resData.Status)
+}
+
+func TestClientTools_EventLifecycle_Rejection(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "I understand you declined location access.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	bus := events.NewEventBus()
+	collector := newEventCollector(bus)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+		sdk.WithEventBus(bus),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	ctx := context.Background()
+
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err)
+	require.True(t, resp.HasPendingClientTools())
+
+	pending := resp.ClientTools()
+	conv.RejectClientTool(ctx, pending[0].CallID, "user declined")
+
+	resp2, err := conv.Resume(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp2.Text())
+
+	// Verify resolved event has status "rejected"
+	resolvedEvents := collector.ofType(events.EventClientToolResolved)
+	require.NotEmpty(t, resolvedEvents, "expected tool.client.resolved event")
+
+	resData := resolvedEvents[0].Data.(*events.ClientToolResolvedData)
+	assert.Equal(t, "rejected", resData.Status)
+	assert.Equal(t, "user declined", resData.RejectionReason)
 }

--- a/sdk/integration/client_tools_test.go
+++ b/sdk/integration/client_tools_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -239,4 +240,373 @@ func TestClientTools_Rejection(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.Text(), "response after rejection should have text")
 	assert.False(t, resp.HasPendingClientTools())
+}
+
+// ---------------------------------------------------------------------------
+// 5.4 — Streaming deferred flow: Stream → pending ChunkClientTool → SendToolResult → ResumeStream
+// ---------------------------------------------------------------------------
+
+func TestClientTools_StreamingDeferredRoundTrip(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "You are in San Francisco.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	ctx := context.Background()
+
+	// Stream the first request — should yield ChunkClientTool
+	var clientToolChunks []sdk.StreamChunk
+	var doneChunk *sdk.StreamChunk
+	for chunk := range conv.Stream(ctx, "Where am I?") {
+		require.NoError(t, chunk.Error, "unexpected streaming error")
+		if chunk.Type == sdk.ChunkClientTool {
+			clientToolChunks = append(clientToolChunks, chunk)
+		}
+		if chunk.Type == sdk.ChunkDone {
+			doneChunk = &chunk
+		}
+	}
+
+	require.NotEmpty(t, clientToolChunks, "expected ChunkClientTool in stream")
+	require.NotNil(t, doneChunk, "expected ChunkDone in stream")
+
+	// Done chunk response should have pending tools
+	require.True(t, doneChunk.Message.HasPendingClientTools(),
+		"ChunkDone response should report pending client tools")
+
+	pendingTool := clientToolChunks[0].ClientTool
+	assert.Equal(t, "get_location", pendingTool.ToolName)
+	assert.NotEmpty(t, pendingTool.CallID)
+
+	// Provide the tool result
+	err = conv.SendToolResult(ctx, pendingTool.CallID, map[string]any{
+		"lat": 37.7749,
+		"lng": -122.4194,
+	})
+	require.NoError(t, err)
+
+	// ResumeStream to get final response
+	var resumeText string
+	var resumeDone *sdk.StreamChunk
+	for chunk := range conv.ResumeStream(ctx) {
+		require.NoError(t, chunk.Error, "unexpected error in ResumeStream")
+		if chunk.Type == sdk.ChunkText {
+			resumeText += chunk.Text
+		}
+		if chunk.Type == sdk.ChunkDone {
+			resumeDone = &chunk
+		}
+	}
+
+	require.NotNil(t, resumeDone, "expected ChunkDone from ResumeStream")
+	assert.NotEmpty(t, resumeText, "resumed stream should produce text")
+	assert.False(t, resumeDone.Message.HasPendingClientTools(),
+		"no more pending tools after ResumeStream")
+}
+
+// ---------------------------------------------------------------------------
+// 5.5 — Consent metadata propagation on PendingClientTool
+// ---------------------------------------------------------------------------
+
+func TestClientTools_ConsentMetadata(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	ctx := context.Background()
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err)
+	require.True(t, resp.HasPendingClientTools())
+
+	clientTools := resp.ClientTools()
+	require.Len(t, clientTools, 1)
+
+	// Verify consent metadata from patchToolMode is propagated
+	assert.Equal(t, "Allow access?", clientTools[0].ConsentMsg,
+		"ConsentMsg should come from the tool descriptor's ClientConfig")
+	assert.Equal(t, []string{"location"}, clientTools[0].Categories,
+		"Categories should come from the tool descriptor's ClientConfig")
+}
+
+// ---------------------------------------------------------------------------
+// 5.6 — OnClientTools batch registration
+// ---------------------------------------------------------------------------
+
+// multiClientToolsPackJSON defines a pack with two client-mode tools.
+const multiClientToolsPackJSON = `{
+	"id": "integration-test-multi-client-tools",
+	"version": "1.0.0",
+	"description": "Pack with multiple client tools",
+	"prompts": {
+		"chat": {
+			"id": "chat",
+			"name": "Chat",
+			"system_template": "You are a helpful assistant.",
+			"tools": ["get_location", "read_contacts"]
+		}
+	},
+	"tools": {
+		"get_location": {
+			"name": "get_location",
+			"description": "Get the user's GPS location",
+			"mode": "client",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"accuracy": {"type": "string"}
+				},
+				"required": ["accuracy"]
+			}
+		},
+		"read_contacts": {
+			"name": "read_contacts",
+			"description": "Read the user's contacts",
+			"mode": "client",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"limit": {"type": "integer"}
+				}
+			}
+		}
+	}
+}`
+
+func TestClientTools_OnClientToolsBatchRegistration(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "You are in San Francisco.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, multiClientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+	patchToolMode(t, conv, "read_contacts", "client")
+
+	// Register both handlers via batch method
+	var locationCalled, contactsCalled atomic.Bool
+	conv.OnClientTools(map[string]sdk.ClientToolHandler{
+		"get_location": func(_ context.Context, req sdk.ClientToolRequest) (any, error) {
+			locationCalled.Store(true)
+			return map[string]any{"lat": 37.7749, "lng": -122.4194}, nil
+		},
+		"read_contacts": func(_ context.Context, req sdk.ClientToolRequest) (any, error) {
+			contactsCalled.Store(true)
+			return []map[string]any{{"name": "Alice"}}, nil
+		},
+	})
+
+	ctx := context.Background()
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err)
+
+	// get_location handler should have been called (the mock only calls get_location)
+	assert.True(t, locationCalled.Load(), "get_location handler should be called")
+	assert.False(t, resp.HasPendingClientTools(),
+		"should not have pending tools when handler is registered via batch")
+	assert.NotEmpty(t, resp.Text())
+}
+
+// ---------------------------------------------------------------------------
+// 5.7 — Handler error propagation
+// ---------------------------------------------------------------------------
+
+func TestClientTools_HandlerErrorSentAsToolResult(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+	// Turn 2: LLM receives the error result and responds gracefully
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "Sorry, I could not access your location.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	// Register a handler that returns an error — the pipeline captures this
+	// as an error tool result and feeds it back to the LLM, rather than
+	// failing the entire pipeline.
+	conv.OnClientTool("get_location", func(_ context.Context, req sdk.ClientToolRequest) (any, error) {
+		return nil, fmt.Errorf("GPS unavailable")
+	})
+
+	ctx := context.Background()
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err, "handler errors are sent as tool results, not pipeline failures")
+	assert.NotEmpty(t, resp.Text(), "LLM should respond after receiving error tool result")
+	assert.False(t, resp.HasPendingClientTools())
+}
+
+// ---------------------------------------------------------------------------
+// 5.8 — Resume without SendToolResult errors
+// ---------------------------------------------------------------------------
+
+func TestClientTools_ResumeWithoutToolResult(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	ctx := context.Background()
+	resp, err := conv.Send(ctx, "Where am I?")
+	require.NoError(t, err)
+	require.True(t, resp.HasPendingClientTools())
+
+	// Resume without providing any tool results — should error
+	_, err = conv.Resume(ctx)
+	assert.Error(t, err, "Resume() without SendToolResult should fail")
+	assert.Contains(t, err.Error(), "no resolved tool results",
+		"error should indicate missing tool results")
+}
+
+// ---------------------------------------------------------------------------
+// 5.9 — Streaming rejection flow
+// ---------------------------------------------------------------------------
+
+func TestClientTools_StreamingRejection(t *testing.T) {
+	repo := newTestTurnRepository()
+	repo.addTurn("default", 1, mock.Turn{
+		Type:    "tool_calls",
+		Content: "Let me check your location",
+		ToolCalls: []mock.ToolCall{{
+			Name:      "get_location",
+			Arguments: map[string]interface{}{"accuracy": "fine"},
+		}},
+	})
+	repo.addTurn("default", 2, mock.Turn{
+		Type:    "text",
+		Content: "I understand you declined location access.",
+	})
+
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+	packPath := writePackFile(t, clientToolsPackJSON)
+
+	conv, err := sdk.Open(packPath, "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	patchToolMode(t, conv, "get_location", "client")
+
+	ctx := context.Background()
+
+	// Stream to get pending tool
+	var pendingTool *sdk.PendingClientTool
+	for chunk := range conv.Stream(ctx, "Where am I?") {
+		require.NoError(t, chunk.Error)
+		if chunk.Type == sdk.ChunkClientTool {
+			pendingTool = chunk.ClientTool
+		}
+	}
+	require.NotNil(t, pendingTool, "expected a ChunkClientTool")
+
+	// Reject and resume via streaming
+	conv.RejectClientTool(ctx, pendingTool.CallID, "user declined")
+
+	var resumeText string
+	var resumeDone *sdk.StreamChunk
+	for chunk := range conv.ResumeStream(ctx) {
+		require.NoError(t, chunk.Error)
+		if chunk.Type == sdk.ChunkText {
+			resumeText += chunk.Text
+		}
+		if chunk.Type == sdk.ChunkDone {
+			resumeDone = &chunk
+		}
+	}
+
+	require.NotNil(t, resumeDone)
+	assert.NotEmpty(t, resumeText, "resumed stream should produce text after rejection")
+	assert.False(t, resumeDone.Message.HasPendingClientTools())
 }


### PR DESCRIPTION
## Summary

Fixes four bugs in the client tools implementation discovered through in-depth code review:

- **Bug 1**: `Send()` fired lifecycle hooks (`IncrementTurn`, `SessionUpdate`, `dispatchTurnEvals`) even when the pipeline suspended with pending client tools — could corrupt turn counters and trigger evals prematurely
- **Bug 2**: `Resume()` was missing `dispatchTurnEvals()` and the pending-tools guard, diverging from `ResumeStream()` behavior
- **Bug 3**: `ClientToolRequest.CallID` was always empty because the call ID wasn't propagated through context to the executor — introduced `tools.WithCallID`/`CallIDFromContext` for context-based propagation
- **Bug 4**: `accumulateResult` in the stream pipeline dropped `ToolCalls` from assistant messages, breaking downstream inspection of pending tool calls

## Test plan

- [x] Unit tests for all four bugs (TDD — tests written first, then fixes applied)
- [x] `TestSend_SkipsHooksWhenPendingClientTools` / `TestSend_FiresHooksWhenNoPendingClientTools`
- [x] `TestResume_SkipsHooksWhenNestedPendingTools` / `TestResume_FiresHooksWhenNoPendingTools`
- [x] `TestClientExecutor_Execute_PopulatesCallID` / `TestClientExecutor_ExecuteAsync_PopulatesCallID`
- [x] `TestStreamPipeline_ExecuteSync/preserves_tool_calls_on_assistant_messages`
- [x] Integration tests: deferred round-trip, sync handler execution, rejection flow
- [x] All pre-commit checks pass (lint, build, tests, coverage ≥80%)
