### PR TITLE
fix(evals): auto-generate default metric for evals without explicit MetricDef

### DIFF
--- a/runtime/evals/integration_test.go
+++ b/runtime/evals/integration_test.go
@@ -118,6 +118,159 @@ func TestE2E_EvalRunner_FullFlow(t *testing.T) {
 	}
 }
 
+// TestE2E_EvalsWithoutExplicitMetric_StillEmitPrometheus verifies that evals
+// without a metric: block in the pack still produce Prometheus gauges using
+// the eval ID as the metric name. This is a regression test — a previous change
+// broke this by skipping evals without explicit MetricDef.
+func TestE2E_EvalsWithoutExplicitMetric_StillEmitPrometheus(t *testing.T) {
+	registry := evals.NewEmptyEvalTypeRegistry()
+	registry.Register(&stubHandler{
+		evalType: "quality_check",
+		result:   &evals.EvalResult{Score: float64P(0.85)},
+	})
+	registry.Register(&stubHandler{
+		evalType: "tone_check",
+		result:   &evals.EvalResult{Score: float64P(1.0)},
+	})
+
+	// Neither eval defines a Metric — this must still produce metrics.
+	defs := []evals.EvalDef{
+		{
+			ID:      "session-helpfulness",
+			Type:    "quality_check",
+			Trigger: evals.TriggerEveryTurn,
+			// No Metric field — should auto-generate gauge.
+		},
+		{
+			ID:      "tone-adherence",
+			Type:    "tone_check",
+			Trigger: evals.TriggerEveryTurn,
+			// No Metric field.
+		},
+	}
+
+	reg := prometheus.NewRegistry()
+	collector := metrics.NewCollector(metrics.CollectorOpts{
+		Registerer:             reg,
+		DisablePipelineMetrics: true,
+	})
+	metricCtx := collector.Bind(nil)
+	metricWriter := evals.NewMetricResultWriter(metricCtx, defs)
+	runner := evals.NewEvalRunner(registry)
+
+	evalCtx := &evals.EvalContext{
+		SessionID:     "test-session",
+		TurnIndex:     1,
+		CurrentOutput: "Sure, I can help with that.",
+	}
+
+	results := runner.RunTurnEvals(context.Background(), defs, evalCtx)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	if err := metricWriter.WriteResults(context.Background(), results); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify both evals produced Prometheus metrics.
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	famByName := make(map[string]*dto.MetricFamily, len(families))
+	for _, fam := range families {
+		famByName[fam.GetName()] = fam
+	}
+
+	// Auto-generated metric names should be: promptkit_eval_{evalID}
+	helpfulnessFam, ok := famByName["promptkit_eval_session-helpfulness"]
+	if !ok {
+		t.Fatal("expected promptkit_eval_session-helpfulness metric to be auto-generated for eval without explicit Metric definition")
+	}
+	if helpfulnessFam.GetType() != dto.MetricType_GAUGE {
+		t.Errorf("expected auto-generated metric to be gauge, got %v", helpfulnessFam.GetType())
+	}
+	if got := helpfulnessFam.GetMetric()[0].GetGauge().GetValue(); got != 0.85 {
+		t.Errorf("expected 0.85, got %v", got)
+	}
+
+	toneFam, ok := famByName["promptkit_eval_tone-adherence"]
+	if !ok {
+		t.Fatal("expected promptkit_eval_tone-adherence metric to be auto-generated")
+	}
+	if got := toneFam.GetMetric()[0].GetGauge().GetValue(); got != 1.0 {
+		t.Errorf("expected 1.0, got %v", got)
+	}
+}
+
+// TestE2E_MixedExplicitAndAutoMetrics verifies that evals with explicit metrics
+// use those definitions while evals without them get auto-generated gauges,
+// and both coexist correctly in the same Prometheus registry.
+func TestE2E_MixedExplicitAndAutoMetrics(t *testing.T) {
+	registry := evals.NewEmptyEvalTypeRegistry()
+	registry.Register(&stubHandler{
+		evalType: "check",
+		result:   &evals.EvalResult{Score: float64P(0.75), MetricValue: float64P(42)},
+	})
+
+	defs := []evals.EvalDef{
+		{
+			ID:      "with-metric",
+			Type:    "check",
+			Trigger: evals.TriggerEveryTurn,
+			Metric:  &evals.MetricDef{Name: "custom_metric", Type: evals.MetricHistogram},
+		},
+		{
+			ID:      "without-metric",
+			Type:    "check",
+			Trigger: evals.TriggerEveryTurn,
+			// No Metric — auto-generated.
+		},
+	}
+
+	reg := prometheus.NewRegistry()
+	collector := metrics.NewCollector(metrics.CollectorOpts{
+		Registerer:             reg,
+		DisablePipelineMetrics: true,
+	})
+	metricCtx := collector.Bind(nil)
+	metricWriter := evals.NewMetricResultWriter(metricCtx, defs)
+	runner := evals.NewEvalRunner(registry)
+
+	results := runner.RunTurnEvals(context.Background(), defs, &evals.EvalContext{
+		SessionID: "s1", TurnIndex: 1, CurrentOutput: "test",
+	})
+	if err := metricWriter.WriteResults(context.Background(), results); err != nil {
+		t.Fatal(err)
+	}
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	famByName := make(map[string]*dto.MetricFamily, len(families))
+	for _, fam := range families {
+		famByName[fam.GetName()] = fam
+	}
+
+	// Explicit metric should use the custom name and type.
+	if _, ok := famByName["promptkit_eval_custom_metric"]; !ok {
+		t.Fatal("expected explicit metric promptkit_eval_custom_metric")
+	}
+
+	// Auto-generated metric should exist as a gauge.
+	autoFam, ok := famByName["promptkit_eval_without-metric"]
+	if !ok {
+		t.Fatal("expected auto-generated metric promptkit_eval_without-metric")
+	}
+	if autoFam.GetType() != dto.MetricType_GAUGE {
+		t.Errorf("expected auto-generated to be gauge, got %v", autoFam.GetType())
+	}
+}
+
 func TestE2E_PackPromptOverrideResolution(t *testing.T) {
 	registry := evals.NewEmptyEvalTypeRegistry()
 	registry.Register(&stubHandler{

--- a/runtime/evals/metrics.go
+++ b/runtime/evals/metrics.go
@@ -12,8 +12,9 @@ type MetricRecorder interface {
 }
 
 // MetricResultWriter feeds eval results to a MetricRecorder for
-// Prometheus exposition. Only results whose corresponding EvalDef
-// has a Metric definition are recorded.
+// Prometheus exposition. Every eval result is recorded: if the EvalDef
+// includes an explicit Metric definition it is used; otherwise a default
+// gauge metric named after the eval ID is created automatically.
 type MetricResultWriter struct {
 	recorder MetricRecorder
 	// defs maps eval ID to its definition for metric lookup.
@@ -32,20 +33,41 @@ func NewMetricResultWriter(
 	return &MetricResultWriter{recorder: recorder, defs: m}
 }
 
-// WriteResults records each result that has an associated metric.
+// WriteResults records each eval result as a Prometheus metric.
+// If the EvalDef has an explicit Metric definition, that is used.
+// Otherwise a default gauge metric named after the eval ID is generated
+// so that every eval produces a metric without requiring pack authors
+// to define one explicitly.
 func (w *MetricResultWriter) WriteResults(
 	_ context.Context, results []EvalResult,
 ) error {
 	for i := range results {
-		def, ok := w.defs[results[i].EvalID]
-		if !ok || def.Metric == nil {
+		metric := w.metricForEval(results[i].EvalID)
+		if metric == nil {
 			continue
 		}
-		if err := w.recorder.Record(results[i], def.Metric); err != nil {
+		if err := w.recorder.Record(results[i], metric); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// metricForEval returns the metric definition for an eval result.
+// Returns the explicit definition if present, generates a default gauge
+// if the eval is known but has no metric, or returns nil for unknown evals.
+func (w *MetricResultWriter) metricForEval(evalID string) *MetricDef {
+	def, ok := w.defs[evalID]
+	if !ok {
+		return nil
+	}
+	if def.Metric != nil {
+		return def.Metric
+	}
+	// Auto-generate a default gauge metric for evals without an explicit definition.
+	m := &MetricDef{Name: evalID, Type: MetricGauge}
+	def.Metric = m
+	return m
 }
 
 // ExtractValue extracts the numeric value from an EvalResult.

--- a/runtime/evals/metrics_test.go
+++ b/runtime/evals/metrics_test.go
@@ -31,19 +31,14 @@ func TestExtractValue_DefaultsToZero(t *testing.T) {
 	}
 }
 
-func TestMetricResultWriter_SkipsEvalsWithoutMetric(t *testing.T) {
+func TestMetricResultWriter_UsesExplicitMetric(t *testing.T) {
 	recorder := &mockRecorder{}
 	defs := []EvalDef{
-		{ID: "e1", Type: "contains"},
-		{ID: "e2", Type: "contains", Metric: &MetricDef{Name: "m2", Type: MetricGauge}},
+		{ID: "e1", Type: "contains", Metric: &MetricDef{Name: "custom_name", Type: MetricHistogram}},
 	}
 	writer := NewMetricResultWriter(recorder, defs)
 
-	results := []EvalResult{
-		{EvalID: "e1"},
-		{EvalID: "e2", Score: float64Ptr(0.9)},
-		{EvalID: "e3"}, // unknown eval ID
-	}
+	results := []EvalResult{{EvalID: "e1", Score: float64Ptr(0.9)}}
 	if err := writer.WriteResults(nil, results); err != nil {
 		t.Fatal(err)
 	}
@@ -51,8 +46,62 @@ func TestMetricResultWriter_SkipsEvalsWithoutMetric(t *testing.T) {
 	if len(recorder.calls) != 1 {
 		t.Fatalf("expected 1 record call, got %d", len(recorder.calls))
 	}
-	if recorder.calls[0].metric.Name != "m2" {
-		t.Errorf("expected metric name m2, got %s", recorder.calls[0].metric.Name)
+	if recorder.calls[0].metric.Name != "custom_name" {
+		t.Errorf("expected metric name custom_name, got %s", recorder.calls[0].metric.Name)
+	}
+	if recorder.calls[0].metric.Type != MetricHistogram {
+		t.Errorf("expected metric type histogram, got %s", recorder.calls[0].metric.Type)
+	}
+}
+
+func TestMetricResultWriter_AutoGeneratesMetricForEvalsWithoutOne(t *testing.T) {
+	recorder := &mockRecorder{}
+	defs := []EvalDef{
+		{ID: "response-quality", Type: "llm_judge"},
+		{ID: "tone-check", Type: "contains"},
+	}
+	writer := NewMetricResultWriter(recorder, defs)
+
+	results := []EvalResult{
+		{EvalID: "response-quality", Score: float64Ptr(0.85)},
+		{EvalID: "tone-check", Score: float64Ptr(1.0)},
+	}
+	if err := writer.WriteResults(nil, results); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(recorder.calls) != 2 {
+		t.Fatalf("expected 2 record calls, got %d", len(recorder.calls))
+	}
+	// Auto-generated metrics should use eval ID as name and gauge as type.
+	if recorder.calls[0].metric.Name != "response-quality" {
+		t.Errorf("expected metric name response-quality, got %s", recorder.calls[0].metric.Name)
+	}
+	if recorder.calls[0].metric.Type != MetricGauge {
+		t.Errorf("expected default metric type gauge, got %s", recorder.calls[0].metric.Type)
+	}
+	if recorder.calls[1].metric.Name != "tone-check" {
+		t.Errorf("expected metric name tone-check, got %s", recorder.calls[1].metric.Name)
+	}
+}
+
+func TestMetricResultWriter_SkipsUnknownEvalIDs(t *testing.T) {
+	recorder := &mockRecorder{}
+	defs := []EvalDef{
+		{ID: "e1", Type: "contains"},
+	}
+	writer := NewMetricResultWriter(recorder, defs)
+
+	results := []EvalResult{
+		{EvalID: "e1", Score: float64Ptr(0.5)},
+		{EvalID: "unknown-eval"}, // not in defs — should be skipped
+	}
+	if err := writer.WriteResults(nil, results); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(recorder.calls) != 1 {
+		t.Fatalf("expected 1 record call (unknown skipped), got %d", len(recorder.calls))
 	}
 }
 

--- a/sdk/evaluate_test.go
+++ b/sdk/evaluate_test.go
@@ -604,7 +604,7 @@ func TestEvaluate_MetricsCollector_TakesPrecedence(t *testing.T) {
 }
 
 func TestEvaluate_MetricRecorder_NoMetricDef(t *testing.T) {
-	// Evals without Metric defs should not cause errors when MetricRecorder is set
+	// Evals without explicit Metric defs should auto-generate a gauge metric.
 	reg := prometheus.NewRegistry()
 	collector := metrics.NewCollector(metrics.CollectorOpts{
 		Registerer:             reg,
@@ -623,10 +623,10 @@ func TestEvaluate_MetricRecorder_NoMetricDef(t *testing.T) {
 	require.NotNil(t, results[0].Score)
 	assert.Equal(t, 1.0, *results[0].Score)
 
-	// No metrics should have been recorded
+	// An auto-generated gauge metric should have been recorded.
 	families, gatherErr := reg.Gather()
 	require.NoError(t, gatherErr)
-	assert.Empty(t, families, "no metrics should be recorded for evals without MetricDef")
+	assert.NotEmpty(t, families, "evals without explicit MetricDef should still emit auto-generated metrics")
 }
 
 func TestValidateEvalTypes_AllRegistered(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fix**: `MetricResultWriter` was skipping evals without an explicit `metric:` block in the pack, silently producing no Prometheus metrics for those evals
- **Change**: Evals without a `MetricDef` now auto-generate a default gauge metric named after the eval ID, so every eval that runs emits a metric without requiring pack authors to opt in
- **Tests**: Added unit and integration tests that verify auto-generation works end-to-end through the Prometheus registry, preventing this regression from recurring

## Test plan

- [x] Unit tests: explicit metrics respected, auto-generation works, unknown eval IDs skipped
- [x] Integration tests: end-to-end eval runner → writer → Prometheus registry with no explicit metrics
- [x] Integration test: mixed explicit + auto-generated metrics coexist in same registry
- [x] SDK test: `Evaluate()` with `MetricRecorder` and no `MetricDef` emits metrics
- [x] Full runtime + SDK test suites pass
- [x] Pre-commit hook passes (lint, build, coverage ≥80%)