### PR TITLE
feat(docs): add Omnia adapter docs to build-time fetch

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -33,6 +33,10 @@ src/content/docs/arena/tutorials/deploy/agentcore/
 src/content/docs/arena/how-to/deploy/agentcore/
 src/content/docs/arena/reference/deploy/agentcore/
 src/content/docs/arena/explanation/deploy/agentcore/
+src/content/docs/arena/tutorials/deploy/omnia/
+src/content/docs/arena/how-to/deploy/omnia/
+src/content/docs/arena/reference/deploy/omnia/
+src/content/docs/arena/explanation/deploy/omnia/
 
 # macOS-specific files
 .DS_Store

--- a/docs/scripts/fetch-adapter-docs.mjs
+++ b/docs/scripts/fetch-adapter-docs.mjs
@@ -4,6 +4,8 @@
  * Fetches adapter documentation from external repos at build time and
  * maps them into the arena/ documentation sections.
  *
+ * Supports multiple adapters — each defined in the ADAPTERS array.
+ *
  * Usage:
  *   node scripts/fetch-adapter-docs.mjs [--ref <branch|tag>]
  *
@@ -20,57 +22,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DOCS_ROOT = path.join(__dirname, "..");
 const ARENA_DIR = path.join(DOCS_ROOT, "src/content/docs/arena");
 
-const REPO = "AltairaLabs/promptarena-deploy-agentcore";
 const SOURCE_PREFIX = "docs/src/content/docs/";
-
-// Mapping from upstream file paths (relative to SOURCE_PREFIX) to arena deploy targets.
-const FILE_MAP = {
-  "index.md": { target: "explanation/deploy/agentcore/overview.md", order: 50 },
-  "tutorials/01-first-deployment.md": {
-    target: "tutorials/deploy/agentcore/first-deployment.md",
-    order: 50,
-  },
-  "tutorials/02-multi-agent.md": {
-    target: "tutorials/deploy/agentcore/multi-agent.md",
-    order: 50,
-  },
-  "how-to/configure.md": {
-    target: "how-to/deploy/agentcore/configure.md",
-    order: 50,
-  },
-  "how-to/dry-run.md": {
-    target: "how-to/deploy/agentcore/dry-run.md",
-    order: 50,
-  },
-  "how-to/tagging.md": {
-    target: "how-to/deploy/agentcore/tagging.md",
-    order: 50,
-  },
-  "how-to/observability.md": {
-    target: "how-to/deploy/agentcore/observability.md",
-    order: 50,
-  },
-  "reference/configuration.md": {
-    target: "reference/deploy/agentcore/configuration.md",
-    order: 50,
-  },
-  "reference/resource-types.md": {
-    target: "reference/deploy/agentcore/resource-types.md",
-    order: 50,
-  },
-  "reference/environment-variables.md": {
-    target: "reference/deploy/agentcore/env-vars.md",
-    order: 50,
-  },
-  "explanation/resource-lifecycle.md": {
-    target: "explanation/deploy/agentcore/resource-lifecycle.md",
-    order: 50,
-  },
-  "explanation/security.md": {
-    target: "explanation/deploy/agentcore/security.md",
-    order: 50,
-  },
-};
 
 // Skip upstream index pages — arena already has section indexes.
 const SKIP_FILES = new Set([
@@ -80,45 +32,7 @@ const SKIP_FILES = new Set([
   "explanation/index.md",
 ]);
 
-// Mapping of upstream internal relative slugs to their new agentcore filenames.
-// Used to rewrite same-section relative links.
-const SLUG_MAP = {
-  "01-first-deployment": "first-deployment",
-  "02-multi-agent": "multi-agent",
-  configure: "configure",
-  "dry-run": "dry-run",
-  tagging: "tagging",
-  observability: "observability",
-  configuration: "configuration",
-  "resource-types": "resource-types",
-  "environment-variables": "env-vars",
-  "resource-lifecycle": "resource-lifecycle",
-  security: "security",
-};
-
-// Mapping from upstream absolute internal paths to new arena paths.
-// These handle links like /reference/configuration/ → /arena/reference/deploy/agentcore/configuration/
-const ABSOLUTE_INTERNAL_MAP = {
-  "/tutorials/01-first-deployment/":
-    "/arena/tutorials/deploy/agentcore/first-deployment/",
-  "/tutorials/02-multi-agent/":
-    "/arena/tutorials/deploy/agentcore/multi-agent/",
-  "/how-to/configure/": "/arena/how-to/deploy/agentcore/configure/",
-  "/how-to/dry-run/": "/arena/how-to/deploy/agentcore/dry-run/",
-  "/how-to/tagging/": "/arena/how-to/deploy/agentcore/tagging/",
-  "/how-to/observability/": "/arena/how-to/deploy/agentcore/observability/",
-  "/reference/configuration/":
-    "/arena/reference/deploy/agentcore/configuration/",
-  "/reference/resource-types/":
-    "/arena/reference/deploy/agentcore/resource-types/",
-  "/reference/environment-variables/":
-    "/arena/reference/deploy/agentcore/env-vars/",
-  "/explanation/resource-lifecycle/":
-    "/arena/explanation/deploy/agentcore/resource-lifecycle/",
-  "/explanation/security/": "/arena/explanation/deploy/agentcore/security/",
-};
-
-// Mapping from old /deploy/ absolute links to their new arena paths.
+// Mapping from old /deploy/ absolute links to their new arena paths (shared across adapters).
 const DEPLOY_LINK_MAP = {
   "/deploy/": "/arena/explanation/deploy/overview/",
   "/deploy/tutorials/01-first-deployment/":
@@ -137,20 +51,151 @@ const DEPLOY_LINK_MAP = {
     "/arena/explanation/deploy/adapter-architecture/",
   "/deploy/explanation/state-management/":
     "/arena/explanation/deploy/state-management/",
-  "/deploy/adapters/agentcore/":
-    "/arena/explanation/deploy/agentcore/overview/",
 };
 
 // Absolute link prefixes that belong to parent PromptKit docs — leave as-is.
 const PARENT_PREFIXES = ["/packc/", "/sdk/", "/arena/", "/runtime/"];
 
-// Sections that exist inside the adapter docs (used to detect internal absolute links).
+// Sections that exist inside adapter docs (used to detect internal absolute links).
 const ADAPTER_SECTIONS = [
   "how-to",
   "reference",
   "explanation",
   "tutorials",
 ];
+
+// ---------------------------------------------------------------------------
+// Adapter definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Build adapter config for a standard adapter repo.
+ *
+ * Convention: each adapter has the same upstream doc structure and maps to
+ * arena/{section}/deploy/{adapterName}/{file}.
+ */
+function buildAdapterConfig(name, repo, extraFiles = {}) {
+  // Standard files every adapter has.
+  const standardFiles = {
+    "index.md": { target: `explanation/deploy/${name}/overview.md`, order: 50 },
+    "tutorials/01-first-deployment.md": {
+      target: `tutorials/deploy/${name}/first-deployment.md`,
+      order: 50,
+    },
+    "tutorials/02-multi-agent.md": {
+      target: `tutorials/deploy/${name}/multi-agent.md`,
+      order: 50,
+    },
+    "how-to/configure.md": {
+      target: `how-to/deploy/${name}/configure.md`,
+      order: 50,
+    },
+    "how-to/dry-run.md": {
+      target: `how-to/deploy/${name}/dry-run.md`,
+      order: 50,
+    },
+    "reference/configuration.md": {
+      target: `reference/deploy/${name}/configuration.md`,
+      order: 50,
+    },
+    "reference/resource-types.md": {
+      target: `reference/deploy/${name}/resource-types.md`,
+      order: 50,
+    },
+    "explanation/resource-lifecycle.md": {
+      target: `explanation/deploy/${name}/resource-lifecycle.md`,
+      order: 50,
+    },
+    "explanation/security.md": {
+      target: `explanation/deploy/${name}/security.md`,
+      order: 50,
+    },
+  };
+
+  // Standard slug mappings.
+  const slugMap = {
+    "01-first-deployment": "first-deployment",
+    "02-multi-agent": "multi-agent",
+    configure: "configure",
+    "dry-run": "dry-run",
+    configuration: "configuration",
+    "resource-types": "resource-types",
+    "resource-lifecycle": "resource-lifecycle",
+    security: "security",
+  };
+
+  // Build absolute internal link map from the file map.
+  const absoluteInternalMap = {};
+  for (const [src, mapping] of Object.entries({ ...standardFiles, ...extraFiles })) {
+    // Derive the upstream absolute path from the source filename.
+    const upstreamSlug = src.replace(/\.md$/, "").replace(/^index$/, "");
+    if (upstreamSlug) {
+      const upstreamPath = `/${upstreamSlug}/`;
+      const arenaPath = `/arena/${mapping.target.replace(/\.md$/, "")}/`;
+      absoluteInternalMap[upstreamPath] = arenaPath;
+    }
+  }
+
+  return {
+    name,
+    repo,
+    fileMap: { ...standardFiles, ...extraFiles },
+    slugMap: { ...slugMap, ...Object.fromEntries(
+      Object.entries(extraFiles).map(([src]) => {
+        const slug = path.basename(src, ".md");
+        return [slug, slug];
+      }),
+    )},
+    absoluteInternalMap,
+  };
+}
+
+const ADAPTERS = [
+  buildAdapterConfig(
+    "agentcore",
+    "AltairaLabs/promptarena-deploy-agentcore",
+    {
+      // Extra files specific to agentcore.
+      "how-to/tagging.md": {
+        target: "how-to/deploy/agentcore/tagging.md",
+        order: 50,
+      },
+      "how-to/observability.md": {
+        target: "how-to/deploy/agentcore/observability.md",
+        order: 50,
+      },
+      "reference/environment-variables.md": {
+        target: "reference/deploy/agentcore/env-vars.md",
+        order: 50,
+      },
+      "reference/runtime-protocols.md": {
+        target: "reference/deploy/agentcore/runtime-protocols.md",
+        order: 50,
+      },
+    },
+  ),
+  buildAdapterConfig(
+    "omnia",
+    "AltairaLabs/PromptArena-deploy-omnia",
+    {
+      // Extra files specific to omnia.
+      "how-to/labels.md": {
+        target: "how-to/deploy/omnia/labels.md",
+        order: 51,
+      },
+    },
+  ),
+];
+
+// Add agentcore-specific deploy link mapping.
+DEPLOY_LINK_MAP["/deploy/adapters/agentcore/"] =
+  "/arena/explanation/deploy/agentcore/overview/";
+DEPLOY_LINK_MAP["/deploy/adapters/omnia/"] =
+  "/arena/explanation/deploy/omnia/overview/";
+
+// ---------------------------------------------------------------------------
+// Shared utilities
+// ---------------------------------------------------------------------------
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -183,8 +228,8 @@ function ghAPI(endpoint) {
 /**
  * List markdown files under SOURCE_PREFIX in the given ref.
  */
-function listFiles(ref) {
-  const data = ghAPI(`repos/${REPO}/git/trees/${ref}?recursive=1`);
+function listFiles(repo, ref) {
+  const data = ghAPI(`repos/${repo}/git/trees/${ref}?recursive=1`);
   if (!data?.tree) return [];
   return data.tree
     .filter(
@@ -199,8 +244,8 @@ function listFiles(ref) {
 /**
  * Fetch a single file's content (base64-decoded).
  */
-function fetchFile(filePath, ref) {
-  const data = ghAPI(`repos/${REPO}/contents/${filePath}?ref=${ref}`);
+function fetchFile(repo, filePath, ref) {
+  const data = ghAPI(`repos/${repo}/contents/${filePath}?ref=${ref}`);
   if (!data?.content) return null;
   return Buffer.from(data.content, "base64").toString("utf-8");
 }
@@ -222,7 +267,6 @@ function rewriteFrontmatter(content, order) {
   }
 
   // If no sidebar section at all, add one before the closing ---
-  // Find the second --- (end of frontmatter)
   const parts = content.split("---");
   if (parts.length >= 3) {
     parts[1] = parts[1].trimEnd() + `\nsidebar:\n  order: ${order}\n`;
@@ -233,15 +277,9 @@ function rewriteFrontmatter(content, order) {
 }
 
 /**
- * Rewrite links in markdown content for agentcore adapter docs.
- *
- * Handles:
- * - Relative same-section links (e.g., ../dry-run/) → ../agentcore-dry-run/
- * - Absolute internal links (/reference/configuration/) → /arena/reference/agentcore-configuration/
- * - Absolute /deploy/ links → new arena paths
- * - External URLs and parent doc links → unchanged
+ * Rewrite links in markdown content for an adapter's docs.
  */
-function rewriteLinks(content) {
+function rewriteLinks(content, adapter) {
   return content.replace(
     /\[([^\]]*)\]\(([^)]+)\)/g,
     (match, text, url) => {
@@ -252,9 +290,7 @@ function rewriteLinks(content) {
 
       // Handle relative links — rewrite slug part
       if (!url.startsWith("/")) {
-        // Extract the slug from relative paths like ../dry-run/ or ./configure/
-        for (const [oldSlug, newSlug] of Object.entries(SLUG_MAP)) {
-          // Match patterns like ../dry-run/, ../dry-run, ./dry-run/, dry-run/
+        for (const [oldSlug, newSlug] of Object.entries(adapter.slugMap)) {
           const patterns = [
             `../${oldSlug}/`,
             `../${oldSlug}`,
@@ -265,7 +301,6 @@ function rewriteLinks(content) {
           ];
           for (const pat of patterns) {
             if (url === pat) {
-              // Preserve the relative prefix style
               const prefix = url.startsWith("../")
                 ? "../"
                 : url.startsWith("./")
@@ -291,8 +326,8 @@ function rewriteLinks(content) {
         return match;
       }
 
-      // Handle absolute internal adapter links (/reference/configuration/)
-      for (const [oldPath, newPath] of Object.entries(ABSOLUTE_INTERNAL_MAP)) {
+      // Handle absolute internal adapter links
+      for (const [oldPath, newPath] of Object.entries(adapter.absoluteInternalMap)) {
         if (url === oldPath) {
           return `[${text}](${newPath})`;
         }
@@ -302,7 +337,6 @@ function rewriteLinks(content) {
       const stripped = url.replace(/^\//, "");
       const firstSegment = stripped.split("/")[0];
       if (ADAPTER_SECTIONS.includes(firstSegment)) {
-        // Fallback: prefix with /arena/ and try to match
         const arenaUrl = `/arena${url}`;
         return `[${text}](${arenaUrl})`;
       }
@@ -313,21 +347,19 @@ function rewriteLinks(content) {
   );
 }
 
-async function main() {
-  if (process.env.SKIP_ADAPTER_DOCS === "1") {
-    console.log("[fetch-adapter-docs] SKIP_ADAPTER_DOCS=1 — skipping.");
-    return;
-  }
+// ---------------------------------------------------------------------------
+// Per-adapter fetch
+// ---------------------------------------------------------------------------
 
-  const { ref } = parseArgs();
-  console.log(`[fetch-adapter-docs] Fetching from ${REPO}@${ref} ...`);
+async function fetchAdapter(adapter, ref) {
+  console.log(`[fetch-adapter-docs] Fetching ${adapter.name} from ${adapter.repo}@${ref} ...`);
 
-  const files = listFiles(ref);
+  const files = listFiles(adapter.repo, ref);
   if (files.length === 0) {
     console.warn(
-      "[fetch-adapter-docs] Warning: no files found (gh CLI missing or API error). Skipping.",
+      `[fetch-adapter-docs] Warning: no files found for ${adapter.name} (gh CLI missing or API error). Skipping.`,
     );
-    return;
+    return { written: 0, skipped: 0 };
   }
 
   let written = 0;
@@ -335,23 +367,21 @@ async function main() {
   for (const filePath of files) {
     const relativePath = filePath.slice(SOURCE_PREFIX.length);
 
-    // Skip upstream index pages
     if (SKIP_FILES.has(relativePath)) {
       skipped++;
       continue;
     }
 
-    // Look up the mapping
-    const mapping = FILE_MAP[relativePath];
+    const mapping = adapter.fileMap[relativePath];
     if (!mapping) {
       console.warn(
-        `[fetch-adapter-docs] Warning: no mapping for ${relativePath} — skipping.`,
+        `[fetch-adapter-docs] Warning: no mapping for ${adapter.name}:${relativePath} — skipping.`,
       );
       skipped++;
       continue;
     }
 
-    const content = fetchFile(filePath, ref);
+    const content = fetchFile(adapter.repo, filePath, ref);
     if (content === null) {
       console.warn(
         `[fetch-adapter-docs] Warning: failed to fetch ${filePath}`,
@@ -359,7 +389,7 @@ async function main() {
       continue;
     }
 
-    let rewritten = rewriteLinks(content);
+    let rewritten = rewriteLinks(content, adapter);
     rewritten = rewriteFrontmatter(rewritten, mapping.order);
 
     const targetPath = path.join(ARENA_DIR, mapping.target);
@@ -368,8 +398,32 @@ async function main() {
     written++;
   }
 
+  return { written, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (process.env.SKIP_ADAPTER_DOCS === "1") {
+    console.log("[fetch-adapter-docs] SKIP_ADAPTER_DOCS=1 — skipping.");
+    return;
+  }
+
+  const { ref } = parseArgs();
+
+  let totalWritten = 0;
+  let totalSkipped = 0;
+
+  for (const adapter of ADAPTERS) {
+    const { written, skipped } = await fetchAdapter(adapter, ref);
+    totalWritten += written;
+    totalSkipped += skipped;
+  }
+
   console.log(
-    `[fetch-adapter-docs] Wrote ${written} files, skipped ${skipped}. Target: arena/`,
+    `[fetch-adapter-docs] Done. Wrote ${totalWritten} files, skipped ${totalSkipped}. Target: arena/`,
   );
 }
 


### PR DESCRIPTION
## Summary

- Refactor `docs/scripts/fetch-adapter-docs.mjs` from single-adapter to multi-adapter via a config-driven `ADAPTERS` array
- Add Omnia adapter (`PromptArena-deploy-omnia`) alongside AgentCore
- Extract `buildAdapterConfig()` helper to reduce duplication across adapters
- Add omnia `.gitignore` paths for fetched docs

## Details

The fetch script now supports multiple adapters. Each adapter is defined with:
- Repository name
- File map (upstream path → arena target path)
- Slug map (for relative link rewriting)
- Absolute internal link map (auto-derived from file map)

Standard doc files (tutorials, how-to, reference, explanation) are shared across all adapters. Adapter-specific extras (e.g. agentcore's `observability.md`, omnia's `labels.md`) are passed as overrides.

Fetched omnia docs land in:
- `arena/tutorials/deploy/omnia/`
- `arena/how-to/deploy/omnia/`
- `arena/reference/deploy/omnia/`
- `arena/explanation/deploy/omnia/`

## Test plan

- [x] `node --check docs/scripts/fetch-adapter-docs.mjs` passes
- [x] `SKIP_ADAPTER_DOCS=1` correctly skips
- [x] Full fetch writes 23 files (13 agentcore + 10 omnia), skips 5 index pages
- [x] Fetched omnia docs have correct frontmatter (`sidebar.order: 50`)
- [x] Gitignore prevents fetched docs from being committed