### PR TITLE
ci: notify promptarena-deploy-omnia on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,6 +618,17 @@ jobs:
           -f "client_payload[version]=$VERSION"
         echo "✓ Dispatched to promptarena-deploy-agentcore"
 
+    - name: Dispatch to promptarena-deploy-omnia
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+        GH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
+      run: |
+        echo "Notifying promptarena-deploy-omnia of runtime/$VERSION..."
+        gh api repos/AltairaLabs/PromptArena-deploy-omnia/dispatches \
+          -f event_type=promptkit-release \
+          -f "client_payload[version]=$VERSION"
+        echo "✓ Dispatched to promptarena-deploy-omnia"
+
   summary:
     name: Release Summary
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `repository_dispatch` step to the `notify-downstream` job in `release.yml`
- Omnia adapter now receives `promptkit-release` events alongside AgentCore
- Triggers the `update-deps.yml` workflow in `PromptArena-deploy-omnia` to auto-update `go.mod`

## Test plan

- [x] YAML is valid (no Go changes, CI skipped by paths-ignore)
- [ ] Next PromptKit release will dispatch to both adapter repos