### PR TITLE
feat(config): deprecate redundant self_play.enabled flag

### DIFF
--- a/.claude/skills/arena-example/SKILL.md
+++ b/.claude/skills/arena-example/SKILL.md
@@ -169,7 +169,6 @@ Self-play requires `self_play` config in the arena config:
 ```yaml
 spec:
   self_play:
-    enabled: true
     roles:
       - id: gemini-user
         provider: <provider-id>

--- a/docs/src/content/docs/arena/tutorials/03-multi-turn.md
+++ b/docs/src/content/docs/arena/tutorials/03-multi-turn.md
@@ -431,7 +431,6 @@ Self-play requires configuration in your `arena.yaml`:
 
 ```yaml
 self_play:
-  enabled: true
   personas:
     - file: personas/frustrated-customer.persona.yaml
   roles:

--- a/examples/assertions-test/config.arena.yaml
+++ b/examples/assertions-test/config.arena.yaml
@@ -25,7 +25,6 @@ spec:
 
     # Self-play configuration
   self_play:
-    enabled: true
     personas:
       - file: personas/curious-learner.persona.yaml
     roles:

--- a/examples/customer-support-integrated/config.arena.yaml
+++ b/examples/customer-support-integrated/config.arena.yaml
@@ -24,7 +24,6 @@ spec:
 
   # Self-play configuration
   self_play:
-    enabled: true
     personas:
       - file: personas/social-engineer.persona.yaml
     roles:

--- a/examples/duplex-streaming/config.arena.yaml
+++ b/examples/duplex-streaming/config.arena.yaml
@@ -50,7 +50,6 @@ spec:
 
   # Self-play configuration for simulated conversations
   self_play:
-    enabled: true
     personas:
       - file: personas/curious-customer.persona.yaml
       - file: personas/technical-user.persona.yaml

--- a/examples/load-testing/config.arena.yaml
+++ b/examples/load-testing/config.arena.yaml
@@ -17,7 +17,6 @@ spec:
     - file: scenarios/deep-conversation.scenario.yaml
 
   self_play:
-    enabled: true
     personas:
       - file: personas/detail-planner.persona.yaml
       - file: personas/senior-engineer.persona.yaml

--- a/examples/variables-demo/config.arena.yaml
+++ b/examples/variables-demo/config.arena.yaml
@@ -68,7 +68,6 @@ spec:
     - file: scenarios/product-enterprise.scenario.yaml
 
   self_play:
-    enabled: true
     personas:
       - file: personas/selfplay-default.persona.yaml
     roles:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -327,6 +327,7 @@ func TestConfig_Defaults(t *testing.T) {
 }
 
 func TestLoadConfig_WithSelfPlay(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
 	// Create a temporary config file
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "test-config.yaml")
@@ -407,7 +408,6 @@ spec:
     - file: provider1.yaml
 
   self_play:
-    enabled: true
     personas:
       - file: persona1.yaml
     roles:
@@ -434,7 +434,7 @@ spec:
 		t.Fatal("SelfPlay config is nil")
 	}
 
-	if !config.SelfPlay.Enabled {
+	if !config.SelfPlay.IsEnabled() {
 		t.Error("Expected self-play to be enabled")
 	}
 

--- a/pkg/config/inline_specs_test.go
+++ b/pkg/config/inline_specs_test.go
@@ -270,7 +270,6 @@ func TestInlinePersonaSpecs(t *testing.T) {
 	configPath := writeArenaConfig(t, dir, `  providers:
     - file: `+provFile+`
   self_play:
-    enabled: true
     personas: []
     persona_specs:
       frustrated-user:

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -233,7 +233,7 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 
 	// Load self-play resources if enabled
-	if cfg.SelfPlay != nil && cfg.SelfPlay.Enabled {
+	if cfg.SelfPlay != nil && cfg.SelfPlay.IsEnabled() {
 		if err := cfg.loadSelfPlayResources(filename); err != nil {
 			return nil, err
 		}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -358,12 +358,25 @@ type ToolRef struct {
 	File string `yaml:"file" json:"file"`
 }
 
-// SelfPlayConfig configures self-play functionality
+// SelfPlayConfig configures self-play functionality.
+// Self-play is enabled by default when this section is present.
 type SelfPlayConfig struct {
-	Enabled      bool                        `yaml:"enabled" json:"enabled"`
+	// Deprecated: Enabled is redundant — self-play is enabled whenever this section
+	// is present. The field is retained for backward compatibility and will be removed
+	// in a future release. To disable self-play, remove the self_play section entirely.
+	Enabled      *bool                       `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	Personas     []PersonaRef                `yaml:"personas" json:"personas"`
 	PersonaSpecs map[string]*UserPersonaPack `yaml:"persona_specs,omitempty" json:"persona_specs,omitempty"`
 	Roles        []SelfPlayRoleGroup         `yaml:"roles" json:"roles"`
+}
+
+// IsEnabled returns whether self-play is enabled. Defaults to true when the
+// Enabled field is not set (nil).
+func (c *SelfPlayConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
 }
 
 // PersonaRef references a persona file

--- a/pkg/config/types_json_test.go
+++ b/pkg/config/types_json_test.go
@@ -64,7 +64,6 @@ func TestConfig_JSONRoundTrip(t *testing.T) {
 			Verbose:     true,
 		},
 		SelfPlay: &SelfPlayConfig{
-			Enabled:  true,
 			Personas: []PersonaRef{{File: "personas/p1.yaml"}},
 			Roles:    []SelfPlayRoleGroup{{ID: "r1", Provider: "openai"}},
 		},

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -236,7 +236,7 @@ func (v *ConfigValidator) validateSelfPlay() {
 		return // Self-play is optional
 	}
 
-	if !v.config.SelfPlay.Enabled {
+	if !v.config.SelfPlay.IsEnabled() {
 		return // Disabled, no need to validate
 	}
 

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -303,9 +303,10 @@ func TestConfigValidator_ValidatePersonas_MissingFile(t *testing.T) {
 }
 
 func TestConfigValidator_ValidateSelfPlay_Disabled(t *testing.T) {
+	disabled := false
 	cfg := &Config{
 		SelfPlay: &SelfPlayConfig{
-			Enabled: false,
+			Enabled: &disabled,
 		},
 	}
 
@@ -321,8 +322,7 @@ func TestConfigValidator_ValidateSelfPlay_Disabled(t *testing.T) {
 func TestConfigValidator_ValidateSelfPlay_NoRoles(t *testing.T) {
 	cfg := &Config{
 		SelfPlay: &SelfPlayConfig{
-			Enabled: true,
-			Roles:   []SelfPlayRoleGroup{},
+			Roles: []SelfPlayRoleGroup{},
 		},
 	}
 
@@ -345,7 +345,6 @@ func TestConfigValidator_ValidateSelfPlay_DuplicateRoleIDs(t *testing.T) {
 
 	cfg := &Config{
 		SelfPlay: &SelfPlayConfig{
-			Enabled: true,
 			Roles: []SelfPlayRoleGroup{
 				{ID: "role1", Provider: "openai-gpt4o-mini"},
 				{ID: "role1", Provider: "claude-haiku"}, // Duplicate ID
@@ -364,7 +363,6 @@ func TestConfigValidator_ValidateSelfPlay_DuplicateRoleIDs(t *testing.T) {
 func TestConfigValidator_ValidateSelfPlay_MissingProvider(t *testing.T) {
 	cfg := &Config{
 		SelfPlay: &SelfPlayConfig{
-			Enabled: true,
 			Roles: []SelfPlayRoleGroup{
 				{ID: "role1"}, // Missing Provider
 			},

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2003,7 +2003,6 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "enabled",
         "personas",
         "roles"
       ]

--- a/tools/arena/cmd/promptarena/config_inspect_collector_interactive.go
+++ b/tools/arena/cmd/promptarena/config_inspect_collector_interactive.go
@@ -15,7 +15,7 @@ func collectInspectionData(cfg *config.Config, configFile string) *InspectionDat
 	data := &InspectionData{
 		ConfigFile:         filepath.Base(configFile),
 		AvailableTaskTypes: getAvailableTaskTypes(cfg),
-		SelfPlayEnabled:    cfg.SelfPlay != nil && cfg.SelfPlay.Enabled,
+		SelfPlayEnabled:    cfg.SelfPlay != nil && cfg.SelfPlay.IsEnabled(),
 	}
 
 	// Collect each section using helper functions

--- a/tools/arena/engine/builder_additional_test.go
+++ b/tools/arena/engine/builder_additional_test.go
@@ -98,7 +98,6 @@ func TestBuildSelfPlayComponents_Success(t *testing.T) {
 			},
 		},
 		SelfPlay: &config.SelfPlayConfig{
-			Enabled: true,
 			Roles: []config.SelfPlayRoleGroup{
 				{
 					ID:       "user-role",
@@ -123,7 +122,6 @@ func TestBuildSelfPlayComponents_UnknownProvider(t *testing.T) {
 	cfg := &config.Config{
 		LoadedProviders: map[string]*config.Provider{},
 		SelfPlay: &config.SelfPlayConfig{
-			Enabled: true,
 			Roles: []config.SelfPlayRoleGroup{
 				{
 					ID:       "user-role",
@@ -153,7 +151,6 @@ func TestBuildSelfPlayComponents_ProviderNotInRegistry(t *testing.T) {
 			},
 		},
 		SelfPlay: &config.SelfPlayConfig{
-			Enabled: true,
 			Roles: []config.SelfPlayRoleGroup{
 				{
 					ID:       "user-role",
@@ -188,7 +185,6 @@ func TestBuildSelfPlayComponents_MultipleRoles(t *testing.T) {
 			},
 		},
 		SelfPlay: &config.SelfPlayConfig{
-			Enabled: true,
 			Roles: []config.SelfPlayRoleGroup{
 				{
 					ID:       "assistant-role",
@@ -229,7 +225,6 @@ func TestNewConversationExecutor_WithSelfPlay(t *testing.T) {
 			},
 		},
 		SelfPlay: &config.SelfPlayConfig{
-			Enabled: true,
 			Roles: []config.SelfPlayRoleGroup{
 				{
 					ID:       "user-role",

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -479,7 +479,7 @@ func newConversationExecutor(
 	var selfPlayExecutor *turnexecutors.SelfPlayExecutor
 	var selfPlayRegistry *selfplay.Registry
 
-	if cfg.SelfPlay != nil && cfg.SelfPlay.Enabled {
+	if cfg.SelfPlay != nil && cfg.SelfPlay.IsEnabled() {
 		var err error
 		selfPlayRegistry, selfPlayExecutor, err = buildSelfPlayComponents(cfg, pipelineExecutor, providerRegistry)
 		if err != nil {

--- a/tools/arena/engine/conversation_executor_streaming_test.go
+++ b/tools/arena/engine/conversation_executor_streaming_test.go
@@ -563,7 +563,7 @@ func TestExecuteConversation_SelfPlayTurnNonStreaming(t *testing.T) {
 		Provider: mockProvider,
 		Config: &config.Config{
 			Defaults: config.Defaults{Verbose: false},
-			SelfPlay: &config.SelfPlayConfig{Enabled: true},
+			SelfPlay: &config.SelfPlayConfig{},
 		},
 		StateStoreConfig: &StateStoreConfig{
 			Store:  createTestStateStore(),
@@ -634,7 +634,7 @@ func TestExecuteConversation_SelfPlayTurnStreaming(t *testing.T) {
 		Provider: mockProvider,
 		Config: &config.Config{
 			Defaults: config.Defaults{Verbose: false},
-			SelfPlay: &config.SelfPlayConfig{Enabled: true},
+			SelfPlay: &config.SelfPlayConfig{},
 		},
 		StateStoreConfig: &StateStoreConfig{
 			Store:  createTestStateStore(),

--- a/tools/arena/engine/duplex_executor_pipeline_integration.go
+++ b/tools/arena/engine/duplex_executor_pipeline_integration.go
@@ -357,7 +357,7 @@ func (de *DuplexConversationExecutor) applySelfPlayVADConfig(
 	cfg *providers.StreamingInputConfig,
 	req *ConversationRequest,
 ) {
-	if req.Config == nil || req.Config.SelfPlay == nil || !req.Config.SelfPlay.Enabled {
+	if req.Config == nil || req.Config.SelfPlay == nil || !req.Config.SelfPlay.IsEnabled() {
 		return
 	}
 	cfg.Metadata["vad_disabled"] = true


### PR DESCRIPTION
## Summary

- Self-play is now enabled by default whenever the `self_play:` section is present in config, making `enabled: true` redundant
- The `Enabled` field is changed from `bool` to `*bool` (optional) with a deprecation notice — `enabled: false` still works for backward compatibility
- Added `IsEnabled()` method on `SelfPlayConfig` that defaults to `true` when the field is omitted
- Removed `enabled` from the JSON schema `required` array; regenerated schemas
- Removed `enabled: true` from all example configs, docs, and skill templates

## Test plan

- [x] All `pkg/config` tests pass (lint, build, coverage ≥80%)
- [x] All `tools/arena` tests pass
- [x] Pre-commit hook passes
- [ ] CI passes