### PR TITLE
feat(pipeline): add BaseMetadata for per-session metadata propagation

### DIFF
--- a/docs/src/content/docs/runtime/explanation/pipeline-architecture.md
+++ b/docs/src/content/docs/runtime/explanation/pipeline-architecture.md
@@ -85,6 +85,19 @@ type StreamElement struct {
 
 **Key insight**: Each element carries one content type, enabling type-safe routing and priority scheduling.
 
+### Base Metadata
+
+Pipelines support `BaseMetadata` — a set of key-value pairs that are automatically merged into every `StreamElement` entering the pipeline. This is designed for session-level context (e.g., `session_id`, `tenant_id`, `user_id`) that should be available to all stages and providers on every turn without manual injection per element.
+
+```go
+pipeline.BaseMetadata = map[string]interface{}{
+    "session_id": sessionID,
+    "tenant_id":  tenantID,
+}
+```
+
+Base metadata is merged at the `Execute`/`ExecuteSync` boundary. Per-element metadata takes precedence on key collision, so stages and callers can always override base values for specific elements.
+
 ## Stage Interface
 
 All stages implement:

--- a/docs/src/content/docs/runtime/how-to/configure-pipeline.md
+++ b/docs/src/content/docs/runtime/how-to/configure-pipeline.md
@@ -425,6 +425,25 @@ func ExecuteSync(ctx context.Context, pipeline *stage.StreamPipeline, message st
 }
 ```
 
+## Session Metadata
+
+Use `BaseMetadata` to attach session-level context that flows through to all stages and providers on every turn:
+
+```go
+pipeline, _ := builder.Build()
+pipeline.BaseMetadata = map[string]interface{}{
+    "session_id": sessionID,
+    "tenant_id":  tenantID,
+    "user_id":    userID,
+}
+
+// All Execute/ExecuteSync calls now include these keys in element metadata.
+// Per-element metadata overrides base metadata on key collision.
+result, err := pipeline.ExecuteSync(ctx, input)
+```
+
+This avoids manually injecting the same metadata into every `StreamElement` on each turn. Providers receive these values in `PredictionRequest.Metadata`.
+
 ## Testing Configuration
 
 ### Test Pipeline

--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -745,6 +745,23 @@ case <-ctx.Done():
 }
 ```
 
+## Base Metadata
+
+`StreamPipeline.BaseMetadata` provides session-level metadata that is automatically merged into every `StreamElement` at the start of each `Execute`/`ExecuteSync` call. This is useful for injecting context that should be available to all stages and providers across every turn of a conversation — without manually setting it on each input element.
+
+```go
+pipeline, _ := builder.Build()
+pipeline.BaseMetadata = map[string]interface{}{
+    "session_id": "sess-abc123",
+    "tenant_id":  "acme-corp",
+    "user_id":    "user-42",
+}
+```
+
+Per-element metadata takes precedence over base metadata on key collision. `BaseMetadata` is nil by default with zero cost when unused.
+
+Base metadata flows through the same path as per-element metadata: it is accumulated by `ProviderStage` and included in `PredictionRequest.Metadata`, making it available to all provider implementations.
+
 ## Metadata Keys
 
 Standard metadata keys used by built-in stages:

--- a/runtime/pipeline/stage/README.md
+++ b/runtime/pipeline/stage/README.md
@@ -418,14 +418,27 @@ func (s *MyStage) Process(ctx context.Context, input <-chan StreamElement, outpu
 }
 ```
 
-#### Pattern 2: State Access via Metadata
+#### Pattern 2: Base Metadata (Session Context)
+
+Use `BaseMetadata` on the pipeline to inject session-level context into every element automatically:
+
+```go
+pipeline.BaseMetadata = map[string]interface{}{
+    "session_id": sessionID,
+    "tenant_id":  tenantID,
+}
+// All elements entering the pipeline will have these keys merged in.
+// Per-element metadata takes precedence on key collision.
+```
+
+#### Pattern 3: State Access via Metadata
 
 ```go
 elem.Metadata["system_prompt"] = "..."
 elem.Metadata["allowed_tools"] = []string{...}
 ```
 
-#### Pattern 3: Error Handling
+#### Pattern 4: Error Handling
 
 ```go
 if err != nil {

--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -22,11 +22,32 @@ type StreamPipeline struct {
 	config       *PipelineConfig
 	eventEmitter *events.Emitter
 
+	// BaseMetadata is merged into every StreamElement at the start of each
+	// Execute/ExecuteSync call. Per-element metadata takes precedence over
+	// base metadata on key collision. Nil by default (zero cost when unused).
+	BaseMetadata map[string]interface{}
+
 	// Concurrency control
 	wg         sync.WaitGroup
 	shutdown   chan struct{}
 	shutdownMu sync.RWMutex
 	isShutdown bool
+}
+
+// applyBaseMetadata merges BaseMetadata into an element. Per-element keys
+// already present take precedence over base metadata keys.
+func (p *StreamPipeline) applyBaseMetadata(elem *StreamElement) {
+	if len(p.BaseMetadata) == 0 {
+		return
+	}
+	if elem.Metadata == nil {
+		elem.Metadata = make(map[string]interface{}, len(p.BaseMetadata))
+	}
+	for k, v := range p.BaseMetadata {
+		if _, exists := elem.Metadata[k]; !exists {
+			elem.Metadata[k] = v
+		}
+	}
 }
 
 // Execute starts the pipeline execution with the given input channel.
@@ -36,6 +57,20 @@ func (p *StreamPipeline) Execute(ctx context.Context, input <-chan StreamElement
 	// Check if shutting down
 	if p.isShuttingDown() {
 		return nil, ErrPipelineShuttingDown
+	}
+
+	// Wrap input to inject base metadata if configured
+	actualInput := input
+	if len(p.BaseMetadata) > 0 {
+		wrapped := make(chan StreamElement, p.config.ChannelBufferSize)
+		go func() {
+			defer close(wrapped)
+			for elem := range input {
+				p.applyBaseMetadata(&elem)
+				wrapped <- elem
+			}
+		}()
+		actualInput = wrapped
 	}
 
 	// Apply execution timeout if configured
@@ -55,7 +90,7 @@ func (p *StreamPipeline) Execute(ctx context.Context, input <-chan StreamElement
 	output := make(chan StreamElement, p.config.ChannelBufferSize)
 
 	// Execute pipeline in background
-	go p.executeBackground(execCtx, input, output, cancel)
+	go p.executeBackground(execCtx, actualInput, output, cancel)
 
 	return output, nil
 }

--- a/runtime/pipeline/stage/pipeline_internal_test.go
+++ b/runtime/pipeline/stage/pipeline_internal_test.go
@@ -309,3 +309,121 @@ func TestEmitCompletionEvent(t *testing.T) {
 		pipeline.emitCompletionEvent(testErr, time.Second)
 	})
 }
+
+// TestBaseMetadata tests the BaseMetadata feature on StreamPipeline.
+func TestBaseMetadata(t *testing.T) {
+	buildPassthroughPipeline := func() *StreamPipeline {
+		p, err := NewPipelineBuilder().
+			Chain(&testPassthroughStage{name: "passthrough"}).
+			Build()
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		return p
+	}
+
+	t.Run("nil by default", func(t *testing.T) {
+		p := buildPassthroughPipeline()
+		if p.BaseMetadata != nil {
+			t.Error("BaseMetadata should be nil by default")
+		}
+	})
+
+	t.Run("no effect when nil", func(t *testing.T) {
+		p := buildPassthroughPipeline()
+		input := StreamElement{
+			Metadata: map[string]interface{}{"key": "value"},
+		}
+		result, err := p.ExecuteSync(context.Background(), input)
+		if err != nil {
+			t.Fatalf("ExecuteSync: %v", err)
+		}
+		if result.Metadata["key"] != "value" {
+			t.Error("expected original metadata to be preserved")
+		}
+	})
+
+	t.Run("merged into elements", func(t *testing.T) {
+		p := buildPassthroughPipeline()
+		p.BaseMetadata = map[string]interface{}{
+			"session_id": "s-123",
+			"tenant_id":  "t-456",
+		}
+		result, err := p.ExecuteSync(context.Background(), StreamElement{})
+		if err != nil {
+			t.Fatalf("ExecuteSync: %v", err)
+		}
+		if result.Metadata["session_id"] != "s-123" {
+			t.Errorf("expected session_id=s-123, got %v", result.Metadata["session_id"])
+		}
+		if result.Metadata["tenant_id"] != "t-456" {
+			t.Errorf("expected tenant_id=t-456, got %v", result.Metadata["tenant_id"])
+		}
+	})
+
+	t.Run("per-element metadata takes precedence", func(t *testing.T) {
+		p := buildPassthroughPipeline()
+		p.BaseMetadata = map[string]interface{}{
+			"session_id": "base-session",
+			"tenant_id":  "base-tenant",
+		}
+		input := StreamElement{
+			Metadata: map[string]interface{}{
+				"session_id": "override-session",
+			},
+		}
+		result, err := p.ExecuteSync(context.Background(), input)
+		if err != nil {
+			t.Fatalf("ExecuteSync: %v", err)
+		}
+		if result.Metadata["session_id"] != "override-session" {
+			t.Errorf("per-element should override base, got %v", result.Metadata["session_id"])
+		}
+		if result.Metadata["tenant_id"] != "base-tenant" {
+			t.Errorf("non-overridden base key should be preserved, got %v", result.Metadata["tenant_id"])
+		}
+	})
+
+	t.Run("works with streaming Execute", func(t *testing.T) {
+		p := buildPassthroughPipeline()
+		p.BaseMetadata = map[string]interface{}{
+			"session_id": "stream-session",
+		}
+
+		inputChan := make(chan StreamElement, 1)
+		inputChan <- StreamElement{
+			Metadata: map[string]interface{}{"run_id": "r-1"},
+		}
+		close(inputChan)
+
+		output, err := p.Execute(context.Background(), inputChan)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+
+		var found bool
+		for elem := range output {
+			if elem.Metadata["session_id"] == "stream-session" && elem.Metadata["run_id"] == "r-1" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected base and per-element metadata to both be present")
+		}
+	})
+
+	t.Run("element with nil metadata gets base metadata", func(t *testing.T) {
+		p := buildPassthroughPipeline()
+		p.BaseMetadata = map[string]interface{}{
+			"tenant_id": "t-789",
+		}
+		input := StreamElement{Metadata: nil}
+		result, err := p.ExecuteSync(context.Background(), input)
+		if err != nil {
+			t.Fatalf("ExecuteSync: %v", err)
+		}
+		if result.Metadata["tenant_id"] != "t-789" {
+			t.Errorf("expected tenant_id=t-789, got %v", result.Metadata["tenant_id"])
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `BaseMetadata map[string]interface{}` field on `StreamPipeline`
- Automatically merged into every `StreamElement` at the start of each `Execute`/`ExecuteSync` call
- Per-element metadata takes precedence on key collision (more specific wins)
- Nil by default, zero cost when unused — fully non-breaking

This enables callers (SDK, Arena) to set conversation-level metadata once (e.g., `sessionId`, `tenantId`, `userId`) and have it automatically flow through to all stages and providers on every turn without per-element injection.

### Usage

```go
p, _ := buildPipeline(...)
p.BaseMetadata = map[string]interface{}{
    "session_id": sessionID,
    "tenant_id":  tenantID,
}
// All subsequent Execute/ExecuteSync calls inherit these keys
```

## Test plan

- [x] `TestBaseMetadata/nil_by_default` — field is nil after Build
- [x] `TestBaseMetadata/no_effect_when_nil` — existing behavior unchanged
- [x] `TestBaseMetadata/merged_into_elements` — base keys appear in output
- [x] `TestBaseMetadata/per-element_metadata_takes_precedence` — element keys override base
- [x] `TestBaseMetadata/works_with_streaming_Execute` — streaming path works
- [x] `TestBaseMetadata/element_with_nil_metadata_gets_base_metadata` — nil metadata initialized
- [x] Full `runtime/pipeline/stage` test suite passes
- [x] Pre-commit: lint clean, 88.7% coverage on changed file