### PR TITLE
fix(ci): auto-publish draft release and isolate downstream notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -607,6 +607,16 @@ jobs:
     if: ${{ inputs.phase == 'full' && needs.create-release.result == 'success' }}
 
     steps:
+    - name: Publish draft release
+      env:
+        GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        VERSION: ${{ needs.validate.outputs.version }}
+        GITHUB_REPO: ${{ github.repository }}
+      run: |
+        echo "Publishing draft release $VERSION..."
+        gh release edit "$VERSION" --repo "$GITHUB_REPO" --draft=false
+        echo "✓ Release $VERSION published"
+
     - name: Wait for docs deployment
       env:
         GH_TOKEN: ${{ github.token }}
@@ -616,13 +626,13 @@ jobs:
         sleep 30
 
         # Find the docs workflow run triggered by this release
-        for i in {1..5}; do
+        for i in {1..10}; do
           RUN_ID=$(gh run list --repo "$GITHUB_REPO" --workflow docs.yml --limit 1 --json databaseId,event,status --jq '.[0] | select(.event == "release") | .databaseId')
           if [ -n "$RUN_ID" ]; then
             echo "Found docs workflow run: $RUN_ID"
             break
           fi
-          echo "Attempt $i/5: Docs workflow not started yet, waiting 15s..."
+          echo "Attempt $i/10: Docs workflow not started yet, waiting 15s..."
           sleep 15
         done
 
@@ -648,6 +658,7 @@ jobs:
 
     steps:
     - name: Dispatch to promptarena-deploy-agentcore
+      continue-on-error: true
       env:
         VERSION: ${{ needs.validate.outputs.version }}
         GH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
@@ -659,6 +670,7 @@ jobs:
         echo "✓ Dispatched to promptarena-deploy-agentcore"
 
     - name: Dispatch to promptarena-deploy-omnia
+      continue-on-error: true
       env:
         VERSION: ${{ needs.validate.outputs.version }}
         GH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
@@ -727,7 +739,7 @@ jobs:
 
         ## Next Steps
         
-        1. Review and publish the [draft release](https://github.com/$GITHUB_REPO/releases)
+        1. Verify the [published release](https://github.com/$GITHUB_REPO/releases)
         2. Update README.md with new version
         3. Announce the release
         4. Restore replace directives on main branch (if needed)


### PR DESCRIPTION
## Summary

Fixes two issues from the v1.3.18 release pipeline run:

- **verify-docs** now publishes the GoReleaser draft release before waiting for docs deployment. Previously, the draft was never published automatically, so the docs workflow (triggered on `release: published`) never started, and verify-docs always timed out.
- **notify-downstream** dispatch steps now use `continue-on-error: true` so one failing repo (omnia returned 403 due to token permissions) doesn't fail the entire job and block the other dispatch.

## Test plan

- [ ] On next release, verify-docs should auto-publish the draft and successfully watch the docs deployment
- [ ] Downstream notification failures should be visible but not block the release summary