### PR TITLE
fix: use waitForType in event lifecycle tests to prevent async race

### DIFF
--- a/sdk/integration/client_tools_test.go
+++ b/sdk/integration/client_tools_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -655,9 +656,11 @@ func TestClientTools_EventLifecycle(t *testing.T) {
 	require.True(t, resp.HasPendingClientTools())
 
 	// Verify: tool.call.started, tool.client.request, tool.call.completed(pending)
-	startedEvents := collector.ofType(events.EventToolCallStarted)
-	requestEvents := collector.ofType(events.EventClientToolRequest)
-	completedEvents := collector.ofType(events.EventToolCallCompleted)
+	// Use waitForType because the event bus dispatches asynchronously via a goroutine.
+	const eventTimeout = 2 * time.Second
+	startedEvents := collector.waitForType(events.EventToolCallStarted, eventTimeout)
+	requestEvents := collector.waitForType(events.EventClientToolRequest, eventTimeout)
+	completedEvents := collector.waitForType(events.EventToolCallCompleted, eventTimeout)
 
 	require.NotEmpty(t, startedEvents, "expected tool.call.started event")
 	require.NotEmpty(t, requestEvents, "expected tool.client.request event")
@@ -684,7 +687,7 @@ func TestClientTools_EventLifecycle(t *testing.T) {
 	assert.NotEmpty(t, resp2.Text())
 
 	// Verify: tool.client.resolved event emitted during Resume
-	resolvedEvents := collector.ofType(events.EventClientToolResolved)
+	resolvedEvents := collector.waitForType(events.EventClientToolResolved, eventTimeout)
 	require.NotEmpty(t, resolvedEvents, "expected tool.client.resolved event after Resume")
 
 	resData := resolvedEvents[0].Data.(*events.ClientToolResolvedData)
@@ -737,7 +740,8 @@ func TestClientTools_EventLifecycle_Rejection(t *testing.T) {
 	assert.NotEmpty(t, resp2.Text())
 
 	// Verify resolved event has status "rejected"
-	resolvedEvents := collector.ofType(events.EventClientToolResolved)
+	const eventTimeout = 2 * time.Second
+	resolvedEvents := collector.waitForType(events.EventClientToolResolved, eventTimeout)
 	require.NotEmpty(t, resolvedEvents, "expected tool.client.resolved event")
 
 	resData := resolvedEvents[0].Data.(*events.ClientToolResolvedData)

--- a/sdk/integration/helpers_test.go
+++ b/sdk/integration/helpers_test.go
@@ -149,6 +149,19 @@ func (ec *eventCollector) ofType(et events.EventType) []*events.Event {
 	return out
 }
 
+// waitForType polls until at least one event of the given type is collected,
+// or the timeout expires. Returns the matching events.
+func (ec *eventCollector) waitForType(et events.EventType, timeout time.Duration) []*events.Event {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if evts := ec.ofType(et); len(evts) > 0 {
+			return evts
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return ec.ofType(et)
+}
+
 // hasType returns true if at least one event of the given type was collected.
 func (ec *eventCollector) hasType(et events.EventType) bool {
 	return len(ec.ofType(et)) > 0


### PR DESCRIPTION
## Summary

Fix flaky `TestClientTools_EventLifecycle` test that reads events immediately after `Send()`/`Resume()` without waiting for the async event bus to deliver them.

## Root cause

The event bus dispatches to subscribers via a goroutine. `collector.ofType()` reads the collected events snapshot, but events may not have been delivered yet when called immediately after a synchronous SDK call.

## Fix

Add `waitForType(eventType, timeout)` helper to `eventCollector` that polls until the event appears or the timeout expires. Use it in `TestClientTools_EventLifecycle` and `TestClientTools_EventLifecycle_Rejection`.

Verified: 10 consecutive runs with `-race` pass.

## Test plan

- [x] `go test ./sdk/integration/ -run TestClientTools_EventLifecycle -count=10 -race` passes