### PR TITLE
feat: add exemplar support to Collector for metric→trace correlation

### DIFF
--- a/runtime/evals/handlers/judge_provider.go
+++ b/runtime/evals/handlers/judge_provider.go
@@ -178,7 +178,13 @@ func (sp *SpecJudgeProvider) Judge(ctx context.Context, opts JudgeOpts) (*JudgeR
 
 	if err != nil {
 		if opts.Emitter != nil {
-			opts.Emitter.ProviderCallFailedCtx(ctx, provider.ID(), provider.Model(), err, duration, nil)
+			opts.Emitter.ProviderCallFailedCtx(ctx, &events.ProviderCallFailedData{
+				Provider: provider.ID(),
+				Model:    provider.Model(),
+				Error:    err,
+				Duration: duration,
+				Source:   events.SourceJudge,
+			})
 		}
 		return nil, fmt.Errorf("judge predict failed: %w", err)
 	}

--- a/runtime/evals/handlers/judge_provider.go
+++ b/runtime/evals/handlers/judge_provider.go
@@ -178,7 +178,7 @@ func (sp *SpecJudgeProvider) Judge(ctx context.Context, opts JudgeOpts) (*JudgeR
 
 	if err != nil {
 		if opts.Emitter != nil {
-			opts.Emitter.ProviderCallFailed(provider.ID(), provider.Model(), err, duration, nil)
+			opts.Emitter.ProviderCallFailedCtx(ctx, provider.ID(), provider.Model(), err, duration, nil)
 		}
 		return nil, fmt.Errorf("judge predict failed: %w", err)
 	}
@@ -197,7 +197,7 @@ func (sp *SpecJudgeProvider) Judge(ctx context.Context, opts JudgeOpts) (*JudgeR
 			completedData.CachedTokens = resp.CostInfo.CachedTokens
 			completedData.Cost = resp.CostInfo.TotalCost
 		}
-		opts.Emitter.ProviderCallCompleted(completedData)
+		opts.Emitter.ProviderCallCompletedCtx(ctx, completedData)
 	}
 
 	return parseJudgeResponse(resp.Content, opts.MinScore)

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -34,13 +36,12 @@ func (e *Emitter) WithUserID(userID string) *Emitter {
 	return e
 }
 
-// emit publishes an event with shared context fields.
+// emit publishes an event with shared context fields (no trace context).
 func (e *Emitter) emit(eventType EventType, data EventData) {
 	if e == nil || e.bus == nil {
 		return
 	}
-
-	event := &Event{
+	e.bus.Publish(&Event{
 		Type:           eventType,
 		Timestamp:      time.Now(),
 		ExecutionID:    e.executionID,
@@ -48,18 +49,22 @@ func (e *Emitter) emit(eventType EventType, data EventData) {
 		ConversationID: e.conversationID,
 		UserID:         e.userID,
 		Data:           data,
-	}
-
-	e.bus.Publish(event)
+	})
 }
 
 // emitCtx publishes an event with shared context fields and a request context
-// for trace correlation (exemplars).
+// for trace correlation (exemplars). The span context is extracted from ctx
+// and stored as a value type on the event.
 func (e *Emitter) emitCtx(ctx context.Context, eventType EventType, data EventData) {
 	if e == nil || e.bus == nil {
 		return
 	}
 
+	var sc trace.SpanContext
+	if ctx != nil {
+		sc = trace.SpanContextFromContext(ctx)
+	}
+
 	event := &Event{
 		Type:           eventType,
 		Timestamp:      time.Now(),
@@ -68,7 +73,7 @@ func (e *Emitter) emitCtx(ctx context.Context, eventType EventType, data EventDa
 		ConversationID: e.conversationID,
 		UserID:         e.userID,
 		Data:           data,
-		Ctx:            ctx,
+		SpanContext:    sc,
 	}
 
 	e.bus.Publish(event)
@@ -260,18 +265,15 @@ func (e *Emitter) ProviderCallCompletedCtx(ctx context.Context, data *ProviderCa
 }
 
 // ProviderCallFailedCtx emits provider.call.failed with trace context for exemplar correlation.
-func (e *Emitter) ProviderCallFailedCtx(
-	ctx context.Context,
-	provider, model string, err error, duration time.Duration, labels map[string]string,
-) {
-	e.emitCtx(ctx, EventProviderCallFailed, &ProviderCallFailedData{
-		Provider: provider,
-		Model:    model,
-		Error:    err,
-		Duration: duration,
-		Source:   SourceAgent,
-		Labels:   labels,
-	})
+// Source defaults to "agent" if not already set on data.
+func (e *Emitter) ProviderCallFailedCtx(ctx context.Context, data *ProviderCallFailedData) {
+	if data == nil {
+		return
+	}
+	if data.Source == "" {
+		data.Source = SourceAgent
+	}
+	e.emitCtx(ctx, EventProviderCallFailed, data)
 }
 
 // ToolCallCompletedCtx emits tool.call.completed with trace context for exemplar correlation.

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -47,6 +48,27 @@ func (e *Emitter) emit(eventType EventType, data EventData) {
 		ConversationID: e.conversationID,
 		UserID:         e.userID,
 		Data:           data,
+	}
+
+	e.bus.Publish(event)
+}
+
+// emitCtx publishes an event with shared context fields and a request context
+// for trace correlation (exemplars).
+func (e *Emitter) emitCtx(ctx context.Context, eventType EventType, data EventData) {
+	if e == nil || e.bus == nil {
+		return
+	}
+
+	event := &Event{
+		Type:           eventType,
+		Timestamp:      time.Now(),
+		ExecutionID:    e.executionID,
+		SessionID:      e.sessionID,
+		ConversationID: e.conversationID,
+		UserID:         e.userID,
+		Data:           data,
+		Ctx:            ctx,
 	}
 
 	e.bus.Publish(event)
@@ -218,6 +240,65 @@ func (e *Emitter) ToolCallFailed(
 	toolName, callID string, err error, duration time.Duration, labels map[string]string,
 ) {
 	e.emit(EventToolCallFailed, &ToolCallFailedData{
+		ToolName: toolName,
+		CallID:   callID,
+		Error:    err,
+		Duration: duration,
+		Labels:   labels,
+	})
+}
+
+// ProviderCallCompletedCtx emits provider.call.completed with trace context for exemplar correlation.
+func (e *Emitter) ProviderCallCompletedCtx(ctx context.Context, data *ProviderCallCompletedData) {
+	if data == nil {
+		return
+	}
+	if data.Source == "" {
+		data.Source = SourceAgent
+	}
+	e.emitCtx(ctx, EventProviderCallCompleted, data)
+}
+
+// ProviderCallFailedCtx emits provider.call.failed with trace context for exemplar correlation.
+func (e *Emitter) ProviderCallFailedCtx(
+	ctx context.Context,
+	provider, model string, err error, duration time.Duration, labels map[string]string,
+) {
+	e.emitCtx(ctx, EventProviderCallFailed, &ProviderCallFailedData{
+		Provider: provider,
+		Model:    model,
+		Error:    err,
+		Duration: duration,
+		Source:   SourceAgent,
+		Labels:   labels,
+	})
+}
+
+// ToolCallCompletedCtx emits tool.call.completed with trace context for exemplar correlation.
+func (e *Emitter) ToolCallCompletedCtx(
+	ctx context.Context,
+	toolName, callID string,
+	duration time.Duration,
+	status string,
+	parts []types.ContentPart,
+	labels map[string]string,
+) {
+	e.emitCtx(ctx, EventToolCallCompleted, &ToolCallCompletedData{
+		ToolName: toolName,
+		CallID:   callID,
+		Duration: duration,
+		Status:   status,
+		Parts:    types.MetadataOnlyParts(parts),
+		Labels:   labels,
+	})
+}
+
+// ToolCallFailedCtx emits tool.call.failed with trace context for exemplar correlation.
+func (e *Emitter) ToolCallFailedCtx(
+	ctx context.Context,
+	toolName, callID string, err error, duration time.Duration, labels map[string]string,
+) {
+	e.emitCtx(ctx, EventToolCallFailed, &ToolCallFailedData{
 		ToolName: toolName,
 		CallID:   callID,
 		Error:    err,

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -1113,6 +1113,16 @@ func TestEmitter_ProviderCallCompletedCtx_NilData(t *testing.T) {
 	emitter.ProviderCallCompletedCtx(context.Background(), nil)
 }
 
+func TestEmitter_ProviderCallFailedCtx_NilData(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctxn2", "session-ctxn2", "conv-ctxn2")
+
+	// Should not panic when data is nil
+	emitter.ProviderCallFailedCtx(context.Background(), nil)
+}
+
 func TestEventBus_PublishStampsSequence(t *testing.T) {
 	t.Parallel()
 

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -920,6 +921,173 @@ func TestEmitter_WithUserID_NilEmitter(t *testing.T) {
 	if result != nil {
 		t.Fatal("expected nil emitter to return nil")
 	}
+}
+
+func TestEmitter_ProviderCallCompletedCtx_SetsContext(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctx", "session-ctx", "conv-ctx")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventProviderCallCompleted, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	type ctxKey string
+	ctx := context.WithValue(context.Background(), ctxKey("test"), "value")
+	emitter.ProviderCallCompletedCtx(ctx, &ProviderCallCompletedData{
+		Provider: "openai",
+		Model:    "gpt-4",
+		Source:   SourceJudge,
+	})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event")
+	}
+
+	if got.Ctx == nil {
+		t.Fatal("expected event.Ctx to be set")
+	}
+	if got.Ctx.Value(ctxKey("test")) != "value" {
+		t.Error("expected context value to propagate")
+	}
+	data := got.Data.(*ProviderCallCompletedData)
+	if data.Source != SourceJudge {
+		t.Errorf("expected Source=%q, got %q", SourceJudge, data.Source)
+	}
+}
+
+func TestEmitter_ProviderCallCompletedCtx_DefaultSource(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctx2", "session-ctx2", "conv-ctx2")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventProviderCallCompleted, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	emitter.ProviderCallCompletedCtx(context.Background(), &ProviderCallCompletedData{
+		Provider: "openai",
+		Model:    "gpt-4",
+	})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event")
+	}
+
+	data := got.Data.(*ProviderCallCompletedData)
+	if data.Source != SourceAgent {
+		t.Errorf("expected default Source=%q, got %q", SourceAgent, data.Source)
+	}
+}
+
+func TestEmitter_ProviderCallFailedCtx_SetsContext(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctx3", "session-ctx3", "conv-ctx3")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventProviderCallFailed, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	ctx := context.Background()
+	emitter.ProviderCallFailedCtx(ctx, "openai", "gpt-4", errors.New("timeout"), time.Second, nil)
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event")
+	}
+
+	if got.Ctx == nil {
+		t.Fatal("expected event.Ctx to be set")
+	}
+}
+
+func TestEmitter_ToolCallCompletedCtx_SetsContext(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctx4", "session-ctx4", "conv-ctx4")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventToolCallCompleted, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	ctx := context.Background()
+	emitter.ToolCallCompletedCtx(ctx, "search", "call-1", time.Millisecond, "success", nil, nil)
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event")
+	}
+
+	if got.Ctx == nil {
+		t.Fatal("expected event.Ctx to be set")
+	}
+}
+
+func TestEmitter_ToolCallFailedCtx_SetsContext(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctx5", "session-ctx5", "conv-ctx5")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventToolCallFailed, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	ctx := context.Background()
+	emitter.ToolCallFailedCtx(ctx, "search", "call-1", errors.New("fail"), time.Millisecond, nil)
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for event")
+	}
+
+	if got.Ctx == nil {
+		t.Fatal("expected event.Ctx to be set")
+	}
+}
+
+func TestEmitter_CtxMethods_NilEmitter(t *testing.T) {
+	t.Parallel()
+
+	var emitter *Emitter
+	ctx := context.Background()
+	// None of these should panic
+	emitter.ProviderCallCompletedCtx(ctx, &ProviderCallCompletedData{})
+	emitter.ProviderCallFailedCtx(ctx, "p", "m", errors.New("e"), time.Second, nil)
+	emitter.ToolCallCompletedCtx(ctx, "t", "c", time.Second, "s", nil, nil)
+	emitter.ToolCallFailedCtx(ctx, "t", "c", errors.New("e"), time.Second, nil)
+}
+
+func TestEmitter_ProviderCallCompletedCtx_NilData(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-ctxn", "session-ctxn", "conv-ctxn")
+
+	// Should not panic when data is nil
+	emitter.ProviderCallCompletedCtx(context.Background(), nil)
 }
 
 func TestEventBus_PublishStampsSequence(t *testing.T) {

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -923,7 +925,7 @@ func TestEmitter_WithUserID_NilEmitter(t *testing.T) {
 	}
 }
 
-func TestEmitter_ProviderCallCompletedCtx_SetsContext(t *testing.T) {
+func TestEmitter_ProviderCallCompletedCtx_SetsSpanContext(t *testing.T) {
 	t.Parallel()
 
 	bus := NewEventBus()
@@ -937,8 +939,13 @@ func TestEmitter_ProviderCallCompletedCtx_SetsContext(t *testing.T) {
 		wg.Done()
 	})
 
-	type ctxKey string
-	ctx := context.WithValue(context.Background(), ctxKey("test"), "value")
+	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     trace.SpanID{1},
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
 	emitter.ProviderCallCompletedCtx(ctx, &ProviderCallCompletedData{
 		Provider: "openai",
 		Model:    "gpt-4",
@@ -949,11 +956,11 @@ func TestEmitter_ProviderCallCompletedCtx_SetsContext(t *testing.T) {
 		t.Fatal("timed out waiting for event")
 	}
 
-	if got.Ctx == nil {
-		t.Fatal("expected event.Ctx to be set")
+	if !got.SpanContext.TraceID().IsValid() {
+		t.Fatal("expected valid trace ID on event.SpanContext")
 	}
-	if got.Ctx.Value(ctxKey("test")) != "value" {
-		t.Error("expected context value to propagate")
+	if got.SpanContext.TraceID().String() != "0102030405060708090a0b0c0d0e0f10" {
+		t.Errorf("expected trace ID 0102030405060708090a0b0c0d0e0f10, got %s", got.SpanContext.TraceID().String())
 	}
 	data := got.Data.(*ProviderCallCompletedData)
 	if data.Source != SourceJudge {
@@ -990,7 +997,7 @@ func TestEmitter_ProviderCallCompletedCtx_DefaultSource(t *testing.T) {
 	}
 }
 
-func TestEmitter_ProviderCallFailedCtx_SetsContext(t *testing.T) {
+func TestEmitter_ProviderCallFailedCtx_SetsSpanContext(t *testing.T) {
 	t.Parallel()
 
 	bus := NewEventBus()
@@ -1004,19 +1011,29 @@ func TestEmitter_ProviderCallFailedCtx_SetsContext(t *testing.T) {
 		wg.Done()
 	})
 
-	ctx := context.Background()
-	emitter.ProviderCallFailedCtx(ctx, "openai", "gpt-4", errors.New("timeout"), time.Second, nil)
+	traceID, _ := trace.TraceIDFromHex("aabbccddeeff00112233445566778899")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID, SpanID: trace.SpanID{2}, TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	emitter.ProviderCallFailedCtx(ctx, &ProviderCallFailedData{
+		Provider: "openai", Model: "gpt-4", Error: errors.New("timeout"), Duration: time.Second,
+	})
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for event")
 	}
 
-	if got.Ctx == nil {
-		t.Fatal("expected event.Ctx to be set")
+	if !got.SpanContext.TraceID().IsValid() {
+		t.Fatal("expected valid trace ID on event.SpanContext")
+	}
+	data := got.Data.(*ProviderCallFailedData)
+	if data.Source != SourceAgent {
+		t.Errorf("expected default Source=%q, got %q", SourceAgent, data.Source)
 	}
 }
 
-func TestEmitter_ToolCallCompletedCtx_SetsContext(t *testing.T) {
+func TestEmitter_ToolCallCompletedCtx_SetsSpanContext(t *testing.T) {
 	t.Parallel()
 
 	bus := NewEventBus()
@@ -1030,19 +1047,22 @@ func TestEmitter_ToolCallCompletedCtx_SetsContext(t *testing.T) {
 		wg.Done()
 	})
 
-	ctx := context.Background()
+	traceID, _ := trace.TraceIDFromHex("11223344556677889900aabbccddeeff")
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID, SpanID: trace.SpanID{3}, TraceFlags: trace.FlagsSampled,
+	}))
 	emitter.ToolCallCompletedCtx(ctx, "search", "call-1", time.Millisecond, "success", nil, nil)
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for event")
 	}
 
-	if got.Ctx == nil {
-		t.Fatal("expected event.Ctx to be set")
+	if !got.SpanContext.TraceID().IsValid() {
+		t.Fatal("expected valid trace ID on event.SpanContext")
 	}
 }
 
-func TestEmitter_ToolCallFailedCtx_SetsContext(t *testing.T) {
+func TestEmitter_ToolCallFailedCtx_SetsSpanContext(t *testing.T) {
 	t.Parallel()
 
 	bus := NewEventBus()
@@ -1056,15 +1076,18 @@ func TestEmitter_ToolCallFailedCtx_SetsContext(t *testing.T) {
 		wg.Done()
 	})
 
-	ctx := context.Background()
+	traceID, _ := trace.TraceIDFromHex("ffeeddccbbaa99887766554433221100")
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID, SpanID: trace.SpanID{4}, TraceFlags: trace.FlagsSampled,
+	}))
 	emitter.ToolCallFailedCtx(ctx, "search", "call-1", errors.New("fail"), time.Millisecond, nil)
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for event")
 	}
 
-	if got.Ctx == nil {
-		t.Fatal("expected event.Ctx to be set")
+	if !got.SpanContext.TraceID().IsValid() {
+		t.Fatal("expected valid trace ID on event.SpanContext")
 	}
 }
 
@@ -1075,7 +1098,7 @@ func TestEmitter_CtxMethods_NilEmitter(t *testing.T) {
 	ctx := context.Background()
 	// None of these should panic
 	emitter.ProviderCallCompletedCtx(ctx, &ProviderCallCompletedData{})
-	emitter.ProviderCallFailedCtx(ctx, "p", "m", errors.New("e"), time.Second, nil)
+	emitter.ProviderCallFailedCtx(ctx, &ProviderCallFailedData{})
 	emitter.ToolCallCompletedCtx(ctx, "t", "c", time.Second, "s", nil, nil)
 	emitter.ToolCallFailedCtx(ctx, "t", "c", errors.New("e"), time.Second, nil)
 }

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -1,8 +1,9 @@
 package events
 
 import (
-	"context"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -121,7 +122,7 @@ type Event struct {
 	ConversationID string
 	UserID         string
 	Data           EventData
-	Ctx            context.Context `json:"-"` // carries trace span for exemplar correlation; not serialized
+	SpanContext    trace.SpanContext `json:"-"` // trace span for exemplar correlation; not serialized
 }
 
 // baseEventData provides a shared marker implementation for all event payloads.

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -120,6 +121,7 @@ type Event struct {
 	ConversationID string
 	UserID         string
 	Data           EventData
+	Ctx            context.Context `json:"-"` // carries trace span for exemplar correlation; not serialized
 }
 
 // baseEventData provides a shared marker implementation for all event payloads.

--- a/runtime/metrics/collector.go
+++ b/runtime/metrics/collector.go
@@ -400,13 +400,22 @@ func (mc *MetricContext) handleProviderCallCompleted(event *events.Event) {
 	if !ok {
 		return
 	}
-	mc.collector.providerRequestDuration.WithLabelValues(
-		mc.labelValues(data.Provider, data.Model, data.Source)...,
-	).Observe(data.Duration.Seconds())
+	exemplar := traceExemplar(event.Ctx)
 
-	mc.collector.providerRequestsTotal.WithLabelValues(
-		mc.labelValues(data.Provider, data.Model, data.Source, statusSuccess)...,
-	).Inc()
+	observeWithExemplar(
+		mc.collector.providerRequestDuration.WithLabelValues(
+			mc.labelValues(data.Provider, data.Model, data.Source)...,
+		),
+		data.Duration.Seconds(),
+		exemplar,
+	)
+
+	incWithExemplar(
+		mc.collector.providerRequestsTotal.WithLabelValues(
+			mc.labelValues(data.Provider, data.Model, data.Source, statusSuccess)...,
+		),
+		exemplar,
+	)
 
 	if data.InputTokens > 0 {
 		mc.collector.providerInputTokensTotal.WithLabelValues(
@@ -436,13 +445,22 @@ func (mc *MetricContext) handleProviderCallFailed(event *events.Event) {
 	if !ok {
 		return
 	}
-	mc.collector.providerRequestDuration.WithLabelValues(
-		mc.labelValues(data.Provider, data.Model, data.Source)...,
-	).Observe(data.Duration.Seconds())
+	exemplar := traceExemplar(event.Ctx)
 
-	mc.collector.providerRequestsTotal.WithLabelValues(
-		mc.labelValues(data.Provider, data.Model, data.Source, statusError)...,
-	).Inc()
+	observeWithExemplar(
+		mc.collector.providerRequestDuration.WithLabelValues(
+			mc.labelValues(data.Provider, data.Model, data.Source)...,
+		),
+		data.Duration.Seconds(),
+		exemplar,
+	)
+
+	incWithExemplar(
+		mc.collector.providerRequestsTotal.WithLabelValues(
+			mc.labelValues(data.Provider, data.Model, data.Source, statusError)...,
+		),
+		exemplar,
+	)
 }
 
 func (mc *MetricContext) handleToolCallCompleted(event *events.Event) {
@@ -450,17 +468,26 @@ func (mc *MetricContext) handleToolCallCompleted(event *events.Event) {
 	if !ok {
 		return
 	}
+	exemplar := traceExemplar(event.Ctx)
+
 	status := statusSuccess
 	if data.Status == statusError {
 		status = statusError
 	}
-	mc.collector.toolCallDuration.WithLabelValues(
-		mc.labelValues(data.ToolName)...,
-	).Observe(data.Duration.Seconds())
+	observeWithExemplar(
+		mc.collector.toolCallDuration.WithLabelValues(
+			mc.labelValues(data.ToolName)...,
+		),
+		data.Duration.Seconds(),
+		exemplar,
+	)
 
-	mc.collector.toolCallsTotal.WithLabelValues(
-		mc.labelValues(data.ToolName, status)...,
-	).Inc()
+	incWithExemplar(
+		mc.collector.toolCallsTotal.WithLabelValues(
+			mc.labelValues(data.ToolName, status)...,
+		),
+		exemplar,
+	)
 }
 
 func (mc *MetricContext) handleToolCallFailed(event *events.Event) {
@@ -468,13 +495,22 @@ func (mc *MetricContext) handleToolCallFailed(event *events.Event) {
 	if !ok {
 		return
 	}
-	mc.collector.toolCallDuration.WithLabelValues(
-		mc.labelValues(data.ToolName)...,
-	).Observe(data.Duration.Seconds())
+	exemplar := traceExemplar(event.Ctx)
 
-	mc.collector.toolCallsTotal.WithLabelValues(
-		mc.labelValues(data.ToolName, statusError)...,
-	).Inc()
+	observeWithExemplar(
+		mc.collector.toolCallDuration.WithLabelValues(
+			mc.labelValues(data.ToolName)...,
+		),
+		data.Duration.Seconds(),
+		exemplar,
+	)
+
+	incWithExemplar(
+		mc.collector.toolCallsTotal.WithLabelValues(
+			mc.labelValues(data.ToolName, statusError)...,
+		),
+		exemplar,
+	)
 }
 
 func (mc *MetricContext) handleValidationPassed(event *events.Event) {

--- a/runtime/metrics/collector.go
+++ b/runtime/metrics/collector.go
@@ -400,7 +400,7 @@ func (mc *MetricContext) handleProviderCallCompleted(event *events.Event) {
 	if !ok {
 		return
 	}
-	exemplar := traceExemplar(event.Ctx)
+	exemplar := traceExemplar(event.SpanContext)
 
 	observeWithExemplar(
 		mc.collector.providerRequestDuration.WithLabelValues(
@@ -445,7 +445,7 @@ func (mc *MetricContext) handleProviderCallFailed(event *events.Event) {
 	if !ok {
 		return
 	}
-	exemplar := traceExemplar(event.Ctx)
+	exemplar := traceExemplar(event.SpanContext)
 
 	observeWithExemplar(
 		mc.collector.providerRequestDuration.WithLabelValues(
@@ -468,7 +468,7 @@ func (mc *MetricContext) handleToolCallCompleted(event *events.Event) {
 	if !ok {
 		return
 	}
-	exemplar := traceExemplar(event.Ctx)
+	exemplar := traceExemplar(event.SpanContext)
 
 	status := statusSuccess
 	if data.Status == statusError {
@@ -495,7 +495,7 @@ func (mc *MetricContext) handleToolCallFailed(event *events.Event) {
 	if !ok {
 		return
 	}
-	exemplar := traceExemplar(event.Ctx)
+	exemplar := traceExemplar(event.SpanContext)
 
 	observeWithExemplar(
 		mc.collector.toolCallDuration.WithLabelValues(

--- a/runtime/metrics/collector_test.go
+++ b/runtime/metrics/collector_test.go
@@ -1,12 +1,15 @@
 package metrics
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -737,5 +740,172 @@ func TestMetricContext_WrongEventDataType(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// traceContext creates a context with a known trace ID for exemplar testing.
+func traceContext(hex string) context.Context {
+	traceID, _ := trace.TraceIDFromHex(hex)
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     trace.SpanID{1},
+		TraceFlags: trace.FlagsSampled,
+	})
+	return trace.ContextWithSpanContext(context.Background(), sc)
+}
+
+// findExemplarTraceID searches gathered metric families for an exemplar with the given trace_id.
+func findExemplarTraceID(families []*dto.MetricFamily, metricName, wantTraceID string) bool {
+	for _, fam := range families {
+		if fam.GetName() != metricName {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			// Check histogram bucket exemplars.
+			if h := m.GetHistogram(); h != nil {
+				for _, b := range h.GetBucket() {
+					if matchExemplarTraceID(b.GetExemplar(), wantTraceID) {
+						return true
+					}
+				}
+			}
+			// Check counter exemplar.
+			if c := m.GetCounter(); c != nil {
+				if matchExemplarTraceID(c.GetExemplar(), wantTraceID) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func matchExemplarTraceID(e *dto.Exemplar, wantTraceID string) bool {
+	if e == nil {
+		return false
+	}
+	for _, lp := range e.GetLabel() {
+		if lp.GetName() == "trace_id" && lp.GetValue() == wantTraceID {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMetricContext_ProviderCallCompleted_Exemplar(t *testing.T) {
+	c, reg := newTestCollector()
+	ctx := c.Bind(nil)
+
+	traceHex := "0102030405060708090a0b0c0d0e0f10"
+	ctx.OnEvent(&events.Event{
+		Type: events.EventProviderCallCompleted,
+		Ctx:  traceContext(traceHex),
+		Data: &events.ProviderCallCompletedData{
+			Provider: "openai",
+			Model:    "gpt-4o",
+			Duration: 500 * time.Millisecond,
+			Source:   events.SourceAgent,
+		},
+	})
+
+	families, _ := reg.Gather()
+	if !findExemplarTraceID(families, "test_provider_request_duration_seconds", traceHex) {
+		t.Error("expected trace_id exemplar on provider_request_duration_seconds histogram")
+	}
+	if !findExemplarTraceID(families, "test_provider_requests_total", traceHex) {
+		t.Error("expected trace_id exemplar on provider_requests_total counter")
+	}
+}
+
+func TestMetricContext_ProviderCallFailed_Exemplar(t *testing.T) {
+	c, reg := newTestCollector()
+	ctx := c.Bind(nil)
+
+	traceHex := "aabbccddeeff00112233445566778899"
+	ctx.OnEvent(&events.Event{
+		Type: events.EventProviderCallFailed,
+		Ctx:  traceContext(traceHex),
+		Data: &events.ProviderCallFailedData{
+			Provider: "anthropic",
+			Model:    "claude-3",
+			Duration: time.Second,
+			Source:   events.SourceAgent,
+		},
+	})
+
+	families, _ := reg.Gather()
+	if !findExemplarTraceID(families, "test_provider_request_duration_seconds", traceHex) {
+		t.Error("expected trace_id exemplar on provider_request_duration_seconds histogram")
+	}
+	if !findExemplarTraceID(families, "test_provider_requests_total", traceHex) {
+		t.Error("expected trace_id exemplar on provider_requests_total counter")
+	}
+}
+
+func TestMetricContext_ToolCallCompleted_Exemplar(t *testing.T) {
+	c, reg := newTestCollector()
+	ctx := c.Bind(nil)
+
+	traceHex := "11223344556677889900aabbccddeeff"
+	ctx.OnEvent(&events.Event{
+		Type: events.EventToolCallCompleted,
+		Ctx:  traceContext(traceHex),
+		Data: &events.ToolCallCompletedData{
+			ToolName: "search",
+			Duration: 100 * time.Millisecond,
+			Status:   "success",
+		},
+	})
+
+	families, _ := reg.Gather()
+	if !findExemplarTraceID(families, "test_tool_call_duration_seconds", traceHex) {
+		t.Error("expected trace_id exemplar on tool_call_duration_seconds histogram")
+	}
+	if !findExemplarTraceID(families, "test_tool_calls_total", traceHex) {
+		t.Error("expected trace_id exemplar on tool_calls_total counter")
+	}
+}
+
+func TestMetricContext_ToolCallFailed_Exemplar(t *testing.T) {
+	c, reg := newTestCollector()
+	ctx := c.Bind(nil)
+
+	traceHex := "ffeeddccbbaa99887766554433221100"
+	ctx.OnEvent(&events.Event{
+		Type: events.EventToolCallFailed,
+		Ctx:  traceContext(traceHex),
+		Data: &events.ToolCallFailedData{
+			ToolName: "calculator",
+			Duration: 50 * time.Millisecond,
+		},
+	})
+
+	families, _ := reg.Gather()
+	if !findExemplarTraceID(families, "test_tool_call_duration_seconds", traceHex) {
+		t.Error("expected trace_id exemplar on tool_call_duration_seconds histogram")
+	}
+	if !findExemplarTraceID(families, "test_tool_calls_total", traceHex) {
+		t.Error("expected trace_id exemplar on tool_calls_total counter")
+	}
+}
+
+func TestMetricContext_NilCtx_NoExemplar(t *testing.T) {
+	c, reg := newTestCollector()
+	ctx := c.Bind(nil)
+
+	// Event with nil Ctx should not panic and should still record metric.
+	ctx.OnEvent(&events.Event{
+		Type: events.EventProviderCallCompleted,
+		Data: &events.ProviderCallCompletedData{
+			Provider: "openai",
+			Model:    "gpt-4o",
+			Duration: time.Second,
+			Source:   events.SourceAgent,
+		},
+	})
+
+	out := gatherMetrics(t, reg)
+	if !strings.Contains(out, "test_provider_request_duration_seconds") {
+		t.Error("expected metric to be recorded even without trace context")
 	}
 }

--- a/runtime/metrics/collector_test.go
+++ b/runtime/metrics/collector_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -743,15 +742,14 @@ func TestMetricContext_WrongEventDataType(t *testing.T) {
 	}
 }
 
-// traceContext creates a context with a known trace ID for exemplar testing.
-func traceContext(hex string) context.Context {
+// traceSpanContext creates a trace.SpanContext with a known trace ID for exemplar testing.
+func traceSpanContext(hex string) trace.SpanContext {
 	traceID, _ := trace.TraceIDFromHex(hex)
-	sc := trace.NewSpanContext(trace.SpanContextConfig{
+	return trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    traceID,
 		SpanID:     trace.SpanID{1},
 		TraceFlags: trace.FlagsSampled,
 	})
-	return trace.ContextWithSpanContext(context.Background(), sc)
 }
 
 // findExemplarTraceID searches gathered metric families for an exemplar with the given trace_id.
@@ -798,8 +796,8 @@ func TestMetricContext_ProviderCallCompleted_Exemplar(t *testing.T) {
 
 	traceHex := "0102030405060708090a0b0c0d0e0f10"
 	ctx.OnEvent(&events.Event{
-		Type: events.EventProviderCallCompleted,
-		Ctx:  traceContext(traceHex),
+		Type:        events.EventProviderCallCompleted,
+		SpanContext: traceSpanContext(traceHex),
 		Data: &events.ProviderCallCompletedData{
 			Provider: "openai",
 			Model:    "gpt-4o",
@@ -823,8 +821,8 @@ func TestMetricContext_ProviderCallFailed_Exemplar(t *testing.T) {
 
 	traceHex := "aabbccddeeff00112233445566778899"
 	ctx.OnEvent(&events.Event{
-		Type: events.EventProviderCallFailed,
-		Ctx:  traceContext(traceHex),
+		Type:        events.EventProviderCallFailed,
+		SpanContext: traceSpanContext(traceHex),
 		Data: &events.ProviderCallFailedData{
 			Provider: "anthropic",
 			Model:    "claude-3",
@@ -848,8 +846,8 @@ func TestMetricContext_ToolCallCompleted_Exemplar(t *testing.T) {
 
 	traceHex := "11223344556677889900aabbccddeeff"
 	ctx.OnEvent(&events.Event{
-		Type: events.EventToolCallCompleted,
-		Ctx:  traceContext(traceHex),
+		Type:        events.EventToolCallCompleted,
+		SpanContext: traceSpanContext(traceHex),
 		Data: &events.ToolCallCompletedData{
 			ToolName: "search",
 			Duration: 100 * time.Millisecond,
@@ -872,8 +870,8 @@ func TestMetricContext_ToolCallFailed_Exemplar(t *testing.T) {
 
 	traceHex := "ffeeddccbbaa99887766554433221100"
 	ctx.OnEvent(&events.Event{
-		Type: events.EventToolCallFailed,
-		Ctx:  traceContext(traceHex),
+		Type:        events.EventToolCallFailed,
+		SpanContext: traceSpanContext(traceHex),
 		Data: &events.ToolCallFailedData{
 			ToolName: "calculator",
 			Duration: 50 * time.Millisecond,

--- a/runtime/metrics/exemplar.go
+++ b/runtime/metrics/exemplar.go
@@ -1,0 +1,43 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// traceExemplar extracts a trace_id exemplar from the context's span.
+// Returns nil if there is no valid trace ID (no span, or invalid trace ID).
+func traceExemplar(ctx context.Context) prometheus.Labels {
+	if ctx == nil {
+		return nil
+	}
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.TraceID().IsValid() {
+		return nil
+	}
+	return prometheus.Labels{"trace_id": sc.TraceID().String()}
+}
+
+// observeWithExemplar observes a histogram value, attaching an exemplar if labels is non-nil.
+func observeWithExemplar(observer prometheus.Observer, value float64, exemplar prometheus.Labels) {
+	if exemplar != nil {
+		if eo, ok := observer.(prometheus.ExemplarObserver); ok {
+			eo.ObserveWithExemplar(value, exemplar)
+			return
+		}
+	}
+	observer.Observe(value)
+}
+
+// incWithExemplar increments a counter by 1, attaching an exemplar if labels is non-nil.
+func incWithExemplar(counter prometheus.Counter, exemplar prometheus.Labels) {
+	if exemplar != nil {
+		if ea, ok := counter.(prometheus.ExemplarAdder); ok {
+			ea.AddWithExemplar(1, exemplar)
+			return
+		}
+	}
+	counter.Inc()
+}

--- a/runtime/metrics/exemplar.go
+++ b/runtime/metrics/exemplar.go
@@ -1,23 +1,18 @@
 package metrics
 
 import (
-	"context"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// traceExemplar extracts a trace_id exemplar from the context's span.
-// Returns nil if there is no valid trace ID (no span, or invalid trace ID).
-func traceExemplar(ctx context.Context) prometheus.Labels {
-	if ctx == nil {
+// traceExemplar extracts a trace_id exemplar from a span context.
+// Returns nil if the trace ID is invalid (zero value or no active trace).
+func traceExemplar(sc trace.SpanContext) prometheus.Labels {
+	tid := sc.TraceID()
+	if !tid.IsValid() {
 		return nil
 	}
-	sc := trace.SpanContextFromContext(ctx)
-	if !sc.TraceID().IsValid() {
-		return nil
-	}
-	return prometheus.Labels{"trace_id": sc.TraceID().String()}
+	return prometheus.Labels{"trace_id": tid.String()}
 }
 
 // observeWithExemplar observes a histogram value, attaching an exemplar if labels is non-nil.

--- a/runtime/metrics/exemplar_test.go
+++ b/runtime/metrics/exemplar_test.go
@@ -1,0 +1,80 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTraceExemplar_NilContext(t *testing.T) {
+	//nolint:staticcheck // intentional nil context for testing
+	if got := traceExemplar(nil); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestTraceExemplar_NoSpan(t *testing.T) {
+	if got := traceExemplar(context.Background()); got != nil {
+		t.Errorf("expected nil for context without span, got %v", got)
+	}
+}
+
+func TestTraceExemplar_ValidSpan(t *testing.T) {
+	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     trace.SpanID{1},
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	got := traceExemplar(ctx)
+	if got == nil {
+		t.Fatal("expected non-nil exemplar")
+	}
+	if got["trace_id"] != "0102030405060708090a0b0c0d0e0f10" {
+		t.Errorf("expected trace_id=0102030405060708090a0b0c0d0e0f10, got %q", got["trace_id"])
+	}
+}
+
+func TestObserveWithExemplar_WithExemplar(t *testing.T) {
+	hist := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "test_exemplar_hist",
+		Buckets: []float64{1, 5, 10},
+	})
+	exemplar := prometheus.Labels{"trace_id": "abc123"}
+
+	// Should not panic, and should record the observation.
+	observeWithExemplar(hist, 2.5, exemplar)
+}
+
+func TestObserveWithExemplar_NilExemplar(t *testing.T) {
+	hist := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "test_exemplar_hist_nil",
+		Buckets: []float64{1, 5, 10},
+	})
+
+	// Should fall back to Observe without panic.
+	observeWithExemplar(hist, 2.5, nil)
+}
+
+func TestIncWithExemplar_WithExemplar(t *testing.T) {
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_exemplar_counter",
+	})
+	exemplar := prometheus.Labels{"trace_id": "abc123"}
+
+	// Should not panic.
+	incWithExemplar(counter, exemplar)
+}
+
+func TestIncWithExemplar_NilExemplar(t *testing.T) {
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_exemplar_counter_nil",
+	})
+
+	// Should fall back to Inc without panic.
+	incWithExemplar(counter, nil)
+}

--- a/runtime/metrics/exemplar_test.go
+++ b/runtime/metrics/exemplar_test.go
@@ -1,36 +1,28 @@
 package metrics
 
 import (
-	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 )
 
-func TestTraceExemplar_NilContext(t *testing.T) {
-	//nolint:staticcheck // intentional nil context for testing
-	if got := traceExemplar(nil); got != nil {
-		t.Errorf("expected nil, got %v", got)
+func TestTraceExemplar_ZeroSpanContext(t *testing.T) {
+	var sc trace.SpanContext // zero value
+	if got := traceExemplar(sc); got != nil {
+		t.Errorf("expected nil for zero SpanContext, got %v", got)
 	}
 }
 
-func TestTraceExemplar_NoSpan(t *testing.T) {
-	if got := traceExemplar(context.Background()); got != nil {
-		t.Errorf("expected nil for context without span, got %v", got)
-	}
-}
-
-func TestTraceExemplar_ValidSpan(t *testing.T) {
+func TestTraceExemplar_ValidSpanContext(t *testing.T) {
 	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    traceID,
 		SpanID:     trace.SpanID{1},
 		TraceFlags: trace.FlagsSampled,
 	})
-	ctx := trace.ContextWithSpanContext(context.Background(), sc)
 
-	got := traceExemplar(ctx)
+	got := traceExemplar(sc)
 	if got == nil {
 		t.Fatal("expected non-nil exemplar")
 	}

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -444,7 +444,14 @@ func (s *ProviderStage) executeRound(
 		logger.Error("Provider call failed", "error", err, "duration", duration)
 		// Emit provider call failed event
 		if s.emitter != nil {
-			s.emitter.ProviderCallFailedCtx(ctx, s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
+			s.emitter.ProviderCallFailedCtx(ctx, &events.ProviderCallFailedData{
+				Provider: s.provider.ID(),
+				Model:    s.provider.Model(),
+				Error:    err,
+				Duration: duration,
+				Source:   s.config.Source,
+				Labels:   s.config.Labels,
+			})
 		}
 		return types.Message{}, false, fmt.Errorf("provider call failed: %w", err)
 	}
@@ -597,7 +604,14 @@ func (s *ProviderStage) executeStreamingRound(
 		duration := time.Since(startTime)
 		// Emit provider call failed event
 		if s.emitter != nil {
-			s.emitter.ProviderCallFailedCtx(ctx, s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
+			s.emitter.ProviderCallFailedCtx(ctx, &events.ProviderCallFailedData{
+				Provider: s.provider.ID(),
+				Model:    s.provider.Model(),
+				Error:    err,
+				Duration: duration,
+				Source:   s.config.Source,
+				Labels:   s.config.Labels,
+			})
 		}
 		return types.Message{}, false, err
 	}
@@ -609,7 +623,14 @@ func (s *ProviderStage) executeStreamingRound(
 	if err != nil {
 		// Emit provider call failed event
 		if s.emitter != nil {
-			s.emitter.ProviderCallFailedCtx(ctx, s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
+			s.emitter.ProviderCallFailedCtx(ctx, &events.ProviderCallFailedData{
+				Provider: s.provider.ID(),
+				Model:    s.provider.Model(),
+				Error:    err,
+				Duration: duration,
+				Source:   s.config.Source,
+				Labels:   s.config.Labels,
+			})
 		}
 		return types.Message{}, false, err
 	}
@@ -948,7 +969,7 @@ func (s *ProviderStage) executeSingleToolCall(
 	}
 
 	if asyncResult.Status == tools.ToolStatusPending {
-		return s.buildPendingResult(toolCall, asyncResult)
+		return s.buildPendingResult(ctx, toolCall, asyncResult)
 	}
 
 	result := s.handleToolResult(toolCall, asyncResult)
@@ -1007,7 +1028,7 @@ func (s *ProviderStage) emitGuardrailEvent(d hooks.Decision, duration time.Durat
 // awaiting fulfillment, and a tool.call.completed with status "pending" so
 // every tool.call.started has a matching completion.
 func (s *ProviderStage) buildPendingResult(
-	toolCall types.MessageToolCall, asyncResult *tools.ToolExecutionResult,
+	ctx context.Context, toolCall types.MessageToolCall, asyncResult *tools.ToolExecutionResult,
 ) toolCallResult {
 	var argsMap map[string]any
 	if toolCall.Args != nil {
@@ -1033,7 +1054,7 @@ func (s *ProviderStage) buildPendingResult(
 	// Emit tool.call.completed with status "pending" so the started event is paired
 	if s.emitter != nil {
 		labels := s.toolLabels(toolCall.Name)
-		s.emitter.ToolCallCompleted(toolCall.Name, toolCall.ID, 0, "pending", nil, labels)
+		s.emitter.ToolCallCompletedCtx(ctx, toolCall.Name, toolCall.ID, 0, "pending", nil, labels)
 	}
 
 	toolResult := s.handleToolResult(toolCall, asyncResult)

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -444,7 +444,7 @@ func (s *ProviderStage) executeRound(
 		logger.Error("Provider call failed", "error", err, "duration", duration)
 		// Emit provider call failed event
 		if s.emitter != nil {
-			s.emitter.ProviderCallFailed(s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
+			s.emitter.ProviderCallFailedCtx(ctx, s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
 		}
 		return types.Message{}, false, fmt.Errorf("provider call failed: %w", err)
 	}
@@ -465,7 +465,7 @@ func (s *ProviderStage) executeRound(
 			completedData.CachedTokens = resp.CostInfo.CachedTokens
 			completedData.Cost = resp.CostInfo.TotalCost
 		}
-		s.emitter.ProviderCallCompleted(completedData)
+		s.emitter.ProviderCallCompletedCtx(ctx, completedData)
 	}
 
 	// Build response message with latency and cost info
@@ -597,7 +597,7 @@ func (s *ProviderStage) executeStreamingRound(
 		duration := time.Since(startTime)
 		// Emit provider call failed event
 		if s.emitter != nil {
-			s.emitter.ProviderCallFailed(s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
+			s.emitter.ProviderCallFailedCtx(ctx, s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
 		}
 		return types.Message{}, false, err
 	}
@@ -609,7 +609,7 @@ func (s *ProviderStage) executeStreamingRound(
 	if err != nil {
 		// Emit provider call failed event
 		if s.emitter != nil {
-			s.emitter.ProviderCallFailed(s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
+			s.emitter.ProviderCallFailedCtx(ctx, s.provider.ID(), s.provider.Model(), err, duration, s.config.Labels)
 		}
 		return types.Message{}, false, err
 	}
@@ -631,7 +631,7 @@ func (s *ProviderStage) executeStreamingRound(
 			completedData.CachedTokens = costInfo.CachedTokens
 			completedData.Cost = costInfo.TotalCost
 		}
-		s.emitter.ProviderCallCompleted(completedData)
+		s.emitter.ProviderCallCompletedCtx(ctx, completedData)
 	}
 
 	// Build final response message with latency and cost info
@@ -936,8 +936,8 @@ func (s *ProviderStage) executeSingleToolCall(
 	asyncResult, err := s.toolRegistry.ExecuteAsync(ctx, toolCall.Name, toolCall.Args)
 	if err != nil {
 		if s.emitter != nil {
-			s.emitter.ToolCallFailed(
-				toolCall.Name, toolCall.ID, err, time.Since(startTime), labels,
+			s.emitter.ToolCallFailedCtx(
+				ctx, toolCall.Name, toolCall.ID, err, time.Since(startTime), labels,
 			)
 		}
 		errResult := types.NewTextToolResult(toolCall.ID, toolCall.Name, fmt.Sprintf("Error: %v", err))
@@ -954,8 +954,8 @@ func (s *ProviderStage) executeSingleToolCall(
 	result := s.handleToolResult(toolCall, asyncResult)
 	if s.emitter != nil {
 		status := string(asyncResult.Status)
-		s.emitter.ToolCallCompleted(
-			toolCall.Name, toolCall.ID, time.Since(startTime), status, result.Parts, labels,
+		s.emitter.ToolCallCompletedCtx(
+			ctx, toolCall.Name, toolCall.ID, time.Since(startTime), status, result.Parts, labels,
 		)
 	}
 	resultMsg := types.NewToolResultMessage(result)

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -2059,3 +2059,64 @@ func TestProviderStage_ToolCallCompletedEvent_MetadataOnlyParts(t *testing.T) {
 	assert.Nil(t, data.Parts[1].Media.Data, "binary data should be stripped from events")
 	assert.Equal(t, "image/png", data.Parts[1].Media.MIMEType)
 }
+
+// errorProvider always returns an error from Predict.
+type errorProvider struct {
+	providers.Provider
+}
+
+func (p *errorProvider) ID() string              { return "error-provider" }
+func (p *errorProvider) Model() string           { return "error-model" }
+func (p *errorProvider) SupportsStreaming() bool { return false }
+func (p *errorProvider) SupportsTools() bool     { return false }
+func (p *errorProvider) Predict(_ context.Context, _ providers.PredictionRequest) (providers.PredictionResponse, error) {
+	return providers.PredictionResponse{}, fmt.Errorf("provider unavailable")
+}
+
+func TestProviderStage_EmitsProviderCallFailedEvent(t *testing.T) {
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "test-run", "test-session", "test-conv")
+
+	var receivedEvent *events.Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	bus.Subscribe(events.EventProviderCallFailed, func(e *events.Event) {
+		receivedEvent = e
+		wg.Done()
+	})
+
+	provider := &errorProvider{}
+	stage := NewProviderStageWithEmitter(provider, nil, nil, &ProviderConfig{
+		MaxTokens:   100,
+		Temperature: 0.7,
+	}, emitter)
+
+	input := make(chan StreamElement, 1)
+	userMsg := types.Message{Role: "user", Content: "Test message"}
+	elem := NewMessageElement(&userMsg)
+	elem.Metadata["system_prompt"] = "You are helpful"
+	input <- elem
+	close(input)
+
+	output := make(chan StreamElement, 10)
+	err := stage.Process(context.Background(), input, output)
+	require.Error(t, err)
+
+	// Drain output
+	for range output {
+	}
+
+	if !waitForWG(&wg, 500*time.Millisecond) {
+		t.Fatal("timed out waiting for ProviderCallFailed event")
+	}
+
+	require.NotNil(t, receivedEvent)
+	assert.Equal(t, events.EventProviderCallFailed, receivedEvent.Type)
+
+	data, ok := receivedEvent.Data.(*events.ProviderCallFailedData)
+	require.True(t, ok)
+	assert.Equal(t, "error-provider", data.Provider)
+	assert.Equal(t, "error-model", data.Model)
+	assert.Contains(t, data.Error.Error(), "provider unavailable")
+}


### PR DESCRIPTION
## Summary

Closes #765 — adds Prometheus exemplar support to the metrics `Collector` so provider and tool call metrics carry `trace_id` exemplar labels, enabling click-through from Grafana latency spikes to Tempo traces.

### What changed

- **`Event.SpanContext`** (`trace.SpanContext` value type) on `events.Event` — stores only trace/span IDs and flags, structurally preventing misuse for cancellation or arbitrary value storage
- **Context-aware emitter methods** (`ProviderCallCompletedCtx`, `ProviderCallFailedCtx`, `ToolCallCompletedCtx`, `ToolCallFailedCtx`) — extract `SpanContext` from `context.Context` at emit time
- **`ProviderCallFailedCtx`** accepts `*ProviderCallFailedData` (mirroring Completed), fixing pre-existing bug where judge provider failures were tagged `source=agent` instead of `source=judge`
- **`runtime/metrics/exemplar.go`** — `traceExemplar()`, `observeWithExemplar()`, `incWithExemplar()` helpers with graceful fallback when no trace context is present
- **Collector handlers** — `handleProviderCallCompleted/Failed` and `handleToolCallCompleted/Failed` attach `trace_id` exemplars to `provider_request_duration_seconds`, `provider_requests_total`, `tool_call_duration_seconds`, `tool_calls_total`
- **All emit call sites** in `stages_provider.go` and `judge_provider.go` updated to use Ctx variants, including `buildPendingResult` which now receives `ctx`

### Design decisions

- **`SpanContext` over `context.Context`**: The Event only needs trace correlation data. Storing `context.Context` would expose cancellation, deadlines, and arbitrary values — a doc comment saying "don't use for cancellation" is not enforceable. `trace.SpanContext` is a value type that carries only what we need.
- **No `Bus`/`Listener` changes**: Option A from the issue. Span context is extracted from `context.Context` in the emitter and stored as a value on the Event. Zero blast radius on the event system interface.
- **Token/cost counters excluded**: `trace_id` on duration histogram + request counter is sufficient for correlation. Adding exemplars to every token/cost counter would create unnecessary overhead.

## Test plan

- [x] Emitter Ctx variant tests — verify `SpanContext` propagation, default source, nil safety (data + emitter)
- [x] `traceExemplar` unit tests — zero SpanContext, valid SpanContext with cached TraceID
- [x] `observeWithExemplar`/`incWithExemplar` — with and without exemplar labels
- [x] Collector integration tests — verify exemplars on all 4 metric types via `reg.Gather()` + proto model inspection
- [x] Zero SpanContext graceful degradation — metrics recorded without exemplar, no panic
- [x] All existing tests pass, 100% coverage on `exemplar.go`, all changed files above 80% threshold