### PR TITLE
fix: always emit provider cost and cached tokens metrics

### DIFF
--- a/runtime/metrics/collector.go
+++ b/runtime/metrics/collector.go
@@ -418,17 +418,13 @@ func (mc *MetricContext) handleProviderCallCompleted(event *events.Event) {
 			mc.labelValues(data.Provider, data.Model, data.Source)...,
 		).Add(float64(data.OutputTokens))
 	}
-	if data.CachedTokens > 0 {
-		mc.collector.providerCachedTokensTotal.WithLabelValues(
-			mc.labelValues(data.Provider, data.Model, data.Source)...,
-		).Add(float64(data.CachedTokens))
-	}
+	mc.collector.providerCachedTokensTotal.WithLabelValues(
+		mc.labelValues(data.Provider, data.Model, data.Source)...,
+	).Add(float64(data.CachedTokens))
 
-	if data.Cost > 0 {
-		mc.collector.providerCostTotal.WithLabelValues(
-			mc.labelValues(data.Provider, data.Model, data.Source)...,
-		).Add(data.Cost)
-	}
+	mc.collector.providerCostTotal.WithLabelValues(
+		mc.labelValues(data.Provider, data.Model, data.Source)...,
+	).Add(data.Cost)
 }
 
 func (mc *MetricContext) handleProviderCallFailed(event *events.Event) {

--- a/runtime/metrics/collector.go
+++ b/runtime/metrics/collector.go
@@ -408,16 +408,13 @@ func (mc *MetricContext) handleProviderCallCompleted(event *events.Event) {
 		mc.labelValues(data.Provider, data.Model, data.Source, statusSuccess)...,
 	).Inc()
 
-	if data.InputTokens > 0 {
-		mc.collector.providerInputTokensTotal.WithLabelValues(
-			mc.labelValues(data.Provider, data.Model, data.Source)...,
-		).Add(float64(data.InputTokens))
-	}
-	if data.OutputTokens > 0 {
-		mc.collector.providerOutputTokensTotal.WithLabelValues(
-			mc.labelValues(data.Provider, data.Model, data.Source)...,
-		).Add(float64(data.OutputTokens))
-	}
+	mc.collector.providerInputTokensTotal.WithLabelValues(
+		mc.labelValues(data.Provider, data.Model, data.Source)...,
+	).Add(float64(data.InputTokens))
+
+	mc.collector.providerOutputTokensTotal.WithLabelValues(
+		mc.labelValues(data.Provider, data.Model, data.Source)...,
+	).Add(float64(data.OutputTokens))
 	mc.collector.providerCachedTokensTotal.WithLabelValues(
 		mc.labelValues(data.Provider, data.Model, data.Source)...,
 	).Add(float64(data.CachedTokens))

--- a/runtime/metrics/collector_test.go
+++ b/runtime/metrics/collector_test.go
@@ -216,7 +216,7 @@ func TestMetricContext_ProviderCallCompleted(t *testing.T) {
 	}
 }
 
-func TestMetricContext_ProviderCallCompleted_ZeroCostEmitsMetric(t *testing.T) {
+func TestMetricContext_ProviderCallCompleted_ZeroValuesEmitMetrics(t *testing.T) {
 	c, reg := newTestCollector()
 	ctx := c.Bind(nil)
 
@@ -226,8 +226,8 @@ func TestMetricContext_ProviderCallCompleted_ZeroCostEmitsMetric(t *testing.T) {
 			Provider:     "ollama",
 			Model:        "llama3",
 			Duration:     200 * time.Millisecond,
-			InputTokens:  50,
-			OutputTokens: 30,
+			InputTokens:  0,
+			OutputTokens: 0,
 			CachedTokens: 0,
 			Cost:         0,
 			Source:       events.SourceAgent,
@@ -236,12 +236,28 @@ func TestMetricContext_ProviderCallCompleted_ZeroCostEmitsMetric(t *testing.T) {
 
 	output := gatherMetrics(t, reg)
 
-	// Cost and cached tokens should appear even when zero, so the time series exists.
-	if !strings.Contains(output, "test_provider_cost_total") {
-		t.Error("expected test_provider_cost_total to be emitted even with zero cost")
+	// All counter metrics should exist even when zero, so Prometheus time series are created.
+	for _, metric := range []string{
+		"test_provider_input_tokens_total",
+		"test_provider_output_tokens_total",
+		"test_provider_cached_tokens_total",
+		"test_provider_cost_total",
+	} {
+		if !strings.Contains(output, metric) {
+			t.Errorf("expected %s to be emitted even with zero value", metric)
+		}
 	}
-	if !strings.Contains(output, "test_provider_cached_tokens_total") {
-		t.Error("expected test_provider_cached_tokens_total to be emitted even with zero cached tokens")
+
+	// Verify all counters have value 0.
+	for _, metric := range []string{
+		`test_provider_input_tokens_total{model="llama3",provider="ollama",source="agent"} 0`,
+		`test_provider_output_tokens_total{model="llama3",provider="ollama",source="agent"} 0`,
+		`test_provider_cached_tokens_total{model="llama3",provider="ollama",source="agent"} 0`,
+		`test_provider_cost_total{model="llama3",provider="ollama",source="agent"} 0`,
+	} {
+		if !strings.Contains(output, metric) {
+			t.Errorf("expected %q in output, got:\n%s", metric, output)
+		}
 	}
 }
 

--- a/runtime/metrics/collector_test.go
+++ b/runtime/metrics/collector_test.go
@@ -216,6 +216,35 @@ func TestMetricContext_ProviderCallCompleted(t *testing.T) {
 	}
 }
 
+func TestMetricContext_ProviderCallCompleted_ZeroCostEmitsMetric(t *testing.T) {
+	c, reg := newTestCollector()
+	ctx := c.Bind(nil)
+
+	ctx.OnEvent(&events.Event{
+		Type: events.EventProviderCallCompleted,
+		Data: &events.ProviderCallCompletedData{
+			Provider:     "ollama",
+			Model:        "llama3",
+			Duration:     200 * time.Millisecond,
+			InputTokens:  50,
+			OutputTokens: 30,
+			CachedTokens: 0,
+			Cost:         0,
+			Source:       events.SourceAgent,
+		},
+	})
+
+	output := gatherMetrics(t, reg)
+
+	// Cost and cached tokens should appear even when zero, so the time series exists.
+	if !strings.Contains(output, "test_provider_cost_total") {
+		t.Error("expected test_provider_cost_total to be emitted even with zero cost")
+	}
+	if !strings.Contains(output, "test_provider_cached_tokens_total") {
+		t.Error("expected test_provider_cached_tokens_total to be emitted even with zero cached tokens")
+	}
+}
+
 func TestMetricContext_ProviderCallFailed(t *testing.T) {
 	c, reg := newTestCollector()
 	ctx := c.Bind(nil)


### PR DESCRIPTION
## Summary

Closes #768 — removes `> 0` guards on `providerCostTotal` and `providerCachedTokensTotal` so the time series exist in Prometheus even when a provider reports zero cost (e.g., Ollama for local inference).

Adding zero to a counter is a no-op for the value but ensures the time series exists, preventing "No data" in Grafana dashboard panels.

## Test plan

- [x] `TestMetricContext_ProviderCallCompleted_ZeroCostEmitsMetric` — emits event with `Cost: 0` and `CachedTokens: 0`, verifies both metrics appear in gathered output
- [x] Existing `TestMetricContext_ProviderCallCompleted` still passes (non-zero cost)
- [x] Full metrics test suite passes