### PR TITLE
chore: configure npm trusted publishing with OIDC provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -68,9 +69,7 @@ jobs:
       
       - name: Publish to npm
         working-directory: npm/${{ matrix.package }}
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
       
       - name: Create summary
         run: |

--- a/npm/packc/package.json
+++ b/npm/packc/package.json
@@ -59,5 +59,9 @@
     "lib/",
     "postinstall.js",
     "README.md"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  }
 }

--- a/npm/promptarena/package.json
+++ b/npm/promptarena/package.json
@@ -68,5 +68,9 @@
   "exports": {
     "./schemas/*": "./schemas/*.json",
     "./schema-map": "./schema-map.json"
+  },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

Switches npm publishing from long-lived `NPM_TOKEN` secret to OIDC-based trusted publishing with provenance attestation.

### Changes
- **`npm-publish.yml`**: Add `id-token: write` permission, replace `NPM_TOKEN` with `--provenance` flag
- **`npm/packc/package.json`**: Add `publishConfig` with `provenance: true` and `access: "public"`
- **`npm/promptarena/package.json`**: Same

### Manual setup required after merge

Configure trusted publisher on npmjs.com for each package:

1. Go to https://www.npmjs.com/package/@altairalabs/packc/access
2. Under **Trusted Publisher**, select **GitHub Actions**
3. Fill in: Org=`AltairaLabs`, Repo=`PromptKit`, Workflow=`npm-publish.yml`
4. Repeat for `@altairalabs/promptarena`

Once configured, the `NPM_TOKEN` secret can be removed from the repo settings.

## Test plan

- [x] Workflow syntax is valid (CI will validate)
- [ ] First publish after merge: verify provenance badge appears on npmjs.com package page
- [ ] Verify `npm audit signatures` passes for published packages