### PR TITLE
feat: add EnableMessageEvents to arena engine

### DIFF
--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -238,9 +238,28 @@ func (e *Engine) Close() error {
 	return e.closeEventStore()
 }
 
+// EventBusOption configures optional behavior when setting the event bus.
+type EventBusOption func(*eventBusConfig)
+
+type eventBusConfig struct {
+	emitMessages bool
+}
+
+// WithMessageEvents enables RecordingStage in pipelines so message.created
+// events are published to the event bus. This does NOT write session recordings
+// to disk — use EnableSessionRecording for that.
+func WithMessageEvents() EventBusOption {
+	return func(c *eventBusConfig) { c.emitMessages = true }
+}
+
 // SetEventBus configures the shared event bus used for runtime and TUI observability.
 // If session recording is enabled, the event store is subscribed to the bus.
-func (e *Engine) SetEventBus(bus events.Bus) {
+func (e *Engine) SetEventBus(bus events.Bus, opts ...EventBusOption) {
+	var cfg eventBusConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	e.eventBus = bus
 	// Subscribe event store to bus if both are configured
 	if e.eventStore != nil && bus != nil {
@@ -250,6 +269,10 @@ func (e *Engine) SetEventBus(bus events.Bus) {
 	// Wire event bus to eval orchestrator for judge provider telemetry
 	if e.evalOrchestrator != nil {
 		e.evalOrchestrator.SetEventBus(bus)
+	}
+	// Enable RecordingStage so message.created events flow to the bus
+	if cfg.emitMessages {
+		e.EnableMessageEvents()
 	}
 }
 

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -281,6 +281,17 @@ func (e *Engine) SetMetrics(collector *metrics.Collector, instanceLabels map[str
 	logger.Debug("Metrics collection enabled for Arena engine")
 }
 
+// EnableMessageEvents enables RecordingStage in pipelines so message.created
+// events are published to the event bus. This does NOT write session recordings
+// to disk — use EnableSessionRecording for that. Requires an event bus to be
+// configured via SetEventBus.
+func (e *Engine) EnableMessageEvents() {
+	if e.recordingConfig == nil {
+		defaults := stage.DefaultRecordingStageConfig()
+		e.recordingConfig = &defaults
+	}
+}
+
 // EnableSessionRecording enables session recording for all runs.
 // Recordings are stored in the specified directory as JSONL files,
 // one file per session (using RunID as session ID).

--- a/tools/arena/engine/event_bus_test.go
+++ b/tools/arena/engine/event_bus_test.go
@@ -131,6 +131,34 @@ func TestEngineEnableMessageEvents_PreservesExisting(t *testing.T) {
 	}
 }
 
+func TestEngineSetEventBus_WithMessageEvents(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewEventBus()
+	defer bus.Close()
+	e := &Engine{}
+
+	e.SetEventBus(bus, WithMessageEvents())
+
+	if e.recordingConfig == nil {
+		t.Fatal("expected recordingConfig to be set with WithMessageEvents option")
+	}
+}
+
+func TestEngineSetEventBus_WithoutMessageEvents(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewEventBus()
+	defer bus.Close()
+	e := &Engine{}
+
+	e.SetEventBus(bus)
+
+	if e.recordingConfig != nil {
+		t.Fatal("expected nil recordingConfig without WithMessageEvents option")
+	}
+}
+
 func TestEngineSetTracerProvider(t *testing.T) {
 	t.Parallel()
 

--- a/tools/arena/engine/event_bus_test.go
+++ b/tools/arena/engine/event_bus_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
@@ -98,6 +99,35 @@ func TestEngineSetEventBus(t *testing.T) {
 	e.SetEventBus(bus)
 	if e.eventBus != bus {
 		t.Fatalf("expected eventBus to be set")
+	}
+}
+
+func TestEngineEnableMessageEvents(t *testing.T) {
+	t.Parallel()
+
+	e := &Engine{}
+	if e.recordingConfig != nil {
+		t.Fatal("expected nil recordingConfig initially")
+	}
+
+	e.EnableMessageEvents()
+
+	if e.recordingConfig == nil {
+		t.Fatal("expected recordingConfig to be set after EnableMessageEvents")
+	}
+}
+
+func TestEngineEnableMessageEvents_PreservesExisting(t *testing.T) {
+	t.Parallel()
+
+	e := &Engine{}
+	custom := &stage.RecordingStageConfig{IncludeAudio: false}
+	e.recordingConfig = custom
+
+	e.EnableMessageEvents()
+
+	if e.recordingConfig != custom {
+		t.Fatal("expected existing recordingConfig to be preserved")
 	}
 }
 


### PR DESCRIPTION
## Summary

Ref #773 — adds `Engine.EnableMessageEvents()` which enables `RecordingStage` in pipelines so `message.created` events are published to the event bus without requiring file-based session recording.

This allows callers (e.g., Omnia) to call `engine.EnableMessageEvents()` after `SetEventBus()` to receive message events for dashboard display without writing JSONL files to disk.

### Usage (Omnia side)
```go
engine.SetEventBus(bus)
engine.EnableMessageEvents() // message.created events flow to bus subscribers
```

## Test plan

- [x] `TestEngineEnableMessageEvents` — verifies `recordingConfig` is set
- [x] `TestEngineEnableMessageEvents_PreservesExisting` — doesn't overwrite custom config
- [x] Full arena engine test suite passes