### PR TITLE
fix: restore NODE_AUTH_TOKEN for npm publish with provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Publish to npm
         working-directory: npm/${{ matrix.package }}
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       
       - name: Create summary
         run: |


### PR DESCRIPTION
## Summary

Fixes the npm publish 404 error introduced by PR #770. `actions/setup-node` with `registry-url` creates an `.npmrc` that expects `NODE_AUTH_TOKEN` for registry auth. Removing it caused npm to fall back to unauthenticated, returning 404 for scoped packages.

The OIDC provenance flow still works with the token present — it overrides it for signing. Both are needed: `NODE_AUTH_TOKEN` for registry auth, `--provenance` + `id-token: write` for attestation.

## Test plan

- [ ] Re-run npm publish workflow after merge to verify v1.3.21 publishes successfully