### PR TITLE
fix: restore registry-url and use Node 22 for OIDC npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,10 +28,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@65d868f8d4d85d7d4abb7de0875cde3fcc8798f5 # v6.1.0
         with:
-          node-version: '20'
-
-      - name: Configure npm registry
-        run: npm config set registry https://registry.npmjs.org/
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Determine version
         id: version


### PR DESCRIPTION
Restore `registry-url` (needed for `.npmrc`) and bump to Node 22 (npm 11+ with native OIDC token exchange). No `NODE_AUTH_TOKEN` needed — npm auto-exchanges the OIDC token when `--provenance` is used.