### PR TITLE
ci: disable fail-fast on npm publish matrix

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         package: [promptarena, packc]
 


### PR DESCRIPTION
Publish each package independently so one failure doesn't cancel the other.