### PR TITLE
fix: revert npm publish to token-based auth

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish:
@@ -70,7 +69,9 @@ jobs:
 
       - name: Publish to npm
         working-directory: npm/${{ matrix.package }}
-        run: npm publish --provenance --access public
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create summary
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         package: [promptarena, packc]
 


### PR DESCRIPTION
Revert to NPM_TOKEN. Trusted publishing OIDC has case-sensitivity issues. Generate a new token at npmjs.com and add it as NPM_TOKEN secret.