### PR TITLE
fix: remove provenance from publishConfig

### DIFF
--- a/npm/packc/package.json
+++ b/npm/packc/package.json
@@ -61,7 +61,6 @@
     "README.md"
   ],
   "publishConfig": {
-    "provenance": true,
     "access": "public"
   }
 }

--- a/npm/promptarena/package.json
+++ b/npm/promptarena/package.json
@@ -70,7 +70,6 @@
     "./schema-map": "./schema-map.json"
   },
   "publishConfig": {
-    "provenance": true,
     "access": "public"
   }
 }


### PR DESCRIPTION
Remove provenance:true from package.json — it triggers OIDC even without the CLI flag.