### PR TITLE
feat: add context compactor to fold stale tool results in tool loop

### DIFF
--- a/runtime/pipeline/stage/compactor.go
+++ b/runtime/pipeline/stage/compactor.go
@@ -1,0 +1,150 @@
+package stage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/tokenizer"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+const (
+	defaultCompactThreshold  = 0.70
+	defaultPinRecentCount    = 4
+	compactedPreviewMaxBytes = 100
+	compactedMarker          = "compacted"
+	roleTool                 = "tool"
+)
+
+// ContextCompactor folds stale tool results between rounds to keep context
+// bounded. Deterministic, zero LLM calls. Only modifies the in-memory message
+// slice sent to the provider — the persisted log (via MessageLog) retains the
+// full uncompacted history.
+type ContextCompactor struct {
+	// BudgetTokens is the context window size. When 0, compaction is disabled.
+	BudgetTokens int
+
+	// Threshold is the fraction of BudgetTokens above which compaction triggers.
+	// Default: 0.70 (compact when usage exceeds 70% of budget).
+	Threshold float64
+
+	// PinRecentCount is the number of recent messages to preserve verbatim.
+	// Default: 4 (2 round-trips).
+	PinRecentCount int
+}
+
+// Compact folds stale tool results to reduce token usage.
+// Returns the original messages unchanged if no compaction is needed.
+// Safe to call on a nil receiver (returns messages unchanged).
+func (c *ContextCompactor) Compact(messages []types.Message) []types.Message {
+	if c == nil || c.BudgetTokens <= 0 || len(messages) == 0 {
+		return messages
+	}
+
+	threshold := c.Threshold
+	if threshold <= 0 {
+		threshold = defaultCompactThreshold
+	}
+	pinCount := c.PinRecentCount
+	if pinCount <= 0 {
+		pinCount = defaultPinRecentCount
+	}
+
+	budget := int(float64(c.BudgetTokens) * threshold)
+	originalTokens := tokenizer.CountMessageTokensDefault(messages)
+	if originalTokens <= budget {
+		return messages
+	}
+
+	// Identify which messages can be compacted:
+	// - Must be a tool result (Role == "tool")
+	// - Must NOT be in the pinned window (last pinCount messages)
+	// - Must NOT be an error result
+	// - Must NOT already be compacted (contains marker)
+	pinBoundary := len(messages) - pinCount
+	if pinBoundary < 0 {
+		pinBoundary = 0
+	}
+
+	compacted := make([]types.Message, len(messages))
+	copy(compacted, messages)
+
+	totalTokens := originalTokens
+	for i := 0; i < pinBoundary && totalTokens > budget; i++ {
+		msg := &compacted[i]
+
+		if !isCompactable(msg) {
+			continue
+		}
+
+		beforeTokens := tokenizer.CountMessageTokensDefault([]types.Message{*msg})
+		msg.Content = foldToolResult(msg)
+		msg.Parts = nil // clear multimodal parts
+		afterTokens := tokenizer.CountMessageTokensDefault([]types.Message{*msg})
+
+		totalTokens -= beforeTokens - afterTokens
+	}
+
+	if totalTokens < originalTokens {
+		logger.Debug("Context compacted",
+			"original_tokens", originalTokens,
+			"compacted_tokens", totalTokens,
+			"budget", budget)
+	}
+
+	return compacted
+}
+
+// isCompactable returns true if a message can be folded.
+func isCompactable(msg *types.Message) bool {
+	if msg.Role != roleTool {
+		return false
+	}
+	if msg.ToolResult != nil && msg.ToolResult.Error != "" {
+		return false
+	}
+	// Already compacted or too small to bother — skip
+	if len(msg.Content) < 50 || strings.Contains(msg.Content, compactedMarker) {
+		return false
+	}
+	return true
+}
+
+// foldToolResult creates a compact summary of a tool result.
+func foldToolResult(msg *types.Message) string {
+	name := ""
+	if msg.ToolResult != nil {
+		name = msg.ToolResult.Name
+	}
+	if name == "" {
+		name = "tool"
+	}
+
+	// Handle multimodal parts
+	if len(msg.Parts) > 0 {
+		totalBytes := 0
+		for _, part := range msg.Parts {
+			if part.Text != nil {
+				totalBytes += len(*part.Text)
+			}
+			if part.Media != nil && part.Media.Data != nil {
+				totalBytes += len(*part.Media.Data)
+			}
+		}
+		return fmt.Sprintf("[%s: %d parts, %d bytes %s]",
+			name, len(msg.Parts), totalBytes, compactedMarker)
+	}
+
+	// Text-only: preview + size
+	content := msg.Content
+	originalBytes := len(content)
+
+	preview := content
+	if len(preview) > compactedPreviewMaxBytes {
+		preview = preview[:compactedPreviewMaxBytes] + "..."
+	}
+
+	return fmt.Sprintf("[%s: %s — %d bytes %s]",
+		name, preview, originalBytes, compactedMarker)
+}

--- a/runtime/pipeline/stage/compactor_test.go
+++ b/runtime/pipeline/stage/compactor_test.go
@@ -1,0 +1,298 @@
+package stage
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func toolResultMsg(name, content string) types.Message {
+	tr := types.NewTextToolResult("call-"+name, name, content)
+	return types.NewToolResultMessage(tr)
+}
+
+func toolResultMsgWithError(name, content, errMsg string) types.Message {
+	tr := types.NewTextToolResult("call-"+name, name, content)
+	tr.Error = errMsg
+	return types.NewToolResultMessage(tr)
+}
+
+func largeToolResult(name string, wordCount int) types.Message {
+	// Use realistic content with spaces so token counting works (~1.3 tokens/word)
+	content := strings.Repeat("the quick brown fox jumps over the lazy dog ", wordCount/9+1)
+	maxLen := wordCount * 6
+	if maxLen > len(content) {
+		maxLen = len(content)
+	}
+	return toolResultMsg(name, content[:maxLen])
+}
+
+func TestCompactor_NoOpUnderThreshold(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens: 10000,
+		Threshold:    0.70,
+	}
+
+	msgs := []types.Message{
+		{Role: "system", Content: "You are a helper"},
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi there"},
+		{Role: "user", Content: "how are you"},
+		{Role: "assistant", Content: "I'm good"},
+	}
+
+	result := c.Compact(msgs)
+	assert.Equal(t, len(msgs), len(result), "should not compact when under threshold")
+	assert.Equal(t, msgs[0].Content, result[0].Content)
+}
+
+func TestCompactor_FoldsOldToolResults(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   500, // very low budget to force compaction
+		Threshold:      0.70,
+		PinRecentCount: 4,
+	}
+
+	msgs := []types.Message{
+		{Role: "system", Content: "You are a helper"},
+		{Role: "user", Content: "read main.go"},
+		{Role: "assistant", Content: "I'll read that file"},
+		largeToolResult("file_read", 2000), // old — should be compacted
+		{Role: "assistant", Content: "Now read config.go"},
+		largeToolResult("file_read", 2000), // old — should be compacted
+		// Recent window (last 4):
+		{Role: "assistant", Content: "Let me edit the file"},
+		toolResultMsg("file_edit", "edit applied"),
+		{Role: "user", Content: "run tests"},
+		{Role: "assistant", Content: "running tests now"},
+	}
+
+	result := c.Compact(msgs)
+
+	// Recent 4 messages should be preserved verbatim
+	assert.Equal(t, "Let me edit the file", result[len(result)-4].Content)
+	assert.Equal(t, "run tests", result[len(result)-2].Content)
+
+	// Old large tool results should be folded (contain "compacted")
+	foundCompacted := false
+	for _, msg := range result {
+		if msg.Role == "tool" && strings.Contains(msg.Content, "compacted") {
+			foundCompacted = true
+			break
+		}
+	}
+	assert.True(t, foundCompacted, "old tool results should be compacted")
+}
+
+func TestCompactor_PreservesSystemMessages(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   100, // very low to force compaction
+		Threshold:      0.50,
+		PinRecentCount: 2,
+	}
+
+	msgs := []types.Message{
+		{Role: "system", Content: strings.Repeat("system prompt ", 50)}, // large system message
+		{Role: "user", Content: "hello"},
+		largeToolResult("search", 1000),
+		{Role: "assistant", Content: "done"},
+	}
+
+	result := c.Compact(msgs)
+
+	// System message must be preserved regardless of size
+	assert.Equal(t, "system", result[0].Role)
+	assert.Contains(t, result[0].Content, "system prompt")
+}
+
+func TestCompactor_PreservesErrors(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   100,
+		Threshold:      0.50,
+		PinRecentCount: 2,
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "do something"},
+		toolResultMsgWithError("failing_tool", strings.Repeat("error details ", 100), "tool failed"),
+		{Role: "assistant", Content: "I see the error"},
+		{Role: "user", Content: "try again"},
+	}
+
+	result := c.Compact(msgs)
+
+	// Error tool result must be preserved verbatim
+	for _, msg := range result {
+		if msg.ToolResult != nil && msg.ToolResult.Error != "" {
+			assert.Contains(t, msg.Content, "error details",
+				"error tool results should not be compacted")
+		}
+	}
+}
+
+func TestCompactor_PreservesRecentMessages(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   200,
+		Threshold:      0.50,
+		PinRecentCount: 4,
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		largeToolResult("old_tool", 2000),
+		// Recent 4:
+		{Role: "assistant", Content: "recent-1"},
+		largeToolResult("recent_tool", 2000), // large but recent — pinned
+		{Role: "user", Content: "recent-3"},
+		{Role: "assistant", Content: "recent-4"},
+	}
+
+	result := c.Compact(msgs)
+
+	// Last 4 messages must be untouched
+	n := len(result)
+	require.GreaterOrEqual(t, n, 4)
+	assert.Equal(t, "recent-1", result[n-4].Content)
+	assert.Equal(t, "recent-3", result[n-2].Content)
+	assert.Equal(t, "recent-4", result[n-1].Content)
+
+	// The recent tool result should NOT be compacted
+	assert.NotContains(t, result[n-3].Content, "compacted",
+		"recent tool result should be preserved verbatim")
+}
+
+func TestCompactor_IdempotentOnAlreadyCompacted(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   200,
+		Threshold:      0.50,
+		PinRecentCount: 2,
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "hello"},
+		largeToolResult("big_tool", 2000),
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	// First compaction
+	result1 := c.Compact(msgs)
+	// Second compaction on already-compacted result
+	result2 := c.Compact(result1)
+
+	assert.Equal(t, len(result1), len(result2), "second compaction should be a no-op")
+	for i := range result1 {
+		assert.Equal(t, result1[i].Content, result2[i].Content)
+	}
+}
+
+func TestCompactor_FoldsOldestFirst(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   2000,
+		Threshold:      0.50,
+		PinRecentCount: 2,
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "step 1"},
+		largeToolResult("tool_oldest", 1000),
+		{Role: "assistant", Content: "step 2"},
+		largeToolResult("tool_middle", 1000),
+		{Role: "assistant", Content: "step 3"},
+		largeToolResult("tool_recent_ish", 1000),
+		// Recent 2:
+		{Role: "user", Content: "final"},
+		{Role: "assistant", Content: "done"},
+	}
+
+	result := c.Compact(msgs)
+
+	// The oldest tool result should be compacted first
+	for _, msg := range result {
+		if msg.ToolResult != nil && msg.ToolResult.Name == "tool_oldest" {
+			assert.Contains(t, msg.Content, "compacted",
+				"oldest tool result should be compacted first")
+		}
+	}
+}
+
+func TestCompactor_DisabledWhenBudgetZero(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens: 0, // disabled
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "hello"},
+		largeToolResult("big", 10000),
+		{Role: "assistant", Content: "done"},
+	}
+
+	result := c.Compact(msgs)
+	assert.Equal(t, len(msgs), len(result), "should not compact when budget is 0")
+}
+
+func TestCompactor_NilCompactorSafe(t *testing.T) {
+	var c *ContextCompactor
+	msgs := []types.Message{{Role: "user", Content: "hello"}}
+
+	// Should not panic
+	result := c.Compact(msgs)
+	assert.Equal(t, msgs, result)
+}
+
+func TestFoldToolResult(t *testing.T) {
+	content := fmt.Sprintf("package main\n\nfunc main() {\n%s\n}", strings.Repeat("\tfmt.Println(\"hello\")\n", 50))
+	msg := toolResultMsg("file_read", content)
+
+	folded := foldToolResult(&msg)
+	assert.Contains(t, folded, "file_read")
+	assert.Contains(t, folded, "compacted")
+	assert.Less(t, len(folded), len(content), "folded should be much shorter")
+}
+
+func TestFoldToolResult_MultimodalParts(t *testing.T) {
+	text1 := strings.Repeat("hello ", 100)
+	msg := types.Message{
+		Role: "tool",
+		ToolResult: &types.MessageToolResult{
+			ID:   "call-img",
+			Name: "screenshot",
+		},
+		Parts: []types.ContentPart{
+			{Type: "text", Text: &text1},
+			{Type: "image", Media: &types.MediaContent{Data: stringPtr(strings.Repeat("x", 500)), MIMEType: "image/png"}},
+		},
+	}
+
+	folded := foldToolResult(&msg)
+	assert.Contains(t, folded, "screenshot")
+	assert.Contains(t, folded, "2 parts")
+	assert.Contains(t, folded, compactedMarker)
+}
+
+func TestFoldToolResult_NoToolResultName(t *testing.T) {
+	msg := types.Message{
+		Role:    "tool",
+		Content: strings.Repeat("data ", 100),
+	}
+
+	folded := foldToolResult(&msg)
+	assert.Contains(t, folded, "tool:")
+	assert.Contains(t, folded, compactedMarker)
+}
+
+func TestFoldToolResult_ShortContent(t *testing.T) {
+	msg := toolResultMsg("short_tool", "brief result here")
+
+	folded := foldToolResult(&msg)
+	// Short content — no "..." truncation
+	assert.Contains(t, folded, "brief result here")
+	assert.NotContains(t, folded, "...")
+	assert.Contains(t, folded, compactedMarker)
+}
+
+func stringPtr(s string) *string { return &s }

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -61,6 +61,10 @@ type ProviderConfig struct {
 
 	// MessageLogConvID is the conversation ID for message log operations.
 	MessageLogConvID string
+
+	// Compactor folds stale tool results between rounds when token usage
+	// exceeds the configured threshold. Nil = disabled.
+	Compactor *ContextCompactor
 }
 
 // streamingRoundParams holds parameters for a streaming round execution.
@@ -392,6 +396,12 @@ func (tl *toolLoop) afterRound(
 	}
 
 	tl.toolChoice = toolChoiceAuto
+
+	// Compact stale tool results before next round's provider call.
+	// This modifies the in-memory slice only — the persisted log retains full history.
+	if tl.stage.config != nil && tl.stage.config.Compactor != nil {
+		tl.messages = tl.stage.config.Compactor.Compact(tl.messages)
+	}
 
 	if round == tl.maxRounds {
 		return true, tl.messages, fmt.Errorf("provider stage: max rounds (%d) exceeded", tl.maxRounds)


### PR DESCRIPTION
## Summary

- New `ContextCompactor` struct with deterministic, rule-based folding of stale tool results
- Called in `toolLoop.afterRound()` between rounds, before the next provider call
- Configurable via `ProviderConfig.Compactor` (nil = disabled)

## Problem

The provider-tool loop accumulates messages without any context budget enforcement. By round 10, stale tool results (file reads, search results) can consume 50k+ tokens — the provider rejects the request or squeezes the response into the remaining tokens.

## Design

When estimated token usage exceeds a configurable threshold (default 70% of budget), the compactor folds old tool results from oldest first:

- **Fold format**: `[tool_name: first_100_chars... — N bytes compacted]`
- **Preserved**: system messages, error results, recent messages (pinned window, default 4)
- **Idempotent**: already-compacted messages detected via marker string and skipped
- **Zero LLM calls**: purely deterministic string manipulation
- **View-only**: modifies the in-memory slice sent to the provider. The persisted log (via MessageLog #786) retains the full uncompacted history.

## Test plan

- [x] `TestCompactor_NoOpUnderThreshold` — no compaction when under budget
- [x] `TestCompactor_FoldsOldToolResults` — old results folded, recent preserved
- [x] `TestCompactor_PreservesSystemMessages` — system messages never compacted
- [x] `TestCompactor_PreservesErrors` — error results never compacted
- [x] `TestCompactor_PreservesRecentMessages` — pinned window untouched
- [x] `TestCompactor_IdempotentOnAlreadyCompacted` — second pass is no-op
- [x] `TestCompactor_FoldsOldestFirst` — oldest folded first
- [x] `TestCompactor_DisabledWhenBudgetZero` — no-op when budget is 0
- [x] `TestCompactor_NilCompactorSafe` — nil receiver safe
- [x] `TestFoldToolResult` — fold format correct
- [x] Full stage suite — zero regressions
- [x] ≥80% coverage on all changed files