### PR TITLE
feat: complete compactor — default-on, events, cost budget, MaxRounds 50

### DIFF
--- a/docs/src/content/docs/architecture/runtime-events.md
+++ b/docs/src/content/docs/architecture/runtime-events.md
@@ -139,6 +139,7 @@ Guardrail hooks in the provider stage emit `validation.passed` or `validation.fa
 
 - `context.built` - Message context assembled (includes token counts)
 - `context.token_budget_exceeded` - Token budget exceeded
+- `context.compacted` - Context compactor folded stale tool results during a tool loop round. Payload: `ContextCompactionData` with `Round`, `OriginalTokens`, `CompactedTokens`, `MessagesFolded`, `BudgetTokens`.
 - `state.loaded` - Conversation state loaded
 - `state.saved` - Conversation state saved
 

--- a/docs/src/content/docs/architecture/runtime-pipeline.md
+++ b/docs/src/content/docs/architecture/runtime-pipeline.md
@@ -192,10 +192,12 @@ assemblyStage := stage.NewPromptAssemblyStage(
 
 **Behavior**:
 - Calls the configured LLM provider
-- Handles multi-round tool execution loops
+- Handles multi-round tool execution loops (default: up to 50 rounds)
 - Supports both streaming and non-streaming modes
-- Enforces tool policies (blocklist, ToolChoice)
-- Tracks token usage and latency
+- Enforces tool policies (blocklist, ToolChoice, cost budget)
+- Context compactor folds stale tool results between rounds to prevent context overflow
+- Tools rejected by hooks twice are auto-excluded from subsequent rounds
+- Tracks token usage, latency, and cumulative cost
 
 **Configuration**:
 ```go
@@ -468,7 +470,7 @@ sequenceDiagram
 **Features**:
 - Automatic tool call detection
 - Parallel tool execution
-- Round limit enforcement (default: 10 rounds)
+- Round limit enforcement (default: 50 rounds)
 - Tool policy enforcement
 
 ## Configuration
@@ -493,7 +495,8 @@ pipeline := stage.NewPipelineBuilderWithConfig(config).
 | Setting | Default | Description |
 |---------|---------|-------------|
 | ChannelBufferSize | 16 | Buffer size for inter-stage channels |
-| ExecutionTimeout | 30s | Maximum pipeline execution time |
+| ExecutionTimeout | 0 (disabled) | Maximum pipeline execution time (wall-clock) |
+| IdleTimeout | 30s | Cancels pipeline after inactivity (resets on each provider call, tool execution, or streaming chunk) |
 | GracefulShutdownTimeout | 10s | Timeout for graceful shutdown |
 | PriorityQueue | false | Enable priority-based scheduling |
 | Metrics | false | Enable per-stage metrics collection |

--- a/docs/src/content/docs/architecture/runtime-tools-mcp.md
+++ b/docs/src/content/docs/architecture/runtime-tools-mcp.md
@@ -687,10 +687,13 @@ Enforces constraints on tool usage:
 
 ```go
 type ToolPolicy struct {
-    ToolChoice          string   // "auto" | "required" | "none"
-    MaxToolCallsPerTurn int      // Per LLM response
-    MaxTotalToolCalls   int      // Across entire conversation
-    Blocklist           []string // Prohibited tools
+    ToolChoice           string   // "auto" | "required" | "none"
+    MaxRounds            int      // Max tool execution rounds (default: 50)
+    MaxToolCallsPerTurn  int      // Per LLM response
+    MaxParallelToolCalls int      // Max concurrent tool executions (default: 10)
+    MaxCallsPerMinute    int      // Per-tool rate limit (0 = unlimited)
+    MaxCostUSD           float64  // Cost budget in USD (0 = unlimited)
+    Blocklist            []string // Prohibited tools
 }
 ```
 
@@ -702,7 +705,7 @@ graph TD
     CheckChoice["Check ToolChoice Policy"]
     CheckCount["Check MaxToolCallsPerTurn"]
     CheckBlocklist["Check Blocklist"]
-    CheckTotal["Check MaxTotalToolCalls"]
+    CheckCost["Check MaxCostUSD Budget"]
     Execute["Execute Tools"]
     Reject["Reject Tool Calls"]
 
@@ -711,14 +714,16 @@ graph TD
     CheckChoice -->|Denied| Reject
     CheckCount -->|Within Limit| CheckBlocklist
     CheckCount -->|Exceeded| Reject
-    CheckBlocklist -->|Allowed| CheckTotal
+    CheckBlocklist -->|Allowed| CheckCost
     CheckBlocklist -->|Blocked| Reject
-    CheckTotal -->|Within Limit| Execute
-    CheckTotal -->|Exceeded| Reject
+    CheckCost -->|Within Budget| Execute
+    CheckCost -->|Exceeded| Reject
 
     style Execute fill:#9f9
     style Reject fill:#f99
 ```
+
+**Auto-Exclusion**: Tools that are rejected by hooks twice within a single tool loop are automatically excluded from the provider's tool list in subsequent rounds. This prevents infinite loops where the LLM repeatedly invokes a rejected tool.
 
 ### Pending Tool Execution
 

--- a/docs/src/content/docs/runtime/how-to/configure-pipeline.md
+++ b/docs/src/content/docs/runtime/how-to/configure-pipeline.md
@@ -88,7 +88,7 @@ for elem := range output {
 ```go
 config := stage.DefaultPipelineConfig().
     WithChannelBufferSize(32).              // Inter-stage channel buffer
-    WithExecutionTimeout(30 * time.Second). // Per-request timeout
+    WithIdleTimeout(60 * time.Second).      // Cancel after 60s of inactivity (default: 30s)
     WithGracefulShutdownTimeout(10 * time.Second). // Shutdown grace period
     WithMetrics(true).                      // Enable per-stage metrics
     WithTracing(true)                       // Enable distributed tracing
@@ -494,12 +494,14 @@ func TestPipeline(t *testing.T) {
 
 **Problem**: Pipeline executions timing out.
 
-**Solution**: Increase execution timeout:
+**Solution**: Increase the idle timeout (resets on each activity — provider call, tool execution, streaming chunk):
 
 ```go
 config := stage.DefaultPipelineConfig().
-    WithExecutionTimeout(120 * time.Second)  // Increase from default 30s
+    WithIdleTimeout(120 * time.Second)  // Increase from default 30s
 ```
+
+For a hard wall-clock limit, use `WithExecutionTimeout` (disabled by default).
 
 ### Issue: Backpressure
 

--- a/docs/src/content/docs/runtime/reference/index.md
+++ b/docs/src/content/docs/runtime/reference/index.md
@@ -169,10 +169,12 @@ provider := openai.NewProvider("openai", "gpt-4o-mini", "", defaults, false)
 
 ```go
 policy := &pipeline.ToolPolicy{
-    ToolChoice:          "auto",     // "auto", "required", "none", or specific tool
-    MaxRounds:           5,          // Max tool execution rounds
-    MaxToolCallsPerTurn: 10,         // Max tools per LLM response
-    Blocklist:           []string{"dangerous_tool"},  // Blocked tools
+    ToolChoice:           "auto",     // "auto", "required", "none", or specific tool
+    MaxRounds:            5,          // Max tool execution rounds (default: 50)
+    MaxToolCallsPerTurn:  10,         // Max tools per LLM response
+    MaxParallelToolCalls: 5,          // Max concurrent tool executions (default: 10)
+    MaxCostUSD:           1.00,       // Stop after $1 spent (0 = unlimited)
+    Blocklist:            []string{"dangerous_tool"},  // Blocked tools
 }
 ```
 

--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -114,7 +114,8 @@ Executable pipeline of connected stages.
 ```go
 type PipelineConfig struct {
     ChannelBufferSize       int           // Default: 16
-    ExecutionTimeout        time.Duration // Default: 30s
+    ExecutionTimeout        time.Duration // Default: 0 (disabled)
+    IdleTimeout             time.Duration // Default: 30s (resets on activity)
     GracefulShutdownTimeout time.Duration // Default: 10s
     PriorityQueue           bool          // Enable priority scheduling
     Metrics                 bool          // Enable per-stage metrics
@@ -494,8 +495,9 @@ config := &stage.ProviderConfig{
 **Tool Policy**:
 ```go
 policy := &pipeline.ToolPolicy{
-    BlockedTools: []string{"dangerous_tool"},
-    ToolChoice:   "auto",  // "auto", "none", "required", or specific tool name
+    ToolChoice:  "auto",  // "auto", "none", "required", or specific tool name
+    MaxCostUSD:  1.00,    // Cost budget in USD (0 = unlimited)
+    Blocklist:   []string{"dangerous_tool"},
 }
 ```
 
@@ -790,12 +792,14 @@ Standard metadata keys used by built-in stages:
 
 ### Timeout Settings
 
-| Pipeline Type | Execution Timeout | Shutdown Timeout |
-|---------------|-------------------|------------------|
-| Simple chat | 30s | 5s |
-| Tool-heavy | 120s | 30s |
-| Voice (VAD) | 300s | 10s |
-| Voice (ASM) | 600s | 15s |
+The default timeout is an **idle timeout** (30s) that resets on each activity (provider call, tool execution, streaming chunk). The hard execution timeout is disabled by default.
+
+| Pipeline Type | Idle Timeout | Execution Timeout | Shutdown Timeout |
+|---------------|--------------|-------------------|------------------|
+| Simple chat | 30s (default) | 0 (disabled) | 5s |
+| Tool-heavy | 60s | 0 (disabled) | 30s |
+| Voice (VAD) | 300s | 0 (disabled) | 10s |
+| Voice (ASM) | 0 (disabled) | 0 (disabled) | 15s |
 
 ## Examples
 

--- a/docs/src/content/docs/runtime/reference/providers.md
+++ b/docs/src/content/docs/runtime/reference/providers.md
@@ -77,6 +77,18 @@ type MultimodalSupport interface {
 }
 ```
 
+### ContextWindowProvider (Optional)
+
+Providers that can report their context window size implement `ContextWindowProvider`. Used by the context compactor to auto-detect token budgets:
+
+```go
+type ContextWindowProvider interface {
+    MaxContextTokens() int
+}
+```
+
+When a provider does not implement this interface, the compactor falls back to a default of 128,000 tokens.
+
 **MultimodalCapabilities**:
 
 ```go

--- a/docs/src/content/docs/runtime/reference/statestore.md
+++ b/docs/src/content/docs/runtime/reference/statestore.md
@@ -74,6 +74,20 @@ type MessageAppender interface {
 
 Used by `IncrementalSaveStage` to append only new messages after each turn.
 
+### MessageLog
+
+Enables per-round write-through persistence during tool loops. Messages are appended after each LLM round, ensuring durability even if the pipeline is interrupted mid-loop:
+
+```go
+type MessageLog interface {
+    LogAppend(ctx context.Context, id string, startSeq int, messages []types.Message) (int, error)
+    LogLoad(ctx context.Context, id string, recent int) ([]types.Message, error)
+    LogLen(ctx context.Context, id string) (int, error)
+}
+```
+
+`LogAppend` uses sequence-based idempotent append: if `startSeq` is behind the current length, already-persisted messages are skipped. Used via `sdk.WithMessageLog()`.
+
 ### SummaryAccessor
 
 Enables reading and writing summaries independently of the full conversation state:

--- a/docs/src/content/docs/runtime/reference/tools-mcp.md
+++ b/docs/src/content/docs/runtime/reference/tools-mcp.md
@@ -329,19 +329,25 @@ if err != nil {
 
 ```go
 type ToolPolicy struct {
-    ToolChoice          string   // "auto", "required", "none", or specific tool
-    MaxRounds           int      // Max tool execution rounds
-    MaxToolCallsPerTurn int      // Max tools per LLM response
-    Blocklist           []string // Blocked tool names
+    ToolChoice           string   // "auto", "required", "none", or specific tool
+    MaxRounds            int      // Max tool execution rounds (default: 50)
+    MaxToolCallsPerTurn  int      // Max tools per LLM response
+    MaxParallelToolCalls int      // Max concurrent tool executions (default: 10)
+    MaxCallsPerMinute    int      // Per-tool rate limit (0 = unlimited)
+    MaxCostUSD           float64  // Cost budget in USD (0 = unlimited)
+    Blocklist            []string // Blocked tool names
 }
 
 policy := &pipeline.ToolPolicy{
     ToolChoice:          "auto",
     MaxRounds:           5,
     MaxToolCallsPerTurn: 10,
+    MaxCostUSD:          1.00, // Stop after $1 spent
     Blocklist:           []string{"dangerous_tool"},
 }
 ```
+
+Tools that are repeatedly rejected by hooks (2+ rejections) are automatically excluded from subsequent rounds to prevent infinite loops.
 
 ## Model Context Protocol (MCP)
 

--- a/docs/src/content/docs/sdk/explanation/observability.md
+++ b/docs/src/content/docs/sdk/explanation/observability.md
@@ -13,7 +13,7 @@ The system is built around an **EventBus** that supports pluggable persistence (
 
 ## Event Types
 
-Events are defined as `events.EventType` in the `runtime/events` package. There are 33 event types across 10 categories:
+Events are defined as `events.EventType` in the `runtime/events` package. There are 34 event types across 10 categories:
 
 ### Pipeline Events
 
@@ -68,6 +68,7 @@ EventValidationFailed  EventType = "validation.failed"
 ```go
 EventContextBuilt          EventType = "context.built"
 EventTokenBudgetExceeded   EventType = "context.token_budget_exceeded"
+EventContextCompacted      EventType = "context.compacted"
 EventStateLoaded           EventType = "state.loaded"
 EventStateSaved            EventType = "state.saved"
 ```

--- a/docs/src/content/docs/sdk/how-to/manage-context.md
+++ b/docs/src/content/docs/sdk/how-to/manage-context.md
@@ -141,6 +141,26 @@ conv, _ := sdk.Open("./app.pack.json", "chat",
 )
 ```
 
+## Context Compaction (Tool Loops)
+
+During multi-round tool execution, tool results accumulate and can exhaust the context window. The **context compactor** runs automatically between rounds and folds stale tool results into compact summaries (e.g., `[file_read: package main... — 12000 bytes compacted]`).
+
+Compaction is **on by default**. It:
+- Triggers when estimated context exceeds 70% of the token budget
+- Folds oldest tool results first, preserving the most recent 4 messages
+- Never modifies error results, system messages, or non-tool messages
+- Emits a `context.compacted` event with token count details
+
+The token budget is auto-detected from the provider if it implements `ContextWindowProvider`, otherwise defaults to 128K tokens.
+
+To disable compaction:
+
+```go
+conv, _ := sdk.Open("./app.pack.json", "chat",
+    sdk.WithCompaction(false),
+)
+```
+
 ## Embedding Providers
 
 ### OpenAI

--- a/docs/src/content/docs/sdk/how-to/monitor-events.md
+++ b/docs/src/content/docs/sdk/how-to/monitor-events.md
@@ -56,6 +56,7 @@ EventValidationFailed  EventType = "validation.failed"
 // Context & state
 EventContextBuilt          EventType = "context.built"
 EventTokenBudgetExceeded   EventType = "context.token_budget_exceeded"
+EventContextCompacted      EventType = "context.compacted"
 EventStateLoaded           EventType = "state.loaded"
 EventStateSaved            EventType = "state.saved"
 

--- a/docs/src/content/docs/sdk/reference/index.md
+++ b/docs/src/content/docs/sdk/reference/index.md
@@ -164,6 +164,25 @@ sdk.WithRecording(&sdk.RecordingConfig{
 Without `WithRecording`, the emitter's `MessageCreated` events strip binary data from content parts (keeping only metadata like MIMEType, SizeKB, dimensions). RecordingStages bypass the emitter and publish full binary data directly to the EventBus.
 :::
 
+### WithCompaction
+
+Control context compaction in tool loops. Compaction is **on by default** — the context compactor folds stale tool results between rounds to prevent context overflow. Pass `false` to disable.
+
+```go
+// Disable compaction (default: enabled)
+sdk.WithCompaction(false)
+```
+
+### WithMessageLog
+
+Enable per-round write-through persistence during tool loops. When set, messages are appended to the log after each LLM round for durability:
+
+```go
+sdk.WithMessageLog(myMessageLog)
+```
+
+The `MessageLog` interface is defined in `runtime/statestore`. `MemoryStore` implements it out of the box.
+
 ## Conversation Type
 
 ### Send

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -512,3 +512,15 @@ func (e *Emitter) WorkflowCompleted(finalState string, transitionCount int) {
 		TransitionCount: transitionCount,
 	})
 }
+
+// ContextCompacted emits the context.compacted event when the compactor
+// folds stale tool results between tool-loop rounds.
+func (e *Emitter) ContextCompacted(round, originalTokens, compactedTokens, messagesFolded, budgetTokens int) {
+	e.emit(EventContextCompacted, &ContextCompactionData{
+		Round:           round,
+		OriginalTokens:  originalTokens,
+		CompactedTokens: compactedTokens,
+		MessagesFolded:  messagesFolded,
+		BudgetTokens:    budgetTokens,
+	})
+}

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -105,6 +105,9 @@ const (
 	EventClientToolRequest EventType = "tool.client.request"
 	// EventClientToolResolved marks a client-mode tool that has been resolved by the caller.
 	EventClientToolResolved EventType = "tool.client.resolved"
+
+	// EventContextCompacted marks context compaction between tool-loop rounds.
+	EventContextCompacted EventType = "context.compacted"
 )
 
 // EventData is a marker interface for event payloads.
@@ -632,4 +635,14 @@ type WorkflowCompletedData struct {
 	FinalState string `json:"final_state"`
 	// TransitionCount is the total number of transitions that occurred.
 	TransitionCount int `json:"transition_count"`
+}
+
+// ContextCompactionData contains data for context compaction events.
+type ContextCompactionData struct {
+	baseEventData
+	Round           int `json:"round"`
+	OriginalTokens  int `json:"original_tokens"`
+	CompactedTokens int `json:"compacted_tokens"`
+	MessagesFolded  int `json:"messages_folded"`
+	BudgetTokens    int `json:"budget_tokens"`
 }

--- a/runtime/pipeline/stage/compactor.go
+++ b/runtime/pipeline/stage/compactor.go
@@ -92,8 +92,16 @@ func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int
 		}
 
 		beforeTokens := tokenizer.CountMessageTokensDefault([]types.Message{*msg})
-		msg.Content = foldToolResult(msg)
+		folded := foldToolResult(msg)
+		msg.Content = folded
 		msg.Parts = nil // clear multimodal parts
+		// Update ToolResult.Parts so GetContent() (which reads from ToolResult
+		// for tool messages) returns the folded content for token counting.
+		if msg.ToolResult != nil {
+			msg.ToolResult.Parts = []types.ContentPart{
+				{Type: types.ContentTypeText, Text: &folded},
+			}
+		}
 		afterTokens := tokenizer.CountMessageTokensDefault([]types.Message{*msg})
 
 		totalTokens -= beforeTokens - afterTokens
@@ -124,8 +132,10 @@ func isCompactable(msg *types.Message) bool {
 	if msg.ToolResult != nil && msg.ToolResult.Error != "" {
 		return false
 	}
-	// Already compacted or too small to bother — skip
-	if len(msg.Content) < 50 || strings.Contains(msg.Content, compactedMarker) {
+	// Already compacted or too small to bother — skip.
+	// Use GetContent() which reads from ToolResult.Parts for tool messages.
+	content := msg.GetContent()
+	if len(content) < 50 || strings.Contains(content, compactedMarker) {
 		return false
 	}
 	return true
@@ -157,7 +167,7 @@ func foldToolResult(msg *types.Message) string {
 	}
 
 	// Text-only: preview + size
-	content := msg.Content
+	content := msg.GetContent()
 	originalBytes := len(content)
 
 	preview := content

--- a/runtime/pipeline/stage/compactor.go
+++ b/runtime/pipeline/stage/compactor.go
@@ -10,12 +10,22 @@ import (
 )
 
 const (
-	defaultCompactThreshold  = 0.70
-	defaultPinRecentCount    = 4
+	defaultCompactThreshold = 0.70
+	defaultPinRecentCount   = 4
+	// DefaultBudgetTokens is the default context window budget for compaction.
+	DefaultBudgetTokens      = 128000 // sensible default for modern models
 	compactedPreviewMaxBytes = 100
 	compactedMarker          = "compacted"
 	roleTool                 = "tool"
 )
+
+// CompactResult contains the output of a compaction pass.
+type CompactResult struct {
+	Messages        []types.Message
+	OriginalTokens  int
+	CompactedTokens int
+	MessagesFolded  int
+}
 
 // ContextCompactor folds stale tool results between rounds to keep context
 // bounded. Deterministic, zero LLM calls. Only modifies the in-memory message
@@ -35,11 +45,13 @@ type ContextCompactor struct {
 }
 
 // Compact folds stale tool results to reduce token usage.
-// Returns the original messages unchanged if no compaction is needed.
+// lastInputTokens is the actual token count from the provider's CostInfo.InputTokens.
+// When > 0, used instead of heuristic counting (more accurate). Pass 0 for heuristic only.
 // Safe to call on a nil receiver (returns messages unchanged).
-func (c *ContextCompactor) Compact(messages []types.Message) []types.Message {
+func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int) CompactResult {
+	noOp := CompactResult{Messages: messages}
 	if c == nil || c.BudgetTokens <= 0 || len(messages) == 0 {
-		return messages
+		return noOp
 	}
 
 	threshold := c.Threshold
@@ -52,16 +64,16 @@ func (c *ContextCompactor) Compact(messages []types.Message) []types.Message {
 	}
 
 	budget := int(float64(c.BudgetTokens) * threshold)
-	originalTokens := tokenizer.CountMessageTokensDefault(messages)
+
+	// Use actual token count from provider if available (more accurate)
+	originalTokens := lastInputTokens
+	if originalTokens <= 0 {
+		originalTokens = tokenizer.CountMessageTokensDefault(messages)
+	}
 	if originalTokens <= budget {
-		return messages
+		return noOp
 	}
 
-	// Identify which messages can be compacted:
-	// - Must be a tool result (Role == "tool")
-	// - Must NOT be in the pinned window (last pinCount messages)
-	// - Must NOT be an error result
-	// - Must NOT already be compacted (contains marker)
 	pinBoundary := len(messages) - pinCount
 	if pinBoundary < 0 {
 		pinBoundary = 0
@@ -71,6 +83,7 @@ func (c *ContextCompactor) Compact(messages []types.Message) []types.Message {
 	copy(compacted, messages)
 
 	totalTokens := originalTokens
+	messagesFolded := 0
 	for i := 0; i < pinBoundary && totalTokens > budget; i++ {
 		msg := &compacted[i]
 
@@ -84,16 +97,23 @@ func (c *ContextCompactor) Compact(messages []types.Message) []types.Message {
 		afterTokens := tokenizer.CountMessageTokensDefault([]types.Message{*msg})
 
 		totalTokens -= beforeTokens - afterTokens
+		messagesFolded++
 	}
 
-	if totalTokens < originalTokens {
+	if messagesFolded > 0 {
 		logger.Debug("Context compacted",
 			"original_tokens", originalTokens,
 			"compacted_tokens", totalTokens,
+			"messages_folded", messagesFolded,
 			"budget", budget)
 	}
 
-	return compacted
+	return CompactResult{
+		Messages:        compacted,
+		OriginalTokens:  originalTokens,
+		CompactedTokens: totalTokens,
+		MessagesFolded:  messagesFolded,
+	}
 }
 
 // isCompactable returns true if a message can be folded.

--- a/runtime/pipeline/stage/compactor_test.go
+++ b/runtime/pipeline/stage/compactor_test.go
@@ -45,9 +45,9 @@ func TestCompactor_NoOpUnderThreshold(t *testing.T) {
 		{Role: "assistant", Content: "I'm good"},
 	}
 
-	result := c.Compact(msgs)
-	assert.Equal(t, len(msgs), len(result), "should not compact when under threshold")
-	assert.Equal(t, msgs[0].Content, result[0].Content)
+	result := c.Compact(msgs, 0)
+	assert.Equal(t, len(msgs), len(result.Messages), "should not compact when under threshold")
+	assert.Equal(t, msgs[0].Content, result.Messages[0].Content)
 }
 
 func TestCompactor_FoldsOldToolResults(t *testing.T) {
@@ -71,15 +71,15 @@ func TestCompactor_FoldsOldToolResults(t *testing.T) {
 		{Role: "assistant", Content: "running tests now"},
 	}
 
-	result := c.Compact(msgs)
+	result := c.Compact(msgs, 0)
 
 	// Recent 4 messages should be preserved verbatim
-	assert.Equal(t, "Let me edit the file", result[len(result)-4].Content)
-	assert.Equal(t, "run tests", result[len(result)-2].Content)
+	assert.Equal(t, "Let me edit the file", result.Messages[len(result.Messages)-4].Content)
+	assert.Equal(t, "run tests", result.Messages[len(result.Messages)-2].Content)
 
 	// Old large tool results should be folded (contain "compacted")
 	foundCompacted := false
-	for _, msg := range result {
+	for _, msg := range result.Messages {
 		if msg.Role == "tool" && strings.Contains(msg.Content, "compacted") {
 			foundCompacted = true
 			break
@@ -102,11 +102,11 @@ func TestCompactor_PreservesSystemMessages(t *testing.T) {
 		{Role: "assistant", Content: "done"},
 	}
 
-	result := c.Compact(msgs)
+	result := c.Compact(msgs, 0)
 
 	// System message must be preserved regardless of size
-	assert.Equal(t, "system", result[0].Role)
-	assert.Contains(t, result[0].Content, "system prompt")
+	assert.Equal(t, "system", result.Messages[0].Role)
+	assert.Contains(t, result.Messages[0].Content, "system prompt")
 }
 
 func TestCompactor_PreservesErrors(t *testing.T) {
@@ -123,10 +123,10 @@ func TestCompactor_PreservesErrors(t *testing.T) {
 		{Role: "user", Content: "try again"},
 	}
 
-	result := c.Compact(msgs)
+	result := c.Compact(msgs, 0)
 
 	// Error tool result must be preserved verbatim
-	for _, msg := range result {
+	for _, msg := range result.Messages {
 		if msg.ToolResult != nil && msg.ToolResult.Error != "" {
 			assert.Contains(t, msg.Content, "error details",
 				"error tool results should not be compacted")
@@ -151,17 +151,17 @@ func TestCompactor_PreservesRecentMessages(t *testing.T) {
 		{Role: "assistant", Content: "recent-4"},
 	}
 
-	result := c.Compact(msgs)
+	result := c.Compact(msgs, 0)
 
 	// Last 4 messages must be untouched
-	n := len(result)
+	n := len(result.Messages)
 	require.GreaterOrEqual(t, n, 4)
-	assert.Equal(t, "recent-1", result[n-4].Content)
-	assert.Equal(t, "recent-3", result[n-2].Content)
-	assert.Equal(t, "recent-4", result[n-1].Content)
+	assert.Equal(t, "recent-1", result.Messages[n-4].Content)
+	assert.Equal(t, "recent-3", result.Messages[n-2].Content)
+	assert.Equal(t, "recent-4", result.Messages[n-1].Content)
 
 	// The recent tool result should NOT be compacted
-	assert.NotContains(t, result[n-3].Content, "compacted",
+	assert.NotContains(t, result.Messages[n-3].Content, "compacted",
 		"recent tool result should be preserved verbatim")
 }
 
@@ -180,13 +180,13 @@ func TestCompactor_IdempotentOnAlreadyCompacted(t *testing.T) {
 	}
 
 	// First compaction
-	result1 := c.Compact(msgs)
+	result1 := c.Compact(msgs, 0)
 	// Second compaction on already-compacted result
-	result2 := c.Compact(result1)
+	result2 := c.Compact(result1.Messages, 0)
 
-	assert.Equal(t, len(result1), len(result2), "second compaction should be a no-op")
-	for i := range result1 {
-		assert.Equal(t, result1[i].Content, result2[i].Content)
+	assert.Equal(t, len(result1.Messages), len(result2.Messages), "second compaction should be a no-op")
+	for i := range result1.Messages {
+		assert.Equal(t, result1.Messages[i].Content, result2.Messages[i].Content)
 	}
 }
 
@@ -209,10 +209,10 @@ func TestCompactor_FoldsOldestFirst(t *testing.T) {
 		{Role: "assistant", Content: "done"},
 	}
 
-	result := c.Compact(msgs)
+	result := c.Compact(msgs, 0)
 
 	// The oldest tool result should be compacted first
-	for _, msg := range result {
+	for _, msg := range result.Messages {
 		if msg.ToolResult != nil && msg.ToolResult.Name == "tool_oldest" {
 			assert.Contains(t, msg.Content, "compacted",
 				"oldest tool result should be compacted first")
@@ -231,8 +231,8 @@ func TestCompactor_DisabledWhenBudgetZero(t *testing.T) {
 		{Role: "assistant", Content: "done"},
 	}
 
-	result := c.Compact(msgs)
-	assert.Equal(t, len(msgs), len(result), "should not compact when budget is 0")
+	result := c.Compact(msgs, 0)
+	assert.Equal(t, len(msgs), len(result.Messages), "should not compact when budget is 0")
 }
 
 func TestCompactor_NilCompactorSafe(t *testing.T) {
@@ -240,8 +240,8 @@ func TestCompactor_NilCompactorSafe(t *testing.T) {
 	msgs := []types.Message{{Role: "user", Content: "hello"}}
 
 	// Should not panic
-	result := c.Compact(msgs)
-	assert.Equal(t, msgs, result)
+	result := c.Compact(msgs, 0)
+	assert.Equal(t, msgs, result.Messages)
 }
 
 func TestFoldToolResult(t *testing.T) {

--- a/runtime/pipeline/stage/compactor_test.go
+++ b/runtime/pipeline/stage/compactor_test.go
@@ -295,4 +295,86 @@ func TestFoldToolResult_ShortContent(t *testing.T) {
 	assert.Contains(t, folded, compactedMarker)
 }
 
+func TestCompactor_LastInputTokensTriggersCompaction(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   10000,
+		Threshold:      0.70,
+		PinRecentCount: 2,
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "hello"},
+		largeToolResult("file_read", 500),
+		{Role: "assistant", Content: "got it"},
+		{Role: "user", Content: "next"},
+	}
+
+	// With heuristic counting, these messages are well under budget (10000 * 0.7 = 7000).
+	result := c.Compact(msgs, 0)
+	assert.Zero(t, result.MessagesFolded, "heuristic should not trigger compaction")
+
+	// Pretend the provider reported 8000 input tokens (above 7000 threshold).
+	// This should trigger compaction even though heuristic says we're fine.
+	result = c.Compact(msgs, 8000)
+	assert.Greater(t, result.MessagesFolded, 0, "lastInputTokens above threshold should trigger compaction")
+}
+
+func TestCompactor_LastInputTokensBelowThresholdSkips(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   10000,
+		Threshold:      0.70,
+		PinRecentCount: 2,
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "hello"},
+		largeToolResult("file_read", 500),
+		{Role: "assistant", Content: "got it"},
+		{Role: "user", Content: "next"},
+	}
+
+	// Provider says 5000 tokens — under 7000 threshold.
+	result := c.Compact(msgs, 5000)
+	assert.Zero(t, result.MessagesFolded, "lastInputTokens below threshold should skip compaction")
+}
+
+func TestCompactor_CompactResultMetadata(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens:   500,
+		Threshold:      0.70,
+		PinRecentCount: 2,
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		largeToolResult("big_tool", 2000),
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	result := c.Compact(msgs, 0)
+	assert.Greater(t, result.MessagesFolded, 0, "should fold at least one message")
+	assert.Greater(t, result.OriginalTokens, 0, "OriginalTokens should be positive")
+	assert.Greater(t, result.CompactedTokens, 0, "CompactedTokens should be positive")
+	assert.Less(t, result.CompactedTokens, result.OriginalTokens,
+		"CompactedTokens should be less than OriginalTokens after folding")
+}
+
+func TestCompactor_NoOpResultMetadata(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokens: 10000,
+		Threshold:    0.70,
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi"},
+	}
+
+	result := c.Compact(msgs, 0)
+	assert.Zero(t, result.MessagesFolded)
+	assert.Zero(t, result.OriginalTokens, "no-op should not compute tokens")
+	assert.Zero(t, result.CompactedTokens)
+}
+
 func stringPtr(s string) *string { return &s }

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -410,13 +410,11 @@ func (tl *toolLoop) afterRound(
 	tl.toolChoice = toolChoiceAuto
 
 	// Compact stale tool results before next round's provider call.
-	// Uses actual token count from the last provider response when available.
+	// Pass 0 for lastInputTokens: the provider's InputTokens reflects what it
+	// saw on the last call, but we've since appended the assistant response and
+	// tool results — using the stale count would under-compact.
 	if tl.stage.config != nil && tl.stage.config.Compactor != nil {
-		lastInputTokens := 0
-		if response.CostInfo != nil {
-			lastInputTokens = response.CostInfo.InputTokens
-		}
-		cr := tl.stage.config.Compactor.Compact(tl.messages, lastInputTokens)
+		cr := tl.stage.config.Compactor.Compact(tl.messages, 0)
 		tl.messages = cr.Messages
 		if cr.MessagesFolded > 0 && tl.stage.emitter != nil {
 			tl.stage.emitter.ContextCompacted(round, cr.OriginalTokens, cr.CompactedTokens,

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultMaxRounds            = 10
+	defaultMaxRounds            = 50
 	defaultMaxParallelToolCalls = 10
 	toolChoiceAuto              = "auto"
 )
@@ -335,7 +335,8 @@ type toolLoop struct {
 	maxRounds        int
 	excluded         map[string]bool
 	rejectionCounts  map[string]int
-	lastPersistedSeq int // messages persisted so far via MessageLog
+	lastPersistedSeq int     // messages persisted so far via MessageLog
+	cumulativeCost   float64 // accumulated cost across rounds
 }
 
 func (s *ProviderStage) newToolLoop(acc *providerInput) (*toolLoop, error) {
@@ -368,6 +369,17 @@ func (tl *toolLoop) afterRound(
 ) (bool, []types.Message, error) {
 	tl.messages = append(tl.messages, *response)
 
+	// Track cumulative cost for budget enforcement
+	if response.CostInfo != nil {
+		tl.cumulativeCost += response.CostInfo.TotalCost
+	}
+	policy := tl.stage.toolPolicy
+	if policy != nil && policy.MaxCostUSD > 0 && tl.cumulativeCost > policy.MaxCostUSD {
+		tl.persistMessages(ctx, round)
+		return true, tl.messages, fmt.Errorf(
+			"provider stage: cost budget exceeded (%.4f > %.4f USD)", tl.cumulativeCost, policy.MaxCostUSD)
+	}
+
 	if !hasToolCalls {
 		tl.persistMessages(ctx, round)
 		return true, tl.messages, nil
@@ -398,9 +410,18 @@ func (tl *toolLoop) afterRound(
 	tl.toolChoice = toolChoiceAuto
 
 	// Compact stale tool results before next round's provider call.
-	// This modifies the in-memory slice only — the persisted log retains full history.
+	// Uses actual token count from the last provider response when available.
 	if tl.stage.config != nil && tl.stage.config.Compactor != nil {
-		tl.messages = tl.stage.config.Compactor.Compact(tl.messages)
+		lastInputTokens := 0
+		if response.CostInfo != nil {
+			lastInputTokens = response.CostInfo.InputTokens
+		}
+		cr := tl.stage.config.Compactor.Compact(tl.messages, lastInputTokens)
+		tl.messages = cr.Messages
+		if cr.MessagesFolded > 0 && tl.stage.emitter != nil {
+			tl.stage.emitter.ContextCompacted(round, cr.OriginalTokens, cr.CompactedTokens,
+				cr.MessagesFolded, tl.stage.config.Compactor.BudgetTokens)
+		}
 	}
 
 	if round == tl.maxRounds {

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -751,7 +751,7 @@ func TestProviderStage_GetMaxRounds(t *testing.T) {
 
 	t.Run("returns default when no policy", func(t *testing.T) {
 		stage := NewProviderStage(provider, nil, nil, nil)
-		assert.Equal(t, 10, stage.getMaxRounds()) // defaultMaxRounds
+		assert.Equal(t, 50, stage.getMaxRounds()) // defaultMaxRounds
 	})
 
 	t.Run("returns policy value when set", func(t *testing.T) {
@@ -761,7 +761,7 @@ func TestProviderStage_GetMaxRounds(t *testing.T) {
 
 	t.Run("returns default when policy MaxRounds is zero", func(t *testing.T) {
 		stage := NewProviderStage(provider, nil, &pipeline.ToolPolicy{MaxRounds: 0}, nil)
-		assert.Equal(t, 10, stage.getMaxRounds())
+		assert.Equal(t, 50, stage.getMaxRounds())
 	})
 }
 

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -2764,3 +2764,148 @@ func TestAfterRound_ExcludesAfterRepeatedRejection(t *testing.T) {
 	assert.False(t, done)
 	assert.True(t, loop.excluded["blocked_tool"], "second rejection should exclude")
 }
+
+func TestAfterRound_CostBudgetExceeded(t *testing.T) {
+	provider := mock.NewToolProvider("test", "model", false, nil)
+	registry := tools.NewRegistry()
+	err := registry.Register(&tools.ToolDescriptor{
+		Name:        "test_tool",
+		Description: "test",
+		InputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:        "mock",
+	})
+	require.NoError(t, err)
+
+	stage := NewProviderStage(provider, registry,
+		&pipeline.ToolPolicy{MaxCostUSD: 0.10},
+		&ProviderConfig{},
+	)
+
+	acc := &providerInput{
+		allowedTools: []string{"test_tool"},
+		messages:     []types.Message{{Role: "user", Content: "hi"}},
+	}
+	loop, err := stage.newToolLoop(acc)
+	require.NoError(t, err)
+
+	// Round 1: cost under budget
+	response1 := types.Message{
+		Role:     "assistant",
+		CostInfo: &types.CostInfo{TotalCost: 0.05},
+		ToolCalls: []types.MessageToolCall{
+			{ID: "c1", Name: "test_tool", Args: json.RawMessage(`{}`)},
+		},
+	}
+	done, _, err := loop.afterRound(context.Background(), []string{"test_tool"}, &response1, true, 1)
+	assert.False(t, done, "should continue when under budget")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.05, loop.cumulativeCost, 0.001)
+
+	// Round 2: cost exceeds budget (0.05 + 0.06 = 0.11 > 0.10)
+	response2 := types.Message{
+		Role:     "assistant",
+		CostInfo: &types.CostInfo{TotalCost: 0.06},
+		ToolCalls: []types.MessageToolCall{
+			{ID: "c2", Name: "test_tool", Args: json.RawMessage(`{}`)},
+		},
+	}
+	done, msgs, err := loop.afterRound(context.Background(), []string{"test_tool"}, &response2, true, 2)
+	assert.True(t, done, "should stop when cost budget exceeded")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cost budget exceeded")
+	assert.Contains(t, err.Error(), "0.1100")
+	assert.Contains(t, err.Error(), "0.1000")
+	assert.NotEmpty(t, msgs, "should return messages even on budget exceeded")
+}
+
+func TestAfterRound_CostBudgetZeroIsUnlimited(t *testing.T) {
+	provider := mock.NewProvider("test", "model", false)
+	stage := NewProviderStage(provider, nil,
+		&pipeline.ToolPolicy{MaxCostUSD: 0}, // zero = unlimited
+		&ProviderConfig{},
+	)
+
+	acc := &providerInput{
+		messages: []types.Message{{Role: "user", Content: "hi"}},
+	}
+	loop, err := stage.newToolLoop(acc)
+	require.NoError(t, err)
+
+	// Even with high cost, should not terminate
+	response := types.Message{
+		Role:     "assistant",
+		Content:  "done",
+		CostInfo: &types.CostInfo{TotalCost: 999.99},
+	}
+	done, _, err := loop.afterRound(context.Background(), nil, &response, false, 1)
+	assert.True(t, done, "done because no tool calls")
+	require.NoError(t, err, "should not error — zero MaxCostUSD means unlimited")
+}
+
+func TestAfterRound_CompactionEmitsEvent(t *testing.T) {
+	provider := mock.NewToolProvider("test", "model", false, nil)
+	registry := tools.NewRegistry()
+	err := registry.Register(&tools.ToolDescriptor{
+		Name:        "test_tool",
+		Description: "test",
+		InputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:        "mock",
+	})
+	require.NoError(t, err)
+
+	bus := events.NewEventBus()
+	defer bus.Close()
+	emitter := events.NewEmitter(bus, "test-run", "test-session", "test-conv")
+
+	stg := NewProviderStageWithHooks(provider, registry, nil, &ProviderConfig{
+		Compactor: &ContextCompactor{
+			BudgetTokens:   100, // very low to force compaction
+			Threshold:      0.50,
+			PinRecentCount: 2,
+		},
+	}, emitter, nil)
+
+	// Build messages with a large tool result that will be compacted
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		largeToolResult("file_read", 2000),
+		{Role: "assistant", Content: "got the file"},
+	}
+	acc := &providerInput{
+		allowedTools: []string{"test_tool"},
+		messages:     msgs,
+	}
+	loop, err := stg.newToolLoop(acc)
+	require.NoError(t, err)
+
+	// Subscribe before the event
+	var receivedEvent *events.Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(events.EventContextCompacted, func(e *events.Event) {
+		receivedEvent = e
+		wg.Done()
+	})
+
+	// afterRound with tool calls triggers compaction
+	response := types.Message{
+		Role: "assistant",
+		ToolCalls: []types.MessageToolCall{
+			{ID: "c1", Name: "test_tool", Args: json.RawMessage(`{}`)},
+		},
+	}
+	done, _, err := loop.afterRound(context.Background(), []string{"test_tool"}, &response, true, 1)
+	assert.False(t, done)
+	require.NoError(t, err)
+
+	// Wait for event delivery
+	wg.Wait()
+	require.NotNil(t, receivedEvent, "should have received context.compacted event")
+	assert.Equal(t, events.EventContextCompacted, receivedEvent.Type)
+	data, ok := receivedEvent.Data.(*events.ContextCompactionData)
+	require.True(t, ok, "event data should be *ContextCompactionData")
+	assert.Equal(t, 1, data.Round)
+	assert.Greater(t, data.MessagesFolded, 0)
+	assert.Greater(t, data.OriginalTokens, data.CompactedTokens)
+	assert.Equal(t, 100, data.BudgetTokens)
+}

--- a/runtime/pipeline/types.go
+++ b/runtime/pipeline/types.go
@@ -18,6 +18,7 @@ type ToolPolicy struct {
 	MaxToolCallsPerTurn  int      `json:"max_tool_calls_per_turn,omitempty"`
 	MaxParallelToolCalls int      `json:"max_parallel_tool_calls,omitempty"` // Max concurrent tool executions (default 10)
 	MaxCallsPerMinute    int      `json:"max_calls_per_minute,omitempty"`    // Per-tool calls/minute (0=unlimited)
+	MaxCostUSD           float64  `json:"max_cost_usd,omitempty"`            // Cost budget in USD (0=unlimited)
 	Blocklist            []string `json:"blocklist,omitempty"`
 }
 

--- a/runtime/providers/provider.go
+++ b/runtime/providers/provider.go
@@ -103,6 +103,12 @@ type Provider interface {
 	CalculateCost(inputTokens, outputTokens, cachedTokens int) types.CostInfo
 }
 
+// ContextWindowProvider is an optional interface for providers that can report
+// their context window size. Used to auto-configure the compactor budget.
+type ContextWindowProvider interface {
+	MaxContextTokens() int
+}
+
 // ToolDescriptor represents a tool that can be used by providers
 type ToolDescriptor struct {
 	Name         string          `json:"name"`

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -420,6 +420,7 @@ func (c *Conversation) buildPipelineConfig(
 		HookRegistry:          c.hookRegistry,
 		ExecutionTimeout:      c.config.executionTimeout,
 		MessageLog:            c.config.messageLog,
+		CompactionEnabled:     c.config.compactionEnabled,
 	}
 
 	// Wire recording config if enabled

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -359,7 +359,9 @@ func buildProviderStages(cfg *Config) ([]stage.Stage, error) {
 		if cfg.CompactionEnabled == nil || *cfg.CompactionEnabled {
 			budgetTokens := stage.DefaultBudgetTokens
 			if cwp, ok := cfg.Provider.(providers.ContextWindowProvider); ok {
-				budgetTokens = cwp.MaxContextTokens()
+				if v := cwp.MaxContextTokens(); v > 0 {
+					budgetTokens = v
+				}
 			}
 			providerConfig.Compactor = &stage.ContextCompactor{
 				BudgetTokens: budgetTokens,

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -73,6 +73,10 @@ type Config struct {
 	// save stage skips message append.
 	MessageLog statestore.MessageLog
 
+	// CompactionEnabled controls context compaction in tool loops.
+	// nil = default (enabled), false = disabled.
+	CompactionEnabled *bool
+
 	// ContextWindow is the hot window size for RAG context assembly.
 	// When > 0, ContextAssemblyStage + IncrementalSaveStage replace the
 	// standard StateStoreLoad/Save stages.
@@ -350,6 +354,16 @@ func buildProviderStages(cfg *Config) ([]stage.Stage, error) {
 			ResponseFormat:   cfg.ResponseFormat,
 			MessageLog:       cfg.MessageLog,
 			MessageLogConvID: cfg.ConversationID,
+		}
+		// Auto-configure compactor (default-on) unless explicitly disabled
+		if cfg.CompactionEnabled == nil || *cfg.CompactionEnabled {
+			budgetTokens := stage.DefaultBudgetTokens
+			if cwp, ok := cfg.Provider.(providers.ContextWindowProvider); ok {
+				budgetTokens = cwp.MaxContextTokens()
+			}
+			providerConfig.Compactor = &stage.ContextCompactor{
+				BudgetTokens: budgetTokens,
+			}
 		}
 		return []stage.Stage{stage.NewProviderStageWithHooks(
 			cfg.Provider,

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -207,6 +207,9 @@ type config struct {
 
 	// MessageLog for per-round write-through during tool loops
 	messageLog statestore.MessageLog
+
+	// Compaction control (nil = default enabled, false = disabled)
+	compactionEnabled *bool
 }
 
 // buildHookRegistry creates a hooks.Registry from the configured hooks.
@@ -815,6 +818,17 @@ func WithMetrics(collector *metrics.Collector, instanceLabels map[string]string)
 func WithLogger(l *slog.Logger) Option {
 	return func(c *config) error {
 		c.logger = l
+		return nil
+	}
+}
+
+// WithCompaction controls context compaction in tool loops.
+// When enabled (default), stale tool results are folded between rounds to
+// prevent context overflow. The budget is auto-detected from the provider's
+// context window or defaults to 128K tokens. Pass false to disable.
+func WithCompaction(enabled bool) Option {
+	return func(c *config) error {
+		c.compactionEnabled = &enabled
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

- **Default-on compactor**: Auto-configured when a provider is available. Budget auto-detected from `ContextWindowProvider` (new optional interface) or defaults to 128K tokens. Opt-out via `WithCompaction(false)`.
- **CompactResult**: `Compact()` returns structured result with original/compacted token counts and fold count for event emission and calibration.
- **Token calibration**: Uses actual `InputTokens` from provider `CostInfo` when available, falls back to heuristic counting.
- **Event telemetry**: New `context.compacted` event emitted when compaction occurs, with round number, token counts, messages folded, and budget.
- **Cost budget**: `MaxCostUSD` on `ToolPolicy` terminates the tool loop when cumulative provider cost exceeds the threshold.
- **MaxRounds raised from 10 → 50**: Safe with compactor preventing context overflow.

Builds on #787 (compactor core) and #786 (MessageLog write-through).

## Test plan

- [x] All compactor tests updated for new `CompactResult` return type and `lastInputTokens` parameter
- [x] Provider stage tests updated for `defaultMaxRounds = 50`
- [x] Pre-commit checks pass (lint, build, tests, coverage ≥ 80%)
- [ ] CI green on all modules
