### PR TITLE
feat: compactor extensibility — strategy pattern, rules, pair collapsing

### DIFF
--- a/runtime/pipeline/stage/compactor.go
+++ b/runtime/pipeline/stage/compactor.go
@@ -28,8 +28,8 @@ type CompactResult struct {
 // across conversations (each conversation has its own message slice).
 type CompactionStrategy interface {
 	Compact(messages []types.Message, lastInputTokens int) CompactResult
-	// BudgetTokens returns the configured token budget for event emission.
-	BudgetTokens() int
+	// TokenBudget returns the configured token budget for event emission.
+	TokenBudget() int
 }
 
 // CompactionRule transforms individual messages during compaction.
@@ -57,10 +57,10 @@ type CompactionContext struct {
 // order to fold stale messages until context is under the token budget.
 // Deterministic, zero LLM calls.
 type ContextCompactor struct {
-	// BudgetTokensValue is the context window size. When 0, compaction is disabled.
-	BudgetTokensValue int
+	// BudgetTokens is the context window size. When 0, compaction is disabled.
+	BudgetTokens int
 
-	// Threshold is the fraction of BudgetTokensValue above which compaction triggers.
+	// Threshold is the fraction of BudgetTokens above which compaction triggers.
 	// Default: 0.70 (compact when usage exceeds 70% of budget).
 	Threshold float64
 
@@ -73,19 +73,19 @@ type ContextCompactor struct {
 	Rules []CompactionRule
 }
 
-// BudgetTokens returns the configured token budget.
-func (c *ContextCompactor) BudgetTokens() int {
+// TokenBudget implements CompactionStrategy.
+func (c *ContextCompactor) TokenBudget() int {
 	if c == nil {
 		return 0
 	}
-	return c.BudgetTokensValue
+	return c.BudgetTokens
 }
 
 // Compact applies rules to fold stale messages until under budget.
 // Safe to call on a nil receiver (returns messages unchanged).
 func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int) CompactResult {
 	noOp := CompactResult{Messages: messages}
-	if c == nil || c.BudgetTokensValue <= 0 || len(messages) == 0 {
+	if c == nil || c.BudgetTokens <= 0 || len(messages) == 0 {
 		return noOp
 	}
 
@@ -98,7 +98,7 @@ func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int
 		pinCount = defaultPinRecentCount
 	}
 
-	budget := int(float64(c.BudgetTokensValue) * threshold)
+	budget := int(float64(c.BudgetTokens) * threshold)
 
 	originalTokens := lastInputTokens
 	if originalTokens <= 0 {
@@ -117,7 +117,7 @@ func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int
 	copy(compacted, messages)
 
 	rules := c.Rules
-	if len(rules) == 0 {
+	if rules == nil {
 		rules = []CompactionRule{FoldToolResults()}
 	}
 

--- a/runtime/pipeline/stage/compactor.go
+++ b/runtime/pipeline/stage/compactor.go
@@ -1,9 +1,6 @@
 package stage
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/tokenizer"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -13,10 +10,8 @@ const (
 	defaultCompactThreshold = 0.70
 	defaultPinRecentCount   = 4
 	// DefaultBudgetTokens is the default context window budget for compaction.
-	DefaultBudgetTokens      = 128000 // sensible default for modern models
-	compactedPreviewMaxBytes = 100
-	compactedMarker          = "compacted"
-	roleTool                 = "tool"
+	DefaultBudgetTokens = 128000 // sensible default for modern models
+	compactedMarker     = "compacted"
 )
 
 // CompactResult contains the output of a compaction pass.
@@ -27,30 +22,70 @@ type CompactResult struct {
 	MessagesFolded  int
 }
 
-// ContextCompactor folds stale tool results between rounds to keep context
-// bounded. Deterministic, zero LLM calls. Only modifies the in-memory message
-// slice sent to the provider — the persisted log (via MessageLog) retains the
-// full uncompacted history.
-type ContextCompactor struct {
-	// BudgetTokens is the context window size. When 0, compaction is disabled.
-	BudgetTokens int
+// CompactionStrategy is the top-level interface for context compaction.
+// Called by ProviderStage between tool loop rounds. Implementations must
+// be safe for concurrent use if the provider stage is used concurrently
+// across conversations (each conversation has its own message slice).
+type CompactionStrategy interface {
+	Compact(messages []types.Message, lastInputTokens int) CompactResult
+	// BudgetTokens returns the configured token budget for event emission.
+	BudgetTokens() int
+}
 
-	// Threshold is the fraction of BudgetTokens above which compaction triggers.
+// CompactionRule transforms individual messages during compaction.
+// Rules are applied in order to each compactable message outside the
+// pinned window. The first rule whose CanFold returns true wins.
+type CompactionRule interface {
+	Name() string
+	// CanFold reports whether this rule can compact the message at idx.
+	CanFold(msg *types.Message, idx int, ctx *CompactionContext) bool
+	// Fold returns the compacted content for the message, plus indices of
+	// additional messages to remove (e.g., the preceding assistant message
+	// in a pair collapse). Return nil for no additional removals.
+	Fold(msg *types.Message, idx int, ctx *CompactionContext) (string, []int)
+}
+
+// CompactionContext provides read-only context to rules.
+type CompactionContext struct {
+	Messages    []types.Message // full message slice (read-only view of the copy)
+	PinBoundary int             // messages at/after this index are pinned
+	Budget      int             // target token count
+	Current     int             // current estimated token count
+}
+
+// ContextCompactor is the default CompactionStrategy. It applies rules in
+// order to fold stale messages until context is under the token budget.
+// Deterministic, zero LLM calls.
+type ContextCompactor struct {
+	// BudgetTokensValue is the context window size. When 0, compaction is disabled.
+	BudgetTokensValue int
+
+	// Threshold is the fraction of BudgetTokensValue above which compaction triggers.
 	// Default: 0.70 (compact when usage exceeds 70% of budget).
 	Threshold float64
 
 	// PinRecentCount is the number of recent messages to preserve verbatim.
 	// Default: 4 (2 round-trips).
 	PinRecentCount int
+
+	// Rules are applied in order; first match wins. When nil/empty,
+	// defaults to [FoldToolResults()].
+	Rules []CompactionRule
 }
 
-// Compact folds stale tool results to reduce token usage.
-// lastInputTokens is the actual token count from the provider's CostInfo.InputTokens.
-// When > 0, used instead of heuristic counting (more accurate). Pass 0 for heuristic only.
+// BudgetTokens returns the configured token budget.
+func (c *ContextCompactor) BudgetTokens() int {
+	if c == nil {
+		return 0
+	}
+	return c.BudgetTokensValue
+}
+
+// Compact applies rules to fold stale messages until under budget.
 // Safe to call on a nil receiver (returns messages unchanged).
 func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int) CompactResult {
 	noOp := CompactResult{Messages: messages}
-	if c == nil || c.BudgetTokens <= 0 || len(messages) == 0 {
+	if c == nil || c.BudgetTokensValue <= 0 || len(messages) == 0 {
 		return noOp
 	}
 
@@ -63,9 +98,8 @@ func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int
 		pinCount = defaultPinRecentCount
 	}
 
-	budget := int(float64(c.BudgetTokens) * threshold)
+	budget := int(float64(c.BudgetTokensValue) * threshold)
 
-	// Use actual token count from provider if available (more accurate)
 	originalTokens := lastInputTokens
 	if originalTokens <= 0 {
 		originalTokens = tokenizer.CountMessageTokensDefault(messages)
@@ -82,30 +116,68 @@ func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int
 	compacted := make([]types.Message, len(messages))
 	copy(compacted, messages)
 
+	rules := c.Rules
+	if len(rules) == 0 {
+		rules = []CompactionRule{FoldToolResults()}
+	}
+
+	ctx := &CompactionContext{
+		Messages:    compacted,
+		PinBoundary: pinBoundary,
+		Budget:      budget,
+		Current:     originalTokens,
+	}
+
 	totalTokens := originalTokens
 	messagesFolded := 0
+	removed := map[int]bool{}
+
 	for i := 0; i < pinBoundary && totalTokens > budget; i++ {
+		if removed[i] {
+			continue
+		}
 		msg := &compacted[i]
 
-		if !isCompactable(msg) {
+		ctx.Current = totalTokens
+
+		var matchedRule CompactionRule
+		for _, rule := range rules {
+			if rule.CanFold(msg, i, ctx) {
+				matchedRule = rule
+				break
+			}
+		}
+		if matchedRule == nil {
 			continue
 		}
 
 		beforeTokens := tokenizer.CountMessageTokensDefault([]types.Message{*msg})
-		folded := foldToolResult(msg)
-		msg.Content = folded
-		msg.Parts = nil // clear multimodal parts
-		// Update ToolResult.Parts so GetContent() (which reads from ToolResult
-		// for tool messages) returns the folded content for token counting.
-		if msg.ToolResult != nil {
-			msg.ToolResult.Parts = []types.ContentPart{
-				{Type: types.ContentTypeText, Text: &folded},
-			}
-		}
+		folded, extraRemovals := matchedRule.Fold(msg, i, ctx)
+		applyFold(msg, folded)
 		afterTokens := tokenizer.CountMessageTokensDefault([]types.Message{*msg})
-
 		totalTokens -= beforeTokens - afterTokens
 		messagesFolded++
+
+		// Handle additional removals (e.g., pair collapse removes the assistant msg)
+		for _, ri := range extraRemovals {
+			if ri >= 0 && ri < pinBoundary && !removed[ri] {
+				removed[ri] = true
+				totalTokens -= tokenizer.CountMessageTokensDefault(
+					[]types.Message{compacted[ri]})
+				messagesFolded++
+			}
+		}
+	}
+
+	// Build final message slice, excluding removed indices
+	if len(removed) > 0 {
+		final := make([]types.Message, 0, len(compacted)-len(removed))
+		for i := range compacted {
+			if !removed[i] {
+				final = append(final, compacted[i])
+			}
+		}
+		compacted = final
 	}
 
 	if messagesFolded > 0 {
@@ -124,57 +196,14 @@ func (c *ContextCompactor) Compact(messages []types.Message, lastInputTokens int
 	}
 }
 
-// isCompactable returns true if a message can be folded.
-func isCompactable(msg *types.Message) bool {
-	if msg.Role != roleTool {
-		return false
-	}
-	if msg.ToolResult != nil && msg.ToolResult.Error != "" {
-		return false
-	}
-	// Already compacted or too small to bother — skip.
-	// Use GetContent() which reads from ToolResult.Parts for tool messages.
-	content := msg.GetContent()
-	if len(content) < 50 || strings.Contains(content, compactedMarker) {
-		return false
-	}
-	return true
-}
-
-// foldToolResult creates a compact summary of a tool result.
-func foldToolResult(msg *types.Message) string {
-	name := ""
+// applyFold sets the folded content on a message, updating both Content
+// and ToolResult.Parts so that GetContent() returns the folded text.
+func applyFold(msg *types.Message, folded string) {
+	msg.Content = folded
+	msg.Parts = nil
 	if msg.ToolResult != nil {
-		name = msg.ToolResult.Name
-	}
-	if name == "" {
-		name = "tool"
-	}
-
-	// Handle multimodal parts
-	if len(msg.Parts) > 0 {
-		totalBytes := 0
-		for _, part := range msg.Parts {
-			if part.Text != nil {
-				totalBytes += len(*part.Text)
-			}
-			if part.Media != nil && part.Media.Data != nil {
-				totalBytes += len(*part.Media.Data)
-			}
+		msg.ToolResult.Parts = []types.ContentPart{
+			{Type: types.ContentTypeText, Text: &folded},
 		}
-		return fmt.Sprintf("[%s: %d parts, %d bytes %s]",
-			name, len(msg.Parts), totalBytes, compactedMarker)
 	}
-
-	// Text-only: preview + size
-	content := msg.GetContent()
-	originalBytes := len(content)
-
-	preview := content
-	if len(preview) > compactedPreviewMaxBytes {
-		preview = preview[:compactedPreviewMaxBytes] + "..."
-	}
-
-	return fmt.Sprintf("[%s: %s — %d bytes %s]",
-		name, preview, originalBytes, compactedMarker)
 }

--- a/runtime/pipeline/stage/compactor_fold.go
+++ b/runtime/pipeline/stage/compactor_fold.go
@@ -1,0 +1,84 @@
+package stage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+const (
+	compactedPreviewMaxBytes = 100
+	roleTool                 = "tool"
+	minCompactableBytes      = 50
+)
+
+// foldToolResultsRule is the default compaction rule. It replaces large
+// tool results with a compact summary containing the tool name, a content
+// preview, and the original byte count.
+type foldToolResultsRule struct{}
+
+// FoldToolResults returns the default compaction rule that folds large
+// tool result messages into compact summaries.
+func FoldToolResults() CompactionRule { return &foldToolResultsRule{} }
+
+// Name implements CompactionRule.
+func (r *foldToolResultsRule) Name() string { return "fold_tool_results" }
+
+// CanFold implements CompactionRule.
+func (r *foldToolResultsRule) CanFold(msg *types.Message, _ int, _ *CompactionContext) bool {
+	if msg.Role != roleTool {
+		return false
+	}
+	if msg.ToolResult != nil && msg.ToolResult.Error != "" {
+		return false
+	}
+	content := msg.GetContent()
+	if len(content) < minCompactableBytes || strings.Contains(content, compactedMarker) {
+		return false
+	}
+	return true
+}
+
+// Fold implements CompactionRule.
+func (r *foldToolResultsRule) Fold(msg *types.Message, _ int, _ *CompactionContext) (folded string, extra []int) {
+	return foldToolResult(msg), nil
+}
+
+// foldToolResult creates a compact summary of a tool result.
+func foldToolResult(msg *types.Message) string {
+	name := ""
+	if msg.ToolResult != nil {
+		name = msg.ToolResult.Name
+	}
+	if name == "" {
+		name = roleTool
+	}
+
+	// Handle multimodal parts
+	if len(msg.Parts) > 0 {
+		totalBytes := 0
+		for _, part := range msg.Parts {
+			if part.Text != nil {
+				totalBytes += len(*part.Text)
+			}
+			if part.Media != nil && part.Media.Data != nil {
+				totalBytes += len(*part.Media.Data)
+			}
+		}
+		return fmt.Sprintf("[%s: %d parts, %d bytes %s]",
+			name, len(msg.Parts), totalBytes, compactedMarker)
+	}
+
+	// Text-only: preview + size
+	content := msg.GetContent()
+	originalBytes := len(content)
+
+	preview := content
+	if len(preview) > compactedPreviewMaxBytes {
+		preview = preview[:compactedPreviewMaxBytes] + "..."
+	}
+
+	return fmt.Sprintf("[%s: %s — %d bytes %s]",
+		name, preview, originalBytes, compactedMarker)
+}

--- a/runtime/pipeline/stage/compactor_pairs.go
+++ b/runtime/pipeline/stage/compactor_pairs.go
@@ -109,8 +109,8 @@ func toolResultKey(msg *types.Message, messages []types.Message) string {
 			}
 		}
 	}
-	// Fallback: key by name only (matches any call to the same tool)
-	return name + ":"
+	// Can't determine args — don't match to avoid false positives
+	return ""
 }
 
 // normalizeArgs produces a canonical string from tool call arguments

--- a/runtime/pipeline/stage/compactor_pairs.go
+++ b/runtime/pipeline/stage/compactor_pairs.go
@@ -1,0 +1,130 @@
+package stage
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// collapsePairsRule detects superseded assistant→tool pairs. When the same
+// tool with the same arguments is called again later in the conversation,
+// the earlier pair (assistant message requesting the call + tool result) is
+// collapsed to a single-line summary.
+type collapsePairsRule struct{}
+
+// CollapsePairs returns a compaction rule that collapses superseded
+// assistant→tool message pairs. A pair is superseded when the same tool
+// name and arguments appear in a later tool result.
+func CollapsePairs() CompactionRule { return &collapsePairsRule{} }
+
+// Name implements CompactionRule.
+func (r *collapsePairsRule) Name() string { return "collapse_pairs" }
+
+// CanFold implements CompactionRule.
+func (r *collapsePairsRule) CanFold(msg *types.Message, idx int, ctx *CompactionContext) bool {
+	if msg.Role != roleTool || msg.ToolResult == nil {
+		return false
+	}
+	if msg.ToolResult.Error != "" {
+		return false
+	}
+	if strings.Contains(msg.GetContent(), compactedMarker) {
+		return false
+	}
+	return isSuperseded(msg, idx, ctx)
+}
+
+// Fold implements CompactionRule.
+func (r *collapsePairsRule) Fold(
+	msg *types.Message, idx int, ctx *CompactionContext,
+) (folded string, extraRemovals []int) {
+	name := msg.ToolResult.Name
+	if name == "" {
+		name = "tool"
+	}
+	summary := fmt.Sprintf("[%s: superseded — %d bytes %s]",
+		name, len(msg.GetContent()), compactedMarker)
+
+	// Also collapse the preceding assistant message if it only contains
+	// the tool call that produced this result.
+	var extra []int
+	if idx > 0 {
+		prev := &ctx.Messages[idx-1]
+		if prev.Role == roleAssistant && isMatchingAssistant(prev, msg) {
+			extra = []int{idx - 1}
+		}
+	}
+	return summary, extra
+}
+
+// isSuperseded returns true if a later message in the conversation has
+// the same tool name and arguments.
+func isSuperseded(msg *types.Message, idx int, ctx *CompactionContext) bool {
+	key := toolResultKey(msg, ctx.Messages)
+	if key == "" {
+		return false
+	}
+	for j := idx + 1; j < len(ctx.Messages); j++ {
+		other := &ctx.Messages[j]
+		if other.Role != roleTool || other.ToolResult == nil {
+			continue
+		}
+		if toolResultKey(other, ctx.Messages) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// isMatchingAssistant returns true if the assistant message contains
+// exactly one tool call that matches the tool result message.
+func isMatchingAssistant(assistant, toolResult *types.Message) bool {
+	if len(assistant.ToolCalls) != 1 {
+		return false
+	}
+	tc := assistant.ToolCalls[0]
+	return tc.Name == toolResult.ToolResult.Name &&
+		tc.ID == toolResult.ToolResult.ID
+}
+
+// toolResultKey produces a canonical key "name:args" for a tool result
+// by finding the assistant message that triggered it and extracting the args.
+func toolResultKey(msg *types.Message, messages []types.Message) string {
+	if msg.ToolResult == nil || msg.ToolResult.Name == "" {
+		return ""
+	}
+	targetID := msg.ToolResult.ID
+	name := msg.ToolResult.Name
+
+	for i := range messages {
+		m := &messages[i]
+		if m.Role != roleAssistant {
+			continue
+		}
+		for _, tc := range m.ToolCalls {
+			if tc.ID == targetID {
+				return name + ":" + normalizeArgs(tc.Args)
+			}
+		}
+	}
+	// Fallback: key by name only (matches any call to the same tool)
+	return name + ":"
+}
+
+// normalizeArgs produces a canonical string from tool call arguments
+// for comparison. Re-marshals JSON objects for consistent key ordering.
+func normalizeArgs(args json.RawMessage) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var obj map[string]any
+	if json.Unmarshal(args, &obj) == nil {
+		canonical, err := json.Marshal(obj)
+		if err == nil {
+			return string(canonical)
+		}
+	}
+	return string(args)
+}

--- a/runtime/pipeline/stage/compactor_test.go
+++ b/runtime/pipeline/stage/compactor_test.go
@@ -1,6 +1,7 @@
 package stage
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -33,8 +34,8 @@ func largeToolResult(name string, wordCount int) types.Message {
 
 func TestCompactor_NoOpUnderThreshold(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens: 10000,
-		Threshold:    0.70,
+		BudgetTokensValue: 10000,
+		Threshold:         0.70,
 	}
 
 	msgs := []types.Message{
@@ -52,9 +53,9 @@ func TestCompactor_NoOpUnderThreshold(t *testing.T) {
 
 func TestCompactor_FoldsOldToolResults(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   500, // very low budget to force compaction
-		Threshold:      0.70,
-		PinRecentCount: 4,
+		BudgetTokensValue: 500, // very low budget to force compaction
+		Threshold:         0.70,
+		PinRecentCount:    4,
 	}
 
 	msgs := []types.Message{
@@ -90,9 +91,9 @@ func TestCompactor_FoldsOldToolResults(t *testing.T) {
 
 func TestCompactor_PreservesSystemMessages(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   100, // very low to force compaction
-		Threshold:      0.50,
-		PinRecentCount: 2,
+		BudgetTokensValue: 100, // very low to force compaction
+		Threshold:         0.50,
+		PinRecentCount:    2,
 	}
 
 	msgs := []types.Message{
@@ -111,9 +112,9 @@ func TestCompactor_PreservesSystemMessages(t *testing.T) {
 
 func TestCompactor_PreservesErrors(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   100,
-		Threshold:      0.50,
-		PinRecentCount: 2,
+		BudgetTokensValue: 100,
+		Threshold:         0.50,
+		PinRecentCount:    2,
 	}
 
 	msgs := []types.Message{
@@ -136,9 +137,9 @@ func TestCompactor_PreservesErrors(t *testing.T) {
 
 func TestCompactor_PreservesRecentMessages(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   200,
-		Threshold:      0.50,
-		PinRecentCount: 4,
+		BudgetTokensValue: 200,
+		Threshold:         0.50,
+		PinRecentCount:    4,
 	}
 
 	msgs := []types.Message{
@@ -167,9 +168,9 @@ func TestCompactor_PreservesRecentMessages(t *testing.T) {
 
 func TestCompactor_IdempotentOnAlreadyCompacted(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   200,
-		Threshold:      0.50,
-		PinRecentCount: 2,
+		BudgetTokensValue: 200,
+		Threshold:         0.50,
+		PinRecentCount:    2,
 	}
 
 	msgs := []types.Message{
@@ -192,9 +193,9 @@ func TestCompactor_IdempotentOnAlreadyCompacted(t *testing.T) {
 
 func TestCompactor_FoldsOldestFirst(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   2000,
-		Threshold:      0.50,
-		PinRecentCount: 2,
+		BudgetTokensValue: 2000,
+		Threshold:         0.50,
+		PinRecentCount:    2,
 	}
 
 	msgs := []types.Message{
@@ -222,7 +223,7 @@ func TestCompactor_FoldsOldestFirst(t *testing.T) {
 
 func TestCompactor_DisabledWhenBudgetZero(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens: 0, // disabled
+		BudgetTokensValue: 0, // disabled
 	}
 
 	msgs := []types.Message{
@@ -297,9 +298,9 @@ func TestFoldToolResult_ShortContent(t *testing.T) {
 
 func TestCompactor_LastInputTokensTriggersCompaction(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   10000,
-		Threshold:      0.70,
-		PinRecentCount: 2,
+		BudgetTokensValue: 10000,
+		Threshold:         0.70,
+		PinRecentCount:    2,
 	}
 
 	msgs := []types.Message{
@@ -321,9 +322,9 @@ func TestCompactor_LastInputTokensTriggersCompaction(t *testing.T) {
 
 func TestCompactor_LastInputTokensBelowThresholdSkips(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   10000,
-		Threshold:      0.70,
-		PinRecentCount: 2,
+		BudgetTokensValue: 10000,
+		Threshold:         0.70,
+		PinRecentCount:    2,
 	}
 
 	msgs := []types.Message{
@@ -340,9 +341,9 @@ func TestCompactor_LastInputTokensBelowThresholdSkips(t *testing.T) {
 
 func TestCompactor_CompactResultMetadata(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens:   500,
-		Threshold:      0.70,
-		PinRecentCount: 2,
+		BudgetTokensValue: 500,
+		Threshold:         0.70,
+		PinRecentCount:    2,
 	}
 
 	msgs := []types.Message{
@@ -362,8 +363,8 @@ func TestCompactor_CompactResultMetadata(t *testing.T) {
 
 func TestCompactor_NoOpResultMetadata(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokens: 10000,
-		Threshold:    0.70,
+		BudgetTokensValue: 10000,
+		Threshold:         0.70,
 	}
 
 	msgs := []types.Message{
@@ -375,6 +376,251 @@ func TestCompactor_NoOpResultMetadata(t *testing.T) {
 	assert.Zero(t, result.MessagesFolded)
 	assert.Zero(t, result.OriginalTokens, "no-op should not compute tokens")
 	assert.Zero(t, result.CompactedTokens)
+}
+
+// --- Strategy interface tests ---
+
+type mockStrategy struct {
+	called bool
+	budget int
+}
+
+func (m *mockStrategy) Compact(msgs []types.Message, _ int) CompactResult {
+	m.called = true
+	return CompactResult{Messages: msgs, MessagesFolded: 42}
+}
+func (m *mockStrategy) BudgetTokens() int { return m.budget }
+
+func TestCompactionStrategy_CustomStrategy(t *testing.T) {
+	s := &mockStrategy{budget: 99999}
+	msgs := []types.Message{{Role: "user", Content: "hello"}}
+
+	result := s.Compact(msgs, 0)
+	assert.True(t, s.called)
+	assert.Equal(t, 42, result.MessagesFolded)
+	assert.Equal(t, 99999, s.BudgetTokens())
+}
+
+func TestContextCompactor_ImplementsCompactionStrategy(t *testing.T) {
+	// Compile-time check
+	var _ CompactionStrategy = (*ContextCompactor)(nil)
+}
+
+// --- Custom rule tests ---
+
+type alwaysFoldRule struct {
+	name string
+}
+
+func (r *alwaysFoldRule) Name() string { return r.name }
+
+func (r *alwaysFoldRule) CanFold(msg *types.Message, _ int, _ *CompactionContext) bool {
+	return msg.Role == roleTool
+}
+
+func (r *alwaysFoldRule) Fold(msg *types.Message, _ int, _ *CompactionContext) (string, []int) {
+	return "[custom-folded]", nil
+}
+
+func TestCompactor_CustomRules(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokensValue: 100,
+		Threshold:         0.50,
+		PinRecentCount:    2,
+		Rules:             []CompactionRule{&alwaysFoldRule{name: "custom"}},
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		largeToolResult("big_tool", 2000),
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	result := c.Compact(msgs, 0)
+	assert.Greater(t, result.MessagesFolded, 0)
+
+	// The custom rule's fold text should appear
+	found := false
+	for _, msg := range result.Messages {
+		if strings.Contains(msg.Content, "custom-folded") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "custom rule fold text should appear")
+}
+
+func TestCompactor_RuleFirstMatchWins(t *testing.T) {
+	called := map[string]int{}
+	rule1 := &trackingRule{name: "first", called: &called, canFold: true}
+	rule2 := &trackingRule{name: "second", called: &called, canFold: true}
+
+	c := &ContextCompactor{
+		BudgetTokensValue: 100,
+		Threshold:         0.50,
+		PinRecentCount:    2,
+		Rules:             []CompactionRule{rule1, rule2},
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		largeToolResult("tool", 2000),
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	c.Compact(msgs, 0)
+	assert.Equal(t, 1, called["first"], "first rule should be called once")
+	assert.Zero(t, called["second"], "second rule should not be called (first matched)")
+}
+
+type trackingRule struct {
+	name    string
+	called  *map[string]int
+	canFold bool
+}
+
+func (r *trackingRule) Name() string { return r.name }
+func (r *trackingRule) CanFold(msg *types.Message, _ int, _ *CompactionContext) bool {
+	return r.canFold && msg.Role == roleTool && len(msg.GetContent()) >= 50
+}
+func (r *trackingRule) Fold(msg *types.Message, _ int, _ *CompactionContext) (string, []int) {
+	(*r.called)[r.name]++
+	return "[folded-by-" + r.name + "]", nil
+}
+
+func TestCompactor_DefaultRuleWhenNoRulesSet(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokensValue: 100,
+		Threshold:         0.50,
+		PinRecentCount:    2,
+		// Rules intentionally nil — should default to FoldToolResults()
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		largeToolResult("file_read", 2000),
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	result := c.Compact(msgs, 0)
+	assert.Greater(t, result.MessagesFolded, 0)
+	// Should use default FoldToolResults format
+	for _, msg := range result.Messages {
+		if msg.Role == roleTool && strings.Contains(msg.Content, compactedMarker) {
+			assert.Contains(t, msg.Content, "file_read")
+			break
+		}
+	}
+}
+
+// --- CollapsePairs rule tests ---
+
+func assistantToolCallMsg(toolCallID, toolName, argsJSON string) types.Message {
+	return types.Message{
+		Role: "assistant",
+		ToolCalls: []types.MessageToolCall{
+			{ID: toolCallID, Name: toolName, Args: json.RawMessage(argsJSON)},
+		},
+	}
+}
+
+func toolResultMsgWithID(id, name, content string) types.Message {
+	tr := types.NewTextToolResult(id, name, content)
+	return types.NewToolResultMessage(tr)
+}
+
+func TestCollapsePairs_SupersededPairCollapsed(t *testing.T) {
+	c := &ContextCompactor{
+		BudgetTokensValue: 100,
+		Threshold:         0.50,
+		PinRecentCount:    2,
+		Rules:             []CompactionRule{CollapsePairs(), FoldToolResults()},
+	}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		// First file_read("main.go") — should be collapsed
+		assistantToolCallMsg("call-1", "file_read", `{"path":"main.go"}`),
+		toolResultMsgWithID("call-1", "file_read", strings.Repeat("package main\n", 200)),
+		// Second file_read("main.go") — supersedes the first
+		assistantToolCallMsg("call-2", "file_read", `{"path":"main.go"}`),
+		toolResultMsgWithID("call-2", "file_read", strings.Repeat("package main\nfunc main() {}\n", 200)),
+		// Recent:
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	result := c.Compact(msgs, 0)
+
+	// The first assistant+tool pair should be collapsed
+	foundSuperseded := false
+	for _, msg := range result.Messages {
+		if strings.Contains(msg.Content, "superseded") {
+			foundSuperseded = true
+			break
+		}
+	}
+	assert.True(t, foundSuperseded, "superseded pair should be collapsed")
+
+	// The message count should be less (assistant msg removed)
+	assert.Less(t, len(result.Messages), len(msgs), "collapsed pair should reduce message count")
+}
+
+func TestCollapsePairs_DifferentArgsDontCollapse(t *testing.T) {
+	rule := CollapsePairs()
+
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		assistantToolCallMsg("call-1", "file_read", `{"path":"main.go"}`),
+		toolResultMsgWithID("call-1", "file_read", strings.Repeat("content a ", 100)),
+		assistantToolCallMsg("call-2", "file_read", `{"path":"config.go"}`),
+		toolResultMsgWithID("call-2", "file_read", strings.Repeat("content b ", 100)),
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	ctx := &CompactionContext{
+		Messages:    msgs,
+		PinBoundary: 5,
+	}
+
+	// The first file_read("main.go") should NOT be superseded by file_read("config.go")
+	assert.False(t, rule.CanFold(&msgs[2], 2, ctx),
+		"different args should not be considered superseded")
+}
+
+func TestCollapsePairs_ErrorsNotCollapsed(t *testing.T) {
+	rule := CollapsePairs()
+
+	errResult := toolResultMsgWithError("file_read", strings.Repeat("error ", 50), "file not found")
+	msgs := []types.Message{
+		{Role: "user", Content: "start"},
+		errResult,
+		toolResultMsgWithID("call-2", "file_read", strings.Repeat("content ", 100)),
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	ctx := &CompactionContext{Messages: msgs, PinBoundary: 3}
+	assert.False(t, rule.CanFold(&msgs[1], 1, ctx), "error results should never be collapsed")
+}
+
+func TestCollapsePairs_AlreadyCompactedSkipped(t *testing.T) {
+	rule := CollapsePairs()
+
+	msg := toolResultMsg("file_read", "[file_read: superseded — 500 bytes compacted]")
+	msgs := []types.Message{
+		msg,
+		toolResultMsgWithID("call-2", "file_read", strings.Repeat("content ", 100)),
+		{Role: "assistant", Content: "done"},
+		{Role: "user", Content: "next"},
+	}
+
+	ctx := &CompactionContext{Messages: msgs, PinBoundary: 2}
+	assert.False(t, rule.CanFold(&msgs[0], 0, ctx), "already compacted should be skipped")
 }
 
 func stringPtr(s string) *string { return &s }

--- a/runtime/pipeline/stage/compactor_test.go
+++ b/runtime/pipeline/stage/compactor_test.go
@@ -34,8 +34,8 @@ func largeToolResult(name string, wordCount int) types.Message {
 
 func TestCompactor_NoOpUnderThreshold(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 10000,
-		Threshold:         0.70,
+		BudgetTokens: 10000,
+		Threshold:    0.70,
 	}
 
 	msgs := []types.Message{
@@ -53,9 +53,9 @@ func TestCompactor_NoOpUnderThreshold(t *testing.T) {
 
 func TestCompactor_FoldsOldToolResults(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 500, // very low budget to force compaction
-		Threshold:         0.70,
-		PinRecentCount:    4,
+		BudgetTokens:   500, // very low budget to force compaction
+		Threshold:      0.70,
+		PinRecentCount: 4,
 	}
 
 	msgs := []types.Message{
@@ -91,9 +91,9 @@ func TestCompactor_FoldsOldToolResults(t *testing.T) {
 
 func TestCompactor_PreservesSystemMessages(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 100, // very low to force compaction
-		Threshold:         0.50,
-		PinRecentCount:    2,
+		BudgetTokens:   100, // very low to force compaction
+		Threshold:      0.50,
+		PinRecentCount: 2,
 	}
 
 	msgs := []types.Message{
@@ -112,9 +112,9 @@ func TestCompactor_PreservesSystemMessages(t *testing.T) {
 
 func TestCompactor_PreservesErrors(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 100,
-		Threshold:         0.50,
-		PinRecentCount:    2,
+		BudgetTokens:   100,
+		Threshold:      0.50,
+		PinRecentCount: 2,
 	}
 
 	msgs := []types.Message{
@@ -137,9 +137,9 @@ func TestCompactor_PreservesErrors(t *testing.T) {
 
 func TestCompactor_PreservesRecentMessages(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 200,
-		Threshold:         0.50,
-		PinRecentCount:    4,
+		BudgetTokens:   200,
+		Threshold:      0.50,
+		PinRecentCount: 4,
 	}
 
 	msgs := []types.Message{
@@ -168,9 +168,9 @@ func TestCompactor_PreservesRecentMessages(t *testing.T) {
 
 func TestCompactor_IdempotentOnAlreadyCompacted(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 200,
-		Threshold:         0.50,
-		PinRecentCount:    2,
+		BudgetTokens:   200,
+		Threshold:      0.50,
+		PinRecentCount: 2,
 	}
 
 	msgs := []types.Message{
@@ -193,9 +193,9 @@ func TestCompactor_IdempotentOnAlreadyCompacted(t *testing.T) {
 
 func TestCompactor_FoldsOldestFirst(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 2000,
-		Threshold:         0.50,
-		PinRecentCount:    2,
+		BudgetTokens:   2000,
+		Threshold:      0.50,
+		PinRecentCount: 2,
 	}
 
 	msgs := []types.Message{
@@ -223,7 +223,7 @@ func TestCompactor_FoldsOldestFirst(t *testing.T) {
 
 func TestCompactor_DisabledWhenBudgetZero(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 0, // disabled
+		BudgetTokens: 0, // disabled
 	}
 
 	msgs := []types.Message{
@@ -298,9 +298,9 @@ func TestFoldToolResult_ShortContent(t *testing.T) {
 
 func TestCompactor_LastInputTokensTriggersCompaction(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 10000,
-		Threshold:         0.70,
-		PinRecentCount:    2,
+		BudgetTokens:   10000,
+		Threshold:      0.70,
+		PinRecentCount: 2,
 	}
 
 	msgs := []types.Message{
@@ -322,9 +322,9 @@ func TestCompactor_LastInputTokensTriggersCompaction(t *testing.T) {
 
 func TestCompactor_LastInputTokensBelowThresholdSkips(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 10000,
-		Threshold:         0.70,
-		PinRecentCount:    2,
+		BudgetTokens:   10000,
+		Threshold:      0.70,
+		PinRecentCount: 2,
 	}
 
 	msgs := []types.Message{
@@ -341,9 +341,9 @@ func TestCompactor_LastInputTokensBelowThresholdSkips(t *testing.T) {
 
 func TestCompactor_CompactResultMetadata(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 500,
-		Threshold:         0.70,
-		PinRecentCount:    2,
+		BudgetTokens:   500,
+		Threshold:      0.70,
+		PinRecentCount: 2,
 	}
 
 	msgs := []types.Message{
@@ -363,8 +363,8 @@ func TestCompactor_CompactResultMetadata(t *testing.T) {
 
 func TestCompactor_NoOpResultMetadata(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 10000,
-		Threshold:         0.70,
+		BudgetTokens: 10000,
+		Threshold:    0.70,
 	}
 
 	msgs := []types.Message{
@@ -389,7 +389,7 @@ func (m *mockStrategy) Compact(msgs []types.Message, _ int) CompactResult {
 	m.called = true
 	return CompactResult{Messages: msgs, MessagesFolded: 42}
 }
-func (m *mockStrategy) BudgetTokens() int { return m.budget }
+func (m *mockStrategy) TokenBudget() int { return m.budget }
 
 func TestCompactionStrategy_CustomStrategy(t *testing.T) {
 	s := &mockStrategy{budget: 99999}
@@ -398,7 +398,7 @@ func TestCompactionStrategy_CustomStrategy(t *testing.T) {
 	result := s.Compact(msgs, 0)
 	assert.True(t, s.called)
 	assert.Equal(t, 42, result.MessagesFolded)
-	assert.Equal(t, 99999, s.BudgetTokens())
+	assert.Equal(t, 99999, s.TokenBudget())
 }
 
 func TestContextCompactor_ImplementsCompactionStrategy(t *testing.T) {
@@ -424,10 +424,10 @@ func (r *alwaysFoldRule) Fold(msg *types.Message, _ int, _ *CompactionContext) (
 
 func TestCompactor_CustomRules(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 100,
-		Threshold:         0.50,
-		PinRecentCount:    2,
-		Rules:             []CompactionRule{&alwaysFoldRule{name: "custom"}},
+		BudgetTokens:   100,
+		Threshold:      0.50,
+		PinRecentCount: 2,
+		Rules:          []CompactionRule{&alwaysFoldRule{name: "custom"}},
 	}
 
 	msgs := []types.Message{
@@ -457,10 +457,10 @@ func TestCompactor_RuleFirstMatchWins(t *testing.T) {
 	rule2 := &trackingRule{name: "second", called: &called, canFold: true}
 
 	c := &ContextCompactor{
-		BudgetTokensValue: 100,
-		Threshold:         0.50,
-		PinRecentCount:    2,
-		Rules:             []CompactionRule{rule1, rule2},
+		BudgetTokens:   100,
+		Threshold:      0.50,
+		PinRecentCount: 2,
+		Rules:          []CompactionRule{rule1, rule2},
 	}
 
 	msgs := []types.Message{
@@ -492,9 +492,9 @@ func (r *trackingRule) Fold(msg *types.Message, _ int, _ *CompactionContext) (st
 
 func TestCompactor_DefaultRuleWhenNoRulesSet(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 100,
-		Threshold:         0.50,
-		PinRecentCount:    2,
+		BudgetTokens:   100,
+		Threshold:      0.50,
+		PinRecentCount: 2,
 		// Rules intentionally nil — should default to FoldToolResults()
 	}
 
@@ -534,10 +534,10 @@ func toolResultMsgWithID(id, name, content string) types.Message {
 
 func TestCollapsePairs_SupersededPairCollapsed(t *testing.T) {
 	c := &ContextCompactor{
-		BudgetTokensValue: 100,
-		Threshold:         0.50,
-		PinRecentCount:    2,
-		Rules:             []CompactionRule{CollapsePairs(), FoldToolResults()},
+		BudgetTokens:   100,
+		Threshold:      0.50,
+		PinRecentCount: 2,
+		Rules:          []CompactionRule{CollapsePairs(), FoldToolResults()},
 	}
 
 	msgs := []types.Message{

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -64,7 +64,7 @@ type ProviderConfig struct {
 
 	// Compactor folds stale tool results between rounds when token usage
 	// exceeds the configured threshold. Nil = disabled.
-	Compactor *ContextCompactor
+	Compactor CompactionStrategy
 }
 
 // streamingRoundParams holds parameters for a streaming round execution.
@@ -418,7 +418,7 @@ func (tl *toolLoop) afterRound(
 		tl.messages = cr.Messages
 		if cr.MessagesFolded > 0 && tl.stage.emitter != nil {
 			tl.stage.emitter.ContextCompacted(round, cr.OriginalTokens, cr.CompactedTokens,
-				cr.MessagesFolded, tl.stage.config.Compactor.BudgetTokens)
+				cr.MessagesFolded, tl.stage.config.Compactor.BudgetTokens())
 		}
 	}
 

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -418,7 +418,7 @@ func (tl *toolLoop) afterRound(
 		tl.messages = cr.Messages
 		if cr.MessagesFolded > 0 && tl.stage.emitter != nil {
 			tl.stage.emitter.ContextCompacted(round, cr.OriginalTokens, cr.CompactedTokens,
-				cr.MessagesFolded, tl.stage.config.Compactor.BudgetTokens())
+				cr.MessagesFolded, tl.stage.config.Compactor.TokenBudget())
 		}
 	}
 

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -2859,9 +2859,9 @@ func TestAfterRound_CompactionEmitsEvent(t *testing.T) {
 
 	stg := NewProviderStageWithHooks(provider, registry, nil, &ProviderConfig{
 		Compactor: &ContextCompactor{
-			BudgetTokensValue: 100, // very low to force compaction
-			Threshold:         0.50,
-			PinRecentCount:    2,
+			BudgetTokens:   100, // very low to force compaction
+			Threshold:      0.50,
+			PinRecentCount: 2,
 		},
 	}, emitter, nil)
 

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -2859,9 +2859,9 @@ func TestAfterRound_CompactionEmitsEvent(t *testing.T) {
 
 	stg := NewProviderStageWithHooks(provider, registry, nil, &ProviderConfig{
 		Compactor: &ContextCompactor{
-			BudgetTokens:   100, // very low to force compaction
-			Threshold:      0.50,
-			PinRecentCount: 2,
+			BudgetTokensValue: 100, // very low to force compaction
+			Threshold:         0.50,
+			PinRecentCount:    2,
 		},
 	}, emitter, nil)
 

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -421,6 +421,8 @@ func (c *Conversation) buildPipelineConfig(
 		ExecutionTimeout:      c.config.executionTimeout,
 		MessageLog:            c.config.messageLog,
 		CompactionEnabled:     c.config.compactionEnabled,
+		CompactionStrategy:    c.config.compactionStrategy,
+		CompactionRules:       c.config.compactionRules,
 	}
 
 	// Wire recording config if enabled

--- a/sdk/examples/custom-compaction/compaction.pack.json
+++ b/sdk/examples/custom-compaction/compaction.pack.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "custom-compaction-example",
+  "name": "Custom Compaction Example",
+  "version": "1.0.0",
+  "description": "Demonstrates custom context compaction strategies and rules",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "chat": {
+      "id": "chat",
+      "name": "Chat",
+      "version": "1.0.0",
+      "system_template": "You are a helpful coding assistant. Use tools to read and edit files as needed."
+    }
+  }
+}

--- a/sdk/examples/custom-compaction/main_interactive.go
+++ b/sdk/examples/custom-compaction/main_interactive.go
@@ -1,0 +1,182 @@
+// Package main demonstrates custom context compaction with the PromptKit SDK.
+//
+// This example shows three extensibility patterns:
+//
+//  1. Custom CompactionRule — a rule that produces domain-specific summaries
+//     for search results instead of the generic preview+bytes format.
+//  2. Built-in CollapsePairs — collapses superseded assistant+tool pairs
+//     when the same tool is called again with the same arguments.
+//  3. Custom CompactionStrategy — a complete replacement for the default
+//     compactor, wrapping it with logging.
+//
+// Run with:
+//
+//	go run .
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// ---------------------------------------------------------------------------
+// Example 1: Custom CompactionRule for search results
+// ---------------------------------------------------------------------------
+
+// SearchResultRule produces compact summaries for search tool results.
+// Instead of the generic "[search: first 100 chars... — 5000 bytes compacted]",
+// it extracts the match count and first few filenames.
+type SearchResultRule struct{}
+
+// Compile-time interface check.
+var _ stage.CompactionRule = (*SearchResultRule)(nil)
+
+func (r *SearchResultRule) Name() string { return "search_result_fold" }
+
+func (r *SearchResultRule) CanFold(msg *types.Message, _ int, _ *stage.CompactionContext) bool {
+	if msg.Role != "tool" || msg.ToolResult == nil {
+		return false
+	}
+	// Only handle search-type tools
+	return msg.ToolResult.Name == "search" || msg.ToolResult.Name == "grep"
+}
+
+func (r *SearchResultRule) Fold(
+	msg *types.Message, _ int, _ *stage.CompactionContext,
+) (folded string, extra []int) {
+	content := msg.GetContent()
+	lines := strings.Split(content, "\n")
+	matchCount := len(lines)
+
+	// Extract first 3 filenames from results
+	var files []string
+	for _, line := range lines {
+		if len(files) >= 3 {
+			break
+		}
+		if idx := strings.Index(line, ":"); idx > 0 {
+			files = append(files, line[:idx])
+		}
+	}
+
+	summary := fmt.Sprintf("[%s: %d matches in %s — %d bytes compacted]",
+		msg.ToolResult.Name, matchCount, strings.Join(files, ", "),
+		len(content))
+	return summary, nil
+}
+
+// ---------------------------------------------------------------------------
+// Example 2: Custom CompactionStrategy — logging wrapper
+// ---------------------------------------------------------------------------
+
+// LoggingCompactor wraps another CompactionStrategy and logs when
+// compaction occurs. This demonstrates the decorator pattern.
+type LoggingCompactor struct {
+	Inner stage.CompactionStrategy
+}
+
+// Compile-time interface check.
+var _ stage.CompactionStrategy = (*LoggingCompactor)(nil)
+
+func (lc *LoggingCompactor) Compact(
+	messages []types.Message, lastInputTokens int,
+) stage.CompactResult {
+	result := lc.Inner.Compact(messages, lastInputTokens)
+	if result.MessagesFolded > 0 {
+		log.Printf("[compaction] folded %d messages: %d → %d tokens",
+			result.MessagesFolded, result.OriginalTokens, result.CompactedTokens)
+	}
+	return result
+}
+
+func (lc *LoggingCompactor) TokenBudget() int {
+	return lc.Inner.TokenBudget()
+}
+
+// ---------------------------------------------------------------------------
+// main — demonstrates all three patterns
+// ---------------------------------------------------------------------------
+
+func main() {
+	// Pattern 1: Use WithCompactionRules to add custom rules alongside
+	// the built-in defaults. Rules are tried in order; first match wins.
+	fmt.Println("=== Pattern 1: Custom rules ===")
+	fmt.Println("sdk.Open(pack, prompt,")
+	fmt.Println("    sdk.WithCompactionRules(")
+	fmt.Println("        &SearchResultRule{},      // custom: domain-specific search folding")
+	fmt.Println("        stage.CollapsePairs(),     // built-in: collapse superseded pairs")
+	fmt.Println("        stage.FoldToolResults(),   // built-in: generic fallback")
+	fmt.Println("    ),")
+	fmt.Println(")")
+
+	// Pattern 2: Use WithCompactionStrategy to replace the compactor entirely.
+	fmt.Println("\n=== Pattern 2: Custom strategy (logging decorator) ===")
+	fmt.Println("sdk.Open(pack, prompt,")
+	fmt.Println("    sdk.WithCompactionStrategy(&LoggingCompactor{")
+	fmt.Println("        Inner: &stage.ContextCompactor{")
+	fmt.Println("            BudgetTokens:   128000,")
+	fmt.Println("            Rules: []stage.CompactionRule{")
+	fmt.Println("                &SearchResultRule{},")
+	fmt.Println("                stage.FoldToolResults(),")
+	fmt.Println("            },")
+	fmt.Println("        },")
+	fmt.Println("    }),")
+	fmt.Println(")")
+
+	// Pattern 3: Disable compaction entirely
+	fmt.Println("\n=== Pattern 3: Disable compaction ===")
+	fmt.Println("sdk.Open(pack, prompt, sdk.WithCompaction(false))")
+
+	// Demonstrate the custom rule in action
+	fmt.Println("\n=== Demo: SearchResultRule folding ===")
+	rule := &SearchResultRule{}
+	msg := types.Message{
+		Role:    "tool",
+		Content: "src/main.go:10:func main() {\nsrc/config.go:5:type Config struct {\nsrc/handler.go:20:func Handle() {\nsrc/utils.go:1:package utils\n",
+		ToolResult: &types.MessageToolResult{
+			ID:   "call-1",
+			Name: "search",
+		},
+	}
+	ctx := &stage.CompactionContext{}
+	if rule.CanFold(&msg, 0, ctx) {
+		folded, _ := rule.Fold(&msg, 0, ctx)
+		fmt.Println("Original:", len(msg.Content), "bytes")
+		fmt.Println("Folded:  ", folded)
+	}
+
+	// Demonstrate the logging compactor
+	fmt.Println("\n=== Demo: LoggingCompactor ===")
+	inner := &stage.ContextCompactor{
+		BudgetTokens:   100,
+		Threshold:      0.50,
+		PinRecentCount: 2,
+		Rules: []stage.CompactionRule{
+			&SearchResultRule{},
+			stage.FoldToolResults(),
+		},
+	}
+	lc := &LoggingCompactor{Inner: inner}
+
+	msgs := []types.Message{
+		{Role: "user", Content: "search for main"},
+		msg,
+		{Role: "assistant", Content: "found matches"},
+		{Role: "user", Content: "next"},
+	}
+	result := lc.Compact(msgs, 5000) // pretend 5000 tokens (above 50 budget)
+	fmt.Printf("Result: %d messages folded, %d → %d tokens\n",
+		result.MessagesFolded, result.OriginalTokens, result.CompactedTokens)
+
+	// Verify the actual SDK options compile
+	_ = sdk.WithCompactionRules(&SearchResultRule{}, stage.CollapsePairs(), stage.FoldToolResults())
+	_ = sdk.WithCompactionStrategy(lc)
+	_ = sdk.WithCompaction(false)
+
+	fmt.Println("\nAll patterns compile and work correctly.")
+}

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -77,6 +77,14 @@ type Config struct {
 	// nil = default (enabled), false = disabled.
 	CompactionEnabled *bool
 
+	// CompactionStrategy replaces the default compactor entirely.
+	// Mutually exclusive with CompactionRules.
+	CompactionStrategy stage.CompactionStrategy
+
+	// CompactionRules configures custom rules on the default ContextCompactor.
+	// Mutually exclusive with CompactionStrategy.
+	CompactionRules []stage.CompactionRule
+
 	// ContextWindow is the hot window size for RAG context assembly.
 	// When > 0, ContextAssemblyStage + IncrementalSaveStage replace the
 	// standard StateStoreLoad/Save stages.
@@ -355,17 +363,9 @@ func buildProviderStages(cfg *Config) ([]stage.Stage, error) {
 			MessageLog:       cfg.MessageLog,
 			MessageLogConvID: cfg.ConversationID,
 		}
-		// Auto-configure compactor (default-on) unless explicitly disabled
+		// Configure compaction strategy
 		if cfg.CompactionEnabled == nil || *cfg.CompactionEnabled {
-			budgetTokens := stage.DefaultBudgetTokens
-			if cwp, ok := cfg.Provider.(providers.ContextWindowProvider); ok {
-				if v := cwp.MaxContextTokens(); v > 0 {
-					budgetTokens = v
-				}
-			}
-			providerConfig.Compactor = &stage.ContextCompactor{
-				BudgetTokens: budgetTokens,
-			}
+			providerConfig.Compactor = buildCompactionStrategy(cfg)
 		}
 		return []stage.Stage{stage.NewProviderStageWithHooks(
 			cfg.Provider,
@@ -436,4 +436,30 @@ func convertTruncationStrategy(strategy string) stage.TruncationStrategy {
 	default:
 		return stage.TruncateOldest
 	}
+}
+
+// buildCompactionStrategy creates the appropriate compaction strategy from config.
+func buildCompactionStrategy(cfg *Config) stage.CompactionStrategy {
+	// User-provided strategy takes precedence
+	if cfg.CompactionStrategy != nil {
+		return cfg.CompactionStrategy
+	}
+
+	budgetTokens := stage.DefaultBudgetTokens
+	if cwp, ok := cfg.Provider.(providers.ContextWindowProvider); ok {
+		if v := cwp.MaxContextTokens(); v > 0 {
+			budgetTokens = v
+		}
+	}
+
+	compactor := &stage.ContextCompactor{
+		BudgetTokensValue: budgetTokens,
+	}
+
+	// User-provided rules replace the defaults
+	if len(cfg.CompactionRules) > 0 {
+		compactor.Rules = cfg.CompactionRules
+	}
+
+	return compactor
 }

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -453,7 +453,7 @@ func buildCompactionStrategy(cfg *Config) stage.CompactionStrategy {
 	}
 
 	compactor := &stage.ContextCompactor{
-		BudgetTokensValue: budgetTokens,
+		BudgetTokens: budgetTokens,
 	}
 
 	// User-provided rules replace the defaults

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -210,6 +210,12 @@ type config struct {
 
 	// Compaction control (nil = default enabled, false = disabled)
 	compactionEnabled *bool
+
+	// Custom compaction strategy (replaces default ContextCompactor entirely)
+	compactionStrategy stage.CompactionStrategy
+
+	// Custom compaction rules (used with default ContextCompactor)
+	compactionRules []stage.CompactionRule
 }
 
 // buildHookRegistry creates a hooks.Registry from the configured hooks.
@@ -829,6 +835,29 @@ func WithLogger(l *slog.Logger) Option {
 func WithCompaction(enabled bool) Option {
 	return func(c *config) error {
 		c.compactionEnabled = &enabled
+		return nil
+	}
+}
+
+// WithCompactionStrategy replaces the default context compactor with a
+// custom CompactionStrategy implementation. This is mutually exclusive
+// with WithCompactionRules — the last one set wins.
+func WithCompactionStrategy(strategy stage.CompactionStrategy) Option {
+	return func(c *config) error {
+		c.compactionStrategy = strategy
+		c.compactionRules = nil // mutually exclusive
+		return nil
+	}
+}
+
+// WithCompactionRules configures the default ContextCompactor with custom
+// rules. Rules are applied in order; first match wins. This replaces the
+// default rules (FoldToolResults). This is mutually exclusive with
+// WithCompactionStrategy — the last one set wins.
+func WithCompactionRules(rules ...stage.CompactionRule) Option {
+	return func(c *config) error {
+		c.compactionRules = rules
+		c.compactionStrategy = nil // mutually exclusive
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

- **CompactionStrategy interface**: Top-level interface (`Compact()` + `BudgetTokens()`) so users can replace the entire compaction algorithm (e.g., LLM summarization, custom logic)
- **CompactionRule interface**: Pluggable per-message transforms within the default `ContextCompactor`. Rules applied in order; first match wins. Supports extra removal indices for pair collapse.
- **FoldToolResults rule**: Existing behavior extracted to `compactor_fold.go` — default when no rules configured
- **CollapsePairs rule**: Detects superseded assistant+tool pairs (same tool name + args called later) and collapses both messages to a single-line summary
- **SDK options**: `WithCompactionStrategy(strategy)` replaces entirely, `WithCompactionRules(rules...)` customizes rules on default compactor
- `ProviderConfig.Compactor` changed from `*ContextCompactor` to `CompactionStrategy` interface

Builds on #788 (compactor completion).

## Test plan

- [x] Strategy interface compile-time check and mock strategy test
- [x] Custom rule replaces default folding behavior
- [x] Rule ordering: first match wins (second rule not called)
- [x] Default FoldToolResults rule used when no rules configured
- [x] CollapsePairs: superseded pairs collapsed, message count reduced
- [x] CollapsePairs: different args don't trigger collapse
- [x] CollapsePairs: errors and already-compacted messages skipped
- [x] All existing compactor + provider stage tests pass
- [x] Pre-commit checks pass (lint, build, tests, coverage ≥ 80%)
- [ ] CI green
