### PR TITLE
feat: RFC 0009 Phase 1 — terminal states + loop guards

### DIFF
--- a/runtime/CLAUDE.md
+++ b/runtime/CLAUDE.md
@@ -1,0 +1,75 @@
+# Runtime Module — Claude Code Instructions
+
+## Role
+
+The runtime is PromptKit's core library. It defines all interfaces, executes LLM calls, manages tools, runs pipelines, and handles state. **Runtime never imports SDK or Arena** — it is the foundation that both depend on.
+
+## Key Invariant
+
+**Runtime has zero dependencies on `sdk/` or `tools/arena/`**. All extensibility is via interfaces that higher-level modules implement. If you need to add functionality that both SDK and Arena use, it belongs here.
+
+## Architecture Overview
+
+```
+runtime/
+├── tools/         # Tool registry, executors, descriptors
+├── pipeline/stage/ # Pipeline DAG, stages, ProviderStage (LLM+tool loop)
+├── workflow/      # State machine, transitions, artifacts, budgets
+├── providers/     # LLM provider interfaces + implementations
+├── events/        # EventBus, Emitter, 40+ event types
+├── hooks/         # ProviderHook, ToolHook, SessionHook
+├── statestore/    # Store interface, MessageLog, optional interfaces
+├── prompt/        # Registry, pack loading, template engine
+├── types/         # Shared types (Message, ContentPart, CostInfo)
+├── tokenizer/     # Heuristic token counting
+└── ...            # audio, stt, tts, mcp, variables, etc.
+```
+
+## Tool Execution Model
+
+Everything flows through the `tools.Executor` interface:
+
+```go
+type Executor interface {
+    Execute(ctx context.Context, descriptor *ToolDescriptor, args json.RawMessage) (json.RawMessage, error)
+    Name() string
+}
+```
+
+**Mode-based dispatch**: Each tool has a `Mode` field. The Registry looks up `executors[tool.Mode]` to find the right executor. Built-in modes: `mock`, `live` (HTTP), `mcp`, `client`, `local`. Custom modes work automatically — register an executor with `Name()` matching the mode string.
+
+**SDK's `OnTool()` handlers are wrapped in a `localExecutor`** that implements `Executor`. Arena registers executors directly. Both paths converge at `Registry.Execute()`.
+
+## Pipeline & ProviderStage
+
+The ProviderStage runs the LLM-tool loop:
+
+1. Call provider (Predict/PredictWithTools)
+2. If response has tool calls → execute via Registry → append results → loop
+3. Between rounds: compaction, cost budget check, idle timeout reset
+4. Max 50 rounds (configurable via ToolPolicy.MaxRounds)
+
+**Key config on ProviderConfig**: `Compactor CompactionStrategy`, `MessageLog`, `MessageLogConvID`
+
+## Workflow State Machine
+
+`runtime/workflow/` owns the state machine, transitions, visit counting, budgets, and artifacts. The `workflow__transition` tool descriptor is built here (`transition_tool.go`), but **handlers are wired by consumers** (SDK, Arena) because they have different execution semantics.
+
+**ProcessEvent returns `(*TransitionResult, error)`** — redirects (max_visits) are successful transitions, not errors.
+
+## Adding New Functionality
+
+- **New tool executor**: Implement `Executor`, register via `Registry.RegisterExecutor()`
+- **New event type**: Add to `events/types.go`, add emitter method, subscribe in consumers
+- **New hook type**: Define interface in `hooks/`, add to Registry, call from appropriate stage
+- **New pipeline stage**: Implement `Stage` interface, wire in `sdk/internal/pipeline/builder.go`
+- **New provider capability**: Define optional interface (like `ContextWindowProvider`), type-assert in consumers
+- **New statestore capability**: Define optional interface (like `MessageLog`), type-assert in pipeline stages
+
+## Testing
+
+```bash
+go test ./runtime/... -v -race -count=1
+```
+
+Runtime tests are self-contained — no external services needed. Mock providers and in-memory stores are used throughout.

--- a/runtime/SERVICE.md
+++ b/runtime/SERVICE.md
@@ -1,0 +1,96 @@
+# Runtime Module — Service Responsibilities
+
+## Ownership
+
+The runtime owns all core abstractions, interfaces, and execution logic. It is the single source of truth for how tools execute, how pipelines run, how providers are called, and how state machines transition.
+
+## Responsibilities
+
+### Tools (`tools/`)
+- **Executor interface** — the universal contract for tool execution
+- **Registry** — tool descriptor cache, executor dispatch by Mode, validation, rate limiting
+- **Mode system** — built-in (mock, live, mcp, client, local) + custom mode routing
+- **Descriptor schema** — JSON Schema validation for tool inputs/outputs
+- **Async execution** — pending status for human-in-the-loop flows
+
+### Pipeline (`pipeline/stage/`)
+- **Stage interface** — Transform, Accumulate, Generate, Sink, Bidirectional
+- **StreamPipeline** — DAG execution with channel-based element flow
+- **ProviderStage** — LLM call orchestration, multi-round tool loop, compaction, cost budget
+- **Context management** — ContextBuilderStage (truncation), CompactionStrategy (inter-round folding)
+- **State persistence** — StateStoreLoad/Save stages, IncrementalSave, ContextAssembly
+- **Idle timeout** — activity-based cancellation (resets on provider calls, tool execution, chunks)
+
+### Workflow (`workflow/`)
+- **State machine** — Spec, State, Context, StateMachine with thread-safe ProcessEvent
+- **Terminal states** — explicit `Terminal` field + backward-compatible empty-OnEvent detection
+- **Loop guards** — max_visits, on_max_visits redirect, VisitCounts tracking
+- **Budgets** — max_total_visits, max_tool_calls, max_wall_time_sec from engine block
+- **Artifacts** — ArtifactDef, SetArtifact/GetArtifact, append/replace modes, transition snapshots
+- **TransitionResult** — structured return with redirect metadata
+- **Tool descriptors** — `RegisterTransitionTool` builds the schema; handlers wired by consumers
+- **Validation** — version, entry state, event targets, loop guard rules
+
+### Providers (`providers/`)
+- **Provider interface** — Predict, PredictStream, CalculateCost
+- **Optional interfaces** — ToolSupport, MultimodalSupport, StreamInputSupport, ContextWindowProvider
+- **Implementations** — Claude, OpenAI, Gemini, Ollama, vLLM, Voyage AI, Imagen, Mock, Replay
+
+### Events (`events/`)
+- **EventBus** — pluggable pub/sub (in-memory default, extensible to NATS/Kafka/Redis)
+- **Emitter** — convenience wrapper stamping execution/session/conversation IDs
+- **40+ event types** — pipeline, stage, provider, tool, validation, context, workflow, multimodal
+
+### Hooks (`hooks/`)
+- **ProviderHook** — BeforeCall/AfterCall interception of LLM requests
+- **ChunkInterceptor** — streaming chunk interception (optional extension of ProviderHook)
+- **ToolHook** — BeforeExecution/AfterExecution interception of tool calls
+- **SessionHook** — session lifecycle (start, update, end)
+- **Decision pattern** — Allow/Deny/Enforced with reason and metadata
+
+### State Store (`statestore/`)
+- **Store interface** — Load/Save/Fork for conversation state
+- **Optional interfaces** — MessageReader (partial reads), MessageAppender (incremental writes), SummaryAccessor, MessageLog (write-through)
+- **Implementations** — MemoryStore (in-memory), RedisStore
+
+### Prompt (`prompt/`)
+- **Registry** — load prompts by task type, variable substitution, model overrides
+- **Repository pattern** — decouples prompt storage from registry logic
+- **Fragment composition** — prompts composed from reusable fragments
+
+### Types (`types/`)
+- **Message** — role, content, parts, tool calls, tool results, cost info
+- **ContentPart** — text, image, audio, video, document
+- **CostInfo** — input/output/cached tokens, costs
+- **ValidationResult** — pass/fail with details
+
+## What Runtime Does NOT Own
+
+- **Pack loading from files** — SDK's `internal/pack/` handles file I/O and JSON parsing
+- **Capability inference** — SDK detects workflow/A2A/skills from pack structure
+- **Deferred transitions** — SDK's workflow conversation defers LLM-initiated transitions
+- **Scenario evaluation** — Arena's engine orchestrates multi-scenario concurrent execution
+- **Tool handler wiring** — consumers wire handlers to tool descriptors (OnTool in SDK, RegisterExecutor in Arena)
+- **Template variable injection** — SDK/Arena inject workflow context, artifacts into prompts
+
+## Behavioral Contracts
+
+### Tool Execution
+- `Registry.Execute()` validates args, routes by Mode, enforces timeout, validates result
+- Executors receive raw `json.RawMessage` args and return raw `json.RawMessage` results
+- MultimodalExecutor extension returns content parts alongside JSON
+- AsyncToolExecutor extension supports pending status for approval flows
+
+### Pipeline Execution
+- Stages run in goroutines, connected by channels
+- Elements flow through: input → stages → output
+- Context cancellation propagates to all stages
+- Idle timeout resets on activity (provider call, tool execution, chunk)
+
+### State Machine
+- ProcessEvent is serialized (write lock)
+- Budget checks run before event resolution
+- Max_visits checks run after event resolution but before recording
+- Redirect targets are NOT checked for their own max_visits (single-hop)
+- Visit count increments for the actual destination (including redirects)
+- Artifact snapshots captured at each transition (when artifacts exist)

--- a/runtime/workflow/artifact_tool.go
+++ b/runtime/workflow/artifact_tool.go
@@ -1,0 +1,138 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// ArtifactToolName is the qualified name of the workflow set_artifact tool.
+const ArtifactToolName = "workflow__set_artifact"
+
+// ArtifactExecutorMode is the executor name for Mode-based routing.
+const ArtifactExecutorMode = "workflow-artifact"
+
+// ArtifactExecutor implements tools.Executor for workflow__set_artifact.
+// Unlike TransitionExecutor, artifact mutations are safe to apply immediately
+// since they only modify the context map without closing/reopening conversations.
+type ArtifactExecutor struct {
+	sm *StateMachine
+}
+
+// NewArtifactExecutor creates an ArtifactExecutor for the given state machine.
+func NewArtifactExecutor(sm *StateMachine) *ArtifactExecutor {
+	return &ArtifactExecutor{sm: sm}
+}
+
+// Name implements tools.Executor.
+func (e *ArtifactExecutor) Name() string { return ArtifactExecutorMode }
+
+// Execute implements tools.Executor. Sets the artifact value on the state machine.
+func (e *ArtifactExecutor) Execute(
+	_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
+	var a struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("failed to parse set_artifact args: %w", err)
+	}
+	if a.Name == "" {
+		return nil, fmt.Errorf("artifact name is required")
+	}
+
+	e.sm.SetArtifact(a.Name, a.Value)
+
+	return json.Marshal(map[string]string{
+		"status":   "artifact_set",
+		"artifact": a.Name,
+	})
+}
+
+// RegisterArtifactTool registers the workflow__set_artifact tool in the given
+// registry. Only registers if the spec declares artifacts on any state.
+func RegisterArtifactTool(registry *tools.Registry, spec *Spec) {
+	if registry == nil || spec == nil {
+		return
+	}
+	// Check if any state declares artifacts
+	hasArtifacts := false
+	for _, state := range spec.States {
+		if len(state.Artifacts) > 0 {
+			hasArtifacts = true
+			break
+		}
+	}
+	if !hasArtifacts {
+		return
+	}
+
+	desc := BuildArtifactToolDescriptor(spec)
+	desc.Mode = ArtifactExecutorMode
+	_ = registry.Register(desc)
+}
+
+// BuildArtifactToolDescriptor creates a tools.ToolDescriptor for the
+// workflow__set_artifact tool, with artifact names as an enum constraint.
+func BuildArtifactToolDescriptor(spec *Spec) *tools.ToolDescriptor {
+	// Collect all artifact names across all states
+	names := collectArtifactNames(spec)
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"enum":        names,
+				"description": "The artifact name to set.",
+			},
+			"value": map[string]any{
+				"type":        "string",
+				"description": "The artifact value.",
+			},
+		},
+		"required": []string{"name", "value"},
+	}
+	schemaJSON, _ := json.Marshal(schema)
+
+	return &tools.ToolDescriptor{
+		Name:        ArtifactToolName,
+		Namespace:   "workflow",
+		Description: "Set a workflow artifact value. Artifacts persist across state transitions.",
+		InputSchema: schemaJSON,
+	}
+}
+
+// collectArtifactNames returns a deduplicated sorted list of artifact names.
+func collectArtifactNames(spec *Spec) []string {
+	seen := map[string]bool{}
+	for _, state := range spec.States {
+		for name := range state.Artifacts {
+			seen[name] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	return SortedStrings(names)
+}
+
+// SortedStrings returns a sorted copy of the input slice.
+func SortedStrings(s []string) []string {
+	cp := make([]string, len(s))
+	copy(cp, s)
+	sortStrings(cp)
+	return cp
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}

--- a/runtime/workflow/artifact_tool.go
+++ b/runtime/workflow/artifact_tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 )
@@ -118,21 +119,6 @@ func collectArtifactNames(spec *Spec) []string {
 	for name := range seen {
 		names = append(names, name)
 	}
-	return SortedStrings(names)
-}
-
-// SortedStrings returns a sorted copy of the input slice.
-func SortedStrings(s []string) []string {
-	cp := make([]string, len(s))
-	copy(cp, s)
-	sortStrings(cp)
-	return cp
-}
-
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j] < s[j-1]; j-- {
-			s[j], s[j-1] = s[j-1], s[j]
-		}
-	}
+	slices.Sort(names)
+	return names
 }

--- a/runtime/workflow/artifact_tool_test.go
+++ b/runtime/workflow/artifact_tool_test.go
@@ -1,0 +1,161 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestArtifactExecutor_SetArtifact(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "t",
+				Artifacts:  map[string]*ArtifactDef{"sha": {Type: "text/plain"}},
+			},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewArtifactExecutor(sm)
+
+	args, _ := json.Marshal(map[string]string{"name": "sha", "value": "abc123"})
+	result, err := exec.Execute(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["status"] != "artifact_set" {
+		t.Errorf("status = %q, want artifact_set", resp["status"])
+	}
+
+	arts := sm.Artifacts()
+	if arts["sha"] != "abc123" {
+		t.Errorf("artifact sha = %q, want abc123", arts["sha"])
+	}
+}
+
+func TestArtifactExecutor_AppendMode(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "t",
+				Artifacts:  map[string]*ArtifactDef{"log": {Type: "text/plain", Mode: "append"}},
+			},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewArtifactExecutor(sm)
+
+	args1, _ := json.Marshal(map[string]string{"name": "log", "value": "line1\n"})
+	if _, err := exec.Execute(context.Background(), nil, args1); err != nil {
+		t.Fatalf("Execute 1: %v", err)
+	}
+
+	args2, _ := json.Marshal(map[string]string{"name": "log", "value": "line2\n"})
+	if _, err := exec.Execute(context.Background(), nil, args2); err != nil {
+		t.Fatalf("Execute 2: %v", err)
+	}
+
+	arts := sm.Artifacts()
+	if arts["log"] != "line1\nline2\n" {
+		t.Errorf("artifact log = %q, want 'line1\\nline2\\n'", arts["log"])
+	}
+}
+
+func TestArtifactExecutor_EmptyNameError(t *testing.T) {
+	spec := &Spec{Version: 1, Entry: "a", States: map[string]*State{
+		"a": {PromptTask: "t"},
+	}}
+	sm := NewStateMachine(spec)
+	exec := NewArtifactExecutor(sm)
+
+	args, _ := json.Marshal(map[string]string{"name": "", "value": "test"})
+	_, err := exec.Execute(context.Background(), nil, args)
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestRegisterArtifactTool_OnlyWhenArtifactsDeclared(t *testing.T) {
+	// Spec with no artifacts — should not register
+	specNoArt := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States:  map[string]*State{"a": {PromptTask: "t"}},
+	}
+	reg1 := newTestRegistry(t)
+	RegisterArtifactTool(reg1, specNoArt)
+	if reg1.Get(ArtifactToolName) != nil {
+		t.Error("artifact tool should not be registered when no artifacts declared")
+	}
+
+	// Spec with artifacts — should register
+	specWithArt := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "t",
+				Artifacts:  map[string]*ArtifactDef{"sha": {Type: "text/plain"}},
+			},
+		},
+	}
+	reg2 := newTestRegistry(t)
+	RegisterArtifactTool(reg2, specWithArt)
+	tool := reg2.Get(ArtifactToolName)
+	if tool == nil {
+		t.Fatal("artifact tool should be registered when artifacts declared")
+	}
+	if tool.Mode != ArtifactExecutorMode {
+		t.Errorf("tool Mode = %q, want %q", tool.Mode, ArtifactExecutorMode)
+	}
+}
+
+func TestBuildArtifactToolDescriptor_EnumConstraint(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", Artifacts: map[string]*ArtifactDef{
+				"sha":    {Type: "text/plain"},
+				"report": {Type: "application/json"},
+			}},
+			"b": {PromptTask: "t", Artifacts: map[string]*ArtifactDef{
+				"sha": {Type: "text/plain"}, // duplicate — should be deduped
+				"log": {Type: "text/plain"},
+			}},
+		},
+	}
+	desc := BuildArtifactToolDescriptor(spec)
+
+	var schema struct {
+		Properties struct {
+			Name struct {
+				Enum []string `json:"enum"`
+			} `json:"name"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(desc.InputSchema, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+
+	names := schema.Properties.Name.Enum
+	if len(names) != 3 {
+		t.Fatalf("expected 3 artifact names, got %d: %v", len(names), names)
+	}
+	// Should be sorted and deduped
+	expected := []string{"log", "report", "sha"}
+	for i, name := range names {
+		if name != expected[i] {
+			t.Errorf("name[%d] = %q, want %q", i, name, expected[i])
+		}
+	}
+}

--- a/runtime/workflow/context.go
+++ b/runtime/workflow/context.go
@@ -14,6 +14,7 @@ func NewContext(entryState string, now time.Time) *Context {
 		CurrentState: entryState,
 		History:      []StateTransition{},
 		Metadata:     map[string]any{},
+		VisitCounts:  map[string]int{entryState: 1},
 		StartedAt:    now,
 		UpdatedAt:    now,
 	}
@@ -32,6 +33,10 @@ func (ctx *Context) RecordTransition(from, to, event string, ts time.Time) {
 		copy(trimmed, ctx.History[len(ctx.History)-MaxHistoryLength:])
 		ctx.History = trimmed
 	}
+	if ctx.VisitCounts == nil {
+		ctx.VisitCounts = make(map[string]int)
+	}
+	ctx.VisitCounts[to]++
 	ctx.CurrentState = to
 	ctx.UpdatedAt = ts
 }
@@ -49,6 +54,12 @@ func (ctx *Context) Clone() *Context {
 	}
 	if ctx.Metadata != nil {
 		c.Metadata = deepCopyMap(ctx.Metadata)
+	}
+	if ctx.VisitCounts != nil {
+		c.VisitCounts = make(map[string]int, len(ctx.VisitCounts))
+		for k, v := range ctx.VisitCounts {
+			c.VisitCounts[k] = v
+		}
 	}
 	return c
 }

--- a/runtime/workflow/context.go
+++ b/runtime/workflow/context.go
@@ -37,6 +37,22 @@ func (ctx *Context) RecordTransition(from, to, event string, ts time.Time) {
 		ctx.VisitCounts = make(map[string]int)
 	}
 	ctx.VisitCounts[to]++
+
+	// Snapshot current artifact values at this transition
+	if len(ctx.Artifacts) > 0 {
+		snapshot := ArtifactSnapshot{
+			FromState: from,
+			ToState:   to,
+			Event:     event,
+			Values:    make(map[string]string, len(ctx.Artifacts)),
+			Timestamp: ts,
+		}
+		for k, v := range ctx.Artifacts {
+			snapshot.Values[k] = v
+		}
+		ctx.ArtifactHistory = append(ctx.ArtifactHistory, snapshot)
+	}
+
 	ctx.CurrentState = to
 	ctx.UpdatedAt = ts
 }
@@ -60,6 +76,24 @@ func (ctx *Context) Clone() *Context {
 		c.VisitCounts = make(map[string]int, len(ctx.VisitCounts))
 		for k, v := range ctx.VisitCounts {
 			c.VisitCounts[k] = v
+		}
+	}
+	if ctx.Artifacts != nil {
+		c.Artifacts = make(map[string]string, len(ctx.Artifacts))
+		for k, v := range ctx.Artifacts {
+			c.Artifacts[k] = v
+		}
+	}
+	if ctx.ArtifactHistory != nil {
+		c.ArtifactHistory = make([]ArtifactSnapshot, len(ctx.ArtifactHistory))
+		for i, s := range ctx.ArtifactHistory {
+			c.ArtifactHistory[i] = s
+			if s.Values != nil {
+				c.ArtifactHistory[i].Values = make(map[string]string, len(s.Values))
+				for k, v := range s.Values {
+					c.ArtifactHistory[i].Values[k] = v
+				}
+			}
 		}
 	}
 	return c
@@ -117,4 +151,21 @@ func (ctx *Context) TotalVisits() int {
 // IncrementToolCalls adds n to the workflow-wide tool call counter.
 func (ctx *Context) IncrementToolCalls(n int) {
 	ctx.TotalToolCalls += n
+}
+
+// SetArtifact sets an artifact value, respecting the mode (replace or append).
+func (ctx *Context) SetArtifact(name, value, mode string) {
+	if ctx.Artifacts == nil {
+		ctx.Artifacts = make(map[string]string)
+	}
+	if mode == "append" {
+		ctx.Artifacts[name] += value
+	} else {
+		ctx.Artifacts[name] = value
+	}
+}
+
+// GetArtifact returns an artifact value, or empty string if not set.
+func (ctx *Context) GetArtifact(name string) string {
+	return ctx.Artifacts[name]
 }

--- a/runtime/workflow/context.go
+++ b/runtime/workflow/context.go
@@ -44,9 +44,10 @@ func (ctx *Context) RecordTransition(from, to, event string, ts time.Time) {
 // Clone returns a deep copy of the Context.
 func (ctx *Context) Clone() *Context {
 	c := &Context{
-		CurrentState: ctx.CurrentState,
-		StartedAt:    ctx.StartedAt,
-		UpdatedAt:    ctx.UpdatedAt,
+		CurrentState:   ctx.CurrentState,
+		TotalToolCalls: ctx.TotalToolCalls,
+		StartedAt:      ctx.StartedAt,
+		UpdatedAt:      ctx.UpdatedAt,
 	}
 	if ctx.History != nil {
 		c.History = make([]StateTransition, len(ctx.History))
@@ -102,4 +103,18 @@ func (ctx *Context) LastTransition() *StateTransition {
 	}
 	t := ctx.History[len(ctx.History)-1]
 	return &t
+}
+
+// TotalVisits returns the sum of all per-state visit counts.
+func (ctx *Context) TotalVisits() int {
+	total := 0
+	for _, v := range ctx.VisitCounts {
+		total += v
+	}
+	return total
+}
+
+// IncrementToolCalls adds n to the workflow-wide tool call counter.
+func (ctx *Context) IncrementToolCalls(n int) {
+	ctx.TotalToolCalls += n
 }

--- a/runtime/workflow/machine.go
+++ b/runtime/workflow/machine.go
@@ -23,10 +23,12 @@ type TimeFunc func() time.Time
 
 // StateMachine manages workflow state transitions.
 type StateMachine struct {
-	mu      sync.RWMutex
-	spec    *Spec
-	context *Context
-	now     TimeFunc
+	mu         sync.RWMutex
+	spec       *Spec
+	context    *Context
+	now        TimeFunc
+	budget     *Budget
+	budgetOnce sync.Once
 }
 
 // NewStateMachine creates a state machine from a workflow spec.
@@ -237,10 +239,11 @@ func (sm *StateMachine) artifactMode(name string) string {
 // checkBudgetLocked checks workflow-level budget limits.
 // Caller must hold the write lock.
 func (sm *StateMachine) checkBudgetLocked() error {
-	budget := sm.parseBudget()
-	if budget == nil {
+	sm.budgetOnce.Do(func() { sm.budget = sm.parseBudgetFromSpec() })
+	if sm.budget == nil {
 		return nil
 	}
+	budget := sm.budget
 	if budget.MaxTotalVisits > 0 && sm.context.TotalVisits() >= budget.MaxTotalVisits {
 		return fmt.Errorf("%w: total visits %d reached limit %d",
 			ErrBudgetExhausted, sm.context.TotalVisits(), budget.MaxTotalVisits)
@@ -259,8 +262,8 @@ func (sm *StateMachine) checkBudgetLocked() error {
 	return nil
 }
 
-// parseBudget extracts the Budget from Spec.Engine["budget"], if present.
-func (sm *StateMachine) parseBudget() *Budget {
+// parseBudgetFromSpec extracts the Budget from Spec.Engine["budget"], if present.
+func (sm *StateMachine) parseBudgetFromSpec() *Budget {
 	if sm.spec.Engine == nil {
 		return nil
 	}

--- a/runtime/workflow/machine.go
+++ b/runtime/workflow/machine.go
@@ -87,8 +87,8 @@ func (sm *StateMachine) ProcessEvent(event string) (*TransitionResult, error) {
 			ErrInvalidEvent, sm.context.CurrentState)
 	}
 
-	if len(state.OnEvent) == 0 {
-		return nil, fmt.Errorf("%w: state %q has no transitions",
+	if state.Terminal || len(state.OnEvent) == 0 {
+		return nil, fmt.Errorf("%w: state %q is terminal",
 			ErrTerminalState, sm.context.CurrentState)
 	}
 

--- a/runtime/workflow/machine.go
+++ b/runtime/workflow/machine.go
@@ -191,6 +191,49 @@ func (sm *StateMachine) IncrementToolCalls(n int) {
 	sm.context.IncrementToolCalls(n)
 }
 
+// SetArtifact sets an artifact value on the workflow context.
+// The mode is looked up from the spec's artifact definitions for the
+// current state. Thread-safe.
+func (sm *StateMachine) SetArtifact(name, value string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	mode := sm.artifactMode(name)
+	sm.context.SetArtifact(name, value, mode)
+}
+
+// Artifacts returns a snapshot of the current artifact values.
+func (sm *StateMachine) Artifacts() map[string]string {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	if sm.context.Artifacts == nil {
+		return nil
+	}
+	cp := make(map[string]string, len(sm.context.Artifacts))
+	for k, v := range sm.context.Artifacts {
+		cp[k] = v
+	}
+	return cp
+}
+
+// artifactMode returns the mode for an artifact by searching the current
+// state's artifact defs first, then all states in the spec.
+// Caller must hold at least a read lock.
+func (sm *StateMachine) artifactMode(name string) string {
+	// Check current state first
+	if state := sm.spec.States[sm.context.CurrentState]; state != nil {
+		if def := state.Artifacts[name]; def != nil {
+			return def.Mode
+		}
+	}
+	// Fall back to any state that declares this artifact
+	for _, state := range sm.spec.States {
+		if def := state.Artifacts[name]; def != nil {
+			return def.Mode
+		}
+	}
+	return "" // default = replace
+}
+
 // checkBudgetLocked checks workflow-level budget limits.
 // Caller must hold the write lock.
 func (sm *StateMachine) checkBudgetLocked() error {

--- a/runtime/workflow/machine.go
+++ b/runtime/workflow/machine.go
@@ -74,33 +74,70 @@ func (sm *StateMachine) CurrentPromptTask() string {
 }
 
 // ProcessEvent applies an event and transitions to the target state.
-func (sm *StateMachine) ProcessEvent(event string) error {
+// Returns a TransitionResult describing the transition (including any
+// max_visits redirect). Returns ErrMaxVisitsExceeded when the target
+// state's visit limit is reached and no on_max_visits fallback is set.
+func (sm *StateMachine) ProcessEvent(event string) (*TransitionResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	state := sm.spec.States[sm.context.CurrentState]
 	if state == nil {
-		return fmt.Errorf("%w: state %q not found in spec", ErrInvalidEvent, sm.context.CurrentState)
+		return nil, fmt.Errorf("%w: state %q not found in spec",
+			ErrInvalidEvent, sm.context.CurrentState)
 	}
 
 	if len(state.OnEvent) == 0 {
-		return fmt.Errorf("%w: state %q has no transitions", ErrTerminalState, sm.context.CurrentState)
+		return nil, fmt.Errorf("%w: state %q has no transitions",
+			ErrTerminalState, sm.context.CurrentState)
 	}
 
 	target, ok := state.OnEvent[event]
 	if !ok {
-		return fmt.Errorf("%w: event %q not defined for state %q (available: %v)",
+		return nil, fmt.Errorf("%w: event %q not defined for state %q (available: %v)",
 			ErrInvalidEvent, event, sm.context.CurrentState, sm.availableEventsLocked())
 	}
 
 	fromState := sm.context.CurrentState
+	originalTarget := target
+
+	// Loop guard: check max_visits on the target state before entering it.
+	targetState := sm.spec.States[target]
+	if targetState != nil && targetState.MaxVisits > 0 {
+		visits := sm.context.VisitCounts[target]
+		if visits >= targetState.MaxVisits {
+			if targetState.OnMaxVisits != "" {
+				target = targetState.OnMaxVisits
+			} else {
+				return nil, fmt.Errorf("%w: state %q visited %d times (max %d)",
+					ErrMaxVisitsExceeded, originalTarget, visits, targetState.MaxVisits)
+			}
+		}
+	}
+
 	sm.context.RecordTransition(fromState, target, event, sm.now())
+
+	result := &TransitionResult{
+		From:  fromState,
+		To:    target,
+		Event: event,
+	}
+	if target != originalTarget {
+		result.Redirected = true
+		result.RedirectReason = fmt.Sprintf("max_visits (%d) reached for %q",
+			targetState.MaxVisits, originalTarget)
+		result.OriginalTarget = originalTarget
+	}
+
 	logger.Info("workflow state transition",
-		"from", fromState, "to", target, "event", event)
-	return nil
+		"from", fromState, "to", target, "event", event,
+		"redirected", result.Redirected)
+	return result, nil
 }
 
-// IsTerminal returns true if the current state has no outgoing transitions.
+// IsTerminal returns true if the current state is terminal.
+// A state is terminal when explicitly marked (Terminal: true) or
+// when it has no outgoing transitions (backward compatible).
 func (sm *StateMachine) IsTerminal() bool {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
@@ -108,7 +145,7 @@ func (sm *StateMachine) IsTerminal() bool {
 	if state == nil {
 		return true
 	}
-	return len(state.OnEvent) == 0
+	return state.Terminal || len(state.OnEvent) == 0
 }
 
 // AvailableEvents returns the set of valid events for the current state, sorted.

--- a/runtime/workflow/machine.go
+++ b/runtime/workflow/machine.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -77,9 +78,15 @@ func (sm *StateMachine) CurrentPromptTask() string {
 // Returns a TransitionResult describing the transition (including any
 // max_visits redirect). Returns ErrMaxVisitsExceeded when the target
 // state's visit limit is reached and no on_max_visits fallback is set.
+// Returns ErrBudgetExhausted when a workflow-level budget limit is reached.
 func (sm *StateMachine) ProcessEvent(event string) (*TransitionResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+
+	// Budget check runs before event resolution.
+	if err := sm.checkBudgetLocked(); err != nil {
+		return nil, err
+	}
 
 	state := sm.spec.States[sm.context.CurrentState]
 	if state == nil {
@@ -174,4 +181,60 @@ func (sm *StateMachine) Context() *Context {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	return sm.context.Clone()
+}
+
+// IncrementToolCalls adds n to the workflow-wide tool call counter.
+// Thread-safe; intended to be called by the SDK after tool executions.
+func (sm *StateMachine) IncrementToolCalls(n int) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.context.IncrementToolCalls(n)
+}
+
+// checkBudgetLocked checks workflow-level budget limits.
+// Caller must hold the write lock.
+func (sm *StateMachine) checkBudgetLocked() error {
+	budget := sm.parseBudget()
+	if budget == nil {
+		return nil
+	}
+	if budget.MaxTotalVisits > 0 && sm.context.TotalVisits() >= budget.MaxTotalVisits {
+		return fmt.Errorf("%w: total visits %d reached limit %d",
+			ErrBudgetExhausted, sm.context.TotalVisits(), budget.MaxTotalVisits)
+	}
+	if budget.MaxToolCalls > 0 && sm.context.TotalToolCalls >= budget.MaxToolCalls {
+		return fmt.Errorf("%w: tool calls %d reached limit %d",
+			ErrBudgetExhausted, sm.context.TotalToolCalls, budget.MaxToolCalls)
+	}
+	if budget.MaxWallTimeSec > 0 {
+		elapsed := sm.now().Sub(sm.context.StartedAt)
+		if int(elapsed.Seconds()) >= budget.MaxWallTimeSec {
+			return fmt.Errorf("%w: wall time %ds reached limit %ds",
+				ErrBudgetExhausted, int(elapsed.Seconds()), budget.MaxWallTimeSec)
+		}
+	}
+	return nil
+}
+
+// parseBudget extracts the Budget from Spec.Engine["budget"], if present.
+func (sm *StateMachine) parseBudget() *Budget {
+	if sm.spec.Engine == nil {
+		return nil
+	}
+	raw, ok := sm.spec.Engine["budget"]
+	if !ok || raw == nil {
+		return nil
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var b Budget
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil
+	}
+	if b.MaxTotalVisits == 0 && b.MaxToolCalls == 0 && b.MaxWallTimeSec == 0 {
+		return nil
+	}
+	return &b
 }

--- a/runtime/workflow/machine_test.go
+++ b/runtime/workflow/machine_test.go
@@ -442,6 +442,31 @@ func TestTerminal_BackwardCompat(t *testing.T) {
 	}
 }
 
+func TestTerminal_WithOnEvent_BlocksTransitions(t *testing.T) {
+	// A state with Terminal: true blocks ProcessEvent even if OnEvent is set.
+	// This ensures consistency between IsTerminal() and ProcessEvent().
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "task_a",
+				Terminal:   true,
+				OnEvent:    map[string]string{"Next": "b"},
+			},
+			"b": {PromptTask: "task_b"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	if !sm.IsTerminal() {
+		t.Error("state a with Terminal: true should be terminal")
+	}
+	_, err := sm.ProcessEvent("Next")
+	if !errors.Is(err, ErrTerminalState) {
+		t.Errorf("expected ErrTerminalState, got: %v", err)
+	}
+}
+
 func TestMaxVisits_RedirectOnExceeded(t *testing.T) {
 	spec := &Spec{
 		Version: 1,

--- a/runtime/workflow/machine_test.go
+++ b/runtime/workflow/machine_test.go
@@ -798,3 +798,183 @@ func TestTotalVisits(t *testing.T) {
 		t.Errorf("TotalVisits = %d, want 3", ctx.TotalVisits())
 	}
 }
+
+// --- Artifact tests ---
+
+func TestArtifact_SetAndGet(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "t",
+				Artifacts: map[string]*ArtifactDef{
+					"commit_sha": {Type: "text/plain"},
+				},
+				OnEvent: map[string]string{"Go": "b"},
+			},
+			"b": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	sm.SetArtifact("commit_sha", "abc123")
+
+	arts := sm.Artifacts()
+	if arts["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha = %q, want %q", arts["commit_sha"], "abc123")
+	}
+}
+
+func TestArtifact_AppendMode(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "t",
+				Artifacts: map[string]*ArtifactDef{
+					"log": {Type: "text/plain", Mode: "append"},
+				},
+			},
+		},
+	}
+	sm := NewStateMachine(spec)
+	sm.SetArtifact("log", "line1\n")
+	sm.SetArtifact("log", "line2\n")
+
+	arts := sm.Artifacts()
+	if arts["log"] != "line1\nline2\n" {
+		t.Errorf("log = %q, want %q", arts["log"], "line1\nline2\n")
+	}
+}
+
+func TestArtifact_ReplaceMode(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "t",
+				Artifacts: map[string]*ArtifactDef{
+					"result": {Type: "text/plain"}, // default = replace
+				},
+			},
+		},
+	}
+	sm := NewStateMachine(spec)
+	sm.SetArtifact("result", "first")
+	sm.SetArtifact("result", "second")
+
+	arts := sm.Artifacts()
+	if arts["result"] != "second" {
+		t.Errorf("result = %q, want %q", arts["result"], "second")
+	}
+}
+
+func TestArtifact_SnapshotOnTransition(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "t",
+				Artifacts: map[string]*ArtifactDef{
+					"sha": {Type: "text/plain"},
+				},
+				OnEvent: map[string]string{"Go": "b"},
+			},
+			"b": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	sm.SetArtifact("sha", "abc123")
+
+	if _, err := sm.ProcessEvent("Go"); err != nil {
+		t.Fatalf("ProcessEvent: %v", err)
+	}
+
+	ctx := sm.Context()
+	if len(ctx.ArtifactHistory) != 1 {
+		t.Fatalf("ArtifactHistory length = %d, want 1", len(ctx.ArtifactHistory))
+	}
+	snap := ctx.ArtifactHistory[0]
+	if snap.FromState != "a" || snap.ToState != "b" {
+		t.Errorf("snapshot states = %q→%q, want a→b", snap.FromState, snap.ToState)
+	}
+	if snap.Values["sha"] != "abc123" {
+		t.Errorf("snapshot sha = %q, want %q", snap.Values["sha"], "abc123")
+	}
+}
+
+func TestArtifact_NoSnapshotWhenEmpty(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	// No artifacts set
+	if _, err := sm.ProcessEvent("Go"); err != nil {
+		t.Fatalf("ProcessEvent: %v", err)
+	}
+
+	ctx := sm.Context()
+	if len(ctx.ArtifactHistory) != 0 {
+		t.Errorf("ArtifactHistory length = %d, want 0 (no artifacts set)", len(ctx.ArtifactHistory))
+	}
+}
+
+func TestArtifact_CloneDeepCopies(t *testing.T) {
+	ctx := NewContext("a", time.Now())
+	ctx.SetArtifact("key", "original", "")
+	ctx.ArtifactHistory = append(ctx.ArtifactHistory, ArtifactSnapshot{
+		Values: map[string]string{"key": "v1"},
+	})
+
+	clone := ctx.Clone()
+
+	// Mutating original should not affect clone
+	ctx.Artifacts["key"] = "mutated"
+	ctx.ArtifactHistory[0].Values["key"] = "mutated"
+
+	if clone.Artifacts["key"] != "original" {
+		t.Error("Clone should deep-copy Artifacts")
+	}
+	if clone.ArtifactHistory[0].Values["key"] != "v1" {
+		t.Error("Clone should deep-copy ArtifactHistory values")
+	}
+}
+
+func TestArtifact_CrossStateScope(t *testing.T) {
+	// Artifacts are workflow-scoped: setting in state A is visible in state B
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {
+				PromptTask: "t",
+				Artifacts:  map[string]*ArtifactDef{"sha": {Type: "text/plain"}},
+				OnEvent:    map[string]string{"Go": "b"},
+			},
+			"b": {
+				PromptTask: "t",
+				Artifacts:  map[string]*ArtifactDef{"sha": {Type: "text/plain"}},
+			},
+		},
+	}
+	sm := NewStateMachine(spec)
+	sm.SetArtifact("sha", "abc123")
+
+	if _, err := sm.ProcessEvent("Go"); err != nil {
+		t.Fatalf("ProcessEvent: %v", err)
+	}
+
+	// After transitioning to B, the artifact is still accessible
+	arts := sm.Artifacts()
+	if arts["sha"] != "abc123" {
+		t.Errorf("artifact sha = %q after transition, want %q", arts["sha"], "abc123")
+	}
+}

--- a/runtime/workflow/machine_test.go
+++ b/runtime/workflow/machine_test.go
@@ -25,7 +25,7 @@ func branchingSpec() *Spec {
 		Entry:   "start",
 		States: map[string]*State{
 			"start": {PromptTask: "triage", OnEvent: map[string]string{
-				"ToBilling":  "billing",
+				"ToBilling":   "billing",
 				"ToTechnical": "technical",
 			}},
 			"billing":   {PromptTask: "billing_task"},
@@ -69,7 +69,7 @@ func TestLinearWorkflow(t *testing.T) {
 	sm := NewStateMachine(linearSpec()).WithTimeFunc(func() time.Time { return fixedTime() })
 
 	// a -> b
-	if err := sm.ProcessEvent("Next"); err != nil {
+	if _, err := sm.ProcessEvent("Next"); err != nil {
 		t.Fatalf("ProcessEvent(Next): %v", err)
 	}
 	if sm.CurrentState() != "b" {
@@ -83,7 +83,7 @@ func TestLinearWorkflow(t *testing.T) {
 	}
 
 	// b -> c
-	if err := sm.ProcessEvent("Next"); err != nil {
+	if _, err := sm.ProcessEvent("Next"); err != nil {
 		t.Fatalf("ProcessEvent(Next): %v", err)
 	}
 	if sm.CurrentState() != "c" {
@@ -94,7 +94,7 @@ func TestLinearWorkflow(t *testing.T) {
 	}
 
 	// c is terminal — further events should fail
-	err := sm.ProcessEvent("Next")
+	_, err := sm.ProcessEvent("Next")
 	if !errors.Is(err, ErrTerminalState) {
 		t.Errorf("expected ErrTerminalState, got: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestLinearWorkflow(t *testing.T) {
 func TestBranchingWorkflow(t *testing.T) {
 	sm := NewStateMachine(branchingSpec())
 
-	if err := sm.ProcessEvent("ToBilling"); err != nil {
+	if _, err := sm.ProcessEvent("ToBilling"); err != nil {
 		t.Fatalf("ProcessEvent(ToBilling): %v", err)
 	}
 	if sm.CurrentState() != "billing" {
@@ -115,7 +115,7 @@ func TestBranchingWorkflow(t *testing.T) {
 
 	// Start fresh and go the other way
 	sm2 := NewStateMachine(branchingSpec())
-	if err := sm2.ProcessEvent("ToTechnical"); err != nil {
+	if _, err := sm2.ProcessEvent("ToTechnical"); err != nil {
 		t.Fatalf("ProcessEvent(ToTechnical): %v", err)
 	}
 	if sm2.CurrentState() != "technical" {
@@ -127,24 +127,24 @@ func TestLoopingWorkflow(t *testing.T) {
 	sm := NewStateMachine(loopingSpec())
 
 	// draft -> review -> draft -> review -> done
-	if err := sm.ProcessEvent("Review"); err != nil {
+	if _, err := sm.ProcessEvent("Review"); err != nil {
 		t.Fatal(err)
 	}
 	if sm.CurrentState() != "review" {
 		t.Fatalf("CurrentState = %q, want review", sm.CurrentState())
 	}
 
-	if err := sm.ProcessEvent("Revise"); err != nil {
+	if _, err := sm.ProcessEvent("Revise"); err != nil {
 		t.Fatal(err)
 	}
 	if sm.CurrentState() != "draft" {
 		t.Fatalf("CurrentState = %q, want draft", sm.CurrentState())
 	}
 
-	if err := sm.ProcessEvent("Review"); err != nil {
+	if _, err := sm.ProcessEvent("Review"); err != nil {
 		t.Fatal(err)
 	}
-	if err := sm.ProcessEvent("Approve"); err != nil {
+	if _, err := sm.ProcessEvent("Approve"); err != nil {
 		t.Fatal(err)
 	}
 	if sm.CurrentState() != "done" {
@@ -162,7 +162,7 @@ func TestLoopingWorkflow(t *testing.T) {
 
 func TestInvalidEvent(t *testing.T) {
 	sm := NewStateMachine(linearSpec())
-	err := sm.ProcessEvent("Nonexistent")
+	_, err := sm.ProcessEvent("Nonexistent")
 	if !errors.Is(err, ErrInvalidEvent) {
 		t.Errorf("expected ErrInvalidEvent, got: %v", err)
 	}
@@ -185,8 +185,8 @@ func TestAvailableEvents(t *testing.T) {
 
 	// Terminal state has no events
 	sm2 := NewStateMachine(linearSpec())
-	_ = sm2.ProcessEvent("Next")
-	_ = sm2.ProcessEvent("Next")
+	_, _ = sm2.ProcessEvent("Next")
+	_, _ = sm2.ProcessEvent("Next")
 	if events := sm2.AvailableEvents(); events != nil {
 		t.Errorf("terminal state AvailableEvents = %v, want nil", events)
 	}
@@ -194,7 +194,7 @@ func TestAvailableEvents(t *testing.T) {
 
 func TestContextSnapshot(t *testing.T) {
 	sm := NewStateMachine(linearSpec()).WithTimeFunc(func() time.Time { return fixedTime() })
-	_ = sm.ProcessEvent("Next")
+	_, _ = sm.ProcessEvent("Next")
 
 	ctx := sm.Context()
 	if ctx.CurrentState != "b" {
@@ -214,7 +214,7 @@ func TestContextSnapshot(t *testing.T) {
 func TestRestoreFromContext(t *testing.T) {
 	spec := linearSpec()
 	sm := NewStateMachine(spec).WithTimeFunc(func() time.Time { return fixedTime() })
-	_ = sm.ProcessEvent("Next") // a -> b
+	_, _ = sm.ProcessEvent("Next") // a -> b
 
 	// Persist and restore
 	savedCtx := sm.Context()
@@ -228,7 +228,7 @@ func TestRestoreFromContext(t *testing.T) {
 	}
 
 	// Continue from restored state
-	if err := sm2.ProcessEvent("Next"); err != nil {
+	if _, err := sm2.ProcessEvent("Next"); err != nil {
 		t.Fatalf("ProcessEvent after restore: %v", err)
 	}
 	if sm2.CurrentState() != "c" {
@@ -254,8 +254,8 @@ func TestTransitionHistoryTimestamps(t *testing.T) {
 		return t
 	})
 
-	_ = sm.ProcessEvent("Next")
-	_ = sm.ProcessEvent("Next")
+	_, _ = sm.ProcessEvent("Next")
+	_, _ = sm.ProcessEvent("Next")
 
 	ctx := sm.Context()
 	if !ctx.History[0].Timestamp.Equal(times[0]) {
@@ -287,7 +287,7 @@ func stateNameForIndex(i int) string {
 
 func TestConcurrentReads(t *testing.T) {
 	sm := NewStateMachine(loopingSpec())
-	_ = sm.ProcessEvent("Review")
+	_, _ = sm.ProcessEvent("Review")
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
@@ -318,9 +318,9 @@ func TestConcurrentProcessEvent(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < 50; j++ {
 				// Try all possible events; ignore errors from invalid state combos
-				_ = sm.ProcessEvent("Review")
-				_ = sm.ProcessEvent("Revise")
-				_ = sm.ProcessEvent("Approve")
+				_, _ = sm.ProcessEvent("Review")
+				_, _ = sm.ProcessEvent("Revise")
+				_, _ = sm.ProcessEvent("Approve")
 			}
 		}()
 	}
@@ -345,8 +345,8 @@ func TestConcurrentReadsDuringWrites(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
-				_ = sm.ProcessEvent("Review")
-				_ = sm.ProcessEvent("Revise")
+				_, _ = sm.ProcessEvent("Review")
+				_, _ = sm.ProcessEvent("Revise")
 			}
 		}()
 	}
@@ -381,8 +381,8 @@ func TestConcurrentContextSnapshot(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = sm.ProcessEvent("Review")
-			_ = sm.ProcessEvent("Revise")
+			_, _ = sm.ProcessEvent("Review")
+			_, _ = sm.ProcessEvent("Revise")
 		}()
 	}
 	for i := 0; i < 20; i++ {
@@ -402,5 +402,227 @@ func TestConcurrentContextSnapshot(t *testing.T) {
 		if snap.CurrentState != "draft" && snap.CurrentState != "review" && snap.CurrentState != "done" {
 			t.Errorf("snapshot %d has invalid state %q", i, snap.CurrentState)
 		}
+	}
+}
+
+func TestTerminal_ExplicitField(t *testing.T) {
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "task_a", OnEvent: map[string]string{"Next": "b"}},
+			"b": {PromptTask: "task_b", Terminal: true},
+		},
+	}
+	sm := NewStateMachine(spec)
+	if _, err := sm.ProcessEvent("Next"); err != nil {
+		t.Fatalf("ProcessEvent(Next): %v", err)
+	}
+	if !sm.IsTerminal() {
+		t.Error("state b with Terminal:true should be terminal")
+	}
+}
+
+func TestTerminal_BackwardCompat(t *testing.T) {
+	// A state with empty OnEvent (no Terminal field set) is still terminal.
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "task_a", OnEvent: map[string]string{"Next": "b"}},
+			"b": {PromptTask: "task_b"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	if _, err := sm.ProcessEvent("Next"); err != nil {
+		t.Fatalf("ProcessEvent(Next): %v", err)
+	}
+	if !sm.IsTerminal() {
+		t.Error("state b with empty OnEvent should be terminal (backward compat)")
+	}
+}
+
+func TestMaxVisits_RedirectOnExceeded(t *testing.T) {
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "task_a", OnEvent: map[string]string{"Loop": "b"}},
+			"b": {
+				PromptTask:  "task_b",
+				MaxVisits:   2,
+				OnMaxVisits: "c",
+				OnEvent:     map[string]string{"Back": "a"},
+			},
+			"c": {PromptTask: "task_c"},
+		},
+	}
+	sm := NewStateMachine(spec)
+
+	// Visit b twice (MaxVisits=2)
+	if _, err := sm.ProcessEvent("Loop"); err != nil { // a -> b (visit 1)
+		t.Fatal(err)
+	}
+	if sm.CurrentState() != "b" {
+		t.Fatalf("expected b, got %q", sm.CurrentState())
+	}
+	if _, err := sm.ProcessEvent("Back"); err != nil { // b -> a
+		t.Fatal(err)
+	}
+	if _, err := sm.ProcessEvent("Loop"); err != nil { // a -> b (visit 2)
+		t.Fatal(err)
+	}
+	if sm.CurrentState() != "b" {
+		t.Fatalf("expected b, got %q", sm.CurrentState())
+	}
+	if _, err := sm.ProcessEvent("Back"); err != nil { // b -> a
+		t.Fatal(err)
+	}
+
+	// Third attempt should redirect to c
+	result, err := sm.ProcessEvent("Loop") // a -> redirect to c
+	if err != nil {
+		t.Fatalf("expected redirect, got error: %v", err)
+	}
+	if sm.CurrentState() != "c" {
+		t.Errorf("expected redirect to c, got %q", sm.CurrentState())
+	}
+	if !result.Redirected {
+		t.Error("expected Redirected=true")
+	}
+	if result.OriginalTarget != "b" {
+		t.Errorf("OriginalTarget = %q, want %q", result.OriginalTarget, "b")
+	}
+}
+
+func TestMaxVisits_ErrorWhenNoFallback(t *testing.T) {
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "task_a", OnEvent: map[string]string{"Loop": "b"}},
+			"b": {
+				PromptTask: "task_b",
+				MaxVisits:  1,
+				OnEvent:    map[string]string{"Back": "a"},
+			},
+		},
+	}
+	sm := NewStateMachine(spec)
+
+	// First visit succeeds
+	if _, err := sm.ProcessEvent("Loop"); err != nil { // a -> b (visit 1)
+		t.Fatal(err)
+	}
+	if _, err := sm.ProcessEvent("Back"); err != nil { // b -> a
+		t.Fatal(err)
+	}
+
+	// Second attempt should fail — no OnMaxVisits fallback
+	_, err := sm.ProcessEvent("Loop")
+	if !errors.Is(err, ErrMaxVisitsExceeded) {
+		t.Errorf("expected ErrMaxVisitsExceeded, got: %v", err)
+	}
+	// State should not change on error
+	if sm.CurrentState() != "a" {
+		t.Errorf("state should remain a on error, got %q", sm.CurrentState())
+	}
+}
+
+func TestMaxVisits_EntryStateCounted(t *testing.T) {
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "task_a", OnEvent: map[string]string{"Next": "b"}},
+			"b": {PromptTask: "task_b"},
+		},
+	}
+	sm := NewStateMachine(spec)
+
+	ctx := sm.Context()
+	if ctx.VisitCounts["a"] != 1 {
+		t.Errorf("entry state visit count = %d, want 1", ctx.VisitCounts["a"])
+	}
+}
+
+func TestMaxVisits_RedirectTargetVisitCounted(t *testing.T) {
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "task_a", OnEvent: map[string]string{"Loop": "b"}},
+			"b": {
+				PromptTask:  "task_b",
+				MaxVisits:   1,
+				OnMaxVisits: "c",
+				OnEvent:     map[string]string{"Back": "a"},
+			},
+			"c": {PromptTask: "task_c"},
+		},
+	}
+	sm := NewStateMachine(spec)
+
+	// Visit b once
+	if _, err := sm.ProcessEvent("Loop"); err != nil { // a -> b (visit 1)
+		t.Fatal(err)
+	}
+	if _, err := sm.ProcessEvent("Back"); err != nil { // b -> a
+		t.Fatal(err)
+	}
+
+	// Second attempt redirects to c
+	if _, err := sm.ProcessEvent("Loop"); err != nil { // a -> redirect to c
+		t.Fatal(err)
+	}
+
+	ctx := sm.Context()
+	if ctx.VisitCounts["c"] != 1 {
+		t.Errorf("redirect target visit count = %d, want 1", ctx.VisitCounts["c"])
+	}
+}
+
+func TestProcessEvent_ReturnsTransitionResult(t *testing.T) {
+	sm := NewStateMachine(linearSpec())
+
+	result, err := sm.ProcessEvent("Next") // a -> b
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.From != "a" {
+		t.Errorf("From = %q, want %q", result.From, "a")
+	}
+	if result.To != "b" {
+		t.Errorf("To = %q, want %q", result.To, "b")
+	}
+	if result.Event != "Next" {
+		t.Errorf("Event = %q, want %q", result.Event, "Next")
+	}
+	if result.Redirected {
+		t.Error("expected Redirected=false for normal transition")
+	}
+	if result.OriginalTarget != "" {
+		t.Errorf("OriginalTarget = %q, want empty", result.OriginalTarget)
+	}
+}
+
+func TestVisitCounts_Persisted(t *testing.T) {
+	sm := NewStateMachine(linearSpec())
+	_, _ = sm.ProcessEvent("Next") // a -> b
+
+	ctx := sm.Context()
+	clone := ctx.Clone()
+
+	if clone.VisitCounts["a"] != 1 {
+		t.Errorf("clone VisitCounts[a] = %d, want 1", clone.VisitCounts["a"])
+	}
+	if clone.VisitCounts["b"] != 1 {
+		t.Errorf("clone VisitCounts[b] = %d, want 1", clone.VisitCounts["b"])
+	}
+
+	// Mutating original should not affect clone
+	ctx.VisitCounts["a"] = 999
+	if clone.VisitCounts["a"] != 1 {
+		t.Error("Clone() should deep-copy VisitCounts")
 	}
 }

--- a/runtime/workflow/machine_test.go
+++ b/runtime/workflow/machine_test.go
@@ -651,3 +651,150 @@ func TestVisitCounts_Persisted(t *testing.T) {
 		t.Error("Clone() should deep-copy VisitCounts")
 	}
 }
+
+// --- Budget tests ---
+
+func TestBudget_MaxTotalVisitsExhausted(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t", OnEvent: map[string]string{"Back": "a"}},
+		},
+		Engine: map[string]any{
+			"budget": map[string]any{"max_total_visits": 3},
+		},
+	}
+	sm := NewStateMachine(spec)
+	// Entry = "a" (visit 1). Budget = 3 total visits.
+	if _, err := sm.ProcessEvent("Go"); err != nil { // → b (visit 2)
+		t.Fatalf("ProcessEvent(Go): %v", err)
+	}
+	if _, err := sm.ProcessEvent("Back"); err != nil { // → a (visit 3, at limit)
+		t.Fatalf("ProcessEvent(Back): %v", err)
+	}
+
+	// Next transition should fail — total visits would be 4
+	_, err := sm.ProcessEvent("Go")
+	if !errors.Is(err, ErrBudgetExhausted) {
+		t.Fatalf("expected ErrBudgetExhausted, got: %v", err)
+	}
+}
+
+func TestBudget_MaxToolCallsExhausted(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+		Engine: map[string]any{
+			"budget": map[string]any{"max_tool_calls": 5},
+		},
+	}
+	sm := NewStateMachine(spec)
+	sm.IncrementToolCalls(5) // hit the limit
+
+	_, err := sm.ProcessEvent("Go")
+	if !errors.Is(err, ErrBudgetExhausted) {
+		t.Fatalf("expected ErrBudgetExhausted, got: %v", err)
+	}
+}
+
+func TestBudget_MaxWallTimeExhausted(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+		Engine: map[string]any{
+			"budget": map[string]any{"max_wall_time_sec": 10},
+		},
+	}
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	sm := NewStateMachine(spec).WithTimeFunc(func() time.Time {
+		return baseTime.Add(11 * time.Second)
+	})
+	sm.context.StartedAt = baseTime
+
+	_, err := sm.ProcessEvent("Go")
+	if !errors.Is(err, ErrBudgetExhausted) {
+		t.Fatalf("expected ErrBudgetExhausted, got: %v", err)
+	}
+}
+
+func TestBudget_NoBudgetIsUnlimited(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+		// No Engine/budget
+	}
+	sm := NewStateMachine(spec)
+	sm.IncrementToolCalls(9999)
+
+	if _, err := sm.ProcessEvent("Go"); err != nil {
+		t.Fatalf("expected no error without budget, got: %v", err)
+	}
+}
+
+func TestBudget_PrecedesMaxVisits(t *testing.T) {
+	// Budget exhaustion should take precedence over max_visits
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", MaxVisits: 100, OnMaxVisits: "fallback",
+				OnEvent: map[string]string{"Go": "a"}},
+			"fallback": {PromptTask: "t"},
+		},
+		Engine: map[string]any{
+			"budget": map[string]any{"max_total_visits": 2},
+		},
+	}
+	sm := NewStateMachine(spec)
+	// Entry = "a" (visit 1). Budget = 2 total visits.
+	if _, err := sm.ProcessEvent("Go"); err != nil { // → a (visit 2, at budget)
+		t.Fatalf("ProcessEvent(Go): %v", err)
+	}
+	_, err := sm.ProcessEvent("Go") // budget exhausted before max_visits
+	if !errors.Is(err, ErrBudgetExhausted) {
+		t.Fatalf("budget should take precedence, got: %v", err)
+	}
+}
+
+func TestIncrementToolCalls(t *testing.T) {
+	spec := &Spec{Version: 1, Entry: "a", States: map[string]*State{
+		"a": {PromptTask: "t"},
+	}}
+	sm := NewStateMachine(spec)
+	sm.IncrementToolCalls(3)
+	sm.IncrementToolCalls(2)
+
+	ctx := sm.Context()
+	if ctx.TotalToolCalls != 5 {
+		t.Errorf("TotalToolCalls = %d, want 5", ctx.TotalToolCalls)
+	}
+}
+
+func TestTotalVisits(t *testing.T) {
+	ctx := NewContext("a", time.Now())
+	if ctx.TotalVisits() != 1 {
+		t.Errorf("TotalVisits = %d, want 1", ctx.TotalVisits())
+	}
+	ctx.RecordTransition("a", "b", "Go", time.Now())
+	if ctx.TotalVisits() != 2 {
+		t.Errorf("TotalVisits = %d, want 2", ctx.TotalVisits())
+	}
+	ctx.RecordTransition("b", "a", "Back", time.Now())
+	if ctx.TotalVisits() != 3 {
+		t.Errorf("TotalVisits = %d, want 3", ctx.TotalVisits())
+	}
+}

--- a/runtime/workflow/transition_executor.go
+++ b/runtime/workflow/transition_executor.go
@@ -84,6 +84,11 @@ func (e *TransitionExecutor) Pending() *PendingTransition {
 	return e.pending
 }
 
+// StateMachine returns the underlying state machine for metadata access.
+func (e *TransitionExecutor) StateMachine() *StateMachine {
+	return e.sm
+}
+
 // ClearPending discards any pending transition without committing.
 func (e *TransitionExecutor) ClearPending() {
 	e.mu.Lock()

--- a/runtime/workflow/transition_executor.go
+++ b/runtime/workflow/transition_executor.go
@@ -1,0 +1,124 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// TransitionExecutorMode is the executor name used for Mode-based routing.
+const TransitionExecutorMode = "workflow-transition"
+
+// PendingTransition captures a deferred workflow transition from a tool call.
+type PendingTransition struct {
+	Event          string `json:"event"`
+	ContextSummary string `json:"context"`
+}
+
+// TransitionExecutor implements tools.Executor for workflow__transition.
+// It defers the actual state transition (ProcessEvent) until CommitPending
+// is called, ensuring the full pipeline completes before state changes.
+//
+// Both SDK and Arena use this executor. After pipeline/turn execution,
+// the consumer calls CommitPending() to apply the transition.
+type TransitionExecutor struct {
+	mu      sync.Mutex
+	sm      *StateMachine
+	spec    *Spec
+	pending *PendingTransition
+}
+
+// NewTransitionExecutor creates a TransitionExecutor for the given state machine.
+func NewTransitionExecutor(sm *StateMachine, spec *Spec) *TransitionExecutor {
+	return &TransitionExecutor{sm: sm, spec: spec}
+}
+
+// Name implements tools.Executor. Returns the mode name for registry routing.
+func (e *TransitionExecutor) Name() string { return TransitionExecutorMode }
+
+// Execute implements tools.Executor. Stores the transition request and returns
+// a confirmation to the LLM. Does NOT call ProcessEvent — that happens in
+// CommitPending after the pipeline completes.
+func (e *TransitionExecutor) Execute(
+	_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
+	var a struct {
+		Event   string `json:"event"`
+		Context string `json:"context"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("failed to parse transition args: %w", err)
+	}
+
+	e.mu.Lock()
+	e.pending = &PendingTransition{Event: a.Event, ContextSummary: a.Context}
+	e.mu.Unlock()
+
+	return json.Marshal(buildTransitionResponse(a.Event, e.spec))
+}
+
+// CommitPending applies the pending transition by calling ProcessEvent.
+// Returns nil, nil if no transition is pending. After commit, the pending
+// state is cleared. Thread-safe.
+func (e *TransitionExecutor) CommitPending() (*TransitionResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.pending == nil {
+		return nil, nil
+	}
+
+	pt := e.pending
+	e.pending = nil
+
+	return e.sm.ProcessEvent(pt.Event)
+}
+
+// Pending returns the current pending transition, or nil if none.
+func (e *TransitionExecutor) Pending() *PendingTransition {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.pending
+}
+
+// ClearPending discards any pending transition without committing.
+func (e *TransitionExecutor) ClearPending() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.pending = nil
+}
+
+// RegisterForState registers the workflow__transition tool in the given
+// registry for the specified state, with Mode set for executor routing.
+// Skips terminal states and externally orchestrated states.
+func (e *TransitionExecutor) RegisterForState(registry *tools.Registry, state *State) {
+	if registry == nil || state == nil || len(state.OnEvent) == 0 {
+		return
+	}
+	if state.Terminal || state.Orchestration == OrchestrationExternal {
+		return
+	}
+	evts := SortedEvents(state.OnEvent)
+	desc := BuildTransitionToolDescriptor(evts)
+	desc.Mode = TransitionExecutorMode
+	_ = registry.Register(desc)
+}
+
+// buildTransitionResponse creates the LLM-facing response for a scheduled transition.
+func buildTransitionResponse(event string, spec *Spec) map[string]string {
+	result := map[string]string{
+		"status": "transition_scheduled",
+		"event":  event,
+	}
+	// Look up target state for informative response
+	for _, state := range spec.States {
+		if target, ok := state.OnEvent[event]; ok {
+			result["target_state"] = target
+			break
+		}
+	}
+	return result
+}

--- a/runtime/workflow/transition_executor_test.go
+++ b/runtime/workflow/transition_executor_test.go
@@ -1,0 +1,235 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+func TestTransitionExecutor_DeferredCommit(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	// Execute stores pending but does NOT transition
+	args, _ := json.Marshal(map[string]string{"event": "Go", "context": "test"})
+	result, err := exec.Execute(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// State should still be "a"
+	if sm.CurrentState() != "a" {
+		t.Fatalf("state should still be 'a' after Execute, got %q", sm.CurrentState())
+	}
+
+	// Result should indicate scheduled
+	var resp map[string]string
+	if err := json.Unmarshal(result, &resp); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if resp["status"] != "transition_scheduled" {
+		t.Errorf("status = %q, want transition_scheduled", resp["status"])
+	}
+
+	// Pending should be set
+	pending := exec.Pending()
+	if pending == nil || pending.Event != "Go" {
+		t.Fatalf("pending = %v, want event=Go", pending)
+	}
+
+	// CommitPending applies the transition
+	tr, err := exec.CommitPending()
+	if err != nil {
+		t.Fatalf("CommitPending: %v", err)
+	}
+	if tr.To != "b" {
+		t.Errorf("transition to = %q, want 'b'", tr.To)
+	}
+	if sm.CurrentState() != "b" {
+		t.Errorf("state after commit = %q, want 'b'", sm.CurrentState())
+	}
+
+	// Pending should be cleared
+	if exec.Pending() != nil {
+		t.Error("pending should be nil after commit")
+	}
+}
+
+func TestTransitionExecutor_CommitPendingNoop(t *testing.T) {
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	// CommitPending with no pending transition is a no-op
+	tr, err := exec.CommitPending()
+	if err != nil {
+		t.Fatalf("CommitPending: %v", err)
+	}
+	if tr != nil {
+		t.Errorf("expected nil TransitionResult, got %+v", tr)
+	}
+}
+
+func TestTransitionExecutor_CommitPendingError(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	// Store a bad event
+	args, _ := json.Marshal(map[string]string{"event": "BadEvent", "context": ""})
+	_, err := exec.Execute(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// CommitPending should fail
+	_, err = exec.CommitPending()
+	if err == nil {
+		t.Fatal("expected error for invalid event")
+	}
+	if !errors.Is(err, ErrInvalidEvent) {
+		t.Errorf("expected ErrInvalidEvent, got: %v", err)
+	}
+
+	// Pending should be cleared even on error
+	if exec.Pending() != nil {
+		t.Error("pending should be cleared after failed commit")
+	}
+}
+
+func TestTransitionExecutor_ClearPending(t *testing.T) {
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	args, _ := json.Marshal(map[string]string{"event": "Go", "context": ""})
+	_, _ = exec.Execute(context.Background(), nil, args)
+
+	exec.ClearPending()
+	if exec.Pending() != nil {
+		t.Error("pending should be nil after ClearPending")
+	}
+	if sm.CurrentState() != "a" {
+		t.Error("state should remain 'a' after ClearPending")
+	}
+}
+
+func TestTransitionExecutor_RegisterForState(t *testing.T) {
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	registry := newTestRegistry(t)
+	exec.RegisterForState(registry, spec.States["a"])
+
+	tool := registry.Get(TransitionToolName)
+	if tool == nil {
+		t.Fatal("transition tool should be registered")
+	}
+	if tool.Mode != TransitionExecutorMode {
+		t.Errorf("tool Mode = %q, want %q", tool.Mode, TransitionExecutorMode)
+	}
+}
+
+func TestTransitionExecutor_SkipsTerminalState(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", Terminal: true},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	registry := newTestRegistry(t)
+	exec.RegisterForState(registry, spec.States["a"])
+
+	if registry.Get(TransitionToolName) != nil {
+		t.Error("transition tool should not be registered for terminal state")
+	}
+}
+
+func TestTransitionExecutor_MaxVisitsRedirect(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Loop": "b"}},
+			"b": {PromptTask: "t", MaxVisits: 1, OnMaxVisits: "done",
+				OnEvent: map[string]string{"Loop": "b"}},
+			"done": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	// First: a → b (visit 1)
+	args, _ := json.Marshal(map[string]string{"event": "Loop", "context": ""})
+	_, _ = exec.Execute(context.Background(), nil, args)
+	tr, err := exec.CommitPending()
+	if err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+	if tr.To != "b" {
+		t.Fatalf("first commit to = %q, want 'b'", tr.To)
+	}
+
+	// Second: b → b, but max_visits=1, redirect to done
+	args2, _ := json.Marshal(map[string]string{"event": "Loop", "context": ""})
+	_, _ = exec.Execute(context.Background(), nil, args2)
+	tr2, err := exec.CommitPending()
+	if err != nil {
+		t.Fatalf("second commit: %v", err)
+	}
+	if tr2.To != "done" {
+		t.Errorf("second commit to = %q, want 'done'", tr2.To)
+	}
+	if !tr2.Redirected {
+		t.Error("expected redirect")
+	}
+}
+
+// newTestRegistry creates a minimal tools.Registry for testing.
+func newTestRegistry(t *testing.T) *tools.Registry {
+	t.Helper()
+	return tools.NewRegistry()
+}

--- a/runtime/workflow/types.go
+++ b/runtime/workflow/types.go
@@ -56,15 +56,25 @@ type Spec struct {
 
 // State defines a single state in the workflow state machine.
 type State struct {
-	PromptTask    string            `json:"prompt_task"`
-	Description   string            `json:"description,omitempty"`
-	OnEvent       map[string]string `json:"on_event,omitempty"`
-	Persistence   Persistence       `json:"persistence,omitempty"`
-	Orchestration Orchestration     `json:"orchestration,omitempty"`
-	Skills        string            `json:"skills,omitempty"`
-	Terminal      bool              `json:"terminal,omitempty"`      // RFC 0009: explicit terminal marker
-	MaxVisits     int               `json:"max_visits,omitempty"`    // RFC 0009: max times this state can be entered
-	OnMaxVisits   string            `json:"on_max_visits,omitempty"` // RFC 0009: redirect target when max_visits reached
+	PromptTask    string                  `json:"prompt_task"`
+	Description   string                  `json:"description,omitempty"`
+	OnEvent       map[string]string       `json:"on_event,omitempty"`
+	Persistence   Persistence             `json:"persistence,omitempty"`
+	Orchestration Orchestration           `json:"orchestration,omitempty"`
+	Skills        string                  `json:"skills,omitempty"`
+	Terminal      bool                    `json:"terminal,omitempty"`      // RFC 0009: explicit terminal marker
+	MaxVisits     int                     `json:"max_visits,omitempty"`    // RFC 0009: max times this state can be entered
+	OnMaxVisits   string                  `json:"on_max_visits,omitempty"` // RFC 0009: redirect on max_visits
+	Artifacts     map[string]*ArtifactDef `json:"artifacts,omitempty"`     // RFC 0009: artifact slot declarations
+}
+
+// ArtifactDef declares a named artifact slot on a workflow state.
+// Artifacts are workflow-scoped: if two states declare the same name, they
+// reference the same artifact. Values are accessible as {{artifacts.<name>}}.
+type ArtifactDef struct {
+	Type        string `json:"type"`                  // MIME type (e.g., "text/plain", "application/json")
+	Description string `json:"description,omitempty"` // What the artifact contains
+	Mode        string `json:"mode,omitempty"`        // "replace" (default) or "append"
 }
 
 // TransitionResult is returned by ProcessEvent to communicate what happened.
@@ -100,13 +110,24 @@ const (
 
 // Context holds the runtime state of a workflow execution.
 type Context struct {
-	CurrentState   string            `json:"current_state"`
-	History        []StateTransition `json:"history"`
-	Metadata       map[string]any    `json:"metadata,omitempty"`
-	VisitCounts    map[string]int    `json:"visit_counts,omitempty"`     // RFC 0009: per-state visit counts
-	TotalToolCalls int               `json:"total_tool_calls,omitempty"` // RFC 0009: workflow-wide tool call count
-	StartedAt      time.Time         `json:"started_at"`
-	UpdatedAt      time.Time         `json:"updated_at"`
+	CurrentState    string             `json:"current_state"`
+	History         []StateTransition  `json:"history"`
+	Metadata        map[string]any     `json:"metadata,omitempty"`
+	VisitCounts     map[string]int     `json:"visit_counts,omitempty"`     // RFC 0009: per-state visit counts
+	TotalToolCalls  int                `json:"total_tool_calls,omitempty"` // RFC 0009: workflow-wide tool call count
+	Artifacts       map[string]string  `json:"artifacts,omitempty"`        // RFC 0009: current artifact values
+	ArtifactHistory []ArtifactSnapshot `json:"artifact_history,omitempty"` // RFC 0009: artifact values at each transition
+	StartedAt       time.Time          `json:"started_at"`
+	UpdatedAt       time.Time          `json:"updated_at"`
+}
+
+// ArtifactSnapshot captures artifact values at a specific state transition.
+type ArtifactSnapshot struct {
+	FromState string            `json:"from_state"`
+	ToState   string            `json:"to_state"`
+	Event     string            `json:"event"`
+	Values    map[string]string `json:"values"`
+	Timestamp time.Time         `json:"timestamp"`
 }
 
 // StateTransition records a single state transition.

--- a/runtime/workflow/types.go
+++ b/runtime/workflow/types.go
@@ -11,9 +11,22 @@ import (
 	"time"
 )
 
-// ErrMaxVisitsExceeded is returned when a state's max_visits limit is reached
-// and no on_max_visits fallback is configured.
-var ErrMaxVisitsExceeded = errors.New("max visits exceeded")
+// Sentinel errors for workflow execution.
+var (
+	// ErrMaxVisitsExceeded is returned when a state's max_visits limit is reached
+	// and no on_max_visits fallback is configured.
+	ErrMaxVisitsExceeded = errors.New("max visits exceeded")
+
+	// ErrBudgetExhausted is returned when a workflow-level budget limit is reached.
+	ErrBudgetExhausted = errors.New("workflow budget exhausted")
+)
+
+// Budget defines workflow-level resource limits from the engine block.
+type Budget struct {
+	MaxTotalVisits int `json:"max_total_visits,omitempty"`
+	MaxToolCalls   int `json:"max_tool_calls,omitempty"`
+	MaxWallTimeSec int `json:"max_wall_time_sec,omitempty"`
+}
 
 // ParseConfig parses an untyped workflow config (typically from config.Workflow
 // which is stored as interface{}) into a typed Spec. Returns nil, nil when
@@ -87,12 +100,13 @@ const (
 
 // Context holds the runtime state of a workflow execution.
 type Context struct {
-	CurrentState string            `json:"current_state"`
-	History      []StateTransition `json:"history"`
-	Metadata     map[string]any    `json:"metadata,omitempty"`
-	VisitCounts  map[string]int    `json:"visit_counts,omitempty"` // RFC 0009: per-state visit counts
-	StartedAt    time.Time         `json:"started_at"`
-	UpdatedAt    time.Time         `json:"updated_at"`
+	CurrentState   string            `json:"current_state"`
+	History        []StateTransition `json:"history"`
+	Metadata       map[string]any    `json:"metadata,omitempty"`
+	VisitCounts    map[string]int    `json:"visit_counts,omitempty"`     // RFC 0009: per-state visit counts
+	TotalToolCalls int               `json:"total_tool_calls,omitempty"` // RFC 0009: workflow-wide tool call count
+	StartedAt      time.Time         `json:"started_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
 }
 
 // StateTransition records a single state transition.

--- a/runtime/workflow/types.go
+++ b/runtime/workflow/types.go
@@ -6,9 +6,14 @@ package workflow
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 )
+
+// ErrMaxVisitsExceeded is returned when a state's max_visits limit is reached
+// and no on_max_visits fallback is configured.
+var ErrMaxVisitsExceeded = errors.New("max visits exceeded")
 
 // ParseConfig parses an untyped workflow config (typically from config.Workflow
 // which is stored as interface{}) into a typed Spec. Returns nil, nil when
@@ -44,6 +49,21 @@ type State struct {
 	Persistence   Persistence       `json:"persistence,omitempty"`
 	Orchestration Orchestration     `json:"orchestration,omitempty"`
 	Skills        string            `json:"skills,omitempty"`
+	Terminal      bool              `json:"terminal,omitempty"`      // RFC 0009: explicit terminal marker
+	MaxVisits     int               `json:"max_visits,omitempty"`    // RFC 0009: max times this state can be entered
+	OnMaxVisits   string            `json:"on_max_visits,omitempty"` // RFC 0009: redirect target when max_visits reached
+}
+
+// TransitionResult is returned by ProcessEvent to communicate what happened.
+// Redirects (e.g., max_visits exceeded → on_max_visits) are successful
+// transitions, not errors.
+type TransitionResult struct {
+	From           string `json:"from"`
+	To             string `json:"to"`
+	Event          string `json:"event"`
+	Redirected     bool   `json:"redirected,omitempty"`
+	RedirectReason string `json:"redirect_reason,omitempty"`
+	OriginalTarget string `json:"original_target,omitempty"`
 }
 
 // Persistence is the storage hint for a workflow state.
@@ -70,6 +90,7 @@ type Context struct {
 	CurrentState string            `json:"current_state"`
 	History      []StateTransition `json:"history"`
 	Metadata     map[string]any    `json:"metadata,omitempty"`
+	VisitCounts  map[string]int    `json:"visit_counts,omitempty"` // RFC 0009: per-state visit counts
 	StartedAt    time.Time         `json:"started_at"`
 	UpdatedAt    time.Time         `json:"updated_at"`
 }

--- a/runtime/workflow/validate.go
+++ b/runtime/workflow/validate.go
@@ -123,18 +123,14 @@ func validateLoopGuards(spec *Spec, name string, state *State, r *ValidationResu
 			name))
 	}
 
-	// on_max_visits must reference an existing state
+	// on_max_visits validation
 	if state.OnMaxVisits != "" {
-		if _, ok := spec.States[state.OnMaxVisits]; !ok {
+		target := spec.States[state.OnMaxVisits]
+		if target == nil {
 			r.Errors = append(r.Errors, fmt.Sprintf(
 				"workflow.states[%q].on_max_visits %q does not exist in states",
 				name, state.OnMaxVisits))
-		}
-	}
-
-	// Warn if on_max_visits target also has max_visits (redirect chain risk)
-	if state.OnMaxVisits != "" {
-		if target := spec.States[state.OnMaxVisits]; target != nil && target.MaxVisits > 0 {
+		} else if target.MaxVisits > 0 {
 			r.Warnings = append(r.Warnings, fmt.Sprintf(
 				"workflow.states[%q].on_max_visits target %q also has max_visits — potential redirect chain",
 				name, state.OnMaxVisits))

--- a/runtime/workflow/validate.go
+++ b/runtime/workflow/validate.go
@@ -39,10 +39,10 @@ func Validate(spec *Spec, promptKeys []string) *ValidationResult {
 	return r
 }
 
-// validateVersion checks rule 1: version must equal 1.
+// validateVersion checks rule 1: version must be 1 or 2.
 func validateVersion(spec *Spec, r *ValidationResult) {
-	if spec.Version != 1 {
-		r.Errors = append(r.Errors, fmt.Sprintf("workflow.version must be 1, got %d", spec.Version))
+	if spec.Version != 1 && spec.Version != 2 {
+		r.Errors = append(r.Errors, fmt.Sprintf("workflow.version must be 1 or 2, got %d", spec.Version))
 	}
 }
 
@@ -71,6 +71,7 @@ func validateStates(spec *Spec, promptSet map[string]bool, r *ValidationResult) 
 		validateEvents(spec, name, state, r)
 		validatePersistence(name, state, r)
 		validateOrchestration(name, state, r)
+		validateLoopGuards(spec, name, state, r)
 	}
 }
 
@@ -110,6 +111,34 @@ func validateOrchestration(name string, state *State, r *ValidationResult) {
 		r.Errors = append(r.Errors, fmt.Sprintf(
 			"workflow.states[%q].orchestration %q is not valid (must be \"internal\", \"external\", or \"hybrid\")",
 			name, state.Orchestration))
+	}
+}
+
+// validateLoopGuards checks RFC 0009 loop guard fields.
+func validateLoopGuards(spec *Spec, name string, state *State, r *ValidationResult) {
+	// Terminal state with transitions is contradictory
+	if state.Terminal && len(state.OnEvent) > 0 {
+		r.Warnings = append(r.Warnings, fmt.Sprintf(
+			"workflow.states[%q]: terminal state has on_event transitions (they will never fire)",
+			name))
+	}
+
+	// on_max_visits must reference an existing state
+	if state.OnMaxVisits != "" {
+		if _, ok := spec.States[state.OnMaxVisits]; !ok {
+			r.Errors = append(r.Errors, fmt.Sprintf(
+				"workflow.states[%q].on_max_visits %q does not exist in states",
+				name, state.OnMaxVisits))
+		}
+	}
+
+	// Warn if on_max_visits target also has max_visits (redirect chain risk)
+	if state.OnMaxVisits != "" {
+		if target := spec.States[state.OnMaxVisits]; target != nil && target.MaxVisits > 0 {
+			r.Warnings = append(r.Warnings, fmt.Sprintf(
+				"workflow.states[%q].on_max_visits target %q also has max_visits — potential redirect chain",
+				name, state.OnMaxVisits))
+		}
 	}
 }
 

--- a/runtime/workflow/validate_test.go
+++ b/runtime/workflow/validate_test.go
@@ -40,14 +40,23 @@ func TestValidate_ValidSpec(t *testing.T) {
 	}
 }
 
-func TestValidate_Rule1_VersionMustBeOne(t *testing.T) {
+func TestValidate_Rule1_VersionMustBeOneOrTwo(t *testing.T) {
+	// Version 1 is valid (tested via validSpec in other tests)
+	// Version 2 is valid (RFC 0009)
 	spec := validSpec()
 	spec.Version = 2
 	r := Validate(spec, allPrompts)
-	if !r.HasErrors() {
-		t.Fatal("expected error for version != 1")
+	if r.HasErrors() {
+		t.Fatalf("version 2 should be valid: %v", r.Errors)
 	}
-	assertContains(t, r.Errors, "version must be 1")
+
+	// Version 3 is invalid
+	spec.Version = 3
+	r = Validate(spec, allPrompts)
+	if !r.HasErrors() {
+		t.Fatal("expected error for version 3")
+	}
+	assertContains(t, r.Errors, "version must be 1 or 2")
 }
 
 func TestValidate_Rule2_StatesNonEmpty(t *testing.T) {

--- a/runtime/workflow/validate_test.go
+++ b/runtime/workflow/validate_test.go
@@ -186,6 +186,58 @@ func TestValidate_MultipleErrors(t *testing.T) {
 	}
 }
 
+func TestValidate_OnMaxVisitsTargetMustExist(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "p1", MaxVisits: 3, OnMaxVisits: "ghost",
+				OnEvent: map[string]string{"Next": "a"}},
+		},
+	}
+	r := Validate(spec, []string{"p1"})
+	if !r.HasErrors() {
+		t.Fatal("expected error for on_max_visits referencing non-existent state")
+	}
+	assertContains(t, r.Errors, "on_max_visits")
+	assertContains(t, r.Errors, "ghost")
+}
+
+func TestValidate_TerminalWithOnEventWarns(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "p1", Terminal: true,
+				OnEvent: map[string]string{"Next": "a"}},
+		},
+	}
+	r := Validate(spec, []string{"p1"})
+	if r.HasErrors() {
+		t.Fatalf("terminal+on_event should be a warning, not error: %v", r.Errors)
+	}
+	assertContains(t, r.Warnings, "terminal")
+}
+
+func TestValidate_RedirectChainWarns(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "p1", MaxVisits: 2, OnMaxVisits: "b",
+				OnEvent: map[string]string{"Next": "a"}},
+			"b": {PromptTask: "p2", MaxVisits: 2, OnMaxVisits: "c",
+				OnEvent: map[string]string{"Next": "a"}},
+			"c": {PromptTask: "p3"},
+		},
+	}
+	r := Validate(spec, []string{"p1", "p2", "p3"})
+	if r.HasErrors() {
+		t.Fatalf("redirect chain should be a warning, not error: %v", r.Errors)
+	}
+	assertContains(t, r.Warnings, "redirect chain")
+}
+
 // --- helpers ---
 
 func assertContains(t *testing.T, strs []string, substr string) {

--- a/sdk/CLAUDE.md
+++ b/sdk/CLAUDE.md
@@ -1,0 +1,92 @@
+# SDK Module — Claude Code Instructions
+
+## Role
+
+The SDK is PromptKit's developer-facing API. It provides `Open()`, `Send()`, and options for building LLM applications from PromptPack files. The SDK composes runtime components into user-friendly abstractions.
+
+## Key Invariant
+
+**The SDK imports runtime but runtime never imports SDK.** The SDK translates developer intent (pack files, options, handlers) into runtime constructs (pipelines, executors, stages).
+
+## Architecture Overview
+
+```
+sdk/
+├── sdk.go                          # Open(), OpenDuplex(), OpenWorkflow() entry points
+├── conversation.go                 # Conversation struct, Send(), pipeline building
+├── workflow.go                     # WorkflowConversation, deferred transitions
+├── workflow_transition_integration.go # transitionInternal(), context carry-forward
+├── capability.go                   # Capability interface, inference, lifecycle
+├── capability_workflow.go          # WorkflowCapability
+├── capability_a2a.go               # A2ACapability
+├── options.go                      # With* option functions
+├── tool_executors.go               # localExecutor, clientExecutor (wraps OnTool → Executor)
+├── internal/
+│   ├── pipeline/builder.go         # Builds runtime pipeline from SDK config
+│   └── pack/                       # SDK's own Pack types (mirrors runtime)
+└── ...
+```
+
+## Critical Design Patterns
+
+### 1. OnTool Wraps in Executor
+
+SDK's `OnTool()` handlers are NOT a separate execution path. They're wrapped in a `localExecutor` implementing `tools.Executor` and registered in the runtime's `tools.Registry`:
+
+```go
+localExec := &localExecutor{handlers: handlersCopy}
+c.toolRegistry.RegisterExecutor(localExec)  // Name() = "local"
+```
+
+The runtime's ProviderStage dispatches to it identically to any other executor. **Do not create parallel execution paths** — always go through `tools.Executor`.
+
+### 2. Pipeline Built Per Send()
+
+Every `Send()` rebuilds the entire pipeline. This enables:
+- Dynamic tool registration between sends
+- Capability registration on first build (guarded by `capabilitiesRegistered`)
+- Handler snapshots at send time
+
+### 3. Deferred Workflow Transitions
+
+When the LLM calls `workflow__transition`, the SDK does NOT execute the transition immediately. It stores a `pendingTransition` and processes it after `Send()` returns the tool result to the LLM. This ensures the LLM sees a consistent response before the state changes.
+
+**This is a fundamental behavioral difference from Arena**, which executes transitions immediately.
+
+### 4. Capability Inference
+
+```go
+inferCapabilities(pack):
+  pack.Workflow != nil  → WorkflowCapability
+  pack.Agents != nil    → A2ACapability
+  pack.Skills != nil    → SkillsCapability
+```
+
+Capabilities are auto-detected from pack structure. Explicit `WithCapability()` options override inference. This reduces boilerplate for common patterns.
+
+### 5. Pack Types Mirror Runtime
+
+`sdk/internal/pack/` defines its own `WorkflowSpec`, `WorkflowState`, etc. rather than importing `runtime/workflow`. This decouples the SDK's package graph from runtime evolution. Conversion happens via `packToRuntimePack()`.
+
+## Adding New Functionality
+
+- **New SDK option**: Add to `options.go` config struct + `With*` function. Wire through `conversation.go` → `internal/pipeline/builder.go`.
+- **New capability**: Implement `Capability` interface. Add inference rule in `capability.go`. Register tools in `RegisterTools()`.
+- **New tool handler type**: Add to `conversation.go` handler maps. Create executor in `tool_executors.go`. Register in `buildPipelineConfig()`.
+- **New workflow tool**: Descriptor belongs in `runtime/workflow/`. Handler wiring belongs here in `registerWorkflowTools()`.
+
+## Common Mistakes to Avoid
+
+- **Don't duplicate runtime interfaces** — use `tools.Executor`, not a parallel dispatch mechanism
+- **Don't import `sdk/` from `runtime/`** — if both need it, it belongs in runtime
+- **Don't cache pipelines across Send() calls** — the per-Send rebuild is intentional
+- **Don't execute workflow transitions immediately** — use the deferred pattern via `pendingTransition`
+
+## Testing
+
+```bash
+go test ./sdk/... -count=1           # All SDK tests
+go test ./sdk/integration/... -v     # Integration tests with mock providers
+```
+
+SDK tests use mock providers — no API keys needed. Workflow integration tests are in `sdk/workflow_test.go`.

--- a/sdk/CLAUDE.md
+++ b/sdk/CLAUDE.md
@@ -49,9 +49,9 @@ Every `Send()` rebuilds the entire pipeline. This enables:
 
 ### 3. Deferred Workflow Transitions
 
-When the LLM calls `workflow__transition`, the SDK does NOT execute the transition immediately. It stores a `pendingTransition` and processes it after `Send()` returns the tool result to the LLM. This ensures the LLM sees a consistent response before the state changes.
+When the LLM calls `workflow__transition`, the runtime's `TransitionExecutor` defers the actual `ProcessEvent` call. The SDK commits it after `Send()` completes via `TransitionExecutor.Pending()` and `CommitPending()`. This ensures the LLM sees a consistent tool response before the state changes.
 
-**This is a fundamental behavioral difference from Arena**, which executes transitions immediately.
+Both SDK and Arena now use the same deferred pattern — the runtime `TransitionExecutor` handles deferral, and each consumer commits at the appropriate point in its turn loop.
 
 ### 4. Capability Inference
 
@@ -80,7 +80,7 @@ Capabilities are auto-detected from pack structure. Explicit `WithCapability()` 
 - **Don't duplicate runtime interfaces** — use `tools.Executor`, not a parallel dispatch mechanism
 - **Don't import `sdk/` from `runtime/`** — if both need it, it belongs in runtime
 - **Don't cache pipelines across Send() calls** — the per-Send rebuild is intentional
-- **Don't execute workflow transitions immediately** — use the deferred pattern via `pendingTransition`
+- **Don't execute workflow transitions immediately** — use the deferred pattern via `TransitionExecutor.Pending()`/`CommitPending()`
 
 ## Testing
 

--- a/sdk/SERVICE.md
+++ b/sdk/SERVICE.md
@@ -1,0 +1,76 @@
+# SDK Module — Service Responsibilities
+
+## Ownership
+
+The SDK owns the developer-facing API surface: conversation lifecycle, options, pack loading, capability inference, and tool handler registration. It translates developer intent into runtime pipelines.
+
+## Responsibilities
+
+### Conversation Lifecycle
+- **Open/OpenDuplex/OpenWorkflow** — create conversations from pack files
+- **Resume** — restore conversations from state store
+- **Send** — execute request/response turns (builds pipeline per call)
+- **Stream** — streaming variant of Send
+- **Close** — cleanup, session hooks, eval dispatch
+
+### Options & Configuration
+- **With* pattern** — ~40 options covering provider, state, context, hooks, capabilities, recording
+- **Cross-option validation** — e.g., WithContextRetrieval requires WithContextWindow
+- **Config → Pipeline translation** — options flow to `internal/pipeline.Config` → runtime stages
+
+### Tool Handler Registration
+- **OnTool / OnToolCtx** — local handlers (mode: "local") wrapped in `localExecutor`
+- **OnClientTool** — deferred client-side handlers (mode: "client") wrapped in `clientExecutor`
+- **OnToolAsync** — human-in-the-loop approval handlers
+- **Handler snapshot at Send time** — consistency within a single pipeline execution
+- **Client handler accessor** — live lookup for deferred tools registered mid-pipeline
+
+### Capability System
+- **Inference** — auto-detect workflow/A2A/skills from pack structure
+- **Merging** — explicit capabilities override inferred ones (by name)
+- **Lifecycle** — Init (receives CapabilityContext) → RegisterTools (on first pipeline build) → Close
+- **WorkflowCapability** — delegates to `runtime/workflow.RegisterTransitionTool`
+- **A2ACapability** — registers agent communication tools
+- **SkillsCapability** — loads and registers skill tools
+
+### Workflow Orchestration
+- **WorkflowConversation** — manages per-state conversations over a StateMachine
+- **Deferred transitions** — LLM-initiated transitions stored as pending, processed after Send completes
+- **Context carry-forward** — summarize previous state's conversation, inject as template variable
+- **State persistence** — persist workflow context to state store at transitions
+- **Tool re-registration** — re-register transition tool for new state's available events
+
+### Pipeline Construction
+- **Stage ordering** — StateLoad → Variables → PromptAssembly → Template → ContextBuilder → Provider → StateSave
+- **Compaction wiring** — auto-configure from provider's ContextWindowProvider or default 128K
+- **Recording stages** — optional input/output capture for session replay
+- **Mode-specific stages** — duplex (ASM), VAD (audio pipeline), text (standard)
+
+## What SDK Does NOT Own
+
+- **Tool execution logic** — runtime's `tools.Executor` and `Registry` own this
+- **LLM call orchestration** — runtime's ProviderStage owns the tool loop
+- **State machine transitions** — runtime's `workflow.StateMachine` owns ProcessEvent
+- **Event emission** — runtime's `events.Emitter` owns event creation
+- **Hook enforcement** — runtime's hooks package owns the Decision pattern
+
+## Behavioral Contracts
+
+### Send() Guarantees
+- Pipeline is rebuilt from scratch on every Send()
+- Tool handlers are snapshot at Send time (local) or live-lookup (client)
+- Capabilities register tools only on first pipeline build
+- Errors from pipeline execution are returned, not swallowed
+
+### Workflow Transition Guarantees
+- LLM-initiated transitions are deferred until after Send() returns the tool result
+- Explicit Transition() calls execute immediately
+- Old conversation is closed before new one opens
+- Context summary is injected as `workflow_context` template variable
+- Workflow context is persisted if state store is configured
+
+### Thread Safety
+- Conversation has RWMutex for closed flag and mode transitions
+- Handler maps have separate mutexes for concurrent reads
+- Each Send() gets independent handler snapshots
+- WorkflowConversation serializes transitions

--- a/sdk/internal/pack/workflow.go
+++ b/sdk/internal/pack/workflow.go
@@ -18,4 +18,7 @@ type WorkflowState struct {
 	Persistence   string            `json:"persistence,omitempty"`
 	Orchestration string            `json:"orchestration,omitempty"`
 	Skills        string            `json:"skills,omitempty"`
+	Terminal      bool              `json:"terminal,omitempty"`      // RFC 0009
+	MaxVisits     int               `json:"max_visits,omitempty"`    // RFC 0009
+	OnMaxVisits   string            `json:"on_max_visits,omitempty"` // RFC 0009
 }

--- a/sdk/internal/pack/workflow.go
+++ b/sdk/internal/pack/workflow.go
@@ -12,13 +12,21 @@ type WorkflowSpec struct {
 
 // WorkflowState is the SDK's mirror of runtime/workflow.WorkflowState.
 type WorkflowState struct {
-	PromptTask    string            `json:"prompt_task"`
-	Description   string            `json:"description,omitempty"`
-	OnEvent       map[string]string `json:"on_event,omitempty"`
-	Persistence   string            `json:"persistence,omitempty"`
-	Orchestration string            `json:"orchestration,omitempty"`
-	Skills        string            `json:"skills,omitempty"`
-	Terminal      bool              `json:"terminal,omitempty"`      // RFC 0009
-	MaxVisits     int               `json:"max_visits,omitempty"`    // RFC 0009
-	OnMaxVisits   string            `json:"on_max_visits,omitempty"` // RFC 0009
+	PromptTask    string                          `json:"prompt_task"`
+	Description   string                          `json:"description,omitempty"`
+	OnEvent       map[string]string               `json:"on_event,omitempty"`
+	Persistence   string                          `json:"persistence,omitempty"`
+	Orchestration string                          `json:"orchestration,omitempty"`
+	Skills        string                          `json:"skills,omitempty"`
+	Terminal      bool                            `json:"terminal,omitempty"`      // RFC 0009
+	MaxVisits     int                             `json:"max_visits,omitempty"`    // RFC 0009
+	OnMaxVisits   string                          `json:"on_max_visits,omitempty"` // RFC 0009
+	Artifacts     map[string]*WorkflowArtifactDef `json:"artifacts,omitempty"`     // RFC 0009
+}
+
+// WorkflowArtifactDef is the SDK's mirror of runtime/workflow.ArtifactDef.
+type WorkflowArtifactDef struct {
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+	Mode        string `json:"mode,omitempty"`
 }

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -47,14 +47,9 @@ type WorkflowConversation struct {
 	workflowID          string
 	contextCarryForward bool
 	workflowCap         *WorkflowCapability
-	pendingTransition   *pendingTransition
+	transExec           *workflow.TransitionExecutor
+	artifactExec        *workflow.ArtifactExecutor
 	closed              bool
-}
-
-// pendingTransition captures an LLM-initiated transition from a tool call.
-type pendingTransition struct {
-	event   string
-	context string
 }
 
 // defaultMaxSummaryMessages is the max messages to include in a carry-forward summary.
@@ -243,7 +238,9 @@ func (wc *WorkflowConversation) Send(ctx context.Context, message any, opts ...S
 		return nil, ErrWorkflowClosed
 	}
 	conv := wc.activeConv
-	wc.pendingTransition = nil
+	if wc.transExec != nil {
+		wc.transExec.ClearPending()
+	}
 	wc.mu.Unlock()
 
 	resp, err := conv.Send(ctx, message, opts...)
@@ -251,18 +248,25 @@ func (wc *WorkflowConversation) Send(ctx context.Context, message any, opts ...S
 		return nil, err
 	}
 
-	// Process pending transition from tool call
+	// Commit any pending transition from a workflow__transition tool call.
+	// The TransitionExecutor deferred the ProcessEvent until now.
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
-	// Re-check closed after re-acquiring lock; Close() may have run while Send was in progress.
 	if wc.closed {
 		return nil, ErrWorkflowClosed
 	}
-	if wc.pendingTransition != nil {
-		pt := wc.pendingTransition
-		wc.pendingTransition = nil
-		if _, transErr := wc.transitionInternal(pt.event, pt.context); transErr != nil {
-			return resp, transErr
+	if wc.transExec != nil {
+		if pending := wc.transExec.Pending(); pending != nil {
+			contextSummary := pending.ContextSummary
+			result, commitErr := wc.transExec.CommitPending()
+			if commitErr != nil {
+				return resp, commitErr
+			}
+			if result != nil {
+				if _, transErr := wc.applyTransition(result, contextSummary); transErr != nil {
+					return resp, transErr
+				}
+			}
 		}
 	}
 	return resp, nil
@@ -298,34 +302,82 @@ func (wc *WorkflowConversation) Transition(event string) (string, error) {
 	return wc.transitionInternal(event, contextSummary)
 }
 
-// registerWorkflowTools registers the workflow__transition tool and handler
-// for the current state on the active conversation.
+// registerWorkflowTools registers the workflow tool executors and descriptors
+// for the current state on the active conversation's tool registry.
 func (wc *WorkflowConversation) registerWorkflowTools() {
+	registry := wc.activeConv.ToolRegistry()
 	state := wc.workflowSpec.States[wc.machine.CurrentState()]
-	if wc.workflowCap != nil {
-		wc.workflowCap.RegisterToolsForState(wc.activeConv.ToolRegistry(), state)
-	}
 
-	// Register tool handler only if the state has events and is not externally orchestrated
-	if state != nil && len(state.OnEvent) > 0 && state.Orchestration != workflow.OrchestrationExternal {
-		wc.activeConv.OnTool(workflow.TransitionToolName, wc.handleTransitionTool)
-	}
+	// Create and register transition executor (deferred commit pattern)
+	wc.transExec = workflow.NewTransitionExecutor(wc.machine, wc.workflowSpec)
+	registry.RegisterExecutor(wc.transExec)
+	wc.transExec.RegisterForState(registry, state)
+
+	// Create and register artifact executor if spec declares artifacts
+	wc.artifactExec = workflow.NewArtifactExecutor(wc.machine)
+	registry.RegisterExecutor(wc.artifactExec)
+	workflow.RegisterArtifactTool(registry, wc.workflowSpec)
 }
 
-// handleTransitionTool processes the workflow__transition tool call from the LLM.
-// It stores the transition request for processing after Send completes.
-func (wc *WorkflowConversation) handleTransitionTool(args map[string]any) (any, error) {
-	event, _ := args["event"].(string)
-	ctx, _ := args["context"].(string)
+// applyTransition handles post-commit transition logic: close old conversation,
+// open new one, re-register tools, persist context, emit events.
+func (wc *WorkflowConversation) applyTransition(
+	result *workflow.TransitionResult, contextSummary string,
+) (string, error) {
+	toState := result.To
 
-	wc.mu.Lock()
-	wc.pendingTransition = &pendingTransition{event: event, context: ctx}
-	wc.mu.Unlock()
+	// Close old conversation
+	if wc.activeConv != nil {
+		_ = wc.activeConv.Close()
+	}
 
-	return transitionResult(event, wc.workflowSpec), nil
+	// Build options, injecting context as a template variable if available
+	opts := wc.opts
+	if contextSummary != "" {
+		opts = append(append([]Option{}, wc.opts...), WithVariables(map[string]string{
+			"workflow_context": contextSummary,
+		}))
+	}
+
+	// Inject artifact values as template variables
+	if arts := wc.machine.Artifacts(); len(arts) > 0 {
+		artVars := make(map[string]string, len(arts))
+		for k, v := range arts {
+			artVars["artifacts."+k] = v
+		}
+		opts = append(append([]Option{}, opts...), WithVariables(artVars))
+	}
+
+	// Open new conversation for the new state
+	promptName := wc.machine.CurrentPromptTask()
+	conv, err := Open(wc.packPath, promptName, opts...)
+	if err != nil {
+		return "", fmt.Errorf("failed to open conversation for state %q (prompt %q): %w",
+			toState, promptName, err)
+	}
+	wc.activeConv = conv
+
+	// Re-register workflow tools for the new state
+	wc.registerWorkflowTools()
+
+	// Persist workflow context if state store is configured
+	if wc.stateStore != nil && wc.workflowID != "" {
+		wc.persistWorkflowContext()
+	}
+
+	// Emit transition event
+	if wc.emitter != nil {
+		wc.emitter.WorkflowTransitioned(result.From, toState, result.Event, promptName)
+		if wc.machine.IsTerminal() {
+			wc.emitter.WorkflowCompleted(toState, wc.machine.Context().TransitionCount())
+		}
+	}
+
+	return toState, nil
 }
 
 // transitionResult builds a response to return to the LLM after a transition tool call.
+// Kept for backward compatibility with explicit Transition() calls.
 func transitionResult(event string, spec *workflow.Spec) map[string]string {
 	result := map[string]string{
 		"status": "transition_scheduled",

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -376,23 +376,6 @@ func (wc *WorkflowConversation) applyTransition(
 	return toState, nil
 }
 
-// transitionResult builds a response to return to the LLM after a transition tool call.
-// Kept for backward compatibility with explicit Transition() calls.
-func transitionResult(event string, spec *workflow.Spec) map[string]string {
-	result := map[string]string{
-		"status": "transition_scheduled",
-		"event":  event,
-	}
-	// Look up the target state for a more informative response
-	for _, state := range spec.States {
-		if target, ok := state.OnEvent[event]; ok {
-			result["target_state"] = target
-			break
-		}
-	}
-	return result
-}
-
 // CurrentState returns the current workflow state name.
 func (wc *WorkflowConversation) CurrentState() string {
 	wc.mu.RLock()

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -975,24 +975,23 @@ func TestHandleTransitionTool(t *testing.T) {
 	}
 	machine := workflow.NewStateMachine(spec)
 
-	wc := &WorkflowConversation{
-		machine:      machine,
-		workflowSpec: spec,
-	}
+	// Use the runtime TransitionExecutor directly (replaces handleTransitionTool)
+	transExec := workflow.NewTransitionExecutor(machine, spec)
 
-	args := map[string]any{
+	args, _ := json.Marshal(map[string]string{
 		"event":   "InfoComplete",
 		"context": "User wants billing help",
-	}
+	})
 
-	result, err := wc.handleTransitionTool(args)
+	result, err := transExec.Execute(context.Background(), nil, args)
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 
-	// Verify pending transition is set
-	assert.NotNil(t, wc.pendingTransition)
-	assert.Equal(t, "InfoComplete", wc.pendingTransition.event)
-	assert.Equal(t, "User wants billing help", wc.pendingTransition.context)
+	// Verify pending transition is set on the executor
+	pending := transExec.Pending()
+	require.NotNil(t, pending)
+	assert.Equal(t, "InfoComplete", pending.Event)
+	assert.Equal(t, "User wants billing help", pending.ContextSummary)
 }
 
 func TestRegisterWorkflowTools_InternalState(t *testing.T) {
@@ -1027,15 +1026,13 @@ func TestRegisterWorkflowTools_InternalState(t *testing.T) {
 
 	wc.registerWorkflowTools()
 
-	// Tool should be registered
+	// Tool should be registered with executor mode
 	tool := conv.ToolRegistry().Get(workflow.TransitionToolName)
 	assert.NotNil(t, tool)
+	assert.Equal(t, workflow.TransitionExecutorMode, tool.Mode)
 
-	// Handler should be registered
-	conv.handlersMu.RLock()
-	_, hasHandler := conv.handlers[workflow.TransitionToolName]
-	conv.handlersMu.RUnlock()
-	assert.True(t, hasHandler)
+	// TransitionExecutor should be created
+	assert.NotNil(t, wc.transExec)
 }
 
 func TestRegisterWorkflowTools_ExternalState(t *testing.T) {
@@ -1171,16 +1168,22 @@ func TestSend_ClearsPendingTransitionBeforeSend(t *testing.T) {
 		States:  map[string]*workflow.State{"s": {PromptTask: "p"}},
 	}
 
+	sm := workflow.NewStateMachine(spec)
+	transExec := workflow.NewTransitionExecutor(sm, spec)
+	// Pre-set a pending transition to verify it gets cleared
+	preArgs, _ := json.Marshal(map[string]string{"event": "stale", "context": "old"})
+	_, _ = transExec.Execute(context.Background(), nil, preArgs)
+
 	wc := &WorkflowConversation{
-		activeConv:        conv,
-		machine:           workflow.NewStateMachine(spec),
-		pendingTransition: &pendingTransition{event: "stale", context: "old"},
+		activeConv: conv,
+		machine:    sm,
+		transExec:  transExec,
 	}
 
 	_, err := wc.Send(context.Background(), "hello")
 	// Send fails because inner conversation is closed
 	assert.ErrorIs(t, err, ErrConversationClosed)
-	// pendingTransition should have been cleared before the send attempt
+	// transExec pending should have been cleared before the send attempt
 }
 
 func TestWorkflowConversation_ConcurrentSendAndTransition(t *testing.T) {

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -929,38 +929,6 @@ func TestWorkflowConversation_ConcurrentReads(t *testing.T) {
 	wg.Wait()
 }
 
-func TestTransitionResult(t *testing.T) {
-	spec := &workflow.Spec{
-		Version: 1,
-		Entry:   "start",
-		States: map[string]*workflow.State{
-			"start": {PromptTask: "p1", OnEvent: map[string]string{"Next": "end"}},
-			"end":   {PromptTask: "p2"},
-		},
-	}
-
-	result := transitionResult("Next", spec)
-	assert.Equal(t, "transition_scheduled", result["status"])
-	assert.Equal(t, "Next", result["event"])
-	assert.Equal(t, "end", result["target_state"])
-}
-
-func TestTransitionResult_UnknownEvent(t *testing.T) {
-	spec := &workflow.Spec{
-		Version: 1,
-		Entry:   "start",
-		States: map[string]*workflow.State{
-			"start": {PromptTask: "p1"},
-		},
-	}
-
-	result := transitionResult("Unknown", spec)
-	assert.Equal(t, "transition_scheduled", result["status"])
-	assert.Equal(t, "Unknown", result["event"])
-	_, hasTarget := result["target_state"]
-	assert.False(t, hasTarget)
-}
-
 func TestHandleTransitionTool(t *testing.T) {
 	spec := &workflow.Spec{
 		Version: 1,

--- a/sdk/workflow_transition_integration.go
+++ b/sdk/workflow_transition_integration.go
@@ -11,13 +11,13 @@ import (
 // This function calls Open() to create a new conversation for the target state,
 // so it requires a valid pack file and is tested via integration tests.
 func (wc *WorkflowConversation) transitionInternal(event, contextSummary string) (string, error) {
-	fromState := wc.machine.CurrentState()
-
-	if err := wc.machine.ProcessEvent(event); err != nil {
+	result, err := wc.machine.ProcessEvent(event)
+	if err != nil {
 		return "", err
 	}
 
-	toState := wc.machine.CurrentState()
+	toState := result.To
+	fromState := result.From
 
 	// Close old conversation
 	if wc.activeConv != nil {

--- a/sdk/workflow_transition_integration.go
+++ b/sdk/workflow_transition_integration.go
@@ -2,62 +2,17 @@ package sdk
 
 import (
 	"context"
-	"fmt"
 )
 
-// transitionInternal is the shared transition logic used by both explicit
-// Transition() and LLM-initiated transitions. Caller must hold wc.mu.
-//
-// This function calls Open() to create a new conversation for the target state,
-// so it requires a valid pack file and is tested via integration tests.
+// transitionInternal handles explicit (caller-initiated) transitions.
+// Calls ProcessEvent directly, then applies the transition.
+// Caller must hold wc.mu.
 func (wc *WorkflowConversation) transitionInternal(event, contextSummary string) (string, error) {
 	result, err := wc.machine.ProcessEvent(event)
 	if err != nil {
 		return "", err
 	}
-
-	toState := result.To
-	fromState := result.From
-
-	// Close old conversation
-	if wc.activeConv != nil {
-		_ = wc.activeConv.Close()
-	}
-
-	// Build options, injecting context as a template variable if available
-	opts := wc.opts
-	if contextSummary != "" {
-		opts = append(append([]Option{}, wc.opts...), WithVariables(map[string]string{
-			"workflow_context": contextSummary,
-		}))
-	}
-
-	// Open new conversation for the new state
-	promptName := wc.machine.CurrentPromptTask()
-	conv, err := Open(wc.packPath, promptName, opts...)
-	if err != nil {
-		return "", fmt.Errorf("failed to open conversation for state %q (prompt %q): %w",
-			toState, promptName, err)
-	}
-	wc.activeConv = conv
-
-	// Register workflow tools for the new state
-	wc.registerWorkflowTools()
-
-	// Persist workflow context if state store is configured and state is not transient
-	if wc.stateStore != nil && wc.workflowID != "" {
-		wc.persistWorkflowContext()
-	}
-
-	// Emit transition event
-	if wc.emitter != nil {
-		wc.emitter.WorkflowTransitioned(fromState, toState, event, promptName)
-		if wc.machine.IsTerminal() {
-			wc.emitter.WorkflowCompleted(toState, wc.machine.Context().TransitionCount())
-		}
-	}
-
-	return toState, nil
+	return wc.applyTransition(result, contextSummary)
 }
 
 // buildContextSummary creates a text summary of the previous state's conversation

--- a/tools/arena/CLAUDE.md
+++ b/tools/arena/CLAUDE.md
@@ -31,21 +31,21 @@ tools/arena/
 
 ## Critical Design Patterns
 
-### 1. Immediate Workflow Transitions (vs SDK's Deferred)
+### 1. Deferred Workflow Transitions
 
-Arena executes workflow transitions **synchronously during tool execution**:
+Arena uses the same deferred transition pattern as the SDK, via the runtime's `TransitionExecutor`. The executor defers `ProcessEvent` during tool execution and commits it after the turn completes:
 
 ```go
 // In workflowTransitionExecutor.Execute():
-tr, err := run.sm.ProcessEvent(event)  // immediate
+// Delegates to TransitionExecutor which defers the transition
+
+// In CommitPendingTransition() — called via PostTurnHook after each turn:
+tr, err := run.transExec.CommitPending()
 run.scenario.TaskType = newState.PromptTask  // update for next turn
-registerTransitionTool(registry, newState)    // re-register for new events
+run.transExec.RegisterForState(registry, newState)  // re-register for new events
 ```
 
-This differs from the SDK which defers transitions until after `Send()`. Arena can do this because:
-- Arena controls the turn loop externally (scripted turns, not interactive)
-- The next turn naturally uses the updated TaskType
-- No need to send a tool result to the LLM before transitioning (Arena manages the conversation)
+Both SDK and Arena now share the same deferred commit pattern — the runtime `TransitionExecutor` handles deferral, and each consumer commits at the appropriate point in its turn loop.
 
 ### 2. Per-Run State Machine Isolation
 

--- a/tools/arena/CLAUDE.md
+++ b/tools/arena/CLAUDE.md
@@ -1,0 +1,121 @@
+# Arena (PromptArena) Module — Claude Code Instructions
+
+## Role
+
+Arena is PromptKit's testing and evaluation framework. It runs scenarios against LLM providers, executes assertions, and produces reports. Arena uses runtime components directly — it does NOT go through the SDK.
+
+## Key Invariant
+
+**Arena imports runtime but never imports SDK.** Arena builds its own pipelines, manages its own tool registry, and handles workflow state machines independently. It uses the same `tools.Registry`, `tools.Executor`, and pipeline stages as the SDK, but wires them differently.
+
+## Architecture Overview
+
+```
+tools/arena/
+├── engine/                         # Core execution engine
+│   ├── engine.go                   # Engine struct, composition root
+│   ├── conversation_executor.go    # Turn-by-turn conversation execution
+│   ├── workflow_tool_executor.go   # Immediate workflow transitions
+│   ├── execution_workflow_integration.go # Workflow init + per-run setup
+│   ├── eval_orchestrator.go        # Assertion/eval dispatch
+│   └── builder_integration.go      # Tool, provider, prompt registry setup
+├── cmd/promptarena/                # CLI entry point
+├── assertions/                     # Built-in assertion handlers
+├── turnexecutors/                  # Pipeline-based turn execution
+├── reader/                         # Config file loading
+├── render/                         # Report generation
+├── results/                        # HTML, JSON, JUnit, Markdown output
+├── tui/                            # Terminal UI
+└── ...
+```
+
+## Critical Design Patterns
+
+### 1. Immediate Workflow Transitions (vs SDK's Deferred)
+
+Arena executes workflow transitions **synchronously during tool execution**:
+
+```go
+// In workflowTransitionExecutor.Execute():
+tr, err := run.sm.ProcessEvent(event)  // immediate
+run.scenario.TaskType = newState.PromptTask  // update for next turn
+registerTransitionTool(registry, newState)    // re-register for new events
+```
+
+This differs from the SDK which defers transitions until after `Send()`. Arena can do this because:
+- Arena controls the turn loop externally (scripted turns, not interactive)
+- The next turn naturally uses the updated TaskType
+- No need to send a tool result to the LLM before transitioning (Arena manages the conversation)
+
+### 2. Per-Run State Machine Isolation
+
+Each scenario execution gets its own `StateMachine` via `RegisterRun(runID, scenario)`:
+
+```go
+type workflowRunState struct {
+    sm          *workflow.StateMachine  // independent per run
+    scenario    *config.Scenario        // mutable TaskType
+    transitions []map[string]any        // transition history
+}
+```
+
+This enables concurrent scenario execution without shared state. Context propagates the run ID: `withWorkflowScenarioID(ctx, runID)`.
+
+### 3. Direct Executor Registration
+
+Arena registers executors directly on the `tools.Registry`, not through a Capability abstraction:
+
+```go
+// In initWorkflow():
+transExec := newWorkflowTransitionExecutor(spec, registry)
+registry.RegisterExecutor(transExec)  // Name() = "workflow-transition"
+registerTransitionTool(registry, entryState)  // sets Mode = "workflow-transition"
+```
+
+The Mode on the tool descriptor routes to the executor via `Registry.getExecutorForTool()`.
+
+### 4. Pipeline Per Turn (not Per Conversation)
+
+Arena builds a fresh pipeline for each turn, not per conversation:
+
+```
+Turn 1: Build pipeline → execute → save results → assertions
+Turn 2: Build pipeline → execute → save results → assertions
+...
+```
+
+This allows per-turn assertion evaluation and state persistence between turns.
+
+### 5. Eval Orchestrator Cloning
+
+Each concurrent run gets a cloned `EvalOrchestrator` to prevent data races:
+
+```go
+runOrch := e.evalOrchestrator.Clone()  // independent metadata per run
+```
+
+The runner (immutable eval defs) is shared; metadata (workflow state, emitter) is per-run.
+
+## Adding New Functionality
+
+- **New tool executor**: Implement `tools.Executor`, register in `initWorkflow()` or `BuildEngineComponents()`
+- **New assertion type**: Add handler in `assertions/`, register in handler registry
+- **New output format**: Implement in `results/`, wire in render pipeline
+- **New workflow tool**: Descriptor in `runtime/workflow/`. Executor in `engine/workflow_tool_executor.go`. Register in `initWorkflow()`.
+
+## Common Mistakes to Avoid
+
+- **Don't import SDK** — Arena and SDK are peers, both consuming runtime
+- **Don't share state machines across runs** — always use `RegisterRun` for per-run isolation
+- **Don't forget to set `desc.Mode`** — Arena's local `registerTransitionTool` sets Mode to route to the custom executor. Without it, the registry can't find the executor.
+- **Don't mutate shared EvalOrchestrator** — always Clone() for concurrent runs
+
+## Testing
+
+```bash
+go test ./tools/arena/... -count=1    # All Arena tests
+
+# Run examples with mock providers
+cd examples/guardrails-test
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --mock-provider --ci --formats html,json
+```

--- a/tools/arena/SERVICE.md
+++ b/tools/arena/SERVICE.md
@@ -1,0 +1,87 @@
+# Arena (PromptArena) Module — Service Responsibilities
+
+## Ownership
+
+Arena owns scenario-based testing and evaluation of LLM applications. It orchestrates multi-turn conversations against providers, runs assertions, and produces structured reports.
+
+## Responsibilities
+
+### Engine (`engine/`)
+- **Composition root** — wires providers, tools, prompts, state store, workflow, evals
+- **Concurrent scenario execution** — per-run isolation with cloned state machines and eval orchestrators
+- **Mock provider mode** — transparent provider replacement for offline testing
+- **Run planning** — scenario x provider x region matrix execution
+
+### Workflow Integration
+- **Detection** — explicit check of `config.Workflow` (no inference — Arena's config is explicit)
+- **workflowTransitionExecutor** — `tools.Executor` that calls `sm.ProcessEvent()` immediately
+- **Per-run state machines** — `RegisterRun/UnregisterRun` for concurrent isolation
+- **Transition metadata** — redirect info, visit counts in run metadata
+- **Tool re-registration** — updates available events after each state transition
+
+### Conversation Execution
+- **DefaultConversationExecutor** — iterates scripted turns, dispatches to turn executors
+- **DuplexConversationExecutor** — streaming variant for ASM/VAD scenarios
+- **PipelineExecutor** — builds runtime pipeline per turn with Arena-specific stages
+- **State persistence** — always-on StateStore, writes per-turn (not deferred)
+
+### Turn Execution Pipeline
+Arena's pipeline has extra stages not present in SDK:
+- **ScenarioContextExtractionStage** — extracts context references from scenario config
+- **MockScenarioContextStage** — injects mock context for mock-provider scenarios
+- **MediaConvertStage** — format conversion for provider capabilities
+- **MediaExternalizerStage** — offload large media to file storage
+- **ArenaAssertionStage** — run turn-level assertions inline
+- **ArenaStateStoreSaveStage** — persist with assertion metadata
+
+### Evaluation Orchestration
+- **EvalOrchestrator** — dispatches assertions at turn, conversation, and session levels
+- **Clone pattern** — per-run cloning for concurrent safety
+- **Handler registry** — content_match, llm_judge, budget, latency, tool_usage, etc.
+- **Metadata injection** — judge targets, prompt registry, workflow state
+
+### Reporting
+- **HTML** — interactive report with charts and filtering
+- **JSON** — structured results for CI integration
+- **JUnit** — CI-compatible test format
+- **Markdown** — human-readable summary
+
+## What Arena Does NOT Own
+
+- **Tool execution dispatch** — runtime's `tools.Registry` owns this (Arena registers executors)
+- **LLM call logic** — runtime's ProviderStage owns the tool loop
+- **State machine logic** — runtime's `workflow.StateMachine` owns ProcessEvent
+- **Provider implementations** — runtime's `providers/` package
+- **Pipeline stage implementations** — runtime's `pipeline/stage/` (Arena adds its own stages)
+
+## Behavioral Contracts
+
+### Workflow Transitions
+- **Immediate execution** — ProcessEvent called synchronously during tool execution
+- **TaskType update** — scenario.TaskType updated to new state's prompt_task for next turn
+- **Tool re-registration** — transition tool updated with new state's available events
+- **Redirect metadata** — captured in per-run transition history
+
+### Concurrent Execution
+- Each run gets: own StateMachine, own EvalOrchestrator clone, own StateStore key
+- Context carries runID for workflow executor routing
+- No shared mutable state between concurrent runs
+
+### State Persistence
+- StateStore is always enabled (not optional like SDK)
+- Messages saved per-turn (not deferred to conversation end)
+- Assertion results attached to state as metadata
+- Enables partial result recovery on failures
+
+## Key Differences from SDK
+
+| Concern | Arena | SDK |
+|---------|-------|-----|
+| Workflow transitions | Immediate (in executor) | Deferred (after Send) |
+| Pipeline lifecycle | Per-turn | Per-Send (rebuilt each time) |
+| Capability detection | Explicit config check | Pack structure inference |
+| Tool registration | Direct RegisterExecutor | Via Capability.RegisterTools |
+| State persistence | Always-on, per-turn | Optional, deferred |
+| Concurrency model | Per-run isolation | Single conversation |
+| Assertions | Inline (ArenaAssertionStage) | Post-execution (eval middleware) |
+| Tool handler model | Custom Executor | OnTool → localExecutor wrapper |

--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -111,6 +111,13 @@ func (ce *DefaultConversationExecutor) executeWithoutStreaming(
 			return result
 		}
 
+		// Commit deferred workflow transitions after the pipeline completes
+		if req.PostTurnHook != nil {
+			if hookErr := req.PostTurnHook(); hookErr != nil {
+				logger.Error("Post-turn hook failed", "turn", turnIdx, "error", hookErr)
+			}
+		}
+
 		ce.notifyTurnCompleted(emitter, turnIdx, scenarioTurn.Role, req.Scenario.ID, nil)
 		logger.Debug("Turn completed",
 			"turn", turnIdx,

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -433,6 +433,12 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 		EvalOrchestrator: runOrch,
 		RecordingConfig:  e.recordingConfig,
 	}
+	// Wire deferred workflow transition commit after each turn
+	if e.workflowTransExec != nil {
+		req.PostTurnHook = func() error {
+			return e.workflowTransExec.CommitPendingTransition(runID)
+		}
+	}
 
 	// Always configure StateStore (always enabled now)
 	req.StateStoreConfig = &StateStoreConfig{

--- a/tools/arena/engine/interfaces.go
+++ b/tools/arena/engine/interfaces.go
@@ -77,6 +77,10 @@ type ConversationRequest struct {
 	// RecordingConfig enables RecordingStage in the pipeline for message.created events.
 	// If nil, no recording stages are added.
 	RecordingConfig *stage.RecordingStageConfig
+
+	// PostTurnHook is called after each turn completes. Used by the workflow
+	// engine to commit deferred transitions after the pipeline finishes.
+	PostTurnHook func() error
 }
 
 // StateStoreConfig wraps the pipeline StateStore configuration for Arena

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -12,9 +12,6 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 )
 
-// workflowTransitionMode is the executor name and tool Mode value for routing.
-const workflowTransitionMode = "workflow-transition"
-
 type workflowScenarioIDKey struct{}
 
 // withWorkflowScenarioID stores the workflow scenario ID in context for per-run dispatch.
@@ -32,14 +29,15 @@ func workflowScenarioIDFromCtx(ctx context.Context) string {
 
 // workflowRunState holds per-run workflow state for concurrent scenario execution.
 type workflowRunState struct {
-	sm          *workflow.StateMachine
+	transExec   *workflow.TransitionExecutor
 	scenario    *config.Scenario
 	transitions []map[string]any
 }
 
-// workflowTransitionExecutor implements tools.Executor for the workflow__transition tool.
-// It supports concurrent scenario execution by maintaining per-run state keyed by
-// a run token set on the request metadata.
+// workflowTransitionExecutor routes workflow__transition tool calls to per-run
+// TransitionExecutors. Each scenario run gets its own TransitionExecutor via
+// RegisterRun. The executor defers ProcessEvent until CommitPendingTransition
+// is called after the turn/pipeline completes.
 type workflowTransitionExecutor struct {
 	mu       sync.Mutex
 	wfSpec   *workflow.Spec
@@ -59,50 +57,62 @@ func newWorkflowTransitionExecutor(
 }
 
 // Name implements tools.Executor.
-func (e *workflowTransitionExecutor) Name() string { return workflowTransitionMode }
+func (e *workflowTransitionExecutor) Name() string { return workflow.TransitionExecutorMode }
 
-// RegisterRun creates a fresh state machine for a scenario run.
-// Called from prepareWorkflowScenario before execution starts.
+// RegisterRun creates a fresh TransitionExecutor for a scenario run.
 func (e *workflowTransitionExecutor) RegisterRun(runID string, scenario *config.Scenario) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	sm := workflow.NewStateMachine(e.wfSpec)
 	e.runs[runID] = &workflowRunState{
-		sm:       workflow.NewStateMachine(e.wfSpec),
-		scenario: scenario,
+		transExec: workflow.NewTransitionExecutor(sm, e.wfSpec),
+		scenario:  scenario,
 	}
 }
 
-// Execute processes a workflow__transition tool call from the LLM.
+// Execute routes the tool call to the per-run TransitionExecutor.
+// The executor defers ProcessEvent — call CommitPendingTransition after the turn.
 func (e *workflowTransitionExecutor) Execute(
-	ctx context.Context, _ *tools.ToolDescriptor, args json.RawMessage,
+	ctx context.Context, desc *tools.ToolDescriptor, args json.RawMessage,
 ) (json.RawMessage, error) {
-	var a struct {
-		Event   string `json:"event"`
-		Context string `json:"context"`
+	scenarioID := workflowScenarioIDFromCtx(ctx)
+
+	e.mu.Lock()
+	run := e.runs[scenarioID]
+	e.mu.Unlock()
+
+	if run == nil {
+		return nil, fmt.Errorf("no active workflow run for scenario %q", scenarioID)
 	}
-	if err := json.Unmarshal(args, &a); err != nil {
-		return nil, fmt.Errorf("failed to parse transition args: %w", err)
+
+	return run.transExec.Execute(ctx, desc, args)
+}
+
+// CommitPendingTransition commits the deferred transition for a run.
+// Called after the turn/pipeline completes. Updates scenario TaskType and
+// re-registers the transition tool for the new state's events.
+func (e *workflowTransitionExecutor) CommitPendingTransition(runID string) error {
+	e.mu.Lock()
+	run := e.runs[runID]
+	e.mu.Unlock()
+
+	if run == nil || run.transExec.Pending() == nil {
+		return nil
+	}
+
+	tr, err := run.transExec.CommitPending()
+	if err != nil {
+		return fmt.Errorf("transition commit failed: %w", err)
+	}
+	if tr == nil {
+		return nil
 	}
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Find the run for this scenario using context-propagated scenario ID
-	scenarioID := workflowScenarioIDFromCtx(ctx)
-	run := e.runs[scenarioID]
-	if run == nil {
-		return nil, fmt.Errorf("no active workflow run for transition event %q", a.Event)
-	}
-
-	tr, err := run.sm.ProcessEvent(a.Event)
-	if err != nil {
-		return nil, fmt.Errorf("transition event %q failed: %w", a.Event, err)
-	}
-	from := tr.From
-	to := tr.To
-
 	transitionRecord := map[string]any{
-		"from": from, "to": to, "event": a.Event,
+		"from": tr.From, "to": tr.To, "event": tr.Event,
 	}
 	if tr.Redirected {
 		transitionRecord["redirected"] = true
@@ -110,22 +120,28 @@ func (e *workflowTransitionExecutor) Execute(
 		transitionRecord["original_target"] = tr.OriginalTarget
 	}
 	run.transitions = append(run.transitions, transitionRecord)
-	logger.Info("workflow state transition", "from", from, "to", to,
-		"event", a.Event, "redirected", tr.Redirected)
+	logger.Info("workflow state transition", "from", tr.From, "to", tr.To,
+		"event", tr.Event, "redirected", tr.Redirected)
 
 	// Update scenario TaskType and re-register tool for the new state
-	if newState := e.wfSpec.States[to]; newState != nil {
+	if newState := e.wfSpec.States[tr.To]; newState != nil {
 		if run.scenario != nil {
 			run.scenario.TaskType = newState.PromptTask
 		}
-		registerTransitionTool(e.registry, newState)
+		run.transExec.RegisterForState(e.registry, newState)
 	}
 
-	result, _ := json.Marshal(struct {
-		NewState string `json:"new_state"`
-		Event    string `json:"event"`
-	}{NewState: to, Event: a.Event})
-	return result, nil
+	return nil
+}
+
+// StateMachine returns the per-run state machine for direct access (e.g., metadata).
+func (e *workflowTransitionExecutor) StateMachine(runID string) *workflow.StateMachine {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if run := e.runs[runID]; run != nil {
+		return run.transExec.StateMachine()
+	}
+	return nil
 }
 
 // RunMetadata returns workflow metadata for a specific run.
@@ -147,20 +163,19 @@ func buildRunMetadata(run *workflowRunState) map[string]any {
 	if run == nil {
 		return nil
 	}
+	sm := run.transExec.StateMachine()
 	transitions := make([]any, len(run.transitions))
 	for i, t := range run.transitions {
 		transitions[i] = t
 	}
 	return map[string]any{
-		"workflow_current_state": run.sm.CurrentState(),
-		"workflow_complete":      run.sm.IsTerminal(),
+		"workflow_current_state": sm.CurrentState(),
+		"workflow_complete":      sm.IsTerminal(),
 		"workflow_transitions":   transitions,
 	}
 }
 
 // workflowRunMetadataProvider wraps the executor for a specific scenario run.
-// This allows per-run metadata to be returned to the eval orchestrator even when
-// multiple scenarios run concurrently.
 type workflowRunMetadataProvider struct {
 	exec       *workflowTransitionExecutor
 	scenarioID string
@@ -182,6 +197,6 @@ func registerTransitionTool(registry *tools.Registry, state *workflow.State) {
 	}
 	evts := workflow.SortedEvents(state.OnEvent)
 	desc := workflow.BuildTransitionToolDescriptor(evts)
-	desc.Mode = workflowTransitionMode
+	desc.Mode = workflow.TransitionExecutorMode
 	_ = registry.Register(desc)
 }

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -94,16 +94,24 @@ func (e *workflowTransitionExecutor) Execute(
 		return nil, fmt.Errorf("no active workflow run for transition event %q", a.Event)
 	}
 
-	from := run.sm.CurrentState()
-	if err := run.sm.ProcessEvent(a.Event); err != nil {
+	tr, err := run.sm.ProcessEvent(a.Event)
+	if err != nil {
 		return nil, fmt.Errorf("transition event %q failed: %w", a.Event, err)
 	}
-	to := run.sm.CurrentState()
+	from := tr.From
+	to := tr.To
 
-	run.transitions = append(run.transitions, map[string]any{
+	transitionRecord := map[string]any{
 		"from": from, "to": to, "event": a.Event,
-	})
-	logger.Info("workflow state transition", "from", from, "to", to, "event", a.Event)
+	}
+	if tr.Redirected {
+		transitionRecord["redirected"] = true
+		transitionRecord["redirect_reason"] = tr.RedirectReason
+		transitionRecord["original_target"] = tr.OriginalTarget
+	}
+	run.transitions = append(run.transitions, transitionRecord)
+	logger.Info("workflow state transition", "from", from, "to", to,
+		"event", a.Event, "redirected", tr.Redirected)
 
 	// Update scenario TaskType and re-register tool for the new state
 	if newState := e.wfSpec.States[to]; newState != nil {

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -189,7 +189,7 @@ func (p *workflowRunMetadataProvider) WorkflowMetadata() map[string]any {
 // registerTransitionTool registers the workflow__transition tool with the executor
 // routing mode set so the registry dispatches to workflowTransitionExecutor.
 func registerTransitionTool(registry *tools.Registry, state *workflow.State) {
-	if registry == nil || state == nil || len(state.OnEvent) == 0 {
+	if registry == nil || state == nil || state.Terminal || len(state.OnEvent) == 0 {
 		return
 	}
 	if state.Orchestration == workflow.OrchestrationExternal {

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -139,6 +139,58 @@ func TestWorkflowTransitionExecutor_ConcurrentRuns(t *testing.T) {
 	assert.Equal(t, "specialist", s2.TaskType)
 }
 
+func TestWorkflowTransitionExecutor_MaxVisitsRedirect(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "start",
+		States: map[string]*workflow.State{
+			"start": {
+				PromptTask: "start",
+				OnEvent:    map[string]string{"Go": "loop"},
+			},
+			"loop": {
+				PromptTask:  "loop",
+				MaxVisits:   1,
+				OnMaxVisits: "done",
+				OnEvent:     map[string]string{"Again": "loop"},
+			},
+			"done": {PromptTask: "done"},
+		},
+	}
+	registry := tools.NewRegistry()
+	exec := newWorkflowTransitionExecutor(spec, registry)
+
+	scenario := &config.Scenario{ID: "test", TaskType: "start"}
+	exec.RegisterRun("test", scenario)
+
+	// First transition: start -> loop (visit 1)
+	args, _ := json.Marshal(map[string]string{"event": "Go", "context": "test"})
+	result, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
+	require.NoError(t, err)
+
+	var res struct {
+		NewState string `json:"new_state"`
+		Event    string `json:"event"`
+	}
+	require.NoError(t, json.Unmarshal(result, &res))
+	assert.Equal(t, "loop", res.NewState)
+
+	// Second transition: loop -> loop, but max_visits=1 so redirect to done
+	args2, _ := json.Marshal(map[string]string{"event": "Again", "context": "test"})
+	result2, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args2)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(result2, &res))
+	assert.Equal(t, "done", res.NewState, "should redirect to on_max_visits target")
+
+	// Verify redirect info in transitions metadata
+	meta := exec.RunMetadata("test")
+	transitions := meta["workflow_transitions"].([]any)
+	lastTransition := transitions[len(transitions)-1].(map[string]any)
+	assert.Equal(t, true, lastTransition["redirected"])
+	assert.Contains(t, lastTransition["redirect_reason"].(string), "max_visits")
+}
+
 func TestRegisterTransitionTool(t *testing.T) {
 	registry := tools.NewRegistry()
 	state := &workflow.State{

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -40,20 +40,20 @@ func TestWorkflowTransitionExecutor_Execute(t *testing.T) {
 	scenario := &config.Scenario{ID: "test", TaskType: "intake"}
 	exec.RegisterRun("test", scenario)
 
-	// Execute Escalate transition
+	// Execute stores pending (deferred)
 	args, _ := json.Marshal(map[string]string{"event": "Escalate", "context": "test"})
 	result, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
 	require.NoError(t, err)
 
-	var res struct {
-		NewState string `json:"new_state"`
-		Event    string `json:"event"`
-	}
+	var res map[string]string
 	require.NoError(t, json.Unmarshal(result, &res))
-	assert.Equal(t, "specialist", res.NewState)
-	assert.Equal(t, "Escalate", res.Event)
+	assert.Equal(t, "transition_scheduled", res["status"])
 
-	// Verify scenario TaskType was updated
+	// TaskType not yet updated (deferred)
+	assert.Equal(t, "intake", scenario.TaskType)
+
+	// Commit applies the transition
+	require.NoError(t, exec.CommitPendingTransition("test"))
 	assert.Equal(t, "specialist", scenario.TaskType)
 }
 
@@ -65,8 +65,12 @@ func TestWorkflowTransitionExecutor_InvalidEvent(t *testing.T) {
 	scenario := &config.Scenario{ID: "test"}
 	exec.RegisterRun("test", scenario)
 
+	// Execute succeeds (stores pending), commit fails
 	args, _ := json.Marshal(map[string]string{"event": "NonExistent"})
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
+	require.NoError(t, err) // Execute always succeeds (just stores pending)
+
+	err = exec.CommitPendingTransition("test")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "NonExistent")
 }
@@ -84,10 +88,11 @@ func TestWorkflowTransitionExecutor_WorkflowMetadata(t *testing.T) {
 	assert.Equal(t, "intake", meta["workflow_current_state"])
 	assert.Equal(t, false, meta["workflow_complete"])
 
-	// After transition
+	// After transition (execute + commit)
 	args, _ := json.Marshal(map[string]string{"event": "Escalate"})
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
 	require.NoError(t, err)
+	require.NoError(t, exec.CommitPendingTransition("test"))
 
 	meta = exec.RunMetadata("test")
 	assert.Equal(t, "specialist", meta["workflow_current_state"])
@@ -110,6 +115,7 @@ func TestWorkflowTransitionExecutor_TerminalState(t *testing.T) {
 	args, _ := json.Marshal(map[string]string{"event": "Resolve"})
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
 	require.NoError(t, err)
+	require.NoError(t, exec.CommitPendingTransition("test"))
 
 	meta := exec.RunMetadata("test")
 	assert.Equal(t, true, meta["workflow_complete"])
@@ -130,12 +136,14 @@ func TestWorkflowTransitionExecutor_ConcurrentRuns(t *testing.T) {
 	args, _ := json.Marshal(map[string]string{"event": "Escalate"})
 	_, err := exec.Execute(ctx1, nil, args)
 	require.NoError(t, err)
+	require.NoError(t, exec.CommitPendingTransition("s1"))
 	assert.Equal(t, "specialist", s1.TaskType)
 
 	// s2 should still be able to Escalate (its own state machine)
 	ctx2 := withWorkflowScenarioID(context.Background(), "s2")
 	_, err = exec.Execute(ctx2, nil, args)
 	require.NoError(t, err)
+	require.NoError(t, exec.CommitPendingTransition("s2"))
 	assert.Equal(t, "specialist", s2.TaskType)
 }
 
@@ -165,23 +173,17 @@ func TestWorkflowTransitionExecutor_MaxVisitsRedirect(t *testing.T) {
 
 	// First transition: start -> loop (visit 1)
 	args, _ := json.Marshal(map[string]string{"event": "Go", "context": "test"})
-	result, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
+	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
 	require.NoError(t, err)
-
-	var res struct {
-		NewState string `json:"new_state"`
-		Event    string `json:"event"`
-	}
-	require.NoError(t, json.Unmarshal(result, &res))
-	assert.Equal(t, "loop", res.NewState)
+	require.NoError(t, exec.CommitPendingTransition("test"))
+	assert.Equal(t, "loop", scenario.TaskType)
 
 	// Second transition: loop -> loop, but max_visits=1 so redirect to done
 	args2, _ := json.Marshal(map[string]string{"event": "Again", "context": "test"})
-	result2, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args2)
+	_, err = exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args2)
 	require.NoError(t, err)
-
-	require.NoError(t, json.Unmarshal(result2, &res))
-	assert.Equal(t, "done", res.NewState, "should redirect to on_max_visits target")
+	require.NoError(t, exec.CommitPendingTransition("test"))
+	assert.Equal(t, "done", scenario.TaskType, "should redirect to on_max_visits target")
 
 	// Verify redirect info in transitions metadata
 	meta := exec.RunMetadata("test")
@@ -201,7 +203,7 @@ func TestRegisterTransitionTool(t *testing.T) {
 
 	tool := registry.Get(workflow.TransitionToolName)
 	require.NotNil(t, tool)
-	assert.Equal(t, workflowTransitionMode, tool.Mode)
+	assert.Equal(t, workflow.TransitionExecutorMode, tool.Mode)
 }
 
 func TestRegisterTransitionTool_TerminalState(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements RFC 0009 (Agent Loops) — terminal states, loop guards, budgets, artifacts, and unified workflow tool execution via runtime executors.

### Phase 1: Terminal States + Loop Guards
- **Terminal states**: Explicit `terminal: bool` field on State. `IsTerminal()` and `ProcessEvent` both check it (consistent).
- **Loop guards**: `max_visits` and `on_max_visits` on State. `VisitCounts` map on Context.
- **ProcessEvent**: Returns `(*TransitionResult, error)` — redirects are successful transitions, not errors.
- **Validation**: Version 1 or 2, on_max_visits targets, terminal+on_event, redirect chains.

### Phase 2: Workflow Budgets
- `Budget` type parsed from `engine.budget` (max_total_visits, max_tool_calls, max_wall_time_sec)
- Budget checks run before event resolution in ProcessEvent (precedence over max_visits)
- Cached via `sync.Once` to avoid JSON re-parse per transition

### Phase 3: Artifacts
- `ArtifactDef` on State: type (MIME), description, mode (replace/append)
- `SetArtifact`/`GetArtifact` on Context, transition-scoped snapshots
- `workflow__set_artifact` tool with `ArtifactExecutor` (immediate execution)
- Artifact values injected as `{{artifacts.<name>}}` template variables

### Runtime Executors (Architectural Improvement)
- **TransitionExecutor**: Deferred commit pattern — `Execute()` stores pending, `CommitPending()` applies after pipeline. Both SDK and Arena use this.
- **ArtifactExecutor**: Immediate execution (safe mid-pipeline).
- Arena wired via `PostTurnHook` on ConversationRequest.
- Fixes Arena bug where immediate transitions skipped pipeline remainder.

### Architecture Documentation
- CLAUDE.md + SERVICE.md for runtime, SDK, and Arena modules.

## Breaking Changes
- `ProcessEvent` signature: `error` → `(*TransitionResult, error)`

## Test plan
- [x] 20+ machine tests (terminal, max_visits, redirect, budget, artifacts)
- [x] 12 executor tests (deferred commit, error, clear, register, redirect)
- [x] 5 artifact tool tests (set, append, empty name, registration, enum)
- [x] 3 validation tests (on_max_visits target, terminal+on_event, chain)
- [x] Arena tests updated for deferred semantics
- [x] SDK tests updated for TransitionExecutor
- [x] All pre-commit checks pass (lint, build, tests)
- [ ] CI green
