### PR TITLE
feat: thinking/reasoning content type for extended thinking models

### DIFF
--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -494,13 +494,20 @@ func (p *Provider) parseAndValidateClaudeResponse(respBody []byte, predictResp p
 		return claudeResp, "", predictResp, fmt.Errorf("no content in response")
 	}
 
-	// Find text content
+	// Extract text and thinking content from response blocks
 	var responseText string
+	var parts []types.ContentPart
 	for _, content := range claudeResp.Content {
-		if content.Type == "text" {
+		switch content.Type {
+		case "text":
 			responseText = content.Text
-			break
+			parts = append(parts, types.NewTextPart(content.Text))
+		case types.ContentTypeThinking:
+			parts = append(parts, types.NewThinkingPart(content.Text))
 		}
+	}
+	if len(parts) > 0 {
+		predictResp.Parts = parts
 	}
 
 	if responseText == "" {

--- a/runtime/providers/claude/claude_test.go
+++ b/runtime/providers/claude/claude_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
@@ -688,4 +689,128 @@ func (c *applyTrackingCredential) Type() string { return "tracking" }
 func (c *applyTrackingCredential) Apply(_ context.Context, _ *http.Request) error {
 	c.onApply()
 	return nil
+}
+
+func TestParseAndValidateClaudeResponse_ThinkingAndText(t *testing.T) {
+	provider := NewProvider("test", "claude-3-5-sonnet-20241022", "https://api.anthropic.com", providers.ProviderDefaults{
+		Pricing: providers.Pricing{InputCostPer1K: 0.003, OutputCostPer1K: 0.015},
+	}, false)
+
+	respJSON := `{
+		"id": "msg_123",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "thinking", "text": "Let me think about this..."},
+			{"type": "text", "text": "Here is my answer."}
+		],
+		"model": "claude-3-5-sonnet-20241022",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 100, "output_tokens": 50}
+	}`
+
+	predictResp := providers.PredictionResponse{}
+	_, responseText, result, err := provider.parseAndValidateClaudeResponse([]byte(respJSON), predictResp, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// responseText should only contain the text block, not thinking
+	if responseText != "Here is my answer." {
+		t.Errorf("expected responseText %q, got %q", "Here is my answer.", responseText)
+	}
+
+	// Parts should contain both thinking and text
+	if len(result.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(result.Parts))
+	}
+
+	if result.Parts[0].Type != "thinking" {
+		t.Errorf("expected first part type 'thinking', got %q", result.Parts[0].Type)
+	}
+	if result.Parts[0].Text == nil || *result.Parts[0].Text != "Let me think about this..." {
+		t.Errorf("expected first part text 'Let me think about this...', got %v", result.Parts[0].Text)
+	}
+
+	if result.Parts[1].Type != "text" {
+		t.Errorf("expected second part type 'text', got %q", result.Parts[1].Type)
+	}
+	if result.Parts[1].Text == nil || *result.Parts[1].Text != "Here is my answer." {
+		t.Errorf("expected second part text 'Here is my answer.', got %v", result.Parts[1].Text)
+	}
+}
+
+func TestParseAndValidateClaudeResponse_TextOnly(t *testing.T) {
+	provider := NewProvider("test", "claude-3-5-sonnet-20241022", "https://api.anthropic.com", providers.ProviderDefaults{
+		Pricing: providers.Pricing{InputCostPer1K: 0.003, OutputCostPer1K: 0.015},
+	}, false)
+
+	respJSON := `{
+		"id": "msg_456",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "text", "text": "Simple response."}
+		],
+		"model": "claude-3-5-sonnet-20241022",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 50, "output_tokens": 20}
+	}`
+
+	predictResp := providers.PredictionResponse{}
+	_, responseText, result, err := provider.parseAndValidateClaudeResponse([]byte(respJSON), predictResp, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if responseText != "Simple response." {
+		t.Errorf("expected responseText %q, got %q", "Simple response.", responseText)
+	}
+
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(result.Parts))
+	}
+	if result.Parts[0].Type != "text" {
+		t.Errorf("expected part type 'text', got %q", result.Parts[0].Type)
+	}
+}
+
+func TestParseAndValidateClaudeResponse_EmptyContent(t *testing.T) {
+	provider := NewProvider("test", "claude-3-5-sonnet-20241022", "https://api.anthropic.com", providers.ProviderDefaults{}, false)
+
+	respJSON := `{
+		"id": "msg_789",
+		"type": "message",
+		"role": "assistant",
+		"content": [],
+		"model": "claude-3-5-sonnet-20241022",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 0}
+	}`
+
+	predictResp := providers.PredictionResponse{}
+	_, _, _, err := provider.parseAndValidateClaudeResponse([]byte(respJSON), predictResp, time.Now())
+	if err == nil {
+		t.Fatal("expected error for empty content, got nil")
+	}
+	if !strings.Contains(err.Error(), "no content") {
+		t.Errorf("expected 'no content' error, got: %v", err)
+	}
+}
+
+func TestParseAndValidateClaudeResponse_APIError(t *testing.T) {
+	provider := NewProvider("test", "claude-3-5-sonnet-20241022", "https://api.anthropic.com", providers.ProviderDefaults{}, false)
+
+	respJSON := `{
+		"error": {"type": "rate_limit_error", "message": "Rate limit exceeded"}
+	}`
+
+	predictResp := providers.PredictionResponse{}
+	_, _, _, err := provider.parseAndValidateClaudeResponse([]byte(respJSON), predictResp, time.Now())
+	if err == nil {
+		t.Fatal("expected error for API error response, got nil")
+	}
+	if !strings.Contains(err.Error(), "Rate limit exceeded") {
+		t.Errorf("expected rate limit error message, got: %v", err)
+	}
 }

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -393,6 +393,21 @@ func extractTextContentFromResponse(content []claudeContent) string {
 	return ""
 }
 
+// extractContentParts converts Claude content blocks to typed ContentParts.
+// Returns text and thinking parts; tool_use blocks are handled separately.
+func extractContentParts(content []claudeContent) []types.ContentPart {
+	var parts []types.ContentPart
+	for _, c := range content {
+		switch c.Type {
+		case "text":
+			parts = append(parts, types.NewTextPart(c.Text))
+		case types.ContentTypeThinking:
+			parts = append(parts, types.NewThinkingPart(c.Text))
+		}
+	}
+	return parts
+}
+
 // parseToolCallsFromRawResponse extracts tool calls from raw JSON response
 func parseToolCallsFromRawResponse(respBytes []byte) []types.MessageToolCall {
 	var toolCalls []types.MessageToolCall
@@ -463,6 +478,7 @@ func (p *ToolProvider) parseToolResponse(
 	costBreakdown := p.Provider.CalculateCost(resp.Usage.InputTokens, resp.Usage.OutputTokens, resp.Usage.CacheReadInputTokens)
 
 	predictResp.Content = textContent
+	predictResp.Parts = extractContentParts(resp.Content)
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBytes

--- a/runtime/providers/claude/claude_tools_test.go
+++ b/runtime/providers/claude/claude_tools_test.go
@@ -1001,3 +1001,80 @@ func TestToolProvider_MakeRequest_BedrockBodyMutation(t *testing.T) {
 		t.Error("model field should be removed from Bedrock request body")
 	}
 }
+
+func TestExtractContentParts(t *testing.T) {
+	t.Run("text and thinking blocks", func(t *testing.T) {
+		content := []claudeContent{
+			{Type: "thinking", Text: "reasoning here"},
+			{Type: "text", Text: "final answer"},
+		}
+		parts := extractContentParts(content)
+		if len(parts) != 2 {
+			t.Fatalf("expected 2 parts, got %d", len(parts))
+		}
+		if parts[0].Type != "thinking" {
+			t.Errorf("expected first part type 'thinking', got %q", parts[0].Type)
+		}
+		if parts[0].Text == nil || *parts[0].Text != "reasoning here" {
+			t.Errorf("expected first part text 'reasoning here', got %v", parts[0].Text)
+		}
+		if parts[1].Type != "text" {
+			t.Errorf("expected second part type 'text', got %q", parts[1].Type)
+		}
+		if parts[1].Text == nil || *parts[1].Text != "final answer" {
+			t.Errorf("expected second part text 'final answer', got %v", parts[1].Text)
+		}
+	})
+
+	t.Run("text only", func(t *testing.T) {
+		content := []claudeContent{
+			{Type: "text", Text: "just text"},
+		}
+		parts := extractContentParts(content)
+		if len(parts) != 1 {
+			t.Fatalf("expected 1 part, got %d", len(parts))
+		}
+		if parts[0].Type != "text" || parts[0].Text == nil || *parts[0].Text != "just text" {
+			t.Errorf("unexpected part: %+v", parts[0])
+		}
+	})
+
+	t.Run("unknown types are skipped", func(t *testing.T) {
+		content := []claudeContent{
+			{Type: "text", Text: "hello"},
+			{Type: "tool_use", Text: ""},
+			{Type: "unknown_type", Text: "should be skipped"},
+		}
+		parts := extractContentParts(content)
+		if len(parts) != 1 {
+			t.Fatalf("expected 1 part (only text), got %d", len(parts))
+		}
+		if parts[0].Type != "text" {
+			t.Errorf("expected text part, got %q", parts[0].Type)
+		}
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		parts := extractContentParts(nil)
+		if len(parts) != 0 {
+			t.Errorf("expected 0 parts for nil input, got %d", len(parts))
+		}
+		parts = extractContentParts([]claudeContent{})
+		if len(parts) != 0 {
+			t.Errorf("expected 0 parts for empty input, got %d", len(parts))
+		}
+	})
+
+	t.Run("thinking only", func(t *testing.T) {
+		content := []claudeContent{
+			{Type: "thinking", Text: "deep thoughts"},
+		}
+		parts := extractContentParts(content)
+		if len(parts) != 1 {
+			t.Fatalf("expected 1 part, got %d", len(parts))
+		}
+		if parts[0].Type != "thinking" || parts[0].Text == nil || *parts[0].Text != "deep thoughts" {
+			t.Errorf("unexpected part: %+v", parts[0])
+		}
+	})
+}

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -611,6 +611,47 @@ func getTextFromPart(part interface{}) string {
 	return textVal
 }
 
+// extractContentParts builds typed ContentParts from OpenAI response content.
+// Handles both string content and array-of-parts content.
+func extractContentParts(content interface{}) []types.ContentPart {
+	if str, ok := content.(string); ok && str != "" {
+		return []types.ContentPart{types.NewTextPart(str)}
+	}
+	parts, ok := content.([]interface{})
+	if !ok {
+		return nil
+	}
+	var result []types.ContentPart
+	for _, part := range parts {
+		if cp := convertOpenAIPart(part); cp != nil {
+			result = append(result, *cp)
+		}
+	}
+	return result
+}
+
+// convertOpenAIPart converts a single OpenAI content part to a typed ContentPart.
+func convertOpenAIPart(part interface{}) *types.ContentPart {
+	partMap, ok := part.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	partType, _ := partMap["type"].(string)
+	switch partType {
+	case "text":
+		if text, ok := partMap["text"].(string); ok {
+			cp := types.NewTextPart(text)
+			return &cp
+		}
+	case types.ContentTypeThinking:
+		if text, ok := partMap["thinking"].(string); ok {
+			cp := types.NewThinkingPart(text)
+			return &cp
+		}
+	}
+	return nil
+}
+
 // predictWithMessages is a refactored version of Predict that accepts pre-converted messages
 func (p *Provider) predictWithMessages(ctx context.Context, req providers.PredictionRequest, messages []openAIMessage) (providers.PredictionResponse, error) {
 	// Enrich context with provider and model info for logging
@@ -731,6 +772,7 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 	content := extractContentString(openAIResp.Choices[0].Message.Content)
 
 	predictResp.Content = content
+	predictResp.Parts = extractContentParts(openAIResp.Choices[0].Message.Content)
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBody

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1222,3 +1222,106 @@ func TestOpenAI_PlatformField(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractContentParts_StringContent(t *testing.T) {
+	parts := extractContentParts("Hello, world!")
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parts))
+	}
+	if parts[0].Type != "text" {
+		t.Errorf("expected type 'text', got %q", parts[0].Type)
+	}
+	if parts[0].Text == nil || *parts[0].Text != "Hello, world!" {
+		t.Errorf("expected text 'Hello, world!', got %v", parts[0].Text)
+	}
+}
+
+func TestExtractContentParts_ArrayContent(t *testing.T) {
+	content := []interface{}{
+		map[string]interface{}{"type": "text", "text": "visible answer"},
+		map[string]interface{}{"type": "thinking", "thinking": "internal reasoning"},
+	}
+	parts := extractContentParts(content)
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	if parts[0].Type != "text" || parts[0].Text == nil || *parts[0].Text != "visible answer" {
+		t.Errorf("unexpected first part: %+v", parts[0])
+	}
+	if parts[1].Type != "thinking" || parts[1].Text == nil || *parts[1].Text != "internal reasoning" {
+		t.Errorf("unexpected second part: %+v", parts[1])
+	}
+}
+
+func TestExtractContentParts_EmptyAndNil(t *testing.T) {
+	if parts := extractContentParts(nil); parts != nil {
+		t.Errorf("expected nil for nil input, got %v", parts)
+	}
+	if parts := extractContentParts(""); parts != nil {
+		t.Errorf("expected nil for empty string, got %v", parts)
+	}
+	if parts := extractContentParts(42); parts != nil {
+		t.Errorf("expected nil for non-string/non-array, got %v", parts)
+	}
+}
+
+func TestConvertOpenAIPart_TextType(t *testing.T) {
+	part := map[string]interface{}{"type": "text", "text": "hello"}
+	cp := convertOpenAIPart(part)
+	if cp == nil {
+		t.Fatal("expected non-nil part")
+	}
+	if cp.Type != "text" {
+		t.Errorf("expected type 'text', got %q", cp.Type)
+	}
+	if cp.Text == nil || *cp.Text != "hello" {
+		t.Errorf("expected text 'hello', got %v", cp.Text)
+	}
+}
+
+func TestConvertOpenAIPart_ThinkingType(t *testing.T) {
+	part := map[string]interface{}{"type": "thinking", "thinking": "deep thought"}
+	cp := convertOpenAIPart(part)
+	if cp == nil {
+		t.Fatal("expected non-nil part")
+	}
+	if cp.Type != "thinking" {
+		t.Errorf("expected type 'thinking', got %q", cp.Type)
+	}
+	if cp.Text == nil || *cp.Text != "deep thought" {
+		t.Errorf("expected text 'deep thought', got %v", cp.Text)
+	}
+}
+
+func TestConvertOpenAIPart_UnknownType(t *testing.T) {
+	part := map[string]interface{}{"type": "image_url", "url": "https://example.com/img.png"}
+	cp := convertOpenAIPart(part)
+	if cp != nil {
+		t.Errorf("expected nil for unknown type, got %+v", cp)
+	}
+}
+
+func TestConvertOpenAIPart_NonMap(t *testing.T) {
+	cp := convertOpenAIPart("not a map")
+	if cp != nil {
+		t.Errorf("expected nil for non-map input, got %+v", cp)
+	}
+}
+
+func TestConvertOpenAIPart_TextMissingField(t *testing.T) {
+	// type is "text" but "text" field is missing
+	part := map[string]interface{}{"type": "text"}
+	cp := convertOpenAIPart(part)
+	if cp != nil {
+		t.Errorf("expected nil when text field is missing, got %+v", cp)
+	}
+}
+
+func TestConvertOpenAIPart_ThinkingMissingField(t *testing.T) {
+	// type is "thinking" but "thinking" field is missing
+	part := map[string]interface{}{"type": "thinking"}
+	cp := convertOpenAIPart(part)
+	if cp != nil {
+		t.Errorf("expected nil when thinking field is missing, got %+v", cp)
+	}
+}

--- a/runtime/types/content.go
+++ b/runtime/types/content.go
@@ -54,6 +54,7 @@ const (
 	ContentTypeAudio    = "audio"
 	ContentTypeVideo    = "video"
 	ContentTypeDocument = "document"
+	ContentTypeThinking = "thinking"
 )
 
 // Common MIME types
@@ -86,6 +87,15 @@ const (
 func NewTextPart(text string) ContentPart {
 	return ContentPart{
 		Type: ContentTypeText,
+		Text: &text,
+	}
+}
+
+// NewThinkingPart creates a ContentPart with thinking/reasoning content.
+// Thinking parts are stored alongside text parts but excluded from GetContent().
+func NewThinkingPart(text string) ContentPart {
+	return ContentPart{
+		Type: ContentTypeThinking,
 		Text: &text,
 	}
 }

--- a/runtime/types/content_test.go
+++ b/runtime/types/content_test.go
@@ -24,6 +24,21 @@ func TestNewTextPart(t *testing.T) {
 	}
 }
 
+func TestNewThinkingPart(t *testing.T) {
+	text := "Let me reason about this..."
+	part := NewThinkingPart(text)
+
+	if part.Type != ContentTypeThinking {
+		t.Errorf("expected type %s, got %s", ContentTypeThinking, part.Type)
+	}
+	if part.Text == nil || *part.Text != text {
+		t.Errorf("expected text %q, got %v", text, part.Text)
+	}
+	if part.Media != nil {
+		t.Errorf("expected nil media, got %v", part.Media)
+	}
+}
+
 func TestNewImagePartFromURL(t *testing.T) {
 	url := "https://example.com/image.jpg"
 	detail := "high"


### PR DESCRIPTION
## Summary

Adds `ContentTypeThinking` as a first-class content part type, enabling Claude extended thinking, OpenAI o-series reasoning, and Gemini thinking to be captured alongside text responses.

- **New constant**: `ContentTypeThinking = "thinking"` + `NewThinkingPart(text)` helper
- **No special struct** — thinking uses `ContentPart.Text` like text parts
- **GetContent() unaffected** — already filters for `ContentTypeText` only, so thinking parts are automatically excluded from the content string
- **Claude provider**: parses `"thinking"` content blocks in both standard and tool responses, populates `PredictionResponse.Parts`
- **OpenAI provider**: `extractContentParts` + `convertOpenAIPart` handle `"thinking"` type parts from o-series models, populates `PredictionResponse.Parts`
- **No breaking changes** — existing code using `response.Content` is unaffected

## Test plan

- [x] All existing content type tests pass
- [x] Claude provider tests pass
- [x] OpenAI provider tests pass
- [x] Pre-commit: lint, build, tests, coverage >= 80%
- [ ] CI green
