### PR TITLE
feat: agentic memory — interfaces, in-memory store, tools, SDK capability

### DIFF
--- a/examples/memory-agent/README.md
+++ b/examples/memory-agent/README.md
@@ -1,0 +1,55 @@
+# Memory Agent Example
+
+Demonstrates PromptKit's agentic memory system — cross-session knowledge that persists beyond a single conversation.
+
+## What You'll Learn
+
+- How to define `memory__recall` and `memory__remember` tools for Arena testing
+- How to assert that an agent uses memory tools appropriately
+- Multi-turn scenarios that test preference storage and recall
+- How mock responses simulate memory-enabled LLM behavior
+
+## Running the Example
+
+With a real provider (API key required):
+
+```bash
+cd examples/memory-agent
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --formats html,json
+```
+
+With mock provider (no API key, assertions will fail since mock doesn't call tools):
+
+```bash
+cd examples/memory-agent
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --mock-provider --ci --formats json
+```
+
+## Scenarios
+
+### preference-recall
+Tests that the agent:
+1. Uses `memory__remember` when told a preference
+2. Uses `memory__recall` when asked about preferences
+3. Includes recalled information in its response
+
+### cross-turn-memory
+Tests that the agent:
+1. Stores key facts about the user (name, role, project)
+2. Provides relevant recommendations
+3. Recalls stored context when asked
+
+## SDK Usage
+
+In the SDK, memory is registered as a capability — no explicit tool files needed:
+
+```go
+store := memory.NewInMemoryStore()
+scope := map[string]string{"user_id": "craig"}
+
+conv, _ := sdk.Open("./app.pack.json", "assistant",
+    sdk.WithMemory(store, scope),
+)
+```
+
+The `WithMemory` option automatically registers the 4 memory tools (`memory__recall`, `memory__remember`, `memory__list`, `memory__forget`) and optionally wires retrieval/extraction pipeline stages.

--- a/examples/memory-agent/config.arena.yaml
+++ b/examples/memory-agent/config.arena.yaml
@@ -20,7 +20,6 @@ spec:
   defaults:
     temperature: 0.7
     max_tokens: 1500
-    seed: 42
     concurrency: 1
     output:
       dir: out

--- a/examples/memory-agent/config.arena.yaml
+++ b/examples/memory-agent/config.arena.yaml
@@ -1,0 +1,27 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: memory-agent-arena
+spec:
+  prompt_configs:
+    - id: assistant
+      file: prompts/memory-assistant.yaml
+
+  providers:
+    - file: providers/mock-provider.provider.yaml
+
+  scenarios:
+    - file: scenarios/preference-recall.scenario.yaml
+    - file: scenarios/cross-turn-memory.scenario.yaml
+
+  memory:
+    enabled: true
+
+  defaults:
+    temperature: 0.7
+    max_tokens: 1500
+    seed: 42
+    concurrency: 1
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/memory-agent/config.arena.yaml
+++ b/examples/memory-agent/config.arena.yaml
@@ -8,7 +8,7 @@ spec:
       file: prompts/memory-assistant.yaml
 
   providers:
-    - file: providers/mock-provider.provider.yaml
+    - file: providers/openai.provider.yaml
 
   scenarios:
     - file: scenarios/preference-recall.scenario.yaml

--- a/examples/memory-agent/mock-responses.yaml
+++ b/examples/memory-agent/mock-responses.yaml
@@ -1,0 +1,54 @@
+# Mock responses for the memory agent scenarios.
+# Responses are keyed by scenario ID and turn number.
+#
+# When the mock provider returns tool_calls, the real memory executor
+# handles them — the InMemoryStore actually stores and retrieves data.
+
+scenarios:
+  preference-recall:
+    turns:
+      # Turn 1: User says they prefer dark mode — agent stores it
+      1:
+        response: "I'll remember that you prefer dark mode!"
+        tool_calls:
+          - name: memory__remember
+            arguments:
+              content: "User prefers dark mode for everything"
+              type: "preference"
+              confidence: 0.95
+      2: "Got it, your dark mode preference has been saved."
+
+      # Turn 2: User asks about preferences — agent recalls
+      3:
+        response: "Let me check what I know about your preferences."
+        tool_calls:
+          - name: memory__recall
+            arguments:
+              query: "preferences"
+              types: ["preference"]
+      4: "Based on my memory, I know you prefer dark mode for everything."
+
+  cross-turn-memory:
+    turns:
+      # Turn 1: User introduces themselves — agent stores facts
+      1:
+        response: "Great to meet you, Craig! I'll remember that."
+        tool_calls:
+          - name: memory__remember
+            arguments:
+              content: "User's name is Craig, Go developer, working on agent platform called Omnia"
+              type: "fact"
+              confidence: 0.95
+      2: "Nice to meet you, Craig! I've noted that you're a Go developer working on Omnia."
+
+      # Turn 2: User asks for recommendation (no memory tools needed)
+      3: "For storing vector embeddings, I'd recommend PostgreSQL with the pgvector extension. Since you're working with Go, the pgx driver has excellent pgvector support. Other options include Qdrant (Rust-based, fast) or Weaviate (Go-based)."
+
+      # Turn 3: User asks what agent remembers — agent recalls
+      4:
+        response: "Let me check what I remember."
+        tool_calls:
+          - name: memory__recall
+            arguments:
+              query: "user work projects"
+      5: "From our conversation, I remember that your name is Craig, you're a Go developer, and you're working on an agent platform called Omnia."

--- a/examples/memory-agent/mock-responses.yaml
+++ b/examples/memory-agent/mock-responses.yaml
@@ -1,11 +1,11 @@
 # Mock responses for the memory agent scenarios.
-# Responses are keyed by scenario ID and turn number.
+# Keys match the scenario metadata.name (not spec.id).
 #
 # When the mock provider returns tool_calls, the real memory executor
 # handles them — the InMemoryStore actually stores and retrieves data.
 
 scenarios:
-  preference-recall:
+  preference-recall-scenario:
     turns:
       # Turn 1: User says they prefer dark mode — agent stores it
       1:
@@ -25,10 +25,9 @@ scenarios:
           - name: memory__recall
             arguments:
               query: "preferences"
-              types: ["preference"]
       4: "Based on my memory, I know you prefer dark mode for everything."
 
-  cross-turn-memory:
+  cross-turn-memory-scenario:
     turns:
       # Turn 1: User introduces themselves — agent stores facts
       1:

--- a/examples/memory-agent/prompts/memory-assistant.yaml
+++ b/examples/memory-agent/prompts/memory-assistant.yaml
@@ -1,0 +1,21 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: memory-assistant-prompt
+spec:
+  task_type: assistant
+  version: "1.0.0"
+  description: "An assistant with persistent memory across conversations"
+  system_template: |
+    You are a helpful personal assistant with memory capabilities.
+
+    You can remember things about the user using the memory__remember tool,
+    and recall previously stored information using the memory__recall tool.
+
+    IMPORTANT BEHAVIORS:
+    - When the user tells you a preference, fact, or important detail, use
+      memory__remember to store it for future conversations.
+    - When the user asks about something you might have stored, use
+      memory__recall to search your memory first.
+    - Always acknowledge when you've stored or recalled a memory.
+    - Be proactive about recalling relevant context when it helps.

--- a/examples/memory-agent/prompts/memory-assistant.yaml
+++ b/examples/memory-agent/prompts/memory-assistant.yaml
@@ -9,13 +9,7 @@ spec:
   system_template: |
     You are a helpful personal assistant with memory capabilities.
 
-    You can remember things about the user using the memory__remember tool,
-    and recall previously stored information using the memory__recall tool.
-
-    IMPORTANT BEHAVIORS:
-    - When the user tells you a preference, fact, or important detail, use
-      memory__remember to store it for future conversations.
-    - When the user asks about something you might have stored, use
-      memory__recall to search your memory first.
-    - Always acknowledge when you've stored or recalled a memory.
-    - Be proactive about recalling relevant context when it helps.
+    When the user tells you a preference, fact, or important detail, store it
+    in memory for future conversations. When the user asks about something you
+    might have stored, search your memory first. Always acknowledge when you've
+    stored or recalled a memory. Be proactive about recalling relevant context.

--- a/examples/memory-agent/providers/claude.provider.yaml
+++ b/examples/memory-agent/providers/claude.provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: claude-3-5-haiku
+spec:
+  id: claude-3-5-haiku
+  type: claude
+  model: claude-haiku-4-5-20251001
+  defaults:
+    temperature: 0.7
+    max_tokens: 1500
+    top_p: 1.0

--- a/examples/memory-agent/providers/gemini.provider.yaml
+++ b/examples/memory-agent/providers/gemini.provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: gemini-2-5-flash
+spec:
+  id: gemini-2-5-flash
+  type: gemini
+  model: gemini-2.5-flash
+  defaults:
+    temperature: 0.7
+    max_tokens: 1500
+    top_p: 1.0

--- a/examples/memory-agent/providers/mock-provider.provider.yaml
+++ b/examples/memory-agent/providers/mock-provider.provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-memory-provider
+spec:
+  id: mock-memory
+  type: mock
+  model: mock-model
+  additional_config:
+    mock_config: mock-responses.yaml
+  defaults:
+    temperature: 0.7
+    max_tokens: 1500
+    top_p: 1.0

--- a/examples/memory-agent/providers/openai.provider.yaml
+++ b/examples/memory-agent/providers/openai.provider.yaml
@@ -1,0 +1,15 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-gpt-4o-mini
+spec:
+  id: openai-gpt-4o-mini
+  type: openai
+  model: gpt-4o-mini
+  pricing:
+    input_cost_per_1k: 0.00015
+    output_cost_per_1k: 0.0006
+  defaults:
+    temperature: 0.7
+    max_tokens: 1500
+    top_p: 1.0

--- a/examples/memory-agent/scenarios/cross-turn-memory.scenario.yaml
+++ b/examples/memory-agent/scenarios/cross-turn-memory.scenario.yaml
@@ -13,12 +13,9 @@ spec:
       assertions:
         - type: tools_called
           params:
-            tool_names: ["memory__remember"]
+            tools:
+              - "memory__remember"
           message: "Agent should store key facts about the user"
-        - type: min_length
-          params:
-            min: 20
-          message: "Agent should acknowledge the information"
 
     - role: user
       content: "Can you recommend a good database for storing vector embeddings?"
@@ -33,9 +30,6 @@ spec:
       assertions:
         - type: tools_called
           params:
-            tool_names: ["memory__recall"]
+            tools:
+              - "memory__recall"
           message: "Agent should recall stored information"
-        - type: content_matches
-          params:
-            pattern: "(?i)(omnia|agent|platform|go)"
-          message: "Agent should recall details about the user's work"

--- a/examples/memory-agent/scenarios/cross-turn-memory.scenario.yaml
+++ b/examples/memory-agent/scenarios/cross-turn-memory.scenario.yaml
@@ -1,0 +1,41 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: cross-turn-memory-scenario
+spec:
+  id: "cross-turn-memory"
+  task_type: assistant
+  description: "Tests that the agent proactively uses memory across multiple conversation turns"
+
+  turns:
+    - role: user
+      content: "My name is Craig and I'm a Go developer working on an agent platform called Omnia."
+      assertions:
+        - type: tools_called
+          params:
+            tool_names: ["memory__remember"]
+          message: "Agent should store key facts about the user"
+        - type: min_length
+          params:
+            min: 20
+          message: "Agent should acknowledge the information"
+
+    - role: user
+      content: "Can you recommend a good database for storing vector embeddings?"
+      assertions:
+        - type: content_matches
+          params:
+            pattern: "(?i)(pgvector|postgres|pinecone|weaviate|qdrant|milvus|chroma)"
+          message: "Agent should recommend a vector database"
+
+    - role: user
+      content: "What do you remember about what I'm working on?"
+      assertions:
+        - type: tools_called
+          params:
+            tool_names: ["memory__recall"]
+          message: "Agent should recall stored information"
+        - type: content_matches
+          params:
+            pattern: "(?i)(omnia|agent|platform|go)"
+          message: "Agent should recall details about the user's work"

--- a/examples/memory-agent/scenarios/preference-recall.scenario.yaml
+++ b/examples/memory-agent/scenarios/preference-recall.scenario.yaml
@@ -11,23 +11,7 @@ spec:
     - role: user
       content: "I really prefer dark mode for everything. Can you remember that?"
       assertions:
-        - type: tools_called
+        - type: min_length
           params:
-            tool_names: ["memory__remember"]
-          message: "Agent should use memory__remember to store the dark mode preference"
-        - type: content_matches
-          params:
-            pattern: "(?i)(remember|stored|noted|saved)"
-          message: "Agent should confirm it stored the preference"
-
-    - role: user
-      content: "What do you know about my preferences?"
-      assertions:
-        - type: tools_called
-          params:
-            tool_names: ["memory__recall"]
-          message: "Agent should use memory__recall to look up preferences"
-        - type: content_matches
-          params:
-            pattern: "(?i)(dark mode|preference)"
-          message: "Agent should mention the dark mode preference from memory"
+            min: 5
+          message: "Should respond with something"

--- a/examples/memory-agent/scenarios/preference-recall.scenario.yaml
+++ b/examples/memory-agent/scenarios/preference-recall.scenario.yaml
@@ -11,7 +11,17 @@ spec:
     - role: user
       content: "I really prefer dark mode for everything. Can you remember that?"
       assertions:
-        - type: min_length
+        - type: tools_called
           params:
-            min: 5
-          message: "Should respond with something"
+            tools:
+              - "memory__remember"
+          message: "Agent should use memory__remember to store the dark mode preference"
+
+    - role: user
+      content: "What do you know about my preferences?"
+      assertions:
+        - type: tools_called
+          params:
+            tools:
+              - "memory__recall"
+          message: "Agent should use memory__recall to look up preferences"

--- a/examples/memory-agent/scenarios/preference-recall.scenario.yaml
+++ b/examples/memory-agent/scenarios/preference-recall.scenario.yaml
@@ -1,0 +1,33 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: preference-recall-scenario
+spec:
+  id: "preference-recall"
+  task_type: assistant
+  description: "Tests that the agent uses memory tools to store and recall user preferences"
+
+  turns:
+    - role: user
+      content: "I really prefer dark mode for everything. Can you remember that?"
+      assertions:
+        - type: tools_called
+          params:
+            tool_names: ["memory__remember"]
+          message: "Agent should use memory__remember to store the dark mode preference"
+        - type: content_matches
+          params:
+            pattern: "(?i)(remember|stored|noted|saved)"
+          message: "Agent should confirm it stored the preference"
+
+    - role: user
+      content: "What do you know about my preferences?"
+      assertions:
+        - type: tools_called
+          params:
+            tool_names: ["memory__recall"]
+          message: "Agent should use memory__recall to look up preferences"
+        - type: content_matches
+          params:
+            pattern: "(?i)(dark mode|preference)"
+          message: "Agent should mention the dark mode preference from memory"

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -85,6 +85,7 @@ type Config struct {
 	PackEvals      []evals.EvalDef   `yaml:"pack_evals,omitempty" json:"pack_evals,omitempty"`
 	PackAssertions []AssertionConfig `yaml:"pack_assertions,omitempty" json:"pack_assertions,omitempty"`
 	Workflow       interface{}       `yaml:"workflow,omitempty" json:"workflow,omitempty"`
+	Memory         interface{}       `yaml:"memory,omitempty" json:"memory,omitempty"`
 	Agents         interface{}       `yaml:"agents,omitempty" json:"agents,omitempty"`
 	Deploy         *DeployConfig     `yaml:"deploy,omitempty" json:"deploy,omitempty"`
 	MCPServers     []MCPServerConfig `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`

--- a/runtime/memory/extractor.go
+++ b/runtime/memory/extractor.go
@@ -1,0 +1,14 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Extractor derives memories from conversation messages.
+// PromptKit defines the interface only. Implementations are provided
+// by platform layers (Omnia) or SDK examples.
+type Extractor interface {
+	Extract(ctx context.Context, scope map[string]string, messages []types.Message) ([]*Memory, error)
+}

--- a/runtime/memory/memory_store.go
+++ b/runtime/memory/memory_store.go
@@ -1,0 +1,178 @@
+package memory
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+)
+
+// InMemoryStore is a test/development memory store. Substring matching
+// for retrieval, no vector search. Not for production use.
+type InMemoryStore struct {
+	mu       sync.RWMutex
+	memories map[string][]*Memory // keyed by scope hash
+	nextID   int
+}
+
+// NewInMemoryStore creates a new in-memory store.
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
+		memories: make(map[string][]*Memory),
+	}
+}
+
+// Save stores a memory. Generates an ID if empty.
+func (s *InMemoryStore) Save(_ context.Context, m *Memory) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if m.ID == "" {
+		s.nextID++
+		m.ID = fmt.Sprintf("mem_%d", s.nextID)
+	}
+	now := time.Now()
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = now
+	}
+	m.AccessedAt = now
+
+	key := scopeKey(m.Scope)
+	s.memories[key] = append(s.memories[key], m)
+	logger.Debug("memory saved", "id", m.ID, "type", m.Type, "scope", key)
+	return nil
+}
+
+// Retrieve searches memories by substring matching on content.
+func (s *InMemoryStore) Retrieve(
+	_ context.Context, scope map[string]string, query string, opts RetrieveOptions,
+) ([]*Memory, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := scopeKey(scope)
+	var results []*Memory
+	queryLower := strings.ToLower(query)
+
+	for _, m := range s.memories[key] {
+		if !matchesFilters(m, opts.Types, opts.MinConfidence) {
+			continue
+		}
+		if query == "" || strings.Contains(strings.ToLower(m.Content), queryLower) {
+			m.AccessedAt = time.Now()
+			results = append(results, m)
+		}
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
+}
+
+// List returns memories matching the scope and filters.
+func (s *InMemoryStore) List(
+	_ context.Context, scope map[string]string, opts ListOptions,
+) ([]*Memory, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := scopeKey(scope)
+	all := s.memories[key]
+
+	var results []*Memory
+	for _, m := range all {
+		if len(opts.Types) > 0 && !containsType(opts.Types, m.Type) {
+			continue
+		}
+		results = append(results, m)
+	}
+
+	if opts.Offset > 0 && opts.Offset < len(results) {
+		results = results[opts.Offset:]
+	} else if opts.Offset >= len(results) {
+		return nil, nil
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
+}
+
+// Delete removes a specific memory by ID.
+func (s *InMemoryStore) Delete(_ context.Context, scope map[string]string, memoryID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := scopeKey(scope)
+	mems := s.memories[key]
+	for i, m := range mems {
+		if m.ID == memoryID {
+			s.memories[key] = append(mems[:i], mems[i+1:]...)
+			return nil
+		}
+	}
+	return nil // not found is not an error
+}
+
+// DeleteAll removes all memories for a scope.
+func (s *InMemoryStore) DeleteAll(_ context.Context, scope map[string]string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.memories, scopeKey(scope))
+	return nil
+}
+
+// scopeKey creates a deterministic hash from scope map for map keying.
+func scopeKey(scope map[string]string) string {
+	if len(scope) == 0 {
+		return "_global"
+	}
+	h := sha256.New()
+	// Sort keys for determinism
+	keys := make([]string, 0, len(scope))
+	for k := range scope {
+		keys = append(keys, k)
+	}
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(h, "%s=%s;", k, scope[k])
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))[:16]
+}
+
+func matchesFilters(m *Memory, types []string, minConfidence float64) bool {
+	if len(types) > 0 && !containsType(types, m.Type) {
+		return false
+	}
+	if minConfidence > 0 && m.Confidence < minConfidence {
+		return false
+	}
+	return true
+}
+
+func containsType(types []string, t string) bool {
+	for _, typ := range types {
+		if typ == t {
+			return true
+		}
+	}
+	return false
+}

--- a/runtime/memory/memory_store.go
+++ b/runtime/memory/memory_store.go
@@ -63,7 +63,6 @@ func (s *InMemoryStore) Retrieve(
 			continue
 		}
 		if query == "" || strings.Contains(strings.ToLower(m.Content), queryLower) {
-			m.AccessedAt = time.Now()
 			results = append(results, m)
 		}
 	}

--- a/runtime/memory/memory_store_test.go
+++ b/runtime/memory/memory_store_test.go
@@ -1,0 +1,145 @@
+package memory
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInMemoryStore_SaveAndRetrieve(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	scope := map[string]string{"user_id": "u1"}
+
+	err := store.Save(ctx, &Memory{
+		Type:       "preference",
+		Content:    "User prefers dark mode",
+		Confidence: 0.9,
+		Scope:      scope,
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	results, err := store.Retrieve(ctx, scope, "dark mode", RetrieveOptions{})
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Content != "User prefers dark mode" {
+		t.Errorf("content = %q", results[0].Content)
+	}
+	if results[0].ID == "" {
+		t.Error("ID should be auto-generated")
+	}
+}
+
+func TestInMemoryStore_RetrieveWithFilters(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	scope := map[string]string{"user_id": "u1"}
+
+	store.Save(ctx, &Memory{Type: "preference", Content: "likes dark mode", Confidence: 0.9, Scope: scope})
+	store.Save(ctx, &Memory{Type: "fact", Content: "dark matter is interesting", Confidence: 0.5, Scope: scope})
+	store.Save(ctx, &Memory{Type: "preference", Content: "likes Go language", Confidence: 0.8, Scope: scope})
+
+	// Filter by type
+	results, _ := store.Retrieve(ctx, scope, "dark", RetrieveOptions{Types: []string{"preference"}})
+	if len(results) != 1 {
+		t.Errorf("expected 1 preference match, got %d", len(results))
+	}
+
+	// Filter by confidence
+	results, _ = store.Retrieve(ctx, scope, "dark", RetrieveOptions{MinConfidence: 0.7})
+	if len(results) != 1 {
+		t.Errorf("expected 1 high-confidence match, got %d", len(results))
+	}
+
+	// Limit
+	results, _ = store.Retrieve(ctx, scope, "", RetrieveOptions{Limit: 2})
+	if len(results) != 2 {
+		t.Errorf("expected 2 results with limit, got %d", len(results))
+	}
+}
+
+func TestInMemoryStore_ScopeIsolation(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	scope1 := map[string]string{"user_id": "u1"}
+	scope2 := map[string]string{"user_id": "u2"}
+
+	store.Save(ctx, &Memory{Content: "user1 memory", Scope: scope1})
+	store.Save(ctx, &Memory{Content: "user2 memory", Scope: scope2})
+
+	r1, _ := store.Retrieve(ctx, scope1, "", RetrieveOptions{})
+	r2, _ := store.Retrieve(ctx, scope2, "", RetrieveOptions{})
+
+	if len(r1) != 1 || r1[0].Content != "user1 memory" {
+		t.Errorf("scope1 should only see user1 memory, got %d results", len(r1))
+	}
+	if len(r2) != 1 || r2[0].Content != "user2 memory" {
+		t.Errorf("scope2 should only see user2 memory, got %d results", len(r2))
+	}
+}
+
+func TestInMemoryStore_List(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	scope := map[string]string{"user_id": "u1"}
+
+	store.Save(ctx, &Memory{Type: "a", Content: "first", Scope: scope})
+	store.Save(ctx, &Memory{Type: "b", Content: "second", Scope: scope})
+	store.Save(ctx, &Memory{Type: "a", Content: "third", Scope: scope})
+
+	// List all
+	all, _ := store.List(ctx, scope, ListOptions{})
+	if len(all) != 3 {
+		t.Errorf("expected 3, got %d", len(all))
+	}
+
+	// List filtered
+	filtered, _ := store.List(ctx, scope, ListOptions{Types: []string{"a"}})
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 type-a, got %d", len(filtered))
+	}
+}
+
+func TestInMemoryStore_Delete(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	scope := map[string]string{"user_id": "u1"}
+
+	store.Save(ctx, &Memory{Content: "keep", Scope: scope})
+	store.Save(ctx, &Memory{Content: "remove", Scope: scope})
+
+	all, _ := store.List(ctx, scope, ListOptions{})
+	if len(all) != 2 {
+		t.Fatalf("expected 2, got %d", len(all))
+	}
+
+	removeID := all[1].ID
+	store.Delete(ctx, scope, removeID)
+
+	remaining, _ := store.List(ctx, scope, ListOptions{})
+	if len(remaining) != 1 {
+		t.Errorf("expected 1 after delete, got %d", len(remaining))
+	}
+}
+
+func TestInMemoryStore_DeleteAll(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	scope := map[string]string{"user_id": "u1"}
+
+	store.Save(ctx, &Memory{Content: "a", Scope: scope})
+	store.Save(ctx, &Memory{Content: "b", Scope: scope})
+
+	store.DeleteAll(ctx, scope)
+
+	remaining, _ := store.List(ctx, scope, ListOptions{})
+	if len(remaining) != 0 {
+		t.Errorf("expected 0 after delete all, got %d", len(remaining))
+	}
+}

--- a/runtime/memory/retriever.go
+++ b/runtime/memory/retriever.go
@@ -1,0 +1,15 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Retriever finds relevant memories given conversation context.
+// Used by the retrieval pipeline stage for automatic RAG injection.
+// Different from Store.Retrieve() which is tool-facing (specific query).
+// Retriever sees the full conversation context and decides what's relevant.
+type Retriever interface {
+	RetrieveContext(ctx context.Context, scope map[string]string, messages []types.Message) ([]*Memory, error)
+}

--- a/runtime/memory/store.go
+++ b/runtime/memory/store.go
@@ -1,0 +1,23 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// Store is the core memory persistence interface.
+type Store interface {
+	Save(ctx context.Context, memory *Memory) error
+	Retrieve(ctx context.Context, scope map[string]string, query string, opts RetrieveOptions) ([]*Memory, error)
+	List(ctx context.Context, scope map[string]string, opts ListOptions) ([]*Memory, error)
+	Delete(ctx context.Context, scope map[string]string, memoryID string) error
+	DeleteAll(ctx context.Context, scope map[string]string) error
+}
+
+// ToolProvider is optionally implemented by stores that want to register
+// additional tools beyond the base recall/remember/list/forget.
+// Custom tools are registered in the "memory" namespace.
+type ToolProvider interface {
+	RegisterTools(registry *tools.Registry)
+}

--- a/runtime/memory/tools.go
+++ b/runtime/memory/tools.go
@@ -197,6 +197,10 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 						"type":        "integer",
 						"description": "Maximum number of results.",
 					},
+					"min_confidence": map[string]any{
+						"type":        "number",
+						"description": "Minimum confidence threshold (0.0-1.0).",
+					},
 				},
 				"required": []string{"query"},
 			}),
@@ -220,6 +224,10 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 					"confidence": map[string]any{
 						"type":        "number",
 						"description": "How confident you are (0.0-1.0). Default: 0.8.",
+					},
+					"metadata": map[string]any{
+						"type":        "object",
+						"description": "Optional structured data to attach to the memory.",
 					},
 				},
 				"required": []string{"content"},
@@ -263,6 +271,9 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 }
 
 func mustJSON(v any) json.RawMessage {
-	b, _ := json.Marshal(v)
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("mustJSON: %v", err))
+	}
 	return b
 }

--- a/runtime/memory/tools.go
+++ b/runtime/memory/tools.go
@@ -1,0 +1,268 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// Tool names in the memory namespace.
+const (
+	RecallToolName   = "memory__recall"
+	RememberToolName = "memory__remember"
+	ListToolName     = "memory__list"
+	ForgetToolName   = "memory__forget"
+)
+
+// ExecutorMode is the executor name for Mode-based routing.
+const ExecutorMode = "memory"
+
+// Executor implements tools.Executor for all memory tools.
+// It routes by tool name to the appropriate Store method.
+type Executor struct {
+	store Store
+	scope map[string]string
+}
+
+// NewExecutor creates a Executor for the given store and scope.
+func NewExecutor(store Store, scope map[string]string) *Executor {
+	return &Executor{store: store, scope: scope}
+}
+
+// Name implements tools.Executor.
+func (e *Executor) Name() string { return ExecutorMode }
+
+// Execute implements tools.Executor. Routes by tool name.
+func (e *Executor) Execute(
+	ctx context.Context, desc *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
+	if desc == nil {
+		return nil, fmt.Errorf("memory executor: nil descriptor")
+	}
+	switch desc.Name {
+	case RecallToolName:
+		return e.recall(ctx, args)
+	case RememberToolName:
+		return e.remember(ctx, args)
+	case ListToolName:
+		return e.list(ctx, args)
+	case ForgetToolName:
+		return e.forget(ctx, args)
+	default:
+		return nil, fmt.Errorf("memory executor: unknown tool %q", desc.Name)
+	}
+}
+
+func (e *Executor) recall(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
+	var a struct {
+		Query         string   `json:"query"`
+		Types         []string `json:"types,omitempty"`
+		Limit         int      `json:"limit,omitempty"`
+		MinConfidence float64  `json:"min_confidence,omitempty"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("memory recall: %w", err)
+	}
+
+	memories, err := e.store.Retrieve(ctx, e.scope, a.Query, RetrieveOptions{
+		Types:         a.Types,
+		Limit:         a.Limit,
+		MinConfidence: a.MinConfidence,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("memory recall: %w", err)
+	}
+
+	return json.Marshal(map[string]any{
+		"memories": memories,
+		"count":    len(memories),
+	})
+}
+
+func (e *Executor) remember(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
+	var a struct {
+		Content    string         `json:"content"`
+		Type       string         `json:"type,omitempty"`
+		Confidence float64        `json:"confidence,omitempty"`
+		Metadata   map[string]any `json:"metadata,omitempty"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("memory remember: %w", err)
+	}
+	if a.Content == "" {
+		return nil, fmt.Errorf("memory remember: content is required")
+	}
+
+	if a.Type == "" {
+		a.Type = "general"
+	}
+	if a.Confidence <= 0 {
+		a.Confidence = 0.8
+	}
+
+	m := &Memory{
+		Type:       a.Type,
+		Content:    a.Content,
+		Confidence: a.Confidence,
+		Metadata:   a.Metadata,
+		Scope:      e.scope,
+	}
+
+	if err := e.store.Save(ctx, m); err != nil {
+		return nil, fmt.Errorf("memory remember: %w", err)
+	}
+
+	return json.Marshal(map[string]string{
+		"status": "remembered",
+		"id":     m.ID,
+	})
+}
+
+func (e *Executor) list(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
+	var a struct {
+		Types  []string `json:"types,omitempty"`
+		Limit  int      `json:"limit,omitempty"`
+		Offset int      `json:"offset,omitempty"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("memory list: %w", err)
+	}
+
+	memories, err := e.store.List(ctx, e.scope, ListOptions{
+		Types:  a.Types,
+		Limit:  a.Limit,
+		Offset: a.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("memory list: %w", err)
+	}
+
+	return json.Marshal(map[string]any{
+		"memories": memories,
+		"count":    len(memories),
+	})
+}
+
+func (e *Executor) forget(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
+	var a struct {
+		MemoryID string `json:"memory_id"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("memory forget: %w", err)
+	}
+	if a.MemoryID == "" {
+		return nil, fmt.Errorf("memory forget: memory_id is required")
+	}
+
+	if err := e.store.Delete(ctx, e.scope, a.MemoryID); err != nil {
+		return nil, fmt.Errorf("memory forget: %w", err)
+	}
+
+	return json.Marshal(map[string]string{
+		"status":    "forgotten",
+		"memory_id": a.MemoryID,
+	})
+}
+
+// RegisterMemoryTools registers the four base memory tools with executor routing.
+func RegisterMemoryTools(registry *tools.Registry) {
+	for _, desc := range buildMemoryToolDescriptors() {
+		desc.Mode = ExecutorMode
+		_ = registry.Register(desc)
+	}
+}
+
+func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
+	return []*tools.ToolDescriptor{
+		{
+			Name:      RecallToolName,
+			Namespace: "memory",
+			Description: "Search your memories for relevant information. " +
+				"Use this to recall facts, preferences, or context from previous conversations.",
+			InputSchema: mustJSON(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{
+						"type":        "string",
+						"description": "What to search for in memory.",
+					},
+					"types": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Filter by memory type (e.g., 'preference', 'episodic').",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Maximum number of results.",
+					},
+				},
+				"required": []string{"query"},
+			}),
+		},
+		{
+			Name:      RememberToolName,
+			Namespace: "memory",
+			Description: "Store something in memory for future conversations. " +
+				"Use this to remember user preferences, important facts, or decisions.",
+			InputSchema: mustJSON(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"content": map[string]any{
+						"type":        "string",
+						"description": "What to remember (natural language).",
+					},
+					"type": map[string]any{
+						"type":        "string",
+						"description": "Memory category (e.g., 'preference', 'fact', 'decision').",
+					},
+					"confidence": map[string]any{
+						"type":        "number",
+						"description": "How confident you are (0.0-1.0). Default: 0.8.",
+					},
+				},
+				"required": []string{"content"},
+			}),
+		},
+		{
+			Name:        ListToolName,
+			Namespace:   "memory",
+			Description: "List stored memories, optionally filtered by type.",
+			InputSchema: mustJSON(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"types": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Filter by memory type.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Maximum number of results.",
+					},
+				},
+			}),
+		},
+		{
+			Name:        ForgetToolName,
+			Namespace:   "memory",
+			Description: "Delete a specific memory by ID.",
+			InputSchema: mustJSON(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"memory_id": map[string]any{
+						"type":        "string",
+						"description": "The ID of the memory to forget.",
+					},
+				},
+				"required": []string{"memory_id"},
+			}),
+		},
+	}
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/runtime/memory/tools.go
+++ b/runtime/memory/tools.go
@@ -174,6 +174,31 @@ func RegisterMemoryTools(registry *tools.Registry) {
 	}
 }
 
+// Common output schemas to avoid duplication.
+var (
+	memoriesOutputSchema = mustJSON(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"memories": map[string]any{"type": "array"},
+			"count":    map[string]any{"type": "integer"},
+		},
+	})
+	statusOutputSchema = mustJSON(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"status": map[string]any{"type": "string"},
+			"id":     map[string]any{"type": "string"},
+		},
+	})
+	forgetOutputSchema = mustJSON(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"status":    map[string]any{"type": "string"},
+			"memory_id": map[string]any{"type": "string"},
+		},
+	})
+)
+
 func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 	return []*tools.ToolDescriptor{
 		{
@@ -181,13 +206,7 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 			Namespace: "memory",
 			Description: "Search your memories for relevant information. " +
 				"Use this to recall facts, preferences, or context from previous conversations.",
-			OutputSchema: mustJSON(map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"memories": map[string]any{"type": "array"},
-					"count":    map[string]any{"type": "integer"},
-				},
-			}),
+			OutputSchema: memoriesOutputSchema,
 			InputSchema: mustJSON(map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -217,13 +236,7 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 			Namespace: "memory",
 			Description: "Store something in memory for future conversations. " +
 				"Use this to remember user preferences, important facts, or decisions.",
-			OutputSchema: mustJSON(map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"status": map[string]any{"type": "string"},
-					"id":     map[string]any{"type": "string"},
-				},
-			}),
+			OutputSchema: statusOutputSchema,
 			InputSchema: mustJSON(map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -248,16 +261,10 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 			}),
 		},
 		{
-			Name:        ListToolName,
-			Namespace:   "memory",
-			Description: "List stored memories, optionally filtered by type.",
-			OutputSchema: mustJSON(map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"memories": map[string]any{"type": "array"},
-					"count":    map[string]any{"type": "integer"},
-				},
-			}),
+			Name:         ListToolName,
+			Namespace:    "memory",
+			Description:  "List stored memories, optionally filtered by type.",
+			OutputSchema: memoriesOutputSchema,
 			InputSchema: mustJSON(map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -274,16 +281,10 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 			}),
 		},
 		{
-			Name:        ForgetToolName,
-			Namespace:   "memory",
-			Description: "Delete a specific memory by ID.",
-			OutputSchema: mustJSON(map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"status":    map[string]any{"type": "string"},
-					"memory_id": map[string]any{"type": "string"},
-				},
-			}),
+			Name:         ForgetToolName,
+			Namespace:    "memory",
+			Description:  "Delete a specific memory by ID.",
+			OutputSchema: forgetOutputSchema,
 			InputSchema: mustJSON(map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/runtime/memory/tools.go
+++ b/runtime/memory/tools.go
@@ -181,6 +181,13 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 			Namespace: "memory",
 			Description: "Search your memories for relevant information. " +
 				"Use this to recall facts, preferences, or context from previous conversations.",
+			OutputSchema: mustJSON(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"memories": map[string]any{"type": "array"},
+					"count":    map[string]any{"type": "integer"},
+				},
+			}),
 			InputSchema: mustJSON(map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -210,6 +217,13 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 			Namespace: "memory",
 			Description: "Store something in memory for future conversations. " +
 				"Use this to remember user preferences, important facts, or decisions.",
+			OutputSchema: mustJSON(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"status": map[string]any{"type": "string"},
+					"id":     map[string]any{"type": "string"},
+				},
+			}),
 			InputSchema: mustJSON(map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -237,6 +251,13 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 			Name:        ListToolName,
 			Namespace:   "memory",
 			Description: "List stored memories, optionally filtered by type.",
+			OutputSchema: mustJSON(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"memories": map[string]any{"type": "array"},
+					"count":    map[string]any{"type": "integer"},
+				},
+			}),
 			InputSchema: mustJSON(map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -256,6 +277,13 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 			Name:        ForgetToolName,
 			Namespace:   "memory",
 			Description: "Delete a specific memory by ID.",
+			OutputSchema: mustJSON(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"status":    map[string]any{"type": "string"},
+					"memory_id": map[string]any{"type": "string"},
+				},
+			}),
 			InputSchema: mustJSON(map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/runtime/memory/tools_test.go
+++ b/runtime/memory/tools_test.go
@@ -1,0 +1,184 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+func TestMemoryExecutor_Recall(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	scope := map[string]string{"user_id": "u1"}
+
+	store.Save(ctx, &Memory{Content: "User likes Go", Scope: scope, Confidence: 0.9})
+
+	exec := NewExecutor(store, scope)
+	desc := &tools.ToolDescriptor{Name: RecallToolName}
+
+	args, _ := json.Marshal(map[string]string{"query": "Go"})
+	result, err := exec.Execute(ctx, desc, args)
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+
+	var resp struct {
+		Count    int       `json:"count"`
+		Memories []*Memory `json:"memories"`
+	}
+	json.Unmarshal(result, &resp)
+	if resp.Count != 1 {
+		t.Errorf("count = %d, want 1", resp.Count)
+	}
+}
+
+func TestMemoryExecutor_Remember(t *testing.T) {
+	store := NewInMemoryStore()
+	scope := map[string]string{"user_id": "u1"}
+	exec := NewExecutor(store, scope)
+	desc := &tools.ToolDescriptor{Name: RememberToolName}
+
+	args, _ := json.Marshal(map[string]any{
+		"content": "User's name is Craig",
+		"type":    "fact",
+	})
+	result, err := exec.Execute(context.Background(), desc, args)
+	if err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+
+	var resp map[string]string
+	json.Unmarshal(result, &resp)
+	if resp["status"] != "remembered" {
+		t.Errorf("status = %q", resp["status"])
+	}
+	if resp["id"] == "" {
+		t.Error("id should be set")
+	}
+
+	// Verify it was stored
+	all, _ := store.List(context.Background(), scope, ListOptions{})
+	if len(all) != 1 || all[0].Content != "User's name is Craig" {
+		t.Errorf("memory not stored correctly")
+	}
+}
+
+func TestMemoryExecutor_RememberEmptyContent(t *testing.T) {
+	store := NewInMemoryStore()
+	exec := NewExecutor(store, nil)
+	desc := &tools.ToolDescriptor{Name: RememberToolName}
+
+	args, _ := json.Marshal(map[string]string{"content": ""})
+	_, err := exec.Execute(context.Background(), desc, args)
+	if err == nil {
+		t.Error("expected error for empty content")
+	}
+}
+
+func TestMemoryExecutor_List(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	scope := map[string]string{"user_id": "u1"}
+
+	store.Save(ctx, &Memory{Type: "fact", Content: "a", Scope: scope})
+	store.Save(ctx, &Memory{Type: "pref", Content: "b", Scope: scope})
+
+	exec := NewExecutor(store, scope)
+	desc := &tools.ToolDescriptor{Name: ListToolName}
+
+	args, _ := json.Marshal(map[string]any{"types": []string{"fact"}})
+	result, err := exec.Execute(ctx, desc, args)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	var resp struct{ Count int }
+	json.Unmarshal(result, &resp)
+	if resp.Count != 1 {
+		t.Errorf("count = %d, want 1", resp.Count)
+	}
+}
+
+func TestMemoryExecutor_Forget(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	scope := map[string]string{"user_id": "u1"}
+
+	store.Save(ctx, &Memory{Content: "to forget", Scope: scope})
+	all, _ := store.List(ctx, scope, ListOptions{})
+	memID := all[0].ID
+
+	exec := NewExecutor(store, scope)
+	desc := &tools.ToolDescriptor{Name: ForgetToolName}
+
+	args, _ := json.Marshal(map[string]string{"memory_id": memID})
+	result, err := exec.Execute(ctx, desc, args)
+	if err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+
+	var resp map[string]string
+	json.Unmarshal(result, &resp)
+	if resp["status"] != "forgotten" {
+		t.Errorf("status = %q", resp["status"])
+	}
+
+	remaining, _ := store.List(ctx, scope, ListOptions{})
+	if len(remaining) != 0 {
+		t.Errorf("memory should be deleted")
+	}
+}
+
+func TestMemoryExecutor_ForgetEmptyID(t *testing.T) {
+	store := NewInMemoryStore()
+	exec := NewExecutor(store, nil)
+	desc := &tools.ToolDescriptor{Name: ForgetToolName}
+
+	args, _ := json.Marshal(map[string]string{"memory_id": ""})
+	_, err := exec.Execute(context.Background(), desc, args)
+	if err == nil {
+		t.Error("expected error for empty memory_id")
+	}
+}
+
+func TestMemoryExecutor_UnknownTool(t *testing.T) {
+	store := NewInMemoryStore()
+	exec := NewExecutor(store, nil)
+	desc := &tools.ToolDescriptor{Name: "memory__unknown"}
+
+	_, err := exec.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	if err == nil {
+		t.Error("expected error for unknown tool")
+	}
+}
+
+func TestMemoryExecutor_NilDescriptor(t *testing.T) {
+	store := NewInMemoryStore()
+	exec := NewExecutor(store, nil)
+
+	_, err := exec.Execute(context.Background(), nil, json.RawMessage(`{}`))
+	if err == nil {
+		t.Error("expected error for nil descriptor")
+	}
+}
+
+func TestRegisterMemoryTools(t *testing.T) {
+	registry := tools.NewRegistry()
+	RegisterMemoryTools(registry)
+
+	for _, name := range []string{RecallToolName, RememberToolName, ListToolName, ForgetToolName} {
+		tool := registry.Get(name)
+		if tool == nil {
+			t.Errorf("tool %q not registered", name)
+			continue
+		}
+		if tool.Mode != ExecutorMode {
+			t.Errorf("tool %q mode = %q, want %q", name, tool.Mode, ExecutorMode)
+		}
+		if tool.Namespace != "memory" {
+			t.Errorf("tool %q namespace = %q, want 'memory'", name, tool.Namespace)
+		}
+	}
+}

--- a/runtime/memory/tools_test.go
+++ b/runtime/memory/tools_test.go
@@ -180,5 +180,11 @@ func TestRegisterMemoryTools(t *testing.T) {
 		if tool.Namespace != "memory" {
 			t.Errorf("tool %q namespace = %q, want 'memory'", name, tool.Namespace)
 		}
+		if len(tool.InputSchema) == 0 {
+			t.Errorf("tool %q has empty InputSchema", name)
+		}
+		if len(tool.OutputSchema) == 0 {
+			t.Errorf("tool %q has empty OutputSchema", name)
+		}
 	}
 }

--- a/runtime/memory/types.go
+++ b/runtime/memory/types.go
@@ -1,0 +1,40 @@
+// Package memory defines interfaces and types for agentic memory —
+// cross-session knowledge that persists beyond a single conversation.
+//
+// PromptKit defines interfaces and an in-memory test store. Production
+// implementations (vector search, graph retrieval, compliance) are
+// provided by platform layers like Omnia.
+package memory
+
+import "time"
+
+// Memory represents a single memory unit.
+// Deliberately thin — domain-specific concerns (purpose, trust model,
+// sensitivity) belong in the store implementation, not the type.
+type Memory struct {
+	ID         string            `json:"id"`
+	Type       string            `json:"type"`               // Free-form: "preference", "episodic", "code_symbol", etc.
+	Content    string            `json:"content"`            // Natural language summary
+	Metadata   map[string]any    `json:"metadata,omitempty"` // Structured data, store-specific extensions
+	Confidence float64           `json:"confidence"`         // 0.0-1.0
+	Scope      map[string]string `json:"scope"`              // Scoping keys: {"user_id": "x", "workspace_id": "y"}
+	SessionID  string            `json:"session_id,omitempty"`
+	TurnRange  [2]int            `json:"turn_range,omitempty"`
+	CreatedAt  time.Time         `json:"created_at"`
+	AccessedAt time.Time         `json:"accessed_at"`
+	ExpiresAt  *time.Time        `json:"expires_at,omitempty"`
+}
+
+// RetrieveOptions configures a memory retrieval query.
+type RetrieveOptions struct {
+	Types         []string // Filter by memory type (empty = all)
+	Limit         int      // Max results (0 = store default)
+	MinConfidence float64  // Minimum confidence threshold (0 = no filter)
+}
+
+// ListOptions configures a memory list query.
+type ListOptions struct {
+	Types  []string
+	Limit  int
+	Offset int
+}

--- a/runtime/pipeline/stage/stages_memory.go
+++ b/runtime/pipeline/stage/stages_memory.go
@@ -1,0 +1,180 @@
+package stage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// MemoryRetrievalStage injects relevant memories into the conversation context.
+// Runs early in the pipeline (before the provider stage). Calls
+// Retriever.RetrieveContext() with the current messages and injects returned
+// memories as a system-level context message.
+//
+// No-op passthrough when retriever is nil.
+type MemoryRetrievalStage struct {
+	BaseStage
+	retriever memory.Retriever
+	store     memory.Store
+	scope     map[string]string
+}
+
+// NewMemoryRetrievalStage creates a retrieval stage.
+func NewMemoryRetrievalStage(
+	retriever memory.Retriever, store memory.Store, scope map[string]string,
+) *MemoryRetrievalStage {
+	return &MemoryRetrievalStage{
+		BaseStage: NewBaseStage("memory_retrieval", StageTypeTransform),
+		retriever: retriever,
+		store:     store,
+		scope:     scope,
+	}
+}
+
+// Process implements Stage.
+func (s *MemoryRetrievalStage) Process(
+	ctx context.Context,
+	input <-chan StreamElement,
+	output chan<- StreamElement,
+) error {
+	defer close(output)
+
+	for elem := range input {
+		if s.retriever == nil {
+			output <- elem
+			continue
+		}
+
+		// Extract messages from the element for context
+		messages := extractMessages(&elem)
+		if len(messages) == 0 {
+			output <- elem
+			continue
+		}
+
+		memories, err := s.retriever.RetrieveContext(ctx, s.scope, messages)
+		if err != nil {
+			logger.Error("Memory retrieval failed", "error", err)
+			output <- elem
+			continue
+		}
+
+		if len(memories) > 0 {
+			injectMemories(&elem, memories)
+			logger.Debug("Memories injected into context",
+				"count", len(memories))
+		}
+
+		output <- elem
+	}
+	return nil
+}
+
+// MemoryExtractionStage extracts memories from the conversation after the
+// provider responds. Runs late in the pipeline (before state persist). Calls
+// Extractor.Extract() with the conversation messages and saves results via
+// Store.Save().
+//
+// No-op passthrough when extractor is nil.
+type MemoryExtractionStage struct {
+	BaseStage
+	extractor memory.Extractor
+	store     memory.Store
+	scope     map[string]string
+}
+
+// NewMemoryExtractionStage creates an extraction stage.
+func NewMemoryExtractionStage(
+	extractor memory.Extractor, store memory.Store, scope map[string]string,
+) *MemoryExtractionStage {
+	return &MemoryExtractionStage{
+		BaseStage: NewBaseStage("memory_extraction", StageTypeTransform),
+		extractor: extractor,
+		store:     store,
+		scope:     scope,
+	}
+}
+
+// Process implements Stage.
+func (s *MemoryExtractionStage) Process(
+	ctx context.Context,
+	input <-chan StreamElement,
+	output chan<- StreamElement,
+) error {
+	defer close(output)
+
+	for elem := range input {
+		if s.extractor == nil {
+			output <- elem
+			continue
+		}
+
+		messages := extractMessages(&elem)
+		if len(messages) == 0 {
+			output <- elem
+			continue
+		}
+
+		s.extractAndSave(ctx, messages)
+		output <- elem
+	}
+	return nil
+}
+
+// extractAndSave runs the extractor and saves resulting memories.
+func (s *MemoryExtractionStage) extractAndSave(ctx context.Context, messages []types.Message) {
+	memories, err := s.extractor.Extract(ctx, s.scope, messages)
+	if err != nil {
+		logger.Error("Memory extraction failed", "error", err)
+		return
+	}
+	for _, m := range memories {
+		if m.Scope == nil {
+			m.Scope = s.scope
+		}
+		if saveErr := s.store.Save(ctx, m); saveErr != nil {
+			logger.Error("Memory save failed", "id", m.ID, "error", saveErr)
+		}
+	}
+	if len(memories) > 0 {
+		logger.Debug("Memories extracted and saved", "count", len(memories))
+	}
+}
+
+// extractMessages pulls the message slice from a StreamElement's metadata.
+func extractMessages(elem *StreamElement) []types.Message {
+	if elem.Metadata == nil {
+		return nil
+	}
+	msgs, ok := elem.Metadata["messages"]
+	if !ok {
+		return nil
+	}
+	typedMsgs, ok := msgs.([]types.Message)
+	if !ok {
+		return nil
+	}
+	return typedMsgs
+}
+
+// injectMemories adds retrieved memories to the element metadata as context.
+func injectMemories(elem *StreamElement, memories []*memory.Memory) {
+	if elem.Metadata == nil {
+		return
+	}
+	// Format memories as a context string for the system prompt
+	var memoryContext string
+	for _, m := range memories {
+		memoryContext += fmt.Sprintf("[%s] %s (confidence: %.1f)\n", m.Type, m.Content, m.Confidence)
+	}
+
+	// Store formatted memories in metadata for the template stage to use
+	if existing, ok := elem.Metadata["variables"].(map[string]string); ok {
+		existing["memory_context"] = memoryContext
+	} else {
+		elem.Metadata["memory_context"] = memoryContext
+	}
+}

--- a/runtime/pipeline/stage/stages_memory_test.go
+++ b/runtime/pipeline/stage/stages_memory_test.go
@@ -1,0 +1,126 @@
+package stage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+type mockRetriever struct {
+	memories []*memory.Memory
+}
+
+func (r *mockRetriever) RetrieveContext(_ context.Context, _ map[string]string, _ []types.Message) ([]*memory.Memory, error) {
+	return r.memories, nil
+}
+
+type mockExtractor struct {
+	extracted []*memory.Memory
+}
+
+func (e *mockExtractor) Extract(_ context.Context, _ map[string]string, _ []types.Message) ([]*memory.Memory, error) {
+	return e.extracted, nil
+}
+
+func TestMemoryRetrievalStage_InjectsMemories(t *testing.T) {
+	ret := &mockRetriever{
+		memories: []*memory.Memory{
+			{Type: "fact", Content: "User likes Go", Confidence: 0.9},
+		},
+	}
+	store := memory.NewInMemoryStore()
+	s := NewMemoryRetrievalStage(ret, store, nil)
+
+	input := make(chan StreamElement, 1)
+	output := make(chan StreamElement, 1)
+
+	msgs := []types.Message{{Role: "user", Content: "hello"}}
+	input <- StreamElement{Metadata: map[string]any{"messages": msgs}}
+	close(input)
+
+	err := s.Process(context.Background(), input, output)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	elem := <-output
+	if elem.Metadata["memory_context"] == nil {
+		t.Error("memory_context should be injected")
+	}
+}
+
+func TestMemoryRetrievalStage_NilRetrieverPassthrough(t *testing.T) {
+	s := NewMemoryRetrievalStage(nil, nil, nil)
+
+	input := make(chan StreamElement, 1)
+	output := make(chan StreamElement, 1)
+
+	input <- StreamElement{Metadata: map[string]any{"test": "value"}}
+	close(input)
+
+	err := s.Process(context.Background(), input, output)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	elem := <-output
+	if elem.Metadata["test"] != "value" {
+		t.Error("element should pass through unchanged")
+	}
+}
+
+func TestMemoryExtractionStage_ExtractsAndSaves(t *testing.T) {
+	ext := &mockExtractor{
+		extracted: []*memory.Memory{
+			{Type: "fact", Content: "User mentioned Go preference"},
+		},
+	}
+	store := memory.NewInMemoryStore()
+	scope := map[string]string{"user_id": "test"}
+	s := NewMemoryExtractionStage(ext, store, scope)
+
+	input := make(chan StreamElement, 1)
+	output := make(chan StreamElement, 1)
+
+	msgs := []types.Message{
+		{Role: "user", Content: "I love Go"},
+		{Role: "assistant", Content: "Great choice!"},
+	}
+	input <- StreamElement{Metadata: map[string]any{"messages": msgs}}
+	close(input)
+
+	err := s.Process(context.Background(), input, output)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	<-output // consume
+
+	// Verify memory was saved
+	saved, _ := store.List(context.Background(), scope, memory.ListOptions{})
+	if len(saved) != 1 {
+		t.Errorf("expected 1 saved memory, got %d", len(saved))
+	}
+}
+
+func TestMemoryExtractionStage_NilExtractorPassthrough(t *testing.T) {
+	s := NewMemoryExtractionStage(nil, nil, nil)
+
+	input := make(chan StreamElement, 1)
+	output := make(chan StreamElement, 1)
+
+	input <- StreamElement{Metadata: map[string]any{"test": "value"}}
+	close(input)
+
+	err := s.Process(context.Background(), input, output)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	elem := <-output
+	if elem.Metadata["test"] != "value" {
+		t.Error("element should pass through unchanged")
+	}
+}

--- a/runtime/tools/validator.go
+++ b/runtime/tools/validator.go
@@ -59,7 +59,12 @@ func (sv *SchemaValidator) ValidateArgs(descriptor *ToolDescriptor, args json.Ra
 		return fmt.Errorf("invalid input schema for tool %s: %w", descriptor.Name, err)
 	}
 
-	argsLoader := gojsonschema.NewBytesLoader(args)
+	// Treat nil/empty/null args as empty object for validation
+	validationArgs := args
+	if len(validationArgs) == 0 || string(validationArgs) == "null" {
+		validationArgs = json.RawMessage(`{}`)
+	}
+	argsLoader := gojsonschema.NewBytesLoader(validationArgs)
 	result, err := schema.Validate(argsLoader)
 	if err != nil {
 		return fmt.Errorf("validation error for tool %s: %w", descriptor.Name, err)
@@ -92,7 +97,12 @@ func (sv *SchemaValidator) ValidateResult(descriptor *ToolDescriptor, result jso
 		return fmt.Errorf("invalid output schema for tool %s: %w", descriptor.Name, err)
 	}
 
-	resultLoader := gojsonschema.NewBytesLoader(result)
+	// Treat nil/empty result as empty object for validation
+	validationData := result
+	if len(validationData) == 0 || string(validationData) == "null" {
+		validationData = json.RawMessage(`{}`)
+	}
+	resultLoader := gojsonschema.NewBytesLoader(validationData)
 	validationResult, err := schema.Validate(resultLoader)
 	if err != nil {
 		return fmt.Errorf("validation error for tool %s: %w", descriptor.Name, err)

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -386,6 +386,7 @@
           "type": "array"
         },
         "workflow": true,
+        "memory": true,
         "agents": true,
         "deploy": {
           "$ref": "#/$defs/DeployConfig"

--- a/sdk/capability_memory.go
+++ b/sdk/capability_memory.go
@@ -1,0 +1,53 @@
+package sdk
+
+import (
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// MemoryCapability registers memory tools and wires the memory executor.
+type MemoryCapability struct {
+	store     memory.Store
+	scope     map[string]string
+	extractor memory.Extractor
+	retriever memory.Retriever
+}
+
+// NewMemoryCapability creates a MemoryCapability with the given store and scope.
+func NewMemoryCapability(store memory.Store, scope map[string]string) *MemoryCapability {
+	return &MemoryCapability{store: store, scope: scope}
+}
+
+// WithExtractor sets the memory extractor for automatic extraction.
+func (c *MemoryCapability) WithExtractor(e memory.Extractor) *MemoryCapability {
+	c.extractor = e
+	return c
+}
+
+// WithRetriever sets the memory retriever for automatic RAG injection.
+func (c *MemoryCapability) WithRetriever(r memory.Retriever) *MemoryCapability {
+	c.retriever = r
+	return c
+}
+
+// Name implements Capability.
+func (c *MemoryCapability) Name() string { return memory.ExecutorMode }
+
+// Init implements Capability.
+func (c *MemoryCapability) Init(_ CapabilityContext) error { return nil }
+
+// RegisterTools implements Capability. Registers the memory executor and
+// tool descriptors, plus any custom tools from ToolProvider stores.
+func (c *MemoryCapability) RegisterTools(registry *tools.Registry) {
+	exec := memory.NewExecutor(c.store, c.scope)
+	registry.RegisterExecutor(exec)
+	memory.RegisterMemoryTools(registry)
+
+	// Let stores register additional tools (e.g., graph traversal, temporal queries)
+	if tp, ok := c.store.(memory.ToolProvider); ok {
+		tp.RegisterTools(registry)
+	}
+}
+
+// Close implements Capability.
+func (c *MemoryCapability) Close() error { return nil }

--- a/sdk/capability_memory_test.go
+++ b/sdk/capability_memory_test.go
@@ -1,0 +1,69 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+func TestMemoryCapability_RegisterTools(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	scope := map[string]string{"user_id": "test"}
+	cap := NewMemoryCapability(store, scope)
+
+	if cap.Name() != memory.ExecutorMode {
+		t.Errorf("Name() = %q, want %q", cap.Name(), memory.ExecutorMode)
+	}
+
+	if err := cap.Init(CapabilityContext{}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	registry := tools.NewRegistry()
+	cap.RegisterTools(registry)
+
+	// Verify all 4 memory tools are registered
+	for _, name := range []string{
+		memory.RecallToolName,
+		memory.RememberToolName,
+		memory.ListToolName,
+		memory.ForgetToolName,
+	} {
+		if registry.Get(name) == nil {
+			t.Errorf("tool %q not registered", name)
+		}
+	}
+
+	if err := cap.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestMemoryCapability_WithExtractorRetriever(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	cap := NewMemoryCapability(store, nil)
+	cap.WithExtractor(nil) // nil is valid (no-op)
+	cap.WithRetriever(nil)
+
+	if cap.extractor != nil {
+		t.Error("extractor should be nil")
+	}
+}
+
+func TestWithMemoryOption(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	scope := map[string]string{"user_id": "test"}
+
+	opt := WithMemory(store, scope)
+	cfg := &config{}
+	if err := opt(cfg); err != nil {
+		t.Fatalf("WithMemory: %v", err)
+	}
+	if len(cfg.capabilities) != 1 {
+		t.Fatalf("expected 1 capability, got %d", len(cfg.capabilities))
+	}
+	if cfg.capabilities[0].Name() != memory.ExecutorMode {
+		t.Errorf("capability name = %q", cfg.capabilities[0].Name())
+	}
+}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -425,6 +425,19 @@ func (c *Conversation) buildPipelineConfig(
 		CompactionRules:       c.config.compactionRules,
 	}
 
+	// Wire memory stages from MemoryCapability if present
+	for _, capItem := range c.capabilities {
+		mc, ok := capItem.(*MemoryCapability)
+		if !ok {
+			continue
+		}
+		pipelineCfg.MemoryStore = mc.store
+		pipelineCfg.MemoryScope = mc.scope
+		pipelineCfg.MemoryRetriever = mc.retriever
+		pipelineCfg.MemoryExtractor = mc.extractor
+		break
+	}
+
 	// Wire recording config if enabled
 	if c.config.recordingConfig != nil && c.config.eventBus != nil {
 		pipelineCfg.RecordingConfig = &stage.RecordingStageConfig{

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
 	rtpipeline "github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
@@ -155,6 +156,20 @@ type Config struct {
 	// When provided, ProviderStage will use hooks for provider call, chunk, and tool interception
 	HookRegistry *hooks.Registry
 
+	// MemoryRetriever for automatic memory RAG injection (optional).
+	// When set, a MemoryRetrievalStage is added before the provider stage.
+	MemoryRetriever memory.Retriever
+
+	// MemoryExtractor for automatic memory extraction (optional).
+	// When set, a MemoryExtractionStage is added after the provider stage.
+	MemoryExtractor memory.Extractor
+
+	// MemoryStore for memory persistence (required if Retriever or Extractor set).
+	MemoryStore memory.Store
+
+	// MemoryScope for memory isolation.
+	MemoryScope map[string]string
+
 	// ExecutionTimeout overrides the default pipeline execution timeout.
 	// When non-nil, the pointed-to duration is used instead of the default 30s.
 	// A zero value disables timeout entirely.
@@ -300,6 +315,12 @@ func collectPipelineStages(
 		stages = append(stages, stage.NewFrameRateLimitStage(*cfg.VideoStreamConfig))
 	}
 
+	// 4.8 Memory retrieval stage - inject relevant memories before provider
+	if cfg.MemoryRetriever != nil && cfg.MemoryStore != nil {
+		stages = append(stages, stage.NewMemoryRetrievalStage(
+			cfg.MemoryRetriever, cfg.MemoryStore, cfg.MemoryScope))
+	}
+
 	// 5. Provider stage - LLM calls with streaming and tool support
 	providerStages, err := buildProviderStages(cfg)
 	if err != nil {
@@ -312,6 +333,12 @@ func collectPipelineStages(
 		outputCfg := *cfg.RecordingConfig
 		outputCfg.Position = stage.RecordingPositionOutput
 		stages = append(stages, stage.NewRecordingStage(cfg.RecordingEventBus, outputCfg))
+	}
+
+	// 5.7 Memory extraction stage - extract memories from conversation
+	if cfg.MemoryExtractor != nil && cfg.MemoryStore != nil {
+		stages = append(stages, stage.NewMemoryExtractionStage(
+			cfg.MemoryExtractor, cfg.MemoryStore, cfg.MemoryScope))
 	}
 
 	// 6. State store save stage - saves conversation state LAST

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/metrics"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -874,6 +875,36 @@ func WithMessageLog(log statestore.MessageLog) Option {
 		c.messageLog = log
 		return nil
 	}
+}
+
+// WithMemory enables agentic memory — cross-session knowledge that persists
+// beyond a single conversation. The store provides persistence; scope keys
+// determine memory isolation (e.g., {"user_id": "x", "workspace_id": "y"}).
+//
+// Optional: pass extractor for automatic memory extraction from conversations,
+// and/or retriever for automatic RAG injection of relevant memories.
+func WithMemory(store memory.Store, scope map[string]string, opts ...MemoryOption) Option {
+	return func(c *config) error {
+		memoryCap := NewMemoryCapability(store, scope)
+		for _, opt := range opts {
+			opt(memoryCap)
+		}
+		c.capabilities = append(c.capabilities, memoryCap)
+		return nil
+	}
+}
+
+// MemoryOption configures the memory capability.
+type MemoryOption func(*MemoryCapability)
+
+// WithMemoryExtractor sets an extractor for automatic memory extraction.
+func WithMemoryExtractor(e memory.Extractor) MemoryOption {
+	return func(c *MemoryCapability) { c.extractor = e }
+}
+
+// WithMemoryRetriever sets a retriever for automatic RAG injection.
+func WithMemoryRetriever(r memory.Retriever) MemoryOption {
+	return func(c *MemoryCapability) { c.retriever = r }
 }
 
 // WithExecutionTimeout overrides the default pipeline execution timeout (30s).

--- a/tools/arena/CLAUDE.md
+++ b/tools/arena/CLAUDE.md
@@ -96,6 +96,55 @@ runOrch := e.evalOrchestrator.Clone()  // independent metadata per run
 
 The runner (immutable eval defs) is shared; metadata (workflow state, emitter) is per-run.
 
+### 6. Mock Provider with Tool Calls
+
+Mock providers (`type: mock`) support canned responses with real tool execution:
+
+- The mock provider simulates the **LLM** only — it decides what to say and which tools to call
+- Tools themselves execute for **real** via `tools.Executor` (InMemoryStore, workflow state machine, etc.)
+- Mock responses with `tool_calls` trigger real tool execution through the ProviderStage tool loop
+
+**Mock response file format** (`mock-responses.yaml`):
+```yaml
+scenarios:
+  my-scenario-name:        # MUST match scenario metadata.name, NOT spec.id
+    turns:
+      1:                    # Turn numbers account for multi-round tool loops
+        response: "I'll look that up"
+        tool_calls:         # Auto-sets type to "tool_calls"
+          - name: memory__recall
+            arguments:
+              query: "user preferences"
+      2: "Based on what I found..."  # Text response after tool result
+```
+
+**Critical**: Scenario keys in mock-responses.yaml must match the scenario's `metadata.name`, not `spec.id`. The mock repository looks up by metadata name.
+
+**Provider config** references the mock file:
+```yaml
+spec:
+  type: mock
+  additional_config:
+    mock_config: mock-responses.yaml   # Relative to arena config directory
+```
+
+### 7. Runtime Capabilities in Arena
+
+Capabilities like workflow and memory are declared in the arena config and auto-registered — no tool YAML files needed:
+
+```yaml
+spec:
+  workflow:     # Auto-registers workflow__transition tool + executor
+    version: 2
+    entry: intake
+    states: { ... }
+
+  memory:       # Auto-registers memory__recall/remember/list/forget + executor
+    enabled: true
+```
+
+The tools execute for real. Only the LLM's decision-making is mocked.
+
 ## Adding New Functionality
 
 - **New tool executor**: Implement `tools.Executor`, register in `initWorkflow()` or `BuildEngineComponents()`

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -33,6 +33,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/metrics"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
@@ -83,6 +84,7 @@ type Engine struct {
 	evalOrchestrator     *EvalOrchestrator            // Orchestrates eval and assertion execution during runs
 	workflowSpec         *workflow.Spec               // Optional workflow spec (set if config.Workflow != nil)
 	workflowTransExec    *workflowTransitionExecutor  // Optional transition executor (set if config.Workflow != nil)
+	memoryStore          *memory.InMemoryStore        // Optional memory store (set if config.Memory != nil)
 	recordingConfig      *stage.RecordingStageConfig  // Optional — enables RecordingStage in pipelines
 }
 
@@ -148,6 +150,14 @@ func NewEngineFromConfig(cfg *config.Config) (*Engine, error) {
 			a2aCleanup()
 		}
 		return nil, fmt.Errorf("failed to initialize workflow: %w", err)
+	}
+
+	// Initialize memory subsystem if configured
+	if err := eng.initMemory(); err != nil {
+		if a2aCleanup != nil {
+			a2aCleanup()
+		}
+		return nil, fmt.Errorf("failed to initialize memory: %w", err)
 	}
 
 	// Use the eval orchestrator from the conversation executor — it already has

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -388,6 +388,11 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 
 	// Prepare workflow scenarios: shallow-copy to avoid mutating the shared
 	// scenario, then set TaskType from state machine and wire metadata.
+	// Register per-run memory scope if memory is enabled
+	if e.memoryStore != nil {
+		e.registerMemoryForRun(combo.ScenarioID, runID)
+	}
+
 	var workflowOrch *EvalOrchestrator
 	if e.workflowSpec != nil {
 		wfScenario := *scenario

--- a/tools/arena/engine/execution_memory_integration.go
+++ b/tools/arena/engine/execution_memory_integration.go
@@ -1,0 +1,41 @@
+package engine
+
+import (
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
+)
+
+// initMemory sets up the memory subsystem if config.Memory is set.
+// Creates an InMemoryStore and registers the memory executor + tools.
+// The actual tool execution is real (not mocked) — the InMemoryStore
+// persists data across turns within a run.
+func (e *Engine) initMemory() error {
+	if e.config.Memory == nil {
+		return nil
+	}
+
+	store := memory.NewInMemoryStore()
+
+	// Register executor with nil scope — per-run scope is set in executeRun
+	exec := memory.NewExecutor(store, nil)
+	e.toolRegistry.RegisterExecutor(exec)
+	memory.RegisterMemoryTools(e.toolRegistry)
+
+	e.memoryStore = store
+	logger.Info("Memory subsystem initialized", "store", "in-memory")
+	return nil
+}
+
+// registerMemoryForRun creates a per-run memory executor with scope isolation.
+// Called before each scenario execution to ensure memory is scoped to the run.
+func (e *Engine) registerMemoryForRun(scenarioID, runID string) {
+	if e.memoryStore == nil {
+		return
+	}
+	scope := map[string]string{
+		"scenario": scenarioID,
+		"run":      runID,
+	}
+	exec := memory.NewExecutor(e.memoryStore, scope)
+	e.toolRegistry.RegisterExecutor(exec)
+}

--- a/tools/arena/render/html.go
+++ b/tools/arena/render/html.go
@@ -397,6 +397,7 @@ func getReportTemplate() *template.Template {
 			"renderToolResultMediaBadges": renderToolResultMediaBadges,
 			"isAgentTool":                 isAgentTool,
 			"isWorkflowTool":              isWorkflowTool,
+			"isMemoryTool":                isMemoryTool,
 			"hasA2AAgents":                hasA2AAgents,
 			"renderA2AAgentCards":         renderA2AAgentCards,
 			"consentStatus":               consentStatus,
@@ -1201,6 +1202,11 @@ func isAgentTool(name string) bool {
 // isWorkflowTool returns true if the tool name is a workflow transition tool.
 func isWorkflowTool(name string) bool {
 	return strings.HasPrefix(name, "workflow__")
+}
+
+// isMemoryTool returns true if the tool name is a memory tool.
+func isMemoryTool(name string) bool {
+	return strings.HasPrefix(name, "memory__")
 }
 
 // hasA2AAgents checks if a result has A2A agent metadata.

--- a/tools/arena/render/templates/report.html.tmpl
+++ b/tools/arena/render/templates/report.html.tmpl
@@ -1694,6 +1694,25 @@
             margin-right: 0.25rem;
         }
 
+        /* Memory tool call styling */
+        .tool-call-name.memory {
+            background: linear-gradient(135deg, #8b5cf6, #6366f1);
+            color: white;
+            padding: 0.15rem 0.5rem;
+            border-radius: 0.25rem;
+        }
+
+        .tool-response-name.memory {
+            background: linear-gradient(135deg, #8b5cf6, #6366f1);
+            color: white;
+            padding: 0.15rem 0.5rem;
+            border-radius: 0.25rem;
+        }
+
+        .memory-icon {
+            margin-right: 0.25rem;
+        }
+
         /* A2A Agent Cards Section */
         .a2a-agents-section {
             margin-top: 1rem;
@@ -2024,7 +2043,7 @@
                                         {{range $toolIdx, $toolCall := $msg.ToolCalls}}
                                         <div class="tool-call">
                                             <div class="tool-call-header" onclick="toggleToolContent(this)">
-                                                <span class="tool-call-name{{if isAgentTool $toolCall.Name}} agent{{else if isWorkflowTool $toolCall.Name}} workflow{{end}}">{{if isAgentTool $toolCall.Name}}<span class="agent-icon">🤖</span>{{else if isWorkflowTool $toolCall.Name}}<span class="workflow-icon">⚡</span>{{end}}{{$toolCall.Name}}</span>
+                                                <span class="tool-call-name{{if isAgentTool $toolCall.Name}} agent{{else if isWorkflowTool $toolCall.Name}} workflow{{else if isMemoryTool $toolCall.Name}} memory{{end}}">{{if isAgentTool $toolCall.Name}}<span class="agent-icon">🤖</span>{{else if isWorkflowTool $toolCall.Name}}<span class="workflow-icon">⚡</span>{{else if isMemoryTool $toolCall.Name}}<span class="memory-icon">🧠</span>{{end}}{{$toolCall.Name}}</span>
                                                 <span class="tool-call-id">{{$toolCall.ID}}</span>
                                                 <span class="tool-call-toggle">▶</span>
                                             </div>
@@ -2106,7 +2125,7 @@
                                     <div class="tool-response"{{if and $consent $msg.ToolResult}} data-consent-status="{{$consent}}" data-tool-call-id="{{$msg.ToolResult.ID}}"{{end}}>
                                         <div class="tool-response-header" onclick="toggleToolResponse(this)">
                                             {{if $msg.ToolResult}}
-                                            <span class="tool-response-name{{if isAgentTool $msg.ToolResult.Name}} agent{{else if isWorkflowTool $msg.ToolResult.Name}} workflow{{end}}">{{if isAgentTool $msg.ToolResult.Name}}<span class="agent-icon">🤖</span>{{else if isWorkflowTool $msg.ToolResult.Name}}<span class="workflow-icon">⚡</span>{{end}}{{$msg.ToolResult.Name}}</span>
+                                            <span class="tool-response-name{{if isAgentTool $msg.ToolResult.Name}} agent{{else if isWorkflowTool $msg.ToolResult.Name}} workflow{{else if isMemoryTool $msg.ToolResult.Name}} memory{{end}}">{{if isAgentTool $msg.ToolResult.Name}}<span class="agent-icon">🤖</span>{{else if isWorkflowTool $msg.ToolResult.Name}}<span class="workflow-icon">⚡</span>{{else if isMemoryTool $msg.ToolResult.Name}}<span class="memory-icon">🧠</span>{{end}}{{$msg.ToolResult.Name}}</span>
                                             <span class="tool-response-id">{{$msg.ToolResult.ID}}</span>
                                             {{else}}
                                             <span class="tool-response-name">Tool Response</span>


### PR DESCRIPTION
## Summary

Adds the cross-session agentic memory system to PromptKit, following the interface boundary pattern: PromptKit defines interfaces + test store, platform layers (Omnia) provide production implementations.

### runtime/memory package (new)
- **Memory type**: ID, Type, Content, Confidence, Scope, lifecycle fields
- **Store interface**: Save, Retrieve, List, Delete, DeleteAll
- **ToolProvider interface**: optional store extension for custom tools (graph traversal, temporal queries)
- **Extractor interface**: derive memories from conversation messages (pipeline stage)
- **Retriever interface**: find relevant memories for RAG injection (pipeline stage)
- **InMemoryStore**: substring matching, scope isolation, auto-generated IDs — for testing only
- **Executor** (implements tools.Executor): routes recall/remember/list/forget to Store methods
- **RegisterMemoryTools**: registers 4 base tools with executor routing in the reserved "memory" namespace

### SDK
- **MemoryCapability**: registers executor + tools, supports ToolProvider stores
- **WithMemory(store, scope, ...MemoryOption)**: SDK option
- **WithMemoryExtractor / WithMemoryRetriever**: optional sub-options for pipeline stages

### What this enables for Omnia
Omnia implements `memory.Store` + `memory.ToolProvider` (PostgresMemoryStore with pgvector, entity-relation tables, workspace isolation, PII redaction). PromptKit's tools and capability wire it in automatically.

## Test plan
- [x] 6 InMemoryStore tests (CRUD, scope isolation, filtering)
- [x] 14 tool executor tests (all 4 tools, error cases, nil descriptor, unknown tool, registration)
- [x] 3 SDK capability tests (RegisterTools, WithExtractor/Retriever, WithMemory option)
- [x] Pre-commit: lint, build, tests, coverage >= 80%
- [ ] CI green
