### PR TITLE
fix: flaky TestConversation_EmitsEventsOnSend race condition

### DIFF
--- a/sdk/integration/conversation_test.go
+++ b/sdk/integration/conversation_test.go
@@ -84,8 +84,15 @@ func TestConversation_EmitsEventsOnSend(t *testing.T) {
 	_, err := conv.Send(context.Background(), "Hello")
 	require.NoError(t, err)
 
-	// Give async listeners a moment to process.
-	ec.waitForEvent(events.EventPipelineCompleted, 2*time.Second)
+	// Wait for all expected events — the bus dispatches via goroutines so
+	// delivery order to the collector is not guaranteed.
+	expected := []events.EventType{
+		events.EventPipelineStarted,
+		events.EventPipelineCompleted,
+		events.EventProviderCallStarted,
+		events.EventProviderCallCompleted,
+	}
+	ec.waitForEvents(expected, 2*time.Second)
 
 	assert.True(t, ec.hasType(events.EventPipelineStarted), "should emit pipeline.started")
 	assert.True(t, ec.hasType(events.EventPipelineCompleted), "should emit pipeline.completed")


### PR DESCRIPTION
## Summary

- `TestConversation_EmitsEventsOnSend` waited only for `pipeline.completed` before asserting `provider.call.*` events existed. Since the event bus dispatches via goroutines, provider events could arrive after the single-event wait returned.
- Replaced `waitForEvent(pipeline.completed)` with `waitForEvents([all 4 expected types])` so the test waits for all events before asserting.
- Verified: 10/10 passes locally with `-race -count=10`

## Test plan

- [x] `go test ./sdk/integration/... -run TestConversation_EmitsEventsOnSend -v -count=10 -race` — 10/10 pass
- [x] Full `sdk/...` test suite passes via pre-commit hook