### PR TITLE
feat: add Gemini 3 Pro and Flash to capability matrix (#824)

### DIFF
--- a/examples/capability-matrix/config.arena.yaml
+++ b/examples/capability-matrix/config.arena.yaml
@@ -93,6 +93,12 @@ spec:
     # Google Gemini Models (uses v1beta API endpoint)
     # ==========================================================================
 
+    # Gemini 3.0 family
+    - file: providers/gemini-3-pro.provider.yaml
+      group: text,streaming,vision,tools,json,audio,video
+    - file: providers/gemini-3-flash.provider.yaml
+      group: text,streaming,vision,tools,json,audio,video
+
     # Gemini 2.5 family
     - file: providers/gemini-25-pro.provider.yaml
       group: text,streaming,vision,tools,json,audio,video

--- a/examples/capability-matrix/providers/gemini-3-flash.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-3-flash.provider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   id: gemini-3-flash
   type: gemini
-  model: gemini-3.0-flash-preview
+  model: gemini-3-flash-preview
   capabilities:
     - text
     - streaming
@@ -18,7 +18,7 @@ spec:
     - duplex
   defaults:
     temperature: 0.1
-    max_tokens: 50
+    max_tokens: 100
     top_p: 1.0
   pricing:
     input_cost_per_1k: 0.00015

--- a/examples/capability-matrix/providers/gemini-3-pro.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-3-pro.provider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   id: gemini-3-pro
   type: gemini
-  model: gemini-3.0-pro-preview
+  model: gemini-3-pro-preview
   capabilities:
     - text
     - streaming
@@ -18,7 +18,7 @@ spec:
     - duplex
   defaults:
     temperature: 0.1
-    max_tokens: 50
+    max_tokens: 100
     top_p: 1.0
   pricing:
     input_cost_per_1k: 0.00125


### PR DESCRIPTION
Fixes #824. Model IDs were wrong (gemini-3.0-* → gemini-3-*-preview). Both verified passing.