### PR TITLE
fix: add audio modalities to ToolProvider buildToolRequest (#823)

### DIFF
--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -256,6 +256,15 @@ func (p *ToolProvider) buildToolRequest(req providers.PredictionRequest, tools i
 		openaiReq["seed"] = *req.Seed
 	}
 
+	// Add modalities for audio models when audio content is present
+	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
+		openaiReq["modalities"] = []string{"text", "audio"}
+		openaiReq["audio"] = map[string]interface{}{
+			"voice":  "alloy",
+			"format": "wav",
+		}
+	}
+
 	// Add tools if provided
 	if tools != nil {
 		openaiReq["tools"] = tools

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -1075,3 +1075,55 @@ func TestToolProvider_ConvertRequestMessages_ToolResultHasContent(t *testing.T) 
 		t.Errorf("Expected tool result content, got '%s'", content)
 	}
 }
+
+// TestBuildToolRequest_AudioModalities verifies that buildToolRequest includes
+// modalities and audio config when the model is an audio model and the request
+// contains audio content. Regression test for #823.
+func TestBuildToolRequest_AudioModalities(t *testing.T) {
+	provider := NewToolProvider(
+		"test-audio", "gpt-4o-audio-preview", "https://api.openai.com/v1",
+		providers.ProviderDefaults{Temperature: 0.7, MaxTokens: 100},
+		false, nil, nil,
+	)
+	// Force completions API mode (audio models need it)
+	provider.apiMode = APIModeCompletions
+
+	audioData := types.MediaContent{MIMEType: "audio/flac"}
+	req := providers.PredictionRequest{
+		Messages: []types.Message{
+			{
+				Role: "user",
+				Parts: []types.ContentPart{
+					types.NewTextPart("Transcribe this audio"),
+					{Type: types.ContentTypeAudio, Media: &audioData},
+				},
+			},
+		},
+	}
+
+	result := provider.buildToolRequest(req, nil, "")
+
+	// Must have modalities set
+	modalities, ok := result["modalities"]
+	if !ok {
+		t.Fatal("buildToolRequest missing 'modalities' for audio model with audio content")
+	}
+	mods, ok := modalities.([]string)
+	if !ok {
+		t.Fatalf("modalities is %T, want []string", modalities)
+	}
+	hasAudio := false
+	for _, m := range mods {
+		if m == "audio" {
+			hasAudio = true
+		}
+	}
+	if !hasAudio {
+		t.Errorf("modalities = %v, should contain 'audio'", mods)
+	}
+
+	// Must have audio output config
+	if _, ok := result["audio"]; !ok {
+		t.Error("buildToolRequest missing 'audio' output config for audio model")
+	}
+}


### PR DESCRIPTION
## Summary

The ToolProvider's `buildToolRequest` was missing the audio modalities logic that exists in the base Provider's `buildPredictionRequest`. When audio models (gpt-4o-audio-preview) were called through the ToolProvider path, the request lacked `modalities: ["text", "audio"]`, causing OpenAI to reject with "This model requires that either input content or output modality contain audio."

## Root cause

All providers registered via the `openai` factory are created as `ToolProvider` (which embeds `Provider`). The audio modalities logic was only in the base `Provider.buildPredictionRequest` but not in `ToolProvider.buildToolRequest`. When the ProviderStage calls `PredictWithTools`, it uses `buildToolRequest` which never set modalities.

## Fix

Add the same audio modalities check to `buildToolRequest`:
```go
if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
    openaiReq["modalities"] = []string{"text", "audio"}
    openaiReq["audio"] = map[string]interface{}{"voice": "alloy", "format": "wav"}
}
```

## Test plan

- [x] `TestBuildToolRequest_AudioModalities` — TDD: verified failing before fix, passing after
- [x] Full OpenAI provider test suite passes

Fixes #823