### PR TITLE
feat: coerce string-encoded tool args to match schema types (#829)

### DIFF
--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -381,6 +381,15 @@ func (r *Registry) Execute(
 		return nil, err
 	}
 
+	// Coerce string-encoded numbers/booleans to match schema types
+	coercedArgs, coercions, coerceErr := r.validator.CoerceArgs(tool, args)
+	if coerceErr != nil {
+		logger.Debug("tool argument coercion failed", "tool", toolName, "error", coerceErr)
+	} else if len(coercions) > 0 {
+		args = coercedArgs
+		logger.Debug("coerced tool arguments", "tool", toolName, "coercions", len(coercions))
+	}
+
 	// Validate arguments
 	if valErr := r.validator.ValidateArgs(tool, args); valErr != nil {
 		logger.Debug("tool argument validation failed",
@@ -484,6 +493,11 @@ func (r *Registry) ExecuteAsync(
 	tool, err := r.GetTool(toolName)
 	if err != nil {
 		return nil, err
+	}
+
+	// Coerce string-encoded numbers/booleans to match schema types
+	if coerced, _, coerceErr := r.validator.CoerceArgs(tool, args); coerceErr == nil && coerced != nil {
+		args = coerced
 	}
 
 	// Validate arguments

--- a/runtime/tools/validator.go
+++ b/runtime/tools/validator.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/xeipuuv/gojsonschema"
@@ -224,4 +225,76 @@ type Coercion struct {
 	Path string `json:"path"`
 	From any    `json:"from"`
 	To   any    `json:"to"`
+}
+
+// CoerceArgs coerces string-encoded values in tool arguments to match the
+// types declared in the tool's input schema. LLMs sometimes send numeric
+// or boolean values as strings (e.g., "10" instead of 10, "true" instead
+// of true). This normalises them before validation and execution.
+func (sv *SchemaValidator) CoerceArgs(
+	descriptor *ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, []Coercion, error) {
+	if len(descriptor.InputSchema) == 0 {
+		return args, nil, nil
+	}
+
+	// Parse the schema to get property types
+	var schema struct {
+		Properties map[string]struct {
+			Type string `json:"type"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(descriptor.InputSchema, &schema); err != nil {
+		return args, nil, nil // can't parse schema, skip coercion
+	}
+	if len(schema.Properties) == 0 {
+		return args, nil, nil
+	}
+
+	// Parse the args
+	var data map[string]any
+	if err := json.Unmarshal(args, &data); err != nil {
+		return args, nil, nil // can't parse args, skip coercion
+	}
+
+	var coercions []Coercion
+	for key, prop := range schema.Properties {
+		str, isString := data[key].(string)
+		if !isString {
+			continue
+		}
+		coerced, err := coerceStringValue(str, prop.Type)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot coerce %q=%q to %s: %w", key, str, prop.Type, err)
+		}
+		if coerced != nil {
+			data[key] = coerced
+			coercions = append(coercions, Coercion{Path: key, From: str, To: coerced})
+		}
+	}
+
+	if len(coercions) == 0 {
+		return args, nil, nil
+	}
+
+	coerced, err := json.Marshal(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot marshal coerced args: %w", err)
+	}
+	return coerced, coercions, nil
+}
+
+// coerceStringValue converts a string to the target JSON schema type.
+// Returns nil if no coercion is needed (e.g., target type is "string").
+func coerceStringValue(s, targetType string) (any, error) {
+	switch targetType {
+	case "integer":
+		return strconv.ParseInt(s, 10, 64)
+	case "number":
+		return strconv.ParseFloat(s, 64)
+	case "boolean":
+		return strconv.ParseBool(s)
+	default:
+		return nil, nil
+	}
 }

--- a/runtime/tools/validator_test.go
+++ b/runtime/tools/validator_test.go
@@ -281,3 +281,113 @@ func TestSchemaValidatorWithSize_ZeroDefaults(t *testing.T) {
 	v := NewSchemaValidatorWithSize(0)
 	assert.Equal(t, DefaultMaxSchemaCacheSize, v.maxSize)
 }
+
+func TestCoerceArgs(t *testing.T) {
+	validator := NewSchemaValidator()
+
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"query": {"type": "string"},
+			"limit": {"type": "integer"},
+			"min_confidence": {"type": "number"},
+			"enabled": {"type": "boolean"},
+			"tags": {"type": "array", "items": {"type": "string"}}
+		}
+	}`)
+
+	descriptor := &ToolDescriptor{
+		Name:        "test-tool",
+		InputSchema: schema,
+	}
+
+	t.Run("coerces string to integer", func(t *testing.T) {
+		args := json.RawMessage(`{"query": "hello", "limit": "10"}`)
+		coerced, coercions, err := validator.CoerceArgs(descriptor, args)
+		require.NoError(t, err)
+		assert.NotEmpty(t, coercions)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(coerced, &result))
+		assert.Equal(t, float64(10), result["limit"]) // JSON numbers are float64
+	})
+
+	t.Run("coerces string to number", func(t *testing.T) {
+		args := json.RawMessage(`{"query": "hello", "min_confidence": "0.85"}`)
+		coerced, coercions, err := validator.CoerceArgs(descriptor, args)
+		require.NoError(t, err)
+		assert.NotEmpty(t, coercions)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(coerced, &result))
+		assert.Equal(t, 0.85, result["min_confidence"])
+	})
+
+	t.Run("coerces string to boolean", func(t *testing.T) {
+		args := json.RawMessage(`{"query": "hello", "enabled": "true"}`)
+		coerced, coercions, err := validator.CoerceArgs(descriptor, args)
+		require.NoError(t, err)
+		assert.NotEmpty(t, coercions)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(coerced, &result))
+		assert.Equal(t, true, result["enabled"])
+	})
+
+	t.Run("coerces false string to boolean", func(t *testing.T) {
+		args := json.RawMessage(`{"query": "hello", "enabled": "false"}`)
+		coerced, _, err := validator.CoerceArgs(descriptor, args)
+		require.NoError(t, err)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(coerced, &result))
+		assert.Equal(t, false, result["enabled"])
+	})
+
+	t.Run("no coercion needed — passes through", func(t *testing.T) {
+		args := json.RawMessage(`{"query": "hello", "limit": 10, "min_confidence": 0.5, "enabled": true}`)
+		coerced, coercions, err := validator.CoerceArgs(descriptor, args)
+		require.NoError(t, err)
+		assert.Empty(t, coercions)
+		assert.Equal(t, args, coerced)
+	})
+
+	t.Run("coerces multiple fields at once", func(t *testing.T) {
+		args := json.RawMessage(`{"query": "hello", "limit": "5", "min_confidence": "0", "enabled": "true"}`)
+		coerced, coercions, err := validator.CoerceArgs(descriptor, args)
+		require.NoError(t, err)
+		assert.Len(t, coercions, 3)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(coerced, &result))
+		assert.Equal(t, float64(5), result["limit"])
+		assert.Equal(t, float64(0), result["min_confidence"])
+		assert.Equal(t, true, result["enabled"])
+	})
+
+	t.Run("leaves strings alone", func(t *testing.T) {
+		args := json.RawMessage(`{"query": "hello"}`)
+		coerced, coercions, err := validator.CoerceArgs(descriptor, args)
+		require.NoError(t, err)
+		assert.Empty(t, coercions)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(coerced, &result))
+		assert.Equal(t, "hello", result["query"])
+	})
+
+	t.Run("no schema — passes through", func(t *testing.T) {
+		noSchema := &ToolDescriptor{Name: "no-schema"}
+		args := json.RawMessage(`{"limit": "10"}`)
+		coerced, coercions, err := validator.CoerceArgs(noSchema, args)
+		require.NoError(t, err)
+		assert.Empty(t, coercions)
+		assert.Equal(t, args, coerced)
+	})
+
+	t.Run("invalid string for integer — returns error", func(t *testing.T) {
+		args := json.RawMessage(`{"limit": "not-a-number"}`)
+		_, _, err := validator.CoerceArgs(descriptor, args)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

LLMs (especially smaller models like Ollama llama3.2) sometimes send numeric and boolean tool arguments as strings (`"10"` instead of `10`, `"true"` instead of `true`). This broke `json.Unmarshal` in tool executors like the memory tools.

### Fix

Add `CoerceArgs` to the schema validator that walks schema properties and converts string values to their declared types:
- `"10"` → `10` (integer)
- `"3.14"` → `3.14` (number)
- `"true"` → `true` (boolean)

Called in both `Registry.Execute` paths before `ValidateArgs`, so **all tools benefit automatically** — no per-executor fixes needed.

### Test plan

- [x] `TestCoerceArgs` — 9 subtests: integer, number, boolean (true/false), no coercion needed, multiple fields, strings untouched, no schema passthrough, invalid string error
- [x] TDD: test written first, verified failing, then implemented
- [x] Full `runtime/tools/...` test suite passes
- [x] Full `runtime/...` test suite passes
- [x] 90.1% coverage on tools package

Fixes #829