### PR TITLE
feat: add logging for capability lifecycle and tool registration

### DIFF
--- a/sdk/capability.go
+++ b/sdk/capability.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/skills"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
@@ -51,14 +52,20 @@ func newCapabilityContext(p *pack.Pack, promptName string, cfg *config) Capabili
 func inferCapabilities(p *pack.Pack) []Capability {
 	var caps []Capability
 	if p.Workflow != nil {
+		logger.Debug("capability inferred from pack", "capability", "workflow")
 		caps = append(caps, NewWorkflowCapability())
 	}
 	if p.Agents != nil && len(p.Agents.Members) > 0 {
+		logger.Debug("capability inferred from pack", "capability", "a2a", "agents", len(p.Agents.Members))
 		caps = append(caps, NewA2ACapability())
 	}
 	if len(p.Skills) > 0 {
+		logger.Debug("capability inferred from pack", "capability", "skills", "sources", len(p.Skills))
 		sources := convertSkillSources(p.Skills)
 		caps = append(caps, NewSkillsCapability(sources))
+	}
+	if len(caps) == 0 {
+		logger.Debug("no capabilities inferred from pack")
 	}
 	return caps
 }

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -378,9 +378,22 @@ func (c *Conversation) buildPipelineConfig(
 	// Register capability tools (includes A2A) — only on first build
 	if !c.capabilitiesRegistered {
 		for _, cap := range c.capabilities {
+			beforeCount := len(c.toolRegistry.List())
 			cap.RegisterTools(c.toolRegistry)
+			afterCount := len(c.toolRegistry.List())
+			registered := afterCount - beforeCount
+			if registered > 0 {
+				logger.Info("capability registered tools",
+					"capability", cap.Name(), "tools_registered", registered)
+			} else {
+				logger.Debug("capability registered no tools", "capability", cap.Name())
+			}
 		}
 		c.capabilitiesRegistered = true
+		allTools := c.toolRegistry.List()
+		if len(allTools) > 0 {
+			logger.Debug("all registered tools", "tools", allTools, "count", len(allTools))
+		}
 	}
 	toolRegistry := c.toolRegistry
 	c.handlersMu.Unlock()
@@ -1047,6 +1060,7 @@ func (c *Conversation) Close() error {
 
 	// Close capabilities
 	for _, cap := range c.capabilities {
+		logger.Debug("closing capability", "capability", cap.Name())
 		if err := cap.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to close capability %q: %w", cap.Name(), err))
 		}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -241,9 +241,17 @@ func initConversation(
 	wireSkillsConfig(allCaps, cfg)
 	capCtx := newCapabilityContext(p, promptName, cfg)
 	for _, cap := range allCaps {
+		logger.Info("initializing capability", "capability", cap.Name())
 		if err := cap.Init(capCtx); err != nil {
 			return nil, nil, fmt.Errorf("capability %q init failed: %w", cap.Name(), err)
 		}
+	}
+	if len(allCaps) > 0 {
+		names := make([]string, len(allCaps))
+		for i, c := range allCaps {
+			names[i] = c.Name()
+		}
+		logger.Info("capabilities initialized", "capabilities", names, "count", len(allCaps))
 	}
 	conv.capabilities = allCaps
 


### PR DESCRIPTION
## Summary

The capability system had zero logging — no way to know which capabilities were inferred, what tools they registered, or when they initialized/closed.

### Log levels

| Level | What's logged |
|-------|--------------|
| INFO | Capability init ("initializing capability workflow"), tool registration counts ("capability registered tools: workflow, 2 tools"), capabilities summary ("capabilities initialized: [workflow, a2a], count: 2") |
| DEBUG | Capability inference from pack ("capability inferred: workflow"), full tool list ("all registered tools: [workflow__transition, a2a__call_agent, ...]"), capability close, no-tools cases |

### Example output at LOG_LEVEL=debug
```
level=DEBUG msg="capability inferred from pack" capability=workflow
level=DEBUG msg="capability inferred from pack" capability=a2a agents=3
level=INFO msg="initializing capability" capability=workflow
level=INFO msg="initializing capability" capability=a2a
level=INFO msg="capabilities initialized" capabilities=[workflow,a2a] count=2
level=INFO msg="capability registered tools" capability=workflow tools_registered=1
level=INFO msg="capability registered tools" capability=a2a tools_registered=3
level=DEBUG msg="all registered tools" tools=[workflow__transition,a2a__agent1,a2a__agent2,a2a__agent3] count=4
level=DEBUG msg="closing capability" capability=workflow
level=DEBUG msg="closing capability" capability=a2a
```

## Test plan
- [x] Full SDK test suite passes
- [x] All changed files meet coverage threshold