### PR TITLE
fix: EventBus data race between Publish and Close

### DIFF
--- a/runtime/events/bus.go
+++ b/runtime/events/bus.go
@@ -100,6 +100,7 @@ type EventBus struct {
 	nextID          atomic.Uint64
 	seq             atomic.Int64 // monotonic sequence counter for events
 
+	publishMu         sync.RWMutex // guards eventCh send (RLock) vs close (Lock)
 	eventCh           chan *Event
 	wg                sync.WaitGroup
 	closed            atomic.Bool
@@ -319,6 +320,10 @@ func (eb *EventBus) SubscribeAll(listener Listener) func() {
 // asynchronously in the dispatch worker (not in the caller's goroutine).
 // Returns false if the bus has been closed.
 func (eb *EventBus) Publish(event *Event) bool {
+	// RLock allows concurrent publishes but blocks during Close.
+	eb.publishMu.RLock()
+	defer eb.publishMu.RUnlock()
+
 	if eb.closed.Load() {
 		return false
 	}
@@ -355,8 +360,11 @@ func (eb *EventBus) DroppedCount() int64 {
 // as closed and drains any buffered events.
 func (eb *EventBus) Close() {
 	if eb.closed.CompareAndSwap(false, true) {
+		// Lock publishMu to ensure no Publish is mid-send before closing channels.
+		eb.publishMu.Lock()
 		close(eb.done)    // cancel orphaned invokeWithTimeout goroutines
 		close(eb.eventCh) // signal workers to drain and exit
+		eb.publishMu.Unlock()
 		if eb.started.Load() {
 			// Wait for workers with a hard deadline. Workers may be blocked
 			// on slow listener timeouts — don't let that hang the process.

--- a/runtime/events/bus_test.go
+++ b/runtime/events/bus_test.go
@@ -788,3 +788,33 @@ func waitForWG(wg *sync.WaitGroup, timeout time.Duration) bool {
 		return false
 	}
 }
+
+// TestPublishConcurrentWithClose verifies that Publish does not panic or
+// race when called concurrently with Close. This reproduces the data race
+// in TestMetrics_ToolCallsTotal where a pipeline goroutine emits
+// PipelineCompleted while the test cleanup calls bus.Close().
+func TestPublishConcurrentWithClose(t *testing.T) {
+	// Run many iterations to reliably trigger the race between
+	// Publish's channel send and Close's channel close.
+	for i := 0; i < 1000; i++ {
+		bus := NewEventBus()
+		bus.SubscribeAll(func(_ *Event) {})
+
+		// Start multiple publishers — each creates its own events
+		// (mirrors real usage where Emitter.emit creates a new Event each call)
+		var wg sync.WaitGroup
+		for g := 0; g < 4; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 50; j++ {
+					bus.Publish(&Event{Type: "test.event", Timestamp: time.Now()})
+				}
+			}()
+		}
+
+		// Close concurrently — must not panic or race
+		bus.Close()
+		wg.Wait()
+	}
+}

--- a/sdk/integration/helpers_test.go
+++ b/sdk/integration/helpers_test.go
@@ -233,12 +233,6 @@ func testMetricsSetup(t *testing.T) (*events.EventBus, *metrics.Collector, *prom
 	})
 	bus := events.NewEventBus()
 	t.Cleanup(func() {
-		// Allow pipeline background goroutines to emit final events
-		// before closing the bus. The pipeline's executeBackground emits
-		// PipelineCompleted after the output channel closes, so
-		// ExecuteSync may have returned while the goroutine is still
-		// running. Without this, bus.Close() races with the emit.
-		time.Sleep(50 * time.Millisecond)
 		bus.Close()
 	})
 


### PR DESCRIPTION
## Summary

`Publish` and `Close` raced on the event channel — `Publish` could be mid-send (`chansend`) while `Close` closed the channel (`closechan`), causing a data race detected by `-race`. This caused intermittent CI failures in `TestMetrics_ToolCallsTotal`.

### Root cause

`Publish` checks `eb.closed.Load()` then does `eb.eventCh <- event`. Between the check and the send, `Close` can set `closed=true` and `close(eb.eventCh)`. The atomic check doesn't synchronize with the channel close.

### Fix

Add `publishMu sync.RWMutex`:
- `Publish` takes `RLock` — allows concurrent publishes (no contention between publishers)
- `Close` takes `Lock` before closing channels — blocks until all in-flight publishes complete

Also removes the `time.Sleep(50ms)` hack in the SDK test helper that was papering over this race.

### Test

`TestPublishConcurrentWithClose` — 4 goroutines × 50 publishes per iteration × 1000 iterations, with `Close` called concurrently. Passes 5/5 with `-race`.

## Test plan

- [x] `TestPublishConcurrentWithClose` — race test, 5/5 passes with `-race`
- [x] Full `runtime/events/...` suite passes with `-race`
- [x] `sdk/integration/...` suite passes with `-race` (including `TestMetrics_ToolCallsTotal`)
- [x] time.Sleep hack removed from test helper