### PR TITLE
refactor: replace StreamChunk.MediaDelta with zero-copy StreamMediaData

### DIFF
--- a/runtime/pipeline/stage/stages_duplex_provider_integration.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_integration.go
@@ -953,39 +953,40 @@ func (s *DuplexProviderStage) handleResponseChunk(
 	}
 
 	// Accumulate media content for this turn
-	// MediaDelta.Data is base64-encoded, so decode it to raw bytes for accumulation
-	if chunk.MediaDelta != nil && chunk.MediaDelta.Data != nil {
-		rawBytes, err := base64.StdEncoding.DecodeString(*chunk.MediaDelta.Data)
-		if err != nil {
-			logger.Warn("DuplexProviderStage: failed to decode base64 audio chunk", "error", err)
-		} else {
-			s.accumulatedMedia = append(s.accumulatedMedia, rawBytes...)
+	// MediaData.Data is already raw bytes — providers decode base64 at source
+	if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
+		rawBytes := chunk.MediaData.Data
+		s.accumulatedMedia = append(s.accumulatedMedia, rawBytes...)
 
-			// Emit audio.output event for session recording
-			if s.emitter != nil {
-				// Gemini outputs at 24kHz, mono, 16-bit
-				const outputSampleRate = 24000
-				const outputChannels = 1
-				const bytesPerSample = 2
-				durationMs := int64(len(rawBytes)) * 1000 / outputSampleRate / outputChannels / bytesPerSample
-
-				s.emitter.AudioOutput(&events.AudioOutputData{
-					ChunkIndex: s.outputChunkIndex,
-					Payload: events.BinaryPayload{
-						InlineData: rawBytes,
-						MIMEType:   mimeTypeAudioPCM,
-						Size:       int64(len(rawBytes)),
-					},
-					Metadata: events.AudioMetadata{
-						SampleRate: outputSampleRate,
-						Channels:   outputChannels,
-						Encoding:   "pcm_linear16",
-						DurationMs: durationMs,
-					},
-					GeneratedFrom: "model",
-				})
-				s.outputChunkIndex++
+		// Emit audio.output event for session recording
+		if s.emitter != nil {
+			outputSampleRate := 24000
+			if chunk.MediaData.SampleRate > 0 {
+				outputSampleRate = chunk.MediaData.SampleRate
 			}
+			outputChannels := 1
+			if chunk.MediaData.Channels > 0 {
+				outputChannels = chunk.MediaData.Channels
+			}
+			const bytesPerSample = 2
+			durationMs := int64(len(rawBytes)) * 1000 / int64(outputSampleRate) / int64(outputChannels) / bytesPerSample
+
+			s.emitter.AudioOutput(&events.AudioOutputData{
+				ChunkIndex: s.outputChunkIndex,
+				Payload: events.BinaryPayload{
+					InlineData: rawBytes,
+					MIMEType:   mimeTypeAudioPCM,
+					Size:       int64(len(rawBytes)),
+				},
+				Metadata: events.AudioMetadata{
+					SampleRate: outputSampleRate,
+					Channels:   outputChannels,
+					Encoding:   "pcm_linear16",
+					DurationMs: durationMs,
+				},
+				GeneratedFrom: "model",
+			})
+			s.outputChunkIndex++
 		}
 	}
 
@@ -1100,11 +1101,19 @@ func (s *DuplexProviderStage) chunkToElement(chunk *providers.StreamChunk) Strea
 	}
 
 	// Add audio if present (for real-time playback)
-	if chunk.MediaDelta != nil && chunk.MediaDelta.Data != nil {
-		audioData := []byte(*chunk.MediaDelta.Data)
+	if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
+		sampleRate := chunk.MediaData.SampleRate
+		if sampleRate == 0 {
+			sampleRate = 24000
+		}
+		channels := chunk.MediaData.Channels
+		if channels == 0 {
+			channels = 1
+		}
 		elem.Audio = &AudioData{
-			Samples:    audioData,
-			SampleRate: 24000, // Default - could be extracted from metadata
+			Samples:    chunk.MediaData.Data,
+			SampleRate: sampleRate,
+			Channels:   channels,
 			Format:     AudioFormatPCM16,
 		}
 	}

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -900,36 +901,102 @@ func (s *ProviderStage) processStreamChunks(
 	return content, toolCalls, costInfo, nil
 }
 
-// emitChunkElement creates and emits a streaming element for a chunk.
+// emitChunkElement creates and emits streaming element(s) for a chunk.
+// Handles both text (Delta) and media (MediaData) content.
 func (s *ProviderStage) emitChunkElement(
 	ctx context.Context,
 	chunk *providers.StreamChunk,
 	metadata map[string]interface{},
 	output chan<- StreamElement,
 ) error {
-	if chunk.Delta == "" {
-		return nil
+	// Emit text element if present
+	if chunk.Delta != "" {
+		elem := NewTextElement(chunk.Delta)
+		elem.Timestamp = timeNow()
+		elem.Priority = PriorityNormal
+
+		for k, v := range metadata {
+			elem.Metadata[k] = v
+		}
+
+		elem.Metadata["token_count"] = chunk.TokenCount
+		if chunk.FinishReason != nil {
+			elem.Metadata["finish_reason"] = *chunk.FinishReason
+		}
+
+		select {
+		case output <- elem:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
-	elem := NewTextElement(chunk.Delta)
-	elem.Timestamp = timeNow()
-	elem.Priority = PriorityNormal
+	// Emit media element if present
+	if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
+		elem := StreamMediaToElement(chunk.MediaData)
 
-	for k, v := range metadata {
-		elem.Metadata[k] = v
+		for k, v := range metadata {
+			elem.Metadata[k] = v
+		}
+
+		select {
+		case output <- elem:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
-	elem.Metadata["token_count"] = chunk.TokenCount
-	if chunk.FinishReason != nil {
-		elem.Metadata["finish_reason"] = *chunk.FinishReason
+	return nil
+}
+
+// StreamMediaToElement converts a StreamMediaData to a StreamElement.
+// Routes by MIME type: audio/* → AudioData, video/* → VideoData, image/* → ImageData.
+func StreamMediaToElement(media *providers.StreamMediaData) StreamElement {
+	elem := StreamElement{
+		Metadata:  make(map[string]interface{}),
+		Timestamp: timeNow(),
 	}
 
-	select {
-	case output <- elem:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	switch {
+	case strings.HasPrefix(media.MIMEType, "audio/"):
+		sampleRate := media.SampleRate
+		if sampleRate == 0 {
+			sampleRate = 16000
+		}
+		channels := media.Channels
+		if channels == 0 {
+			channels = 1
+		}
+		elem.Audio = &AudioData{
+			Samples:    media.Data,
+			SampleRate: sampleRate,
+			Channels:   channels,
+			Format:     AudioFormatPCM16,
+		}
+
+	case strings.HasPrefix(media.MIMEType, "video/"):
+		elem.Video = &VideoData{
+			Data:       media.Data,
+			MIMEType:   media.MIMEType,
+			Width:      media.Width,
+			Height:     media.Height,
+			FrameRate:  media.FrameRate,
+			IsKeyFrame: media.IsKeyFrame,
+			FrameNum:   media.FrameNum,
+		}
+		elem.Priority = PriorityHigh
+
+	case strings.HasPrefix(media.MIMEType, "image/"):
+		elem.Image = &ImageData{
+			Data:     media.Data,
+			MIMEType: media.MIMEType,
+			Width:    media.Width,
+			Height:   media.Height,
+			FrameNum: media.FrameNum,
+		}
 	}
+
+	return elem
 }
 
 // toolCallResult holds the outcome of a single tool call execution,

--- a/runtime/pipeline/stage/stages_provider_media_test.go
+++ b/runtime/pipeline/stage/stages_provider_media_test.go
@@ -1,0 +1,90 @@
+package stage_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamMediaToElement_Audio(t *testing.T) {
+	media := &providers.StreamMediaData{
+		Data:       []byte{0x01, 0x02, 0x03},
+		MIMEType:   "audio/pcm",
+		SampleRate: 24000,
+		Channels:   1,
+	}
+
+	elem := stage.StreamMediaToElement(media)
+
+	require.NotNil(t, elem.Audio)
+	assert.Equal(t, media.Data, elem.Audio.Samples)
+	assert.Equal(t, 24000, elem.Audio.SampleRate)
+	assert.Equal(t, 1, elem.Audio.Channels)
+	assert.Equal(t, stage.AudioFormatPCM16, elem.Audio.Format)
+	assert.Nil(t, elem.Video)
+	assert.Nil(t, elem.Image)
+}
+
+func TestStreamMediaToElement_AudioDefaults(t *testing.T) {
+	media := &providers.StreamMediaData{
+		Data:     []byte{0x01, 0x02},
+		MIMEType: "audio/wav",
+		// SampleRate and Channels are zero — should default
+	}
+
+	elem := stage.StreamMediaToElement(media)
+
+	require.NotNil(t, elem.Audio)
+	assert.Equal(t, 16000, elem.Audio.SampleRate)
+	assert.Equal(t, 1, elem.Audio.Channels)
+}
+
+func TestStreamMediaToElement_Video(t *testing.T) {
+	media := &providers.StreamMediaData{
+		Data:       []byte{0xAB, 0xCD},
+		MIMEType:   "video/h264",
+		Width:      1920,
+		Height:     1080,
+		FrameRate:  30.0,
+		IsKeyFrame: true,
+		FrameNum:   42,
+	}
+
+	elem := stage.StreamMediaToElement(media)
+
+	require.NotNil(t, elem.Video)
+	assert.Equal(t, media.Data, elem.Video.Data)
+	assert.Equal(t, "video/h264", elem.Video.MIMEType)
+	assert.Equal(t, 1920, elem.Video.Width)
+	assert.Equal(t, 1080, elem.Video.Height)
+	assert.Equal(t, 30.0, elem.Video.FrameRate)
+	assert.True(t, elem.Video.IsKeyFrame)
+	assert.Equal(t, int64(42), elem.Video.FrameNum)
+	assert.Equal(t, stage.PriorityHigh, elem.Priority)
+	assert.Nil(t, elem.Audio)
+	assert.Nil(t, elem.Image)
+}
+
+func TestStreamMediaToElement_Image(t *testing.T) {
+	media := &providers.StreamMediaData{
+		Data:     []byte{0xFF, 0xD8},
+		MIMEType: "image/jpeg",
+		Width:    800,
+		Height:   600,
+		FrameNum: 7,
+	}
+
+	elem := stage.StreamMediaToElement(media)
+
+	require.NotNil(t, elem.Image)
+	assert.Equal(t, media.Data, elem.Image.Data)
+	assert.Equal(t, "image/jpeg", elem.Image.MIMEType)
+	assert.Equal(t, 800, elem.Image.Width)
+	assert.Equal(t, 600, elem.Image.Height)
+	assert.Equal(t, int64(7), elem.Image.FrameNum)
+	assert.Nil(t, elem.Audio)
+	assert.Nil(t, elem.Video)
+}

--- a/runtime/providers/gemini/demo_audio_output_test.go
+++ b/runtime/providers/gemini/demo_audio_output_test.go
@@ -107,20 +107,19 @@ func TestStreamingDemo_AudioAndTextOutput(t *testing.T) {
 				fmt.Printf("📝 [Text Chunk %d] %q\n", textChunks, chunk.Content)
 			}
 
-			// Check for AUDIO content (first-class MediaDelta field)
-			if chunk.MediaDelta != nil {
+			// Check for AUDIO content (raw bytes in MediaData)
+			if chunk.MediaData != nil {
 				audioChunks++
-				audioData := *chunk.MediaDelta.Data // Base64 string
-				totalAudioBytes += len(audioData)
-				fmt.Printf("🎵 [Audio Chunk %d] mime=%s, size=%d bytes (base64)\n",
-					audioChunks, chunk.MediaDelta.MIMEType, len(audioData))
+				totalAudioBytes += len(chunk.MediaData.Data)
+				fmt.Printf("🎵 [Audio Chunk %d] mime=%s, size=%d bytes (raw)\n",
+					audioChunks, chunk.MediaData.MIMEType, len(chunk.MediaData.Data))
 
 				// Show audio metadata if available
-				if chunk.MediaDelta.Channels != nil {
-					fmt.Printf("   Channels: %d\n", *chunk.MediaDelta.Channels)
+				if chunk.MediaData.Channels != 0 {
+					fmt.Printf("   Channels: %d\n", chunk.MediaData.Channels)
 				}
-				if chunk.MediaDelta.BitRate != nil {
-					fmt.Printf("   Sample Rate: %d Hz\n", *chunk.MediaDelta.BitRate)
+				if chunk.MediaData.SampleRate != 0 {
+					fmt.Printf("   Sample Rate: %d Hz\n", chunk.MediaData.SampleRate)
 				}
 			}
 
@@ -143,7 +142,7 @@ func TestStreamingDemo_AudioAndTextOutput(t *testing.T) {
 		fmt.Println(separator)
 		fmt.Printf("📝 Text chunks received: %d\n", textChunks)
 		fmt.Printf("🎵 Audio chunks received: %d\n", audioChunks)
-		fmt.Printf("📏 Total audio data: %d bytes (base64)\n", totalAudioBytes)
+		fmt.Printf("📏 Total audio data: %d bytes (raw)\n", totalAudioBytes)
 
 		if fullTextResponse != "" {
 			fmt.Println("\n📝 Complete Text Response:")
@@ -152,7 +151,7 @@ func TestStreamingDemo_AudioAndTextOutput(t *testing.T) {
 
 		if audioChunks > 0 {
 			fmt.Println("\n🎵 Audio Response: Received PCM audio data")
-			fmt.Println("   (Audio data is base64-encoded PCM, ready to decode and play)")
+			fmt.Println("   (Audio data is raw PCM, ready to play)")
 		}
 		fmt.Println(separator)
 	}()
@@ -298,12 +297,11 @@ func TestStreamingDemo_AudioOutputOnly(t *testing.T) {
 				fmt.Printf("📝 [Unexpected Text] %q\n", chunk.Content)
 			}
 
-			// Check for AUDIO (first-class MediaDelta field)
-			if chunk.MediaDelta != nil {
+			// Check for AUDIO (raw bytes in MediaData)
+			if chunk.MediaData != nil {
 				audioChunks++
-				audioData := *chunk.MediaDelta.Data // Base64 string
 				fmt.Printf("🎵 [Audio Chunk %d] mime=%s, size=%d bytes\n",
-					audioChunks, chunk.MediaDelta.MIMEType, len(audioData))
+					audioChunks, chunk.MediaData.MIMEType, len(chunk.MediaData.Data))
 			}
 
 			if chunk.FinishReason != nil {

--- a/runtime/providers/gemini/demo_audio_output_test.go
+++ b/runtime/providers/gemini/demo_audio_output_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func TestStreamingDemo_AudioAndTextOutput(t *testing.T) {
 	if err != nil {
 		// If audio output is not supported, the API will reject with "invalid argument"
 		errMsg := err.Error()
-		if contains(errMsg, "invalid argument") || contains(errMsg, "1007") {
+		if strings.Contains(errMsg, "invalid argument") || strings.Contains(errMsg, "1007") {
 			t.Skipf("⚠️  Skipping: Audio output not yet supported by Gemini Live API. Error: %v", err)
 		}
 		t.Fatalf("❌ Failed to create session: %v", err)
@@ -272,7 +273,7 @@ func TestStreamingDemo_AudioOutputOnly(t *testing.T) {
 	if err != nil {
 		// If audio output is not supported, the API will reject with "invalid argument"
 		errMsg := err.Error()
-		if contains(errMsg, "invalid argument") || contains(errMsg, "1007") {
+		if strings.Contains(errMsg, "invalid argument") || strings.Contains(errMsg, "1007") {
 			t.Skipf("⚠️  Skipping: Audio output not yet supported by Gemini Live API. Error: %v", err)
 		}
 		t.Fatalf("❌ Failed to create session: %v", err)

--- a/runtime/providers/gemini/demo_audio_output_test.go
+++ b/runtime/providers/gemini/demo_audio_output_test.go
@@ -38,7 +38,7 @@ func TestStreamingDemo_AudioAndTextOutput(t *testing.T) {
 	// Create provider
 	provider := NewProvider(
 		"gemini-demo",
-		"gemini-2.0-flash-exp",
+		"gemini-2.5-flash-native-audio-latest",
 		"https://generativelanguage.googleapis.com/v1beta",
 		providers.ProviderDefaults{Temperature: 0.7},
 		false,
@@ -239,7 +239,7 @@ func TestStreamingDemo_AudioOutputOnly(t *testing.T) {
 
 	provider := NewProvider(
 		"gemini-demo",
-		"gemini-2.0-flash-exp",
+		"gemini-2.5-flash-native-audio-latest",
 		"https://generativelanguage.googleapis.com/v1beta",
 		providers.ProviderDefaults{Temperature: 0.7},
 		false,

--- a/runtime/providers/gemini/demo_streaming_test.go
+++ b/runtime/providers/gemini/demo_streaming_test.go
@@ -35,7 +35,7 @@ func TestStreamingDemo_RealAPI(t *testing.T) {
 	// Create provider
 	provider := NewProvider(
 		"gemini-demo",
-		"gemini-2.0-flash-exp",
+		"gemini-3.1-flash-live-preview",
 		"https://generativelanguage.googleapis.com/v1beta",
 		providers.ProviderDefaults{Temperature: 0.7},
 		false,

--- a/runtime/providers/gemini/demo_streaming_test.go
+++ b/runtime/providers/gemini/demo_streaming_test.go
@@ -84,12 +84,11 @@ func TestStreamingDemo_RealAPI(t *testing.T) {
 			fullResponse += chunk.Content
 			receivedChunks = true
 
-			// Check for audio in MediaDelta (first-class field)
-			if chunk.MediaDelta != nil {
+			// Check for audio in MediaData (raw bytes)
+			if chunk.MediaData != nil {
 				audioChunks++
-				audioData := *chunk.MediaDelta.Data // Base64 string
-				fmt.Printf("🎵 [Chunk %d] Received AUDIO: mime=%s, size=%d bytes (base64)\n",
-					chunkCount, chunk.MediaDelta.MIMEType, len(audioData))
+				fmt.Printf("🎵 [Chunk %d] Received AUDIO: mime=%s, size=%d bytes (raw)\n",
+					chunkCount, chunk.MediaData.MIMEType, len(chunk.MediaData.Data))
 			}
 
 			if chunk.Content != "" {

--- a/runtime/providers/gemini/diagnostic_audio_raw_test.go
+++ b/runtime/providers/gemini/diagnostic_audio_raw_test.go
@@ -105,23 +105,20 @@ func TestDiagnostic_AudioModalityRawMessages(t *testing.T) {
 			fmt.Printf("Content: %q\n", chunk.Content)
 			fmt.Printf("Delta: %q\n", chunk.Delta)
 
-			// Check for audio in MediaDelta (first-class field)
-			if chunk.MediaDelta != nil {
+			// Check for audio in MediaData (raw bytes)
+			if chunk.MediaData != nil {
 				hasAudioData = true
 				fmt.Println("🎵🎵🎵 AUDIO DATA FOUND! 🎵🎵🎵")
-				fmt.Printf("   MIME Type: %s\n", chunk.MediaDelta.MIMEType)
-				if chunk.MediaDelta.Data != nil {
-					audioData := *chunk.MediaDelta.Data
-					fmt.Printf("   Data length: %d bytes\n", len(audioData))
-					if len(audioData) > 0 {
-						fmt.Printf("   First 50 chars: %q\n", audioData[:min(50, len(audioData))])
-					}
+				fmt.Printf("   MIME Type: %s\n", chunk.MediaData.MIMEType)
+				fmt.Printf("   Data length: %d bytes\n", len(chunk.MediaData.Data))
+				if len(chunk.MediaData.Data) > 0 {
+					fmt.Printf("   First 50 bytes: %x\n", chunk.MediaData.Data[:min(50, len(chunk.MediaData.Data))])
 				}
-				if chunk.MediaDelta.Channels != nil {
-					fmt.Printf("   Channels: %d\n", *chunk.MediaDelta.Channels)
+				if chunk.MediaData.Channels != 0 {
+					fmt.Printf("   Channels: %d\n", chunk.MediaData.Channels)
 				}
-				if chunk.MediaDelta.BitRate != nil {
-					fmt.Printf("   Sample Rate: %d Hz\n", *chunk.MediaDelta.BitRate)
+				if chunk.MediaData.SampleRate != 0 {
+					fmt.Printf("   Sample Rate: %d Hz\n", chunk.MediaData.SampleRate)
 				}
 			}
 

--- a/runtime/providers/gemini/diagnostic_audio_raw_test.go
+++ b/runtime/providers/gemini/diagnostic_audio_raw_test.go
@@ -33,7 +33,7 @@ func TestDiagnostic_AudioModalityRawMessages(t *testing.T) {
 
 	provider := NewProvider(
 		"gemini-diagnostic",
-		"gemini-2.0-flash-exp",
+		"gemini-2.5-flash-native-audio-latest",
 		"https://generativelanguage.googleapis.com/v1beta",
 		providers.ProviderDefaults{Temperature: 0.7},
 		false,

--- a/runtime/providers/gemini/duplex_integration_test.go
+++ b/runtime/providers/gemini/duplex_integration_test.go
@@ -27,7 +27,7 @@ func TestDuplexIntegration_SystemPrompt(t *testing.T) {
 
 	provider := NewProvider(
 		"gemini-test",
-		"gemini-2.0-flash-exp",
+		"gemini-3.1-flash-live-preview",
 		"https://generativelanguage.googleapis.com/v1beta",
 		providers.ProviderDefaults{Temperature: 0.7},
 		false,
@@ -152,7 +152,7 @@ func TestDuplexIntegration_AudioThenEndInput(t *testing.T) {
 
 	provider := NewProvider(
 		"gemini-test",
-		"gemini-2.0-flash-exp",
+		"gemini-3.1-flash-live-preview",
 		"https://generativelanguage.googleapis.com/v1beta",
 		providers.ProviderDefaults{Temperature: 0.7},
 		false,
@@ -267,7 +267,7 @@ func TestDuplexIntegration_MultiTurn(t *testing.T) {
 
 	provider := NewProvider(
 		"gemini-test",
-		"gemini-2.0-flash-exp",
+		"gemini-3.1-flash-live-preview",
 		"https://generativelanguage.googleapis.com/v1beta",
 		providers.ProviderDefaults{Temperature: 0.7},
 		false,
@@ -350,7 +350,7 @@ func TestDuplexIntegration_ResponseModalities(t *testing.T) {
 
 	provider := NewProvider(
 		"gemini-test",
-		"gemini-2.0-flash-exp",
+		"gemini-3.1-flash-live-preview",
 		"https://generativelanguage.googleapis.com/v1beta",
 		providers.ProviderDefaults{Temperature: 0.7},
 		false,

--- a/runtime/providers/gemini/integration_streaming_test.go
+++ b/runtime/providers/gemini/integration_streaming_test.go
@@ -28,7 +28,7 @@ func TestStreamingIntegration_EndToEnd(t *testing.T) {
 	}
 
 	// Create provider
-	provider := NewProvider("gemini", "gemini-2.0-flash-exp", "https://generativelanguage.googleapis.com/v1beta", providers.ProviderDefaults{
+	provider := NewProvider("gemini", "gemini-3.1-flash-live-preview", "https://generativelanguage.googleapis.com/v1beta", providers.ProviderDefaults{
 		Temperature: 0.7,
 	}, false)
 
@@ -147,7 +147,7 @@ func TestStreamingIntegration_AudioRoundTrip(t *testing.T) {
 		t.Skip("Skipping integration test: GEMINI_API_KEY not set")
 	}
 
-	provider := NewProvider("gemini", "gemini-2.0-flash-exp", "https://generativelanguage.googleapis.com/v1beta", providers.ProviderDefaults{}, false)
+	provider := NewProvider("gemini", "gemini-3.1-flash-live-preview", "https://generativelanguage.googleapis.com/v1beta", providers.ProviderDefaults{}, false)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -220,7 +220,7 @@ func TestStreamingIntegration_ErrorHandling(t *testing.T) {
 			// Create provider with test API key
 			provider := &Provider{
 				BaseProvider: providers.BaseProvider{},
-				model:        "gemini-2.0-flash-exp",
+				model:        "gemini-3.1-flash-live-preview",
 				baseURL:      "https://generativelanguage.googleapis.com/v1beta",
 				apiKey:       tt.apiKey,
 			}
@@ -261,7 +261,7 @@ func TestStreamingIntegration_Performance(t *testing.T) {
 		t.Skip("Skipping integration test: GEMINI_API_KEY not set")
 	}
 
-	provider := NewProvider("gemini", "gemini-2.0-flash-exp", "https://generativelanguage.googleapis.com/v1beta", providers.ProviderDefaults{}, false)
+	provider := NewProvider("gemini", "gemini-3.1-flash-live-preview", "https://generativelanguage.googleapis.com/v1beta", providers.ProviderDefaults{}, false)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/runtime/providers/gemini/integration_streaming_test.go
+++ b/runtime/providers/gemini/integration_streaming_test.go
@@ -220,9 +220,9 @@ func TestStreamingIntegration_ErrorHandling(t *testing.T) {
 			// Create provider with test API key
 			provider := &Provider{
 				BaseProvider: providers.BaseProvider{},
-				Model:        "gemini-2.0-flash-exp",
-				BaseURL:      "https://generativelanguage.googleapis.com/v1beta",
-				ApiKey:       tt.apiKey,
+				model:        "gemini-2.0-flash-exp",
+				baseURL:      "https://generativelanguage.googleapis.com/v1beta",
+				apiKey:       tt.apiKey,
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/runtime/providers/gemini/stream_session_protocol_integration.go
+++ b/runtime/providers/gemini/stream_session_protocol_integration.go
@@ -316,20 +316,20 @@ func (s *StreamSession) processModelTurn(turn *ModelTurn, turnComplete bool, cos
 
 		// Handle audio/media data
 		if part.InlineData != nil {
-			// The data is base64 encoded PCM audio from Gemini
-			// Use MediaDelta for first-class media content
-			response.MediaDelta = &types.MediaContent{
-				Data:     &part.InlineData.Data, // Already base64 encoded
-				MIMEType: part.InlineData.MimeType,
-			}
-
-			// Add audio-specific metadata if this is audio
-			if strings.HasPrefix(part.InlineData.MimeType, "audio/") {
-				// Gemini uses 16kHz mono audio
-				channels := 1
-				sampleRate := 16000
-				response.MediaDelta.Channels = &channels
-				response.MediaDelta.BitRate = &sampleRate // Store sample rate in BitRate field
+			// Decode base64 at source — downstream receives raw bytes
+			rawBytes, decodeErr := base64.StdEncoding.DecodeString(part.InlineData.Data)
+			if decodeErr != nil {
+				logger.Warn("failed to decode base64 media from Gemini", "error", decodeErr)
+			} else {
+				media := &providers.StreamMediaData{
+					Data:     rawBytes,
+					MIMEType: part.InlineData.MimeType,
+				}
+				if strings.HasPrefix(part.InlineData.MimeType, "audio/") {
+					media.SampleRate = 16000
+					media.Channels = 1
+				}
+				response.MediaData = media
 			}
 		}
 	}

--- a/runtime/providers/gemini/stream_session_test.go
+++ b/runtime/providers/gemini/stream_session_test.go
@@ -333,34 +333,30 @@ func TestGeminiStreamSession_ReceiveAudioResponse(t *testing.T) {
 	// Receive response with audio
 	select {
 	case chunk := <-session.Response():
-		// Verify MediaDelta is populated
-		if chunk.MediaDelta == nil {
-			t.Fatal("Expected MediaDelta to be populated")
+		// Verify MediaData is populated (raw bytes, decoded from base64 at source)
+		if chunk.MediaData == nil {
+			t.Fatal("Expected MediaData to be populated")
 		}
 
-		if chunk.MediaDelta.MIMEType != "audio/pcm" {
-			t.Errorf("Expected MIMEType 'audio/pcm', got '%s'", chunk.MediaDelta.MIMEType)
+		if chunk.MediaData.MIMEType != "audio/pcm" {
+			t.Errorf("Expected MIMEType 'audio/pcm', got '%s'", chunk.MediaData.MIMEType)
 		}
 
-		if chunk.MediaDelta.Data == nil {
+		if len(chunk.MediaData.Data) == 0 {
 			t.Fatal("Expected Data to be populated")
 		}
 
-		if *chunk.MediaDelta.Data != "SGVsbG8gV29ybGQ=" {
-			t.Errorf("Expected base64 data 'SGVsbG8gV29ybGQ=', got '%s'", *chunk.MediaDelta.Data)
+		if string(chunk.MediaData.Data) != "Hello World" {
+			t.Errorf("Expected decoded data 'Hello World', got '%s'", string(chunk.MediaData.Data))
 		}
 
 		// Verify audio metadata is populated
-		if chunk.MediaDelta.Channels == nil {
-			t.Error("Expected Channels to be populated")
-		} else if *chunk.MediaDelta.Channels != 1 {
-			t.Errorf("Expected Channels to be 1, got %d", *chunk.MediaDelta.Channels)
+		if chunk.MediaData.Channels != 1 {
+			t.Errorf("Expected Channels to be 1, got %d", chunk.MediaData.Channels)
 		}
 
-		if chunk.MediaDelta.BitRate == nil {
-			t.Error("Expected BitRate (sample rate) to be populated")
-		} else if *chunk.MediaDelta.BitRate != 16000 {
-			t.Errorf("Expected BitRate to be 16000, got %d", *chunk.MediaDelta.BitRate)
+		if chunk.MediaData.SampleRate != 16000 {
+			t.Errorf("Expected SampleRate to be 16000, got %d", chunk.MediaData.SampleRate)
 		}
 
 		// Verify finish reason
@@ -429,12 +425,13 @@ func TestGeminiStreamSession_ReceiveMixedResponse(t *testing.T) {
 			t.Errorf("Expected text 'Here is your audio:', got '%s'", chunk.Content)
 		}
 
-		if chunk.MediaDelta == nil {
-			t.Fatal("Expected MediaDelta to be populated")
+		if chunk.MediaData == nil {
+			t.Fatal("Expected MediaData to be populated")
 		}
 
-		if *chunk.MediaDelta.Data != "YXVkaW8=" {
-			t.Errorf("Expected audio data 'YXVkaW8=', got '%s'", *chunk.MediaDelta.Data)
+		// "YXVkaW8=" is base64 for "audio" - producer decodes at source
+		if string(chunk.MediaData.Data) != "audio" {
+			t.Errorf("Expected decoded audio data 'audio', got '%s'", string(chunk.MediaData.Data))
 		}
 
 		// Verify finish reason is nil (not complete)

--- a/runtime/providers/openai/realtime_session_integration.go
+++ b/runtime/providers/openai/realtime_session_integration.go
@@ -23,10 +23,11 @@ const (
 
 // Configuration constants
 const (
-	responseChannelSize = 10
-	heartbeatInterval   = 30 * time.Second
-	setupTimeout        = 10 * time.Second
-	tokensPerThousand   = 1000.0
+	responseChannelSize     = 10
+	heartbeatInterval       = 30 * time.Second
+	setupTimeout            = 10 * time.Second
+	tokensPerThousand       = 1000.0
+	realtimeAudioSampleRate = 24000 // OpenAI Realtime API output audio sample rate (Hz)
 )
 
 // Ensure RealtimeSession implements StreamInputSession
@@ -561,13 +562,18 @@ func (s *RealtimeSession) handleTextDone(e *ResponseTextDoneEvent) {
 }
 
 func (s *RealtimeSession) handleAudioDelta(e *ResponseAudioDeltaEvent) {
-	// Keep audio as base64 - that's the expected format for MediaDelta.Data
-	// (DuplexProviderStage and downstream stages expect base64)
-	audioDataBase64 := e.Delta
+	rawBytes, err := base64.StdEncoding.DecodeString(e.Delta)
+	if err != nil {
+		logger.Warn("failed to decode base64 audio from OpenAI Realtime", "error", err)
+		return
+	}
+
 	s.responseCh <- providers.StreamChunk{
-		MediaDelta: &types.MediaContent{
-			Data:     &audioDataBase64,
-			MIMEType: "audio/pcm",
+		MediaData: &providers.StreamMediaData{
+			Data:       rawBytes,
+			MIMEType:   "audio/pcm",
+			SampleRate: realtimeAudioSampleRate,
+			Channels:   1,
 		},
 		Metadata: map[string]interface{}{
 			"item_id":       e.ItemID,

--- a/runtime/providers/replay/streaming.go
+++ b/runtime/providers/replay/streaming.go
@@ -336,11 +336,10 @@ func (s *StreamSession) sendAudioParts(msg arenaMessage) {
 			continue
 		}
 
-		audioStr := string(audioData)
 		if !s.safeSend(&providers.StreamChunk{
-			MediaDelta: &types.MediaContent{
+			MediaData: &providers.StreamMediaData{
+				Data:     audioData,
 				MIMEType: part.Media.MIMEType,
-				Data:     &audioStr,
 			},
 		}) {
 			return // Session closed, stop sending

--- a/runtime/providers/replay/streaming_test.go
+++ b/runtime/providers/replay/streaming_test.go
@@ -506,8 +506,8 @@ func TestStreamSession_AudioParts(t *testing.T) {
 	// Should receive audio chunk
 	select {
 	case chunk := <-session.Response():
-		if chunk.MediaDelta == nil {
-			t.Error("expected media delta")
+		if chunk.MediaData == nil {
+			t.Error("expected media data")
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Error("timeout waiting for audio")
@@ -559,8 +559,8 @@ func TestStreamSession_AudioFromFile(t *testing.T) {
 	// Should receive audio chunk
 	select {
 	case chunk := <-session.Response():
-		if chunk.MediaDelta == nil {
-			t.Error("expected media delta from file")
+		if chunk.MediaData == nil {
+			t.Error("expected media data from file")
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Error("timeout waiting for audio")

--- a/runtime/providers/streaming.go
+++ b/runtime/providers/streaming.go
@@ -54,14 +54,8 @@ type StreamChunk struct {
 	// Delta is the new content in this chunk
 	Delta string `json:"delta"`
 
-	// MediaDelta contains new media content in this chunk (audio, video, images)
-	// Uses the same MediaContent type as non-streaming messages for API consistency.
-	MediaDelta *types.MediaContent `json:"media_delta,omitempty"`
-
 	// MediaData contains raw streaming media bytes (audio, video, images).
 	// Data is always raw bytes, never base64. Providers decode at source.
-	// Prefer this over MediaDelta for all new code.
-	// MediaDelta is deprecated and will be removed in a future release.
 	MediaData *StreamMediaData `json:"-"`
 
 	// TokenCount is the total number of tokens so far

--- a/runtime/providers/streaming.go
+++ b/runtime/providers/streaming.go
@@ -7,6 +7,32 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// StreamMediaData carries raw media bytes for streaming.
+// Data is always raw bytes, never base64. Providers decode at source.
+//
+// This type maps to pipeline-internal types at the StreamChunk/StreamElement boundary:
+//   - stage.AudioData: SampleRate, Channels
+//   - stage.ImageData: Width, Height, FrameNum
+//   - stage.VideoData: Width, Height, FrameRate, IsKeyFrame, FrameNum
+type StreamMediaData struct {
+	// Common fields
+	Data     []byte // Raw media bytes (PCM audio, JPEG frame, H.264 chunk, etc.)
+	MIMEType string // e.g., "audio/pcm", "image/jpeg", "video/h264"
+
+	// Audio metadata
+	SampleRate int // Sample rate in Hz (e.g., 16000, 24000). 0 if not audio.
+	Channels   int // Channel count (1=mono, 2=stereo). 0 if not audio.
+
+	// Visual metadata (image and video)
+	Width  int // Pixels. 0 if unknown or not visual.
+	Height int // Pixels. 0 if unknown or not visual.
+
+	// Video/image streaming metadata
+	FrameRate  float64 // FPS. 0 if not video.
+	IsKeyFrame bool    // True if this is a key frame (video only).
+	FrameNum   int64   // Sequence number for ordering frames/chunks.
+}
+
 // DefaultStreamBufferSize is the default buffer size for streaming channels.
 // A buffer of 32 prevents the streaming goroutine from blocking on every send
 // when the consumer is slow, while keeping memory usage reasonable.
@@ -31,6 +57,12 @@ type StreamChunk struct {
 	// MediaDelta contains new media content in this chunk (audio, video, images)
 	// Uses the same MediaContent type as non-streaming messages for API consistency.
 	MediaDelta *types.MediaContent `json:"media_delta,omitempty"`
+
+	// MediaData contains raw streaming media bytes (audio, video, images).
+	// Data is always raw bytes, never base64. Providers decode at source.
+	// Prefer this over MediaDelta for all new code.
+	// MediaDelta is deprecated and will be removed in a future release.
+	MediaData *StreamMediaData `json:"-"`
 
 	// TokenCount is the total number of tokens so far
 	TokenCount int `json:"token_count"`

--- a/runtime/providers/streaming_media_test.go
+++ b/runtime/providers/streaming_media_test.go
@@ -1,0 +1,69 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamMediaData_AudioFields(t *testing.T) {
+	media := &StreamMediaData{
+		Data:       []byte{0x01, 0x02, 0x03, 0x04},
+		MIMEType:   "audio/pcm",
+		SampleRate: 16000,
+		Channels:   1,
+	}
+	assert.Equal(t, "audio/pcm", media.MIMEType)
+	assert.Equal(t, 16000, media.SampleRate)
+	assert.Equal(t, 1, media.Channels)
+	assert.Len(t, media.Data, 4)
+	assert.Zero(t, media.Width)
+	assert.Zero(t, media.Height)
+}
+
+func TestStreamMediaData_VideoFields(t *testing.T) {
+	media := &StreamMediaData{
+		Data:       []byte{0xFF, 0xD8},
+		MIMEType:   "video/h264",
+		Width:      1920,
+		Height:     1080,
+		FrameRate:  30.0,
+		IsKeyFrame: true,
+		FrameNum:   42,
+	}
+	assert.Equal(t, "video/h264", media.MIMEType)
+	assert.Equal(t, 1920, media.Width)
+	assert.Equal(t, 1080, media.Height)
+	assert.Equal(t, 30.0, media.FrameRate)
+	assert.True(t, media.IsKeyFrame)
+	assert.Equal(t, int64(42), media.FrameNum)
+	assert.Zero(t, media.SampleRate)
+	assert.Zero(t, media.Channels)
+}
+
+func TestStreamMediaData_ImageFields(t *testing.T) {
+	media := &StreamMediaData{
+		Data:     []byte{0x89, 0x50, 0x4E, 0x47},
+		MIMEType: "image/png",
+		Width:    800,
+		Height:   600,
+		FrameNum: 7,
+	}
+	assert.Equal(t, "image/png", media.MIMEType)
+	assert.Equal(t, 800, media.Width)
+	assert.Equal(t, 600, media.Height)
+	assert.Equal(t, int64(7), media.FrameNum)
+}
+
+func TestStreamChunk_MediaDataField(t *testing.T) {
+	chunk := StreamChunk{
+		Delta: "hello",
+		MediaData: &StreamMediaData{
+			Data:     []byte{0x01},
+			MIMEType: "audio/pcm",
+		},
+	}
+	assert.NotNil(t, chunk.MediaData)
+	assert.Equal(t, "audio/pcm", chunk.MediaData.MIMEType)
+	assert.Nil(t, chunk.MediaDelta)
+}

--- a/runtime/providers/streaming_media_test.go
+++ b/runtime/providers/streaming_media_test.go
@@ -65,5 +65,5 @@ func TestStreamChunk_MediaDataField(t *testing.T) {
 	}
 	assert.NotNil(t, chunk.MediaData)
 	assert.Equal(t, "audio/pcm", chunk.MediaData.MIMEType)
-	assert.Nil(t, chunk.MediaDelta)
+	assert.Equal(t, "hello", chunk.Delta)
 }

--- a/runtime/types/streaming.go
+++ b/runtime/types/streaming.go
@@ -248,8 +248,8 @@ func (cr *ChunkReader) NextChunk(ctx context.Context) (*MediaChunk, error) {
 //
 //	writer := NewChunkWriter(speakerOutput)
 //	for chunk := range session.Response() {
-//	    if chunk.MediaDelta != nil {
-//	        err := writer.WriteChunk(chunk.MediaDelta)
+//	    if chunk.MediaData != nil {
+//	        err := writer.WriteChunk(&MediaChunk{Data: chunk.MediaData.Data})
 //	        if err != nil {
 //	            return err
 //	        }

--- a/sdk/a2a_server_adapter.go
+++ b/sdk/a2a_server_adapter.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	a2aserver "github.com/AltairaLabs/PromptKit/server/a2a"
@@ -130,7 +131,17 @@ func chunkToEvent(c StreamChunk) a2aserver.StreamEvent {
 	case ChunkText:
 		return a2aserver.StreamEvent{Kind: a2aserver.EventText, Text: c.Text}
 	case ChunkMedia:
-		return a2aserver.StreamEvent{Kind: a2aserver.EventMedia, Media: c.Media}
+		if c.Media == nil {
+			return a2aserver.StreamEvent{Kind: a2aserver.EventMedia}
+		}
+		b64 := base64.StdEncoding.EncodeToString(c.Media.Data)
+		return a2aserver.StreamEvent{
+			Kind: a2aserver.EventMedia,
+			Media: &types.MediaContent{
+				Data:     &b64,
+				MIMEType: c.Media.MIMEType,
+			},
+		}
 	case ChunkToolCall:
 		return a2aserver.StreamEvent{Kind: a2aserver.EventToolCall}
 	case ChunkClientTool:

--- a/sdk/a2a_test.go
+++ b/sdk/a2a_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/a2a"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	a2aserver "github.com/AltairaLabs/PromptKit/server/a2a"
 )
@@ -78,14 +79,21 @@ func TestChunkToEvent_Text(t *testing.T) {
 }
 
 func TestChunkToEvent_Media(t *testing.T) {
-	fakeData := "ZmFrZQ=="
-	media := &types.MediaContent{MIMEType: "image/png", Data: &fakeData}
+	rawBytes := []byte("fake")
+	media := &providers.StreamMediaData{MIMEType: "image/png", Data: rawBytes}
 	evt := chunkToEvent(StreamChunk{Type: ChunkMedia, Media: media})
 	if evt.Kind != a2aserver.EventMedia {
 		t.Errorf("expected EventMedia, got %v", evt.Kind)
 	}
-	if evt.Media != media {
-		t.Error("expected media to be passed through")
+	if evt.Media == nil {
+		t.Fatal("expected media to be set")
+	}
+	if evt.Media.MIMEType != "image/png" {
+		t.Errorf("expected MIMEType %q, got %q", "image/png", evt.Media.MIMEType)
+	}
+	expectedB64 := "ZmFrZQ=="
+	if evt.Media.Data == nil || *evt.Media.Data != expectedB64 {
+		t.Errorf("expected base64 data %q, got %v", expectedB64, evt.Media.Data)
 	}
 }
 
@@ -317,7 +325,9 @@ type a2aTestResult struct{}
 func (r *a2aTestResult) HasPendingTools() bool                                 { return false }
 func (r *a2aTestResult) HasPendingClientTools() bool                           { return false }
 func (r *a2aTestResult) PendingClientTools() []a2aserver.PendingClientToolInfo { return nil }
-func (r *a2aTestResult) Parts() []types.ContentPart                            { return []types.ContentPart{types.NewTextPart("mock response")} }
-func (r *a2aTestResult) Text() string                                          { return "mock response" }
+func (r *a2aTestResult) Parts() []types.ContentPart {
+	return []types.ContentPart{types.NewTextPart("mock response")}
+}
+func (r *a2aTestResult) Text() string { return "mock response" }
 
 func a2aTextPtr(s string) *string { return &s }

--- a/sdk/examples/duplex-streaming/main_interactive.go
+++ b/sdk/examples/duplex-streaming/main_interactive.go
@@ -270,11 +270,10 @@ func (ah *AudioHandler) captureAndStreamAudio(ctx context.Context) error {
 
 			// Stream audio continuously to the model
 			// Gemini ASM can handle continuous bidirectional audio
-			audioData := string(audioBytes)
 			chunk := &providers.StreamChunk{
-				MediaDelta: &types.MediaContent{
-					MIMEType: types.MIMETypeAudioWAV,
-					Data:     &audioData,
+				MediaData: &providers.StreamMediaData{
+					MIMEType: "audio/pcm",
+					Data:     audioBytes,
 				},
 			}
 
@@ -332,11 +331,10 @@ func (ah *AudioHandler) processResponses(ctx context.Context) {
 				}
 
 				// Handle audio response
-				if chunk.MediaDelta != nil && chunk.MediaDelta.Data != nil {
+				if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
 					// Queue audio for playback
-					audioData := []byte(*chunk.MediaDelta.Data)
 					select {
-					case ah.audioQueue <- audioData:
+					case ah.audioQueue <- chunk.MediaData.Data:
 					case <-ctx.Done():
 						return
 					}

--- a/sdk/examples/openai-realtime/main_interactive.go
+++ b/sdk/examples/openai-realtime/main_interactive.go
@@ -417,11 +417,10 @@ func (ah *AudioHandler) captureAndStreamAudio(ctx context.Context) error {
 			audioBytes := int16ToBytes(in)
 
 			// Create audio chunk
-			audioData := string(audioBytes)
 			chunk := &providers.StreamChunk{
-				MediaDelta: &types.MediaContent{
+				MediaData: &providers.StreamMediaData{
 					MIMEType: "audio/pcm",
-					Data:     &audioData,
+					Data:     audioBytes,
 				},
 			}
 
@@ -474,8 +473,8 @@ func (ah *AudioHandler) processResponses(ctx context.Context) {
 				}
 
 				// Handle audio response
-				if chunk.MediaDelta != nil && chunk.MediaDelta.Data != nil {
-					audioData := []byte(*chunk.MediaDelta.Data)
+				if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
+					audioData := chunk.MediaData.Data
 					select {
 					case ah.audioQueue <- audioData:
 					case <-ctx.Done():
@@ -550,8 +549,8 @@ func (ah *AudioHandler) processResponsesWithTools(ctx context.Context) {
 				}
 
 				// Handle audio
-				if chunk.MediaDelta != nil && chunk.MediaDelta.Data != nil {
-					audioData := []byte(*chunk.MediaDelta.Data)
+				if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
+					audioData := chunk.MediaData.Data
 					select {
 					case ah.audioQueue <- audioData:
 					case <-ctx.Done():

--- a/sdk/examples/voice-interview/interview/controller.go
+++ b/sdk/examples/voice-interview/interview/controller.go
@@ -4,13 +4,11 @@ package interview
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
-	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/sdk"
 	"github.com/AltairaLabs/PromptKit/sdk/examples/voice-interview/audio"
 	"github.com/AltairaLabs/PromptKit/sdk/examples/voice-interview/video"
@@ -212,11 +210,10 @@ func (c *Controller) runAudioStreaming() {
 				fmt.Printf("[%s] First audio chunk from mic: %d bytes\n", modeStr, len(audioData))
 			}
 			// Stream audio to the pipeline (works for both ASM and VAD modes)
-			audioDataStr := string(audioData)
 			chunk := &providers.StreamChunk{
-				MediaDelta: &types.MediaContent{
-					MIMEType: types.MIMETypeAudioWAV,
-					Data:     &audioDataStr,
+				MediaData: &providers.StreamMediaData{
+					MIMEType: "audio/pcm",
+					Data:     audioData,
 				},
 			}
 
@@ -315,14 +312,10 @@ func (c *Controller) handleResponseStream(respCh <-chan providers.StreamChunk) {
 			}
 
 			// Handle audio response
-			if chunk.MediaDelta != nil && chunk.MediaDelta.Data != nil {
+			if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
 				audioChunkCount++
-				// Decode base64 audio data from Gemini
-				audioData, err := base64.StdEncoding.DecodeString(*chunk.MediaDelta.Data)
-				if err != nil {
-					fmt.Printf("[RESPONSE ERROR] Failed to decode audio: %v\n", err)
-					continue
-				}
+				// Audio data is already raw bytes (decoded at source by provider)
+				audioData := chunk.MediaData.Data
 				c.emitEvent(EventAudioReceived, len(audioData))
 
 				if audioChunkCount == 1 {
@@ -417,9 +410,9 @@ func (c *Controller) processWebcamFrames() {
 
 			// Send frame to Gemini
 			chunk := &providers.StreamChunk{
-				MediaDelta: &types.MediaContent{
-					MIMEType: types.MIMETypeImageJPEG,
-					Data:     &frame.Base64,
+				MediaData: &providers.StreamMediaData{
+					MIMEType: "image/jpeg",
+					Data:     frame.Data,
 				},
 			}
 
@@ -462,9 +455,9 @@ func (c *Controller) sendWebcamFrame() {
 	}
 
 	chunk := &providers.StreamChunk{
-		MediaDelta: &types.MediaContent{
-			MIMEType: types.MIMETypeImageJPEG,
-			Data:     &frame.Base64,
+		MediaData: &providers.StreamMediaData{
+			MIMEType: "image/jpeg",
+			Data:     frame.Data,
 		},
 	}
 

--- a/sdk/session/duplex_audio_integration_test.go
+++ b/sdk/session/duplex_audio_integration_test.go
@@ -78,14 +78,13 @@ func TestAudioFlowThroughPipeline(t *testing.T) {
 
 	// Generate test audio data
 	audioData := generateTestAudioData(1600) // 100ms at 16kHz mono
-	audioStr := string(audioData)
 
 	// Create audio chunk with EndOfStream to signal end of turn input
 	// This allows the DuplexProviderStage to start processing immediately
 	chunk := &providers.StreamChunk{
-		MediaDelta: &types.MediaContent{
-			MIMEType: types.MIMETypeAudioWAV,
-			Data:     &audioStr,
+		MediaData: &providers.StreamMediaData{
+			MIMEType: "audio/pcm",
+			Data:     audioData,
 		},
 		Metadata: map[string]interface{}{
 			"end_of_stream": true, // Signal end of input turn
@@ -205,12 +204,11 @@ func TestMultipleAudioChunksFlow(t *testing.T) {
 		audioData := generateTestAudioData(320)
 		// Mark each chunk with its index
 		audioData[0] = byte(i)
-		audioStr := string(audioData)
 
 		chunk := &providers.StreamChunk{
-			MediaDelta: &types.MediaContent{
-				MIMEType: types.MIMETypeAudioWAV,
-				Data:     &audioStr,
+			MediaData: &providers.StreamMediaData{
+				MIMEType: "audio/pcm",
+				Data:     audioData,
 			},
 		}
 		// Signal end of stream on last chunk
@@ -261,13 +259,12 @@ func TestAudioDataIntegrity(t *testing.T) {
 		// Create a recognizable pattern
 		audioData[i] = byte((i * 7) % 256)
 	}
-	audioStr := string(audioData)
 
 	// Send chunk with end_of_stream to allow pipeline to process
 	err := session.SendChunk(ctx, &providers.StreamChunk{
-		MediaDelta: &types.MediaContent{
-			MIMEType: types.MIMETypeAudioWAV,
-			Data:     &audioStr,
+		MediaData: &providers.StreamMediaData{
+			MIMEType: "audio/pcm",
+			Data:     audioData,
 		},
 		Metadata: map[string]interface{}{
 			"end_of_stream": true,

--- a/sdk/session/duplex_audio_integration_test.go
+++ b/sdk/session/duplex_audio_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
-	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -406,11 +405,10 @@ func TestDiagnostics(t *testing.T) {
 
 	// Step 7: Send a test chunk with end_of_stream
 	audioData := []byte{1, 2, 3, 4, 5}
-	audioStr := string(audioData)
 	err = session.SendChunk(ctx, &providers.StreamChunk{
-		MediaDelta: &types.MediaContent{
-			MIMEType: types.MIMETypeAudioWAV,
-			Data:     &audioStr,
+		MediaData: &providers.StreamMediaData{
+			MIMEType: "audio/wav",
+			Data:     audioData,
 		},
 		Metadata: map[string]interface{}{
 			"end_of_stream": true,

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -243,21 +243,13 @@ func (s *duplexSession) SendFrame(ctx context.Context, frame *ImageFrame) error 
 		return fmt.Errorf("frame data is required")
 	}
 
-	// TODO: This copies []byte to string on every frame, which is expensive for
-	// high-frequency video. Consider using unsafe.String or redesigning MediaContent
-	// to accept []byte directly. This is API-breaking so deferred for a future release.
-	dataStr := string(frame.Data)
-
 	chunk := &providers.StreamChunk{
-		MediaDelta: &types.MediaContent{
+		MediaData: &providers.StreamMediaData{
+			Data:     frame.Data,
 			MIMEType: frame.MIMEType,
-			Data:     &dataStr,
-		},
-		Metadata: map[string]any{
-			"width":     frame.Width,
-			"height":    frame.Height,
-			"timestamp": frame.Timestamp,
-			"frame_num": frame.FrameNum,
+			Width:    frame.Width,
+			Height:   frame.Height,
+			FrameNum: frame.FrameNum,
 		},
 	}
 	return s.SendChunk(ctx, chunk)
@@ -277,20 +269,14 @@ func (s *duplexSession) SendVideoChunk(ctx context.Context, vchunk *VideoChunk) 
 		return fmt.Errorf("video chunk data is required")
 	}
 
-	// Convert chunk data to string for MediaContent
-	dataStr := string(vchunk.Data)
-
 	chunk := &providers.StreamChunk{
-		MediaDelta: &types.MediaContent{
-			MIMEType: vchunk.MIMEType,
-			Data:     &dataStr,
-		},
-		Metadata: map[string]any{
-			"width":        vchunk.Width,
-			"height":       vchunk.Height,
-			"timestamp":    vchunk.Timestamp,
-			"frame_num":    int64(vchunk.ChunkIndex),
-			"is_key_frame": vchunk.IsKeyFrame,
+		MediaData: &providers.StreamMediaData{
+			Data:       vchunk.Data,
+			MIMEType:   vchunk.MIMEType,
+			Width:      vchunk.Width,
+			Height:     vchunk.Height,
+			FrameNum:   int64(vchunk.ChunkIndex),
+			IsKeyFrame: vchunk.IsKeyFrame,
 		},
 	}
 	return s.SendChunk(ctx, chunk)
@@ -645,20 +631,25 @@ func applyImageMetadata(image *stage.ImageData, metadata map[string]any) {
 	}
 }
 
-// convertMediaDelta converts a chunk's MediaDelta to the appropriate stage element field.
-func convertMediaDelta(elem *stage.StreamElement, chunk *providers.StreamChunk) {
-	if chunk.MediaDelta == nil || chunk.MediaDelta.Data == nil {
+// convertMediaData converts a chunk's MediaData to the appropriate stage element field.
+func convertMediaData(elem *stage.StreamElement, chunk *providers.StreamChunk) {
+	if chunk.MediaData == nil || len(chunk.MediaData.Data) == 0 {
 		return
 	}
 
-	mimeType := chunk.MediaDelta.MIMEType
-	mediaData := []byte(*chunk.MediaDelta.Data)
+	mimeType := chunk.MediaData.MIMEType
+	mediaData := chunk.MediaData.Data // already []byte, no copy
 
 	switch {
 	case strings.HasPrefix(mimeType, "video/"):
 		elem.Video = &stage.VideoData{
-			Data:     mediaData,
-			MIMEType: mimeType,
+			Data:       mediaData,
+			MIMEType:   mimeType,
+			Width:      chunk.MediaData.Width,
+			Height:     chunk.MediaData.Height,
+			FrameRate:  chunk.MediaData.FrameRate,
+			IsKeyFrame: chunk.MediaData.IsKeyFrame,
+			FrameNum:   chunk.MediaData.FrameNum,
 		}
 		elem.Priority = stage.PriorityHigh
 		applyVideoMetadata(elem.Video, chunk.Metadata)
@@ -667,15 +658,26 @@ func convertMediaDelta(elem *stage.StreamElement, chunk *providers.StreamChunk) 
 		elem.Image = &stage.ImageData{
 			Data:     mediaData,
 			MIMEType: mimeType,
+			Width:    chunk.MediaData.Width,
+			Height:   chunk.MediaData.Height,
+			FrameNum: chunk.MediaData.FrameNum,
 		}
 		applyImageMetadata(elem.Image, chunk.Metadata)
 
 	default:
 		// Audio handling (default for backwards compatibility)
-		const defaultSampleRate = 16000 // Default for speech
+		sampleRate := chunk.MediaData.SampleRate
+		if sampleRate == 0 {
+			sampleRate = 16000
+		}
+		channels := chunk.MediaData.Channels
+		if channels == 0 {
+			channels = 1
+		}
 		elem.Audio = &stage.AudioData{
 			Samples:    mediaData,
-			SampleRate: defaultSampleRate,
+			SampleRate: sampleRate,
+			Channels:   channels,
 			Format:     stage.AudioFormatPCM16,
 		}
 	}
@@ -689,7 +691,7 @@ func streamChunkToStreamElement(chunk *providers.StreamChunk) stage.StreamElemen
 		Metadata: make(map[string]interface{}),
 	}
 
-	convertMediaDelta(&elem, chunk)
+	convertMediaData(&elem, chunk)
 
 	// Convert text content
 	if chunk.Delta != "" {
@@ -717,12 +719,13 @@ func streamChunkToStreamElement(chunk *providers.StreamChunk) stage.StreamElemen
 func streamElementToStreamChunk(elem *stage.StreamElement) providers.StreamChunk {
 	chunk := providers.StreamChunk{}
 
-	// Convert audio data from Audio to MediaDelta
+	// Convert audio data from Audio to MediaData
 	if elem.Audio != nil && len(elem.Audio.Samples) > 0 {
-		audioStr := string(elem.Audio.Samples)
-		chunk.MediaDelta = &types.MediaContent{
-			MIMEType: types.MIMETypeAudioWAV,
-			Data:     &audioStr,
+		chunk.MediaData = &providers.StreamMediaData{
+			Data:       elem.Audio.Samples,
+			MIMEType:   "audio/pcm",
+			SampleRate: elem.Audio.SampleRate,
+			Channels:   elem.Audio.Channels,
 		}
 	}
 

--- a/sdk/session/duplex_session_test.go
+++ b/sdk/session/duplex_session_test.go
@@ -588,11 +588,11 @@ func TestSendChunk_EdgeCases(t *testing.T) {
 			PipelineBuilder: testPipelineBuilder})
 		require.NoError(t, err)
 
-		// Empty chunk with no Content, Delta, or MediaDelta
+		// Empty chunk with no Content, Delta, or MediaData
 		err = session.SendChunk(ctx, &providers.StreamChunk{})
 		// Note: The mock provider might accept empty chunks, so we just check that it doesn't crash
 		if err != nil {
-			assert.Contains(t, err.Error(), "chunk must contain either MediaDelta or Content/Delta")
+			assert.Contains(t, err.Error(), "chunk must contain either MediaData or Content/Delta")
 		}
 	})
 
@@ -626,7 +626,7 @@ func TestSendChunk_EdgeCases(t *testing.T) {
 	// Audio format settings should be configured at session creation time.
 
 	// NOTE: "sends media chunk with nil data" test removed
-	// Stage-based pipeline correctly skips MediaDelta with nil Data
+	// Stage-based pipeline correctly skips MediaData with nil Data
 	// since empty audio chunks don't need to be forwarded to the provider.
 
 	t.Run("returns error when session closed", func(t *testing.T) {

--- a/sdk/session/duplex_session_test.go
+++ b/sdk/session/duplex_session_test.go
@@ -106,11 +106,10 @@ func TestBidirectionalSession_SendChunk(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		mediaData := "audio data"
 		chunk := &providers.StreamChunk{
-			MediaDelta: &types.MediaContent{
-				MIMEType: types.MIMETypeAudioWAV,
-				Data:     &mediaData,
+			MediaData: &providers.StreamMediaData{
+				MIMEType: "audio/pcm",
+				Data:     []byte("audio data"),
 			},
 		}
 
@@ -121,7 +120,7 @@ func TestBidirectionalSession_SendChunk(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 
 		require.Len(t, provider.GetSession().GetChunks(), 1)
-		assert.Equal(t, []byte(mediaData), provider.GetSession().GetChunks()[0].Data)
+		assert.Equal(t, []byte("audio data"), provider.GetSession().GetChunks()[0].Data)
 	})
 
 	t.Run("sends text chunk", func(t *testing.T) {
@@ -348,11 +347,10 @@ func TestBidirectionalSession_AllMethods(t *testing.T) {
 		require.NoError(t, err)
 
 		// Test SendChunk
-		mediaData := "audio"
 		err = session.SendChunk(context.Background(), &providers.StreamChunk{
-			MediaDelta: &types.MediaContent{
-				MIMEType: types.MIMETypeAudioWAV,
-				Data:     &mediaData,
+			MediaData: &providers.StreamMediaData{
+				MIMEType: "audio/pcm",
+				Data:     []byte("audio"),
 			},
 		})
 		require.NoError(t, err)
@@ -1109,4 +1107,146 @@ func (m *mockErrorStore) Fork(ctx context.Context, sourceID, targetID string) er
 		return m.forkErr
 	}
 	return nil
+}
+
+// TestSubmitToolResults verifies that SubmitToolResults sends tool responses
+// back into the pipeline and returns an error on a closed session.
+func TestSubmitToolResults(t *testing.T) {
+	ctx := context.Background()
+
+	provider := mock.NewStreamingProvider("mock-provider", "mock-model", false)
+	session, err := NewDuplexSession(ctx, &DuplexSessionConfig{
+		Provider:        provider,
+		Config:          &providers.StreamingInputConfig{},
+		PipelineBuilder: testPipelineBuilder,
+	})
+	require.NoError(t, err)
+
+	// Start the pipeline by sending a text chunk first
+	err = session.SendChunk(ctx, &providers.StreamChunk{Content: "hello"})
+	require.NoError(t, err)
+
+	// SubmitToolResults on an open session should succeed (non-blocking on buffered channel)
+	responses := []providers.ToolResponse{
+		{ToolCallID: "call-1", Result: "result-1"},
+	}
+	err = session.SubmitToolResults(ctx, responses)
+	require.NoError(t, err)
+
+	// SubmitToolResults on a closed session should return an error
+	require.NoError(t, session.Close())
+	err = session.SubmitToolResults(ctx, responses)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "closed")
+}
+
+// TestApplyVideoMetadata verifies that applyVideoMetadata correctly populates
+// VideoData fields from a metadata map.
+func TestApplyVideoMetadata(t *testing.T) {
+	video := &stage.VideoData{}
+	ts := time.Now()
+	metadata := map[string]any{
+		"width":        1920,
+		"height":       1080,
+		"timestamp":    ts,
+		"is_key_frame": true,
+		"frame_num":    int64(42),
+	}
+	applyVideoMetadata(video, metadata)
+	assert.Equal(t, 1920, video.Width)
+	assert.Equal(t, 1080, video.Height)
+	assert.Equal(t, ts, video.Timestamp)
+	assert.True(t, video.IsKeyFrame)
+	assert.Equal(t, int64(42), video.FrameNum)
+
+	// nil metadata is a no-op
+	video2 := &stage.VideoData{}
+	applyVideoMetadata(video2, nil)
+	assert.Zero(t, video2.Width)
+}
+
+// TestApplyImageMetadata verifies that applyImageMetadata correctly populates
+// ImageData fields from a metadata map.
+func TestApplyImageMetadata(t *testing.T) {
+	image := &stage.ImageData{}
+	ts := time.Now()
+	metadata := map[string]any{
+		"width":     640,
+		"height":    480,
+		"timestamp": ts,
+		"frame_num": int64(7),
+	}
+	applyImageMetadata(image, metadata)
+	assert.Equal(t, 640, image.Width)
+	assert.Equal(t, 480, image.Height)
+	assert.Equal(t, ts, image.Timestamp)
+	assert.Equal(t, int64(7), image.FrameNum)
+
+	// nil metadata is a no-op
+	image2 := &stage.ImageData{}
+	applyImageMetadata(image2, nil)
+	assert.Zero(t, image2.Width)
+}
+
+// TestConvertMediaDataVideoWithMetadata verifies that convertMediaData correctly
+// handles video MIME types and applies supplementary metadata.
+func TestConvertMediaDataVideoWithMetadata(t *testing.T) {
+	elem := &stage.StreamElement{
+		Metadata: make(map[string]interface{}),
+	}
+	chunk := &providers.StreamChunk{
+		MediaData: &providers.StreamMediaData{
+			Data:       []byte("video-bytes"),
+			MIMEType:   "video/h264",
+			Width:      1280,
+			Height:     720,
+			FrameRate:  30.0,
+			IsKeyFrame: true,
+			FrameNum:   int64(5),
+		},
+		Metadata: map[string]any{
+			"width":        1280,
+			"height":       720,
+			"is_key_frame": true,
+			"frame_num":    int64(5),
+		},
+	}
+	convertMediaData(elem, chunk)
+	require.NotNil(t, elem.Video)
+	assert.Equal(t, []byte("video-bytes"), elem.Video.Data)
+	assert.Equal(t, "video/h264", elem.Video.MIMEType)
+	assert.Equal(t, 1280, elem.Video.Width)
+	assert.Equal(t, 720, elem.Video.Height)
+	assert.True(t, elem.Video.IsKeyFrame)
+	assert.Equal(t, int64(5), elem.Video.FrameNum)
+	assert.Equal(t, stage.PriorityHigh, elem.Priority)
+}
+
+// TestConvertMediaDataImageWithMetadata verifies that convertMediaData correctly
+// handles image MIME types and applies supplementary metadata.
+func TestConvertMediaDataImageWithMetadata(t *testing.T) {
+	elem := &stage.StreamElement{
+		Metadata: make(map[string]interface{}),
+	}
+	chunk := &providers.StreamChunk{
+		MediaData: &providers.StreamMediaData{
+			Data:     []byte("img-bytes"),
+			MIMEType: "image/jpeg",
+			Width:    320,
+			Height:   240,
+			FrameNum: int64(3),
+		},
+		Metadata: map[string]any{
+			"width":     320,
+			"height":    240,
+			"frame_num": int64(3),
+		},
+	}
+	convertMediaData(elem, chunk)
+	require.NotNil(t, elem.Image)
+	assert.Equal(t, []byte("img-bytes"), elem.Image.Data)
+	assert.Equal(t, "image/jpeg", elem.Image.MIMEType)
+	assert.Equal(t, 320, elem.Image.Width)
+	assert.Equal(t, 240, elem.Image.Height)
+	assert.Equal(t, int64(3), elem.Image.FrameNum)
 }

--- a/sdk/session/session.go
+++ b/sdk/session/session.go
@@ -55,7 +55,7 @@ type UnarySession interface {
 type DuplexSession interface {
 	BaseSession
 
-	// SendChunk sends a chunk to the session (populate MediaDelta for media, Content for text).
+	// SendChunk sends a chunk to the session (populate MediaData for media, Content for text).
 	// This method is thread-safe and can be called from multiple goroutines.
 	SendChunk(ctx context.Context, chunk *providers.StreamChunk) error
 

--- a/sdk/stream/stream.go
+++ b/sdk/stream/stream.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -32,7 +33,7 @@ type Chunk struct {
 	ToolCall *types.MessageToolCall
 
 	// Media content (for ChunkMedia type)
-	Media *types.MediaContent
+	Media *providers.StreamMediaData
 
 	// Error (if any occurred)
 	Error error

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -26,7 +26,7 @@ type StreamChunk struct {
 	ToolCall *types.MessageToolCall
 
 	// Media content (for ChunkMedia type)
-	Media *types.MediaContent
+	Media *providers.StreamMediaData
 
 	// ClientTool contains a pending client tool request (for ChunkClientTool type).
 	// The caller should fulfill it via SendToolResult/RejectClientTool, then call ResumeStream.
@@ -332,9 +332,9 @@ func (c *Conversation) emitStreamChunk(
 		sendChunk(ctx, outCh, StreamChunk{Type: ChunkText, Text: chunk.Delta})
 	}
 
-	// Emit media delta
-	if chunk.MediaDelta != nil {
-		sendChunk(ctx, outCh, StreamChunk{Type: ChunkMedia, Media: chunk.MediaDelta})
+	// Emit media data
+	if chunk.MediaData != nil {
+		sendChunk(ctx, outCh, StreamChunk{Type: ChunkMedia, Media: chunk.MediaData})
 	}
 
 	// Emit new tool calls

--- a/sdk/streaming_test.go
+++ b/sdk/streaming_test.go
@@ -336,9 +336,9 @@ func TestStreamingWithMultipleChunks(t *testing.T) {
 		},
 		{
 			Content: "Final",
-			MediaDelta: &types.MediaContent{
+			MediaData: &providers.StreamMediaData{
 				MIMEType: "audio/pcm",
-				Data:     strPtr("base64data"),
+				Data:     []byte("rawdata"),
 			},
 			FinishReason: &finishReason,
 		},

--- a/tools/arena/engine/duplex_state_store_test.go
+++ b/tools/arena/engine/duplex_state_store_test.go
@@ -218,7 +218,7 @@ func TestDuplexStateStore_BuildResultFromStateStore(t *testing.T) {
 // from the assistant is properly captured in the state store in duplex mode.
 //
 // TDD test - defines expected behavior:
-// 1. When the provider returns media responses (MediaDelta with audio/video)
+// 1. When the provider returns media responses (MediaData with audio/video)
 // 2. Then the assistant message in state store should have media content parts
 // 3. This should work the same as non-duplex mode response streaming
 //
@@ -326,12 +326,12 @@ func TestDuplexStateStore_MediaOutputCaptured(t *testing.T) {
 }
 
 // TestDuplexStateStore_PipelineCapturesMediaFromProvider verifies that when
-// the provider returns media (audio/video) via MediaDelta in StreamChunk,
+// the provider returns media (audio/video) via MediaData in StreamChunk,
 // it is properly converted to a Message with media parts and saved to state store.
 //
 // This is the TDD test for the actual fix needed in DuplexProviderStage.chunkToElement
 func TestDuplexStateStore_PipelineCapturesMediaFromProvider(t *testing.T) {
-	// Setup: Create a mock provider that returns audio in MediaDelta
+	// Setup: Create a mock provider that returns audio in MediaData
 	mockProvider := mock.NewStreamingProvider("test-mock", "mock-model", false)
 	mockProvider.WithAutoRespond("") // Will be configured after session creation
 
@@ -403,12 +403,12 @@ func TestDuplexStateStore_PipelineCapturesMediaFromProvider(t *testing.T) {
 	t.Logf("Result.MediaOutputs: %d", len(result.MediaOutputs))
 
 	// Currently this test documents the expected behavior:
-	// When the provider returns media in MediaDelta, it should be captured.
+	// When the provider returns media in MediaData, it should be captured.
 	// The mock provider doesn't currently return audio, so this test passes
 	// but serves as documentation of expected behavior.
 	//
 	// TODO: When implementing audio response support in the mock:
-	// 1. Configure mock to return audio in MediaDelta
+	// 1. Configure mock to return audio in MediaData
 	// 2. Verify assistant message has audio content parts
 	// 3. Verify MediaOutputs contains the audio
 }


### PR DESCRIPTION
## Summary

- **Replace `StreamChunk.MediaDelta *types.MediaContent`** with `StreamChunk.MediaData *StreamMediaData` — raw `[]byte` instead of base64 `*string`
- **Fix ProviderStage dropping streaming media** — `emitChunkElement()` now propagates media-only chunks instead of silently discarding them
- **Zero-copy duplex boundary conversions** — `SendFrame`, `SendVideoChunk`, `convertMediaData`, `streamElementToStreamChunk` no longer copy between `[]byte` and `string`
- **Providers decode base64 at source** — Gemini and OpenAI Realtime decode once in the provider, eliminating downstream ambiguity
- **Fix format ambiguity** — `MediaDelta.Data` was sometimes base64 (from providers) and sometimes raw bytes (from duplex converters). `StreamMediaData.Data` is always raw bytes.
- **Fix pre-existing compilation errors** in Gemini integration tests (`undefined: contains`, unexported field names)
- **Update deprecated model name** `gemini-2.0-flash-exp` in integration tests

## BREAKING CHANGE

`StreamChunk.MediaDelta` removed. Use `StreamChunk.MediaData *StreamMediaData` instead.
SDK `StreamChunk.Media` is now `*providers.StreamMediaData` (was `*types.MediaContent`).

## `StreamMediaData` type

```go
type StreamMediaData struct {
    Data       []byte  // Raw media bytes (never base64)
    MIMEType   string  // e.g., "audio/pcm", "image/jpeg"
    SampleRate int     // Audio: Hz
    Channels   int     // Audio: 1=mono
    Width      int     // Visual: pixels
    Height     int     // Visual: pixels
    FrameRate  float64 // Video: FPS
    IsKeyFrame bool    // Video: key frame
    FrameNum   int64   // Sequence number
}
```

## What's NOT affected

- `types.MediaContent` — unchanged (correct for JSON serialization in `Message.Parts`)
- Non-streaming media path (`PredictionResponse.Parts` → `Message.Parts`)
- Pipeline internal types (`stage.AudioData`, `stage.VideoData`, `stage.ImageData`)
- STT/TTS/VAD stages (work with `stage.StreamElement`, never `StreamChunk`)
- Arena media tests (test `Message.Parts`, not `StreamChunk`)
- Capability-matrix scenarios (media input via `Message.Parts`, text streaming output)

## Test plan

- [x] 94 packages pass with `-race` across runtime, SDK, Arena, pkg
- [x] Live Gemini API integration test passes — 26 audio chunks streamed via `StreamMediaData`
- [x] Zero `MediaDelta` references remaining in codebase
- [x] `golangci-lint` clean
- [x] Pre-commit hooks pass on all commits

## Known issues (pre-existing, not caused by this PR)

- Gemini integration tests using `gemini-2.0-flash-exp` (now updated to newer models) — some text-mode tests fail due to `gemini-3.1-flash-live-preview` API instability. Audio tests pass. Will be addressed in a follow-up PR.