### PR TITLE
docs: update SDK example docs to use StreamMediaData

### DIFF
--- a/sdk/examples/duplex-streaming/ARCHITECTURE.md
+++ b/sdk/examples/duplex-streaming/ARCHITECTURE.md
@@ -186,7 +186,7 @@ func initDuplexSession(conv *Conversation, cfg *config, streamProvider providers
 2. Loop forever:
    - Read audio frame (100ms chunks = 1600 samples)
    - Convert int16 samples to bytes (PCM16)
-   - Create StreamChunk with MediaDelta
+   - Create StreamChunk with MediaData
    - Call conv.SendChunk(ctx, chunk)
    - Visual feedback: █ for audio, ░ for silence
 ```
@@ -201,7 +201,7 @@ func initDuplexSession(conv *Conversation, cfg *config, streamProvider providers
 1. Loop forever:
    - Call conv.Response() to get response channel
    - For each chunk from channel:
-     - If MediaDelta: queue audio for playback
+     - If MediaData: queue audio for playback
      - If Delta (text): print to console
      - If FinishReason: complete, get next response
 ```
@@ -230,7 +230,7 @@ Microphone Input (16kHz PCM16)
         ↓
   [Audio Capture]
         ↓
-  StreamChunk { MediaDelta: audio bytes }
+  StreamChunk { MediaData: audio bytes }
         ↓
   conv.SendChunk(ctx, chunk)
         ↓
@@ -238,7 +238,7 @@ Microphone Input (16kHz PCM16)
         ↓
   Response Channel ← Gemini Live API
         ↓
-  StreamChunk { MediaDelta: audio bytes, Delta: text }
+  StreamChunk { MediaData: audio bytes, Delta: text }
         ↓
   [Response Processor]
         ↓

--- a/sdk/examples/duplex-streaming/README.md
+++ b/sdk/examples/duplex-streaming/README.md
@@ -77,11 +77,10 @@ The example supports three modes:
 conv, err := sdk.OpenDuplex("./duplex.pack.json", "assistant")
 
 // Send audio chunk
-audioData := string(pcmBytes) // PCM16 audio data
 chunk := &providers.StreamChunk{
-    MediaDelta: &types.MediaContent{
-        MIMEType: types.MIMETypeAudioWAV,
-        Data:     &audioData,
+    MediaData: &providers.StreamMediaData{
+        Data:     pcmBytes, // Raw PCM16 bytes
+        MIMEType: "audio/pcm",
     },
 }
 conv.SendChunk(ctx, chunk)

--- a/sdk/examples/openai-realtime/README.md
+++ b/sdk/examples/openai-realtime/README.md
@@ -143,9 +143,9 @@ func main() {
 
     // Send audio chunk
     chunk := &providers.StreamChunk{
-        MediaDelta: &types.MediaContent{
+        MediaData: &providers.StreamMediaData{
+            Data:     pcmBytes, // Raw PCM16 bytes (24kHz mono)
             MIMEType: "audio/pcm",
-            Data:     &audioData, // PCM16 bytes as string
         },
     }
     conv.SendChunk(ctx, chunk)
@@ -156,8 +156,8 @@ func main() {
     // Receive streaming response
     respCh, _ := conv.Response()
     for chunk := range respCh {
-        if chunk.MediaDelta != nil {
-            // Play audio
+        if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
+            // Play audio (raw PCM bytes in chunk.MediaData.Data)
         }
         if chunk.Delta != "" {
             // Print text


### PR DESCRIPTION
## Summary

Update 3 markdown docs that still referenced the removed `MediaDelta` API:

- `sdk/examples/openai-realtime/README.md`
- `sdk/examples/duplex-streaming/README.md`
- `sdk/examples/duplex-streaming/ARCHITECTURE.md`

All code examples now show `StreamMediaData` with raw `[]byte` instead of `MediaContent` with base64 `*string`.

Zero `MediaDelta` references remain in the codebase (code or docs).