### PR TITLE
chore: retract v1.4.0 (published prematurely)

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -2,6 +2,8 @@ module github.com/AltairaLabs/PromptKit/pkg
 
 go 1.25.1
 
+retract v1.4.0 // Published prematurely; use v1.4.1+
+
 replace github.com/AltairaLabs/PromptKit/runtime => ../runtime
 
 require (

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -2,6 +2,8 @@ module github.com/AltairaLabs/PromptKit/runtime
 
 go 1.25.1
 
+retract v1.4.0 // Published prematurely; missing StreamMediaData changes and breaking MediaDelta removal
+
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1

--- a/tools/arena/go.mod
+++ b/tools/arena/go.mod
@@ -2,6 +2,8 @@ module github.com/AltairaLabs/PromptKit/tools/arena
 
 go 1.25.1
 
+retract v1.4.0 // Published prematurely; use v1.4.1+
+
 replace github.com/AltairaLabs/PromptKit/runtime => ../../runtime
 
 replace github.com/AltairaLabs/PromptKit/pkg => ../../pkg

--- a/tools/packc/go.mod
+++ b/tools/packc/go.mod
@@ -2,6 +2,8 @@ module github.com/AltairaLabs/PromptKit/tools/packc
 
 go 1.25.1
 
+retract v1.4.0 // Published prematurely; use v1.4.1+
+
 replace github.com/AltairaLabs/PromptKit/pkg => ../../pkg
 
 replace github.com/AltairaLabs/PromptKit/runtime => ../../runtime


### PR DESCRIPTION
## Summary

Add `retract v1.4.0` directives to all modules that were published to the Go proxy:

- `runtime/go.mod`
- `pkg/go.mod`
- `tools/arena/go.mod`
- `tools/packc/go.mod`

v1.4.0 was published before the StreamMediaData migration and breaking `MediaDelta` removal. Consumers should use v1.4.1+.

The retract directive causes `go get` to warn users and prefer other versions when resolving dependencies.

**This should be merged before triggering the v1.4.1 release.**