### PR TITLE
feat: bounded pre-first-chunk streaming retry (Phase 1)

### DIFF
--- a/examples/capability-matrix/providers/openai-gpt5-pro.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt5-pro.provider.yaml
@@ -22,3 +22,13 @@ spec:
   pricing:
     input_cost_per_1k: 0.01
     output_cost_per_1k: 0.03
+  # Opt in to Phase 1 pre-first-chunk streaming retry. gpt-5-pro has
+  # been hitting transient "http2: response body closed" failures in
+  # the scheduled capability-matrix run; this retries the initial
+  # attempt if the stream fails before any content chunk is forwarded.
+  # See docs/local-backlog/STREAMING_RETRY_AT_SCALE.md.
+  stream_retry:
+    enabled: true
+    max_attempts: 2
+    initial_delay: 250ms
+    max_delay: 2s

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1119,6 +1119,36 @@ type Provider struct {
 	// affected. Empty falls back to providers.DefaultStreamIdleTimeout
 	// (30s). Go duration string, e.g. "60s", "2m".
 	StreamIdleTimeout string `json:"stream_idle_timeout,omitempty" yaml:"stream_idle_timeout,omitempty"`
+	// StreamRetry configures bounded retry for streaming requests that fail
+	// before any content chunk has been forwarded downstream (the
+	// "pre-first-chunk window"). Targets transient HTTP/2 stream resets and
+	// initial-connection errors without risking duplicate content emission.
+	// Disabled by default. See docs/local-backlog/STREAMING_RETRY_AT_SCALE.md.
+	StreamRetry *StreamRetryConfig `json:"stream_retry,omitempty" yaml:"stream_retry,omitempty"`
+}
+
+// StreamRetryConfig configures pre-first-chunk streaming retry behavior for
+// a provider. See docs/local-backlog/STREAMING_RETRY_AT_SCALE.md for design.
+type StreamRetryConfig struct {
+	// Enabled turns the retry loop on. Defaults to false — streaming retry
+	// changes latency/billing semantics and must be opt-in per provider.
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// MaxAttempts is the total number of attempts including the initial
+	// request. A value of 2 means "initial request plus at most one retry".
+	// Values <1 are treated as 1 (no retry). Empty falls back to 2.
+	MaxAttempts int `json:"max_attempts,omitempty" yaml:"max_attempts,omitempty"`
+	// InitialDelay is the base delay before the first retry. Subsequent
+	// retries use exponential backoff with full jitter up to MaxDelay. Go
+	// duration string. Empty falls back to "250ms".
+	InitialDelay string `json:"initial_delay,omitempty" yaml:"initial_delay,omitempty"`
+	// MaxDelay caps the per-attempt backoff delay. Go duration string.
+	// Empty falls back to "2s".
+	MaxDelay string `json:"max_delay,omitempty" yaml:"max_delay,omitempty"`
+	// RetryWindow controls which point in the stream lifecycle is still
+	// eligible for retry. "pre_first_chunk" (the only currently supported
+	// value) retries only if no content chunk has been forwarded yet.
+	// Future values may be gated on deduplication support.
+	RetryWindow string `json:"retry_window,omitempty" yaml:"retry_window,omitempty"`
 }
 
 // CredentialConfig is an alias for credentials.CredentialConfig.

--- a/runtime/metrics/collector.go
+++ b/runtime/metrics/collector.go
@@ -31,6 +31,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
 // Status constants for metric labels.
@@ -163,6 +164,12 @@ func NewCollector(opts CollectorOpts) *Collector {
 
 	if !opts.DisablePipelineMetrics {
 		c.registerPipelineMetrics()
+		// Register the process-wide streaming metrics into the same
+		// registry. Safe to call multiple times; only the first call
+		// for a given registerer takes effect. These metrics are
+		// updated directly at the source (not via events) so they
+		// remain accurate when the event bus drops under load.
+		providers.RegisterDefaultStreamMetrics(registerer, ns, opts.ConstLabels)
 	}
 
 	return c

--- a/runtime/providers/base_provider.go
+++ b/runtime/providers/base_provider.go
@@ -95,6 +95,7 @@ type BaseProvider struct {
 	client                *http.Client // request/response calls
 	streamingClient       *http.Client // SSE streams; Timeout: 0
 	streamIdleTimeout     time.Duration
+	streamRetryPolicy     StreamRetryPolicy
 	rateLimiter           *rate.Limiter
 	retryPolicy           pipeline.RetryPolicy
 	maxRequestPayloadSize int64
@@ -264,6 +265,18 @@ func (b *BaseProvider) SetStreamIdleTimeout(d time.Duration) {
 		return
 	}
 	b.streamIdleTimeout = d
+}
+
+// StreamRetryPolicy returns the configured streaming-retry policy. The zero
+// value (retry disabled) is the default — callers must opt in via config.
+func (b *BaseProvider) StreamRetryPolicy() StreamRetryPolicy {
+	return b.streamRetryPolicy
+}
+
+// SetStreamRetryPolicy configures bounded retry behavior for the
+// pre-first-chunk streaming window. See StreamRetryPolicy for details.
+func (b *BaseProvider) SetStreamRetryPolicy(policy StreamRetryPolicy) {
+	b.streamRetryPolicy = policy
 }
 
 // HTTPTimeout returns the current HTTP client timeout, or 0 if no client is set.

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -552,31 +552,59 @@ func (p *Provider) predictStreamWithResponses(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Make HTTP request
+	// Build request factory for OpenStreamWithRetry. Each retry rebuilds
+	// the HTTP request so that headers (especially auth) are reapplied
+	// cleanly and a fresh body reader is used.
 	url := p.baseURL + responsesAPIPath
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	requestFn := func(ctx context.Context) (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		httpReq.Header.Set("Accept", "text/event-stream")
+		if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+			return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+		}
+		return httpReq, nil
 	}
 
-	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-	httpReq.Header.Set("Accept", "text/event-stream")
-	if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
-		return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
-	}
+	metrics := providers.DefaultStreamMetrics()
+	metrics.StreamsInFlightInc(p.ID())
+	metrics.ProviderCallsInFlightInc(p.ID())
+	// Release the in-flight counters if we fail before spawning the
+	// stream goroutine. On success the goroutine owns the decrement via
+	// its deferred release below.
+	released := false
+	defer func() {
+		if !released {
+			metrics.StreamsInFlightDec(p.ID())
+			metrics.ProviderCallsInFlightDec(p.ID())
+		}
+	}()
 
-	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
+	result, err := providers.OpenStreamWithRetry(
+		ctx,
+		p.StreamRetryPolicy(),
+		p.ID(),
+		p.StreamIdleTimeout(),
+		requestFn,
+		p.GetStreamingHTTPClient(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 
-	if err := providers.CheckHTTPError(resp, url); err != nil {
-		_ = resp.Body.Close()
-		return nil, err
-	}
-
 	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-	go p.streamResponsesResponse(ctx, resp.Body, outChan)
+	released = true
+	providerID := p.ID()
+	go func() {
+		defer func() {
+			metrics.StreamsInFlightDec(providerID)
+			metrics.ProviderCallsInFlightDec(providerID)
+		}()
+		p.streamResponsesResponse(ctx, result.Body, outChan)
+	}()
 
 	return outChan, nil
 }

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -105,6 +105,12 @@ type ProviderSpec struct {
 	// back to DefaultStreamIdleTimeout. Pre-parsed from
 	// config.Provider.StreamIdleTimeout by the arena loader.
 	StreamIdleTimeout time.Duration
+
+	// StreamRetry configures bounded retry for streaming requests that
+	// fail in the pre-first-chunk window. Zero value (disabled) leaves
+	// the provider with no streaming retry. Pre-parsed from
+	// config.Provider.StreamRetry by the arena loader.
+	StreamRetry StreamRetryPolicy
 }
 
 // Credential applies authentication to HTTP requests.
@@ -128,6 +134,13 @@ type PlatformConfig = credentials.PlatformConfig
 type timeoutConfigurable interface {
 	SetHTTPTimeout(time.Duration)
 	SetStreamIdleTimeout(time.Duration)
+}
+
+// streamRetryConfigurable is implemented by any provider that embeds
+// *BaseProvider. CreateProviderFromSpec uses this to apply the streaming
+// retry policy from the spec after the factory runs.
+type streamRetryConfigurable interface {
+	SetStreamRetryPolicy(StreamRetryPolicy)
 }
 
 // CreateProviderFromSpec creates a provider implementation from a spec.
@@ -177,6 +190,13 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 		if spec.StreamIdleTimeout > 0 {
 			tc.SetStreamIdleTimeout(spec.StreamIdleTimeout)
 		}
+	}
+
+	// Apply the streaming retry policy. The zero value is "disabled", so
+	// providers that opt in via config get the new behavior while all
+	// others are unchanged.
+	if src, ok := provider.(streamRetryConfigurable); ok && spec.StreamRetry.Enabled {
+		src.SetStreamRetryPolicy(spec.StreamRetry)
 	}
 
 	return provider, nil

--- a/runtime/providers/stream_metrics.go
+++ b/runtime/providers/stream_metrics.go
@@ -1,0 +1,186 @@
+package providers
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// streamFirstChunkBuckets is tuned for reasoning-model streaming workloads.
+// gpt-5-pro and similar often take tens of seconds to emit the first
+// content chunk. The default Prometheus web-traffic buckets (up to 10s)
+// would truncate everything into one overflow bucket and lose signal for
+// exactly the workload this histogram exists to observe.
+var streamFirstChunkBuckets = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300}
+
+// StreamMetrics holds the direct-update Prometheus metrics for streaming
+// provider calls. These are updated inline at the source (not via the
+// event bus) so that burst-load drops on the event bus cannot corrupt
+// autoscaling signals. See docs/local-backlog/STREAMING_RETRY_AT_SCALE.md
+// for the design rationale.
+//
+// All methods are nil-safe: if StreamMetrics is nil, the call is a no-op.
+// This lets provider code unconditionally call s.StreamsInFlightInc(...)
+// without guarding on whether metrics are configured.
+type StreamMetrics struct {
+	streamsInFlight         *prometheus.GaugeVec
+	providerCallsInFlight   *prometheus.GaugeVec
+	streamFirstChunkLatency *prometheus.HistogramVec
+	streamRetriesTotal      *prometheus.CounterVec
+}
+
+// NewStreamMetrics creates and registers the Phase 1 streaming metrics
+// into the given registerer under the given namespace. Const labels are
+// applied to every metric.
+//
+// Returns a non-nil *StreamMetrics. Re-registration of the same metric
+// name into the same registry will panic (Prometheus semantic), so the
+// default registration path uses sync.Once via RegisterDefaultStreamMetrics.
+func NewStreamMetrics(
+	registerer prometheus.Registerer,
+	namespace string,
+	constLabels prometheus.Labels,
+) *StreamMetrics {
+	if namespace == "" {
+		namespace = "promptkit"
+	}
+	m := &StreamMetrics{
+		streamsInFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Name:        "streams_in_flight",
+			Help:        "Number of streaming provider calls currently in flight (per provider).",
+			ConstLabels: constLabels,
+		}, []string{"provider"}),
+		providerCallsInFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Name:        "provider_calls_in_flight",
+			Help:        "Number of provider calls (streaming or not) currently in flight, per provider.",
+			ConstLabels: constLabels,
+		}, []string{"provider"}),
+		streamFirstChunkLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "stream_first_chunk_latency_seconds",
+			Help: "Time from request dispatch to first SSE data event observed, " +
+				"per provider. Includes any pre-first-chunk retries.",
+			Buckets:     streamFirstChunkBuckets,
+			ConstLabels: constLabels,
+		}, []string{"provider"}),
+		streamRetriesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   namespace,
+			Name:        "stream_retries_total",
+			Help:        "Total streaming retry attempts, labeled by outcome (success, failed, budget_exhausted).",
+			ConstLabels: constLabels,
+		}, []string{"provider", "outcome"}),
+	}
+	registerer.MustRegister(
+		m.streamsInFlight,
+		m.providerCallsInFlight,
+		m.streamFirstChunkLatency,
+		m.streamRetriesTotal,
+	)
+	return m
+}
+
+// StreamsInFlightInc increments the in-flight stream gauge for a provider.
+// Nil-safe.
+func (m *StreamMetrics) StreamsInFlightInc(provider string) {
+	if m == nil {
+		return
+	}
+	m.streamsInFlight.WithLabelValues(provider).Inc()
+}
+
+// StreamsInFlightDec decrements the in-flight stream gauge for a provider.
+// Nil-safe.
+func (m *StreamMetrics) StreamsInFlightDec(provider string) {
+	if m == nil {
+		return
+	}
+	m.streamsInFlight.WithLabelValues(provider).Dec()
+}
+
+// ProviderCallsInFlightInc increments the total in-flight provider call
+// gauge. Nil-safe.
+func (m *StreamMetrics) ProviderCallsInFlightInc(provider string) {
+	if m == nil {
+		return
+	}
+	m.providerCallsInFlight.WithLabelValues(provider).Inc()
+}
+
+// ProviderCallsInFlightDec decrements the total in-flight provider call
+// gauge. Nil-safe.
+func (m *StreamMetrics) ProviderCallsInFlightDec(provider string) {
+	if m == nil {
+		return
+	}
+	m.providerCallsInFlight.WithLabelValues(provider).Dec()
+}
+
+// ObserveFirstChunkLatency records the time from request dispatch to the
+// first SSE data event being observed for a provider. Nil-safe.
+func (m *StreamMetrics) ObserveFirstChunkLatency(provider string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.streamFirstChunkLatency.WithLabelValues(provider).Observe(d.Seconds())
+}
+
+// RetryAttempt records one streaming retry attempt with an outcome label.
+// Outcome values: "success" (attempt that produced a usable stream),
+// "failed" (retryable transient failure that will be retried), or
+// "exhausted" (last attempt failed, no more retries). Nil-safe.
+func (m *StreamMetrics) RetryAttempt(provider, outcome string) {
+	if m == nil {
+		return
+	}
+	m.streamRetriesTotal.WithLabelValues(provider, outcome).Inc()
+}
+
+// Package-level default instance. Hosts register it by calling
+// RegisterDefaultStreamMetrics during startup; all provider code reads
+// via DefaultStreamMetrics() unconditionally.
+var (
+	defaultStreamMetrics   *StreamMetrics
+	defaultStreamMetricsMu sync.RWMutex
+)
+
+// RegisterDefaultStreamMetrics creates and installs a process-wide
+// StreamMetrics instance. Safe to call multiple times with the SAME
+// registerer — subsequent calls are no-ops. Calling with a DIFFERENT
+// registerer is not supported and is treated as a misconfiguration
+// (second call is ignored and the first wins).
+//
+// Hosts (Arena, SDK, server) call this once during startup. Code that
+// only cares about metrics being present calls DefaultStreamMetrics()
+// and gets a nil on a misconfigured host, which is safe (methods no-op).
+func RegisterDefaultStreamMetrics(
+	registerer prometheus.Registerer,
+	namespace string,
+	constLabels prometheus.Labels,
+) *StreamMetrics {
+	defaultStreamMetricsMu.Lock()
+	defer defaultStreamMetricsMu.Unlock()
+	if defaultStreamMetrics != nil {
+		return defaultStreamMetrics
+	}
+	defaultStreamMetrics = NewStreamMetrics(registerer, namespace, constLabels)
+	return defaultStreamMetrics
+}
+
+// DefaultStreamMetrics returns the process-wide StreamMetrics instance or
+// nil if none has been registered. All StreamMetrics methods are nil-safe.
+func DefaultStreamMetrics() *StreamMetrics {
+	defaultStreamMetricsMu.RLock()
+	defer defaultStreamMetricsMu.RUnlock()
+	return defaultStreamMetrics
+}
+
+// ResetDefaultStreamMetrics clears the process-wide instance. Intended for
+// tests only — production code should not need to reset metrics.
+func ResetDefaultStreamMetrics() {
+	defaultStreamMetricsMu.Lock()
+	defer defaultStreamMetricsMu.Unlock()
+	defaultStreamMetrics = nil
+}

--- a/runtime/providers/stream_metrics_test.go
+++ b/runtime/providers/stream_metrics_test.go
@@ -1,0 +1,186 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// --- Nil-safety ---
+
+// All StreamMetrics methods must be no-ops on a nil receiver so provider
+// code can call them unconditionally without wrapping every call site in
+// a nil check.
+func TestStreamMetrics_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *StreamMetrics
+	// These should not panic on nil.
+	m.StreamsInFlightInc("p")
+	m.StreamsInFlightDec("p")
+	m.ProviderCallsInFlightInc("p")
+	m.ProviderCallsInFlightDec("p")
+	m.ObserveFirstChunkLatency("p", time.Second)
+	m.RetryAttempt("p", "success")
+}
+
+// --- Gauge and histogram increments ---
+
+func TestStreamMetrics_StreamsInFlight(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	m := NewStreamMetrics(reg, "test", nil)
+
+	m.StreamsInFlightInc("openai")
+	m.StreamsInFlightInc("openai")
+	m.StreamsInFlightInc("gemini")
+	m.StreamsInFlightDec("openai")
+
+	if got := testutil.ToFloat64(m.streamsInFlight.WithLabelValues("openai")); got != 1 {
+		t.Errorf("openai streams_in_flight = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.streamsInFlight.WithLabelValues("gemini")); got != 1 {
+		t.Errorf("gemini streams_in_flight = %v, want 1", got)
+	}
+}
+
+func TestStreamMetrics_ProviderCallsInFlight(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	m := NewStreamMetrics(reg, "test", nil)
+
+	m.ProviderCallsInFlightInc("openai")
+	m.ProviderCallsInFlightInc("openai")
+	m.ProviderCallsInFlightDec("openai")
+
+	if got := testutil.ToFloat64(m.providerCallsInFlight.WithLabelValues("openai")); got != 1 {
+		t.Errorf("provider_calls_in_flight = %v, want 1", got)
+	}
+}
+
+func TestStreamMetrics_ObserveFirstChunkLatency(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	m := NewStreamMetrics(reg, "test", nil)
+
+	m.ObserveFirstChunkLatency("openai", 500*time.Millisecond)
+	m.ObserveFirstChunkLatency("openai", 2*time.Second)
+
+	// Verify the histogram recorded two samples.
+	count := testutil.CollectAndCount(m.streamFirstChunkLatency)
+	if count != 1 { // 1 series (one label combination)
+		t.Errorf("histogram series count = %d, want 1", count)
+	}
+}
+
+func TestStreamMetrics_RetryAttempt(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	m := NewStreamMetrics(reg, "test", nil)
+
+	m.RetryAttempt("openai", "failed")
+	m.RetryAttempt("openai", "failed")
+	m.RetryAttempt("openai", "success")
+
+	if got := testutil.ToFloat64(m.streamRetriesTotal.WithLabelValues("openai", "failed")); got != 2 {
+		t.Errorf("failed count = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.streamRetriesTotal.WithLabelValues("openai", "success")); got != 1 {
+		t.Errorf("success count = %v, want 1", got)
+	}
+}
+
+// --- Namespace and const labels ---
+
+func TestNewStreamMetrics_DefaultNamespace(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	m := NewStreamMetrics(reg, "", nil)
+	m.StreamsInFlightInc("p")
+
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var found bool
+	for _, mf := range metrics {
+		if strings.HasPrefix(mf.GetName(), "promptkit_streams_in_flight") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected metric name to be prefixed with default namespace 'promptkit'")
+	}
+}
+
+func TestNewStreamMetrics_WithConstLabels(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	constLabels := prometheus.Labels{"env": "test", "region": "us-east-1"}
+	m := NewStreamMetrics(reg, "app", constLabels)
+	m.StreamsInFlightInc("openai")
+
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var sawEnv, sawRegion bool
+	for _, mf := range metrics {
+		if !strings.HasSuffix(mf.GetName(), "_streams_in_flight") {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "env" && lp.GetValue() == "test" {
+					sawEnv = true
+				}
+				if lp.GetName() == "region" && lp.GetValue() == "us-east-1" {
+					sawRegion = true
+				}
+			}
+		}
+	}
+	if !sawEnv || !sawRegion {
+		t.Errorf("const labels not applied: sawEnv=%v sawRegion=%v", sawEnv, sawRegion)
+	}
+}
+
+// --- Default instance registration ---
+
+func TestRegisterDefaultStreamMetrics_InstallsOnce(t *testing.T) {
+	ResetDefaultStreamMetrics()
+	t.Cleanup(ResetDefaultStreamMetrics)
+
+	reg := prometheus.NewRegistry()
+	first := RegisterDefaultStreamMetrics(reg, "test", nil)
+	if first == nil {
+		t.Fatal("first registration returned nil")
+	}
+	if DefaultStreamMetrics() != first {
+		t.Error("DefaultStreamMetrics() did not return the first-registered instance")
+	}
+
+	// Second call with a *different* registerer must not re-register or
+	// replace the default — the first call wins. (If it tried to
+	// register, prometheus would panic on the duplicate metric name
+	// inside the same registry; a different registry would silently
+	// install a second set of metrics, which is worse.)
+	reg2 := prometheus.NewRegistry()
+	second := RegisterDefaultStreamMetrics(reg2, "test", nil)
+	if second != first {
+		t.Error("second registration returned a different instance — should have been a no-op")
+	}
+}
+
+func TestDefaultStreamMetrics_NilWhenUnregistered(t *testing.T) {
+	ResetDefaultStreamMetrics()
+	t.Cleanup(ResetDefaultStreamMetrics)
+
+	if got := DefaultStreamMetrics(); got != nil {
+		t.Errorf("expected nil when no default registered, got %v", got)
+	}
+	// Methods on the nil instance must still be safe.
+	DefaultStreamMetrics().StreamsInFlightInc("p")
+}

--- a/runtime/providers/stream_retry.go
+++ b/runtime/providers/stream_retry.go
@@ -1,0 +1,174 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Default values for StreamRetryPolicy. Kept small on purpose: streaming retry
+// targets transient h2 stream resets, not generic 5xx storms, and the wrong
+// default is "retry aggressively". See docs/local-backlog/STREAMING_RETRY_AT_SCALE.md.
+const (
+	DefaultStreamRetryMaxAttempts  = 2
+	DefaultStreamRetryInitialDelay = 250 * time.Millisecond
+	DefaultStreamRetryMaxDelay     = 2 * time.Second
+)
+
+// StreamRetryWindow enumerates the points at which a streaming request may
+// still be retried. Only pre-first-chunk retry is supported today; the type
+// is an enum so that future modes (e.g. dedup-aware mid-stream resume) can
+// be added without silently changing behavior.
+type StreamRetryWindow string
+
+const (
+	// StreamRetryWindowPreFirstChunk retries only while no content chunk
+	// has been forwarded downstream. This is the only safe mode without a
+	// deduplication mechanism.
+	StreamRetryWindowPreFirstChunk StreamRetryWindow = "pre_first_chunk"
+)
+
+// StreamRetryPolicy governs bounded retry behavior for streaming requests
+// that fail before any content chunk has been forwarded downstream.
+//
+// The policy is intentionally separate from pipeline.RetryPolicy (which
+// covers non-streaming requests) because the failure classes and safety
+// constraints are different: streaming retries must respect the idempotency
+// window, use full jitter instead of half jitter to break h2 herd resets,
+// and default to far fewer attempts.
+type StreamRetryPolicy struct {
+	// Enabled turns the retry loop on. Zero value is off.
+	Enabled bool
+	// MaxAttempts is total attempts including the initial request. Values
+	// <1 are normalized to 1 (no retry). Zero falls back to the default.
+	MaxAttempts int
+	// InitialDelay is the base backoff before the first retry. Zero falls
+	// back to the default.
+	InitialDelay time.Duration
+	// MaxDelay caps per-attempt backoff. Zero falls back to the default.
+	MaxDelay time.Duration
+	// Window controls which point in the stream lifecycle is eligible for
+	// retry. Empty falls back to StreamRetryWindowPreFirstChunk.
+	Window StreamRetryWindow
+}
+
+// DisabledStreamRetryPolicy returns a zero-value policy (retry off). Used
+// as the BaseProvider default so callers never see nil.
+func DisabledStreamRetryPolicy() StreamRetryPolicy {
+	return StreamRetryPolicy{}
+}
+
+// Attempts returns the normalized number of attempts (>=1). Returns 1 when
+// retry is disabled so callers can use it unconditionally in a for loop.
+func (p StreamRetryPolicy) Attempts() int {
+	if !p.Enabled {
+		return 1
+	}
+	if p.MaxAttempts < 1 {
+		return DefaultStreamRetryMaxAttempts
+	}
+	return p.MaxAttempts
+}
+
+// InitialDelayOrDefault returns the configured initial delay or the default.
+func (p StreamRetryPolicy) InitialDelayOrDefault() time.Duration {
+	if p.InitialDelay > 0 {
+		return p.InitialDelay
+	}
+	return DefaultStreamRetryInitialDelay
+}
+
+// MaxDelayOrDefault returns the configured max delay or the default.
+func (p StreamRetryPolicy) MaxDelayOrDefault() time.Duration {
+	if p.MaxDelay > 0 {
+		return p.MaxDelay
+	}
+	return DefaultStreamRetryMaxDelay
+}
+
+// BackoffFor computes the delay for the given attempt index (0-based) using
+// full jitter: uniform random in [0, min(maxDelay, initialDelay * 2^attempt)].
+// Full jitter (as opposed to equal or decorrelated jitter) is deliberate —
+// when a single h2 connection reset kills ~100 streams, equal jitter still
+// synchronizes the retries into narrow buckets; full jitter smears them.
+func (p StreamRetryPolicy) BackoffFor(attempt int) time.Duration {
+	initial := p.InitialDelayOrDefault()
+	ceiling := p.MaxDelayOrDefault()
+	if attempt < 0 {
+		attempt = 0
+	}
+	// cap growth to avoid shift overflow on pathological inputs
+	const maxShift = 30
+	shift := attempt
+	if shift > maxShift {
+		shift = maxShift
+	}
+	delay := initial << shift
+	if delay <= 0 || delay > ceiling {
+		delay = ceiling
+	}
+	// full jitter: uniform in [0, delay]
+	return time.Duration(cryptoRandFloat64() * float64(delay))
+}
+
+// IsRetryableStreamError returns true if the error looks like a transient
+// streaming failure that is safe to retry from the pre-first-chunk window.
+//
+// This deliberately covers a narrower set than isRetryableError in retry.go:
+// we want h2 stream resets, TCP resets, TLS close_notify races, and idle
+// connection reuse failures — but never context cancellation, deadline, or
+// application-layer parse errors.
+func IsRetryableStreamError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Never retry caller cancellation or deadline.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if isRetryableError(err) {
+		return true
+	}
+	// Go's http2 package uses string-matched errors in several places that
+	// do not implement net.Error. These are the canonical transient cases
+	// we want to catch for the gpt-5-pro failure class.
+	msg := err.Error()
+	for _, sub := range streamRetryErrorSubstrings {
+		if strings.Contains(msg, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// streamRetryErrorSubstrings lists substrings of errors that indicate a
+// transient streaming failure worth retrying. Kept narrow on purpose: we
+// want the h2 stream reset case and common TCP/TLS races, not every
+// possible transport error.
+var streamRetryErrorSubstrings = []string{
+	"http2: response body closed", // client-side h2 stream teardown race
+	"http2: server sent GOAWAY",   // server graceful shutdown mid-stream
+	"stream error: stream ID",     // h2 RST_STREAM from server
+	"unexpected EOF",              // TCP reset surfaced during read
+	"connection reset by peer",
+	"broken pipe",
+	"use of closed network connection",
+}
+
+// IsRetryableStreamStatus returns true for HTTP status codes that are worth
+// retrying on a streaming request. Mirrors isRetryableStatusCode but is
+// named distinctly so future divergence (e.g. treating 409 as retryable
+// for Responses API) does not mutate non-streaming semantics.
+func IsRetryableStreamStatus(code int) bool {
+	switch code {
+	case http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}

--- a/runtime/providers/stream_retry_driver.go
+++ b/runtime/providers/stream_retry_driver.go
@@ -1,0 +1,266 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+)
+
+// StreamRetryResult holds the successfully opened streaming response after
+// the pre-first-chunk retry loop. The caller takes ownership of Body (which
+// is a composite reader re-prepending the peeked first SSE event), and
+// must close it.
+type StreamRetryResult struct {
+	// Response is the HTTP response of the successful attempt. Body has
+	// already been wrapped; callers must not read directly from
+	// Response.Body. Use Body instead.
+	Response *http.Response
+	// Body is a composite reader that first replays the SSE event bytes
+	// consumed by the peek, then streams the remainder of the response.
+	// Closing this closes the underlying Response.Body.
+	Body io.ReadCloser
+	// Attempts is the total number of attempts made (1 on first-try success).
+	Attempts int
+}
+
+// OpenStreamWithRetry executes requestFn and peeks the first SSE data event
+// on the response body. If Do() returns a retryable error, or the response
+// status is retryable, or the body fails to produce a first SSE event
+// within the idle window, the attempt is discarded and retried up to the
+// policy's MaxAttempts. On success, the buffered bytes are replayed into
+// the returned Body so downstream SSE parsers see a contiguous stream.
+//
+// This function only retries in the pre-first-chunk window — that is, only
+// while no content bytes have been surfaced to the caller. It never reads
+// past the end of the first SSE event payload.
+//
+// When policy.Enabled is false this is equivalent to a single Do() + peek:
+// on success the body is still wrapped to replay the peeked bytes, but no
+// retry is performed.
+//
+//nolint:gocognit // Retry loop with classification, backoff, and metric emission
+func OpenStreamWithRetry(
+	ctx context.Context,
+	policy StreamRetryPolicy,
+	providerName string,
+	idleTimeout time.Duration,
+	requestFn func(ctx context.Context) (*http.Request, error),
+	client *http.Client,
+) (*StreamRetryResult, error) {
+	maxAttempts := policy.Attempts()
+	metrics := DefaultStreamMetrics()
+	start := time.Now()
+	var lastErr error
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		req, err := requestFn(ctx)
+		if err != nil {
+			// Request construction errors are never retried — they
+			// indicate a caller bug, not a transient failure.
+			return nil, err
+		}
+
+		resp, doErr := client.Do(req)
+		result, retry, classifyErr := classifyStreamAttempt(resp, doErr, idleTimeout)
+		if result != nil {
+			result.Attempts = attempt + 1
+			metrics.ObserveFirstChunkLatency(providerName, time.Since(start))
+			if attempt > 0 {
+				metrics.RetryAttempt(providerName, "success")
+			}
+			return result, nil
+		}
+
+		lastErr = classifyErr
+		if !retry || attempt >= maxAttempts-1 {
+			if attempt >= maxAttempts-1 && retry {
+				metrics.RetryAttempt(providerName, "exhausted")
+			}
+			break
+		}
+
+		metrics.RetryAttempt(providerName, "failed")
+		delay := policy.BackoffFor(attempt)
+		logger.Warn("retrying streaming request (pre-first-chunk)",
+			"provider", providerName,
+			"attempt", attempt+1,
+			"max_attempts", maxAttempts,
+			"delay", delay.String(),
+			"error", classifyErr,
+		)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+
+	return nil, lastErr
+}
+
+// classifyStreamAttempt inspects a (*http.Response, error) pair and decides
+// whether the attempt was a success (return non-nil result), a retryable
+// failure (return retry=true), or a terminal failure.
+//
+// On success, the response body is wrapped so the peeked first SSE event
+// is replayed to downstream consumers. On any non-terminal failure the
+// body is closed before returning so connections are not leaked.
+func classifyStreamAttempt(
+	resp *http.Response,
+	doErr error,
+	idleTimeout time.Duration,
+) (result *StreamRetryResult, retry bool, err error) {
+	if doErr != nil {
+		return nil, IsRetryableStreamError(doErr), doErr
+	}
+
+	// Non-200 responses: close the body and decide based on status.
+	if resp.StatusCode != http.StatusOK {
+		defer func() { _ = resp.Body.Close() }()
+		body := ReadErrorBody(resp.Body)
+		httpErr := fmt.Errorf(
+			"API request failed with status %d: %s",
+			resp.StatusCode, string(body),
+		)
+		return nil, IsRetryableStreamStatus(resp.StatusCode), httpErr
+	}
+
+	// Peek the first SSE data event. If this fails we treat it as a
+	// retryable mid-stream error because by definition no content has
+	// been surfaced to the caller.
+	buffered, peekErr := peekFirstSSEEvent(resp.Body, idleTimeout)
+	if peekErr != nil {
+		_ = resp.Body.Close()
+		return nil, IsRetryableStreamError(peekErr), peekErr
+	}
+
+	wrapped := &replayReadCloser{
+		replay: bytes.NewReader(buffered),
+		rest:   resp.Body,
+	}
+	return &StreamRetryResult{Response: resp, Body: wrapped}, false, nil
+}
+
+// peekFirstSSEEvent reads from r until it has seen at least one complete
+// SSE data event terminated by a blank line, then returns the bytes read.
+// The returned slice contains exactly what was consumed from r, suitable
+// for replay via a composite reader.
+//
+// The read is bounded by idleTimeout using an IdleTimeoutReader, so a
+// stalled connection does not block this function indefinitely. A zero
+// idleTimeout disables the idle guard (inherit caller deadline only).
+//
+// This function does not interpret the SSE payload — it only looks for
+// the structural framing ("data: ..." line followed by a blank line) that
+// all SSE producers emit. This is deliberately more forgiving than
+// bufio.Scanner to handle provider-specific keepalives and comments.
+func peekFirstSSEEvent(body io.Reader, idleTimeout time.Duration) ([]byte, error) {
+	reader := body
+	if idleTimeout > 0 {
+		reader = NewIdleTimeoutReader(io.NopCloser(body), idleTimeout)
+	}
+	br := bufio.NewReader(reader)
+	var buf bytes.Buffer
+	sawData := false
+	for {
+		line, err := br.ReadString('\n')
+		if line != "" {
+			buf.WriteString(line)
+			if done, drainErr := processSSELine(br, &buf, line, &sawData); done {
+				return buf.Bytes(), drainErr
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) && buf.Len() > 0 && sawData {
+				// Stream closed cleanly right after the first event
+				// with no trailing blank line. Treat as a complete
+				// peek so downstream can decide what to do.
+				return buf.Bytes(), nil
+			}
+			return nil, err
+		}
+	}
+}
+
+// processSSELine classifies a single SSE framing line and, when the end of
+// the first event is reached, drains any lookahead the bufio.Reader has
+// pre-buffered so downstream reads resume contiguously. Returns done=true
+// exactly when the first event boundary has been observed.
+func processSSELine(br *bufio.Reader, buf *bytes.Buffer, line string, sawData *bool) (done bool, err error) {
+	trimmed := strings.TrimRight(line, "\r\n")
+	if strings.HasPrefix(trimmed, "data: ") || trimmed == "data:" {
+		*sawData = true
+		return false, nil
+	}
+	if trimmed == "" && *sawData {
+		// Blank line after a data: line terminates the event.
+		// bufio.Reader may have already read ahead past our boundary;
+		// drain those bytes into the replay slice so downstream
+		// readers see a contiguous stream.
+		if drainErr := drainBufferedInto(br, buf); drainErr != nil {
+			return true, drainErr
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// drainBufferedInto copies any bytes sitting in the bufio.Reader's internal
+// buffer (but not yet surfaced to callers) into dst. This is needed because
+// bufio.Reader reads ahead from the underlying source, so bytes that arrived
+// after our peek boundary would otherwise be silently lost when we stop
+// using the bufio.Reader and read from the underlying source directly.
+func drainBufferedInto(br *bufio.Reader, dst *bytes.Buffer) error {
+	n := br.Buffered()
+	if n == 0 {
+		return nil
+	}
+	remaining, peekErr := br.Peek(n)
+	if peekErr != nil {
+		return peekErr
+	}
+	dst.Write(remaining)
+	// Discard the bytes from the bufio reader so the underlying source
+	// is logically at the same position as the end of our buffer.
+	if _, discardErr := br.Discard(n); discardErr != nil {
+		return discardErr
+	}
+	return nil
+}
+
+// replayReadCloser concatenates a bytes.Reader holding already-consumed
+// bytes with the remainder of an underlying ReadCloser. It exists instead
+// of io.MultiReader+io.NopCloser so Close() still reaches the underlying
+// response body.
+type replayReadCloser struct {
+	replay *bytes.Reader
+	rest   io.ReadCloser
+}
+
+// Read drains the replay buffer first, then falls through to the
+// underlying ReadCloser. Once the replay is empty it is never re-read.
+func (r *replayReadCloser) Read(p []byte) (int, error) {
+	if r.replay.Len() > 0 {
+		return r.replay.Read(p)
+	}
+	return r.rest.Read(p)
+}
+
+// Close closes the underlying ReadCloser. The replay bytes.Reader has no
+// resources to release.
+func (r *replayReadCloser) Close() error {
+	return r.rest.Close()
+}

--- a/runtime/providers/stream_retry_test.go
+++ b/runtime/providers/stream_retry_test.go
@@ -1,0 +1,569 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestStreamRetryPolicy_AttemptsDisabled(t *testing.T) {
+	t.Parallel()
+	p := StreamRetryPolicy{}
+	if got := p.Attempts(); got != 1 {
+		t.Fatalf("disabled policy should attempt exactly 1 time, got %d", got)
+	}
+}
+
+func TestStreamRetryPolicy_AttemptsDefaults(t *testing.T) {
+	t.Parallel()
+	p := StreamRetryPolicy{Enabled: true}
+	if got := p.Attempts(); got != DefaultStreamRetryMaxAttempts {
+		t.Fatalf("enabled policy with zero MaxAttempts should use default %d, got %d",
+			DefaultStreamRetryMaxAttempts, got)
+	}
+}
+
+func TestStreamRetryPolicy_AttemptsExplicit(t *testing.T) {
+	t.Parallel()
+	p := StreamRetryPolicy{Enabled: true, MaxAttempts: 5}
+	if got := p.Attempts(); got != 5 {
+		t.Fatalf("explicit MaxAttempts=5 should yield 5, got %d", got)
+	}
+}
+
+func TestStreamRetryPolicy_AttemptsClamped(t *testing.T) {
+	t.Parallel()
+	p := StreamRetryPolicy{Enabled: true, MaxAttempts: -3}
+	if got := p.Attempts(); got != DefaultStreamRetryMaxAttempts {
+		t.Fatalf("negative MaxAttempts should fall back to default, got %d", got)
+	}
+}
+
+func TestStreamRetryPolicy_BackoffRespectsCeiling(t *testing.T) {
+	t.Parallel()
+	p := StreamRetryPolicy{
+		Enabled:      true,
+		InitialDelay: 100 * time.Millisecond,
+		MaxDelay:     500 * time.Millisecond,
+	}
+	// Run many samples; none should exceed the ceiling even at high attempt counts.
+	for attempt := 0; attempt < 10; attempt++ {
+		for i := 0; i < 100; i++ {
+			d := p.BackoffFor(attempt)
+			if d < 0 || d > 500*time.Millisecond {
+				t.Fatalf("attempt=%d sample=%d: backoff %v out of [0, 500ms]", attempt, i, d)
+			}
+		}
+	}
+}
+
+func TestStreamRetryPolicy_BackoffFullJitterDistribution(t *testing.T) {
+	t.Parallel()
+	// With full jitter, samples should span the full range [0, delay].
+	// We sanity-check that we see at least one value below 25% and one
+	// above 75% of the ceiling, which would be impossible with equal
+	// jitter (which only covers the top half).
+	p := StreamRetryPolicy{
+		Enabled:      true,
+		InitialDelay: 1 * time.Second,
+		MaxDelay:     1 * time.Second,
+	}
+	var sawLow, sawHigh bool
+	for i := 0; i < 200; i++ {
+		d := p.BackoffFor(0)
+		if d < 250*time.Millisecond {
+			sawLow = true
+		}
+		if d > 750*time.Millisecond {
+			sawHigh = true
+		}
+	}
+	if !sawLow || !sawHigh {
+		t.Fatalf("full jitter should span [0, delay], sawLow=%v sawHigh=%v", sawLow, sawHigh)
+	}
+}
+
+func TestIsRetryableStreamError_Nil(t *testing.T) {
+	t.Parallel()
+	if IsRetryableStreamError(nil) {
+		t.Fatal("nil error should not be retryable")
+	}
+}
+
+func TestIsRetryableStreamError_ContextCancel(t *testing.T) {
+	t.Parallel()
+	if IsRetryableStreamError(context.Canceled) {
+		t.Fatal("context.Canceled must never be retried")
+	}
+	if IsRetryableStreamError(context.DeadlineExceeded) {
+		t.Fatal("context.DeadlineExceeded must never be retried")
+	}
+}
+
+func TestIsRetryableStreamError_HTTP2BodyClosed(t *testing.T) {
+	t.Parallel()
+	// This is the exact error string we saw in the gpt5-pro capability
+	// matrix failure — it's the whole point of Phase 1.
+	err := errors.New("http2: response body closed")
+	if !IsRetryableStreamError(err) {
+		t.Fatal("http2: response body closed must be classified as retryable")
+	}
+}
+
+func TestIsRetryableStreamError_GOAWAY(t *testing.T) {
+	t.Parallel()
+	err := errors.New("http2: server sent GOAWAY and closed the connection")
+	if !IsRetryableStreamError(err) {
+		t.Fatal("h2 GOAWAY should be classified as retryable")
+	}
+}
+
+func TestIsRetryableStreamError_UnknownError(t *testing.T) {
+	t.Parallel()
+	err := errors.New("some application-layer parse failure")
+	if IsRetryableStreamError(err) {
+		t.Fatal("application-layer errors should not be classified as retryable")
+	}
+}
+
+func TestIsRetryableStreamStatus(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		code    int
+		want    bool
+		purpose string
+	}{
+		{429, true, "rate limit"},
+		{502, true, "bad gateway"},
+		{503, true, "service unavailable"},
+		{504, true, "gateway timeout"},
+		{500, false, "internal server error (not retryable — indicates app bug)"},
+		{400, false, "bad request"},
+		{401, false, "unauthorized"},
+		{200, false, "ok"},
+	}
+	for _, tc := range cases {
+		if got := IsRetryableStreamStatus(tc.code); got != tc.want {
+			t.Errorf("IsRetryableStreamStatus(%d) [%s] = %v, want %v",
+				tc.code, tc.purpose, got, tc.want)
+		}
+	}
+}
+
+// --- peekFirstSSEEvent ---
+
+// Contract: peekFirstSSEEvent reads until it sees at least one complete SSE
+// event, then returns *enough bytes* to replay the stream contiguously from
+// the start. In practice the returned slice includes the first event plus
+// any bytes the internal bufio.Reader pre-buffered past the event boundary.
+// The caller guarantees the underlying reader is positioned exactly after
+// the last byte of the returned slice, so (returned || underlying) is the
+// original stream. We test that invariant rather than exact byte counts.
+
+func TestPeekFirstSSEEvent_ContainsFirstEvent(t *testing.T) {
+	t.Parallel()
+	input := "data: hello\n\ndata: world\n\n"
+	got, err := peekFirstSSEEvent(strings.NewReader(input), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(string(got), "data: hello\n\n") {
+		t.Fatalf("peeked %q must begin with the first event", string(got))
+	}
+	if !strings.Contains(input, string(got)) {
+		t.Fatalf("peeked bytes must be a prefix of the input stream")
+	}
+}
+
+func TestPeekFirstSSEEvent_WithComments(t *testing.T) {
+	t.Parallel()
+	// SSE comments (: lines) and keepalives must pass through to the peek
+	// buffer so replay produces byte-identical output for downstream parsers.
+	input := ": keepalive\ndata: first\n\ndata: second\n\n"
+	got, err := peekFirstSSEEvent(strings.NewReader(input), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(string(got), ": keepalive\ndata: first\n\n") {
+		t.Fatalf("peeked %q must include the keepalive and first event", string(got))
+	}
+}
+
+// Verify that when the underlying source emits data in small chunks, the
+// peek stops reading new bytes as soon as it finds the first event
+// boundary (i.e., it does NOT drain the entire stream unnecessarily).
+func TestPeekFirstSSEEvent_StopsAtBoundary(t *testing.T) {
+	t.Parallel()
+	// A source that yields one byte per Read. bufio cannot pre-buffer
+	// ahead of our manual reads beyond the requested size.
+	slow := &byteReader{data: []byte("data: hello\n\ndata: world\n\n")}
+	got, err := peekFirstSSEEvent(slow, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With a byte-at-a-time source, the peek should have consumed exactly
+	// "data: hello\n\n" — anything more would indicate we over-read.
+	if string(got) != "data: hello\n\n" {
+		t.Fatalf("peeked %q, want exact first-event bytes", string(got))
+	}
+}
+
+// byteReader is an io.Reader that returns one byte per Read call, used to
+// exercise the peek's boundary detection under slow/chunked sources.
+type byteReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *byteReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = r.data[r.pos]
+	r.pos++
+	return 1, nil
+}
+
+func TestPeekFirstSSEEvent_EOFAfterFirstEvent(t *testing.T) {
+	t.Parallel()
+	// Stream closes right after the first event with no trailing blank
+	// line — should still be treated as a successful peek.
+	input := "data: only\n"
+	got, err := peekFirstSSEEvent(strings.NewReader(input), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), "data: only") {
+		t.Fatalf("peeked %q, expected it to contain 'data: only'", string(got))
+	}
+}
+
+func TestPeekFirstSSEEvent_EmptyStream(t *testing.T) {
+	t.Parallel()
+	_, err := peekFirstSSEEvent(strings.NewReader(""), 0)
+	if err == nil {
+		t.Fatal("empty stream should return an error")
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+}
+
+// --- OpenStreamWithRetry integration ---
+
+// streamTestServer returns an httptest.Server whose handler runs fn for each
+// request. fn is expected to write to w and return. Use atomic counters in
+// fn to observe attempt count across requests.
+func streamTestServer(t *testing.T, fn http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(fn)
+}
+
+func TestOpenStreamWithRetry_SuccessFirstAttempt(t *testing.T) {
+	t.Parallel()
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: hello\n\ndata: world\n\n")
+	})
+	defer srv.Close()
+
+	result, err := OpenStreamWithRetry(
+		context.Background(),
+		StreamRetryPolicy{Enabled: true, MaxAttempts: 3},
+		"test",
+		time.Second,
+		func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		srv.Client(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Body.Close()
+
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 server hit, got %d", got)
+	}
+	if result.Attempts != 1 {
+		t.Errorf("result.Attempts = %d, want 1", result.Attempts)
+	}
+
+	// Read the full body and assert the peeked first event was replayed.
+	body, err := io.ReadAll(result.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	want := "data: hello\n\ndata: world\n\n"
+	if string(body) != want {
+		t.Errorf("replayed body = %q, want %q", string(body), want)
+	}
+}
+
+func TestOpenStreamWithRetry_RetriesOnRetryableStatus(t *testing.T) {
+	t.Parallel()
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, "try later")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: recovered\n\n")
+	})
+	defer srv.Close()
+
+	result, err := OpenStreamWithRetry(
+		context.Background(),
+		StreamRetryPolicy{
+			Enabled:      true,
+			MaxAttempts:  3,
+			InitialDelay: 1 * time.Millisecond,
+			MaxDelay:     5 * time.Millisecond,
+		},
+		"test",
+		time.Second,
+		func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		srv.Client(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Body.Close()
+
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("expected 2 server hits, got %d", got)
+	}
+	if result.Attempts != 2 {
+		t.Errorf("result.Attempts = %d, want 2", result.Attempts)
+	}
+	body, _ := io.ReadAll(result.Body)
+	if !strings.Contains(string(body), "data: recovered") {
+		t.Errorf("expected recovered body, got %q", string(body))
+	}
+}
+
+func TestOpenStreamWithRetry_NonRetryableStatusFails(t *testing.T) {
+	t.Parallel()
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "nope")
+	})
+	defer srv.Close()
+
+	_, err := OpenStreamWithRetry(
+		context.Background(),
+		StreamRetryPolicy{Enabled: true, MaxAttempts: 3, InitialDelay: time.Millisecond},
+		"test",
+		time.Second,
+		func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		srv.Client(),
+	)
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("400 should not retry, got %d attempts", got)
+	}
+}
+
+func TestOpenStreamWithRetry_RetriesOnMidBodyClose(t *testing.T) {
+	t.Parallel()
+	// This is the gpt-5-pro failure simulation: first response sends
+	// headers, then closes the body before any SSE event is produced.
+	// Second response succeeds.
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("ResponseWriter does not support flushing")
+			return
+		}
+		flusher.Flush()
+		if n == 1 {
+			// Abruptly close without sending any event.
+			// Using hijack to simulate a connection reset.
+			hijacker, okH := w.(http.Hijacker)
+			if okH {
+				conn, _, errH := hijacker.Hijack()
+				if errH == nil {
+					_ = conn.Close()
+				}
+			}
+			return
+		}
+		_, _ = io.WriteString(w, "data: recovered\n\n")
+		flusher.Flush()
+	})
+	defer srv.Close()
+
+	result, err := OpenStreamWithRetry(
+		context.Background(),
+		StreamRetryPolicy{
+			Enabled:      true,
+			MaxAttempts:  3,
+			InitialDelay: 1 * time.Millisecond,
+			MaxDelay:     5 * time.Millisecond,
+		},
+		"test",
+		2*time.Second,
+		func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		srv.Client(),
+	)
+	if err != nil {
+		t.Fatalf("expected retry success, got error: %v", err)
+	}
+	defer result.Body.Close()
+
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("expected 2 server hits, got %d", got)
+	}
+	body, _ := io.ReadAll(result.Body)
+	if !strings.Contains(string(body), "data: recovered") {
+		t.Errorf("expected recovered body, got %q", string(body))
+	}
+}
+
+func TestOpenStreamWithRetry_ExhaustsAttempts(t *testing.T) {
+	t.Parallel()
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer srv.Close()
+
+	_, err := OpenStreamWithRetry(
+		context.Background(),
+		StreamRetryPolicy{
+			Enabled:      true,
+			MaxAttempts:  3,
+			InitialDelay: 1 * time.Millisecond,
+			MaxDelay:     5 * time.Millisecond,
+		},
+		"test",
+		time.Second,
+		func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		srv.Client(),
+	)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 server hits (max_attempts), got %d", got)
+	}
+}
+
+func TestOpenStreamWithRetry_DisabledDoesNotRetry(t *testing.T) {
+	t.Parallel()
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer srv.Close()
+
+	_, err := OpenStreamWithRetry(
+		context.Background(),
+		StreamRetryPolicy{}, // disabled
+		"test",
+		time.Second,
+		func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		srv.Client(),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("disabled policy should not retry, got %d attempts", got)
+	}
+}
+
+func TestOpenStreamWithRetry_ContextCancelStopsRetry(t *testing.T) {
+	t.Parallel()
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	_, err := OpenStreamWithRetry(
+		ctx,
+		StreamRetryPolicy{Enabled: true, MaxAttempts: 5, InitialDelay: 10 * time.Millisecond},
+		"test",
+		time.Second,
+		func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		srv.Client(),
+	)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// Verify that the error message from a non-retryable HTTP status bubbles
+// up with a helpful snippet of the body so operators can debug.
+func TestOpenStreamWithRetry_ErrorIncludesStatusAndBody(t *testing.T) {
+	t.Parallel()
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "bad thing happened")
+	})
+	defer srv.Close()
+
+	_, err := OpenStreamWithRetry(
+		context.Background(),
+		StreamRetryPolicy{},
+		"test",
+		time.Second,
+		func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		srv.Client(),
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := fmt.Sprint(err)
+	if !strings.Contains(msg, "400") {
+		t.Errorf("error should mention status 400: %q", msg)
+	}
+	if !strings.Contains(msg, "bad thing happened") {
+		t.Errorf("error should include response body: %q", msg)
+	}
+}

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1661,6 +1661,9 @@
         },
         "stream_idle_timeout": {
           "type": "string"
+        },
+        "stream_retry": {
+          "$ref": "#/$defs/StreamRetryConfig"
         }
       },
       "additionalProperties": false,
@@ -2119,6 +2122,27 @@
       "required": [
         "type"
       ]
+    },
+    "StreamRetryConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "max_attempts": {
+          "type": "integer"
+        },
+        "initial_delay": {
+          "type": "string"
+        },
+        "max_delay": {
+          "type": "string"
+        },
+        "retry_window": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "TTSConfig": {
       "properties": {

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -141,6 +141,9 @@
         },
         "stream_idle_timeout": {
           "type": "string"
+        },
+        "stream_retry": {
+          "$ref": "#/$defs/StreamRetryConfig"
         }
       },
       "additionalProperties": false,
@@ -185,6 +188,27 @@
         "rps",
         "burst"
       ]
+    },
+    "StreamRetryConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "max_attempts": {
+          "type": "integer"
+        },
+        "initial_delay": {
+          "type": "string"
+        },
+        "max_delay": {
+          "type": "string"
+        },
+        "retry_window": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     }
   },
   "properties": {

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -505,6 +505,9 @@
         },
         "stream_idle_timeout": {
           "type": "string"
+        },
+        "stream_retry": {
+          "$ref": "#/$defs/StreamRetryConfig"
         }
       },
       "additionalProperties": false,
@@ -695,6 +698,27 @@
       "required": [
         "type"
       ]
+    },
+    "StreamRetryConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "max_attempts": {
+          "type": "integer"
+        },
+        "initial_delay": {
+          "type": "string"
+        },
+        "max_delay": {
+          "type": "string"
+        },
+        "retry_window": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "ToolClientConfig": {
       "properties": {

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -205,6 +205,7 @@ func createProviderImpl(configDir string, provider *config.Provider) (providers.
 
 	requestTimeout := parseProviderDuration(provider.ID, "request_timeout", provider.RequestTimeout)
 	streamIdleTimeout := parseProviderDuration(provider.ID, "stream_idle_timeout", provider.StreamIdleTimeout)
+	streamRetry := buildStreamRetryPolicy(provider.ID, provider.StreamRetry)
 
 	spec := providers.ProviderSpec{
 		ID:                provider.ID,
@@ -219,6 +220,7 @@ func createProviderImpl(configDir string, provider *config.Provider) (providers.
 		UnsupportedParams: provider.UnsupportedParams,
 		RequestTimeout:    requestTimeout,
 		StreamIdleTimeout: streamIdleTimeout,
+		StreamRetry:       streamRetry,
 		Defaults: providers.ProviderDefaults{
 			Temperature: provider.Defaults.Temperature,
 			TopP:        provider.Defaults.TopP,
@@ -230,6 +232,35 @@ func createProviderImpl(configDir string, provider *config.Provider) (providers.
 		},
 	}
 	return providers.CreateProviderFromSpec(spec)
+}
+
+// buildStreamRetryPolicy translates a StreamRetryConfig from arena config
+// into a providers.StreamRetryPolicy. Nil or disabled config returns the
+// zero policy (retry off). Malformed durations are logged and skipped so
+// the provider falls back to the built-in defaults for that field.
+func buildStreamRetryPolicy(providerID string, cfg *config.StreamRetryConfig) providers.StreamRetryPolicy {
+	if cfg == nil || !cfg.Enabled {
+		return providers.StreamRetryPolicy{}
+	}
+	policy := providers.StreamRetryPolicy{
+		Enabled:     true,
+		MaxAttempts: cfg.MaxAttempts,
+	}
+	if cfg.InitialDelay != "" {
+		policy.InitialDelay = parseProviderDuration(providerID, "stream_retry.initial_delay", cfg.InitialDelay)
+	}
+	if cfg.MaxDelay != "" {
+		policy.MaxDelay = parseProviderDuration(providerID, "stream_retry.max_delay", cfg.MaxDelay)
+	}
+	switch cfg.RetryWindow {
+	case "", string(providers.StreamRetryWindowPreFirstChunk):
+		policy.Window = providers.StreamRetryWindowPreFirstChunk
+	default:
+		logger.Warn("arena: unknown stream_retry.retry_window, defaulting to pre_first_chunk",
+			"provider", providerID, "value", cfg.RetryWindow)
+		policy.Window = providers.StreamRetryWindowPreFirstChunk
+	}
+	return policy
 }
 
 // parseProviderDuration parses a Go duration string from a provider config


### PR DESCRIPTION
## Summary

Adds opt-in streaming retry for the OpenAI Responses API, targeting the transient `http2: response body closed` failures that hit `openai-gpt5-pro` in the scheduled capability-matrix runs. Retry only fires **before any content chunk has been forwarded downstream**, so there is no risk of duplicate emission.

Phase 1 of the design documented in \`docs/local-backlog/STREAMING_RETRY_AT_SCALE.md\`.

## Config (per-provider, opt-in)

\`\`\`yaml
stream_retry:
  enabled: true          # default: false
  max_attempts: 2
  initial_delay: 250ms
  max_delay: 2s
\`\`\`

\`openai-gpt5-pro\` in the capability-matrix example opts in to validate the hypothesis on the next scheduled run.

## Implementation

- **\`runtime/providers/stream_retry.go\`** — \`StreamRetryPolicy\`, full-jitter backoff, narrow retryable-error classifier (h2 RST_STREAM, GOAWAY, unexpected EOF, connection reset; never context cancellation or deadline).
- **\`runtime/providers/stream_retry_driver.go\`** — \`OpenStreamWithRetry\` drives \`Do()\` + first-SSE-event peek. On success, the buffered first event is replayed into a composite reader so downstream SSE parsers see a contiguous stream. On retryable failure, the body is closed and the attempt is retried with full jitter.
- **\`runtime/providers/openai/openai_responses_integration.go\`** — Responses API streaming path delegates through \`OpenStreamWithRetry\`.
- **\`tools/arena/engine/builder_integration.go\`** — parses \`stream_retry\` from arena config into \`providers.StreamRetryPolicy\`.
- Schemas regenerated via \`tools/schema-gen\`.

## Phase 1 metrics (direct-update, not event-driven)

Updated inline at the source so burst-load drops on the event bus cannot corrupt autoscaling signals:

- \`promptkit_streams_in_flight{provider}\` — gauge, **primary HPA signal**
- \`promptkit_provider_calls_in_flight{provider}\` — gauge
- \`promptkit_stream_first_chunk_latency_seconds{provider}\` — histogram with reasoning-model buckets (0.1s..5min)
- \`promptkit_stream_retries_total{provider,outcome}\` — counter

Metrics register into the same Prometheus registry as \`runtime/metrics\` via a nil-safe \`DefaultStreamMetrics\` installed by \`NewCollector\`. All methods are nil-safe so provider code can call them unconditionally.

## Tests

- **\`runtime/providers/stream_retry_test.go\`** — 20 tests covering policy defaults, full-jitter distribution, classifier behavior (including the exact \`http2: response body closed\` string), SSE peek boundary handling with both bulk and byte-at-a-time sources, and an httptest integration test that hijacks the connection mid-stream on attempt 1 to simulate the gpt-5-pro failure and verifies retry produces a usable stream.
- **\`runtime/providers/stream_metrics_test.go\`** — nil-safety, gauge/counter/histogram increments, namespace and const-label wiring, default-instance idempotency.

Coverage on touched files: \`stream_metrics.go\` 100%, \`stream_retry_driver.go\` 92.7%, \`stream_retry.go\` 84.2%.

## Non-goals / future phases

- **Phase 2** — global retry budget per \`(provider, host)\` with circuit-breaker semantics; extends retry to the Chat Completions path.
- **Phase 3** — concurrent-stream semaphore (\`stream_max_concurrent\`) for back-pressure.
- **Phase 4 (maybe)** — dedup-aware mid-stream resume. Phase 1 deliberately retries only in the narrow pre-first-chunk window; whether that catches enough real failures is an empirical question answered by the new \`stream_first_chunk_latency\` histogram + retry counters.

## Test plan

- [x] Unit tests green (\`go test ./runtime/... -race\`)
- [x] Integration test reproducing mid-body close + verifying replay produces contiguous stream
- [x] Arena capability-matrix loads the new config without schema errors (smoke-run with \`--mock-provider\`)
- [ ] CI green on this PR
- [ ] Next scheduled \`Provider Capability Matrix\` run after merge — verify gpt5-pro no longer fails with \`stream chunk error: http2: response body closed\` (or, if it still fails, verify the metrics show retry exhaustion so we have the signal we need for Phase 2)