### PR TITLE
feat: retry budget + Chat Completions streaming retry (Phase 2)

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1149,6 +1149,25 @@ type StreamRetryConfig struct {
 	// value) retries only if no content chunk has been forwarded yet.
 	// Future values may be gated on deduplication support.
 	RetryWindow string `json:"retry_window,omitempty" yaml:"retry_window,omitempty"`
+	// Budget configures a token bucket that rate-limits retry attempts
+	// across all in-flight requests on this provider. Protects against
+	// thundering-herd reconnects when a single upstream connection reset
+	// kills many streams simultaneously. When nil, retries are unbounded
+	// (Phase 1 behavior).
+	Budget *StreamRetryBudgetConfig `json:"budget,omitempty" yaml:"budget,omitempty"`
+}
+
+// StreamRetryBudgetConfig configures the token bucket that gates retry
+// attempts to prevent thundering-herd reconnects under upstream degradation.
+// Only retries consume tokens; the initial attempt of each request is
+// always allowed through.
+type StreamRetryBudgetConfig struct {
+	// RatePerSec is the sustained token refill rate. Empty or non-positive
+	// disables the budget (unbounded retries).
+	RatePerSec float64 `json:"rate_per_sec,omitempty" yaml:"rate_per_sec,omitempty"`
+	// Burst is the maximum number of tokens that can accumulate. Empty
+	// or non-positive disables the budget.
+	Burst int `json:"burst,omitempty" yaml:"burst,omitempty"`
 }
 
 // CredentialConfig is an alias for credentials.CredentialConfig.

--- a/runtime/providers/base_provider.go
+++ b/runtime/providers/base_provider.go
@@ -96,6 +96,7 @@ type BaseProvider struct {
 	streamingClient       *http.Client // SSE streams; Timeout: 0
 	streamIdleTimeout     time.Duration
 	streamRetryPolicy     StreamRetryPolicy
+	streamRetryBudget     *RetryBudget
 	rateLimiter           *rate.Limiter
 	retryPolicy           pipeline.RetryPolicy
 	maxRequestPayloadSize int64
@@ -277,6 +278,19 @@ func (b *BaseProvider) StreamRetryPolicy() StreamRetryPolicy {
 // pre-first-chunk streaming window. See StreamRetryPolicy for details.
 func (b *BaseProvider) SetStreamRetryPolicy(policy StreamRetryPolicy) {
 	b.streamRetryPolicy = policy
+}
+
+// StreamRetryBudget returns the per-provider retry budget. A nil return
+// means retries are unbounded (only MaxAttempts caps them).
+func (b *BaseProvider) StreamRetryBudget() *RetryBudget {
+	return b.streamRetryBudget
+}
+
+// SetStreamRetryBudget installs a token bucket that rate-limits retry
+// attempts across all in-flight requests on this provider. Passing nil
+// restores unbounded-retry behavior.
+func (b *BaseProvider) SetStreamRetryBudget(budget *RetryBudget) {
+	b.streamRetryBudget = budget
 }
 
 // HTTPTimeout returns the current HTTP client timeout, or 0 if no client is set.

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -904,31 +904,54 @@ func (p *Provider) predictStreamWithMessages(ctx context.Context, req providers.
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Make HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+openAIPredictCompletionsPath, bytes.NewReader(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	url := p.baseURL + openAIPredictCompletionsPath
+	requestFn := func(ctx context.Context) (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		httpReq.Header.Set("Accept", "text/event-stream")
+		if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+			return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+		}
+		return httpReq, nil
 	}
 
-	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-	httpReq.Header.Set("Accept", "text/event-stream")
-	if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
-		return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
-	}
+	metrics := providers.DefaultStreamMetrics()
+	metrics.StreamsInFlightInc(p.ID())
+	metrics.ProviderCallsInFlightInc(p.ID())
+	released := false
+	defer func() {
+		if !released {
+			metrics.StreamsInFlightDec(p.ID())
+			metrics.ProviderCallsInFlightDec(p.ID())
+		}
+	}()
 
-	//nolint:bodyclose // body is closed in streamResponse goroutine
-	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
+	result, err := providers.OpenStreamWithRetryRequest(ctx, &providers.StreamRetryRequest{
+		Policy:       p.StreamRetryPolicy(),
+		Budget:       p.StreamRetryBudget(),
+		ProviderName: p.ID(),
+		Host:         providers.HostFromURL(url),
+		IdleTimeout:  p.StreamIdleTimeout(),
+		RequestFn:    requestFn,
+		Client:       p.GetStreamingHTTPClient(),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 
-	if err := providers.CheckHTTPError(resp, p.baseURL+openAIPredictCompletionsPath); err != nil {
-		return nil, err
-	}
-
 	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-
-	go p.streamResponse(ctx, resp.Body, outChan)
+	released = true
+	providerID := p.ID()
+	go func() {
+		defer func() {
+			metrics.StreamsInFlightDec(providerID)
+			metrics.ProviderCallsInFlightDec(providerID)
+		}()
+		p.streamResponse(ctx, result.Body, outChan)
+	}()
 
 	return outChan, nil
 }

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -583,14 +583,15 @@ func (p *Provider) predictStreamWithResponses(
 		}
 	}()
 
-	result, err := providers.OpenStreamWithRetry(
-		ctx,
-		p.StreamRetryPolicy(),
-		p.ID(),
-		p.StreamIdleTimeout(),
-		requestFn,
-		p.GetStreamingHTTPClient(),
-	)
+	result, err := providers.OpenStreamWithRetryRequest(ctx, &providers.StreamRetryRequest{
+		Policy:       p.StreamRetryPolicy(),
+		Budget:       p.StreamRetryBudget(),
+		ProviderName: p.ID(),
+		Host:         providers.HostFromURL(url),
+		IdleTimeout:  p.StreamIdleTimeout(),
+		RequestFn:    requestFn,
+		Client:       p.GetStreamingHTTPClient(),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -111,6 +111,14 @@ type ProviderSpec struct {
 	// the provider with no streaming retry. Pre-parsed from
 	// config.Provider.StreamRetry by the arena loader.
 	StreamRetry StreamRetryPolicy
+
+	// StreamRetryBudget is a pre-constructed token bucket that
+	// rate-limits retry attempts across all in-flight requests on this
+	// provider. Nil means "unbounded retries" (only MaxAttempts caps
+	// them). Pre-parsed from config.Provider.StreamRetry.Budget by the
+	// arena loader. Each provider instance gets its own budget so one
+	// misbehaving model cannot starve retry capacity for others.
+	StreamRetryBudget *RetryBudget
 }
 
 // Credential applies authentication to HTTP requests.
@@ -138,9 +146,10 @@ type timeoutConfigurable interface {
 
 // streamRetryConfigurable is implemented by any provider that embeds
 // *BaseProvider. CreateProviderFromSpec uses this to apply the streaming
-// retry policy from the spec after the factory runs.
+// retry policy (and its budget) from the spec after the factory runs.
 type streamRetryConfigurable interface {
 	SetStreamRetryPolicy(StreamRetryPolicy)
+	SetStreamRetryBudget(*RetryBudget)
 }
 
 // CreateProviderFromSpec creates a provider implementation from a spec.
@@ -192,11 +201,19 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 		}
 	}
 
-	// Apply the streaming retry policy. The zero value is "disabled", so
-	// providers that opt in via config get the new behavior while all
-	// others are unchanged.
-	if src, ok := provider.(streamRetryConfigurable); ok && spec.StreamRetry.Enabled {
-		src.SetStreamRetryPolicy(spec.StreamRetry)
+	// Apply the streaming retry policy and its (optional) budget. The
+	// zero policy is "disabled", so providers that opt in via config get
+	// the new behavior while all others are unchanged. The budget is
+	// applied independently: a provider may have retry enabled without a
+	// budget (unbounded retries) or — perversely — a budget without
+	// retry enabled (the budget is then unused but harmless).
+	if src, ok := provider.(streamRetryConfigurable); ok {
+		if spec.StreamRetry.Enabled {
+			src.SetStreamRetryPolicy(spec.StreamRetry)
+		}
+		if spec.StreamRetryBudget != nil {
+			src.SetStreamRetryBudget(spec.StreamRetryBudget)
+		}
 	}
 
 	return provider, nil

--- a/runtime/providers/stream_metrics.go
+++ b/runtime/providers/stream_metrics.go
@@ -24,10 +24,11 @@ var streamFirstChunkBuckets = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 1
 // This lets provider code unconditionally call s.StreamsInFlightInc(...)
 // without guarding on whether metrics are configured.
 type StreamMetrics struct {
-	streamsInFlight         *prometheus.GaugeVec
-	providerCallsInFlight   *prometheus.GaugeVec
-	streamFirstChunkLatency *prometheus.HistogramVec
-	streamRetriesTotal      *prometheus.CounterVec
+	streamsInFlight            *prometheus.GaugeVec
+	providerCallsInFlight      *prometheus.GaugeVec
+	streamFirstChunkLatency    *prometheus.HistogramVec
+	streamRetriesTotal         *prometheus.CounterVec
+	streamRetryBudgetAvailable *prometheus.GaugeVec
 }
 
 // NewStreamMetrics creates and registers the Phase 1 streaming metrics
@@ -72,12 +73,21 @@ func NewStreamMetrics(
 			Help:        "Total streaming retry attempts, labeled by outcome (success, failed, budget_exhausted).",
 			ConstLabels: constLabels,
 		}, []string{"provider", "outcome"}),
+		streamRetryBudgetAvailable: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "stream_retry_budget_available",
+			Help: "Current tokens available in the streaming retry budget, per (provider, host). " +
+				"Early-warning signal for upstream degradation — a provider whose budget is " +
+				"trending toward zero is about to start failing retries.",
+			ConstLabels: constLabels,
+		}, []string{"provider", "host"}),
 	}
 	registerer.MustRegister(
 		m.streamsInFlight,
 		m.providerCallsInFlight,
 		m.streamFirstChunkLatency,
 		m.streamRetriesTotal,
+		m.streamRetryBudgetAvailable,
 	)
 	return m
 }
@@ -129,13 +139,32 @@ func (m *StreamMetrics) ObserveFirstChunkLatency(provider string, d time.Duratio
 
 // RetryAttempt records one streaming retry attempt with an outcome label.
 // Outcome values: "success" (attempt that produced a usable stream),
-// "failed" (retryable transient failure that will be retried), or
-// "exhausted" (last attempt failed, no more retries). Nil-safe.
+// "failed" (retryable transient failure that will be retried), "exhausted"
+// (last attempt failed, no more retries), or "budget_exhausted" (retry
+// was rejected because the per-provider retry budget had no tokens).
+// Nil-safe.
 func (m *StreamMetrics) RetryAttempt(provider, outcome string) {
 	if m == nil {
 		return
 	}
 	m.streamRetriesTotal.WithLabelValues(provider, outcome).Inc()
+}
+
+// ObserveRetryBudgetAvailable samples the current token count of a retry
+// budget and publishes it to the stream_retry_budget_available gauge.
+// Intended to be called whenever a retry attempts to acquire a token —
+// the gauge then reflects the budget state at the moment of highest
+// interest (right before a retry decision).
+//
+// A nil budget publishes 0, which is intentional: it lets operators
+// distinguish "no budget configured" (gauge absent) from "budget fully
+// drained" (gauge at 0) by gauge presence rather than value. Nil-safe
+// on the receiver.
+func (m *StreamMetrics) ObserveRetryBudgetAvailable(provider, host string, budget *RetryBudget) {
+	if m == nil || budget == nil {
+		return
+	}
+	m.streamRetryBudgetAvailable.WithLabelValues(provider, host).Set(budget.Available())
 }
 
 // Package-level default instance. Hosts register it by calling

--- a/runtime/providers/stream_retry.go
+++ b/runtime/providers/stream_retry.go
@@ -4,9 +4,22 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
+
+// HostFromURL extracts just the host portion (without scheme or path)
+// from a URL string, intended for use as a Prometheus label on
+// streaming metrics. Returns an empty string on parse error — callers
+// treat empty-host labels as "unknown host" rather than failing.
+func HostFromURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return u.Host
+}
 
 // Default values for StreamRetryPolicy. Kept small on purpose: streaming retry
 // targets transient h2 stream resets, not generic 5xx storms, and the wrong

--- a/runtime/providers/stream_retry_budget.go
+++ b/runtime/providers/stream_retry_budget.go
@@ -1,0 +1,96 @@
+package providers
+
+import (
+	"golang.org/x/time/rate"
+)
+
+// RetryBudget is a token bucket that governs how often streaming retries
+// may actually re-dial the upstream. The initial attempt of each request
+// is NOT gated by the budget — only retries consume tokens.
+//
+// Rationale: per-call bounded retry (policy.MaxAttempts) is not enough at
+// scale. When a single HTTP/2 connection reset kills ~100 streams at once,
+// naive bounded retry causes 100 simultaneous reconnect attempts, which
+// amplifies the upstream problem instead of recovering from it. The budget
+// caps the *rate* at which retries hit the upstream so one storm cannot
+// saturate the provider's capacity for the entire runtime.
+//
+// Design: gRPC's "retry throttling" pattern, implemented with a standard
+// golang.org/x/time/rate token bucket. Non-blocking acquire (fail-fast) —
+// exhausted budgets return the original error immediately rather than
+// stacking goroutines on a starved bucket.
+//
+// All methods are nil-safe: a nil *RetryBudget allows every retry
+// (equivalent to unlimited budget). This lets callers use the budget
+// unconditionally without guarding every call site.
+type RetryBudget struct {
+	limiter    *rate.Limiter
+	ratePerSec float64
+	burst      int
+}
+
+// NewRetryBudget creates a new token bucket sized for streaming retries.
+// ratePerSec is the sustained refill rate; burst is the maximum number of
+// tokens that can accumulate. Returns nil when either parameter is
+// non-positive (unlimited budget).
+//
+// Typical sizing: start with rate=5/s, burst=10 and tune based on
+// promptkit_stream_retries_total{outcome="budget_exhausted"}. These
+// defaults are deliberately conservative — a healthy workload should
+// almost never hit the budget, so high rejection counts are a signal
+// that either retries are storming (upstream degraded) or the budget
+// is undersized (bump it).
+func NewRetryBudget(ratePerSec float64, burst int) *RetryBudget {
+	if ratePerSec <= 0 || burst <= 0 {
+		return nil
+	}
+	return &RetryBudget{
+		limiter:    rate.NewLimiter(rate.Limit(ratePerSec), burst),
+		ratePerSec: ratePerSec,
+		burst:      burst,
+	}
+}
+
+// TryAcquire attempts to take one token from the bucket without blocking.
+// Returns true if a token was consumed (retry is permitted), false if the
+// bucket is empty (retry must be rejected). A nil budget always returns
+// true so provider code can call TryAcquire unconditionally.
+func (b *RetryBudget) TryAcquire() bool {
+	if b == nil {
+		return true
+	}
+	return b.limiter.Allow()
+}
+
+// Available returns the current number of tokens in the bucket. Intended
+// for the promptkit_stream_retry_budget_available gauge. A nil budget
+// returns math-infinity-ish sentinel: since there is no concept of
+// "available" for unlimited buckets, we return the burst capacity so
+// gauges still report a meaningful finite number.
+//
+// Note: rate.Limiter.Tokens reflects state at the time of the call; it
+// may drift between TryAcquire and Available under concurrent load.
+// This is fine for observability — the gauge is a trailing indicator.
+func (b *RetryBudget) Available() float64 {
+	if b == nil {
+		return 0
+	}
+	return b.limiter.Tokens()
+}
+
+// Burst returns the configured burst size. Used by callers that want to
+// compute saturation ratios (available / burst). Returns 0 for nil.
+func (b *RetryBudget) Burst() int {
+	if b == nil {
+		return 0
+	}
+	return b.burst
+}
+
+// RatePerSec returns the configured refill rate. Returns 0 for nil.
+func (b *RetryBudget) RatePerSec() float64 {
+	if b == nil {
+		return 0
+	}
+	return b.ratePerSec
+}

--- a/runtime/providers/stream_retry_budget_test.go
+++ b/runtime/providers/stream_retry_budget_test.go
@@ -1,0 +1,162 @@
+package providers
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- Constructor and nil-safety ---
+
+func TestNewRetryBudget_NilOnZero(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		rate  float64
+		burst int
+	}{
+		{"zero rate", 0, 10},
+		{"zero burst", 5, 0},
+		{"negative rate", -1, 10},
+		{"negative burst", 5, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if b := NewRetryBudget(tc.rate, tc.burst); b != nil {
+				t.Errorf("NewRetryBudget(%v, %d) = %v, want nil", tc.rate, tc.burst, b)
+			}
+		})
+	}
+}
+
+func TestNewRetryBudget_Valid(t *testing.T) {
+	t.Parallel()
+	b := NewRetryBudget(5, 10)
+	if b == nil {
+		t.Fatal("NewRetryBudget(5, 10) returned nil")
+	}
+	if got := b.Burst(); got != 10 {
+		t.Errorf("Burst() = %d, want 10", got)
+	}
+	if got := b.RatePerSec(); got != 5 {
+		t.Errorf("RatePerSec() = %v, want 5", got)
+	}
+}
+
+func TestRetryBudget_NilSafe(t *testing.T) {
+	t.Parallel()
+	var b *RetryBudget
+	// All methods must handle nil receiver without panicking.
+	if !b.TryAcquire() {
+		t.Error("nil budget TryAcquire should return true (unlimited)")
+	}
+	if got := b.Available(); got != 0 {
+		t.Errorf("nil budget Available() = %v, want 0", got)
+	}
+	if got := b.Burst(); got != 0 {
+		t.Errorf("nil budget Burst() = %d, want 0", got)
+	}
+	if got := b.RatePerSec(); got != 0 {
+		t.Errorf("nil budget RatePerSec() = %v, want 0", got)
+	}
+}
+
+// --- Burst enforcement ---
+
+func TestRetryBudget_BurstEnforcement(t *testing.T) {
+	t.Parallel()
+	// Rate low enough that refill during the test is negligible.
+	b := NewRetryBudget(0.001, 5)
+
+	// Should allow exactly burst tokens before rejecting.
+	for i := 0; i < 5; i++ {
+		if !b.TryAcquire() {
+			t.Fatalf("attempt %d: expected success within burst, got rejection", i)
+		}
+	}
+	// 6th attempt should be rejected.
+	if b.TryAcquire() {
+		t.Error("6th acquire should be rejected after burst exhausted")
+	}
+}
+
+// --- Refill ---
+
+func TestRetryBudget_Refill(t *testing.T) {
+	t.Parallel()
+	// 100 tokens/sec = 10ms per token. Burst 1 means we have exactly 1
+	// token initially, then must wait ~10ms for the next.
+	b := NewRetryBudget(100, 1)
+
+	if !b.TryAcquire() {
+		t.Fatal("first acquire should succeed with full burst")
+	}
+	if b.TryAcquire() {
+		t.Fatal("second acquire immediately after should fail")
+	}
+
+	// Wait long enough for refill.
+	time.Sleep(20 * time.Millisecond)
+
+	if !b.TryAcquire() {
+		t.Error("acquire after refill window should succeed")
+	}
+}
+
+// --- Concurrent access (race detector) ---
+
+func TestRetryBudget_Concurrent(t *testing.T) {
+	t.Parallel()
+	b := NewRetryBudget(1000, 100)
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+	const perGoroutine = 20
+	acquired := make(chan bool, goroutines*perGoroutine)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				acquired <- b.TryAcquire()
+			}
+		}()
+	}
+	wg.Wait()
+	close(acquired)
+
+	// Count successes. We cannot assert an exact number because refill
+	// happens during the test, but it must be at least the burst size
+	// and at most goroutines*perGoroutine.
+	var successes int
+	for ok := range acquired {
+		if ok {
+			successes++
+		}
+	}
+	if successes < 100 {
+		t.Errorf("concurrent acquires: got %d successes, expected at least burst=100", successes)
+	}
+	if successes > goroutines*perGoroutine {
+		t.Errorf("concurrent acquires: got %d successes, max possible is %d", successes, goroutines*perGoroutine)
+	}
+}
+
+// --- Available() for gauge ---
+
+func TestRetryBudget_AvailableDecreasesOnAcquire(t *testing.T) {
+	t.Parallel()
+	b := NewRetryBudget(0.001, 10) // low rate, high burst
+	initial := b.Available()
+	if initial < 9 || initial > 10 {
+		t.Fatalf("initial Available() = %v, want ~10", initial)
+	}
+	for i := 0; i < 5; i++ {
+		b.TryAcquire()
+	}
+	after := b.Available()
+	if after > initial-4 { // allow some tolerance for refill
+		t.Errorf("Available() after 5 acquires = %v, expected significantly less than %v", after, initial)
+	}
+}

--- a/runtime/providers/stream_retry_driver.go
+++ b/runtime/providers/stream_retry_driver.go
@@ -31,6 +31,19 @@ type StreamRetryResult struct {
 	Attempts int
 }
 
+// StreamRetryRequest bundles the dependencies for a streaming retry
+// attempt. This exists so OpenStreamWithRetryRequest can grow new
+// parameters (budget, host label, etc.) without breaking every call site.
+type StreamRetryRequest struct {
+	Policy       StreamRetryPolicy
+	Budget       *RetryBudget // nil means unbounded retries
+	ProviderName string
+	Host         string // metric label; may be empty
+	IdleTimeout  time.Duration
+	RequestFn    func(ctx context.Context) (*http.Request, error)
+	Client       *http.Client
+}
+
 // OpenStreamWithRetry executes requestFn and peeks the first SSE data event
 // on the response body. If Do() returns a retryable error, or the response
 // status is retryable, or the body fails to produce a first SSE event
@@ -46,7 +59,8 @@ type StreamRetryResult struct {
 // on success the body is still wrapped to replay the peeked bytes, but no
 // retry is performed.
 //
-//nolint:gocognit // Retry loop with classification, backoff, and metric emission
+// Thin wrapper over OpenStreamWithRetryRequest for callers that don't need
+// the budget or host-label parameters.
 func OpenStreamWithRetry(
 	ctx context.Context,
 	policy StreamRetryPolicy,
@@ -55,30 +69,51 @@ func OpenStreamWithRetry(
 	requestFn func(ctx context.Context) (*http.Request, error),
 	client *http.Client,
 ) (*StreamRetryResult, error) {
-	maxAttempts := policy.Attempts()
+	return OpenStreamWithRetryRequest(ctx, &StreamRetryRequest{
+		Policy:       policy,
+		ProviderName: providerName,
+		IdleTimeout:  idleTimeout,
+		RequestFn:    requestFn,
+		Client:       client,
+	})
+}
+
+// OpenStreamWithRetryRequest is the full-featured form of OpenStreamWithRetry
+// that accepts a budget and host label. Retries beyond the initial attempt
+// must acquire a token from req.Budget (if non-nil) before re-dialing; an
+// empty budget causes the function to return the last error immediately
+// (fail-fast) rather than waiting for token refill.
+//
+//nolint:gocognit // Retry loop with classification, backoff, budget, and metric emission
+func OpenStreamWithRetryRequest(ctx context.Context, req *StreamRetryRequest) (*StreamRetryResult, error) {
+	maxAttempts := req.Policy.Attempts()
 	metrics := DefaultStreamMetrics()
 	start := time.Now()
 	var lastErr error
+
+	// Publish initial budget state so operators see the metric even when
+	// no retries have happened yet. For nil budgets this is a no-op.
+	metrics.ObserveRetryBudgetAvailable(req.ProviderName, req.Host, req.Budget)
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
 
-		req, err := requestFn(ctx)
+		httpReq, err := req.RequestFn(ctx)
 		if err != nil {
 			// Request construction errors are never retried — they
 			// indicate a caller bug, not a transient failure.
 			return nil, err
 		}
 
-		resp, doErr := client.Do(req)
-		result, retry, classifyErr := classifyStreamAttempt(resp, doErr, idleTimeout)
+		resp, doErr := req.Client.Do(httpReq)
+		result, retry, classifyErr := classifyStreamAttempt(resp, doErr, req.IdleTimeout)
 		if result != nil {
 			result.Attempts = attempt + 1
-			metrics.ObserveFirstChunkLatency(providerName, time.Since(start))
+			metrics.ObserveFirstChunkLatency(req.ProviderName, time.Since(start))
 			if attempt > 0 {
-				metrics.RetryAttempt(providerName, "success")
+				metrics.RetryAttempt(req.ProviderName, "success")
 			}
 			return result, nil
 		}
@@ -86,15 +121,34 @@ func OpenStreamWithRetry(
 		lastErr = classifyErr
 		if !retry || attempt >= maxAttempts-1 {
 			if attempt >= maxAttempts-1 && retry {
-				metrics.RetryAttempt(providerName, "exhausted")
+				metrics.RetryAttempt(req.ProviderName, "exhausted")
 			}
 			break
 		}
 
-		metrics.RetryAttempt(providerName, "failed")
-		delay := policy.BackoffFor(attempt)
+		// Before we commit to a retry, take a token from the budget.
+		// Empty budget = fail fast. This is the load-bearing line of
+		// Phase 2: when an upstream connection reset kills 100 streams
+		// at once, the budget ensures only ~burst of them re-dial and
+		// the rest fail fast with the original error, preserving the
+		// upstream's remaining capacity for the retries that win the
+		// race.
+		if !req.Budget.TryAcquire() {
+			metrics.RetryAttempt(req.ProviderName, "budget_exhausted")
+			metrics.ObserveRetryBudgetAvailable(req.ProviderName, req.Host, req.Budget)
+			logger.Warn("streaming retry budget exhausted, failing fast",
+				"provider", req.ProviderName,
+				"host", req.Host,
+				"error", classifyErr,
+			)
+			break
+		}
+		metrics.ObserveRetryBudgetAvailable(req.ProviderName, req.Host, req.Budget)
+
+		metrics.RetryAttempt(req.ProviderName, "failed")
+		delay := req.Policy.BackoffFor(attempt)
 		logger.Warn("retrying streaming request (pre-first-chunk)",
-			"provider", providerName,
+			"provider", req.ProviderName,
 			"attempt", attempt+1,
 			"max_attempts", maxAttempts,
 			"delay", delay.String(),

--- a/runtime/providers/stream_retry_test.go
+++ b/runtime/providers/stream_retry_test.go
@@ -536,6 +536,154 @@ func TestOpenStreamWithRetry_ContextCancelStopsRetry(t *testing.T) {
 	}
 }
 
+// --- Budget integration (Phase 2) ---
+
+// When the budget is empty, a retryable failure must not trigger a retry —
+// the call should fail fast with the original error. This is the
+// load-bearing guarantee of the budget: during an upstream storm we burn
+// attempts on the healthy traffic, not on re-dial amplification.
+func TestOpenStreamWithRetryRequest_BudgetExhaustedFailsFast(t *testing.T) {
+	t.Parallel()
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer srv.Close()
+
+	// Pre-drained budget: burst 1, immediately consume it.
+	budget := NewRetryBudget(0.001, 1)
+	if !budget.TryAcquire() {
+		t.Fatal("pre-drain failed to acquire the single token")
+	}
+
+	_, err := OpenStreamWithRetryRequest(context.Background(), &StreamRetryRequest{
+		Policy: StreamRetryPolicy{
+			Enabled:      true,
+			MaxAttempts:  5,
+			InitialDelay: 1 * time.Millisecond,
+			MaxDelay:     5 * time.Millisecond,
+		},
+		Budget:       budget,
+		ProviderName: "test",
+		IdleTimeout:  time.Second,
+		RequestFn: func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		Client: srv.Client(),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Only 1 server hit expected: the initial attempt, then budget
+	// blocks retry and we return immediately.
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 hit (budget should block retry), got %d", got)
+	}
+}
+
+// With a healthy budget, retries proceed normally — same behavior as
+// Phase 1 (nil budget) but routing through the Phase 2 TryAcquire path.
+func TestOpenStreamWithRetryRequest_BudgetAllowsRetry(t *testing.T) {
+	t.Parallel()
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: ok\n\n")
+	})
+	defer srv.Close()
+
+	budget := NewRetryBudget(100, 10)
+
+	result, err := OpenStreamWithRetryRequest(context.Background(), &StreamRetryRequest{
+		Policy: StreamRetryPolicy{
+			Enabled:      true,
+			MaxAttempts:  3,
+			InitialDelay: 1 * time.Millisecond,
+			MaxDelay:     5 * time.Millisecond,
+		},
+		Budget:       budget,
+		ProviderName: "test",
+		Host:         "localhost",
+		IdleTimeout:  time.Second,
+		RequestFn: func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		Client: srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	defer result.Body.Close()
+
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("expected 2 hits, got %d", got)
+	}
+	// Budget should have been decremented by 1 (the retry).
+	if avail := budget.Available(); avail > 9.5 { // allow minor refill
+		t.Errorf("budget should be decremented, got Available() = %v", avail)
+	}
+}
+
+// A nil budget must preserve Phase 1 semantics exactly — unbounded
+// retries up to MaxAttempts. This is the backwards-compat guarantee.
+func TestOpenStreamWithRetryRequest_NilBudgetIsUnbounded(t *testing.T) {
+	t.Parallel()
+	var attempts int32
+	srv := streamTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer srv.Close()
+
+	_, err := OpenStreamWithRetryRequest(context.Background(), &StreamRetryRequest{
+		Policy: StreamRetryPolicy{
+			Enabled:      true,
+			MaxAttempts:  3,
+			InitialDelay: 1 * time.Millisecond,
+			MaxDelay:     5 * time.Millisecond,
+		},
+		Budget:       nil, // explicit
+		ProviderName: "test",
+		IdleTimeout:  time.Second,
+		RequestFn: func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", srv.URL, http.NoBody)
+		},
+		Client: srv.Client(),
+	})
+	if err == nil {
+		t.Fatal("expected error after retries exhausted")
+	}
+	// All 3 attempts should land — nil budget = unbounded.
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 hits with nil budget, got %d", got)
+	}
+}
+
+// --- Host label ---
+
+func TestHostFromURL(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"https://api.openai.com/v1/chat/completions":           "api.openai.com",
+		"http://localhost:8080/responses":                      "localhost:8080",
+		"https://generativelanguage.googleapis.com/v1beta/...": "generativelanguage.googleapis.com",
+		"":                 "",
+		"not a url at all": "",
+		"://broken":        "",
+	}
+	for input, want := range cases {
+		if got := HostFromURL(input); got != want {
+			t.Errorf("HostFromURL(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 // Verify that the error message from a non-retryable HTTP status bubbles
 // up with a helpful snippet of the body so operators can debug.
 func TestOpenStreamWithRetry_ErrorIncludesStatusAndBody(t *testing.T) {

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2123,6 +2123,18 @@
         "type"
       ]
     },
+    "StreamRetryBudgetConfig": {
+      "properties": {
+        "rate_per_sec": {
+          "type": "number"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "StreamRetryConfig": {
       "properties": {
         "enabled": {
@@ -2139,6 +2151,9 @@
         },
         "retry_window": {
           "type": "string"
+        },
+        "budget": {
+          "$ref": "#/$defs/StreamRetryBudgetConfig"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -189,6 +189,18 @@
         "burst"
       ]
     },
+    "StreamRetryBudgetConfig": {
+      "properties": {
+        "rate_per_sec": {
+          "type": "number"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "StreamRetryConfig": {
       "properties": {
         "enabled": {
@@ -205,6 +217,9 @@
         },
         "retry_window": {
           "type": "string"
+        },
+        "budget": {
+          "$ref": "#/$defs/StreamRetryBudgetConfig"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -699,6 +699,18 @@
         "type"
       ]
     },
+    "StreamRetryBudgetConfig": {
+      "properties": {
+        "rate_per_sec": {
+          "type": "number"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "StreamRetryConfig": {
       "properties": {
         "enabled": {
@@ -715,6 +727,9 @@
         },
         "retry_window": {
           "type": "string"
+        },
+        "budget": {
+          "$ref": "#/$defs/StreamRetryBudgetConfig"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -206,6 +206,7 @@ func createProviderImpl(configDir string, provider *config.Provider) (providers.
 	requestTimeout := parseProviderDuration(provider.ID, "request_timeout", provider.RequestTimeout)
 	streamIdleTimeout := parseProviderDuration(provider.ID, "stream_idle_timeout", provider.StreamIdleTimeout)
 	streamRetry := buildStreamRetryPolicy(provider.ID, provider.StreamRetry)
+	streamRetryBudget := buildStreamRetryBudget(provider.StreamRetry)
 
 	spec := providers.ProviderSpec{
 		ID:                provider.ID,
@@ -221,6 +222,7 @@ func createProviderImpl(configDir string, provider *config.Provider) (providers.
 		RequestTimeout:    requestTimeout,
 		StreamIdleTimeout: streamIdleTimeout,
 		StreamRetry:       streamRetry,
+		StreamRetryBudget: streamRetryBudget,
 		Defaults: providers.ProviderDefaults{
 			Temperature: provider.Defaults.Temperature,
 			TopP:        provider.Defaults.TopP,
@@ -261,6 +263,17 @@ func buildStreamRetryPolicy(providerID string, cfg *config.StreamRetryConfig) pr
 		policy.Window = providers.StreamRetryWindowPreFirstChunk
 	}
 	return policy
+}
+
+// buildStreamRetryBudget constructs a per-provider retry budget from the
+// arena config's stream_retry.budget block. Returns nil when the config
+// is absent, disabled, or missing required fields — the caller treats
+// nil as "unbounded retries" (Phase 1 behavior).
+func buildStreamRetryBudget(cfg *config.StreamRetryConfig) *providers.RetryBudget {
+	if cfg == nil || !cfg.Enabled || cfg.Budget == nil {
+		return nil
+	}
+	return providers.NewRetryBudget(cfg.Budget.RatePerSec, cfg.Budget.Burst)
 }
 
 // parseProviderDuration parses a Go duration string from a provider config


### PR DESCRIPTION
## Summary

Builds on Phase 1 (#855) with herd control and broader coverage. Three things:

1. **`RetryBudget`** — token bucket per provider instance that caps the rate at which streaming retries actually re-dial. When a single HTTP/2 connection reset kills ~100 streams at once, Phase 1's bounded retry would cause 100 synchronized reconnect attempts. The budget (gRPC's "retry throttling" pattern) ensures the first few retries win the race and the rest fail fast with the original error. Per-provider scope so a gpt-5-pro storm cannot starve gpt-4o retries.

2. **`promptkit_stream_retry_budget_available{provider,host}`** — direct-update gauge sampled on every retry decision. Early warning for upstream degradation: a provider whose budget is trending toward zero is about to start failing retries. Plus the `budget_exhausted` outcome on the existing `promptkit_stream_retries_total` counter when a retry is rejected.

3. **Chat Completions streaming path now uses `OpenStreamWithRetry`** — `predictStreamWithMessages` in `openai.go` delegates through the same retry driver as the Responses API path, so the gpt-4* family gets the same pre-first-chunk retry, budget, and metrics as gpt-5-pro.

## Config

\`\`\`yaml
stream_retry:
  enabled: true
  max_attempts: 2
  budget:
    rate_per_sec: 5    # sustained refill
    burst: 10          # max accumulated tokens
\`\`\`

Only retries consume tokens; the initial attempt of each request is always allowed through. Empty budget = immediate return of the last error (fail fast), not blocking wait — stacking goroutines on a starved bucket would make things worse under load.

## Design notes

- **Struct-form API:** new parameters (budget, host label) would have bloated the positional \`OpenStreamWithRetry\` signature. Introduced \`OpenStreamWithRetryRequest(ctx, *StreamRetryRequest)\` as the full-featured form; the old positional function remains as a thin wrapper for callers that don't need the new parameters. Request struct passed by pointer to avoid gocritic \`hugeParam\` warnings.
- **\`HostFromURL\` helper** in \`runtime/providers\` — generic URL host extraction for Prometheus labels, used by both streaming paths. Empty host on parse error so labeled metrics use \`""\` to mean "unknown host" rather than dropping the sample.
- **Events intentionally omitted.** Phase 2 in the design doc called for \`stream.retry.attempted\` / \`stream.retry.budget_exhausted\` events on the event bus, but the event bus drops events under exactly the load conditions where these matter most (AltairaLabs/PromptKit#853). Direct-update Prometheus metrics carry the same signal and are drop-immune. Events can land as a follow-up after #853.

## Scope deferred to Phase 3

- \`stream_max_concurrent\` semaphore for per-provider concurrent-stream bounds
- Connection pool / \`MaxConnsPerHost\` config exposure

## Tests

- **\`stream_retry_budget_test.go\`** — constructor nil-safety, burst enforcement, token refill, concurrent access under \`-race\`, \`Available()\` for gauge sampling.
- **\`stream_retry_test.go\`** — new integration cases:
  - Exhausted budget fails fast (only 1 server hit, retry blocked)
  - Healthy budget allows retry and decrements tokens
  - Nil budget preserves Phase 1 unbounded behavior (backwards-compat guarantee)
  - \`HostFromURL\` edge cases (valid URLs, malformed inputs, empty)

Coverage on touched files: \`stream_retry_budget.go\` 100%, \`stream_metrics.go\` 97.4%, \`stream_retry_driver.go\` 93.3%.

Schemas regenerated via \`tools/schema-gen\`.

## Test plan

- [x] Unit + integration tests green (\`go test ./runtime/... -race\`)
- [x] \`openai.go\` Chat Completions path smoke-tested via existing openai package tests
- [x] Arena builder wires config cleanly (engine tests pass)
- [ ] CI green on this PR
- [ ] Next scheduled \`Provider Capability Matrix\` run — verify \`promptkit_stream_retry_budget_available\` gauge is populated for gpt5-pro

## Related

- AltairaLabs/PromptKit#855 (Phase 1, merged) — pre-first-chunk retry + direct-update metrics foundation
- AltairaLabs/PromptKit#853 — event bus configurability (blocks event-based retry observability for a later phase)
- Design doc: \`docs/local-backlog/STREAMING_RETRY_AT_SCALE.md\` (local)