### PR TITLE
fix: address Phase 2 code review nits

### DIFF
--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -201,16 +201,14 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 		}
 	}
 
-	// Apply the streaming retry policy and its (optional) budget. The
-	// zero policy is "disabled", so providers that opt in via config get
-	// the new behavior while all others are unchanged. The budget is
-	// applied independently: a provider may have retry enabled without a
-	// budget (unbounded retries) or — perversely — a budget without
-	// retry enabled (the budget is then unused but harmless).
-	if src, ok := provider.(streamRetryConfigurable); ok {
-		if spec.StreamRetry.Enabled {
-			src.SetStreamRetryPolicy(spec.StreamRetry)
-		}
+	// Apply the streaming retry policy and its (optional) budget. Both
+	// are only applied when StreamRetry.Enabled is true — a budget
+	// without retry enabled would be silently ignored at request time,
+	// and allocating one anyway wastes tokens that would never be
+	// consulted. Gating both together makes the configuration
+	// self-consistent.
+	if src, ok := provider.(streamRetryConfigurable); ok && spec.StreamRetry.Enabled {
+		src.SetStreamRetryPolicy(spec.StreamRetry)
 		if spec.StreamRetryBudget != nil {
 			src.SetStreamRetryBudget(spec.StreamRetryBudget)
 		}

--- a/runtime/providers/stream_retry_budget.go
+++ b/runtime/providers/stream_retry_budget.go
@@ -64,9 +64,9 @@ func (b *RetryBudget) TryAcquire() bool {
 
 // Available returns the current number of tokens in the bucket. Intended
 // for the promptkit_stream_retry_budget_available gauge. A nil budget
-// returns math-infinity-ish sentinel: since there is no concept of
-// "available" for unlimited buckets, we return the burst capacity so
-// gauges still report a meaningful finite number.
+// returns 0; callers in the hot path also skip publishing the gauge for
+// nil budgets (see StreamMetrics.ObserveRetryBudgetAvailable), so the
+// return value is only observable in tests.
 //
 // Note: rate.Limiter.Tokens reflects state at the time of the call; it
 // may drift between TryAcquire and Available under concurrent load.

--- a/runtime/providers/stream_retry_budget_test.go
+++ b/runtime/providers/stream_retry_budget_test.go
@@ -156,7 +156,11 @@ func TestRetryBudget_AvailableDecreasesOnAcquire(t *testing.T) {
 		b.TryAcquire()
 	}
 	after := b.Available()
-	if after > initial-4 { // allow some tolerance for refill
-		t.Errorf("Available() after 5 acquires = %v, expected significantly less than %v", after, initial)
+	// At 0.001 tokens/sec the refill during 5 microsecond-scale acquires
+	// is effectively zero, so the decrement should be very close to 5.
+	// Tolerance of 0.1 allows for scheduling jitter without letting a
+	// broken implementation (no decrement) slip through.
+	if delta := initial - after; delta < 4.9 || delta > 5.1 {
+		t.Errorf("Available() after 5 acquires: delta = %v, want ~5 (±0.1)", delta)
 	}
 }

--- a/runtime/providers/stream_retry_driver.go
+++ b/runtime/providers/stream_retry_driver.go
@@ -86,6 +86,9 @@ func OpenStreamWithRetry(
 //
 //nolint:gocognit // Retry loop with classification, backoff, budget, and metric emission
 func OpenStreamWithRetryRequest(ctx context.Context, req *StreamRetryRequest) (*StreamRetryResult, error) {
+	if req == nil {
+		return nil, errors.New("providers: OpenStreamWithRetryRequest called with nil request")
+	}
 	maxAttempts := req.Policy.Attempts()
 	metrics := DefaultStreamMetrics()
 	start := time.Now()


### PR DESCRIPTION
## Summary

Five small cleanups from the code review on #856 (Phase 2 streaming retry budget). All non-functional — no semantic changes to retry behavior.

1. **`RetryBudget.Available()` docstring** now matches the implementation. Old comment described returning "burst capacity" for nil receivers "so gauges still report a meaningful finite number", but the code returns 0. Functionally correct (the gauge publisher also short-circuits on nil budgets), but the comment would have misled future readers.

2. **`OpenStreamWithRetryRequest` nil guard.** The pointer-form parameter exists to sidestep gocritic's `hugeParam` warning, not for any semantic reason. Every in-repo caller passes a literal so the panic path is unreachable today — but a one-line guard is cheap and kills a foot-gun for future callers.

3. **`CreateProviderFromSpec` gates retry policy and budget together.** Previously the budget was applied independently of `StreamRetry.Enabled`, which meant a caller constructing a `ProviderSpec` manually with a budget but no retry policy would allocate a bucket that would never be consulted at request time. Harmless in practice (arena was the only caller and it gated both together) but a silent no-op waiting to cost someone debugging time.

4. **Tightened `TestRetryBudget_AvailableDecreasesOnAcquire` tolerance.** Old check `after > initial-4` would have silently passed a broken implementation that didn't decrement at all. Now asserts delta is within ±0.1 of the expected value.

5. **Design doc clarification (local-only).** `docs/local-backlog/STREAMING_RETRY_AT_SCALE.md` updated to say budget scope is "per provider instance" rather than "per (provider, host)". The two are equivalent for current PromptKit topology but the old wording promised storm isolation that wouldn't hold for a future multi-region provider. Host is still carried as a metric label. Not in this PR since `local-backlog` is gitignored.

## Test plan

- [x] `go test ./runtime/... -race` green
- [x] Pre-commit hook passed (lint, build, coverage: all changed files ≥80%)
- [ ] CI green on this PR

## Related

- AltairaLabs/PromptKit#856 (Phase 2, merged) — the code being cleaned up
- AltairaLabs/PromptKit#855 (Phase 1, merged)