### PR TITLE
feat: concurrency bounds for OpenAI Realtime WebSocket sessions

### DIFF
--- a/runtime/providers/openai/streaming_support_integration.go
+++ b/runtime/providers/openai/streaming_support_integration.go
@@ -4,6 +4,7 @@ package openai
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
@@ -19,6 +20,15 @@ import (
 // Audio Format:
 // OpenAI Realtime API uses 24kHz 16-bit PCM mono audio by default.
 // The session automatically handles base64 encoding/decoding of audio data.
+//
+// Concurrency bounds:
+// If the provider has `stream_max_concurrent` configured, this call will
+// block until a slot is available (respecting the caller's ctx) or return
+// a rejection error recorded on
+// promptkit_stream_concurrency_rejections_total. The slot is released
+// when the session ends — whether via Close() or via the underlying
+// Done() channel (e.g. context cancellation). This makes Realtime
+// sessions subject to the same Phase 3 back-pressure as SSE streams.
 //
 // Example usage:
 //
@@ -39,6 +49,32 @@ func (p *Provider) CreateStreamSession(
 		return nil, err
 	}
 
+	// Acquire a concurrent-stream slot before dialing the WebSocket.
+	// Nil semaphore is a no-op; a saturated semaphore blocks until
+	// the caller's ctx is done, at which point AcquireStreamSlot
+	// emits the rejection metric with the correct reason label.
+	if err := p.AcquireStreamSlot(ctx); err != nil {
+		return nil, fmt.Errorf("failed to acquire stream slot: %w", err)
+	}
+	slotReleased := false
+	defer func() {
+		if !slotReleased {
+			p.ReleaseStreamSlot()
+		}
+	}()
+
+	metrics := providers.DefaultStreamMetrics()
+	providerID := p.ID()
+	metrics.StreamsInFlightInc(providerID)
+	metrics.ProviderCallsInFlightInc(providerID)
+	metricsReleased := false
+	defer func() {
+		if !metricsReleased {
+			metrics.StreamsInFlightDec(providerID)
+			metrics.ProviderCallsInFlightDec(providerID)
+		}
+	}()
+
 	config := p.buildRealtimeSessionConfig(req)
 	p.applyStreamMetadata(req.Metadata, &config)
 	p.applyStreamTools(req.Tools, &config)
@@ -48,5 +84,51 @@ func (p *Provider) CreateStreamSession(
 		return nil, fmt.Errorf("failed to create realtime session: %w", err)
 	}
 
-	return session, nil
+	// Transfer slot and gauge ownership to the bookkeeping wrapper.
+	// The outer defers above are now no-ops on this success path; the
+	// wrapper is responsible for releasing on either session.Close() or
+	// session.Done() firing (whichever comes first).
+	slotReleased = true
+	metricsReleased = true
+
+	wrapper := &realtimeSessionBookkeeping{
+		StreamInputSession: session,
+		release: func() {
+			metrics.StreamsInFlightDec(providerID)
+			metrics.ProviderCallsInFlightDec(providerID)
+			p.ReleaseStreamSlot()
+		},
+	}
+	// A caller that never calls Close() — for example, one whose ctx
+	// is canceled and who then drops the reference — would otherwise
+	// leak the semaphore slot. Watch Done() as a backup so every
+	// session ever created gets its slot back, exactly once.
+	go func() {
+		<-session.Done()
+		wrapper.releaseOnce.Do(wrapper.release)
+	}()
+
+	return wrapper, nil
+}
+
+// realtimeSessionBookkeeping wraps a RealtimeSession with a
+// release-exactly-once callback that decrements the in-flight gauges
+// and returns a slot to the concurrent-stream semaphore. It is
+// transparent to callers: all non-Close methods are promoted from the
+// embedded StreamInputSession interface; only Close is intercepted so
+// the release runs at the first of {explicit Close, session Done}.
+type realtimeSessionBookkeeping struct {
+	providers.StreamInputSession
+	release     func()
+	releaseOnce sync.Once
+}
+
+// Close runs the bookkeeping release (once) and then closes the
+// underlying session. sync.Once ensures the release is idempotent even
+// if Close is called multiple times (which the interface contract
+// explicitly permits) or concurrently with the Done()-watching
+// goroutine started in CreateStreamSession.
+func (s *realtimeSessionBookkeeping) Close() error {
+	s.releaseOnce.Do(s.release)
+	return s.StreamInputSession.Close()
 }

--- a/runtime/providers/openai/streaming_support_test.go
+++ b/runtime/providers/openai/streaming_support_test.go
@@ -1,7 +1,13 @@
 package openai
 
 import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -323,4 +329,236 @@ func TestProvider_applyStreamTools(t *testing.T) {
 func TestProvider_StreamInputSupport_Interface(t *testing.T) {
 	// Verify Provider implements StreamInputSupport
 	var _ providers.StreamInputSupport = (*Provider)(nil)
+}
+
+// --- Realtime concurrency bounds (#862) ---
+//
+// The tests below verify the semaphore + gauge bookkeeping added to
+// CreateStreamSession without hitting a real WebSocket. The semaphore
+// acquire happens BEFORE NewRealtimeSession is called, so we can test
+// the rejection path cleanly by pre-draining a small semaphore and
+// asserting CreateStreamSession fails on acquire.
+//
+// The bookkeeping wrapper (realtimeSessionBookkeeping) is tested
+// directly with a fake StreamInputSession because constructing a real
+// session requires a live WebSocket handshake (covered by the
+// integration-tag tests in realtime_integration_test.go).
+
+// When the concurrent-stream semaphore is pre-drained, CreateStreamSession
+// must return an acquire error before any WebSocket dial. The test uses a
+// short context deadline so the acquire times out quickly rather than
+// blocking forever on a saturated semaphore.
+func TestCreateStreamSession_SemaphoreRejectsBeforeDial(t *testing.T) {
+	p := NewProvider(
+		"openai-realtime-test",
+		"gpt-4o-realtime-preview",
+		"https://api.openai.com",
+		providers.ProviderDefaults{},
+		false,
+	)
+	// Install a size-1 semaphore and drain its only slot.
+	p.SetStreamSemaphore(providers.NewStreamSemaphore(1))
+	if err := p.AcquireStreamSlot(context.Background()); err != nil {
+		t.Fatalf("priming acquire failed: %v", err)
+	}
+	defer p.ReleaseStreamSlot()
+
+	// Short deadline so the saturated acquire inside CreateStreamSession
+	// times out quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	session, err := p.CreateStreamSession(ctx, &providers.StreamingInputConfig{
+		Config: types.StreamingMediaConfig{
+			Type:       types.ContentTypeAudio,
+			SampleRate: 24000,
+			Encoding:   "pcm16",
+			Channels:   1,
+			ChunkSize:  1024,
+		},
+	})
+	if err == nil {
+		_ = session.Close()
+		t.Fatal("expected acquire error on saturated semaphore, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) &&
+		!strings.Contains(err.Error(), "failed to acquire stream slot") {
+		t.Errorf("expected acquire-related error, got %v", err)
+	}
+}
+
+// The nil-semaphore no-op path for CreateStreamSession is covered
+// indirectly: providers.BaseProvider.AcquireStreamSlot has explicit
+// nil-receiver handling tested by
+// TestBaseProvider_AcquireStreamSlot_NilSemaphore in the providers
+// package, and CreateStreamSession calls it unconditionally. We do
+// not add a direct end-to-end test here because the Realtime
+// WebSocket URL is hardcoded inside NewRealtimeWebSocket (does not
+// use Provider.baseURL), so any test that reaches NewRealtimeSession
+// would have to touch real OpenAI infrastructure — fragile for CI.
+
+// --- realtimeSessionBookkeeping wrapper tests ---
+
+// fakeStreamInputSession is a minimal StreamInputSession implementation
+// for unit-testing the bookkeeping wrapper without a live WebSocket.
+// Both Close() and signalDoneExternal() close the shared done channel
+// via a single sync.Once so either path can be called first without
+// panicking on a double close.
+type fakeStreamInputSession struct {
+	done     chan struct{}
+	doneOnce sync.Once
+	closed   atomic.Bool
+	closeErr error
+}
+
+func newFakeStreamSession() *fakeStreamInputSession {
+	return &fakeStreamInputSession{done: make(chan struct{})}
+}
+
+func (f *fakeStreamInputSession) SendChunk(_ context.Context, _ *types.MediaChunk) error {
+	return nil
+}
+
+func (f *fakeStreamInputSession) SendText(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeStreamInputSession) SendSystemContext(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeStreamInputSession) Response() <-chan providers.StreamChunk {
+	return make(chan providers.StreamChunk)
+}
+
+func (f *fakeStreamInputSession) Close() error {
+	f.closed.Store(true)
+	f.doneOnce.Do(func() { close(f.done) })
+	return f.closeErr
+}
+
+func (f *fakeStreamInputSession) Error() error          { return nil }
+func (f *fakeStreamInputSession) Done() <-chan struct{} { return f.done }
+
+// signalDoneExternal simulates the session's done channel closing from
+// its internal lifecycle (e.g. ctx cancellation in the receive loop)
+// without the caller having called Close. Safe to call alongside
+// Close — doneOnce ensures the channel is closed exactly once.
+func (f *fakeStreamInputSession) signalDoneExternal() {
+	f.doneOnce.Do(func() { close(f.done) })
+}
+
+// The wrapper's Close must be idempotent under repeated calls — the
+// StreamInputSession contract explicitly permits multiple Close calls,
+// and the release callback must fire exactly once.
+func TestRealtimeSessionBookkeeping_CloseIsIdempotent(t *testing.T) {
+	fake := newFakeStreamSession()
+	var releases atomic.Int32
+	wrapper := &realtimeSessionBookkeeping{
+		StreamInputSession: fake,
+		release:            func() { releases.Add(1) },
+	}
+
+	// First Close: release fires, fake.Close runs.
+	if err := wrapper.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	// Second Close: release must NOT fire again.
+	if err := wrapper.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+	// Third, for good measure.
+	if err := wrapper.Close(); err != nil {
+		t.Errorf("third Close: %v", err)
+	}
+
+	if got := releases.Load(); got != 1 {
+		t.Errorf("release fired %d times, want exactly 1", got)
+	}
+	if !fake.closed.Load() {
+		t.Error("underlying session was not closed")
+	}
+}
+
+// When a caller forgets to call Close() but the session signals Done()
+// (e.g. because its ctx was cancelled), the release callback must still
+// fire exactly once — via the Done-watching goroutine installed in
+// CreateStreamSession. This guarantees no slot leaks on abandoned
+// sessions.
+//
+// We simulate the goroutine manually here because the wrapper itself
+// doesn't start the watcher; CreateStreamSession does. The test
+// mirrors that goroutine's logic.
+func TestRealtimeSessionBookkeeping_DoneTriggersReleaseExactlyOnce(t *testing.T) {
+	fake := newFakeStreamSession()
+	var releases atomic.Int32
+	wrapper := &realtimeSessionBookkeeping{
+		StreamInputSession: fake,
+		release:            func() { releases.Add(1) },
+	}
+
+	// Simulate the watcher goroutine CreateStreamSession starts.
+	done := make(chan struct{})
+	go func() {
+		<-fake.Done()
+		wrapper.releaseOnce.Do(wrapper.release)
+		close(done)
+	}()
+
+	// Signal Done externally (as if the session's ctx was cancelled).
+	fake.signalDoneExternal()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watcher goroutine did not run after Done signal")
+	}
+
+	// Caller then tries to Close anyway. Release must still only have
+	// fired once total.
+	if err := wrapper.Close(); err != nil {
+		t.Errorf("Close after Done: %v", err)
+	}
+
+	if got := releases.Load(); got != 1 {
+		t.Errorf("release fired %d times, want exactly 1 "+
+			"(Done signal + explicit Close must be idempotent)", got)
+	}
+}
+
+// Concurrent Close and Done-watcher race test — sync.Once must make
+// the release exactly-once even under -race with both paths firing
+// simultaneously.
+func TestRealtimeSessionBookkeeping_ConcurrentCloseAndDone(t *testing.T) {
+	for iter := 0; iter < 100; iter++ {
+		fake := newFakeStreamSession()
+		var releases atomic.Int32
+		wrapper := &realtimeSessionBookkeeping{
+			StreamInputSession: fake,
+			release:            func() { releases.Add(1) },
+		}
+
+		var wg sync.WaitGroup
+
+		// Watcher goroutine.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-fake.Done()
+			wrapper.releaseOnce.Do(wrapper.release)
+		}()
+
+		// Caller goroutine that races the watcher.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = wrapper.Close()
+		}()
+
+		wg.Wait()
+
+		if got := releases.Load(); got != 1 {
+			t.Fatalf("iter %d: release fired %d times, want exactly 1", iter, got)
+		}
+	}
 }


### PR DESCRIPTION
Closes #862. Wires the Phase 3 stream semaphore and in-flight gauges around the OpenAI Realtime session lifecycle, so voice sessions get the same back-pressure guarantees as SSE streams.

## What changed

\`CreateStreamSession\` in \`streaming_support_integration.go\` now:

1. **Acquires a concurrent-stream slot BEFORE dialing the WebSocket.** Nil semaphore is a no-op; saturation blocks on the caller's context. Rejection classifier emits \`promptkit_stream_concurrency_rejections_total\` with the correct reason label (\`context_canceled\` / \`deadline_exceeded\`).
2. **Increments \`streams_in_flight\` and \`provider_calls_in_flight\` gauges** at session start.
3. **Wraps the returned \`RealtimeSession\`** in \`realtimeSessionBookkeeping\`, which intercepts \`Close()\` to run a release-exactly-once callback.
4. **Starts a small goroutine watching \`session.Done()\`** as a backup: if the caller forgets to Close (e.g. ctx canceled and they drop the reference), the Done channel still fires and the watcher runs the same release-exactly-once callback via \`sync.Once\`.

The \`sync.Once\` guarantee is load-bearing: Close() and the Done watcher race in the normal case (Close causes Done to fire), so both paths must share the same Once to guarantee exactly one release per session — not zero (leak) and not two (double-release panic).

## What does NOT apply from the SSE work

Phase 1 retry and Phase 2 retry budget are deliberately omitted for WebSocket. Mid-session reconnect is a genuinely different problem for bidirectional protocols: OpenAI Realtime has no resume token, so reconnect cannot recover conversation state, and the client is holding buffered audio/text that may or may not have been processed. Out of scope for this PR — can be revisited separately if/when it becomes a real need.

The property #862 addresses that DOES apply cleanly: **bounding the number of concurrent Realtime sessions a process will hold open**, so goroutine/timer growth is linear in the configured limit rather than unbounded.

## Tests

Four new unit tests in \`streaming_support_test.go\`, all runnable under normal \`go test\` (no build tag, no network I/O):

1. **\`TestCreateStreamSession_SemaphoreRejectsBeforeDial\`** — pre-drains a size-1 semaphore, asserts \`CreateStreamSession\` fails on acquire with a short ctx deadline, **before any WebSocket dial**. Primary behavior guarantee.
2. **\`TestRealtimeSessionBookkeeping_CloseIsIdempotent\`** — fake session, multiple \`Close()\` calls, assert release fires exactly once.
3. **\`TestRealtimeSessionBookkeeping_DoneTriggersReleaseExactlyOnce\`** — fake session whose Done channel closes externally (simulating ctx cancellation), assert watcher releases and subsequent Close is no-op.
4. **\`TestRealtimeSessionBookkeeping_ConcurrentCloseAndDone\`** — 100 iterations of racing Close and Done-watcher goroutines under \`-race\`, assert exactly one release per iteration.

A \`fakeStreamInputSession\` test helper uses a shared \`doneOnce\` guarding \`close(done)\` so both Close() and the simulated external-signal path can run safely in either order.

## Why no end-to-end test

\`RealtimeSession\` construction requires a live WebSocket handshake against \`wss://api.openai.com\`. \`NewRealtimeWebSocket\` hardcodes the URL (does not use \`Provider.baseURL\`), so any test that constructs a real session from outside the package must touch real OpenAI infrastructure. The existing integration-tagged tests in \`realtime_integration_test.go\` cover that path against real API keys; the new unit tests cover the bookkeeping layer in isolation.

The nil-semaphore no-op path is covered indirectly by \`TestBaseProvider_AcquireStreamSlot_NilSemaphore\` in the providers package (\`BaseProvider.AcquireStreamSlot\` has explicit nil-receiver handling that \`CreateStreamSession\` calls unconditionally).

## Test plan

- [x] All four new tests pass under \`-race\`
- [x] Full openai package test suite still passes
- [x] Pre-commit hook green (lint, build, coverage)
- [ ] CI green

## Related

- #862 (this issue)
- #858 (Phase 3 — the semaphore infrastructure being reused)
- Design doc: \`docs/local-backlog/STREAMING_RETRY_AT_SCALE.md\`