### PR TITLE
feat: pluggable FrameDetector, wire Gemini and Ollama through retry driver

### DIFF
--- a/runtime/providers/frame_detector.go
+++ b/runtime/providers/frame_detector.go
@@ -1,0 +1,347 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// FrameDetector extracts the bytes of the first complete "frame" from a
+// streaming response body. The concept of a frame is protocol-specific —
+// SSE uses `data: ...\n\n` boundaries, NDJSON uses line terminators,
+// Gemini's JSON-array streaming uses balanced-brace JSON objects inside
+// a top-level array.
+//
+// The returned bytes MUST be exactly a prefix of the underlying stream:
+// the detector reads from r, returns everything it has consumed so far,
+// and leaves r positioned immediately after the returned bytes. This is
+// what lets the retry driver wrap the returned bytes + remaining body
+// in a replayReadCloser so downstream parsers see a contiguous stream.
+//
+// Detectors MUST drain any internal bufio lookahead into the returned
+// slice before returning — if they use a bufio.Reader for efficiency,
+// bytes buffered past the frame boundary belong in the replay slice,
+// not stuck in a throwaway bufio buffer.
+//
+// Detectors SHOULD NOT wrap r with an idle-timeout reader themselves;
+// the retry driver applies the caller's StreamIdleTimeout to r before
+// handing it to the detector, so each detector gets uniform idle
+// protection for free.
+type FrameDetector interface {
+	// Name identifies the detector in logs and errors. Should be a
+	// short lowercase token: "sse", "ndjson", "json-array", etc.
+	Name() string
+
+	// PeekFirstFrame reads from r until at least one complete frame has
+	// been seen, then returns the bytes consumed so far. Returns an
+	// error if r fails before a complete frame is found, or if the
+	// stream ends cleanly before any frame has been observed.
+	//
+	// On success, the returned slice is non-empty and r is positioned
+	// immediately after the last returned byte.
+	PeekFirstFrame(r io.Reader) ([]byte, error)
+}
+
+// defaultFrameDetector returns the detector to use when a caller did
+// not specify one on StreamRetryRequest. SSE is the most common
+// streaming format across providers, so it's the default.
+func defaultFrameDetector() FrameDetector { return SSEFrameDetector{} }
+
+// --- SSE ---
+
+// SSEFrameDetector detects server-sent event boundaries. A complete
+// frame is one or more `data: ...` lines terminated by a blank line,
+// optionally preceded by `:` comments or other SSE directive lines
+// that get passed through as part of the frame bytes.
+//
+// This is the framing used by OpenAI Chat Completions, OpenAI Responses
+// API, Claude Messages, VLLM, and most SSE-based LLM providers.
+type SSEFrameDetector struct{}
+
+// Name implements FrameDetector.
+func (SSEFrameDetector) Name() string { return "sse" }
+
+// PeekFirstFrame reads until a `data: ...` line has been seen and then
+// a terminating blank line. Comments and other directives before the
+// first data line are included in the returned bytes.
+//
+// If the stream closes cleanly right after the first event without a
+// trailing blank line, this is still treated as a complete frame so
+// downstream can decide what to do.
+func (SSEFrameDetector) PeekFirstFrame(r io.Reader) ([]byte, error) {
+	br := bufio.NewReader(r)
+	var buf bytes.Buffer
+	sawData := false
+	for {
+		line, err := br.ReadString('\n')
+		if line != "" {
+			buf.WriteString(line)
+			if done, drainErr := processSSELine(br, &buf, line, &sawData); done {
+				return buf.Bytes(), drainErr
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) && buf.Len() > 0 && sawData {
+				return buf.Bytes(), nil
+			}
+			return nil, err
+		}
+	}
+}
+
+// processSSELine classifies a single SSE framing line and, when the end
+// of the first event is reached, drains any lookahead the bufio.Reader
+// has pre-buffered so downstream reads resume contiguously. Returns
+// done=true exactly when the first event boundary has been observed.
+func processSSELine(br *bufio.Reader, buf *bytes.Buffer, line string, sawData *bool) (done bool, err error) {
+	trimmed := strings.TrimRight(line, "\r\n")
+	if strings.HasPrefix(trimmed, "data: ") || trimmed == "data:" {
+		*sawData = true
+		return false, nil
+	}
+	if trimmed == "" && *sawData {
+		// Blank line after a data: line terminates the event. Drain
+		// any bytes bufio has read past our boundary into the replay
+		// buffer so downstream sees a contiguous stream.
+		if drainErr := drainBufferedInto(br, buf); drainErr != nil {
+			return true, drainErr
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// --- NDJSON ---
+
+// NDJSONFrameDetector detects newline-delimited JSON frames. Each frame
+// is one complete JSON object terminated by a literal `\n`. This is
+// the framing used by Ollama's streaming API (`{"response":"..."}\n`)
+// and several other non-SSE providers that stream raw JSON.
+//
+// This detector does NOT validate that the line is parseable JSON —
+// it only looks for the line terminator. Upstream producers that
+// emit partial JSON would fail at the downstream parser, not here.
+// This matches the SSE detector's behavior of not interpreting the
+// payload.
+type NDJSONFrameDetector struct{}
+
+// Name implements FrameDetector.
+func (NDJSONFrameDetector) Name() string { return "ndjson" }
+
+// PeekFirstFrame reads until the first `\n` and returns the line
+// (including the newline) plus any bufio lookahead. Blank lines are
+// skipped so leading whitespace or keepalive newlines from certain
+// producers don't count as a "frame".
+//
+//nolint:gocognit // Line reader with blank-skip + EOF fallback
+func (NDJSONFrameDetector) PeekFirstFrame(r io.Reader) ([]byte, error) {
+	br := bufio.NewReader(r)
+	var buf bytes.Buffer
+	for {
+		line, err := br.ReadString('\n')
+		if line != "" {
+			buf.WriteString(line)
+			// A "frame" in NDJSON is a non-empty line terminated by \n.
+			// Blank or whitespace-only lines are treated as keepalives
+			// (loosely — the JSON RFC doesn't permit them but some
+			// producers emit them) and we keep reading until we find
+			// a real frame.
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" {
+				if drainErr := drainBufferedInto(br, &buf); drainErr != nil {
+					return nil, drainErr
+				}
+				return buf.Bytes(), nil
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) && buf.Len() > 0 {
+				// Last line without trailing \n — treat as a complete
+				// frame if it has any content.
+				trimmed := strings.TrimSpace(buf.String())
+				if trimmed != "" {
+					return buf.Bytes(), nil
+				}
+			}
+			return nil, err
+		}
+	}
+}
+
+// --- JSON array ---
+
+// JSONArrayFrameDetector detects the first complete top-level object
+// inside a streaming JSON array. This is the framing used by Gemini's
+// `streamGenerateContent` endpoint, which returns
+//
+//	[
+//	  {"candidates": [...], "usageMetadata": {...}},
+//	  {"candidates": [...], "usageMetadata": {...}},
+//	  ...
+//	]
+//
+// parsed incrementally by a downstream `json.Decoder`. The detector
+// reads past leading whitespace and the opening `[`, then scans bytes
+// until it finds the end of the first `{...}` at depth 0 (respecting
+// JSON string escapes).
+//
+// Byte-level parsing is deliberate — a `json.Decoder` would work but
+// it buffers aggressively and makes it harder to track exactly how
+// many bytes have been consumed from the underlying reader.
+//
+// On success the returned bytes form a prefix of the stream ending at
+// the closing brace of the first object. The downstream `json.Decoder`
+// continues from there and expects either `,` or `]` next, which is
+// exactly what remains in the stream.
+type JSONArrayFrameDetector struct{}
+
+// Name implements FrameDetector.
+func (JSONArrayFrameDetector) Name() string { return "json-array" }
+
+// PeekFirstFrame reads bytes from r tracking JSON state until the
+// first top-level object inside the array is complete.
+func (JSONArrayFrameDetector) PeekFirstFrame(r io.Reader) ([]byte, error) {
+	br := bufio.NewReader(r)
+	var buf bytes.Buffer
+
+	// Phase 1: skip leading whitespace and consume the opening `[`.
+	if err := consumeJSONArrayOpen(br, &buf); err != nil {
+		return nil, err
+	}
+
+	// Phase 2: scan until we've read a complete object at depth 0.
+	if err := consumeFirstObject(br, &buf); err != nil {
+		return nil, err
+	}
+
+	// Phase 3: drain any bufio lookahead into the replay slice.
+	if err := drainBufferedInto(br, &buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// consumeJSONArrayOpen skips whitespace and reads the opening `[` into
+// buf. Returns an error if the stream does not start with a valid
+// array prefix.
+func consumeJSONArrayOpen(br *bufio.Reader, buf *bytes.Buffer) error {
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			return fmt.Errorf("reading JSON array open: %w", err)
+		}
+		buf.WriteByte(b)
+		if b == '[' {
+			return nil
+		}
+		if !isJSONWhitespace(b) {
+			return fmt.Errorf("expected '[' at start of JSON array, got %q", b)
+		}
+	}
+}
+
+// consumeFirstObject reads bytes into buf until a complete `{...}` at
+// brace depth 0 has been seen, respecting JSON string literals and
+// escapes. Leading whitespace between `[` and the first `{` is
+// consumed. Returns an error on EOF before the object is complete, or
+// on a non-whitespace/non-brace byte before the object opens.
+//
+//nolint:gocognit // JSON byte-level state machine tracks string/escape/depth/started dimensions
+func consumeFirstObject(br *bufio.Reader, buf *bytes.Buffer) error {
+	depth := 0
+	inString := false
+	escaped := false
+	started := false
+
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			return fmt.Errorf("reading JSON array element: %w", err)
+		}
+		buf.WriteByte(b)
+
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch b {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		// Once we've entered an object (depth > 0), any character
+		// except a string delimiter or a matching brace is just a
+		// payload byte we pass through. Nested arrays, nested
+		// objects, and JSON primitives all fall into this bucket.
+		if started && depth > 0 {
+			switch b {
+			case '"':
+				inString = true
+			case '{':
+				depth++
+			case '}':
+				depth--
+				if depth == 0 {
+					return nil
+				}
+			}
+			continue
+		}
+
+		// At depth 0 (haven't opened the first object yet): only
+		// whitespace, commas, a closing `]` for an empty array, or
+		// the opening `{` of the first object are valid. Anything
+		// else is malformed.
+		switch b {
+		case '{':
+			depth++
+			started = true
+		case ']':
+			// Empty array — no frames available. Return EOF so
+			// classifyStreamAttempt treats the stream as a terminal
+			// failure (no content to forward downstream).
+			return io.EOF
+		default:
+			if !isJSONWhitespace(b) && b != ',' {
+				return fmt.Errorf("unexpected %q before object opened", b)
+			}
+		}
+	}
+}
+
+// isJSONWhitespace reports whether b is a JSON insignificant
+// whitespace character (RFC 8259 §2).
+func isJSONWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// --- Shared helpers ---
+
+// drainBufferedInto copies any bytes sitting in the bufio.Reader's
+// internal buffer (but not yet surfaced to callers) into dst, then
+// advances the bufio.Reader past them. Used by every frame detector
+// to transfer pre-read lookahead bytes into the replay slice so
+// downstream reads resume contiguously from the underlying stream.
+func drainBufferedInto(br *bufio.Reader, dst *bytes.Buffer) error {
+	n := br.Buffered()
+	if n == 0 {
+		return nil
+	}
+	remaining, peekErr := br.Peek(n)
+	if peekErr != nil {
+		return peekErr
+	}
+	dst.Write(remaining)
+	if _, discardErr := br.Discard(n); discardErr != nil {
+		return discardErr
+	}
+	return nil
+}

--- a/runtime/providers/frame_detector_test.go
+++ b/runtime/providers/frame_detector_test.go
@@ -1,0 +1,232 @@
+package providers
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// --- NDJSON ---
+
+func TestNDJSONFrameDetector_SingleLine(t *testing.T) {
+	t.Parallel()
+	input := `{"response":"hello"}` + "\n"
+	got, err := (NDJSONFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != input {
+		t.Errorf("peeked %q, want %q", string(got), input)
+	}
+}
+
+func TestNDJSONFrameDetector_MultipleLines(t *testing.T) {
+	t.Parallel()
+	// The detector should return the first complete line. The returned
+	// bytes may include bufio lookahead (more lines drained into the
+	// replay slice) but must begin with the first line.
+	input := `{"response":"a"}` + "\n" + `{"response":"b"}` + "\n" + `{"response":"c"}` + "\n"
+	got, err := (NDJSONFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(string(got), `{"response":"a"}`+"\n") {
+		t.Fatalf("peeked %q must begin with the first line", string(got))
+	}
+	if !strings.Contains(input, string(got)) {
+		t.Fatalf("peeked bytes must be a prefix of the input stream")
+	}
+}
+
+func TestNDJSONFrameDetector_SkipsBlankLines(t *testing.T) {
+	t.Parallel()
+	// Some producers emit blank lines as keepalives — these are not
+	// "frames" and the detector must keep reading until it finds a
+	// real JSON line.
+	input := "\n\n" + `{"response":"hi"}` + "\n"
+	got, err := (NDJSONFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), `{"response":"hi"}`) {
+		t.Errorf("peeked bytes %q must include the real content line", string(got))
+	}
+}
+
+func TestNDJSONFrameDetector_EOFAfterFirstLineNoNewline(t *testing.T) {
+	t.Parallel()
+	// Last line without trailing newline — should still be treated as a
+	// complete frame when EOF is reached.
+	input := `{"response":"no newline"}`
+	got, err := (NDJSONFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != input {
+		t.Errorf("peeked %q, want %q", string(got), input)
+	}
+}
+
+func TestNDJSONFrameDetector_EmptyStream(t *testing.T) {
+	t.Parallel()
+	_, err := (NDJSONFrameDetector{}).PeekFirstFrame(strings.NewReader(""))
+	if err == nil {
+		t.Fatal("empty stream should return an error")
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestNDJSONFrameDetector_Name(t *testing.T) {
+	t.Parallel()
+	if got := (NDJSONFrameDetector{}).Name(); got != "ndjson" {
+		t.Errorf("Name() = %q, want %q", got, "ndjson")
+	}
+}
+
+// --- JSON array ---
+
+func TestJSONArrayFrameDetector_SimpleObject(t *testing.T) {
+	t.Parallel()
+	input := `[{"candidates":[]}]`
+	got, err := (JSONArrayFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Detector should return everything up through the closing `}` of
+	// the first element. The closing `]` may or may not be in the
+	// returned bytes depending on bufio lookahead.
+	if !strings.HasPrefix(string(got), `[{"candidates":[]}`) {
+		t.Errorf("peeked %q must include the first object", string(got))
+	}
+}
+
+func TestJSONArrayFrameDetector_NestedObjects(t *testing.T) {
+	t.Parallel()
+	// Balanced-brace tracking must handle nested objects correctly.
+	input := `[{"a":{"b":{"c":1}},"d":2},{"next":true}]`
+	got, err := (JSONArrayFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// First element ends at the `}` matching the outermost `{` of the
+	// first element, which is at position 25: `[{"a":{"b":{"c":1}},"d":2}`
+	want := `[{"a":{"b":{"c":1}},"d":2}`
+	if !strings.HasPrefix(string(got), want) {
+		t.Errorf("peeked %q must begin with %q", string(got), want)
+	}
+}
+
+func TestJSONArrayFrameDetector_StringWithEscapedQuotes(t *testing.T) {
+	t.Parallel()
+	// An escaped quote inside a string must NOT terminate the string —
+	// the detector's string-state tracking must respect `\` escapes.
+	input := `[{"text":"he said \"hi\" then {stopped}"},"next"]`
+	got, err := (JSONArrayFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := `[{"text":"he said \"hi\" then {stopped}"}`
+	if !strings.HasPrefix(string(got), want) {
+		t.Errorf("peeked %q must begin with %q", string(got), want)
+	}
+}
+
+func TestJSONArrayFrameDetector_BracesInsideStrings(t *testing.T) {
+	t.Parallel()
+	// Braces inside JSON strings must not affect depth tracking.
+	input := `[{"msg":"{not a brace}{also not}"},"next"]`
+	got, err := (JSONArrayFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := `[{"msg":"{not a brace}{also not}"}`
+	if !strings.HasPrefix(string(got), want) {
+		t.Errorf("peeked %q must begin with %q", string(got), want)
+	}
+}
+
+func TestJSONArrayFrameDetector_LeadingWhitespace(t *testing.T) {
+	t.Parallel()
+	// Whitespace before the opening `[` and between `[` and the first
+	// `{` must be tolerated — JSON producers may pretty-print or emit
+	// newlines between elements.
+	input := "  \n  [\n  {\"first\":1},\n  {\"second\":2}\n]"
+	got, err := (JSONArrayFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The returned bytes must include `{"first":1}` — preserve exact
+	// whitespace from the input as a prefix.
+	if !strings.Contains(string(got), `{"first":1}`) {
+		t.Errorf("peeked %q must include the first object", string(got))
+	}
+}
+
+func TestJSONArrayFrameDetector_EmptyArray(t *testing.T) {
+	t.Parallel()
+	// An empty `[]` has no frames — detector should return io.EOF so
+	// classifyStreamAttempt treats it as a terminal failure.
+	input := `[]`
+	_, err := (JSONArrayFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("empty array should return an error")
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestJSONArrayFrameDetector_MissingOpenBracket(t *testing.T) {
+	t.Parallel()
+	// A stream that doesn't start with an array is an error, not a
+	// retryable transient — the caller's parser would also fail.
+	input := `{"not":"an array"}`
+	_, err := (JSONArrayFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("missing `[` should return an error")
+	}
+	if !strings.Contains(err.Error(), "expected '['") {
+		t.Errorf("expected '[' error, got %v", err)
+	}
+}
+
+func TestJSONArrayFrameDetector_StopsAtBoundary(t *testing.T) {
+	t.Parallel()
+	// With a byte-at-a-time source, the detector should consume exactly
+	// the bytes of the first object — no more, no less. Any over-read
+	// would indicate the byte-level scanner is consuming from the
+	// underlying reader past the object boundary.
+	slow := &byteReader{data: []byte(`[{"x":1},{"y":2}]`)}
+	got, err := (JSONArrayFrameDetector{}).PeekFirstFrame(slow)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With a byte-at-a-time reader, bufio cannot pre-buffer beyond
+	// our last ReadByte() call, so the returned bytes must be exactly
+	// `[{"x":1}`.
+	if string(got) != `[{"x":1}` {
+		t.Errorf("peeked %q, want exactly `[{\"x\":1}` (no over-read)", string(got))
+	}
+}
+
+func TestJSONArrayFrameDetector_Name(t *testing.T) {
+	t.Parallel()
+	if got := (JSONArrayFrameDetector{}).Name(); got != "json-array" {
+		t.Errorf("Name() = %q, want %q", got, "json-array")
+	}
+}
+
+// --- Interface compliance checks ---
+
+func TestFrameDetector_InterfaceCompliance(t *testing.T) {
+	t.Parallel()
+	// Compile-time check that each concrete type implements the
+	// interface. A failure here would fail the build, not the test,
+	// but having them listed as assertions documents the intent.
+	var _ FrameDetector = SSEFrameDetector{}
+	var _ FrameDetector = NDJSONFrameDetector{}
+	var _ FrameDetector = JSONArrayFrameDetector{}
+}

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -40,30 +40,32 @@ func (p *Provider) PredictStream(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Make HTTP request
+	// Gemini's streamGenerateContent endpoint returns a JSON array
+	// ([{...},{...},...]) parsed incrementally by json.Decoder in
+	// streamResponse. The retry driver's JSONArrayFrameDetector reads
+	// past the opening '[' and the first complete element so
+	// peekFirstFrame can confirm the stream is "live" before handing
+	// ownership to the consumer goroutine.
 	url := fmt.Sprintf("%s/models/%s:streamGenerateContent?key=%s", p.baseURL, p.model, p.apiKey)
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	requestFn := func(ctx context.Context) (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		return httpReq, nil
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	//nolint:bodyclose // body is closed in streamResponse goroutine
-	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-
-	if err := providers.CheckHTTPError(resp, logger.RedactSensitiveData(url)); err != nil {
-		return nil, err
-	}
-
-	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-
-	go p.streamResponse(ctx, resp.Body, outChan)
-
-	return outChan, nil
+	return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+		Policy:        p.StreamRetryPolicy(),
+		Budget:        p.StreamRetryBudget(),
+		ProviderName:  p.ID(),
+		Host:          providers.HostFromURL(url),
+		IdleTimeout:   p.StreamIdleTimeout(),
+		RequestFn:     requestFn,
+		Client:        p.GetStreamingHTTPClient(),
+		FrameDetector: providers.JSONArrayFrameDetector{},
+	}, p.streamResponse)
 }
 
 // processGeminiStreamChunk processes a single chunk from the Gemini stream

--- a/runtime/providers/ollama/ollama.go
+++ b/runtime/providers/ollama/ollama.go
@@ -629,31 +629,30 @@ func (p *Provider) predictStreamWithMessages(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Make HTTP request - Ollama doesn't require Authorization header
+	// Ollama in PromptKit uses the OpenAI-compatible
+	// /v1/chat/completions endpoint which speaks SSE, so the default
+	// FrameDetector (SSE) applies — no override needed.
 	url := p.baseURL + ollamaChatCompletionsPath
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	requestFn := func(ctx context.Context) (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		httpReq.Header.Set("Accept", "text/event-stream")
+		// Ollama doesn't require Authorization header.
+		return httpReq, nil
 	}
 
-	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-	httpReq.Header.Set("Accept", "text/event-stream")
-
-	//nolint:bodyclose // body is closed in streamResponse goroutine
-	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-
-	if err := providers.CheckHTTPError(resp, url); err != nil {
-		return nil, err
-	}
-
-	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-
-	go p.streamResponse(ctx, resp.Body, outChan)
-
-	return outChan, nil
+	return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+		Policy:       p.StreamRetryPolicy(),
+		Budget:       p.StreamRetryBudget(),
+		ProviderName: p.ID(),
+		Host:         providers.HostFromURL(url),
+		IdleTimeout:  p.StreamIdleTimeout(),
+		RequestFn:    requestFn,
+		Client:       p.GetStreamingHTTPClient(),
+	}, p.streamResponse)
 }
 
 // SupportsStreaming is provided by BaseProvider (returns true)

--- a/runtime/providers/stream_retry_driver.go
+++ b/runtime/providers/stream_retry_driver.go
@@ -1,14 +1,12 @@
 package providers
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
@@ -42,6 +40,13 @@ type StreamRetryRequest struct {
 	IdleTimeout  time.Duration
 	RequestFn    func(ctx context.Context) (*http.Request, error)
 	Client       *http.Client
+	// FrameDetector identifies the first complete protocol frame on
+	// the response body so the retry driver knows when the stream is
+	// "established" and retry must not fire. Nil defaults to
+	// SSEFrameDetector — set to NDJSONFrameDetector for Ollama,
+	// JSONArrayFrameDetector for Gemini, or any custom FrameDetector
+	// implementation for new protocols.
+	FrameDetector FrameDetector
 }
 
 // OpenStreamWithRetry executes requestFn and peeks the first SSE data event
@@ -111,7 +116,7 @@ func OpenStreamWithRetryRequest(ctx context.Context, req *StreamRetryRequest) (*
 		}
 
 		resp, doErr := req.Client.Do(httpReq)
-		result, retry, classifyErr := classifyStreamAttempt(resp, doErr, req.IdleTimeout)
+		result, retry, classifyErr := classifyStreamAttempt(resp, doErr, req.IdleTimeout, req.FrameDetector)
 		if result != nil {
 			result.Attempts = attempt + 1
 			metrics.ObserveFirstChunkLatency(req.ProviderName, time.Since(start))
@@ -172,13 +177,15 @@ func OpenStreamWithRetryRequest(ctx context.Context, req *StreamRetryRequest) (*
 // whether the attempt was a success (return non-nil result), a retryable
 // failure (return retry=true), or a terminal failure.
 //
-// On success, the response body is wrapped so the peeked first SSE event
-// is replayed to downstream consumers. On any non-terminal failure the
-// body is closed before returning so connections are not leaked.
+// On success, the response body is wrapped so the peeked first frame
+// (SSE event, NDJSON line, JSON-array element, ...) is replayed to
+// downstream consumers. On any non-terminal failure the body is closed
+// before returning so connections are not leaked.
 func classifyStreamAttempt(
 	resp *http.Response,
 	doErr error,
 	idleTimeout time.Duration,
+	detector FrameDetector,
 ) (result *StreamRetryResult, retry bool, err error) {
 	if doErr != nil {
 		return nil, IsRetryableStreamError(doErr), doErr
@@ -195,10 +202,22 @@ func classifyStreamAttempt(
 		return nil, IsRetryableStreamStatus(resp.StatusCode), httpErr
 	}
 
-	// Peek the first SSE data event. If this fails we treat it as a
+	// Wrap the response body with an idle-timeout reader for the peek
+	// phase so stalled connections don't block here indefinitely. The
+	// NopCloser prevents the IdleTimeoutReader from closing the body
+	// when it goes out of scope — the consumer owns the body's close.
+	var peekReader io.Reader = resp.Body
+	if idleTimeout > 0 {
+		peekReader = NewIdleTimeoutReader(io.NopCloser(resp.Body), idleTimeout)
+	}
+
+	// Peek the first protocol frame. If this fails we treat it as a
 	// retryable mid-stream error because by definition no content has
 	// been surfaced to the caller.
-	buffered, peekErr := peekFirstSSEEvent(resp.Body, idleTimeout)
+	if detector == nil {
+		detector = defaultFrameDetector()
+	}
+	buffered, peekErr := detector.PeekFirstFrame(peekReader)
 	if peekErr != nil {
 		_ = resp.Body.Close()
 		return nil, IsRetryableStreamError(peekErr), peekErr
@@ -209,93 +228,6 @@ func classifyStreamAttempt(
 		rest:   resp.Body,
 	}
 	return &StreamRetryResult{Response: resp, Body: wrapped}, false, nil
-}
-
-// peekFirstSSEEvent reads from r until it has seen at least one complete
-// SSE data event terminated by a blank line, then returns the bytes read.
-// The returned slice contains exactly what was consumed from r, suitable
-// for replay via a composite reader.
-//
-// The read is bounded by idleTimeout using an IdleTimeoutReader, so a
-// stalled connection does not block this function indefinitely. A zero
-// idleTimeout disables the idle guard (inherit caller deadline only).
-//
-// This function does not interpret the SSE payload — it only looks for
-// the structural framing ("data: ..." line followed by a blank line) that
-// all SSE producers emit. This is deliberately more forgiving than
-// bufio.Scanner to handle provider-specific keepalives and comments.
-func peekFirstSSEEvent(body io.Reader, idleTimeout time.Duration) ([]byte, error) {
-	reader := body
-	if idleTimeout > 0 {
-		reader = NewIdleTimeoutReader(io.NopCloser(body), idleTimeout)
-	}
-	br := bufio.NewReader(reader)
-	var buf bytes.Buffer
-	sawData := false
-	for {
-		line, err := br.ReadString('\n')
-		if line != "" {
-			buf.WriteString(line)
-			if done, drainErr := processSSELine(br, &buf, line, &sawData); done {
-				return buf.Bytes(), drainErr
-			}
-		}
-		if err != nil {
-			if errors.Is(err, io.EOF) && buf.Len() > 0 && sawData {
-				// Stream closed cleanly right after the first event
-				// with no trailing blank line. Treat as a complete
-				// peek so downstream can decide what to do.
-				return buf.Bytes(), nil
-			}
-			return nil, err
-		}
-	}
-}
-
-// processSSELine classifies a single SSE framing line and, when the end of
-// the first event is reached, drains any lookahead the bufio.Reader has
-// pre-buffered so downstream reads resume contiguously. Returns done=true
-// exactly when the first event boundary has been observed.
-func processSSELine(br *bufio.Reader, buf *bytes.Buffer, line string, sawData *bool) (done bool, err error) {
-	trimmed := strings.TrimRight(line, "\r\n")
-	if strings.HasPrefix(trimmed, "data: ") || trimmed == "data:" {
-		*sawData = true
-		return false, nil
-	}
-	if trimmed == "" && *sawData {
-		// Blank line after a data: line terminates the event.
-		// bufio.Reader may have already read ahead past our boundary;
-		// drain those bytes into the replay slice so downstream
-		// readers see a contiguous stream.
-		if drainErr := drainBufferedInto(br, buf); drainErr != nil {
-			return true, drainErr
-		}
-		return true, nil
-	}
-	return false, nil
-}
-
-// drainBufferedInto copies any bytes sitting in the bufio.Reader's internal
-// buffer (but not yet surfaced to callers) into dst. This is needed because
-// bufio.Reader reads ahead from the underlying source, so bytes that arrived
-// after our peek boundary would otherwise be silently lost when we stop
-// using the bufio.Reader and read from the underlying source directly.
-func drainBufferedInto(br *bufio.Reader, dst *bytes.Buffer) error {
-	n := br.Buffered()
-	if n == 0 {
-		return nil
-	}
-	remaining, peekErr := br.Peek(n)
-	if peekErr != nil {
-		return peekErr
-	}
-	dst.Write(remaining)
-	// Discard the bytes from the bufio reader so the underlying source
-	// is logically at the same position as the end of our buffer.
-	if _, discardErr := br.Discard(n); discardErr != nil {
-		return discardErr
-	}
-	return nil
 }
 
 // replayReadCloser concatenates a bytes.Reader holding already-consumed

--- a/runtime/providers/stream_retry_test.go
+++ b/runtime/providers/stream_retry_test.go
@@ -170,7 +170,7 @@ func TestIsRetryableStreamStatus(t *testing.T) {
 func TestPeekFirstSSEEvent_ContainsFirstEvent(t *testing.T) {
 	t.Parallel()
 	input := "data: hello\n\ndata: world\n\n"
-	got, err := peekFirstSSEEvent(strings.NewReader(input), 0)
+	got, err := (SSEFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestPeekFirstSSEEvent_WithComments(t *testing.T) {
 	// SSE comments (: lines) and keepalives must pass through to the peek
 	// buffer so replay produces byte-identical output for downstream parsers.
 	input := ": keepalive\ndata: first\n\ndata: second\n\n"
-	got, err := peekFirstSSEEvent(strings.NewReader(input), 0)
+	got, err := (SSEFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestPeekFirstSSEEvent_StopsAtBoundary(t *testing.T) {
 	// A source that yields one byte per Read. bufio cannot pre-buffer
 	// ahead of our manual reads beyond the requested size.
 	slow := &byteReader{data: []byte("data: hello\n\ndata: world\n\n")}
-	got, err := peekFirstSSEEvent(slow, 0)
+	got, err := (SSEFrameDetector{}).PeekFirstFrame(slow)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestPeekFirstSSEEvent_EOFAfterFirstEvent(t *testing.T) {
 	// Stream closes right after the first event with no trailing blank
 	// line — should still be treated as a successful peek.
 	input := "data: only\n"
-	got, err := peekFirstSSEEvent(strings.NewReader(input), 0)
+	got, err := (SSEFrameDetector{}).PeekFirstFrame(strings.NewReader(input))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestPeekFirstSSEEvent_EOFAfterFirstEvent(t *testing.T) {
 
 func TestPeekFirstSSEEvent_EmptyStream(t *testing.T) {
 	t.Parallel()
-	_, err := peekFirstSSEEvent(strings.NewReader(""), 0)
+	_, err := (SSEFrameDetector{}).PeekFirstFrame(strings.NewReader(""))
 	if err == nil {
 		t.Fatal("empty stream should return an error")
 	}


### PR DESCRIPTION
Closes #861. Partial fix for #860 (the Gemini portion that was blocked on #861).

## The refactor

Introduces a \`FrameDetector\` interface that abstracts the "what counts as the first complete protocol frame" decision the retry driver needs before it can declare a stream live and disarm retry. Three concrete implementations:

- **\`SSEFrameDetector\`** — \`data: ...\\n\\n\` boundaries. Default. Used by OpenAI Chat Completions, OpenAI Responses API, Claude, VLLM, and Ollama's OpenAI-compatible endpoint.
- **\`NDJSONFrameDetector\`** — one complete JSON object per line terminated by \`\\n\`. Not currently used by any in-tree provider; kept as a reusable abstraction for future native-NDJSON providers.
- **\`JSONArrayFrameDetector\`** — a complete top-level object inside a streaming JSON array. **Used by Gemini** — its \`streamGenerateContent\` endpoint returns \`[{...},{...},...]\` parsed incrementally by \`json.Decoder\` on the consumer side.

\`StreamRetryRequest\` gains an optional \`FrameDetector\` field; nil defaults to SSE so every existing caller is backwards-compatible.

## Byte-level JSON scanner (the tricky one)

\`JSONArrayFrameDetector\` does byte-level parsing rather than using \`json.Decoder\` because the decoder buffers aggressively and replay semantics require exact byte-tracking. The scanner tracks four state dimensions: string state, escape state, brace depth, and a "started" flag.

**Key subtlety**: square brackets inside objects are pass-through bytes. Nested arrays are common in Gemini responses (\`candidates[]\`, \`parts[]\`, \`safetyRatings[]\`) and must not affect depth tracking. A unit test caught this exact bug during development — \`[{"candidates":[]}]\` initially failed with "unexpected ']' inside object" because the first version tracked only brace depth.

## Providers wired

- **Gemini** (\`gemini_streaming.go\`) now delegates to \`BaseProvider.RunStreamingRequest\` with \`FrameDetector: providers.JSONArrayFrameDetector{}\`. Phase 1 retry, Phase 2 budget, Phase 3 semaphore all now apply to Gemini.
- **Ollama** (\`ollama.go\`) delegates to \`RunStreamingRequest\` with the default SSE detector (no override). Ollama in PromptKit uses the OpenAI-compatible \`/v1/chat/completions\` endpoint with SSE framing, not its native \`/api/chat\` NDJSON endpoint. If we ever add native NDJSON support, \`NDJSONFrameDetector\` is ready.

## Tests

**19 new unit tests** across \`frame_detector_test.go\` covering all three detectors. The \`JSONArrayFrameDetector\` suite covers:
- Simple object, nested objects (where the bug was caught)
- Escaped quotes in strings (\`{"text":"he said \\"hi\\" then {stopped}"}\`)
- Braces inside strings (\`{"msg":"{not a brace}"}\`)
- Leading whitespace, empty array (returns \`io.EOF\`), missing \`[\` (returns parse error)
- Byte-boundary enforcement under a byte-at-a-time reader (proves the scanner doesn't over-read)
- \`Name()\` method for each detector
- Compile-time interface compliance assertions

All pass under \`-race\`.

## End-to-end validation

Ran \`promptarena\` against **real Gemini** (\`gemini-20-flash-lite\`) with the refactored code: streaming scenario passed both assertions on the first attempt. This is the first time any streaming retry infrastructure has successfully parsed real Gemini JSON-array framing end-to-end.

## Coverage

- \`frame_detector.go\`: 88.3%
- \`gemini_streaming.go\`: 94.6%
- \`ollama.go\`: 89.9%
- \`stream_retry_driver.go\`: 93.5%

## Test plan

- [x] \`go test ./runtime/... -race\` green (including 35s Gemini suite)
- [x] Real Gemini end-to-end via \`promptarena run --provider gemini-20-flash-lite --scenario streaming\`
- [x] Pre-commit hook green (lint, build, coverage)
- [ ] CI green

## Related

- #861 (this issue — closed)
- #860 (Gemini portion closed by this PR)
- #865 (Bedrock eventstream — can now extend the \`FrameDetector\` abstraction once the binary-framing parser is written)
- #855, #856, #858 (the Phase 1-3 foundations being reused)