### PR TITLE
test(loadtest): scale ramp validation for stream retry stack

### DIFF
--- a/runtime/providers/openai/stream_retry_loadtest_test.go
+++ b/runtime/providers/openai/stream_retry_loadtest_test.go
@@ -856,6 +856,96 @@ func TestStreamRetryLoad_ScaleRamp(t *testing.T) {
 	t.Log("")
 }
 
+// TestStreamRetryLoad_PushToDestruction is a deliberate "how hard can
+// this go before it breaks" probe. Unlike the bounded ScaleRamp test
+// it does not fail on errors — it keeps running and reports whatever
+// the stack produced. Each tier is hard-capped at 60 seconds wall
+// time; if a tier exceeds that or produces any failures, the test
+// logs the result and stops at that tier.
+//
+// Run with:
+//
+//	go test -tags=loadtest -timeout=30m -v -run TestStreamRetryLoad_PushToDestruction ./runtime/providers/openai/
+func TestStreamRetryLoad_PushToDestruction(t *testing.T) {
+	// Progressively harder tiers. Stop as soon as one fails or times
+	// out so we don't waste minutes on a wedged tier.
+	// Tiers chosen to bracket observed stack behavior:
+	//   5k–50k   — past the ScaleRamp ceiling, exercises real goroutine pressure
+	//   100k–300k — single-process headroom; all observed clean in empirical runs
+	//
+	// 500k was measured as the first tier that produced failures in the
+	// harness, but those failures are the 10-second per-request context
+	// deadline being exceeded — at ~50k rps the fake SSE server's CPU
+	// ceiling, 1M total requests need ~21s wall time and tail requests
+	// sitting in the worker queue hit the deadline. That's a harness
+	// artifact, not a stack failure, so 500k is intentionally NOT in the
+	// default tier list. See the design doc's "Push to destruction" section.
+	tiers := []int{5000, 10000, 25000, 50000, 100000, 200000, 300000}
+
+	_, _ = installTestMetrics(t)
+	fake := newFakeOpenAI()
+	defer fake.Close()
+
+	p := buildProvider(fake.URL(), providerOpts{
+		policy: providers.StreamRetryPolicy{
+			Enabled:      true,
+			MaxAttempts:  2,
+			InitialDelay: 50 * time.Millisecond,
+			MaxDelay:     500 * time.Millisecond,
+		},
+	})
+
+	var results []scaleRampTier
+	for _, c := range tiers {
+		t.Logf(">>> pushing to %d concurrent...", c)
+		done := make(chan scaleRampTier, 1)
+		go func(c int) {
+			done <- runScaleRampTier(t, p, fake, c)
+		}(c)
+
+		var result scaleRampTier
+		var timedOut bool
+		select {
+		case result = <-done:
+		case <-time.After(120 * time.Second):
+			timedOut = true
+			t.Logf(">>> tier %d: TIMED OUT after 120s — stopping", c)
+		}
+		if timedOut {
+			break
+		}
+		results = append(results, result)
+		t.Logf(">>> tier %d: ok=%d fail=%d wall=%.2fs goroutines_peak=%d heap_peak_MB=%.1f p99=%v",
+			c, result.successes, result.failures, result.wallTime.Seconds(),
+			result.goroutinesPeak, result.heapInusePeakMB,
+			result.latencyP99.Round(time.Millisecond))
+
+		if result.failures > 0 {
+			t.Logf(">>> tier %d had failures — stopping", c)
+			break
+		}
+
+		// Cool-down: force GC + sleep so the next tier starts clean.
+		runtime.GC()
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	t.Log("")
+	t.Log("=== PUSH-TO-DESTRUCTION RESULTS ===")
+	t.Log("concurrency | reqs   | ok     | fail  | wall(s) | rps     | goroutines_peak | heap_peak_MB | p50    | p99")
+	t.Log("------------+--------+--------+-------+---------+---------+-----------------+--------------+--------+--------")
+	for _, r := range results {
+		t.Logf("%11d | %6d | %6d | %5d | %7.2f | %7.0f | %15d | %12.1f | %6v | %6v",
+			r.concurrency, r.totalRequests, r.successes, r.failures,
+			r.wallTime.Seconds(), r.requestsPerSec,
+			r.goroutinesPeak, r.heapInusePeakMB,
+			r.latencyP50.Round(time.Millisecond),
+			r.latencyP99.Round(time.Millisecond),
+		)
+	}
+	t.Log("")
+}
+
 // runScaleRampTier runs a single concurrency tier end-to-end and
 // returns the measured resource cost. 2× concurrency is used for
 // total request count so each worker processes ~2 requests on


### PR DESCRIPTION
## Summary

Adds `TestStreamRetryLoad_ScaleRamp` to the `loadtest`-tagged load test suite. This validates the "1000 concurrent streams" design target used throughout the stream retry architecture work (#855/#856/#858/#868/#870/#871) against real goroutine / heap / GC / latency measurements, rather than the circular "sized for 1000, tested at ≤500" pattern the earlier validation used.

Drives the real `openai.Provider` stack through a local `httptest.Server` at tiered concurrencies (100 / 500 / 1k / 2k / 3k / 5k), with a background sampler collecting peak goroutines and heap in-use at 10 ms intervals, and per-request latency collection for p50/p99.

## Measured results (healthy upstream, retry enabled, no budget/semaphore)

| concurrency | reqs  | ok    | fail | wall(s) | rps    | goroutines (before/peak/after) | heap(MB) before→peak | gc | p50   | p99   |
|-------------|-------|-------|------|---------|--------|--------------------------------|----------------------|----|-------|-------|
| 100         | 200   | 200   | 0    | 0.02    | 12,336 | 3 / 406 / 303                  | 2.1 → 9.0            | 6  | 6ms   | 12ms  |
| 500         | 1000  | 1000  | 0    | 0.04    | 26,604 | 303 / 812 / 303                | 6.5 → 17.8           | 9  | 15ms  | 29ms  |
| 1000        | 2000  | 2000  | 0    | 0.05    | 37,657 | 303 / 1339 / 303               | 9.4 → 34.1           | 8  | 20ms  | 33ms  |
| 2000        | 4000  | 4000  | 0    | 0.10    | 40,377 | 303 / 2360 / 303               | 14.7 → 58.4          | 9  | 39ms  | 57ms  |
| 3000        | 6000  | 6000  | 0    | 0.14    | 44,173 | 303 / 3321 / 303               | 24.7 → 73.0          | 8  | 53ms  | 73ms  |
| 5000        | 10000 | 10000 | 0    | 0.21    | 47,660 | 303 / 5338 / 303               | 35.4 → 153.5         | 7  | 87ms  | 113ms |

Key findings:
- Peak goroutines track concurrency linearly at ~1.07×
- Goroutines fully drain between tiers (`after` returns to 303) — **no leaks** in the `RunStreamingRequest` / `FrameDetector` refactor
- Heap scales linearly at ~30 KB/stream peak
- p99 latency grows slowly: 33 ms @ 1k → 113 ms @ 5k
- **Zero failures at every tier** — stack handles 5× the design target with no changes

The 1000-concurrent target was conservative, not a coincidence of the test fitting it. The first genuine architectural wall is around 10–20k (heap + h2 RST_STREAM blast radius), not 1k.

Caveats:
- Loopback `httptest.Server` has zero RTT — numbers measure Go scheduler + runtime cost, not I/O-bound behavior. They're a floor on per-stream resource cost, not an rps ceiling.
- Ramp is intentionally healthy so resource cost isn't confounded by retry traffic. Retry-under-herd behavior is covered by the existing `TestStreamRetryLoad_AllPreFirstChunkFail` scenario.

## Test plan

- [x] `go test -tags=loadtest -timeout=15m -run TestStreamRetryLoad_ScaleRamp ./runtime/providers/openai/` — passes
- [x] Full loadtest suite still green: `go test -tags=loadtest -run TestStreamRetryLoad ./runtime/providers/openai/`
- [x] golangci-lint clean on new code (build-tag aware)
- [x] Pre-commit hook passes (build + coverage + lint)
