### PR TITLE
feat(providers): per-provider HTTP transport pool config + in-use gauge

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1131,6 +1131,43 @@ type Provider struct {
 	// fail-fast, a long one queues. Zero or negative means unlimited
 	// (current default). Reduces goroutine/timer explosion under load.
 	StreamMaxConcurrent int `json:"stream_max_concurrent,omitempty" yaml:"stream_max_concurrent,omitempty"`
+	// HTTPTransport configures the per-provider HTTP connection pool.
+	// Lets operators raise MaxConnsPerHost and related limits above the
+	// single-process defaults when scaling up concurrent streams per
+	// upstream. Note that raising MaxConnsPerHost alone is not sufficient
+	// if the upstream advertises a low SETTINGS_MAX_CONCURRENT_STREAMS
+	// (RFC 7540 §6.5.2) — the effective ceiling is
+	// MaxConnsPerHost × SETTINGS_MAX_CONCURRENT_STREAMS per upstream.
+	// See AltairaLabs/PromptKit#873.
+	HTTPTransport *HTTPTransportConfig `json:"http_transport,omitempty" yaml:"http_transport,omitempty"`
+}
+
+// HTTPTransportConfig configures the per-provider HTTP connection pool
+// used for both request/response and streaming calls. Empty or zero
+// fields fall back to the runtime's built-in defaults
+// (providers.DefaultMaxConnsPerHost etc.), so operators only need to
+// set the values they want to override.
+//
+// See AltairaLabs/PromptKit#873 for motivation. The
+// promptkit_http_conns_in_use gauge is the operational signal for
+// tuning these values.
+type HTTPTransportConfig struct {
+	// MaxConnsPerHost caps the total TCP connections the transport may
+	// open to any single upstream host (in-use + idle). Zero or negative
+	// falls back to providers.DefaultMaxConnsPerHost (100). Raising this
+	// increases the realistic concurrent-stream ceiling per upstream,
+	// at the cost of ephemeral port and file-descriptor usage.
+	MaxConnsPerHost int `json:"max_conns_per_host,omitempty" yaml:"max_conns_per_host,omitempty"`
+	// MaxIdleConnsPerHost caps idle keep-alive connections retained per
+	// host for reuse. Zero or negative falls back to
+	// providers.DefaultMaxIdleConnsPerHost (100). Usually tracked to
+	// MaxConnsPerHost so the whole pool is reusable.
+	MaxIdleConnsPerHost int `json:"max_idle_conns_per_host,omitempty" yaml:"max_idle_conns_per_host,omitempty"`
+	// IdleConnTimeout is how long an idle keep-alive connection lingers
+	// before being closed. Empty falls back to
+	// providers.DefaultIdleConnTimeout (90s). Go duration string, e.g.
+	// "60s", "5m".
+	IdleConnTimeout string `json:"idle_conn_timeout,omitempty" yaml:"idle_conn_timeout,omitempty"`
 }
 
 // StreamRetryConfig configures pre-first-chunk streaming retry behavior for

--- a/runtime/providers/base_provider.go
+++ b/runtime/providers/base_provider.go
@@ -50,9 +50,61 @@ const (
 	bytesPerMB = 1024 * 1024
 )
 
-// NewPooledTransport creates an *http.Transport configured with connection
-// pooling settings suitable for high-throughput provider communication.
+// HTTPTransportOptions configures the connection pool for a pooled
+// HTTP transport. Zero values fall back to the package-level defaults
+// (DefaultMaxConnsPerHost, DefaultMaxIdleConnsPerHost, DefaultIdleConnTimeout)
+// so callers can set only the fields they want to override.
+//
+// These are the single-process h2 pool controls that bound how many
+// concurrent streams a provider can multiplex to a single upstream
+// host. See AltairaLabs/PromptKit#873 for background: in combination
+// with the upstream's advertised SETTINGS_MAX_CONCURRENT_STREAMS
+// (RFC 7540 §6.5.2), MaxConnsPerHost is the wall that determines the
+// realistic steady-state ceiling for concurrent streams per process.
+type HTTPTransportOptions struct {
+	// MaxConnsPerHost caps the total TCP connections the transport may
+	// open to any single host (in-use + idle). Zero uses
+	// DefaultMaxConnsPerHost. Raising this lets more h2 connections
+	// multiplex streams in parallel, at the cost of ephemeral port /
+	// file-descriptor usage on the client side.
+	MaxConnsPerHost int
+	// MaxIdleConnsPerHost caps the number of idle keep-alive
+	// connections the transport will retain per host for reuse. Zero
+	// uses DefaultMaxIdleConnsPerHost. Usually tracked to
+	// MaxConnsPerHost to keep the whole pool reusable.
+	MaxIdleConnsPerHost int
+	// IdleConnTimeout is how long an idle keep-alive connection lingers
+	// before being closed. Zero uses DefaultIdleConnTimeout. Longer
+	// timeouts favor reuse; shorter ones release memory and FD slots
+	// faster.
+	IdleConnTimeout time.Duration
+}
+
+// NewPooledTransport creates an *http.Transport configured with default
+// connection pooling settings suitable for high-throughput provider
+// communication. Equivalent to NewPooledTransportWithOptions(HTTPTransportOptions{}).
 func NewPooledTransport() *http.Transport {
+	return NewPooledTransportWithOptions(HTTPTransportOptions{})
+}
+
+// NewPooledTransportWithOptions creates an *http.Transport with the given
+// pool configuration. Zero-valued fields in opts fall back to the
+// package-level defaults. The resulting transport is otherwise identical
+// to NewPooledTransport (same TLS minimum version, same dial timeouts,
+// same HTTP/2 upgrade policy).
+func NewPooledTransportWithOptions(opts HTTPTransportOptions) *http.Transport {
+	maxConns := opts.MaxConnsPerHost
+	if maxConns <= 0 {
+		maxConns = DefaultMaxConnsPerHost
+	}
+	maxIdle := opts.MaxIdleConnsPerHost
+	if maxIdle <= 0 {
+		maxIdle = DefaultMaxIdleConnsPerHost
+	}
+	idleTimeout := opts.IdleConnTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = DefaultIdleConnTimeout
+	}
 	return &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   DefaultDialTimeout,
@@ -60,9 +112,9 @@ func NewPooledTransport() *http.Transport {
 		}).DialContext,
 		TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
 		MaxIdleConns:        DefaultMaxIdleConns,
-		MaxIdleConnsPerHost: DefaultMaxIdleConnsPerHost,
-		MaxConnsPerHost:     DefaultMaxConnsPerHost,
-		IdleConnTimeout:     DefaultIdleConnTimeout,
+		MaxIdleConnsPerHost: maxIdle,
+		MaxConnsPerHost:     maxConns,
+		IdleConnTimeout:     idleTimeout,
 		TLSHandshakeTimeout: DefaultTLSHandshakeTimeout,
 		ForceAttemptHTTP2:   true,
 	}
@@ -248,6 +300,38 @@ func (b *BaseProvider) SetHTTPTimeout(timeout time.Duration) {
 		b.streamingClient.Transport = transport
 	} else if transport != nil {
 		b.streamingClient = &http.Client{Timeout: 0, Transport: transport}
+	}
+}
+
+// SetHTTPTransport replaces the RoundTripper on both the regular and
+// streaming HTTP clients so the provider routes every outbound request
+// through the supplied transport. Both clients share the transport so
+// connection pooling is effective across request/response and streaming
+// traffic to the same upstream.
+//
+// This is the hook CreateProviderFromSpec uses to apply per-provider
+// connection pool config (see ProviderSpec.HTTPTransport and
+// AltairaLabs/PromptKit#873). Provider factories are not aware of this
+// plumbing — they create their client with the default pooled transport
+// and the spec wiring replaces it after construction when the operator
+// has configured overrides.
+//
+// A nil transport resets both clients to Go's http.DefaultTransport via
+// the http.Client zero-value behavior. Passing nil is not the typical
+// use case; callers should build a transport via
+// NewPooledTransportWithOptions and wrap it with NewInstrumentedTransport
+// so the OpenTelemetry span wiring is preserved.
+func (b *BaseProvider) SetHTTPTransport(rt http.RoundTripper) {
+	if b.client != nil {
+		b.client.Transport = rt
+	}
+	if b.streamingClient != nil {
+		b.streamingClient.Transport = rt
+	} else if rt != nil {
+		// Tests and edge cases may construct a BaseProvider without a
+		// streaming client. Materialize one here so streaming callers
+		// also pick up the new transport.
+		b.streamingClient = &http.Client{Timeout: 0, Transport: rt}
 	}
 }
 

--- a/runtime/providers/http_transport_test.go
+++ b/runtime/providers/http_transport_test.go
@@ -1,0 +1,292 @@
+package providers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// --- NewPooledTransportWithOptions ---
+
+func TestNewPooledTransportWithOptions_Defaults(t *testing.T) {
+	t.Parallel()
+	// Zero-valued options must yield a transport with the package
+	// defaults applied. This is the path NewPooledTransport() takes.
+	tr := NewPooledTransportWithOptions(HTTPTransportOptions{})
+	if tr.MaxConnsPerHost != DefaultMaxConnsPerHost {
+		t.Errorf("MaxConnsPerHost = %d, want %d", tr.MaxConnsPerHost, DefaultMaxConnsPerHost)
+	}
+	if tr.MaxIdleConnsPerHost != DefaultMaxIdleConnsPerHost {
+		t.Errorf("MaxIdleConnsPerHost = %d, want %d", tr.MaxIdleConnsPerHost, DefaultMaxIdleConnsPerHost)
+	}
+	if tr.IdleConnTimeout != DefaultIdleConnTimeout {
+		t.Errorf("IdleConnTimeout = %v, want %v", tr.IdleConnTimeout, DefaultIdleConnTimeout)
+	}
+	// Non-pool defaults must still be set so the returned transport is
+	// ready-to-use and identical in every other way to NewPooledTransport().
+	if !tr.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 should be true")
+	}
+	if tr.TLSHandshakeTimeout != DefaultTLSHandshakeTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", tr.TLSHandshakeTimeout, DefaultTLSHandshakeTimeout)
+	}
+}
+
+func TestNewPooledTransportWithOptions_Overrides(t *testing.T) {
+	t.Parallel()
+	tr := NewPooledTransportWithOptions(HTTPTransportOptions{
+		MaxConnsPerHost:     500,
+		MaxIdleConnsPerHost: 250,
+		IdleConnTimeout:     5 * time.Minute,
+	})
+	if tr.MaxConnsPerHost != 500 {
+		t.Errorf("MaxConnsPerHost = %d, want 500", tr.MaxConnsPerHost)
+	}
+	if tr.MaxIdleConnsPerHost != 250 {
+		t.Errorf("MaxIdleConnsPerHost = %d, want 250", tr.MaxIdleConnsPerHost)
+	}
+	if tr.IdleConnTimeout != 5*time.Minute {
+		t.Errorf("IdleConnTimeout = %v, want 5m", tr.IdleConnTimeout)
+	}
+}
+
+func TestNewPooledTransportWithOptions_NegativeValuesFallBack(t *testing.T) {
+	t.Parallel()
+	// Arena config parsers clamp to zero on malformed input, but a
+	// library caller could pass negatives directly. Negatives must
+	// fall back to defaults rather than being stored literally (Go's
+	// http.Transport treats negative as "zero idle" which would break
+	// pooling silently).
+	tr := NewPooledTransportWithOptions(HTTPTransportOptions{
+		MaxConnsPerHost:     -5,
+		MaxIdleConnsPerHost: -5,
+		IdleConnTimeout:     -time.Second,
+	})
+	if tr.MaxConnsPerHost != DefaultMaxConnsPerHost {
+		t.Errorf("negative MaxConnsPerHost should fall back to default, got %d", tr.MaxConnsPerHost)
+	}
+	if tr.MaxIdleConnsPerHost != DefaultMaxIdleConnsPerHost {
+		t.Errorf("negative MaxIdleConnsPerHost should fall back to default, got %d", tr.MaxIdleConnsPerHost)
+	}
+	if tr.IdleConnTimeout != DefaultIdleConnTimeout {
+		t.Errorf("negative IdleConnTimeout should fall back to default, got %v", tr.IdleConnTimeout)
+	}
+}
+
+// --- BaseProvider.SetHTTPTransport ---
+
+func TestBaseProvider_SetHTTPTransport_UpdatesBothClients(t *testing.T) {
+	t.Parallel()
+	// Construct a BaseProvider with the standard factory path so both
+	// clients are populated. Use a canary transport so we can observe
+	// the swap.
+	original := &canaryRoundTripper{name: "original"}
+	b := NewBaseProvider("p", false, &http.Client{Transport: original})
+
+	replacement := &canaryRoundTripper{name: "replacement"}
+	b.SetHTTPTransport(replacement)
+
+	if b.client.Transport != replacement {
+		t.Errorf("regular client transport = %v, want replacement", b.client.Transport)
+	}
+	if b.streamingClient == nil {
+		t.Fatal("streaming client unexpectedly nil")
+	}
+	if b.streamingClient.Transport != replacement {
+		t.Errorf("streaming client transport = %v, want replacement", b.streamingClient.Transport)
+	}
+}
+
+func TestBaseProvider_SetHTTPTransport_MaterializesStreamingClient(t *testing.T) {
+	t.Parallel()
+	// Corner case: a BaseProvider constructed with a nil client (which
+	// newStreamingClient returns nil for) must get a streaming client
+	// when a non-nil transport is installed, so streaming callers
+	// aren't left with a nil client.
+	var b BaseProvider
+	b.client = &http.Client{} // no transport, no streaming client
+
+	rt := &canaryRoundTripper{name: "fresh"}
+	b.SetHTTPTransport(rt)
+
+	if b.streamingClient == nil {
+		t.Fatal("streaming client should have been materialised")
+	}
+	if b.streamingClient.Timeout != 0 {
+		t.Errorf("streaming client timeout = %v, want 0 (unbounded for SSE)", b.streamingClient.Timeout)
+	}
+	if b.streamingClient.Transport != rt {
+		t.Errorf("streaming client transport not set from replacement")
+	}
+}
+
+// canaryRoundTripper is a no-op RoundTripper used to verify transport
+// identity after SetHTTPTransport. The name field makes test failures
+// more readable.
+type canaryRoundTripper struct {
+	name string
+}
+
+func (c *canaryRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, http.ErrNotSupported
+}
+
+// --- connTrackingTransport ---
+
+func TestConnTrackingTransport_IncrementsAndDecrements(t *testing.T) {
+	t.Parallel()
+	// End-to-end: wrap a real httptest server with the tracking
+	// transport, make one request, verify the gauge goes up during
+	// the body read and returns to zero after Close.
+	reg := prometheus.NewRegistry()
+	metrics := NewStreamMetrics(reg, "test", nil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "hello")
+	}))
+	defer server.Close()
+
+	rt := newConnTrackingTransport(http.DefaultTransport, metrics)
+	client := &http.Client{Transport: rt}
+
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	host := strings.TrimPrefix(server.URL, "http://")
+
+	// Before closing the body the gauge must be 1 — this is the
+	// "request is holding a connection slot" state.
+	if got := testutil.ToFloat64(metrics.httpConnsInUse.WithLabelValues(host)); got != 1 {
+		t.Errorf("gauge during active request = %v, want 1", got)
+	}
+
+	// Reading the body does not decrement — only Close does, because
+	// the connection slot is released back to the pool on body close.
+	_, _ = io.ReadAll(resp.Body)
+	if got := testutil.ToFloat64(metrics.httpConnsInUse.WithLabelValues(host)); got != 1 {
+		t.Errorf("gauge after ReadAll but before Close = %v, want 1", got)
+	}
+
+	// Close must decrement.
+	_ = resp.Body.Close()
+	if got := testutil.ToFloat64(metrics.httpConnsInUse.WithLabelValues(host)); got != 0 {
+		t.Errorf("gauge after Close = %v, want 0", got)
+	}
+}
+
+func TestConnTrackingTransport_DoubleCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+	// A buggy caller that calls Close() twice must not double-
+	// decrement the gauge. This is the exact class of bug that
+	// negative gauge values hide until alerts fire on "<0".
+	reg := prometheus.NewRegistry()
+	metrics := NewStreamMetrics(reg, "test", nil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "hi")
+	}))
+	defer server.Close()
+
+	client := &http.Client{Transport: newConnTrackingTransport(http.DefaultTransport, metrics)}
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	host := strings.TrimPrefix(server.URL, "http://")
+
+	_ = resp.Body.Close()
+	_ = resp.Body.Close() // second close must be a no-op for the gauge
+
+	if got := testutil.ToFloat64(metrics.httpConnsInUse.WithLabelValues(host)); got != 0 {
+		t.Errorf("gauge after double close = %v, want 0 (double-close must not double-decrement)", got)
+	}
+}
+
+func TestConnTrackingTransport_TransportErrorDecrements(t *testing.T) {
+	t.Parallel()
+	// When the underlying transport errors before producing a body,
+	// the wrapper must still balance the gauge — otherwise a brief
+	// network blip would leak gauge counts forever.
+	reg := prometheus.NewRegistry()
+	metrics := NewStreamMetrics(reg, "test", nil)
+
+	rt := newConnTrackingTransport(&errorRoundTripper{}, metrics)
+	client := &http.Client{Transport: rt}
+
+	// Use a URL that will never be dialed (errorRoundTripper short-
+	// circuits) but still parses cleanly.
+	_, err := client.Get("http://127.0.0.1:1/x")
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+
+	if got := testutil.ToFloat64(metrics.httpConnsInUse.WithLabelValues("127.0.0.1:1")); got != 0 {
+		t.Errorf("gauge after transport error = %v, want 0", got)
+	}
+}
+
+// errorRoundTripper always returns an error without contacting any
+// network. Used to exercise connTrackingTransport's error decrement
+// path without relying on a real failed dial.
+type errorRoundTripper struct{}
+
+func (errorRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, io.ErrUnexpectedEOF
+}
+
+func TestConnTrackingTransport_NilMetricsSafe(t *testing.T) {
+	t.Parallel()
+	// The metrics instance is allowed to be nil (DefaultStreamMetrics()
+	// returns nil when no host has registered metrics). The wrapper
+	// must remain functional in that case — provider code installed
+	// through CreateProviderFromSpec on a host without metrics still
+	// needs HTTP to work.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+
+	rt := newConnTrackingTransport(http.DefaultTransport, nil)
+	client := &http.Client{Transport: rt}
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("GET with nil metrics: %v", err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+}
+
+func TestConnTrackingTransport_NilBaseFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	// A caller wrapping with a nil base must get a working transport
+	// via http.DefaultTransport rather than a nil-deref panic.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+
+	rt := newConnTrackingTransport(nil, nil)
+	client := &http.Client{Transport: rt}
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("GET with nil base: %v", err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+}
+
+// --- StreamMetrics http_conns_in_use nil-safety ---
+
+func TestStreamMetrics_HTTPConnsInUse_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *StreamMetrics
+	m.HTTPConnsInUseInc("example.com")
+	m.HTTPConnsInUseDec("example.com")
+}

--- a/runtime/providers/http_transport_tracking.go
+++ b/runtime/providers/http_transport_tracking.go
@@ -1,0 +1,90 @@
+package providers
+
+import (
+	"io"
+	"net/http"
+	"sync"
+)
+
+// connTrackingTransport wraps an http.RoundTripper and maintains the
+// httpConnsInUse gauge on DefaultStreamMetrics. It counts per-request
+// "connection holding" (from RoundTrip start to response body close),
+// which is an upper bound on physical TCP connections in use because
+// HTTP/2 may multiplex multiple requests on one connection.
+//
+// The gauge semantic is operationally useful for tuning
+// MaxConnsPerHost: when it saturates the configured pool, new streams
+// will serialize behind in-use slots. See AltairaLabs/PromptKit#873.
+//
+// The wrapper is constructed in CreateProviderFromSpec and installed on
+// every provider via SetHTTPTransport so the gauge is always present
+// regardless of whether operators have overridden pool config.
+type connTrackingTransport struct {
+	base    http.RoundTripper
+	metrics *StreamMetrics
+}
+
+// newConnTrackingTransport wraps base with conn-lifecycle tracking
+// against the given metrics. A nil base is treated as
+// http.DefaultTransport so callers can chain wrappers without
+// pre-checking.
+func newConnTrackingTransport(base http.RoundTripper, metrics *StreamMetrics) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &connTrackingTransport{base: base, metrics: metrics}
+}
+
+// RoundTrip increments the in-use gauge before delegating to the base
+// transport and arranges for the decrement to fire when the response
+// body is closed (or, on error, when the base returns). The decrement
+// is guarded by sync.Once so double-close on the body is safe.
+func (t *connTrackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := req.URL.Host
+	t.metrics.HTTPConnsInUseInc(host)
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		// No response body to wrap; fire the decrement inline so the
+		// gauge balances even when RoundTrip never produced a body.
+		t.metrics.HTTPConnsInUseDec(host)
+		return nil, err
+	}
+
+	// A successful RoundTrip always yields a non-nil Body per
+	// net/http contract, but defend against bizarre custom transports
+	// returning nil to keep the decrement balanced.
+	if resp.Body == nil {
+		t.metrics.HTTPConnsInUseDec(host)
+		return resp, nil
+	}
+
+	resp.Body = &trackedResponseBody{
+		ReadCloser: resp.Body,
+		onClose: func() {
+			t.metrics.HTTPConnsInUseDec(host)
+		},
+	}
+	return resp, nil
+}
+
+// trackedResponseBody wraps a response body so the first Close() fires
+// an onClose callback. Subsequent closes are no-ops on the callback but
+// still propagate to the underlying body so callers that call Close
+// more than once (notably io.ReadAll on error paths) do not double-
+// decrement the gauge.
+type trackedResponseBody struct {
+	io.ReadCloser
+	once    sync.Once
+	onClose func()
+}
+
+// Close closes the underlying body and fires the onClose callback
+// exactly once. The underlying Close error is returned; the callback
+// is invoked regardless of whether Close succeeded so the gauge cannot
+// leak on failed closes.
+func (t *trackedResponseBody) Close() error {
+	err := t.ReadCloser.Close()
+	t.once.Do(t.onClose)
+	return err
+}

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -127,6 +127,20 @@ type ProviderSpec struct {
 	// via SetStreamSemaphore on providers that implement the
 	// streamConcurrencyConfigurable interface.
 	StreamMaxConcurrent int
+
+	// HTTPTransport configures the per-provider HTTP connection pool.
+	// Zero-valued fields fall back to package-level defaults
+	// (DefaultMaxConnsPerHost, etc.). Applied via SetHTTPTransport on
+	// providers that implement the httpTransportConfigurable interface,
+	// replacing the default pooled transport the factory constructed.
+	//
+	// See AltairaLabs/PromptKit#873 for motivation: at higher concurrency
+	// than the repo was originally sized for, the hardcoded
+	// MaxConnsPerHost: 100 becomes the wall before PromptKit's own
+	// machinery does. Raising this (paired with operator awareness of
+	// the upstream's SETTINGS_MAX_CONCURRENT_STREAMS) is the primary
+	// lever on realistic single-process concurrent-stream capacity.
+	HTTPTransport HTTPTransportOptions
 }
 
 // Credential applies authentication to HTTP requests.
@@ -168,6 +182,15 @@ type streamRetryConfigurable interface {
 // neither.
 type streamConcurrencyConfigurable interface {
 	SetStreamSemaphore(*StreamSemaphore)
+}
+
+// httpTransportConfigurable is implemented by any provider that embeds
+// *BaseProvider. CreateProviderFromSpec uses this to replace the default
+// pooled transport with one built from spec.HTTPTransport after the
+// provider factory has run. The swap preserves the OpenTelemetry
+// instrumentation wrapper so trace propagation is not lost.
+type httpTransportConfigurable interface {
+	SetHTTPTransport(http.RoundTripper)
 }
 
 // CreateProviderFromSpec creates a provider implementation from a spec.
@@ -237,6 +260,22 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 	// versa. A non-positive limit is a no-op (unlimited default).
 	if scc, ok := provider.(streamConcurrencyConfigurable); ok && spec.StreamMaxConcurrent > 0 {
 		scc.SetStreamSemaphore(NewStreamSemaphore(spec.StreamMaxConcurrent))
+	}
+
+	// Replace the HTTP transport with a pooled-and-instrumented one
+	// built from spec.HTTPTransport. Done unconditionally (not gated
+	// on operator overrides) so the conn-tracking wrapper is always
+	// in play — the http_conns_in_use gauge needs to be populated
+	// whether the operator has tuned pool config or not. Zero-valued
+	// options in spec.HTTPTransport fall back to package defaults, so
+	// the replacement is functionally equivalent to the factory's
+	// original transport when no overrides are set, with the added
+	// conn-tracking layer.
+	if htc, ok := provider.(httpTransportConfigurable); ok {
+		base := NewPooledTransportWithOptions(spec.HTTPTransport)
+		rt := NewInstrumentedTransport(base)
+		rt = newConnTrackingTransport(rt, DefaultStreamMetrics())
+		htc.SetHTTPTransport(rt)
 	}
 
 	return provider, nil

--- a/runtime/providers/stream_metrics.go
+++ b/runtime/providers/stream_metrics.go
@@ -30,6 +30,7 @@ type StreamMetrics struct {
 	streamRetriesTotal          *prometheus.CounterVec
 	streamRetryBudgetAvailable  *prometheus.GaugeVec
 	streamConcurrencyRejections *prometheus.CounterVec
+	httpConnsInUse              *prometheus.GaugeVec
 }
 
 // NewStreamMetrics creates and registers the Phase 1 streaming metrics
@@ -91,6 +92,19 @@ func NewStreamMetrics(
 				"indicate the semaphore limit is undersized or upstream is saturated.",
 			ConstLabels: constLabels,
 		}, []string{"provider", "reason"}),
+		httpConnsInUse: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "http_conns_in_use",
+			Help: "HTTP requests currently holding a connection slot to each upstream host. " +
+				"With HTTP/2 multiplexing, multiple requests may share one TCP connection, so " +
+				"this is an upper bound on physical connections in use rather than an exact " +
+				"count. Operationally this is the pool-pressure signal for tuning " +
+				"MaxConnsPerHost (see AltairaLabs/PromptKit#873): when this gauge approaches " +
+				"the configured MaxConnsPerHost × upstream SETTINGS_MAX_CONCURRENT_STREAMS, " +
+				"the transport is pool-saturated and new streams will serialize behind in-use " +
+				"connections.",
+			ConstLabels: constLabels,
+		}, []string{"host"}),
 	}
 	registerer.MustRegister(
 		m.streamsInFlight,
@@ -99,8 +113,30 @@ func NewStreamMetrics(
 		m.streamRetriesTotal,
 		m.streamRetryBudgetAvailable,
 		m.streamConcurrencyRejections,
+		m.httpConnsInUse,
 	)
 	return m
+}
+
+// HTTPConnsInUseInc increments the in-use HTTP connection gauge for a
+// host. Called by the conn-tracking transport wrapper at the start of
+// each RoundTrip. Nil-safe.
+func (m *StreamMetrics) HTTPConnsInUseInc(host string) {
+	if m == nil {
+		return
+	}
+	m.httpConnsInUse.WithLabelValues(host).Inc()
+}
+
+// HTTPConnsInUseDec decrements the in-use HTTP connection gauge for a
+// host. Called by the conn-tracking transport wrapper when a request's
+// response body is closed (or when the RoundTrip errored before
+// returning a body). Nil-safe.
+func (m *StreamMetrics) HTTPConnsInUseDec(host string) {
+	if m == nil {
+		return
+	}
+	m.httpConnsInUse.WithLabelValues(host).Dec()
 }
 
 // StreamsInFlightInc increments the in-flight stream gauge for a provider.

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -972,6 +972,21 @@
         "timeout_ms"
       ]
     },
+    "HTTPTransportConfig": {
+      "properties": {
+        "max_conns_per_host": {
+          "type": "integer"
+        },
+        "max_idle_conns_per_host": {
+          "type": "integer"
+        },
+        "idle_conn_timeout": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ImageConfig": {
       "properties": {
         "max_size_mb": {
@@ -1667,6 +1682,9 @@
         },
         "stream_max_concurrent": {
           "type": "integer"
+        },
+        "http_transport": {
+          "$ref": "#/$defs/HTTPTransportConfig"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -17,6 +17,21 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "HTTPTransportConfig": {
+      "properties": {
+        "max_conns_per_host": {
+          "type": "integer"
+        },
+        "max_idle_conns_per_host": {
+          "type": "integer"
+        },
+        "idle_conn_timeout": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ObjectMeta": {
       "properties": {
         "name": {
@@ -147,6 +162,9 @@
         },
         "stream_max_concurrent": {
           "type": "integer"
+        },
+        "http_transport": {
+          "$ref": "#/$defs/HTTPTransportConfig"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -183,6 +183,21 @@
         "timeout_ms"
       ]
     },
+    "HTTPTransportConfig": {
+      "properties": {
+        "max_conns_per_host": {
+          "type": "integer"
+        },
+        "max_idle_conns_per_host": {
+          "type": "integer"
+        },
+        "idle_conn_timeout": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "LoggingConfigSpec": {
       "properties": {
         "defaultLevel": {
@@ -511,6 +526,9 @@
         },
         "stream_max_concurrent": {
           "type": "integer"
+        },
+        "http_transport": {
+          "$ref": "#/$defs/HTTPTransportConfig"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -207,6 +207,7 @@ func createProviderImpl(configDir string, provider *config.Provider) (providers.
 	streamIdleTimeout := parseProviderDuration(provider.ID, "stream_idle_timeout", provider.StreamIdleTimeout)
 	streamRetry := buildStreamRetryPolicy(provider.ID, provider.StreamRetry)
 	streamRetryBudget := buildStreamRetryBudget(provider.StreamRetry)
+	httpTransport := buildHTTPTransportOptions(provider.ID, provider.HTTPTransport)
 
 	spec := providers.ProviderSpec{
 		ID:                  provider.ID,
@@ -224,6 +225,7 @@ func createProviderImpl(configDir string, provider *config.Provider) (providers.
 		StreamRetry:         streamRetry,
 		StreamRetryBudget:   streamRetryBudget,
 		StreamMaxConcurrent: provider.StreamMaxConcurrent,
+		HTTPTransport:       httpTransport,
 		Defaults: providers.ProviderDefaults{
 			Temperature: provider.Defaults.Temperature,
 			TopP:        provider.Defaults.TopP,
@@ -275,6 +277,23 @@ func buildStreamRetryBudget(cfg *config.StreamRetryConfig) *providers.RetryBudge
 		return nil
 	}
 	return providers.NewRetryBudget(cfg.Budget.RatePerSec, cfg.Budget.Burst)
+}
+
+// buildHTTPTransportOptions translates an HTTPTransportConfig from arena
+// config into providers.HTTPTransportOptions. A nil config yields the
+// zero value, which the runtime interprets as "use package defaults".
+// Malformed idle_conn_timeout values are logged and ignored so the
+// provider falls back to the built-in default rather than failing hard
+// on a single typo.
+func buildHTTPTransportOptions(providerID string, cfg *config.HTTPTransportConfig) providers.HTTPTransportOptions {
+	if cfg == nil {
+		return providers.HTTPTransportOptions{}
+	}
+	return providers.HTTPTransportOptions{
+		MaxConnsPerHost:     cfg.MaxConnsPerHost,
+		MaxIdleConnsPerHost: cfg.MaxIdleConnsPerHost,
+		IdleConnTimeout:     parseProviderDuration(providerID, "http_transport.idle_conn_timeout", cfg.IdleConnTimeout),
+	}
 }
 
 // parseProviderDuration parses a Go duration string from a provider config


### PR DESCRIPTION
Closes #873.

## Summary

Exposes the connection pool settings that were previously hardcoded in `NewPooledTransport` as per-provider YAML config, and adds the `promptkit_http_conns_in_use` gauge that the design doc's Phase 3 metrics section reserved a slot for.

## Motivation

#872's push-to-destruction measurements showed the retry stack handles 300k concurrent streams against a loopback upstream, but real-world deployments are capped far below that by the hardcoded `MaxConnsPerHost: 100` ceiling. For operators scaling up concurrent streams per upstream, this is the primary lever — alongside awareness that the effective ceiling is `MaxConnsPerHost × upstream SETTINGS_MAX_CONCURRENT_STREAMS` per host (RFC 7540 §6.5.2).

## Configuration

```yaml
providers:
  - id: openai-gpt5-pro
    http_transport:
      max_conns_per_host: 250
      max_idle_conns_per_host: 250
      idle_conn_timeout: 90s
```

All fields are optional. Omitting `http_transport` (or any individual field) preserves the current defaults. Negative values fall back to defaults rather than being stored literally (Go's `http.Transport` treats negative `IdleConnTimeout` as "zero idle" which would break pooling silently).

## Architecture

1. **`HTTPTransportOptions`** in `runtime/providers/base_provider.go` — the go-native struct passed to the new `NewPooledTransportWithOptions(opts)`. `NewPooledTransport()` becomes a thin wrapper that calls it with zero options, so callers of the old function are unchanged.
2. **`SetHTTPTransport(rt)`** on `BaseProvider` — swaps the transport on both the request/response and streaming clients so they share pooling. Materializes a streaming client if one doesn't exist (edge case for tests that construct BaseProvider directly).
3. **`httpTransportConfigurable` interface + `CreateProviderFromSpec` wiring** — unconditionally replaces the factory's default transport with a pooled + instrumented + conn-tracking one built from `spec.HTTPTransport`. Unconditional so the gauge is populated for every provider regardless of whether operators have overridden pool config — the zero-value `HTTPTransportOptions` yields the same pool params as before, with the tracking wrapper added.
4. **`connTrackingTransport`** — a `RoundTripper` wrapper that increments `http_conns_in_use` on RoundTrip start and decrements via a `sync.Once`-guarded callback on response body close. Balanced on transport errors (no body produced). Double-close on the response body is idempotent.
5. **`http_conns_in_use{host}`** — new `GaugeVec` on `StreamMetrics` alongside the existing Phase 1–3 metrics. Help text honestly describes the semantic: "HTTP requests currently holding a connection slot to each upstream host. With HTTP/2 multiplexing, multiple requests may share one TCP connection, so this is an upper bound on physical connections in use rather than an exact count."

## Tests (11 new)

- **`NewPooledTransportWithOptions`**: default fallback, overrides, negative-value fallback (defends against Go's `http.Transport` negative-semantics footgun).
- **`SetHTTPTransport`**: updates both clients; materializes streaming client when absent.
- **`connTrackingTransport`**: end-to-end increment/decrement against an `httptest` server; double-close idempotency (critical — prevents negative gauge leaks); transport-error decrement; nil-metrics safety; nil-base-transport safety.
- **`HTTPConnsInUse` gauge**: nil-safe.

## Coverage on changed files

- `pkg/config/types.go`: 96.9%
- `runtime/providers/base_provider.go`: 94.1%
- `runtime/providers/registry.go`: 90.4%
- `runtime/providers/stream_metrics.go`: 95.7%
- `runtime/providers/http_transport_tracking.go`: 88.9%

All exceed the 80% pre-commit threshold.

## Non-goals (tracked as follow-up in the issue)

- **Capturing `SETTINGS_MAX_CONCURRENT_STREAMS` empirically** for OpenAI / Anthropic / Gemini / Ollama to inform default tuning. The help text documents the interaction; the measurement is a separate piece of work.
- **Re-homing the retry budget** out of the provider struct for multi-host deployments (Azure multi-region etc.) — architectural follow-up from the scale horizons doc.

## Test plan

- [x] `go test ./... -count=1` across runtime, pkg, tools/arena, sdk modules — all green
- [x] `golangci-lint run --new-from-rev=main` on changed packages — 0 issues
- [x] Schemas regenerated via `go run ./tools/schema-gen/...`
- [x] Pre-commit hook passes (build + lint + test + coverage on all changed files)
