### PR TITLE
feat(events): env var overrides for event bus buffer/worker/timeout

### DIFF
--- a/runtime/events/bus.go
+++ b/runtime/events/bus.go
@@ -2,6 +2,8 @@
 package events
 
 import (
+	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,6 +19,72 @@ const (
 	dropLogRateLimit         = 100 // log every Nth drop to avoid spam
 	closeTimeout             = 10 * time.Second
 )
+
+// Environment variable names for operator-level event bus tuning. These
+// are read by NewEventBus when an option is not supplied, so existing
+// call sites (arena, SDK, examples) pick up operator config without any
+// code changes.
+//
+// See AltairaLabs/PromptKit#853: the capability-matrix run dropped 201
+// events due to worker-pool throughput saturation under bursty load.
+// Operators can raise these values to match their expected concurrency
+// without a code change.
+const (
+	// EnvEventBusBufferSize overrides DefaultEventBufferSize. Invalid
+	// or non-positive values are ignored and the default is used.
+	EnvEventBusBufferSize = "PROMPTKIT_EVENT_BUS_BUFFER_SIZE"
+	// EnvEventBusWorkerPoolSize overrides DefaultWorkerPoolSize.
+	// Invalid or non-positive values are ignored.
+	EnvEventBusWorkerPoolSize = "PROMPTKIT_EVENT_BUS_WORKER_POOL_SIZE"
+	// EnvEventBusSubscriberTimeout overrides DefaultSubscriberTimeout.
+	// Value is a Go duration string (e.g. "10s", "2m"). Invalid or
+	// non-positive values are ignored.
+	EnvEventBusSubscriberTimeout = "PROMPTKIT_EVENT_BUS_SUBSCRIBER_TIMEOUT"
+)
+
+// envDefaultBusConfig returns a busConfig seeded from environment
+// variables, falling back to the package defaults when a variable is
+// unset, malformed, or non-positive. Malformed values log a warning
+// once per NewEventBus call so operators see their typos without
+// spamming logs for every event.
+func envDefaultBusConfig() *busConfig {
+	cfg := &busConfig{
+		workerPoolSize:    DefaultWorkerPoolSize,
+		eventBufferSize:   DefaultEventBufferSize,
+		subscriberTimeout: DefaultSubscriberTimeout,
+	}
+	if v := os.Getenv(EnvEventBusBufferSize); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.eventBufferSize = n
+		} else {
+			logger.Warn("ignoring invalid event bus buffer size from env",
+				"env", EnvEventBusBufferSize,
+				"value", v,
+			)
+		}
+	}
+	if v := os.Getenv(EnvEventBusWorkerPoolSize); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.workerPoolSize = n
+		} else {
+			logger.Warn("ignoring invalid event bus worker pool size from env",
+				"env", EnvEventBusWorkerPoolSize,
+				"value", v,
+			)
+		}
+	}
+	if v := os.Getenv(EnvEventBusSubscriberTimeout); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.subscriberTimeout = d
+		} else {
+			logger.Warn("ignoring invalid event bus subscriber timeout from env",
+				"env", EnvEventBusSubscriberTimeout,
+				"value", v,
+			)
+		}
+	}
+	return cfg
+}
 
 // Listener is a function that handles events.
 type Listener func(*Event)
@@ -120,17 +188,26 @@ type EventBus struct {
 }
 
 // NewEventBus creates a new event bus with a worker pool.
-// Options can be provided to configure pool size and buffer capacity.
-// The zero-argument form uses sensible defaults and is fully backward-compatible.
+//
+// Configuration precedence (highest first):
+//
+//  1. Explicit options passed as BusOption arguments (WithWorkerPoolSize,
+//     WithEventBufferSize, WithSubscriberTimeout). Tests and programmatic
+//     callers that want deterministic behavior should use these.
+//  2. Environment variables (PROMPTKIT_EVENT_BUS_BUFFER_SIZE,
+//     PROMPTKIT_EVENT_BUS_WORKER_POOL_SIZE,
+//     PROMPTKIT_EVENT_BUS_SUBSCRIBER_TIMEOUT). Invalid values are logged
+//     and ignored. This is the operator knob for tuning without code
+//     changes — see AltairaLabs/PromptKit#853.
+//  3. Package defaults (DefaultEventBufferSize etc.).
+//
+// The zero-argument form reads env vars and falls back to defaults, so
+// existing call sites pick up operator configuration automatically.
 //
 // Workers are started lazily: goroutines are only spawned when the first
 // subscriber is added via Subscribe or SubscribeAll.
 func NewEventBus(opts ...BusOption) *EventBus {
-	cfg := &busConfig{
-		workerPoolSize:    DefaultWorkerPoolSize,
-		eventBufferSize:   DefaultEventBufferSize,
-		subscriberTimeout: DefaultSubscriberTimeout,
-	}
+	cfg := envDefaultBusConfig()
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/runtime/events/bus_test.go
+++ b/runtime/events/bus_test.go
@@ -818,3 +818,92 @@ func TestPublishConcurrentWithClose(t *testing.T) {
 		wg.Wait()
 	}
 }
+
+// --- Environment variable configuration (AltairaLabs/PromptKit#853) ---
+
+func TestNewEventBus_EnvVarDefaults(t *testing.T) {
+	// Not t.Parallel — t.Setenv requires a serial test.
+	t.Setenv(EnvEventBusBufferSize, "2500")
+	t.Setenv(EnvEventBusWorkerPoolSize, "25")
+	t.Setenv(EnvEventBusSubscriberTimeout, "12s")
+
+	bus := NewEventBus()
+	defer bus.Close()
+
+	if got := cap(bus.eventCh); got != 2500 {
+		t.Errorf("buffer size = %d, want 2500 from env", got)
+	}
+	if got := bus.workerPoolSize; got != 25 {
+		t.Errorf("worker pool size = %d, want 25 from env", got)
+	}
+	if got := bus.subscriberTimeout; got != 12*time.Second {
+		t.Errorf("subscriber timeout = %v, want 12s from env", got)
+	}
+}
+
+func TestNewEventBus_ExplicitOptionsOverrideEnv(t *testing.T) {
+	// Explicit BusOption arguments must win over env vars so tests and
+	// programmatic callers retain deterministic behavior regardless of
+	// the operator's environment.
+	t.Setenv(EnvEventBusBufferSize, "9999")
+	t.Setenv(EnvEventBusWorkerPoolSize, "99")
+
+	bus := NewEventBus(
+		WithEventBufferSize(50),
+		WithWorkerPoolSize(3),
+	)
+	defer bus.Close()
+
+	if got := cap(bus.eventCh); got != 50 {
+		t.Errorf("buffer size = %d, want 50 from explicit option (env was 9999)", got)
+	}
+	if got := bus.workerPoolSize; got != 3 {
+		t.Errorf("worker pool size = %d, want 3 from explicit option (env was 99)", got)
+	}
+}
+
+func TestNewEventBus_InvalidEnvVarsFallBackToDefaults(t *testing.T) {
+	// Malformed or non-positive env vars must be ignored so a typo in
+	// the operator's config cannot silently turn the event bus off.
+	t.Setenv(EnvEventBusBufferSize, "not-a-number")
+	t.Setenv(EnvEventBusWorkerPoolSize, "-5")
+	t.Setenv(EnvEventBusSubscriberTimeout, "garbage")
+
+	bus := NewEventBus()
+	defer bus.Close()
+
+	if got := cap(bus.eventCh); got != DefaultEventBufferSize {
+		t.Errorf("buffer size = %d, want default %d after invalid env", got, DefaultEventBufferSize)
+	}
+	if got := bus.workerPoolSize; got != DefaultWorkerPoolSize {
+		t.Errorf("worker pool size = %d, want default %d after invalid env", got, DefaultWorkerPoolSize)
+	}
+	if got := bus.subscriberTimeout; got != DefaultSubscriberTimeout {
+		t.Errorf("subscriber timeout = %v, want default %v after invalid env", got, DefaultSubscriberTimeout)
+	}
+}
+
+func TestNewEventBus_UnsetEnvVarsUseDefaults(t *testing.T) {
+	// Unset/empty env vars (the common case for existing deployments)
+	// must preserve the package defaults exactly — this is the
+	// backwards-compat guarantee that makes the env-var path safe to
+	// ship. envDefaultBusConfig treats empty-string the same as unset,
+	// so t.Setenv("") is sufficient isolation without needing
+	// os.Unsetenv (which doesn't restore the parent environment).
+	t.Setenv(EnvEventBusBufferSize, "")
+	t.Setenv(EnvEventBusWorkerPoolSize, "")
+	t.Setenv(EnvEventBusSubscriberTimeout, "")
+
+	bus := NewEventBus()
+	defer bus.Close()
+
+	if got := cap(bus.eventCh); got != DefaultEventBufferSize {
+		t.Errorf("buffer size = %d, want default %d with unset env", got, DefaultEventBufferSize)
+	}
+	if got := bus.workerPoolSize; got != DefaultWorkerPoolSize {
+		t.Errorf("worker pool size = %d, want default %d with unset env", got, DefaultWorkerPoolSize)
+	}
+	if got := bus.subscriberTimeout; got != DefaultSubscriberTimeout {
+		t.Errorf("subscriber timeout = %v, want default %v with unset env", got, DefaultSubscriberTimeout)
+	}
+}


### PR DESCRIPTION
Closes #853.

## Summary

Adds three operator-facing environment variables that override the event bus defaults without requiring code changes at any call site:

- `PROMPTKIT_EVENT_BUS_BUFFER_SIZE` (default 1000)
- `PROMPTKIT_EVENT_BUS_WORKER_POOL_SIZE` (default 10)
- `PROMPTKIT_EVENT_BUS_SUBSCRIBER_TIMEOUT` (default 5s, Go duration string)

## Motivation

The capability-matrix run that prompted #853 dropped 201 events when the worker pool couldn't drain the 1000-slot buffer fast enough under bursty concurrent-provider load. The `BusOption` functional options (`WithEventBufferSize`, `WithWorkerPoolSize`, `WithSubscriberTimeout`) already existed for programmatic callers, but every production call site in arena and sdk uses `NewEventBus()` with no options — so operators had no way to tune without patching code.

Env vars fix that: existing call sites (`tools/arena/cmd/promptarena/serve_interactive.go`, `run_interactive.go`, `sdk/sdk.go`, `sdk/options.go`, `sdk/evaluate.go`) pick up operator config automatically.

## Precedence

1. **Explicit `BusOption` arguments** — tests and programmatic callers retain deterministic behavior regardless of the operator's environment.
2. **Environment variables** — the operator knob for tuning.
3. **Package defaults** — `DefaultEventBufferSize = 1000`, `DefaultWorkerPoolSize = 10`, `DefaultSubscriberTimeout = 5s`.

## Safety

Invalid or non-positive env var values (typos, bad duration strings, negative numbers) log a warning once at `NewEventBus` time and fall back to the package default — a typo in operator config cannot silently turn the event bus off.

## Tests (4 new, all passing)

- **`TestNewEventBus_EnvVarDefaults`**: env vars apply when no options are passed.
- **`TestNewEventBus_ExplicitOptionsOverrideEnv`**: explicit `BusOption` arguments win over env vars (tests stay deterministic).
- **`TestNewEventBus_InvalidEnvVarsFallBackToDefaults`**: malformed/negative env values fall back to defaults and log warnings.
- **`TestNewEventBus_UnsetEnvVarsUseDefaults`**: empty/unset env preserves existing behavior exactly — the backwards-compat guarantee.

Coverage on `runtime/events/bus.go`: **96.9%**.

## Non-goals (deferred)

- **Prometheus dropped-events counter and buffer-depth gauge** (design doc Phase 2 metrics). The `droppedCount atomic.Int64` and `DroppedCount()` accessor already exist; exposing them via Prometheus pulls a new dep into `runtime/events` and is worth its own PR if anyone needs it. The env-var path addresses the root cause (under-sized buffer/pool) whereas the counter only improves visibility after the fact.
- **Per-slow-listener isolation queues** (suggested in the issue as "consider whether slow listeners should run through their own buffered queue"). Separate scope.

## Test plan

- [x] `go test ./events/... -count=1` — passes, 83.4% package coverage
- [x] `go test ./... -count=1` across runtime, sdk, tools/arena — no regressions
- [x] `golangci-lint run --new-from-rev=main` — 0 issues
- [x] Pre-commit hook passes (lint + build + test + coverage ≥80% on bus.go → 96.9%)
