### PR TITLE
feat(metrics): histogram of chunks forwarded before stream error (unblocks #864)

### DIFF
--- a/runtime/providers/base_provider.go
+++ b/runtime/providers/base_provider.go
@@ -487,22 +487,89 @@ func (b *BaseProvider) RunStreamingRequest(
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 
+	// Two-channel pipeline so we can instrument every stream at a single
+	// point rather than threading bookkeeping through every provider's
+	// stream consumer:
+	//
+	//   body → consumer → innerChan → relay → outChan → caller
+	//
+	// The relay goroutine counts content chunks and observes the
+	// stream_error_chunks_forwarded histogram on the terminal error
+	// chunk. This is the load-bearing measurement for the Phase 4
+	// dedup-resume decision (see AltairaLabs/PromptKit#864): a
+	// distribution concentrated at 0 means Phase 1 pre-first-chunk
+	// retry is catching everything that matters; mass at ≥1 means
+	// mid-stream failures are leaking through the safe-retry window
+	// and Phase 4 would be worth building.
+	innerChan := make(chan StreamChunk, DefaultStreamBufferSize)
 	outChan := make(chan StreamChunk, DefaultStreamBufferSize)
+
 	// From this point on, ownership of the acquired slot and gauge
-	// increments transfers to the stream goroutine's defer below. We
-	// flip the flags so the outer defers are no-ops on the success path.
+	// increments transfers to the goroutines' defers below. Flip the
+	// flags so the outer defers are no-ops on the success path.
 	released = true
 	slotReleased = true
+
+	// Consumer goroutine: drives the body through the provider-specific
+	// parser into innerChan, then closes innerChan. Releases the
+	// concurrent-stream semaphore the moment the upstream body is
+	// fully drained so a slow caller does not hold an upstream slot.
+	go func() {
+		defer b.ReleaseStreamSlot()
+		consumer(ctx, result.Body, innerChan)
+	}()
+
+	// Relay goroutine: observes instrumentation while forwarding every
+	// chunk from innerChan to outChan. The in-flight gauges are
+	// decremented here (not in the consumer) so they reflect the
+	// caller's view of stream lifetime: "stream is in flight until
+	// outChan is closed". The terminal close of outChan is the last
+	// step, signaling the caller that the stream is fully delivered.
 	go func() {
 		defer func() {
+			close(outChan)
 			metrics.StreamsInFlightDec(providerID)
 			metrics.ProviderCallsInFlightDec(providerID)
-			b.ReleaseStreamSlot()
 		}()
-		consumer(ctx, result.Body, outChan)
+		var contentChunks int
+		for chunk := range innerChan {
+			// A chunk "forwarded content" if it delivered any user-
+			// visible payload: text delta, media data, or tool call
+			// arguments. Finish-reason-only chunks and the terminal
+			// error chunk itself do not count toward the pre-error
+			// content count — only payload that the downstream
+			// consumer has already committed to.
+			if chunkForwardedContent(&chunk) {
+				contentChunks++
+			}
+			if chunk.Error != nil {
+				metrics.ObserveStreamErrorChunksForwarded(providerID, contentChunks)
+			}
+			outChan <- chunk
+		}
 	}()
 
 	return outChan, nil
+}
+
+// chunkForwardedContent reports whether a StreamChunk delivered any
+// user-visible payload downstream. Only payload-bearing chunks count
+// toward the "chunks forwarded before error" histogram; pure
+// finish-reason chunks and error terminals do not. Takes a pointer
+// rather than a value because StreamChunk is large (multiple string
+// and slice fields) and this function is called once per chunk in
+// the relay hot path.
+func chunkForwardedContent(chunk *StreamChunk) bool {
+	if chunk.Delta != "" {
+		return true
+	}
+	if chunk.MediaData != nil {
+		return true
+	}
+	if len(chunk.ToolCalls) > 0 {
+		return true
+	}
+	return false
 }
 
 // HTTPTimeout returns the current HTTP client timeout, or 0 if no client is set.

--- a/runtime/providers/stream_error_chunks_test.go
+++ b/runtime/providers/stream_error_chunks_test.go
@@ -1,0 +1,329 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// --- Nil-safety ---
+
+func TestStreamMetrics_ObserveStreamErrorChunksForwarded_NilSafe(t *testing.T) {
+	t.Parallel()
+	var m *StreamMetrics
+	// Must not panic on a nil receiver.
+	m.ObserveStreamErrorChunksForwarded("openai", 5)
+}
+
+// --- chunkForwardedContent ---
+
+func TestChunkForwardedContent_Classification(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		chunk   StreamChunk
+		forward bool
+	}{
+		{
+			name:    "text delta counts",
+			chunk:   StreamChunk{Delta: "hello"},
+			forward: true,
+		},
+		{
+			name:    "tool call counts",
+			chunk:   StreamChunk{ToolCalls: []types.MessageToolCall{{ID: "c1", Name: "search"}}},
+			forward: true,
+		},
+		{
+			name:    "media data counts",
+			chunk:   StreamChunk{MediaData: &StreamMediaData{Data: []byte{1, 2, 3}}},
+			forward: true,
+		},
+		{
+			name:    "content-only without delta does not count",
+			chunk:   StreamChunk{Content: "accumulated"},
+			forward: false,
+		},
+		{
+			name:    "finish reason alone does not count",
+			chunk:   StreamChunk{FinishReason: stringPtr("stop")},
+			forward: false,
+		},
+		{
+			name:    "error chunk does not count",
+			chunk:   StreamChunk{Error: errors.New("boom")},
+			forward: false,
+		},
+		{
+			name:    "empty chunk does not count",
+			chunk:   StreamChunk{},
+			forward: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chunk := tc.chunk
+			if got := chunkForwardedContent(&chunk); got != tc.forward {
+				t.Errorf("chunkForwardedContent() = %v, want %v", got, tc.forward)
+			}
+		})
+	}
+}
+
+// stringPtr is a local helper so tests can build StreamChunk values
+// with a finish reason without importing the providers.StringPtr
+// helper from another file (which would create a naming collision in
+// this test file).
+func stringPtr(s string) *string {
+	return &s
+}
+
+// --- End-to-end via RunStreamingRequest ---
+
+// runStreamingTestHarness wires up a BaseProvider, a fake upstream, and
+// a synthetic consumer that emits a caller-specified sequence of
+// StreamChunks. Returns the drained chunks (in order) and the registered
+// metrics registry for inspection.
+//
+// The fake upstream just serves a 200 OK with a body the consumer
+// ignores — all real test logic lives in the consumer closure.
+type runStreamingTestHarness struct {
+	t        *testing.T
+	chunks   []StreamChunk
+	provider *BaseProvider
+	metrics  *StreamMetrics
+	reg      *prometheus.Registry
+}
+
+func newRunStreamingTestHarness(t *testing.T, chunks []StreamChunk) *runStreamingTestHarness {
+	t.Helper()
+	ResetDefaultStreamMetrics()
+	t.Cleanup(ResetDefaultStreamMetrics)
+
+	reg := prometheus.NewRegistry()
+	metrics := RegisterDefaultStreamMetrics(reg, "test", nil)
+
+	// Build a BaseProvider with a canned HTTP client whose RoundTripper
+	// always returns 200 OK + an SSE-ish body. The consumer ignores the
+	// body and emits the caller's pre-programmed chunk sequence so tests
+	// can exercise the relay in isolation from real parser logic.
+	b := NewBaseProvider("test", false, &http.Client{
+		Transport: &fixedResponseRoundTripper{
+			body: "data: {}\n\ndata: [DONE]\n\n",
+		},
+	})
+
+	return &runStreamingTestHarness{
+		t:        t,
+		chunks:   chunks,
+		provider: &b,
+		metrics:  metrics,
+		reg:      reg,
+	}
+}
+
+func (h *runStreamingTestHarness) run() []StreamChunk {
+	h.t.Helper()
+	ctx := context.Background()
+	req := &StreamRetryRequest{
+		Policy:       StreamRetryPolicy{},
+		ProviderName: "test",
+		IdleTimeout:  5 * time.Second,
+		RequestFn: func(ctx context.Context) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "POST", "http://test.invalid/x", http.NoBody)
+		},
+		Client: h.provider.GetStreamingHTTPClient(),
+	}
+	ch, err := h.provider.RunStreamingRequest(ctx, req, func(_ context.Context, body io.ReadCloser, out chan<- StreamChunk) {
+		defer close(out)
+		defer func() { _ = body.Close() }()
+		for _, c := range h.chunks {
+			out <- c
+		}
+	})
+	if err != nil {
+		h.t.Fatalf("RunStreamingRequest: %v", err)
+	}
+	var got []StreamChunk
+	for c := range ch {
+		got = append(got, c)
+	}
+	return got
+}
+
+// fixedResponseRoundTripper returns a 200 OK with a static SSE body
+// regardless of the request. Used so the retry driver's peek succeeds
+// and RunStreamingRequest enters the success path where the relay runs.
+type fixedResponseRoundTripper struct {
+	body string
+}
+
+func (f *fixedResponseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(f.body))),
+		Request:    req,
+	}, nil
+}
+
+func TestRunStreamingRequest_HealthyStreamObservesNothing(t *testing.T) {
+	// Not t.Parallel: the harness mutates the package-level
+	// DefaultStreamMetrics via ResetDefaultStreamMetrics +
+	// RegisterDefaultStreamMetrics, and RunStreamingRequest reads
+	// DefaultStreamMetrics() inside the relay goroutine. Running
+	// these tests in parallel would interleave resets and cause one
+	// test's observations to land in another test's registry.
+	// A successful stream with content chunks and a clean finish must
+	// NOT produce a sample in the error-chunks histogram — the metric
+	// is strictly for errored streams.
+	h := newRunStreamingTestHarness(t, []StreamChunk{
+		{Delta: "hello "},
+		{Delta: "world"},
+		{FinishReason: stringPtr("stop")},
+	})
+
+	got := h.run()
+	if len(got) != 3 {
+		t.Errorf("chunks received = %d, want 3", len(got))
+	}
+
+	count := testutil.CollectAndCount(h.metrics.streamErrorChunksForwarded)
+	if count != 0 {
+		t.Errorf("error chunks histogram series count = %d, want 0 (no errors occurred)", count)
+	}
+}
+
+func TestRunStreamingRequest_ErrorAtZeroContentChunks(t *testing.T) {
+	// Not t.Parallel — see harness note on TestRunStreamingRequest_HealthyStreamObservesNothing.
+	// An error terminal chunk with nothing forwarded first must be
+	// observed as 0 — this is the bucket that represents errors Phase 1
+	// could have caught if the classifier had recognised them.
+	h := newRunStreamingTestHarness(t, []StreamChunk{
+		{Error: errors.New("upstream exploded"), FinishReason: stringPtr("error")},
+	})
+
+	_ = h.run()
+
+	if c, s := histogramSample(h.reg, "test_stream_error_chunks_forwarded", "test"); c != 1 || s != 0 {
+		t.Errorf("histogram count=%d sum=%f, want count=1 sum=0 (zero content chunks before error)", c, s)
+	}
+}
+
+func TestRunStreamingRequest_ErrorAfterContentChunks(t *testing.T) {
+	// Not t.Parallel — see harness note on TestRunStreamingRequest_HealthyStreamObservesNothing.
+	// The Phase 4 value-proposition case: an error after N content
+	// chunks have been delivered downstream. The relay must count each
+	// content-bearing chunk and observe N on the terminal error.
+	h := newRunStreamingTestHarness(t, []StreamChunk{
+		{Delta: "chunk-1"},
+		{Delta: "chunk-2"},
+		{Delta: "chunk-3"},
+		{Error: errors.New("mid-stream kill"), FinishReason: stringPtr("error")},
+	})
+
+	got := h.run()
+	// Caller must see all 4 chunks, including the terminal error — the
+	// relay must not drop chunks on the way past the metric observation.
+	if len(got) != 4 {
+		t.Errorf("chunks received = %d, want 4 (relay must not drop chunks)", len(got))
+	}
+	if got[3].Error == nil {
+		t.Error("final chunk must carry the error to the caller")
+	}
+
+	if c, s := histogramSample(h.reg, "test_stream_error_chunks_forwarded", "test"); c != 1 || s != 3 {
+		t.Errorf("histogram count=%d sum=%f, want count=1 sum=3 (three content chunks before error)", c, s)
+	}
+}
+
+func TestRunStreamingRequest_FinishReasonChunkDoesNotCount(t *testing.T) {
+	// Not t.Parallel — see harness note on TestRunStreamingRequest_HealthyStreamObservesNothing.
+	// A chunk carrying only a finish reason (no delta, no tool calls,
+	// no media) must NOT increment the content chunk count. Providers
+	// emit this style of chunk as a clean-close marker, and it has no
+	// payload the caller committed to.
+	h := newRunStreamingTestHarness(t, []StreamChunk{
+		{Delta: "one"},
+		{FinishReason: stringPtr("stop")}, // clean close marker, no content
+		{Error: errors.New("fail after close")},
+	})
+	_ = h.run()
+
+	// Expected: content count = 1 (only the "one" delta), not 2.
+	if c, s := histogramSample(h.reg, "test_stream_error_chunks_forwarded", "test"); c != 1 || s != 1 {
+		t.Errorf("histogram count=%d sum=%f, want count=1 sum=1", c, s)
+	}
+}
+
+func TestRunStreamingRequest_InFlightGaugesReturnToZero(t *testing.T) {
+	// Not t.Parallel — see harness note on TestRunStreamingRequest_HealthyStreamObservesNothing.
+	// Regression guard for the relay refactor: splitting the consumer
+	// goroutine from the relay goroutine must not leave any in-flight
+	// gauge stuck above zero after the caller drains outChan. This is
+	// the same invariant the loadtest suite's
+	// assertInFlightGaugesZero helper enforces, but scoped to the
+	// relay path specifically.
+	h := newRunStreamingTestHarness(t, []StreamChunk{
+		{Delta: "a"},
+		{Delta: "b"},
+		{FinishReason: stringPtr("stop")},
+	})
+	_ = h.run()
+
+	// Allow the relay's deferred decrements to settle — they fire
+	// after the caller reads the closed channel.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(h.metrics.streamsInFlight.WithLabelValues("test")) == 0 &&
+			testutil.ToFloat64(h.metrics.providerCallsInFlight.WithLabelValues("test")) == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("in-flight gauges did not return to zero: streams=%v calls=%v",
+		testutil.ToFloat64(h.metrics.streamsInFlight.WithLabelValues("test")),
+		testutil.ToFloat64(h.metrics.providerCallsInFlight.WithLabelValues("test")),
+	)
+}
+
+// histogramSample returns the total sample count and sum for a named
+// histogram series labelled provider=<provider>, reading from a
+// prometheus registry. Returns (0, 0) when the histogram has no
+// samples matching the label. Using Gather() avoids pulling the
+// client_model/go dto package into this file's imports.
+func histogramSample(reg *prometheus.Registry, metricName, provider string) (count uint64, sum float64) {
+	mfs, _ := reg.Gather()
+	for _, mf := range mfs {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var matches bool
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "provider" && lp.GetValue() == provider {
+					matches = true
+				}
+			}
+			if !matches {
+				continue
+			}
+			hist := m.GetHistogram()
+			if hist == nil {
+				continue
+			}
+			count += hist.GetSampleCount()
+			sum += hist.GetSampleSum()
+		}
+	}
+	return count, sum
+}

--- a/runtime/providers/stream_metrics.go
+++ b/runtime/providers/stream_metrics.go
@@ -14,6 +14,21 @@ import (
 // exactly the workload this histogram exists to observe.
 var streamFirstChunkBuckets = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300}
 
+// streamErrorChunksForwardedBuckets partitions the "chunks forwarded
+// before error" histogram. The critical boundary is 0 vs 1: zero
+// chunks means Phase 1 pre-first-chunk retry could have caught the
+// failure (and the caller saw no content), whereas one or more means
+// the stream leaked through the safe-retry window and content has
+// already been emitted downstream — the regime where only Phase 4
+// dedup-aware resume can help. The upper tail covers full reasoning
+// responses that can run into tens of thousands of chunks.
+//
+// See AltairaLabs/PromptKit#864: this histogram is the load-bearing
+// measurement for deciding whether Phase 4 is worth building.
+var streamErrorChunksForwardedBuckets = []float64{
+	0, 1, 5, 20, 100, 500, 2000, 10000,
+}
+
 // StreamMetrics holds the direct-update Prometheus metrics for streaming
 // provider calls. These are updated inline at the source (not via the
 // event bus) so that burst-load drops on the event bus cannot corrupt
@@ -27,6 +42,7 @@ type StreamMetrics struct {
 	streamsInFlight             *prometheus.GaugeVec
 	providerCallsInFlight       *prometheus.GaugeVec
 	streamFirstChunkLatency     *prometheus.HistogramVec
+	streamErrorChunksForwarded  *prometheus.HistogramVec
 	streamRetriesTotal          *prometheus.CounterVec
 	streamRetryBudgetAvailable  *prometheus.GaugeVec
 	streamConcurrencyRejections *prometheus.CounterVec
@@ -67,6 +83,22 @@ func NewStreamMetrics(
 			Help: "Time from request dispatch to first SSE data event observed, " +
 				"per provider. Includes any pre-first-chunk retries.",
 			Buckets:     streamFirstChunkBuckets,
+			ConstLabels: constLabels,
+		}, []string{"provider"}),
+		streamErrorChunksForwarded: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "stream_error_chunks_forwarded",
+			Help: "Number of content chunks forwarded downstream before a stream " +
+				"terminated with an error, per provider. Observed once per failed " +
+				"stream on the terminal error chunk. The bucket at 0 counts errors " +
+				"that reached the consumer with no content already emitted (a regime " +
+				"Phase 1 pre-first-chunk retry could cover if the classifier recognized " +
+				"the error as retryable); buckets at 1 and above count mid-stream " +
+				"failures that leaked past the safe-retry window and would require " +
+				"Phase 4 dedup-aware resume to recover (see AltairaLabs/PromptKit#864). " +
+				"This histogram is the load-bearing measurement for deciding whether " +
+				"Phase 4 is worth building.",
+			Buckets:     streamErrorChunksForwardedBuckets,
 			ConstLabels: constLabels,
 		}, []string{"provider"}),
 		streamRetriesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -110,12 +142,25 @@ func NewStreamMetrics(
 		m.streamsInFlight,
 		m.providerCallsInFlight,
 		m.streamFirstChunkLatency,
+		m.streamErrorChunksForwarded,
 		m.streamRetriesTotal,
 		m.streamRetryBudgetAvailable,
 		m.streamConcurrencyRejections,
 		m.httpConnsInUse,
 	)
 	return m
+}
+
+// ObserveStreamErrorChunksForwarded records how many content chunks were
+// forwarded downstream before a streaming request terminated with an
+// error. Called exactly once per errored stream by the RunStreamingRequest
+// relay goroutine, with the count of non-empty content chunks observed
+// prior to the terminal error chunk. Nil-safe.
+func (m *StreamMetrics) ObserveStreamErrorChunksForwarded(provider string, chunks int) {
+	if m == nil {
+		return
+	}
+	m.streamErrorChunksForwarded.WithLabelValues(provider).Observe(float64(chunks))
 }
 
 // HTTPConnsInUseInc increments the in-use HTTP connection gauge for a


### PR DESCRIPTION
## Summary

Adds the single missing measurement that gates the Phase 4 dedup-resume build/skip decision in #864.

The problem with #864 was never that Phase 4 was hard to design — the design is straightforward. The problem was deciding whether it was worth building without knowing what fraction of real stream failures actually land in the mid-stream window that Phase 4 would cover. #874 showed the mechanism (catch rate is 100% on pure pre-first-chunk, 0% on pure mid-stream, 50% on 50/50 mix), but gave no production signal on the real pre/mid ratio.

This PR adds `promptkit_stream_error_chunks_forwarded{provider}`, a histogram that observes, on every errored stream, how many content chunks were delivered downstream before the terminal error.

## What the distribution tells you

| Mass concentration | Interpretation | Phase 4 value |
|---|---|---|
| at bucket `0` | errors reach the consumer with no content forwarded yet — Phase 1 could cover if the classifier recognized the error as retryable | **Fix Phase 1 classification, skip Phase 4** |
| mass at `≥1` | errors leak past the safe-retry window with content already downstream | **Phase 4 worth building** |
| heavy tail (`≥100`) | long reasoning responses are dying mid-stream after meaningful output | **Phase 4 is the only recovery path** |

Buckets `[0, 1, 5, 20, 100, 500, 2000, 10000]` cover the critical `0`/`1` boundary and the full span of real stream lengths from short chat responses to long reasoning output.

## Implementation

A relay goroutine splits the existing `RunStreamingRequest` pipeline:

```
body → consumer → innerChan → relay → outChan → caller
```

The relay counts content-bearing chunks and observes the histogram on terminal error chunks, then forwards to the outer channel. **Single point of instrumentation means every provider is covered automatically** — no per-provider wiring. This is the same design pattern that made the earlier retry driver and conn-tracking transport work cleanly across every SSE provider, Realtime WebSocket, Gemini, and Ollama simultaneously.

Lifetime ownership:
- **Consumer goroutine's defer**: releases the upstream stream semaphore immediately when the body is drained, so a slow caller cannot hold an upstream connection slot.
- **Relay goroutine's defer**: decrements the `streams_in_flight` and `provider_calls_in_flight` gauges and closes `outChan`, so those gauges reflect the caller's view of stream lifetime.

A chunk "forwards content" if it delivers a text delta, media data, or tool call arguments. Pure finish-reason chunks and error terminals do not count — only payload the downstream consumer has committed to.

## Tests (6 new, all passing)

- **Nil-safety** on the observer.
- **`chunkForwardedContent` classification** across seven chunk shapes (text delta, tool call, media, content-only without delta, finish-reason-only, error, empty).
- **End-to-end: healthy stream** observes nothing in the histogram.
- **End-to-end: error at 0 content chunks** observes 0 — the Phase-1-coverable bucket.
- **End-to-end: error after N content chunks** observes N — the Phase-4-only bucket. Verifies that the relay does not drop the terminal error chunk on the way past instrumentation.
- **End-to-end: finish-reason-only chunk** does not count toward content.
- **End-to-end: in-flight gauges return to zero** through the relay path — regression guard for the lifetime-ownership split.

## Regression coverage

All existing tests including the full loadtest suite remain green:
- Mid-stream failure invariant (#869)
- Herd-kill synchronization (#875)
- Scale ramp to 5k (#872)
- Push-to-destruction to 300k (#872)
- First-chunk latency validation (#874)

The relay is transparent to observable behavior.

## Coverage on changed files

- `runtime/providers/base_provider.go`: **94.6%**
- `runtime/providers/stream_metrics.go`: **96.0%**

## Next step for #864

Let the capability matrix (nightly, 35 providers) and any production deployments scrape this histogram for a week, then look at the distribution. Until that data exists, Phase 4 remains speculative — and now the blocker is time-on-prod rather than "we don't have the data."

## Test plan

- [x] `go test ./runtime/providers/... -count=1` — all green
- [x] `go test ./runtime/... -count=1` — all green
- [x] `go test ./sdk/... -count=1` — all green
- [x] `go test ./tools/arena/... -count=1` — all green
- [x] `go test -tags=loadtest -run TestStreamRetryLoad ./runtime/providers/openai/` — all 9 loadtest scenarios green
- [x] `golangci-lint run --new-from-rev=main` — 0 issues
- [x] Pre-commit hook passes (lint + build + test + coverage ≥80% on all changed files)
