### PR TITLE
docs: document streaming retry, transport pool, and concurrency provider config

### DIFF
--- a/docs/src/content/docs/arena/how-to/configure-providers.md
+++ b/docs/src/content/docs/arena/how-to/configure-providers.md
@@ -362,6 +362,62 @@ spec:
     guided_choice: ["yes", "no", "maybe"]
 ```
 
+## Streaming and Reliability
+
+Provider configs support streaming retry, concurrency limits, and connection pool tuning. These are all optional and default to safe values.
+
+### Streaming Retry
+
+Recover from transient HTTP/2 stream resets without failing the test:
+
+```yaml
+spec:
+  type: openai
+  model: gpt-5-pro
+  stream_retry:
+    enabled: true
+    max_attempts: 2           # initial + 1 retry
+    retry_window: pre_first_chunk  # safe default
+    budget:
+      rate_per_sec: 5
+      burst: 10
+```
+
+Set `retry_window: always` to also retry mid-stream failures (the response is discarded and re-requested from scratch, costing additional tokens):
+
+```yaml
+  stream_retry:
+    enabled: true
+    retry_window: always      # costs tokens on mid-stream retry
+```
+
+### Concurrency and Timeouts
+
+```yaml
+spec:
+  type: openai
+  model: gpt-4o
+  request_timeout: "60s"          # non-streaming call timeout
+  stream_idle_timeout: "30s"      # abort if stream goes silent
+  stream_max_concurrent: 50       # max parallel streams (0 = unlimited)
+```
+
+### Connection Pool
+
+Raise `max_conns_per_host` when running high-concurrency test suites against a single provider:
+
+```yaml
+spec:
+  type: openai
+  model: gpt-4o
+  http_transport:
+    max_conns_per_host: 250       # default: 100
+    max_idle_conns_per_host: 250
+    idle_conn_timeout: "90s"
+```
+
+The effective concurrent-stream ceiling is `max_conns_per_host` multiplied by the upstream's HTTP/2 max concurrent streams setting (typically 100-256). The `promptkit_http_conns_in_use` Prometheus gauge tracks pool pressure.
+
 ## Arena Configuration
 
 Reference providers in your `arena.yaml`:

--- a/docs/src/content/docs/sdk/reference/runtime-config.md
+++ b/docs/src/content/docs/sdk/reference/runtime-config.md
@@ -71,6 +71,11 @@ Validation requires `type` and `model` on every entry.
 | `capabilities` | string[] | no | Declared provider capabilities: `text`, `streaming`, `vision`, `tools`, `json`, `audio`, `video`, `documents`. |
 | `include_raw_output` | bool | no | Include raw API request/response in output for debugging. |
 | `additional_config` | map[string]any | no | Provider-specific configuration not covered by other fields. |
+| `request_timeout` | string | no | Wall-clock timeout for non-streaming HTTP calls (Predict, embeddings). Go duration string, e.g. `"60s"`, `"2m"`. Does not apply to streaming. |
+| `stream_idle_timeout` | string | no | Max silence between bytes on a streaming body before the stream is aborted. Timer resets on every byte received. Default: `"30s"`. |
+| `stream_retry` | object | no | Streaming retry configuration. See [stream_retry](#stream_retry). |
+| `stream_max_concurrent` | int | no | Max concurrent streaming requests in flight. Requests beyond the limit block on the caller's context. `0` = unlimited (default). |
+| `http_transport` | object | no | HTTP connection pool tuning. See [http_transport](#http_transport). |
 
 #### credential
 
@@ -119,6 +124,36 @@ Configures hyperscaler hosting platforms (Bedrock, Vertex, Azure) that provide m
 | `project` | string | Cloud project ID. Required for Vertex. |
 | `endpoint` | string | Custom endpoint URL override. |
 | `additional_config` | map[string]any | Platform-specific settings. |
+
+#### stream_retry
+
+Bounded retry for streaming requests. By default, retry only fires in the pre-first-chunk window (before any content has been forwarded to the caller), which is safe and invisible. Setting `retry_window: always` enables mid-stream retry: on failure after content has been forwarded, a `Reset` signal is emitted so consumers discard accumulated state, then the full request is retried from scratch. Mid-stream retry costs additional tokens because the provider generates a new response.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | bool | Turn the retry loop on. Default: `false`. |
+| `max_attempts` | int | Total attempts including the initial request. `2` = one retry. Default: `2`. |
+| `initial_delay` | string | Base backoff before the first retry. Go duration string. Default: `"250ms"`. |
+| `max_delay` | string | Maximum per-attempt backoff. Go duration string. Default: `"2s"`. |
+| `retry_window` | string | `"pre_first_chunk"` (default, safe) or `"always"` (mid-stream reset retry, costs tokens). |
+| `budget` | object | Token bucket that gates retry attempts to prevent thundering-herd reconnects. See below. |
+
+**stream_retry.budget:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rate_per_sec` | float | Sustained token refill rate. |
+| `burst` | int | Maximum tokens that can accumulate. |
+
+#### http_transport
+
+Per-provider HTTP connection pool tuning. Controls how many TCP connections the provider opens to its upstream and how long idle connections linger. The effective concurrent-stream ceiling per upstream is `max_conns_per_host` multiplied by the upstream's HTTP/2 `SETTINGS_MAX_CONCURRENT_STREAMS` (typically 100-256).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `max_conns_per_host` | int | Max TCP connections to any single host (in-use + idle). Default: `100`. |
+| `max_idle_conns_per_host` | int | Max idle keep-alive connections retained per host. Default: `100`. |
+| `idle_conn_timeout` | string | How long idle connections linger before being closed. Go duration string. Default: `"90s"`. |
 
 ---
 
@@ -294,6 +329,19 @@ spec:
       pricing:
         input_cost_per_1k: 0.003
         output_cost_per_1k: 0.015
+      request_timeout: "60s"
+      stream_idle_timeout: "30s"
+      stream_retry:
+        enabled: true
+        max_attempts: 2
+        retry_window: pre_first_chunk  # or "always" for mid-stream reset retry
+        budget:
+          rate_per_sec: 5
+          burst: 10
+      stream_max_concurrent: 100
+      http_transport:
+        max_conns_per_host: 200
+        max_idle_conns_per_host: 200
 
     - id: embeddings
       type: voyageai


### PR DESCRIPTION
## Summary

Updates two existing doc pages to cover the provider config fields added during the streaming retry arc (#855 through #895). No new pages — just filling gaps in the existing reference.

## Changes

**`docs/src/content/docs/sdk/reference/runtime-config.md`** (SDK YAML reference):
- Added `request_timeout`, `stream_idle_timeout`, `stream_retry`, `stream_max_concurrent`, `http_transport` to the `spec.providers[]` field table
- Added `stream_retry` subsection with full field table (enabled, max_attempts, initial_delay, max_delay, retry_window, budget)
- Added `http_transport` subsection with field table (max_conns_per_host, max_idle_conns_per_host, idle_conn_timeout)
- Updated the complete example YAML to show all new fields on the main-llm provider

**`docs/src/content/docs/arena/how-to/configure-providers.md`** (Arena guide):
- Added "Streaming and Reliability" section before "Arena Configuration"
- Three subsections with copy-pasteable YAML examples:
  - Streaming Retry (pre_first_chunk and always modes)
  - Concurrency and Timeouts
  - Connection Pool tuning

## Test plan

- [x] Verified the markdown renders correctly (no broken tables or formatting)
- [x] All YAML examples match the actual config struct fields in `pkg/config/types.go`
- [x] Field descriptions match the Go doc comments
