### PR TITLE
feat(providers): wire Bedrock eventstream through retry driver

### DIFF
--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -67,20 +67,41 @@ func (p *Provider) PredictStream(
 		}
 	}
 
-	// Bedrock: use binary event-stream format
+	// Bedrock: use binary event-stream format, wired through the same
+	// RunStreamingRequest path as the direct API so Bedrock gets retry,
+	// budget, semaphore, and metrics for free.
 	if p.isBedrock() {
 		reqBody, err := p.marshalBedrockStreamingRequest(claudeReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal request: %w", err)
 		}
-		body, scanner, err := p.makeBedrockStreamingRequest(ctx, reqBody)
-		if err != nil {
-			return nil, err
+		url := p.messagesStreamURL()
+		requestFn := func(ctx context.Context) (*http.Request, error) {
+			httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+			if reqErr != nil {
+				return nil, fmt.Errorf("failed to create request: %w", reqErr)
+			}
+			httpReq.Header.Set(contentTypeHeader, applicationJSON)
+			httpReq.Header.Set("Accept", "application/vnd.amazon.eventstream")
+			if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+				return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+			}
+			return httpReq, nil
 		}
-		idleBody := providers.NewIdleTimeoutReader(body, p.StreamIdleTimeout())
-		outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-		go p.streamResponse(ctx, idleBody, scanner, outChan)
-		return outChan, nil
+		return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+			Policy:        p.StreamRetryPolicy(),
+			Budget:        p.StreamRetryBudget(),
+			ProviderName:  p.ID(),
+			Host:          providers.HostFromURL(url),
+			IdleTimeout:   p.StreamIdleTimeout(),
+			RequestFn:     requestFn,
+			Client:        p.GetStreamingHTTPClient(),
+			FrameDetector: providers.BedrockEventStreamFrameDetector{},
+		}, func(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
+			idleBody := providers.NewIdleTimeoutReader(body, p.StreamIdleTimeout())
+			scanner := providers.NewBedrockEventScanner(idleBody)
+			p.streamResponse(ctx, idleBody, scanner, outChan)
+		})
 	}
 
 	reqBody, err := json.Marshal(claudeReq)

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -569,20 +570,40 @@ func (p *ToolProvider) PredictStreamWithTools(
 	// Add streaming flag
 	claudeReq["stream"] = true
 
-	// Bedrock: use binary event-stream format
+	// Bedrock: use binary event-stream format, wired through
+	// RunStreamingRequest for retry, budget, semaphore, and metrics.
 	if p.isBedrock() {
 		reqBody, err := p.marshalBedrockStreamingRequest(claudeReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal request: %w", err)
 		}
-		body, scanner, err := p.makeBedrockStreamingRequest(ctx, reqBody)
-		if err != nil {
-			return nil, err
+		url := p.messagesStreamURL()
+		requestFn := func(ctx context.Context) (*http.Request, error) {
+			httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+			if reqErr != nil {
+				return nil, fmt.Errorf("failed to create request: %w", reqErr)
+			}
+			httpReq.Header.Set(contentTypeHeader, applicationJSON)
+			httpReq.Header.Set("Accept", "application/vnd.amazon.eventstream")
+			if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+				return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+			}
+			return httpReq, nil
 		}
-		idleBody := providers.NewIdleTimeoutReader(body, p.StreamIdleTimeout())
-		outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-		go p.streamResponse(ctx, idleBody, scanner, outChan)
-		return outChan, nil
+		return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+			Policy:        p.StreamRetryPolicy(),
+			Budget:        p.StreamRetryBudget(),
+			ProviderName:  p.ID(),
+			Host:          providers.HostFromURL(url),
+			IdleTimeout:   p.StreamIdleTimeout(),
+			RequestFn:     requestFn,
+			Client:        p.GetStreamingHTTPClient(),
+			FrameDetector: providers.BedrockEventStreamFrameDetector{},
+		}, func(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
+			idleBody := providers.NewIdleTimeoutReader(body, p.StreamIdleTimeout())
+			scanner := providers.NewBedrockEventScanner(idleBody)
+			p.streamResponse(ctx, idleBody, scanner, outChan)
+		})
 	}
 
 	requestBytes, err := json.Marshal(claudeReq)

--- a/runtime/providers/frame_detector.go
+++ b/runtime/providers/frame_detector.go
@@ -323,6 +323,58 @@ func isJSONWhitespace(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
+// --- AWS Bedrock event-stream ---
+
+// BedrockEventStreamFrameDetector reads one complete AWS binary
+// event-stream message. The format is:
+//
+//	[4-byte total_length BE][4-byte headers_length BE][4-byte prelude_crc]
+//	[headers...][payload...][4-byte message_crc]
+//
+// The detector reads the 4-byte total_length prefix, then reads
+// exactly (total_length - 4) more bytes to complete the message.
+// This gives the retry driver one full binary frame for replay,
+// confirming the stream is "live" before handing it to the consumer.
+//
+// Used by the Claude provider when running on AWS Bedrock
+// (Content-Type: application/vnd.amazon.eventstream).
+type BedrockEventStreamFrameDetector struct{}
+
+// Name implements FrameDetector.
+func (BedrockEventStreamFrameDetector) Name() string { return "bedrock-eventstream" }
+
+// PeekFirstFrame reads one complete event-stream message from r and
+// returns the raw bytes. The reader must be positioned at the start
+// of a message boundary.
+func (BedrockEventStreamFrameDetector) PeekFirstFrame(r io.Reader) ([]byte, error) {
+	// Read the 4-byte total message length (big-endian uint32).
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return nil, fmt.Errorf("bedrock eventstream: reading message length: %w", err)
+	}
+	totalLen := uint32(lenBuf[0])<<24 | uint32(lenBuf[1])<<16 | uint32(lenBuf[2])<<8 | uint32(lenBuf[3])
+
+	// Sanity: messages must be at least 16 bytes (12-byte prelude + 4-byte CRC).
+	const minMessageSize = 16
+	if totalLen < minMessageSize {
+		return nil, fmt.Errorf("bedrock eventstream: message length %d too small (min %d)", totalLen, minMessageSize)
+	}
+
+	// Cap at a reasonable max to guard against corrupted length fields.
+	const maxMessageSize = 16 * 1024 * 1024 // 16 MB
+	if totalLen > maxMessageSize {
+		return nil, fmt.Errorf("bedrock eventstream: message length %d exceeds max %d", totalLen, maxMessageSize)
+	}
+
+	// Allocate and fill the complete message (including the length prefix).
+	msg := make([]byte, totalLen)
+	copy(msg[:4], lenBuf[:])
+	if _, err := io.ReadFull(r, msg[4:]); err != nil {
+		return nil, fmt.Errorf("bedrock eventstream: reading message body: %w", err)
+	}
+	return msg, nil
+}
+
 // --- Shared helpers ---
 
 // drainBufferedInto copies any bytes sitting in the bufio.Reader's

--- a/runtime/providers/frame_detector_test.go
+++ b/runtime/providers/frame_detector_test.go
@@ -223,10 +223,116 @@ func TestJSONArrayFrameDetector_Name(t *testing.T) {
 
 func TestFrameDetector_InterfaceCompliance(t *testing.T) {
 	t.Parallel()
-	// Compile-time check that each concrete type implements the
-	// interface. A failure here would fail the build, not the test,
-	// but having them listed as assertions documents the intent.
 	var _ FrameDetector = SSEFrameDetector{}
 	var _ FrameDetector = NDJSONFrameDetector{}
 	var _ FrameDetector = JSONArrayFrameDetector{}
+	var _ FrameDetector = BedrockEventStreamFrameDetector{}
+}
+
+// --- Bedrock event-stream ---
+
+func TestBedrockEventStreamFrameDetector_Name(t *testing.T) {
+	t.Parallel()
+	if got := (BedrockEventStreamFrameDetector{}).Name(); got != "bedrock-eventstream" {
+		t.Errorf("Name() = %q, want %q", got, "bedrock-eventstream")
+	}
+}
+
+// buildEventStreamMessage creates a raw AWS binary event-stream message
+// from a payload. Minimal implementation: only sets total_length and
+// headers_length (0 headers), fills prelude CRC and message CRC with
+// zeroes (the frame detector doesn't validate CRCs — the AWS SDK
+// decoder handles that).
+func buildEventStreamMessage(payload []byte) []byte {
+	// Total length = 12 (prelude) + 0 (headers) + len(payload) + 4 (message CRC)
+	totalLen := uint32(12 + len(payload) + 4)
+	msg := make([]byte, totalLen)
+	// 4 bytes: total length (big-endian)
+	msg[0] = byte(totalLen >> 24)
+	msg[1] = byte(totalLen >> 16)
+	msg[2] = byte(totalLen >> 8)
+	msg[3] = byte(totalLen)
+	// 4 bytes: headers length (0)
+	// 4 bytes: prelude CRC (0 — not validated by detector)
+	// payload
+	copy(msg[12:], payload)
+	// 4 bytes: message CRC (0 — not validated by detector)
+	return msg
+}
+
+func TestBedrockEventStreamFrameDetector_SingleMessage(t *testing.T) {
+	t.Parallel()
+	payload := []byte(`{"bytes":"aGVsbG8="}`)
+	msg := buildEventStreamMessage(payload)
+
+	got, err := (BedrockEventStreamFrameDetector{}).PeekFirstFrame(
+		strings.NewReader(string(msg)),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(msg) {
+		t.Errorf("peeked %d bytes, want %d", len(got), len(msg))
+	}
+}
+
+func TestBedrockEventStreamFrameDetector_TwoMessages(t *testing.T) {
+	t.Parallel()
+	msg1 := buildEventStreamMessage([]byte(`{"bytes":"Zmlyc3Q="}`))
+	msg2 := buildEventStreamMessage([]byte(`{"bytes":"c2Vjb25k"}`))
+	combined := append(msg1, msg2...)
+
+	got, err := (BedrockEventStreamFrameDetector{}).PeekFirstFrame(
+		strings.NewReader(string(combined)),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should return exactly the first message, not both.
+	if len(got) != len(msg1) {
+		t.Errorf("peeked %d bytes, want %d (first message only)", len(got), len(msg1))
+	}
+}
+
+func TestBedrockEventStreamFrameDetector_EmptyStream(t *testing.T) {
+	t.Parallel()
+	_, err := (BedrockEventStreamFrameDetector{}).PeekFirstFrame(
+		strings.NewReader(""),
+	)
+	if err == nil {
+		t.Fatal("empty stream should return an error")
+	}
+}
+
+func TestBedrockEventStreamFrameDetector_TruncatedPrelude(t *testing.T) {
+	t.Parallel()
+	// Only 2 bytes — not enough for the 4-byte length prefix.
+	_, err := (BedrockEventStreamFrameDetector{}).PeekFirstFrame(
+		strings.NewReader("\x00\x00"),
+	)
+	if err == nil {
+		t.Fatal("truncated prelude should return an error")
+	}
+}
+
+func TestBedrockEventStreamFrameDetector_TruncatedBody(t *testing.T) {
+	t.Parallel()
+	// Length says 100 bytes total but we only provide the 4-byte prefix.
+	_, err := (BedrockEventStreamFrameDetector{}).PeekFirstFrame(
+		strings.NewReader("\x00\x00\x00\x64"),
+	)
+	if err == nil {
+		t.Fatal("truncated body should return an error")
+	}
+}
+
+func TestBedrockEventStreamFrameDetector_TooSmallLength(t *testing.T) {
+	t.Parallel()
+	// Length = 4 is below the minimum 16-byte message size.
+	_, err := (BedrockEventStreamFrameDetector{}).PeekFirstFrame(
+		strings.NewReader("\x00\x00\x00\x04"),
+	)
+	if err == nil {
+		t.Fatal("too-small message length should return an error")
+	}
 }


### PR DESCRIPTION
Closes #865.

## Summary

AWS Bedrock's binary eventstream streaming was the last provider path that bypassed `RunStreamingRequest`. Now wired through the same single entry point as every other provider, giving Bedrock streaming the full Phase 1-3 retry/budget/semaphore/metrics stack for free.

## What changed

- **`BedrockEventStreamFrameDetector`** — new `FrameDetector` implementation for the AWS binary eventstream protocol. Reads one complete message by parsing the 4-byte big-endian total_length prefix. Sanity checks for minimum (16 bytes) and maximum (16 MB) message sizes.
- **`PredictStream` Bedrock branch** — refactored from `makeBedrockStreamingRequest` (direct HTTP + manual channel) to `RunStreamingRequest` with a `requestFn` closure and `BedrockEventStreamFrameDetector`.
- **`PredictStreamWithTools` Bedrock branch** — same refactor.

## What Bedrock streaming now gets

Everything the SSE providers already had:
- Pre-first-chunk retry on connection failures
- Mid-stream reset retry (`retry_window: always`)
- Retry budget anti-amplification
- Concurrent-stream semaphore
- `streams_in_flight`, `provider_calls_in_flight` gauges
- `stream_first_chunk_latency_seconds` histogram
- `stream_error_chunks_forwarded` histogram
- `http_conns_in_use` gauge

## Tests (7 new)

- `BedrockEventStreamFrameDetector`: Name, SingleMessage, TwoMessages (only first returned), EmptyStream, TruncatedPrelude, TruncatedBody, TooSmallLength
- Interface compliance check updated to include the new detector
- All existing Bedrock streaming tests pass unchanged

## Coverage

- `claude_streaming.go`: 89.6%
- `claude_tools.go`: 85.3%
- `frame_detector.go`: 89.1%

## Test plan

- [x] All provider tests pass (claude, openai, gemini, ollama, vllm, etc.)
- [x] Existing Bedrock streaming tests unchanged and passing
- [x] `golangci-lint --new-from-rev=main` — 0 issues
- [x] Pre-commit hook passes
