### PR TITLE
fix(realtime): heartbeat failure closes connection + connection loss error signal

### DIFF
--- a/runtime/providers/internal/streaming/conn.go
+++ b/runtime/providers/internal/streaming/conn.go
@@ -348,6 +348,12 @@ func (c *Conn) heartbeatLoop(ctx context.Context, interval time.Duration) {
 			return
 		case <-ticker.C:
 			if !c.sendPing() {
+				// Ping failed — the connection is dead or stalled.
+				// Close the underlying WebSocket so ReceiveLoop
+				// unblocks with an error and the session terminates
+				// instead of silently going stale.
+				c.cfg.Logger.Warn("heartbeat ping failed, closing connection")
+				_ = c.Close()
 				return
 			}
 		}

--- a/runtime/providers/openai/realtime_session_integration.go
+++ b/runtime/providers/openai/realtime_session_integration.go
@@ -16,6 +16,13 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// ErrConnectionLost is the error type emitted on the Response channel
+// when the WebSocket connection drops mid-session (network failure,
+// heartbeat timeout, server-initiated close with a non-graceful code).
+// Callers can check for this with errors.Is to distinguish recoverable
+// connection loss from clean session termination or server-side errors.
+var ErrConnectionLost = errors.New("websocket connection lost")
+
 // Common error messages
 const (
 	errSessionClosed = "session is closed"
@@ -461,11 +468,34 @@ func (s *RealtimeSession) receiveLoop() {
 			return
 		case err := <-errCh:
 			if err != nil && !errors.Is(err, context.Canceled) {
-				logger.Error("OpenAI Realtime: receive loop error", "error", err)
+				connErr := fmt.Errorf("%w: %w", ErrConnectionLost, err)
+				logger.Error("OpenAI Realtime: connection lost", "error", err)
+
+				// Emit a terminal error chunk so callers reading
+				// Response() learn the session died with a
+				// distinguishable error type. errors.Is(chunk.Error,
+				// ErrConnectionLost) returns true.
+				reason := "error"
 				select {
-				case s.errCh <- err:
+				case s.responseCh <- providers.StreamChunk{
+					Error:        connErr,
+					FinishReason: &reason,
+				}:
 				default:
 				}
+
+				// Propagate to errCh for callers using Error().
+				select {
+				case s.errCh <- connErr:
+				default:
+				}
+
+				// Cancel the session context so Done() fires.
+				// Callers watching Done() + Error() now have a
+				// complete signal: Done fired, Error returns
+				// ErrConnectionLost, Response channel has the
+				// terminal chunk.
+				s.cancel()
 			} else {
 				logger.Debug("OpenAI Realtime: WebSocket receive loop ended", "error", err)
 			}


### PR DESCRIPTION
## Summary

Two fixes for the Realtime WebSocket session that prevent silent zombie sessions and give callers a clean signal when the connection drops.

## Bug 1: Heartbeat failure was silent

**Before:** When a WebSocket ping failed (network down, connection half-closed), the heartbeat goroutine exited silently. The session continued in an unknown state — `receiveLoop` blocked on `ReadMessage` indefinitely on a dead connection, and callers had no idea the session was stale.

**After:** `heartbeatLoop` calls `c.Close()` on ping failure. This sends a graceful close frame, closes the TCP connection, and unblocks `ReceiveLoop` with an error. The session terminates cleanly.

**File:** `runtime/providers/internal/streaming/conn.go` — 3 lines added in `heartbeatLoop`.

## Bug 2: Connection loss didn't fire Done() or emit error chunk

**Before:** When `receiveLoop` saw a connection error from `ReceiveLoop`, it logged it and sent it to `errCh` (capacity-1, non-blocking), but did NOT cancel the session context. So `Done()` never fired. Callers watching `Done()` didn't know the session died. Callers reading `Response()` got a closed channel with no terminal error chunk — they couldn't distinguish "clean close" from "connection dropped."

**After:** On connection loss, `receiveLoop` now:
1. Emits a terminal `StreamChunk{Error: ErrConnectionLost, FinishReason: "error"}` on `Response()` — callers reading chunks see a distinguishable error
2. Sends the wrapped error to `errCh` — callers using `Error()` get it
3. Calls `s.cancel()` — `Done()` fires so callers watching the context learn the session ended

**New exported sentinel:** `ErrConnectionLost` — callers use `errors.Is(err, openai.ErrConnectionLost)` to distinguish connection drops from clean closes and server-side errors.

**File:** `runtime/providers/openai/realtime_session_integration.go` — ~30 lines changed in `receiveLoop`.

## Test plan

- [x] `go test ./providers/openai/... -count=1` — all passing
- [x] `go test ./providers/internal/streaming/... -count=1` — all passing
- [x] Full runtime test suite — zero failures
- [x] `golangci-lint --new-from-rev=main` — 0 issues
- [x] Pre-commit hook passes (coverage: conn.go 86.4%)
