### PR TITLE
feat(tts,stt): bounded retry for synthesis and transcription calls

### DIFF
--- a/runtime/stt/retry.go
+++ b/runtime/stt/retry.go
@@ -1,0 +1,123 @@
+package stt
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+)
+
+// Retry defaults for STT transcription.
+const (
+	defaultRetryMaxAttempts  = 3
+	defaultRetryInitialDelay = 250 * time.Millisecond
+	defaultRetryMaxDelay     = 2 * time.Second
+	maxBackoffShift          = 30
+)
+
+// RetryConfig configures bounded retry for STT transcription calls.
+// Defaults are on (unlike streaming retry) because STT calls are
+// one-shot and idempotent — retry has no content-duplication risk,
+// and the alternative is silently dropped speech.
+type RetryConfig struct {
+	// MaxAttempts is the total number of attempts including the initial
+	// call. 3 means "initial + up to 2 retries". Values < 1 are
+	// treated as 1 (no retry).
+	MaxAttempts int
+	// InitialDelay is the base backoff before the first retry.
+	InitialDelay time.Duration
+	// MaxDelay caps the per-attempt backoff.
+	MaxDelay time.Duration
+}
+
+// DefaultRetryConfig returns sensible defaults for STT retry.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts:  defaultRetryMaxAttempts,
+		InitialDelay: defaultRetryInitialDelay,
+		MaxDelay:     defaultRetryMaxDelay,
+	}
+}
+
+// TranscribeWithRetry calls svc.Transcribe with bounded retry on
+// transient errors. Only errors where TranscriptionError.Retryable is
+// true are retried; all others are returned immediately. Uses full
+// jitter backoff to avoid synchronized retries across concurrent
+// callers.
+//
+//nolint:gocritic // hugeParam: config value is caller-owned and not modified
+func TranscribeWithRetry(
+	ctx context.Context,
+	svc Service,
+	audio []byte,
+	config TranscriptionConfig,
+	retry RetryConfig,
+) (string, error) {
+	maxAttempts := retry.MaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		result, err := svc.Transcribe(ctx, audio, config)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+		if !isRetryable(err) || attempt >= maxAttempts-1 {
+			break
+		}
+
+		delay := backoff(attempt, retry.InitialDelay, retry.MaxDelay)
+		logger.Warn("STT transcription failed, retrying",
+			"provider", svc.Name(),
+			"attempt", attempt+1,
+			"max_attempts", maxAttempts,
+			"delay", delay.String(),
+			"error", err,
+		)
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return "", lastErr
+}
+
+// isRetryable checks if err is a TranscriptionError with Retryable set.
+func isRetryable(err error) bool {
+	var te *TranscriptionError
+	if errors.As(err, &te) {
+		return te.Retryable
+	}
+	return false
+}
+
+// backoff computes full-jitter delay for the given attempt.
+func backoff(attempt int, initial, ceiling time.Duration) time.Duration {
+	if initial <= 0 {
+		initial = defaultRetryInitialDelay
+	}
+	if ceiling <= 0 {
+		ceiling = defaultRetryMaxDelay
+	}
+	shift := uint(min(attempt, maxBackoffShift)) //nolint:gosec // bounded by min
+	delay := initial << shift
+	if delay <= 0 || delay > ceiling {
+		delay = ceiling
+	}
+	jitter := time.Duration(time.Now().UnixNano()) % delay
+	if jitter < 0 {
+		jitter = -jitter
+	}
+	return jitter
+}

--- a/runtime/stt/retry_test.go
+++ b/runtime/stt/retry_test.go
@@ -1,0 +1,149 @@
+package stt
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockSTTService implements Service for testing retry behavior.
+type mockSTTService struct {
+	calls   atomic.Int32
+	results []mockResult
+}
+
+type mockResult struct {
+	text string
+	err  error
+}
+
+func (m *mockSTTService) Name() string               { return "mock" }
+func (m *mockSTTService) SupportedFormats() []string { return nil }
+
+func (m *mockSTTService) Transcribe(_ context.Context, _ []byte, _ TranscriptionConfig) (string, error) {
+	idx := int(m.calls.Add(1)) - 1
+	if idx < len(m.results) {
+		return m.results[idx].text, m.results[idx].err
+	}
+	return "transcribed", nil
+}
+
+func TestTranscribeWithRetry_SuccessFirstAttempt(t *testing.T) {
+	t.Parallel()
+	svc := &mockSTTService{}
+	result, err := TranscribeWithRetry(context.Background(), svc, []byte("audio"), TranscriptionConfig{}, DefaultRetryConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "transcribed" {
+		t.Errorf("result = %q, want %q", result, "transcribed")
+	}
+	if svc.calls.Load() != 1 {
+		t.Errorf("calls = %d, want 1", svc.calls.Load())
+	}
+}
+
+func TestTranscribeWithRetry_RetryOnRetryableError(t *testing.T) {
+	t.Parallel()
+	svc := &mockSTTService{
+		results: []mockResult{
+			{err: NewTranscriptionError("mock", "429", "rate limited", nil, true)},
+			{err: NewTranscriptionError("mock", "503", "unavailable", nil, true)},
+			{text: "hello world"},
+		},
+	}
+	result, err := TranscribeWithRetry(context.Background(), svc, []byte("audio"), TranscriptionConfig{}, RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "hello world" {
+		t.Errorf("result = %q, want %q", result, "hello world")
+	}
+	if svc.calls.Load() != 3 {
+		t.Errorf("calls = %d, want 3", svc.calls.Load())
+	}
+}
+
+func TestTranscribeWithRetry_NoRetryOnNonRetryableError(t *testing.T) {
+	t.Parallel()
+	svc := &mockSTTService{
+		results: []mockResult{
+			{err: NewTranscriptionError("mock", "401", "unauthorized", nil, false)},
+		},
+	}
+	_, err := TranscribeWithRetry(context.Background(), svc, []byte("audio"), TranscriptionConfig{}, RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if svc.calls.Load() != 1 {
+		t.Errorf("calls = %d, want 1", svc.calls.Load())
+	}
+}
+
+func TestTranscribeWithRetry_NoRetryOnAudioTooShort(t *testing.T) {
+	t.Parallel()
+	svc := &mockSTTService{
+		results: []mockResult{
+			{err: errors.New("audio too short")},
+		},
+	}
+	_, err := TranscribeWithRetry(context.Background(), svc, []byte(""), TranscriptionConfig{}, RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if svc.calls.Load() != 1 {
+		t.Errorf("calls = %d, want 1 (plain errors not retryable)", svc.calls.Load())
+	}
+}
+
+func TestTranscribeWithRetry_ExhaustsAttempts(t *testing.T) {
+	t.Parallel()
+	svc := &mockSTTService{
+		results: []mockResult{
+			{err: NewTranscriptionError("mock", "503", "down", nil, true)},
+			{err: NewTranscriptionError("mock", "503", "still down", nil, true)},
+			{err: NewTranscriptionError("mock", "503", "really down", nil, true)},
+		},
+	}
+	_, err := TranscribeWithRetry(context.Background(), svc, []byte("audio"), TranscriptionConfig{}, RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if svc.calls.Load() != 3 {
+		t.Errorf("calls = %d, want 3", svc.calls.Load())
+	}
+}
+
+func TestTranscribeWithRetry_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	svc := &mockSTTService{
+		results: []mockResult{
+			{err: NewTranscriptionError("mock", "503", "down", nil, true)},
+		},
+	}
+	_, err := TranscribeWithRetry(ctx, svc, []byte("audio"), TranscriptionConfig{}, DefaultRetryConfig())
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}

--- a/runtime/tts/retry.go
+++ b/runtime/tts/retry.go
@@ -1,0 +1,124 @@
+package tts
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+)
+
+// Retry defaults for TTS synthesis.
+const (
+	defaultRetryMaxAttempts  = 3
+	defaultRetryInitialDelay = 250 * time.Millisecond
+	defaultRetryMaxDelay     = 2 * time.Second
+	maxBackoffShift          = 30
+)
+
+// RetryConfig configures bounded retry for TTS synthesis calls.
+// Defaults are on (unlike streaming retry) because TTS calls are
+// one-shot and idempotent — retry has no content-duplication risk,
+// and the alternative is silence.
+type RetryConfig struct {
+	// MaxAttempts is the total number of attempts including the initial
+	// call. 3 means "initial + up to 2 retries". Values < 1 are
+	// treated as 1 (no retry).
+	MaxAttempts int
+	// InitialDelay is the base backoff before the first retry.
+	InitialDelay time.Duration
+	// MaxDelay caps the per-attempt backoff.
+	MaxDelay time.Duration
+}
+
+// DefaultRetryConfig returns sensible defaults for TTS retry.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts:  defaultRetryMaxAttempts,
+		InitialDelay: defaultRetryInitialDelay,
+		MaxDelay:     defaultRetryMaxDelay,
+	}
+}
+
+// SynthesizeWithRetry calls svc.Synthesize with bounded retry on
+// transient errors. Only errors where SynthesisError.Retryable is
+// true are retried; all others are returned immediately. Uses full
+// jitter backoff to avoid synchronized retries across concurrent
+// callers.
+//
+//nolint:gocritic // hugeParam: config value is caller-owned and not modified
+func SynthesizeWithRetry(
+	ctx context.Context,
+	svc Service,
+	text string,
+	config SynthesisConfig,
+	retry RetryConfig,
+) (io.ReadCloser, error) {
+	maxAttempts := retry.MaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		result, err := svc.Synthesize(ctx, text, config)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+		if !isRetryable(err) || attempt >= maxAttempts-1 {
+			break
+		}
+
+		delay := backoff(attempt, retry.InitialDelay, retry.MaxDelay)
+		logger.Warn("TTS synthesis failed, retrying",
+			"provider", svc.Name(),
+			"attempt", attempt+1,
+			"max_attempts", maxAttempts,
+			"delay", delay.String(),
+			"error", err,
+		)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return nil, lastErr
+}
+
+// isRetryable checks if err is a SynthesisError with Retryable set.
+func isRetryable(err error) bool {
+	var se *SynthesisError
+	if errors.As(err, &se) {
+		return se.Retryable
+	}
+	return false
+}
+
+// backoff computes full-jitter delay for the given attempt.
+func backoff(attempt int, initial, ceiling time.Duration) time.Duration {
+	if initial <= 0 {
+		initial = defaultRetryInitialDelay
+	}
+	if ceiling <= 0 {
+		ceiling = defaultRetryMaxDelay
+	}
+	shift := uint(min(attempt, maxBackoffShift)) //nolint:gosec // bounded by min
+	delay := initial << shift
+	if delay <= 0 || delay > ceiling {
+		delay = ceiling
+	}
+	jitter := time.Duration(time.Now().UnixNano()) % delay
+	if jitter < 0 {
+		jitter = -jitter
+	}
+	return jitter
+}

--- a/runtime/tts/retry_test.go
+++ b/runtime/tts/retry_test.go
@@ -1,0 +1,162 @@
+package tts
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockTTSService implements Service for testing retry behavior.
+type mockTTSService struct {
+	calls   atomic.Int32
+	results []mockResult
+}
+
+type mockResult struct {
+	err error
+}
+
+func (m *mockTTSService) Name() string                    { return "mock" }
+func (m *mockTTSService) SupportedVoices() []Voice        { return nil }
+func (m *mockTTSService) SupportedFormats() []AudioFormat { return nil }
+
+func (m *mockTTSService) Synthesize(_ context.Context, _ string, _ SynthesisConfig) (io.ReadCloser, error) {
+	idx := int(m.calls.Add(1)) - 1
+	if idx < len(m.results) && m.results[idx].err != nil {
+		return nil, m.results[idx].err
+	}
+	return io.NopCloser(strings.NewReader("audio-data")), nil
+}
+
+func TestSynthesizeWithRetry_SuccessFirstAttempt(t *testing.T) {
+	t.Parallel()
+	svc := &mockTTSService{}
+	result, err := SynthesizeWithRetry(context.Background(), svc, "hello", SynthesisConfig{}, DefaultRetryConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Close()
+	if svc.calls.Load() != 1 {
+		t.Errorf("calls = %d, want 1", svc.calls.Load())
+	}
+}
+
+func TestSynthesizeWithRetry_RetryOnRetryableError(t *testing.T) {
+	t.Parallel()
+	svc := &mockTTSService{
+		results: []mockResult{
+			{err: NewSynthesisError("mock", "429", "rate limited", nil, true)},
+			{err: NewSynthesisError("mock", "503", "unavailable", nil, true)},
+			{}, // success on 3rd attempt
+		},
+	}
+	result, err := SynthesizeWithRetry(context.Background(), svc, "hello", SynthesisConfig{}, RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Close()
+	if svc.calls.Load() != 3 {
+		t.Errorf("calls = %d, want 3 (initial + 2 retries)", svc.calls.Load())
+	}
+}
+
+func TestSynthesizeWithRetry_NoRetryOnNonRetryableError(t *testing.T) {
+	t.Parallel()
+	svc := &mockTTSService{
+		results: []mockResult{
+			{err: NewSynthesisError("mock", "401", "unauthorized", nil, false)},
+		},
+	}
+	_, err := SynthesizeWithRetry(context.Background(), svc, "hello", SynthesisConfig{}, RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if svc.calls.Load() != 1 {
+		t.Errorf("calls = %d, want 1 (no retry on non-retryable)", svc.calls.Load())
+	}
+}
+
+func TestSynthesizeWithRetry_NoRetryOnPlainError(t *testing.T) {
+	t.Parallel()
+	svc := &mockTTSService{
+		results: []mockResult{
+			{err: errors.New("some non-synthesis error")},
+		},
+	}
+	_, err := SynthesizeWithRetry(context.Background(), svc, "hello", SynthesisConfig{}, RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if svc.calls.Load() != 1 {
+		t.Errorf("calls = %d, want 1 (plain errors are not retryable)", svc.calls.Load())
+	}
+}
+
+func TestSynthesizeWithRetry_ExhaustsAttempts(t *testing.T) {
+	t.Parallel()
+	svc := &mockTTSService{
+		results: []mockResult{
+			{err: NewSynthesisError("mock", "503", "down", nil, true)},
+			{err: NewSynthesisError("mock", "503", "still down", nil, true)},
+			{err: NewSynthesisError("mock", "503", "really down", nil, true)},
+		},
+	}
+	_, err := SynthesizeWithRetry(context.Background(), svc, "hello", SynthesisConfig{}, RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting attempts")
+	}
+	if svc.calls.Load() != 3 {
+		t.Errorf("calls = %d, want 3", svc.calls.Load())
+	}
+}
+
+func TestSynthesizeWithRetry_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	svc := &mockTTSService{
+		results: []mockResult{
+			{err: NewSynthesisError("mock", "503", "down", nil, true)},
+		},
+	}
+	_, err := SynthesizeWithRetry(ctx, svc, "hello", SynthesisConfig{}, DefaultRetryConfig())
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestSynthesizeWithRetry_MaxAttemptsZeroMeansOneCall(t *testing.T) {
+	t.Parallel()
+	svc := &mockTTSService{}
+	result, err := SynthesizeWithRetry(context.Background(), svc, "hello", SynthesisConfig{}, RetryConfig{
+		MaxAttempts: 0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Close()
+	if svc.calls.Load() != 1 {
+		t.Errorf("calls = %d, want 1", svc.calls.Load())
+	}
+}


### PR DESCRIPTION
Closes #899.

## Summary

Adds `SynthesizeWithRetry` and `TranscribeWithRetry` wrappers that give TTS and STT service calls the same bounded-retry treatment the streaming providers already have. Both services already classified errors as retryable (`SynthesisError.Retryable`, `TranscriptionError.Retryable`) — but nobody acted on the flag. A transient 429 or 5xx during a voice conversation meant silence or dropped speech.

## Design

- **Defaults ON** (3 attempts, 250ms initial delay, 2s max) — unlike streaming retry which defaults to off. TTS/STT are one-shot idempotent calls with no content-duplication risk, and the alternative is silence.
- **Only retries typed retryable errors** — `SynthesisError{Retryable: true}` or `TranscriptionError{Retryable: true}`. Plain errors and non-retryable errors (401 auth, 400 bad request, audio-too-short) return immediately.
- **Full-jitter backoff** — same pattern as the streaming retry driver to avoid synchronized retries.
- **Context cancellation** — terminates the retry loop immediately.

## Files

| File | What |
|---|---|
| `runtime/tts/retry.go` | `SynthesizeWithRetry`, `RetryConfig`, `DefaultRetryConfig`, backoff helper |
| `runtime/tts/retry_test.go` | 7 tests |
| `runtime/stt/retry.go` | `TranscribeWithRetry`, `RetryConfig`, `DefaultRetryConfig`, backoff helper |
| `runtime/stt/retry_test.go` | 6 tests |

## Tests (13 new)

**TTS (7):** success first attempt, retry on retryable error, no retry on non-retryable, no retry on plain error, exhausts max attempts, respects context cancellation, zero max_attempts treated as 1.

**STT (6):** success first attempt, retry on retryable error, no retry on non-retryable, no retry on audio-too-short, exhausts max attempts, respects context cancellation.

## Coverage

- `tts/retry.go`: 85.7%
- `stt/retry.go`: 82.9%

## Next step

Wire `SynthesizeWithRetry` into `TTSStageWithInterruption` and `TranscribeWithRetry` into `STTStage` so the pipeline stages use retry automatically. That's a separate PR — this one lands the retry wrappers and their tests.

## Test plan

- [x] `go test ./tts/... ./stt/... -count=1` — all passing
- [x] Full runtime test suite — zero failures
- [x] `golangci-lint --new-from-rev=main` — 0 issues
- [x] Pre-commit hook passes
