### PR TITLE
fix: memory tools for anonymous users + Cartesia WS resilience + Realtime reconnect API

### DIFF
--- a/runtime/providers/openai/realtime_session_integration.go
+++ b/runtime/providers/openai/realtime_session_integration.go
@@ -398,6 +398,20 @@ func (s *RealtimeSession) Response() <-chan providers.StreamChunk {
 	return s.responseCh
 }
 
+// Config returns the session configuration. Callers can use this to
+// create a new session with the same settings after a connection loss:
+//
+//	if errors.Is(session.Error(), openai.ErrConnectionLost) {
+//	    newSession, _ := openai.NewRealtimeSession(ctx, apiKey, session.Config())
+//	}
+//
+// Note: server-side conversation state is lost on reconnection —
+// this only preserves the client-side configuration.
+func (s *RealtimeSession) Config() *RealtimeSessionConfig {
+	cfg := s.config
+	return &cfg
+}
+
 // Done returns a channel that's closed when the session ends.
 func (s *RealtimeSession) Done() <-chan struct{} {
 	return s.ctx.Done()

--- a/runtime/tts/cartesia_interactive.go
+++ b/runtime/tts/cartesia_interactive.go
@@ -75,12 +75,25 @@ func (s *CartesiaService) SynthesizeStream(
 }
 
 // readStreamResponses reads audio chunks from the WebSocket connection.
+// Closes the connection when the context is canceled so ReadJSON
+// unblocks immediately instead of hanging indefinitely on a stale
+// connection. Sets a read deadline on each iteration so a silent
+// server doesn't block forever.
 func (s *CartesiaService) readStreamResponses(
 	ctx context.Context, conn *websocket.Conn, chunks chan<- AudioChunk,
 ) {
 	defer close(chunks)
 	defer conn.Close()
 
+	// Close the WebSocket when the context is canceled so ReadJSON
+	// unblocks immediately. Without this, a stale connection holds
+	// the goroutine forever.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	const readTimeout = 30 * time.Second
 	index := 0
 
 	for {
@@ -89,10 +102,20 @@ func (s *CartesiaService) readStreamResponses(
 			return
 		}
 
+		// Set a read deadline so a silent server doesn't block forever.
+		_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
+
 		var resp cartesiaWSResponse
 		if err := conn.ReadJSON(&resp); err != nil {
+			if ctx.Err() != nil {
+				// Context canceled — the close goroutine above killed
+				// the connection. Don't report as an error.
+				return
+			}
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-				chunks <- AudioChunk{Error: err}
+				chunks <- AudioChunk{Error: NewSynthesisError(
+					"cartesia", "", "websocket read failed", err, true,
+				)}
 			}
 			return
 		}

--- a/sdk/capability_memory.go
+++ b/sdk/capability_memory.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 )
@@ -38,7 +39,17 @@ func (c *MemoryCapability) Init(_ CapabilityContext) error { return nil }
 
 // RegisterTools implements Capability. Registers the memory executor and
 // tool descriptors, plus any custom tools from ToolProvider stores.
+//
+// When scope["user_id"] is empty (anonymous user), tools are NOT
+// registered — the LLM simply doesn't see memory as an option. This
+// prevents confusing backend errors when the memory store rejects
+// operations without a user_id. See AltairaLabs/PromptKit#852.
 func (c *MemoryCapability) RegisterTools(registry *tools.Registry) {
+	if c.scope["user_id"] == "" {
+		logger.Debug("memory tools skipped: scope has no user_id (anonymous user)")
+		return
+	}
+
 	exec := memory.NewExecutor(c.store, c.scope)
 	registry.RegisterExecutor(exec)
 	memory.RegisterMemoryTools(registry)


### PR DESCRIPTION
Closes #852.

## Summary

Three independent fixes that close out the remaining items from the resilience work:

### 1. Skip memory tools when scope lacks user_id (#852)

`MemoryCapability.RegisterTools` now checks `scope["user_id"]` before registering memory tools. When empty (anonymous user), tools are not included in the LLM's tool schema — the model simply doesn't see memory as an option, preventing confusing backend errors from memory stores that require user_id.

**Before:** LLM calls `memory__save` → backend returns "user_id in scope is required" → LLM retries or fabricates a user_id → confusing UX.

**After:** LLM doesn't see memory tools → doesn't try to use them → no error.

### 2. Cartesia WebSocket read deadline + context cancellation

`readStreamResponses` now:
- Sets a 30-second read deadline on each iteration so a silent server doesn't block the goroutine forever
- Closes the WebSocket when the context is canceled so `ReadJSON` unblocks immediately instead of hanging on a stale connection
- Wraps errors in `SynthesisError{Retryable: true}` so the TTS retry wrapper can recover

**Before:** A stale Cartesia WebSocket connection hung the goroutine indefinitely. Context cancellation didn't unblock the read.

**After:** Stale connections time out after 30s. Context cancellation unblocks immediately.

### 3. Config() accessor for Realtime session reconnection

`RealtimeSession.Config()` returns the session configuration so callers can create a new session with the same settings after detecting `ErrConnectionLost`:

```go
if errors.Is(session.Error(), openai.ErrConnectionLost) {
    newSession, _ := openai.NewRealtimeSession(ctx, apiKey, session.Config())
}
```

Note: server-side conversation state is lost on reconnection — this only preserves client-side configuration.

## Test plan

- [x] `go test ./runtime/... -count=1` — all passing
- [x] `go test ./sdk/... -count=1` — all passing
- [x] `golangci-lint --new-from-rev=main` — 0 issues
- [x] Pre-commit hook passes (capability_memory.go coverage: 81.2%)
