### PR TITLE
fix(recording): audio playback mangled by cross-turn interleaving + wrong sample rate

### DIFF
--- a/runtime/events/media_timeline.go
+++ b/runtime/events/media_timeline.go
@@ -149,9 +149,12 @@ func (mt *MediaTimeline) extractAudioSegments(eventType EventType, _ TrackType) 
 		segments = append(segments, segment)
 	}
 
-	// Sort by chunk index for proper ordering
+	// Sort by event index (recording order) rather than chunk index.
+	// Chunk index resets to 0 on each conversation turn, so sorting by
+	// it interleaves audio from different turns. Event index is
+	// monotonically increasing across the whole session.
 	sort.Slice(segments, func(i, j int) bool {
-		return segments[i].ChunkIndex < segments[j].ChunkIndex
+		return segments[i].EventIndex < segments[j].EventIndex
 	})
 
 	return segments

--- a/runtime/providers/gemini/stream_session_protocol_integration.go
+++ b/runtime/providers/gemini/stream_session_protocol_integration.go
@@ -326,7 +326,7 @@ func (s *StreamSession) processModelTurn(turn *ModelTurn, turnComplete bool, cos
 					MIMEType: part.InlineData.MimeType,
 				}
 				if strings.HasPrefix(part.InlineData.MimeType, "audio/") {
-					media.SampleRate = 16000
+					media.SampleRate = 24000 // Gemini native audio models output 24kHz
 					media.Channels = 1
 				}
 				response.MediaData = media

--- a/runtime/providers/gemini/stream_session_test.go
+++ b/runtime/providers/gemini/stream_session_test.go
@@ -355,8 +355,8 @@ func TestGeminiStreamSession_ReceiveAudioResponse(t *testing.T) {
 			t.Errorf("Expected Channels to be 1, got %d", chunk.MediaData.Channels)
 		}
 
-		if chunk.MediaData.SampleRate != 16000 {
-			t.Errorf("Expected SampleRate to be 16000, got %d", chunk.MediaData.SampleRate)
+		if chunk.MediaData.SampleRate != 24000 {
+			t.Errorf("Expected SampleRate to be 24000, got %d", chunk.MediaData.SampleRate)
 		}
 
 		// Verify finish reason


### PR DESCRIPTION
## Summary
Fixes #910

- **Audio interleaving fix**: `extractAudioSegments` sorted by `ChunkIndex` which resets per turn, causing cross-turn audio scrambling. Changed to sort by `EventIndex` which is monotonically increasing across the entire recording.
- **Gemini sample rate fix**: Output audio sample rate was hardcoded to 16kHz but native audio models output at 24kHz, causing playback at 2/3 speed. Changed to 24kHz.

## Test plan
- [x] Existing `TestGeminiStreamSession_ReceiveAudioResponse` updated and passing
- [x] Verified Gemini and OpenAI recordings play back correctly after fixes
- [x] Pre-commit checks pass (lint, build, tests with coverage)