### PR TITLE
feat: configurable output sample rate for Gemini and OpenAI Realtime

### DIFF
--- a/runtime/providers/gemini/stream_session_integration.go
+++ b/runtime/providers/gemini/stream_session_integration.go
@@ -118,6 +118,10 @@ type StreamSessionConfig struct {
 	// OpenAPI schema subset supported by Gemini.
 	Tools []ToolDefinition
 
+	// OutputSampleRate is the sample rate in Hz for audio output from the model.
+	// Default: 24000 (Gemini native audio models output 24kHz).
+	OutputSampleRate int
+
 	// AutoReconnect enables automatic reconnection on unexpected connection drops.
 	// When enabled, the session will attempt to reconnect and continue receiving
 	// responses. Note: conversation context may be lost on reconnection.

--- a/runtime/providers/gemini/stream_session_protocol_integration.go
+++ b/runtime/providers/gemini/stream_session_protocol_integration.go
@@ -17,6 +17,17 @@ const finishReasonComplete = "complete"
 // audioPCMMime is the MIME type for PCM audio used by Gemini Live API.
 const audioPCMMime = "audio/pcm"
 
+// defaultOutputSampleRate is the default output sample rate for Gemini native audio models (24kHz).
+const defaultOutputSampleRate = 24000
+
+// outputSampleRate returns the configured output sample rate, defaulting to 24kHz.
+func (s *StreamSession) outputSampleRate() int {
+	if s.config.OutputSampleRate > 0 {
+		return s.config.OutputSampleRate
+	}
+	return defaultOutputSampleRate
+}
+
 // sliceContains checks if a string slice contains a value
 func sliceContains(slice []string, val string) bool {
 	for _, s := range slice {
@@ -326,7 +337,7 @@ func (s *StreamSession) processModelTurn(turn *ModelTurn, turnComplete bool, cos
 					MIMEType: part.InlineData.MimeType,
 				}
 				if strings.HasPrefix(part.InlineData.MimeType, "audio/") {
-					media.SampleRate = 24000 // Gemini native audio models output 24kHz
+					media.SampleRate = s.outputSampleRate()
 					media.Channels = 1
 				}
 				response.MediaData = media

--- a/runtime/providers/gemini/stream_session_test.go
+++ b/runtime/providers/gemini/stream_session_test.go
@@ -371,6 +371,52 @@ func TestGeminiStreamSession_ReceiveAudioResponse(t *testing.T) {
 	}
 }
 
+func TestGeminiStreamSession_CustomOutputSampleRate(t *testing.T) {
+	server := newMockWebSocketServer(func(conn *websocket.Conn) {
+		_, _, _ = conn.ReadMessage()
+
+		setupResponse := ServerMessage{SetupComplete: &SetupComplete{}}
+		setupData, _ := json.Marshal(setupResponse)
+		_ = conn.WriteMessage(websocket.TextMessage, setupData)
+
+		audioData := "SGVsbG8=" // Base64 encoded "Hello"
+		response := ServerMessage{
+			ServerContent: &ServerContent{
+				ModelTurn: &ModelTurn{
+					Parts: []Part{{InlineData: &InlineData{MimeType: "audio/pcm", Data: audioData}}},
+				},
+				TurnComplete: true,
+			},
+		}
+		data, _ := json.Marshal(response)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		_, _, _ = conn.ReadMessage()
+	})
+	defer server.Close()
+
+	session, err := NewStreamSession(context.Background(), server.URL(), "test-key", &StreamSessionConfig{
+		Model:              "gemini-2.5-flash-native-audio-latest",
+		ResponseModalities: []string{"AUDIO"},
+		OutputSampleRate:   48000,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer session.Close()
+
+	select {
+	case chunk := <-session.Response():
+		if chunk.MediaData == nil {
+			t.Fatal("Expected MediaData")
+		}
+		if chunk.MediaData.SampleRate != 48000 {
+			t.Errorf("Expected SampleRate 48000, got %d", chunk.MediaData.SampleRate)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for response")
+	}
+}
+
 func TestGeminiStreamSession_ReceiveMixedResponse(t *testing.T) {
 	server := newMockWebSocketServer(func(conn *websocket.Conn) {
 		// First read setup message

--- a/runtime/providers/openai/realtime_session_integration.go
+++ b/runtime/providers/openai/realtime_session_integration.go
@@ -30,11 +30,10 @@ const (
 
 // Configuration constants
 const (
-	responseChannelSize     = 10
-	heartbeatInterval       = 30 * time.Second
-	setupTimeout            = 10 * time.Second
-	tokensPerThousand       = 1000.0
-	realtimeAudioSampleRate = 24000 // OpenAI Realtime API output audio sample rate (Hz)
+	responseChannelSize = 10
+	heartbeatInterval   = 30 * time.Second
+	setupTimeout        = 10 * time.Second
+	tokensPerThousand   = 1000.0
 )
 
 // Ensure RealtimeSession implements StreamInputSession
@@ -606,6 +605,14 @@ func (s *RealtimeSession) handleTextDone(e *ResponseTextDoneEvent) {
 	}
 }
 
+// outputSampleRate returns the configured output sample rate, defaulting to 24kHz.
+func (s *RealtimeSession) outputSampleRate() int {
+	if s.config.OutputSampleRate > 0 {
+		return s.config.OutputSampleRate
+	}
+	return DefaultRealtimeSampleRate
+}
+
 func (s *RealtimeSession) handleAudioDelta(e *ResponseAudioDeltaEvent) {
 	rawBytes, err := base64.StdEncoding.DecodeString(e.Delta)
 	if err != nil {
@@ -617,7 +624,7 @@ func (s *RealtimeSession) handleAudioDelta(e *ResponseAudioDeltaEvent) {
 		MediaData: &providers.StreamMediaData{
 			Data:       rawBytes,
 			MIMEType:   "audio/pcm",
-			SampleRate: realtimeAudioSampleRate,
+			SampleRate: s.outputSampleRate(),
 			Channels:   1,
 		},
 		Metadata: map[string]interface{}{

--- a/runtime/providers/openai/realtime_types.go
+++ b/runtime/providers/openai/realtime_types.go
@@ -65,6 +65,10 @@ type RealtimeSessionConfig struct {
 	// Tools defines available functions for the session.
 	Tools []RealtimeToolDefinition
 
+	// OutputSampleRate is the sample rate in Hz for output audio.
+	// Default: 24000 (OpenAI Realtime API outputs 24kHz PCM).
+	OutputSampleRate int
+
 	// Temperature controls randomness (0.6-1.2, default 0.8).
 	Temperature float64
 

--- a/runtime/providers/openai/realtime_types_test.go
+++ b/runtime/providers/openai/realtime_types_test.go
@@ -109,6 +109,23 @@ func TestRealtimeConstants(t *testing.T) {
 	}
 }
 
+func TestRealtimeSession_OutputSampleRate(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		s := &RealtimeSession{config: DefaultRealtimeSessionConfig()}
+		if got := s.outputSampleRate(); got != 24000 {
+			t.Errorf("expected default 24000, got %d", got)
+		}
+	})
+	t.Run("custom", func(t *testing.T) {
+		cfg := DefaultRealtimeSessionConfig()
+		cfg.OutputSampleRate = 48000
+		s := &RealtimeSession{config: cfg}
+		if got := s.outputSampleRate(); got != 48000 {
+			t.Errorf("expected 48000, got %d", got)
+		}
+	})
+}
+
 func TestRealtimeSessionConfig_Modalities(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary
- Adds `OutputSampleRate` field to `StreamSessionConfig` (Gemini) and `RealtimeSessionConfig` (OpenAI Realtime)
- Both providers default to 24kHz when the field is zero, preserving existing behavior
- Removes duplicate `realtimeAudioSampleRate` constant in OpenAI, reuses existing `DefaultRealtimeSampleRate`

## Test plan
- [x] `TestGeminiStreamSession_CustomOutputSampleRate` — verifies custom 48kHz override
- [x] `TestRealtimeSession_OutputSampleRate` — verifies default and custom override
- [x] Existing audio response tests continue to pass with default 24kHz
- [x] Pre-commit checks pass (lint, build, tests with coverage)