### PR TITLE
perf: default MaxConnsPerHost to unlimited, fix zero-value semantics

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1153,10 +1153,9 @@ type Provider struct {
 // tuning these values.
 type HTTPTransportConfig struct {
 	// MaxConnsPerHost caps the total TCP connections the transport may
-	// open to any single upstream host (in-use + idle). Zero or negative
-	// falls back to providers.DefaultMaxConnsPerHost (100). Raising this
-	// increases the realistic concurrent-stream ceiling per upstream,
-	// at the cost of ephemeral port and file-descriptor usage.
+	// open to any single upstream host (in-use + idle). Zero means
+	// unlimited (the default, matching Go's http.Transport). Set a
+	// positive value to cap connections for backends that need it.
 	MaxConnsPerHost int `json:"max_conns_per_host,omitempty" yaml:"max_conns_per_host,omitempty"`
 	// MaxIdleConnsPerHost caps idle keep-alive connections retained per
 	// host for reuse. Zero or negative falls back to

--- a/runtime/providers/base_provider.go
+++ b/runtime/providers/base_provider.go
@@ -25,7 +25,12 @@ import (
 const (
 	DefaultMaxIdleConns        = 1000
 	DefaultMaxIdleConnsPerHost = 100
-	DefaultMaxConnsPerHost     = 100
+	// DefaultMaxConnsPerHost is the default cap on total TCP connections
+	// per upstream host. Zero means unlimited, matching Go's stdlib
+	// http.Transport default. Real LLM providers enforce rate limits
+	// server-side; a client-side connection cap adds a hidden throughput
+	// ceiling that's hard to debug (see #916).
+	DefaultMaxConnsPerHost     = 0
 	DefaultIdleConnTimeout     = 90 * time.Second
 	DefaultTLSHandshakeTimeout = 10 * time.Second
 	DefaultDialTimeout         = 30 * time.Second
@@ -51,9 +56,9 @@ const (
 )
 
 // HTTPTransportOptions configures the connection pool for a pooled
-// HTTP transport. Zero values fall back to the package-level defaults
-// (DefaultMaxConnsPerHost, DefaultMaxIdleConnsPerHost, DefaultIdleConnTimeout)
-// so callers can set only the fields they want to override.
+// HTTP transport. Zero values mean unlimited for connection counts
+// (matching Go's http.Transport) and fall back to DefaultIdleConnTimeout
+// for the timeout. Negative values fall back to package-level defaults.
 //
 // These are the single-process h2 pool controls that bound how many
 // concurrent streams a provider can multiplex to a single upstream
@@ -63,10 +68,9 @@ const (
 // realistic steady-state ceiling for concurrent streams per process.
 type HTTPTransportOptions struct {
 	// MaxConnsPerHost caps the total TCP connections the transport may
-	// open to any single host (in-use + idle). Zero uses
-	// DefaultMaxConnsPerHost. Raising this lets more h2 connections
-	// multiplex streams in parallel, at the cost of ephemeral port /
-	// file-descriptor usage on the client side.
+	// open to any single host (in-use + idle). Zero means unlimited
+	// (matching Go's http.Transport default). Negative values fall
+	// back to DefaultMaxConnsPerHost.
 	MaxConnsPerHost int
 	// MaxIdleConnsPerHost caps the number of idle keep-alive
 	// connections the transport will retain per host for reuse. Zero
@@ -94,7 +98,7 @@ func NewPooledTransport() *http.Transport {
 // same HTTP/2 upgrade policy).
 func NewPooledTransportWithOptions(opts HTTPTransportOptions) *http.Transport {
 	maxConns := opts.MaxConnsPerHost
-	if maxConns <= 0 {
+	if maxConns < 0 {
 		maxConns = DefaultMaxConnsPerHost
 	}
 	maxIdle := opts.MaxIdleConnsPerHost

--- a/runtime/providers/http_transport_test.go
+++ b/runtime/providers/http_transport_test.go
@@ -56,6 +56,23 @@ func TestNewPooledTransportWithOptions_Overrides(t *testing.T) {
 	}
 }
 
+func TestNewPooledTransportWithOptions_ZeroMaxConnsPerHostMeansUnlimited(t *testing.T) {
+	t.Parallel()
+	// MaxConnsPerHost=0 must be passed through as-is (unlimited),
+	// matching Go's http.Transport behavior. This is the default.
+	tr := NewPooledTransportWithOptions(HTTPTransportOptions{
+		MaxConnsPerHost: 0,
+	})
+	if tr.MaxConnsPerHost != 0 {
+		t.Errorf("MaxConnsPerHost = %d, want 0 (unlimited)", tr.MaxConnsPerHost)
+	}
+	// MaxIdleConnsPerHost=0 still falls back to default (0 idle conns
+	// would disable connection reuse, which is never useful).
+	if tr.MaxIdleConnsPerHost != DefaultMaxIdleConnsPerHost {
+		t.Errorf("MaxIdleConnsPerHost = %d, want %d", tr.MaxIdleConnsPerHost, DefaultMaxIdleConnsPerHost)
+	}
+}
+
 func TestNewPooledTransportWithOptions_NegativeValuesFallBack(t *testing.T) {
 	t.Parallel()
 	// Arena config parsers clamp to zero on malformed input, but a


### PR DESCRIPTION
## Summary

- Change `DefaultMaxConnsPerHost` from 100 to 0 (unlimited), matching Go's `http.Transport` default
- Fix `NewPooledTransportWithOptions` to treat `MaxConnsPerHost=0` as unlimited instead of silently replacing with the default of 100
- Negative values still fall back to `DefaultMaxConnsPerHost`

The previous hardcoded limit of 100 silently capped streaming throughput at ~149 rps with typical LLM response times (~670ms), creating a hidden bottleneck discovered during benchmark profiling. The `max_conns_per_host` field in `provider.yaml` `http_transport` config was already wired through but couldn't set unlimited because 0 was silently replaced.

### Benchmark impact (bare metal, 14-core Apple Silicon)

| Concurrency | Before (MaxConns=100) | After (unlimited) |
|------------|----------------------|-------------------|
| 100 | 143 rps | 143 rps |
| 500 | 142 rps | 696 rps |
| 1000 | 142 rps | 1,407 rps |

## Test plan

- [x] New test: `TestNewPooledTransportWithOptions_ZeroMaxConnsPerHostMeansUnlimited`
- [x] Existing test updated: negative values still fall back to default
- [x] Full `runtime/providers/...` test suite passes
- [x] Full `pkg/...` test suite passes
- [x] Pre-commit hook passes (lint, build, test, coverage)

Closes #916