### PR TITLE
feat: efficiency benchmark — PromptKit vs LangChain vs Vercel AI vs Strands

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -7,9 +7,9 @@ help: ## Show this help
 
 all: round1 round1-tools round2 ## Run all rounds
 
-round1: ## Run Round 1: LLM streaming (PromptKit vs LangChain vs Vercel AI SDK)
+round1: ## Run Round 1: LLM streaming (PromptKit vs LangChain vs Vercel AI SDK vs Strands)
 	@echo "=== Round 1: LLM Streaming ==="
-	docker compose --profile round1 up --build -d mockupstream promptkit-round1 langchain vercelai
+	docker compose --profile round1 up --build -d mockupstream promptkit-round1 langchain vercelai strands
 	@echo "Waiting for services..."
 	@sleep 3
 	@for tier in $(TIERS); do \
@@ -28,6 +28,11 @@ round1: ## Run Round 1: LLM streaming (PromptKit vs LangChain vs Vercel AI SDK)
 			--round round1 --target http://vercelai:8092 \
 			--framework vercelai --concurrency $$tier \
 			--requests $$(( $$tier * 10 )) --output /results; \
+		echo "--- Strands @ $$tier concurrent ---"; \
+		docker compose --profile round1 run --rm benchmark-round1 \
+			--round round1 --target http://strands:8093 \
+			--framework strands --concurrency $$tier \
+			--requests $$(( $$tier * 10 )) --output /results; \
 	done
 	docker compose --profile round1 down
 
@@ -35,7 +40,7 @@ TOOL_TIERS := 100 250 500 1000 2000
 
 round1-tools: ## Run Round 1 with tool-calling: cost comparison
 	@echo "=== Round 1: Tool-Calling Cost Comparison ==="
-	docker compose --profile round1 up --build -d mockupstream promptkit-round1 langchain vercelai
+	docker compose --profile round1 up --build -d mockupstream promptkit-round1 langchain vercelai strands
 	@echo "Waiting for services..."
 	@sleep 5
 	@for tier in $(TOOL_TIERS); do \
@@ -56,6 +61,12 @@ round1-tools: ## Run Round 1 with tool-calling: cost comparison
 			--round round1 --target http://vercelai:8092 \
 			--path /v1/chat/completions/tools \
 			--framework vercelai --concurrency $$tier \
+			--requests $$(( $$tier * 10 )) --output /results; \
+		echo "--- Strands @ $$tier concurrent (tools) ---"; \
+		docker compose --profile round1 run --rm benchmark-round1 \
+			--round round1 --target http://strands:8093 \
+			--path /v1/chat/completions/tools \
+			--framework strands --concurrency $$tier \
 			--requests $$(( $$tier * 10 )) --output /results; \
 	done
 	docker compose --profile round1 down

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,11 +1,11 @@
-.PHONY: round1 round2 all build clean help
+.PHONY: round1 round1-tools round2 all build clean help
 
 TIERS := 10 50 100 250 500 1000
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-all: round1 round2 ## Run both rounds
+all: round1 round1-tools round2 ## Run all rounds
 
 round1: ## Run Round 1: LLM streaming (PromptKit vs LangChain vs Vercel AI SDK)
 	@echo "=== Round 1: LLM Streaming ==="
@@ -26,6 +26,35 @@ round1: ## Run Round 1: LLM streaming (PromptKit vs LangChain vs Vercel AI SDK)
 		echo "--- VercelAI @ $$tier concurrent ---"; \
 		docker compose --profile round1 run --rm benchmark-round1 \
 			--round round1 --target http://vercelai:8092 \
+			--framework vercelai --concurrency $$tier \
+			--requests $$(( $$tier * 10 )) --output /results; \
+	done
+	docker compose --profile round1 down
+
+TOOL_TIERS := 100 250 500 1000 2000
+
+round1-tools: ## Run Round 1 with tool-calling: cost comparison
+	@echo "=== Round 1: Tool-Calling Cost Comparison ==="
+	docker compose --profile round1 up --build -d mockupstream promptkit-round1 langchain vercelai
+	@echo "Waiting for services..."
+	@sleep 5
+	@for tier in $(TOOL_TIERS); do \
+		echo "--- PromptKit @ $$tier concurrent (tools) ---"; \
+		docker compose --profile round1 run --rm benchmark-round1 \
+			--round round1 --target http://promptkit-round1:8090 \
+			--path /v1/chat/completions/tools \
+			--framework promptkit --concurrency $$tier \
+			--requests $$(( $$tier * 10 )) --output /results; \
+		echo "--- LangChain @ $$tier concurrent (tools) ---"; \
+		docker compose --profile round1 run --rm benchmark-round1 \
+			--round round1 --target http://langchain:8091 \
+			--path /v1/chat/completions/tools \
+			--framework langchain --concurrency $$tier \
+			--requests $$(( $$tier * 10 )) --output /results; \
+		echo "--- VercelAI @ $$tier concurrent (tools) ---"; \
+		docker compose --profile round1 run --rm benchmark-round1 \
+			--round round1 --target http://vercelai:8092 \
+			--path /v1/chat/completions/tools \
 			--framework vercelai --concurrency $$tier \
 			--requests $$(( $$tier * 10 )) --output /results; \
 	done

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -7,9 +7,9 @@ help: ## Show this help
 
 all: round1 round2 ## Run both rounds
 
-round1: ## Run Round 1: LLM streaming (PromptKit vs LangChain)
+round1: ## Run Round 1: LLM streaming (PromptKit vs LangChain vs Vercel AI SDK)
 	@echo "=== Round 1: LLM Streaming ==="
-	docker compose --profile round1 up --build -d mockupstream promptkit-round1 langchain
+	docker compose --profile round1 up --build -d mockupstream promptkit-round1 langchain vercelai
 	@echo "Waiting for services..."
 	@sleep 3
 	@for tier in $(TIERS); do \
@@ -22,6 +22,11 @@ round1: ## Run Round 1: LLM streaming (PromptKit vs LangChain)
 		docker compose --profile round1 run --rm benchmark-round1 \
 			--round round1 --target http://langchain:8091 \
 			--framework langchain --concurrency $$tier \
+			--requests $$(( $$tier * 10 )) --output /results; \
+		echo "--- VercelAI @ $$tier concurrent ---"; \
+		docker compose --profile round1 run --rm benchmark-round1 \
+			--round round1 --target http://vercelai:8092 \
+			--framework vercelai --concurrency $$tier \
 			--requests $$(( $$tier * 10 )) --output /results; \
 	done
 	docker compose --profile round1 down

--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -64,6 +64,22 @@ services:
     profiles:
       - round1
 
+  strands:
+    build:
+      context: ..
+      dockerfile: benchmarks/frameworks/strands/Dockerfile
+    ports:
+      - "8093:8093"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-benchmark}
+      - OPENAI_BASE_URL=http://mockupstream:8081/v1
+      - TOOL_URL=http://mockupstream:8085
+    depends_on:
+      mockupstream:
+        condition: service_healthy
+    profiles:
+      - round1
+
   promptkit-round2:
     build:
       context: ..

--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -45,6 +45,21 @@ services:
     profiles:
       - round1
 
+  vercelai:
+    build:
+      context: ..
+      dockerfile: benchmarks/frameworks/vercelai/Dockerfile
+    ports:
+      - "8092:8092"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-benchmark}
+      - OPENAI_BASE_URL=http://mockupstream:8081/v1
+    depends_on:
+      mockupstream:
+        condition: service_healthy
+    profiles:
+      - round1
+
   promptkit-round2:
     build:
       context: ..
@@ -88,6 +103,7 @@ services:
     depends_on:
       - promptkit-round1
       - langchain
+      - vercelai
     profiles:
       - round1
 

--- a/benchmarks/docker-compose.yaml
+++ b/benchmarks/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       - "8081:8081"
       - "8082:8082"
       - "8083:8083"
+      - "8085:8085"
     volumes:
       - ./profiles:/profiles:ro
     healthcheck:
@@ -24,6 +25,7 @@ services:
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-benchmark}
       - OPENAI_BASE_URL=http://mockupstream:8081/v1
+      - TOOL_URL=http://mockupstream:8085
     depends_on:
       mockupstream:
         condition: service_healthy
@@ -39,6 +41,7 @@ services:
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-benchmark}
       - OPENAI_BASE_URL=http://mockupstream:8081/v1
+      - TOOL_URL=http://mockupstream:8085
     depends_on:
       mockupstream:
         condition: service_healthy
@@ -54,6 +57,7 @@ services:
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-benchmark}
       - OPENAI_BASE_URL=http://mockupstream:8081/v1
+      - TOOL_URL=http://mockupstream:8085
     depends_on:
       mockupstream:
         condition: service_healthy

--- a/benchmarks/frameworks/langchain/Dockerfile
+++ b/benchmarks/frameworks/langchain/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY requirements.txt .
+COPY benchmarks/frameworks/langchain/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY app.py .
+COPY benchmarks/frameworks/langchain/app.py .
 ENV PORT=8091
 EXPOSE 8091
 CMD ["python", "app.py"]

--- a/benchmarks/frameworks/langchain/app.py
+++ b/benchmarks/frameworks/langchain/app.py
@@ -2,15 +2,17 @@
 
 import json
 import os
+import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
 from langchain_openai import ChatOpenAI
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 app = FastAPI()
 
 OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", "http://localhost:8081/v1")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "sk-bench-fake")
+TOOL_URL = os.environ.get("TOOL_URL", "http://localhost:8085")
 
 
 @app.post("/v1/chat/completions")
@@ -52,6 +54,60 @@ async def chat_completions(request: Request):
                 }]
             }
             yield f"data: {json.dumps(data)}\n\n"
+        stop = {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+        yield f"data: {json.dumps(stop)}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+@app.post("/v1/chat/completions/tools")
+async def chat_completions_tools(request: Request):
+    body = await request.json()
+    messages = body.get("messages", [])
+
+    if not messages:
+        return {"error": "no messages"}
+
+    llm = ChatOpenAI(
+        model="gpt-4o",
+        openai_api_base=OPENAI_BASE_URL,
+        openai_api_key=OPENAI_API_KEY,
+        temperature=0.7,
+        max_tokens=256,
+    )
+
+    user_content = messages[-1]["content"]
+    lc_messages = [HumanMessage(content=user_content)]
+
+    # First LLM call — expects tool_calls response (non-streaming)
+    response = await llm.ainvoke(lc_messages)
+    lc_messages.append(response)
+
+    # Execute tool calls if present
+    if response.tool_calls:
+        for tc in response.tool_calls:
+            async with httpx.AsyncClient() as client:
+                tool_resp = await client.post(
+                    f"{TOOL_URL}/tool",
+                    json=tc["args"],
+                )
+                tool_result = tool_resp.text
+            lc_messages.append(
+                ToolMessage(content=tool_result, tool_call_id=tc["id"])
+            )
+
+    # Second LLM call — streaming response
+    async def generate():
+        async for chunk in llm.astream(lc_messages):
+            if isinstance(chunk.content, str) and chunk.content:
+                data = {
+                    "choices": [{
+                        "delta": {"content": chunk.content},
+                        "finish_reason": None,
+                    }]
+                }
+                yield f"data: {json.dumps(data)}\n\n"
         stop = {"choices": [{"delta": {}, "finish_reason": "stop"}]}
         yield f"data: {json.dumps(stop)}\n\n"
         yield "data: [DONE]\n\n"

--- a/benchmarks/frameworks/langchain/requirements.txt
+++ b/benchmarks/frameworks/langchain/requirements.txt
@@ -2,3 +2,4 @@ langchain==0.3.25
 langchain-openai==0.3.12
 fastapi==0.115.12
 uvicorn==0.34.2
+httpx==0.28.1

--- a/benchmarks/frameworks/promptkit/round1/main.go
+++ b/benchmarks/frameworks/promptkit/round1/main.go
@@ -3,10 +3,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -69,6 +71,11 @@ func main() {
 		baseURL = "https://api.openai.com/v1"
 	}
 
+	toolURL := os.Getenv("TOOL_URL")
+	if toolURL == "" {
+		toolURL = "http://localhost:8085"
+	}
+
 	// Build an OpenAI provider pointing at the mock upstream.
 	p := openai.NewProvider(
 		"openai",
@@ -122,6 +129,61 @@ func main() {
 		} else {
 			handleUnary(ctx, w, conv, userMsg)
 		}
+	})
+
+	mux.HandleFunc("/v1/chat/completions/tools", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		userMsg := ""
+		for i := len(req.Messages) - 1; i >= 0; i-- {
+			if req.Messages[i].Role == "user" {
+				userMsg = req.Messages[i].Content
+				break
+			}
+		}
+		if userMsg == "" && len(req.Messages) > 0 {
+			userMsg = req.Messages[len(req.Messages)-1].Content
+		}
+
+		conv, err := sdk.Open(*packPath, "chat", sdk.WithProvider(p))
+		if err != nil {
+			http.Error(w, "failed to open conversation: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer conv.Close()
+
+		conv.OnTool("lookup_order", func(args map[string]any) (any, error) {
+			payload, err := json.Marshal(args)
+			if err != nil {
+				return nil, fmt.Errorf("marshal tool args: %w", err)
+			}
+			resp, err := http.Post(toolURL+"/tool", "application/json", bytes.NewReader(payload))
+			if err != nil {
+				return nil, fmt.Errorf("tool call failed: %w", err)
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("read tool response: %w", err)
+			}
+			var result any
+			if err := json.Unmarshal(body, &result); err != nil {
+				return string(body), nil
+			}
+			return result, nil
+		})
+
+		ctx := r.Context()
+		handleStream(ctx, w, conv, userMsg)
 	})
 
 	addr := fmt.Sprintf(":%d", *port)

--- a/benchmarks/frameworks/strands/Dockerfile
+++ b/benchmarks/frameworks/strands/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY requirements.txt .
+COPY benchmarks/frameworks/strands/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY app.py .
+COPY benchmarks/frameworks/strands/app.py .
 ENV PORT=8093
 EXPOSE 8093
 CMD ["python", "app.py"]

--- a/benchmarks/frameworks/strands/app.py
+++ b/benchmarks/frameworks/strands/app.py
@@ -7,15 +7,17 @@ Follows the documented stream_async pattern from Strands docs.
 import json
 import os
 
+import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
-from strands import Agent
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
 
 app = FastAPI()
 
 OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", "http://localhost:8081/v1")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "sk-bench-fake")
+TOOL_URL = os.environ.get("TOOL_URL", "http://localhost:8085")
 
 
 def make_model():
@@ -54,6 +56,42 @@ async def chat_completions(request: Request):
         }
 
     agent = Agent(model=make_model(), callback_handler=None)
+
+    async def generate():
+        async for event in agent.stream_async(user_content):
+            if "data" in event:
+                data = {
+                    "choices": [{
+                        "delta": {"content": event["data"]},
+                        "finish_reason": None,
+                    }]
+                }
+                yield f"data: {json.dumps(data)}\n\n"
+        stop = {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+        yield f"data: {json.dumps(stop)}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+@tool
+def lookup_order(order_id: str) -> dict:
+    """Look up an order by ID."""
+    resp = httpx.post(f"{TOOL_URL}/tool", json={"order_id": order_id})
+    return resp.json()
+
+
+@app.post("/v1/chat/completions/tools")
+async def chat_completions_tools(request: Request):
+    body = await request.json()
+    messages = body.get("messages", [])
+
+    if not messages:
+        return {"error": "no messages"}
+
+    user_content = messages[-1]["content"]
+
+    agent = Agent(model=make_model(), tools=[lookup_order], callback_handler=None)
 
     async def generate():
         async for event in agent.stream_async(user_content):

--- a/benchmarks/frameworks/strands/requirements.txt
+++ b/benchmarks/frameworks/strands/requirements.txt
@@ -1,3 +1,4 @@
 strands-agents[openai]==1.34.1
 fastapi==0.115.12
 uvicorn==0.34.2
+httpx==0.28.1

--- a/benchmarks/frameworks/vercelai/Dockerfile
+++ b/benchmarks/frameworks/vercelai/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+COPY benchmarks/frameworks/vercelai/package.json benchmarks/frameworks/vercelai/package-lock.json* ./
+RUN npm ci
+COPY benchmarks/frameworks/vercelai/ .
+RUN npm run build
+
+FROM node:22-slim
+WORKDIR /app
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+ENV PORT=8092
+EXPOSE 8092
+CMD ["node", "server.js"]

--- a/benchmarks/frameworks/vercelai/app/api/chat-tools/route.ts
+++ b/benchmarks/frameworks/vercelai/app/api/chat-tools/route.ts
@@ -1,0 +1,82 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText } from "ai";
+import { z } from "zod";
+
+const openai = createOpenAI({
+  baseURL: process.env.OPENAI_BASE_URL || "http://localhost:8081/v1",
+  apiKey: process.env.OPENAI_API_KEY || "sk-bench-fake",
+});
+
+const TOOL_URL = process.env.TOOL_URL || "http://localhost:8085";
+
+interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+interface ChatRequest {
+  messages: ChatMessage[];
+  stream?: boolean;
+}
+
+export async function POST(req: Request) {
+  const body: ChatRequest = await req.json();
+  const messages = body.messages ?? [];
+
+  if (messages.length === 0) {
+    return Response.json({ error: "no messages" }, { status: 400 });
+  }
+
+  const userContent = messages[messages.length - 1].content;
+
+  const result = await streamText({
+    model: openai("gpt-4o"),
+    prompt: userContent,
+    tools: {
+      lookup_order: {
+        description: "Look up an order by ID",
+        parameters: z.object({ order_id: z.string() }),
+        execute: async ({ order_id }) => {
+          const resp = await fetch(`${TOOL_URL}/tool`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ order_id }),
+          });
+          return resp.json();
+        },
+      },
+    },
+    maxSteps: 2,
+  });
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const chunk of result.textStream) {
+          const data = JSON.stringify({
+            choices: [{ delta: { content: chunk }, finish_reason: null }],
+          });
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+        }
+        const stop = JSON.stringify({
+          choices: [{ delta: {}, finish_reason: "stop" }],
+        });
+        controller.enqueue(encoder.encode(`data: ${stop}\n\n`));
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/benchmarks/frameworks/vercelai/app/api/chat/route.ts
+++ b/benchmarks/frameworks/vercelai/app/api/chat/route.ts
@@ -1,0 +1,80 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText } from "ai";
+
+const openai = createOpenAI({
+  baseURL: process.env.OPENAI_BASE_URL || "http://localhost:8081/v1",
+  apiKey: process.env.OPENAI_API_KEY || "sk-bench-fake",
+});
+
+interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+interface ChatRequest {
+  messages: ChatMessage[];
+  stream?: boolean;
+}
+
+export async function POST(req: Request) {
+  const body: ChatRequest = await req.json();
+  const messages = body.messages ?? [];
+
+  if (messages.length === 0) {
+    return Response.json({ error: "no messages" }, { status: 400 });
+  }
+
+  const userContent = messages[messages.length - 1].content;
+
+  if (!body.stream) {
+    const result = await streamText({
+      model: openai("gpt-4o"),
+      prompt: userContent,
+    });
+    let text = "";
+    for await (const chunk of result.textStream) {
+      text += chunk;
+    }
+    return Response.json({
+      choices: [
+        {
+          message: { role: "assistant", content: text },
+          finish_reason: "stop",
+        },
+      ],
+    });
+  }
+
+  // Streaming: emit OpenAI-compatible SSE
+  const result = streamText({
+    model: openai("gpt-4o"),
+    prompt: userContent,
+  });
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of (await result).textStream) {
+        const data = JSON.stringify({
+          choices: [{ delta: { content: chunk }, finish_reason: null }],
+        });
+        controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+      }
+      const stop = JSON.stringify({
+        choices: [{ delta: {}, finish_reason: "stop" }],
+      });
+      controller.enqueue(encoder.encode(`data: ${stop}\n\n`));
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/benchmarks/frameworks/vercelai/app/api/chat/route.ts
+++ b/benchmarks/frameworks/vercelai/app/api/chat/route.ts
@@ -46,7 +46,7 @@ export async function POST(req: Request) {
   }
 
   // Streaming: emit OpenAI-compatible SSE
-  const result = streamText({
+  const result = await streamText({
     model: openai("gpt-4o"),
     prompt: userContent,
   });
@@ -55,18 +55,22 @@ export async function POST(req: Request) {
 
   const stream = new ReadableStream({
     async start(controller) {
-      for await (const chunk of (await result).textStream) {
-        const data = JSON.stringify({
-          choices: [{ delta: { content: chunk }, finish_reason: null }],
+      try {
+        for await (const chunk of result.textStream) {
+          const data = JSON.stringify({
+            choices: [{ delta: { content: chunk }, finish_reason: null }],
+          });
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+        }
+        const stop = JSON.stringify({
+          choices: [{ delta: {}, finish_reason: "stop" }],
         });
-        controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+        controller.enqueue(encoder.encode(`data: ${stop}\n\n`));
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      } catch (err) {
+        controller.error(err);
       }
-      const stop = JSON.stringify({
-        choices: [{ delta: {}, finish_reason: "stop" }],
-      });
-      controller.enqueue(encoder.encode(`data: ${stop}\n\n`));
-      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-      controller.close();
     },
   });
 

--- a/benchmarks/frameworks/vercelai/app/api/health/route.ts
+++ b/benchmarks/frameworks/vercelai/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ status: "ok" });
+}

--- a/benchmarks/frameworks/vercelai/app/layout.tsx
+++ b/benchmarks/frameworks/vercelai/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/benchmarks/frameworks/vercelai/next-env.d.ts
+++ b/benchmarks/frameworks/vercelai/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/benchmarks/frameworks/vercelai/next.config.ts
+++ b/benchmarks/frameworks/vercelai/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       { source: "/v1/chat/completions", destination: "/api/chat" },
+      { source: "/v1/chat/completions/tools", destination: "/api/chat-tools" },
       { source: "/health", destination: "/api/health" },
     ];
   },

--- a/benchmarks/frameworks/vercelai/next.config.ts
+++ b/benchmarks/frameworks/vercelai/next.config.ts
@@ -1,0 +1,13 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  output: "standalone",
+  async rewrites() {
+    return [
+      { source: "/v1/chat/completions", destination: "/api/chat" },
+      { source: "/health", destination: "/api/health" },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/benchmarks/frameworks/vercelai/package-lock.json
+++ b/benchmarks/frameworks/vercelai/package-lock.json
@@ -10,7 +10,8 @@
         "ai": "^4.3",
         "next": "^15.3",
         "react": "^19.1",
-        "react-dom": "^19.1"
+        "react-dom": "^19.1",
+        "zod": "^3.24"
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -1170,7 +1171,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/benchmarks/frameworks/vercelai/package-lock.json
+++ b/benchmarks/frameworks/vercelai/package-lock.json
@@ -1,0 +1,1188 @@
+{
+  "name": "bench-vercelai",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bench-vercelai",
+      "dependencies": {
+        "@ai-sdk/openai": "^1.3",
+        "ai": "^4.3",
+        "next": "^15.3",
+        "react": "^19.1",
+        "react-dom": "^19.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22",
+        "@types/react": "^19",
+        "typescript": "^5.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
+      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
+      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
+      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
+      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
+      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
+      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
+      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
+      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
+      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
+      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.5.14",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.14",
+        "@next/swc-darwin-x64": "15.5.14",
+        "@next/swc-linux-arm64-gnu": "15.5.14",
+        "@next/swc-linux-arm64-musl": "15.5.14",
+        "@next/swc-linux-x64-gnu": "15.5.14",
+        "@next/swc-linux-x64-musl": "15.5.14",
+        "@next/swc-win32-arm64-msvc": "15.5.14",
+        "@next/swc-win32-x64-msvc": "15.5.14",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/benchmarks/frameworks/vercelai/package.json
+++ b/benchmarks/frameworks/vercelai/package.json
@@ -11,7 +11,8 @@
     "@ai-sdk/openai": "^1.3",
     "next": "^15.3",
     "react": "^19.1",
-    "react-dom": "^19.1"
+    "react-dom": "^19.1",
+    "zod": "^3.24"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/benchmarks/frameworks/vercelai/package.json
+++ b/benchmarks/frameworks/vercelai/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "bench-vercelai",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start -p ${PORT:-8092}"
+  },
+  "dependencies": {
+    "ai": "^4.3",
+    "@ai-sdk/openai": "^1.3",
+    "next": "^15.3",
+    "react": "^19.1",
+    "react-dom": "^19.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "typescript": "^5.8"
+  }
+}

--- a/benchmarks/frameworks/vercelai/package.json
+++ b/benchmarks/frameworks/vercelai/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -p ${PORT:-8092}"
+    "start": "next start -p 8092"
   },
   "dependencies": {
     "ai": "^4.3",

--- a/benchmarks/frameworks/vercelai/tsconfig.json
+++ b/benchmarks/frameworks/vercelai/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/benchmarks/frameworks/vercelai/tsconfig.json
+++ b/benchmarks/frameworks/vercelai/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,9 +17,24 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
-    "paths": { "@/*": ["./*"] }
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/benchmarks/harness/main.go
+++ b/benchmarks/harness/main.go
@@ -136,5 +136,8 @@ func main() {
 	}
 
 	fmt.Println(RenderMarkdown(report))
+	if resources.PeakRSSMB > 0 {
+		fmt.Println(RenderCostMarkdown(report))
+	}
 	log.Printf("results written to %s and %s", jsonPath, csvPath)
 }

--- a/benchmarks/harness/main.go
+++ b/benchmarks/harness/main.go
@@ -22,6 +22,7 @@ func main() {
 	requests := flag.Int("requests", 1000, "total requests (round1) or sessions (round2)")
 	timeout := flag.Duration("timeout", 30*time.Second, "per-request timeout")
 	outputDir := flag.String("output", "results", "output directory for results")
+	path := flag.String("path", "/v1/chat/completions", "endpoint path to POST to")
 	profile := flag.String("profile", "default", "profile name (for reporting)")
 	frameworkPID := flag.Int("framework-pid", 0, "PID of framework process to monitor (0 = skip)")
 	flag.Parse()
@@ -49,6 +50,7 @@ func main() {
 	case "round1":
 		cfg := StreamingConfig{
 			TargetURL:   *targetURL,
+			Path:        *path,
 			Concurrency: *concurrency,
 			Requests:    *requests,
 			Timeout:     *timeout,

--- a/benchmarks/harness/reporter.go
+++ b/benchmarks/harness/reporter.go
@@ -119,3 +119,73 @@ func WriteCSV(report BenchmarkReport, path string) error {
 	w.Flush()
 	return w.Error()
 }
+
+// c6g.xlarge reference instance for cost calculations.
+const (
+	refInstanceName   = "c6g.xlarge"
+	refInstanceCPUPct = 400.0  // 4 vCPUs = 400%
+	refInstanceRAMMB  = 8192.0 // 8 GB
+	refInstanceCostHr = 0.136  // USD on-demand
+)
+
+// CostSummary holds derived cost metrics for one framework/tier result.
+type CostSummary struct {
+	InstancesPerBox   int     `json:"instances_per_box"`
+	AggregateRPS      float64 `json:"aggregate_rps"`
+	CostPerMillionReq float64 `json:"cost_per_million_requests"`
+}
+
+// ComputeCost derives how many instances fit on the reference instance
+// and the resulting cost per million requests.
+func ComputeCost(rps float64, peakRSSMB float64, avgCPUPct float64) CostSummary {
+	if rps <= 0 || peakRSSMB <= 0 || avgCPUPct <= 0 {
+		return CostSummary{}
+	}
+
+	byRAM := int(refInstanceRAMMB / peakRSSMB)
+	byCPU := int(refInstanceCPUPct / avgCPUPct)
+
+	instances := byRAM
+	if byCPU < instances {
+		instances = byCPU
+	}
+	if instances < 1 {
+		instances = 1
+	}
+
+	aggRPS := float64(instances) * rps
+	costPerMillion := (refInstanceCostHr / aggRPS) * (1_000_000.0 / 3600.0)
+
+	return CostSummary{
+		InstancesPerBox:   instances,
+		AggregateRPS:      aggRPS,
+		CostPerMillionReq: costPerMillion,
+	}
+}
+
+// RenderCostMarkdown returns a Markdown cost comparison table.
+func RenderCostMarkdown(report BenchmarkReport) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "## Cost Summary (%s: %d vCPU, %.0f GB, $%.3f/hr)\n\n",
+		refInstanceName, int(refInstanceCPUPct/100), refInstanceRAMMB/1024, refInstanceCostHr)
+
+	fmt.Fprintln(&b, "| Framework | Concurrent | rps | Peak RSS | Avg CPU | Instances/box | Agg rps | $/M reqs |")
+	fmt.Fprintln(&b, "|-----------|------------|-----|----------|---------|---------------|---------|----------|")
+
+	for _, r := range report.Results {
+		cost := ComputeCost(r.Summary.Throughput, r.Resources.PeakRSSMB, r.Resources.AvgCPUPct)
+		fmt.Fprintf(&b, "| %s | %d | %.0f | %.0f MB | %.1f%% | %d | %.0f | $%.2f |\n",
+			r.Framework,
+			r.Concurrency,
+			r.Summary.Throughput,
+			r.Resources.PeakRSSMB,
+			r.Resources.AvgCPUPct,
+			cost.InstancesPerBox,
+			cost.AggregateRPS,
+			cost.CostPerMillionReq,
+		)
+	}
+
+	return b.String()
+}

--- a/benchmarks/harness/reporter_test.go
+++ b/benchmarks/harness/reporter_test.go
@@ -156,3 +156,47 @@ func TestReporter_CSV(t *testing.T) {
 		t.Error("expected 'baseline' in CSV output")
 	}
 }
+
+func TestComputeCost(t *testing.T) {
+	t.Parallel()
+
+	// 100 rps, 100MB RSS, 50% CPU
+	// By RAM: 8192/100 = 81 instances
+	// By CPU: 400/50 = 8 instances (limiting)
+	// Agg rps: 8 * 100 = 800
+	// Cost: (0.136/800) * (1e6/3600) = $0.0472
+	cost := ComputeCost(100, 100, 50)
+	if cost.InstancesPerBox != 8 {
+		t.Errorf("instances = %d, want 8", cost.InstancesPerBox)
+	}
+	if cost.AggregateRPS != 800 {
+		t.Errorf("agg rps = %.0f, want 800", cost.AggregateRPS)
+	}
+	if cost.CostPerMillionReq < 0.04 || cost.CostPerMillionReq > 0.05 {
+		t.Errorf("cost = $%.4f, want ~$0.047", cost.CostPerMillionReq)
+	}
+}
+
+func TestComputeCost_ZeroValues(t *testing.T) {
+	t.Parallel()
+	cost := ComputeCost(0, 0, 0)
+	if cost.InstancesPerBox != 0 {
+		t.Errorf("instances = %d, want 0 for zero input", cost.InstancesPerBox)
+	}
+}
+
+func TestComputeCost_RAMLimited(t *testing.T) {
+	t.Parallel()
+
+	// 500 rps, 2048MB RSS, 10% CPU
+	// By RAM: 8192/2048 = 4 instances (limiting)
+	// By CPU: 400/10 = 40 instances
+	// Agg rps: 4 * 500 = 2000
+	cost := ComputeCost(500, 2048, 10)
+	if cost.InstancesPerBox != 4 {
+		t.Errorf("instances = %d, want 4 (RAM limited)", cost.InstancesPerBox)
+	}
+	if cost.AggregateRPS != 2000 {
+		t.Errorf("agg rps = %.0f, want 2000", cost.AggregateRPS)
+	}
+}

--- a/benchmarks/harness/streaming.go
+++ b/benchmarks/harness/streaming.go
@@ -15,6 +15,7 @@ import (
 // StreamingConfig holds parameters for a streaming benchmark run.
 type StreamingConfig struct {
 	TargetURL   string
+	Path        string // endpoint path, e.g. "/v1/chat/completions"
 	Concurrency int
 	Requests    int
 	Timeout     time.Duration
@@ -75,7 +76,7 @@ func doStreamRequest(ctx context.Context, client *http.Client, cfg StreamingConf
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		cfg.TargetURL+"/v1/chat/completions", bytes.NewReader(body))
+		cfg.TargetURL+cfg.Path, bytes.NewReader(body))
 	if err != nil {
 		return RequestResult{Error: fmt.Errorf("new request: %w", err)}
 	}

--- a/benchmarks/mockupstream/main.go
+++ b/benchmarks/mockupstream/main.go
@@ -31,6 +31,10 @@ func main() {
 	}
 
 	openaiMux := http.NewServeMux()
+	openaiMux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
 	openaiMux.Handle("/v1/chat/completions", NewOpenAIHandler(profile.OpenAI))
 	openaiMux.Handle("/v1/audio/transcriptions", NewOpenAISTTHandler(profile.STT))
 	openaiMux.Handle("/v1/audio/speech", NewOpenAITTSHandler(profile.TTS))

--- a/benchmarks/mockupstream/main.go
+++ b/benchmarks/mockupstream/main.go
@@ -43,12 +43,14 @@ func main() {
 	// append query params or construct paths from base_url still match.
 	sttHandler := NewSTTHandler(profile.STT)
 	ttsHandler := NewTTSHandler(profile.TTS)
+	toolHandler := NewToolHandler(profile.Tool)
 
 	go serve("openai-sse", *openaiPort, openaiMux)
 	go serve("stt-ws", *sttPort, sttHandler)
 	go serve("tts-ws", *ttsPort, ttsHandler)
+	go serve("tool", 8085, toolHandler)
 
-	log.Printf("mock upstream ready: openai=:%d stt=:%d tts=:%d", *openaiPort, *sttPort, *ttsPort)
+	log.Printf("mock upstream ready: openai=:%d stt=:%d tts=:%d tool=:8085", *openaiPort, *sttPort, *ttsPort)
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)

--- a/benchmarks/mockupstream/openai_sse.go
+++ b/benchmarks/mockupstream/openai_sse.go
@@ -9,9 +9,45 @@ import (
 )
 
 // chatRequest is the subset of an OpenAI chat completion request body we care
-// about: only the stream flag needs to be inspected.
+// about: stream flag and messages (to detect tool-call round-trips).
 type chatRequest struct {
-	Stream bool `json:"stream"`
+	Messages []chatMsg `json:"messages"`
+	Stream   bool      `json:"stream"`
+}
+
+// chatMsg captures just the role of each message in the request.
+type chatMsg struct {
+	Role string `json:"role"`
+}
+
+// toolCallResponse is a non-streaming response that requests tool execution.
+type toolCallResponse struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Choices []toolCallChoice `json:"choices"`
+}
+
+type toolCallChoice struct {
+	Index        int         `json:"index"`
+	Message      toolCallMsg `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type toolCallMsg struct {
+	Role      string     `json:"role"`
+	Content   *string    `json:"content"`
+	ToolCalls []toolCall `json:"tool_calls"`
+}
+
+type toolCall struct {
+	ID       string       `json:"id"`
+	Type     string       `json:"type"`
+	Function toolCallFunc `json:"function"`
+}
+
+type toolCallFunc struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
 }
 
 // chunkChoice is a single choice inside a streaming chunk.
@@ -81,11 +117,24 @@ func NewOpenAIHandler(cfg OpenAIProfile) http.Handler {
 			return
 		}
 
-		if req.Stream {
-			handleStream(w, cfg)
-		} else {
-			handleNonStream(w, cfg)
+		// Second round (tool result present) → normal completion
+		if hasToolResult(req.Messages) {
+			if req.Stream {
+				handleStream(w, cfg)
+			} else {
+				handleNonStream(w, cfg)
+			}
+			return
 		}
+
+		// First round, non-streaming → tool_calls response
+		if !req.Stream {
+			handleToolCallResponse(w)
+			return
+		}
+
+		// First round, streaming → normal stream (backwards compatible)
+		handleStream(w, cfg)
 	})
 }
 
@@ -151,6 +200,46 @@ func handleStream(w http.ResponseWriter, cfg OpenAIProfile) {
 func writeSSEChunk(w http.ResponseWriter, v any) {
 	data, _ := json.Marshal(v)
 	fmt.Fprintf(w, "data: %s\n\n", data)
+}
+
+// hasToolResult returns true if any message in the request has role "tool",
+// indicating the client has already executed a tool call and is sending results.
+func hasToolResult(msgs []chatMsg) bool {
+	for _, m := range msgs {
+		if m.Role == "tool" {
+			return true
+		}
+	}
+	return false
+}
+
+// handleToolCallResponse writes a non-streaming JSON response that requests
+// the client to execute a tool call (lookup_order).
+func handleToolCallResponse(w http.ResponseWriter) {
+	resp := toolCallResponse{
+		ID:     "chatcmpl-bench-tool",
+		Object: "chat.completion",
+		Choices: []toolCallChoice{{
+			Index: 0,
+			Message: toolCallMsg{
+				Role:    "assistant",
+				Content: nil,
+				ToolCalls: []toolCall{{
+					ID:   "call_bench_1",
+					Type: "function",
+					Function: toolCallFunc{
+						Name:      "lookup_order",
+						Arguments: `{"order_id":"12345"}`,
+					},
+				}},
+			},
+			FinishReason: "tool_calls",
+		}},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp) //nolint:errcheck
 }
 
 // handleNonStream writes a single JSON response whose content is the

--- a/benchmarks/mockupstream/openai_sse_test.go
+++ b/benchmarks/mockupstream/openai_sse_test.go
@@ -176,7 +176,9 @@ func TestOpenAISSE_NonStreamRequest(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp := postJSON(t, srv, `{"model":"gpt-4","stream":false,"messages":[]}`)
+	// Include a tool role message so the handler treats this as a second-round
+	// request and returns a normal non-streaming completion (not a tool_calls response).
+	resp := postJSON(t, srv, `{"model":"gpt-4","stream":false,"messages":[{"role":"user","content":"hi"},{"role":"tool","tool_call_id":"c1","content":"{}"}]}`)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -209,5 +211,93 @@ func TestOpenAISSE_NonStreamRequest(t *testing.T) {
 	}
 	if result.Choices[0].FinishReason != "stop" {
 		t.Errorf("expected finish_reason 'stop', got %q", result.Choices[0].FinishReason)
+	}
+}
+
+// TestOpenAISSE_ToolCallResponse verifies that a non-streaming request without
+// tool results returns a tool_calls response.
+func TestOpenAISSE_ToolCallResponse(t *testing.T) {
+	cfg := OpenAIProfile{
+		ChunkCount:      10,
+		InterChunkDelay: time.Millisecond,
+		FirstChunkDelay: time.Millisecond,
+	}
+	handler := NewOpenAIHandler(cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp := postJSON(t, srv, `{"messages":[{"role":"user","content":"check order 12345"}],"stream":false}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Type     string `json:"type"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(result.Choices) != 1 {
+		t.Fatalf("choices = %d, want 1", len(result.Choices))
+	}
+	if len(result.Choices[0].Message.ToolCalls) != 1 {
+		t.Fatalf("tool_calls = %d, want 1", len(result.Choices[0].Message.ToolCalls))
+	}
+	tc := result.Choices[0].Message.ToolCalls[0]
+	if tc.Function.Name != "lookup_order" {
+		t.Errorf("function name = %q, want lookup_order", tc.Function.Name)
+	}
+	if result.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", result.Choices[0].FinishReason)
+	}
+}
+
+// TestOpenAISSE_ToolResultStreams verifies that a streaming request with tool
+// results produces normal streaming output (second-round completion).
+func TestOpenAISSE_ToolResultStreams(t *testing.T) {
+	cfg := OpenAIProfile{
+		ChunkCount:      5,
+		InterChunkDelay: time.Millisecond,
+		FirstChunkDelay: time.Millisecond,
+	}
+	handler := NewOpenAIHandler(cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	body := `{"messages":[{"role":"user","content":"check order"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup_order","arguments":"{}"}}]},{"role":"tool","tool_call_id":"call_1","content":"{}"}],"stream":true}`
+	resp := postJSON(t, srv, body)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	chunks := 0
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") && line != "data: [DONE]" {
+			chunks++
+		}
+	}
+
+	// 5 content chunks + 1 stop chunk = 6
+	if chunks != 6 {
+		t.Errorf("chunks = %d, want 6 (5 content + 1 stop)", chunks)
 	}
 }

--- a/benchmarks/mockupstream/profile.go
+++ b/benchmarks/mockupstream/profile.go
@@ -13,6 +13,7 @@ type Profile struct {
 	OpenAI OpenAIProfile `yaml:"openai"`
 	STT    STTProfile    `yaml:"stt"`
 	TTS    TTSProfile    `yaml:"tts"`
+	Tool   ToolProfile   `yaml:"tool"`
 }
 
 // OpenAIProfile configures the mock OpenAI SSE chat completion server.
@@ -36,6 +37,11 @@ type TTSProfile struct {
 	InterChunkDelay time.Duration `yaml:"inter_chunk_delay"`
 }
 
+// ToolProfile configures the mock tool execution endpoint.
+type ToolProfile struct {
+	ExecutionDelay time.Duration `yaml:"execution_delay"`
+}
+
 // DefaultProfile returns sensible default latencies suitable for local testing.
 func DefaultProfile() Profile {
 	return Profile{
@@ -53,6 +59,9 @@ func DefaultProfile() Profile {
 			FirstByteDelay:  60 * time.Millisecond,
 			ChunkSize:       4096,
 			InterChunkDelay: 30 * time.Millisecond,
+		},
+		Tool: ToolProfile{
+			ExecutionDelay: 500 * time.Millisecond,
 		},
 	}
 }

--- a/benchmarks/mockupstream/tool_endpoint.go
+++ b/benchmarks/mockupstream/tool_endpoint.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var toolResponse = map[string]interface{}{
+	"order_id": "12345",
+	"status":   "shipped",
+	"eta":      "2026-04-10",
+}
+
+func NewToolHandler(cfg ToolProfile) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/tool", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if cfg.ExecutionDelay > 0 {
+			time.Sleep(cfg.ExecutionDelay)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(toolResponse)
+	})
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+
+	return mux
+}

--- a/benchmarks/mockupstream/tool_endpoint_test.go
+++ b/benchmarks/mockupstream/tool_endpoint_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestToolEndpoint_ReturnsJSON(t *testing.T) {
+	handler := NewToolHandler(ToolProfile{ExecutionDelay: 0})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/tool", "application/json",
+		strings.NewReader(`{"order_id":"12345"}`))
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result["order_id"] != "12345" {
+		t.Errorf("order_id = %v, want 12345", result["order_id"])
+	}
+	if result["status"] != "shipped" {
+		t.Errorf("status = %v, want shipped", result["status"])
+	}
+}
+
+func TestToolEndpoint_RespectsDelay(t *testing.T) {
+	handler := NewToolHandler(ToolProfile{ExecutionDelay: 100 * time.Millisecond})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	start := time.Now()
+	resp, err := http.Post(srv.URL+"/tool", "application/json",
+		strings.NewReader(`{"order_id":"1"}`))
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	resp.Body.Close()
+	elapsed := time.Since(start)
+
+	if elapsed < 90*time.Millisecond {
+		t.Errorf("elapsed = %v, want >= 90ms (delay=100ms)", elapsed)
+	}
+}
+
+func TestToolEndpoint_Health(t *testing.T) {
+	handler := NewToolHandler(ToolProfile{ExecutionDelay: 0})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/benchmarks/profiles/fast.yaml
+++ b/benchmarks/profiles/fast.yaml
@@ -10,3 +10,5 @@ tts:
   first_byte_delay: 10ms
   chunk_size: 4096
   inter_chunk_delay: 10ms
+tool:
+  execution_delay: 10ms

--- a/benchmarks/profiles/realistic.yaml
+++ b/benchmarks/profiles/realistic.yaml
@@ -10,3 +10,5 @@ tts:
   first_byte_delay: 80ms
   chunk_size: 4096
   inter_chunk_delay: 30ms
+tool:
+  execution_delay: 500ms


### PR DESCRIPTION
## Summary

Extends the streaming benchmark suite with:

- **Vercel AI SDK** (Next.js App Router) as a fourth framework in Round 1
- **Strands Agents** (AWS AgentCore recommended runtime) added to all benchmarks
- **Tool-calling benchmark profile** — mock upstream returns tool_calls, frameworks execute tools against a mock tool endpoint, feed results back, stream final response
- **Cost-per-million-requests reporter** — derives instances-per-box and $/M from measured RSS and CPU against c6g.xlarge reference pricing
- **Configurable harness `--path` flag** for targeting different endpoints

### Tool-calling benchmark results (realistic profile, bare metal, darwin/arm64 14 cores)

c6g.xlarge reference: 4 vCPU, 8 GB, $0.136/hr

| Concurrent | PK RSS | PK CPU | PK $/M | LC RSS | LC CPU | LC $/M | VAI RSS | VAI CPU | VAI $/M | SA RSS | SA CPU | SA $/M |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 100 | 74 MB | 29% | **$0.03** | 220 MB | 67% | $0.14 | 370 MB | 54% | $0.06 | 458 MB | 54% | $0.09 |
| 500 | 210 MB | 29% | **$0.03** | 688 MB | 98% | $0.11 | 903 MB | 140% | $0.05 | 1.2 GB | 96% | $0.08 |
| 1000 | 348 MB | 29% | **$0.03** | 1.3 GB | 99% | $0.12 | 1.0 GB | 131% | $0.03 | 2.3 GB | 99% | $0.10 |
| 2000 | 607 MB | 29% | **$0.03** | **OOM** | 99% | - | 1.0 GB | 115% | $0.04 | 4.5 GB | 99% | $0.33 |

PromptKit holds 29% CPU and $0.03/M from 100 to 2000 concurrent. Strands uses 6.6x more memory at 1000 concurrent. LangChain OOMs at 2000.

## Test plan

- [x] Mock upstream tool-calling tests pass (18 tests)
- [x] Harness cost calculation tests pass (3 tests)
- [x] PromptKit tool endpoint builds and serves tool-calling flow
- [x] LangChain tool endpoint serves tool-calling flow
- [x] Vercel AI SDK tool endpoint builds and serves tool-calling flow
- [x] Strands tool endpoint serves tool-calling flow
- [x] Full 4-framework benchmark run completed with resource measurement
- [x] Cost summary table renders correctly