### PR TITLE
fix: enable stream retry for capability matrix providers

### DIFF
--- a/examples/capability-matrix/providers/anthropic-haiku45.provider.yaml
+++ b/examples/capability-matrix/providers/anthropic-haiku45.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.001
     output_cost_per_1k: 0.005
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/anthropic-opus4.provider.yaml
+++ b/examples/capability-matrix/providers/anthropic-opus4.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.015
     output_cost_per_1k: 0.075
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/anthropic-opus41.provider.yaml
+++ b/examples/capability-matrix/providers/anthropic-opus41.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.015
     output_cost_per_1k: 0.075
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/anthropic-opus45.provider.yaml
+++ b/examples/capability-matrix/providers/anthropic-opus45.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.005
     output_cost_per_1k: 0.025
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/anthropic-opus46.provider.yaml
+++ b/examples/capability-matrix/providers/anthropic-opus46.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.005
     output_cost_per_1k: 0.025
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/anthropic-sonnet4.provider.yaml
+++ b/examples/capability-matrix/providers/anthropic-sonnet4.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.003
     output_cost_per_1k: 0.015
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/anthropic-sonnet45.provider.yaml
+++ b/examples/capability-matrix/providers/anthropic-sonnet45.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.003
     output_cost_per_1k: 0.015
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/anthropic-sonnet46.provider.yaml
+++ b/examples/capability-matrix/providers/anthropic-sonnet46.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.003
     output_cost_per_1k: 0.015
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/gemini-20-flash-lite.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-20-flash-lite.provider.yaml
@@ -23,3 +23,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.000075
     output_cost_per_1k: 0.0003
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/gemini-20-flash.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-20-flash.provider.yaml
@@ -23,3 +23,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00015
     output_cost_per_1k: 0.0006
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/gemini-25-flash-lite.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-25-flash-lite.provider.yaml
@@ -23,3 +23,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.0001
     output_cost_per_1k: 0.0004
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/gemini-25-flash.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-25-flash.provider.yaml
@@ -23,3 +23,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00015
     output_cost_per_1k: 0.0006
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/gemini-25-pro.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-25-pro.provider.yaml
@@ -23,3 +23,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00125
     output_cost_per_1k: 0.01
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/gemini-3-flash.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-3-flash.provider.yaml
@@ -23,3 +23,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00015
     output_cost_per_1k: 0.0006
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/gemini-3-pro.provider.yaml
+++ b/examples/capability-matrix/providers/gemini-3-pro.provider.yaml
@@ -23,3 +23,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00125
     output_cost_per_1k: 0.01
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt41-mini.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt41-mini.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.002
     output_cost_per_1k: 0.008
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt41-nano.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt41-nano.provider.yaml
@@ -20,3 +20,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.001
     output_cost_per_1k: 0.004
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt41.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt41.provider.yaml
@@ -19,3 +19,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.002
     output_cost_per_1k: 0.008
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt4o-audio.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt4o-audio.provider.yaml
@@ -20,3 +20,6 @@ spec:
   additional_config:
     # Audio models require Chat Completions API (not Responses API)
     api_mode: completions
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt4o-mini-audio.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt4o-mini-audio.provider.yaml
@@ -20,3 +20,6 @@ spec:
   additional_config:
     # Audio models require Chat Completions API (not Responses API)
     api_mode: completions
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt4o-mini.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt4o-mini.provider.yaml
@@ -19,3 +19,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00015
     output_cost_per_1k: 0.0006
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt4o.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt4o.provider.yaml
@@ -19,3 +19,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.0025
     output_cost_per_1k: 0.01
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt5-mini.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt5-mini.provider.yaml
@@ -21,3 +21,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00075
     output_cost_per_1k: 0.003
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt5-nano.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt5-nano.provider.yaml
@@ -21,3 +21,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.0003
     output_cost_per_1k: 0.0012
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt5.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt5.provider.yaml
@@ -22,3 +22,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.005
     output_cost_per_1k: 0.015
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt51.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt51.provider.yaml
@@ -19,3 +19,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.005
     output_cost_per_1k: 0.015
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt52-pro.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt52-pro.provider.yaml
@@ -22,3 +22,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.01
     output_cost_per_1k: 0.03
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-gpt52.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt52.provider.yaml
@@ -19,3 +19,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00125
     output_cost_per_1k: 0.01
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-o1-pro.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o1-pro.provider.yaml
@@ -17,3 +17,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.015
     output_cost_per_1k: 0.06
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-o1.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o1.provider.yaml
@@ -17,3 +17,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.015
     output_cost_per_1k: 0.06
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-o3-mini.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o3-mini.provider.yaml
@@ -18,3 +18,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00055
     output_cost_per_1k: 0.0022
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-o3.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o3.provider.yaml
@@ -18,3 +18,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.002
     output_cost_per_1k: 0.008
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/capability-matrix/providers/openai-o4-mini.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o4-mini.provider.yaml
@@ -18,3 +18,6 @@ spec:
   pricing:
     input_cost_per_1k: 0.00055
     output_cost_per_1k: 0.0022
+  stream_retry:
+    enabled: true
+    max_attempts: 3


### PR DESCRIPTION
## Summary

Enable `stream_retry` (max 3 attempts) on all cloud provider configs in the capability matrix. The retry logic was already implemented but not enabled in these configs, so transient failures (http2 connection drops, 503s) were counted as hard errors.

Last run: 170/176 passed with 6 errors (threshold: 5). Most were transient `http2: response body closed` and Gemini 503 "high demand" — exactly what the retry driver is designed to handle.

## Test plan

- [ ] CI passes
- [ ] Trigger capability matrix run after merge to verify reduced error count