### PR TITLE
fix(openai): config-driven audio output modalities instead of auto-inference

### DIFF
--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -291,6 +291,26 @@ func applyAudioModalities(openAIReq map[string]interface{}, additionalConfig map
 	}
 }
 
+// enrichRequest applies common request fields: audio modalities, max tokens,
+// sampling parameters, seed, and response format. Both predictWithMessages
+// and predictStreamWithMessages call this after constructing the base request map.
+func (p *Provider) enrichRequest(
+	openAIReq map[string]interface{}, req *providers.PredictionRequest, audioFmtFallback string,
+) {
+	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(req) {
+		applyAudioModalities(openAIReq, p.additionalConfig, audioFmtFallback)
+	}
+	temperature, topP, maxTokens := p.applyRequestDefaults(*req)
+	addMaxTokensToRequest(openAIReq, p.unsupportedParams, maxTokens)
+	addSamplingParamsToRequest(openAIReq, p.unsupportedParams, temperature, topP)
+	if req.Seed != nil {
+		openAIReq["seed"] = *req.Seed
+	}
+	if req.ResponseFormat != nil {
+		openAIReq["response_format"] = p.convertResponseFormat(req.ResponseFormat)
+	}
+}
+
 // applyAuth applies authentication to an HTTP request.
 func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
 	if p.credential != nil {
@@ -819,33 +839,11 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 
 	start := time.Now()
 
-	// Apply provider defaults for zero values
-	temperature, topP, maxTokens := p.applyRequestDefaults(req)
-
-	// Create request as a map for flexibility with o-series models
 	openAIReq := map[string]interface{}{
 		"model":    p.model,
 		"messages": messages,
 	}
-
-	// Apply audio output modalities from additional_config for audio models.
-	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
-		applyAudioModalities(openAIReq, p.additionalConfig, "wav")
-	}
-
-	// Add max tokens with the correct parameter name for the model type
-	addMaxTokensToRequest(openAIReq, p.unsupportedParams, maxTokens)
-	// Add sampling parameters (temperature, top_p) if model supports them
-	addSamplingParamsToRequest(openAIReq, p.unsupportedParams, temperature, topP)
-
-	if req.Seed != nil {
-		openAIReq["seed"] = *req.Seed
-	}
-
-	// Add response format if specified
-	if req.ResponseFormat != nil {
-		openAIReq["response_format"] = p.convertResponseFormat(req.ResponseFormat)
-	}
+	p.enrichRequest(openAIReq, &req, "wav")
 
 	reqBody, err := json.Marshal(openAIReq)
 	if err != nil {
@@ -942,10 +940,6 @@ func (p *Provider) predictStreamWithMessages(ctx context.Context, req providers.
 		Model:    p.model,
 	})
 
-	// Apply provider defaults for zero values
-	temperature, topP, maxTokens := p.applyRequestDefaults(req)
-
-	// Create streaming request
 	openAIReq := map[string]interface{}{
 		"model":    p.model,
 		"messages": messages,
@@ -954,24 +948,8 @@ func (p *Provider) predictStreamWithMessages(ctx context.Context, req providers.
 			"include_usage": true,
 		},
 	}
-
-	// Apply audio output modalities from additional_config for audio models.
 	// When stream=true, OpenAI only supports "pcm16" for audio.format.
-	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
-		applyAudioModalities(openAIReq, p.additionalConfig, "pcm16")
-	}
-
-	// Add max tokens with the correct parameter name for the model type
-	addMaxTokensToRequest(openAIReq, p.unsupportedParams, maxTokens)
-	// Add sampling parameters (temperature, top_p) if model supports them
-	addSamplingParamsToRequest(openAIReq, p.unsupportedParams, temperature, topP)
-	if req.Seed != nil {
-		openAIReq["seed"] = *req.Seed
-	}
-	// Add response format if specified
-	if req.ResponseFormat != nil {
-		openAIReq["response_format"] = p.convertResponseFormat(req.ResponseFormat)
-	}
+	p.enrichRequest(openAIReq, &req, "pcm16")
 
 	reqBody, err := json.Marshal(openAIReq)
 	if err != nil {

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -286,6 +286,23 @@ func hasModality(modalities []string, target string) bool {
 	return false
 }
 
+// applyAudioModalities sets the "modalities" and optional "audio" fields on
+// an OpenAI request map. formatFallback is used when additional_config does
+// not specify audio_format (e.g. "wav" for non-streaming, "pcm16" for streaming).
+func applyAudioModalities(openAIReq map[string]interface{}, additionalConfig map[string]any, formatFallback string) {
+	modalities := getAudioModalities(additionalConfig)
+	if modalities == nil {
+		modalities = []string{"text"}
+	}
+	openAIReq["modalities"] = modalities
+	if hasModality(modalities, "audio") {
+		openAIReq["audio"] = map[string]interface{}{
+			"voice":  getAudioVoice(additionalConfig),
+			"format": getAudioOutputFormat(additionalConfig, formatFallback),
+		}
+	}
+}
+
 // applyAuth applies authentication to an HTTP request.
 func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
 	if p.credential != nil {
@@ -825,17 +842,7 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 
 	// Apply audio output modalities from additional_config for audio models.
 	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
-		modalities := getAudioModalities(p.additionalConfig)
-		if modalities == nil {
-			modalities = []string{"text"}
-		}
-		openAIReq["modalities"] = modalities
-		if hasModality(modalities, "audio") {
-			openAIReq["audio"] = map[string]interface{}{
-				"voice":  getAudioVoice(p.additionalConfig),
-				"format": getAudioOutputFormat(p.additionalConfig, "wav"),
-			}
-		}
+		applyAudioModalities(openAIReq, p.additionalConfig, "wav")
 	}
 
 	// Add max tokens with the correct parameter name for the model type
@@ -963,17 +970,7 @@ func (p *Provider) predictStreamWithMessages(ctx context.Context, req providers.
 	// Apply audio output modalities from additional_config for audio models.
 	// When stream=true, OpenAI only supports "pcm16" for audio.format.
 	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
-		modalities := getAudioModalities(p.additionalConfig)
-		if modalities == nil {
-			modalities = []string{"text"}
-		}
-		openAIReq["modalities"] = modalities
-		if hasModality(modalities, "audio") {
-			openAIReq["audio"] = map[string]interface{}{
-				"voice":  getAudioVoice(p.additionalConfig),
-				"format": getAudioOutputFormat(p.additionalConfig, "pcm16"),
-			}
-		}
+		applyAudioModalities(openAIReq, p.additionalConfig, "pcm16")
 	}
 
 	// Add max tokens with the correct parameter name for the model type

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -215,6 +215,77 @@ func getReasoningEffort(additionalConfig map[string]any) string {
 	}
 }
 
+// getAudioModalities returns the output modalities for audio models from
+// additional_config. Returns nil when not configured — the caller decides
+// whether to apply a default.
+//
+// Provider YAML example:
+//
+//	additional_config:
+//	  modalities: ["text", "audio"]
+//	  voice: alloy
+//	  audio_format: pcm16
+func getAudioModalities(additionalConfig map[string]any) []string {
+	if additionalConfig == nil {
+		return nil
+	}
+	raw, ok := additionalConfig["modalities"]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []interface{}:
+		result := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+// defaultAudioVoice is the default voice for OpenAI audio output.
+const defaultAudioVoice = "alloy"
+
+// getAudioVoice returns the voice setting from additional_config.
+// Defaults to "alloy" when not configured.
+func getAudioVoice(additionalConfig map[string]any) string {
+	if additionalConfig == nil {
+		return defaultAudioVoice
+	}
+	if v, ok := additionalConfig["voice"].(string); ok && v != "" {
+		return v
+	}
+	return defaultAudioVoice
+}
+
+// getAudioOutputFormat returns the audio output format from additional_config.
+// Defaults to the provided fallback when not configured.
+func getAudioOutputFormat(additionalConfig map[string]any, fallback string) string {
+	if additionalConfig == nil {
+		return fallback
+	}
+	if v, ok := additionalConfig["audio_format"].(string); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+// hasModality returns true if the modalities slice contains the given value.
+func hasModality(modalities []string, target string) bool {
+	for _, m := range modalities {
+		if strings.EqualFold(m, target) {
+			return true
+		}
+	}
+	return false
+}
+
 // applyAuth applies authentication to an HTTP request.
 func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
 	if p.credential != nil {
@@ -752,13 +823,18 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 		"messages": messages,
 	}
 
-	// Add modalities for audio models when audio content is present
+	// Apply audio output modalities from additional_config for audio models.
 	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
-		openAIReq["modalities"] = []string{"text", "audio"}
-		// Audio models require audio output configuration
-		openAIReq["audio"] = map[string]interface{}{
-			"voice":  "alloy",
-			"format": "wav",
+		modalities := getAudioModalities(p.additionalConfig)
+		if modalities == nil {
+			modalities = []string{"text"}
+		}
+		openAIReq["modalities"] = modalities
+		if hasModality(modalities, "audio") {
+			openAIReq["audio"] = map[string]interface{}{
+				"voice":  getAudioVoice(p.additionalConfig),
+				"format": getAudioOutputFormat(p.additionalConfig, "wav"),
+			}
 		}
 	}
 
@@ -884,14 +960,19 @@ func (p *Provider) predictStreamWithMessages(ctx context.Context, req providers.
 		},
 	}
 
-	// Add modalities for audio models when audio content is present.
-	// When stream=true, OpenAI chat/completions only supports "pcm16" for audio.format;
-	// "wav"/"mp3" are valid only for non-streaming requests.
+	// Apply audio output modalities from additional_config for audio models.
+	// When stream=true, OpenAI only supports "pcm16" for audio.format.
 	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
-		openAIReq["modalities"] = []string{"text", "audio"}
-		openAIReq["audio"] = map[string]interface{}{
-			"voice":  "alloy",
-			"format": "pcm16",
+		modalities := getAudioModalities(p.additionalConfig)
+		if modalities == nil {
+			modalities = []string{"text"}
+		}
+		openAIReq["modalities"] = modalities
+		if hasModality(modalities, "audio") {
+			openAIReq["audio"] = map[string]interface{}{
+				"voice":  getAudioVoice(p.additionalConfig),
+				"format": getAudioOutputFormat(p.additionalConfig, "pcm16"),
+			}
 		}
 	}
 

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -252,25 +252,13 @@ func getAudioModalities(additionalConfig map[string]any) []string {
 // defaultAudioVoice is the default voice for OpenAI audio output.
 const defaultAudioVoice = "alloy"
 
-// getAudioVoice returns the voice setting from additional_config.
-// Defaults to "alloy" when not configured.
-func getAudioVoice(additionalConfig map[string]any) string {
-	if additionalConfig == nil {
-		return defaultAudioVoice
-	}
-	if v, ok := additionalConfig["voice"].(string); ok && v != "" {
-		return v
-	}
-	return defaultAudioVoice
-}
-
-// getAudioOutputFormat returns the audio output format from additional_config.
-// Defaults to the provided fallback when not configured.
-func getAudioOutputFormat(additionalConfig map[string]any, fallback string) string {
+// getStringConfigOrDefault returns the value of key from additionalConfig if
+// it is a non-empty string, otherwise returns fallback.
+func getStringConfigOrDefault(additionalConfig map[string]any, key, fallback string) string {
 	if additionalConfig == nil {
 		return fallback
 	}
-	if v, ok := additionalConfig["audio_format"].(string); ok && v != "" {
+	if v, ok := additionalConfig[key].(string); ok && v != "" {
 		return v
 	}
 	return fallback
@@ -297,8 +285,8 @@ func applyAudioModalities(openAIReq map[string]interface{}, additionalConfig map
 	openAIReq["modalities"] = modalities
 	if hasModality(modalities, "audio") {
 		openAIReq["audio"] = map[string]interface{}{
-			"voice":  getAudioVoice(additionalConfig),
-			"format": getAudioOutputFormat(additionalConfig, formatFallback),
+			"voice":  getStringConfigOrDefault(additionalConfig, "voice", defaultAudioVoice),
+			"format": getStringConfigOrDefault(additionalConfig, "audio_format", formatFallback),
 		}
 	}
 }

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1428,6 +1428,107 @@ func TestPredict_AudioFormat_WAV(t *testing.T) {
 	}
 }
 
+// TestPredict_AudioModel_NoModalitiesConfig verifies that when an audio model
+// has no "modalities" in additional_config, we default to ["text"] and omit
+// the "audio" output config block.
+func TestPredict_AudioModel_NoModalitiesConfig(t *testing.T) {
+	var capturedReq map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedReq); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", server.URL,
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "completions"}, // no "modalities" key
+	)
+
+	audioB64 := "AA=="
+	audioMedia := types.MediaContent{MIMEType: "audio/wav", Data: &audioB64}
+	req := providers.PredictionRequest{
+		Messages: []types.Message{{
+			Role: "user",
+			Parts: []types.ContentPart{
+				types.NewTextPart("Transcribe"),
+				{Type: types.ContentTypeAudio, Media: &audioMedia},
+			},
+		}},
+	}
+
+	if _, err := provider.Predict(context.Background(), req); err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+
+	mods, ok := capturedReq["modalities"].([]any)
+	if !ok {
+		t.Fatalf("expected modalities in request, got: %v", capturedReq)
+	}
+	if len(mods) != 1 || mods[0] != "text" {
+		t.Errorf("modalities = %v, want [text]", mods)
+	}
+	if _, hasAudio := capturedReq["audio"]; hasAudio {
+		t.Error("expected no audio config when modalities omit audio")
+	}
+}
+
+// TestPredictStream_AudioModel_NoModalitiesConfig is the streaming counterpart.
+func TestPredictStream_AudioModel_NoModalitiesConfig(t *testing.T) {
+	var capturedReq map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedReq); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", server.URL,
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "completions"}, // no "modalities" key
+	)
+
+	audioB64 := "AA=="
+	audioMedia := types.MediaContent{MIMEType: "audio/wav", Data: &audioB64}
+	req := providers.PredictionRequest{
+		Messages: []types.Message{{
+			Role: "user",
+			Parts: []types.ContentPart{
+				types.NewTextPart("Transcribe"),
+				{Type: types.ContentTypeAudio, Media: &audioMedia},
+			},
+		}},
+	}
+
+	streamChan, err := provider.PredictStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("PredictStream failed: %v", err)
+	}
+	for range streamChan { //nolint:revive // drain
+	}
+
+	mods, ok := capturedReq["modalities"].([]any)
+	if !ok {
+		t.Fatalf("expected modalities in request, got: %v", capturedReq)
+	}
+	if len(mods) != 1 || mods[0] != "text" {
+		t.Errorf("modalities = %v, want [text]", mods)
+	}
+	if _, hasAudio := capturedReq["audio"]; hasAudio {
+		t.Error("expected no audio config when modalities omit audio")
+	}
+}
+
 func TestGetAudioModalities(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1427,3 +1427,93 @@ func TestPredict_AudioFormat_WAV(t *testing.T) {
 		t.Errorf("non-streaming audio.format = %q, want wav", format)
 	}
 }
+
+func TestGetAudioModalities(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]any
+		want   []string
+	}{
+		{"nil config", nil, nil},
+		{"missing key", map[string]any{}, nil},
+		{"[]string value", map[string]any{"modalities": []string{"text", "audio"}}, []string{"text", "audio"}},
+		{"[]interface{} value", map[string]any{"modalities": []interface{}{"text", "audio"}}, []string{"text", "audio"}},
+		{"wrong type", map[string]any{"modalities": "text"}, nil},
+		{"[]interface{} with non-strings", map[string]any{"modalities": []interface{}{"text", 42}}, []string{"text"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getAudioModalities(tt.config)
+			if len(got) != len(tt.want) {
+				t.Fatalf("getAudioModalities() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("getAudioModalities()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetAudioVoice(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]any
+		want   string
+	}{
+		{"nil config", nil, "alloy"},
+		{"missing key", map[string]any{}, "alloy"},
+		{"empty string", map[string]any{"voice": ""}, "alloy"},
+		{"custom voice", map[string]any{"voice": "nova"}, "nova"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAudioVoice(tt.config); got != tt.want {
+				t.Errorf("getAudioVoice() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAudioOutputFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]any
+		fallback string
+		want     string
+	}{
+		{"nil config", nil, "wav", "wav"},
+		{"missing key", map[string]any{}, "pcm16", "pcm16"},
+		{"empty string", map[string]any{"audio_format": ""}, "wav", "wav"},
+		{"custom format", map[string]any{"audio_format": "mp3"}, "wav", "mp3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAudioOutputFormat(tt.config, tt.fallback); got != tt.want {
+				t.Errorf("getAudioOutputFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasModality(t *testing.T) {
+	tests := []struct {
+		name       string
+		modalities []string
+		target     string
+		want       bool
+	}{
+		{"found exact", []string{"text", "audio"}, "audio", true},
+		{"found case-insensitive", []string{"Text", "Audio"}, "audio", true},
+		{"not found", []string{"text"}, "audio", false},
+		{"empty slice", nil, "audio", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasModality(tt.modalities, tt.target); got != tt.want {
+				t.Errorf("hasModality() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1622,42 +1622,25 @@ func TestGetAudioModalities(t *testing.T) {
 	}
 }
 
-func TestGetAudioVoice(t *testing.T) {
-	tests := []struct {
-		name   string
-		config map[string]any
-		want   string
-	}{
-		{"nil config", nil, "alloy"},
-		{"missing key", map[string]any{}, "alloy"},
-		{"empty string", map[string]any{"voice": ""}, "alloy"},
-		{"custom voice", map[string]any{"voice": "nova"}, "nova"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getAudioVoice(tt.config); got != tt.want {
-				t.Errorf("getAudioVoice() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestGetAudioOutputFormat(t *testing.T) {
+func TestGetStringConfigOrDefault(t *testing.T) {
 	tests := []struct {
 		name     string
 		config   map[string]any
+		key      string
 		fallback string
 		want     string
 	}{
-		{"nil config", nil, "wav", "wav"},
-		{"missing key", map[string]any{}, "pcm16", "pcm16"},
-		{"empty string", map[string]any{"audio_format": ""}, "wav", "wav"},
-		{"custom format", map[string]any{"audio_format": "mp3"}, "wav", "mp3"},
+		{"nil config", nil, "voice", "alloy", "alloy"},
+		{"missing key", map[string]any{}, "voice", "alloy", "alloy"},
+		{"empty string", map[string]any{"voice": ""}, "voice", "alloy", "alloy"},
+		{"custom value", map[string]any{"voice": "nova"}, "voice", "alloy", "nova"},
+		{"audio_format fallback", map[string]any{}, "audio_format", "pcm16", "pcm16"},
+		{"audio_format custom", map[string]any{"audio_format": "mp3"}, "audio_format", "wav", "mp3"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getAudioOutputFormat(tt.config, tt.fallback); got != tt.want {
-				t.Errorf("getAudioOutputFormat() = %q, want %q", got, tt.want)
+			if got := getStringConfigOrDefault(tt.config, tt.key, tt.fallback); got != tt.want {
+				t.Errorf("getStringConfigOrDefault() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1529,6 +1529,71 @@ func TestPredictStream_AudioModel_NoModalitiesConfig(t *testing.T) {
 	}
 }
 
+func TestApplyAudioModalities(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         map[string]any
+		fallback       string
+		wantMods       []any
+		wantAudioBlock bool
+		wantVoice      string
+		wantFormat     string
+	}{
+		{
+			name:           "nil modalities defaults to text only",
+			config:         nil,
+			fallback:       "wav",
+			wantMods:       []any{"text"},
+			wantAudioBlock: false,
+		},
+		{
+			name:           "text+audio includes audio block",
+			config:         map[string]any{"modalities": []any{"text", "audio"}, "voice": "nova", "audio_format": "mp3"},
+			fallback:       "wav",
+			wantMods:       []any{"text", "audio"},
+			wantAudioBlock: true,
+			wantVoice:      "nova",
+			wantFormat:     "mp3",
+		},
+		{
+			name:           "text+audio uses fallback format",
+			config:         map[string]any{"modalities": []any{"text", "audio"}},
+			fallback:       "pcm16",
+			wantMods:       []any{"text", "audio"},
+			wantAudioBlock: true,
+			wantVoice:      "alloy",
+			wantFormat:     "pcm16",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := map[string]interface{}{}
+			applyAudioModalities(req, tt.config, tt.fallback)
+
+			mods, ok := req["modalities"].([]string)
+			if !ok {
+				t.Fatalf("modalities not set or wrong type")
+			}
+			if len(mods) != len(tt.wantMods) {
+				t.Fatalf("modalities = %v, want %v", mods, tt.wantMods)
+			}
+
+			audioCfg, hasAudio := req["audio"].(map[string]interface{})
+			if hasAudio != tt.wantAudioBlock {
+				t.Fatalf("audio block present = %v, want %v", hasAudio, tt.wantAudioBlock)
+			}
+			if tt.wantAudioBlock {
+				if audioCfg["voice"] != tt.wantVoice {
+					t.Errorf("voice = %v, want %v", audioCfg["voice"], tt.wantVoice)
+				}
+				if audioCfg["format"] != tt.wantFormat {
+					t.Errorf("format = %v, want %v", audioCfg["format"], tt.wantFormat)
+				}
+			}
+		})
+	}
+}
+
 func TestGetAudioModalities(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1349,7 +1349,7 @@ func TestPredictStream_AudioFormat_PCM16(t *testing.T) {
 	provider := NewProviderWithConfig(
 		"test", "gpt-4o-audio-preview", server.URL,
 		providers.ProviderDefaults{}, false,
-		map[string]any{"api_mode": "completions"},
+		map[string]any{"api_mode": "completions", "modalities": []any{"text", "audio"}},
 	)
 
 	audioB64 := "AA=="
@@ -1398,7 +1398,7 @@ func TestPredict_AudioFormat_WAV(t *testing.T) {
 	provider := NewProviderWithConfig(
 		"test", "gpt-4o-audio-preview", server.URL,
 		providers.ProviderDefaults{}, false,
-		map[string]any{"api_mode": "completions"},
+		map[string]any{"api_mode": "completions", "modalities": []any{"text", "audio"}},
 	)
 
 	audioB64 := "AA=="

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -258,17 +258,7 @@ func (p *ToolProvider) buildToolRequest(req providers.PredictionRequest, tools i
 
 	// Apply audio output modalities from additional_config for audio models.
 	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
-		modalities := getAudioModalities(p.additionalConfig)
-		if modalities == nil {
-			modalities = []string{"text"}
-		}
-		openaiReq["modalities"] = modalities
-		if hasModality(modalities, "audio") {
-			openaiReq["audio"] = map[string]interface{}{
-				"voice":  getAudioVoice(p.additionalConfig),
-				"format": getAudioOutputFormat(p.additionalConfig, "wav"),
-			}
-		}
+		applyAudioModalities(openaiReq, p.additionalConfig, "wav")
 	}
 
 	// Add tools if provided

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -256,12 +256,18 @@ func (p *ToolProvider) buildToolRequest(req providers.PredictionRequest, tools i
 		openaiReq["seed"] = *req.Seed
 	}
 
-	// Add modalities for audio models when audio content is present
+	// Apply audio output modalities from additional_config for audio models.
 	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
-		openaiReq["modalities"] = []string{"text", "audio"}
-		openaiReq["audio"] = map[string]interface{}{
-			"voice":  "alloy",
-			"format": "wav",
+		modalities := getAudioModalities(p.additionalConfig)
+		if modalities == nil {
+			modalities = []string{"text"}
+		}
+		openaiReq["modalities"] = modalities
+		if hasModality(modalities, "audio") {
+			openaiReq["audio"] = map[string]interface{}{
+				"voice":  getAudioVoice(p.additionalConfig),
+				"format": getAudioOutputFormat(p.additionalConfig, "wav"),
+			}
 		}
 	}
 

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -1087,6 +1087,12 @@ func TestBuildToolRequest_AudioModalities(t *testing.T) {
 	)
 	// Force completions API mode (audio models need it)
 	provider.apiMode = APIModeCompletions
+	// Opt in to audio output via additional_config
+	provider.additionalConfig = map[string]any{
+		"modalities":   []any{"text", "audio"},
+		"voice":        "alloy",
+		"audio_format": "wav",
+	}
 
 	audioData := types.MediaContent{MIMEType: "audio/flac"}
 	req := providers.PredictionRequest{
@@ -1154,7 +1160,7 @@ func TestPredictStreamWithTools_AudioFormat_PCM16(t *testing.T) {
 	provider := NewToolProvider(
 		"test", "gpt-4o-audio-preview", server.URL,
 		providers.ProviderDefaults{}, false,
-		map[string]any{"api_mode": "completions"}, nil,
+		map[string]any{"api_mode": "completions", "modalities": []any{"text", "audio"}}, nil,
 	)
 
 	audioB64 := "AA=="


### PR DESCRIPTION
## Summary

OpenAI audio models previously auto-added `modalities: ["text", "audio"]` whenever audio input was detected. This caused the model to return text in `audio.transcript` instead of `choices[0].delta.content`, making assertion evaluation fail because `BuildEvalContext` reads content from the assistant message's `.Content` field.

Now audio output modalities default to `["text"]` unless explicitly configured via `additional_config` in the provider YAML:

```yaml
additional_config:
  modalities: ["text", "audio"]  # opt in to audio output
  voice: alloy                    # configurable (was hardcoded)
  audio_format: pcm16             # configurable (was hardcoded)
```

This matches how Gemini handles modalities — via `additional_config.response_modalities` in provider YAML, not auto-inferred from input.

### Impact

- **Capability matrix audio tests**: Now get text responses they can assert against (assertion_0 goes from score 0 to score 1)
- **Duplex/voice pipelines**: Need to set `modalities: ["text", "audio"]` in provider config (Gemini examples already do this)
- **SDK users**: Audio input still works for transcription — model responds in text by default

## Test plan

- [x] All OpenAI provider tests pass (including audio format regression tests)
- [x] Audio capability matrix test locally: assertion_0 (content_includes) now scores 1
- [x] Pre-commit passes (lint, build, test, coverage)