### PR TITLE
feat(openai): parse audio responses in Completions and Responses APIs

### DIFF
--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -352,9 +352,17 @@ type openAIJSONSchema struct {
 	Strict bool        `json:"strict,omitempty"`
 }
 
+type openAIAudioResponse struct {
+	ID         string `json:"id"`
+	Data       string `json:"data"`
+	Transcript string `json:"transcript"`
+	ExpiresAt  int64  `json:"expires_at"`
+}
+
 type openAIMessage struct {
-	Role    string      `json:"role"`
-	Content interface{} `json:"content"` // Can be string or []interface{} for multimodal
+	Role    string               `json:"role"`
+	Content interface{}          `json:"content"` // Can be string or []interface{} for multimodal
+	Audio   *openAIAudioResponse `json:"audio,omitempty"`
 }
 
 type openAIResponse struct {
@@ -922,9 +930,21 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 
 	// Extract content - can be string or array of content parts
 	content := extractContentString(openAIResp.Choices[0].Message.Content)
+	parts := extractContentParts(openAIResp.Choices[0].Message.Content)
+
+	if audio := openAIResp.Choices[0].Message.Audio; audio != nil {
+		if audio.Transcript != "" {
+			content = audio.Transcript
+			parts = append(parts, types.NewTextPart(audio.Transcript))
+		}
+		if audio.Data != "" {
+			audioFormat := getStringConfigOrDefault(p.additionalConfig, "audio_format", "wav")
+			parts = append(parts, types.NewAudioPartFromData(audio.Data, audioFormatToMIME(audioFormat)))
+		}
+	}
 
 	predictResp.Content = content
-	predictResp.Parts = extractContentParts(openAIResp.Choices[0].Message.Content)
+	predictResp.Parts = parts
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBody

--- a/runtime/providers/openai/openai_multimodal.go
+++ b/runtime/providers/openai/openai_multimodal.go
@@ -29,8 +29,9 @@ func (p *Provider) GetMultimodalCapabilities() providers.MultimodalCapabilities 
 		MaxVideoSizeMB: 0,
 	}
 
-	// Audio models (gpt-4o-audio-preview) support audio input when using Chat Completions API
-	if p.apiMode == APIModeCompletions && isAudioModel(p.model) {
+	// Audio models (gpt-4o-audio-preview) support audio input via both APIs:
+	// Chat Completions (non-streaming + streaming) and Responses API (streaming events).
+	if isAudioModel(p.model) {
 		caps.SupportsAudio = true
 		caps.AudioFormats = []string{
 			types.MIMETypeAudioWAV,

--- a/runtime/providers/openai/openai_multimodal.go
+++ b/runtime/providers/openai/openai_multimodal.go
@@ -8,6 +8,8 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+const audioPCM16Format = "pcm16"
+
 // GetMultimodalCapabilities returns OpenAI's multimodal capabilities
 func (p *Provider) GetMultimodalCapabilities() providers.MultimodalCapabilities {
 	caps := providers.MultimodalCapabilities{
@@ -216,6 +218,27 @@ func getAudioFormat(mimeType string) string {
 		return "mp3"
 	default:
 		return ""
+	}
+}
+
+// audioFormatToMIME maps an OpenAI audio format string (from the audio.format
+// request parameter or response) to a MIME type.
+func audioFormatToMIME(format string) string {
+	switch format {
+	case "wav":
+		return types.MIMETypeAudioWAV
+	case "mp3":
+		return types.MIMETypeAudioMP3
+	case audioPCM16Format:
+		return "audio/pcm"
+	case "aac":
+		return "audio/aac"
+	case "flac":
+		return "audio/flac"
+	case "opus":
+		return "audio/opus"
+	default:
+		return "application/octet-stream"
 	}
 }
 

--- a/runtime/providers/openai/openai_multimodal_test.go
+++ b/runtime/providers/openai/openai_multimodal_test.go
@@ -1119,17 +1119,17 @@ func TestOpenAIProvider_AudioModelConvertMessage(t *testing.T) {
 }
 
 func TestOpenAIProvider_AudioModelWithResponsesAPI(t *testing.T) {
-	// Audio model with Responses API should NOT support audio
+	// Audio model with Responses API should support audio (via streaming events)
 	provider := NewProviderWithConfig(
 		"test-audio", "gpt-4o-audio-preview", "https://api.openai.com/v1",
 		providers.ProviderDefaults{}, false,
-		map[string]any{"api_mode": "responses"}, // Not completions
+		map[string]any{"api_mode": "responses"},
 	)
 
 	caps := provider.GetMultimodalCapabilities()
 
-	if caps.SupportsAudio {
-		t.Error("Expected audio model with Responses API not to support audio")
+	if !caps.SupportsAudio {
+		t.Error("Expected audio model with Responses API to support audio")
 	}
 }
 

--- a/runtime/providers/openai/openai_multimodal_test.go
+++ b/runtime/providers/openai/openai_multimodal_test.go
@@ -1217,3 +1217,26 @@ func TestOpenAIProvider_APIMode_Configuration(t *testing.T) {
 		})
 	}
 }
+
+func TestAudioFormatToMIME(t *testing.T) {
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{"wav", types.MIMETypeAudioWAV},
+		{"mp3", types.MIMETypeAudioMP3},
+		{"pcm16", "audio/pcm"},
+		{"aac", "audio/aac"},
+		{"flac", "audio/flac"},
+		{"opus", "audio/opus"},
+		{"unknown", "application/octet-stream"},
+		{"", "application/octet-stream"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			if got := audioFormatToMIME(tt.format); got != tt.want {
+				t.Errorf("audioFormatToMIME(%q) = %q, want %q", tt.format, got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,6 +31,12 @@ const (
 	eventTypeOutputAdded   = "response.output_item.added"
 	eventTypeCompleted     = "response.completed"
 	eventTypeError         = "error"
+
+	// Audio event types for Responses API streaming
+	eventTypeAudioDelta      = "response.audio.delta"
+	eventTypeAudioDone       = "response.audio.done"
+	eventTypeAudioTransDelta = "response.audio_transcript.delta"
+	eventTypeAudioTransDone  = "response.audio_transcript.done"
 
 	// Common string constants
 	toolChoiceAuto        = "auto"
@@ -635,6 +642,20 @@ func (p *Provider) handleStreamEvent(
 	case eventTypeError:
 		p.handleErrorEvent(data, sb.String(), toolCalls, outChan)
 		return totalTokens, toolCalls, usage
+
+	case eventTypeAudioDelta:
+		p.handleAudioDelta(data, outChan)
+		return totalTokens, toolCalls, usage
+
+	case eventTypeAudioDone:
+		return totalTokens, toolCalls, usage
+
+	case eventTypeAudioTransDelta:
+		newTokens = p.handleAudioTranscriptDelta(data, sb, totalTokens, toolCalls, outChan)
+		return newTokens, toolCalls, usage
+
+	case eventTypeAudioTransDone:
+		return totalTokens, toolCalls, usage
 	}
 
 	return totalTokens, toolCalls, usage
@@ -662,6 +683,54 @@ func (p *Provider) handleTextDelta(
 			TokenCount:  totalTokens,
 			DeltaTokens: 1,
 		}
+	}
+	return totalTokens
+}
+
+// handleAudioDelta processes audio delta events, decoding base64 PCM data and
+// emitting it as a StreamChunk with MediaData.
+func (p *Provider) handleAudioDelta(data string, outChan chan<- providers.StreamChunk) {
+	var delta struct {
+		Delta string `json:"delta"`
+	}
+	if err := json.Unmarshal([]byte(data), &delta); err != nil || delta.Delta == "" {
+		return
+	}
+	raw, err := base64.StdEncoding.DecodeString(delta.Delta)
+	if err != nil {
+		return
+	}
+	outChan <- providers.StreamChunk{
+		MediaData: &providers.StreamMediaData{
+			Data:     raw,
+			MIMEType: "audio/pcm",
+		},
+	}
+}
+
+// handleAudioTranscriptDelta processes audio transcript delta events, emitting
+// transcript text as regular text deltas.
+func (p *Provider) handleAudioTranscriptDelta(
+	data string,
+	sb *strings.Builder,
+	totalTokens int,
+	toolCalls []types.MessageToolCall,
+	outChan chan<- providers.StreamChunk,
+) int {
+	var delta struct {
+		Delta string `json:"delta"`
+	}
+	if err := json.Unmarshal([]byte(data), &delta); err != nil || delta.Delta == "" {
+		return totalTokens
+	}
+	sb.WriteString(delta.Delta)
+	totalTokens++
+	outChan <- providers.StreamChunk{
+		Content:     sb.String(),
+		Delta:       delta.Delta,
+		ToolCalls:   toolCalls,
+		TokenCount:  totalTokens,
+		DeltaTokens: 1,
 	}
 	return totalTokens
 }

--- a/runtime/providers/openai/openai_responses_integration_test.go
+++ b/runtime/providers/openai/openai_responses_integration_test.go
@@ -1,6 +1,10 @@
 package openai
 
 import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -120,5 +124,118 @@ func TestGetReasoningEffort_DirectParsing(t *testing.T) {
 				t.Errorf("getReasoningEffort(%v) = %q, want %q", tt.cfg, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestHandleStreamEvent_AudioDelta(t *testing.T) {
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", "http://localhost",
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "responses"},
+	)
+
+	outChan := make(chan providers.StreamChunk, 10)
+	var sb strings.Builder
+	idMap := make(itemIDMap)
+
+	audioB64 := base64.StdEncoding.EncodeToString([]byte("raw-pcm-bytes"))
+	data := fmt.Sprintf(`{"type":"response.audio.delta","delta":"%s"}`, audioB64)
+
+	tokens, tc, usage := provider.handleStreamEvent(
+		responsesStreamEvent{Type: "response.audio.delta"},
+		data, &sb, 0, nil, nil, outChan, idMap,
+	)
+
+	if tokens != 0 {
+		t.Errorf("tokens = %d, want 0", tokens)
+	}
+	if tc != nil {
+		t.Errorf("unexpected tool calls")
+	}
+	if usage != nil {
+		t.Errorf("unexpected usage")
+	}
+
+	select {
+	case chunk := <-outChan:
+		if chunk.MediaData == nil {
+			t.Fatal("expected MediaData in chunk")
+		}
+		if !bytes.Equal(chunk.MediaData.Data, []byte("raw-pcm-bytes")) {
+			t.Errorf("MediaData.Data mismatch")
+		}
+		if chunk.MediaData.MIMEType != "audio/pcm" {
+			t.Errorf("MIMEType = %q, want audio/pcm", chunk.MediaData.MIMEType)
+		}
+	default:
+		t.Fatal("no chunk emitted for audio delta")
+	}
+}
+
+func TestHandleStreamEvent_AudioTranscriptDelta(t *testing.T) {
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", "http://localhost",
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "responses"},
+	)
+
+	outChan := make(chan providers.StreamChunk, 10)
+	var sb strings.Builder
+	idMap := make(itemIDMap)
+
+	data := `{"type":"response.audio_transcript.delta","delta":"Hello "}`
+
+	tokens, _, _ := provider.handleStreamEvent(
+		responsesStreamEvent{Type: "response.audio_transcript.delta"},
+		data, &sb, 0, nil, nil, outChan, idMap,
+	)
+
+	if tokens != 1 {
+		t.Errorf("tokens = %d, want 1", tokens)
+	}
+
+	select {
+	case chunk := <-outChan:
+		if chunk.Delta != "Hello " {
+			t.Errorf("Delta = %q, want %q", chunk.Delta, "Hello ")
+		}
+		if chunk.Content != "Hello " {
+			t.Errorf("Content = %q, want accumulated text", chunk.Content)
+		}
+	default:
+		t.Fatal("no chunk emitted for transcript delta")
+	}
+}
+
+func TestHandleStreamEvent_AudioDone(t *testing.T) {
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", "http://localhost",
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "responses"},
+	)
+
+	outChan := make(chan providers.StreamChunk, 10)
+	var sb strings.Builder
+	idMap := make(itemIDMap)
+
+	data := `{"type":"response.audio.done"}`
+
+	tokens, tc, usage := provider.handleStreamEvent(
+		responsesStreamEvent{Type: "response.audio.done"},
+		data, &sb, 5, nil, nil, outChan, idMap,
+	)
+
+	if tokens != 5 {
+		t.Errorf("tokens = %d, want 5 (unchanged)", tokens)
+	}
+	if tc != nil || usage != nil {
+		t.Error("unexpected side effects")
+	}
+
+	select {
+	case <-outChan:
+		t.Fatal("unexpected chunk emitted for audio done")
+	default:
+		// expected — no chunk
 	}
 }

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -2,7 +2,9 @@ package openai
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -1664,5 +1666,127 @@ func TestHasModality(t *testing.T) {
 				t.Errorf("hasModality() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestPredict_AudioResponse_WithTranscript(t *testing.T) {
+	audioB64 := base64.StdEncoding.EncodeToString([]byte("fake-wav-data"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := fmt.Sprintf(`{
+			"choices":[{
+				"index":0,
+				"message":{
+					"role":"assistant",
+					"content":null,
+					"audio":{
+						"id":"audio_123",
+						"data":"%s",
+						"transcript":"Hello, how can I help you?",
+						"expires_at":1700000000
+					}
+				},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+		}`, audioB64)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", server.URL,
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "completions", "modalities": []any{"text", "audio"}, "audio_format": "wav"},
+	)
+
+	audioB64Input := "AA=="
+	audioInput := types.MediaContent{MIMEType: "audio/wav", Data: &audioB64Input}
+	req := providers.PredictionRequest{
+		Messages: []types.Message{{
+			Role: "user",
+			Parts: []types.ContentPart{
+				types.NewTextPart("What is this audio?"),
+				{Type: types.ContentTypeAudio, Media: &audioInput},
+			},
+		}},
+	}
+
+	resp, err := provider.Predict(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+
+	if resp.Content != "Hello, how can I help you?" {
+		t.Errorf("Content = %q, want transcript", resp.Content)
+	}
+
+	if len(resp.Parts) < 2 {
+		t.Fatalf("expected at least 2 parts, got %d", len(resp.Parts))
+	}
+
+	var foundText, foundAudio bool
+	for _, p := range resp.Parts {
+		switch p.Type {
+		case types.ContentTypeText:
+			if p.Text != nil && *p.Text == "Hello, how can I help you?" {
+				foundText = true
+			}
+		case types.ContentTypeAudio:
+			if p.Media != nil && p.Media.Data != nil && *p.Media.Data == audioB64 {
+				foundAudio = true
+			}
+		}
+	}
+	if !foundText {
+		t.Error("expected a text part with the transcript")
+	}
+	if !foundAudio {
+		t.Error("expected an audio part with base64 data")
+	}
+}
+
+func TestPredict_AudioResponse_TextContentOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"The audio says hello."},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", server.URL,
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "completions"},
+	)
+
+	audioB64Input := "AA=="
+	audioInput := types.MediaContent{MIMEType: "audio/wav", Data: &audioB64Input}
+	req := providers.PredictionRequest{
+		Messages: []types.Message{{
+			Role: "user",
+			Parts: []types.ContentPart{
+				types.NewTextPart("What is this audio?"),
+				{Type: types.ContentTypeAudio, Media: &audioInput},
+			},
+		}},
+	}
+
+	resp, err := provider.Predict(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+
+	if resp.Content != "The audio says hello." {
+		t.Errorf("Content = %q, want text response", resp.Content)
+	}
+	if len(resp.Parts) != 1 || resp.Parts[0].Type != types.ContentTypeText {
+		t.Errorf("expected 1 text part, got %v", resp.Parts)
 	}
 }

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -429,8 +429,9 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte) (providers.Prediction
 	var openaiResp struct {
 		Choices []struct {
 			Message struct {
-				Content   string           `json:"content"`
-				ToolCalls []openAIToolCall `json:"tool_calls,omitempty"`
+				Content   string               `json:"content"`
+				Audio     *openAIAudioResponse `json:"audio,omitempty"`
+				ToolCalls []openAIToolCall     `json:"tool_calls,omitempty"`
 			} `json:"message"`
 		} `json:"choices"`
 		Usage struct {
@@ -465,6 +466,17 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte) (providers.Prediction
 		Content:  choice.Message.Content,
 		CostInfo: &costBreakdown,
 		Raw:      respBytes,
+	}
+
+	if audio := choice.Message.Audio; audio != nil {
+		if audio.Transcript != "" {
+			resp.Content = audio.Transcript
+			resp.Parts = append(resp.Parts, types.NewTextPart(audio.Transcript))
+		}
+		if audio.Data != "" {
+			audioFormat := getStringConfigOrDefault(p.additionalConfig, "audio_format", "wav")
+			resp.Parts = append(resp.Parts, types.NewAudioPartFromData(audio.Data, audioFormatToMIME(audioFormat)))
+		}
 	}
 
 	// Extract tool calls

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1193,5 +1194,51 @@ func TestPredictStreamWithTools_AudioFormat_PCM16(t *testing.T) {
 	}
 	if format, _ := audioCfg["format"].(string); format != "pcm16" {
 		t.Errorf("streaming tool-request audio.format = %q, want pcm16", format)
+	}
+}
+
+func TestParseToolResponse_AudioResponse(t *testing.T) {
+	audioB64 := base64.StdEncoding.EncodeToString([]byte("fake-wav-data"))
+	respJSON := fmt.Sprintf(`{
+		"choices":[{
+			"message":{
+				"role":"assistant",
+				"content":null,
+				"audio":{
+					"id":"audio_456",
+					"data":"%s",
+					"transcript":"Tool response with audio",
+					"expires_at":1700000000
+				}
+			}
+		}],
+		"usage":{"prompt_tokens":10,"completion_tokens":5}
+	}`, audioB64)
+
+	provider := NewToolProvider(
+		"test", "gpt-4o-audio-preview", "http://localhost",
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "completions", "audio_format": "wav"}, nil,
+	)
+
+	resp, toolCalls, err := provider.parseToolResponse([]byte(respJSON))
+	if err != nil {
+		t.Fatalf("parseToolResponse failed: %v", err)
+	}
+	if len(toolCalls) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(toolCalls))
+	}
+	if resp.Content != "Tool response with audio" {
+		t.Errorf("Content = %q, want transcript", resp.Content)
+	}
+
+	var foundAudio bool
+	for _, p := range resp.Parts {
+		if p.Type == types.ContentTypeAudio && p.Media != nil && p.Media.Data != nil && *p.Media.Data == audioB64 {
+			foundAudio = true
+		}
+	}
+	if !foundAudio {
+		t.Error("expected an audio part in response")
 	}
 }


### PR DESCRIPTION
## Summary

- Parse `message.audio` (data + transcript) from Chat Completions non-streaming responses, surfacing audio as `ContentPart` entries on `PredictionResponse`
- Handle 4 audio streaming events (`response.audio.delta`, `response.audio.done`, `response.audio_transcript.delta`, `response.audio_transcript.done`) in the Responses API streaming path
- Enable audio capabilities for audio models regardless of API mode (Completions or Responses)
- Add `audioFormatToMIME` helper for mapping OpenAI format strings to MIME types

## Test plan

- [ ] `TestPredict_AudioResponse_WithTranscript` — verifies audio data + transcript extracted from Completions response
- [ ] `TestPredict_AudioResponse_TextContentOnly` — verifies text-only response (no audio field) still works
- [ ] `TestParseToolResponse_AudioResponse` — verifies tool provider path extracts audio
- [ ] `TestHandleStreamEvent_AudioDelta` — verifies base64 audio decoded to raw bytes in StreamChunk.MediaData
- [ ] `TestHandleStreamEvent_AudioTranscriptDelta` — verifies transcript emitted as text delta
- [ ] `TestHandleStreamEvent_AudioDone` — verifies no spurious chunks on audio completion
- [ ] `TestAudioFormatToMIME` — verifies format→MIME mapping for wav, mp3, pcm16, aac, flac, opus
- [ ] `TestOpenAIProvider_AudioModelWithResponsesAPI` — verifies audio capabilities enabled for Responses API