### PR TITLE
fix: enable stream retry for ToolProvider across all providers

### DIFF
--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -613,38 +613,36 @@ func (p *ToolProvider) PredictStreamWithTools(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := p.messagesURL()
-
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-	httpReq.Header.Set(apiKeyHeader, p.apiKey)
-	httpReq.Header.Set(anthropicVersionKey, anthropicVersionValue)
-	httpReq.Header.Set("Accept", "text/event-stream")
-
-	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
-	if err != nil {
-		return nil, &providers.ProviderTransportError{Cause: err, Provider: p.ID()}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		body := providers.ReadErrorBody(resp.Body)
-		_ = resp.Body.Close()
-		return nil, &providers.ProviderHTTPError{
-			StatusCode: resp.StatusCode, URL: url,
-			Body: string(body), Provider: p.ID(),
+	// Direct API: wire through RunStreamingRequest so retries, budget,
+	// semaphore, and metrics all work the same as the Bedrock path.
+	url := p.messagesStreamURL()
+	requestFn := func(ctx context.Context) (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestBytes))
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
 		}
+		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		httpReq.Header.Set(anthropicVersionKey, anthropicVersionValue)
+		httpReq.Header.Set("Accept", "text/event-stream")
+		if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+			return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+		}
+		return httpReq, nil
 	}
 
-	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-	idleBody := providers.NewIdleTimeoutReader(resp.Body, p.StreamIdleTimeout())
-	scanner := providers.NewSSEScanner(idleBody)
-	go p.streamResponse(ctx, idleBody, scanner, outChan)
-
-	return outChan, nil
+	return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+		Policy:       p.StreamRetryPolicy(),
+		Budget:       p.StreamRetryBudget(),
+		ProviderName: p.ID(),
+		Host:         providers.HostFromURL(url),
+		IdleTimeout:  p.StreamIdleTimeout(),
+		RequestFn:    requestFn,
+		Client:       p.GetStreamingHTTPClient(),
+	}, func(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
+		idleBody := providers.NewIdleTimeoutReader(body, p.StreamIdleTimeout())
+		scanner := providers.NewSSEScanner(idleBody)
+		p.streamResponse(ctx, idleBody, scanner, outChan)
+	})
 }
 
 //nolint:gochecknoinits // Factory registration requires init

--- a/runtime/providers/claude/claude_tools_test.go
+++ b/runtime/providers/claude/claude_tools_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1151,5 +1152,57 @@ func TestAddClaudeToolConfig_ToolChoice(t *testing.T) {
 				t.Errorf("tool_choice = %s, want %s", gotJSON, wantJSON)
 			}
 		})
+	}
+}
+
+func TestClaudeToolProvider_PredictStreamWithTools_Retries503(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := atomic.AddInt32(&attempts, 1)
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error": {"type": "overloaded_error", "message": "overloaded"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-20250514\",\"usage\":{\"input_tokens\":10,\"output_tokens\":1}}}\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	provider := NewToolProvider("test", "claude-sonnet-4-20250514", server.URL, providers.ProviderDefaults{}, false)
+	provider.SetStreamRetryPolicy(providers.StreamRetryPolicy{
+		Enabled:     true,
+		MaxAttempts: 3,
+	})
+
+	stream, err := provider.PredictStreamWithTools(
+		context.Background(),
+		providers.PredictionRequest{
+			Messages: []types.Message{{Role: "user", Content: "test"}},
+		}, nil, "auto",
+	)
+	if err != nil {
+		t.Fatalf("Expected retry to succeed, got: %v", err)
+	}
+
+	var lastChunk providers.StreamChunk
+	for chunk := range stream {
+		lastChunk = chunk
+	}
+	if lastChunk.Content == "" {
+		t.Error("Expected content from retried stream")
+	}
+	if atomic.LoadInt32(&attempts) < 2 {
+		t.Errorf("Expected at least 2 attempts, got %d", attempts)
 	}
 }

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -622,34 +622,25 @@ func (p *ToolProvider) PredictStreamWithTools(
 		p.baseURL, p.model, p.apiKey,
 	)
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-
-	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
-	if err != nil {
-		return nil, &providers.ProviderTransportError{Cause: err, Provider: p.ID()}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		body := providers.ReadErrorBody(resp.Body)
-		_ = resp.Body.Close()
-		if p.platform != "" {
-			return nil, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, body)
+	requestFn := func(ctx context.Context) (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestBytes))
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
 		}
-		return nil, &providers.ProviderHTTPError{
-			StatusCode: resp.StatusCode, URL: logger.RedactSensitiveData(url),
-			Body: string(body), Provider: p.ID(),
-		}
+		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		return httpReq, nil
 	}
 
-	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-	go p.streamResponse(ctx, resp.Body, outChan)
-
-	return outChan, nil
+	return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+		Policy:        p.StreamRetryPolicy(),
+		Budget:        p.StreamRetryBudget(),
+		ProviderName:  p.ID(),
+		Host:          providers.HostFromURL(url),
+		IdleTimeout:   p.StreamIdleTimeout(),
+		RequestFn:     requestFn,
+		Client:        p.GetStreamingHTTPClient(),
+		FrameDetector: providers.JSONArrayFrameDetector{},
+	}, p.streamResponse)
 }
 
 // Ensure ToolProvider implements StreamInputSupport by forwarding to embedded Provider

--- a/runtime/providers/gemini/gemini_tools_test.go
+++ b/runtime/providers/gemini/gemini_tools_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -538,6 +539,52 @@ func TestGeminiToolProvider_PredictStreamWithTools_HTTPError(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("Expected error for HTTP 500")
+	}
+}
+
+func TestGeminiToolProvider_PredictStreamWithTools_Retries503(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := atomic.AddInt32(&attempts, 1)
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error": {"code": 503, "message": "overloaded"}}`))
+			return
+		}
+		// Second attempt succeeds with a valid Gemini JSON array response
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"candidates":[{"content":{"parts":[{"text":"hello"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}]`))
+	}))
+	defer server.Close()
+
+	geminiProvider := NewProvider("test", "gemini-2.0-flash", server.URL, providers.ProviderDefaults{}, false)
+	geminiProvider.SetStreamRetryPolicy(providers.StreamRetryPolicy{
+		Enabled:     true,
+		MaxAttempts: 3,
+	})
+	provider := &ToolProvider{Provider: geminiProvider}
+
+	ctx := context.Background()
+	stream, err := provider.PredictStreamWithTools(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "test"}},
+	}, nil, "auto")
+
+	if err != nil {
+		t.Fatalf("Expected retry to succeed, got error: %v", err)
+	}
+
+	// Drain the stream
+	var lastChunk providers.StreamChunk
+	for chunk := range stream {
+		lastChunk = chunk
+	}
+
+	if lastChunk.Content == "" {
+		t.Error("Expected content from retried stream")
+	}
+
+	if atomic.LoadInt32(&attempts) < 2 {
+		t.Errorf("Expected at least 2 attempts (1 fail + 1 success), got %d", attempts)
 	}
 }
 

--- a/runtime/providers/ollama/ollama_tools.go
+++ b/runtime/providers/ollama/ollama_tools.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -322,6 +323,12 @@ func (p *ToolProvider) PredictStreamWithTools(
 	tools any,
 	toolChoice string,
 ) (<-chan providers.StreamChunk, error) {
+	// Enrich context with provider and model info for logging
+	ctx = logger.WithLoggingContext(ctx, &logger.LoggingFields{
+		Provider: p.ID(),
+		Model:    p.model,
+	})
+
 	// Build Ollama request with tools (same as non-streaming)
 	ollamaReq := p.buildToolRequest(req, tools, toolChoice)
 
@@ -334,32 +341,30 @@ func (p *ToolProvider) PredictStreamWithTools(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Make HTTP request
+	// Ollama in PromptKit uses the OpenAI-compatible
+	// /v1/chat/completions endpoint which speaks SSE, so the default
+	// FrameDetector (SSE) applies — no override needed.
 	url := p.baseURL + ollamaChatCompletionsPath
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	requestFn := func(ctx context.Context) (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		httpReq.Header.Set("Accept", "text/event-stream")
+		// Ollama doesn't require Authorization header.
+		return httpReq, nil
 	}
 
-	// Ollama doesn't require Authorization header
-	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-	httpReq.Header.Set("Accept", "text/event-stream")
-
-	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
-	if err != nil {
-		return nil, &providers.ProviderTransportError{Cause: err, Provider: p.ID()}
-	}
-
-	if err := providers.CheckHTTPError(resp, url); err != nil {
-		_ = resp.Body.Close()
-		return nil, err
-	}
-
-	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-
-	go p.streamResponse(ctx, resp.Body, outChan)
-
-	return outChan, nil
+	return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+		Policy:       p.StreamRetryPolicy(),
+		Budget:       p.StreamRetryBudget(),
+		ProviderName: p.ID(),
+		Host:         providers.HostFromURL(url),
+		IdleTimeout:  p.StreamIdleTimeout(),
+		RequestFn:    requestFn,
+		Client:       p.GetStreamingHTTPClient(),
+	}, p.streamResponse)
 }
 
 //nolint:gochecknoinits // Factory registration requires init

--- a/runtime/providers/ollama/ollama_tools_test.go
+++ b/runtime/providers/ollama/ollama_tools_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -621,5 +622,53 @@ func TestToolProvider_PredictStreamWithTools_Error(t *testing.T) {
 
 	if err == nil {
 		t.Error("Expected error for server error")
+	}
+}
+
+func TestToolProvider_PredictStreamWithTools_Retries503(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := atomic.AddInt32(&attempts, 1)
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error": "overloaded"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: " + `{"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}` + "\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("data: " + `{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}` + "\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	provider := NewToolProvider("test", "llama3", server.URL+"/api", providers.ProviderDefaults{}, false, nil)
+	provider.SetStreamRetryPolicy(providers.StreamRetryPolicy{
+		Enabled:     true,
+		MaxAttempts: 3,
+	})
+
+	stream, err := provider.PredictStreamWithTools(
+		context.Background(),
+		providers.PredictionRequest{
+			Messages: []types.Message{{Role: "user", Content: "test"}},
+		}, nil, "auto",
+	)
+	if err != nil {
+		t.Fatalf("Expected retry to succeed, got: %v", err)
+	}
+
+	var lastChunk providers.StreamChunk
+	for chunk := range stream {
+		lastChunk = chunk
+	}
+	if lastChunk.Content == "" {
+		t.Error("Expected content from retried stream")
+	}
+	if atomic.LoadInt32(&attempts) < 2 {
+		t.Errorf("Expected at least 2 attempts, got %d", attempts)
 	}
 }

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -547,32 +547,27 @@ func (p *ToolProvider) predictStreamWithCompletions(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Make HTTP request
 	url := p.baseURL + openAIPredictCompletionsPath
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	requestFn := func(ctx context.Context) (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		httpReq.Header.Set(authorizationHeader, bearerPrefix+p.apiKey)
+		httpReq.Header.Set("Accept", "text/event-stream")
+		return httpReq, nil
 	}
 
-	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-	httpReq.Header.Set(authorizationHeader, bearerPrefix+p.apiKey)
-	httpReq.Header.Set("Accept", "text/event-stream")
-
-	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
-	if err != nil {
-		return nil, &providers.ProviderTransportError{Cause: err, Provider: p.ID()}
-	}
-
-	if err := providers.CheckHTTPError(resp, url); err != nil {
-		_ = resp.Body.Close()
-		return nil, err
-	}
-
-	outChan := make(chan providers.StreamChunk, providers.DefaultStreamBufferSize)
-
-	go p.streamResponse(ctx, resp.Body, outChan)
-
-	return outChan, nil
+	return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+		Policy:       p.StreamRetryPolicy(),
+		Budget:       p.StreamRetryBudget(),
+		ProviderName: p.ID(),
+		Host:         providers.HostFromURL(url),
+		IdleTimeout:  p.StreamIdleTimeout(),
+		RequestFn:    requestFn,
+		Client:       p.GetStreamingHTTPClient(),
+	}, p.streamResponse)
 }
 
 //nolint:gochecknoinits // Factory registration requires init

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -1240,5 +1241,57 @@ func TestParseToolResponse_AudioResponse(t *testing.T) {
 	}
 	if !foundAudio {
 		t.Error("expected an audio part in response")
+	}
+}
+
+func TestToolProvider_PredictStreamWithTools_Retries503(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := atomic.AddInt32(&attempts, 1)
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error": "overloaded"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\n"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	provider := NewToolProvider(
+		"test", "gpt-4o", server.URL,
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "completions"}, nil,
+	)
+	provider.SetStreamRetryPolicy(providers.StreamRetryPolicy{
+		Enabled:     true,
+		MaxAttempts: 3,
+	})
+
+	stream, err := provider.PredictStreamWithTools(
+		context.Background(),
+		providers.PredictionRequest{
+			Messages: []types.Message{{Role: "user", Content: "test"}},
+		}, nil, "auto",
+	)
+	if err != nil {
+		t.Fatalf("Expected retry to succeed, got: %v", err)
+	}
+
+	var lastChunk providers.StreamChunk
+	for chunk := range stream {
+		lastChunk = chunk
+	}
+	if lastChunk.Content == "" {
+		t.Error("Expected content from retried stream")
+	}
+	if atomic.LoadInt32(&attempts) < 2 {
+		t.Errorf("Expected at least 2 attempts, got %d", attempts)
 	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,7 +33,7 @@ sonar.coverage.exclusions=**/examples/**,**/*example*/**,**/tools/arena/cmd/prom
 # Provider tool/streaming implementations share interface-mandated patterns
 # Persistence repository implementations share interface-mandated patterns (JSON/YAML/memory)
 # Arena assertion validators share interface-mandated patterns (turn + conversation level)
-sonar.cpd.exclusions=**/runtime/pipeline/stage/stages_video_frames.go,**/runtime/pipeline/stage/stages_media_compose.go,**/npm/**/lib/installer.js,**/npm/**/postinstall.js,**/runtime/providers/openai/openai_tools.go,**/runtime/providers/claude/claude_tools.go,**/runtime/providers/gemini/gemini_tools.go,**/runtime/providers/claude/claude_streaming.go,**/runtime/providers/gemini/gemini_streaming.go,**/.github/actions/**/src/runner.ts,**/runtime/persistence/yaml/yaml_tool.go,**/runtime/persistence/json/json.go,**/tools/arena/assertions/agent_*.go,**/tools/arena/assertions/tools_*.go
+sonar.cpd.exclusions=**/runtime/pipeline/stage/stages_video_frames.go,**/runtime/pipeline/stage/stages_media_compose.go,**/npm/**/lib/installer.js,**/npm/**/postinstall.js,**/runtime/providers/openai/openai_tools.go,**/runtime/providers/claude/claude_tools.go,**/runtime/providers/gemini/gemini_tools.go,**/runtime/providers/ollama/ollama_tools.go,**/runtime/providers/claude/claude_streaming.go,**/runtime/providers/gemini/gemini_streaming.go,**/.github/actions/**/src/runner.ts,**/runtime/persistence/yaml/yaml_tool.go,**/runtime/persistence/json/json.go,**/tools/arena/assertions/agent_*.go,**/tools/arena/assertions/tools_*.go
 
 # Function-level coverage exclusions using patterns
 # Exclude untestable interactive I/O functions in init.go (require terminal stdin/stdout)


### PR DESCRIPTION
## Summary

`PredictStreamWithTools` on Gemini, OpenAI (completions), Claude (direct API), and Ollama bypassed `RunStreamingRequest` and did raw HTTP calls. Transient errors like 503 were never retried despite `stream_retry` being enabled in config.

Rewrite all four to use `RunStreamingRequest` with the same retry policy, budget, and idle timeout as the base `PredictStream` path.

## Root cause

Found because Gemini 2.5 Pro returned 503 ("high demand") in the capability matrix and the retry logic from PR #922 never fired. The base `PredictStream` used `RunStreamingRequest` but the `ToolProvider` streaming paths were written before the retry infrastructure existed and were never migrated.

## Providers fixed

| Provider | Path | Before | After |
|----------|------|--------|-------|
| Gemini | `gemini_tools.go` | Raw `Do(httpReq)` | `RunStreamingRequest` |
| OpenAI | `openai_tools.go` (`predictStreamWithCompletions`) | Raw `Do(httpReq)` | `RunStreamingRequest` |
| Claude | `claude_tools.go` (direct API, non-Bedrock) | Raw `Do(httpReq)` | `RunStreamingRequest` |
| Ollama | `ollama_tools.go` | Raw `Do(httpReq)` | `RunStreamingRequest` |

Note: Claude Bedrock and OpenAI Responses API paths already used `RunStreamingRequest`.

## Test plan

Each provider has a new `_Retries503` test that:
- Spins up a mock server returning 503 on first request, valid stream on second
- Configures `StreamRetryPolicy{Enabled: true, MaxAttempts: 3}`
- Verifies the stream succeeds after retry
- Verifies at least 2 attempts were made

- [x] `TestGeminiToolProvider_PredictStreamWithTools_Retries503`
- [x] `TestToolProvider_PredictStreamWithTools_Retries503` (OpenAI)
- [x] `TestClaudeToolProvider_PredictStreamWithTools_Retries503`
- [x] `TestToolProvider_PredictStreamWithTools_Retries503` (Ollama)
- [x] Full test suites pass for all four providers