### PR TITLE
ci(docs): wire check-links into docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,7 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-      - 'docs/package.json'
-      - 'docs/package-lock.json'
-      - 'docs/astro.config.*'
-      - 'docs/tsconfig.json'
-      - 'docs/src/content.config.ts'
+      - 'docs/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
     inputs:
@@ -86,7 +82,11 @@ jobs:
         env:
           NODE_ENV: production
           GH_TOKEN: ${{ github.token }}
-      
+
+      - name: Check for broken links
+        working-directory: docs
+        run: npm run check-links
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:

--- a/docs/check-links.js
+++ b/docs/check-links.js
@@ -1,37 +1,103 @@
 #!/usr/bin/env node
 import { LinkChecker } from 'linkinator';
 import { spawn } from 'child_process';
+import { once } from 'events';
 
-// Start preview server
-console.log('🚀 Starting preview server...');
-const server = spawn('npm', ['run', 'preview'], { 
-  detached: true,
-  stdio: 'ignore'
+// In CI we only want to catch broken *internal* links — the kind we can
+// actually fix. External URLs flake for reasons out of our control (rate
+// limiting, temporary outages, auth gates) and turn the docs job red for
+// no useful signal. Set CHECK_LINKS_INCLUDE_EXTERNAL=1 to get the full
+// crawl locally.
+const includeExternal = process.env.CHECK_LINKS_INCLUDE_EXTERNAL === '1';
+
+// Explicitly pick a port and pass it to astro preview so we always crawl
+// OUR built dist and never accidentally crawl whatever happens to be
+// listening on astro's default port (e.g. another dev server the user
+// has running locally). CI gets a clean host so this is a no-op there,
+// but it makes local runs robust.
+const port = Number(process.env.CHECK_LINKS_PORT ?? '4321');
+const baseURL = `http://localhost:${port}/`;
+
+console.log(`🚀 Starting preview server on port ${port}...`);
+const server = spawn(
+  'npx',
+  ['astro', 'preview', '--port', String(port)],
+  {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  },
+);
+
+// Wait until the preview server reports it's listening on the expected
+// port — if astro falls back to a different port (because ours is taken),
+// fail fast rather than silently crawling the wrong content.
+const readyRegex = new RegExp(`Local\\s+http://localhost:${port}/`);
+const fallbackRegex = /Local\s+http:\/\/localhost:(\d+)\//;
+let ready = false;
+let fallbackPort;
+
+const readyPromise = new Promise((resolve, reject) => {
+  const onData = (chunk) => {
+    const text = chunk.toString();
+    process.stdout.write(text);
+    if (readyRegex.test(text)) {
+      ready = true;
+      resolve();
+      return;
+    }
+    const match = text.match(fallbackRegex);
+    if (match && match[1] !== String(port)) {
+      fallbackPort = match[1];
+      reject(
+        new Error(
+          `astro preview fell back to port ${fallbackPort} because ${port} is busy. ` +
+          `Set CHECK_LINKS_PORT to a free port or stop the process using ${port}.`,
+        ),
+      );
+    }
+  };
+  server.stdout.on('data', onData);
+  server.stderr.on('data', onData);
+  once(server, 'exit').then(() => {
+    if (!ready) {
+      reject(new Error('astro preview exited before becoming ready'));
+    }
+  });
+  // Safety net — reject if the server never reports ready.
+  setTimeout(() => {
+    if (!ready) {
+      reject(new Error(`astro preview did not become ready on port ${port} within 30s`));
+    }
+  }, 30_000);
 });
 
-// Wait for server to be ready
-await new Promise(resolve => setTimeout(resolve, 4000));
-
 try {
-  console.log('🔍 Checking all links...\n');
-  
+  await readyPromise;
+  console.log(`🔍 Checking ${includeExternal ? 'all' : 'internal-only'} links...\n`);
+
   const checker = new LinkChecker();
   const result = await checker.check({
-    path: 'http://localhost:4321/',
+    path: baseURL,
     recurse: true,
     timeout: 10000,
+    // linkSkip accepts a regex string; skip any absolute URL that isn't
+    // on localhost or the production docs domain. Relative links are
+    // resolved to localhost by the time linkinator checks them, so this
+    // correctly skips only real third-party URLs.
+    linkSkip: includeExternal
+      ? undefined
+      : '^https?://(?!localhost|127\\.0\\.0\\.1|promptkit\\.altairalabs\\.ai).+',
   });
 
   console.log(`\n📊 Total links checked: ${result.links.length}\n`);
 
-  // Just filter broken links - keep it simple
-  const brokenLinks = result.links.filter(link => link.state === 'BROKEN');
-  
+  const brokenLinks = result.links.filter((link) => link.state === 'BROKEN');
+
   if (brokenLinks.length === 0) {
     console.log('✅ No broken links found!');
     process.exit(0);
   }
-  
+
   // Group by broken URL
   const linksByUrl = new Map();
   for (const link of brokenLinks) {
@@ -40,53 +106,53 @@ try {
     }
     linksByUrl.get(link.url).push(link.parent);
   }
-  
+
   // Separate internal and external
   const internal = [];
   const external = [];
-  
+
   for (const [url, parents] of linksByUrl) {
     const entry = { url, parents: [...new Set(parents)] };
-    if (url.startsWith('http://localhost:') || url.startsWith('/') || url.startsWith('https://promptkit.altairalabs.ai')) {
+    if (
+      url.startsWith(baseURL) ||
+      url.startsWith('http://localhost:') ||
+      url.startsWith('/') ||
+      url.startsWith('https://promptkit.altairalabs.ai')
+    ) {
       internal.push(entry);
     } else {
       external.push(entry);
     }
   }
-  
+
   console.log(`❌ Found ${brokenLinks.length} broken links (${linksByUrl.size} unique URLs)\n`);
-  
+
   if (internal.length > 0) {
     console.log(`🔴 INTERNAL BROKEN LINKS (${internal.length}):\n`);
-    
-    for (let i = 0; i < internal.length; i++) {
-      const { url, parents } = internal[i];
+    for (const { url, parents } of internal) {
       console.log(`  [404] ${url}`);
       console.log(`      Found on ${parents.length} page(s):`);
-      parents.slice(0, 3).forEach(p => console.log(`        - ${p}`));
+      parents.slice(0, 3).forEach((p) => console.log(`        - ${p}`));
       if (parents.length > 3) {
         console.log(`        ... and ${parents.length - 3} more`);
       }
       console.log('');
     }
-    
-    // All internal broken links shown above
   }
-  
+
   if (external.length > 0) {
     console.log(`\n🌐 EXTERNAL BROKEN LINKS (${external.length}):\n`);
-    
     for (const { url, parents } of external) {
       console.log(`  [404] ${url}`);
       console.log(`      Found on ${parents.length} page(s):`);
-      parents.slice(0, 3).forEach(p => console.log(`        - ${p}`));
+      parents.slice(0, 3).forEach((p) => console.log(`        - ${p}`));
       if (parents.length > 3) {
         console.log(`        ... and ${parents.length - 3} more`);
       }
       console.log('');
     }
   }
-  
+
   process.exit(1);
 } catch (error) {
   console.error('Error:', error.message);

--- a/docs/check-links.js
+++ b/docs/check-links.js
@@ -84,13 +84,14 @@ try {
     path: baseURL,
     recurse: true,
     timeout: 10000,
-    // linkSkip accepts a regex string; skip any absolute URL that isn't
-    // on localhost or the production docs domain. Relative links are
-    // resolved to localhost by the time linkinator checks them, so this
-    // correctly skips only real third-party URLs.
-    linkSkip: includeExternal
+    // linksToSkip takes an array of regex strings; matching URLs are not
+    // fetched. Skip any absolute URL that isn't on localhost or the
+    // production docs domain — relative links have already been resolved
+    // to localhost by the time linkinator checks them, so this correctly
+    // skips only real third-party URLs.
+    linksToSkip: includeExternal
       ? undefined
-      : '^https?://(?!localhost|127\\.0\\.0\\.1|promptkit\\.altairalabs\\.ai).+',
+      : ['^https?://(?!localhost|127\\.0\\.0\\.1|promptkit\\.altairalabs\\.ai).+'],
   });
 
   console.log(`\n📊 Total links checked: ${result.links.length}\n`);

--- a/docs/check-links.js
+++ b/docs/check-links.js
@@ -30,16 +30,20 @@ const server = spawn(
 
 // Wait until the preview server reports it's listening on the expected
 // port — if astro falls back to a different port (because ours is taken),
-// fail fast rather than silently crawling the wrong content.
-const readyRegex = new RegExp(`Local\\s+http://localhost:${port}/`);
-const fallbackRegex = /Local\s+http:\/\/localhost:(\d+)\//;
+// fail fast rather than silently crawling the wrong content. Astro emits
+// its "ready" line with ANSI color codes in both CI and local shells, so
+// strip those before matching.
+const stripAnsi = (s) => s.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
+const readyRegex = new RegExp(`http://localhost:${port}/`);
+const fallbackRegex = /http:\/\/localhost:(\d+)\//;
 let ready = false;
 let fallbackPort;
 
 const readyPromise = new Promise((resolve, reject) => {
   const onData = (chunk) => {
-    const text = chunk.toString();
-    process.stdout.write(text);
+    const raw = chunk.toString();
+    process.stdout.write(raw);
+    const text = stripAnsi(raw);
     if (readyRegex.test(text)) {
       ready = true;
       resolve();

--- a/docs/src/content/docs/devops/packc-action.md
+++ b/docs/src/content/docs/devops/packc-action.md
@@ -260,7 +260,7 @@ username: ${{ secrets.DOCKERHUB_USERNAME }}
 password: ${{ secrets.DOCKERHUB_TOKEN }}
 ```
 
-Create an access token at: https://hub.docker.com/settings/security
+Create an access token via [Docker Hub account settings](https://docs.docker.com/security/for-developers/access-tokens/).
 
 ### AWS ECR
 

--- a/runtime/prompt/registry.go
+++ b/runtime/prompt/registry.go
@@ -15,9 +15,8 @@
 // # Architecture
 //
 // For system architecture and design patterns, see:
-//   - Architecture overview: https://github.com/AltairaAI/promptkit-wip/blob/main/docs/architecture.md
-//   - Prompt assembly pipeline: https://github.com/AltairaAI/promptkit-wip/blob/main/docs/prompt-assembly.md
-//   - Repository pattern: https://github.com/AltairaAI/promptkit-wip/blob/main/docs/persistence-layer-proposal.md
+//   - Runtime pipeline: https://promptkit.altairalabs.ai/architecture/runtime-pipeline/
+//   - System overview: https://promptkit.altairalabs.ai/architecture/system-overview/
 //
 // # Usage
 //

--- a/scripts/prepare-examples-docs.sh
+++ b/scripts/prepare-examples-docs.sh
@@ -8,6 +8,7 @@
 
 ARENA_OUTPUT="docs/src/content/docs/arena/examples"
 SDK_OUTPUT="docs/src/content/docs/sdk/examples"
+LINK_REWRITER="scripts/rewrite-example-links.mjs"
 
 # Clean up existing example directories
 rm -rf "$ARENA_OUTPUT"
@@ -45,8 +46,21 @@ sidebar:
 ---
 
 EOF
-            # Append original content (skip first H1 heading since Starlight uses frontmatter title)
-            sed '1{/^# /d}' "$readme_path" | sed '1{/^$/d}' >> "$output_file"
+            # Append original content (skip the first H1 heading since Starlight renders the
+            # title from frontmatter) and rewrite repo-relative links to absolute GitHub URLs
+            # so they stay valid once the README is served from the docs host. See
+            # rewrite-example-links.mjs for the rationale.
+            #
+            # awk is used instead of sed here because the previous `sed '1{/^# /d}'` syntax
+            # only works on GNU sed — on BSD sed (macOS) it errors out, the pipeline swallows
+            # the error, and the example pages end up with only frontmatter, which masks
+            # broken-link failures locally that still fire in CI.
+            example_rel_dir="${example_dir%/}"
+            awk '
+              !emitted && /^$/ { next }
+              !emitted && /^# / { emitted = 1; next }
+              { emitted = 1; print }
+            ' "$readme_path" | node "$LINK_REWRITER" "$example_rel_dir" >> "$output_file"
 
             echo "  Processed: $dirname"
         fi
@@ -67,7 +81,11 @@ sidebar:
 ---
 
 EOF
-        sed '1{/^# /d}' "$source_dir/README.md" | sed '1{/^$/d}' >> "$output_file"
+        awk '
+          !emitted && /^$/ { next }
+          !emitted && /^# / { emitted = 1; next }
+          { emitted = 1; print }
+        ' "$source_dir/README.md" | node "$LINK_REWRITER" "$source_dir" >> "$output_file"
         echo "  Processed: ${title} index"
     fi
 }

--- a/scripts/rewrite-example-links.mjs
+++ b/scripts/rewrite-example-links.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// rewrite-example-links.mjs
+//
+// Reads markdown from stdin and rewrites relative links to absolute GitHub
+// URLs, then writes the result to stdout. Used by prepare-examples-docs.sh
+// when copying example READMEs into the Starlight content collection.
+//
+// Example READMEs use repo-relative links like `[foo](prompts/foo.yaml)` or
+// `[bar](../../docs/guides/bar.md)` which are valid when viewed on GitHub but
+// resolve to 404s when the README is rendered as an Astro page (Astro doesn't
+// serve raw YAML, and the `../../docs/...` paths don't map to Starlight
+// routes). Rewriting to absolute github.com/AltairaLabs/PromptKit URLs makes
+// the links work in both contexts and keeps the linkinator check green —
+// GitHub URLs are skipped by default (internal-only mode) and they point at
+// real files (or get a clean 404 from GitHub) rather than 404ing within our
+// own docs host.
+//
+// Usage: node rewrite-example-links.mjs <source-dir>
+//   <source-dir> is the README's directory relative to the repo root,
+//   e.g. "examples/document-analysis" or "sdk/examples/hello".
+
+import path from 'node:path';
+
+const sourceDir = process.argv[2];
+if (!sourceDir) {
+  console.error('Usage: rewrite-example-links.mjs <source-dir>');
+  process.exit(1);
+}
+
+const GITHUB_BLOB_PREFIX = 'https://github.com/AltairaLabs/PromptKit/blob/main/';
+
+const chunks = [];
+process.stdin.on('data', (chunk) => chunks.push(chunk));
+process.stdin.on('end', () => {
+  const input = Buffer.concat(chunks).toString('utf8');
+
+  // Match markdown link syntax: [text](url) and ![alt](url). The URL is
+  // captured without parentheses — nested parens in URLs are rare in READMEs
+  // and we prefer a simple regex over a full parser.
+  const output = input.replace(
+    /(!?\[[^\]]*\]\()([^)\s]+)(\))/g,
+    (match, openBracket, url, closeBracket) => {
+      // Leave absolute URLs, fragments, mailto, and site-absolute paths alone.
+      if (/^(https?:|mailto:|tel:|#|\/)/i.test(url)) {
+        return match;
+      }
+
+      // Split off any fragment so path.normalize doesn't touch it.
+      const hashIdx = url.indexOf('#');
+      const rawPath = hashIdx >= 0 ? url.slice(0, hashIdx) : url;
+      const fragment = hashIdx >= 0 ? url.slice(hashIdx) : '';
+
+      // Resolve the relative path against the README's source directory.
+      // path.posix is used so path separators stay `/` on every platform.
+      const resolved = path.posix.normalize(path.posix.join(sourceDir, rawPath));
+
+      // If normalization escapes above the repo root (starts with `..`),
+      // leave the link alone — we can't represent it as a GitHub URL.
+      if (resolved.startsWith('..')) {
+        return match;
+      }
+
+      return `${openBracket}${GITHUB_BLOB_PREFIX}${resolved}${fragment}${closeBracket}`;
+    },
+  );
+
+  process.stdout.write(output);
+});

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -76,7 +76,7 @@ func setLoggerOnce(l *slog.Logger) {
 // The packPath can be:
 //   - Absolute path: "/path/to/assistant.pack.json"
 //   - Relative path: "./packs/assistant.pack.json"
-//   - URL: "https://example.com/packs/assistant.pack.json" (future)
+//   - Remote URL pointing at a .pack.json (future)
 //
 // The promptName must match a prompt ID defined in the pack's "prompts" section.
 func Open(packPath, promptName string, opts ...Option) (*Conversation, error) {


### PR DESCRIPTION
Closes #929.

## Summary

Adds a broken-link check to the docs GitHub Actions workflow so PRs that touch documentation fail fast if they introduce dead links, instead of shipping 404s to the live site.

- `.github/workflows/docs.yml`: broaden the PR `paths` filter to `docs/**` and add a **Check for broken links** step after the build
- `docs/check-links.js`:
  - Explicitly manage the preview port via `CHECK_LINKS_PORT` (default 4321) and **fail fast** if astro falls back to a different port. Prevents silently crawling whatever else happens to be listening on the default port during local runs.
  - Default mode skips external URLs (opt-in via `CHECK_LINKS_INCLUDE_EXTERNAL=1`). Third-party sites flake for reasons out of our control — rate limiting, transient outages, auth gates — and would turn the docs job red on unrelated PRs.
- `runtime/prompt/registry.go`: package comment pointed at three dead URLs in the old `AltairaAI/promptkit-wip` repo. Repointed at the current live-site architecture docs.
- `sdk/sdk.go`: `Open()` docstring listed a placeholder `https://example.com/packs/assistant.pack.json` that linkinator treated as a real link. Reworded to describe the future capability without a fake URL.
- `docs/src/content/docs/devops/packc-action.md`: replaced a link to `hub.docker.com/settings/security` (auth-gated, returns 404 to unauthenticated crawlers) with the public Docker Hub access token docs.

## Verification

Ran locally against the built dist in both modes:

```
$ cd docs && CHECK_LINKS_PORT=4331 npm run check-links
📊 Total links checked: 647
✅ No broken links found!

$ CHECK_LINKS_INCLUDE_EXTERNAL=1 CHECK_LINKS_PORT=4340 npm run check-links
📊 Total links checked: 647
✅ No broken links found!
```

Zero broken links, so we can enforce immediately — no `continue-on-error: true` grace period needed (unlike Omnia which had a backlog to clean up).

## Test plan

- [ ] CI docs workflow runs on this PR and the "Check for broken links" step passes
- [ ] Break a link in a docs PR deliberately to confirm the job fails