### PR TITLE
docs: fix dangling references in example READMEs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
     paths:
       - 'docs/**'
+      - 'examples/**/README.md'
+      - 'sdk/examples/**/README.md'
+      - 'scripts/prepare-examples-docs.sh'
+      - 'scripts/rewrite-example-links.mjs'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
     inputs:

--- a/examples/assertions-test/MOCK_PROVIDER_USAGE.md
+++ b/examples/assertions-test/MOCK_PROVIDER_USAGE.md
@@ -40,5 +40,5 @@ promptarena run --mock-provider --scenario scripted-turns
 ## See Also
 
 - [Mock Configuration](mock-responses.yaml) - Mock responses for this example
-- [Arena User Guide](../../docs/guides/arena-user-guide.md) - General Arena usage
+- [Arena how-to guides](https://promptkit.altairalabs.ai/arena/how-to/) - General Arena usage
 - [Main Examples README](../README.md) - Overview of all examples

--- a/examples/context-management/MOCK_PROVIDER_USAGE.md
+++ b/examples/context-management/MOCK_PROVIDER_USAGE.md
@@ -72,5 +72,5 @@ Same input always produces same output:
 ## See Also
 
 - [Mock Configuration](mock-responses.yaml) - Example configuration for this example
-- [Arena User Guide](../../docs/guides/arena-user-guide.md) - General Arena usage
+- [Arena how-to guides](https://promptkit.altairalabs.ai/arena/how-to/) - General Arena usage
 - [Main Examples README](../README.md) - Overview of all examples

--- a/examples/customer-support/MOCK_PROVIDER_USAGE.md
+++ b/examples/customer-support/MOCK_PROVIDER_USAGE.md
@@ -183,6 +183,6 @@ Currently, the mock provider:
 ## See Also
 
 - [Mock Configuration Example](mock-config-example.yaml) - Full configuration format
-- [Arena User Guide](../../docs/guides/arena-user-guide.md) - General Arena usage
+- [Arena how-to guides](https://promptkit.altairalabs.ai/arena/how-to/) - General Arena usage
 - [GitHub Issue #27](https://github.com/AltairaLabs/PromptKit/issues/27) - Mock Provider enhancement tracking
 

--- a/examples/guardrails-test/MOCK_PROVIDER_USAGE.md
+++ b/examples/guardrails-test/MOCK_PROVIDER_USAGE.md
@@ -40,5 +40,5 @@ promptarena run --mock-provider --scenario guardrail-should-trigger
 ## See Also
 
 - [Mock Configuration](mock-responses.yaml) - Mock responses for this example
-- [Arena User Guide](../../docs/guides/arena-user-guide.md) - General Arena usage
+- [Arena how-to guides](https://promptkit.altairalabs.ai/arena/how-to/) - General Arena usage
 - [Main Examples README](../README.md) - Overview of all examples

--- a/examples/guardrails-test/README.md
+++ b/examples/guardrails-test/README.md
@@ -164,6 +164,5 @@ middleware.DynamicValidatorMiddlewareWithSuppression(registry, true)
 
 ## Related Documentation
 
-- [GUARDRAIL_ASSERTION_PROPOSAL.md](../../docs/local-backlog/GUARDRAIL_ASSERTION_PROPOSAL.md) - Original proposal
-- [GitHub Issue #25](https://github.com/altairalabs/promptkit-public/issues/25) - Implementation tracking
-- [Arena User Guide](../../docs/guides/arena-user-guide.md) - General Arena testing documentation
+- [Arena assertions reference](https://promptkit.altairalabs.ai/arena/reference/assertions/) - Full list of built-in assertions, including guardrail matchers
+- [Validation strategies](https://promptkit.altairalabs.ai/arena/explanation/validation-strategies/) - When to use guardrails vs other assertion styles

--- a/examples/mcp-chatbot/MOCK_PROVIDER_USAGE.md
+++ b/examples/mcp-chatbot/MOCK_PROVIDER_USAGE.md
@@ -40,5 +40,5 @@ promptarena run --mock-provider --scenario memory-conversations
 ## See Also
 
 - [Mock Configuration](mock-responses.yaml) - Mock responses for this example
-- [Arena User Guide](../../docs/guides/arena-user-guide.md) - General Arena usage
+- [Arena how-to guides](https://promptkit.altairalabs.ai/arena/how-to/) - General Arena usage
 - [Main Examples README](../README.md) - Overview of all examples

--- a/examples/mcp-chatbot/README.md
+++ b/examples/mcp-chatbot/README.md
@@ -264,6 +264,6 @@ which node
 
 ## Learn More
 
-- [MCP Integration Guide](../../docs/mcp-integration.md) - Full MCP documentation
-- [Tool Calling Guide](../../docs/tool-calling.md) - How tool execution works
+- [Testing MCP tools in Arena](https://promptkit.altairalabs.ai/arena/how-to/test-mcp-tools/) - Full MCP documentation
+- [Tools & MCP concept overview](https://promptkit.altairalabs.ai/concepts/tools-mcp/) - How tool execution works
 - [Official MCP Servers](https://github.com/modelcontextprotocol/servers) - More MCP servers to try

--- a/examples/mcp-filesystem-test/MOCK_PROVIDER_USAGE.md
+++ b/examples/mcp-filesystem-test/MOCK_PROVIDER_USAGE.md
@@ -40,5 +40,5 @@ promptarena run --mock-provider --scenario file-operations
 ## See Also
 
 - [Mock Configuration](mock-responses.yaml) - Mock responses for this example
-- [Arena User Guide](../../docs/guides/arena-user-guide.md) - General Arena usage
+- [Arena how-to guides](https://promptkit.altairalabs.ai/arena/how-to/) - General Arena usage
 - [Main Examples README](../README.md) - Overview of all examples

--- a/examples/mcp-memory-test/MOCK_PROVIDER_USAGE.md
+++ b/examples/mcp-memory-test/MOCK_PROVIDER_USAGE.md
@@ -40,5 +40,5 @@ promptarena run --mock-provider --scenario mcp-memory-test
 ## See Also
 
 - [Mock Configuration](mock-responses.yaml) - Mock responses for this example
-- [Arena User Guide](../../docs/guides/arena-user-guide.md) - General Arena usage
+- [Arena how-to guides](https://promptkit.altairalabs.ai/arena/how-to/) - General Arena usage
 - [Main Examples README](../README.md) - Overview of all examples

--- a/examples/multimodal-basics/README.md
+++ b/examples/multimodal-basics/README.md
@@ -340,9 +340,8 @@ Use mock provider in automated tests:
 
 ## Related Documentation
 
-- [MediaConfig Specification](../../docs/guides/multimodal-support.md)
-- [PromptArena User Guide](../../docs/guides/arena-user-guide.md)
-- [Provider Configuration](../../docs/guides/provider-configuration.md)
+- [Configure LLM providers](https://promptkit.altairalabs.ai/arena/how-to/configure-providers/) - Including multimodal-capable providers
+- [Arena tutorials](https://promptkit.altairalabs.ai/arena/tutorials/01-first-test/) - Step-by-step Arena usage
 - [Mock Provider Usage](../assertions-test/MOCK_PROVIDER_USAGE.md)
 
 ## Related Examples

--- a/examples/resilience-testing/README.md
+++ b/examples/resilience-testing/README.md
@@ -1,7 +1,8 @@
 # Resilience Testing Example
 
-Comprehensive example demonstrating 25+ assertion types from the
-[Dynamic Context & Tool-Using LLM Testing Proposal](../../docs/local-backlog/DYNAMIC_CONTEXT_TOOL_TESTING_PROPOSAL.md).
+Comprehensive example demonstrating 25+ assertion types. See the full
+[Arena assertions reference](https://promptkit.altairalabs.ai/arena/reference/assertions/)
+for the complete list of supported assertion types.
 
 ## Scenarios
 

--- a/examples/variables-demo/README.md
+++ b/examples/variables-demo/README.md
@@ -435,9 +435,9 @@ variables:
 
 ## 📚 Related Documentation
 
-- [Configuration Schema](../../docs/src/content/arena/reference/config-schema.md)
-- [How to Write Scenarios](../../docs/src/content/arena/how-to/write-scenarios.md)
-- [Template Variables](../../docs/src/content/concepts/templates.md)
+- [Configuration Schema](https://promptkit.altairalabs.ai/arena/reference/config-schema/)
+- [How to Write Scenarios](https://promptkit.altairalabs.ai/arena/how-to/write-scenarios/)
+- [Template Variables](https://promptkit.altairalabs.ai/concepts/templates/)
 
 ---
 

--- a/sdk/examples/README.md
+++ b/sdk/examples/README.md
@@ -8,12 +8,6 @@ All examples use the **Pipeline architecture** - audio, TTS, VAD, and other feat
 
 ## Available Examples
 
-### 🎙️ [streaming-tts](./streaming-tts/)
-Demonstrates streaming text-to-speech through the Pipeline.
-- Streaming LLM responses
-- TTS middleware converting text to audio
-- Real-time audio generation during streaming
-
 ### 🗣️ [voice-chat](./voice-chat/)
 Demonstrates voice conversation through the Pipeline.
 - VAD (Voice Activity Detection)


### PR DESCRIPTION
Cleanup follow-up from #931.

## Problem

Several example READMEs referenced files that don't exist anywhere in the repo:

- \`docs/guides/arena-user-guide.md\`
- \`docs/guides/multimodal-support.md\`
- \`docs/guides/provider-configuration.md\`
- \`docs/mcp-integration.md\`
- \`docs/tool-calling.md\`
- \`docs/local-backlog/GUARDRAIL_ASSERTION_PROPOSAL.md\`
- \`docs/local-backlog/DYNAMIC_CONTEXT_TOOL_TESTING_PROPOSAL.md\`
- \`docs/src/content/arena/reference/config-schema.md\` and siblings (missing \`/docs/\` segment — the actual path is \`docs/src/content/docs/arena/...\`)
- \`sdk/examples/streaming-tts/\` (the directory was removed, only \`sdk/examples/streaming/\` exists)
- \`https://github.com/altairalabs/promptkit-public/issues/25\` (wrong repo)

These were broken in both contexts:
- On GitHub: relative paths pointing at missing files → 404
- On the docs site: \`prepare-examples-docs.sh\` rewrites them to GitHub blob URLs, but the files are still missing → 404

#931's link check didn't catch them because the default internal-only mode skips external URLs, which is where these land after rewriting. I noted this as a follow-up in the #931 merge notes.

## Fix

Every broken reference repointed at its closest live-site equivalent, or removed when there's no valid replacement:

| Broken ref | Replacement |
|---|---|
| \`docs/guides/arena-user-guide.md\` | [\`/arena/how-to/\`](https://promptkit.altairalabs.ai/arena/how-to/) / [\`/arena/tutorials/01-first-test/\`](https://promptkit.altairalabs.ai/arena/tutorials/01-first-test/) |
| \`docs/guides/multimodal-support.md\` + \`docs/guides/provider-configuration.md\` | [\`/arena/how-to/configure-providers/\`](https://promptkit.altairalabs.ai/arena/how-to/configure-providers/) |
| \`docs/mcp-integration.md\` | [\`/arena/how-to/test-mcp-tools/\`](https://promptkit.altairalabs.ai/arena/how-to/test-mcp-tools/) |
| \`docs/tool-calling.md\` | [\`/concepts/tools-mcp/\`](https://promptkit.altairalabs.ai/concepts/tools-mcp/) |
| \`docs/local-backlog/GUARDRAIL_ASSERTION_PROPOSAL.md\` | [\`/arena/reference/assertions/\`](https://promptkit.altairalabs.ai/arena/reference/assertions/) + [\`/arena/explanation/validation-strategies/\`](https://promptkit.altairalabs.ai/arena/explanation/validation-strategies/) |
| \`docs/local-backlog/DYNAMIC_CONTEXT_TOOL_TESTING_PROPOSAL.md\` | [\`/arena/reference/assertions/\`](https://promptkit.altairalabs.ai/arena/reference/assertions/) |
| \`docs/src/content/arena/...\` (3 refs) | Corresponding live-site URLs |
| \`sdk/examples/streaming-tts/\` | Section removed |
| \`https://github.com/altairalabs/promptkit-public/issues/25\` | Removed |

## Verification

Built the docs, grepped the entire dist for \`https://github.com/AltairaLabs/PromptKit/blob/...\` URLs, \`curl\`'d each one:

\`\`\`
$ wc -l /tmp/all-gh-urls.txt
      30 /tmp/all-gh-urls.txt
# (zero 404s)
\`\`\`

Both link-check modes pass:

\`\`\`
$ CHECK_LINKS_PORT=4352 npm run check-links
📊 Total links checked: 662
✅ No broken links found!

$ CHECK_LINKS_INCLUDE_EXTERNAL=1 CHECK_LINKS_PORT=4351 npm run check-links
📊 Total links checked: 662
✅ No broken links found!
\`\`\`

## Test plan

- [x] \`curl\` all GitHub blob URLs from dist → 0 × 404
- [x] Default link check mode passes
- [x] Full-external link check mode passes
- [x] CI docs workflow runs on this PR