### PR TITLE
fix(sdk): pack validator spec compliance (#933)

### DIFF
--- a/runtime/evals/handlers/guardrail_triggered.go
+++ b/runtime/evals/handlers/guardrail_triggered.go
@@ -107,3 +107,14 @@ func extractValidatorType(params map[string]any) string {
 	v, _ := params["validator"].(string)
 	return v
 }
+
+// ValidateParams checks that the required 'validator_type' (or alias
+// 'validator') param is set to a non-empty string.
+func (h *GuardrailTriggeredHandler) ValidateParams(params map[string]any) error {
+	if extractValidatorType(params) == "" {
+		return fmt.Errorf(
+			"%s requires a non-empty 'validator_type' (or 'validator') string param",
+			h.Type())
+	}
+	return nil
+}

--- a/runtime/evals/handlers/length.go
+++ b/runtime/evals/handlers/length.go
@@ -180,3 +180,41 @@ func (h *MaxLengthHandler) EvalPartial(
 		Explanation: fmt.Sprintf("stream length %d, max %d", actual, maxLen),
 	}, nil
 }
+
+// ValidateParams checks that at least one of the canonical or aliased
+// max-length keys is set to a positive integer. Called at guardrail
+// hook construction and at eval preflight so invalid pack validators
+// fail loudly at load time instead of at request time.
+func (h *MaxLengthHandler) ValidateParams(params map[string]any) error {
+	maxLen := extractInt(params, "max", 0)
+	if maxLen == 0 {
+		maxLen = extractInt(params, "max_characters", 0)
+	}
+	if maxLen == 0 {
+		maxLen = extractInt(params, "max_chars", 0)
+	}
+	if maxLen <= 0 {
+		return fmt.Errorf(
+			"%s requires one of 'max', 'max_characters', or 'max_chars' to be a positive integer",
+			h.Type())
+	}
+	return nil
+}
+
+// ValidateParams checks that at least one of the canonical or aliased
+// min-length keys is set to a positive integer.
+func (h *MinLengthHandler) ValidateParams(params map[string]any) error {
+	minLen := extractInt(params, "min", 0)
+	if minLen == 0 {
+		minLen = extractInt(params, "min_characters", 0)
+	}
+	if minLen == 0 {
+		minLen = extractInt(params, "min_chars", 0)
+	}
+	if minLen <= 0 {
+		return fmt.Errorf(
+			"%s requires one of 'min', 'min_characters', or 'min_chars' to be a positive integer",
+			h.Type())
+	}
+	return nil
+}

--- a/runtime/evals/handlers/param_validator_test.go
+++ b/runtime/evals/handlers/param_validator_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// Compile-time interface checks: these break the build if any of the
+// four handlers stop implementing ParamValidator.
+var (
+	_ evals.ParamValidator = (*MaxLengthHandler)(nil)
+	_ evals.ParamValidator = (*MinLengthHandler)(nil)
+	_ evals.ParamValidator = (*WorkflowStateIsHandler)(nil)
+	_ evals.ParamValidator = (*GuardrailTriggeredHandler)(nil)
+)
+
+func TestMaxLengthValidateParams(t *testing.T) {
+	h := &MaxLengthHandler{}
+
+	// Happy paths.
+	require.NoError(t, h.ValidateParams(map[string]any{"max_characters": 2000}))
+	require.NoError(t, h.ValidateParams(map[string]any{"max": 2000}))
+	require.NoError(t, h.ValidateParams(map[string]any{"max_chars": 2000}))
+
+	// Missing required key.
+	err := h.ValidateParams(map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max")
+
+	// Nil params.
+	err = h.ValidateParams(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max")
+
+	// Zero is treated as missing.
+	err = h.ValidateParams(map[string]any{"max_characters": 0})
+	require.Error(t, err)
+
+	// Negative is invalid.
+	err = h.ValidateParams(map[string]any{"max_characters": -5})
+	require.Error(t, err)
+}
+
+func TestMinLengthValidateParams(t *testing.T) {
+	h := &MinLengthHandler{}
+
+	require.NoError(t, h.ValidateParams(map[string]any{"min_characters": 10}))
+	require.NoError(t, h.ValidateParams(map[string]any{"min": 10}))
+
+	err := h.ValidateParams(map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "min")
+}
+
+func TestWorkflowStateIsValidateParams(t *testing.T) {
+	h := &WorkflowStateIsHandler{}
+
+	require.NoError(t, h.ValidateParams(map[string]any{"state": "greeting"}))
+
+	err := h.ValidateParams(map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "state")
+
+	err = h.ValidateParams(map[string]any{"state": ""})
+	require.Error(t, err)
+}
+
+func TestGuardrailTriggeredValidateParams(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+
+	require.NoError(t, h.ValidateParams(map[string]any{"validator_type": "max_length"}))
+	// Alias also works.
+	require.NoError(t, h.ValidateParams(map[string]any{"validator": "max_length"}))
+
+	err := h.ValidateParams(map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validator_type")
+}

--- a/runtime/evals/handlers/workflow_state_is.go
+++ b/runtime/evals/handlers/workflow_state_is.go
@@ -58,3 +58,13 @@ func (h *WorkflowStateIsHandler) Eval(
 		Details:     map[string]any{"expected": expected, "actual": actual},
 	}, nil
 }
+
+// ValidateParams checks that the required 'state' param is set to a
+// non-empty string.
+func (h *WorkflowStateIsHandler) ValidateParams(params map[string]any) error {
+	state, _ := params["state"].(string)
+	if state == "" {
+		return fmt.Errorf("%s requires a non-empty 'state' string param", h.Type())
+	}
+	return nil
+}

--- a/runtime/evals/param_validator_test.go
+++ b/runtime/evals/param_validator_test.go
@@ -1,0 +1,30 @@
+package evals
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// stubParamValidator is a minimal handler implementing ParamValidator
+// for interface-satisfaction assertions.
+type stubParamValidator struct {
+	err error
+}
+
+func (s *stubParamValidator) ValidateParams(_ map[string]any) error {
+	return s.err
+}
+
+func TestParamValidatorInterface(t *testing.T) {
+	// Compile-time check: the stub satisfies ParamValidator.
+	var _ ParamValidator = (*stubParamValidator)(nil)
+
+	s := &stubParamValidator{err: errors.New("bad params")}
+	err := s.ValidateParams(map[string]any{})
+	assert.EqualError(t, err, "bad params")
+
+	ok := &stubParamValidator{}
+	assert.NoError(t, ok.ValidateParams(nil))
+}

--- a/runtime/evals/registry.go
+++ b/runtime/evals/registry.go
@@ -32,6 +32,29 @@ type StreamableEvalHandler interface {
 	EvalPartial(ctx context.Context, content string, params map[string]any) (*EvalResult, error)
 }
 
+// ParamValidator is an optional interface for EvalTypeHandler implementations
+// that have required or strictly-typed params. Handlers without required
+// params need not implement it.
+//
+// ValidateParams is called at two points:
+//  1. Guardrail hook construction in runtime/hooks/guardrails/factory.go,
+//     so pack validators with unusable params are surfaced at SDK load
+//     time instead of silently failing every turn.
+//  2. runtime/evals/validate.go:ValidateEvalTypes, so Arena's fail-fast
+//     build-time check and the SDK's warn-and-skip middleware both see
+//     param errors the same way.
+//
+// Params passed to ValidateParams have already been normalised via
+// ApplyDefaults and NormalizeParams, so implementations should check
+// for canonical key names only.
+type ParamValidator interface {
+	// ValidateParams returns nil if params are usable by this handler,
+	// or an error describing what is missing or wrong. The error message
+	// should be self-contained — it is logged and/or surfaced in a
+	// ValidateEvalTypes result without a wrapping prefix.
+	ValidateParams(params map[string]any) error
+}
+
 // EvalTypeRegistry provides thread-safe registration and lookup of
 // EvalTypeHandler implementations by type name.
 type EvalTypeRegistry struct {

--- a/runtime/evals/validate.go
+++ b/runtime/evals/validate.go
@@ -94,17 +94,42 @@ func validateEvalFields(def *EvalDef, prefix string) []string {
 }
 
 // ValidateEvalTypes checks that every EvalDef's Type has a registered handler
-// in the given registry. Returns a list of human-readable error strings for
-// any unknown types. This is safe to call from any package that has access
-// to both the defs and the registry.
+// in the given registry, AND — when the handler implements ParamValidator —
+// that its params are usable by the handler. Returns a list of human-readable
+// error strings for any type-lookup or param-validation failures.
+//
+// Params are normalised (ApplyDefaults + NormalizeParams) before calling
+// ValidateParams, so handlers only need to check canonical key names.
+//
+// Callers:
+//   - tools/arena/engine/builder_integration.go treats any returned errors as fatal.
+//   - sdk/eval_middleware.go uses this to warn-and-skip bad defs.
+//   - sdk/evaluate.go exposes it as a public preflight.
 func ValidateEvalTypes(defs []EvalDef, registry *EvalTypeRegistry) []string {
 	logger.Debug("evals: validating eval types", "def_count", len(defs), "registered_types", registry.Types())
 	var errs []string
 	for i := range defs {
-		if defs[i].Type != "" && !registry.Has(defs[i].Type) {
+		def := &defs[i]
+		if def.Type == "" {
+			continue
+		}
+		handler, err := registry.Get(def.Type)
+		if err != nil {
 			errs = append(errs, fmt.Sprintf(
 				"eval %q: unknown type %q (registered types: %v)",
-				defs[i].ID, defs[i].Type, registry.Types(),
+				def.ID, def.Type, registry.Types(),
+			))
+			continue
+		}
+		pv, ok := handler.(ParamValidator)
+		if !ok {
+			continue
+		}
+		normalized := ApplyDefaults(def.Type, def.Params)
+		normalized = NormalizeParams(def.Type, normalized)
+		if perr := pv.ValidateParams(normalized); perr != nil {
+			errs = append(errs, fmt.Sprintf(
+				"eval %q: %s", def.ID, perr.Error(),
 			))
 		}
 	}

--- a/runtime/evals/validate_test.go
+++ b/runtime/evals/validate_test.go
@@ -1,10 +1,14 @@
 package evals
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
-)
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestValidateEvals(t *testing.T) {
 	tests := []struct {
@@ -476,4 +480,64 @@ func TestValidateEvals_DisabledEvalStillValidated(t *testing.T) {
 	if len(errs) != 1 {
 		t.Errorf("disabled eval should still be validated, got %d errors", len(errs))
 	}
+}
+
+// paramCheckStubHandler is a test-only handler that implements both
+// EvalTypeHandler and ParamValidator. It requires a "foo" param for
+// stub_requires_foo; stub_no_req accepts anything.
+type paramCheckStubHandler struct{ typeName string }
+
+func (s *paramCheckStubHandler) Type() string { return s.typeName }
+
+func (s *paramCheckStubHandler) Eval(_ context.Context, _ *EvalContext, _ map[string]any) (*EvalResult, error) {
+	return &EvalResult{Type: s.typeName}, nil
+}
+
+func (s *paramCheckStubHandler) ValidateParams(params map[string]any) error {
+	if s.typeName != "stub_requires_foo" {
+		return nil
+	}
+	if _, ok := params["foo"]; !ok {
+		return fmt.Errorf("missing required 'foo' param")
+	}
+	return nil
+}
+
+func TestValidateEvalTypesChecksParams(t *testing.T) {
+	reg := NewEmptyEvalTypeRegistry()
+	reg.Register(&paramCheckStubHandler{typeName: "stub_requires_foo"})
+	reg.Register(&paramCheckStubHandler{typeName: "stub_no_req"})
+
+	t.Run("missing required param surfaces as error", func(t *testing.T) {
+		defs := []EvalDef{
+			{ID: "eval-1", Type: "stub_requires_foo", Params: map[string]any{}},
+		}
+		errs := ValidateEvalTypes(defs, reg)
+		require.Len(t, errs, 1)
+		assert.Contains(t, errs[0], `eval "eval-1"`)
+		assert.Contains(t, strings.ToLower(errs[0]), "foo")
+	})
+
+	t.Run("valid params produce no errors", func(t *testing.T) {
+		defs := []EvalDef{
+			{ID: "eval-2", Type: "stub_requires_foo", Params: map[string]any{"foo": "bar"}},
+		}
+		assert.Empty(t, ValidateEvalTypes(defs, reg))
+	})
+
+	t.Run("unknown type still surfaces as error", func(t *testing.T) {
+		defs := []EvalDef{
+			{ID: "eval-3", Type: "unregistered", Params: map[string]any{}},
+		}
+		errs := ValidateEvalTypes(defs, reg)
+		require.Len(t, errs, 1)
+		assert.Contains(t, errs[0], "unknown type")
+	})
+
+	t.Run("handler without ParamValidator accepts any params", func(t *testing.T) {
+		defs := []EvalDef{
+			{ID: "eval-4", Type: "stub_no_req", Params: map[string]any{"anything": "goes"}},
+		}
+		assert.Empty(t, ValidateEvalTypes(defs, reg))
+	})
 }

--- a/runtime/hooks/guardrails/factory.go
+++ b/runtime/hooks/guardrails/factory.go
@@ -26,6 +26,13 @@ func WithMonitorOnly() GuardrailOption {
 
 // NewGuardrailHookFromRegistry creates a guardrail ProviderHook using the eval registry.
 // Any registered eval handler (including aliases) can be used as a guardrail.
+//
+// If the handler implements evals.ParamValidator, the params are normalised
+// (ApplyDefaults + NormalizeParams) and passed to ValidateParams before the
+// hook is constructed. This surfaces invalid pack validators at SDK load
+// time instead of silently failing every turn — handlers for which params
+// are unusable return an error here, and the SDK's warn-and-skip loop in
+// convertPackValidatorsToHooks logs and drops them.
 func NewGuardrailHookFromRegistry(
 	typeName string, params map[string]any, registry *evals.EvalTypeRegistry,
 	opts ...GuardrailOption,
@@ -33,6 +40,17 @@ func NewGuardrailHookFromRegistry(
 	handler, err := registry.Get(typeName)
 	if err != nil {
 		return nil, fmt.Errorf("unknown guardrail type: %q", typeName)
+	}
+
+	// Normalise params the same way adapter.AfterCall does before passing
+	// to ValidateParams, so handlers only need to check canonical key names.
+	normalized := evals.ApplyDefaults(typeName, params)
+	normalized = evals.NormalizeParams(typeName, normalized)
+
+	if pv, ok := handler.(evals.ParamValidator); ok {
+		if verr := pv.ValidateParams(normalized); verr != nil {
+			return nil, fmt.Errorf("guardrail %q: %w", typeName, verr)
+		}
 	}
 
 	direction := directionOutput

--- a/runtime/hooks/guardrails/factory_test.go
+++ b/runtime/hooks/guardrails/factory_test.go
@@ -2,13 +2,55 @@ package guardrails
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers" // register default handlers
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+func TestNewGuardrailHookRejectsMissingRequiredParams(t *testing.T) {
+	reg := evals.NewEvalTypeRegistry()
+
+	// max_length with no params — the handler's ParamValidator must reject.
+	_, err := NewGuardrailHookFromRegistry("max_length", map[string]any{}, reg)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "max",
+		"error should name the missing key")
+}
+
+func TestNewGuardrailHookAcceptsValidParams(t *testing.T) {
+	reg := evals.NewEvalTypeRegistry()
+
+	hook, err := NewGuardrailHookFromRegistry(
+		"max_length", map[string]any{"max_characters": 2000}, reg,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, hook)
+}
+
+func TestNewGuardrailHookAcceptsHandlersWithoutRequiredParams(t *testing.T) {
+	reg := evals.NewEvalTypeRegistry()
+
+	// banned_words maps to content_excludes, which has no required params
+	// (patterns is optional). Must succeed even with empty params.
+	hook, err := NewGuardrailHookFromRegistry("banned_words", map[string]any{}, reg)
+	require.NoError(t, err)
+	require.NotNil(t, hook)
+}
+
+func TestNewGuardrailHookStillRejectsUnknownType(t *testing.T) {
+	reg := evals.NewEvalTypeRegistry()
+
+	_, err := NewGuardrailHookFromRegistry("nonexistent", map[string]any{}, reg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown guardrail type")
+}
 
 func TestNewGuardrailHook_AllTypes(t *testing.T) {
 	tests := []struct {
@@ -17,7 +59,7 @@ func TestNewGuardrailHook_AllTypes(t *testing.T) {
 	}{
 		{"banned_words", map[string]any{"words": []any{"bad"}}},
 		{"length", map[string]any{"max_characters": 100}},
-		{"max_length", map[string]any{"max_tokens": 50}},
+		{"max_length", map[string]any{"max_characters": 200, "max_tokens": 50}},
 		{"max_sentences", map[string]any{"max_sentences": 3}},
 		{"required_fields", map[string]any{"required_fields": []any{"name"}}},
 		{"content_excludes", map[string]any{"patterns": []any{"bad"}}},

--- a/sdk/eval_middleware.go
+++ b/sdk/eval_middleware.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -10,6 +11,91 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// filterInvalidEvalDefs removes eval defs whose type is unregistered or
+// whose params are unusable by their handler. Each removed def is logged
+// as a warning. Returns the filtered slice (never nil).
+//
+// This runs at middleware creation time, so the EvalRunner never sees
+// bad defs at dispatch time. Mirrors the validator warn-and-skip loop in
+// sdk.go:convertPackValidatorsToHooks.
+func filterInvalidEvalDefs(defs []evals.EvalDef, registry *evals.EvalTypeRegistry) []evals.EvalDef {
+	if len(defs) == 0 {
+		return defs
+	}
+	errs := evals.ValidateEvalTypes(defs, registry)
+	if len(errs) == 0 {
+		return defs
+	}
+
+	// ValidateEvalTypes formats each error as: eval "<id>": <reason>
+	badIDs := make(map[string]string, len(errs))
+	for _, e := range errs {
+		id, reason := parseEvalValidationError(e)
+		if id != "" {
+			badIDs[id] = reason
+			logger.Warn("Skipping unusable pack eval", "id", id, "reason", reason)
+		}
+	}
+
+	filtered := make([]evals.EvalDef, 0, len(defs))
+	for i := range defs {
+		if _, bad := badIDs[defs[i].ID]; bad {
+			continue
+		}
+		filtered = append(filtered, defs[i])
+	}
+	return filtered
+}
+
+// resolveRunnerAndFilter returns the EvalRunner to use (creating one if
+// necessary) and the eval defs filtered for type/param validity.
+//
+// Behavior:
+//   - No explicit runner: build one from the configured (or default)
+//     registry and filter defs against it.
+//   - Explicit runner + explicit registry: trust the caller's runner, but
+//     filter against the explicit registry.
+//   - Explicit runner only: trust the caller and skip filtering (we
+//     cannot inspect the runner's internal registry).
+func resolveRunnerAndFilter(
+	cfg *config, defs []evals.EvalDef,
+) (*evals.EvalRunner, []evals.EvalDef) {
+	if runner := cfg.evalRunner; runner != nil {
+		if reg := cfg.evalRegistry; reg != nil {
+			return runner, filterInvalidEvalDefs(defs, reg)
+		}
+		return runner, defs
+	}
+	registry := cfg.evalRegistry
+	if registry == nil {
+		registry = evals.NewEvalTypeRegistry()
+	}
+	filtered := filterInvalidEvalDefs(defs, registry)
+	if len(filtered) == 0 {
+		return nil, filtered
+	}
+	return evals.NewEvalRunner(registry), filtered
+}
+
+// parseEvalValidationError extracts id and reason from an error produced
+// by evals.ValidateEvalTypes. The format is: eval "<id>": <reason>.
+// If the format doesn't match, the whole string is returned as reason
+// and id is empty.
+func parseEvalValidationError(s string) (id, reason string) {
+	const prefix = `eval "`
+	if !strings.HasPrefix(s, prefix) {
+		return "", s
+	}
+	rest := s[len(prefix):]
+	end := strings.Index(rest, `":`)
+	if end < 0 {
+		return "", s
+	}
+	id = rest[:end]
+	reason = strings.TrimSpace(rest[end+2:])
+	return id, reason
+}
 
 // DefaultMaxConcurrentEvals is the default maximum number of concurrent eval goroutines.
 const DefaultMaxConcurrentEvals = 10
@@ -70,15 +156,12 @@ func newEvalMiddleware(conv *Conversation) *evalMiddleware {
 		return nil
 	}
 
-	// Get or create runner
-	runner := conv.config.evalRunner
-	if runner == nil {
-		registry := conv.config.evalRegistry
-		if registry == nil {
-			registry = evals.NewEvalTypeRegistry()
-		}
-		runner = evals.NewEvalRunner(registry)
+	runner, filteredDefs := resolveRunnerAndFilter(conv.config, defs)
+	if len(filteredDefs) == 0 {
+		logger.Debug("evals: middleware skipped, all defs filtered", "reason", "no valid defs")
+		return nil
 	}
+	defs = filteredDefs
 
 	// Build emitter from event bus (nil-safe), populating session ID if available.
 	emitter := conv.newEmitter(conv.config.eventBus)

--- a/sdk/eval_middleware_test.go
+++ b/sdk/eval_middleware_test.go
@@ -1,18 +1,78 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/metrics"
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
 )
+
+// captureLogs redirects the global logger to a buffer for the duration
+// of a test. Not goroutine-safe across parallel tests.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	h := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger.SetLogger(slog.New(h))
+	return buf
+}
+
+func TestFilterInvalidEvalDefs_UnknownType(t *testing.T) {
+	logs := captureLogs(t)
+
+	reg := evals.NewEvalTypeRegistry()
+	defs := []evals.EvalDef{
+		{ID: "good", Type: "max_length", Trigger: evals.TriggerEveryTurn, Params: map[string]any{"max": 100}},
+		{ID: "bad", Type: "nonexistent_type", Trigger: evals.TriggerEveryTurn},
+	}
+
+	filtered := filterInvalidEvalDefs(defs, reg)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "good", filtered[0].ID)
+
+	logOut := logs.String()
+	assert.Contains(t, logOut, "Skipping unusable pack eval")
+	assert.Contains(t, logOut, "bad")
+}
+
+func TestFilterInvalidEvalDefs_MissingRequiredParam(t *testing.T) {
+	logs := captureLogs(t)
+
+	reg := evals.NewEvalTypeRegistry()
+	defs := []evals.EvalDef{
+		{ID: "good", Type: "max_length", Trigger: evals.TriggerEveryTurn, Params: map[string]any{"max_characters": 100}},
+		{ID: "bad", Type: "max_length", Trigger: evals.TriggerEveryTurn, Params: map[string]any{}},
+	}
+
+	filtered := filterInvalidEvalDefs(defs, reg)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "good", filtered[0].ID)
+	assert.Contains(t, logs.String(), "Skipping unusable pack eval")
+}
+
+func TestFilterInvalidEvalDefs_AllValid(t *testing.T) {
+	_ = captureLogs(t)
+
+	reg := evals.NewEvalTypeRegistry()
+	defs := []evals.EvalDef{
+		{ID: "a", Type: "max_length", Trigger: evals.TriggerEveryTurn, Params: map[string]any{"max": 100}},
+		{ID: "b", Type: "min_length", Trigger: evals.TriggerEveryTurn, Params: map[string]any{"min": 1}},
+	}
+	filtered := filterInvalidEvalDefs(defs, reg)
+	assert.Len(t, filtered, 2)
+}
 
 func TestNewEvalMiddleware_DisabledReturnsNil(t *testing.T) {
 	conv := &Conversation{
@@ -103,8 +163,8 @@ func TestEvalMiddleware_ResolvesPackAndPromptEvals(t *testing.T) {
 		},
 		prompt: &pack.Prompt{
 			Evals: []evals.EvalDef{
-				{ID: "b", Type: "regex_override", Trigger: evals.TriggerEveryTurn}, // Override
-				{ID: "c", Type: "length", Trigger: evals.TriggerOnSessionComplete},
+				{ID: "b", Type: "json_valid", Trigger: evals.TriggerEveryTurn}, // Override
+				{ID: "c", Type: "contains", Trigger: evals.TriggerOnSessionComplete},
 			},
 		},
 	}
@@ -121,8 +181,8 @@ func TestEvalMiddleware_ResolvesPackAndPromptEvals(t *testing.T) {
 	if mw.defs[0].ID != "a" {
 		t.Errorf("expected first def ID 'a', got %q", mw.defs[0].ID)
 	}
-	if mw.defs[1].Type != "regex_override" {
-		t.Errorf("expected second def type 'regex_override', got %q", mw.defs[1].Type)
+	if mw.defs[1].Type != "json_valid" {
+		t.Errorf("expected second def type 'json_valid', got %q", mw.defs[1].Type)
 	}
 	if mw.defs[2].ID != "c" {
 		t.Errorf("expected third def ID 'c', got %q", mw.defs[2].ID)

--- a/sdk/internal/pack/load.go
+++ b/sdk/internal/pack/load.go
@@ -166,13 +166,30 @@ type Parameters struct {
 }
 
 // Validator represents a validator configuration.
+// Mirrors the PromptPack spec Validator definition at
+// https://promptpack.org/schema/latest/promptpack.schema.json (see
+// runtime/prompt/schema/promptpack.schema.json#/$defs/Validator).
+//
+// The PromptPack spec sets additionalProperties:false on Validator —
+// this struct must contain exactly the fields listed there, no more, no less.
+// TestValidatorStructMatchesPromptPackSpec pins this at build time.
 type Validator struct {
-	Type    string         `json:"type"`
-	Config  map[string]any `json:"config,omitempty"`
-	Message string         `json:"message,omitempty"` // User-facing message when content is blocked
-	// Monitor when true means the validator only records results without enforcing.
-	// Equivalent to FailOnViolation=false in ValidatorConfig.
-	Monitor bool `json:"monitor,omitempty"`
+	// Type is the validator identifier (e.g. "max_length", "banned_words").
+	// Required by the spec.
+	Type string `json:"type"`
+
+	// Enabled toggles the validator on/off without removing it. Required by the spec.
+	Enabled bool `json:"enabled"`
+
+	// FailOnViolation controls enforcement. When true, violations cause the
+	// guardrail adapter to enforce in-place. When false or absent (spec default),
+	// violations are logged but content is unchanged (monitor-only mode).
+	FailOnViolation *bool `json:"fail_on_violation,omitempty"`
+
+	// Params holds validator-specific parameters (e.g. {"max_characters": 2000}
+	// for max_length). Shape is handler-specific. Optional per the spec; each
+	// handler decides which keys it requires via the ParamValidator interface.
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // AgentsConfig maps prompts to A2A-compatible agent definitions.

--- a/sdk/internal/pack/validator_loadjson_test.go
+++ b/sdk/internal/pack/validator_loadjson_test.go
@@ -3,6 +3,7 @@ package pack
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,4 +85,74 @@ func TestValidatorMarshalRoundTrip(t *testing.T) {
 	require.NotNil(t, round.FailOnViolation)
 	assert.Equal(t, *original.FailOnViolation, *round.FailOnViolation)
 	assert.Equal(t, original.Params, round.Params)
+}
+
+// TestValidatorJSONRejectsForbiddenFields proves that the embedded
+// promptpack schema (loaded by ValidateAgainstSchema) rejects validator
+// JSON containing fields the spec forbids via additionalProperties:false.
+// This is the outer guarantee that the SDK never reaches struct unmarshal
+// for a non-spec pack.
+func TestValidatorJSONRejectsForbiddenFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		extra   string
+		wantErr string
+	}{
+		{
+			name:    "monitor field forbidden",
+			extra:   `"monitor": true`,
+			wantErr: "monitor",
+		},
+		{
+			name:    "config field forbidden",
+			extra:   `"config": {"foo": "bar"}`,
+			wantErr: "config",
+		},
+		{
+			name:    "message field forbidden",
+			extra:   `"message": "custom"`,
+			wantErr: "message",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			packJSON := []byte(`{
+				"id": "test-pack",
+				"name": "Test Pack",
+				"version": "1.0.0",
+				"description": "test",
+				"prompts": {
+					"default": {
+						"id": "default",
+						"name": "Default",
+						"description": "test prompt",
+						"version": "1.0.0",
+						"system_template": "hi",
+						"validators": [
+							{"type": "max_length", "enabled": true, ` + tc.extra + `}
+						]
+					}
+				}
+			}`)
+
+			err := ValidateAgainstSchema(packJSON)
+			require.Error(t, err, "schema must reject validator with forbidden field %q", tc.extra)
+
+			var schemaErr *SchemaValidationError
+			require.ErrorAs(t, err, &schemaErr)
+			// At least one error must mention the forbidden field or
+			// flag it as an unknown/additional property.
+			found := false
+			for _, e := range schemaErr.Errors {
+				if strings.Contains(e, tc.wantErr) || strings.Contains(e, "additional property") {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found,
+				"expected schema error to reference %q or additionalProperties; got %v",
+				tc.wantErr, schemaErr.Errors)
+		})
+	}
 }

--- a/sdk/internal/pack/validator_loadjson_test.go
+++ b/sdk/internal/pack/validator_loadjson_test.go
@@ -1,0 +1,87 @@
+// Package pack — validator JSON load tests.
+package pack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidatorLoadsFromPromptPackJSON is the regression test for issue #933.
+// A pack declaring a validator with params must load into pack.Validator
+// with params populated — the SDK's struct tag must match the promptpack spec.
+func TestValidatorLoadsFromPromptPackJSON(t *testing.T) {
+	packJSON := []byte(`{
+		"$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+		"id": "test-pack",
+		"name": "Test Pack",
+		"version": "1.0.0",
+		"description": "test",
+		"prompts": {
+			"default": {
+				"id": "default",
+				"name": "Default",
+				"description": "test prompt",
+				"version": "1.0.0",
+				"system_template": "you are helpful",
+				"validators": [
+					{
+						"type": "max_length",
+						"enabled": true,
+						"fail_on_violation": false,
+						"params": {"max_characters": 2000}
+					}
+				]
+			}
+		}
+	}`)
+
+	// Use Parse to bypass schema validation — we want to isolate the
+	// struct-unmarshal behaviour from the schema validator in this test.
+	pack, err := Parse(packJSON)
+	require.NoError(t, err)
+
+	prompt := pack.GetPrompt("default")
+	require.NotNil(t, prompt)
+	require.Len(t, prompt.Validators, 1, "pack should have one validator")
+
+	v := prompt.Validators[0]
+	assert.Equal(t, "max_length", v.Type)
+	assert.True(t, v.Enabled, "enabled should be true")
+	require.NotNil(t, v.FailOnViolation, "fail_on_violation should be present (pointer non-nil)")
+	assert.False(t, *v.FailOnViolation, "fail_on_violation should be false")
+
+	// THIS IS THE BUG: params arrives as nil today because the struct tag
+	// is `json:"config"` instead of `json:"params"`.
+	require.NotNil(t, v.Params, "params must survive JSON unmarshal (bug #933)")
+	assert.Equal(t, float64(2000), v.Params["max_characters"],
+		"max_characters must survive as float64 (JSON number default)")
+}
+
+// TestValidatorMarshalRoundTrip proves field-level fidelity: a Validator
+// marshalled to JSON and unmarshalled back must compare equal.
+func TestValidatorMarshalRoundTrip(t *testing.T) {
+	failOn := true
+	original := Validator{
+		Type:            "max_length",
+		Enabled:         true,
+		FailOnViolation: &failOn,
+		Params: map[string]any{
+			"max_characters": float64(2000),
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var round Validator
+	require.NoError(t, json.Unmarshal(data, &round))
+
+	assert.Equal(t, original.Type, round.Type)
+	assert.Equal(t, original.Enabled, round.Enabled)
+	require.NotNil(t, round.FailOnViolation)
+	assert.Equal(t, *original.FailOnViolation, *round.FailOnViolation)
+	assert.Equal(t, original.Params, round.Params)
+}

--- a/sdk/internal/pack/validator_spec_parity_test.go
+++ b/sdk/internal/pack/validator_spec_parity_test.go
@@ -1,0 +1,99 @@
+package pack
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/prompt/schema"
+)
+
+// TestValidatorStructMatchesPromptPackSpec pins pack.Validator to the
+// embedded PromptPack spec. Any drift — a renamed JSON tag, a removed
+// field, a new field not in the spec — fails this test at build time.
+// This is the mechanism that prevents the class of bug in issue #933.
+func TestValidatorStructMatchesPromptPackSpec(t *testing.T) {
+	raw := schema.GetEmbeddedSchema()
+	require.NotEmpty(t, raw, "embedded promptpack schema must load")
+
+	var root map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &root))
+
+	defs, ok := root["$defs"].(map[string]any)
+	require.True(t, ok, "embedded schema must have $defs")
+
+	validatorDef, ok := defs["Validator"].(map[string]any)
+	require.True(t, ok, "embedded schema must define $defs/Validator")
+
+	props, ok := validatorDef["properties"].(map[string]any)
+	require.True(t, ok, "Validator must have properties")
+
+	expected := make(map[string]bool, len(props))
+	for name := range props {
+		expected[name] = true
+	}
+
+	required := map[string]bool{}
+	if reqList, ok := validatorDef["required"].([]any); ok {
+		for _, r := range reqList {
+			if name, ok := r.(string); ok {
+				required[name] = true
+			}
+		}
+	}
+
+	addlProps := true
+	if v, ok := validatorDef["additionalProperties"].(bool); ok {
+		addlProps = v
+	}
+
+	// Walk pack.Validator via reflection.
+	tp := reflect.TypeOf(Validator{})
+	actual := make(map[string]bool, tp.NumField())
+	omitEmpty := make(map[string]bool, tp.NumField())
+	for i := 0; i < tp.NumField(); i++ {
+		field := tp.Field(i)
+		tag := field.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		parts := strings.Split(tag, ",")
+		name := parts[0]
+		actual[name] = true
+		for _, opt := range parts[1:] {
+			if opt == "omitempty" {
+				omitEmpty[name] = true
+			}
+		}
+	}
+
+	// Assertion 1: every schema property exists on the struct.
+	for name := range expected {
+		if !actual[name] {
+			t.Errorf("promptpack Validator property %q is missing from pack.Validator", name)
+		}
+	}
+
+	// Assertion 2: the struct has no fields the schema doesn't define
+	// (mirrors the schema's additionalProperties:false).
+	if !addlProps {
+		for name := range actual {
+			if !expected[name] {
+				t.Errorf("pack.Validator has JSON field %q not in the promptpack spec "+
+					"(additionalProperties:false)", name)
+			}
+		}
+	}
+
+	// Assertion 3: required fields must not have omitempty — they must
+	// always serialize, so a round-trip preserves the spec's required set.
+	for name := range required {
+		if omitEmpty[name] {
+			t.Errorf("promptpack required field %q has omitempty on pack.Validator — "+
+				"required fields must always serialize", name)
+		}
+	}
+}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -988,24 +988,35 @@ func packToRuntimePack(p *pack.Pack) *rtprompt.Pack {
 
 // convertPackValidatorsToHooks auto-converts pack prompt validators into
 // provider hooks, prepending them before any user-registered hooks.
-// This enables pack-defined guardrails (e.g., banned_words, length) to
+// This enables pack-defined guardrails (e.g., banned_words, max_length) to
 // run as enforcement hooks in the SDK pipeline.
+//
+// Validators are skipped (with a warning logged) when:
+//   - Enabled is false.
+//   - The validator type is not registered in the runtime registry.
+//   - The validator's params are unusable by its handler (missing required keys, etc.).
 func convertPackValidatorsToHooks(prompt *pack.Prompt, cfg *config) {
 	if len(prompt.Validators) == 0 {
 		return
 	}
 	var packHooks []hooks.ProviderHook
 	for _, v := range prompt.Validators {
-		var opts []guardrails.GuardrailOption
-		if v.Message != "" {
-			opts = append(opts, guardrails.WithMessage(v.Message))
+		if !v.Enabled {
+			logger.Debug("Skipping disabled pack validator", "type", v.Type)
+			continue
 		}
-		if v.Monitor {
+
+		var opts []guardrails.GuardrailOption
+		// Spec default for fail_on_violation is false (monitor-only). We enforce
+		// only when the pack explicitly sets fail_on_violation: true.
+		if v.FailOnViolation == nil || !*v.FailOnViolation {
 			opts = append(opts, guardrails.WithMonitorOnly())
 		}
-		hook, err := guardrails.NewGuardrailHook(v.Type, v.Config, opts...)
+
+		hook, err := guardrails.NewGuardrailHook(v.Type, v.Params, opts...)
 		if err != nil {
-			logger.Warn("Skipping unknown pack validator type", "type", v.Type, "error", err)
+			logger.Warn("Skipping unusable pack validator",
+				"type", v.Type, "error", err)
 			continue
 		}
 		packHooks = append(packHooks, hook)

--- a/sdk/validate_pack.go
+++ b/sdk/validate_pack.go
@@ -53,27 +53,44 @@ func (p PackIssue) String() string {
 }
 
 // ValidatePack loads the pack at path and reports any semantic issues —
-// unknown validator/eval types, missing required params, etc. — that
-// would cause Open() to warn-and-skip them or Arena to fail fast.
+// unknown validator/eval types, missing required params — that would
+// cause Open() to warn-and-skip them or Arena to fail fast.
+//
+// By default, ValidatePack runs strict promptpack JSON schema validation
+// against the embedded schema. A pack that fails schema validation (for
+// example, a validator declaring a forbidden field like "monitor") is
+// returned as a non-nil error — not as PackIssues — because the file
+// itself is non-spec. Pass WithSkipSchemaValidation to bypass this and
+// check only handler-level issues.
 //
 // Returns (nil, nil) if the pack is fully valid.
-// Returns (nil, err) if the pack file is missing, unreadable, or fails
-// structural parsing (e.g. missing required top-level fields) — these
-// are considered fatal and distinct from semantic issues.
+// Returns (nil, err) if the pack file is missing, unreadable, fails
+// JSON parse, or fails schema validation (when strict). These are
+// considered fatal and distinct from semantic issues.
 // Returns (issues, nil) if the pack loads cleanly but has semantic
-// problems the caller should address.
-//
-// Schema validation is intentionally skipped — ValidatePack focuses on
-// handler-level semantics (what convertPackValidatorsToHooks and
-// filterInvalidEvalDefs would warn-and-skip at Open() time). Schema
-// conformance is an orthogonal check most CI pipelines already run
-// separately.
+// problems (unknown validator/eval types, missing required params)
+// the caller should address.
 //
 // This is a pre-flight check for CI gates and operator tools. It runs
-// the same handler-level param validation the SDK runs internally
-// during Open(), exposed as a standalone function.
-func ValidatePack(path string) ([]PackIssue, error) {
-	loaded, err := pack.Load(path, pack.LoadOptions{SkipSchemaValidation: true})
+// the same handler-level validation the SDK runs internally during
+// Open(), exposed as a standalone function.
+//
+// ValidatePack accepts the same Option values as Open(), but only
+// consults WithSkipSchemaValidation — every other option is ignored.
+func ValidatePack(path string, opts ...Option) ([]PackIssue, error) {
+	cfg := &config{}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(cfg); err != nil {
+			return nil, fmt.Errorf("apply option: %w", err)
+		}
+	}
+
+	loaded, err := pack.Load(path, pack.LoadOptions{
+		SkipSchemaValidation: cfg.skipSchemaValidation,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/validate_pack.go
+++ b/sdk/validate_pack.go
@@ -1,0 +1,186 @@
+package sdk
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
+	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
+)
+
+// PackIssue describes a single semantic problem with a loaded pack.
+// Structural issues (malformed JSON, missing required fields, schema
+// violations) are returned as an error from ValidatePack, not as
+// PackIssues.
+type PackIssue struct {
+	// Severity is "error" for all current issues — each one would cause
+	// the corresponding validator or eval to be warn-and-skipped by
+	// sdk.Open() or fail-fast by Arena.
+	Severity string
+
+	// Kind identifies the subsystem: "validator" or "eval".
+	Kind string
+
+	// PromptID is the prompt name this issue came from. Empty for
+	// pack-level evals that apply to all prompts.
+	PromptID string
+
+	// Index is the position within the prompt's validators or evals slice.
+	Index int
+
+	// Type is the handler type, e.g. "max_length" or "content_excludes".
+	Type string
+
+	// ID is the eval def ID. Empty for validators.
+	ID string
+
+	// Reason is a human-readable explanation of the issue.
+	Reason string
+}
+
+// String formats a PackIssue for logging or CLI output.
+func (p PackIssue) String() string {
+	loc := p.Kind
+	if p.PromptID != "" {
+		loc = fmt.Sprintf("prompts.%s.%ss[%d]", p.PromptID, p.Kind, p.Index)
+	}
+	tag := p.Type
+	if p.ID != "" {
+		tag = fmt.Sprintf("%s id=%s", p.Type, p.ID)
+	}
+	return fmt.Sprintf("%s %s: %s (%s)", p.Severity, loc, p.Reason, tag)
+}
+
+// ValidatePack loads the pack at path and reports any semantic issues —
+// unknown validator/eval types, missing required params, etc. — that
+// would cause Open() to warn-and-skip them or Arena to fail fast.
+//
+// Returns (nil, nil) if the pack is fully valid.
+// Returns (nil, err) if the pack file is missing, unreadable, or fails
+// structural parsing (e.g. missing required top-level fields) — these
+// are considered fatal and distinct from semantic issues.
+// Returns (issues, nil) if the pack loads cleanly but has semantic
+// problems the caller should address.
+//
+// Schema validation is intentionally skipped — ValidatePack focuses on
+// handler-level semantics (what convertPackValidatorsToHooks and
+// filterInvalidEvalDefs would warn-and-skip at Open() time). Schema
+// conformance is an orthogonal check most CI pipelines already run
+// separately.
+//
+// This is a pre-flight check for CI gates and operator tools. It runs
+// the same handler-level param validation the SDK runs internally
+// during Open(), exposed as a standalone function.
+func ValidatePack(path string) ([]PackIssue, error) {
+	loaded, err := pack.Load(path, pack.LoadOptions{SkipSchemaValidation: true})
+	if err != nil {
+		return nil, err
+	}
+
+	registry := evals.NewEvalTypeRegistry()
+	var issues []PackIssue
+
+	// Per-prompt validators.
+	for promptID, promptDef := range loaded.Prompts {
+		if promptDef == nil {
+			continue
+		}
+		issues = append(issues, validatePromptValidators(promptID, promptDef.Validators, registry)...)
+	}
+
+	// Pack-level evals (apply to all prompts, PromptID="").
+	issues = append(issues, validateEvalDefs("", loaded.Evals, registry)...)
+
+	// Per-prompt evals.
+	for promptID, promptDef := range loaded.Prompts {
+		if promptDef == nil {
+			continue
+		}
+		issues = append(issues, validateEvalDefs(promptID, promptDef.Evals, registry)...)
+	}
+
+	return issues, nil
+}
+
+// validatePromptValidators dry-run constructs each enabled validator
+// through NewGuardrailHookFromRegistry — that function already performs
+// type lookup, param normalisation, and ParamValidator checks. Disabled
+// validators are skipped (matching convertPackValidatorsToHooks behavior
+// at Open() time).
+func validatePromptValidators(
+	promptID string, vs []pack.Validator, registry *evals.EvalTypeRegistry,
+) []PackIssue {
+	var issues []PackIssue
+	for i, v := range vs {
+		if !v.Enabled {
+			continue
+		}
+		if _, err := guardrails.NewGuardrailHookFromRegistry(v.Type, v.Params, registry); err != nil {
+			issues = append(issues, PackIssue{
+				Severity: "error",
+				Kind:     "validator",
+				PromptID: promptID,
+				Index:    i,
+				Type:     v.Type,
+				Reason:   cleanGuardrailError(err.Error()),
+			})
+		}
+	}
+	return issues
+}
+
+// validateEvalDefs runs evals.ValidateEvalTypes on the given defs and
+// converts each returned error string into a PackIssue. promptID is the
+// owning prompt name, or "" for pack-level evals.
+func validateEvalDefs(
+	promptID string, defs []evals.EvalDef, registry *evals.EvalTypeRegistry,
+) []PackIssue {
+	errs := evals.ValidateEvalTypes(defs, registry)
+	if len(errs) == 0 {
+		return nil
+	}
+	issues := make([]PackIssue, 0, len(errs))
+	for _, e := range errs {
+		id, reason := parseEvalValidationError(e)
+		issues = append(issues, PackIssue{
+			Severity: "error",
+			Kind:     "eval",
+			PromptID: promptID,
+			ID:       id,
+			Type:     findEvalTypeByID(defs, id),
+			Reason:   reason,
+		})
+	}
+	return issues
+}
+
+// cleanGuardrailError strips the `guardrail "<type>": ` prefix that
+// NewGuardrailHookFromRegistry wraps around ParamValidator errors so
+// the Reason field carries just the handler's message. The unknown
+// type error has a different shape (`unknown guardrail type: "..."`)
+// and is returned unchanged — still contains the word "unknown".
+func cleanGuardrailError(msg string) string {
+	const prefix = "guardrail "
+	if !strings.HasPrefix(msg, prefix) {
+		return msg
+	}
+	rest := msg[len(prefix):]
+	end := strings.Index(rest, `": `)
+	if end < 0 {
+		return msg
+	}
+	return strings.TrimSpace(rest[end+3:])
+}
+
+// findEvalTypeByID returns the Type field of an EvalDef with the given
+// ID, or an empty string if not found. Iterates by index to avoid
+// copying the EvalDef struct on each iteration.
+func findEvalTypeByID(defs []evals.EvalDef, id string) string {
+	for i := range defs {
+		if defs[i].ID == id {
+			return defs[i].Type
+		}
+	}
+	return ""
+}

--- a/sdk/validate_pack.go
+++ b/sdk/validate_pack.go
@@ -56,11 +56,12 @@ func (p PackIssue) String() string {
 // unknown validator/eval types, missing required params — that would
 // cause Open() to warn-and-skip them or Arena to fail fast.
 //
-// By default, ValidatePack runs strict promptpack JSON schema validation
-// against the embedded schema. A pack that fails schema validation (for
-// example, a validator declaring a forbidden field like "monitor") is
-// returned as a non-nil error — not as PackIssues — because the file
-// itself is non-spec. Pass WithSkipSchemaValidation to bypass this and
+// When skipSchemaValidation is false (the default for callers who pass
+// the zero value), ValidatePack runs strict promptpack JSON schema
+// validation against the embedded schema. A pack that fails schema
+// validation (for example, a validator declaring a forbidden field like
+// "monitor") is returned as a non-nil error — not as PackIssues —
+// because the file itself is non-spec. Pass true to bypass this and
 // check only handler-level issues.
 //
 // Returns (nil, nil) if the pack is fully valid.
@@ -74,22 +75,9 @@ func (p PackIssue) String() string {
 // This is a pre-flight check for CI gates and operator tools. It runs
 // the same handler-level validation the SDK runs internally during
 // Open(), exposed as a standalone function.
-//
-// ValidatePack accepts the same Option values as Open(), but only
-// consults WithSkipSchemaValidation — every other option is ignored.
-func ValidatePack(path string, opts ...Option) ([]PackIssue, error) {
-	cfg := &config{}
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		if err := opt(cfg); err != nil {
-			return nil, fmt.Errorf("apply option: %w", err)
-		}
-	}
-
+func ValidatePack(path string, skipSchemaValidation bool) ([]PackIssue, error) {
 	loaded, err := pack.Load(path, pack.LoadOptions{
-		SkipSchemaValidation: cfg.skipSchemaValidation,
+		SkipSchemaValidation: skipSchemaValidation,
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/validate_pack_internal_test.go
+++ b/sdk/validate_pack_internal_test.go
@@ -1,0 +1,54 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+func TestCleanGuardrailError(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "strips standard guardrail prefix",
+			in:   `guardrail "max_length": max_length requires positive int`,
+			want: "max_length requires positive int",
+		},
+		{
+			name: "no prefix is returned unchanged",
+			in:   `unknown guardrail type: "foo"`,
+			want: `unknown guardrail type: "foo"`,
+		},
+		{
+			name: "prefix present but without closing `\": ` is returned unchanged",
+			in:   `guardrail mid-sentence text`,
+			want: `guardrail mid-sentence text`,
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, cleanGuardrailError(tc.in))
+		})
+	}
+}
+
+func TestFindEvalTypeByID(t *testing.T) {
+	defs := []evals.EvalDef{
+		{ID: "one", Type: "max_length"},
+		{ID: "two", Type: "contains"},
+	}
+	assert.Equal(t, "max_length", findEvalTypeByID(defs, "one"))
+	assert.Equal(t, "contains", findEvalTypeByID(defs, "two"))
+	assert.Equal(t, "", findEvalTypeByID(defs, "missing"), "missing id returns empty type")
+	assert.Equal(t, "", findEvalTypeByID(nil, "anything"), "nil slice returns empty type")
+}

--- a/sdk/validate_pack_test.go
+++ b/sdk/validate_pack_test.go
@@ -55,7 +55,7 @@ func TestValidatePack_ValidPackReturnsNoIssues(t *testing.T) {
 	pack := baseValidPack()
 	path := writeValidatePackFixture(t, pack)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.NoError(t, err)
 	assert.Empty(t, issues, "a valid pack must produce no issues")
 }
@@ -73,7 +73,7 @@ func TestValidatePack_ValidPackWithGoodValidator(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, pack)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.NoError(t, err)
 	assert.Empty(t, issues)
 }
@@ -91,7 +91,7 @@ func TestValidatePack_ReportsUnknownValidatorType(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, pack)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	assert.Equal(t, "validator", issues[0].Kind)
@@ -113,7 +113,7 @@ func TestValidatePack_ReportsMissingValidatorParams(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, pack)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	assert.Equal(t, "validator", issues[0].Kind)
@@ -136,7 +136,7 @@ func TestValidatePack_SkipsDisabledValidator(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, pack)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.NoError(t, err)
 	assert.Empty(t, issues, "disabled validators must not produce issues")
 }
@@ -154,7 +154,7 @@ func TestValidatePack_ReportsUnknownEvalType(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, pack)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	assert.Equal(t, "eval", issues[0].Kind)
@@ -176,7 +176,7 @@ func TestValidatePack_ReportsMissingEvalParams(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, pack)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	assert.Equal(t, "eval", issues[0].Kind)
@@ -197,13 +197,13 @@ func TestValidatePack_MultipleIssues(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, pack)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.NoError(t, err)
 	assert.Len(t, issues, 3, "must report all three issues")
 }
 
 func TestValidatePack_FileNotFound(t *testing.T) {
-	issues, err := sdk.ValidatePack("/nonexistent/path/pack.json")
+	issues, err := sdk.ValidatePack("/nonexistent/path/pack.json", false)
 	require.Error(t, err)
 	assert.Nil(t, issues)
 }
@@ -263,7 +263,7 @@ func TestValidatePack_SchemaValidationError(t *testing.T) {
 	path := filepath.Join(dir, "bad.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{"id": "bad"}`), 0o600))
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.Error(t, err, "structural failure must be returned as error, not as issues")
 	assert.Nil(t, issues)
 }
@@ -288,13 +288,13 @@ func TestValidatePack_StrictSchemaRejectsNonSpecFields(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, p)
 
-	issues, err := sdk.ValidatePack(path)
+	issues, err := sdk.ValidatePack(path, false)
 	require.Error(t, err, "strict schema validation must reject non-spec validator fields")
 	assert.Nil(t, issues, "schema failures must be returned as error, not issues")
 }
 
 // TestValidatePack_SkipSchemaAllowsNonSpecFields confirms the opt-out.
-// With WithSkipSchemaValidation, strict schema is bypassed; handler-level
+// With skipSchemaValidation=true, strict schema is bypassed; handler-level
 // validation still runs on the declared validators. The forbidden
 // "monitor" field is ignored at load time (it's not in the Go struct),
 // and the validator itself is semantically valid, so no issues are
@@ -313,7 +313,7 @@ func TestValidatePack_SkipSchemaAllowsNonSpecFields(t *testing.T) {
 	}
 	path := writeValidatePackFixture(t, p)
 
-	issues, err := sdk.ValidatePack(path, sdk.WithSkipSchemaValidation())
-	require.NoError(t, err, "schema check must be bypassed with WithSkipSchemaValidation")
+	issues, err := sdk.ValidatePack(path, true)
+	require.NoError(t, err, "schema check must be bypassed with skipSchemaValidation=true")
 	assert.Empty(t, issues, "semantically valid validator produces no issues")
 }

--- a/sdk/validate_pack_test.go
+++ b/sdk/validate_pack_test.go
@@ -1,0 +1,262 @@
+package sdk_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// writeValidatePackFixture writes a promptpack JSON to a temp file and
+// returns its path. Reused by the ValidatePack tests.
+func writeValidatePackFixture(t *testing.T, pack map[string]any) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pack.json")
+	data, err := json.MarshalIndent(pack, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+// baseValidPack returns a minimal promptpack with one prompt and no
+// validators or evals. Callers can mutate the returned map before
+// passing to writeValidatePackFixture.
+func baseValidPack() map[string]any {
+	return map[string]any{
+		"id":          "validate-pack-test",
+		"name":        "Validate Pack Test",
+		"version":     "1.0.0",
+		"description": "ValidatePack test fixture",
+		"prompts": map[string]any{
+			"default": map[string]any{
+				"id":              "default",
+				"name":            "Default",
+				"description":     "test prompt",
+				"version":         "1.0.0",
+				"system_template": "You are helpful.",
+			},
+		},
+	}
+}
+
+func TestValidatePack_ValidPackReturnsNoIssues(t *testing.T) {
+	pack := baseValidPack()
+	path := writeValidatePackFixture(t, pack)
+
+	issues, err := sdk.ValidatePack(path)
+	require.NoError(t, err)
+	assert.Empty(t, issues, "a valid pack must produce no issues")
+}
+
+func TestValidatePack_ValidPackWithGoodValidator(t *testing.T) {
+	pack := baseValidPack()
+	prompts := pack["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["validators"] = []any{
+		map[string]any{
+			"type":    "max_length",
+			"enabled": true,
+			"params":  map[string]any{"max_characters": 2000},
+		},
+	}
+	path := writeValidatePackFixture(t, pack)
+
+	issues, err := sdk.ValidatePack(path)
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}
+
+func TestValidatePack_ReportsUnknownValidatorType(t *testing.T) {
+	pack := baseValidPack()
+	prompts := pack["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["validators"] = []any{
+		map[string]any{
+			"type":    "nonexistent_validator",
+			"enabled": true,
+			"params":  map[string]any{},
+		},
+	}
+	path := writeValidatePackFixture(t, pack)
+
+	issues, err := sdk.ValidatePack(path)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "validator", issues[0].Kind)
+	assert.Equal(t, "default", issues[0].PromptID)
+	assert.Equal(t, "nonexistent_validator", issues[0].Type)
+	assert.Contains(t, issues[0].Reason, "unknown")
+}
+
+func TestValidatePack_ReportsMissingValidatorParams(t *testing.T) {
+	pack := baseValidPack()
+	prompts := pack["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["validators"] = []any{
+		map[string]any{
+			"type":    "max_length",
+			"enabled": true,
+			"params":  map[string]any{}, // missing required max_characters
+		},
+	}
+	path := writeValidatePackFixture(t, pack)
+
+	issues, err := sdk.ValidatePack(path)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "validator", issues[0].Kind)
+	assert.Equal(t, "max_length", issues[0].Type)
+	assert.Contains(t, issues[0].Reason, "max")
+}
+
+func TestValidatePack_SkipsDisabledValidator(t *testing.T) {
+	// Disabled validators are not checked — consistent with
+	// convertPackValidatorsToHooks behaviour at Open() time.
+	pack := baseValidPack()
+	prompts := pack["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["validators"] = []any{
+		map[string]any{
+			"type":    "max_length",
+			"enabled": false,
+			"params":  map[string]any{}, // would be invalid if enabled
+		},
+	}
+	path := writeValidatePackFixture(t, pack)
+
+	issues, err := sdk.ValidatePack(path)
+	require.NoError(t, err)
+	assert.Empty(t, issues, "disabled validators must not produce issues")
+}
+
+func TestValidatePack_ReportsUnknownEvalType(t *testing.T) {
+	pack := baseValidPack()
+	prompts := pack["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["evals"] = []any{
+		map[string]any{
+			"id":      "bad-eval",
+			"type":    "nonexistent_eval",
+			"trigger": "every_turn",
+		},
+	}
+	path := writeValidatePackFixture(t, pack)
+
+	issues, err := sdk.ValidatePack(path)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "eval", issues[0].Kind)
+	assert.Equal(t, "bad-eval", issues[0].ID)
+	assert.Contains(t, issues[0].Reason, "unknown")
+}
+
+func TestValidatePack_ReportsMissingEvalParams(t *testing.T) {
+	pack := baseValidPack()
+	prompts := pack["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["evals"] = []any{
+		map[string]any{
+			"id":      "len-eval",
+			"type":    "max_length",
+			"trigger": "every_turn",
+			"params":  map[string]any{}, // missing required max_characters
+		},
+	}
+	path := writeValidatePackFixture(t, pack)
+
+	issues, err := sdk.ValidatePack(path)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "eval", issues[0].Kind)
+	assert.Equal(t, "len-eval", issues[0].ID)
+	assert.Contains(t, issues[0].Reason, "max")
+}
+
+func TestValidatePack_MultipleIssues(t *testing.T) {
+	pack := baseValidPack()
+	prompts := pack["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["validators"] = []any{
+		map[string]any{"type": "max_length", "enabled": true, "params": map[string]any{}},
+		map[string]any{"type": "unknown_type", "enabled": true, "params": map[string]any{}},
+	}
+	def["evals"] = []any{
+		map[string]any{"id": "bad1", "type": "nonexistent", "trigger": "every_turn"},
+	}
+	path := writeValidatePackFixture(t, pack)
+
+	issues, err := sdk.ValidatePack(path)
+	require.NoError(t, err)
+	assert.Len(t, issues, 3, "must report all three issues")
+}
+
+func TestValidatePack_FileNotFound(t *testing.T) {
+	issues, err := sdk.ValidatePack("/nonexistent/path/pack.json")
+	require.Error(t, err)
+	assert.Nil(t, issues)
+}
+
+func TestPackIssue_String(t *testing.T) {
+	// Validator issue with a prompt — uses the "prompts.<id>.<kind>s[i]"
+	// location format and the Type tag.
+	vIssue := sdk.PackIssue{
+		Severity: "error",
+		Kind:     "validator",
+		PromptID: "default",
+		Index:    2,
+		Type:     "max_length",
+		Reason:   "max_length requires positive integer",
+	}
+	got := vIssue.String()
+	assert.Contains(t, got, "error")
+	assert.Contains(t, got, "prompts.default.validators[2]")
+	assert.Contains(t, got, "max_length")
+	assert.Contains(t, got, "requires positive integer")
+
+	// Eval issue with an ID — tag should show both type and id.
+	eIssue := sdk.PackIssue{
+		Severity: "error",
+		Kind:     "eval",
+		PromptID: "default",
+		Index:    0,
+		Type:     "contains",
+		ID:       "tone-check",
+		Reason:   "missing 'needle'",
+	}
+	got = eIssue.String()
+	assert.Contains(t, got, "prompts.default.evals[0]")
+	assert.Contains(t, got, "id=tone-check")
+
+	// Pack-level issue (no PromptID) — location collapses to bare Kind.
+	packLevel := sdk.PackIssue{
+		Severity: "error",
+		Kind:     "eval",
+		ID:       "pack-wide",
+		Type:     "unknown",
+		Reason:   "unknown type",
+	}
+	got = packLevel.String()
+	assert.Contains(t, got, "error eval")
+	assert.NotContains(t, got, "prompts.")
+}
+
+func TestValidatePack_SchemaValidationError(t *testing.T) {
+	// Malformed pack — missing required top-level "prompts" field.
+	// pack.Parse returns "pack contains no prompts" which ValidatePack
+	// surfaces as an error, not a PackIssue (consistent with the
+	// contract: structural failures are errors, semantic problems are
+	// issues).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"id": "bad"}`), 0o600))
+
+	issues, err := sdk.ValidatePack(path)
+	require.Error(t, err, "structural failure must be returned as error, not as issues")
+	assert.Nil(t, issues)
+}

--- a/sdk/validate_pack_test.go
+++ b/sdk/validate_pack_test.go
@@ -25,14 +25,20 @@ func writeValidatePackFixture(t *testing.T, pack map[string]any) string {
 }
 
 // baseValidPack returns a minimal promptpack with one prompt and no
-// validators or evals. Callers can mutate the returned map before
-// passing to writeValidatePackFixture.
+// validators or evals. The shape matches the promptpack spec's
+// required top-level fields so the fixture passes strict schema
+// validation (ValidatePack's default). Callers can mutate the returned
+// map before passing to writeValidatePackFixture.
 func baseValidPack() map[string]any {
 	return map[string]any{
 		"id":          "validate-pack-test",
 		"name":        "Validate Pack Test",
 		"version":     "1.0.0",
 		"description": "ValidatePack test fixture",
+		"template_engine": map[string]any{
+			"version": "v1",
+			"syntax":  "{{variable}}",
+		},
 		"prompts": map[string]any{
 			"default": map[string]any{
 				"id":              "default",
@@ -247,11 +253,12 @@ func TestPackIssue_String(t *testing.T) {
 }
 
 func TestValidatePack_SchemaValidationError(t *testing.T) {
-	// Malformed pack — missing required top-level "prompts" field.
-	// pack.Parse returns "pack contains no prompts" which ValidatePack
-	// surfaces as an error, not a PackIssue (consistent with the
-	// contract: structural failures are errors, semantic problems are
-	// issues).
+	// Malformed pack — missing required top-level fields
+	// ("name", "version", "template_engine", "prompts"). With strict
+	// schema validation on by default, this fails at the schema layer;
+	// ValidatePack surfaces the failure as an error, not a PackIssue
+	// (consistent with the contract: structural/schema failures are
+	// errors, semantic problems are issues).
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bad.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{"id": "bad"}`), 0o600))
@@ -259,4 +266,54 @@ func TestValidatePack_SchemaValidationError(t *testing.T) {
 	issues, err := sdk.ValidatePack(path)
 	require.Error(t, err, "structural failure must be returned as error, not as issues")
 	assert.Nil(t, issues)
+}
+
+// TestValidatePack_StrictSchemaRejectsNonSpecFields pins the strict
+// default: a validator declaring a field the promptpack spec forbids
+// (additionalProperties:false) is returned as a load-time error, not as
+// a PackIssue. This is the schema-level guarantee — the same one that
+// would catch the issue #933 class of struct drift if someone added
+// "monitor" back to pack.Validator.
+func TestValidatePack_StrictSchemaRejectsNonSpecFields(t *testing.T) {
+	p := baseValidPack()
+	prompts := p["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["validators"] = []any{
+		map[string]any{
+			"type":    "max_length",
+			"enabled": true,
+			"params":  map[string]any{"max_characters": 2000},
+			"monitor": true, // forbidden by additionalProperties:false
+		},
+	}
+	path := writeValidatePackFixture(t, p)
+
+	issues, err := sdk.ValidatePack(path)
+	require.Error(t, err, "strict schema validation must reject non-spec validator fields")
+	assert.Nil(t, issues, "schema failures must be returned as error, not issues")
+}
+
+// TestValidatePack_SkipSchemaAllowsNonSpecFields confirms the opt-out.
+// With WithSkipSchemaValidation, strict schema is bypassed; handler-level
+// validation still runs on the declared validators. The forbidden
+// "monitor" field is ignored at load time (it's not in the Go struct),
+// and the validator itself is semantically valid, so no issues are
+// reported.
+func TestValidatePack_SkipSchemaAllowsNonSpecFields(t *testing.T) {
+	p := baseValidPack()
+	prompts := p["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["validators"] = []any{
+		map[string]any{
+			"type":    "max_length",
+			"enabled": true,
+			"params":  map[string]any{"max_characters": 2000},
+			"monitor": true, // forbidden by schema, ignored at unmarshal
+		},
+	}
+	path := writeValidatePackFixture(t, p)
+
+	issues, err := sdk.ValidatePack(path, sdk.WithSkipSchemaValidation())
+	require.NoError(t, err, "schema check must be bypassed with WithSkipSchemaValidation")
+	assert.Empty(t, issues, "semantically valid validator produces no issues")
 }

--- a/sdk/validators_e2e_test.go
+++ b/sdk/validators_e2e_test.go
@@ -1,0 +1,143 @@
+package sdk_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// Regression coverage for https://github.com/AltairaLabs/PromptKit/issues/933.
+//
+// Prior to the fix, every turn of a conversation with a `max_length` validator
+// declared (even one with a generous 2000-character cap) had its assistant
+// content silently replaced by DefaultBlockedMessage. The root cause was a
+// mismatch between the PromptPack spec's `params` field and the SDK's
+// internal struct, which unmarshalled as nil and caused the validator to
+// emit an "impossible" violation on every response.
+//
+// These tests exercise the full path — promptpack JSON on disk, sdk.Open,
+// mock provider, Send — and assert the content is what we expect.
+
+// buildTestPackWithMaxLength returns promptpack JSON with a max_length
+// validator configured against the supplied parameters.
+func buildTestPackWithMaxLength(t *testing.T, maxChars int, failOnViolation bool) []byte {
+	t.Helper()
+	failField := ""
+	if failOnViolation {
+		failField = `"fail_on_violation": true,`
+	}
+	packJSON := fmt.Sprintf(`{
+  "id": "test-pack-933",
+  "version": "1.0.0",
+  "description": "issue #933 regression",
+  "prompts": {
+    "default": {
+      "id": "default",
+      "name": "Default",
+      "system_template": "You are helpful.",
+      "validators": [
+        {
+          "type": "max_length",
+          "enabled": true,
+          %s
+          "params": {"max_characters": %d}
+        }
+      ]
+    }
+  }
+}`, failField, maxChars)
+	return []byte(packJSON)
+}
+
+// writeTestPack writes the given promptpack JSON to a temp file and returns
+// its path.
+func writeTestPack(t *testing.T, packJSON []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.pack.json")
+	require.NoError(t, os.WriteFile(path, packJSON, 0o600))
+	return path
+}
+
+// openWithMockResponse opens a conversation against a promptpack file backed
+// by a mock provider that returns the given canned response.
+func openWithMockResponse(t *testing.T, packPath, cannedResponse string) *sdk.Conversation {
+	t.Helper()
+	repo := mock.NewInMemoryMockRepository(cannedResponse)
+	provider := mock.NewProviderWithRepository("mock-test", "mock-model", false, repo)
+
+	conv, err := sdk.Open(packPath, "default",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+	return conv
+}
+
+// TestIssue933_MaxLengthValidatorDoesNotBlockShortResponse is the direct
+// regression for #933. A short assistant response must flow through a
+// max_length validator with a generous cap untouched.
+func TestIssue933_MaxLengthValidatorDoesNotBlockShortResponse(t *testing.T) {
+	const cannedResponse = "Hi there, this is a short reply." // 32 chars
+	packPath := writeTestPack(t, buildTestPackWithMaxLength(t, 2000, true))
+	conv := openWithMockResponse(t, packPath, cannedResponse)
+
+	resp, err := conv.Send(context.Background(), "Hello")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	got := resp.Text()
+	assert.Equal(t, cannedResponse, got,
+		"short response should pass through untouched when max_characters=2000")
+	assert.NotEqual(t, prompt.DefaultBlockedMessage, got,
+		"response must not be replaced with DefaultBlockedMessage (issue #933)")
+	assert.NotContains(t, got, "blocked",
+		"response must not mention being blocked (issue #933 regression)")
+}
+
+// TestValidatorEnforcesOnRealViolation verifies that fail_on_violation:true
+// still enforces when the response actually exceeds the limit. For
+// max_length the enforcement action is truncation.
+func TestValidatorEnforcesOnRealViolation(t *testing.T) {
+	const cannedResponse = "This response is definitely longer than ten characters."
+	const maxChars = 10
+	packPath := writeTestPack(t, buildTestPackWithMaxLength(t, maxChars, true))
+	conv := openWithMockResponse(t, packPath, cannedResponse)
+
+	resp, err := conv.Send(context.Background(), "Hello")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	got := resp.Text()
+	assert.NotEqual(t, cannedResponse, got,
+		"enforcement should have modified the response")
+	assert.LessOrEqual(t, len(got), maxChars,
+		"content must be truncated to at most max_characters when fail_on_violation=true")
+}
+
+// TestValidatorMonitorOnlyDoesNotEnforce verifies the spec-default behaviour:
+// with fail_on_violation absent, the validator logs violations but leaves
+// content untouched.
+func TestValidatorMonitorOnlyDoesNotEnforce(t *testing.T) {
+	const cannedResponse = "This response is definitely longer than ten characters."
+	packPath := writeTestPack(t, buildTestPackWithMaxLength(t, 10, false))
+	conv := openWithMockResponse(t, packPath, cannedResponse)
+
+	resp, err := conv.Send(context.Background(), "Hello")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	got := resp.Text()
+	assert.Equal(t, cannedResponse, got,
+		"monitor-only mode must not modify content even on violation")
+}

--- a/sdk/validators_e2e_test.go
+++ b/sdk/validators_e2e_test.go
@@ -188,3 +188,86 @@ func TestValidatorMonitorOnlyDoesNotEnforce(t *testing.T) {
 	assert.Equal(t, cannedResponse, got,
 		"monitor-only mode must not modify content even on violation")
 }
+
+// TestIssue933_TicketExactReproducer mirrors the exact scenario from
+// https://github.com/AltairaLabs/PromptKit/issues/933 — a max_length
+// validator with fail_on_violation:false (monitor-only per spec default)
+// and max_characters:2000, sending a short response that should pass
+// through unchanged. Before the fix, params unmarshalled as nil, the
+// handler reported a violation every turn, and the guardrail adapter
+// replaced the response with DefaultBlockedMessage despite monitor-only
+// being set.
+//
+// This test simultaneously pins two fixes from this branch:
+//  1. The json:"params" struct tag (otherwise params drops to nil and
+//     the validator is filtered out by convertPackValidatorsToHooks —
+//     caught here by the log-capture assertion).
+//  2. The fail_on_violation:false → monitor-only mapping in
+//     convertPackValidatorsToHooks (otherwise even with a real violation,
+//     enforcement would run; here the response is well under the limit
+//     so enforcement is a no-op either way — this is covered by the
+//     sibling TestValidatorMonitorOnlyDoesNotEnforce test).
+//
+// The value of THIS test over the others is that it is the literal
+// reproducer from the issue: fail_on_violation is present explicitly
+// set to false, matching the ticket verbatim. Any future change that
+// breaks the ticket's exact scenario will fail this test by name.
+func TestIssue933_TicketExactReproducer(t *testing.T) {
+	logs := captureValidatorLogs(t)
+
+	// Inline pack JSON with fail_on_violation explicitly present and
+	// set to false — matches the JSON pasted in the issue verbatim.
+	// The shared helper omits the field when false, which would make
+	// this test a duplicate of TestValidatorMonitorOnlyDoesNotEnforce;
+	// building the JSON inline preserves fidelity to the reproducer.
+	packJSON := []byte(`{
+  "id": "test-pack-933-ticket",
+  "version": "1.0.0",
+  "description": "issue #933 ticket-exact reproducer",
+  "prompts": {
+    "default": {
+      "id": "default",
+      "name": "Default",
+      "system_template": "You are helpful.",
+      "validators": [
+        {
+          "type": "max_length",
+          "enabled": true,
+          "fail_on_violation": false,
+          "params": { "max_characters": 2000 }
+        }
+      ]
+    }
+  }
+}`)
+	packPath := writeTestPack(t, packJSON)
+
+	// Short canned response, well under the 2000-char limit. 25 characters
+	// to mirror the "25-character response" the issue mentions.
+	const canned = "Hi - 25 char reply exact."
+	require.Equal(t, 25, len(canned), "sanity: response length must match ticket scenario")
+
+	conv := openWithMockResponse(t, packPath, canned)
+	resp, err := conv.Send(context.Background(), "hello")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	got := resp.Text()
+
+	// Assertion 1 — the response is unchanged. Before the fix, this was
+	// DefaultBlockedMessage because enforcement fired on the synthetic
+	// "missing param" violation.
+	assert.Equal(t, canned, got,
+		"response must be unchanged; before the fix it was replaced with DefaultBlockedMessage")
+
+	// Assertion 2 — the response does not contain the default blocked message text.
+	assert.NotEqual(t, prompt.DefaultBlockedMessage, got,
+		"response must not be DefaultBlockedMessage")
+
+	// Assertion 3 — the validator was actually registered, not silently
+	// skipped by the warn-and-skip layer. This is what catches a
+	// struct-tag regression (validator hook gets dropped entirely, so
+	// the content-equality assertion alone would be a tautology).
+	assert.NotContains(t, logs.String(), "Skipping unusable pack validator",
+		"validator hook must be registered — struct tag regression would cause it to be skipped")
+}

--- a/sdk/validators_e2e_test.go
+++ b/sdk/validators_e2e_test.go
@@ -1,19 +1,55 @@
 package sdk_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/sdk"
 )
+
+// syncBuffer is a mutex-guarded bytes.Buffer. Needed because the SDK's
+// global logger is shared across pipeline goroutines which keep emitting
+// log records concurrently with the test reading the captured output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// captureValidatorLogs redirects the global logger to a concurrency-safe
+// buffer for the duration of a test. Local to this file because
+// eval_middleware_test.go's captureLogs lives in package sdk and this file
+// is in sdk_test.
+func captureValidatorLogs(t *testing.T) *syncBuffer {
+	t.Helper()
+	buf := &syncBuffer{}
+	h := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger.SetLogger(slog.New(h))
+	return buf
+}
 
 // Regression coverage for https://github.com/AltairaLabs/PromptKit/issues/933.
 //
@@ -88,6 +124,8 @@ func openWithMockResponse(t *testing.T, packPath, cannedResponse string) *sdk.Co
 // regression for #933. A short assistant response must flow through a
 // max_length validator with a generous cap untouched.
 func TestIssue933_MaxLengthValidatorDoesNotBlockShortResponse(t *testing.T) {
+	logs := captureValidatorLogs(t)
+
 	const cannedResponse = "Hi there, this is a short reply." // 32 chars
 	packPath := writeTestPack(t, buildTestPackWithMaxLength(t, 2000, true))
 	conv := openWithMockResponse(t, packPath, cannedResponse)
@@ -103,6 +141,15 @@ func TestIssue933_MaxLengthValidatorDoesNotBlockShortResponse(t *testing.T) {
 		"response must not be replaced with DefaultBlockedMessage (issue #933)")
 	assert.NotContains(t, got, "blocked",
 		"response must not mention being blocked (issue #933 regression)")
+
+	// Structural assertion: without this, the content-equality check above
+	// is a tautology — if the validator hook is silently dropped by
+	// convertPackValidatorsToHooks (e.g. because params unmarshal to nil
+	// from a struct-tag regression), a short response still passes through
+	// unchanged for the wrong reason. Pinning the absence of the skip
+	// warning proves the hook was actually registered.
+	assert.NotContains(t, logs.String(), "Skipping unusable pack validator",
+		"validator must be registered, not silently skipped (regression for #933)")
 }
 
 // TestValidatorEnforcesOnRealViolation verifies that fail_on_violation:true

--- a/sdk/validators_to_hooks_test.go
+++ b/sdk/validators_to_hooks_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 func TestConvertPackValidatorsToHooks(t *testing.T) {
 	t.Run("no validators is no-op", func(t *testing.T) {
 		prompt := &pack.Prompt{}
@@ -18,10 +20,14 @@ func TestConvertPackValidatorsToHooks(t *testing.T) {
 		assert.Empty(t, cfg.providerHooks)
 	})
 
-	t.Run("converts known validator to hook", func(t *testing.T) {
+	t.Run("converts enabled known validator to hook", func(t *testing.T) {
 		prompt := &pack.Prompt{
 			Validators: []pack.Validator{
-				{Type: "banned_words", Config: map[string]any{"words": []any{"bad"}}},
+				{
+					Type:    "banned_words",
+					Enabled: true,
+					Params:  map[string]any{"patterns": []any{"bad"}},
+				},
 			},
 		}
 		cfg := &config{}
@@ -30,10 +36,25 @@ func TestConvertPackValidatorsToHooks(t *testing.T) {
 		assert.Equal(t, "banned_words", cfg.providerHooks[0].Name())
 	})
 
+	t.Run("skips disabled validator", func(t *testing.T) {
+		prompt := &pack.Prompt{
+			Validators: []pack.Validator{
+				{
+					Type:    "banned_words",
+					Enabled: false,
+					Params:  map[string]any{"patterns": []any{"bad"}},
+				},
+			},
+		}
+		cfg := &config{}
+		convertPackValidatorsToHooks(prompt, cfg)
+		assert.Empty(t, cfg.providerHooks)
+	})
+
 	t.Run("skips unknown validator type", func(t *testing.T) {
 		prompt := &pack.Prompt{
 			Validators: []pack.Validator{
-				{Type: "nonexistent", Config: map[string]any{}},
+				{Type: "nonexistent", Enabled: true, Params: map[string]any{}},
 			},
 		}
 		cfg := &config{}
@@ -44,7 +65,11 @@ func TestConvertPackValidatorsToHooks(t *testing.T) {
 	t.Run("pack validators prepended before user hooks", func(t *testing.T) {
 		prompt := &pack.Prompt{
 			Validators: []pack.Validator{
-				{Type: "banned_words", Config: map[string]any{"words": []any{"bad"}}},
+				{
+					Type:    "banned_words",
+					Enabled: true,
+					Params:  map[string]any{"patterns": []any{"bad"}},
+				},
 			},
 		}
 		userHook := &testProviderHook{name: "user-hook"}
@@ -57,34 +82,58 @@ func TestConvertPackValidatorsToHooks(t *testing.T) {
 		assert.Equal(t, "user-hook", cfg.providerHooks[1].Name())
 	})
 
-	t.Run("multiple validators", func(t *testing.T) {
+	t.Run("multiple enabled validators", func(t *testing.T) {
 		prompt := &pack.Prompt{
 			Validators: []pack.Validator{
-				{Type: "banned_words", Config: map[string]any{"words": []any{"bad"}}},
-				{Type: "length", Config: map[string]any{"max_characters": 100}},
+				{
+					Type:    "banned_words",
+					Enabled: true,
+					Params:  map[string]any{"patterns": []any{"bad"}},
+				},
+				{
+					Type:    "max_length",
+					Enabled: true,
+					Params:  map[string]any{"max_characters": 100},
+				},
 			},
 		}
 		cfg := &config{}
 		convertPackValidatorsToHooks(prompt, cfg)
 		require.Len(t, cfg.providerHooks, 2)
 		assert.Equal(t, "banned_words", cfg.providerHooks[0].Name())
-		assert.Equal(t, "length", cfg.providerHooks[1].Name())
+		assert.Equal(t, "max_length", cfg.providerHooks[1].Name())
 	})
 
-	t.Run("validator with message and monitor options", func(t *testing.T) {
+	t.Run("fail_on_violation omitted defaults to monitor-only", func(t *testing.T) {
 		prompt := &pack.Prompt{
 			Validators: []pack.Validator{
 				{
 					Type:    "banned_words",
-					Config:  map[string]any{"words": []any{"bad"}},
-					Message: "custom rejection message",
-					Monitor: true,
+					Enabled: true,
+					Params:  map[string]any{"patterns": []any{"bad"}},
 				},
 			},
 		}
 		cfg := &config{}
 		convertPackValidatorsToHooks(prompt, cfg)
 		require.Len(t, cfg.providerHooks, 1)
-		assert.Equal(t, "banned_words", cfg.providerHooks[0].Name())
+		// Monitor-only is an internal flag on the adapter; the behavioural
+		// assertion lives in the e2e test in a later task.
+	})
+
+	t.Run("fail_on_violation true enables enforcement", func(t *testing.T) {
+		prompt := &pack.Prompt{
+			Validators: []pack.Validator{
+				{
+					Type:            "banned_words",
+					Enabled:         true,
+					FailOnViolation: boolPtr(true),
+					Params:          map[string]any{"patterns": []any{"bad"}},
+				},
+			},
+		}
+		cfg := &config{}
+		convertPackValidatorsToHooks(prompt, cfg)
+		require.Len(t, cfg.providerHooks, 1)
 	})
 }

--- a/tools/arena/engine/eval_param_validation_test.go
+++ b/tools/arena/engine/eval_param_validation_test.go
@@ -1,0 +1,38 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers" // register default handlers
+)
+
+// TestArenaEvalOrchestratorFailsOnMissingRequiredParams confirms that
+// Arena's fail-fast path picks up param-validation errors from
+// ValidateEvalTypes, not just unknown-type errors. This is a side effect
+// of extending ValidateEvalTypes to call ParamValidator — Arena gains
+// stricter checks for free.
+//
+// This test asserts the contract at the ValidateEvalTypes level because
+// buildEvalOrchestrator in builder_integration.go uses the same function,
+// and a direct call avoids standing up a full arena pack fixture.
+func TestArenaEvalOrchestratorFailsOnMissingRequiredParams(t *testing.T) {
+	reg := evals.NewEvalTypeRegistry()
+	defs := []evals.EvalDef{
+		{
+			ID:      "max-length-bad",
+			Type:    "max_length",
+			Trigger: evals.TriggerEveryTurn,
+			Params:  map[string]any{}, // missing required max_characters
+		},
+	}
+
+	errs := evals.ValidateEvalTypes(defs, reg)
+	require.NotEmpty(t, errs, "Arena fail-fast must surface missing-param error")
+	assert.Contains(t, strings.ToLower(errs[0]), "max")
+	assert.Contains(t, errs[0], "max-length-bad")
+}


### PR DESCRIPTION
## Summary

Fixes AltairaLabs/PromptKit#933 — the SDK silently replaced every response with `DefaultBlockedMessage` when a pack declared any validator, due to a JSON tag mismatch that dropped validator params.

This PR delivers the immediate fix and a set of prevention mechanisms so the class of bug cannot recur.

## The bug

`sdk/internal/pack.Validator` had `json:"config"` where the promptpack spec uses `json:"params"`, plus forbidden `monitor`/`message` fields the spec's `additionalProperties:false` rejects. Params silently unmarshalled to nil, every declared validator ran with empty params, the `max_length` handler reported `"missing or zero 'max'/'max_characters' param"` every turn, and the guardrail adapter replaced every response with `DefaultBlockedMessage`.

The pack in the issue is fully valid per the promptpack spec. The SDK was the defect.

## What changed

**Immediate fix** (`e5c66290`): SDK `Validator` struct aligned to `$defs/Validator` in `runtime/prompt/schema/promptpack.schema.json` — `type`, `enabled` (required), `fail_on_violation` (optional), `params` (optional). `convertPackValidatorsToHooks` updated to skip disabled validators, honor the spec default of monitor-only when `fail_on_violation` is absent, and pass `Params` (not `Config`) to the guardrail factory.

**Prevention mechanisms**:
- **Spec-parity reflection test** (`2538c7d3`) — walks `pack.Validator` via reflection and diffs against the embedded schema's `$defs/Validator`. Any future tag rename, extra field, or required-with-omitempty fails the build.
- **Schema rejection test** (`a02bed79`) — pins that `ValidateAgainstSchema` rejects validators with forbidden `monitor`/`config`/`message` fields before struct unmarshal.
- **`ParamValidator` interface** (`4edfb07b`, `580cfe11`) — new optional interface in `runtime/evals` that handlers can implement to expose required-param contracts. Implemented on `MaxLengthHandler`, `MinLengthHandler`, `WorkflowStateIsHandler`, `GuardrailTriggeredHandler`.
- **Guardrail factory validates params at construction** (`a32e8170`) — `NewGuardrailHookFromRegistry` normalises params (`ApplyDefaults` + `NormalizeParams`) and calls `ValidateParams`, so pack validators with unusable params fail at SDK load instead of silently enforcing every turn.
- **`ValidateEvalTypes` extended** (`af6ad2b3`) — the existing function used by Arena fail-fast and SDK eval preflight now also invokes `ParamValidator`. Arena gains stricter checks for free.
- **SDK warn-and-skip for evals** (`d1e76e49`) — `sdk/eval_middleware.go` filters bad eval defs at middleware creation with a warning, mirroring the existing validator warn-and-skip in `convertPackValidatorsToHooks`.
- **Public `sdk.ValidatePack(path, skipSchemaValidation)` preflight API** (`8849cb5b`, `2809df11`, `a868f1a2`) — lets CI gates and operator tools check whether a pack will load cleanly before `sdk.Open()` is called. Strict-by-default (uses the embedded promptpack schema). Returns `[]PackIssue` for semantic problems and `error` for structural/schema failures.

**Tests**:
- End-to-end regression (`77c070ad`, `b88a385f`) — full path `sdk.Open() → pack.Load() → Send()` with a mock provider, asserts content unchanged AND validator actually registered (not silently dropped by the warn-and-skip layer). Empirically verified to fail if the struct tag regresses.
- Ticket-exact reproducer (`9f74362c`) — literal mirror of the reproducer in AltairaLabs/PromptKit#933 (`fail_on_violation: false`, 25-char response).
- Arena fail-fast test (`7517857c`) — pins that Arena's existing fail-fast picks up `ParamValidator` errors.
- `ValidatePack` tests covering valid pack, unknown validator type, missing required params, disabled skip, unknown eval type, missing eval params, multiple issues, file-not-found, structural error, strict schema rejection of non-spec fields, and the skip-schema opt-out.

## Latent bugs surfaced

The stricter validation revealed two pre-existing test-fixture bugs, both fixed in the same commits that introduced the stricter check:
- `TestNewGuardrailHook_AllTypes` declared `max_length` with only `max_tokens` (no `max_characters`) — was relying on silent runtime tolerance.
- `TestEvalMiddleware_ResolvesPackAndPromptEvals` used fabricated eval types (`regex_override`) and bare `length` with empty params — was bypassing validation entirely.

## API addition

```go
// strict (default — zero value)
issues, err := sdk.ValidatePack("pack.json", false)

// opt-out for tooling that wants only handler-level checks
issues, err := sdk.ValidatePack("pack.json", true)

type PackIssue struct {
    Severity string  // "error"
    Kind     string  // "validator" or "eval"
    PromptID string  // owning prompt, or "" for pack-level evals
    Index    int     // position within validators/evals slice
    Type     string  // handler type
    ID       string  // eval def ID (empty for validators)
    Reason   string  // human-readable explanation
}
```

## Test plan

- [x] Unit tests for `ParamValidator` on all four handlers with happy paths, missing keys, nil params, zero, negative, and alias key names
- [x] Unit tests for guardrail factory happy path, missing params, unknown type, handlers without `ParamValidator`
- [x] Unit tests for `ValidateEvalTypes` extension with stub handler
- [x] SDK warn-and-skip filter tests (unknown type, missing params, all-valid)
- [x] Spec-parity reflection test against embedded schema
- [x] Schema rejection test for `additionalProperties:false` fields
- [x] JSON round-trip fidelity test for `Validator` struct
- [x] End-to-end happy path: short response not blocked (empirically verified to fail on struct-tag regression via log-capture assertion)
- [x] End-to-end enforcement: long response truncated with `fail_on_violation:true`
- [x] End-to-end monitor-only: long response passes through with `fail_on_violation:false`
- [x] Ticket-exact reproducer matching the issue's literal JSON
- [x] Arena fail-fast regression test for missing required params
- [x] `sdk.ValidatePack` tests covering 12 scenarios including strict default and opt-out
- [x] Full test matrix (`runtime`, `sdk`, `pkg`, `tools/arena`, `tools/packc`, `tools/schema-gen`) passes with `-count=1 -race`
- [x] Lint clean (`golangci-lint run --new-from-rev=main`) on all changed files