### PR TITLE
feat(providers): Azure OpenAI first-class platform support + validator message fix

### DIFF
--- a/docs/src/content/docs/arena/how-to/configure-providers.md
+++ b/docs/src/content/docs/arena/how-to/configure-providers.md
@@ -189,6 +189,8 @@ Authentication uses the `GOOGLE_API_KEY` environment variable automatically.
 
 ### Azure OpenAI
 
+Azure OpenAI uses `type: openai` with Azure platform authentication. The provider auto-derives the deployment URL from `platform.endpoint` and `model`:
+
 ```yaml
 # providers/azure-openai.yaml
 apiVersion: promptkit.altairalabs.ai/v1alpha1
@@ -199,17 +201,38 @@ metadata:
     provider: azure-openai
 
 spec:
-  type: azure-openai
+  type: openai
   model: gpt-4o
 
-  base_url: https://your-resource.openai.azure.com
+  platform:
+    type: azure
+    endpoint: https://your-resource.openai.azure.com
+    additional_config:
+      api_version: "2024-12-01-preview"   # optional, this is the default
 
   defaults:
     temperature: 0.6
     max_tokens: 2000
 ```
 
-Authentication uses the `AZURE_OPENAI_API_KEY` environment variable automatically.
+Authentication uses the Azure Default Credential chain automatically (Managed Identity in AKS/Azure VMs, Azure CLI, or environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`).
+
+For API key auth instead of Azure AD, use the credential field:
+
+```yaml
+spec:
+  type: openai
+  model: gpt-4o
+  platform:
+    type: azure
+    endpoint: https://your-resource.openai.azure.com
+  credential:
+    credential_env: AZURE_OPENAI_API_KEY
+```
+
+:::note
+Azure OpenAI uses the Chat Completions API. The OpenAI Responses API is not available on Azure deployments — the provider automatically falls back to Completions mode.
+:::
 
 ### Ollama (Local)
 

--- a/docs/src/content/docs/runtime/how-to/setup-providers.md
+++ b/docs/src/content/docs/runtime/how-to/setup-providers.md
@@ -244,13 +244,45 @@ result, err := provider.Predict(ctx, req)
 
 ### Azure OpenAI
 
+Use `NewProviderWithCredential` with the Azure platform and an `AzureCredential`:
+
 ```go
-provider := openai.NewProvider(
+import "github.com/AltairaLabs/PromptKit/runtime/credentials"
+
+cred, err := credentials.NewAzureCredential(ctx, "https://your-resource.openai.azure.com")
+if err != nil {
+    log.Fatal(err)
+}
+
+provider := openai.NewProviderWithCredential(
     "azure-openai",
-    "gpt-4",
-    "https://your-resource.openai.azure.com/openai/deployments/your-deployment",
+    "gpt-4o",
+    "",  // auto-derived from endpoint + model
     defaults,
     false,
+    cred,
+    "azure",
+    &providers.PlatformConfig{
+        Type:     "azure",
+        Endpoint: "https://your-resource.openai.azure.com",
+    },
+)
+```
+
+The provider auto-derives the deployment URL (`{endpoint}/openai/deployments/{model}`) and appends `?api-version=...` to requests. Azure AD auth (Managed Identity, CLI, env vars) is handled by `AzureCredential`.
+
+For API key auth, use a simple credential instead:
+
+```go
+provider := openai.NewProviderWithCredential(
+    "azure-openai",
+    "gpt-4o",
+    credentials.AzureOpenAIEndpoint("https://your-resource.openai.azure.com", "gpt-4o"),
+    defaults,
+    false,
+    credentials.NewAPIKeyCredential(os.Getenv("AZURE_OPENAI_API_KEY"), credentials.WithHeaderName("api-key"), credentials.WithPrefix("")),
+    "azure",
+    nil,
 )
 ```
 

--- a/runtime/credentials/azure_integration.go
+++ b/runtime/credentials/azure_integration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +15,17 @@ import (
 
 // tokenRefreshBuffer is the time before token expiration to trigger a refresh.
 const tokenRefreshBuffer = 5 * time.Minute
+
+// DefaultAzureAPIVersion is the default Azure OpenAI API version used when
+// platform.additional_config.api_version is not set.
+const DefaultAzureAPIVersion = "2024-12-01-preview"
+
+// AzureOpenAIEndpoint returns the base URL for an Azure OpenAI deployment.
+// The returned URL does NOT include the API path (/chat/completions) or
+// api-version query param — the provider appends those per-request.
+func AzureOpenAIEndpoint(endpoint, deployment string) string {
+	return strings.TrimRight(endpoint, "/") + "/openai/deployments/" + deployment
+}
 
 // AzureCredential implements Azure AD token-based authentication for Azure AI services.
 type AzureCredential struct {

--- a/runtime/credentials/azure_integration_test.go
+++ b/runtime/credentials/azure_integration_test.go
@@ -155,6 +155,43 @@ func TestAzureCredential_TokenRefresh(t *testing.T) {
 	assert.Equal(t, 2, mock.getCalls())
 }
 
+func TestAzureOpenAIEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpoint   string
+		deployment string
+		expected   string
+	}{
+		{
+			name:       "default api version",
+			endpoint:   "https://my-resource.openai.azure.com",
+			deployment: "gpt-4o",
+			expected:   "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+		},
+		{
+			name:       "trailing slash stripped",
+			endpoint:   "https://my-resource.openai.azure.com/",
+			deployment: "gpt-4o",
+			expected:   "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AzureOpenAIEndpoint(tt.endpoint, tt.deployment)
+			if got != tt.expected {
+				t.Errorf("AzureOpenAIEndpoint(%q, %q) = %q, want %q",
+					tt.endpoint, tt.deployment, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultAzureAPIVersion(t *testing.T) {
+	if DefaultAzureAPIVersion == "" {
+		t.Error("DefaultAzureAPIVersion must not be empty")
+	}
+}
+
 func TestAzureCredential_ConcurrentAccess(t *testing.T) {
 	mock := &mockAzureTokenCredential{
 		token: azcore.AccessToken{

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	credentials "github.com/AltairaLabs/PromptKit/runtime/credentials"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -321,6 +322,44 @@ func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
 		req.Header.Set(authorizationHeader, bearerPrefix+p.apiKey)
 	}
 	return nil
+}
+
+const azurePlatform = "azure" //nolint:unused // wired in upcoming Azure URL integration
+
+// isAzure returns true if this provider is hosted on Azure OpenAI.
+func (p *Provider) isAzure() bool { //nolint:unused // wired in upcoming Azure URL integration
+	return p.platform == azurePlatform
+}
+
+// azureAPIVersion returns the api-version query parameter for Azure OpenAI.
+func (p *Provider) azureAPIVersion() string { //nolint:unused // wired in upcoming Azure URL integration
+	if p.platformConfig != nil {
+		if v, ok := p.platformConfig.AdditionalConfig["api_version"].(string); ok && v != "" {
+			return v
+		}
+	}
+	return credentials.DefaultAzureAPIVersion
+}
+
+// chatCompletionsURL returns the Chat Completions API endpoint.
+// For Azure: {baseURL}/chat/completions?api-version={version}
+// For standard OpenAI: {baseURL}/chat/completions
+func (p *Provider) chatCompletionsURL() string { //nolint:unused // wired in upcoming Azure URL integration
+	url := p.baseURL + openAIPredictCompletionsPath
+	if p.isAzure() {
+		url += "?api-version=" + p.azureAPIVersion()
+	}
+	return url
+}
+
+// responsesURL returns the Responses API endpoint.
+// Azure OpenAI does not support the Responses API, so this falls back
+// to the Chat Completions endpoint.
+func (p *Provider) responsesURL() string { //nolint:unused // wired in upcoming Azure URL integration
+	if p.isAzure() {
+		return p.chatCompletionsURL()
+	}
+	return p.baseURL + responsesAPIPath
 }
 
 // Model returns the model name/identifier used by this provider.

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -324,15 +324,15 @@ func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
 	return nil
 }
 
-const azurePlatform = "azure" //nolint:unused // wired in upcoming Azure URL integration
+const azurePlatform = "azure"
 
 // isAzure returns true if this provider is hosted on Azure OpenAI.
-func (p *Provider) isAzure() bool { //nolint:unused // wired in upcoming Azure URL integration
+func (p *Provider) isAzure() bool {
 	return p.platform == azurePlatform
 }
 
 // azureAPIVersion returns the api-version query parameter for Azure OpenAI.
-func (p *Provider) azureAPIVersion() string { //nolint:unused // wired in upcoming Azure URL integration
+func (p *Provider) azureAPIVersion() string {
 	if p.platformConfig != nil {
 		if v, ok := p.platformConfig.AdditionalConfig["api_version"].(string); ok && v != "" {
 			return v
@@ -344,7 +344,7 @@ func (p *Provider) azureAPIVersion() string { //nolint:unused // wired in upcomi
 // chatCompletionsURL returns the Chat Completions API endpoint.
 // For Azure: {baseURL}/chat/completions?api-version={version}
 // For standard OpenAI: {baseURL}/chat/completions
-func (p *Provider) chatCompletionsURL() string { //nolint:unused // wired in upcoming Azure URL integration
+func (p *Provider) chatCompletionsURL() string {
 	url := p.baseURL + openAIPredictCompletionsPath
 	if p.isAzure() {
 		url += "?api-version=" + p.azureAPIVersion()
@@ -355,7 +355,7 @@ func (p *Provider) chatCompletionsURL() string { //nolint:unused // wired in upc
 // responsesURL returns the Responses API endpoint.
 // Azure OpenAI does not support the Responses API, so this falls back
 // to the Chat Completions endpoint.
-func (p *Provider) responsesURL() string { //nolint:unused // wired in upcoming Azure URL integration
+func (p *Provider) responsesURL() string {
 	if p.isAzure() {
 		return p.chatCompletionsURL()
 	}
@@ -906,7 +906,7 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 	}
 
 	// Make HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+openAIPredictCompletionsPath, bytes.NewReader(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.chatCompletionsURL(), bytes.NewReader(reqBody))
 	if err != nil {
 		return predictResp, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -919,7 +919,7 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 		return predictResp, hdrErr
 	}
 
-	logger.APIRequest("OpenAI", "POST", p.baseURL+openAIPredictCompletionsPath, map[string]string{
+	logger.APIRequest("OpenAI", "POST", p.chatCompletionsURL(), map[string]string{
 		contentTypeHeader:   applicationJSON,
 		authorizationHeader: "***",
 	}, openAIReq)
@@ -936,7 +936,7 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 			return predictResp, providers.ParsePlatformHTTPError(p.platform, statusCode, respBody)
 		}
 		return predictResp, &providers.ProviderHTTPError{
-			StatusCode: statusCode, URL: p.baseURL + openAIPredictCompletionsPath,
+			StatusCode: statusCode, URL: p.chatCompletionsURL(),
 			Body: string(respBody), Provider: p.ID(),
 		}
 	}
@@ -1018,7 +1018,7 @@ func (p *Provider) predictStreamWithMessages(ctx context.Context, req providers.
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := p.baseURL + openAIPredictCompletionsPath
+	url := p.chatCompletionsURL()
 	requestFn := func(ctx context.Context) (*http.Request, error) {
 		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 		if reqErr != nil {

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -178,10 +178,15 @@ func NewProviderFromConfig(cfg *ProviderConfig) *Provider {
 		unsupported = []string{"temperature", "top_p", "max_tokens"}
 	}
 
-	return &Provider{
+	baseURL := cfg.BaseURL
+	if baseURL == "" && cfg.Platform == azurePlatform && cfg.PlatformConfig != nil && cfg.PlatformConfig.Endpoint != "" {
+		baseURL = credentials.AzureOpenAIEndpoint(cfg.PlatformConfig.Endpoint, cfg.Model)
+	}
+
+	p := &Provider{
 		BaseProvider:      base,
 		model:             cfg.Model,
-		baseURL:           cfg.BaseURL,
+		baseURL:           baseURL,
 		apiKey:            apiKey,
 		credential:        cfg.Credential,
 		defaults:          cfg.Defaults,
@@ -192,6 +197,11 @@ func NewProviderFromConfig(cfg *ProviderConfig) *Provider {
 		unsupportedParams: unsupported,
 		reasoningEffort:   getReasoningEffort(cfg.AdditionalConfig),
 	}
+	// Azure OpenAI doesn't support the Responses API.
+	if p.isAzure() {
+		p.apiMode = APIModeCompletions
+	}
+	return p
 }
 
 // getReasoningEffort resolves the reasoning.effort setting for the OpenAI

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -432,7 +432,7 @@ func (p *Provider) predictWithResponses(
 	}
 
 	// Make HTTP request
-	url := p.baseURL + responsesAPIPath
+	url := p.responsesURL()
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 	if err != nil {
 		return predictResp, nil, fmt.Errorf("failed to create request: %w", err)
@@ -564,7 +564,7 @@ func (p *Provider) predictStreamWithResponses(
 	// Build request factory for OpenStreamWithRetry. Each retry rebuilds
 	// the HTTP request so that headers (especially auth) are reapplied
 	// cleanly and a fresh body reader is used.
-	url := p.baseURL + responsesAPIPath
+	url := p.responsesURL()
 	requestFn := func(ctx context.Context) (*http.Request, error) {
 		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 		if reqErr != nil {

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -100,7 +100,8 @@ type mockCredential struct {
 }
 
 func (m *mockCredential) Type() string { return m.credType }
-func (m *mockCredential) Apply(_ context.Context, _ *http.Request) error {
+func (m *mockCredential) Apply(_ context.Context, req *http.Request) error {
+	req.Header.Set("Authorization", "Bearer mock-token")
 	return nil
 }
 

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	credentials "github.com/AltairaLabs/PromptKit/runtime/credentials"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -1813,4 +1814,89 @@ func TestPredict_AudioResponse_TextContentOnly(t *testing.T) {
 	if len(resp.Parts) != 1 || resp.Parts[0].Type != types.ContentTypeText {
 		t.Errorf("expected 1 text part, got %v", resp.Parts)
 	}
+}
+
+func TestOpenAI_IsAzure(t *testing.T) {
+	tests := []struct {
+		platform string
+		expected bool
+	}{
+		{"azure", true},
+		{"bedrock", false},
+		{"", false},
+		{"vertex", false},
+	}
+	for _, tt := range tests {
+		p := &Provider{platform: tt.platform}
+		if got := p.isAzure(); got != tt.expected {
+			t.Errorf("platform=%q: isAzure() = %v, want %v", tt.platform, got, tt.expected)
+		}
+	}
+}
+
+func TestOpenAI_ChatCompletionsURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *Provider
+		expected string
+	}{
+		{
+			name:     "standard openai",
+			provider: &Provider{baseURL: "https://api.openai.com/v1"},
+			expected: "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name: "azure with default api version",
+			provider: &Provider{
+				baseURL:  "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+				platform: "azure",
+			},
+			expected: "https://my-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=" + credentials.DefaultAzureAPIVersion,
+		},
+		{
+			name: "azure with custom api version",
+			provider: &Provider{
+				baseURL:  "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+				platform: "azure",
+				platformConfig: &providers.PlatformConfig{
+					AdditionalConfig: map[string]interface{}{
+						"api_version": "2024-06-01",
+					},
+				},
+			},
+			expected: "https://my-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-06-01",
+		},
+		{
+			name:     "custom base_url (gateway)",
+			provider: &Provider{baseURL: "https://litellm.internal:4000/v1"},
+			expected: "https://litellm.internal:4000/v1/chat/completions",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.provider.chatCompletionsURL()
+			if got != tt.expected {
+				t.Errorf("chatCompletionsURL() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOpenAI_ResponsesURL(t *testing.T) {
+	t.Run("standard openai", func(t *testing.T) {
+		p := &Provider{baseURL: "https://api.openai.com/v1"}
+		if got := p.responsesURL(); got != "https://api.openai.com/v1/responses" {
+			t.Errorf("responsesURL() = %q, want standard path", got)
+		}
+	})
+	t.Run("azure falls back to chat completions", func(t *testing.T) {
+		p := &Provider{
+			baseURL:  "https://r.openai.azure.com/openai/deployments/gpt-4o",
+			platform: "azure",
+		}
+		expected := "https://r.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=" + credentials.DefaultAzureAPIVersion
+		if got := p.responsesURL(); got != expected {
+			t.Errorf("responsesURL() = %q, want %q", got, expected)
+		}
+	})
 }

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1883,6 +1883,58 @@ func TestOpenAI_ChatCompletionsURL(t *testing.T) {
 	}
 }
 
+func TestOpenAI_AzureBaseURLAutoDerive(t *testing.T) {
+	t.Run("derives base_url from platform endpoint and model", func(t *testing.T) {
+		cred := &mockCredential{credType: "azure"}
+		pc := &providers.PlatformConfig{
+			Type:     "azure",
+			Endpoint: "https://my-resource.openai.azure.com",
+		}
+		provider := NewProviderWithCredential(
+			"test", "gpt-4o", "", // empty base_url
+			providers.ProviderDefaults{Temperature: 0.7},
+			false, cred, "azure", pc,
+		)
+		expected := "https://my-resource.openai.azure.com/openai/deployments/gpt-4o"
+		if provider.baseURL != expected {
+			t.Errorf("baseURL = %q, want %q", provider.baseURL, expected)
+		}
+	})
+
+	t.Run("explicit base_url takes precedence", func(t *testing.T) {
+		cred := &mockCredential{credType: "azure"}
+		pc := &providers.PlatformConfig{
+			Type:     "azure",
+			Endpoint: "https://my-resource.openai.azure.com",
+		}
+		provider := NewProviderWithCredential(
+			"test", "gpt-4o", "https://custom.example.com/v1",
+			providers.ProviderDefaults{Temperature: 0.7},
+			false, cred, "azure", pc,
+		)
+		if provider.baseURL != "https://custom.example.com/v1" {
+			t.Errorf("baseURL = %q, want explicit override", provider.baseURL)
+		}
+	})
+}
+
+func TestOpenAI_AzureForcesCompletionsMode(t *testing.T) {
+	cred := &mockCredential{credType: "azure"}
+	pc := &providers.PlatformConfig{
+		Type:     "azure",
+		Endpoint: "https://my-resource.openai.azure.com",
+	}
+	// gpt-4.1 would normally get APIModeResponses
+	provider := NewProviderWithCredential(
+		"test", "gpt-4.1", "",
+		providers.ProviderDefaults{Temperature: 0.7},
+		false, cred, "azure", pc,
+	)
+	if provider.apiMode != APIModeCompletions {
+		t.Errorf("apiMode = %v, want APIModeCompletions for Azure", provider.apiMode)
+	}
+}
+
 func TestOpenAI_ResponsesURL(t *testing.T) {
 	t.Run("standard openai", func(t *testing.T) {
 		p := &Provider{baseURL: "https://api.openai.com/v1"}

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -494,7 +494,43 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte) (providers.Prediction
 
 // makeRequest makes an HTTP request to the OpenAI API
 func (p *ToolProvider) makeRequest(ctx context.Context, request interface{}) ([]byte, error) {
-	url := p.baseURL + openAIPredictCompletionsPath
+	url := p.chatCompletionsURL()
+	if p.credential != nil {
+		reqBytes, err := json.Marshal(request)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request: %w", err)
+		}
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBytes))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+			return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+		}
+		if hdrErr := p.ApplyCustomHeaders(httpReq); hdrErr != nil {
+			return nil, hdrErr
+		}
+		resp, doErr := p.GetHTTPClient().Do(httpReq)
+		if doErr != nil {
+			return nil, &providers.ProviderTransportError{Cause: doErr, Provider: p.ID()}
+		}
+		defer resp.Body.Close()
+		body, readErr := providers.ReadResponseBody(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read response: %w", readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			if p.platform != "" {
+				return nil, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, body)
+			}
+			return nil, &providers.ProviderHTTPError{
+				StatusCode: resp.StatusCode, URL: url,
+				Body: string(body), Provider: p.ID(),
+			}
+		}
+		return body, nil
+	}
 	headers := providers.RequestHeaders{
 		contentTypeHeader:   applicationJSON,
 		authorizationHeader: bearerPrefix + p.apiKey,
@@ -547,14 +583,16 @@ func (p *ToolProvider) predictStreamWithCompletions(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := p.baseURL + openAIPredictCompletionsPath
+	url := p.chatCompletionsURL()
 	requestFn := func(ctx context.Context) (*http.Request, error) {
 		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 		if reqErr != nil {
 			return nil, fmt.Errorf("failed to create request: %w", reqErr)
 		}
 		httpReq.Header.Set(contentTypeHeader, applicationJSON)
-		httpReq.Header.Set(authorizationHeader, bearerPrefix+p.apiKey)
+		if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+			return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+		}
 		httpReq.Header.Set("Accept", "text/event-stream")
 		if hdrErr := p.ApplyCustomHeaders(httpReq); hdrErr != nil {
 			return nil, hdrErr

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -4,16 +4,26 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// failingCredential is a credential that always returns an error.
+type failingCredential struct{}
+
+func (f *failingCredential) Type() string { return "failing" }
+func (f *failingCredential) Apply(_ context.Context, _ *http.Request) error {
+	return fmt.Errorf("credential expired")
+}
 
 // ============================================================================
 // NewToolProvider Tests
@@ -1324,5 +1334,85 @@ func TestToolProvider_MakeRequest_UsesApplyAuth(t *testing.T) {
 	authHeader := capturedHeaders.Get("Authorization")
 	if authHeader != "Bearer mock-token" {
 		t.Errorf("tool provider should use applyAuth (credential) not hardcoded apiKey, got %q", authHeader)
+	}
+}
+
+func TestToolProvider_MakeRequest_CredentialPath_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer server.Close()
+
+	cred := &mockCredential{credType: "azure"}
+	provider := NewToolProviderWithCredential(
+		"test", "gpt-4o", server.URL, providers.ProviderDefaults{Temperature: 0.7},
+		false, map[string]any{"api_mode": "completions"}, cred, "", nil, nil,
+	)
+
+	_, _, err := provider.PredictWithTools(
+		context.Background(),
+		providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "hello"}}},
+		nil, "",
+	)
+	if err == nil {
+		t.Fatal("expected error for 429 response")
+	}
+	var httpErr *providers.ProviderHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected ProviderHTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", httpErr.StatusCode)
+	}
+}
+
+func TestToolProvider_MakeRequest_CredentialPath_PlatformError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message":"service unavailable"}`))
+	}))
+	defer server.Close()
+
+	cred := &mockCredential{credType: "azure"}
+	provider := NewToolProviderWithCredential(
+		"test", "gpt-4o", server.URL, providers.ProviderDefaults{Temperature: 0.7},
+		false, map[string]any{"api_mode": "completions"}, cred, "azure", nil, nil,
+	)
+
+	_, _, err := provider.PredictWithTools(
+		context.Background(),
+		providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "hello"}}},
+		nil, "",
+	)
+	if err == nil {
+		t.Fatal("expected error for 503 response")
+	}
+	var httpErr *providers.ProviderHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected ProviderHTTPError, got %T: %v", err, err)
+	}
+	if httpErr.URL != "azure" {
+		t.Errorf("URL = %q, want platform name 'azure'", httpErr.URL)
+	}
+}
+
+func TestToolProvider_MakeRequest_CredentialPath_AuthError(t *testing.T) {
+	cred := &failingCredential{}
+	provider := NewToolProviderWithCredential(
+		"test", "gpt-4o", "http://localhost:1", providers.ProviderDefaults{Temperature: 0.7},
+		false, map[string]any{"api_mode": "completions"}, cred, "", nil, nil,
+	)
+
+	_, _, err := provider.PredictWithTools(
+		context.Background(),
+		providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "hello"}}},
+		nil, "",
+	)
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	if !strings.Contains(err.Error(), "apply authentication") {
+		t.Errorf("error = %q, want auth failure message", err.Error())
 	}
 }

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -1295,3 +1295,34 @@ func TestToolProvider_PredictStreamWithTools_Retries503(t *testing.T) {
 		t.Errorf("Expected at least 2 attempts, got %d", attempts)
 	}
 }
+
+func TestToolProvider_MakeRequest_UsesApplyAuth(t *testing.T) {
+	var capturedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"}}]}`))
+	}))
+	defer server.Close()
+
+	cred := &mockCredential{credType: "azure"}
+	provider := NewToolProviderWithCredential(
+		"test", "gpt-4o", server.URL, providers.ProviderDefaults{Temperature: 0.7},
+		false, map[string]any{"api_mode": "completions"}, cred, "azure", nil, nil,
+	)
+
+	resp, _, err := provider.PredictWithTools(
+		context.Background(),
+		providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "hello"}}},
+		nil, "",
+	)
+	_ = resp
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	authHeader := capturedHeaders.Get("Authorization")
+	if authHeader != "Bearer mock-token" {
+		t.Errorf("tool provider should use applyAuth (credential) not hardcoded apiKey, got %q", authHeader)
+	}
+}


### PR DESCRIPTION
## Summary

- **Azure OpenAI as a first-class platform** on the OpenAI provider, matching Bedrock parity — `platform.type: azure` + `endpoint` auto-derives URLs, auth, and API version
- **Fix validator `message` field** not surviving pack compilation or reaching the guardrail adapter at runtime (#937 bugs 2+3)
- **Fix ToolProvider auth bypass** — two call sites hardcoded `bearerPrefix + apiKey` instead of using `applyAuth()`, breaking all credential-based auth (Azure AD, AWS SigV4) on the tool-capable code path

### Azure OpenAI platform support

Config is now:
```yaml
spec:
  type: openai
  model: gpt-4o
  platform:
    type: azure
    endpoint: https://your-resource.openai.azure.com
```

Everything else (deployment URL, `api-version` query param, Azure AD auth via DefaultAzureCredential chain) is automatic. API key auth also supported via `credential.credential_env`.

Key changes:
- `AzureOpenAIEndpoint()` helper + `DefaultAzureAPIVersion` const in credentials package
- `isAzure()`, `chatCompletionsURL()`, `responsesURL()` methods on OpenAI provider
- Auto-derive `base_url` from `platform.endpoint` + `model` when not explicitly set
- Force `APIModeCompletions` on Azure (Responses API not available)
- All 6 URL construction sites and 2 auth sites in the OpenAI provider now use the new methods

### Validator message fix (#937)

- `packc` now folds `ValidatorConfig.Message` into `Params["message"]` during compilation, conforming to the authoritative promptpack schema
- SDK's `convertPackValidatorsToHooks` now reads `params["message"]` and passes `WithMessage()` to the guardrail adapter
- Docs: Azure OpenAI config updated in both arena and runtime how-to guides, guardrails reference updated

## Test plan

- [ ] `go test ./runtime/credentials/... -race` — AzureOpenAIEndpoint, DefaultAzureAPIVersion
- [ ] `go test ./runtime/providers/openai/... -race` — isAzure, chatCompletionsURL, responsesURL, base URL auto-derive, Completions mode forcing, ToolProvider auth via applyAuth
- [ ] `go test ./runtime/prompt/... -count=1` — validator message folding during pack compilation
- [ ] `go test ./sdk/... -count=1` — WithMessage from params, default message fallback
- [ ] `golangci-lint run --new-from-rev=main` — 0 issues on new code

Closes #937 (bugs 2 and 3)