### PR TITLE
fix(providers): Responses API tool call args dropped when delta uses output_index

### DIFF
--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -744,15 +744,17 @@ func (p *Provider) handleFuncArgsDelta(
 	idMap itemIDMap,
 ) []types.MessageToolCall {
 	var delta struct {
-		CallID string `json:"call_id"`
-		ItemID string `json:"item_id"`
-		Delta  string `json:"delta"`
+		CallID      string `json:"call_id"`
+		ItemID      string `json:"item_id"`
+		OutputIndex *int   `json:"output_index"`
+		Delta       string `json:"delta"`
 	}
 	if err := json.Unmarshal([]byte(data), &delta); err != nil {
 		return toolCalls
 	}
 
-	// Look up the tool call index from the ID map (matches item_id or call_id)
+	// Look up the tool call index: try item_id, then call_id, then output_index.
+	// The Responses API may send only output_index in delta events.
 	idx := -1
 	if delta.ItemID != "" {
 		if i, ok := idMap[delta.ItemID]; ok {
@@ -761,6 +763,11 @@ func (p *Provider) handleFuncArgsDelta(
 	}
 	if idx < 0 && delta.CallID != "" {
 		if i, ok := idMap[delta.CallID]; ok {
+			idx = i
+		}
+	}
+	if idx < 0 && delta.OutputIndex != nil {
+		if i, ok := idMap[outputIndexKey(*delta.OutputIndex)]; ok {
 			idx = i
 		}
 	}
@@ -779,14 +786,21 @@ func (p *Provider) handleFuncArgsDelta(
 
 // itemIDMap tracks the mapping from Responses API item_id (fc_...) to the
 // index in the toolCalls slice, enabling delta events to find their tool call.
+// Also maps output_index (as "idx:N") for delta events that lack item_id/call_id.
 type itemIDMap map[string]int
+
+// outputIndexKey returns the idMap key for an output_index value.
+func outputIndexKey(idx int) string {
+	return fmt.Sprintf("idx:%d", idx)
+}
 
 // handleOutputAdded processes output item added events
 func (p *Provider) handleOutputAdded(
 	data string, toolCalls []types.MessageToolCall, idMap itemIDMap,
 ) []types.MessageToolCall {
 	var item struct {
-		Item struct {
+		OutputIndex *int `json:"output_index"`
+		Item        struct {
 			Type   string `json:"type"`
 			ID     string `json:"id"`
 			CallID string `json:"call_id"`
@@ -801,12 +815,16 @@ func (p *Provider) handleOutputAdded(
 				Name: item.Item.Name,
 				Args: json.RawMessage(""), // Will be populated by delta events
 			})
-			// Map both id and call_id to this index for delta matching
+			// Map id, call_id, and output_index to this index for delta matching.
+			// Delta events may use any of these to reference the tool call.
 			if item.Item.ID != "" {
 				idMap[item.Item.ID] = idx
 			}
 			if item.Item.CallID != "" {
 				idMap[item.Item.CallID] = idx
+			}
+			if item.OutputIndex != nil {
+				idMap[outputIndexKey(*item.OutputIndex)] = idx
 			}
 		}
 	}

--- a/runtime/providers/openai/openai_responses_integration_test.go
+++ b/runtime/providers/openai/openai_responses_integration_test.go
@@ -2,8 +2,11 @@ package openai
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -239,3 +242,135 @@ func TestHandleStreamEvent_AudioDone(t *testing.T) {
 		// expected — no chunk
 	}
 }
+
+// --- #940 regression tests: tool call argument accumulation ---
+
+func TestHandleFuncArgsDelta_IDMatching(t *testing.T) {
+	p := &Provider{}
+
+	outputAddedData := `{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_abc123","call_id":"call_xyz789","name":"lookup_order","arguments":"","status":"in_progress"}}`
+
+	idMap := make(itemIDMap)
+	toolCalls := p.handleOutputAdded(outputAddedData, nil, idMap)
+
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(toolCalls))
+	}
+	if toolCalls[0].Name != "lookup_order" {
+		t.Errorf("name = %q, want lookup_order", toolCalls[0].Name)
+	}
+
+	// Verify all three IDs are mapped
+	if _, ok := idMap["fc_abc123"]; !ok {
+		t.Error("idMap missing fc_abc123 (item.id)")
+	}
+	if _, ok := idMap["call_xyz789"]; !ok {
+		t.Error("idMap missing call_xyz789 (item.call_id)")
+	}
+	if _, ok := idMap["idx:0"]; !ok {
+		t.Error("idMap missing idx:0 (output_index)")
+	}
+
+	// Delta using item_id
+	delta1 := `{"type":"response.function_call_arguments.delta","item_id":"fc_abc123","output_index":0,"delta":"{\"order_id\":"}`
+	toolCalls = p.handleFuncArgsDelta(delta1, toolCalls, idMap)
+
+	delta2 := `{"type":"response.function_call_arguments.delta","item_id":"fc_abc123","output_index":0,"delta":"\"1023\"}"}`
+	toolCalls = p.handleFuncArgsDelta(delta2, toolCalls, idMap)
+
+	expected := `{"order_id":"1023"}`
+	if string(toolCalls[0].Args) != expected {
+		t.Errorf("args = %q, want %q", string(toolCalls[0].Args), expected)
+	}
+}
+
+func TestHandleFuncArgsDelta_OutputIndexOnly(t *testing.T) {
+	// Reproduce #940: delta events may only have output_index, not item_id or call_id.
+	p := &Provider{}
+
+	idMap := make(itemIDMap)
+	toolCalls := p.handleOutputAdded(
+		`{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_abc123","call_id":"call_xyz789","name":"lookup_order"}}`,
+		nil, idMap,
+	)
+
+	// Delta with output_index but NO item_id or call_id
+	deltaData := `{"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"order_id\":\"1023\"}"}`
+	toolCalls = p.handleFuncArgsDelta(deltaData, toolCalls, idMap)
+
+	expected := `{"order_id":"1023"}`
+	if string(toolCalls[0].Args) != expected {
+		t.Errorf("output_index-only delta: args = %q, want %q", string(toolCalls[0].Args), expected)
+	}
+}
+
+func TestHandleFuncArgsDelta_CallIDFallback(t *testing.T) {
+	p := &Provider{}
+
+	idMap := make(itemIDMap)
+	toolCalls := p.handleOutputAdded(
+		`{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_abc","call_id":"call_xyz","name":"get_weather"}}`,
+		nil, idMap,
+	)
+
+	deltaData := `{"type":"response.function_call_arguments.delta","call_id":"call_xyz","delta":"{\"city\":\"London\"}"}`
+	toolCalls = p.handleFuncArgsDelta(deltaData, toolCalls, idMap)
+
+	if string(toolCalls[0].Args) != `{"city":"London"}` {
+		t.Errorf("call_id fallback: args = %q", string(toolCalls[0].Args))
+	}
+}
+
+func TestStreamResponsesResponse_ToolCallAccumulation(t *testing.T) {
+	sseStream := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_abc123","call_id":"call_xyz789","name":"lookup_order","arguments":"","status":"in_progress"}}`,
+		``,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_abc123","output_index":0,"delta":"{\"order_id\":"}`,
+		``,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_abc123","output_index":0,"delta":"\"1023\"}"}`,
+		``,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_abc123","call_id":"call_xyz789","name":"lookup_order","arguments":"{\"order_id\":\"1023\"}","status":"completed"}],"usage":{"input_tokens":10,"output_tokens":5}}}`,
+		``,
+	}, "\n")
+
+	p := &Provider{}
+	body := io.NopCloser(strings.NewReader(sseStream))
+	ctx := context.Background()
+	outChan := make(chan providers.StreamChunk, 10)
+
+	go p.streamResponsesResponse(ctx, body, outChan)
+
+	var chunks []providers.StreamChunk
+	for chunk := range outChan {
+		chunks = append(chunks, chunk)
+	}
+
+	var toolCallChunk *providers.StreamChunk
+	for i := range chunks {
+		if len(chunks[i].ToolCalls) > 0 {
+			toolCallChunk = &chunks[i]
+			break
+		}
+	}
+
+	if toolCallChunk == nil {
+		t.Fatal("no chunk with tool calls found")
+	}
+	if len(toolCallChunk.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(toolCallChunk.ToolCalls))
+	}
+
+	tc := toolCallChunk.ToolCalls[0]
+	if tc.Name != "lookup_order" {
+		t.Errorf("name = %q, want lookup_order", tc.Name)
+	}
+
+	expectedArgs := `{"order_id":"1023"}`
+	if string(tc.Args) != expectedArgs {
+		t.Errorf("args = %q, want %q", string(tc.Args), expectedArgs)
+	}
+}
+
+// Ensure unused imports are referenced
+var _ = json.Marshal
+var _ = context.Background


### PR DESCRIPTION
## Summary

- Fix tool call arguments silently dropped during OpenAI Responses API streaming when delta events use `output_index` instead of `item_id`/`call_id`
- Add `output_index` as a third fallback key in the delta-to-tool-call mapping

## Root Cause

`handleFuncArgsDelta` matched delta events to tool calls using only `item_id` and `call_id`. The OpenAI Responses API can send `response.function_call_arguments.delta` events with only `output_index` — when this happens, the ID lookup fails silently, args stay as `json.RawMessage("")` (serializes to `null`), and the tool validator fails with EOF.

## Fix

- `handleOutputAdded` now stores `output_index` (as `"idx:N"`) in the `idMap` alongside `item.id` and `item.call_id`
- `handleFuncArgsDelta` falls back to `output_index` when both `item_id` and `call_id` lookups miss

## Test plan

- [ ] `TestHandleFuncArgsDelta_OutputIndexOnly` — reproduces the exact #940 failure: delta with only output_index, no item_id/call_id
- [ ] `TestHandleFuncArgsDelta_IDMatching` — verifies all three ID types are stored in idMap
- [ ] `TestHandleFuncArgsDelta_CallIDFallback` — call_id-only delta
- [ ] `TestStreamResponsesResponse_ToolCallAccumulation` — end-to-end SSE stream with full tool call lifecycle

Closes #940