### PR TITLE
feat(evals): tools_called require_args param to catch empty tool arguments

### DIFF
--- a/examples/capability-matrix/scenarios/streaming-tools.scenario.yaml
+++ b/examples/capability-matrix/scenarios/streaming-tools.scenario.yaml
@@ -22,7 +22,8 @@ spec:
       content: "Call the get_weather function for New York City and tell me the result."
       assertions:
         - type: tools_called
-          message: "Should call the get_weather tool"
+          message: "Should call the get_weather tool with arguments"
           params:
             tools:
               - "get_weather"
+            require_args: true

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -590,6 +590,69 @@ func TestToolsCalledHandler_MixedSuccessAndError(t *testing.T) {
 	}
 }
 
+func TestToolsCalledHandler_RequireArgs_Pass(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "lookup_order", Arguments: map[string]any{"order_id": "1023"}},
+		},
+	}
+	params := map[string]any{
+		"tools":        []any{"lookup_order"},
+		"require_args": true,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !(result.Score != nil && *result.Score >= 1.0) {
+		t.Fatalf("expected pass: tool has non-empty args: %s", result.Explanation)
+	}
+}
+
+func TestToolsCalledHandler_RequireArgs_FailEmpty(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "lookup_order", Arguments: nil},
+		},
+	}
+	params := map[string]any{
+		"tools":        []any{"lookup_order"},
+		"require_args": true,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score != nil && *result.Score >= 1.0 {
+		t.Fatal("expected fail: tool has nil args with require_args=true")
+	}
+}
+
+func TestToolsCalledHandler_RequireArgs_DefaultFalse(t *testing.T) {
+	// Without require_args, nil args should still count as called
+	h := &ToolsCalledHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "lookup_order", Arguments: nil},
+		},
+	}
+	params := map[string]any{
+		"tools": []any{"lookup_order"},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !(result.Score != nil && *result.Score >= 1.0) {
+		t.Fatalf("expected pass: require_args defaults to false: %s", result.Explanation)
+	}
+}
+
 // --- ToolsNotCalled ---
 
 func TestToolsNotCalledHandler_Type(t *testing.T) {

--- a/runtime/evals/handlers/tools_called.go
+++ b/runtime/evals/handlers/tools_called.go
@@ -18,6 +18,7 @@ import (
 //   - tool_names/tools []string — required tool names
 //   - min_calls int — minimum calls per tool (default 1)
 //   - ignore_validation bool — count validation failures as successful (default false)
+//   - require_args bool — only count calls with non-empty arguments (default false)
 type ToolsCalledHandler struct{}
 
 // Type returns the eval type identifier.
@@ -43,7 +44,8 @@ func (h *ToolsCalledHandler) Eval(
 
 	minCalls := extractInt(params, "min_calls", 1)
 	ignoreValidation := extractBool(params, "ignore_validation")
-	callCounts := buildCallCounts(evalCtx.ToolCalls, ignoreValidation)
+	requireArgs := extractBool(params, "require_args")
+	callCounts := buildCallCounts(evalCtx.ToolCalls, ignoreValidation, requireArgs)
 
 	return h.checkToolCalls(toolNames, callCounts, minCalls)
 }
@@ -91,12 +93,13 @@ func (h *ToolsCalledHandler) checkToolCalls(
 // buildCallCounts counts how many times each tool was called successfully.
 // A call is considered successful when it has no error, or when
 // ignoreValidation is true and the error is a validation failure.
+// When requireArgs is true, calls with nil/empty arguments are not counted.
 func buildCallCounts(
-	toolCalls []evals.ToolCallRecord, ignoreValidation bool,
+	toolCalls []evals.ToolCallRecord, ignoreValidation, requireArgs bool,
 ) map[string]int {
 	counts := make(map[string]int)
 	for i := range toolCalls {
-		if !shouldCountCall(&toolCalls[i], ignoreValidation) {
+		if !shouldCountCall(&toolCalls[i], ignoreValidation, requireArgs) {
 			continue
 		}
 		counts[toolCalls[i].ToolName]++
@@ -105,14 +108,14 @@ func buildCallCounts(
 }
 
 // shouldCountCall determines whether a tool call should be counted as successful.
-func shouldCountCall(tc *evals.ToolCallRecord, ignoreValidation bool) bool {
-	if tc.Error == "" {
-		return true // no error = success
+func shouldCountCall(tc *evals.ToolCallRecord, ignoreValidation, requireArgs bool) bool {
+	if tc.Error != "" && (!ignoreValidation || tc.ErrorType != types.ToolErrorValidation) {
+		return false
 	}
-	if ignoreValidation && tc.ErrorType == types.ToolErrorValidation {
-		return true // validation error but caller opted to ignore
+	if requireArgs && len(tc.Arguments) == 0 {
+		return false
 	}
-	return false
+	return true
 }
 
 // extractInt extracts an int from params with a default value.


### PR DESCRIPTION
## Summary

- Add `require_args: true` param to `tools_called` assertion handler
- Only counts tool calls with non-empty arguments when enabled
- Update capability matrix `streaming-tools` scenario to use it

## Context

Issue #940 revealed that tool call arguments can be silently dropped during Responses API streaming. The `tools_called` assertion passed because it only checks tool names, not argument correctness. This meant the capability matrix didn't catch the regression.

## Changes

- `tools_called` handler: new `require_args` param (default false for backward compat)
- `shouldCountCall`: skip calls with `nil`/empty `Arguments` when `requireArgs` is true
- `streaming-tools.scenario.yaml`: enabled `require_args: true`

## Test plan

- [ ] `TestToolsCalledHandler_RequireArgs_Pass` — tool with args passes
- [ ] `TestToolsCalledHandler_RequireArgs_FailEmpty` — tool with nil args fails
- [ ] `TestToolsCalledHandler_RequireArgs_DefaultFalse` — backward compat: nil args still pass without the flag
- [ ] All existing `TestToolsCalledHandler_*` tests pass (no regressions)

Closes #943