### PR TITLE
feat(arena): seed_memories — pre-populate memory store before scenario execution

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -614,6 +614,18 @@ type Scenario struct {
 	// Trials is the number of times to execute this scenario for statistical evaluation.
 	// When > 1, assertion results are aggregated across trials using pass rates and flakiness scores.
 	Trials int `json:"trials,omitempty" yaml:"trials,omitempty" jsonschema:"description=Number of times to run this scenario for statistical evaluation"` //nolint:lll
+	// SeedMemories pre-populates the memory store before the first turn.
+	// Uses the same fields as memory__remember: content (required), type, confidence, metadata.
+	SeedMemories []SeedMemoryEntry `json:"seed_memories,omitempty" yaml:"seed_memories,omitempty"`
+}
+
+// SeedMemoryEntry defines a memory to pre-populate before scenario execution.
+// Fields match the memory__remember tool arguments.
+type SeedMemoryEntry struct {
+	Content    string         `json:"content" yaml:"content"`
+	Type       string         `json:"type,omitempty" yaml:"type,omitempty"`
+	Confidence float64        `json:"confidence,omitempty" yaml:"confidence,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 // ShouldStreamTurn returns whether streaming should be used for a specific turn.

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -388,9 +388,12 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 
 	// Prepare workflow scenarios: shallow-copy to avoid mutating the shared
 	// scenario, then set TaskType from state machine and wire metadata.
-	// Register per-run memory scope if memory is enabled
+	// Register per-run memory scope and seed memories if configured
 	if e.memoryStore != nil {
-		e.registerMemoryForRun(combo.ScenarioID, runID)
+		scope := e.registerMemoryForRun(combo.ScenarioID, runID)
+		if err := e.seedMemoriesForRun(scenario, scope); err != nil {
+			return saveError(fmt.Sprintf("failed to seed memories: %v", err))
+		}
 	}
 
 	var workflowOrch *EvalOrchestrator

--- a/tools/arena/engine/execution_memory_integration.go
+++ b/tools/arena/engine/execution_memory_integration.go
@@ -1,6 +1,10 @@
 package engine
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/memory"
 )
@@ -28,9 +32,9 @@ func (e *Engine) initMemory() error {
 
 // registerMemoryForRun creates a per-run memory executor with scope isolation.
 // Called before each scenario execution to ensure memory is scoped to the run.
-func (e *Engine) registerMemoryForRun(scenarioID, runID string) {
+func (e *Engine) registerMemoryForRun(scenarioID, runID string) map[string]string {
 	if e.memoryStore == nil {
-		return
+		return nil
 	}
 	scope := map[string]string{
 		"scenario": scenarioID,
@@ -38,4 +42,40 @@ func (e *Engine) registerMemoryForRun(scenarioID, runID string) {
 	}
 	exec := memory.NewExecutor(e.memoryStore, scope)
 	e.toolRegistry.RegisterExecutor(exec)
+	return scope
+}
+
+// seedMemoriesForRun pre-populates the memory store with seed entries from the
+// scenario config. Called after registerMemoryForRun and before the first turn.
+func (e *Engine) seedMemoriesForRun(scenario *config.Scenario, scope map[string]string) error {
+	if e.memoryStore == nil || len(scenario.SeedMemories) == 0 {
+		return nil
+	}
+	ctx := context.Background()
+	for i, entry := range scenario.SeedMemories {
+		if entry.Content == "" {
+			return fmt.Errorf("seed_memories[%d]: empty content", i)
+		}
+		memType := entry.Type
+		if memType == "" {
+			memType = "general"
+		}
+		confidence := entry.Confidence
+		if confidence <= 0 {
+			confidence = 0.8
+		}
+		m := &memory.Memory{
+			Type:       memType,
+			Content:    entry.Content,
+			Confidence: confidence,
+			Metadata:   entry.Metadata,
+			Scope:      scope,
+		}
+		m.SetProvenance(memory.ProvenanceOperatorCurated)
+		if err := e.memoryStore.Save(ctx, m); err != nil {
+			return fmt.Errorf("seed_memories[%d]: %w", i, err)
+		}
+	}
+	logger.Info("Seeded memories for scenario", "scenario", scenario.ID, "count", len(scenario.SeedMemories))
+	return nil
 }

--- a/tools/arena/engine/execution_memory_integration_test.go
+++ b/tools/arena/engine/execution_memory_integration_test.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedMemoriesForRun(t *testing.T) {
+	store := memory.NewInMemoryStore()
+
+	eng := &Engine{
+		memoryStore: store,
+	}
+
+	scenario := &config.Scenario{
+		ID: "test-scenario",
+		SeedMemories: []config.SeedMemoryEntry{
+			{
+				Content: "Customer prefers dark mode.",
+			},
+			{
+				Content:    "Order #1023 was delayed 5 days.",
+				Type:       "episodic",
+				Confidence: 0.95,
+				Metadata:   map[string]any{"tags": []string{"order-1023"}},
+			},
+		},
+	}
+
+	scope := map[string]string{"scenario": "test-scenario", "run": "run-1"}
+	err := eng.seedMemoriesForRun(scenario, scope)
+	require.NoError(t, err)
+
+	// Verify memories were saved with correct scope
+	memories, err := store.List(t.Context(), scope, memory.ListOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, memories, 2)
+
+	// First memory — defaults applied
+	assert.Equal(t, "Customer prefers dark mode.", memories[0].Content)
+	assert.Equal(t, "general", memories[0].Type)
+	assert.Equal(t, 0.8, memories[0].Confidence)
+	assert.Equal(t, scope, memories[0].Scope)
+
+	// Second memory — explicit values preserved
+	assert.Equal(t, "Order #1023 was delayed 5 days.", memories[1].Content)
+	assert.Equal(t, "episodic", memories[1].Type)
+	assert.Equal(t, 0.95, memories[1].Confidence)
+	assert.Contains(t, memories[1].Metadata, "tags")
+}
+
+func TestSeedMemoriesForRun_NoMemoryStore(t *testing.T) {
+	eng := &Engine{memoryStore: nil}
+	scenario := &config.Scenario{
+		SeedMemories: []config.SeedMemoryEntry{{Content: "test"}},
+	}
+	// Should be a no-op, not an error
+	err := eng.seedMemoriesForRun(scenario, nil)
+	assert.NoError(t, err)
+}
+
+func TestSeedMemoriesForRun_EmptySeeds(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	eng := &Engine{memoryStore: store}
+	scenario := &config.Scenario{}
+
+	err := eng.seedMemoriesForRun(scenario, map[string]string{"run": "1"})
+	assert.NoError(t, err)
+
+	memories, _ := store.List(t.Context(), map[string]string{"run": "1"}, memory.ListOptions{Limit: 10})
+	assert.Empty(t, memories)
+}
+
+func TestSeedMemoriesForRun_EmptyContent(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	eng := &Engine{memoryStore: store}
+	scenario := &config.Scenario{
+		SeedMemories: []config.SeedMemoryEntry{{Content: ""}},
+	}
+
+	err := eng.seedMemoriesForRun(scenario, map[string]string{"run": "1"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty content")
+}


### PR DESCRIPTION
## Summary

- Add `seed_memories` field to Scenario config for pre-populating the memory store
- Uses same fields as `memory__remember`: `content` (required), `type`, `confidence`, `metadata`
- Memories are scoped per-run and use `ProvenanceOperatorCurated` provenance

## Problem

Scenarios modeling returning customers (e.g., "Sarah comes back to thank the agent") start with an empty memory store. There's no way to simulate prior session context that `memory__recall` should find.

## Design

```yaml
spec:
  seed_memories:
    - content: "Sarah Chen contacted support about order #1023. Agent issued EXPRESS_UPGRADE."
      metadata:
        tags: [sarah-chen, order-1023, resolved]
    - content: "Sarah prefers email over phone for follow-ups."
  turns:
    - role: user
      content: "Hi, I'm back — the dress arrived this morning!"
```

Engine behavior: after `registerMemoryForRun()` creates the per-run scope, iterates `seed_memories`, calls `store.Save()` for each with the run's scope. No changes to `memory__recall`/`memory__remember` — seeded entries are just pre-existing rows.

## Test plan

- [ ] `TestSeedMemoriesForRun` — seeds 2 memories, verifies content/type/confidence/scope/metadata
- [ ] `TestSeedMemoriesForRun_NoMemoryStore` — no-op when memory not enabled
- [ ] `TestSeedMemoriesForRun_EmptySeeds` — no-op with no seed entries
- [ ] `TestSeedMemoriesForRun_EmptyContent` — error on empty content
- [ ] Full arena engine test suite passes

Closes #946