### PR TITLE
fix(arena): wire preloaded skill instructions and skills index into prompts

### DIFF
--- a/examples/workflow-skills/config.arena.yaml
+++ b/examples/workflow-skills/config.arena.yaml
@@ -21,7 +21,16 @@ spec:
     - file: scenarios/orders-flow.scenario.yaml
 
   skills:
-    - path: skills/
+    # brand-voice is preloaded — its instructions are injected into the
+    # system prompt from turn 1 without requiring skill__activate.
+    - path: skills/brand-voice
+      preload: true
+    # Remaining skills are on-demand — the LLM can discover them from the
+    # skill__activate tool description (which includes the available-skills
+    # index) and activate them when needed.
+    - path: skills/billing
+    - path: skills/orders
+    - path: skills/escalation
 
   workflow:
     version: 1

--- a/tools/arena/engine/builder_additional_test.go
+++ b/tools/arena/engine/builder_additional_test.go
@@ -271,7 +271,7 @@ func TestNewConversationExecutor_WithSelfPlay(t *testing.T) {
 	providerRegistry := providers.NewRegistry()
 	providerRegistry.Register(mock.NewProvider("mock-assistant", "mock-model", false))
 
-	executor, adapterReg, err := newConversationExecutor(cfg, nil, nil, nil, providerRegistry, nil)
+	executor, adapterReg, err := newConversationExecutor(cfg, nil, nil, nil, providerRegistry, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, executor)
 	require.NotNil(t, adapterReg)
@@ -393,7 +393,7 @@ func TestNewConversationExecutor_WithoutSelfPlay(t *testing.T) {
 	// Empty provider registry (no self-play, so not used)
 	providerRegistry := providers.NewRegistry()
 
-	executor, adapterReg, err := newConversationExecutor(cfg, nil, nil, nil, providerRegistry, nil)
+	executor, adapterReg, err := newConversationExecutor(cfg, nil, nil, nil, providerRegistry, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, executor)
 	require.NotNil(t, adapterReg)
@@ -468,20 +468,59 @@ func TestDiscoverAndRegisterSkillTools_FromConfig(t *testing.T) {
 	}
 
 	registry := tools.NewRegistry()
-	exec, err := discoverAndRegisterSkillTools(cfg, registry)
+	exec, preloadedInstructions, err := discoverAndRegisterSkillTools(cfg, registry)
 	require.NoError(t, err)
 	require.NotNil(t, exec)
 
 	allTools := registry.GetTools()
 	assert.Contains(t, allTools, "skill__activate")
 	assert.Contains(t, allTools, "skill__deactivate")
+
+	// skill__activate descriptor must embed the available-skills index so the
+	// LLM can discover which skills exist (issue #954).
+	activateDesc := registry.Get("skill__activate")
+	require.NotNil(t, activateDesc)
+	assert.Contains(t, activateDesc.Description, "Available skills:",
+		"skill__activate description should embed the skills index")
+	assert.Contains(t, activateDesc.Description, "test-skill: A test skill")
+
+	// Skill has no preload: true, so preloaded instructions should be empty.
+	assert.Empty(t, preloadedInstructions)
+}
+
+func TestDiscoverAndRegisterSkillTools_PreloadedInstructions(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "skills", "memory-protocol")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: memory-protocol\ndescription: Memory rules\n---\nMUST call memory__recall first.\n"),
+		0o600,
+	))
+
+	cfg := &config.Config{
+		LoadedSkillSources: []prompt.SkillSourceConfig{
+			{Path: filepath.Join(dir, "skills", "memory-protocol"), Preload: true},
+		},
+	}
+
+	registry := tools.NewRegistry()
+	_, preloadedInstructions, err := discoverAndRegisterSkillTools(cfg, registry)
+	require.NoError(t, err)
+
+	// Preloaded skill instructions must be returned so they can be injected
+	// into the system prompt (issue #953).
+	assert.Contains(t, preloadedInstructions, "# Active Skills")
+	assert.Contains(t, preloadedInstructions, "memory-protocol")
+	assert.Contains(t, preloadedInstructions, "MUST call memory__recall first.")
 }
 
 func TestDiscoverAndRegisterSkillTools_EmptyConfig(t *testing.T) {
 	cfg := &config.Config{}
 	registry := tools.NewRegistry()
-	exec, err := discoverAndRegisterSkillTools(cfg, registry)
+	exec, preloadedInstructions, err := discoverAndRegisterSkillTools(cfg, registry)
 	require.NoError(t, err)
 	assert.Nil(t, exec)
+	assert.Empty(t, preloadedInstructions)
 	assert.Empty(t, registry.GetTools())
 }

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -131,9 +131,12 @@ func BuildEngineComponents(cfg *config.Config, providerFilter []string) (
 		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to start A2A agents: %w", a2aErr)
 	}
 
-	// Discover and register skill tools (if pack has skills configured)
+	// Discover and register skill tools (if pack has skills configured).
+	// preloadedSkillInstructions are appended to the system prompt by the
+	// conversation executor so preload: true skills are active from turn 1.
 	var skillErr error
-	skillExec, skillErr = discoverAndRegisterSkillTools(cfg, toolRegistry)
+	var preloadedSkillInstructions string
+	skillExec, preloadedSkillInstructions, skillErr = discoverAndRegisterSkillTools(cfg, toolRegistry)
 	if skillErr != nil {
 		if a2aCleanupFn != nil {
 			a2aCleanupFn()
@@ -154,7 +157,8 @@ func BuildEngineComponents(cfg *config.Config, providerFilter []string) (
 
 	// Build conversation executor (engine-specific, stays here)
 	conversationExecutor, adapterRegistry, err := newConversationExecutor(
-		cfg, toolRegistry, promptRegistry, mediaStorage, providerRegistry, evalOrchestrator)
+		cfg, toolRegistry, promptRegistry, mediaStorage, providerRegistry, evalOrchestrator,
+		preloadedSkillInstructions)
 	if err != nil {
 		if a2aCleanupFn != nil {
 			a2aCleanupFn()
@@ -588,9 +592,11 @@ func newConversationExecutor(
 	mediaStorage storage.MediaStorageService,
 	providerRegistry *providers.Registry,
 	evalOrchestrator *EvalOrchestrator,
+	preloadedSkillInstructions string,
 ) (ConversationExecutor, *adapters.Registry, error) {
 	// Build turn executors (always needed, even without self-play)
 	pipelineExecutor := turnexecutors.NewPipelineExecutor(toolRegistry, mediaStorage)
+	pipelineExecutor.SetPreloadedSkillInstructions(preloadedSkillInstructions)
 	scriptedExecutor := turnexecutors.NewScriptedExecutor(pipelineExecutor)
 
 	// Build self-play components if enabled
@@ -781,9 +787,15 @@ func buildStateStore(cfg *config.Config) (runtimestore.Store, error) {
 
 // discoverAndRegisterSkillTools discovers skills from the arena config and registers
 // skill tool descriptors and executor in the tool registry.
-func discoverAndRegisterSkillTools(cfg *config.Config, toolRegistry *tools.Registry) (*skills.Executor, error) {
+//
+// Returns the executor and the preloaded-skill instructions block that should be
+// appended to the system prompt so skills marked preload: true are active from
+// turn 1 without the model having to call skill__activate.
+func discoverAndRegisterSkillTools(
+	cfg *config.Config, toolRegistry *tools.Registry,
+) (*skills.Executor, string, error) {
 	if len(cfg.LoadedSkillSources) == 0 {
-		return nil, nil
+		return nil, "", nil
 	}
 
 	// Convert config skill sources to runtime SkillSource
@@ -801,25 +813,50 @@ func discoverAndRegisterSkillTools(cfg *config.Config, toolRegistry *tools.Regis
 	// Discover skills
 	reg := skills.NewRegistry()
 	if err := reg.Discover(sources); err != nil {
-		return nil, fmt.Errorf("skills discovery: %w", err)
+		return nil, "", fmt.Errorf("skills discovery: %w", err)
 	}
 
 	// Create executor (no selector, no pack tool ceiling in arena)
 	executor := skills.NewExecutor(skills.ExecutorConfig{Registry: reg, ConfigDir: cfg.ConfigDir})
 
-	// Register tool descriptors + executor
-	_ = toolRegistry.Register(skills.BuildSkillActivateDescriptor())
+	// Register tool descriptors + executor. The skill__activate descriptor
+	// embeds the available-skills index so the LLM can discover which skills
+	// exist and choose which to activate.
+	_ = toolRegistry.Register(skills.BuildSkillActivateDescriptorWithIndex(executor.SkillIndex("")))
 	_ = toolRegistry.Register(skills.BuildSkillDeactivateDescriptor())
 	_ = toolRegistry.Register(skills.BuildSkillReadResourceDescriptor())
 	toolRegistry.RegisterExecutor(skills.NewToolExecutor(executor))
 
-	// Preload skills marked with preload: true
-	for _, sk := range reg.PreloadedSkills() {
+	// Preload skills marked with preload: true. Activating registers their
+	// tools in the registry; instructions are threaded into the system prompt
+	// via the returned preloadedInstructions block.
+	preloaded := reg.PreloadedSkills()
+	preloadedInstructions := buildPreloadedSkillInstructions(preloaded)
+	for _, sk := range preloaded {
 		_, _, _ = executor.Activate(sk.Name)
 	}
 
-	logger.Info("Discovered skills", "count", len(reg.List()))
-	return executor, nil
+	logger.Info("Discovered skills", "count", len(reg.List()), "preloaded", len(preloaded))
+	return executor, preloadedInstructions, nil
+}
+
+// buildPreloadedSkillInstructions formats preloaded skill instructions into a
+// single block to append to the system prompt.
+func buildPreloadedSkillInstructions(preloaded []*skills.Skill) string {
+	if len(preloaded) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("\n\n# Active Skills\n\nThe following skills are active for this conversation. ")
+	sb.WriteString("Follow their instructions.\n")
+	for _, sk := range preloaded {
+		sb.WriteString("\n## ")
+		sb.WriteString(sk.Name)
+		sb.WriteString("\n\n")
+		sb.WriteString(sk.Instructions)
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }
 
 // a2aInitTimeout is the timeout for discovering and registering A2A agent tools.

--- a/tools/arena/stages/skill_instruction.go
+++ b/tools/arena/stages/skill_instruction.go
@@ -1,0 +1,47 @@
+package stages
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// SkillInstructionStage appends preloaded skill instructions to the
+// system_prompt metadata so the model sees skills marked preload: true
+// from turn 1 without having to call skill__activate.
+type SkillInstructionStage struct {
+	stage.BaseStage
+	instructions string
+}
+
+// NewSkillInstructionStage creates a stage that appends the given preloaded
+// skill instructions block to the "system_prompt" metadata key.
+func NewSkillInstructionStage(instructions string) *SkillInstructionStage {
+	return &SkillInstructionStage{
+		BaseStage:    stage.NewBaseStage("skill_instruction", stage.StageTypeTransform),
+		instructions: instructions,
+	}
+}
+
+// Process appends the preloaded skill instructions to the system_prompt metadata.
+//
+//nolint:lll // Channel signature cannot be shortened
+func (s *SkillInstructionStage) Process(ctx context.Context, input <-chan stage.StreamElement, output chan<- stage.StreamElement) error {
+	defer close(output)
+
+	for elem := range input {
+		if elem.Metadata != nil && s.instructions != "" {
+			if sp, ok := elem.Metadata["system_prompt"].(string); ok {
+				elem.Metadata["system_prompt"] = sp + s.instructions
+			}
+		}
+
+		select {
+		case output <- elem:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}

--- a/tools/arena/stages/skill_instruction_test.go
+++ b/tools/arena/stages/skill_instruction_test.go
@@ -1,0 +1,63 @@
+package stages
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillInstructionStage_AppendsToSystemPrompt(t *testing.T) {
+	s := NewSkillInstructionStage("\n\n# Active Skills\n\n## memory-protocol\n\nCall memory__recall first.\n")
+
+	elem := stage.StreamElement{
+		Metadata: map[string]interface{}{
+			"system_prompt": "You are a helpful assistant.",
+		},
+	}
+
+	results := runStage(t, s, []stage.StreamElement{elem})
+	require.Len(t, results, 1)
+	assert.Equal(t,
+		"You are a helpful assistant.\n\n# Active Skills\n\n## memory-protocol\n\nCall memory__recall first.\n",
+		results[0].Metadata["system_prompt"])
+}
+
+func TestSkillInstructionStage_EmptyInstructionsNoOp(t *testing.T) {
+	s := NewSkillInstructionStage("")
+
+	elem := stage.StreamElement{
+		Metadata: map[string]interface{}{
+			"system_prompt": "You are helpful.",
+		},
+	}
+
+	results := runStage(t, s, []stage.StreamElement{elem})
+	require.Len(t, results, 1)
+	assert.Equal(t, "You are helpful.", results[0].Metadata["system_prompt"])
+}
+
+func TestSkillInstructionStage_NoSystemPromptKey(t *testing.T) {
+	s := NewSkillInstructionStage("\nskill instructions")
+
+	elem := stage.StreamElement{
+		Metadata: map[string]interface{}{
+			"other_key": "value",
+		},
+	}
+
+	results := runStage(t, s, []stage.StreamElement{elem})
+	require.Len(t, results, 1)
+	assert.Nil(t, results[0].Metadata["system_prompt"])
+}
+
+func TestSkillInstructionStage_NilMetadata(t *testing.T) {
+	s := NewSkillInstructionStage("\nskill instructions")
+
+	elem := stage.StreamElement{Metadata: nil}
+
+	results := runStage(t, s, []stage.StreamElement{elem})
+	require.Len(t, results, 1)
+	assert.Nil(t, results[0].Metadata)
+}

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -28,8 +28,9 @@ import (
 // PipelineExecutor executes conversations through the pipeline architecture.
 // It handles both non-streaming and streaming execution, including multi-round tool calls.
 type PipelineExecutor struct {
-	toolRegistry *tools.Registry
-	mediaStorage storage.MediaStorageService // Media storage service for externalization
+	toolRegistry               *tools.Registry
+	mediaStorage               storage.MediaStorageService // Media storage service for externalization
+	preloadedSkillInstructions string                      // Appended to system_prompt when non-empty
 }
 
 // NewPipelineExecutor creates a new pipeline executor with the specified tool registry and media storage.
@@ -39,6 +40,13 @@ func NewPipelineExecutor(toolRegistry *tools.Registry, mediaStorage storage.Medi
 		toolRegistry: toolRegistry,
 		mediaStorage: mediaStorage,
 	}
+}
+
+// SetPreloadedSkillInstructions sets the preloaded-skill instructions block that
+// will be appended to the system prompt for every turn. Passing an empty string
+// disables the stage.
+func (e *PipelineExecutor) SetPreloadedSkillInstructions(instructions string) {
+	e.preloadedSkillInstructions = instructions
 }
 
 // buildBaseVariables creates base variables map from request
@@ -298,6 +306,13 @@ func (e *PipelineExecutor) buildStagePipeline(
 		arenastages.NewScenarioContextExtractionStage(req.Scenario),
 		stage.NewTemplateStage(),
 	)
+
+	// 4b. Append preloaded skill instructions to system_prompt so skills
+	// marked preload: true are active from turn 1 without requiring the
+	// model to call skill__activate.
+	if e.preloadedSkillInstructions != "" {
+		stages = append(stages, arenastages.NewSkillInstructionStage(e.preloadedSkillInstructions))
+	}
 
 	// 4a. Mock scenario context (for mock providers only)
 	if isMockProvider(req.Provider) {


### PR DESCRIPTION
## Summary

Fixes #953 and #954 — two helpers added in #951 (`BuildSkillActivateDescriptorWithIndex`, `Executor.SkillIndex`, and the unused result of `reg.PreloadedSkills()`) were never actually called from the arena engine, so:

- **#954** — The `skill__activate` tool descriptor used the generic description; the LLM had no way to discover which skills existed.
- **#953** — Skills with `preload: true` were activated in the registry but their SKILL.md instructions were never appended to the system prompt, so `preload` had no observable effect.

## What changed

- `discoverAndRegisterSkillTools` now registers `skill__activate` via `BuildSkillActivateDescriptorWithIndex(executor.SkillIndex(""))`, and returns a formatted `# Active Skills` block built from `reg.PreloadedSkills()`.
- That block is threaded through `BuildEngineComponents` → `newConversationExecutor` → `PipelineExecutor.SetPreloadedSkillInstructions`.
- New `SkillInstructionStage` (mirrors `CompletionInstructionStage`) appends the block to `system_prompt` metadata after `TemplateStage`, so preloaded skills are in context from turn 1.
- Updated `examples/workflow-skills/config.arena.yaml` to mark `brand-voice` as `preload: true` — this exercises the fix end-to-end against the mock provider.

## Proof

Running the `workflow-skills` example before vs after:

| | Before | After |
|---|---|---|
| System message length | 556 chars (base prompt only) | 1091 chars (base + Active Skills block) |
| `skill__activate` description | Generic static string | Base + `Available skills:\n- brand-voice: ...\n- ...` for all 5 skills |

## Test plan

- [x] `go test ./tools/arena/engine/... ./tools/arena/stages/... ./tools/arena/turnexecutors/...` — all green
- [x] New unit tests: `TestSkillInstructionStage_*` (4 tests), `TestDiscoverAndRegisterSkillTools_PreloadedInstructions`, `TestDiscoverAndRegisterSkillTools_FromConfig` now asserts the index is embedded in the descriptor
- [x] `make build-arena && promptarena run -c examples/workflow-skills/config.arena.yaml --ci` — verified system message contains `# Active Skills` header and brand-voice instructions, `skill__activate` descriptor contains the available-skills index
- [x] `golangci-lint run --new-from-rev=main ./tools/arena/...` — 0 new issues

## Note

While testing I hit a latent bug in `Registry.Discover` (`runtime/skills/registry.go:103`): first-wins dedup means a broad `path: skills/` entry swallows any subsequent per-directory entry, dropping its `preload: true` flag. Worked around in the example by listing directories individually. Probably worth its own issue.