### PR TITLE
fix(skills): allow narrower SkillSource to upgrade preload flag (#956)

### DIFF
--- a/examples/workflow-skills/config.arena.yaml
+++ b/examples/workflow-skills/config.arena.yaml
@@ -21,16 +21,15 @@ spec:
     - file: scenarios/orders-flow.scenario.yaml
 
   skills:
-    # brand-voice is preloaded — its instructions are injected into the
+    # Load everything under skills/ as on-demand. The LLM can discover these
+    # from the skill__activate tool description (which includes the
+    # available-skills index) and activate them when needed.
+    - path: skills/
+    # Upgrade brand-voice to preload — its instructions are injected into the
     # system prompt from turn 1 without requiring skill__activate.
+    # Later entries can upgrade the preload flag but cannot change path/metadata.
     - path: skills/brand-voice
       preload: true
-    # Remaining skills are on-demand — the LLM can discover them from the
-    # skill__activate tool description (which includes the available-skills
-    # index) and activate them when needed.
-    - path: skills/billing
-    - path: skills/orders
-    - path: skills/escalation
 
   workflow:
     version: 1

--- a/runtime/skills/registry.go
+++ b/runtime/skills/registry.go
@@ -39,7 +39,10 @@ func NewRegistry() *Registry {
 }
 
 // Discover scans skill sources and registers all found skills.
-// Sources are processed in order — later sources do NOT override earlier ones (first wins).
+// Sources are processed in order: the first source to register a skill name wins
+// for path/metadata, but a later source may upgrade the preload flag from false to true.
+// This supports the common pattern of a broad `path: skills/` entry followed by
+// narrower per-directory entries that mark specific skills as preload.
 func (r *Registry) Discover(sources []SkillSource) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -100,8 +103,13 @@ func (r *Registry) discoverDirectory(src SkillSource) error {
 		}
 
 		skillDir := filepath.Dir(path)
-		if _, exists := r.skills[meta.Name]; exists {
-			logger.Warn("skills: duplicate skill ignored (already registered)", "skill", meta.Name)
+		if existing, exists := r.skills[meta.Name]; exists {
+			if src.Preload && !existing.preload {
+				existing.preload = true
+				logger.Debug("skills: upgrading preload flag from duplicate source", "skill", meta.Name)
+			} else {
+				logger.Debug("skills: duplicate skill ignored (already registered)", "skill", meta.Name)
+			}
 			return nil
 		}
 
@@ -117,8 +125,13 @@ func (r *Registry) discoverDirectory(src SkillSource) error {
 // registerInline registers an inline skill source directly.
 // Must be called with r.mu held.
 func (r *Registry) registerInline(src SkillSource) {
-	if _, exists := r.skills[src.Name]; exists {
-		logger.Warn("skills: duplicate skill ignored (already registered)", "skill", src.Name)
+	if existing, exists := r.skills[src.Name]; exists {
+		if src.Preload && !existing.preload {
+			existing.preload = true
+			logger.Debug("skills: upgrading preload flag from duplicate inline source", "skill", src.Name)
+		} else {
+			logger.Debug("skills: duplicate skill ignored (already registered)", "skill", src.Name)
+		}
 		return
 	}
 

--- a/runtime/skills/registry_test.go
+++ b/runtime/skills/registry_test.go
@@ -466,3 +466,76 @@ func TestResolveRefIntegration(t *testing.T) {
 		t.Errorf("ResolveRef() = %q, want %q", gotPath, wantPath)
 	}
 }
+
+// TestDiscoverPreloadUpgrade verifies that a later SkillSource with preload=true
+// upgrades the preload flag on a skill already registered by an earlier broader source.
+// This supports the common pattern of `path: skills/` followed by per-directory
+// entries that mark specific skills as preload.
+func TestDiscoverPreloadUpgrade(t *testing.T) {
+	root := t.TempDir()
+	brandDir := filepath.Join(root, "brand-voice")
+	otherDir := filepath.Join(root, "other")
+	writeTestSkill(t, brandDir, "brand-voice", "Brand voice", "Brand instructions")
+	writeTestSkill(t, otherDir, "other", "Other", "Other instructions")
+
+	reg := NewRegistry()
+	err := reg.Discover([]SkillSource{
+		{Dir: root},                    // registers both with preload=false
+		{Dir: brandDir, Preload: true}, // upgrades brand-voice to preload=true
+	})
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	preloaded := reg.PreloadedSkills()
+	if len(preloaded) != 1 {
+		t.Fatalf("expected 1 preloaded skill, got %d", len(preloaded))
+	}
+	if preloaded[0].Name != "brand-voice" {
+		t.Errorf("expected 'brand-voice' to be preloaded, got %q", preloaded[0].Name)
+	}
+
+	// All skills still registered.
+	if len(reg.List()) != 2 {
+		t.Errorf("expected 2 total skills, got %d", len(reg.List()))
+	}
+}
+
+// TestDiscoverInlinePreloadUpgrade verifies the same upgrade semantics for inline sources.
+func TestDiscoverInlinePreloadUpgrade(t *testing.T) {
+	reg := NewRegistry()
+	err := reg.Discover([]SkillSource{
+		{Name: "s", Description: "d", Instructions: "i"},                // preload=false
+		{Name: "s", Description: "d", Instructions: "i", Preload: true}, // upgrades
+	})
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	preloaded := reg.PreloadedSkills()
+	if len(preloaded) != 1 || preloaded[0].Name != "s" {
+		t.Fatalf("expected s to be preloaded, got %+v", preloaded)
+	}
+}
+
+// TestDiscoverPreloadNotDowngraded verifies that a later source with preload=false
+// does NOT downgrade a skill already registered with preload=true.
+func TestDiscoverPreloadNotDowngraded(t *testing.T) {
+	root := t.TempDir()
+	brandDir := filepath.Join(root, "brand-voice")
+	writeTestSkill(t, brandDir, "brand-voice", "Brand voice", "Brand instructions")
+
+	reg := NewRegistry()
+	err := reg.Discover([]SkillSource{
+		{Dir: brandDir, Preload: true}, // preload=true
+		{Dir: root},                    // would re-register with preload=false; must NOT downgrade
+	})
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	preloaded := reg.PreloadedSkills()
+	if len(preloaded) != 1 {
+		t.Fatalf("expected 1 preloaded skill, got %d", len(preloaded))
+	}
+}

--- a/tools/packc/compiler/skills_validator_integration.go
+++ b/tools/packc/compiler/skills_validator_integration.go
@@ -35,7 +35,10 @@ func validatePathContainment(rawPath, baseDir string) error {
 func ValidateSkillErrors(pack *prompt.Pack, packDir string) []string {
 	var errs []string
 
-	seen := make(map[string]bool)
+	// seen maps skill name -> canonical location ("" for inline, else abs skill dir).
+	// Duplicates are allowed when they resolve to the same location; this mirrors
+	// the runtime registry, which uses such "duplicates" to upgrade the preload flag.
+	seen := make(map[string]string)
 
 	for i := range pack.Skills {
 		src := &pack.Skills[i]
@@ -83,7 +86,7 @@ func ValidateSkills(pack *prompt.Pack, packDir string) []string {
 }
 
 // validateSkillDirectory validates a directory-based skill source.
-func validateSkillDirectory(dir, packDir string, idx int, seen map[string]bool) []string {
+func validateSkillDirectory(dir, packDir string, idx int, seen map[string]string) []string {
 	var errs []string
 
 	if err := validatePathContainment(dir, packDir); err != nil {
@@ -116,10 +119,11 @@ func validateSkillDirectory(dir, packDir string, idx int, seen map[string]bool) 
 			return nil
 		}
 
-		if seen[meta.Name] {
+		skillDir := filepath.Dir(path)
+		if prev, exists := seen[meta.Name]; exists && prev != skillDir {
 			errs = append(errs, fmt.Sprintf("skills[%d]: duplicate skill name %q", idx, meta.Name))
 		}
-		seen[meta.Name] = true
+		seen[meta.Name] = skillDir
 
 		return nil
 	})
@@ -131,7 +135,7 @@ func validateSkillDirectory(dir, packDir string, idx int, seen map[string]bool) 
 }
 
 // validateInlineSkill validates an inline skill definition.
-func validateInlineSkill(src *prompt.SkillSourceConfig, idx int, seen map[string]bool) []string {
+func validateInlineSkill(src *prompt.SkillSourceConfig, idx int, seen map[string]string) []string {
 	var errs []string
 
 	if src.Name == "" {
@@ -145,10 +149,10 @@ func validateInlineSkill(src *prompt.SkillSourceConfig, idx int, seen map[string
 	}
 
 	if src.Name != "" {
-		if seen[src.Name] {
+		if _, exists := seen[src.Name]; exists {
 			errs = append(errs, fmt.Sprintf("skills[%d]: duplicate skill name %q", idx, src.Name))
 		}
-		seen[src.Name] = true
+		seen[src.Name] = ""
 	}
 
 	return errs

--- a/tools/packc/skills_validator.go
+++ b/tools/packc/skills_validator.go
@@ -37,7 +37,11 @@ func validatePathContainment(rawPath, baseDir string) error {
 func ValidateSkillErrors(pack *prompt.Pack, packDir string) []string {
 	var errs []string
 
-	seen := make(map[string]bool)
+	// seen maps skill name -> canonical location ("" for inline, else abs skill dir).
+	// Duplicates are allowed when they resolve to the same location (supports the
+	// broad "path: skills/" followed by a narrower per-directory entry pattern that
+	// the runtime registry uses to upgrade preload flags).
+	seen := make(map[string]string)
 
 	for i := range pack.Skills {
 		src := &pack.Skills[i]
@@ -89,7 +93,7 @@ func ValidateSkills(pack *prompt.Pack, packDir string) []string {
 }
 
 // validateSkillDirectory validates a directory-based skill source.
-func validateSkillDirectory(dir, packDir string, idx int, seen map[string]bool) []string {
+func validateSkillDirectory(dir, packDir string, idx int, seen map[string]string) []string {
 	var errs []string
 
 	if err := validatePathContainment(dir, packDir); err != nil {
@@ -123,10 +127,11 @@ func validateSkillDirectory(dir, packDir string, idx int, seen map[string]bool) 
 			return nil
 		}
 
-		if seen[meta.Name] {
+		skillDir := filepath.Dir(path)
+		if prev, exists := seen[meta.Name]; exists && prev != skillDir {
 			errs = append(errs, fmt.Sprintf("skills[%d]: duplicate skill name %q", idx, meta.Name))
 		}
-		seen[meta.Name] = true
+		seen[meta.Name] = skillDir
 
 		return nil
 	})
@@ -138,7 +143,7 @@ func validateSkillDirectory(dir, packDir string, idx int, seen map[string]bool) 
 }
 
 // validateInlineSkill validates an inline skill definition.
-func validateInlineSkill(src *prompt.SkillSourceConfig, idx int, seen map[string]bool) []string {
+func validateInlineSkill(src *prompt.SkillSourceConfig, idx int, seen map[string]string) []string {
 	var errs []string
 
 	if src.Name == "" {
@@ -152,10 +157,10 @@ func validateInlineSkill(src *prompt.SkillSourceConfig, idx int, seen map[string
 	}
 
 	if src.Name != "" {
-		if seen[src.Name] {
+		if _, exists := seen[src.Name]; exists {
 			errs = append(errs, fmt.Sprintf("skills[%d]: duplicate skill name %q", idx, src.Name))
 		}
-		seen[src.Name] = true
+		seen[src.Name] = ""
 	}
 
 	return errs

--- a/tools/packc/skills_validator_test.go
+++ b/tools/packc/skills_validator_test.go
@@ -95,6 +95,26 @@ func TestValidateSkillErrors_DuplicateNames(t *testing.T) {
 	assert.Contains(t, errs[0], "duplicate skill name")
 }
 
+// TestValidateSkillErrors_DuplicateSameSkillAllowed verifies that the broad
+// "path: skills/" + narrower "path: skills/brand-voice" pattern is not flagged
+// as a duplicate — both entries resolve to the same underlying skill directory,
+// which the runtime registry uses to upgrade the preload flag.
+func TestValidateSkillErrors_DuplicateSameSkillAllowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeSkillMD(t, filepath.Join(tmpDir, "skills", "brand-voice"), "brand-voice", "Brand voice")
+
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: "skills"},
+			{Dir: "skills/brand-voice", Preload: true},
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	errs := ValidateSkillErrors(pack, tmpDir)
+	assert.Empty(t, errs, "broad+narrow pattern resolving to same SKILL.md should not error")
+}
+
 func TestValidateSkillErrors_InlineComplete(t *testing.T) {
 	pack := &prompt.Pack{
 		Skills: []prompt.SkillSourceConfig{


### PR DESCRIPTION
## Summary

- `Registry.Discover` now OR-combines the `preload` flag across duplicate `SkillSource` entries, so a broad `path: skills/` entry followed by a narrower per-directory entry with `preload: true` works as users expect.
- First source still wins for path/metadata; `preload` is never downgraded.
- Demotes the noisy "duplicate skill ignored" log from Warn to Debug — it's expected when layering sources.
- Updates `examples/workflow-skills` to use the broad-then-narrow pattern, exercising the fix end-to-end.

Fixes #956.

## Test plan

- [x] `go test ./runtime/skills/... -count=1 -race` — passes (new tests: `TestDiscoverPreloadUpgrade`, `TestDiscoverInlinePreloadUpgrade`, `TestDiscoverPreloadNotDowngraded`)
- [x] Coverage on `registry.go`: 88.6% (threshold 80%)
- [x] `golangci-lint run --new-from-rev=main` — 0 issues
- [x] `make build-arena && promptarena run -c examples/workflow-skills/config.arena.yaml --ci` — `Discovered skills count=5 preloaded=1`