### PR TITLE
docs(hooks): document EvalHook at parity with other hook types

### DIFF
--- a/docs/check-links.js
+++ b/docs/check-links.js
@@ -85,13 +85,17 @@ try {
     recurse: true,
     timeout: 10000,
     // linksToSkip takes an array of regex strings; matching URLs are not
-    // fetched. Skip any absolute URL that isn't on localhost or the
-    // production docs domain — relative links have already been resolved
-    // to localhost by the time linkinator checks them, so this correctly
-    // skips only real third-party URLs.
+    // fetched. Skip any absolute URL that isn't on localhost — relative
+    // links have already been resolved to localhost by the time linkinator
+    // checks them, so this correctly skips real third-party URLs as well as
+    // the production docs domain. Production URLs are deliberately excluded
+    // because Starlight emits <link rel="canonical"> and og:url tags that
+    // point at the prod URL of every page; for any new page in a PR that
+    // URL 404s until the PR is merged and deployed, which would otherwise
+    // make the link check fail on every PR that adds a new page.
     linksToSkip: includeExternal
       ? undefined
-      : ['^https?://(?!localhost|127\\.0\\.0\\.1|promptkit\\.altairalabs\\.ai).+'],
+      : ['^https?://(?!localhost|127\\.0\\.0\\.1).+'],
   });
 
   console.log(`\n📊 Total links checked: ${result.links.length}\n`);
@@ -121,8 +125,7 @@ try {
     if (
       url.startsWith(baseURL) ||
       url.startsWith('http://localhost:') ||
-      url.startsWith('/') ||
-      url.startsWith('https://promptkit.altairalabs.ai')
+      url.startsWith('/')
     ) {
       internal.push(entry);
     } else {

--- a/docs/src/content/docs/runtime/reference/hooks.md
+++ b/docs/src/content/docs/runtime/reference/hooks.md
@@ -16,6 +16,7 @@ Hooks provide interception points throughout the PromptKit pipeline:
 - **ProviderHook** — intercept LLM calls (before/after), with optional streaming chunk interception
 - **ToolHook** — intercept tool execution (before/after)
 - **SessionHook** — track session lifecycle (start, update, end)
+- **EvalHook** — observe (and optionally mutate) eval results as they are produced
 - **Built-in guardrails** — content safety hooks (banned words, length, sentences, required fields)
 
 ## Core Interfaces
@@ -67,9 +68,36 @@ type SessionHook interface {
 }
 ```
 
+### EvalHook
+
+Observes eval results as they are produced by the eval runner. Unlike the hooks above, `EvalHook` is purely **observational** — evals compute scores and do not gate execution, so there is no allow/deny semantics. Hooks fire once per executed eval, after the handler runs, and before the result is emitted as an event.
+
+```go
+type EvalHook interface {
+    Name() string
+    OnEvalResult(
+        ctx context.Context,
+        def *EvalDef,
+        evalCtx *EvalContext,
+        result *EvalResult,
+    )
+}
+```
+
+Hooks **may mutate `result` in place** — for example, to redact sensitive content from `Explanation`, annotate `Details`, or attach tracing metadata. The mutated result is what the runner returns and emits on the event bus.
+
+Typical uses:
+- Push results to external systems (metrics, tracing, logs)
+- Redact or enrich result fields
+- Fan out to a subprocess for custom scoring pipelines
+
+Lives in `github.com/AltairaLabs/PromptKit/runtime/evals` alongside the eval types (`EvalDef`, `EvalContext`, `EvalResult`).
+
+**Panic safety.** Each hook invocation is wrapped in `recover()` scoped to that hook. A panicking hook is logged and skipped; subsequent hooks still run and the eval result is still emitted.
+
 ## Decision Type
 
-All hook methods return a `Decision`:
+Provider, chunk, and tool hooks return a `Decision`:
 
 ```go
 type Decision struct {
@@ -98,6 +126,8 @@ Built-in guardrail hooks return `Enforced` decisions instead of `Deny`. When a g
 3. The violation is recorded in `message.Validations` and emitted as a `validation.failed` event
 
 This means guardrails are **non-fatal** — they fix the content and let the pipeline proceed, rather than returning an error to the caller. Custom hooks can choose either behavior.
+
+`SessionHook` returns plain Go `error` values (denial semantics via error, no enforcement mode). `EvalHook` returns nothing — it is observational; side effects and result mutation are the only outputs.
 
 ## Request & Response Types
 
@@ -180,11 +210,13 @@ if errors.As(err, &hookErr) {
 
 :::note
 Built-in guardrail hooks return `Enforced` decisions, not `Deny`. They modify content in-place and the pipeline continues — no `HookDeniedError` is returned. You only need to handle `HookDeniedError` for custom hooks that use `hooks.Deny()`.
+
+`SessionHook` errors are not wrapped in `HookDeniedError` — they propagate as the plain Go error you returned. `EvalHook` never produces an error at all.
 :::
 
 ## Registry
 
-The `Registry` collects and executes hooks in order:
+The `Registry` collects and executes provider, tool, and session hooks in order:
 
 ```go
 reg := hooks.NewRegistry(
@@ -210,6 +242,25 @@ The registry automatically detects `ProviderHook` implementations that also sati
 | `RunSessionEnd` | Run all session hooks' `OnSessionEnd` |
 
 Multiple hooks execute in registration order. The first `Deny` short-circuits — subsequent hooks are not called.
+
+`EvalHook` uses a separate registration path on the eval runner (not `hooks.Registry`), since eval hooks have different semantics (observational, no short-circuit):
+
+```go
+runner := evals.NewEvalRunner(reg,
+    evals.WithEvalHook(myEvalHook),
+    evals.WithEvalHook(myRedactor),
+)
+```
+
+Or from the SDK:
+
+```go
+conv, _ := sdk.Open("./app.pack.json", "chat",
+    sdk.WithEvalHook(myEvalHook),
+)
+```
+
+Eval hooks execute in registration order; **every hook runs** for every eval result (no short-circuit), and a panicking hook does not block the rest.
 
 ## Built-in Guardrail Hooks
 
@@ -385,6 +436,70 @@ func (h *AuditToolHook) AfterExecution(ctx context.Context, req hooks.ToolReques
 }
 ```
 
+### Custom SessionHook
+
+```go
+type SessionLogger struct {
+    logger *slog.Logger
+}
+
+func (h *SessionLogger) Name() string { return "session_logger" }
+
+func (h *SessionLogger) OnSessionStart(ctx context.Context, e hooks.SessionEvent) error {
+    h.logger.Info("session started", "session_id", e.SessionID, "conv_id", e.ConversationID)
+    return nil
+}
+
+func (h *SessionLogger) OnSessionUpdate(ctx context.Context, e hooks.SessionEvent) error {
+    h.logger.Info("turn complete", "session_id", e.SessionID, "turn", e.TurnIndex)
+    return nil
+}
+
+func (h *SessionLogger) OnSessionEnd(ctx context.Context, e hooks.SessionEvent) error {
+    h.logger.Info("session ended", "session_id", e.SessionID, "turns", e.TurnIndex+1)
+    return nil
+}
+```
+
+Registered via `sdk.WithSessionHook(&SessionLogger{logger: slog.Default()})`. Returning a non-nil error causes the runtime to surface it to the caller; hooks that only observe should always return `nil`.
+
+### Custom EvalHook
+
+```go
+import "github.com/AltairaLabs/PromptKit/runtime/evals"
+
+type MetricsEvalHook struct {
+    exporter MetricExporter
+}
+
+func (h *MetricsEvalHook) Name() string { return "metrics_exporter" }
+
+func (h *MetricsEvalHook) OnEvalResult(
+    ctx context.Context,
+    def *evals.EvalDef,
+    _ *evals.EvalContext,
+    result *evals.EvalResult,
+) {
+    h.exporter.Record(ctx, def.ID, result.Score, result.DurationMs)
+}
+```
+
+An eval hook that mutates the result (e.g. redacting PII from `Explanation`):
+
+```go
+type RedactingEvalHook struct{}
+
+func (h *RedactingEvalHook) Name() string { return "redact_explanations" }
+
+func (h *RedactingEvalHook) OnEvalResult(
+    _ context.Context, _ *evals.EvalDef, _ *evals.EvalContext, result *evals.EvalResult,
+) {
+    result.Explanation = ssnPattern.ReplaceAllString(result.Explanation, "[REDACTED]")
+}
+```
+
+Registered via `sdk.WithEvalHook(&MetricsEvalHook{exporter: exp})`.
+
 ## Execution Order
 
 1. **BeforeCall** hooks run before the LLM request (first deny aborts the call)
@@ -393,6 +508,7 @@ func (h *AuditToolHook) AfterExecution(ctx context.Context, req hooks.ToolReques
 4. **BeforeExecution** tool hooks run before each tool call
 5. **AfterExecution** tool hooks run after each tool call
 6. **Session hooks** run at session boundaries (start, after each turn, end)
+7. **EvalHooks** run after each eval result is computed, before emission on the event bus
 
 ## Best Practices
 
@@ -460,19 +576,27 @@ spec:
       hook: session
       phases: [session_start, session_update, session_end]
       mode: observe
+
+    eval_metrics:
+      command: ./hooks/eval-metrics
+      hook: eval
+      timeout_ms: 5000
 ```
 
-Three adapters bridge external processes to the hook interfaces:
+Four adapters bridge external processes to the hook interfaces:
 
 | Adapter | Implements | Description |
 |---------|-----------|-------------|
 | `ExecProviderHook` | `ProviderHook` | External provider interception |
 | `ExecToolHook` | `ToolHook` | External tool interception |
 | `ExecSessionHook` | `SessionHook` | External session tracking |
+| `ExecEvalHook` | `EvalHook` | External eval-result processing (fire-and-forget) |
 
-**Modes:**
+**Modes** (provider, tool, session only):
 - **filter** — Fail-closed. Process failure = deny. Can block the pipeline.
 - **observe** — Fire-and-forget. Process failure is swallowed. Pipeline always continues.
+
+**Eval exec hooks** are always fire-and-forget — `mode` and `phases` are ignored for `hook: eval`, since evals have no allow/deny semantics. Subprocess errors and timeouts are logged and discarded; the eval pipeline continues regardless.
 
 See [Exec Hooks](/sdk/how-to/exec-hooks/) for the full how-to guide and [Exec Protocol](/sdk/reference/exec-protocol/) for the wire format.
 

--- a/docs/src/content/docs/sdk/explanation/hooks.md
+++ b/docs/src/content/docs/sdk/explanation/hooks.md
@@ -1,0 +1,89 @@
+---
+title: The Hook System
+sidebar:
+  order: 20
+---
+
+PromptKit exposes four families of hooks that let you observe, mutate, or veto work happening inside the runtime. They share a family resemblance but their semantics differ in important ways. This page explains the mental model so you can pick the right one and reason about what happens when something goes wrong.
+
+## Why four hook types?
+
+Different parts of the runtime have different contracts with the caller. A single "hook" abstraction would either be too weak (unable to gate a live LLM call) or too strong (forcing observational concerns to think about denial semantics). Four hook types, one per contract:
+
+| Hook | Contract | Can deny? | Can mutate? | Fires per |
+|---|---|---|---|---|
+| **ProviderHook** | Request/response around an LLM call | Yes | Yes (via enforcement) | Each provider call |
+| **ChunkInterceptor** | Each streaming chunk | Yes (abort stream) | Yes (enforcement) | Each chunk |
+| **ToolHook** | Request/response around a tool call | Yes | Yes (enforcement) | Each tool call |
+| **SessionHook** | Session lifecycle | Yes (via error return) | No | Session start, each turn, session end |
+| **EvalHook** | Eval result | No (observational) | Yes (direct result mutation) | Each eval result |
+
+Pick the hook whose contract matches your intent. A PII redactor gates content → `ProviderHook`. An audit log observes turns → `SessionHook`. A metrics exporter watches eval scores → `EvalHook`. A kill-switch that aborts mid-stream → `ChunkInterceptor`.
+
+## The two shapes of "mutate"
+
+All hooks that can modify behavior fall into one of two shapes.
+
+**Decision-based** (Provider, Chunk, Tool). The hook returns a `Decision` struct. To "mutate," the hook modifies the request/response in place **before** returning `hooks.Enforced(...)`. The pipeline then continues with the modified content. The alternative is `hooks.Deny(...)`, which produces a `HookDeniedError` and aborts. Built-in guardrails always use `Enforced`; denial is reserved for hooks that want to be fatal.
+
+**Direct-mutation** (Eval). The hook is handed a pointer to the result and mutates it in place. There's no decision struct — the hook is observational by contract, but it's allowed to edit the observation before it propagates (redact explanations, enrich details, add tracing metadata). No pipeline gating happens either way.
+
+Session hooks are unusual: they return a plain Go `error`. Non-nil errors propagate to the caller but there's no enforcement/denial distinction. Use session hooks for pure observation or for "abort the session" errors, not for content modification.
+
+## Execution ordering
+
+Within a registered conversation, hooks execute in a fixed order relative to pipeline stages:
+
+1. `SessionHook.OnSessionStart` — at session creation.
+2. `ProviderHook.BeforeCall` — before each LLM call.
+3. `ChunkInterceptor.OnChunk` — for each streaming chunk.
+4. `ProviderHook.AfterCall` — after each LLM call.
+5. `ToolHook.BeforeExecution` — before each tool call.
+6. `ToolHook.AfterExecution` — after each tool call.
+7. `SessionHook.OnSessionUpdate` — after each turn completes.
+8. `SessionHook.OnSessionEnd` — at session teardown.
+9. `EvalHook.OnEvalResult` — each time an eval produces a result (independent of the session loop — fires from the eval runner).
+
+Within a single phase, multiple hooks run in **registration order**. For decision-based hooks, the first `Deny` short-circuits. For eval hooks, every registered hook always runs — a panic in one doesn't block the others.
+
+## Error handling and safety
+
+**Nil-safety.** A nil `*hooks.Registry` is a no-op. You can wire hooks optionally without special-casing "no hooks configured."
+
+**Panic safety.** Eval hooks run inside a `recover()` scoped to each hook — one panic does not block the rest, and the eval result is still emitted. Provider, tool, and session hooks do **not** currently recover panics; a panicking hook crashes the request. Don't panic in a hook.
+
+**Timeouts.** Exec-based hooks (subprocess-backed) have a configurable `timeout_ms`. If the subprocess exceeds it, the parent kills it and — in `filter` mode — treats the timeout as a denial. In `observe` mode and for eval hooks, the timeout just aborts the subprocess and the pipeline continues.
+
+**Concurrency.** Hooks may run concurrently with one another across different conversations. Stateless hooks are always safe. Stateful hooks (e.g. a streaming buffer per response) must scope their state to a single conversation or synchronize explicitly.
+
+## When to use an exec hook vs. a Go hook
+
+A **Go hook** is the right choice when:
+- You're shipping a library that wraps PromptKit and wants opinionated defaults.
+- The hook logic is fast enough that process-spawn overhead would dominate.
+- You need access to Go types (e.g. inspecting `*providers.StreamChunk` internals).
+
+An **exec hook** is the right choice when:
+- The hook is implemented in a non-Go language (Python ML models, Node log shippers).
+- The hook is operated by a different team and should be upgraded independently of the runtime.
+- You want per-deployment configurability via `RuntimeConfig` YAML without rebuilding.
+
+Exec hooks are slower (process spawn per call) and less expressive (JSON round-trip), but they're more flexible operationally. Most teams start with Go hooks and graduate specific policies (PII, audit) to exec hooks when the operational boundary matters.
+
+## When not to reach for a hook
+
+Hooks are the right tool for **cross-cutting concerns** — observability, safety, policy — that apply uniformly across many calls. They are the wrong tool for:
+
+- **Per-prompt behavior** — use the prompt itself, or a scenario variable.
+- **Business logic** — put it in a tool, not a tool hook.
+- **State that only one hook reads** — use a local struct field, not a hook.
+- **Changing what the LLM sees in a specific turn** — use a pipeline stage (see [Pipeline Reference](/runtime/reference/pipeline/)), which is a cleaner extension point for content transformation.
+
+If you find yourself writing "if this tool, then that hook," the logic probably belongs in the tool or the pipeline stage, not in a hook.
+
+## See also
+
+- [Hooks Reference](/runtime/reference/hooks/) — interface signatures, registration, built-in guardrails
+- [Exec Hooks How-To](/sdk/how-to/exec-hooks/) — subprocess-backed hooks in any language
+- [Exec Protocol Reference](/sdk/reference/exec-protocol/) — stdin/stdout wire format
+- [RuntimeConfig](/sdk/how-to/use-runtime-config/) — declarative hook configuration via YAML

--- a/docs/src/content/docs/sdk/how-to/exec-hooks.md
+++ b/docs/src/content/docs/sdk/how-to/exec-hooks.md
@@ -30,7 +30,7 @@ The runtime starts `./hooks/pii-redactor` before each provider call, sends the r
 
 ## Hook Types
 
-There are three hook types, each receiving a different payload on stdin.
+There are four hook types, each receiving a different payload on stdin.
 
 ### Provider Hooks
 
@@ -59,6 +59,14 @@ Observe session lifecycle events.
 | `session_start` | A new session begins |
 | `session_update` | The session state changes |
 | `session_end` | The session ends |
+
+### Eval Hooks
+
+Observe eval results as they are produced by the runner. Eval hooks are **always fire-and-forget** — `mode` and `phases` are ignored; the subprocess never gates execution.
+
+| Phase | When it fires |
+|-------|---------------|
+| (implicit) | Once per executed eval, after the handler runs, before the result is emitted |
 
 ---
 
@@ -200,6 +208,28 @@ The runtime starts the subprocess, writes a JSON object to stdin, and reads a JS
 {"ack": true}
 ```
 
+### Eval Hook
+
+The eval runner writes the raw `EvalResult` JSON to the subprocess's stdin. Stdout is ignored — this is strictly fire-and-forget.
+
+**stdin:**
+
+```json
+{
+  "eval_id": "assertion_1_tool_called",
+  "type": "assertion",
+  "score": 1.0,
+  "passed": true,
+  "duration_ms": 3,
+  "explanation": "tool 'lookup_order' was called",
+  "details": {"tool_name": "lookup_order"}
+}
+```
+
+**stdout:** discarded.
+
+Errors, non-zero exits, and timeouts are logged via the runtime logger but never propagate to the eval pipeline. Missing stdout, empty stdout, or any other I/O anomaly is not an error.
+
 ---
 
 ## Examples
@@ -270,6 +300,40 @@ with open("/var/log/promptkit-audit.jsonl", "a") as f:
 json.dump({"ack": True}, sys.stdout)
 ```
 
+### Metrics Exporter (Eval / Fire-and-forget)
+
+Push every eval result to an external metrics backend without blocking the eval pipeline.
+
+```yaml
+spec:
+  hooks:
+    eval_metrics:
+      command: python3
+      args: [./hooks/eval-metrics.py]
+      hook: eval
+      timeout_ms: 5000
+```
+
+```python
+#!/usr/bin/env python3
+import json, sys, urllib.request
+
+result = json.load(sys.stdin)
+payload = {
+    "eval_id": result["eval_id"],
+    "score": result.get("score", 0.0),
+    "passed": result.get("passed", False),
+    "duration_ms": result.get("duration_ms", 0),
+}
+
+req = urllib.request.Request(
+    "https://metrics.internal/evals",
+    data=json.dumps(payload).encode(),
+    headers={"Content-Type": "application/json"},
+)
+urllib.request.urlopen(req, timeout=2)  # stdout is ignored
+```
+
 ### Query Allowlist (Tool / Filter)
 
 Only permit pre-approved SQL queries to run.
@@ -334,16 +398,22 @@ spec:
       hook: session
       phases: [session_start, session_update, session_end]
       mode: observe
+
+    eval_metrics:
+      command: python3
+      args: [./hooks/eval-metrics.py]
+      hook: eval
+      timeout_ms: 5000
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `command` | Yes | Path to the executable or interpreter |
 | `args` | No | Additional arguments passed to the command |
-| `hook` | Yes | Hook type: `provider`, `tool`, or `session` |
-| `phases` | Yes | List of phases this hook fires on |
-| `mode` | Yes | `filter` (fail-closed) or `observe` (fire-and-forget) |
-| `timeout_ms` | No | Subprocess timeout in milliseconds (filter mode only) |
+| `hook` | Yes | Hook type: `provider`, `tool`, `session`, or `eval` |
+| `phases` | Yes (ignored for `eval`) | List of phases this hook fires on |
+| `mode` | Yes (ignored for `eval`) | `filter` (fail-closed) or `observe` (fire-and-forget) |
+| `timeout_ms` | No | Subprocess timeout in milliseconds |
 
 ---
 

--- a/docs/src/content/docs/sdk/how-to/run-evals.md
+++ b/docs/src/content/docs/sdk/how-to/run-evals.md
@@ -276,10 +276,43 @@ type EvalResult struct {
 
 Eval handlers produce scores only. Use `result.IsPassed()` to derive pass/fail from the score (true when score is nil or ≥ 1.0). The `Passed` field is deprecated for standalone evals — it is only set explicitly by `AssertionEvalHandler` and `GuardrailEvalHandler` wrappers.
 
+## Observing Results with EvalHook
+
+Register an `EvalHook` to observe (or mutate) each eval result as it's produced. Useful for:
+
+- Pushing results to external metrics/tracing systems.
+- Redacting sensitive content from `Explanation` or `Details` before results propagate.
+- Fanning out to a subprocess via `ExecEvalHook` (configured in `RuntimeConfig`).
+
+```go
+type MetricsHook struct {
+    exporter MetricExporter
+}
+
+func (h *MetricsHook) Name() string { return "metrics_exporter" }
+
+func (h *MetricsHook) OnEvalResult(
+    ctx context.Context,
+    def *evals.EvalDef,
+    _ *evals.EvalContext,
+    result *evals.EvalResult,
+) {
+    h.exporter.Record(ctx, def.ID, result.Score, result.DurationMs)
+}
+
+conv, _ := sdk.Open("./app.pack.json", "chat",
+    sdk.WithEvalHook(&MetricsHook{exporter: exp}),
+)
+```
+
+Eval hooks are observational by contract — they cannot gate execution. Every registered hook runs for every eval result, in registration order, with per-hook panic recovery. See [Hooks Explanation](/sdk/explanation/hooks/) for the full mental model and [Hooks Reference](/runtime/reference/hooks/#evalhook) for the interface details.
+
 ## See Also
 
 - [Metrics Reference](/runtime/reference/metrics/) -- Complete catalog of all emitted metrics
 - [Checks Reference](/reference/checks/) -- All check types and parameters
 - [Unified Check Model](/concepts/validation/) -- How evals, assertions, and guardrails relate
 - [Eval Framework](/arena/explanation/eval-framework/) -- Eval architecture, triggers, and metrics
+- [Hooks Reference](/runtime/reference/hooks/#evalhook) -- `EvalHook` and `ExecEvalHook` API
+- [Exec Hooks How-To](/sdk/how-to/exec-hooks/) -- subprocess-backed eval hooks in any language
 - [Monitor Events](/sdk/how-to/monitor-events/) -- Event-based observability


### PR DESCRIPTION
## Summary

Brings `EvalHook` documentation to the same level of coverage as `ProviderHook`, `ToolHook`, and `SessionHook`. Also fills a smaller gap for `SessionHook` (no custom-hook example in the reference before) and adds a single mental-model explanation covering the whole hook system.

## What changed

- **`runtime/reference/hooks.md`** — add `EvalHook` to the overview, core interfaces, registry, execution order, Custom Hooks (with new Go examples for `SessionHook` and `EvalHook`), and the exec adapters table. Clarify where Decision semantics apply and where they don't.
- **`sdk/how-to/exec-hooks.md`** — add the eval hook type, payload shape, and a fire-and-forget metrics-exporter example. Document that `mode`/`phases` are ignored for `hook: eval`.
- **`sdk/how-to/run-evals.md`** — new _Observing Results with EvalHook_ section covering `sdk.WithEvalHook` with a code sample and cross-links.
- **`sdk/explanation/hooks.md`** — new: mental model for the four hook families, decision vs direct-mutation shapes, execution ordering, panic/timeout/concurrency semantics, when to use exec vs Go hooks, and when not to reach for a hook.

## Test plan

- [x] `cd docs && npm run build` — 281 pages built, no errors.
- [x] All internal links used resolve to existing pages (spot-checked against `docs/dist/`).