### PR TITLE
feat(skills): MountAs virtual path indirection for SkillSource

### DIFF
--- a/runtime/skills/executor_test.go
+++ b/runtime/skills/executor_test.go
@@ -416,6 +416,35 @@ func createSkillTree(t *testing.T) (root string, skillsDir string) {
 	return root, skillsDir
 }
 
+// TestExecutor_SetFilter_MatchesMountAsVirtualPath verifies that a workflow
+// filter glob matches against the MountAs-virtual path, not the real disk path.
+// A skill at <root>/external/pci mounted as "skills/billing" should match
+// the workflow filter "skills/billing/*".
+func TestExecutor_SetFilter_MatchesMountAsVirtualPath(t *testing.T) {
+	root := t.TempDir()
+	external := filepath.Join(root, "external")
+	pciDir := filepath.Join(external, "pci")
+	if err := os.MkdirAll(pciDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pciDir, "SKILL.md"),
+		[]byte("---\nname: pci\ndescription: PCI\n---\nPCI instructions.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := NewRegistry()
+	if err := reg.Discover([]SkillSource{{Dir: external, MountAs: "skills/billing"}}); err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	exec := NewExecutor(ExecutorConfig{Registry: reg, ConfigDir: root})
+	exec.SetFilter("skills/billing/*")
+
+	if _, _, err := exec.Activate("pci"); err != nil {
+		t.Errorf("expected pci to match virtual-path glob, got error: %v", err)
+	}
+}
+
 func TestExecutor_SetFilter_AllowsMatchingSkills(t *testing.T) {
 	root, skillsDir := createSkillTree(t)
 	reg := NewRegistry()

--- a/runtime/skills/registry.go
+++ b/runtime/skills/registry.go
@@ -26,9 +26,16 @@ type Registry struct {
 
 type registeredSkill struct {
 	metadata SkillMetadata
-	path     string // filesystem path to skill directory (empty for inline)
-	inline   *Skill // non-nil for inline skills
-	preload  bool
+	// realPath is the filesystem path to the skill directory (empty for inline).
+	// Used for all IO: ParseSkillFile, ReadResource, path-containment checks.
+	realPath string
+	// virtualPath is the path presented to consumers (Skill.Path), workflow
+	// glob filters, and ListForDir. Equals realPath unless the source had
+	// MountAs set, in which case it's MountAs + the relative subpath under
+	// the source dir. Empty for inline skills.
+	virtualPath string
+	inline      *Skill // non-nil for inline skills
+	preload     bool
 }
 
 // NewRegistry creates a new empty skill registry.
@@ -47,7 +54,10 @@ func (r *Registry) Discover(sources []SkillSource) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for _, src := range sources {
+	for i, src := range sources {
+		if err := validateSkillSource(&src); err != nil {
+			return fmt.Errorf("skills[%d]: %w", i, err)
+		}
 		if dir := src.EffectiveDir(); dir != "" {
 			resolved, err := r.resolveSource(&src)
 			if err != nil {
@@ -58,6 +68,25 @@ func (r *Registry) Discover(sources []SkillSource) error {
 			}
 		} else if src.Name != "" {
 			r.registerInline(src)
+		}
+	}
+	return nil
+}
+
+// validateSkillSource enforces structural rules on a SkillSource before discovery.
+func validateSkillSource(src *SkillSource) error {
+	if src.MountAs == "" {
+		return nil
+	}
+	if src.EffectiveDir() == "" {
+		return fmt.Errorf("MountAs is only valid for directory-based sources, not inline")
+	}
+	if strings.ContainsAny(src.MountAs, "*?[") {
+		return fmt.Errorf("MountAs must be a literal directory prefix, not a glob: %q", src.MountAs)
+	}
+	for _, segment := range strings.Split(filepath.ToSlash(src.MountAs), "/") {
+		if segment == ".." {
+			return fmt.Errorf("MountAs must not contain '..' segments: %q", src.MountAs)
 		}
 	}
 	return nil
@@ -78,7 +107,7 @@ func (r *Registry) resolveSource(src *SkillSource) (SkillSource, error) {
 	if err != nil {
 		return SkillSource{}, fmt.Errorf("resolving skill reference %s: %w", dir, err)
 	}
-	return SkillSource{Dir: resolved, Preload: src.Preload}, nil
+	return SkillSource{Dir: resolved, Preload: src.Preload, MountAs: src.MountAs}, nil
 }
 
 // discoverDirectory walks a directory looking for SKILL.md files and registers each skill found.
@@ -103,6 +132,7 @@ func (r *Registry) discoverDirectory(src SkillSource) error {
 		}
 
 		skillDir := filepath.Dir(path)
+		virtualPath := computeVirtualPath(absDir, skillDir, src.MountAs)
 		if existing, exists := r.skills[meta.Name]; exists {
 			if src.Preload && !existing.preload {
 				existing.preload = true
@@ -114,12 +144,27 @@ func (r *Registry) discoverDirectory(src SkillSource) error {
 		}
 
 		r.skills[meta.Name] = &registeredSkill{
-			metadata: *meta,
-			path:     skillDir,
-			preload:  src.Preload,
+			metadata:    *meta,
+			realPath:    skillDir,
+			virtualPath: virtualPath,
+			preload:     src.Preload,
 		}
 		return nil
 	})
+}
+
+// computeVirtualPath returns the path that consumers see for a discovered skill.
+// When mountAs is empty, it equals the real on-disk path. When mountAs is set,
+// the skill's subdirectory under sourceDir is preserved under the mountAs prefix.
+func computeVirtualPath(sourceDir, skillDir, mountAs string) string {
+	if mountAs == "" {
+		return skillDir
+	}
+	rel, err := filepath.Rel(sourceDir, skillDir)
+	if err != nil || rel == "." {
+		return mountAs
+	}
+	return filepath.Join(mountAs, rel)
 }
 
 // registerInline registers an inline skill source directly.
@@ -165,8 +210,11 @@ func (r *Registry) List() []SkillMetadata {
 	return result
 }
 
-// ListForDir returns metadata for skills whose path is under the given directory.
-// If dir is empty, returns all skills. Results are sorted by name.
+// ListForDir returns metadata for skills whose virtual path is under the given
+// directory. If dir is empty, returns all skills. Results are sorted by name.
+//
+// Matching uses the virtual path (i.e. honoring MountAs), which is what the
+// workflow filter and consumers see. Inline skills are skipped.
 func (r *Registry) ListForDir(dir string) []SkillMetadata {
 	if dir == "" {
 		return r.List()
@@ -183,10 +231,10 @@ func (r *Registry) ListForDir(dir string) []SkillMetadata {
 
 	var result []SkillMetadata
 	for _, rs := range r.skills {
-		if rs.path == "" {
+		if rs.virtualPath == "" {
 			continue
 		}
-		absPath, err := filepath.Abs(rs.path)
+		absPath, err := filepath.Abs(rs.virtualPath)
 		if err != nil {
 			continue
 		}
@@ -215,12 +263,12 @@ func (r *Registry) Load(name string) (*Skill, error) {
 		return rs.inline, nil
 	}
 
-	skillPath := filepath.Join(rs.path, skillMDFile)
+	skillPath := filepath.Join(rs.realPath, skillMDFile)
 	skill, err := ParseSkillFile(skillPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading skill %q: %w", name, err)
 	}
-	skill.Path = rs.path
+	skill.Path = rs.virtualPath
 	return skill, nil
 }
 
@@ -235,12 +283,14 @@ func (r *Registry) ReadResource(name, resourcePath string) ([]byte, error) {
 		return nil, fmt.Errorf("skill %q not found", name)
 	}
 
-	if rs.path == "" {
+	if rs.realPath == "" {
 		return nil, fmt.Errorf("skill %q is inline and has no directory", name)
 	}
 
-	// Resolve the skill directory to its canonical absolute path.
-	baseDir, err := filepath.EvalSymlinks(rs.path)
+	// Resolve the skill directory to its canonical absolute path. ReadResource
+	// always uses the real on-disk path — MountAs only affects display and
+	// glob matching, never IO or path-containment checks.
+	baseDir, err := filepath.EvalSymlinks(rs.realPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolving skill directory: %w", err)
 	}
@@ -295,13 +345,13 @@ func (r *Registry) PreloadedSkills() []*Skill {
 			result = append(result, rs.inline)
 			continue
 		}
-		skillPath := filepath.Join(rs.path, skillMDFile)
+		skillPath := filepath.Join(rs.realPath, skillMDFile)
 		skill, err := ParseSkillFile(skillPath)
 		if err != nil {
 			logger.Error("skills: failed to preload skill", "skill", name, "error", err)
 			continue
 		}
-		skill.Path = rs.path
+		skill.Path = rs.virtualPath
 		result = append(result, skill)
 	}
 	sort.Slice(result, func(i, j int) bool {

--- a/runtime/skills/registry_test.go
+++ b/runtime/skills/registry_test.go
@@ -518,6 +518,116 @@ func TestDiscoverInlinePreloadUpgrade(t *testing.T) {
 	}
 }
 
+// TestDiscoverMountAs verifies that MountAs presents skills under a virtual prefix
+// while preserving subdirectory structure under the source dir.
+func TestDiscoverMountAs(t *testing.T) {
+	source := t.TempDir()
+	writeTestSkill(t, filepath.Join(source, "billing"), "payments", "Payment processing", "Pay instructions")
+	writeTestSkill(t, filepath.Join(source, "orders"), "fulfillment", "Order fulfillment", "Fulfillment instructions")
+
+	reg := NewRegistry()
+	err := reg.Discover([]SkillSource{{Dir: source, MountAs: "skills"}})
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	pay, err := reg.Load("payments")
+	if err != nil {
+		t.Fatalf("Load(payments): %v", err)
+	}
+	if got, want := pay.Path, filepath.Join("skills", "billing", "payments"); got != want {
+		t.Errorf("payments.Path = %q, want %q (virtual path under MountAs prefix)", got, want)
+	}
+
+	ful, err := reg.Load("fulfillment")
+	if err != nil {
+		t.Fatalf("Load(fulfillment): %v", err)
+	}
+	if got, want := ful.Path, filepath.Join("skills", "orders", "fulfillment"); got != want {
+		t.Errorf("fulfillment.Path = %q, want %q", got, want)
+	}
+}
+
+// TestDiscoverMountAsReadResource verifies that ReadResource still uses the real
+// on-disk path even when MountAs is set, so files can actually be read.
+func TestDiscoverMountAsReadResource(t *testing.T) {
+	source := t.TempDir()
+	skillDir := writeTestSkill(t, filepath.Join(source, "billing"), "payments", "Payment processing", "Pay instructions")
+
+	const markerName = "marker.txt"
+	const markerBody = "marker contents"
+	if err := os.WriteFile(filepath.Join(skillDir, markerName), []byte(markerBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := NewRegistry()
+	if err := reg.Discover([]SkillSource{{Dir: source, MountAs: "skills"}}); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	got, err := reg.ReadResource("payments", markerName)
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	if string(got) != markerBody {
+		t.Errorf("ReadResource body = %q, want %q", got, markerBody)
+	}
+}
+
+// TestDiscoverMountAsDoesNotEscape ensures MountAs cannot be used to bypass
+// path-containment in ReadResource: even if the virtual path looks like
+// "/etc", reads are still scoped to the real source dir.
+func TestDiscoverMountAsDoesNotEscape(t *testing.T) {
+	source := t.TempDir()
+	writeTestSkill(t, source, "rogue", "Rogue", "Rogue instructions")
+
+	reg := NewRegistry()
+	if err := reg.Discover([]SkillSource{{Dir: source, MountAs: "/etc"}}); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if _, err := reg.ReadResource("rogue", "../../../../etc/passwd"); err == nil {
+		t.Error("ReadResource should reject path traversal even with arbitrary MountAs")
+	}
+}
+
+// TestDiscoverMountAsRejectedOnInline asserts that setting MountAs on an inline
+// skill source (Name set, no Dir) returns a validation error from Discover.
+func TestDiscoverMountAsRejectedOnInline(t *testing.T) {
+	reg := NewRegistry()
+	err := reg.Discover([]SkillSource{
+		{Name: "inline-with-mount", Description: "x", Instructions: "y", MountAs: "skills"},
+	})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+}
+
+// TestDiscoverMountAsRejectsGlob asserts that MountAs containing glob metacharacters
+// is rejected — MountAs is a literal directory prefix.
+func TestDiscoverMountAsRejectsGlob(t *testing.T) {
+	source := t.TempDir()
+	writeTestSkill(t, source, "alpha", "Alpha", "Alpha")
+
+	reg := NewRegistry()
+	err := reg.Discover([]SkillSource{{Dir: source, MountAs: "skills/*/billing"}})
+	if err == nil {
+		t.Fatal("expected validation error for glob in MountAs, got nil")
+	}
+}
+
+// TestDiscoverMountAsRejectsParent asserts MountAs with .. segments is rejected.
+func TestDiscoverMountAsRejectsParent(t *testing.T) {
+	source := t.TempDir()
+	writeTestSkill(t, source, "alpha", "Alpha", "Alpha")
+
+	reg := NewRegistry()
+	err := reg.Discover([]SkillSource{{Dir: source, MountAs: "skills/../../escape"}})
+	if err == nil {
+		t.Fatal("expected validation error for .. in MountAs, got nil")
+	}
+}
+
 // TestDiscoverPreloadNotDowngraded verifies that a later source with preload=false
 // does NOT downgrade a skill already registered with preload=true.
 func TestDiscoverPreloadNotDowngraded(t *testing.T) {

--- a/runtime/skills/types.go
+++ b/runtime/skills/types.go
@@ -21,37 +21,66 @@ type SkillMetadata struct {
 type Skill struct {
 	SkillMetadata
 	Instructions string `json:"instructions"` // Markdown body from SKILL.md
-	Path         string `json:"path"`         // Filesystem path to skill directory
+	// Path is the consumer-facing skill directory. For sources without
+	// MountAs this is the real on-disk path. For sources with MountAs it
+	// is the *virtual* path (MountAs prefix + relative subpath under the
+	// source dir) — workflow glob filters and ListForDir match against
+	// this. To read files from the skill, always go through
+	// Registry.ReadResource; do not treat Path as a filesystem path.
+	Path string `json:"path"`
 }
 
-// SkillSource represents a skill reference from the pack YAML.
+// SkillSource describes one source of skills to register with a Registry.
+//
+// A source is either:
+//   - directory-based — set Dir (or Path as an alias). The registry walks the
+//     directory for SKILL.md files and registers each one found. MountAs and
+//     Preload apply.
+//   - inline — set Name, Description, and Instructions. The skill is
+//     registered as if it had been read from disk. MountAs is rejected here.
+//
+// Multiple SkillSources can be passed to Registry.Discover. They are processed
+// in order; the first source to register a given skill name wins for path and
+// metadata. Preload is OR-combined: a later source can upgrade preload from
+// false to true but never the reverse.
 type SkillSource struct {
-	// For directory-based skills
+	// For directory-based skills.
+	// Dir is the real on-disk directory to walk for SKILL.md files. Path is a
+	// YAML/JSON alias accepted for legacy schemas; if both are set Dir wins.
 	Dir  string `yaml:"dir,omitempty" json:"dir,omitempty"`
-	Path string `yaml:"path,omitempty" json:"path,omitempty"` // schema alias for dir
+	Path string `yaml:"path,omitempty" json:"path,omitempty"`
 
-	// For inline skills
+	// For inline skills — Name is required and uniquely identifies the
+	// skill in the registry. Description and Instructions populate the
+	// in-memory Skill directly; no SKILL.md is read.
 	Name         string `yaml:"name,omitempty" json:"name,omitempty"`
 	Description  string `yaml:"description,omitempty" json:"description,omitempty"`
 	Instructions string `yaml:"instructions,omitempty" json:"instructions,omitempty"`
 
 	// MountAs, when set on a directory-based source, presents discovered
-	// skills to the registry, workflow filters, and consumers as if they
-	// lived under this virtual directory prefix instead of their real
-	// on-disk location. Read operations (ReadResource, ParseSkillFile)
-	// continue to use the real path — MountAs only affects display and
-	// glob matching.
+	// skills to the registry, workflow filters, and Skill.Path consumers
+	// as if they lived under this virtual directory prefix instead of
+	// their real on-disk location. ReadResource always uses the real
+	// path — MountAs only affects display and glob matching, never IO
+	// or path-containment checks.
 	//
-	// Subdirectory structure under the source dir is preserved: a skill
-	// at /foo/agentskills/billing/payments/SKILL.md discovered with
+	// Subdirectory structure under Dir is preserved: a skill at
+	// /foo/agentskills/billing/payments/SKILL.md discovered with
 	// Dir: "/foo/agentskills" and MountAs: "skills" is exposed as
-	// virtual path "skills/billing/payments".
+	// virtual path "skills/billing/payments", which means a workflow
+	// state with `skills: "skills/billing/*"` will match it.
 	//
-	// MountAs is ignored for inline sources (Name set, Dir empty) and
-	// rejected by the packc validator if set on one.
+	// MountAs must be a literal directory prefix — glob metacharacters
+	// (* ? [) and ".." segments are rejected at Discover time. Setting
+	// MountAs on an inline source (Name set, Dir empty) is also rejected.
 	MountAs string `yaml:"mount_as,omitempty" json:"mount_as,omitempty"`
 
-	// Options
+	// Preload, when true, causes the skill's instructions to be loaded
+	// into the system prompt at session start instead of being activated
+	// on demand via skill__activate. Use sparingly — preloaded skills
+	// consume context budget every turn. Across duplicate sources Preload
+	// is OR-combined: a later source can upgrade preload from false to
+	// true, but never the reverse.
 	Preload bool `yaml:"preload,omitempty" json:"preload,omitempty"`
 }
 
@@ -107,7 +136,9 @@ func ParseSkillRef(s string) (SkillRef, error) {
 	}, nil
 }
 
-// EffectiveDir returns the directory path, preferring Dir over Path.
+// EffectiveDir returns the real on-disk source directory, preferring Dir over
+// the legacy Path alias. Returns the empty string for inline sources. This is
+// always the *real* path; MountAs has no effect here.
 func (s *SkillSource) EffectiveDir() string {
 	if s.Dir != "" {
 		return s.Dir

--- a/runtime/skills/types.go
+++ b/runtime/skills/types.go
@@ -35,6 +35,22 @@ type SkillSource struct {
 	Description  string `yaml:"description,omitempty" json:"description,omitempty"`
 	Instructions string `yaml:"instructions,omitempty" json:"instructions,omitempty"`
 
+	// MountAs, when set on a directory-based source, presents discovered
+	// skills to the registry, workflow filters, and consumers as if they
+	// lived under this virtual directory prefix instead of their real
+	// on-disk location. Read operations (ReadResource, ParseSkillFile)
+	// continue to use the real path — MountAs only affects display and
+	// glob matching.
+	//
+	// Subdirectory structure under the source dir is preserved: a skill
+	// at /foo/agentskills/billing/payments/SKILL.md discovered with
+	// Dir: "/foo/agentskills" and MountAs: "skills" is exposed as
+	// virtual path "skills/billing/payments".
+	//
+	// MountAs is ignored for inline sources (Name set, Dir empty) and
+	// rejected by the packc validator if set on one.
+	MountAs string `yaml:"mount_as,omitempty" json:"mount_as,omitempty"`
+
 	// Options
 	Preload bool `yaml:"preload,omitempty" json:"preload,omitempty"`
 }

--- a/sdk/capability_skills_test.go
+++ b/sdk/capability_skills_test.go
@@ -331,6 +331,48 @@ func TestEnsureSkillsCapability_SkipsWhenNoDirs(t *testing.T) {
 	assert.Empty(t, caps)
 }
 
+// TestWithSkillSource verifies the option appends a SkillSource (with MountAs)
+// to skillSources, and ensureSkillsCapability picks it up alongside skillsDirs.
+func TestWithSkillSource(t *testing.T) {
+	cfg := &config{}
+	opt := WithSkillSource(skills.SkillSource{
+		Dir:     "/external",
+		MountAs: "skills/billing",
+		Preload: true,
+	})
+	require.NoError(t, opt(cfg))
+
+	require.Len(t, cfg.skillSources, 1)
+	assert.Equal(t, "/external", cfg.skillSources[0].Dir)
+	assert.Equal(t, "skills/billing", cfg.skillSources[0].MountAs)
+	assert.True(t, cfg.skillSources[0].Preload)
+
+	// ensureSkillsCapability should add a SkillsCapability when only
+	// skillSources is set (skillsDirs empty).
+	caps := ensureSkillsCapability(nil, cfg)
+	require.Len(t, caps, 1)
+	assert.Equal(t, "skills", caps[0].Name())
+}
+
+// TestEnsureSkillsCapability_CombinesDirsAndSources checks that both
+// skillsDirs (legacy convenience) and skillSources contribute to the
+// resulting capability.
+func TestEnsureSkillsCapability_CombinesDirsAndSources(t *testing.T) {
+	cfg := &config{
+		skillsDirs:   []string{"/a", "/b"},
+		skillSources: []skills.SkillSource{{Dir: "/c", MountAs: "skills"}},
+	}
+	caps := ensureSkillsCapability(nil, cfg)
+	require.Len(t, caps, 1)
+	sc, ok := caps[0].(*SkillsCapability)
+	require.True(t, ok)
+	require.Len(t, sc.sources, 3)
+	assert.Equal(t, "/a", sc.sources[0].Dir)
+	assert.Equal(t, "/b", sc.sources[1].Dir)
+	assert.Equal(t, "/c", sc.sources[2].Dir)
+	assert.Equal(t, "skills", sc.sources[2].MountAs)
+}
+
 func TestWireSkillsConfig(t *testing.T) {
 	selector := skills.NewModelDrivenSelector()
 	cfg := &config{

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -2242,9 +2242,14 @@ func WithMetricRecorder(r evals.MetricRecorder) Option {
 	}
 }
 
-// WithSkillsDir adds a directory-based skill source.
-// Skills are discovered by scanning for SKILL.md files in the directory.
-// Multiple directories can be added by calling this option multiple times.
+// WithSkillsDir adds a directory-based skill source. The runtime walks the
+// directory for SKILL.md files and registers each one found. Call multiple
+// times to register skills from multiple directories — sources are processed
+// in order and the first source to register a given skill name wins.
+//
+// This is a thin convenience over [WithSkillSource] for the common case of a
+// plain directory with no MountAs. For virtual-path mounting, preloading, or
+// inline skill definitions, use [WithSkillSource] directly.
 //
 //	conv, _ := sdk.Open("./assistant.pack.json", "chat",
 //	    sdk.WithSkillsDir("./skills"),
@@ -2256,9 +2261,26 @@ func WithSkillsDir(dir string) Option {
 	}
 }
 
-// WithSkillSource registers a [skills.SkillSource] verbatim. Use this when you
-// need fields beyond a plain directory path — most commonly MountAs to present
-// skills to the workflow filter under a virtual prefix:
+// WithSkillSource registers a [skills.SkillSource] verbatim. Use this when
+// you need anything beyond a plain directory path — most commonly:
+//
+//   - MountAs, to present skills to the workflow filter under a virtual
+//     prefix without moving the files. A skill at "./agentskills/billing/pci"
+//     mounted as "skills" appears at virtual path "skills/billing/pci", so a
+//     workflow state with `skills: "skills/*"` will match it. ReadResource
+//     still uses the real on-disk path; MountAs only affects display and
+//     glob matching.
+//   - Preload, to inject the skill's instructions into the system prompt at
+//     session start instead of waiting for the model to call skill__activate.
+//   - Inline skills, where Name + Description + Instructions are provided
+//     directly instead of being read from a SKILL.md file.
+//
+// Multiple sources can be registered by calling this option multiple times
+// and freely mixed with [WithSkillsDir]. When a skill name is discovered by
+// more than one source the first source wins for path/metadata; the Preload
+// flag is OR-combined (a later source can upgrade preload from false to true
+// but not vice versa). MountAs is rejected on inline sources, on glob
+// patterns, and on values containing ".." segments.
 //
 //	conv, _ := sdk.Open("./assistant.pack.json", "chat",
 //	    sdk.WithSkillSource(skills.SkillSource{
@@ -2267,14 +2289,6 @@ func WithSkillsDir(dir string) Option {
 //	        Preload: false,
 //	    }),
 //	)
-//
-// Multiple sources can be registered by calling this option multiple times,
-// and freely mixed with [WithSkillsDir]. When a skill name is discovered by
-// more than one source the first source wins for path/metadata; the Preload
-// flag is OR-combined across sources (a later source can upgrade preload from
-// false to true but not vice versa).
-//
-// MountAs is rejected on inline sources (where Name is set instead of Dir).
 //
 //nolint:gocritic // SkillSource is a public config struct; pass by value for API ergonomics.
 func WithSkillSource(src skills.SkillSource) Option {

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -171,6 +171,7 @@ type config struct {
 
 	// Skills configuration
 	skillsDirs      []string
+	skillSources    []skills.SkillSource
 	skillSelector   skills.SkillSelector
 	maxActiveSkills int
 
@@ -2251,6 +2252,34 @@ func WithMetricRecorder(r evals.MetricRecorder) Option {
 func WithSkillsDir(dir string) Option {
 	return func(c *config) error {
 		c.skillsDirs = append(c.skillsDirs, dir)
+		return nil
+	}
+}
+
+// WithSkillSource registers a [skills.SkillSource] verbatim. Use this when you
+// need fields beyond a plain directory path — most commonly MountAs to present
+// skills to the workflow filter under a virtual prefix:
+//
+//	conv, _ := sdk.Open("./assistant.pack.json", "chat",
+//	    sdk.WithSkillSource(skills.SkillSource{
+//	        Dir:     "./agentskills",
+//	        MountAs: "skills",
+//	        Preload: false,
+//	    }),
+//	)
+//
+// Multiple sources can be registered by calling this option multiple times,
+// and freely mixed with [WithSkillsDir]. When a skill name is discovered by
+// more than one source the first source wins for path/metadata; the Preload
+// flag is OR-combined across sources (a later source can upgrade preload from
+// false to true but not vice versa).
+//
+// MountAs is rejected on inline sources (where Name is set instead of Dir).
+//
+//nolint:gocritic // SkillSource is a public config struct; pass by value for API ergonomics.
+func WithSkillSource(src skills.SkillSource) Option {
+	return func(c *config) error {
+		c.skillSources = append(c.skillSources, src)
 		return nil
 	}
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -853,10 +853,10 @@ func ensureA2ACapability(caps []Capability, cfg *config) []Capability {
 	return append(caps, NewA2ACapability())
 }
 
-// ensureSkillsCapability adds a SkillsCapability if config has skills dirs
+// ensureSkillsCapability adds a SkillsCapability if config has skill sources
 // but no SkillsCapability was already inferred or explicit.
 func ensureSkillsCapability(caps []Capability, cfg *config) []Capability {
-	if len(cfg.skillsDirs) == 0 {
+	if len(cfg.skillsDirs) == 0 && len(cfg.skillSources) == 0 {
 		return caps
 	}
 	for _, cap := range caps {
@@ -864,10 +864,11 @@ func ensureSkillsCapability(caps []Capability, cfg *config) []Capability {
 			return caps
 		}
 	}
-	var sources []skills.SkillSource
+	sources := make([]skills.SkillSource, 0, len(cfg.skillsDirs)+len(cfg.skillSources))
 	for _, dir := range cfg.skillsDirs {
 		sources = append(sources, skills.SkillSource{Dir: dir})
 	}
+	sources = append(sources, cfg.skillSources...)
 	return append(caps, NewSkillsCapability(sources))
 }
 


### PR DESCRIPTION
## Summary

Adds `MountAs` to `skills.SkillSource`. A skill source can be discovered from one filesystem path but presented to the registry, workflow filters, and consumers as if it lived under a different virtual prefix. Read operations stay on the real path; only display/match paths use the virtual one.

**Use case:** SDK callers can register skills from their own directory layout (e.g. `/agentskills/`) while targeting a pack that hard-codes a workflow filter like `skills/billing/*` — without symlinks or copies.

## What's in the box

- `runtime/skills/types.go` — new `MountAs string` field on `SkillSource`.
- `runtime/skills/registry.go` — internal `registeredSkill` now tracks `realPath` (IO) and `virtualPath` (display/match). `discoverDirectory` joins `MountAs` with each skill's relative subpath under the source dir, preserving subdirectory structure. `ReadResource` keeps using `realPath` — `MountAs` cannot bypass path containment. `ListForDir` filters by `virtualPath`. `resolveSource` preserves `MountAs` through `@org/name` resolution.
- `runtime/skills/registry.go` — `validateSkillSource` rejects `MountAs` on inline sources, glob metacharacters (`*?[`), and `..` segments.
- `sdk/options.go` — new `WithSkillSource(src skills.SkillSource)` for full struct registration. Existing `WithSkillsDir(dir)` stays as the convenience.
- `sdk/sdk.go` — `ensureSkillsCapability` now consumes both `skillsDirs` and the new `skillSources` slice.

## Tests

- Positive path: virtual path under prefix, subdirectory structure preserved.
- IO still works: `ReadResource` reads through to real on-disk file.
- Security: `MountAs` cannot escape path containment in `ReadResource`.
- Validation: rejects on inline, rejects glob, rejects `..`.
- End-to-end: workflow filter glob matches the virtual path (Executor test).
- SDK wiring: `WithSkillSource` + combined dirs/sources path.

## Out of scope (deferred per proposal)

- Pack YAML `mount_as` field + schema regeneration. SDK-only is enough to validate the design.

See `docs/local-backlog/SKILL_MOUNT_AS_PROPOSAL.md` for the full design + open questions.

## Test plan

- [x] `go test ./runtime/skills/... ./sdk/... -count=1 -race` — all green
- [x] `golangci-lint run --new-from-rev=main` — 0 issues
- [x] Coverage on changed files ≥ 80% (`runtime/skills/registry.go`: 89.3%, `runtime/skills/types.go`: 100%, `sdk/options.go`: 80.6%, `sdk/sdk.go`: 81.4%)