### PR TITLE
fix(server,docs): lint shadow + collapse duplicate hooks-page overview

### DIFF
--- a/docs/src/content/docs/runtime/reference/hooks.md
+++ b/docs/src/content/docs/runtime/reference/hooks.md
@@ -18,9 +18,7 @@ For *when* to reach for which hook type, see [The Hook System](/sdk/explanation/
 | [`SessionHook`](#sessionhook) | Session start, each turn, session end | `error` (nil = ok) | None |
 | [`EvalHook`](#evalhook) | Each eval result, before emission | none — direct mutation only | None |
 
-## Core Interfaces
-
-### ProviderHook
+## ProviderHook
 
 Intercepts LLM provider calls. This is the primary hook for content validation and guardrails.
 
@@ -32,7 +30,7 @@ type ProviderHook interface {
 }
 ```
 
-### ChunkInterceptor
+## ChunkInterceptor
 
 An opt-in streaming extension for `ProviderHook`. Hooks that also implement `ChunkInterceptor` can inspect each streaming chunk in real time:
 
@@ -42,7 +40,7 @@ type ChunkInterceptor interface {
 }
 ```
 
-### ToolHook
+## ToolHook
 
 Intercepts LLM-initiated tool calls:
 
@@ -54,7 +52,7 @@ type ToolHook interface {
 }
 ```
 
-### SessionHook
+## SessionHook
 
 Tracks session lifecycle events:
 
@@ -67,7 +65,7 @@ type SessionHook interface {
 }
 ```
 
-### EvalHook
+## EvalHook
 
 Observes eval results as they are produced by the eval runner. Unlike the hooks above, `EvalHook` is purely **observational** — evals compute scores and do not gate execution, so there is no allow/deny semantics. Hooks fire once per executed eval, after the handler runs, and before the result is emitted as an event.
 

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -503,8 +503,8 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request, req *
 	}
 
 	taskID := generateID()
-	if _, err := s.taskStore.Create(taskID, contextID); err != nil {
-		log.Printf("a2a: failed to create task for context %s: %v", contextID, err)
+	if _, createErr := s.taskStore.Create(taskID, contextID); createErr != nil {
+		log.Printf("a2a: failed to create task for context %s: %v", contextID, createErr)
 		writeRPCError(w, req.ID, -32000, "internal server error")
 		return
 	}


### PR DESCRIPTION
## Two unrelated fixes

**1. server/a2a/server.go:506 lint shadow (cosmetic)** — \`if _, err := ...\` inside the function shadows the outer \`err\` declared at line 485. The CI lint job uses \`--issues-exit-code=0\` and \`only-new-issues: true\` so this never failed CI; main's red run on commit a0e03c37 was actually a 504 from the GHA control plane (the rerun confirmed: green). Cleaning up the shadow regardless because it's a real warning that surfaces in fresh local lint runs and there's no reason to keep it.

**2. docs/runtime/reference/hooks.md two-overviews issue** — the page rendered with both a \"Hook types\" summary table AND a \"Core Interfaces\" wrapper heading immediately after, both summarising the same five interfaces. Dropped the wrapper, promoted each interface to a top-level \`##\` so the table is the single overview and each hook type is a peer in the page TOC.

## Test plan

- [x] \`golangci-lint run ./server/a2a/...\` — 0 issues
- [x] \`go test ./server/a2a/... -count=1\` — pass, coverage 85.9%
- [x] \`npm run build\` — 282 pages, no errors
- [x] \`npm run check-links\` — 655 internal links, 0 broken