### PR TITLE
feat(workflow): observability events for RFC 0009 + arena artifact tool + agent-loops example

### DIFF
--- a/examples/workflow-agent-loops/README.md
+++ b/examples/workflow-agent-loops/README.md
@@ -1,0 +1,96 @@
+# Agent Loops
+
+End-to-end demo of [RFC 0009 — Agent Loop Extension](https://promptpack.org/docs/rfcs/agent-loops) running on PromptArena.
+
+Demonstrates, in a single runnable example:
+
+- **Self-transitioning states** — `research` loops back to itself via `on_event: More → research`.
+- **`max_visits` with `on_max_visits` redirect** — `research` is capped at 3 iterations; the fourth attempted `More` is transparently redirected to `summarize`.
+- **Workflow-level budgets** — `engine.budget` caps total visits, tool calls, and wall time.
+- **Artifacts** — the `findings` artifact uses `mode: append`, so successive `workflow__set_artifact` calls accumulate notes across iterations. The summariser state reads them back via `{{artifacts.findings}}`.
+- **Observability events** — PromptKit emits `workflow.transitioned`, `workflow.max_visits_exceeded`, `workflow.budget_exhausted`, and `workflow.completed` on the event bus, so any listener can observe loop progress and termination.
+
+## Scenarios
+
+| Scenario | What it shows |
+|---|---|
+| `loop-converges` | LLM gathers three notes and chooses `Done` on its own. Workflow ends via the normal path: `research → summarize → done`. |
+| `loop-hits-max-visits` | LLM keeps asking for `More` past the cap. On the fourth attempt, the state machine redirects to `summarize` regardless of what the LLM decided. A `workflow.max_visits_exceeded` event fires. |
+
+## Run
+
+```bash
+# Build promptarena if you haven't
+make build-arena
+
+# Run the example
+cd examples/workflow-agent-loops
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --formats html,json
+
+# Open the HTML report
+open out/report.html
+```
+
+The example uses a mock provider so no API keys are needed — the canned LLM responses are in `mock-responses.yaml`.
+
+## What to look for in the report
+
+**`loop-converges`**
+
+- Three successive `research → research` transitions, each with `workflow__set_artifact` appending a note.
+- A `research → summarize` transition on `Done`.
+- A `summarize → done` transition on `Complete`, followed by `workflow.completed`.
+
+**`loop-hits-max-visits`**
+
+- Three `research → research` transitions.
+- A fourth transition attempt that appears as `research → summarize` with `redirected: true` and `original_target: research`.
+- A `workflow.max_visits_exceeded` event alongside the redirect.
+- Eventual `workflow.completed`.
+
+## Anatomy
+
+```yaml
+# config.arena.yaml excerpt
+workflow:
+  version: 2
+  entry: research
+  engine:
+    budget:
+      max_total_visits: 10
+      max_tool_calls: 50
+      max_wall_time_sec: 60
+  states:
+    research:
+      prompt_task: research
+      max_visits: 3
+      on_max_visits: summarize         # forced exit when cap is hit
+      artifacts:
+        findings:
+          type: text/plain
+          mode: append                  # successive set_artifact calls concat
+      on_event:
+        More: research                  # self-transition
+        Done: summarize
+    summarize:
+      prompt_task: summarize
+      on_event: { Complete: done }
+    done:
+      terminal: true
+```
+
+The research prompt reads the accumulated findings via the template variable
+the runtime injects on each transition:
+
+```
+{{artifacts.findings}}
+```
+
+## Why this example exists
+
+The three features exercised here are each individually simple, but their
+interaction is the whole point of RFC 0009: let an agent iterate, bound
+the iteration cheaply, and accumulate structured state across the loop
+without reaching for session memory. If you're implementing an agent
+with any iterative behaviour (research, code-gen, planning, extract &
+refine), this is the shape.

--- a/examples/workflow-agent-loops/config.arena.yaml
+++ b/examples/workflow-agent-loops/config.arena.yaml
@@ -1,0 +1,78 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: workflow-agent-loops-arena
+spec:
+  prompt_configs:
+    - id: research
+      file: prompts/research.yaml
+    - id: summarize
+      file: prompts/summarize.yaml
+    - id: done
+      file: prompts/done.yaml
+
+  providers:
+    - file: providers/mock-provider.yaml
+
+  scenarios:
+    - file: scenarios/loop-converges.scenario.yaml
+    - file: scenarios/loop-hits-max-visits.scenario.yaml
+
+  # Agent loop workflow (RFC 0009).
+  #
+  # The `research` state is a self-transition loop. Each iteration appends to
+  # the `findings` artifact. max_visits caps the number of iterations; when
+  # reached, on_max_visits forces a redirect to `summarize` regardless of
+  # what the LLM decided — a non-optional brake.
+  #
+  # The `summarize` state reads the accumulated findings out of the template
+  # variable `{{artifacts.findings}}` and produces a final answer. It then
+  # transitions to `done`, which is terminal.
+  #
+  # engine.budget applies globally — if the workflow transitions more than
+  # max_total_visits times in total, it fails with workflow.budget_exhausted.
+  workflow:
+    version: 2
+    entry: research
+    engine:
+      budget:
+        max_total_visits: 10
+        max_tool_calls: 50
+        max_wall_time_sec: 60
+    states:
+      research:
+        prompt_task: research
+        description: "One iteration of the research loop"
+        max_visits: 3
+        on_max_visits: summarize
+        artifacts:
+          findings:
+            type: text/plain
+            description: "Accumulated research notes across iterations"
+            mode: append
+        on_event:
+          More: research
+          Done: summarize
+
+      summarize:
+        prompt_task: summarize
+        description: "Produce a final answer from accumulated findings"
+        artifacts:
+          findings:
+            type: text/plain
+            description: "Accumulated research notes (read-only here)"
+            mode: append
+        on_event:
+          Complete: done
+
+      done:
+        prompt_task: done
+        description: "Workflow complete"
+        terminal: true
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 512
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/workflow-agent-loops/mock-responses.yaml
+++ b/examples/workflow-agent-loops/mock-responses.yaml
@@ -1,0 +1,140 @@
+# Mock LLM responses for the agent-loops example.
+#
+# Each numbered turn here is one LLM response. Within a single scenario
+# turn (user message → agent reply), the ProviderStage tool loop may
+# consume multiple responses: one that emits tool calls, and a follow-up
+# text response after the tool results come back.
+#
+# Numbers below are the LLM-response index (not the scenario turn).
+
+scenarios:
+  loop-converges:
+    turns:
+      # Pipeline turn 1: user asks → LLM does a research step (iteration 1 → 2)
+      1:
+        response: "Gathering the first piece of information."
+        tool_calls:
+          - name: workflow__set_artifact
+            arguments:
+              name: findings
+              value: "Note 1: The library exposes a hook registry with four interface types."
+          - name: workflow__transition
+            arguments:
+              event: More
+              context: "Recorded note 1"
+      2: "Noted: the hook registry has four interface types. Continuing."
+
+      # Pipeline turn 2: user prompts next iteration (2 → 3)
+      3:
+        response: "Gathering a second piece of information."
+        tool_calls:
+          - name: workflow__set_artifact
+            arguments:
+              name: findings
+              value: "Note 2: EvalHook differs from the others: purely observational, may mutate result in place."
+          - name: workflow__transition
+            arguments:
+              event: More
+              context: "Recorded note 2"
+      4: "Added note 2. One more iteration should cover it."
+
+      # Pipeline turn 3: user prompts final iteration → LLM emits Done
+      5:
+        response: "I have what I need — moving to summarise."
+        tool_calls:
+          - name: workflow__set_artifact
+            arguments:
+              name: findings
+              value: "Note 3: Hooks are registered via sdk.WithProviderHook / WithToolHook / WithSessionHook / WithEvalHook."
+          - name: workflow__transition
+            arguments:
+              event: Done
+              context: "Recorded note 3 and leaving research"
+      6: "Done. Handing off to the summariser."
+
+      # Pipeline turn 4: summarise state. LLM reads findings and emits Complete.
+      7:
+        response: "Summary prepared; marking complete."
+        tool_calls:
+          - name: workflow__transition
+            arguments:
+              event: Complete
+              context: "Summary written based on the three notes"
+      8: "PromptKit exposes four hook interfaces (Provider, Tool, Session, Eval), registered via the matching sdk.With*Hook options; EvalHook is observational and can mutate its result in place."
+
+      # Pipeline turn 5: done state confirmation.
+      9: "All done — the final summary is above. Let me know if you need anything else."
+
+  loop-hits-max-visits:
+    turns:
+      # Pipeline turn 1: research iteration 1 → 2
+      1:
+        response: "Iteration 1 — gathering a note."
+        tool_calls:
+          - name: workflow__set_artifact
+            arguments:
+              name: findings
+              value: "Note 1"
+          - name: workflow__transition
+            arguments:
+              event: More
+              context: "it 1"
+      2: "Iteration 1 complete."
+
+      # Pipeline turn 2: research iteration 2 → 3
+      3:
+        response: "Iteration 2 — gathering a note."
+        tool_calls:
+          - name: workflow__set_artifact
+            arguments:
+              name: findings
+              value: "Note 2"
+          - name: workflow__transition
+            arguments:
+              event: More
+              context: "it 2"
+      4: "Iteration 2 complete."
+
+      # Pipeline turn 3: research iteration 3 (at cap)
+      5:
+        response: "Iteration 3 — gathering a note."
+        tool_calls:
+          - name: workflow__set_artifact
+            arguments:
+              name: findings
+              value: "Note 3"
+          - name: workflow__transition
+            arguments:
+              event: More
+              context: "it 3"
+      6: "Iteration 3 complete."
+
+      # Pipeline turn 4: LLM attempts a 4th iteration. max_visits (3) has been
+      # reached on `research`, so the runtime redirects to `summarize`
+      # regardless of what the LLM chose. A workflow.max_visits_exceeded event
+      # fires.
+      7:
+        response: "Iteration 4 — gathering a note."
+        tool_calls:
+          - name: workflow__set_artifact
+            arguments:
+              name: findings
+              value: "Note 4"
+          - name: workflow__transition
+            arguments:
+              event: More
+              context: "it 4 — will be redirected"
+      8: "Redirected to summariser by the workflow engine after hitting the iteration cap."
+
+      # Pipeline turn 5: summarise state. LLM emits Complete.
+      9:
+        response: "Summarising with whatever findings accumulated before the cap."
+        tool_calls:
+          - name: workflow__transition
+            arguments:
+              event: Complete
+              context: "Cap-driven summary"
+      10: "After three research iterations, the workflow engine stopped further attempts and produced this summary."
+
+      # Pipeline turn 6: done confirmation.
+      11: "Workflow complete — the iteration cap successfully bounded the loop."

--- a/examples/workflow-agent-loops/prompts/done.yaml
+++ b/examples/workflow-agent-loops/prompts/done.yaml
@@ -1,0 +1,12 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: done
+spec:
+  task_type: "done"
+  version: "v1.0.0"
+  description: "Workflow complete"
+
+  system_template: |
+    The workflow is complete. Confirm to the user that their question has
+    been answered.

--- a/examples/workflow-agent-loops/prompts/research.yaml
+++ b/examples/workflow-agent-loops/prompts/research.yaml
@@ -1,0 +1,22 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: research
+spec:
+  task_type: "research"
+  version: "v1.0.0"
+  description: "One iteration of a research loop"
+
+  system_template: |
+    You are a research agent running in a bounded loop.
+
+    On each iteration:
+    - Gather one new piece of information about the user's question.
+    - Record it by calling `workflow__set_artifact` with name `findings`
+      and a short one-line value. The artifact is declared `mode: append`
+      so each call adds to the accumulated notes.
+    - Then call `workflow__transition` with event `More` to loop back, or
+      `Done` once you have enough.
+
+    You have a hard cap on iterations — if you exceed it, the workflow will
+    redirect you to the summariser regardless of what you decide.

--- a/examples/workflow-agent-loops/prompts/summarize.yaml
+++ b/examples/workflow-agent-loops/prompts/summarize.yaml
@@ -1,0 +1,16 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: summarize
+spec:
+  task_type: "summarize"
+  version: "v1.0.0"
+  description: "Produce a final answer from accumulated findings"
+
+  system_template: |
+    You are the summariser. The research loop has finished; your job is to
+    turn the accumulated findings into a clear, concise final answer for
+    the user. The findings were recorded as a `findings` artifact during
+    the research loop.
+
+    When you are done, call `workflow__transition` with event `Complete`.

--- a/examples/workflow-agent-loops/providers/mock-provider.yaml
+++ b/examples/workflow-agent-loops/providers/mock-provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-loops
+spec:
+  id: mock-loops
+  type: mock
+  model: mock-model
+  additional_config:
+    mock_config: mock-responses.yaml
+  defaults:
+    temperature: 0.1
+    max_tokens: 512
+    top_p: 1.0

--- a/examples/workflow-agent-loops/scenarios/loop-converges.scenario.yaml
+++ b/examples/workflow-agent-loops/scenarios/loop-converges.scenario.yaml
@@ -1,0 +1,33 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: loop-converges
+spec:
+  id: loop-converges
+  task_type: research
+  description: "Agent loop converges in 3 iterations, summarises, completes"
+  turns:
+    # Iteration 1: user kicks off research; LLM emits set_artifact + More.
+    - role: user
+      content: "Please research the PromptKit hook system and summarise."
+      assertions:
+        - type: tools_called
+          params:
+            tool_names: ["workflow__set_artifact", "workflow__transition"]
+
+    # Remaining turns drive the loop — each one triggers one LLM pass that
+    # may or may not emit tool calls depending on where we are in the loop.
+    # We keep assertions out of these: the interesting output is in the log
+    # and in the HTML report (state transitions, artifact accumulation,
+    # workflow.completed event).
+    - role: user
+      content: "continue"
+
+    - role: user
+      content: "wrap up when ready"
+
+    - role: user
+      content: "summary please"
+
+    - role: user
+      content: "thanks"

--- a/examples/workflow-agent-loops/scenarios/loop-hits-max-visits.scenario.yaml
+++ b/examples/workflow-agent-loops/scenarios/loop-hits-max-visits.scenario.yaml
@@ -1,0 +1,36 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: loop-hits-max-visits
+spec:
+  id: loop-hits-max-visits
+  task_type: research
+  description: "Agent keeps emitting More; max_visits=3 forces redirect to summarise"
+  turns:
+    # Iteration 1: research → research on More.
+    - role: user
+      content: "Please research something."
+      assertions:
+        - type: tools_called
+          params:
+            tool_names: ["workflow__transition"]
+
+    # Iterations 2–4: LLM keeps emitting More. After 3 visits the runtime
+    # redirects transparently to `summarize` (see log line with
+    # redirected=true). Assertions are intentionally light here — the
+    # interesting signal is in the log and in the emitted
+    # workflow.max_visits_exceeded event.
+    - role: user
+      content: "more"
+
+    - role: user
+      content: "more"
+
+    - role: user
+      content: "more"
+
+    - role: user
+      content: "summary please"
+
+    - role: user
+      content: "thanks"

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -513,6 +513,18 @@ func (e *Emitter) WorkflowCompleted(finalState string, transitionCount int) {
 	})
 }
 
+// WorkflowMaxVisitsExceeded emits the workflow.max_visits_exceeded event.
+// redirectedTo is empty and terminated is true when the workflow stopped for
+// lack of an on_max_visits fallback.
+func (e *Emitter) WorkflowMaxVisitsExceeded(data *WorkflowMaxVisitsExceededData) {
+	e.emit(EventWorkflowMaxVisitsExceeded, data)
+}
+
+// WorkflowBudgetExhausted emits the workflow.budget_exhausted event.
+func (e *Emitter) WorkflowBudgetExhausted(data *WorkflowBudgetExhaustedData) {
+	e.emit(EventWorkflowBudgetExhausted, data)
+}
+
 // ContextCompacted emits the context.compacted event when the compactor
 // folds stale tool results between tool-loop rounds.
 func (e *Emitter) ContextCompacted(round, originalTokens, compactedTokens, messagesFolded, budgetTokens int) {

--- a/runtime/events/store.go
+++ b/runtime/events/store.go
@@ -202,8 +202,10 @@ var eventDataRegistry = map[string]eventDataFactory{
 	"*events.StreamInterruptedData":   func() EventData { return &StreamInterruptedData{} },
 
 	// Workflow events
-	"*events.WorkflowTransitionedData": func() EventData { return &WorkflowTransitionedData{} },
-	"*events.WorkflowCompletedData":    func() EventData { return &WorkflowCompletedData{} },
+	"*events.WorkflowTransitionedData":      func() EventData { return &WorkflowTransitionedData{} },
+	"*events.WorkflowCompletedData":         func() EventData { return &WorkflowCompletedData{} },
+	"*events.WorkflowMaxVisitsExceededData": func() EventData { return &WorkflowMaxVisitsExceededData{} },
+	"*events.WorkflowBudgetExhaustedData":   func() EventData { return &WorkflowBudgetExhaustedData{} },
 }
 
 // deserializeEventData attempts to deserialize event data based on the type name.

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -100,6 +100,13 @@ const (
 	EventWorkflowTransitioned EventType = "workflow.transitioned"
 	// EventWorkflowCompleted marks a workflow reaching a terminal state.
 	EventWorkflowCompleted EventType = "workflow.completed"
+	// EventWorkflowMaxVisitsExceeded marks a state hitting its max_visits
+	// cap. Fires whether the workflow redirected to on_max_visits (successful
+	// transition) or terminated for lack of a fallback.
+	EventWorkflowMaxVisitsExceeded EventType = "workflow.max_visits_exceeded"
+	// EventWorkflowBudgetExhausted marks a workflow-level budget being
+	// reached (max_total_visits, max_tool_calls, or max_wall_time_sec).
+	EventWorkflowBudgetExhausted EventType = "workflow.budget_exhausted"
 
 	// EventClientToolRequest marks a client-mode tool request awaiting caller fulfillment.
 	EventClientToolRequest EventType = "tool.client.request"
@@ -641,6 +648,52 @@ type WorkflowCompletedData struct {
 	// FinalState is the terminal state the workflow reached.
 	FinalState string `json:"final_state"`
 	// TransitionCount is the total number of transitions that occurred.
+	TransitionCount int `json:"transition_count"`
+}
+
+// WorkflowMaxVisitsExceededData contains data for the
+// workflow.max_visits_exceeded event. Emitted when the state machine attempts
+// to enter a state whose max_visits cap has already been reached.
+type WorkflowMaxVisitsExceededData struct {
+	baseEventData
+	// FromState is the state we were about to leave.
+	FromState string `json:"from_state"`
+	// OriginalTarget is the state the transition originally targeted
+	// (before the redirect).
+	OriginalTarget string `json:"original_target"`
+	// Event is the transition event that triggered the attempt.
+	Event string `json:"event"`
+	// VisitCount is how many times OriginalTarget had been entered prior
+	// to this attempt.
+	VisitCount int `json:"visit_count"`
+	// MaxVisits is the declared limit on OriginalTarget.
+	MaxVisits int `json:"max_visits"`
+	// RedirectedTo is the state the machine entered instead, when
+	// OriginalTarget had an on_max_visits fallback. Empty when the
+	// workflow terminated for lack of a fallback.
+	RedirectedTo string `json:"redirected_to,omitempty"`
+	// Terminated is true when no on_max_visits fallback was configured
+	// and the workflow stopped.
+	Terminated bool `json:"terminated"`
+}
+
+// WorkflowBudgetExhaustedData contains data for the
+// workflow.budget_exhausted event. Emitted when a workflow-level budget
+// (max_total_visits, max_tool_calls, max_wall_time_sec) is reached.
+type WorkflowBudgetExhaustedData struct {
+	baseEventData
+	// Limit identifies which budget tripped: "max_total_visits",
+	// "max_tool_calls", or "max_wall_time_sec".
+	Limit string `json:"limit"`
+	// Current is the observed value at the time of exhaustion.
+	Current int `json:"current"`
+	// Max is the configured limit.
+	Max int `json:"max"`
+	// CurrentState is the state the workflow was in when the budget
+	// tripped (the attempted transition did not complete).
+	CurrentState string `json:"current_state"`
+	// TransitionCount is the number of transitions that had occurred
+	// before exhaustion.
 	TransitionCount int `json:"transition_count"`
 }
 

--- a/runtime/workflow/machine.go
+++ b/runtime/workflow/machine.go
@@ -118,8 +118,13 @@ func (sm *StateMachine) ProcessEvent(event string) (*TransitionResult, error) {
 			if targetState.OnMaxVisits != "" {
 				target = targetState.OnMaxVisits
 			} else {
-				return nil, fmt.Errorf("%w: state %q visited %d times (max %d)",
-					ErrMaxVisitsExceeded, originalTarget, visits, targetState.MaxVisits)
+				return nil, &MaxVisitsExceededError{
+					FromState:      fromState,
+					OriginalTarget: originalTarget,
+					Event:          event,
+					VisitCount:     visits,
+					MaxVisits:      targetState.MaxVisits,
+				}
 			}
 		}
 	}
@@ -245,18 +250,30 @@ func (sm *StateMachine) checkBudgetLocked() error {
 	}
 	budget := sm.budget
 	if budget.MaxTotalVisits > 0 && sm.context.TotalVisits() >= budget.MaxTotalVisits {
-		return fmt.Errorf("%w: total visits %d reached limit %d",
-			ErrBudgetExhausted, sm.context.TotalVisits(), budget.MaxTotalVisits)
+		return &BudgetExhaustedError{
+			Limit:        BudgetLimitTotalVisits,
+			Current:      sm.context.TotalVisits(),
+			Max:          budget.MaxTotalVisits,
+			CurrentState: sm.context.CurrentState,
+		}
 	}
 	if budget.MaxToolCalls > 0 && sm.context.TotalToolCalls >= budget.MaxToolCalls {
-		return fmt.Errorf("%w: tool calls %d reached limit %d",
-			ErrBudgetExhausted, sm.context.TotalToolCalls, budget.MaxToolCalls)
+		return &BudgetExhaustedError{
+			Limit:        BudgetLimitToolCalls,
+			Current:      sm.context.TotalToolCalls,
+			Max:          budget.MaxToolCalls,
+			CurrentState: sm.context.CurrentState,
+		}
 	}
 	if budget.MaxWallTimeSec > 0 {
 		elapsed := sm.now().Sub(sm.context.StartedAt)
 		if int(elapsed.Seconds()) >= budget.MaxWallTimeSec {
-			return fmt.Errorf("%w: wall time %ds reached limit %ds",
-				ErrBudgetExhausted, int(elapsed.Seconds()), budget.MaxWallTimeSec)
+			return &BudgetExhaustedError{
+				Limit:        BudgetLimitWallTimeSec,
+				Current:      int(elapsed.Seconds()),
+				Max:          budget.MaxWallTimeSec,
+				CurrentState: sm.context.CurrentState,
+			}
 		}
 	}
 	return nil

--- a/runtime/workflow/machine_test.go
+++ b/runtime/workflow/machine_test.go
@@ -682,6 +682,122 @@ func TestBudget_MaxTotalVisitsExhausted(t *testing.T) {
 	}
 }
 
+// TestMaxVisitsExceededError_ErrorString verifies the Error message format.
+func TestMaxVisitsExceededError_ErrorString(t *testing.T) {
+	e := &MaxVisitsExceededError{
+		OriginalTarget: "research",
+		VisitCount:     3,
+		MaxVisits:      3,
+	}
+	got := e.Error()
+	want := `max visits exceeded: state "research" visited 3 times (max 3)`
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	if !errors.Is(e, ErrMaxVisitsExceeded) {
+		t.Error("errors.Is should match ErrMaxVisitsExceeded via Unwrap")
+	}
+}
+
+// TestBudgetExhaustedError_ErrorString verifies the Error message format.
+func TestBudgetExhaustedError_ErrorString(t *testing.T) {
+	e := &BudgetExhaustedError{
+		Limit:   BudgetLimitToolCalls,
+		Current: 10,
+		Max:     10,
+	}
+	got := e.Error()
+	want := "workflow budget exhausted: max_tool_calls 10 reached limit 10"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	if !errors.Is(e, ErrBudgetExhausted) {
+		t.Error("errors.Is should match ErrBudgetExhausted via Unwrap")
+	}
+}
+
+// TestBudget_ReturnsStructuredError verifies that ErrBudgetExhausted is
+// returned as a *BudgetExhaustedError carrying the tripped limit name, the
+// current/max values, and the state the workflow was in. Callers (SDK,
+// Arena) use these fields to populate observability events.
+func TestBudget_ReturnsStructuredError(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t", OnEvent: map[string]string{"Back": "a"}},
+		},
+		Engine: map[string]any{
+			"budget": map[string]any{"max_total_visits": 3},
+		},
+	}
+	sm := NewStateMachine(spec)
+	_, _ = sm.ProcessEvent("Go")
+	_, _ = sm.ProcessEvent("Back")
+	_, err := sm.ProcessEvent("Go")
+
+	var bErr *BudgetExhaustedError
+	if !errors.As(err, &bErr) {
+		t.Fatalf("expected *BudgetExhaustedError, got %T: %v", err, err)
+	}
+	if bErr.Limit != BudgetLimitTotalVisits {
+		t.Errorf("Limit = %q, want %q", bErr.Limit, BudgetLimitTotalVisits)
+	}
+	if bErr.Max != 3 {
+		t.Errorf("Max = %d, want 3", bErr.Max)
+	}
+	if bErr.Current < 3 {
+		t.Errorf("Current = %d, want >= 3", bErr.Current)
+	}
+	if bErr.CurrentState == "" {
+		t.Error("CurrentState should be populated")
+	}
+}
+
+// TestMaxVisits_ReturnsStructuredError verifies that when a state's
+// max_visits cap is reached without an on_max_visits fallback, the error
+// is a *MaxVisitsExceededError carrying the originating state, target, event,
+// visit count, and declared max.
+func TestMaxVisits_ReturnsStructuredError(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t", MaxVisits: 1, OnEvent: map[string]string{"Back": "a"}},
+		},
+	}
+	sm := NewStateMachine(spec)
+	if _, err := sm.ProcessEvent("Go"); err != nil {
+		t.Fatalf("ProcessEvent(Go): %v", err)
+	}
+	if _, err := sm.ProcessEvent("Back"); err != nil {
+		t.Fatalf("ProcessEvent(Back): %v", err)
+	}
+	_, err := sm.ProcessEvent("Go")
+
+	var mvErr *MaxVisitsExceededError
+	if !errors.As(err, &mvErr) {
+		t.Fatalf("expected *MaxVisitsExceededError, got %T: %v", err, err)
+	}
+	if mvErr.OriginalTarget != "b" {
+		t.Errorf("OriginalTarget = %q, want \"b\"", mvErr.OriginalTarget)
+	}
+	if mvErr.FromState != "a" {
+		t.Errorf("FromState = %q, want \"a\"", mvErr.FromState)
+	}
+	if mvErr.Event != "Go" {
+		t.Errorf("Event = %q, want \"Go\"", mvErr.Event)
+	}
+	if mvErr.MaxVisits != 1 {
+		t.Errorf("MaxVisits = %d, want 1", mvErr.MaxVisits)
+	}
+	if mvErr.VisitCount < 1 {
+		t.Errorf("VisitCount = %d, want >= 1", mvErr.VisitCount)
+	}
+}
+
 func TestBudget_MaxToolCallsExhausted(t *testing.T) {
 	spec := &Spec{
 		Version: 2,

--- a/runtime/workflow/types.go
+++ b/runtime/workflow/types.go
@@ -14,12 +14,73 @@ import (
 // Sentinel errors for workflow execution.
 var (
 	// ErrMaxVisitsExceeded is returned when a state's max_visits limit is reached
-	// and no on_max_visits fallback is configured.
+	// and no on_max_visits fallback is configured. The concrete error returned
+	// is typically a *MaxVisitsExceededError wrapping this sentinel; callers
+	// wanting structured details should use errors.As.
 	ErrMaxVisitsExceeded = errors.New("max visits exceeded")
 
-	// ErrBudgetExhausted is returned when a workflow-level budget limit is reached.
+	// ErrBudgetExhausted is returned when a workflow-level budget limit is
+	// reached. The concrete error returned is typically a *BudgetExhaustedError
+	// wrapping this sentinel; callers wanting structured details should use
+	// errors.As.
 	ErrBudgetExhausted = errors.New("workflow budget exhausted")
 )
+
+// MaxVisitsExceededError is the structured error returned from ProcessEvent
+// when a state has reached its max_visits cap and no on_max_visits fallback
+// is configured. It wraps ErrMaxVisitsExceeded so errors.Is still matches.
+type MaxVisitsExceededError struct {
+	// FromState is the state the transition was leaving.
+	FromState string
+	// OriginalTarget is the state whose max_visits was reached.
+	OriginalTarget string
+	// Event is the transition event that triggered the attempt.
+	Event string
+	// VisitCount is the number of times OriginalTarget had already been entered.
+	VisitCount int
+	// MaxVisits is the declared limit on OriginalTarget.
+	MaxVisits int
+}
+
+// Error returns a human-readable description.
+func (e *MaxVisitsExceededError) Error() string {
+	return fmt.Sprintf("%s: state %q visited %d times (max %d)",
+		ErrMaxVisitsExceeded.Error(), e.OriginalTarget, e.VisitCount, e.MaxVisits)
+}
+
+// Unwrap returns the sentinel for errors.Is.
+func (e *MaxVisitsExceededError) Unwrap() error { return ErrMaxVisitsExceeded }
+
+// Budget limit names, used by BudgetExhaustedError.Limit.
+const (
+	BudgetLimitTotalVisits = "max_total_visits"
+	BudgetLimitToolCalls   = "max_tool_calls"
+	BudgetLimitWallTimeSec = "max_wall_time_sec"
+)
+
+// BudgetExhaustedError is the structured error returned from ProcessEvent
+// when a workflow-level budget is reached. It wraps ErrBudgetExhausted so
+// errors.Is still matches.
+type BudgetExhaustedError struct {
+	// Limit is one of BudgetLimitTotalVisits, BudgetLimitToolCalls,
+	// BudgetLimitWallTimeSec.
+	Limit string
+	// Current is the observed value at the time the limit was hit.
+	Current int
+	// Max is the configured limit.
+	Max int
+	// CurrentState is the state the workflow was in when the budget tripped.
+	CurrentState string
+}
+
+// Error returns a human-readable description.
+func (e *BudgetExhaustedError) Error() string {
+	return fmt.Sprintf("%s: %s %d reached limit %d",
+		ErrBudgetExhausted.Error(), e.Limit, e.Current, e.Max)
+}
+
+// Unwrap returns the sentinel for errors.Is.
+func (e *BudgetExhaustedError) Unwrap() error { return ErrBudgetExhausted }
 
 // Budget defines workflow-level resource limits from the engine block.
 type Budget struct {

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -255,21 +255,37 @@ func (wc *WorkflowConversation) Send(ctx context.Context, message any, opts ...S
 	if wc.closed {
 		return nil, ErrWorkflowClosed
 	}
-	if wc.transExec != nil {
-		if pending := wc.transExec.Pending(); pending != nil {
-			contextSummary := pending.ContextSummary
-			result, commitErr := wc.transExec.CommitPending()
-			if commitErr != nil {
-				return resp, commitErr
-			}
-			if result != nil {
-				if _, transErr := wc.applyTransition(result, contextSummary); transErr != nil {
-					return resp, transErr
-				}
-			}
-		}
+	if err := wc.commitDeferredTransition(); err != nil {
+		return resp, err
 	}
 	return resp, nil
+}
+
+// commitDeferredTransition commits any pending transition recorded by the
+// workflow__transition tool during the just-completed Send. Errors from
+// ProcessEvent are routed through emitWorkflowError before being returned
+// so observability events fire even when the transition aborts. Caller
+// must hold wc.mu.
+func (wc *WorkflowConversation) commitDeferredTransition() error {
+	if wc.transExec == nil {
+		return nil
+	}
+	pending := wc.transExec.Pending()
+	if pending == nil {
+		return nil
+	}
+	contextSummary := pending.ContextSummary
+	result, commitErr := wc.transExec.CommitPending()
+	if commitErr != nil {
+		wc.emitWorkflowError(pending.Event, commitErr)
+		return commitErr
+	}
+	if result != nil {
+		if _, transErr := wc.applyTransition(result, contextSummary); transErr != nil {
+			return transErr
+		}
+	}
+	return nil
 }
 
 // Transition processes an event and moves to the next state.
@@ -365,13 +381,9 @@ func (wc *WorkflowConversation) applyTransition(
 		wc.persistWorkflowContext()
 	}
 
-	// Emit transition event
-	if wc.emitter != nil {
-		wc.emitter.WorkflowTransitioned(result.From, toState, result.Event, promptName)
-		if wc.machine.IsTerminal() {
-			wc.emitter.WorkflowCompleted(toState, wc.machine.Context().TransitionCount())
-		}
-	}
+	// Emit transition events (transitioned, max_visits_exceeded if this was
+	// a redirect, and completed if the new state is terminal).
+	wc.emitTransitionEvents(result, toState, promptName)
 
 	return toState, nil
 }
@@ -554,3 +566,5 @@ func convertWorkflowSpec(sdkSpec *pack.WorkflowSpec) *workflow.Spec {
 		Engine:  sdkSpec.Engine,
 	}
 }
+
+// emitTransitionEvents and maxVisitsForState live in sdk/workflow_events.go.

--- a/sdk/workflow_events.go
+++ b/sdk/workflow_events.go
@@ -1,0 +1,83 @@
+package sdk
+
+import (
+	"errors"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/workflow"
+)
+
+// emitTransitionEvents emits the workflow.transitioned event for a successful
+// transition, plus workflow.max_visits_exceeded when the transition was a
+// max_visits redirect, plus workflow.completed when the new state is terminal.
+// Safe to call with a nil emitter (no-op).
+func (wc *WorkflowConversation) emitTransitionEvents(
+	result *workflow.TransitionResult, toState, promptName string,
+) {
+	if wc.emitter == nil {
+		return
+	}
+	if result.Redirected {
+		wc.emitter.WorkflowMaxVisitsExceeded(&events.WorkflowMaxVisitsExceededData{
+			FromState:      result.From,
+			OriginalTarget: result.OriginalTarget,
+			Event:          result.Event,
+			VisitCount:     wc.machine.Context().VisitCounts[result.OriginalTarget],
+			MaxVisits:      maxVisitsForState(wc.workflowSpec, result.OriginalTarget),
+			RedirectedTo:   result.To,
+			Terminated:     false,
+		})
+	}
+	wc.emitter.WorkflowTransitioned(result.From, toState, result.Event, promptName)
+	if wc.machine.IsTerminal() {
+		wc.emitter.WorkflowCompleted(toState, wc.machine.Context().TransitionCount())
+	}
+}
+
+// maxVisitsForState returns the max_visits cap declared on the named state,
+// or 0 if the state is unknown or has no cap. Used for populating
+// observability event fields; safe with nil spec.
+func maxVisitsForState(spec *workflow.Spec, name string) int {
+	if spec == nil {
+		return 0
+	}
+	s := spec.States[name]
+	if s == nil {
+		return 0
+	}
+	return s.MaxVisits
+}
+
+// emitWorkflowError emits a typed observability event for errors returned
+// from ProcessEvent / CommitPending. Non-fatal: a nil emitter or an error
+// that doesn't match a known workflow error type is a no-op. Called from
+// every caller that consumes ProcessEvent errors so the event fires exactly
+// once per termination regardless of which transition path triggered it.
+func (wc *WorkflowConversation) emitWorkflowError(_ string, err error) {
+	if wc.emitter == nil || err == nil {
+		return
+	}
+	var mvErr *workflow.MaxVisitsExceededError
+	if errors.As(err, &mvErr) {
+		wc.emitter.WorkflowMaxVisitsExceeded(&events.WorkflowMaxVisitsExceededData{
+			FromState:      mvErr.FromState,
+			OriginalTarget: mvErr.OriginalTarget,
+			Event:          mvErr.Event,
+			VisitCount:     mvErr.VisitCount,
+			MaxVisits:      mvErr.MaxVisits,
+			Terminated:     true,
+		})
+		return
+	}
+	var bErr *workflow.BudgetExhaustedError
+	if errors.As(err, &bErr) {
+		wc.emitter.WorkflowBudgetExhausted(&events.WorkflowBudgetExhaustedData{
+			Limit:           bErr.Limit,
+			Current:         bErr.Current,
+			Max:             bErr.Max,
+			CurrentState:    bErr.CurrentState,
+			TransitionCount: wc.machine.Context().TransitionCount(),
+		})
+		return
+	}
+}

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -1298,3 +1298,282 @@ func TestPersistWorkflowContext_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, state.Metadata["workflow"])
 }
+
+// TestCommitDeferredTransition_NoTransExec is a no-op when the workflow
+// conversation has no transition executor wired up.
+func TestCommitDeferredTransition_NoTransExec(t *testing.T) {
+	wc := &WorkflowConversation{}
+	require.NoError(t, wc.commitDeferredTransition())
+}
+
+// TestCommitDeferredTransition_NoPending is a no-op when there is no
+// pending transition to commit.
+func TestCommitDeferredTransition_NoPending(t *testing.T) {
+	spec := &workflow.Spec{Version: 1, Entry: "a", States: map[string]*workflow.State{
+		"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+		"b": {PromptTask: "t"},
+	}}
+	machine := workflow.NewStateMachine(spec)
+	wc := &WorkflowConversation{
+		machine:   machine,
+		transExec: workflow.NewTransitionExecutor(machine, spec),
+	}
+	require.NoError(t, wc.commitDeferredTransition())
+}
+
+// TestCommitDeferredTransition_FiresErrorEvent verifies that a deferred
+// commit returning an error routes through emitWorkflowError to fire the
+// matching observability event. The state machine is pre-seeded so the very
+// first commit hits max_visits and never tries to call applyTransition.
+func TestCommitDeferredTransition_FiresErrorEvent(t *testing.T) {
+	bus := events.NewEventBus()
+	gotEvent := make(chan *events.Event, 1)
+	bus.Subscribe(events.EventWorkflowMaxVisitsExceeded, func(e *events.Event) { gotEvent <- e })
+
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*workflow.State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t", MaxVisits: 1},
+		},
+	}
+	// Pre-seed the context so b is at its visit cap before the test transition.
+	machine := workflow.NewStateMachineFromContext(spec, &workflow.Context{
+		CurrentState: "a",
+		VisitCounts:  map[string]int{"a": 1, "b": 1},
+	})
+	transExec := workflow.NewTransitionExecutor(machine, spec)
+
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		emitter:      events.NewEmitter(bus, "", "", ""),
+		transExec:    transExec,
+	}
+
+	args, _ := json.Marshal(map[string]string{"event": "Go"})
+	_, err := transExec.Execute(context.Background(), nil, args)
+	require.NoError(t, err)
+	commitErr := wc.commitDeferredTransition()
+	require.Error(t, commitErr, "Go into b should fail because visit cap is reached")
+
+	select {
+	case e := <-gotEvent:
+		data := e.Data.(*events.WorkflowMaxVisitsExceededData)
+		assert.Equal(t, "b", data.OriginalTarget)
+		assert.True(t, data.Terminated)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected workflow.max_visits_exceeded event")
+	}
+}
+
+// TestEmitTransitionEvents_All verifies emitTransitionEvents fires the
+// expected combination of workflow.transitioned, workflow.max_visits_exceeded
+// (on redirect), and workflow.completed (on terminal entry).
+func TestEmitTransitionEvents_All(t *testing.T) {
+	bus := events.NewEventBus()
+	seen := make(map[events.EventType]int)
+	var mu sync.Mutex
+	bus.SubscribeAll(func(e *events.Event) {
+		mu.Lock()
+		seen[e.Type]++
+		mu.Unlock()
+	})
+
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "loop",
+		States: map[string]*workflow.State{
+			"loop": {PromptTask: "loop", MaxVisits: 1, OnMaxVisits: "exit",
+				OnEvent: map[string]string{"Again": "loop"}},
+			"exit": {PromptTask: "exit"}, // terminal: no OnEvent
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		emitter:      events.NewEmitter(bus, "", "", ""),
+	}
+
+	// Plain transition (not redirected, not terminal).
+	wc.emitTransitionEvents(&workflow.TransitionResult{
+		From: "loop", To: "loop", Event: "Again",
+	}, "loop", "loop")
+
+	// Drive the machine into a terminal state so IsTerminal returns true.
+	wc.machine = workflow.NewStateMachineFromContext(spec, &workflow.Context{
+		CurrentState: "exit",
+		VisitCounts:  map[string]int{"loop": 1, "exit": 1},
+	})
+
+	// Redirected + terminal transition.
+	wc.emitTransitionEvents(&workflow.TransitionResult{
+		From: "loop", To: "exit", Event: "Again",
+		Redirected: true, OriginalTarget: "loop",
+	}, "exit", "exit")
+
+	// Allow async delivery to land.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := seen[events.EventWorkflowTransitioned] +
+			seen[events.EventWorkflowMaxVisitsExceeded] +
+			seen[events.EventWorkflowCompleted]
+		mu.Unlock()
+		if got >= 4 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 2, seen[events.EventWorkflowTransitioned], "two transitioned events")
+	assert.Equal(t, 1, seen[events.EventWorkflowMaxVisitsExceeded], "one redirect event")
+	assert.Equal(t, 1, seen[events.EventWorkflowCompleted], "one completed event")
+}
+
+// TestEmitTransitionEvents_NilEmitterNoOp verifies the helper short-circuits
+// safely when no emitter is configured.
+func TestEmitTransitionEvents_NilEmitterNoOp(t *testing.T) {
+	wc := &WorkflowConversation{}
+	wc.emitTransitionEvents(&workflow.TransitionResult{}, "x", "x") // no panic
+}
+
+// TestMaxVisitsForState verifies the lookup helper.
+func TestMaxVisitsForState(t *testing.T) {
+	assert.Equal(t, 0, maxVisitsForState(nil, "x"))
+	spec := &workflow.Spec{States: map[string]*workflow.State{
+		"a": {MaxVisits: 5},
+	}}
+	assert.Equal(t, 5, maxVisitsForState(spec, "a"))
+	assert.Equal(t, 0, maxVisitsForState(spec, "missing"))
+}
+
+// TestEmitWorkflowError_MaxVisits verifies emitWorkflowError fires
+// workflow.max_visits_exceeded when handed a *MaxVisitsExceededError.
+func TestEmitWorkflowError_MaxVisits(t *testing.T) {
+	bus := events.NewEventBus()
+
+	var received *events.Event
+	var mu sync.Mutex
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	bus.Subscribe(events.EventWorkflowMaxVisitsExceeded, func(e *events.Event) {
+		mu.Lock()
+		received = e
+		mu.Unlock()
+		wg.Done()
+	})
+
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*workflow.State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t", MaxVisits: 1, OnEvent: map[string]string{"Back": "a"}},
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		emitter:      events.NewEmitter(bus, "", "", ""),
+	}
+
+	err := &workflow.MaxVisitsExceededError{
+		FromState:      "a",
+		OriginalTarget: "b",
+		Event:          "Go",
+		VisitCount:     1,
+		MaxVisits:      1,
+	}
+	wc.emitWorkflowError("Go", err)
+
+	waitWithTimeout(t, wg, 200*time.Millisecond, "workflow.max_visits_exceeded")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, received)
+	data, ok := received.Data.(*events.WorkflowMaxVisitsExceededData)
+	require.True(t, ok, "unexpected data type: %T", received.Data)
+	assert.Equal(t, "b", data.OriginalTarget)
+	assert.Equal(t, 1, data.MaxVisits)
+	assert.True(t, data.Terminated)
+}
+
+// TestEmitWorkflowError_Budget verifies emitWorkflowError fires
+// workflow.budget_exhausted when handed a *BudgetExhaustedError.
+func TestEmitWorkflowError_Budget(t *testing.T) {
+	bus := events.NewEventBus()
+
+	var received *events.Event
+	var mu sync.Mutex
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	bus.Subscribe(events.EventWorkflowBudgetExhausted, func(e *events.Event) {
+		mu.Lock()
+		received = e
+		mu.Unlock()
+		wg.Done()
+	})
+
+	spec := &workflow.Spec{Version: 2, Entry: "a", States: map[string]*workflow.State{
+		"a": {PromptTask: "t"},
+	}}
+	machine := workflow.NewStateMachine(spec)
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		emitter:      events.NewEmitter(bus, "", "", ""),
+	}
+
+	err := &workflow.BudgetExhaustedError{
+		Limit:        workflow.BudgetLimitToolCalls,
+		Current:      10,
+		Max:          10,
+		CurrentState: "a",
+	}
+	wc.emitWorkflowError("", err)
+
+	waitWithTimeout(t, wg, 200*time.Millisecond, "workflow.budget_exhausted")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, received)
+	data, ok := received.Data.(*events.WorkflowBudgetExhaustedData)
+	require.True(t, ok)
+	assert.Equal(t, workflow.BudgetLimitToolCalls, data.Limit)
+	assert.Equal(t, 10, data.Max)
+}
+
+// TestEmitWorkflowError_NilSafe verifies the helper is a no-op when either
+// the emitter or the error is nil, or when the error doesn't match a known
+// workflow type.
+func TestEmitWorkflowError_NilSafe(t *testing.T) {
+	wc := &WorkflowConversation{}
+	wc.emitWorkflowError("", nil)             // no emitter, no error
+	wc.emitWorkflowError("", fmt.Errorf("x")) // no emitter, arbitrary error
+	bus := events.NewEventBus()
+	wc.emitter = events.NewEmitter(bus, "", "", "")
+	wc.emitWorkflowError("", nil)             // nil error is ignored
+	wc.emitWorkflowError("", fmt.Errorf("x")) // unmatched error is ignored
+}
+
+// waitWithTimeout blocks on wg with a deadline. Fails the test if the
+// deadline expires before wg counts down to zero.
+func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration, label string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}

--- a/sdk/workflow_transition_integration.go
+++ b/sdk/workflow_transition_integration.go
@@ -10,6 +10,7 @@ import (
 func (wc *WorkflowConversation) transitionInternal(event, contextSummary string) (string, error) {
 	result, err := wc.machine.ProcessEvent(event)
 	if err != nil {
+		wc.emitWorkflowError(event, err)
 		return "", err
 	}
 	return wc.applyTransition(result, contextSummary)

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/skills"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -38,6 +39,12 @@ func (e *Engine) initWorkflow() error {
 	if entryState := spec.States[spec.Entry]; entryState != nil {
 		registerTransitionTool(e.toolRegistry, entryState)
 	}
+
+	// Register the per-run artifact executor + workflow__set_artifact tool when
+	// any state declares artifacts. The executor dispatches to the per-run
+	// state machine via the shared transExec run map.
+	e.toolRegistry.RegisterExecutor(&workflowArtifactExecutor{transExec: transExec})
+	workflow.RegisterArtifactTool(e.toolRegistry, spec)
 
 	e.workflowSpec = spec
 	e.workflowTransExec = transExec
@@ -186,7 +193,11 @@ func (e *Engine) buildEntryStateMeta(stateName string) map[string]interface{} {
 // the per-run skill filter into context for the next turn's tool execution.
 func (e *Engine) wireWorkflowHooks(req *ConversationRequest, runID string) {
 	req.PostTurnHook = func() error {
-		return e.workflowTransExec.CommitPendingTransition(runID)
+		var emitter *events.Emitter
+		if req.EventBus != nil {
+			emitter = events.NewEmitter(req.EventBus, req.RunID, req.RunID, req.ConversationID)
+		}
+		return e.workflowTransExec.CommitPendingTransition(runID, emitter)
 	}
 	req.ContextEnricher = func(ctx context.Context) context.Context {
 		filter := e.workflowTransExec.SkillFilter(runID)

--- a/tools/arena/engine/workflow_events.go
+++ b/tools/arena/engine/workflow_events.go
@@ -1,0 +1,90 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/workflow"
+)
+
+// workflowArtifactExecutor dispatches workflow__set_artifact calls to the
+// per-run state machine, keyed on the scenario ID carried in the context.
+// Mirrors workflowTransitionExecutor's per-run isolation so concurrent
+// scenarios don't stomp on each other's artifact maps.
+type workflowArtifactExecutor struct {
+	transExec *workflowTransitionExecutor
+}
+
+// Name implements tools.Executor.
+func (a *workflowArtifactExecutor) Name() string { return workflow.ArtifactExecutorMode }
+
+// Execute routes to the per-run ArtifactExecutor via the shared transition
+// executor's run map.
+func (a *workflowArtifactExecutor) Execute(
+	ctx context.Context, desc *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
+	scenarioID := workflowScenarioIDFromCtx(ctx)
+	a.transExec.mu.Lock()
+	run := a.transExec.runs[scenarioID]
+	a.transExec.mu.Unlock()
+	if run == nil {
+		return nil, fmt.Errorf("no active workflow run for scenario %q", scenarioID)
+	}
+	artExec := workflow.NewArtifactExecutor(run.transExec.StateMachine())
+	return artExec.Execute(ctx, desc, args)
+}
+
+// emitWorkflowError emits the typed workflow error event (max_visits_exceeded
+// or budget_exhausted) for a ProcessEvent / CommitPending error. No-op when
+// emitter is nil or err doesn't match a known workflow error type.
+func (e *workflowTransitionExecutor) emitWorkflowError(
+	run *workflowRunState, emitter *events.Emitter, _ string, err error,
+) {
+	if emitter == nil || err == nil {
+		return
+	}
+	var mvErr *workflow.MaxVisitsExceededError
+	if errors.As(err, &mvErr) {
+		emitter.WorkflowMaxVisitsExceeded(&events.WorkflowMaxVisitsExceededData{
+			FromState:      mvErr.FromState,
+			OriginalTarget: mvErr.OriginalTarget,
+			Event:          mvErr.Event,
+			VisitCount:     mvErr.VisitCount,
+			MaxVisits:      mvErr.MaxVisits,
+			Terminated:     true,
+		})
+		return
+	}
+	var bErr *workflow.BudgetExhaustedError
+	if errors.As(err, &bErr) {
+		transitions := 0
+		if run != nil {
+			transitions = run.transExec.StateMachine().Context().TransitionCount()
+		}
+		emitter.WorkflowBudgetExhausted(&events.WorkflowBudgetExhaustedData{
+			Limit:           bErr.Limit,
+			Current:         bErr.Current,
+			Max:             bErr.Max,
+			CurrentState:    bErr.CurrentState,
+			TransitionCount: transitions,
+		})
+		return
+	}
+}
+
+// maxVisitsForWorkflowState returns the max_visits cap declared on a state
+// in the given spec, or 0 if not set.
+func maxVisitsForWorkflowState(spec *workflow.Spec, name string) int {
+	if spec == nil {
+		return 0
+	}
+	s := spec.States[name]
+	if s == nil {
+		return 0
+	}
+	return s.MaxVisits
+}

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
@@ -98,7 +99,15 @@ func (e *workflowTransitionExecutor) Execute(
 // CommitPendingTransition commits the deferred transition for a run.
 // Called after the turn/pipeline completes. Updates scenario TaskType and
 // re-registers the transition tool for the new state's events.
-func (e *workflowTransitionExecutor) CommitPendingTransition(runID string) error {
+//
+// When emitter is non-nil, emits workflow observability events:
+// workflow.transitioned on every commit, workflow.max_visits_exceeded when
+// the transition redirected or a max-visits cap terminated the workflow,
+// workflow.budget_exhausted when a budget limit tripped, and
+// workflow.completed when the new state is terminal.
+func (e *workflowTransitionExecutor) CommitPendingTransition(
+	runID string, emitter *events.Emitter,
+) error {
 	e.mu.Lock()
 	run := e.runs[runID]
 	e.mu.Unlock()
@@ -107,8 +116,10 @@ func (e *workflowTransitionExecutor) CommitPendingTransition(runID string) error
 		return nil
 	}
 
+	pending := run.transExec.Pending()
 	tr, err := run.transExec.CommitPending()
 	if err != nil {
+		e.emitWorkflowError(run, emitter, pending.Event, err)
 		return fmt.Errorf("transition commit failed: %w", err)
 	}
 	if tr == nil {
@@ -129,6 +140,28 @@ func (e *workflowTransitionExecutor) CommitPendingTransition(runID string) error
 	run.transitions = append(run.transitions, transitionRecord)
 	logger.Info("workflow state transition", "from", tr.From, "to", tr.To,
 		"event", tr.Event, "redirected", tr.Redirected)
+
+	// Emit transition observability events before mutating state below, so
+	// listeners see the transition and any max_visits redirect in order.
+	if emitter != nil {
+		if tr.Redirected {
+			emitter.WorkflowMaxVisitsExceeded(&events.WorkflowMaxVisitsExceededData{
+				FromState:      tr.From,
+				OriginalTarget: tr.OriginalTarget,
+				Event:          tr.Event,
+				VisitCount:     run.transExec.StateMachine().Context().VisitCounts[tr.OriginalTarget],
+				MaxVisits:      maxVisitsForWorkflowState(e.wfSpec, tr.OriginalTarget),
+				RedirectedTo:   tr.To,
+				Terminated:     false,
+			})
+		}
+		emitter.WorkflowTransitioned(tr.From, tr.To, tr.Event, "")
+		if newState := e.wfSpec.States[tr.To]; newState != nil &&
+			(newState.Terminal || len(newState.OnEvent) == 0) {
+			emitter.WorkflowCompleted(
+				tr.To, run.transExec.StateMachine().Context().TransitionCount())
+		}
+	}
 
 	// Update scenario TaskType and re-register tool for the new state
 	if newState := e.wfSpec.States[tr.To]; newState != nil {

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +55,7 @@ func TestWorkflowTransitionExecutor_Execute(t *testing.T) {
 	assert.Equal(t, "intake", scenario.TaskType)
 
 	// Commit applies the transition
-	require.NoError(t, exec.CommitPendingTransition("test"))
+	require.NoError(t, exec.CommitPendingTransition("test", nil))
 	assert.Equal(t, "specialist", scenario.TaskType)
 }
 
@@ -70,7 +72,7 @@ func TestWorkflowTransitionExecutor_InvalidEvent(t *testing.T) {
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
 	require.NoError(t, err) // Execute always succeeds (just stores pending)
 
-	err = exec.CommitPendingTransition("test")
+	err = exec.CommitPendingTransition("test", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "NonExistent")
 }
@@ -92,7 +94,7 @@ func TestWorkflowTransitionExecutor_WorkflowMetadata(t *testing.T) {
 	args, _ := json.Marshal(map[string]string{"event": "Escalate"})
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
 	require.NoError(t, err)
-	require.NoError(t, exec.CommitPendingTransition("test"))
+	require.NoError(t, exec.CommitPendingTransition("test", nil))
 
 	meta = exec.RunMetadata("test")
 	assert.Equal(t, "specialist", meta["workflow_current_state"])
@@ -115,7 +117,7 @@ func TestWorkflowTransitionExecutor_TerminalState(t *testing.T) {
 	args, _ := json.Marshal(map[string]string{"event": "Resolve"})
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
 	require.NoError(t, err)
-	require.NoError(t, exec.CommitPendingTransition("test"))
+	require.NoError(t, exec.CommitPendingTransition("test", nil))
 
 	meta := exec.RunMetadata("test")
 	assert.Equal(t, true, meta["workflow_complete"])
@@ -136,14 +138,14 @@ func TestWorkflowTransitionExecutor_ConcurrentRuns(t *testing.T) {
 	args, _ := json.Marshal(map[string]string{"event": "Escalate"})
 	_, err := exec.Execute(ctx1, nil, args)
 	require.NoError(t, err)
-	require.NoError(t, exec.CommitPendingTransition("s1"))
+	require.NoError(t, exec.CommitPendingTransition("s1", nil))
 	assert.Equal(t, "specialist", s1.TaskType)
 
 	// s2 should still be able to Escalate (its own state machine)
 	ctx2 := withWorkflowScenarioID(context.Background(), "s2")
 	_, err = exec.Execute(ctx2, nil, args)
 	require.NoError(t, err)
-	require.NoError(t, exec.CommitPendingTransition("s2"))
+	require.NoError(t, exec.CommitPendingTransition("s2", nil))
 	assert.Equal(t, "specialist", s2.TaskType)
 }
 
@@ -175,14 +177,14 @@ func TestWorkflowTransitionExecutor_MaxVisitsRedirect(t *testing.T) {
 	args, _ := json.Marshal(map[string]string{"event": "Go", "context": "test"})
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
 	require.NoError(t, err)
-	require.NoError(t, exec.CommitPendingTransition("test"))
+	require.NoError(t, exec.CommitPendingTransition("test", nil))
 	assert.Equal(t, "loop", scenario.TaskType)
 
 	// Second transition: loop -> loop, but max_visits=1 so redirect to done
 	args2, _ := json.Marshal(map[string]string{"event": "Again", "context": "test"})
 	_, err = exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args2)
 	require.NoError(t, err)
-	require.NoError(t, exec.CommitPendingTransition("test"))
+	require.NoError(t, exec.CommitPendingTransition("test", nil))
 	assert.Equal(t, "done", scenario.TaskType, "should redirect to on_max_visits target")
 
 	// Verify redirect info in transitions metadata
@@ -301,7 +303,7 @@ func TestCommitPendingTransition_SetsSkillFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Commit should store the skill filter on the per-run state
-	err = exec.CommitPendingTransition("run1")
+	err = exec.CommitPendingTransition("run1", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "skills/billing/*", exec.SkillFilter("run1"))
 }
@@ -333,6 +335,148 @@ func TestCommitPendingTransition_NilSkillFilterer(t *testing.T) {
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "run1"), nil, args)
 	require.NoError(t, err)
 
-	err = exec.CommitPendingTransition("run1")
+	err = exec.CommitPendingTransition("run1", nil)
 	require.NoError(t, err)
+}
+
+// TestWorkflowArtifactExecutor_DispatchesToRun verifies the per-run artifact
+// executor mutates the right state machine's artifact map.
+func TestWorkflowArtifactExecutor_DispatchesToRun(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "s",
+		States: map[string]*workflow.State{
+			"s": {
+				PromptTask: "s",
+				Artifacts: map[string]*workflow.ArtifactDef{
+					"notes": {Type: "text/plain", Mode: "append"},
+				},
+			},
+		},
+	}
+	registry := tools.NewRegistry()
+	transExec := newWorkflowTransitionExecutor(spec, registry)
+	transExec.RegisterRun("r1", &config.Scenario{ID: "r1"})
+	transExec.RegisterRun("r2", &config.Scenario{ID: "r2"})
+
+	artExec := &workflowArtifactExecutor{transExec: transExec}
+	assert.Equal(t, workflow.ArtifactExecutorMode, artExec.Name())
+
+	args, _ := json.Marshal(map[string]string{"name": "notes", "value": "first"})
+	_, err := artExec.Execute(withWorkflowScenarioID(context.Background(), "r1"), nil, args)
+	require.NoError(t, err)
+
+	args2, _ := json.Marshal(map[string]string{"name": "notes", "value": "second"})
+	_, err = artExec.Execute(withWorkflowScenarioID(context.Background(), "r1"), nil, args2)
+	require.NoError(t, err)
+
+	// r1's artifact has both appended values; r2's artifact is untouched.
+	r1Notes := transExec.runs["r1"].transExec.StateMachine().Artifacts()["notes"]
+	r2Notes := transExec.runs["r2"].transExec.StateMachine().Artifacts()["notes"]
+	assert.Contains(t, r1Notes, "first")
+	assert.Contains(t, r1Notes, "second")
+	assert.Empty(t, r2Notes)
+
+	// Unknown scenario errors out.
+	_, err = artExec.Execute(withWorkflowScenarioID(context.Background(), "missing"), nil, args)
+	assert.Error(t, err)
+}
+
+// TestEmitWorkflowError_Arena verifies the arena's emitWorkflowError
+// helper fires the right typed event for each workflow error type.
+func TestEmitWorkflowError_Arena(t *testing.T) {
+	registry := tools.NewRegistry()
+	exec := newWorkflowTransitionExecutor(testWorkflowSpec(), registry)
+	exec.RegisterRun("r", &config.Scenario{ID: "r"})
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run", "sess", "conv")
+
+	mvCh := make(chan *events.Event, 1)
+	bgCh := make(chan *events.Event, 1)
+	bus.Subscribe(events.EventWorkflowMaxVisitsExceeded, func(e *events.Event) { mvCh <- e })
+	bus.Subscribe(events.EventWorkflowBudgetExhausted, func(e *events.Event) { bgCh <- e })
+
+	run := exec.runs["r"]
+	exec.emitWorkflowError(run, emitter, "Go", &workflow.MaxVisitsExceededError{
+		FromState: "a", OriginalTarget: "b", Event: "Go", VisitCount: 3, MaxVisits: 3,
+	})
+	exec.emitWorkflowError(run, emitter, "Go", &workflow.BudgetExhaustedError{
+		Limit: workflow.BudgetLimitWallTimeSec, Current: 60, Max: 60, CurrentState: "a",
+	})
+	// Nil-safety: nil emitter, nil error, unmatched error — all no-ops.
+	exec.emitWorkflowError(run, nil, "", &workflow.MaxVisitsExceededError{})
+	exec.emitWorkflowError(run, emitter, "", nil)
+	exec.emitWorkflowError(run, emitter, "", assert.AnError)
+
+	select {
+	case e := <-mvCh:
+		data := e.Data.(*events.WorkflowMaxVisitsExceededData)
+		assert.Equal(t, "b", data.OriginalTarget)
+		assert.True(t, data.Terminated)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for max_visits_exceeded")
+	}
+	select {
+	case e := <-bgCh:
+		data := e.Data.(*events.WorkflowBudgetExhaustedData)
+		assert.Equal(t, workflow.BudgetLimitWallTimeSec, data.Limit)
+		assert.Equal(t, 60, data.Max)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for budget_exhausted")
+	}
+}
+
+// TestCommitPendingTransition_EmitsRedirectedEvent verifies that a commit
+// that redirects (max_visits cap hit with on_max_visits fallback) emits
+// workflow.max_visits_exceeded alongside workflow.transitioned.
+func TestCommitPendingTransition_EmitsRedirectedEvent(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "loop",
+		States: map[string]*workflow.State{
+			"loop": {
+				PromptTask:  "loop",
+				MaxVisits:   2,
+				OnMaxVisits: "exit",
+				OnEvent:     map[string]string{"Again": "loop"},
+			},
+			"exit": {PromptTask: "exit"},
+		},
+	}
+	registry := tools.NewRegistry()
+	exec := newWorkflowTransitionExecutor(spec, registry)
+
+	scenario := &config.Scenario{ID: "r", TaskType: "loop"}
+	exec.RegisterRun("r", scenario)
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run", "sess", "conv")
+
+	received := make(chan *events.Event, 4)
+	bus.Subscribe(events.EventWorkflowMaxVisitsExceeded, func(e *events.Event) {
+		received <- e
+	})
+
+	// First transition: 0 visits → no redirect, visits[loop]=1
+	args, _ := json.Marshal(map[string]string{"event": "Again"})
+	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "r"), nil, args)
+	require.NoError(t, err)
+	require.NoError(t, exec.CommitPendingTransition("r", emitter))
+
+	// Second transition: visits[loop]=1 == MaxVisits, should redirect to exit.
+	_, err = exec.Execute(withWorkflowScenarioID(context.Background(), "r"), nil, args)
+	require.NoError(t, err)
+	require.NoError(t, exec.CommitPendingTransition("r", emitter))
+
+	select {
+	case e := <-received:
+		data, ok := e.Data.(*events.WorkflowMaxVisitsExceededData)
+		require.True(t, ok)
+		assert.Equal(t, "loop", data.OriginalTarget)
+		assert.Equal(t, "exit", data.RedirectedTo)
+		assert.False(t, data.Terminated)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for workflow.max_visits_exceeded")
+	}
 }


### PR DESCRIPTION
## Summary

Closes the two observability gaps in PromptKit's RFC 0009 (Agent Loop Extension) implementation and adds a runnable arena example demonstrating the full loop feature set.

## What's new

**Runtime events**
- `EventWorkflowMaxVisitsExceeded` / `WorkflowMaxVisitsExceededData` — fires on max_visits redirect or termination.
- `EventWorkflowBudgetExhausted` / `WorkflowBudgetExhaustedData` — fires when `max_total_visits`/`max_tool_calls`/`max_wall_time_sec` trips.
- `*MaxVisitsExceededError` and `*BudgetExhaustedError` wrap the existing sentinels with structured fields (limit, current, max, etc.).

**SDK + Arena emission**
- SDK \`emitTransitionEvents\` fires \`transitioned\` + \`max_visits_exceeded\` (on redirect) + \`completed\` (on terminal).
- \`emitWorkflowError\` routes typed errors to the matching exhausted event before propagating.
- Arena's \`CommitPendingTransition\` now emits the same set (arena previously emitted no workflow events).

**Arena artifact tool** — \`workflowArtifactExecutor\` dispatches \`workflow__set_artifact\` to the correct per-run state machine. Previously the artifact tool was registered only in the SDK path.

**Example** — \`examples/workflow-agent-loops/\` exercises \`max_visits + on_max_visits\`, \`engine.budget\`, and a findings artifact with \`mode: append\`. Two scenarios: loop converges naturally, loop hits the cap and gets redirected.

## Test plan

- [x] \`go test ./runtime/workflow/... ./runtime/events/... -count=1\`
- [x] \`go test ./sdk/... -count=1 -race\`
- [x] \`go test ./tools/arena/engine/... -count=1\`
- [x] \`golangci-lint run --new-from-rev=main\` — 0 issues
- [x] Coverage on changed files ≥ 80%
- [x] \`promptarena run -c examples/workflow-agent-loops/config.arena.yaml --ci\` — both scenarios run; logs show all transition + redirect events