### PR TITLE
feat(hooks): pluggable Sandbox interface for exec-backed hooks (M1)

### DIFF
--- a/runtime/evals/exec_hook.go
+++ b/runtime/evals/exec_hook.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox/direct"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 )
 
@@ -16,15 +15,10 @@ import (
 // of an ExecEvalHook may run before it is killed and the result abandoned.
 const DefaultExecEvalHookTimeout = 5 * time.Second
 
-// execEvalHookWaitDelay bounds how long cmd.Wait() will block on I/O
-// after the context expires. Set above zero so an orphaned grandchild
-// inheriting our Stderr pipe cannot hang the hook indefinitely after
-// SIGKILL — e.g. a bash wrapper whose `sleep` child survives the kill.
-const execEvalHookWaitDelay = 500 * time.Millisecond
-
 // ExecEvalHookConfig configures an ExecEvalHook. It is the eval-side
 // analog of hooks.ExecHookConfig: a command to spawn, its arguments
-// and environment, and a per-call timeout.
+// and environment, a per-call timeout, and an optional Sandbox that
+// controls how the subprocess is actually launched.
 type ExecEvalHookConfig struct {
 	// Name is a stable identifier used in logs.
 	Name string
@@ -39,6 +33,10 @@ type ExecEvalHookConfig struct {
 	// TimeoutMs is the per-invocation timeout in milliseconds. Zero
 	// means use DefaultExecEvalHookTimeout.
 	TimeoutMs int
+	// Sandbox, when non-nil, overrides the default direct-exec sandbox.
+	// Use this to run eval hooks in a container, a sidecar, or a custom
+	// backend; see runtime/hooks/sandbox for the interface.
+	Sandbox sandbox.Sandbox
 }
 
 // ExecEvalHook is an EvalHook that spawns an external process per eval
@@ -55,19 +53,27 @@ type ExecEvalHook struct {
 	args      []string
 	env       []string
 	timeoutMs int
+	sandbox   sandbox.Sandbox
 }
 
 // Compile-time interface check.
 var _ EvalHook = (*ExecEvalHook)(nil)
 
 // NewExecEvalHook constructs an ExecEvalHook from the given config.
+// When cfg.Sandbox is nil the hook falls back to the built-in direct
+// sandbox, which matches the historical local-exec behavior.
 func NewExecEvalHook(cfg *ExecEvalHookConfig) *ExecEvalHook {
+	sb := cfg.Sandbox
+	if sb == nil {
+		sb = direct.New(direct.ModeName)
+	}
 	return &ExecEvalHook{
 		name:      cfg.Name,
 		command:   cfg.Command,
 		args:      cfg.Args,
 		env:       cfg.Env,
 		timeoutMs: cfg.TimeoutMs,
+		sandbox:   sb,
 	}
 }
 
@@ -92,33 +98,27 @@ func (h *ExecEvalHook) OnEvalResult(
 	if timeout <= 0 {
 		timeout = DefaultExecEvalHookTimeout
 	}
-	execCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
-	cmd := exec.CommandContext(execCtx, h.command, h.args...) //#nosec G204 -- command from trusted runtime config
-	cmd.Stdin = bytes.NewReader(payload)
-
-	// See execEvalHookWaitDelay for why this is set.
-	cmd.WaitDelay = execEvalHookWaitDelay
-
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	if len(h.env) > 0 {
-		cmd.Env = os.Environ()
-		for _, name := range h.env {
-			if val, ok := os.LookupEnv(name); ok {
-				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", name, val))
-			}
-		}
+	resp, spawnErr := h.sandbox.Spawn(ctx, sandbox.Request{
+		Command: h.command,
+		Args:    h.args,
+		Env:     h.env,
+		Stdin:   payload,
+		Timeout: timeout,
+	})
+	// Spawn returns err only for transport-level failure; non-zero exit
+	// and timeout come back as a populated Response.Err. Treat both the
+	// same way — log and drop, per fire-and-forget contract.
+	runErr := spawnErr
+	if runErr == nil {
+		runErr = resp.Err
 	}
-
-	if err := cmd.Run(); err != nil {
+	if runErr != nil {
 		logger.Warn("exec eval hook: subprocess failed",
 			"hook", h.name,
 			"eval_id", result.EvalID,
-			"error", err,
-			"stderr", bytes.TrimSpace(stderr.Bytes()),
+			"error", runErr,
+			"stderr", bytes.TrimSpace(resp.Stderr),
 		)
 	}
 }

--- a/runtime/hooks/exec_hooks.go
+++ b/runtime/hooks/exec_hooks.go
@@ -5,14 +5,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox/direct"
 )
 
 const defaultExecHookTimeout = 10 * time.Second
 
 // ExecHookConfig holds the configuration for creating exec-based hooks.
+//
+// Sandbox, when non-nil, controls how the hook subprocess is launched.
+// When nil, the exec hooks fall back to the built-in direct sandbox
+// which matches the historical behavior: exec.CommandContext(Command,
+// Args...) in-process with the local environment. SDK consumers that
+// want their hooks to run elsewhere — in a sidecar, a disposable
+// container, a managed cloud sandbox — construct a Sandbox
+// implementation and pass it here.
 type ExecHookConfig struct {
 	Name      string
 	Command   string
@@ -21,6 +30,7 @@ type ExecHookConfig struct {
 	TimeoutMs int
 	Phases    []string
 	Mode      string // "filter" | "observe"
+	Sandbox   sandbox.Sandbox
 }
 
 // execHookRequest is the JSON payload sent to an exec hook subprocess on stdin.
@@ -50,6 +60,7 @@ type execHookBase struct {
 	timeoutMs int
 	phases    map[string]bool
 	mode      string
+	sandbox   sandbox.Sandbox
 }
 
 func newExecHookBase(cfg *ExecHookConfig) execHookBase {
@@ -61,6 +72,10 @@ func newExecHookBase(cfg *ExecHookConfig) execHookBase {
 	if mode == "" {
 		mode = "filter"
 	}
+	sb := cfg.Sandbox
+	if sb == nil {
+		sb = direct.New(direct.ModeName)
+	}
 	return execHookBase{
 		name:      cfg.Name,
 		command:   cfg.Command,
@@ -69,6 +84,7 @@ func newExecHookBase(cfg *ExecHookConfig) execHookBase {
 		timeoutMs: cfg.TimeoutMs,
 		phases:    phases,
 		mode:      mode,
+		sandbox:   sb,
 	}
 }
 
@@ -87,27 +103,22 @@ func (b *execHookBase) isObserve() bool {
 	return b.mode == "observe"
 }
 
+// runProcess delegates subprocess execution to the configured Sandbox.
+// It preserves the previous signature so the filter/observe helpers
+// below don't change. The timeout is applied by the sandbox (it's in
+// the Request); the inbound ctx still carries cancellation.
 func (b *execHookBase) runProcess(ctx context.Context, stdin []byte) (stdout, stderr []byte, err error) {
-	cmd := exec.CommandContext(ctx, b.command, b.args...) //#nosec G204 -- command from trusted config
-	cmd.Stdin = bytes.NewReader(stdin)
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-
-	if len(b.env) > 0 {
-		cmd.Env = os.Environ()
-		for _, name := range b.env {
-			if val, ok := os.LookupEnv(name); ok {
-				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", name, val))
-			}
-		}
+	resp, spawnErr := b.sandbox.Spawn(ctx, sandbox.Request{
+		Command: b.command,
+		Args:    b.args,
+		Env:     b.env,
+		Stdin:   stdin,
+		Timeout: b.timeout(),
+	})
+	if spawnErr != nil {
+		return resp.Stdout, resp.Stderr, spawnErr
 	}
-
-	if err := cmd.Run(); err != nil {
-		return stdoutBuf.Bytes(), stderrBuf.Bytes(), err
-	}
-	return stdoutBuf.Bytes(), stderrBuf.Bytes(), nil
+	return resp.Stdout, resp.Stderr, resp.Err
 }
 
 // execFilter runs the hook subprocess and returns a Decision based on its response.

--- a/runtime/hooks/exec_hooks_test.go
+++ b/runtime/hooks/exec_hooks_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -432,3 +433,83 @@ var (
 	_ ToolHook     = (*ExecToolHook)(nil)
 	_ SessionHook  = (*ExecSessionHook)(nil)
 )
+
+// --- Sandbox integration ---
+
+// recordingSandbox captures the Request it is given and returns a
+// pre-canned Response. Used below to verify Exec*Hook wires through a
+// caller-provided Sandbox instead of spawning locally.
+type recordingSandbox struct {
+	lastReq sandbox.Request
+	resp    sandbox.Response
+	err     error
+}
+
+func (s *recordingSandbox) Name() string { return "recording" }
+func (s *recordingSandbox) Spawn(_ context.Context, req sandbox.Request) (sandbox.Response, error) {
+	s.lastReq = req
+	return s.resp, s.err
+}
+
+// TestExecHookConfig_CustomSandboxIsUsed verifies that when
+// ExecHookConfig.Sandbox is set, the hook routes all subprocess
+// invocations through it — no local exec happens.
+func TestExecHookConfig_CustomSandboxIsUsed(t *testing.T) {
+	stub := &recordingSandbox{
+		resp: sandbox.Response{Stdout: []byte(`{"allow": true}`)},
+	}
+	hook := NewExecProviderHook(&ExecHookConfig{
+		Name:      "pii",
+		Command:   "/would/not/exist/on/disk",
+		Args:      []string{"arg1"},
+		Env:       []string{"PK_TEST_VAR=value"},
+		TimeoutMs: 1234,
+		Phases:    []string{"before_call"},
+		Mode:      "filter",
+		Sandbox:   stub,
+	})
+
+	decision := hook.BeforeCall(context.Background(), &ProviderRequest{})
+	if !decision.Allow {
+		t.Errorf("Allow = %v, want true", decision.Allow)
+	}
+
+	// The stub captured the request — verify everything routed through it.
+	if stub.lastReq.Command != "/would/not/exist/on/disk" {
+		t.Errorf("Command = %q", stub.lastReq.Command)
+	}
+	if len(stub.lastReq.Args) != 1 || stub.lastReq.Args[0] != "arg1" {
+		t.Errorf("Args = %v", stub.lastReq.Args)
+	}
+	if len(stub.lastReq.Env) != 1 || stub.lastReq.Env[0] != "PK_TEST_VAR=value" {
+		t.Errorf("Env = %v", stub.lastReq.Env)
+	}
+	if stub.lastReq.Timeout != 1234*time.Millisecond {
+		t.Errorf("Timeout = %v, want 1234ms", stub.lastReq.Timeout)
+	}
+	if len(stub.lastReq.Stdin) == 0 {
+		t.Error("Stdin should carry the exec-hook JSON payload")
+	}
+}
+
+// TestExecHookConfig_NilSandboxDefaultsToDirect verifies that an
+// ExecHookConfig with Sandbox left unset still works — falling back to
+// the direct backend (historical behavior).
+func TestExecHookConfig_NilSandboxDefaultsToDirect(t *testing.T) {
+	// Use /bin/cat or similar only if present; we just need to verify
+	// that the hook constructs and invokes cleanly without a panic.
+	hook := NewExecProviderHook(&ExecHookConfig{
+		Name:      "nil-sandbox",
+		Command:   "/nonexistent/command/for/this/test",
+		Phases:    []string{"before_call"},
+		Mode:      "filter",
+		TimeoutMs: 100,
+	})
+	// The hook uses the default direct sandbox; invoking it against a
+	// nonexistent command should produce a deny (filter mode, process
+	// failed), not a panic or crash.
+	decision := hook.BeforeCall(context.Background(), &ProviderRequest{})
+	if decision.Allow {
+		t.Error("missing command with filter mode should deny, not allow")
+	}
+}

--- a/runtime/hooks/sandbox/direct/direct.go
+++ b/runtime/hooks/sandbox/direct/direct.go
@@ -1,0 +1,141 @@
+// Package direct provides the default Sandbox implementation for exec
+// hooks: it spawns the command as a local subprocess via exec.CommandContext.
+//
+// This is the built-in, zero-config behavior. When ExecHookConfig.Sandbox
+// is nil, the exec hooks fall back to direct.New() — so existing
+// deployments get the exact same semantics they had before the Sandbox
+// abstraction was introduced.
+package direct
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+)
+
+// ModeName is the mode identifier under which this backend registers
+// with sandbox.RegisterFactory.
+const ModeName = "direct"
+
+// Sandbox runs exec-hook commands as local subprocesses.
+type Sandbox struct {
+	name string
+}
+
+// New returns a direct-mode sandbox with the given display name. An
+// empty name defaults to "direct".
+func New(name string) *Sandbox {
+	if name == "" {
+		name = ModeName
+	}
+	return &Sandbox{name: name}
+}
+
+// Factory is a sandbox.Factory that ignores the config block (direct
+// mode has no configuration) and returns a ready Sandbox.
+func Factory(name string, _ map[string]any) (sandbox.Sandbox, error) {
+	return New(name), nil
+}
+
+// init registers the default backend globally at package load so that a
+// RuntimeConfig entry of `mode: direct` resolves without any consumer
+// opt-in. Other backends (docker, kubectl) are examples the consumer
+// opts into by importing an example package or calling
+// sandbox.RegisterFactory explicitly.
+//
+//nolint:gochecknoinits // registry self-registration is the plug-in pattern.
+func init() {
+	_ = sandbox.RegisterFactory(ModeName, Factory)
+}
+
+// Name returns the configured sandbox name.
+func (s *Sandbox) Name() string { return s.name }
+
+// defaultTimeout is used when Request.Timeout is zero or negative.
+const defaultTimeout = 10 * time.Second
+
+// grandchildWaitDelay bounds how long cmd.Wait() will block on I/O
+// after the context expires. Set > 0 so an orphaned grandchild that
+// inherited the stdout/stderr pipes cannot hang the hook indefinitely
+// after SIGKILL — e.g. a bash wrapper whose `sleep` child outlives the
+// kill.
+const grandchildWaitDelay = 500 * time.Millisecond
+
+// Spawn runs req.Command locally, piping req.Stdin into its stdin and
+// collecting stdout and stderr. req.Env entries are merged on top of the
+// host environment: each entry is either a bare env var name (its value
+// is looked up on the host and forwarded) or a "KEY=value" pair
+// (forwarded verbatim). A timeout or non-zero exit surfaces as a
+// non-nil Response.Err.
+//
+//nolint:gocritic // Request is a public interface param; pass-by-value keeps ownership clear.
+func (s *Sandbox) Spawn(ctx context.Context, req sandbox.Request) (sandbox.Response, error) {
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, req.Command, req.Args...) //#nosec G204 -- command from trusted config
+	cmd.Stdin = bytes.NewReader(req.Stdin)
+	cmd.WaitDelay = grandchildWaitDelay
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if len(req.Env) > 0 {
+		cmd.Env = buildEnv(req.Env)
+	}
+
+	runErr := cmd.Run()
+	return sandbox.Response{
+		Stdout: stdout.Bytes(),
+		Stderr: stderr.Bytes(),
+		Err:    runErr,
+	}, nil
+}
+
+// buildEnv returns the child-process environment: host env as the base,
+// with each entry in extras applied on top. Each entry is interpreted
+// as follows:
+//
+//   - contains '=': treated as a literal "KEY=value" pair and appended.
+//   - no '=': treated as a host env var name; its value is looked up via
+//     os.LookupEnv and forwarded as "KEY=value" when present.
+//
+// The bare-name form matches the long-standing exec hook behavior where
+// Env lists var names whose host values should be forwarded; the
+// literal form is the more general case sandboxes generally want.
+func buildEnv(extras []string) []string {
+	base := os.Environ()
+	out := make([]string, 0, len(base)+len(extras))
+	out = append(out, base...)
+	for _, entry := range extras {
+		if i := indexOfByte(entry, '='); i >= 0 {
+			out = append(out, entry)
+			continue
+		}
+		if val, ok := os.LookupEnv(entry); ok {
+			out = append(out, fmt.Sprintf("%s=%s", entry, val))
+		}
+	}
+	return out
+}
+
+// indexOfByte is strings.IndexByte without pulling in the strings
+// import; keeps this package dependency-minimal.
+func indexOfByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}

--- a/runtime/hooks/sandbox/direct/direct_test.go
+++ b/runtime/hooks/sandbox/direct/direct_test.go
@@ -1,0 +1,124 @@
+package direct
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+)
+
+func TestDirect_Name(t *testing.T) {
+	if got := New("").Name(); got != ModeName {
+		t.Errorf("Name() with empty input = %q, want %q", got, ModeName)
+	}
+	if got := New("custom").Name(); got != "custom" {
+		t.Errorf("Name() = %q, want %q", got, "custom")
+	}
+}
+
+func TestDirect_SpawnEchoesStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cat isn't portable on Windows")
+	}
+	sb := New("")
+	resp, err := sb.Spawn(context.Background(), sandbox.Request{
+		Command: "cat",
+		Stdin:   []byte(`{"hello":"world"}`),
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if resp.Err != nil {
+		t.Fatalf("Response.Err = %v", resp.Err)
+	}
+	if got := string(resp.Stdout); got != `{"hello":"world"}` {
+		t.Errorf("Stdout = %q, want echo of stdin", got)
+	}
+}
+
+func TestDirect_SpawnNonZeroExitIsReported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("false isn't portable on Windows")
+	}
+	sb := New("")
+	resp, err := sb.Spawn(context.Background(), sandbox.Request{
+		Command: "false",
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if resp.Err == nil {
+		t.Fatal("expected Response.Err to be non-nil on non-zero exit")
+	}
+}
+
+func TestDirect_SpawnTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sleep isn't portable on Windows")
+	}
+	sb := New("")
+	start := time.Now()
+	resp, err := sb.Spawn(context.Background(), sandbox.Request{
+		Command: "sleep",
+		Args:    []string{"5"},
+		Timeout: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if resp.Err == nil {
+		t.Fatal("expected Response.Err on timeout")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("Spawn blocked for %v, timeout should have fired within ~100ms", elapsed)
+	}
+}
+
+// TestDirect_EnvForwarding verifies both supported Env forms round-trip:
+//   - "KEY=value" is forwarded verbatim
+//   - "KEY" looks up the host value and forwards "KEY=<value>"
+func TestDirect_EnvForwarding(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh isn't portable on Windows")
+	}
+	t.Setenv("PK_SB_HOST_VAR", "from_host")
+
+	sb := New("")
+	resp, err := sb.Spawn(context.Background(), sandbox.Request{
+		Command: "sh",
+		Args:    []string{"-c", `echo "$PK_SB_LITERAL:$PK_SB_HOST_VAR"`},
+		Env:     []string{"PK_SB_LITERAL=literal", "PK_SB_HOST_VAR"},
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if resp.Err != nil {
+		t.Fatalf("Response.Err = %v", resp.Err)
+	}
+	got := strings.TrimSpace(string(resp.Stdout))
+	if got != "literal:from_host" {
+		t.Errorf("env round-trip: got %q, want %q", got, "literal:from_host")
+	}
+}
+
+// TestDirect_RegisteredAsDefault verifies the package-init side-effect
+// registers the direct factory under ModeName.
+func TestDirect_RegisteredAsDefault(t *testing.T) {
+	factory, err := sandbox.LookupFactory(ModeName)
+	if err != nil {
+		t.Fatalf("LookupFactory: %v", err)
+	}
+	sb, err := factory("default", nil)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if sb == nil {
+		t.Fatal("factory returned nil sandbox")
+	}
+}

--- a/runtime/hooks/sandbox/registry.go
+++ b/runtime/hooks/sandbox/registry.go
@@ -1,0 +1,104 @@
+package sandbox
+
+import (
+	"fmt"
+	"sync"
+)
+
+// globalRegistry holds the process-wide factory registry. It's the
+// default lookup path for RuntimeConfig-based sandbox resolution; SDK
+// callers that want per-conversation scoping should pass a Registry
+// explicitly via the SDK option instead of registering globally.
+var globalRegistry = NewRegistry()
+
+// Registry maps mode names to sandbox factories. It is safe for
+// concurrent use.
+type Registry struct {
+	mu        sync.RWMutex
+	factories map[string]Factory
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{factories: make(map[string]Factory)}
+}
+
+// Register adds a factory under the given mode name. An empty name or a
+// nil factory is rejected. Duplicate registrations fail rather than
+// silently overwriting — use Replace if overwrite is intentional.
+func (r *Registry) Register(mode string, f Factory) error {
+	if mode == "" {
+		return fmt.Errorf("sandbox: mode name must not be empty")
+	}
+	if f == nil {
+		return fmt.Errorf("sandbox: factory for mode %q must not be nil", mode)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.factories[mode]; exists {
+		return fmt.Errorf("sandbox: mode %q is already registered", mode)
+	}
+	r.factories[mode] = f
+	return nil
+}
+
+// Replace is like Register but unconditionally overwrites any existing
+// factory registered under mode. Use sparingly; the normal path is
+// Register.
+func (r *Registry) Replace(mode string, f Factory) error {
+	if mode == "" {
+		return fmt.Errorf("sandbox: mode name must not be empty")
+	}
+	if f == nil {
+		return fmt.Errorf("sandbox: factory for mode %q must not be nil", mode)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[mode] = f
+	return nil
+}
+
+// Lookup returns the factory registered under mode, or an error
+// describing the available modes when the name is unknown.
+func (r *Registry) Lookup(mode string) (Factory, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	f, ok := r.factories[mode]
+	if !ok {
+		return nil, fmt.Errorf("sandbox: no factory registered for mode %q (known modes: %v)",
+			mode, r.knownModesLocked())
+	}
+	return f, nil
+}
+
+// knownModesLocked returns the registered mode names, sorted by insertion.
+// Caller must hold r.mu.
+func (r *Registry) knownModesLocked() []string {
+	names := make([]string, 0, len(r.factories))
+	for k := range r.factories {
+		names = append(names, k)
+	}
+	return names
+}
+
+// RegisterFactory registers f against the given mode in the process-wide
+// registry. Typically called from an init function by consumers bringing
+// their own sandbox implementations.
+func RegisterFactory(mode string, f Factory) error {
+	return globalRegistry.Register(mode, f)
+}
+
+// ReplaceFactory is the process-wide equivalent of Registry.Replace.
+func ReplaceFactory(mode string, f Factory) error {
+	return globalRegistry.Replace(mode, f)
+}
+
+// LookupFactory returns the factory registered against mode in the
+// process-wide registry.
+func LookupFactory(mode string) (Factory, error) {
+	return globalRegistry.Lookup(mode)
+}
+
+// GlobalRegistry returns the process-wide registry, primarily for
+// package tests and the SDK option that seeds per-conversation overrides.
+func GlobalRegistry() *Registry { return globalRegistry }

--- a/runtime/hooks/sandbox/registry_test.go
+++ b/runtime/hooks/sandbox/registry_test.go
@@ -1,0 +1,124 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type stubSandbox struct{ name string }
+
+func (s *stubSandbox) Name() string { return s.name }
+func (s *stubSandbox) Spawn(_ context.Context, _ Request) (Response, error) {
+	return Response{}, nil
+}
+
+func TestRegistry_RegisterAndLookup(t *testing.T) {
+	r := NewRegistry()
+	factory := func(name string, _ map[string]any) (Sandbox, error) {
+		return &stubSandbox{name: name}, nil
+	}
+	if err := r.Register("stub", factory); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	got, err := r.Lookup("stub")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	sb, err := got("my_stub", nil)
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if sb.Name() != "my_stub" {
+		t.Errorf("Name = %q, want %q", sb.Name(), "my_stub")
+	}
+}
+
+func TestRegistry_DuplicateRegisterErrors(t *testing.T) {
+	r := NewRegistry()
+	f := func(_ string, _ map[string]any) (Sandbox, error) { return nil, nil }
+	if err := r.Register("once", f); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	err := r.Register("once", f)
+	if err == nil {
+		t.Fatal("second Register should fail")
+	}
+	if !strings.Contains(err.Error(), "already registered") {
+		t.Errorf("expected duplicate-registration error, got: %v", err)
+	}
+}
+
+func TestRegistry_ReplaceOverwritesSilently(t *testing.T) {
+	r := NewRegistry()
+	one := func(_ string, _ map[string]any) (Sandbox, error) { return &stubSandbox{name: "one"}, nil }
+	two := func(_ string, _ map[string]any) (Sandbox, error) { return &stubSandbox{name: "two"}, nil }
+	_ = r.Register("mode", one)
+	if err := r.Replace("mode", two); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	f, err := r.Lookup("mode")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	sb, _ := f("", nil)
+	if sb.Name() != "two" {
+		t.Errorf("Replace should have overwritten, got name=%q", sb.Name())
+	}
+}
+
+func TestRegistry_RejectsEmptyName(t *testing.T) {
+	r := NewRegistry()
+	f := func(_ string, _ map[string]any) (Sandbox, error) { return nil, nil }
+	if err := r.Register("", f); err == nil {
+		t.Error("Register with empty name should fail")
+	}
+	if err := r.Replace("", f); err == nil {
+		t.Error("Replace with empty name should fail")
+	}
+}
+
+func TestRegistry_RejectsNilFactory(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register("nil_fact", nil); err == nil {
+		t.Error("Register with nil factory should fail")
+	}
+	if err := r.Replace("nil_fact", nil); err == nil {
+		t.Error("Replace with nil factory should fail")
+	}
+}
+
+func TestRegistry_LookupUnknownListsKnownModes(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register("alpha", func(_ string, _ map[string]any) (Sandbox, error) { return nil, nil })
+	_ = r.Register("beta", func(_ string, _ map[string]any) (Sandbox, error) { return nil, nil })
+
+	_, err := r.Lookup("missing")
+	if err == nil {
+		t.Fatal("Lookup of unknown mode should fail")
+	}
+	if !strings.Contains(err.Error(), "missing") ||
+		!strings.Contains(err.Error(), "alpha") ||
+		!strings.Contains(err.Error(), "beta") {
+		t.Errorf("error should mention requested and known modes, got: %v", err)
+	}
+}
+
+// TestRegistry_FactoryError is a sanity check that errors from the
+// factory function itself propagate cleanly to the caller.
+func TestRegistry_FactoryError(t *testing.T) {
+	r := NewRegistry()
+	sentinel := errors.New("boom")
+	_ = r.Register("bad", func(_ string, _ map[string]any) (Sandbox, error) {
+		return nil, sentinel
+	})
+	f, err := r.Lookup("bad")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if _, err := f("x", nil); !errors.Is(err, sentinel) {
+		t.Errorf("factory error should propagate, got %v", err)
+	}
+}

--- a/runtime/hooks/sandbox/sandbox.go
+++ b/runtime/hooks/sandbox/sandbox.go
@@ -1,0 +1,104 @@
+// Package sandbox defines the Sandbox interface used by exec-backed hooks
+// to externalize where and how the hook subprocess is spawned.
+//
+// An exec hook's wire protocol with its subprocess is stdin-in-JSON →
+// stdout-out-JSON. A Sandbox is the pluggable mechanism that gets those
+// bytes into the right process and back out. Implementations can run the
+// command locally (the default "direct" backend), inside a container, in
+// a remote sidecar via "kubectl exec", against a cloud sandbox API, or
+// anywhere else — the subprocess itself never knows or cares.
+//
+// Two ways to wire a sandbox to an exec hook:
+//
+//  1. Programmatic: construct a Sandbox yourself and set it on an
+//     ExecHookConfig.Sandbox before passing the config to NewExec*Hook.
+//     The caller owns the sandbox's lifetime.
+//
+//  2. Declarative: register a Factory against a mode name via
+//     RegisterFactory (package-init) or sdk.WithSandboxFactory (per
+//     conversation). A RuntimeConfig YAML can then refer to the sandbox
+//     by name under spec.sandboxes, and individual hook entries can
+//     select one with the "sandbox:" field.
+//
+// The Sandbox interface is intentionally narrow: request/response only,
+// stdin/stdout bytes only, no streaming. That matches the existing
+// exec-hook protocol exactly and keeps backend implementations small.
+package sandbox
+
+import (
+	"context"
+	"time"
+)
+
+// Sandbox launches an exec-hook subprocess and returns its output.
+// Implementations must enforce req.Timeout; exceeding it returns a
+// non-nil Response.Err describing the timeout. Implementations must not
+// retain req.Stdin beyond the call.
+type Sandbox interface {
+	// Name returns a stable identifier used in logs and observability
+	// events. Typically matches the mode name or the registered sandbox
+	// name from RuntimeConfig.
+	Name() string
+
+	// Spawn runs the given command, pipes Stdin to its stdin, collects
+	// stdout and stderr, and returns when the process exits, the timeout
+	// expires, or the transport fails. A non-zero exit code, a timeout,
+	// or a transport error all surface as a non-nil Response.Err —
+	// implementations should include enough detail for callers to
+	// distinguish those cases (e.g. by wrapping a context.DeadlineExceeded).
+	Spawn(ctx context.Context, req Request) (Response, error)
+}
+
+// Request describes a single hook-subprocess invocation.
+type Request struct {
+	// Command is the program to execute. Sandboxes that spawn locally
+	// (direct) treat this as a file path; sandboxes that run the command
+	// somewhere else (kubectl exec, docker exec) typically pass it
+	// verbatim to the remote runner.
+	Command string
+
+	// Args are positional arguments passed to Command.
+	Args []string
+
+	// Env contains additional environment entries in "KEY=value" form to
+	// be merged on top of whatever the sandbox considers baseline. The
+	// caller is responsible for resolving any host-side lookups (e.g.
+	// os.LookupEnv) before populating this slice.
+	Env []string
+
+	// Stdin is the bytes piped to the subprocess's stdin. Typically the
+	// exec-hook JSON payload. The sandbox does not retain this slice.
+	Stdin []byte
+
+	// Timeout bounds the invocation. Zero means the sandbox's own
+	// default; negative is treated as zero.
+	Timeout time.Duration
+}
+
+// Response is the outcome of a single Spawn call.
+type Response struct {
+	// Stdout is the bytes read from the subprocess's stdout.
+	Stdout []byte
+	// Stderr is the bytes read from the subprocess's stderr. Empty when
+	// the sandbox cannot separately capture stderr (e.g. a remote
+	// transport that conflates the streams); in that case stderr content
+	// should be appended to Stdout or included in Err instead.
+	Stderr []byte
+	// Err is non-nil when the process exited non-zero, the timeout
+	// expired, or the transport failed. Callers distinguish these cases
+	// with errors.Is against standard sentinels (context.DeadlineExceeded,
+	// exec.ExitError) where applicable.
+	Err error
+}
+
+// Closer is an optional interface implemented by sandboxes that hold
+// long-lived resources such as an HTTP client, a gRPC connection, or a
+// pooled kubectl client. The hook registry calls Close on teardown.
+type Closer interface {
+	Close() error
+}
+
+// Factory builds a Sandbox from a mode-specific configuration block.
+// Factories are registered under a mode name via RegisterFactory; the
+// RuntimeConfig YAML refers to them by that name.
+type Factory func(name string, cfg map[string]any) (Sandbox, error)

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	"github.com/AltairaLabs/PromptKit/runtime/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/metrics"
@@ -1136,6 +1137,34 @@ func WithProviderHook(h hooks.ProviderHook) Option {
 	return func(c *config) error {
 		c.providerHooks = append(c.providerHooks, h)
 		return nil
+	}
+}
+
+// WithSandboxFactory registers a sandbox factory for the given mode name.
+// The factory is added to the process-wide sandbox registry, where it
+// becomes available for RuntimeConfig-based hook configuration (the
+// spec.sandboxes block looks factories up by their mode name).
+//
+// Use this when a deployment uses a declarative RuntimeConfig and the
+// sandbox backend is implemented outside PromptKit core — for example a
+// k8s sidecar, a docker wrapper, or a bespoke cloud-sandbox adapter.
+// Construct your factory in the consumer's package and wire it up at
+// SDK open time:
+//
+//	conv, _ := sdk.Open("./pack.json", "chat",
+//	    sdk.WithSandboxFactory("k8s_sidecar", k8ssidecar.Factory),
+//	)
+//
+// Callers who don't use RuntimeConfig can instead construct a Sandbox
+// directly and set it on ExecHookConfig.Sandbox before passing to
+// NewExec*Hook — that path doesn't touch any registry.
+//
+// Duplicate registration for a given mode returns an error (as with
+// sandbox.RegisterFactory). If a deployment legitimately needs to
+// overwrite an existing factory, use sandbox.ReplaceFactory directly.
+func WithSandboxFactory(mode string, factory sandbox.Factory) Option {
+	return func(_ *config) error {
+		return sandbox.RegisterFactory(mode, factory)
 	}
 }
 


### PR DESCRIPTION
## Summary

M1 of the [exec-hook sandbox proposal](../blob/main/docs/local-backlog/EXEC_HOOK_SANDBOX_PROPOSAL.md) — introduces a narrow extension point for externalizing where and how exec-backed hooks launch their subprocess, without changing the stdin/stdout JSON contract the subprocess sees.

## What ships

**Core (zero behavior change for existing users):**
- \`runtime/hooks/sandbox\`: \`Sandbox\` interface, optional \`Closer\`, \`Factory\` type, \`Registry\` with process-wide convenience functions.
- \`runtime/hooks/sandbox/direct\`: built-in default backend. Self-registers as mode \`direct\` at package init.
- \`ExecHookConfig.Sandbox\` and \`ExecEvalHookConfig.Sandbox\` fields — nil falls back to \`direct.New()\`.
- The four \`Exec*Hook\` types now route all subprocess invocations through the Sandbox; env merging, WaitDelay, and timeout enforcement now live once in the direct backend.
- \`sdk.WithSandboxFactory\` for registering custom backends.

**Two first-class configuration paths:**
1. **Programmatic** — construct any \`Sandbox\` impl yourself, set it on \`ExecHookConfig.Sandbox\`, pass via \`sdk.WithProviderHook\`. No registry needed.
2. **Declarative** (follow-up PR) — RuntimeConfig YAML will gain \`spec.sandboxes\` and per-hook \`sandbox:\` field, resolved through the factory registry.

## Explicitly not in this PR

- \`docker_run\` / \`docker_exec\` / \`kubectl_exec\` backends (M2 — reference impls in \`sdk/examples/sandboxes/\`).
- RuntimeConfig YAML binding + schema regen (M2 follow-up).
- Docs / how-to pages (M3).

See \`docs/local-backlog/EXEC_HOOK_SANDBOX_PROPOSAL.md\` for full design.

## Test plan

- [x] \`go test ./runtime/... -count=1 -race\` — all green
- [x] \`go test ./sdk/... -count=1 -race\` — all green
- [x] \`golangci-lint run --new-from-rev=main\` — 0 issues
- [x] Coverage on changed files ≥ 80% (direct: 97.1%, exec_hooks.go: 90.8%, exec_hook.go: 88.9%, registry.go: 87.9%, options.go: 80.2%)