### PR TITLE
feat(hooks): sandbox backend examples — docker_run, docker_exec, kubectl_exec (M2)

### DIFF
--- a/sdk/examples/sandboxes/README.md
+++ b/sdk/examples/sandboxes/README.md
@@ -1,0 +1,88 @@
+# Exec Hook Sandboxes — Examples
+
+Reference implementations of [`sandbox.Sandbox`](../../../runtime/hooks/sandbox/sandbox.go) that route exec-hook subprocess invocations through something other than `exec.CommandContext`. These are **example code** — not imported by PromptKit core. Copy and adapt, or import them directly; both are fine.
+
+| Package | Mode | Use when |
+|---|---|---|
+| [`dockerrun/`](dockerrun/) | `docker_run` | Each hook call should run in a fresh disposable container. |
+| [`dockerexec/`](dockerexec/) | `docker_exec` | A long-lived sidecar container has the hook runtime baked in. |
+| [`kubectlexec/`](kubectlexec/) | `kubectl_exec` | Same as `dockerexec`, but the sidecar lives in a Kubernetes pod. |
+
+## The stdin/stdout protocol is unchanged
+
+All three backends preserve the existing exec-hook wire protocol: PromptKit writes a JSON request to the subprocess's stdin, the subprocess writes a JSON response to stdout. The backends just change *how* bytes get to that subprocess — `docker run` spawns a fresh container and pipes through it, `docker exec` pipes into an existing container, `kubectl exec` does the same across the k8s API. Your hook scripts don't know or care which backend is active.
+
+## Two ways to wire one in
+
+### 1. Programmatic — construct directly, no registry
+
+```go
+import (
+    "github.com/AltairaLabs/PromptKit/runtime/hooks"
+    "github.com/AltairaLabs/PromptKit/sdk/examples/sandboxes/dockerrun"
+)
+
+sb := dockerrun.New(dockerrun.Config{
+    Image:   "python:3.12-slim",
+    Network: "none",
+    Mounts:  []string{"./hooks:/hooks:ro"},
+})
+
+hook := hooks.NewExecProviderHook(&hooks.ExecHookConfig{
+    Name:    "pii_redactor",
+    Command: "/hooks/pii.py",
+    Phases:  []string{"before_call"},
+    Mode:    "filter",
+    Sandbox: sb, // <-- the sandbox is injected here
+})
+```
+
+### 2. Declarative — register a factory for RuntimeConfig-driven deployments
+
+```go
+import (
+    "github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+    "github.com/AltairaLabs/PromptKit/sdk/examples/sandboxes/kubectlexec"
+)
+
+func init() {
+    _ = sandbox.RegisterFactory(kubectlexec.ModeName, kubectlexec.Factory)
+}
+```
+
+Or via an SDK option (no `init` side effects):
+
+```go
+conv, _ := sdk.Open("./pack.json", "chat",
+    sdk.WithSandboxFactory(kubectlexec.ModeName, kubectlexec.Factory),
+)
+```
+
+Then reference the mode in RuntimeConfig YAML *(binding coming in a follow-up PR)*:
+
+```yaml
+spec:
+  sandboxes:
+    hooks_sidecar:
+      mode: kubectl_exec
+      pod: my-agent-pod
+      namespace: default
+      container: hooks
+  hooks:
+    pii_redactor:
+      command: /hooks/pii.py
+      hook: provider
+      phases: [before_call]
+      mode: filter
+      sandbox: hooks_sidecar
+```
+
+## Writing your own backend
+
+The pattern each example uses is the same:
+
+1. Implement `sandbox.Sandbox` (`Name()`, `Spawn(ctx, req) (Response, error)`).
+2. Internally, rewrite `req.Command`/`req.Args` to the argv you actually want to run (`docker run ...`, `kubectl exec ...`, or whatever your backend needs).
+3. Delegate to a `*direct.Sandbox` for the actual subprocess management — stdin piping, timeout enforcement, WaitDelay, env merging are all handled there.
+
+For bespoke backends that aren't just "different argv around `exec`" — cloud sandbox APIs, gRPC to a hook service, whatever — implement `Spawn` however you need. The only invariants are: (a) `req.Stdin` reaches the remote process's stdin, (b) its stdout is returned as `Response.Stdout`, (c) non-zero exit, timeout, or transport failure populates `Response.Err`.

--- a/sdk/examples/sandboxes/dockerexec/dockerexec.go
+++ b/sdk/examples/sandboxes/dockerexec/dockerexec.go
@@ -1,0 +1,153 @@
+// Package dockerexec is an example sandbox implementation that runs
+// each exec-hook invocation inside an already-running container via
+// `docker exec -i`. This is the cheap sibling of dockerrun: no
+// per-call container startup cost, just a docker exec that pipes
+// stdin/stdout through.
+//
+// Typical use case: a long-lived sidecar container in the same Compose
+// stack that has the hook scripts and their runtime dependencies baked
+// in. A nearby example: `kubectlexec` for the Kubernetes equivalent.
+//
+// This is reference/example code — not imported by PromptKit core.
+// Register via sdk.WithSandboxFactory or sandbox.RegisterFactory, or
+// construct one directly and set it on ExecHookConfig.Sandbox.
+//
+// Configuration:
+//
+//	mode: docker_exec
+//	container: my-hooks-sidecar    # required
+//	workdir: /app                  # optional; maps to --workdir
+//	user: hookuser                 # optional; maps to --user
+//	extra_args: [--tty]            # optional
+package dockerexec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox/direct"
+)
+
+// ModeName is the identifier under which this backend registers with
+// sandbox.RegisterFactory.
+const ModeName = "docker_exec"
+
+// Config configures the docker-exec backend.
+type Config struct {
+	// Container is the name or ID of the running container to exec into.
+	// Required.
+	Container string
+	// Workdir maps to `docker exec --workdir=<value>`. Empty means don't
+	// pass the flag.
+	Workdir string
+	// User maps to `docker exec --user=<value>`. Empty means don't pass
+	// the flag.
+	User string
+	// ExtraArgs are extra `docker exec` flags inserted after the
+	// standard ones and before the container name.
+	ExtraArgs []string
+	// DockerPath overrides the `docker` binary name. Empty uses `docker`
+	// resolved from PATH.
+	DockerPath string
+}
+
+// Sandbox runs exec-hook commands via `docker exec` in an existing
+// container.
+type Sandbox struct {
+	name  string
+	cfg   Config
+	inner *direct.Sandbox
+}
+
+// New constructs a Sandbox from a Config.
+func New(cfg Config) *Sandbox {
+	return NewNamed(ModeName, cfg)
+}
+
+// NewNamed is like New but lets the caller override the sandbox name.
+func NewNamed(name string, cfg Config) *Sandbox {
+	return &Sandbox{
+		name:  name,
+		cfg:   cfg,
+		inner: direct.New(name),
+	}
+}
+
+// Factory is a sandbox.Factory compatible with RuntimeConfig-based
+// resolution.
+func Factory(name string, cfg map[string]any) (sandbox.Sandbox, error) {
+	container, _ := cfg["container"].(string)
+	if container == "" {
+		return nil, fmt.Errorf("dockerexec: required config field 'container' is missing or not a string")
+	}
+	return NewNamed(name, Config{
+		Container:  container,
+		Workdir:    stringOr(cfg, "workdir"),
+		User:       stringOr(cfg, "user"),
+		ExtraArgs:  stringSlice(cfg, "extra_args"),
+		DockerPath: stringOr(cfg, "docker_path"),
+	}), nil
+}
+
+// Name returns the sandbox's name.
+func (s *Sandbox) Name() string { return s.name }
+
+// Spawn builds a `docker exec -i [flags] <container> <cmd> <args...>`
+// argv and delegates to the inner direct sandbox.
+func (s *Sandbox) Spawn(ctx context.Context, req sandbox.Request) (sandbox.Response, error) {
+	dockerArgs := s.buildArgs(req.Command, req.Args)
+	cmd := s.cfg.DockerPath
+	if cmd == "" {
+		cmd = "docker"
+	}
+	return s.inner.Spawn(ctx, sandbox.Request{
+		Command: cmd,
+		Args:    dockerArgs,
+		Env:     req.Env,
+		Stdin:   req.Stdin,
+		Timeout: req.Timeout,
+	})
+}
+
+// buildArgs assembles the argv passed to `docker`. Exposed for tests.
+func (s *Sandbox) buildArgs(command string, args []string) []string {
+	out := make([]string, 0, 4+len(s.cfg.ExtraArgs)+len(args))
+	out = append(out, "exec", "-i")
+	if s.cfg.Workdir != "" {
+		out = append(out, "--workdir="+s.cfg.Workdir)
+	}
+	if s.cfg.User != "" {
+		out = append(out, "--user="+s.cfg.User)
+	}
+	out = append(out, s.cfg.ExtraArgs...)
+	out = append(out, s.cfg.Container)
+	out = append(out, command)
+	out = append(out, args...)
+	return out
+}
+
+func stringOr(cfg map[string]any, key string) string {
+	s, _ := cfg[key].(string)
+	return s
+}
+
+func stringSlice(cfg map[string]any, key string) []string {
+	v, ok := cfg[key]
+	if !ok {
+		return nil
+	}
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/sdk/examples/sandboxes/dockerexec/dockerexec_test.go
+++ b/sdk/examples/sandboxes/dockerexec/dockerexec_test.go
@@ -1,0 +1,88 @@
+package dockerexec
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildArgs_MinimalConfig(t *testing.T) {
+	sb := New(Config{Container: "my-sidecar"})
+	got := sb.buildArgs("/hooks/pii.py", []string{"--strict"})
+	want := []string{
+		"exec", "-i",
+		"my-sidecar",
+		"/hooks/pii.py", "--strict",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs = %v, want %v", got, want)
+	}
+}
+
+func TestBuildArgs_WithWorkdirAndUser(t *testing.T) {
+	sb := New(Config{
+		Container: "my-sidecar",
+		Workdir:   "/app",
+		User:      "hookuser",
+	})
+	got := sb.buildArgs("cmd", nil)
+	want := []string{
+		"exec", "-i",
+		"--workdir=/app",
+		"--user=hookuser",
+		"my-sidecar", "cmd",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestBuildArgs_ExtraArgs(t *testing.T) {
+	sb := New(Config{
+		Container: "c",
+		ExtraArgs: []string{"--env=FOO=bar"},
+	})
+	got := sb.buildArgs("cmd", []string{"arg"})
+	want := []string{
+		"exec", "-i",
+		"--env=FOO=bar",
+		"c", "cmd", "arg",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestFactory_RequiresContainer(t *testing.T) {
+	if _, err := Factory("m", nil); err == nil {
+		t.Fatal("Factory with no container should error")
+	}
+	if _, err := Factory("m", map[string]any{"workdir": "/app"}); err == nil {
+		t.Fatal("Factory with only workdir should error")
+	}
+}
+
+func TestFactory_ParsesConfig(t *testing.T) {
+	sb, err := Factory("my_sidecar", map[string]any{
+		"container":  "my-sidecar",
+		"workdir":    "/app",
+		"user":       "hookuser",
+		"extra_args": []any{"--env=FOO=bar"},
+	})
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+	if sb.Name() != "my_sidecar" {
+		t.Errorf("Name = %q", sb.Name())
+	}
+	got := sb.(*Sandbox).buildArgs("cmd", nil)
+	want := []string{
+		"exec", "-i",
+		"--workdir=/app",
+		"--user=hookuser",
+		"--env=FOO=bar",
+		"my-sidecar", "cmd",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs mismatch\n got: %v\nwant: %v", got, want)
+	}
+}

--- a/sdk/examples/sandboxes/dockerrun/dockerrun.go
+++ b/sdk/examples/sandboxes/dockerrun/dockerrun.go
@@ -1,0 +1,181 @@
+// Package dockerrun is an example sandbox implementation that runs each
+// exec-hook invocation in a fresh disposable container via `docker run
+// --rm -i`. The hook subprocess still sees the standard stdin/stdout
+// JSON protocol; only the spawn mechanism changes.
+//
+// This is reference/example code — not imported by PromptKit core.
+// Copy, adapt, or import the package directly; either path is fine.
+// Register the factory in your own init or via sdk.WithSandboxFactory:
+//
+//	import (
+//	    "github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+//	    "github.com/AltairaLabs/PromptKit/sdk/examples/sandboxes/dockerrun"
+//	)
+//
+//	func init() {
+//	    _ = sandbox.RegisterFactory(dockerrun.ModeName, dockerrun.Factory)
+//	}
+//
+// Or programmatically, without the registry:
+//
+//	sb := dockerrun.New(dockerrun.Config{Image: "python:3.12-slim"})
+//	hook := hooks.NewExecProviderHook(&hooks.ExecHookConfig{
+//	    Command: "/hooks/pii.py",
+//	    Sandbox: sb,
+//	    ...
+//	})
+//
+// Configuration (via the Factory config map):
+//
+//	mode: docker_run
+//	image: python:3.12-slim       # required
+//	network: none                 # optional; maps to --network=<value>
+//	mounts:                       # optional; each value is passed as -v <spec>
+//	  - ./hooks:/hooks:ro
+//	extra_args:                   # optional; arbitrary extra docker flags
+//	  - --memory=256m
+//	  - --cpus=0.5
+package dockerrun
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox/direct"
+)
+
+// ModeName is the identifier under which this backend registers with
+// sandbox.RegisterFactory.
+const ModeName = "docker_run"
+
+// Config configures the docker-run backend.
+type Config struct {
+	// Image is the container image to run. Required.
+	Image string
+	// Network maps to `docker run --network=<value>`. Empty means
+	// don't pass the flag (docker default).
+	Network string
+	// Mounts are passed as `-v <spec>` for each entry. Example:
+	// "./hooks:/hooks:ro" bind-mounts the hooks directory read-only.
+	Mounts []string
+	// ExtraArgs are extra `docker run` arguments inserted after the
+	// standard flags and before the image. Use sparingly.
+	ExtraArgs []string
+	// DockerPath overrides the `docker` binary name. Empty uses `docker`
+	// resolved from PATH.
+	DockerPath string
+}
+
+// Sandbox runs exec-hook commands inside a fresh docker container per call.
+type Sandbox struct {
+	name  string
+	cfg   Config
+	inner *direct.Sandbox
+}
+
+// New constructs a Sandbox from a Config. The inner direct backend
+// handles the actual subprocess spawning, timeout, and stdin piping; we
+// just rewrite argv to prepend `docker run`.
+func New(cfg Config) *Sandbox {
+	return NewNamed(ModeName, cfg)
+}
+
+// NewNamed is like New but lets the caller override the sandbox name
+// (useful when multiple docker-run sandboxes are registered under
+// different names in RuntimeConfig).
+func NewNamed(name string, cfg Config) *Sandbox {
+	return &Sandbox{
+		name:  name,
+		cfg:   cfg,
+		inner: direct.New(name),
+	}
+}
+
+// Factory is a sandbox.Factory compatible with RuntimeConfig-based
+// resolution. It reads the config map, validates required fields, and
+// returns a ready Sandbox.
+func Factory(name string, cfg map[string]any) (sandbox.Sandbox, error) {
+	image, _ := cfg["image"].(string)
+	if image == "" {
+		return nil, fmt.Errorf("dockerrun: required config field 'image' is missing or not a string")
+	}
+	out := Config{
+		Image:      image,
+		Network:    stringOr(cfg, "network"),
+		Mounts:     stringSlice(cfg, "mounts"),
+		ExtraArgs:  stringSlice(cfg, "extra_args"),
+		DockerPath: stringOr(cfg, "docker_path"),
+	}
+	return NewNamed(name, out), nil
+}
+
+// Name returns the sandbox's name.
+func (s *Sandbox) Name() string { return s.name }
+
+// Spawn builds a `docker run --rm -i [flags] <image> <cmd> <args...>`
+// argv and delegates to the inner direct sandbox, which handles stdin
+// piping, timeout, and stdout/stderr collection. The hook subprocess
+// inside the container receives req.Stdin on its stdin exactly as it
+// would with the direct backend.
+func (s *Sandbox) Spawn(ctx context.Context, req sandbox.Request) (sandbox.Response, error) {
+	dockerArgs := s.buildArgs(req.Command, req.Args)
+	cmd := s.cfg.DockerPath
+	if cmd == "" {
+		cmd = "docker"
+	}
+	return s.inner.Spawn(ctx, sandbox.Request{
+		Command: cmd,
+		Args:    dockerArgs,
+		Env:     req.Env,
+		Stdin:   req.Stdin,
+		Timeout: req.Timeout,
+	})
+}
+
+// buildArgs assembles the argv passed to `docker`. Exposed in-package
+// for unit tests.
+func (s *Sandbox) buildArgs(command string, args []string) []string {
+	out := make([]string, 0, 8+len(s.cfg.Mounts)*2+len(s.cfg.ExtraArgs)+len(args))
+	out = append(out, "run", "--rm", "-i")
+	if s.cfg.Network != "" {
+		out = append(out, "--network="+s.cfg.Network)
+	}
+	for _, m := range s.cfg.Mounts {
+		out = append(out, "-v", m)
+	}
+	out = append(out, s.cfg.ExtraArgs...)
+	out = append(out, s.cfg.Image)
+	out = append(out, command)
+	out = append(out, args...)
+	return out
+}
+
+// stringOr returns cfg[key] as a string or "" if missing or wrong type.
+func stringOr(cfg map[string]any, key string) string {
+	s, _ := cfg[key].(string)
+	return s
+}
+
+// stringSlice returns cfg[key] as []string or nil. Accepts either a
+// []string (Go direct construction) or a []any of strings (YAML
+// unmarshal).
+func stringSlice(cfg map[string]any, key string) []string {
+	v, ok := cfg[key]
+	if !ok {
+		return nil
+	}
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/sdk/examples/sandboxes/dockerrun/dockerrun_test.go
+++ b/sdk/examples/sandboxes/dockerrun/dockerrun_test.go
@@ -1,0 +1,103 @@
+package dockerrun
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildArgs_MinimalConfig(t *testing.T) {
+	sb := New(Config{Image: "python:3.12-slim"})
+	got := sb.buildArgs("/hooks/pii.py", []string{"--strict"})
+	want := []string{
+		"run", "--rm", "-i",
+		"python:3.12-slim",
+		"/hooks/pii.py", "--strict",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs = %v, want %v", got, want)
+	}
+}
+
+func TestBuildArgs_WithNetworkAndMounts(t *testing.T) {
+	sb := New(Config{
+		Image:   "python:3.12-slim",
+		Network: "none",
+		Mounts:  []string{"./hooks:/hooks:ro", "./scratch:/scratch"},
+	})
+	got := sb.buildArgs("python", []string{"-m", "pii"})
+	want := []string{
+		"run", "--rm", "-i",
+		"--network=none",
+		"-v", "./hooks:/hooks:ro",
+		"-v", "./scratch:/scratch",
+		"python:3.12-slim",
+		"python", "-m", "pii",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestBuildArgs_WithExtraArgs(t *testing.T) {
+	sb := New(Config{
+		Image:     "python:3.12-slim",
+		ExtraArgs: []string{"--memory=256m", "--cpus=0.5"},
+	})
+	got := sb.buildArgs("cmd", nil)
+	want := []string{
+		"run", "--rm", "-i",
+		"--memory=256m", "--cpus=0.5",
+		"python:3.12-slim", "cmd",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs = %v, want %v", got, want)
+	}
+}
+
+func TestFactory_RequiresImage(t *testing.T) {
+	_, err := Factory("m", nil)
+	if err == nil {
+		t.Fatal("Factory with no image should error")
+	}
+	_, err = Factory("m", map[string]any{"network": "none"})
+	if err == nil {
+		t.Fatal("Factory with no image should error even with other fields set")
+	}
+}
+
+func TestFactory_ParsesConfig(t *testing.T) {
+	sb, err := Factory("my_docker", map[string]any{
+		"image":       "python:3.12-slim",
+		"network":     "none",
+		"mounts":      []any{"./a:/a", "./b:/b:ro"},
+		"extra_args":  []string{"--memory=256m"},
+		"docker_path": "/usr/local/bin/docker",
+	})
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+	if sb.Name() != "my_docker" {
+		t.Errorf("Name = %q, want %q", sb.Name(), "my_docker")
+	}
+	got := sb.(*Sandbox).buildArgs("cmd", nil)
+	want := []string{
+		"run", "--rm", "-i",
+		"--network=none",
+		"-v", "./a:/a",
+		"-v", "./b:/b:ro",
+		"--memory=256m",
+		"python:3.12-slim", "cmd",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestName_Defaults(t *testing.T) {
+	if got := New(Config{Image: "x"}).Name(); got != ModeName {
+		t.Errorf("Name() = %q, want %q", got, ModeName)
+	}
+	if got := NewNamed("custom", Config{Image: "x"}).Name(); got != "custom" {
+		t.Errorf("Name() = %q, want %q", got, "custom")
+	}
+}

--- a/sdk/examples/sandboxes/kubectlexec/kubectlexec.go
+++ b/sdk/examples/sandboxes/kubectlexec/kubectlexec.go
@@ -1,0 +1,165 @@
+// Package kubectlexec is an example sandbox implementation that runs
+// each exec-hook invocation inside a sidecar container in an existing
+// Kubernetes pod via `kubectl exec -i -- <cmd>`. The pattern fits
+// deployments where PromptKit runs in-cluster with a long-lived
+// hooks sidecar that has the hook runtime (Python, Node, etc.) and
+// scripts baked in.
+//
+// This is reference/example code — not imported by PromptKit core.
+// Register via sdk.WithSandboxFactory or sandbox.RegisterFactory, or
+// construct one directly and set it on ExecHookConfig.Sandbox.
+//
+// Configuration:
+//
+//	mode: kubectl_exec
+//	pod: my-agent-pod              # required
+//	namespace: default             # optional; maps to -n
+//	container: hooks               # optional; maps to -c
+//	kubeconfig: /etc/kube.yaml     # optional; maps to --kubeconfig
+//	context: prod                  # optional; maps to --context
+//	extra_args: [--request-timeout=5s]
+package kubectlexec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox/direct"
+)
+
+// ModeName is the identifier under which this backend registers with
+// sandbox.RegisterFactory.
+const ModeName = "kubectl_exec"
+
+// Config configures the kubectl-exec backend.
+type Config struct {
+	// Pod is the target pod. Required.
+	Pod string
+	// Namespace maps to `-n <value>`. Empty means don't pass the flag
+	// (kubectl falls back to the current-context default).
+	Namespace string
+	// Container maps to `-c <value>`. Empty means don't pass the flag.
+	Container string
+	// Kubeconfig maps to `--kubeconfig=<value>`.
+	Kubeconfig string
+	// Context maps to `--context=<value>`.
+	Context string
+	// ExtraArgs are extra `kubectl exec` flags inserted after the
+	// standard ones and before the `--` command separator.
+	ExtraArgs []string
+	// KubectlPath overrides the `kubectl` binary name. Empty uses
+	// `kubectl` resolved from PATH.
+	KubectlPath string
+}
+
+// Sandbox runs exec-hook commands via `kubectl exec` in an existing pod.
+type Sandbox struct {
+	name  string
+	cfg   Config
+	inner *direct.Sandbox
+}
+
+// New constructs a Sandbox from a Config.
+func New(cfg Config) *Sandbox {
+	return NewNamed(ModeName, cfg)
+}
+
+// NewNamed is like New but lets the caller override the sandbox name.
+func NewNamed(name string, cfg Config) *Sandbox {
+	return &Sandbox{
+		name:  name,
+		cfg:   cfg,
+		inner: direct.New(name),
+	}
+}
+
+// Factory is a sandbox.Factory compatible with RuntimeConfig-based
+// resolution.
+func Factory(name string, cfg map[string]any) (sandbox.Sandbox, error) {
+	pod, _ := cfg["pod"].(string)
+	if pod == "" {
+		return nil, fmt.Errorf("kubectlexec: required config field 'pod' is missing or not a string")
+	}
+	return NewNamed(name, Config{
+		Pod:         pod,
+		Namespace:   stringOr(cfg, "namespace"),
+		Container:   stringOr(cfg, "container"),
+		Kubeconfig:  stringOr(cfg, "kubeconfig"),
+		Context:     stringOr(cfg, "context"),
+		ExtraArgs:   stringSlice(cfg, "extra_args"),
+		KubectlPath: stringOr(cfg, "kubectl_path"),
+	}), nil
+}
+
+// Name returns the sandbox's name.
+func (s *Sandbox) Name() string { return s.name }
+
+// Spawn builds a kubectl exec argv and delegates to the inner direct
+// sandbox. Layout:
+//
+//	kubectl [--kubeconfig=...] [--context=...] exec -i \
+//	        [-n <ns>] [-c <container>] <extra...> <pod> -- <cmd> <args...>
+func (s *Sandbox) Spawn(ctx context.Context, req sandbox.Request) (sandbox.Response, error) {
+	kubectlArgs := s.buildArgs(req.Command, req.Args)
+	cmd := s.cfg.KubectlPath
+	if cmd == "" {
+		cmd = "kubectl"
+	}
+	return s.inner.Spawn(ctx, sandbox.Request{
+		Command: cmd,
+		Args:    kubectlArgs,
+		Env:     req.Env,
+		Stdin:   req.Stdin,
+		Timeout: req.Timeout,
+	})
+}
+
+// buildArgs assembles the argv passed to `kubectl`. Exposed for tests.
+func (s *Sandbox) buildArgs(command string, args []string) []string {
+	out := make([]string, 0, 10+len(s.cfg.ExtraArgs)+len(args))
+	// Global flags go before the subcommand.
+	if s.cfg.Kubeconfig != "" {
+		out = append(out, "--kubeconfig="+s.cfg.Kubeconfig)
+	}
+	if s.cfg.Context != "" {
+		out = append(out, "--context="+s.cfg.Context)
+	}
+	out = append(out, "exec", "-i")
+	if s.cfg.Namespace != "" {
+		out = append(out, "-n", s.cfg.Namespace)
+	}
+	if s.cfg.Container != "" {
+		out = append(out, "-c", s.cfg.Container)
+	}
+	out = append(out, s.cfg.ExtraArgs...)
+	out = append(out, s.cfg.Pod, "--")
+	out = append(out, command)
+	out = append(out, args...)
+	return out
+}
+
+func stringOr(cfg map[string]any, key string) string {
+	s, _ := cfg[key].(string)
+	return s
+}
+
+func stringSlice(cfg map[string]any, key string) []string {
+	v, ok := cfg[key]
+	if !ok {
+		return nil
+	}
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/sdk/examples/sandboxes/kubectlexec/kubectlexec_test.go
+++ b/sdk/examples/sandboxes/kubectlexec/kubectlexec_test.go
@@ -1,0 +1,86 @@
+package kubectlexec
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildArgs_MinimalConfig(t *testing.T) {
+	sb := New(Config{Pod: "my-pod"})
+	got := sb.buildArgs("/hooks/pii.py", []string{"--strict"})
+	want := []string{
+		"exec", "-i",
+		"my-pod", "--",
+		"/hooks/pii.py", "--strict",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs = %v, want %v", got, want)
+	}
+}
+
+func TestBuildArgs_FullConfig(t *testing.T) {
+	sb := New(Config{
+		Pod:        "my-pod",
+		Namespace:  "default",
+		Container:  "hooks",
+		Kubeconfig: "/etc/kube.yaml",
+		Context:    "prod",
+		ExtraArgs:  []string{"--request-timeout=5s"},
+	})
+	got := sb.buildArgs("python", []string{"-m", "pii"})
+	want := []string{
+		"--kubeconfig=/etc/kube.yaml",
+		"--context=prod",
+		"exec", "-i",
+		"-n", "default",
+		"-c", "hooks",
+		"--request-timeout=5s",
+		"my-pod", "--",
+		"python", "-m", "pii",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestFactory_RequiresPod(t *testing.T) {
+	if _, err := Factory("m", nil); err == nil {
+		t.Fatal("Factory with no pod should error")
+	}
+	if _, err := Factory("m", map[string]any{"namespace": "default"}); err == nil {
+		t.Fatal("Factory with only namespace should error")
+	}
+}
+
+func TestFactory_ParsesConfig(t *testing.T) {
+	sb, err := Factory("my_sidecar", map[string]any{
+		"pod":        "my-pod",
+		"namespace":  "default",
+		"container":  "hooks",
+		"extra_args": []any{"--request-timeout=5s"},
+	})
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+	if sb.Name() != "my_sidecar" {
+		t.Errorf("Name = %q", sb.Name())
+	}
+	got := sb.(*Sandbox).buildArgs("cmd", nil)
+	want := []string{
+		"exec", "-i",
+		"-n", "default",
+		"-c", "hooks",
+		"--request-timeout=5s",
+		"my-pod", "--",
+		"cmd",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestName_Defaults(t *testing.T) {
+	if got := New(Config{Pod: "x"}).Name(); got != ModeName {
+		t.Errorf("Name() = %q, want %q", got, ModeName)
+	}
+}


### PR DESCRIPTION
## Summary

M2 of the [exec-hook sandbox proposal](../blob/main/docs/local-backlog/EXEC_HOOK_SANDBOX_PROPOSAL.md) — three reference backends under \`sdk/examples/sandboxes/\`. None are imported by PromptKit core; consumers import directly or copy-adapt.

| Package | Mode | Use when |
|---|---|---|
| \`dockerrun/\` | \`docker_run\` | Fresh disposable container per invocation. |
| \`dockerexec/\` | \`docker_exec\` | Long-lived sidecar container has the hook runtime baked in. |
| \`kubectlexec/\` | \`kubectl_exec\` | Same as dockerexec, across the k8s API. |

## Pattern

Each backend is ~40-50 LOC. It (a) validates required config, (b) rewrites \`Command\`/\`Args\` into the right argv, (c) delegates to \`direct.Sandbox.Spawn\` for all the actual subprocess management (stdin, timeout, WaitDelay, env merging, stdout/stderr collection). The stdin/stdout JSON wire protocol is unchanged — the hook subprocess doesn't know or care which backend is active.

## Two registration paths

- Programmatic: construct one with \`dockerrun.New(...)\` and drop it on \`ExecHookConfig.Sandbox\`. No registry needed.
- Factory: \`sandbox.RegisterFactory(dockerrun.ModeName, dockerrun.Factory)\` at init, or \`sdk.WithSandboxFactory(...)\` per conversation, for RuntimeConfig-driven deployments.

## Coming next (M3, follow-up PR)

- RuntimeConfig YAML binding (\`spec.sandboxes\` + per-hook \`sandbox:\` field).
- How-to page: *\"Run hooks in a k8s sidecar\"*.

## Test plan

- [x] \`go test ./sdk/examples/sandboxes/... -count=1 -race\` — all green
- [x] \`golangci-lint run --new-from-rev=main\` — 0 issues
- [x] Each backend: argv builder unit tests across knob combinations, factory required-field validation, YAML-style (\`[]any\`) + Go-style (\`[]string\`) config parsing