### PR TITLE
feat(hooks): RuntimeConfig YAML binding for sandbox backends (M3)

### DIFF
--- a/docs/src/content/docs/sdk/how-to/sandbox-hooks.md
+++ b/docs/src/content/docs/sdk/how-to/sandbox-hooks.md
@@ -1,0 +1,165 @@
+---
+title: Sandbox Exec Hooks
+description: Run exec hook subprocesses in a container, sidecar, or custom backend
+sidebar:
+  order: 18
+---
+
+Exec hooks spawn subprocesses on the host by default. When host-local execution isn't what you want -- e.g. you'd rather hit a long-lived Kubernetes hooks sidecar, start each call in a fresh Docker container, or route through a bespoke cloud-sandbox -- PromptKit lets you swap the spawn mechanism via the **Sandbox** interface without changing the hook's wire protocol.
+
+The hook subprocess still reads JSON on stdin and writes JSON on stdout. Only where it runs changes.
+
+---
+
+## Quick Start
+
+Sandboxes are declared under `spec.sandboxes` in `RuntimeConfig` and referenced from individual hooks by name:
+
+```yaml
+spec:
+  sandboxes:
+    pii_runner:
+      mode: docker_run
+      image: promptkit/pii-hook:1.2
+      network: none
+      mounts:
+        - ./hooks:/hooks:ro
+
+  hooks:
+    pii_redactor:
+      command: /hooks/pii.py
+      hook: provider
+      phases: [before_call]
+      mode: filter
+      sandbox: pii_runner
+```
+
+Each `mode` names a factory registered via `sandbox.RegisterFactory` (or `sdk.WithSandboxFactory`). The rest of the entry is passed verbatim to that factory as its configuration map.
+
+The built-in `direct` mode spawns the command on the host and ships in core; it's the default when a hook omits `sandbox:`.
+
+---
+
+## Available Backends
+
+- **`direct`** (core, default) -- spawns the command on the host via `exec.CommandContext`. No configuration.
+- **`docker_run`**, **`docker_exec`**, **`kubectl_exec`** -- reference implementations in [`sdk/examples/sandboxes/`](https://github.com/AltairaLabs/PromptKit/tree/main/sdk/examples/sandboxes). Copy, adapt, or import directly.
+
+Reference backends aren't wired in by default. Register them in consumer code:
+
+```go
+import (
+    "github.com/AltairaLabs/PromptKit/sdk"
+    "github.com/AltairaLabs/PromptKit/sdk/examples/sandboxes/dockerrun"
+    "github.com/AltairaLabs/PromptKit/sdk/examples/sandboxes/kubectlexec"
+)
+
+conv, err := sdk.Open("./pack.json", "chat",
+    sdk.WithSandboxFactory(dockerrun.ModeName, dockerrun.Factory),
+    sdk.WithSandboxFactory(kubectlexec.ModeName, kubectlexec.Factory),
+    sdk.WithRuntimeConfig("./runtime.yaml"),
+)
+```
+
+Factories must be registered **before** `WithRuntimeConfig` runs; otherwise the mode lookup fails.
+
+---
+
+## Running Hooks in a Kubernetes Sidecar
+
+A common production shape: PromptKit runs as the main container in a pod, alongside a long-lived `hooks` sidecar that has Python (or Node, or whatever hook runtime you need) and your hook scripts baked in. Every hook invocation is a `kubectl exec` into that sidecar.
+
+```yaml
+# runtime.yaml
+spec:
+  sandboxes:
+    sidecar:
+      mode: kubectl_exec
+      pod: ${POD_NAME}
+      container: hooks
+      extra_args: [--request-timeout=5s]
+
+  hooks:
+    pii_redactor:
+      command: python
+      args: [-m, pii]
+      hook: provider
+      phases: [before_call]
+      mode: filter
+      sandbox: sidecar
+    audit_logger:
+      command: python
+      args: [-m, audit]
+      hook: session
+      phases: [session_start, session_end]
+      mode: observe
+      sandbox: sidecar
+```
+
+```go
+conv, err := sdk.Open("./pack.json", "chat",
+    sdk.WithSandboxFactory(kubectlexec.ModeName, kubectlexec.Factory),
+    sdk.WithRuntimeConfig("./runtime.yaml"),
+)
+```
+
+Multiple hooks can share the same sandbox. The sidecar reuses its process tree across invocations, so startup cost is one-time rather than per-call.
+
+---
+
+## Writing a Custom Backend
+
+Implement `sandbox.Sandbox` and `sandbox.Factory`:
+
+```go
+package mybackend
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
+)
+
+const ModeName = "my_backend"
+
+type Sandbox struct{ name string /* ... */ }
+
+func (s *Sandbox) Name() string { return s.name }
+
+func (s *Sandbox) Spawn(ctx context.Context, req sandbox.Request) (sandbox.Response, error) {
+    // Run req.Command with req.Args, pipe req.Stdin in, return stdout/stderr.
+    // The hook subprocess's stdout is what PromptKit parses as the verdict.
+    return sandbox.Response{Stdout: out, Stderr: errb}, nil
+}
+
+func Factory(name string, cfg map[string]any) (sandbox.Sandbox, error) {
+    // Read and validate cfg, return a ready Sandbox.
+    return &Sandbox{name: name /* ... */}, nil
+}
+```
+
+Register at SDK open time:
+
+```go
+sdk.WithSandboxFactory(mybackend.ModeName, mybackend.Factory)
+```
+
+The same type works programmatically without any registry: construct a `sandbox.Sandbox` and assign it to `ExecHookConfig.Sandbox` before calling `hooks.NewExecProviderHook` (or friends). RuntimeConfig only wires the declarative path.
+
+---
+
+## Behavior Notes
+
+- Sandbox resolution happens at `WithRuntimeConfig` time, once per load. If a hook references a name not declared under `spec.sandboxes`, the config load fails loudly.
+- When a hook omits `sandbox:`, the built-in `direct` backend is used -- existing configs keep working unchanged.
+- The wire protocol (JSON stdin/stdout, timeout, phase/mode semantics) is independent of the sandbox. Anything that works under `direct` works under every other backend.
+- Per-call timeouts (`timeout_ms`) are enforced by the runtime regardless of backend. A stuck container or pod exec will still be cancelled.
+
+---
+
+## See Also
+
+- [Exec Hooks](/sdk/how-to/exec-hooks/) -- the wire protocol and phase semantics.
+- [`sdk/examples/sandboxes/`](https://github.com/AltairaLabs/PromptKit/tree/main/sdk/examples/sandboxes) -- reference implementations for Docker and Kubernetes.
+- [`runtime/hooks/sandbox/`](https://github.com/AltairaLabs/PromptKit/tree/main/runtime/hooks/sandbox) -- the core interface and registry.

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -53,6 +53,32 @@ type RuntimeConfigSpec struct {
 	// Hooks configures external process hooks for pipeline lifecycle events.
 	//nolint:lll // jsonschema tags require single line
 	Hooks map[string]*ExecHook `yaml:"hooks,omitempty" json:"hooks,omitempty" jsonschema:"title=Hooks,description=External hook process configurations"`
+
+	// Sandboxes declares named sandbox backends that exec hooks can
+	// reference via their "sandbox:" field. Each entry's "mode" selects
+	// a factory registered via runtime/hooks/sandbox.RegisterFactory;
+	// the remaining fields are passed verbatim to that factory as the
+	// config map. The built-in "direct" mode resolves without any
+	// consumer opt-in; other modes (docker_run, docker_exec, kubectl_exec,
+	// or custom) require that their factory has been registered before
+	// RuntimeConfig is loaded.
+	//nolint:lll // jsonschema tags require single line
+	Sandboxes map[string]*SandboxConfig `yaml:"sandboxes,omitempty" json:"sandboxes,omitempty" jsonschema:"title=Sandboxes,description=Named sandbox backends for exec-hook subprocess launch"`
+}
+
+// SandboxConfig declares a named sandbox backend. Mode selects a
+// factory registered via runtime/hooks/sandbox.RegisterFactory; every
+// other field is passed to the factory as its config map.
+type SandboxConfig struct {
+	// Mode names a registered sandbox factory. "direct" ships in-tree
+	// and needs no extra registration.
+	//nolint:lll // jsonschema tags require single line
+	Mode string `yaml:"mode" json:"mode" jsonschema:"title=Mode,description=Registered sandbox factory name (direct ships in-tree; docker_run/docker_exec/kubectl_exec are examples)"`
+
+	// Config carries mode-specific configuration. Each factory
+	// documents its own keys. For example, the docker_run example
+	// expects "image", "network", and "mounts".
+	Config map[string]any `yaml:",inline" json:"-" jsonschema:"-"`
 }
 
 // ExecBinding defines how to invoke an external process for tool or eval execution.
@@ -71,6 +97,12 @@ type ExecBinding struct {
 	// TimeoutMs is the per-invocation timeout in milliseconds.
 	//nolint:lll // jsonschema tags require single line
 	TimeoutMs int `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty" jsonschema:"title=Timeout,description=Per-invocation timeout in milliseconds"`
+	// Sandbox names a sandbox backend declared under spec.sandboxes.
+	// When empty the built-in "direct" backend is used. Only applies to
+	// exec hooks; ignored for exec tools and exec eval handlers (which
+	// reuse this struct via embedding but do not yet support sandboxing).
+	//nolint:lll // jsonschema tags require single line
+	Sandbox string `yaml:"sandbox,omitempty" json:"sandbox,omitempty" jsonschema:"title=Sandbox,description=Name of a sandbox declared under spec.sandboxes"`
 }
 
 // ExecHook defines an external process hook bound to a pipeline lifecycle event.
@@ -148,6 +180,9 @@ func (s *RuntimeConfigSpec) Validate() error {
 	if err := s.validateEvals(); err != nil {
 		return err
 	}
+	if err := s.validateSandboxes(); err != nil {
+		return err
+	}
 	return s.validateHooks()
 }
 
@@ -220,7 +255,22 @@ func (s *RuntimeConfigSpec) validateEvals() error {
 	return nil
 }
 
-var validHookTypes = map[string]bool{"provider": true, "tool": true, "session": true}
+var validHookTypes = map[string]bool{"provider": true, "tool": true, "session": true, "eval": true}
+
+func (s *RuntimeConfigSpec) validateSandboxes() error {
+	for name, sb := range s.Sandboxes {
+		if sb == nil {
+			continue
+		}
+		if sb.Mode == "" {
+			return &ValidationError{
+				Field:   fmt.Sprintf("sandboxes[%s].mode", name),
+				Message: "sandbox mode is required",
+			}
+		}
+	}
+	return nil
+}
 
 func (s *RuntimeConfigSpec) validateHooks() error {
 	for name, h := range s.Hooks {
@@ -233,14 +283,23 @@ func (s *RuntimeConfigSpec) validateHooks() error {
 		if h.Hook == "" {
 			return &ValidationError{
 				Field:   fmt.Sprintf("hooks[%s].hook", name),
-				Message: "hook type is required (provider, tool, or session)",
+				Message: "hook type is required (provider, tool, session, or eval)",
 			}
 		}
 		if !validHookTypes[h.Hook] {
 			return &ValidationError{
 				Field:   fmt.Sprintf("hooks[%s].hook", name),
-				Message: "must be one of: provider, tool, session",
+				Message: "must be one of: provider, tool, session, eval",
 				Value:   h.Hook,
+			}
+		}
+		if h.Sandbox != "" {
+			if _, ok := s.Sandboxes[h.Sandbox]; !ok {
+				return &ValidationError{
+					Field:   fmt.Sprintf("hooks[%s].sandbox", name),
+					Message: "references a sandbox not declared under spec.sandboxes",
+					Value:   h.Sandbox,
+				}
 			}
 		}
 	}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -304,6 +304,75 @@ func TestRuntimeConfigSpec_Validate_InvalidLogging(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigSpec_Validate_SandboxMissingMode(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		Sandboxes: map[string]*SandboxConfig{
+			"my_sandbox": {Config: map[string]any{"image": "alpine"}},
+		},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing sandbox mode")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_HookReferencesUndeclaredSandbox(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		Hooks: map[string]*ExecHook{
+			"h": {
+				ExecBinding: ExecBinding{Command: "./x", Sandbox: "ghost"},
+				Hook:        "provider",
+			},
+		},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("expected error referencing undeclared sandbox")
+	}
+}
+
+func TestLoadRuntimeConfig_SandboxesInline(t *testing.T) {
+	yaml := `
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: RuntimeConfig
+spec:
+  sandboxes:
+    my_docker:
+      mode: docker_run
+      image: python:3.12-slim
+      network: none
+      mounts:
+        - ./hooks:/hooks:ro
+  hooks:
+    pii:
+      command: /hooks/pii.py
+      hook: provider
+      sandbox: my_docker
+`
+	path := writeTemp(t, "rc.yaml", yaml)
+	rc, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig: %v", err)
+	}
+	sb, ok := rc.Spec.Sandboxes["my_docker"]
+	if !ok {
+		t.Fatalf("sandbox my_docker not loaded")
+	}
+	if sb.Mode != "docker_run" {
+		t.Errorf("Mode = %q, want docker_run", sb.Mode)
+	}
+	if got := sb.Config["image"]; got != "python:3.12-slim" {
+		t.Errorf("Config[image] = %v, want python:3.12-slim", got)
+	}
+	if got := sb.Config["network"]; got != "none" {
+		t.Errorf("Config[network] = %v, want none", got)
+	}
+	hook := rc.Spec.Hooks["pii"]
+	if hook.Sandbox != "my_docker" {
+		t.Errorf("hook.Sandbox = %q, want my_docker", hook.Sandbox)
+	}
+}
+
 func writeTemp(t *testing.T, name, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -895,6 +895,11 @@
           "type": "integer",
           "title": "Timeout",
           "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -54,6 +54,11 @@
           "type": "integer",
           "title": "Timeout",
           "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
         }
       },
       "additionalProperties": false,
@@ -99,6 +104,11 @@
           "type": "integer",
           "title": "Timeout",
           "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
         },
         "hook": {
           "type": "string",
@@ -707,10 +717,32 @@
           "type": "object",
           "title": "Hooks",
           "description": "External hook process configurations"
+        },
+        "sandboxes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SandboxConfig"
+          },
+          "type": "object",
+          "title": "Sandboxes",
+          "description": "Named sandbox backends for exec-hook subprocess launch"
         }
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "SandboxConfig": {
+      "properties": {
+        "mode": {
+          "type": "string",
+          "title": "Mode",
+          "description": "Registered sandbox factory name (direct ships in-tree; docker_run/docker_exec/kubectl_exec are examples)"
+        }
+      },
+      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "mode"
+      ]
     },
     "StateStoreConfig": {
       "properties": {

--- a/schemas/v1alpha1/tool.json
+++ b/schemas/v1alpha1/tool.json
@@ -39,6 +39,11 @@
           "type": "integer",
           "title": "Timeout",
           "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
         }
       },
       "additionalProperties": false,

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -14,18 +14,56 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 )
 
+// resolveSandboxes builds a map from declared sandbox names to ready
+// Sandbox instances by looking up each mode in the process-wide factory
+// registry. Factories are expected to have been registered via
+// sandbox.RegisterFactory, direct's init, or sdk.WithSandboxFactory
+// before RuntimeConfig is applied.
+func resolveSandboxes(specs map[string]*pkgconfig.SandboxConfig) (map[string]sandbox.Sandbox, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]sandbox.Sandbox, len(specs))
+	for name, sb := range specs {
+		if sb == nil {
+			continue
+		}
+		factory, err := sandbox.LookupFactory(sb.Mode)
+		if err != nil {
+			return nil, fmt.Errorf("sandbox %q: %w", name, err)
+		}
+		inst, err := factory(name, sb.Config)
+		if err != nil {
+			return nil, fmt.Errorf("building sandbox %q: %w", name, err)
+		}
+		out[name] = inst
+	}
+	return out, nil
+}
+
 // applyExecHooks creates exec hook adapters from RuntimeConfig hook bindings
 // and appends them to the appropriate hook slices in the SDK config.
-func applyExecHooks(c *config, hookBindings map[string]*pkgconfig.ExecHook) {
+// Resolved sandboxes (from spec.Sandboxes) are looked up by name when a
+// binding sets its "sandbox:" field; unknown names are rejected.
+func applyExecHooks(c *config, hookBindings map[string]*pkgconfig.ExecHook, resolved map[string]sandbox.Sandbox) error {
 	for name, binding := range hookBindings {
 		if binding == nil {
 			continue
+		}
+		var sb sandbox.Sandbox
+		if binding.Sandbox != "" {
+			var ok bool
+			sb, ok = resolved[binding.Sandbox]
+			if !ok {
+				return fmt.Errorf("hook %q references undeclared sandbox %q", name, binding.Sandbox)
+			}
 		}
 		cfg := &hooks.ExecHookConfig{
 			Name:      name,
@@ -35,6 +73,7 @@ func applyExecHooks(c *config, hookBindings map[string]*pkgconfig.ExecHook) {
 			TimeoutMs: binding.TimeoutMs,
 			Phases:    binding.Phases,
 			Mode:      binding.Mode,
+			Sandbox:   sb,
 		}
 		switch binding.Hook {
 		case "provider":
@@ -52,9 +91,11 @@ func applyExecHooks(c *config, hookBindings map[string]*pkgconfig.ExecHook) {
 				Args:      binding.Args,
 				Env:       binding.Env,
 				TimeoutMs: binding.TimeoutMs,
+				Sandbox:   sb,
 			}))
 		}
 	}
+	return nil
 }
 
 // WithRuntimeConfig loads a RuntimeConfig YAML file and applies its settings
@@ -139,8 +180,15 @@ func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 	// Apply exec eval handlers from RuntimeConfig evals map
 	applyExecEvalHandlers(c, spec.Evals)
 
-	// Apply exec hooks from RuntimeConfig hooks map
-	applyExecHooks(c, spec.Hooks)
+	// Resolve declared sandboxes, then apply exec hooks (which may
+	// reference them by name).
+	resolved, err := resolveSandboxes(spec.Sandboxes)
+	if err != nil {
+		return fmt.Errorf("resolving sandboxes from runtime config: %w", err)
+	}
+	if err := applyExecHooks(c, spec.Hooks, resolved); err != nil {
+		return fmt.Errorf("applying exec hooks from runtime config: %w", err)
+	}
 
 	return nil
 }

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -576,6 +576,68 @@ func TestApplyExecHooks_MultipleTypes(t *testing.T) {
 	assert.Len(t, c.sessionHooks, 1)
 }
 
+func TestApplyExecHooks_WithSandboxReference(t *testing.T) {
+	spec := &pkgconfig.RuntimeConfigSpec{
+		Sandboxes: map[string]*pkgconfig.SandboxConfig{
+			"local": {Mode: "direct"},
+		},
+		Hooks: map[string]*pkgconfig.ExecHook{
+			"pii": {
+				ExecBinding: pkgconfig.ExecBinding{
+					Command: "./pii",
+					Sandbox: "local",
+				},
+				Hook:   "provider",
+				Phases: []string{"before_call"},
+			},
+		},
+	}
+
+	c := &config{}
+	require.NoError(t, applyRuntimeConfig(c, spec))
+	require.Len(t, c.providerHooks, 1)
+}
+
+func TestApplyExecHooks_UndeclaredSandboxReference(t *testing.T) {
+	spec := &pkgconfig.RuntimeConfigSpec{
+		Hooks: map[string]*pkgconfig.ExecHook{
+			"pii": {
+				ExecBinding: pkgconfig.ExecBinding{
+					Command: "./pii",
+					Sandbox: "ghost",
+				},
+				Hook:   "provider",
+				Phases: []string{"before_call"},
+			},
+		},
+	}
+
+	c := &config{}
+	err := applyRuntimeConfig(c, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undeclared sandbox")
+	assert.Contains(t, err.Error(), "ghost")
+}
+
+func TestResolveSandboxes_UnknownMode(t *testing.T) {
+	specs := map[string]*pkgconfig.SandboxConfig{
+		"x": {Mode: "not_a_registered_mode"},
+	}
+	_, err := resolveSandboxes(specs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not_a_registered_mode")
+}
+
+func TestResolveSandboxes_NilAndEmpty(t *testing.T) {
+	out, err := resolveSandboxes(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	out, err = resolveSandboxes(map[string]*pkgconfig.SandboxConfig{"skip": nil})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
 // rtcMockStore is a minimal statestore.Store for runtime_config tests.
 type rtcMockStore struct{}
 

--- a/tools/schema-gen/generators/runtime_config.go
+++ b/tools/schema-gen/generators/runtime_config.go
@@ -19,7 +19,23 @@ func GenerateRuntimeConfigSchema() (interface{}, error) {
 	})
 }
 
+// allowSandboxAdditionalProps flips SandboxConfig's additionalProperties
+// to true. SandboxConfig has a yaml-inline `Config map[string]any` that
+// receives all mode-specific keys (image, network, mounts, ...), so the
+// default strict setting would incorrectly reject valid configs.
+func allowSandboxAdditionalProps(schema *jsonschema.Schema) {
+	if schema.Definitions == nil {
+		return
+	}
+	sb, ok := schema.Definitions["SandboxConfig"]
+	if !ok {
+		return
+	}
+	sb.AdditionalProperties = &jsonschema.Schema{}
+}
+
 func addRuntimeConfigExample(schema *jsonschema.Schema) {
+	allowSandboxAdditionalProps(schema)
 	schema.Examples = []interface{}{
 		map[string]interface{}{
 			"apiVersion": "promptkit.altairalabs.ai/v1alpha1",


### PR DESCRIPTION
## Summary

Closes out the exec-hook sandbox proposal (M1 core + M2 examples already shipped). Adds the declarative path: sandboxes declared under `spec.sandboxes`, referenced from individual hooks by name.

- `pkg/config`: new `SandboxConfig` (mode + yaml-inline config map), `Sandbox` field on `ExecBinding`, validation of sandbox declarations and hook cross-references. Also fixes a pre-existing bug where `eval` was missing from `validHookTypes`.
- `sdk`: `resolveSandboxes` + updated `applyExecHooks` look factories up in the process-wide registry and wire them into `ExecHookConfig` / `ExecEvalHookConfig`. Undeclared sandbox references fail loudly at load time.
- `schemas/v1alpha1/runtime-config.json`: regenerated; `SandboxConfig` allows `additionalProperties` so mode-specific keys (image, pod, ...) validate.
- `docs/sdk/how-to/sandbox-hooks.md`: new how-to covering k8s sidecar + docker patterns and the path for writing a custom backend.

Pair this with `WithSandboxFactory` (already shipped in M1) to register out-of-tree backends:

```go
sdk.Open("./pack.json", "chat",
    sdk.WithSandboxFactory(kubectlexec.ModeName, kubectlexec.Factory),
    sdk.WithRuntimeConfig("./runtime.yaml"),
)
```

## Test plan

- [x] `go test ./sdk/... ./pkg/... ./tools/schema-gen/...`
- [x] `golangci-lint run --new-from-rev=main`
- [x] New tests: YAML inline parsing, resolve + reference + missing-mode failure paths
- [x] Schema regenerated and checked in
- [ ] CI green