### PR TITLE
docs(selection): reference selector implementations (M2)

### DIFF
--- a/sdk/examples/selectors/README.md
+++ b/sdk/examples/selectors/README.md
@@ -1,0 +1,99 @@
+# Selector Examples
+
+Reference implementations of the `selection.Selector` interface
+(see issue #980). PromptKit core ships only the exec client; everything
+in here is example code consumers can copy, adapt, or import directly.
+
+Two patterns covered:
+
+| Path | Pattern | Lives | Wire-up |
+|---|---|---|---|
+| [`cosine/`](./cosine) | In-process Go: cosine similarity over PromptKit `EmbeddingProvider` vectors | inside the SDK process | `sdk.WithSelector(name, impl)` |
+| [`exec_rerank/`](./exec_rerank) | External subprocess: forwards to a hosted rerank API | separate process (host or sandbox) | `spec.selectors.<name>.command` in RuntimeConfig |
+
+The two paths are functionally interchangeable from PromptKit's point
+of view — pick based on operational preference (deployment unit, language,
+hot-path latency, blast-radius isolation).
+
+---
+
+## In-Process: Cosine Selector
+
+```go
+import (
+    "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+    "github.com/AltairaLabs/PromptKit/sdk"
+    "github.com/AltairaLabs/PromptKit/sdk/examples/selectors/cosine"
+)
+
+emb, _ := openai.NewEmbeddingProvider()
+sel := cosine.New("skills_local", emb, cosine.Options{TopK: 5})
+
+conv, _ := sdk.Open("./pack.json", "chat",
+    sdk.WithSelector("skills_local", sel),
+    sdk.WithRuntimeConfig("./runtime.yaml"), // spec.skills.selector: skills_local
+)
+```
+
+The selector caches candidate embeddings keyed on `(ID, Description)`,
+so a stable skill catalog only embeds once across many `Send` calls.
+The query embedding is recomputed each turn (it changes every turn).
+
+If `WithContextRetrieval` already configured an embedding provider for
+RAG, that instance is supplied to `Init` via `SelectorContext.Embeddings`
+and overrides the constructor argument — one provider, one connection
+pool, one rate-limit bucket.
+
+---
+
+## External Process: Rerank Script
+
+```yaml
+spec:
+  selectors:
+    rerank:
+      command: python
+      args: [/selectors/rerank.py]
+      env: [RERANK_API_KEY, RERANK_URL]
+      timeout_ms: 3000
+      # sandbox: sidecar     # optional — runs the script inside a k8s sidecar
+  skills:
+    selector: rerank
+```
+
+The wire protocol is:
+
+```jsonc
+// stdin
+{
+  "query":      {"text": "...", "kind": "skill", "pack_id": "...", "k": 5},
+  "candidates": [{"id": "...", "name": "...", "description": "...", "metadata": {}}]
+}
+
+// stdout
+{"selected": ["id1", "id2"], "reason": "optional"}
+```
+
+The bundled `rerank.py` calls a remote rerank endpoint when
+`RERANK_URL` and `RERANK_API_KEY` are set; otherwise it falls back to a
+trivial token-overlap ranker so the example runs without external
+dependencies.
+
+Combine with the sandbox examples in [`../sandboxes/`](../sandboxes/) to
+run the selector inside a docker container or kubectl-exec sidecar
+without changing the script.
+
+---
+
+## Behavior Notes
+
+- A selector returning an error or an empty result is non-fatal —
+  PromptKit falls back to "include all eligible" so a misconfigured
+  ranker can never break a conversation.
+- The `Query.Kind` field carries `"skill"` today and `"tool"` once the
+  M3 work lands. A single selector implementation can dispatch on
+  `kind` to serve both hook points; one binding under
+  `spec.selectors.<name>` is fine.
+- Selectors are called once per `Send` (per turn). Internal caching is
+  the implementation's responsibility; the cosine example is one
+  reasonable shape for it.

--- a/sdk/examples/selectors/cosine/cosine.go
+++ b/sdk/examples/selectors/cosine/cosine.go
@@ -1,0 +1,215 @@
+// Package cosine is a reference Selector implementation that ranks
+// candidates by cosine similarity over embeddings produced by a
+// PromptKit EmbeddingProvider.
+//
+// This is the Go port of the in-tree EmbeddingSelector that shipped
+// before #980 deleted it. It exists as an example, not as core code:
+// PromptKit no longer ships any selector implementations beyond the
+// exec client. Copy, adapt, or import directly.
+//
+// Usage:
+//
+//	emb, _ := openai.NewEmbeddingProvider()
+//	sel := cosine.New("skills_local", emb, cosine.Options{TopK: 5})
+//	conv, _ := sdk.Open("./pack.json", "chat",
+//	    sdk.WithSelector("skills_local", sel),
+//	    sdk.WithRuntimeConfig("./runtime.yaml"), // spec.skills.selector: skills_local
+//	)
+//
+// The provider on SelectorContext (set by RAG / WithContextRetrieval)
+// takes precedence over the one passed to New, which lets a single
+// embedding instance back both RAG and selection. Pass nil to opt
+// into context-driven embeddings exclusively.
+package cosine
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/selection"
+)
+
+const defaultTopK = 10
+
+// Options configures the cosine selector.
+type Options struct {
+	// TopK caps the number of candidates returned. Zero falls back to
+	// defaultTopK (10). Use a large value to effectively disable
+	// truncation.
+	TopK int
+}
+
+// Selector ranks candidates by cosine similarity. Embeddings for
+// identical (Candidate.ID, Description) pairs are cached across
+// Select calls; changing a description re-embeds the candidate.
+type Selector struct {
+	name        string
+	embFromCtor providers.EmbeddingProvider
+	embCtx      providers.EmbeddingProvider
+	topK        int
+
+	mu    sync.Mutex
+	cache map[cacheKey][]float32
+}
+
+type cacheKey struct {
+	id   string
+	desc string
+}
+
+// New returns a Selector that uses the given embedding provider when
+// SelectorContext doesn't supply one. Pass nil to require the context
+// to provide a provider; Select returns an error otherwise.
+func New(name string, embeddings providers.EmbeddingProvider, opts Options) *Selector {
+	topK := opts.TopK
+	if topK <= 0 {
+		topK = defaultTopK
+	}
+	return &Selector{
+		name:        name,
+		embFromCtor: embeddings,
+		topK:        topK,
+		cache:       make(map[cacheKey][]float32),
+	}
+}
+
+// Name returns the selector's registered name.
+func (s *Selector) Name() string { return s.name }
+
+// Init records the embedding provider supplied by the host (typically
+// the same instance configured for RAG). When non-nil it overrides the
+// constructor-supplied provider so a single embedding pool serves both
+// selection and retrieval.
+func (s *Selector) Init(ctx selection.SelectorContext) error {
+	if ctx.Embeddings != nil {
+		s.embCtx = ctx.Embeddings
+	}
+	if s.provider() == nil {
+		return fmt.Errorf("cosine selector %q: no embedding provider configured", s.name)
+	}
+	return nil
+}
+
+// Select embeds the query and the candidates, ranks by cosine
+// similarity, and returns the top-K IDs. On any embedding failure
+// it returns the error; the caller (skills executor) treats that as
+// "include all eligible".
+func (s *Selector) Select(ctx context.Context, q selection.Query, candidates []selection.Candidate) ([]string, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	prov := s.provider()
+	if prov == nil {
+		return nil, fmt.Errorf("cosine selector %q: no embedding provider", s.name)
+	}
+
+	candVecs, err := s.embedCandidates(ctx, prov, candidates)
+	if err != nil {
+		return nil, fmt.Errorf("cosine selector %q: candidate embed: %w", s.name, err)
+	}
+
+	resp, err := prov.Embed(ctx, providers.EmbeddingRequest{Texts: []string{q.Text}})
+	if err != nil {
+		return nil, fmt.Errorf("cosine selector %q: query embed: %w", s.name, err)
+	}
+	if len(resp.Embeddings) == 0 {
+		return nil, fmt.Errorf("cosine selector %q: empty query embedding", s.name)
+	}
+	queryVec := resp.Embeddings[0]
+
+	type scored struct {
+		id    string
+		score float64
+	}
+	scores := make([]scored, len(candidates))
+	for i, c := range candidates {
+		scores[i] = scored{id: c.ID, score: cosineSimilarity(queryVec, candVecs[i])}
+	}
+	sort.Slice(scores, func(i, j int) bool { return scores[i].score > scores[j].score })
+
+	k := q.K
+	if k <= 0 || k > s.topK {
+		k = s.topK
+	}
+	if k > len(scores) {
+		k = len(scores)
+	}
+	out := make([]string, k)
+	for i := 0; i < k; i++ {
+		out[i] = scores[i].id
+	}
+	return out, nil
+}
+
+func (s *Selector) provider() providers.EmbeddingProvider {
+	if s.embCtx != nil {
+		return s.embCtx
+	}
+	return s.embFromCtor
+}
+
+// embedCandidates returns one embedding per candidate, batching the
+// uncached descriptions into a single Embed call. Cache lives for the
+// selector's lifetime.
+func (s *Selector) embedCandidates(ctx context.Context, prov providers.EmbeddingProvider,
+	candidates []selection.Candidate,
+) ([][]float32, error) {
+	s.mu.Lock()
+	out := make([][]float32, len(candidates))
+	var pending []string
+	var pendingIdx []int
+	for i, c := range candidates {
+		key := cacheKey{id: c.ID, desc: c.Description}
+		if v, ok := s.cache[key]; ok {
+			out[i] = v
+			continue
+		}
+		pending = append(pending, c.Name+": "+c.Description)
+		pendingIdx = append(pendingIdx, i)
+	}
+	s.mu.Unlock()
+
+	if len(pending) == 0 {
+		return out, nil
+	}
+	resp, err := prov.Embed(ctx, providers.EmbeddingRequest{Texts: pending})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Embeddings) != len(pending) {
+		return nil, fmt.Errorf("provider returned %d embeddings, expected %d", len(resp.Embeddings), len(pending))
+	}
+
+	s.mu.Lock()
+	for j, idx := range pendingIdx {
+		c := candidates[idx]
+		s.cache[cacheKey{id: c.ID, desc: c.Description}] = resp.Embeddings[j]
+		out[idx] = resp.Embeddings[j]
+	}
+	s.mu.Unlock()
+	return out, nil
+}
+
+// cosineSimilarity returns the cosine similarity of two equal-length
+// vectors, or 0 when either has zero magnitude or differing length.
+func cosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, magA, magB float64
+	for i := range a {
+		af, bf := float64(a[i]), float64(b[i])
+		dot += af * bf
+		magA += af * af
+		magB += bf * bf
+	}
+	mag := math.Sqrt(magA) * math.Sqrt(magB)
+	if mag == 0 {
+		return 0
+	}
+	return dot / mag
+}

--- a/sdk/examples/selectors/cosine/cosine_test.go
+++ b/sdk/examples/selectors/cosine/cosine_test.go
@@ -1,0 +1,200 @@
+package cosine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/selection"
+)
+
+// fakeEmbedder returns a deterministic embedding per text via a lookup
+// map. Texts not in the map get a zero vector. embedCalls counts how
+// many Embed invocations the selector made — useful for asserting cache
+// behavior.
+type fakeEmbedder struct {
+	vectors    map[string][]float32
+	err        error
+	embedCalls int
+}
+
+func (f *fakeEmbedder) Embed(_ context.Context, req providers.EmbeddingRequest) (providers.EmbeddingResponse, error) {
+	f.embedCalls++
+	if f.err != nil {
+		return providers.EmbeddingResponse{}, f.err
+	}
+	out := make([][]float32, len(req.Texts))
+	for i, t := range req.Texts {
+		if v, ok := f.vectors[t]; ok {
+			out[i] = v
+			continue
+		}
+		out[i] = []float32{0, 0, 0}
+	}
+	return providers.EmbeddingResponse{Embeddings: out}, nil
+}
+
+func (f *fakeEmbedder) EmbeddingDimensions() int { return 3 }
+func (f *fakeEmbedder) MaxBatchSize() int        { return 100 }
+func (f *fakeEmbedder) ID() string               { return "fake" }
+
+func candidatesABC() []selection.Candidate {
+	return []selection.Candidate{
+		{ID: "alpha", Name: "alpha", Description: "weather and forecasting"},
+		{ID: "beta", Name: "beta", Description: "billing and invoices"},
+		{ID: "gamma", Name: "gamma", Description: "user profile management"},
+	}
+}
+
+func newTestSelector(t *testing.T, fe *fakeEmbedder, topK int) *Selector {
+	t.Helper()
+	s := New("test", fe, Options{TopK: topK})
+	if err := s.Init(selection.SelectorContext{}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return s
+}
+
+func TestSelect_RanksMostSimilarFirst(t *testing.T) {
+	fe := &fakeEmbedder{vectors: map[string][]float32{
+		"alpha: weather and forecasting": {1, 0, 0},
+		"beta: billing and invoices":     {0, 1, 0},
+		"gamma: user profile management": {0, 0, 1},
+		"will it rain tomorrow":          {1, 0, 0}, // matches alpha
+	}}
+	s := newTestSelector(t, fe, 0)
+
+	ids, err := s.Select(context.Background(),
+		selection.Query{Text: "will it rain tomorrow", Kind: "skill"},
+		candidatesABC(),
+	)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if len(ids) == 0 || ids[0] != "alpha" {
+		t.Errorf("top result = %v, want alpha first", ids)
+	}
+}
+
+func TestSelect_HonorsQueryK(t *testing.T) {
+	fe := &fakeEmbedder{vectors: map[string][]float32{
+		"alpha: weather and forecasting": {1, 0, 0},
+		"beta: billing and invoices":     {1, 0, 0},
+		"gamma: user profile management": {1, 0, 0},
+		"q":                              {1, 0, 0},
+	}}
+	s := newTestSelector(t, fe, 10)
+	ids, _ := s.Select(context.Background(),
+		selection.Query{Text: "q", K: 2},
+		candidatesABC(),
+	)
+	if len(ids) != 2 {
+		t.Errorf("got %d ids, want 2", len(ids))
+	}
+}
+
+func TestSelect_OptionsTopKCap(t *testing.T) {
+	fe := &fakeEmbedder{vectors: map[string][]float32{
+		"alpha: weather and forecasting": {1, 0, 0},
+		"beta: billing and invoices":     {1, 0, 0},
+		"gamma: user profile management": {1, 0, 0},
+		"q":                              {1, 0, 0},
+	}}
+	s := newTestSelector(t, fe, 1)
+	ids, _ := s.Select(context.Background(), selection.Query{Text: "q"}, candidatesABC())
+	if len(ids) != 1 {
+		t.Errorf("got %d ids, want 1 (TopK cap)", len(ids))
+	}
+}
+
+func TestSelect_CachesCandidateEmbeddings(t *testing.T) {
+	fe := &fakeEmbedder{vectors: map[string][]float32{
+		"alpha: weather and forecasting": {1, 0, 0},
+		"beta: billing and invoices":     {0, 1, 0},
+		"gamma: user profile management": {0, 0, 1},
+		"q1":                             {1, 0, 0},
+		"q2":                             {0, 1, 0},
+	}}
+	s := newTestSelector(t, fe, 5)
+	cands := candidatesABC()
+
+	_, _ = s.Select(context.Background(), selection.Query{Text: "q1"}, cands)
+	firstCalls := fe.embedCalls
+	_, _ = s.Select(context.Background(), selection.Query{Text: "q2"}, cands)
+	// Second call should embed only the new query, not the candidates again.
+	if fe.embedCalls-firstCalls != 1 {
+		t.Errorf("expected 1 additional embed call (query only), got %d", fe.embedCalls-firstCalls)
+	}
+}
+
+func TestSelect_EmptyCandidates(t *testing.T) {
+	fe := &fakeEmbedder{}
+	s := newTestSelector(t, fe, 0)
+	ids, err := s.Select(context.Background(), selection.Query{Text: "q"}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if ids != nil {
+		t.Errorf("ids = %v, want nil", ids)
+	}
+	if fe.embedCalls != 0 {
+		t.Errorf("should not call embed for empty candidates, got %d calls", fe.embedCalls)
+	}
+}
+
+func TestSelect_EmbeddingError(t *testing.T) {
+	fe := &fakeEmbedder{err: errors.New("rate limited")}
+	s := newTestSelector(t, fe, 0)
+	_, err := s.Select(context.Background(), selection.Query{Text: "q"}, candidatesABC())
+	if err == nil {
+		t.Fatal("expected error from embedding failure")
+	}
+}
+
+func TestInit_RequiresEmbeddingProvider(t *testing.T) {
+	s := New("test", nil, Options{})
+	err := s.Init(selection.SelectorContext{})
+	if err == nil {
+		t.Fatal("expected error when no provider supplied")
+	}
+}
+
+func TestInit_ContextProviderOverridesCtor(t *testing.T) {
+	ctor := &fakeEmbedder{vectors: map[string][]float32{"q": {1, 0, 0}}}
+	ctxProv := &fakeEmbedder{vectors: map[string][]float32{
+		"alpha: weather and forecasting": {1, 0, 0},
+		"beta: billing and invoices":     {0, 1, 0},
+		"gamma: user profile management": {0, 0, 1},
+		"q":                              {1, 0, 0},
+	}}
+	s := New("test", ctor, Options{TopK: 1})
+	if err := s.Init(selection.SelectorContext{Embeddings: ctxProv}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	_, _ = s.Select(context.Background(), selection.Query{Text: "q"}, candidatesABC())
+	if ctor.embedCalls != 0 {
+		t.Errorf("constructor provider should not be used; got %d calls", ctor.embedCalls)
+	}
+	if ctxProv.embedCalls == 0 {
+		t.Errorf("context provider should have been used")
+	}
+}
+
+func TestName(t *testing.T) {
+	if got := New("my_sel", &fakeEmbedder{}, Options{}).Name(); got != "my_sel" {
+		t.Errorf("Name() = %q", got)
+	}
+}
+
+func TestCosineSimilarity_EdgeCases(t *testing.T) {
+	if cosineSimilarity(nil, nil) != 0 {
+		t.Error("nil/nil should be 0")
+	}
+	if cosineSimilarity([]float32{1, 2}, []float32{1}) != 0 {
+		t.Error("differing lengths should be 0")
+	}
+	if cosineSimilarity([]float32{0, 0}, []float32{1, 1}) != 0 {
+		t.Error("zero magnitude should be 0")
+	}
+}

--- a/sdk/examples/selectors/exec_rerank/rerank.py
+++ b/sdk/examples/selectors/exec_rerank/rerank.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Reference exec selector that calls a remote rerank service.
+
+Wire protocol (matches PromptKit's selection.ExecClient):
+
+  stdin:  {"query": {"text": "...", "kind": "skill", "k": 5}, "candidates": [...]}
+  stdout: {"selected": ["id1", "id2"], "reason": "optional"}
+
+This script forwards the candidates to a hosted reranker (Cohere, Voyage,
+Jina — pick your favorite) and returns the top-K IDs. It's a starting
+point: swap the API call for whatever ranker you actually use.
+
+Usage from RuntimeConfig:
+
+  spec:
+    selectors:
+      rerank:
+        command: python
+        args: [/selectors/rerank.py]
+        env: [RERANK_API_KEY, RERANK_URL]
+        timeout_ms: 3000
+    skills:
+      selector: rerank
+
+Requires: Python 3.9+, `requests` (or swap for httpx / urllib).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+# Replace this block with your provider-of-choice. Kept inline so the
+# script is self-contained and copy-pasteable.
+import urllib.request
+
+
+DEFAULT_K = 10
+
+
+def call_reranker(query: str, docs: list[str], k: int) -> list[int]:
+    """Return the indices of the top-k documents, ranked best first.
+
+    Stub implementation: ranks by the count of overlapping whitespace
+    tokens between the query and each document. Replace with a real
+    rerank API call (Cohere /v1/rerank, Voyage /v1/rerank, etc.).
+    """
+    api_url = os.environ.get("RERANK_URL")
+    api_key = os.environ.get("RERANK_API_KEY")
+    if api_url and api_key:
+        body = json.dumps({"query": query, "documents": docs, "top_k": k}).encode()
+        req = urllib.request.Request(
+            api_url,
+            data=body,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=2.5) as r:  # noqa: S310
+            data = json.load(r)
+        # Expect provider response like {"results": [{"index": int, "score": float}, ...]}
+        return [int(item["index"]) for item in data.get("results", [])][:k]
+
+    # Fallback for local testing without a configured backend.
+    q_tokens = set(query.lower().split())
+    scored = [
+        (i, sum(1 for t in d.lower().split() if t in q_tokens))
+        for i, d in enumerate(docs)
+    ]
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return [i for i, _ in scored[:k]]
+
+
+def main() -> None:
+    payload: dict[str, Any] = json.load(sys.stdin)
+    query = payload.get("query", {})
+    candidates = payload.get("candidates", [])
+
+    text = query.get("text", "")
+    k = query.get("k") or DEFAULT_K
+
+    docs = [
+        f"{c.get('name','')}: {c.get('description','')}"
+        for c in candidates
+    ]
+
+    if not text or not docs:
+        json.dump({"selected": []}, sys.stdout)
+        return
+
+    indices = call_reranker(text, docs, k)
+    selected = [candidates[i]["id"] for i in indices if 0 <= i < len(candidates)]
+    json.dump({"selected": selected}, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #980. Two reference Selector implementations + a walkthrough.

## What's added

- **`sdk/examples/selectors/cosine`** — in-process Go selector that ranks candidates by cosine similarity over a PromptKit `EmbeddingProvider`. Caches candidate embeddings so a stable catalog only embeds once across many `Send`s. Honors `SelectorContext.Embeddings` to share the RAG embedding instance — one provider, one connection pool, one rate-limit bucket.
- **`sdk/examples/selectors/exec_rerank/rerank.py`** — Python script implementing the JSON-stdin/JSON-stdout wire protocol. Calls a hosted rerank API (Cohere/Voyage/Jina shape) when `RERANK_URL`/`RERANK_API_KEY` are set; falls back to token-overlap so the example runs without external dependencies.
- **`sdk/examples/selectors/README.md`** — covers both patterns, wire protocol, sandbox combo, and behavior notes (fallback on error, `Query.Kind` dispatch, per-Send invocation).

This is the in-process port of the `EmbeddingSelector` that M1 deleted from `runtime/skills` — same logic, new interface, and now actually invocable through the wired-up Send path.

## Test plan

- [x] `go test ./sdk/examples/selectors/cosine -race -count=1` — 95% coverage
- [x] `golangci-lint run ./sdk/examples/selectors/...` — clean
- [x] Python script smoke-tested end-to-end (stdin → stdout)
- [ ] CI green

## Left for M3

Extend the same `Selector` interface to tool descriptor assembly so tools narrow per-turn alongside skills.