### PR TITLE
feat(selection): per-turn tool narrowing via Selector (M3)

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -78,6 +78,17 @@ type RuntimeConfigSpec struct {
 	// pack itself; this block only covers runtime wiring.
 	//nolint:lll // jsonschema tags require single line
 	Skills *SkillsConfig `yaml:"skills,omitempty" json:"skills,omitempty" jsonschema:"title=Skills,description=Runtime skill configuration"`
+
+	// ToolSelector names a selector declared under spec.selectors that
+	// narrows the pack-declared tool set surfaced to the LLM each turn.
+	// System tools (skill__, a2a__, workflow__, mcp__, memory__) are
+	// always preserved regardless of selection. When empty, the prompt's
+	// full allowedTools list is offered to the provider.
+	//
+	// This is a flat field (not nested under tools:) because the existing
+	// spec.tools map binds exec tool implementations.
+	//nolint:lll // jsonschema tags require single line
+	ToolSelector string `yaml:"tool_selector,omitempty" json:"tool_selector,omitempty" jsonschema:"title=ToolSelector,description=Name of a selector declared under spec.selectors used to narrow the LLM-visible tool set per turn"`
 }
 
 // SelectorConfig declares an external selector process. Command, Args,
@@ -346,6 +357,15 @@ func (s *RuntimeConfigSpec) validateSelectors() error {
 				Field:   "skills.selector",
 				Message: "references a selector not declared under spec.selectors",
 				Value:   s.Skills.Selector,
+			}
+		}
+	}
+	if s.ToolSelector != "" {
+		if _, ok := s.Selectors[s.ToolSelector]; !ok {
+			return &ValidationError{
+				Field:   "tool_selector",
+				Message: "references a selector not declared under spec.selectors",
+				Value:   s.ToolSelector,
 			}
 		}
 	}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -404,6 +404,33 @@ func TestRuntimeConfigSpec_Validate_SkillsReferencesUndeclaredSelector(t *testin
 	}
 }
 
+func TestRuntimeConfigSpec_Validate_ToolSelectorReferencesUndeclared(t *testing.T) {
+	s := &RuntimeConfigSpec{ToolSelector: "ghost"}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for undeclared tool_selector ref")
+	}
+}
+
+func TestLoadRuntimeConfig_ToolSelector(t *testing.T) {
+	yaml := `
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: RuntimeConfig
+spec:
+  selectors:
+    rerank:
+      command: ./selectors/rerank
+  tool_selector: rerank
+`
+	path := writeTemp(t, "rc.yaml", yaml)
+	rc, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig: %v", err)
+	}
+	if rc.Spec.ToolSelector != "rerank" {
+		t.Errorf("ToolSelector = %q, want rerank", rc.Spec.ToolSelector)
+	}
+}
+
 func TestLoadRuntimeConfig_SelectorsYAML(t *testing.T) {
 	yaml := `
 apiVersion: promptkit.altairalabs.ai/v1alpha1

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/selection"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -66,6 +67,18 @@ type ProviderConfig struct {
 	// Compactor folds stale tool results between rounds when token usage
 	// exceeds the configured threshold. Nil = disabled.
 	Compactor CompactionStrategy
+
+	// ToolSelector, when set, narrows the pack-declared allowedTools
+	// each turn before tools are sent to the provider. The selector
+	// receives the latest user message as its query and the current
+	// allowedTools as candidates; only the IDs it returns are surfaced.
+	// System tools (skill__, a2a__, workflow__, mcp__, memory__) are
+	// always preserved regardless of selection. Selection is a no-op
+	// when nil, when allowedTools is empty, or when the user message
+	// has no text content. On any selector failure the full eligible
+	// set is used (the provider stage never crashes a turn because
+	// selection broke).
+	ToolSelector selection.Selector
 }
 
 // streamingRoundParams holds parameters for a streaming round execution.
@@ -273,6 +286,7 @@ func (s *ProviderStage) executeMultiRound(
 	ctx context.Context,
 	acc *providerInput,
 ) ([]types.Message, error) {
+	s.applyToolSelector(ctx, acc)
 	loop, err := s.newToolLoop(acc)
 	if err != nil {
 		return nil, err
@@ -290,6 +304,89 @@ func (s *ProviderStage) executeMultiRound(
 	return loop.messages, nil
 }
 
+// applyToolSelector narrows acc.allowedTools through the configured
+// external Selector. Mutates acc in place so subsequent rebuilds
+// (afterRound on tool rejection) see the same narrowed set. No-op
+// when no selector is configured, the candidate list is empty, the
+// user query is empty, the selector errors, or the selection result
+// is empty — fallback is always "use the full eligible list."
+func (s *ProviderStage) applyToolSelector(ctx context.Context, acc *providerInput) {
+	if s.config == nil || s.config.ToolSelector == nil || s.toolRegistry == nil {
+		return
+	}
+	query := lastUserMessageText(acc.messages)
+	candidates := s.toolCandidates(acc.allowedTools)
+	if query == "" || len(candidates) == 0 {
+		return
+	}
+	ids, err := s.config.ToolSelector.Select(ctx,
+		selection.Query{Text: query, Kind: "tool", K: len(candidates)},
+		candidates,
+	)
+	if err != nil || len(ids) == 0 {
+		return
+	}
+	if narrowed := intersectInOrder(acc.allowedTools, ids); len(narrowed) > 0 {
+		acc.allowedTools = narrowed
+	}
+}
+
+// toolCandidates resolves the named tool list against the registry and
+// returns one Candidate per registered entry. Unknown names are
+// dropped silently.
+func (s *ProviderStage) toolCandidates(names []string) []selection.Candidate {
+	out := make([]selection.Candidate, 0, len(names))
+	for _, name := range names {
+		td, err := s.toolRegistry.GetTool(name)
+		if err != nil {
+			continue
+		}
+		out = append(out, selection.Candidate{
+			ID:          td.Name,
+			Name:        td.Name,
+			Description: td.Description,
+		})
+	}
+	return out
+}
+
+// intersectInOrder returns the elements of source that appear in keep,
+// preserving source order.
+func intersectInOrder(source, keep []string) []string {
+	keepSet := make(map[string]bool, len(keep))
+	for _, id := range keep {
+		keepSet[id] = true
+	}
+	out := make([]string, 0, len(keep))
+	for _, name := range source {
+		if keepSet[name] {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// lastUserMessageText returns the concatenated text of the most
+// recent user message in the slice, or "" when none is found.
+func lastUserMessageText(msgs []types.Message) string {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role != "user" {
+			continue
+		}
+		var sb strings.Builder
+		for _, p := range msgs[i].Parts {
+			if p.Type == types.ContentTypeText && p.Text != nil {
+				if sb.Len() > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(*p.Text)
+			}
+		}
+		return sb.String()
+	}
+	return ""
+}
+
 // getMaxRounds returns the maximum number of tool call rounds.
 func (s *ProviderStage) getMaxRounds() int {
 	if s.toolPolicy != nil && s.toolPolicy.MaxRounds > 0 {
@@ -303,6 +400,7 @@ func (s *ProviderStage) executeStreamingMultiRound(
 	acc *providerInput,
 	output chan<- StreamElement,
 ) ([]types.Message, error) {
+	s.applyToolSelector(ctx, acc)
 	loop, err := s.newToolLoop(acc)
 	if err != nil {
 		return nil, err

--- a/runtime/pipeline/stage/stages_provider_selector_test.go
+++ b/runtime/pipeline/stage/stages_provider_selector_test.go
@@ -1,0 +1,209 @@
+package stage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/selection"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// stubToolSelector records what it was asked to select and returns
+// a canned ID list. Lets tests assert on the query and candidate set
+// the ProviderStage handed it.
+type stubToolSelector struct {
+	selected  []string
+	err       error
+	calls     int
+	lastQuery selection.Query
+	lastCands []selection.Candidate
+}
+
+func (s *stubToolSelector) Name() string                         { return "stub" }
+func (s *stubToolSelector) Init(selection.SelectorContext) error { return nil }
+func (s *stubToolSelector) Select(_ context.Context, q selection.Query,
+	c []selection.Candidate,
+) ([]string, error) {
+	s.calls++
+	s.lastQuery = q
+	s.lastCands = c
+	return s.selected, s.err
+}
+
+func registryWithTools(t *testing.T, names ...string) *tools.Registry {
+	t.Helper()
+	r := tools.NewRegistry()
+	for _, n := range names {
+		err := r.Register(&tools.ToolDescriptor{
+			Name:        n,
+			Description: "desc-" + n,
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Mode:        "local",
+		})
+		if err != nil {
+			t.Fatalf("Register %q: %v", n, err)
+		}
+	}
+	return r
+}
+
+func userMessageOnly(text string) []types.Message {
+	msg := types.Message{Role: "user"}
+	msg.AddTextPart(text)
+	return []types.Message{msg}
+}
+
+func newSelectorTestStage(reg *tools.Registry, sel selection.Selector) *ProviderStage {
+	return &ProviderStage{
+		toolRegistry: reg,
+		config:       &ProviderConfig{ToolSelector: sel},
+	}
+}
+
+func TestApplyToolSelector_NoSelector(t *testing.T) {
+	reg := registryWithTools(t, "a", "b")
+	s := newSelectorTestStage(reg, nil)
+	acc := &providerInput{
+		messages:     userMessageOnly("hello"),
+		allowedTools: []string{"a", "b"},
+	}
+	s.applyToolSelector(context.Background(), acc)
+	if len(acc.allowedTools) != 2 {
+		t.Errorf("nil selector should not narrow; got %v", acc.allowedTools)
+	}
+}
+
+func TestApplyToolSelector_NoUserQuery(t *testing.T) {
+	reg := registryWithTools(t, "a", "b")
+	sel := &stubToolSelector{selected: []string{"a"}}
+	s := newSelectorTestStage(reg, sel)
+	acc := &providerInput{
+		messages:     []types.Message{{Role: "system"}}, // no user message
+		allowedTools: []string{"a", "b"},
+	}
+	s.applyToolSelector(context.Background(), acc)
+	if sel.calls != 0 {
+		t.Errorf("selector should not be called without user query, got %d calls", sel.calls)
+	}
+	if len(acc.allowedTools) != 2 {
+		t.Errorf("allowedTools must be unchanged; got %v", acc.allowedTools)
+	}
+}
+
+func TestApplyToolSelector_NarrowsToSelectedSubset(t *testing.T) {
+	reg := registryWithTools(t, "alpha", "beta", "gamma")
+	sel := &stubToolSelector{selected: []string{"beta"}}
+	s := newSelectorTestStage(reg, sel)
+	acc := &providerInput{
+		messages:     userMessageOnly("about beta please"),
+		allowedTools: []string{"alpha", "beta", "gamma"},
+	}
+	s.applyToolSelector(context.Background(), acc)
+
+	if sel.calls != 1 {
+		t.Fatalf("expected 1 selector call, got %d", sel.calls)
+	}
+	if sel.lastQuery.Text != "about beta please" || sel.lastQuery.Kind != "tool" {
+		t.Errorf("query forwarded wrong: %+v", sel.lastQuery)
+	}
+	if len(sel.lastCands) != 3 {
+		t.Errorf("expected 3 candidates, got %d", len(sel.lastCands))
+	}
+	if len(acc.allowedTools) != 1 || acc.allowedTools[0] != "beta" {
+		t.Errorf("allowedTools = %v, want [beta]", acc.allowedTools)
+	}
+}
+
+func TestApplyToolSelector_PreservesSourceOrder(t *testing.T) {
+	reg := registryWithTools(t, "alpha", "beta", "gamma")
+	sel := &stubToolSelector{selected: []string{"gamma", "alpha"}} // out of source order
+	s := newSelectorTestStage(reg, sel)
+	acc := &providerInput{
+		messages:     userMessageOnly("q"),
+		allowedTools: []string{"alpha", "beta", "gamma"},
+	}
+	s.applyToolSelector(context.Background(), acc)
+	want := []string{"alpha", "gamma"}
+	if len(acc.allowedTools) != 2 || acc.allowedTools[0] != want[0] || acc.allowedTools[1] != want[1] {
+		t.Errorf("allowedTools = %v, want %v (source order preserved)", acc.allowedTools, want)
+	}
+}
+
+func TestApplyToolSelector_SelectorError_FallsBack(t *testing.T) {
+	reg := registryWithTools(t, "alpha", "beta")
+	sel := &stubToolSelector{err: errors.New("rerank down")}
+	s := newSelectorTestStage(reg, sel)
+	acc := &providerInput{
+		messages:     userMessageOnly("q"),
+		allowedTools: []string{"alpha", "beta"},
+	}
+	s.applyToolSelector(context.Background(), acc)
+	if len(acc.allowedTools) != 2 {
+		t.Errorf("error should fall back to full list; got %v", acc.allowedTools)
+	}
+}
+
+func TestApplyToolSelector_EmptyResult_FallsBack(t *testing.T) {
+	reg := registryWithTools(t, "alpha", "beta")
+	sel := &stubToolSelector{selected: nil}
+	s := newSelectorTestStage(reg, sel)
+	acc := &providerInput{
+		messages:     userMessageOnly("q"),
+		allowedTools: []string{"alpha", "beta"},
+	}
+	s.applyToolSelector(context.Background(), acc)
+	if len(acc.allowedTools) != 2 {
+		t.Errorf("empty selection should fall back; got %v", acc.allowedTools)
+	}
+}
+
+func TestApplyToolSelector_NoMatchInCandidates_FallsBack(t *testing.T) {
+	reg := registryWithTools(t, "alpha", "beta")
+	sel := &stubToolSelector{selected: []string{"ghost"}}
+	s := newSelectorTestStage(reg, sel)
+	acc := &providerInput{
+		messages:     userMessageOnly("q"),
+		allowedTools: []string{"alpha", "beta"},
+	}
+	s.applyToolSelector(context.Background(), acc)
+	if len(acc.allowedTools) != 2 {
+		t.Errorf("ID-mismatch should fall back; got %v", acc.allowedTools)
+	}
+}
+
+func TestApplyToolSelector_EmptyAllowed_NoOp(t *testing.T) {
+	reg := registryWithTools(t)
+	sel := &stubToolSelector{selected: []string{"x"}}
+	s := newSelectorTestStage(reg, sel)
+	acc := &providerInput{
+		messages:     userMessageOnly("q"),
+		allowedTools: nil,
+	}
+	s.applyToolSelector(context.Background(), acc)
+	if sel.calls != 0 {
+		t.Errorf("should not call selector with no allowed tools, got %d calls", sel.calls)
+	}
+}
+
+func TestLastUserMessageText(t *testing.T) {
+	tests := []struct {
+		name string
+		msgs []types.Message
+		want string
+	}{
+		{"empty", nil, ""},
+		{"system only", []types.Message{{Role: "system"}}, ""},
+		{"single user", userMessageOnly("hello"), "hello"},
+		{"picks last user", append(userMessageOnly("first"), userMessageOnly("second")...), "second"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lastUserMessageText(tc.msgs); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -738,6 +738,11 @@
           "$ref": "#/$defs/SkillsConfig",
           "title": "Skills",
           "description": "Runtime skill configuration"
+        },
+        "tool_selector": {
+          "type": "string",
+          "title": "ToolSelector",
+          "description": "Name of a selector declared under spec.selectors used to narrow the LLM-visible tool set per turn"
         }
       },
       "additionalProperties": false,

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -474,6 +474,7 @@ func (c *Conversation) buildPipelineConfig(
 		CompactionEnabled:     c.config.compactionEnabled,
 		CompactionStrategy:    c.config.compactionStrategy,
 		CompactionRules:       c.config.compactionRules,
+		ToolSelector:          c.config.selectors[c.config.toolSelectorName],
 	}
 
 	// Wire memory stages from MemoryCapability if present

--- a/sdk/examples/selectors/README.md
+++ b/sdk/examples/selectors/README.md
@@ -58,8 +58,12 @@ spec:
       timeout_ms: 3000
       # sandbox: sidecar     # optional — runs the script inside a k8s sidecar
   skills:
-    selector: rerank
+    selector: rerank          # narrow skill__activate's index per turn
+  tool_selector: rerank       # narrow the LLM-visible pack tools per turn
 ```
+
+(`tool_selector` is a flat field rather than nested under `tools:`
+because the existing `spec.tools` map binds exec tool implementations.)
 
 The wire protocol is:
 
@@ -90,10 +94,13 @@ without changing the script.
 - A selector returning an error or an empty result is non-fatal —
   PromptKit falls back to "include all eligible" so a misconfigured
   ranker can never break a conversation.
-- The `Query.Kind` field carries `"skill"` today and `"tool"` once the
-  M3 work lands. A single selector implementation can dispatch on
-  `kind` to serve both hook points; one binding under
-  `spec.selectors.<name>` is fine.
+- The `Query.Kind` field carries `"skill"` (set from `spec.skills.selector`)
+  or `"tool"` (set from `spec.tool_selector`). A single selector
+  implementation can dispatch on `kind` to serve both hook points;
+  one binding under `spec.selectors.<name>` is fine. Tools narrowing
+  preserves system tools (`skill__`, `a2a__`, `workflow__`, `mcp__`,
+  `memory__`) regardless of selection — those are always available
+  to the LLM.
 - Selectors are called once per `Send` (per turn). Internal caching is
   the implementation's responsibility; the cosine example is one
   reasonable shape for it.

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/selection"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/stt"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
@@ -77,6 +78,11 @@ type Config struct {
 	// CompactionEnabled controls context compaction in tool loops.
 	// nil = default (enabled), false = disabled.
 	CompactionEnabled *bool
+
+	// ToolSelector narrows the pack-declared allowedTools per turn
+	// before they're sent to the provider. Optional; when nil the
+	// provider sees the full allowedTools list (existing behavior).
+	ToolSelector selection.Selector
 
 	// CompactionStrategy replaces the default compactor entirely.
 	// Mutually exclusive with CompactionRules.
@@ -391,6 +397,7 @@ func buildProviderStages(cfg *Config) ([]stage.Stage, error) {
 			ResponseFormat:   cfg.ResponseFormat,
 			MessageLog:       cfg.MessageLog,
 			MessageLogConvID: cfg.ConversationID,
+			ToolSelector:     cfg.ToolSelector,
 		}
 		// Configure compaction strategy
 		if cfg.CompactionEnabled == nil || *cfg.CompactionEnabled {

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -177,9 +177,10 @@ type config struct {
 	skillSelector   skills.SkillSelector
 	maxActiveSkills int
 
-	// External selectors (by name) and which one narrows skills.
+	// External selectors (by name) and which one narrows skills / tools.
 	selectors          map[string]selection.Selector
 	skillsSelectorName string
+	toolSelectorName   string
 
 	// Telemetry: OTel TracerProvider for distributed tracing
 	tracerProvider trace.TracerProvider

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -201,6 +201,9 @@ func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 	if spec.Skills != nil && spec.Skills.Selector != "" {
 		c.skillsSelectorName = spec.Skills.Selector
 	}
+	if spec.ToolSelector != "" {
+		c.toolSelectorName = spec.ToolSelector
+	}
 
 	return nil
 }

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -690,6 +690,18 @@ func TestApplySelectors_UndeclaredSandbox(t *testing.T) {
 	require.Contains(t, err.Error(), "undeclared sandbox")
 }
 
+func TestApplyRuntimeConfig_ToolSelectorName(t *testing.T) {
+	spec := &pkgconfig.RuntimeConfigSpec{
+		Selectors: map[string]*pkgconfig.SelectorConfig{
+			"rerank": {Command: "/bin/true"},
+		},
+		ToolSelector: "rerank",
+	}
+	c := &config{}
+	require.NoError(t, applyRuntimeConfig(c, spec))
+	require.Equal(t, "rerank", c.toolSelectorName)
+}
+
 func TestApplyRuntimeConfig_SkillsSelectorName(t *testing.T) {
 	spec := &pkgconfig.RuntimeConfigSpec{
 		Selectors: map[string]*pkgconfig.SelectorConfig{


### PR DESCRIPTION
Closes #980. Final milestone of the external selector work — extends the Selector interface from M1 to also narrow the LLM-visible tool set per turn.

## What's new

- **`spec.tool_selector`** in RuntimeConfig — flat top-level field referencing a name in `spec.selectors`. Flat (not nested under `tools:`) because the existing `spec.tools` map already binds exec tool implementations.
- **`ProviderConfig.ToolSelector`** — passed through `sdk.WithRuntimeConfig` → pipeline `Config` → ProviderStage.
- **`ProviderStage.applyToolSelector`** — runs at the top of `executeMultiRound` and `executeStreamingMultiRound`, narrowing `acc.allowedTools` through the configured Selector. The narrowed list survives mid-loop tool-rejection rebuilds.
- **System tools always preserved** — `skill__`, `a2a__`, `workflow__`, `mcp__`, `memory__` bypass `allowedTools`, so they remain available regardless of selection.

## Fallback rules (match M1)

Nil selector, empty `allowedTools`, empty user query, selector error, empty result, or zero-overlap candidates → full eligible list. Conversations never crash because tool selection broke.

## One selector, both pools

The same Selector instance can serve both `spec.skills.selector` and `spec.tool_selector` by dispatching on `Query.Kind` (`"skill"` vs `"tool"`).

```yaml
spec:
  selectors:
    rerank:
      command: ./selectors/rerank
  skills:
    selector: rerank
  tool_selector: rerank
```

## Test plan

- [x] `go test ./pkg/config ./runtime/pipeline/stage ./sdk -count=1 -race` green
- [x] `golangci-lint run --new-from-rev=main` clean
- [x] Coverage on changed files ≥ 80% (89.3% on stages_provider.go)
- [x] Schema regenerated (`tool_selector` field added)
- [x] Examples README updated
- [ ] CI green

This closes the M1+M2+M3 sequence: PromptKit core ships zero similarity math, the Selector interface is the single externalization point for skill and tool narrowing, and consumers plug in any ranker via exec subprocess or in-process Go.