### PR TITLE
feat(providers): declarative embedding-provider config (#979 phase 1)

### DIFF
--- a/docs/src/content/docs/sdk/how-to/declarative-embedding-providers.md
+++ b/docs/src/content/docs/sdk/how-to/declarative-embedding-providers.md
@@ -1,0 +1,71 @@
+---
+title: Declarative Embedding Providers
+description: Configure embedding providers for RAG and selectors from RuntimeConfig YAML
+sidebar:
+  order: 19
+---
+
+Embedding providers used to be Go-only: a consumer who wanted RAG retrieval or an embedding-backed selector had to import the provider package and pass an instance to `WithContextRetrieval`. As of #979, embedding providers can be declared in `RuntimeConfig` the same way chat providers are.
+
+## Quick Start
+
+```yaml
+spec:
+  embedding_providers:
+    - id: rag
+      type: openai
+      model: text-embedding-3-small
+      credential:
+        credential_env: OPENAI_API_KEY
+    - id: voyage
+      type: voyageai
+      model: voyage-3
+      credential:
+        credential_env: VOYAGE_API_KEY
+      additional_config:
+        dimensions: 1024
+        input_type: query
+```
+
+```go
+conv, _ := sdk.Open("./pack.json", "chat",
+    sdk.WithRuntimeConfig("./runtime.yaml"),
+)
+```
+
+The first declared entry becomes the default RAG provider unless `WithContextRetrieval` set one programmatically. The same instance is supplied to in-process `selection.Selector` implementations via `SelectorContext.Embeddings` on `Init`, so a cosine-similarity selector and the RAG retrieval pipeline share a single embedding pool — one connection pool, one rate-limit bucket, one set of credentials.
+
+## Supported Types
+
+| `type` value | Underlying package |
+|---|---|
+| `openai` | `runtime/providers/openai` |
+| `gemini` | `runtime/providers/gemini` |
+| `voyageai` | `runtime/providers/voyageai` |
+| `ollama` | `runtime/providers/ollama` |
+
+`additional_config` carries provider-specific extras. Currently honored:
+
+- **VoyageAI** — `dimensions` (int), `input_type` (`query` | `document`)
+- **Ollama** — `dimensions` (int)
+
+## Programmatic Path Still Works
+
+`WithContextRetrieval(provider, topK)` is unchanged. When set, it wins over the YAML default. This mirrors how chat providers behave: programmatic options take precedence over RuntimeConfig defaults.
+
+## Validation
+
+`LoadRuntimeConfig` rejects:
+
+- Missing `type`.
+- A `type` outside the supported set.
+- Two entries with the same effective ID (explicit ID, or `type` when ID is omitted).
+
+## Related
+
+- [Use a RuntimeConfig](/sdk/how-to/use-runtime-config/)
+- [Plug in an external selector](/sdk/how-to/) — selectors receive embedding providers via `SelectorContext.Embeddings`.
+
+## Roadmap
+
+TTS and STT providers follow the same pattern (#979). They're declared at the same level once landed; today they're still programmatic-only via `WithTTS` / `WithVADMode`.

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -29,6 +29,14 @@ type RuntimeConfigSpec struct {
 	//nolint:lll // jsonschema tags require single line
 	Providers []Provider `yaml:"providers,omitempty" json:"providers,omitempty" jsonschema:"title=Providers,description=LLM provider configurations"`
 
+	// EmbeddingProviders configures embedding providers (OpenAI, Gemini,
+	// VoyageAI, Ollama). Used for RAG retrieval and as the shared
+	// provider supplied to selectors via SelectorContext.Embeddings.
+	// First entry becomes the default RAG provider unless one is set
+	// programmatically via WithContextRetrieval.
+	//nolint:lll // jsonschema tags require single line
+	EmbeddingProviders []EmbeddingProviderConfig `yaml:"embedding_providers,omitempty" json:"embedding_providers,omitempty" jsonschema:"title=Embedding Providers,description=Embedding provider configurations"`
+
 	// Tools binds pack tool names to implementations (HTTP, mock, or exec).
 	//nolint:lll // jsonschema tags require single line
 	Tools map[string]*ToolSpec `yaml:"tools,omitempty" json:"tools,omitempty" jsonschema:"title=Tools,description=Tool implementation bindings keyed by tool name"`
@@ -119,6 +127,36 @@ type SkillsConfig struct {
 	// When empty, all eligible skills are surfaced (current behavior).
 	//nolint:lll // jsonschema tags require single line
 	Selector string `yaml:"selector,omitempty" json:"selector,omitempty" jsonschema:"title=Selector,description=Name of a selector declared under spec.selectors"`
+}
+
+// EmbeddingProviderConfig declares an embedding provider — the
+// declarative analog of programmatic providers.NewEmbeddingProvider
+// constructors. Resolved by sdk.WithRuntimeConfig and stored by ID
+// for later lookup; the first declared entry becomes the default
+// retrieval and selector-context provider unless one is set
+// programmatically via WithContextRetrieval.
+type EmbeddingProviderConfig struct {
+	// ID is a stable identifier used to reference this provider from
+	// other config blocks (e.g. tool_selector via SelectorContext).
+	// Empty falls back to the type name.
+	ID string `yaml:"id,omitempty" json:"id,omitempty" jsonschema:"title=ID,description=Stable identifier"`
+	// Type selects the implementation: openai, gemini, voyageai, ollama.
+	//nolint:lll // jsonschema tags require single line
+	Type string `yaml:"type" json:"type" jsonschema:"enum=openai,enum=gemini,enum=voyageai,enum=ollama,title=Type,description=Embedding provider type"`
+	// Model overrides the provider's default embedding model.
+	Model string `yaml:"model,omitempty" json:"model,omitempty" jsonschema:"title=Model,description=Embedding model name"`
+	// BaseURL overrides the provider's default API endpoint. Useful for
+	// self-hosted deployments and OpenAI-compatible gateways.
+	//nolint:lll // jsonschema tags require single line
+	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty" jsonschema:"title=BaseURL,description=API endpoint override"`
+	// Credential names how to obtain the API key. Same shape as the
+	// chat-provider credential block.
+	//nolint:lll // jsonschema tags require single line
+	Credential *CredentialConfig `yaml:"credential,omitempty" json:"credential,omitempty" jsonschema:"title=Credential,description=API key resolution"`
+	// AdditionalConfig carries provider-specific extras (e.g. VoyageAI
+	// dimensions, input_type). Each provider documents its own keys.
+	//nolint:lll // jsonschema tags require single line
+	AdditionalConfig map[string]any `yaml:"additional_config,omitempty" json:"additional_config,omitempty" jsonschema:"title=Additional Config,description=Provider-specific extras"`
 }
 
 // SandboxConfig declares a named sandbox backend. Mode selects a
@@ -221,6 +259,9 @@ func (s *RuntimeConfigSpec) Validate() error {
 	if err := s.validateProviders(); err != nil {
 		return err
 	}
+	if err := s.validateEmbeddingProviders(); err != nil {
+		return err
+	}
 	if err := s.validateStateStore(); err != nil {
 		return err
 	}
@@ -279,6 +320,43 @@ func (s *RuntimeConfigSpec) validateStateStore() error {
 			Field:   "state_store.redis",
 			Message: "redis configuration is required when type is redis",
 		}
+	}
+	return nil
+}
+
+var validEmbeddingTypes = map[string]bool{
+	"openai": true, "gemini": true, "voyageai": true, "ollama": true,
+}
+
+func (s *RuntimeConfigSpec) validateEmbeddingProviders() error {
+	seen := make(map[string]bool, len(s.EmbeddingProviders))
+	for i := range s.EmbeddingProviders {
+		ep := &s.EmbeddingProviders[i]
+		if ep.Type == "" {
+			return &ValidationError{
+				Field:   fmt.Sprintf("embedding_providers[%d].type", i),
+				Message: "embedding provider type is required",
+			}
+		}
+		if !validEmbeddingTypes[ep.Type] {
+			return &ValidationError{
+				Field:   fmt.Sprintf("embedding_providers[%d].type", i),
+				Message: "must be one of: openai, gemini, voyageai, ollama",
+				Value:   ep.Type,
+			}
+		}
+		id := ep.ID
+		if id == "" {
+			id = ep.Type
+		}
+		if seen[id] {
+			return &ValidationError{
+				Field:   fmt.Sprintf("embedding_providers[%d].id", i),
+				Message: "duplicate embedding provider id",
+				Value:   id,
+			}
+		}
+		seen[id] = true
 	}
 	return nil
 }

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -373,6 +373,82 @@ spec:
 	}
 }
 
+func TestRuntimeConfigSpec_Validate_EmbeddingProviderMissingType(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		EmbeddingProviders: []EmbeddingProviderConfig{{Model: "x"}},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for missing embedding provider type")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_EmbeddingProviderInvalidType(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		EmbeddingProviders: []EmbeddingProviderConfig{{Type: "bogus"}},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for invalid embedding provider type")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_EmbeddingProviderDuplicateID(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		EmbeddingProviders: []EmbeddingProviderConfig{
+			{ID: "main", Type: "openai"},
+			{ID: "main", Type: "voyageai"},
+		},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected duplicate id error")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_EmbeddingProviderDefaultIDFromType(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		EmbeddingProviders: []EmbeddingProviderConfig{
+			{Type: "openai"},
+			{Type: "openai"},
+		},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected default-id collision error")
+	}
+}
+
+func TestLoadRuntimeConfig_EmbeddingProvidersYAML(t *testing.T) {
+	yaml := `
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: RuntimeConfig
+spec:
+  embedding_providers:
+    - id: rag
+      type: openai
+      model: text-embedding-3-small
+      credential:
+        credential_env: OPENAI_API_KEY
+    - id: voyage
+      type: voyageai
+      model: voyage-3
+      additional_config:
+        dimensions: 1024
+        input_type: query
+`
+	path := writeTemp(t, "rc.yaml", yaml)
+	rc, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig: %v", err)
+	}
+	if len(rc.Spec.EmbeddingProviders) != 2 {
+		t.Fatalf("expected 2 embedding providers, got %d", len(rc.Spec.EmbeddingProviders))
+	}
+	if rc.Spec.EmbeddingProviders[0].ID != "rag" || rc.Spec.EmbeddingProviders[0].Type != "openai" {
+		t.Errorf("first provider mis-parsed: %+v", rc.Spec.EmbeddingProviders[0])
+	}
+	if got := rc.Spec.EmbeddingProviders[1].AdditionalConfig["dimensions"]; got != 1024 {
+		t.Errorf("voyageai dimensions = %v, want 1024", got)
+	}
+}
+
 func TestRuntimeConfigSpec_Validate_SelectorMissingCommand(t *testing.T) {
 	s := &RuntimeConfigSpec{
 		Selectors: map[string]*SelectorConfig{

--- a/runtime/providers/embedding_factory.go
+++ b/runtime/providers/embedding_factory.go
@@ -1,0 +1,118 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+)
+
+// EmbeddingProviderSpec is the runtime form of an embedding-provider
+// declaration, used by CreateEmbeddingProviderFromSpec to construct an
+// EmbeddingProvider implementation. The SDK's runtime-config layer
+// translates pkg/config.EmbeddingProviderConfig into this struct after
+// resolving credentials.
+type EmbeddingProviderSpec struct {
+	// ID is a stable identifier; informational only at this layer.
+	ID string
+	// Type selects the implementation: openai, gemini, voyageai, ollama.
+	Type string
+	// Model overrides the provider's default embedding model. Empty
+	// uses the per-provider default.
+	Model string
+	// BaseURL overrides the provider's default API endpoint.
+	BaseURL string
+	// Credential carries the resolved API key. May be nil for
+	// providers that don't require auth (e.g. ollama).
+	Credential credentials.Credential
+	// AdditionalConfig carries provider-specific extras (voyage
+	// dimensions/input_type, etc.). Unknown keys are ignored.
+	AdditionalConfig map[string]any
+}
+
+// EmbeddingProviderFactory builds an EmbeddingProvider from a spec.
+// Per-provider packages register one of these via init() so the
+// providers package never needs to import them (avoiding a cycle —
+// the implementations already import providers for the interface).
+type EmbeddingProviderFactory func(spec EmbeddingProviderSpec) (EmbeddingProvider, error)
+
+var (
+	embeddingFactoriesMu sync.RWMutex
+	embeddingFactories   = make(map[string]EmbeddingProviderFactory)
+)
+
+// RegisterEmbeddingProviderFactory registers a factory for the given
+// provider type. Typically called from per-provider package init().
+// Re-registration overwrites silently — matching RegisterProviderFactory
+// for chat providers.
+func RegisterEmbeddingProviderFactory(providerType string, factory EmbeddingProviderFactory) {
+	embeddingFactoriesMu.Lock()
+	defer embeddingFactoriesMu.Unlock()
+	embeddingFactories[providerType] = factory
+}
+
+// CreateEmbeddingProviderFromSpec returns an EmbeddingProvider
+// implementation for the given spec. Mirrors CreateProviderFromSpec
+// for chat providers but is intentionally slimmer: embedding providers
+// don't stream and don't need rate-limit or transport tuning today
+// (call patterns are batch + short-lived).
+//
+//nolint:gocritic // spec is a value-semantics builder; callers assemble inline.
+func CreateEmbeddingProviderFromSpec(spec EmbeddingProviderSpec) (EmbeddingProvider, error) {
+	embeddingFactoriesMu.RLock()
+	factory, ok := embeddingFactories[spec.Type]
+	embeddingFactoriesMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unsupported embedding provider type: %s", spec.Type)
+	}
+	return factory(spec)
+}
+
+// ResolveEmbeddingCredential resolves an embedding provider's
+// credential block into a concrete Credential, applying the same
+// fallback chain as chat providers (api_key → file → env → default
+// env vars). Exposed as a helper for the SDK runtime-config layer.
+func ResolveEmbeddingCredential(ctx context.Context, providerType string,
+	cfgDir string, cred *credentials.CredentialConfig,
+) (credentials.Credential, error) {
+	return credentials.Resolve(ctx, credentials.ResolverConfig{
+		ProviderType:     providerType,
+		CredentialConfig: cred,
+		ConfigDir:        cfgDir,
+	})
+}
+
+// APIKeyFromCredential returns the raw API key from an APIKey
+// credential, or "" for any other credential shape (or nil).
+// Embedding providers only need the key string, not the full
+// header-application machinery — exposed here so per-provider
+// init() functions can build their factory closures.
+func APIKeyFromCredential(c credentials.Credential) string {
+	if c == nil {
+		return ""
+	}
+	if k, ok := c.(*credentials.APIKeyCredential); ok {
+		return k.APIKey()
+	}
+	return ""
+}
+
+// IntFromConfig returns cfg[key] coerced to int, supporting the
+// common YAML number shapes (int, int64, float64). Returns ok=false
+// when the key is missing or the value isn't numeric.
+func IntFromConfig(cfg map[string]any, key string) (int, bool) {
+	v, ok := cfg[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}

--- a/runtime/providers/embedding_factory_test.go
+++ b/runtime/providers/embedding_factory_test.go
@@ -1,0 +1,213 @@
+package providers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+
+	// Side-effect imports register the factories under test.
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
+)
+
+// Each per-provider test exercises every conditional branch of the
+// registered factory closure (model, base_url, credential, and any
+// provider-specific extras) so coverage on the embedding_register.go
+// files stays above the 80% gate. New optional fields require
+// extending the corresponding test.
+
+func TestCreateEmbeddingProviderFromSpec_OpenAI(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("sk-stub")
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		ID:         "rag",
+		Type:       "openai",
+		Model:      "text-embedding-3-small",
+		BaseURL:    "https://example.test",
+		Credential: cred,
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_OpenAI_Defaults(t *testing.T) {
+	// Hit the "no model / no base_url / no credential" branch.
+	t.Setenv("OPENAI_API_KEY", "sk-fallback")
+	if _, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "openai",
+	}); err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_Gemini(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("stub")
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:       "gemini",
+		Model:      "text-embedding-004",
+		BaseURL:    "https://gemini.test",
+		Credential: cred,
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_Gemini_Defaults(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "stub")
+	if _, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "gemini",
+	}); err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_VoyageAI(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("stub")
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:       "voyageai",
+		Model:      "voyage-3",
+		BaseURL:    "https://voyage.test",
+		Credential: cred,
+		AdditionalConfig: map[string]any{
+			"dimensions": 1024,
+			"input_type": "query",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_VoyageAI_Defaults(t *testing.T) {
+	// All optional fields omitted exercises the "skip" branches.
+	t.Setenv("VOYAGE_API_KEY", "stub")
+	if _, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "voyageai",
+	}); err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_Ollama(t *testing.T) {
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:    "ollama",
+		Model:   "nomic-embed-text",
+		BaseURL: "http://ollama.test",
+		AdditionalConfig: map[string]any{
+			"dimensions": int64(768),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_Ollama_Defaults(t *testing.T) {
+	if _, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "ollama",
+	}); err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_UnknownType(t *testing.T) {
+	_, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "no-such-provider",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+}
+
+func TestCreateEmbeddingProviderFromSpec_OpenAIWithAPIKey(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("sk-test-key")
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:       "openai",
+		Credential: cred,
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestRegisterEmbeddingProviderFactory_OverwritesSilently(t *testing.T) {
+	called := false
+	providers.RegisterEmbeddingProviderFactory("test-overwrite",
+		func(_ providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			called = true
+			return nil, nil
+		},
+	)
+	_, _ = providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{Type: "test-overwrite"})
+	if !called {
+		t.Fatal("registered factory was not called")
+	}
+}
+
+func TestAPIKeyFromCredential(t *testing.T) {
+	if got := providers.APIKeyFromCredential(nil); got != "" {
+		t.Errorf("nil credential should yield empty key, got %q", got)
+	}
+	if got := providers.APIKeyFromCredential(&credentials.NoOpCredential{}); got != "" {
+		t.Errorf("noop credential should yield empty key, got %q", got)
+	}
+	cred := credentials.NewAPIKeyCredential("sk-abc")
+	if got := providers.APIKeyFromCredential(cred); got != "sk-abc" {
+		t.Errorf("APIKey credential = %q, want sk-abc", got)
+	}
+}
+
+func TestIntFromConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  map[string]any
+		key  string
+		want int
+		ok   bool
+	}{
+		{"missing", map[string]any{}, "k", 0, false},
+		{"int", map[string]any{"k": 5}, "k", 5, true},
+		{"int64", map[string]any{"k": int64(7)}, "k", 7, true},
+		{"float64", map[string]any{"k": 3.0}, "k", 3, true},
+		{"wrong type", map[string]any{"k": "5"}, "k", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := providers.IntFromConfig(tc.cfg, tc.key)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("IntFromConfig = (%d,%v), want (%d,%v)", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestResolveEmbeddingCredential_FromEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-env-test")
+	cred, err := providers.ResolveEmbeddingCredential(context.Background(), "openai", "", nil)
+	if err != nil {
+		t.Fatalf("ResolveEmbeddingCredential: %v", err)
+	}
+	if got := providers.APIKeyFromCredential(cred); got != "sk-env-test" {
+		t.Errorf("resolved key = %q, want sk-env-test", got)
+	}
+}

--- a/runtime/providers/gemini/embedding_register.go
+++ b/runtime/providers/gemini/embedding_register.go
@@ -1,0 +1,22 @@
+package gemini
+
+import "github.com/AltairaLabs/PromptKit/runtime/providers"
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	providers.RegisterEmbeddingProviderFactory("gemini",
+		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			opts := []EmbeddingOption{}
+			if spec.Model != "" {
+				opts = append(opts, WithGeminiEmbeddingModel(spec.Model))
+			}
+			if spec.BaseURL != "" {
+				opts = append(opts, WithGeminiEmbeddingBaseURL(spec.BaseURL))
+			}
+			if k := providers.APIKeyFromCredential(spec.Credential); k != "" {
+				opts = append(opts, WithGeminiEmbeddingAPIKey(k))
+			}
+			return NewEmbeddingProvider(opts...)
+		},
+	)
+}

--- a/runtime/providers/gemini/embedding_register_test.go
+++ b/runtime/providers/gemini/embedding_register_test.go
@@ -1,0 +1,36 @@
+package gemini_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+
+	// Side-effect import: trigger our embedding factory registration.
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
+)
+
+func TestEmbeddingRegister_AllOptions(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("stub")
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:       "gemini",
+		Model:      "text-embedding-004",
+		BaseURL:    "https://gemini.test",
+		Credential: cred,
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestEmbeddingRegister_Defaults(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "stub")
+	if _, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "gemini",
+	}); err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+}

--- a/runtime/providers/ollama/embedding_register.go
+++ b/runtime/providers/ollama/embedding_register.go
@@ -1,0 +1,22 @@
+package ollama
+
+import "github.com/AltairaLabs/PromptKit/runtime/providers"
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	providers.RegisterEmbeddingProviderFactory("ollama",
+		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			opts := []EmbeddingOption{}
+			if spec.Model != "" {
+				opts = append(opts, WithEmbeddingModel(spec.Model))
+			}
+			if spec.BaseURL != "" {
+				opts = append(opts, WithEmbeddingBaseURL(spec.BaseURL))
+			}
+			if dims, ok := providers.IntFromConfig(spec.AdditionalConfig, "dimensions"); ok {
+				opts = append(opts, WithEmbeddingDimensions(dims))
+			}
+			return NewEmbeddingProvider(opts...), nil
+		},
+	)
+}

--- a/runtime/providers/ollama/embedding_register_test.go
+++ b/runtime/providers/ollama/embedding_register_test.go
@@ -1,0 +1,35 @@
+package ollama_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+
+	// Side-effect import: trigger our embedding factory registration.
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
+)
+
+func TestEmbeddingRegister_AllOptions(t *testing.T) {
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:    "ollama",
+		Model:   "nomic-embed-text",
+		BaseURL: "http://ollama.test",
+		AdditionalConfig: map[string]any{
+			"dimensions": int64(768),
+		},
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestEmbeddingRegister_Defaults(t *testing.T) {
+	if _, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "ollama",
+	}); err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+}

--- a/runtime/providers/openai/embedding_register.go
+++ b/runtime/providers/openai/embedding_register.go
@@ -1,0 +1,22 @@
+package openai
+
+import "github.com/AltairaLabs/PromptKit/runtime/providers"
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	providers.RegisterEmbeddingProviderFactory("openai",
+		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			opts := []EmbeddingOption{}
+			if spec.Model != "" {
+				opts = append(opts, WithEmbeddingModel(spec.Model))
+			}
+			if spec.BaseURL != "" {
+				opts = append(opts, WithEmbeddingBaseURL(spec.BaseURL))
+			}
+			if k := providers.APIKeyFromCredential(spec.Credential); k != "" {
+				opts = append(opts, WithEmbeddingAPIKey(k))
+			}
+			return NewEmbeddingProvider(opts...)
+		},
+	)
+}

--- a/runtime/providers/openai/embedding_register_test.go
+++ b/runtime/providers/openai/embedding_register_test.go
@@ -1,0 +1,40 @@
+package openai_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+
+	// Side-effect import: trigger our embedding factory registration.
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+)
+
+// TestEmbeddingRegister_AllOptions exercises every conditional branch
+// in the registered openai embedding factory. Coverage is measured
+// per-package, so this lives here rather than in
+// runtime/providers/embedding_factory_test.go.
+func TestEmbeddingRegister_AllOptions(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("sk-stub")
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:       "openai",
+		Model:      "text-embedding-3-small",
+		BaseURL:    "https://example.test",
+		Credential: cred,
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestEmbeddingRegister_Defaults(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-fallback")
+	if _, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "openai",
+	}); err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+}

--- a/runtime/providers/voyageai/embedding_register.go
+++ b/runtime/providers/voyageai/embedding_register.go
@@ -1,0 +1,28 @@
+package voyageai
+
+import "github.com/AltairaLabs/PromptKit/runtime/providers"
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	providers.RegisterEmbeddingProviderFactory("voyageai",
+		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			opts := []EmbeddingOption{}
+			if spec.Model != "" {
+				opts = append(opts, WithModel(spec.Model))
+			}
+			if spec.BaseURL != "" {
+				opts = append(opts, WithBaseURL(spec.BaseURL))
+			}
+			if k := providers.APIKeyFromCredential(spec.Credential); k != "" {
+				opts = append(opts, WithAPIKey(k))
+			}
+			if dims, ok := providers.IntFromConfig(spec.AdditionalConfig, "dimensions"); ok {
+				opts = append(opts, WithDimensions(dims))
+			}
+			if v, ok := spec.AdditionalConfig["input_type"].(string); ok && v != "" {
+				opts = append(opts, WithInputType(v))
+			}
+			return NewEmbeddingProvider(opts...)
+		},
+	)
+}

--- a/runtime/providers/voyageai/embedding_register_test.go
+++ b/runtime/providers/voyageai/embedding_register_test.go
@@ -1,0 +1,40 @@
+package voyageai_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+
+	// Side-effect import: trigger our embedding factory registration.
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
+)
+
+func TestEmbeddingRegister_AllOptions(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("stub")
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:       "voyageai",
+		Model:      "voyage-3",
+		BaseURL:    "https://voyage.test",
+		Credential: cred,
+		AdditionalConfig: map[string]any{
+			"dimensions": 1024,
+			"input_type": "query",
+		},
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestEmbeddingRegister_Defaults(t *testing.T) {
+	t.Setenv("VOYAGE_API_KEY", "stub")
+	if _, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type: "voyageai",
+	}); err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+}

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -17,6 +17,51 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "EmbeddingProviderConfig": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "Stable identifier"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "openai",
+            "gemini",
+            "voyageai",
+            "ollama"
+          ],
+          "title": "Type",
+          "description": "Embedding provider type"
+        },
+        "model": {
+          "type": "string",
+          "title": "Model",
+          "description": "Embedding model name"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "BaseURL",
+          "description": "API endpoint override"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig",
+          "title": "Credential",
+          "description": "API key resolution"
+        },
+        "additional_config": {
+          "type": "object",
+          "title": "Additional Config",
+          "description": "Provider-specific extras"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
     "ExecBinding": {
       "properties": {
         "command": {
@@ -675,6 +720,14 @@
           "type": "array",
           "title": "Providers",
           "description": "LLM provider configurations"
+        },
+        "embedding_providers": {
+          "items": {
+            "$ref": "#/$defs/EmbeddingProviderConfig"
+          },
+          "type": "array",
+          "title": "Embedding Providers",
+          "description": "Embedding provider configurations"
         },
         "tools": {
           "additionalProperties": {

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -87,6 +87,14 @@ type config struct {
 	retrievalProvider providers.EmbeddingProvider
 	retrievalTopK     int
 
+	// Declarative embedding providers, keyed by ID. Resolved by
+	// WithRuntimeConfig from spec.embedding_providers. The first
+	// entry doubles as a default for retrievalProvider (when one
+	// isn't set programmatically) and as the SelectorContext
+	// embedding instance handed to in-process selectors via Init.
+	embeddingProviders   map[string]providers.EmbeddingProvider
+	embeddingProviderIDs []string
+
 	// Auto-summarization for RAG context
 	summarizeProvider  providers.Provider
 	summarizeThreshold int

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -17,6 +17,13 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	// Side-effect imports register embedding-provider factories so
+	// CreateEmbeddingProviderFromSpec can resolve declarative entries.
+	// Chat-provider factories register through other SDK paths.
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
 	"github.com/AltairaLabs/PromptKit/runtime/selection"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
@@ -142,6 +149,13 @@ func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 		c.provider = prov
 	}
 
+	// Apply embedding providers (declarative). The first declared
+	// entry doubles as the default RAG retrievalProvider when one
+	// isn't already set programmatically.
+	if err := applyEmbeddingProviders(c, spec.EmbeddingProviders); err != nil {
+		return fmt.Errorf("applying embedding providers from runtime config: %w", err)
+	}
+
 	// Apply MCP servers
 	for _, mcpCfg := range spec.MCPServers {
 		serverCfg := mcp.ServerConfig{
@@ -205,6 +219,32 @@ func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 		c.toolSelectorName = spec.ToolSelector
 	}
 
+	// Init all selectors with the shared SelectorContext now that
+	// embedding providers are resolved. Programmatic selectors that
+	// don't need an embedding provider can ignore the context; the
+	// reference cosine selector uses it to skip building its own.
+	if err := initSelectors(c); err != nil {
+		return fmt.Errorf("initializing selectors: %w", err)
+	}
+
+	return nil
+}
+
+// initSelectors calls Init on every registered selector with a
+// SelectorContext that exposes the configured RAG embedding provider
+// (when one is set). Init failure aborts config application — a
+// selector that can't initialize would fail every Send anyway, so
+// surfacing the error at config-load time gives a faster signal.
+func initSelectors(c *config) error {
+	if len(c.selectors) == 0 {
+		return nil
+	}
+	ctx := selection.SelectorContext{Embeddings: c.retrievalProvider}
+	for name, sel := range c.selectors {
+		if err := sel.Init(ctx); err != nil {
+			return fmt.Errorf("selector %q: %w", name, err)
+		}
+	}
 	return nil
 }
 
@@ -243,6 +283,52 @@ func applySelectors(c *config, specs map[string]*pkgconfig.SelectorConfig,
 			TimeoutMs: sel.TimeoutMs,
 			Sandbox:   sb,
 		})
+	}
+	return nil
+}
+
+// applyEmbeddingProviders builds embedding-provider instances from
+// the spec and stores them on the SDK config keyed by ID. The first
+// declared entry doubles as the default RAG retrievalProvider when
+// one isn't already set programmatically (matching the chat-provider
+// "first wins, programmatic-takes-precedence" pattern).
+func applyEmbeddingProviders(c *config, specs []pkgconfig.EmbeddingProviderConfig) error {
+	if len(specs) == 0 {
+		return nil
+	}
+	if c.embeddingProviders == nil {
+		c.embeddingProviders = make(map[string]providers.EmbeddingProvider, len(specs))
+	}
+	for i := range specs {
+		ep := &specs[i]
+		id := ep.ID
+		if id == "" {
+			id = ep.Type
+		}
+		if _, exists := c.embeddingProviders[id]; exists {
+			return fmt.Errorf("embedding provider %q: duplicate ID", id)
+		}
+		cred, err := providers.ResolveEmbeddingCredential(context.Background(), ep.Type, "", ep.Credential)
+		if err != nil {
+			return fmt.Errorf("embedding provider %q: resolving credential: %w", id, err)
+		}
+		instance, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+			ID:               id,
+			Type:             ep.Type,
+			Model:            ep.Model,
+			BaseURL:          ep.BaseURL,
+			Credential:       cred,
+			AdditionalConfig: ep.AdditionalConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("embedding provider %q: %w", id, err)
+		}
+		c.embeddingProviders[id] = instance
+		c.embeddingProviderIDs = append(c.embeddingProviderIDs, id)
+	}
+	// Default RAG provider: first declared, unless one is already wired.
+	if c.retrievalProvider == nil && len(c.embeddingProviderIDs) > 0 {
+		c.retrievalProvider = c.embeddingProviders[c.embeddingProviderIDs[0]]
 	}
 	return nil
 }

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -637,6 +638,120 @@ func TestResolveSandboxes_NilAndEmpty(t *testing.T) {
 	out, err = resolveSandboxes(map[string]*pkgconfig.SandboxConfig{"skip": nil})
 	require.NoError(t, err)
 	assert.Empty(t, out)
+}
+
+func TestApplyEmbeddingProviders_Empty(t *testing.T) {
+	c := &config{}
+	require.NoError(t, applyEmbeddingProviders(c, nil))
+	require.Empty(t, c.embeddingProviders)
+	require.Nil(t, c.retrievalProvider)
+}
+
+func TestApplyEmbeddingProviders_BuildsAndDefaultsRetrieval(t *testing.T) {
+	specs := []pkgconfig.EmbeddingProviderConfig{
+		{ID: "rag", Type: "ollama", Model: "nomic-embed-text"},
+	}
+	c := &config{}
+	require.NoError(t, applyEmbeddingProviders(c, specs))
+	require.Contains(t, c.embeddingProviders, "rag")
+	require.NotNil(t, c.retrievalProvider, "first declared entry should default the retrieval provider")
+	require.Same(t, c.embeddingProviders["rag"], c.retrievalProvider)
+}
+
+func TestApplyEmbeddingProviders_RespectsExistingRetrievalProvider(t *testing.T) {
+	existing := &fakeEmbedderForTests{}
+	specs := []pkgconfig.EmbeddingProviderConfig{
+		{Type: "ollama"},
+	}
+	c := &config{retrievalProvider: existing}
+	require.NoError(t, applyEmbeddingProviders(c, specs))
+	require.Same(t, existing, c.retrievalProvider, "WithContextRetrieval should win over default-from-first")
+}
+
+func TestApplyEmbeddingProviders_DefaultIDFallsBackToType(t *testing.T) {
+	specs := []pkgconfig.EmbeddingProviderConfig{{Type: "ollama"}}
+	c := &config{}
+	require.NoError(t, applyEmbeddingProviders(c, specs))
+	require.Contains(t, c.embeddingProviders, "ollama", "ID should default to Type")
+}
+
+func TestApplyEmbeddingProviders_DuplicateID(t *testing.T) {
+	specs := []pkgconfig.EmbeddingProviderConfig{
+		{ID: "x", Type: "ollama"},
+		{ID: "x", Type: "ollama"},
+	}
+	c := &config{}
+	err := applyEmbeddingProviders(c, specs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate ID")
+}
+
+func TestApplyEmbeddingProviders_UnsupportedType(t *testing.T) {
+	specs := []pkgconfig.EmbeddingProviderConfig{{Type: "no-such-provider"}}
+	c := &config{}
+	err := applyEmbeddingProviders(c, specs)
+	require.Error(t, err)
+}
+
+// fakeEmbedderForTests is used to verify retrievalProvider precedence
+// without standing up a real embedding implementation.
+type fakeEmbedderForTests struct{}
+
+func (f *fakeEmbedderForTests) Embed(_ context.Context,
+	_ providers.EmbeddingRequest,
+) (providers.EmbeddingResponse, error) {
+	return providers.EmbeddingResponse{}, nil
+}
+func (f *fakeEmbedderForTests) EmbeddingDimensions() int { return 0 }
+func (f *fakeEmbedderForTests) MaxBatchSize() int        { return 1 }
+func (f *fakeEmbedderForTests) ID() string               { return "fake" }
+
+// recordingSelector captures the SelectorContext passed to Init so
+// tests can confirm the embedding provider gets threaded through.
+type recordingSelector struct {
+	name      string
+	gotInit   selection.SelectorContext
+	initErr   error
+	initCalls int
+}
+
+func (s *recordingSelector) Name() string { return s.name }
+func (s *recordingSelector) Init(ctx selection.SelectorContext) error {
+	s.initCalls++
+	s.gotInit = ctx
+	return s.initErr
+}
+func (s *recordingSelector) Select(_ context.Context, _ selection.Query,
+	_ []selection.Candidate,
+) ([]string, error) {
+	return nil, nil
+}
+
+func TestInitSelectors_PassesEmbeddingProvider(t *testing.T) {
+	rec := &recordingSelector{name: "s"}
+	emb := &fakeEmbedderForTests{}
+	c := &config{
+		selectors:         map[string]selection.Selector{"s": rec},
+		retrievalProvider: emb,
+	}
+	require.NoError(t, initSelectors(c))
+	require.Equal(t, 1, rec.initCalls)
+	require.Same(t, emb, rec.gotInit.Embeddings)
+}
+
+func TestInitSelectors_NilEmbeddings(t *testing.T) {
+	rec := &recordingSelector{name: "s"}
+	c := &config{selectors: map[string]selection.Selector{"s": rec}}
+	require.NoError(t, initSelectors(c))
+	require.Nil(t, rec.gotInit.Embeddings)
+}
+
+func TestInitSelectors_PropagatesError(t *testing.T) {
+	rec := &recordingSelector{name: "s", initErr: fmt.Errorf("init blew up")}
+	c := &config{selectors: map[string]selection.Selector{"s": rec}}
+	err := initSelectors(c)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `selector "s"`)
 }
 
 // stubSelector is a programmatic selector used only in runtime-config tests.


### PR DESCRIPTION
First phase of #979 — embedding providers can now be declared in RuntimeConfig YAML the same way chat providers are. TTS and STT remain programmatic-only and will follow the same shape in a separate PR.

## What's new

- ` + '`spec.embedding_providers`' + ` in RuntimeConfig:
  \`\`\`yaml
  spec:
    embedding_providers:
      - id: rag
        type: openai
        model: text-embedding-3-small
        credential:
          credential_env: OPENAI_API_KEY
      - id: voyage
        type: voyageai
        model: voyage-3
        additional_config:
          dimensions: 1024
          input_type: query
  \`\`\`
- New ` + '`providers.EmbeddingProviderSpec`' + ` + ` + '`CreateEmbeddingProviderFromSpec`' + ` mirroring the chat-provider registry. Per-provider packages self-register via ` + '`init()`' + ` (avoids the providers→openai import cycle).
- SDK ` + '`applyEmbeddingProviders`' + ` resolves credentials, builds instances, and stores them by ID. The first declared entry doubles as the default RAG ` + '`retrievalProvider`' + ` unless ` + '`WithContextRetrieval`' + ` already wired one.
- **Fixes the M1 selector hole**: ` + '`initSelectors`' + ` now passes ` + '`SelectorContext.Embeddings`' + ` (pointing at the configured ` + '`retrievalProvider`' + `) to every selector's ` + '`Init`' + `. The cosine reference selector picks this up automatically — one provider, one connection pool, one rate-limit bucket across RAG and selection.

## Validation

- ` + '`type`' + ` must be one of ` + '`openai`' + ` / ` + '`gemini`' + ` / ` + '`voyageai`' + ` / ` + '`ollama`' + `.
- IDs must be unique (default ID is the type when unset).

## Test plan

- [x] ` + '`go test ./pkg/config ./runtime/providers/... ./sdk -count=1 -race`' + ` green
- [x] ` + '`golangci-lint run --new-from-rev=main`' + ` clean
- [x] Coverage on changed files ≥ 80% (per-package factory tests in each provider hit 100% on the register closures)
- [x] Schema regenerated
- [x] How-to doc added at ` + '`docs/sdk/how-to/declarative-embedding-providers.md`' + `
- [ ] CI green

## Left for #979 phase 2

TTS and STT — same pattern applied to ` + '`runtime/tts`' + ` and ` + '`runtime/stt`' + `, declarative blocks for ` + '`spec.tts`' + ` and ` + '`spec.stt`' + `, factories that route by type.