### PR TITLE
feat(providers): declarative TTS + STT provider config (#979 phase 2)

### DIFF
--- a/docs/src/content/docs/sdk/how-to/declarative-tts-stt-providers.md
+++ b/docs/src/content/docs/sdk/how-to/declarative-tts-stt-providers.md
@@ -1,0 +1,89 @@
+---
+title: Declarative TTS / STT Providers
+description: Configure speech synthesis and transcription providers from RuntimeConfig YAML
+sidebar:
+  order: 20
+---
+
+The chat-provider and embedding-provider declarative pattern (#979) extends to text-to-speech and speech-to-text. Voice-mode applications no longer need to hard-code provider construction in Go.
+
+## Quick Start
+
+```yaml
+spec:
+  tts_providers:
+    - id: voice
+      type: elevenlabs
+      model: eleven_turbo_v2
+      credential:
+        credential_env: ELEVEN_API_KEY
+    - id: cart
+      type: cartesia
+      credential:
+        credential_env: CARTESIA_API_KEY
+      additional_config:
+        ws_url: wss://api.cartesia.ai/tts/websocket
+
+  stt_providers:
+    - id: whisper
+      type: openai
+      model: whisper-1
+      credential:
+        credential_env: OPENAI_API_KEY
+```
+
+```go
+conv, _ := sdk.Open("./pack.json", "chat",
+    sdk.WithRuntimeConfig("./runtime.yaml"),
+)
+```
+
+The first declared TTS entry becomes the default `ttsService` unless `WithTTS` (or `WithVADMode`) wired one programmatically. Same for STT and `sttService`.
+
+## Supported Types
+
+| Block | `type` value | Underlying package |
+|---|---|---|
+| `tts_providers` | `openai` | `runtime/tts` (OpenAI TTS) |
+| `tts_providers` | `elevenlabs` | `runtime/tts` (ElevenLabs) |
+| `tts_providers` | `cartesia` | `runtime/tts` (Cartesia) |
+| `stt_providers` | `openai` | `runtime/stt` (OpenAI Whisper) |
+
+`additional_config` honored extras:
+
+- **Cartesia** — `ws_url` (string) for the websocket streaming endpoint.
+
+## Programmatic Path Still Works
+
+`WithTTS(service)` and `WithVADMode(stt, tts, ...)` are unchanged. When set, they win over the YAML default — same precedence rule as chat and embedding providers.
+
+## Validation
+
+`LoadRuntimeConfig` rejects:
+
+- Missing `type`.
+- A `type` outside the supported set.
+- Two entries with the same effective ID (explicit ID, or `type` when ID is omitted).
+
+## Adding a New Provider
+
+The factory pattern is open: a per-provider package can self-register via `init()`:
+
+```go
+package mytts
+
+import "github.com/AltairaLabs/PromptKit/runtime/tts"
+
+func init() {
+    tts.RegisterFactory("my_tts", func(spec tts.ProviderSpec) (tts.Service, error) {
+        return NewMyTTS(spec.Model, tts.APIKeyFromCredential(spec.Credential)), nil
+    })
+}
+```
+
+Side-effect-import the package from your application and the new `type:` value works in YAML immediately.
+
+## Related
+
+- [Declarative Embedding Providers](/sdk/how-to/declarative-embedding-providers/)
+- [Use a RuntimeConfig](/sdk/how-to/use-runtime-config/)

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -37,6 +37,19 @@ type RuntimeConfigSpec struct {
 	//nolint:lll // jsonschema tags require single line
 	EmbeddingProviders []EmbeddingProviderConfig `yaml:"embedding_providers,omitempty" json:"embedding_providers,omitempty" jsonschema:"title=Embedding Providers,description=Embedding provider configurations"`
 
+	// TTSProviders configures text-to-speech providers (OpenAI,
+	// ElevenLabs, Cartesia). First entry becomes the default TTS
+	// service unless one is set programmatically via WithTTS or
+	// WithVADMode.
+	//nolint:lll // jsonschema tags require single line
+	TTSProviders []TTSProviderConfig `yaml:"tts_providers,omitempty" json:"tts_providers,omitempty" jsonschema:"title=TTS Providers,description=Text-to-speech provider configurations"`
+
+	// STTProviders configures speech-to-text providers (OpenAI). First
+	// entry becomes the default STT service unless one is set
+	// programmatically via WithVADMode.
+	//nolint:lll // jsonschema tags require single line
+	STTProviders []STTProviderConfig `yaml:"stt_providers,omitempty" json:"stt_providers,omitempty" jsonschema:"title=STT Providers,description=Speech-to-text provider configurations"`
+
 	// Tools binds pack tool names to implementations (HTTP, mock, or exec).
 	//nolint:lll // jsonschema tags require single line
 	Tools map[string]*ToolSpec `yaml:"tools,omitempty" json:"tools,omitempty" jsonschema:"title=Tools,description=Tool implementation bindings keyed by tool name"`
@@ -159,6 +172,52 @@ type EmbeddingProviderConfig struct {
 	AdditionalConfig map[string]any `yaml:"additional_config,omitempty" json:"additional_config,omitempty" jsonschema:"title=Additional Config,description=Provider-specific extras"`
 }
 
+// TTSProviderConfig declares a text-to-speech provider — the
+// declarative analog of programmatic tts.NewOpenAI / NewElevenLabs /
+// NewCartesia constructors. Resolved by sdk.WithRuntimeConfig.
+type TTSProviderConfig struct {
+	// ID is a stable identifier; defaults to the type when empty.
+	ID string `yaml:"id,omitempty" json:"id,omitempty" jsonschema:"title=ID,description=Stable identifier"`
+	// Type selects the implementation: openai, elevenlabs, cartesia.
+	//nolint:lll // jsonschema tags require single line
+	Type string `yaml:"type" json:"type" jsonschema:"enum=openai,enum=elevenlabs,enum=cartesia,title=Type,description=TTS provider type"`
+	// Model overrides the provider's default voice/model.
+	Model string `yaml:"model,omitempty" json:"model,omitempty" jsonschema:"title=Model,description=Voice or model name"`
+	// BaseURL overrides the provider's default API endpoint.
+	//nolint:lll // jsonschema tags require single line
+	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty" jsonschema:"title=BaseURL,description=API endpoint override"`
+	// Credential names how to obtain the API key.
+	//nolint:lll // jsonschema tags require single line
+	Credential *CredentialConfig `yaml:"credential,omitempty" json:"credential,omitempty" jsonschema:"title=Credential,description=API key resolution"`
+	// AdditionalConfig carries provider-specific extras (Cartesia
+	// `ws_url`, etc.).
+	//nolint:lll // jsonschema tags require single line
+	AdditionalConfig map[string]any `yaml:"additional_config,omitempty" json:"additional_config,omitempty" jsonschema:"title=Additional Config,description=Provider-specific extras"`
+}
+
+// STTProviderConfig declares a speech-to-text provider — the
+// declarative analog of programmatic stt.NewOpenAI constructors.
+// Today only "openai" is supported; more types slot in via the
+// stt.RegisterSTTFactory pattern.
+type STTProviderConfig struct {
+	// ID is a stable identifier; defaults to the type when empty.
+	ID string `yaml:"id,omitempty" json:"id,omitempty" jsonschema:"title=ID,description=Stable identifier"`
+	// Type selects the implementation. Today only "openai".
+	Type string `yaml:"type" json:"type" jsonschema:"enum=openai,title=Type,description=STT provider type"`
+	// Model overrides the provider's default transcription model.
+	//nolint:lll // jsonschema tags require single line
+	Model string `yaml:"model,omitempty" json:"model,omitempty" jsonschema:"title=Model,description=Transcription model name"`
+	// BaseURL overrides the provider's default API endpoint.
+	//nolint:lll // jsonschema tags require single line
+	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty" jsonschema:"title=BaseURL,description=API endpoint override"`
+	// Credential names how to obtain the API key.
+	//nolint:lll // jsonschema tags require single line
+	Credential *CredentialConfig `yaml:"credential,omitempty" json:"credential,omitempty" jsonschema:"title=Credential,description=API key resolution"`
+	// AdditionalConfig carries provider-specific extras.
+	//nolint:lll // jsonschema tags require single line
+	AdditionalConfig map[string]any `yaml:"additional_config,omitempty" json:"additional_config,omitempty" jsonschema:"title=Additional Config,description=Provider-specific extras"`
+}
+
 // SandboxConfig declares a named sandbox backend. Mode selects a
 // factory registered via runtime/hooks/sandbox.RegisterFactory; every
 // other field is passed to the factory as its config map.
@@ -262,6 +321,12 @@ func (s *RuntimeConfigSpec) Validate() error {
 	if err := s.validateEmbeddingProviders(); err != nil {
 		return err
 	}
+	if err := s.validateTTSProviders(); err != nil {
+		return err
+	}
+	if err := s.validateSTTProviders(); err != nil {
+		return err
+	}
 	if err := s.validateStateStore(); err != nil {
 		return err
 	}
@@ -353,6 +418,80 @@ func (s *RuntimeConfigSpec) validateEmbeddingProviders() error {
 			return &ValidationError{
 				Field:   fmt.Sprintf("embedding_providers[%d].id", i),
 				Message: "duplicate embedding provider id",
+				Value:   id,
+			}
+		}
+		seen[id] = true
+	}
+	return nil
+}
+
+var validTTSTypes = map[string]bool{
+	"openai": true, "elevenlabs": true, "cartesia": true,
+}
+
+func (s *RuntimeConfigSpec) validateTTSProviders() error {
+	seen := make(map[string]bool, len(s.TTSProviders))
+	for i := range s.TTSProviders {
+		tp := &s.TTSProviders[i]
+		if tp.Type == "" {
+			return &ValidationError{
+				Field:   fmt.Sprintf("tts_providers[%d].type", i),
+				Message: "TTS provider type is required",
+			}
+		}
+		if !validTTSTypes[tp.Type] {
+			return &ValidationError{
+				Field:   fmt.Sprintf("tts_providers[%d].type", i),
+				Message: "must be one of: openai, elevenlabs, cartesia",
+				Value:   tp.Type,
+			}
+		}
+		id := tp.ID
+		if id == "" {
+			id = tp.Type
+		}
+		if seen[id] {
+			return &ValidationError{
+				Field:   fmt.Sprintf("tts_providers[%d].id", i),
+				Message: "duplicate TTS provider id",
+				Value:   id,
+			}
+		}
+		seen[id] = true
+	}
+	return nil
+}
+
+var validSTTTypes = map[string]bool{
+	"openai": true,
+}
+
+func (s *RuntimeConfigSpec) validateSTTProviders() error {
+	seen := make(map[string]bool, len(s.STTProviders))
+	for i := range s.STTProviders {
+		sp := &s.STTProviders[i]
+		if sp.Type == "" {
+			return &ValidationError{
+				Field:   fmt.Sprintf("stt_providers[%d].type", i),
+				Message: "STT provider type is required",
+			}
+		}
+		if !validSTTTypes[sp.Type] {
+			return &ValidationError{
+				Field:   fmt.Sprintf("stt_providers[%d].type", i),
+				Message: "must be one of: openai",
+				Value:   sp.Type,
+			}
+		}
+		id := sp.ID
+		if id == "" {
+			id = sp.Type
+		}
+		if seen[id] {
+			return &ValidationError{
+				Field:   fmt.Sprintf("stt_providers[%d].id", i),
+				Message: "duplicate STT provider id",
 				Value:   id,
 			}
 		}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -373,6 +373,92 @@ spec:
 	}
 }
 
+func TestRuntimeConfigSpec_Validate_TTSProviderMissingType(t *testing.T) {
+	s := &RuntimeConfigSpec{TTSProviders: []TTSProviderConfig{{Model: "x"}}}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for missing TTS provider type")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_TTSProviderInvalidType(t *testing.T) {
+	s := &RuntimeConfigSpec{TTSProviders: []TTSProviderConfig{{Type: "bogus"}}}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for invalid TTS provider type")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_TTSProviderDuplicateID(t *testing.T) {
+	s := &RuntimeConfigSpec{TTSProviders: []TTSProviderConfig{
+		{Type: "openai"}, {Type: "openai"},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected duplicate TTS id error")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_STTProviderMissingType(t *testing.T) {
+	s := &RuntimeConfigSpec{STTProviders: []STTProviderConfig{{Model: "x"}}}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for missing STT provider type")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_STTProviderInvalidType(t *testing.T) {
+	s := &RuntimeConfigSpec{STTProviders: []STTProviderConfig{{Type: "bogus"}}}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for invalid STT provider type")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_STTProviderDuplicateID(t *testing.T) {
+	s := &RuntimeConfigSpec{STTProviders: []STTProviderConfig{
+		{Type: "openai"}, {Type: "openai"},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected duplicate STT id error")
+	}
+}
+
+func TestLoadRuntimeConfig_TTSAndSTTYAML(t *testing.T) {
+	yaml := `
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: RuntimeConfig
+spec:
+  tts_providers:
+    - id: voice
+      type: elevenlabs
+      model: eleven_turbo_v2
+      credential:
+        credential_env: ELEVEN_API_KEY
+    - id: cart
+      type: cartesia
+      additional_config:
+        ws_url: wss://api.cartesia.ai/tts/websocket
+  stt_providers:
+    - type: openai
+      model: whisper-1
+      credential:
+        credential_env: OPENAI_API_KEY
+`
+	path := writeTemp(t, "rc.yaml", yaml)
+	rc, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig: %v", err)
+	}
+	if len(rc.Spec.TTSProviders) != 2 {
+		t.Fatalf("expected 2 tts providers, got %d", len(rc.Spec.TTSProviders))
+	}
+	if rc.Spec.TTSProviders[0].ID != "voice" || rc.Spec.TTSProviders[0].Type != "elevenlabs" {
+		t.Errorf("first tts mis-parsed: %+v", rc.Spec.TTSProviders[0])
+	}
+	if got := rc.Spec.TTSProviders[1].AdditionalConfig["ws_url"]; got != "wss://api.cartesia.ai/tts/websocket" {
+		t.Errorf("cartesia ws_url = %v", got)
+	}
+	if len(rc.Spec.STTProviders) != 1 || rc.Spec.STTProviders[0].Type != "openai" {
+		t.Errorf("stt providers mis-parsed: %+v", rc.Spec.STTProviders)
+	}
+}
+
 func TestRuntimeConfigSpec_Validate_EmbeddingProviderMissingType(t *testing.T) {
 	s := &RuntimeConfigSpec{
 		EmbeddingProviders: []EmbeddingProviderConfig{{Model: "x"}},

--- a/runtime/stt/factory.go
+++ b/runtime/stt/factory.go
@@ -1,0 +1,83 @@
+package stt
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+)
+
+// ProviderSpec is the runtime form of an STT-provider declaration,
+// used by CreateFromSpec to construct a Service implementation.
+// The SDK's runtime-config layer translates pkg/config.STTProviderConfig
+// into this struct after resolving credentials.
+type ProviderSpec struct {
+	// ID is a stable identifier; informational only at this layer.
+	ID string
+	// Type selects the implementation: openai (only one today).
+	Type string
+	// Model overrides the provider's default transcription model.
+	Model string
+	// BaseURL overrides the provider's default API endpoint.
+	BaseURL string
+	// Credential carries the resolved API key.
+	Credential credentials.Credential
+	// AdditionalConfig carries provider-specific extras. Unknown keys
+	// are ignored.
+	AdditionalConfig map[string]any
+}
+
+// Factory builds a Service from a spec.
+type Factory func(spec ProviderSpec) (Service, error)
+
+var (
+	sttFactoriesMu sync.RWMutex
+	sttFactories   = make(map[string]Factory)
+)
+
+// RegisterFactory registers a factory for the given provider type.
+// Typically called from per-provider package init().
+func RegisterFactory(providerType string, factory Factory) {
+	sttFactoriesMu.Lock()
+	defer sttFactoriesMu.Unlock()
+	sttFactories[providerType] = factory
+}
+
+// CreateFromSpec returns a Service implementation for the given spec.
+//
+//nolint:gocritic // spec is a value-semantics builder; callers assemble inline.
+func CreateFromSpec(spec ProviderSpec) (Service, error) {
+	sttFactoriesMu.RLock()
+	factory, ok := sttFactories[spec.Type]
+	sttFactoriesMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unsupported STT provider type: %s", spec.Type)
+	}
+	return factory(spec)
+}
+
+// ResolveCredential resolves an STT provider's credential block
+// into a concrete Credential, applying the same fallback chain as
+// chat providers.
+func ResolveCredential(ctx context.Context, providerType string,
+	cfgDir string, cred *credentials.CredentialConfig,
+) (credentials.Credential, error) {
+	return credentials.Resolve(ctx, credentials.ResolverConfig{
+		ProviderType:     providerType,
+		CredentialConfig: cred,
+		ConfigDir:        cfgDir,
+	})
+}
+
+// APIKeyFromCredential returns the raw API key from an APIKey
+// credential, or "" for any other credential shape (or nil).
+func APIKeyFromCredential(c credentials.Credential) string {
+	if c == nil {
+		return ""
+	}
+	if k, ok := c.(*credentials.APIKeyCredential); ok {
+		return k.APIKey()
+	}
+	return ""
+}

--- a/runtime/stt/openai_register.go
+++ b/runtime/stt/openai_register.go
@@ -1,0 +1,15 @@
+package stt
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	RegisterFactory("openai", func(spec ProviderSpec) (Service, error) {
+		opts := []OpenAIOption{}
+		if spec.Model != "" {
+			opts = append(opts, WithOpenAIModel(spec.Model))
+		}
+		if spec.BaseURL != "" {
+			opts = append(opts, WithOpenAIBaseURL(spec.BaseURL))
+		}
+		return NewOpenAI(APIKeyFromCredential(spec.Credential), opts...), nil
+	})
+}

--- a/runtime/stt/register_test.go
+++ b/runtime/stt/register_test.go
@@ -1,0 +1,61 @@
+package stt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/stt"
+)
+
+func TestSTTRegister_OpenAI_AllOptions(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("sk-stub")
+	svc, err := stt.CreateFromSpec(stt.ProviderSpec{
+		Type:       "openai",
+		Model:      "whisper-1",
+		BaseURL:    "https://api.openai.test",
+		Credential: cred,
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("nil service")
+	}
+}
+
+func TestSTTRegister_OpenAI_Defaults(t *testing.T) {
+	if _, err := stt.CreateFromSpec(stt.ProviderSpec{Type: "openai"}); err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+}
+
+func TestSTTRegister_UnknownType(t *testing.T) {
+	if _, err := stt.CreateFromSpec(stt.ProviderSpec{Type: "no-such"}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestAPIKeyFromCredential_STT(t *testing.T) {
+	if got := stt.APIKeyFromCredential(nil); got != "" {
+		t.Errorf("nil = %q", got)
+	}
+	if got := stt.APIKeyFromCredential(&credentials.NoOpCredential{}); got != "" {
+		t.Errorf("noop = %q", got)
+	}
+	cred := credentials.NewAPIKeyCredential("k")
+	if got := stt.APIKeyFromCredential(cred); got != "k" {
+		t.Errorf("apikey = %q", got)
+	}
+}
+
+func TestResolveCredential(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-env")
+	cred, err := stt.ResolveCredential(context.Background(), "openai", "", nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got := stt.APIKeyFromCredential(cred); got != "sk-env" {
+		t.Errorf("got %q want sk-env", got)
+	}
+}

--- a/runtime/tts/cartesia_register.go
+++ b/runtime/tts/cartesia_register.go
@@ -1,0 +1,18 @@
+package tts
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	RegisterFactory("cartesia", func(spec ProviderSpec) (Service, error) {
+		opts := []CartesiaOption{}
+		if spec.Model != "" {
+			opts = append(opts, WithCartesiaModel(spec.Model))
+		}
+		if spec.BaseURL != "" {
+			opts = append(opts, WithCartesiaBaseURL(spec.BaseURL))
+		}
+		if v, ok := spec.AdditionalConfig["ws_url"].(string); ok && v != "" {
+			opts = append(opts, WithCartesiaWSURL(v))
+		}
+		return NewCartesia(APIKeyFromCredential(spec.Credential), opts...), nil
+	})
+}

--- a/runtime/tts/elevenlabs_register.go
+++ b/runtime/tts/elevenlabs_register.go
@@ -1,0 +1,15 @@
+package tts
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	RegisterFactory("elevenlabs", func(spec ProviderSpec) (Service, error) {
+		opts := []ElevenLabsOption{}
+		if spec.Model != "" {
+			opts = append(opts, WithElevenLabsModel(spec.Model))
+		}
+		if spec.BaseURL != "" {
+			opts = append(opts, WithElevenLabsBaseURL(spec.BaseURL))
+		}
+		return NewElevenLabs(APIKeyFromCredential(spec.Credential), opts...), nil
+	})
+}

--- a/runtime/tts/factory.go
+++ b/runtime/tts/factory.go
@@ -1,0 +1,89 @@
+package tts
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+)
+
+// ProviderSpec is the runtime form of a TTS-provider declaration,
+// used by CreateFromSpec to construct a Service implementation.
+// The SDK's runtime-config layer translates pkg/config.TTSProviderConfig
+// into this struct after resolving credentials.
+type ProviderSpec struct {
+	// ID is a stable identifier; informational only at this layer.
+	ID string
+	// Type selects the implementation: openai, elevenlabs, cartesia.
+	Type string
+	// Model overrides the provider's default voice/model. Empty uses
+	// the per-provider default.
+	Model string
+	// BaseURL overrides the provider's default API endpoint.
+	BaseURL string
+	// Credential carries the resolved API key.
+	Credential credentials.Credential
+	// AdditionalConfig carries provider-specific extras (cartesia
+	// websocket URL, etc.). Unknown keys are ignored.
+	AdditionalConfig map[string]any
+}
+
+// Factory builds a Service from a spec. Per-provider packages
+// register one of these via init() so this package never needs to
+// import them (avoiding a cycle — implementations already import
+// this package for the Service interface).
+type Factory func(spec ProviderSpec) (Service, error)
+
+var (
+	ttsFactoriesMu sync.RWMutex
+	ttsFactories   = make(map[string]Factory)
+)
+
+// RegisterFactory registers a factory for the given provider type.
+// Typically called from per-provider package init().
+func RegisterFactory(providerType string, factory Factory) {
+	ttsFactoriesMu.Lock()
+	defer ttsFactoriesMu.Unlock()
+	ttsFactories[providerType] = factory
+}
+
+// CreateFromSpec returns a Service implementation for the given spec.
+//
+//nolint:gocritic // spec is a value-semantics builder; callers assemble inline.
+func CreateFromSpec(spec ProviderSpec) (Service, error) {
+	ttsFactoriesMu.RLock()
+	factory, ok := ttsFactories[spec.Type]
+	ttsFactoriesMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unsupported TTS provider type: %s", spec.Type)
+	}
+	return factory(spec)
+}
+
+// ResolveCredential resolves a TTS provider's credential block
+// into a concrete Credential, applying the same fallback chain as
+// chat providers. Exposed as a helper for the SDK runtime-config
+// layer.
+func ResolveCredential(ctx context.Context, providerType string,
+	cfgDir string, cred *credentials.CredentialConfig,
+) (credentials.Credential, error) {
+	return credentials.Resolve(ctx, credentials.ResolverConfig{
+		ProviderType:     providerType,
+		CredentialConfig: cred,
+		ConfigDir:        cfgDir,
+	})
+}
+
+// APIKeyFromCredential returns the raw API key from an APIKey
+// credential, or "" for any other credential shape (or nil). TTS
+// providers want the key string for their constructors.
+func APIKeyFromCredential(c credentials.Credential) string {
+	if c == nil {
+		return ""
+	}
+	if k, ok := c.(*credentials.APIKeyCredential); ok {
+		return k.APIKey()
+	}
+	return ""
+}

--- a/runtime/tts/openai_register.go
+++ b/runtime/tts/openai_register.go
@@ -1,0 +1,15 @@
+package tts
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	RegisterFactory("openai", func(spec ProviderSpec) (Service, error) {
+		opts := []OpenAIOption{}
+		if spec.Model != "" {
+			opts = append(opts, WithOpenAIModel(spec.Model))
+		}
+		if spec.BaseURL != "" {
+			opts = append(opts, WithOpenAIBaseURL(spec.BaseURL))
+		}
+		return NewOpenAI(APIKeyFromCredential(spec.Credential), opts...), nil
+	})
+}

--- a/runtime/tts/register_test.go
+++ b/runtime/tts/register_test.go
@@ -1,0 +1,113 @@
+package tts_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
+)
+
+func TestResolveCredential(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-env")
+	cred, err := tts.ResolveCredential(context.Background(), "openai", "", nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got := tts.APIKeyFromCredential(cred); got != "sk-env" {
+		t.Errorf("got %q want sk-env", got)
+	}
+}
+
+// Each test exercises every conditional branch of one provider's
+// registered factory closure (model, base_url, credential, and any
+// provider-specific extras). Coverage is measured per-package, so
+// these need to live alongside the providers they cover.
+
+func TestTTSRegister_OpenAI_AllOptions(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("sk-stub")
+	svc, err := tts.CreateFromSpec(tts.ProviderSpec{
+		Type:       "openai",
+		Model:      "tts-1",
+		BaseURL:    "https://api.openai.test",
+		Credential: cred,
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("nil service")
+	}
+}
+
+func TestTTSRegister_OpenAI_Defaults(t *testing.T) {
+	if _, err := tts.CreateFromSpec(tts.ProviderSpec{Type: "openai"}); err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+}
+
+func TestTTSRegister_ElevenLabs_AllOptions(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("eleven-stub")
+	svc, err := tts.CreateFromSpec(tts.ProviderSpec{
+		Type:       "elevenlabs",
+		Model:      "eleven_turbo_v2",
+		BaseURL:    "https://api.elevenlabs.test",
+		Credential: cred,
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("nil service")
+	}
+}
+
+func TestTTSRegister_ElevenLabs_Defaults(t *testing.T) {
+	if _, err := tts.CreateFromSpec(tts.ProviderSpec{Type: "elevenlabs"}); err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+}
+
+func TestTTSRegister_Cartesia_AllOptions(t *testing.T) {
+	cred := credentials.NewAPIKeyCredential("cart-stub")
+	svc, err := tts.CreateFromSpec(tts.ProviderSpec{
+		Type:       "cartesia",
+		Model:      "sonic",
+		BaseURL:    "https://api.cartesia.test",
+		Credential: cred,
+		AdditionalConfig: map[string]any{
+			"ws_url": "wss://api.cartesia.test/ws",
+		},
+	})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("nil service")
+	}
+}
+
+func TestTTSRegister_Cartesia_Defaults(t *testing.T) {
+	if _, err := tts.CreateFromSpec(tts.ProviderSpec{Type: "cartesia"}); err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+}
+
+func TestTTSRegister_UnknownType(t *testing.T) {
+	if _, err := tts.CreateFromSpec(tts.ProviderSpec{Type: "no-such"}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestAPIKeyFromCredential_TTS(t *testing.T) {
+	if got := tts.APIKeyFromCredential(nil); got != "" {
+		t.Errorf("nil = %q", got)
+	}
+	if got := tts.APIKeyFromCredential(&credentials.NoOpCredential{}); got != "" {
+		t.Errorf("noop = %q", got)
+	}
+	cred := credentials.NewAPIKeyCredential("k")
+	if got := tts.APIKeyFromCredential(cred); got != "k" {
+		t.Errorf("apikey = %q", got)
+	}
+}

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -729,6 +729,22 @@
           "title": "Embedding Providers",
           "description": "Embedding provider configurations"
         },
+        "tts_providers": {
+          "items": {
+            "$ref": "#/$defs/TTSProviderConfig"
+          },
+          "type": "array",
+          "title": "TTS Providers",
+          "description": "Text-to-speech provider configurations"
+        },
+        "stt_providers": {
+          "items": {
+            "$ref": "#/$defs/STTProviderConfig"
+          },
+          "type": "array",
+          "title": "STT Providers",
+          "description": "Speech-to-text provider configurations"
+        },
         "tools": {
           "additionalProperties": {
             "$ref": "#/$defs/ToolSpec"
@@ -800,6 +816,48 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "STTProviderConfig": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "Stable identifier"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "openai"
+          ],
+          "title": "Type",
+          "description": "STT provider type"
+        },
+        "model": {
+          "type": "string",
+          "title": "Model",
+          "description": "Transcription model name"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "BaseURL",
+          "description": "API endpoint override"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig",
+          "title": "Credential",
+          "description": "API key resolution"
+        },
+        "additional_config": {
+          "type": "object",
+          "title": "Additional Config",
+          "description": "Provider-specific extras"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
     },
     "SandboxConfig": {
       "properties": {
@@ -916,6 +974,50 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "TTSProviderConfig": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "Stable identifier"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "openai",
+            "elevenlabs",
+            "cartesia"
+          ],
+          "title": "Type",
+          "description": "TTS provider type"
+        },
+        "model": {
+          "type": "string",
+          "title": "Model",
+          "description": "Voice or model name"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "BaseURL",
+          "description": "API endpoint override"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig",
+          "title": "Credential",
+          "description": "API key resolution"
+        },
+        "additional_config": {
+          "type": "object",
+          "title": "Additional Config",
+          "description": "Provider-specific extras"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
     },
     "ToolClientConfig": {
       "properties": {

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -95,6 +95,14 @@ type config struct {
 	embeddingProviders   map[string]providers.EmbeddingProvider
 	embeddingProviderIDs []string
 
+	// Declarative TTS / STT providers, keyed by ID. First entry
+	// becomes the default ttsService / sttService unless one is
+	// already set via WithTTS / WithVADMode.
+	ttsProviders   map[string]tts.Service
+	ttsProviderIDs []string
+	sttProviders   map[string]stt.Service
+	sttProviderIDs []string
+
 	// Auto-summarization for RAG context
 	summarizeProvider  providers.Provider
 	summarizeThreshold int

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -26,7 +26,9 @@ import (
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
 	"github.com/AltairaLabs/PromptKit/runtime/selection"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/stt"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
 )
 
 // resolveSandboxes builds a map from declared sandbox names to ready
@@ -154,6 +156,16 @@ func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 	// isn't already set programmatically.
 	if err := applyEmbeddingProviders(c, spec.EmbeddingProviders); err != nil {
 		return fmt.Errorf("applying embedding providers from runtime config: %w", err)
+	}
+
+	// Apply TTS / STT providers (declarative). First declared entry
+	// becomes the default ttsService / sttService when one isn't set
+	// programmatically via WithTTS / WithVADMode.
+	if err := applyTTSProviders(c, spec.TTSProviders); err != nil {
+		return fmt.Errorf("applying TTS providers from runtime config: %w", err)
+	}
+	if err := applySTTProviders(c, spec.STTProviders); err != nil {
+		return fmt.Errorf("applying STT providers from runtime config: %w", err)
 	}
 
 	// Apply MCP servers
@@ -329,6 +341,95 @@ func applyEmbeddingProviders(c *config, specs []pkgconfig.EmbeddingProviderConfi
 	// Default RAG provider: first declared, unless one is already wired.
 	if c.retrievalProvider == nil && len(c.embeddingProviderIDs) > 0 {
 		c.retrievalProvider = c.embeddingProviders[c.embeddingProviderIDs[0]]
+	}
+	return nil
+}
+
+// applyTTSProviders builds TTS instances from the spec and stores
+// them by ID. The first declared entry doubles as the default
+// ttsService when one isn't already set programmatically (matching
+// the embedding-provider precedence pattern).
+//
+//nolint:dupl // applySTTProviders is structurally identical but operates on a different type.
+func applyTTSProviders(c *config, specs []pkgconfig.TTSProviderConfig) error {
+	if len(specs) == 0 {
+		return nil
+	}
+	if c.ttsProviders == nil {
+		c.ttsProviders = make(map[string]tts.Service, len(specs))
+	}
+	for i := range specs {
+		tp := &specs[i]
+		id := tp.ID
+		if id == "" {
+			id = tp.Type
+		}
+		if _, exists := c.ttsProviders[id]; exists {
+			return fmt.Errorf("TTS provider %q: duplicate ID", id)
+		}
+		cred, err := tts.ResolveCredential(context.Background(), tp.Type, "", tp.Credential)
+		if err != nil {
+			return fmt.Errorf("TTS provider %q: resolving credential: %w", id, err)
+		}
+		instance, err := tts.CreateFromSpec(tts.ProviderSpec{
+			ID:               id,
+			Type:             tp.Type,
+			Model:            tp.Model,
+			BaseURL:          tp.BaseURL,
+			Credential:       cred,
+			AdditionalConfig: tp.AdditionalConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("TTS provider %q: %w", id, err)
+		}
+		c.ttsProviders[id] = instance
+		c.ttsProviderIDs = append(c.ttsProviderIDs, id)
+	}
+	if c.ttsService == nil && len(c.ttsProviderIDs) > 0 {
+		c.ttsService = c.ttsProviders[c.ttsProviderIDs[0]]
+	}
+	return nil
+}
+
+// applySTTProviders mirrors applyTTSProviders for STT.
+//
+//nolint:dupl // applyTTSProviders is structurally identical but operates on a different type.
+func applySTTProviders(c *config, specs []pkgconfig.STTProviderConfig) error {
+	if len(specs) == 0 {
+		return nil
+	}
+	if c.sttProviders == nil {
+		c.sttProviders = make(map[string]stt.Service, len(specs))
+	}
+	for i := range specs {
+		sp := &specs[i]
+		id := sp.ID
+		if id == "" {
+			id = sp.Type
+		}
+		if _, exists := c.sttProviders[id]; exists {
+			return fmt.Errorf("STT provider %q: duplicate ID", id)
+		}
+		cred, err := stt.ResolveCredential(context.Background(), sp.Type, "", sp.Credential)
+		if err != nil {
+			return fmt.Errorf("STT provider %q: resolving credential: %w", id, err)
+		}
+		instance, err := stt.CreateFromSpec(stt.ProviderSpec{
+			ID:               id,
+			Type:             sp.Type,
+			Model:            sp.Model,
+			BaseURL:          sp.BaseURL,
+			Credential:       cred,
+			AdditionalConfig: sp.AdditionalConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("STT provider %q: %w", id, err)
+		}
+		c.sttProviders[id] = instance
+		c.sttProviderIDs = append(c.sttProviderIDs, id)
+	}
+	if c.sttService == nil && len(c.sttProviderIDs) > 0 {
+		c.sttService = c.sttProviders[c.sttProviderIDs[0]]
 	}
 	return nil
 }

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -14,7 +15,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/selection"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/stt"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -639,6 +642,99 @@ func TestResolveSandboxes_NilAndEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
+
+func TestApplyTTSProviders_BuildsAndDefaults(t *testing.T) {
+	specs := []pkgconfig.TTSProviderConfig{
+		{ID: "voice", Type: "openai"},
+	}
+	c := &config{}
+	require.NoError(t, applyTTSProviders(c, specs))
+	require.Contains(t, c.ttsProviders, "voice")
+	require.NotNil(t, c.ttsService)
+	require.Same(t, c.ttsProviders["voice"], c.ttsService)
+}
+
+func TestApplyTTSProviders_RespectsExistingService(t *testing.T) {
+	existing := &noopTTS{}
+	specs := []pkgconfig.TTSProviderConfig{{Type: "openai"}}
+	c := &config{ttsService: existing}
+	require.NoError(t, applyTTSProviders(c, specs))
+	require.Same(t, existing, c.ttsService, "WithTTS should win over default-from-first")
+}
+
+func TestApplyTTSProviders_DuplicateID(t *testing.T) {
+	specs := []pkgconfig.TTSProviderConfig{
+		{ID: "x", Type: "openai"}, {ID: "x", Type: "openai"},
+	}
+	c := &config{}
+	err := applyTTSProviders(c, specs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate ID")
+}
+
+func TestApplyTTSProviders_UnsupportedType(t *testing.T) {
+	specs := []pkgconfig.TTSProviderConfig{{Type: "no-such"}}
+	c := &config{}
+	require.Error(t, applyTTSProviders(c, specs))
+}
+
+func TestApplyTTSProviders_DefaultIDFallsBackToType(t *testing.T) {
+	specs := []pkgconfig.TTSProviderConfig{{Type: "openai"}}
+	c := &config{}
+	require.NoError(t, applyTTSProviders(c, specs))
+	require.Contains(t, c.ttsProviders, "openai")
+}
+
+func TestApplySTTProviders_BuildsAndDefaults(t *testing.T) {
+	specs := []pkgconfig.STTProviderConfig{{Type: "openai"}}
+	c := &config{}
+	require.NoError(t, applySTTProviders(c, specs))
+	require.Contains(t, c.sttProviders, "openai")
+	require.NotNil(t, c.sttService)
+}
+
+func TestApplySTTProviders_RespectsExistingService(t *testing.T) {
+	existing := &noopSTT{}
+	specs := []pkgconfig.STTProviderConfig{{Type: "openai"}}
+	c := &config{sttService: existing}
+	require.NoError(t, applySTTProviders(c, specs))
+	require.Same(t, existing, c.sttService)
+}
+
+func TestApplySTTProviders_DuplicateID(t *testing.T) {
+	specs := []pkgconfig.STTProviderConfig{
+		{Type: "openai"}, {Type: "openai"},
+	}
+	c := &config{}
+	err := applySTTProviders(c, specs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate ID")
+}
+
+func TestApplySTTProviders_UnsupportedType(t *testing.T) {
+	specs := []pkgconfig.STTProviderConfig{{Type: "no-such"}}
+	c := &config{}
+	require.Error(t, applySTTProviders(c, specs))
+}
+
+// noopTTS / noopSTT satisfy the Service interfaces minimally for
+// "respects existing programmatic instance" tests.
+type noopTTS struct{}
+
+func (noopTTS) Name() string { return "noop" }
+func (noopTTS) Synthesize(_ context.Context, _ string, _ tts.SynthesisConfig) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (noopTTS) SupportedVoices() []tts.Voice        { return nil }
+func (noopTTS) SupportedFormats() []tts.AudioFormat { return nil }
+
+type noopSTT struct{}
+
+func (noopSTT) Name() string { return "noop" }
+func (noopSTT) Transcribe(_ context.Context, _ []byte, _ stt.TranscriptionConfig) (string, error) {
+	return "", nil
+}
+func (noopSTT) SupportedFormats() []string { return nil }
 
 func TestApplyEmbeddingProviders_Empty(t *testing.T) {
 	c := &config{}


### PR DESCRIPTION
Closes #979. TTS and STT providers now follow the same declarative shape as chat (existing) and embedding (#984) providers.

## What's new

```yaml
spec:
  tts_providers:
    - id: voice
      type: elevenlabs
      model: eleven_turbo_v2
      credential:
        credential_env: ELEVEN_API_KEY
    - id: cart
      type: cartesia
      additional_config:
        ws_url: wss://api.cartesia.ai/tts/websocket
  stt_providers:
    - type: openai
      model: whisper-1
      credential:
        credential_env: OPENAI_API_KEY
```

- ` + '`pkg/config`' + ` — `TTSProviderConfig`/`STTProviderConfig` and matching slices on RuntimeConfigSpec; validation enforces type allowlists (TTS: openai/elevenlabs/cartesia, STT: openai) and rejects duplicate IDs.
- ` + '`runtime/tts`' + ` and ` + '`runtime/stt`' + ` — ProviderSpec/Factory/CreateFromSpec/RegisterFactory/ResolveCredential, mirroring the embedding-factory pattern. Each provider self-registers via `init()` in an `*_register.go` file.
- ` + '`sdk`' + ` — applyTTSProviders + applySTTProviders build instances from the spec; first declared entry becomes the default ttsService/sttService unless one is set programmatically via WithTTS / WithVADMode.
- New how-to doc at `docs/sdk/how-to/declarative-tts-stt-providers.md`.

## Test plan

- [x] `go test ./pkg/config ./runtime/tts ./runtime/stt ./sdk -count=1 -race` green
- [x] `golangci-lint run --new-from-rev=main` clean
- [x] Coverage on changed files ≥ 80% (100% on register closures)
- [x] Schema regenerated
- [ ] CI green

This wraps #979 — chat, embedding, TTS, and STT providers all share the same declarative shape now.