### PR TITLE
feat(workflow): warn on v2 non-terminal states without exits

### DIFF
--- a/runtime/workflow/validate.go
+++ b/runtime/workflow/validate.go
@@ -136,6 +136,14 @@ func validateLoopGuards(spec *Spec, name string, state *State, r *ValidationResu
 				name, state.OnMaxVisits))
 		}
 	}
+
+	// Reachability: v2 opts into explicit terminal semantics. A state with no
+	// transitions and no loop guard is a dead-end that should be marked terminal.
+	if spec.Version >= 2 && !state.Terminal && len(state.OnEvent) == 0 && state.MaxVisits == 0 {
+		r.Warnings = append(r.Warnings, fmt.Sprintf(
+			"workflow.states[%q]: non-terminal state has no on_event and no max_visits (mark terminal: true to silence)",
+			name))
+	}
 }
 
 // validateCycles checks rule 10: DFS cycle detection (warn only).

--- a/runtime/workflow/validate_test.go
+++ b/runtime/workflow/validate_test.go
@@ -219,6 +219,55 @@ func TestValidate_TerminalWithOnEventWarns(t *testing.T) {
 	assertContains(t, r.Warnings, "terminal")
 }
 
+func TestValidate_NonTerminalWithoutExitWarns(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "p1"}, // no Terminal, no OnEvent, no MaxVisits — dead-end
+		},
+	}
+	r := Validate(spec, []string{"p1"})
+	if r.HasErrors() {
+		t.Fatalf("dead-end state should be a warning, not error: %v", r.Errors)
+	}
+	assertContains(t, r.Warnings, "no on_event and no max_visits")
+}
+
+func TestValidate_NonTerminalWithoutExit_TerminalSilences(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "p1", Terminal: true},
+		},
+	}
+	r := Validate(spec, []string{"p1"})
+	for _, w := range r.Warnings {
+		if contains(w, "no on_event and no max_visits") {
+			t.Errorf("terminal: true should silence reachability warning, got: %s", w)
+		}
+	}
+}
+
+func TestValidate_NonTerminalWithoutExit_V1Silent(t *testing.T) {
+	// v1 predates RFC 0009; dead-end states are implicitly terminal and
+	// should not trigger the reachability warning.
+	spec := &Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "p1"},
+		},
+	}
+	r := Validate(spec, []string{"p1"})
+	for _, w := range r.Warnings {
+		if contains(w, "no on_event and no max_visits") {
+			t.Errorf("v1 should not trigger RFC 0009 reachability warning, got: %s", w)
+		}
+	}
+}
+
 func TestValidate_RedirectChainWarns(t *testing.T) {
 	spec := &Spec{
 		Version: 2,


### PR DESCRIPTION
## Summary

Closes the last RFC 0009 compliance gap — adds the reachability warning for v2 workflows.

Per RFC 0009: *"Validators should warn if a non-terminal state has no outgoing transitions and no max_visits."*

- New warning in `validateLoopGuards` fires when a v2 state has `terminal: false`, no `on_event`, and no `max_visits` — nudging authors to mark dead-ends with `terminal: true` explicitly.
- Gated on `version >= 2` so existing v1 workflows (which rely on empty `on_event` as implicit terminal) remain silent. Fully backward compatible.
- Warning only — matches the RFC's *should* wording.

With this, PromptKit satisfies RFC 0009 Level 2 (full artifacts + budget enforcement) end-to-end.

## Test plan

- [x] `TestValidate_NonTerminalWithoutExitWarns` — v2 dead-end state emits warning
- [x] `TestValidate_NonTerminalWithoutExit_TerminalSilences` — `terminal: true` suppresses it
- [x] `TestValidate_NonTerminalWithoutExit_V1Silent` — v1 unchanged
- [x] `go test ./runtime/... ./sdk/... ./tools/arena/...` all green
- [x] Pre-commit hook: lint + 100% coverage on `validate.go`