### PR TITLE
chore(providers): extract duplicated literals in claude/vllm (Sonar S1192)

### DIFF
--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -22,6 +22,10 @@ const (
 	// Claude content source types
 	sourceTypeBase64 = "base64"
 	sourceTypeURL    = "url"
+
+	// Shared error-wrapping formats for tool-path request building.
+	errMarshalRequestFailed = "failed to marshal request: %w"
+	errCreateRequestFailed  = "failed to create request: %w"
 )
 
 // ToolProvider extends ClaudeProvider with tool support
@@ -529,12 +533,12 @@ func (p *ToolProvider) makeRequest(ctx context.Context, request interface{}) ([]
 
 	reqBytes, err := json.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf(errMarshalRequestFailed, err)
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBytes))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf(errCreateRequestFailed, err)
 	}
 
 	if hdrErr := p.applyToolRequestHeaders(ctx, httpReq); hdrErr != nil {
@@ -601,7 +605,7 @@ func (p *ToolProvider) streamBedrockToolRequest(
 ) (<-chan providers.StreamChunk, error) {
 	reqBody, err := p.marshalBedrockStreamingRequest(claudeReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf(errMarshalRequestFailed, err)
 	}
 	url := p.messagesStreamURL()
 	requestFn := p.buildBedrockStreamingRequestFn(url, reqBody)
@@ -629,7 +633,7 @@ func (p *ToolProvider) streamDirectToolRequest(
 ) (<-chan providers.StreamChunk, error) {
 	requestBytes, err := json.Marshal(claudeReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf(errMarshalRequestFailed, err)
 	}
 	url := p.messagesStreamURL()
 	requestFn := p.buildDirectStreamingRequestFn(url, requestBytes)
@@ -658,7 +662,7 @@ func (p *ToolProvider) buildBedrockStreamingRequestFn(
 	return func(ctx context.Context) (*http.Request, error) {
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
+			return nil, fmt.Errorf(errCreateRequestFailed, err)
 		}
 		httpReq.Header.Set("Accept", "application/vnd.amazon.eventstream")
 		if err := p.applyToolRequestHeaders(ctx, httpReq); err != nil {
@@ -676,7 +680,7 @@ func (p *ToolProvider) buildDirectStreamingRequestFn(
 	return func(ctx context.Context) (*http.Request, error) {
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
+			return nil, fmt.Errorf(errCreateRequestFailed, err)
 		}
 		httpReq.Header.Set("Accept", "text/event-stream")
 		if err := p.applyToolRequestHeaders(ctx, httpReq); err != nil {

--- a/runtime/providers/vllm/vllm_tools.go
+++ b/runtime/providers/vllm/vllm_tools.go
@@ -22,6 +22,9 @@ const (
 	toolChoiceNone     = "none"
 	toolChoiceAuto     = "auto"
 	sseDoneMessage     = "[DONE]"
+
+	// OpenAI-compatible chat completions endpoint — vLLM uses this path.
+	chatCompletionsPath = "/v1/chat/completions"
 )
 
 // vLLM-specific tool structures (OpenAI-compatible format)
@@ -115,7 +118,7 @@ func (p *Provider) PredictWithTools( // NOSONAR
 	}
 
 	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/chat/completions", bytes.NewReader(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+chatCompletionsPath, bytes.NewReader(reqBody))
 	if err != nil {
 		return providers.PredictionResponse{}, nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -143,7 +146,7 @@ func (p *Provider) PredictWithTools( // NOSONAR
 
 	// Check for HTTP errors
 	if httpResp.StatusCode != http.StatusOK {
-		url := p.baseURL + "/v1/chat/completions"
+		url := p.baseURL + chatCompletionsPath
 		body := string(respBody)
 		var apiErr vllmErrorResponse
 		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Error.Message != "" {
@@ -230,7 +233,7 @@ func (p *Provider) PredictStreamWithTools(
 	}
 
 	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/v1/chat/completions", bytes.NewReader(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+chatCompletionsPath, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -254,7 +257,7 @@ func (p *Provider) PredictStreamWithTools(
 	if httpResp.StatusCode != http.StatusOK {
 		defer httpResp.Body.Close()
 		respBody, _ := io.ReadAll(httpResp.Body)
-		url := p.baseURL + "/v1/chat/completions"
+		url := p.baseURL + chatCompletionsPath
 		body := string(respBody)
 		var apiErr vllmErrorResponse
 		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Error.Message != "" {


### PR DESCRIPTION
Clears 3 SonarCloud S1192 CRITICALs in Claude and vLLM provider code. Extracts 'failed to marshal request: %w', 'failed to create request: %w', and '/v1/chat/completions' as named constants. No behavior change.