### PR TITLE
chore: annotate empty functions (Sonar S1186)

### DIFF
--- a/runtime/pipeline/stage/idle_timeout.go
+++ b/runtime/pipeline/stage/idle_timeout.go
@@ -22,7 +22,7 @@ type idleResetKey struct{}
 func withIdleTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc, func()) {
 	if timeout <= 0 {
 		ctx, cancel := context.WithCancel(parent)
-		return ctx, cancel, func() {}
+		return ctx, cancel, func() { /* no-op reset: idle timeout disabled */ }
 	}
 
 	ctx, cancelCause := context.WithCancelCause(parent)

--- a/runtime/providers/internal/streaming/conn.go
+++ b/runtime/providers/internal/streaming/conn.go
@@ -87,16 +87,16 @@ type Logger interface {
 type noopLogger struct{}
 
 // Debug implements Logger.
-func (noopLogger) Debug(_ string, _ ...interface{}) {}
+func (noopLogger) Debug(_ string, _ ...interface{}) { /* discarded */ }
 
 // Info implements Logger.
-func (noopLogger) Info(_ string, _ ...interface{}) {}
+func (noopLogger) Info(_ string, _ ...interface{}) { /* discarded */ }
 
 // Warn implements Logger.
-func (noopLogger) Warn(_ string, _ ...interface{}) {}
+func (noopLogger) Warn(_ string, _ ...interface{}) { /* discarded */ }
 
 // Error implements Logger.
-func (noopLogger) Error(_ string, _ ...interface{}) {}
+func (noopLogger) Error(_ string, _ ...interface{}) { /* discarded */ }
 
 func (c *ConnConfig) defaults() {
 	if c.DialTimeout == 0 {

--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -369,7 +369,7 @@ func (r *Registry) withTimeout(
 			ctx, time.Duration(tool.TimeoutMs)*time.Millisecond,
 		)
 	}
-	return ctx, func() {}
+	return ctx, func() { /* no-op cancel: tool has no timeout */ }
 }
 
 // Execute executes a tool with the given arguments

--- a/sdk/capability_workflow.go
+++ b/sdk/capability_workflow.go
@@ -28,7 +28,9 @@ func (w *WorkflowCapability) Init(ctx CapabilityContext) error {
 
 // RegisterTools is a no-op at conversation level.
 // WorkflowConversation calls RegisterToolsForState per-state.
-func (w *WorkflowCapability) RegisterTools(_ *tools.Registry) {}
+func (w *WorkflowCapability) RegisterTools(_ *tools.Registry) {
+	/* no-op: tools are registered per-state via RegisterToolsForState */
+}
 
 // RegisterToolsForState registers workflow__transition for a specific state.
 // Called by WorkflowConversation when opening a conversation for a state.

--- a/sdk/stream_events.go
+++ b/sdk/stream_events.go
@@ -14,7 +14,7 @@ type TextDeltaEvent struct {
 	Delta string
 }
 
-func (TextDeltaEvent) streamEvent() {}
+func (TextDeltaEvent) streamEvent() { /* marker method — intentionally empty */ }
 
 // ClientToolRequestEvent is emitted when the pipeline encounters a client tool
 // that needs caller fulfillment.
@@ -35,7 +35,7 @@ type ClientToolRequestEvent struct {
 	Categories []string
 }
 
-func (ClientToolRequestEvent) streamEvent() {}
+func (ClientToolRequestEvent) streamEvent() { /* marker method — intentionally empty */ }
 
 // StreamDoneEvent is emitted when the stream completes.
 type StreamDoneEvent struct {
@@ -43,7 +43,7 @@ type StreamDoneEvent struct {
 	Response *Response
 }
 
-func (StreamDoneEvent) streamEvent() {}
+func (StreamDoneEvent) streamEvent() { /* marker method — intentionally empty */ }
 
 // StreamEventHandler is called for each event during streaming.
 type StreamEventHandler func(event StreamEvent)


### PR DESCRIPTION
Clears all 9 SonarCloud S1186 CRITICALs by adding short inline comments explaining why each intentionally-empty function body is empty. All sites are no-op implementations (marker methods, no-op reset/cancel closures, discard-log methods). No behavior change.