### PR TITLE
refactor(storage/policy): drop dead ctx field in TimeBasedPolicyHandler

### DIFF
--- a/runtime/storage/policy/time_based.go
+++ b/runtime/storage/policy/time_based.go
@@ -85,8 +85,8 @@ type TimeBasedPolicyHandler struct {
 	// indexBuilt indicates whether the expiry index has been populated
 	indexBuilt bool
 
-	// ctx is the context used for auto-started enforcement
-	ctx    context.Context
+	// cancel stops the auto-started enforcement goroutine. Set only when
+	// autoStart is true; nil otherwise. Call Stop() to invoke it.
 	cancel context.CancelFunc
 }
 
@@ -107,8 +107,9 @@ func NewTimeBasedPolicyHandler(enforcementInterval time.Duration, opts ...Option
 	}
 
 	if h.autoStart && h.baseDir != "" && h.enforcementInterval > 0 {
-		h.ctx, h.cancel = context.WithCancel(context.Background())
-		h.StartEnforcement(h.ctx, h.baseDir)
+		var ctx context.Context
+		ctx, h.cancel = context.WithCancel(context.Background())
+		h.StartEnforcement(ctx, h.baseDir)
 	}
 
 	return h


### PR DESCRIPTION
## Summary

Clears one Sonar S8242 (ctx-in-struct) MAJOR by removing a dead field.

The \`ctx\` field on \`TimeBasedPolicyHandler\` was written once in the auto-start branch of \`NewTimeBasedPolicyHandler\` and never read anywhere. Only \`cancel\` is consumed (in \`Stop()\`). Moved the \`ctx\` to a local variable at the assignment site.

No behavior change: auto-started enforcement still runs under a Background-rooted context, and \`Stop()\` still cancels via \`h.cancel\`.

## Scope note

This is the only genuinely refactorable site among the 25 current MAJOR issues. The other 24 are either:
- Legitimate ctx+cancel lifecycle holders (players, sessions, OTel span entries — already have \`//nolint:containedctx\` comments Sonar ignores)
- ctx-in-struct needed for framework integration (bubbletea View() has no ctx param)
- Function signatures with 8+ params that would break public API (provider constructors)

Those will stay open until either (a) the lifecycle/framework constraints change or (b) they're marked "Won't Fix" in the SonarCloud UI.

## Test plan

- [x] \`go test ./runtime/storage/policy/... -race\` passes
- [x] Pre-commit hook: 92.1% coverage on the changed file
- [x] No public API change — field is private