### PR TITLE
chore: sweep Sonar MINOR code smells (S8193/S8209/S8184)

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -279,7 +279,7 @@ type k8sManifest interface {
 
 // loadSimpleK8sManifest is a generic loader for K8s-style manifest files
 // This is used for simple config types (Scenario, Provider) that don't support legacy formats
-func loadSimpleK8sManifest[T k8sManifest](filename string, expectedKind string) (T, error) {
+func loadSimpleK8sManifest[T k8sManifest](filename, expectedKind string) (T, error) {
 	var zero T
 
 	data, err := os.ReadFile(filename)

--- a/runtime/evals/handlers/tool_args.go
+++ b/runtime/evals/handlers/tool_args.go
@@ -131,9 +131,7 @@ func findMatchingCalls(
 
 // argsMatch checks if actual arguments contain all expected args
 // with matching string representations.
-func argsMatch(
-	actual map[string]any, expected map[string]any,
-) bool {
+func argsMatch(actual, expected map[string]any) bool {
 	for k, expectedVal := range expected {
 		actualVal, exists := actual[k]
 		if !exists {

--- a/runtime/hooks/sandbox/direct/direct.go
+++ b/runtime/hooks/sandbox/direct/direct.go
@@ -118,7 +118,7 @@ func buildEnv(extras []string) []string {
 	out := make([]string, 0, len(base)+len(extras))
 	out = append(out, base...)
 	for _, entry := range extras {
-		if i := indexOfByte(entry, '='); i >= 0 {
+		if indexOfByte(entry, '=') >= 0 {
 			out = append(out, entry)
 			continue
 		}

--- a/runtime/persistence/interfaces.go
+++ b/runtime/persistence/interfaces.go
@@ -16,7 +16,7 @@ type PromptRepository interface {
 	LoadPrompt(taskType string) (*prompt.Config, error)
 
 	// LoadFragment loads a fragment by name and optional path
-	LoadFragment(name string, relativePath string, baseDir string) (*prompt.Fragment, error)
+	LoadFragment(name, relativePath, baseDir string) (*prompt.Fragment, error)
 
 	// ListPrompts returns all available prompt task types
 	ListPrompts() ([]string, error)

--- a/runtime/prompt/fragment_resolver.go
+++ b/runtime/prompt/fragment_resolver.go
@@ -9,7 +9,7 @@ import (
 
 // FragmentRepository interface for loading fragments (to avoid import cycles)
 type FragmentRepository interface {
-	LoadFragment(name string, relativePath string, baseDir string) (*Fragment, error)
+	LoadFragment(name, relativePath, baseDir string) (*Fragment, error)
 }
 
 // FragmentResolver handles fragment loading, resolution, and variable substitution using the repository pattern

--- a/runtime/prompt/registry.go
+++ b/runtime/prompt/registry.go
@@ -355,7 +355,7 @@ type ModelOverride struct {
 // This should match persistence.Repository interface
 type Repository interface {
 	LoadPrompt(taskType string) (*Config, error)
-	LoadFragment(name string, relativePath string, baseDir string) (*Fragment, error)
+	LoadFragment(name, relativePath, baseDir string) (*Fragment, error)
 	ListPrompts() ([]string, error)
 	SavePrompt(config *Config) error
 }

--- a/runtime/skills/registry.go
+++ b/runtime/skills/registry.go
@@ -58,7 +58,7 @@ func (r *Registry) Discover(sources []SkillSource) error {
 		if err := validateSkillSource(&src); err != nil {
 			return fmt.Errorf("skills[%d]: %w", i, err)
 		}
-		if dir := src.EffectiveDir(); dir != "" {
+		if src.EffectiveDir() != "" {
 			resolved, err := r.resolveSource(&src)
 			if err != nil {
 				return err

--- a/tools/arena/adapters/adapter.go
+++ b/tools/arena/adapters/adapter.go
@@ -39,7 +39,7 @@ type RecordingAdapter interface {
 	// CanHandle returns true if this adapter supports the given source/type hint.
 	// The source could be a file path, glob pattern, database query, etc.
 	// typeHint is an optional explicit format indicator from the eval config.
-	CanHandle(source string, typeHint string) bool
+	CanHandle(source, typeHint string) bool
 
 	// Enumerate expands a source into individual recording references.
 	// For file-based adapters, this expands glob patterns to matching files.

--- a/tools/arena/adapters/arena_output.go
+++ b/tools/arena/adapters/arena_output.go
@@ -18,7 +18,7 @@ func NewArenaOutputAdapter() *ArenaOutputAdapter {
 }
 
 // CanHandle returns true for *.arena-output.json files or "arena_output" type hint.
-func (a *ArenaOutputAdapter) CanHandle(source string, typeHint string) bool {
+func (a *ArenaOutputAdapter) CanHandle(source, typeHint string) bool {
 	if matchesTypeHint(typeHint, "arena", "arena_output", "scenario_output") {
 		return true
 	}

--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -912,7 +912,7 @@ func (ce *DefaultConversationExecutor) calculateTotalsFromMessages(messages []ty
 }
 
 // aggregateMessageCost adds message cost information to the total
-func (ce *DefaultConversationExecutor) aggregateMessageCost(totalCost *types.CostInfo, msgCost *types.CostInfo) {
+func (ce *DefaultConversationExecutor) aggregateMessageCost(totalCost, msgCost *types.CostInfo) {
 	if msgCost == nil {
 		return
 	}

--- a/tools/arena/mocks/parser.go
+++ b/tools/arena/mocks/parser.go
@@ -125,7 +125,7 @@ func convertToolCalls(calls []types.MessageToolCall) ([]mock.ToolCall, error) {
 			// Try to decode args as JSON; if it fails, fall back to string.
 			if err := json.Unmarshal(tc.Args, &args); err != nil {
 				var asString string
-				if err2 := json.Unmarshal(tc.Args, &asString); err2 == nil {
+				if json.Unmarshal(tc.Args, &asString) == nil {
 					args = map[string]interface{}{"_raw": asString}
 				} else {
 					return nil, fmt.Errorf("tool call %s: failed to decode args: %w", tc.Name, err)

--- a/tools/arena/render/html.go
+++ b/tools/arena/render/html.go
@@ -11,7 +11,7 @@
 package render
 
 import (
-	_ "embed"
+	_ "embed" // for go:embed directives on the HTML template files below
 	"encoding/json"
 	"fmt"
 	"html/template"

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -416,7 +416,7 @@ func (s *ArenaStateStore) deepCloneMessage(msg *types.Message) types.Message {
 }
 
 // cloneMessageParts clones the Parts slice (multimodal content) with deep copy of pointer fields
-func (s *ArenaStateStore) cloneMessageParts(cloned *types.Message, msg *types.Message) {
+func (s *ArenaStateStore) cloneMessageParts(cloned, msg *types.Message) {
 	if len(msg.Parts) > 0 {
 		cloned.Parts = make([]types.ContentPart, len(msg.Parts))
 		for i, part := range msg.Parts {
@@ -494,7 +494,7 @@ func cloneInt64Ptr(i *int64) *int64 {
 }
 
 // cloneMessageToolCalls clones the ToolCalls slice
-func (s *ArenaStateStore) cloneMessageToolCalls(cloned *types.Message, msg *types.Message) {
+func (s *ArenaStateStore) cloneMessageToolCalls(cloned, msg *types.Message) {
 	if len(msg.ToolCalls) == 0 {
 		return
 	}
@@ -510,7 +510,7 @@ func (s *ArenaStateStore) cloneMessageToolCalls(cloned *types.Message, msg *type
 }
 
 // cloneMessageToolResult clones the ToolResult
-func (s *ArenaStateStore) cloneMessageToolResult(cloned *types.Message, msg *types.Message) {
+func (s *ArenaStateStore) cloneMessageToolResult(cloned, msg *types.Message) {
 	if msg.ToolResult != nil {
 		partsCopy := make([]types.ContentPart, len(msg.ToolResult.Parts))
 		for i, part := range msg.ToolResult.Parts {
@@ -527,7 +527,7 @@ func (s *ArenaStateStore) cloneMessageToolResult(cloned *types.Message, msg *typ
 }
 
 // cloneMessageCostInfo clones the CostInfo
-func (s *ArenaStateStore) cloneMessageCostInfo(cloned *types.Message, msg *types.Message) {
+func (s *ArenaStateStore) cloneMessageCostInfo(cloned, msg *types.Message) {
 	if msg.CostInfo != nil {
 		cloned.CostInfo = &types.CostInfo{
 			InputTokens:   msg.CostInfo.InputTokens,
@@ -542,7 +542,7 @@ func (s *ArenaStateStore) cloneMessageCostInfo(cloned *types.Message, msg *types
 }
 
 // cloneMessageMeta clones the Meta map
-func (s *ArenaStateStore) cloneMessageMeta(cloned *types.Message, msg *types.Message) {
+func (s *ArenaStateStore) cloneMessageMeta(cloned, msg *types.Message) {
 	if len(msg.Meta) > 0 {
 		cloned.Meta = make(map[string]interface{}, len(msg.Meta))
 		for k, v := range msg.Meta {
@@ -552,7 +552,7 @@ func (s *ArenaStateStore) cloneMessageMeta(cloned *types.Message, msg *types.Mes
 }
 
 // cloneMessageValidations clones the Validations slice
-func (s *ArenaStateStore) cloneMessageValidations(cloned *types.Message, msg *types.Message) {
+func (s *ArenaStateStore) cloneMessageValidations(cloned, msg *types.Message) {
 	if len(msg.Validations) == 0 {
 		return
 	}
@@ -569,7 +569,7 @@ func (s *ArenaStateStore) cloneMessageValidations(cloned *types.Message, msg *ty
 }
 
 // cloneValidationDetails clones the Details map in a ValidationResult
-func (s *ArenaStateStore) cloneValidationDetails(cloned *types.ValidationResult, vr *types.ValidationResult) {
+func (s *ArenaStateStore) cloneValidationDetails(cloned, vr *types.ValidationResult) {
 	if len(vr.Details) > 0 {
 		cloned.Details = make(map[string]interface{}, len(vr.Details))
 		for k, v := range vr.Details {

--- a/tools/arena/web/server.go
+++ b/tools/arena/web/server.go
@@ -280,7 +280,7 @@ func LoadResultsIntoStore(outDir string, store *statestore.ArenaStateStore) int 
 			Messages: r.Messages,
 			Metadata: make(map[string]interface{}),
 		}
-		if saveErr := store.Save(ctx, convState); saveErr != nil {
+		if store.Save(ctx, convState) != nil {
 			continue
 		}
 		meta := &statestore.RunMetadata{
@@ -299,7 +299,7 @@ func LoadResultsIntoStore(outDir string, store *statestore.ArenaStateStore) int 
 			PersonaID:                    r.PersonaID,
 			ConversationAssertionResults: r.ConversationAssertions.Results,
 		}
-		if saveErr := store.SaveMetadata(ctx, r.RunID, meta); saveErr != nil {
+		if store.SaveMetadata(ctx, r.RunID, meta) != nil {
 			continue
 		}
 		loaded++


### PR DESCRIPTION
## Summary

Clears 19 trivial MINOR Sonar issues in one sweep. No behavior change.

## Changes

**S8193 (remove unnecessary var declaration) — 5:**
- \`runtime/hooks/sandbox/direct/direct.go\`: inline \`indexOfByte(entry, '=') >= 0\`
- \`tools/arena/web/server.go\`: inline \`store.Save\` and \`SaveMetadata\` in \`loadRuns\`
- \`runtime/skills/registry.go\`: inline \`src.EffectiveDir()\`
- \`tools/arena/mocks/parser.go\`: inline \`json.Unmarshal\`

**S8209 (group consecutive same-type params) — 13:**
- \`argsMatch(actual, expected map[string]any)\`
- \`LoadFragment(name, relativePath, baseDir string)\` (persistence + prompt pkg)
- \`loadSimpleK8sManifest[T](filename, expectedKind string)\`
- Adapter \`CanHandle(source, typeHint string)\`
- \`aggregateMessageCost(totalCost, msgCost *types.CostInfo)\`
- 7 × \`cloneMessage*(cloned, msg *types.Message)\` in arena statestore
- \`cloneValidationDetails(cloned, vr *types.ValidationResult)\`

**S8184 (comment blank import) — 1:**
- \`tools/arena/render/html.go\`: document the \`_ "embed"\` import

## Scope note

Skipped the 9 × S8196 "single-method interface rename" items — those touch public API (like \`sdk.StreamEvent\` marker interface) and are case-by-case, not a sweep.

## Test plan

- [x] \`go build ./...\` across runtime/pkg/tools
- [x] Full test suite passes
- [x] Pre-commit hook: lint + coverage green across 14 changed files