### PR TITLE
chore: reclaim S1192 constants on well-covered files

### DIFF
--- a/runtime/a2a/mock/mock.go
+++ b/runtime/a2a/mock/mock.go
@@ -16,6 +16,11 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/a2a"
 )
 
+const (
+	headerContentType = "Content-Type"
+	mimeJSON          = "application/json"
+)
+
 // Response holds the parts returned by a matched rule.
 type Response struct {
 	Parts []a2a.Part
@@ -121,7 +126,7 @@ func (m *A2AServer) handler() http.Handler {
 
 // handleAgentCard serves the agent card as JSON.
 func (m *A2AServer) handleAgentCard(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, mimeJSON)
 	_ = json.NewEncoder(w).Encode(m.card)
 }
 
@@ -241,7 +246,7 @@ func messageText(msg *a2a.Message) string {
 // writeRPCResult writes a JSON-RPC 2.0 success response.
 func writeRPCResult(w http.ResponseWriter, id, result any) {
 	data, _ := json.Marshal(result)
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, mimeJSON)
 	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
@@ -251,7 +256,7 @@ func writeRPCResult(w http.ResponseWriter, id, result any) {
 
 // writeRPCError writes a JSON-RPC 2.0 error response.
 func writeRPCError(w http.ResponseWriter, id any, code int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, mimeJSON)
 	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,

--- a/runtime/tools/http_executor.go
+++ b/runtime/tools/http_executor.go
@@ -28,6 +28,11 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+const (
+	headerContentType = "Content-Type"
+	mimeJSON          = "application/json"
+)
+
 // Default configuration values for HTTP tool execution.
 const (
 	defaultHTTPMethod       = "POST"
@@ -244,7 +249,7 @@ func (e *HTTPExecutor) buildRequest(
 	}
 
 	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(headerContentType, mimeJSON)
 	}
 
 	e.applyHeaders(req, cfg)
@@ -330,7 +335,7 @@ func (e *HTTPExecutor) buildMappedRequest(
 	}
 
 	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(headerContentType, mimeJSON)
 	}
 
 	if err := e.applyMappedHeaders(req, mapper, cfg.Request.HeaderParams, argsMap); err != nil {
@@ -514,7 +519,7 @@ func (e *HTTPExecutor) ExecuteMultimodal(
 	defer resp.Body.Close()
 
 	// Check if response is binary based on Content-Type.
-	contentType := resp.Header.Get("Content-Type")
+	contentType := resp.Header.Get(headerContentType)
 	if IsBinaryContentType(contentType, cfg.Multimodal.AcceptTypes) {
 		return e.handleBinaryResponse(resp, cfg)
 	}

--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -18,6 +18,7 @@ import (
 const (
 	errInvalidToolDescriptor  = "invalid tool descriptor in %s: %w"
 	errResultValidationFailed = "result validation failed: %v"
+	errToolTimeoutFormat      = "%s: %s exceeded %dms timeout"
 
 	// DefaultToolTimeout is the default execution timeout applied to tools
 	// that don't specify their own TimeoutMs. 30 seconds accommodates HTTP-calling
@@ -439,7 +440,7 @@ func (r *Registry) Execute(
 		errMsg := err.Error()
 		if execCtx.Err() == context.DeadlineExceeded {
 			errMsg = fmt.Sprintf(
-				"%s: %s exceeded %dms timeout",
+				errToolTimeoutFormat,
 				ErrToolTimeout, toolName, tool.TimeoutMs,
 			)
 			logger.Warn("tool execution timed out",
@@ -592,7 +593,7 @@ func (r *Registry) executeWithAsyncExecutor(
 		errMsg := err.Error()
 		if ctx.Err() == context.DeadlineExceeded {
 			errMsg = fmt.Sprintf(
-				"%s: %s exceeded %dms timeout",
+				errToolTimeoutFormat,
 				ErrToolTimeout, tool.Name, tool.TimeoutMs,
 			)
 		}
@@ -641,7 +642,7 @@ func (r *Registry) executeSyncFallback(
 		errMsg := err.Error()
 		if ctx.Err() == context.DeadlineExceeded {
 			errMsg = fmt.Sprintf(
-				"%s: %s exceeded %dms timeout",
+				errToolTimeoutFormat,
 				ErrToolTimeout, tool.Name, tool.TimeoutMs,
 			)
 		}

--- a/sdk/capability.go
+++ b/sdk/capability.go
@@ -8,6 +8,8 @@ import (
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
 )
 
+const logCapabilityInferred = "capability inferred from pack"
+
 // Capability represents a platform feature that provides namespaced tools.
 // Capabilities are auto-inferred from pack structure or explicitly added
 // via WithCapability.
@@ -57,15 +59,15 @@ func newCapabilityContext(p *pack.Pack, promptName string, cfg *config) Capabili
 func inferCapabilities(p *pack.Pack) []Capability {
 	var caps []Capability
 	if p.Workflow != nil {
-		logger.Debug("capability inferred from pack", "capability", "workflow")
+		logger.Debug(logCapabilityInferred, "capability", "workflow")
 		caps = append(caps, NewWorkflowCapability())
 	}
 	if p.Agents != nil && len(p.Agents.Members) > 0 {
-		logger.Debug("capability inferred from pack", "capability", "a2a", "agents", len(p.Agents.Members))
+		logger.Debug(logCapabilityInferred, "capability", "a2a", "agents", len(p.Agents.Members))
 		caps = append(caps, NewA2ACapability())
 	}
 	if len(p.Skills) > 0 {
-		logger.Debug("capability inferred from pack", "capability", "skills", "sources", len(p.Skills))
+		logger.Debug(logCapabilityInferred, "capability", "skills", "sources", len(p.Skills))
 		sources := convertSkillSources(p.Skills)
 		caps = append(caps, NewSkillsCapability(sources))
 	}

--- a/sdk/client_tools.go
+++ b/sdk/client_tools.go
@@ -12,6 +12,8 @@ import (
 	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
 )
 
+const errSerializeClientToolResult = "failed to serialize client tool result: %w"
+
 // ClientToolRequest contains information about a client-side tool invocation.
 // It is passed to handlers registered via [Conversation.OnClientTool].
 type ClientToolRequest struct {
@@ -194,7 +196,7 @@ func (c *Conversation) SendToolResult(_ context.Context, callID string, result a
 	}
 	resultJSON, err := json.Marshal(result)
 	if err != nil {
-		return fmt.Errorf("failed to serialize client tool result: %w", err)
+		return fmt.Errorf(errSerializeClientToolResult, err)
 	}
 	c.resolvedStore.Add(&sdktools.ToolResolution{
 		ID:         callID,
@@ -427,7 +429,7 @@ func (e *clientExecutor) executeHandler(
 	// Serialize result
 	resultJSON, err := json.Marshal(result)
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialize client tool result: %w", err)
+		return nil, fmt.Errorf(errSerializeClientToolResult, err)
 	}
 
 	return resultJSON, nil
@@ -470,7 +472,7 @@ func (e *clientExecutor) executeHandlerAsync(
 	// Default: JSON-serialize result
 	resultJSON, err := json.Marshal(result)
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialize client tool result: %w", err)
+		return nil, fmt.Errorf(errSerializeClientToolResult, err)
 	}
 
 	return &tools.ToolExecutionResult{

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -4,6 +4,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -19,6 +20,8 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+const errSessionClosed = "session is closed"
 
 // duplexSession implements BidirectionalSession with stage-based StreamPipeline.
 // It manages streaming input/output through the stage pipeline.
@@ -180,7 +183,7 @@ func (s *duplexSession) SendChunk(ctx context.Context, chunk *providers.StreamCh
 	s.closeMu.Lock()
 	if s.closed {
 		s.closeMu.Unlock()
-		return fmt.Errorf("session is closed")
+		return errors.New(errSessionClosed)
 	}
 	s.closeMu.Unlock()
 
@@ -219,7 +222,7 @@ func (s *duplexSession) SendText(ctx context.Context, text string) error {
 	s.closeMu.Lock()
 	if s.closed {
 		s.closeMu.Unlock()
-		return fmt.Errorf("session is closed")
+		return errors.New(errSessionClosed)
 	}
 	s.closeMu.Unlock()
 
@@ -235,7 +238,7 @@ func (s *duplexSession) SendFrame(ctx context.Context, frame *ImageFrame) error 
 	s.closeMu.Lock()
 	if s.closed {
 		s.closeMu.Unlock()
-		return fmt.Errorf("session is closed")
+		return errors.New(errSessionClosed)
 	}
 	s.closeMu.Unlock()
 
@@ -261,7 +264,7 @@ func (s *duplexSession) SendVideoChunk(ctx context.Context, vchunk *VideoChunk) 
 	s.closeMu.Lock()
 	if s.closed {
 		s.closeMu.Unlock()
-		return fmt.Errorf("session is closed")
+		return errors.New(errSessionClosed)
 	}
 	s.closeMu.Unlock()
 
@@ -494,7 +497,7 @@ func (s *duplexSession) SubmitToolResults(ctx context.Context, responses []provi
 	s.closeMu.Lock()
 	if s.closed {
 		s.closeMu.Unlock()
-		return fmt.Errorf("session is closed")
+		return errors.New(errSessionClosed)
 	}
 	s.closeMu.Unlock()
 


### PR DESCRIPTION
## Summary

Clears 8 more SonarCloud S1192 CRITICALs. Revives 6 of the 9 files from the closed PR #992 — the ones whose touched lines sit on code paths covered by existing unit tests.

## Changes

| File | Constant |
|------|----------|
| \`sdk/capability.go\` | \`logCapabilityInferred\` |
| \`sdk/client_tools.go\` | \`errSerializeClientToolResult\` |
| \`sdk/session/duplex_session.go\` | \`errSessionClosed\` (also switches \`fmt.Errorf\` → \`errors.New\` for the no-placeholder case) |
| \`runtime/tools/http_executor.go\` | \`headerContentType\`, \`mimeJSON\` |
| \`runtime/tools/registry.go\` | \`errToolTimeoutFormat\` |
| \`runtime/a2a/mock/mock.go\` | \`headerContentType\`, \`mimeJSON\` |

No behavior change.

## Still parked

The 3 files excluded from this PR — \`runtime/statestore/redis.go\`, \`runtime/storage/local/filestore.go\`, \`runtime/deploy/adaptersdk/serve.go\`, and \`pkg/config/loader.go\` — have S1192 literals on error branches that aren't hit by unit tests. Renaming them would fail SonarCloud's new_code_coverage gate again. They stay open until those error paths get coverage.

## Test plan

- [x] \`go build\` passes for runtime + sdk
- [x] Full test suites run
- [x] Pre-commit hook: lint + coverage all green (ranges 84%–100% on changed files)