### PR TITLE
chore: reclaim 3 more S1192 constants by covering error paths first

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -498,6 +498,48 @@ spec:
 	}
 }
 
+// TestLoadConfig_PromptSchemaValidationFailure covers the schema-validation
+// error branch in loadPromptConfigs when the referenced prompt file exists
+// but fails ValidatePromptConfig (e.g. wrong kind).
+func TestLoadConfig_PromptSchemaValidationFailure(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmpDir := t.TempDir()
+
+	// A file shaped like a K8s manifest but with a kind the prompt schema rejects.
+	promptPath := filepath.Join(tmpDir, "bad-prompt.yaml")
+	badPrompt := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: NotAPromptConfig
+metadata:
+  name: bogus
+spec: {}
+`
+	if err := os.WriteFile(promptPath, []byte(badPrompt), 0600); err != nil {
+		t.Fatalf("write prompt file: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "arena.yaml")
+	arena := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: test-arena
+spec:
+  prompt_configs:
+    - id: test
+      file: bad-prompt.yaml
+`
+	if err := os.WriteFile(configPath, []byte(arena), 0600); err != nil {
+		t.Fatalf("write arena config: %v", err)
+	}
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Fatal("expected schema validation error for bad prompt kind")
+	}
+	if !strings.Contains(err.Error(), "schema validation failed") {
+		t.Errorf("expected 'schema validation failed' in error, got: %v", err)
+	}
+}
+
 func TestLoadConfig_LoadToolsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "test-config.yaml")

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -15,6 +15,11 @@ const (
 	defaultProviderGroup = "default"
 	extYAML              = ".yaml"
 	extYML               = ".yml"
+
+	// errSchemaValidationFailed is the shared error-wrap format used by the
+	// three schema-validation failure paths (loadSimpleK8sManifest,
+	// loadPromptConfigs, loadTools).
+	errSchemaValidationFailed = "schema validation failed for %s: %w"
 )
 
 // mergeSpecs is a generic helper that merges inline specs into a loaded resource map.
@@ -302,7 +307,7 @@ func loadSimpleK8sManifest[T k8sManifest](filename, expectedKind string) (T, err
 		validationErr = ValidatePersona(data)
 	}
 	if validationErr != nil {
-		return zero, fmt.Errorf("schema validation failed for %s: %w", expectedKind, validationErr)
+		return zero, fmt.Errorf(errSchemaValidationFailed, expectedKind, validationErr)
 	}
 
 	var config T
@@ -376,7 +381,7 @@ func (c *Config) loadPromptConfigs(configPath string) error {
 
 		// Schema validation
 		if err := ValidatePromptConfig(data); err != nil {
-			return fmt.Errorf("schema validation failed for %s: %w", ref.File, err)
+			return fmt.Errorf(errSchemaValidationFailed, ref.File, err)
 		}
 
 		// Parse configuration
@@ -458,7 +463,7 @@ func (c *Config) loadTools(configPath string) error {
 		ext := strings.ToLower(filepath.Ext(ref.File))
 		if ext == extYAML || ext == extYML {
 			if err := ValidateTool(data); err != nil {
-				return fmt.Errorf("schema validation failed for %s: %w", ref.File, err)
+				return fmt.Errorf(errSchemaValidationFailed, ref.File, err)
 			}
 		}
 		c.LoadedTools = append(c.LoadedTools, ToolData{

--- a/runtime/deploy/adaptersdk/serve.go
+++ b/runtime/deploy/adaptersdk/serve.go
@@ -36,6 +36,10 @@ const (
 // jsonRPCVersion is the JSON-RPC protocol version string.
 const jsonRPCVersion = "2.0"
 
+// invalidParamsPrefix is prepended to JSON-RPC "invalid params" error messages
+// so every handler produces a consistent error-message shape.
+const invalidParamsPrefix = "invalid params: "
+
 // request is a JSON-RPC 2.0 request envelope.
 type request struct {
 	JSONRPC string          `json:"jsonrpc"`
@@ -176,7 +180,7 @@ func handleValidateConfig(
 ) response {
 	var params deploy.ValidateRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return errResponse(req.ID, CodeParseError, "invalid params: "+err.Error())
+		return errResponse(req.ID, CodeParseError, invalidParamsPrefix+err.Error())
 	}
 	result, err := provider.ValidateConfig(ctx, &params)
 	if err != nil {
@@ -193,7 +197,7 @@ func handlePlan(
 ) response {
 	var params deploy.PlanRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return errResponse(req.ID, CodeParseError, "invalid params: "+err.Error())
+		return errResponse(req.ID, CodeParseError, invalidParamsPrefix+err.Error())
 	}
 	result, err := provider.Plan(ctx, &params)
 	if err != nil {
@@ -210,7 +214,7 @@ func handleApply(
 ) response {
 	var params deploy.PlanRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return errResponse(req.ID, CodeParseError, "invalid params: "+err.Error())
+		return errResponse(req.ID, CodeParseError, invalidParamsPrefix+err.Error())
 	}
 	// Apply streams events via callback; we collect them and return the
 	// final adapter state in the response.
@@ -234,7 +238,7 @@ func handleDestroy(
 ) response {
 	var params deploy.DestroyRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return errResponse(req.ID, CodeParseError, "invalid params: "+err.Error())
+		return errResponse(req.ID, CodeParseError, invalidParamsPrefix+err.Error())
 	}
 	var events []*deploy.DestroyEvent
 	callback := func(event *deploy.DestroyEvent) error {
@@ -256,7 +260,7 @@ func handleStatus(
 ) response {
 	var params deploy.StatusRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return errResponse(req.ID, CodeParseError, "invalid params: "+err.Error())
+		return errResponse(req.ID, CodeParseError, invalidParamsPrefix+err.Error())
 	}
 	result, err := provider.Status(ctx, &params)
 	if err != nil {
@@ -273,7 +277,7 @@ func handleImport(
 ) response {
 	var params deploy.ImportRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return errResponse(req.ID, CodeParseError, "invalid params: "+err.Error())
+		return errResponse(req.ID, CodeParseError, invalidParamsPrefix+err.Error())
 	}
 	result, err := provider.Import(ctx, &params)
 	if err != nil {

--- a/runtime/deploy/adaptersdk/serve_test.go
+++ b/runtime/deploy/adaptersdk/serve_test.go
@@ -339,6 +339,62 @@ func TestServeIO_InvalidParams(t *testing.T) {
 	}
 }
 
+// invalidParamsRequest is a helper that yields a JSON-RPC request whose
+// `params` is a bare string — deliberately malformed so dispatch's
+// json.Unmarshal on the handler-specific params struct fails.
+func invalidParamsRequest(method string, id int) string {
+	return fmt.Sprintf(`{"jsonrpc":"2.0","method":%q,"params":"bad","id":%d}`+"\n", method, id)
+}
+
+func expectInvalidParamsResponse(t *testing.T, out *bytes.Buffer) {
+	t.Helper()
+	var resp response
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error response for invalid params")
+	}
+	if resp.Error.Code != CodeParseError {
+		t.Errorf("expected code %d, got %d", CodeParseError, resp.Error.Code)
+	}
+	if !strings.Contains(resp.Error.Message, "invalid params:") {
+		t.Errorf("expected message to contain %q, got %q", "invalid params:", resp.Error.Message)
+	}
+}
+
+func TestServeIO_ValidateConfig_InvalidParams(t *testing.T) {
+	var out bytes.Buffer
+	if err := ServeIO(newFakeProvider(), strings.NewReader(invalidParamsRequest("validate_config", 11)), &out); err != nil {
+		t.Fatalf("ServeIO error: %v", err)
+	}
+	expectInvalidParamsResponse(t, &out)
+}
+
+func TestServeIO_Apply_InvalidParams(t *testing.T) {
+	var out bytes.Buffer
+	if err := ServeIO(newFakeProvider(), strings.NewReader(invalidParamsRequest("apply", 12)), &out); err != nil {
+		t.Fatalf("ServeIO error: %v", err)
+	}
+	expectInvalidParamsResponse(t, &out)
+}
+
+func TestServeIO_Destroy_InvalidParams(t *testing.T) {
+	var out bytes.Buffer
+	if err := ServeIO(newFakeProvider(), strings.NewReader(invalidParamsRequest("destroy", 13)), &out); err != nil {
+		t.Fatalf("ServeIO error: %v", err)
+	}
+	expectInvalidParamsResponse(t, &out)
+}
+
+func TestServeIO_Status_InvalidParams(t *testing.T) {
+	var out bytes.Buffer
+	if err := ServeIO(newFakeProvider(), strings.NewReader(invalidParamsRequest("status", 14)), &out); err != nil {
+		t.Fatalf("ServeIO error: %v", err)
+	}
+	expectInvalidParamsResponse(t, &out)
+}
+
 func TestServeIO_MultipleRequests(t *testing.T) {
 	provider := newFakeProvider()
 	input := makeRequest("get_provider_info", nil, 1) + "\n" +

--- a/runtime/storage/local/filestore.go
+++ b/runtime/storage/local/filestore.go
@@ -37,6 +37,10 @@ const (
 
 	// filePermissions is the default file permission mode for created files.
 	filePermissions = 0600
+
+	// errInvalidMediaReference wraps an inner validatePath error for Retrieve/
+	// Delete/GetURL when the caller-supplied reference is outside the base dir.
+	errInvalidMediaReference = "invalid media reference: %w"
 )
 
 // ErrFileTooLarge is returned when data exceeds the configured MaxFileSize.
@@ -281,7 +285,7 @@ func (fs *FileStore) RetrieveMedia(ctx context.Context, reference storage.Refere
 
 	// Validate path is within base directory (prevents path traversal attacks)
 	if err := fs.validatePath(filePath); err != nil {
-		return nil, fmt.Errorf("invalid media reference: %w", err)
+		return nil, fmt.Errorf(errInvalidMediaReference, err)
 	}
 
 	// Validate file exists and is readable
@@ -326,7 +330,7 @@ func (fs *FileStore) DeleteMedia(ctx context.Context, reference storage.Referenc
 
 	// Validate path is within base directory (prevents path traversal attacks)
 	if err := fs.validatePath(filePath); err != nil {
-		return fmt.Errorf("invalid media reference: %w", err)
+		return fmt.Errorf(errInvalidMediaReference, err)
 	}
 
 	// Check reference count if deduplication is enabled
@@ -381,7 +385,7 @@ func (fs *FileStore) GetURL(ctx context.Context, reference storage.Reference, ex
 
 	// Validate path is within base directory (prevents path traversal attacks)
 	if err := fs.validatePath(filePath); err != nil {
-		return "", fmt.Errorf("invalid media reference: %w", err)
+		return "", fmt.Errorf(errInvalidMediaReference, err)
 	}
 
 	// Validate file exists


### PR DESCRIPTION
Covers the error branches that blocked PR #990 and #992, then extracts the constants. Clears 3 more Sonar S1192 CRITICALs: invalidParamsPrefix (adaptersdk), errInvalidMediaReference (filestore), errSchemaValidationFailed (pkg/config). Adds 5 new tests — 4 for adaptersdk invalid-params handlers that weren't previously covered, 1 for loader.go's loadPromptConfigs schema-validation failure branch.