### PR TITLE
refactor(types): split getMediaItemSummary (Sonar S3776)

### DIFF
--- a/runtime/types/message.go
+++ b/runtime/types/message.go
@@ -468,6 +468,55 @@ func (m *Message) getMediaSummary() *MediaSummary {
 	return summary
 }
 
+// estimateBase64DecodedSize returns the approximate decoded-byte count for a
+// base64-encoded string. Every 4 base64 chars encode 3 bytes of payload; we
+// ignore padding for this rough estimate.
+func estimateBase64DecodedSize(data string) int {
+	const (
+		base64Ratio     = 4
+		base64Numerator = 3
+	)
+	return (len(data) * base64Numerator) / base64Ratio
+}
+
+// hasInlineData returns true when a MediaContent carries a non-empty base64 Data string.
+func hasInlineData(media *MediaContent) bool {
+	return media.Data != nil && *media.Data != ""
+}
+
+// populateMediaSource fills Source/Loaded/SizeBytes on item based on which
+// MediaContent field identifies the media. FilePath/URL/StorageReference take
+// priority over inline data for display; the SizeBytes estimate is only
+// applied on the FilePath and inline-data branches to preserve the
+// pre-refactor behavior.
+func populateMediaSource(item *MediaItemSummary, media *MediaContent) {
+	switch {
+	case media.FilePath != nil:
+		item.Source = *media.FilePath
+		if hasInlineData(media) {
+			item.Loaded = true
+			item.SizeBytes = estimateBase64DecodedSize(*media.Data)
+		}
+	case media.URL != nil:
+		item.Source = *media.URL
+		if hasInlineData(media) {
+			item.Loaded = true
+		}
+	case media.StorageReference != nil:
+		// StorageReference means media was externalized to storage; we don't
+		// mark Loaded here because the reference alone doesn't imply the data
+		// has been fetched into memory.
+		item.Source = *media.StorageReference
+	case hasInlineData(media):
+		item.Source = "inline data"
+		item.Loaded = true
+		item.SizeBytes = estimateBase64DecodedSize(*media.Data)
+	default:
+		item.Source = "unknown"
+		item.Error = "no data source"
+	}
+}
+
 // getMediaItemSummary extracts summary information from a media ContentPart.
 func getMediaItemSummary(part ContentPart) MediaItemSummary {
 	item := MediaItemSummary{
@@ -481,48 +530,13 @@ func getMediaItemSummary(part ContentPart) MediaItemSummary {
 	}
 
 	item.MIMEType = part.Media.MIMEType
+	populateMediaSource(&item, part.Media)
 
-	// Determine source - prefer FilePath/URL/StorageReference over "inline data" for better display
-	if part.Media.FilePath != nil {
-		item.Source = *part.Media.FilePath
-		// If Data field is also set, media was successfully loaded
-		if part.Media.Data != nil && *part.Media.Data != "" {
-			item.Loaded = true
-			// Estimate size from base64 data (roughly 3/4 of base64 length)
-			const (
-				base64Ratio     = 4
-				base64Numerator = 3
-			)
-			item.SizeBytes = (len(*part.Media.Data) * base64Numerator) / base64Ratio
-		}
-	} else if part.Media.URL != nil {
-		item.Source = *part.Media.URL
-		if part.Media.Data != nil && *part.Media.Data != "" {
-			item.Loaded = true
-		}
-	} else if part.Media.StorageReference != nil {
-		item.Source = *part.Media.StorageReference
-		// StorageReference means media was externalized to storage
-	} else if part.Media.Data != nil && *part.Media.Data != "" {
-		item.Source = "inline data"
-		item.Loaded = true
-		// Estimate size from base64 data (roughly 3/4 of base64 length)
-		const (
-			base64Ratio     = 4
-			base64Numerator = 3
-		)
-		item.SizeBytes = (len(*part.Media.Data) * base64Numerator) / base64Ratio
-	} else {
-		item.Source = "unknown"
-		item.Error = "no data source"
-	}
-
-	// Add detail level for images
 	if part.Type == ContentTypeImage && part.Media.Detail != nil {
 		item.Detail = *part.Media.Detail
 	}
 
-	// Use size metadata if available
+	// SizeKB metadata overrides any base64-derived estimate.
 	if part.Media.SizeKB != nil {
 		const bytesPerKB = 1024
 		item.SizeBytes = int(*part.Media.SizeKB * bytesPerKB)

--- a/runtime/types/message_marshal_test.go
+++ b/runtime/types/message_marshal_test.go
@@ -465,3 +465,144 @@ func TestMediaSummary_Counts(t *testing.T) {
 func strPtr(s string) *string {
 	return &s
 }
+
+// TestGetMediaItemSummary locks in the per-branch behavior of getMediaItemSummary
+// ahead of an S3776 cognitive-complexity refactor. If a refactor changes observable
+// behavior, these will catch it.
+func TestGetMediaItemSummary(t *testing.T) {
+	const base64Text = "YWJjZGVmZ2hpamtsbW5vcA==" // 24 chars → expect 18 bytes
+	const expectedBase64Bytes = 18
+
+	t.Run("nil media reports error and exits", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{Type: ContentTypeImage, Media: nil})
+		if got.Error != "no media content" {
+			t.Errorf("Error = %q, want %q", got.Error, "no media content")
+		}
+		if got.Loaded {
+			t.Error("Loaded should be false for nil media")
+		}
+	})
+
+	t.Run("file path without data sets source but not loaded", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeImage,
+			Media: &MediaContent{FilePath: strPtr("/img.jpg"), MIMEType: MIMETypeImageJPEG},
+		})
+		if got.Source != "/img.jpg" {
+			t.Errorf("Source = %q, want %q", got.Source, "/img.jpg")
+		}
+		if got.Loaded {
+			t.Error("Loaded should be false without Data")
+		}
+		if got.SizeBytes != 0 {
+			t.Errorf("SizeBytes = %d, want 0", got.SizeBytes)
+		}
+	})
+
+	t.Run("file path with data sets loaded and estimates size", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeImage,
+			Media: &MediaContent{FilePath: strPtr("/img.jpg"), Data: strPtr(base64Text), MIMEType: MIMETypeImageJPEG},
+		})
+		if got.Source != "/img.jpg" {
+			t.Errorf("Source = %q, want %q", got.Source, "/img.jpg")
+		}
+		if !got.Loaded {
+			t.Error("Loaded should be true when Data is non-empty")
+		}
+		if got.SizeBytes != expectedBase64Bytes {
+			t.Errorf("SizeBytes = %d, want %d (estimated from base64)", got.SizeBytes, expectedBase64Bytes)
+		}
+	})
+
+	t.Run("url source with data sets loaded but no size estimate", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeImage,
+			Media: &MediaContent{URL: strPtr("https://x/y.jpg"), Data: strPtr(base64Text)},
+		})
+		if got.Source != "https://x/y.jpg" {
+			t.Errorf("Source = %q, want URL", got.Source)
+		}
+		if !got.Loaded {
+			t.Error("Loaded should be true when Data is set on URL branch")
+		}
+		if got.SizeBytes != 0 {
+			// URL branch intentionally doesn't estimate size from base64.
+			t.Errorf("SizeBytes = %d, want 0 (URL branch does not estimate)", got.SizeBytes)
+		}
+	})
+
+	t.Run("storage reference sets source but leaves Loaded false", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeImage,
+			Media: &MediaContent{StorageReference: strPtr("store://ref"), MIMEType: MIMETypeImageJPEG},
+		})
+		if got.Source != "store://ref" {
+			t.Errorf("Source = %q, want store://ref", got.Source)
+		}
+		if got.Loaded {
+			t.Error("Loaded should remain false for storage reference branch")
+		}
+	})
+
+	t.Run("inline data only sets loaded and estimates size", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeImage,
+			Media: &MediaContent{Data: strPtr(base64Text), MIMEType: MIMETypeImageJPEG},
+		})
+		if got.Source != "inline data" {
+			t.Errorf("Source = %q, want %q", got.Source, "inline data")
+		}
+		if !got.Loaded {
+			t.Error("Loaded should be true for inline data")
+		}
+		if got.SizeBytes != expectedBase64Bytes {
+			t.Errorf("SizeBytes = %d, want %d", got.SizeBytes, expectedBase64Bytes)
+		}
+	})
+
+	t.Run("no data source reports error", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeImage,
+			Media: &MediaContent{MIMEType: MIMETypeImageJPEG},
+		})
+		if got.Source != "unknown" {
+			t.Errorf("Source = %q, want unknown", got.Source)
+		}
+		if got.Error != "no data source" {
+			t.Errorf("Error = %q, want %q", got.Error, "no data source")
+		}
+	})
+
+	t.Run("image detail is copied when present", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeImage,
+			Media: &MediaContent{FilePath: strPtr("/img.jpg"), Detail: strPtr("high"), MIMEType: MIMETypeImageJPEG},
+		})
+		if got.Detail != "high" {
+			t.Errorf("Detail = %q, want high", got.Detail)
+		}
+	})
+
+	t.Run("detail is ignored for non-image types", func(t *testing.T) {
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeAudio,
+			Media: &MediaContent{FilePath: strPtr("/a.wav"), Detail: strPtr("high"), MIMEType: MIMETypeAudioWAV},
+		})
+		if got.Detail != "" {
+			t.Errorf("Detail = %q, want empty for non-image", got.Detail)
+		}
+	})
+
+	t.Run("SizeKB overrides base64 size estimate", func(t *testing.T) {
+		kb := int64(10)
+		got := getMediaItemSummary(ContentPart{
+			Type:  ContentTypeImage,
+			Media: &MediaContent{FilePath: strPtr("/img.jpg"), Data: strPtr(base64Text), SizeKB: &kb, MIMEType: MIMETypeImageJPEG},
+		})
+		const expectedBytes = 10 * 1024
+		if got.SizeBytes != expectedBytes {
+			t.Errorf("SizeBytes = %d, want %d (from SizeKB)", got.SizeBytes, expectedBytes)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Clears one Sonar S3776 cognitive-complexity CRITICAL (\`runtime/types/message.go:472\`, was 16 / allowed 15). First in a series of small, behavior-preserving S3776 cleanups, each backed by characterization tests.

## Why & how

\`getMediaItemSummary\` mixed three concerns in one function body: a nil-check, a 5-way source-picking if/else-if chain (with nested base64 size-estimate duplication), and post-processing for image detail + SizeKB override.

Split into three helpers, each with a single responsibility:

- \`estimateBase64DecodedSize(data)\` — deduplicates the \`(len * 3) / 4\` calculation that previously appeared in two branches
- \`hasInlineData(media)\` — named predicate for the repeated \`media.Data != nil && *media.Data != ""\` check
- \`populateMediaSource(item, media)\` — the source-picking switch, preserving the subtle per-branch differences (FilePath and inline-data estimate size; URL does not; StorageReference does not mark \`Loaded\`)

\`getMediaItemSummary\` is now a thin orchestrator: nil-check → MIME → populate source → image detail → SizeKB override.

## Test plan

- [x] 10-case characterization test \`TestGetMediaItemSummary\` added BEFORE the refactor locks in every branch (nil media, FilePath ± data, URL ± data, StorageReference, inline data only, no source, image detail, non-image detail ignored, SizeKB override)
- [x] All 10 pass both before and after the refactor — behavior preserved
- [x] \`runtime/types\` coverage rises from 84.8% → 87.4%
- [x] \`go test ./runtime/...\`, golangci-lint both clean
- [x] Pre-commit hook: 90.6% on changed file

## Scope

Intentionally narrow. The sibling \`getMediaItemSummaryFromPart\` in \`tools/arena/render/media.go\` (which mirrors this function but with its own subtle differences around \`Loaded\` semantics) stays as-is — consolidating the two is a larger cross-package refactor that deserves its own design discussion.