### PR TITLE
refactor(tools): split coerceStringValue per target type (Sonar S3776)

### DIFF
--- a/runtime/tools/validator.go
+++ b/runtime/tools/validator.go
@@ -442,49 +442,71 @@ func normalizeEnum(val string, enum []string) (string, bool) {
 }
 
 // coerceStringValue converts a string to the target JSON schema type.
-// Returns nil if no coercion is needed (e.g., target type is "string").
+// Returns (nil, nil) if no coercion is defined for targetType (e.g., "string"
+// or anything unrecognized — the caller treats that as "leave the value alone").
 func coerceStringValue(s, targetType string) (any, error) {
 	switch targetType {
 	case "integer":
-		if v, err := strconv.ParseInt(s, 10, 64); err == nil {
-			return v, nil
-		}
-		// Fall back: "5.0" → parse as float, truncate if no fractional part.
-		if f, err := strconv.ParseFloat(s, 64); err == nil {
-			if f == math.Trunc(f) {
-				return int64(f), nil
-			}
-		}
-		return nil, fmt.Errorf("cannot parse %q as integer", s)
+		return coerceStringToInteger(s)
 	case "number":
 		return strconv.ParseFloat(s, 64)
 	case "boolean":
-		// strconv.ParseBool handles "true", "false", "1", "0", "t", "f".
-		if v, err := strconv.ParseBool(s); err == nil {
-			return v, nil
-		}
-		// Extended: "yes"/"no" (case-insensitive).
-		switch strings.ToLower(strings.TrimSpace(s)) {
-		case "yes":
-			return true, nil
-		case "no":
-			return false, nil
-		}
-		return nil, fmt.Errorf("cannot parse %q as boolean", s)
+		return coerceStringToBoolean(s)
 	case "object":
-		var obj map[string]any
-		if err := json.Unmarshal([]byte(s), &obj); err != nil {
-			return nil, err
-		}
-		return obj, nil
+		return coerceStringToObject(s)
 	case "array":
-		var arr []any
-		if err := json.Unmarshal([]byte(s), &arr); err == nil {
-			return arr, nil
-		}
-		// Bare string → single-element array.
-		return []any{s}, nil
+		return coerceStringToArray(s)
 	default:
 		return nil, nil
 	}
+}
+
+// coerceStringToInteger parses s as int64 directly, falling back to a
+// whole-number float (so "5.0" is acceptable but "3.14" is not).
+func coerceStringToInteger(s string) (any, error) {
+	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return v, nil
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil && f == math.Trunc(f) {
+		return int64(f), nil
+	}
+	return nil, fmt.Errorf("cannot parse %q as integer", s)
+}
+
+// coerceStringToBoolean parses s as a bool. Accepts strconv.ParseBool's
+// canonical forms ("true"/"false"/"1"/"0"/"t"/"f") and, case-insensitively
+// with whitespace trimmed, the natural-language forms "yes" and "no".
+func coerceStringToBoolean(s string) (any, error) {
+	if v, err := strconv.ParseBool(s); err == nil {
+		return v, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "yes":
+		return true, nil
+	case "no":
+		return false, nil
+	}
+	return nil, fmt.Errorf("cannot parse %q as boolean", s)
+}
+
+// coerceStringToObject parses s as a JSON object. Returns an error when the
+// string isn't valid JSON — unlike array coercion there's no sensible fallback
+// for a bare value.
+func coerceStringToObject(s string) (any, error) {
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// coerceStringToArray parses s as a JSON array, falling back to wrapping the
+// bare string in a single-element slice so simple tool arguments like "tag1"
+// still validate against schemas expecting an array.
+func coerceStringToArray(s string) (any, error) {
+	var arr []any
+	if err := json.Unmarshal([]byte(s), &arr); err == nil {
+		return arr, nil
+	}
+	return []any{s}, nil
 }

--- a/runtime/tools/validator_test.go
+++ b/runtime/tools/validator_test.go
@@ -447,3 +447,95 @@ func TestCoerceArgs(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// TestCoerceStringValue locks in per-branch behavior of the package-private
+// coerceStringValue helper ahead of an S3776 cognitive-complexity refactor.
+func TestCoerceStringValue(t *testing.T) {
+	t.Run("integer parses plain number", func(t *testing.T) {
+		v, err := coerceStringValue("42", "integer")
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), v)
+	})
+
+	t.Run("integer falls back to float when fractional part is zero", func(t *testing.T) {
+		v, err := coerceStringValue("5.0", "integer")
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), v)
+	})
+
+	t.Run("integer rejects non-integer float", func(t *testing.T) {
+		_, err := coerceStringValue("3.14", "integer")
+		assert.Error(t, err)
+	})
+
+	t.Run("integer rejects non-numeric string", func(t *testing.T) {
+		_, err := coerceStringValue("abc", "integer")
+		assert.Error(t, err)
+	})
+
+	t.Run("number parses float", func(t *testing.T) {
+		v, err := coerceStringValue("0.85", "number")
+		require.NoError(t, err)
+		assert.Equal(t, 0.85, v)
+	})
+
+	t.Run("number rejects non-numeric", func(t *testing.T) {
+		_, err := coerceStringValue("abc", "number")
+		assert.Error(t, err)
+	})
+
+	t.Run("boolean parses strconv forms", func(t *testing.T) {
+		for _, s := range []string{"true", "false", "1", "0", "t", "f"} {
+			_, err := coerceStringValue(s, "boolean")
+			assert.NoError(t, err, "input: %q", s)
+		}
+	})
+
+	t.Run("boolean accepts yes and no case-insensitively with trim", func(t *testing.T) {
+		v, err := coerceStringValue("  YES ", "boolean")
+		require.NoError(t, err)
+		assert.Equal(t, true, v)
+
+		v, err = coerceStringValue("No", "boolean")
+		require.NoError(t, err)
+		assert.Equal(t, false, v)
+	})
+
+	t.Run("boolean rejects garbage", func(t *testing.T) {
+		_, err := coerceStringValue("maybe", "boolean")
+		assert.Error(t, err)
+	})
+
+	t.Run("object parses JSON map", func(t *testing.T) {
+		v, err := coerceStringValue(`{"k":"v","n":1}`, "object")
+		require.NoError(t, err)
+		m, ok := v.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "v", m["k"])
+	})
+
+	t.Run("object rejects non-JSON string", func(t *testing.T) {
+		_, err := coerceStringValue("not json", "object")
+		assert.Error(t, err)
+	})
+
+	t.Run("array parses JSON array", func(t *testing.T) {
+		v, err := coerceStringValue(`["a","b",3]`, "array")
+		require.NoError(t, err)
+		a, ok := v.([]any)
+		require.True(t, ok)
+		assert.Len(t, a, 3)
+	})
+
+	t.Run("array wraps bare string as single-element slice", func(t *testing.T) {
+		v, err := coerceStringValue("bare", "array")
+		require.NoError(t, err)
+		assert.Equal(t, []any{"bare"}, v)
+	})
+
+	t.Run("unknown target type returns (nil, nil) for no-op", func(t *testing.T) {
+		v, err := coerceStringValue("x", "mystery")
+		require.NoError(t, err)
+		assert.Nil(t, v)
+	})
+}


### PR DESCRIPTION
Clears go:S3776 on coerceStringValue (was complexity 16, allowed 15). Extracts 4 per-type helpers (integer, boolean, object, array) so the top-level function becomes a flat dispatch. 14-case characterization test added before the refactor covers every branch including previously-untested ones ("5.0"→int fallback, yes/no boolean, bare-string array wrap, unknown-type no-op). Coverage on validator.go goes 91.2% → 93.6%.