### PR TITLE
fix(arena-web): bump Vite 6.4.1 → 6.4.2 (HIGH-severity dev-server CVEs)

### DIFF
--- a/tools/arena/web/frontend/package-lock.json
+++ b/tools/arena/web/frontend/package-lock.json
@@ -5148,9 +5148,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Closes two HIGH-severity Vite advisories that `npm audit` has been flagging on the arena web frontend:

- [GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9) — path traversal in optimized deps `.map` handling
- [GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583) — arbitrary file read via Vite dev server WebSocket

Both are dev-server bugs, so real-world exposure is bounded to anyone running `npm run dev` on a host reachable by an attacker. Still a high rating — not worth sitting on.

## Change

`npm audit fix` bumps the transitive `vite` dependency from 6.4.1 to 6.4.2 (a patch release). No `package.json` range change needed. 3-line lock diff.

## Test plan

- [x] `npm audit` now reports `found 0 vulnerabilities` in the frontend
- [x] Other npm workspaces (packc-action, promptarena-action, npm/packc, npm/promptarena) already clean, no follow-ups needed
- [x] `npm run build` succeeds under Vite 6.4.2
- [x] `npm run test:ci` passes (20/20 unit tests, utils.ts 100% covered)