### PR TITLE
fix(providers): hyperscaler routing — openai+azure (#1010), gemini+vertex (#1009 cell)

### DIFF
--- a/examples/azure-foundry-test/config.arena.yaml
+++ b/examples/azure-foundry-test/config.arena.yaml
@@ -1,0 +1,40 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+
+metadata:
+  name: azure-foundry-test
+
+spec:
+  prompt_configs:
+    - id: capability-test
+      file: prompts/capability-test.yaml
+
+  providers:
+    - file: providers/openai-azure-gpt4o.provider.yaml
+      group: text,streaming,tools
+
+  scenarios:
+    - file: scenarios/text-basic.scenario.yaml
+    - file: scenarios/streaming.scenario.yaml
+    - file: scenarios/tools.scenario.yaml
+
+  tools:
+    - file: tools/get-weather.tool.yaml
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 200
+    concurrency: 1
+    output:
+      dir: out
+      formats: ["json", "html", "markdown"]
+      html:
+        file: azure-foundry.html
+      markdown:
+        file: azure-foundry.md
+        include_details: true
+        show_overview: true
+        show_results_matrix: true
+        show_failed_tests: true
+        show_cost_summary: true
+    fail_on: []

--- a/examples/azure-foundry-test/prompts/capability-test.yaml
+++ b/examples/azure-foundry-test/prompts/capability-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+
+metadata:
+  name: capability-test
+
+spec:
+  version: "1.0.0"
+  description: "Minimal prompt for testing Azure Foundry"
+  task_type: "capability-test"
+
+  system_template: |
+    You are a capability testing assistant. Follow instructions precisely.
+    When asked to say something specific, include it exactly as requested.
+    When asked to call a tool, call the appropriate tool with the specified parameters.
+
+  allowed_tools:
+    - get_weather

--- a/examples/azure-foundry-test/providers/openai-azure-gpt4o.provider.yaml
+++ b/examples/azure-foundry-test/providers/openai-azure-gpt4o.provider.yaml
@@ -1,0 +1,23 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-azure-gpt4o
+spec:
+  id: openai-azure-gpt4o
+  type: openai
+  model: gpt-4o
+  platform:
+    type: azure
+    endpoint: https://aoai-omnia-demo-33eebkdcvsi4a.cognitiveservices.azure.com
+  capabilities:
+    - text
+    - streaming
+    - tools
+    - json
+  defaults:
+    temperature: 0.1
+    max_tokens: 100
+    top_p: 1.0
+  pricing:
+    input_cost_per_1k: 0.0025
+    output_cost_per_1k: 0.01

--- a/examples/azure-foundry-test/scenarios/streaming.scenario.yaml
+++ b/examples/azure-foundry-test/scenarios/streaming.scenario.yaml
@@ -1,0 +1,30 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: streaming
+
+spec:
+  id: streaming
+  task_type: capability-test
+  description: "Test streaming response against Azure Foundry"
+  required_capabilities:
+    - streaming
+  streaming: true
+  tool_policy:
+    tool_choice: none
+    max_tool_calls_per_turn: 0
+    max_total_tool_calls: 0
+
+  turns:
+    - role: user
+      content: "Count from 1 to 5, one number per line, then say AZURE_FOUNDRY_PASS on a new line."
+      assertions:
+        - type: content_includes
+          message: "Streaming response should include AZURE_FOUNDRY_PASS"
+          params:
+            patterns: ["AZURE_FOUNDRY_PASS"]
+        - type: content_matches
+          message: "Should contain numbers 1-5"
+          params:
+            pattern: "[1-5]"

--- a/examples/azure-foundry-test/scenarios/text-basic.scenario.yaml
+++ b/examples/azure-foundry-test/scenarios/text-basic.scenario.yaml
@@ -1,0 +1,25 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: text-basic
+
+spec:
+  id: text-basic
+  task_type: capability-test
+  description: "Test basic text completion against Azure Foundry"
+  required_capabilities:
+    - text
+  tool_policy:
+    tool_choice: none
+    max_tool_calls_per_turn: 0
+    max_total_tool_calls: 0
+
+  turns:
+    - role: user
+      content: "Say exactly: AZURE_FOUNDRY_PASS"
+      assertions:
+        - type: content_includes
+          message: "Response should include AZURE_FOUNDRY_PASS"
+          params:
+            patterns: ["AZURE_FOUNDRY_PASS"]

--- a/examples/azure-foundry-test/scenarios/tools.scenario.yaml
+++ b/examples/azure-foundry-test/scenarios/tools.scenario.yaml
@@ -1,0 +1,22 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: tools
+
+spec:
+  id: tools
+  task_type: capability-test
+  description: "Test function calling against Azure Foundry"
+  required_capabilities:
+    - tools
+
+  turns:
+    - role: user
+      content: "Call the get_weather function for New York City and tell me the result."
+      assertions:
+        - type: tools_called
+          message: "Should call the get_weather tool"
+          params:
+            tools:
+              - "get_weather"

--- a/examples/azure-foundry-test/tools/get-weather.tool.yaml
+++ b/examples/azure-foundry-test/tools/get-weather.tool.yaml
@@ -1,0 +1,22 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+
+metadata:
+  name: get_weather
+
+spec:
+  name: get_weather
+  description: Get the current weather for a location
+  input_schema:
+    type: object
+    properties:
+      location:
+        type: string
+        description: The city or location to get weather for
+    required:
+      - location
+  output_schema:
+    type: string
+  mode: mock
+  mock_result: "Sunny, 72F"
+  timeout_ms: 5000

--- a/examples/bedrock-test/config.arena.yaml
+++ b/examples/bedrock-test/config.arena.yaml
@@ -1,0 +1,40 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+
+metadata:
+  name: bedrock-test
+
+spec:
+  prompt_configs:
+    - id: capability-test
+      file: prompts/capability-test.yaml
+
+  providers:
+    - file: providers/claude-bedrock-haiku45.provider.yaml
+      group: text,streaming,tools
+
+  scenarios:
+    - file: scenarios/text-basic.scenario.yaml
+    - file: scenarios/streaming.scenario.yaml
+    - file: scenarios/tools.scenario.yaml
+
+  tools:
+    - file: tools/get-weather.tool.yaml
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 200
+    concurrency: 1
+    output:
+      dir: out
+      formats: ["json", "html", "markdown"]
+      html:
+        file: bedrock.html
+      markdown:
+        file: bedrock.md
+        include_details: true
+        show_overview: true
+        show_results_matrix: true
+        show_failed_tests: true
+        show_cost_summary: true
+    fail_on: []

--- a/examples/bedrock-test/prompts/capability-test.yaml
+++ b/examples/bedrock-test/prompts/capability-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+
+metadata:
+  name: capability-test
+
+spec:
+  version: "1.0.0"
+  description: "Minimal prompt for testing AWS Bedrock"
+  task_type: "capability-test"
+
+  system_template: |
+    You are a capability testing assistant. Follow instructions precisely.
+    When asked to say something specific, include it exactly as requested.
+    When asked to call a tool, call the appropriate tool with the specified parameters.
+
+  allowed_tools:
+    - get_weather

--- a/examples/bedrock-test/providers/claude-bedrock-haiku45.provider.yaml
+++ b/examples/bedrock-test/providers/claude-bedrock-haiku45.provider.yaml
@@ -1,0 +1,23 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: claude-bedrock-haiku45
+spec:
+  id: claude-bedrock-haiku45
+  type: claude
+  model: us.anthropic.claude-haiku-4-5-20251001-v1:0
+  base_url: https://bedrock-runtime.us-west-2.amazonaws.com
+  platform:
+    type: bedrock
+    region: us-west-2
+  capabilities:
+    - text
+    - streaming
+    - tools
+  defaults:
+    temperature: 0.1
+    max_tokens: 200
+    top_p: 1.0
+  pricing:
+    input_cost_per_1k: 0.001
+    output_cost_per_1k: 0.005

--- a/examples/bedrock-test/scenarios/streaming.scenario.yaml
+++ b/examples/bedrock-test/scenarios/streaming.scenario.yaml
@@ -1,0 +1,30 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: streaming
+
+spec:
+  id: streaming
+  task_type: capability-test
+  description: "Test streaming response against AWS Bedrock"
+  required_capabilities:
+    - streaming
+  streaming: true
+  tool_policy:
+    tool_choice: none
+    max_tool_calls_per_turn: 0
+    max_total_tool_calls: 0
+
+  turns:
+    - role: user
+      content: "Count from 1 to 5, one number per line, then say BEDROCK_PASS on a new line."
+      assertions:
+        - type: content_includes
+          message: "Streaming response should include BEDROCK_PASS"
+          params:
+            patterns: ["BEDROCK_PASS"]
+        - type: content_matches
+          message: "Should contain numbers 1-5"
+          params:
+            pattern: "[1-5]"

--- a/examples/bedrock-test/scenarios/text-basic.scenario.yaml
+++ b/examples/bedrock-test/scenarios/text-basic.scenario.yaml
@@ -1,0 +1,25 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: text-basic
+
+spec:
+  id: text-basic
+  task_type: capability-test
+  description: "Test basic text completion against AWS Bedrock"
+  required_capabilities:
+    - text
+  tool_policy:
+    tool_choice: none
+    max_tool_calls_per_turn: 0
+    max_total_tool_calls: 0
+
+  turns:
+    - role: user
+      content: "Say exactly: BEDROCK_PASS"
+      assertions:
+        - type: content_includes
+          message: "Response should include BEDROCK_PASS"
+          params:
+            patterns: ["BEDROCK_PASS"]

--- a/examples/bedrock-test/scenarios/tools.scenario.yaml
+++ b/examples/bedrock-test/scenarios/tools.scenario.yaml
@@ -1,0 +1,22 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: tools
+
+spec:
+  id: tools
+  task_type: capability-test
+  description: "Test function calling against AWS Bedrock"
+  required_capabilities:
+    - tools
+
+  turns:
+    - role: user
+      content: "Call the get_weather function for New York City and tell me the result."
+      assertions:
+        - type: tools_called
+          message: "Should call the get_weather tool"
+          params:
+            tools:
+              - "get_weather"

--- a/examples/bedrock-test/tools/get-weather.tool.yaml
+++ b/examples/bedrock-test/tools/get-weather.tool.yaml
@@ -1,0 +1,22 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+
+metadata:
+  name: get_weather
+
+spec:
+  name: get_weather
+  description: Get the current weather for a location
+  input_schema:
+    type: object
+    properties:
+      location:
+        type: string
+        description: The city or location to get weather for
+    required:
+      - location
+  output_schema:
+    type: string
+  mode: mock
+  mock_result: "Sunny, 72F"
+  timeout_ms: 5000

--- a/examples/vertex-test/config.arena.yaml
+++ b/examples/vertex-test/config.arena.yaml
@@ -1,0 +1,40 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+
+metadata:
+  name: vertex-test
+
+spec:
+  prompt_configs:
+    - id: capability-test
+      file: prompts/capability-test.yaml
+
+  providers:
+    - file: providers/gemini-vertex-25flash.provider.yaml
+      group: text,streaming,tools
+
+  scenarios:
+    - file: scenarios/text-basic.scenario.yaml
+    - file: scenarios/streaming.scenario.yaml
+    - file: scenarios/tools.scenario.yaml
+
+  tools:
+    - file: tools/get-weather.tool.yaml
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 200
+    concurrency: 1
+    output:
+      dir: out
+      formats: ["json", "html", "markdown"]
+      html:
+        file: vertex.html
+      markdown:
+        file: vertex.md
+        include_details: true
+        show_overview: true
+        show_results_matrix: true
+        show_failed_tests: true
+        show_cost_summary: true
+    fail_on: []

--- a/examples/vertex-test/prompts/capability-test.yaml
+++ b/examples/vertex-test/prompts/capability-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+
+metadata:
+  name: capability-test
+
+spec:
+  version: "1.0.0"
+  description: "Minimal prompt for testing GCP Vertex AI"
+  task_type: "capability-test"
+
+  system_template: |
+    You are a capability testing assistant. Follow instructions precisely.
+    When asked to say something specific, include it exactly as requested.
+    When asked to call a tool, call the appropriate tool with the specified parameters.
+
+  allowed_tools:
+    - get_weather

--- a/examples/vertex-test/providers/gemini-vertex-25flash.provider.yaml
+++ b/examples/vertex-test/providers/gemini-vertex-25flash.provider.yaml
@@ -1,0 +1,23 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: gemini-vertex-25flash
+spec:
+  id: gemini-vertex-25flash
+  type: gemini
+  model: gemini-2.5-flash
+  platform:
+    type: vertex
+    region: us-central1
+    project: hsbc-vertex-001
+  capabilities:
+    - text
+    - streaming
+    - tools
+  defaults:
+    temperature: 0.1
+    max_tokens: 200
+    top_p: 1.0
+  pricing:
+    input_cost_per_1k: 0.000075
+    output_cost_per_1k: 0.0003

--- a/examples/vertex-test/scenarios/streaming.scenario.yaml
+++ b/examples/vertex-test/scenarios/streaming.scenario.yaml
@@ -1,0 +1,30 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: streaming
+
+spec:
+  id: streaming
+  task_type: capability-test
+  description: "Test streaming response against Vertex"
+  required_capabilities:
+    - streaming
+  streaming: true
+  tool_policy:
+    tool_choice: none
+    max_tool_calls_per_turn: 0
+    max_total_tool_calls: 0
+
+  turns:
+    - role: user
+      content: "Count from 1 to 5, one number per line, then say VERTEX_PASS on a new line."
+      assertions:
+        - type: content_includes
+          message: "Streaming response should include VERTEX_PASS"
+          params:
+            patterns: ["VERTEX_PASS"]
+        - type: content_matches
+          message: "Should contain numbers 1-5"
+          params:
+            pattern: "[1-5]"

--- a/examples/vertex-test/scenarios/text-basic.scenario.yaml
+++ b/examples/vertex-test/scenarios/text-basic.scenario.yaml
@@ -1,0 +1,25 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: text-basic
+
+spec:
+  id: text-basic
+  task_type: capability-test
+  description: "Test basic text completion against Vertex"
+  required_capabilities:
+    - text
+  tool_policy:
+    tool_choice: none
+    max_tool_calls_per_turn: 0
+    max_total_tool_calls: 0
+
+  turns:
+    - role: user
+      content: "Say exactly: VERTEX_PASS"
+      assertions:
+        - type: content_includes
+          message: "Response should include VERTEX_PASS"
+          params:
+            patterns: ["VERTEX_PASS"]

--- a/examples/vertex-test/scenarios/tools.scenario.yaml
+++ b/examples/vertex-test/scenarios/tools.scenario.yaml
@@ -1,0 +1,22 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: tools
+
+spec:
+  id: tools
+  task_type: capability-test
+  description: "Test function calling against Vertex"
+  required_capabilities:
+    - tools
+
+  turns:
+    - role: user
+      content: "Call the get_weather function for New York City and tell me the result."
+      assertions:
+        - type: tools_called
+          message: "Should call the get_weather tool"
+          params:
+            tools:
+              - "get_weather"

--- a/examples/vertex-test/tools/get-weather.tool.yaml
+++ b/examples/vertex-test/tools/get-weather.tool.yaml
@@ -1,0 +1,22 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+
+metadata:
+  name: get_weather
+
+spec:
+  name: get_weather
+  description: Get the current weather for a location
+  input_schema:
+    type: object
+    properties:
+      location:
+        type: string
+        description: The city or location to get weather for
+    required:
+      - location
+  output_schema:
+    type: string
+  mode: mock
+  mock_result: "Sunny, 72F"
+  timeout_ms: 5000

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -22,6 +22,21 @@ const (
 	httpClientTimeout = 60 * time.Second
 )
 
+// Platform constants
+const (
+	vertexPlatform = "vertex"
+)
+
+// vertexGeminiEndpoint returns the Vertex AI base URL for Google publisher
+// models. The result ends in `/publishers/google/models` (no trailing slash);
+// per-call code appends `/{model}:{action}` to address a specific model.
+func vertexGeminiEndpoint(region, project string) string {
+	return fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models",
+		region, project, region,
+	)
+}
+
 // streamSessionFactory is the function signature for creating stream sessions.
 type streamSessionFactory func(
 	ctx context.Context, wsURL, apiKey string, config *StreamSessionConfig,
@@ -54,12 +69,23 @@ func NewProvider(id, model, baseURL string, defaults providers.ProviderDefaults,
 }
 
 // NewProviderWithCredential creates a new Gemini provider with explicit credential.
+//
+// When platform=="vertex" and baseURL is empty, the Vertex publisher-models
+// URL is built from platformConfig.Region and platformConfig.Project. This
+// mirrors the openai+azure path: callers that pass an explicit baseURL still
+// win, but Arena-style configs that only set platform.region/project work
+// without users having to know the Vertex URL shape.
 func NewProviderWithCredential(
 	id, model, baseURL string, defaults providers.ProviderDefaults,
 	includeRawOutput bool, cred providers.Credential,
 	platform string, platformConfig *providers.PlatformConfig,
 ) *Provider {
 	base, apiKey := providers.NewBaseProviderWithCredential(id, includeRawOutput, httpClientTimeout, cred)
+
+	if baseURL == "" && platform == vertexPlatform &&
+		platformConfig != nil && platformConfig.Region != "" && platformConfig.Project != "" {
+		baseURL = vertexGeminiEndpoint(platformConfig.Region, platformConfig.Project)
+	}
 
 	return &Provider{
 		BaseProvider:   base,
@@ -71,6 +97,40 @@ func NewProviderWithCredential(
 		platform:       platform,
 		platformConfig: platformConfig,
 	}
+}
+
+// isVertex returns true if this provider is hosted on Google Vertex AI.
+func (p *Provider) isVertex() bool {
+	return p.platform == vertexPlatform
+}
+
+// generateContentURL returns the full URL for a generateContent-style call.
+// action is typically "generateContent" or "streamGenerateContent".
+//
+// Vertex:    {baseURL}/{model}:{action}                — auth via Bearer header
+// AI Studio: {baseURL}/models/{model}:{action}?key={k} — auth via query param
+//
+// The Vertex URL shape relies on baseURL ending in `/publishers/google/models`,
+// which vertexGeminiEndpoint produces and which the SDK platformBaseURL also
+// emits.
+func (p *Provider) generateContentURL(action string) string {
+	if p.isVertex() {
+		return fmt.Sprintf("%s/%s:%s", p.baseURL, p.model, action)
+	}
+	return fmt.Sprintf("%s/models/%s:%s?key=%s", p.baseURL, p.model, action, p.apiKey)
+}
+
+// applyAuth attaches platform-appropriate authentication to a request.
+//
+// Vertex requires an OAuth Bearer token in the Authorization header (sourced
+// from the GCP credential chain). Direct Google AI Studio uses the API key in
+// the URL, so applyAuth is a no-op for that path — callers still embed the
+// key via generateContentURL.
+func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
+	if p.isVertex() && p.credential != nil {
+		return p.credential.Apply(ctx, req)
+	}
+	return nil
 }
 
 // Model returns the model name/identifier used by this provider.
@@ -353,8 +413,7 @@ func (p *Provider) makeGeminiHTTPRequest(ctx context.Context, geminiReq geminiRe
 		return nil, predictResp, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Build URL with API key
-	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", p.baseURL, p.model, p.apiKey)
+	url := p.generateContentURL("generateContent")
 
 	// Debug log the request
 	headers := map[string]string{
@@ -370,6 +429,11 @@ func (p *Provider) makeGeminiHTTPRequest(ctx context.Context, geminiReq geminiRe
 	}
 
 	httpReq.Header.Set(contentTypeHeader, applicationJSON)
+
+	if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+		predictResp.Latency = time.Since(start)
+		return nil, predictResp, fmt.Errorf("failed to apply authentication: %w", authErr)
+	}
 
 	if hdrErr := p.ApplyCustomHeaders(httpReq); hdrErr != nil {
 		return nil, predictResp, hdrErr

--- a/runtime/providers/gemini/gemini_multimodal.go
+++ b/runtime/providers/gemini/gemini_multimodal.go
@@ -204,8 +204,7 @@ func (p *Provider) predictWithContents(ctx context.Context, contents []geminiCon
 		predictResp.RawRequest = geminiReq
 	}
 
-	// Build URL with API key
-	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", p.baseURL, p.model, p.apiKey)
+	url := p.generateContentURL("generateContent")
 
 	// Debug log the request
 	headers := map[string]string{
@@ -221,6 +220,11 @@ func (p *Provider) predictWithContents(ctx context.Context, contents []geminiCon
 	}
 
 	httpReq.Header.Set(contentTypeHeader, applicationJSON)
+
+	if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+		predictResp.Latency = time.Since(start)
+		return predictResp, fmt.Errorf("failed to apply authentication: %w", authErr)
+	}
 
 	respBody, statusCode, err := p.DoAndReadResponse(httpReq, &predictResp, start, "Gemini")
 	if err != nil {
@@ -331,8 +335,7 @@ func (p *Provider) predictStreamWithContents(ctx context.Context, contents []gem
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Build URL for streaming
-	url := fmt.Sprintf("%s/models/%s:streamGenerateContent?key=%s", p.baseURL, p.model, p.apiKey)
+	url := p.generateContentURL("streamGenerateContent")
 
 	// Make HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
@@ -341,6 +344,10 @@ func (p *Provider) predictStreamWithContents(ctx context.Context, contents []gem
 	}
 
 	httpReq.Header.Set(contentTypeHeader, applicationJSON)
+
+	if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+		return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+	}
 
 	resp, err := p.GetStreamingHTTPClient().Do(httpReq)
 	if err != nil {

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -46,13 +46,16 @@ func (p *Provider) PredictStream(
 	// past the opening '[' and the first complete element so
 	// peekFirstFrame can confirm the stream is "live" before handing
 	// ownership to the consumer goroutine.
-	url := fmt.Sprintf("%s/models/%s:streamGenerateContent?key=%s", p.baseURL, p.model, p.apiKey)
+	url := p.generateContentURL("streamGenerateContent")
 	requestFn := func(ctx context.Context) (*http.Request, error) {
 		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 		if reqErr != nil {
 			return nil, fmt.Errorf("failed to create request: %w", reqErr)
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
+		if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+			return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+		}
 		return httpReq, nil
 	}
 

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -551,8 +551,7 @@ func (p *ToolProvider) makeRequest(ctx context.Context, request any) ([]byte, er
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Build URL with API key for Gemini
-	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", p.baseURL, p.model, p.apiKey)
+	url := p.generateContentURL("generateContent")
 
 	// Debug log the request
 	var requestObj any
@@ -571,6 +570,10 @@ func (p *ToolProvider) makeRequest(ctx context.Context, request any) ([]byte, er
 	}
 
 	req.Header.Set(contentTypeHeader, applicationJSON)
+
+	if authErr := p.applyAuth(ctx, req); authErr != nil {
+		return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+	}
 
 	if hdrErr := p.ApplyCustomHeaders(req); hdrErr != nil {
 		return nil, hdrErr
@@ -620,11 +623,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Use streamGenerateContent endpoint
-	url := fmt.Sprintf(
-		"%s/models/%s:streamGenerateContent?key=%s",
-		p.baseURL, p.model, p.apiKey,
-	)
+	url := p.generateContentURL("streamGenerateContent")
 
 	requestFn := func(ctx context.Context) (*http.Request, error) {
 		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestBytes))
@@ -632,6 +631,9 @@ func (p *ToolProvider) PredictStreamWithTools(
 			return nil, fmt.Errorf("failed to create request: %w", reqErr)
 		}
 		httpReq.Header.Set(contentTypeHeader, applicationJSON)
+		if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+			return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+		}
 		if hdrErr := p.ApplyCustomHeaders(httpReq); hdrErr != nil {
 			return nil, hdrErr
 		}

--- a/runtime/providers/gemini/vertex_integration_test.go
+++ b/runtime/providers/gemini/vertex_integration_test.go
@@ -1,0 +1,277 @@
+//go:build integration
+
+// Vertex AI integration tests for the gemini provider.
+//
+// These tests exercise gemini against Google Vertex AI's publisher-models
+// endpoint (rather than direct AI Studio) to prove the Vertex code path:
+// URL shape (no `/models/` segment, no `?key=`) and Bearer-token auth via
+// the GCP credential chain.
+//
+// Run locally:
+//
+//	gcloud auth application-default login
+//	export GCP_PROJECT=<your-project>
+//	export GCP_REGION=us-central1
+//	export VERTEX_GEMINI_MODEL=gemini-2.0-flash-001   # optional
+//	go test -tags=integration ./runtime/providers/gemini/... -run Vertex -v
+package gemini
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func vertexProject() string { return os.Getenv("GCP_PROJECT") }
+
+func vertexRegion() string {
+	if r := os.Getenv("GCP_REGION"); r != "" {
+		return r
+	}
+	return "us-central1"
+}
+
+func vertexModel() string {
+	if m := os.Getenv("VERTEX_GEMINI_MODEL"); m != "" {
+		return m
+	}
+	return "gemini-2.0-flash-001"
+}
+
+// skipIfNoVertex skips when GCP project/credentials aren't available.
+// Credential construction succeeds even with no logged-in identity, so the
+// helper also issues a real token request to confirm the chain works.
+func skipIfNoVertex(t *testing.T) {
+	t.Helper()
+
+	if vertexProject() == "" {
+		t.Skip("GCP_PROJECT not set, skipping Vertex integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cred, err := credentials.NewGCPCredential(ctx, vertexProject(), vertexRegion())
+	if err != nil {
+		t.Skipf("GCP credentials not available (try: gcloud auth application-default login): %v", err)
+	}
+
+	probe, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", http.NoBody)
+	if err := cred.Apply(ctx, probe); err != nil {
+		t.Skipf("GCP token not available: %v", err)
+	}
+}
+
+// vertexTestProvider builds a Vertex-configured gemini Provider, skipping
+// the test if creds aren't available.
+func vertexTestProvider(t *testing.T) *Provider {
+	t.Helper()
+	skipIfNoVertex(t)
+
+	ctx := context.Background()
+	cred, err := credentials.NewGCPCredential(ctx, vertexProject(), vertexRegion())
+	if err != nil {
+		t.Fatalf("failed to create GCP credential: %v", err)
+	}
+
+	platformConfig := &providers.PlatformConfig{
+		Type:    "vertex",
+		Region:  vertexRegion(),
+		Project: vertexProject(),
+	}
+
+	// BaseURL is deliberately empty: this exercises the Arena path where the
+	// gemini factory derives the publisher-models URL from PlatformConfig.
+	return NewProviderWithCredential(
+		"vertex-gemini-test", vertexModel(), "",
+		providers.ProviderDefaults{
+			MaxTokens:   256,
+			Temperature: 0.1,
+			Pricing: providers.Pricing{
+				InputCostPer1K:  0.000075,
+				OutputCostPer1K: 0.0003,
+			},
+		},
+		false, cred, "vertex", platformConfig,
+	)
+}
+
+func vertexTestToolProvider(t *testing.T) *ToolProvider {
+	t.Helper()
+	return &ToolProvider{Provider: vertexTestProvider(t)}
+}
+
+func TestVertex_BaseURLConstruction(t *testing.T) {
+	skipIfNoVertex(t)
+
+	p := vertexTestProvider(t)
+	expected := vertexGeminiEndpoint(vertexRegion(), vertexProject())
+	if p.baseURL != expected {
+		t.Fatalf("baseURL = %q, want %q (Vertex publisher-models URL)", p.baseURL, expected)
+	}
+}
+
+func TestVertex_GenerateContentURLShape(t *testing.T) {
+	skipIfNoVertex(t)
+
+	p := vertexTestProvider(t)
+	url := p.generateContentURL("generateContent")
+
+	if strings.Contains(url, "?key=") {
+		t.Errorf("Vertex URL must not embed an API key query param: %s", url)
+	}
+	if !strings.Contains(url, "/publishers/google/models/"+vertexModel()+":generateContent") {
+		t.Errorf("URL missing canonical Vertex path: %s", url)
+	}
+	if strings.Contains(url, "/models/models/") {
+		t.Errorf("URL contains doubled /models/ segment: %s", url)
+	}
+}
+
+func TestVertex_Predict(t *testing.T) {
+	provider := vertexTestProvider(t)
+	ctx := context.Background()
+
+	resp, err := provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.Content == "" {
+		t.Fatal("expected non-empty response content")
+	}
+	t.Logf("Response: %s", resp.Content)
+
+	if resp.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+}
+
+func TestVertex_PredictWithTools(t *testing.T) {
+	provider := vertexTestToolProvider(t)
+	ctx := context.Background()
+
+	tools, err := provider.BuildTooling([]*providers.ToolDescriptor{
+		{
+			Name:        "get_weather",
+			Description: "Get weather for a city",
+			InputSchema: []byte(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildTooling failed: %v", err)
+	}
+
+	resp, toolCalls, err := provider.PredictWithTools(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "What is the weather in Paris?"},
+		},
+	}, tools, "auto")
+	if err != nil {
+		t.Fatalf("PredictWithTools failed: %v", err)
+	}
+	if resp.Content == "" && len(toolCalls) == 0 {
+		t.Fatal("expected either text content or tool calls")
+	}
+	if len(toolCalls) > 0 {
+		t.Logf("Tool call: %s(%s)", toolCalls[0].Name, string(toolCalls[0].Args))
+	} else {
+		t.Logf("Text response: %s", resp.Content)
+	}
+}
+
+func TestVertex_PredictStream(t *testing.T) {
+	provider := vertexTestProvider(t)
+	ctx := context.Background()
+
+	stream, err := provider.PredictStream(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream failed: %v", err)
+	}
+
+	chunkCount := 0
+	var lastChunk providers.StreamChunk
+	for chunk := range stream {
+		if chunk.Error != nil {
+			t.Fatalf("stream error: %v", chunk.Error)
+		}
+		lastChunk = chunk
+		chunkCount++
+	}
+	if chunkCount == 0 {
+		t.Fatal("expected at least one stream chunk")
+	}
+	if lastChunk.Content == "" {
+		t.Fatal("expected non-empty content in final chunk")
+	}
+	t.Logf("Stream response (%d chunks): %s", chunkCount, lastChunk.Content)
+}
+
+func TestVertex_ErrorOnInvalidModel(t *testing.T) {
+	skipIfNoVertex(t)
+
+	ctx := context.Background()
+	cred, err := credentials.NewGCPCredential(ctx, vertexProject(), vertexRegion())
+	if err != nil {
+		t.Fatalf("failed to create GCP credential: %v", err)
+	}
+
+	provider := NewProviderWithCredential(
+		"vertex-gemini-test-bad", "model-that-does-not-exist-xyz", "",
+		providers.ProviderDefaults{MaxTokens: 100},
+		false, cred, "vertex",
+		&providers.PlatformConfig{
+			Type: "vertex", Region: vertexRegion(), Project: vertexProject(),
+		},
+	)
+
+	_, err = provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid model, got nil")
+	}
+	t.Logf("Got expected error: %v", err)
+}
+
+func TestVertex_CostCalculation(t *testing.T) {
+	provider := vertexTestProvider(t)
+	ctx := context.Background()
+
+	resp, err := provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+	if resp.CostInfo.InputTokens <= 0 {
+		t.Errorf("expected positive InputTokens, got %d", resp.CostInfo.InputTokens)
+	}
+	if resp.CostInfo.OutputTokens <= 0 {
+		t.Errorf("expected positive OutputTokens, got %d", resp.CostInfo.OutputTokens)
+	}
+	if resp.CostInfo.TotalCost <= 0 {
+		t.Errorf("expected positive TotalCost, got %f", resp.CostInfo.TotalCost)
+	}
+	t.Logf("Cost: input=%d tokens, output=%d tokens, total=$%.6f",
+		resp.CostInfo.InputTokens, resp.CostInfo.OutputTokens, resp.CostInfo.TotalCost)
+}

--- a/runtime/providers/gemini/vertex_unit_test.go
+++ b/runtime/providers/gemini/vertex_unit_test.go
@@ -1,0 +1,188 @@
+package gemini
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// mockBearerCredential records whether Apply was invoked. Used to verify the
+// Vertex auth branch attaches the credential while the AI Studio branch
+// leaves the request unauthenticated.
+type mockBearerCredential struct{ applied bool }
+
+func (m *mockBearerCredential) Type() string { return "bearer" }
+func (m *mockBearerCredential) Apply(_ context.Context, _ *http.Request) error {
+	m.applied = true
+	return nil
+}
+
+func TestVertexGeminiEndpoint(t *testing.T) {
+	got := vertexGeminiEndpoint("us-central1", "my-project")
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google/models"
+	if got != want {
+		t.Errorf("vertexGeminiEndpoint = %q, want %q", got, want)
+	}
+}
+
+func TestProvider_IsVertex(t *testing.T) {
+	tests := []struct {
+		platform string
+		want     bool
+	}{
+		{vertexPlatform, true},
+		{"bedrock", false},
+		{"azure", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			p := &Provider{platform: tt.platform}
+			if got := p.isVertex(); got != tt.want {
+				t.Errorf("isVertex() platform=%q got %v, want %v", tt.platform, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvider_GenerateContentURL(t *testing.T) {
+	t.Run("vertex omits api key and /models prefix", func(t *testing.T) {
+		p := &Provider{
+			platform: vertexPlatform,
+			baseURL:  "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/publishers/google/models",
+			model:    "gemini-2.5-flash",
+		}
+		got := p.generateContentURL("generateContent")
+		want := "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
+		if got != want {
+			t.Errorf("vertex URL = %q, want %q", got, want)
+		}
+		if strings.Contains(got, "?key=") {
+			t.Errorf("vertex URL must not embed an API key: %s", got)
+		}
+		if strings.Contains(got, "/models/models/") {
+			t.Errorf("vertex URL must not double up /models/: %s", got)
+		}
+	})
+
+	t.Run("vertex stream action", func(t *testing.T) {
+		p := &Provider{
+			platform: vertexPlatform,
+			baseURL:  "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/publishers/google/models",
+			model:    "gemini-2.5-flash",
+		}
+		got := p.generateContentURL("streamGenerateContent")
+		if !strings.HasSuffix(got, "/gemini-2.5-flash:streamGenerateContent") {
+			t.Errorf("vertex stream URL did not end with model:action — got %s", got)
+		}
+	})
+
+	t.Run("ai studio embeds api key in query string", func(t *testing.T) {
+		p := &Provider{
+			platform: "",
+			baseURL:  "https://generativelanguage.googleapis.com/v1beta",
+			apiKey:   "test-api-key",
+			model:    "gemini-2.5-flash",
+		}
+		got := p.generateContentURL("generateContent")
+		want := "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=test-api-key"
+		if got != want {
+			t.Errorf("ai studio URL = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestProvider_ApplyAuth(t *testing.T) {
+	t.Run("vertex applies bearer credential", func(t *testing.T) {
+		cred := &mockBearerCredential{}
+		p := &Provider{platform: vertexPlatform, credential: cred}
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.com", http.NoBody)
+		if err := p.applyAuth(context.Background(), req); err != nil {
+			t.Fatalf("applyAuth returned error: %v", err)
+		}
+		if !cred.applied {
+			t.Error("vertex applyAuth did not invoke credential.Apply")
+		}
+	})
+
+	t.Run("vertex with nil credential is a no-op", func(t *testing.T) {
+		p := &Provider{platform: vertexPlatform, credential: nil}
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.com", http.NoBody)
+		if err := p.applyAuth(context.Background(), req); err != nil {
+			t.Errorf("applyAuth with nil credential should not error, got %v", err)
+		}
+	})
+
+	t.Run("ai studio does not invoke credential", func(t *testing.T) {
+		cred := &mockBearerCredential{}
+		p := &Provider{platform: "", credential: cred}
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.com", http.NoBody)
+		if err := p.applyAuth(context.Background(), req); err != nil {
+			t.Fatalf("applyAuth returned error: %v", err)
+		}
+		if cred.applied {
+			t.Error("ai studio applyAuth must not call credential.Apply (key is in URL)")
+		}
+	})
+}
+
+func TestNewProviderWithCredential_DerivesVertexURL(t *testing.T) {
+	cred := &mockBearerCredential{}
+
+	t.Run("empty BaseURL with vertex platform derives publisher-models URL", func(t *testing.T) {
+		pc := &providers.PlatformConfig{
+			Type: vertexPlatform, Region: "us-central1", Project: "my-proj",
+		}
+		p := NewProviderWithCredential(
+			"test", "gemini-2.5-flash", "",
+			providers.ProviderDefaults{},
+			false, cred, vertexPlatform, pc,
+		)
+		want := vertexGeminiEndpoint("us-central1", "my-proj")
+		if p.baseURL != want {
+			t.Errorf("baseURL = %q, want %q", p.baseURL, want)
+		}
+	})
+
+	t.Run("explicit BaseURL is preserved on vertex", func(t *testing.T) {
+		pc := &providers.PlatformConfig{
+			Type: vertexPlatform, Region: "us-central1", Project: "my-proj",
+		}
+		custom := "https://custom.vertex.example/v1/.../models"
+		p := NewProviderWithCredential(
+			"test", "gemini-2.5-flash", custom,
+			providers.ProviderDefaults{},
+			false, cred, vertexPlatform, pc,
+		)
+		if p.baseURL != custom {
+			t.Errorf("explicit baseURL must win, got %q", p.baseURL)
+		}
+	})
+
+	t.Run("missing project leaves BaseURL empty", func(t *testing.T) {
+		pc := &providers.PlatformConfig{Type: vertexPlatform, Region: "us-central1"}
+		p := NewProviderWithCredential(
+			"test", "gemini-2.5-flash", "",
+			providers.ProviderDefaults{},
+			false, cred, vertexPlatform, pc,
+		)
+		if p.baseURL != "" {
+			t.Errorf("incomplete PlatformConfig should not derive URL, got %q", p.baseURL)
+		}
+	})
+
+	t.Run("non-vertex platform does not derive URL", func(t *testing.T) {
+		pc := &providers.PlatformConfig{Type: "bedrock", Region: "us-west-2"}
+		p := NewProviderWithCredential(
+			"test", "gemini-2.5-flash", "",
+			providers.ProviderDefaults{},
+			false, cred, "bedrock", pc,
+		)
+		if p.baseURL != "" {
+			t.Errorf("non-vertex platform should not derive URL, got %q", p.baseURL)
+		}
+	})
+}

--- a/runtime/providers/openai/azure_integration_test.go
+++ b/runtime/providers/openai/azure_integration_test.go
@@ -1,0 +1,299 @@
+//go:build integration
+
+// Package openai integration tests for Azure OpenAI / Azure AI Foundry.
+//
+// These tests exercise the openai provider against a real Azure deployment.
+// They are gated by the `integration` build tag and skipped when Azure
+// credentials or the AZURE_OPENAI_ENDPOINT env var are unavailable.
+//
+// Run locally:
+//
+//	az login --scope https://cognitiveservices.azure.com/.default
+//	export AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com
+//	export AZURE_OPENAI_DEPLOYMENT=<deployment-name>   # e.g. gpt-4o-mini
+//	go test -tags=integration ./runtime/providers/openai/... -run Azure -v
+//
+// Optional:
+//
+//	AZURE_OPENAI_API_VERSION  api-version query param (default: 2024-12-01-preview)
+package openai
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// azureEndpoint returns the configured Azure OpenAI / Foundry resource endpoint.
+func azureEndpoint() string {
+	return os.Getenv("AZURE_OPENAI_ENDPOINT")
+}
+
+// azureDeployment returns the deployment name to address. Azure routes by
+// deployment, not model name.
+func azureDeployment() string {
+	if d := os.Getenv("AZURE_OPENAI_DEPLOYMENT"); d != "" {
+		return d
+	}
+	return "gpt-4o-mini"
+}
+
+// azureAPIVersionOverride lets tests pin a specific api-version. Empty falls
+// back to credentials.DefaultAzureAPIVersion.
+func azureAPIVersionOverride() string {
+	return os.Getenv("AZURE_OPENAI_API_VERSION")
+}
+
+// skipIfNoAzure skips the test unless Azure credentials are available AND a
+// token can actually be acquired for the cognitive services scope. Credential
+// construction succeeds even with no logged-in identity, so we must Apply()
+// to confirm the chain works end-to-end.
+func skipIfNoAzure(t *testing.T) {
+	t.Helper()
+
+	if azureEndpoint() == "" {
+		t.Skip("AZURE_OPENAI_ENDPOINT not set, skipping Azure integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cred, err := credentials.NewAzureCredential(ctx, azureEndpoint())
+	if err != nil {
+		t.Skipf("Azure credentials not available: %v", err)
+	}
+
+	probe, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", http.NoBody)
+	if err := cred.Apply(ctx, probe); err != nil {
+		t.Skipf("Azure token not available (try: az login --scope https://cognitiveservices.azure.com/.default): %v", err)
+	}
+}
+
+// azureTestProvider builds an openai Provider configured for Azure and skips
+// the test if credentials are unavailable.
+func azureTestProvider(t *testing.T) *Provider {
+	t.Helper()
+	skipIfNoAzure(t)
+
+	ctx := context.Background()
+	cred, err := credentials.NewAzureCredential(ctx, azureEndpoint())
+	if err != nil {
+		t.Fatalf("failed to create Azure credential: %v", err)
+	}
+
+	platformConfig := &providers.PlatformConfig{
+		Type:     "azure",
+		Endpoint: azureEndpoint(),
+	}
+	if v := azureAPIVersionOverride(); v != "" {
+		platformConfig.AdditionalConfig = map[string]any{"api_version": v}
+	}
+
+	return NewProviderFromConfig(&ProviderConfig{
+		ID:    "azure-openai-test",
+		Model: azureDeployment(),
+		// BaseURL deliberately empty — exercises issue #1010 fix where the
+		// Azure URL is built by the factory from PlatformConfig rather than
+		// being clobbered by the registry's api.openai.com default.
+		BaseURL: "",
+		Defaults: providers.ProviderDefaults{
+			MaxTokens:   256,
+			Temperature: 0.1,
+			Pricing: providers.Pricing{
+				InputCostPer1K:  0.00015,
+				OutputCostPer1K: 0.0006,
+			},
+		},
+		Credential:     cred,
+		Platform:       "azure",
+		PlatformConfig: platformConfig,
+	})
+}
+
+func azureTestToolProvider(t *testing.T) *ToolProvider {
+	t.Helper()
+	return &ToolProvider{Provider: azureTestProvider(t)}
+}
+
+func TestAzure_BaseURLConstruction(t *testing.T) {
+	skipIfNoAzure(t)
+
+	p := azureTestProvider(t)
+	expected := credentials.AzureOpenAIEndpoint(azureEndpoint(), azureDeployment())
+	if p.baseURL != expected {
+		t.Fatalf("baseURL = %q, want %q (Azure deployment URL)", p.baseURL, expected)
+	}
+}
+
+func TestAzure_ChatCompletionsURLAppendsAPIVersion(t *testing.T) {
+	skipIfNoAzure(t)
+
+	p := azureTestProvider(t)
+	url := p.chatCompletionsURL()
+	if !strings.Contains(url, "/openai/deployments/"+azureDeployment()+"/chat/completions") {
+		t.Errorf("URL missing deployment path: %s", url)
+	}
+	if !strings.Contains(url, "api-version=") {
+		t.Errorf("URL missing api-version query param: %s", url)
+	}
+}
+
+func TestAzure_Predict(t *testing.T) {
+	provider := azureTestProvider(t)
+	ctx := context.Background()
+
+	resp, err := provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+
+	if resp.Content == "" {
+		t.Fatal("expected non-empty response content")
+	}
+	t.Logf("Response: %s", resp.Content)
+
+	if resp.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+}
+
+func TestAzure_PredictWithTools(t *testing.T) {
+	provider := azureTestToolProvider(t)
+	ctx := context.Background()
+
+	tools, err := provider.BuildTooling([]*providers.ToolDescriptor{
+		{
+			Name:        "get_weather",
+			Description: "Get weather for a city",
+			InputSchema: []byte(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildTooling failed: %v", err)
+	}
+
+	resp, toolCalls, err := provider.PredictWithTools(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "What is the weather in Paris?"},
+		},
+	}, tools, "auto")
+	if err != nil {
+		t.Fatalf("PredictWithTools failed: %v", err)
+	}
+
+	if resp.Content == "" && len(toolCalls) == 0 {
+		t.Fatal("expected either text content or tool calls")
+	}
+
+	if len(toolCalls) > 0 {
+		t.Logf("Tool call: %s(%s)", toolCalls[0].Name, string(toolCalls[0].Args))
+	} else {
+		t.Logf("Text response: %s", resp.Content)
+	}
+}
+
+func TestAzure_PredictStream(t *testing.T) {
+	provider := azureTestProvider(t)
+	ctx := context.Background()
+
+	stream, err := provider.PredictStream(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream failed: %v", err)
+	}
+
+	var lastChunk providers.StreamChunk
+	chunkCount := 0
+	for chunk := range stream {
+		if chunk.Error != nil {
+			t.Fatalf("stream error: %v", chunk.Error)
+		}
+		lastChunk = chunk
+		chunkCount++
+	}
+
+	if chunkCount == 0 {
+		t.Fatal("expected at least one stream chunk")
+	}
+	if lastChunk.Content == "" {
+		t.Fatal("expected non-empty content in final chunk")
+	}
+	t.Logf("Stream response (%d chunks): %s", chunkCount, lastChunk.Content)
+}
+
+func TestAzure_ErrorOnInvalidDeployment(t *testing.T) {
+	skipIfNoAzure(t)
+
+	ctx := context.Background()
+	cred, err := credentials.NewAzureCredential(ctx, azureEndpoint())
+	if err != nil {
+		t.Fatalf("failed to create Azure credential: %v", err)
+	}
+
+	provider := NewProviderFromConfig(&ProviderConfig{
+		ID:      "azure-openai-test-bad",
+		Model:   "deployment-that-does-not-exist-xyz",
+		BaseURL: "",
+		Defaults: providers.ProviderDefaults{
+			MaxTokens: 100,
+		},
+		Credential: cred,
+		Platform:   "azure",
+		PlatformConfig: &providers.PlatformConfig{
+			Type:     "azure",
+			Endpoint: azureEndpoint(),
+		},
+	})
+
+	_, err = provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid deployment, got nil")
+	}
+	t.Logf("Got expected error: %v", err)
+}
+
+func TestAzure_CostCalculation(t *testing.T) {
+	provider := azureTestProvider(t)
+	ctx := context.Background()
+
+	resp, err := provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+
+	if resp.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+	if resp.CostInfo.InputTokens <= 0 {
+		t.Errorf("expected positive InputTokens, got %d", resp.CostInfo.InputTokens)
+	}
+	if resp.CostInfo.OutputTokens <= 0 {
+		t.Errorf("expected positive OutputTokens, got %d", resp.CostInfo.OutputTokens)
+	}
+	if resp.CostInfo.TotalCost <= 0 {
+		t.Errorf("expected positive TotalCost, got %f", resp.CostInfo.TotalCost)
+	}
+
+	t.Logf("Cost: input=%d tokens, output=%d tokens, total=$%.6f",
+		resp.CostInfo.InputTokens, resp.CostInfo.OutputTokens, resp.CostInfo.TotalCost)
+}

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -211,14 +211,28 @@ type headersConfigurable interface {
 // CreateProviderFromSpec creates a provider implementation from a spec.
 // Returns an error if the provider type is unsupported.
 func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
-	// Use default base URLs if not specified
+	// Use default base URLs if not specified.
 	baseURL := spec.BaseURL
 	if baseURL == "" {
 		switch spec.Type {
 		case "openai":
-			baseURL = "https://api.openai.com/v1"
+			// Skip the api.openai.com default for Azure — the openai
+			// factory builds the deployment URL from PlatformConfig.
+			// Without this skip the default clobbers spec.BaseURL and
+			// the Azure branch in NewProviderFromConfig becomes
+			// unreachable (issue #1010).
+			if spec.Platform != "azure" {
+				baseURL = "https://api.openai.com/v1"
+			}
 		case "gemini":
-			baseURL = DefaultGeminiBaseURL
+			// Skip the AI Studio default for Vertex — the gemini
+			// factory builds the publisher-models URL from
+			// PlatformConfig.Region+Project. Same #1010 root cause as
+			// openai+azure: the default would clobber spec.BaseURL
+			// and make the Vertex branch unreachable.
+			if spec.Platform != "vertex" {
+				baseURL = DefaultGeminiBaseURL
+			}
 		case "claude":
 			baseURL = "https://api.anthropic.com"
 		case "imagen":

--- a/runtime/providers/registry_extended_test.go
+++ b/runtime/providers/registry_extended_test.go
@@ -230,6 +230,43 @@ func TestCreateProviderFromSpecOpenAIAzureSkipsDefault(t *testing.T) {
 	}
 }
 
+// TestCreateProviderFromSpecGeminiVertexSkipsDefault is a regression test for
+// the Vertex cell of #1009: when spec.Type=="gemini" and spec.Platform=="vertex",
+// the registry must NOT default BaseURL to the AI Studio v1beta endpoint.
+// The gemini factory builds the publisher-models URL from PlatformConfig and
+// that branch is gated on baseURL=="" — clobbering it makes the Vertex path
+// unreachable, the same root cause as openai+azure (#1010).
+func TestCreateProviderFromSpecGeminiVertexSkipsDefault(t *testing.T) {
+	originalFactory := providerFactories["gemini"]
+	capturedBaseURL := "sentinel"
+	providerFactories["gemini"] = func(spec ProviderSpec) (Provider, error) {
+		capturedBaseURL = spec.BaseURL
+		return &mockProviderForTest{id: spec.ID}, nil
+	}
+	defer func() {
+		if originalFactory != nil {
+			providerFactories["gemini"] = originalFactory
+		} else {
+			delete(providerFactories, "gemini")
+		}
+	}()
+
+	spec := ProviderSpec{
+		ID:       "vertex-gemini",
+		Type:     "gemini",
+		Model:    testModelName,
+		Platform: "vertex",
+	}
+
+	if _, err := CreateProviderFromSpec(spec); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if capturedBaseURL != "" {
+		t.Errorf("Expected empty BaseURL for gemini+vertex, got %q (regression of #1010-class bug)", capturedBaseURL)
+	}
+}
+
 func TestCreateProviderFromSpecCustomBaseURL(t *testing.T) {
 	customURL := "https://custom.api.example.com"
 	spec := ProviderSpec{

--- a/runtime/providers/registry_extended_test.go
+++ b/runtime/providers/registry_extended_test.go
@@ -192,6 +192,44 @@ func TestCreateProviderFromSpecDefaultBaseURLs(t *testing.T) {
 	}
 }
 
+// TestCreateProviderFromSpecOpenAIAzureSkipsDefault is a regression test for
+// issue #1010: when spec.Type=="openai" and spec.Platform=="azure", the
+// registry must NOT default BaseURL to https://api.openai.com/v1. The openai
+// factory builds the deployment URL from PlatformConfig and that branch is
+// gated on baseURL=="" — so clobbering it makes the Azure path unreachable.
+func TestCreateProviderFromSpecOpenAIAzureSkipsDefault(t *testing.T) {
+	originalFactory := providerFactories["openai"]
+	capturedBaseURL := "sentinel"
+	providerFactories["openai"] = func(spec ProviderSpec) (Provider, error) {
+		capturedBaseURL = spec.BaseURL
+		return &mockProviderForTest{id: spec.ID}, nil
+	}
+	defer func() {
+		if originalFactory != nil {
+			providerFactories["openai"] = originalFactory
+		} else {
+			delete(providerFactories, "openai")
+		}
+	}()
+
+	spec := ProviderSpec{
+		ID:       "azure-openai",
+		Type:     "openai",
+		Model:    testModelName,
+		Platform: "azure",
+		// No BaseURL — the factory must see "" so it can build the
+		// deployment URL from PlatformConfig.
+	}
+
+	if _, err := CreateProviderFromSpec(spec); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if capturedBaseURL != "" {
+		t.Errorf("Expected empty BaseURL for openai+azure, got %q (issue #1010)", capturedBaseURL)
+	}
+}
+
 func TestCreateProviderFromSpecCustomBaseURL(t *testing.T) {
 	customURL := "https://custom.api.example.com"
 	spec := ProviderSpec{


### PR DESCRIPTION
## Summary

Closes the openai+azure routing bug (#1010) and adds the missing
gemini+vertex code path (one cell of #1009). Both fixes share the same
root cause: the provider registry's vendor-default-baseURL switch
clobbered the empty `spec.BaseURL` that per-provider factories rely on
to derive platform-specific URLs.

End-to-end verified locally — all three hyperscaler cells now route
correctly through both the unit-integration tests and the full Arena
pipeline.

| Cell | Status |
|---|---|
| openai+azure (Azure AI Foundry) | ✅ 7/7 integration tests, 3/3 Arena scenarios |
| claude+bedrock (existing canonical) | ✅ 5/5 integration tests, 3/3 Arena scenarios |
| gemini+vertex (Vertex AI) | ✅ 7/7 integration tests, 3/3 Arena scenarios |

## What changed

### `fix(providers): unblock openai+azure routing (#1010)`
- `runtime/providers/registry.go` — skip the `https://api.openai.com/v1`
  default when `spec.Platform=="azure"` so the openai factory's existing
  Azure URL builder (`NewProviderFromConfig`) becomes reachable.
- `runtime/providers/registry_extended_test.go` — regression test
  asserting `BaseURL` stays empty for openai+azure.
- `runtime/providers/openai/azure_integration_test.go` — 7 build-tag
  `integration` tests covering URL construction, predict, tools,
  streaming, error path, cost.

### `feat(providers): add gemini vertex code path (#1009 cell)`
- `runtime/providers/gemini/gemini.go` — adds `vertexPlatform`,
  `vertexGeminiEndpoint`, `isVertex()`, `generateContentURL(action)`,
  `applyAuth()`. `NewProviderWithCredential` derives the Vertex URL
  from `PlatformConfig` when caller passes empty `BaseURL`, mirroring
  the openai+azure pattern.
- `runtime/providers/gemini/{gemini,gemini_tools,gemini_multimodal,gemini_streaming}.go`
  — all six URL build sites switched to `generateContentURL`; all six
  request paths now call `applyAuth` (Bearer token for Vertex, no-op
  for AI Studio).
- `runtime/providers/registry.go` — skip the AI Studio default when
  `spec.Platform=="vertex"` (same root cause as openai+azure).
- `runtime/providers/gemini/vertex_integration_test.go` — 7 tests
  mirroring the Azure suite.

### `docs(examples): add hyperscaler smoke-test arena examples`
Three minimal Arena examples that exercise each cell end-to-end:
`examples/azure-foundry-test`, `examples/bedrock-test`,
`examples/vertex-test`. Each ships a provider config + 3 scenarios
(text, streaming, tool calling) + 1 mock tool.

## Authentication

No PromptKit changes for credentials — each cloud uses its native
SDK's default chain, which transparently picks up either local CLI
caches (`az login` / `~/.aws/credentials` / `gcloud auth
application-default login`) or CI-side workload identity federation
(`azure/login@v2` / `aws-actions/configure-aws-credentials@v4` /
`google-github-actions/auth@v2`). Same code path; the chain just
selects a different element.

## Pre-commit

All three commits passed the local pre-commit hook:
- lint: 0 issues
- build: clean
- coverage on changed files: registry.go 91.1%, gemini.go 82.0%,
  gemini_multimodal.go 82.4%, gemini_streaming.go 93.4%,
  gemini_tools.go 88.1% (all ≥80% threshold)

## Test plan

- [x] `go test -race -count=1 ./runtime/providers/...` — all packages green
- [x] `go test -tags=integration -run ^TestAzure_ ./runtime/providers/openai/` — 7/7 pass against Azure AI Foundry
- [x] `go test -tags=integration -run ^TestBedrock_ ./runtime/providers/claude/` — 5/5 pass against AWS Bedrock
- [x] `go test -tags=integration -run ^TestVertex_ ./runtime/providers/gemini/` — 7/7 pass against GCP Vertex
- [x] `promptarena run --ci --formats html,json` in each example dir — 3/3 scenarios pass per cloud
- [ ] Verify in CI (deferred — not wiring up the hyperscaler tier in this PR; standard SDK chains support GitHub OIDC unchanged)

## Out of scope

- The remaining 5 cells of #1009 (claude+vertex, claude+azure, openai+vertex, openai+bedrock, gemini+bedrock) — each needs its own factory branch.
- Wiring the hyperscaler tier into `capability-matrix.yml` — requires per-cloud OIDC + IAM setup separately.

Fixes #1010
Refs #1009
