### PR TITLE
feat(providers): claude on vertex (#1009 cell)

### DIFF
--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -41,12 +41,25 @@ func normalizeBaseURL(baseURL string) string {
 	return baseURL
 }
 
-// Bedrock constants
+// Platform constants
 const (
 	bedrockPlatform       = "bedrock"
 	bedrockVersionValue   = "bedrock-2023-05-31"
+	vertexPlatform        = "vertex"
+	vertexVersionValue    = "vertex-2023-10-16"
 	bedrockVersionBodyKey = "anthropic_version"
 )
+
+// vertexAnthropicEndpoint returns the Vertex AI base URL for Anthropic
+// publisher models. The result ends in `/publishers/anthropic/models` (no
+// trailing slash); per-call code appends `/{model}:rawPredict` (or
+// `:streamRawPredict`) to address a specific model.
+func vertexAnthropicEndpoint(region, project string) string {
+	return fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models",
+		region, project, region,
+	)
+}
 
 // Provider implements the Provider interface for Anthropic Claude
 type Provider struct {
@@ -74,12 +87,24 @@ func NewProvider(id, model, baseURL string, defaults providers.ProviderDefaults,
 }
 
 // NewProviderWithCredential creates a new Claude provider with explicit credential.
+//
+// When platform=="vertex" and baseURL is empty, the Vertex publisher-models
+// URL is built from platformConfig.Region and platformConfig.Project.
+// Mirrors the openai+azure and gemini+vertex pattern: callers that pass an
+// explicit baseURL still win, but Arena-style configs that only set
+// platform.region/project work without users having to know the Vertex URL
+// shape.
 func NewProviderWithCredential(
 	id, model, baseURL string, defaults providers.ProviderDefaults,
 	includeRawOutput bool, cred providers.Credential,
 	platform string, platformConfig *providers.PlatformConfig,
 ) *Provider {
 	base, apiKey := providers.NewBaseProviderWithCredential(id, includeRawOutput, httpClientTimeout, cred)
+
+	if baseURL == "" && platform == vertexPlatform &&
+		platformConfig != nil && platformConfig.Region != "" && platformConfig.Project != "" {
+		baseURL = vertexAnthropicEndpoint(platformConfig.Region, platformConfig.Project)
+	}
 
 	return &Provider{
 		BaseProvider:   base,
@@ -103,32 +128,76 @@ func (p *Provider) isBedrock() bool {
 	return p.platform == bedrockPlatform
 }
 
-// messagesURL returns the appropriate API endpoint URL.
-// For Bedrock: {baseURL}/model/{model}/invoke
-// For direct Anthropic API: {baseURL}/messages
-func (p *Provider) messagesURL() string {
-	if p.isBedrock() {
-		return p.baseURL + "/model/" + p.model + "/invoke"
+// isVertex returns true if this provider is hosted on Google Vertex AI's
+// Anthropic partner endpoint.
+func (p *Provider) isVertex() bool {
+	return p.platform == vertexPlatform
+}
+
+// isPartnerHosted returns true when the provider sits behind a hyperscaler
+// partner endpoint (Bedrock or Vertex). These share three traits that
+// distinguish them from the direct Anthropic API: the model identifier
+// appears in the URL path (not the request body); the request body must
+// include `anthropic_version` set to a platform-specific value; and
+// authentication uses the resolved Credential (SigV4 / Bearer) rather than
+// the x-api-key header.
+func (p *Provider) isPartnerHosted() bool {
+	return p.isBedrock() || p.isVertex()
+}
+
+// platformAnthropicVersion returns the anthropic_version body value for the
+// current partner platform. Returns an empty string for the direct API
+// path, where the version is sent as a header instead.
+func (p *Provider) platformAnthropicVersion() string {
+	switch {
+	case p.isBedrock():
+		return bedrockVersionValue
+	case p.isVertex():
+		return vertexVersionValue
+	default:
+		return ""
 	}
-	return p.baseURL + "/messages"
+}
+
+// messagesURL returns the appropriate API endpoint URL.
+// Bedrock: {baseURL}/model/{model}/invoke
+// Vertex:  {baseURL}/{model}:rawPredict
+// Direct:  {baseURL}/messages
+func (p *Provider) messagesURL() string {
+	switch {
+	case p.isBedrock():
+		return p.baseURL + "/model/" + p.model + "/invoke"
+	case p.isVertex():
+		return p.baseURL + "/" + p.model + ":rawPredict"
+	default:
+		return p.baseURL + "/messages"
+	}
 }
 
 // messagesStreamURL returns the appropriate streaming API endpoint URL.
-// For Bedrock: {baseURL}/model/{model}/invoke-with-response-stream
-// For direct Anthropic API: {baseURL}/messages (same as messagesURL; streaming is SSE-based)
+// Bedrock: {baseURL}/model/{model}/invoke-with-response-stream  (binary event-stream)
+// Vertex:  {baseURL}/{model}:streamRawPredict                   (SSE)
+// Direct:  {baseURL}/messages                                   (SSE; same path as messagesURL)
 func (p *Provider) messagesStreamURL() string {
-	if p.isBedrock() {
+	switch {
+	case p.isBedrock():
 		return p.baseURL + "/model/" + p.model + "/invoke-with-response-stream"
+	case p.isVertex():
+		return p.baseURL + "/" + p.model + ":streamRawPredict"
+	default:
+		return p.baseURL + "/messages"
 	}
-	return p.baseURL + "/messages"
 }
 
-// marshalBedrockStreamingRequest converts any request map to Bedrock-compatible JSON,
-// injecting anthropic_version and removing model (Bedrock uses the URL path).
+// marshalBedrockStreamingRequest converts any request map to partner-platform
+// streaming JSON: injects anthropic_version (with the platform-specific value)
+// and removes both the model and stream fields. Used by both Bedrock
+// (binary event-stream) and Vertex (SSE via :streamRawPredict) — neither
+// puts the model in the body, neither uses the stream flag (the URL action
+// signals streaming for both).
 func (p *Provider) marshalBedrockStreamingRequest(reqMap map[string]interface{}) ([]byte, error) {
-	reqMap[bedrockVersionBodyKey] = bedrockVersionValue
+	reqMap[bedrockVersionBodyKey] = p.platformAnthropicVersion()
 	delete(reqMap, "model")
-	// Bedrock streaming does not use the "stream" field — streaming is indicated by the URL path
 	delete(reqMap, "stream")
 	return json.Marshal(reqMap)
 }
@@ -170,12 +239,13 @@ func (p *Provider) makeBedrockStreamingRequest(
 	return resp.Body, scanner, nil
 }
 
-// marshalBedrockRequest converts a claudeRequest to JSON with Bedrock-specific fields.
-// Bedrock expects anthropic_version in the body and does not use the model field in the body
-// (the model is specified in the URL path).
+// marshalBedrockRequest converts a claudeRequest to JSON with partner-platform
+// fields: anthropic_version (with the platform-specific value) and no model
+// field (the model is specified in the URL path). Used by both Bedrock and
+// Vertex non-streaming Predict calls.
 func (p *Provider) marshalBedrockRequest(claudeReq *claudeRequest) ([]byte, error) {
 	m := map[string]interface{}{
-		bedrockVersionBodyKey: bedrockVersionValue,
+		bedrockVersionBodyKey: p.platformAnthropicVersion(),
 		"max_tokens":          claudeReq.MaxTokens,
 		"messages":            claudeReq.Messages,
 	}
@@ -362,10 +432,11 @@ func (p *Provider) applyDefaults(temperature, topP float32, maxTokens int) (fina
 
 // makeClaudeHTTPRequest sends the HTTP request to Claude API
 func (p *Provider) makeClaudeHTTPRequest(ctx context.Context, claudeReq claudeRequest, predictResp providers.PredictionResponse, start time.Time) ([]byte, providers.PredictionResponse, error) {
-	// For Bedrock, marshal via a map so we can inject anthropic_version into the body
+	// Partner-hosted (Bedrock/Vertex): marshal via a map so we can inject
+	// anthropic_version into the body and drop the model field.
 	var reqBody []byte
 	var err error
-	if p.isBedrock() {
+	if p.isPartnerHosted() {
 		reqBody, err = p.marshalBedrockRequest(&claudeReq)
 	} else {
 		reqBody, err = json.Marshal(claudeReq)
@@ -389,8 +460,8 @@ func (p *Provider) makeClaudeHTTPRequest(ctx context.Context, claudeReq claudeRe
 	}
 
 	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-	// Bedrock uses anthropic_version in the body, not as a header
-	if !p.isBedrock() {
+	// Partner-hosted (Bedrock/Vertex) puts anthropic_version in the body, not the header.
+	if !p.isPartnerHosted() {
 		httpReq.Header.Set(anthropicVersionKey, anthropicVersionValue)
 	}
 
@@ -434,12 +505,16 @@ func (p *Provider) makeClaudeHTTPRequest(ctx context.Context, claudeReq claudeRe
 			"response", string(respBody))
 		predictResp.Latency = time.Since(start)
 		predictResp.Raw = respBody
-		if p.isBedrock() {
+		switch {
+		case p.isBedrock():
 			return nil, predictResp, parseBedrockHTTPError(resp.StatusCode, respBody)
-		}
-		return nil, predictResp, &providers.ProviderHTTPError{
-			StatusCode: resp.StatusCode, URL: url,
-			Body: string(respBody), Provider: p.ID(),
+		case p.isVertex():
+			return nil, predictResp, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, respBody)
+		default:
+			return nil, predictResp, &providers.ProviderHTTPError{
+				StatusCode: resp.StatusCode, URL: url,
+				Body: string(respBody), Provider: p.ID(),
+			}
 		}
 	}
 

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -107,6 +107,45 @@ func (p *Provider) PredictStream(
 		})
 	}
 
+	// Vertex: SSE via :streamRawPredict. Body uses the partner shape (no
+	// model, no stream flag, anthropic_version=vertex-2023-10-16); auth via
+	// GCP credential Bearer token; no anthropic-version header (in body).
+	if p.isVertex() {
+		reqBody, err := p.marshalBedrockStreamingRequest(claudeReq)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request: %w", err)
+		}
+		url := p.messagesStreamURL()
+		requestFn := func(ctx context.Context) (*http.Request, error) {
+			httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+			if reqErr != nil {
+				return nil, fmt.Errorf("failed to create request: %w", reqErr)
+			}
+			httpReq.Header.Set(contentTypeHeader, applicationJSON)
+			httpReq.Header.Set("Accept", "text/event-stream")
+			if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+				return nil, fmt.Errorf("failed to apply authentication: %w", authErr)
+			}
+			if hdrErr := p.ApplyCustomHeaders(httpReq); hdrErr != nil {
+				return nil, hdrErr
+			}
+			return httpReq, nil
+		}
+		return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+			Policy:       p.StreamRetryPolicy(),
+			Budget:       p.StreamRetryBudget(),
+			ProviderName: p.ID(),
+			Host:         providers.HostFromURL(url),
+			IdleTimeout:  p.StreamIdleTimeout(),
+			RequestFn:    requestFn,
+			Client:       p.GetStreamingHTTPClient(),
+		}, func(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
+			idleBody := providers.NewIdleTimeoutReader(body, p.StreamIdleTimeout())
+			scanner := providers.NewSSEScanner(idleBody)
+			p.streamResponse(ctx, idleBody, scanner, outChan)
+		})
+	}
+
 	reqBody, err := json.Marshal(claudeReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -502,13 +502,14 @@ func (p *ToolProvider) parseToolResponse(
 }
 
 // applyToolRequestHeaders sets content-type, anthropic auth, and custom
-// headers on req. Uses Bedrock SigV4 signing when isBedrock, otherwise the
-// direct-API x-api-key + anthropic-version headers. Centralizing this keeps
-// the caller functions below cognitive-complexity limits and ensures every
-// request path goes through the same custom-header collision check.
+// headers on req. Partner-hosted (Bedrock SigV4 / Vertex Bearer) auth via
+// the resolved Credential; direct API uses x-api-key + anthropic-version
+// headers. Centralizing this keeps the caller functions below
+// cognitive-complexity limits and ensures every request path goes through
+// the same custom-header collision check.
 func (p *ToolProvider) applyToolRequestHeaders(ctx context.Context, req *http.Request) error {
 	req.Header.Set(contentTypeHeader, applicationJSON)
-	if p.isBedrock() {
+	if p.isPartnerHosted() {
 		if err := p.applyAuth(ctx, req); err != nil {
 			return fmt.Errorf("failed to apply authentication: %w", err)
 		}
@@ -522,11 +523,12 @@ func (p *ToolProvider) applyToolRequestHeaders(ctx context.Context, req *http.Re
 func (p *ToolProvider) makeRequest(ctx context.Context, request interface{}) ([]byte, error) {
 	url := p.messagesURL()
 
-	// For Bedrock, inject anthropic_version into the request body and omit the header
-	if p.isBedrock() {
+	// Partner-hosted (Bedrock/Vertex): inject anthropic_version into the
+	// request body (with the platform-specific value) and drop the model
+	// field — both put the model in the URL path.
+	if p.isPartnerHosted() {
 		if reqMap, ok := request.(map[string]interface{}); ok {
-			reqMap[bedrockVersionBodyKey] = bedrockVersionValue
-			// Remove model from body — Bedrock uses the URL path for model selection
+			reqMap[bedrockVersionBodyKey] = p.platformAnthropicVersion()
 			delete(reqMap, "model")
 		}
 	}
@@ -557,12 +559,16 @@ func (p *ToolProvider) makeRequest(ctx context.Context, request interface{}) ([]
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		if p.isBedrock() {
+		switch {
+		case p.isBedrock():
 			return nil, parseBedrockHTTPError(resp.StatusCode, respBody)
-		}
-		return nil, &providers.ProviderHTTPError{
-			StatusCode: resp.StatusCode, URL: url,
-			Body: string(respBody), Provider: p.ID(),
+		case p.isVertex():
+			return nil, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, respBody)
+		default:
+			return nil, &providers.ProviderHTTPError{
+				StatusCode: resp.StatusCode, URL: url,
+				Body: string(respBody), Provider: p.ID(),
+			}
 		}
 	}
 
@@ -587,13 +593,59 @@ func (p *ToolProvider) PredictStreamWithTools(
 	// Add streaming flag
 	claudeReq["stream"] = true
 
-	// Bedrock: use binary event-stream format, wired through
-	// RunStreamingRequest for retry, budget, semaphore, and metrics.
+	// Bedrock: binary event-stream format.
 	if p.isBedrock() {
 		return p.streamBedrockToolRequest(ctx, claudeReq)
 	}
 
+	// Vertex: SSE via :streamRawPredict with the partner body shape.
+	if p.isVertex() {
+		return p.streamVertexToolRequest(ctx, claudeReq)
+	}
+
 	return p.streamDirectToolRequest(ctx, claudeReq)
+}
+
+// streamVertexToolRequest handles the Vertex AI Anthropic-partner
+// tool-calling streaming path. URL is :streamRawPredict; body uses the
+// shared partner shape (no model field, anthropic_version=vertex-2023-10-16,
+// no stream flag); auth via the GCP credential. The response is plain SSE
+// like the direct API, so the SSE helper is reused.
+func (p *ToolProvider) streamVertexToolRequest(
+	ctx context.Context,
+	claudeReq map[string]interface{},
+) (<-chan providers.StreamChunk, error) {
+	reqBody, err := p.marshalBedrockStreamingRequest(claudeReq)
+	if err != nil {
+		return nil, fmt.Errorf(errMarshalRequestFailed, err)
+	}
+	return p.runSSEToolStream(ctx, reqBody)
+}
+
+// runSSEToolStream is the shared SSE streaming engine for tool-calling
+// requests. Both the direct Anthropic API and the Vertex Anthropic-partner
+// path call into this once they have produced a serialized body — they
+// differ only in body encoding (direct: full claudeReq as-is; vertex: the
+// partner-shape body with anthropic_version+no model+no stream). URL,
+// header set, and SSE scanner are identical.
+func (p *ToolProvider) runSSEToolStream(
+	ctx context.Context, reqBody []byte,
+) (<-chan providers.StreamChunk, error) {
+	url := p.messagesStreamURL()
+	requestFn := p.buildDirectStreamingRequestFn(url, reqBody)
+	return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
+		Policy:       p.StreamRetryPolicy(),
+		Budget:       p.StreamRetryBudget(),
+		ProviderName: p.ID(),
+		Host:         providers.HostFromURL(url),
+		IdleTimeout:  p.StreamIdleTimeout(),
+		RequestFn:    requestFn,
+		Client:       p.GetStreamingHTTPClient(),
+	}, func(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
+		idleBody := providers.NewIdleTimeoutReader(body, p.StreamIdleTimeout())
+		scanner := providers.NewSSEScanner(idleBody)
+		p.streamResponse(ctx, idleBody, scanner, outChan)
+	})
 }
 
 // streamBedrockToolRequest handles the Bedrock tool-calling streaming path.
@@ -626,7 +678,8 @@ func (p *ToolProvider) streamBedrockToolRequest(
 }
 
 // streamDirectToolRequest handles the direct Anthropic API tool-calling
-// streaming path.
+// streaming path. Body is the full claudeReq (model, stream:true and all)
+// serialized as-is; auth is x-api-key via applyToolRequestHeaders.
 func (p *ToolProvider) streamDirectToolRequest(
 	ctx context.Context,
 	claudeReq map[string]interface{},
@@ -635,21 +688,7 @@ func (p *ToolProvider) streamDirectToolRequest(
 	if err != nil {
 		return nil, fmt.Errorf(errMarshalRequestFailed, err)
 	}
-	url := p.messagesStreamURL()
-	requestFn := p.buildDirectStreamingRequestFn(url, requestBytes)
-	return p.RunStreamingRequest(ctx, &providers.StreamRetryRequest{
-		Policy:       p.StreamRetryPolicy(),
-		Budget:       p.StreamRetryBudget(),
-		ProviderName: p.ID(),
-		Host:         providers.HostFromURL(url),
-		IdleTimeout:  p.StreamIdleTimeout(),
-		RequestFn:    requestFn,
-		Client:       p.GetStreamingHTTPClient(),
-	}, func(ctx context.Context, body io.ReadCloser, outChan chan<- providers.StreamChunk) {
-		idleBody := providers.NewIdleTimeoutReader(body, p.StreamIdleTimeout())
-		scanner := providers.NewSSEScanner(idleBody)
-		p.streamResponse(ctx, idleBody, scanner, outChan)
-	})
+	return p.runSSEToolStream(ctx, requestBytes)
 }
 
 // buildBedrockStreamingRequestFn returns a RequestFn for the Bedrock

--- a/runtime/providers/claude/vertex_integration_test.go
+++ b/runtime/providers/claude/vertex_integration_test.go
@@ -1,0 +1,257 @@
+//go:build integration
+
+// Vertex AI integration tests for the claude provider (Anthropic partner
+// endpoint). Exercises the publishers/anthropic/models URL shape, the
+// vertex-2023-10-16 anthropic_version body field, and Bearer-token auth
+// via the GCP credential chain.
+//
+// Run locally:
+//
+//	gcloud auth application-default login
+//	gcloud auth application-default set-quota-project <your-project>
+//	export GCP_PROJECT=<your-project>
+//	export GCP_REGION=us-east5    # optional; us-east5 hosts Anthropic models
+//	export VERTEX_CLAUDE_MODEL=claude-haiku-4-5@20251001  # optional
+//	go test -tags=integration ./runtime/providers/claude/... -run Vertex -v
+//
+// Tests skip if GCP credentials or quota project aren't available, or if
+// Anthropic models aren't enabled in your Vertex Model Garden (which
+// requires an explicit terms acceptance in the GCP console).
+package claude
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func vertexProject() string { return os.Getenv("GCP_PROJECT") }
+
+func vertexRegion() string {
+	if r := os.Getenv("GCP_REGION"); r != "" {
+		return r
+	}
+	return "us-east5"
+}
+
+func vertexClaudeModel() string {
+	if m := os.Getenv("VERTEX_CLAUDE_MODEL"); m != "" {
+		return m
+	}
+	return "claude-haiku-4-5@20251001"
+}
+
+func skipIfNoVertex(t *testing.T) {
+	t.Helper()
+
+	if vertexProject() == "" {
+		t.Skip("GCP_PROJECT not set, skipping Vertex integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cred, err := credentials.NewGCPCredential(ctx, vertexProject(), vertexRegion())
+	if err != nil {
+		t.Skipf("GCP credentials not available (try: gcloud auth application-default login): %v", err)
+	}
+
+	probe, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", http.NoBody)
+	if err := cred.Apply(ctx, probe); err != nil {
+		t.Skipf("GCP token not available: %v", err)
+	}
+}
+
+func vertexClaudeTestProvider(t *testing.T) *Provider {
+	t.Helper()
+	skipIfNoVertex(t)
+
+	ctx := context.Background()
+	cred, err := credentials.NewGCPCredential(ctx, vertexProject(), vertexRegion())
+	if err != nil {
+		t.Fatalf("failed to create GCP credential: %v", err)
+	}
+
+	pc := &providers.PlatformConfig{
+		Type:    "vertex",
+		Region:  vertexRegion(),
+		Project: vertexProject(),
+	}
+
+	// BaseURL deliberately empty: exercises the Arena path where the claude
+	// factory derives the publishers/anthropic/models URL from PlatformConfig.
+	return NewProviderWithCredential(
+		"vertex-claude-test", vertexClaudeModel(), "",
+		providers.ProviderDefaults{
+			MaxTokens:   256,
+			Temperature: 0.1,
+			Pricing: providers.Pricing{
+				InputCostPer1K:  0.001,
+				OutputCostPer1K: 0.005,
+			},
+		},
+		false, cred, "vertex", pc,
+	)
+}
+
+func vertexClaudeTestToolProvider(t *testing.T) *ToolProvider {
+	t.Helper()
+	return &ToolProvider{Provider: vertexClaudeTestProvider(t)}
+}
+
+func TestClaudeVertex_BaseURLConstruction(t *testing.T) {
+	skipIfNoVertex(t)
+
+	p := vertexClaudeTestProvider(t)
+	want := vertexAnthropicEndpoint(vertexRegion(), vertexProject())
+	if p.baseURL != want {
+		t.Fatalf("baseURL = %q, want %q (Vertex publishers/anthropic/models URL)", p.baseURL, want)
+	}
+}
+
+func TestClaudeVertex_Predict(t *testing.T) {
+	provider := vertexClaudeTestProvider(t)
+	ctx := context.Background()
+
+	resp, err := provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.Content == "" {
+		t.Fatal("expected non-empty response content")
+	}
+	t.Logf("Response: %s", resp.Content)
+
+	if resp.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+}
+
+func TestClaudeVertex_PredictWithTools(t *testing.T) {
+	provider := vertexClaudeTestToolProvider(t)
+	ctx := context.Background()
+
+	tools, err := provider.BuildTooling([]*providers.ToolDescriptor{
+		{
+			Name:        "get_weather",
+			Description: "Get weather for a city",
+			InputSchema: []byte(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildTooling failed: %v", err)
+	}
+
+	resp, toolCalls, err := provider.PredictWithTools(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "What is the weather in Paris?"},
+		},
+	}, tools, "auto")
+	if err != nil {
+		t.Fatalf("PredictWithTools failed: %v", err)
+	}
+	if resp.Content == "" && len(toolCalls) == 0 {
+		t.Fatal("expected either text content or tool calls")
+	}
+	if len(toolCalls) > 0 {
+		t.Logf("Tool call: %s(%s)", toolCalls[0].Name, string(toolCalls[0].Args))
+	} else {
+		t.Logf("Text response: %s", resp.Content)
+	}
+}
+
+func TestClaudeVertex_PredictStream(t *testing.T) {
+	provider := vertexClaudeTestProvider(t)
+	ctx := context.Background()
+
+	stream, err := provider.PredictStream(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream failed: %v", err)
+	}
+
+	chunkCount := 0
+	var lastChunk providers.StreamChunk
+	for chunk := range stream {
+		if chunk.Error != nil {
+			t.Fatalf("stream error: %v", chunk.Error)
+		}
+		lastChunk = chunk
+		chunkCount++
+	}
+	if chunkCount == 0 {
+		t.Fatal("expected at least one stream chunk")
+	}
+	if lastChunk.Content == "" {
+		t.Fatal("expected non-empty content in final chunk")
+	}
+	t.Logf("Stream response (%d chunks): %s", chunkCount, lastChunk.Content)
+}
+
+func TestClaudeVertex_ErrorOnInvalidModel(t *testing.T) {
+	skipIfNoVertex(t)
+
+	ctx := context.Background()
+	cred, err := credentials.NewGCPCredential(ctx, vertexProject(), vertexRegion())
+	if err != nil {
+		t.Fatalf("failed to create GCP credential: %v", err)
+	}
+
+	provider := NewProviderWithCredential(
+		"vertex-claude-test-bad", "claude-model-that-does-not-exist-xyz", "",
+		providers.ProviderDefaults{MaxTokens: 100},
+		false, cred, "vertex",
+		&providers.PlatformConfig{
+			Type: "vertex", Region: vertexRegion(), Project: vertexProject(),
+		},
+	)
+
+	_, err = provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid model, got nil")
+	}
+	t.Logf("Got expected error: %v", err)
+}
+
+func TestClaudeVertex_CostCalculation(t *testing.T) {
+	provider := vertexClaudeTestProvider(t)
+	ctx := context.Background()
+
+	resp, err := provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+	if resp.CostInfo.InputTokens <= 0 {
+		t.Errorf("expected positive InputTokens, got %d", resp.CostInfo.InputTokens)
+	}
+	if resp.CostInfo.OutputTokens <= 0 {
+		t.Errorf("expected positive OutputTokens, got %d", resp.CostInfo.OutputTokens)
+	}
+	if resp.CostInfo.TotalCost <= 0 {
+		t.Errorf("expected positive TotalCost, got %f", resp.CostInfo.TotalCost)
+	}
+	t.Logf("Cost: input=%d tokens, output=%d tokens, total=$%.6f",
+		resp.CostInfo.InputTokens, resp.CostInfo.OutputTokens, resp.CostInfo.TotalCost)
+}

--- a/runtime/providers/claude/vertex_streaming_test.go
+++ b/runtime/providers/claude/vertex_streaming_test.go
@@ -1,0 +1,172 @@
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// buildVertexSSEStream returns the body of a Vertex Anthropic-partner SSE
+// stream: each event is a single JSON object preceded by `data: `, terminated
+// by a blank line (matching Anthropic's SSE format that Vertex re-emits).
+func buildVertexSSEStream(events []string) string {
+	var sb strings.Builder
+	for _, ev := range events {
+		sb.WriteString("data: ")
+		sb.WriteString(ev)
+		sb.WriteString("\n\n")
+	}
+	return sb.String()
+}
+
+// vertexStreamCapture holds the request and body the test server saw.
+// Returned by newVertexStreamingTestProvider so tests can assert on the
+// wire format after the stream has been consumed.
+type vertexStreamCapture struct {
+	req  *http.Request
+	body string
+}
+
+// newVertexStreamingTestProvider stands up an httptest server that answers
+// :streamRawPredict with a canned SSE body, and returns a Provider wired to
+// it together with a capture struct populated when the request arrives.
+func newVertexStreamingTestProvider(
+	t *testing.T, sseBody string,
+) (*Provider, *vertexStreamCapture) {
+	t.Helper()
+
+	cap := &vertexStreamCapture{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.req = r.Clone(context.Background())
+		body, _ := io.ReadAll(r.Body)
+		cap.body = string(body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody))
+	}))
+	t.Cleanup(server.Close)
+
+	p := &Provider{
+		BaseProvider: providers.NewBaseProvider("test-vertex", false, server.Client()),
+		model:        "claude-haiku-4-5@20251001",
+		baseURL:      server.URL, // tests do not exercise URL derivation here
+		platform:     vertexPlatform,
+		credential:   &mockBearerCredential{},
+		defaults:     providers.ProviderDefaults{MaxTokens: 256},
+	}
+	return p, cap
+}
+
+func TestVertexPredictStream_SendsRawPredictAndPartnerBody(t *testing.T) {
+	events := []string{
+		`{"type":"message_start","message":{"usage":{"input_tokens":3}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}
+
+	p, cap := newVertexStreamingTestProvider(t, buildVertexSSEStream(events))
+
+	req := providers.PredictionRequest{
+		Messages:  []types.Message{{Role: "user", Content: "hi"}},
+		MaxTokens: 100,
+	}
+	ch, err := p.PredictStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("PredictStream returned error: %v", err)
+	}
+
+	var (
+		text          string
+		stopChunkSeen bool
+	)
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Error)
+		}
+		if chunk.Delta != "" {
+			text += chunk.Delta
+		}
+		if chunk.FinishReason != nil {
+			stopChunkSeen = true
+		}
+	}
+
+	if text != "Hello" {
+		t.Errorf("accumulated text = %q, want %q", text, "Hello")
+	}
+	if !stopChunkSeen {
+		t.Error("expected a final chunk with finish reason")
+	}
+
+	if cap.req == nil {
+		t.Fatal("test server never received a request")
+	}
+
+	// Verify the wire format the provider sent.
+	if got := cap.req.URL.Path; !strings.HasSuffix(got, "/claude-haiku-4-5@20251001:streamRawPredict") {
+		t.Errorf("URL path = %q, want suffix /<model>:streamRawPredict", got)
+	}
+	if got := cap.req.Header.Get("Accept"); got != "text/event-stream" {
+		t.Errorf("Accept = %q, want text/event-stream", got)
+	}
+	if h := cap.req.Header.Get(anthropicVersionKey); h != "" {
+		t.Errorf("Vertex must not set %s header (version is in body), got %q", anthropicVersionKey, h)
+	}
+	if h := cap.req.Header.Get(apiKeyHeader); h != "" {
+		t.Errorf("Vertex must not set %s header, got %q", apiKeyHeader, h)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal([]byte(cap.body), &body); err != nil {
+		t.Fatalf("body not valid JSON: %v", err)
+	}
+	if body[bedrockVersionBodyKey] != vertexVersionValue {
+		t.Errorf("anthropic_version = %v, want %q", body[bedrockVersionBodyKey], vertexVersionValue)
+	}
+	if _, hasModel := body["model"]; hasModel {
+		t.Error("Vertex body must not include `model` field")
+	}
+	if _, hasStream := body["stream"]; hasStream {
+		t.Error("Vertex body must not include `stream` field (URL action signals streaming)")
+	}
+}
+
+func TestVertexPredictStream_AppliesCredential(t *testing.T) {
+	cred := &mockBearerCredential{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	p := &Provider{
+		BaseProvider: providers.NewBaseProvider("test-vertex", false, server.Client()),
+		model:        "claude-haiku-4-5@20251001",
+		baseURL:      server.URL,
+		platform:     vertexPlatform,
+		credential:   cred,
+		defaults:     providers.ProviderDefaults{MaxTokens: 64},
+	}
+
+	ch, err := p.PredictStream(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream: %v", err)
+	}
+	for range ch {
+	}
+
+	if !cred.applied {
+		t.Error("Vertex stream path must call credential.Apply (Bearer)")
+	}
+}

--- a/runtime/providers/claude/vertex_unit_test.go
+++ b/runtime/providers/claude/vertex_unit_test.go
@@ -1,0 +1,262 @@
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// mockBearerCredential records whether Apply was invoked. Used to verify the
+// Vertex auth path attaches the credential and the direct path leaves the
+// request unauthenticated by the credential (it uses x-api-key instead).
+type mockBearerCredential struct{ applied bool }
+
+func (m *mockBearerCredential) Type() string { return "bearer" }
+func (m *mockBearerCredential) Apply(_ context.Context, _ *http.Request) error {
+	m.applied = true
+	return nil
+}
+
+func TestVertexAnthropicEndpoint(t *testing.T) {
+	got := vertexAnthropicEndpoint("us-east5", "my-project")
+	want := "https://us-east5-aiplatform.googleapis.com/v1/projects/my-project/locations/us-east5/publishers/anthropic/models"
+	if got != want {
+		t.Errorf("vertexAnthropicEndpoint = %q, want %q", got, want)
+	}
+}
+
+func TestProvider_PlatformPredicates(t *testing.T) {
+	tests := []struct {
+		platform                             string
+		wantBedrock, wantVertex, wantPartner bool
+		wantVersion                          string
+	}{
+		{bedrockPlatform, true, false, true, bedrockVersionValue},
+		{vertexPlatform, false, true, true, vertexVersionValue},
+		{"azure", false, false, false, ""},
+		{"", false, false, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			p := &Provider{platform: tt.platform}
+			if got := p.isBedrock(); got != tt.wantBedrock {
+				t.Errorf("isBedrock platform=%q got %v want %v", tt.platform, got, tt.wantBedrock)
+			}
+			if got := p.isVertex(); got != tt.wantVertex {
+				t.Errorf("isVertex platform=%q got %v want %v", tt.platform, got, tt.wantVertex)
+			}
+			if got := p.isPartnerHosted(); got != tt.wantPartner {
+				t.Errorf("isPartnerHosted platform=%q got %v want %v", tt.platform, got, tt.wantPartner)
+			}
+			if got := p.platformAnthropicVersion(); got != tt.wantVersion {
+				t.Errorf("platformAnthropicVersion platform=%q got %q want %q",
+					tt.platform, got, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestProvider_MessagesURL_Vertex(t *testing.T) {
+	p := &Provider{
+		platform: vertexPlatform,
+		baseURL:  "https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5/publishers/anthropic/models",
+		model:    "claude-haiku-4-5@20251001",
+	}
+	t.Run("rawPredict", func(t *testing.T) {
+		got := p.messagesURL()
+		want := "https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5/publishers/anthropic/models/claude-haiku-4-5@20251001:rawPredict"
+		if got != want {
+			t.Errorf("messagesURL = %q, want %q", got, want)
+		}
+	})
+	t.Run("streamRawPredict", func(t *testing.T) {
+		got := p.messagesStreamURL()
+		want := "https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5/publishers/anthropic/models/claude-haiku-4-5@20251001:streamRawPredict"
+		if got != want {
+			t.Errorf("messagesStreamURL = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestProvider_MarshalBedrockRequest_VertexVersion(t *testing.T) {
+	// marshalBedrockRequest is shared by Bedrock and Vertex; the
+	// anthropic_version body field must reflect the active platform.
+	p := &Provider{platform: vertexPlatform, model: "claude-haiku-4-5@20251001"}
+	req := &claudeRequest{
+		MaxTokens: 100,
+		Messages: []claudeMessage{
+			{Role: "user", Content: []claudeContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	}
+	body, err := p.marshalBedrockRequest(req)
+	if err != nil {
+		t.Fatalf("marshalBedrockRequest: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("response body not valid JSON: %v", err)
+	}
+	if parsed[bedrockVersionBodyKey] != vertexVersionValue {
+		t.Errorf("anthropic_version = %v, want %q", parsed[bedrockVersionBodyKey], vertexVersionValue)
+	}
+	if _, hasModel := parsed["model"]; hasModel {
+		t.Errorf("partner body must not include model field, got: %v", parsed["model"])
+	}
+}
+
+func TestProvider_MarshalBedrockStreamingRequest_VertexVersion(t *testing.T) {
+	p := &Provider{platform: vertexPlatform, model: "claude-haiku-4-5@20251001"}
+	reqMap := map[string]any{
+		"model":      "claude-haiku-4-5@20251001",
+		"max_tokens": 100,
+		"messages":   []any{},
+		"stream":     true,
+	}
+	body, err := p.marshalBedrockStreamingRequest(reqMap)
+	if err != nil {
+		t.Fatalf("marshalBedrockStreamingRequest: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("body not valid JSON: %v", err)
+	}
+	if parsed[bedrockVersionBodyKey] != vertexVersionValue {
+		t.Errorf("anthropic_version = %v, want %q", parsed[bedrockVersionBodyKey], vertexVersionValue)
+	}
+	if _, hasModel := parsed["model"]; hasModel {
+		t.Error("vertex streaming body must not include model field")
+	}
+	if _, hasStream := parsed["stream"]; hasStream {
+		t.Error("vertex streaming body must not include stream field (URL action signals streaming)")
+	}
+}
+
+func TestNewProviderWithCredential_DerivesVertexURL(t *testing.T) {
+	cred := &mockBearerCredential{}
+
+	t.Run("empty BaseURL with vertex platform derives publisher-models URL", func(t *testing.T) {
+		pc := &providers.PlatformConfig{
+			Type: vertexPlatform, Region: "us-east5", Project: "my-proj",
+		}
+		p := NewProviderWithCredential(
+			"test", "claude-haiku-4-5@20251001", "",
+			providers.ProviderDefaults{},
+			false, cred, vertexPlatform, pc,
+		)
+		want := vertexAnthropicEndpoint("us-east5", "my-proj")
+		if p.baseURL != want {
+			t.Errorf("baseURL = %q, want %q", p.baseURL, want)
+		}
+	})
+
+	t.Run("explicit BaseURL is preserved on vertex", func(t *testing.T) {
+		pc := &providers.PlatformConfig{
+			Type: vertexPlatform, Region: "us-east5", Project: "my-proj",
+		}
+		custom := "https://custom.vertex.example/v1/.../publishers/anthropic/models"
+		p := NewProviderWithCredential(
+			"test", "claude-haiku-4-5@20251001", custom,
+			providers.ProviderDefaults{},
+			false, cred, vertexPlatform, pc,
+		)
+		if p.baseURL != custom {
+			t.Errorf("explicit baseURL must win, got %q", p.baseURL)
+		}
+	})
+
+	t.Run("missing project leaves BaseURL empty", func(t *testing.T) {
+		pc := &providers.PlatformConfig{Type: vertexPlatform, Region: "us-east5"}
+		p := NewProviderWithCredential(
+			"test", "claude-haiku-4-5@20251001", "",
+			providers.ProviderDefaults{},
+			false, cred, vertexPlatform, pc,
+		)
+		if p.baseURL != "" {
+			t.Errorf("incomplete PlatformConfig should not derive URL, got %q", p.baseURL)
+		}
+	})
+
+	t.Run("non-vertex platform does not derive URL", func(t *testing.T) {
+		pc := &providers.PlatformConfig{Type: "bedrock", Region: "us-west-2"}
+		p := NewProviderWithCredential(
+			"test", "claude-haiku-4-5", "",
+			providers.ProviderDefaults{},
+			false, cred, "bedrock", pc,
+		)
+		if p.baseURL != "" {
+			t.Errorf("non-vertex platform should not derive URL, got %q", p.baseURL)
+		}
+	})
+}
+
+// TestVertex_DirectAPIPathStillUsesAPIKeyHeader sanity-checks that the
+// direct-API tool request path is not regressed by the partner-hosted
+// branching — direct requests must still set x-api-key + anthropic-version
+// (verified via the ToolProvider's applyToolRequestHeaders).
+func TestProvider_ApplyToolRequestHeaders_VertexUsesCredential(t *testing.T) {
+	cred := &mockBearerCredential{}
+	tp := &ToolProvider{
+		Provider: &Provider{
+			platform:   vertexPlatform,
+			credential: cred,
+			apiKey:     "should-not-be-used",
+		},
+	}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.com", http.NoBody)
+	if err := tp.applyToolRequestHeaders(context.Background(), req); err != nil {
+		t.Fatalf("applyToolRequestHeaders: %v", err)
+	}
+	if !cred.applied {
+		t.Error("vertex path must invoke credential.Apply (Bearer)")
+	}
+	if h := req.Header.Get(apiKeyHeader); h != "" {
+		t.Errorf("vertex path must not set %s header, got %q", apiKeyHeader, h)
+	}
+	if h := req.Header.Get(anthropicVersionKey); h != "" {
+		t.Errorf("vertex path must not set %s header (version is in body), got %q", anthropicVersionKey, h)
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}
+
+func TestProvider_ApplyToolRequestHeaders_DirectStillUsesAPIKey(t *testing.T) {
+	tp := &ToolProvider{
+		Provider: &Provider{
+			platform: "",
+			apiKey:   "direct-key",
+		},
+	}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://example.com", http.NoBody)
+	if err := tp.applyToolRequestHeaders(context.Background(), req); err != nil {
+		t.Fatalf("applyToolRequestHeaders: %v", err)
+	}
+	if got := req.Header.Get(apiKeyHeader); got != "direct-key" {
+		t.Errorf("direct path must set %s, got %q", apiKeyHeader, got)
+	}
+	if got := req.Header.Get(anthropicVersionKey); got == "" {
+		t.Errorf("direct path must set %s header", anthropicVersionKey)
+	}
+}
+
+// Catch a doubled segment regression like /models/models/{model}.
+func TestProvider_MessagesURL_NoDoubledSegments(t *testing.T) {
+	p := &Provider{
+		platform: vertexPlatform,
+		baseURL:  vertexAnthropicEndpoint("us-east5", "p"),
+		model:    "claude-haiku-4-5",
+	}
+	for _, fn := range []func() string{p.messagesURL, p.messagesStreamURL} {
+		got := fn()
+		if strings.Contains(got, "/models/models/") {
+			t.Errorf("doubled /models/ segment in URL: %s", got)
+		}
+		if strings.Contains(got, "?key=") {
+			t.Errorf("vertex URL must not embed an API key: %s", got)
+		}
+	}
+}

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -234,7 +234,13 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 				baseURL = DefaultGeminiBaseURL
 			}
 		case "claude":
-			baseURL = "https://api.anthropic.com"
+			// Skip the api.anthropic.com default for Vertex — the claude
+			// factory builds the publishers/anthropic/models URL from
+			// PlatformConfig. Same #1010 root cause as openai+azure and
+			// gemini+vertex.
+			if spec.Platform != "vertex" {
+				baseURL = "https://api.anthropic.com"
+			}
 		case "imagen":
 			baseURL = DefaultGeminiBaseURL
 		case "ollama":

--- a/runtime/providers/registry_extended_test.go
+++ b/runtime/providers/registry_extended_test.go
@@ -230,30 +230,28 @@ func TestCreateProviderFromSpecOpenAIAzureSkipsDefault(t *testing.T) {
 	}
 }
 
-// TestCreateProviderFromSpecGeminiVertexSkipsDefault is a regression test for
-// the Vertex cell of #1009: when spec.Type=="gemini" and spec.Platform=="vertex",
-// the registry must NOT default BaseURL to the AI Studio v1beta endpoint.
-// The gemini factory builds the publisher-models URL from PlatformConfig and
-// that branch is gated on baseURL=="" — clobbering it makes the Vertex path
-// unreachable, the same root cause as openai+azure (#1010).
-func TestCreateProviderFromSpecGeminiVertexSkipsDefault(t *testing.T) {
-	originalFactory := providerFactories["gemini"]
+// TestCreateProviderFromSpecClaudeVertexSkipsDefault is the matching
+// regression test for the claude+vertex cell: api.anthropic.com must not
+// clobber spec.BaseURL when Platform=="vertex". The claude factory derives
+// the publishers/anthropic/models URL from PlatformConfig in that case.
+func TestCreateProviderFromSpecClaudeVertexSkipsDefault(t *testing.T) {
+	originalFactory := providerFactories["claude"]
 	capturedBaseURL := "sentinel"
-	providerFactories["gemini"] = func(spec ProviderSpec) (Provider, error) {
+	providerFactories["claude"] = func(spec ProviderSpec) (Provider, error) {
 		capturedBaseURL = spec.BaseURL
 		return &mockProviderForTest{id: spec.ID}, nil
 	}
 	defer func() {
 		if originalFactory != nil {
-			providerFactories["gemini"] = originalFactory
+			providerFactories["claude"] = originalFactory
 		} else {
-			delete(providerFactories, "gemini")
+			delete(providerFactories, "claude")
 		}
 	}()
 
 	spec := ProviderSpec{
-		ID:       "vertex-gemini",
-		Type:     "gemini",
+		ID:       "vertex-claude",
+		Type:     "claude",
 		Model:    testModelName,
 		Platform: "vertex",
 	}
@@ -263,7 +261,7 @@ func TestCreateProviderFromSpecGeminiVertexSkipsDefault(t *testing.T) {
 	}
 
 	if capturedBaseURL != "" {
-		t.Errorf("Expected empty BaseURL for gemini+vertex, got %q (regression of #1010-class bug)", capturedBaseURL)
+		t.Errorf("Expected empty BaseURL for claude+vertex, got %q (regression of #1010-class bug)", capturedBaseURL)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds Vertex AI Anthropic-partner support to the claude provider. Third
cell delivered against the #1009 matrix following openai+azure (#1010)
and gemini+vertex (#1023). Same pattern as those two: per-provider
factory derives the platform URL from `PlatformConfig` when caller
passes empty `BaseURL`, registry skips the vendor default for that
platform pair so the factory branch is reachable.

## What changed

### Code

- `runtime/providers/claude/claude.go`
  - New `vertexPlatform`, `vertexVersionValue`, `vertexAnthropicEndpoint`.
  - `isVertex()`, `isPartnerHosted()`, `platformAnthropicVersion()` predicates so callers branch by capability rather than enumerating platforms inline.
  - `messagesURL()` / `messagesStreamURL()` extended with the Vertex branch (`{baseURL}/{model}:rawPredict` and `:streamRawPredict`).
  - `marshalBedrockRequest` / `marshalBedrockStreamingRequest` generalized: same body shape for both partners, version sourced from `platformAnthropicVersion()`.
  - `makeClaudeHTTPRequest` switched from `isBedrock` to `isPartnerHosted` for body/header decisions; Vertex errors routed through `providers.ParsePlatformHTTPError`.
  - `NewProviderWithCredential` derives the Vertex publishers/anthropic/models URL when caller passes empty `BaseURL`.
- `runtime/providers/claude/claude_streaming.go` — new Vertex branch in `PredictStream` that reuses `marshalBedrockStreamingRequest` for the partner body shape, posts to `:streamRawPredict`, applies the GCP credential as a Bearer token, no `anthropic-version` header.
- `runtime/providers/claude/claude_tools.go` — `applyToolRequestHeaders` and `makeRequest` switched to `isPartnerHosted`. Tool-streaming gains `streamVertexToolRequest`. SSE wiring extracted into `runSSEToolStream` so direct and Vertex paths share the engine and only differ in body bytes (kills a `dupl` lint).
- `runtime/providers/registry.go` — skips `https://api.anthropic.com` default when `spec.Platform=="vertex"`.

### Tests

- `runtime/providers/claude/vertex_unit_test.go` — predicates, URL builders, body marshallers, factory URL derivation; verifies the direct API path is unchanged (still uses x-api-key + anthropic-version header).
- `runtime/providers/claude/vertex_streaming_test.go` — drives `PredictStream` through the new Vertex branch via `httptest`. Asserts wire format: `:streamRawPredict` URL action, no `model`/`stream` in body, `anthropic_version=vertex-2023-10-16`, Bearer auth, no `x-api-key`/`anthropic-version` headers.
- `runtime/providers/registry_extended_test.go` — claude+vertex regression test mirroring the openai+azure and gemini+vertex ones.
- `runtime/providers/claude/vertex_integration_test.go` — `//go:build integration` suite covering URL derivation, predict, predict-with-tools, streaming, error propagation, and cost calculation against a real Vertex deployment.

### Bedrock untouched

The shared `marshalBedrockRequest` / `marshalBedrockStreamingRequest` now consult `platformAnthropicVersion()` instead of hardcoding `bedrockVersionValue`, but Bedrock's value is unchanged so the wire format on the Bedrock path is byte-identical. Verified: `BEDROCK_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0 go test -tags=integration -run ^TestBedrock_ ./runtime/providers/claude/` — 5/5 still pass against AWS.

## Pre-commit

Both commits passed locally:
- lint: 0 issues
- coverage on changed files: claude.go 83.1%, claude_streaming.go 88.0% (up from 78.5% pre-test), claude_tools.go 84.1%, registry.go 91.2% (all ≥80%)

## Test plan

- [x] `go test -race -count=1 ./runtime/providers/...` — green
- [x] `go test ./runtime/providers/claude/ -run TestVertex` — 13 unit + 2 streaming tests pass
- [x] `go test ./runtime/providers/ -run TestCreateProviderFromSpecClaudeVertexSkipsDefault` — pass
- [x] Bedrock integration suite (`-tags=integration -run ^TestBedrock_`) — 5/5 still pass after the refactor
- [-] Live Vertex Anthropic integration tests — skipped: account requires Anthropic models to be enabled in Vertex Model Garden (manual GCP-console terms acceptance, analogous to AWS use-case form). Structural tests (URL construction, error propagation) confirm the code path is reachable; live runs will turn green once the project enables Anthropic in Model Garden.

## Out of scope

- Remaining 5 cells of #1009: claude+azure, openai+bedrock, openai+vertex, gemini+bedrock, gemini+azure.
- Arena example for claude+vertex — same pattern as `examples/azure-foundry-test/` and friends; trivial to add once Anthropic is enabled in Model Garden.

Refs #1009
