### PR TITLE
feat(providers): reject unsupported provider×platform pairs (#1009)

### DIFF
--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -676,18 +676,25 @@ func (p *ToolProvider) GetStreamingCapabilities() providers.StreamingCapabilitie
 
 //nolint:gochecknoinits // Factory registration requires init
 func init() {
-	providers.RegisterProviderFactory("gemini", providers.CredentialFactory(
-		func(spec providers.ProviderSpec) (providers.Provider, error) {
-			return NewToolProviderWithCredential(
-				spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
-				spec.IncludeRawOutput, spec.Credential,
-				spec.Platform, spec.PlatformConfig,
-			), nil
-		},
-		func(spec providers.ProviderSpec) (providers.Provider, error) {
-			return NewToolProvider(
-				spec.ID, spec.Model, spec.BaseURL, spec.Defaults, spec.IncludeRawOutput,
-			), nil
-		},
+	// Reject (gemini, bedrock) and (gemini, azure): neither AWS Bedrock nor
+	// Azure AI Foundry hosts Google Gemini as a partner endpoint. Routing
+	// these would either 404 or send the wrong auth shape. Fail at
+	// construction with a clear error instead. (#1009)
+	providers.RegisterProviderFactory("gemini", providers.RejectPlatforms(
+		map[string]bool{"bedrock": true, "azure": true},
+		providers.CredentialFactory(
+			func(spec providers.ProviderSpec) (providers.Provider, error) {
+				return NewToolProviderWithCredential(
+					spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
+					spec.IncludeRawOutput, spec.Credential,
+					spec.Platform, spec.PlatformConfig,
+				), nil
+			},
+			func(spec providers.ProviderSpec) (providers.Provider, error) {
+				return NewToolProvider(
+					spec.ID, spec.Model, spec.BaseURL, spec.Defaults, spec.IncludeRawOutput,
+				), nil
+			},
+		),
 	))
 }

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -613,19 +613,26 @@ func (p *ToolProvider) predictStreamWithCompletions(
 
 //nolint:gochecknoinits // Factory registration requires init
 func init() {
-	providers.RegisterProviderFactory("openai", providers.CredentialFactory(
-		func(spec providers.ProviderSpec) (providers.Provider, error) {
-			return NewToolProviderWithCredential(
-				spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
-				spec.IncludeRawOutput, spec.AdditionalConfig, spec.Credential,
-				spec.Platform, spec.PlatformConfig, spec.UnsupportedParams,
-			), nil
-		},
-		func(spec providers.ProviderSpec) (providers.Provider, error) {
-			return NewToolProvider(
-				spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
-				spec.IncludeRawOutput, spec.AdditionalConfig, spec.UnsupportedParams,
-			), nil
-		},
+	// Reject (openai, vertex): Vertex AI does not host OpenAI models as a
+	// native partner endpoint. Routing this combination would either 404
+	// at the wire or silently send Entra-style auth to an OpenAI-shaped
+	// URL. Fail at construction with a clear error instead. (#1009)
+	providers.RegisterProviderFactory("openai", providers.RejectPlatforms(
+		map[string]bool{"vertex": true},
+		providers.CredentialFactory(
+			func(spec providers.ProviderSpec) (providers.Provider, error) {
+				return NewToolProviderWithCredential(
+					spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
+					spec.IncludeRawOutput, spec.AdditionalConfig, spec.Credential,
+					spec.Platform, spec.PlatformConfig, spec.UnsupportedParams,
+				), nil
+			},
+			func(spec providers.ProviderSpec) (providers.Provider, error) {
+				return NewToolProvider(
+					spec.ID, spec.Model, spec.BaseURL, spec.Defaults,
+					spec.IncludeRawOutput, spec.AdditionalConfig, spec.UnsupportedParams,
+				), nil
+			},
+		),
 	))
 }

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -333,6 +333,42 @@ func (e *UnsupportedProviderError) Error() string {
 	return "unsupported provider type: " + e.ProviderType
 }
 
+// UnsupportedProviderPlatformError is returned when a provider type is
+// recognized but the requested platform is not a real partner endpoint
+// for that vendor (e.g. openai+vertex — Vertex does not host OpenAI
+// models natively). The error fires at provider construction so the
+// failure is config-time rather than first-request, giving operators a
+// fast and explicit signal that the combination is unavailable.
+type UnsupportedProviderPlatformError struct {
+	ProviderType string
+	Platform     string
+}
+
+// Error returns the error message for this unsupported pair.
+func (e *UnsupportedProviderPlatformError) Error() string {
+	return "provider type " + e.ProviderType +
+		" does not support platform " + e.Platform +
+		" — this combination is not offered by the platform vendor"
+}
+
+// RejectPlatforms wraps a ProviderFactory so it returns an
+// UnsupportedProviderPlatformError when spec.Platform is in rejected.
+// Used by per-provider init() to fail fast on (provider, platform) pairs
+// the underlying vendor doesn't host. Pairs that are real partner
+// endpoints either route through inner with a custom URL builder, or
+// fall through unchanged when the spec carries no platform.
+func RejectPlatforms(rejected map[string]bool, inner ProviderFactory) ProviderFactory {
+	return func(spec ProviderSpec) (Provider, error) {
+		if rejected[spec.Platform] {
+			return nil, &UnsupportedProviderPlatformError{
+				ProviderType: spec.Type,
+				Platform:     spec.Platform,
+			}
+		}
+		return inner(spec)
+	}
+}
+
 // HasCredential returns true if the spec has a real (non-empty, non-"none") credential.
 // Use this in factory functions to decide between credential-based and env-var-based constructors.
 func (s *ProviderSpec) HasCredential() bool {

--- a/runtime/providers/reject_platforms_test.go
+++ b/runtime/providers/reject_platforms_test.go
@@ -1,0 +1,119 @@
+package providers
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRejectPlatforms_RejectsListedPlatform(t *testing.T) {
+	innerCalled := false
+	wrapped := RejectPlatforms(
+		map[string]bool{"vertex": true},
+		func(spec ProviderSpec) (Provider, error) {
+			innerCalled = true
+			return &mockProviderForTest{id: spec.ID}, nil
+		},
+	)
+
+	_, err := wrapped(ProviderSpec{Type: "openai", Platform: "vertex"})
+	if err == nil {
+		t.Fatal("expected error for rejected platform, got nil")
+	}
+	if innerCalled {
+		t.Error("inner factory must not be invoked for rejected platforms")
+	}
+
+	var typed *UnsupportedProviderPlatformError
+	if !errors.As(err, &typed) {
+		t.Fatalf("expected UnsupportedProviderPlatformError, got %T: %v", err, err)
+	}
+	if typed.ProviderType != "openai" || typed.Platform != "vertex" {
+		t.Errorf("error fields = (%q, %q), want (openai, vertex)", typed.ProviderType, typed.Platform)
+	}
+}
+
+func TestRejectPlatforms_AllowsUnlistedPlatform(t *testing.T) {
+	wrapped := RejectPlatforms(
+		map[string]bool{"vertex": true},
+		func(spec ProviderSpec) (Provider, error) {
+			return &mockProviderForTest{id: spec.ID}, nil
+		},
+	)
+
+	tests := []string{"", "azure", "bedrock"}
+	for _, platform := range tests {
+		t.Run("platform="+platform, func(t *testing.T) {
+			p, err := wrapped(ProviderSpec{ID: "x", Type: "openai", Platform: platform})
+			if err != nil {
+				t.Fatalf("unexpected error for allowed platform %q: %v", platform, err)
+			}
+			if p == nil {
+				t.Fatal("expected non-nil provider for allowed platform")
+			}
+		})
+	}
+}
+
+func TestUnsupportedProviderPlatformError_Message(t *testing.T) {
+	err := &UnsupportedProviderPlatformError{ProviderType: "gemini", Platform: "bedrock"}
+	msg := err.Error()
+	for _, want := range []string{"gemini", "bedrock", "not offered by the platform vendor"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message %q missing %q", msg, want)
+		}
+	}
+}
+
+// TestCreateProviderFromSpec_RejectsOpenAIVertex verifies the registered
+// openai factory returns UnsupportedProviderPlatformError when the spec
+// asks for Vertex (which Google does not host as an OpenAI partner
+// endpoint).
+func TestCreateProviderFromSpec_RejectsOpenAIVertex(t *testing.T) {
+	if _, ok := providerFactories["openai"]; !ok {
+		t.Skip("openai factory not registered; subpackage not imported in this test build")
+	}
+	_, err := CreateProviderFromSpec(ProviderSpec{
+		ID:       "x",
+		Type:     "openai",
+		Model:    testModelName,
+		Platform: "vertex",
+	})
+	if err == nil {
+		t.Fatal("expected error for openai+vertex, got nil")
+	}
+	var typed *UnsupportedProviderPlatformError
+	if !errors.As(err, &typed) {
+		t.Fatalf("expected UnsupportedProviderPlatformError, got %T: %v", err, err)
+	}
+}
+
+// TestCreateProviderFromSpec_RejectsGeminiOnHyperscalers verifies the
+// registered gemini factory rejects both bedrock and azure (neither AWS
+// nor Azure hosts Gemini natively).
+func TestCreateProviderFromSpec_RejectsGeminiOnHyperscalers(t *testing.T) {
+	if _, ok := providerFactories["gemini"]; !ok {
+		t.Skip("gemini factory not registered; subpackage not imported in this test build")
+	}
+
+	for _, platform := range []string{"bedrock", "azure"} {
+		t.Run("platform="+platform, func(t *testing.T) {
+			_, err := CreateProviderFromSpec(ProviderSpec{
+				ID:       "x",
+				Type:     "gemini",
+				Model:    testModelName,
+				Platform: platform,
+			})
+			if err == nil {
+				t.Fatalf("expected error for gemini+%s, got nil", platform)
+			}
+			var typed *UnsupportedProviderPlatformError
+			if !errors.As(err, &typed) {
+				t.Fatalf("expected UnsupportedProviderPlatformError, got %T: %v", err, err)
+			}
+			if typed.Platform != platform {
+				t.Errorf("error platform = %q, want %q", typed.Platform, platform)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes three fail-fast cells of the provider matrix — combinations
where the hyperscaler does not host the model vendor as a partner
endpoint. These pairs previously would 404 at the wire or silently
route to the wrong URL with the wrong auth; they now fail at provider
construction with a typed, actionable error.

| Cell | Reason |
|---|---|
| `openai × vertex`  | Vertex AI does not host OpenAI as a partner endpoint |
| `gemini × bedrock` | AWS Bedrock does not host Google Gemini |
| `gemini × azure`   | Azure AI Foundry does not host Google Gemini |

This follows the three real-partner cells already landed —
openai+azure (#1010), gemini+vertex (#1023), claude+vertex (#1024) —
leaving 2 real cells still open in #1009 (claude+azure, openai+bedrock).

## Mechanism

- New `UnsupportedProviderPlatformError{ProviderType, Platform}` in
  `runtime/providers/registry.go`, a sibling to the existing
  `UnsupportedProviderError` for unknown provider types.
- New `RejectPlatforms(rejected, inner)` helper that wraps a
  `ProviderFactory` and short-circuits with the typed error when
  `spec.Platform` is in the rejected set. Reusable for future cells.
- openai factory `init()` wraps with `RejectPlatforms{vertex}`.
- gemini factory `init()` wraps with `RejectPlatforms{bedrock, azure}`.
- Existing real pairs (openai+azure, gemini+vertex, claude+bedrock,
  claude+vertex, plus non-platform direct-API paths) fall through
  `RejectPlatforms` unchanged.

## Tests

`runtime/providers/reject_platforms_test.go`:
- `RejectPlatforms` wrapper — rejects listed, allows unlisted+empty,
  error surfaces through `errors.As(..., &UnsupportedProviderPlatformError)`.
- End-to-end `CreateProviderFromSpec` rejection for `openai+vertex`
  and `gemini+{bedrock,azure}`.

## Pre-commit

- lint: 0 issues
- coverage on changed files: registry.go 93.5%, openai_tools.go 85.2%,
  gemini_tools.go 88.1% (all ≥80%)

## Test plan

- [x] `go test -race -count=1 ./runtime/providers/... ./runtime/providers/claude/... ./runtime/providers/openai/... ./runtime/providers/gemini/...` — all green
- [x] New unit tests exercise each rejection path and the fall-through behaviour
- [x] Existing openai+azure, gemini+vertex, claude+bedrock, claude+vertex, direct-API tests unaffected

## Matrix status after this PR

| providerType | bedrock | vertex | azure |
|---|---|---|---|
| **claude** | ✅ | ✅ (#1024) | ❌ still open |
| **openai** | ❌ still open | ⛔ rejected | ✅ (#1010) |
| **gemini** | ⛔ rejected | ✅ (#1023) | ⛔ rejected |

Refs #1009
