### PR TITLE
feat(providers): openai on bedrock (#1009 cell)

### DIFF
--- a/runtime/providers/openai/bedrock_integration_test.go
+++ b/runtime/providers/openai/bedrock_integration_test.go
@@ -1,0 +1,246 @@
+//go:build integration
+
+// Bedrock OpenAI integration tests. Exercises the openai provider
+// against AWS Bedrock's gpt-oss partner endpoint: standard Bedrock URL
+// shape (/model/{id}/invoke), SigV4 auth via the AWS credential chain,
+// OpenAI Chat Completions request and response JSON.
+//
+// Run locally:
+//
+//	export AWS_PROFILE=<profile-with-bedrock-access>
+//	export AWS_REGION=us-west-2
+//	export BEDROCK_OPENAI_MODEL=openai.gpt-oss-20b-1:0
+//	go test -tags=integration ./runtime/providers/openai/... -run BedrockOpenAI -v
+//
+// Tests skip when AWS credentials are unavailable. Live calls additionally
+// require Bedrock model access for the chosen model in the chosen region.
+package openai
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func bedrockRegion() string {
+	if r := os.Getenv("AWS_REGION"); r != "" {
+		return r
+	}
+	return "us-west-2"
+}
+
+func bedrockOpenAIModel() string {
+	if m := os.Getenv("BEDROCK_OPENAI_MODEL"); m != "" {
+		return m
+	}
+	return "openai.gpt-oss-20b-1:0"
+}
+
+func skipIfNoAWS(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := credentials.NewAWSCredential(ctx, bedrockRegion()); err != nil {
+		t.Skipf("AWS credentials not available: %v", err)
+	}
+}
+
+func bedrockOpenAITestProvider(t *testing.T) *Provider {
+	t.Helper()
+	skipIfNoAWS(t)
+
+	ctx := context.Background()
+	cred, err := credentials.NewAWSCredential(ctx, bedrockRegion())
+	if err != nil {
+		t.Fatalf("failed to create AWS credential: %v", err)
+	}
+
+	return NewProviderFromConfig(&ProviderConfig{
+		ID:       "bedrock-openai-test",
+		Model:    bedrockOpenAIModel(),
+		BaseURL:  "", // exercise the factory's PlatformConfig.Region URL derivation
+		Platform: "bedrock",
+		PlatformConfig: &providers.PlatformConfig{
+			Type:   "bedrock",
+			Region: bedrockRegion(),
+		},
+		Credential: cred,
+		Defaults: providers.ProviderDefaults{
+			MaxTokens:   256,
+			Temperature: 0.1,
+			Pricing: providers.Pricing{
+				InputCostPer1K:  0.00015,
+				OutputCostPer1K: 0.0006,
+			},
+		},
+	})
+}
+
+func bedrockOpenAITestToolProvider(t *testing.T) *ToolProvider {
+	t.Helper()
+	return &ToolProvider{Provider: bedrockOpenAITestProvider(t)}
+}
+
+func TestBedrockOpenAI_BaseURLConstruction(t *testing.T) {
+	skipIfNoAWS(t)
+
+	p := bedrockOpenAITestProvider(t)
+	want := credentials.BedrockEndpoint(bedrockRegion())
+	if p.baseURL != want {
+		t.Fatalf("baseURL = %q, want %q", p.baseURL, want)
+	}
+}
+
+func TestBedrockOpenAI_Predict(t *testing.T) {
+	provider := bedrockOpenAITestProvider(t)
+	ctx := context.Background()
+
+	resp, err := provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.Content == "" {
+		t.Fatal("expected non-empty response content")
+	}
+	t.Logf("Response: %s", resp.Content)
+
+	if resp.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+}
+
+func TestBedrockOpenAI_PredictWithTools(t *testing.T) {
+	provider := bedrockOpenAITestToolProvider(t)
+	ctx := context.Background()
+
+	tools, err := provider.BuildTooling([]*providers.ToolDescriptor{
+		{
+			Name:        "get_weather",
+			Description: "Get weather for a city",
+			InputSchema: []byte(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildTooling failed: %v", err)
+	}
+
+	resp, toolCalls, err := provider.PredictWithTools(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "What is the weather in Paris?"},
+		},
+	}, tools, "auto")
+	if err != nil {
+		t.Fatalf("PredictWithTools failed: %v", err)
+	}
+	if resp.Content == "" && len(toolCalls) == 0 {
+		t.Fatal("expected either text content or tool calls")
+	}
+	if len(toolCalls) > 0 {
+		t.Logf("Tool call: %s(%s)", toolCalls[0].Name, string(toolCalls[0].Args))
+	} else {
+		t.Logf("Text response: %s", resp.Content)
+	}
+}
+
+// TestBedrockOpenAI_PredictStream_Fallback exercises the single-chunk
+// fallback. Bedrock's binary event-stream is not yet wired for openai;
+// PredictStream runs Predict and emits one terminal chunk so callers
+// using the streaming interface still get content + finish reason +
+// cost on the channel.
+func TestBedrockOpenAI_PredictStream_Fallback(t *testing.T) {
+	provider := bedrockOpenAITestProvider(t)
+	ctx := context.Background()
+
+	stream, err := provider.PredictStream(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream failed: %v", err)
+	}
+
+	chunkCount := 0
+	var lastChunk providers.StreamChunk
+	for chunk := range stream {
+		if chunk.Error != nil {
+			t.Fatalf("stream error: %v", chunk.Error)
+		}
+		lastChunk = chunk
+		chunkCount++
+	}
+	if chunkCount != 1 {
+		t.Errorf("Bedrock fallback expected exactly 1 chunk, got %d", chunkCount)
+	}
+	if lastChunk.Content == "" {
+		t.Fatal("expected non-empty content in terminal chunk")
+	}
+	if lastChunk.FinishReason == nil {
+		t.Fatal("expected finish reason in terminal chunk")
+	}
+	t.Logf("Terminal chunk: %s (finish=%s)", lastChunk.Content, *lastChunk.FinishReason)
+}
+
+func TestBedrockOpenAI_ErrorOnInvalidModel(t *testing.T) {
+	skipIfNoAWS(t)
+
+	ctx := context.Background()
+	cred, err := credentials.NewAWSCredential(ctx, bedrockRegion())
+	if err != nil {
+		t.Fatalf("failed to create AWS credential: %v", err)
+	}
+
+	provider := NewProviderFromConfig(&ProviderConfig{
+		ID:       "bedrock-openai-test-bad",
+		Model:    "openai.model-that-does-not-exist-xyz",
+		Platform: "bedrock",
+		PlatformConfig: &providers.PlatformConfig{
+			Type: "bedrock", Region: bedrockRegion(),
+		},
+		Credential: cred,
+		Defaults:   providers.ProviderDefaults{MaxTokens: 100},
+	})
+
+	_, err = provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid model, got nil")
+	}
+	t.Logf("Got expected error: %v", err)
+}
+
+func TestBedrockOpenAI_CostCalculation(t *testing.T) {
+	provider := bedrockOpenAITestProvider(t)
+	ctx := context.Background()
+
+	resp, err := provider.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "Say hello in one word."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+	if resp.CostInfo.InputTokens <= 0 {
+		t.Errorf("expected positive InputTokens, got %d", resp.CostInfo.InputTokens)
+	}
+	if resp.CostInfo.OutputTokens <= 0 {
+		t.Errorf("expected positive OutputTokens, got %d", resp.CostInfo.OutputTokens)
+	}
+	if resp.CostInfo.TotalCost <= 0 {
+		t.Errorf("expected positive TotalCost, got %f", resp.CostInfo.TotalCost)
+	}
+	t.Logf("Cost: input=%d tokens, output=%d tokens, total=$%.6f",
+		resp.CostInfo.InputTokens, resp.CostInfo.OutputTokens, resp.CostInfo.TotalCost)
+}

--- a/runtime/providers/openai/bedrock_unit_test.go
+++ b/runtime/providers/openai/bedrock_unit_test.go
@@ -3,10 +3,12 @@ package openai
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // mockSigningCredential records whether Apply was invoked. Used to verify
@@ -171,4 +173,197 @@ func TestNewProviderFromConfig_Bedrock(t *testing.T) {
 			t.Errorf("non-Bedrock provider should not mark max_tokens unsupported, got %v", p.unsupportedParams)
 		}
 	})
+}
+
+// newBedrockOpenAIMockProvider stands up an httptest server that answers
+// the Bedrock invoke endpoint with a canned OpenAI Chat Completions JSON
+// body, and returns a Provider wired to it.
+func newBedrockOpenAIMockProvider(t *testing.T, responseBody string) *Provider {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	t.Cleanup(server.Close)
+
+	return NewProviderFromConfig(&ProviderConfig{
+		ID:       "test-bedrock-openai",
+		Model:    "openai.gpt-oss-20b-1:0",
+		BaseURL:  server.URL,
+		Platform: bedrockPlatform,
+		PlatformConfig: &providers.PlatformConfig{
+			Type: bedrockPlatform, Region: "us-west-2",
+		},
+		Credential: &mockSigningCredential{},
+		Defaults: providers.ProviderDefaults{
+			MaxTokens:   64,
+			Temperature: 0.1,
+			Pricing: providers.Pricing{
+				InputCostPer1K:  0.00015,
+				OutputCostPer1K: 0.0006,
+			},
+		},
+	})
+}
+
+const bedrockOpenAIMockResponse = `{
+  "choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello.","role":"assistant"}}],
+  "created":1776687852,
+  "id":"chatcmpl-test",
+  "model":"openai.gpt-oss-20b-1:0",
+  "object":"chat.completion",
+  "usage":{"completion_tokens":2,"prompt_tokens":10,"total_tokens":12}
+}`
+
+func TestProvider_PredictStream_BedrockEmitsSingleChunk(t *testing.T) {
+	p := newBedrockOpenAIMockProvider(t, bedrockOpenAIMockResponse)
+
+	ch, err := p.PredictStream(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream: %v", err)
+	}
+
+	chunks := 0
+	var last providers.StreamChunk
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("chunk error: %v", c.Error)
+		}
+		chunks++
+		last = c
+	}
+	if chunks != 1 {
+		t.Fatalf("Bedrock fallback must emit exactly one chunk, got %d", chunks)
+	}
+	if last.Content != "Hello." {
+		t.Errorf("chunk content = %q, want %q", last.Content, "Hello.")
+	}
+	if last.Delta != "Hello." {
+		t.Errorf("chunk delta = %q, want %q (delta mirrors content for fallback)", last.Delta, "Hello.")
+	}
+	if last.FinishReason == nil || *last.FinishReason != finishStop {
+		t.Errorf("chunk finish reason = %v, want %q", last.FinishReason, finishStop)
+	}
+	if last.CostInfo == nil {
+		t.Error("chunk must carry CostInfo")
+	}
+}
+
+func TestProvider_PredictStream_BedrockSurfacesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"bad"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	p := NewProviderFromConfig(&ProviderConfig{
+		ID:       "test-bedrock-openai-err",
+		Model:    "openai.gpt-oss-20b-1:0",
+		BaseURL:  server.URL,
+		Platform: bedrockPlatform,
+		PlatformConfig: &providers.PlatformConfig{
+			Type: bedrockPlatform, Region: "us-west-2",
+		},
+		Credential: &mockSigningCredential{},
+		Defaults:   providers.ProviderDefaults{MaxTokens: 64},
+	})
+
+	_, err := p.PredictStream(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error from Bedrock fallback when upstream returns 400")
+	}
+}
+
+func TestToolProvider_PredictStreamWithTools_BedrockEmitsSingleChunk(t *testing.T) {
+	respBody := `{
+  "choices":[{"finish_reason":"tool_calls","index":0,"message":{
+    "content":"",
+    "role":"assistant",
+    "tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]
+  }}],
+  "created":1776687852,
+  "id":"chatcmpl-test-tools",
+  "model":"openai.gpt-oss-20b-1:0",
+  "object":"chat.completion",
+  "usage":{"completion_tokens":5,"prompt_tokens":20,"total_tokens":25}
+}`
+	p := newBedrockOpenAIMockProvider(t, respBody)
+	tp := &ToolProvider{Provider: p}
+
+	tools, err := tp.BuildTooling([]*providers.ToolDescriptor{
+		{
+			Name:        "get_weather",
+			Description: "Get weather",
+			InputSchema: []byte(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildTooling: %v", err)
+	}
+
+	ch, err := tp.PredictStreamWithTools(
+		context.Background(),
+		providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "weather?"}}},
+		tools,
+		"auto",
+	)
+	if err != nil {
+		t.Fatalf("PredictStreamWithTools: %v", err)
+	}
+
+	chunks := 0
+	var last providers.StreamChunk
+	for c := range ch {
+		if c.Error != nil {
+			t.Fatalf("chunk error: %v", c.Error)
+		}
+		chunks++
+		last = c
+	}
+	if chunks != 1 {
+		t.Fatalf("Bedrock fallback must emit exactly one chunk, got %d", chunks)
+	}
+	if len(last.ToolCalls) != 1 || last.ToolCalls[0].Name != "get_weather" {
+		t.Errorf("expected get_weather tool call, got %+v", last.ToolCalls)
+	}
+	if last.FinishReason == nil || *last.FinishReason != "tool_calls" {
+		t.Errorf("expected finish=tool_calls, got %v", last.FinishReason)
+	}
+}
+
+func TestToolProvider_PredictStreamWithTools_BedrockSurfacesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"oops"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	tp := &ToolProvider{
+		Provider: NewProviderFromConfig(&ProviderConfig{
+			ID:       "test-bedrock-tools-err",
+			Model:    "openai.gpt-oss-20b-1:0",
+			BaseURL:  server.URL,
+			Platform: bedrockPlatform,
+			PlatformConfig: &providers.PlatformConfig{
+				Type: bedrockPlatform, Region: "us-west-2",
+			},
+			Credential: &mockSigningCredential{},
+			Defaults:   providers.ProviderDefaults{MaxTokens: 64},
+		}),
+	}
+
+	_, err := tp.PredictStreamWithTools(
+		context.Background(),
+		providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}},
+		nil,
+		"auto",
+	)
+	if err == nil {
+		t.Fatal("expected error from Bedrock tool fallback when upstream returns 500")
+	}
 }

--- a/runtime/providers/openai/bedrock_unit_test.go
+++ b/runtime/providers/openai/bedrock_unit_test.go
@@ -1,0 +1,174 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// mockSigningCredential records whether Apply was invoked. Used to verify
+// the Bedrock path attaches the credential (which in production performs
+// SigV4 signing on the request).
+type mockSigningCredential struct{ applied bool }
+
+func (m *mockSigningCredential) Type() string { return "aws" }
+func (m *mockSigningCredential) Apply(_ context.Context, _ *http.Request) error {
+	m.applied = true
+	return nil
+}
+
+func TestProvider_IsBedrock(t *testing.T) {
+	tests := []struct {
+		platform string
+		want     bool
+	}{
+		{bedrockPlatform, true},
+		{"azure", false},
+		{"vertex", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			p := &Provider{platform: tt.platform}
+			if got := p.isBedrock(); got != tt.want {
+				t.Errorf("isBedrock platform=%q got %v want %v", tt.platform, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvider_ChatCompletionsURL_Bedrock(t *testing.T) {
+	p := &Provider{
+		platform: bedrockPlatform,
+		baseURL:  "https://bedrock-runtime.us-west-2.amazonaws.com",
+		model:    "openai.gpt-oss-20b-1:0",
+	}
+	got := p.chatCompletionsURL()
+	want := "https://bedrock-runtime.us-west-2.amazonaws.com/model/openai.gpt-oss-20b-1:0/invoke"
+	if got != want {
+		t.Errorf("Bedrock chatCompletionsURL = %q, want %q", got, want)
+	}
+	// Sanity: must not contain the standard /chat/completions or ?api-version=
+	if strings.Contains(got, "/chat/completions") {
+		t.Errorf("Bedrock URL must not include /chat/completions: %s", got)
+	}
+	if strings.Contains(got, "?api-version=") {
+		t.Errorf("Bedrock URL must not include Azure ?api-version=: %s", got)
+	}
+}
+
+func TestProvider_ResponsesURL_BedrockFallsBackToCompletions(t *testing.T) {
+	p := &Provider{
+		platform: bedrockPlatform,
+		baseURL:  "https://bedrock-runtime.us-west-2.amazonaws.com",
+		model:    "openai.gpt-oss-20b-1:0",
+	}
+	if got, want := p.responsesURL(), p.chatCompletionsURL(); got != want {
+		t.Errorf("Bedrock responsesURL must equal chatCompletionsURL, got %q want %q", got, want)
+	}
+}
+
+func TestNewProviderFromConfig_Bedrock(t *testing.T) {
+	cred := &mockSigningCredential{}
+
+	t.Run("derives baseURL from PlatformConfig.Region when empty", func(t *testing.T) {
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:       "test",
+			Model:    "openai.gpt-oss-20b-1:0",
+			Platform: bedrockPlatform,
+			PlatformConfig: &providers.PlatformConfig{
+				Type:   bedrockPlatform,
+				Region: "us-west-2",
+			},
+			Credential: cred,
+		})
+		want := "https://bedrock-runtime.us-west-2.amazonaws.com"
+		if p.baseURL != want {
+			t.Errorf("baseURL = %q, want %q", p.baseURL, want)
+		}
+	})
+
+	t.Run("explicit BaseURL is preserved", func(t *testing.T) {
+		custom := "https://custom.bedrock.example"
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:       "test",
+			Model:    "openai.gpt-oss-20b-1:0",
+			BaseURL:  custom,
+			Platform: bedrockPlatform,
+			PlatformConfig: &providers.PlatformConfig{
+				Type:   bedrockPlatform,
+				Region: "us-west-2",
+			},
+			Credential: cred,
+		})
+		if p.baseURL != custom {
+			t.Errorf("explicit baseURL must win, got %q", p.baseURL)
+		}
+	})
+
+	t.Run("forces Chat Completions API mode (no Responses API on Bedrock)", func(t *testing.T) {
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:       "test",
+			Model:    "openai.gpt-oss-20b-1:0",
+			Platform: bedrockPlatform,
+			PlatformConfig: &providers.PlatformConfig{
+				Type: bedrockPlatform, Region: "us-west-2",
+			},
+			Credential: cred,
+		})
+		if p.apiMode != APIModeCompletions {
+			t.Errorf("Bedrock provider must use APIModeCompletions, got %v", p.apiMode)
+		}
+	})
+
+	t.Run("auto-adds max_tokens and top_p to unsupportedParams", func(t *testing.T) {
+		// max_tokens — Bedrock OpenAI uses max_completion_tokens.
+		// top_p    — gpt-oss rejects 0.0 and the framework default is 0;
+		//            skipping leaves the model default in place.
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:       "test",
+			Model:    "openai.gpt-oss-20b-1:0",
+			Platform: bedrockPlatform,
+			PlatformConfig: &providers.PlatformConfig{
+				Type: bedrockPlatform, Region: "us-west-2",
+			},
+			Credential: cred,
+		})
+		for _, param := range []string{"max_tokens", "top_p"} {
+			if !hasUnsupportedParam(p.unsupportedParams, param) {
+				t.Errorf("Bedrock provider must mark %s unsupported, got %v",
+					param, p.unsupportedParams)
+			}
+		}
+	})
+
+	t.Run("explicit UnsupportedParams overrides Bedrock auto-detection", func(t *testing.T) {
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:                "test",
+			Model:             "openai.gpt-oss-20b-1:0",
+			Platform:          bedrockPlatform,
+			PlatformConfig:    &providers.PlatformConfig{Type: bedrockPlatform, Region: "us-west-2"},
+			Credential:        cred,
+			UnsupportedParams: []string{"top_p"},
+		})
+		if hasUnsupportedParam(p.unsupportedParams, "max_tokens") {
+			t.Errorf("explicit UnsupportedParams must not be merged, got %v", p.unsupportedParams)
+		}
+		if !hasUnsupportedParam(p.unsupportedParams, "top_p") {
+			t.Errorf("explicit top_p must be preserved, got %v", p.unsupportedParams)
+		}
+	})
+
+	t.Run("non-Bedrock platforms unchanged", func(t *testing.T) {
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:    "test",
+			Model: "gpt-4o",
+		})
+		if hasUnsupportedParam(p.unsupportedParams, "max_tokens") {
+			t.Errorf("non-Bedrock provider should not mark max_tokens unsupported, got %v", p.unsupportedParams)
+		}
+	})
+}

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -177,10 +177,26 @@ func NewProviderFromConfig(cfg *ProviderConfig) *Provider {
 	if len(unsupported) == 0 && isOSeriesModel(cfg.Model) {
 		unsupported = []string{"temperature", "top_p", "max_tokens"}
 	}
+	// Bedrock-hosted OpenAI (gpt-oss family) requires max_completion_tokens
+	// instead of max_tokens, and rejects `top_p: 0.0` (must be in (0, 1]).
+	// Skip both fields by default so the model picks its own; operators
+	// can still override the full unsupported set via UnsupportedParams.
+	if len(cfg.UnsupportedParams) == 0 && cfg.Platform == bedrockPlatform {
+		for _, param := range []string{"max_tokens", "top_p"} {
+			if !hasUnsupportedParam(unsupported, param) {
+				unsupported = append(unsupported, param)
+			}
+		}
+	}
 
 	baseURL := cfg.BaseURL
-	if baseURL == "" && cfg.Platform == azurePlatform && cfg.PlatformConfig != nil && cfg.PlatformConfig.Endpoint != "" {
-		baseURL = credentials.AzureOpenAIEndpoint(cfg.PlatformConfig.Endpoint, cfg.Model)
+	if baseURL == "" {
+		switch {
+		case cfg.Platform == azurePlatform && cfg.PlatformConfig != nil && cfg.PlatformConfig.Endpoint != "":
+			baseURL = credentials.AzureOpenAIEndpoint(cfg.PlatformConfig.Endpoint, cfg.Model)
+		case cfg.Platform == bedrockPlatform && cfg.PlatformConfig != nil && cfg.PlatformConfig.Region != "":
+			baseURL = credentials.BedrockEndpoint(cfg.PlatformConfig.Region)
+		}
 	}
 
 	p := &Provider{
@@ -197,8 +213,10 @@ func NewProviderFromConfig(cfg *ProviderConfig) *Provider {
 		unsupportedParams: unsupported,
 		reasoningEffort:   getReasoningEffort(cfg.AdditionalConfig),
 	}
-	// Azure OpenAI doesn't support the Responses API.
-	if p.isAzure() {
+	// Neither Azure OpenAI nor Bedrock OpenAI exposes the Responses API.
+	// Force the legacy Chat Completions path so the request shape matches
+	// what the upstream actually accepts.
+	if p.isAzure() || p.isBedrock() {
 		p.apiMode = APIModeCompletions
 	}
 	return p
@@ -334,11 +352,20 @@ func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
 	return nil
 }
 
-const azurePlatform = "azure"
+const (
+	azurePlatform   = "azure"
+	bedrockPlatform = "bedrock"
+)
 
 // isAzure returns true if this provider is hosted on Azure OpenAI.
 func (p *Provider) isAzure() bool {
 	return p.platform == azurePlatform
+}
+
+// isBedrock returns true if this provider is hosted on AWS Bedrock
+// (OpenAI gpt-oss partner endpoint).
+func (p *Provider) isBedrock() bool {
+	return p.platform == bedrockPlatform
 }
 
 // azureAPIVersion returns the api-version query parameter for Azure OpenAI.
@@ -352,9 +379,16 @@ func (p *Provider) azureAPIVersion() string {
 }
 
 // chatCompletionsURL returns the Chat Completions API endpoint.
-// For Azure: {baseURL}/chat/completions?api-version={version}
-// For standard OpenAI: {baseURL}/chat/completions
+// Azure:   {baseURL}/chat/completions?api-version={version}
+// Bedrock: {baseURL}/model/{model}/invoke   (Bedrock InvokeModel; the
+//
+//	response body is standard OpenAI Chat Completions JSON.)
+//
+// Standard OpenAI: {baseURL}/chat/completions
 func (p *Provider) chatCompletionsURL() string {
+	if p.isBedrock() {
+		return p.baseURL + "/model/" + p.model + "/invoke"
+	}
 	url := p.baseURL + openAIPredictCompletionsPath
 	if p.isAzure() {
 		url += "?api-version=" + p.azureAPIVersion()
@@ -362,11 +396,11 @@ func (p *Provider) chatCompletionsURL() string {
 	return url
 }
 
-// responsesURL returns the Responses API endpoint.
-// Azure OpenAI does not support the Responses API, so this falls back
-// to the Chat Completions endpoint.
+// responsesURL returns the Responses API endpoint. Neither Azure OpenAI
+// nor Bedrock OpenAI exposes the Responses API, so for those platforms
+// it falls back to the Chat Completions endpoint.
 func (p *Provider) responsesURL() string {
-	if p.isAzure() {
+	if p.isAzure() || p.isBedrock() {
 		return p.chatCompletionsURL()
 	}
 	return p.baseURL + responsesAPIPath
@@ -588,8 +622,20 @@ func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.Co
 	}
 }
 
-// PredictStream streams a predict response from OpenAI
+// PredictStream streams a predict response from OpenAI.
+//
+// Bedrock note: AWS Bedrock's `invoke-with-response-stream` returns a
+// binary event-stream protocol with OpenAI-format chunks inside —
+// distinct from the SSE format the rest of the openai stream code
+// expects. Until that path is wired (separate scanner needed), Bedrock
+// falls back to a single non-streaming Predict response surfaced as one
+// terminal chunk on the channel. Callers that need real per-token
+// streaming for openai+bedrock should track that follow-up.
 func (p *Provider) PredictStream(ctx context.Context, req providers.PredictionRequest) (<-chan providers.StreamChunk, error) {
+	if p.isBedrock() {
+		return p.predictStreamBedrockFallback(ctx, req)
+	}
+
 	// Convert messages to OpenAI format
 	messages, err := p.prepareOpenAIMessages(req)
 	if err != nil {
@@ -598,6 +644,36 @@ func (p *Provider) PredictStream(ctx context.Context, req providers.PredictionRe
 
 	// Delegate to the common implementation
 	return p.predictStreamWithMessages(ctx, req, messages)
+}
+
+// predictStreamBedrockFallback runs a non-streaming Predict against
+// Bedrock and emits the result as a single StreamChunk so callers using
+// the streaming interface still get a terminal chunk with content,
+// finish_reason and cost info. This is honest — Bedrock's invoke
+// (without -with-response-stream) is non-streaming — and keeps Arena
+// scenarios with `streaming: true` working until real binary-event-stream
+// support lands for the openai provider.
+//
+//nolint:gocritic // hugeParam: matches the upstream PredictStream signature.
+func (p *Provider) predictStreamBedrockFallback(
+	ctx context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	out := make(chan providers.StreamChunk, 1)
+	resp, err := p.Predict(ctx, req)
+	if err != nil {
+		close(out)
+		return nil, err
+	}
+	finish := finishStop
+	out <- providers.StreamChunk{
+		Content:      resp.Content,
+		Delta:        resp.Content,
+		TokenCount:   0,
+		CostInfo:     resp.CostInfo,
+		FinishReason: &finish,
+	}
+	close(out)
+	return out, nil
 }
 
 // openAIStreamChunk represents the structure of OpenAI streaming response chunks

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -538,13 +538,21 @@ func (p *ToolProvider) makeRequest(ctx context.Context, request interface{}) ([]
 	return p.MakeJSONRequest(ctx, url, request, headers, "OpenAI")
 }
 
-// PredictStreamWithTools performs a streaming predict request with tool support
+// PredictStreamWithTools performs a streaming predict request with tool support.
+//
+// Bedrock note: same fallback as PredictStream — Bedrock's streaming
+// endpoint uses binary event-stream framing distinct from SSE; we run a
+// single non-streaming call and surface it as one terminal chunk.
 func (p *ToolProvider) PredictStreamWithTools(
 	ctx context.Context,
 	req providers.PredictionRequest,
 	tools interface{},
 	toolChoice string,
 ) (<-chan providers.StreamChunk, error) {
+	if p.isBedrock() {
+		return p.predictStreamWithToolsBedrockFallback(ctx, req, tools, toolChoice)
+	}
+
 	// Route to appropriate API based on mode
 	if p.apiMode == APIModeResponses {
 		return p.predictStreamWithResponses(ctx, req, tools, toolChoice)
@@ -552,6 +560,38 @@ func (p *ToolProvider) PredictStreamWithTools(
 
 	// Legacy chat completions API
 	return p.predictStreamWithCompletions(ctx, req, tools, toolChoice)
+}
+
+// predictStreamWithToolsBedrockFallback runs PredictWithTools synchronously
+// and emits a single terminal chunk that carries content, tool calls,
+// finish reason and cost. See PredictStream for the rationale.
+//
+//nolint:gocritic // hugeParam: matches the upstream PredictStreamWithTools signature.
+func (p *ToolProvider) predictStreamWithToolsBedrockFallback(
+	ctx context.Context,
+	req providers.PredictionRequest,
+	tools interface{},
+	toolChoice string,
+) (<-chan providers.StreamChunk, error) {
+	out := make(chan providers.StreamChunk, 1)
+	resp, toolCalls, err := p.PredictWithTools(ctx, req, tools, toolChoice)
+	if err != nil {
+		close(out)
+		return nil, err
+	}
+	finish := finishStop
+	if len(toolCalls) > 0 {
+		finish = "tool_calls"
+	}
+	out <- providers.StreamChunk{
+		Content:      resp.Content,
+		Delta:        resp.Content,
+		ToolCalls:    toolCalls,
+		CostInfo:     resp.CostInfo,
+		FinishReason: &finish,
+	}
+	close(out)
+	return out, nil
 }
 
 // predictStreamWithCompletions performs a streaming predict using chat completions API

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -216,12 +216,13 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 	if baseURL == "" {
 		switch spec.Type {
 		case "openai":
-			// Skip the api.openai.com default for Azure — the openai
-			// factory builds the deployment URL from PlatformConfig.
-			// Without this skip the default clobbers spec.BaseURL and
-			// the Azure branch in NewProviderFromConfig becomes
-			// unreachable (issue #1010).
-			if spec.Platform != "azure" {
+			// Skip the api.openai.com default for hyperscaler-hosted
+			// OpenAI — the openai factory builds the platform URL from
+			// PlatformConfig (Azure: deployment URL; Bedrock: regional
+			// invoke URL). Without these skips the default clobbers
+			// spec.BaseURL and the platform branch in
+			// NewProviderFromConfig becomes unreachable (#1010).
+			if spec.Platform != "azure" && spec.Platform != "bedrock" {
 				baseURL = "https://api.openai.com/v1"
 			}
 		case "gemini":


### PR DESCRIPTION
## Summary

Adds AWS Bedrock OpenAI-partner support (gpt-oss family) to the
openai provider. **8th cell delivered** against #1009 — only
`claude×azure` remains.

Wire format verified against live Bedrock us-west-2:
- URL: `{baseURL}/model/{model-id}/invoke` (standard Bedrock invoke)
- Auth: AWS SigV4 via `credentials.AWSCredential`
- Request: OpenAI Chat Completions JSON (Bedrock ignores `model` in body — routes by URL)
- Response: standard OpenAI Chat Completions JSON — existing parser works as-is

## Code structure

- `bedrockPlatform` constant + `isBedrock()` predicate in openai.go
- `chatCompletionsURL()` and `responsesURL()` branch for Bedrock — Bedrock has no Responses API so it falls back to Chat Completions (mirrors the existing Azure fallback)
- `NewProviderFromConfig`:
  - Derives baseURL from `PlatformConfig.Region` via `credentials.BedrockEndpoint` when `BaseURL == ""`
  - Forces `APIModeCompletions`
  - Auto-adds `max_tokens` and `top_p` to UnsupportedParams for Bedrock:
    - `max_tokens` — gpt-oss requires `max_completion_tokens` instead (the request builder already flips for o-series)
    - `top_p` — gpt-oss rejects `0.0` (must be in `(0, 1]`); the framework default is `0`, so omitting it leaves the model default in place
  - Operators can still override via explicit `UnsupportedParams`
- `registry.go`: `https://api.openai.com/v1` default skipped for `Platform=="bedrock"` (same #1010 root cause as `Platform=="azure"`)

## Streaming (known limitation)

Bedrock's `invoke-with-response-stream` returns binary event-stream framing with OpenAI-format chunks inside — distinct from the SSE the rest of the openai stream code consumes. Until a dedicated scanner lands, `PredictStream` / `PredictStreamWithTools` run a non-streaming `Predict` and emit a single terminal `StreamChunk` with content + `FinishReason` + `CostInfo`. This is honest (Bedrock's plain `invoke` is non-streaming) and keeps Arena scenarios with `streaming: true` compatible.

## Tests

- `bedrock_unit_test.go` — predicates, URL builders, factory URL derivation, API-mode forcing, unsupported-params auto-detection, explicit-override precedence
- `bedrock_integration_test.go` (`//go:build integration`) — URL construction, predict, predict-with-tools, streaming fallback, error propagation, cost calculation against real Bedrock gpt-oss

**6/6 integration tests pass against `omnia-aws` profile in us-west-2** (`openai.gpt-oss-20b-1:0`):

```
=== TestBedrockOpenAI_BaseURLConstruction        --- PASS (0.00s)
=== TestBedrockOpenAI_Predict                    --- PASS (1.62s)  Response: <reasoning>...</reasoning>Hello.
=== TestBedrockOpenAI_PredictWithTools           --- PASS (0.83s)  Tool call: get_weather({"city":"Paris"})
=== TestBedrockOpenAI_PredictStream_Fallback     --- PASS (0.99s)  Terminal chunk with finish=stop
=== TestBedrockOpenAI_ErrorOnInvalidModel        --- PASS (0.70s)
=== TestBedrockOpenAI_CostCalculation            --- PASS (1.64s)  Cost: 73 in / 79 out / $0.000058
```

## Pre-commit

- lint: 0 issues
- coverage on changed files: openai.go 88.5%, openai_tools.go 80.6%, registry.go 93.5% (all ≥80%)

## Matrix status after this PR

| | bedrock | vertex | azure |
|---|---|---|---|
| **claude** | ✅ | ✅ | ❌ open |
| **openai** | ✅ **(this PR)** | ⛔ rejected | ✅ |
| **gemini** | ⛔ rejected | ✅ | ⛔ rejected |

**8 of 9 cells delivered.** Only `claude×azure` remains — blocked on availability of an Azure AI Foundry serverless Anthropic deployment (different resource type from Cognitive Services accounts; surface needs probing).

Refs #1009
