### PR TITLE
feat(providers): claude on azure (#1009 final cell)

### DIFF
--- a/runtime/providers/claude/azure_unit_test.go
+++ b/runtime/providers/claude/azure_unit_test.go
@@ -1,0 +1,265 @@
+package claude
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestAzureAnthropicDeploymentEndpoint(t *testing.T) {
+	tests := []struct {
+		name, endpoint, deployment, want string
+	}{
+		{
+			name:       "trailing slash trimmed",
+			endpoint:   "https://my-resource.services.ai.azure.com/",
+			deployment: "claude-haiku-4-5",
+			want:       "https://my-resource.services.ai.azure.com/openai/deployments/claude-haiku-4-5",
+		},
+		{
+			name:       "no trailing slash",
+			endpoint:   "https://my-resource.services.ai.azure.com",
+			deployment: "claude-haiku-4-5",
+			want:       "https://my-resource.services.ai.azure.com/openai/deployments/claude-haiku-4-5",
+		},
+		{
+			name:       "deployment name with hyphens preserved",
+			endpoint:   "https://my-resource.services.ai.azure.com",
+			deployment: "claude-sonnet-4-6",
+			want:       "https://my-resource.services.ai.azure.com/openai/deployments/claude-sonnet-4-6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := azureAnthropicDeploymentEndpoint(tt.endpoint, tt.deployment)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvider_IsAzure(t *testing.T) {
+	tests := []struct {
+		platform string
+		want     bool
+	}{
+		{azurePlatform, true},
+		{bedrockPlatform, false},
+		{vertexPlatform, false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			p := &Provider{platform: tt.platform}
+			if got := p.isAzure(); got != tt.want {
+				t.Errorf("isAzure platform=%q got %v want %v", tt.platform, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvider_UsesCredentialAuth(t *testing.T) {
+	tests := []struct {
+		platform string
+		want     bool
+	}{
+		{bedrockPlatform, true},
+		{vertexPlatform, true},
+		{azurePlatform, true},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			p := &Provider{platform: tt.platform}
+			if got := p.usesCredentialAuth(); got != tt.want {
+				t.Errorf("usesCredentialAuth platform=%q got %v want %v", tt.platform, got, tt.want)
+			}
+		})
+	}
+}
+
+// Azure must NOT be in isPartnerHosted — it uses the direct API body shape,
+// not the Bedrock/Vertex partner shape.
+func TestProvider_AzureNotPartnerHosted(t *testing.T) {
+	p := &Provider{platform: azurePlatform}
+	if p.isPartnerHosted() {
+		t.Error("Azure must not be classified as partner-hosted (direct API body shape, no anthropic_version body field)")
+	}
+}
+
+func TestProvider_AzureAPIVersion(t *testing.T) {
+	t.Run("default when not configured", func(t *testing.T) {
+		p := &Provider{platform: azurePlatform, platformConfig: &providers.PlatformConfig{}}
+		if got := p.azureAPIVersion(); got != defaultAzureAPIVersion {
+			t.Errorf("got %q, want default %q", got, defaultAzureAPIVersion)
+		}
+	})
+	t.Run("override via PlatformConfig.AdditionalConfig", func(t *testing.T) {
+		p := &Provider{
+			platform: azurePlatform,
+			platformConfig: &providers.PlatformConfig{
+				AdditionalConfig: map[string]any{"api_version": "2025-04-01-preview"},
+			},
+		}
+		if got := p.azureAPIVersion(); got != "2025-04-01-preview" {
+			t.Errorf("got %q, want override", got)
+		}
+	})
+	t.Run("nil platformConfig falls back to default", func(t *testing.T) {
+		p := &Provider{platform: azurePlatform, platformConfig: nil}
+		if got := p.azureAPIVersion(); got != defaultAzureAPIVersion {
+			t.Errorf("got %q, want default %q", got, defaultAzureAPIVersion)
+		}
+	})
+}
+
+func TestProvider_MessagesURL_Azure(t *testing.T) {
+	p := &Provider{
+		platform: azurePlatform,
+		baseURL:  "https://my-resource.services.ai.azure.com/openai/deployments/claude-haiku-4-5",
+		model:    "claude-haiku-4-5",
+		platformConfig: &providers.PlatformConfig{
+			AdditionalConfig: map[string]any{"api_version": "2024-12-01-preview"},
+		},
+	}
+	t.Run("messagesURL appends api-version", func(t *testing.T) {
+		got := p.messagesURL()
+		want := "https://my-resource.services.ai.azure.com/openai/deployments/claude-haiku-4-5/messages?api-version=2024-12-01-preview"
+		if got != want {
+			t.Errorf("messagesURL = %q, want %q", got, want)
+		}
+	})
+	t.Run("messagesStreamURL same path as non-streaming (Azure uses single endpoint)", func(t *testing.T) {
+		if p.messagesURL() != p.messagesStreamURL() {
+			t.Errorf("Azure messagesURL and messagesStreamURL should match — they share the deployment path; got %q vs %q",
+				p.messagesURL(), p.messagesStreamURL())
+		}
+	})
+	t.Run("URL must not contain partner-style segments", func(t *testing.T) {
+		got := p.messagesURL()
+		for _, bad := range []string{"/model/", ":rawPredict", ":streamRawPredict"} {
+			if strings.Contains(got, bad) {
+				t.Errorf("Azure URL must not contain %q, got %s", bad, got)
+			}
+		}
+	})
+}
+
+func TestNewProviderWithCredential_DerivesAzureURL(t *testing.T) {
+	cred := &mockBearerCredential{}
+
+	t.Run("empty BaseURL with azure platform derives deployment URL from PlatformConfig.Endpoint", func(t *testing.T) {
+		pc := &providers.PlatformConfig{
+			Type:     azurePlatform,
+			Endpoint: "https://my-resource.services.ai.azure.com",
+		}
+		p := NewProviderWithCredential(
+			"test", "claude-haiku-4-5", "",
+			providers.ProviderDefaults{},
+			false, cred, azurePlatform, pc,
+		)
+		want := azureAnthropicDeploymentEndpoint(pc.Endpoint, "claude-haiku-4-5")
+		if p.baseURL != want {
+			t.Errorf("baseURL = %q, want %q", p.baseURL, want)
+		}
+	})
+
+	t.Run("explicit BaseURL is preserved on azure", func(t *testing.T) {
+		pc := &providers.PlatformConfig{
+			Type:     azurePlatform,
+			Endpoint: "https://my-resource.services.ai.azure.com",
+		}
+		custom := "https://custom.azure.example/openai/deployments/foo"
+		p := NewProviderWithCredential(
+			"test", "claude-haiku-4-5", custom,
+			providers.ProviderDefaults{},
+			false, cred, azurePlatform, pc,
+		)
+		if p.baseURL != custom {
+			t.Errorf("explicit baseURL must win, got %q", p.baseURL)
+		}
+	})
+
+	t.Run("missing endpoint leaves BaseURL empty", func(t *testing.T) {
+		pc := &providers.PlatformConfig{Type: azurePlatform}
+		p := NewProviderWithCredential(
+			"test", "claude-haiku-4-5", "",
+			providers.ProviderDefaults{},
+			false, cred, azurePlatform, pc,
+		)
+		if p.baseURL != "" {
+			t.Errorf("incomplete PlatformConfig should not derive URL, got %q", p.baseURL)
+		}
+	})
+}
+
+// TestProvider_PredictStream_AzureSendsCorrectWireFormat exercises the
+// streaming path through PredictStream against a mock httptest server,
+// and asserts the wire format the provider produces:
+//   - URL ends in /messages?api-version=...
+//   - body includes model field (direct API shape, not partner shape)
+//   - Bearer auth via credential, no x-api-key, no anthropic-version header
+func TestProvider_PredictStream_AzureSendsCorrectWireFormat(t *testing.T) {
+	var capturedReq *http.Request
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r.Clone(context.Background())
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		capturedBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	cred := &mockBearerCredential{}
+	p := &Provider{
+		BaseProvider: providers.NewBaseProvider("test-azure", false, server.Client()),
+		model:        "claude-haiku-4-5",
+		baseURL:      server.URL,
+		platform:     azurePlatform,
+		credential:   cred,
+		defaults:     providers.ProviderDefaults{MaxTokens: 64},
+		platformConfig: &providers.PlatformConfig{
+			Type:             azurePlatform,
+			Endpoint:         server.URL,
+			AdditionalConfig: map[string]any{"api_version": "2024-12-01-preview"},
+		},
+	}
+
+	ch, err := p.PredictStream(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream: %v", err)
+	}
+	for range ch {
+	}
+
+	if capturedReq == nil {
+		t.Fatal("server never received a request")
+	}
+	if !strings.HasSuffix(capturedReq.URL.Path+"?"+capturedReq.URL.RawQuery, "/messages?api-version=2024-12-01-preview") {
+		t.Errorf("URL = %s?%s, want suffix /messages?api-version=2024-12-01-preview",
+			capturedReq.URL.Path, capturedReq.URL.RawQuery)
+	}
+	if h := capturedReq.Header.Get(anthropicVersionKey); h != "" {
+		t.Errorf("Azure must not set %s header (api-version is in URL), got %q", anthropicVersionKey, h)
+	}
+	if h := capturedReq.Header.Get("X-API-Key"); h != "" {
+		t.Errorf("Azure must not set X-API-Key, got %q", h)
+	}
+	if !cred.applied {
+		t.Error("Azure must invoke credential.Apply")
+	}
+	if !strings.Contains(string(capturedBody), `"model":"claude-haiku-4-5"`) {
+		t.Errorf("Azure body must include model field (direct API shape), got: %s", string(capturedBody))
+	}
+}

--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -47,7 +47,13 @@ const (
 	bedrockVersionValue   = "bedrock-2023-05-31"
 	vertexPlatform        = "vertex"
 	vertexVersionValue    = "vertex-2023-10-16"
+	azurePlatform         = "azure"
 	bedrockVersionBodyKey = "anthropic_version"
+
+	// defaultAzureAPIVersion is the api-version query parameter used when
+	// the caller has not supplied one via PlatformConfig.AdditionalConfig.
+	// Tracks the openai+azure default for consistency.
+	defaultAzureAPIVersion = "2024-12-01-preview"
 )
 
 // vertexAnthropicEndpoint returns the Vertex AI base URL for Anthropic
@@ -59,6 +65,33 @@ func vertexAnthropicEndpoint(region, project string) string {
 		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models",
 		region, project, region,
 	)
+}
+
+// azureAnthropicDeploymentEndpoint returns the Azure AI Foundry base URL
+// for an Anthropic deployment on an AIServices account. The result ends
+// in `/openai/deployments/{deployment}` (no trailing slash); per-call
+// code appends `/messages?api-version={v}` to address the Anthropic
+// Messages API for that deployment.
+//
+// The path layout mirrors Azure OpenAI deployments
+// (`{endpoint}/openai/deployments/{deployment}/chat/completions?api-version=v`)
+// — Microsoft routes Foundry partner models through the same
+// deployment-name surface, swapping only the trailing API path. The
+// {deployment} segment is the deployment name the user assigned at
+// deploy time (passed through via spec.Model, mirroring openai+azure).
+//
+// Note: this is a best-endeavors URL pattern; the AI Foundry
+// deployment-style surface is the most-Microsoft-native shape but has
+// not been verified end-to-end against a live deployment in this PR.
+// The Anthropic-on-Foundry quota SKU is named
+// `AIServices.GlobalStandard.claude-*`, strongly suggesting deployment
+// via the AIServices account model surface (i.e. this layout) rather
+// than the older Marketplace + Foundry-hub serverless-API path. First
+// live run should validate; switching to a vendor-prefixed pattern
+// (`{endpoint}/anthropic/v1/messages?...`) is a one-line change to
+// `messagesURL`/`messagesStreamURL` if needed.
+func azureAnthropicDeploymentEndpoint(endpoint, deployment string) string {
+	return strings.TrimRight(endpoint, "/") + "/openai/deployments/" + deployment
 }
 
 // Provider implements the Provider interface for Anthropic Claude
@@ -88,12 +121,10 @@ func NewProvider(id, model, baseURL string, defaults providers.ProviderDefaults,
 
 // NewProviderWithCredential creates a new Claude provider with explicit credential.
 //
-// When platform=="vertex" and baseURL is empty, the Vertex publisher-models
-// URL is built from platformConfig.Region and platformConfig.Project.
-// Mirrors the openai+azure and gemini+vertex pattern: callers that pass an
-// explicit baseURL still win, but Arena-style configs that only set
-// platform.region/project work without users having to know the Vertex URL
-// shape.
+// When baseURL is empty the URL is derived from platformConfig for the
+// platforms that support it: Vertex (`publishers/anthropic/models`) and
+// Azure (`openai/deployments/{deployment}`). Callers that pass an
+// explicit baseURL always win.
 func NewProviderWithCredential(
 	id, model, baseURL string, defaults providers.ProviderDefaults,
 	includeRawOutput bool, cred providers.Credential,
@@ -101,9 +132,14 @@ func NewProviderWithCredential(
 ) *Provider {
 	base, apiKey := providers.NewBaseProviderWithCredential(id, includeRawOutput, httpClientTimeout, cred)
 
-	if baseURL == "" && platform == vertexPlatform &&
-		platformConfig != nil && platformConfig.Region != "" && platformConfig.Project != "" {
-		baseURL = vertexAnthropicEndpoint(platformConfig.Region, platformConfig.Project)
+	if baseURL == "" && platformConfig != nil {
+		switch {
+		case platform == vertexPlatform &&
+			platformConfig.Region != "" && platformConfig.Project != "":
+			baseURL = vertexAnthropicEndpoint(platformConfig.Region, platformConfig.Project)
+		case platform == azurePlatform && platformConfig.Endpoint != "":
+			baseURL = azureAnthropicDeploymentEndpoint(platformConfig.Endpoint, model)
+		}
 	}
 
 	return &Provider{
@@ -134,15 +170,46 @@ func (p *Provider) isVertex() bool {
 	return p.platform == vertexPlatform
 }
 
+// isAzure returns true if this provider is hosted on Azure AI Foundry's
+// Anthropic deployment surface.
+func (p *Provider) isAzure() bool {
+	return p.platform == azurePlatform
+}
+
 // isPartnerHosted returns true when the provider sits behind a hyperscaler
-// partner endpoint (Bedrock or Vertex). These share three traits that
-// distinguish them from the direct Anthropic API: the model identifier
-// appears in the URL path (not the request body); the request body must
-// include `anthropic_version` set to a platform-specific value; and
-// authentication uses the resolved Credential (SigV4 / Bearer) rather than
-// the x-api-key header.
+// partner endpoint that uses the partner body shape (Bedrock or Vertex).
+// These share three traits that distinguish them from the direct Anthropic
+// API: the model identifier appears in the URL path (not the request body);
+// the request body must include `anthropic_version` set to a platform-
+// specific value; and authentication uses the resolved Credential (SigV4 /
+// Bearer) rather than the x-api-key header.
+//
+// Azure is intentionally NOT in this set — Azure AI Foundry passes the
+// Anthropic Messages API through verbatim (model field stays in the body,
+// no anthropic_version), so only the URL and auth differ from the direct
+// path. Azure shares the auth half via usesCredentialAuth().
 func (p *Provider) isPartnerHosted() bool {
 	return p.isBedrock() || p.isVertex()
+}
+
+// usesCredentialAuth returns true when authentication goes through the
+// Credential interface (SigV4 for Bedrock, Bearer for Vertex/Azure)
+// rather than the direct API's x-api-key header. This is the broader
+// auth-side counterpart to isPartnerHosted().
+func (p *Provider) usesCredentialAuth() bool {
+	return p.isPartnerHosted() || p.isAzure()
+}
+
+// azureAPIVersion returns the api-version query parameter for Azure AI
+// Foundry calls. Configurable via PlatformConfig.AdditionalConfig
+// ("api_version"); falls back to defaultAzureAPIVersion.
+func (p *Provider) azureAPIVersion() string {
+	if p.platformConfig != nil {
+		if v, ok := p.platformConfig.AdditionalConfig["api_version"].(string); ok && v != "" {
+			return v
+		}
+	}
+	return defaultAzureAPIVersion
 }
 
 // platformAnthropicVersion returns the anthropic_version body value for the
@@ -162,6 +229,11 @@ func (p *Provider) platformAnthropicVersion() string {
 // messagesURL returns the appropriate API endpoint URL.
 // Bedrock: {baseURL}/model/{model}/invoke
 // Vertex:  {baseURL}/{model}:rawPredict
+// Azure:   {baseURL}/messages?api-version={v}        (baseURL is the
+//
+//	deployment URL `…/openai/deployments/{deployment}` built by
+//	azureAnthropicDeploymentEndpoint; streaming uses the same path)
+//
 // Direct:  {baseURL}/messages
 func (p *Provider) messagesURL() string {
 	switch {
@@ -169,6 +241,8 @@ func (p *Provider) messagesURL() string {
 		return p.baseURL + "/model/" + p.model + "/invoke"
 	case p.isVertex():
 		return p.baseURL + "/" + p.model + ":rawPredict"
+	case p.isAzure():
+		return p.baseURL + "/messages?api-version=" + p.azureAPIVersion()
 	default:
 		return p.baseURL + "/messages"
 	}
@@ -177,6 +251,7 @@ func (p *Provider) messagesURL() string {
 // messagesStreamURL returns the appropriate streaming API endpoint URL.
 // Bedrock: {baseURL}/model/{model}/invoke-with-response-stream  (binary event-stream)
 // Vertex:  {baseURL}/{model}:streamRawPredict                   (SSE)
+// Azure:   {baseURL}/messages?api-version={v}                   (SSE; same as messagesURL)
 // Direct:  {baseURL}/messages                                   (SSE; same path as messagesURL)
 func (p *Provider) messagesStreamURL() string {
 	switch {
@@ -184,6 +259,8 @@ func (p *Provider) messagesStreamURL() string {
 		return p.baseURL + "/model/" + p.model + "/invoke-with-response-stream"
 	case p.isVertex():
 		return p.baseURL + "/" + p.model + ":streamRawPredict"
+	case p.isAzure():
+		return p.baseURL + "/messages?api-version=" + p.azureAPIVersion()
 	default:
 		return p.baseURL + "/messages"
 	}
@@ -460,8 +537,10 @@ func (p *Provider) makeClaudeHTTPRequest(ctx context.Context, claudeReq claudeRe
 	}
 
 	httpReq.Header.Set(contentTypeHeader, applicationJSON)
-	// Partner-hosted (Bedrock/Vertex) puts anthropic_version in the body, not the header.
-	if !p.isPartnerHosted() {
+	// Partner-hosted (Bedrock/Vertex) puts anthropic_version in the body.
+	// Azure pins the API contract via the api-version query parameter.
+	// Only the direct API path uses the anthropic-version request header.
+	if !p.isPartnerHosted() && !p.isAzure() {
 		httpReq.Header.Set(anthropicVersionKey, anthropicVersionValue)
 	}
 
@@ -508,7 +587,7 @@ func (p *Provider) makeClaudeHTTPRequest(ctx context.Context, claudeReq claudeRe
 		switch {
 		case p.isBedrock():
 			return nil, predictResp, parseBedrockHTTPError(resp.StatusCode, respBody)
-		case p.isVertex():
+		case p.isVertex(), p.isAzure():
 			return nil, predictResp, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, respBody)
 		default:
 			return nil, predictResp, &providers.ProviderHTTPError{

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -146,6 +146,11 @@ func (p *Provider) PredictStream(
 		})
 	}
 
+	// Direct Anthropic API path. Azure shares this path because its body
+	// format is identical (model in body, stream:true) — only the URL
+	// differs (handled by messagesStreamURL) and the anthropic-version
+	// header must be skipped (Azure pins the contract via the api-version
+	// query parameter on the URL).
 	reqBody, err := json.Marshal(claudeReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -155,14 +160,16 @@ func (p *Provider) PredictStream(
 	// (auth tokens may have rotated between attempts) and a fresh body
 	// reader. The request factory is called once per attempt by the
 	// retry driver.
-	url := p.messagesURL()
+	url := p.messagesStreamURL()
 	requestFn := func(ctx context.Context) (*http.Request, error) {
 		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 		if reqErr != nil {
 			return nil, fmt.Errorf("failed to create request: %w", reqErr)
 		}
 		httpReq.Header.Set(contentTypeHeader, applicationJSON)
-		httpReq.Header.Set(anthropicVersionKey, anthropicVersionValue)
+		if !p.isAzure() {
+			httpReq.Header.Set(anthropicVersionKey, anthropicVersionValue)
+		}
 		httpReq.Header.Set("Accept", "text/event-stream")
 		if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
 			return nil, fmt.Errorf("failed to apply authentication: %w", authErr)

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -502,14 +502,16 @@ func (p *ToolProvider) parseToolResponse(
 }
 
 // applyToolRequestHeaders sets content-type, anthropic auth, and custom
-// headers on req. Partner-hosted (Bedrock SigV4 / Vertex Bearer) auth via
-// the resolved Credential; direct API uses x-api-key + anthropic-version
-// headers. Centralizing this keeps the caller functions below
-// cognitive-complexity limits and ensures every request path goes through
-// the same custom-header collision check.
+// headers on req. Credential-based auth (Bedrock SigV4 / Vertex Bearer /
+// Azure Bearer) goes via the resolved Credential; the direct API uses
+// x-api-key + anthropic-version headers. Azure pins the API contract via
+// the api-version query parameter so it does not need the
+// anthropic-version header. Centralizing this keeps the caller functions
+// below cognitive-complexity limits and ensures every request path goes
+// through the same custom-header collision check.
 func (p *ToolProvider) applyToolRequestHeaders(ctx context.Context, req *http.Request) error {
 	req.Header.Set(contentTypeHeader, applicationJSON)
-	if p.isPartnerHosted() {
+	if p.usesCredentialAuth() {
 		if err := p.applyAuth(ctx, req); err != nil {
 			return fmt.Errorf("failed to apply authentication: %w", err)
 		}
@@ -562,7 +564,7 @@ func (p *ToolProvider) makeRequest(ctx context.Context, request interface{}) ([]
 		switch {
 		case p.isBedrock():
 			return nil, parseBedrockHTTPError(resp.StatusCode, respBody)
-		case p.isVertex():
+		case p.isVertex(), p.isAzure():
 			return nil, providers.ParsePlatformHTTPError(p.platform, resp.StatusCode, respBody)
 		default:
 			return nil, &providers.ProviderHTTPError{

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -235,11 +235,11 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 				baseURL = DefaultGeminiBaseURL
 			}
 		case "claude":
-			// Skip the api.anthropic.com default for Vertex — the claude
-			// factory builds the publishers/anthropic/models URL from
-			// PlatformConfig. Same #1010 root cause as openai+azure and
-			// gemini+vertex.
-			if spec.Platform != "vertex" {
+			// Skip the api.anthropic.com default for hyperscaler-hosted
+			// Anthropic — the claude factory builds the platform URL from
+			// PlatformConfig (Vertex: publishers/anthropic/models; Azure:
+			// openai/deployments/{deployment}). Same #1010 root cause.
+			if spec.Platform != "vertex" && spec.Platform != "azure" {
 				baseURL = "https://api.anthropic.com"
 			}
 		case "imagen":

--- a/runtime/providers/registry_extended_test.go
+++ b/runtime/providers/registry_extended_test.go
@@ -265,6 +265,42 @@ func TestCreateProviderFromSpecClaudeVertexSkipsDefault(t *testing.T) {
 	}
 }
 
+// TestCreateProviderFromSpecClaudeAzureSkipsDefault is the regression test
+// for the claude+azure cell of #1009: api.anthropic.com must not clobber
+// spec.BaseURL when Platform=="azure". The claude factory derives the
+// openai/deployments/{deployment} URL from PlatformConfig.Endpoint in
+// that case.
+func TestCreateProviderFromSpecClaudeAzureSkipsDefault(t *testing.T) {
+	originalFactory := providerFactories["claude"]
+	capturedBaseURL := "sentinel"
+	providerFactories["claude"] = func(spec ProviderSpec) (Provider, error) {
+		capturedBaseURL = spec.BaseURL
+		return &mockProviderForTest{id: spec.ID}, nil
+	}
+	defer func() {
+		if originalFactory != nil {
+			providerFactories["claude"] = originalFactory
+		} else {
+			delete(providerFactories, "claude")
+		}
+	}()
+
+	spec := ProviderSpec{
+		ID:       "azure-claude",
+		Type:     "claude",
+		Model:    testModelName,
+		Platform: "azure",
+	}
+
+	if _, err := CreateProviderFromSpec(spec); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if capturedBaseURL != "" {
+		t.Errorf("Expected empty BaseURL for claude+azure, got %q (regression of #1010-class bug)", capturedBaseURL)
+	}
+}
+
 func TestCreateProviderFromSpecCustomBaseURL(t *testing.T) {
 	customURL := "https://custom.api.example.com"
 	spec := ProviderSpec{


### PR DESCRIPTION
## Summary

Closes the final cell of the provider × platform matrix. Best-endeavors:
the URL pattern follows Microsoft's standard AIServices deployment shape
(mirrors openai+azure exactly except `/messages` instead of
`/chat/completions`). **No live verification has been done** — the
Foundry Anthropic quota for our subscription is currently 0 in eastus2
and swedencentral and quota requests are portal-only.

## Wire format (planned, to verify on first live run)

| | |
|---|---|
| URL | `{endpoint}/openai/deployments/{deployment}/messages?api-version={v}` |
| Auth | Entra Bearer via `credentials.AzureCredential` (same as openai+azure) |
| Body | Standard Anthropic Messages API verbatim — model in body, `stream:true` for streaming. Distinct from Bedrock/Vertex which use the partner shape. |
| API version | `PlatformConfig.AdditionalConfig.api_version` → defaults to `2024-12-01-preview` (same as openai+azure) |
| Headers | No `anthropic-version` (api-version query parameter pins the contract) |

If the Foundry deployment turns out to use a vendor-prefixed pattern
(`{endpoint}/anthropic/v1/messages?api-version=...`) instead, the fix
is a one-line change to `messagesURL`/`messagesStreamURL`.

## Code structure

- `azurePlatform` constant + `defaultAzureAPIVersion` in claude.go,
  plus `azureAnthropicDeploymentEndpoint(endpoint, deployment)`.
- `isAzure()` predicate. New `usesCredentialAuth()` predicate
  covering Bedrock + Vertex + Azure (the auth-side superset of
  `isPartnerHosted`, which stays Bedrock+Vertex only because Azure
  does **not** use the partner body shape).
- `azureAPIVersion()` reads `PlatformConfig.AdditionalConfig` with
  `defaultAzureAPIVersion` fallback.
- `messagesURL()` / `messagesStreamURL()` branch on Azure to produce
  `{baseURL}/messages?api-version={v}`. Both return the same path —
  Azure uses one endpoint signalled by `stream:true` in body.
- `NewProviderWithCredential` derives the deployment URL from
  `PlatformConfig.Endpoint` when `BaseURL == ""` and Platform="azure".
- `makeClaudeHTTPRequest` skips the `anthropic-version` header for
  Azure (api-version pins it). Errors route through
  `providers.ParsePlatformHTTPError`.
- `applyToolRequestHeaders` switched to `usesCredentialAuth` so Azure
  goes through `credential.Apply` (Bearer) rather than x-api-key.
- `PredictStream` direct branch now calls `messagesStreamURL()`
  (Azure-aware) and skips the `anthropic-version` header for Azure.
- Registry skips `https://api.anthropic.com` default for
  `Platform == "azure"`.

## Tests

- `azure_unit_test.go` — predicates, URL builder, factory URL
  derivation, api-version selection, header omission, full
  PredictStream wire-format assertion against an httptest server.
- `registry_extended_test.go` — claude+azure regression test
  matching the openai+azure / gemini+vertex / claude+vertex pattern.

Bedrock / Vertex / direct paths unchanged — confirmed via existing
unit tests (all pass) and not regressed by the predicate refactor.

## Pre-commit

- lint: 0 issues
- coverage on changed files: claude.go 83.9%, claude_streaming.go
  88.1%, claude_tools.go 84.1%, registry.go 93.5% (all ≥80%)

## Test plan

- [x] `go test -race -count=1 ./runtime/providers/claude/... ./runtime/providers/...` — green
- [x] New Azure unit tests pass (URL/auth/body wire format verified via httptest)
- [x] Registry regression test pass
- [x] Existing claude+vertex, claude+bedrock, direct-API tests pass — refactor didn't regress
- [ ] Live verification — deferred: requires Anthropic quota allocation in your Foundry subscription (portal-only flow). First live PredictStream call will validate the URL shape; if the model returns 404 the fix is a one-line URL pattern swap to `/anthropic/v1/messages` per the inline comment.

## Matrix status after this PR

| | bedrock | vertex | azure |
|---|---|---|---|
| **claude** | ✅ | ✅ | ✅ **(this PR, unverified)** |
| **openai** | ✅ | ⛔ rejected | ✅ |
| **gemini** | ⛔ rejected | ✅ | ⛔ rejected |

**9 of 9 cells delivered.** #1009 is closeable on the code side; one cell flagged as "URL-shape unverified pending live deployment".

Closes #1009
