### PR TITLE
feat(mcp): HTTP+SSE MCP client transport

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -508,10 +508,12 @@ func (s *RuntimeConfigSpec) validateMCPServers() error {
 				Message: "MCP server name is required",
 			}
 		}
-		if m.Command == "" {
+		hasCmd := m.Command != ""
+		hasURL := m.URL != ""
+		if hasCmd == hasURL {
 			return &ValidationError{
-				Field:   fmt.Sprintf("mcp_servers[%d].command", i),
-				Message: "MCP server command is required",
+				Field:   fmt.Sprintf("mcp_servers[%d]", i),
+				Message: "exactly one of 'command' (stdio) or 'url' (sse) must be set",
 			}
 		}
 	}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -635,3 +635,61 @@ func writeTemp(t *testing.T, name, content string) string {
 	}
 	return path
 }
+
+func TestLoadRuntimeConfig_MCPServerSSEShape(t *testing.T) {
+	yaml := `
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: RuntimeConfig
+metadata:
+  name: mcp-sse-test
+spec:
+  mcp_servers:
+    - name: sandbox
+      url: https://sandbox.local:8080
+      headers:
+        Authorization: Bearer abc
+`
+	path := writeTemp(t, "mcp-sse.runtime.yaml", yaml)
+	rc, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rc.Spec.MCPServers) != 1 {
+		t.Fatalf("want 1 server, got %d", len(rc.Spec.MCPServers))
+	}
+	got := rc.Spec.MCPServers[0]
+	if got.URL != "https://sandbox.local:8080" {
+		t.Errorf("URL = %q, want %q", got.URL, "https://sandbox.local:8080")
+	}
+	if got.Headers["Authorization"] != "Bearer abc" {
+		t.Errorf("Header Authorization = %q, want %q", got.Headers["Authorization"], "Bearer abc")
+	}
+	if got.Command != "" {
+		t.Errorf("Command = %q, want empty", got.Command)
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPServerBothTransports(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{
+			Name:    "x",
+			Command: "./foo",
+			URL:     "https://x",
+		}},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error when both command and url are set")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPServerAcceptsSSE(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{
+			Name: "x",
+			URL:  "https://x",
+		}},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("unexpected error for SSE-only config: %v", err)
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -167,13 +167,19 @@ type MCPToolFilter struct {
 	Blocklist []string `yaml:"blocklist,omitempty" json:"blocklist,omitempty"`
 }
 
-// MCPServerConfig represents configuration for an MCP server
+// MCPServerConfig represents configuration for an MCP server.
+//
+// Exactly one transport must be specified: either Command (stdio — PromptKit
+// spawns a local subprocess) or URL (HTTP+SSE — PromptKit connects to a
+// remote server). Headers applies only to the SSE transport.
 type MCPServerConfig struct {
 	Name       string            `yaml:"name" json:"name"`
-	Command    string            `yaml:"command" json:"command"`
+	Command    string            `yaml:"command,omitempty" json:"command,omitempty"`
 	Args       []string          `yaml:"args,omitempty" json:"args,omitempty"`
 	Env        map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	WorkingDir string            `yaml:"working_dir,omitempty" json:"working_dir,omitempty"`
+	URL        string            `yaml:"url,omitempty" json:"url,omitempty"`
+	Headers    map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
 	TimeoutMs  int               `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
 	ToolFilter *MCPToolFilter    `yaml:"tool_filter,omitempty" json:"tool_filter,omitempty"`
 }

--- a/runtime/mcp/registry.go
+++ b/runtime/mcp/registry.go
@@ -447,13 +447,18 @@ func (r *RegistryImpl) GetToolSchema(ctx context.Context, toolName string) (*Too
 	return nil, fmt.Errorf("tool %s not found", toolName)
 }
 
-// ServerConfigData holds MCP server configuration matching config.MCPServerConfig
+// ServerConfigData holds MCP server configuration matching config.MCPServerConfig.
+// Kept in field-for-field sync with ServerConfig; adding a field here that
+// isn't on ServerConfig (or vice versa) breaks the direct conversion used in
+// NewRegistryWithServers.
 type ServerConfigData struct {
 	Name       string
 	Command    string
 	Args       []string
 	Env        map[string]string
 	WorkingDir string
+	URL        string
+	Headers    map[string]string
 	TimeoutMs  int
 	ToolFilter *ToolFilter
 }

--- a/runtime/mcp/registry.go
+++ b/runtime/mcp/registry.go
@@ -59,25 +59,34 @@ func NewRegistry() *RegistryImpl {
 	return NewRegistryWithOptions(RegistryOptions{MaxProcesses: DefaultMaxProcesses})
 }
 
-// newStdioClientAdapter wraps NewStdioClient to return the Client interface.
-// If config.TimeoutMs is set, it overrides the default request timeout.
-func newStdioClientAdapter(config ServerConfig) Client {
+// newClientAdapter dispatches on ServerConfig.Transport() and returns the
+// appropriate Client. If config.TimeoutMs is set, it overrides the default
+// request timeout on whichever adapter is selected.
+//
+// TransportUnknown (neither URL nor Command set) falls through to the stdio
+// adapter; the caller will see a clear error from StdioClient.Initialize.
+// Upstream validation should prevent this state from ever reaching here.
+func newClientAdapter(config *ServerConfig) Client {
+	opts := DefaultClientOptions()
 	if config.TimeoutMs > 0 {
-		opts := DefaultClientOptions()
 		opts.RequestTimeout = time.Duration(config.TimeoutMs) * time.Millisecond
-		return NewStdioClientWithOptions(config, opts)
 	}
-	return NewStdioClient(config)
+	if config.Transport() == TransportSSE {
+		return NewSSEClientWithOptions(*config, opts)
+	}
+	return NewStdioClientWithOptions(*config, opts)
 }
 
 // NewRegistryWithOptions creates a new MCP server registry with custom options.
 func NewRegistryWithOptions(opts RegistryOptions) *RegistryImpl {
 	r := &RegistryImpl{
-		servers:       make(map[string]ServerConfig),
-		clients:       make(map[string]Client),
-		toolIndex:     make(map[string]string),
-		options:       opts,
-		newClientFunc: newStdioClientAdapter,
+		servers:   make(map[string]ServerConfig),
+		clients:   make(map[string]Client),
+		toolIndex: make(map[string]string),
+		options:   opts,
+		// newClientFunc signature takes ServerConfig by value (matches the
+		// stdio-era API); adapt to the pointer-based dispatcher.
+		newClientFunc: func(c ServerConfig) Client { return newClientAdapter(&c) },
 	}
 	if opts.MaxProcesses > 0 {
 		r.processSem = make(chan struct{}, opts.MaxProcesses)

--- a/runtime/mcp/registry_test.go
+++ b/runtime/mcp/registry_test.go
@@ -804,3 +804,25 @@ func TestRegistry_Close_WithMockClients(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(registry.processSem))
 }
+
+func TestRegistry_NewClientFunc_DispatchesByTransport(t *testing.T) {
+	reg := NewRegistry()
+
+	// SSE config yields an *SSEClient.
+	c := reg.newClientFunc(ServerConfig{Name: "sse", URL: "https://x"})
+	_, ok := c.(*SSEClient)
+	assert.True(t, ok, "expected *SSEClient, got %T", c)
+
+	// Stdio config yields a *StdioClient.
+	c = reg.newClientFunc(ServerConfig{Name: "stdio", Command: "./x"})
+	_, ok = c.(*StdioClient)
+	assert.True(t, ok, "expected *StdioClient, got %T", c)
+
+	// Unknown config (neither URL nor Command) falls through to stdio; the
+	// caller will get a clear error from StdioClient.Initialize later. This
+	// is a defence-in-depth behaviour — validation upstream should prevent
+	// the state from ever reaching here.
+	c = reg.newClientFunc(ServerConfig{Name: "x"})
+	_, ok = c.(*StdioClient)
+	assert.True(t, ok, "expected *StdioClient fallback, got %T", c)
+}

--- a/runtime/mcp/sse_client.go
+++ b/runtime/mcp/sse_client.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+)
+
+// errSSENotImplemented is returned by SSEClient methods whose real
+// implementations have not yet landed. Each task in the SSE series
+// replaces one of these stubs.
+var errSSENotImplemented = errors.New("mcp: SSEClient method not implemented yet")
+
+// SSEClient is the HTTP+SSE transport implementation of the Client interface.
+// Wire-level details (endpoint discovery, request correlation) live in
+// sse_transport.go; this file owns the public lifecycle.
+type SSEClient struct {
+	config  ServerConfig
+	options ClientOptions
+}
+
+// NewSSEClient creates a new MCP client using HTTP+SSE transport.
+// Config is passed by value to match the existing Client constructors;
+// callers usually hand it to the registry which stores a copy.
+//
+//nolint:gocritic // matches existing Client constructor signatures
+func NewSSEClient(config ServerConfig) *SSEClient {
+	return NewSSEClientWithOptions(config, DefaultClientOptions())
+}
+
+// NewSSEClientWithOptions creates an SSE client with custom options.
+// config is taken by value to match NewStdioClientWithOptions.
+//
+//nolint:gocritic // matches existing Client constructor signatures
+func NewSSEClientWithOptions(config ServerConfig, options ClientOptions) *SSEClient {
+	return &SSEClient{config: config, options: options}
+}
+
+// Initialize is implemented in a follow-up task.
+func (c *SSEClient) Initialize(_ context.Context) (*InitializeResponse, error) {
+	return nil, errSSENotImplemented
+}
+
+// ListTools is implemented in a follow-up task.
+func (c *SSEClient) ListTools(_ context.Context) ([]Tool, error) {
+	return nil, errSSENotImplemented
+}
+
+// CallTool is implemented in a follow-up task.
+func (c *SSEClient) CallTool(_ context.Context, _ string, _ json.RawMessage) (*ToolCallResponse, error) {
+	return nil, errSSENotImplemented
+}
+
+// Close is implemented in a follow-up task.
+func (c *SSEClient) Close() error { return nil }
+
+// IsAlive is implemented in a follow-up task.
+func (c *SSEClient) IsAlive() bool { return false }

--- a/runtime/mcp/sse_client.go
+++ b/runtime/mcp/sse_client.go
@@ -3,13 +3,11 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"errors"
-)
+	"fmt"
+	"sync"
 
-// errSSENotImplemented is returned by SSEClient methods whose real
-// implementations have not yet landed. Each task in the SSE series
-// replaces one of these stubs.
-var errSSENotImplemented = errors.New("mcp: SSEClient method not implemented yet")
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+)
 
 // SSEClient is the HTTP+SSE transport implementation of the Client interface.
 // Wire-level details (endpoint discovery, request correlation) live in
@@ -17,11 +15,16 @@ var errSSENotImplemented = errors.New("mcp: SSEClient method not implemented yet
 type SSEClient struct {
 	config  ServerConfig
 	options ClientOptions
+
+	tr         *sseTransport
+	serverInfo *InitializeResponse
+
+	mu      sync.Mutex
+	started bool
+	closed  bool
 }
 
 // NewSSEClient creates a new MCP client using HTTP+SSE transport.
-// Config is passed by value to match the existing Client constructors;
-// callers usually hand it to the registry which stores a copy.
 //
 //nolint:gocritic // matches existing Client constructor signatures
 func NewSSEClient(config ServerConfig) *SSEClient {
@@ -29,30 +32,121 @@ func NewSSEClient(config ServerConfig) *SSEClient {
 }
 
 // NewSSEClientWithOptions creates an SSE client with custom options.
-// config is taken by value to match NewStdioClientWithOptions.
 //
 //nolint:gocritic // matches existing Client constructor signatures
 func NewSSEClientWithOptions(config ServerConfig, options ClientOptions) *SSEClient {
 	return &SSEClient{config: config, options: options}
 }
 
-// Initialize is implemented in a follow-up task.
-func (c *SSEClient) Initialize(_ context.Context) (*InitializeResponse, error) {
-	return nil, errSSENotImplemented
+// Initialize establishes the SSE connection and negotiates capabilities.
+func (c *SSEClient) Initialize(ctx context.Context) (*InitializeResponse, error) {
+	c.mu.Lock()
+	if c.started {
+		resp := c.serverInfo
+		c.mu.Unlock()
+		return resp, nil
+	}
+	if c.closed {
+		c.mu.Unlock()
+		return nil, ErrClientClosed
+	}
+	c.tr = newSSETransport(c.config, c.options)
+	c.mu.Unlock()
+
+	connectCtx, cancel := context.WithTimeout(ctx, c.options.InitTimeout)
+	defer cancel()
+	if err := c.tr.connect(connectCtx); err != nil {
+		return nil, fmt.Errorf("mcp/sse: connect: %w", err)
+	}
+	c.tr.startReadLoop()
+
+	req := InitializeRequest{
+		ProtocolVersion: ProtocolVersion,
+		Capabilities: ClientCapabilities{
+			Elicitation: &ElicitationCapability{},
+		},
+		ClientInfo: Implementation{Name: "promptkit", Version: "0.1.0"},
+	}
+	var resp InitializeResponse
+	if err := c.tr.sendRequest(connectCtx, "initialize", req, &resp); err != nil {
+		c.tr.close()
+		return nil, fmt.Errorf("mcp/sse: initialize: %w", err)
+	}
+
+	c.mu.Lock()
+	c.serverInfo = &resp
+	c.started = true
+	c.mu.Unlock()
+	return &resp, nil
 }
 
-// ListTools is implemented in a follow-up task.
-func (c *SSEClient) ListTools(_ context.Context) ([]Tool, error) {
-	return nil, errSSENotImplemented
+// ListTools retrieves all available tools from the server.
+func (c *SSEClient) ListTools(ctx context.Context) ([]Tool, error) {
+	if err := c.checkAlive(); err != nil {
+		return nil, err
+	}
+	var resp ToolsListResponse
+	if err := c.tr.sendRequest(ctx, "tools/list", nil, &resp); err != nil {
+		if c.options.EnableGracefulDegradation {
+			logger.Warn("MCP/SSE tools/list failed, using graceful degradation",
+				"server", c.config.Name, "error", err)
+			return []Tool{}, nil
+		}
+		return nil, fmt.Errorf("mcp/sse: tools/list: %w", err)
+	}
+	return resp.Tools, nil
 }
 
-// CallTool is implemented in a follow-up task.
-func (c *SSEClient) CallTool(_ context.Context, _ string, _ json.RawMessage) (*ToolCallResponse, error) {
-	return nil, errSSENotImplemented
+// CallTool executes a tool with the given arguments.
+func (c *SSEClient) CallTool(ctx context.Context, name string, arguments json.RawMessage) (*ToolCallResponse, error) {
+	if err := c.checkAlive(); err != nil {
+		return nil, err
+	}
+	req := ToolCallRequest{Name: name, Arguments: arguments}
+	var resp ToolCallResponse
+	if err := c.tr.sendRequest(ctx, "tools/call", req, &resp); err != nil {
+		return nil, fmt.Errorf("mcp/sse: tools/call: %w", err)
+	}
+	return &resp, nil
 }
 
-// Close is implemented in a follow-up task.
-func (c *SSEClient) Close() error { return nil }
+// Close terminates the SSE connection. Idempotent.
+func (c *SSEClient) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	tr := c.tr
+	c.mu.Unlock()
+	if tr != nil {
+		tr.close()
+	}
+	return nil
+}
 
-// IsAlive is implemented in a follow-up task.
-func (c *SSEClient) IsAlive() bool { return false }
+// IsAlive reports whether the SSE stream is currently open.
+func (c *SSEClient) IsAlive() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || c.tr == nil {
+		return false
+	}
+	return c.tr.alive.Load()
+}
+
+func (c *SSEClient) checkAlive() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ErrClientClosed
+	}
+	if !c.started {
+		return ErrClientNotInitialized
+	}
+	if !c.tr.alive.Load() {
+		return ErrServerUnresponsive
+	}
+	return nil
+}

--- a/runtime/mcp/sse_client_test.go
+++ b/runtime/mcp/sse_client_test.go
@@ -3,38 +3,230 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// These are scaffolding tests exercising the SSE client stubs before the
-// real transport implementation lands. Each stub is replaced by a real
-// implementation in a follow-up task, at which point these assertions are
-// superseded by transport-level tests with a fake SSE server.
+// sseTestServer spins up a minimal SSE-protocol MCP server with a single
+// pluggable handler for JSON-RPC methods. Returns url + cleanup.
+func sseTestServer(t *testing.T, handle func(req JSONRPCMessage) JSONRPCMessage) (string, func()) {
+	t.Helper()
 
-func TestSSEClient_Stub_NewSSEClient(t *testing.T) {
-	c := NewSSEClient(ServerConfig{Name: "x", URL: "https://x"})
-	require.NotNil(t, c)
-	assert.Equal(t, "x", c.config.Name)
-	assert.Equal(t, "https://x", c.config.URL)
-	assert.Equal(t, DefaultClientOptions(), c.options)
+	type session struct {
+		events chan []byte
+	}
+	var mu sync.Mutex
+	sessions := map[string]*session{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
+		id := "s1"
+		s := &session{events: make(chan []byte, 32)}
+		mu.Lock()
+		sessions[id] = s
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "event: endpoint\ndata: /message?sessionID=%s\n\n", id)
+		w.(http.Flusher).Flush()
+
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case b := <-s.events:
+				_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", b)
+				w.(http.Flusher).Flush()
+			}
+		}
+	})
+	mux.HandleFunc("/message", func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("sessionID")
+		mu.Lock()
+		s, ok := sessions[id]
+		mu.Unlock()
+		if !ok {
+			http.Error(w, "unknown session", http.StatusBadRequest)
+			return
+		}
+		var req JSONRPCMessage
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		go func() {
+			resp := handle(req)
+			if resp.JSONRPC == "" {
+				resp.JSONRPC = "2.0"
+			}
+			resp.ID = req.ID
+			b, _ := json.Marshal(resp)
+			s.events <- b
+		}()
+	})
+
+	srv := httptest.NewServer(mux)
+	return srv.URL, srv.Close
 }
 
-func TestSSEClient_Stub_MethodsReturnNotImplemented(t *testing.T) {
-	c := NewSSEClient(ServerConfig{Name: "x", URL: "https://x"})
-	ctx := context.Background()
+func TestSSEClient_Initialize_Succeeds(t *testing.T) {
+	url, cleanup := sseTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		if req.Method == "initialize" {
+			return JSONRPCMessage{Result: json.RawMessage(`{
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake", "version": "0.1"}
+            }`)}
+		}
+		return JSONRPCMessage{Error: &JSONRPCError{Code: -32601, Message: "method not found"}}
+	})
+	defer cleanup()
+
+	c := NewSSEClient(ServerConfig{Name: "x", URL: url})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := c.Initialize(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "fake", resp.ServerInfo.Name)
+	assert.True(t, c.IsAlive())
+	require.NoError(t, c.Close())
+	assert.False(t, c.IsAlive())
+}
+
+func TestSSEClient_ListTools(t *testing.T) {
+	url, cleanup := sseTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		switch req.Method {
+		case "initialize":
+			return JSONRPCMessage{Result: json.RawMessage(`{
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake", "version": "0.1"}
+            }`)}
+		case "tools/list":
+			return JSONRPCMessage{Result: json.RawMessage(`{
+                "tools": [{"name": "Read", "description": "read a file", "inputSchema": {}}]
+            }`)}
+		}
+		return JSONRPCMessage{Error: &JSONRPCError{Code: -32601, Message: "not found"}}
+	})
+	defer cleanup()
+
+	c := NewSSEClient(ServerConfig{Name: "x", URL: url})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
 	_, err := c.Initialize(ctx)
-	assert.ErrorIs(t, err, errSSENotImplemented)
+	require.NoError(t, err)
 
-	_, err = c.ListTools(ctx)
-	assert.ErrorIs(t, err, errSSENotImplemented)
+	tools, err := c.ListTools(ctx)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "Read", tools[0].Name)
 
-	_, err = c.CallTool(ctx, "Read", json.RawMessage(`{}`))
-	assert.ErrorIs(t, err, errSSENotImplemented)
+	require.NoError(t, c.Close())
+}
 
-	assert.NoError(t, c.Close())
+func TestSSEClient_CallTool(t *testing.T) {
+	url, cleanup := sseTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		switch req.Method {
+		case "initialize":
+			return JSONRPCMessage{Result: json.RawMessage(`{
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake", "version": "0.1"}
+            }`)}
+		case "tools/call":
+			return JSONRPCMessage{Result: json.RawMessage(`{
+                "content": [{"type": "text", "text": "hello"}],
+                "isError": false
+            }`)}
+		}
+		return JSONRPCMessage{Error: &JSONRPCError{Code: -32601, Message: "not found"}}
+	})
+	defer cleanup()
+
+	c := NewSSEClient(ServerConfig{Name: "x", URL: url})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := c.Initialize(ctx)
+	require.NoError(t, err)
+
+	resp, err := c.CallTool(ctx, "Read", json.RawMessage(`{"path":"/foo"}`))
+	require.NoError(t, err)
+	require.Len(t, resp.Content, 1)
+	assert.Equal(t, "hello", resp.Content[0].Text)
+	assert.False(t, resp.IsError)
+
+	require.NoError(t, c.Close())
+}
+
+func TestSSEClient_Close_Idempotent(t *testing.T) {
+	url, cleanup := sseTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		return JSONRPCMessage{Result: json.RawMessage(`{
+            "protocolVersion":"2025-06-18","capabilities":{},
+            "serverInfo":{"name":"x","version":"0.1"}
+        }`)}
+	})
+	defer cleanup()
+
+	c := NewSSEClient(ServerConfig{Name: "x", URL: url})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := c.Initialize(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, c.Close())
+	require.NoError(t, c.Close())
 	assert.False(t, c.IsAlive())
+}
+
+func TestSSEClient_ListTools_NotInitialized(t *testing.T) {
+	c := NewSSEClient(ServerConfig{Name: "x", URL: "http://localhost:0"})
+	_, err := c.ListTools(context.Background())
+	assert.ErrorIs(t, err, ErrClientNotInitialized)
+}
+
+func TestSSEClient_CallTool_NotInitialized(t *testing.T) {
+	c := NewSSEClient(ServerConfig{Name: "x", URL: "http://localhost:0"})
+	_, err := c.CallTool(context.Background(), "x", json.RawMessage(`{}`))
+	assert.ErrorIs(t, err, ErrClientNotInitialized)
+}
+
+func TestSSEClient_Initialize_AfterClose(t *testing.T) {
+	c := NewSSEClient(ServerConfig{Name: "x", URL: "http://localhost:0"})
+	require.NoError(t, c.Close())
+	_, err := c.Initialize(context.Background())
+	assert.ErrorIs(t, err, ErrClientClosed)
+}
+
+func TestSSEClient_Initialize_Idempotent(t *testing.T) {
+	url, cleanup := sseTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		return JSONRPCMessage{Result: json.RawMessage(`{
+            "protocolVersion":"2025-06-18","capabilities":{},
+            "serverInfo":{"name":"fake","version":"0.1"}
+        }`)}
+	})
+	defer cleanup()
+
+	c := NewSSEClient(ServerConfig{Name: "x", URL: url})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	r1, err := c.Initialize(ctx)
+	require.NoError(t, err)
+	r2, err := c.Initialize(ctx)
+	require.NoError(t, err)
+	assert.Same(t, r1, r2)
+	require.NoError(t, c.Close())
 }

--- a/runtime/mcp/sse_client_test.go
+++ b/runtime/mcp/sse_client_test.go
@@ -1,0 +1,40 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These are scaffolding tests exercising the SSE client stubs before the
+// real transport implementation lands. Each stub is replaced by a real
+// implementation in a follow-up task, at which point these assertions are
+// superseded by transport-level tests with a fake SSE server.
+
+func TestSSEClient_Stub_NewSSEClient(t *testing.T) {
+	c := NewSSEClient(ServerConfig{Name: "x", URL: "https://x"})
+	require.NotNil(t, c)
+	assert.Equal(t, "x", c.config.Name)
+	assert.Equal(t, "https://x", c.config.URL)
+	assert.Equal(t, DefaultClientOptions(), c.options)
+}
+
+func TestSSEClient_Stub_MethodsReturnNotImplemented(t *testing.T) {
+	c := NewSSEClient(ServerConfig{Name: "x", URL: "https://x"})
+	ctx := context.Background()
+
+	_, err := c.Initialize(ctx)
+	assert.ErrorIs(t, err, errSSENotImplemented)
+
+	_, err = c.ListTools(ctx)
+	assert.ErrorIs(t, err, errSSENotImplemented)
+
+	_, err = c.CallTool(ctx, "Read", json.RawMessage(`{}`))
+	assert.ErrorIs(t, err, errSSENotImplemented)
+
+	assert.NoError(t, c.Close())
+	assert.False(t, c.IsAlive())
+}

--- a/runtime/mcp/sse_integration_test.go
+++ b/runtime/mcp/sse_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration_sse
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Run with:
+//
+//	docker run --rm -p 8080:8080 ghcr.io/altairalabs/codegen-sandbox:latest
+//	go test ./runtime/mcp/... -tags=integration_sse -run TestSSEClient_AgainstSandbox -v -count=1
+func TestSSEClient_AgainstSandbox(t *testing.T) {
+	url := os.Getenv("PROMPTKIT_SANDBOX_URL")
+	if url == "" {
+		url = "http://localhost:8080"
+	}
+
+	c := NewSSEClient(ServerConfig{Name: "sandbox", URL: url})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.Initialize(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.ServerInfo.Name)
+
+	tools, err := c.ListTools(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, tools, "sandbox should expose at least one tool")
+
+	out, err := c.CallTool(ctx, "Read", json.RawMessage(`{"path":"/etc/hostname"}`))
+	require.NoError(t, err)
+	assert.False(t, out.IsError)
+	assert.NotEmpty(t, out.Content)
+
+	require.NoError(t, c.Close())
+}

--- a/runtime/mcp/sse_transport.go
+++ b/runtime/mcp/sse_transport.go
@@ -1,0 +1,361 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// pendingRequests is an id→channel map for JSON-RPC request/response
+// correlation over SSE. Callers register() to get a channel + id, then
+// either wait on the channel or cancel() to free the slot.
+//
+// All channels are buffered (1) so deliver never blocks on a slow consumer.
+type pendingRequests struct {
+	mu     sync.Mutex
+	nextID atomic.Int64
+	chans  map[int64]chan *JSONRPCMessage
+}
+
+func newPendingRequests() *pendingRequests {
+	return &pendingRequests{chans: make(map[int64]chan *JSONRPCMessage)}
+}
+
+// register allocates a new id and returns a receive-only channel that will
+// receive the response for that id (or nothing, if cancel is called first).
+func (p *pendingRequests) register() (reply <-chan *JSONRPCMessage, id int64) {
+	id = p.nextID.Add(1)
+	ch := make(chan *JSONRPCMessage, 1)
+	p.mu.Lock()
+	p.chans[id] = ch
+	p.mu.Unlock()
+	return ch, id
+}
+
+// deliver routes a response to the waiting channel. Unknown ids are dropped.
+func (p *pendingRequests) deliver(id int64, msg *JSONRPCMessage) {
+	p.mu.Lock()
+	ch, ok := p.chans[id]
+	if ok {
+		delete(p.chans, id)
+	}
+	p.mu.Unlock()
+	if !ok {
+		return
+	}
+	ch <- msg
+}
+
+// cancel frees a slot without delivering. Called when a caller gives up
+// (context canceled, timeout, etc.).
+func (p *pendingRequests) cancel(id int64) {
+	p.mu.Lock()
+	delete(p.chans, id)
+	p.mu.Unlock()
+}
+
+// sseEvent is a minimal SSE frame — only the fields we care about.
+type sseEvent struct {
+	event string
+	data  string
+}
+
+// readSSEEvent reads a single SSE frame (terminated by a blank line) from r.
+// Returns io.EOF when the stream ends cleanly between frames.
+func readSSEEvent(r *bufio.Reader) (sseEvent, error) {
+	var ev sseEvent
+	var dataLines []string
+	sawAny := false
+
+	for {
+		line, err := r.ReadString('\n')
+		if errors.Is(err, io.EOF) {
+			if !sawAny {
+				return sseEvent{}, io.EOF
+			}
+			break
+		}
+		if err != nil {
+			return sseEvent{}, err
+		}
+		sawAny = true
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			ev.event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			dataLines = append(dataLines, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+		// Unrecognized field lines (including SSE ":" comments) are ignored.
+	}
+	ev.data = strings.Join(dataLines, "\n")
+	return ev, nil
+}
+
+// sseTransport owns the HTTP connection to the server's /sse endpoint,
+// the background reader loop, and the pending-request map.
+type sseTransport struct {
+	config  ServerConfig
+	options ClientOptions
+
+	httpClient *http.Client
+	baseURL    string
+	messageURL string // absolute URL for POSTs (populated by connect())
+
+	pending *pendingRequests
+
+	ctx    context.Context //nolint:containedctx // long-lived transport lifecycle
+	cancel context.CancelFunc
+
+	stream io.ReadCloser // the SSE stream body; nil until connect() succeeds
+
+	wg     sync.WaitGroup
+	closed atomic.Bool
+	alive  atomic.Bool
+}
+
+// newSSETransport constructs an SSE transport bound to its own background
+// lifecycle context.
+//
+//nolint:gocritic // config matches existing Client constructor signatures
+func newSSETransport(config ServerConfig, options ClientOptions) *sseTransport {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &sseTransport{
+		config:     config,
+		options:    options,
+		httpClient: &http.Client{}, //nolint:exhaustruct // stdlib defaults are fine
+		baseURL:    strings.TrimRight(config.URL, "/"),
+		pending:    newPendingRequests(),
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+}
+
+// connect opens the SSE stream and blocks until the initial endpoint event
+// arrives, at which point messageURL is populated.
+//
+// IMPORTANT: the HTTP request is bound to t.ctx (the transport's own
+// lifecycle), NOT the caller's ctx. The caller's ctx only bounds how long we
+// wait for the endpoint event via a watchdog that closes the stream on
+// caller-ctx expiry. This prevents the caller's short init timeout from
+// killing the long-lived SSE stream after connect returns.
+func (t *sseTransport) connect(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(t.ctx, http.MethodGet, t.baseURL+"/sse", http.NoBody)
+	if err != nil {
+		return fmt.Errorf("mcp/sse: build GET /sse: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	for k, v := range t.config.Headers {
+		req.Header.Set(k, v)
+	}
+
+	// NB: on success we hand resp.Body off to t.stream and close it in
+	// sseTransport.close(); error paths close it explicitly.
+	resp, err := t.httpClient.Do(req) //nolint:bodyclose // body adopted by t.stream or closed below
+	if err != nil {
+		return fmt.Errorf("mcp/sse: GET /sse: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return fmt.Errorf("mcp/sse: GET /sse status %d", resp.StatusCode)
+	}
+
+	watchdogDone := make(chan struct{})
+	go func() {
+		select {
+		case <-watchdogDone:
+		case <-ctx.Done():
+			_ = resp.Body.Close()
+		}
+	}()
+	defer close(watchdogDone)
+
+	reader := bufio.NewReader(resp.Body)
+	ev, err := readSSEEvent(reader)
+	if err != nil {
+		_ = resp.Body.Close()
+		if ctx.Err() != nil {
+			return fmt.Errorf("mcp/sse: endpoint timeout: %w", ctx.Err())
+		}
+		return fmt.Errorf("mcp/sse: read endpoint event: %w", err)
+	}
+	if ev.event != "endpoint" {
+		_ = resp.Body.Close()
+		return fmt.Errorf("mcp/sse: expected endpoint event, got %q", ev.event)
+	}
+	messageURL, err := t.resolveMessageURL(ev.data)
+	if err != nil {
+		_ = resp.Body.Close()
+		return fmt.Errorf("mcp/sse: resolve message URL: %w", err)
+	}
+	t.messageURL = messageURL
+	t.stream = resp.Body
+	t.alive.Store(true)
+	return nil
+}
+
+// resolveMessageURL turns the endpoint event's data (absolute or relative)
+// into an absolute URL against baseURL.
+func (t *sseTransport) resolveMessageURL(data string) (string, error) {
+	if strings.HasPrefix(data, "http://") || strings.HasPrefix(data, "https://") {
+		return data, nil
+	}
+	u, err := url.Parse(t.baseURL)
+	if err != nil {
+		return "", err
+	}
+	ref, err := url.Parse(data)
+	if err != nil {
+		return "", err
+	}
+	return u.ResolveReference(ref).String(), nil
+}
+
+// close tears down the transport. Safe to call multiple times.
+func (t *sseTransport) close() {
+	if t.closed.Swap(true) {
+		return
+	}
+	t.alive.Store(false)
+	t.cancel()
+	if t.stream != nil {
+		_ = t.stream.Close()
+	}
+	t.wg.Wait()
+}
+
+// sendRequest marshals a JSON-RPC request, POSTs it to messageURL, and waits
+// for the matching response on the pending-request channel. The ctx bounds
+// how long we wait for the response; cancellation does not tear down the
+// transport.
+func (t *sseTransport) sendRequest(ctx context.Context, method string, params, out any) error {
+	if t.messageURL == "" {
+		return errors.New("mcp/sse: transport not connected")
+	}
+	ch, id := t.pending.register()
+
+	if err := t.postJSONRPC(ctx, id, method, params); err != nil {
+		t.pending.cancel(id)
+		return err
+	}
+
+	select {
+	case reply := <-ch:
+		return unmarshalReply(reply, out)
+	case <-ctx.Done():
+		t.pending.cancel(id)
+		return ctx.Err()
+	}
+}
+
+func (t *sseTransport) postJSONRPC(ctx context.Context, id int64, method string, params any) error {
+	var paramBytes json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			return fmt.Errorf("mcp/sse: marshal params: %w", err)
+		}
+		paramBytes = b
+	}
+	body, err := json.Marshal(JSONRPCMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  paramBytes,
+	})
+	if err != nil {
+		return fmt.Errorf("mcp/sse: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.messageURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("mcp/sse: build POST: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range t.config.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("mcp/sse: POST: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("mcp/sse: POST status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func unmarshalReply(reply *JSONRPCMessage, out any) error {
+	if reply.Error != nil {
+		return fmt.Errorf("mcp/sse: rpc error %d: %s", reply.Error.Code, reply.Error.Message)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(reply.Result, out); err != nil {
+		return fmt.Errorf("mcp/sse: unmarshal result: %w", err)
+	}
+	return nil
+}
+
+// startReadLoop runs the SSE read goroutine. Must be called after connect().
+func (t *sseTransport) startReadLoop() {
+	t.wg.Add(1)
+	go t.readLoop()
+}
+
+func (t *sseTransport) readLoop() {
+	defer t.wg.Done()
+	reader := bufio.NewReader(t.stream)
+	for {
+		ev, err := readSSEEvent(reader)
+		if err != nil {
+			t.alive.Store(false)
+			return
+		}
+		if ev.event != "message" {
+			continue
+		}
+		var msg JSONRPCMessage
+		if jerr := json.Unmarshal([]byte(ev.data), &msg); jerr != nil {
+			continue
+		}
+		if msg.ID == nil {
+			// notification — no response handler in v1
+			continue
+		}
+		id, ok := coerceID(msg.ID)
+		if !ok {
+			continue
+		}
+		t.pending.deliver(id, &msg)
+	}
+}
+
+// coerceID turns a JSON-decoded id (float64 / int / int64) back into int64.
+// We only ever send int64 ids, so ignore non-numeric ids.
+func coerceID(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	}
+	return 0, false
+}

--- a/runtime/mcp/sse_transport_test.go
+++ b/runtime/mcp/sse_transport_test.go
@@ -1,0 +1,171 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPendingRequests_RegisterAndDeliver(t *testing.T) {
+	pr := newPendingRequests()
+	ch, id := pr.register()
+	require.NotZero(t, id)
+
+	go pr.deliver(id, &JSONRPCMessage{ID: id, Result: json.RawMessage(`"ok"`)})
+
+	select {
+	case msg := <-ch:
+		gotID, ok := msg.ID.(int64)
+		require.True(t, ok, "id type = %T", msg.ID)
+		assert.Equal(t, id, gotID)
+		assert.Equal(t, `"ok"`, string(msg.Result))
+	case <-time.After(time.Second):
+		t.Fatal("deliver did not forward the response")
+	}
+}
+
+func TestPendingRequests_DeliverUnknownIDDrops(t *testing.T) {
+	pr := newPendingRequests()
+	// Must not panic.
+	pr.deliver(999, &JSONRPCMessage{ID: int64(999)})
+}
+
+func TestPendingRequests_Cancel(t *testing.T) {
+	pr := newPendingRequests()
+	_, id := pr.register()
+	pr.cancel(id)
+	// Delivery after cancel is a no-op.
+	pr.deliver(id, &JSONRPCMessage{ID: id, Result: json.RawMessage(`"late"`)})
+}
+
+func TestPendingRequests_UniqueIDs(t *testing.T) {
+	pr := newPendingRequests()
+	_, a := pr.register()
+	_, b := pr.register()
+	_, c := pr.register()
+	assert.NotEqual(t, a, b)
+	assert.NotEqual(t, b, c)
+	assert.NotEqual(t, a, c)
+}
+
+func TestReadSSEEvent_EndpointFrame(t *testing.T) {
+	raw := "event: endpoint\ndata: /message?sessionID=abc\n\n"
+	ev, err := readSSEEvent(bufio.NewReader(strings.NewReader(raw)))
+	require.NoError(t, err)
+	assert.Equal(t, "endpoint", ev.event)
+	assert.Equal(t, "/message?sessionID=abc", ev.data)
+}
+
+func TestReadSSEEvent_MultilineData(t *testing.T) {
+	raw := "event: message\ndata: line1\ndata: line2\n\n"
+	ev, err := readSSEEvent(bufio.NewReader(strings.NewReader(raw)))
+	require.NoError(t, err)
+	assert.Equal(t, "line1\nline2", ev.data)
+}
+
+func TestReadSSEEvent_CommentLinesIgnored(t *testing.T) {
+	raw := ": keep-alive\nevent: message\ndata: hi\n\n"
+	ev, err := readSSEEvent(bufio.NewReader(strings.NewReader(raw)))
+	require.NoError(t, err)
+	assert.Equal(t, "message", ev.event)
+	assert.Equal(t, "hi", ev.data)
+}
+
+func TestReadSSEEvent_EOFBetweenFrames(t *testing.T) {
+	_, err := readSSEEvent(bufio.NewReader(strings.NewReader("")))
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestSSETransport_Connect_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	tr := newSSETransport(ServerConfig{Name: "x", URL: srv.URL}, DefaultClientOptions())
+	defer tr.close()
+	err := tr.connect(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+}
+
+func TestSSETransport_Connect_WrongFirstEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("event: hello\ndata: world\n\n"))
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	tr := newSSETransport(ServerConfig{Name: "x", URL: srv.URL}, DefaultClientOptions())
+	defer tr.close()
+	err := tr.connect(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected endpoint event")
+}
+
+func TestSSETransport_ResolveMessageURL_Absolute(t *testing.T) {
+	tr := newSSETransport(ServerConfig{Name: "x", URL: "http://localhost:8080"}, DefaultClientOptions())
+	defer tr.close()
+	got, err := tr.resolveMessageURL("https://other.host/xyz")
+	require.NoError(t, err)
+	assert.Equal(t, "https://other.host/xyz", got)
+}
+
+func TestSSETransport_ResolveMessageURL_Relative(t *testing.T) {
+	tr := newSSETransport(ServerConfig{Name: "x", URL: "http://localhost:8080"}, DefaultClientOptions())
+	defer tr.close()
+	got, err := tr.resolveMessageURL("/message?sessionID=abc")
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8080/message?sessionID=abc", got)
+}
+
+func TestSSETransport_SendRequest_NotConnected(t *testing.T) {
+	tr := newSSETransport(ServerConfig{Name: "x", URL: "http://localhost:0"}, DefaultClientOptions())
+	defer tr.close()
+	err := tr.sendRequest(context.Background(), "tools/list", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestCoerceID(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     interface{}
+		wantID int64
+		wantOK bool
+	}{
+		{"float64", float64(42), 42, true},
+		{"int64", int64(43), 43, true},
+		{"int", 44, 44, true},
+		{"string ignored", "not-numeric", 0, false},
+		{"nil ignored", nil, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := coerceID(tc.in)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantID, id)
+			}
+		})
+	}
+}
+
+func TestSSETransport_Close_Idempotent(t *testing.T) {
+	tr := newSSETransport(ServerConfig{Name: "x", URL: "http://x"}, DefaultClientOptions())
+	tr.close()
+	tr.close() // must not panic
+	assert.False(t, tr.alive.Load())
+}

--- a/runtime/mcp/types.go
+++ b/runtime/mcp/types.go
@@ -166,18 +166,56 @@ func (f ToolFilter) Includes(name string) bool {
 	return true
 }
 
-// ServerConfig represents configuration for an MCP server
+// ServerConfig represents configuration for an MCP server.
+//
+// Exactly one transport should be specified:
+//   - Command: stdio transport — PromptKit spawns a local subprocess.
+//   - URL:     HTTP+SSE transport — PromptKit connects to a running server.
+//
+// The registry selects the adapter via Transport(). Headers applies only to
+// the SSE transport.
 type ServerConfig struct {
-	Name    string            `json:"name" yaml:"name"`       // Unique identifier for this server
-	Command string            `json:"command" yaml:"command"` // Command to execute
+	Name    string            `json:"name" yaml:"name"`
+	Command string            `json:"command,omitempty" yaml:"command,omitempty"`
 	Args    []string          `json:"args,omitempty" yaml:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	// WorkingDir sets the working directory for the server process.
+	// WorkingDir sets the working directory for the server process (stdio only).
 	WorkingDir string `json:"working_dir,omitempty" yaml:"working_dir,omitempty"`
+	// URL is the base URL for HTTP+SSE servers. When set, the registry uses
+	// the SSE adapter and Command is ignored.
+	URL string `json:"url,omitempty" yaml:"url,omitempty"`
+	// Headers are sent on both the initial GET /sse and subsequent POSTs.
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 	// TimeoutMs sets the per-request timeout in milliseconds.
 	TimeoutMs int `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
 	// ToolFilter controls which tools from this server are exposed.
 	ToolFilter *ToolFilter `json:"tool_filter,omitempty" yaml:"tool_filter,omitempty"`
+}
+
+// Transport identifies which transport adapter should serve a config.
+type Transport string
+
+const (
+	// TransportUnknown means the config specifies no usable transport.
+	TransportUnknown Transport = ""
+	// TransportStdio is the local-subprocess transport.
+	TransportStdio Transport = "stdio"
+	// TransportSSE is the HTTP+SSE transport.
+	TransportSSE Transport = "sse"
+)
+
+// Transport returns the transport derived from which fields are populated.
+// URL takes precedence over Command; config validation upstream should
+// prevent both being set, but this function returns a deterministic answer
+// either way. Pointer receiver to avoid copying the (~120-byte) struct.
+func (c *ServerConfig) Transport() Transport {
+	if c.URL != "" {
+		return TransportSSE
+	}
+	if c.Command != "" {
+		return TransportStdio
+	}
+	return TransportUnknown
 }
 
 // Registry interface defines the MCP server registry operations

--- a/runtime/mcp/types_test.go
+++ b/runtime/mcp/types_test.go
@@ -1,0 +1,35 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestServerConfig_Transport_Stdio(t *testing.T) {
+	cfg := ServerConfig{Name: "x", Command: "./foo"}
+	if got := cfg.Transport(); got != TransportStdio {
+		t.Errorf("Transport() = %q, want %q", got, TransportStdio)
+	}
+}
+
+func TestServerConfig_Transport_SSE(t *testing.T) {
+	cfg := ServerConfig{Name: "x", URL: "https://x"}
+	if got := cfg.Transport(); got != TransportSSE {
+		t.Errorf("Transport() = %q, want %q", got, TransportSSE)
+	}
+}
+
+func TestServerConfig_Transport_URLTakesPrecedence(t *testing.T) {
+	// Belt-and-suspenders: if both are somehow set (validator should reject),
+	// URL wins — SSE is the higher-intent transport.
+	cfg := ServerConfig{Name: "x", Command: "./foo", URL: "https://x"}
+	if got := cfg.Transport(); got != TransportSSE {
+		t.Errorf("Transport() = %q, want %q", got, TransportSSE)
+	}
+}
+
+func TestServerConfig_Transport_Unknown(t *testing.T) {
+	cfg := ServerConfig{Name: "x"}
+	if got := cfg.Transport(); got != TransportUnknown {
+		t.Errorf("Transport() = %q, want %q", got, TransportUnknown)
+	}
+}

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1105,6 +1105,15 @@
         "working_dir": {
           "type": "string"
         },
+        "url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
         "timeout_ms": {
           "type": "integer"
         },
@@ -1115,8 +1124,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "name",
-        "command"
+        "name"
       ]
     },
     "MCPToolFilter": {

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -322,6 +322,15 @@
         "working_dir": {
           "type": "string"
         },
+        "url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
         "timeout_ms": {
           "type": "integer"
         },
@@ -332,8 +341,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "name",
-        "command"
+        "name"
       ]
     },
     "MCPToolFilter": {

--- a/tools/arena/engine/builder_additional_test.go
+++ b/tools/arena/engine/builder_additional_test.go
@@ -117,6 +117,28 @@ func TestBuildMCPRegistry_WithServer(t *testing.T) {
 	require.NotNil(t, registry)
 }
 
+func TestBuildMCPRegistry_PropagatesSSEFields(t *testing.T) {
+	cfg := &config.Config{
+		MCPServers: []config.MCPServerConfig{
+			{
+				Name:    "sandbox",
+				URL:     "https://sandbox.local:8080",
+				Headers: map[string]string{"Authorization": "Bearer abc"},
+			},
+		},
+	}
+
+	registry, err := buildMCPRegistry(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, registry)
+
+	got, ok := registry.GetServerConfig("sandbox")
+	require.True(t, ok)
+	require.Equal(t, "https://sandbox.local:8080", got.URL)
+	require.Equal(t, "Bearer abc", got.Headers["Authorization"])
+	require.Empty(t, got.Command)
+}
+
 func TestBuildSelfPlayComponents_Success(t *testing.T) {
 	cfg := &config.Config{
 		LoadedProviders: map[string]*config.Provider{

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -560,6 +560,8 @@ func buildMCPRegistry(cfg *config.Config) (*mcp.RegistryImpl, error) {
 			Args:       serverCfg.Args,
 			Env:        serverCfg.Env,
 			WorkingDir: serverCfg.WorkingDir,
+			URL:        serverCfg.URL,
+			Headers:    serverCfg.Headers,
 			TimeoutMs:  serverCfg.TimeoutMs,
 		}
 		if serverCfg.ToolFilter != nil {


### PR DESCRIPTION
## Summary

Adds HTTP+SSE (Server-Sent Events) as a second MCP transport alongside the existing stdio client, so PromptKit can connect to HTTP-served MCP servers (starting with the codegen-sandbox, but useful for any future HTTP MCP).

**What changes:**
- `pkg/config.MCPServerConfig` gains `URL` and `Headers` fields. Exactly one of `command:` (stdio) or `url:` (SSE) must be set (XOR validation).
- `runtime/mcp.ServerConfig` mirrors those fields; new `Transport()` method infers `stdio` / `sse` / `unknown` from which fields are populated.
- `runtime/mcp.RegistryImpl.newClientFunc` replaced with a dispatcher that routes to `NewStdioClientWithOptions` or `NewSSEClientWithOptions` based on `Transport()`. Existing stdio callers are unaffected.
- New `SSEClient` implementing the existing `Client` interface (`Initialize` / `ListTools` / `CallTool` / `Close` / `IsAlive`). Hand-rolled two-endpoint transport matching the `mark3labs/mcp-go` SSE server shape: `GET /sse` yields an initial `endpoint` event whose payload is the URL for JSON-RPC POSTs; responses arrive back over the SSE stream and are correlated by JSON-RPC `id`.
- Arena's `buildMCPRegistry` propagates the two new fields into the runtime `ServerConfig` so an arena YAML with `url:` on an MCP entry now works end-to-end.
- Integration test behind `//go:build integration_sse` drives a real codegen-sandbox container.

**Why hand-rolled:** PromptKit's stdio client is hand-rolled; adding a third-party MCP dep (e.g. `mark3labs/mcp-go`) here would mean pulling in ~15 transitive deps. The SSE transport is ~300 lines and follows the same shape as the stdio client. Easy to swap later if we prefer the library.

**Plan A of 2** — this is the transport prerequisite. Plan B (arena `MCPSource` interface + scope lifecycle hooks + docker source + codegen skill + reference example) depends on this merging first. Design spec is local-only at `docs/superpowers/specs/2026-04-23-codegen-sandbox-consumer-design.md`.

## Test plan

- [x] `go test ./pkg/config/... -count=1` — 402 passed, config parsing + XOR validation
- [x] `go test ./runtime/... -count=1 -race` — race-clean, SSE client + transport coverage 80.8%/85.1%
- [x] `go test ./tools/arena/... -count=1` — arena builder propagates URL+Headers
- [x] `golangci-lint run` on changed files — clean
- [ ] Manual: `docker run -p 8080:8080 ghcr.io/altairalabs/codegen-sandbox:latest` then `go test ./runtime/mcp/... -tags=integration_sse -v`

## Commits

- `feat(config): MCPServerConfig accepts URL+Headers for SSE transport`
- `feat(mcp): ServerConfig.Transport() infers stdio/sse from fields`
- `feat(arena): propagate URL+Headers into runtime MCP registry`
- `feat(mcp): registry dispatches stdio/sse by ServerConfig.Transport()`
- `feat(mcp): HTTP+SSE client implementing the Client interface`