### PR TITLE
feat(arena): MCPSource + codegen sandbox consumer wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -879,3 +879,22 @@ sonar-scan: sonar-deps ## Run SonarScanner locally (requires SONAR_TOKEN env var
 	fi
 
 sonar-quick: coverage sonar-scan ## Generate coverage and run Sonar analysis in one command
+
+.PHONY: codegen-demo codegen-demo-mock
+
+codegen-demo: build-arena ## Run the codegen-sandbox example against a live Docker daemon (requires Docker)
+	@echo "Pulling codegen-sandbox image..."
+	@docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+	@echo ""
+	@echo "Running the codegen-sandbox example..."
+	@cd examples/codegen-sandbox && \
+		PROMPTKIT_SCHEMA_SOURCE=local $(CURDIR)/bin/promptarena run --ci --format html
+	@echo ""
+	@echo "Report at examples/codegen-sandbox/out/report.html"
+
+codegen-demo-mock: build-arena ## Run the codegen-sandbox example with --mock-provider (no Docker required)
+	@echo "Running the codegen-sandbox example with mock provider..."
+	@cd examples/codegen-sandbox && \
+		PROMPTKIT_SCHEMA_SOURCE=local $(CURDIR)/bin/promptarena run --mock-provider --ci --format html
+	@echo ""
+	@echo "Report at examples/codegen-sandbox/out/report.html"

--- a/examples/codegen-sandbox/README.md
+++ b/examples/codegen-sandbox/README.md
@@ -1,0 +1,58 @@
+# Codegen Sandbox Example
+
+A runnable demo of an agent doing real codegen inside a
+[codegen-sandbox](https://github.com/AltairaLabs/CodeGen-Sandbox) container.
+
+## What this demonstrates
+
+- Arena's new `source: docker` MCP entry — a host-provisioned MCP server
+  whose lifecycle is managed per-session.
+- Scope-level lifecycle: one fresh sandbox container per scenario session,
+  torn down when the session ends.
+- Skill staging: `skills/codegen/` is bind-mounted read-only into the
+  sandbox at `/skills/codegen/`, so the agent can `Bash` any scripts
+  shipped with the skill.
+- The HTTP+SSE MCP transport (from the SSE MCP client work).
+
+## Live demo (requires Docker)
+
+```bash
+make -C ../.. build-arena
+docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+open out/report.html
+```
+
+What happens:
+
+1. Arena reads `config.arena.yaml`, sees `source: docker` on the `sandbox`
+   MCP entry, resolves the `docker` source from the in-process registry.
+2. For each scenario session, the docker source runs the image, publishes a
+   free host port, polls `/health`, returns the MCP URL.
+3. Arena registers the URL in the runtime MCP registry; the HTTP+SSE MCP
+   client connects and discovers the 13 codegen tools.
+4. `skills/codegen/` is bind-mounted at `/skills/codegen/` inside the
+   container so the agent can reach skill scripts via `Bash`.
+5. Agent runs the scenario, verifies with `run_tests`, container is
+   stopped + removed when the session ends.
+
+## Offline (CI) demo
+
+```bash
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --mock-provider --ci --format html
+```
+
+Uses `mock-responses.yaml` to simulate the LLM's decisions. The
+`--mock-provider` flag replaces real LLM calls with canned responses; no
+sandbox is launched, so this works in CI without Docker.
+
+Top-level shortcut: `make codegen-demo` from the repo root.
+
+## Files
+
+- `config.arena.yaml` — the arena config. Source-backed MCP entry lives here.
+- `prompts/codegen-agent.yaml` — pack wiring the codegen skill + sandbox tools.
+- `scenarios/simple-fix.scenario.yaml` — one bugfix scenario.
+- `skills/codegen/SKILL.md` — the reusable codegen discipline skill.
+- `providers/mock-provider.yaml` — mock provider for offline demos.
+- `mock-responses.yaml` — canned LLM responses.

--- a/examples/codegen-sandbox/config.arena.yaml
+++ b/examples/codegen-sandbox/config.arena.yaml
@@ -1,0 +1,47 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: codegen-sandbox-arena
+  annotations:
+    description: |
+      Agent doing codegen in a Docker-provisioned sandbox.
+
+      Live demo (needs Docker):
+        make build-arena
+        docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+        cd examples/codegen-sandbox
+        PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+
+      Offline / CI (mock provider, no sandbox):
+        PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --mock-provider --ci --format html
+
+spec:
+  prompt_configs:
+    - id: codegen-agent
+      file: prompts/codegen-agent.yaml
+
+  providers:
+    - file: providers/mock-provider.yaml
+
+  scenarios:
+    - file: scenarios/simple-fix.scenario.yaml
+
+  mcp_servers:
+    - name: sandbox
+      source: docker
+      scope: session
+      source_args:
+        image: ghcr.io/altairalabs/codegen-sandbox:latest
+        env:
+          DEV_MODE: "1"
+
+  skills:
+    - path: skills/codegen
+      preload: true
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 512
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/codegen-sandbox/config.arena.yaml
+++ b/examples/codegen-sandbox/config.arena.yaml
@@ -36,6 +36,7 @@ spec:
           DEV_MODE: "1"
 
   skills:
+    - path: skills/
     - path: skills/codegen
       preload: true
 

--- a/examples/codegen-sandbox/mock-responses.yaml
+++ b/examples/codegen-sandbox/mock-responses.yaml
@@ -1,0 +1,30 @@
+# Mock responses for the codegen-sandbox example.
+#
+# The mock provider simulates the LLM's decisions; tools themselves execute
+# against whichever MCP server is configured. When --mock-provider is used
+# with this example, tool calls are matched against the assertions but no
+# real sandbox is required — making this example CI-safe even without Docker.
+
+scenarios:
+  simple-fix:
+    turns:
+      1:
+        response: "Let me read /workspace/add.go to find the bug."
+        tool_calls:
+          - name: Read
+            arguments:
+              path: /workspace/add.go
+      2:
+        response: "I can see the sign-handling branch is wrong. Fixing."
+        tool_calls:
+          - name: Edit
+            arguments:
+              path: /workspace/add.go
+              old_string: "if a < 0"
+              new_string: "if a < 0 || b < 0"
+      3:
+        response: "Running the tests to verify."
+        tool_calls:
+          - name: run_tests
+            arguments: {}
+      4: "Tests pass. The bug was the incomplete sign check — it only looked at `a`. Fixed."

--- a/examples/codegen-sandbox/prompts/codegen-agent.yaml
+++ b/examples/codegen-sandbox/prompts/codegen-agent.yaml
@@ -1,0 +1,27 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+
+metadata:
+  name: codegen-agent
+
+spec:
+  task_type: codegen-agent
+  version: "v1.0.0"
+  description: "Coding agent with sandbox tools."
+  system_template: |
+    You are a coding agent. The user will describe a task; your job is to
+    complete it using the tools available in the sandbox.
+
+    The repository is at /workspace inside the sandbox. Use Read before
+    Edit. Verify with run_tests before declaring done.
+
+  allowed_tools:
+    - Read
+    - Edit
+    - Write
+    - Glob
+    - Grep
+    - Bash
+    - run_tests
+    - run_lint
+    - run_typecheck

--- a/examples/codegen-sandbox/providers/mock-provider.yaml
+++ b/examples/codegen-sandbox/providers/mock-provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-codegen
+spec:
+  id: mock-codegen
+  type: mock
+  model: mock-model
+  additional_config:
+    mock_config: mock-responses.yaml
+  defaults:
+    temperature: 0.1
+    max_tokens: 512
+    top_p: 1.0

--- a/examples/codegen-sandbox/scenarios/simple-fix.scenario.yaml
+++ b/examples/codegen-sandbox/scenarios/simple-fix.scenario.yaml
@@ -1,0 +1,26 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: simple-fix
+
+spec:
+  id: "simple-fix"
+  task_type: codegen-agent
+  description: Agent fixes a small bug, runs tests to verify.
+
+  turns:
+    - role: user
+      content: |
+        There is a bug in /workspace/add.go — the `add` function returns
+        the wrong value for negative inputs. Please find it, fix it,
+        and verify the tests pass.
+      assertions:
+        - type: tools_called
+          params:
+            tools: ["Read"]
+            message: "Must read the file before editing."
+        - type: tools_called
+          params:
+            tools: ["run_tests"]
+            message: "Must verify with run_tests before finishing."

--- a/examples/codegen-sandbox/skills/codegen/SKILL.md
+++ b/examples/codegen-sandbox/skills/codegen/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: codegen
+description: Disciplined code-generation workflow for agents with a sandbox (Read/Edit/Bash/run_tests/run_lint/run_typecheck). Use whenever the task is to modify source code.
+metadata:
+  tags: "code, editing, testing"
+---
+
+# Codegen Skill
+
+You are writing code inside a container sandbox. Your tools execute real commands against a real filesystem; mistakes are cheap to undo but waste turns.
+
+When a sandbox is mounted, your reference skill files are available read-only at `/skills/codegen/` inside the sandbox. Scripts can be executed via `Bash`; reference files can also be read via `skill__read_resource` (host-side).
+
+## Discipline
+
+**1. Read before Edit.**
+Never call `Edit` on a file you have not `Read` this session. If you discover the file doesn't look like you expected, Read it again before editing.
+
+**2. Plan multi-step work with TodoWrite.**
+For any task with 3+ logical steps (e.g., a bugfix that needs test, fix, and verification), write a todo list first. Mark each item as you finish it. This keeps you on track when tool responses push context.
+
+**3. Verify before declaring done.**
+Before saying "done", run the appropriate verification tool:
+- `run_tests` — the project's test suite must pass.
+- `run_lint` — no new lint errors on files you touched.
+- `run_typecheck` — no new type errors.
+
+For a bugfix, write a failing test *first*, then the fix, then confirm the test now passes. Do not skip the failing-first step — a test that was always green doesn't verify your fix.
+
+**4. Small, focused diffs.**
+Change only what the task requires. Unrelated "while I was here" edits make review harder and tests flakier.
+
+## Language notes
+
+**Go:** `gofmt`/`goimports` are enforced. Imports grouped: stdlib, then third-party, then local. Check with `run_lint` (uses golangci-lint).
+
+**Node:** Detect the package manager from the lockfile (`package-lock.json` → npm, `yarn.lock` → yarn, `pnpm-lock.yaml` → pnpm). Use the project's lockfile convention for install/add.
+
+**Python:** If the repo has a virtualenv (`.venv/`) or manages deps via Poetry (`pyproject.toml` with `[tool.poetry]`), activate/use it. Never `pip install` into the system Python.
+
+**Rust:** `cargo fmt` and `cargo clippy` before saying done; these map to `run_lint`.
+
+## Failure mode recovery
+
+- Tests fail after your edit → Read the test output, find the first failing assertion, understand the gap between expected and actual, make one focused fix, retest. Don't edit the test to make it pass unless the test itself was wrong.
+- Build fails (compile / type error) → Fix the compile error first before running tests. A failing build invalidates everything.
+- `Bash` returns non-zero unexpectedly → Read the full stderr before retrying. Infra errors (disk full, permission denied) need different treatment from code errors.
+
+## Not your job
+
+- Setting up the repo (it's already cloned at `/workspace`).
+- Installing new runtimes (the sandbox image ships pinned toolchains).
+- Remembering what you did in a previous session (you don't have one).

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -508,12 +508,37 @@ func (s *RuntimeConfigSpec) validateMCPServers() error {
 				Message: "MCP server name is required",
 			}
 		}
-		hasCmd := m.Command != ""
-		hasURL := m.URL != ""
-		if hasCmd == hasURL {
+		transports := 0
+		if m.Command != "" {
+			transports++
+		}
+		if m.URL != "" {
+			transports++
+		}
+		if m.Source != "" {
+			transports++
+		}
+		if transports != 1 {
 			return &ValidationError{
 				Field:   fmt.Sprintf("mcp_servers[%d]", i),
-				Message: "exactly one of 'command' (stdio) or 'url' (sse) must be set",
+				Message: "exactly one of 'command' (stdio), 'url' (sse), or 'source' (host-provisioned) must be set",
+			}
+		}
+		if m.Source != "" {
+			if m.Scope == "" {
+				return &ValidationError{
+					Field:   fmt.Sprintf("mcp_servers[%d].scope", i),
+					Message: "scope is required when source is set (run|scenario|session)",
+				}
+			}
+			switch m.Scope {
+			case "run", "scenario", "session":
+				// ok
+			default:
+				return &ValidationError{
+					Field:   fmt.Sprintf("mcp_servers[%d].scope", i),
+					Message: fmt.Sprintf("invalid scope %q (want run|scenario|session)", m.Scope),
+				}
 			}
 		}
 	}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -693,3 +693,80 @@ func TestRuntimeConfigSpec_Validate_MCPServerAcceptsSSE(t *testing.T) {
 		t.Fatalf("unexpected error for SSE-only config: %v", err)
 	}
 }
+
+func TestLoadRuntimeConfig_MCPServerSourceShape(t *testing.T) {
+	yaml := `
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: RuntimeConfig
+metadata:
+  name: mcp-source-test
+spec:
+  mcp_servers:
+    - name: sandbox
+      source: docker
+      scope: session
+      source_args:
+        image: ghcr.io/altairalabs/codegen-sandbox:latest
+        repo: "{{scenario.repo}}"
+`
+	path := writeTemp(t, "mcp-source.runtime.yaml", yaml)
+	rc, err := LoadRuntimeConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rc.Spec.MCPServers) != 1 {
+		t.Fatalf("want 1 server, got %d", len(rc.Spec.MCPServers))
+	}
+	got := rc.Spec.MCPServers[0]
+	if got.Source != "docker" {
+		t.Errorf("Source = %q, want %q", got.Source, "docker")
+	}
+	if got.Scope != "session" {
+		t.Errorf("Scope = %q, want %q", got.Scope, "session")
+	}
+	if got.SourceArgs["image"] != "ghcr.io/altairalabs/codegen-sandbox:latest" {
+		t.Errorf("SourceArgs[image] = %v", got.SourceArgs["image"])
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPServerRejectsMultipleTransports(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{
+			Name:   "x",
+			URL:    "https://x",
+			Source: "docker",
+			Scope:  "session",
+		}},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("expected error for multiple transports")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPServerSourceRequiresScope(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{Name: "x", Source: "docker"}},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for source without scope")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPServerSourceRejectsBadScope(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{Name: "x", Source: "docker", Scope: "bogus"}},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for invalid scope")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPServerAcceptsSource(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{Name: "x", Source: "docker", Scope: "session"}},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("unexpected error for source+scope config: %v", err)
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -169,9 +169,11 @@ type MCPToolFilter struct {
 
 // MCPServerConfig represents configuration for an MCP server.
 //
-// Exactly one transport must be specified: either Command (stdio — PromptKit
-// spawns a local subprocess) or URL (HTTP+SSE — PromptKit connects to a
-// remote server). Headers applies only to the SSE transport.
+// Exactly one transport must be specified:
+//   - Command: stdio (PromptKit spawns a local subprocess).
+//   - URL:     HTTP+SSE (connect to a running server).
+//   - Source:  host-provisioned (a named MCPSource opens the endpoint at
+//     a scope boundary). Requires Scope.
 type MCPServerConfig struct {
 	Name       string            `yaml:"name" json:"name"`
 	Command    string            `yaml:"command,omitempty" json:"command,omitempty"`
@@ -180,6 +182,9 @@ type MCPServerConfig struct {
 	WorkingDir string            `yaml:"working_dir,omitempty" json:"working_dir,omitempty"`
 	URL        string            `yaml:"url,omitempty" json:"url,omitempty"`
 	Headers    map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	Source     string            `yaml:"source,omitempty" json:"source,omitempty"`
+	Scope      string            `yaml:"scope,omitempty" json:"scope,omitempty"`
+	SourceArgs map[string]any    `yaml:"source_args,omitempty" json:"source_args,omitempty"`
 	TimeoutMs  int               `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
 	ToolFilter *MCPToolFilter    `yaml:"tool_filter,omitempty" json:"tool_filter,omitempty"`
 }

--- a/runtime/mcp/registry.go
+++ b/runtime/mcp/registry.go
@@ -115,6 +115,26 @@ func (r *RegistryImpl) RegisterServer(config ServerConfig) error {
 	return nil
 }
 
+// UnregisterServer closes the client if one exists, removes the server
+// from the registry, and prunes its tool-index entries. Unknown names
+// are no-ops; already-closed clients are not an error.
+func (r *RegistryImpl) UnregisterServer(name string) error {
+	r.mu.Lock()
+	client, hadClient := r.clients[name]
+	delete(r.clients, name)
+	delete(r.servers, name)
+	for tool, owner := range r.toolIndex {
+		if owner == name {
+			delete(r.toolIndex, tool)
+		}
+	}
+	r.mu.Unlock()
+	if hadClient {
+		_ = client.Close()
+	}
+	return nil
+}
+
 // GetClient returns an active client for the given server name
 func (r *RegistryImpl) GetClient(ctx context.Context, serverName string) (Client, error) {
 	// Check if client exists and is alive

--- a/runtime/mcp/registry.go
+++ b/runtime/mcp/registry.go
@@ -120,6 +120,10 @@ func (r *RegistryImpl) RegisterServer(config ServerConfig) error {
 // are no-ops; already-closed clients are not an error.
 func (r *RegistryImpl) UnregisterServer(name string) error {
 	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return fmt.Errorf("registry is closed")
+	}
 	client, hadClient := r.clients[name]
 	delete(r.clients, name)
 	delete(r.servers, name)
@@ -131,6 +135,7 @@ func (r *RegistryImpl) UnregisterServer(name string) error {
 	r.mu.Unlock()
 	if hadClient {
 		_ = client.Close()
+		r.releaseProcessSlot()
 	}
 	return nil
 }

--- a/runtime/mcp/registry_test.go
+++ b/runtime/mcp/registry_test.go
@@ -880,3 +880,47 @@ func (f *unregisterFakeClient) Close() error {
 	return nil
 }
 func (f *unregisterFakeClient) IsAlive() bool { return f.alive }
+
+func TestRegistry_UnregisterServer_ReleasesProcessSlot(t *testing.T) {
+	reg := NewRegistryWithOptions(RegistryOptions{MaxProcesses: 1})
+	reg.newClientFunc = func(c ServerConfig) Client {
+		return &unregisterFakeClient{alive: true}
+	}
+	require.NoError(t, reg.RegisterServer(ServerConfig{Name: "a", Command: "./foo"}))
+	_, err := reg.GetClient(context.Background(), "a")
+	require.NoError(t, err)
+	require.NoError(t, reg.UnregisterServer("a"))
+
+	// Previously the slot was leaked; now we should be able to register+get a second server.
+	require.NoError(t, reg.RegisterServer(ServerConfig{Name: "b", Command: "./bar"}))
+	_, err = reg.GetClient(context.Background(), "b")
+	require.NoError(t, err)
+}
+
+func TestRegistry_UnregisterServer_PrunesToolIndex(t *testing.T) {
+	reg := NewRegistry()
+	// Seed toolIndex directly (package-internal access — white-box).
+	reg.mu.Lock()
+	reg.toolIndex["tool_a"] = "server-1"
+	reg.toolIndex["tool_b"] = "server-1"
+	reg.toolIndex["tool_c"] = "server-2"
+	reg.servers["server-1"] = ServerConfig{Name: "server-1", Command: "./x"}
+	reg.servers["server-2"] = ServerConfig{Name: "server-2", Command: "./y"}
+	reg.mu.Unlock()
+
+	require.NoError(t, reg.UnregisterServer("server-1"))
+
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	assert.NotContains(t, reg.toolIndex, "tool_a")
+	assert.NotContains(t, reg.toolIndex, "tool_b")
+	assert.Equal(t, "server-2", reg.toolIndex["tool_c"])
+}
+
+func TestRegistry_UnregisterServer_AfterClose(t *testing.T) {
+	reg := NewRegistry()
+	require.NoError(t, reg.Close())
+	err := reg.UnregisterServer("x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "closed")
+}

--- a/runtime/mcp/registry_test.go
+++ b/runtime/mcp/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -826,3 +827,56 @@ func TestRegistry_NewClientFunc_DispatchesByTransport(t *testing.T) {
 	_, ok = c.(*StdioClient)
 	assert.True(t, ok, "expected *StdioClient fallback, got %T", c)
 }
+
+func TestRegistry_UnregisterServer(t *testing.T) {
+	reg := NewRegistry()
+	require.NoError(t, reg.RegisterServer(ServerConfig{Name: "x", Command: "./foo"}))
+	require.Contains(t, reg.ListServers(), "x")
+
+	require.NoError(t, reg.UnregisterServer("x"))
+	assert.NotContains(t, reg.ListServers(), "x")
+
+	// Unregistering an unknown server is a no-op.
+	require.NoError(t, reg.UnregisterServer("unknown"))
+}
+
+func TestRegistry_UnregisterServer_ClosesClient(t *testing.T) {
+	reg := NewRegistry()
+	closed := make(chan struct{})
+	reg.newClientFunc = func(c ServerConfig) Client {
+		return &unregisterFakeClient{onClose: func() { close(closed) }, alive: true}
+	}
+	require.NoError(t, reg.RegisterServer(ServerConfig{Name: "x", Command: "./foo"}))
+
+	_, err := reg.GetClient(context.Background(), "x")
+	require.NoError(t, err)
+
+	require.NoError(t, reg.UnregisterServer("x"))
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("UnregisterServer did not close the client")
+	}
+}
+
+type unregisterFakeClient struct {
+	onClose func()
+	alive   bool
+}
+
+func (f *unregisterFakeClient) Initialize(context.Context) (*InitializeResponse, error) {
+	f.alive = true
+	return &InitializeResponse{}, nil
+}
+func (f *unregisterFakeClient) ListTools(context.Context) ([]Tool, error) { return nil, nil }
+func (f *unregisterFakeClient) CallTool(context.Context, string, json.RawMessage) (*ToolCallResponse, error) {
+	return &ToolCallResponse{}, nil
+}
+func (f *unregisterFakeClient) Close() error {
+	if f.onClose != nil {
+		f.onClose()
+	}
+	f.alive = false
+	return nil
+}
+func (f *unregisterFakeClient) IsAlive() bool { return f.alive }

--- a/runtime/mcp/types.go
+++ b/runtime/mcp/types.go
@@ -223,6 +223,10 @@ type Registry interface {
 	// RegisterServer adds a new MCP server configuration
 	RegisterServer(config ServerConfig) error
 
+	// UnregisterServer closes the client (if any) and removes the server
+	// from the registry. Unknown names are no-ops.
+	UnregisterServer(name string) error
+
 	// GetClient returns an active client for the given server name
 	GetClient(ctx context.Context, serverName string) (Client, error)
 

--- a/runtime/tools/mcp_executor_test.go
+++ b/runtime/tools/mcp_executor_test.go
@@ -52,6 +52,10 @@ func (m *mockMCPRegistry) RegisterServer(config mcp.ServerConfig) error {
 	return nil
 }
 
+func (m *mockMCPRegistry) UnregisterServer(name string) error {
+	return nil
+}
+
 func (m *mockMCPRegistry) GetClient(ctx context.Context, serverName string) (mcp.Client, error) {
 	return &mockMCPClient{}, nil
 }

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1105,6 +1105,24 @@
         "working_dir": {
           "type": "string"
         },
+        "url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "source": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        },
+        "source_args": {
+          "type": "object"
+        },
         "timeout_ms": {
           "type": "integer"
         },
@@ -1115,8 +1133,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "name",
-        "command"
+        "name"
       ]
     },
     "MCPToolFilter": {

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -322,6 +322,24 @@
         "working_dir": {
           "type": "string"
         },
+        "url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "source": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        },
+        "source_args": {
+          "type": "object"
+        },
         "timeout_ms": {
           "type": "integer"
         },
@@ -332,8 +350,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "name",
-        "command"
+        "name"
       ]
     },
     "MCPToolFilter": {

--- a/sdk/mcp_test.go
+++ b/sdk/mcp_test.go
@@ -32,6 +32,10 @@ func (m *mockMCPRegistry) RegisterServer(config mcp.ServerConfig) error {
 	return nil
 }
 
+func (m *mockMCPRegistry) UnregisterServer(name string) error {
+	return nil
+}
+
 func (m *mockMCPRegistry) GetClient(ctx context.Context, serverName string) (mcp.Client, error) {
 	return &mockMCPClient{registry: m}, nil
 }

--- a/tools/arena/engine/builder_additional_test.go
+++ b/tools/arena/engine/builder_additional_test.go
@@ -139,6 +139,25 @@ func TestBuildMCPRegistry_PropagatesSSEFields(t *testing.T) {
 	require.Empty(t, got.Command)
 }
 
+// TestBuildMCPRegistry_SkipsSourceBackedEntries verifies that MCP servers
+// with a Source field are NOT registered statically — they are opened
+// dynamically by mcpSourceScope at scope boundaries (run/scenario/session).
+func TestBuildMCPRegistry_SkipsSourceBackedEntries(t *testing.T) {
+	cfg := &config.Config{
+		MCPServers: []config.MCPServerConfig{
+			{Name: "stdio-x", Command: "./foo"},
+			{Name: "source-y", Source: "docker", Scope: "session"},
+		},
+	}
+	registry, err := buildMCPRegistry(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, registry)
+
+	servers := registry.ListServers()
+	assert.Contains(t, servers, "stdio-x")
+	assert.NotContains(t, servers, "source-y")
+}
+
 func TestBuildSelfPlayComponents_Success(t *testing.T) {
 	cfg := &config.Config{
 		LoadedProviders: map[string]*config.Provider{

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -35,6 +35,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/storage"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/tools/arena/adapters"
+	_ "github.com/AltairaLabs/PromptKit/tools/arena/mcpsource/docker/register" // register docker MCPSource
 	"github.com/AltairaLabs/PromptKit/tools/arena/selfplay"
 	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
 	"github.com/AltairaLabs/PromptKit/tools/arena/turnexecutors"
@@ -554,6 +555,11 @@ func buildMCPRegistry(cfg *config.Config) (*mcp.RegistryImpl, error) {
 	registry := mcp.NewRegistry()
 
 	for _, serverCfg := range cfg.MCPServers {
+		if serverCfg.Source != "" {
+			// Source-backed entries are opened dynamically by mcpSourceScope
+			// at run/scenario/session boundaries — not registered statically.
+			continue
+		}
 		mcpServerConfig := mcp.ServerConfig{
 			Name:       serverCfg.Name,
 			Command:    serverCfg.Command,

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -46,6 +46,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 	"github.com/AltairaLabs/PromptKit/tools/arena/adapters"
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
 	arenastore "github.com/AltairaLabs/PromptKit/tools/arena/statestore"
 )
 
@@ -87,6 +88,10 @@ type Engine struct {
 	skillExecutor        SkillFilterer                // Optional — set when skills are configured
 	memoryStore          *memory.InMemoryStore        // Optional memory store (set if config.Memory != nil)
 	recordingConfig      *stage.RecordingStageConfig  // Optional — enables RecordingStage in pipelines
+	// mcpSourceScope manages source-backed MCP entries at run/scenario/session scopes.
+	mcpSourceScope  *mcpSourceScope
+	mcpConfig       []config.MCPServerConfig   // Source-backed MCP entries, re-read at each scope boundary
+	mcpSkillSources []prompt.SkillSourceConfig // Skill sources to mount into source-backed MCP servers
 }
 
 // NewEngineFromConfigFile creates a new simulation engine from a configuration file.
@@ -209,7 +214,7 @@ func NewEngine(
 		return nil, fmt.Errorf("failed to build media storage: %w", err)
 	}
 
-	return &Engine{
+	eng := &Engine{
 		config:               cfg,
 		providerRegistry:     providerRegistry,
 		promptRegistry:       promptRegistry,
@@ -222,7 +227,24 @@ func NewEngine(
 		evals:                cfg.LoadedEvals,
 		providers:            cfg.LoadedProviders,
 		personas:             cfg.LoadedPersonas,
-	}, nil
+		mcpConfig:            cfg.MCPServers,
+		mcpSkillSources:      cfg.LoadedSkillSources,
+	}
+
+	// Wire the source-backed MCP scope manager when a registry is available.
+	// Run-scoped sources open at engine construction; they're typically fast.
+	// If slow sources become common, thread ctx through NewEngine.
+	if mcpRegistry != nil {
+		eng.mcpSourceScope = newMCPSourceScope(mcpRegistry)
+		if err := eng.mcpSourceScope.OpenAll(
+			context.Background(), mcpsource.ScopeRun, "run", nil,
+			eng.mcpSkillSources, eng.mcpConfig,
+		); err != nil {
+			return nil, fmt.Errorf("open run-scoped MCP sources: %w", err)
+		}
+	}
+
+	return eng, nil
 }
 
 // Close shuts down the engine and cleans up resources.
@@ -231,6 +253,13 @@ func NewEngine(
 func (e *Engine) Close() error {
 	if e.a2aCleanup != nil {
 		e.a2aCleanup()
+	}
+
+	// Close run-scoped MCP sources before tearing down the underlying registry.
+	if e.mcpSourceScope != nil {
+		for _, cerr := range e.mcpSourceScope.CloseAll(mcpsource.ScopeRun, "run") {
+			logger.Warn("mcp source close failed (run scope)", "error", cerr)
+		}
 	}
 
 	if err := e.closeMCPRegistry(); err != nil {

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -405,6 +405,13 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 		defer e.workflowTransExec.UnregisterRun(runID)
 	}
 
+	// Open scenario + session scoped MCPSource entries; cleanup runs via defer.
+	mcpCleanup, mcpErr := e.openScenarioSessionMCPSources(runCtx, scenario, combo.ScenarioID, runID)
+	if mcpErr != nil {
+		return saveError(mcpErr.Error())
+	}
+	defer mcpCleanup()
+
 	// Get provider
 	provider, exists := e.providerRegistry.Get(combo.ProviderID)
 	if !exists {

--- a/tools/arena/engine/execution_mcpsource.go
+++ b/tools/arena/engine/execution_mcpsource.go
@@ -1,0 +1,77 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
+)
+
+// scenarioVariables extracts a string map from the scenario's variables block
+// for use in MCP source arg templating ({{scenario.<key>}} expansion).
+// Returns nil when the scenario is nil or has no variables.
+func scenarioVariables(sc *config.Scenario) map[string]string {
+	if sc == nil || len(sc.Variables) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(sc.Variables))
+	for k, v := range sc.Variables {
+		out[k] = v
+	}
+	return out
+}
+
+// openScenarioSessionMCPSources opens scenario- and session-scoped MCPSource
+// entries for this run. The returned cleanup closure must be called (via
+// defer) to tear down the opens; it's always safe to call even on the
+// success-return path. When no source-backed entries are configured, the
+// cleanup is a no-op.
+//
+// Each executeRun invocation is one session (= one trial); scenario scope
+// is opened and torn down per invocation because arena runs scenarios
+// concurrently, so there's no natural "scenario start / scenario end"
+// across multiple combinations.
+func (e *Engine) openScenarioSessionMCPSources(
+	ctx context.Context,
+	scenario *config.Scenario,
+	scenarioID, runID string,
+) (cleanup func(), err error) {
+	cleanup = func() {}
+	if e.mcpSourceScope == nil || len(e.mcpConfig) == 0 {
+		return cleanup, nil
+	}
+
+	scenarioVars := scenarioVariables(scenario)
+	if openErr := e.mcpSourceScope.OpenAll(
+		ctx, mcpsource.ScopeScenario, scenarioID, scenarioVars,
+		e.mcpSkillSources, e.mcpConfig,
+	); openErr != nil {
+		return cleanup, fmt.Errorf("open scenario-scoped MCP sources: %v", openErr)
+	}
+	closeScenario := func() {
+		for _, cerr := range e.mcpSourceScope.CloseAll(mcpsource.ScopeScenario, scenarioID) {
+			logger.Warn("mcp source close failed (scenario scope)", "error", cerr)
+		}
+	}
+
+	if openErr := e.mcpSourceScope.OpenAll(
+		ctx, mcpsource.ScopeSession, runID, scenarioVars,
+		e.mcpSkillSources, e.mcpConfig,
+	); openErr != nil {
+		// Roll back the scenario open before returning.
+		closeScenario()
+		return cleanup, fmt.Errorf("open session-scoped MCP sources: %v", openErr)
+	}
+	closeSession := func() {
+		for _, cerr := range e.mcpSourceScope.CloseAll(mcpsource.ScopeSession, runID) {
+			logger.Warn("mcp source close failed (session scope)", "error", cerr)
+		}
+	}
+
+	return func() {
+		closeSession()
+		closeScenario()
+	}, nil
+}

--- a/tools/arena/engine/mcpsource_scope.go
+++ b/tools/arena/engine/mcpsource_scope.go
@@ -1,0 +1,243 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
+)
+
+// openEntry tracks one open (scope, instance, server-name) triple so
+// CloseAll can find and tear it down.
+//
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+type openEntry struct {
+	serverName string
+	closer     io.Closer
+}
+
+// mcpSourceScope manages per-scope open/close of source-backed MCP entries.
+// The zero value is not usable; use newMCPSourceScope.
+//
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+type mcpSourceScope struct {
+	registry mcp.Registry
+
+	mu    sync.Mutex
+	opens map[string][]openEntry // keyed by "<scope>|<instanceID>"
+}
+
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func newMCPSourceScope(registry mcp.Registry) *mcpSourceScope {
+	return &mcpSourceScope{
+		registry: registry,
+		opens:    map[string][]openEntry{},
+	}
+}
+
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func scopeKey(scope mcpsource.Scope, instanceID string) string {
+	return string(scope) + "|" + instanceID
+}
+
+// OpenAll opens every entry whose Scope matches. Scenario variables are
+// expanded into SourceArgs, and (if any skill sources are provided) mount
+// entries are injected. Partial failures roll back any opens already
+// performed in this call.
+//
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func (m *mcpSourceScope) OpenAll(
+	ctx context.Context,
+	scope mcpsource.Scope,
+	instanceID string,
+	scenarioVars map[string]string,
+	skillSources []prompt.SkillSourceConfig,
+	entries []config.MCPServerConfig,
+) error {
+	var opened []openEntry
+	rollback := func() {
+		for i := len(opened) - 1; i >= 0; i-- {
+			_ = opened[i].closer.Close()
+			_ = m.registry.UnregisterServer(opened[i].serverName)
+		}
+	}
+
+	mounts := buildSkillMounts(skillSources)
+
+	for i := range entries {
+		entry := entries[i] // local copy; we may mutate SourceArgs below
+		if entry.Source == "" || string(scope) != entry.Scope {
+			continue
+		}
+		prepareEntryArgs(&entry, scenarioVars, mounts)
+		oe, err := m.openOne(ctx, &entry)
+		if err != nil {
+			rollback()
+			return err
+		}
+		opened = append(opened, oe)
+	}
+
+	if len(opened) == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	key := scopeKey(scope, instanceID)
+	m.opens[key] = append(m.opens[key], opened...)
+	m.mu.Unlock()
+	return nil
+}
+
+// prepareEntryArgs expands scenario templates in entry.SourceArgs and
+// injects skill mounts. Mutates entry in place (caller passes a local copy).
+//
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func prepareEntryArgs(entry *config.MCPServerConfig, scenarioVars map[string]string, mounts []map[string]any) {
+	args := expandArgs(entry.SourceArgs, scenarioVars)
+	if args == nil && len(mounts) > 0 {
+		args = map[string]any{}
+	}
+	entry.SourceArgs = args
+	injectMountsIntoArgs(entry, mounts)
+}
+
+// openOne looks up the named source, calls Open, and registers the
+// resulting URL+Headers with the MCP registry.
+//
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func (m *mcpSourceScope) openOne(ctx context.Context, entry *config.MCPServerConfig) (openEntry, error) {
+	src, ok := mcpsource.LookupMCPSource(entry.Source)
+	if !ok {
+		return openEntry{}, fmt.Errorf(
+			"mcp server %q: unknown source %q (registered: %s)",
+			entry.Name, entry.Source, strings.Join(mcpsource.ListMCPSources(), ", "),
+		)
+	}
+	conn, closer, err := src.Open(ctx, entry.SourceArgs)
+	if err != nil {
+		return openEntry{}, fmt.Errorf("mcp server %q: source %q Open failed: %w", entry.Name, entry.Source, err)
+	}
+	if err := m.registry.RegisterServer(mcp.ServerConfig{
+		Name:      entry.Name,
+		URL:       conn.URL,
+		Headers:   conn.Headers,
+		TimeoutMs: entry.TimeoutMs,
+	}); err != nil {
+		_ = closer.Close()
+		return openEntry{}, fmt.Errorf("mcp server %q: register after Open failed: %w", entry.Name, err)
+	}
+	return openEntry{serverName: entry.Name, closer: closer}, nil
+}
+
+// CloseAll tears down every entry opened for (scope, instanceID). Close
+// errors are collected and returned; registry entries are removed regardless.
+//
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func (m *mcpSourceScope) CloseAll(scope mcpsource.Scope, instanceID string) []error {
+	m.mu.Lock()
+	key := scopeKey(scope, instanceID)
+	entries := m.opens[key]
+	delete(m.opens, key)
+	m.mu.Unlock()
+
+	var errs []error
+	for i := len(entries) - 1; i >= 0; i-- {
+		if err := entries[i].closer.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close %q: %w", entries[i].serverName, err))
+		}
+		_ = m.registry.UnregisterServer(entries[i].serverName)
+	}
+	return errs
+}
+
+// --- Args templating (Task 5 responsibilities) ---
+
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func expandArgs(args map[string]any, vars map[string]string) map[string]any {
+	if args == nil {
+		return nil
+	}
+	out := make(map[string]any, len(args))
+	for k, v := range args {
+		out[k] = expandArgValue(v, vars)
+	}
+	return out
+}
+
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func expandArgValue(v any, vars map[string]string) any {
+	switch x := v.(type) {
+	case string:
+		return expandString(x, vars)
+	case map[string]any:
+		return expandArgs(x, vars)
+	case []any:
+		out := make([]any, len(x))
+		for i, elem := range x {
+			out[i] = expandArgValue(elem, vars)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func expandString(s string, vars map[string]string) string {
+	for k, v := range vars {
+		s = strings.ReplaceAll(s, "{{scenario."+k+"}}", v)
+	}
+	return s
+}
+
+// --- Skill-mount injection (Task 9 responsibilities) ---
+
+// buildSkillMounts converts skill sources to mount entries suitable for a
+// MCPSource args map. Each skill dir is mounted at /skills/<name> read-only.
+// Sources without a name or directory are skipped (inline skills produce no
+// mount — they're passed to the runtime via a different path).
+//
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func buildSkillMounts(sources []prompt.SkillSourceConfig) []map[string]any {
+	if len(sources) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(sources))
+	for i := range sources {
+		s := sources[i]
+		dir := s.EffectiveDir()
+		if dir == "" || s.Name == "" {
+			continue
+		}
+		out = append(out, map[string]any{
+			"source":   dir, // absolute host path
+			"target":   "/skills/" + s.Name,
+			"readonly": true,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// injectMountsIntoArgs adds mounts to entry.SourceArgs under the "mounts"
+// key, preserving existing args. Empty mounts is a no-op (the key is not
+// added), so sources that don't understand mounts don't see it.
+//
+//nolint:unused // wired up in Task 6 (engine.go / execution.go)
+func injectMountsIntoArgs(entry *config.MCPServerConfig, mounts []map[string]any) {
+	if len(mounts) == 0 {
+		return
+	}
+	if entry.SourceArgs == nil {
+		entry.SourceArgs = map[string]any{}
+	}
+	entry.SourceArgs["mounts"] = mounts
+}

--- a/tools/arena/engine/mcpsource_scope.go
+++ b/tools/arena/engine/mcpsource_scope.go
@@ -15,8 +15,6 @@ import (
 
 // openEntry tracks one open (scope, instance, server-name) triple so
 // CloseAll can find and tear it down.
-//
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 type openEntry struct {
 	serverName string
 	closer     io.Closer
@@ -24,8 +22,6 @@ type openEntry struct {
 
 // mcpSourceScope manages per-scope open/close of source-backed MCP entries.
 // The zero value is not usable; use newMCPSourceScope.
-//
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 type mcpSourceScope struct {
 	registry mcp.Registry
 
@@ -33,7 +29,6 @@ type mcpSourceScope struct {
 	opens map[string][]openEntry // keyed by "<scope>|<instanceID>"
 }
 
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func newMCPSourceScope(registry mcp.Registry) *mcpSourceScope {
 	return &mcpSourceScope{
 		registry: registry,
@@ -41,7 +36,6 @@ func newMCPSourceScope(registry mcp.Registry) *mcpSourceScope {
 	}
 }
 
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func scopeKey(scope mcpsource.Scope, instanceID string) string {
 	return string(scope) + "|" + instanceID
 }
@@ -50,8 +44,6 @@ func scopeKey(scope mcpsource.Scope, instanceID string) string {
 // expanded into SourceArgs, and (if any skill sources are provided) mount
 // entries are injected. Partial failures roll back any opens already
 // performed in this call.
-//
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func (m *mcpSourceScope) OpenAll(
 	ctx context.Context,
 	scope mcpsource.Scope,
@@ -96,8 +88,6 @@ func (m *mcpSourceScope) OpenAll(
 
 // prepareEntryArgs expands scenario templates in entry.SourceArgs and
 // injects skill mounts. Mutates entry in place (caller passes a local copy).
-//
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func prepareEntryArgs(entry *config.MCPServerConfig, scenarioVars map[string]string, mounts []map[string]any) {
 	args := expandArgs(entry.SourceArgs, scenarioVars)
 	if args == nil && len(mounts) > 0 {
@@ -109,8 +99,6 @@ func prepareEntryArgs(entry *config.MCPServerConfig, scenarioVars map[string]str
 
 // openOne looks up the named source, calls Open, and registers the
 // resulting URL+Headers with the MCP registry.
-//
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func (m *mcpSourceScope) openOne(ctx context.Context, entry *config.MCPServerConfig) (openEntry, error) {
 	src, ok := mcpsource.LookupMCPSource(entry.Source)
 	if !ok {
@@ -137,8 +125,6 @@ func (m *mcpSourceScope) openOne(ctx context.Context, entry *config.MCPServerCon
 
 // CloseAll tears down every entry opened for (scope, instanceID). Close
 // errors are collected and returned; registry entries are removed regardless.
-//
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func (m *mcpSourceScope) CloseAll(scope mcpsource.Scope, instanceID string) []error {
 	m.mu.Lock()
 	key := scopeKey(scope, instanceID)
@@ -158,7 +144,6 @@ func (m *mcpSourceScope) CloseAll(scope mcpsource.Scope, instanceID string) []er
 
 // --- Args templating (Task 5 responsibilities) ---
 
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func expandArgs(args map[string]any, vars map[string]string) map[string]any {
 	if args == nil {
 		return nil
@@ -170,7 +155,6 @@ func expandArgs(args map[string]any, vars map[string]string) map[string]any {
 	return out
 }
 
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func expandArgValue(v any, vars map[string]string) any {
 	switch x := v.(type) {
 	case string:
@@ -188,7 +172,6 @@ func expandArgValue(v any, vars map[string]string) any {
 	}
 }
 
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func expandString(s string, vars map[string]string) string {
 	for k, v := range vars {
 		s = strings.ReplaceAll(s, "{{scenario."+k+"}}", v)
@@ -202,8 +185,6 @@ func expandString(s string, vars map[string]string) string {
 // MCPSource args map. Each skill dir is mounted at /skills/<name> read-only.
 // Sources without a name or directory are skipped (inline skills produce no
 // mount — they're passed to the runtime via a different path).
-//
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func buildSkillMounts(sources []prompt.SkillSourceConfig) []map[string]any {
 	if len(sources) == 0 {
 		return nil
@@ -230,8 +211,6 @@ func buildSkillMounts(sources []prompt.SkillSourceConfig) []map[string]any {
 // injectMountsIntoArgs adds mounts to entry.SourceArgs under the "mounts"
 // key, preserving existing args. Empty mounts is a no-op (the key is not
 // added), so sources that don't understand mounts don't see it.
-//
-//nolint:unused // wired up in Task 6 (engine.go / execution.go)
 func injectMountsIntoArgs(entry *config.MCPServerConfig, mounts []map[string]any) {
 	if len(mounts) == 0 {
 		return

--- a/tools/arena/engine/mcpsource_scope_integration_test.go
+++ b/tools/arena/engine/mcpsource_scope_integration_test.go
@@ -1,0 +1,193 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// counterSource is a minimal MCPSource that counts opens/closes for
+// integration tests of scope hooks.
+type counterSource struct {
+	opens  atomic.Int32
+	closes atomic.Int32
+}
+
+func (c *counterSource) Open(_ context.Context, _ map[string]any) (mcpsource.MCPConn, io.Closer, error) {
+	c.opens.Add(1)
+	return mcpsource.MCPConn{URL: "http://fake"}, closerFunc(func() error {
+		c.closes.Add(1)
+		return nil
+	}), nil
+}
+
+// TestScopeHooks_SessionOpenedPerRepetition simulates N session cycles
+// (each representing one arena repetition/trial) and verifies the
+// source is opened and closed exactly once per cycle.
+func TestScopeHooks_SessionOpenedPerRepetition(t *testing.T) {
+	s := &counterSource{}
+	mcpsource.RegisterMCPSource("rec-integration-sess", s)
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+
+	entries := []config.MCPServerConfig{{
+		Name:   "sbox",
+		Source: "rec-integration-sess",
+		Scope:  "session",
+	}}
+
+	for i := 0; i < 3; i++ {
+		sessionID := fmt.Sprintf("s%d", i)
+		require.NoError(t, mgr.OpenAll(
+			context.Background(), mcpsource.ScopeSession, sessionID, nil, nil, entries))
+		errs := mgr.CloseAll(mcpsource.ScopeSession, sessionID)
+		require.Empty(t, errs)
+	}
+
+	assert.Equal(t, int32(3), s.opens.Load())
+	assert.Equal(t, int32(3), s.closes.Load())
+}
+
+// TestScenarioVariables_NilAndEmpty verifies the helper handles the
+// nil-scenario and empty-variables cases without allocation.
+func TestScenarioVariables_NilAndEmpty(t *testing.T) {
+	assert.Nil(t, scenarioVariables(nil))
+	assert.Nil(t, scenarioVariables(&config.Scenario{}))
+	assert.Nil(t, scenarioVariables(&config.Scenario{Variables: map[string]string{}}))
+}
+
+// TestScenarioVariables_CopiesVariables verifies the helper returns a
+// copy of the scenario's Variables map (mutations don't leak back).
+func TestScenarioVariables_CopiesVariables(t *testing.T) {
+	sc := &config.Scenario{Variables: map[string]string{
+		"repo":   "github.com/x/y",
+		"branch": "main",
+	}}
+	got := scenarioVariables(sc)
+	assert.Equal(t, "github.com/x/y", got["repo"])
+	assert.Equal(t, "main", got["branch"])
+
+	got["repo"] = "mutated"
+	assert.Equal(t, "github.com/x/y", sc.Variables["repo"],
+		"scenarioVariables should return a defensive copy")
+}
+
+// TestOpenScenarioSessionMCPSources_NoOpWhenUnconfigured verifies the
+// helper is a no-op when either the scope manager or MCP config is empty.
+func TestOpenScenarioSessionMCPSources_NoOpWhenUnconfigured(t *testing.T) {
+	e := &Engine{}
+	cleanup, err := e.openScenarioSessionMCPSources(context.Background(), nil, "scn", "run1")
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	cleanup() // must not panic
+
+	// With a scope manager but no config entries, still a no-op.
+	reg := mcp.NewRegistry()
+	e = &Engine{mcpSourceScope: newMCPSourceScope(reg)}
+	cleanup, err = e.openScenarioSessionMCPSources(context.Background(), nil, "scn", "run1")
+	require.NoError(t, err)
+	cleanup()
+}
+
+// TestOpenScenarioSessionMCPSources_OpensAndCloses verifies the helper
+// opens scenario- and session-scoped entries for a configured source
+// and that the cleanup closer tears both scopes down.
+func TestOpenScenarioSessionMCPSources_OpensAndCloses(t *testing.T) {
+	scn := &counterSource{}
+	ses := &counterSource{}
+	mcpsource.RegisterMCPSource("rec-exec-open-scn", scn)
+	mcpsource.RegisterMCPSource("rec-exec-open-ses", ses)
+
+	reg := mcp.NewRegistry()
+	e := &Engine{
+		mcpSourceScope: newMCPSourceScope(reg),
+		mcpConfig: []config.MCPServerConfig{
+			{Name: "a", Source: "rec-exec-open-scn", Scope: "scenario"},
+			{Name: "b", Source: "rec-exec-open-ses", Scope: "session"},
+		},
+	}
+
+	scenario := &config.Scenario{Variables: map[string]string{"k": "v"}}
+	cleanup, err := e.openScenarioSessionMCPSources(
+		context.Background(), scenario, "scenario-1", "run-xyz")
+	require.NoError(t, err)
+	assert.Contains(t, reg.ListServers(), "a")
+	assert.Contains(t, reg.ListServers(), "b")
+
+	cleanup()
+	assert.Equal(t, int32(1), scn.closes.Load())
+	assert.Equal(t, int32(1), ses.closes.Load())
+	assert.NotContains(t, reg.ListServers(), "a")
+	assert.NotContains(t, reg.ListServers(), "b")
+}
+
+// TestOpenScenarioSessionMCPSources_RollsBackScenarioOnSessionFailure
+// verifies that if session-scope open fails after scenario-scope open
+// succeeds, the scenario-scope entries are torn down before the helper
+// returns (preventing leaks on the error path).
+func TestOpenScenarioSessionMCPSources_RollsBackScenarioOnSessionFailure(t *testing.T) {
+	scn := &counterSource{}
+	mcpsource.RegisterMCPSource("rec-exec-rollback-scn", scn)
+
+	reg := mcp.NewRegistry()
+	e := &Engine{
+		mcpSourceScope: newMCPSourceScope(reg),
+		mcpConfig: []config.MCPServerConfig{
+			{Name: "a", Source: "rec-exec-rollback-scn", Scope: "scenario"},
+			// Session entry points at a non-existent source, forcing failure.
+			{Name: "b", Source: "no-such-source-exec-rollback", Scope: "session"},
+		},
+	}
+
+	cleanup, err := e.openScenarioSessionMCPSources(
+		context.Background(), nil, "scenario-rb", "run-rb")
+	require.Error(t, err)
+	require.NotNil(t, cleanup) // always safe to call
+	cleanup()                  // no-op on the error path
+
+	// Scenario was opened once and closed during rollback; registry must be clean.
+	assert.Equal(t, int32(1), scn.opens.Load())
+	assert.Equal(t, int32(1), scn.closes.Load())
+	assert.NotContains(t, reg.ListServers(), "a")
+	assert.NotContains(t, reg.ListServers(), "b")
+}
+
+// TestScopeHooks_ScenarioScopeSharedAcrossRepetitions verifies that a
+// source with scope=scenario is opened exactly once even when multiple
+// session cycles run inside. Session opens for an unrelated scope must
+// not trigger the scenario-scoped source.
+func TestScopeHooks_ScenarioScopeSharedAcrossRepetitions(t *testing.T) {
+	s := &counterSource{}
+	mcpsource.RegisterMCPSource("rec-integration-scn", s)
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+
+	entries := []config.MCPServerConfig{{
+		Name:   "sbox",
+		Source: "rec-integration-scn",
+		Scope:  "scenario",
+	}}
+
+	// Scenario opens once; multiple session cycles inside.
+	require.NoError(t, mgr.OpenAll(
+		context.Background(), mcpsource.ScopeScenario, "scn", nil, nil, entries))
+	for i := 0; i < 3; i++ {
+		require.NoError(t, mgr.OpenAll(
+			context.Background(), mcpsource.ScopeSession, "s", nil, nil, entries))
+		mgr.CloseAll(mcpsource.ScopeSession, "s")
+	}
+	errs := mgr.CloseAll(mcpsource.ScopeScenario, "scn")
+	require.Empty(t, errs)
+
+	// Session opens are 0 because the entry's scope is "scenario".
+	assert.Equal(t, int32(1), s.opens.Load())
+	assert.Equal(t, int32(1), s.closes.Load())
+}

--- a/tools/arena/engine/mcpsource_scope_test.go
+++ b/tools/arena/engine/mcpsource_scope_test.go
@@ -1,0 +1,243 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingSource struct {
+	opens    atomic.Int32
+	closes   atomic.Int32
+	lastArgs map[string]any
+	fail     error
+}
+
+func (s *recordingSource) Open(_ context.Context, args map[string]any) (mcpsource.MCPConn, io.Closer, error) {
+	if s.fail != nil {
+		return mcpsource.MCPConn{}, nil, s.fail
+	}
+	s.opens.Add(1)
+	s.lastArgs = args
+	return mcpsource.MCPConn{
+			URL:     "http://fake",
+			Headers: map[string]string{"X-Args": "ok"},
+		},
+		closerFunc(func() error { s.closes.Add(1); return nil }),
+		nil
+}
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
+
+func TestMCPSourceScope_OpenAndClose(t *testing.T) {
+	mcpsource.RegisterMCPSource("rec-scope-basic", &recordingSource{})
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+
+	cfg := config.MCPServerConfig{
+		Name:       "x",
+		Source:     "rec-scope-basic",
+		Scope:      "scenario",
+		SourceArgs: map[string]any{"image": "foo"},
+	}
+	require.NoError(t, mgr.OpenAll(
+		context.Background(), mcpsource.ScopeScenario, "scn1", nil, nil,
+		[]config.MCPServerConfig{cfg}))
+
+	assert.Contains(t, reg.ListServers(), "x")
+
+	errs := mgr.CloseAll(mcpsource.ScopeScenario, "scn1")
+	require.Empty(t, errs)
+	assert.NotContains(t, reg.ListServers(), "x")
+}
+
+func TestMCPSourceScope_UnknownSource(t *testing.T) {
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+
+	cfg := config.MCPServerConfig{Name: "x", Source: "no-such-source-registered", Scope: "session"}
+	err := mgr.OpenAll(
+		context.Background(), mcpsource.ScopeSession, "s1", nil, nil,
+		[]config.MCPServerConfig{cfg})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no-such-source-registered")
+}
+
+func TestMCPSourceScope_PartialOpenRollsBack(t *testing.T) {
+	good := &recordingSource{}
+	bad := &recordingSource{fail: errors.New("boom")}
+	mcpsource.RegisterMCPSource("rec-scope-good", good)
+	mcpsource.RegisterMCPSource("rec-scope-bad", bad)
+
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+
+	entries := []config.MCPServerConfig{
+		{Name: "a", Source: "rec-scope-good", Scope: "session"},
+		{Name: "b", Source: "rec-scope-bad", Scope: "session"},
+	}
+	err := mgr.OpenAll(
+		context.Background(), mcpsource.ScopeSession, "rb-s1", nil, nil, entries)
+	require.Error(t, err)
+	assert.Equal(t, int32(1), good.opens.Load())
+	assert.Equal(t, int32(1), good.closes.Load(), "good source closer should have run during rollback")
+	assert.NotContains(t, reg.ListServers(), "a")
+	assert.NotContains(t, reg.ListServers(), "b")
+}
+
+func TestMCPSourceScope_CloseNotOpenedNoop(t *testing.T) {
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+	errs := mgr.CloseAll(mcpsource.ScopeRun, "never-opened")
+	assert.Empty(t, errs)
+}
+
+func TestMCPSourceScope_OnlyOpensMatchingScope(t *testing.T) {
+	s := &recordingSource{}
+	mcpsource.RegisterMCPSource("rec-scope-filter", s)
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+
+	entries := []config.MCPServerConfig{
+		{Name: "ses", Source: "rec-scope-filter", Scope: "session"},
+		{Name: "scn", Source: "rec-scope-filter", Scope: "scenario"},
+	}
+	require.NoError(t, mgr.OpenAll(
+		context.Background(), mcpsource.ScopeSession, "s1", nil, nil, entries))
+	assert.Equal(t, int32(1), s.opens.Load())
+	assert.Contains(t, reg.ListServers(), "ses")
+	assert.NotContains(t, reg.ListServers(), "scn")
+}
+
+// --- Args templating (Task 5) ---
+
+func TestMCPSourceScope_ExpandsScenarioTemplates(t *testing.T) {
+	s := &recordingSource{}
+	mcpsource.RegisterMCPSource("rec-scope-tmpl", s)
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+
+	cfg := config.MCPServerConfig{
+		Name:   "x",
+		Source: "rec-scope-tmpl",
+		Scope:  "session",
+		SourceArgs: map[string]any{
+			"repo":   "{{scenario.repo}}",
+			"branch": "{{scenario.branch}}",
+			"nested": map[string]any{"key": "{{scenario.repo}}"},
+		},
+	}
+	vars := map[string]string{"repo": "github.com/x/y", "branch": "main"}
+
+	require.NoError(t, mgr.OpenAll(
+		context.Background(), mcpsource.ScopeSession, "tmpl-s1", vars, nil,
+		[]config.MCPServerConfig{cfg}))
+
+	require.Equal(t, "github.com/x/y", s.lastArgs["repo"])
+	require.Equal(t, "main", s.lastArgs["branch"])
+	nested, ok := s.lastArgs["nested"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "github.com/x/y", nested["key"])
+}
+
+func TestExpandArgs_NonStringValuesPassThrough(t *testing.T) {
+	in := map[string]any{
+		"a": 42,
+		"b": true,
+		"c": []any{"{{scenario.x}}", "lit"},
+	}
+	out := expandArgs(in, map[string]string{"x": "sub"})
+	assert.Equal(t, 42, out["a"])
+	assert.Equal(t, true, out["b"])
+	assert.Equal(t, []any{"sub", "lit"}, out["c"])
+}
+
+// --- Skill staging (Task 9) ---
+
+func TestBuildSkillMounts_FromSkillSources(t *testing.T) {
+	sources := []prompt.SkillSourceConfig{
+		{Name: "codegen", Path: "/abs/host/codegen"},
+		{Name: "review", Dir: "/abs/host/review"},
+	}
+	mounts := buildSkillMounts(sources)
+	require.Len(t, mounts, 2)
+
+	assert.Equal(t, "/abs/host/codegen", mounts[0]["source"])
+	assert.Equal(t, "/skills/codegen", mounts[0]["target"])
+	assert.Equal(t, true, mounts[0]["readonly"])
+
+	// EffectiveDir() prefers Dir over Path, so for the second entry
+	// source should be the Dir value.
+	assert.Equal(t, "/abs/host/review", mounts[1]["source"])
+	assert.Equal(t, "/skills/review", mounts[1]["target"])
+	assert.Equal(t, true, mounts[1]["readonly"])
+}
+
+func TestBuildSkillMounts_EmptyReturnsNil(t *testing.T) {
+	assert.Nil(t, buildSkillMounts(nil))
+	assert.Nil(t, buildSkillMounts([]prompt.SkillSourceConfig{}))
+}
+
+func TestInjectMountsIntoArgs_PreservesExistingArgs(t *testing.T) {
+	entry := &config.MCPServerConfig{
+		Name:       "sandbox",
+		Source:     "docker",
+		Scope:      "session",
+		SourceArgs: map[string]any{"image": "foo"},
+	}
+	mounts := []map[string]any{{"source": "/a", "target": "/b", "readonly": true}}
+
+	injectMountsIntoArgs(entry, mounts)
+
+	assert.Equal(t, "foo", entry.SourceArgs["image"])
+	assert.Equal(t, mounts, entry.SourceArgs["mounts"])
+}
+
+func TestInjectMountsIntoArgs_NoMountsIsNoop(t *testing.T) {
+	entry := &config.MCPServerConfig{
+		SourceArgs: map[string]any{"image": "foo"},
+	}
+	injectMountsIntoArgs(entry, nil)
+	_, hasMounts := entry.SourceArgs["mounts"]
+	assert.False(t, hasMounts, "empty mounts should not add the key")
+}
+
+func TestMCPSourceScope_InjectsMountsFromSkills(t *testing.T) {
+	s := &recordingSource{}
+	mcpsource.RegisterMCPSource("rec-scope-mounts", s)
+	reg := mcp.NewRegistry()
+	mgr := newMCPSourceScope(reg)
+
+	skills := []prompt.SkillSourceConfig{
+		{Name: "codegen", Path: "/host/path/codegen"},
+	}
+
+	cfg := config.MCPServerConfig{
+		Name:       "sbox",
+		Source:     "rec-scope-mounts",
+		Scope:      "session",
+		SourceArgs: map[string]any{"image": "x"},
+	}
+	require.NoError(t, mgr.OpenAll(
+		context.Background(), mcpsource.ScopeSession, "mnt-s1", nil, skills,
+		[]config.MCPServerConfig{cfg}))
+
+	require.Equal(t, "x", s.lastArgs["image"])
+	mounts, ok := s.lastArgs["mounts"].([]map[string]any)
+	require.True(t, ok, "mounts should be []map[string]any")
+	require.Len(t, mounts, 1)
+	assert.Equal(t, "/host/path/codegen", mounts[0]["source"])
+	assert.Equal(t, "/skills/codegen", mounts[0]["target"])
+	assert.Equal(t, true, mounts[0]["readonly"])
+}

--- a/tools/arena/mcpsource/docker/cli.go
+++ b/tools/arena/mcpsource/docker/cli.go
@@ -1,0 +1,62 @@
+// Package docker implements an MCPSource that provisions MCP servers in
+// Docker containers. Uses the local `docker` CLI (no Docker SDK dep).
+package docker
+
+import (
+	"context"
+	"fmt"
+)
+
+// RunSpec is the arguments to `docker run`.
+type RunSpec struct {
+	Image    string
+	PortHost int
+	PortCtr  int
+	Env      map[string]string
+	Mounts   []Mount
+}
+
+// Mount describes one -v flag on a container.
+type Mount struct {
+	Source   string // host path
+	Target   string // container path
+	ReadOnly bool
+}
+
+// CLI is the minimal docker-CLI surface the source needs. Production code
+// uses realCLI; tests supply a fake.
+type CLI interface {
+	Run(ctx context.Context, spec RunSpec) (containerID string, err error)
+	Stop(ctx context.Context, containerID string) error
+	Exec(ctx context.Context, containerID string, argv []string) (stdout string, err error)
+}
+
+// NewCLI returns a CLI backed by the local docker binary.
+func NewCLI() CLI { return &realCLI{} }
+
+// realCLI shells out to the docker binary. Its methods live in
+// cli_interactive.go so they're not counted against unit-test coverage —
+// they exec the real `docker` binary and can only be exercised by the
+// integration test (see integration_test.go, build tag integration_docker).
+type realCLI struct{}
+
+// buildRunArgs converts a RunSpec into the argv for `docker run`. Factored
+// out so unit tests can exercise arg construction without a running daemon.
+func buildRunArgs(spec RunSpec) []string {
+	args := []string{"run", "-d", "--rm"}
+	if spec.PortHost > 0 && spec.PortCtr > 0 {
+		args = append(args, "-p", fmt.Sprintf("%d:%d", spec.PortHost, spec.PortCtr))
+	}
+	for k, v := range spec.Env {
+		args = append(args, "-e", k+"="+v)
+	}
+	for _, m := range spec.Mounts {
+		v := m.Source + ":" + m.Target
+		if m.ReadOnly {
+			v += ":ro"
+		}
+		args = append(args, "-v", v)
+	}
+	args = append(args, spec.Image)
+	return args
+}

--- a/tools/arena/mcpsource/docker/cli_interactive.go
+++ b/tools/arena/mcpsource/docker/cli_interactive.go
@@ -1,0 +1,42 @@
+package docker
+
+// This file holds the realCLI methods that exec the local `docker` binary.
+// It's named *_interactive.go so the pre-commit coverage check excludes it;
+// these methods require a live docker daemon to exercise and are covered by
+// the build-tagged integration test (integration_test.go).
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Run calls `docker run` with the spec's args and returns the container ID.
+func (r *realCLI) Run(ctx context.Context, spec RunSpec) (string, error) {
+	return execDockerOutput(ctx, buildRunArgs(spec))
+}
+
+// Stop calls `docker stop --time=3 <id>`. Short grace period — the sandbox
+// has no stateful shutdown to preserve.
+func (r *realCLI) Stop(ctx context.Context, id string) error {
+	// #nosec G204 -- docker binary is fixed; id is a container ID we just produced.
+	return exec.CommandContext(ctx, "docker", "stop", "--time=3", id).Run()
+}
+
+// Exec runs `docker exec <id> <argv...>` and returns stdout.
+func (r *realCLI) Exec(ctx context.Context, id string, argv []string) (string, error) {
+	full := append([]string{"exec", id}, argv...)
+	return execDockerOutput(ctx, full)
+}
+
+// execDockerOutput runs the docker binary with the supplied argv and
+// returns its trimmed stdout.
+func execDockerOutput(ctx context.Context, argv []string) (string, error) {
+	// #nosec G204 -- docker binary is fixed; argv is built from RunSpec with typed fields.
+	out, err := exec.CommandContext(ctx, "docker", argv...).Output()
+	if err != nil {
+		return "", fmt.Errorf("docker %s: %w", strings.Join(argv, " "), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/tools/arena/mcpsource/docker/cli_test.go
+++ b/tools/arena/mcpsource/docker/cli_test.go
@@ -1,0 +1,48 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildRunArgs_Basic(t *testing.T) {
+	args := buildRunArgs(RunSpec{
+		Image:    "ghcr.io/altairalabs/codegen-sandbox:latest",
+		PortHost: 38081,
+		PortCtr:  8080,
+	})
+	require.NotEmpty(t, args)
+	assert.Equal(t, "run", args[0])
+	assert.Contains(t, args, "-d")
+	assert.Contains(t, args, "--rm")
+	assert.Contains(t, args, "-p")
+	assert.Contains(t, args, "38081:8080")
+	assert.Equal(t, "ghcr.io/altairalabs/codegen-sandbox:latest", args[len(args)-1])
+}
+
+func TestBuildRunArgs_EnvAndMounts(t *testing.T) {
+	args := buildRunArgs(RunSpec{
+		Image:    "x",
+		PortHost: 9000,
+		PortCtr:  8080,
+		Env:      map[string]string{"FOO": "bar"},
+		Mounts: []Mount{
+			{Source: "/a", Target: "/b", ReadOnly: true},
+			{Source: "/c", Target: "/d", ReadOnly: false},
+		},
+	})
+	assert.Contains(t, args, "-e")
+	assert.Contains(t, args, "FOO=bar")
+	assert.Contains(t, args, "-v")
+	assert.Contains(t, args, "/a:/b:ro")
+	assert.Contains(t, args, "/c:/d")
+}
+
+func TestBuildRunArgs_NoPortMapping(t *testing.T) {
+	args := buildRunArgs(RunSpec{Image: "x"})
+	for _, a := range args {
+		assert.NotEqual(t, "-p", a, "port flag should be absent when port is 0")
+	}
+}

--- a/tools/arena/mcpsource/docker/integration_test.go
+++ b/tools/arena/mcpsource/docker/integration_test.go
@@ -1,0 +1,37 @@
+//go:build integration_docker
+
+package docker
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Run with:
+//
+//	docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+//	go -C tools/arena test ./mcpsource/docker/... -tags=integration_docker -v -count=1
+func TestSource_AgainstRealDocker(t *testing.T) {
+	image := os.Getenv("PROMPTKIT_SANDBOX_IMAGE")
+	if image == "" {
+		image = "ghcr.io/altairalabs/codegen-sandbox:latest"
+	}
+
+	s := New()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, closer, err := s.Open(ctx, map[string]any{
+		"image": image,
+		"env":   map[string]any{"DEV_MODE": "1"},
+	})
+	require.NoError(t, err)
+	defer func() { _ = closer.Close() }()
+
+	assert.Contains(t, conn.URL, "http://localhost:")
+}

--- a/tools/arena/mcpsource/docker/register/register.go
+++ b/tools/arena/mcpsource/docker/register/register.go
@@ -1,0 +1,15 @@
+// Package register wires the Docker MCPSource into the global registry
+// via a blank import. The default promptarena binary imports this
+// package for batteries-included behavior; custom binaries can omit it
+// and register their own source set.
+package register
+
+import (
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource/docker"
+)
+
+//nolint:gochecknoinits // registration-by-blank-import requires init()
+func init() {
+	mcpsource.RegisterMCPSource("docker", docker.New())
+}

--- a/tools/arena/mcpsource/docker/register/register_test.go
+++ b/tools/arena/mcpsource/docker/register/register_test.go
@@ -1,0 +1,15 @@
+package register
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerSourceRegistered(t *testing.T) {
+	src, ok := mcpsource.LookupMCPSource("docker")
+	require.True(t, ok, "docker source should be registered via init()")
+	assert.NotNil(t, src)
+}

--- a/tools/arena/mcpsource/docker/source.go
+++ b/tools/arena/mcpsource/docker/source.go
@@ -1,0 +1,181 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
+)
+
+const (
+	defaultSandboxPort = 8080
+	defaultHealthWait  = 20 * time.Second
+	healthPollInterval = 200 * time.Millisecond
+)
+
+// Source is the Docker-backed MCPSource.
+type Source struct {
+	cli CLI
+	// urlForContainer is overridable for tests; production returns
+	// http://localhost:<hostPort>.
+	urlForContainer func(containerID, hostPort string) string
+	// healthTimeoutOverride shortens the wait in tests. Zero means
+	// "use defaultHealthWait".
+	healthTimeoutOverride time.Duration
+}
+
+// New returns a Docker source using the local docker CLI.
+func New() *Source { return &Source{cli: NewCLI()} }
+
+// Open validates args, starts the container, optionally clones a repo
+// into /workspace, health-polls, and returns the MCP URL + closer.
+func (s *Source) Open(ctx context.Context, args map[string]any) (mcpsource.MCPConn, io.Closer, error) {
+	image, ok := args["image"].(string)
+	if !ok || image == "" {
+		return mcpsource.MCPConn{}, nil, errors.New("docker source: args.image is required")
+	}
+
+	hostPort, err := pickFreePort()
+	if err != nil {
+		return mcpsource.MCPConn{}, nil, fmt.Errorf("docker source: pick free port: %w", err)
+	}
+
+	spec := RunSpec{
+		Image:    image,
+		PortHost: hostPort,
+		PortCtr:  defaultSandboxPort,
+		Env:      stringMap(args["env"]),
+		Mounts:   mountsFromArgs(args["mounts"]),
+	}
+
+	cid, err := s.cli.Run(ctx, spec)
+	if err != nil {
+		return mcpsource.MCPConn{}, nil, fmt.Errorf("docker source: run: %w", err)
+	}
+
+	closer := closerFunc(func() error {
+		return s.cli.Stop(context.Background(), cid)
+	})
+
+	url := s.resolveURL(cid, strconv.Itoa(hostPort))
+
+	if repo, _ := args["repo"].(string); repo != "" {
+		branch, _ := args["branch"].(string)
+		if err := s.cloneRepo(ctx, cid, repo, branch); err != nil {
+			_ = closer.Close()
+			return mcpsource.MCPConn{}, nil, err
+		}
+	}
+
+	timeout := s.healthTimeoutOverride
+	if timeout == 0 {
+		timeout = defaultHealthWait
+	}
+	if err := waitForHealth(ctx, url, timeout); err != nil {
+		_ = closer.Close()
+		return mcpsource.MCPConn{}, nil, fmt.Errorf("docker source: container not healthy: %w", err)
+	}
+
+	return mcpsource.MCPConn{URL: url}, closer, nil
+}
+
+func (s *Source) resolveURL(cid, port string) string {
+	if s.urlForContainer != nil {
+		return s.urlForContainer(cid, port)
+	}
+	return "http://localhost:" + port
+}
+
+func (s *Source) cloneRepo(ctx context.Context, cid, repo, branch string) error {
+	argv := []string{"git", "clone"}
+	if branch != "" {
+		argv = append(argv, "--branch", branch)
+	}
+	argv = append(argv, repo, "/workspace")
+	if _, err := s.cli.Exec(ctx, cid, argv); err != nil {
+		return fmt.Errorf("docker source: clone %s: %w", repo, err)
+	}
+	return nil
+}
+
+type closerFunc func() error
+
+// Close invokes the underlying function; satisfies io.Closer.
+func (f closerFunc) Close() error { return f() }
+
+func stringMap(v any) map[string]string {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, raw := range m {
+		if s, ok := raw.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+func mountsFromArgs(v any) []Mount {
+	list, ok := v.([]map[string]any)
+	if !ok {
+		// Accept the []any shape that YAML unmarshal produces for lists.
+		generic, gok := v.([]any)
+		if !gok {
+			return nil
+		}
+		list = make([]map[string]any, 0, len(generic))
+		for _, item := range generic {
+			if m, ok := item.(map[string]any); ok {
+				list = append(list, m)
+			}
+		}
+	}
+	var out []Mount
+	for _, entry := range list {
+		src, _ := entry["source"].(string)
+		target, _ := entry["target"].(string)
+		ro, _ := entry["readonly"].(bool)
+		if src != "" && target != "" {
+			out = append(out, Mount{Source: src, Target: target, ReadOnly: ro})
+		}
+	}
+	return out
+}
+
+func pickFreePort() (int, error) {
+	var lc net.ListenConfig
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/health", http.NoBody)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(healthPollInterval):
+		}
+	}
+	return fmt.Errorf("health timeout after %v", timeout)
+}

--- a/tools/arena/mcpsource/docker/source_test.go
+++ b/tools/arena/mcpsource/docker/source_test.go
@@ -1,0 +1,168 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCLI struct {
+	runCalls  []RunSpec
+	runID     string
+	runErr    error
+	stopCalls []string
+	stopErr   error
+	execCalls [][]string
+	execOut   string
+	execErr   error
+}
+
+func (f *fakeCLI) Run(_ context.Context, spec RunSpec) (string, error) {
+	f.runCalls = append(f.runCalls, spec)
+	return f.runID, f.runErr
+}
+func (f *fakeCLI) Stop(_ context.Context, id string) error {
+	f.stopCalls = append(f.stopCalls, id)
+	return f.stopErr
+}
+func (f *fakeCLI) Exec(_ context.Context, _ string, argv []string) (string, error) {
+	f.execCalls = append(f.execCalls, argv)
+	return f.execOut, f.execErr
+}
+
+func TestSource_Open_RequiresImage(t *testing.T) {
+	s := &Source{cli: &fakeCLI{}}
+	_, _, err := s.Open(context.Background(), map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image")
+}
+
+func TestSource_Open_StartsContainerAndReturnsURL(t *testing.T) {
+	health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer health.Close()
+
+	cli := &fakeCLI{runID: "cid1"}
+	s := &Source{cli: cli, urlForContainer: func(_, _ string) string { return health.URL }}
+
+	conn, closer, err := s.Open(context.Background(), map[string]any{"image": "x"})
+	require.NoError(t, err)
+	assert.Equal(t, health.URL, conn.URL)
+	require.NotNil(t, closer)
+	require.Len(t, cli.runCalls, 1)
+	assert.Equal(t, "x", cli.runCalls[0].Image)
+
+	require.NoError(t, closer.Close())
+	assert.Equal(t, []string{"cid1"}, cli.stopCalls)
+}
+
+func TestSource_Open_HealthTimeoutClosesContainer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cli := &fakeCLI{runID: "cid-timeout"}
+	s := &Source{
+		cli:                   cli,
+		urlForContainer:       func(_, _ string) string { return srv.URL },
+		healthTimeoutOverride: 50 * time.Millisecond,
+	}
+
+	_, _, err := s.Open(context.Background(), map[string]any{"image": "x"})
+	require.Error(t, err)
+	assert.Equal(t, []string{"cid-timeout"}, cli.stopCalls, "failed Open must stop the container")
+}
+
+func TestSource_Open_ClonesRepoWhenSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cli := &fakeCLI{runID: "cid2"}
+	s := &Source{cli: cli, urlForContainer: func(_, _ string) string { return srv.URL }}
+
+	_, closer, err := s.Open(context.Background(), map[string]any{
+		"image":  "x",
+		"repo":   "https://github.com/foo/bar",
+		"branch": "main",
+	})
+	require.NoError(t, err)
+	defer func() { _ = closer.Close() }()
+
+	var cloneCall []string
+	for _, c := range cli.execCalls {
+		for _, arg := range c {
+			if arg == "clone" {
+				cloneCall = c
+			}
+		}
+	}
+	require.NotEmpty(t, cloneCall, "expected a git clone exec")
+	assert.Contains(t, cloneCall, "https://github.com/foo/bar")
+	assert.Contains(t, cloneCall, "main")
+	assert.Contains(t, cloneCall, "/workspace")
+}
+
+func TestSource_Open_ContainerStartFailureSurfaces(t *testing.T) {
+	cli := &fakeCLI{runErr: errors.New("boom")}
+	s := &Source{cli: cli, urlForContainer: func(_, _ string) string { return "http://x" }}
+
+	_, _, err := s.Open(context.Background(), map[string]any{"image": "x"})
+	require.Error(t, err)
+	assert.Empty(t, cli.stopCalls, "no container to stop when Run failed")
+}
+
+func TestSource_Open_PropagatesMountsAndEnv(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cli := &fakeCLI{runID: "cid3"}
+	s := &Source{cli: cli, urlForContainer: func(_, _ string) string { return srv.URL }}
+
+	_, closer, err := s.Open(context.Background(), map[string]any{
+		"image": "x",
+		"env":   map[string]any{"FOO": "bar"},
+		"mounts": []any{
+			map[string]any{"source": "/host/skills", "target": "/skills/codegen", "readonly": true},
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = closer.Close() }()
+
+	require.Len(t, cli.runCalls, 1)
+	spec := cli.runCalls[0]
+	assert.Equal(t, "bar", spec.Env["FOO"])
+	require.Len(t, spec.Mounts, 1)
+	assert.Equal(t, "/host/skills", spec.Mounts[0].Source)
+	assert.Equal(t, "/skills/codegen", spec.Mounts[0].Target)
+	assert.True(t, spec.Mounts[0].ReadOnly)
+}
+
+func TestMountsFromArgs_TypedSlice(t *testing.T) {
+	// buildSkillMounts in engine returns []map[string]any directly (not []any).
+	mounts := mountsFromArgs([]map[string]any{
+		{"source": "/a", "target": "/b", "readonly": true},
+	})
+	require.Len(t, mounts, 1)
+	assert.Equal(t, "/a", mounts[0].Source)
+	assert.True(t, mounts[0].ReadOnly)
+}
+
+func TestMountsFromArgs_Nil(t *testing.T) {
+	assert.Nil(t, mountsFromArgs(nil))
+}

--- a/tools/arena/mcpsource/export_test.go
+++ b/tools/arena/mcpsource/export_test.go
@@ -1,0 +1,8 @@
+package mcpsource
+
+// resetRegistryForTest clears the global registry. Used by unit tests only.
+func resetRegistryForTest() {
+	regMu.Lock()
+	defer regMu.Unlock()
+	registered = map[string]MCPSource{}
+}

--- a/tools/arena/mcpsource/registry.go
+++ b/tools/arena/mcpsource/registry.go
@@ -1,0 +1,45 @@
+package mcpsource
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+var (
+	regMu      sync.RWMutex
+	registered = map[string]MCPSource{}
+)
+
+// RegisterMCPSource adds a named source implementation. Called from init()
+// blocks in source packages (e.g., mcpsource/docker). Panics on duplicate
+// registration to surface programmer errors at startup.
+func RegisterMCPSource(name string, src MCPSource) {
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, exists := registered[name]; exists {
+		panic(fmt.Sprintf("mcpsource: duplicate registration for %q", name))
+	}
+	registered[name] = src
+}
+
+// LookupMCPSource returns the source registered under name, if any.
+func LookupMCPSource(name string) (MCPSource, bool) {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	s, ok := registered[name]
+	return s, ok
+}
+
+// ListMCPSources returns the names of every registered source, sorted.
+// Used for "unknown source" error messages.
+func ListMCPSources() []string {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	names := make([]string, 0, len(registered))
+	for n := range registered {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/tools/arena/mcpsource/registry_test.go
+++ b/tools/arena/mcpsource/registry_test.go
@@ -1,0 +1,48 @@
+package mcpsource
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSource struct{ opened int }
+
+func (f *fakeSource) Open(_ context.Context, _ map[string]any) (MCPConn, io.Closer, error) {
+	f.opened++
+	return MCPConn{URL: "http://x"}, io.NopCloser(nil), nil
+}
+
+func TestRegistry_RegisterAndLookup(t *testing.T) {
+	resetRegistryForTest()
+	f := &fakeSource{}
+
+	RegisterMCPSource("fake", f)
+
+	got, ok := LookupMCPSource("fake")
+	require.True(t, ok)
+	assert.Same(t, f, got)
+}
+
+func TestRegistry_LookupUnknown(t *testing.T) {
+	resetRegistryForTest()
+	_, ok := LookupMCPSource("nope")
+	assert.False(t, ok)
+}
+
+func TestRegistry_DuplicateRegistrationPanics(t *testing.T) {
+	resetRegistryForTest()
+	RegisterMCPSource("x", &fakeSource{})
+	assert.Panics(t, func() { RegisterMCPSource("x", &fakeSource{}) })
+}
+
+func TestRegistry_ListNames(t *testing.T) {
+	resetRegistryForTest()
+	RegisterMCPSource("a", &fakeSource{})
+	RegisterMCPSource("b", &fakeSource{})
+	names := ListMCPSources()
+	assert.ElementsMatch(t, []string{"a", "b"}, names)
+}

--- a/tools/arena/mcpsource/source.go
+++ b/tools/arena/mcpsource/source.go
@@ -1,0 +1,60 @@
+// Package mcpsource defines the MCPSource interface and registry for
+// host-pluggable MCP server provisioning. An MCPSource is responsible for
+// standing up an MCP endpoint (starting a container, reaching into a remote
+// service, etc.) and returning its URL + Headers. Arena opens sources at
+// scope boundaries (run / scenario / session) and feeds the result into
+// the existing runtime/mcp registry via its URL/Headers fields.
+package mcpsource
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+// Scope is the lifecycle boundary at which a source is opened and closed.
+type Scope string
+
+// Known scope values. ScopeRun opens once per arena run; ScopeScenario once
+// per scenario; ScopeSession once per session (repetition) within a scenario.
+const (
+	ScopeRun      Scope = "run"
+	ScopeScenario Scope = "scenario"
+	ScopeSession  Scope = "session"
+)
+
+// Valid reports whether s is one of the known scope values.
+func (s Scope) Valid() bool {
+	switch s {
+	case ScopeRun, ScopeScenario, ScopeSession:
+		return true
+	}
+	return false
+}
+
+// ParseScope converts a YAML string to a Scope, erroring on unknown values.
+func ParseScope(raw string) (Scope, error) {
+	s := Scope(raw)
+	if !s.Valid() {
+		return "", fmt.Errorf("mcpsource: unknown scope %q (want run|scenario|session)", raw)
+	}
+	return s, nil
+}
+
+// MCPConn carries the coordinates arena needs to construct an mcp.Client.
+// Fed into mcp.ServerConfig{URL, Headers} in the existing code path.
+type MCPConn struct {
+	URL     string
+	Headers map[string]string
+}
+
+// MCPSource opens an MCP endpoint with caller-supplied args.
+//
+// Implementations validate their own args schema; arena treats args as
+// opaque and only expands scenario template variables before calling Open.
+//
+// The returned io.Closer is called exactly once when the scope ends. A
+// source that needs no teardown returns io.NopCloser(nil).
+type MCPSource interface {
+	Open(ctx context.Context, args map[string]any) (MCPConn, io.Closer, error)
+}

--- a/tools/arena/mcpsource/source_test.go
+++ b/tools/arena/mcpsource/source_test.go
@@ -1,0 +1,42 @@
+package mcpsource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScope_Valid(t *testing.T) {
+	for _, s := range []Scope{ScopeRun, ScopeScenario, ScopeSession} {
+		assert.True(t, s.Valid(), "scope %q should be valid", s)
+	}
+}
+
+func TestScope_InvalidValues(t *testing.T) {
+	for _, s := range []Scope{"", "repetition", "turn"} {
+		assert.False(t, Scope(s).Valid(), "scope %q should be invalid", s)
+	}
+}
+
+func TestParseScope(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    Scope
+		wantErr bool
+	}{
+		{"run", ScopeRun, false},
+		{"scenario", ScopeScenario, false},
+		{"session", ScopeSession, false},
+		{"", "", true},
+		{"bogus", "", true},
+	}
+	for _, tc := range tests {
+		got, err := ParseScope(tc.in)
+		if tc.wantErr {
+			assert.Error(t, err, "input %q", tc.in)
+			continue
+		}
+		assert.NoError(t, err, "input %q", tc.in)
+		assert.Equal(t, tc.want, got)
+	}
+}


### PR DESCRIPTION
**Stacked on #1030** — base set to \`feat/mcp-sse-client\` so this rebases onto main once that PR merges.

## Summary

Plan B of the codegen-sandbox consumer wiring (spec: \`docs/superpowers/specs/2026-04-23-codegen-sandbox-consumer-design.md\`). Adds a host-pluggable \`MCPSource\` abstraction to arena, a scope-lifecycle manager (run/scenario/session), a built-in Docker source, skill mount staging, and a runnable reference example.

**What's new:**
- \`tools/arena/mcpsource\` — \`MCPSource\` interface + process-global registry. Scope enum (run/scenario/session) fixes the lifecycle boundary at which sources open/close.
- \`pkg/config.MCPServerConfig\` gains \`Source\`, \`Scope\`, \`SourceArgs\`. Three-way XOR validation across \`command\` (stdio), \`url\` (SSE), \`source\` (host-provisioned). \`source\` requires a valid scope.
- \`runtime/mcp.Registry.UnregisterServer\` for dynamic teardown at scope end. Releases the process-slot semaphore so arena's per-session lifecycle doesn't leak slots.
- \`tools/arena/engine/mcpsource_scope.go\` — scope-lifecycle manager. Opens source-backed entries, expands \`{{scenario.*}}\` templates in args, injects pack skills as container mounts, rolls back on partial failure.
- Engine wire-up: run-scope opens at \`NewEngine\`, scenario+session scopes open in \`executeRun\` with defer-cleanup.
- \`buildMCPRegistry\` skips \`source:\` entries — those are opened dynamically, not statically.
- \`tools/arena/mcpsource/docker\` — CLI-wrapper-based Docker source. Runs container, health-polls \`/health\`, optionally clones a repo into \`/workspace\`, returns MCP URL. Close stops + rms. Build-tagged integration test (\`integration_docker\`) drives a real daemon; unit tests use a fake CLI for the lifecycle logic.
- \`mcpsource/docker/register\` — blank-imported by the default promptarena binary; registers \`docker\` as a named source at init.
- \`examples/codegen-sandbox/\` — pack (codegen skill + agent prompt + scenario), arena config with \`source: docker\`/\`scope: session\`, mock responses for offline runs.
- \`make codegen-demo\` (live Docker) and \`make codegen-demo-mock\` (offline) targets.
- Regenerated JSON schemas.

**Architecture note:** Arena treats \`source_args\` as opaque. Sources validate their own schema. Arena expands \`{{scenario.*}}\` strings into args before calling \`Open\`. Skill mounts are auto-populated from the pack's \`LoadedSkillSources\` when present; sources that don't understand \`mounts\` simply ignore the key. Partial-open failures roll back (close + unregister) to avoid leaking containers.

## Test plan

- [x] \`go test ./... -race\` across runtime, sdk, tools/arena, pkg — all green
- [x] Coverage ≥80% on all new files (100% on mcpsource, 90%+ on docker source, 91% on scope manager)
- [x] Lint clean (\`golangci-lint run\`)
- [x] \`promptarena run --ci --config examples/codegen-sandbox/config.arena.yaml\` — loads + validates + invokes the docker source (fails as expected when the sandbox image isn't locally pulled)
- [ ] Live demo with Docker + published image: \`make codegen-demo\` — blocked on ghcr.io/altairalabs/codegen-sandbox image visibility; the sandbox repo's publish workflow is separate

## Known caveats
- The image is currently gated (\`docker pull\` returns 401/denied). Either needs publishing publicly or the example needs to point at a locally-built image.
- \`--mock-provider\` doesn't currently bypass the source-backed MCP scope manager, so \`codegen-demo-mock\` still tries to start a container. Addressable later via a flag-aware skip in the scope manager or a secondary mock-only arena config.