### PR TITLE
test(sdk/integration): stage contract testing regime + #1035 verification

### DIFF
--- a/sdk/integration/bench_pipeline_test.go
+++ b/sdk/integration/bench_pipeline_test.go
@@ -1,0 +1,47 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// BenchmarkPipeline_PerSend measures wall time and allocations of a single
+// Send across a range of conversation history sizes.
+//
+// The benchmark is parameterised so future-you can spot O(N²) regressions
+// (where doubling history more than doubles per-Send cost). It does not
+// assert anything by itself — its purpose is to surface performance cliffs
+// that contract tests cannot see.
+//
+//   - bench=0: control. Per-Send cost should be roughly equal across runs.
+//   - bench=50: typical short conversation.
+//   - bench=500: long-running agent session.
+//   - bench=2000: stress; if anything is O(N²), it shows here.
+//
+// Run with:
+//
+//	go test -bench=BenchmarkPipeline_PerSend ./sdk/integration -benchmem
+func BenchmarkPipeline_PerSend(b *testing.B) {
+	for _, history := range []int{0, 50, 500, 2000} {
+		b.Run(fmt.Sprintf("history=%d", history), func(b *testing.B) {
+			b.ReportAllocs()
+			ctx := context.Background()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				_, conv := probes.Run(b, probes.RunOptions{
+					SeedHistory:    history,
+					ConversationID: fmt.Sprintf("bench-%d-%d", history, i),
+				})
+				b.StartTimer()
+
+				if _, err := conv.Send(ctx, "x"); err != nil {
+					b.Fatalf("Send failed: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/sdk/integration/contract_budget_test.go
+++ b/sdk/integration/contract_budget_test.go
@@ -1,0 +1,74 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/sdk"
+	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// TestContract_TokenBudgetCapsProviderInput verifies that when WithTokenBudget
+// is set, the message volume entering the provider stays bounded by the
+// budget regardless of how long the conversation grows.
+//
+// We assert via provider.call.completed event payloads (which carry actual
+// InputTokens reported by the provider) rather than counting messages — this
+// is what the budget is actually meant to bound.
+//
+// The mock provider's token estimates are coarse; we therefore assert a
+// generous tolerance (≤ 2× budget) so the test isn't flaky on estimation
+// noise but still catches order-of-magnitude regressions where the budget
+// is silently ignored and the entire history flows to the provider.
+func TestContract_TokenBudgetCapsProviderInput(t *testing.T) {
+	const budget = 4000
+	const tolerance = 2 // mock provider estimates are coarse
+
+	cases := []struct {
+		name    string
+		history int
+	}{
+		{"no-history", 0},
+		{"history-100", 100},
+		{"history-1000", 1000},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, conv := probes.Run(t, probes.RunOptions{
+				SeedHistory: tc.history,
+				SDKOptions: []sdk.Option{
+					sdk.WithTokenBudget(budget),
+					sdk.WithCompaction(true),
+				},
+			})
+			_, err := conv.Send(context.Background(), "x")
+			require.NoError(t, err)
+
+			require.True(t,
+				p.WaitForCount("events.provider.call.completed", 1, 5*time.Second),
+				"timed out waiting for provider.call.completed")
+			time.Sleep(50 * time.Millisecond)
+
+			calls := p.Events(events.EventProviderCallCompleted)
+			require.NotEmpty(t, calls, "expected at least one provider call")
+
+			maxInput := 0
+			for _, e := range calls {
+				data, ok := e.Data.(*events.ProviderCallCompletedData)
+				require.True(t, ok, "unexpected payload type for provider.call.completed")
+				if data.InputTokens > maxInput {
+					maxInput = data.InputTokens
+				}
+			}
+
+			require.LessOrEqual(t, maxInput, budget*tolerance,
+				"provider received %d input tokens, budget is %d (tolerance %dx); "+
+					"history=%d", maxInput, budget, tolerance, tc.history)
+		})
+	}
+}

--- a/sdk/integration/contract_compaction_test.go
+++ b/sdk/integration/contract_compaction_test.go
@@ -1,0 +1,62 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// TestContract_CompactionRunsOncePerProviderRound pins the per-Send budget
+// for context compaction.
+//
+// Compaction is invoked by ProviderStage between tool-loop rounds. With a
+// single-round (no tool calls) Send, compaction either runs once (if the
+// configured threshold is exceeded) or zero times (if not). It must NEVER
+// scale with conversation history depth — that would make compaction itself
+// O(N) on top of the work it is meant to amortise.
+//
+// We assert at most 1 context.compacted event per Send across history sizes
+// from 0 to 2000. The exact lower bound depends on whether the compactor
+// triggers (which depends on the default budget vs. the seeded message
+// content), so we only bound the upper end.
+func TestContract_CompactionRunsOncePerProviderRound(t *testing.T) {
+	contract := probes.StageContract{
+		Stage: "compaction",
+		PerSend: probes.Ops{
+			"events.context.compacted": probes.AtMost(1),
+		},
+	}
+
+	cases := []struct {
+		name    string
+		history int
+	}{
+		{"no-history", 0},
+		{"history-50", 50},
+		{"history-500", 500},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, conv := probes.Run(t, probes.RunOptions{
+				SeedHistory: tc.history,
+				SDKOptions: []sdk.Option{
+					sdk.WithCompaction(true),
+				},
+			})
+			_, err := conv.Send(context.Background(), "x")
+			require.NoError(t, err)
+
+			// Compaction events are bus-async; settle so the upper-bound
+			// assertion catches overshoot rather than racing to read 0.
+			time.Sleep(50 * time.Millisecond)
+
+			contract.AssertHolds(t, p.Snapshot())
+		})
+	}
+}

--- a/sdk/integration/contract_known_bugs_test.go
+++ b/sdk/integration/contract_known_bugs_test.go
@@ -63,6 +63,35 @@ func TestKnownBug_Issue1035_HistoryMultipliesTemplateEvents(t *testing.T) {
 		"BUG #1035: template.rendered should be 1 per Send; pinned at N_history+1 until fix lands")
 }
 
+// TestKnownBug_Issue1035_AtScale confirms #1035 reproduces identically at
+// production-scale conversation lengths. If anything truncated, throttled,
+// or coalesced events at high N this would surface differently than the
+// short-history pin above. It does not — the bug is linear in history depth.
+//
+// Skipped under -short to keep the regular test loop fast; CI runs it.
+func TestKnownBug_Issue1035_AtScale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scale test skipped under -short")
+	}
+	const history = 2000
+	const expected = history + 1
+
+	p, conv := probes.Run(t, probes.RunOptions{SeedHistory: history})
+	_, err := conv.Send(context.Background(), "current input")
+	require.NoError(t, err)
+
+	// At 2000 events, drain takes longer; allow more time before settling.
+	require.True(t, p.WaitForCount("events.prompt.template.started", expected, 30*time.Second),
+		"timed out waiting for template.started to reach %d at scale", expected)
+	require.True(t, p.WaitForCount("events.prompt.template.rendered", expected, 30*time.Second),
+		"timed out waiting for template.rendered to reach %d at scale", expected)
+	time.Sleep(eventSettleDelay)
+
+	snap := p.Snapshot()
+	require.Equal(t, expected, snap.Count("events.prompt.template.started"))
+	require.Equal(t, expected, snap.Count("events.prompt.template.rendered"))
+}
+
 // TestKnownBug_StateStoreSaveStageRedundantLoad pins the current redundant
 // store.Load call performed inside StateStoreSaveStage.
 //

--- a/sdk/integration/contract_known_bugs_test.go
+++ b/sdk/integration/contract_known_bugs_test.go
@@ -1,0 +1,72 @@
+package integration
+
+// Tests in this file pin the *current* (incorrect) behavior of known bugs.
+// They pass green today; they fail loudly when the bug is fixed, prompting
+// the developer to flip the assertion and move the case to the corresponding
+// contract_*_test.go file.
+//
+// When adding a new known-bug pin:
+//   1. Reference the issue number in the test name and doc comment.
+//   2. Pin the exact observed counts so silent drift is caught.
+//   3. Cross-link to the matching skipped case in the contract test.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// TestKnownBug_Issue1035_HistoryMultipliesTemplateEvents pins the current
+// over-emission of template lifecycle events.
+//
+// Bug: PromptAssemblyStage stamps system_template metadata onto every
+// StreamElement; TemplateStage re-renders + re-emits per element; and
+// StateStoreLoadStage emits one element per historical message. The
+// observed count is therefore N_history + 1 instead of the contracted 1.
+//
+// See https://github.com/AltairaLabs/PromptKit/issues/1035 .
+//
+// When fixed, this test will fail. Replace it by removing the matching skip
+// in TestContract_TemplateStage (contract_template_test.go).
+func TestKnownBug_Issue1035_HistoryMultipliesTemplateEvents(t *testing.T) {
+	const history = 4
+	const expected = history + 1 // current buggy count: one render per stream element
+
+	p, conv := probes.Run(t, probes.RunOptions{SeedHistory: history})
+	_, err := conv.Send(context.Background(), "current input")
+	require.NoError(t, err)
+
+	snap := p.Snapshot()
+	require.Equal(t, expected, snap.Count("events.prompt.template.started"),
+		"BUG #1035: template.started should be 1 per Send; pinned at N_history+1 until fix lands")
+	require.Equal(t, expected, snap.Count("events.prompt.template.rendered"),
+		"BUG #1035: template.rendered should be 1 per Send; pinned at N_history+1 until fix lands")
+}
+
+// TestKnownBug_StateStoreSaveStageRedundantLoad pins the current redundant
+// store.Load call performed inside StateStoreSaveStage.
+//
+// Bug: StateStoreSaveStage.loadOrCreateState (runtime/pipeline/stage/
+// stages_core.go) calls store.Load before saving so it can preserve fields
+// not present in the element stream (Summaries, TokenCount, UserID). This
+// is functionally a load-modify-save and doubles per-Send Load count from
+// 1 to 2.
+//
+// Surfaced during investigation of issue #1035.
+//
+// When fixed, remove the matching skip in TestContract_PipelineStateStoreBudget
+// (contract_pipeline_test.go).
+func TestKnownBug_StateStoreSaveStageRedundantLoad(t *testing.T) {
+	p, conv := probes.Run(t, probes.RunOptions{SeedHistory: 0})
+	_, err := conv.Send(context.Background(), "x")
+	require.NoError(t, err)
+
+	snap := p.Snapshot()
+	require.Equal(t, 2, snap.Count("store.Load"),
+		"redundant Load: 1 in StateStoreLoadStage, 1 in StateStoreSaveStage.loadOrCreateState")
+	require.Equal(t, 1, snap.Count("store.Save"),
+		"Save itself is correctly Send-scoped — only Load is redundant")
+}

--- a/sdk/integration/contract_known_bugs_test.go
+++ b/sdk/integration/contract_known_bugs_test.go
@@ -13,10 +13,19 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// eventDrainTimeout caps how long known-bug tests will wait for the async
+// EventBus to deliver the events the bug emits. Pinned counts also re-check
+// after a brief settle to catch overshoot.
+const (
+	eventDrainTimeout = 5 * time.Second
+	eventSettleDelay  = 50 * time.Millisecond
 )
 
 // TestKnownBug_Issue1035_HistoryMultipliesTemplateEvents pins the current
@@ -38,6 +47,14 @@ func TestKnownBug_Issue1035_HistoryMultipliesTemplateEvents(t *testing.T) {
 	p, conv := probes.Run(t, probes.RunOptions{SeedHistory: history})
 	_, err := conv.Send(context.Background(), "current input")
 	require.NoError(t, err)
+
+	// EventBus dispatches asynchronously; wait for at least `expected` events
+	// to land, then settle briefly so we'd notice an overshoot.
+	require.True(t, p.WaitForCount("events.prompt.template.started", expected, eventDrainTimeout),
+		"timed out waiting for template.started to reach %d", expected)
+	require.True(t, p.WaitForCount("events.prompt.template.rendered", expected, eventDrainTimeout),
+		"timed out waiting for template.rendered to reach %d", expected)
+	time.Sleep(eventSettleDelay)
 
 	snap := p.Snapshot()
 	require.Equal(t, expected, snap.Count("events.prompt.template.started"),

--- a/sdk/integration/contract_pipeline_test.go
+++ b/sdk/integration/contract_pipeline_test.go
@@ -1,0 +1,50 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// TestContract_PipelineStateStoreBudget pins the cross-stage per-Send budget
+// for state store traffic. Regardless of stage composition, a single Send
+// should produce exactly one Load (history assembly) and exactly one Save
+// (state persistence).
+//
+// Currently violated by StateStoreSaveStage.loadOrCreateState, which performs
+// an additional Load inside the save path. See contract_known_bugs_test.go
+// for the pinned violation count.
+func TestContract_PipelineStateStoreBudget(t *testing.T) {
+	inv := probes.PipelineInvariants{
+		Label: "state-store-budget",
+		PerSend: probes.Ops{
+			"store.Load": probes.Exactly(1),
+			"store.Save": probes.Exactly(1),
+			"store.Fork": probes.Exactly(0),
+		},
+	}
+
+	cases := []struct {
+		name             string
+		history          int
+		knownViolationOf string
+	}{
+		{"no-history", 0, "#1035: redundant Load in StateStoreSaveStage"},
+		{"history-5", 5, "#1035: redundant Load in StateStoreSaveStage"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.knownViolationOf != "" {
+				t.Skipf("known violation: %s — see contract_known_bugs_test.go", tc.knownViolationOf)
+			}
+			p, conv := probes.Run(t, probes.RunOptions{SeedHistory: tc.history})
+			_, err := conv.Send(context.Background(), "x")
+			require.NoError(t, err)
+			inv.AssertHolds(t, p.Snapshot())
+		})
+	}
+}

--- a/sdk/integration/contract_summarize_test.go
+++ b/sdk/integration/contract_summarize_test.go
@@ -1,0 +1,74 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// TestContract_AutoSummarizeFiresOncePerThresholdCrossing pins the per-Send
+// behavior of WithAutoSummarize.
+//
+// LLMSummarizer.Summarize calls Provider.Predict directly without going
+// through the pipeline ProviderStage, so the regular provider.call.* events
+// don't cover summarizer traffic. The probes layer wraps the dedicated
+// summarizer provider and exposes the count under op "summarizer.Predict".
+//
+// Contract: when history exceeds the threshold, a single Send produces at
+// most one Summarize call (one batch per Send). When history is below the
+// threshold, no Summarize call should fire.
+func TestContract_AutoSummarizeFiresOncePerThresholdCrossing(t *testing.T) {
+	const threshold = 50
+	const batchSize = 25
+
+	// Note: a Send appends both the user message and the assistant response,
+	// so the threshold check sees pre-Send-history + 2. "below-threshold"
+	// means pre-Send + 2 stays well under the threshold.
+	cases := []struct {
+		name     string
+		history  int
+		expected probes.Bound
+	}{
+		{"well-below-threshold", 10, probes.Exactly(0)},
+		{"just-below", threshold - 5, probes.Exactly(0)},
+		{"at-threshold", threshold, probes.AtMost(1)},
+		{"above-threshold", threshold * 2, probes.AtMost(1)},
+		// Even at 10× threshold, summarization fires at most once per Send —
+		// the IncrementalSaveStage processes one batch per turn, not many.
+		{"deeply-above", threshold * 10, probes.AtMost(1)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, conv := probes.Run(t, probes.RunOptions{
+				SeedHistory: tc.history,
+				AutoSummarize: &probes.AutoSummarizeOpts{
+					Threshold: threshold,
+					BatchSize: batchSize,
+				},
+				SDKOptions: []sdk.Option{
+					sdk.WithContextWindow(20),
+				},
+			})
+
+			_, err := conv.Send(context.Background(), "x")
+			require.NoError(t, err)
+
+			// Summarize runs in the IncrementalSaveStage AFTER the provider
+			// call. Allow time for it to complete and for any final events
+			// to land before snapshotting.
+			time.Sleep(150 * time.Millisecond)
+
+			contract := probes.StageContract{
+				Stage:   "auto-summarize",
+				PerSend: probes.Ops{"summarizer.Predict": tc.expected},
+			}
+			contract.AssertHolds(t, p.Snapshot())
+		})
+	}
+}

--- a/sdk/integration/contract_template_test.go
+++ b/sdk/integration/contract_template_test.go
@@ -40,6 +40,10 @@ func TestContract_TemplateStage(t *testing.T) {
 		{"history-1", 1, "#1035"},
 		{"history-5", 5, "#1035"},
 		{"history-50", 50, "#1035"},
+		// Scale: a 2000-turn conversation is plausible production traffic for
+		// long-running agent sessions. The bug behaves identically here, but
+		// once #1035 is fixed this case proves the contract holds at scale.
+		{"history-2000", 2000, "#1035"},
 	}
 
 	for _, tc := range cases {

--- a/sdk/integration/contract_template_test.go
+++ b/sdk/integration/contract_template_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -49,6 +50,12 @@ func TestContract_TemplateStage(t *testing.T) {
 			p, conv := probes.Run(t, probes.RunOptions{SeedHistory: tc.history})
 			_, err := conv.Send(context.Background(), "x")
 			require.NoError(t, err)
+
+			// EventBus is async; wait for the rendered event before snapshotting
+			// so we don't false-fail with count == 0 due to in-flight delivery.
+			require.True(t, p.WaitForCount("events.prompt.template.rendered", 1, 5*time.Second),
+				"timed out waiting for prompt.template.rendered to land")
+
 			contract.AssertHolds(t, p.Snapshot())
 		})
 	}

--- a/sdk/integration/contract_template_test.go
+++ b/sdk/integration/contract_template_test.go
@@ -1,0 +1,55 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// TestContract_TemplateStage pins the per-Send operation budget for
+// TemplateStage:
+//   - render the system_template exactly once
+//   - emit prompt.template.started exactly once
+//   - emit prompt.template.rendered exactly once
+//   - never emit prompt.template.failed
+//
+// Cases marked with a knownViolation reference are skipped pending the bug
+// fix. Removing the skip is the signal that the fix has landed; if the
+// assertions then hold the contract is enforced for that fixture going
+// forward.
+func TestContract_TemplateStage(t *testing.T) {
+	contract := probes.StageContract{
+		Stage: "template",
+		PerSend: probes.Ops{
+			"events.prompt.template.started":  probes.Exactly(1),
+			"events.prompt.template.rendered": probes.Exactly(1),
+			"events.prompt.template.failed":   probes.AtMost(0),
+		},
+	}
+
+	cases := []struct {
+		name             string
+		history          int
+		knownViolationOf string
+	}{
+		{"no-history", 0, ""},
+		{"history-1", 1, "#1035"},
+		{"history-5", 5, "#1035"},
+		{"history-50", 50, "#1035"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.knownViolationOf != "" {
+				t.Skipf("known violation: %s — see contract_known_bugs_test.go", tc.knownViolationOf)
+			}
+			p, conv := probes.Run(t, probes.RunOptions{SeedHistory: tc.history})
+			_, err := conv.Send(context.Background(), "x")
+			require.NoError(t, err)
+			contract.AssertHolds(t, p.Snapshot())
+		})
+	}
+}

--- a/sdk/integration/probes/contract.go
+++ b/sdk/integration/probes/contract.go
@@ -1,0 +1,147 @@
+// Package probes provides instrumented dependency wrappers and operation
+// contracts for SDK integration tests.
+//
+// The package addresses a class of bug that PromptKit's existing test suite
+// could not detect: stages whose element flow is correct (1 in → 1 out) but
+// whose external side effects (Load, Save, render, emit) multiply with input
+// cardinality. Without explicit operation counters, "did X happen" tests pass
+// while "did X happen exactly N times" remains unenforced.
+//
+// Contracts declare per-Send operation budgets ("renderer.RenderDetailed
+// must execute exactly once per Send, regardless of history depth").
+// Probes capture the actual count. Tests run a fixture matrix that varies
+// the dimensions which drive multiplication and assert contracts hold across
+// all of them.
+package probes
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// Op is the name of a counted operation, e.g. "store.Load" or
+// "events.template.rendered".
+type Op string
+
+// Bound describes the acceptable count range for an operation per Send.
+// A Max of -1 means unbounded.
+type Bound struct {
+	Min int
+	Max int
+}
+
+// Exactly returns a Bound that requires exactly n occurrences.
+func Exactly(n int) Bound { return Bound{Min: n, Max: n} }
+
+// AtMost returns a Bound that requires at most n occurrences.
+func AtMost(n int) Bound { return Bound{Min: 0, Max: n} }
+
+// AtLeast returns a Bound that requires at least n occurrences (no upper bound).
+func AtLeast(n int) Bound { return Bound{Min: n, Max: -1} }
+
+// Range returns a Bound that requires lo <= count <= hi.
+func Range(lo, hi int) Bound { return Bound{Min: lo, Max: hi} }
+
+// String returns a human-readable description of the Bound.
+func (b Bound) String() string {
+	switch {
+	case b.Max == b.Min:
+		return fmt.Sprintf("exactly %d", b.Min)
+	case b.Max < 0:
+		return fmt.Sprintf("at least %d", b.Min)
+	case b.Min == 0:
+		return fmt.Sprintf("at most %d", b.Max)
+	default:
+		return fmt.Sprintf("between %d and %d", b.Min, b.Max)
+	}
+}
+
+// Contains reports whether n satisfies the bound.
+func (b Bound) Contains(n int) bool {
+	if n < b.Min {
+		return false
+	}
+	if b.Max >= 0 && n > b.Max {
+		return false
+	}
+	return true
+}
+
+// Ops maps an operation name to its expected per-Send bound.
+type Ops map[Op]Bound
+
+// StageContract declares the per-Send operation budget for a single stage.
+// Used by tests as a first-class fixture: assert that a stage performs each
+// declared operation within bounds across a matrix of inputs.
+type StageContract struct {
+	// Stage is a free-form label used in failure messages.
+	Stage string
+	// PerSend lists operations whose count is expected to be Send-scoped.
+	PerSend Ops
+}
+
+// reporter is the subset of *testing.T that AssertHolds needs. Defined as a
+// local interface (not testing.TB, which has unexported methods) so unit
+// tests can verify the violation path with a stub.
+type reporter interface {
+	Helper()
+	Errorf(format string, args ...any)
+}
+
+// AssertHolds checks that the snapshot satisfies every clause of the contract.
+// Each violation produces a separate t.Errorf so all failures surface at once.
+func (c StageContract) AssertHolds(t *testing.T, snap Snapshot) {
+	t.Helper()
+	c.assert(t, snap)
+}
+
+func (c StageContract) assert(t reporter, snap Snapshot) {
+	t.Helper()
+	for _, op := range sortedOps(c.PerSend) {
+		bound := c.PerSend[op]
+		got := snap.Count(op)
+		if !bound.Contains(got) {
+			t.Errorf("[contract %s] %s: got %d, want %s", c.Stage, op, got, bound)
+		}
+	}
+}
+
+// PipelineInvariants declares per-Send budgets that hold across the entire
+// pipeline (cross-stage), not for any single stage.
+type PipelineInvariants struct {
+	// Label is a free-form name used in failure messages.
+	Label string
+	// PerSend lists pipeline-wide operations whose count is Send-scoped.
+	PerSend Ops
+}
+
+// AssertHolds checks that the snapshot satisfies every clause.
+func (p PipelineInvariants) AssertHolds(t *testing.T, snap Snapshot) {
+	t.Helper()
+	p.assert(t, snap)
+}
+
+func (p PipelineInvariants) assert(t reporter, snap Snapshot) {
+	t.Helper()
+	label := p.Label
+	if label == "" {
+		label = "pipeline"
+	}
+	for _, op := range sortedOps(p.PerSend) {
+		bound := p.PerSend[op]
+		got := snap.Count(op)
+		if !bound.Contains(got) {
+			t.Errorf("[invariant %s] %s: got %d, want %s", label, op, got, bound)
+		}
+	}
+}
+
+func sortedOps(ops Ops) []Op {
+	keys := make([]Op, 0, len(ops))
+	for k := range ops {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/sdk/integration/probes/probes.go
+++ b/sdk/integration/probes/probes.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
 // Probes captures observed operation counts for a single Send window.
@@ -16,14 +17,25 @@ import (
 // rather than wrapping each interface — the lifecycle events on the bus are
 // already authoritative for "this operation happened once."
 //
+// For tests that need to inspect event payloads (e.g. assert tokens entering
+// the provider stay within budget), the full event records are retained and
+// exposed via Events(eventType).
+//
+// A separately-counted Provider wrapper is exposed via SummarizerProvider for
+// auto-summarize tests, since the LLMSummarizer calls Predict on its provider
+// directly without going through the pipeline's ProviderStage (so no
+// provider.call.* events fire for summarization).
+//
 // Counters are reset by ResetCounters; Run calls it after sdk.Open completes
 // so that init-time Loads/Saves do not appear in Send-scoped snapshots.
 type Probes struct {
-	store *probedStore
-	bus   *events.EventBus
+	store              *probedStore
+	bus                *events.EventBus
+	summarizerProvider *probedProvider
 
-	mu     sync.Mutex
-	events map[events.EventType]int
+	mu           sync.Mutex
+	events       map[events.EventType]int
+	eventRecords map[events.EventType][]*events.Event
 }
 
 // Snapshot is an immutable point-in-time view of probe counters.
@@ -51,30 +63,53 @@ func (s Snapshot) All() map[Op]int {
 // Snapshot captures the current counter state.
 func (p *Probes) Snapshot() Snapshot {
 	loads, saves, forks := p.store.snapshot()
+	summarizerPredicts := p.summarizerProvider.predicts()
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	const storeOpCount = 3 // store.Load, store.Save, store.Fork
+	const fixedCounters = 4 // store.{Load,Save,Fork}, summarizer.Predict
 
-	counts := make(map[Op]int, len(p.events)+storeOpCount)
+	counts := make(map[Op]int, len(p.events)+fixedCounters)
 	counts["store.Load"] = loads
 	counts["store.Save"] = saves
 	counts["store.Fork"] = forks
+	counts["summarizer.Predict"] = summarizerPredicts
 	for et, n := range p.events {
 		counts[Op("events."+string(et))] = n
 	}
 	return Snapshot{counts: counts}
 }
 
+// Events returns a snapshot of all collected events of the given type, in
+// the order they were observed. Useful for inspecting payload data — for
+// example, asserting that tokens entering the provider stay within budget.
+func (p *Probes) Events(et events.EventType) []*events.Event {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	src := p.eventRecords[et]
+	out := make([]*events.Event, len(src))
+	copy(out, src)
+	return out
+}
+
+// SummarizerProvider returns a counted Provider wrapper suitable to pass as
+// the auto-summarize provider via sdk.WithAutoSummarize. Predict calls on
+// this provider are counted under op "summarizer.Predict".
+func (p *Probes) SummarizerProvider() providers.Provider {
+	return p.summarizerProvider
+}
+
 // ResetCounters zeroes every counter. Run calls this after sdk.Open so that
 // initialisation traffic does not leak into per-Send observations.
 func (p *Probes) ResetCounters() {
 	p.store.reset()
+	p.summarizerProvider.reset()
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.events = make(map[events.EventType]int, len(p.events))
+	p.eventRecords = make(map[events.EventType][]*events.Event, len(p.eventRecords))
 }
 
 // Bus returns the event bus the probes are listening on. Tests can use it

--- a/sdk/integration/probes/probes.go
+++ b/sdk/integration/probes/probes.go
@@ -3,6 +3,7 @@ package probes
 import (
 	"maps"
 	"sync"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 )
@@ -80,4 +81,27 @@ func (p *Probes) ResetCounters() {
 // for additional subscriptions, but should not close it — Run wires cleanup.
 func (p *Probes) Bus() *events.EventBus {
 	return p.bus
+}
+
+// WaitForCount blocks until the count for op reaches at least atLeast or
+// the timeout expires. Returns true if the threshold was met, false on
+// timeout.
+//
+// Counts grow monotonically inside a single observation window (we do not
+// emit anti-events), so a successful WaitForCount guarantees the snapshot
+// holds at least the requested count. Callers asserting an *exact* count
+// should pair WaitForCount with a brief settle period and an Equal check
+// to catch overshoot.
+func (p *Probes) WaitForCount(op Op, atLeast int, timeout time.Duration) bool {
+	const pollInterval = 5 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+	for {
+		if p.Snapshot().Count(op) >= atLeast {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(pollInterval)
+	}
 }

--- a/sdk/integration/probes/probes.go
+++ b/sdk/integration/probes/probes.go
@@ -1,0 +1,83 @@
+package probes
+
+import (
+	"maps"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+)
+
+// Probes captures observed operation counts for a single Send window.
+//
+// Probes is wired into the SDK via Run: store calls are counted via a wrapping
+// statestore.Store; events are counted via a SubscribeAll listener on the bus.
+// Renderer / tool / provider counts are derived from existing event types
+// rather than wrapping each interface — the lifecycle events on the bus are
+// already authoritative for "this operation happened once."
+//
+// Counters are reset by ResetCounters; Run calls it after sdk.Open completes
+// so that init-time Loads/Saves do not appear in Send-scoped snapshots.
+type Probes struct {
+	store *probedStore
+	bus   *events.EventBus
+
+	mu     sync.Mutex
+	events map[events.EventType]int
+}
+
+// Snapshot is an immutable point-in-time view of probe counters.
+//
+// Operation names follow the convention "<dependency>.<method>" for direct
+// wraps (e.g. "store.Load") and "events.<event_type>" for events (e.g.
+// "events.prompt.template.rendered").
+type Snapshot struct {
+	counts map[Op]int
+}
+
+// Count returns the count for op, or 0 if op was never seen.
+func (s Snapshot) Count(op Op) int {
+	return s.counts[op]
+}
+
+// All returns a copy of the underlying counts map. Mostly useful for
+// debugging — assertions should use Count.
+func (s Snapshot) All() map[Op]int {
+	out := make(map[Op]int, len(s.counts))
+	maps.Copy(out, s.counts)
+	return out
+}
+
+// Snapshot captures the current counter state.
+func (p *Probes) Snapshot() Snapshot {
+	loads, saves, forks := p.store.snapshot()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	const storeOpCount = 3 // store.Load, store.Save, store.Fork
+
+	counts := make(map[Op]int, len(p.events)+storeOpCount)
+	counts["store.Load"] = loads
+	counts["store.Save"] = saves
+	counts["store.Fork"] = forks
+	for et, n := range p.events {
+		counts[Op("events."+string(et))] = n
+	}
+	return Snapshot{counts: counts}
+}
+
+// ResetCounters zeroes every counter. Run calls this after sdk.Open so that
+// initialisation traffic does not leak into per-Send observations.
+func (p *Probes) ResetCounters() {
+	p.store.reset()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = make(map[events.EventType]int, len(p.events))
+}
+
+// Bus returns the event bus the probes are listening on. Tests can use it
+// for additional subscriptions, but should not close it — Run wires cleanup.
+func (p *Probes) Bus() *events.EventBus {
+	return p.bus
+}

--- a/sdk/integration/probes/probes_test.go
+++ b/sdk/integration/probes/probes_test.go
@@ -260,6 +260,20 @@ func TestProbes_BusReturnsSameInstance(t *testing.T) {
 	assert.Same(t, p.bus, p.Bus())
 }
 
+func TestProbes_WaitForCount_Reaches(t *testing.T) {
+	p := newTestProbes(t)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		p.bus.Publish(&events.Event{Type: events.EventTemplateRendered})
+	}()
+	assert.True(t, p.WaitForCount("events.prompt.template.rendered", 1, 2*time.Second))
+}
+
+func TestProbes_WaitForCount_Timeout(t *testing.T) {
+	p := newTestProbes(t)
+	assert.False(t, p.WaitForCount("events.prompt.template.rendered", 1, 20*time.Millisecond))
+}
+
 // ---------------------------------------------------------------------------
 // Run (smoke + seed)
 // ---------------------------------------------------------------------------

--- a/sdk/integration/probes/probes_test.go
+++ b/sdk/integration/probes/probes_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // stubReporter implements the local reporter interface (Helper + Errorf) so
@@ -189,6 +192,113 @@ func TestProbedStore_ForkCounts(t *testing.T) {
 	assert.Equal(t, 1, forks)
 }
 
+func TestProbedStore_OptionalInterfacesDelegate(t *testing.T) {
+	inner := statestore.NewMemoryStore()
+	require.NoError(t, inner.Save(context.Background(), &statestore.ConversationState{
+		ID:       "c1",
+		Messages: []types.Message{{Role: "user", Content: "hi"}, {Role: "assistant", Content: "yo"}},
+	}))
+	s := newProbedStore(inner)
+
+	// MessageReader: LoadRecentMessages + MessageCount
+	recent, err := s.LoadRecentMessages(context.Background(), "c1", 10)
+	require.NoError(t, err)
+	assert.Len(t, recent, 2)
+	count, err := s.MessageCount(context.Background(), "c1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// MessageAppender: MemoryStore implements it
+	require.NoError(t, s.AppendMessages(context.Background(), "c1",
+		[]types.Message{{Role: "user", Content: "more"}}))
+	count, err = s.MessageCount(context.Background(), "c1")
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	// MetadataAccessor — return value may be nil for state without metadata;
+	// what matters is that the call delegates without error.
+	_, err = s.LoadMetadata(context.Background(), "c1")
+	require.NoError(t, err)
+
+	// SummaryAccessor: LoadSummaries returns nil for fresh state
+	summaries, err := s.LoadSummaries(context.Background(), "c1")
+	require.NoError(t, err)
+	assert.Empty(t, summaries)
+	require.NoError(t, s.SaveSummary(context.Background(), "c1",
+		statestore.Summary{StartTurn: 0, EndTurn: 1, Content: "summary"}))
+	summaries, err = s.LoadSummaries(context.Background(), "c1")
+	require.NoError(t, err)
+	assert.Len(t, summaries, 1)
+}
+
+// stubBareStore implements only statestore.Store (no optional interfaces).
+type stubBareStore struct{}
+
+func (stubBareStore) Load(_ context.Context, _ string) (*statestore.ConversationState, error) {
+	return &statestore.ConversationState{}, nil
+}
+
+func (stubBareStore) Save(_ context.Context, _ *statestore.ConversationState) error { return nil }
+
+func (stubBareStore) Fork(_ context.Context, _, _ string) error { return nil }
+
+func TestProbedStore_OptionalInterfacesFallbackOnBareStore(t *testing.T) {
+	s := newProbedStore(stubBareStore{})
+
+	_, err := s.LoadRecentMessages(context.Background(), "c", 10)
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+
+	_, err = s.MessageCount(context.Background(), "c")
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+
+	err = s.AppendMessages(context.Background(), "c", nil)
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+
+	_, err = s.LoadMetadata(context.Background(), "c")
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+
+	summaries, err := s.LoadSummaries(context.Background(), "c")
+	assert.NoError(t, err)
+	assert.Nil(t, summaries)
+
+	err = s.SaveSummary(context.Background(), "c", statestore.Summary{})
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+func TestProbedProvider_PredictAndStreamCount(t *testing.T) {
+	inner := mock.NewProvider("test-mock", "test-model", false)
+	p := newProbedProvider(inner)
+
+	// ID/Model/SupportsStreaming/ShouldIncludeRawOutput/Close/CalculateCost
+	assert.NotEmpty(t, p.ID())
+	assert.NotEmpty(t, p.Model())
+	_ = p.SupportsStreaming()
+	_ = p.ShouldIncludeRawOutput()
+	cost := p.CalculateCost(100, 50, 0)
+	assert.NotNil(t, cost)
+
+	_, err := p.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.predicts())
+
+	if p.SupportsStreaming() {
+		ch, err := p.PredictStream(context.Background(), providers.PredictionRequest{
+			Messages: []types.Message{{Role: "user", Content: "hi"}},
+		})
+		require.NoError(t, err)
+		// Drain so the goroutine exits cleanly.
+		for range ch {
+		}
+		// Stream count is internal state; nothing to assert beyond no error.
+	}
+
+	require.NoError(t, p.Close())
+	p.reset()
+	assert.Equal(t, 0, p.predicts())
+}
+
 // ---------------------------------------------------------------------------
 // Probes (Snapshot / ResetCounters / Bus)
 // ---------------------------------------------------------------------------
@@ -203,13 +313,16 @@ func newTestProbes(t *testing.T) *Probes {
 	bus := events.NewEventBus()
 	t.Cleanup(bus.Close)
 	p := &Probes{
-		store:  newProbedStore(statestore.NewMemoryStore()),
-		bus:    bus,
-		events: map[events.EventType]int{},
+		store:              newProbedStore(statestore.NewMemoryStore()),
+		bus:                bus,
+		summarizerProvider: newProbedProvider(mock.NewProvider("unit-summarizer", "unit-summarizer-model", false)),
+		events:             map[events.EventType]int{},
+		eventRecords:       map[events.EventType][]*events.Event{},
 	}
 	bus.SubscribeAll(func(e *events.Event) {
 		p.mu.Lock()
 		p.events[e.Type]++
+		p.eventRecords[e.Type] = append(p.eventRecords[e.Type], e)
 		p.mu.Unlock()
 	})
 	return p

--- a/sdk/integration/probes/probes_test.go
+++ b/sdk/integration/probes/probes_test.go
@@ -1,0 +1,288 @@
+package probes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+)
+
+// stubReporter implements the local reporter interface (Helper + Errorf) so
+// unit tests can drive the violation path of AssertHolds without going
+// through *testing.T.
+type stubReporter struct {
+	errors []string
+}
+
+func (s *stubReporter) Helper() {}
+
+func (s *stubReporter) Errorf(format string, args ...any) {
+	s.errors = append(s.errors, format)
+}
+
+// ---------------------------------------------------------------------------
+// Bound
+// ---------------------------------------------------------------------------
+
+func TestBound_Exactly(t *testing.T) {
+	b := Exactly(3)
+	assert.False(t, b.Contains(2))
+	assert.True(t, b.Contains(3))
+	assert.False(t, b.Contains(4))
+	assert.Equal(t, "exactly 3", b.String())
+}
+
+func TestBound_AtMost(t *testing.T) {
+	b := AtMost(2)
+	assert.True(t, b.Contains(0))
+	assert.True(t, b.Contains(2))
+	assert.False(t, b.Contains(3))
+	assert.Equal(t, "at most 2", b.String())
+}
+
+func TestBound_AtLeast(t *testing.T) {
+	b := AtLeast(1)
+	assert.False(t, b.Contains(0))
+	assert.True(t, b.Contains(1))
+	assert.True(t, b.Contains(1_000_000))
+	assert.Equal(t, "at least 1", b.String())
+}
+
+func TestBound_Range(t *testing.T) {
+	b := Range(2, 5)
+	assert.False(t, b.Contains(1))
+	assert.True(t, b.Contains(2))
+	assert.True(t, b.Contains(4))
+	assert.True(t, b.Contains(5))
+	assert.False(t, b.Contains(6))
+	assert.Equal(t, "between 2 and 5", b.String())
+}
+
+// ---------------------------------------------------------------------------
+// Contract assertions (via the unexported assert helper that takes reporter)
+// ---------------------------------------------------------------------------
+
+func TestStageContract_Pass(t *testing.T) {
+	contract := StageContract{
+		Stage: "demo",
+		PerSend: Ops{
+			"events.demo.x": Exactly(1),
+			"events.demo.y": AtMost(2),
+		},
+	}
+	snap := Snapshot{counts: map[Op]int{
+		"events.demo.x": 1,
+		"events.demo.y": 0,
+	}}
+	r := &stubReporter{}
+	contract.assert(r, snap)
+	assert.Empty(t, r.errors)
+}
+
+func TestStageContract_AllViolationsReported(t *testing.T) {
+	contract := StageContract{
+		Stage: "demo",
+		PerSend: Ops{
+			"events.demo.x": Exactly(1),
+			"events.demo.y": AtMost(0),
+		},
+	}
+	snap := Snapshot{counts: map[Op]int{
+		"events.demo.x": 5,
+		"events.demo.y": 7,
+	}}
+	r := &stubReporter{}
+	contract.assert(r, snap)
+	assert.Len(t, r.errors, 2, "both clauses should report independently")
+}
+
+func TestPipelineInvariants_Pass(t *testing.T) {
+	inv := PipelineInvariants{
+		Label: "store-budget",
+		PerSend: Ops{
+			"store.Load": Exactly(1),
+			"store.Save": Exactly(1),
+		},
+	}
+	snap := Snapshot{counts: map[Op]int{"store.Load": 1, "store.Save": 1}}
+	r := &stubReporter{}
+	inv.assert(r, snap)
+	assert.Empty(t, r.errors)
+}
+
+func TestPipelineInvariants_Fail(t *testing.T) {
+	inv := PipelineInvariants{
+		Label: "store-budget",
+		PerSend: Ops{
+			"store.Load": Exactly(1),
+		},
+	}
+	snap := Snapshot{counts: map[Op]int{"store.Load": 2}}
+	r := &stubReporter{}
+	inv.assert(r, snap)
+	assert.Len(t, r.errors, 1)
+}
+
+func TestPipelineInvariants_DefaultLabel(t *testing.T) {
+	inv := PipelineInvariants{
+		PerSend: Ops{"x": Exactly(0)},
+	}
+	snap := Snapshot{counts: map[Op]int{"x": 1}}
+	r := &stubReporter{}
+	inv.assert(r, snap)
+	assert.Len(t, r.errors, 1)
+}
+
+// AssertHolds itself is the public *testing.T variant — exercise it once
+// against a passing case so the t.Helper / delegation path is covered.
+func TestStageContract_AssertHolds_Public(t *testing.T) {
+	contract := StageContract{
+		Stage:   "demo",
+		PerSend: Ops{"x": AtMost(0)},
+	}
+	contract.AssertHolds(t, Snapshot{counts: map[Op]int{"x": 0}})
+}
+
+func TestPipelineInvariants_AssertHolds_Public(t *testing.T) {
+	inv := PipelineInvariants{PerSend: Ops{"x": AtMost(0)}}
+	inv.AssertHolds(t, Snapshot{counts: map[Op]int{"x": 0}})
+}
+
+// ---------------------------------------------------------------------------
+// probedStore
+// ---------------------------------------------------------------------------
+
+func TestProbedStore_CountsCallsAndForwards(t *testing.T) {
+	inner := statestore.NewMemoryStore()
+	s := newProbedStore(inner)
+
+	state := &statestore.ConversationState{ID: "c1"}
+	require.NoError(t, s.Save(context.Background(), state))
+	got, err := s.Load(context.Background(), "c1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NoError(t, s.Save(context.Background(), state))
+
+	loads, saves, forks := s.snapshot()
+	assert.Equal(t, 1, loads)
+	assert.Equal(t, 2, saves)
+	assert.Equal(t, 0, forks)
+
+	s.reset()
+	loads, saves, forks = s.snapshot()
+	assert.Equal(t, 0, loads)
+	assert.Equal(t, 0, saves)
+	assert.Equal(t, 0, forks)
+}
+
+func TestProbedStore_ForkCounts(t *testing.T) {
+	inner := statestore.NewMemoryStore()
+	require.NoError(t, inner.Save(context.Background(), &statestore.ConversationState{ID: "src"}))
+	s := newProbedStore(inner)
+	require.NoError(t, s.Fork(context.Background(), "src", "dst"))
+	_, _, forks := s.snapshot()
+	assert.Equal(t, 1, forks)
+}
+
+// ---------------------------------------------------------------------------
+// Probes (Snapshot / ResetCounters / Bus)
+// ---------------------------------------------------------------------------
+
+const (
+	eventDeliveryTimeout = 2 * time.Second
+	eventDeliveryPoll    = 5 * time.Millisecond
+)
+
+func newTestProbes(t *testing.T) *Probes {
+	t.Helper()
+	bus := events.NewEventBus()
+	t.Cleanup(bus.Close)
+	p := &Probes{
+		store:  newProbedStore(statestore.NewMemoryStore()),
+		bus:    bus,
+		events: map[events.EventType]int{},
+	}
+	bus.SubscribeAll(func(e *events.Event) {
+		p.mu.Lock()
+		p.events[e.Type]++
+		p.mu.Unlock()
+	})
+	return p
+}
+
+func TestProbes_SnapshotIncludesEventsAndStore(t *testing.T) {
+	p := newTestProbes(t)
+
+	require.NoError(t, p.store.Save(context.Background(), &statestore.ConversationState{ID: "x"}))
+	p.bus.Publish(&events.Event{Type: events.EventTemplateRendered})
+	p.bus.Publish(&events.Event{Type: events.EventTemplateRendered})
+	p.bus.Publish(&events.Event{Type: events.EventTemplateStarted})
+
+	require.Eventually(t, func() bool {
+		s := p.Snapshot()
+		return s.Count("events.prompt.template.rendered") == 2 &&
+			s.Count("events.prompt.template.started") == 1
+	}, eventDeliveryTimeout, eventDeliveryPoll)
+
+	snap := p.Snapshot()
+	assert.Equal(t, 0, snap.Count("events.prompt.template.failed"))
+	assert.Equal(t, 1, snap.Count("store.Save"))
+
+	all := snap.All()
+	assert.Equal(t, 2, all["events.prompt.template.rendered"])
+	// All() returns a copy — mutating it must not affect future snapshots.
+	all["events.prompt.template.rendered"] = 999
+	assert.Equal(t, 2, p.Snapshot().Count("events.prompt.template.rendered"))
+}
+
+func TestProbes_ResetCounters(t *testing.T) {
+	p := newTestProbes(t)
+
+	require.NoError(t, p.store.Save(context.Background(), &statestore.ConversationState{ID: "x"}))
+	p.bus.Publish(&events.Event{Type: events.EventTemplateRendered})
+	require.Eventually(t, func() bool {
+		return p.Snapshot().Count("events.prompt.template.rendered") == 1
+	}, eventDeliveryTimeout, eventDeliveryPoll)
+
+	p.ResetCounters()
+	snap := p.Snapshot()
+	assert.Equal(t, 0, snap.Count("store.Save"))
+	assert.Equal(t, 0, snap.Count("events.prompt.template.rendered"))
+}
+
+func TestProbes_BusReturnsSameInstance(t *testing.T) {
+	p := newTestProbes(t)
+	assert.Same(t, p.bus, p.Bus())
+}
+
+// ---------------------------------------------------------------------------
+// Run (smoke + seed)
+// ---------------------------------------------------------------------------
+
+func TestRun_DefaultsAreSane(t *testing.T) {
+	p, conv := Run(t, RunOptions{})
+	require.NotNil(t, p)
+	require.NotNil(t, conv)
+	// Counters reset post-Open: a fresh Snapshot reports zero.
+	snap := p.Snapshot()
+	assert.Equal(t, 0, snap.Count("store.Load"))
+	assert.Equal(t, 0, snap.Count("store.Save"))
+}
+
+func TestRun_SeedHistoryFlowsThroughSend(t *testing.T) {
+	const seedN = 3
+	p, conv := Run(t, RunOptions{SeedHistory: seedN})
+	require.NotNil(t, conv)
+
+	_, err := conv.Send(context.Background(), "ping")
+	require.NoError(t, err)
+
+	// The pipeline must Save at least once; Load count is left for the
+	// pipeline contract test in the parent package to assert.
+	assert.GreaterOrEqual(t, p.Snapshot().Count("store.Save"), 1)
+}

--- a/sdk/integration/probes/provider.go
+++ b/sdk/integration/probes/provider.go
@@ -1,0 +1,92 @@
+package probes
+
+import (
+	"context"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// probedProvider wraps a providers.Provider and counts Predict / PredictStream
+// calls. It is the simplest path to count auto-summarize traffic, because the
+// LLMSummarizer calls Provider.Predict directly without going through the
+// pipeline ProviderStage (so no provider.call.* events fire for summary work).
+//
+// The wrapper implements only the base Provider interface — it does NOT
+// satisfy ToolSupport. That is intentional: summarization does not use
+// tools, and keeping the wrapper minimal avoids accidentally being passed
+// where the agent tool-loop needs ToolSupport.
+type probedProvider struct {
+	inner providers.Provider
+
+	mu      sync.Mutex
+	predict int
+	stream  int
+}
+
+func newProbedProvider(inner providers.Provider) *probedProvider {
+	return &probedProvider{inner: inner}
+}
+
+// ID delegates to the inner provider.
+func (p *probedProvider) ID() string { return p.inner.ID() }
+
+// Model delegates to the inner provider.
+func (p *probedProvider) Model() string { return p.inner.Model() }
+
+// SupportsStreaming delegates to the inner provider.
+func (p *probedProvider) SupportsStreaming() bool { return p.inner.SupportsStreaming() }
+
+// ShouldIncludeRawOutput delegates to the inner provider.
+func (p *probedProvider) ShouldIncludeRawOutput() bool { return p.inner.ShouldIncludeRawOutput() }
+
+// Close delegates to the inner provider.
+func (p *probedProvider) Close() error { return p.inner.Close() }
+
+// CalculateCost delegates to the inner provider.
+func (p *probedProvider) CalculateCost(inputTokens, outputTokens, cachedTokens int) types.CostInfo {
+	return p.inner.CalculateCost(inputTokens, outputTokens, cachedTokens)
+}
+
+// Predict counts the call and forwards to the inner provider.
+//
+// Signature must match providers.Provider; PredictionRequest is passed by
+// value there and we cannot deviate.
+//
+//nolint:gocritic // hugeParam — locked by interface contract.
+func (p *probedProvider) Predict(
+	ctx context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.mu.Lock()
+	p.predict++
+	p.mu.Unlock()
+	return p.inner.Predict(ctx, req)
+}
+
+// PredictStream counts the call and forwards to the inner provider.
+//
+//nolint:gocritic // hugeParam — locked by interface contract.
+func (p *probedProvider) PredictStream(
+	ctx context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	p.mu.Lock()
+	p.stream++
+	p.mu.Unlock()
+	return p.inner.PredictStream(ctx, req)
+}
+
+func (p *probedProvider) reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.predict, p.stream = 0, 0
+}
+
+func (p *probedProvider) predicts() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.predict
+}
+
+// Compile-time assertion that probedProvider implements providers.Provider.
+var _ providers.Provider = (*probedProvider)(nil)

--- a/sdk/integration/probes/runner.go
+++ b/sdk/integration/probes/runner.go
@@ -59,6 +59,16 @@ type RunOptions struct {
 	// provider or a different state store), but doing so will defeat the
 	// corresponding probe.
 	SDKOptions []sdk.Option
+	// AutoSummarize, when non-nil, wires sdk.WithAutoSummarize using the
+	// probes' counted summarizer provider, so summarizer.Predict shows up
+	// in Snapshot.Count.
+	AutoSummarize *AutoSummarizeOpts
+}
+
+// AutoSummarizeOpts configures probed auto-summarization.
+type AutoSummarizeOpts struct {
+	Threshold int
+	BatchSize int
 }
 
 // numDefaultOptions tracks the count of options Run installs internally.
@@ -67,15 +77,18 @@ const numDefaultOptions = 5
 // Run wires probes around a fresh sdk.Conversation and returns both. Counters
 // are reset before Run returns, so the caller observes only post-Open traffic.
 //
-// Cleanup (closing the conv and the bus) is registered with t.Cleanup.
+// Cleanup (closing the conv and the bus) is registered with tb.Cleanup.
+//
+// Accepts testing.TB so both *testing.T (unit / integration tests) and
+// *testing.B (benchmarks) can use the helper.
 //
 // RunOptions is intentionally passed by value: tests benefit from the inline
 // struct-literal call site (Run(t, RunOptions{SeedHistory: 5})), and the
 // per-call cost of an 80-byte copy is negligible against the work Run does.
 //
 //nolint:gocritic // hugeParam suppression — see godoc above.
-func Run(t *testing.T, ro RunOptions) (*Probes, *sdk.Conversation) {
-	t.Helper()
+func Run(tb testing.TB, ro RunOptions) (*Probes, *sdk.Conversation) {
+	tb.Helper()
 
 	packJSON := ro.PackJSON
 	if packJSON == "" {
@@ -93,26 +106,35 @@ func Run(t *testing.T, ro RunOptions) (*Probes, *sdk.Conversation) {
 	inner := statestore.NewMemoryStore()
 
 	if ro.SeedHistory > 0 {
-		seedStore(t, inner, convID, ro.SeedHistory)
+		seedStore(tb, inner, convID, ro.SeedHistory)
 	}
 
 	bus := events.NewEventBus()
-	t.Cleanup(func() { bus.Close() })
+	tb.Cleanup(func() { bus.Close() })
+
+	summarizerInner := mock.NewProvider("probes-summarizer", "probes-summarizer-model", false)
 
 	p := &Probes{
-		store:  newProbedStore(inner),
-		bus:    bus,
-		events: make(map[events.EventType]int),
+		store:              newProbedStore(inner),
+		bus:                bus,
+		summarizerProvider: newProbedProvider(summarizerInner),
+		events:             make(map[events.EventType]int),
+		eventRecords:       make(map[events.EventType][]*events.Event),
 	}
 	bus.SubscribeAll(func(e *events.Event) {
 		p.mu.Lock()
 		p.events[e.Type]++
+		p.eventRecords[e.Type] = append(p.eventRecords[e.Type], e)
 		p.mu.Unlock()
 	})
 
 	provider := mock.NewProvider("probes-mock", "probes-model", false)
 
-	allOpts := make([]sdk.Option, 0, numDefaultOptions+len(ro.SDKOptions))
+	extraSlots := len(ro.SDKOptions)
+	if ro.AutoSummarize != nil {
+		extraSlots++
+	}
+	allOpts := make([]sdk.Option, 0, numDefaultOptions+extraSlots)
 	allOpts = append(allOpts,
 		sdk.WithProvider(provider),
 		sdk.WithSkipSchemaValidation(),
@@ -120,19 +142,24 @@ func Run(t *testing.T, ro RunOptions) (*Probes, *sdk.Conversation) {
 		sdk.WithConversationID(convID),
 		sdk.WithEventBus(bus),
 	)
+	if ro.AutoSummarize != nil {
+		allOpts = append(allOpts, sdk.WithAutoSummarize(
+			p.summarizerProvider, ro.AutoSummarize.Threshold, ro.AutoSummarize.BatchSize,
+		))
+	}
 	allOpts = append(allOpts, ro.SDKOptions...)
 
-	packPath := writePackFile(t, packJSON)
+	packPath := writePackFile(tb, packJSON)
 	conv, err := sdk.Open(packPath, promptName, allOpts...)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = conv.Close() })
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = conv.Close() })
 
 	p.ResetCounters()
 	return p, conv
 }
 
-func seedStore(t *testing.T, store statestore.Store, convID string, n int) {
-	t.Helper()
+func seedStore(tb testing.TB, store statestore.Store, convID string, n int) {
+	tb.Helper()
 	msgs := make([]types.Message, n)
 	for i := range n {
 		role := "user"
@@ -141,16 +168,16 @@ func seedStore(t *testing.T, store statestore.Store, convID string, n int) {
 		}
 		msgs[i] = types.Message{Role: role, Content: "prior"}
 	}
-	require.NoError(t, store.Save(context.Background(), &statestore.ConversationState{
+	require.NoError(tb, store.Save(context.Background(), &statestore.ConversationState{
 		ID:       convID,
 		Messages: msgs,
 	}))
 }
 
-func writePackFile(t *testing.T, pack string) string {
-	t.Helper()
-	dir := t.TempDir()
+func writePackFile(tb testing.TB, pack string) string {
+	tb.Helper()
+	dir := tb.TempDir()
 	path := filepath.Join(dir, "probes.pack.json")
-	require.NoError(t, os.WriteFile(path, []byte(pack), packFilePerms))
+	require.NoError(tb, os.WriteFile(path, []byte(pack), packFilePerms))
 	return path
 }

--- a/sdk/integration/probes/runner.go
+++ b/sdk/integration/probes/runner.go
@@ -1,0 +1,156 @@
+package probes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// minimalPackJSON is a tiny valid pack used by Run when the caller does not
+// supply one. Mirrors the pack used in sdk/integration/helpers_test.go but
+// kept here so probes can be used from any test package without coupling.
+const minimalPackJSON = `{
+	"id": "probes-default-pack",
+	"version": "1.0.0",
+	"description": "Default pack for probe-based contract tests",
+	"prompts": {
+		"chat": {
+			"id": "chat",
+			"name": "Chat",
+			"system_template": "You are a helpful assistant."
+		}
+	}
+}`
+
+const (
+	defaultPromptName = "chat"
+	defaultConvID     = "probes-conv"
+	packFilePerms     = 0o600
+)
+
+// RunOptions configures a probed conversation.
+//
+// Zero values give a sensible default: a fresh in-memory store, the minimal
+// pack, the "chat" prompt, a deterministic conversation ID, and a mock
+// provider. Tests override only what they need.
+type RunOptions struct {
+	// PackJSON is the pack definition. If empty, a minimal default is used.
+	PackJSON string
+	// PromptName selects the prompt within the pack. Defaults to "chat".
+	PromptName string
+	// ConversationID is passed to sdk.WithConversationID. Defaults to
+	// "probes-conv".
+	ConversationID string
+	// SeedHistory pre-populates the conversation with N prior messages
+	// (alternating user/assistant). Used to exercise stages whose work
+	// scales with conversation length.
+	SeedHistory int
+	// SDKOptions are appended after the probe-default options. Caller-supplied
+	// options can override defaults (for example, providing a non-mock
+	// provider or a different state store), but doing so will defeat the
+	// corresponding probe.
+	SDKOptions []sdk.Option
+}
+
+// numDefaultOptions tracks the count of options Run installs internally.
+const numDefaultOptions = 5
+
+// Run wires probes around a fresh sdk.Conversation and returns both. Counters
+// are reset before Run returns, so the caller observes only post-Open traffic.
+//
+// Cleanup (closing the conv and the bus) is registered with t.Cleanup.
+//
+// RunOptions is intentionally passed by value: tests benefit from the inline
+// struct-literal call site (Run(t, RunOptions{SeedHistory: 5})), and the
+// per-call cost of an 80-byte copy is negligible against the work Run does.
+//
+//nolint:gocritic // hugeParam suppression — see godoc above.
+func Run(t *testing.T, ro RunOptions) (*Probes, *sdk.Conversation) {
+	t.Helper()
+
+	packJSON := ro.PackJSON
+	if packJSON == "" {
+		packJSON = minimalPackJSON
+	}
+	promptName := ro.PromptName
+	if promptName == "" {
+		promptName = defaultPromptName
+	}
+	convID := ro.ConversationID
+	if convID == "" {
+		convID = defaultConvID
+	}
+
+	inner := statestore.NewMemoryStore()
+
+	if ro.SeedHistory > 0 {
+		seedStore(t, inner, convID, ro.SeedHistory)
+	}
+
+	bus := events.NewEventBus()
+	t.Cleanup(func() { bus.Close() })
+
+	p := &Probes{
+		store:  newProbedStore(inner),
+		bus:    bus,
+		events: make(map[events.EventType]int),
+	}
+	bus.SubscribeAll(func(e *events.Event) {
+		p.mu.Lock()
+		p.events[e.Type]++
+		p.mu.Unlock()
+	})
+
+	provider := mock.NewProvider("probes-mock", "probes-model", false)
+
+	allOpts := make([]sdk.Option, 0, numDefaultOptions+len(ro.SDKOptions))
+	allOpts = append(allOpts,
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+		sdk.WithStateStore(p.store),
+		sdk.WithConversationID(convID),
+		sdk.WithEventBus(bus),
+	)
+	allOpts = append(allOpts, ro.SDKOptions...)
+
+	packPath := writePackFile(t, packJSON)
+	conv, err := sdk.Open(packPath, promptName, allOpts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	p.ResetCounters()
+	return p, conv
+}
+
+func seedStore(t *testing.T, store statestore.Store, convID string, n int) {
+	t.Helper()
+	msgs := make([]types.Message, n)
+	for i := range n {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		msgs[i] = types.Message{Role: role, Content: "prior"}
+	}
+	require.NoError(t, store.Save(context.Background(), &statestore.ConversationState{
+		ID:       convID,
+		Messages: msgs,
+	}))
+}
+
+func writePackFile(t *testing.T, pack string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "probes.pack.json")
+	require.NoError(t, os.WriteFile(path, []byte(pack), packFilePerms))
+	return path
+}

--- a/sdk/integration/probes/store.go
+++ b/sdk/integration/probes/store.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // probedStore wraps a statestore.Store and counts Load/Save/Fork calls.
@@ -62,3 +63,73 @@ func (s *probedStore) snapshot() (loads, saves, forks int) {
 
 // Compile-time assertion that probedStore implements statestore.Store.
 var _ statestore.Store = (*probedStore)(nil)
+
+// The probed store also surfaces optional statestore interfaces by delegating
+// to the inner store when it implements them. Without these passthroughs,
+// IncrementalSaveStage's type assertions against MessageReader / MessageAppender
+// would fail on the wrapper and silently disable auto-summarization /
+// incremental save — which would make probe-based contract tests vacuous.
+
+// LoadRecentMessages delegates if the inner supports MessageReader;
+// otherwise returns ErrNotFound so callers fall back to Load().
+func (s *probedStore) LoadRecentMessages(
+	ctx context.Context, id string, n int,
+) ([]types.Message, error) {
+	if r, ok := s.inner.(statestore.MessageReader); ok {
+		return r.LoadRecentMessages(ctx, id, n)
+	}
+	return nil, statestore.ErrNotFound
+}
+
+// MessageCount delegates if the inner supports MessageReader; otherwise
+// returns ErrNotFound.
+func (s *probedStore) MessageCount(ctx context.Context, id string) (int, error) {
+	if r, ok := s.inner.(statestore.MessageReader); ok {
+		return r.MessageCount(ctx, id)
+	}
+	return 0, statestore.ErrNotFound
+}
+
+// AppendMessages delegates if the inner supports MessageAppender; otherwise
+// returns ErrNotFound. Save calls remain counted via the wrapper's Save.
+func (s *probedStore) AppendMessages(
+	ctx context.Context, id string, messages []types.Message,
+) error {
+	if a, ok := s.inner.(statestore.MessageAppender); ok {
+		return a.AppendMessages(ctx, id, messages)
+	}
+	return statestore.ErrNotFound
+}
+
+// LoadMetadata delegates if the inner supports MetadataAccessor; otherwise
+// returns ErrNotFound.
+func (s *probedStore) LoadMetadata(
+	ctx context.Context, id string,
+) (map[string]any, error) {
+	if a, ok := s.inner.(statestore.MetadataAccessor); ok {
+		return a.LoadMetadata(ctx, id)
+	}
+	return nil, statestore.ErrNotFound
+}
+
+// LoadSummaries delegates if the inner supports SummaryAccessor; otherwise
+// returns nil (no summaries) so callers don't error.
+func (s *probedStore) LoadSummaries(
+	ctx context.Context, id string,
+) ([]statestore.Summary, error) {
+	if a, ok := s.inner.(statestore.SummaryAccessor); ok {
+		return a.LoadSummaries(ctx, id)
+	}
+	return nil, nil
+}
+
+// SaveSummary delegates if the inner supports SummaryAccessor; otherwise
+// returns ErrNotFound.
+func (s *probedStore) SaveSummary(
+	ctx context.Context, id string, summary statestore.Summary,
+) error {
+	if a, ok := s.inner.(statestore.SummaryAccessor); ok {
+		return a.SaveSummary(ctx, id, summary)
+	}
+	return statestore.ErrNotFound
+}

--- a/sdk/integration/probes/store.go
+++ b/sdk/integration/probes/store.go
@@ -1,0 +1,64 @@
+package probes
+
+import (
+	"context"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+)
+
+// probedStore wraps a statestore.Store and counts Load/Save/Fork calls.
+// Counts are reset by Probes.ResetCounters at the start of each observation
+// window, so init-time traffic from sdk.Open does not pollute Send-scoped
+// assertions.
+type probedStore struct {
+	inner statestore.Store
+
+	mu    sync.Mutex
+	loads int
+	saves int
+	forks int
+}
+
+func newProbedStore(inner statestore.Store) *probedStore {
+	return &probedStore{inner: inner}
+}
+
+// Load forwards to the inner store and increments the Load counter.
+func (s *probedStore) Load(ctx context.Context, id string) (*statestore.ConversationState, error) {
+	s.mu.Lock()
+	s.loads++
+	s.mu.Unlock()
+	return s.inner.Load(ctx, id)
+}
+
+// Save forwards to the inner store and increments the Save counter.
+func (s *probedStore) Save(ctx context.Context, state *statestore.ConversationState) error {
+	s.mu.Lock()
+	s.saves++
+	s.mu.Unlock()
+	return s.inner.Save(ctx, state)
+}
+
+// Fork forwards to the inner store and increments the Fork counter.
+func (s *probedStore) Fork(ctx context.Context, sourceID, newID string) error {
+	s.mu.Lock()
+	s.forks++
+	s.mu.Unlock()
+	return s.inner.Fork(ctx, sourceID, newID)
+}
+
+func (s *probedStore) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.loads, s.saves, s.forks = 0, 0, 0
+}
+
+func (s *probedStore) snapshot() (loads, saves, forks int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loads, s.saves, s.forks
+}
+
+// Compile-time assertion that probedStore implements statestore.Store.
+var _ statestore.Store = (*probedStore)(nil)


### PR DESCRIPTION
## Summary

- Adds `sdk/integration/probes/`: instrumented dependency layer (counted state store, event-bus listener) + first-class operation-budget contracts (`StageContract`, `PipelineInvariants`, `Bound`).
- Adds three contract test files that exercise the regime against the real SDK pipeline.
- Verifies issue #1035 *and* a related redundant-`Load` bug uncovered during investigation, without applying a fix in this PR.

## Why

The codebase had no vocabulary for "external operation budget per Send". Tests asserted "did X happen" (boolean) rather than "did X happen exactly N times" (cardinal). `MetricsStage` counts elements but not side effects. Stage authors could ship per-element work that should have been per-Send, with no test-level signal — the failure mode that allowed #1035 through.

## What's new

| File | Role |
|---|---|
| `probes/probes.go` | `Probes` + `Snapshot` API (counts events + store ops) |
| `probes/store.go` | `probedStore` — counts `Load`/`Save`/`Fork` |
| `probes/contract.go` | `StageContract`, `PipelineInvariants`, `Bound` (`Exactly`/`AtMost`/`AtLeast`/`Range`) |
| `probes/runner.go` | `Run(t, RunOptions{...})` — wires probes into a real SDK conversation, resets counters post-Open |
| `probes/probes_test.go` | 100% unit coverage of probes |
| `contract_template_test.go` | TemplateStage contract over a history-depth matrix |
| `contract_pipeline_test.go` | Cross-stage `store.Load == 1` / `store.Save == 1` invariant |
| `contract_known_bugs_test.go` | Pinned canaries for #1035 + the redundant-Load bug |

## Verification of #1035

`TestKnownBug_Issue1035_HistoryMultipliesTemplateEvents` proves the bug:

```
seedHistory=4 →
  events.prompt.template.started:  5  (contract: 1)
  events.prompt.template.rendered: 5  (contract: 1)
```

`TestContract_TemplateStage` declares the desired contract (`Exactly(1)`) and skips the violating cases with `#1035` references. Removing the `t.Skipf` is the signal the fix has landed.

## Bonus finding

Investigating #1035 surfaced a second bug: `StateStoreSaveStage.loadOrCreateState` performs a `store.Load` inside the save path, doubling per-Send Load count from 1 to 2. Pinned in `TestKnownBug_StateStoreSaveStageRedundantLoad`; contracted in `TestContract_PipelineStateStoreBudget`.

## How fixes will use this

1. Implement the fix (e.g. skip rendering on `from_history` elements).
2. Run `go test ./sdk/integration/...`. The `KnownBug_*` test fails because the count is now 1, not 5.
3. Delete the known-bug test; remove the matching `t.Skipf` in the contract test. Contract enforces `Exactly(1)` going forward.

## Test plan

- [x] `go test ./sdk/integration/probes/... -count=1` (100% coverage)
- [x] `go test ./sdk/integration/... -count=1` (full suite)
- [x] `golangci-lint run ./sdk/integration/...` (0 issues)
- [x] Pre-commit hook (lint + build + test + coverage) green
- [ ] CI pipeline green
