### PR TITLE
feat(sdk): WithToolDescriptorOverride + memory__remember category (#1033)

### DIFF
--- a/docs/src/content/docs/sdk/how-to/override-capability-tools.md
+++ b/docs/src/content/docs/sdk/how-to/override-capability-tools.md
@@ -1,0 +1,88 @@
+---
+title: Override Capability Tool Definitions
+sidebar:
+  order: 4
+---
+
+Capabilities like memory, workflow, and A2A register their tools with hard-coded descriptors (description, input/output schema). When you need to customize those — for example, to add a domain-specific parameter that downstream consumers rely on — you don't need to fork PromptKit. Use `WithToolDescriptorOverride` to patch the descriptor after the capability registers it.
+
+## When to use this
+
+- The default tool description doesn't fit your deployment's wording or policy.
+- You need to add or constrain an input parameter (e.g. an `enum` validating allowed values).
+- You want to relabel the namespace or augment the output schema.
+- Consumer code (Omnia, internal services) reads a non-standard parameter and the LLM should know to set it.
+
+## Basic example
+
+```go
+import (
+    "github.com/AltairaLabs/PromptKit/runtime/memory"
+    "github.com/AltairaLabs/PromptKit/runtime/tools"
+    "github.com/AltairaLabs/PromptKit/sdk"
+)
+
+conv, err := sdk.Open(packPath, "chat",
+    sdk.WithMemory(store, scope),
+    sdk.WithToolDescriptorOverride(memory.RememberToolName,
+        func(d *tools.ToolDescriptor) {
+            d.Description = "Store something in memory; tag it with a category."
+        }),
+)
+```
+
+The patch function receives a clone of the descriptor that the capability registered. Mutate fields in place; the SDK re-registers the patched descriptor before the first `Send()`.
+
+## Replacing the input schema
+
+```go
+import "encoding/json"
+
+categorySchema := json.RawMessage(`{
+    "type": "object",
+    "properties": {
+        "content":  {"type": "string"},
+        "category": {
+            "type": "string",
+            "enum": ["memory:health", "memory:identity", "memory:preferences"]
+        }
+    },
+    "required": ["content", "category"]
+}`)
+
+sdk.WithToolDescriptorOverride(memory.RememberToolName,
+    func(d *tools.ToolDescriptor) {
+        d.InputSchema = categorySchema
+    })
+```
+
+## Composing overrides
+
+Multiple overrides for the same tool compose in registration order — the second sees the descriptor already mutated by the first:
+
+```go
+sdk.WithToolDescriptorOverride("memory__remember",
+    func(d *tools.ToolDescriptor) { d.Description = "step 1" }),
+sdk.WithToolDescriptorOverride("memory__remember",
+    func(d *tools.ToolDescriptor) { d.Description += " | step 2" }),
+// Final description: "step 1 | step 2"
+```
+
+## Tolerance to version skew
+
+If you reference a tool name that doesn't exist in the registry (for example, a tool that was renamed or removed in a newer PromptKit release), the override is logged at WARN level and skipped. Other overrides still apply. This means override lists survive PromptKit upgrades without breaking the consumer build.
+
+## How it works
+
+`WithToolDescriptorOverride` does not subvert the capability — the capability still registers its tools with their defaults. Once all capabilities have run `RegisterTools`, the SDK iterates the configured overrides and:
+
+1. Looks up each tool by name in the registry. If absent, logs and skips.
+2. Clones the descriptor (so mutations don't leak into shared registry state).
+3. Calls the patch function on the clone.
+4. Re-registers the patched descriptor (`Registry.Register` is last-write-wins, so this replaces the original).
+
+## Does not affect
+
+- The executor that handles the tool. The executor remains the one the capability registered. If you need the executor to recognise a new parameter, you must change the capability code (or wrap the capability — see [Capabilities reference](/sdk/reference/capabilities/)).
+- Other tools — patches operate on a clone of one descriptor.
+- Capability lifecycle (Init, Close).

--- a/runtime/memory/tools.go
+++ b/runtime/memory/tools.go
@@ -86,6 +86,7 @@ func (e *Executor) remember(ctx context.Context, args json.RawMessage) (json.Raw
 		Content    string         `json:"content"`
 		Type       string         `json:"type,omitempty"`
 		Confidence float64        `json:"confidence,omitempty"`
+		Category   string         `json:"category,omitempty"`
 		Metadata   map[string]any `json:"metadata,omitempty"`
 	}
 	if err := json.Unmarshal(args, &a); err != nil {
@@ -108,6 +109,16 @@ func (e *Executor) remember(ctx context.Context, args json.RawMessage) (json.Raw
 		Confidence: a.Confidence,
 		Metadata:   a.Metadata,
 		Scope:      e.scope,
+	}
+	// Stash the LLM-supplied consent category so downstream consumers
+	// (e.g. Omnia's PII redactor / per-category retention) can read it
+	// without re-classifying. Empty category is allowed and lets a
+	// server-side classifier act as the fallback.
+	if a.Category != "" {
+		if m.Metadata == nil {
+			m.Metadata = make(map[string]any)
+		}
+		m.Metadata[MetaKeyConsentCategory] = a.Category
 	}
 	// Always set provenance — overwrites any LLM-provided value.
 	m.SetProvenance(ProvenanceUserRequested)
@@ -253,6 +264,19 @@ func buildMemoryToolDescriptors() []*tools.ToolDescriptor {
 					"confidence": map[string]any{
 						"type":        "number",
 						"description": "How confident you are (0.0-1.0). Default: 0.8.",
+					},
+					"category": map[string]any{
+						"type": "string",
+						"description": "Optional consent category for downstream policies " +
+							"(retention, redaction, opt-out). Pick the most specific match " +
+							"for the memory's content; leave unset if uncertain so a " +
+							"server-side classifier can decide. Suggested values:\n" +
+							"  memory:identity     names, IDs, pronouns, contact details\n" +
+							"  memory:preferences  likes, dislikes, settings, configuration\n" +
+							"  memory:context      work/project context, domain knowledge, current task\n" +
+							"  memory:location     geographic info, addresses, IP\n" +
+							"  memory:health       health, dietary, medical, accessibility info\n" +
+							"  memory:history      past conversations, decisions, what was said before",
 					},
 					"metadata": map[string]any{
 						"type":        "object",

--- a/runtime/memory/tools_test.go
+++ b/runtime/memory/tools_test.go
@@ -231,6 +231,55 @@ func TestMemoryExecutor_Remember_PreservesUserMetadata(t *testing.T) {
 	}
 }
 
+func TestMemoryExecutor_Remember_StashesConsentCategory(t *testing.T) {
+	store := NewInMemoryStore()
+	scope := map[string]string{"user_id": "u1"}
+	exec := NewExecutor(store, scope)
+	desc := &tools.ToolDescriptor{Name: RememberToolName}
+
+	args, _ := json.Marshal(map[string]any{
+		"content":  "allergic to peanuts",
+		"category": "memory:health",
+	})
+	if _, err := exec.Execute(context.Background(), desc, args); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+
+	all, _ := store.List(context.Background(), scope, ListOptions{})
+	if len(all) != 1 {
+		t.Fatalf("expected 1 memory, got %d", len(all))
+	}
+	if got := all[0].Metadata[MetaKeyConsentCategory]; got != "memory:health" {
+		t.Errorf("%s = %q, want %q", MetaKeyConsentCategory, got, "memory:health")
+	}
+	// Provenance still pinned regardless of category presence.
+	if all[0].Metadata[MetaKeyProvenance] != string(ProvenanceUserRequested) {
+		t.Errorf("provenance lost when category supplied")
+	}
+}
+
+func TestMemoryExecutor_Remember_NoCategoryLeavesMetadataAlone(t *testing.T) {
+	store := NewInMemoryStore()
+	scope := map[string]string{"user_id": "u1"}
+	exec := NewExecutor(store, scope)
+	desc := &tools.ToolDescriptor{Name: RememberToolName}
+
+	args, _ := json.Marshal(map[string]any{
+		"content": "I prefer dark mode",
+	})
+	if _, err := exec.Execute(context.Background(), desc, args); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+
+	all, _ := store.List(context.Background(), scope, ListOptions{})
+	if len(all) != 1 {
+		t.Fatalf("expected 1 memory, got %d", len(all))
+	}
+	if _, ok := all[0].Metadata[MetaKeyConsentCategory]; ok {
+		t.Errorf("expected %s absent when not supplied", MetaKeyConsentCategory)
+	}
+}
+
 func TestMemoryExecutor_Remember_UserCannotOverrideProvenance(t *testing.T) {
 	store := NewInMemoryStore()
 	scope := map[string]string{"user_id": "u1"}

--- a/runtime/memory/types.go
+++ b/runtime/memory/types.go
@@ -34,6 +34,13 @@ const (
 	// MetaKeyProvenance is the well-known Metadata key for provenance.
 	MetaKeyProvenance = "provenance"
 
+	// MetaKeyConsentCategory is the well-known Metadata key for the
+	// consent category supplied by the calling LLM via memory__remember.
+	// Populated when present; consumers that classify server-side may
+	// fall back to their own classifier if absent. Values are not
+	// validated by PromptKit — semantics are owned by the consumer.
+	MetaKeyConsentCategory = "consent_category"
+
 	// ProvenanceUserRequested — user explicitly asked the agent to remember this.
 	ProvenanceUserRequested Provenance = "user_requested"
 

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -427,6 +427,14 @@ func (c *Conversation) buildPipelineConfig(
 				logger.Debug("capability registered no tools", "capability", cap.Name())
 			}
 		}
+		// Apply per-tool descriptor overrides AFTER capabilities have
+		// registered their defaults. Last-write-wins semantics in
+		// Registry.Register let us replace any tool by name regardless of
+		// which capability owns it. See WithToolDescriptorOverride.
+		if len(c.config.toolDescriptorOverrides) > 0 {
+			applyToolDescriptorOverrides(c.toolRegistry, c.config.toolDescriptorOverrides)
+		}
+
 		c.capabilitiesRegistered = true
 		allTools := c.toolRegistry.List()
 		if len(allTools) > 0 {

--- a/sdk/integration/contract_tool_overrides_test.go
+++ b/sdk/integration/contract_tool_overrides_test.go
@@ -1,0 +1,142 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/sdk"
+	"github.com/AltairaLabs/PromptKit/sdk/integration/probes"
+)
+
+// memoryScope is a fixed scope used by override tests; the memory capability
+// no-ops when user_id is empty (see capability_memory.go), so it must be
+// non-empty for tools to actually register.
+var memoryScope = map[string]string{"user_id": "override-test-user"}
+
+// runWithMemoryAndRegistry opens a probed conversation with the memory
+// capability wired up via a test-owned registry, so the test can inspect
+// final descriptor state after capability + override registration runs.
+func runWithMemoryAndRegistry(t *testing.T, extra ...sdk.Option) (*tools.Registry, *sdk.Conversation) {
+	t.Helper()
+	registry := tools.NewRegistry()
+	store := memory.NewInMemoryStore()
+	opts := []sdk.Option{
+		sdk.WithToolRegistry(registry),
+		sdk.WithMemory(store, memoryScope),
+	}
+	opts = append(opts, extra...)
+	_, conv := probes.Run(t, probes.RunOptions{SDKOptions: opts})
+	return registry, conv
+}
+
+// TestContract_ToolDescriptorOverride_PatchesDescription verifies a basic
+// case: an override on memory__remember replaces the description string.
+func TestContract_ToolDescriptorOverride_PatchesDescription(t *testing.T) {
+	const customDesc = "OMNIA-CUSTOM: store with consent category."
+
+	registry, conv := runWithMemoryAndRegistry(t,
+		sdk.WithToolDescriptorOverride(memory.RememberToolName,
+			func(d *tools.ToolDescriptor) { d.Description = customDesc }),
+	)
+
+	// Trigger pipeline build (which is where capabilities + overrides apply).
+	_, err := conv.Send(context.Background(), "hi")
+	require.NoError(t, err)
+
+	desc := registry.Get(memory.RememberToolName)
+	require.NotNil(t, desc, "memory__remember should be registered")
+	assert.Equal(t, customDesc, desc.Description)
+}
+
+// TestContract_ToolDescriptorOverride_InputSchemaReplacement covers the
+// schema path: the memory category use case from #1033.
+func TestContract_ToolDescriptorOverride_InputSchemaReplacement(t *testing.T) {
+	customSchema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"content":  {"type": "string"},
+			"category": {"type": "string", "enum": ["memory:health", "memory:identity"]}
+		},
+		"required": ["content", "category"]
+	}`)
+
+	registry, conv := runWithMemoryAndRegistry(t,
+		sdk.WithToolDescriptorOverride(memory.RememberToolName,
+			func(d *tools.ToolDescriptor) { d.InputSchema = customSchema }),
+	)
+
+	_, err := conv.Send(context.Background(), "hi")
+	require.NoError(t, err)
+
+	desc := registry.Get(memory.RememberToolName)
+	require.NotNil(t, desc)
+	assert.Contains(t, string(desc.InputSchema), `"enum"`)
+	assert.Contains(t, string(desc.InputSchema), `"memory:health"`)
+}
+
+// TestContract_ToolDescriptorOverride_ComposesInOrder verifies that two
+// overrides for the same tool compose: the second sees the descriptor
+// already mutated by the first.
+func TestContract_ToolDescriptorOverride_ComposesInOrder(t *testing.T) {
+	registry, conv := runWithMemoryAndRegistry(t,
+		sdk.WithToolDescriptorOverride(memory.RememberToolName,
+			func(d *tools.ToolDescriptor) { d.Description = "step1" }),
+		sdk.WithToolDescriptorOverride(memory.RememberToolName,
+			func(d *tools.ToolDescriptor) { d.Description += " | step2" }),
+	)
+
+	_, err := conv.Send(context.Background(), "hi")
+	require.NoError(t, err)
+
+	desc := registry.Get(memory.RememberToolName)
+	require.NotNil(t, desc)
+	assert.Equal(t, "step1 | step2", desc.Description)
+}
+
+// TestContract_ToolDescriptorOverride_MissingToolWarnsAndSkips ensures the
+// override is tolerant of version skew. Naming a tool that doesn't exist
+// must not break Send.
+func TestContract_ToolDescriptorOverride_MissingToolWarnsAndSkips(t *testing.T) {
+	registry, conv := runWithMemoryAndRegistry(t,
+		sdk.WithToolDescriptorOverride("nonexistent__tool",
+			func(d *tools.ToolDescriptor) { d.Description = "won't apply" }),
+		sdk.WithToolDescriptorOverride(memory.RememberToolName,
+			func(d *tools.ToolDescriptor) { d.Description = "this one applies" }),
+	)
+
+	_, err := conv.Send(context.Background(), "hi")
+	require.NoError(t, err)
+
+	// The valid override still applies.
+	desc := registry.Get(memory.RememberToolName)
+	require.NotNil(t, desc)
+	assert.Equal(t, "this one applies", desc.Description)
+	// The invalid override is silently absent.
+	assert.Nil(t, registry.Get("nonexistent__tool"))
+}
+
+// TestContract_ToolDescriptorOverride_DoesNotAffectOtherTools confirms a
+// patch on one descriptor doesn't leak into others — the cloning behavior
+// in applyToolDescriptorOverrides matters for shared registry state.
+func TestContract_ToolDescriptorOverride_DoesNotAffectOtherTools(t *testing.T) {
+	registry, conv := runWithMemoryAndRegistry(t,
+		sdk.WithToolDescriptorOverride(memory.RememberToolName,
+			func(d *tools.ToolDescriptor) { d.Description = "PATCHED" }),
+	)
+
+	_, err := conv.Send(context.Background(), "hi")
+	require.NoError(t, err)
+
+	other := registry.Get(memory.RecallToolName)
+	require.NotNil(t, other)
+	assert.NotEqual(t, "PATCHED", other.Description,
+		"recall tool description should be untouched")
+	assert.Contains(t, strings.ToLower(other.Description), "search")
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -187,6 +187,12 @@ type config struct {
 	// Platform capabilities (workflow, a2a, memory, etc.)
 	capabilities []Capability
 
+	// Tool descriptor overrides applied after capabilities register their
+	// tools. Each entry patches a registered descriptor by name. Maintained
+	// as an ordered slice (not a map) so multiple overrides for the same
+	// tool compose deterministically.
+	toolDescriptorOverrides []toolDescriptorOverride
+
 	// Skills configuration
 	skillsDirs      []string
 	skillSources    []skills.SkillSource

--- a/sdk/tool_descriptor_override.go
+++ b/sdk/tool_descriptor_override.go
@@ -1,0 +1,123 @@
+package sdk
+
+import (
+	"errors"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// Errors returned by WithToolDescriptorOverride for misuse.
+var (
+	errEmptyToolOverrideName = errors.New("WithToolDescriptorOverride: tool name must not be empty")
+	errNilToolOverrideFn     = errors.New("WithToolDescriptorOverride: patch function must not be nil")
+)
+
+// ToolDescriptorPatchFn mutates a tool descriptor in place.
+//
+// Patch functions receive a clone of the descriptor that the capability
+// originally registered, so mutations cannot leak into other conversations
+// or other consumers of the same registry.
+//
+// To replace the entire descriptor (rare), assign field-by-field. To wrap
+// or augment the description, mutate d.Description. To extend the input
+// schema, replace d.InputSchema with a new json.RawMessage.
+type ToolDescriptorPatchFn func(d *tools.ToolDescriptor)
+
+// toolDescriptorOverride pairs a tool name with a patch function.
+type toolDescriptorOverride struct {
+	name string
+	fn   ToolDescriptorPatchFn
+}
+
+// WithToolDescriptorOverride patches a registered capability tool descriptor
+// after capabilities have registered their defaults.
+//
+// This is a general-purpose hook: it works for memory tools, workflow tools,
+// A2A tools, skills, and any future capability that registers tools through
+// the standard Capability.RegisterTools path. Use it to customize tool
+// descriptions, extend input schemas, or relabel namespaces without forking
+// PromptKit.
+//
+// Multiple overrides for the same tool compose in registration order — the
+// patch from the second WithToolDescriptorOverride sees the descriptor
+// already mutated by the first.
+//
+// If no tool with the given name is registered when overrides are applied,
+// the override is logged and skipped. This makes the option tolerant of
+// version skew (a tool removed upstream does not break the consumer's
+// override list).
+//
+// Example: customize the memory__remember tool's description for an Omnia
+// deployment that wants the LLM to tag a category alongside the memory.
+//
+//	conv, err := sdk.Open(packPath, "chat",
+//	    sdk.WithMemory(store, scope),
+//	    sdk.WithToolDescriptorOverride("memory__remember",
+//	        func(d *tools.ToolDescriptor) {
+//	            d.Description = "Store something in memory ..."
+//	            d.InputSchema = customSchemaJSON
+//	        }),
+//	)
+func WithToolDescriptorOverride(name string, fn ToolDescriptorPatchFn) Option {
+	return func(c *config) error {
+		if name == "" {
+			return errEmptyToolOverrideName
+		}
+		if fn == nil {
+			return errNilToolOverrideFn
+		}
+		c.toolDescriptorOverrides = append(c.toolDescriptorOverrides, toolDescriptorOverride{
+			name: name,
+			fn:   fn,
+		})
+		return nil
+	}
+}
+
+// applyToolDescriptorOverrides applies the configured patches to descriptors
+// already registered in the tool registry. Called once after all capabilities
+// have run RegisterTools, before the conversation marks capability registration
+// complete.
+//
+// Each override gets a clone of the descriptor; if the patch mutates the
+// clone, the new descriptor is re-registered (Registry.Register is
+// last-write-wins, so the patched descriptor replaces the original).
+func applyToolDescriptorOverrides(
+	registry *tools.Registry, overrides []toolDescriptorOverride,
+) {
+	for _, ov := range overrides {
+		desc := registry.Get(ov.name)
+		if desc == nil {
+			logger.Warn("tool descriptor override skipped: tool not registered",
+				"name", ov.name)
+			continue
+		}
+		patched := cloneToolDescriptor(desc)
+		ov.fn(patched)
+		if err := registry.Register(patched); err != nil {
+			logger.Warn("tool descriptor override failed to re-register",
+				"name", ov.name, "error", err)
+			continue
+		}
+		logger.Debug("tool descriptor override applied", "name", ov.name)
+	}
+}
+
+// cloneToolDescriptor returns a deep-enough copy of d so a patch fn can
+// mutate fields without affecting the original. JSON-typed schema fields
+// are cloned by byte-copy; slice fields are copied; pointer-typed fields
+// are not deep-copied (the pipeline does not mutate them in practice).
+func cloneToolDescriptor(d *tools.ToolDescriptor) *tools.ToolDescriptor {
+	if d == nil {
+		return nil
+	}
+	cp := *d
+	if d.InputSchema != nil {
+		cp.InputSchema = append([]byte(nil), d.InputSchema...)
+	}
+	if d.OutputSchema != nil {
+		cp.OutputSchema = append([]byte(nil), d.OutputSchema...)
+	}
+	return &cp
+}

--- a/sdk/tool_descriptor_override_test.go
+++ b/sdk/tool_descriptor_override_test.go
@@ -1,0 +1,128 @@
+package sdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+func TestWithToolDescriptorOverride_RejectsEmptyName(t *testing.T) {
+	c := &config{}
+	err := WithToolDescriptorOverride("", func(*tools.ToolDescriptor) {})(c)
+	require.ErrorIs(t, err, errEmptyToolOverrideName)
+	assert.Empty(t, c.toolDescriptorOverrides)
+}
+
+func TestWithToolDescriptorOverride_RejectsNilFn(t *testing.T) {
+	c := &config{}
+	err := WithToolDescriptorOverride("memory__remember", nil)(c)
+	require.ErrorIs(t, err, errNilToolOverrideFn)
+	assert.Empty(t, c.toolDescriptorOverrides)
+}
+
+func TestWithToolDescriptorOverride_AppendsToConfigSlice(t *testing.T) {
+	c := &config{}
+	require.NoError(t, WithToolDescriptorOverride("a", func(*tools.ToolDescriptor) {})(c))
+	require.NoError(t, WithToolDescriptorOverride("b", func(*tools.ToolDescriptor) {})(c))
+	require.NoError(t, WithToolDescriptorOverride("a", func(*tools.ToolDescriptor) {})(c))
+
+	require.Len(t, c.toolDescriptorOverrides, 3)
+	assert.Equal(t, "a", c.toolDescriptorOverrides[0].name)
+	assert.Equal(t, "b", c.toolDescriptorOverrides[1].name)
+	assert.Equal(t, "a", c.toolDescriptorOverrides[2].name,
+		"duplicate names are preserved so they compose in order")
+}
+
+func TestApplyToolDescriptorOverrides_PatchesDescriptor(t *testing.T) {
+	registry := tools.NewRegistry()
+	require.NoError(t, registry.Register(&tools.ToolDescriptor{
+		Name:        "test__tool",
+		Description: "original",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}))
+
+	applyToolDescriptorOverrides(registry, []toolDescriptorOverride{
+		{name: "test__tool", fn: func(d *tools.ToolDescriptor) { d.Description = "patched" }},
+	})
+
+	got := registry.Get("test__tool")
+	require.NotNil(t, got)
+	assert.Equal(t, "patched", got.Description)
+}
+
+func TestApplyToolDescriptorOverrides_SkipsMissingTool(t *testing.T) {
+	registry := tools.NewRegistry()
+	// Empty registry — nothing to override.
+	applyToolDescriptorOverrides(registry, []toolDescriptorOverride{
+		{name: "absent__tool", fn: func(d *tools.ToolDescriptor) { d.Description = "never" }},
+	})
+
+	assert.Nil(t, registry.Get("absent__tool"))
+}
+
+func TestApplyToolDescriptorOverrides_ClonesBeforePatch(t *testing.T) {
+	registry := tools.NewRegistry()
+	original := &tools.ToolDescriptor{
+		Name:        "test__tool",
+		Description: "original",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}
+	require.NoError(t, registry.Register(original))
+
+	applyToolDescriptorOverrides(registry, []toolDescriptorOverride{
+		{name: "test__tool", fn: func(d *tools.ToolDescriptor) {
+			d.Description = "patched"
+			d.InputSchema = json.RawMessage(`{"type":"string"}`)
+		}},
+	})
+
+	// The original struct passed to Register must not be mutated by the
+	// override — clones isolate them. (Registry.Register stores a pointer,
+	// so this also guards against accidental shared-state mutation.)
+	assert.Equal(t, "original", original.Description)
+	assert.JSONEq(t, `{"type":"object"}`, string(original.InputSchema))
+}
+
+func TestApplyToolDescriptorOverrides_ComposeOrder(t *testing.T) {
+	registry := tools.NewRegistry()
+	require.NoError(t, registry.Register(&tools.ToolDescriptor{
+		Name:        "test__tool",
+		Description: "base",
+	}))
+
+	applyToolDescriptorOverrides(registry, []toolDescriptorOverride{
+		{name: "test__tool", fn: func(d *tools.ToolDescriptor) { d.Description = "x" }},
+		{name: "test__tool", fn: func(d *tools.ToolDescriptor) { d.Description += "y" }},
+		{name: "test__tool", fn: func(d *tools.ToolDescriptor) { d.Description += "z" }},
+	})
+
+	assert.Equal(t, "xyz", registry.Get("test__tool").Description)
+}
+
+func TestCloneToolDescriptor_NilInput(t *testing.T) {
+	assert.Nil(t, cloneToolDescriptor(nil))
+}
+
+func TestCloneToolDescriptor_DeepCopiesSchemas(t *testing.T) {
+	src := &tools.ToolDescriptor{
+		Name:         "x",
+		Description:  "d",
+		InputSchema:  json.RawMessage(`{"a":1}`),
+		OutputSchema: json.RawMessage(`{"b":2}`),
+	}
+
+	cp := cloneToolDescriptor(src)
+	require.NotNil(t, cp)
+	require.NotSame(t, src, cp)
+
+	// Mutate clone's schemas; src must remain intact.
+	cp.InputSchema[0] = '['
+	cp.OutputSchema[0] = '['
+
+	assert.Equal(t, byte('{'), src.InputSchema[0])
+	assert.Equal(t, byte('{'), src.OutputSchema[0])
+}


### PR DESCRIPTION
Closes #1033.

## Summary

- New SDK option `WithToolDescriptorOverride(name, patchFn)` lets consumers customize any capability-registered tool descriptor without forking PromptKit. Works for memory, workflow, A2A, skills, and any future capability that registers tools through `Capability.RegisterTools`.
- `memory__remember` gains an optional `category` parameter with a rubric covering the seven Omnia consent categories. The executor stashes it in `Memory.Metadata[MetaKeyConsentCategory]` when supplied; absent values let server-side classifiers act as fallback.
- Provenance was already pinned to `ProvenanceUserRequested` from an earlier change; this PR adds tests asserting it stays that way.
- New how-to doc at `docs/src/content/docs/sdk/how-to/override-capability-tools.md`.

## How `WithToolDescriptorOverride` works

After all capabilities run `RegisterTools`, the SDK iterates configured overrides. For each one it:

1. Looks up the named descriptor in `tools.Registry`. If absent (e.g. tool renamed/removed upstream), logs at WARN and skips.
2. Clones the descriptor (so mutations don't leak into shared registry state).
3. Calls the patch function on the clone.
4. Re-registers (`Registry.Register` is last-write-wins, replacing the original).

Multiple overrides for the same tool compose in registration order — the second sees state already mutated by the first.

The override only changes the descriptor the LLM sees. The executor remains the one the capability registered, so adding a parameter that the runtime executor doesn't recognise is harmless.

## Tests

- `runtime/memory/tools_test.go` — category stashed, absent when not supplied, provenance preserved alongside.
- `sdk/tool_descriptor_override_test.go` — input validation, append ordering, clone-before-patch isolation, missing-tool skip, compose order, schema deep copy. (92% coverage on the file.)
- `sdk/integration/contract_tool_overrides_test.go` — end-to-end through `Send`: description patch, schema replacement, two-step compose, missing-tool skip, no-leak-to-other-tools.

## Test plan

- [x] `go test ./runtime/memory/... ./sdk/...` green
- [x] `golangci-lint run --new-from-rev HEAD` 0 issues
- [x] Pre-commit hook (lint + build + test + coverage on changed files) green
- [ ] CI green
- [ ] Document downstream Omnia migration steps separately if needed
