### PR TITLE
fix(providers/claude): route Bedrock spec to bedrock-runtime, not api.anthropic.com (#1029)

### DIFF
--- a/runtime/providers/claude/bedrock_unit_test.go
+++ b/runtime/providers/claude/bedrock_unit_test.go
@@ -1,0 +1,68 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// TestBedrockAnthropicEndpoint covers the Bedrock URL helper added for
+// PromptKit#1029 — Bedrock-hosted Anthropic was previously routed to
+// api.anthropic.com and 404ed.
+func TestBedrockAnthropicEndpoint(t *testing.T) {
+	tests := []struct {
+		region string
+		want   string
+	}{
+		{"us-east-1", "https://bedrock-runtime.us-east-1.amazonaws.com"},
+		{"us-west-2", "https://bedrock-runtime.us-west-2.amazonaws.com"},
+		{"eu-central-1", "https://bedrock-runtime.eu-central-1.amazonaws.com"},
+		{"", ""}, // empty region → empty result so callers can fall back
+	}
+	for _, tt := range tests {
+		t.Run(tt.region, func(t *testing.T) {
+			got := bedrockAnthropicEndpoint(tt.region)
+			if got != tt.want {
+				t.Errorf("bedrockAnthropicEndpoint(%q) = %q, want %q",
+					tt.region, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewProviderWithCredential_BedrockComputesBaseURL pins the regression
+// for #1029 in the claude factory: when caller passes Platform=bedrock,
+// non-empty Region, and an empty BaseURL, the factory must compute the
+// Bedrock-Runtime URL rather than leave baseURL empty.
+func TestNewProviderWithCredential_BedrockComputesBaseURL(t *testing.T) {
+	p := NewProviderWithCredential(
+		"id", "anthropic.claude-haiku-4-5-20251001-v1:0",
+		"", // BaseURL intentionally empty — factory must compute from PlatformConfig
+		providers.ProviderDefaults{},
+		false, nil,
+		bedrockPlatform,
+		&providers.PlatformConfig{Type: "bedrock", Region: "us-west-2"},
+	)
+	if got, want := p.baseURL, "https://bedrock-runtime.us-west-2.amazonaws.com"; got != want {
+		t.Errorf("p.baseURL = %q, want %q", got, want)
+	}
+}
+
+// TestNewProviderWithCredential_BedrockExplicitBaseURLWins ensures an
+// explicit BaseURL still takes precedence over the computed Bedrock URL,
+// matching the documented "callers that pass an explicit baseURL always win"
+// contract.
+func TestNewProviderWithCredential_BedrockExplicitBaseURLWins(t *testing.T) {
+	const explicit = "https://bedrock-runtime.eu-central-1.amazonaws.com"
+	p := NewProviderWithCredential(
+		"id", "anthropic.claude-haiku-4-5-20251001-v1:0",
+		explicit,
+		providers.ProviderDefaults{},
+		false, nil,
+		bedrockPlatform,
+		&providers.PlatformConfig{Type: "bedrock", Region: "us-west-2"},
+	)
+	if p.baseURL != explicit {
+		t.Errorf("p.baseURL = %q, want explicit %q", p.baseURL, explicit)
+	}
+}

--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -67,6 +67,18 @@ func vertexAnthropicEndpoint(region, project string) string {
 	)
 }
 
+// bedrockAnthropicEndpoint returns the AWS Bedrock Runtime base URL for the
+// given region. The result has no trailing slash; per-call code appends
+// `/model/{model}/invoke` (or `/invoke-with-response-stream`) to address a
+// specific model. Returns an empty string if region is empty so callers
+// can fall back to an explicit BaseURL.
+func bedrockAnthropicEndpoint(region string) string {
+	if region == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com", region)
+}
+
 // azureAnthropicDeploymentEndpoint returns the Azure AI Foundry base URL
 // for an Anthropic deployment on an AIServices account. The result ends
 // in `/openai/deployments/{deployment}` (no trailing slash); per-call
@@ -139,6 +151,8 @@ func NewProviderWithCredential(
 			baseURL = vertexAnthropicEndpoint(platformConfig.Region, platformConfig.Project)
 		case platform == azurePlatform && platformConfig.Endpoint != "":
 			baseURL = azureAnthropicDeploymentEndpoint(platformConfig.Endpoint, model)
+		case platform == bedrockPlatform && platformConfig.Region != "":
+			baseURL = bedrockAnthropicEndpoint(platformConfig.Region)
 		}
 	}
 

--- a/runtime/providers/claude/vertex_unit_test.go
+++ b/runtime/providers/claude/vertex_unit_test.go
@@ -180,15 +180,20 @@ func TestNewProviderWithCredential_DerivesVertexURL(t *testing.T) {
 		}
 	})
 
-	t.Run("non-vertex platform does not derive URL", func(t *testing.T) {
-		pc := &providers.PlatformConfig{Type: "bedrock", Region: "us-west-2"}
+	t.Run("unrecognized platform does not derive URL", func(t *testing.T) {
+		// Note: bedrock used to be exercised here as the "non-vertex"
+		// example, but Bedrock URL derivation was added in #1029. Use
+		// a synthetic unsupported platform name instead so the test
+		// continues to assert "platforms outside the supported set
+		// fall through to an empty derived URL".
+		pc := &providers.PlatformConfig{Type: "unknown-platform", Region: "us-west-2"}
 		p := NewProviderWithCredential(
 			"test", "claude-haiku-4-5", "",
 			providers.ProviderDefaults{},
-			false, cred, "bedrock", pc,
+			false, cred, "unknown-platform", pc,
 		)
 		if p.baseURL != "" {
-			t.Errorf("non-vertex platform should not derive URL, got %q", p.baseURL)
+			t.Errorf("unrecognized platform should not derive URL, got %q", p.baseURL)
 		}
 	})
 }

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -238,8 +238,11 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 			// Skip the api.anthropic.com default for hyperscaler-hosted
 			// Anthropic — the claude factory builds the platform URL from
 			// PlatformConfig (Vertex: publishers/anthropic/models; Azure:
-			// openai/deployments/{deployment}). Same #1010 root cause.
-			if spec.Platform != "vertex" && spec.Platform != "azure" {
+			// openai/deployments/{deployment}; Bedrock:
+			// bedrock-runtime.{region}.amazonaws.com). Same #1010 root cause.
+			// See #1029 for the Bedrock case that previously fell through.
+			if spec.Platform != "vertex" && spec.Platform != "azure" &&
+				spec.Platform != "bedrock" {
 				baseURL = "https://api.anthropic.com"
 			}
 		case "imagen":

--- a/runtime/providers/registry_extended_test.go
+++ b/runtime/providers/registry_extended_test.go
@@ -301,6 +301,47 @@ func TestCreateProviderFromSpecClaudeAzureSkipsDefault(t *testing.T) {
 	}
 }
 
+// TestCreateProviderFromSpecClaudeBedrockSkipsDefault is the regression test
+// for #1029: api.anthropic.com must not clobber spec.BaseURL when
+// Platform=="bedrock". The claude factory derives the
+// bedrock-runtime.{region}.amazonaws.com URL from PlatformConfig.Region in
+// that case; if the registry overwrites BaseURL, requests 404 against the
+// public Anthropic API.
+func TestCreateProviderFromSpecClaudeBedrockSkipsDefault(t *testing.T) {
+	originalFactory := providerFactories["claude"]
+	capturedBaseURL := "sentinel"
+	providerFactories["claude"] = func(spec ProviderSpec) (Provider, error) {
+		capturedBaseURL = spec.BaseURL
+		return &mockProviderForTest{id: spec.ID}, nil
+	}
+	defer func() {
+		if originalFactory != nil {
+			providerFactories["claude"] = originalFactory
+		} else {
+			delete(providerFactories, "claude")
+		}
+	}()
+
+	spec := ProviderSpec{
+		ID:       "bedrock-claude",
+		Type:     "claude",
+		Model:    testModelName,
+		Platform: "bedrock",
+		PlatformConfig: &PlatformConfig{
+			Type:   "bedrock",
+			Region: "us-west-2",
+		},
+	}
+
+	if _, err := CreateProviderFromSpec(spec); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if capturedBaseURL != "" {
+		t.Errorf("Expected empty BaseURL for claude+bedrock, got %q (regression of #1029)", capturedBaseURL)
+	}
+}
+
 func TestCreateProviderFromSpecCustomBaseURL(t *testing.T) {
 	customURL := "https://custom.api.example.com"
 	spec := ProviderSpec{


### PR DESCRIPTION
Closes #1029.

## Summary

`CreateProviderFromSpec` skipped the `api.anthropic.com` BaseURL default for `claude+vertex` and `claude+azure` but not `claude+bedrock`. Specs with empty `BaseURL` and `Platform="bedrock"` got rewritten to `https://api.anthropic.com`; the claude factory then appended `/model/{model}/invoke[-with-response-stream]` and POSTed against the public Anthropic API → 404.

## Fix

Two-line surface change:

1. **`runtime/providers/registry.go`** — add `bedrock` to the claude skip list, matching the precedent set by `openai+bedrock` (line 225).
2. **`runtime/providers/claude/claude.go`** — add `bedrockAnthropicEndpoint(region)` returning `https://bedrock-runtime.{region}.amazonaws.com`, and wire `NewProviderWithCredential` to derive that URL from `PlatformConfig.Region` when `BaseURL` is empty. Mirrors the existing vertex/azure derivation paths. Explicit `BaseURL` still wins.

## Tests

- `runtime/providers/registry_extended_test.go::TestCreateProviderFromSpecClaudeBedrockSkipsDefault` — pins the registry-level skip-list contract for bedrock alongside the existing vertex/azure cases.
- `runtime/providers/claude/bedrock_unit_test.go`:
  - `TestBedrockAnthropicEndpoint` — region → URL helper + empty-region fallback.
  - `TestNewProviderWithCredential_BedrockComputesBaseURL` — factory derives the URL from `PlatformConfig.Region`.
  - `TestNewProviderWithCredential_BedrockExplicitBaseURLWins` — explicit `BaseURL` precedence.
- `runtime/providers/claude/vertex_unit_test.go` — the `non-vertex platform does not derive URL` case used `bedrock` as the example; that was effectively pinning the bug. Replaced with a synthetic unrecognized platform name so the test asserts what it intended.

## Verification

- `go test ./runtime/providers/...` green (all 12 packages, including the new claude bedrock unit tests).
- `golangci-lint run --new-from-rev HEAD` 0 issues.
- Pre-commit hook green: 84.2% coverage on `claude.go`, 93.5% on `registry.go`.

## Test plan

- [x] Local `go test ./runtime/providers/...`
- [x] `golangci-lint run` clean
- [x] Pre-commit lint+build+test+coverage green
- [ ] CI green
- [ ] Validation against an actual Bedrock account is up to a downstream consumer; this PR ships the URL-derivation logic and the unit tests pin the invariants.
