### PR TITLE
feat(events,evals): widen EvalEventData with Details, structured Violations, Trigger (#1028)

### DIFF
--- a/runtime/evals/runner.go
+++ b/runtime/evals/runner.go
@@ -179,7 +179,7 @@ func (r *EvalRunner) runEvals(
 			result.SessionID = evalCtx.SessionID
 			result.TurnIndex = evalCtx.TurnIndex
 			r.runHooks(ctx, &defs[i], evalCtx, result)
-			r.emitResult(result)
+			r.emitResult(&defs[i], result)
 			results = append(results, *result)
 		}
 	}
@@ -332,7 +332,11 @@ func (r *EvalRunner) invokeHook(
 }
 
 // emitResult publishes eval.completed or eval.failed via the emitter (if set).
-func (r *EvalRunner) emitResult(result *EvalResult) {
+//
+// def is the EvalDef the result came from; when non-nil its Trigger is
+// propagated to the event payload. Some test callers pass nil where
+// Trigger doesn't matter.
+func (r *EvalRunner) emitResult(def *EvalDef, result *EvalResult) {
 	if r.emitter == nil {
 		return
 	}
@@ -344,8 +348,12 @@ func (r *EvalRunner) emitResult(result *EvalResult) {
 		DurationMs:  result.DurationMs,
 		Error:       result.Error,
 		Message:     result.Message,
+		Details:     result.Details,
 		Skipped:     result.Skipped,
 		SkipReason:  result.SkipReason,
+	}
+	if def != nil {
+		data.Trigger = string(def.Trigger)
 	}
 	// Determine passed status: skip skipped evals, use handler's Value (bool)
 	// if available (accounts for min_score/max_score thresholds), otherwise
@@ -357,8 +365,15 @@ func (r *EvalRunner) emitResult(result *EvalResult) {
 			data.Passed = true
 		}
 	}
-	for _, v := range result.Violations {
-		data.Violations = append(data.Violations, v.Description)
+	if len(result.Violations) > 0 {
+		data.Violations = make([]events.EvalViolationData, len(result.Violations))
+		for i, v := range result.Violations {
+			data.Violations[i] = events.EvalViolationData{
+				TurnIndex:   v.TurnIndex,
+				Description: v.Description,
+				Evidence:    v.Evidence,
+			}
+		}
 	}
 	if result.Error != "" {
 		r.emitter.EvalFailed(data)

--- a/runtime/evals/runner_test.go
+++ b/runtime/evals/runner_test.go
@@ -634,7 +634,7 @@ func TestEvalRunner_EmitResult(t *testing.T) {
 	emitter := events.NewEmitter(bus, "run1", "sess1", "conv1")
 	r := NewEvalRunner(reg, WithEmitter(emitter))
 
-	r.emitResult(&EvalResult{
+	r.emitResult(nil, &EvalResult{
 		EvalID: "e1",
 		Type:   "test",
 		Score:  func() *float64 { v := 1.0; return &v }(),
@@ -668,7 +668,7 @@ func TestEvalRunner_EmitResult_UsesValueForPassed(t *testing.T) {
 	r := NewEvalRunner(reg, WithEmitter(emitter))
 
 	// Score is 0.7 (below 1.0) but Value is true (threshold passed)
-	r.emitResult(&EvalResult{
+	r.emitResult(nil, &EvalResult{
 		EvalID: "e1",
 		Type:   "test",
 		Score:  func() *float64 { v := 0.7; return &v }(),
@@ -680,6 +680,98 @@ func TestEvalRunner_EmitResult_UsesValueForPassed(t *testing.T) {
 		data := e.Data.(*events.EvalCompletedData)
 		if !data.Passed {
 			t.Error("expected passed=true from Value, not score")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+// TestEvalRunner_EmitResult_Lossless1028 pins the #1028 contract: the event
+// payload carries Trigger, Details, and full structured Violations, not the
+// previously-flattened []string. Removing any of these would have to update
+// this test (and the consumer-facing payload).
+func TestEvalRunner_EmitResult_Lossless1028(t *testing.T) {
+	reg := NewEvalTypeRegistry()
+	bus := events.NewEventBus()
+	defer bus.Close()
+
+	received := make(chan *events.Event, 10)
+	bus.Subscribe(events.EventEvalCompleted, func(e *events.Event) {
+		received <- e
+	})
+
+	emitter := events.NewEmitter(bus, "", "", "")
+	r := NewEvalRunner(reg, WithEmitter(emitter))
+
+	def := &EvalDef{ID: "e1", Type: "test", Trigger: TriggerEveryTurn}
+	r.emitResult(def, &EvalResult{
+		EvalID:  "e1",
+		Type:    "test",
+		Score:   func() *float64 { v := 1.0; return &v }(),
+		Details: map[string]any{"per_criterion": []float64{0.9, 0.95}, "model": "judge-v1"},
+		Violations: []EvalViolation{
+			{
+				TurnIndex:   2,
+				Description: "tool args drifted",
+				Evidence:    map[string]any{"expected": "x", "actual": "y"},
+			},
+			{TurnIndex: 5, Description: "format mismatch"},
+		},
+	})
+
+	select {
+	case e := <-received:
+		data := e.Data.(*events.EvalCompletedData)
+		if data.Trigger != string(TriggerEveryTurn) {
+			t.Errorf("Trigger = %q, want %q", data.Trigger, TriggerEveryTurn)
+		}
+		if data.Details["model"] != "judge-v1" {
+			t.Errorf("Details[\"model\"] = %v, want %q", data.Details["model"], "judge-v1")
+		}
+		if len(data.Violations) != 2 {
+			t.Fatalf("Violations len = %d, want 2", len(data.Violations))
+		}
+		v0 := data.Violations[0]
+		if v0.TurnIndex != 2 || v0.Description != "tool args drifted" {
+			t.Errorf("Violation[0] = %+v, want TurnIndex=2 Description=\"tool args drifted\"", v0)
+		}
+		if v0.Evidence["expected"] != "x" || v0.Evidence["actual"] != "y" {
+			t.Errorf("Violation[0].Evidence lost evidence map")
+		}
+		v1 := data.Violations[1]
+		if v1.TurnIndex != 5 || v1.Description != "format mismatch" {
+			t.Errorf("Violation[1] = %+v, want TurnIndex=5 Description=\"format mismatch\"", v1)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for EvalCompleted event")
+	}
+}
+
+// TestEvalRunner_EmitResult_TriggerOmittedWhenNilDef sanity-checks the
+// nil-def fallback (used by the existing test scaffolding above).
+func TestEvalRunner_EmitResult_TriggerOmittedWhenNilDef(t *testing.T) {
+	reg := NewEvalTypeRegistry()
+	bus := events.NewEventBus()
+	defer bus.Close()
+
+	received := make(chan *events.Event, 10)
+	bus.Subscribe(events.EventEvalCompleted, func(e *events.Event) {
+		received <- e
+	})
+
+	emitter := events.NewEmitter(bus, "", "", "")
+	r := NewEvalRunner(reg, WithEmitter(emitter))
+
+	r.emitResult(nil, &EvalResult{
+		EvalID: "e1", Type: "test",
+		Score: func() *float64 { v := 1.0; return &v }(),
+	})
+
+	select {
+	case e := <-received:
+		data := e.Data.(*events.EvalCompletedData)
+		if data.Trigger != "" {
+			t.Errorf("Trigger should be empty when def is nil, got %q", data.Trigger)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out")

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -604,22 +604,38 @@ type ClientToolResolvedData struct {
 
 // --- Eval events (consolidated) ---
 
+// EvalViolationData mirrors evals.EvalViolation so consumers of the event
+// bus can read structured violations without importing the evals package
+// (which depends on this one). Field names and JSON tags match the source
+// struct so payloads round-trip cleanly.
+type EvalViolationData struct {
+	TurnIndex   int            `json:"turn_index"`
+	Description string         `json:"description"`
+	Evidence    map[string]any `json:"evidence,omitempty"`
+}
+
 // EvalEventData is the unified payload for eval lifecycle events
 // (completed, failed). It captures the eval result and metadata.
+//
+// Violations and Details carry the lossless content of the underlying
+// EvalResult — see https://github.com/AltairaLabs/PromptKit/issues/1028
+// for the rationale. Consumers that only want a textual summary can
+// derive it from Violations[].Description.
 type EvalEventData struct {
 	baseEventData
-	EvalID      string   `json:"eval_id"`
-	EvalType    string   `json:"eval_type"` // handler type: "llm_judge", "content_check", etc.
-	Trigger     string   `json:"trigger"`   // "every_turn", "on_session_complete", etc.
-	Passed      bool     `json:"passed"`
-	Score       *float64 `json:"score,omitempty"`
-	Explanation string   `json:"explanation,omitempty"`
-	DurationMs  int64    `json:"duration_ms"`
-	Error       string   `json:"error,omitempty"`
-	Message     string   `json:"message,omitempty"`
-	Violations  []string `json:"violations,omitempty"` // flattened from EvalViolation
-	Skipped     bool     `json:"skipped,omitempty"`
-	SkipReason  string   `json:"skip_reason,omitempty"`
+	EvalID      string              `json:"eval_id"`
+	EvalType    string              `json:"eval_type"` // handler type: "llm_judge", "content_check", etc.
+	Trigger     string              `json:"trigger"`   // "every_turn", "on_session_complete", etc.
+	Passed      bool                `json:"passed"`
+	Score       *float64            `json:"score,omitempty"`
+	Explanation string              `json:"explanation,omitempty"`
+	DurationMs  int64               `json:"duration_ms"`
+	Error       string              `json:"error,omitempty"`
+	Message     string              `json:"message,omitempty"`
+	Details     map[string]any      `json:"details,omitempty"`    // handler-specific structured detail
+	Violations  []EvalViolationData `json:"violations,omitempty"` // structured (was []string before #1028)
+	Skipped     bool                `json:"skipped,omitempty"`
+	SkipReason  string              `json:"skip_reason,omitempty"`
 }
 
 type (


### PR DESCRIPTION
Closes #1028.

## Summary

`EvalEventData` now carries the lossless content of `*EvalResult`. Three changes:

1. **`Violations` is now structured** — was `[]string` (a flatten of just `Description`), now `[]EvalViolationData` carrying `TurnIndex`, `Description`, `Evidence`. The new struct mirrors `evals.EvalViolation` field-for-field; it lives in `events` (not `evals`) because the events package can't import evals (cycle).
2. **`Details map[string]any` added** — surfaces handler-specific structured data (per-criterion scores, model identifiers, etc.) that was previously dropped during the `EvalResult → EvalEventData` conversion.
3. **`Trigger` is now populated** — the field already existed on the struct but `emitResult` never set it. Now plumbed from the matching `EvalDef.Trigger`.

## Implementation

- `runtime/events/types.go`: new `EvalViolationData` struct, updated `EvalEventData` definition.
- `runtime/evals/runner.go`: `emitResult` signature changes from `emitResult(result)` to `emitResult(def, result)`. Pre-existing test scaffolding that lacks a def passes `nil`; the runtime tolerates that and just omits Trigger.

## Tests

- `TestEvalRunner_EmitResult_Lossless1028` — new pin: Trigger, Details, structured Violations all flow through, evidence map preserved.
- `TestEvalRunner_EmitResult_TriggerOmittedWhenNilDef` — documents the nil-def fallback used by other tests.
- Existing `TestEvalRunner_EmitResult` cases updated to pass `nil` for the new def parameter.

## Compatibility

- **In-tree:** zero readers of `EvalEventData.Violations` outside the eval emitter itself. The bundled telemetry listener reads `EvalID`, `EvalType`, `Score`, `Explanation`, `Passed`, `Error` only. Internal SDK paths (Arena, eval middleware tests, integration tests) don't read either field. No internal breakage.
- **External (Go):** the Go type changes from `[]string` to `[]EvalViolationData`. Downstream Go consumers that read `data.Violations` need to update their type assertion.
- **External (JSON wire):** `violations` array entries change from string scalars to objects with `turn_index`/`description`/`evidence`. Consumers that consume the JSON need to update their parser. This change is the literal request of #1028 — the issue rationale is that the lossy flatten forced consumers to re-subscribe via `WithEvalHook` to recover the data.

## Test plan

- [x] `go test ./runtime/evals/... ./runtime/events/... ./sdk/integration/...` green
- [x] `golangci-lint run --new-from-rev HEAD` 0 issues
- [x] Pre-commit hook (lint + build + test + coverage on changed files) green: 93.7% on `runner.go`, 100% on `events/types.go`
- [ ] CI green
