### PR TITLE
feat(sdk): adopt providers.Registry as the agent + summarizer pool

### DIFF
--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -453,7 +453,7 @@ func (c *Conversation) buildPipelineConfig(
 
 	// Build pipeline configuration
 	pipelineCfg := &intpipeline.Config{
-		Provider:              c.config.provider,
+		Provider:              c.config.getAgentProvider(),
 		ToolRegistry:          toolRegistry,
 		PromptRegistry:        c.promptRegistry,
 		TaskType:              c.promptName,
@@ -514,8 +514,8 @@ func (c *Conversation) buildPipelineConfig(
 	if c.config.retrievalProvider != nil {
 		pipelineCfg.MessageIndex = statestore.NewInMemoryIndex(c.config.retrievalProvider)
 	}
-	if c.config.summarizeProvider != nil {
-		pipelineCfg.Summarizer = statestore.NewLLMSummarizer(c.config.summarizeProvider)
+	if sp := c.config.getSummarizeProvider(); sp != nil {
+		pipelineCfg.Summarizer = statestore.NewLLMSummarizer(sp)
 	}
 
 	// Apply parameters from prompt if available
@@ -1117,6 +1117,14 @@ func (c *Conversation) Close() error {
 	if c.mcpRegistry != nil {
 		if err := c.mcpRegistry.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to close MCP registry: %w", err))
+		}
+	}
+
+	// Close the provider pool — closes every provider registered via
+	// WithProvider, WithAutoSummarize, etc. in one shot.
+	if c.config != nil && c.config.providers != nil {
+		if err := c.config.providers.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close provider pool: %w", err))
 		}
 	}
 

--- a/sdk/conversation_test.go
+++ b/sdk/conversation_test.go
@@ -468,7 +468,8 @@ func TestConversationStateStoreMiddlewareIntegration(t *testing.T) {
 	conv := newTestConversation()
 	initInternalStateStore(conv, &config{}) // This sets up both store and ID
 
-	// Use existing mockStreamProvider (no extra setup needed)
+	// Use existing mockStreamProvider (no extra setup needed).
+	// Sets the deprecated legacy field; getAgentProvider lifts it on read.
 	conv.config.provider = &mockStreamProvider{}
 
 	ctx := context.Background()

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -52,7 +52,22 @@ type config struct {
 	// Prompt selection
 	promptName string
 
-	// Provider configuration
+	// Provider configuration. Providers used by the conversation (agent
+	// and summarizer today) are held in a single pool so they share one
+	// lifecycle. The pool is closed once on Conversation.Close. Lookups
+	// happen by ID — see agentProviderID / summarizeProviderID below.
+	// See ARCHITECTURE.md §1.1.
+	providers       *providers.Registry
+	agentProviderID string
+	// agentSet tracks whether an agent provider has been registered.
+	// We need a separate bool because providers may legitimately have
+	// empty ID() values (e.g. minimal test mocks), so empty
+	// agentProviderID is not a reliable "unset" sentinel.
+	agentSet bool
+	// Deprecated: legacy field for test scaffolding that builds *config
+	// directly. Production code uses WithProvider, which registers the
+	// provider into the pool. Reads via getAgentProvider() lift this
+	// field into the pool on first access.
 	provider   providers.Provider
 	apiKey     string
 	model      string
@@ -103,7 +118,15 @@ type config struct {
 	sttProviders   map[string]stt.Service
 	sttProviderIDs []string
 
-	// Auto-summarization for RAG context
+	// Auto-summarization for RAG context. The summarize provider is held
+	// in the providers pool; summarizeProviderID points at it.
+	summarizeProviderID string
+	// summarizeSet tracks whether a summarize provider has been registered.
+	// Empty IDs are valid for the same reason as agentSet — see above.
+	summarizeSet bool
+	// Deprecated: legacy field for test scaffolding. Production code uses
+	// WithAutoSummarize. Reads via getSummarizeProvider() lift this into
+	// the pool on first access.
 	summarizeProvider  providers.Provider
 	summarizeThreshold int
 	summarizeBatchSize int
@@ -308,9 +331,60 @@ func WithAPIKey(key string) Option {
 //	)
 func WithProvider(p providers.Provider) Option {
 	return func(c *config) error {
-		c.provider = p
+		if p == nil {
+			// Match prior behavior: WithProvider(nil) is a no-op rather
+			// than an error. Tests rely on this; callers that haven't
+			// yet resolved a provider are expected to either resolve via
+			// auto-detect or call WithProvider again.
+			return nil
+		}
+		registerAgentProvider(c, p)
 		return nil
 	}
+}
+
+// ensureProviderPool lazy-initializes the provider pool. Called by every
+// option that needs to register a provider, and by sdk.Open's resolution
+// paths that auto-detect or build providers from spec.
+func ensureProviderPool(c *config) {
+	if c.providers == nil {
+		c.providers = providers.NewRegistry()
+	}
+}
+
+// getAgentProvider returns the configured agent provider, or nil if none
+// is registered. Internal helper used by Open / pipeline construction.
+//
+// As a backward-compatibility step, this method lifts the legacy
+// `provider` field into the pool on first access if WithProvider has not
+// already done so. This lets test scaffolding that constructs *config
+// struct literals directly continue to work.
+func (c *config) getAgentProvider() providers.Provider {
+	if c.provider != nil && !c.agentSet {
+		registerAgentProvider(c, c.provider)
+	}
+	if !c.agentSet || c.providers == nil {
+		return nil
+	}
+	p, _ := c.providers.Get(c.agentProviderID)
+	return p
+}
+
+// getSummarizeProvider returns the configured summarizer provider, or
+// nil if WithAutoSummarize wasn't called. Lifts the legacy
+// `summarizeProvider` field on first access.
+func (c *config) getSummarizeProvider() providers.Provider {
+	if c.summarizeProvider != nil && !c.summarizeSet {
+		ensureProviderPool(c)
+		c.providers.Register(c.summarizeProvider)
+		c.summarizeProviderID = c.summarizeProvider.ID()
+		c.summarizeSet = true
+	}
+	if !c.summarizeSet || c.providers == nil {
+		return nil
+	}
+	p, _ := c.providers.Get(c.summarizeProviderID)
+	return p
 }
 
 // CredentialOption configures credentials for a provider.
@@ -1146,7 +1220,10 @@ func WithAutoSummarize(provider providers.Provider, threshold, batchSize int) Op
 		if batchSize <= 0 {
 			return fmt.Errorf("WithAutoSummarize: batchSize must be positive, got %d", batchSize)
 		}
-		c.summarizeProvider = provider
+		ensureProviderPool(c)
+		c.providers.Register(provider)
+		c.summarizeProviderID = provider.ID()
+		c.summarizeSet = true
 		c.summarizeThreshold = threshold
 		c.summarizeBatchSize = batchSize
 		return nil

--- a/sdk/options_test.go
+++ b/sdk/options_test.go
@@ -998,7 +998,8 @@ func TestWithAutoSummarize(t *testing.T) {
 	cfg := &config{}
 	err := opt(cfg)
 	assert.NoError(t, err)
-	assert.Equal(t, sumProvider, cfg.summarizeProvider)
+	assert.Equal(t, sumProvider, cfg.getSummarizeProvider())
+	assert.Equal(t, sumProvider.ID(), cfg.summarizeProviderID)
 	assert.Equal(t, 100, cfg.summarizeThreshold)
 	assert.Equal(t, 50, cfg.summarizeBatchSize)
 }

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -143,12 +143,12 @@ func WithRuntimeConfig(path string) Option {
 // of the host process.
 func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 	// Apply provider (use first provider if configured and no provider already set)
-	if len(spec.Providers) > 0 && c.provider == nil {
+	if len(spec.Providers) > 0 && c.getAgentProvider() == nil {
 		prov, err := createProviderFromConfig(&spec.Providers[0])
 		if err != nil {
 			return fmt.Errorf("creating provider from runtime config: %w", err)
 		}
-		c.provider = prov
+		registerAgentProvider(c, prov)
 	}
 
 	// Apply embedding providers (declarative). The first declared

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -171,14 +171,16 @@ func TestApplyRuntimeConfig_Provider_SkipsIfSet(t *testing.T) {
 	existing := &rtcMockProvider{}
 	c := &config{provider: existing}
 	require.NoError(t, applyRuntimeConfig(c, spec))
-	assert.Equal(t, existing, c.provider, "should not override existing provider")
+	// applyRuntimeConfig reads via getAgentProvider which lifts the legacy
+	// field into the pool — verify resolution returns the same instance.
+	assert.Equal(t, existing, c.getAgentProvider(), "should not override existing provider")
 }
 
 func TestApplyRuntimeConfig_EmptySpec(t *testing.T) {
 	spec := &pkgconfig.RuntimeConfigSpec{}
 	c := &config{}
 	require.NoError(t, applyRuntimeConfig(c, spec))
-	assert.Nil(t, c.provider)
+	assert.Nil(t, c.getAgentProvider())
 	assert.Empty(t, c.mcpServers)
 	assert.Nil(t, c.stateStore)
 	assert.Nil(t, c.logger)
@@ -238,7 +240,7 @@ func TestApplyRuntimeConfig_Provider_MockType(t *testing.T) {
 	c := &config{}
 	err := applyRuntimeConfig(c, spec)
 	require.NoError(t, err)
-	assert.NotNil(t, c.provider)
+	assert.NotNil(t, c.getAgentProvider())
 }
 
 func TestCreateProviderFromConfig_WithPlatform(t *testing.T) {
@@ -936,3 +938,7 @@ func (m *rtcMockStore) Fork(_ context.Context, _, _ string) error               
 
 // rtcMockProvider is a minimal providers.Provider for runtime_config tests.
 type rtcMockProvider struct{ providers.Provider }
+
+// ID overrides the embedded interface's nil method so the provider can
+// be safely registered into a providers.Registry, which keys by ID().
+func (m *rtcMockProvider) ID() string { return "rtc-mock" }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -299,7 +299,7 @@ func applyOptions(promptName string, opts []Option) (*config, error) {
 	if cfg.retrievalProvider != nil && cfg.contextWindow <= 0 {
 		return nil, fmt.Errorf("WithContextRetrieval requires WithContextWindow")
 	}
-	if cfg.summarizeProvider != nil && cfg.contextWindow <= 0 {
+	if cfg.summarizeSet && cfg.contextWindow <= 0 {
 		return nil, fmt.Errorf("WithAutoSummarize requires WithContextWindow")
 	}
 
@@ -362,10 +362,11 @@ func loadAndValidatePack(packPath, promptName string, cfg *config) (*pack.Pack, 
 }
 
 // resolveProvider auto-detects or uses the configured provider.
-// Stores the resolved provider in cfg.provider for later use.
+// Resolved provider is registered in cfg.providers and cfg.agentProviderID
+// is set to its ID.
 func resolveProvider(cfg *config) (providers.Provider, error) {
-	if cfg.provider != nil {
-		return cfg.provider, nil
+	if existing := cfg.getAgentProvider(); existing != nil {
+		return existing, nil
 	}
 
 	// Resolve credential config into an API key if set.
@@ -386,7 +387,7 @@ func resolveProvider(cfg *config) (providers.Provider, error) {
 		if err != nil {
 			return nil, err
 		}
-		cfg.provider = p
+		registerAgentProvider(cfg, p)
 		return p, nil
 	}
 
@@ -394,8 +395,16 @@ func resolveProvider(cfg *config) (providers.Provider, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect provider: %w", err)
 	}
-	cfg.provider = detected
+	registerAgentProvider(cfg, detected)
 	return detected, nil
+}
+
+// registerAgentProvider installs p as the agent provider in the pool.
+func registerAgentProvider(cfg *config, p providers.Provider) {
+	ensureProviderPool(cfg)
+	cfg.providers.Register(p)
+	cfg.agentProviderID = p.ID()
+	cfg.agentSet = true
 }
 
 // resolveCredentialAPIKey resolves a credentialConfig into an API key string.

--- a/sdk/sdk_provider_pool_test.go
+++ b/sdk/sdk_provider_pool_test.go
@@ -1,0 +1,104 @@
+package sdk
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// closingProvider is a Provider that records Close invocations. The embedded
+// interface keeps the type definition minimal — tests below only call Close
+// and ID on these instances.
+type closingProvider struct {
+	providers.Provider
+	id     string
+	closeN atomic.Int32
+}
+
+func (p *closingProvider) ID() string   { return p.id }
+func (p *closingProvider) Close() error { p.closeN.Add(1); return nil }
+
+// TestSDK_ProviderPool_RegistersBothAgentAndSummarize pins the contract that
+// WithProvider and WithAutoSummarize both feed the same providers.Registry.
+// The pool closes every registered provider exactly once when invoked.
+func TestSDK_ProviderPool_RegistersBothAgentAndSummarize(t *testing.T) {
+	agent := &closingProvider{id: "agent-test"}
+	summarizer := &closingProvider{id: "summarizer-test"}
+
+	c := &config{}
+	require.NoError(t, WithProvider(agent)(c))
+	require.NoError(t, WithAutoSummarize(summarizer, 100, 50)(c))
+
+	require.NotNil(t, c.providers, "pool should be initialised by With* options")
+	assert.Equal(t, agent, c.getAgentProvider())
+	assert.Equal(t, summarizer, c.getSummarizeProvider())
+	assert.True(t, c.agentSet)
+	assert.True(t, c.summarizeSet)
+
+	// Pool.Close fans out to every registered provider exactly once.
+	require.NoError(t, c.providers.Close())
+	assert.Equal(t, int32(1), agent.closeN.Load(),
+		"agent provider closed exactly once")
+	assert.Equal(t, int32(1), summarizer.closeN.Load(),
+		"summarizer provider closed exactly once")
+}
+
+// TestSDK_ProviderPool_LiftsLegacyAgentField pins the back-compat path: a
+// *config built directly via struct literal with the deprecated `provider`
+// field continues to work because getAgentProvider lifts it into the pool
+// transparently.
+func TestSDK_ProviderPool_LiftsLegacyAgentField(t *testing.T) {
+	legacy := &closingProvider{id: "legacy-agent"}
+	c := &config{provider: legacy}
+
+	got := c.getAgentProvider()
+	assert.Equal(t, legacy, got)
+	assert.True(t, c.agentSet, "lift should mark agentSet true")
+	assert.NotNil(t, c.providers, "pool should be initialised by lift")
+
+	// Subsequent calls hit the pool, not the field — verify by mutating
+	// the legacy field and confirming the resolved provider doesn't change.
+	other := &closingProvider{id: "other-agent"}
+	c.provider = other
+	assert.Equal(t, legacy, c.getAgentProvider(),
+		"already-lifted provider takes precedence over later legacy-field writes")
+}
+
+// TestSDK_ProviderPool_LiftsLegacySummarizeField mirrors the agent test
+// for the summarizer path.
+func TestSDK_ProviderPool_LiftsLegacySummarizeField(t *testing.T) {
+	legacy := &closingProvider{id: "legacy-summarizer"}
+	c := &config{summarizeProvider: legacy}
+
+	got := c.getSummarizeProvider()
+	assert.Equal(t, legacy, got)
+	assert.True(t, c.summarizeSet)
+	assert.NotNil(t, c.providers)
+}
+
+// TestSDK_ProviderPool_EmptyIDProvidersAreSetCorrectly pins the design
+// decision to track presence via agentSet/summarizeSet rather than
+// relying on a non-empty ID. Minimal mock providers may legitimately
+// return an empty ID; they must still resolve through the pool.
+func TestSDK_ProviderPool_EmptyIDProvidersAreSetCorrectly(t *testing.T) {
+	emptyAgent := &closingProvider{id: ""}
+	c := &config{}
+	require.NoError(t, WithProvider(emptyAgent)(c))
+
+	assert.True(t, c.agentSet)
+	assert.Equal(t, emptyAgent, c.getAgentProvider(),
+		"empty-ID providers must resolve via the presence flag, not ID matching")
+}
+
+// TestSDK_ProviderPool_NilWithProviderIsNoOp pins the prior behaviour:
+// WithProvider(nil) must not error and must not register anything.
+func TestSDK_ProviderPool_NilWithProviderIsNoOp(t *testing.T) {
+	c := &config{}
+	require.NoError(t, WithProvider(nil)(c))
+	assert.False(t, c.agentSet)
+	assert.Nil(t, c.getAgentProvider())
+}


### PR DESCRIPTION
PR 2 in the layered-pipeline-architecture sequence (anchor: ARCHITECTURE.md from #1048). Adopts `runtime/providers.Registry` as the SDK's provider pool, matching Arena's existing convention.

## Why

The SDK held three independent provider-paths: `cfg.provider` (agent), `cfg.summarizeProvider` (auto-summarize), `JudgeProvider`/`JudgeTargets` (evals). Three lifecycles, no shared `Close()`. Arena, by contrast, already uses `*providers.Registry` for both its agent pool and its self-play roles. ARCHITECTURE.md §1.1 documents that the SDK should match.

## What

- `WithProvider(p)` registers `p` into `c.providers *providers.Registry` and tracks `c.agentProviderID` + `c.agentSet`.
- `WithAutoSummarize(p, ...)` registers into the same pool, tracks `c.summarizeProviderID` + `c.summarizeSet`.
- `Conversation.Close()` calls `c.config.providers.Close()` once — fans out to every registered provider.
- Production reads route through `getAgentProvider()` / `getSummarizeProvider()`. No more direct field access in production code.

## Backward compatibility

- The legacy `cfg.provider` and `cfg.summarizeProvider` fields stay as `// Deprecated`. Test scaffolding that builds `*config{provider: x}` literals continues to compile.
- `getAgentProvider()` / `getSummarizeProvider()` lift legacy field values into the pool transparently on first read.
- `WithProvider(nil)` is still a no-op (preserves prior behaviour, pinned by a new test).
- Public option signatures unchanged.

## Empty-ID edge case

Minimal test mocks may return `""` from `provider.ID()`. The pool keys by ID. Presence is tracked via `agentSet` / `summarizeSet` booleans, not by `agentProviderID != ""`, so empty-ID providers resolve correctly.

## Tests

- New `sdk/sdk_provider_pool_test.go`:
  - `TestSDK_ProviderPool_RegistersBothAgentAndSummarize` — both providers register; `Close` fans out exactly once.
  - `TestSDK_ProviderPool_LiftsLegacyAgentField` / `_LiftsLegacySummarizeField` — back-compat paths work.
  - `TestSDK_ProviderPool_EmptyIDProvidersAreSetCorrectly` — pins the presence-flag design.
  - `TestSDK_ProviderPool_NilWithProviderIsNoOp` — preserves prior behaviour.
- Existing tests updated to use the accessors where they previously read fields directly.
- `rtcMockProvider` in `runtime_config_test.go` gains an `ID()` override (the embedded interface's nil method previously panicked when registered).

## Test plan

- [x] `go test ./sdk/...` green (1633+ tests)
- [x] `golangci-lint run --new-from-rev HEAD ./sdk/...` 0 issues
- [x] Pre-commit hook (lint + build + test + coverage on changed files) green
- [ ] CI green
