### PR TITLE
feat(arena): thread TurnState into Arena pipelines; read validator configs from TurnState

### DIFF
--- a/tools/arena/engine/duplex_executor_pipeline_integration.go
+++ b/tools/arena/engine/duplex_executor_pipeline_integration.go
@@ -251,14 +251,15 @@ func (de *DuplexConversationExecutor) buildDuplexPipeline(
 	if req.Scenario != nil {
 		taskType = req.Scenario.TaskType
 	}
+	turnState := stage.NewTurnState()
 	stages = append(stages,
 		stage.NewVariableProviderStageWithVars(mergedVars, nil),
-		stage.NewPromptAssemblyStage(de.promptRegistry, taskType, mergedVars),
+		stage.NewPromptAssemblyStageWithTurnState(de.promptRegistry, taskType, mergedVars, turnState),
 		// NOTE: ScenarioContextExtractionStage is NOT included in the duplex pipeline.
 		// It accumulates ALL elements before forwarding, which blocks the real-time
 		// element flow needed for duplex streaming. Context extraction is handled
 		// via mergedVars passed to PromptAssemblyStage.
-		stage.NewTemplateStage(),
+		stage.NewTemplateStageWithTurnState(nil, turnState),
 	)
 
 	// 2. Duplex provider stage - creates session using system_prompt from metadata

--- a/tools/arena/selfplay/generator.go
+++ b/tools/arena/selfplay/generator.go
@@ -126,6 +126,7 @@ func (cg *ContentGenerator) NextUserTurn(
 		selfplayContextStage = arenastages.NewSelfPlayUserTurnContextStage(&config.Scenario{ID: scenarioID})
 	}
 
+	turnState := stage.NewTurnState()
 	stages := []stage.Stage{
 		arenastages.NewPersonaAssemblyStage(cg.persona, region, baseVariables),
 	}
@@ -141,7 +142,7 @@ func (cg *ContentGenerator) NextUserTurn(
 	stages = append(stages,
 		arenastages.NewHistoryInjectionStageSwapped(history),
 		selfplayContextStage,
-		stage.NewTemplateStage(),
+		stage.NewTemplateStageWithTurnState(emitter, turnState),
 		stage.NewProviderStageWithEmitter(cg.provider, nil, nil, providerConfig, emitter),
 	)
 

--- a/tools/arena/stages/guardrail_eval.go
+++ b/tools/arena/stages/guardrail_eval.go
@@ -19,17 +19,28 @@ import (
 // the guardrail by modifying the message content (e.g., truncating for length
 // validators, replacing content for content blockers).
 //
-// This stage reads "validator_configs" from element metadata (set by
-// PromptAssemblyStage) and uses guardrails.NewGuardrailHook to instantiate
-// each hook, then calls AfterCall to evaluate the response.
+// Validator configs are sourced from the per-Turn *TurnState* (populated by
+// PromptAssemblyStage). When TurnState is not wired, the stage falls back to
+// reading "validator_configs" from element metadata for backward compat.
 type GuardrailEvalStage struct {
 	stage.BaseStage
+	turnState *stage.TurnState
 }
 
 // NewGuardrailEvalStage creates a new guardrail evaluation stage.
+// Pipelines that have migrated to TurnState should use NewGuardrailEvalStageWithTurnState.
 func NewGuardrailEvalStage() *GuardrailEvalStage {
 	return &GuardrailEvalStage{
 		BaseStage: stage.NewBaseStage("guardrail_eval", stage.StageTypeTransform),
+	}
+}
+
+// NewGuardrailEvalStageWithTurnState creates a guardrail evaluation stage that
+// reads validator configurations from the shared *TurnState.
+func NewGuardrailEvalStageWithTurnState(turnState *stage.TurnState) *GuardrailEvalStage {
+	return &GuardrailEvalStage{
+		BaseStage: stage.NewBaseStage("guardrail_eval", stage.StageTypeTransform),
+		turnState: turnState,
 	}
 }
 
@@ -120,8 +131,13 @@ func (s *GuardrailEvalStage) Process(
 	return s.forwardAll(ctx, elements, output)
 }
 
-// extractValidatorConfigs finds validator_configs in any element's metadata.
+// extractValidatorConfigs sources validator configs from TurnState when wired,
+// otherwise falls back to scanning element metadata for the deprecated
+// "validator_configs" key.
 func (s *GuardrailEvalStage) extractValidatorConfigs(elements []stage.StreamElement) []prompt.ValidatorConfig {
+	if s.turnState != nil && len(s.turnState.Validators) > 0 {
+		return s.turnState.Validators
+	}
 	for i := range elements {
 		if elements[i].Metadata == nil {
 			continue

--- a/tools/arena/stages/guardrail_eval_test.go
+++ b/tools/arena/stages/guardrail_eval_test.go
@@ -9,6 +9,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGuardrailEvalStage_TurnStateTakesPrecedenceOverMetadata(t *testing.T) {
+	// When wired with a TurnState that has Validators, the stage uses those
+	// configs in preference to the deprecated metadata bag. The metadata
+	// fallback path is exercised by all the other tests in this file.
+	turnState := stage.NewTurnState()
+	turnState.Validators = []prompt.ValidatorConfig{
+		{Type: "banned_words", Params: map[string]interface{}{"words": []any{"forbidden"}}},
+	}
+	s := NewGuardrailEvalStageWithTurnState(turnState)
+
+	elem := newTestMessageElement("assistant", "This is forbidden content.")
+	// Bag contains a different (incorrect) config; TurnState must win.
+	elem.Metadata["validator_configs"] = []prompt.ValidatorConfig{
+		{Type: "banned_words", Params: map[string]interface{}{"words": []any{"never_match"}}},
+	}
+
+	results := runStage(t, s, []stage.StreamElement{elem})
+	require.Len(t, results, 1)
+	msg := results[0].Message
+	require.Len(t, msg.Validations, 1)
+	assert.False(t, msg.Validations[0].Passed, "TurnState validator should fail on the forbidden word")
+}
+
+func TestGuardrailEvalStage_TurnStateEmptyFallsBackToMetadata(t *testing.T) {
+	// When TurnState is wired but has no Validators, the stage falls back
+	// to scanning the metadata bag for back-compat.
+	turnState := stage.NewTurnState()
+	s := NewGuardrailEvalStageWithTurnState(turnState)
+
+	elem := newTestMessageElement("assistant", "This is forbidden content.")
+	elem.Metadata["validator_configs"] = []prompt.ValidatorConfig{
+		{Type: "banned_words", Params: map[string]interface{}{"words": []any{"forbidden"}}},
+	}
+
+	results := runStage(t, s, []stage.StreamElement{elem})
+	require.Len(t, results, 1)
+	msg := results[0].Message
+	require.Len(t, msg.Validations, 1)
+	assert.False(t, msg.Validations[0].Passed)
+}
+
 func TestGuardrailEvalStage_BannedWordsTriggers(t *testing.T) {
 	s := NewGuardrailEvalStage()
 

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -274,6 +274,7 @@ func (e *PipelineExecutor) buildStagePipeline(
 ) (*stage.StreamPipeline, error) {
 	logger.Debug("Building stage pipeline", "provider_type", fmt.Sprintf("%T", req.Provider))
 	builder := stage.NewPipelineBuilder()
+	turnState := stage.NewTurnState()
 
 	// Merge prompt vars into base variables
 	mergedVars := map[string]string{}
@@ -302,9 +303,9 @@ func (e *PipelineExecutor) buildStagePipeline(
 
 	// 2-4. Prompt assembly, context extraction, template
 	stages = append(stages,
-		stage.NewPromptAssemblyStage(req.PromptRegistry, req.TaskType, mergedVars),
+		stage.NewPromptAssemblyStageWithTurnState(req.PromptRegistry, req.TaskType, mergedVars, turnState),
 		arenastages.NewScenarioContextExtractionStage(req.Scenario),
-		stage.NewTemplateStage(),
+		stage.NewTemplateStageWithTurnState(emitterFromRequest(req), turnState),
 	)
 
 	// 4b. Append preloaded skill instructions to system_prompt so skills
@@ -339,7 +340,10 @@ func (e *PipelineExecutor) buildStagePipeline(
 	// 6. Provider stage (with consent simulation hook if overrides are present)
 	// 7. Guardrail evaluation (evaluative, not enforcement — records pass/fail for assertions)
 	providerConfig := buildProviderConfig(req)
-	stages = append(stages, e.buildProviderStage(req, providerConfig), arenastages.NewGuardrailEvalStage())
+	stages = append(stages,
+		e.buildProviderStage(req, providerConfig),
+		arenastages.NewGuardrailEvalStageWithTurnState(turnState),
+	)
 
 	// 7a. Output recording stage (opt-in via RecordingConfig)
 	stages = appendRecordingStage(stages, req, stage.RecordingPositionOutput)
@@ -508,6 +512,7 @@ func (e *PipelineExecutor) buildCommonStreamingStages(
 ) (*stage.StreamPipeline, error) {
 	mergedVars := mergePromptVars(req)
 	builder := stage.NewPipelineBuilder()
+	turnState := stage.NewTurnState()
 	var stages []stage.Stage
 
 	// StateStore Load stage
@@ -526,7 +531,8 @@ func (e *PipelineExecutor) buildCommonStreamingStages(
 	}
 
 	// Prompt assembly
-	stages = append(stages, stage.NewPromptAssemblyStage(req.PromptRegistry, req.TaskType, mergedVars))
+	stages = append(stages,
+		stage.NewPromptAssemblyStageWithTurnState(req.PromptRegistry, req.TaskType, mergedVars, turnState))
 
 	// Scenario context extraction (scripted only)
 	if cfg.IncludeScenarioContextExtraction {
@@ -534,7 +540,7 @@ func (e *PipelineExecutor) buildCommonStreamingStages(
 	}
 
 	// Template
-	stages = append(stages, stage.NewTemplateStage())
+	stages = append(stages, stage.NewTemplateStageWithTurnState(emitterFromRequest(req), turnState))
 
 	// Strip tool messages (self-play only)
 	if cfg.IncludeStripToolMessages {
@@ -567,7 +573,7 @@ func (e *PipelineExecutor) buildCommonStreamingStages(
 
 	// Guardrail evaluation (scripted only)
 	if cfg.IncludeGuardrailEval {
-		stages = append(stages, arenastages.NewGuardrailEvalStage())
+		stages = append(stages, arenastages.NewGuardrailEvalStageWithTurnState(turnState))
 	}
 
 	// Output recording stage (opt-in via RecordingConfig)


### PR DESCRIPTION
## Summary

PR 4 in the layered-pipeline-architecture sequence (after #1048, #1049, #1050). Threads the `*TurnState` introduced in #1050 through Arena's pipeline builders so `PromptAssemblyStage`, `TemplateStage`, and `GuardrailEvalStage` share a per-Turn instance. Arena now reads the runtime-owned `validator_configs` key from `TurnState.Validators`, with a fallback to the deprecated metadata bag for legacy callers.

## What changed

- `tools/arena/stages/guardrail_eval.go` — `GuardrailEvalStage` gains a `turnState` field and a `NewGuardrailEvalStageWithTurnState` constructor. `extractValidatorConfigs` prefers `TurnState.Validators` when wired and populated; otherwise falls back to scanning element metadata for `"validator_configs"`. The fallback keeps legacy callers working without code changes.
- `tools/arena/stages/guardrail_eval_test.go` — two new tests covering the TurnState-precedence path and the empty-TurnState-falls-back-to-bag path.
- `tools/arena/turnexecutors/pipeline_stages_integration.go` — both `buildStagePipeline` (non-streaming) and `buildCommonStreamingStages` (streaming/scripted) construct a `*TurnState` at the top of the builder and thread it into `NewPromptAssemblyStageWithTurnState`, `NewTemplateStageWithTurnState`, and `NewGuardrailEvalStageWithTurnState`.
- `tools/arena/selfplay/generator.go` — self-play pipeline builder threads TurnState into `NewTemplateStageWithTurnState`.
- `tools/arena/engine/duplex_executor_pipeline_integration.go` — duplex pipeline builder threads TurnState into `NewPromptAssemblyStageWithTurnState` and `NewTemplateStageWithTurnState`. Duplex passes `nil` for the emitter to preserve prior `NewTemplateStage` behaviour exactly.

## Out of PR 4 scope (per the proposal)

- **`CompletionInstructionStage` and `SkillInstructionStage` stay on the bag-only path.** They mutate `system_prompt` mid-pipeline; migrating them to TurnState now interacts badly with `TemplateStage`'s cache-write-back to the bag (cycle: cache hit re-emits appended value to the next element, instruction stage re-appends, etc.). PR 5 deletes the bag and removes the cache-write-back, at which point these stages migrate cleanly.
- **`ArenaStateStoreSaveStage`'s wholesale `Metadata` copy** and the arena/statestore reads of `ConversationState.Metadata` stay. They operate on **persisted** state, not on `StreamElement.Metadata` (the pipeline bag this PR sequence targets). PR 5 separates concerns.
- **Arena-unique keys** (chaos, selfplay, mock-scenario, duplex/voice, context-extraction, telemetry) keep flowing through the bag — they are Arena-internal (producer + consumer both in Arena). PR 5 will give each a typed home before the bag is removed.

## Test plan

- [x] `go test ./runtime/... ./sdk/... ./tools/arena/...` — full sweep green
- [x] `examples/customer-support` rebuilt arena binary, ran with mock provider — 3/3 scenarios passed; behaviour matches main
- [x] `golangci-lint run --new-from-rev HEAD ./tools/arena/...` — 0 issues
- [x] Pre-commit hook passes (lint + build + per-file coverage on changed packages)
- [ ] CI green
- [ ] CI Arena example jobs (Customer Support / Multimodal / Variables / Assertions / LLM Judge / Guardrails / Eval) all green — they ARE the byte-equivalence regression check for behaviour
