### PR TITLE
feat(pipeline): runtime consumers read system_prompt + allowed_tools from TurnState

### DIFF
--- a/runtime/pipeline/stage/stages_duplex_provider_integration.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_integration.go
@@ -67,6 +67,11 @@ type DuplexProviderStage struct {
 	provider   providers.StreamInputSupport
 	baseConfig *providers.StreamingInputConfig
 
+	// turnState is the per-Turn shared state. When wired, system_prompt is
+	// sourced from TurnState.SystemPrompt rather than scanning element
+	// metadata at session-creation time. May be nil for legacy callers.
+	turnState *TurnState
+
 	// Session created on first element with system_prompt
 	session          providers.StreamInputSession
 	systemPromptSent bool
@@ -153,6 +158,21 @@ func NewDuplexProviderStageWithEmitter(
 	return s
 }
 
+// NewDuplexProviderStageWithTurnState creates a new duplex provider stage that
+// sources system_prompt from the shared *TurnState rather than the deprecated
+// metadata bag. The emitter remains optional.
+func NewDuplexProviderStageWithTurnState(
+	provider providers.StreamInputSupport,
+	baseConfig *providers.StreamingInputConfig,
+	emitter *events.Emitter,
+	turnState *TurnState,
+) *DuplexProviderStage {
+	s := NewDuplexProviderStage(provider, baseConfig)
+	s.emitter = emitter
+	s.turnState = turnState
+	return s
+}
+
 // Process implements the Stage interface.
 // Handles bidirectional streaming between input channel and WebSocket session.
 //
@@ -183,9 +203,12 @@ func (s *DuplexProviderStage) Process(
 			return errors.New("duplex provider stage: input channel closed before receiving first element")
 		}
 
-		// Extract system_prompt from metadata
+		// Source system_prompt: TurnState wins, falls back to element metadata
+		// for legacy callers.
 		systemPrompt := ""
-		if firstElem.Metadata != nil {
+		if s.turnState != nil && s.turnState.SystemPrompt != "" {
+			systemPrompt = s.turnState.SystemPrompt
+		} else if firstElem.Metadata != nil {
 			if sp, ok := firstElem.Metadata["system_prompt"].(string); ok {
 				systemPrompt = sp
 			}
@@ -486,9 +509,17 @@ func (s *DuplexProviderStage) sendElementToSession(ctx context.Context, elem *St
 		}
 	}
 
-	// Check for system prompt in metadata (sent once at the start)
-	if !s.systemPromptSent && elem.Metadata != nil {
-		if systemPrompt, ok := elem.Metadata["system_prompt"].(string); ok && systemPrompt != "" {
+	// Source the system prompt: TurnState wins, fall back to element metadata.
+	if !s.systemPromptSent {
+		systemPrompt := ""
+		if s.turnState != nil && s.turnState.SystemPrompt != "" {
+			systemPrompt = s.turnState.SystemPrompt
+		} else if elem.Metadata != nil {
+			if sp, ok := elem.Metadata["system_prompt"].(string); ok {
+				systemPrompt = sp
+			}
+		}
+		if systemPrompt != "" {
 			logger.Debug("DuplexProviderStage: sending system prompt as context (no turn_complete)",
 				"promptLength", len(systemPrompt))
 			// Use SendSystemContext to send prompt WITHOUT triggering a response

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -44,6 +44,11 @@ type ProviderStage struct {
 	config       *ProviderConfig
 	emitter      *events.Emitter // Optional event emitter for provider call events
 	hookRegistry *hooks.Registry // Optional hook registry for policy enforcement
+	// turnState is the per-Turn shared state. When wired, system_prompt and
+	// allowed_tools are sourced from TurnState.SystemPrompt /
+	// TurnState.AllowedTools rather than from element metadata. May be nil
+	// for legacy callers; in that case the stage falls back to the bag.
+	turnState *TurnState
 }
 
 // ProviderConfig contains configuration for the provider stage.
@@ -125,6 +130,22 @@ func NewProviderStageWithHooks(
 	emitter *events.Emitter,
 	hookRegistry *hooks.Registry,
 ) *ProviderStage {
+	return NewProviderStageWithTurnState(provider, toolRegistry, toolPolicy, config, emitter, hookRegistry, nil)
+}
+
+// NewProviderStageWithTurnState creates a provider stage that sources
+// system_prompt and allowed_tools from the shared *TurnState rather than the
+// deprecated element metadata bag. Pipelines that have migrated to TurnState
+// should use this constructor.
+func NewProviderStageWithTurnState(
+	provider providers.Provider,
+	toolRegistry *tools.Registry,
+	toolPolicy *pipeline.ToolPolicy,
+	config *ProviderConfig,
+	emitter *events.Emitter,
+	hookRegistry *hooks.Registry,
+	turnState *TurnState,
+) *ProviderStage {
 	if config == nil {
 		config = &ProviderConfig{}
 	}
@@ -136,6 +157,7 @@ func NewProviderStageWithHooks(
 		config:       config,
 		emitter:      emitter,
 		hookRegistry: hookRegistry,
+		turnState:    turnState,
 	}
 }
 
@@ -196,10 +218,28 @@ func (s *ProviderStage) accumulateInput(input <-chan StreamElement) *providerInp
 		s.extractMetadata(&elem, acc)
 	}
 
+	// TurnState takes precedence over the bag for the runtime-owned keys.
+	// The bag-derived values populated above are overwritten when
+	// TurnState is wired and has these fields set.
+	if s.turnState != nil {
+		if s.turnState.SystemPrompt != "" {
+			acc.systemPrompt = s.turnState.SystemPrompt
+		}
+		if len(s.turnState.AllowedTools) > 0 {
+			acc.allowedTools = s.turnState.AllowedTools
+			logger.Debug("ProviderStage allowed_tools from TurnState",
+				"tools", s.turnState.AllowedTools, "count", len(s.turnState.AllowedTools))
+		}
+	}
+
 	return acc
 }
 
 // extractMetadata extracts prompt data and merges metadata from element.
+//
+// The system_prompt and allowed_tools reads are kept here for backward
+// compatibility with legacy callers that don't wire a *TurnState.
+// accumulateInput overwrites these from TurnState when available.
 func (s *ProviderStage) extractMetadata(elem *StreamElement, acc *providerInput) {
 	if elem.Metadata == nil {
 		return

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -120,6 +120,56 @@ func TestProviderStage_MetadataExtraction(t *testing.T) {
 	assert.Greater(t, len(elements), 0, "should receive output")
 }
 
+// TestProviderStage_TurnStateOverridesMetadata pins the contract that when
+// a *TurnState is wired into the stage, its SystemPrompt and AllowedTools
+// fields override whatever is in the deprecated metadata bag.
+func TestProviderStage_TurnStateOverridesMetadata(t *testing.T) {
+	provider := mock.NewProvider("test-provider", "test-model", false)
+	turnState := NewTurnState()
+	turnState.SystemPrompt = "TurnState system prompt"
+	turnState.AllowedTools = []string{"turnstate_tool_a", "turnstate_tool_b"}
+
+	stage := NewProviderStageWithTurnState(provider, nil, nil,
+		&ProviderConfig{MaxTokens: 100, Temperature: 0.7}, nil, nil, turnState)
+
+	input := make(chan StreamElement, 2)
+	elem := NewMessageElement(&types.Message{Role: "user", Content: "Test"})
+	elem.Metadata["system_prompt"] = "BAG should NOT win"
+	elem.Metadata["allowed_tools"] = []string{"bag_tool"}
+	input <- elem
+	close(input)
+
+	acc := stage.accumulateInput(input)
+	assert.Equal(t, "TurnState system prompt", acc.systemPrompt,
+		"TurnState.SystemPrompt must override the bag value")
+	assert.Equal(t, []string{"turnstate_tool_a", "turnstate_tool_b"}, acc.allowedTools,
+		"TurnState.AllowedTools must override the bag value")
+}
+
+// TestProviderStage_TurnStateEmptyFallsBackToMetadata pins the back-compat
+// path: when TurnState is wired but its fields are zero/empty, the stage
+// falls back to reading from the metadata bag.
+func TestProviderStage_TurnStateEmptyFallsBackToMetadata(t *testing.T) {
+	provider := mock.NewProvider("test-provider", "test-model", false)
+	turnState := NewTurnState() // empty
+
+	stage := NewProviderStageWithTurnState(provider, nil, nil,
+		&ProviderConfig{MaxTokens: 100, Temperature: 0.7}, nil, nil, turnState)
+
+	input := make(chan StreamElement, 2)
+	elem := NewMessageElement(&types.Message{Role: "user", Content: "Test"})
+	elem.Metadata["system_prompt"] = "Bag system prompt"
+	elem.Metadata["allowed_tools"] = []string{"bag_tool"}
+	input <- elem
+	close(input)
+
+	acc := stage.accumulateInput(input)
+	assert.Equal(t, "Bag system prompt", acc.systemPrompt,
+		"empty TurnState.SystemPrompt should fall through to bag")
+	assert.Equal(t, []string{"bag_tool"}, acc.allowedTools,
+		"empty TurnState.AllowedTools should fall through to bag")
+}
+
 // TestProviderStage_NoProvider tests error when provider is nil
 func TestProviderStage_NoProvider(t *testing.T) {
 	stage := NewProviderStage(nil, nil, nil, &ProviderConfig{})

--- a/runtime/pipeline/stage/stages_utilities.go
+++ b/runtime/pipeline/stage/stages_utilities.go
@@ -730,10 +730,21 @@ type ContextBuilderStage struct {
 	BaseStage
 	policy       *ContextBuilderPolicy
 	tokenCounter tokenizer.TokenCounter
+	// turnState is the per-Turn shared state. When wired, the system prompt
+	// used for token-budget accounting is sourced from TurnState.SystemPrompt
+	// rather than scanning element metadata.
+	turnState *TurnState
 }
 
 // NewContextBuilderStage creates a context builder stage.
+// Pipelines that have migrated to TurnState should use NewContextBuilderStageWithTurnState.
 func NewContextBuilderStage(policy *ContextBuilderPolicy) *ContextBuilderStage {
+	return NewContextBuilderStageWithTurnState(policy, nil)
+}
+
+// NewContextBuilderStageWithTurnState creates a context builder stage that
+// reads the system prompt from the shared *TurnState.
+func NewContextBuilderStageWithTurnState(policy *ContextBuilderPolicy, turnState *TurnState) *ContextBuilderStage {
 	// Use provided TokenCounter or default to heuristic counter
 	var tc tokenizer.TokenCounter = tokenizer.DefaultTokenCounter
 	if policy != nil && policy.TokenCounter != nil {
@@ -744,6 +755,7 @@ func NewContextBuilderStage(policy *ContextBuilderPolicy) *ContextBuilderStage {
 		BaseStage:    NewBaseStage("context_builder", StageTypeAccumulate),
 		policy:       policy,
 		tokenCounter: tc,
+		turnState:    turnState,
 	}
 }
 
@@ -781,10 +793,15 @@ func (s *ContextBuilderStage) Process(
 			messages = append(messages, *elem.Message)
 		}
 
-		// Extract system prompt from metadata
+		// Extract system prompt from metadata (legacy fallback path).
 		if sp, ok := elem.Metadata["system_prompt"].(string); ok {
 			systemPrompt = sp
 		}
+	}
+
+	// TurnState takes precedence over the bag for the system prompt.
+	if s.turnState != nil && s.turnState.SystemPrompt != "" {
+		systemPrompt = s.turnState.SystemPrompt
 	}
 
 	// Calculate available budget

--- a/runtime/pipeline/stage/stages_utilities_test.go
+++ b/runtime/pipeline/stage/stages_utilities_test.go
@@ -494,6 +494,42 @@ func TestTemplateStage_WithEmitter(t *testing.T) {
 	})
 }
 
+func TestContextBuilderStage_TurnStateOverridesMetadataSystemPrompt(t *testing.T) {
+	// Force budget pressure: TurnState carries a long system prompt that
+	// drains the budget; the bag carries an empty value. If TurnState is
+	// honoured, we should observe truncation; if the bag wins, no truncation.
+	turnState := NewTurnState()
+	turnState.SystemPrompt = "Long system prompt that takes up significant token budget for testing purposes"
+
+	policy := &ContextBuilderPolicy{
+		TokenBudget:      30,
+		ReserveForOutput: 5,
+		Strategy:         TruncateOldest,
+	}
+	stage := NewContextBuilderStageWithTurnState(policy, turnState)
+
+	input := make(chan StreamElement, 5)
+	output := make(chan StreamElement, 5)
+
+	for i := 0; i < 5; i++ {
+		elem := NewMessageElement(&types.Message{Role: "user", Content: "Some message content here"})
+		// Bag deliberately empty for system_prompt — TurnState must drive the budget math.
+		input <- elem
+	}
+	close(input)
+
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	var results []types.Message
+	for elem := range output {
+		if elem.Message != nil {
+			results = append(results, *elem.Message)
+		}
+	}
+	assert.Less(t, len(results), 5,
+		"long TurnState.SystemPrompt should consume the budget and force truncation")
+}
+
 func TestContextBuilderStage_PassThroughWhenUnderBudget(t *testing.T) {
 	policy := &ContextBuilderPolicy{
 		TokenBudget:      1000,

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -312,7 +312,7 @@ func collectPipelineStages(
 	// 4.5 Context builder stage - manages token budget and truncation
 	if cfg.TokenBudget > 0 {
 		contextPolicy := buildContextBuilderPolicy(cfg)
-		stages = append(stages, stage.NewContextBuilderStage(contextPolicy))
+		stages = append(stages, stage.NewContextBuilderStageWithTurnState(contextPolicy, turnState))
 	}
 
 	// 4.6 Image preprocessing stage - resize/optimize images before provider
@@ -332,7 +332,7 @@ func collectPipelineStages(
 	}
 
 	// 5. Provider stage - LLM calls with streaming and tool support
-	providerStages, err := buildProviderStages(cfg)
+	providerStages, err := buildProviderStages(cfg, turnState)
 	if err != nil {
 		return nil, err
 	}
@@ -381,11 +381,13 @@ func appendStateStoreLoadStages(
 }
 
 // buildProviderStages returns the appropriate provider stage(s) based on config.
-func buildProviderStages(cfg *Config) ([]stage.Stage, error) {
+func buildProviderStages(cfg *Config, turnState *stage.TurnState) ([]stage.Stage, error) {
 	if cfg.StreamInputProvider != nil {
 		// ASM mode: Direct audio streaming to LLM
 		logger.Debug("Using DuplexProviderStage for ASM mode")
-		return []stage.Stage{stage.NewDuplexProviderStage(cfg.StreamInputProvider, cfg.StreamInputConfig)}, nil
+		return []stage.Stage{stage.NewDuplexProviderStageWithTurnState(
+			cfg.StreamInputProvider, cfg.StreamInputConfig, nil, turnState,
+		)}, nil
 	}
 	if cfg.VADConfig != nil && cfg.STTService != nil && cfg.TTSService != nil {
 		// VAD mode: build audio pipeline
@@ -405,13 +407,14 @@ func buildProviderStages(cfg *Config) ([]stage.Stage, error) {
 		if cfg.CompactionEnabled == nil || *cfg.CompactionEnabled {
 			providerConfig.Compactor = buildCompactionStrategy(cfg)
 		}
-		return []stage.Stage{stage.NewProviderStageWithHooks(
+		return []stage.Stage{stage.NewProviderStageWithTurnState(
 			cfg.Provider,
 			cfg.ToolRegistry,
 			cfg.ToolPolicy,
 			providerConfig,
 			cfg.EventEmitter,
 			cfg.HookRegistry,
+			turnState,
 		)}, nil
 	}
 	return nil, nil

--- a/tools/arena/engine/duplex_executor_pipeline_integration.go
+++ b/tools/arena/engine/duplex_executor_pipeline_integration.go
@@ -274,11 +274,9 @@ func (de *DuplexConversationExecutor) buildDuplexPipeline(
 		emitter = events.NewEmitter(req.EventBus, req.RunID, req.RunID, req.ConversationID)
 	}
 
-	if emitter != nil {
-		stages = append(stages, stage.NewDuplexProviderStageWithEmitter(streamProvider, baseConfig, emitter))
-	} else {
-		stages = append(stages, stage.NewDuplexProviderStage(streamProvider, baseConfig))
-	}
+	stages = append(stages, stage.NewDuplexProviderStageWithTurnState(
+		streamProvider, baseConfig, emitter, turnState,
+	))
 
 	// NOTE: ResponseVADStage was removed. It was intended to delay EndOfStream until
 	// VAD confirmed response audio stopped, but it caused timing issues with selfplay:

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -326,7 +326,7 @@ func (e *PipelineExecutor) buildStagePipeline(
 
 	// 5. Context builder (if policy exists)
 	if contextPolicy := buildContextPolicy(req.Scenario); contextPolicy != nil {
-		stages = append(stages, stage.NewContextBuilderStage(contextPolicy))
+		stages = append(stages, stage.NewContextBuilderStageWithTurnState(contextPolicy, turnState))
 	}
 
 	// 5a. Media conversion stage - converts media to provider-supported formats
@@ -341,7 +341,7 @@ func (e *PipelineExecutor) buildStagePipeline(
 	// 7. Guardrail evaluation (evaluative, not enforcement — records pass/fail for assertions)
 	providerConfig := buildProviderConfig(req)
 	stages = append(stages,
-		e.buildProviderStage(req, providerConfig),
+		e.buildProviderStage(req, providerConfig, turnState),
 		arenastages.NewGuardrailEvalStageWithTurnState(turnState),
 	)
 
@@ -407,7 +407,9 @@ func emitterFromRequest(req *TurnRequest) *events.Emitter {
 
 // buildProviderStage creates a provider stage, attaching hooks
 // for consent simulation and/or chaos injection when configured.
-func (e *PipelineExecutor) buildProviderStage(req *TurnRequest, providerConfig *stage.ProviderConfig) stage.Stage {
+func (e *PipelineExecutor) buildProviderStage(
+	req *TurnRequest, providerConfig *stage.ProviderConfig, turnState *stage.TurnState,
+) stage.Stage {
 	toolPolicy := buildToolPolicy(req.Scenario)
 	emitter := emitterFromRequest(req)
 
@@ -419,15 +421,17 @@ func (e *PipelineExecutor) buildProviderStage(req *TurnRequest, providerConfig *
 		toolHooks = append(toolHooks, chaos.NewHook())
 	}
 
+	var hookReg *hooks.Registry
 	if len(toolHooks) > 0 {
 		var opts []hooks.Option
 		for _, h := range toolHooks {
 			opts = append(opts, hooks.WithToolHook(h))
 		}
-		hookReg := hooks.NewRegistry(opts...)
-		return stage.NewProviderStageWithHooks(req.Provider, e.toolRegistry, toolPolicy, providerConfig, emitter, hookReg)
+		hookReg = hooks.NewRegistry(opts...)
 	}
-	return stage.NewProviderStageWithEmitter(req.Provider, e.toolRegistry, toolPolicy, providerConfig, emitter)
+	return stage.NewProviderStageWithTurnState(
+		req.Provider, e.toolRegistry, toolPolicy, providerConfig, emitter, hookReg, turnState,
+	)
 }
 
 // Execute runs the conversation through the pipeline and returns the new messages generated.
@@ -555,7 +559,7 @@ func (e *PipelineExecutor) buildCommonStreamingStages(
 	// Context builder (if policy exists) — scripted path
 	if cfg.IncludeScenarioContextExtraction {
 		if contextPolicy := buildContextPolicy(req.Scenario); contextPolicy != nil {
-			stages = append(stages, stage.NewContextBuilderStage(contextPolicy))
+			stages = append(stages, stage.NewContextBuilderStageWithTurnState(contextPolicy, turnState))
 		}
 	}
 
@@ -565,10 +569,12 @@ func (e *PipelineExecutor) buildCommonStreamingStages(
 	// Provider stage
 	providerConfig := buildProviderConfig(req)
 	if cfg.UseHooksProvider {
-		stages = append(stages, e.buildProviderStage(req, providerConfig))
+		stages = append(stages, e.buildProviderStage(req, providerConfig, turnState))
 	} else {
-		stages = append(stages, stage.NewProviderStageWithEmitter(
-			req.Provider, e.toolRegistry, buildToolPolicy(req.Scenario), providerConfig, emitterFromRequest(req)))
+		stages = append(stages, stage.NewProviderStageWithTurnState(
+			req.Provider, e.toolRegistry, buildToolPolicy(req.Scenario),
+			providerConfig, emitterFromRequest(req), nil, turnState,
+		))
 	}
 
 	// Guardrail evaluation (scripted only)


### PR DESCRIPTION
## Summary

PR 5a in the layered-pipeline-architecture sequence (after #1048-#1051). Migrates the three runtime consumers of the runtime-owned bag keys (`system_prompt`, `allowed_tools`) onto the `*TurnState` wiring introduced in #1050. Each gains a `*WithTurnState` constructor and prefers `TurnState` over the deprecated metadata bag, with a fallback to the bag for legacy direct callers.

Prerequisite for PR 5b (Arena unique-key migration) and PR 5c (deletion of `StreamElement.Metadata`).

## What changed

- `runtime/pipeline/stage/stages_provider.go` — `ProviderStage` gains a `turnState` field and `NewProviderStageWithTurnState` constructor. `accumulateInput` overrides the bag-derived `systemPrompt` / `allowedTools` with TurnState values when wired and populated.
- `runtime/pipeline/stage/stages_utilities.go` — `ContextBuilderStage` gains a `turnState` field and `NewContextBuilderStageWithTurnState` constructor. Token-budget accounting reads `SystemPrompt` from TurnState when wired.
- `runtime/pipeline/stage/stages_duplex_provider_integration.go` — `DuplexProviderStage` gains a `turnState` field and `NewDuplexProviderStageWithTurnState` constructor. Both session-creation (lazy first-element path) and per-element `SendSystemContext` source the prompt from TurnState first.
- `sdk/internal/pipeline/builder.go` — threads the per-Send `*TurnState` into `ContextBuilderStage`, `ProviderStage`, and `DuplexProviderStage` via the new constructors.
- `tools/arena/turnexecutors/pipeline_stages_integration.go` — both Arena pipeline builders thread their per-Turn `*TurnState` into `ContextBuilderStage` and `ProviderStage`. `PipelineExecutor.buildProviderStage` now takes a `*TurnState` parameter.
- `tools/arena/engine/duplex_executor_pipeline_integration.go` — duplex pipeline switches to `NewDuplexProviderStageWithTurnState`.
- `runtime/pipeline/stage/stages_provider_test.go` — two new tests pinning that TurnState overrides the bag, and that an empty TurnState falls back to the bag.
- `runtime/pipeline/stage/stages_utilities_test.go` — one new test verifying `TurnState.SystemPrompt` drives `ContextBuilderStage` budget math.

## Out of PR 5a scope

- Arena instruction stages (`CompletionInstructionStage`, `SkillInstructionStage`) and Arena-unique keys (chaos, selfplay, mock, duplex/voice, telemetry) stay on the bag. **PR 5b** migrates them.
- `TemplateStage` still writes `system_prompt` back to the bag for back-compat with the unmigrated stages above. **PR 5c** removes the cache-write-back and deletes the bag.

## Test plan

- [x] `go test ./runtime/... ./sdk/... ./tools/arena/...` — full sweep green
- [x] `golangci-lint --new-from-rev HEAD` on all three modules — 0 issues
- [x] Three new tests pass and exercise the override + fallback paths directly
- [x] Pre-commit hook passes (lint + build + per-file coverage on changed packages)
- [ ] CI green
- [ ] Arena example jobs green (byte-equivalence regression check on report output via existing CI)
