### PR TITLE
feat(arena): instruction stages append once per Turn via TurnState

### DIFF
--- a/tools/arena/selfplay/generator.go
+++ b/tools/arena/selfplay/generator.go
@@ -133,7 +133,9 @@ func (cg *ContentGenerator) NextUserTurn(
 
 	// Append natural termination instruction when enabled
 	if opts != nil && opts.NaturalTerminationEnabled {
-		stages = append(stages, arenastages.NewCompletionInstructionStage(CompletionInstruction))
+		stages = append(stages,
+			arenastages.NewCompletionInstructionStageWithTurnState(CompletionInstruction, turnState),
+		)
 	}
 
 	// Swap user↔assistant roles so the self-play LLM sees its own prior outputs

--- a/tools/arena/stages/completion_instruction.go
+++ b/tools/arena/stages/completion_instruction.go
@@ -7,14 +7,18 @@ import (
 )
 
 // CompletionInstructionStage appends natural termination instructions to the
-// system prompt assembled by PersonaAssemblyStage.
+// system prompt assembled by PersonaAssemblyStage. The instruction is appended
+// exactly once per Turn — TurnState.SystemPrompt is the source of truth and
+// the stage is idempotent across the elements that flow through it.
 type CompletionInstructionStage struct {
 	stage.BaseStage
 	instruction string
+	turnState   *stage.TurnState
 }
 
-// NewCompletionInstructionStage creates a stage that appends the given instruction
-// to the "system_prompt" metadata key.
+// NewCompletionInstructionStage creates a stage that appends the given
+// instruction to the system prompt. Pipelines that have migrated to TurnState
+// should use NewCompletionInstructionStageWithTurnState.
 func NewCompletionInstructionStage(instruction string) *CompletionInstructionStage {
 	return &CompletionInstructionStage{
 		BaseStage:   stage.NewBaseStage("completion_instruction", stage.StageTypeTransform),
@@ -22,25 +26,21 @@ func NewCompletionInstructionStage(instruction string) *CompletionInstructionSta
 	}
 }
 
-// Process appends the completion instruction to the system_prompt metadata.
+// NewCompletionInstructionStageWithTurnState creates a stage that reads and
+// writes the system prompt through the shared *TurnState.
+func NewCompletionInstructionStageWithTurnState(
+	instruction string, turnState *stage.TurnState,
+) *CompletionInstructionStage {
+	return &CompletionInstructionStage{
+		BaseStage:   stage.NewBaseStage("completion_instruction", stage.StageTypeTransform),
+		instruction: instruction,
+		turnState:   turnState,
+	}
+}
+
+// Process appends the completion instruction to the system prompt.
 //
 //nolint:lll // Channel signature cannot be shortened
 func (s *CompletionInstructionStage) Process(ctx context.Context, input <-chan stage.StreamElement, output chan<- stage.StreamElement) error {
-	defer close(output)
-
-	for elem := range input {
-		if elem.Metadata != nil {
-			if sp, ok := elem.Metadata["system_prompt"].(string); ok {
-				elem.Metadata["system_prompt"] = sp + s.instruction
-			}
-		}
-
-		select {
-		case output <- elem:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-
-	return nil
+	return processInstructionStage(ctx, input, output, s.instruction, s.turnState)
 }

--- a/tools/arena/stages/completion_instruction_test.go
+++ b/tools/arena/stages/completion_instruction_test.go
@@ -86,6 +86,48 @@ func TestCompletionInstructionStage_Constructor(t *testing.T) {
 	assert.Equal(t, stage.StageTypeTransform, s.Type())
 }
 
+func TestCompletionInstructionStage_TurnStateAppendsOnce(t *testing.T) {
+	// With TurnState, the stage appends exactly once per Turn — even across
+	// multiple elements that all carry a system_prompt. The shared
+	// SystemPrompt becomes the source of truth and propagates onto every
+	// element's bag for back-compat readers.
+	turnState := stage.NewTurnState()
+	turnState.SystemPrompt = "You are a helpful assistant."
+	s := NewCompletionInstructionStageWithTurnState("\nPlease finish now.", turnState)
+
+	inputs := []stage.StreamElement{
+		{Metadata: map[string]interface{}{"system_prompt": "stale-bag-value"}},
+		{Metadata: map[string]interface{}{"system_prompt": "another-stale-value"}},
+		{Metadata: map[string]interface{}{"other": "no system_prompt"}},
+	}
+	results := runStage(t, s, inputs)
+	require.Len(t, results, 3)
+
+	expected := "You are a helpful assistant.\nPlease finish now."
+	assert.Equal(t, expected, turnState.SystemPrompt, "TurnState should hold the appended prompt exactly once")
+	assert.Equal(t, expected, results[0].Metadata["system_prompt"])
+	assert.Equal(t, expected, results[1].Metadata["system_prompt"],
+		"second element's bag should mirror the appended TurnState prompt — no double-append")
+	assert.Equal(t, expected, results[2].Metadata["system_prompt"],
+		"element without prior system_prompt still gets the propagated value")
+}
+
+func TestCompletionInstructionStage_TurnStateEmptyFallsBackToBag(t *testing.T) {
+	// When TurnState.SystemPrompt is empty (legacy callers wiring TurnState
+	// but not having TemplateStage populate it), the stage seeds from the
+	// first element's bag and writes the appended value back.
+	turnState := stage.NewTurnState()
+	s := NewCompletionInstructionStageWithTurnState(" END", turnState)
+
+	inputs := []stage.StreamElement{
+		{Metadata: map[string]interface{}{"system_prompt": "First"}},
+	}
+	results := runStage(t, s, inputs)
+	require.Len(t, results, 1)
+	assert.Equal(t, "First END", turnState.SystemPrompt)
+	assert.Equal(t, "First END", results[0].Metadata["system_prompt"])
+}
+
 func TestCompletionInstructionStage_MultipleElements(t *testing.T) {
 	s := NewCompletionInstructionStage(" END")
 

--- a/tools/arena/stages/instruction_helpers.go
+++ b/tools/arena/stages/instruction_helpers.go
@@ -1,0 +1,133 @@
+package stages
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// processInstructionStage is the shared pipeline body for stages that append a
+// fixed instruction string to the system prompt
+// (CompletionInstructionStage, SkillInstructionStage). It supports two paths:
+//
+//  1. With a *TurnState wired: the instruction is appended exactly once per
+//     Turn into TurnState.SystemPrompt, regardless of how many elements flow
+//     through. Subsequent elements just propagate the appended value back to
+//     their own metadata bag for any back-compat readers that haven't
+//     migrated.
+//  2. Without TurnState (legacy callers): per-element bag append on every
+//     element that has a system_prompt key. This preserves pre-#1052
+//     behavior for callers that haven't yet wired TurnState into their
+//     pipeline builder.
+//
+// An empty instruction string short-circuits to a pure passthrough — no
+// element is mutated.
+//
+//nolint:lll // Channel signature cannot be shortened
+func processInstructionStage(ctx context.Context, input <-chan stage.StreamElement, output chan<- stage.StreamElement, instruction string, turnState *stage.TurnState) error {
+	defer close(output)
+
+	if instruction == "" {
+		return forwardAllInstructionElements(ctx, input, output)
+	}
+
+	if turnState != nil {
+		return appendInstructionViaTurnState(ctx, input, output, instruction, turnState)
+	}
+
+	return appendInstructionViaBag(ctx, input, output, instruction)
+}
+
+func forwardAllInstructionElements(
+	ctx context.Context, input <-chan stage.StreamElement, output chan<- stage.StreamElement,
+) error {
+	for elem := range input {
+		select {
+		case output <- elem:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// appendInstructionViaBag is the legacy per-element bag-append path. Each
+// element with a system_prompt key gets the instruction appended to its bag
+// value. Used only when TurnState is not wired.
+func appendInstructionViaBag(
+	ctx context.Context, input <-chan stage.StreamElement, output chan<- stage.StreamElement, instruction string,
+) error {
+	for elem := range input {
+		// Legacy bag path: preserved for back-compat with callers that
+		// haven't wired TurnState into their pipeline builder yet.
+		//nolint:staticcheck // see comment above
+		if elem.Metadata != nil {
+			//nolint:staticcheck // see comment above
+			if sp, ok := elem.Metadata["system_prompt"].(string); ok {
+				//nolint:staticcheck // see comment above
+				elem.Metadata["system_prompt"] = sp + instruction
+			}
+		}
+		select {
+		case output <- elem:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// appendInstructionViaTurnState appends the instruction exactly once into
+// TurnState.SystemPrompt and propagates the appended value onto every
+// element's metadata bag (for back-compat readers downstream that haven't yet
+// migrated off the bag).
+func appendInstructionViaTurnState(
+	ctx context.Context, input <-chan stage.StreamElement, output chan<- stage.StreamElement,
+	instruction string, turnState *stage.TurnState,
+) error {
+	appended := false
+	for elem := range input {
+		if !appended {
+			seedTurnStateSystemPrompt(&elem, instruction, turnState)
+			appended = true
+		}
+		propagateTurnStateSystemPromptToBag(&elem, turnState)
+
+		select {
+		case output <- elem:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func seedTurnStateSystemPrompt(elem *stage.StreamElement, instruction string, turnState *stage.TurnState) {
+	if turnState.SystemPrompt != "" {
+		turnState.SystemPrompt += instruction
+		return
+	}
+	//nolint:staticcheck // Reading the bag for first-time seeding is the explicit back-compat path.
+	if elem.Metadata == nil {
+		return
+	}
+	//nolint:staticcheck // see above
+	if sp, ok := elem.Metadata["system_prompt"].(string); ok {
+		turnState.SystemPrompt = sp + instruction
+	}
+}
+
+func propagateTurnStateSystemPromptToBag(elem *stage.StreamElement, turnState *stage.TurnState) {
+	if turnState.SystemPrompt == "" {
+		return
+	}
+	// Writing system_prompt back to the bag keeps any unmigrated
+	// downstream reader in sync; removed when the bag is removed.
+	//nolint:staticcheck // see comment above
+	if elem.Metadata == nil {
+		//nolint:staticcheck // see comment above
+		elem.Metadata = make(map[string]interface{})
+	}
+	//nolint:staticcheck // see comment above
+	elem.Metadata["system_prompt"] = turnState.SystemPrompt
+}

--- a/tools/arena/stages/skill_instruction.go
+++ b/tools/arena/stages/skill_instruction.go
@@ -6,16 +6,19 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 )
 
-// SkillInstructionStage appends preloaded skill instructions to the
-// system_prompt metadata so the model sees skills marked preload: true
-// from turn 1 without having to call skill__activate.
+// SkillInstructionStage appends preloaded skill instructions to the system
+// prompt so the model sees skills marked preload: true from turn 1 without
+// having to call skill__activate. The instructions are appended exactly once
+// per Turn when wired with a *TurnState.
 type SkillInstructionStage struct {
 	stage.BaseStage
 	instructions string
+	turnState    *stage.TurnState
 }
 
 // NewSkillInstructionStage creates a stage that appends the given preloaded
-// skill instructions block to the "system_prompt" metadata key.
+// skill instructions block to the system prompt. Pipelines that have migrated
+// to TurnState should use NewSkillInstructionStageWithTurnState.
 func NewSkillInstructionStage(instructions string) *SkillInstructionStage {
 	return &SkillInstructionStage{
 		BaseStage:    stage.NewBaseStage("skill_instruction", stage.StageTypeTransform),
@@ -23,25 +26,21 @@ func NewSkillInstructionStage(instructions string) *SkillInstructionStage {
 	}
 }
 
-// Process appends the preloaded skill instructions to the system_prompt metadata.
+// NewSkillInstructionStageWithTurnState creates a stage that reads and writes
+// the system prompt through the shared *TurnState.
+func NewSkillInstructionStageWithTurnState(
+	instructions string, turnState *stage.TurnState,
+) *SkillInstructionStage {
+	return &SkillInstructionStage{
+		BaseStage:    stage.NewBaseStage("skill_instruction", stage.StageTypeTransform),
+		instructions: instructions,
+		turnState:    turnState,
+	}
+}
+
+// Process appends the preloaded skill instructions to the system prompt.
 //
 //nolint:lll // Channel signature cannot be shortened
 func (s *SkillInstructionStage) Process(ctx context.Context, input <-chan stage.StreamElement, output chan<- stage.StreamElement) error {
-	defer close(output)
-
-	for elem := range input {
-		if elem.Metadata != nil && s.instructions != "" {
-			if sp, ok := elem.Metadata["system_prompt"].(string); ok {
-				elem.Metadata["system_prompt"] = sp + s.instructions
-			}
-		}
-
-		select {
-		case output <- elem:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-
-	return nil
+	return processInstructionStage(ctx, input, output, s.instructions, s.turnState)
 }

--- a/tools/arena/stages/skill_instruction_test.go
+++ b/tools/arena/stages/skill_instruction_test.go
@@ -8,6 +8,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSkillInstructionStage_TurnStateAppendsOnce(t *testing.T) {
+	turnState := stage.NewTurnState()
+	turnState.SystemPrompt = "Base prompt."
+	s := NewSkillInstructionStageWithTurnState("\n\n# Skills\nFoo", turnState)
+
+	inputs := []stage.StreamElement{
+		{Metadata: map[string]interface{}{"system_prompt": "stale-1"}},
+		{Metadata: map[string]interface{}{"system_prompt": "stale-2"}},
+	}
+	results := runStage(t, s, inputs)
+	require.Len(t, results, 2)
+
+	expected := "Base prompt.\n\n# Skills\nFoo"
+	assert.Equal(t, expected, turnState.SystemPrompt, "appended exactly once into TurnState")
+	assert.Equal(t, expected, results[0].Metadata["system_prompt"])
+	assert.Equal(t, expected, results[1].Metadata["system_prompt"], "no double-append on second element")
+}
+
 func TestSkillInstructionStage_AppendsToSystemPrompt(t *testing.T) {
 	s := NewSkillInstructionStage("\n\n# Active Skills\n\n## memory-protocol\n\nCall memory__recall first.\n")
 

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -312,7 +312,9 @@ func (e *PipelineExecutor) buildStagePipeline(
 	// marked preload: true are active from turn 1 without requiring the
 	// model to call skill__activate.
 	if e.preloadedSkillInstructions != "" {
-		stages = append(stages, arenastages.NewSkillInstructionStage(e.preloadedSkillInstructions))
+		stages = append(stages,
+			arenastages.NewSkillInstructionStageWithTurnState(e.preloadedSkillInstructions, turnState),
+		)
 	}
 
 	// 4a. Mock scenario context (for mock providers only)


### PR DESCRIPTION
## Summary

PR 5b in the layered-pipeline-architecture sequence (after #1048-#1052). Migrates Arena's `CompletionInstructionStage` and `SkillInstructionStage` onto the `*TurnState` wiring.

**Together with #1052 this fixes a latent bug introduced there:** `ProviderStage` / `ContextBuilderStage` / `DuplexProviderStage` now read `system_prompt` from `TurnState`, but the instruction stages were still writing only to the deprecated metadata bag — the appended instruction was being silently dropped on the path between `TemplateStage` and `ProviderStage`. Triggered only by self-play with `NaturalTermination` enabled or packs with `preload: true` skills. No CI example exercises either path, so the bug never surfaced when #1052 merged.

## What changed

- `tools/arena/stages/instruction_helpers.go` (new) — `processInstructionStage` is the shared pipeline body for both instruction stages. Two paths:
  - **WithTurnState**: appended exactly once per Turn into `TurnState.SystemPrompt`, then propagated onto every element's bag for any unmigrated downstream readers.
  - **Legacy bag-only**: per-element append for callers that haven't wired TurnState. Pre-#1052 behavior preserved.
  - Empty instruction string short-circuits to passthrough.
- `tools/arena/stages/completion_instruction.go` — gains `turnState` field + `NewCompletionInstructionStageWithTurnState`; `Process` delegates to the helper.
- `tools/arena/stages/skill_instruction.go` — same treatment.
- `tools/arena/stages/completion_instruction_test.go` — two new tests: TurnState appends exactly once across multiple elements (no double-append on element 2/3 even when their bags carry stale values), and an empty TurnState seeded from the first element's bag.
- `tools/arena/stages/skill_instruction_test.go` — one new test for the TurnState idempotent path.
- `tools/arena/turnexecutors/pipeline_stages_integration.go` — skill instruction stage construction switches to the `WithTurnState` constructor.
- `tools/arena/selfplay/generator.go` — completion instruction stage construction switches to the `WithTurnState` constructor.

## Out of PR 5b scope

- Arena-unique cross-stage reads still using the bag (`arena_user_completed_turns`, `arena_user_next_turn`) — these need an `ArenaTurnState` extension; deferred to PR 5c alongside the bag rename / lockdown.
- Arena-unique provider-delivery keys (`mock_scenario_id`, `mock_turn_number`, `mock_persona_id`, `persona`, etc.) keep flowing through the bag — they are intentionally provider-specific config delivered via `PredictionRequest.Metadata`. The bag is the right conduit for this; PR 5c will rename / formalise.
- `ArenaStateStoreSaveStage`'s wholesale `Metadata` copy stays — it operates on persisted state, not pipeline cross-stage communication.

## Test plan

- [x] `go test ./runtime/... ./sdk/... ./tools/arena/...` — full sweep green
- [x] New TurnState tests pass; existing legacy-bag tests still pass unchanged
- [x] `golangci-lint --new-from-rev HEAD ./tools/arena/...` — 0 issues
- [x] Pre-commit hook passes (lint + build + per-file coverage on changed packages: 100% on completion_instruction.go, 100% on skill_instruction.go, 86.8% on instruction_helpers.go)
- [ ] CI green
- [ ] Arena example jobs green (existing CI is the byte-equivalence regression check on report output)
