### PR TITLE
feat(statestore): typed write mutators + BulkWriter split (PR 7)

### DIFF
--- a/runtime/pipeline/stage/stages_save.go
+++ b/runtime/pipeline/stage/stages_save.go
@@ -179,11 +179,19 @@ func (s *IncrementalSaveStage) filterNewMessages(messages []types.Message) []typ
 	return newMsgs
 }
 
-// fullSave performs a full load+replace+save cycle (fallback when MessageAppender unavailable).
+// fullSave performs a full load+replace+save cycle. This path is reached
+// only when the store does not implement MessageAppender; persistence
+// requires the store to also implement BulkWriter (otherwise the state
+// is fundamentally unwritable and the stage errors clearly).
 func (s *IncrementalSaveStage) fullSave(ctx context.Context, collected *incrementalCollectedData) error {
 	store, ok := s.config.StateStoreConfig.Store.(statestore.Store)
 	if !ok {
 		return fmt.Errorf("incremental save: invalid store type")
+	}
+	bulkWriter, ok := s.config.StateStoreConfig.Store.(statestore.BulkWriter)
+	if !ok {
+		return fmt.Errorf(
+			"incremental save: store implements neither MessageAppender nor BulkWriter — cannot persist state")
 	}
 
 	convID := s.config.StateStoreConfig.ConversationID
@@ -226,7 +234,7 @@ func (s *IncrementalSaveStage) fullSave(ctx context.Context, collected *incremen
 		state.Summaries = summaries
 	}
 
-	return store.Save(ctx, state)
+	return bulkWriter.Save(ctx, state)
 }
 
 // indexNewMessages indexes new messages in the message index (Phase 2).

--- a/runtime/pipeline/stage/structural_guards_test.go
+++ b/runtime/pipeline/stage/structural_guards_test.go
@@ -1,0 +1,100 @@
+package stage
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoBulkWriterInStageConfigs is a structural invariant: no struct field
+// declared in this package may have a type that mentions BulkWriter. Hot-path
+// stages must reach the store via MessageAppender, MetadataAccessor, or
+// SummaryAccessor — never via the bulk-write escape hatch. This test catches
+// regressions by walking the AST instead of relying on reflection (which
+// would miss un-instantiated config types).
+func TestNoBulkWriterInStageConfigs(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	entries, err := os.ReadDir(wd)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var violations []string
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(wd, name)
+		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+			if st.Fields == nil {
+				return true
+			}
+			for _, field := range st.Fields.List {
+				if mentionsBulkWriter(field.Type) {
+					pos := fset.Position(field.Pos())
+					names := fieldNames(field)
+					violations = append(violations,
+						pos.String()+": struct "+ts.Name.Name+" field "+names+" references BulkWriter")
+				}
+			}
+			return true
+		})
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("hot-path stages must not depend on BulkWriter — use MessageAppender / "+
+			"MetadataAccessor / SummaryAccessor instead:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+// mentionsBulkWriter walks a type expression and reports whether any
+// identifier in it is "BulkWriter". Catches both `statestore.BulkWriter` and
+// `*statestore.BulkWriter`, plus the unqualified form should anyone alias
+// the type into the package.
+func mentionsBulkWriter(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == "BulkWriter" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func fieldNames(f *ast.Field) string {
+	if len(f.Names) == 0 {
+		return "<embedded>"
+	}
+	parts := make([]string, len(f.Names))
+	for i, n := range f.Names {
+		parts[i] = n.Name
+	}
+	return strings.Join(parts, ", ")
+}

--- a/runtime/statestore/interface.go
+++ b/runtime/statestore/interface.go
@@ -9,16 +9,33 @@ import (
 )
 
 // Store defines the interface for persistent conversation state storage.
+//
+// Store is read-shaped: it deliberately does not include bulk-write methods.
+// Callers needing to persist state should use the typed write interfaces
+// (MessageAppender, MetadataAccessor.MergeMetadata, SummaryAccessor.SaveSummary).
+// Admin/seed paths that need to replace whole state should type-assert for
+// BulkWriter; hot-path pipeline stages must not.
 type Store interface {
 	// Load retrieves conversation state by ID
 	Load(ctx context.Context, id string) (*ConversationState, error)
 
-	// Save persists conversation state
-	Save(ctx context.Context, state *ConversationState) error
-
 	// Fork creates a copy of an existing conversation state with a new ID
 	// The original conversation is left unchanged. Returns ErrNotFound if sourceID doesn't exist.
 	Fork(ctx context.Context, sourceID, newID string) error
+}
+
+// BulkWriter allows replacing the entire conversation state in one
+// operation. Optional and explicitly OUT-OF-BAND for hot-path stages —
+// it exists for admin tools, test seeders, and Session.Clear-style ops.
+//
+// Pipeline stages must NEVER take a BulkWriter as a config field. Use
+// MessageAppender, MetadataAccessor.MergeMetadata, and SummaryAccessor.SaveSummary
+// for typed, race-safe writes instead. A reflective test in
+// runtime/pipeline/stage enforces this invariant.
+type BulkWriter interface {
+	// Save persists the entire conversation state, overwriting any existing
+	// record. Auto-creates the conversation if it doesn't exist.
+	Save(ctx context.Context, state *ConversationState) error
 }
 
 // ListOptions provides filtering and pagination options for listing conversations.
@@ -58,22 +75,30 @@ type MessageReader interface {
 
 // MessageAppender allows appending messages without a full load+replace+save cycle.
 // This is an optional interface — stores that implement it enable incremental saves.
-// Pipeline stages type-assert for this interface and fall back to Store.Save when unavailable.
+// Pipeline stages type-assert for this interface and fall back to BulkWriter when unavailable.
 type MessageAppender interface {
 	// AppendMessages appends messages to the conversation's message history.
-	// Creates the conversation if it doesn't exist.
+	// Auto-creates the conversation if it doesn't exist.
 	AppendMessages(ctx context.Context, id string, messages []types.Message) error
 }
 
-// MetadataAccessor allows reading metadata without loading the full state.
-// This is an optional interface — stores that implement it enable efficient
-// metadata reads without the cost of deep-copying the message history.
-// Pipeline stages type-assert for this interface and fall back to Store.Load when unavailable.
+// MetadataAccessor allows reading and writing metadata without loading the
+// full state. This is an optional interface — stores that implement it
+// enable efficient metadata operations without the cost of deep-copying the
+// message history. Pipeline stages type-assert for this interface; reads
+// fall back to Store.Load when LoadMetadata is unavailable, and writes fall
+// back to BulkWriter when MergeMetadata is unavailable.
 type MetadataAccessor interface {
 	// LoadMetadata returns just the metadata map for the given conversation.
 	// Returns ErrNotFound if the conversation doesn't exist.
 	// The returned map is a deep copy safe for mutation by the caller.
 	LoadMetadata(ctx context.Context, id string) (map[string]interface{}, error)
+
+	// MergeMetadata atomically merges the supplied keys into the
+	// conversation's Metadata map. Existing keys are overwritten, other
+	// fields (Messages, Summaries, etc.) are untouched. Auto-creates the
+	// conversation if it doesn't exist.
+	MergeMetadata(ctx context.Context, id string, updates map[string]interface{}) error
 }
 
 // SummaryAccessor allows reading and writing summaries independently of the full state.
@@ -84,6 +109,7 @@ type SummaryAccessor interface {
 	LoadSummaries(ctx context.Context, id string) ([]Summary, error)
 
 	// SaveSummary appends a summary to the conversation's summary list.
+	// Auto-creates the conversation if it doesn't exist.
 	SaveSummary(ctx context.Context, id string, summary Summary) error
 }
 

--- a/runtime/statestore/memory.go
+++ b/runtime/statestore/memory.go
@@ -611,7 +611,7 @@ func (s *MemoryStore) LoadSummaries(ctx context.Context, id string) ([]Summary, 
 }
 
 // SaveSummary appends a summary to the conversation's summary list.
-// Expired entries return ErrNotFound.
+// Auto-creates the conversation if it doesn't exist.
 func (s *MemoryStore) SaveSummary(ctx context.Context, id string, summary Summary) error {
 	if id == "" {
 		return ErrInvalidID
@@ -620,17 +620,35 @@ func (s *MemoryStore) SaveSummary(ctx context.Context, id string, summary Summar
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	state, exists := s.states[id]
-	if !exists {
-		return ErrNotFound
-	}
-
-	if s.isExpired(state) {
-		s.deleteStateLocked(id, state)
-		return ErrNotFound
-	}
-
+	state := s.getOrCreateStateLocked(id)
 	state.Summaries = append(state.Summaries, summary)
+	now := time.Now()
+	state.LastAccessedAt = now
+	s.touchLRULocked(id, now)
+
+	return nil
+}
+
+// MergeMetadata atomically merges the supplied keys into the conversation's
+// Metadata map. Auto-creates the conversation if it doesn't exist.
+func (s *MemoryStore) MergeMetadata(ctx context.Context, id string, updates map[string]interface{}) error {
+	if id == "" {
+		return ErrInvalidID
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := s.getOrCreateStateLocked(id)
+	if state.Metadata == nil {
+		state.Metadata = make(map[string]interface{}, len(updates))
+	}
+	for k, v := range updates {
+		state.Metadata[k] = v
+	}
 	now := time.Now()
 	state.LastAccessedAt = now
 	s.touchLRULocked(id, now)

--- a/runtime/statestore/memory_test.go
+++ b/runtime/statestore/memory_test.go
@@ -1044,9 +1044,12 @@ func TestMemoryStore_SaveSummary(t *testing.T) {
 	assert.Equal(t, "First summary of the conversation.", loaded.Summaries[0].Content)
 	assert.Equal(t, "Second summary of the conversation.", loaded.Summaries[1].Content)
 
-	// Not found
-	err = store.SaveSummary(ctx, "nonexistent", summary1)
-	assert.ErrorIs(t, err, ErrNotFound)
+	// Auto-create on first SaveSummary for a new conversation
+	err = store.SaveSummary(ctx, "auto-created", summary1)
+	require.NoError(t, err)
+	created, err := store.Load(ctx, "auto-created")
+	require.NoError(t, err)
+	require.Len(t, created.Summaries, 1)
 
 	// Invalid ID
 	err = store.SaveSummary(ctx, "", summary1)
@@ -1268,6 +1271,66 @@ func TestMemoryStore_LoadMetadata(t *testing.T) {
 	metadata, err = store.LoadMetadata(ctx, "conv-no-meta")
 	require.NoError(t, err)
 	assert.Nil(t, metadata)
+}
+
+func TestMemoryStore_MergeMetadata(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Auto-create on first MergeMetadata
+	require.NoError(t, store.MergeMetadata(ctx, "conv-merge", map[string]interface{}{
+		"a": 1, "b": "two",
+	}))
+	got, err := store.LoadMetadata(ctx, "conv-merge")
+	require.NoError(t, err)
+	assert.Equal(t, 1, got["a"])
+	assert.Equal(t, "two", got["b"])
+
+	// Subsequent merge adds and overwrites — other fields untouched
+	require.NoError(t, store.AppendMessages(ctx, "conv-merge", []types.Message{{Role: "user", Content: "hi"}}))
+	require.NoError(t, store.MergeMetadata(ctx, "conv-merge", map[string]interface{}{
+		"b": "TWO", "c": 3,
+	}))
+	loaded, err := store.Load(ctx, "conv-merge")
+	require.NoError(t, err)
+	assert.Equal(t, 1, loaded.Metadata["a"])
+	assert.Equal(t, "TWO", loaded.Metadata["b"])
+	assert.Equal(t, 3, loaded.Metadata["c"])
+	require.Len(t, loaded.Messages, 1)
+	assert.Equal(t, "hi", loaded.Messages[0].Content)
+
+	// Empty updates is a no-op
+	require.NoError(t, store.MergeMetadata(ctx, "conv-merge", nil))
+	require.NoError(t, store.MergeMetadata(ctx, "conv-merge", map[string]interface{}{}))
+
+	// Invalid ID
+	assert.ErrorIs(t, store.MergeMetadata(ctx, "", map[string]interface{}{"x": 1}), ErrInvalidID)
+}
+
+func TestMemoryStore_MergeMetadataConcurrent(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := store.MergeMetadata(ctx, "race", map[string]interface{}{
+				fmt.Sprintf("k%d", i): i,
+			})
+			require.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := store.LoadMetadata(ctx, "race")
+	require.NoError(t, err)
+	require.Len(t, got, goroutines)
+	for i := 0; i < goroutines; i++ {
+		assert.Equal(t, i, got[fmt.Sprintf("k%d", i)])
+	}
 }
 
 func TestMemoryStore_LoadMetadata_Expired(t *testing.T) {

--- a/runtime/statestore/memory_ttl_test.go
+++ b/runtime/statestore/memory_ttl_test.go
@@ -274,17 +274,30 @@ func TestMemoryStore_TTLLoadSummariesExpired(t *testing.T) {
 	assert.Nil(t, summaries)
 }
 
-func TestMemoryStore_TTLSaveSummaryExpired(t *testing.T) {
+func TestMemoryStore_TTLSaveSummaryExpiredAutoRecreates(t *testing.T) {
+	// SaveSummary auto-creates the conversation if missing or expired.
+	// After expiry, SaveSummary re-creates the entry with the new summary
+	// and no prior messages.
 	store := NewMemoryStore(WithMemoryTTL(50 * time.Millisecond))
 	ctx := context.Background()
 
-	err := store.Save(ctx, &ConversationState{ID: "conv-ss"})
+	err := store.Save(ctx, &ConversationState{
+		ID:       "conv-ss",
+		Messages: []types.Message{{Role: "user", Content: "old"}},
+	})
 	require.NoError(t, err)
 
 	time.Sleep(80 * time.Millisecond)
 
 	err = store.SaveSummary(ctx, "conv-ss", Summary{Content: "Late summary"})
-	assert.ErrorIs(t, err, ErrNotFound)
+	require.NoError(t, err)
+
+	loaded, err := store.Load(ctx, "conv-ss")
+	require.NoError(t, err)
+	require.Len(t, loaded.Summaries, 1)
+	assert.Equal(t, "Late summary", loaded.Summaries[0].Content)
+	// Messages from the expired entry are gone.
+	assert.Empty(t, loaded.Messages)
 }
 
 func TestMemoryStore_MaxEntries(t *testing.T) {

--- a/runtime/statestore/redis.go
+++ b/runtime/statestore/redis.go
@@ -598,6 +598,92 @@ func (s *RedisStore) LoadMetadata(ctx context.Context, id string) (map[string]in
 	return state.Metadata, nil
 }
 
+// MergeMetadata atomically merges the supplied keys into the conversation's
+// Metadata map. Uses Redis WATCH/MULTI/EXEC to serialize concurrent merges
+// against the same conversation (so two interleaved MergeMetadata calls
+// can't drop each other's updates). Auto-creates the conversation if the
+// meta key doesn't yet exist.
+func (s *RedisStore) MergeMetadata(ctx context.Context, id string, updates map[string]interface{}) error {
+	if id == "" {
+		return ErrInvalidID
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+
+	metaKey := s.metaKey(id)
+
+	// Optimistic concurrency: WATCH + retry. The retry budget is sized for
+	// realistic contention (a handful of stages writing metadata for the
+	// same conversation in flight); exhausting it indicates pathological
+	// contention or a hot-spot misuse.
+	const maxAttempts = 32
+	for range maxAttempts {
+		err := s.client.Watch(ctx, func(tx *redis.Tx) error {
+			return s.mergeMetadataTx(ctx, tx, id, metaKey, updates)
+		}, metaKey)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, redis.TxFailedErr) {
+			return fmt.Errorf("redis merge metadata failed: %w", err)
+		}
+		// TxFailedErr means the watched key changed — retry.
+	}
+	return fmt.Errorf("redis merge metadata: aborted after %d retries due to contention", maxAttempts)
+}
+
+// mergeMetadataTx runs the body of a MergeMetadata WATCH transaction:
+// load → merge → set. Extracted so MergeMetadata stays under the
+// gocognit threshold and the merge body can be exercised by the unit
+// tests without spinning up a contention scenario.
+func (s *RedisStore) mergeMetadataTx(
+	ctx context.Context, tx *redis.Tx, id, metaKey string, updates map[string]interface{},
+) error {
+	meta, err := s.loadMetaTx(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	if meta.Metadata == nil {
+		meta.Metadata = make(map[string]interface{}, len(updates))
+	}
+	for k, v := range updates {
+		meta.Metadata[k] = v
+	}
+	meta.LastAccessedAt = time.Now()
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal meta: %w", err)
+	}
+	_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.Set(ctx, metaKey, data, s.ttl)
+		return nil
+	})
+	return err
+}
+
+// loadMetaTx loads the meta blob inside a WATCH transaction. Returns a fresh
+// redisStateMeta seeded with the conversation ID when the key doesn't exist
+// (auto-create semantics for typed write paths).
+func (s *RedisStore) loadMetaTx(ctx context.Context, tx *redis.Tx, id string) (*redisStateMeta, error) {
+	data, err := tx.Get(ctx, s.metaKey(id)).Bytes()
+	if err == nil {
+		var meta redisStateMeta
+		if unmarshalErr := json.Unmarshal(data, &meta); unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to unmarshal meta: %w", unmarshalErr)
+		}
+		if meta.ID == "" {
+			meta.ID = id
+		}
+		return &meta, nil
+	}
+	if !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("redis get meta failed: %w", err)
+	}
+	return &redisStateMeta{ID: id}, nil
+}
+
 // LoadRecentMessages returns the last n messages using LRANGE on the messages list.
 // Falls back to loading from the monolithic key if the list doesn't exist.
 func (s *RedisStore) LoadRecentMessages(ctx context.Context, id string, n int) ([]types.Message, error) {

--- a/runtime/statestore/redis.go
+++ b/runtime/statestore/redis.go
@@ -14,6 +14,13 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// Error message format strings, kept as constants so the same wording
+// doesn't repeat across each call site (Sonar's go:S1192 threshold of 3).
+const (
+	errUnmarshalMeta = "failed to unmarshal meta: %w"
+	errMarshalMeta   = "failed to marshal meta: %w"
+)
+
 // RedisStore provides a Redis-backed implementation of the Store interface.
 // It uses JSON serialization for state storage and supports automatic TTL-based cleanup.
 // This implementation is suitable for distributed systems and production deployments.
@@ -132,7 +139,7 @@ func (s *RedisStore) loadMeta(ctx context.Context, id string) (*redisStateMeta, 
 
 	var meta redisStateMeta
 	if unmarshalErr := json.Unmarshal(data, &meta); unmarshalErr != nil {
-		return nil, fmt.Errorf("failed to unmarshal meta: %w", unmarshalErr)
+		return nil, fmt.Errorf(errUnmarshalMeta, unmarshalErr)
 	}
 	return &meta, nil
 }
@@ -227,7 +234,7 @@ func (s *RedisStore) Save(ctx context.Context, state *ConversationState) error {
 	meta.LastAccessedAt = now
 	metaData, err := json.Marshal(meta)
 	if err != nil {
-		return fmt.Errorf("failed to marshal meta: %w", err)
+		return fmt.Errorf(errMarshalMeta, err)
 	}
 
 	// Check how many messages are already stored so we can do a delta RPUSH
@@ -654,7 +661,7 @@ func (s *RedisStore) mergeMetadataTx(
 
 	data, err := json.Marshal(meta)
 	if err != nil {
-		return fmt.Errorf("failed to marshal meta: %w", err)
+		return fmt.Errorf(errMarshalMeta, err)
 	}
 	_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 		pipe.Set(ctx, metaKey, data, s.ttl)
@@ -671,7 +678,7 @@ func (s *RedisStore) loadMetaTx(ctx context.Context, tx *redis.Tx, id string) (*
 	if err == nil {
 		var meta redisStateMeta
 		if unmarshalErr := json.Unmarshal(data, &meta); unmarshalErr != nil {
-			return nil, fmt.Errorf("failed to unmarshal meta: %w", unmarshalErr)
+			return nil, fmt.Errorf(errUnmarshalMeta, unmarshalErr)
 		}
 		if meta.ID == "" {
 			meta.ID = id
@@ -826,7 +833,7 @@ func (s *RedisStore) updateMetaTTL(ctx context.Context, id, msgKey string) error
 	if err == nil {
 		// Existing meta found — update timestamp
 		if unmarshalErr := json.Unmarshal(data, &meta); unmarshalErr != nil {
-			return fmt.Errorf("failed to unmarshal meta: %w", unmarshalErr)
+			return fmt.Errorf(errUnmarshalMeta, unmarshalErr)
 		}
 	} else if !errors.Is(err, redis.Nil) {
 		return fmt.Errorf("redis get meta failed: %w", err)
@@ -837,7 +844,7 @@ func (s *RedisStore) updateMetaTTL(ctx context.Context, id, msgKey string) error
 
 	metaData, err := json.Marshal(meta)
 	if err != nil {
-		return fmt.Errorf("failed to marshal meta: %w", err)
+		return fmt.Errorf(errMarshalMeta, err)
 	}
 
 	pipe := s.client.Pipeline()

--- a/runtime/statestore/redis_test.go
+++ b/runtime/statestore/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -2171,4 +2172,98 @@ func TestRedisStore_MarshalMessageSlice_Empty(t *testing.T) {
 	vals, err := marshalMessageSlice(nil)
 	require.NoError(t, err)
 	assert.Empty(t, vals)
+}
+
+func TestRedisStore_MergeMetadata_AutoCreatesAndMerges(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Auto-create on first MergeMetadata
+	require.NoError(t, store.MergeMetadata(ctx, "conv-merge", map[string]interface{}{
+		"a": "one",
+		"b": float64(2), // JSON round-trip turns ints into float64
+	}))
+
+	got, err := store.LoadMetadata(ctx, "conv-merge")
+	require.NoError(t, err)
+	assert.Equal(t, "one", got["a"])
+	assert.Equal(t, float64(2), got["b"])
+
+	// Subsequent merge adds and overwrites; other fields untouched
+	require.NoError(t, store.AppendMessages(ctx, "conv-merge", []types.Message{
+		{Role: "user", Content: "hi"},
+	}))
+	require.NoError(t, store.MergeMetadata(ctx, "conv-merge", map[string]interface{}{
+		"b": "TWO",
+		"c": float64(3),
+	}))
+
+	loaded, err := store.Load(ctx, "conv-merge")
+	require.NoError(t, err)
+	assert.Equal(t, "one", loaded.Metadata["a"])
+	assert.Equal(t, "TWO", loaded.Metadata["b"])
+	assert.Equal(t, float64(3), loaded.Metadata["c"])
+	require.Len(t, loaded.Messages, 1)
+	assert.Equal(t, "hi", loaded.Messages[0].Content)
+}
+
+func TestRedisStore_MergeMetadata_EmptyOrInvalid(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Empty updates is a no-op (no key created)
+	require.NoError(t, store.MergeMetadata(ctx, "conv-empty", nil))
+	require.NoError(t, store.MergeMetadata(ctx, "conv-empty", map[string]interface{}{}))
+	_, err := store.LoadMetadata(ctx, "conv-empty")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	// Invalid ID
+	assert.ErrorIs(t,
+		store.MergeMetadata(ctx, "", map[string]interface{}{"x": 1}),
+		ErrInvalidID)
+}
+
+// TestRedisStore_MergeMetadata_CorruptMeta covers the unmarshal-error branch
+// in loadMetaTx: when the meta key holds invalid JSON, MergeMetadata must
+// surface a marshal error rather than silently overwriting the bad value.
+func TestRedisStore_MergeMetadata_CorruptMeta(t *testing.T) {
+	store, mr := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Plant invalid JSON at the meta key for "conv-corrupt".
+	require.NoError(t, mr.Set(store.metaKey("conv-corrupt"), "not-json{{"))
+
+	err := store.MergeMetadata(ctx, "conv-corrupt", map[string]interface{}{"k": "v"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal meta")
+}
+
+func TestRedisStore_MergeMetadata_ConcurrentMergesSerialise(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Realistic contention: a handful of stages writing concurrently to the
+	// same conversation. Pinning at the natural worst case (handful, not
+	// tens) keeps the test deterministic against miniredis's strict WATCH
+	// semantics.
+	const goroutines = 8
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := store.MergeMetadata(ctx, "race", map[string]interface{}{
+				fmt.Sprintf("k%d", i): float64(i),
+			})
+			require.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := store.LoadMetadata(ctx, "race")
+	require.NoError(t, err)
+	require.Len(t, got, goroutines, "every concurrent MergeMetadata must land")
+	for i := range goroutines {
+		assert.Equal(t, float64(i), got[fmt.Sprintf("k%d", i)])
+	}
 }

--- a/runtime/variables/state_test.go
+++ b/runtime/variables/state_test.go
@@ -29,10 +29,10 @@ func (m *mockStateStore) Fork(_ context.Context, _, _ string) error {
 // It tracks whether LoadMetadata was called to verify the fast path is used.
 type mockMetadataStore struct {
 	mockStateStore
-	metadata         map[string]interface{}
-	metadataErr      error
-	loadMetaCalled   bool
-	loadStateCalled  bool
+	metadata        map[string]interface{}
+	metadataErr     error
+	loadMetaCalled  bool
+	loadStateCalled bool
 }
 
 func (m *mockMetadataStore) Load(_ context.Context, _ string) (*statestore.ConversationState, error) {
@@ -43,6 +43,10 @@ func (m *mockMetadataStore) Load(_ context.Context, _ string) (*statestore.Conve
 func (m *mockMetadataStore) LoadMetadata(_ context.Context, _ string) (map[string]interface{}, error) {
 	m.loadMetaCalled = true
 	return m.metadata, m.metadataErr
+}
+
+func (m *mockMetadataStore) MergeMetadata(_ context.Context, _ string, _ map[string]interface{}) error {
+	return nil
 }
 
 func TestStateProvider_Name(t *testing.T) {

--- a/sdk/integration/probes/runner.go
+++ b/sdk/integration/probes/runner.go
@@ -160,6 +160,9 @@ func Run(tb testing.TB, ro RunOptions) (*Probes, *sdk.Conversation) {
 
 func seedStore(tb testing.TB, store statestore.Store, convID string, n int) {
 	tb.Helper()
+	bulkWriter, ok := store.(statestore.BulkWriter)
+	require.True(tb, ok, "seedStore: probe store must implement BulkWriter")
+
 	msgs := make([]types.Message, n)
 	for i := range n {
 		role := "user"
@@ -168,7 +171,7 @@ func seedStore(tb testing.TB, store statestore.Store, convID string, n int) {
 		}
 		msgs[i] = types.Message{Role: role, Content: "prior"}
 	}
-	require.NoError(tb, store.Save(context.Background(), &statestore.ConversationState{
+	require.NoError(tb, bulkWriter.Save(context.Background(), &statestore.ConversationState{
 		ID:       convID,
 		Messages: msgs,
 	}))

--- a/sdk/integration/probes/store.go
+++ b/sdk/integration/probes/store.go
@@ -34,12 +34,19 @@ func (s *probedStore) Load(ctx context.Context, id string) (*statestore.Conversa
 	return s.inner.Load(ctx, id)
 }
 
-// Save forwards to the inner store and increments the Save counter.
+// Save forwards to the inner store's BulkWriter and increments the Save
+// counter. Counted under "store.Save" in the snapshot. Returns
+// ErrNotFound when the inner store does not implement BulkWriter — keeps
+// admin/test-seed paths working without forcing every probed store
+// configuration to support bulk writes.
 func (s *probedStore) Save(ctx context.Context, state *statestore.ConversationState) error {
 	s.mu.Lock()
 	s.saves++
 	s.mu.Unlock()
-	return s.inner.Save(ctx, state)
+	if bw, ok := s.inner.(statestore.BulkWriter); ok {
+		return bw.Save(ctx, state)
+	}
+	return statestore.ErrNotFound
 }
 
 // Fork forwards to the inner store and increments the Fork counter.

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -543,32 +543,14 @@ func (s *duplexSession) GetVar(name string) (string, bool) {
 	return val, ok
 }
 
-// Messages implements BaseSession. Conversations are created lazily on the
-// first typed write, so a brand-new session may not yet exist in the store.
-// Treat ErrNotFound as an empty conversation rather than propagating the error.
+// Messages implements BaseSession.
 func (s *duplexSession) Messages(ctx context.Context) ([]types.Message, error) {
-	state, err := s.store.Load(ctx, s.id)
-	if err != nil {
-		if errors.Is(err, statestore.ErrNotFound) {
-			return []types.Message{}, nil
-		}
-		return nil, err
-	}
-	return state.Messages, nil
+	return loadMessages(ctx, s.store, s.id)
 }
 
-// Clear implements BaseSession. Bulk operation — requires the store to
-// implement BulkWriter. Stores without bulk-write support cannot honor
-// Clear and return an error.
+// Clear implements BaseSession.
 func (s *duplexSession) Clear(ctx context.Context) error {
-	bulkWriter, ok := s.store.(statestore.BulkWriter)
-	if !ok {
-		return fmt.Errorf("session clear: store does not implement BulkWriter")
-	}
-	return bulkWriter.Save(ctx, &statestore.ConversationState{
-		ID:       s.id,
-		Messages: nil,
-	})
+	return clearSession(ctx, s.store, s.id)
 }
 
 // ForkSession implements DuplexSession.
@@ -577,20 +559,8 @@ func (s *duplexSession) ForkSession(
 	forkID string,
 	pipelineBuilder PipelineBuilder,
 ) (DuplexSession, error) {
-	// Fork the state in the store. If the source conversation has not yet been
-	// materialized (e.g. a session that has only run pipelines without typed
-	// writes), create an empty fork target via BulkWriter when available.
-	if err := s.store.Fork(ctx, s.id, forkID); err != nil {
-		if !errors.Is(err, statestore.ErrNotFound) {
-			return nil, fmt.Errorf("failed to fork state: %w", err)
-		}
-		bulkWriter, ok := s.store.(statestore.BulkWriter)
-		if !ok {
-			return nil, fmt.Errorf("failed to fork state: %w", err)
-		}
-		if saveErr := bulkWriter.Save(ctx, &statestore.ConversationState{ID: forkID}); saveErr != nil {
-			return nil, fmt.Errorf("failed to fork state: %w", saveErr)
-		}
+	if err := forkOrCreate(ctx, s.store, s.id, forkID); err != nil {
+		return nil, err
 	}
 
 	// Copy variables

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -69,19 +69,20 @@ type duplexSession struct {
 
 const streamBufferSize = 100 // Size of buffered channels for streaming
 
-// initConversationState initializes state for a new conversation if it doesn't exist.
+// initConversationState seeds initial metadata for a new conversation if
+// any is provided. Otherwise the conversation is created lazily on the
+// first typed write (AppendMessages, MergeMetadata, SaveSummary). No bulk
+// Save needed.
 func initConversationState(ctx context.Context, store statestore.Store, cfg *DuplexSessionConfig, convID string) error {
-	_, err := store.Load(ctx, convID)
-	if err != nil {
-		initialState := &statestore.ConversationState{
-			ID:       convID,
-			UserID:   cfg.UserID,
-			Messages: []types.Message{},
-			Metadata: cfg.Metadata,
-		}
-		if err := store.Save(ctx, initialState); err != nil {
-			return fmt.Errorf("failed to initialize conversation state: %w", err)
-		}
+	if len(cfg.Metadata) == 0 {
+		return nil
+	}
+	accessor, ok := store.(statestore.MetadataAccessor)
+	if !ok {
+		return fmt.Errorf("session: store does not implement MetadataAccessor; cannot seed initial metadata")
+	}
+	if err := accessor.MergeMetadata(ctx, convID, cfg.Metadata); err != nil {
+		return fmt.Errorf("failed to seed conversation metadata: %w", err)
 	}
 	return nil
 }
@@ -542,22 +543,32 @@ func (s *duplexSession) GetVar(name string) (string, bool) {
 	return val, ok
 }
 
-// Messages implements BaseSession.
+// Messages implements BaseSession. Conversations are created lazily on the
+// first typed write, so a brand-new session may not yet exist in the store.
+// Treat ErrNotFound as an empty conversation rather than propagating the error.
 func (s *duplexSession) Messages(ctx context.Context) ([]types.Message, error) {
 	state, err := s.store.Load(ctx, s.id)
 	if err != nil {
+		if errors.Is(err, statestore.ErrNotFound) {
+			return []types.Message{}, nil
+		}
 		return nil, err
 	}
 	return state.Messages, nil
 }
 
-// Clear implements BaseSession.
+// Clear implements BaseSession. Bulk operation — requires the store to
+// implement BulkWriter. Stores without bulk-write support cannot honor
+// Clear and return an error.
 func (s *duplexSession) Clear(ctx context.Context) error {
-	state := &statestore.ConversationState{
+	bulkWriter, ok := s.store.(statestore.BulkWriter)
+	if !ok {
+		return fmt.Errorf("session clear: store does not implement BulkWriter")
+	}
+	return bulkWriter.Save(ctx, &statestore.ConversationState{
 		ID:       s.id,
 		Messages: nil,
-	}
-	return s.store.Save(ctx, state)
+	})
 }
 
 // ForkSession implements DuplexSession.
@@ -566,9 +577,20 @@ func (s *duplexSession) ForkSession(
 	forkID string,
 	pipelineBuilder PipelineBuilder,
 ) (DuplexSession, error) {
-	// Fork the state in the store
+	// Fork the state in the store. If the source conversation has not yet been
+	// materialized (e.g. a session that has only run pipelines without typed
+	// writes), create an empty fork target via BulkWriter when available.
 	if err := s.store.Fork(ctx, s.id, forkID); err != nil {
-		return nil, fmt.Errorf("failed to fork state: %w", err)
+		if !errors.Is(err, statestore.ErrNotFound) {
+			return nil, fmt.Errorf("failed to fork state: %w", err)
+		}
+		bulkWriter, ok := s.store.(statestore.BulkWriter)
+		if !ok {
+			return nil, fmt.Errorf("failed to fork state: %w", err)
+		}
+		if saveErr := bulkWriter.Save(ctx, &statestore.ConversationState{ID: forkID}); saveErr != nil {
+			return nil, fmt.Errorf("failed to fork state: %w", saveErr)
+		}
 	}
 
 	// Copy variables

--- a/sdk/session/store_helpers.go
+++ b/sdk/session/store_helpers.go
@@ -1,0 +1,62 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// errFailedToForkState is shared by the fork-with-bulk-fallback paths in
+// both unarySession and duplexSession. Defined as a const so the literal
+// doesn't appear three times in each file (Sonar's go:S1192 threshold).
+const errFailedToForkState = "failed to fork state: %w"
+
+// loadMessages returns the conversation's messages, treating ErrNotFound
+// as an empty conversation. Conversations are created lazily on the first
+// typed write, so a brand-new session may not yet exist in the store.
+func loadMessages(ctx context.Context, store statestore.Store, id string) ([]types.Message, error) {
+	state, err := store.Load(ctx, id)
+	if err != nil {
+		if errors.Is(err, statestore.ErrNotFound) {
+			return []types.Message{}, nil
+		}
+		return nil, err
+	}
+	return state.Messages, nil
+}
+
+// clearSession resets the conversation by writing an empty state. Bulk
+// operation — requires the store to implement BulkWriter. Stores without
+// bulk-write support cannot honor Clear and the function returns an error.
+func clearSession(ctx context.Context, store statestore.Store, id string) error {
+	bulkWriter, ok := store.(statestore.BulkWriter)
+	if !ok {
+		return fmt.Errorf("session clear: store does not implement BulkWriter")
+	}
+	return bulkWriter.Save(ctx, &statestore.ConversationState{
+		ID:       id,
+		Messages: nil,
+	})
+}
+
+// forkOrCreate forks the source conversation to a new ID. If the source
+// has not yet been materialized (lazy-created), it falls back to creating
+// an empty fork target via BulkWriter when the store supports it.
+func forkOrCreate(ctx context.Context, store statestore.Store, sourceID, forkID string) error {
+	if err := store.Fork(ctx, sourceID, forkID); err != nil {
+		if !errors.Is(err, statestore.ErrNotFound) {
+			return fmt.Errorf(errFailedToForkState, err)
+		}
+		bulkWriter, ok := store.(statestore.BulkWriter)
+		if !ok {
+			return fmt.Errorf(errFailedToForkState, err)
+		}
+		if saveErr := bulkWriter.Save(ctx, &statestore.ConversationState{ID: forkID}); saveErr != nil {
+			return fmt.Errorf(errFailedToForkState, saveErr)
+		}
+	}
+	return nil
+}

--- a/sdk/session/unary_session.go
+++ b/sdk/session/unary_session.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -260,32 +259,14 @@ func (s *unarySession) Variables() map[string]string {
 	return vars
 }
 
-// Messages implements BaseSession. Conversations are created lazily on the
-// first typed write, so a brand-new session may not yet exist in the store.
-// Treat ErrNotFound as an empty conversation rather than propagating the error.
+// Messages implements BaseSession.
 func (s *unarySession) Messages(ctx context.Context) ([]types.Message, error) {
-	state, err := s.store.Load(ctx, s.id)
-	if err != nil {
-		if errors.Is(err, statestore.ErrNotFound) {
-			return []types.Message{}, nil
-		}
-		return nil, err
-	}
-	return state.Messages, nil
+	return loadMessages(ctx, s.store, s.id)
 }
 
-// Clear implements BaseSession. Bulk operation — requires the store to
-// implement BulkWriter. Stores without bulk-write support cannot honor
-// Clear and return an error.
+// Clear implements BaseSession.
 func (s *unarySession) Clear(ctx context.Context) error {
-	bulkWriter, ok := s.store.(statestore.BulkWriter)
-	if !ok {
-		return fmt.Errorf("session clear: store does not implement BulkWriter")
-	}
-	return bulkWriter.Save(ctx, &statestore.ConversationState{
-		ID:       s.id,
-		Messages: nil,
-	})
+	return clearSession(ctx, s.store, s.id)
 }
 
 // ForkSession implements UnarySession.
@@ -294,20 +275,8 @@ func (s *unarySession) ForkSession(
 	forkID string,
 	pipelineArg *stage.StreamPipeline,
 ) (UnarySession, error) {
-	// Fork the state in the store. If the source conversation has not yet been
-	// materialized (e.g. a session that has only run pipelines without typed
-	// writes), create an empty fork target via BulkWriter when available.
-	if err := s.store.Fork(ctx, s.id, forkID); err != nil {
-		if !errors.Is(err, statestore.ErrNotFound) {
-			return nil, fmt.Errorf("failed to fork state: %w", err)
-		}
-		bulkWriter, ok := s.store.(statestore.BulkWriter)
-		if !ok {
-			return nil, fmt.Errorf("failed to fork state: %w", err)
-		}
-		if saveErr := bulkWriter.Save(ctx, &statestore.ConversationState{ID: forkID}); saveErr != nil {
-			return nil, fmt.Errorf("failed to fork state: %w", saveErr)
-		}
+	if err := forkOrCreate(ctx, s.store, s.id, forkID); err != nil {
+		return nil, err
 	}
 
 	// Copy variables

--- a/sdk/session/unary_session.go
+++ b/sdk/session/unary_session.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -36,16 +37,16 @@ func NewUnarySession(cfg UnarySessionConfig) (UnarySession, error) {
 		return nil, fmt.Errorf("pipeline is required")
 	}
 
-	_, err := cfg.StateStore.Load(context.Background(), cfg.ConversationID)
-	if err != nil {
-		initialState := &statestore.ConversationState{
-			ID:       cfg.ConversationID,
-			UserID:   cfg.UserID,
-			Messages: []types.Message{},
-			Metadata: cfg.Metadata,
-		}
-		if err := cfg.StateStore.Save(context.Background(), initialState); err != nil {
-			return nil, fmt.Errorf("failed to initialize conversation state: %w", err)
+	// Seed initial metadata if provided. Otherwise the conversation is
+	// created lazily on the first typed write (AppendMessages, MergeMetadata,
+	// SaveSummary). No bulk Save needed.
+	if len(cfg.Metadata) > 0 {
+		if accessor, ok := cfg.StateStore.(statestore.MetadataAccessor); ok {
+			if err := accessor.MergeMetadata(context.Background(), cfg.ConversationID, cfg.Metadata); err != nil {
+				return nil, fmt.Errorf("failed to seed conversation metadata: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("session: store does not implement MetadataAccessor; cannot seed initial metadata")
 		}
 	}
 
@@ -259,22 +260,32 @@ func (s *unarySession) Variables() map[string]string {
 	return vars
 }
 
-// Messages implements BaseSession.
+// Messages implements BaseSession. Conversations are created lazily on the
+// first typed write, so a brand-new session may not yet exist in the store.
+// Treat ErrNotFound as an empty conversation rather than propagating the error.
 func (s *unarySession) Messages(ctx context.Context) ([]types.Message, error) {
 	state, err := s.store.Load(ctx, s.id)
 	if err != nil {
+		if errors.Is(err, statestore.ErrNotFound) {
+			return []types.Message{}, nil
+		}
 		return nil, err
 	}
 	return state.Messages, nil
 }
 
-// Clear implements BaseSession.
+// Clear implements BaseSession. Bulk operation — requires the store to
+// implement BulkWriter. Stores without bulk-write support cannot honor
+// Clear and return an error.
 func (s *unarySession) Clear(ctx context.Context) error {
-	state := &statestore.ConversationState{
+	bulkWriter, ok := s.store.(statestore.BulkWriter)
+	if !ok {
+		return fmt.Errorf("session clear: store does not implement BulkWriter")
+	}
+	return bulkWriter.Save(ctx, &statestore.ConversationState{
 		ID:       s.id,
 		Messages: nil,
-	}
-	return s.store.Save(ctx, state)
+	})
 }
 
 // ForkSession implements UnarySession.
@@ -283,9 +294,20 @@ func (s *unarySession) ForkSession(
 	forkID string,
 	pipelineArg *stage.StreamPipeline,
 ) (UnarySession, error) {
-	// Fork the state in the store
+	// Fork the state in the store. If the source conversation has not yet been
+	// materialized (e.g. a session that has only run pipelines without typed
+	// writes), create an empty fork target via BulkWriter when available.
 	if err := s.store.Fork(ctx, s.id, forkID); err != nil {
-		return nil, fmt.Errorf("failed to fork state: %w", err)
+		if !errors.Is(err, statestore.ErrNotFound) {
+			return nil, fmt.Errorf("failed to fork state: %w", err)
+		}
+		bulkWriter, ok := s.store.(statestore.BulkWriter)
+		if !ok {
+			return nil, fmt.Errorf("failed to fork state: %w", err)
+		}
+		if saveErr := bulkWriter.Save(ctx, &statestore.ConversationState{ID: forkID}); saveErr != nil {
+			return nil, fmt.Errorf("failed to fork state: %w", saveErr)
+		}
 	}
 
 	// Copy variables

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -484,6 +484,10 @@ func extractMessageText(msg *types.Message) string {
 
 // persistWorkflowContext saves the workflow context to the state store.
 // It respects the persistence hint on the current state: transient states skip writes.
+//
+// Uses MetadataAccessor.MergeMetadata when available — the typed, race-safe
+// path. Falls back to load-modify-BulkWrite for stores that lack typed
+// metadata writes.
 func (wc *WorkflowConversation) persistWorkflowContext() {
 	// Check if current state is transient
 	currentState := wc.machine.CurrentState()
@@ -496,13 +500,29 @@ func (wc *WorkflowConversation) persistWorkflowContext() {
 	}
 
 	ctx := context.Background()
+	wfCtx := wc.machine.Context()
+
+	if accessor, ok := wc.stateStore.(statestore.MetadataAccessor); ok {
+		if err := accessor.MergeMetadata(ctx, wc.workflowID, map[string]any{"workflow": wfCtx}); err != nil {
+			logger.Warn("failed to persist workflow context",
+				"workflow_id", wc.workflowID, "error", err)
+		}
+		return
+	}
+
+	bulkWriter, ok := wc.stateStore.(statestore.BulkWriter)
+	if !ok {
+		logger.Warn("workflow context not persisted: store implements neither MetadataAccessor nor BulkWriter",
+			"workflow_id", wc.workflowID)
+		return
+	}
+
 	state, err := wc.stateStore.Load(ctx, wc.workflowID)
 	if err != nil {
 		logger.Warn("failed to load workflow state, creating fresh state",
 			"workflow_id", wc.workflowID, "error", err)
 	}
 	if err != nil || state == nil {
-		// Create new state if not found or on load error
 		state = &statestore.ConversationState{
 			ID:       wc.workflowID,
 			Metadata: make(map[string]any),
@@ -511,10 +531,8 @@ func (wc *WorkflowConversation) persistWorkflowContext() {
 	if state.Metadata == nil {
 		state.Metadata = make(map[string]any)
 	}
-
-	wfCtx := wc.machine.Context()
 	state.Metadata["workflow"] = wfCtx
-	if err := wc.stateStore.Save(ctx, state); err != nil {
+	if err := bulkWriter.Save(ctx, state); err != nil {
 		logger.Warn("failed to persist workflow context", "workflow_id", wc.workflowID, "error", err)
 	}
 }

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -1273,6 +1273,75 @@ func TestPersistWorkflowContext_TransientStateSkipped(t *testing.T) {
 	wc.persistWorkflowContext()
 }
 
+// loadErrorBulkStore implements Store + BulkWriter but its Load always
+// errors. Exercises the "Load failed → fresh state" branch in
+// persistWorkflowContext's BulkWriter fallback path.
+type loadErrorBulkStore struct{}
+
+func (loadErrorBulkStore) Load(_ context.Context, _ string) (*statestore.ConversationState, error) {
+	return nil, errors.New("simulated load failure")
+}
+func (loadErrorBulkStore) Fork(_ context.Context, _, _ string) error { return nil }
+func (loadErrorBulkStore) Save(_ context.Context, _ *statestore.ConversationState) error {
+	return nil
+}
+
+// TestPersistWorkflowContext_BulkWriterLoadFails covers the fallback branch
+// where the store is BulkWriter-only and Load errors — the function should
+// proceed with a fresh state and not panic.
+func TestPersistWorkflowContext_BulkWriterLoadFails(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States: map[string]*workflow.State{
+			"start": {PromptTask: "p1"},
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		stateStore:   loadErrorBulkStore{},
+		workflowID:   "wf-1",
+	}
+
+	wc.persistWorkflowContext() // Must not panic.
+}
+
+// readOnlyStore implements only the bare Store interface (Load + Fork) —
+// no BulkWriter, no MetadataAccessor. Used to exercise the warning path
+// in persistWorkflowContext when neither typed nor bulk write is available.
+type readOnlyStore struct{}
+
+func (readOnlyStore) Load(_ context.Context, id string) (*statestore.ConversationState, error) {
+	return &statestore.ConversationState{ID: id, Metadata: make(map[string]any)}, nil
+}
+func (readOnlyStore) Fork(_ context.Context, _, _ string) error { return nil }
+
+// TestPersistWorkflowContext_NoWriteCapability covers the branch where the
+// store implements neither MetadataAccessor nor BulkWriter — the function
+// must log a warning and return without panicking.
+func TestPersistWorkflowContext_NoWriteCapability(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States: map[string]*workflow.State{
+			"start": {PromptTask: "p1"},
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		stateStore:   readOnlyStore{},
+		workflowID:   "wf-1",
+	}
+
+	wc.persistWorkflowContext() // Must not panic.
+}
+
 func TestPersistWorkflowContext_Success(t *testing.T) {
 	spec := &workflow.Spec{
 		Version: 1,

--- a/tools/arena/engine/conversation_executor_multiturn_test.go
+++ b/tools/arena/engine/conversation_executor_multiturn_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
@@ -43,31 +42,12 @@ func TestExecuteConversation_TenScriptedTurns(t *testing.T) {
 			}
 
 			if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil && req.ConversationID != "" {
-				store, ok := req.StateStoreConfig.Store.(statestore.Store)
+				appender, ok := req.StateStoreConfig.Store.(statestore.MessageAppender)
 				if !ok {
 					return nil
 				}
-
-				// Load existing conversation
-				state, loadErr := store.Load(ctx, req.ConversationID)
-				if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
-					return loadErr
-				}
-
-				if state == nil {
-					state = &statestore.ConversationState{
-						ID:       req.ConversationID,
-						UserID:   req.StateStoreConfig.UserID,
-						Messages: []types.Message{},
-					}
-				}
-
-				// Append new messages
-				state.Messages = append(state.Messages, messages...)
-
-				// Save back
-				if saveErr := store.Save(ctx, state); saveErr != nil {
-					return saveErr
+				if appendErr := appender.AppendMessages(ctx, req.ConversationID, messages); appendErr != nil {
+					return appendErr
 				}
 			}
 

--- a/tools/arena/engine/conversation_executor_selfplay_multiturn_test.go
+++ b/tools/arena/engine/conversation_executor_selfplay_multiturn_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
@@ -326,31 +325,11 @@ func saveMessagesToStateStore(ctx context.Context, req turnexecutors.TurnRequest
 	if req.StateStoreConfig == nil || req.StateStoreConfig.Store == nil || req.ConversationID == "" {
 		return nil
 	}
-
-	store, ok := req.StateStoreConfig.Store.(statestore.Store)
+	appender, ok := req.StateStoreConfig.Store.(statestore.MessageAppender)
 	if !ok {
 		return nil
 	}
-
-	// Load existing conversation
-	state, loadErr := store.Load(ctx, req.ConversationID)
-	if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
-		return loadErr
-	}
-
-	if state == nil {
-		state = &statestore.ConversationState{
-			ID:       req.ConversationID,
-			UserID:   req.StateStoreConfig.UserID,
-			Messages: []types.Message{},
-		}
-	}
-
-	// Append new messages
-	state.Messages = append(state.Messages, messages...)
-
-	// Save back
-	return store.Save(ctx, state)
+	return appender.AppendMessages(ctx, req.ConversationID, messages)
 }
 
 // createTestSelfPlayRegistry creates a minimal self-play registry for testing

--- a/tools/arena/engine/conversation_executor_streaming_test.go
+++ b/tools/arena/engine/conversation_executor_streaming_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
@@ -283,22 +282,10 @@ func (m *MockStreamingTurnExecutor) ExecuteTurn(ctx context.Context, req turnexe
 			{Role: "assistant", Content: "mock response"},
 		}
 
-		store, ok := req.StateStoreConfig.Store.(statestore.Store)
+		appender, ok := req.StateStoreConfig.Store.(statestore.MessageAppender)
 		if ok {
-			state, loadErr := store.Load(ctx, req.ConversationID)
-			if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
-				return loadErr
-			}
-			if state == nil {
-				state = &statestore.ConversationState{
-					ID:       req.ConversationID,
-					UserID:   req.StateStoreConfig.UserID,
-					Messages: []types.Message{},
-				}
-			}
-			state.Messages = append(state.Messages, messages...)
-			if saveErr := store.Save(ctx, state); saveErr != nil {
-				return saveErr
+			if appendErr := appender.AppendMessages(ctx, req.ConversationID, messages); appendErr != nil {
+				return appendErr
 			}
 		}
 	}
@@ -360,28 +347,10 @@ func (m *MockStreamingTurnExecutor) ExecuteTurnStream(ctx context.Context, req t
 
 		// Save messages to StateStore if configured
 		if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil && req.ConversationID != "" {
-			store, ok := req.StateStoreConfig.Store.(statestore.Store)
+			appender, ok := req.StateStoreConfig.Store.(statestore.MessageAppender)
 			if ok {
-				// Load existing conversation
-				state, loadErr := store.Load(ctx, req.ConversationID)
-				if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
-					ch <- turnexecutors.MessageStreamChunk{Messages: messages, Error: loadErr}
-					return
-				}
-				if state == nil {
-					state = &statestore.ConversationState{
-						ID:       req.ConversationID,
-						UserID:   req.StateStoreConfig.UserID,
-						Messages: []types.Message{},
-					}
-				}
-
-				// Append new messages
-				state.Messages = append(state.Messages, messages...)
-
-				// Save back
-				if saveErr := store.Save(ctx, state); saveErr != nil {
-					ch <- turnexecutors.MessageStreamChunk{Messages: messages, Error: saveErr}
+				if appendErr := appender.AppendMessages(ctx, req.ConversationID, messages); appendErr != nil {
+					ch <- turnexecutors.MessageStreamChunk{Messages: messages, Error: appendErr}
 					return
 				}
 			}

--- a/tools/arena/engine/conversation_executor_test.go
+++ b/tools/arena/engine/conversation_executor_test.go
@@ -220,27 +220,10 @@ func (m *MockTurnExecutor) ExecuteTurn(ctx context.Context, req turnexecutors.Tu
 		},
 	} // Save messages to StateStore if configured
 	if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil && req.ConversationID != "" {
-		store, ok := req.StateStoreConfig.Store.(statestore.Store)
+		appender, ok := req.StateStoreConfig.Store.(statestore.MessageAppender)
 		if ok {
-			// Load existing conversation
-			state, loadErr := store.Load(ctx, req.ConversationID)
-			if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
-				return loadErr
-			}
-			if state == nil {
-				state = &statestore.ConversationState{
-					ID:       req.ConversationID,
-					UserID:   req.StateStoreConfig.UserID,
-					Messages: []types.Message{},
-				}
-			}
-
-			// Append new messages
-			state.Messages = append(state.Messages, messages...)
-
-			// Save back
-			if saveErr := store.Save(ctx, state); saveErr != nil {
-				return saveErr
+			if appendErr := appender.AppendMessages(ctx, req.ConversationID, messages); appendErr != nil {
+				return appendErr
 			}
 		}
 	}
@@ -565,22 +548,10 @@ func TestExecuteConversation_WithToolCalls(t *testing.T) {
 
 			// Save to StateStore
 			if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil && req.ConversationID != "" {
-				store, ok := req.StateStoreConfig.Store.(statestore.Store)
+				appender, ok := req.StateStoreConfig.Store.(statestore.MessageAppender)
 				if ok {
-					state, loadErr := store.Load(ctx, req.ConversationID)
-					if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
-						return loadErr
-					}
-					if state == nil {
-						state = &statestore.ConversationState{
-							ID:       req.ConversationID,
-							UserID:   req.StateStoreConfig.UserID,
-							Messages: []types.Message{},
-						}
-					}
-					state.Messages = append(state.Messages, messages...)
-					if saveErr := store.Save(ctx, state); saveErr != nil {
-						return saveErr
+					if appendErr := appender.AppendMessages(ctx, req.ConversationID, messages); appendErr != nil {
+						return appendErr
 					}
 				}
 			}
@@ -723,21 +694,11 @@ func TestExecuteConversation_ValidationFailurePreservesMessages(t *testing.T) {
 
 			// Save to StateStore
 			if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil {
-				state, loadErr := req.StateStoreConfig.Store.(statestore.Store).Load(ctx, req.ConversationID)
-				if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
-					return loadErr
-				}
-				if state == nil {
-					state = &statestore.ConversationState{
-						ID:       req.ConversationID,
-						Messages: []types.Message{},
+				appender, ok := req.StateStoreConfig.Store.(statestore.MessageAppender)
+				if ok {
+					if appendErr := appender.AppendMessages(ctx, req.ConversationID, messages); appendErr != nil {
+						return appendErr
 					}
-				}
-
-				state.Messages = append(state.Messages, messages...)
-
-				if saveErr := req.StateStoreConfig.Store.(statestore.Store).Save(ctx, state); saveErr != nil {
-					return saveErr
 				}
 			}
 
@@ -971,17 +932,7 @@ func TestExecuteConversation_ValidationFailureMultipleTurns(t *testing.T) {
 		executeFunc: func(ctx context.Context, req turnexecutors.TurnRequest) error {
 			callCount++
 
-			// Load existing state
-			state, loadErr := req.StateStoreConfig.Store.(statestore.Store).Load(ctx, req.ConversationID)
-			if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
-				return loadErr
-			}
-			if state == nil {
-				state = &statestore.ConversationState{
-					ID:       req.ConversationID,
-					Messages: []types.Message{},
-				}
-			}
+			appender, _ := req.StateStoreConfig.Store.(statestore.MessageAppender)
 
 			if callCount == 1 {
 				// First turn succeeds
@@ -1000,8 +951,9 @@ func TestExecuteConversation_ValidationFailureMultipleTurns(t *testing.T) {
 						},
 					},
 				}
-				state.Messages = append(state.Messages, messages...)
-				_ = req.StateStoreConfig.Store.(statestore.Store).Save(ctx, state) // Ignore error in test
+				if appender != nil {
+					_ = appender.AppendMessages(ctx, req.ConversationID, messages) // Ignore error in test
+				}
 				return nil
 			} else {
 				// Second turn fails validation but saves messages first
@@ -1020,8 +972,9 @@ func TestExecuteConversation_ValidationFailureMultipleTurns(t *testing.T) {
 						},
 					},
 				}
-				state.Messages = append(state.Messages, messages...)
-				_ = req.StateStoreConfig.Store.(statestore.Store).Save(ctx, state) // Ignore error in test
+				if appender != nil {
+					_ = appender.AppendMessages(ctx, req.ConversationID, messages) // Ignore error in test
+				}
 				return errors.New("validation failed (*validators.BannedWordsValidator): [guarantee]")
 			}
 		},

--- a/tools/arena/engine/duplex_executor_pipeline_integration.go
+++ b/tools/arena/engine/duplex_executor_pipeline_integration.go
@@ -121,15 +121,15 @@ func (de *DuplexConversationExecutor) clearStateStoreForRetry(ctx context.Contex
 	// ArenaStateStore has a Delete method, but the generic Store interface doesn't
 	arenaStore, ok := req.StateStoreConfig.Store.(*arenastore.ArenaStateStore)
 	if !ok {
-		// For other store types, save an empty state to reset
-		store, ok := req.StateStoreConfig.Store.(statestore.Store)
-		if ok {
+		// For other store types, bulk-write an empty state to reset.
+		// Requires BulkWriter; stores without bulk-write support are skipped.
+		if bulkWriter, ok := req.StateStoreConfig.Store.(statestore.BulkWriter); ok {
 			emptyState := &statestore.ConversationState{
 				ID:       req.ConversationID,
 				Messages: []types.Message{},
 				Metadata: make(map[string]interface{}),
 			}
-			return store.Save(ctx, emptyState)
+			return bulkWriter.Save(ctx, emptyState)
 		}
 		return nil
 	}

--- a/tools/arena/engine/statestore_test.go
+++ b/tools/arena/engine/statestore_test.go
@@ -276,11 +276,13 @@ func (m *mockTurnExecutor) ExecuteTurn(ctx context.Context, req turnexecutors.Tu
 		{Role: "assistant", Content: "mock response"},
 	}
 
-	// Save messages to StateStore if configured
+	// Save messages to StateStore if configured.
+	// Use BulkWriter directly: ArenaStateStore (used by Engine tests) implements
+	// BulkWriter but not MessageAppender, so we replace the whole state here.
 	if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil && req.ConversationID != "" {
-		store, ok := req.StateStoreConfig.Store.(statestore.Store)
-		if ok {
-			// Load existing conversation
+		store, storeOK := req.StateStoreConfig.Store.(statestore.Store)
+		bulkWriter, bulkOK := req.StateStoreConfig.Store.(statestore.BulkWriter)
+		if storeOK && bulkOK {
 			state, loadErr := store.Load(ctx, req.ConversationID)
 			if loadErr != nil && !errors.Is(loadErr, statestore.ErrNotFound) {
 				return loadErr
@@ -292,12 +294,8 @@ func (m *mockTurnExecutor) ExecuteTurn(ctx context.Context, req turnexecutors.Tu
 					Messages: []types.Message{},
 				}
 			}
-
-			// Append new messages
 			state.Messages = append(state.Messages, messages...)
-
-			// Save back
-			if saveErr := store.Save(ctx, state); saveErr != nil {
+			if saveErr := bulkWriter.Save(ctx, state); saveErr != nil {
 				return saveErr
 			}
 		}

--- a/tools/arena/turnexecutors/assertions_integration_test.go
+++ b/tools/arena/turnexecutors/assertions_integration_test.go
@@ -51,15 +51,15 @@ func TestPipelineExecutor_AssertionsPass(t *testing.T) {
 
 	// Pre-initialize state store (required for ArenaStateStore)
 	storeIface := storeConfig.Store
-	rtStore, ok := storeIface.(runtimestore.Store)
-	require.True(t, ok, "state store must implement runtimestore.Store")
+	bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
+	require.True(t, ok, "state store must implement runtimestore.BulkWriter")
 	initState := &runtimestore.ConversationState{
 		ID:       "test-conv",
 		UserID:   "test-user",
 		Messages: []types.Message{},
 		Metadata: map[string]interface{}{},
 	}
-	saveErr := rtStore.Save(context.Background(), initState)
+	saveErr := bulkWriter.Save(context.Background(), initState)
 	require.NoError(t, saveErr)
 
 	// Create request with assertions
@@ -151,15 +151,15 @@ func TestPipelineExecutor_AssertionsFail(t *testing.T) {
 
 	// Pre-initialize state store (required for ArenaStateStore)
 	storeIface := storeConfig.Store
-	rtStore, ok := storeIface.(runtimestore.Store)
-	require.True(t, ok, "state store must implement runtimestore.Store")
+	bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
+	require.True(t, ok, "state store must implement runtimestore.BulkWriter")
 	initState := &runtimestore.ConversationState{
 		ID:       "test-conv-fail",
 		UserID:   "test-user",
 		Messages: []types.Message{},
 		Metadata: map[string]interface{}{},
 	}
-	saveErr := rtStore.Save(context.Background(), initState)
+	saveErr := bulkWriter.Save(context.Background(), initState)
 	require.NoError(t, saveErr)
 
 	// Create request with assertions that will fail
@@ -238,15 +238,15 @@ func TestPipelineExecutor_NoAssertions(t *testing.T) {
 
 	// Pre-initialize state store (required for ArenaStateStore)
 	storeIface := storeConfig.Store
-	rtStore, ok := storeIface.(runtimestore.Store)
-	require.True(t, ok, "state store must implement runtimestore.Store")
+	bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
+	require.True(t, ok, "state store must implement runtimestore.BulkWriter")
 	initState := &runtimestore.ConversationState{
 		ID:       "test-conv-no-assertions",
 		UserID:   "test-user",
 		Messages: []types.Message{},
 		Metadata: map[string]interface{}{},
 	}
-	saveErr := rtStore.Save(context.Background(), initState)
+	saveErr := bulkWriter.Save(context.Background(), initState)
 	require.NoError(t, saveErr)
 
 	// Create request without assertions

--- a/tools/arena/turnexecutors/scripted_executor_test.go
+++ b/tools/arena/turnexecutors/scripted_executor_test.go
@@ -124,8 +124,8 @@ func TestScriptedExecutor_ExecuteTurn_Success(t *testing.T) {
 	// state store expects a ConversationState to exist for the given ID.
 	if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil {
 		storeIface := req.StateStoreConfig.Store
-		store, ok := storeIface.(runtimestore.Store)
-		require.True(t, ok, "state store must implement runtimestore.Store")
+		bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
+		require.True(t, ok, "state store must implement runtimestore.BulkWriter")
 
 		initState := &runtimestore.ConversationState{
 			ID:       req.ConversationID,
@@ -133,7 +133,7 @@ func TestScriptedExecutor_ExecuteTurn_Success(t *testing.T) {
 			Messages: []types.Message{},
 			Metadata: map[string]interface{}{},
 		}
-		saveErr := store.Save(context.Background(), initState)
+		saveErr := bulkWriter.Save(context.Background(), initState)
 		require.NoError(t, saveErr)
 	}
 
@@ -218,8 +218,8 @@ func TestScriptedExecutor_ExecuteTurn_EmptyScriptedContent(t *testing.T) {
 	// Ensure conversation exists in state store before executing the turn.
 	if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil {
 		storeIface := req.StateStoreConfig.Store
-		store, ok := storeIface.(runtimestore.Store)
-		require.True(t, ok, "state store must implement runtimestore.Store")
+		bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
+		require.True(t, ok, "state store must implement runtimestore.BulkWriter")
 
 		initState := &runtimestore.ConversationState{
 			ID:       req.ConversationID,
@@ -227,7 +227,7 @@ func TestScriptedExecutor_ExecuteTurn_EmptyScriptedContent(t *testing.T) {
 			Messages: []types.Message{},
 			Metadata: map[string]interface{}{},
 		}
-		saveErr := store.Save(context.Background(), initState)
+		saveErr := bulkWriter.Save(context.Background(), initState)
 		require.NoError(t, saveErr)
 	}
 
@@ -305,8 +305,8 @@ func TestScriptedExecutor_ExecuteTurn_WithHistory(t *testing.T) {
 	// is available to the executor.
 	if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil {
 		storeIface := req.StateStoreConfig.Store
-		store, ok := storeIface.(runtimestore.Store)
-		require.True(t, ok, "state store must implement runtimestore.Store")
+		bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
+		require.True(t, ok, "state store must implement runtimestore.BulkWriter")
 
 		// Add a prior message to simulate history
 		initState := &runtimestore.ConversationState{
@@ -317,7 +317,7 @@ func TestScriptedExecutor_ExecuteTurn_WithHistory(t *testing.T) {
 			},
 			Metadata: map[string]interface{}{},
 		}
-		saveErr := store.Save(context.Background(), initState)
+		saveErr := bulkWriter.Save(context.Background(), initState)
 		require.NoError(t, saveErr)
 	}
 
@@ -393,8 +393,8 @@ func TestScriptedExecutor_ExecuteTurn_SetsTimestamp(t *testing.T) {
 	// Initialize conversation state
 	if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil {
 		storeIface := req.StateStoreConfig.Store
-		store, ok := storeIface.(runtimestore.Store)
-		require.True(t, ok, "state store must implement runtimestore.Store")
+		bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
+		require.True(t, ok, "state store must implement runtimestore.BulkWriter")
 
 		initState := &runtimestore.ConversationState{
 			ID:       req.ConversationID,
@@ -402,7 +402,7 @@ func TestScriptedExecutor_ExecuteTurn_SetsTimestamp(t *testing.T) {
 			Messages: []types.Message{},
 			Metadata: map[string]interface{}{},
 		}
-		saveErr := store.Save(context.Background(), initState)
+		saveErr := bulkWriter.Save(context.Background(), initState)
 		require.NoError(t, saveErr)
 	}
 

--- a/tools/arena/turnexecutors/selfplay_assertions_test.go
+++ b/tools/arena/turnexecutors/selfplay_assertions_test.go
@@ -70,15 +70,15 @@ func TestSelfPlayExecutor_WithAssertions_Pass(t *testing.T) {
 
 	// Pre-initialize state store
 	storeIface := storeConfig.Store
-	rtStore, ok := storeIface.(runtimestore.Store)
-	require.True(t, ok, "state store must implement runtimestore.Store")
+	bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
+	require.True(t, ok, "state store must implement runtimestore.BulkWriter")
 	initState := &runtimestore.ConversationState{
 		ID:       "test-selfplay-conv",
 		UserID:   "test-user",
 		Messages: []types.Message{},
 		Metadata: map[string]interface{}{},
 	}
-	saveErr := rtStore.Save(context.Background(), initState)
+	saveErr := bulkWriter.Save(context.Background(), initState)
 	require.NoError(t, saveErr)
 
 	// Create request with assertions
@@ -203,7 +203,7 @@ func TestSelfPlayExecutor_WithAssertions_Fail(t *testing.T) {
 
 	// Pre-initialize state store
 	storeIface := storeConfig.Store
-	rtStore, ok := storeIface.(runtimestore.Store)
+	bulkWriter, ok := storeIface.(runtimestore.BulkWriter)
 	require.True(t, ok)
 	initState := &runtimestore.ConversationState{
 		ID:       "test-selfplay-fail",
@@ -211,7 +211,7 @@ func TestSelfPlayExecutor_WithAssertions_Fail(t *testing.T) {
 		Messages: []types.Message{},
 		Metadata: map[string]interface{}{},
 	}
-	saveErr := rtStore.Save(context.Background(), initState)
+	saveErr := bulkWriter.Save(context.Background(), initState)
 	require.NoError(t, saveErr)
 
 	// Create request with assertions that will fail


### PR DESCRIPTION
## Summary

PR 7 of the statestore write-path rationalization (`docs/superpowers/plans/2026-04-28-statestore-write-path-rationalization.md`). Builds on PR #1055 (now merged).

- **Removes `Save` from the `Store` interface** and moves it to a new opt-in `BulkWriter` interface. `Store` becomes `Load + Fork` only — read-shaped.
- **Adds `MetadataAccessor.MergeMetadata`** — atomic per-key merge with auto-create. `MemoryStore` uses its existing locking; `RedisStore` uses `WATCH/MULTI/EXEC` for serialised retries (budget 32, ample for realistic stage contention).
- **`SaveSummary` now auto-creates** the conversation, matching `AppendMessages` semantics.
- **Hot-path stages can no longer reach bulk writes.** Enforced by `TestNoBulkWriterInStageConfigs` in `runtime/pipeline/stage` — walks the AST so future regressions surface in CI.

### Migrated callers

| Site | Before | After |
|---|---|---|
| `IncrementalSaveStage.fullSave` | direct `store.Save` | `BulkWriter` type-assert; clear error if neither `MessageAppender` nor `BulkWriter` |
| Session creation (unary + duplex) | `Save(emptyState)` | Lazy: `MergeMetadata` if metadata present, else nothing — first typed write creates |
| `Session.Clear` | `store.Save({Messages: nil})` | `BulkWriter` type-assert |
| Workflow context persistence | `Load → mutate → Save` | `MergeMetadata` (race-safe), `BulkWriter` fallback |
| Probed test wrapper | direct `inner.Save` | delegates to inner `BulkWriter` |
| Test/admin sites (~17 across runtime, sdk, tools/arena) | mixed | Pattern A (`MessageAppender`) for append-shape, Pattern B (`BulkWriter`) for bulk seeds |

`Messages()` and `ForkSession()` now tolerate `ErrNotFound` — necessary because conversations are lazy-created.

### Race-safety

- `MergeMetadata` serialises concurrent merges per conversation. New tests:
  - `TestMemoryStore_MergeMetadataConcurrent` (50 goroutines, all keys must land)
  - `TestRedisStore_MergeMetadata_ConcurrentMergesSerialise` (8 goroutines under miniredis WATCH)
- All race tests pass under `-race -count=2`.

### Diff

24 files, +692 / -259. Includes 1 new file (`runtime/pipeline/stage/structural_guards_test.go`).

## Test plan

- [x] `go vet ./runtime/... ./sdk/... ./pkg/... ./tools/arena/...` — clean (only the 2 pre-existing `streaming_test.go` cancel-leak issues, untouched)
- [x] `go test ./runtime/... ./sdk/... ./pkg/... ./tools/arena/...` — 13,232 passed / 0 failed / 35 skipped across 138 packages
- [x] `go test -race -count=2 ./runtime/statestore/... ./runtime/pipeline/stage/... ./sdk/integration/... ./sdk/session/...` — clean
- [x] `golangci-lint run ./runtime/... ./sdk/... ./pkg/... ./tools/arena/...` — 0 issues
- [x] Pre-commit hook: lint + build + per-file 80% coverage on changed code — green
- [x] Structural guard test (`TestNoBulkWriterInStageConfigs`) catches any future stage that adds a `BulkWriter` field
- [ ] CI green
