### PR TITLE
docs(sdk): drop dead link to non-existent /sdk/reference/capabilities/

### DIFF
--- a/docs/src/content/docs/sdk/how-to/override-capability-tools.md
+++ b/docs/src/content/docs/sdk/how-to/override-capability-tools.md
@@ -83,6 +83,6 @@ If you reference a tool name that doesn't exist in the registry (for example, a 
 
 ## Does not affect
 
-- The executor that handles the tool. The executor remains the one the capability registered. If you need the executor to recognise a new parameter, you must change the capability code (or wrap the capability — see [Capabilities reference](/sdk/reference/capabilities/)).
+- The executor that handles the tool. The executor remains the one the capability registered. If you need the executor to recognise a new parameter, you must change the capability code (or wrap the capability with your own).
 - Other tools — patches operate on a clone of one descriptor.
 - Capability lifecycle (Init, Close).


### PR DESCRIPTION
## Summary

The `override-capability-tools` how-to links to `/sdk/reference/capabilities/`, which has never existed in the docs. The link checker (`npm run check-links` in the docs build) now flags it as a 404 — breaking the **Deploy Documentation to GitHub Pages** workflow on every dependabot PR that touches `/docs` (currently #1046).

Two options:
1. Drop the dead link (this PR — minimal, unblocks docs CI now)
2. Write the missing Capabilities reference page (worth doing, but a real docs writing project — separate)

Going with (1).

## Test plan

- [x] Local — diff is one-line markdown
- [ ] CI: `npm run check-links` should now pass
- [ ] Once merged: rebase #1046 (`@dependabot rebase`), verify it goes green
