### PR TITLE
perf(pipeline): drop history from in-memory slice + load summarize tail via MessageReader

### DIFF
--- a/runtime/pipeline/stage/stages_save.go
+++ b/runtime/pipeline/stage/stages_save.go
@@ -84,15 +84,16 @@ func (s *IncrementalSaveStage) Process(
 		return s.passthrough(ctx, input, output)
 	}
 
-	// Collect messages while forwarding elements
+	// Collect new (non-history) messages while forwarding elements. History
+	// messages are dropped from the in-memory slice — they're already in
+	// the store and don't need to be re-persisted. Holding them here would
+	// scale O(conversation-length) per Send for long conversations.
 	collected, err := s.collectAndForward(ctx, input, output)
 	if err != nil {
 		return err
 	}
 
-	// Identify new messages (those not from history)
-	newMessages := s.filterNewMessages(collected.messages)
-	if len(newMessages) == 0 {
+	if len(collected.messages) == 0 {
 		return nil
 	}
 
@@ -102,14 +103,14 @@ func (s *IncrementalSaveStage) Process(
 	// When MessageLog IS active, messages are already persisted per-round
 	// by the provider stage write-through — skip message append.
 	if s.config.MessageLog == nil {
-		if err := s.persistMessages(ctx, convID, newMessages, collected); err != nil {
+		if err := s.persistMessages(ctx, convID, collected.messages); err != nil {
 			return err
 		}
 	}
 
 	// Index and summarize regardless of persistence path
 	if s.config.MessageIndex != nil {
-		s.indexNewMessages(ctx, convID, newMessages)
+		s.indexNewMessages(ctx, convID, collected.messages)
 	}
 	if s.config.Summarizer != nil && s.config.SummarizeThreshold > 0 {
 		s.maybeSummarize(ctx, convID)
@@ -118,12 +119,12 @@ func (s *IncrementalSaveStage) Process(
 	return nil
 }
 
-// persistMessages saves new messages to the store via MessageAppender or full save fallback.
+// persistMessages saves new messages to the store via MessageAppender or
+// the BulkWriter fallback (Load + append-to-state + Save).
 func (s *IncrementalSaveStage) persistMessages(
 	ctx context.Context,
 	convID string,
 	newMessages []types.Message,
-	collected *incrementalCollectedData,
 ) error {
 	if appender, ok := s.config.StateStoreConfig.Store.(statestore.MessageAppender); ok {
 		if err := appender.AppendMessages(ctx, convID, newMessages); err != nil {
@@ -131,15 +132,21 @@ func (s *IncrementalSaveStage) persistMessages(
 		}
 		return nil
 	}
-	return s.fullSave(ctx, collected)
+	return s.fullSave(ctx, newMessages)
 }
 
 // incrementalCollectedData holds data collected during processing.
 type incrementalCollectedData struct {
+	// messages contains only the new (non-history) messages produced by
+	// this Send. History elements coming through the stream are filtered
+	// out at collect time so we don't duplicate the conversation in memory.
 	messages []types.Message
 }
 
-// collectAndForward collects messages while forwarding all elements.
+// collectAndForward collects new messages while forwarding all elements.
+// Messages whose Source is "statestore", "summary", or "retrieved" are
+// considered history and are forwarded but not collected — they're
+// already persisted upstream.
 func (s *IncrementalSaveStage) collectAndForward(
 	ctx context.Context,
 	input <-chan StreamElement,
@@ -148,7 +155,7 @@ func (s *IncrementalSaveStage) collectAndForward(
 	collected := &incrementalCollectedData{}
 
 	for elem := range input {
-		if elem.Message != nil {
+		if elem.Message != nil && isNewMessage(elem.Message) {
 			collected.messages = append(collected.messages, *elem.Message)
 		}
 
@@ -167,23 +174,23 @@ func (s *IncrementalSaveStage) collectAndForward(
 	return collected, nil
 }
 
-// filterNewMessages returns only messages that were not loaded from history.
-func (s *IncrementalSaveStage) filterNewMessages(messages []types.Message) []types.Message {
-	var newMsgs []types.Message
-	for i := range messages {
-		src := messages[i].Source
-		if src != sourceStateStore && src != sourceSummary && src != sourceRetrieved {
-			newMsgs = append(newMsgs, messages[i])
-		}
+// isNewMessage reports whether a message originated from this Send (true)
+// or was loaded from history by an upstream stage (false).
+func isNewMessage(m *types.Message) bool {
+	switch m.Source {
+	case sourceStateStore, sourceSummary, sourceRetrieved:
+		return false
+	default:
+		return true
 	}
-	return newMsgs
 }
 
-// fullSave performs a full load+replace+save cycle. This path is reached
-// only when the store does not implement MessageAppender; persistence
-// requires the store to also implement BulkWriter (otherwise the state
-// is fundamentally unwritable and the stage errors clearly).
-func (s *IncrementalSaveStage) fullSave(ctx context.Context, collected *incrementalCollectedData) error {
+// fullSave appends the new messages to the existing state and writes via
+// BulkWriter. This path is reached only when the store does not implement
+// MessageAppender; persistence requires the store to also implement
+// BulkWriter (otherwise the state is fundamentally unwritable and the
+// stage errors clearly).
+func (s *IncrementalSaveStage) fullSave(ctx context.Context, newMessages []types.Message) error {
 	store, ok := s.config.StateStoreConfig.Store.(statestore.Store)
 	if !ok {
 		return fmt.Errorf("incremental save: invalid store type")
@@ -204,13 +211,15 @@ func (s *IncrementalSaveStage) fullSave(ctx context.Context, collected *incremen
 		state = &statestore.ConversationState{
 			ID:       convID,
 			UserID:   s.config.StateStoreConfig.UserID,
-			Messages: make([]types.Message, 0),
+			Messages: make([]types.Message, 0, len(newMessages)),
 			Metadata: make(map[string]any),
 		}
 	}
 
-	state.Messages = make([]types.Message, len(collected.messages))
-	copy(state.Messages, collected.messages)
+	// Append the new messages to whatever was already in the store —
+	// the stage no longer collects history into memory, so this is the
+	// only path that knows the full message set.
+	state.Messages = append(state.Messages, newMessages...)
 
 	if state.Metadata == nil {
 		state.Metadata = make(map[string]any)
@@ -306,25 +315,29 @@ func (s *IncrementalSaveStage) maybeSummarize(ctx context.Context, convID string
 		return
 	}
 
-	// Load the batch to summarize
-	store, ok := s.config.StateStoreConfig.Store.(statestore.Store)
-	if !ok {
-		return
-	}
-
-	state, err := store.Load(ctx, convID)
+	// Load only the unsummarized tail via MessageReader. We hit this path
+	// only when reader is non-nil (asserted at the top of the function),
+	// so avoid the legacy Store.Load that deep-copies the entire history.
+	tail, err := reader.LoadRecentMessages(ctx, convID, unsummarized)
 	if err != nil {
-		logger.Warn("Auto-summarize: failed to load state for summarization",
+		logger.Warn("Auto-summarize: failed to load message tail for summarization",
 			"conversation", convID, "error", err)
 		return
 	}
-
-	endTurn := lastSummarizedTurn + s.config.SummarizeBatchSize
-	if endTurn > len(state.Messages) {
-		endTurn = len(state.Messages)
+	if len(tail) < unsummarized {
+		// Reader returned fewer than asked — adjust unsummarized so the
+		// turn-index math below stays consistent.
+		unsummarized = len(tail)
 	}
 
-	batch := state.Messages[lastSummarizedTurn:endTurn]
+	endTurn := lastSummarizedTurn + s.config.SummarizeBatchSize
+	if endTurn-lastSummarizedTurn > unsummarized {
+		endTurn = lastSummarizedTurn + unsummarized
+	}
+
+	// tail covers messages [lastSummarizedTurn, count). Slice off the
+	// SummarizeBatchSize prefix to get the oldest unsummarized batch.
+	batch := tail[:endTurn-lastSummarizedTurn]
 	content, err := s.config.Summarizer.Summarize(ctx, batch)
 	if err != nil {
 		logger.Error("Auto-summarize: summarization failed",

--- a/runtime/pipeline/stage/stages_save_test.go
+++ b/runtime/pipeline/stage/stages_save_test.go
@@ -110,7 +110,9 @@ func TestIncrementalSaveStage_FallbackToFullSave(t *testing.T) {
 	state, err := store.Load(ctx, "conv-123")
 	require.NoError(t, err)
 
-	// Full save replaces all messages with what was collected
+	// fullSave appends new messages onto the loaded state — history
+	// elements that streamed through the pipeline are NOT re-collected
+	// (they were already in the store).
 	require.Len(t, state.Messages, 2)
 	assert.Equal(t, "Old message", state.Messages[0].Content)
 	assert.Equal(t, "New response", state.Messages[1].Content)
@@ -223,6 +225,48 @@ func TestIncrementalSaveStage_NoNewMessages(t *testing.T) {
 	assert.Len(t, state.Messages, 2)
 	assert.Equal(t, "History 1", state.Messages[0].Content)
 	assert.Equal(t, "History 2", state.Messages[1].Content)
+}
+
+// TestIncrementalSaveStage_DropsHistoryFromInMemorySlice asserts that
+// history elements streaming through the stage are NOT retained in
+// collected.messages. Pre-fix the stage held the full history slice in
+// memory until end-of-Send, scaling O(conversation-length) per Send.
+//
+// History size is kept under the runTestStage output-channel buffer
+// (100) — the contract under test is "filter, don't collect", not the
+// channel's buffering capacity.
+func TestIncrementalSaveStage_DropsHistoryFromInMemorySlice(t *testing.T) {
+	store := statestore.NewMemoryStore()
+
+	config := &IncrementalSaveConfig{
+		StateStoreConfig: &pipeline.StateStoreConfig{
+			Store:          store,
+			ConversationID: "long-conv",
+		},
+	}
+	s := NewIncrementalSaveStage(config)
+
+	// Simulate ContextAssemblyStage emitting many history messages plus
+	// one fresh user message — the realistic shape of a Send on a long
+	// conversation.
+	const historyLen = 80
+	inputs := make([]StreamElement, 0, historyLen+1)
+	for range historyLen {
+		msg := types.Message{Role: "user", Content: "history", Source: sourceStateStore}
+		inputs = append(inputs, NewMessageElement(&msg))
+	}
+	newMsg := types.Message{Role: "user", Content: "new"}
+	inputs = append(inputs, NewMessageElement(&newMsg))
+
+	results := runTestStage(t, s, inputs)
+	require.Len(t, results, historyLen+1)
+
+	// Store contains only the new message (no history was pre-populated,
+	// no history was re-collected from the stream).
+	state, err := store.Load(context.Background(), "long-conv")
+	require.NoError(t, err)
+	require.Len(t, state.Messages, 1)
+	assert.Equal(t, "new", state.Messages[0].Content)
 }
 
 func TestIncrementalSaveStage_FiltersSummaryAndRetrievedSources(t *testing.T) {
@@ -534,6 +578,7 @@ type readerWithSummaryStore struct {
 	countOverride  int
 	loadSumErr     error
 	loadErr        error
+	loadRecentErr  error
 	saveSummaryErr error
 }
 
@@ -558,6 +603,9 @@ func (s *readerWithSummaryStore) AppendMessages(_ context.Context, id string, ms
 }
 
 func (s *readerWithSummaryStore) LoadRecentMessages(_ context.Context, id string, n int) ([]types.Message, error) {
+	if s.loadRecentErr != nil {
+		return nil, s.loadRecentErr
+	}
 	msgs := s.messages[id]
 	if n > len(msgs) {
 		n = len(msgs)
@@ -746,20 +794,15 @@ func TestMaybeSummarize_UnsummarizedLessThanBatch(t *testing.T) {
 	assert.Equal(t, 0, summarizer.summarizeCalls)
 }
 
-func TestMaybeSummarize_StoreLoadFails(t *testing.T) {
-	// Use noStoreInterfaceSummaryStore which doesn't implement Store
-	store := newNoStoreInterfaceSummaryStore()
-	store.countOverride = 10
-	summarizer := &mockSummarizerForSave{summaryContent: "summary"}
-	callMaybeSummarize(t, store, summarizer, 3, 3)
-	// Store doesn't implement statestore.Store → early return at store.Load
-	assert.Equal(t, 0, summarizer.summarizeCalls)
-}
-
-func TestMaybeSummarize_StoreLoadReturnsError(t *testing.T) {
+// TestMaybeSummarize_LoadRecentMessagesReturnsError verifies that the
+// summarizer is NOT invoked when MessageReader.LoadRecentMessages
+// returns an error. Replaces the previous TestMaybeSummarize_StoreLoadFails
+// and TestMaybeSummarize_StoreLoadReturnsError pair, which pinned the
+// (now removed) Store.Load fallback path.
+func TestMaybeSummarize_LoadRecentMessagesReturnsError(t *testing.T) {
 	store := newReaderWithSummaryStore()
 	store.countOverride = 10
-	store.loadErr = errors.New("load error")
+	store.loadRecentErr = errors.New("load recent error")
 	summarizer := &mockSummarizerForSave{summaryContent: "summary"}
 	callMaybeSummarize(t, store, summarizer, 3, 3)
 	assert.Equal(t, 0, summarizer.summarizeCalls)
@@ -894,8 +937,9 @@ func TestIncrementalSaveStage_Passthrough_WithErrors(t *testing.T) {
 // deliberately omits summaries from the snapshot to simulate a stale
 // Load that pre-dates a SaveSummary on a different goroutine.
 type summaryAccessorOnlyStore struct {
-	state     *statestore.ConversationState
-	summaries []statestore.Summary
+	state            *statestore.ConversationState
+	summaries        []statestore.Summary
+	loadSummariesErr error
 }
 
 func (s *summaryAccessorOnlyStore) Load(_ context.Context, _ string) (*statestore.ConversationState, error) {
@@ -920,12 +964,120 @@ func (s *summaryAccessorOnlyStore) Save(_ context.Context, state *statestore.Con
 func (s *summaryAccessorOnlyStore) Fork(_ context.Context, _, _ string) error { return nil }
 
 func (s *summaryAccessorOnlyStore) LoadSummaries(_ context.Context, _ string) ([]statestore.Summary, error) {
+	if s.loadSummariesErr != nil {
+		return nil, s.loadSummariesErr
+	}
 	return s.summaries, nil
 }
 
 func (s *summaryAccessorOnlyStore) SaveSummary(_ context.Context, _ string, summary statestore.Summary) error {
 	s.summaries = append(s.summaries, summary)
 	return nil
+}
+
+// readOnlyMinimalStore implements only Store (Load + Fork). No
+// MessageAppender, no BulkWriter — used to verify fullSave errors
+// clearly when bulk write is unavailable.
+type readOnlyMinimalStore struct {
+	states map[string]*statestore.ConversationState
+}
+
+func newReadOnlyMinimalStore() *readOnlyMinimalStore {
+	return &readOnlyMinimalStore{states: make(map[string]*statestore.ConversationState)}
+}
+
+func (s *readOnlyMinimalStore) Load(_ context.Context, id string) (*statestore.ConversationState, error) {
+	state, ok := s.states[id]
+	if !ok {
+		return nil, statestore.ErrNotFound
+	}
+	return state, nil
+}
+
+func (s *readOnlyMinimalStore) Fork(_ context.Context, _, _ string) error { return nil }
+
+// TestIncrementalSaveStage_FullSaveErrorsWithoutBulkWriter pins the
+// error contract: when the store implements neither MessageAppender nor
+// BulkWriter, fullSave must surface a clear error rather than silently
+// dropping the persist.
+func TestIncrementalSaveStage_FullSaveErrorsWithoutBulkWriter(t *testing.T) {
+	store := newReadOnlyMinimalStore()
+	config := &IncrementalSaveConfig{
+		StateStoreConfig: &pipeline.StateStoreConfig{
+			Store:          store,
+			ConversationID: "no-write",
+		},
+	}
+	s := NewIncrementalSaveStage(config)
+
+	msg := types.Message{Role: "user", Content: "x"}
+	input := make(chan StreamElement, 1)
+	input <- NewMessageElement(&msg)
+	close(input)
+
+	output := make(chan StreamElement, 4)
+	err := s.Process(context.Background(), input, output)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BulkWriter")
+}
+
+// TestIncrementalSaveStage_FullSaveCreatesFreshStateOnNotFound pins the
+// auto-create branch of fullSave: when the store has no record for the
+// conversation yet, the stage builds a fresh ConversationState with the
+// new messages rather than erroring.
+func TestIncrementalSaveStage_FullSaveCreatesFreshStateOnNotFound(t *testing.T) {
+	// minimalStore returns ErrNotFound when no state has been pre-saved.
+	store := newMinimalStore()
+	config := &IncrementalSaveConfig{
+		StateStoreConfig: &pipeline.StateStoreConfig{
+			Store:          store,
+			ConversationID: "fresh",
+			UserID:         "u1",
+		},
+	}
+	s := NewIncrementalSaveStage(config)
+
+	msg := types.Message{Role: "user", Content: "hello"}
+	results := runTestStage(t, s, []StreamElement{NewMessageElement(&msg)})
+	require.Len(t, results, 1)
+
+	state, err := store.Load(context.Background(), "fresh")
+	require.NoError(t, err)
+	require.Len(t, state.Messages, 1)
+	assert.Equal(t, "hello", state.Messages[0].Content)
+	assert.Equal(t, "u1", state.UserID)
+}
+
+// TestIncrementalSaveStage_FullSavePropagatesSummaryReloadError pins the
+// error-path of the summary re-load guard in fullSave: when LoadSummaries
+// fails, the stage must surface the error rather than silently writing
+// state without summaries.
+func TestIncrementalSaveStage_FullSavePropagatesSummaryReloadError(t *testing.T) {
+	store := &summaryAccessorOnlyStore{
+		state: &statestore.ConversationState{
+			ID:       "conv-summary-err",
+			Messages: []types.Message{},
+		},
+		loadSummariesErr: errors.New("boom"),
+	}
+
+	config := &IncrementalSaveConfig{
+		StateStoreConfig: &pipeline.StateStoreConfig{
+			Store:          store,
+			ConversationID: "conv-summary-err",
+		},
+	}
+	s := NewIncrementalSaveStage(config)
+
+	msg := types.Message{Role: "user", Content: "x"}
+	input := make(chan StreamElement, 1)
+	input <- NewMessageElement(&msg)
+	close(input)
+
+	output := make(chan StreamElement, 8)
+	err := s.Process(context.Background(), input, output)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to reload summaries")
 }
 
 // Regression: IncrementalSaveStage.fullSave must reload summaries via


### PR DESCRIPTION
## Summary

Closes review items **#1** (eager filter in `collectAndForward`) and **#2** (window load in `maybeSummarize`) from the post-PR-7 code review.

`IncrementalSaveStage` was retaining the entire conversation history in its in-memory `collected.messages` slice for the duration of every `Send`. For long conversations (2k+ messages, especially multimodal with embedded media), this scaled per-Send memory linearly with conversation length even though only the new messages were ever persisted. Separately, `maybeSummarize` was doing a `Store.Load` to slice a small batch out of a possibly-huge state.

### Fixes

1. **`collectAndForward` filters by `Source` at collect time.** History elements (`statestore`, `summary`, `retrieved`) are forwarded but not appended to the slice. `filterNewMessages` is gone.
2. **`fullSave` switched from "replace state.Messages with collected" to "append new messages onto the loaded state".** The old behavior relied on the stream re-emitting the full history; the new behavior reads the existing history from the store and adds only the delta. Same end state.
3. **`maybeSummarize` uses `MessageReader.LoadRecentMessages`** for the unsummarized tail rather than `Store.Load`. The function only reaches that path when `MessageReader` is non-nil (already required for the message-count check above), so no fallback is needed. For a 2k-message conversation with a 50-batch summarizer, the load drops from 2k messages → 50–100.

### Tests

- New: `TestIncrementalSaveStage_DropsHistoryFromInMemorySlice` — pipes 80 history elements + 1 new through the stage; only the new message lands in the store. Pin against any future regression that re-collects history.
- Replaced: `TestMaybeSummarize_StoreLoadFails` and `TestMaybeSummarize_StoreLoadReturnsError` (pinned the now-removed Store.Load fallback) → `TestMaybeSummarize_LoadRecentMessagesReturnsError` (pins the new failure mode).
- Updated `TestIncrementalSaveStage_FallbackToFullSave` comment to reflect append-not-replace semantics. Existing assertions unchanged.

### Diff

2 files, ~+90 / −50.

## Test plan

- [x] `go test ./runtime/pipeline/stage/... -count=1` — all 22 IncrementalSaveStage / maybeSummarize tests pass
- [x] `go test ./runtime/... ./sdk/... ./tools/arena/... -count=1` — full sweep green
- [x] `go test -race ./runtime/pipeline/stage/... ./runtime/statestore/... ./sdk/integration/...` — clean
- [x] `golangci-lint --new-from-rev=HEAD ./runtime/pipeline/stage/...` — 0 new issues
- [ ] CI green
