### PR TITLE
chore(review): clarify forkOrCreate error + scope-doc structural guard

### DIFF
--- a/runtime/pipeline/stage/structural_guards_test.go
+++ b/runtime/pipeline/stage/structural_guards_test.go
@@ -10,12 +10,20 @@ import (
 	"testing"
 )
 
-// TestNoBulkWriterInStageConfigs is a structural invariant: no struct field
-// declared in this package may have a type that mentions BulkWriter. Hot-path
-// stages must reach the store via MessageAppender, MetadataAccessor, or
-// SummaryAccessor — never via the bulk-write escape hatch. This test catches
-// regressions by walking the AST instead of relying on reflection (which
-// would miss un-instantiated config types).
+// TestNoBulkWriterInStageConfigs is a structural invariant: no struct
+// field declared in **this package** (runtime/pipeline/stage) may have a
+// type that mentions BulkWriter. Hot-path runtime stages must reach the
+// store via MessageAppender, MetadataAccessor, or SummaryAccessor —
+// never via the bulk-write escape hatch.
+//
+// Scope is intentionally limited to the runtime stages. Arena's stages
+// (tools/arena/stages) and admin tooling (tools/arena/cmd/) are explicit
+// consumers of BulkWriter and live outside this guard. If a parallel
+// hot-path stage is added in another directory, this test won't catch
+// it — extend the walk to that directory if/when that happens.
+//
+// Walks the AST rather than reflecting because the latter would miss
+// un-instantiated config types.
 func TestNoBulkWriterInStageConfigs(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {

--- a/sdk/session/store_helpers.go
+++ b/sdk/session/store_helpers.go
@@ -50,9 +50,13 @@ func forkOrCreate(ctx context.Context, store statestore.Store, sourceID, forkID 
 		if !errors.Is(err, statestore.ErrNotFound) {
 			return fmt.Errorf(errFailedToForkState, err)
 		}
+		// Source doesn't exist yet (lazy-created). Try to create an empty
+		// fork target via BulkWriter; surface a precise error when the
+		// store can't help.
 		bulkWriter, ok := store.(statestore.BulkWriter)
 		if !ok {
-			return fmt.Errorf(errFailedToForkState, err)
+			return fmt.Errorf(
+				"fork: source conversation not found and store does not implement BulkWriter for fallback: %w", err)
 		}
 		if saveErr := bulkWriter.Save(ctx, &statestore.ConversationState{ID: forkID}); saveErr != nil {
 			return fmt.Errorf(errFailedToForkState, saveErr)


### PR DESCRIPTION
## Summary

Two small cleanups from the post-PR-7 review (items #12 and #20).

**#12 — `forkOrCreate` error wording.** When `Store.Fork` returned `ErrNotFound` and the store also lacked `BulkWriter`, the function wrapped the original `ErrNotFound` with the generic `"failed to fork state: %w"` message. A user debugging this got "fork failed because not found" — true but unhelpful, since the real issue is the store can't fall back to bulk-write a fresh fork target. Replaced with a precise message naming both conditions.

**#20 — Structural guard scope.** `TestNoBulkWriterInStageConfigs` walks `runtime/pipeline/stage` only. Arena's stages and admin tooling live outside the guard intentionally. Added a comment so the next person who wants to extend hot-path stages elsewhere knows to extend the walk.

No behavior change beyond the error wording.

## Test plan

- [x] Pre-commit: lint + build + tests + 80% coverage on changed files — green
- [ ] CI green
