### PR TITLE
feat(statestore): incremental workflow history via ListAccessor (#4)

### DIFF
--- a/runtime/statestore/interface.go
+++ b/runtime/statestore/interface.go
@@ -113,6 +113,36 @@ type SummaryAccessor interface {
 	SaveSummary(ctx context.Context, id string, summary Summary) error
 }
 
+// ListAccessor allows storing append-only collections of opaque items
+// (JSON-encoded by the caller) per conversation. Each list is keyed by
+// a stable name (e.g. "workflow.history").
+//
+// Stores that implement this interface persist appends incrementally —
+// MemoryStore in a Go slice, RedisStore as a Redis list (RPUSH). This
+// keeps per-write cost O(new entries) regardless of how long the
+// collection has grown — the load-bearing property for long-running
+// workflows whose History/ArtifactHistory grow without bound.
+//
+// Optional. Callers (typically the SDK workflow code) type-assert; the
+// caller surfaces a clear error when the store doesn't satisfy.
+type ListAccessor interface {
+	// AppendList appends items to the named list for the conversation.
+	// Items are opaque bytes (typically JSON-encoded by the caller).
+	// Auto-creates the conversation and the list if either is missing.
+	AppendList(ctx context.Context, id, listName string, items [][]byte) error
+
+	// LoadList returns all items of the named list, in append order.
+	// Returns (nil, nil) — not an error — when the list is empty or
+	// has never been written. Returns ErrNotFound only when the
+	// conversation itself doesn't exist.
+	LoadList(ctx context.Context, id, listName string) ([][]byte, error)
+
+	// ListLen returns the current length of the named list. Returns 0
+	// for empty/missing lists; ErrNotFound only when the conversation
+	// doesn't exist.
+	ListLen(ctx context.Context, id, listName string) (int, error)
+}
+
 // ErrNotFound is returned when a conversation doesn't exist in the store.
 var ErrNotFound = errors.New("conversation not found")
 

--- a/runtime/statestore/list_accessor_test.go
+++ b/runtime/statestore/list_accessor_test.go
@@ -1,0 +1,191 @@
+package statestore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MemoryStore implements ListAccessor for append-only typed collections
+// (e.g. workflow.History, workflow.ArtifactHistory). The tests below
+// pin the contract every implementation of ListAccessor must satisfy.
+
+func TestMemoryStore_AppendList_NewList(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte(`{"v":1}`)}))
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, `{"v":1}`, string(got[0]))
+}
+
+func TestMemoryStore_AppendList_AppendsToExisting(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte(`a`), []byte(`b`)}))
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte(`c`)}))
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "a", string(got[0]))
+	assert.Equal(t, "b", string(got[1]))
+	assert.Equal(t, "c", string(got[2]))
+}
+
+func TestMemoryStore_AppendList_DoesNotMutateInput(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	original := []byte("original-bytes")
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{original}))
+
+	// Mutate the caller's buffer; loaded items must not change.
+	for i := range original {
+		original[i] = 'x'
+	}
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "original-bytes", string(got[0]))
+}
+
+func TestMemoryStore_AppendList_EmptyItemsNoOp(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", nil))
+
+	// Conversation should not have been auto-created by an empty append.
+	_, err := store.LoadList(ctx, "conv-1", "events")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestMemoryStore_AppendList_InvalidID(t *testing.T) {
+	store := NewMemoryStore()
+	err := store.AppendList(context.Background(), "", "events", [][]byte{[]byte("x")})
+	assert.ErrorIs(t, err, ErrInvalidID)
+}
+
+func TestMemoryStore_LoadList_Empty(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Conversation exists, list does not — (nil, nil).
+	require.NoError(t, store.AppendList(ctx, "conv-1", "other", [][]byte{[]byte("x")}))
+	got, err := store.LoadList(ctx, "conv-1", "missing-list")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Conversation doesn't exist — ErrNotFound.
+	_, err = store.LoadList(ctx, "conv-missing", "events")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestMemoryStore_LoadList_PreservesAppendOrder(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	for i := range 50 {
+		require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{
+			fmt.Appendf(nil, "entry-%d", i),
+		}))
+	}
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 50)
+	for i, item := range got {
+		assert.Equal(t, fmt.Sprintf("entry-%d", i), string(item))
+	}
+}
+
+func TestMemoryStore_ListLen_Tracks(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	// Conversation must exist for ListLen to return 0 instead of ErrNotFound.
+	require.NoError(t, store.AppendList(ctx, "conv-1", "warm", [][]byte{[]byte("x")}))
+
+	// Empty list on existing conversation.
+	n, err := store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("a"), []byte("b")}))
+	n, err = store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	// Missing conversation returns ErrNotFound.
+	_, err = store.ListLen(ctx, "conv-missing", "events")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestMemoryStore_AppendList_Concurrent(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	const goroutines = 16
+	const itemsPerGoroutine = 50
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range itemsPerGoroutine {
+				payload := fmt.Appendf(nil, "g%d-i%d", g, i)
+				require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{payload}))
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	n, err := store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, goroutines*itemsPerGoroutine, n)
+}
+
+func TestMemoryStore_LoadList_DeepCopiesItems(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("payload")}))
+
+	first, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+
+	// Mutate the returned slice — a second load must not observe the change.
+	for i := range first[0] {
+		first[0][i] = 'X'
+	}
+
+	second, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(second[0]))
+}
+
+func TestMemoryStore_DeleteRemovesLists(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("x")}))
+	// Delete needs the conversation to exist via Save first (Delete loads
+	// state for index cleanup), so seed it.
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-1"}))
+
+	require.NoError(t, store.Delete(ctx, "conv-1"))
+
+	_, err := store.LoadList(ctx, "conv-1", "events")
+	assert.ErrorIs(t, err, ErrNotFound)
+}

--- a/runtime/statestore/memory.go
+++ b/runtime/statestore/memory.go
@@ -128,6 +128,11 @@ type MemoryStore struct {
 	mu     sync.RWMutex
 	states map[string]*ConversationState
 
+	// Append-only typed lists (ListAccessor). Keyed by conversation ID,
+	// then by list name. Values are deep-copied JSON bytes to match the
+	// store's existing immutability guarantees.
+	lists map[string]map[string][][]byte
+
 	// Index for efficient user-based lookups
 	userIndex map[string]map[string]struct{} // userID -> set of conversationIDs
 
@@ -154,6 +159,7 @@ type MemoryStore struct {
 func NewMemoryStore(opts ...MemoryStoreOption) *MemoryStore {
 	s := &MemoryStore{
 		states:    make(map[string]*ConversationState),
+		lists:     make(map[string]map[string][][]byte),
 		userIndex: make(map[string]map[string]struct{}),
 		heapIndex: make(map[string]*accessEntry),
 	}
@@ -684,12 +690,98 @@ func (s *MemoryStore) deleteStateLocked(id string, state *ConversationState) {
 		s.removeFromUserIndex(state.UserID, id)
 	}
 	delete(s.states, id)
+	delete(s.lists, id)
 
 	// Remove from LRU heap
 	if entry, ok := s.heapIndex[id]; ok {
 		heap.Remove(&s.lruHeap, entry.index)
 		delete(s.heapIndex, id)
 	}
+}
+
+// AppendList appends items to the named list for the conversation.
+// Auto-creates the conversation entry if missing. Items are deep-copied
+// so subsequent caller mutations don't affect stored state.
+func (s *MemoryStore) AppendList(ctx context.Context, id, listName string, items [][]byte) error {
+	if id == "" {
+		return ErrInvalidID
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := s.getOrCreateStateLocked(id)
+	if s.lists[id] == nil {
+		s.lists[id] = make(map[string][][]byte)
+	}
+	cp := make([][]byte, len(items))
+	for i, item := range items {
+		cp[i] = make([]byte, len(item))
+		copy(cp[i], item)
+	}
+	s.lists[id][listName] = append(s.lists[id][listName], cp...)
+
+	now := time.Now()
+	state.LastAccessedAt = now
+	s.touchLRULocked(id, now)
+	return nil
+}
+
+// LoadList returns all items of the named list, deep-copied. Returns
+// (nil, nil) when the list is empty or never written. Returns
+// ErrNotFound when the conversation itself doesn't exist.
+func (s *MemoryStore) LoadList(ctx context.Context, id, listName string) ([][]byte, error) {
+	if id == "" {
+		return nil, ErrInvalidID
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	state, exists := s.states[id]
+	if !exists {
+		return nil, ErrNotFound
+	}
+	if s.isExpired(state) {
+		return nil, ErrNotFound
+	}
+	listMap, ok := s.lists[id]
+	if !ok {
+		return nil, nil
+	}
+	items := listMap[listName]
+	if len(items) == 0 {
+		return nil, nil
+	}
+	out := make([][]byte, len(items))
+	for i, item := range items {
+		out[i] = make([]byte, len(item))
+		copy(out[i], item)
+	}
+	return out, nil
+}
+
+// ListLen returns the length of the named list. ErrNotFound only when
+// the conversation itself doesn't exist.
+func (s *MemoryStore) ListLen(ctx context.Context, id, listName string) (int, error) {
+	if id == "" {
+		return 0, ErrInvalidID
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	state, exists := s.states[id]
+	if !exists {
+		return 0, ErrNotFound
+	}
+	if s.isExpired(state) {
+		return 0, ErrNotFound
+	}
+	return len(s.lists[id][listName]), nil
 }
 
 // touchLRULocked updates or inserts a key in the LRU heap with the given access time.

--- a/runtime/statestore/redis.go
+++ b/runtime/statestore/redis.go
@@ -463,15 +463,28 @@ func (s *RedisStore) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	// Pipeline: DEL all keys for this conversation + optional SRem from user index
-	pipe := s.client.Pipeline()
-	delCmd := pipe.Del(ctx,
+	// Enumerate any append-only list keys via the per-conversation index
+	// set so we can DEL them in the same pipeline (no SCAN required).
+	listNames, err := s.client.SMembers(ctx, s.listsIndexKey(id)).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return fmt.Errorf("redis smembers lists index failed: %w", err)
+	}
+
+	keys := []string{
 		s.conversationKey(id), // legacy monolithic key
 		s.metaKey(id),         // decomposed meta
 		s.messagesKey(id),     // decomposed messages list
 		s.summariesKey(id),    // decomposed summaries list
 		s.metadataKey(id),     // decomposed user metadata hash
-	)
+		s.listsIndexKey(id),   // per-conversation list-name index set
+	}
+	for _, name := range listNames {
+		keys = append(keys, s.listKey(id, name))
+	}
+
+	// Pipeline: DEL all keys for this conversation + optional SRem from user index
+	pipe := s.client.Pipeline()
+	delCmd := pipe.Del(ctx, keys...)
 
 	if state.UserID != "" {
 		indexKey := s.userIndexKey(state.UserID)
@@ -635,6 +648,20 @@ func (s *RedisStore) metadataKey(id string) string {
 	return fmt.Sprintf("%s:conversation:%s:metadata", s.prefix, id)
 }
 
+// listKey generates the Redis key for a named append-only list belonging
+// to a conversation. Each list lives in its own Redis list (RPUSH per
+// item), so per-write cost is O(new entries) rather than O(list length).
+func (s *RedisStore) listKey(id, listName string) string {
+	return fmt.Sprintf("%s:conversation:%s:list:%s", s.prefix, id, listName)
+}
+
+// listsIndexKey generates the Redis key for the per-conversation set of
+// list names that have been written. Used by Delete to enumerate list
+// keys for cleanup without a SCAN.
+func (s *RedisStore) listsIndexKey(id string) string {
+	return fmt.Sprintf("%s:conversation:%s:lists", s.prefix, id)
+}
+
 // LoadMetadata returns the user metadata map for the given conversation
 // by reading the dedicated metadata hash. Returns ErrNotFound when the
 // conversation doesn't exist (matches MemoryStore.LoadMetadata).
@@ -737,6 +764,117 @@ func (s *RedisStore) MergeMetadata(ctx context.Context, id string, updates map[s
 		return fmt.Errorf("redis merge metadata failed: %w", err)
 	}
 	return nil
+}
+
+// AppendList appends opaque items to the named per-conversation list using
+// RPUSH. The list name is also recorded in a per-conversation index set
+// (SADD) so Delete can enumerate list keys without a SCAN. All commands
+// run in a single pipeline; TTLs are refreshed on the list, the index
+// set, and the meta key so that long-running workflows that only append
+// list entries don't expire prematurely.
+//
+// Auto-creates the conversation if it doesn't exist — meta is touched on
+// the next interaction (or by an explicit Save). No Save is required.
+func (s *RedisStore) AppendList(ctx context.Context, id, listName string, items [][]byte) error {
+	if id == "" {
+		return ErrInvalidID
+	}
+	if listName == "" {
+		return fmt.Errorf("redis append list: list name must not be empty")
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	args := make([]interface{}, len(items))
+	for i, item := range items {
+		args[i] = item
+	}
+
+	listK := s.listKey(id, listName)
+	indexK := s.listsIndexKey(id)
+
+	pipe := s.client.Pipeline()
+	pipe.RPush(ctx, listK, args...)
+	pipe.SAdd(ctx, indexK, listName)
+	if s.ttl > 0 {
+		pipe.Expire(ctx, listK, s.ttl)
+		pipe.Expire(ctx, indexK, s.ttl)
+		// Touch the meta key so the conversation doesn't expire while
+		// only its lists are being written.
+		pipe.Expire(ctx, s.metaKey(id), s.ttl)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("redis append list failed: %w", err)
+	}
+	return nil
+}
+
+// LoadList returns all items of the named list in append order. Returns
+// (nil, nil) when the list is empty or has never been written and the
+// conversation exists. Returns ErrNotFound only when the conversation
+// itself doesn't exist (distinguished by an EXISTS check on the meta key).
+func (s *RedisStore) LoadList(ctx context.Context, id, listName string) ([][]byte, error) {
+	if id == "" {
+		return nil, ErrInvalidID
+	}
+	if listName == "" {
+		return nil, fmt.Errorf("redis load list: list name must not be empty")
+	}
+
+	// Pipeline LRANGE on the list with EXISTS on the meta key in one
+	// round-trip so we can distinguish "empty list" from "no conversation".
+	pipe := s.client.Pipeline()
+	rangeCmd := pipe.LRange(ctx, s.listKey(id, listName), 0, -1)
+	existsCmd := pipe.Exists(ctx, s.metaKey(id))
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("redis load list pipeline failed: %w", err)
+	}
+
+	vals, err := rangeCmd.Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("redis lrange list failed: %w", err)
+	}
+	if len(vals) == 0 {
+		if existsCmd.Val() == 0 {
+			return nil, ErrNotFound
+		}
+		return nil, nil
+	}
+
+	out := make([][]byte, len(vals))
+	for i, v := range vals {
+		out[i] = []byte(v)
+	}
+	return out, nil
+}
+
+// ListLen returns the current length of the named list. Returns 0 for
+// empty/missing lists; ErrNotFound only when the conversation itself
+// doesn't exist.
+func (s *RedisStore) ListLen(ctx context.Context, id, listName string) (int, error) {
+	if id == "" {
+		return 0, ErrInvalidID
+	}
+	if listName == "" {
+		return 0, fmt.Errorf("redis list len: list name must not be empty")
+	}
+
+	pipe := s.client.Pipeline()
+	lenCmd := pipe.LLen(ctx, s.listKey(id, listName))
+	existsCmd := pipe.Exists(ctx, s.metaKey(id))
+	if _, err := pipe.Exec(ctx); err != nil {
+		return 0, fmt.Errorf("redis list len pipeline failed: %w", err)
+	}
+
+	count, err := lenCmd.Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return 0, fmt.Errorf("redis llen list failed: %w", err)
+	}
+	if count == 0 && existsCmd.Val() == 0 {
+		return 0, ErrNotFound
+	}
+	return int(count), nil
 }
 
 // LoadRecentMessages returns the last n messages using LRANGE on the messages list.

--- a/runtime/statestore/redis_list_accessor_test.go
+++ b/runtime/statestore/redis_list_accessor_test.go
@@ -1,0 +1,152 @@
+package statestore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RedisStore implements ListAccessor backed by Redis lists (RPUSH per
+// item, LRANGE on read). The tests below pin per-implementation details
+// — index-set housekeeping, EXISTS-based ErrNotFound disambiguation, and
+// Delete cleanup of all list keys.
+
+func TestRedisStore_AppendList_NewList(t *testing.T) {
+	store, mr := setupRedisStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-1"}))
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte(`{"v":1}`)}))
+
+	// Underlying list key was created with the right name.
+	assert.True(t, mr.Exists(store.listKey("conv-1", "events")))
+	// Lists index set received the list name.
+	indexed, err := mr.SMembers(store.listsIndexKey("conv-1"))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"events"}, indexed)
+}
+
+func TestRedisStore_AppendList_AppendsToExisting(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-1"}))
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("a"), []byte("b")}))
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("c")}))
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "a", string(got[0]))
+	assert.Equal(t, "b", string(got[1]))
+	assert.Equal(t, "c", string(got[2]))
+}
+
+func TestRedisStore_AppendList_EmptyItemsNoOp(t *testing.T) {
+	store, mr := setupRedisStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", nil))
+	assert.False(t, mr.Exists(store.listKey("conv-1", "events")))
+}
+
+func TestRedisStore_LoadList_DistinguishesEmptyFromMissing(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	// Conversation exists but list never written → (nil, nil).
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-1"}))
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// No conversation at all → ErrNotFound.
+	_, err = store.LoadList(ctx, "missing", "events")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestRedisStore_LoadList_PreservesAppendOrder(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-1"}))
+
+	for i := range 25 {
+		require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{
+			fmt.Appendf(nil, "entry-%d", i),
+		}))
+	}
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 25)
+	for i, item := range got {
+		assert.Equal(t, fmt.Sprintf("entry-%d", i), string(item))
+	}
+}
+
+func TestRedisStore_ListLen_Tracks(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-1"}))
+
+	n, err := store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("a"), []byte("b")}))
+	n, err = store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	// Missing conversation returns ErrNotFound.
+	_, err = store.ListLen(ctx, "missing", "events")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestRedisStore_AppendList_Concurrent(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-1"}))
+
+	const goroutines = 8
+	const itemsPerGoroutine = 25
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range itemsPerGoroutine {
+				payload := fmt.Appendf(nil, "g%d-i%d", g, i)
+				require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{payload}))
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	n, err := store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, goroutines*itemsPerGoroutine, n)
+}
+
+// TestRedisStore_Delete_RemovesLists ensures the per-conversation list
+// keys plus the index set are removed when the conversation is deleted —
+// without this Delete, list keys would leak.
+func TestRedisStore_Delete_RemovesLists(t *testing.T) {
+	store, mr := setupRedisStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-1", UserID: "user-1"}))
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("a")}))
+	require.NoError(t, store.AppendList(ctx, "conv-1", "audit", [][]byte{[]byte("b")}))
+
+	require.NoError(t, store.Delete(ctx, "conv-1"))
+
+	assert.False(t, mr.Exists(store.listKey("conv-1", "events")))
+	assert.False(t, mr.Exists(store.listKey("conv-1", "audit")))
+	assert.False(t, mr.Exists(store.listsIndexKey("conv-1")))
+}

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -12,6 +13,20 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
+)
+
+// Persisted-state keys for split workflow context storage.
+//
+// `workflowCurrentKey` lives in the conversation's user metadata hash and
+// holds the small struct (current_state, visit_counts, artifacts, etc.).
+// History and ArtifactHistory live in their own append-only lists keyed
+// by `workflowHistoryListName` and `workflowArtifactListName`. Splitting
+// keeps per-transition write cost O(1 new entry) instead of O(full
+// History) every time. See plans/2026-04-28-workflow-context-incremental-history.md.
+const (
+	workflowCurrentKey       = "workflow.current"
+	workflowHistoryListName  = "workflow.history"
+	workflowArtifactListName = "workflow.artifact_history"
 )
 
 // WorkflowConversation manages a stateful workflow that transitions between
@@ -49,7 +64,13 @@ type WorkflowConversation struct {
 	workflowCap         *WorkflowCapability
 	transExec           *workflow.TransitionExecutor
 	artifactExec        *workflow.ArtifactExecutor
-	closed              bool
+	// historyAppended is the length of machine.Context().History at the
+	// last persistWorkflowContext call. Used to compute the per-transition
+	// delta — only the new tail is RPUSH'd to the workflow.history list.
+	historyAppended int
+	// artifactHistoryAppended is the analogous tracker for ArtifactHistory.
+	artifactHistoryAppended int
+	closed                  bool
 }
 
 // defaultMaxSummaryMessages is the max messages to include in a carry-forward summary.
@@ -178,10 +199,18 @@ func ResumeWorkflow(workflowID, packPath string, opts ...Option) (*WorkflowConve
 		return nil, ErrConversationNotFound
 	}
 
-	// Extract workflow context from metadata
+	// Extract the small workflow.current view from metadata.
 	wfCtx, err := extractWorkflowContext(state.Metadata)
 	if err != nil {
 		return nil, fmt.Errorf("failed to restore workflow context: %w", err)
+	}
+
+	// Hydrate the append-only History / ArtifactHistory collections from
+	// their dedicated lists. The returned lengths seed the per-instance
+	// delta trackers so subsequent persists only RPUSH new entries.
+	historyLen, artifactHistoryLen, err := hydrateWorkflowContextLists(ctx, cfg.stateStore, workflowID, wfCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hydrate workflow context lists: %w", err)
 	}
 
 	spec := convertWorkflowSpec(p.Workflow)
@@ -206,16 +235,18 @@ func ResumeWorkflow(workflowID, packPath string, opts ...Option) (*WorkflowConve
 	}
 
 	wc := &WorkflowConversation{
-		machine:             machine,
-		workflowSpec:        spec,
-		packPath:            packPath,
-		sdkPack:             p,
-		activeConv:          conv,
-		opts:                opts,
-		stateStore:          cfg.stateStore,
-		workflowID:          workflowID,
-		contextCarryForward: cfg.contextCarryForward,
-		workflowCap:         wfCap,
+		machine:                 machine,
+		workflowSpec:            spec,
+		packPath:                packPath,
+		sdkPack:                 p,
+		activeConv:              conv,
+		opts:                    opts,
+		stateStore:              cfg.stateStore,
+		workflowID:              workflowID,
+		contextCarryForward:     cfg.contextCarryForward,
+		workflowCap:             wfCap,
+		historyAppended:         historyLen,
+		artifactHistoryAppended: artifactHistoryLen,
 	}
 	wc.emitter = conv.newEmitter(cfg.eventBus)
 
@@ -482,14 +513,22 @@ func extractMessageText(msg *types.Message) string {
 	return ""
 }
 
-// persistWorkflowContext saves the workflow context to the state store.
-// It respects the persistence hint on the current state: transient states skip writes.
+// persistWorkflowContext saves the workflow context to the state store
+// using the split storage layout: the small "current" view (everything
+// except the unbounded history collections) goes to a single field of the
+// metadata hash, while History and ArtifactHistory deltas are RPUSH'd to
+// their own append-only lists. This keeps per-transition write cost
+// O(1 new entry) regardless of conversation length.
 //
-// Uses MetadataAccessor.MergeMetadata when available — the typed, race-safe
-// path. Falls back to load-modify-BulkWrite for stores that lack typed
-// metadata writes.
+// It respects the persistence hint on the current state: transient states
+// skip writes.
+//
+// Requires the state store to implement both MetadataAccessor and
+// ListAccessor. Stores that don't satisfy both interfaces log an error
+// and skip the write — the workflow continues in memory but won't be
+// recoverable. All built-in stores (MemoryStore, RedisStore, ArenaStateStore)
+// satisfy both.
 func (wc *WorkflowConversation) persistWorkflowContext() {
-	// Check if current state is transient
 	currentState := wc.machine.CurrentState()
 	if wc.workflowSpec != nil {
 		if st, ok := wc.workflowSpec.States[currentState]; ok {
@@ -502,54 +541,94 @@ func (wc *WorkflowConversation) persistWorkflowContext() {
 	ctx := context.Background()
 	wfCtx := wc.machine.Context()
 
-	if accessor, ok := wc.stateStore.(statestore.MetadataAccessor); ok {
-		if err := accessor.MergeMetadata(ctx, wc.workflowID, map[string]any{"workflow": wfCtx}); err != nil {
-			logger.Warn("failed to persist workflow context",
-				"workflow_id", wc.workflowID, "error", err)
-		}
+	accessor, hasMeta := wc.stateStore.(statestore.MetadataAccessor)
+	listAcc, hasList := wc.stateStore.(statestore.ListAccessor)
+	if !hasMeta || !hasList {
+		logger.Error("workflow context not persisted: state store missing required interfaces",
+			"workflow_id", wc.workflowID,
+			"has_metadata_accessor", hasMeta,
+			"has_list_accessor", hasList)
 		return
 	}
 
-	bulkWriter, ok := wc.stateStore.(statestore.BulkWriter)
-	if !ok {
-		logger.Warn("workflow context not persisted: store implements neither MetadataAccessor nor BulkWriter",
-			"workflow_id", wc.workflowID)
-		return
-	}
-
-	state, err := wc.stateStore.Load(ctx, wc.workflowID)
-	if err != nil {
-		logger.Warn("failed to load workflow state, creating fresh state",
+	// 1. Write the small "current" view — everything except the
+	// append-only history collections, which live in their own lists.
+	current := *wfCtx
+	current.History = nil
+	current.ArtifactHistory = nil
+	if err := accessor.MergeMetadata(ctx, wc.workflowID, map[string]any{
+		workflowCurrentKey: current,
+	}); err != nil {
+		logger.Warn("failed to persist workflow.current",
 			"workflow_id", wc.workflowID, "error", err)
 	}
-	if err != nil || state == nil {
-		state = &statestore.ConversationState{
-			ID:       wc.workflowID,
-			Metadata: make(map[string]any),
-		}
+
+	// 2. Append History delta — only entries added since the last persist.
+	if err := appendWorkflowListDelta(ctx, listAcc, wc.workflowID, workflowHistoryListName,
+		wfCtx.History, &wc.historyAppended,
+	); err != nil {
+		logger.Warn("failed to append workflow.history delta",
+			"workflow_id", wc.workflowID, "error", err)
 	}
-	if state.Metadata == nil {
-		state.Metadata = make(map[string]any)
-	}
-	state.Metadata["workflow"] = wfCtx
-	if err := bulkWriter.Save(ctx, state); err != nil {
-		logger.Warn("failed to persist workflow context", "workflow_id", wc.workflowID, "error", err)
+
+	// 3. Append ArtifactHistory delta.
+	if err := appendWorkflowListDelta(ctx, listAcc, wc.workflowID, workflowArtifactListName,
+		wfCtx.ArtifactHistory, &wc.artifactHistoryAppended,
+	); err != nil {
+		logger.Warn("failed to append workflow.artifact_history delta",
+			"workflow_id", wc.workflowID, "error", err)
 	}
 }
 
-// extractWorkflowContext extracts and deserializes workflow.Context from state metadata.
+// appendWorkflowListDelta marshals only the new tail of items (those past
+// *appended) and appends them to the named list. On success it advances
+// *appended to len(items) so the next call computes the correct delta.
+// Returns nil with no write when there are no new items.
+func appendWorkflowListDelta[T any](
+	ctx context.Context,
+	listAcc statestore.ListAccessor,
+	id, listName string,
+	items []T,
+	appended *int,
+) error {
+	if *appended >= len(items) {
+		return nil
+	}
+	delta := items[*appended:]
+	encoded := make([][]byte, len(delta))
+	for i, item := range delta {
+		b, err := json.Marshal(item)
+		if err != nil {
+			return fmt.Errorf("marshal item %d in %q: %w", *appended+i, listName, err)
+		}
+		encoded[i] = b
+	}
+	if err := listAcc.AppendList(ctx, id, listName, encoded); err != nil {
+		return err
+	}
+	*appended = len(items)
+	return nil
+}
+
+// extractWorkflowContext extracts and deserializes the small workflow
+// "current" view from state metadata. The returned Context has nil
+// History and ArtifactHistory — those are stored in append-only lists
+// and must be hydrated separately via hydrateWorkflowContextLists.
 func extractWorkflowContext(metadata map[string]any) (*workflow.Context, error) {
-	raw, ok := metadata["workflow"]
+	raw, ok := metadata[workflowCurrentKey]
 	if !ok {
 		return nil, fmt.Errorf("no workflow context in metadata")
 	}
 
-	// Handle both direct *workflow.Context and JSON-deserialized map
 	switch v := raw.(type) {
 	case *workflow.Context:
 		return v, nil
+	case workflow.Context:
+		return &v, nil
 	case map[string]any:
-		// Re-serialize and deserialize through JSON for type safety
+		// Re-serialize and deserialize through JSON for type safety —
+		// stores that round-trip through JSON (RedisStore) hand back a
+		// generic map.
 		data, err := json.Marshal(v)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal workflow context: %w", err)
@@ -562,6 +641,58 @@ func extractWorkflowContext(metadata map[string]any) (*workflow.Context, error) 
 	default:
 		return nil, fmt.Errorf("unexpected workflow context type: %T", raw)
 	}
+}
+
+// hydrateWorkflowContextLists loads History and ArtifactHistory from the
+// state store's append-only lists and assigns them onto wfCtx. Returns
+// the loaded slice lengths so the caller can initialize the per-instance
+// delta trackers (historyAppended, artifactHistoryAppended) — without
+// these the next persist would re-RPUSH the entire history.
+func hydrateWorkflowContextLists(
+	ctx context.Context,
+	store statestore.Store,
+	id string,
+	wfCtx *workflow.Context,
+) (historyLen, artifactHistoryLen int, err error) {
+	listAcc, ok := store.(statestore.ListAccessor)
+	if !ok {
+		return 0, 0, fmt.Errorf("workflow restore: state store does not implement ListAccessor")
+	}
+
+	history, err := loadWorkflowList[workflow.StateTransition](ctx, listAcc, id, workflowHistoryListName)
+	if err != nil {
+		return 0, 0, fmt.Errorf("load workflow history: %w", err)
+	}
+	wfCtx.History = history
+
+	artHist, err := loadWorkflowList[workflow.ArtifactSnapshot](ctx, listAcc, id, workflowArtifactListName)
+	if err != nil {
+		return 0, 0, fmt.Errorf("load workflow artifact history: %w", err)
+	}
+	wfCtx.ArtifactHistory = artHist
+
+	return len(history), len(artHist), nil
+}
+
+func loadWorkflowList[T any](
+	ctx context.Context,
+	listAcc statestore.ListAccessor,
+	id, listName string,
+) ([]T, error) {
+	items, err := listAcc.LoadList(ctx, id, listName)
+	if err != nil && !errors.Is(err, statestore.ErrNotFound) {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	out := make([]T, len(items))
+	for i, raw := range items {
+		if err := json.Unmarshal(raw, &out[i]); err != nil {
+			return nil, fmt.Errorf("decode item %d in %q: %w", i, listName, err)
+		}
+	}
+	return out, nil
 }
 
 // convertWorkflowSpec converts the SDK's internal pack.WorkflowSpec to a

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -510,25 +510,20 @@ func TestWorkflowConversation_NilEmitterSafe(t *testing.T) {
 func TestExtractWorkflowContext_Direct(t *testing.T) {
 	wfCtx := &workflow.Context{
 		CurrentState: "processing",
-		History: []workflow.StateTransition{
-			{From: "intake", To: "processing", Event: "Next"},
-		},
 	}
-	metadata := map[string]any{"workflow": wfCtx}
+	metadata := map[string]any{workflowCurrentKey: wfCtx}
 
 	result, err := extractWorkflowContext(metadata)
 	require.NoError(t, err)
 	assert.Equal(t, "processing", result.CurrentState)
-	assert.Len(t, result.History, 1)
+	// History/ArtifactHistory now live in lists, not in workflow.current.
+	assert.Nil(t, result.History)
 }
 
 func TestExtractWorkflowContext_FromJSON(t *testing.T) {
-	// Simulate what happens after JSON round-trip (e.g., Redis store)
+	// Simulate what happens after JSON round-trip (e.g., Redis store).
 	wfCtx := &workflow.Context{
 		CurrentState: "done",
-		History: []workflow.StateTransition{
-			{From: "start", To: "done", Event: "Finish"},
-		},
 	}
 	data, err := json.Marshal(wfCtx)
 	require.NoError(t, err)
@@ -536,11 +531,10 @@ func TestExtractWorkflowContext_FromJSON(t *testing.T) {
 	var rawMap map[string]any
 	require.NoError(t, json.Unmarshal(data, &rawMap))
 
-	metadata := map[string]any{"workflow": rawMap}
+	metadata := map[string]any{workflowCurrentKey: rawMap}
 	result, err := extractWorkflowContext(metadata)
 	require.NoError(t, err)
 	assert.Equal(t, "done", result.CurrentState)
-	assert.Len(t, result.History, 1)
 }
 
 func TestExtractWorkflowContext_Missing(t *testing.T) {
@@ -551,7 +545,7 @@ func TestExtractWorkflowContext_Missing(t *testing.T) {
 }
 
 func TestExtractWorkflowContext_InvalidType(t *testing.T) {
-	metadata := map[string]any{"workflow": "invalid"}
+	metadata := map[string]any{workflowCurrentKey: "invalid"}
 	_, err := extractWorkflowContext(metadata)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected workflow context type")
@@ -577,14 +571,12 @@ func TestPersistWorkflowContext(t *testing.T) {
 		packPath:     "/nonexistent/pack.json",
 	}
 
-	// Persist creates new state
 	wc.persistWorkflowContext()
 
 	ctx := context.Background()
-	state, err := store.Load(ctx, "wf-123")
+	meta, err := store.LoadMetadata(ctx, "wf-123")
 	require.NoError(t, err)
-	require.NotNil(t, state)
-	assert.NotNil(t, state.Metadata["workflow"])
+	require.NotNil(t, meta[workflowCurrentKey])
 }
 
 func TestPersistWorkflowContext_TransientSkips(t *testing.T) {
@@ -765,7 +757,7 @@ func TestResumeWorkflow_NoWorkflow(t *testing.T) {
 	ctx := context.Background()
 	_ = store.Save(ctx, &statestore.ConversationState{
 		ID:       "wf-no-wf",
-		Metadata: map[string]any{"workflow": &workflow.Context{CurrentState: "main"}},
+		Metadata: map[string]any{workflowCurrentKey: &workflow.Context{CurrentState: "main"}},
 	})
 
 	_, err := ResumeWorkflow("wf-no-wf", packPath,
@@ -801,17 +793,16 @@ func TestResumeWorkflow_ValidMetadataButOpenFails(t *testing.T) {
 	store := statestore.NewMemoryStore()
 	ctx := context.Background()
 
-	// Save valid workflow context
-	wfCtx := &workflow.Context{
-		CurrentState: "processing",
-		History: []workflow.StateTransition{
-			{From: "intake", To: "processing", Event: "InfoComplete"},
-		},
-	}
+	// Save the workflow.current view in metadata, plus a single
+	// History entry in the workflow.history list — matches the split
+	// storage layout that ResumeWorkflow rebuilds from.
+	wfCtx := &workflow.Context{CurrentState: "processing"}
 	_ = store.Save(ctx, &statestore.ConversationState{
 		ID:       "wf-resume-test",
-		Metadata: map[string]any{"workflow": wfCtx},
+		Metadata: map[string]any{workflowCurrentKey: wfCtx},
 	})
+	historyEntry, _ := json.Marshal(workflow.StateTransition{From: "intake", To: "processing", Event: "InfoComplete"})
+	require.NoError(t, store.AppendList(ctx, "wf-resume-test", workflowHistoryListName, [][]byte{historyEntry}))
 
 	// ResumeWorkflow will succeed through metadata extraction and state machine
 	// creation, but fail at Open() because no provider is configured.
@@ -835,7 +826,7 @@ func TestResumeWorkflow_ValidMetadataButOpenFails(t *testing.T) {
 func TestExtractWorkflowContext_MarshalError(t *testing.T) {
 	// Test with a map that would fail JSON round-trip (channel value)
 	metadata := map[string]any{
-		"workflow": map[string]any{
+		workflowCurrentKey: map[string]any{
 			"current_state": make(chan int), // Can't marshal channels
 		},
 	}
@@ -1212,43 +1203,6 @@ func TestWorkflowConversation_ConcurrentSendAndTransition(t *testing.T) {
 	// No assertions needed — test validates absence of data races with -race flag
 }
 
-// errorStore is a statestore.Store that always returns errors on Save.
-type errorStore struct {
-	statestore.Store
-}
-
-func (s *errorStore) Load(_ context.Context, _ string) (*statestore.ConversationState, error) {
-	return &statestore.ConversationState{
-		ID:       "wf-1",
-		Metadata: make(map[string]any),
-	}, nil
-}
-
-func (s *errorStore) Save(_ context.Context, _ *statestore.ConversationState) error {
-	return errors.New("save failed")
-}
-
-func TestPersistWorkflowContext_SaveError(t *testing.T) {
-	spec := &workflow.Spec{
-		Version: 1,
-		Entry:   "start",
-		States: map[string]*workflow.State{
-			"start": {PromptTask: "p1"},
-		},
-	}
-	machine := workflow.NewStateMachine(spec)
-
-	wc := &WorkflowConversation{
-		machine:      machine,
-		workflowSpec: spec,
-		stateStore:   &errorStore{},
-		workflowID:   "wf-1",
-	}
-
-	// Should not panic — logs the error instead of discarding
-	wc.persistWorkflowContext()
-}
-
 func TestPersistWorkflowContext_TransientStateSkipped(t *testing.T) {
 	spec := &workflow.Spec{
 		Version: 1,
@@ -1269,49 +1223,14 @@ func TestPersistWorkflowContext_TransientStateSkipped(t *testing.T) {
 		workflowID:   "wf-1",
 	}
 
-	// Should be a no-op (transient state)
+	// Should be a no-op (transient state).
 	wc.persistWorkflowContext()
 }
 
-// loadErrorBulkStore implements Store + BulkWriter but its Load always
-// errors. Exercises the "Load failed → fresh state" branch in
-// persistWorkflowContext's BulkWriter fallback path.
-type loadErrorBulkStore struct{}
-
-func (loadErrorBulkStore) Load(_ context.Context, _ string) (*statestore.ConversationState, error) {
-	return nil, errors.New("simulated load failure")
-}
-func (loadErrorBulkStore) Fork(_ context.Context, _, _ string) error { return nil }
-func (loadErrorBulkStore) Save(_ context.Context, _ *statestore.ConversationState) error {
-	return nil
-}
-
-// TestPersistWorkflowContext_BulkWriterLoadFails covers the fallback branch
-// where the store is BulkWriter-only and Load errors — the function should
-// proceed with a fresh state and not panic.
-func TestPersistWorkflowContext_BulkWriterLoadFails(t *testing.T) {
-	spec := &workflow.Spec{
-		Version: 1,
-		Entry:   "start",
-		States: map[string]*workflow.State{
-			"start": {PromptTask: "p1"},
-		},
-	}
-	machine := workflow.NewStateMachine(spec)
-
-	wc := &WorkflowConversation{
-		machine:      machine,
-		workflowSpec: spec,
-		stateStore:   loadErrorBulkStore{},
-		workflowID:   "wf-1",
-	}
-
-	wc.persistWorkflowContext() // Must not panic.
-}
-
 // readOnlyStore implements only the bare Store interface (Load + Fork) —
-// no BulkWriter, no MetadataAccessor. Used to exercise the warning path
-// in persistWorkflowContext when neither typed nor bulk write is available.
+// no MetadataAccessor, no ListAccessor. Used to exercise the early-return
+// path in persistWorkflowContext when the store can't satisfy either of
+// the required typed-write interfaces.
 type readOnlyStore struct{}
 
 func (readOnlyStore) Load(_ context.Context, id string) (*statestore.ConversationState, error) {
@@ -1320,8 +1239,8 @@ func (readOnlyStore) Load(_ context.Context, id string) (*statestore.Conversatio
 func (readOnlyStore) Fork(_ context.Context, _, _ string) error { return nil }
 
 // TestPersistWorkflowContext_NoWriteCapability covers the branch where the
-// store implements neither MetadataAccessor nor BulkWriter — the function
-// must log a warning and return without panicking.
+// store implements neither MetadataAccessor nor ListAccessor — the
+// function must log an error and return without panicking.
 func TestPersistWorkflowContext_NoWriteCapability(t *testing.T) {
 	spec := &workflow.Spec{
 		Version: 1,
@@ -1340,6 +1259,56 @@ func TestPersistWorkflowContext_NoWriteCapability(t *testing.T) {
 	}
 
 	wc.persistWorkflowContext() // Must not panic.
+}
+
+// metadataOnlyStore satisfies MetadataAccessor but not ListAccessor —
+// exercises the requirement that persistWorkflowContext refuses to write
+// when the store can't store History/ArtifactHistory deltas.
+type metadataOnlyStore struct {
+	readOnlyStore
+	merged map[string]any
+}
+
+func (s *metadataOnlyStore) LoadMetadata(_ context.Context, _ string) (map[string]any, error) {
+	return s.merged, nil
+}
+func (s *metadataOnlyStore) MergeMetadata(_ context.Context, _ string, updates map[string]any) error {
+	if s.merged == nil {
+		s.merged = make(map[string]any)
+	}
+	for k, v := range updates {
+		s.merged[k] = v
+	}
+	return nil
+}
+
+// TestPersistWorkflowContext_FailsWhenStoreMissingListAccessor verifies
+// that a store with MetadataAccessor but no ListAccessor is rejected
+// up-front — no metadata is written, since a partial write would leave
+// the workflow unrecoverable.
+func TestPersistWorkflowContext_FailsWhenStoreMissingListAccessor(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States: map[string]*workflow.State{
+			"start": {PromptTask: "p1"},
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+
+	store := &metadataOnlyStore{}
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		stateStore:   store,
+		workflowID:   "wf-1",
+	}
+
+	wc.persistWorkflowContext()
+
+	// Nothing should have been written — the missing ListAccessor
+	// triggers an early return before MergeMetadata is called.
+	assert.Empty(t, store.merged)
 }
 
 func TestPersistWorkflowContext_Success(t *testing.T) {
@@ -1362,10 +1331,9 @@ func TestPersistWorkflowContext_Success(t *testing.T) {
 
 	wc.persistWorkflowContext()
 
-	// Verify the workflow context was saved
-	state, err := store.Load(context.Background(), "wf-1")
+	meta, err := store.LoadMetadata(context.Background(), "wf-1")
 	require.NoError(t, err)
-	require.NotNil(t, state.Metadata["workflow"])
+	require.NotNil(t, meta[workflowCurrentKey])
 }
 
 // TestCommitDeferredTransition_NoTransExec is a no-op when the workflow
@@ -1645,4 +1613,232 @@ func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration, label st
 	case <-time.After(d):
 		t.Fatalf("timed out waiting for %s", label)
 	}
+}
+
+// pinHistory rewrites machine.Context().History (and ArtifactHistory)
+// in-place via a fresh state machine seeded with a synthetic context.
+// Used by the incremental-persistence tests to drive the delta logic
+// without going through real transitions.
+func pinHistory(spec *workflow.Spec, history []workflow.StateTransition, artHist []workflow.ArtifactSnapshot) *workflow.StateMachine {
+	wfCtx := &workflow.Context{
+		CurrentState:    spec.Entry,
+		History:         history,
+		ArtifactHistory: artHist,
+	}
+	return workflow.NewStateMachineFromContext(spec, wfCtx)
+}
+
+// TestPersistWorkflowContext_SecondPersistAppendsOnlyDelta drives the
+// per-transition delta logic: a second persist with one new History
+// entry appends exactly one item to the workflow.history list, not the
+// full slice.
+func TestPersistWorkflowContext_SecondPersistAppendsOnlyDelta(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States: map[string]*workflow.State{
+			"start": {PromptTask: "p1"},
+		},
+	}
+	store := statestore.NewMemoryStore()
+	ctx := context.Background()
+
+	wc := &WorkflowConversation{
+		machine:      pinHistory(spec, []workflow.StateTransition{{From: "a", To: "b", Event: "X"}}, nil),
+		workflowSpec: spec,
+		stateStore:   store,
+		workflowID:   "wf-1",
+	}
+
+	wc.persistWorkflowContext()
+	require.Equal(t, 1, wc.historyAppended)
+	n, err := store.ListLen(ctx, "wf-1", workflowHistoryListName)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	// Add a second history entry. persistWorkflowContext should RPUSH
+	// only the new tail entry — the list grows from 1 to 2, not from 1
+	// to 3 (which a "rewrite the whole slice" implementation would
+	// produce).
+	wc.machine = pinHistory(spec, []workflow.StateTransition{
+		{From: "a", To: "b", Event: "X"},
+		{From: "b", To: "c", Event: "Y"},
+	}, nil)
+	wc.persistWorkflowContext()
+	require.Equal(t, 2, wc.historyAppended)
+	n, err = store.ListLen(ctx, "wf-1", workflowHistoryListName)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+// TestPersistWorkflowContext_NoArtifactChangeSkipsArtifactList confirms
+// that when ArtifactHistory's length is unchanged, no AppendList write
+// hits the artifact_history list.
+func TestPersistWorkflowContext_NoArtifactChangeSkipsArtifactList(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States:  map[string]*workflow.State{"start": {PromptTask: "p1"}},
+	}
+	store := statestore.NewMemoryStore()
+	ctx := context.Background()
+
+	// First persist seeds one history entry, no artifact entry.
+	wc := &WorkflowConversation{
+		machine:      pinHistory(spec, []workflow.StateTransition{{From: "a", To: "b"}}, nil),
+		workflowSpec: spec,
+		stateStore:   store,
+		workflowID:   "wf-1",
+	}
+	wc.persistWorkflowContext()
+
+	// Second persist adds one new history entry but no artifact change.
+	wc.machine = pinHistory(spec, []workflow.StateTransition{
+		{From: "a", To: "b"},
+		{From: "b", To: "c"},
+	}, nil)
+	wc.persistWorkflowContext()
+
+	// History list grew, artifact list never received any writes.
+	hN, err := store.ListLen(ctx, "wf-1", workflowHistoryListName)
+	require.NoError(t, err)
+	assert.Equal(t, 2, hN)
+	aN, err := store.ListLen(ctx, "wf-1", workflowArtifactListName)
+	require.NoError(t, err)
+	assert.Equal(t, 0, aN)
+	assert.Equal(t, 0, wc.artifactHistoryAppended)
+}
+
+// TestHydrateWorkflowContextLists_StoreMissingListAccessor exercises the
+// early-return path when the store can't satisfy the ListAccessor
+// contract — Resume should fail loudly rather than silently returning a
+// half-built context.
+func TestHydrateWorkflowContextLists_StoreMissingListAccessor(t *testing.T) {
+	wfCtx := &workflow.Context{CurrentState: "x"}
+	_, _, err := hydrateWorkflowContextLists(context.Background(), readOnlyStore{}, "wf-1", wfCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ListAccessor")
+}
+
+// listLoadErrorStore satisfies ListAccessor with LoadList always returning
+// a non-ErrNotFound failure — exercises the propagation path in
+// loadWorkflowList / hydrateWorkflowContextLists.
+type listLoadErrorStore struct{ readOnlyStore }
+
+func (listLoadErrorStore) AppendList(_ context.Context, _, _ string, _ [][]byte) error {
+	return nil
+}
+func (listLoadErrorStore) LoadList(_ context.Context, _, _ string) ([][]byte, error) {
+	return nil, errors.New("simulated list load failure")
+}
+func (listLoadErrorStore) ListLen(_ context.Context, _, _ string) (int, error) {
+	return 0, errors.New("simulated list len failure")
+}
+
+func TestHydrateWorkflowContextLists_LoadListError(t *testing.T) {
+	wfCtx := &workflow.Context{CurrentState: "x"}
+	_, _, err := hydrateWorkflowContextLists(context.Background(), listLoadErrorStore{}, "wf-1", wfCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load workflow history")
+}
+
+// TestAppendWorkflowListDelta_NoNewItemsSkipsWrite covers the early-return
+// branch when the in-memory slice length matches the tracker — no
+// AppendList call should be made and the tracker is unchanged.
+func TestAppendWorkflowListDelta_NoNewItemsSkipsWrite(t *testing.T) {
+	store := statestore.NewMemoryStore()
+	ctx := context.Background()
+
+	// Seed the store so we can detect any unexpected write.
+	require.NoError(t, store.AppendList(ctx, "wf-1", "events", [][]byte{[]byte(`"x"`)}))
+
+	tracker := 1
+	err := appendWorkflowListDelta(ctx, store, "wf-1", "events",
+		[]string{"x"}, &tracker)
+	require.NoError(t, err)
+	assert.Equal(t, 1, tracker)
+
+	n, err := store.ListLen(ctx, "wf-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+}
+
+// listAppendErrorStore satisfies the interfaces needed by
+// persistWorkflowContext but every AppendList call fails — exercises the
+// warn-and-continue branches inside persistWorkflowContext.
+type listAppendErrorStore struct{ readOnlyStore }
+
+func (listAppendErrorStore) LoadMetadata(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+func (listAppendErrorStore) MergeMetadata(_ context.Context, _ string, _ map[string]any) error {
+	return nil
+}
+func (listAppendErrorStore) AppendList(_ context.Context, _, _ string, _ [][]byte) error {
+	return errors.New("simulated append failure")
+}
+func (listAppendErrorStore) LoadList(_ context.Context, _, _ string) ([][]byte, error) {
+	return nil, nil
+}
+func (listAppendErrorStore) ListLen(_ context.Context, _, _ string) (int, error) {
+	return 0, nil
+}
+
+func TestPersistWorkflowContext_AppendErrorsLoggedNotFatal(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "start",
+		States:  map[string]*workflow.State{"start": {PromptTask: "p1"}},
+	}
+	wc := &WorkflowConversation{
+		machine: pinHistory(spec, []workflow.StateTransition{{From: "a", To: "b"}}, []workflow.ArtifactSnapshot{
+			{FromState: "a", ToState: "b"},
+		}),
+		workflowSpec: spec,
+		stateStore:   listAppendErrorStore{},
+		workflowID:   "wf-1",
+	}
+
+	// Both AppendList calls fail; persist must log and return without
+	// panicking, and the trackers must not advance past the failed write.
+	wc.persistWorkflowContext()
+	assert.Equal(t, 0, wc.historyAppended)
+	assert.Equal(t, 0, wc.artifactHistoryAppended)
+}
+
+// TestExtractWorkflowContext_ValueType covers the workflow.Context (by
+// value) branch of extractWorkflowContext, which complements the
+// pointer/map branches already exercised.
+func TestExtractWorkflowContext_ValueType(t *testing.T) {
+	metadata := map[string]any{workflowCurrentKey: workflow.Context{CurrentState: "v"}}
+	got, err := extractWorkflowContext(metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "v", got.CurrentState)
+}
+
+// TestHydrateWorkflowContextLists_RebuildsFromLists exercises the
+// reverse half of the split-storage round-trip: after appending entries
+// to the lists, a fresh hydrate populates History/ArtifactHistory and
+// returns the lengths the caller needs to seed delta trackers.
+func TestHydrateWorkflowContextLists_RebuildsFromLists(t *testing.T) {
+	store := statestore.NewMemoryStore()
+	ctx := context.Background()
+
+	histA, _ := json.Marshal(workflow.StateTransition{From: "a", To: "b", Event: "X"})
+	histB, _ := json.Marshal(workflow.StateTransition{From: "b", To: "c", Event: "Y"})
+	require.NoError(t, store.AppendList(ctx, "wf-1", workflowHistoryListName, [][]byte{histA, histB}))
+
+	artA, _ := json.Marshal(workflow.ArtifactSnapshot{FromState: "a", ToState: "b", Event: "X"})
+	require.NoError(t, store.AppendList(ctx, "wf-1", workflowArtifactListName, [][]byte{artA}))
+
+	wfCtx := &workflow.Context{CurrentState: "c"}
+	historyLen, artHistLen, err := hydrateWorkflowContextLists(ctx, store, "wf-1", wfCtx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, historyLen)
+	assert.Equal(t, 1, artHistLen)
+	require.Len(t, wfCtx.History, 2)
+	assert.Equal(t, "a", wfCtx.History[0].From)
+	assert.Equal(t, "Y", wfCtx.History[1].Event)
+	require.Len(t, wfCtx.ArtifactHistory, 1)
+	assert.Equal(t, "a", wfCtx.ArtifactHistory[0].FromState)
 }

--- a/tools/arena/statestore/list_accessor_test.go
+++ b/tools/arena/statestore/list_accessor_test.go
@@ -1,0 +1,132 @@
+package statestore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	runtimestore "github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ArenaStateStore mirrors MemoryStore's ListAccessor semantics for use
+// from arena (which builds its own store rather than going through the
+// SDK). The tests below pin those semantics — input/output deep-copy,
+// auto-create on first append, distinguishing empty list from missing
+// conversation.
+
+func TestArenaStateStore_AppendList_NewList(t *testing.T) {
+	store := NewArenaStateStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte(`{"v":1}`)}))
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, `{"v":1}`, string(got[0]))
+}
+
+func TestArenaStateStore_AppendList_AppendsToExisting(t *testing.T) {
+	store := NewArenaStateStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("a"), []byte("b")}))
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("c")}))
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "a", string(got[0]))
+	assert.Equal(t, "b", string(got[1]))
+	assert.Equal(t, "c", string(got[2]))
+}
+
+func TestArenaStateStore_AppendList_DoesNotMutateInput(t *testing.T) {
+	store := NewArenaStateStore()
+	ctx := context.Background()
+
+	original := []byte("original-bytes")
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{original}))
+
+	for i := range original {
+		original[i] = 'x'
+	}
+
+	got, err := store.LoadList(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "original-bytes", string(got[0]))
+}
+
+func TestArenaStateStore_LoadList_DistinguishesEmptyFromMissing(t *testing.T) {
+	store := NewArenaStateStore()
+	ctx := context.Background()
+
+	// Conversation exists, list does not — (nil, nil).
+	require.NoError(t, store.AppendList(ctx, "conv-1", "other", [][]byte{[]byte("x")}))
+	got, err := store.LoadList(ctx, "conv-1", "missing-list")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Conversation doesn't exist — ErrNotFound.
+	_, err = store.LoadList(ctx, "missing", "events")
+	assert.ErrorIs(t, err, runtimestore.ErrNotFound)
+}
+
+func TestArenaStateStore_ListLen_Tracks(t *testing.T) {
+	store := NewArenaStateStore()
+	ctx := context.Background()
+	require.NoError(t, store.AppendList(ctx, "conv-1", "warm", [][]byte{[]byte("x")}))
+
+	n, err := store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("a"), []byte("b")}))
+	n, err = store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	_, err = store.ListLen(ctx, "missing", "events")
+	assert.ErrorIs(t, err, runtimestore.ErrNotFound)
+}
+
+func TestArenaStateStore_AppendList_Concurrent(t *testing.T) {
+	store := NewArenaStateStore()
+	ctx := context.Background()
+
+	const goroutines = 16
+	const itemsPerGoroutine = 25
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range itemsPerGoroutine {
+				payload := fmt.Appendf(nil, "g%d-i%d", g, i)
+				require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{payload}))
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	n, err := store.ListLen(ctx, "conv-1", "events")
+	require.NoError(t, err)
+	assert.Equal(t, goroutines*itemsPerGoroutine, n)
+}
+
+func TestArenaStateStore_DeleteRemovesLists(t *testing.T) {
+	store := NewArenaStateStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AppendList(ctx, "conv-1", "events", [][]byte{[]byte("x")}))
+
+	require.NoError(t, store.Delete(ctx, "conv-1"))
+
+	_, err := store.LoadList(ctx, "conv-1", "events")
+	assert.ErrorIs(t, err, runtimestore.ErrNotFound)
+}

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -118,13 +118,19 @@ type ArenaConversationState struct {
 // ArenaStateStore is an in-memory state store with Arena-specific telemetry
 type ArenaStateStore struct {
 	conversations map[string]*ArenaConversationState
-	mu            sync.RWMutex
+	// lists holds per-conversation, per-name append-only collections that
+	// satisfy the runtime statestore.ListAccessor interface. Used by SDK
+	// workflow code to persist History / ArtifactHistory incrementally
+	// without rewriting the full slice on every transition.
+	lists map[string]map[string][][]byte
+	mu    sync.RWMutex
 }
 
 // NewArenaStateStore creates a new Arena state store
 func NewArenaStateStore() *ArenaStateStore {
 	return &ArenaStateStore{
 		conversations: make(map[string]*ArenaConversationState),
+		lists:         make(map[string]map[string][][]byte),
 	}
 }
 
@@ -133,6 +139,7 @@ func (s *ArenaStateStore) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.conversations = make(map[string]*ArenaConversationState)
+	s.lists = make(map[string]map[string][][]byte)
 }
 
 // Save stores conversation state (implements Store interface).
@@ -689,7 +696,93 @@ func (s *ArenaStateStore) Delete(ctx context.Context, conversationID string) err
 	defer s.mu.Unlock()
 
 	delete(s.conversations, conversationID)
+	delete(s.lists, conversationID)
 	return nil
+}
+
+// AppendList implements runtime statestore.ListAccessor — items are
+// deep-copied and appended to the named per-conversation list. Auto-creates
+// the conversation entry on first use so list writes can land before any
+// Save (matching MemoryStore semantics).
+func (s *ArenaStateStore) AppendList(_ context.Context, id, listName string, items [][]byte) error {
+	if id == "" {
+		return runtimestore.ErrInvalidID
+	}
+	if listName == "" {
+		return fmt.Errorf("arena append list: list name must not be empty")
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.conversations[id]; !exists {
+		s.conversations[id] = &ArenaConversationState{
+			ConversationState: runtimestore.ConversationState{ID: id},
+		}
+	}
+	if s.lists[id] == nil {
+		s.lists[id] = make(map[string][][]byte)
+	}
+	cp := make([][]byte, len(items))
+	for i, item := range items {
+		cp[i] = make([]byte, len(item))
+		copy(cp[i], item)
+	}
+	s.lists[id][listName] = append(s.lists[id][listName], cp...)
+	return nil
+}
+
+// LoadList implements runtime statestore.ListAccessor — returns deep copies
+// of every item in the named list, in append order. Returns (nil, nil) for
+// an empty/missing list when the conversation exists; ErrNotFound only when
+// the conversation itself doesn't exist.
+func (s *ArenaStateStore) LoadList(_ context.Context, id, listName string) ([][]byte, error) {
+	if id == "" {
+		return nil, runtimestore.ErrInvalidID
+	}
+	if listName == "" {
+		return nil, fmt.Errorf("arena load list: list name must not be empty")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if _, exists := s.conversations[id]; !exists {
+		return nil, runtimestore.ErrNotFound
+	}
+	items := s.lists[id][listName]
+	if len(items) == 0 {
+		return nil, nil
+	}
+	out := make([][]byte, len(items))
+	for i, item := range items {
+		out[i] = make([]byte, len(item))
+		copy(out[i], item)
+	}
+	return out, nil
+}
+
+// ListLen implements runtime statestore.ListAccessor — returns the current
+// length of the named list. Returns ErrNotFound only when the conversation
+// itself doesn't exist.
+func (s *ArenaStateStore) ListLen(_ context.Context, id, listName string) (int, error) {
+	if id == "" {
+		return 0, runtimestore.ErrInvalidID
+	}
+	if listName == "" {
+		return 0, fmt.Errorf("arena list len: list name must not be empty")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if _, exists := s.conversations[id]; !exists {
+		return 0, runtimestore.ErrNotFound
+	}
+	return len(s.lists[id][listName]), nil
 }
 
 // GetArenaState retrieves the full Arena state including telemetry.


### PR DESCRIPTION
## Summary

- Closes review item **#4** from the post-PR-7 statestore code review.
- Splits workflow context storage so per-transition write cost is `O(1 new entry)` instead of `O(full History + ArtifactHistory)`.
- Introduces a generic `ListAccessor` optional interface for typed append-only collections — implemented by `MemoryStore`, `RedisStore`, and `ArenaStateStore`.

## Why

`workflow.Context.History` and `workflow.Context.ArtifactHistory` grow without bound. `persistWorkflowContext` used to JSON-marshal the entire `*workflow.Context` and write it through `MergeMetadata({"workflow": wfCtx})` on every transition. For a 2k-turn workflow that's roughly **400KB of marshal + write per transition**. Per-key Redis writes are cheap post-#3 but the marshal cost still scales O(N).

## Data model

After this PR, per conversation `id`:

| Redis key | Type | What it holds |
|---|---|---|
| `pk:conv:{id}:metadata` field `user.workflow.current` | hash field | small struct: `current_state`, `visit_counts`, `artifacts`, `metadata`, etc. |
| `pk:conv:{id}:list:workflow.history` | **NEW: list** | one `StateTransition` per element |
| `pk:conv:{id}:list:workflow.artifact_history` | **NEW: list** | one `ArtifactSnapshot` per element |
| `pk:conv:{id}:lists` | **NEW: set** | per-conversation index of list names — used by `Delete` to enumerate without `SCAN` |

`WorkflowConversation` tracks `historyAppended` / `artifactHistoryAppended`; each persist computes the slice tail, JSON-marshals only the new entries, and `RPUSH`'s them. `ResumeWorkflow` calls `LoadList` for both, decodes each item, and seeds the trackers from the loaded lengths so subsequent persists compute correct deltas.

See `plans/2026-04-28-workflow-context-incremental-history.md` for the full design and a worked 3-turn example.

## No fallbacks

`persistWorkflowContext` requires both `MetadataAccessor` and `ListAccessor` and refuses to write when either is missing — a partial write would leave the workflow unrecoverable. All built-in stores satisfy both. The old `BulkWriter` fallback in `persistWorkflowContext` is gone.

## Test plan

- [x] `go test ./runtime/statestore/... -count=1 -race` (Memory + Redis ListAccessor contract, Delete cleanup)
- [x] `go test ./sdk/... -count=1 -race` (incremental persist delta, hydrate round-trip, missing-ListAccessor early return)
- [x] `go test ./tools/arena/statestore/... -count=1 -race` (Arena ListAccessor parity with Memory)
- [x] `golangci-lint run` clean on all touched packages
- [x] Pre-commit coverage gate ≥80% on every changed `.go` file
