### PR TITLE
fix(openai): honor audio modalities on text-only inputs (#1066)

### DIFF
--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -303,6 +303,14 @@ func hasModality(modalities []string, target string) bool {
 	return false
 }
 
+// hasAudioOutputConfigured reports whether additional_config explicitly
+// asks for audio output. Used by the request builders to honor the
+// configured modalities even on text-only inputs — without this check,
+// text-in / audio-out callers were silently dropped.
+func hasAudioOutputConfigured(additionalConfig map[string]any) bool {
+	return hasModality(getAudioModalities(additionalConfig), "audio")
+}
+
 // applyAudioModalities sets the "modalities" and optional "audio" fields on
 // an OpenAI request map. formatFallback is used when additional_config does
 // not specify audio_format (e.g. "wav" for non-streaming, "pcm16" for streaming).
@@ -326,7 +334,8 @@ func applyAudioModalities(openAIReq map[string]interface{}, additionalConfig map
 func (p *Provider) enrichRequest(
 	openAIReq map[string]interface{}, req *providers.PredictionRequest, audioFmtFallback string,
 ) {
-	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(req) {
+	if p.apiMode == APIModeCompletions && isAudioModel(p.model) &&
+		(requestContainsAudio(req) || hasAudioOutputConfigured(p.additionalConfig)) {
 		applyAudioModalities(openAIReq, p.additionalConfig, audioFmtFallback)
 	}
 	temperature, topP, maxTokens := p.applyRequestDefaults(*req)

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1674,6 +1674,133 @@ func TestGetStringConfigOrDefault(t *testing.T) {
 	}
 }
 
+// TestPredict_AudioModel_TextInputAudioOutputConfig is the regression
+// test for #1066. Before the fix, the openai provider only forwarded
+// configured audio modalities when the input contained audio — so
+// text-in / audio-out callers (TTS-style use of gpt-4o-audio-preview)
+// hit a 400 from OpenAI: "this model requires that either input
+// content or output modality contain audio". With the explicit
+// modalities config now honored, the request must carry both the
+// modalities slice and the audio block even with a pure text input.
+func TestPredict_AudioModel_TextInputAudioOutputConfig(t *testing.T) {
+	var capturedReq map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedReq); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", server.URL,
+		providers.ProviderDefaults{}, false,
+		map[string]any{
+			"api_mode":     "completions",
+			"modalities":   []any{"text", "audio"},
+			"voice":        "alloy",
+			"audio_format": "wav",
+		},
+	)
+
+	req := providers.PredictionRequest{
+		Messages: []types.Message{{
+			Role: "user",
+			Parts: []types.ContentPart{
+				types.NewTextPart("Say hello aloud."),
+			},
+		}},
+	}
+
+	if _, err := provider.Predict(context.Background(), req); err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+
+	mods, ok := capturedReq["modalities"].([]any)
+	if !ok {
+		t.Fatalf("expected modalities in request, got: %v", capturedReq)
+	}
+	if len(mods) != 2 || mods[0] != "text" || mods[1] != "audio" {
+		t.Errorf("modalities = %v, want [text, audio]", mods)
+	}
+	audioCfg, ok := capturedReq["audio"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected audio block in request, got: %v", capturedReq)
+	}
+	if voice, _ := audioCfg["voice"].(string); voice != "alloy" {
+		t.Errorf("audio.voice = %q, want alloy", voice)
+	}
+	if format, _ := audioCfg["format"].(string); format != "wav" {
+		t.Errorf("audio.format = %q, want wav", format)
+	}
+}
+
+// TestPredict_AudioModel_TextInputNoModalitiesConfig pins the
+// default-off behavior: a text-only request with no modalities
+// configured must not get a "modalities" key at all (preserves the
+// pre-#1066 path for text-only callers).
+func TestPredict_AudioModel_TextInputNoModalitiesConfig(t *testing.T) {
+	var capturedReq map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedReq); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	provider := NewProviderWithConfig(
+		"test", "gpt-4o-audio-preview", server.URL,
+		providers.ProviderDefaults{}, false,
+		map[string]any{"api_mode": "completions"}, // no "modalities" key
+	)
+
+	req := providers.PredictionRequest{
+		Messages: []types.Message{{
+			Role: "user",
+			Parts: []types.ContentPart{
+				types.NewTextPart("Just text, no audio expected."),
+			},
+		}},
+	}
+
+	if _, err := provider.Predict(context.Background(), req); err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+
+	if _, has := capturedReq["modalities"]; has {
+		t.Errorf("modalities should be absent for text-only/no-config; got %v", capturedReq["modalities"])
+	}
+	if _, has := capturedReq["audio"]; has {
+		t.Errorf("audio block should be absent for text-only/no-config")
+	}
+}
+
+func TestHasAudioOutputConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  map[string]any
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"no modalities key", map[string]any{"voice": "alloy"}, false},
+		{"text only", map[string]any{"modalities": []any{"text"}}, false},
+		{"text and audio", map[string]any{"modalities": []any{"text", "audio"}}, true},
+		{"audio only", map[string]any{"modalities": []any{"audio"}}, true},
+		{"case-insensitive Audio", map[string]any{"modalities": []any{"Text", "Audio"}}, true},
+		{"native []string", map[string]any{"modalities": []string{"text", "audio"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasAudioOutputConfigured(tt.cfg); got != tt.want {
+				t.Errorf("hasAudioOutputConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasModality(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -256,8 +256,13 @@ func (p *ToolProvider) buildToolRequest(req providers.PredictionRequest, tools i
 		openaiReq["seed"] = *req.Seed
 	}
 
-	// Apply audio output modalities from additional_config for audio models.
-	if p.apiMode == APIModeCompletions && isAudioModel(p.model) && requestContainsAudio(&req) {
+	// Apply audio output modalities for audio models. Two trigger conditions:
+	//   - request already contains audio input (legacy behavior), or
+	//   - additional_config explicitly asks for audio output (text-in/audio-out).
+	// Without the second clause, configured modalities were silently dropped on
+	// text-only inputs and OpenAI rejected the request as "must contain audio".
+	if p.apiMode == APIModeCompletions && isAudioModel(p.model) &&
+		(requestContainsAudio(&req) || hasAudioOutputConfigured(p.additionalConfig)) {
 		applyAudioModalities(openaiReq, p.additionalConfig, "wav")
 	}
 

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -1149,6 +1149,50 @@ func TestBuildToolRequest_AudioModalities(t *testing.T) {
 	}
 }
 
+// TestBuildToolRequest_AudioModalities_TextInput is the tools-path
+// regression for #1066. Without the fix, audio modality config was
+// dropped on text-only inputs, so the OpenAI request omitted both the
+// modalities slice and the audio block — and the API returned a 400.
+func TestBuildToolRequest_AudioModalities_TextInput(t *testing.T) {
+	provider := NewToolProvider(
+		"test-audio", "gpt-4o-audio-preview", "https://api.openai.com/v1",
+		providers.ProviderDefaults{Temperature: 0.7, MaxTokens: 100},
+		false, nil, nil,
+	)
+	provider.apiMode = APIModeCompletions
+	provider.additionalConfig = map[string]any{
+		"modalities":   []any{"text", "audio"},
+		"voice":        "alloy",
+		"audio_format": "wav",
+	}
+
+	req := providers.PredictionRequest{
+		Messages: []types.Message{{
+			Role:  "user",
+			Parts: []types.ContentPart{types.NewTextPart("Read this aloud")},
+		}},
+	}
+
+	result := provider.buildToolRequest(req, nil, "")
+
+	mods, ok := result["modalities"].([]string)
+	if !ok {
+		t.Fatalf("modalities missing or wrong type: %T %v", result["modalities"], result["modalities"])
+	}
+	hasAudio := false
+	for _, m := range mods {
+		if m == "audio" {
+			hasAudio = true
+		}
+	}
+	if !hasAudio {
+		t.Errorf("modalities = %v, should contain 'audio' on text-only input when configured", mods)
+	}
+	if _, ok := result["audio"].(map[string]interface{}); !ok {
+		t.Error("audio output config missing on text-only input when modalities configured")
+	}
+}
+
 // TestPredictStreamWithTools_AudioFormat_PCM16 verifies that the tools streaming
 // path overrides buildToolRequest's default "wav" audio format to "pcm16", which
 // is required by OpenAI when stream=true.


### PR DESCRIPTION
## Summary

Closes #1066.

The OpenAI provider only forwarded the configured audio output modalities to the request body when the input message already contained audio. The `requestContainsAudio(&req)` guard at `openai_tools.go:260` and `openai.go:329` silently dropped the user's explicit `modalities: ["text", "audio"]` on text-only prompts, and OpenAI rejected with HTTP 400 — text-in / audio-out (TTS-style use of `gpt-4o-audio-preview`) was effectively unusable.

## Fix

New `hasAudioOutputConfigured` helper checks whether `additional_config` opts into audio output. Both call sites OR it with the legacy `requestContainsAudio` clause. Behavior matrix:

| Input | Config | Before | After |
|---|---|---|---|
| audio | none | modalities forwarded | unchanged |
| text only | none | no modalities key | unchanged |
| text only | `["text", "audio"]` | silently dropped → 400 | modalities + audio block emitted ✅ |

## Test plan

- [x] `TestPredict_AudioModel_TextInputAudioOutputConfig` — the regression
- [x] `TestPredict_AudioModel_TextInputNoModalitiesConfig` — pins default-off
- [x] `TestBuildToolRequest_AudioModalities_TextInput` — tools-path variant
- [x] `TestHasAudioOutputConfigured` — helper unit table
- [x] All existing `TestPredict_AudioModel_*` and `TestApplyAudioModalities` tests still pass
- [x] Coverage on touched files: openai.go 91.5%, openai_tools.go 86.1% (≥80%)
