### PR TITLE
fix(arena): preserve file path on input audio/video + render data fallback (#1065)

### DIFF
--- a/tools/arena/render/media.go
+++ b/tools/arena/render/media.go
@@ -212,34 +212,53 @@ func renderMessageWithMedia(msg types.Message) string {
 		html.WriteString(fmt.Sprintf("<div class='message-text'>%s</div>", renderedContent))
 	}
 
-	// Render inline images directly from Parts (to get actual image data)
+	// Render inline images and inline-only audio directly from Parts —
+	// these need access to the raw Media (image bytes / data URLs) the
+	// summary form doesn't carry.
+	inlineDataAudioIdx := make(map[int]bool)
 	if len(msg.Parts) > 0 {
-		for _, part := range msg.Parts {
-			if part.Type == types.ContentTypeImage && part.Media != nil {
+		for i, part := range msg.Parts {
+			if part.Media == nil {
+				continue
+			}
+			switch part.Type {
+			case types.ContentTypeImage:
 				html.WriteString(renderInlineImage(part))
+			case types.ContentTypeAudio:
+				if isInlineDataOnly(part.Media) {
+					html.WriteString(renderInlineAudio(part))
+					inlineDataAudioIdx[i] = true
+				}
 			}
 		}
 	}
 
-	// Render other media items (audio, video) with metadata cards
+	// Render other media items (audio with a real source, video) with
+	// metadata cards. Inline-data audio handled above is skipped to
+	// avoid double-rendering.
 	var mediaSummary *types.MediaSummary
 	if len(msg.Parts) > 0 {
 		mediaSummary = getMediaSummaryFromParts(msg.Parts)
 	}
 	if mediaSummary != nil && len(mediaSummary.MediaItems) > 0 {
-		// Check if there are any non-image media items
-		hasNonImageMedia := false
-		for _, item := range mediaSummary.MediaItems {
-			if item.Type != types.ContentTypeImage {
-				hasNonImageMedia = true
-				break
+		hasOtherMedia := false
+		for i, item := range mediaSummary.MediaItems {
+			if item.Type == types.ContentTypeImage {
+				continue
 			}
+			if item.Type == types.ContentTypeAudio && inlineDataAudioIdx[i] {
+				continue
+			}
+			hasOtherMedia = true
+			break
 		}
-		if hasNonImageMedia {
+		if hasOtherMedia {
 			html.WriteString("<div class='media-items'>")
-			for _, item := range mediaSummary.MediaItems {
-				// Skip images - they're rendered inline above
+			for i, item := range mediaSummary.MediaItems {
 				if item.Type == types.ContentTypeImage {
+					continue
+				}
+				if item.Type == types.ContentTypeAudio && inlineDataAudioIdx[i] {
 					continue
 				}
 				html.WriteString(renderMediaItem(item))
@@ -317,6 +336,61 @@ func renderInlineImage(part types.ContentPart) string {
 			sizeStr,
 		)
 	}
+}
+
+// isInlineDataOnly reports whether the media content has inline base64
+// Data set but no playable/resolvable source (no FilePath, URL, or
+// StorageReference). The audio/video renderer uses this to fall back
+// to a `data:` URL instead of the unhelpful "inline data" placeholder.
+func isInlineDataOnly(media *types.MediaContent) bool {
+	if media == nil || media.Data == nil || *media.Data == "" {
+		return false
+	}
+	if media.FilePath != nil && *media.FilePath != "" {
+		return false
+	}
+	if media.URL != nil && *media.URL != "" {
+		return false
+	}
+	if media.StorageReference != nil && *media.StorageReference != "" {
+		return false
+	}
+	return true
+}
+
+// renderInlineAudio emits a playable HTML5 audio element backed by an
+// inline base64 data URL. Used when an audio part has only Media.Data
+// (no FilePath/URL/StorageReference) — without this, such parts fell
+// through to the "inline data" string label and were unplayable.
+//
+// The audio is embedded directly in the HTML rather than externalized.
+// For the typical user-input audio case this is fine; very large
+// payloads should be externalized upstream by MediaExternalizerStage.
+func renderInlineAudio(part types.ContentPart) string {
+	if part.Media == nil || part.Media.Data == nil || *part.Media.Data == "" {
+		return ""
+	}
+	mimeType := part.Media.MIMEType
+	if mimeType == "" {
+		mimeType = "audio/wav"
+	}
+	// Browsers can't play raw PCM via <audio>; render the same
+	// "(raw PCM - not directly playable)" hint as the file-backed path.
+	if getPlayableAudioMIME("", mimeType) == "" {
+		return `<div class="audio-not-playable">(raw PCM - not directly playable)</div>`
+	}
+	return fmt.Sprintf(`
+        <div class="audio-player">
+            <audio controls preload="metadata">
+                <source src="data:%s;base64,%s" type="%s">
+                Your browser does not support audio playback.
+            </audio>
+        </div>
+    `,
+		template.HTMLEscapeString(mimeType),
+		template.HTMLEscapeString(*part.Media.Data),
+		template.HTMLEscapeString(mimeType),
+	)
 }
 
 // getMediaSummaryFromParts generates a MediaSummary from ContentParts.

--- a/tools/arena/render/media_test.go
+++ b/tools/arena/render/media_test.go
@@ -654,6 +654,138 @@ func TestRenderInlineImage(t *testing.T) {
 	}
 }
 
+func TestIsInlineDataOnly(t *testing.T) {
+	tests := []struct {
+		name  string
+		media *types.MediaContent
+		want  bool
+	}{
+		{"nil media", nil, false},
+		{"no data", &types.MediaContent{MIMEType: "audio/wav"}, false},
+		{
+			"data only — true",
+			&types.MediaContent{MIMEType: "audio/wav", Data: testutil.Ptr("AAA")},
+			true,
+		},
+		{
+			"data + filepath — false",
+			&types.MediaContent{
+				MIMEType: "audio/wav",
+				Data:     testutil.Ptr("AAA"),
+				FilePath: testutil.Ptr("/tmp/foo.wav"),
+			},
+			false,
+		},
+		{
+			"data + url — false",
+			&types.MediaContent{
+				MIMEType: "audio/wav",
+				Data:     testutil.Ptr("AAA"),
+				URL:      testutil.Ptr("https://example.com/foo.wav"),
+			},
+			false,
+		},
+		{
+			"data + storage ref — false",
+			&types.MediaContent{
+				MIMEType:         "audio/wav",
+				Data:             testutil.Ptr("AAA"),
+				StorageReference: testutil.Ptr("out/media/run-1/abc.wav"),
+			},
+			false,
+		},
+		{
+			"empty data string — false",
+			&types.MediaContent{MIMEType: "audio/wav", Data: testutil.Ptr("")},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInlineDataOnly(tt.media); got != tt.want {
+				t.Errorf("isInlineDataOnly() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderInlineAudio(t *testing.T) {
+	tests := []struct {
+		name    string
+		part    types.ContentPart
+		want    []string
+		wantNot []string
+	}{
+		{
+			// Inline-data audio must render as a playable <audio> with
+			// a base64 data: URL — without this fix the user-input
+			// audio fell through to the "inline data" placeholder and
+			// nothing actually played in the report.
+			name: "wav with inline base64 renders <audio> with data URL",
+			part: types.ContentPart{
+				Type: types.ContentTypeAudio,
+				Media: &types.MediaContent{
+					MIMEType: "audio/wav",
+					Data:     testutil.Ptr("AAAA"),
+				},
+			},
+			want:    []string{"<audio", `<source src="data:audio/wav;base64,AAAA" type="audio/wav"`, "audio-player"},
+			wantNot: []string{"inline data", "audio-not-playable"},
+		},
+		{
+			name: "missing mime type defaults to audio/wav",
+			part: types.ContentPart{
+				Type:  types.ContentTypeAudio,
+				Media: &types.MediaContent{Data: testutil.Ptr("AAAA")},
+			},
+			want:    []string{"audio/wav"},
+			wantNot: []string{"inline data"},
+		},
+		{
+			// Raw PCM is not playable in browsers — same behavior as
+			// the file-backed renderer's "(raw PCM ...)" hint.
+			name: "raw pcm renders not-playable hint",
+			part: types.ContentPart{
+				Type: types.ContentTypeAudio,
+				Media: &types.MediaContent{
+					MIMEType: "audio/pcm",
+					Data:     testutil.Ptr("AAAA"),
+				},
+			},
+			want:    []string{"audio-not-playable", "raw PCM"},
+			wantNot: []string{"<audio"},
+		},
+		{
+			name: "nil media returns empty",
+			part: types.ContentPart{Type: types.ContentTypeAudio, Media: nil},
+			want: []string{},
+		},
+		{
+			name: "empty data returns empty",
+			part: types.ContentPart{
+				Type:  types.ContentTypeAudio,
+				Media: &types.MediaContent{MIMEType: "audio/wav", Data: testutil.Ptr("")},
+			},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderInlineAudio(tt.part)
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("renderInlineAudio() missing %q\nGot: %s", want, got)
+				}
+			}
+			for _, wantNot := range tt.wantNot {
+				if strings.Contains(got, wantNot) {
+					t.Errorf("renderInlineAudio() unexpectedly contains %q\nGot: %s", wantNot, got)
+				}
+			}
+		})
+	}
+}
+
 func TestReportRelativeMediaPath(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tools/arena/turnexecutors/media_loader.go
+++ b/tools/arena/turnexecutors/media_loader.go
@@ -356,6 +356,10 @@ func loadAudioFromFile(filePath, baseDir string, index int) (types.ContentPart, 
 	// renderer handles WAV wrapping for browser playback independently
 	// via the recording/externalization path.
 	part := types.NewAudioPartFromData(data, mimeType)
+	// Preserve original file path for the HTML report so the rendered
+	// <audio> tag can resolve to the file on disk instead of falling
+	// back to the "inline data" placeholder. Mirrors loadImageFromFile.
+	part.Media.FilePath = &filePath
 	return part, nil
 }
 
@@ -368,7 +372,10 @@ func loadVideoFromFile(filePath, baseDir string, index int) (types.ContentPart, 
 		return types.ContentPart{}, err
 	}
 
-	return types.NewVideoPartFromData(data, mimeType), nil
+	part := types.NewVideoPartFromData(data, mimeType)
+	// Preserve original file path for the HTML report — see loadAudioFromFile.
+	part.Media.FilePath = &filePath
+	return part, nil
 }
 
 // convertDocumentPart converts a document content part, loading from storage reference, file, or URL if needed

--- a/tools/arena/turnexecutors/media_loader_coverage_test.go
+++ b/tools/arena/turnexecutors/media_loader_coverage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func newLocalServer(t *testing.T, handler http.Handler) *httptest.Server {
@@ -461,6 +462,11 @@ func TestLoadAudioFromFile_Success(t *testing.T) {
 	assert.Equal(t, types.ContentTypeAudio, part.Type)
 	assert.NotNil(t, part.Media)
 	assert.Equal(t, types.MIMETypeAudioWAV, part.Media.MIMEType)
+	// FilePath must be preserved alongside Data so the HTML report
+	// can resolve the audio source instead of falling through to
+	// the "inline data" placeholder. Regression for #1065.
+	require.NotNil(t, part.Media.FilePath)
+	assert.Equal(t, "audio.wav", *part.Media.FilePath)
 }
 
 func TestLoadAudioFromFile_FileNotFound(t *testing.T) {
@@ -484,6 +490,9 @@ func TestLoadVideoFromFile_Success(t *testing.T) {
 	assert.Equal(t, types.ContentTypeVideo, part.Type)
 	assert.NotNil(t, part.Media)
 	assert.Equal(t, types.MIMETypeVideoWebM, part.Media.MIMEType)
+	// FilePath preserved — see TestLoadAudioFromFile_Success.
+	require.NotNil(t, part.Media.FilePath)
+	assert.Equal(t, "video.webm", *part.Media.FilePath)
 }
 
 func TestLoadVideoFromFile_FileNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1065.

When a scenario sent a media part with `file_path:`, the report rendered audio inputs as `<source src="inline data">` — unplayable. Two adjacent gaps lined up:

1. **Loaders dropped `FilePath`.** `loadAudioFromFile` and `loadVideoFromFile` constructed parts via `NewAudioPartFromData` / `NewVideoPartFromData` and never set `Media.FilePath`. The image and document loaders did set it; audio/video were the outliers.
2. **No render fallback for inline-only data.** When a part had only `Media.Data`, the summary path emitted the literal string `"inline data"` as the audio source — there was no inline-audio counterpart to `renderInlineImage`.

## What changed

- `loadAudioFromFile` and `loadVideoFromFile` now set `Media.FilePath` alongside `Media.Data`, mirroring the image/document loaders.
- New `renderInlineAudio` emits a playable `<audio>` with a base64 `data:` URL, used as a fallback in `renderMessageWithMedia` when an audio part has only `Data`. Raw PCM still renders the "(raw PCM - not directly playable)" hint.
- New `isInlineDataOnly` predicate keeps the fallback condition local. The media-items loop skips audio parts handled by the new inline path so nothing double-renders.

## Test plan

- [x] `TestLoadAudioFromFile_Success` extended — asserts `FilePath` is preserved
- [x] `TestLoadVideoFromFile_Success` extended — same
- [x] `TestIsInlineDataOnly` — table coverage for the four source-source combinations
- [x] `TestRenderInlineAudio` — wav with data → `<audio>` with data URL; raw PCM hint; nil/empty edge cases
- [x] All pre-existing render + turnexecutor tests still pass
- [x] Coverage on touched files: render/media.go 88.6%, turnexecutors/media_loader.go 90.3% (≥80%)
