### PR TITLE
feat(storage): instrument MediaStorageService with events + OTel spans (#1063)

### DIFF
--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -122,6 +122,17 @@ const (
 	EventTemplateRendered EventType = "prompt.template.rendered"
 	// EventTemplateFailed marks a template rendering failure.
 	EventTemplateFailed EventType = "prompt.template.failed"
+
+	// EventMediaStored marks media bytes written to a MediaStorageService.
+	EventMediaStored EventType = "media.stored"
+	// EventMediaRetrieved marks media bytes read from a MediaStorageService.
+	EventMediaRetrieved EventType = "media.retrieved"
+	// EventMediaDeleted marks media bytes removed from a MediaStorageService
+	// (either explicitly or as a side effect of a retention policy).
+	EventMediaDeleted EventType = "media.deleted"
+	// EventMediaStoreError marks any failure on the four MediaStorageService
+	// operations (Store / Retrieve / Delete / GetURL).
+	EventMediaStoreError EventType = "media.store_error"
 )
 
 // EventData is a marker interface for event payloads.
@@ -368,6 +379,29 @@ type CustomEventData struct {
 	EventName      string
 	Data           map[string]interface{}
 	Message        string
+}
+
+// MediaStorageEventData is the unified payload for all four
+// MediaStorageService lifecycle events (stored, retrieved, deleted,
+// store_error). Fields like SizeBytes/Reason/Error are zero-valued
+// when not applicable to the current operation.
+//
+// `Operation` distinguishes the call (`store` / `retrieve` / `delete` /
+// `get_url`) so a single subscription can sort errors by op without
+// branching on event type.
+type MediaStorageEventData struct {
+	baseEventData
+	Operation  string        // "store" | "retrieve" | "delete" | "get_url"
+	Backend    string        // "local", "s3", etc. — set by the wrapper from the inner type
+	Reference  string        // storage reference (path or backend-specific)
+	MIMEType   string        // set on store/retrieve when known
+	SizeBytes  int64         // set on store/retrieve when known
+	Duration   time.Duration // wall-clock latency of the operation
+	Reason     string        // set on delete: "explicit" | "policy:<name>"
+	Error      error         // set on store_error
+	RunID      string        // from MediaMetadata when available
+	MessageIdx int           // from MediaMetadata
+	PartIdx    int           // from MediaMetadata
 }
 
 // MessageToolCall represents a tool call in a message event (mirrors runtime/types.MessageToolCall).

--- a/runtime/storage/instrumented.go
+++ b/runtime/storage/instrumented.go
@@ -1,0 +1,299 @@
+// Package storage exposes the MediaStorageService interface for media
+// persistence, plus instrumentation that wires storage operations into
+// the runtime's event bus and OpenTelemetry spans.
+package storage
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// instrumentationTracerName is the OTel tracer name used for media storage spans.
+const instrumentationTracerName = "github.com/AltairaLabs/PromptKit/runtime/storage"
+
+// InstrumentedStorage wraps any MediaStorageService with telemetry —
+// OTel spans on every call, runtime events on success/failure, and
+// (when wired in by the consumer) bytes/latency/error metrics derived
+// from the emitted events.
+//
+// The wrapper is nil-safe at every level: a nil bus or nil inner is a
+// hard error, but missing fields on MediaMetadata never panic.
+//
+// Backend identification (`local`, `s3`, ...) is supplied by the
+// caller at construction time so the same wrapper works regardless of
+// the concrete inner implementation.
+type InstrumentedStorage struct {
+	inner   MediaStorageService
+	tracer  trace.Tracer
+	backend string
+
+	busMu sync.RWMutex
+	bus   events.Bus
+}
+
+// NewInstrumentedStorage wraps inner so every call publishes a media
+// lifecycle event to bus and records an OTel span. backend names the
+// concrete implementation (e.g. "local", "s3") and ends up on every
+// emitted event and span.
+//
+// Passing a nil inner returns nil — the wrapper has nothing to wrap.
+// A nil bus is allowed (events become no-ops); spans still emit via
+// the global tracer provider.
+func NewInstrumentedStorage(inner MediaStorageService, bus events.Bus, backend string) *InstrumentedStorage {
+	if inner == nil {
+		return nil
+	}
+	return &InstrumentedStorage{
+		inner:   inner,
+		bus:     bus,
+		tracer:  otel.Tracer(instrumentationTracerName),
+		backend: backend,
+	}
+}
+
+// SetBus swaps the event bus the wrapper publishes to. Arena
+// constructs the storage before the runtime event bus exists, then
+// late-binds it via this method once the bus is wired up. Safe to
+// call once before the wrapper sees any traffic; safe to call
+// concurrently with operations because the bus pointer is guarded by
+// busMu.
+func (s *InstrumentedStorage) SetBus(bus events.Bus) {
+	if s == nil {
+		return
+	}
+	s.busMu.Lock()
+	defer s.busMu.Unlock()
+	s.bus = bus
+}
+
+func (s *InstrumentedStorage) currentBus() events.Bus {
+	s.busMu.RLock()
+	defer s.busMu.RUnlock()
+	return s.bus
+}
+
+// Inner returns the wrapped MediaStorageService — useful for callers
+// that need to type-assert to a backend-specific interface.
+func (s *InstrumentedStorage) Inner() MediaStorageService {
+	if s == nil {
+		return nil
+	}
+	return s.inner
+}
+
+// StoreMedia traces, times, and announces a store operation.
+func (s *InstrumentedStorage) StoreMedia(
+	ctx context.Context, content *types.MediaContent, metadata *MediaMetadata,
+) (Reference, error) {
+	ctx, span := s.startSpan(ctx, "media.store", metadata)
+	defer span.End()
+
+	start := time.Now()
+	ref, err := s.inner.StoreMedia(ctx, content, metadata)
+	dur := time.Since(start)
+
+	mime := mimeFromContent(content)
+	size := sizeFromMetadata(metadata)
+	span.SetAttributes(
+		attribute.String("media.mime_type", mime),
+		attribute.Int64("media.size_bytes", size),
+	)
+
+	if err != nil {
+		s.recordFailure(span, "store", string(ref), mime, dur, metadata, err)
+		return ref, err
+	}
+
+	span.SetAttributes(attribute.String("media.reference", string(ref)))
+	s.publish(events.EventMediaStored, &events.MediaStorageEventData{
+		Operation:  "store",
+		Backend:    s.backend,
+		Reference:  string(ref),
+		MIMEType:   mime,
+		SizeBytes:  size,
+		Duration:   dur,
+		RunID:      metadataRunID(metadata),
+		MessageIdx: metadataMessageIdx(metadata),
+		PartIdx:    metadataPartIdx(metadata),
+	}, metadata)
+	return ref, nil
+}
+
+// RetrieveMedia traces, times, and announces a retrieve operation.
+func (s *InstrumentedStorage) RetrieveMedia(
+	ctx context.Context, reference Reference,
+) (*types.MediaContent, error) {
+	ctx, span := s.startSpan(ctx, "media.retrieve", nil)
+	defer span.End()
+	span.SetAttributes(attribute.String("media.reference", string(reference)))
+
+	start := time.Now()
+	content, err := s.inner.RetrieveMedia(ctx, reference)
+	dur := time.Since(start)
+
+	mime := mimeFromContent(content)
+	if err != nil {
+		s.recordFailure(span, "retrieve", string(reference), mime, dur, nil, err)
+		return content, err
+	}
+
+	span.SetAttributes(attribute.String("media.mime_type", mime))
+	s.publish(events.EventMediaRetrieved, &events.MediaStorageEventData{
+		Operation: "retrieve",
+		Backend:   s.backend,
+		Reference: string(reference),
+		MIMEType:  mime,
+		Duration:  dur,
+	}, nil)
+	return content, nil
+}
+
+// DeleteMedia traces, times, and announces a delete operation.
+func (s *InstrumentedStorage) DeleteMedia(ctx context.Context, reference Reference) error {
+	ctx, span := s.startSpan(ctx, "media.delete", nil)
+	defer span.End()
+	span.SetAttributes(attribute.String("media.reference", string(reference)))
+
+	start := time.Now()
+	err := s.inner.DeleteMedia(ctx, reference)
+	dur := time.Since(start)
+
+	if err != nil {
+		s.recordFailure(span, "delete", string(reference), "", dur, nil, err)
+		return err
+	}
+
+	s.publish(events.EventMediaDeleted, &events.MediaStorageEventData{
+		Operation: "delete",
+		Backend:   s.backend,
+		Reference: string(reference),
+		Duration:  dur,
+		Reason:    "explicit",
+	}, nil)
+	return nil
+}
+
+// GetURL traces and times URL generation. No success event is emitted
+// — URL generation is a metadata operation that doesn't move bytes —
+// but failures still publish an error event so opaque 404s are visible.
+func (s *InstrumentedStorage) GetURL(
+	ctx context.Context, reference Reference, expiry time.Duration,
+) (string, error) {
+	ctx, span := s.startSpan(ctx, "media.get_url", nil)
+	defer span.End()
+	span.SetAttributes(attribute.String("media.reference", string(reference)))
+
+	start := time.Now()
+	url, err := s.inner.GetURL(ctx, reference, expiry)
+	dur := time.Since(start)
+
+	if err != nil {
+		s.recordFailure(span, "get_url", string(reference), "", dur, nil, err)
+		return url, err
+	}
+	return url, nil
+}
+
+func (s *InstrumentedStorage) startSpan(
+	ctx context.Context, name string, metadata *MediaMetadata,
+) (context.Context, trace.Span) {
+	ctx, span := s.tracer.Start(ctx, name)
+	span.SetAttributes(attribute.String("media.backend", s.backend))
+	if runID := metadataRunID(metadata); runID != "" {
+		span.SetAttributes(attribute.String("media.run_id", runID))
+	}
+	return ctx, span
+}
+
+func (s *InstrumentedStorage) recordFailure(
+	span trace.Span, op, ref, mime string, dur time.Duration,
+	metadata *MediaMetadata, err error,
+) {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	s.publish(events.EventMediaStoreError, &events.MediaStorageEventData{
+		Operation:  op,
+		Backend:    s.backend,
+		Reference:  ref,
+		MIMEType:   mime,
+		Duration:   dur,
+		Error:      err,
+		RunID:      metadataRunID(metadata),
+		MessageIdx: metadataMessageIdx(metadata),
+		PartIdx:    metadataPartIdx(metadata),
+	}, metadata)
+}
+
+func (s *InstrumentedStorage) publish(
+	eventType events.EventType, data *events.MediaStorageEventData, metadata *MediaMetadata,
+) {
+	bus := s.currentBus()
+	if bus == nil {
+		return
+	}
+	bus.Publish(&events.Event{
+		Type:           eventType,
+		Timestamp:      time.Now(),
+		ConversationID: metadataConversationID(metadata),
+		SessionID:      metadataSessionID(metadata),
+		Data:           data,
+	})
+}
+
+func mimeFromContent(content *types.MediaContent) string {
+	if content == nil {
+		return ""
+	}
+	return content.MIMEType
+}
+
+func sizeFromMetadata(metadata *MediaMetadata) int64 {
+	if metadata == nil {
+		return 0
+	}
+	return metadata.SizeBytes
+}
+
+func metadataRunID(metadata *MediaMetadata) string {
+	if metadata == nil {
+		return ""
+	}
+	return metadata.RunID
+}
+
+func metadataConversationID(metadata *MediaMetadata) string {
+	if metadata == nil {
+		return ""
+	}
+	return metadata.ConversationID
+}
+
+func metadataSessionID(metadata *MediaMetadata) string {
+	if metadata == nil {
+		return ""
+	}
+	return metadata.SessionID
+}
+
+func metadataMessageIdx(metadata *MediaMetadata) int {
+	if metadata == nil {
+		return 0
+	}
+	return metadata.MessageIdx
+}
+
+func metadataPartIdx(metadata *MediaMetadata) int {
+	if metadata == nil {
+		return 0
+	}
+	return metadata.PartIdx
+}

--- a/runtime/storage/instrumented_test.go
+++ b/runtime/storage/instrumented_test.go
@@ -1,0 +1,252 @@
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingBus drains every Publish into a slice. Lets tests assert on
+// the exact set of events the InstrumentedStorage emitted, without
+// needing the full async EventBus machinery.
+type recordingBus struct {
+	mu     sync.Mutex
+	events []*events.Event
+}
+
+func (b *recordingBus) Publish(e *events.Event) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = append(b.events, e)
+	return true
+}
+
+func (b *recordingBus) Subscribe(_ events.EventType, _ events.Listener) func() {
+	return func() {}
+}
+
+func (b *recordingBus) SubscribeAll(_ events.Listener) func() {
+	return func() {}
+}
+
+func (b *recordingBus) Close() {}
+
+func (b *recordingBus) snapshot() []*events.Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]*events.Event, len(b.events))
+	copy(out, b.events)
+	return out
+}
+
+// fakeStorage is a programmable MediaStorageService for the wrapper
+// tests — no disk, no network, just controllable success/failure.
+type fakeStorage struct {
+	storeRef     string
+	storeErr     error
+	retrieveResp *types.MediaContent
+	retrieveErr  error
+	deleteErr    error
+	urlResp      string
+	urlErr       error
+	calls        []string
+}
+
+func (f *fakeStorage) StoreMedia(_ context.Context, _ *types.MediaContent, _ *storage.MediaMetadata) (storage.Reference, error) {
+	f.calls = append(f.calls, "store")
+	return storage.Reference(f.storeRef), f.storeErr
+}
+
+func (f *fakeStorage) RetrieveMedia(_ context.Context, _ storage.Reference) (*types.MediaContent, error) {
+	f.calls = append(f.calls, "retrieve")
+	return f.retrieveResp, f.retrieveErr
+}
+
+func (f *fakeStorage) DeleteMedia(_ context.Context, _ storage.Reference) error {
+	f.calls = append(f.calls, "delete")
+	return f.deleteErr
+}
+
+func (f *fakeStorage) GetURL(_ context.Context, _ storage.Reference, _ time.Duration) (string, error) {
+	f.calls = append(f.calls, "get_url")
+	return f.urlResp, f.urlErr
+}
+
+func TestNewInstrumentedStorage_NilInner(t *testing.T) {
+	got := storage.NewInstrumentedStorage(nil, nil, "local")
+	assert.Nil(t, got, "nil inner should yield nil wrapper — caller can detect misuse early")
+}
+
+func TestInstrumentedStorage_StoreEmitsEvent(t *testing.T) {
+	inner := &fakeStorage{storeRef: "out/media/run-1/abc.png"}
+	bus := &recordingBus{}
+	s := storage.NewInstrumentedStorage(inner, bus, "local")
+
+	ref, err := s.StoreMedia(context.Background(), &types.MediaContent{MIMEType: "image/png"},
+		&storage.MediaMetadata{
+			RunID:          "run-1",
+			ConversationID: "conv-1",
+			SessionID:      "sess-1",
+			MIMEType:       "image/png",
+			SizeBytes:      1024,
+			MessageIdx:     2,
+			PartIdx:        0,
+		})
+	require.NoError(t, err)
+	assert.Equal(t, storage.Reference("out/media/run-1/abc.png"), ref)
+	assert.Equal(t, []string{"store"}, inner.calls)
+
+	evs := bus.snapshot()
+	require.Len(t, evs, 1)
+	assert.Equal(t, events.EventMediaStored, evs[0].Type)
+	assert.Equal(t, "conv-1", evs[0].ConversationID)
+	assert.Equal(t, "sess-1", evs[0].SessionID)
+
+	data, ok := evs[0].Data.(*events.MediaStorageEventData)
+	require.True(t, ok, "event data should be *MediaStorageEventData")
+	assert.Equal(t, "store", data.Operation)
+	assert.Equal(t, "local", data.Backend)
+	assert.Equal(t, "out/media/run-1/abc.png", data.Reference)
+	assert.Equal(t, "image/png", data.MIMEType)
+	assert.Equal(t, int64(1024), data.SizeBytes)
+	assert.Equal(t, "run-1", data.RunID)
+	assert.Equal(t, 2, data.MessageIdx)
+	assert.Greater(t, data.Duration, time.Duration(0))
+}
+
+func TestInstrumentedStorage_StoreErrorEmitsErrorEvent(t *testing.T) {
+	storeErr := errors.New("disk full")
+	inner := &fakeStorage{storeErr: storeErr}
+	bus := &recordingBus{}
+	s := storage.NewInstrumentedStorage(inner, bus, "local")
+
+	_, err := s.StoreMedia(context.Background(), &types.MediaContent{MIMEType: "image/png"},
+		&storage.MediaMetadata{RunID: "run-1", MIMEType: "image/png"})
+	assert.ErrorIs(t, err, storeErr)
+
+	evs := bus.snapshot()
+	require.Len(t, evs, 1)
+	assert.Equal(t, events.EventMediaStoreError, evs[0].Type)
+	data := evs[0].Data.(*events.MediaStorageEventData)
+	assert.Equal(t, "store", data.Operation)
+	assert.ErrorIs(t, data.Error, storeErr)
+}
+
+func TestInstrumentedStorage_RetrieveEmitsEvent(t *testing.T) {
+	inner := &fakeStorage{retrieveResp: &types.MediaContent{MIMEType: "audio/wav"}}
+	bus := &recordingBus{}
+	s := storage.NewInstrumentedStorage(inner, bus, "local")
+
+	got, err := s.RetrieveMedia(context.Background(), "out/media/abc.wav")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	evs := bus.snapshot()
+	require.Len(t, evs, 1)
+	assert.Equal(t, events.EventMediaRetrieved, evs[0].Type)
+	data := evs[0].Data.(*events.MediaStorageEventData)
+	assert.Equal(t, "retrieve", data.Operation)
+	assert.Equal(t, "audio/wav", data.MIMEType)
+	assert.Equal(t, "out/media/abc.wav", data.Reference)
+}
+
+func TestInstrumentedStorage_RetrieveErrorEmitsErrorEvent(t *testing.T) {
+	retrieveErr := errors.New("not found")
+	inner := &fakeStorage{retrieveErr: retrieveErr}
+	bus := &recordingBus{}
+	s := storage.NewInstrumentedStorage(inner, bus, "local")
+
+	_, err := s.RetrieveMedia(context.Background(), "missing")
+	assert.ErrorIs(t, err, retrieveErr)
+
+	evs := bus.snapshot()
+	require.Len(t, evs, 1)
+	assert.Equal(t, events.EventMediaStoreError, evs[0].Type)
+	assert.Equal(t, "retrieve", evs[0].Data.(*events.MediaStorageEventData).Operation)
+}
+
+func TestInstrumentedStorage_DeleteEmitsExplicitEvent(t *testing.T) {
+	inner := &fakeStorage{}
+	bus := &recordingBus{}
+	s := storage.NewInstrumentedStorage(inner, bus, "local")
+
+	require.NoError(t, s.DeleteMedia(context.Background(), "out/media/abc.png"))
+
+	evs := bus.snapshot()
+	require.Len(t, evs, 1)
+	assert.Equal(t, events.EventMediaDeleted, evs[0].Type)
+	data := evs[0].Data.(*events.MediaStorageEventData)
+	assert.Equal(t, "delete", data.Operation)
+	assert.Equal(t, "explicit", data.Reason)
+}
+
+func TestInstrumentedStorage_GetURLEmitsErrorOnFailure(t *testing.T) {
+	urlErr := errors.New("not accessible")
+	inner := &fakeStorage{urlErr: urlErr}
+	bus := &recordingBus{}
+	s := storage.NewInstrumentedStorage(inner, bus, "local")
+
+	// Success: no event published — URL generation doesn't move bytes.
+	innerOK := &fakeStorage{urlResp: "file:///tmp/abc.png"}
+	busOK := &recordingBus{}
+	sOK := storage.NewInstrumentedStorage(innerOK, busOK, "local")
+	url, err := sOK.GetURL(context.Background(), "out/media/abc.png", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "file:///tmp/abc.png", url)
+	assert.Empty(t, busOK.snapshot(), "successful GetURL should not emit an event")
+
+	// Failure: error event published.
+	_, err = s.GetURL(context.Background(), "missing", 0)
+	assert.ErrorIs(t, err, urlErr)
+	evs := bus.snapshot()
+	require.Len(t, evs, 1)
+	assert.Equal(t, events.EventMediaStoreError, evs[0].Type)
+	assert.Equal(t, "get_url", evs[0].Data.(*events.MediaStorageEventData).Operation)
+}
+
+func TestInstrumentedStorage_NilBusIsNoOp(t *testing.T) {
+	inner := &fakeStorage{storeRef: "out/media/abc.png"}
+	s := storage.NewInstrumentedStorage(inner, nil, "local")
+
+	// Must not panic when bus is nil — spans still emit via the global
+	// tracer provider, but events become no-ops.
+	_, err := s.StoreMedia(context.Background(), &types.MediaContent{MIMEType: "image/png"},
+		&storage.MediaMetadata{RunID: "run-1"})
+	assert.NoError(t, err)
+}
+
+func TestInstrumentedStorage_NilMetadataDoesNotPanic(t *testing.T) {
+	inner := &fakeStorage{storeRef: "ref"}
+	bus := &recordingBus{}
+	s := storage.NewInstrumentedStorage(inner, bus, "local")
+
+	// Real callers should pass metadata, but the wrapper must tolerate
+	// a nil — events still fire, with empty IDs.
+	_, err := s.StoreMedia(context.Background(), &types.MediaContent{MIMEType: "image/png"}, nil)
+	assert.NoError(t, err)
+
+	evs := bus.snapshot()
+	require.Len(t, evs, 1)
+	data := evs[0].Data.(*events.MediaStorageEventData)
+	assert.Empty(t, data.RunID)
+	assert.Empty(t, evs[0].ConversationID)
+}
+
+func TestInstrumentedStorage_InnerExposesUnderlyingService(t *testing.T) {
+	inner := &fakeStorage{}
+	s := storage.NewInstrumentedStorage(inner, nil, "local")
+	assert.Same(t, inner, s.Inner())
+}
+
+func TestInstrumentedStorage_NilSafeInner(t *testing.T) {
+	var s *storage.InstrumentedStorage
+	assert.Nil(t, s.Inner())
+}

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -313,6 +313,12 @@ func (e *Engine) SetEventBus(bus events.Bus, opts ...EventBusOption) {
 	if e.evalOrchestrator != nil {
 		e.evalOrchestrator.SetEventBus(bus)
 	}
+	// Late-bind the bus on the instrumented media storage so storage
+	// lifecycle events can flow through. Built before the bus exists,
+	// so the wrapper started with a nil bus.
+	if instrumented, ok := e.mediaStorage.(*storage.InstrumentedStorage); ok {
+		instrumented.SetBus(bus)
+	}
 	// Enable RecordingStage so message.created events flow to the bus
 	if cfg.emitMessages {
 		e.EnableMessageEvents()
@@ -620,6 +626,11 @@ func (e *Engine) GetStateStore() statestore.Store {
 // It stores media files in the <output_dir>/media/ subdirectory using run-based organization.
 // This enables automatic externalization of large media content to reduce memory usage and
 // improve performance when processing media-heavy scenarios.
+//
+// The returned service is wrapped with InstrumentedStorage so every
+// store/retrieve/delete emits a runtime event and OTel span. The
+// event bus is bound later via Engine.SetEventBus → SetBus on the
+// wrapper; until then events are no-ops but spans still emit.
 func buildMediaStorage(cfg *config.Config) (storage.MediaStorageService, error) {
 	// Determine the media storage directory
 	outDir := cfg.Defaults.Output.Dir
@@ -640,5 +651,5 @@ func buildMediaStorage(cfg *config.Config) (storage.MediaStorageService, error) 
 		return nil, fmt.Errorf("failed to create media file store: %w", err)
 	}
 
-	return fileStore, nil
+	return storage.NewInstrumentedStorage(fileStore, nil, "local"), nil
 }


### PR DESCRIPTION
## Summary

Closes #1063 (events + spans). Metrics deferred — the metrics package can subscribe to the new event types without any storage-side changes.

The `MediaStorageService` had no observability: no events on Store/Retrieve/Delete/GetURL, no OTel spans, no way to answer "how much storage did this run burn", "is the write path the bottleneck", or "did anything fail". Fine while almost nothing used the service, but PR #1064 puts every assistant-generated image/audio/video through `StoreMedia` on the hot path of every turn.

## What's in

- **Four new event types** in `runtime/events`: `EventMediaStored`, `EventMediaRetrieved`, `EventMediaDeleted`, `EventMediaStoreError`. Unified `MediaStorageEventData` payload (operation, backend, reference, MIME, size, duration, conversation/run/message context, error on failures).
- **`runtime/storage.InstrumentedStorage`** — transparent wrapper around any `MediaStorageService` that:
  - starts an OTel span on every call (`media.store`, `.retrieve`, `.delete`, `.get_url`) with backend, reference, MIME, size attributes
  - publishes an event on completion (success or failure) carrying measured latency
  - is nil-safe at every level (nil bus, nil metadata, nil inner all handled)
  - exposes `Inner()` for callers needing backend-specific type assertions
- **Late-binding `SetBus`** so consumers that build storage before the bus exists (arena's `NewEngineFromConfig` pattern) can wire it up later. Bus pointer guarded by `RWMutex` so the late-bind is race-safe.
- **Arena wiring**: `buildMediaStorage` now returns the wrapper unconditionally; `Engine.SetEventBus` pushes the bus into the wrapper. All existing arena flows start emitting media events for free, no per-call site changes.

## Test plan

- [x] `TestNewInstrumentedStorage_NilInner` — wrapper refuses nil inner
- [x] `TestInstrumentedStorage_StoreEmitsEvent` — full store success event with all metadata fields
- [x] `TestInstrumentedStorage_StoreErrorEmitsErrorEvent` — store failure publishes error event
- [x] `TestInstrumentedStorage_RetrieveEmitsEvent` + error variant
- [x] `TestInstrumentedStorage_DeleteEmitsExplicitEvent` — delete event with reason="explicit"
- [x] `TestInstrumentedStorage_GetURLEmitsErrorOnFailure` — success silent, failure published
- [x] `TestInstrumentedStorage_NilBusIsNoOp` + `TestInstrumentedStorage_NilMetadataDoesNotPanic` — nil-safety
- [x] `TestInstrumentedStorage_InnerExposesUnderlyingService` + nil-receiver `Inner()`
- [x] All existing arena engine tests still pass with the wrapper inserted
- [x] Coverage on touched files: events/types.go 100.0%, storage/instrumented.go 92.6%, arena/engine/engine.go 80.4% (≥80%)

## Follow-ups (not blocking this PR)

- Metrics: a small subscriber in `runtime/metrics` can produce `promptkit_media_store_*` counters/histograms from these events without touching the storage layer.
- Arena's audio-output example (#1064) will start producing visible `media.stored` events in TUI/JUnit/recording sinks once this lands — useful smoke check.
