### PR TITLE
docs: braid funnel positioning into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,31 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/AltairaLabs/PromptKit.svg)](https://pkg.go.dev/github.com/AltairaLabs/PromptKit)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-**Test, red-team, and deploy LLM applications with confidence.**
+> **Multi-provider prompt testing and deployment. Test prompts before they fail in production.**
+
+PromptKit is the open-source toolkit for [**PromptPack**](https://github.com/AltairaLabs/promptpack-spec) — test prompts across Claude, OpenAI, Gemini, Azure, and local models, run red-team scenarios in CI, and compile portable packs for runtime. The spec lives upstream so your config isn't locked to a vendor.
+
+## How it fits together
+
+```
+PromptPack  ── open spec for portable prompts (JSON, vendor-neutral)
+    │
+    └── PromptKit  ── this repo
+         ├── promptarena  ── test, red-team, evaluate (CLI)
+         ├── packc        ── compile config → portable pack
+         └── SDK          ── embed in your Go application
+```
+
+## Why PromptKit
+
+| | PromptKit | Promptfoo | LangSmith | Helicone |
+|---|---|---|---|---|
+| Multi-provider testing | ✅ | ✅ | LangChain-only | Observability-only |
+| Built-in workflow orchestration | ✅ | ❌ | Partial | ❌ |
+| Red-team / security scenarios | ✅ | Partial | ❌ | ❌ |
+| MCP integration | ✅ | ❌ | ❌ | ❌ |
+| Spec-driven (portable packs) | ✅ ([PromptPack](https://github.com/AltairaLabs/promptpack-spec)) | ❌ | ❌ | ❌ |
+| License | Apache 2.0 | MIT | Closed | Closed |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ PromptPack  ── open spec for portable prompts (JSON, vendor-neutral)
 ## Install
 
 ```bash
-git clone https://github.com/AltairaLabs/PromptKit.git && cd PromptKit
-make install-tools-user
+npm install -g @altairalabs/promptarena @altairalabs/packc
 ```
+
+Building from source: see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Reframes the README as the open-source toolkit for PromptPack so visitors understand where PromptKit fits in the broader ecosystem before they read further.

- **New tagline** picks ONE hero job (multi-provider prompt testing + deployment) instead of three disconnected jobs (test/red-team/deploy). Discoverable on "prompt testing" and "Promptfoo alternative" search.
- **First-paragraph link to PromptPack** braids the funnel — visitors immediately understand they're looking at the toolkit for the open spec.
- **"How it fits together" tree** solves the naming-soup problem inline (PromptPack / PromptKit / promptarena / packc / SDK in 5 lines).
- **"Why PromptKit" comparison table** vs Promptfoo / LangSmith / Helicone closes the silent "is this another LangSmith?" question that visitors ask before bouncing.

## What's unchanged

- Install instructions
- GIF-driven Quick Start (already converting well)
- GitHub Actions section
- Repository Structure
- Contributing / License sections

## Test plan

- [ ] Visual review of rendered README on the PR page
- [ ] Comparison table renders correctly on GitHub mobile
- [ ] Links to PromptPack repo resolve