### PR TITLE
fix(types): allow MediaContent.Data + FilePath as origin hint

### DIFF
--- a/runtime/types/content.go
+++ b/runtime/types/content.go
@@ -241,25 +241,26 @@ func (cp *ContentPart) Validate() error {
 	return nil
 }
 
-// Validate checks if the MediaContent is valid
+// Validate checks if the MediaContent is valid.
+//
+// At least one of Data, FilePath, or URL must be set. Data + FilePath is
+// permitted: Data is the canonical bytes and FilePath is an origin hint
+// (set by Arena's media loaders so the HTML renderer can resolve the
+// original file). URL is mutually exclusive with Data — a URL refers to
+// an external resource we don't carry inline.
 func (mc *MediaContent) Validate() error {
-	// Exactly one data source must be set
-	sourceCount := 0
-	if mc.Data != nil && *mc.Data != "" {
-		sourceCount++
-	}
-	if mc.FilePath != nil && *mc.FilePath != "" {
-		sourceCount++
-	}
-	if mc.URL != nil && *mc.URL != "" {
-		sourceCount++
-	}
+	hasData := mc.Data != nil && *mc.Data != ""
+	hasFilePath := mc.FilePath != nil && *mc.FilePath != ""
+	hasURL := mc.URL != nil && *mc.URL != ""
 
-	if sourceCount == 0 {
-		return fmt.Errorf("media content must have exactly one data source (data, file_path, or url)")
+	if !hasData && !hasFilePath && !hasURL {
+		return fmt.Errorf("media content must have a data source (data, file_path, or url)")
 	}
-	if sourceCount > 1 {
-		return fmt.Errorf("media content must have exactly one data source, found %d", sourceCount)
+	if hasURL && hasData {
+		return fmt.Errorf("media content cannot have both url and inline data")
+	}
+	if hasURL && hasFilePath {
+		return fmt.Errorf("media content cannot have both url and file_path")
 	}
 
 	// MIME type is required

--- a/runtime/types/content_test.go
+++ b/runtime/types/content_test.go
@@ -226,10 +226,28 @@ func TestMediaContentValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "invalid - multiple data sources",
+			name: "valid - data with file path origin hint",
 			media: MediaContent{
 				Data:     testutil.Ptr("base64data"),
 				FilePath: testutil.Ptr("/path/to/image.jpg"),
+				MIMEType: MIMETypeImageJPEG,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid - url with inline data",
+			media: MediaContent{
+				Data:     testutil.Ptr("base64data"),
+				URL:      testutil.Ptr("https://example.com/image.jpg"),
+				MIMEType: MIMETypeImageJPEG,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid - url with file path",
+			media: MediaContent{
+				FilePath: testutil.Ptr("/path/to/image.jpg"),
+				URL:      testutil.Ptr("https://example.com/image.jpg"),
 				MIMEType: MIMETypeImageJPEG,
 			},
 			wantErr: true,


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #1068 (\`fix(arena): preserve file path on input audio/video + render data fallback\`) two days ago. That PR set \`part.Media.FilePath = &filePath\` in the Arena audio/video media loaders so the HTML report could resolve the original file. But \`MediaContent.Validate()\` rejects "two data sources" — Data plus FilePath — and that validator runs on the externalization path (\`StoreMedia\`).

Result: every Arena duplex example with audio fixtures fails mid-run with:

\`\`\`
ERROR Failed to externalize media error="failed to externalize media at message 0, part 0:
       failed to store media: invalid media content: media content must have exactly one data source, found 2"
\`\`\`

Reproduces on \`examples/duplex-streaming/duplex-basic\` and \`duplex-tools\` with \`--provider mock-duplex\`.

## Fix

Relax \`MediaContent.Validate()\` to accept \`Data + FilePath\`: Data is the canonical bytes, FilePath is an origin hint set by media loaders for HTML rendering. URL is still mutually exclusive with both — URLs reference external resources we don't carry inline.

\`\`\`go
// at least one of Data, FilePath, URL must be set
// Data + FilePath: OK (FilePath is an origin hint)
// URL + Data: still rejected (mutually exclusive)
// URL + FilePath: still rejected (mutually exclusive)
\`\`\`

## Test plan

- [x] Updated \`TestMediaContentValidate\` test cases:
  - "invalid - multiple data sources" → "valid - data with file path origin hint"
  - Added "invalid - url with inline data"
  - Added "invalid - url with file path"
- [x] \`go test ./runtime/types/... -count=1 -race\` passes
- [x] \`go test ./runtime/... ./tools/arena/... -count=1\` — full suite passes
- [x] Manual: \`examples/duplex-streaming/duplex-basic\` with \`mock-duplex\` provider — runs cleanly, recordings contain ~7500 audio events
- [x] Pre-commit hook clean (lint + 80% coverage; \`runtime/types/content.go\` at 95.4%)

## Why now

Discovered while verifying end-to-end behavior of the audio monitoring work in #1077. The audio monitoring stack is structurally complete but no audio frames flow through the pipeline because of this validator failure. With this fix landed, audio frames flow through MonitorTap → AudioRouter → consumers as designed.

## Notes

The bug only affected Arena's HTML-render-friendly file-path-preservation path — \`loadAudioFromFile\` and \`loadVideoFromFile\`. Image loading was already setting both Data and FilePath (per \`loadImageFromFile\`); presumably the image path either doesn't go through StoreMedia or hadn't been exercised against the validator on the same code path.