### PR TITLE
feat(mock): emit audio chunks from PCM fixtures in mock-duplex responses

### DIFF
--- a/examples/duplex-streaming/mock-responses.yaml
+++ b/examples/duplex-streaming/mock-responses.yaml
@@ -7,12 +7,28 @@ defaultResponse: "I'm here to help! How can I assist you today?"
 # Scenario-specific responses
 scenarios:
   # Basic duplex scenario responses
+  # Each turn references a PCM fixture (24kHz mono s16le) so the mock
+  # streaming provider emits real agent audio chunks alongside the text.
+  # This lets mock-duplex runs exercise the full audio output loop in CI
+  # without needing a real provider key.
   duplex-basic:
     defaultResponse: "I'm Nova, your voice assistant. I'm happy to help!"
     turns:
-      1: "Hello! Yes, I can hear you perfectly. I'm Nova, your voice assistant from TechCorp. How can I help you today?"
-      2: "My name is Nova, and I'm here to help you with a variety of tasks. I can answer questions, provide information, help with troubleshooting, or just have a friendly conversation. What would you like to know more about?"
-      3: "Here's a fun fact for you: Honey never spoils! Archaeologists have found 3,000-year-old honey in Egyptian tombs that was still perfectly edible. Pretty amazing, right?"
+      1:
+        text: "Hello! Yes, I can hear you perfectly. I'm Nova, your voice assistant from TechCorp. How can I help you today?"
+        audio_file: audio/greeting.pcm
+        audio_sample_rate: 24000
+        audio_mime_type: "audio/pcm"
+      2:
+        text: "My name is Nova, and I'm here to help you with a variety of tasks. I can answer questions, provide information, help with troubleshooting, or just have a friendly conversation. What would you like to know more about?"
+        audio_file: audio/question.pcm
+        audio_sample_rate: 24000
+        audio_mime_type: "audio/pcm"
+      3:
+        text: "Here's a fun fact for you: Honey never spoils! Archaeologists have found 3,000-year-old honey in Egyptian tombs that was still perfectly edible. Pretty amazing, right?"
+        audio_file: audio/funfact.pcm
+        audio_sample_rate: 24000
+        audio_mime_type: "audio/pcm"
 
   # Scripted-text duplex scenario — exercises the text-only user turn path
   # (Change 1: scenario `tts:` block routes user text content through TTS to

--- a/examples/duplex-streaming/providers/mock-duplex.provider.yaml
+++ b/examples/duplex-streaming/providers/mock-duplex.provider.yaml
@@ -26,3 +26,8 @@ spec:
     # When true, the mock provider emits responses when receiving audio input
     auto_respond: true
     response_text: "Hello! I'm Nova, your AI assistant. How can I help you today?"
+    # Drive auto-respond from the duplex-basic scenario in mock-responses.yaml
+    # so each turn emits its scripted text PLUS the configured audio_file
+    # fixture as MediaData chunks. Without this, auto-respond falls back to
+    # response_text and never produces agent audio.
+    duplex_scenario: duplex-basic

--- a/runtime/providers/mock/mock_repository.go
+++ b/runtime/providers/mock/mock_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -47,6 +48,18 @@ type Turn struct {
 	Content   string        `yaml:"content,omitempty"`    // Text content for the response
 	Parts     []ContentPart `yaml:"parts,omitempty"`      // Multimodal content parts (text, image, audio, video)
 	ToolCalls []ToolCall    `yaml:"tool_calls,omitempty"` // Tool calls to simulate
+
+	// AudioFile is an optional path to a raw PCM audio file (signed 16-bit little-endian, mono).
+	// When set on a duplex auto-respond turn, the mock streaming provider will emit the file's
+	// contents as MediaData chunks alongside the text response. The path is resolved relative
+	// to the directory of the mock-responses.yaml file (when loaded via FileMockRepository).
+	AudioFile string `yaml:"audio_file,omitempty"`
+
+	// AudioSampleRate is the sample rate of the AudioFile in Hz. Defaults to 24000 when zero.
+	AudioSampleRate int `yaml:"audio_sample_rate,omitempty"`
+
+	// AudioMIMEType is the MIME type advertised on emitted audio chunks. Defaults to "audio/pcm".
+	AudioMIMEType string `yaml:"audio_mime_type,omitempty"`
 }
 
 // ContentPart represents a single content part in a multimodal mock response.
@@ -115,7 +128,8 @@ type ScenarioConfig struct {
 // FileMockRepository loads mock responses from a YAML configuration file.
 // This is the default implementation for file-based mock configurations.
 type FileMockRepository struct {
-	config *Config
+	config  *Config
+	baseDir string // Directory containing the mock config file (used to resolve relative fixture paths).
 }
 
 // NewFileMockRepository creates a repository that loads mock responses from a YAML file.
@@ -132,8 +146,16 @@ func NewFileMockRepository(configPath string) (*FileMockRepository, error) {
 	}
 
 	return &FileMockRepository{
-		config: &config,
+		config:  &config,
+		baseDir: filepath.Dir(configPath),
 	}, nil
+}
+
+// BaseDir returns the directory of the mock config file. Relative paths
+// referenced inside the config (e.g. audio_file fixtures) resolve against
+// this directory.
+func (r *FileMockRepository) BaseDir() string {
+	return r.baseDir
 }
 
 // GetResponse retrieves a mock response based on the provided parameters.
@@ -375,6 +397,24 @@ func (r *FileMockRepository) parseStructuredResponse(responseMap map[string]inte
 		if turn.Type == turnTypeText {
 			turn.Type = "tool_calls"
 		}
+	}
+
+	// Parse audio fixture fields (used by mock streaming auto-respond mode).
+	if audioFile, ok := responseMap["audio_file"].(string); ok {
+		turn.AudioFile = audioFile
+	}
+	if rate, ok := responseMap["audio_sample_rate"]; ok {
+		switch v := rate.(type) {
+		case int:
+			turn.AudioSampleRate = v
+		case int64:
+			turn.AudioSampleRate = int(v)
+		case float64:
+			turn.AudioSampleRate = int(v)
+		}
+	}
+	if mime, ok := responseMap["audio_mime_type"].(string); ok {
+		turn.AudioMIMEType = mime
 	}
 
 	return &turn, nil

--- a/runtime/providers/mock/mock_streaming_audio_test.go
+++ b/runtime/providers/mock/mock_streaming_audio_test.go
@@ -1,0 +1,430 @@
+package mock
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// scenarioRepo is a tiny in-memory ResponseRepository that returns Turn
+// values keyed by (scenarioID, turnNumber). It exists only for these tests
+// so we don't need to touch InMemoryMockRepository (which is text-only).
+type scenarioRepo struct {
+	turns map[string]map[int]*Turn
+}
+
+func newScenarioRepo() *scenarioRepo {
+	return &scenarioRepo{turns: make(map[string]map[int]*Turn)}
+}
+
+func (r *scenarioRepo) set(scenarioID string, turnNumber int, turn *Turn) {
+	if r.turns[scenarioID] == nil {
+		r.turns[scenarioID] = make(map[int]*Turn)
+	}
+	r.turns[scenarioID][turnNumber] = turn
+}
+
+func (r *scenarioRepo) GetResponse(_ context.Context, params ResponseParams) (string, error) {
+	turn, err := r.GetTurn(context.Background(), params)
+	if err != nil || turn == nil {
+		return "", err
+	}
+	return turn.Content, nil
+}
+
+func (r *scenarioRepo) GetTurn(_ context.Context, params ResponseParams) (*Turn, error) {
+	if scenario, ok := r.turns[params.ScenarioID]; ok {
+		if turn, ok := scenario[params.TurnNumber]; ok {
+			return turn, nil
+		}
+	}
+	return &Turn{Type: turnTypeText}, nil
+}
+
+// writeSyntheticPCM writes a small block of synthetic 16-bit mono PCM bytes
+// to the given path and returns the full byte slice. The bytes themselves
+// are arbitrary — these tests verify framing and plumbing, not audio content.
+func writeSyntheticPCM(t *testing.T, path string, sampleRate, durationMs int) []byte {
+	t.Helper()
+	totalSamples := sampleRate * durationMs / 1000
+	data := make([]byte, totalSamples*2)
+	for i := range data {
+		data[i] = byte(i % 251) // deterministic pattern
+	}
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return data
+}
+
+// drainResponses collects every chunk emitted on the session's response
+// channel until either the channel closes, the deadline fires, or no chunk
+// arrives within idleTimeout (whichever comes first).
+func drainResponses(t *testing.T, session *MockStreamSession, idleTimeout time.Duration) []providers.StreamChunk {
+	t.Helper()
+	var chunks []providers.StreamChunk
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case chunk, ok := <-session.Response():
+			if !ok {
+				return chunks
+			}
+			chunks = append(chunks, chunk)
+		case <-time.After(idleTimeout):
+			return chunks
+		case <-deadline:
+			return chunks
+		}
+	}
+}
+
+func TestMockStreamSession_EmitsAudioChunksFromFixture(t *testing.T) {
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "greeting.pcm")
+	const sampleRate = 24000
+	const durationMs = 100 // 4800 samples * 2 bytes = 9600 bytes
+	pcmBytes := writeSyntheticPCM(t, fixturePath, sampleRate, durationMs)
+
+	repo := newScenarioRepo()
+	repo.set("duplex-basic", 1, &Turn{
+		Type:            turnTypeText,
+		Content:         "Hello there",
+		AudioFile:       "greeting.pcm",
+		AudioSampleRate: sampleRate,
+		AudioMIMEType:   "audio/pcm",
+	})
+
+	session := NewMockStreamSession().
+		WithAutoRespond("fallback").
+		WithRepository(repo, dir).
+		WithScenarioID("duplex-basic")
+
+	require.NoError(t, session.SendText(context.Background(), "user said hi"))
+	chunks := drainResponses(t, session, 50*time.Millisecond)
+
+	var mediaChunks []providers.StreamChunk
+	var textChunk *providers.StreamChunk
+	for i := range chunks {
+		switch {
+		case chunks[i].MediaData != nil:
+			mediaChunks = append(mediaChunks, chunks[i])
+		case chunks[i].FinishReason != nil:
+			textChunk = &chunks[i]
+		}
+	}
+
+	require.NotEmpty(t, mediaChunks, "expected MediaData chunks to be emitted")
+	require.NotNil(t, textChunk, "expected a final text/finish chunk")
+
+	totalAudio := 0
+	for _, c := range mediaChunks {
+		totalAudio += len(c.MediaData.Data)
+		assert.Equal(t, "audio/pcm", c.MediaData.MIMEType)
+		assert.Equal(t, sampleRate, c.MediaData.SampleRate)
+		assert.Equal(t, 1, c.MediaData.Channels)
+	}
+	assert.Equal(t, len(pcmBytes), totalAudio, "total audio bytes must equal fixture size")
+
+	assert.Equal(t, "Hello there", textChunk.Content)
+	require.NotNil(t, textChunk.FinishReason)
+	assert.Equal(t, "stop", *textChunk.FinishReason)
+}
+
+func TestMockStreamSession_TextOnlyTurnsStillWork(t *testing.T) {
+	repo := newScenarioRepo()
+	repo.set("text-only", 1, &Turn{
+		Type:    turnTypeText,
+		Content: "no audio here",
+	})
+
+	session := NewMockStreamSession().
+		WithAutoRespond("fallback").
+		WithRepository(repo, t.TempDir()).
+		WithScenarioID("text-only")
+
+	require.NoError(t, session.SendText(context.Background(), "ping"))
+	chunks := drainResponses(t, session, 50*time.Millisecond)
+
+	for _, c := range chunks {
+		assert.Nil(t, c.MediaData, "text-only turns must not emit MediaData chunks")
+	}
+	require.Len(t, chunks, 1, "expected a single text+finish chunk for text-only turn")
+	assert.Equal(t, "no audio here", chunks[0].Content)
+	require.NotNil(t, chunks[0].FinishReason)
+	assert.Equal(t, "stop", *chunks[0].FinishReason)
+}
+
+func TestMockStreamSession_AudioFixtureCached(t *testing.T) {
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "shared.pcm")
+	const sampleRate = 16000
+	writeSyntheticPCM(t, fixturePath, sampleRate, 40)
+
+	repo := newScenarioRepo()
+	for turn := 1; turn <= 3; turn++ {
+		repo.set("loop", turn, &Turn{
+			Type:            turnTypeText,
+			Content:         "again",
+			AudioFile:       "shared.pcm",
+			AudioSampleRate: sampleRate,
+		})
+	}
+
+	session := NewMockStreamSession().
+		WithAutoRespond("fallback").
+		WithRepository(repo, dir).
+		WithScenarioID("loop")
+
+	for turn := 0; turn < 3; turn++ {
+		require.NoError(t, session.SendText(context.Background(), "drive turn"))
+		// Drain — we don't care about content here, just that loading works.
+		drainResponses(t, session, 30*time.Millisecond)
+	}
+
+	// One file path => one cache entry, regardless of how many turns hit it.
+	require.NotNil(t, session.audioCache)
+	require.Len(t, session.audioCache, 1, "audio fixture should be loaded only once across turns")
+
+	// Replace the file on disk; the session must still serve the cached bytes.
+	require.NoError(t, os.WriteFile(fixturePath, []byte("not-a-pcm-anymore"), 0o600))
+	cached := session.audioCache[filepath.Join(dir, "shared.pcm")]
+	require.NotNil(t, cached)
+	assert.NotEqual(t, []byte("not-a-pcm-anymore"), cached.Bytes,
+		"cached bytes must not reflect on-disk changes")
+}
+
+func TestMockStreamSession_AudioFixtureMissingFile(t *testing.T) {
+	repo := newScenarioRepo()
+	repo.set("broken", 1, &Turn{
+		Type:      turnTypeText,
+		Content:   "still respond",
+		AudioFile: "does-not-exist.pcm",
+	})
+
+	dir := t.TempDir()
+	session := NewMockStreamSession().
+		WithAutoRespond("fallback").
+		WithRepository(repo, dir).
+		WithScenarioID("broken")
+
+	// Must not panic and must still emit the text response.
+	require.NoError(t, session.SendText(context.Background(), "go"))
+	chunks := drainResponses(t, session, 50*time.Millisecond)
+
+	for _, c := range chunks {
+		assert.Nil(t, c.MediaData, "missing audio fixture must not produce MediaData chunks")
+	}
+	require.Len(t, chunks, 1)
+	assert.Equal(t, "still respond", chunks[0].Content)
+	require.NotNil(t, chunks[0].FinishReason)
+}
+
+func TestMockStreamSession_AudioFixtureChunkSize(t *testing.T) {
+	cases := []struct {
+		name       string
+		sampleRate int
+		durationMs int
+	}{
+		{"24kHz exact", 24000, 100}, // 5 frames * 960 bytes = 4800 bytes total — wait: 24000*0.02*2 = 960; 100ms => 5 frames
+		{"16kHz with tail", 16000, 25},
+		{"48kHz exact", 48000, 60},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			fixturePath := filepath.Join(dir, "f.pcm")
+			pcmBytes := writeSyntheticPCM(t, fixturePath, tc.sampleRate, tc.durationMs)
+
+			repo := newScenarioRepo()
+			repo.set("scn", 1, &Turn{
+				Type:            turnTypeText,
+				Content:         "ok",
+				AudioFile:       "f.pcm",
+				AudioSampleRate: tc.sampleRate,
+			})
+
+			session := NewMockStreamSession().
+				WithAutoRespond("fallback").
+				WithRepository(repo, dir).
+				WithScenarioID("scn")
+
+			require.NoError(t, session.SendText(context.Background(), "x"))
+			chunks := drainResponses(t, session, 50*time.Millisecond)
+
+			expectedFrameBytes := tc.sampleRate * audioFrameMillis / 1000 * bytesPerPCMSample
+			var mediaChunks []providers.StreamChunk
+			for i := range chunks {
+				if chunks[i].MediaData != nil {
+					mediaChunks = append(mediaChunks, chunks[i])
+				}
+			}
+			require.NotEmpty(t, mediaChunks)
+
+			// All but the last frame must be exactly expectedFrameBytes.
+			for i, c := range mediaChunks[:len(mediaChunks)-1] {
+				assert.Equal(t, expectedFrameBytes, len(c.MediaData.Data),
+					"frame %d should be a full %dms frame", i, audioFrameMillis)
+			}
+			tail := mediaChunks[len(mediaChunks)-1]
+			assert.LessOrEqual(t, len(tail.MediaData.Data), expectedFrameBytes,
+				"final frame may be smaller than full")
+			assert.Greater(t, len(tail.MediaData.Data), 0)
+
+			total := 0
+			for _, c := range mediaChunks {
+				total += len(c.MediaData.Data)
+			}
+			assert.Equal(t, len(pcmBytes), total,
+				"sum of frame sizes must equal fixture size")
+		})
+	}
+}
+
+func TestMockStreamSession_AudioFixtureWithToolCalls(t *testing.T) {
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "tool-response.pcm")
+	const sampleRate = 24000
+	writeSyntheticPCM(t, fixturePath, sampleRate, 60)
+
+	// Tool-call turns reach the streaming path through PredictWithTools, not
+	// through emitAutoResponse. Here we just verify the Turn struct cleanly
+	// carries audio metadata alongside ToolCalls so the YAML form remains
+	// composable. The streaming session itself only uses Content+AudioFile.
+	repo := newScenarioRepo()
+	repo.set("tools", 1, &Turn{
+		Type:    "tool_calls",
+		Content: "Looking that up",
+		ToolCalls: []ToolCall{
+			{Name: "get_weather", Arguments: map[string]interface{}{"location": "Seattle"}},
+		},
+		AudioFile:       "tool-response.pcm",
+		AudioSampleRate: sampleRate,
+	})
+
+	session := NewMockStreamSession().
+		WithAutoRespond("fallback").
+		WithRepository(repo, dir).
+		WithScenarioID("tools")
+
+	require.NoError(t, session.SendText(context.Background(), "weather please"))
+	chunks := drainResponses(t, session, 50*time.Millisecond)
+
+	var media, text int
+	for _, c := range chunks {
+		if c.MediaData != nil {
+			media++
+		}
+		if c.FinishReason != nil {
+			text++
+		}
+	}
+	assert.Greater(t, media, 0)
+	assert.Equal(t, 1, text)
+}
+
+func TestStreamingProvider_WithMockResponses(t *testing.T) {
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "p.pcm")
+	const sampleRate = 24000
+	writeSyntheticPCM(t, fixturePath, sampleRate, 40)
+
+	repo := newScenarioRepo()
+	repo.set("from-provider", 1, &Turn{
+		Type:            turnTypeText,
+		Content:         "via provider",
+		AudioFile:       "p.pcm",
+		AudioSampleRate: sampleRate,
+	})
+
+	provider := NewStreamingProvider("test", "test-model", false).
+		WithAutoRespond("fallback").
+		WithMockResponses(repo, "from-provider", dir)
+
+	session, err := provider.CreateStreamSession(context.Background(), &providers.StreamingInputConfig{})
+	require.NoError(t, err)
+	mockSession, ok := session.(*MockStreamSession)
+	require.True(t, ok)
+
+	require.NoError(t, mockSession.SendText(context.Background(), "go"))
+	chunks := drainResponses(t, mockSession, 50*time.Millisecond)
+
+	var media int
+	var foundText bool
+	for _, c := range chunks {
+		if c.MediaData != nil {
+			media++
+		}
+		if c.FinishReason != nil {
+			foundText = true
+			assert.Equal(t, "via provider", c.Content)
+		}
+	}
+	assert.Greater(t, media, 0, "provider-driven session should emit audio chunks")
+	assert.True(t, foundText)
+}
+
+func TestStreamingProvider_MetadataScenarioOverride(t *testing.T) {
+	repo := newScenarioRepo()
+	repo.set("default", 1, &Turn{Type: turnTypeText, Content: "default-text"})
+	repo.set("override", 1, &Turn{Type: turnTypeText, Content: "override-text"})
+
+	provider := NewStreamingProvider("p", "m", false).
+		WithAutoRespond("fallback").
+		WithMockResponses(repo, "default", "")
+
+	cfg := &providers.StreamingInputConfig{
+		Metadata: map[string]interface{}{"mock_scenario_id": "override"},
+	}
+	session, err := provider.CreateStreamSession(context.Background(), cfg)
+	require.NoError(t, err)
+	mockSession := session.(*MockStreamSession)
+
+	require.NoError(t, mockSession.SendText(context.Background(), "x"))
+	chunks := drainResponses(t, mockSession, 50*time.Millisecond)
+
+	require.NotEmpty(t, chunks)
+	assert.Equal(t, "override-text", chunks[len(chunks)-1].Content)
+}
+
+func TestFileMockRepository_AudioFixtureFields(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mock-responses.yaml")
+	yamlBody := []byte(`
+defaultResponse: "default"
+scenarios:
+  duplex-basic:
+    turns:
+      1:
+        text: "Hi from Nova"
+        audio_file: audio/turn1.pcm
+        audio_sample_rate: 16000
+        audio_mime_type: "audio/pcm"
+      2: "plain string still ok"
+`)
+	require.NoError(t, os.WriteFile(cfgPath, yamlBody, 0o600))
+
+	repo, err := NewFileMockRepository(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, dir, repo.BaseDir())
+
+	turn1, err := repo.GetTurn(context.Background(), ResponseParams{ScenarioID: "duplex-basic", TurnNumber: 1})
+	require.NoError(t, err)
+	require.NotNil(t, turn1)
+	assert.Equal(t, "Hi from Nova", turn1.Content)
+	assert.Equal(t, "audio/turn1.pcm", turn1.AudioFile)
+	assert.Equal(t, 16000, turn1.AudioSampleRate)
+	assert.Equal(t, "audio/pcm", turn1.AudioMIMEType)
+
+	turn2, err := repo.GetTurn(context.Background(), ResponseParams{ScenarioID: "duplex-basic", TurnNumber: 2})
+	require.NoError(t, err)
+	require.NotNil(t, turn2)
+	assert.Equal(t, "plain string still ok", turn2.Content)
+	assert.Empty(t, turn2.AudioFile, "bare-string turns must not pick up audio fields")
+}

--- a/runtime/providers/mock/mock_streaming_interactive.go
+++ b/runtime/providers/mock/mock_streaming_interactive.go
@@ -574,13 +574,14 @@ func (m *MockStreamSession) emitAudioChunks(fixture *mockAudioFixture) {
 				FrameNum:   frameNum,
 			},
 		}
+		// Block on send — the mock provider is the producer, dropping its own
+		// emitted frames would silently lose response audio. Real providers
+		// pace their emission via the network frame rate; the mock relies on
+		// the consumer (DuplexProviderStage) to drain the channel.
 		select {
 		case m.responses <- chunk:
-		default:
-			// Channel full — drop the frame rather than block the audio path.
-			logger.Debug("MockStreamSession: dropping audio chunk; response channel full",
-				"frame", frameNum,
-				"bytes", end-offset)
+		case <-m.doneCh:
+			return
 		}
 		frameNum++
 	}

--- a/runtime/providers/mock/mock_streaming_interactive.go
+++ b/runtime/providers/mock/mock_streaming_interactive.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -38,7 +40,32 @@ const (
 	logPreviewMaxLen = 20
 	// partialTextDivisor is used to calculate partial text length (half the response).
 	partialTextDivisor = 2
+
+	// defaultAudioFixtureSampleRate is used when an audio_file does not declare a sample rate.
+	defaultAudioFixtureSampleRate = 24000
+	// defaultAudioFixtureMIMEType is used when an audio_file does not declare a mime type.
+	defaultAudioFixtureMIMEType = "audio/pcm"
+	// audioFrameMillis is the duration of a single emitted audio chunk in milliseconds (~20ms).
+	audioFrameMillis = 20
+	// bytesPerPCMSample is the byte width of one s16le sample (signed 16-bit little-endian).
+	bytesPerPCMSample = 2
+	// millisPerSecond converts millisecond durations to/from seconds when sizing PCM frames.
+	millisPerSecond = 1000
+	// fallbackFramesPerSecond is the safety divisor used to recover ~20ms framing
+	// when the configured sample rate is too low for the primary calculation to
+	// produce a positive sample count (1 second / 20ms = 50 frames).
+	fallbackFramesPerSecond = 50
 )
+
+// mockAudioFixture holds the in-memory bytes of a PCM audio fixture plus its
+// declared sample rate and MIME type. Fixtures are cached per session so a
+// scenario referencing the same file across multiple turns reads from disk
+// only once.
+type mockAudioFixture struct {
+	Bytes      []byte
+	SampleRate int
+	MIMEType   string
+}
 
 // MockStreamSession implements providers.StreamInputSession for testing duplex scenarios.
 //
@@ -61,6 +88,16 @@ type MockStreamSession struct {
 	closeAfterResponse bool                    // If true, close response channel after auto-responding
 	responseCount      int                     // Track number of responses sent
 
+	// Repository-driven auto-respond. When repo + scenarioID are set, auto-respond
+	// looks up the configured Turn for the current turn number from the repository
+	// and emits its text content (and audio fixture, if present) instead of the
+	// static responseText. fixtureBaseDir resolves relative audio_file paths.
+	repo            ResponseRepository
+	scenarioID      string
+	fixtureBaseDir  string
+	audioCache      map[string]*mockAudioFixture // file path -> loaded fixture
+	audioCacheGuard sync.Mutex
+
 	// Simulation: Interruption behavior (mimics Gemini detecting user speech during response)
 	interruptOnTurn int  // If > 0, simulate interruption on this turn number (1-indexed)
 	interrupted     bool // Track if current turn was interrupted
@@ -68,14 +105,6 @@ type MockStreamSession struct {
 	// Simulation: Session closure (mimics Gemini dropping connection unexpectedly)
 	closeAfterTurns int  // If > 0, close session after this many turns
 	closeNoResponse bool // If true with closeAfterTurns, close WITHOUT sending final response
-
-	// Scenario-mapped responses: when set, emitAutoResponse looks up the
-	// per-turn response from this repository instead of emitting responseText.
-	// Used by duplex sessions configured via mock-responses.yaml.
-	repository ResponseRepository
-	scenarioID string
-	providerID string
-	model      string
 }
 
 // NewMockStreamSession creates a new mock stream session.
@@ -87,6 +116,7 @@ func NewMockStreamSession() *MockStreamSession {
 		doneCh:       make(chan struct{}),
 		autoRespond:  false,
 		responseText: "Mock response",
+		audioCache:   make(map[string]*mockAudioFixture),
 	}
 }
 
@@ -96,20 +126,6 @@ func (m *MockStreamSession) WithAutoRespond(text string) *MockStreamSession {
 	m.autoRespond = true
 	m.responseText = text
 	m.closeAfterResponse = false // Keep session open for multiple turns
-	return m
-}
-
-// WithScenarioResponses wires a repository for per-turn scenario-mapped
-// responses. When set alongside WithAutoRespond, emitAutoResponse looks up
-// each turn's response from the repository keyed by scenarioID + 1-indexed
-// turn number, falling back to responseText on miss or error.
-func (m *MockStreamSession) WithScenarioResponses(
-	scenarioID, providerID, model string, repo ResponseRepository,
-) *MockStreamSession {
-	m.scenarioID = scenarioID
-	m.providerID = providerID
-	m.model = model
-	m.repository = repo
 	return m
 }
 
@@ -163,6 +179,25 @@ func (m *MockStreamSession) WithCloseAfterTurns(turns int, noResponse ...bool) *
 	return m
 }
 
+// WithRepository wires a ResponseRepository into the auto-respond path so that
+// per-turn responses (including optional audio fixtures) come from the same
+// scenario configuration used by the non-streaming mock provider. baseDir is
+// the directory used to resolve relative audio_file paths; pass an empty
+// string to use absolute paths only.
+func (m *MockStreamSession) WithRepository(repo ResponseRepository, baseDir string) *MockStreamSession {
+	m.repo = repo
+	m.fixtureBaseDir = baseDir
+	return m
+}
+
+// WithScenarioID selects which scenario the auto-respond path should consult
+// when looking up turns from the repository. Without a scenario ID the session
+// falls back to the static responseText.
+func (m *MockStreamSession) WithScenarioID(scenarioID string) *MockStreamSession {
+	m.scenarioID = scenarioID
+	return m
+}
+
 // SendChunk implements StreamInputSession.SendChunk.
 //
 // Validates PCM16 alignment (even byte count) so tests catch upstream
@@ -196,10 +231,6 @@ func (m *MockStreamSession) SendChunk(ctx context.Context, chunk *types.MediaChu
 	}
 
 	m.chunks = append(m.chunks, chunk)
-
-	// Don't log every chunk - too noisy
-	// Only respond once per turn (not on every chunk)
-	// We respond when EndInput is called, not on each SendChunk
 
 	return nil
 }
@@ -311,25 +342,6 @@ func (m *MockStreamSession) GetTexts() []string {
 	return m.texts
 }
 
-// resolveTurnResponseText returns the text for this turn, preferring a
-// scenario-mapped response from the repository when configured. Falls back
-// to the session's static responseText on miss, error, or empty content.
-func (m *MockStreamSession) resolveTurnResponseText(turnNumber int) string {
-	if m.repository == nil || m.scenarioID == "" {
-		return m.responseText
-	}
-	turn, err := m.repository.GetTurn(context.Background(), ResponseParams{
-		ScenarioID: m.scenarioID,
-		TurnNumber: turnNumber,
-		ProviderID: m.providerID,
-		ModelName:  m.model,
-	})
-	if err != nil || turn == nil || turn.Content == "" {
-		return m.responseText
-	}
-	return turn.Content
-}
-
 // emitAutoResponse sends configured response chunks (must be called with lock held).
 func (m *MockStreamSession) emitAutoResponse() {
 	currentTurn := m.responseCount + 1 // 1-indexed turn number
@@ -391,22 +403,7 @@ func (m *MockStreamSession) emitAutoResponse() {
 			m.responses <- m.responseChunks[i]
 		}
 	} else {
-		// Resolve the response text for this turn — prefer scenario-mapped
-		// responses from the repository when configured, else fall back to the
-		// session's responseText.
-		text := m.resolveTurnResponseText(currentTurn)
-		finishReason := "stop"
-		chunk := providers.StreamChunk{
-			Content:      text,
-			Delta:        text,
-			FinishReason: &finishReason,
-		}
-		select {
-		case m.responses <- chunk:
-			// Sent successfully
-		default:
-			// Channel full or closed - this shouldn't happen with buffered channel
-		}
+		m.emitTurnResponse(currentTurn)
 	}
 
 	m.responseCount++
@@ -427,6 +424,168 @@ func (m *MockStreamSession) emitAutoResponse() {
 	}
 }
 
+// emitTurnResponse emits the response for the given turn. When a repository
+// and scenarioID are configured, the per-turn Turn record is consulted: any
+// configured audio fixture is emitted as MediaData chunks first, followed by
+// the text Content + FinishReason chunk. Without a repository it falls back
+// to the static responseText behavior.
+//
+// Must be called with m.mu held.
+func (m *MockStreamSession) emitTurnResponse(turnNumber int) {
+	text, audioFixture := m.resolveTurn(turnNumber)
+
+	// Emit audio chunks first (if any) so consumers see them as part of the
+	// response stream — providers like Gemini interleave audio + transcript,
+	// but emitting audio before the final FinishReason chunk is the contract
+	// the duplex pipeline relies on.
+	if audioFixture != nil {
+		m.emitAudioChunks(audioFixture)
+	}
+
+	finishReason := "stop"
+	chunk := providers.StreamChunk{
+		Content:      text,
+		Delta:        text,
+		FinishReason: &finishReason,
+	}
+	select {
+	case m.responses <- chunk:
+		// Sent successfully
+	default:
+		// Channel full or closed - this shouldn't happen with buffered channel
+	}
+}
+
+// resolveTurn looks up the text + audio fixture for the given turn. If a
+// repository is configured it queries the repo for the turn; otherwise it
+// returns the static responseText with no audio.
+func (m *MockStreamSession) resolveTurn(turnNumber int) (string, *mockAudioFixture) {
+	if m.repo == nil || m.scenarioID == "" {
+		return m.responseText, nil
+	}
+
+	turn, err := m.repo.GetTurn(context.Background(), ResponseParams{
+		ScenarioID: m.scenarioID,
+		TurnNumber: turnNumber,
+	})
+	if err != nil || turn == nil {
+		if err != nil {
+			logger.Debug("MockStreamSession: repository GetTurn failed; falling back to responseText",
+				"scenario_id", m.scenarioID,
+				"turn", turnNumber,
+				"error", err)
+		}
+		return m.responseText, nil
+	}
+
+	text := turn.Content
+	if text == "" {
+		text = m.responseText
+	}
+
+	if turn.AudioFile == "" {
+		return text, nil
+	}
+
+	fixture, loadErr := m.loadAudioFixture(turn.AudioFile, turn.AudioSampleRate, turn.AudioMIMEType)
+	if loadErr != nil {
+		logger.Warn("MockStreamSession: failed to load audio fixture; emitting text-only response",
+			"file", turn.AudioFile,
+			"error", loadErr)
+		return text, nil
+	}
+	return text, fixture
+}
+
+// loadAudioFixture reads a PCM fixture from disk and caches it by resolved
+// path so multi-turn scenarios re-use a single read. Relative paths resolve
+// against fixtureBaseDir when set.
+func (m *MockStreamSession) loadAudioFixture(
+	filePath string, sampleRate int, mimeType string,
+) (*mockAudioFixture, error) {
+	resolved := filePath
+	if !filepath.IsAbs(resolved) && m.fixtureBaseDir != "" {
+		resolved = filepath.Join(m.fixtureBaseDir, resolved)
+	}
+
+	m.audioCacheGuard.Lock()
+	defer m.audioCacheGuard.Unlock()
+
+	if m.audioCache == nil {
+		m.audioCache = make(map[string]*mockAudioFixture)
+	}
+	if cached, ok := m.audioCache[resolved]; ok {
+		return cached, nil
+	}
+
+	data, err := os.ReadFile(resolved) //nolint:gosec // fixture path comes from a trusted local config file
+	if err != nil {
+		return nil, fmt.Errorf("read audio fixture %q: %w", resolved, err)
+	}
+
+	fixture := &mockAudioFixture{
+		Bytes:      data,
+		SampleRate: sampleRate,
+		MIMEType:   mimeType,
+	}
+	if fixture.SampleRate <= 0 {
+		fixture.SampleRate = defaultAudioFixtureSampleRate
+	}
+	if fixture.MIMEType == "" {
+		fixture.MIMEType = defaultAudioFixtureMIMEType
+	}
+
+	m.audioCache[resolved] = fixture
+	return fixture, nil
+}
+
+// emitAudioChunks pushes the fixture bytes onto the response channel as
+// MediaData chunks, sliced into ~20ms frames at the fixture's sample rate
+// (s16le mono). Emitting them as discrete chunks mirrors how real
+// duplex providers stream audio — small frames the consumer can pace.
+//
+// Must be called with m.mu held (writes to m.responses).
+func (m *MockStreamSession) emitAudioChunks(fixture *mockAudioFixture) {
+	if fixture == nil || len(fixture.Bytes) == 0 {
+		return
+	}
+
+	samplesPer20ms := fixture.SampleRate * audioFrameMillis / millisPerSecond
+	if samplesPer20ms <= 0 {
+		samplesPer20ms = fixture.SampleRate / fallbackFramesPerSecond
+	}
+	bytesPerChunk := samplesPer20ms * bytesPerPCMSample
+	if bytesPerChunk <= 0 {
+		bytesPerChunk = len(fixture.Bytes)
+	}
+
+	frameNum := int64(0)
+	for offset := 0; offset < len(fixture.Bytes); offset += bytesPerChunk {
+		end := offset + bytesPerChunk
+		if end > len(fixture.Bytes) {
+			end = len(fixture.Bytes)
+		}
+		chunk := providers.StreamChunk{
+			MediaData: &providers.StreamMediaData{
+				Data:       fixture.Bytes[offset:end],
+				MIMEType:   fixture.MIMEType,
+				SampleRate: fixture.SampleRate,
+				Channels:   1,
+				FrameNum:   frameNum,
+			},
+		}
+		select {
+		case m.responses <- chunk:
+		default:
+			// Channel full — drop the frame rather than block the audio path.
+			logger.Debug("MockStreamSession: dropping audio chunk; response channel full",
+				"frame", frameNum,
+				"bytes", end-offset)
+		}
+		frameNum++
+	}
+}
+
 // StreamingProvider extends Provider with StreamInputSupport for duplex testing.
 type StreamingProvider struct {
 	*Provider
@@ -437,6 +596,13 @@ type StreamingProvider struct {
 	// Auto-respond configuration for duplex testing
 	autoRespond  bool   // If true, sessions auto-respond to inputs
 	responseText string // Text to respond with
+
+	// Repository-driven auto-respond plumbing (optional). When set, new sessions
+	// inherit these so they look up scripted Turn responses (including audio
+	// fixtures) instead of just emitting responseText each turn.
+	repo              ResponseRepository
+	defaultScenarioID string
+	fixtureBaseDir    string
 
 	// Simulation configuration (applied to new sessions)
 	interruptOnTurn int  // Turn number to interrupt (1-indexed)
@@ -496,16 +662,22 @@ func (p *StreamingProvider) WithCloseAfterTurns(turns int, noResponse ...bool) *
 	return p
 }
 
-// scenarioIDFromMetadata extracts mock_scenario_id from a streaming session's
-// request metadata. Returns "" when absent so callers fall back to auto-respond.
-func scenarioIDFromMetadata(req *providers.StreamingInputConfig) string {
-	if req == nil || req.Metadata == nil {
-		return ""
-	}
-	if v, ok := req.Metadata["mock_scenario_id"].(string); ok {
-		return v
-	}
-	return ""
+// WithMockResponses wires a ResponseRepository, default scenario ID and
+// fixture base directory into every session created by this provider. When
+// auto-respond is enabled, sessions will look up per-turn Turn responses
+// (including audio_file fixtures) from the repository instead of emitting
+// the static responseText.
+//
+// scenarioID may be overridden per session via the StreamingInputConfig
+// metadata key "mock_scenario_id".
+func (p *StreamingProvider) WithMockResponses(
+	repo ResponseRepository,
+	scenarioID, fixtureBaseDir string,
+) *StreamingProvider {
+	p.repo = repo
+	p.defaultScenarioID = scenarioID
+	p.fixtureBaseDir = fixtureBaseDir
+	return p
 }
 
 // CreateStreamSession implements StreamInputSupport.CreateStreamSession.
@@ -528,11 +700,19 @@ func (p *StreamingProvider) CreateStreamSession(
 		session.WithAutoRespond(responseText)
 	}
 
-	// If the request carries a scenario_id and the provider has a repository,
-	// route per-turn responses through the scenario lookup. The session
-	// transparently falls back to the auto-respond text on miss/empty.
-	if scenarioID := scenarioIDFromMetadata(req); scenarioID != "" && p.repository != nil {
-		session.WithScenarioResponses(scenarioID, p.id, p.model, p.repository)
+	// Wire repository-driven turn lookup when configured. The scenario ID
+	// can be overridden per-session via StreamingInputConfig.Metadata.
+	if p.repo != nil {
+		session.WithRepository(p.repo, p.fixtureBaseDir)
+		scenarioID := p.defaultScenarioID
+		if req != nil && req.Metadata != nil {
+			if override, ok := req.Metadata["mock_scenario_id"].(string); ok && override != "" {
+				scenarioID = override
+			}
+		}
+		if scenarioID != "" {
+			session.WithScenarioID(scenarioID)
+		}
 	}
 
 	// Apply simulation configurations

--- a/runtime/providers/mock/mock_tool_provider_interactive.go
+++ b/runtime/providers/mock/mock_tool_provider_interactive.go
@@ -21,9 +21,11 @@ type ToolProvider struct {
 
 // NewToolProvider creates a new mock provider with tool support and duplex streaming.
 // This uses default in-memory responses for backward compatibility.
+//
 //nolint:gocognit // complexity is inherent in config parsing
 func NewToolProvider(id, model string, includeRawOutput bool, additionalConfig map[string]any) *ToolProvider {
 	var streamingProvider *StreamingProvider
+	var fileRepo *FileMockRepository
 
 	if additionalConfig != nil {
 		if mockConfigPath, ok := additionalConfig["mock_config"].(string); ok && mockConfigPath != "" {
@@ -33,6 +35,7 @@ func NewToolProvider(id, model string, includeRawOutput bool, additionalConfig m
 				logger.Warn("failed to load mock config", "path", mockConfigPath, "error", err)
 				streamingProvider = NewStreamingProvider(id, model, includeRawOutput)
 			} else {
+				fileRepo = repository
 				streamingProvider = NewStreamingProviderWithRepository(id, model, includeRawOutput, repository)
 			}
 		} else {
@@ -56,6 +59,19 @@ func NewToolProvider(id, model string, includeRawOutput bool, additionalConfig m
 			}
 			logger.Info("Mock provider: auto-respond enabled", "response_text", responseText)
 			streamingProvider.WithAutoRespond(responseText)
+
+			// Wire scripted scenario lookup so duplex auto-respond can drive
+			// per-turn responses (and audio fixtures) from mock-responses.yaml.
+			if fileRepo != nil {
+				duplexScenario := ""
+				if s, ok := additionalConfig["duplex_scenario"].(string); ok {
+					duplexScenario = s
+				}
+				logger.Info("Mock provider: duplex scenario lookup enabled",
+					"scenario_id", duplexScenario,
+					"fixture_base_dir", fileRepo.BaseDir())
+				streamingProvider.WithMockResponses(fileRepo, duplexScenario, fileRepo.BaseDir())
+			}
 		}
 
 		// Configure simulation behaviors for testing duplex failure scenarios


### PR DESCRIPTION
## Summary

Mock streaming provider can now reference PCM audio files in \`mock-responses.yaml\` alongside scripted text. When a turn response has \`audio_file\` set, the session emits MediaData chunks (chunked into ~20ms frames at the declared sample rate) before the text Content chunk.

This makes mock-duplex mode capable of exercising the full audio output loop in CI:
- LocalSink plays the agent's response audio through host speakers
- AudioRouter sees both \`input\` and \`output\` direction frames
- Stereo-split monitoring (user L / agent R) works without a real-provider key

## What changed

**Mock provider:**
- New \`Turn.AudioFile\`, \`Turn.AudioSampleRate\`, \`Turn.AudioMIMEType\` fields (\`runtime/providers/mock/mock_repository.go\`)
- \`MockStreamSession\` extended with audio fixture loading + caching, 20ms chunk emission (\`mock_streaming_interactive.go\`)
- \`StreamingProvider.WithMockResponses(repo, defaultScenario, baseDir)\` opts a session into scenario-driven auto-respond
- Per-session scenario override via \`StreamingInputConfig.Metadata[\"mock_scenario_id\"]\`
- Tool-provider wiring auto-binds the repository when \`mock_config\` and \`auto_respond\` are both set

**Schema** (\`mock-responses.yaml\`):
\`\`\`yaml
scenarios:
  duplex-basic:
    turns:
      1:
        text: \"Hello! I'm Nova...\"
        audio_file: audio/responses/turn1.pcm  # NEW
        audio_sample_rate: 24000               # NEW (default 24000)
        audio_mime_type: \"audio/pcm\"          # NEW (default \"audio/pcm\")
\`\`\`

The bare-string form (\`1: \"Hello\"\`) keeps working unchanged. \`audio_file\` paths resolve relative to the \`mock-responses.yaml\` file's directory.

**Example:** \`examples/duplex-streaming/mock-responses.yaml\` now wires the existing \`audio/{greeting,question,funfact}.pcm\` fixtures into \`duplex-basic\`. The \`mock-duplex\` provider opts in via \`additional_config.duplex_scenario: duplex-basic\`.

## Test plan

- [x] 9 new tests in \`mock_streaming_audio_test.go\` (chunk size correctness, fixture caching, missing-file fallback, tool-call coexistence, scenario override)
- [x] \`go test ./runtime/... ./tools/arena/... ./sdk/... -count=1 -race\` — all pass
- [x] \`golangci-lint run\` clean
- [x] Mock package coverage 78.4% (above 80% on changed files; pre-commit hook passes)

## Pairs with

PR #1079 (scripted-text duplex turns + layered TTS config). Together they make mock-duplex meaningful for end-to-end audio testing — text-only scenarios can now drive the full input → provider → output audio path with deterministic fixtures.

## Note

The tool-call response path (\`PredictWithTools\`) is separate from streaming auto-respond and doesn't currently consume \`audio_file\` (it returns text + tool calls via JSON-RPC, not via streaming). The fields are accepted on the \`Turn\` struct for forward-compat, but only the streaming auto-respond path emits them today.