### PR TITLE
fix(arena): wire source-backed MCP discovery + green codegen-sandbox demo

### DIFF
--- a/examples/codegen-sandbox/mock-responses.yaml
+++ b/examples/codegen-sandbox/mock-responses.yaml
@@ -9,22 +9,59 @@ scenarios:
   simple-fix:
     turns:
       1:
-        response: "Let me read /workspace/add.go to find the bug."
+        response: "Setting up the workspace with a buggy add function and a failing test."
+        tool_calls:
+          - name: Bash
+            arguments:
+              description: "seed workspace with go module, buggy add, and failing test"
+              command: |
+                set -e
+                mkdir -p /workspace
+                cd /workspace
+                cat > go.mod <<'GOMOD'
+                module example.com/add
+
+                go 1.21
+                GOMOD
+                cat > add.go <<'ADDGO'
+                package add
+
+                // Add returns a + b. The negative-input branch is buggy.
+                func Add(a, b int) int {
+                    if a < 0 {
+                        return a - b
+                    }
+                    return a + b
+                }
+                ADDGO
+                cat > add_test.go <<'TESTGO'
+                package add
+
+                import "testing"
+
+                func TestAdd(t *testing.T) {
+                    if got := Add(-1, 2); got != 1 {
+                        t.Fatalf("Add(-1, 2) = %d; want 1", got)
+                    }
+                }
+                TESTGO
+      2:
+        response: "Now let me read add.go to find the bug."
         tool_calls:
           - name: Read
             arguments:
-              path: /workspace/add.go
-      2:
-        response: "I can see the sign-handling branch is wrong. Fixing."
+              file_path: /workspace/add.go
+      3:
+        response: "The negative branch returns `a - b` instead of `a + b`. Fixing."
         tool_calls:
           - name: Edit
             arguments:
-              path: /workspace/add.go
-              old_string: "if a < 0"
-              new_string: "if a < 0 || b < 0"
-      3:
+              file_path: /workspace/add.go
+              old_string: "return a - b"
+              new_string: "return a + b"
+      4:
         response: "Running the tests to verify."
         tool_calls:
           - name: run_tests
             arguments: {}
-      4: "Tests pass. The bug was the incomplete sign check — it only looked at `a`. Fixed."
+      5: "Tests pass. The bug was the negative branch returning a-b instead of a+b. Fixed."

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1602,6 +1603,29 @@ func TestLoadConfig_SkillsInline(t *testing.T) {
 	require.Len(t, cfg.LoadedSkillSources, 1)
 	assert.Equal(t, "inline-skill", cfg.LoadedSkillSources[0].Name)
 	assert.Equal(t, "Do the thing", cfg.LoadedSkillSources[0].Instructions)
+}
+
+func TestLoadSkills_RelativeConfigPath(t *testing.T) {
+	// When promptarena is invoked from an example directory with a relative
+	// --config like "config.arena.yaml", filepath.Dir(...) returns ".",
+	// which historically tripped the path-containment check because
+	// filepath.Clean("./skills") == "skills" but the prefix comparison
+	// expected "./".
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "skills", "test-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: test-skill\ndescription: A test skill\n---\nInstructions here.\n"),
+		0o600,
+	))
+
+	t.Chdir(dir)
+
+	cfg := &Config{Skills: []prompt.SkillSourceConfig{{Path: "skills/"}}}
+	err := cfg.loadSkills("config.arena.yaml")
+	require.NoError(t, err)
+	require.Len(t, cfg.LoadedSkillSources, 1)
 }
 
 func TestLoadConfig_SkillsPathTraversal(t *testing.T) {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -480,7 +480,16 @@ func (c *Config) loadSkills(configPath string) error {
 		return nil
 	}
 
+	// Resolve to absolute paths before the prefix comparison. When configPath
+	// is relative (e.g. "config.arena.yaml" run from the example dir), Dir
+	// returns "." and Clean("./skills") returns "skills" — the historical
+	// HasPrefix check then fails closed because "skills" doesn't start with
+	// "./". Anchoring both sides at filepath.Abs side-steps that.
 	configDir := filepath.Dir(configPath)
+	absBase, err := filepath.Abs(configDir)
+	if err != nil {
+		return fmt.Errorf("skills: resolve config dir %q: %w", configDir, err)
+	}
 
 	for _, src := range c.Skills {
 		dir := src.EffectiveDir()
@@ -493,13 +502,12 @@ func (c *Config) loadSkills(configPath string) error {
 		// Resolve relative path.
 		absDir := dir
 		if !filepath.IsAbs(absDir) {
-			absDir = filepath.Join(configDir, absDir)
+			absDir = filepath.Join(absBase, absDir)
 		}
 		absDir = filepath.Clean(absDir)
 
 		// Validate path containment.
-		cleanBase := filepath.Clean(configDir)
-		if absDir != cleanBase && !strings.HasPrefix(absDir, cleanBase+string(filepath.Separator)) {
+		if absDir != absBase && !strings.HasPrefix(absDir, absBase+string(filepath.Separator)) {
 			return fmt.Errorf("skills: path traversal detected: %q resolves outside config directory %q", dir, configDir)
 		}
 

--- a/tools/arena/engine/arena_statestore_test.go
+++ b/tools/arena/engine/arena_statestore_test.go
@@ -64,7 +64,7 @@ func TestArenaStateStore_CapturesTelemetry(t *testing.T) {
 	)
 
 	// Create engine
-	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil)
+	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestArenaStateStore_MultipleRuns(t *testing.T) {
 	)
 
 	// Create engine
-	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil)
+	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)
 	}

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -186,7 +186,7 @@ func NewEngineFromConfig(cfg *config.Config, providerFilter ...string) (*Engine,
 	}
 
 	// Create engine with all components
-	eng, err := NewEngine(cfg, providerRegistry, promptRegistry, mcpRegistry, convExecutor, adapterRegistry)
+	eng, err := NewEngine(cfg, providerRegistry, promptRegistry, mcpRegistry, convExecutor, adapterRegistry, toolRegistry)
 	if err != nil {
 		if a2aCleanup != nil {
 			a2aCleanup()
@@ -194,7 +194,6 @@ func NewEngineFromConfig(cfg *config.Config, providerFilter ...string) (*Engine,
 		return nil, err
 	}
 	eng.a2aCleanup = a2aCleanup
-	eng.toolRegistry = toolRegistry
 	eng.skillExecutor = skillExec
 
 	// Initialize workflow state machine and register transition tool if configured
@@ -245,6 +244,7 @@ func NewEngine(
 	mcpRegistry *mcp.RegistryImpl,
 	convExecutor ConversationExecutor,
 	adapterRegistry *adapters.Registry,
+	toolRegistry *tools.Registry,
 ) (*Engine, error) {
 	// Build state store from config if configured
 	stateStore, err := buildStateStore(cfg)
@@ -279,7 +279,8 @@ func NewEngine(
 	// Run-scoped sources open at engine construction; they're typically fast.
 	// If slow sources become common, thread ctx through NewEngine.
 	if mcpRegistry != nil {
-		eng.mcpSourceScope = newMCPSourceScope(mcpRegistry)
+		eng.toolRegistry = toolRegistry
+		eng.mcpSourceScope = newMCPSourceScopeWithTools(mcpRegistry, toolRegistry)
 		if err := eng.mcpSourceScope.OpenAll(
 			context.Background(), mcpsource.ScopeRun, "run", nil,
 			eng.mcpSkillSources, eng.mcpConfig,

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -267,6 +267,7 @@ func NewEngine(
 		mediaStorage:         mediaStorage,
 		conversationExecutor: convExecutor,
 		adapterRegistry:      adapterRegistry,
+		toolRegistry:         toolRegistry,
 		scenarios:            cfg.LoadedScenarios,
 		evals:                cfg.LoadedEvals,
 		providers:            cfg.LoadedProviders,
@@ -279,7 +280,6 @@ func NewEngine(
 	// Run-scoped sources open at engine construction; they're typically fast.
 	// If slow sources become common, thread ctx through NewEngine.
 	if mcpRegistry != nil {
-		eng.toolRegistry = toolRegistry
 		eng.mcpSourceScope = newMCPSourceScopeWithTools(mcpRegistry, toolRegistry)
 		if err := eng.mcpSourceScope.OpenAll(
 			context.Background(), mcpsource.ScopeRun, "run", nil,

--- a/tools/arena/engine/engine_test.go
+++ b/tools/arena/engine/engine_test.go
@@ -235,7 +235,7 @@ func TestEnableMockProviderMode(t *testing.T) {
 	}
 
 	// Create minimal engine using the direct constructor
-	eng, err := NewEngine(cfg, providerRegistry, nil, nil, nil, nil)
+	eng, err := NewEngine(cfg, providerRegistry, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestEnableMockProviderMode_WithConfigFile(t *testing.T) {
 	mockProvider := mock.NewProvider("test-provider", "gpt-4", false)
 	providerRegistry.Register(mockProvider)
 
-	eng, err := NewEngine(cfg, providerRegistry, nil, nil, nil, nil)
+	eng, err := NewEngine(cfg, providerRegistry, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestEnableMockProviderMode_WithInvalidConfigFile(t *testing.T) {
 	mockProvider := mock.NewProvider("test-provider", "gpt-4", false)
 	providerRegistry.Register(mockProvider)
 
-	eng, err := NewEngine(cfg, providerRegistry, nil, nil, nil, nil)
+	eng, err := NewEngine(cfg, providerRegistry, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)
 	}

--- a/tools/arena/engine/mcpsource_dispatch_test.go
+++ b/tools/arena/engine/mcpsource_dispatch_test.go
@@ -1,0 +1,271 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
+)
+
+// fakeSSEMCPServer stands up an in-process SSE-MCP server speaking the
+// JSON-RPC 2.0 wire protocol. It serves a single configurable tool and
+// records every CallTool invocation for assertions.
+//
+// Lifted in spirit from runtime/mcp/sse_client_test.go's sseTestServer,
+// kept inline here so this test stays self-contained.
+type fakeSSEMCPServer struct {
+	URL      string
+	close    func()
+	tool     mcp.Tool
+	callsMu  sync.Mutex
+	calls    []recordedCall
+	callResp mcp.ToolCallResponse
+}
+
+type recordedCall struct {
+	Name string
+	Args json.RawMessage
+}
+
+func newFakeSSEMCPServer(t *testing.T, tool mcp.Tool, callResp mcp.ToolCallResponse) *fakeSSEMCPServer {
+	t.Helper()
+
+	srv := &fakeSSEMCPServer{tool: tool, callResp: callResp}
+
+	type session struct {
+		events chan []byte
+	}
+	var sessionsMu sync.Mutex
+	sessions := map[string]*session{}
+	var sessionCounter atomic.Int64
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
+		id := fmt.Sprintf("s%d", sessionCounter.Add(1))
+		s := &session{events: make(chan []byte, 32)}
+		sessionsMu.Lock()
+		sessions[id] = s
+		sessionsMu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "event: endpoint\ndata: /message?sessionID=%s\n\n", id)
+		w.(http.Flusher).Flush()
+
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case b := <-s.events:
+				_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", b)
+				w.(http.Flusher).Flush()
+			}
+		}
+	})
+
+	mux.HandleFunc("/message", func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("sessionID")
+		sessionsMu.Lock()
+		s, ok := sessions[id]
+		sessionsMu.Unlock()
+		if !ok {
+			http.Error(w, "unknown session", http.StatusBadRequest)
+			return
+		}
+		var req mcp.JSONRPCMessage
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+
+		go func() {
+			resp := srv.handle(req)
+			if resp.JSONRPC == "" {
+				resp.JSONRPC = "2.0"
+			}
+			resp.ID = req.ID
+			b, _ := json.Marshal(resp)
+			s.events <- b
+		}()
+	})
+
+	httpSrv := httptest.NewServer(mux)
+	srv.URL = httpSrv.URL
+	srv.close = httpSrv.Close
+	t.Cleanup(httpSrv.Close)
+	return srv
+}
+
+func (s *fakeSSEMCPServer) handle(req mcp.JSONRPCMessage) mcp.JSONRPCMessage {
+	switch req.Method {
+	case "initialize":
+		return mcp.JSONRPCMessage{Result: json.RawMessage(`{
+            "protocolVersion": "2025-06-18",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "fake", "version": "0.1"}
+        }`)}
+	case "tools/list":
+		toolsJSON, _ := json.Marshal(map[string]any{"tools": []mcp.Tool{s.tool}})
+		return mcp.JSONRPCMessage{Result: toolsJSON}
+	case "tools/call":
+		var p struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
+		s.callsMu.Lock()
+		s.calls = append(s.calls, recordedCall{Name: p.Name, Args: p.Arguments})
+		s.callsMu.Unlock()
+
+		respJSON, _ := json.Marshal(s.callResp)
+		return mcp.JSONRPCMessage{Result: respJSON}
+	}
+	return mcp.JSONRPCMessage{Error: &mcp.JSONRPCError{Code: -32601, Message: "method not found: " + req.Method}}
+}
+
+func (s *fakeSSEMCPServer) recordedCalls() []recordedCall {
+	s.callsMu.Lock()
+	defer s.callsMu.Unlock()
+	out := make([]recordedCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+// fakeMCPSource is an MCPSource that returns a fixed URL — typically
+// pointing at a fakeSSEMCPServer in tests.
+type fakeMCPSource struct{ url string }
+
+func (s fakeMCPSource) Open(_ context.Context, _ map[string]any) (mcpsource.MCPConn, io.Closer, error) {
+	return mcpsource.MCPConn{URL: s.url}, io.NopCloser(nil), nil
+}
+
+// registerTestSource registers a fakeMCPSource under a unique name and
+// returns the name. The mcpsource package panics on duplicate names, so we
+// derive the name from the test name to avoid cross-test collisions.
+var testSourceCounter atomic.Int64
+
+func registerTestSource(t *testing.T, url string) string {
+	t.Helper()
+	name := fmt.Sprintf("test-source-%d", testSourceCounter.Add(1))
+	mcpsource.RegisterMCPSource(name, fakeMCPSource{url: url})
+	return name
+}
+
+// TestMCPSourceScope_DiscoversToolsAfterOpen is the key wiring assertion:
+// after a session-scoped source is opened, its tools must become resolvable
+// through the runtime tools.Registry. Currently this fails because
+// mcpSourceScope.openOne registers the MCP server in the MCP registry but
+// never triggers MCP tool discovery — so the tools.Registry never learns
+// about them and downstream lookups (ProviderStage / Executor) miss.
+func TestMCPSourceScope_DiscoversToolsAfterOpen(t *testing.T) {
+	srv := newFakeSSEMCPServer(t,
+		mcp.Tool{
+			Name:        "Read",
+			Description: "Read a file",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+		},
+		mcp.ToolCallResponse{Content: []mcp.Content{{Type: "text", Text: "file-contents"}}},
+	)
+
+	sourceName := registerTestSource(t, srv.URL)
+
+	mcpReg := mcp.NewRegistry()
+	t.Cleanup(func() { _ = mcpReg.Close() })
+	toolReg := tools.NewRegistry()
+	toolReg.RegisterExecutor(tools.NewMCPExecutor(mcpReg))
+
+	scope := newMCPSourceScopeWithTools(mcpReg, toolReg)
+
+	cfg := []config.MCPServerConfig{{
+		Name:   "sandbox",
+		Source: sourceName,
+		Scope:  string(mcpsource.ScopeSession),
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, scope.OpenAll(ctx, mcpsource.ScopeSession, "session-1", nil, nil, cfg))
+	t.Cleanup(func() {
+		for _, err := range scope.CloseAll(mcpsource.ScopeSession, "session-1") {
+			t.Logf("close error: %v", err)
+		}
+	})
+
+	// The MCP server should be registered in the MCP registry.
+	_, ok := mcpReg.GetServerConfig("sandbox")
+	require.True(t, ok, "MCP server should be registered after Open")
+
+	// Source-backed MCP servers register tools under their raw name —
+	// the sandbox is "just another MCP server" from the pack author's
+	// perspective.
+	desc, lookupErr := toolReg.GetTool("Read")
+	require.NoError(t, lookupErr, "tool descriptor should be registered after source open")
+	assert.Equal(t, "Read", desc.Name)
+	assert.Equal(t, "mcp", desc.Mode)
+}
+
+// TestMCPSourceScope_ToolDispatchEndToEnd verifies the full request path:
+// once the session source is open, calling the MCP tool through the runtime
+// tools.Registry round-trips to the SSE server and returns the response.
+func TestMCPSourceScope_ToolDispatchEndToEnd(t *testing.T) {
+	srv := newFakeSSEMCPServer(t,
+		mcp.Tool{
+			Name:        "Read",
+			Description: "Read a file",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+		},
+		mcp.ToolCallResponse{Content: []mcp.Content{{Type: "text", Text: "fake-file-contents"}}},
+	)
+
+	sourceName := registerTestSource(t, srv.URL)
+
+	mcpReg := mcp.NewRegistry()
+	t.Cleanup(func() { _ = mcpReg.Close() })
+	toolReg := tools.NewRegistry()
+	toolReg.RegisterExecutor(tools.NewMCPExecutor(mcpReg))
+
+	scope := newMCPSourceScopeWithTools(mcpReg, toolReg)
+
+	cfg := []config.MCPServerConfig{{
+		Name:   "sandbox",
+		Source: sourceName,
+		Scope:  string(mcpsource.ScopeSession),
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, scope.OpenAll(ctx, mcpsource.ScopeSession, "session-1", nil, nil, cfg))
+	t.Cleanup(func() {
+		for _, err := range scope.CloseAll(mcpsource.ScopeSession, "session-1") {
+			t.Logf("close error: %v", err)
+		}
+	})
+
+	result, err := toolReg.Execute(ctx, "Read", json.RawMessage(`{"path":"/etc/hostname"}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Error, "tool execution should succeed")
+	assert.Contains(t, string(result.Result), "fake-file-contents")
+
+	calls := srv.recordedCalls()
+	require.Len(t, calls, 1, "expected exactly one MCP tool call to reach the server")
+	assert.Equal(t, "Read", calls[0].Name, "MCP server should see the raw tool name")
+}

--- a/tools/arena/engine/mcpsource_dispatch_test.go
+++ b/tools/arena/engine/mcpsource_dispatch_test.go
@@ -28,12 +28,13 @@ import (
 // Lifted in spirit from runtime/mcp/sse_client_test.go's sseTestServer,
 // kept inline here so this test stays self-contained.
 type fakeSSEMCPServer struct {
-	URL      string
-	close    func()
-	tool     mcp.Tool
-	callsMu  sync.Mutex
-	calls    []recordedCall
-	callResp mcp.ToolCallResponse
+	URL           string
+	close         func()
+	tool          mcp.Tool
+	callsMu       sync.Mutex
+	calls         []recordedCall
+	callResp      mcp.ToolCallResponse
+	failListTools atomic.Bool // when true, tools/list returns a JSON-RPC error
 }
 
 type recordedCall struct {
@@ -121,6 +122,9 @@ func (s *fakeSSEMCPServer) handle(req mcp.JSONRPCMessage) mcp.JSONRPCMessage {
             "serverInfo": {"name": "fake", "version": "0.1"}
         }`)}
 	case "tools/list":
+		if s.failListTools.Load() {
+			return mcp.JSONRPCMessage{Error: &mcp.JSONRPCError{Code: -32000, Message: "tools/list disabled"}}
+		}
 		toolsJSON, _ := json.Marshal(map[string]any{"tools": []mcp.Tool{s.tool}})
 		return mcp.JSONRPCMessage{Result: toolsJSON}
 	case "tools/call":
@@ -268,4 +272,78 @@ func TestMCPSourceScope_ToolDispatchEndToEnd(t *testing.T) {
 	calls := srv.recordedCalls()
 	require.Len(t, calls, 1, "expected exactly one MCP tool call to reach the server")
 	assert.Equal(t, "Read", calls[0].Name, "MCP server should see the raw tool name")
+}
+
+// TestMCPSourceScope_DiscoveryRespectsToolFilter exercises the
+// allowlist branch of lookupToolFilter inside discoverAndRegisterServerTools.
+func TestMCPSourceScope_DiscoveryRespectsToolFilter(t *testing.T) {
+	srv := newFakeSSEMCPServer(t,
+		mcp.Tool{Name: "Read", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		mcp.ToolCallResponse{Content: []mcp.Content{{Type: "text", Text: "ok"}}},
+	)
+	sourceName := registerTestSource(t, srv.URL)
+
+	mcpReg := mcp.NewRegistry()
+	t.Cleanup(func() { _ = mcpReg.Close() })
+	toolReg := tools.NewRegistry()
+	toolReg.RegisterExecutor(tools.NewMCPExecutor(mcpReg))
+
+	scope := newMCPSourceScopeWithTools(mcpReg, toolReg)
+
+	cfg := []config.MCPServerConfig{{
+		Name:       "sandbox",
+		Source:     sourceName,
+		Scope:      string(mcpsource.ScopeSession),
+		ToolFilter: &config.MCPToolFilter{Blocklist: []string{"Read"}},
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, scope.OpenAll(ctx, mcpsource.ScopeSession, "session-1", nil, nil, cfg))
+	t.Cleanup(func() { _ = scope.CloseAll(mcpsource.ScopeSession, "session-1") })
+
+	_, err := toolReg.GetTool("Read")
+	assert.Error(t, err, "blocklisted tool should not be registered")
+}
+
+// TestMCPSourceScope_DiscoveryFailureRollsBackOpen exercises the rollback
+// path in openOne: when discoverAndRegisterServerTools fails after
+// RegisterServer succeeds, the source is closed and the server is
+// unregistered so the host doesn't leak the (failed) Open.
+//
+// We point the source at an httptest server that has already been closed,
+// so the SSE client's Initialize fails — that surfaces as a GetClient
+// error inside discoverAndRegisterServerTools.
+func TestMCPSourceScope_DiscoveryFailureRollsBackOpen(t *testing.T) {
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "gone", http.StatusGone)
+	}))
+	dead.Close() // dial will fail
+
+	sourceName := registerTestSource(t, dead.URL)
+
+	mcpReg := mcp.NewRegistry()
+	t.Cleanup(func() { _ = mcpReg.Close() })
+	toolReg := tools.NewRegistry()
+	toolReg.RegisterExecutor(tools.NewMCPExecutor(mcpReg))
+
+	scope := newMCPSourceScopeWithTools(mcpReg, toolReg)
+
+	cfg := []config.MCPServerConfig{{
+		Name:      "sandbox",
+		Source:    sourceName,
+		Scope:     string(mcpsource.ScopeSession),
+		TimeoutMs: 500, // bound the wait so the test is snappy
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := scope.OpenAll(ctx, mcpsource.ScopeSession, "session-1", nil, nil, cfg)
+	require.Error(t, err, "OpenAll should propagate the discovery failure")
+	assert.Contains(t, err.Error(), "discover tools after Open failed")
+
+	_, ok := mcpReg.GetServerConfig("sandbox")
+	assert.False(t, ok, "MCP server should be unregistered after discovery rollback")
 }

--- a/tools/arena/engine/mcpsource_scope.go
+++ b/tools/arena/engine/mcpsource_scope.go
@@ -2,16 +2,25 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
 )
+
+// discoveryTimeout bounds the per-server tools/list call made after a
+// source opens. The MCP client itself may also enforce a shorter timeout
+// based on the server's TimeoutMs.
+const discoveryTimeout = 30 * time.Second
 
 // openEntry tracks one open (scope, instance, server-name) triple so
 // CloseAll can find and tear it down.
@@ -24,15 +33,24 @@ type openEntry struct {
 // The zero value is not usable; use newMCPSourceScope.
 type mcpSourceScope struct {
 	registry mcp.Registry
+	// toolRegistry, when non-nil, receives MCP tool descriptors discovered
+	// for each server opened by this scope. Production wires this through
+	// newMCPSourceScopeWithTools; lifecycle-only unit tests pass nil.
+	toolRegistry *tools.Registry
 
 	mu    sync.Mutex
 	opens map[string][]openEntry // keyed by "<scope>|<instanceID>"
 }
 
 func newMCPSourceScope(registry mcp.Registry) *mcpSourceScope {
+	return newMCPSourceScopeWithTools(registry, nil)
+}
+
+func newMCPSourceScopeWithTools(registry mcp.Registry, toolReg *tools.Registry) *mcpSourceScope {
 	return &mcpSourceScope{
-		registry: registry,
-		opens:    map[string][]openEntry{},
+		registry:     registry,
+		toolRegistry: toolReg,
+		opens:        map[string][]openEntry{},
 	}
 }
 
@@ -97,8 +115,10 @@ func prepareEntryArgs(entry *config.MCPServerConfig, scenarioVars map[string]str
 	injectMountsIntoArgs(entry, mounts)
 }
 
-// openOne looks up the named source, calls Open, and registers the
-// resulting URL+Headers with the MCP registry.
+// openOne looks up the named source, calls Open, registers the resulting
+// URL+Headers with the MCP registry, and (when a toolRegistry is wired)
+// discovers and registers the server's tools so the runtime can dispatch
+// to them.
 func (m *mcpSourceScope) openOne(ctx context.Context, entry *config.MCPServerConfig) (openEntry, error) {
 	src, ok := mcpsource.LookupMCPSource(entry.Source)
 	if !ok {
@@ -120,8 +140,103 @@ func (m *mcpSourceScope) openOne(ctx context.Context, entry *config.MCPServerCon
 		_ = closer.Close()
 		return openEntry{}, fmt.Errorf("mcp server %q: register after Open failed: %w", entry.Name, err)
 	}
+	if err := m.discoverAndRegisterServerTools(ctx, entry.Name); err != nil {
+		_ = m.registry.UnregisterServer(entry.Name)
+		_ = closer.Close()
+		return openEntry{}, fmt.Errorf("mcp server %q: discover tools after Open failed: %w", entry.Name, err)
+	}
 	return openEntry{serverName: entry.Name, closer: closer}, nil
 }
+
+// discoverAndRegisterServerTools lists tools from the just-registered MCP
+// server and adds each as a ToolDescriptor in the tools.Registry under the
+// qualified name "mcp__<server>__<tool>". This mirrors the construction-time
+// discovery done by discoverAndRegisterMCPTools, but for one server at a
+// time so it can run after a source-backed open.
+//
+// When the toolRegistry is nil (lifecycle-only tests) discovery is skipped.
+func (m *mcpSourceScope) discoverAndRegisterServerTools(ctx context.Context, serverName string) error {
+	if m.toolRegistry == nil {
+		return nil
+	}
+
+	// Bound the lookup so a slow server can't stall scope open.
+	ctx, cancel := context.WithTimeout(ctx, discoveryTimeout)
+	defer cancel()
+
+	client, err := m.registry.GetClient(ctx, serverName)
+	if err != nil {
+		return fmt.Errorf("get MCP client: %w", err)
+	}
+
+	mcpTools, err := client.ListTools(ctx)
+	if err != nil {
+		return fmt.Errorf("list MCP tools: %w", err)
+	}
+
+	// Source-backed servers register tools under their raw MCP name
+	// (e.g. "Read") rather than the namespaced "mcp__<server>__<tool>"
+	// form used by static MCP discovery in builder_integration.go. The
+	// design goal is that a sandbox is "just another MCP server" from the
+	// pack author's perspective — allowed_tools and assertions reference
+	// "Read", not "mcp__sandbox__Read".
+	//
+	// Routing still works because MCPExecutor.callMCPTool runs each tool
+	// name through mcpRawToolName (a no-op when there's no namespace) and
+	// looks up the owning server via mcp.Registry.toolIndex, which is
+	// keyed by raw tool name.
+	for _, t := range mcpTools {
+		if filter, fok := m.lookupToolFilter(serverName); fok && filter != nil && !filter.Includes(t.Name) {
+			continue
+		}
+		desc := &tools.ToolDescriptor{
+			Name:         t.Name,
+			Description:  t.Description,
+			InputSchema:  t.InputSchema,
+			OutputSchema: mcpOutputSchema,
+			Mode:         "mcp",
+		}
+		if err := m.toolRegistry.Register(desc); err != nil {
+			return fmt.Errorf("register tool %q: %w", t.Name, err)
+		}
+	}
+	logger.Info("Discovered MCP tools (source-backed)", "server", serverName, "tools", len(mcpTools))
+	return nil
+}
+
+// lookupToolFilter returns the configured tool filter for a server, if any.
+func (m *mcpSourceScope) lookupToolFilter(serverName string) (*mcp.ToolFilter, bool) {
+	cfg, ok := m.registry.GetServerConfig(serverName)
+	if !ok {
+		return nil, false
+	}
+	return cfg.ToolFilter, true
+}
+
+// mcpOutputSchema is the generic shape MCP tool calls return — kept here
+// so the source-backed discovery path matches the construction-time path
+// in builder_integration.go.
+var mcpOutputSchema = json.RawMessage(`{
+    "type": "object",
+    "properties": {
+        "content": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string"},
+                    "text": {"type": "string"},
+                    "data": {"type": "string"},
+                    "mimeType": {"type": "string"},
+                    "uri": {"type": "string"}
+                },
+                "required": ["type"]
+            }
+        },
+        "isError": {"type": "boolean"}
+    },
+    "required": ["content"]
+}`)
 
 // CloseAll tears down every entry opened for (scope, instanceID). Close
 // errors are collected and returned; registry entries are removed regardless.

--- a/tools/arena/engine/mcpsource_scope.go
+++ b/tools/arena/engine/mcpsource_scope.go
@@ -131,12 +131,19 @@ func (m *mcpSourceScope) openOne(ctx context.Context, entry *config.MCPServerCon
 	if err != nil {
 		return openEntry{}, fmt.Errorf("mcp server %q: source %q Open failed: %w", entry.Name, entry.Source, err)
 	}
-	if err := m.registry.RegisterServer(mcp.ServerConfig{
+	serverCfg := mcp.ServerConfig{
 		Name:      entry.Name,
 		URL:       conn.URL,
 		Headers:   conn.Headers,
 		TimeoutMs: entry.TimeoutMs,
-	}); err != nil {
+	}
+	if entry.ToolFilter != nil {
+		serverCfg.ToolFilter = &mcp.ToolFilter{
+			Allowlist: entry.ToolFilter.Allowlist,
+			Blocklist: entry.ToolFilter.Blocklist,
+		}
+	}
+	if err := m.registry.RegisterServer(serverCfg); err != nil {
 		_ = closer.Close()
 		return openEntry{}, fmt.Errorf("mcp server %q: register after Open failed: %w", entry.Name, err)
 	}

--- a/tools/arena/engine/statestore_integration_test.go
+++ b/tools/arena/engine/statestore_integration_test.go
@@ -65,7 +65,7 @@ func TestStateStore_EndToEnd(t *testing.T) {
 	)
 
 	// Create engine
-	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil)
+	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)
 	}

--- a/tools/arena/engine/statestore_test.go
+++ b/tools/arena/engine/statestore_test.go
@@ -406,7 +406,7 @@ func TestEngine_WithStateStore(t *testing.T) {
 	}
 
 	// Create engine (this will call buildStateStore)
-	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil)
+	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)
 	}
@@ -513,7 +513,7 @@ func TestEngine_WithoutStateStore(t *testing.T) {
 	}
 
 	// Create engine (no StateStore in config, should default to MemoryStore)
-	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil)
+	engine, err := NewEngine(cfg, providerRegistry, nil, nil, conversationExecutor, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)
 	}

--- a/tools/arena/mcpsource/docker/source.go
+++ b/tools/arena/mcpsource/docker/source.go
@@ -160,14 +160,20 @@ func pickFreePort() (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
+// waitForHealth polls baseURL+/sse until the server returns 2xx or the
+// timeout elapses. The mcp-go SSE server (used by codegen-sandbox and other
+// SSE-MCP images) does not expose a separate /health endpoint — /sse itself
+// is the readiness signal: it returns 200 the moment the server can accept
+// MCP clients, then begins streaming events. We close the body immediately
+// once headers are received; the streaming body is irrelevant to the probe.
 func waitForHealth(ctx context.Context, baseURL string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/health", http.NoBody)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/sse", http.NoBody)
 		resp, err := http.DefaultClient.Do(req)
 		if err == nil {
 			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 				return nil
 			}
 		}

--- a/tools/arena/mcpsource/docker/source_test.go
+++ b/tools/arena/mcpsource/docker/source_test.go
@@ -45,7 +45,7 @@ func TestSource_Open_RequiresImage(t *testing.T) {
 
 func TestSource_Open_StartsContainerAndReturnsURL(t *testing.T) {
 	health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/health" {
+		if r.URL.Path == "/sse" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -65,6 +65,29 @@ func TestSource_Open_StartsContainerAndReturnsURL(t *testing.T) {
 
 	require.NoError(t, closer.Close())
 	assert.Equal(t, []string{"cid1"}, cli.stopCalls)
+}
+
+func TestSource_Open_ProbesSSEPath(t *testing.T) {
+	var probed []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probed = append(probed, r.URL.Path)
+		if r.URL.Path == "/sse" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cli := &fakeCLI{runID: "cid-sse"}
+	s := &Source{cli: cli, urlForContainer: func(_, _ string) string { return srv.URL }}
+
+	_, closer, err := s.Open(context.Background(), map[string]any{"image": "x"})
+	require.NoError(t, err)
+	defer func() { _ = closer.Close() }()
+
+	require.NotEmpty(t, probed, "expected at least one HTTP probe")
+	assert.Contains(t, probed, "/sse", "source must probe /sse for SSE-MCP readiness")
 }
 
 func TestSource_Open_HealthTimeoutClosesContainer(t *testing.T) {

--- a/tools/packc/compiler/skills_validator_integration.go
+++ b/tools/packc/compiler/skills_validator_integration.go
@@ -17,16 +17,25 @@ const skillMDFilename = "SKILL.md"
 var errPathTraversal = fmt.Errorf("path traversal detected")
 
 // validatePathContainment checks that resolvedAbs is within or equal to baseDir.
+//
+// Both rawPath and baseDir are resolved to absolute paths before comparison
+// so a relative baseDir (e.g. "examples/foo") doesn't false-positive against
+// an already-absolute rawPath stored by the config loader.
 func validatePathContainment(rawPath, baseDir string) error {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return fmt.Errorf("resolve base dir %q: %w", baseDir, err)
+	}
+	absBase = filepath.Clean(absBase)
+
 	absPath := rawPath
 	if !filepath.IsAbs(absPath) {
-		absPath = filepath.Join(baseDir, absPath)
+		absPath = filepath.Join(absBase, absPath)
 	}
 	absPath = filepath.Clean(absPath)
-	cleanBase := filepath.Clean(baseDir)
 
-	if absPath != cleanBase && !strings.HasPrefix(absPath, cleanBase+string(filepath.Separator)) {
-		return fmt.Errorf("%w: %q resolves outside pack directory %q", errPathTraversal, rawPath, cleanBase)
+	if absPath != absBase && !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %q resolves outside pack directory %q", errPathTraversal, rawPath, baseDir)
 	}
 	return nil
 }

--- a/tools/packc/skills_validator.go
+++ b/tools/packc/skills_validator.go
@@ -18,17 +18,25 @@ var errPathTraversal = fmt.Errorf("path traversal detected")
 
 // validatePathContainment checks that resolvedAbs is within or equal to baseDir.
 // Returns an error if the resolved path escapes the base directory.
+//
+// Both rawPath and baseDir are resolved to absolute paths before comparison
+// so a relative baseDir (e.g. "examples/foo") doesn't false-positive against
+// an already-absolute rawPath stored by the config loader.
 func validatePathContainment(rawPath, baseDir string) error {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return fmt.Errorf("resolve base dir %q: %w", baseDir, err)
+	}
+	absBase = filepath.Clean(absBase)
+
 	absPath := rawPath
 	if !filepath.IsAbs(absPath) {
-		absPath = filepath.Join(baseDir, absPath)
+		absPath = filepath.Join(absBase, absPath)
 	}
 	absPath = filepath.Clean(absPath)
-	cleanBase := filepath.Clean(baseDir)
 
-	// The resolved path must be the base itself or start with base + separator.
-	if absPath != cleanBase && !strings.HasPrefix(absPath, cleanBase+string(filepath.Separator)) {
-		return fmt.Errorf("%w: %q resolves outside pack directory %q", errPathTraversal, rawPath, cleanBase)
+	if absPath != absBase && !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %q resolves outside pack directory %q", errPathTraversal, rawPath, baseDir)
 	}
 	return nil
 }

--- a/tools/packc/skills_validator_test.go
+++ b/tools/packc/skills_validator_test.go
@@ -375,6 +375,38 @@ func TestValidateSkillErrors_PathTraversal(t *testing.T) {
 	}
 }
 
+func TestValidateSkillErrors_AbsolutePathInsideRelativeBaseDir(t *testing.T) {
+	// pkg/config.LoadConfig stores skill dirs as absolute paths in
+	// LoadedSkillSources, but packc's compiler invokes ValidateSkillErrors
+	// with a relative baseDir like "examples/foo". Without resolving both
+	// sides through filepath.Abs, the prefix check false-positives.
+	pack := &prompt.Pack{
+		Skills: []prompt.SkillSourceConfig{
+			{Dir: filepath.Join(".", "skills")}, // emulates the relative form actually held in YAML
+		},
+		Prompts: map[string]*prompt.PackPrompt{"p": {ID: "p"}},
+	}
+
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "skills", "demo")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: demo\ndescription: demo skill\n---\nbody\n"),
+		0o600,
+	))
+
+	// Now simulate the post-loader form: skill dir is absolute, base dir is relative.
+	pack.Skills[0] = prompt.SkillSourceConfig{Dir: filepath.Join(tmpDir, "skills")}
+
+	t.Chdir(filepath.Dir(tmpDir))
+	relBase, err := filepath.Rel(filepath.Dir(tmpDir), tmpDir)
+	require.NoError(t, err)
+
+	errs := ValidateSkillErrors(pack, relBase)
+	assert.Empty(t, errs, "absolute skill dir inside relative base dir must not false-positive")
+}
+
 func TestValidateSkillErrors_PathTraversal_WorkflowState(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Three fixes that make `examples/codegen-sandbox` work end-to-end against the published `ghcr.io/altairalabs/codegen-sandbox:latest` image. The load-bearing one is **(1)**:

1. **Source-backed MCP tool discovery.** A session-scoped `MCPSource` was opening a container and registering URL+headers in the MCP registry, but `tools/list` discovery + `ToolDescriptor` registration only ran at engine construction in `discoverAndRegisterMCPTools` — so source-backed tools never landed in `tools.Registry` and every call returned `tool not found`. `mcpSourceScope` now lists tools per-server after `Open` and registers each under its raw MCP name (`Read`, `Edit`, …). Routing already works because `MCPExecutor.callMCPTool` strips namespaces and looks up via `mcp.Registry.toolIndex`.

2. **Docker source health probe.** Arena polled `/health`, but the `mark3labs/mcp-go` SSE server (used by codegen-sandbox) doesn't expose `/health` — only `/sse`. Probe `/sse`; any 2xx is ready.

3. **Skill loader path containment.** `filepath.Dir("config.arena.yaml")` returns `"."` and `filepath.Clean("./skills")` returns `"skills"`, which failed the `HasPrefix` check (`"skills"` doesn't start with `"./"`). Anchor both sides at `filepath.Abs`.

## Why this matters

The codegen-sandbox example merged in #1032 couldn't actually run end-to-end without these fixes — the smoke test surfaced all three.

## What's verified

- New in-process integration test (`tools/arena/engine/mcpsource_dispatch_test.go`) exercises the full chain — fake `MCPSource` → `RegisterServer` → `tools/list` → `ToolDescriptor.Register` → `tools.Registry.Execute` round-trip — against an httptest SSE-MCP server. Future regressions surface in <1s without Docker.
- Existing arena/engine + pkg/config suites pass.
- Live smoke against the published image: container starts, 32 MCP tools discovered, full Bash → Read → Edit → run_tests sequence completes, both \`tools_called\` assertions score=1, exit code 0.

## API change

`engine.NewEngine` gains a trailing `*tools.Registry` parameter so the source-backed scope manager opened during construction can register discovered tools. Existing in-package test callers pass nil.

## Demo content

`examples/codegen-sandbox/mock-responses.yaml` now seeds its workspace via Bash (creating `go.mod`, a buggy `add.go`, and a failing test) before the Read/Edit/run_tests narrative, so the demo passes against an empty container with `--ci`. Tool argument names corrected to match the actual sandbox schema (`file_path` rather than `path`).

## Test plan

- [x] `go test ./tools/arena/... -count=1` — green
- [x] `go test ./pkg/... -count=1` — green
- [x] `make codegen-demo` against `ghcr.io/altairalabs/codegen-sandbox:latest` — exit 0, both assertions pass