### PR TITLE
docs(examples): add live Anthropic-driven codegen example

### DIFF
--- a/examples/codegen-anthropic/.env.example
+++ b/examples/codegen-anthropic/.env.example
@@ -1,0 +1,3 @@
+# Required: Anthropic API key for the Claude provider.
+# Get yours at https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=your_anthropic_key_here

--- a/examples/codegen-anthropic/README.md
+++ b/examples/codegen-anthropic/README.md
@@ -1,0 +1,80 @@
+# Codegen Sandbox — Real Anthropic Agent
+
+A live coding agent (Claude Sonnet 4.6) that writes a fresh Go module
+inside a [codegen-sandbox](https://github.com/AltairaLabs/CodeGen-Sandbox)
+container, runs the tests, and reports back.
+
+This is the companion to [`examples/codegen-sandbox/`](../codegen-sandbox/),
+which uses a mock provider for offline CI. Use that one to verify wiring;
+use this one to see an actual model do the work.
+
+## Prerequisites
+
+- Docker daemon running.
+- `ANTHROPIC_API_KEY` set in your environment.
+- `bin/promptarena` built (`make build-arena` from repo root).
+
+```bash
+cp .env.example .env
+# fill in ANTHROPIC_API_KEY
+export ANTHROPIC_API_KEY=...
+docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+make -C ../.. build-arena
+```
+
+## Run
+
+```bash
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+open out/report.html
+```
+
+What you should see:
+
+1. Arena starts a fresh codegen-sandbox container (port 8080 mapped to
+   a random local port).
+2. The runtime discovers the sandbox's MCP tools (Read, Edit, Bash,
+   run_tests, run_lint, …) and registers them under their raw names so
+   the agent can reference `Read`, not `mcp__sandbox__Read`.
+3. Claude Sonnet receives the scenario and starts working — typically
+   `Bash` to `go mod init`, `Write` for the implementation and tests,
+   `run_tests` to verify, then a final summary.
+4. Container is stopped and removed when the session ends.
+5. The HTML report shows every tool call with its arguments and
+   results, plus pass/fail status on the two `tools_called` assertions.
+
+The scenario asks for `IsPalindrome(s string) bool` — case-insensitive,
+whitespace-ignoring, with a table-driven test. Sonnet typically lands
+this in 6–10 tool calls.
+
+## Files
+
+- `config.arena.yaml` — arena config; the `mcp_servers` block declares
+  the source-backed sandbox.
+- `prompts/codegen-agent.yaml` — system prompt + `allowed_tools` listing
+  the sandbox tools.
+- `providers/claude-sonnet.provider.yaml` — Claude Sonnet 4.6.
+- `scenarios/implement-palindrome.scenario.yaml` — the coding task.
+- `skills/codegen/SKILL.md` — agent discipline (Read-before-Edit,
+  verify-before-done, etc.). Mounted read-only into the sandbox at
+  `/skills/codegen/`.
+
+## Cost
+
+A successful run is typically 5–10k input + 1–3k output tokens against
+Sonnet ≈ $0.05–$0.10 per run.
+
+## Failure modes
+
+- `tool_filter` rejected: the agent asked for a tool not in
+  `allowed_tools`. Add it to the prompt config.
+- `run_tests`: returns "no supported project detected" → the agent
+  hasn't initialised `go.mod` yet. Usually self-corrects on the next
+  turn.
+- HTTP rate limit from Anthropic: bump `max_tokens` down and retry, or
+  wait and rerun.
+
+## See also
+
+- [Provision an MCP Sandbox per Scenario](https://promptkit.altairalabs.ai/arena/how-to/provision-mcp-sandbox/) — reference docs for the source/scope/source_args fields.
+- [`examples/codegen-sandbox/`](../codegen-sandbox/) — mock-provider variant for CI.

--- a/examples/codegen-anthropic/config.arena.yaml
+++ b/examples/codegen-anthropic/config.arena.yaml
@@ -1,0 +1,48 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: codegen-anthropic-arena
+  annotations:
+    description: |
+      A real Anthropic-driven coding agent writing a Go module from scratch
+      inside the codegen-sandbox container. Companion to examples/codegen-sandbox/
+      (which uses a mock provider for offline CI).
+
+      Run:
+        export ANTHROPIC_API_KEY=...
+        make build-arena
+        docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+        cd examples/codegen-anthropic
+        PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+
+spec:
+  prompt_configs:
+    - id: codegen-agent
+      file: prompts/codegen-agent.yaml
+
+  providers:
+    - file: providers/claude-sonnet.provider.yaml
+
+  scenarios:
+    - file: scenarios/implement-palindrome.scenario.yaml
+
+  mcp_servers:
+    - name: sandbox
+      source: docker
+      scope: session
+      source_args:
+        image: ghcr.io/altairalabs/codegen-sandbox:latest
+        env:
+          DEV_MODE: "1"
+
+  skills:
+    - path: skills/
+    - path: skills/codegen
+      preload: true
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 4096
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/codegen-anthropic/prompts/codegen-agent.yaml
+++ b/examples/codegen-anthropic/prompts/codegen-agent.yaml
@@ -1,0 +1,37 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+
+metadata:
+  name: codegen-agent
+
+spec:
+  task_type: codegen-agent
+  version: "v1.0.0"
+  description: "Coding agent with sandbox tools — implements + verifies real Go programs."
+  system_template: |
+    You are a coding agent. The user will describe a task; complete it
+    using the sandbox tools.
+
+    Workspace conventions:
+      - The container's working directory is /workspace and starts empty.
+      - You are responsible for setting up the project layout (go.mod,
+        package files, test files) before writing application code.
+      - Verify with run_tests before declaring done.
+
+    Discipline:
+      - Read before Edit. Edit a file you haven't Read this session and
+        the call will fail.
+      - When tests fail, fix the code — never the test — unless the test
+        itself was wrong.
+      - Be terse. The user reads tool calls; they don't need narration.
+
+  allowed_tools:
+    - Read
+    - Edit
+    - Write
+    - Glob
+    - Grep
+    - Bash
+    - run_tests
+    - run_lint
+    - run_typecheck

--- a/examples/codegen-anthropic/providers/claude-sonnet.provider.yaml
+++ b/examples/codegen-anthropic/providers/claude-sonnet.provider.yaml
@@ -1,0 +1,23 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: anthropic-sonnet
+spec:
+  id: anthropic-sonnet
+  type: claude
+  model: claude-sonnet-4-6
+  capabilities:
+    - text
+    - streaming
+    - tools
+    - json
+  defaults:
+    temperature: 0.1
+    top_p: 1.0
+    max_tokens: 4096
+  pricing:
+    input_cost_per_1k: 0.003
+    output_cost_per_1k: 0.015
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/examples/codegen-anthropic/scenarios/implement-palindrome.scenario.yaml
+++ b/examples/codegen-anthropic/scenarios/implement-palindrome.scenario.yaml
@@ -1,0 +1,36 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: implement-palindrome
+
+spec:
+  id: implement-palindrome
+  task_type: codegen-agent
+  description: Agent implements IsPalindrome from scratch and verifies tests pass.
+
+  turns:
+    - role: user
+      content: |
+        Inside /workspace, implement a Go module called example.com/palindrome
+        that exposes:
+
+            func IsPalindrome(s string) bool
+
+        The function must:
+          - Be case-insensitive ("Racecar" → true).
+          - Ignore whitespace ("nurses run" → true).
+          - Treat the empty string as a palindrome.
+
+        Add a table-driven test (palindrome_test.go) covering each rule and
+        at least one negative case. Implement the function, run the tests
+        with run_tests, and only declare done once they pass.
+      assertions:
+        - type: tools_called
+          params:
+            tools: ["Bash"]
+            message: "Must initialise the workspace (go mod, file scaffolding) via Bash."
+        - type: tools_called
+          params:
+            tools: ["run_tests"]
+            message: "Must verify with run_tests before finishing."

--- a/examples/codegen-anthropic/skills/codegen/SKILL.md
+++ b/examples/codegen-anthropic/skills/codegen/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: codegen
+description: Disciplined code-generation workflow for agents with a sandbox (Read/Edit/Bash/run_tests/run_lint/run_typecheck). Use whenever the task is to modify source code.
+metadata:
+  tags: "code, editing, testing"
+---
+
+# Codegen Skill
+
+You are writing code inside a container sandbox. Your tools execute real commands against a real filesystem; mistakes are cheap to undo but waste turns.
+
+When a sandbox is mounted, your reference skill files are available read-only at `/skills/codegen/` inside the sandbox. Scripts can be executed via `Bash`; reference files can also be read via `skill__read_resource` (host-side).
+
+## Discipline
+
+**1. Read before Edit.**
+Never call `Edit` on a file you have not `Read` this session. If you discover the file doesn't look like you expected, Read it again before editing.
+
+**2. Plan multi-step work with TodoWrite.**
+For any task with 3+ logical steps (e.g., a bugfix that needs test, fix, and verification), write a todo list first. Mark each item as you finish it. This keeps you on track when tool responses push context.
+
+**3. Verify before declaring done.**
+Before saying "done", run the appropriate verification tool:
+- `run_tests` — the project's test suite must pass.
+- `run_lint` — no new lint errors on files you touched.
+- `run_typecheck` — no new type errors.
+
+For a bugfix, write a failing test *first*, then the fix, then confirm the test now passes. Do not skip the failing-first step — a test that was always green doesn't verify your fix.
+
+**4. Small, focused diffs.**
+Change only what the task requires. Unrelated "while I was here" edits make review harder and tests flakier.
+
+## Language notes
+
+**Go:** `gofmt`/`goimports` are enforced. Imports grouped: stdlib, then third-party, then local. Check with `run_lint` (uses golangci-lint).
+
+**Node:** Detect the package manager from the lockfile (`package-lock.json` → npm, `yarn.lock` → yarn, `pnpm-lock.yaml` → pnpm). Use the project's lockfile convention for install/add.
+
+**Python:** If the repo has a virtualenv (`.venv/`) or manages deps via Poetry (`pyproject.toml` with `[tool.poetry]`), activate/use it. Never `pip install` into the system Python.
+
+**Rust:** `cargo fmt` and `cargo clippy` before saying done; these map to `run_lint`.
+
+## Failure mode recovery
+
+- Tests fail after your edit → Read the test output, find the first failing assertion, understand the gap between expected and actual, make one focused fix, retest. Don't edit the test to make it pass unless the test itself was wrong.
+- Build fails (compile / type error) → Fix the compile error first before running tests. A failing build invalidates everything.
+- `Bash` returns non-zero unexpectedly → Read the full stderr before retrying. Infra errors (disk full, permission denied) need different treatment from code errors.
+
+## Not your job
+
+- Setting up the repo (it's already cloned at `/workspace`).
+- Installing new runtimes (the sandbox image ships pinned toolchains).
+- Remembering what you did in a previous session (you don't have one).


### PR DESCRIPTION
## Summary

Adds `examples/codegen-anthropic/` — a real Claude Sonnet 4.6 agent writing a fresh Go module inside the codegen-sandbox container, then running the tests to verify.

Companion to `examples/codegen-sandbox/` (mock provider for CI). Same source-backed MCP wiring landed in #1082; different provider and a from-scratch task instead of a seeded bug-fix.

## Scenario

> Inside `/workspace`, implement a Go module `example.com/palindrome` exposing `IsPalindrome(s string) bool`. Case-insensitive, ignores whitespace, empty string is a palindrome. Add a table-driven test covering each rule plus a negative case. Verify with `run_tests`.

Assertions: \`tools_called: [Bash]\` (workspace setup) and \`tools_called: [run_tests]\` (verification).

## Files

- \`config.arena.yaml\` — declares Anthropic provider + source-backed MCP sandbox.
- \`prompts/codegen-agent.yaml\` — system prompt + \`allowed_tools\` (Read, Edit, Write, Glob, Grep, Bash, run_tests, run_lint, run_typecheck).
- \`providers/claude-sonnet.provider.yaml\` — Sonnet 4.6.
- \`scenarios/implement-palindrome.scenario.yaml\` — the coding task + assertions.
- \`skills/codegen/SKILL.md\` — copied from the mock variant.
- \`README.md\`, \`.env.example\`.

## Verification

- packc compile: clean.
- \`promptarena run --mock-provider --ci\`: config loads, container starts, 32 MCP tools discovered (the wiring is exercised, assertions fail as expected with no canned responses — mock mode is for wiring smoke only on this example).
- Live run requires \`ANTHROPIC_API_KEY\` — not running it from CI on cost grounds.

## Test plan

- [x] \`packc compile -c examples/codegen-anthropic/config.arena.yaml\` succeeds
- [x] \`promptarena run --mock-provider --ci\` exercises the source-backed MCP wiring without burning API credits
- [ ] User-side: set \`ANTHROPIC_API_KEY\`, run \`promptarena run --ci --format html\`, confirm tests pass and the HTML report shows the agent's tool sequence