### PR TITLE
feat(sdk): MCP endpoint resolver for name-only servers

### DIFF
--- a/sdk/mcp_resolver.go
+++ b/sdk/mcp_resolver.go
@@ -1,0 +1,58 @@
+package sdk
+
+// MCPEndpoint is the live coordinates a host hands the SDK so an MCP
+// server declared by name can be reached. URL is the base URL the
+// runtime/mcp client will dial; Headers are attached to every request
+// (typical use: bearer auth, tenancy hints).
+type MCPEndpoint struct {
+	URL     string
+	Headers map[string]string
+}
+
+// MCPEndpointResolver maps an MCP server name to a live endpoint.
+//
+// The SDK calls Resolve at conversation open for any server declared by
+// name (without a static URL or stdio Command) so the host — Omnia, a
+// dev-only docker shim, a custom orchestrator — can decide where the
+// server actually lives. Pack/agent authors stay oblivious to
+// provisioning concerns.
+//
+// Mirrors the A2A [EndpointResolver] interface: pack declares by name,
+// host injects the lookup, SDK plugs the result into descriptors at
+// construction time.
+//
+// An empty URL signals "no endpoint available" — the SDK surfaces a
+// clear error to the caller. Resolvers that genuinely have no opinion
+// for an unknown name should return [MCPEndpoint]{}.
+type MCPEndpointResolver interface {
+	Resolve(serverName string) MCPEndpoint
+}
+
+// StaticMCPEndpointResolver returns the same endpoint for every name.
+// Useful when all MCP traffic flows through a single gateway or when a
+// dev loop runs one local sandbox.
+type StaticMCPEndpointResolver struct {
+	URL     string
+	Headers map[string]string
+}
+
+// Resolve returns the static endpoint for any server name.
+func (r *StaticMCPEndpointResolver) Resolve(_ string) MCPEndpoint {
+	return MCPEndpoint{URL: r.URL, Headers: r.Headers}
+}
+
+// MapMCPEndpointResolver maps each MCP server name to a specific
+// endpoint. Names not in the map resolve to [MCPEndpoint]{}, which the
+// SDK treats as an error.
+type MapMCPEndpointResolver struct {
+	Endpoints map[string]MCPEndpoint
+}
+
+// Resolve returns the endpoint for the given name, or the zero value
+// when the name is not in the map.
+func (r *MapMCPEndpointResolver) Resolve(serverName string) MCPEndpoint {
+	if r == nil || r.Endpoints == nil {
+		return MCPEndpoint{}
+	}
+	return r.Endpoints[serverName]
+}

--- a/sdk/mcp_resolver_test.go
+++ b/sdk/mcp_resolver_test.go
@@ -1,0 +1,129 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaticMCPEndpointResolver(t *testing.T) {
+	r := &StaticMCPEndpointResolver{
+		URL:     "http://gateway",
+		Headers: map[string]string{"Authorization": "Bearer x"},
+	}
+	ep := r.Resolve("anything")
+	assert.Equal(t, "http://gateway", ep.URL)
+	assert.Equal(t, "Bearer x", ep.Headers["Authorization"])
+}
+
+func TestMapMCPEndpointResolver(t *testing.T) {
+	r := &MapMCPEndpointResolver{
+		Endpoints: map[string]MCPEndpoint{
+			"codegen": {URL: "http://cg.svc:8080"},
+			"fs":      {URL: "http://fs.svc:8080", Headers: map[string]string{"X-Tenant": "acme"}},
+		},
+	}
+	assert.Equal(t, "http://cg.svc:8080", r.Resolve("codegen").URL)
+	assert.Equal(t, "acme", r.Resolve("fs").Headers["X-Tenant"])
+	assert.Empty(t, r.Resolve("unknown").URL, "unknown name returns zero endpoint")
+
+	var nilResolver *MapMCPEndpointResolver
+	assert.Empty(t, nilResolver.Resolve("anything").URL, "nil resolver is safe")
+}
+
+func TestNewMCPServerByName(t *testing.T) {
+	b := NewMCPServerByName("codegen")
+	cfg := b.Build()
+	assert.Equal(t, "codegen", cfg.Name)
+	assert.Empty(t, cfg.Command, "name-only builder must not set Command")
+	assert.Empty(t, cfg.URL, "name-only builder must not set URL")
+}
+
+func TestResolveMCPEndpoint_StaticURLPassesThrough(t *testing.T) {
+	cfg := &mcp.ServerConfig{Name: "x", URL: "http://existing"}
+	r := &StaticMCPEndpointResolver{URL: "http://resolver-shouldnt-fire"}
+	require.NoError(t, resolveMCPEndpoint(cfg, r))
+	assert.Equal(t, "http://existing", cfg.URL, "resolver must not overwrite a static URL")
+}
+
+func TestResolveMCPEndpoint_StdioCommandPassesThrough(t *testing.T) {
+	cfg := &mcp.ServerConfig{Name: "x", Command: "npx"}
+	r := &StaticMCPEndpointResolver{URL: "http://resolver-shouldnt-fire"}
+	require.NoError(t, resolveMCPEndpoint(cfg, r))
+	assert.Empty(t, cfg.URL)
+	assert.Equal(t, "npx", cfg.Command)
+}
+
+func TestResolveMCPEndpoint_NameOnlyFillsURLAndHeaders(t *testing.T) {
+	cfg := &mcp.ServerConfig{Name: "codegen"}
+	r := &StaticMCPEndpointResolver{
+		URL:     "http://sandbox.svc:8080",
+		Headers: map[string]string{"Authorization": "Bearer t"},
+	}
+	require.NoError(t, resolveMCPEndpoint(cfg, r))
+	assert.Equal(t, "http://sandbox.svc:8080", cfg.URL)
+	assert.Equal(t, "Bearer t", cfg.Headers["Authorization"])
+}
+
+func TestResolveMCPEndpoint_NameOnlyMergesIntoExistingHeaders(t *testing.T) {
+	cfg := &mcp.ServerConfig{
+		Name:    "codegen",
+		Headers: map[string]string{"X-Existing": "preserved"},
+	}
+	r := &StaticMCPEndpointResolver{
+		URL:     "http://sandbox.svc:8080",
+		Headers: map[string]string{"Authorization": "Bearer t"},
+	}
+	require.NoError(t, resolveMCPEndpoint(cfg, r))
+	assert.Equal(t, "preserved", cfg.Headers["X-Existing"])
+	assert.Equal(t, "Bearer t", cfg.Headers["Authorization"])
+}
+
+func TestResolveMCPEndpoint_NameOnlyWithoutResolverErrors(t *testing.T) {
+	cfg := &mcp.ServerConfig{Name: "codegen"}
+	err := resolveMCPEndpoint(cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WithMCPEndpoints")
+}
+
+func TestResolveMCPEndpoint_ResolverReturningEmptyURLErrors(t *testing.T) {
+	cfg := &mcp.ServerConfig{Name: "codegen"}
+	r := &MapMCPEndpointResolver{Endpoints: map[string]MCPEndpoint{}} // unknown name
+	err := resolveMCPEndpoint(cfg, r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no URL")
+}
+
+func TestWithMCPEndpoints_StoresResolverOnConfig(t *testing.T) {
+	r := &StaticMCPEndpointResolver{URL: "http://x"}
+	c := &config{}
+	require.NoError(t, WithMCPEndpoints(r)(c))
+	assert.Same(t, r, c.mcpEndpointResolver)
+}
+
+func TestInitMCPRegistry_NameOnlyWithResolver(t *testing.T) {
+	conv := &Conversation{}
+	cfg := &config{
+		mcpServers: []mcp.ServerConfig{
+			{Name: "codegen"}, // name-only, will be resolved
+		},
+		mcpEndpointResolver: &StaticMCPEndpointResolver{URL: "http://resolved"},
+	}
+	require.NoError(t, initMCPRegistry(conv, cfg))
+	require.NotNil(t, conv.mcpRegistry)
+	got, ok := conv.mcpRegistry.(*mcp.RegistryImpl).GetServerConfig("codegen")
+	require.True(t, ok)
+	assert.Equal(t, "http://resolved", got.URL)
+}
+
+func TestInitMCPRegistry_NameOnlyWithoutResolverErrors(t *testing.T) {
+	conv := &Conversation{}
+	cfg := &config{
+		mcpServers: []mcp.ServerConfig{{Name: "codegen"}},
+	}
+	err := initMCPRegistry(conv, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MCP server \"codegen\"")
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -188,6 +188,11 @@ type config struct {
 	// Multi-agent endpoint resolution
 	agentEndpointResolver EndpointResolver
 
+	// MCP endpoint resolution — fills URL/Headers for MCP servers
+	// declared by name only (no static URL/Command). Mirrors the A2A
+	// agent-endpoint resolver pattern.
+	mcpEndpointResolver MCPEndpointResolver
+
 	// Local agent executor for in-process multi-agent routing
 	localAgentExecutor *LocalAgentExecutor
 
@@ -1557,6 +1562,62 @@ func (b *MCPServerBuilder) Build() mcp.ServerConfig {
 func WithMCPServer(builder *MCPServerBuilder) Option {
 	return func(c *config) error {
 		c.mcpServers = append(c.mcpServers, builder.Build())
+		return nil
+	}
+}
+
+// NewMCPServerByName declares an MCP server by name only — no command,
+// no URL. The endpoint must be filled in at conversation open by an
+// [MCPEndpointResolver] registered via [WithMCPEndpoints]. Use this
+// when the host (e.g. Omnia, a sandbox pool, a service-discovery
+// layer) owns provisioning and the SDK consumer only needs to declare
+// "I want an MCP server called X".
+//
+//	conv, _ := sdk.Open("./assistant.pack.json", "assistant",
+//	    sdk.WithMCPServer(sdk.NewMCPServerByName("codegen")),
+//	    sdk.WithMCPEndpoints(omniaResolver),
+//	)
+func NewMCPServerByName(name string) *MCPServerBuilder {
+	return &MCPServerBuilder{
+		config: mcp.ServerConfig{Name: name},
+	}
+}
+
+// WithMCPEndpoints configures endpoint resolution for MCP servers
+// declared by name only (no static URL or stdio Command).
+//
+// At conversation open the SDK calls Resolve once per name-only server
+// and plugs the returned URL+Headers into the runtime MCP registry.
+// Servers declared with a URL or Command bypass the resolver.
+//
+// Mirrors [WithAgentEndpoints] for A2A. The host injects a single
+// resolver; pack/agent authors stay oblivious to provisioning.
+//
+// Example with a single gateway:
+//
+//	conv, _ := sdk.Open("./assistant.pack.json", "assistant",
+//	    sdk.WithMCPServer(sdk.NewMCPServerByName("codegen")),
+//	    sdk.WithMCPEndpoints(&sdk.StaticMCPEndpointResolver{
+//	        URL:     "http://localhost:9000",
+//	        Headers: map[string]string{"Authorization": "Bearer " + token},
+//	    }),
+//	)
+//
+// Example with per-server endpoints:
+//
+//	conv, _ := sdk.Open("./assistant.pack.json", "assistant",
+//	    sdk.WithMCPServer(sdk.NewMCPServerByName("codegen")),
+//	    sdk.WithMCPServer(sdk.NewMCPServerByName("filesystem")),
+//	    sdk.WithMCPEndpoints(&sdk.MapMCPEndpointResolver{
+//	        Endpoints: map[string]sdk.MCPEndpoint{
+//	            "codegen":    {URL: "http://codegen-pool.svc:8080"},
+//	            "filesystem": {URL: "http://fs.svc:8080"},
+//	        },
+//	    }),
+//	)
+func WithMCPEndpoints(resolver MCPEndpointResolver) Option {
+	return func(c *config) error {
+		c.mcpEndpointResolver = resolver
 		return nil
 	}
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -755,6 +755,12 @@ func initDuplexSession(conv *Conversation, cfg *config, streamProvider providers
 }
 
 // initMCPRegistry initializes the MCP registry if servers are configured.
+//
+// Each server configured by name only (no URL, no Command) gets its
+// endpoint filled in by cfg.mcpEndpointResolver before it's registered.
+// Servers with a static URL or stdio Command bypass the resolver. A
+// name-only server with no resolver configured is a clear error rather
+// than a silent skip.
 func initMCPRegistry(conv *Conversation, cfg *config) error {
 	if len(cfg.mcpServers) == 0 {
 		return nil
@@ -764,9 +770,41 @@ func initMCPRegistry(conv *Conversation, cfg *config) error {
 	conv.mcpRegistry = registry
 
 	for _, serverCfg := range cfg.mcpServers {
+		if err := resolveMCPEndpoint(&serverCfg, cfg.mcpEndpointResolver); err != nil {
+			_ = registry.Close()
+			return err
+		}
 		if err := registry.RegisterServer(serverCfg); err != nil {
 			_ = registry.Close()
 			return fmt.Errorf("failed to register MCP server %q: %w", serverCfg.Name, err)
+		}
+	}
+	return nil
+}
+
+// resolveMCPEndpoint fills serverCfg.URL/Headers via the resolver when
+// the server was declared by name only. Mutates serverCfg in place.
+func resolveMCPEndpoint(serverCfg *mcp.ServerConfig, resolver MCPEndpointResolver) error {
+	if serverCfg.URL != "" || serverCfg.Command != "" {
+		return nil
+	}
+	if resolver == nil {
+		return fmt.Errorf(
+			"MCP server %q declared by name only but no MCPEndpointResolver is configured (see WithMCPEndpoints)",
+			serverCfg.Name,
+		)
+	}
+	endpoint := resolver.Resolve(serverCfg.Name)
+	if endpoint.URL == "" {
+		return fmt.Errorf("MCP endpoint resolver returned no URL for server %q", serverCfg.Name)
+	}
+	serverCfg.URL = endpoint.URL
+	if len(endpoint.Headers) > 0 {
+		if serverCfg.Headers == nil {
+			serverCfg.Headers = make(map[string]string, len(endpoint.Headers))
+		}
+		for k, v := range endpoint.Headers {
+			serverCfg.Headers[k] = v
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Adds the MCP equivalent of \`sdk.WithAgentEndpoints\` (A2A's host-injected endpoint resolver). Pack/SDK consumers can declare an MCP server by name only and have the host fill in URL+Headers at conversation open.

\`\`\`go
conv, _ := sdk.Open(pack, "agent",
    sdk.WithMCPServer(sdk.NewMCPServerByName("codegen")),
    sdk.WithMCPEndpoints(hostResolver),
)
\`\`\`

The host injects a single \`MCPEndpointResolver\`; pack/agent authors stay oblivious to where the server actually runs. Servers declared with a static URL or stdio Command bypass the resolver, so existing \`WithMCP\` / \`WithMCPServer\` call sites are unaffected. A name-only server with no resolver configured is a clear error.

## Why

Pattern symmetry — A2A already has it (\`sdk/agent_resolver.go\`, \`sdk.WithAgentEndpoints\`), MCP didn't. This closes the gap so SDK consumers using a sandbox pool, a service-discovery layer, or any other host-managed MCP provisioning can declare servers abstractly without baking provisioning concerns into pack/agent surface.

## Out of scope

**This is not the integration path for Omnia.** Omnia ships its own \`tools.Executor\` (\`omnia/internal/runtime/tools/omnia_executor.go\`) that bypasses \`runtime/mcp\` entirely; per-conversation sandbox pools are configured via \`MCPCfg.Endpoint\` on the Omnia side at agent boot. This PR is for the open-source SDK consumer who wants the ergonomic "declare by name, host resolves" pattern without writing a custom executor.

## Files

- \`sdk/mcp_resolver.go\` — \`MCPEndpointResolver\` interface, \`MCPEndpoint\` struct, \`Static\` and \`Map\` helpers (mirrors \`agent_resolver.go\`).
- \`sdk/mcp_resolver_test.go\` — unit tests covering helpers, static-URL bypass, name-only resolution, header merge, error paths.
- \`sdk/options.go\` — \`WithMCPEndpoints\` option + \`NewMCPServerByName\` builder.
- \`sdk/sdk.go\` — \`initMCPRegistry\` calls \`resolveMCPEndpoint\` per server before \`RegisterServer\`.

## Test plan

- [x] \`go test ./sdk/... -count=1\` — green; new file at 100% coverage; \`sdk.go\` and \`options.go\` over the 80% threshold on changed lines.
- [x] Existing \`WithMCP\` / \`WithMCPServer\` paths unaffected (servers with URL or Command bypass resolver entirely; tests confirm).