### PR TITLE
fix(sdk): wire MCP tools into the pipeline + add live codegen example

### DIFF
--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -450,6 +450,13 @@ func (c *Conversation) registerMCPExecutors() {
 		return
 	}
 
+	// Register a single runtime MCP executor that dispatches every
+	// Mode="mcp" tool to the underlying MCP client. This is the canonical
+	// wiring used by arena (tools/arena/engine/builder_integration.go) —
+	// the runtime's tools.Registry.getExecutorForTool resolves Mode="mcp"
+	// to executor name "mcp", which only the runtime executor satisfies.
+	c.toolRegistry.RegisterExecutor(tools.NewMCPExecutor(c.mcpRegistry))
+
 	for serverName, serverTools := range mcpTools {
 		// Look up the server config to check for tool filters.
 		var toolFilter *mcp.ToolFilter
@@ -470,7 +477,9 @@ func (c *Conversation) registerMCPExecutors() {
 
 			qualifiedName := fmt.Sprintf("mcp__%s__%s", serverName, tool.Name)
 
-			// Register the MCP tool in the registry with qualified name
+			// Register the MCP tool in the registry with qualified name.
+			// The runtime MCPExecutor strips the namespace and looks up
+			// the owning server via mcp.Registry.toolIndex.
 			desc := &tools.ToolDescriptor{
 				Name:        qualifiedName,
 				Description: tool.Description,
@@ -478,13 +487,6 @@ func (c *Conversation) registerMCPExecutors() {
 				Mode:        "mcp",
 			}
 			_ = c.toolRegistry.Register(desc)
-
-			adapter := &mcpHandlerAdapter{
-				qualifiedName: qualifiedName,
-				rawName:       tool.Name,
-				registry:      c.mcpRegistry,
-			}
-			c.toolRegistry.RegisterExecutor(adapter)
 		}
 	}
 }

--- a/sdk/examples/codegen-resolver/README.md
+++ b/sdk/examples/codegen-resolver/README.md
@@ -1,0 +1,57 @@
+# Codegen Sandbox via MCP Endpoint Resolver
+
+SDK example exercising `sdk.WithMCPEndpoints` — pack declares the MCP
+server by name only, host injects the lookup.
+
+## What this shows
+
+- `sdk.NewMCPServerByName("codegen")` — declare an MCP server with no
+  URL/Command. The pack-author surface stays free of provisioning
+  concerns.
+- `sdk.WithMCPEndpoints(resolver)` — host injects a single resolver. At
+  conversation open the SDK calls `resolver.Resolve("codegen")` and
+  plugs the URL+Headers into the runtime MCP registry.
+- Real model + real container. Claude Sonnet 4.6 talks to the
+  codegen-sandbox via the resolved endpoint, writes a Go module from
+  scratch, runs the tests.
+
+In production your resolver would call a sandbox pool, service
+discovery, or some host-managed orchestrator. Here it's a tiny
+`StaticMCPEndpointResolver` and the example provisions the container
+itself for a single self-contained demo.
+
+## Prerequisites
+
+- Docker daemon running.
+- `ANTHROPIC_API_KEY` in environment.
+- `ghcr.io/altairalabs/codegen-sandbox:latest` pulled (or the example
+  pulls it on first `docker run`).
+
+## Run
+
+```bash
+export ANTHROPIC_API_KEY=...
+docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+go run .
+```
+
+Expected output:
+
+```
+sandbox ready: http://localhost:42813 (container 5f3a92b1c0d4)
+=== Agent reply ===
+All 7 tests pass with 100% coverage. ...
+```
+
+The container is stopped + removed on exit.
+
+## Cost
+
+A single run is typically 5–10k input + ~1k output tokens against
+Sonnet ≈ $0.05–$0.10.
+
+## See also
+
+- The arena variant: [`examples/codegen-anthropic/`](../../../examples/codegen-anthropic/) — same idea but driven through arena's source-backed MCP machinery instead of an SDK resolver. Better for batch evaluation.
+- `sdk/examples/mcp-tools/` — non-resolver MCP example (declare with
+  `WithMCP("name", "command", args...)`).

--- a/sdk/examples/codegen-resolver/codegen-resolver.pack.json
+++ b/sdk/examples/codegen-resolver/codegen-resolver.pack.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "codegen-resolver-example",
+  "name": "Codegen Resolver Example",
+  "version": "1.0.0",
+  "description": "SDK example: name-only MCP server resolved by a host-injected MCPEndpointResolver.",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "codegen": {
+      "id": "codegen",
+      "name": "Codegen Agent",
+      "version": "1.0.0",
+      "system_template": "You are a coding agent operating inside a sandboxed container. The container's working directory is /workspace and starts empty. You are responsible for setting up the project layout (go.mod, files) before writing application code.\n\nYou have an MCP server named 'codegen' providing Read, Edit, Write, Bash, run_tests, run_lint, and run_typecheck. Tools appear in your tool list as mcp__codegen__<name>.\n\nDiscipline:\n- Read before Edit. Editing a file you haven't Read this session will fail.\n- Verify with mcp__codegen__run_tests before declaring done.\n- Be terse. The user reads tool calls; they don't need narration."
+    }
+  }
+}

--- a/sdk/examples/codegen-resolver/main.go
+++ b/sdk/examples/codegen-resolver/main.go
@@ -1,0 +1,158 @@
+// Package main demonstrates the SDK's MCP endpoint resolver pattern.
+//
+// The pack declares an MCP server by name only ("codegen"); a host-supplied
+// resolver fills in URL/Headers at conversation open. This example wears
+// both hats — it spins up a codegen-sandbox container, points a
+// StaticMCPEndpointResolver at it, then opens a conversation and asks
+// Claude Sonnet to write a small Go module.
+//
+// In production the resolver would talk to your sandbox pool / service
+// discovery / Omnia. The pack/agent layer stays oblivious to provisioning.
+//
+// Run:
+//
+//	export ANTHROPIC_API_KEY=...
+//	docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+//	go run .
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+const (
+	sandboxImage    = "ghcr.io/altairalabs/codegen-sandbox:latest"
+	sandboxPort     = 8080
+	healthBudget    = 30 * time.Second
+	healthInterval  = 250 * time.Millisecond
+	conversationCtx = 5 * time.Minute
+)
+
+func main() {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		log.Fatal("ANTHROPIC_API_KEY not set")
+	}
+
+	// 1. Provision a sandbox. In prod, your resolver would call a pool
+	//    API; here we shell out to docker for a self-contained demo.
+	bgCtx := context.Background()
+	hostPort, err := pickFreePort(bgCtx)
+	if err != nil {
+		log.Fatalf("pick port: %v", err)
+	}
+	containerID, err := startSandbox(bgCtx, hostPort)
+	if err != nil {
+		log.Fatalf("start sandbox: %v", err)
+	}
+	defer stopSandbox(containerID)
+
+	sandboxURL := fmt.Sprintf("http://localhost:%d", hostPort)
+	if err := waitForSSE(bgCtx, sandboxURL); err != nil {
+		log.Fatalf("sandbox not ready: %v", err)
+	}
+	log.Printf("sandbox ready: %s (container %s)", sandboxURL, containerID[:12])
+
+	// 2. Wire the resolver. Pack/agent code never sees this URL.
+	resolver := &sdk.StaticMCPEndpointResolver{URL: sandboxURL}
+
+	conv, err := sdk.Open("./codegen-resolver.pack.json", "codegen",
+		sdk.WithModel("claude-sonnet-4-6"),
+		sdk.WithAPIKey(apiKey),
+		sdk.WithMCPServer(sdk.NewMCPServerByName("codegen")),
+		sdk.WithMCPEndpoints(resolver),
+	)
+	if err != nil {
+		log.Fatalf("open conversation: %v", err)
+	}
+	defer conv.Close()
+
+	// 3. Ask the agent to do something real. It uses Bash/Write/run_tests
+	//    via the MCP server we just resolved — tool calls round-trip to
+	//    the running container.
+	ctx, cancel := context.WithTimeout(context.Background(), conversationCtx)
+	defer cancel()
+
+	task := strings.TrimSpace(`
+Inside /workspace, set up a Go module called example.com/reverse and
+implement:
+
+    func Reverse(s string) string
+
+The function must reverse a Unicode string by runes (not bytes), so
+"héllo" reverses to "olléh". Add a table-driven test (reverse_test.go)
+covering ASCII, accented characters, an empty string, and a
+mixed-case word. Run the tests with mcp__codegen__run_tests and only
+declare done once they pass.
+`)
+
+	resp, err := conv.Send(ctx, task)
+	if err != nil {
+		log.Fatalf("send: %v", err)
+	}
+
+	fmt.Println("=== Agent reply ===")
+	fmt.Println(resp.Text())
+}
+
+func pickFreePort(ctx context.Context) (int, error) {
+	var lc net.ListenConfig
+	l, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func startSandbox(ctx context.Context, hostPort int) (string, error) {
+	out, err := exec.CommandContext(ctx, "docker", "run", "-d", "--rm",
+		"-p", fmt.Sprintf("%d:%d", hostPort, sandboxPort),
+		"-e", "DEV_MODE=1",
+		sandboxImage,
+	).Output()
+	if err != nil {
+		return "", fmt.Errorf("docker run: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func stopSandbox(containerID string) {
+	if containerID == "" {
+		return
+	}
+	// Use a fresh background context; the parent ctx may already be done by
+	// the time we tear the container down (e.g. user canceled mid-run).
+	if err := exec.CommandContext(context.Background(), "docker", "stop", containerID).Run(); err != nil {
+		log.Printf("warning: docker stop %s: %v", containerID[:12], err)
+	}
+}
+
+func waitForSSE(ctx context.Context, baseURL string) error {
+	deadline := time.Now().Add(healthBudget)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/sse", http.NoBody)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+		}
+		time.Sleep(healthInterval)
+	}
+	return fmt.Errorf("sandbox not ready within %s", healthBudget)
+}

--- a/sdk/mcp_resolver_test.go
+++ b/sdk/mcp_resolver_test.go
@@ -186,13 +186,11 @@ func TestOpen_NameOnlyMCPWithResolverSucceeds(t *testing.T) {
 	assert.NotNil(t, conv)
 }
 
-// TestOpenDuplex_InitMCPRegistryRunsBeforePipelineBuild covers the
-// duplex path's MCP-init hoist. The mock provider doesn't satisfy
-// providers.StreamInputSupport so OpenDuplex returns a clear "not
-// supported" error — but only after option application; the MCP init
-// runs first if the path got here. Negative test confirms ordering
-// without requiring a real streaming provider.
-func TestOpenDuplex_InitMCPRegistryReachable(t *testing.T) {
+// TestOpenDuplex_NameOnlyMCPWithoutResolverErrors covers the duplex
+// path's MCP-init hoist. With no resolver configured, OpenDuplex must
+// surface the MCP error before the streaming-support check — the
+// reorder keeps Open() and OpenDuplex() validating the same surface.
+func TestOpenDuplex_NameOnlyMCPWithoutResolverErrors(t *testing.T) {
 	packFile := writeMCPTestPack(t)
 	provider := mock.NewProvider("mock", "mock-model", false)
 
@@ -202,8 +200,6 @@ func TestOpenDuplex_InitMCPRegistryReachable(t *testing.T) {
 		WithMCPServer(NewMCPServerByName("codegen")),
 	)
 	require.Error(t, err)
-	// Either the duplex provider check fires first, or the MCP error does.
-	// Both are acceptable paths from this branch; the test exists to
-	// exercise OpenDuplex's option/init plumbing post-reorder.
-	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "MCP server \"codegen\"",
+		"MCP-init error must surface before the streaming-support check")
 }

--- a/sdk/mcp_resolver_test.go
+++ b/sdk/mcp_resolver_test.go
@@ -1,9 +1,12 @@
 package sdk
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -126,4 +129,81 @@ func TestInitMCPRegistry_NameOnlyWithoutResolverErrors(t *testing.T) {
 	err := initMCPRegistry(conv, cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "MCP server \"codegen\"")
+}
+
+// writeMCPTestPack writes a minimal pack file usable by Open() in tests
+// that need the full conversation init path (e.g. covering the
+// initMCPRegistry hoist into Open and OpenDuplex).
+func writeMCPTestPack(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	packFile := filepath.Join(dir, "test.pack.json")
+	packContent := `{
+        "name": "test-pack",
+        "version": "v1",
+        "prompts": {
+            "main": {"system_template": "You are a helpful assistant."}
+        }
+    }`
+	require.NoError(t, os.WriteFile(packFile, []byte(packContent), 0o644))
+	return packFile
+}
+
+// TestOpen_NameOnlyMCPWithoutResolverErrors covers the Open() path
+// where initMCPRegistry now runs before pipeline construction and
+// surfaces a clear error when a name-only server has no resolver.
+func TestOpen_NameOnlyMCPWithoutResolverErrors(t *testing.T) {
+	packFile := writeMCPTestPack(t)
+	provider := mock.NewProvider("mock", "mock-model", false)
+
+	_, err := Open(packFile, "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithMCPServer(NewMCPServerByName("codegen")),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MCP server \"codegen\"")
+}
+
+// TestOpen_NameOnlyMCPWithResolverSucceeds covers the Open() happy path
+// for a resolver-backed MCP server: Open must complete cleanly even
+// though the resolver points at a URL that doesn't actually serve MCP
+// (the runtime client's tool listing degrades to an empty tool set
+// rather than failing the open).
+func TestOpen_NameOnlyMCPWithResolverSucceeds(t *testing.T) {
+	packFile := writeMCPTestPack(t)
+	provider := mock.NewProvider("mock", "mock-model", false)
+	resolver := &StaticMCPEndpointResolver{URL: "http://127.0.0.1:1"} // unreachable, intentionally
+
+	conv, err := Open(packFile, "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithMCPServer(NewMCPServerByName("codegen")),
+		WithMCPEndpoints(resolver),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+	assert.NotNil(t, conv)
+}
+
+// TestOpenDuplex_InitMCPRegistryRunsBeforePipelineBuild covers the
+// duplex path's MCP-init hoist. The mock provider doesn't satisfy
+// providers.StreamInputSupport so OpenDuplex returns a clear "not
+// supported" error — but only after option application; the MCP init
+// runs first if the path got here. Negative test confirms ordering
+// without requiring a real streaming provider.
+func TestOpenDuplex_InitMCPRegistryReachable(t *testing.T) {
+	packFile := writeMCPTestPack(t)
+	provider := mock.NewProvider("mock", "mock-model", false)
+
+	_, err := OpenDuplex(packFile, "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithMCPServer(NewMCPServerByName("codegen")),
+	)
+	require.Error(t, err)
+	// Either the duplex provider check fires first, or the MCP error does.
+	// Both are acceptable paths from this branch; the test exists to
+	// exercise OpenDuplex's option/init plumbing post-reorder.
+	assert.NotNil(t, err)
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -87,16 +87,23 @@ func Open(packPath, promptName string, opts ...Option) (*Conversation, error) {
 		return nil, err
 	}
 
+	// Initialize the MCP registry BEFORE the pipeline is built. The pipeline
+	// build path calls registerMCPExecutors, which queries the MCP registry
+	// to surface tool descriptors; if the registry is still nil at that
+	// point the conversation ends up with zero MCP tools regardless of how
+	// servers were declared.
+	if err := initMCPRegistry(conv, conv.config); err != nil {
+		return nil, err
+	}
+
 	// Initialize internal memory store for conversation history
 	// This is used by StateStoreLoad/Save middleware in the pipeline
 	if err := initInternalStateStore(conv, conv.config); err != nil {
 		return nil, err
 	}
 
-	// Finalize conversation (eval middleware, MCP, session start hooks)
-	if err := finalizeConversation(conv, conv.config); err != nil {
-		return nil, err
-	}
+	// Finalize conversation (eval middleware, session start hooks)
+	finalizeConversation(conv)
 
 	// Register with shutdown manager if configured
 	if conv.config.shutdownManager != nil {
@@ -153,15 +160,19 @@ func OpenDuplex(packPath, promptName string, opts ...Option) (*Conversation, err
 		)
 	}
 
+	// Initialize the MCP registry BEFORE building the duplex pipeline so
+	// registerMCPExecutors sees a populated registry. See note in Open().
+	if err := initMCPRegistry(conv, conv.config); err != nil {
+		return nil, err
+	}
+
 	// Initialize duplex session
 	if err := initDuplexSession(conv, conv.config, streamProvider); err != nil {
 		return nil, err
 	}
 
-	// Finalize conversation (eval middleware, MCP, session start hooks)
-	if err := finalizeConversation(conv, conv.config); err != nil {
-		return nil, err
-	}
+	// Finalize conversation (eval middleware, session start hooks)
+	finalizeConversation(conv)
 
 	// Register with shutdown manager if configured
 	if conv.config.shutdownManager != nil {
@@ -265,22 +276,16 @@ func initConversation(
 	return conv, prov, nil
 }
 
-// finalizeConversation completes the conversation setup after mode-specific
-// initialization (unary or duplex). It wires eval middleware, MCP servers,
-// and dispatches session start hooks.
-func finalizeConversation(conv *Conversation, cfg *config) error {
+// finalizeConversation completes the conversation setup after the MCP
+// registry and mode-specific session have been initialized. It wires
+// eval middleware and dispatches session start hooks. (MCP registry
+// initialization moved earlier so it precedes pipeline construction.)
+func finalizeConversation(conv *Conversation) {
 	// Initialize eval middleware
 	conv.evalMW = newEvalMiddleware(conv)
 
-	// Initialize MCP registry if configured
-	if err := initMCPRegistry(conv, cfg); err != nil {
-		return err
-	}
-
 	// Dispatch session start hooks
 	conv.sessionHooks.SessionStart(context.Background())
-
-	return nil
 }
 
 // applyOptions applies the configuration options and validates cross-option constraints.

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -151,6 +151,14 @@ func OpenDuplex(packPath, promptName string, opts ...Option) (*Conversation, err
 		return nil, err
 	}
 
+	// Initialize the MCP registry BEFORE the streaming-support check so
+	// the same surface validates both Open() and OpenDuplex() consistently —
+	// a misconfigured MCP entry surfaces with the same error in either
+	// flavor, regardless of which provider was wired. (See note in Open().)
+	if err := initMCPRegistry(conv, conv.config); err != nil {
+		return nil, err
+	}
+
 	// Verify provider supports streaming input
 	streamProvider, ok := prov.(providers.StreamInputSupport)
 	if !ok {
@@ -158,12 +166,6 @@ func OpenDuplex(packPath, promptName string, opts ...Option) (*Conversation, err
 			"provider %T does not support duplex streaming (must implement providers.StreamInputSupport)",
 			prov,
 		)
-	}
-
-	// Initialize the MCP registry BEFORE building the duplex pipeline so
-	// registerMCPExecutors sees a populated registry. See note in Open().
-	if err := initMCPRegistry(conv, conv.config); err != nil {
-		return nil, err
 	}
 
 	// Initialize duplex session

--- a/sdk/template.go
+++ b/sdk/template.go
@@ -147,15 +147,18 @@ func (t *PackTemplate) openConversation(
 		return nil, err
 	}
 
+	// MCP registry must be initialized BEFORE the session/pipeline so the
+	// pipeline build can surface MCP tool descriptors. See sdk.go:Open for
+	// the same ordering invariant.
+	if err := initMCPRegistry(conv, cfg); err != nil {
+		return nil, err
+	}
+
 	if err := t.initSession(conv, cfg, prov, duplex); err != nil {
 		return nil, err
 	}
 
 	conv.evalMW = newEvalMiddleware(conv)
-
-	if err := initMCPRegistry(conv, cfg); err != nil {
-		return nil, err
-	}
 
 	conv.sessionHooks.SessionStart(context.Background())
 	return conv, nil


### PR DESCRIPTION
## Summary

Building a runnable SDK example for the MCPEndpointResolver landed in #1098 surfaced two pre-existing bugs that prevented any SDK-configured MCP server from actually delivering tools to the LLM. **The existing `sdk/examples/mcp-tools/` example was also affected** — anyone running it was getting a model with no tools, and the model was responding with text-formatted "tool calls" rather than real ones.

## Bug 1 — Wrong ordering

\`Open()\` built the pipeline (which calls \`registerMCPExecutors\`) BEFORE \`finalizeConversation\` ran \`initMCPRegistry\`. So the MCP registry was always nil during the one pipeline build, MCP tool descriptors never reached \`tools.Registry\`, and the LLM was called with \`tools=false\`. Affects all three transports: stdio (\`WithMCP\`), URL (\`WithMCPServer\`), and the new resolver path.

**Fix:** hoist \`initMCPRegistry\` above the pipeline build in \`Open()\`, \`OpenDuplex()\`, and \`PackTemplate.Open()\`. The MCP registry is now populated by the time \`registerMCPExecutors\` runs. \`finalizeConversation\` no longer touches MCP and no longer returns an error.

## Bug 2 — Missing executor

\`registerMCPExecutors\` registered per-tool \`mcpHandlerAdapter\` instances keyed by the qualified name (\`mcp__<server>__<tool>\`). But \`runtime/tools.Registry.getExecutorForTool\` resolves \`Mode="mcp"\` to executor name \`"mcp"\` specifically (registry.go:570-571). With no executor registered under that name, every MCP tool call failed lookup, the result message had \`Error\` set, and after two rejections the tool was excluded from the LLM's tool list.

**Fix:** register a single \`tools.NewMCPExecutor\` (matches arena's pattern at \`tools/arena/engine/builder_integration.go:377\`). It handles namespace stripping and routes via \`mcp.Registry.toolIndex\`. The per-tool \`mcpHandlerAdapter\` is now dead in the dispatch path; left in place for now since it still has unit tests — can prune in a follow-up.

## Live demo

\`sdk/examples/codegen-resolver/\` exercises the new \`WithMCPEndpoints\` resolver against the real codegen-sandbox image. A \`StaticMCPEndpointResolver\` points at a container the example provisions itself; Claude Sonnet 4.6 implements a \`Reverse\` function with table-driven tests covering ASCII, accented characters, emoji, and edge cases — verified end-to-end with \`run_tests\` passing 9/9 at 100% coverage. ~$0.05–$0.10 per run.

\`\`\`
$ go run .
sandbox ready: http://localhost:55520 (container 3cf56f67776f)
=== Agent reply ===
All 9 sub-tests pass with **100% statement coverage**. ...
\`\`\`

## Test plan

- [x] \`go test ./sdk/... -count=1\` — all green
- [x] \`go run ./sdk/examples/codegen-resolver/\` — exit 0, 4 tool calls (Bash + 2×Write + run_tests), test suite passes inside the sandbox
- [x] No regressions on existing SDK MCP tests