### PR TITLE
feat(evals): tool_exec handler — invoke a tool, assert it succeeded

### DIFF
--- a/docs/src/content/docs/arena/how-to/provision-mcp-sandbox.md
+++ b/docs/src/content/docs/arena/how-to/provision-mcp-sandbox.md
@@ -188,6 +188,55 @@ For a no-Docker variant against the canned LLM responses, use
 
 ---
 
+## Hard gating on a sandbox tool
+
+Once the sandbox is wired, the natural pairing is the [`tool_exec`
+check](/reference/checks/#tool-invocation-checks) — it invokes a
+registered tool at the end of the session and asserts the call
+succeeded. Codegen sandboxes typically expose `run_tests` /
+`run_lint` / `run_typecheck`, all of which return structured
+success/failure that `tool_exec` reads directly. The result is a
+hard "did the agent's edits actually pass tests" gate on the run:
+
+```yaml
+spec:
+  mcp_servers:
+    - name: sandbox
+      source: docker
+      scope: session
+      source_args:
+        image: ghcr.io/altairalabs/codegen-sandbox:latest
+
+  scenarios:
+    - file: scenarios/fix-the-bug.scenario.yaml
+```
+
+```yaml
+# scenarios/fix-the-bug.scenario.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: fix-the-bug
+spec:
+  id: fix-the-bug
+  task_type: codegen-agent
+  turns:
+    - role: user
+      content: "There's a bug in /workspace/add.go. Fix it."
+  conversation_assertions:
+    - type: tool_exec
+      params:
+        tool: run_tests
+      message: "Hidden test suite must pass"
+```
+
+The session-scoped MCP source keeps the container alive across both
+the agent's tool calls and the `tool_exec` gate's call — the gate
+just runs `run_tests` one more time after the agent declares done,
+and the test result drives the hard gate.
+
+---
+
 ## Skill staging
 
 When a pack declares skills and the source supports it, Arena

--- a/docs/src/content/docs/arena/reference/assertions.md
+++ b/docs/src/content/docs/arena/reference/assertions.md
@@ -67,6 +67,7 @@ The table below lists the most commonly used assertion types. For full details a
 | `json_schema` | Response conforms to a JSON Schema |
 | `no_tool_errors` | All tool calls completed without errors |
 | `tool_call_chain` | Tools were called in a specific order |
+| `tool_exec` | Invoke a registered tool (e.g. a sandbox's `run_tests`) at session end and assert it succeeded |
 
 :::note[Type aliases]
 Assertions support both canonical and alias names. For example, `content_includes` is an alias for `contains`. See the [Checks Reference](/reference/checks/#assertion-aliases) for the full alias table.

--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -139,6 +139,76 @@ Session-level tool checks use the `on_session_complete` or `on_conversation_comp
 
 ---
 
+## Tool Invocation Checks
+
+Unlike the tool checks above (which evaluate tools the agent already
+called), this check **invokes a tool itself** and asserts on the
+result. Typical use is to run a verification tool — a sandbox's
+`run_tests`, a render-and-diff utility, a custom HTTP probe — as the
+hard gate after the conversation completes.
+
+### `tool_exec`
+
+Invokes a registered tool by name through the runtime tool registry
+and passes if the call succeeded. The pass condition is:
+
+- `tools.Registry.Execute` returns no error, **and**
+- the resulting `ToolResult.Error` field is empty.
+
+This makes `tool_exec` a generic "is this tool happy" gate that works
+with any registered tool — MCP-discovered (e.g. a sandbox's
+`run_tests`), HTTP, local executors, custom client tools. The handler
+doesn't know or care about the transport.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tool` | string | Yes | Registry name of the tool to invoke. |
+| `args` | object | No | Arguments passed verbatim to the tool. Defaults to `{}`. |
+| `timeout_seconds` | int | No | Per-call timeout. Default `120`. Generous because the typical use case is a long-running test suite inside a sandbox. |
+
+**Surfaces:** A E (conversation-level / session-level — invoke at the end of the session, not per turn)
+
+**Example — gating on a sandbox's hidden test suite:**
+
+```yaml
+conversation_assertions:
+  - type: tool_exec
+    params:
+      tool: run_tests
+    message: "Hidden tests must pass"
+```
+
+Pair this with a [source-backed MCP entry](/arena/how-to/provision-mcp-sandbox/)
+that supplies the `run_tests` tool — the sandbox lives for the
+session, runs the agent's edits, and the gate checks them at the end.
+
+**Example — pack-shipped validation tool:**
+
+```yaml
+conversation_assertions:
+  - type: tool_exec
+    params:
+      tool: validate_invoice
+      args:
+        strict: true
+      timeout_seconds: 30
+    message: "Final invoice must validate"
+```
+
+**Notes**
+
+- The host (arena, SDK, …) must inject a `*tools.Registry` into
+  `EvalContext.Metadata["tool_registry"]`. Arena does this
+  automatically; SDK consumers using the runtime evals API directly
+  need to populate it themselves.
+- Because the gate _calls_ a tool, it counts toward whatever cost /
+  side-effect budget the tool implies (e.g. running the test suite
+  costs CPU time, an HTTP probe costs a request).
+- Errors from the tool surface in the assertion's `Explanation` so
+  failures are debuggable from the report without re-running.
+
+---
+
 ## Agent & Skill Checks
 
 | Type | Params | Surfaces |

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -1487,6 +1487,9 @@ func TestRegisterInit(t *testing.T) {
 		"a2a_eval",
 		"a2a_eval_session",
 
+		// Tool-invocation gate
+		"tool_exec",
+
 		// Length validation handlers
 		"min_length",
 		"max_length",

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -83,6 +83,11 @@ func init() {
 	evals.RegisterDefault(&A2AEvalHandler{})
 	evals.RegisterDefault(&A2AEvalSessionHandler{})
 
+	// Tool-invocation gate. Calls a registered tool by name and asserts
+	// the call succeeded — generic primitive for "did this side-effect
+	// pass" assertions (sandbox test runs, validation tools, …).
+	evals.RegisterDefault(&ToolExecHandler{})
+
 	// Behavioral testing handlers (Phase 6)
 	evals.RegisterDefault(&OutcomeEquivalentHandler{})
 	evals.RegisterDefault(&DirectionalHandler{})

--- a/runtime/evals/handlers/tool_exec.go
+++ b/runtime/evals/handlers/tool_exec.go
@@ -1,0 +1,152 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// defaultToolExecTimeout bounds the per-call timeout when params don't
+// specify one. Generous because the typical use case is "run the test
+// suite inside a sandbox" — much longer than a normal tool call.
+const defaultToolExecTimeout = 120 * time.Second
+
+// metadataKeyToolRegistry is the EvalContext.Metadata key under which
+// the consuming host (arena, SDK, etc.) injects a *tools.Registry.
+// Without it, ToolExecHandler returns a clear configuration error
+// rather than panicking on a nil registry.
+const metadataKeyToolRegistry = "tool_registry"
+
+// ToolExecHandler invokes a tool by name through the runtime tool
+// registry and asserts the call succeeded. The pass condition is:
+//
+//   - tools.Registry.Execute returns no error, AND
+//   - the resulting ToolResult has an empty Error field.
+//
+// This makes it a generic "is this tool happy" gate that works with
+// any registered tool: MCP-backed (e.g. a sandbox's run_tests),
+// HTTP/local executors, custom client tools — whatever the host has
+// wired up. The handler doesn't know or care about the transport.
+//
+// Params:
+//   - tool string (required) — registry name of the tool to invoke
+//   - args map[string]any (optional) — arguments passed verbatim to Execute
+//   - timeout_seconds int (optional) — bounds the call; default 120
+//
+// Score is 1.0 on success, 0.0 on any failure (error returned, result
+// has Error field set, missing tool, missing registry, timeout).
+type ToolExecHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ToolExecHandler) Type() string { return "tool_exec" }
+
+// Eval invokes the named tool and returns pass/fail based on whether
+// the tool reported success.
+func (h *ToolExecHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	toolName, _ := params["tool"].(string)
+	if toolName == "" {
+		return failResult(h.Type(), "tool_exec: 'tool' parameter is required"), nil
+	}
+
+	registry, err := h.resolveRegistry(evalCtx)
+	if err != nil {
+		return failResult(h.Type(), err.Error()), nil
+	}
+
+	args, err := h.encodeArgs(params)
+	if err != nil {
+		return failResult(h.Type(), fmt.Sprintf("tool_exec: encode args for %q: %v", toolName, err)), nil
+	}
+
+	timeout := h.timeout(params)
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	result, execErr := registry.Execute(execCtx, toolName, args)
+	if execErr != nil {
+		return failResult(h.Type(), fmt.Sprintf("tool_exec: %q failed: %v", toolName, execErr)), nil
+	}
+	if result == nil {
+		return failResult(h.Type(), fmt.Sprintf("tool_exec: %q returned no result", toolName)), nil
+	}
+	if result.Error != "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Score:       boolScore(false),
+			Explanation: fmt.Sprintf("tool_exec: %q reported error: %s", toolName, result.Error),
+			Value:       map[string]any{"tool": toolName, "error": result.Error},
+		}, nil
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Score:       boolScore(true),
+		Explanation: fmt.Sprintf("tool_exec: %q succeeded", toolName),
+		Value: map[string]any{
+			"tool":       toolName,
+			"latency_ms": result.LatencyMs,
+		},
+	}, nil
+}
+
+// resolveRegistry pulls the tools.Registry out of EvalContext.Metadata.
+// Returns a clear error rather than nil so callers learn how to fix
+// the wiring (host needs to inject the registry before evaluating).
+func (h *ToolExecHandler) resolveRegistry(evalCtx *evals.EvalContext) (*tools.Registry, error) {
+	if evalCtx == nil || evalCtx.Metadata == nil {
+		return nil, fmt.Errorf("tool_exec: no metadata on eval context; host must inject tool_registry")
+	}
+	raw, ok := evalCtx.Metadata[metadataKeyToolRegistry]
+	if !ok {
+		return nil, fmt.Errorf(
+			"tool_exec: %q not present in metadata; host must inject the tool registry",
+			metadataKeyToolRegistry,
+		)
+	}
+	registry, ok := raw.(*tools.Registry)
+	if !ok || registry == nil {
+		return nil, fmt.Errorf("tool_exec: %q is not a *tools.Registry (got %T)", metadataKeyToolRegistry, raw)
+	}
+	return registry, nil
+}
+
+// encodeArgs marshals the params.args map (if any) to JSON for Execute.
+// Empty / missing args returns an empty json.RawMessage which most
+// executors accept as "no args".
+func (h *ToolExecHandler) encodeArgs(params map[string]any) (json.RawMessage, error) {
+	raw, ok := params["args"]
+	if !ok || raw == nil {
+		return json.RawMessage(`{}`), nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	return encoded, nil
+}
+
+// timeout reads timeout_seconds from params, clamped to a sane default.
+func (h *ToolExecHandler) timeout(params map[string]any) time.Duration {
+	secs := extractInt(params, "timeout_seconds", 0)
+	if secs <= 0 {
+		return defaultToolExecTimeout
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// failResult is a small helper for the early-exit fail paths.
+func failResult(typeName, explanation string) *evals.EvalResult {
+	return &evals.EvalResult{
+		Type:        typeName,
+		Score:       boolScore(false),
+		Explanation: explanation,
+	}
+}

--- a/runtime/evals/handlers/tool_exec_test.go
+++ b/runtime/evals/handlers/tool_exec_test.go
@@ -1,0 +1,164 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubExecutor is a minimal tools.Executor that returns a configured
+// result and/or error. Lets tool_exec tests exercise the success/error
+// paths without standing up a real MCP server or sandbox.
+type stubExecutor struct {
+	name      string
+	result    json.RawMessage
+	returnErr error
+}
+
+func (e *stubExecutor) Name() string { return e.name }
+
+func (e *stubExecutor) Execute(_ context.Context, _ *tools.ToolDescriptor, _ json.RawMessage) (json.RawMessage, error) {
+	if e.returnErr != nil {
+		return nil, e.returnErr
+	}
+	if e.result != nil {
+		return e.result, nil
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+// newStubRegistry wires a registry where the named tool maps to a stub
+// executor under a custom Mode. tool_exec dispatches by Mode → executor
+// name, so registering the executor under a custom name and giving the
+// descriptor the matching Mode is the cleanest test scaffold.
+func newStubRegistry(t *testing.T, toolName string, exec *stubExecutor) *tools.Registry {
+	t.Helper()
+	registry := tools.NewRegistry()
+	registry.RegisterExecutor(exec)
+	desc := &tools.ToolDescriptor{
+		Name: toolName,
+		Mode: exec.Name(),
+		// The handler under test passes args verbatim; tool_exec doesn't
+		// care about argument validation. Skip InputSchema to bypass.
+	}
+	require.NoError(t, registry.Register(desc))
+	return registry
+}
+
+func evalCtxWithRegistry(registry *tools.Registry) *evals.EvalContext {
+	return &evals.EvalContext{
+		Metadata: map[string]any{"tool_registry": registry},
+	}
+}
+
+func TestToolExec_Type(t *testing.T) {
+	assert.Equal(t, "tool_exec", (&ToolExecHandler{}).Type())
+}
+
+func TestToolExec_RequiresToolParam(t *testing.T) {
+	registry := newStubRegistry(t, "noop", &stubExecutor{name: "stub-pass"})
+	h := &ToolExecHandler{}
+	res, err := h.Eval(context.Background(), evalCtxWithRegistry(registry), map[string]any{})
+	require.NoError(t, err)
+	assert.NotNil(t, res.Score)
+	assert.Equal(t, 0.0, *res.Score)
+	assert.Contains(t, res.Explanation, "'tool' parameter is required")
+}
+
+func TestToolExec_NoRegistryConfigured(t *testing.T) {
+	h := &ToolExecHandler{}
+	res, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{"tool": "noop"})
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, *res.Score)
+	assert.Contains(t, res.Explanation, "no metadata")
+}
+
+func TestToolExec_RegistryWrongType(t *testing.T) {
+	h := &ToolExecHandler{}
+	res, err := h.Eval(context.Background(),
+		&evals.EvalContext{Metadata: map[string]any{"tool_registry": "not a registry"}},
+		map[string]any{"tool": "noop"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, *res.Score)
+	assert.Contains(t, res.Explanation, "not a *tools.Registry")
+}
+
+func TestToolExec_SuccessPath(t *testing.T) {
+	registry := newStubRegistry(t, "run_tests", &stubExecutor{
+		name:   "stub-pass",
+		result: json.RawMessage(`{"output": "PASS"}`),
+	})
+	h := &ToolExecHandler{}
+	res, err := h.Eval(context.Background(), evalCtxWithRegistry(registry), map[string]any{
+		"tool": "run_tests",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, *res.Score)
+	assert.Contains(t, res.Explanation, "succeeded")
+}
+
+func TestToolExec_ExecutorReturnsError(t *testing.T) {
+	registry := newStubRegistry(t, "run_tests", &stubExecutor{
+		name:      "stub-erroring",
+		returnErr: errors.New("simulated tool error"),
+	})
+	h := &ToolExecHandler{}
+	res, err := h.Eval(context.Background(), evalCtxWithRegistry(registry), map[string]any{
+		"tool": "run_tests",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, *res.Score)
+	// The handler treats Registry.Execute returning err *or* ToolResult.Error
+	// as failure — both end up here. Either branch is acceptable; both are
+	// covered by other tests.
+	assert.Contains(t, res.Explanation, "run_tests")
+}
+
+func TestToolExec_PassesArgsToExecute(t *testing.T) {
+	var capturedArgs json.RawMessage
+	exec := &stubExecutor{
+		name:   "capture",
+		result: json.RawMessage(`{}`),
+	}
+	registry := tools.NewRegistry()
+	registry.RegisterExecutor(&capturingExecutor{name: exec.name, captured: &capturedArgs})
+	require.NoError(t, registry.Register(&tools.ToolDescriptor{
+		Name: "Bash",
+		Mode: exec.name,
+	}))
+
+	h := &ToolExecHandler{}
+	res, err := h.Eval(context.Background(), evalCtxWithRegistry(registry), map[string]any{
+		"tool": "Bash",
+		"args": map[string]any{"command": "echo hi", "description": "smoke"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, *res.Score)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(capturedArgs, &got))
+	assert.Equal(t, "echo hi", got["command"])
+	assert.Equal(t, "smoke", got["description"])
+}
+
+// capturingExecutor records the args it received without erroring.
+type capturingExecutor struct {
+	name     string
+	captured *json.RawMessage
+}
+
+func (e *capturingExecutor) Name() string { return e.name }
+
+func (e *capturingExecutor) Execute(_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+	clone := make(json.RawMessage, len(args))
+	copy(clone, args)
+	*e.captured = clone
+	return json.RawMessage(`{}`), nil
+}

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -146,12 +146,17 @@ func BuildEngineComponents(cfg *config.Config, providerFilter []string) (
 	}
 
 	// Inject judge metadata so eval handlers (llm_judge, llm_judge_session)
-	// can resolve judge providers from config targets.
+	// can resolve judge providers from config targets. Also expose the tool
+	// registry under a known key so the tool_exec handler can invoke
+	// pack-declared / MCP-discovered tools as conversation-level gates.
 	if evalOrchestrator != nil {
 		metadata := make(map[string]any)
 		attachJudgeMetadata(metadata, cfg)
 		if promptRegistry != nil {
 			metadata["prompt_registry"] = promptRegistry
+		}
+		if toolRegistry != nil {
+			metadata["tool_registry"] = toolRegistry
 		}
 		evalOrchestrator.SetMetadata(metadata)
 	}


### PR DESCRIPTION
## Summary

A generic conversation/session-level eval handler that invokes a registered tool by name through the runtime tool registry and treats "executor returned no error AND \`result.Error\` is empty" as pass.

\`\`\`yaml
conversation_assertions:
  - type: tool_exec
    params:
      tool: run_tests
      args: {}
      timeout_seconds: 120
    message: "Hidden tests must pass"
\`\`\`

## Why

The handler doesn't know or care what the tool does or where it executes — it just asks "did the call succeed?". Two immediate use cases:

- **Codegen-eval gate.** Point at a sandbox's \`run_tests\` and you have a hard gate on whether the agent's edits actually pass the hidden test suite. The codegen-sandbox's MCP tools already return \`isError: true\` on failure, so the runtime translation gives us pass/fail for free.
- **Pack-shipped validation tools.** Render-and-diff, run a query, hit a custom HTTP endpoint, run a fuzzer. Anywhere a pack ships a tool that decides "did this side-effect work", \`tool_exec\` makes it a hard gate.

This is the gate primitive the codegen-eval methodology proposal calls for — generalized so it isn't codegen-specific.

## Wiring

The handler reads its tool registry from \`EvalContext.Metadata["tool_registry"]\`. Arena's \`BuildEngineComponents\` now injects that key alongside the existing \`prompt_registry\` / judge metadata, so any pack-declared or MCP-discovered tool is reachable from a gate without further plumbing.

## Files

- \`runtime/evals/handlers/tool_exec.go\` — handler (~140 LOC)
- \`runtime/evals/handlers/tool_exec_test.go\` — 7 unit tests
- \`runtime/evals/handlers/register.go\` — \`RegisterDefault\` wiring
- \`runtime/evals/handlers/handlers_test.go\` — bump expected type list
- \`tools/arena/engine/builder_integration.go\` — inject \`tool_registry\` into EvalOrchestrator metadata

## Test plan

- [x] \`go test ./runtime/evals/... ./tools/arena/engine/... -count=1\` — all green
- [x] tool_exec.go at 85.7% coverage on changed files
- [x] register + handlers tests bumped for the new type

## Follow-ups

- Task packaging format under \`benchmarks/codegen-eval/tasks/<id>/\` with a setup.sh / gate.sh contract validated against a known-good fix.
- First methodology spike — 5 hand-rolled Go bugfix tasks × Sonnet single-agent × {with tool_exec gate, without} × 3 reps. ~$5, validates the substrate produces a usable Pareto data point before sinking time into SWE-bench task adaptation.