### PR TITLE
feat(arena): carry scenario metadata.labels through to JSON + HTML reports

### DIFF
--- a/examples/guardrails-test/scenarios/guardrail-should-not-trigger.scenario.yaml
+++ b/examples/guardrails-test/scenarios/guardrail-should-not-trigger.scenario.yaml
@@ -2,6 +2,9 @@ apiVersion: promptkit.altairalabs.ai/v1alpha1
 kind: Scenario
 metadata:
   name: guardrail-should-not-trigger
+  labels:
+    difficulty: easy
+    category: guardrail
 spec:
   id: "guardrail-should-not-trigger"
   task_type: assistant

--- a/examples/guardrails-test/scenarios/guardrail-should-trigger.scenario.yaml
+++ b/examples/guardrails-test/scenarios/guardrail-should-trigger.scenario.yaml
@@ -2,6 +2,9 @@ apiVersion: promptkit.altairalabs.ai/v1alpha1
 kind: Scenario
 metadata:
   name: guardrail-should-trigger
+  labels:
+    difficulty: medium
+    category: guardrail
 spec:
   id: "guardrail-should-trigger"
   task_type: assistant

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -204,6 +204,46 @@ spec:
 	}
 }
 
+func TestLoadScenario_LabelsRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	scenarioPath := filepath.Join(tmpDir, "labelled-scenario.yaml")
+
+	scenarioContent := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: labelled-scenario
+  labels:
+    difficulty: easy
+    category: bugfix
+spec:
+  id: labelled-scenario
+  task_type: support
+  description: Scenario with metadata.labels for stratification
+  turns:
+    - role: user
+      content: "Hello"
+`
+
+	if err := os.WriteFile(scenarioPath, []byte(scenarioContent), 0644); err != nil {
+		t.Fatalf("Failed to write test scenario: %v", err)
+	}
+
+	scenario, err := LoadScenario(scenarioPath)
+	if err != nil {
+		t.Fatalf("LoadScenario failed: %v", err)
+	}
+	if scenario == nil {
+		t.Fatal("Scenario is nil")
+	}
+
+	if got := scenario.Labels["difficulty"]; got != "easy" {
+		t.Errorf("Expected Labels[difficulty]=easy, got %q (full: %v)", got, scenario.Labels)
+	}
+	if got := scenario.Labels["category"]; got != "bugfix" {
+		t.Errorf("Expected Labels[category]=bugfix, got %q (full: %v)", got, scenario.Labels)
+	}
+}
+
 func TestLoadProvider(t *testing.T) {
 	tmpDir := t.TempDir()
 	providerPath := filepath.Join(tmpDir, "test-provider.yaml")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -205,42 +205,27 @@ spec:
 }
 
 func TestLoadScenario_LabelsRoundTrip(t *testing.T) {
-	tmpDir := t.TempDir()
-	scenarioPath := filepath.Join(tmpDir, "labelled-scenario.yaml")
-
-	scenarioContent := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+	path := filepath.Join(t.TempDir(), "s.yaml")
+	yaml := `apiVersion: promptkit.altairalabs.ai/v1alpha1
 kind: Scenario
 metadata:
-  name: labelled-scenario
-  labels:
-    difficulty: easy
-    category: bugfix
+  name: s
+  labels: {difficulty: easy, category: bugfix}
 spec:
-  id: labelled-scenario
+  id: s
   task_type: support
-  description: Scenario with metadata.labels for stratification
-  turns:
-    - role: user
-      content: "Hello"
+  description: x
+  turns: [{role: user, content: hi}]
 `
-
-	if err := os.WriteFile(scenarioPath, []byte(scenarioContent), 0644); err != nil {
-		t.Fatalf("Failed to write test scenario: %v", err)
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
 	}
-
-	scenario, err := LoadScenario(scenarioPath)
+	scenario, err := LoadScenario(path)
 	if err != nil {
-		t.Fatalf("LoadScenario failed: %v", err)
+		t.Fatal(err)
 	}
-	if scenario == nil {
-		t.Fatal("Scenario is nil")
-	}
-
-	if got := scenario.Labels["difficulty"]; got != "easy" {
-		t.Errorf("Expected Labels[difficulty]=easy, got %q (full: %v)", got, scenario.Labels)
-	}
-	if got := scenario.Labels["category"]; got != "bugfix" {
-		t.Errorf("Expected Labels[category]=bugfix, got %q (full: %v)", got, scenario.Labels)
+	if scenario.Labels["difficulty"] != "easy" || scenario.Labels["category"] != "bugfix" {
+		t.Errorf("labels=%v", scenario.Labels)
 	}
 }
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -339,10 +340,7 @@ func LoadScenario(filename string) (*Scenario, error) {
 	// (engine, statestore, report) carry stratification labels alongside
 	// the rest of the scenario.
 	if len(config.Metadata.Labels) > 0 {
-		config.Spec.Labels = make(map[string]string, len(config.Metadata.Labels))
-		for k, v := range config.Metadata.Labels {
-			config.Spec.Labels[k] = v
-		}
+		config.Spec.Labels = maps.Clone(config.Metadata.Labels)
 	}
 
 	return &config.Spec, nil

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -335,6 +335,16 @@ func LoadScenario(filename string) (*Scenario, error) {
 		return nil, fmt.Errorf("scenario validation failed for %s: %w", filename, err)
 	}
 
+	// Copy K8s metadata.labels into the spec so downstream consumers
+	// (engine, statestore, report) carry stratification labels alongside
+	// the rest of the scenario.
+	if len(config.Metadata.Labels) > 0 {
+		config.Spec.Labels = make(map[string]string, len(config.Metadata.Labels))
+		for k, v := range config.Metadata.Labels {
+			config.Spec.Labels[k] = v
+		}
+	}
+
 	return &config.Spec, nil
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -626,10 +626,14 @@ type ScenarioConfigK8s struct {
 // Workflow scenarios use the same turns format — the workflow state machine
 // (defined in config.arena.yaml) dynamically selects the prompt per turn.
 type Scenario struct {
-	ID              string                 `json:"id,omitempty" yaml:"id,omitempty"`
-	TaskType        string                 `json:"task_type,omitempty" yaml:"task_type,omitempty"`
-	Mode            string                 `json:"mode,omitempty" yaml:"mode,omitempty"`
-	Description     string                 `json:"description" yaml:"description"`
+	ID          string `json:"id,omitempty" yaml:"id,omitempty"`
+	TaskType    string `json:"task_type,omitempty" yaml:"task_type,omitempty"`
+	Mode        string `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Description string `json:"description" yaml:"description"`
+	// Labels are key/value tags copied from the scenario manifest's metadata.labels
+	// (K8s-style). Used for stratified reporting in arena. Populated by LoadScenario;
+	// not read from the spec body itself.
+	Labels          map[string]string      `json:"labels,omitempty" yaml:"labels,omitempty"`
 	ContextMetadata *ContextMetadata       `json:"context_metadata,omitempty" yaml:"context_metadata,omitempty"`
 	Turns           []TurnDefinition       `json:"turns,omitempty" yaml:"turns,omitempty"`
 	Context         map[string]interface{} `json:"context,omitempty" yaml:"context,omitempty"`

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1986,6 +1986,12 @@
         "description": {
           "type": "string"
         },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
         "context_metadata": {
           "$ref": "#/$defs/ContextMetadata"
         },

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -246,6 +246,12 @@
         "description": {
           "type": "string"
         },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
         "context_metadata": {
           "$ref": "#/$defs/ContextMetadata"
         },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,8 +32,10 @@ sonar.coverage.exclusions=**/examples/**,**/*example*/**,**/tools/arena/cmd/prom
 # GitHub Actions runner files have similar patterns across actions
 # Provider tool/streaming implementations share interface-mandated patterns
 # Persistence repository implementations share interface-mandated patterns (JSON/YAML/memory)
+# Arena statestore RunMetadata/RunResult are intentional parallel structs — RunResult is the
+# reconstructed view of RunMetadata + statestore data built by GetResult
 # Arena assertion validators share interface-mandated patterns (turn + conversation level)
-sonar.cpd.exclusions=**/runtime/pipeline/stage/stages_video_frames.go,**/runtime/pipeline/stage/stages_media_compose.go,**/npm/**/lib/installer.js,**/npm/**/postinstall.js,**/runtime/providers/openai/openai_tools.go,**/runtime/providers/claude/claude_tools.go,**/runtime/providers/gemini/gemini_tools.go,**/runtime/providers/ollama/ollama_tools.go,**/runtime/providers/claude/claude_streaming.go,**/runtime/providers/gemini/gemini_streaming.go,**/.github/actions/**/src/runner.ts,**/runtime/persistence/yaml/yaml_tool.go,**/runtime/persistence/json/json.go,**/tools/arena/assertions/agent_*.go,**/tools/arena/assertions/tools_*.go
+sonar.cpd.exclusions=**/runtime/pipeline/stage/stages_video_frames.go,**/runtime/pipeline/stage/stages_media_compose.go,**/npm/**/lib/installer.js,**/npm/**/postinstall.js,**/runtime/providers/openai/openai_tools.go,**/runtime/providers/claude/claude_tools.go,**/runtime/providers/gemini/gemini_tools.go,**/runtime/providers/ollama/ollama_tools.go,**/runtime/providers/claude/claude_streaming.go,**/runtime/providers/gemini/gemini_streaming.go,**/.github/actions/**/src/runner.ts,**/runtime/persistence/yaml/yaml_tool.go,**/runtime/persistence/json/json.go,**/tools/arena/statestore/store.go,**/tools/arena/assertions/agent_*.go,**/tools/arena/assertions/tools_*.go
 
 # Function-level coverage exclusions using patterns
 # Exclude untestable interactive I/O functions in init.go (require terminal stdin/stdout)

--- a/tools/arena/cmd/promptarena/run.go
+++ b/tools/arena/cmd/promptarena/run.go
@@ -432,6 +432,7 @@ func convertToEngineRunResult(sr *statestore.RunResult) engine.RunResult {
 		Region:       sr.Region,
 		ScenarioID:   sr.ScenarioID,
 		ProviderID:   sr.ProviderID,
+		Labels:       sr.Labels,
 		Params:       sr.Params,
 		Messages:     sr.Messages,
 		Commit:       sr.Commit,

--- a/tools/arena/engine/engine_extended_test.go
+++ b/tools/arena/engine/engine_extended_test.go
@@ -252,6 +252,37 @@ func TestGenerateRunPlan_WithFilters(t *testing.T) {
 	}
 }
 
+func TestEngine_ScenarioLabels(t *testing.T) {
+	cfg := &config.Config{Defaults: config.Defaults{Verbose: false}}
+	tmpDir := t.TempDir()
+	eng := newTestEngine(t, tmpDir, cfg)
+
+	src := map[string]string{"difficulty": "easy", "category": "bugfix"}
+	eng.scenarios = map[string]*config.Scenario{
+		"labeled":   {ID: "labeled", Labels: src},
+		"unlabeled": {ID: "unlabeled"},
+	}
+
+	got := eng.scenarioLabels("labeled")
+	if got["difficulty"] != "easy" || got["category"] != "bugfix" {
+		t.Errorf("scenarioLabels(labeled) = %v, want %v", got, src)
+	}
+
+	// Returned map must be a copy — mutating it shouldn't affect the engine's
+	// scenario map.
+	got["difficulty"] = "hard"
+	if eng.scenarios["labeled"].Labels["difficulty"] != "easy" {
+		t.Error("scenarioLabels returned a live reference; expected an isolated copy")
+	}
+
+	if got := eng.scenarioLabels("unlabeled"); got != nil {
+		t.Errorf("scenarioLabels(unlabeled) = %v, want nil", got)
+	}
+	if got := eng.scenarioLabels("missing"); got != nil {
+		t.Errorf("scenarioLabels(missing) = %v, want nil", got)
+	}
+}
+
 func TestGenerateRunPlan_RegionFilter(t *testing.T) {
 	cfg := &config.Config{
 		Defaults: config.Defaults{

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -622,6 +622,7 @@ func (e *Engine) saveRunError(
 		Region:     combo.Region,
 		ScenarioID: combo.ScenarioID,
 		ProviderID: combo.ProviderID,
+		Labels:     e.scenarioLabels(combo.ScenarioID),
 		StartTime:  start,
 		EndTime:    time.Now(),
 		Duration:   time.Since(start),
@@ -647,6 +648,21 @@ func (e *Engine) saveRunError(
 	return runID, nil
 }
 
+// scenarioLabels returns a copy of the named scenario's metadata labels, or
+// nil if the scenario is unknown or has no labels. Returning a copy keeps the
+// statestore independent of the in-memory scenario map.
+func (e *Engine) scenarioLabels(scenarioID string) map[string]string {
+	scenario, ok := e.scenarios[scenarioID]
+	if !ok || len(scenario.Labels) == 0 {
+		return nil
+	}
+	labels := make(map[string]string, len(scenario.Labels))
+	for k, v := range scenario.Labels {
+		labels[k] = v
+	}
+	return labels
+}
+
 func (e *Engine) saveRunMetadata(
 	ctx context.Context,
 	store *statestore.ArenaStateStore,
@@ -661,6 +677,7 @@ func (e *Engine) saveRunMetadata(
 		Region:                       combo.Region,
 		ScenarioID:                   combo.ScenarioID,
 		ProviderID:                   combo.ProviderID,
+		Labels:                       e.scenarioLabels(combo.ScenarioID),
 		StartTime:                    start,
 		EndTime:                      time.Now(),
 		Duration:                     duration,

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -653,14 +654,10 @@ func (e *Engine) saveRunError(
 // statestore independent of the in-memory scenario map.
 func (e *Engine) scenarioLabels(scenarioID string) map[string]string {
 	scenario, ok := e.scenarios[scenarioID]
-	if !ok || len(scenario.Labels) == 0 {
+	if !ok {
 		return nil
 	}
-	labels := make(map[string]string, len(scenario.Labels))
-	for k, v := range scenario.Labels {
-		labels[k] = v
-	}
-	return labels
+	return maps.Clone(scenario.Labels)
 }
 
 func (e *Engine) saveRunMetadata(

--- a/tools/arena/engine/types.go
+++ b/tools/arena/engine/types.go
@@ -36,11 +36,14 @@ type TrialGroupKey struct {
 
 // RunResult contains the complete results of a single test execution
 type RunResult struct {
-	RunID      string                  `json:"RunID"`
-	PromptPack string                  `json:"PromptPack"`
-	Region     string                  `json:"Region"`
-	ScenarioID string                  `json:"ScenarioID"`
-	ProviderID string                  `json:"ProviderID"`
+	RunID      string `json:"RunID"`
+	PromptPack string `json:"PromptPack"`
+	Region     string `json:"Region"`
+	ScenarioID string `json:"ScenarioID"`
+	ProviderID string `json:"ProviderID"`
+	// Labels are stratification tags copied from the scenario manifest's
+	// metadata.labels. Carried through to JSON/HTML reports for slicing.
+	Labels     map[string]string       `json:"Labels,omitempty"`
 	Params     map[string]interface{}  `json:"Params"`
 	Messages   []types.Message         `json:"Messages"`
 	Commit     map[string]interface{}  `json:"Commit"`

--- a/tools/arena/render/html.go
+++ b/tools/arena/render/html.go
@@ -62,6 +62,10 @@ type ScenarioGroup struct {
 	Regions    []string           `json:"regions"`
 	Matrix     [][]MatrixCell     `json:"matrix"`
 	Results    []engine.RunResult `json:"results"`
+	// Labels surfaces stratification labels copied from the scenario manifest's
+	// metadata.labels. Picked from the first labeled result in the group; all
+	// repetitions of a scenario carry identical labels.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // ReportSummary contains aggregate statistics
@@ -292,6 +296,23 @@ func updateMatrixCell(cell *MatrixCell, result engine.RunResult) {
 	}
 }
 
+// firstNonEmptyLabels returns a copy of the first non-empty Labels map across
+// the given results. All repetitions of the same scenario share labels, so the
+// first labeled result is authoritative.
+func firstNonEmptyLabels(results []engine.RunResult) map[string]string {
+	for i := range results {
+		if len(results[i].Labels) == 0 {
+			continue
+		}
+		labels := make(map[string]string, len(results[i].Labels))
+		for k, v := range results[i].Labels {
+			labels[k] = v
+		}
+		return labels
+	}
+	return nil
+}
+
 func generateScenarioGroups(results []engine.RunResult, scenarios []string) []ScenarioGroup {
 	groups := make([]ScenarioGroup, 0, len(scenarios))
 
@@ -344,6 +365,7 @@ func generateScenarioGroups(results []engine.RunResult, scenarios []string) []Sc
 			Regions:    regions,
 			Matrix:     matrix,
 			Results:    scenarioResults,
+			Labels:     firstNonEmptyLabels(scenarioResults),
 		})
 	}
 

--- a/tools/arena/render/html.go
+++ b/tools/arena/render/html.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -304,11 +305,7 @@ func firstNonEmptyLabels(results []engine.RunResult) map[string]string {
 		if len(results[i].Labels) == 0 {
 			continue
 		}
-		labels := make(map[string]string, len(results[i].Labels))
-		for k, v := range results[i].Labels {
-			labels[k] = v
-		}
-		return labels
+		return maps.Clone(results[i].Labels)
 	}
 	return nil
 }

--- a/tools/arena/render/html_test.go
+++ b/tools/arena/render/html_test.go
@@ -1580,6 +1580,28 @@ func TestGenerateScenarioGroups_SingleScenario(t *testing.T) {
 	}
 }
 
+func TestGenerateScenarioGroups_PropagatesLabels(t *testing.T) {
+	r1 := createTestResult(testRunID1, testProviderOpenAI, testRegionUSWest, testScenario1,
+		0.05, 100, 50, false, 500*time.Millisecond)
+	r1.Labels = map[string]string{"difficulty": "easy", "category": "bugfix"}
+	r2 := createTestResult(testRunID2, testProviderAnthropic, testRegionUSEast, testScenario1,
+		0.03, 80, 40, false, 300*time.Millisecond)
+	// r2 omits labels; the group should still surface them from r1.
+
+	groups := generateScenarioGroups([]engine.RunResult{r1, r2}, []string{testScenario1})
+
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 group, got %d", len(groups))
+	}
+	got := groups[0].Labels
+	if got["difficulty"] != "easy" {
+		t.Errorf("Expected Labels[difficulty]=easy, got %q (full: %v)", got["difficulty"], got)
+	}
+	if got["category"] != "bugfix" {
+		t.Errorf("Expected Labels[category]=bugfix, got %q (full: %v)", got["category"], got)
+	}
+}
+
 func TestGenerateScenarioGroups_MultipleScenarios(t *testing.T) {
 	results := []engine.RunResult{
 		createTestResult(testRunID1, testProviderOpenAI, testRegionUSWest, testScenario1, 0.05, 100, 50, false, 500*time.Millisecond),

--- a/tools/arena/render/templates/report.html.tmpl
+++ b/tools/arena/render/templates/report.html.tmpl
@@ -189,7 +189,34 @@
             font-size: 1.3rem;
             font-weight: 600;
         }
-        
+
+        .scenario-labels {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+            margin-left: auto;
+        }
+
+        .scenario-label-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 0.15rem 0.6rem;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.18);
+            color: white;
+            font-size: 0.78rem;
+            font-weight: 500;
+            line-height: 1.3;
+            white-space: nowrap;
+        }
+
+        .scenario-label-key {
+            opacity: 0.75;
+            font-weight: 400;
+        }
+
+
         .scenario-content {
             padding: 1.5rem;
             transition: max-height 0.3s ease-out, opacity 0.3s ease-out;
@@ -1922,6 +1949,13 @@
             <div class="scenario-header" onclick="toggleScenario('scenario-{{$scenarioGroup.ScenarioID}}')">
                 <span class="collapse-icon">▼</span>
                 <div class="scenario-title">{{$scenarioGroup.ScenarioID}}</div>
+                {{if $scenarioGroup.Labels}}
+                <div class="scenario-labels">
+                    {{range $labelKey, $labelVal := $scenarioGroup.Labels}}
+                    <span class="scenario-label-chip"><span class="scenario-label-key">{{$labelKey}}:</span>{{$labelVal}}</span>
+                    {{end}}
+                </div>
+                {{end}}
             </div>
             <div class="scenario-content">
                 <div class="matrix-section" style="box-shadow: none; margin-bottom: 1rem;">

--- a/tools/arena/statestore/arena_store_test.go
+++ b/tools/arena/statestore/arena_store_test.go
@@ -417,6 +417,43 @@ func TestArenaStateStore_SaveMetadata(t *testing.T) {
 	assert.Equal(t, "customer", arenaState.RunMetadata.PersonaID)
 }
 
+// TestArenaStateStore_SaveMetadata_LabelsRoundTrip ensures stratification
+// labels survive SaveMetadata → GetResult.
+func TestArenaStateStore_SaveMetadata_LabelsRoundTrip(t *testing.T) {
+	store := NewArenaStateStore()
+	ctx := context.Background()
+
+	state := &statestore.ConversationState{
+		ID:       "run-labels",
+		UserID:   "test-user",
+		Messages: []types.Message{{Role: "user", Content: "Hello"}},
+	}
+	require.NoError(t, store.Save(ctx, state))
+
+	metadata := &RunMetadata{
+		RunID:      "run-labels",
+		Region:     "us-west",
+		ScenarioID: "labelled-scenario",
+		ProviderID: "test-provider",
+		StartTime:  time.Now().Add(-time.Second),
+		EndTime:    time.Now(),
+		Duration:   time.Second,
+		Labels: map[string]string{
+			"difficulty": "easy",
+			"category":   "bugfix",
+		},
+	}
+	require.NoError(t, store.SaveMetadata(ctx, "run-labels", metadata))
+
+	// Mutate the source map after save — the deep clone must isolate it.
+	metadata.Labels["difficulty"] = "hard"
+
+	result, err := store.GetResult(ctx, "run-labels")
+	require.NoError(t, err)
+	assert.Equal(t, "easy", result.Labels["difficulty"])
+	assert.Equal(t, "bugfix", result.Labels["category"])
+}
+
 // TestArenaStateStore_SaveMetadata_WithError tests saving metadata with error
 func TestArenaStateStore_SaveMetadata_WithError(t *testing.T) {
 	store := NewArenaStateStore()

--- a/tools/arena/statestore/arena_store_test.go
+++ b/tools/arena/statestore/arena_store_test.go
@@ -418,35 +418,18 @@ func TestArenaStateStore_SaveMetadata(t *testing.T) {
 }
 
 // TestArenaStateStore_SaveMetadata_LabelsRoundTrip ensures stratification
-// labels survive SaveMetadata → GetResult.
+// labels survive SaveMetadata → GetResult and that the deep clone isolates
+// post-save mutation of the source map.
 func TestArenaStateStore_SaveMetadata_LabelsRoundTrip(t *testing.T) {
 	store := NewArenaStateStore()
 	ctx := context.Background()
 
-	state := &statestore.ConversationState{
-		ID:       "run-labels",
-		UserID:   "test-user",
-		Messages: []types.Message{{Role: "user", Content: "Hello"}},
-	}
-	require.NoError(t, store.Save(ctx, state))
-
-	metadata := &RunMetadata{
-		RunID:      "run-labels",
-		Region:     "us-west",
-		ScenarioID: "labelled-scenario",
-		ProviderID: "test-provider",
-		StartTime:  time.Now().Add(-time.Second),
-		EndTime:    time.Now(),
-		Duration:   time.Second,
-		Labels: map[string]string{
-			"difficulty": "easy",
-			"category":   "bugfix",
-		},
-	}
-	require.NoError(t, store.SaveMetadata(ctx, "run-labels", metadata))
-
-	// Mutate the source map after save — the deep clone must isolate it.
-	metadata.Labels["difficulty"] = "hard"
+	src := map[string]string{"difficulty": "easy", "category": "bugfix"}
+	require.NoError(t, store.SaveMetadata(ctx, "run-labels", &RunMetadata{
+		RunID:  "run-labels",
+		Labels: src,
+	}))
+	src["difficulty"] = "hard"
 
 	result, err := store.GetResult(ctx, "run-labels")
 	require.NoError(t, err)

--- a/tools/arena/statestore/metadata.go
+++ b/tools/arena/statestore/metadata.go
@@ -78,6 +78,7 @@ func (s *ArenaStateStore) GetResult(ctx context.Context, runID string) (*RunResu
 		Region:     arenaState.RunMetadata.Region,
 		ScenarioID: arenaState.RunMetadata.ScenarioID,
 		ProviderID: arenaState.RunMetadata.ProviderID,
+		Labels:     arenaState.RunMetadata.Labels,
 		Params:     params,
 		Messages:   arenaState.Messages,
 		Commit:     arenaState.RunMetadata.Commit,

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -61,6 +61,7 @@ type RunMetadata struct {
 	Region     string                 `json:"region"`
 	ScenarioID string                 `json:"scenario_id"`
 	ProviderID string                 `json:"provider_id"`
+	Labels     map[string]string      `json:"labels,omitempty"`
 	Params     map[string]interface{} `json:"params,omitempty"`
 	Commit     map[string]interface{} `json:"commit,omitempty"`
 	StartTime  time.Time              `json:"start_time"`
@@ -832,6 +833,12 @@ func (s *ArenaStateStore) deepCloneRunMetadata(m *RunMetadata) *RunMetadata {
 	cloned.Params = s.deepCloneMap(m.Params)
 	cloned.Commit = s.deepCloneMap(m.Commit)
 	cloned.TrialResults = m.TrialResults
+	if m.Labels != nil {
+		cloned.Labels = make(map[string]string, len(m.Labels))
+		for k, v := range m.Labels {
+			cloned.Labels[k] = v
+		}
+	}
 	s.cloneRunMetadataRoles(cloned, m)
 	s.cloneRunMetadataFeedback(cloned, m)
 	s.cloneRunMetadataSlices(cloned, m)
@@ -914,6 +921,7 @@ type RunResult struct {
 	Region       string                  `json:"Region"`
 	ScenarioID   string                  `json:"ScenarioID"`
 	ProviderID   string                  `json:"ProviderID"`
+	Labels       map[string]string       `json:"Labels,omitempty"`
 	Params       map[string]interface{}  `json:"Params"`
 	Messages     []types.Message         `json:"Messages"`
 	Commit       map[string]interface{}  `json:"Commit"`

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"sync"
 	"time"
@@ -833,12 +834,7 @@ func (s *ArenaStateStore) deepCloneRunMetadata(m *RunMetadata) *RunMetadata {
 	cloned.Params = s.deepCloneMap(m.Params)
 	cloned.Commit = s.deepCloneMap(m.Commit)
 	cloned.TrialResults = m.TrialResults
-	if m.Labels != nil {
-		cloned.Labels = make(map[string]string, len(m.Labels))
-		for k, v := range m.Labels {
-			cloned.Labels[k] = v
-		}
-	}
+	cloned.Labels = maps.Clone(m.Labels)
 	s.cloneRunMetadataRoles(cloned, m)
 	s.cloneRunMetadataFeedback(cloned, m)
 	s.cloneRunMetadataSlices(cloned, m)


### PR DESCRIPTION
## Summary

- `LoadScenario` copies `metadata.labels` from the K8s manifest wrapper into the spec
- Engine populates `RunMetadata.Labels` from the scenario map at run-record time (incl. early-fail path)
- `statestore.RunMetadata` / `RunResult`, `engine.RunResult`, and `convertToEngineRunResult` all carry the field through
- `ScenarioGroup` picks the first labelled result; HTML template renders chips on the scenario-group header; JSON output includes `Labels`

## Why

Unblocks stratified reporting in arena (e.g. `difficulty: easy/medium/hard`, `category: bugfix/feature`). Without this, scenario tags were dropped at the loader and never reached the report — labels were defined in YAML but invisible in any output. This is the first prerequisite from the codegen-eval methodology v2 build order.

## Test plan

- [x] `go test ./pkg/config/... ./tools/arena/... -count=1 -race` (3703 pass)
- [x] `golangci-lint run --new-from-rev=main ./pkg/... ./tools/arena/...` clean
- [x] New unit tests:
  - `pkg/config.TestLoadScenario_LabelsRoundTrip` — labels survive the loader
  - `tools/arena/statestore.TestArenaStateStore_SaveMetadata_LabelsRoundTrip` — survive save/load + deep clone is isolated
  - `tools/arena/engine.TestEngine_ScenarioLabels` — helper handles missing/unlabeled scenarios + returns a copy
  - `tools/arena/render.TestGenerateScenarioGroups_PropagatesLabels` — group picks up labels from results
- [x] Smoke run on `examples/guardrails-test` (two scenarios labelled, two unlabelled) — chips render on the labelled headers, JSON file includes `Labels` key, unlabelled scenarios show no chips
