### PR TITLE
feat(benchmarks): codegen-eval methodology spike substrate

### DIFF
--- a/benchmarks/codegen-eval/README.md
+++ b/benchmarks/codegen-eval/README.md
@@ -1,0 +1,116 @@
+# Codegen Eval — Methodology Spike
+
+This directory hosts the v1 spike for the codegen evaluation methodology
+described in `docs/local-backlog/CODEGEN_EVAL_METHODOLOGY_PROPOSAL.md`
+(local-only). Goal: validate that the substrate produces a usable
+signal before sinking effort into SWE-bench adaptation or expanding
+the task suite.
+
+## What's here
+
+```
+benchmarks/codegen-eval/
+├── sonnet-baseline.arena.yaml       Bundle A — no skill
+├── sonnet-disciplined.arena.yaml    Bundle D — with skill
+├── scenarios/                       5 hand-rolled Go bugfix tasks
+│   ├── go-add-bugfix                (easy, arithmetic)
+│   ├── go-strings-reverse           (easy, encoding)
+│   ├── go-fizzbuzz-order            (medium, control-flow)
+│   ├── go-counter-race              (medium, concurrency)
+│   └── go-binary-search             (hard, boundary)
+├── packs/
+│   └── codegen-agent.yaml           Shared bare prompt + tool palette
+├── providers/
+│   └── claude-sonnet.provider.yaml  claude-sonnet-4-6
+└── skills/
+    └── codegen-disciplined/         Read-before-Edit + verify-before-done
+```
+
+The two arena configs live at the spike root (not under `configs/`)
+because arena's path-traversal protection rejects scenario/skill paths
+that escape the config directory. Forward-only paths only.
+
+The two bundles share everything except the skill. That's the v1
+question: *does the discipline skill change pass-rate enough to
+justify the extra tool calls?*
+
+## Running
+
+Requires Docker + `ANTHROPIC_API_KEY` exported (or in a `.env` the
+arena binary can read). The `tool_exec` gate calls `run_tests` which
+the codegen-sandbox returns isError=true on test failures — so a
+single hidden-test failure flips the assertion to fail.
+
+```bash
+make -C ../.. build-arena
+docker pull ghcr.io/altairalabs/codegen-sandbox:latest
+
+# Bundle A — baseline
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run \
+  --config sonnet-baseline.arena.yaml --ci --formats json,html
+
+# Bundle D — disciplined
+PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run \
+  --config sonnet-disciplined.arena.yaml --ci --formats json,html
+```
+
+For variance bands, set `spec.trials: 3` on each scenario before the
+run (or leave at 1 for a smoke pass). Per-rep raw JSON files land in
+`out/<bundle>/`; aggregate `pass_rate` and `flakiness_score` land in
+`out/<bundle>/report-data.json[].trial_results`.
+
+## Reporting
+
+Stratified pass-rate query (works on either bundle's `report-data.json`):
+
+```bash
+jq '[.results[] | {
+       diff: .Labels.difficulty,
+       cat:  .Labels.category,
+       passed: .ConversationAssertions.passed
+     }] |
+     group_by(.diff) |
+     map({diff: .[0].diff,
+          n: length,
+          pass: ([.[] | select(.passed)] | length)})' \
+  out/sonnet-baseline/report-data.json
+```
+
+Pareto cost vs pass-rate per bundle:
+
+```bash
+for b in sonnet-baseline sonnet-disciplined; do
+  jq --arg b "$b" '
+    [.results[] | {pass: .ConversationAssertions.passed, cost: .Cost.TotalCost}] |
+    {bundle: $b,
+     n: length,
+     pass_rate: ([.[] | select(.pass)] | length) / length,
+     total_cost: ([.[] | .cost] | add)}' \
+    "out/$b/report-data.json"
+done
+```
+
+## Cost ballpark
+
+5 scenarios × 2 bundles × 3 reps = 30 sessions. Sonnet 4.6 at 0.003/1k
+input + 0.015/1k output, with `max_tokens: 4096` and typical bugfix
+sessions running ~5-10 turns: roughly $0.10 per session, ~$3 per
+matrix sweep. Setting trials=1 for a first pass cuts that by 3×.
+
+## What this spike will and won't tell us
+
+**Will:**
+- Whether the discipline skill changes pass-rate at all (signal vs noise).
+- Whether scenario stratification (difficulty × category) shows where
+  discipline matters most.
+- Cost / wall-time / tool-call overhead of the disciplined bundle vs
+  baseline — directly readable from arena's existing cost tracker.
+
+**Won't (deferred to v1 / v2):**
+- Soft metrics (diff LOC, regression count) — needs a sandbox tool. See
+  proposal §10.2.
+- SWE-bench tasks — needs a differential gate (`FAIL_TO_PASS` /
+  `PASS_TO_PASS`). See proposal §10.3.
+- Multi-agent bundles (planner + executor, panel-of-experts) — needs
+  A2A token-accounting verification + orchestrator decision. See
+  proposal §10.5.

--- a/benchmarks/codegen-eval/providers/claude-sonnet.provider.yaml
+++ b/benchmarks/codegen-eval/providers/claude-sonnet.provider.yaml
@@ -1,0 +1,23 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: anthropic-sonnet
+spec:
+  id: anthropic-sonnet
+  type: claude
+  model: claude-sonnet-4-6
+  capabilities:
+    - text
+    - streaming
+    - tools
+    - json
+  defaults:
+    temperature: 0.1
+    top_p: 1.0
+    max_tokens: 4096
+  pricing:
+    input_cost_per_1k: 0.003
+    output_cost_per_1k: 0.015
+  stream_retry:
+    enabled: true
+    max_attempts: 3

--- a/benchmarks/codegen-eval/scenarios/go-add-bugfix.scenario.yaml
+++ b/benchmarks/codegen-eval/scenarios/go-add-bugfix.scenario.yaml
@@ -1,0 +1,61 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: go-add-bugfix
+  labels:
+    shape: bugfix
+    language: go
+    difficulty: easy
+    source: hand-rolled
+    category: arithmetic
+
+spec:
+  id: go-add-bugfix
+  task_type: codegen-agent
+  description: |
+    Classic off-by-sign bug in an arithmetic helper. Tests catch the
+    regression on negative inputs.
+
+  turns:
+    - role: user
+      content: |
+        Set up a Go module at /workspace with this content, then find and
+        fix the bug so the tests pass:
+
+        /workspace/go.mod:
+          module example.com/add
+          go 1.22
+
+        /workspace/add.go:
+          package add
+          func Add(a, b int) int {
+              if a < 0 {
+                  return a - b
+              }
+              return a + b
+          }
+
+        /workspace/add_test.go:
+          package add
+          import "testing"
+          func TestAdd(t *testing.T) {
+              cases := []struct{ a, b, want int }{
+                  {1, 2, 3}, {-3, 5, 2}, {-7, -2, -9}, {0, 0, 0},
+              }
+              for _, c := range cases {
+                  if got := Add(c.a, c.b); got != c.want {
+                      t.Errorf("Add(%d,%d)=%d want %d", c.a, c.b, got, c.want)
+                  }
+              }
+          }
+
+        Use the codegen tools to seed the files, fix the bug, and
+        verify the suite is green.
+
+  conversation_assertions:
+    - type: tool_exec
+      params:
+        tool: run_tests
+        timeout_seconds: 120
+      message: "Hidden test suite must pass"

--- a/benchmarks/codegen-eval/scenarios/go-binary-search.scenario.yaml
+++ b/benchmarks/codegen-eval/scenarios/go-binary-search.scenario.yaml
@@ -1,0 +1,76 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: go-binary-search
+  labels:
+    shape: bugfix
+    language: go
+    difficulty: hard
+    source: hand-rolled
+    category: boundary
+
+spec:
+  id: go-binary-search
+  task_type: codegen-agent
+  description: |
+    Off-by-one in binary search — uses `hi := len(arr) - 1` plus
+    `lo < hi`, so the final element is never inspected. Subtle —
+    most cases pass; only the boundary case fails.
+
+  turns:
+    - role: user
+      content: |
+        Set up a Go module at /workspace with this content, then find and
+        fix the off-by-one so the tests pass:
+
+        /workspace/go.mod:
+          module example.com/bsearch
+          go 1.22
+
+        /workspace/bsearch.go:
+          package bsearch
+          func Search(arr []int, target int) int {
+              lo, hi := 0, len(arr)-1
+              for lo < hi {
+                  mid := (lo + hi) / 2
+                  if arr[mid] == target {
+                      return mid
+                  }
+                  if arr[mid] < target {
+                      lo = mid + 1
+                  } else {
+                      hi = mid - 1
+                  }
+              }
+              return -1
+          }
+
+        /workspace/bsearch_test.go:
+          package bsearch
+          import "testing"
+          func TestSearch(t *testing.T) {
+              arr := []int{1, 3, 5, 7, 9, 11, 13, 15}
+              cases := []struct{ target, want int }{
+                  {1, 0},   // first
+                  {7, 3},   // middle
+                  {15, 7},  // last — this is the one that breaks
+                  {4, -1},  // missing
+                  {16, -1}, // beyond
+              }
+              for _, c := range cases {
+                  if got := Search(arr, c.target); got != c.want {
+                      t.Errorf("Search(%d)=%d want %d", c.target, got, c.want)
+                  }
+              }
+          }
+
+        Seed the files, identify which boundary the loop misses, fix
+        it, and verify all five cases pass.
+
+  conversation_assertions:
+    - type: tool_exec
+      params:
+        tool: run_tests
+        timeout_seconds: 120
+      message: "Hidden test suite must pass — the last-element case is the trap"

--- a/benchmarks/codegen-eval/scenarios/go-counter-race.scenario.yaml
+++ b/benchmarks/codegen-eval/scenarios/go-counter-race.scenario.yaml
@@ -1,0 +1,75 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: go-counter-race
+  labels:
+    shape: bugfix
+    language: go
+    difficulty: medium
+    source: hand-rolled
+    category: concurrency
+
+spec:
+  id: go-counter-race
+  task_type: codegen-agent
+  description: |
+    Concurrent counter has a data race — the unprotected int field is
+    read-modify-written from N goroutines. Tests run with -race.
+
+  turns:
+    - role: user
+      content: |
+        Set up a Go module at /workspace with this content, then find and
+        fix the data race so the tests pass under -race:
+
+        /workspace/go.mod:
+          module example.com/counter
+          go 1.22
+
+        /workspace/counter.go:
+          package counter
+          type Counter struct {
+              n int
+          }
+          func (c *Counter) Inc() {
+              c.n++
+          }
+          func (c *Counter) Value() int {
+              return c.n
+          }
+
+        /workspace/counter_test.go:
+          package counter
+          import (
+              "sync"
+              "testing"
+          )
+          func TestCounterConcurrent(t *testing.T) {
+              const G, K = 100, 1000
+              c := &Counter{}
+              var wg sync.WaitGroup
+              for g := 0; g < G; g++ {
+                  wg.Add(1)
+                  go func() {
+                      defer wg.Done()
+                      for i := 0; i < K; i++ {
+                          c.Inc()
+                      }
+                  }()
+              }
+              wg.Wait()
+              if got := c.Value(); got != G*K {
+                  t.Errorf("Value()=%d want %d", got, G*K)
+              }
+          }
+
+        Note: the test runner here passes -race; the sandbox's
+        run_tests reports failure on race detection.
+
+  conversation_assertions:
+    - type: tool_exec
+      params:
+        tool: run_tests
+        timeout_seconds: 180
+      message: "Hidden test suite must pass under -race"

--- a/benchmarks/codegen-eval/scenarios/go-fizzbuzz-order.scenario.yaml
+++ b/benchmarks/codegen-eval/scenarios/go-fizzbuzz-order.scenario.yaml
@@ -1,0 +1,69 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: go-fizzbuzz-order
+  labels:
+    shape: bugfix
+    language: go
+    difficulty: medium
+    source: hand-rolled
+    category: control-flow
+
+spec:
+  id: go-fizzbuzz-order
+  task_type: codegen-agent
+  description: |
+    FizzBuzz with branch-order bug — multiples of 15 get classified as
+    "Fizz" because the %3 check fires before the %15 check.
+
+  turns:
+    - role: user
+      content: |
+        Set up a Go module at /workspace with this content, then find and
+        fix the bug so the tests pass:
+
+        /workspace/go.mod:
+          module example.com/fizzbuzz
+          go 1.22
+
+        /workspace/fizzbuzz.go:
+          package fizzbuzz
+          import "strconv"
+          func FizzBuzz(n int) string {
+              if n%3 == 0 {
+                  return "Fizz"
+              }
+              if n%5 == 0 {
+                  return "Buzz"
+              }
+              if n%15 == 0 {
+                  return "FizzBuzz"
+              }
+              return strconv.Itoa(n)
+          }
+
+        /workspace/fizzbuzz_test.go:
+          package fizzbuzz
+          import "testing"
+          func TestFizzBuzz(t *testing.T) {
+              cases := []struct{ n int; want string }{
+                  {1, "1"}, {3, "Fizz"}, {5, "Buzz"},
+                  {15, "FizzBuzz"}, {30, "FizzBuzz"}, {45, "FizzBuzz"},
+                  {7, "7"},
+              }
+              for _, c := range cases {
+                  if got := FizzBuzz(c.n); got != c.want {
+                      t.Errorf("FizzBuzz(%d)=%q want %q", c.n, got, c.want)
+                  }
+              }
+          }
+
+        Seed the files, fix the branch order, run the tests.
+
+  conversation_assertions:
+    - type: tool_exec
+      params:
+        tool: run_tests
+        timeout_seconds: 120
+      message: "Hidden test suite must pass"

--- a/benchmarks/codegen-eval/scenarios/go-strings-reverse.scenario.yaml
+++ b/benchmarks/codegen-eval/scenarios/go-strings-reverse.scenario.yaml
@@ -1,0 +1,66 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: go-strings-reverse
+  labels:
+    shape: bugfix
+    language: go
+    difficulty: easy
+    source: hand-rolled
+    category: encoding
+
+spec:
+  id: go-strings-reverse
+  task_type: codegen-agent
+  description: |
+    Byte-naive string reversal corrupts multi-byte runes. Hidden test
+    requires rune-correct output.
+
+  turns:
+    - role: user
+      content: |
+        Set up a Go module at /workspace with this content, then find and
+        fix the bug so the tests pass:
+
+        /workspace/go.mod:
+          module example.com/revstr
+          go 1.22
+
+        /workspace/reverse.go:
+          package revstr
+          func Reverse(s string) string {
+              b := []byte(s)
+              n := len(b)
+              for i := 0; i < n/2; i++ {
+                  b[i], b[n-1-i] = b[n-1-i], b[i]
+              }
+              return string(b)
+          }
+
+        /workspace/reverse_test.go:
+          package revstr
+          import "testing"
+          func TestReverse(t *testing.T) {
+              cases := []struct{ in, want string }{
+                  {"abc", "cba"},
+                  {"héllo", "olléh"},
+                  {"日本語", "語本日"},
+                  {"", ""},
+              }
+              for _, c := range cases {
+                  if got := Reverse(c.in); got != c.want {
+                      t.Errorf("Reverse(%q)=%q want %q", c.in, got, c.want)
+                  }
+              }
+          }
+
+        Seed the files, diagnose the multi-byte corruption, fix it, and
+        verify with the test runner.
+
+  conversation_assertions:
+    - type: tool_exec
+      params:
+        tool: run_tests
+        timeout_seconds: 120
+      message: "Hidden test suite must pass"

--- a/benchmarks/codegen-eval/skills/codegen-disciplined/SKILL.md
+++ b/benchmarks/codegen-eval/skills/codegen-disciplined/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: codegen-disciplined
+description: Disciplined code-generation workflow for agents with a sandbox (Read/Edit/Bash/run_tests/run_lint/run_typecheck). Use whenever the task is to modify source code.
+metadata:
+  tags: "code, editing, testing"
+---
+
+# Disciplined Codegen
+
+You are writing code inside a container sandbox. Tools execute real commands against a real filesystem; mistakes are cheap to undo but waste turns.
+
+This skill is the variable under test in the codegen-eval spike. The baseline bundle does NOT load this skill; this bundle does. The hypothesis: explicit discipline raises pass-rate enough to justify the extra tool calls.
+
+## Discipline
+
+**1. Read before Edit.**
+Never call `Edit` on a file you have not `Read` this session. If you discover the file doesn't look like you expected, Read it again before editing.
+
+**2. Plan multi-step work.**
+For any task with 3+ logical steps (e.g., a bugfix that needs seed, edit, verify), enumerate the steps before starting. Mark each as you finish it.
+
+**3. Verify before declaring done.**
+Before saying "done", run the verification tool:
+- `run_tests` — the project's test suite must pass.
+- `run_lint` — no new lint errors on files you touched.
+- `run_typecheck` — no new type errors.
+
+For a bugfix, the workflow is: seed → run_tests (red) → fix → run_tests (green). The failing-first run proves the test is actually exercising the bug.
+
+**4. Small, focused diffs.**
+Change only what the task requires. Unrelated edits make review harder and tests flakier.
+
+## Failure mode recovery
+
+- Tests fail after your edit → Read the test output, find the first failing assertion, understand the gap between expected and actual, make one focused fix, retest. Don't edit the test to make it pass unless the test itself was wrong.
+- Build fails (compile / type error) → Fix the compile error first before running tests. A failing build invalidates everything.
+- `Bash` returns non-zero unexpectedly → Read the full stderr before retrying.
+
+## Go specifics
+
+`gofmt`/`goimports` are enforced. Imports grouped: stdlib, then third-party, then local. Check with `run_lint` (uses golangci-lint).

--- a/benchmarks/codegen-eval/sonnet-baseline.arena.yaml
+++ b/benchmarks/codegen-eval/sonnet-baseline.arena.yaml
@@ -1,0 +1,38 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: codegen-eval-sonnet-baseline
+  annotations:
+    description: |
+      Bundle A: Sonnet 4.6, no discipline skill. Baseline for the spike.
+
+spec:
+  prompt_configs:
+    - id: codegen-agent
+      file: packs/codegen-agent.yaml
+
+  providers:
+    - file: providers/claude-sonnet.provider.yaml
+
+  scenarios:
+    - file: scenarios/go-add-bugfix.scenario.yaml
+    - file: scenarios/go-strings-reverse.scenario.yaml
+    - file: scenarios/go-fizzbuzz-order.scenario.yaml
+    - file: scenarios/go-counter-race.scenario.yaml
+    - file: scenarios/go-binary-search.scenario.yaml
+
+  mcp_servers:
+    - name: sandbox
+      source: docker
+      scope: session
+      source_args:
+        image: ghcr.io/altairalabs/codegen-sandbox:latest
+        env:
+          DEV_MODE: "1"
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 4096
+    output:
+      dir: out/sonnet-baseline
+      formats: ["json", "html"]

--- a/benchmarks/codegen-eval/sonnet-disciplined.arena.yaml
+++ b/benchmarks/codegen-eval/sonnet-disciplined.arena.yaml
@@ -1,0 +1,43 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: codegen-eval-sonnet-disciplined
+  annotations:
+    description: |
+      Bundle D: Sonnet 4.6 + the codegen-disciplined skill (Read-before-Edit,
+      verify-before-done). Same model + tools + scenarios as bundle A.
+
+spec:
+  prompt_configs:
+    - id: codegen-agent
+      file: packs/codegen-agent.yaml
+
+  providers:
+    - file: providers/claude-sonnet.provider.yaml
+
+  scenarios:
+    - file: scenarios/go-add-bugfix.scenario.yaml
+    - file: scenarios/go-strings-reverse.scenario.yaml
+    - file: scenarios/go-fizzbuzz-order.scenario.yaml
+    - file: scenarios/go-counter-race.scenario.yaml
+    - file: scenarios/go-binary-search.scenario.yaml
+
+  mcp_servers:
+    - name: sandbox
+      source: docker
+      scope: session
+      source_args:
+        image: ghcr.io/altairalabs/codegen-sandbox:latest
+        env:
+          DEV_MODE: "1"
+
+  skills:
+    - path: skills/codegen-disciplined
+      preload: true
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 4096
+    output:
+      dir: out/sonnet-disciplined
+      formats: ["json", "html"]


### PR DESCRIPTION
## Summary

Adds the v1 spike substrate for the codegen-eval methodology. Builds on #1101 — uses `metadata.labels` for stratification and `tool_exec` (#1100) as the hard gate.

Five hand-rolled Go bugfix scenarios with stratification labels:
- `go-add-bugfix` (easy, arithmetic) — off-by-sign on negative inputs
- `go-strings-reverse` (easy, encoding) — byte-naive reverse corrupts multi-byte runes
- `go-fizzbuzz-order` (medium, control-flow) — branch-order bug at multiples of 15
- `go-counter-race` (medium, concurrency) — unprotected int field, fails under `-race`
- `go-binary-search` (hard, boundary) — off-by-one on last-element case

Two arena bundle configs share the scenarios but vary one dimension:
- `sonnet-baseline.arena.yaml` — Sonnet 4.6, no skill
- `sonnet-disciplined.arena.yaml` — same model + the new `codegen-disciplined` skill (Read-before-Edit, verify-before-done)

The single variable under test for v1 is whether explicit discipline pays for itself in pass-rate vs the extra tool calls. README documents jq queries for stratified pass-rate per `Labels.difficulty` and Pareto cost-vs-pass per bundle.

## Why

Methodology proposal v2 (local-only, see `docs/local-backlog/CODEGEN_EVAL_METHODOLOGY_PROPOSAL.md`) build-order steps 4 & 5: 5 hand-rolled scenarios + 2 bundle configs. Unblocks the first spike run (5 × 2 × 3 = 30 sessions, ~$3-5 against real Sonnet).

## Test plan

- [x] `promptarena validate` passes for both arena configs and all five scenarios (with `PROMPTKIT_SCHEMA_SOURCE=local`)
- [x] Smoke run with `--mock-provider`: 5 run combinations generate, source-backed Docker sandbox spawns per session, `tool_exec` fires `run_tests`, stratification labels propagate to per-run JSON. Assertions fail with mock (expected — mock LLM doesn't actually fix bugs); the substrate plumbing is the test target.
- [ ] Real run pending — `make build-arena && cd benchmarks/codegen-eval && PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --config sonnet-baseline.arena.yaml --ci --formats json,html`. Requires `ANTHROPIC_API_KEY` and Docker.

## Out of scope (deferred)

- Soft metric capture (diff LOC, regression count) — needs a sandbox tool. See proposal §10.2.
- SWE-bench differential gate (`FAIL_TO_PASS` / `PASS_TO_PASS`). See §10.3.
- Multi-agent bundles (planner+executor, panel-of-experts). See §10.5.
- HTML rendering of `TrialResults` (aggregate stats currently land in `report-data.json` only). See proposal §10 follow-ups.
