### PR TITLE
fix(arena): per-run MCP registry isolation for concurrent source-backed opens

### DIFF
--- a/runtime/mcp/registry.go
+++ b/runtime/mcp/registry.go
@@ -30,6 +30,13 @@ type RegistryOptions struct {
 type RegistryImpl struct {
 	mu sync.RWMutex
 
+	// parent is non-nil when this registry was produced by Fork. Lookups
+	// for servers/clients/tool ownership fall through to the parent when
+	// not found locally, so per-conversation children can resolve static
+	// (parent-registered) servers without re-registering or re-dialing.
+	// Registration is always local to this registry.
+	parent *RegistryImpl
+
 	// Server configurations
 	servers map[string]ServerConfig
 
@@ -94,7 +101,38 @@ func NewRegistryWithOptions(opts RegistryOptions) *RegistryImpl {
 	return r
 }
 
-// RegisterServer adds a new MCP server configuration
+// Fork returns a child registry that shares this registry's static
+// servers and clients via lookup fall-through, but has its own
+// per-instance dynamic state. Children can register their own servers
+// (including names that exist in the parent) without colliding; this
+// is the mechanism that lets concurrent runs each open their own
+// session-scoped MCP source while sharing static client connections.
+//
+// Registration on the child is local-only: the parent never sees the
+// child's entries. Lookups (GetServerConfig, GetClient, GetClientForTool,
+// ListServers) try local state first, then fall through to the parent.
+// UnregisterServer is local-only.
+//
+// Cycle safety is the caller's responsibility; in practice forks only
+// chain one level deep (engine → run).
+func (r *RegistryImpl) Fork() *RegistryImpl {
+	return &RegistryImpl{
+		parent:        r,
+		servers:       make(map[string]ServerConfig),
+		clients:       make(map[string]Client),
+		toolIndex:     make(map[string]string),
+		options:       r.options,
+		newClientFunc: r.newClientFunc,
+		// processSem is intentionally not shared: child opens are subject
+		// to the same global limit only when the parent's semaphore is
+		// reachable via parent-level operations. Children of an unlimited
+		// parent are also unlimited.
+	}
+}
+
+// RegisterServer adds a new MCP server configuration. Child registries
+// (produced by Fork) accept names that exist in the parent — registration
+// is local-only.
 func (r *RegistryImpl) RegisterServer(config ServerConfig) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -140,24 +178,40 @@ func (r *RegistryImpl) UnregisterServer(name string) error {
 	return nil
 }
 
-// GetClient returns an active client for the given server name
+// GetClient returns an active client for the given server name. For
+// child registries (Fork), if the name resolves only to the parent,
+// the parent's client is returned — preserving connection sharing for
+// static servers across all per-run forks.
 func (r *RegistryImpl) GetClient(ctx context.Context, serverName string) (Client, error) {
-	// Check if client exists and is alive
+	// Check if client exists and is alive (local first).
 	if client, err := r.tryGetExistingClient(serverName); err != nil {
 		return nil, err
 	} else if client != nil {
 		return client, nil
 	}
 
-	// Create new client with write lock
-	return r.createNewClient(ctx, serverName)
+	// If the name is registered locally, create a new local client.
+	r.mu.RLock()
+	_, hasLocal := r.servers[serverName]
+	r.mu.RUnlock()
+	if hasLocal {
+		return r.createNewClient(ctx, serverName)
+	}
+
+	// Fall through to parent. Parent owns the client; child shares it.
+	if r.parent != nil {
+		return r.parent.GetClient(ctx, serverName)
+	}
+	return nil, fmt.Errorf("server %s not registered", serverName)
 }
 
-// tryGetExistingClient attempts to return an existing alive client
+// tryGetExistingClient attempts to return an existing alive client from
+// this registry's local state. Returns (nil, nil) when no local client
+// exists (caller decides whether to create one or fall through to a
+// parent registry). Errors are reserved for the closed-registry case.
 func (r *RegistryImpl) tryGetExistingClient(serverName string) (Client, error) {
 	r.mu.RLock()
 	client, exists := r.clients[serverName]
-	_, hasConfig := r.servers[serverName]
 	closed := r.closed
 	r.mu.RUnlock()
 
@@ -165,16 +219,12 @@ func (r *RegistryImpl) tryGetExistingClient(serverName string) (Client, error) {
 		return nil, fmt.Errorf("registry is closed")
 	}
 
-	if !hasConfig {
-		return nil, fmt.Errorf("server %s not registered", serverName)
-	}
-
 	// If client exists and is alive, return it
 	if exists && client.IsAlive() {
 		return client, nil
 	}
 
-	return nil, nil // No existing client, need to create new one
+	return nil, nil // No existing client, caller decides next step
 }
 
 // createNewClient creates and initializes a new client.
@@ -273,48 +323,76 @@ func (r *RegistryImpl) ActiveProcessCount() int {
 	return len(r.processSem)
 }
 
-// GetClientForTool returns the client that provides the specified tool
+// GetClientForTool returns the client that provides the specified tool.
+// Child registries (Fork) check their own tool index first; if the tool
+// is not owned by a locally-registered server, the lookup falls through
+// to the parent's tool index.
 func (r *RegistryImpl) GetClientForTool(ctx context.Context, toolName string) (Client, error) {
 	r.mu.RLock()
 	serverName, exists := r.toolIndex[toolName]
 	r.mu.RUnlock()
 
-	if !exists {
-		// Tool not in index - try to refresh all tools
-		if err := r.refreshAllToolIndices(ctx); err != nil {
-			return nil, fmt.Errorf("tool %s not found and refresh failed: %w", toolName, err)
-		}
+	if exists {
+		return r.GetClient(ctx, serverName)
+	}
 
-		r.mu.RLock()
-		serverName, exists = r.toolIndex[toolName]
-		r.mu.RUnlock()
+	// Try refreshing local tool index before falling through.
+	if err := r.refreshAllToolIndices(ctx); err != nil {
+		return nil, fmt.Errorf("tool %s not found and refresh failed: %w", toolName, err)
+	}
+	r.mu.RLock()
+	serverName, exists = r.toolIndex[toolName]
+	r.mu.RUnlock()
+	if exists {
+		return r.GetClient(ctx, serverName)
+	}
 
-		if !exists {
-			return nil, fmt.Errorf("tool %s not found in any MCP server", toolName)
+	// Fall through to parent — the tool may be owned by a parent-registered
+	// (static) server.
+	if r.parent != nil {
+		return r.parent.GetClientForTool(ctx, toolName)
+	}
+	return nil, fmt.Errorf("tool %s not found in any MCP server", toolName)
+}
+
+// ListServers returns all registered server names. For child registries
+// (produced by Fork), this is the union of local and parent entries —
+// child names override parent names with the same key.
+func (r *RegistryImpl) ListServers() []string {
+	r.mu.RLock()
+	seen := make(map[string]struct{}, len(r.servers))
+	for name := range r.servers {
+		seen[name] = struct{}{}
+	}
+	r.mu.RUnlock()
+
+	if r.parent != nil {
+		for _, name := range r.parent.ListServers() {
+			seen[name] = struct{}{}
 		}
 	}
 
-	return r.GetClient(ctx, serverName)
-}
-
-// ListServers returns all registered server names
-func (r *RegistryImpl) ListServers() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	servers := make([]string, 0, len(r.servers))
-	for name := range r.servers {
+	servers := make([]string, 0, len(seen))
+	for name := range seen {
 		servers = append(servers, name)
 	}
 	return servers
 }
 
 // GetServerConfig returns the configuration for a registered server.
+// Child registries fall through to the parent when the name is not
+// registered locally.
 func (r *RegistryImpl) GetServerConfig(serverName string) (ServerConfig, bool) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
 	cfg, ok := r.servers[serverName]
-	return cfg, ok
+	r.mu.RUnlock()
+	if ok {
+		return cfg, true
+	}
+	if r.parent != nil {
+		return r.parent.GetServerConfig(serverName)
+	}
+	return ServerConfig{}, false
 }
 
 // ListAllTools returns all tools from all connected servers

--- a/runtime/mcp/registry_test.go
+++ b/runtime/mcp/registry_test.go
@@ -225,11 +225,19 @@ func TestRegistry_GetServerNames(t *testing.T) {
 }
 
 func TestRegistry_TryGetExistingClient_NotRegistered(t *testing.T) {
+	// tryGetExistingClient returns (nil, nil) when no local client exists —
+	// the "not registered" error is reported by GetClient at the boundary.
+	// This loose contract lets child registries (Fork) fall through to a
+	// parent before the caller decides the lookup truly failed.
 	registry := NewRegistry()
 
 	client, err := registry.tryGetExistingClient("non-existent")
-	assert.Error(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, client)
+
+	// GetClient surfaces the "not registered" error at the public boundary.
+	_, err = registry.GetClient(context.Background(), "non-existent")
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not registered")
 }
 
@@ -923,4 +931,82 @@ func TestRegistry_UnregisterServer_AfterClose(t *testing.T) {
 	err := reg.UnregisterServer("x")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "closed")
+}
+
+// TestRegistry_Fork_IsolatesRegistration verifies that two children of the
+// same parent can each register a server under the same name without
+// collision — the core property needed to run concurrent sandboxes that
+// each present at a different URL.
+func TestRegistry_Fork_IsolatesRegistration(t *testing.T) {
+	parent := NewRegistry()
+	childA := parent.Fork()
+	childB := parent.Fork()
+
+	cfgA := ServerConfig{Name: "sandbox", URL: "http://localhost:50001/sse"}
+	cfgB := ServerConfig{Name: "sandbox", URL: "http://localhost:50002/sse"}
+
+	require.NoError(t, childA.RegisterServer(cfgA))
+	require.NoError(t, childB.RegisterServer(cfgB), "both children must accept the same name")
+
+	// Each child resolves "sandbox" to its own URL.
+	gotA, ok := childA.GetServerConfig("sandbox")
+	require.True(t, ok)
+	assert.Equal(t, "http://localhost:50001/sse", gotA.URL)
+	gotB, ok := childB.GetServerConfig("sandbox")
+	require.True(t, ok)
+	assert.Equal(t, "http://localhost:50002/sse", gotB.URL)
+
+	// Parent does not see either child's registration.
+	_, ok = parent.GetServerConfig("sandbox")
+	assert.False(t, ok, "parent must not inherit child registrations")
+}
+
+// TestRegistry_Fork_FallsThroughToParent verifies that lookups for
+// parent-registered (static) servers succeed in the child without the
+// child needing to re-register them.
+func TestRegistry_Fork_FallsThroughToParent(t *testing.T) {
+	parent := NewRegistry()
+	require.NoError(t, parent.RegisterServer(ServerConfig{
+		Name: "shared-mcp",
+		URL:  "http://shared.example/sse",
+	}))
+
+	child := parent.Fork()
+	got, ok := child.GetServerConfig("shared-mcp")
+	require.True(t, ok, "child must see parent-registered servers via fall-through")
+	assert.Equal(t, "http://shared.example/sse", got.URL)
+
+	// ListServers includes both parent and child entries.
+	require.NoError(t, child.RegisterServer(ServerConfig{
+		Name: "own", URL: "http://x/sse",
+	}))
+	names := child.ListServers()
+	assert.Contains(t, names, "shared-mcp")
+	assert.Contains(t, names, "own")
+}
+
+// TestRegistry_Fork_UnregisterChildOnly verifies that unregistering on
+// the child does not affect the parent's static state.
+func TestRegistry_Fork_UnregisterChildOnly(t *testing.T) {
+	parent := NewRegistry()
+	require.NoError(t, parent.RegisterServer(ServerConfig{
+		Name: "shared-mcp", URL: "http://shared/sse",
+	}))
+
+	child := parent.Fork()
+	require.NoError(t, child.RegisterServer(ServerConfig{
+		Name: "own", URL: "http://own/sse",
+	}))
+
+	require.NoError(t, child.UnregisterServer("own"))
+	_, ok := child.GetServerConfig("own")
+	assert.False(t, ok, "child's own entry should be gone")
+
+	// Parent's static entry is untouched.
+	_, ok = parent.GetServerConfig("shared-mcp")
+	assert.True(t, ok, "parent's entry must remain after child unregister")
+
+	// Child can still see parent's entry via fall-through.
+	_, ok = child.GetServerConfig("shared-mcp")
+	assert.True(t, ok)
 }

--- a/runtime/tools/mcp_executor.go
+++ b/runtime/tools/mcp_executor.go
@@ -18,7 +18,10 @@ const (
 	mcpDefaultTimeoutSc = 30
 )
 
-// MCPExecutor executes tools using MCP (Model Context Protocol) servers
+// MCPExecutor executes tools using MCP (Model Context Protocol) servers.
+// The configured registry is used as a default; callers can attach a
+// per-call registry override via WithMCPRegistry to give each concurrent
+// run its own MCP routing without sharing tool-to-server mappings.
 type MCPExecutor struct {
 	registry mcp.Registry
 }
@@ -28,6 +31,37 @@ func NewMCPExecutor(registry mcp.Registry) *MCPExecutor {
 	return &MCPExecutor{
 		registry: registry,
 	}
+}
+
+type mcpRegistryCtxKeyType struct{}
+
+var mcpRegistryCtxKey mcpRegistryCtxKeyType
+
+// WithMCPRegistry attaches an MCP registry to the context. The
+// MCPExecutor reads this on each Execute and routes via that registry,
+// falling back to the executor's configured registry when absent.
+//
+// Use this to give each concurrent run its own per-run MCP registry
+// (typically a Fork of the engine's parent registry) so that
+// session-scoped servers registered under the same name (e.g. "sandbox")
+// resolve to different URLs without collision.
+func WithMCPRegistry(ctx context.Context, reg mcp.Registry) context.Context {
+	if reg == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, mcpRegistryCtxKey, reg)
+}
+
+// mcpRegistryFromCtx returns a per-call MCP registry override if present.
+// Returns nil when the context carries no override.
+func mcpRegistryFromCtx(ctx context.Context) mcp.Registry {
+	if ctx == nil {
+		return nil
+	}
+	if reg, ok := ctx.Value(mcpRegistryCtxKey).(mcp.Registry); ok {
+		return reg
+	}
+	return nil
 }
 
 // Name returns the executor name
@@ -67,7 +101,16 @@ func (e *MCPExecutor) callMCPTool(
 	// Use the raw MCP name (without namespace prefix) for server communication
 	rawName := mcpRawToolName(toolName)
 
-	client, err := e.registry.GetClientForTool(ctx, rawName)
+	// Per-run override (if the caller attached one via WithMCPRegistry)
+	// takes precedence over the executor's configured registry. This is
+	// what lets each concurrent run's MCP dispatch route to its own
+	// session-scoped server even though a single MCPExecutor is shared.
+	registry := mcpRegistryFromCtx(ctx)
+	if registry == nil {
+		registry = e.registry
+	}
+
+	client, err := registry.GetClientForTool(ctx, rawName)
 	if err != nil {
 		logger.Error("MCP tool failed to get client", "tool", toolName, "error", err)
 		return nil, fmt.Errorf("failed to get MCP client for tool %s: %w", toolName, err)

--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -118,6 +119,34 @@ func newRegistry(repository ToolRepository, opts ...RegistryOption) *Registry {
 	}
 
 	return registry
+}
+
+// Fork returns a child Registry that snapshots the parent's tool
+// descriptors and executors at the moment of the call. After Fork the
+// child and parent are independent: descriptors and executors registered
+// on the child do not leak to the parent (and vice versa).
+//
+// Use this to give each concurrent run its own per-run dispatch state —
+// a per-run MCPExecutor wired to a per-run mcp.Registry, plus per-run
+// MCP tool descriptors discovered from session-scoped sources, without
+// colliding with other runs that share the engine's parent Registry.
+//
+// Memory cost is two shallow map copies; descriptor and executor values
+// are pointer-typed so the underlying objects are shared.
+func (r *Registry) Fork() *Registry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return &Registry{
+		// Children intentionally don't carry over the repository: they
+		// represent ephemeral per-run state and shouldn't persist.
+		repository:        nil,
+		tools:             maps.Clone(r.tools),
+		validator:         r.validator,
+		executors:         maps.Clone(r.executors),
+		defaultTimeoutMs:  r.defaultTimeoutMs,
+		maxToolResultSize: r.maxToolResultSize,
+		rateLimiter:       r.rateLimiter,
+	}
 }
 
 // Register adds a tool descriptor to the registry with validation.

--- a/runtime/tools/registry_test.go
+++ b/runtime/tools/registry_test.go
@@ -1006,3 +1006,77 @@ func TestIterateTools(t *testing.T) {
 		t.Errorf("expected both tools visited, got %v", visited)
 	}
 }
+
+// TestRegistry_Fork_InheritsParentTools verifies that descriptors
+// registered on the parent are visible in the child after Fork.
+func TestRegistry_Fork_InheritsParentTools(t *testing.T) {
+	parent := tools.NewRegistry()
+	if err := parent.Register(&tools.ToolDescriptor{Name: "shared", Mode: "mock"}); err != nil {
+		t.Fatalf("parent register: %v", err)
+	}
+
+	child := parent.Fork()
+	if got := child.Get("shared"); got == nil {
+		t.Errorf("child should inherit parent's 'shared' descriptor")
+	}
+}
+
+// TestRegistry_Fork_LocalRegisterStaysLocal verifies that registering a
+// descriptor on the child does not leak into the parent — the core
+// concurrency-safety property for per-run forks.
+func TestRegistry_Fork_LocalRegisterStaysLocal(t *testing.T) {
+	parent := tools.NewRegistry()
+	child := parent.Fork()
+
+	if err := child.Register(&tools.ToolDescriptor{Name: "child-only", Mode: "mock"}); err != nil {
+		t.Fatalf("child register: %v", err)
+	}
+
+	if got := child.Get("child-only"); got == nil {
+		t.Errorf("child should see its own registration")
+	}
+	if got := parent.Get("child-only"); got != nil {
+		t.Errorf("parent should NOT see child's registration; got %v", got)
+	}
+}
+
+// TestRegistry_Fork_PerChildExecutor verifies that two children each
+// register their own executor under the same Mode without colliding —
+// each child's tools dispatch to its own executor instance. Verified by
+// behavior (Execute returns the executor's tag).
+func TestRegistry_Fork_PerChildExecutor(t *testing.T) {
+	parent := tools.NewRegistry()
+	if err := parent.Register(&tools.ToolDescriptor{Name: "ping", Mode: "fork-tag"}); err != nil {
+		t.Fatalf("parent register: %v", err)
+	}
+
+	childA := parent.Fork()
+	childB := parent.Fork()
+	childA.RegisterExecutor(&forkTagExecutor{tag: "A"})
+	childB.RegisterExecutor(&forkTagExecutor{tag: "B"})
+
+	exec := func(r *tools.Registry) string {
+		out, err := r.Execute(context.Background(), "ping", []byte("{}"))
+		if err != nil {
+			return "ERR:" + err.Error()
+		}
+		if out == nil {
+			return ""
+		}
+		return string(out.Result)
+	}
+
+	if got := exec(childA); got != `"A"` {
+		t.Errorf("childA Execute(ping) = %q, want %q", got, `"A"`)
+	}
+	if got := exec(childB); got != `"B"` {
+		t.Errorf("childB Execute(ping) = %q, want %q", got, `"B"`)
+	}
+}
+
+type forkTagExecutor struct{ tag string }
+
+func (e *forkTagExecutor) Execute(_ context.Context, _ *tools.ToolDescriptor, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(e.tag)
+}
+func (e *forkTagExecutor) Name() string { return "fork-tag" }

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -407,11 +407,15 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 	}
 
 	// Open scenario + session scoped MCPSource entries; cleanup runs via defer.
-	mcpCleanup, mcpErr := e.openScenarioSessionMCPSources(runCtx, scenario, combo.ScenarioID, runID)
+	// The returned context carries a per-run forked MCP registry so the
+	// pipeline's MCPExecutor routes to this run's session-scoped servers
+	// rather than the engine's shared registry.
+	mcpRunCtx, mcpCleanup, mcpErr := e.openScenarioSessionMCPSources(runCtx, scenario, combo.ScenarioID, runID)
 	if mcpErr != nil {
 		return saveError(mcpErr.Error())
 	}
 	defer mcpCleanup()
+	runCtx = mcpRunCtx
 
 	// Get provider
 	provider, exists := e.providerRegistry.Get(combo.ProviderID)

--- a/tools/arena/engine/execution_mcpsource.go
+++ b/tools/arena/engine/execution_mcpsource.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/tools/arena/mcpsource"
 )
 
@@ -29,48 +30,56 @@ func scenarioVariables(sc *config.Scenario) map[string]string {
 // success-return path. When no source-backed entries are configured, the
 // cleanup is a no-op.
 //
-// Each executeRun invocation is one session (= one trial); scenario scope
-// is opened and torn down per invocation because arena runs scenarios
-// concurrently, so there's no natural "scenario start / scenario end"
-// across multiple combinations.
+// Each executeRun invocation is one session (= one trial). To allow
+// concurrent runs of source-backed MCP entries that present at different
+// URLs under the same logical name, this function forks the engine's
+// MCP registry and runs the scenario+session opens against the fork. The
+// returned per-run registry is attached to runCtx so MCPExecutor routes
+// to the run's own server set; on cleanup the fork is unregistered and
+// dropped.
 func (e *Engine) openScenarioSessionMCPSources(
 	ctx context.Context,
 	scenario *config.Scenario,
 	scenarioID, runID string,
-) (cleanup func(), err error) {
+) (runCtx context.Context, cleanup func(), err error) {
 	cleanup = func() {}
 	if e.mcpSourceScope == nil || len(e.mcpConfig) == 0 {
-		return cleanup, nil
+		return ctx, cleanup, nil
 	}
 
+	// Per-run forked registry isolates this run's session-scoped servers
+	// from concurrent runs that may use the same logical names.
+	runMCPRegistry := e.mcpRegistry.Fork()
+	runScope := newMCPSourceScopeWithTools(runMCPRegistry, e.toolRegistry)
+	runCtx = tools.WithMCPRegistry(ctx, runMCPRegistry)
+
 	scenarioVars := scenarioVariables(scenario)
-	if openErr := e.mcpSourceScope.OpenAll(
-		ctx, mcpsource.ScopeScenario, scenarioID, scenarioVars,
+	if openErr := runScope.OpenAll(
+		runCtx, mcpsource.ScopeScenario, scenarioID, scenarioVars,
 		e.mcpSkillSources, e.mcpConfig,
 	); openErr != nil {
-		return cleanup, fmt.Errorf("open scenario-scoped MCP sources: %v", openErr)
+		return ctx, cleanup, fmt.Errorf("open scenario-scoped MCP sources: %v", openErr)
 	}
 	closeScenario := func() {
-		for _, cerr := range e.mcpSourceScope.CloseAll(mcpsource.ScopeScenario, scenarioID) {
+		for _, cerr := range runScope.CloseAll(mcpsource.ScopeScenario, scenarioID) {
 			logger.Warn("mcp source close failed (scenario scope)", "error", cerr)
 		}
 	}
 
-	if openErr := e.mcpSourceScope.OpenAll(
-		ctx, mcpsource.ScopeSession, runID, scenarioVars,
+	if openErr := runScope.OpenAll(
+		runCtx, mcpsource.ScopeSession, runID, scenarioVars,
 		e.mcpSkillSources, e.mcpConfig,
 	); openErr != nil {
-		// Roll back the scenario open before returning.
 		closeScenario()
-		return cleanup, fmt.Errorf("open session-scoped MCP sources: %v", openErr)
+		return ctx, cleanup, fmt.Errorf("open session-scoped MCP sources: %v", openErr)
 	}
 	closeSession := func() {
-		for _, cerr := range e.mcpSourceScope.CloseAll(mcpsource.ScopeSession, runID) {
+		for _, cerr := range runScope.CloseAll(mcpsource.ScopeSession, runID) {
 			logger.Warn("mcp source close failed (session scope)", "error", cerr)
 		}
 	}
 
-	return func() {
+	return runCtx, func() {
 		closeSession()
 		closeScenario()
 	}, nil

--- a/tools/arena/engine/mcpsource_scope_integration_test.go
+++ b/tools/arena/engine/mcpsource_scope_integration_test.go
@@ -84,7 +84,7 @@ func TestScenarioVariables_CopiesVariables(t *testing.T) {
 // helper is a no-op when either the scope manager or MCP config is empty.
 func TestOpenScenarioSessionMCPSources_NoOpWhenUnconfigured(t *testing.T) {
 	e := &Engine{}
-	cleanup, err := e.openScenarioSessionMCPSources(context.Background(), nil, "scn", "run1")
+	_, cleanup, err := e.openScenarioSessionMCPSources(context.Background(), nil, "scn", "run1")
 	require.NoError(t, err)
 	require.NotNil(t, cleanup)
 	cleanup() // must not panic
@@ -92,7 +92,7 @@ func TestOpenScenarioSessionMCPSources_NoOpWhenUnconfigured(t *testing.T) {
 	// With a scope manager but no config entries, still a no-op.
 	reg := mcp.NewRegistry()
 	e = &Engine{mcpSourceScope: newMCPSourceScope(reg)}
-	cleanup, err = e.openScenarioSessionMCPSources(context.Background(), nil, "scn", "run1")
+	_, cleanup, err = e.openScenarioSessionMCPSources(context.Background(), nil, "scn", "run1")
 	require.NoError(t, err)
 	cleanup()
 }
@@ -108,6 +108,7 @@ func TestOpenScenarioSessionMCPSources_OpensAndCloses(t *testing.T) {
 
 	reg := mcp.NewRegistry()
 	e := &Engine{
+		mcpRegistry:    reg,
 		mcpSourceScope: newMCPSourceScope(reg),
 		mcpConfig: []config.MCPServerConfig{
 			{Name: "a", Source: "rec-exec-open-scn", Scope: "scenario"},
@@ -116,17 +117,21 @@ func TestOpenScenarioSessionMCPSources_OpensAndCloses(t *testing.T) {
 	}
 
 	scenario := &config.Scenario{Variables: map[string]string{"k": "v"}}
-	cleanup, err := e.openScenarioSessionMCPSources(
+	_, cleanup, err := e.openScenarioSessionMCPSources(
 		context.Background(), scenario, "scenario-1", "run-xyz")
 	require.NoError(t, err)
-	assert.Contains(t, reg.ListServers(), "a")
-	assert.Contains(t, reg.ListServers(), "b")
+	// Open once each (counter on the fake source).
+	assert.Equal(t, int32(1), scn.opens.Load())
+	assert.Equal(t, int32(1), ses.opens.Load())
+	// Source-backed entries land on the per-run forked registry, not the
+	// parent — that's the isolation property that lets concurrent runs
+	// open the same name without colliding. The parent must stay clean.
+	assert.NotContains(t, reg.ListServers(), "a")
+	assert.NotContains(t, reg.ListServers(), "b")
 
 	cleanup()
 	assert.Equal(t, int32(1), scn.closes.Load())
 	assert.Equal(t, int32(1), ses.closes.Load())
-	assert.NotContains(t, reg.ListServers(), "a")
-	assert.NotContains(t, reg.ListServers(), "b")
 }
 
 // TestOpenScenarioSessionMCPSources_RollsBackScenarioOnSessionFailure
@@ -139,6 +144,7 @@ func TestOpenScenarioSessionMCPSources_RollsBackScenarioOnSessionFailure(t *test
 
 	reg := mcp.NewRegistry()
 	e := &Engine{
+		mcpRegistry:    reg,
 		mcpSourceScope: newMCPSourceScope(reg),
 		mcpConfig: []config.MCPServerConfig{
 			{Name: "a", Source: "rec-exec-rollback-scn", Scope: "scenario"},
@@ -147,7 +153,7 @@ func TestOpenScenarioSessionMCPSources_RollsBackScenarioOnSessionFailure(t *test
 		},
 	}
 
-	cleanup, err := e.openScenarioSessionMCPSources(
+	_, cleanup, err := e.openScenarioSessionMCPSources(
 		context.Background(), nil, "scenario-rb", "run-rb")
 	require.Error(t, err)
 	require.NotNil(t, cleanup) // always safe to call


### PR DESCRIPTION
## Summary

Two commits, in order:

1. **`feat(runtime): Fork() on mcp.Registry and tools.Registry`** — adds primitives so consumers can give each concurrent run its own dispatch state. `mcp.Registry.Fork()` returns a child with parent fall-through (preserves client sharing for static servers); `tools.Registry.Fork()` snapshots descriptors and executors at fork time. Both keep registration local-only.

2. **`fix(arena): per-run MCP registry isolation for concurrent source opens`** — wires arena to use the primitives. Each `executeRun` forks `e.mcpRegistry`, opens scenario+session-scoped sources into the fork, and attaches the fork to `runCtx` via `tools.WithMCPRegistry`. The shared `MCPExecutor` reads the per-call registry from context and routes per-run.

## Why

Arena's session-scoped MCP source-backed entries (e.g. `sandbox` from the codegen-sandbox example) all registered into a single shared `mcp.Registry` under the same name. Concurrent runs collided on registration with `server sandbox already registered`. Found during the codegen-eval spike — only `-j 1` worked, defeating the SDK-style "many concurrent conversations" use case.

The SDK already does the right thing (each `Conversation.Open()` creates its own `mcp.NewRegistry()`); the bug was arena-only. The fork pattern matches that semantic without forcing every consumer to allocate fresh registries: static (run-scoped) servers register on the parent and clients are shared; only session/scenario-scoped servers fork.

## Memory

Per-run overhead: a few empty maps + the per-session sandbox connection (which is unavoidable — each session needs its own URL). Static servers stay single-instance with shared clients via parent fall-through.

## Test plan

- [x] `runtime/mcp.RegistryImpl` Fork — three new tests for isolation, fall-through, unregister-child-only
- [x] `runtime/tools.Registry` Fork — three new tests for inheritance, local-only registration, per-child executor
- [x] `runtime/tools.MCPExecutor` reads per-call registry from context — exercised through arena integration
- [x] `tools/arena/engine.openScenarioSessionMCPSources` updated to fork; existing scope-integration tests pass with new signature
- [x] `go test ./runtime/... ./tools/arena/... -count=1 -race` — 11298 pass, 0 fail, 0 race
- [x] Real-LLM end-to-end at `-j 6` (default concurrency): 5/5 baseline scenarios pass at simultaneous start, no "already registered" errors. Cost ~$0.50, elapsed ~50s vs ~110s serial.

## Out of scope

- Tools registry per-run isolation in the conversation pipeline (not needed for this case — MCP tool descriptors are stable across runs; only routing needed isolation, which the context override handles).
- Future use cases that need per-run tool descriptors (e.g. dynamic tool registration mid-conversation) can use `tools.Registry.Fork()` — the primitive is in place.
