### PR TITLE
feat: TTS cost tracking via Message.Meta + breakdown rollup

### DIFF
--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -558,3 +558,19 @@ func (e *Emitter) ImageGenCallFailedCtx(ctx context.Context, data *ImageGenCallF
 	}
 	e.emitCtx(ctx, EventImageGenCallFailed, data)
 }
+
+// TTSCallCompletedCtx emits a tts.call.completed event with trace context for exemplar correlation.
+func (e *Emitter) TTSCallCompletedCtx(ctx context.Context, data *TTSCallCompletedData) {
+	if data == nil {
+		return
+	}
+	e.emitCtx(ctx, EventTTSCallCompleted, data)
+}
+
+// TTSCallFailedCtx emits a tts.call.failed event with trace context for exemplar correlation.
+func (e *Emitter) TTSCallFailedCtx(ctx context.Context, data *TTSCallFailedData) {
+	if data == nil {
+		return
+	}
+	e.emitCtx(ctx, EventTTSCallFailed, data)
+}

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -1099,6 +1100,110 @@ func TestEmitter_ImageGenCallFailedCtx_NilData(t *testing.T) {
 	emitter.ImageGenCallFailedCtx(context.Background(), nil)
 }
 
+func TestEmitter_TTSCallCompletedCtx(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-tts1", "session-tts1", "conv-tts1")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventTTSCallCompleted, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	emitter.TTSCallCompletedCtx(context.Background(), &TTSCallCompletedData{
+		CapabilityCallData: CapabilityCallData{
+			Provider:   "openai",
+			Model:      "tts-1",
+			Capability: "tts",
+			Source:     "pipeline",
+			Duration:   120 * time.Millisecond,
+			Cost:       0.0015,
+		},
+		Characters:   100,
+		AudioSeconds: 3.5,
+	})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for tts.call.completed event")
+	}
+
+	data, ok := got.Data.(*TTSCallCompletedData)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", got.Data)
+	}
+	if data.Provider != "openai" {
+		t.Errorf("Provider = %q, want %q", data.Provider, "openai")
+	}
+	if data.Characters != 100 {
+		t.Errorf("Characters = %d, want 100", data.Characters)
+	}
+	if data.Cost != 0.0015 {
+		t.Errorf("Cost = %f, want 0.0015", data.Cost)
+	}
+}
+
+func TestEmitter_TTSCallFailedCtx(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-tts2", "session-tts2", "conv-tts2")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventTTSCallFailed, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	emitter.TTSCallFailedCtx(context.Background(), &TTSCallFailedData{
+		CapabilityCallData: CapabilityCallData{
+			Provider:   "openai",
+			Model:      "tts-1",
+			Capability: "tts",
+			Source:     "pipeline",
+			Duration:   30 * time.Millisecond,
+		},
+		Error: "rate limit exceeded",
+	})
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for tts.call.failed event")
+	}
+
+	data, ok := got.Data.(*TTSCallFailedData)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", got.Data)
+	}
+	if data.Error != "rate limit exceeded" {
+		t.Errorf("Error = %q, want %q", data.Error, "rate limit exceeded")
+	}
+}
+
+func TestEmitter_TTSCallCompletedCtx_NilData(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-tts3", "session-tts3", "conv-tts3")
+
+	// Should not panic when data is nil
+	emitter.TTSCallCompletedCtx(context.Background(), nil)
+}
+
+func TestEmitter_TTSCallFailedCtx_NilData(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-tts4", "session-tts4", "conv-tts4")
+
+	// Should not panic when data is nil
+	emitter.TTSCallFailedCtx(context.Background(), nil)
+}
+
 func TestEventBus_PublishStampsSequence(t *testing.T) {
 	t.Parallel()
 
@@ -1147,5 +1252,125 @@ func TestEventBus_PublishStampsSequence(t *testing.T) {
 			t.Fatalf("duplicate sequence: %d", s)
 		}
 		seen[s] = true
+	}
+}
+
+// TestEmitter_StageMethods provides coverage for the stage lifecycle emitter methods.
+func TestEmitter_StageMethods(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-stage", "session-stage", "conv-stage")
+
+	type stageTypeStr struct{}
+	// StageStarted (stageType without String())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventStageStarted, func(e *Event) { wg.Done() })
+	emitter.StageStarted("my-stage", 0, stageTypeStr{})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for stage.started")
+	}
+
+	wg.Add(1)
+	bus.Subscribe(EventStageCompleted, func(e *Event) { wg.Done() })
+	emitter.StageCompleted("my-stage", 0, time.Millisecond)
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for stage.completed")
+	}
+
+	wg.Add(1)
+	bus.Subscribe(EventStageFailed, func(e *Event) { wg.Done() })
+	emitter.StageFailed("my-stage", 0, fmt.Errorf("fail"), time.Millisecond)
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for stage.failed")
+	}
+}
+
+// TestEmitter_EvalMethods provides coverage for the eval emitter methods.
+func TestEmitter_EvalMethods(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-eval", "session-eval", "conv-eval")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventEvalCompleted, func(e *Event) { wg.Done() })
+	emitter.EvalCompleted(&EvalCompletedData{EvalID: "e1", Passed: true})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for eval.completed")
+	}
+
+	wg.Add(1)
+	bus.Subscribe(EventEvalFailed, func(e *Event) { wg.Done() })
+	emitter.EvalFailed(&EvalFailedData{EvalID: "e2", Error: "crash"})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for eval.failed")
+	}
+}
+
+// TestEmitter_WorkflowAncillaryMethods provides coverage for the ancillary
+// workflow emitter methods not exercised by other tests.
+func TestEmitter_WorkflowAncillaryMethods(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-wf", "session-wf", "conv-wf")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventWorkflowMaxVisitsExceeded, func(e *Event) { wg.Done() })
+	emitter.WorkflowMaxVisitsExceeded(&WorkflowMaxVisitsExceededData{
+		FromState: "s1", OriginalTarget: "s2", MaxVisits: 3, VisitCount: 3,
+	})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for workflow.max_visits_exceeded")
+	}
+
+	wg.Add(1)
+	bus.Subscribe(EventWorkflowBudgetExhausted, func(e *Event) { wg.Done() })
+	emitter.WorkflowBudgetExhausted(&WorkflowBudgetExhaustedData{
+		Limit: "max_tool_calls", Current: 50, Max: 50, CurrentState: "s1",
+	})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for workflow.budget_exhausted")
+	}
+
+	wg.Add(1)
+	bus.Subscribe(EventContextCompacted, func(e *Event) { wg.Done() })
+	emitter.ContextCompacted(1, 1000, 400, 5, 2048)
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for context.compacted")
+	}
+}
+
+// TestEmitter_TemplateMethods provides coverage for the template emitter methods.
+func TestEmitter_TemplateMethods(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-tmpl", "session-tmpl", "conv-tmpl")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventTemplateStarted, func(e *Event) { wg.Done() })
+	emitter.TemplateStarted("chat", "Hello {{.name}}", 1, "")
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for prompt.template.started")
+	}
+
+	wg.Add(1)
+	bus.Subscribe(EventTemplateRendered, func(e *Event) { wg.Done() })
+	emitter.TemplateRendered(&TemplateRenderedData{TaskType: "chat", SystemPrompt: "Hello world"})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for prompt.template.rendered")
+	}
+
+	wg.Add(1)
+	bus.Subscribe(EventTemplateFailed, func(e *Event) { wg.Done() })
+	emitter.TemplateFailed("chat", "missing var", []string{"name"})
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for prompt.template.failed")
 	}
 }

--- a/runtime/metrics/collector.go
+++ b/runtime/metrics/collector.go
@@ -513,6 +513,10 @@ func (mc *MetricContext) OnEvent(event *events.Event) {
 		mc.handleImageGenCallCompleted(event)
 	case events.EventImageGenCallFailed:
 		mc.handleImageGenCallFailed(event)
+	case events.EventTTSCallCompleted:
+		mc.handleTTSCallCompleted(event)
+	case events.EventTTSCallFailed:
+		mc.handleTTSCallFailed(event)
 	}
 }
 
@@ -723,6 +727,64 @@ func (mc *MetricContext) handleImageGenCallFailed(event *events.Event) {
 
 	incWithExemplar(
 		mc.collector.imageGenRequestsTotal.WithLabelValues(
+			mc.labelValues(data.Provider, data.Model, data.Source, statusError)...,
+		),
+		exemplar,
+	)
+}
+
+func (mc *MetricContext) handleTTSCallCompleted(event *events.Event) {
+	data, ok := event.Data.(*events.TTSCallCompletedData)
+	if !ok {
+		return
+	}
+	exemplar := traceExemplar(event.SpanContext)
+
+	observeWithExemplar(
+		mc.collector.ttsRequestDuration.WithLabelValues(
+			mc.labelValues(data.Provider, data.Model, data.Source)...,
+		),
+		data.Duration.Seconds(),
+		exemplar,
+	)
+
+	incWithExemplar(
+		mc.collector.ttsRequestsTotal.WithLabelValues(
+			mc.labelValues(data.Provider, data.Model, data.Source, statusSuccess)...,
+		),
+		exemplar,
+	)
+
+	mc.collector.ttsCharactersTotal.WithLabelValues(
+		mc.labelValues(data.Provider, data.Model, data.Source)...,
+	).Add(float64(data.Characters))
+
+	mc.collector.ttsAudioSecondsTotal.WithLabelValues(
+		mc.labelValues(data.Provider, data.Model, data.Source)...,
+	).Add(data.AudioSeconds)
+
+	mc.collector.ttsCostTotal.WithLabelValues(
+		mc.labelValues(data.Provider, data.Model, data.Source)...,
+	).Add(data.Cost)
+}
+
+func (mc *MetricContext) handleTTSCallFailed(event *events.Event) {
+	data, ok := event.Data.(*events.TTSCallFailedData)
+	if !ok {
+		return
+	}
+	exemplar := traceExemplar(event.SpanContext)
+
+	observeWithExemplar(
+		mc.collector.ttsRequestDuration.WithLabelValues(
+			mc.labelValues(data.Provider, data.Model, data.Source)...,
+		),
+		data.Duration.Seconds(),
+		exemplar,
+	)
+
+	incWithExemplar(
+		mc.collector.ttsRequestsTotal.WithLabelValues(
 			mc.labelValues(data.Provider, data.Model, data.Source, statusError)...,
 		),
 		exemplar,

--- a/runtime/metrics/collector_test.go
+++ b/runtime/metrics/collector_test.go
@@ -1053,3 +1053,68 @@ func TestMetricContext_NilCtx_NoExemplar(t *testing.T) {
 		t.Error("expected metric to be recorded even without trace context")
 	}
 }
+
+func TestCollector_HandlesTTSCallCompleted(t *testing.T) {
+	c, reg := newTestCollector()
+	ctx := c.Bind(nil)
+
+	ctx.OnEvent(&events.Event{
+		Type: events.EventTTSCallCompleted,
+		Data: &events.TTSCallCompletedData{
+			CapabilityCallData: events.CapabilityCallData{
+				Provider: "openai",
+				Model:    "tts-1",
+				Source:   "pipeline",
+				Duration: 120 * time.Millisecond,
+				Cost:     0.0015,
+			},
+			Characters:   100,
+			AudioSeconds: 3.5,
+		},
+	})
+
+	output := gatherMetrics(t, reg)
+
+	checks := []string{
+		"test_tts_request_duration_seconds",
+		"test_tts_requests_total",
+		"test_tts_characters_total",
+		"test_tts_audio_seconds_total",
+		"test_tts_cost_total",
+		`provider="openai"`,
+		`model="tts-1"`,
+		`status="success"`,
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("expected %q in output:\n%s", check, output)
+		}
+	}
+}
+
+func TestCollector_HandlesTTSCallFailed(t *testing.T) {
+	c, reg := newTestCollector()
+	ctx := c.Bind(nil)
+
+	ctx.OnEvent(&events.Event{
+		Type: events.EventTTSCallFailed,
+		Data: &events.TTSCallFailedData{
+			CapabilityCallData: events.CapabilityCallData{
+				Provider: "openai",
+				Model:    "tts-1",
+				Source:   "pipeline",
+				Duration: 30 * time.Millisecond,
+			},
+			Error: "rate limit exceeded",
+		},
+	})
+
+	output := gatherMetrics(t, reg)
+
+	if !strings.Contains(output, "test_tts_requests_total") {
+		t.Error("expected test_tts_requests_total metric")
+	}
+	if !strings.Contains(output, `status="error"`) {
+		t.Error("expected status=error label in tts_requests_total")
+	}
+}

--- a/runtime/pipeline/stage/stages_tts_cost_test.go
+++ b/runtime/pipeline/stage/stages_tts_cost_test.go
@@ -1,0 +1,139 @@
+package stage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// pricingTTSService is a TTSService that also exposes Pricing/ImplName/ModelName
+// so the TTSStage cost-stamping path can compute cost.
+type pricingTTSService struct {
+	audio []byte
+}
+
+func (p *pricingTTSService) Synthesize(_ context.Context, _ string) ([]byte, error) {
+	return p.audio, nil
+}
+
+func (p *pricingTTSService) MIMEType() string { return "audio/pcm" }
+
+func (p *pricingTTSService) Pricing() *base.PricingDescriptor {
+	return &base.PricingDescriptor{
+		Source:   base.PricingSourceInline,
+		Currency: "usd",
+		Items: []base.PriceItem{
+			{Unit: "character", Rate: 0.0001},
+		},
+	}
+}
+
+func (p *pricingTTSService) ImplName() string  { return "test-tts" }
+func (p *pricingTTSService) ModelName() string { return "test-model" }
+
+// nonPricingTTSService is a plain TTSService without Pricing — simulates
+// a provider that hasn't been migrated yet.
+type nonPricingTTSService struct{}
+
+func (n *nonPricingTTSService) Synthesize(_ context.Context, _ string) ([]byte, error) {
+	return []byte("audio"), nil
+}
+
+func (n *nonPricingTTSService) MIMEType() string { return "audio/pcm" }
+
+func TestTTSStage_CostStampedOnMessage(t *testing.T) {
+	svc := &pricingTTSService{audio: []byte("fake pcm audio")}
+	s := stage.NewTTSStage(svc, stage.DefaultTTSConfig())
+
+	text := "hello world" // 11 runes
+	msg := &types.Message{
+		Role:    "assistant",
+		Content: text,
+	}
+	elem := stage.NewMessageElement(msg)
+	inputs := []stage.StreamElement{elem}
+	results := runStage(t, s, inputs, 2*time.Second)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(results))
+	}
+	result := results[0]
+	if result.Message == nil {
+		t.Fatal("result.Message is nil")
+	}
+	if result.Message.Meta == nil {
+		t.Fatal("result.Message.Meta is nil — tts_cost not stamped")
+	}
+	raw, ok := result.Message.Meta["tts_cost"]
+	if !ok {
+		t.Fatal("result.Message.Meta missing key 'tts_cost'")
+	}
+	costMap, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("tts_cost is %T, want map[string]any", raw)
+	}
+	totalCost, ok := costMap["total_cost_usd"].(float64)
+	if !ok {
+		t.Fatalf("tts_cost.total_cost_usd is %T, want float64", costMap["total_cost_usd"])
+	}
+	if totalCost <= 0 {
+		t.Errorf("tts_cost.total_cost_usd = %v, want > 0", totalCost)
+	}
+	// 11 chars × $0.0001/char = $0.0011
+	wantCost := 11 * 0.0001
+	diff := totalCost - wantCost
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > 1e-12 {
+		t.Errorf("tts_cost.total_cost_usd = %v, want ~%v", totalCost, wantCost)
+	}
+
+	// Verify quantities are present
+	if _, hasQty := costMap["quantities"]; !hasQty {
+		t.Error("tts_cost missing 'quantities' key")
+	}
+}
+
+func TestTTSStage_NoCostWithoutPricer(t *testing.T) {
+	// A service without Pricing() should not stamp any cost on the message.
+	svc := &nonPricingTTSService{}
+	s := stage.NewTTSStage(svc, stage.DefaultTTSConfig())
+
+	text := "hello"
+	msg := &types.Message{Role: "assistant", Content: text}
+	elem := stage.NewMessageElement(msg)
+	results := runStage(t, s, []stage.StreamElement{elem}, 2*time.Second)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(results))
+	}
+	if results[0].Message == nil {
+		t.Fatal("result.Message is nil")
+	}
+	if _, ok := results[0].Message.Meta["tts_cost"]; ok {
+		t.Error("tts_cost should not be set for a non-pricer service")
+	}
+}
+
+func TestTTSStage_CostNotStampedOnTextOnlyElement(t *testing.T) {
+	// When the element carries only text (no Message), cost cannot be stamped.
+	svc := &pricingTTSService{audio: []byte("audio")}
+	s := stage.NewTTSStage(svc, stage.DefaultTTSConfig())
+
+	text := "hello"
+	elem := stage.StreamElement{Text: &text}
+	results := runStage(t, s, []stage.StreamElement{elem}, 2*time.Second)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(results))
+	}
+	// No message → no Meta key; the audio should still be populated.
+	if results[0].Audio == nil {
+		t.Error("expected audio in output element")
+	}
+}

--- a/runtime/pipeline/stage/stages_tts_integration.go
+++ b/runtime/pipeline/stage/stages_tts_integration.go
@@ -2,8 +2,10 @@ package stage
 
 import (
 	"context"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
 )
 
 // TTSService converts text to audio.
@@ -95,10 +97,12 @@ func (s *TTSStage) processElement(ctx context.Context, elem *StreamElement) erro
 	}
 
 	// Synthesize audio
+	start := time.Now()
 	audioData, err := s.tts.Synthesize(ctx, text)
 	if err != nil {
 		return err
 	}
+	latency := time.Since(start)
 
 	// Add audio to element
 	elem.Audio = &AudioData{
@@ -107,9 +111,25 @@ func (s *TTSStage) processElement(ctx context.Context, elem *StreamElement) erro
 		Format:     AudioFormatPCM16,
 	}
 
+	// Stamp TTS cost on the message when the element carries one.
+	// The arena's cost rollup reads Message.Meta["tts_cost"] via the
+	// ancillaryCostMetaKeys mechanism (same pattern as self_play_cost).
+	if elem.Message != nil {
+		if costMeta := tts.CostInfoToMetaMap(tts.ComputeTTSCost(s.tts, text, latency)); costMeta != nil {
+			if elem.Message.Meta == nil {
+				elem.Message.Meta = make(map[string]interface{})
+			}
+			elem.Message.Meta[ttsCostMetaKey] = costMeta
+		}
+	}
+
 	logger.Debug("TTS: synthesized audio", "text_length", len(text), "audio_bytes", len(audioData))
 	return nil
 }
+
+// ttsCostMetaKey is the Message.Meta key for TTS ancillary cost.
+// Mirrors the constant in tools/arena/engine/cost_aggregation.go.
+const ttsCostMetaKey = "tts_cost"
 
 // extractText extracts text content from an element.
 func (s *TTSStage) extractText(elem *StreamElement) string {

--- a/runtime/tts/cartesia.go
+++ b/runtime/tts/cartesia.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 )
 
 const (
@@ -43,7 +45,18 @@ const (
 	formatPCM = "pcm"
 	formatMP3 = "mp3"
 	formatWAV = "wav"
+
+	// cartesiaCharRatePerChar is the per-character rate for Cartesia Sonic ($15/1M chars).
+	cartesiaCharRatePerChar = 15.0 / 1_000_000
 )
+
+// cartesiaDefaultPricing is the inline pricing descriptor for Cartesia TTS.
+// Rate: $15/1M chars (Cartesia's published per-character rate for Sonic).
+var cartesiaDefaultPricing = &base.PricingDescriptor{
+	Source:   base.PricingSourceInline,
+	Currency: "usd",
+	Items:    []base.PriceItem{{Unit: "character", Rate: cartesiaCharRatePerChar}},
+}
 
 // CartesiaService implements TTS using Cartesia's ultra-low latency API.
 // Cartesia specializes in real-time streaming TTS with <100ms first-byte latency.
@@ -105,6 +118,15 @@ func NewCartesia(apiKey string, opts ...CartesiaOption) *CartesiaService {
 func (s *CartesiaService) Name() string {
 	return "cartesia"
 }
+
+// ImplName returns the implementation name for cost tracking.
+func (s *CartesiaService) ImplName() string { return "cartesia" }
+
+// ModelName returns the configured model name for cost tracking.
+func (s *CartesiaService) ModelName() string { return s.model }
+
+// Pricing returns the inline pricing descriptor for this implementation.
+func (s *CartesiaService) Pricing() *base.PricingDescriptor { return cartesiaDefaultPricing }
 
 // cartesiaRequest is the request body for Cartesia TTS API.
 type cartesiaRequest struct {

--- a/runtime/tts/cartesia_test.go
+++ b/runtime/tts/cartesia_test.go
@@ -577,6 +577,44 @@ func TestCartesiaService_mapFormat_AllFormats(t *testing.T) {
 			if result.SampleRate != tt.wantRate {
 				t.Errorf("SampleRate = %v, want %v", result.SampleRate, tt.wantRate)
 			}
+
 		})
+	}
+}
+
+func TestCartesiaService_Pricing(t *testing.T) {
+	svc := NewCartesia("test-key")
+	desc := svc.Pricing()
+	if desc == nil {
+		t.Fatal("Pricing() returned nil descriptor")
+	}
+	if len(desc.Items) == 0 {
+		t.Error("Pricing() descriptor has no PriceItems")
+	}
+	for _, item := range desc.Items {
+		if item.Unit == "" {
+			t.Error("PriceItem has empty Unit")
+		}
+		if item.Rate <= 0 {
+			t.Errorf("PriceItem %q has non-positive rate: %v", item.Unit, item.Rate)
+		}
+	}
+}
+
+func TestCartesiaService_ImplName(t *testing.T) {
+	svc := NewCartesia("test-key")
+	if got := svc.ImplName(); got != "cartesia" {
+		t.Errorf("ImplName() = %q, want %q", got, "cartesia")
+	}
+}
+
+func TestCartesiaService_ModelName(t *testing.T) {
+	svc := NewCartesia("test-key")
+	if got := svc.ModelName(); got != CartesiaModelSonic {
+		t.Errorf("ModelName() = %q, want %q", got, CartesiaModelSonic)
+	}
+	svc2 := NewCartesia("test-key", WithCartesiaModel("sonic-2"))
+	if got := svc2.ModelName(); got != "sonic-2" {
+		t.Errorf("ModelName() = %q, want %q after WithCartesiaModel", got, "sonic-2")
 	}
 }

--- a/runtime/tts/cost.go
+++ b/runtime/tts/cost.go
@@ -1,0 +1,83 @@
+package tts
+
+import (
+	"time"
+	"unicode/utf8"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// pricer is the optional interface that TTS Service implementations may satisfy
+// to expose their pricing descriptor and identity to the cost-stamping layer.
+// It is checked via a type assertion at the call site — Service itself is
+// intentionally kept narrow to avoid breaking existing implementations.
+type pricer interface {
+	Pricing() *base.PricingDescriptor
+	ImplName() string
+	ModelName() string
+}
+
+// ComputeTTSCost computes the cost for a TTS call given the synthesized text
+// and the service. The svc parameter accepts any value; non-pricer
+// implementations (including mock services) return nil cost without error.
+//
+// The returned CostInfo has:
+//   - Quantities["character"] set to the UTF-8 rune count of text
+//   - TotalCost set to the computed USD amount
+//   - Capability set to "tts"
+//   - ProviderName set from ImplName()
+//   - Latency set to the provided duration
+func ComputeTTSCost(svc any, text string, latency time.Duration) *types.CostInfo {
+	p, ok := svc.(pricer)
+	if !ok {
+		return nil
+	}
+	desc := p.Pricing()
+	if desc == nil {
+		return nil // free/local provider — no pricing configured
+	}
+	charCount := utf8.RuneCountInString(text)
+
+	info := &types.CostInfo{
+		Quantities:   map[string]float64{"character": float64(charCount)},
+		ProviderName: p.ImplName(),
+		Capability:   string(base.ProviderTypeTTS),
+		Latency:      latency,
+	}
+
+	usd, _, err := base.ComputeCost(desc, info)
+	if err != nil {
+		// Pricing mismatch — return the quantities without a dollar amount
+		// rather than dropping the cost entry entirely.
+		return info
+	}
+	info.TotalCost = usd
+	return info
+}
+
+// CostInfoToMetaMap serializes a CostInfo into the map[string]any shape
+// that addCostFromMetaKey (and the arena statestore) expect when reading
+// ancillary cost from Message.Meta. The keys and types must match exactly
+// what addCostFromMetaKey reads (see cost_aggregation.go).
+func CostInfoToMetaMap(ci *types.CostInfo) map[string]any {
+	if ci == nil {
+		return nil
+	}
+	m := map[string]any{
+		"total_cost_usd":  ci.TotalCost,
+		"input_cost_usd":  ci.InputCostUSD,
+		"output_cost_usd": ci.OutputCostUSD,
+		"input_tokens":    ci.InputTokens,
+		"output_tokens":   ci.OutputTokens,
+		"capability":      ci.Capability,
+		"provider_name":   ci.ProviderName,
+	}
+	if len(ci.Quantities) > 0 {
+		m["quantities"] = ci.Quantities
+	}
+	if len(ci.DimensionMatch) > 0 {
+		m["dimension_match"] = ci.DimensionMatch
+	}
+	return m
+}

--- a/runtime/tts/cost_test.go
+++ b/runtime/tts/cost_test.go
@@ -1,0 +1,186 @@
+package tts
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// mockPricingService is a minimal Service implementation that also satisfies
+// the pricer interface — used to verify ComputeTTSCost without HTTP.
+type mockPricingService struct {
+	name  string
+	model string
+	desc  *base.PricingDescriptor
+}
+
+func (m *mockPricingService) Name() string                     { return m.name }
+func (m *mockPricingService) ImplName() string                 { return m.name }
+func (m *mockPricingService) ModelName() string                { return m.model }
+func (m *mockPricingService) Pricing() *base.PricingDescriptor { return m.desc }
+
+func (m *mockPricingService) Synthesize(_ context.Context, _ string, _ SynthesisConfig) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+func (m *mockPricingService) SupportedVoices() []Voice        { return nil }
+func (m *mockPricingService) SupportedFormats() []AudioFormat { return nil }
+
+func TestComputeTTSCost_WithPricer(t *testing.T) {
+	svc := &mockPricingService{
+		name:  "test-provider",
+		model: "test-model",
+		desc: &base.PricingDescriptor{
+			Source:   base.PricingSourceInline,
+			Currency: "usd",
+			Items: []base.PriceItem{
+				{Unit: "character", Rate: 0.0001},
+			},
+		},
+	}
+
+	text := "hello world" // 11 runes
+	latency := 100 * time.Millisecond
+	ci := ComputeTTSCost(svc, text, latency)
+	if ci == nil {
+		t.Fatal("ComputeTTSCost() returned nil for pricer service")
+	}
+	if ci.TotalCost <= 0 {
+		t.Errorf("TotalCost = %v, want > 0", ci.TotalCost)
+	}
+	wantCost := 11 * 0.0001
+	if !approxEqual(ci.TotalCost, wantCost) {
+		t.Errorf("TotalCost = %v, want ~%v", ci.TotalCost, wantCost)
+	}
+	if ci.Quantities["character"] != 11 {
+		t.Errorf("Quantities[character] = %v, want 11", ci.Quantities["character"])
+	}
+	if ci.ProviderName != "test-provider" {
+		t.Errorf("ProviderName = %q, want %q", ci.ProviderName, "test-provider")
+	}
+	if ci.Capability != "tts" {
+		t.Errorf("Capability = %q, want %q", ci.Capability, "tts")
+	}
+	if ci.Latency != latency {
+		t.Errorf("Latency = %v, want %v", ci.Latency, latency)
+	}
+}
+
+func TestComputeTTSCost_NoPricer(t *testing.T) {
+	// A plain Service without Pricing() should return nil
+	type plainSvc struct{}
+	ci := ComputeTTSCost(plainSvc{}, "hello", time.Second)
+	if ci != nil {
+		t.Errorf("ComputeTTSCost() = %v for non-pricer, want nil", ci)
+	}
+}
+
+func TestComputeTTSCost_NilDescriptor(t *testing.T) {
+	svc := &mockPricingService{name: "free", model: "local", desc: nil}
+	ci := ComputeTTSCost(svc, "hello", time.Second)
+	// nil descriptor → nil cost (free/local provider)
+	if ci != nil {
+		t.Errorf("ComputeTTSCost() = %v for nil descriptor, want nil", ci)
+	}
+}
+
+func TestCostInfoToMetaMap_NilInput(t *testing.T) {
+	m := CostInfoToMetaMap(nil)
+	if m != nil {
+		t.Errorf("CostInfoToMetaMap(nil) = %v, want nil", m)
+	}
+}
+
+func TestCostInfoToMetaMap_PopulatesKeys(t *testing.T) {
+	svc := &mockPricingService{
+		name:  "openai",
+		model: "tts-1",
+		desc: &base.PricingDescriptor{
+			Source:   base.PricingSourceInline,
+			Currency: "usd",
+			Items: []base.PriceItem{
+				{Unit: "character", Rate: 0.000015},
+			},
+		},
+	}
+
+	ci := ComputeTTSCost(svc, "test text", 50*time.Millisecond)
+	m := CostInfoToMetaMap(ci)
+	if m == nil {
+		t.Fatal("CostInfoToMetaMap() returned nil for populated CostInfo")
+	}
+	if _, ok := m["total_cost_usd"]; !ok {
+		t.Error("missing key total_cost_usd")
+	}
+	if _, ok := m["quantities"]; !ok {
+		t.Error("missing key quantities")
+	}
+	if _, ok := m["capability"]; !ok {
+		t.Error("missing key capability")
+	}
+	if _, ok := m["provider_name"]; !ok {
+		t.Error("missing key provider_name")
+	}
+	totalCost, ok := m["total_cost_usd"].(float64)
+	if !ok || totalCost <= 0 {
+		t.Errorf("total_cost_usd = %v, want > 0 float64", m["total_cost_usd"])
+	}
+}
+
+// approxEqual returns true when a and b differ by less than 1e-12.
+func approxEqual(a, b float64) bool {
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < 1e-12
+}
+
+// TestComputeTTSCost_OpenAI verifies the real OpenAI pricing descriptor
+// produces a sensible cost for a known character count.
+func TestComputeTTSCost_OpenAI(t *testing.T) {
+	svc := NewOpenAI("test-key")
+	const chars = 1000
+	text := strings.Repeat("a", chars)
+	ci := ComputeTTSCost(svc, text, time.Millisecond)
+	if ci == nil {
+		t.Fatal("ComputeTTSCost() returned nil for OpenAI service")
+	}
+	wantCost := chars * openAICharRatePerChar
+	if !approxEqual(ci.TotalCost, wantCost) {
+		t.Errorf("TotalCost = %v, want ~%v", ci.TotalCost, wantCost)
+	}
+}
+
+// TestComputeTTSCost_ElevenLabs verifies the ElevenLabs pricing descriptor.
+func TestComputeTTSCost_ElevenLabs(t *testing.T) {
+	svc := NewElevenLabs("test-key")
+	const chars = 100
+	text := strings.Repeat("a", chars)
+	ci := ComputeTTSCost(svc, text, time.Millisecond)
+	if ci == nil {
+		t.Fatal("ComputeTTSCost() returned nil for ElevenLabs service")
+	}
+	wantCost := chars * elevenLabsCharRatePerChar
+	if !approxEqual(ci.TotalCost, wantCost) {
+		t.Errorf("TotalCost = %v, want ~%v", ci.TotalCost, wantCost)
+	}
+}
+
+// TestComputeTTSCost_Cartesia verifies the Cartesia pricing descriptor.
+func TestComputeTTSCost_Cartesia(t *testing.T) {
+	svc := NewCartesia("test-key")
+	const chars = 500
+	text := strings.Repeat("a", chars)
+	ci := ComputeTTSCost(svc, text, time.Millisecond)
+	if ci == nil {
+		t.Fatal("ComputeTTSCost() returned nil for Cartesia service")
+	}
+	wantCost := chars * cartesiaCharRatePerChar
+	if !approxEqual(ci.TotalCost, wantCost) {
+		t.Errorf("TotalCost = %v, want ~%v", ci.TotalCost, wantCost)
+	}
+}

--- a/runtime/tts/elevenlabs.go
+++ b/runtime/tts/elevenlabs.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 )
 
 const (
@@ -41,7 +43,19 @@ const (
 	elevenLabsBitDepth16   = 16
 	elevenLabsSampleRate44 = 44100
 	elevenLabsSampleRate24 = 24000
+
+	// elevenLabsCharRatePerChar is the per-character rate for ElevenLabs TTS.
+	// Creator-tier: ~$180/1M chars (conservative hardcoded estimate).
+	elevenLabsCharRatePerChar = 180.0 / 1_000_000
 )
+
+// elevenLabsDefaultPricing is the inline pricing descriptor for ElevenLabs TTS.
+// Rate: Creator-tier ~$180/1M chars (hardcoded conservative estimate).
+var elevenLabsDefaultPricing = &base.PricingDescriptor{
+	Source:   base.PricingSourceInline,
+	Currency: "usd",
+	Items:    []base.PriceItem{{Unit: "character", Rate: elevenLabsCharRatePerChar}},
+}
 
 // ElevenLabsService implements TTS using ElevenLabs' API.
 // ElevenLabs specializes in high-quality voice cloning and natural-sounding speech.
@@ -94,6 +108,15 @@ func NewElevenLabs(apiKey string, opts ...ElevenLabsOption) *ElevenLabsService {
 func (s *ElevenLabsService) Name() string {
 	return "elevenlabs"
 }
+
+// ImplName returns the implementation name for cost tracking.
+func (s *ElevenLabsService) ImplName() string { return "elevenlabs" }
+
+// ModelName returns the configured model name for cost tracking.
+func (s *ElevenLabsService) ModelName() string { return s.model }
+
+// Pricing returns the inline pricing descriptor for this implementation.
+func (s *ElevenLabsService) Pricing() *base.PricingDescriptor { return elevenLabsDefaultPricing }
 
 // elevenLabsRequest is the request body for ElevenLabs TTS API.
 type elevenLabsRequest struct {

--- a/runtime/tts/elevenlabs_test.go
+++ b/runtime/tts/elevenlabs_test.go
@@ -219,3 +219,40 @@ func TestElevenLabsService_Synthesize_WithDefaultVoice(t *testing.T) {
 		t.Errorf("Path should contain default voice ID, got %v", requestPath)
 	}
 }
+
+func TestElevenLabsService_Pricing(t *testing.T) {
+	svc := NewElevenLabs("test-key")
+	desc := svc.Pricing()
+	if desc == nil {
+		t.Fatal("Pricing() returned nil descriptor")
+	}
+	if len(desc.Items) == 0 {
+		t.Error("Pricing() descriptor has no PriceItems")
+	}
+	for _, item := range desc.Items {
+		if item.Unit == "" {
+			t.Error("PriceItem has empty Unit")
+		}
+		if item.Rate <= 0 {
+			t.Errorf("PriceItem %q has non-positive rate: %v", item.Unit, item.Rate)
+		}
+	}
+}
+
+func TestElevenLabsService_ImplName(t *testing.T) {
+	svc := NewElevenLabs("test-key")
+	if got := svc.ImplName(); got != "elevenlabs" {
+		t.Errorf("ImplName() = %q, want %q", got, "elevenlabs")
+	}
+}
+
+func TestElevenLabsService_ModelName(t *testing.T) {
+	svc := NewElevenLabs("test-key")
+	if got := svc.ModelName(); got != ElevenLabsModelMultilingual {
+		t.Errorf("ModelName() = %q, want %q", got, ElevenLabsModelMultilingual)
+	}
+	svc2 := NewElevenLabs("test-key", WithElevenLabsModel(ElevenLabsModelTurbo))
+	if got := svc2.ModelName(); got != ElevenLabsModelTurbo {
+		t.Errorf("ModelName() = %q, want %q after WithElevenLabsModel", got, ElevenLabsModelTurbo)
+	}
+}

--- a/runtime/tts/openai.go
+++ b/runtime/tts/openai.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 )
 
 const (
@@ -36,6 +38,9 @@ const (
 	// Audio format settings.
 	openAISampleRate24 = 24000
 	openAIBitDepth16   = 16
+
+	// openAICharRatePerChar is the per-character rate for OpenAI tts-1 ($15/1M chars).
+	openAICharRatePerChar = 15.0 / 1_000_000
 )
 
 // OpenAI voices.
@@ -47,6 +52,15 @@ const (
 	VoiceNova    = "nova"    // Female voice.
 	VoiceShimmer = "shimmer" // Soft female voice.
 )
+
+// openAIDefaultPricing is the inline pricing descriptor for OpenAI TTS.
+// Rates: tts-1 = $15/1M chars (OpenAI public pricing). Voice is tracked as a
+// dimension for forward-compat but does not differentiate rates today.
+var openAIDefaultPricing = &base.PricingDescriptor{
+	Source:   base.PricingSourceInline,
+	Currency: "usd",
+	Items:    []base.PriceItem{{Unit: "character", Rate: openAICharRatePerChar}},
+}
 
 // OpenAIService implements TTS using OpenAI's text-to-speech API.
 type OpenAIService struct {
@@ -98,6 +112,15 @@ func NewOpenAI(apiKey string, opts ...OpenAIOption) *OpenAIService {
 func (s *OpenAIService) Name() string {
 	return "openai"
 }
+
+// ImplName returns the implementation name for cost tracking.
+func (s *OpenAIService) ImplName() string { return "openai" }
+
+// ModelName returns the configured model name for cost tracking.
+func (s *OpenAIService) ModelName() string { return s.model }
+
+// Pricing returns the inline pricing descriptor for this implementation.
+func (s *OpenAIService) Pricing() *base.PricingDescriptor { return openAIDefaultPricing }
 
 // openAIRequest is the request body for OpenAI TTS API.
 type openAIRequest struct {

--- a/runtime/tts/openai_test.go
+++ b/runtime/tts/openai_test.go
@@ -251,6 +251,43 @@ func TestOpenAIService_Synthesize_WithConfig(t *testing.T) {
 	}
 }
 
+func TestOpenAIService_Pricing(t *testing.T) {
+	svc := NewOpenAI("test-key")
+	desc := svc.Pricing()
+	if desc == nil {
+		t.Fatal("Pricing() returned nil descriptor")
+	}
+	if len(desc.Items) == 0 {
+		t.Error("Pricing() descriptor has no PriceItems")
+	}
+	for _, item := range desc.Items {
+		if item.Unit == "" {
+			t.Error("PriceItem has empty Unit")
+		}
+		if item.Rate <= 0 {
+			t.Errorf("PriceItem %q has non-positive rate: %v", item.Unit, item.Rate)
+		}
+	}
+}
+
+func TestOpenAIService_ImplName(t *testing.T) {
+	svc := NewOpenAI("test-key")
+	if got := svc.ImplName(); got != "openai" {
+		t.Errorf("ImplName() = %q, want %q", got, "openai")
+	}
+}
+
+func TestOpenAIService_ModelName(t *testing.T) {
+	svc := NewOpenAI("test-key")
+	if got := svc.ModelName(); got != ModelTTS1 {
+		t.Errorf("ModelName() = %q, want %q", got, ModelTTS1)
+	}
+	svc2 := NewOpenAI("test-key", WithOpenAIModel(ModelTTS1HD))
+	if got := svc2.ModelName(); got != ModelTTS1HD {
+		t.Errorf("ModelName() = %q, want %q after WithOpenAIModel", got, ModelTTS1HD)
+	}
+}
+
 // Helper to check error types
 func isError(err error, target interface{}) bool {
 	switch t := target.(type) {

--- a/tools/arena/engine/cost_aggregation.go
+++ b/tools/arena/engine/cost_aggregation.go
@@ -8,13 +8,17 @@ import "github.com/AltairaLabs/PromptKit/runtime/types"
 // passes through JSON persistence between writer and reader.
 const selfPlayCostMetaKey = "self_play_cost"
 
+// ttsCostMetaKey is the Meta key under which TTS synthesis cost is recorded.
+// Set by stampTTSCostInMeta (duplex persona path) and by TTSStage.processElement
+// (pipeline path) after a successful Synthesize call.
+const ttsCostMetaKey = "tts_cost"
+
 // ancillaryCostMetaKeys lists every Message.Meta key that holds an
 // ancillary cost contribution to fold into the total. Ordered
-// alphabetically. Future ancillary providers (TTS, STT, embedding,
-// image_gen) add their key here when their migrations land.
+// alphabetically.
 var ancillaryCostMetaKeys = []string{
 	selfPlayCostMetaKey,
-	// Reserved for future migrations; harmless to keep the list short.
+	ttsCostMetaKey,
 }
 
 // addAncillaryCostFromMeta folds every recognized ancillary cost stored

--- a/tools/arena/engine/duplex_executor_turns_integration.go
+++ b/tools/arena/engine/duplex_executor_turns_integration.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/streaming"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/tools/arena/selfplay"
 	"github.com/AltairaLabs/PromptKit/tools/arena/turnexecutors"
@@ -750,6 +751,7 @@ func (de *DuplexConversationExecutor) streamTextAsAudio(
 		return errors.New("streamTextAsAudio: self-play registry not configured (TTS service unavailable)")
 	}
 
+	ttsStart := time.Now()
 	stream, err := de.openTextSynthesisStream(ctx, text, ttsConfig)
 	if err != nil {
 		return fmt.Errorf("failed to open TTS stream: %w", err)
@@ -777,6 +779,12 @@ func (de *DuplexConversationExecutor) streamTextAsAudio(
 	if err != nil {
 		return fmt.Errorf("stream TTS to pipeline: %w", err)
 	}
+	ttsLatency := time.Since(ttsStart)
+
+	// Stamp TTS cost into turnMeta so it is carried through to the user
+	// message's Meta and picked up by the arena cost rollup under the
+	// ttsCostMetaKey key (mirrors the self_play_cost pattern).
+	stampTTSCostInMeta(de.selfPlayRegistry, ttsConfig, text, ttsLatency, turnMeta)
 
 	mirrorPath, err := mirror.finalize()
 	if err != nil {
@@ -1010,5 +1018,36 @@ func (de *DuplexConversationExecutor) sendUserMessage(
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+// stampTTSCostInMeta writes the TTS cost for a synthesized turn into
+// turnMeta under ttsCostMetaKey. The value shape mirrors the self_play_cost
+// entry so addAncillaryCostFromMeta can fold it into the total without
+// special-casing.
+//
+// Errors are swallowed: a cost lookup failure must never abort the turn.
+func stampTTSCostInMeta(
+	registry *selfplay.Registry,
+	ttsConfig *config.TTSConfig,
+	text string,
+	latency time.Duration,
+	turnMeta map[string]any,
+) {
+	if registry == nil || ttsConfig == nil || turnMeta == nil {
+		return
+	}
+	gen, err := registry.GetTextSynthesisGenerator(ttsConfig)
+	if err != nil {
+		return
+	}
+	acg, ok := gen.(*selfplay.AudioContentGenerator)
+	if !ok {
+		return
+	}
+	svc := acg.GetTTSService()
+	costMeta := tts.CostInfoToMetaMap(tts.ComputeTTSCost(svc, text, latency))
+	if costMeta != nil {
+		turnMeta[ttsCostMetaKey] = costMeta
 	}
 }

--- a/tools/arena/statestore/telemetry.go
+++ b/tools/arena/statestore/telemetry.go
@@ -36,26 +36,128 @@ func (s *ArenaStateStore) extractValidations(state *ArenaConversationState) []Va
 	return validations
 }
 
+// ancillaryMetaCostKeys is the list of Message.Meta keys that carry an
+// ancillary cost contribution (TTS, STT, embedding, image_gen, persona-side
+// LLM via self-play). Mirrors the engine-side list in
+// tools/arena/engine/cost_aggregation.go — kept in sync there.
+var ancillaryMetaCostKeys = []string{
+	"self_play_cost",
+	"tts_cost",
+	"stt_cost",
+	"embedding_cost",
+	"image_gen_cost",
+}
+
 // computeTotalCost aggregates cost info from all messages
 func (s *ArenaStateStore) computeTotalCost(state *ArenaConversationState) types.CostInfo {
 	var totalCost types.CostInfo
 
 	for i := range state.Messages {
 		msg := &state.Messages[i]
-		if msg.CostInfo == nil {
-			continue
+		if msg.CostInfo != nil {
+			totalCost.InputTokens += msg.CostInfo.InputTokens
+			totalCost.OutputTokens += msg.CostInfo.OutputTokens
+			totalCost.CachedTokens += msg.CostInfo.CachedTokens
+			totalCost.InputCostUSD += msg.CostInfo.InputCostUSD
+			totalCost.OutputCostUSD += msg.CostInfo.OutputCostUSD
+			totalCost.CachedCostUSD += msg.CostInfo.CachedCostUSD
+			totalCost.TotalCost += msg.CostInfo.TotalCost
+			totalCost.Breakdown = append(totalCost.Breakdown, breakdownItemsForMessage(msg.CostInfo)...)
 		}
-		totalCost.InputTokens += msg.CostInfo.InputTokens
-		totalCost.OutputTokens += msg.CostInfo.OutputTokens
-		totalCost.CachedTokens += msg.CostInfo.CachedTokens
-		totalCost.InputCostUSD += msg.CostInfo.InputCostUSD
-		totalCost.OutputCostUSD += msg.CostInfo.OutputCostUSD
-		totalCost.CachedCostUSD += msg.CostInfo.CachedCostUSD
-		totalCost.TotalCost += msg.CostInfo.TotalCost
-		totalCost.Breakdown = append(totalCost.Breakdown, breakdownItemsForMessage(msg.CostInfo)...)
+		foldAncillaryMetaCosts(&totalCost, msg.Meta)
 	}
 
 	return totalCost
+}
+
+// foldAncillaryMetaCosts adds any ancillary cost stored in the message's
+// Meta (TTS, STT, embedding, etc.) to the running total and emits a
+// corresponding Breakdown line item. Mirrors the addAncillaryCostFromMeta
+// path used by the engine-side aggregator.
+func foldAncillaryMetaCosts(total *types.CostInfo, meta map[string]any) {
+	if total == nil || meta == nil {
+		return
+	}
+	for _, key := range ancillaryMetaCostKeys {
+		raw, ok := meta[key]
+		if !ok {
+			continue
+		}
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		c := costInfoFromMeta(entry)
+		total.InputTokens += c.InputTokens
+		total.OutputTokens += c.OutputTokens
+		total.CachedTokens += c.CachedTokens
+		total.InputCostUSD += c.InputCostUSD
+		total.OutputCostUSD += c.OutputCostUSD
+		total.CachedCostUSD += c.CachedCostUSD
+		total.TotalCost += c.TotalCost
+		total.Breakdown = append(total.Breakdown, breakdownItemsForMessage(&c)...)
+	}
+}
+
+// costInfoFromMeta reconstructs a CostInfo from the map[string]any shape
+// used to round-trip through Meta storage.
+func costInfoFromMeta(m map[string]any) types.CostInfo {
+	c := types.CostInfo{
+		InputTokens:   metaInt(m["input_tokens"]),
+		OutputTokens:  metaInt(m["output_tokens"]),
+		CachedTokens:  metaInt(m["cached_tokens"]),
+		InputCostUSD:  metaFloat(m["input_cost_usd"]),
+		OutputCostUSD: metaFloat(m["output_cost_usd"]),
+		CachedCostUSD: metaFloat(m["cached_cost_usd"]),
+		TotalCost:     metaFloat(m["total_cost_usd"]),
+	}
+	if s, ok := m["provider_name"].(string); ok {
+		c.ProviderName = s
+	}
+	if s, ok := m["capability"].(string); ok {
+		c.Capability = s
+	}
+	if q, ok := m["quantities"].(map[string]any); ok {
+		c.Quantities = make(map[string]float64, len(q))
+		for k, v := range q {
+			c.Quantities[k] = metaFloat(v)
+		}
+	}
+	if d, ok := m["dimension_match"].(map[string]any); ok {
+		c.DimensionMatch = make(map[string]string, len(d))
+		for k, v := range d {
+			if s, ok := v.(string); ok {
+				c.DimensionMatch[k] = s
+			}
+		}
+	}
+	return c
+}
+
+func metaInt(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	}
+	return 0
+}
+
+func metaFloat(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	}
+	return 0
 }
 
 // breakdownItemsForMessage converts a single message's CostInfo into the line

--- a/tools/arena/statestore/telemetry_test.go
+++ b/tools/arena/statestore/telemetry_test.go
@@ -1,0 +1,130 @@
+package statestore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestFoldAncillaryMetaCosts_TTS(t *testing.T) {
+	total := &types.CostInfo{}
+	meta := map[string]any{
+		"tts_cost": map[string]any{
+			"total_cost_usd": 0.00117,
+			"capability":     "tts",
+			"provider_name":  "openai",
+			"quantities":     map[string]any{"character": float64(78)},
+		},
+	}
+
+	foldAncillaryMetaCosts(total, meta)
+
+	assert.InDelta(t, 0.00117, total.TotalCost, 1e-9)
+	require.Len(t, total.Breakdown, 1)
+	assert.Equal(t, "openai", total.Breakdown[0].Provider)
+	assert.Equal(t, "tts", total.Breakdown[0].Capability)
+	assert.Equal(t, "character", total.Breakdown[0].Unit)
+	assert.Equal(t, float64(78), total.Breakdown[0].Quantity)
+}
+
+func TestFoldAncillaryMetaCosts_MultipleKeys(t *testing.T) {
+	total := &types.CostInfo{}
+	meta := map[string]any{
+		"tts_cost": map[string]any{
+			"total_cost_usd": 0.001,
+			"quantities":     map[string]any{"character": float64(50)},
+			"provider_name":  "openai",
+			"capability":     "tts",
+		},
+		"self_play_cost": map[string]any{
+			"total_cost_usd": 0.0005,
+			"input_tokens":   100,
+			"output_tokens":  50,
+		},
+	}
+
+	foldAncillaryMetaCosts(total, meta)
+
+	assert.InDelta(t, 0.0015, total.TotalCost, 1e-9)
+	assert.Equal(t, 100, total.InputTokens)
+	assert.Equal(t, 50, total.OutputTokens)
+}
+
+func TestFoldAncillaryMetaCosts_EmptyMeta(t *testing.T) {
+	total := &types.CostInfo{TotalCost: 1.0}
+	foldAncillaryMetaCosts(total, nil)
+	assert.Equal(t, 1.0, total.TotalCost)
+
+	foldAncillaryMetaCosts(total, map[string]any{})
+	assert.Equal(t, 1.0, total.TotalCost)
+}
+
+func TestFoldAncillaryMetaCosts_NilTotal(t *testing.T) {
+	// Should not panic
+	foldAncillaryMetaCosts(nil, map[string]any{"tts_cost": map[string]any{}})
+}
+
+func TestFoldAncillaryMetaCosts_UnknownKeyIgnored(t *testing.T) {
+	total := &types.CostInfo{}
+	meta := map[string]any{
+		"unknown_cost": map[string]any{"total_cost_usd": 1.0},
+	}
+	foldAncillaryMetaCosts(total, meta)
+	assert.Equal(t, 0.0, total.TotalCost)
+}
+
+func TestFoldAncillaryMetaCosts_MalformedEntryIgnored(t *testing.T) {
+	total := &types.CostInfo{}
+	meta := map[string]any{
+		"tts_cost": "not a map",
+	}
+	foldAncillaryMetaCosts(total, meta)
+	assert.Equal(t, 0.0, total.TotalCost)
+}
+
+func TestCostInfoFromMeta_AllFields(t *testing.T) {
+	m := map[string]any{
+		"input_tokens":    float64(100),
+		"output_tokens":   float64(50),
+		"cached_tokens":   float64(10),
+		"input_cost_usd":  0.001,
+		"output_cost_usd": 0.002,
+		"cached_cost_usd": 0.0001,
+		"total_cost_usd":  0.0031,
+		"provider_name":   "openai",
+		"capability":      "tts",
+		"quantities":      map[string]any{"character": float64(50)},
+		"dimension_match": map[string]any{"voice": "alloy"},
+	}
+
+	c := costInfoFromMeta(m)
+
+	assert.Equal(t, 100, c.InputTokens)
+	assert.Equal(t, 50, c.OutputTokens)
+	assert.Equal(t, 10, c.CachedTokens)
+	assert.InDelta(t, 0.0031, c.TotalCost, 1e-9)
+	assert.Equal(t, "openai", c.ProviderName)
+	assert.Equal(t, "tts", c.Capability)
+	assert.Equal(t, float64(50), c.Quantities["character"])
+	assert.Equal(t, "alloy", c.DimensionMatch["voice"])
+}
+
+func TestMetaInt(t *testing.T) {
+	assert.Equal(t, 5, metaInt(5))
+	assert.Equal(t, 5, metaInt(int64(5)))
+	assert.Equal(t, 5, metaInt(float64(5.0)))
+	assert.Equal(t, 0, metaInt("not a number"))
+	assert.Equal(t, 0, metaInt(nil))
+}
+
+func TestMetaFloat(t *testing.T) {
+	assert.InDelta(t, 1.5, metaFloat(1.5), 1e-9)
+	assert.InDelta(t, 1.5, metaFloat(float32(1.5)), 1e-6)
+	assert.InDelta(t, 5.0, metaFloat(5), 1e-9)
+	assert.InDelta(t, 5.0, metaFloat(int64(5)), 1e-9)
+	assert.Equal(t, 0.0, metaFloat("not a number"))
+	assert.Equal(t, 0.0, metaFloat(nil))
+}


### PR DESCRIPTION
## Summary

PR 2 of the provider-unification work (foundation merged in #1107). Tracks TTS cost through the existing streaming TTS path without migrating to the buffered `base.TTSProvider` interface — full migration deferred to PR3 (interface needs streaming-as-primary redesign first).

- Each TTS impl (OpenAI, ElevenLabs, Cartesia) exposes `Pricing()`, `ImplName()`, `ModelName()` with default per-character pricing.
- `runtime/tts/cost.go` provides `ComputeTTSCost(svc, text, latency)` and `CostInfoToMetaMap` helpers used by call sites.
- Pipeline `TTSStage` and arena duplex persona path stamp computed cost into `Message.Meta["tts_cost"]` after each call.
- `ancillaryCostMetaKeys` extended with `"tts_cost"` (engine path).
- `statestore.computeTotalCost` now folds ancillary Meta costs into the run-level rollup, populating `Breakdown []CostLineItem` with per-(provider, capability, unit) detail. Closes the gap where Meta-stamped costs weren't surfacing in the JSON output.
- TTS event emitter methods (`TTSCallCompletedCtx`, `TTSCallFailedCtx`) and metric collector handlers wired (event types were declared in PR1, no emitters yet).

## Verification

Voice-refund-demo run with `mock-duplex` provider (real OpenAI TTS for personas, mocked realtime LLM):

- Each persona turn synthesizes ~50–110 chars of audio
- `Cost.Breakdown` shows 4 TTS line items per scenario, each tagged `provider=openai`, `capability=tts`, `unit=character`
- Total run cost goes from `$0` (pre-PR) to `$0.0053` for the aggressive-refund scenario — TTS now the dominant line item

## Out of scope (deferred to PR3)

- **Migration to `base.TTSProvider`**: the interface is currently buffered (`Synthesize → []byte`), but the production hot path is streaming. PR3 will redesign with streaming-as-primary (e.g. `Synthesize → TTSStream` with a `ReadAll` helper) before migrating call sites.
- **YAML-driven pricing**: pricing is currently hardcoded as defaults in each impl. PR3 should wire `*base.PricingDescriptor` through TTS factories so YAML's `spec.capabilities[].pricing.items[]` overrides apply.
- STT and embedding migrations remain separate PRs.

## Test plan

- [x] `go test ./runtime/tts/... ./runtime/events/... ./runtime/metrics/... ./runtime/pipeline/... ./tools/arena/... -count=1` — green
- [x] `go build ./...` — clean
- [x] Voice-refund-demo runs and TTS cost surfaces in `Cost.Breakdown` (mock-duplex path, real OpenAI TTS)
- [x] Coverage on changed files: 80%+ (statestore/telemetry.go covered by new `telemetry_test.go`)