### PR TITLE
chore(tts): collapse Voice/AudioFormat literals via makeVoice/makeFormat

### DIFF
--- a/runtime/tts/cartesia.go
+++ b/runtime/tts/cartesia.go
@@ -244,67 +244,19 @@ func (s *CartesiaService) handleError(resp *http.Response) error {
 // SupportedVoices returns a sample of available Cartesia voices.
 func (s *CartesiaService) SupportedVoices() []Voice {
 	return []Voice{
-		{
-			ID:          "a0e99841-438c-4a64-b679-ae501e7d6091",
-			Name:        "Barbershop Man",
-			Language:    "en",
-			Gender:      "male",
-			Description: "Deep, warm male voice",
-		},
-		{
-			ID:          "156fb8d2-335b-4950-9cb3-a2d33befec77",
-			Name:        "British Lady",
-			Language:    "en",
-			Gender:      "female",
-			Description: "British accent, professional",
-		},
-		{
-			ID:          "79a125e8-cd45-4c13-8a67-188112f4dd22",
-			Name:        "California Girl",
-			Language:    "en",
-			Gender:      "female",
-			Description: "Casual, friendly American",
-		},
-		{
-			ID:          "bf991597-6c13-47e4-8411-91ec2de5c466",
-			Name:        "Confident Man",
-			Language:    "en",
-			Gender:      "male",
-			Description: "Clear, confident delivery",
-		},
-		{
-			ID:          "9121c0ae-12a6-4012-8158-6e4a72e6da91",
-			Name:        "Friendly Woman",
-			Language:    "en",
-			Gender:      "female",
-			Description: "Warm, approachable",
-		},
+		makeVoice("a0e99841-438c-4a64-b679-ae501e7d6091", "Barbershop Man", "en", "male", "Deep, warm male voice"),
+		makeVoice("156fb8d2-335b-4950-9cb3-a2d33befec77", "British Lady", "en", "female", "British accent, professional"),
+		makeVoice("79a125e8-cd45-4c13-8a67-188112f4dd22", "California Girl", "en", "female", "Casual, friendly American"),
+		makeVoice("bf991597-6c13-47e4-8411-91ec2de5c466", "Confident Man", "en", "male", "Clear, confident delivery"),
+		makeVoice("9121c0ae-12a6-4012-8158-6e4a72e6da91", "Friendly Woman", "en", "female", "Warm, approachable"),
 	}
 }
 
 // SupportedFormats returns audio formats supported by Cartesia.
 func (s *CartesiaService) SupportedFormats() []AudioFormat {
 	return []AudioFormat{
-		{
-			Name:       formatPCM,
-			MIMEType:   "audio/pcm",
-			SampleRate: sampleRate24000,
-			BitDepth:   bitDepth16,
-			Channels:   1,
-		},
-		{
-			Name:       formatMP3,
-			MIMEType:   "audio/mpeg",
-			SampleRate: sampleRate44100,
-			BitDepth:   0,
-			Channels:   1,
-		},
-		{
-			Name:       formatWAV,
-			MIMEType:   "audio/wav",
-			SampleRate: sampleRate44100,
-			BitDepth:   bitDepth16,
-			Channels:   1,
-		},
+		makeFormat(formatPCM, "audio/pcm", sampleRate24000, bitDepth16),
+		makeFormat(formatMP3, "audio/mpeg", sampleRate44100, 0),
+		makeFormat(formatWAV, "audio/wav", sampleRate44100, bitDepth16),
 	}
 }

--- a/runtime/tts/elevenlabs.go
+++ b/runtime/tts/elevenlabs.go
@@ -182,88 +182,22 @@ func (s *ElevenLabsService) handleError(resp *http.Response) error {
 // Use the ElevenLabs API to get a complete list of available voices.
 func (s *ElevenLabsService) SupportedVoices() []Voice {
 	return []Voice{
-		{
-			ID:          "21m00Tcm4TlvDq8ikWAM",
-			Name:        "Rachel",
-			Language:    "en",
-			Gender:      "female",
-			Description: "American, calm, young",
-		},
-		{
-			ID:          "AZnzlk1XvdvUeBnXmlld",
-			Name:        "Domi",
-			Language:    "en",
-			Gender:      "female",
-			Description: "American, confident",
-		},
-		{
-			ID:          "EXAVITQu4vr4xnSDxMaL",
-			Name:        "Bella",
-			Language:    "en",
-			Gender:      "female",
-			Description: "American, soft",
-		},
-		{
-			ID:          "ErXwobaYiN019PkySvjV",
-			Name:        "Antoni",
-			Language:    "en",
-			Gender:      "male",
-			Description: "American, well-rounded",
-		},
-		{
-			ID:          "MF3mGyEYCl7XYWbV9V6O",
-			Name:        "Elli",
-			Language:    "en",
-			Gender:      "female",
-			Description: "American, young",
-		},
-		{
-			ID:          "TxGEqnHWrfWFTfGW9XjX",
-			Name:        "Josh",
-			Language:    "en",
-			Gender:      "male",
-			Description: "American, young, deep",
-		},
-		{
-			ID:          "VR6AewLTigWG4xSOukaG",
-			Name:        "Arnold",
-			Language:    "en",
-			Gender:      "male",
-			Description: "American, deep, professional",
-		},
-		{
-			ID:          "pNInz6obpgDQGcFmaJgB",
-			Name:        "Adam",
-			Language:    "en",
-			Gender:      "male",
-			Description: "American, deep, narrative",
-		},
-		{
-			ID:          "yoZ06aMxZJJ28mfd3POQ",
-			Name:        "Sam",
-			Language:    "en",
-			Gender:      "male",
-			Description: "American, young, casual",
-		},
+		makeVoice("21m00Tcm4TlvDq8ikWAM", "Rachel", "en", "female", "American, calm, young"),
+		makeVoice("AZnzlk1XvdvUeBnXmlld", "Domi", "en", "female", "American, confident"),
+		makeVoice("EXAVITQu4vr4xnSDxMaL", "Bella", "en", "female", "American, soft"),
+		makeVoice("ErXwobaYiN019PkySvjV", "Antoni", "en", "male", "American, well-rounded"),
+		makeVoice("MF3mGyEYCl7XYWbV9V6O", "Elli", "en", "female", "American, young"),
+		makeVoice("TxGEqnHWrfWFTfGW9XjX", "Josh", "en", "male", "American, young, deep"),
+		makeVoice("VR6AewLTigWG4xSOukaG", "Arnold", "en", "male", "American, deep, professional"),
+		makeVoice("pNInz6obpgDQGcFmaJgB", "Adam", "en", "male", "American, deep, narrative"),
+		makeVoice("yoZ06aMxZJJ28mfd3POQ", "Sam", "en", "male", "American, young, casual"),
 	}
 }
 
 // SupportedFormats returns audio formats supported by ElevenLabs.
 func (s *ElevenLabsService) SupportedFormats() []AudioFormat {
 	return []AudioFormat{
-		{
-			Name:       "mp3",
-			MIMEType:   "audio/mpeg",
-			SampleRate: elevenLabsSampleRate44,
-			BitDepth:   0,
-			Channels:   1,
-		},
-		{
-			Name:       "pcm",
-			MIMEType:   "audio/pcm",
-			SampleRate: elevenLabsSampleRate24,
-			BitDepth:   elevenLabsBitDepth16,
-			Channels:   1,
-		},
+		makeFormat("mp3", "audio/mpeg", elevenLabsSampleRate44, 0),
+		makeFormat("pcm", "audio/pcm", elevenLabsSampleRate24, elevenLabsBitDepth16),
 	}
 }

--- a/runtime/tts/openai.go
+++ b/runtime/tts/openai.go
@@ -252,48 +252,12 @@ func (s *OpenAIService) handleError(resp *http.Response) error {
 // SupportedVoices returns available OpenAI voices.
 func (s *OpenAIService) SupportedVoices() []Voice {
 	return []Voice{
-		{
-			ID:          VoiceAlloy,
-			Name:        "Alloy",
-			Language:    "en",
-			Gender:      "neutral",
-			Description: "Balanced, versatile voice",
-		},
-		{
-			ID:          VoiceEcho,
-			Name:        "Echo",
-			Language:    "en",
-			Gender:      "male",
-			Description: "Clear male voice",
-		},
-		{
-			ID:          VoiceFable,
-			Name:        "Fable",
-			Language:    "en",
-			Gender:      "female",
-			Description: "Expressive, British accent",
-		},
-		{
-			ID:          VoiceOnyx,
-			Name:        "Onyx",
-			Language:    "en",
-			Gender:      "male",
-			Description: "Deep, authoritative voice",
-		},
-		{
-			ID:          VoiceNova,
-			Name:        "Nova",
-			Language:    "en",
-			Gender:      "female",
-			Description: "Warm, friendly voice",
-		},
-		{
-			ID:          VoiceShimmer,
-			Name:        "Shimmer",
-			Language:    "en",
-			Gender:      "female",
-			Description: "Soft, calm voice",
-		},
+		makeVoice(VoiceAlloy, "Alloy", "en", "neutral", "Balanced, versatile voice"),
+		makeVoice(VoiceEcho, "Echo", "en", "male", "Clear male voice"),
+		makeVoice(VoiceFable, "Fable", "en", "female", "Expressive, British accent"),
+		makeVoice(VoiceOnyx, "Onyx", "en", "male", "Deep, authoritative voice"),
+		makeVoice(VoiceNova, "Nova", "en", "female", "Warm, friendly voice"),
+		makeVoice(VoiceShimmer, "Shimmer", "en", "female", "Soft, calm voice"),
 	}
 }
 
@@ -305,12 +269,6 @@ func (s *OpenAIService) SupportedFormats() []AudioFormat {
 		FormatAAC,
 		FormatFLAC,
 		FormatWAV,
-		{
-			Name:       "pcm",
-			MIMEType:   "audio/pcm",
-			SampleRate: openAISampleRate24,
-			BitDepth:   openAIBitDepth16,
-			Channels:   1,
-		},
+		makeFormat("pcm", "audio/pcm", openAISampleRate24, openAIBitDepth16),
 	}
 }

--- a/runtime/tts/service.go
+++ b/runtime/tts/service.go
@@ -183,3 +183,17 @@ var (
 func (f AudioFormat) String() string {
 	return f.Name
 }
+
+// makeVoice builds a Voice with the listed metadata. Used by provider
+// SupportedVoices implementations to keep entries on a single line.
+//
+//nolint:unparam // language is always "en" in current voice tables but is part of the schema for non-English voices.
+func makeVoice(id, name, language, gender, description string) Voice {
+	return Voice{ID: id, Name: name, Language: language, Gender: gender, Description: description}
+}
+
+// makeFormat builds a mono-channel AudioFormat with the listed parameters.
+// Used by provider SupportedFormats implementations to keep entries compact.
+func makeFormat(name, mime string, sampleRate, bitDepth int) AudioFormat {
+	return AudioFormat{Name: name, MIMEType: mime, SampleRate: sampleRate, BitDepth: bitDepth, Channels: 1}
+}


### PR DESCRIPTION
## Summary
- Add `makeVoice` and `makeFormat` helpers in `runtime/tts/service.go`.
- Rewrite `SupportedVoices` / `SupportedFormats` across `openai.go`, `elevenlabs.go`, `cartesia.go` as one-line entries.
- Net: **+40 / -182 lines**, no behaviour change.

## Why
Each provider's `SupportedVoices` was 5-9 identical 7-line struct literals. SonarCloud CPD treats that structural repetition as duplicate blocks, both within each file and across providers, and the cross-file similarity tipped new-code duplication over the 3% gate on PR #1110. This pre-emptively keeps headroom under the gate the next time we touch this area.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./runtime/tts/... -count=1\` passes
- [x] Pre-commit hook (lint + coverage) passes
- [ ] CI green
- [ ] SonarCloud quality gate green