### PR TITLE
feat(tools): pass unknown tool args through into Memory/A2A metadata bags

### DIFF
--- a/runtime/a2a/executor.go
+++ b/runtime/a2a/executor.go
@@ -186,7 +186,14 @@ func buildRequest(
 	cfg := descriptor.A2AConfig
 
 	var input a2aInput
-	if err := json.Unmarshal(args, &input); err != nil {
+	// Decode typed fields and capture any unknown top-level args. Hosts use
+	// sdk.WithToolDescriptorOverride to extend A2A tool input schemas with
+	// deployment-specific fields (e.g. correlation IDs, tenant tags); without
+	// this passthrough those fields would be dropped between the LLM and the
+	// outgoing A2A Message.Metadata.
+	extras, err := tools.DecodeArgsExtras(args, &input,
+		"query", "image_url", "image_data", "audio_data")
+	if err != nil {
 		return nil, nil, fmt.Errorf("a2a executor: parse args: %w", err)
 	}
 
@@ -204,11 +211,13 @@ func buildRequest(
 		parts = append(parts, Part{Raw: []byte(input.AudioData), MediaType: "audio/*"})
 	}
 
-	// Build metadata with skillId for mock server routing.
+	// Build metadata with skillId for mock server routing, then merge any
+	// host-supplied extras alongside without clobbering skillId.
 	var metadata map[string]any
 	if cfg.SkillID != "" {
 		metadata = map[string]any{"skillId": cfg.SkillID}
 	}
+	metadata = tools.MergeExtrasIntoMetadata(metadata, extras)
 
 	req := &SendMessageRequest{
 		Message: Message{

--- a/runtime/a2a/executor_test.go
+++ b/runtime/a2a/executor_test.go
@@ -213,6 +213,57 @@ func TestExecutor_Execute_WithSkillIDMetadata(t *testing.T) {
 	}
 }
 
+func TestExecutor_Execute_PassesUnknownArgsAlongsideSkillID(t *testing.T) {
+	// Hosts use sdk.WithToolDescriptorOverride to extend A2A tool input
+	// schemas with deployment-specific fields (correlation IDs, tenant tags).
+	// Those fields must flow through to outgoing Message.Metadata, alongside
+	// any skillId set by the descriptor — without clobbering it.
+	var receivedMetadata map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(r)
+		var params SendMessageRequest
+		raw, _ := json.Marshal(req.Params)
+		_ = json.Unmarshal(raw, &params)
+		receivedMetadata = params.Message.Metadata
+
+		text := "ok"
+		task := &Task{
+			ID: "task-passthrough",
+			Status: TaskStatus{
+				State:   TaskStateCompleted,
+				Message: &Message{Role: RoleAgent, Parts: []Part{{Text: &text}}},
+			},
+		}
+		rpcResult(w, req.ID, task)
+	}))
+	defer srv.Close()
+
+	e := NewExecutor()
+	defer e.Close()
+	desc := &tools.ToolDescriptor{
+		Name: "test-tool",
+		A2AConfig: &tools.A2AConfig{
+			AgentURL: srv.URL,
+			SkillID:  "my_skill",
+		},
+	}
+
+	args := json.RawMessage(`{"query":"hello","trace_id":"abc-123","tenant":"acme"}`)
+	if _, err := e.Execute(context.Background(), desc, args); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if receivedMetadata["skillId"] != "my_skill" {
+		t.Errorf("skillId clobbered: got %v", receivedMetadata["skillId"])
+	}
+	if receivedMetadata["trace_id"] != "abc-123" {
+		t.Errorf("trace_id not passed through: got %v", receivedMetadata["trace_id"])
+	}
+	if receivedMetadata["tenant"] != "acme" {
+		t.Errorf("tenant not passed through: got %v", receivedMetadata["tenant"])
+	}
+}
+
 func TestExecutor_Execute_NoSkillIDMetadata(t *testing.T) {
 	var receivedMetadata map[string]any
 

--- a/runtime/memory/tools.go
+++ b/runtime/memory/tools.go
@@ -89,7 +89,12 @@ func (e *Executor) remember(ctx context.Context, args json.RawMessage) (json.Raw
 		Category   string         `json:"category,omitempty"`
 		Metadata   map[string]any `json:"metadata,omitempty"`
 	}
-	if err := json.Unmarshal(args, &a); err != nil {
+	// Decode typed fields and capture any unknown top-level args. Hosts use
+	// sdk.WithToolDescriptorOverride to extend memory__remember's input
+	// schema with deployment-specific fields (e.g. Omnia's `about` for
+	// dedup); without this passthrough those fields would be dropped.
+	extras, err := tools.DecodeArgsExtras(args, &a, "content", "type", "confidence", "category", "metadata")
+	if err != nil {
 		return nil, fmt.Errorf("memory remember: %w", err)
 	}
 	if a.Content == "" {
@@ -107,7 +112,7 @@ func (e *Executor) remember(ctx context.Context, args json.RawMessage) (json.Raw
 		Type:       a.Type,
 		Content:    a.Content,
 		Confidence: a.Confidence,
-		Metadata:   a.Metadata,
+		Metadata:   tools.MergeExtrasIntoMetadata(a.Metadata, extras),
 		Scope:      e.scope,
 	}
 	// Stash the LLM-supplied consent category so downstream consumers

--- a/runtime/memory/tools_test.go
+++ b/runtime/memory/tools_test.go
@@ -231,6 +231,80 @@ func TestMemoryExecutor_Remember_PreservesUserMetadata(t *testing.T) {
 	}
 }
 
+func TestMemoryExecutor_Remember_PassesUnknownArgsThroughToMetadata(t *testing.T) {
+	// Hosts use sdk.WithToolDescriptorOverride to extend memory__remember's
+	// schema with deployment-specific fields (Omnia adds `about` for dedup).
+	// Those fields must flow through into Memory.Metadata; previously the
+	// executor's typed decode dropped them silently.
+	store := NewInMemoryStore()
+	scope := map[string]string{"user_id": "u1"}
+	exec := NewExecutor(store, scope)
+	desc := &tools.ToolDescriptor{Name: RememberToolName}
+
+	args, _ := json.Marshal(map[string]any{
+		"content":    "Aisle seat",
+		"category":   "memory:preferences",
+		"about":      map[string]any{"kind": "preference", "key": "seat"},
+		"source_uri": "file:///settings/seat.txt",
+		"trace_id":   "abc-123",
+	})
+	if _, err := exec.Execute(context.Background(), desc, args); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+
+	all, _ := store.List(context.Background(), scope, ListOptions{})
+	if len(all) != 1 {
+		t.Fatalf("expected 1 memory, got %d", len(all))
+	}
+	m := all[0]
+
+	about, ok := m.Metadata["about"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected metadata[about] to be a map, got %T", m.Metadata["about"])
+	}
+	if about["kind"] != "preference" || about["key"] != "seat" {
+		t.Errorf("about not preserved: %+v", about)
+	}
+	if m.Metadata["source_uri"] != "file:///settings/seat.txt" {
+		t.Errorf("source_uri = %v", m.Metadata["source_uri"])
+	}
+	if m.Metadata["trace_id"] != "abc-123" {
+		t.Errorf("trace_id = %v", m.Metadata["trace_id"])
+	}
+	// Typed pipeline still works: provenance and category land as before.
+	if m.Metadata[MetaKeyProvenance] != string(ProvenanceUserRequested) {
+		t.Errorf("provenance lost: %v", m.Metadata[MetaKeyProvenance])
+	}
+	if m.Metadata[MetaKeyConsentCategory] != "memory:preferences" {
+		t.Errorf("consent category lost: %v", m.Metadata[MetaKeyConsentCategory])
+	}
+}
+
+func TestMemoryExecutor_Remember_TypedMetadataWinsOverPassthrough(t *testing.T) {
+	// If the host's schema extension produces a top-level key with the same
+	// name as something in the typed `metadata` arg, the typed value wins.
+	// Documented contract: extras only fill gaps, they never overwrite.
+	store := NewInMemoryStore()
+	scope := map[string]string{"user_id": "u1"}
+	exec := NewExecutor(store, scope)
+	desc := &tools.ToolDescriptor{Name: RememberToolName}
+
+	args, _ := json.Marshal(map[string]any{
+		"content":  "hello",
+		"metadata": map[string]any{"shared_key": "from-typed"},
+		// Unknown top-level field with the SAME key as the typed metadata above.
+		"shared_key": "from-extras",
+	})
+	if _, err := exec.Execute(context.Background(), desc, args); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+
+	all, _ := store.List(context.Background(), scope, ListOptions{})
+	if all[0].Metadata["shared_key"] != "from-typed" {
+		t.Errorf("typed metadata should win on conflict; got %v", all[0].Metadata["shared_key"])
+	}
+}
+
 func TestMemoryExecutor_Remember_StashesConsentCategory(t *testing.T) {
 	store := NewInMemoryStore()
 	scope := map[string]string{"user_id": "u1"}

--- a/runtime/tools/args_passthrough.go
+++ b/runtime/tools/args_passthrough.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeArgsExtras decodes raw tool args twice: once into the executor's typed
+// struct, and once into a generic map so any keys NOT named in knownKeys can be
+// returned to the caller for routing into the output's Metadata bag.
+//
+// Hosts use sdk.WithToolDescriptorOverride to extend a capability tool's
+// InputSchema with deployment-specific top-level fields. Without this helper,
+// the executor's typed Unmarshal would drop those fields silently. With it,
+// the executor can keep its strict typing AND let unknown args flow through
+// as metadata extras.
+//
+// knownKeys must list every top-level JSON key the executor's typed struct
+// owns; passing the wrong list causes typed fields to be duplicated into
+// extras (annoying but harmless — typed values still win when merged).
+//
+// Returns an empty map (not nil) when args contains no extras, so callers can
+// merge unconditionally without nil checks. Returns nil + nil when args is
+// empty or "null" — both mean "no args at all".
+func DecodeArgsExtras(args json.RawMessage, typed any, knownKeys ...string) (map[string]any, error) {
+	if len(args) == 0 || string(args) == "null" {
+		return nil, nil
+	}
+	if err := json.Unmarshal(args, typed); err != nil {
+		return nil, fmt.Errorf("decode typed args: %w", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(args, &raw); err != nil {
+		// Args parsed as the typed struct but not as an object — e.g. a JSON
+		// array or scalar. There are no extras to extract.
+		return map[string]any{}, nil //nolint:nilerr // typed decode succeeded; non-object args have no extras
+	}
+	for _, k := range knownKeys {
+		delete(raw, k)
+	}
+	return raw, nil
+}
+
+// MergeExtrasIntoMetadata copies extras into target, leaving any keys already
+// present in target untouched. This implements the "typed-fields-win" conflict
+// rule: if both the typed `metadata` arg and a passthrough extra have the same
+// key, the typed value (already in target) wins.
+//
+// If target is nil and extras is non-empty, returns a fresh map; otherwise
+// mutates target in place and returns it. Returns nil when both are empty.
+func MergeExtrasIntoMetadata(target, extras map[string]any) map[string]any {
+	if len(extras) == 0 {
+		return target
+	}
+	if target == nil {
+		target = make(map[string]any, len(extras))
+	}
+	for k, v := range extras {
+		if _, ok := target[k]; ok {
+			continue
+		}
+		target[k] = v
+	}
+	return target
+}

--- a/runtime/tools/args_passthrough_test.go
+++ b/runtime/tools/args_passthrough_test.go
@@ -1,0 +1,118 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecodeArgsExtras_TypedAndUnknown(t *testing.T) {
+	type typed struct {
+		Content string `json:"content"`
+		Type    string `json:"type"`
+	}
+	args := json.RawMessage(`{"content":"hello","type":"fact","about":"the dog","priority":3}`)
+	var got typed
+	extras, err := DecodeArgsExtras(args, &got, "content", "type")
+	if err != nil {
+		t.Fatalf("DecodeArgsExtras: %v", err)
+	}
+	if got.Content != "hello" || got.Type != "fact" {
+		t.Errorf("typed decode wrong: %+v", got)
+	}
+	if extras["about"] != "the dog" {
+		t.Errorf("expected extras.about='the dog', got %v", extras["about"])
+	}
+	if v, ok := extras["priority"].(float64); !ok || v != 3 {
+		t.Errorf("expected extras.priority=3 (float64), got %v", extras["priority"])
+	}
+	if _, leaked := extras["content"]; leaked {
+		t.Errorf("known key 'content' leaked into extras")
+	}
+}
+
+func TestDecodeArgsExtras_NoExtras(t *testing.T) {
+	type typed struct {
+		Content string `json:"content"`
+	}
+	args := json.RawMessage(`{"content":"hello"}`)
+	var got typed
+	extras, err := DecodeArgsExtras(args, &got, "content")
+	if err != nil {
+		t.Fatalf("DecodeArgsExtras: %v", err)
+	}
+	if len(extras) != 0 {
+		t.Errorf("expected no extras, got %+v", extras)
+	}
+}
+
+func TestDecodeArgsExtras_EmptyAndNullArgs(t *testing.T) {
+	type typed struct{}
+	for _, raw := range []string{"", "null"} {
+		var got typed
+		extras, err := DecodeArgsExtras(json.RawMessage(raw), &got)
+		if err != nil {
+			t.Fatalf("DecodeArgsExtras(%q): %v", raw, err)
+		}
+		if extras != nil {
+			t.Errorf("DecodeArgsExtras(%q): expected nil extras, got %+v", raw, extras)
+		}
+	}
+}
+
+func TestDecodeArgsExtras_NestedObjectPreserved(t *testing.T) {
+	type typed struct {
+		Content string `json:"content"`
+	}
+	args := json.RawMessage(`{"content":"x","about":{"kind":"preference","key":"seat"}}`)
+	var got typed
+	extras, err := DecodeArgsExtras(args, &got, "content")
+	if err != nil {
+		t.Fatalf("DecodeArgsExtras: %v", err)
+	}
+	about, ok := extras["about"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected extras.about to be a map, got %T", extras["about"])
+	}
+	if about["kind"] != "preference" || about["key"] != "seat" {
+		t.Errorf("nested about not preserved: %+v", about)
+	}
+}
+
+func TestDecodeArgsExtras_TypedDecodeError(t *testing.T) {
+	type typed struct {
+		Count int `json:"count"`
+	}
+	args := json.RawMessage(`{"count":"not-a-number"}`)
+	var got typed
+	if _, err := DecodeArgsExtras(args, &got); err == nil {
+		t.Fatal("expected typed decode error, got nil")
+	}
+}
+
+func TestMergeExtrasIntoMetadata_TypedWinsOnConflict(t *testing.T) {
+	target := map[string]any{"x": 1, "y": 2}
+	extras := map[string]any{"x": 99, "z": 3}
+	got := MergeExtrasIntoMetadata(target, extras)
+	if got["x"] != 1 {
+		t.Errorf("typed value should win on conflict; got x=%v", got["x"])
+	}
+	if got["z"] != 3 {
+		t.Errorf("expected z=3 from extras; got %v", got["z"])
+	}
+}
+
+func TestMergeExtrasIntoMetadata_NilTarget(t *testing.T) {
+	got := MergeExtrasIntoMetadata(nil, map[string]any{"a": 1})
+	if got["a"] != 1 {
+		t.Errorf("expected fresh map with a=1; got %+v", got)
+	}
+}
+
+func TestMergeExtrasIntoMetadata_BothEmpty(t *testing.T) {
+	if got := MergeExtrasIntoMetadata(nil, nil); got != nil {
+		t.Errorf("expected nil result for two empty inputs; got %+v", got)
+	}
+	if got := MergeExtrasIntoMetadata(nil, map[string]any{}); got != nil {
+		t.Errorf("expected nil result for empty extras; got %+v", got)
+	}
+}

--- a/sdk/tool_descriptor_override.go
+++ b/sdk/tool_descriptor_override.go
@@ -48,17 +48,36 @@ type toolDescriptorOverride struct {
 // version skew (a tool removed upstream does not break the consumer's
 // override list).
 //
+// # Schema extension and metadata passthrough
+//
+// Extending the InputSchema with new top-level fields produces structured
+// LLM args, but the executor's typed decode would historically drop unknown
+// keys. As of issue #1072, executors that own a Metadata bag —
+// memory__remember (Memory.Metadata) and the A2A tools (Message.Metadata) —
+// pass any unknown top-level args through into that bag automatically.
+//
+// Conflict rule: typed fields win. If the LLM provides both a typed
+// `metadata: {x: 1}` arg and a top-level `x: 2` extra, the typed value
+// stays; the extra is dropped silently.
+//
+// Other capability tools (workflow transition/artifact, skills) have typed
+// outputs with no metadata sink — adding a new top-level field there has
+// no effect on the executor today.
+//
 // Example: customize the memory__remember tool's description for an Omnia
-// deployment that wants the LLM to tag a category alongside the memory.
+// deployment that wants the LLM to tag a category alongside the memory,
+// and extend the schema with an `about` field that flows into Memory.Metadata.
 //
 //	conv, err := sdk.Open(packPath, "chat",
 //	    sdk.WithMemory(store, scope),
 //	    sdk.WithToolDescriptorOverride("memory__remember",
 //	        func(d *tools.ToolDescriptor) {
 //	            d.Description = "Store something in memory ..."
-//	            d.InputSchema = customSchemaJSON
+//	            d.InputSchema = customSchemaJSON // adds top-level `about`
 //	        }),
 //	)
+//	// LLM calls memory__remember(content="...", about={kind:"preference",key:"seat"})
+//	// → Memory.Metadata["about"] = {kind:..., key:...}
 func WithToolDescriptorOverride(name string, fn ToolDescriptorPatchFn) Option {
 	return func(c *config) error {
 		if name == "" {


### PR DESCRIPTION
## Summary

Closes part of #1072 (Mechanism 1 — pass-through into the existing Metadata bag).

`WithToolDescriptorOverride` lets hosts extend a capability tool's `InputSchema` with deployment-specific top-level fields, but the executor's typed \`json.Unmarshal\` would silently drop anything outside its struct. The override path was cosmetic — the LLM produced the extension field but it never reached the host.

This change:

- Adds \`runtime/tools.DecodeArgsExtras\` + \`MergeExtrasIntoMetadata\` helpers that decode raw args into the typed struct AND a generic map, returning the unknown keys for routing into the executor output's Metadata bag.
- Wires it into the two executors with a natural Metadata sink:
  - \`memory.Executor.remember\` → \`Memory.Metadata\`
  - \`a2a.buildRequest\` → outgoing \`Message.Metadata\` (alongside \`skillId\`)

**Conflict rule**: typed fields win. If the LLM passes both \`metadata: {x:1}\` and a top-level \`x: 2\`, the typed value stays and the extra is dropped silently.

## Scope correction vs the issue

The issue claimed every capability executor had this problem. After audit:

| Executor | Has Metadata sink? | Action |
|---|---|---|
| memory.remember | ✅ | passthrough |
| a2a.buildRequest | ✅ (already used for \`skillId\`) | passthrough |
| workflow.TransitionExecutor | ❌ typed PendingTransition | skip |
| workflow.ArtifactExecutor | ❌ typed map[string]string | skip |
| skills.ToolExecutor | ❌ typed inputs/result | skip |

Adding a metadata bag to the typed executors would contradict the recent ElementMetadata cleanup. The issue's other examples (workflow escalation reasons, skills billing tags) would need a different design.

## Mechanism 2 deferred

\`WithToolMetadataMapping\` (renames + JSON-path extraction) is deferred until a concrete user need surfaces. Mechanism 1 covers the cited Omnia dedup case — their existing \`about_kind\`/\`about_key\` lookup pairs with the schema-extension's \`about\` field directly.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./runtime/tools/... ./runtime/memory/... ./runtime/a2a/...\` (674 tests)
- [x] Pre-commit hook (lint + coverage) passes; coverage ≥80% on every changed file
- [ ] CI green
- [ ] SonarCloud quality gate green