### PR TITLE
chore: bump go.work toolchain to 1.26 + golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/capability-matrix.yml
+++ b/.github/workflows/capability-matrix.yml
@@ -25,7 +25,7 @@ permissions:
   checks: write
 
 env:
-  GO_VERSION: '1.25.1'
+  GO_VERSION: '1.26.0'
 
 jobs:
   capability-matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       PROMPTKIT_SCHEMA_SOURCE: local
     strategy:
       matrix:
-        go-version: ['1.25.1']
+        go-version: ['1.26.0']
     
     steps:
     - name: Checkout code
@@ -274,7 +274,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
 
     - name: Install gotestsum
       run: go install gotest.tools/gotestsum@latest
@@ -321,7 +321,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
         cache-dependency-path: |
           runtime/go.sum
           sdk/go.sum
@@ -334,7 +334,7 @@ jobs:
     - name: Run golangci-lint in ${{ matrix.module }}
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.6.0
+        version: v2.12.2
         working-directory: ${{ matrix.module }}
         args: --issues-exit-code=0
         only-new-issues: true
@@ -352,7 +352,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
     
     - name: Build runtime components
       run: make build
@@ -369,7 +369,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
 
     - name: Build benchmark binaries
       run: |
@@ -451,7 +451,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
 
     - name: Validate all example configs
       run: make validate-examples
@@ -474,7 +474,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
 
     - name: Build Arena
       run: make build-arena

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: '1.25.1'
+          go-version: '1.26.0'
           cache: true
 
       # Required by oto/v3 (transitive via tools/arena/audio LocalSink).

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
         cache: false  # Disable cache since we use a workspace setup
 
     - name: Determine tool to test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       if: ${{ !inputs.skip_tests }}
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
         cache: false  # Disable cache since we use a workspace setup
     
     - name: Install dependencies
@@ -257,7 +257,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
         cache: false  # Disable cache since we use a workspace setup
 
     - name: Configure Git
@@ -587,7 +587,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
         cache: false  # Disable cache since we use a workspace setup
 
     - name: Run GoReleaser

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
     
     - name: Install dependencies
       run: |
@@ -82,7 +82,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
 
     - name: Install dependencies
       run: go work sync
@@ -152,7 +152,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: '1.25.1'
+        go-version: '1.26.0'
 
     - name: Install dependencies
       run: go work sync

--- a/benchmarks/frameworks/genkit/go.mod
+++ b/benchmarks/frameworks/genkit/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/benchmarks/frameworks/genkit
 
-go 1.25.1
+go 1.26.0
 
 require github.com/firebase/genkit/go v1.6.1
 

--- a/benchmarks/frameworks/promptkit/round1/go.mod
+++ b/benchmarks/frameworks/promptkit/round1/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/benchmarks/frameworks/promptkit/round1
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/AltairaLabs/PromptKit/runtime v1.3.5

--- a/benchmarks/frameworks/promptkit/round2/go.mod
+++ b/benchmarks/frameworks/promptkit/round2/go.mod
@@ -1,5 +1,5 @@
 module github.com/AltairaLabs/PromptKit/benchmarks/frameworks/promptkit/round2
 
-go 1.25.1
+go 1.26.0
 
 require github.com/gorilla/websocket v1.5.3

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/benchmarks
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/examples/a2a-auth-test/go.mod
+++ b/examples/a2a-auth-test/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/examples/a2a-auth-test
 
-go 1.25.1
+go 1.26.0
 
 replace github.com/AltairaLabs/PromptKit/runtime => ../../runtime
 

--- a/examples/a2a-demo/go.mod
+++ b/examples/a2a-demo/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/examples/a2a-demo
 
-go 1.25.1
+go 1.26.0
 
 replace github.com/AltairaLabs/PromptKit/runtime => ../../runtime
 

--- a/examples/programmatic-arena/go.mod
+++ b/examples/programmatic-arena/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/examples/programmatic-arena
 
-go 1.25.1
+go 1.26.0
 
 replace github.com/AltairaLabs/PromptKit/pkg => ../../pkg
 

--- a/examples/workflow-support/sdk-example/go.mod
+++ b/examples/workflow-support/sdk-example/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/examples/workflow-support/sdk-example
 
-go 1.25.1
+go 1.26.0
 
 replace github.com/AltairaLabs/PromptKit/runtime => ../../../runtime
 

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.1
+go 1.26.0
 
 use (
 	./benchmarks

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/pkg
 
-go 1.25.1
+go 1.26.0
 
 retract v1.4.0 // Published prematurely; use v1.4.1+
 

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/runtime
 
-go 1.25.1
+go 1.26.0
 
 retract v1.4.0 // Published prematurely; missing StreamMediaData changes and breaking MediaDelta removal
 

--- a/sdk/examples/eval-hooks/go.mod
+++ b/sdk/examples/eval-hooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/sdk/examples/eval-hooks
 
-go 1.25.1
+go 1.26.0
 
 replace github.com/AltairaLabs/PromptKit/runtime => ../../../runtime
 

--- a/sdk/examples/sdk-evals/go.mod
+++ b/sdk/examples/sdk-evals/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/sdk/examples/sdk-evals
 
-go 1.25.1
+go 1.26.0
 
 replace github.com/AltairaLabs/PromptKit/runtime => ../../../runtime
 

--- a/sdk/examples/sdk-http-auth/go.mod
+++ b/sdk/examples/sdk-http-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/sdk/examples/sdk-http-auth
 
-go 1.25.1
+go 1.26.0
 
 replace github.com/AltairaLabs/PromptKit/runtime => ../../../runtime
 

--- a/sdk/examples/voice-chat/go.mod
+++ b/sdk/examples/voice-chat/go.mod
@@ -1,6 +1,6 @@
 module voice-chat
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/AltairaLabs/PromptKit/runtime v0.0.0

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/sdk
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/AltairaLabs/PromptKit/pkg v0.0.0

--- a/server/a2a/go.mod
+++ b/server/a2a/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/server/a2a
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/AltairaLabs/PromptKit/runtime v1.2.0

--- a/tools/arena/go.mod
+++ b/tools/arena/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/tools/arena
 
-go 1.25.1
+go 1.26.0
 
 retract v1.4.0 // Published prematurely; use v1.4.1+
 

--- a/tools/inspect-state/go.mod
+++ b/tools/inspect-state/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/tools/inspect-state
 
-go 1.25.1
+go 1.26.0
 
 require github.com/AltairaLabs/PromptKit/runtime v0.0.0
 

--- a/tools/packc/go.mod
+++ b/tools/packc/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/tools/packc
 
-go 1.25.1
+go 1.26.0
 
 retract v1.4.0 // Published prematurely; use v1.4.1+
 

--- a/tools/schema-gen/go.mod
+++ b/tools/schema-gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/AltairaLabs/PromptKit/tools/schema-gen
 
-go 1.25.1
+go 1.26.0
 
 replace (
 	github.com/AltairaLabs/PromptKit/pkg => ../../pkg


### PR DESCRIPTION
## Summary

Closes #1070.

- Bumps the \`go\` directive in \`go.work\` and all 20 module \`go.mod\` files from \`1.25.1\` → \`1.26.0\`.
- Bumps every CI workflow \`go-version\` pin (ci, release, schemas, docs, release-test, capability-matrix) to match.
- Bumps the \`golangci/golangci-lint-action\` pin from \`v2.6.0\` → \`v2.12.2\` — v2.6.0 was built against Go 1.25 and refuses to load 1.26 modules.

## Why

Dependabot has been opening (and CI has been failing) k8s.io/apimachinery 0.36.x bumps every patch release because they require Go 1.26. Per #1070 the cleanest fix is the toolchain bump on its own PR; the dependabot PRs will reopen automatically once this lands.

## Verification

- \`go build ./...\` — clean (Go auto-fetched 1.26.0 via GOTOOLCHAIN=auto).
- \`go test ./runtime/... ./sdk/... ./pkg/... -count=1\` — 10,414 tests pass.
- \`go test ./tools/arena/... -count=1\` — clean.
- No analyzer fallout from the toolchain bump.
- Local golangci-lint upgraded to 2.12.2 to match CI.

## Test plan

- [x] Local build + tests
- [ ] CI green
- [ ] SonarCloud quality gate green
- [ ] Reopen dependabot PRs #1041, #1043, #1045 once merged