### PR TITLE
feat(memory): pluggable context formatter for MemoryRetrievalStage

### DIFF
--- a/runtime/memory/formatter.go
+++ b/runtime/memory/formatter.go
@@ -1,0 +1,26 @@
+package memory
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ContextFormatter renders a slice of retrieved memories into the string
+// that gets written onto TurnState.Variables["memory_context"] by the
+// retrieval pipeline stage. Hosts implement this to control how
+// categories, dedup keys, confidence, or other metadata are surfaced to
+// the LLM. See [DefaultContextFormatter] for the built-in behavior.
+type ContextFormatter func(memories []*Memory) string
+
+// DefaultContextFormatter is the formatter the retrieval stage uses when
+// no override is supplied. It renders each memory on its own line as
+// "[type] content (confidence: N.N)" — matching the historical
+// hardcoded behavior. Callers should treat the output as opaque text
+// suitable for direct injection into a system prompt.
+func DefaultContextFormatter(memories []*Memory) string {
+	var b strings.Builder
+	for _, m := range memories {
+		fmt.Fprintf(&b, "[%s] %s (confidence: %.1f)\n", m.Type, m.Content, m.Confidence)
+	}
+	return b.String()
+}

--- a/runtime/memory/formatter_test.go
+++ b/runtime/memory/formatter_test.go
@@ -1,0 +1,24 @@
+package memory
+
+import "testing"
+
+func TestDefaultContextFormatter_RendersTypeContentConfidence(t *testing.T) {
+	got := DefaultContextFormatter([]*Memory{
+		{Type: "fact", Content: "User likes Go", Confidence: 0.9},
+		{Type: "pref", Content: "Dark mode", Confidence: 0.75},
+	})
+	want := "[fact] User likes Go (confidence: 0.9)\n" +
+		"[pref] Dark mode (confidence: 0.8)\n"
+	if got != want {
+		t.Errorf("DefaultContextFormatter:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestDefaultContextFormatter_EmptyInput(t *testing.T) {
+	if got := DefaultContextFormatter(nil); got != "" {
+		t.Errorf("expected empty string for nil memories, got %q", got)
+	}
+	if got := DefaultContextFormatter([]*Memory{}); got != "" {
+		t.Errorf("expected empty string for empty slice, got %q", got)
+	}
+}

--- a/runtime/pipeline/stage/stages_memory.go
+++ b/runtime/pipeline/stage/stages_memory.go
@@ -2,7 +2,6 @@ package stage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/memory"
@@ -22,6 +21,7 @@ type MemoryRetrievalStage struct {
 	store     memory.Store
 	scope     map[string]string
 	turnState *TurnState
+	formatter memory.ContextFormatter
 }
 
 // NewMemoryRetrievalStage creates a retrieval stage.
@@ -43,6 +43,14 @@ func NewMemoryRetrievalStageWithTurnState(
 		scope:     scope,
 		turnState: turnState,
 	}
+}
+
+// WithContextFormatter overrides the formatter used to render retrieved
+// memories into the "memory_context" template variable. Falls back to
+// [memory.DefaultContextFormatter] when nil.
+func (s *MemoryRetrievalStage) WithContextFormatter(fn memory.ContextFormatter) *MemoryRetrievalStage {
+	s.formatter = fn
+	return s
 }
 
 // Process implements Stage.
@@ -84,16 +92,17 @@ func (s *MemoryRetrievalStage) Process(
 }
 
 // injectMemoryContext formats the retrieved memories and writes them onto
-// TurnState.Variables["memory_context"].
+// TurnState.Variables["memory_context"]. Uses the stage's configured
+// formatter, or [memory.DefaultContextFormatter] when none is set.
 func (s *MemoryRetrievalStage) injectMemoryContext(memories []*memory.Memory) {
-	var ctx string
-	for _, m := range memories {
-		ctx += fmt.Sprintf("[%s] %s (confidence: %.1f)\n", m.Type, m.Content, m.Confidence)
+	formatter := s.formatter
+	if formatter == nil {
+		formatter = memory.DefaultContextFormatter
 	}
 	if s.turnState.Variables == nil {
 		s.turnState.Variables = make(map[string]string)
 	}
-	s.turnState.Variables["memory_context"] = ctx
+	s.turnState.Variables["memory_context"] = formatter(memories)
 }
 
 // MemoryExtractionStage extracts memories from the conversation after the

--- a/runtime/pipeline/stage/stages_memory_test.go
+++ b/runtime/pipeline/stage/stages_memory_test.go
@@ -2,6 +2,7 @@ package stage
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/memory"
@@ -50,6 +51,77 @@ func TestMemoryRetrievalStage_InjectsMemories(t *testing.T) {
 
 	if turnState.Variables["memory_context"] == "" {
 		t.Error("memory_context should be injected onto TurnState.Variables")
+	}
+}
+
+func TestMemoryRetrievalStage_UsesDefaultFormatterWhenUnset(t *testing.T) {
+	ret := &mockRetriever{
+		memories: []*memory.Memory{
+			{Type: "fact", Content: "User likes Go", Confidence: 0.9},
+		},
+	}
+	store := memory.NewInMemoryStore()
+	turnState := NewTurnState()
+	s := NewMemoryRetrievalStageWithTurnState(ret, store, nil, turnState)
+
+	input := make(chan StreamElement, 1)
+	output := make(chan StreamElement, 1)
+	msg := types.Message{Role: "user", Content: "hello"}
+	input <- StreamElement{Message: &msg}
+	close(input)
+
+	if err := s.Process(context.Background(), input, output); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	<-output
+	got := turnState.Variables["memory_context"]
+	want := "[fact] User likes Go (confidence: 0.9)\n"
+	if got != want {
+		t.Errorf("default format = %q, want %q", got, want)
+	}
+}
+
+func TestMemoryRetrievalStage_HostFormatterOverridesDefault(t *testing.T) {
+	ret := &mockRetriever{
+		memories: []*memory.Memory{
+			{Type: "fact", Content: "User likes Go", Confidence: 0.9,
+				Metadata: map[string]any{"category": "preferences"}},
+			{Type: "fact", Content: "User uses macOS",
+				Metadata: map[string]any{"category": "context"}},
+		},
+	}
+	store := memory.NewInMemoryStore()
+	turnState := NewTurnState()
+	// Host formatter that groups by metadata["category"] — proves the
+	// override receives the same memories the default would have, plus
+	// access to metadata fields the default ignores.
+	s := NewMemoryRetrievalStageWithTurnState(ret, store, nil, turnState).
+		WithContextFormatter(func(memories []*memory.Memory) string {
+			var b strings.Builder
+			for _, m := range memories {
+				cat, _ := m.Metadata["category"].(string)
+				b.WriteString(cat)
+				b.WriteString(":")
+				b.WriteString(m.Content)
+				b.WriteString("\n")
+			}
+			return b.String()
+		})
+
+	input := make(chan StreamElement, 1)
+	output := make(chan StreamElement, 1)
+	msg := types.Message{Role: "user", Content: "hello"}
+	input <- StreamElement{Message: &msg}
+	close(input)
+
+	if err := s.Process(context.Background(), input, output); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	<-output
+	got := turnState.Variables["memory_context"]
+	want := "preferences:User likes Go\ncontext:User uses macOS\n"
+	if got != want {
+		t.Errorf("custom format = %q, want %q", got, want)
 	}
 }
 

--- a/sdk/capability_memory.go
+++ b/sdk/capability_memory.go
@@ -12,6 +12,7 @@ type MemoryCapability struct {
 	scope     map[string]string
 	extractor memory.Extractor
 	retriever memory.Retriever
+	formatter memory.ContextFormatter
 }
 
 // NewMemoryCapability creates a MemoryCapability with the given store and scope.

--- a/sdk/capability_memory_test.go
+++ b/sdk/capability_memory_test.go
@@ -67,3 +67,43 @@ func TestWithMemoryOption(t *testing.T) {
 		t.Errorf("capability name = %q", cfg.capabilities[0].Name())
 	}
 }
+
+func TestWithMemoryContextFormatter_StoredOnCapability(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	scope := map[string]string{"user_id": "test"}
+
+	sentinel := "from-host-formatter"
+	formatter := func(_ []*memory.Memory) string { return sentinel }
+
+	cfg := &config{}
+	opt := WithMemory(store, scope, WithMemoryContextFormatter(formatter))
+	if err := opt(cfg); err != nil {
+		t.Fatalf("WithMemory: %v", err)
+	}
+	cap, ok := cfg.capabilities[0].(*MemoryCapability)
+	if !ok {
+		t.Fatalf("expected *MemoryCapability, got %T", cfg.capabilities[0])
+	}
+	if cap.formatter == nil {
+		t.Fatal("expected formatter to be set on capability")
+	}
+	if got := cap.formatter(nil); got != sentinel {
+		t.Errorf("formatter returned %q, want %q", got, sentinel)
+	}
+}
+
+func TestWithMemoryContextFormatter_NilFormatterIsAccepted(t *testing.T) {
+	// Passing nil should be allowed — it just leaves the default in place.
+	store := memory.NewInMemoryStore()
+	scope := map[string]string{"user_id": "test"}
+
+	cfg := &config{}
+	opt := WithMemory(store, scope, WithMemoryContextFormatter(nil))
+	if err := opt(cfg); err != nil {
+		t.Fatalf("WithMemory: %v", err)
+	}
+	cap := cfg.capabilities[0].(*MemoryCapability)
+	if cap.formatter != nil {
+		t.Error("formatter should remain nil when WithMemoryContextFormatter(nil)")
+	}
+}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -495,6 +495,7 @@ func (c *Conversation) buildPipelineConfig(
 		pipelineCfg.MemoryScope = mc.scope
 		pipelineCfg.MemoryRetriever = mc.retriever
 		pipelineCfg.MemoryExtractor = mc.extractor
+		pipelineCfg.MemoryContextFormatter = mc.formatter
 		break
 	}
 

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -177,6 +177,11 @@ type Config struct {
 	// MemoryScope for memory isolation.
 	MemoryScope map[string]string
 
+	// MemoryContextFormatter overrides the rendering of retrieved memories
+	// into the "memory_context" template variable. Defaults to
+	// [memory.DefaultContextFormatter] when nil.
+	MemoryContextFormatter memory.ContextFormatter
+
 	// ExecutionTimeout overrides the default pipeline execution timeout.
 	// When non-nil, the pointed-to duration is used instead of the default 30s.
 	// A zero value disables timeout entirely.
@@ -329,8 +334,12 @@ func collectPipelineStages(
 
 	// 4.8 Memory retrieval stage - inject relevant memories before provider
 	if cfg.MemoryRetriever != nil && cfg.MemoryStore != nil {
-		stages = append(stages, stage.NewMemoryRetrievalStageWithTurnState(
-			cfg.MemoryRetriever, cfg.MemoryStore, cfg.MemoryScope, turnState))
+		retrievalStage := stage.NewMemoryRetrievalStageWithTurnState(
+			cfg.MemoryRetriever, cfg.MemoryStore, cfg.MemoryScope, turnState)
+		if cfg.MemoryContextFormatter != nil {
+			retrievalStage.WithContextFormatter(cfg.MemoryContextFormatter)
+		}
+		stages = append(stages, retrievalStage)
 	}
 
 	// 5. Provider stage - LLM calls with streaming and tool support

--- a/sdk/internal/pipeline/builder_test.go
+++ b/sdk/internal/pipeline/builder_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	memorystore "github.com/AltairaLabs/PromptKit/runtime/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
 	rtpipeline "github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
@@ -115,6 +116,53 @@ func TestBuild(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, pipe)
 	})
+
+	t.Run("with memory retriever and custom context formatter", func(t *testing.T) {
+		registry := createTestRegistry("chat")
+		store := memorystore.NewInMemoryStore()
+		retriever := &noopRetriever{}
+		formatter := func(_ []*memorystore.Memory) string { return "host-formatted" }
+
+		cfg := &Config{
+			PromptRegistry:         registry,
+			TaskType:               "chat",
+			MemoryStore:            store,
+			MemoryRetriever:        retriever,
+			MemoryContextFormatter: formatter,
+		}
+
+		pipe, err := Build(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, pipe)
+	})
+
+	t.Run("with memory retriever but no formatter", func(t *testing.T) {
+		registry := createTestRegistry("chat")
+		store := memorystore.NewInMemoryStore()
+		retriever := &noopRetriever{}
+
+		cfg := &Config{
+			PromptRegistry:  registry,
+			TaskType:        "chat",
+			MemoryStore:     store,
+			MemoryRetriever: retriever,
+			// MemoryContextFormatter intentionally left nil; default applies.
+		}
+
+		pipe, err := Build(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, pipe)
+	})
+}
+
+// noopRetriever satisfies memorystore.Retriever for builder tests; it is
+// never actually invoked because Build() only wires the stage.
+type noopRetriever struct{}
+
+func (noopRetriever) RetrieveContext(
+	_ context.Context, _ map[string]string, _ []types.Message,
+) ([]*memorystore.Memory, error) {
+	return nil, nil
 }
 
 func TestConfig(t *testing.T) {

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -1078,6 +1078,27 @@ func WithMemoryRetriever(r memory.Retriever) MemoryOption {
 	return func(c *MemoryCapability) { c.retriever = r }
 }
 
+// WithMemoryContextFormatter overrides how retrieved memories are rendered
+// into the "memory_context" template variable that the system prompt sees.
+// Composes with [WithMemory] / [WithMemoryRetriever]; ignored when no
+// retriever is configured. Falls back to [memory.DefaultContextFormatter]
+// when fn is nil.
+//
+// Use this to surface metadata (consent category, dedup keys), group by
+// type or category, hedge confidence verbally, or otherwise tailor what
+// the LLM sees beyond the default "[type] content (confidence: N.N)"
+// line-per-memory format.
+//
+//	conv, _ := sdk.Open(packPath, "chat",
+//	    sdk.WithMemory(store, scope,
+//	        sdk.WithMemoryRetriever(myRetriever),
+//	        sdk.WithMemoryContextFormatter(myFormatter),
+//	    ),
+//	)
+func WithMemoryContextFormatter(fn memory.ContextFormatter) MemoryOption {
+	return func(c *MemoryCapability) { c.formatter = fn }
+}
+
 // WithExecutionTimeout overrides the default pipeline execution timeout (30s).
 // Use this for pipelines that need more time, such as multi-round tool-calling
 // with slower providers like Ollama. Pass 0 to disable the timeout entirely.


### PR DESCRIPTION
## Summary

Closes #1073.

`MemoryRetrievalStage`'s `memory_context` template variable was rendered by a hardcoded `"[type] content (confidence: N.N)\n"` template buried in \`injectMemoryContext\`. Hosts couldn't surface metadata (consent category, dedup keys), group by category, hedge confidence verbally, or otherwise tailor what the LLM sees without forking or replacing the stage.

This adds:

- \`memory.ContextFormatter\` func type + \`memory.DefaultContextFormatter\` matching today's output byte-for-byte.
- \`MemoryRetrievalStage.WithContextFormatter\` to override per-stage.
- \`sdk.WithMemoryContextFormatter\` MemoryOption, threaded through the pipeline builder so hosts wire it next to \`WithMemoryRetriever\`.

No behavior change when unset.

## Example

\`\`\`go
conv, _ := sdk.Open(packPath, "chat",
    sdk.WithMemory(store, scope,
        sdk.WithMemoryRetriever(myRetriever),
        sdk.WithMemoryContextFormatter(func(memories []*memory.Memory) string {
            // group by consent category, surface metadata, etc.
        }),
    ),
)
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./runtime/memory/... ./runtime/pipeline/stage/... ./sdk/...\` passes
- [x] Pre-commit hook (lint + coverage) green; \`formatter.go\` 100% covered
- [ ] CI green
- [ ] SonarCloud quality gate green