### PR TITLE
feat(memory): consent category taxonomy + prompt rubric primitives

### DIFF
--- a/runtime/memory/consent_category.go
+++ b/runtime/memory/consent_category.go
@@ -1,0 +1,97 @@
+package memory
+
+import "strings"
+
+// ConsentCategory is the well-known taxonomy used by consent-aware consumers
+// (e.g. Omnia) to apply per-category retention, opt-outs, and PII rules at
+// memory-write time. Values are stored in [Memory.Metadata] under the key
+// [MetaKeyConsentCategory] regardless of which path produced the memory:
+// the explicit `memory__remember` tool (LLM-supplied category arg) or an
+// extractor stage that classifies and tags during write.
+//
+// PromptKit defines the vocabulary and helpers; semantics (retention,
+// access control, redaction) are owned by the consumer.
+type ConsentCategory string
+
+// Known consent categories. The string values are the wire format consumers
+// match against — do not change them without coordinating with downstream
+// platforms.
+const (
+	CategoryIdentity    ConsentCategory = "memory:identity"    // Names, IDs, pronouns, contact details.
+	CategoryPreferences ConsentCategory = "memory:preferences" // Likes, dislikes, settings, configuration.
+	CategoryContext     ConsentCategory = "memory:context"     // Work / project context, domain knowledge, current task.
+	CategoryLocation    ConsentCategory = "memory:location"    // Geographic info, addresses, IP.
+	CategoryHealth      ConsentCategory = "memory:health"      // Health, dietary, medical, accessibility info.
+	CategoryHistory     ConsentCategory = "memory:history"     // Past conversations, decisions, what was said before.
+)
+
+// KnownCategories returns the canonical set of categories in a stable order.
+// Useful for filling option lists, validation tables, or rubric expansion.
+func KnownCategories() []ConsentCategory {
+	return []ConsentCategory{
+		CategoryIdentity,
+		CategoryPreferences,
+		CategoryContext,
+		CategoryLocation,
+		CategoryHealth,
+		CategoryHistory,
+	}
+}
+
+// IsKnownCategory reports whether s exactly matches one of the canonical
+// category strings. Unknown values are not rejected by the storage layer —
+// this helper exists for consumer validation only.
+func IsKnownCategory(s string) bool {
+	for _, c := range KnownCategories() {
+		if string(c) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// CategoryRubric is a prompt fragment that consumer extractors splice into
+// their extraction prompt so the extracting LLM tags each memory with one
+// of the canonical categories. PromptKit owns the rubric so all consumers
+// see the same vocabulary and downstream platforms can apply uniform rules.
+//
+// Usage:
+//
+//	prompt := basePrompt + "\n" + memory.CategoryRubric
+const CategoryRubric = `For each extracted memory, choose ONE consent category:
+  memory:identity     names, IDs, pronouns, contact details
+  memory:preferences  likes, dislikes, settings, configuration
+  memory:context      work/project context, domain knowledge, current task
+  memory:location     geographic info, addresses, IP
+  memory:health       health, dietary, medical, accessibility info
+  memory:history      past conversations, decisions, what was said before
+If none of the above fits, omit the category entirely so the platform's
+fallback classifier handles it.`
+
+// SetConsentCategory writes a category onto m.Metadata[MetaKeyConsentCategory],
+// initializing the map when nil. Empty input is a no-op so callers can pass
+// LLM output unconditionally without checking first. Unknown (non-canonical)
+// values are accepted as-is — see [IsKnownCategory] for validation.
+func (m *Memory) SetConsentCategory(c ConsentCategory) {
+	v := strings.TrimSpace(string(c))
+	if v == "" {
+		return
+	}
+	if m.Metadata == nil {
+		m.Metadata = map[string]any{}
+	}
+	m.Metadata[MetaKeyConsentCategory] = v
+}
+
+// GetConsentCategory returns the consent category previously written via
+// [Memory.SetConsentCategory] or the `memory__remember` tool, or empty
+// string when unset.
+func (m *Memory) GetConsentCategory() ConsentCategory {
+	if m.Metadata == nil {
+		return ""
+	}
+	if v, ok := m.Metadata[MetaKeyConsentCategory].(string); ok {
+		return ConsentCategory(v)
+	}
+	return ""
+}

--- a/runtime/memory/consent_category_test.go
+++ b/runtime/memory/consent_category_test.go
@@ -1,0 +1,104 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKnownCategories_StableOrder(t *testing.T) {
+	cats := KnownCategories()
+	if len(cats) != 6 {
+		t.Fatalf("expected 6 known categories, got %d", len(cats))
+	}
+	want := []ConsentCategory{
+		CategoryIdentity, CategoryPreferences, CategoryContext,
+		CategoryLocation, CategoryHealth, CategoryHistory,
+	}
+	for i, c := range want {
+		if cats[i] != c {
+			t.Errorf("cats[%d] = %q, want %q", i, cats[i], c)
+		}
+	}
+}
+
+func TestIsKnownCategory(t *testing.T) {
+	cases := map[string]bool{
+		"memory:identity":    true,
+		"memory:preferences": true,
+		"memory:context":     true,
+		"memory:location":    true,
+		"memory:health":      true,
+		"memory:history":     true,
+		"memory:other":       false, // not in the canonical taxonomy
+		"identity":           false, // missing prefix
+		"":                   false,
+		"MEMORY:HEALTH":      false, // case-sensitive
+	}
+	for in, want := range cases {
+		if got := IsKnownCategory(in); got != want {
+			t.Errorf("IsKnownCategory(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestCategoryRubric_MentionsAllKnownCategories(t *testing.T) {
+	// The rubric is what extractor prompts splice in; if a new category
+	// is added to the taxonomy, the rubric MUST mention it or extractors
+	// won't know to emit it. This test pins that contract.
+	for _, c := range KnownCategories() {
+		if !strings.Contains(CategoryRubric, string(c)) {
+			t.Errorf("CategoryRubric does not mention category %q", c)
+		}
+	}
+}
+
+func TestMemory_SetConsentCategory(t *testing.T) {
+	m := &Memory{}
+	m.SetConsentCategory(CategoryHealth)
+	if got := m.Metadata[MetaKeyConsentCategory]; got != "memory:health" {
+		t.Errorf("expected metadata[%s]=memory:health, got %v", MetaKeyConsentCategory, got)
+	}
+	if got := m.GetConsentCategory(); got != CategoryHealth {
+		t.Errorf("GetConsentCategory = %q, want %q", got, CategoryHealth)
+	}
+}
+
+func TestMemory_SetConsentCategory_EmptyIsNoop(t *testing.T) {
+	m := &Memory{Metadata: map[string]any{"existing": "value"}}
+	m.SetConsentCategory("")
+	if _, ok := m.Metadata[MetaKeyConsentCategory]; ok {
+		t.Error("empty category should not write to metadata")
+	}
+	if m.Metadata["existing"] != "value" {
+		t.Error("existing metadata clobbered")
+	}
+}
+
+func TestMemory_SetConsentCategory_WhitespaceIsNoop(t *testing.T) {
+	m := &Memory{}
+	m.SetConsentCategory("   ")
+	if _, ok := m.Metadata[MetaKeyConsentCategory]; ok {
+		t.Error("whitespace-only category should not write to metadata")
+	}
+}
+
+func TestMemory_SetConsentCategory_AcceptsUnknownValues(t *testing.T) {
+	// Per the doc contract: PromptKit does NOT validate, so a consumer
+	// extending the taxonomy ad-hoc still gets their value stored.
+	m := &Memory{}
+	m.SetConsentCategory("memory:custom_thing")
+	if m.Metadata[MetaKeyConsentCategory] != "memory:custom_thing" {
+		t.Error("unknown category should be stored verbatim")
+	}
+}
+
+func TestMemory_GetConsentCategory_UnsetReturnsEmpty(t *testing.T) {
+	m := &Memory{}
+	if got := m.GetConsentCategory(); got != "" {
+		t.Errorf("expected empty string for unset category, got %q", got)
+	}
+	m.Metadata = map[string]any{"other": "value"}
+	if got := m.GetConsentCategory(); got != "" {
+		t.Errorf("expected empty string when key missing, got %q", got)
+	}
+}

--- a/runtime/memory/tools.go
+++ b/runtime/memory/tools.go
@@ -117,14 +117,9 @@ func (e *Executor) remember(ctx context.Context, args json.RawMessage) (json.Raw
 	}
 	// Stash the LLM-supplied consent category so downstream consumers
 	// (e.g. Omnia's PII redactor / per-category retention) can read it
-	// without re-classifying. Empty category is allowed and lets a
+	// without re-classifying. Empty input is a no-op and lets a
 	// server-side classifier act as the fallback.
-	if a.Category != "" {
-		if m.Metadata == nil {
-			m.Metadata = make(map[string]any)
-		}
-		m.Metadata[MetaKeyConsentCategory] = a.Category
-	}
+	m.SetConsentCategory(ConsentCategory(a.Category))
 	// Always set provenance — overwrites any LLM-provided value.
 	m.SetProvenance(ProvenanceUserRequested)
 

--- a/runtime/memory/types.go
+++ b/runtime/memory/types.go
@@ -35,10 +35,19 @@ const (
 	MetaKeyProvenance = "provenance"
 
 	// MetaKeyConsentCategory is the well-known Metadata key for the
-	// consent category supplied by the calling LLM via memory__remember.
-	// Populated when present; consumers that classify server-side may
-	// fall back to their own classifier if absent. Values are not
-	// validated by PromptKit — semantics are owned by the consumer.
+	// consent category attached to a memory. Two write paths populate it:
+	//
+	//   - Explicit: the LLM calls memory__remember with a category arg,
+	//     which the executor stashes here verbatim.
+	//   - Implicit: an Extractor stage classifies and tags during write,
+	//     typically via [Memory.SetConsentCategory] driven by the
+	//     extracting LLM's structured output ([CategoryRubric] supplies
+	//     the prompt fragment).
+	//
+	// Consumers that classify server-side may fall back to their own
+	// classifier when this is absent. Values are not validated by
+	// PromptKit — see [IsKnownCategory] for an opt-in check against the
+	// canonical [ConsentCategory] taxonomy.
 	MetaKeyConsentCategory = "consent_category"
 
 	// ProvenanceUserRequested — user explicitly asked the agent to remember this.


### PR DESCRIPTION
## Summary

Re: #1034.

The issue is framed around extending "the built-in extraction stage's prompt", but PromptKit doesn't ship a built-in extractor — \`memory.Extractor\` is just an interface, and consumers (Omnia) own the prompt. The actionable scope on PromptKit's side is to ship the **primitives** that consumer extractors use to populate \`consent_category\` consistently, so the wire format matches the explicit \`memory__remember\` path and downstream consumers can apply uniform rules.

## What's added

- \`memory.ConsentCategory\` typed alias + 6 canonical constants:
  - \`CategoryIdentity\`, \`CategoryPreferences\`, \`CategoryContext\`, \`CategoryLocation\`, \`CategoryHealth\`, \`CategoryHistory\`
- \`memory.KnownCategories()\` / \`memory.IsKnownCategory(s)\` for opt-in validation (PromptKit still does not reject unknown values at the storage layer — semantics owned by consumer).
- \`memory.CategoryRubric\`: 6-line prompt fragment consumer extractors splice into their extraction prompt so the LLM emits a canonical category alongside each memory. PromptKit owns the rubric so all consumers see the same vocabulary.
- \`Memory.SetConsentCategory\` / \`GetConsentCategory\` helpers; the existing \`memory__remember\` executor now uses \`SetConsentCategory\` for consistency.

The \`MetaKeyConsentCategory\` doc is updated to cover both write paths (explicit tool + extractor classification) and to reference the new helpers.

## Why not extend a built-in stage prompt?

PromptKit deliberately doesn't ship an extractor — Omnia (and other platforms) own the LLM-side prompt because the extraction LLM choice, structured-output schema, and follow-on classification differ per host. This PR lets every host build a compliant extractor without duplicating the category taxonomy.

## Out of scope (Omnia work)

- Splicing \`memory.CategoryRubric\` into Omnia's extractor prompt.
- Parsing the extracting LLM's structured output and calling \`memory.SetConsentCategory\` on each emitted memory.
- Reducing the fallback classifier override rate.

These are tracked on the Omnia repo.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./runtime/memory/...\` passes (8 new tests, \`consent_category.go\` 100% covered)
- [x] Pre-commit hook (lint + coverage) green
- [ ] CI green
- [ ] SonarCloud quality gate green