### PR TITLE
feat(tts): introduce runtime/tts/markup parser for characterization tags

### DIFF
--- a/runtime/tts/markup/parser.go
+++ b/runtime/tts/markup/parser.go
@@ -1,0 +1,363 @@
+// Package markup is the canonical scanner for TTS characterization tags.
+//
+// Personas and scripts emit bracket-tagged text like
+//
+//	"[whispers]Come here[/]Did you hear that?"
+//	"[excited][pause:500ms]Surprise!"
+//
+// and each TTS provider adapter lowers those tags into its native dialect:
+// ElevenLabs v3 receives them verbatim, OpenAI gpt-4o-mini-tts splits them
+// into a free-form `instructions` field, Cartesia maps known names into its
+// `emotion` array, SSML providers translate them to <prosody>/<break>.
+//
+// This package owns the parsing and the canonical taxonomy so all providers
+// agree on what the LLM is allowed to emit. Each provider remains free to
+// drop tags it doesn't understand — see "Unknown tags" below.
+//
+// # Tag form
+//
+//   - "[name]" — a flag tag (e.g. [whispers]).
+//   - "[name:value]" — a tag with a value (e.g. [pause:500ms]).
+//   - "[/]" — explicit end of the current span; no value, no name.
+//   - "\[" and "\]" — literal brackets, not part of a tag.
+//
+// Tag scope runs from the tag itself until the next tag, the end of the
+// containing sentence (`.`, `?`, `!`), or an explicit "[/]" terminator.
+// Spans do not overlap; a new tag implicitly closes the previous one.
+//
+// # Unknown tags
+//
+// Parsing accepts any name. Whether a name is meaningful is decided by the
+// downstream consumer ([ToSSML] knows a fixed set; provider adapters know
+// their own set). Unknown names degrade gracefully — they are dropped from
+// SSML output and ignored by [ExtractInstructions]'s textual phrasing.
+package markup
+
+import (
+	"strings"
+)
+
+// Canonical tag names. The taxonomy is intentionally small; adding a name
+// here is a commitment that every consumer (SSML, instructions, provider
+// adapters) should map it sensibly. Plural and singular forms are accepted
+// where natural.
+const (
+	tagWhispers = "whispers"
+	tagWhisper  = "whisper"
+	tagShouts   = "shouts"
+	tagShout    = "shout"
+	tagLaughs   = "laughs"
+	tagLaugh    = "laugh"
+	tagSighs    = "sighs"
+	tagSigh     = "sigh"
+	tagExcited  = "excited"
+	tagSad      = "sad"
+	tagSmiles   = "smiles"
+	tagSmile    = "smile"
+	tagCalm     = "calm"
+	tagPause    = "pause"
+)
+
+// Tag is a parsed bracket-tagged directive.
+type Tag struct {
+	// Name is the tag name, lower-cased and trimmed. "/" indicates the
+	// explicit end-of-span marker "[/]".
+	Name string
+
+	// Value is the optional value portion ("[pause:500ms]" → "500ms").
+	// Empty for flag tags.
+	Value string
+
+	// Start is the byte offset in the input where "[" begins.
+	Start int
+
+	// End is the byte offset immediately after the closing "]".
+	End int
+}
+
+// IsClose reports whether t is the explicit end-of-span marker "[/]".
+func (t Tag) IsClose() bool { return t.Name == "/" }
+
+// ParseTags returns every bracket tag in text, in textual order. Malformed
+// tags (unbalanced brackets, empty body) are skipped silently — the source
+// LLM occasionally emits typos and the safer behavior is to keep going.
+func ParseTags(text string) []Tag {
+	var tags []Tag
+	for i := 0; i < len(text); i++ {
+		ch := text[i]
+		// "\[" — literal bracket, skip the escape and the bracket.
+		if ch == '\\' && i+1 < len(text) && (text[i+1] == '[' || text[i+1] == ']') {
+			i++
+			continue
+		}
+		if ch != '[' {
+			continue
+		}
+		end := indexCloseBracket(text, i+1)
+		if end < 0 {
+			// Unbalanced "[" — stop scanning; the rest is plain text.
+			break
+		}
+		body := text[i+1 : end]
+		tag, ok := parseTagBody(body, i, end+1)
+		if ok {
+			tags = append(tags, tag)
+		}
+		i = end // outer loop's i++ then advances past "]"
+	}
+	return tags
+}
+
+// parseTagBody parses the content between "[" and "]" into a Tag.
+// Returns ok=false for empty bodies.
+func parseTagBody(body string, start, end int) (Tag, bool) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return Tag{}, false
+	}
+	if body == "/" {
+		return Tag{Name: "/", Start: start, End: end}, true
+	}
+	name, value, _ := strings.Cut(body, ":")
+	return Tag{
+		Name:  strings.ToLower(strings.TrimSpace(name)),
+		Value: strings.TrimSpace(value),
+		Start: start,
+		End:   end,
+	}, true
+}
+
+// indexCloseBracket returns the byte offset of the next unescaped "]" at or
+// after start, or -1 if there is none.
+func indexCloseBracket(text string, start int) int {
+	for i := start; i < len(text); i++ {
+		if text[i] == '\\' && i+1 < len(text) {
+			i++ // skip the escaped char
+			continue
+		}
+		if text[i] == ']' {
+			return i
+		}
+	}
+	return -1
+}
+
+// StripTags returns text with every bracket tag removed. Escaped brackets
+// ("\[" and "\]") are unescaped to their literal form. Whitespace
+// collapsing is intentionally minimal — providers should treat the output
+// as the verbatim spoken text and decide their own normalization.
+func StripTags(text string) string {
+	tags := ParseTags(text)
+	if len(tags) == 0 {
+		return unescapeBrackets(text)
+	}
+	var b strings.Builder
+	b.Grow(len(text))
+	cursor := 0
+	for _, t := range tags {
+		b.WriteString(text[cursor:t.Start])
+		cursor = t.End
+	}
+	b.WriteString(text[cursor:])
+	return unescapeBrackets(b.String())
+}
+
+func unescapeBrackets(s string) string {
+	if !strings.Contains(s, `\[`) && !strings.Contains(s, `\]`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) && (s[i+1] == '[' || s[i+1] == ']') {
+			b.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// ExtractInstructions splits text into a free-form instructions phrase
+// (suitable for the OpenAI gpt-4o-mini-tts `instructions` field) and the
+// stripped spoken text. Tags are phrased with [tagPhrasing]; unknown tag
+// names appear verbatim. Close tags ("[/]") are filtered out — they have
+// no instruction value.
+//
+// Example:
+//
+//	"[whispers]Come here[/]Did you hear that?"
+//	→ ("whisper", "Come here Did you hear that?")
+//
+//	"[excited][pause:500ms]Surprise!"
+//	→ ("excited; pause for 500ms", "Surprise!")
+func ExtractInstructions(text string) (instructions, stripped string) {
+	stripped = StripTags(text)
+	tags := ParseTags(text)
+	if len(tags) == 0 {
+		return "", stripped
+	}
+	parts := make([]string, 0, len(tags))
+	seen := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		if t.IsClose() {
+			continue
+		}
+		phrase := tagPhrasing(t)
+		if phrase == "" {
+			continue
+		}
+		// De-duplicate so "[excited][excited]" doesn't produce a repeat.
+		if _, dup := seen[phrase]; dup {
+			continue
+		}
+		seen[phrase] = struct{}{}
+		parts = append(parts, phrase)
+	}
+	return strings.Join(parts, "; "), stripped
+}
+
+// tagPhrasing converts a tag to a short instruction phrase. Unknown names
+// fall through and are emitted verbatim (with their value, if any).
+func tagPhrasing(t Tag) string {
+	switch t.Name {
+	case tagWhispers, tagWhisper:
+		return tagWhisper
+	case tagShouts, tagShout:
+		return tagShout
+	case tagLaughs, tagLaugh:
+		return "laugh briefly"
+	case tagSighs, tagSigh:
+		return tagSigh
+	case tagExcited:
+		return tagExcited
+	case tagSad:
+		return tagSad
+	case tagSmile, tagSmiles:
+		return "smile while speaking"
+	case tagCalm:
+		return tagCalm
+	case tagPause:
+		if t.Value == "" {
+			return tagPause
+		}
+		return "pause for " + t.Value
+	default:
+		// Unknown name — preserve the value if present, drop otherwise.
+		if t.Value != "" {
+			return t.Name + " " + t.Value
+		}
+		return t.Name
+	}
+}
+
+// ToSSML converts text into an SSML fragment for providers that consume
+// SSML natively (Google, Azure). Tags wrap the span they govern:
+//
+//   - whisper/shout/calm/excited/sad/smile → <prosody> with rate/volume/pitch
+//   - pause → <break time="…"/>
+//   - unknown names → dropped (the text segment is rendered without a wrapper)
+//
+// The returned string is *not* wrapped in <speak>; callers add that boundary
+// when they assemble the request body. Output text is XML-escaped.
+func ToSSML(text string) string {
+	var b strings.Builder
+	tags := ParseTags(text)
+	stripped := StripTags(text)
+	if len(tags) == 0 {
+		return xmlEscape(stripped)
+	}
+
+	// Re-walk text, splitting at tag boundaries. Each non-close tag opens
+	// a span; the span ends at the next tag, "[/]", or a sentence-ender.
+	cursor := 0
+	var open *Tag // currently-open prosody-like tag, if any
+	flushOpen := func(upTo int) {
+		segment := xmlEscape(StripTags(text[cursor:upTo]))
+		if open != nil {
+			wrapped := wrapSSML(*open, segment)
+			b.WriteString(wrapped)
+		} else {
+			b.WriteString(segment)
+		}
+		cursor = upTo
+	}
+
+	for i, t := range tags {
+		// Plain text up to the start of this tag belongs to the previous
+		// open tag (or to no tag).
+		flushOpen(t.Start)
+		// Consume the tag itself (cursor jumps over it).
+		cursor = t.End
+		if t.IsClose() {
+			open = nil
+			continue
+		}
+		if t.Name == tagPause {
+			// <break/> is self-closing and does not govern a span.
+			b.WriteString(breakSSML(t.Value))
+			continue
+		}
+		// Open the new span. Implicitly close any prior open span first
+		// (no overlapping spans, per the design).
+		tag := tags[i]
+		open = &tag
+	}
+	// Flush trailing content past the last tag.
+	// Spans also implicitly close at sentence enders; if the final span
+	// hasn't been explicitly closed we still emit it as a single wrapper.
+	flushOpen(len(text))
+	_ = stripped // referenced for symmetry; flushOpen already strips.
+	return b.String()
+}
+
+// wrapSSML wraps segment with the SSML element implied by t. Returns the
+// bare segment when t has no SSML mapping.
+func wrapSSML(t Tag, segment string) string {
+	if segment == "" {
+		return ""
+	}
+	const closeProsody = `</prosody>`
+	switch t.Name {
+	case tagWhispers, tagWhisper:
+		return `<prosody volume="x-soft" rate="slow">` + segment + closeProsody
+	case tagShouts, tagShout:
+		return `<prosody volume="x-loud">` + segment + closeProsody
+	case tagLaughs, tagLaugh, tagExcited:
+		return `<prosody pitch="+2st" rate="fast">` + segment + closeProsody
+	case tagSighs, tagSigh, tagSad:
+		return `<prosody pitch="-2st" rate="slow">` + segment + closeProsody
+	case tagSmile, tagSmiles:
+		return `<prosody pitch="+1st">` + segment + closeProsody
+	case tagCalm:
+		return `<prosody rate="slow">` + segment + closeProsody
+	default:
+		return segment
+	}
+}
+
+// breakSSML emits a <break/> element with the given time value, defaulting
+// to a short pause when value is empty.
+func breakSSML(value string) string {
+	if value == "" {
+		return `<break time="500ms"/>`
+	}
+	return `<break time="` + xmlEscapeAttr(value) + `"/>`
+}
+
+// xmlEscape escapes characters that are unsafe in SSML text content.
+func xmlEscape(s string) string {
+	if !strings.ContainsAny(s, `<>&"`) {
+		return s
+	}
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
+	return r.Replace(s)
+}
+
+// xmlEscapeAttr escapes characters that are unsafe in SSML attribute values.
+// Attribute values use double quotes here, so " must be encoded.
+func xmlEscapeAttr(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", `"`, "&quot;")
+	return r.Replace(s)
+}

--- a/runtime/tts/markup/parser_test.go
+++ b/runtime/tts/markup/parser_test.go
@@ -1,0 +1,206 @@
+package markup
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTags_FlagTag(t *testing.T) {
+	tags := ParseTags("[whispers]Come here")
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+	got := tags[0]
+	if got.Name != "whispers" || got.Value != "" {
+		t.Errorf("Name=%q Value=%q", got.Name, got.Value)
+	}
+	if got.Start != 0 || got.End != 10 {
+		t.Errorf("Start=%d End=%d", got.Start, got.End)
+	}
+}
+
+func TestParseTags_ValuedTag(t *testing.T) {
+	tags := ParseTags("hello [pause:500ms]world")
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+	if tags[0].Name != "pause" || tags[0].Value != "500ms" {
+		t.Errorf("got %+v", tags[0])
+	}
+}
+
+func TestParseTags_CloseTag(t *testing.T) {
+	tags := ParseTags("[excited]Hi[/]")
+	if len(tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(tags))
+	}
+	if !tags[1].IsClose() {
+		t.Errorf("expected second tag to be close marker; got %+v", tags[1])
+	}
+}
+
+func TestParseTags_MultipleAndOrder(t *testing.T) {
+	tags := ParseTags("[a]one [b:val]two [c]three")
+	names := make([]string, 0, len(tags))
+	for _, t := range tags {
+		names = append(names, t.Name)
+	}
+	if !reflect.DeepEqual(names, []string{"a", "b", "c"}) {
+		t.Errorf("got names %v", names)
+	}
+}
+
+func TestParseTags_CaseInsensitiveAndTrimmed(t *testing.T) {
+	tags := ParseTags("[ Whispers ]")
+	if len(tags) != 1 || tags[0].Name != "whispers" {
+		t.Errorf("got %+v", tags)
+	}
+}
+
+func TestParseTags_MalformedAreSkipped(t *testing.T) {
+	// Empty body
+	if got := ParseTags("[]"); len(got) != 0 {
+		t.Errorf("empty body should be skipped, got %+v", got)
+	}
+	// Unbalanced — should stop scanning, no tags.
+	if got := ParseTags("[unclosed text"); len(got) != 0 {
+		t.Errorf("unbalanced should be ignored, got %+v", got)
+	}
+}
+
+func TestParseTags_EscapedBracketsAreNotTags(t *testing.T) {
+	tags := ParseTags(`stage direction \[smile\] inline`)
+	if len(tags) != 0 {
+		t.Errorf("escaped brackets should not produce tags; got %+v", tags)
+	}
+}
+
+func TestStripTags_NoTags(t *testing.T) {
+	if got := StripTags("plain text"); got != "plain text" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestStripTags_RemovesAll(t *testing.T) {
+	got := StripTags("[whispers]Come here[/]Did you hear that?")
+	want := "Come hereDid you hear that?"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStripTags_UnescapesLiteralBrackets(t *testing.T) {
+	got := StripTags(`stage direction \[smile\] inline`)
+	want := `stage direction [smile] inline`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractInstructions_FlagTag(t *testing.T) {
+	ins, stripped := ExtractInstructions("[whispers]Come here")
+	if ins != "whisper" {
+		t.Errorf("instructions = %q", ins)
+	}
+	if stripped != "Come here" {
+		t.Errorf("stripped = %q", stripped)
+	}
+}
+
+func TestExtractInstructions_MultipleTags(t *testing.T) {
+	ins, stripped := ExtractInstructions("[excited][pause:500ms]Surprise!")
+	want := "excited; pause for 500ms"
+	if ins != want {
+		t.Errorf("instructions = %q, want %q", ins, want)
+	}
+	if stripped != "Surprise!" {
+		t.Errorf("stripped = %q", stripped)
+	}
+}
+
+func TestExtractInstructions_DedupesRepeats(t *testing.T) {
+	ins, _ := ExtractInstructions("[excited][excited]Hello")
+	if ins != "excited" {
+		t.Errorf("repeats should de-dupe; got %q", ins)
+	}
+}
+
+func TestExtractInstructions_CloseTagsIgnored(t *testing.T) {
+	ins, _ := ExtractInstructions("[whispers]hi[/]bye")
+	if ins != "whisper" {
+		t.Errorf("close marker should be filtered; got %q", ins)
+	}
+}
+
+func TestExtractInstructions_UnknownTagPassesThrough(t *testing.T) {
+	ins, _ := ExtractInstructions("[mysterious]Hello")
+	if ins != "mysterious" {
+		t.Errorf("unknown tag should appear verbatim; got %q", ins)
+	}
+}
+
+func TestExtractInstructions_NoTags(t *testing.T) {
+	ins, stripped := ExtractInstructions("just plain text")
+	if ins != "" {
+		t.Errorf("expected empty instructions; got %q", ins)
+	}
+	if stripped != "just plain text" {
+		t.Errorf("stripped = %q", stripped)
+	}
+}
+
+func TestToSSML_NoTags(t *testing.T) {
+	if got := ToSSML("hello"); got != "hello" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestToSSML_WrapsWithProsody(t *testing.T) {
+	got := ToSSML("[whispers]Come here[/]Plain")
+	// The whisper span runs from the tag to "[/]"; "Plain" follows un-wrapped.
+	want := `<prosody volume="x-soft" rate="slow">Come here</prosody>Plain`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestToSSML_PauseEmitsBreak(t *testing.T) {
+	got := ToSSML("hello [pause:500ms]world")
+	want := `hello <break time="500ms"/>world`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestToSSML_PauseDefaultDuration(t *testing.T) {
+	got := ToSSML("[pause]hello")
+	want := `<break time="500ms"/>hello`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestToSSML_UnknownTagDropsWrapper(t *testing.T) {
+	got := ToSSML("[mysterious]hello")
+	if got != "hello" {
+		t.Errorf("got %q (expected 'hello' — unknown tag should drop wrapper)", got)
+	}
+}
+
+func TestToSSML_EscapesUnsafeChars(t *testing.T) {
+	got := ToSSML(`a & b < c > "d"`)
+	want := `a &amp; b &lt; c &gt; &quot;d&quot;`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestToSSML_ConsecutiveTagsImplicitlyClosePrior(t *testing.T) {
+	// New tag implicitly closes the previous span.
+	got := ToSSML("[whispers]soft[shouts]loud")
+	want := `<prosody volume="x-soft" rate="slow">soft</prosody>` +
+		`<prosody volume="x-loud">loud</prosody>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

First PR of the TTS characterization series — issue #1081.

Adds the canonical scanner that subsequent provider-adapter PRs will use to lower bracket-tagged personas/scripts into each TTS provider's native dialect (ElevenLabs v3 native, OpenAI \`gpt-4o-mini-tts\` instructions, Cartesia \`emotion\`, SSML \`<prosody>\`/\`<break>\`).

## Why a separate parser PR first?

Per the rollout plan in #1081: "One PR per provider adapter so each is independently revertible." This PR ships the parser standalone with no behavior change anywhere — providers don't call into it yet. Each subsequent adapter PR (OpenAI → ElevenLabs → Cartesia → Mock) is a focused diff against the same package.

## Public surface (\`runtime/tts/markup\`)

- \`Tag{Name, Value, Start, End}\` + \`IsClose()\` for \`[/]\`.
- \`ParseTags(text)\` — every tag in textual order; malformed entries (empty body, unbalanced, escaped \`\\[\`) skipped silently.
- \`StripTags(text)\` — clean spoken text; \`\\[\` and \`\\]\` unescaped to literal brackets.
- \`ExtractInstructions(text) (instructions, stripped)\` — free-form phrasing for OpenAI's \`instructions\` field; dedupes repeats; close markers filtered.
- \`ToSSML(text)\` — minimal SSML fragment for Google/Azure; \`<prosody>\` wraps whisper/shout/laugh/sigh/excited/sad/smile/calm spans; \`<break>\` for pause; unknown names drop their wrapper. XML-escapes unsafe chars.

## Canonical taxonomy

Closed set for v1 per the issue's "Decisions" section: \`whisper(s)\`, \`shout(s)\`, \`laugh(s)\`, \`sigh(s)\`, \`excited\`, \`sad\`, \`smile(s)\`, \`calm\`, \`pause[:duration]\`, \`/\` (close). Unknown names accepted at the parse layer and degrade gracefully per consumer.

## Test plan

- [x] 23 unit tests cover flag/valued/close tags, escape handling, dedup, SSML wrapping, unknown-tag passthrough, XML escaping
- [x] \`go build ./...\` clean
- [x] Pre-commit hook (lint + coverage) green; \`parser.go\` 88.1% covered
- [ ] CI green
- [ ] SonarCloud quality gate green

## Out of scope (follow-up PRs in the series)

- Provider adapters wiring the parser in (OpenAI, ElevenLabs, Cartesia, Mock).
- \`VoiceSettings\` on \`TTSConfig\` / \`SynthesisConfig\` + persona-level \`tts\` slot.
- \`resolveTTS\` persona layer.
- \`examples/duplex-expressive/\` scenario.