### PR TITLE
feat(tts): wire markup parser into OpenAI adapter (instructions field)

### DIFF
--- a/runtime/tts/openai.go
+++ b/runtime/tts/openai.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tts/markup"
 )
 
 // Compile-time checks: all three TTS service types must satisfy base.TTSProvider.
@@ -23,10 +25,19 @@ const (
 	openAIBaseURL     = "https://api.openai.com/v1"
 	openAITTSEndpoint = "/audio/speech"
 
-	// ModelTTS1 is the OpenAI TTS model optimized for speed.
+	// ModelTTS1 is the OpenAI TTS model optimized for speed. Does not
+	// support the `instructions` field — characterization tags supplied
+	// to this model are stripped from the spoken text and the LLM
+	// directives are dropped (with a debug log).
 	ModelTTS1 = "tts-1"
-	// ModelTTS1HD is the OpenAI TTS model optimized for quality.
+	// ModelTTS1HD is the OpenAI TTS model optimized for quality. Also
+	// has no `instructions` support; same behavior as ModelTTS1 for
+	// characterization tags.
 	ModelTTS1HD = "tts-1-hd"
+	// ModelGPT4oMiniTTS is the expressive OpenAI TTS model. Honors the
+	// `instructions` request field, which the adapter populates from
+	// markup tags in the input text (see runtime/tts/markup).
+	ModelGPT4oMiniTTS = "gpt-4o-mini-tts"
 
 	// Default timeout for TTS requests.
 	defaultOpenAITimeout = 30 * time.Second
@@ -106,6 +117,10 @@ type openAIRequest struct {
 	Voice          string  `json:"voice"`
 	ResponseFormat string  `json:"response_format,omitempty"`
 	Speed          float64 `json:"speed,omitempty"`
+	// Instructions steers expressive delivery on gpt-4o-mini-tts. Ignored
+	// by tts-1 / tts-1-hd; omitted when no markup tags are present in the
+	// input so cache keys for plain-text utterances stay stable.
+	Instructions string `json:"instructions,omitempty"`
 }
 
 // Synthesize converts text to audio using OpenAI's TTS API.
@@ -142,12 +157,21 @@ func (s *OpenAIService) Synthesize(
 		model = s.Model
 	}
 
+	// Lower markup tags into the model's native dialect:
+	//   - gpt-4o-mini-tts honors `instructions` — populate from the tags.
+	//   - tts-1 / tts-1-hd ignore `instructions` entirely; the tags get
+	//     stripped from the spoken text but the directives are dropped.
+	// Plain-text utterances (no tags) hit the same wire format as before
+	// so cache keys stay stable.
+	input, instructions := lowerOpenAIMarkup(text, model)
+
 	reqBody := openAIRequest{
 		Model:          model,
-		Input:          text,
+		Input:          input,
 		Voice:          voice,
 		ResponseFormat: format,
 		Speed:          speed,
+		Instructions:   instructions,
 	}
 
 	bodyBytes, err := json.Marshal(reqBody)
@@ -179,6 +203,29 @@ func (s *OpenAIService) Synthesize(
 	}
 
 	return resp.Body, nil
+}
+
+// lowerOpenAIMarkup translates characterization tags in the input text into
+// the OpenAI request shape. For gpt-4o-mini-tts (expressive), tags become
+// the `instructions` field and the spoken text is stripped. For tts-1 and
+// tts-1-hd, the tags are stripped from the spoken text and the directives
+// are dropped (with a debug log noting the lossy lowering). When no tags
+// are present, returns (text, "") so cache keys for plain-text utterances
+// stay byte-identical to the pre-markup wire format.
+func lowerOpenAIMarkup(text, model string) (input, instructions string) {
+	tags := markup.ParseTags(text)
+	if len(tags) == 0 {
+		return text, ""
+	}
+	if model == ModelGPT4oMiniTTS {
+		ins, stripped := markup.ExtractInstructions(text)
+		return stripped, ins
+	}
+	logger.Debug(
+		"openai tts: markup tags dropped on non-expressive model",
+		"model", model, "tag_count", len(tags),
+	)
+	return markup.StripTags(text), ""
 }
 
 // mapFormat converts AudioFormat to OpenAI format string.

--- a/runtime/tts/openai_test.go
+++ b/runtime/tts/openai_test.go
@@ -154,6 +154,101 @@ func TestOpenAIService_Synthesize_Error(t *testing.T) {
 	}
 }
 
+func TestOpenAIService_Synthesize_LowersMarkupToInstructions_GPT4oMiniTTS(t *testing.T) {
+	// Bracket tags on the expressive model should land in `instructions`,
+	// and the spoken text in `input` should be the stripped version.
+	var got openAIRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("audio"))
+	}))
+	defer server.Close()
+
+	service := NewOpenAI("k", base.WithBaseURL(server.URL))
+	reader, err := service.Synthesize(context.Background(),
+		"[whispers]Come here[/]Did you hear that?",
+		SynthesisConfig{Voice: VoiceAlloy, Model: ModelGPT4oMiniTTS},
+	)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	defer reader.Close()
+	_, _ = io.ReadAll(reader)
+
+	if got.Input != "Come hereDid you hear that?" {
+		t.Errorf("Input = %q, want stripped spoken text", got.Input)
+	}
+	if got.Instructions != "whisper" {
+		t.Errorf("Instructions = %q, want %q", got.Instructions, "whisper")
+	}
+	if got.Model != ModelGPT4oMiniTTS {
+		t.Errorf("Model = %q, want %q", got.Model, ModelGPT4oMiniTTS)
+	}
+}
+
+func TestOpenAIService_Synthesize_StripsMarkup_TTS1(t *testing.T) {
+	// On tts-1, tags should still be stripped from `input` (so the model
+	// doesn't literally speak "[whispers]"), but `instructions` MUST be
+	// omitted because the model doesn't support it.
+	var got openAIRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("audio"))
+	}))
+	defer server.Close()
+
+	service := NewOpenAI("k", base.WithBaseURL(server.URL))
+	reader, err := service.Synthesize(context.Background(),
+		"[excited]Surprise!",
+		SynthesisConfig{Voice: VoiceAlloy, Model: ModelTTS1},
+	)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	defer reader.Close()
+	_, _ = io.ReadAll(reader)
+
+	if got.Input != "Surprise!" {
+		t.Errorf("Input = %q, want stripped %q", got.Input, "Surprise!")
+	}
+	if got.Instructions != "" {
+		t.Errorf("Instructions should be empty on tts-1, got %q", got.Instructions)
+	}
+}
+
+func TestOpenAIService_Synthesize_PlainTextUnchanged(t *testing.T) {
+	// No tags ⇒ input is byte-identical to what callers passed in and
+	// `instructions` is omitted, so the JSON cache key is unchanged.
+	var raw []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("audio"))
+	}))
+	defer server.Close()
+
+	service := NewOpenAI("k", base.WithBaseURL(server.URL))
+	reader, err := service.Synthesize(context.Background(),
+		"Plain text without any tags.",
+		SynthesisConfig{Voice: VoiceAlloy, Model: ModelGPT4oMiniTTS},
+	)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	defer reader.Close()
+	_, _ = io.ReadAll(reader)
+
+	if strings.Contains(string(raw), `"instructions"`) {
+		t.Errorf("instructions field should be omitted for plain text; got body %s", raw)
+	}
+}
+
 func TestOpenAIService_SupportedVoices(t *testing.T) {
 	service := NewOpenAI("test-key")
 	voices := service.SupportedVoices()


### PR DESCRIPTION
## Summary

Second PR of the TTS characterization series — issue #1081 — following #1126 which shipped the parser standalone.

OpenAI's \`gpt-4o-mini-tts\` model honors a free-form \`instructions\` request field for expressive delivery; \`tts-1\` and \`tts-1-hd\` do not. This PR lowers bracket-tagged input into the right shape per model:

| Model | Input | Instructions |
|---|---|---|
| \`gpt-4o-mini-tts\` | stripped spoken text | populated from \`markup.ExtractInstructions\` |
| \`tts-1\` / \`tts-1-hd\` | stripped spoken text | omitted (with debug log) |
| any model, no tags | unchanged (byte-identical) | omitted |

The plain-text path is byte-identical to the pre-markup wire format, so the on-disk audio cache key is unchanged.

## What's added

- \`tts.ModelGPT4oMiniTTS = "gpt-4o-mini-tts"\` constant.
- \`Instructions\` field on \`openAIRequest\` (\`json:"instructions,omitempty"\` — omitted for non-expressive models or plain text).
- Internal \`lowerOpenAIMarkup(text, model) (input, instructions)\` helper that dispatches by model.
- 3 new tests:
  - \`Synthesize_LowersMarkupToInstructions_GPT4oMiniTTS\` — tags land in \`instructions\`, spoken text is stripped.
  - \`Synthesize_StripsMarkup_TTS1\` — tags stripped from \`input\`, \`instructions\` empty.
  - \`Synthesize_PlainTextUnchanged\` — request body has no \`"instructions"\` field at all.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./runtime/tts/...\` passes; \`openai.go\` 87.7% covered
- [x] Pre-commit hook (lint + coverage) green
- [ ] CI green
- [ ] SonarCloud quality gate green

## Series progress

- ✅ #1126 — parser
- ✅ this PR — OpenAI adapter
- ⏭ ElevenLabs adapter (v3 pass-through / non-v3 strip)
- ⏭ Cartesia adapter (tags → emotion array)
- ⏭ Mock adapter (strip-from-cache-key)
- ⏭ \`VoiceSettings\` + persona-level \`tts\` slot, \`resolveTTS\`, \`examples/duplex-expressive/\`