### PR TITLE
feat(tts): wire markup parser into ElevenLabs adapter

### DIFF
--- a/runtime/tts/elevenlabs.go
+++ b/runtime/tts/elevenlabs.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tts/markup"
 )
 
 const (
@@ -21,6 +23,11 @@ const (
 	ElevenLabsModelEnglish = "eleven_monolingual_v1"
 	// ElevenLabsModelMultilingualV1 is the older multilingual v1 model.
 	ElevenLabsModelMultilingualV1 = "eleven_multilingual_v1"
+	// ElevenLabsModelV3 is the v3 expressive model that natively consumes
+	// inline characterization tags such as "[whispers]" / "[laughs]".
+	// Markup tags are passed through verbatim in the request body for
+	// any model whose ID starts with "eleven_v3".
+	ElevenLabsModelV3 = "eleven_v3"
 
 	// Default timeout for ElevenLabs requests.
 	defaultElevenLabsTimeout = 60 * time.Second
@@ -117,8 +124,14 @@ func (s *ElevenLabsService) Synthesize(
 		model = s.Model
 	}
 
+	// Lower markup tags into the model's dialect: v3 consumes inline
+	// "[whispers]" / "[laughs]" tags natively, so we pass the text
+	// through verbatim. Non-v3 models would speak the brackets literally,
+	// so strip them. Plain text (no tags) is byte-identical either way.
+	body := lowerElevenLabsMarkup(text, model)
+
 	reqBody := elevenLabsRequest{
-		Text:    text,
+		Text:    body,
 		ModelID: model,
 		VoiceSettings: &elevenLabsVoiceSettings{
 			Stability:       elevenLabsDefaultStability,
@@ -137,6 +150,26 @@ func (s *ElevenLabsService) Synthesize(
 		"Accept":       "audio/mpeg",
 	}
 	return postJSONForAudio(ctx, s.Client, "elevenlabs", endpoint, reqBody, headers, s.handleError)
+}
+
+// lowerElevenLabsMarkup returns the spoken-text body to send to ElevenLabs:
+// pass-through verbatim for v3-class models (they consume inline tags
+// natively), strip tags for older models so they don't literally speak
+// the brackets. No tags ⇒ identical wire output either way, so the
+// audio cache key for plain-text utterances stays stable.
+func lowerElevenLabsMarkup(text, model string) string {
+	if elevenLabsSupportsInlineTags(model) {
+		return text
+	}
+	return markup.StripTags(text)
+}
+
+// elevenLabsSupportsInlineTags reports whether the given model ID accepts
+// inline characterization tags in the request body. Currently true for
+// every model whose ID starts with "eleven_v3" (matches "eleven_v3",
+// "eleven_v3_alpha", etc.).
+func elevenLabsSupportsInlineTags(model string) bool {
+	return strings.HasPrefix(model, ElevenLabsModelV3)
 }
 
 // mapFormat converts AudioFormat to ElevenLabs format string.

--- a/runtime/tts/elevenlabs_test.go
+++ b/runtime/tts/elevenlabs_test.go
@@ -119,6 +119,107 @@ func TestElevenLabsService_Synthesize_Success(t *testing.T) {
 	}
 }
 
+func TestElevenLabsService_Synthesize_V3PassesThroughTags(t *testing.T) {
+	// v3 model: the request Text should contain the bracket tags verbatim.
+	var got elevenLabsRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("audio"))
+	}))
+	defer server.Close()
+
+	service := NewElevenLabs("k", base.WithBaseURL(server.URL))
+	reader, err := service.Synthesize(context.Background(),
+		"[whispers]Come here[/]Did you hear that?",
+		SynthesisConfig{Voice: "v", Model: ElevenLabsModelV3},
+	)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	defer reader.Close()
+	_, _ = io.ReadAll(reader)
+
+	want := "[whispers]Come here[/]Did you hear that?"
+	if got.Text != want {
+		t.Errorf("v3 should pass tags through verbatim; got Text = %q, want %q", got.Text, want)
+	}
+}
+
+func TestElevenLabsService_Synthesize_NonV3StripsTags(t *testing.T) {
+	// Non-v3 model: brackets get stripped so the model doesn't speak them.
+	var got elevenLabsRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("audio"))
+	}))
+	defer server.Close()
+
+	service := NewElevenLabs("k", base.WithBaseURL(server.URL))
+	reader, err := service.Synthesize(context.Background(),
+		"[excited]Surprise!",
+		SynthesisConfig{Voice: "v", Model: ElevenLabsModelMultilingual},
+	)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	defer reader.Close()
+	_, _ = io.ReadAll(reader)
+
+	if got.Text != "Surprise!" {
+		t.Errorf("non-v3 should strip tags; got Text = %q, want %q", got.Text, "Surprise!")
+	}
+}
+
+func TestElevenLabsService_Synthesize_PlainTextUnchanged(t *testing.T) {
+	// No tags ⇒ Text is byte-identical regardless of model. Cache key stable.
+	for _, model := range []string{ElevenLabsModelV3, ElevenLabsModelMultilingual} {
+		var got elevenLabsRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			w.Header().Set("Content-Type", "audio/mpeg")
+			_, _ = w.Write([]byte("audio"))
+		}))
+
+		service := NewElevenLabs("k", base.WithBaseURL(server.URL))
+		reader, err := service.Synthesize(context.Background(),
+			"Plain text without any tags.",
+			SynthesisConfig{Voice: "v", Model: model},
+		)
+		if err != nil {
+			t.Fatalf("Synthesize(%s): %v", model, err)
+		}
+		_, _ = io.ReadAll(reader)
+		reader.Close()
+		server.Close()
+
+		if got.Text != "Plain text without any tags." {
+			t.Errorf("model=%s: Text should be unchanged, got %q", model, got.Text)
+		}
+	}
+}
+
+func TestElevenLabsSupportsInlineTags(t *testing.T) {
+	for in, want := range map[string]bool{
+		"eleven_v3":              true,
+		"eleven_v3_alpha":        true,
+		"eleven_multilingual_v2": false,
+		"eleven_turbo_v2_5":      false,
+		"":                       false,
+	} {
+		if got := elevenLabsSupportsInlineTags(in); got != want {
+			t.Errorf("elevenLabsSupportsInlineTags(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
 func TestElevenLabsService_Synthesize_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
## Summary

Third PR of the TTS characterization series — issue #1081 — following #1126 (parser) and #1127 (OpenAI).

ElevenLabs v3 consumes inline characterization tags natively (\`[whispers]\`, \`[laughs]\`, etc.), so the adapter passes them through verbatim. Older v1/v2/turbo models would speak the brackets literally, so the adapter strips them.

| Model class | Request body \`text\` |
|---|---|
| \`eleven_v3\` (and \`eleven_v3_*\` variants) | tags verbatim |
| \`eleven_multilingual_v2\`, \`eleven_turbo_v2_5\`, \`eleven_*_v1\` | \`markup.StripTags(text)\` |
| any model, no tags | unchanged (byte-identical) |

Plain text (no tags) is byte-identical regardless of model, so the on-disk audio cache key stays stable.

## What's added

- \`tts.ElevenLabsModelV3 = "eleven_v3"\` constant.
- \`elevenLabsSupportsInlineTags(model)\` — prefix match on \`"eleven_v3"\` so future variants (\`eleven_v3_alpha\`, \`eleven_v3.1\`, etc.) get pass-through automatically.
- Internal \`lowerElevenLabsMarkup(text, model)\` helper.
- 4 new tests: v3 pass-through, non-v3 stripping, plain-text invariance across both classes, prefix helper.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./runtime/tts/...\` passes; \`elevenlabs.go\` 97.1% covered
- [x] Pre-commit hook (lint + coverage) green
- [ ] CI green
- [ ] SonarCloud quality gate green

## Series progress

- ✅ #1126 — parser
- ✅ #1127 — OpenAI adapter
- ✅ this PR — ElevenLabs adapter
- ⏭ Cartesia adapter (tags → emotion array)
- ⏭ Mock adapter (strip-from-cache-key)
- ⏭ \`VoiceSettings\` + persona-level \`tts\` slot, \`resolveTTS\`, \`examples/duplex-expressive/\`