### PR TITLE
feat(tts): wire markup parser into Cartesia adapter (emotion array)

### DIFF
--- a/runtime/tts/cartesia.go
+++ b/runtime/tts/cartesia.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tts/markup"
 )
 
 const (
@@ -110,8 +111,20 @@ type cartesiaRequest struct {
 }
 
 type cartesiaVoiceConfig struct {
-	Mode string `json:"mode"`
-	ID   string `json:"id,omitempty"`
+	Mode                 string                        `json:"mode"`
+	ID                   string                        `json:"id,omitempty"`
+	ExperimentalControls *cartesiaExperimentalControls `json:"__experimental_controls,omitempty"`
+}
+
+// cartesiaExperimentalControls carries Cartesia's experimental voice knobs.
+// Currently only `Emotion` is populated, derived from markup tags in the
+// input text. Other knobs (speed, etc.) live here when added.
+type cartesiaExperimentalControls struct {
+	// Emotion is Cartesia's emotion-array control. Each entry has the
+	// form "<name>:<level>" (e.g. "positivity:high"). Cartesia silently
+	// ignores unknown emotion names, so we map a conservative subset of
+	// our canonical tags and drop the rest.
+	Emotion []string `json:"emotion,omitempty"`
 }
 
 type cartesiaOutputFormat struct {
@@ -140,13 +153,22 @@ func (s *CartesiaService) Synthesize(
 		model = s.Model
 	}
 
+	// Lower markup tags into Cartesia's dialect: bracket directives are
+	// translated to entries in the experimental-controls `emotion` array,
+	// and stripped from the transcript so they are not spoken literally.
+	// Plain text (no tags) produces a request that's byte-identical to
+	// the pre-markup wire format, keeping the audio cache key stable.
+	transcript, emotions := lowerCartesiaMarkup(text)
+
+	voiceCfg := cartesiaVoiceConfig{Mode: "id", ID: voice}
+	if len(emotions) > 0 {
+		voiceCfg.ExperimentalControls = &cartesiaExperimentalControls{Emotion: emotions}
+	}
+
 	reqBody := cartesiaRequest{
-		ModelID:    model,
-		Transcript: text,
-		Voice: cartesiaVoiceConfig{
-			Mode: "id",
-			ID:   voice,
-		},
+		ModelID:      model,
+		Transcript:   transcript,
+		Voice:        voiceCfg,
 		OutputFormat: s.mapFormat(config.Format),
 		Language:     config.Language,
 	}
@@ -159,6 +181,59 @@ func (s *CartesiaService) Synthesize(
 	return postJSONForAudio(
 		ctx, s.Client, "cartesia", s.BaseURL+cartesiaRESTURL, reqBody, headers, s.handleError,
 	)
+}
+
+// lowerCartesiaMarkup translates characterization tags in text into the
+// Cartesia request shape: a stripped transcript and a slice of "emotion:level"
+// strings suitable for the experimental-controls emotion array. Returns the
+// raw text and a nil slice when no tags are present (cache key stable).
+//
+// The taxonomy mapping is conservative — Cartesia's emotion vocabulary is
+// narrow (positivity / sadness / anger / surprise / curiosity) so several
+// of our canonical tag names (whispers, pause, calm) have no analog and
+// are dropped. Cartesia silently ignores unrecognized emotion entries, so
+// the mapping degrades safely even if Cartesia's API changes.
+func lowerCartesiaMarkup(text string) (transcript string, emotions []string) {
+	tags := markup.ParseTags(text)
+	if len(tags) == 0 {
+		return text, nil
+	}
+	seen := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		if t.IsClose() {
+			continue
+		}
+		e := cartesiaEmotionForTag(t)
+		if e == "" {
+			continue
+		}
+		if _, dup := seen[e]; dup {
+			continue
+		}
+		seen[e] = struct{}{}
+		emotions = append(emotions, e)
+	}
+	return markup.StripTags(text), emotions
+}
+
+// cartesiaEmotionForTag maps a canonical tag onto Cartesia's experimental
+// emotion vocabulary, or returns "" when there is no sensible analog (the
+// tag is then dropped). Levels follow Cartesia's "<emotion>:<level>" form
+// with levels lowest/low/medium/high/highest.
+func cartesiaEmotionForTag(t markup.Tag) string {
+	switch t.Name {
+	case "excited", "laughs", "laugh":
+		return "positivity:high"
+	case "smile", "smiles":
+		return "positivity:medium"
+	case "sad", "sighs", "sigh":
+		return "sadness:high"
+	case "shouts", "shout":
+		return "anger:high"
+	default:
+		// whispers/calm/pause and unknown names — no Cartesia analog.
+		return ""
+	}
 }
 
 // cartesiaWSResponse represents a WebSocket response from Cartesia.

--- a/runtime/tts/cartesia_test.go
+++ b/runtime/tts/cartesia_test.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tts/markup"
 )
 
 func TestNewCartesia(t *testing.T) {
@@ -125,6 +127,102 @@ func TestCartesiaService_Synthesize_Success(t *testing.T) {
 
 	if string(data) != "mock audio data" {
 		t.Errorf("data = %v, want mock audio data", string(data))
+	}
+}
+
+func TestCartesiaService_Synthesize_LowersTagsToEmotion(t *testing.T) {
+	// Tags map to Cartesia's emotion array; transcript drops the brackets.
+	var got cartesiaRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "audio/wav")
+		_, _ = w.Write([]byte("audio"))
+	}))
+	defer server.Close()
+
+	service := NewCartesia("k", base.WithBaseURL(server.URL))
+	reader, err := service.Synthesize(context.Background(),
+		"[excited]Surprise![smile]Hi.",
+		SynthesisConfig{Voice: "v"},
+	)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	defer reader.Close()
+	_, _ = io.ReadAll(reader)
+
+	if got.Transcript != "Surprise!Hi." {
+		t.Errorf("Transcript = %q, want stripped %q", got.Transcript, "Surprise!Hi.")
+	}
+	if got.Voice.ExperimentalControls == nil {
+		t.Fatal("ExperimentalControls should be set when tags are present")
+	}
+	emo := got.Voice.ExperimentalControls.Emotion
+	if len(emo) != 2 {
+		t.Fatalf("emotion = %v, want 2 entries", emo)
+	}
+	if emo[0] != "positivity:high" || emo[1] != "positivity:medium" {
+		t.Errorf("emotion = %v, want [positivity:high positivity:medium]", emo)
+	}
+}
+
+func TestCartesiaService_Synthesize_PlainTextUnchanged(t *testing.T) {
+	// No tags ⇒ Transcript byte-identical, ExperimentalControls omitted.
+	var raw []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "audio/wav")
+		_, _ = w.Write([]byte("audio"))
+	}))
+	defer server.Close()
+
+	service := NewCartesia("k", base.WithBaseURL(server.URL))
+	reader, err := service.Synthesize(context.Background(),
+		"Plain text without any tags.",
+		SynthesisConfig{Voice: "v"},
+	)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	defer reader.Close()
+	_, _ = io.ReadAll(reader)
+
+	if strings.Contains(string(raw), `__experimental_controls`) {
+		t.Errorf("experimental_controls should be omitted for plain text; got %s", raw)
+	}
+}
+
+func TestCartesiaEmotionForTag(t *testing.T) {
+	cases := map[string]string{
+		"excited":  "positivity:high",
+		"laughs":   "positivity:high",
+		"smile":    "positivity:medium",
+		"smiles":   "positivity:medium",
+		"sad":      "sadness:high",
+		"sighs":    "sadness:high",
+		"shouts":   "anger:high",
+		"whispers": "", // no Cartesia analog
+		"calm":     "",
+		"pause":    "",
+		"mystery":  "", // unknown
+	}
+	for name, want := range cases {
+		got := cartesiaEmotionForTag(markup.Tag{Name: name})
+		if got != want {
+			t.Errorf("cartesiaEmotionForTag(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestLowerCartesiaMarkup_DedupesAndDropsCloseTags(t *testing.T) {
+	transcript, emotions := lowerCartesiaMarkup("[excited]a[excited]b[/]c")
+	if transcript != "abc" {
+		t.Errorf("transcript = %q, want %q", transcript, "abc")
+	}
+	if len(emotions) != 1 || emotions[0] != "positivity:high" {
+		t.Errorf("emotions = %v, want [positivity:high]", emotions)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fourth PR of the TTS characterization series — issue #1081 — following #1126 (parser), #1127 (OpenAI), #1128 (ElevenLabs).

Cartesia ships an experimental \`emotion\` array on its voice config (\`voice.__experimental_controls.emotion\`). This adapter translates canonical markup tags into that vocabulary and strips the brackets from the spoken transcript.

## Mapping

| Tag | Cartesia emotion |
|---|---|
| \`excited\`, \`laughs\` | \`positivity:high\` |
| \`smile(s)\` | \`positivity:medium\` |
| \`sad\`, \`sighs\` | \`sadness:high\` |
| \`shouts\` | \`anger:high\` |
| \`whispers\`, \`calm\`, \`pause\`, unknown | dropped (no Cartesia analog) |

Conservative on purpose — Cartesia's vocabulary is narrow (positivity / sadness / anger / surprise / curiosity) and the experimental controls path may change. Unrecognized entries are ignored by Cartesia, so the mapping degrades safely either way.

## What's added

- \`cartesiaExperimentalControls\` struct with \`Emotion []string\` (JSON: \`voice.__experimental_controls.emotion\`).
- \`cartesiaEmotionForTag(tag)\` — table mapping.
- \`lowerCartesiaMarkup(text) → (transcript, emotions)\` — strips tags, deduplicates emotions, drops close markers.

Plain-text inputs (no tags) produce a request that's byte-identical to the pre-markup wire format, keeping the audio cache key stable.

## Test plan

- [x] 4 new tests cover end-to-end synthesize-with-tags, plain-text invariance, tag→emotion mapping table, dedup + close-tag handling
- [x] \`go build ./...\` clean
- [x] Pre-commit hook (lint + coverage) green; \`cartesia.go\` 96.9% covered
- [ ] CI green
- [ ] SonarCloud quality gate green

## Series progress

- ✅ #1126 — parser
- ✅ #1127 — OpenAI adapter
- ✅ #1128 — ElevenLabs adapter
- ✅ this PR — Cartesia adapter
- ⏭ Mock adapter (strip-from-cache-key)
- ⏭ \`VoiceSettings\` + persona-level \`tts\` slot, \`resolveTTS\`, \`examples/duplex-expressive/\`