### PR TITLE
feat(tts): provider-default characterization rubric + persona opt-in

### DIFF
--- a/examples/voice-refund-demo/personas/aggressive-entitled.persona.yaml
+++ b/examples/voice-refund-demo/personas/aggressive-entitled.persona.yaml
@@ -36,3 +36,9 @@ spec:
       - hostile
       - entitled
       - persistent
+    # Opt this persona into TTS characterization markup. When the
+    # scenario's TTS provider supports it (gpt-4o-mini-tts, ElevenLabs v3,
+    # Cartesia), the runtime prepends a provider-tuned rubric to the
+    # system prompt so the LLM can emit "[shouts]", "[sighs]", etc.
+    # The TTS adapter then lowers those tags into its native dialect.
+    expressive: true

--- a/pkg/config/persona.go
+++ b/pkg/config/persona.go
@@ -61,6 +61,21 @@ type PersonaStyle struct {
 	Verbosity      string   `json:"verbosity" yaml:"verbosity"`             // "short", "medium", "long"
 	ChallengeLevel string   `json:"challenge_level" yaml:"challenge_level"` // "low", "medium", "high"
 	FrictionTags   []string `json:"friction_tags" yaml:"friction_tags"`     // e.g., ["skeptical", "impatient", "detail-oriented"]
+
+	// Expressive opts the persona into TTS characterization markup. When
+	// true, [UserPersonaPack.BuildSystemPrompt] prepends a bracket-tag
+	// rubric (from the resolved TTS provider, or from
+	// CharacterizationRubric below) so the LLM emits "[whispers]" /
+	// "[excited]" / "[laughs]" etc. that downstream provider adapters
+	// lower into their native dialects. Default false — existing personas
+	// produce byte-identical prompts.
+	Expressive bool `json:"expressive,omitempty" yaml:"expressive,omitempty"`
+
+	// CharacterizationRubric is an optional override that replaces the
+	// provider-default rubric verbatim. Only consulted when Expressive is
+	// true. Use this when a persona has unusual delivery requirements
+	// (custom tag examples, narrower vocabulary, alternative phrasing).
+	CharacterizationRubric string `json:"characterization_rubric,omitempty" yaml:"characterization_rubric,omitempty"`
 }
 
 // PersonaDefaults contains default LLM parameters for the persona.
@@ -235,7 +250,59 @@ func validatePersonaStyle(style PersonaStyle) error {
 // 1. system_template + fragments (new, preferred)
 // 2. system_prompt (legacy, plain text)
 // 3. prompt_activity (deprecated, will be removed)
+//
+// Callers that want TTS characterization markup (issue #1130) should use
+// [UserPersonaPack.BuildSystemPromptWithRubric] instead.
 func (p *UserPersonaPack) BuildSystemPrompt(region string, contextVars map[string]string) (string, error) {
+	return p.BuildSystemPromptWithRubric(region, contextVars, "")
+}
+
+// BuildSystemPromptWithRubric builds the system prompt and optionally
+// prepends a TTS characterization rubric so the LLM emits bracket-tagged
+// expressive output the configured TTS provider can act on.
+//
+// Rubric selection (matches the build-path rules from issue #1130):
+//   - p.Style.Expressive is false → providerRubric is ignored; result is
+//     byte-identical to [UserPersonaPack.BuildSystemPrompt].
+//   - p.Style.CharacterizationRubric is non-empty → it replaces
+//     providerRubric verbatim.
+//   - Otherwise → providerRubric is used as supplied (callers pass the
+//     empty string when the resolved provider has no characterization
+//     support, which makes this method a no-op).
+//
+// The rubric is prepended to the rendered system prompt, separated by a
+// blank line. The base prompt body is unchanged.
+func (p *UserPersonaPack) BuildSystemPromptWithRubric(
+	region string, contextVars map[string]string, providerRubric string,
+) (string, error) {
+	body, err := p.buildSystemPromptBody(region, contextVars)
+	if err != nil {
+		return "", err
+	}
+	rubric := p.resolveRubric(providerRubric)
+	if rubric == "" {
+		return body, nil
+	}
+	return rubric + "\n\n" + body, nil
+}
+
+// resolveRubric picks the rubric to prepend per the precedence in
+// [UserPersonaPack.BuildSystemPromptWithRubric]. Returns "" when no
+// rubric should be injected.
+func (p *UserPersonaPack) resolveRubric(providerRubric string) string {
+	if !p.Style.Expressive {
+		return ""
+	}
+	if p.Style.CharacterizationRubric != "" {
+		return p.Style.CharacterizationRubric
+	}
+	return providerRubric
+}
+
+// buildSystemPromptBody renders the persona's base prompt (without any
+// characterization rubric prefix). Shared by BuildSystemPrompt and
+// BuildSystemPromptWithRubric.
+func (p *UserPersonaPack) buildSystemPromptBody(region string, contextVars map[string]string) (string, error) {
 	// NEW: Use template system if system_template is specified
 	if p.SystemTemplate != "" || len(p.Fragments) > 0 {
 		return p.buildTemplatedPrompt(region, contextVars)

--- a/pkg/config/persona_test.go
+++ b/pkg/config/persona_test.go
@@ -27,6 +27,71 @@ func TestPersonaStyle_Structure(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPromptWithRubric_NoOpWhenNotExpressive(t *testing.T) {
+	// Personas that have not opted into expressive output must produce a
+	// system prompt that is byte-identical to BuildSystemPrompt regardless
+	// of what providerRubric the caller passes. This is the "zero-surprise"
+	// invariant from #1130.
+	p := &UserPersonaPack{
+		ID:           "p",
+		SystemPrompt: "You are a test persona.",
+	}
+	withRubric, err := p.BuildSystemPromptWithRubric("us", nil, "PROVIDER RUBRIC TEXT")
+	if err != nil {
+		t.Fatalf("BuildSystemPromptWithRubric: %v", err)
+	}
+	plain, _ := p.BuildSystemPrompt("us", nil)
+	if withRubric != plain {
+		t.Errorf("non-expressive persona should be byte-identical:\n  with    = %q\n  without = %q", withRubric, plain)
+	}
+}
+
+func TestBuildSystemPromptWithRubric_PrependsProviderRubric(t *testing.T) {
+	p := &UserPersonaPack{
+		ID:           "p",
+		SystemPrompt: "Body text.",
+		Style:        PersonaStyle{Expressive: true},
+	}
+	got, err := p.BuildSystemPromptWithRubric("us", nil, "PROVIDER")
+	if err != nil {
+		t.Fatalf("BuildSystemPromptWithRubric: %v", err)
+	}
+	want := "PROVIDER\n\nBody text."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSystemPromptWithRubric_OverrideWinsOverProvider(t *testing.T) {
+	p := &UserPersonaPack{
+		ID:           "p",
+		SystemPrompt: "Body text.",
+		Style: PersonaStyle{
+			Expressive:             true,
+			CharacterizationRubric: "OVERRIDE",
+		},
+	}
+	got, _ := p.BuildSystemPromptWithRubric("us", nil, "PROVIDER")
+	want := "OVERRIDE\n\nBody text."
+	if got != want {
+		t.Errorf("override should win; got %q", got)
+	}
+}
+
+func TestBuildSystemPromptWithRubric_EmptyProviderRubricIsNoOp(t *testing.T) {
+	// Expressive=true but the provider returned empty (e.g., tts-1, mock).
+	// Result must NOT have a leading newline/blank from a phantom rubric.
+	p := &UserPersonaPack{
+		ID:           "p",
+		SystemPrompt: "Body text.",
+		Style:        PersonaStyle{Expressive: true},
+	}
+	got, _ := p.BuildSystemPromptWithRubric("us", nil, "")
+	if got != "Body text." {
+		t.Errorf("got %q, want %q", got, "Body text.")
+	}
+}
+
 func TestPersonaDefaults_Structure(t *testing.T) {
 	temp := float32(0.8)
 	seed := 123

--- a/runtime/tts/cartesia.go
+++ b/runtime/tts/cartesia.go
@@ -99,6 +99,16 @@ func (s *CartesiaService) ImplName() string { return "cartesia" }
 // ModelName returns the configured model name for cost tracking.
 func (s *CartesiaService) ModelName() string { return s.Model }
 
+// PersonaRubric implements [PersonaRubricProvider]. Returns the
+// emotion-only rubric: Cartesia's experimental controls accept a narrow
+// vocabulary (positivity / sadness / anger), so we advertise only the
+// tags the adapter actually maps. Other tags (e.g. whispers, pause) would
+// be dropped by lowerCartesiaMarkup, so we omit them from the rubric to
+// keep persona tokens focused on directives that move audio.
+func (s *CartesiaService) PersonaRubric() string {
+	return markup.RubricEmotionOnly
+}
+
 // cartesiaRequest is the request body for Cartesia TTS API.
 type cartesiaRequest struct {
 	ModelID       string               `json:"model_id"`

--- a/runtime/tts/cartesia_test.go
+++ b/runtime/tts/cartesia_test.go
@@ -194,6 +194,17 @@ func TestCartesiaService_Synthesize_PlainTextUnchanged(t *testing.T) {
 	}
 }
 
+func TestCartesiaService_PersonaRubric_AlwaysEmotionOnly(t *testing.T) {
+	// Cartesia returns the narrow emotion-only rubric regardless of model
+	// (Cartesia's experimental controls work the same across model IDs).
+	for _, model := range []string{CartesiaModelSonic, "sonic-2", "sonic-future"} {
+		s := NewCartesia("k", base.WithModel(model))
+		if got := s.PersonaRubric(); got != markup.RubricEmotionOnly {
+			t.Errorf("model=%s: expected RubricEmotionOnly, got len=%d", model, len(got))
+		}
+	}
+}
+
 func TestCartesiaEmotionForTag(t *testing.T) {
 	cases := map[string]string{
 		"excited":  "positivity:high",

--- a/runtime/tts/elevenlabs.go
+++ b/runtime/tts/elevenlabs.go
@@ -90,6 +90,17 @@ func (s *ElevenLabsService) ImplName() string { return "elevenlabs" }
 // ModelName returns the configured model name for cost tracking.
 func (s *ElevenLabsService) ModelName() string { return s.Model }
 
+// PersonaRubric implements [PersonaRubricProvider]. Returns the full markup
+// rubric on v3-class models (they consume bracket tags natively); older
+// models (v1, v2, turbo) speak the brackets literally, so we return the
+// empty string and the persona prompt is left untouched.
+func (s *ElevenLabsService) PersonaRubric() string {
+	if elevenLabsSupportsInlineTags(s.Model) {
+		return markup.RubricExpressiveFull
+	}
+	return ""
+}
+
 // elevenLabsRequest is the request body for ElevenLabs TTS API.
 type elevenLabsRequest struct {
 	Text          string                   `json:"text"`

--- a/runtime/tts/elevenlabs_test.go
+++ b/runtime/tts/elevenlabs_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tts/markup"
 )
 
 func TestNewElevenLabs(t *testing.T) {
@@ -202,6 +203,28 @@ func TestElevenLabsService_Synthesize_PlainTextUnchanged(t *testing.T) {
 
 		if got.Text != "Plain text without any tags." {
 			t.Errorf("model=%s: Text should be unchanged, got %q", model, got.Text)
+		}
+	}
+}
+
+func TestElevenLabsService_PersonaRubric_PerModel(t *testing.T) {
+	cases := map[string]bool{
+		ElevenLabsModelV3:             true,
+		"eleven_v3_alpha":             true,
+		ElevenLabsModelMultilingual:   false,
+		ElevenLabsModelTurbo:          false,
+		ElevenLabsModelEnglish:        false,
+		ElevenLabsModelMultilingualV1: false,
+	}
+	for model, wantRubric := range cases {
+		s := NewElevenLabs("k", base.WithModel(model))
+		got := s.PersonaRubric()
+		if wantRubric {
+			if got != markup.RubricExpressiveFull {
+				t.Errorf("model=%s: expected RubricExpressiveFull, got len=%d", model, len(got))
+			}
+		} else if got != "" {
+			t.Errorf("model=%s: expected empty rubric, got %q", model, got)
 		}
 	}
 }

--- a/runtime/tts/markup/rubrics.go
+++ b/runtime/tts/markup/rubrics.go
@@ -1,0 +1,49 @@
+package markup
+
+// Persona rubric constants are system-prompt fragments that consumer code
+// (self-play personas, scripted-text turns, SDK extractors) splices into
+// an LLM's system prompt so the LLM emits canonical bracket tags. Each
+// provider variant lists only the tags that provider can actually act on
+// — sending a Cartesia persona a [whispers] suggestion would just waste
+// tokens, because the Cartesia adapter drops it.
+//
+// Each provider's adapter returns one of these via PersonaRubricProvider
+// (declared in runtime/tts/service.go). The strings are public so SDK
+// consumers can re-use them for non-self-play surfaces (custom personas,
+// scripted authoring tools, docs).
+
+// RubricExpressiveFull lists every tag in the canonical taxonomy. Provider
+// adapters that consume the full vocabulary (OpenAI gpt-4o-mini-tts via the
+// instructions field, ElevenLabs v3 inline tags) return this string.
+const RubricExpressiveFull = `When you want to add emotional or vocal characterization
+to spoken output, wrap text in bracket tags. Use at most one or two per turn
+— sparingly, only when the directive genuinely matters. Available tags:
+
+  [whispers]  ...  [/]   speak the wrapped span as a whisper
+  [shouts]    ...  [/]   speak the wrapped span at high volume
+  [laughs]    ...  [/]   render the wrapped span with a chuckle
+  [sighs]     ...  [/]   render the wrapped span with a sigh
+  [excited]   ...  [/]   warm, upbeat delivery
+  [sad]       ...  [/]   downbeat, slower delivery
+  [smile]     ...  [/]   a smile in the voice
+  [calm]      ...  [/]   slower, measured pace
+  [pause:Ns]              insert a pause of N (e.g. 300ms, 1s)
+
+A new tag implicitly closes the previous span. [/] closes the current span
+explicitly. Tags you do not need can be omitted; do not invent new tag names.`
+
+// RubricEmotionOnly lists only the tags Cartesia maps to its emotion array.
+// Cartesia's vocabulary is narrow (positivity / sadness / anger), so any
+// other tag we include here would be silently dropped by the adapter.
+const RubricEmotionOnly = `When you want to color spoken output emotionally, wrap text
+in bracket tags. Use at most one or two per turn. Available tags:
+
+  [excited]   ...  [/]   upbeat, energetic delivery
+  [laughs]    ...  [/]   render the wrapped span with a chuckle
+  [smile]     ...  [/]   a smile in the voice
+  [sad]       ...  [/]   downbeat, slower delivery
+  [sighs]     ...  [/]   render the wrapped span with a sigh
+  [shouts]    ...  [/]   render the wrapped span as if shouting
+
+A new tag implicitly closes the previous span. [/] closes the current span
+explicitly. Do not invent new tag names.`

--- a/runtime/tts/openai.go
+++ b/runtime/tts/openai.go
@@ -110,6 +110,18 @@ func (s *OpenAIService) ImplName() string { return "openai" }
 // ModelName returns the configured model name for cost tracking.
 func (s *OpenAIService) ModelName() string { return s.Model }
 
+// PersonaRubric implements [PersonaRubricProvider]. Returns the full
+// markup rubric on gpt-4o-mini-tts (the model honors arbitrary instructions
+// via the request's instructions field). Older models (tts-1, tts-1-hd) do
+// not understand the markup, so we return the empty string — emitting tags
+// would just waste persona tokens.
+func (s *OpenAIService) PersonaRubric() string {
+	if s.Model == ModelGPT4oMiniTTS {
+		return markup.RubricExpressiveFull
+	}
+	return ""
+}
+
 // openAIRequest is the request body for OpenAI TTS API.
 type openAIRequest struct {
 	Model          string  `json:"model"`

--- a/runtime/tts/openai_test.go
+++ b/runtime/tts/openai_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tts/markup"
 )
 
 func TestNewOpenAI(t *testing.T) {
@@ -246,6 +247,31 @@ func TestOpenAIService_Synthesize_PlainTextUnchanged(t *testing.T) {
 
 	if strings.Contains(string(raw), `"instructions"`) {
 		t.Errorf("instructions field should be omitted for plain text; got body %s", raw)
+	}
+}
+
+func TestOpenAIService_PersonaRubric_PerModel(t *testing.T) {
+	// gpt-4o-mini-tts honors the `instructions` field — full rubric.
+	// tts-1 / tts-1-hd ignore it — empty so we don't waste persona tokens.
+	cases := map[string]bool{
+		ModelGPT4oMiniTTS: true,
+		ModelTTS1:         false,
+		ModelTTS1HD:       false,
+		"unknown-model":   false,
+	}
+	for model, wantRubric := range cases {
+		s := NewOpenAI("k", base.WithModel(model))
+		got := s.PersonaRubric()
+		if wantRubric {
+			if got == "" {
+				t.Errorf("model=%s: expected non-empty rubric", model)
+			}
+			if got != markup.RubricExpressiveFull {
+				t.Errorf("model=%s: rubric does not match RubricExpressiveFull", model)
+			}
+		} else if got != "" {
+			t.Errorf("model=%s: expected empty rubric, got %q", model, got)
+		}
 	}
 }
 

--- a/runtime/tts/service.go
+++ b/runtime/tts/service.go
@@ -46,6 +46,19 @@ type StreamingService interface {
 	SynthesizeStream(ctx context.Context, text string, config SynthesisConfig) (<-chan audio.Chunk, error)
 }
 
+// PersonaRubricProvider is an optional extension interface that TTS adapters
+// implement to advertise the bracket-tag rubric an upstream persona / script
+// should splice into its system prompt. Implementations return the empty
+// string when the configured model cannot consume characterization markup —
+// callers MUST treat the empty string as "do not inject any rubric" so we
+// do not waste persona tokens on tags that would be silently dropped.
+//
+// See [github.com/AltairaLabs/PromptKit/runtime/tts/markup] for the canonical
+// rubric strings each adapter may return.
+type PersonaRubricProvider interface {
+	PersonaRubric() string
+}
+
 // SynthesisConfig configures text-to-speech synthesis.
 type SynthesisConfig struct {
 	// Voice is the voice ID to use for synthesis.

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1621,6 +1621,12 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "expressive": {
+          "type": "boolean"
+        },
+        "characterization_rubric": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/persona.json
+++ b/schemas/v1alpha1/persona.json
@@ -78,6 +78,12 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "expressive": {
+          "type": "boolean"
+        },
+        "characterization_rubric": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/selfplay/audio_generator.go
+++ b/tools/arena/selfplay/audio_generator.go
@@ -85,11 +85,22 @@ type AudioContentGenerator struct {
 
 // NewAudioContentGenerator creates a new audio content generator.
 // textGenerator may be nil for TTS-only generators.
+//
+// When the TTS service exposes a PersonaRubric (see [tts.PersonaRubricProvider]),
+// it is forwarded to the underlying text generator so that personas opting in
+// via style.expressive get a provider-tuned rubric prepended to their system
+// prompt (issue #1130). Providers that do not implement the interface, or
+// implement it and return the empty string, are no-ops.
 func NewAudioContentGenerator(
 	textGenerator *ContentGenerator,
 	ttsService base.TTSProvider,
 	ttsConfig *config.TTSConfig,
 ) *AudioContentGenerator {
+	if textGenerator != nil {
+		if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
+			textGenerator.WithProviderRubric(rp.PersonaRubric())
+		}
+	}
 	return &AudioContentGenerator{
 		textGenerator: textGenerator,
 		ttsService:    ttsService,

--- a/tools/arena/selfplay/generator.go
+++ b/tools/arena/selfplay/generator.go
@@ -20,8 +20,9 @@ const selfPlayUserRole = "self-play user"
 
 // ContentGenerator generates user messages using an LLM
 type ContentGenerator struct {
-	provider providers.Provider
-	persona  *config.UserPersonaPack
+	provider       providers.Provider
+	persona        *config.UserPersonaPack
+	providerRubric string
 }
 
 // NewContentGenerator creates a new content generator with a specific provider and persona
@@ -30,6 +31,16 @@ func NewContentGenerator(provider providers.Provider, persona *config.UserPerson
 		provider: provider,
 		persona:  persona,
 	}
+}
+
+// WithProviderRubric sets the TTS provider's characterization rubric that
+// will be prepended to the persona's system prompt when the persona has
+// opted in via style.expressive. Empty string disables the rubric (no-op
+// for personas that did not opt in, and the explicit "this provider does
+// not support characterization" signal otherwise). See issue #1130.
+func (cg *ContentGenerator) WithProviderRubric(rubric string) *ContentGenerator {
+	cg.providerRubric = rubric
+	return cg
 }
 
 // extractRegionFromPersonaID extracts the region suffix from a persona ID
@@ -196,7 +207,8 @@ func (cg *ContentGenerator) NextUserTurn(
 	}
 
 	stages := []stage.Stage{
-		arenastages.NewPersonaAssemblyStageWithTurnState(cg.persona, region, baseVariables, turnState),
+		arenastages.NewPersonaAssemblyStageWithTurnState(cg.persona, region, baseVariables, turnState).
+			WithProviderRubric(cg.providerRubric),
 	}
 
 	// Append natural termination instruction when enabled

--- a/tools/arena/stages/persona_assembly.go
+++ b/tools/arena/stages/persona_assembly.go
@@ -13,16 +13,19 @@ import (
 // fragment/template system as PromptAssemblyStage.
 //
 // This stage mirrors the behavior of PromptAssemblyMiddleware but for personas:
-// - Uses persona's BuildSystemPrompt() which handles fragment assembly
-// - Supports template variable substitution with {{variable}} syntax
-// - Injects persona-specific variables (goals, constraints, style)
-// - Writes the rendered system prompt and base variables into TurnState
+//   - Uses persona's BuildSystemPrompt() which handles fragment assembly
+//   - Supports template variable substitution with {{variable}} syntax
+//   - Injects persona-specific variables (goals, constraints, style)
+//   - Optionally prepends a TTS characterization rubric when the persona
+//     has opted in via style.expressive (see issue #1130)
+//   - Writes the rendered system prompt and base variables into TurnState
 type PersonaAssemblyStage struct {
 	stage.BaseStage
-	persona       *config.UserPersonaPack
-	region        string
-	baseVariables map[string]string
-	turnState     *stage.TurnState
+	persona        *config.UserPersonaPack
+	region         string
+	baseVariables  map[string]string
+	turnState      *stage.TurnState
+	providerRubric string
 }
 
 // NewPersonaAssemblyStageWithTurnState creates a persona assembly stage that
@@ -42,6 +45,15 @@ func NewPersonaAssemblyStageWithTurnState(
 	}
 }
 
+// WithProviderRubric sets the TTS provider's characterization rubric. The
+// stage uses it as the default when the persona opts into expressive output
+// (style.expressive) and does not provide its own override. Empty string
+// disables the default and is the no-op path for non-expressive providers.
+func (s *PersonaAssemblyStage) WithProviderRubric(rubric string) *PersonaAssemblyStage {
+	s.providerRubric = rubric
+	return s
+}
+
 // Process assembles the persona prompt and writes it into TurnState. All input
 // elements are forwarded unchanged.
 //
@@ -49,11 +61,14 @@ func NewPersonaAssemblyStageWithTurnState(
 func (s *PersonaAssemblyStage) Process(ctx context.Context, input <-chan stage.StreamElement, output chan<- stage.StreamElement) error {
 	defer close(output)
 
-	// Use persona's BuildSystemPrompt which handles:
+	// Use persona's BuildSystemPromptWithRubric which handles:
 	// - Fragment assembly (if persona uses fragments)
 	// - Template variable substitution
 	// - Persona-specific variable injection (goals, constraints, style)
-	systemPrompt, err := s.persona.BuildSystemPrompt(s.region, s.baseVariables)
+	// - Optional TTS characterization rubric prefix (when style.expressive
+	//   is set on the persona; otherwise the rubric argument is ignored
+	//   and the result is byte-identical to BuildSystemPrompt)
+	systemPrompt, err := s.persona.BuildSystemPromptWithRubric(s.region, s.baseVariables, s.providerRubric)
 	if err != nil {
 		return fmt.Errorf("failed to assemble persona prompt: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes #1130. Follow-up to the #1081 TTS characterization series — the parser and provider adapters were dark until personas opt in to emit bracket tags. This PR makes that opt-in trivial.

## What's added

**Rubric strings** (\`runtime/tts/markup/rubrics.go\`):
- \`RubricExpressiveFull\` — every canonical tag (whispers, shouts, laughs, sighs, excited, sad, smile, calm, pause). For providers that consume the full vocabulary.
- \`RubricEmotionOnly\` — narrow positivity/sadness/anger subset for Cartesia, whose emotion array maps only those.

**Optional interface** (\`runtime/tts/service.go\`):
\`\`\`go
type PersonaRubricProvider interface {
    PersonaRubric() string  // \"\" = provider can't use characterization
}
\`\`\`

**Per-adapter implementations**:
| Provider | Returns |
|---|---|
| OpenAI on \`gpt-4o-mini-tts\` | \`RubricExpressiveFull\` |
| OpenAI on \`tts-1\` / \`tts-1-hd\` | \`\"\"\` |
| ElevenLabs v3 | \`RubricExpressiveFull\` |
| ElevenLabs non-v3 | \`\"\"\` |
| Cartesia | \`RubricEmotionOnly\` |

**Persona opt-in** (\`pkg/config/persona.go\`):
- \`PersonaStyle.Expressive bool\` — gate (default false; existing personas byte-identical).
- \`PersonaStyle.CharacterizationRubric string\` — verbatim override.
- New \`BuildSystemPromptWithRubric\` that implements the precedence rules from #1130 (no-opt = pass-through; opt-in = override-wins-else-provider-rubric).

**Arena plumbing**:
- \`PersonaAssemblyStage.WithProviderRubric\` setter.
- \`ContentGenerator.WithProviderRubric\` setter.
- \`AudioContentGenerator\` type-asserts the TTS service for \`PersonaRubricProvider\` at construction and forwards the rubric to its text generator. Zero-config for the demo path.

**Demo** (\`examples/voice-refund-demo/personas/aggressive-entitled.persona.yaml\`):
- Opts in via \`style.expressive: true\`. Once the demo runs against \`gpt-4o-mini-tts\` / ElevenLabs v3 / Cartesia, the persona will receive the appropriate rubric in its system prompt and start emitting tags the adapter actually acts on.

## Test plan

- [x] Per-provider \`PersonaRubric()\` tests for supported/unsupported models.
- [x] \`BuildSystemPromptWithRubric\` precedence tests — no-opt, opt-in+override, opt-in+provider, opt-in+empty-provider.
- [x] \`go build ./...\` clean
- [x] Pre-commit hook (lint + coverage) green; every changed file meets the 80% threshold.
- [ ] CI green
- [ ] SonarCloud quality gate green
- [ ] Live smoke against the voice-refund-demo with a real TTS provider (manual, post-merge)