### PR TITLE
feat(arena): TTSConfig.Model + demos that exercise characterization

### DIFF
--- a/examples/duplex-streaming/personas/busy-professional.persona.yaml
+++ b/examples/duplex-streaming/personas/busy-professional.persona.yaml
@@ -54,3 +54,9 @@ spec:
     verbosity: short
     formality: casual
     challenge_level: low
+    # Opt into TTS characterization markup. The persona naturally hits
+    # moments of light impatience ("[sighs]") and brief warmth
+    # ("[smile]") — markup tags surface those shifts to the listener
+    # when paired with an expressive provider (gpt-4o-mini-tts /
+    # eleven_v3 / cartesia).
+    expressive: true

--- a/examples/duplex-streaming/scenarios/duplex-tools.scenario.yaml
+++ b/examples/duplex-streaming/scenarios/duplex-tools.scenario.yaml
@@ -57,7 +57,11 @@ spec:
       persona: busy-professional
       turns: 4
       tts:
+        # gpt-4o-mini-tts honors expressive instructions, so the
+        # busy-professional persona's "[sighs]" / "[smile]" markup
+        # gets passed through as delivery cues.
         provider: openai
+        model: gpt-4o-mini-tts
         voice: alloy
       assertions:
         # Each turn should get a substantive response

--- a/examples/voice-refund-demo/personas/impersonator.persona.yaml
+++ b/examples/voice-refund-demo/personas/impersonator.persona.yaml
@@ -44,3 +44,7 @@ spec:
     friction_tags:
       - evasive
       - persistent
+    # Opt into TTS characterization markup so the LLM can emit "[sighs]"
+    # before a deflection or "[calm]" when feigning patience — the
+    # impersonator's tactic-shifting maps naturally to delivery shifts.
+    expressive: true

--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -39,7 +39,12 @@ spec:
       persona: aggressive-entitled
       turns: 4
       tts:
+        # gpt-4o-mini-tts unlocks the persona characterization rubric so the
+        # aggressive-entitled persona's "[shouts]" / "[sighs]" markup gets
+        # passed through as expressive `instructions`. tts-1 would strip
+        # tags and ignore directives.
         provider: openai
+        model: gpt-4o-mini-tts
         voice: onyx
         sample_rate: 24000
       assertions:

--- a/examples/voice-refund-demo/scenarios/impersonator-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/impersonator-refund.scenario.yaml
@@ -39,7 +39,11 @@ spec:
       persona: impersonator
       turns: 4
       tts:
+        # gpt-4o-mini-tts unlocks expressive output for personas with
+        # style.expressive: true. The impersonator switches between
+        # sympathetic and threatening; markup tags carry that contrast.
         provider: openai
+        model: gpt-4o-mini-tts
         voice: shimmer
         sample_rate: 24000
       assertions:

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -913,6 +913,14 @@ type TTSConfig struct {
 	Provider string `json:"provider" yaml:"provider"`
 	// Voice is the voice ID to use for synthesis.
 	Voice string `json:"voice" yaml:"voice"`
+	// Model overrides the provider's default TTS model. Examples:
+	//   openai: "tts-1", "tts-1-hd", "gpt-4o-mini-tts"
+	//   elevenlabs: "eleven_v3", "eleven_multilingual_v2", "eleven_turbo_v2_5"
+	//   cartesia: "sonic-3"
+	// When empty, each provider's adapter falls back to its own default.
+	// Picking gpt-4o-mini-tts / eleven_v3 also unlocks the persona
+	// characterization rubric (see PersonaStyle.Expressive).
+	Model string `json:"model,omitempty" yaml:"model,omitempty"`
 	// AudioFiles is a list of PCM audio files to use for mock TTS provider.
 	// When provider is "mock", these files are loaded and rotated through for each synthesis call.
 	// Paths are relative to the scenario file location.

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2329,6 +2329,9 @@
         "voice": {
           "type": "string"
         },
+        "model": {
+          "type": "string"
+        },
         "audio_files": {
           "items": {
             "type": "string"

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -356,6 +356,9 @@
         "voice": {
           "type": "string"
         },
+        "model": {
+          "type": "string"
+        },
         "audio_files": {
           "items": {
             "type": "string"

--- a/tools/arena/selfplay/tts_registry.go
+++ b/tools/arena/selfplay/tts_registry.go
@@ -139,6 +139,18 @@ func (r *TTSRegistry) GetWithConfig(cfg *config.TTSConfig) (base.TTSProvider, er
 		return svc, nil
 	}
 
+	// When the scenario pins a model, instantiate the provider directly
+	// and skip the per-provider singleton cache — different scenarios may
+	// pick different models (e.g. tts-1 for cheap takes, gpt-4o-mini-tts
+	// for expressive takes) and must not share one service.
+	if cfg.Model != "" {
+		svc, err := r.createServiceWithModel(cfg.Provider, cfg.Model)
+		if err != nil {
+			return nil, err
+		}
+		return wrapWithDiskCache(cfg.Provider, svc), nil
+	}
+
 	// For all other cases, use the standard cached lookup
 	return r.Get(cfg.Provider)
 }
@@ -151,15 +163,23 @@ func (r *TTSRegistry) Register(provider string, svc base.TTSProvider) {
 	r.services[provider] = svc
 }
 
-// createService creates a new TTS provider for the given provider name.
+// createService creates a new TTS provider for the given provider name
+// using the adapter's default model.
 func (r *TTSRegistry) createService(provider string) (base.TTSProvider, error) {
+	return r.createServiceWithModel(provider, "")
+}
+
+// createServiceWithModel creates a new TTS provider, optionally pinning a
+// specific model. Empty model = adapter default. Used by GetWithConfig
+// when a scenario / role pins a model via TTSConfig.Model.
+func (r *TTSRegistry) createServiceWithModel(provider, model string) (base.TTSProvider, error) {
 	switch provider {
 	case TTSProviderOpenAI:
-		return r.createOpenAI()
+		return r.createOpenAI(model)
 	case TTSProviderElevenLabs:
-		return r.createElevenLabs()
+		return r.createElevenLabs(model)
 	case TTSProviderCartesia:
-		return r.createCartesia()
+		return r.createCartesia(model)
 	case TTSProviderMock:
 		return r.createMock()
 	default:
@@ -196,35 +216,53 @@ func (r *TTSRegistry) createMock() (base.TTSProvider, error) {
 	return NewMockTTS(), nil
 }
 
-// createOpenAI creates an OpenAI TTS provider.
-func (r *TTSRegistry) createOpenAI() (base.TTSProvider, error) {
+// createOpenAI creates an OpenAI TTS provider. When model is empty, the
+// adapter's default (tts-1) applies; pass "gpt-4o-mini-tts" to unlock the
+// expressive instructions field and the persona characterization rubric.
+func (r *TTSRegistry) createOpenAI(model string) (base.TTSProvider, error) {
 	apiKey := os.Getenv(envOpenAIAPIKey)
 	if apiKey == "" {
 		return nil, fmt.Errorf("openAI TTS requires %s environment variable", envOpenAIAPIKey)
 	}
-	return tts.NewOpenAI(apiKey), nil
+	opts := []base.HTTPServiceOption{}
+	if model != "" {
+		opts = append(opts, base.WithModel(model))
+	}
+	return tts.NewOpenAI(apiKey, opts...), nil
 }
 
 // createElevenLabs creates an ElevenLabs TTS provider.
 //
-// Selfplay uses turbo_v2_5 because it's optimized for real-time conversational
-// agents (~250ms TTFB vs ~1s for multilingual_v2). The default
-// multilingual_v2 model would dominate per-turn latency.
-func (r *TTSRegistry) createElevenLabs() (base.TTSProvider, error) {
+// Selfplay defaults to turbo_v2_5 because it's optimized for real-time
+// conversational agents (~250ms TTFB vs ~1s for multilingual_v2). The
+// default multilingual_v2 model would dominate per-turn latency. Pass
+// "eleven_v3" (or any "eleven_v3*") to unlock inline characterization
+// tags and the persona rubric.
+func (r *TTSRegistry) createElevenLabs(model string) (base.TTSProvider, error) {
 	apiKey := os.Getenv(envElevenLabsAPIKey)
 	if apiKey == "" {
 		return nil, fmt.Errorf("elevenLabs TTS requires %s environment variable", envElevenLabsAPIKey)
 	}
-	return tts.NewElevenLabs(apiKey, base.WithModel(tts.ElevenLabsModelTurbo)), nil
+	if model == "" {
+		model = tts.ElevenLabsModelTurbo
+	}
+	return tts.NewElevenLabs(apiKey, base.WithModel(model)), nil
 }
 
-// createCartesia creates a Cartesia TTS provider.
-func (r *TTSRegistry) createCartesia() (base.TTSProvider, error) {
+// createCartesia creates a Cartesia TTS provider. Empty model = adapter
+// default (sonic-3); Cartesia's PersonaRubric returns the emotion-only
+// rubric regardless of model, so no model override is needed to unlock
+// expressive personas on Cartesia.
+func (r *TTSRegistry) createCartesia(model string) (base.TTSProvider, error) {
 	apiKey := os.Getenv(envCartesiaAPIKey)
 	if apiKey == "" {
 		return nil, fmt.Errorf("cartesia TTS requires %s environment variable", envCartesiaAPIKey)
 	}
-	return tts.NewCartesia(apiKey), nil
+	opts := []base.HTTPServiceOption{}
+	if model != "" {
+		opts = append(opts, base.WithModel(model))
+	}
+	return tts.NewCartesia(apiKey, opts...), nil
 }
 
 // SupportedProviders returns a list of supported TTS provider names.

--- a/tools/arena/selfplay/tts_registry_test.go
+++ b/tools/arena/selfplay/tts_registry_test.go
@@ -119,6 +119,49 @@ func TestTTSRegistry_Get_WithAPIKey(t *testing.T) {
 	}
 }
 
+func TestTTSRegistry_GetWithConfig_ModelOverride(t *testing.T) {
+	// Pinning a model via TTSConfig.Model should:
+	//   1. Bypass the per-provider singleton cache (a scenario picking
+	//      gpt-4o-mini-tts must not get the cached tts-1 instance).
+	//   2. Yield a service whose ModelName() reflects the override.
+	//   3. Expose the matching PersonaRubric for expressive personas.
+	registry := NewTTSRegistry()
+	t.Setenv(envOpenAIAPIKey, "test-key")
+
+	def, err := registry.Get(TTSProviderOpenAI)
+	if err != nil {
+		t.Fatalf("Get default: %v", err)
+	}
+
+	override, err := registry.GetWithConfig(&config.TTSConfig{
+		Provider: TTSProviderOpenAI,
+		Voice:    "alloy",
+		Model:    tts.ModelGPT4oMiniTTS,
+	})
+	if err != nil {
+		t.Fatalf("GetWithConfig override: %v", err)
+	}
+
+	if def == override {
+		t.Error("model-pinned service should be a separate instance from the default-cached one")
+	}
+
+	modelExposer, ok := override.(interface{ ModelName() string })
+	if !ok {
+		t.Skip("override service does not expose ModelName(); skipping detailed check")
+	} else if got := modelExposer.ModelName(); got != tts.ModelGPT4oMiniTTS {
+		t.Errorf("override ModelName = %q, want %q", got, tts.ModelGPT4oMiniTTS)
+	}
+
+	rp, ok := override.(tts.PersonaRubricProvider)
+	if !ok {
+		t.Fatal("override should still satisfy PersonaRubricProvider")
+	}
+	if rp.PersonaRubric() == "" {
+		t.Error("gpt-4o-mini-tts override should expose a non-empty PersonaRubric")
+	}
+}
+
 func TestTTSRegistry_Get_Caching(t *testing.T) {
 	registry := NewTTSRegistry()
 	t.Setenv(envOpenAIAPIKey, "test-key")


### PR DESCRIPTION
## Summary

Follow-up to #1131. The persona rubric only fires when the configured TTS provider supports characterization, but the registry was hardcoding \`tts-1\` / \`eleven_turbo_v2_5\` — both of which return \`PersonaRubric() == \"\"\`. This PR adds the missing knob (\`TTSConfig.Model\`) and updates the two realtime audio demos so the new feature is audible in recordings.

## Runtime change

- New \`TTSConfig.Model\` field (yaml: \`model\`) — overrides the adapter default per-scenario. Empty preserves existing behavior.
- \`TTSRegistry.GetWithConfig\` now bypasses the per-provider singleton cache when \`Model\` is set; the previous behavior would have made a \`tts-1\` scenario and a \`gpt-4o-mini-tts\` scenario share one cached client.
- \`createOpenAI\` / \`createElevenLabs\` / \`createCartesia\` take an optional model arg and fall back to their previous defaults when empty.

Schemas regenerated.

## Demo updates

| Demo | Scenario | TTS change | Persona opt-in |
|---|---|---|---|
| voice-refund-demo | aggressive-refund | \`model: gpt-4o-mini-tts\` | aggressive-entitled (already opted-in by #1131) |
| voice-refund-demo | impersonator-refund | \`model: gpt-4o-mini-tts\` | impersonator (new) |
| voice-refund-demo | patient-baseline | unchanged | unchanged (flat for contrast) |
| duplex-streaming | duplex-tools | \`model: gpt-4o-mini-tts\` | busy-professional (new) |

Other duplex-streaming scenarios (curious-customer baseline) left flat so the recordings have an obvious contrast between expressive and non-expressive personas.

## Test plan

- [x] \`TestTTSRegistry_GetWithConfig_ModelOverride\` — model-pinned services bypass the cache and expose a non-empty PersonaRubric on \`gpt-4o-mini-tts\`.
- [x] \`go build ./...\` clean
- [x] Pre-commit hook (lint + coverage) green; changed files ≥80%.
- [ ] CI green
- [ ] SonarCloud quality gate green
- [ ] Live smoke against \`voice-refund-demo\` with a real \`OPENAI_API_KEY\` (manual, post-merge)