### PR TITLE
fix(arena/web): share playback timeline so scripted turns don't overlap

### DIFF
--- a/tools/arena/web/frontend/src/audio/player.test.ts
+++ b/tools/arena/web/frontend/src/audio/player.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { base64ToInt16, int16ToFloat32 } from "./player";
+import {
+  base64ToInt16,
+  int16ToFloat32,
+  newPlaybackTimeline,
+  scheduleFrame,
+} from "./player";
 
 describe("base64ToInt16", () => {
   it("decodes empty string to empty Int16Array", () => {
@@ -45,5 +50,43 @@ describe("int16ToFloat32", () => {
     const b64 = btoa(String.fromCharCode(...bytes));
     const float = int16ToFloat32(base64ToInt16(b64));
     expect(float[0]).toBeCloseTo(0.5, 6);
+  });
+});
+
+describe("scheduleFrame", () => {
+  it("schedules the first frame at now when timeline is empty", () => {
+    const r = scheduleFrame(newPlaybackTimeline(), "output", 0.5, 1.0);
+    expect(r.startAt).toBe(1.0);
+    expect(r.timeline.nextStart).toBe(1.5);
+  });
+
+  it("serializes back-to-back frames in the same direction", () => {
+    let t = newPlaybackTimeline();
+    let r = scheduleFrame(t, "output", 1.0, 0);
+    t = r.timeline;
+    r = scheduleFrame(t, "output", 0.5, 0.1);
+    expect(r.startAt).toBe(1.0); // not 0.1 — must follow first frame's tail
+    expect(r.timeline.nextStart).toBe(1.5);
+  });
+
+  // This is the demo overlap bug. With the old per-direction logic, a fresh
+  // input frame would start immediately even though output is still playing.
+  // The fix is to share one nextStart across directions so scripted turns
+  // serialize cleanly.
+  it("serializes frames regardless of direction (no left-right overlap)", () => {
+    let t = newPlaybackTimeline();
+    // 2s of agent output
+    let r = scheduleFrame(t, "output", 2.0, 0);
+    t = r.timeline;
+    // user input frame arrives at now=0.5 — must wait for output to finish
+    r = scheduleFrame(t, "input", 1.0, 0.5);
+    expect(r.startAt).toBe(2.0);
+    expect(r.timeline.nextStart).toBe(3.0);
+  });
+
+  it("falls back to now when the timeline has fallen into the past", () => {
+    const r = scheduleFrame({ nextStart: 1.0 }, "input", 0.5, 5.0);
+    expect(r.startAt).toBe(5.0);
+    expect(r.timeline.nextStart).toBe(5.5);
   });
 });

--- a/tools/arena/web/frontend/src/audio/player.ts
+++ b/tools/arena/web/frontend/src/audio/player.ts
@@ -16,11 +16,45 @@ interface AudioFrame {
   samples: string; // base64 s16le
 }
 
+export type Direction = "input" | "output";
+
+// PlaybackTimeline holds a single shared "next start" instant across both
+// directions. Scripted self-play demos rely on this — without it the user
+// (left) and agent (right) timelines drift independently and consecutive
+// turns audibly overlap on the demo.
+export interface PlaybackTimeline {
+  nextStart: number;
+}
+
+export const newPlaybackTimeline = (): PlaybackTimeline => ({ nextStart: 0 });
+
+export interface FrameSchedule {
+  startAt: number;
+  timeline: PlaybackTimeline;
+}
+
+// scheduleFrame returns the AudioContext start time for a new frame and an
+// updated timeline. The same `nextStart` is used for both directions so a
+// user-side frame waits for an in-flight agent tail to finish instead of
+// stepping on it.
+export function scheduleFrame(
+  timeline: PlaybackTimeline,
+  _direction: Direction,
+  durationSec: number,
+  now: number,
+): FrameSchedule {
+  const startAt = Math.max(now, timeline.nextStart);
+  return {
+    startAt,
+    timeline: { nextStart: startAt + durationSec },
+  };
+}
+
 export class AudioPlayer {
   private readonly ctx: AudioContext;
   private readonly leftPanner: StereoPannerNode;
   private readonly rightPanner: StereoPannerNode;
-  private nextStartTime: Record<"input" | "output", number> = { input: 0, output: 0 };
+  private timeline: PlaybackTimeline = newPlaybackTimeline();
   private source: EventSource | null = null;
   private readonly opts: AudioPlayerOptions;
 
@@ -43,8 +77,8 @@ export class AudioPlayer {
    * user has clicked anything; frames arrive but stay silent until play(). */
   connect(eventsUrl: string): void {
     if (this.source) return;
-    // Reset scheduling clocks each session.
-    this.nextStartTime = { input: 0, output: 0 };
+    // Reset scheduling clock each session.
+    this.timeline = newPlaybackTimeline();
     const url = `${eventsUrl}?audio=1`;
     this.source = new EventSource(url);
     this.source.addEventListener("audio", (ev) => this.onAudio(ev));
@@ -101,10 +135,14 @@ export class AudioPlayer {
       const panner = frame.direction === "input" ? this.leftPanner : this.rightPanner;
       node.connect(panner);
 
-      const now = this.ctx.currentTime;
-      const startAt = Math.max(now, this.nextStartTime[frame.direction]);
+      const { startAt, timeline } = scheduleFrame(
+        this.timeline,
+        frame.direction,
+        buffer.duration,
+        this.ctx.currentTime,
+      );
       node.start(startAt);
-      this.nextStartTime[frame.direction] = startAt + buffer.duration;
+      this.timeline = timeline;
     } catch (err) {
       this.opts.onError?.(`audio decode error: ${err}`);
     }


### PR DESCRIPTION
## Summary

`AudioPlayer` in `tools/arena/web/frontend/src/audio/player.ts` scheduled frames on **independent per-direction clocks** (`nextStartTime.input` vs `.output`). A fresh user-side input frame for a self-play turn would start at `AudioContext.currentTime` regardless of how much agent audio was still queued on the output timeline — so on the voice-refund demo, the next self-play user could audibly start in the left ear while the agent was still finishing in the right ear at every turn boundary.

Fix: extract scheduling into a pure `scheduleFrame(timeline, direction, durationSec, now)` that uses **one shared `nextStart`**, and route `AudioPlayer.onAudio` through it. Scripted turns now serialize cleanly across directions; same-direction back-to-back frames are unchanged.

## Caveat

This addresses the overlap source I could deterministically reproduce in a vitest spec. If the live demo still overlaps after this lands, the bug is server-side (executor / drain) and needs a separate Go integration test — there's no existing test for inter-turn drain.

## Test plan

- [x] `scheduleFrame` — empty timeline schedules at now, back-to-back same-direction serializes, **back-to-back cross-direction serializes** (the overlap repro), past-timeline falls back to now.
- [x] All existing player tests (`base64ToInt16`, `int16ToFloat32`) still pass.
- [x] `npm run build` clean (`tsc -b && vite build`).