### PR TITLE
fix(sdk/integration): wait for every contracted event before snapshotting

### DIFF
--- a/sdk/integration/contract_template_test.go
+++ b/sdk/integration/contract_template_test.go
@@ -51,10 +51,20 @@ func TestContract_TemplateStage(t *testing.T) {
 			_, err := conv.Send(context.Background(), "x")
 			require.NoError(t, err)
 
-			// EventBus is async; wait for the rendered event before snapshotting
-			// so we don't false-fail with count == 0 due to in-flight delivery.
-			require.True(t, p.WaitForCount("events.prompt.template.rendered", 1, 10*time.Second),
-				"timed out waiting for prompt.template.rendered to land")
+			// EventBus dispatches events through a 10-worker pool, so the
+			// `started` and `rendered` events the stage emits in order land
+			// at the listener in any order. Waiting only for `rendered`
+			// produced flakes where the snapshot saw rendered=1 but
+			// started=0 because the worker for `started` hadn't reached
+			// the increment yet. Wait for every event the contract demands
+			// before snapshotting.
+			for op, bound := range contract.PerSend {
+				if bound.Min <= 0 {
+					continue
+				}
+				require.Truef(t, p.WaitForCount(op, bound.Min, 10*time.Second),
+					"timed out waiting for %s to reach %d", op, bound.Min)
+			}
 
 			contract.AssertHolds(t, p.Snapshot())
 		})


### PR DESCRIPTION
## Summary

`TestContract_TemplateStage` flaked on CI with `events.prompt.template.started: got 0, want exactly 1` while `events.prompt.template.rendered` was correctly 1. There is no production code path that emits `rendered` without first emitting `started` — `runtime/pipeline/stage/stages_utilities.go:215-254` always fires `Started` (line 227) before `Rendered` (line 244).

The race is in test infrastructure: `runtime/events/bus.go` dispatches via a 10-worker pool. The emitter publishes `Started` then `Rendered` in order, but workers grab them concurrently — the listener invocations interleave, so the `Rendered` counter can land first. The test only called `WaitForCount` for `rendered` and snapshotted, catching the in-flight `started` increment.

Fix: wait for every event the contract declares a positive `Min` for, not just `rendered`.

## Test plan

- [x] `go test ./sdk/integration/ -run TestContract_TemplateStage -count=100 -race` — 100/100 pass locally.
- [x] Pre-commit (lint + sdk test suite) green.