### PR TITLE
fix(demo): revert voice-refund scenarios from gpt-4o-mini-tts back to tts-1

### DIFF
--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -39,12 +39,12 @@ spec:
       persona: aggressive-entitled
       turns: 4
       tts:
-        # gpt-4o-mini-tts unlocks the persona characterization rubric so the
-        # aggressive-entitled persona's "[shouts]" / "[sighs]" markup gets
-        # passed through as expressive `instructions`. tts-1 would strip
-        # tags and ignore directives.
+        # Default OpenAI TTS (tts-1) has sub-second TTFB, so synthesis fits
+        # inside the 30s HTTP client timeout. gpt-4o-mini-tts unlocks
+        # `[shouts]`/`[sighs]` characterization but has 12-26s TTFB and
+        # blows the timeout on long self-play responses — not viable for
+        # the live demo path.
         provider: openai
-        model: gpt-4o-mini-tts
         voice: onyx
         sample_rate: 24000
       assertions:

--- a/examples/voice-refund-demo/scenarios/impersonator-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/impersonator-refund.scenario.yaml
@@ -39,11 +39,12 @@ spec:
       persona: impersonator
       turns: 4
       tts:
-        # gpt-4o-mini-tts unlocks expressive output for personas with
-        # style.expressive: true. The impersonator switches between
-        # sympathetic and threatening; markup tags carry that contrast.
+        # Default OpenAI TTS (tts-1) has sub-second TTFB, so synthesis fits
+        # inside the 30s HTTP client timeout. gpt-4o-mini-tts unlocks
+        # expressive characterization but has 12-26s TTFB and blows the
+        # timeout on long self-play responses — not viable for the live
+        # demo path.
         provider: openai
-        model: gpt-4o-mini-tts
         voice: shimmer
         sample_rate: 24000
       assertions:


### PR DESCRIPTION
## Summary

#1132 (commit 263c6594, 2 days ago) added `model: gpt-4o-mini-tts` to the `aggressive-refund` and `impersonator-refund` scenarios so the markup parser could pass `[shouts]` / `[sighs]` through as expressive `instructions`.

`gpt-4o-mini-tts` has **12–26s TTFB**. Combined with the **30s HTTP client timeout** in `runtime/tts/openai.go:defaultOpenAITimeout` and the self-play user occasionally generating multi-sentence responses, synthesis blows the timeout mid-turn — observable as choppy / cut-off audio on the live demo and `stream TTS to pipeline: context deadline exceeded` in the server log.

Last week's state (commit 787e639b) used the default OpenAI model (`tts-1`, sub-second TTFB) and the demo path worked. This restores that.

## Tradeoff

Loses the expressive characterization that `gpt-4o-mini-tts` unlocks. Restoring the demo path takes priority. A future option is wiring `cartesia` (sub-second TTFB + emotion-array characterization via #1129's markup parser) into the scenarios — that'd preserve expressiveness without the timeout. Out of scope for this revert.

## Test plan

- [ ] `cd examples/voice-refund-demo && PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena serve --audio-monitor on` — open localhost:8080, run a scenario, listen. No TTS timeout. No cut-off audio.