### PR TITLE
fix(arena/serve): persist each run as it completes, not after the batch

### DIFF
--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -92,6 +92,8 @@ type Engine struct {
 	audioMonitorOpts     *arenaaudio.Options          // Optional — enables audio monitoring on duplex runs
 	audioMonitorHooks    []AudioMonitorHook           // Subscribers fired when a per-run AudioRouter is built
 	audioMonitorMu       sync.RWMutex                 // Guards audioMonitorHooks
+	runCompletedHooks    []RunCompletedHook           // Subscribers fired when each run finishes
+	runCompletedMu       sync.RWMutex                 // Guards runCompletedHooks
 	// mcpSourceScope manages source-backed MCP entries at run/scenario/session scopes.
 	mcpSourceScope  *mcpSourceScope
 	mcpConfig       []config.MCPServerConfig   // Source-backed MCP entries, re-read at each scope boundary
@@ -135,6 +137,39 @@ func (e *Engine) fireAudioMonitorHooks(runID string, router *arenaaudio.AudioRou
 	e.audioMonitorMu.RUnlock()
 	for _, h := range hooks {
 		h(runID, router, rate)
+	}
+}
+
+// RunCompletedHook fires after each individual run finishes (success or
+// failure). Used by the web server to persist completed runs to disk as
+// soon as they're done, so killing the server mid-batch doesn't strand
+// completed runs in the in-memory state store with no on-disk record.
+//
+// runID is the identifier of the run that just completed. err is the
+// run's error, or nil on success. Hooks should not retain runID across
+// calls — the next run uses a fresh ID.
+type RunCompletedHook func(runID string, err error)
+
+// RegisterRunCompletedHook registers a callback fired after each run
+// in ExecuteRuns completes. Multiple hooks are supported and fire in
+// registration order. Nil hooks are ignored. Hook panics propagate to
+// the worker goroutine; treat hook bodies as application code.
+func (e *Engine) RegisterRunCompletedHook(hook RunCompletedHook) {
+	if hook == nil {
+		return
+	}
+	e.runCompletedMu.Lock()
+	e.runCompletedHooks = append(e.runCompletedHooks, hook)
+	e.runCompletedMu.Unlock()
+}
+
+func (e *Engine) fireRunCompletedHooks(runID string, err error) {
+	e.runCompletedMu.RLock()
+	hooks := make([]RunCompletedHook, len(e.runCompletedHooks))
+	copy(hooks, e.runCompletedHooks)
+	e.runCompletedMu.RUnlock()
+	for _, h := range hooks {
+		h(runID, err)
 	}
 }
 
@@ -702,6 +737,10 @@ func (e *Engine) ExecuteRuns(ctx context.Context, plan *RunPlan, concurrency int
 				runIDs[item.idx] = runID
 				errors[item.idx] = err
 				mu.Unlock()
+
+				if runID != "" {
+					e.fireRunCompletedHooks(runID, err)
+				}
 			}
 		}()
 	}

--- a/tools/arena/engine/engine_audio_test.go
+++ b/tools/arena/engine/engine_audio_test.go
@@ -168,6 +168,32 @@ func TestRegisterAudioMonitorHook_NilHookIgnored(t *testing.T) {
 	eng.fireAudioMonitorHooks("r", router, arenaaudio.Rate24k)
 }
 
+// TestRegisterRunCompletedHook_FiresInRegistrationOrder verifies hooks are
+// invoked in the order they were registered, with the runID and error
+// passed through unmodified. Nil hooks are dropped at registration.
+func TestRegisterRunCompletedHook_FiresInRegistrationOrder(t *testing.T) {
+	eng := &Engine{}
+	var calls []string
+	eng.RegisterRunCompletedHook(func(id string, err error) {
+		calls = append(calls, "first:"+id)
+	})
+	eng.RegisterRunCompletedHook(nil) // dropped
+	eng.RegisterRunCompletedHook(func(id string, err error) {
+		calls = append(calls, "second:"+id)
+	})
+	eng.fireRunCompletedHooks("run-abc", nil)
+	if len(calls) != 2 || calls[0] != "first:run-abc" || calls[1] != "second:run-abc" {
+		t.Fatalf("expected [first:run-abc second:run-abc], got %v", calls)
+	}
+}
+
+// TestRegisterRunCompletedHook_NoHooksNoOp verifies firing with zero hooks
+// is a safe no-op.
+func TestRegisterRunCompletedHook_NoHooksNoOp(t *testing.T) {
+	eng := &Engine{}
+	eng.fireRunCompletedHooks("r", nil) // should not panic
+}
+
 // TestRegisterAudioMonitorHook_NoHooksNoOp verifies firing with zero hooks
 // is a safe no-op.
 func TestRegisterAudioMonitorHook_NoHooksNoOp(t *testing.T) {

--- a/tools/arena/web/server.go
+++ b/tools/arena/web/server.go
@@ -43,6 +43,7 @@ type engineRunner interface {
 	GetConfig() *config.Config
 	ListProviders() []engine.ProviderInfo
 	ListScenarios() []engine.ScenarioInfo
+	RegisterRunCompletedHook(hook engine.RunCompletedHook)
 }
 
 // Server is the Arena web UI HTTP server.
@@ -85,6 +86,11 @@ func newServerWithRunner(
 		stateStore: store,
 		outputDir:  outputDir,
 		mux:        http.NewServeMux(),
+	}
+	if runner != nil && store != nil && outputDir != "" {
+		runner.RegisterRunCompletedHook(func(runID string, _ error) {
+			s.persistOneRun(context.Background(), runID)
+		})
 	}
 	s.mux.HandleFunc("GET /api/events", s.handleSSE)
 	s.mux.HandleFunc("GET /api/config", s.handleGetConfig)
@@ -228,27 +234,34 @@ func (s *Server) handleStartRun(w http.ResponseWriter, r *http.Request) {
 // persistRunResults writes each completed run as <runID>.json under
 // outputDir, matching the format JSONResultRepository.SaveResult produces
 // so LoadResultsIntoStore can hydrate them on the next server boot.
+// Used as a fallback after ExecuteRuns returns; the per-run RunCompletedHook
+// path is the primary persistence trigger so killing the server mid-batch
+// doesn't strand finished runs.
 func (s *Server) persistRunResults(ctx context.Context, runIDs []string) {
-	if s.stateStore == nil || s.outputDir == "" || len(runIDs) == 0 {
+	for _, runID := range runIDs {
+		s.persistOneRun(ctx, runID)
+	}
+}
+
+// persistOneRun writes a single run's JSON to outputDir. Called from the
+// engine's RunCompletedHook so each finished run lands on disk
+// immediately, not at the end of the batch.
+func (s *Server) persistOneRun(ctx context.Context, runID string) {
+	if s.stateStore == nil || s.outputDir == "" || runID == "" {
 		return
 	}
 	if err := os.MkdirAll(s.outputDir, resultsDirPerm); err != nil {
 		return
 	}
-	for _, runID := range runIDs {
-		if runID == "" {
-			continue
-		}
-		result, err := s.stateStore.GetResult(ctx, runID)
-		if err != nil || result == nil {
-			continue
-		}
-		data, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			continue
-		}
-		_ = os.WriteFile(filepath.Join(s.outputDir, runID+".json"), data, resultsFilePerm)
+	result, err := s.stateStore.GetResult(ctx, runID)
+	if err != nil || result == nil {
+		return
 	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(s.outputDir, runID+".json"), data, resultsFilePerm)
 }
 
 // handleGetConfig returns the loaded arena config.

--- a/tools/arena/web/server_test.go
+++ b/tools/arena/web/server_test.go
@@ -48,6 +48,8 @@ func (m *mockEngine) ListScenarios() []engine.ScenarioInfo {
 	return m.scenarios
 }
 
+func (m *mockEngine) RegisterRunCompletedHook(_ engine.RunCompletedHook) {}
+
 func TestSSEEndpoint(t *testing.T) {
 	adapter := NewEventAdapter()
 	srv := NewServer(adapter, nil, nil, "") // no engine or statestore needed for SSE test
@@ -266,12 +268,15 @@ func TestStartRunSuccess(t *testing.T) {
 }
 
 // persistingMockEngine returns a fixed runID from ExecuteRuns and seeds the
-// state store with matching metadata, so the server's persistence step has
-// something concrete to write to disk.
+// state store with matching metadata. The RunCompletedHook is invoked
+// after metadata is saved so the server's per-run persistence path can
+// observe the same end state the real engine produces.
 type persistingMockEngine struct {
-	plan  *engine.RunPlan
-	store *statestore.ArenaStateStore
-	runID string
+	plan      *engine.RunPlan
+	store     *statestore.ArenaStateStore
+	runID     string
+	hooks     []engine.RunCompletedHook
+	preReturn func() // optional: invoked just before ExecuteRuns returns
 }
 
 func (m *persistingMockEngine) GenerateRunPlan(_, _, _, _ []string) (*engine.RunPlan, error) {
@@ -284,12 +289,21 @@ func (m *persistingMockEngine) ExecuteRuns(ctx context.Context, _ *engine.RunPla
 		ScenarioID: "greeting",
 		ProviderID: "openai",
 	})
+	for _, h := range m.hooks {
+		h(m.runID, nil)
+	}
+	if m.preReturn != nil {
+		m.preReturn()
+	}
 	return []string{m.runID}, nil
 }
 
 func (m *persistingMockEngine) GetConfig() *config.Config            { return nil }
 func (m *persistingMockEngine) ListProviders() []engine.ProviderInfo { return nil }
 func (m *persistingMockEngine) ListScenarios() []engine.ScenarioInfo { return nil }
+func (m *persistingMockEngine) RegisterRunCompletedHook(h engine.RunCompletedHook) {
+	m.hooks = append(m.hooks, h)
+}
 
 // TestStartRun_PersistsResultsToDisk locks in the invariant that runs started
 // via POST /api/run are written to <outputDir>/<runID>.json. Without this,
@@ -345,6 +359,55 @@ func TestStartRun_PersistsResultsToDisk(t *testing.T) {
 	}
 	if got.ScenarioID != "greeting" {
 		t.Errorf("ScenarioID = %q, want %q", got.ScenarioID, "greeting")
+	}
+}
+
+// TestStartRun_PersistsEachRunBeforeExecuteRunsReturns locks in the
+// per-run persistence invariant: the JSON for a completed run must be on
+// disk by the time ExecuteRuns is finishing, not buffered until after.
+// Without this, killing the server mid-batch strands completed runs in
+// the in-memory state store with no on-disk record.
+func TestStartRun_PersistsEachRunBeforeExecuteRunsReturns(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := statestore.NewArenaStateStore()
+	runID := "run-per-hook-1"
+
+	expected := filepath.Join(tmpDir, runID+".json")
+	var sawOnDiskBeforeReturn bool
+
+	mock := &persistingMockEngine{
+		plan: &engine.RunPlan{
+			Combinations: []engine.RunCombination{{ScenarioID: "greeting", ProviderID: "openai"}},
+		},
+		store: store,
+		runID: runID,
+		preReturn: func() {
+			if _, err := os.Stat(expected); err == nil {
+				sawOnDiskBeforeReturn = true
+			}
+		},
+	}
+
+	adapter := NewEventAdapter()
+	srv := newServerWithRunner(adapter, mock, store, tmpDir)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/api/run", "application/json", strings.NewReader("{}")) //nolint:noctx
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	resp.Body.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, statErr := os.Stat(expected); statErr == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !sawOnDiskBeforeReturn {
+		t.Errorf("expected %s to exist before ExecuteRuns returned, but it didn't", expected)
 	}
 }
 


### PR DESCRIPTION
## Summary

#1133's persistence path lived in the goroutine wrapping `ExecuteRuns`, so JSON files only landed on disk when every run in the batch had finished. Killing the server mid-batch — common in iterative demo loops — stranded completed runs in the in-memory state store with no on-disk record, so they vanished on next boot even though their media WAVs were already written.

Adds `Engine.RegisterRunCompletedHook` firing after each individual `executeRun`. The web server registers a hook that persists the just-finished run immediately. The batched fallback in `handleStartRun` still runs (no harm; `persistOneRun` is idempotent at file-write granularity).

## Test plan

- [x] `TestStartRun_PersistsEachRunBeforeExecuteRunsReturns` — mock's `preReturn` callback fires while `ExecuteRuns` is still in flight and asserts the JSON is already on disk.
- [x] `TestRegisterRunCompletedHook_FiresInRegistrationOrder` + `_NoHooksNoOp` for the engine plumbing.
- [x] Pre-commit (lint + tests + coverage thresholds) green.