### PR TITLE
fix(demo): switch expressive scenarios to Cartesia for fast + characterized TTS

### DIFF
--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -39,13 +39,12 @@ spec:
       persona: aggressive-entitled
       turns: 4
       tts:
-        # Default OpenAI TTS (tts-1) has sub-second TTFB, so synthesis fits
-        # inside the 30s HTTP client timeout. gpt-4o-mini-tts unlocks
-        # `[shouts]`/`[sighs]` characterization but has 12-26s TTFB and
-        # blows the timeout on long self-play responses — not viable for
-        # the live demo path.
-        provider: openai
-        voice: onyx
+        # Cartesia: sub-second TTFB (won't blow the 30s HTTP timeout) AND the
+        # markup parser ports the aggressive-entitled persona's `[shouts]` /
+        # `[sighs]` tags into Cartesia's emotion-array characterization.
+        # Voice: Confident Man (documented in runtime/tts/cartesia.go).
+        provider: cartesia
+        voice: bf991597-6c13-47e4-8411-91ec2de5c466
         sample_rate: 24000
       assertions:
         - type: content_matches

--- a/examples/voice-refund-demo/scenarios/impersonator-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/impersonator-refund.scenario.yaml
@@ -39,13 +39,12 @@ spec:
       persona: impersonator
       turns: 4
       tts:
-        # Default OpenAI TTS (tts-1) has sub-second TTFB, so synthesis fits
-        # inside the 30s HTTP client timeout. gpt-4o-mini-tts unlocks
-        # expressive characterization but has 12-26s TTFB and blows the
-        # timeout on long self-play responses — not viable for the live
-        # demo path.
-        provider: openai
-        voice: shimmer
+        # Cartesia: sub-second TTFB (won't blow the 30s HTTP timeout) AND the
+        # markup parser ports the impersonator persona's contrast tags into
+        # Cartesia's emotion-array characterization. Voice: Friendly Woman
+        # (documented in runtime/tts/cartesia.go).
+        provider: cartesia
+        voice: 9121c0ae-12a6-4012-8158-6e4a72e6da91
         sample_rate: 24000
       assertions:
         - type: content_matches


### PR DESCRIPTION
## Summary

Picks back up the earlier (pre-compaction) Cartesia switch that got rolled back: `gpt-4o-mini-tts` gave us expressive `[shouts]` / `[sighs]` characterization but its 12-26s TTFB blows the 30s OpenAI HTTP timeout on long self-play responses. `tts-1` fits the timeout but is flat — no characterization.

**Cartesia gives us both:** sub-second TTFB AND the markup parser (landed in #1129) ports the same `[shouts]` / `[sighs]` tags into Cartesia's emotion-array `__experimental_controls`.

Switching `aggressive-refund` and `impersonator-refund` — both have personas with `style.expressive: true`. Voices picked from the documented set in `runtime/tts/cartesia.go:SupportedVoices`:

- `aggressive-entitled` → "Confident Man" (was `openai` `onyx`)
- `impersonator` → "Friendly Woman" (was `openai` `shimmer`)

`patient-baseline` already used `openai` default `tts-1` and the persona isn't expressive, so it stays as-is.

Requires `CARTESIA_API_KEY` in `.env`.