### PR TITLE
fix(arena/audio): bump drainTailGrace to cover SSE/browser playback latency

### DIFF
--- a/tools/arena/audio/local_sink.go
+++ b/tools/arena/audio/local_sink.go
@@ -19,9 +19,16 @@ const (
 	// drain. Beyond this we accept losing the tail of the run rather than
 	// blocking shutdown indefinitely.
 	drainMaxWait = 8 * time.Second
-	// drainTailGrace is the small extra wait after the queues empty so
-	// oto's internal buffer can finish playing the last samples it pulled.
-	drainTailGrace = 500 * time.Millisecond
+	// drainTailGrace is the wait after the queues empty before the
+	// inter-turn drain barrier returns. Covers two delays the LocalSink's
+	// per-direction queue-empty signal does not: (1) oto's internal
+	// playback buffer finishing the last samples it pulled (typically
+	// ≤200 ms), and (2) the SSE relay still forwarding the tail to a
+	// browser listener whose audio scheduler hasn't finished consuming
+	// the frames yet (≈1 s observed empirically on the voice-refund
+	// demo). Too short → next-turn audio starts in the input ear while
+	// the previous turn's output is still audible in the right ear.
+	drainTailGrace = 1500 * time.Millisecond
 	// localSinkBufFrames is the channel buffer depth for each direction's
 	// pending mono frames. Frames overflow drop silently — the sink trails
 	// the run when the audio device can't keep up, but never blocks the


### PR DESCRIPTION
## Summary

`waitForLocalPlaybackDrained` blocks on `LocalSink.WaitDrained`, which polls per-direction queues to empty then waits `drainTailGrace` before returning. At 500 ms that covered `oto`'s local audio buffer (~200 ms) — but **not** the SSE relay still forwarding the tail to a browser whose audio scheduler hasn't finished consuming the frames yet (≈1 s observed empirically).

The result: on the voice-refund demo with `--audio-monitor on`, the next turn's self-play user audio (input direction, left ear) starts while the browser is still playing the previous turn's assistant tail (output direction, right ear). This is the inter-turn overlap reported on the live listen.

Bumps `drainTailGrace` to 1500 ms. **This is an interim fix**, not a root-cause fix — the principled version is a `DrainHandler` on the SSE relay that explicitly tracks consumer-channel drain plus a way to confirm browser playback. The grace bump removes the audible artefact today with zero risk to in-turn duplex (where input+output overlap is desired during a single turn).

## Tradeoff

Adds up to 1 s extra silence between turns on every duplex run, even when no browser is listening. Acceptable for the demo path; will revisit when wiring the SSE drain handler.

## Test plan

- [x] Existing audio package tests still pass
- [ ] Pull, rebuild, run the demo, confirm overlap is gone