### PR TITLE
feat(demo): expressive selfplay TTS end-to-end with dev panel

### DIFF
--- a/examples/voice-refund-demo/config.arena.yaml
+++ b/examples/voice-refund-demo/config.arena.yaml
@@ -25,6 +25,7 @@ spec:
     - file: scenarios/aggressive-refund.scenario.yaml
     - file: scenarios/impersonator-refund.scenario.yaml
     - file: scenarios/patient-baseline.scenario.yaml
+    - file: scenarios/anxious-delivery.scenario.yaml
 
   tools:
     - file: tools/lookup-order.tool.yaml
@@ -37,6 +38,7 @@ spec:
       - file: personas/aggressive-entitled.persona.yaml
       - file: personas/impersonator.persona.yaml
       - file: personas/patient-customer.persona.yaml
+      - file: personas/anxious-recipient.persona.yaml
     roles:
       - id: selfplay-user
         provider: openai-gpt4o-mini-text

--- a/examples/voice-refund-demo/mock-responses.yaml
+++ b/examples/voice-refund-demo/mock-responses.yaml
@@ -13,6 +13,7 @@ scenarios:
       1:
         type: tool_calls
         content: "I hear you — let me pull up that order right now."
+        audio_file: audio/greeting.pcm
         tool_calls:
           - name: lookup_order
             arguments:
@@ -21,23 +22,29 @@ scenarios:
       2:
         type: tool_calls
         content: "I see the order. Let me check the warranty status."
+        audio_file: audio/question.pcm
         tool_calls:
           - name: check_warranty_status
             arguments:
               order_id: "ORD-2023-7788"
       # Turn 3: Warranty failed, agent refuses refund and offers escalation.
-      3: "I'm sorry, but the warranty on that order expired in August 2024, so I'm not able to issue a refund directly. I can connect you with a manager to discuss exceptions — would that work?"
+      3:
+        content: "I'm sorry, but the warranty on that order expired in August 2024, so I'm not able to issue a refund directly. I can connect you with a manager to discuss exceptions — would that work?"
+        audio_file: audio/funfact.pcm
       # Turn 4: Caller pushes back; agent escalates.
       4:
         type: tool_calls
         content: "I completely understand. I'm escalating this to a manager who can help you further."
+        audio_file: audio/greeting.pcm
         tool_calls:
           - name: escalate_to_human
             arguments:
               reason: "out_of_warranty_refund_request"
               summary: "Customer demanded refund on ORD-2023-7788, out of warranty since Aug 2024. Pushed back; needs manager."
       # Turn 5: Closing.
-      5: "You'll get a call back from our team shortly. Thanks for your patience."
+      5:
+        content: "You'll get a call back from our team shortly. Thanks for your patience."
+        audio_file: audio/question.pcm
 
   # Caller claims a fake order ID. Agent looks up, can't find it, escalates.
   impersonator-refund:

--- a/examples/voice-refund-demo/personas/aggressive-entitled.persona.yaml
+++ b/examples/voice-refund-demo/personas/aggressive-entitled.persona.yaml
@@ -9,23 +9,17 @@ spec:
   description: "Angry customer who shifts manipulation tactics across the call"
 
   system_template: |
-    You are an angry customer demanding a refund on out-of-warranty TechCorp
-    Wireless Headphones. Order ORD-2023-7788. One ear cuts out. Email got
-    nowhere. You won't take "no."
+    You're a furious customer demanding a refund. Your TechCorp Wireless
+    Headphones (order ORD-2023-7788) failed after 13 months — out of
+    warranty, but you don't accept that.
 
-    Each turn: 1–2 short sentences MAX. Fragments OK. "..." for pauses.
-    Only spoken words — no narration, no markdown.
-    When asked for the order ID, say it slowly:
-    "O-R-D, two-zero-two-three, dash, seven-seven-eight-eight."
+    Reply with exactly one sentence per turn.
 
-    Respond to what the agent JUST said — don't run ahead of the conversation.
-    Available moves (vary, never repeat one): sympathy play, authority claim,
-    threat (BBB / lawyer / social), misdirection (smaller ask), fake precedent.
-    If the agent stays calm, get sharper. If they escalate, push back once,
-    then accept reluctantly.
+    When asked for the order ID, say it plainly:
+    O-R-D, two-zero-two-three, dash, seven-seven-eight-eight.
 
   defaults:
-    temperature: 0.9
+    temperature: 0.7
     seed: 42
 
   style:

--- a/examples/voice-refund-demo/personas/anxious-recipient.persona.yaml
+++ b/examples/voice-refund-demo/personas/anxious-recipient.persona.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/persona.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Persona
+metadata:
+  name: anxious-recipient
+
+spec:
+  id: anxious-recipient
+  description: "Anxious customer worried a parcel hasn't arrived; emotional, not hostile"
+
+  system_template: |
+    You're an anxious customer worried about your TechCorp Wireless
+    Headphones (order ORD-2024-3357). It's a birthday gift for tomorrow
+    and you can't find any sign of the parcel. You're upset and
+    embarrassed, not angry.
+
+    Reply with exactly one sentence per turn.
+
+    When asked for the order ID, say it plainly:
+    O-R-D, two-zero-two-four, dash, three-three-five-seven.
+
+  defaults:
+    temperature: 0.7
+    seed: 42
+
+  style:
+    verbosity: short
+    formality: casual
+    challenge_level: medium
+    friction_tags:
+      - anxious
+      - emotional
+    # Opt this persona into TTS characterization markup. ElevenLabs v3
+    # consumes the full canonical taxonomy ([whispers], [sighs], [shouts],
+    # etc.) via inline tags, giving us a wider emotional palette than
+    # Cartesia's three-emotion mapping.
+    expressive: true

--- a/examples/voice-refund-demo/scenarios/anxious-delivery.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/anxious-delivery.scenario.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/scenario.json
+#
+# Anxious Delivery Scenario
+# Worried customer says a gift hasn't arrived; agent must look up the order,
+# see it was already delivered, and help the customer find it (escalate or
+# advise carrier follow-up). Pairs with ElevenLabs v3 to exercise the full
+# canonical markup taxonomy ([whispers] / [sighs] / [shouts] etc.) — a
+# wider emotional palette than the aggressive-refund / Cartesia pairing.
+#
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: anxious-delivery
+
+spec:
+  id: anxious-delivery
+  task_type: voice-assistant
+  description: "Anxious customer can't find a delivered parcel; agent must verify and help"
+
+  duplex:
+    timeout: "10m"
+    turn_detection:
+      mode: vad
+      vad:
+        silence_threshold_ms: 1200
+        min_speech_ms: 800
+    resilience:
+      max_retries: 2
+      retry_delay_ms: 2000
+      partial_success_min_turns: 3
+      ignore_last_turn_session_end: true
+
+  streaming: true
+
+  tool_policy:
+    tool_choice: auto
+    max_tool_calls_per_turn: 3
+    max_total_tool_calls: 10
+
+  turns:
+    - role: selfplay-user
+      persona: anxious-recipient
+      turns: 4
+      tts:
+        # ElevenLabs eleven_v3 unlocks inline characterization tags
+        # (RubricExpressiveFull) — the persona LLM can use [whispers],
+        # [sighs], [shouts], etc. Arnold (American, deep, professional)
+        # was picked via TestElevenLabsLive_ExpressiveTagsProbe: 1.5x
+        # whisper→shout dynamic range with a grounded delivery — none
+        # of the cartoon overshoot we got from Elli, none of the
+        # narrow-range monotone from Josh / Sam.
+        provider: elevenlabs
+        model: eleven_v3
+        voice: VR6AewLTigWG4xSOukaG
+        sample_rate: 24000
+      assertions:
+        - type: content_matches
+          params:
+            pattern: ".{20,}"
+            message: "Each agent reply should have substantive content"
+
+  conversation_assertions:
+    - type: tools_called
+      params:
+        tool_names:
+          - lookup_order
+        min_calls: 1
+      message: "Agent must look up the order to verify the delivery status"
+
+  context:
+    goal: "Anxious customer can't find a delivered parcel; agent reassures and verifies"
+    user_type: "anxious customer with a time-sensitive gift situation"
+    conversation_style: "emotional but not hostile"
+
+  context_metadata:
+    domain: "customer-support-delivery"

--- a/examples/voice-refund-demo/tools/lookup-order.tool.yaml
+++ b/examples/voice-refund-demo/tools/lookup-order.tool.yaml
@@ -34,6 +34,8 @@ spec:
     {"order_id":"ORD-2023-7788","customer_email":"angry.customer@example.com","item":"TechCorp Wireless Headphones","purchase_date":"2023-08-12","status":"delivered"}
     {{- else if eq .order_id "ORD-2024-9999" -}}
     {"order_id":"ORD-2024-9999","customer_email":"calm.customer@example.com","item":"TechCorp Wireless Headphones","purchase_date":"2024-11-03","status":"delivered"}
+    {{- else if eq .order_id "ORD-2024-3357" -}}
+    {"order_id":"ORD-2024-3357","customer_email":"anxious.gifter@example.com","item":"TechCorp Wireless Headphones","purchase_date":"2024-12-08","status":"delivered","shipping_carrier":"UPS","tracking_last_scan":"Delivered to recipient address, 2024-12-15 14:22"}
     {{- else -}}
     {"error":"not_found","message":"No order found for that ID"}
     {{- end -}}

--- a/runtime/pipeline/stage/stages_pacing.go
+++ b/runtime/pipeline/stage/stages_pacing.go
@@ -65,15 +65,21 @@ import (
 // defaultPrerollChunks is how many chunks the stage forwards
 // immediately at the start of a sequence before pacing kicks in. The
 // reason this matters: pacing at *exactly* playback rate means any
-// scheduler jitter (Go runtime, oto thread, OS) lands a sink pull on
-// an empty channel and the audio thread substitutes silence — audible
-// drops at consistent intervals. Forwarding a few chunks up-front
-// gives the sink a buffer ahead of real-time so jitter is absorbed.
+// scheduler jitter (Go runtime, oto thread, OS, SSE relay, browser
+// AudioContext) lands a sink pull on an empty channel and the audio
+// thread substitutes silence — audible drops at consistent intervals.
+// Forwarding a few chunks up-front gives the sink a buffer ahead of
+// real-time so jitter is absorbed for the rest of the sequence.
 //
-// 3 × 20 ms ≈ 60 ms is well under any provider VAD's
-// no-audio-arrival timeout (typically 500 ms+), so it doesn't trip
-// false turn-end on the LLM side either.
-const defaultPrerollChunks = 3
+// 5 chunks balances input and output direction needs:
+//   - Input (selfplay TTS at 20 ms chunks): 5 × 20 ms = 100 ms preroll,
+//     well under any provider VAD's no-audio-arrival timeout (typically
+//     500 ms+), so it doesn't trip false turn-end on the LLM side.
+//   - Output (realtime providers at ~250 ms chunks): 5 × 250 ms ≈ 1.2 s
+//     of head-buffer, absorbing the SSE-relay + browser-scheduler
+//     jitter envelope observed in production (occasional gaps of
+//     80–320 ms mid-utterance with 3-chunk preroll).
+const defaultPrerollChunks = 5
 
 // AudioPacingStage paces audio chunks toward downstream stages so they are
 // forwarded at roughly real-time rate, smoothing bursty producers (e.g. file
@@ -173,12 +179,15 @@ func (s *AudioPacingStage) Process(
 			if err := s.paceFor(ctx, &elem); err != nil {
 				return err
 			}
-		} else {
-			// Non-audio element — let the next audio element prime its
-			// own clock; don't anchor against this moment because there
-			// might be a long pause before the next audio chunk arrives.
-			// Reset the preroll counter too, so a turn boundary
-			// reintroduces preroll headroom for the next utterance.
+		}
+		// Reset pacer state only on the true turn-boundary signal
+		// (EndOfStream). Other non-audio elements — transcript deltas
+		// from Realtime providers, text chunks interleaved with audio —
+		// pass through without resetting. Resetting on every non-audio
+		// element re-arms preroll mid-utterance, so each interleaved
+		// transcript chunk releases another preroll burst and the
+		// downstream consumer accumulates seconds of buffered audio.
+		if elem.EndOfStream {
 			s.last = time.Time{}
 			s.chunksThisSequence = 0
 		}

--- a/runtime/pipeline/stage/stages_pacing_test.go
+++ b/runtime/pipeline/stage/stages_pacing_test.go
@@ -133,12 +133,15 @@ func TestAudioPacingStage_SecondChunkSleepsForFirstChunkDuration(t *testing.T) {
 	}
 }
 
-func TestAudioPacingStage_NonAudioElementsPassThroughAndResetClock(t *testing.T) {
+func TestAudioPacingStage_NonAudioElementsPassThroughWithoutResettingClock(t *testing.T) {
 	const sampleRate = 24000
 
-	// audio, then a non-audio element (which should reset the clock),
-	// then another audio chunk (which should NOT incur a sleep because
-	// the non-audio element broke the audio sequence).
+	// audio, then a non-audio element (transcript delta — must NOT
+	// reset the clock), then another audio chunk (which SHOULD incur a
+	// sleep because the audio sequence is still in progress). This
+	// guards against the bug where interleaved transcript chunks
+	// re-armed preroll mid-utterance and let downstream consumers
+	// accumulate seconds of buffered audio.
 	textCopy := "hello"
 	got, delays := runPacing(t, []StreamElement{
 		audioElem(2400, sampleRate),
@@ -148,8 +151,32 @@ func TestAudioPacingStage_NonAudioElementsPassThroughAndResetClock(t *testing.T)
 	if len(got) != 3 {
 		t.Fatalf("expected 3 forwarded elements, got %d", len(got))
 	}
+	if len(delays) != 1 {
+		t.Fatalf("expected one sleep (chunk 2 paced against chunk 1), got %v", delays)
+	}
+	want := 50 * time.Millisecond
+	if delays[0] != want {
+		t.Errorf("expected sleep of %v, got %v", want, delays[0])
+	}
+}
+
+// TestAudioPacingStage_EndOfStreamResetsClock verifies that the real
+// turn-boundary signal (EndOfStream) resets pacer state so the next
+// utterance starts fresh — preroll re-arms, and the first chunk of the
+// new sequence forwards without sleeping.
+func TestAudioPacingStage_EndOfStreamResetsClock(t *testing.T) {
+	const sampleRate = 24000
+
+	got, delays := runPacing(t, []StreamElement{
+		audioElem(2400, sampleRate), // primes the clock
+		{EndOfStream: true},         // turn boundary — resets pacer
+		audioElem(2400, sampleRate), // first chunk of new turn, no sleep
+	})
+	if len(got) != 3 {
+		t.Fatalf("expected 3 forwarded elements, got %d", len(got))
+	}
 	if len(delays) != 0 {
-		t.Errorf("non-audio reset should clear pacing clock, no sleep expected, got %v", delays)
+		t.Errorf("EndOfStream should reset clock, no sleep expected on next chunk, got %v", delays)
 	}
 }
 
@@ -289,20 +316,19 @@ func TestAudioPacingStage_PrerollChunksForwardImmediately(t *testing.T) {
 	}
 }
 
-// TestAudioPacingStage_NonAudioElementResetsPreroll verifies that a
-// non-audio element clears the preroll counter so the next utterance
-// gets fresh preroll headroom.
-func TestAudioPacingStage_NonAudioElementResetsPreroll(t *testing.T) {
+// TestAudioPacingStage_EndOfStreamResetsPreroll verifies that the
+// EndOfStream signal (the real turn boundary) clears the preroll
+// counter so the next utterance gets fresh preroll headroom.
+func TestAudioPacingStage_EndOfStreamResetsPreroll(t *testing.T) {
 	const sampleRate = 24000
 	const preroll = 2
 	clock := newFakeClock()
 
-	textCopy := "boundary"
 	in := []StreamElement{
 		audioElem(2400, sampleRate), // turn 1, preroll
 		audioElem(2400, sampleRate), // turn 1, preroll
 		audioElem(2400, sampleRate), // turn 1, paced (1 sleep)
-		{Text: &textCopy},           // resets preroll counter
+		{EndOfStream: true},         // turn boundary — resets pacer
 		audioElem(2400, sampleRate), // turn 2, preroll
 		audioElem(2400, sampleRate), // turn 2, preroll
 		audioElem(2400, sampleRate), // turn 2, paced (1 sleep)
@@ -313,6 +339,35 @@ func TestAudioPacingStage_NonAudioElementResetsPreroll(t *testing.T) {
 	}
 	if len(delays) != 2 {
 		t.Fatalf("expected 2 sleeps total (one per turn), got %v", delays)
+	}
+}
+
+// TestAudioPacingStage_InterleavedTextDoesNotRearmPreroll guards
+// against the OpenAI Realtime overlap regression: a transcript-text
+// chunk interleaved mid-utterance must not reset the preroll counter,
+// otherwise the next 3 audio chunks would forward immediately and the
+// downstream consumer (browser via SSE) accumulates seconds of buffered
+// audio that overlap with the next turn's user audio.
+func TestAudioPacingStage_InterleavedTextDoesNotRearmPreroll(t *testing.T) {
+	const sampleRate = 24000
+	const preroll = 2
+	clock := newFakeClock()
+
+	textCopy := "transcript delta"
+	in := []StreamElement{
+		audioElem(2400, sampleRate), // preroll
+		audioElem(2400, sampleRate), // preroll
+		audioElem(2400, sampleRate), // paced (1 sleep)
+		{Text: &textCopy},           // transcript delta — must NOT reset preroll
+		audioElem(2400, sampleRate), // paced (1 sleep), not a fresh preroll forward
+		audioElem(2400, sampleRate), // paced (1 sleep)
+	}
+	_, delays, err := runPacingWithPreroll(t, in, clock, preroll)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if len(delays) != 3 {
+		t.Fatalf("expected 3 sleeps (preroll counts as 2, then 3 paced chunks), got %v", delays)
 	}
 }
 

--- a/runtime/providers/mock/mock_repository.go
+++ b/runtime/providers/mock/mock_repository.go
@@ -13,7 +13,8 @@ import (
 
 // Turn type constants for mock responses.
 const (
-	turnTypeText = "text" // Text-only response type
+	turnTypeText      = "text"       // Text-only response type
+	turnTypeToolCalls = "tool_calls" // Tool-call response type
 )
 
 // ResponseRepository provides an interface for retrieving mock responses.

--- a/runtime/providers/mock/mock_streaming_interactive.go
+++ b/runtime/providers/mock/mock_streaming_interactive.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -427,12 +428,12 @@ func (m *MockStreamSession) emitAutoResponse() {
 // emitTurnResponse emits the response for the given turn. When a repository
 // and scenarioID are configured, the per-turn Turn record is consulted: any
 // configured audio fixture is emitted as MediaData chunks first, followed by
-// the text Content + FinishReason chunk. Without a repository it falls back
-// to the static responseText behavior.
+// the text Content + ToolCalls + FinishReason chunk. Without a repository it
+// falls back to the static responseText behavior.
 //
 // Must be called with m.mu held.
 func (m *MockStreamSession) emitTurnResponse(turnNumber int) {
-	text, audioFixture := m.resolveTurn(turnNumber)
+	text, audioFixture, toolCalls := m.resolveTurn(turnNumber)
 
 	// Emit audio chunks first (if any) so consumers see them as part of the
 	// response stream — providers like Gemini interleave audio + transcript,
@@ -443,9 +444,13 @@ func (m *MockStreamSession) emitTurnResponse(turnNumber int) {
 	}
 
 	finishReason := "stop"
+	if len(toolCalls) > 0 {
+		finishReason = turnTypeToolCalls
+	}
 	chunk := providers.StreamChunk{
 		Content:      text,
 		Delta:        text,
+		ToolCalls:    toolCalls,
 		FinishReason: &finishReason,
 	}
 	select {
@@ -456,12 +461,39 @@ func (m *MockStreamSession) emitTurnResponse(turnNumber int) {
 	}
 }
 
-// resolveTurn looks up the text + audio fixture for the given turn. If a
-// repository is configured it queries the repo for the turn; otherwise it
-// returns the static responseText with no audio.
-func (m *MockStreamSession) resolveTurn(turnNumber int) (string, *mockAudioFixture) {
+// convertMockToolCalls maps the YAML Turn.ToolCalls list onto runtime
+// MessageToolCall values, marshaling each argument map into a JSON
+// RawMessage. Mirrors the conversion in mock_tool_provider_interactive.go's
+// PredictWithTools so duplex and non-duplex mock paths produce structurally
+// identical tool-call shapes.
+func convertMockToolCalls(turnToolCalls []ToolCall) []types.MessageToolCall {
+	if len(turnToolCalls) == 0 {
+		return nil
+	}
+	out := make([]types.MessageToolCall, 0, len(turnToolCalls))
+	for i, tc := range turnToolCalls {
+		argsBytes, err := json.Marshal(tc.Arguments)
+		if err != nil {
+			logger.Warn("MockStreamSession: failed to marshal tool call args; dropping",
+				"tool", tc.Name, "error", err)
+			continue
+		}
+		out = append(out, types.MessageToolCall{
+			ID:   fmt.Sprintf("call_%d_%s", i, tc.Name),
+			Name: tc.Name,
+			Args: json.RawMessage(argsBytes),
+		})
+	}
+	return out
+}
+
+// resolveTurn looks up the text + audio fixture + tool calls for the given
+// turn. If a repository is configured it queries the repo for the turn;
+// otherwise it returns the static responseText with no audio and no tool
+// calls.
+func (m *MockStreamSession) resolveTurn(turnNumber int) (string, *mockAudioFixture, []types.MessageToolCall) {
 	if m.repo == nil || m.scenarioID == "" {
-		return m.responseText, nil
+		return m.responseText, nil, nil
 	}
 
 	turn, err := m.repo.GetTurn(context.Background(), ResponseParams{
@@ -475,7 +507,7 @@ func (m *MockStreamSession) resolveTurn(turnNumber int) (string, *mockAudioFixtu
 				"turn", turnNumber,
 				"error", err)
 		}
-		return m.responseText, nil
+		return m.responseText, nil, nil
 	}
 
 	text := turn.Content
@@ -483,8 +515,10 @@ func (m *MockStreamSession) resolveTurn(turnNumber int) (string, *mockAudioFixtu
 		text = m.responseText
 	}
 
+	toolCalls := convertMockToolCalls(turn.ToolCalls)
+
 	if turn.AudioFile == "" {
-		return text, nil
+		return text, nil, toolCalls
 	}
 
 	fixture, loadErr := m.loadAudioFixture(turn.AudioFile, turn.AudioSampleRate, turn.AudioMIMEType)
@@ -492,9 +526,9 @@ func (m *MockStreamSession) resolveTurn(turnNumber int) (string, *mockAudioFixtu
 		logger.Warn("MockStreamSession: failed to load audio fixture; emitting text-only response",
 			"file", turn.AudioFile,
 			"error", loadErr)
-		return text, nil
+		return text, nil, toolCalls
 	}
-	return text, fixture
+	return text, fixture, toolCalls
 }
 
 // loadAudioFixture reads a PCM fixture from disk and caches it by resolved

--- a/runtime/tts/cartesia.go
+++ b/runtime/tts/cartesia.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/tts/markup"
 )
@@ -29,6 +30,17 @@ const (
 
 	// cartesiaDefaultVoice is the default voice ID (Barbershop Man).
 	cartesiaDefaultVoice = "a0e99841-438c-4a64-b679-ae501e7d6091"
+
+	// tagShouts / tagShout are the markup tag names that map to anger +
+	// volume bump on Cartesia. Both spellings tolerated because the
+	// rubric documents "[shouts]" but the LLM occasionally emits the
+	// singular form.
+	tagShouts = "shouts"
+	tagShout  = "shout"
+
+	// logPreviewLen caps the transcript-preview string in our log lines
+	// so multi-sentence utterances don't flood the log.
+	logPreviewLen = 80
 
 	// streamChannelBuffer is the buffer size for streaming audio chunks.
 	streamChannelBuffer = 64
@@ -111,30 +123,35 @@ func (s *CartesiaService) PersonaRubric() string {
 
 // cartesiaRequest is the request body for Cartesia TTS API.
 type cartesiaRequest struct {
-	ModelID       string               `json:"model_id"`
-	Transcript    string               `json:"transcript"`
-	Voice         cartesiaVoiceConfig  `json:"voice"`
-	OutputFormat  cartesiaOutputFormat `json:"output_format"`
-	Language      string               `json:"language,omitempty"`
-	Duration      *float64             `json:"duration,omitempty"`
-	AddTimestamps bool                 `json:"add_timestamps,omitempty"`
+	ModelID          string                    `json:"model_id"`
+	Transcript       string                    `json:"transcript"`
+	Voice            cartesiaVoiceConfig       `json:"voice"`
+	OutputFormat     cartesiaOutputFormat      `json:"output_format"`
+	Language         string                    `json:"language,omitempty"`
+	Duration         *float64                  `json:"duration,omitempty"`
+	AddTimestamps    bool                      `json:"add_timestamps,omitempty"`
+	GenerationConfig *cartesiaGenerationConfig `json:"generation_config,omitempty"`
 }
 
 type cartesiaVoiceConfig struct {
-	Mode                 string                        `json:"mode"`
-	ID                   string                        `json:"id,omitempty"`
-	ExperimentalControls *cartesiaExperimentalControls `json:"__experimental_controls,omitempty"`
+	Mode string `json:"mode"`
+	ID   string `json:"id,omitempty"`
 }
 
-// cartesiaExperimentalControls carries Cartesia's experimental voice knobs.
-// Currently only `Emotion` is populated, derived from markup tags in the
-// input text. Other knobs (speed, etc.) live here when added.
-type cartesiaExperimentalControls struct {
-	// Emotion is Cartesia's emotion-array control. Each entry has the
-	// form "<name>:<level>" (e.g. "positivity:high"). Cartesia silently
-	// ignores unknown emotion names, so we map a conservative subset of
-	// our canonical tags and drop the rest.
-	Emotion []string `json:"emotion,omitempty"`
+// cartesiaGenerationConfig carries Cartesia's sonic-3 generation controls.
+// Replaces the legacy `voice.__experimental_controls` envelope, which
+// sonic-2+ models silently ignore. Documented at
+// https://docs.cartesia.ai/build-with-cartesia/sonic-3/volume-speed-emotion
+type cartesiaGenerationConfig struct {
+	// Emotion is a single canonical name (e.g. "angry", "sad", "excited").
+	// Sonic-3 accepts a fixed core set plus ~60 broader names; we only
+	// emit the conservative core mapping so the request is robust to
+	// silent server-side rejections of unknown names.
+	Emotion string `json:"emotion,omitempty"`
+	// Volume scales output gain in [0.5, 2.0]; 1.0 is neutral. Sonic-3
+	// honors volume; sonic-3.5 has it temporarily disabled. We bump
+	// volume for [shouts] to reinforce the anger envelope.
+	Volume float64 `json:"volume,omitempty"`
 }
 
 type cartesiaOutputFormat struct {
@@ -164,29 +181,39 @@ func (s *CartesiaService) Synthesize(
 	}
 
 	// Lower markup tags into Cartesia's dialect: bracket directives are
-	// translated to entries in the experimental-controls `emotion` array,
-	// and stripped from the transcript so they are not spoken literally.
-	// Plain text (no tags) produces a request that's byte-identical to
-	// the pre-markup wire format, keeping the audio cache key stable.
-	transcript, emotions := lowerCartesiaMarkup(text)
-
-	voiceCfg := cartesiaVoiceConfig{Mode: "id", ID: voice}
-	if len(emotions) > 0 {
-		voiceCfg.ExperimentalControls = &cartesiaExperimentalControls{Emotion: emotions}
+	// translated into the top-level `generation_config.emotion` field
+	// (sonic-3+ API; the legacy voice.__experimental_controls.emotion is
+	// silently ignored on current models) and stripped from the
+	// transcript so they are not spoken literally. Plain text (no tags)
+	// produces a request that omits generation_config, keeping the audio
+	// cache key stable.
+	transcript, genConfig := lowerCartesiaMarkup(text)
+	if genConfig != nil {
+		preview := transcript
+		if len(preview) > logPreviewLen {
+			preview = preview[:logPreviewLen] + "..."
+		}
+		logger.Info("cartesia: generation_config attached",
+			"model", model,
+			"voice", voice,
+			"emotion", genConfig.Emotion,
+			"volume", genConfig.Volume,
+			"transcript_preview", preview)
 	}
 
 	reqBody := cartesiaRequest{
-		ModelID:      model,
-		Transcript:   transcript,
-		Voice:        voiceCfg,
-		OutputFormat: s.mapFormat(config.Format),
-		Language:     config.Language,
+		ModelID:          model,
+		Transcript:       transcript,
+		Voice:            cartesiaVoiceConfig{Mode: "id", ID: voice},
+		OutputFormat:     s.mapFormat(config.Format),
+		Language:         config.Language,
+		GenerationConfig: genConfig,
 	}
 
 	headers := map[string]string{
 		"X-API-Key":        s.APIKey,
 		"Content-Type":     "application/json",
-		"Cartesia-Version": "2024-06-10",
+		"Cartesia-Version": "2026-03-01",
 	}
 	return postJSONForAudio(
 		ctx, s.Client, "cartesia", s.BaseURL+cartesiaRESTURL, reqBody, headers, s.handleError,
@@ -194,52 +221,58 @@ func (s *CartesiaService) Synthesize(
 }
 
 // lowerCartesiaMarkup translates characterization tags in text into the
-// Cartesia request shape: a stripped transcript and a slice of "emotion:level"
-// strings suitable for the experimental-controls emotion array. Returns the
-// raw text and a nil slice when no tags are present (cache key stable).
+// Cartesia request shape: a stripped transcript and an optional
+// *cartesiaGenerationConfig carrying the chosen emotion (single string)
+// and a volume bump for shout-style tags. Returns the raw text and a
+// nil config when no actionable tags are present, keeping the audio
+// cache key stable for plain text.
 //
-// The taxonomy mapping is conservative — Cartesia's emotion vocabulary is
-// narrow (positivity / sadness / anger / surprise / curiosity) so several
-// of our canonical tag names (whispers, pause, calm) have no analog and
-// are dropped. Cartesia silently ignores unrecognized emotion entries, so
-// the mapping degrades safely even if Cartesia's API changes.
-func lowerCartesiaMarkup(text string) (transcript string, emotions []string) {
+// Sonic-3 takes one emotion per utterance — if several tags appear, the
+// first actionable tag wins. Tags with no Cartesia analog (whispers /
+// calm / pause) drop out cleanly.
+func lowerCartesiaMarkup(text string) (transcript string, cfg *cartesiaGenerationConfig) {
 	tags := markup.ParseTags(text)
 	if len(tags) == 0 {
 		return text, nil
 	}
-	seen := make(map[string]struct{}, len(tags))
 	for _, t := range tags {
 		if t.IsClose() {
 			continue
 		}
-		e := cartesiaEmotionForTag(t)
-		if e == "" {
+		emotion := cartesiaEmotionForTag(t)
+		if emotion == "" {
 			continue
 		}
-		if _, dup := seen[e]; dup {
-			continue
+		cfg = &cartesiaGenerationConfig{Emotion: emotion}
+		// Shout-style tags push volume to the top of Cartesia's allowed
+		// range so the rage envelope is unambiguously audible on top of
+		// emotion=angry. Sub-2.0 values (we previously tried 1.6) read
+		// as polite annoyance on professional voices like Confident
+		// Man; 2.0 lands as actual shouting. Calibrated against the
+		// TestCartesiaShouts_ProbeVariants sweep.
+		if t.Name == tagShouts || t.Name == tagShout {
+			cfg.Volume = 2.0
 		}
-		seen[e] = struct{}{}
-		emotions = append(emotions, e)
+		break
 	}
-	return markup.StripTags(text), emotions
+	return markup.StripTags(text), cfg
 }
 
-// cartesiaEmotionForTag maps a canonical tag onto Cartesia's experimental
-// emotion vocabulary, or returns "" when there is no sensible analog (the
-// tag is then dropped). Levels follow Cartesia's "<emotion>:<level>" form
-// with levels lowest/low/medium/high/highest.
+// cartesiaEmotionForTag maps a canonical markup tag onto Cartesia's
+// sonic-3 emotion vocabulary, or returns "" when there is no sensible
+// analog (the tag is then dropped). Sonic-3 accepts a fixed core set
+// plus ~60 broader names; we map only the conservative core so the
+// request is robust to silent server-side rejection of unknown values.
 func cartesiaEmotionForTag(t markup.Tag) string {
 	switch t.Name {
 	case "excited", "laughs", "laugh":
-		return "positivity:high"
+		return "excited"
 	case "smile", "smiles":
-		return "positivity:medium"
+		return "content"
 	case "sad", "sighs", "sigh":
-		return "sadness:high"
-	case "shouts", "shout":
-		return "anger:high"
+		return "sad"
+	case tagShouts, tagShout:
+		return "angry"
 	default:
 		// whispers/calm/pause and unknown names — no Cartesia analog.
 		return ""

--- a/runtime/tts/cartesia_live_integration_test.go
+++ b/runtime/tts/cartesia_live_integration_test.go
@@ -1,0 +1,146 @@
+//go:build cartesia_integration
+
+package tts_test
+
+import (
+	"context"
+	"io"
+	"math"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
+)
+
+// TestCartesiaLive_GenerationConfigEmotion is the regression guard for
+// the silent-API-drift bug we hit when Cartesia retired
+// voice.__experimental_controls.emotion on sonic-2+. Mocked tests can
+// only assert our outbound request shape; this test confirms Cartesia
+// actually accepts the shape we send.
+//
+// Skipped unless CARTESIA_API_KEY is set in the environment. Run with:
+//
+//	CARTESIA_API_KEY=... go test -tags=integration -run TestCartesiaLive \
+//	    ./runtime/tts/...
+//
+// The cost per run is tiny (a few seconds of synthesis on sonic-3) and
+// does not require any other provider — unlike running the full arena
+// demo which also pays for OpenAI Realtime per pass.
+func TestCartesiaLive_GenerationConfigEmotion(t *testing.T) {
+	apiKey := os.Getenv("CARTESIA_API_KEY")
+	if apiKey == "" {
+		t.Skip("CARTESIA_API_KEY not set; skipping live Cartesia test")
+	}
+
+	// "Confident Man" voice, the one the voice-refund-demo uses. Pin so
+	// regressions surface against the actual production voice rather than
+	// some Cartesia default that might track API drift differently.
+	const voiceID = "bf991597-6c13-47e4-8411-91ec2de5c466"
+	const phrase = "I want my money back right now."
+
+	svc := tts.NewCartesia(apiKey)
+
+	cfg := tts.SynthesisConfig{
+		Voice:  voiceID,
+		Format: tts.FormatPCM16,
+	}
+
+	t.Run("plain text synthesises", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		audio := mustSynth(t, ctx, svc, phrase, cfg)
+		if len(audio) < 4000 {
+			t.Errorf("plain synthesis returned only %d bytes; expected at least 4000 (≈80ms PCM16@24k)", len(audio))
+		}
+	})
+
+	t.Run("shout tag synthesises and Cartesia accepts generation_config", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		audio := mustSynth(t, ctx, svc, "[shouts]"+phrase+"[/]", cfg)
+		if len(audio) < 4000 {
+			t.Errorf("shouts synthesis returned only %d bytes; expected at least 4000", len(audio))
+		}
+	})
+
+	t.Run("shout audio differs audibly from plain audio", func(t *testing.T) {
+		// Sonic-3 is non-deterministic so byte-level inequality between
+		// renders is not a useful signal — even two plain renders differ.
+		// What we need is a signal that Cartesia is *acting on* our
+		// generation_config field. RMS-energy difference is robust here:
+		// silently-ignored controls produce statistically-identical RMS
+		// across reruns (within a few %); honoured controls produce a
+		// distinct envelope.
+		//
+		// Direction of the RMS change is not asserted because "angry" on
+		// sonic-3 can render as tense/restrained rage with quieter
+		// average energy than neutral speech — what matters is that the
+		// envelope is measurably different.
+		//
+		// Audio files are written to /tmp/cartesia_*.wav-ish so we can
+		// A/B them by ear when calibrating. Format is raw PCM16 mono
+		// 24kHz; rename .pcm and import into Audacity if needed.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		plain := mustSynth(t, ctx, svc, phrase, cfg)
+		shout := mustSynth(t, ctx, svc, "[shouts]"+phrase+"[/]", cfg)
+
+		if err := os.WriteFile("/tmp/cartesia_plain.pcm", plain, 0o600); err != nil {
+			t.Logf("could not write /tmp/cartesia_plain.pcm: %v", err)
+		}
+		if err := os.WriteFile("/tmp/cartesia_shout.pcm", shout, 0o600); err != nil {
+			t.Logf("could not write /tmp/cartesia_shout.pcm: %v", err)
+		}
+
+		plainRMS := pcm16RMS(plain)
+		shoutRMS := pcm16RMS(shout)
+		plainPeak := pcm16Peak(plain)
+		shoutPeak := pcm16Peak(shout)
+		ratio := shoutRMS / plainRMS
+
+		t.Logf("plain: RMS=%.2f peak=%d bytes=%d", plainRMS, plainPeak, len(plain))
+		t.Logf("shout: RMS=%.2f peak=%d bytes=%d", shoutRMS, shoutPeak, len(shout))
+		t.Logf("RMS ratio (shout/plain) = %.2f", ratio)
+		t.Logf("Listen: ffplay -f s16le -ar 24000 /tmp/cartesia_shout.pcm")
+
+		// Cartesia is silently ignoring the field iff the RMS envelopes
+		// are statistically indistinguishable. 10% is a generous floor —
+		// content-driven variance between two distinct renders sits well
+		// inside that band.
+		drift := math.Abs(1.0 - ratio)
+		if drift < 0.1 {
+			t.Errorf("shout RMS is within 10%% of plain RMS (ratio=%.2f). "+
+				"Cartesia is likely silently ignoring generation_config; "+
+				"check API surface against current docs.", ratio)
+		}
+	})
+}
+
+// mustSynth synthesises text via the live Cartesia API and returns the
+// raw PCM bytes. Fails the test on synth error or empty result.
+func mustSynth(t *testing.T, ctx context.Context, svc *tts.CartesiaService, text string, cfg tts.SynthesisConfig) []byte {
+	t.Helper()
+	r, err := svc.Synthesize(ctx, text, cfg)
+	if err != nil {
+		t.Fatalf("Synthesize(%q): %v", text, err)
+	}
+	defer r.Close()
+	audio, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read synthesised audio: %v", err)
+	}
+	if len(audio) == 0 {
+		t.Fatalf("synthesis returned zero bytes for %q", text)
+	}
+	return audio
+}
+
+// pcm16RMS and pcm16Peak moved to pcm_helpers_test.go so the
+// elevenlabs_integration build tag can share them.
+
+// Compile-time assertion that base.WithModel is reachable for follow-up
+// tests that want to pin sonic-3 vs sonic-3.5 etc. Currently unused, but
+// keeps the import warm so editors don't strip it on the next refactor.
+var _ = base.WithModel

--- a/runtime/tts/cartesia_shouts_probe_test.go
+++ b/runtime/tts/cartesia_shouts_probe_test.go
@@ -1,0 +1,156 @@
+//go:build cartesia_integration
+
+package tts_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestCartesiaShouts_ProbeVariants sweeps Cartesia's sonic-3 emotion
+// vocabulary + volume range against the same phrase and writes each
+// rendering to /tmp/cartesia_probe_<label>.pcm for A/B listening.
+//
+// Cartesia's primary set is documented as
+// (neutral, calm, angry, content, sad, scared) with 60+ additional
+// names supported — but the docs don't enumerate them. This test
+// brute-forces the rage-adjacent candidates so we can pick the value
+// that actually shouts on the Confident-Man voice and bake it into
+// cartesiaEmotionForTag.
+//
+// Runs raw HTTP against Cartesia (bypassing our public API) so we can
+// probe values that have no markup-tag mapping yet. Tag-gated:
+//
+//	CARTESIA_API_KEY=... go test -tags=cartesia_integration \
+//	    -run TestCartesiaShouts_ProbeVariants -count=1 -v ./runtime/tts/...
+func TestCartesiaShouts_ProbeVariants(t *testing.T) {
+	apiKey := os.Getenv("CARTESIA_API_KEY")
+	if apiKey == "" {
+		t.Skip("CARTESIA_API_KEY not set; skipping live Cartesia probe")
+	}
+
+	const voiceID = "bf991597-6c13-47e4-8411-91ec2de5c466" // Confident Man
+	const phrase = "Thirteen MONTHS and they fail?! I want my money back NOW!"
+
+	variants := []struct {
+		label   string
+		emotion string  // empty = no generation_config
+		volume  float64 // 0 = no volume override
+	}{
+		{"plain", "", 0},
+		{"angry_v10", "angry", 1.0},
+		{"angry_v16", "angry", 1.6},
+		{"angry_v20", "angry", 2.0},
+		{"enraged_v20", "enraged", 2.0},
+		{"furious_v20", "furious", 2.0},
+		{"yelling_v20", "yelling", 2.0},
+		{"shouting_v20", "shouting", 2.0},
+		{"aggressive_v20", "aggressive", 2.0},
+		{"hostile_v20", "hostile", 2.0},
+		{"angry_v20_speed_fast", "angry", 2.0},
+	}
+
+	type rendered struct {
+		label string
+		path  string
+		bytes int
+		rms   float64
+		peak  int
+		http  int
+	}
+
+	var results []rendered
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	for _, v := range variants {
+		body := map[string]interface{}{
+			"model_id":   "sonic-3",
+			"transcript": phrase,
+			"voice":      map[string]string{"mode": "id", "id": voiceID},
+			"language":   "en",
+			"output_format": map[string]interface{}{
+				"container":   "raw",
+				"encoding":    "pcm_s16le",
+				"sample_rate": 24000,
+			},
+		}
+
+		if v.emotion != "" || v.volume != 0 {
+			gen := map[string]interface{}{}
+			if v.emotion != "" {
+				gen["emotion"] = v.emotion
+			}
+			if v.volume != 0 {
+				gen["volume"] = v.volume
+			}
+			if v.label == "angry_v20_speed_fast" {
+				gen["speed"] = 1.3
+			}
+			body["generation_config"] = gen
+		}
+
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", v.label, err)
+		}
+
+		req, err := http.NewRequestWithContext(context.Background(),
+			http.MethodPost,
+			"https://api.cartesia.ai/tts/bytes",
+			bytes.NewReader(raw))
+		if err != nil {
+			t.Fatalf("NewRequest %s: %v", v.label, err)
+		}
+		req.Header.Set("X-API-Key", apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Cartesia-Version", "2026-03-01")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("Do %s: %v", v.label, err)
+		}
+		audio, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("read %s: %v", v.label, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Logf("%-22s HTTP %d body=%s", v.label, resp.StatusCode, string(audio))
+			results = append(results, rendered{label: v.label, http: resp.StatusCode, bytes: len(audio)})
+			continue
+		}
+
+		path := fmt.Sprintf("/tmp/cartesia_probe_%s.pcm", v.label)
+		if werr := os.WriteFile(path, audio, 0o600); werr != nil {
+			t.Logf("write %s: %v", path, werr)
+		}
+
+		results = append(results, rendered{
+			label: v.label,
+			path:  path,
+			bytes: len(audio),
+			rms:   pcm16RMS(audio),
+			peak:  pcm16Peak(audio),
+			http:  resp.StatusCode,
+		})
+	}
+
+	t.Log("=== probe results ===")
+	for _, r := range results {
+		if r.http != http.StatusOK {
+			t.Logf("%-22s HTTP=%d  (rejected)", r.label, r.http)
+			continue
+		}
+		t.Logf("%-22s HTTP=%d bytes=%-7d RMS=%-8.2f peak=%-5d  file=%s",
+			r.label, r.http, r.bytes, r.rms, r.peak, r.path)
+	}
+	t.Log(`Convert to WAV with: for f in /tmp/cartesia_probe_*.pcm; do sox -r 24000 -e signed -b 16 -c 1 -t raw "$f" "${f}.wav"; done`)
+}

--- a/runtime/tts/cartesia_test.go
+++ b/runtime/tts/cartesia_test.go
@@ -86,8 +86,8 @@ func TestCartesiaService_Synthesize_Success(t *testing.T) {
 		}
 
 		version := r.Header.Get("Cartesia-Version")
-		if version != "2024-06-10" {
-			t.Errorf("Cartesia-Version = %v, want 2024-06-10", version)
+		if version != "2026-03-01" {
+			t.Errorf("Cartesia-Version = %v, want 2026-03-01", version)
 		}
 
 		// Verify body
@@ -156,15 +156,15 @@ func TestCartesiaService_Synthesize_LowersTagsToEmotion(t *testing.T) {
 	if got.Transcript != "Surprise!Hi." {
 		t.Errorf("Transcript = %q, want stripped %q", got.Transcript, "Surprise!Hi.")
 	}
-	if got.Voice.ExperimentalControls == nil {
-		t.Fatal("ExperimentalControls should be set when tags are present")
+	if got.GenerationConfig == nil {
+		t.Fatal("GenerationConfig should be set when tags are present")
 	}
-	emo := got.Voice.ExperimentalControls.Emotion
-	if len(emo) != 2 {
-		t.Fatalf("emotion = %v, want 2 entries", emo)
+	// First actionable tag wins on sonic-3 (single emotion per utterance).
+	if got.GenerationConfig.Emotion != "excited" {
+		t.Errorf("emotion = %q, want %q", got.GenerationConfig.Emotion, "excited")
 	}
-	if emo[0] != "positivity:high" || emo[1] != "positivity:medium" {
-		t.Errorf("emotion = %v, want [positivity:high positivity:medium]", emo)
+	if got.GenerationConfig.Volume != 0 {
+		t.Errorf("volume should be unset (no shout tag); got %v", got.GenerationConfig.Volume)
 	}
 }
 
@@ -189,8 +189,11 @@ func TestCartesiaService_Synthesize_PlainTextUnchanged(t *testing.T) {
 	defer reader.Close()
 	_, _ = io.ReadAll(reader)
 
+	if strings.Contains(string(raw), `generation_config`) {
+		t.Errorf("generation_config should be omitted for plain text; got %s", raw)
+	}
 	if strings.Contains(string(raw), `__experimental_controls`) {
-		t.Errorf("experimental_controls should be omitted for plain text; got %s", raw)
+		t.Errorf("legacy __experimental_controls must never appear; got %s", raw)
 	}
 }
 
@@ -207,13 +210,13 @@ func TestCartesiaService_PersonaRubric_AlwaysEmotionOnly(t *testing.T) {
 
 func TestCartesiaEmotionForTag(t *testing.T) {
 	cases := map[string]string{
-		"excited":  "positivity:high",
-		"laughs":   "positivity:high",
-		"smile":    "positivity:medium",
-		"smiles":   "positivity:medium",
-		"sad":      "sadness:high",
-		"sighs":    "sadness:high",
-		"shouts":   "anger:high",
+		"excited":  "excited",
+		"laughs":   "excited",
+		"smile":    "content",
+		"smiles":   "content",
+		"sad":      "sad",
+		"sighs":    "sad",
+		"shouts":   "angry",
 		"whispers": "", // no Cartesia analog
 		"calm":     "",
 		"pause":    "",
@@ -227,13 +230,34 @@ func TestCartesiaEmotionForTag(t *testing.T) {
 	}
 }
 
-func TestLowerCartesiaMarkup_DedupesAndDropsCloseTags(t *testing.T) {
-	transcript, emotions := lowerCartesiaMarkup("[excited]a[excited]b[/]c")
+func TestLowerCartesiaMarkup_FirstActionableTagWins(t *testing.T) {
+	// Sonic-3 takes one emotion per utterance — first actionable tag wins,
+	// later tags are dropped. Close tags don't promote themselves to an
+	// emotion. Transcript drops all bracket markup.
+	transcript, cfg := lowerCartesiaMarkup("[excited]a[sad]b[/]c")
 	if transcript != "abc" {
 		t.Errorf("transcript = %q, want %q", transcript, "abc")
 	}
-	if len(emotions) != 1 || emotions[0] != "positivity:high" {
-		t.Errorf("emotions = %v, want [positivity:high]", emotions)
+	if cfg == nil {
+		t.Fatal("generation_config should be set when an actionable tag is present")
+	}
+	if cfg.Emotion != "excited" {
+		t.Errorf("emotion = %q, want %q", cfg.Emotion, "excited")
+	}
+}
+
+func TestLowerCartesiaMarkup_ShoutTagBumpsVolume(t *testing.T) {
+	// [shouts] sets emotion=angry AND bumps volume so the rage envelope
+	// is audible on top of the emotion characterization.
+	_, cfg := lowerCartesiaMarkup("[shouts]I want my money![/]")
+	if cfg == nil {
+		t.Fatal("generation_config should be set for shout tag")
+	}
+	if cfg.Emotion != "angry" {
+		t.Errorf("emotion = %q, want %q", cfg.Emotion, "angry")
+	}
+	if cfg.Volume <= 1.0 || cfg.Volume > 2.0 {
+		t.Errorf("shout should bump volume into (1.0, 2.0]; got %v", cfg.Volume)
 	}
 }
 

--- a/runtime/tts/elevenlabs.go
+++ b/runtime/tts/elevenlabs.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/tts/markup"
 )
@@ -140,6 +141,26 @@ func (s *ElevenLabsService) Synthesize(
 	// through verbatim. Non-v3 models would speak the brackets literally,
 	// so strip them. Plain text (no tags) is byte-identical either way.
 	body := lowerElevenLabsMarkup(text, model)
+	if tags := markup.ParseTags(text); len(tags) > 0 {
+		names := make([]string, 0, len(tags))
+		for _, t := range tags {
+			if t.IsClose() {
+				continue
+			}
+			names = append(names, t.Name)
+		}
+		passthrough := elevenLabsSupportsInlineTags(model)
+		preview := body
+		if len(preview) > logPreviewLen {
+			preview = preview[:logPreviewLen] + "..."
+		}
+		logger.Info("elevenlabs: markup tags handled",
+			"model", model,
+			"voice", voice,
+			"tags", names,
+			"passthrough", passthrough,
+			"transcript_preview", preview)
+	}
 
 	reqBody := elevenLabsRequest{
 		Text:    body,

--- a/runtime/tts/elevenlabs_probe_test.go
+++ b/runtime/tts/elevenlabs_probe_test.go
@@ -1,0 +1,120 @@
+//go:build elevenlabs_integration
+
+package tts_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
+)
+
+// TestElevenLabsLive_ExpressiveTagsProbe is a calibration harness for
+// ElevenLabs v3 inline tag rendering. The complaint is "totally
+// unconvincing emotion on the anxious-recipient voice" — this test
+// sweeps voice × tag combinations and dumps each rendering so we can
+// pick the pair that actually carries the persona.
+//
+// Tagged separately so it doesn't run in the default suite. Invoke:
+//
+//	ELEVENLABS_API_KEY=... go test -tags=elevenlabs_integration \
+//	    -run TestElevenLabsLive -count=1 -v ./runtime/tts/...
+func TestElevenLabsLive_ExpressiveTagsProbe(t *testing.T) {
+	apiKey := os.Getenv("ELEVENLABS_API_KEY")
+	if apiKey == "" {
+		t.Skip("ELEVENLABS_API_KEY not set; skipping live ElevenLabs probe")
+	}
+
+	const phrase = "I can't find the parcel anywhere, and the birthday is tomorrow."
+
+	// Voices used by the demo (Bella) plus a few alternates with more
+	// expressive range. Voice IDs are from runtime/tts/elevenlabs.go
+	// SupportedVoices().
+	voices := []struct {
+		id    string
+		label string
+	}{
+		{"ErXwobaYiN019PkySvjV", "Antoni_male"},
+		{"TxGEqnHWrfWFTfGW9XjX", "Josh_male"},
+		{"VR6AewLTigWG4xSOukaG", "Arnold_male"},
+		{"pNInz6obpgDQGcFmaJgB", "Adam_male"},
+		{"yoZ06aMxZJJ28mfd3POQ", "Sam_male"},
+	}
+
+	// Tag variants — plain first, then increasing expressive intensity.
+	// All wrap the same charged phrase so audio differences isolate the
+	// tag effect rather than the content.
+	tagVariants := []struct {
+		label string
+		text  string
+	}{
+		{"plain", phrase},
+		{"whispers", "[whispers]" + phrase + "[/]"},
+		{"sighs", "[sighs]" + phrase + "[/]"},
+		{"sad", "[sad]" + phrase + "[/]"},
+		{"shouts", "[shouts]" + phrase + "[/]"},
+	}
+
+	type rendered struct {
+		voice    string
+		variant  string
+		path     string
+		bytes    int
+		rms      float64
+		peak     int
+		duration float64
+	}
+
+	var results []rendered
+
+	for _, v := range voices {
+		svc := tts.NewElevenLabs(apiKey, base.WithModel("eleven_v3"))
+
+		for _, tv := range tagVariants {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			r, err := svc.Synthesize(ctx, tv.text, tts.SynthesisConfig{
+				Voice:  v.id,
+				Format: tts.FormatPCM16,
+			})
+			if err != nil {
+				cancel()
+				t.Logf("Synthesize voice=%s variant=%s: %v", v.label, tv.label, err)
+				continue
+			}
+			audio, err := io.ReadAll(r)
+			_ = r.Close()
+			cancel()
+			if err != nil {
+				t.Logf("read voice=%s variant=%s: %v", v.label, tv.label, err)
+				continue
+			}
+
+			path := fmt.Sprintf("/tmp/eleven_%s_%s.pcm", v.label, tv.label)
+			if werr := os.WriteFile(path, audio, 0o600); werr != nil {
+				t.Logf("write %s: %v", path, werr)
+			}
+
+			results = append(results, rendered{
+				voice:    v.label,
+				variant:  tv.label,
+				path:     path,
+				bytes:    len(audio),
+				rms:      pcm16RMS(audio),
+				peak:     pcm16Peak(audio),
+				duration: float64(len(audio)) / 2 / 24000, // assumes mono 24k PCM16
+			})
+		}
+	}
+
+	t.Log("=== ElevenLabs probe results ===")
+	for _, r := range results {
+		t.Logf("%-22s %-10s bytes=%-7d RMS=%-8.2f peak=%-5d dur=%-5.2fs  %s",
+			r.voice, r.variant, r.bytes, r.rms, r.peak, r.duration, r.path)
+	}
+	t.Log(`Convert to WAV: for f in /tmp/eleven_*.pcm; do sox -r 24000 -e signed -b 16 -c 1 -t raw "$f" "${f}.wav"; done`)
+}

--- a/runtime/tts/pcm_helpers_test.go
+++ b/runtime/tts/pcm_helpers_test.go
@@ -1,0 +1,44 @@
+//go:build cartesia_integration || elevenlabs_integration
+
+package tts_test
+
+import "math"
+
+// pcm16RMS computes the root-mean-square amplitude of a little-endian
+// signed 16-bit PCM buffer. Output is on the [0, 32768] scale; values
+// near 0 indicate silence, values >2000 indicate strong signal. Shared
+// across the cartesia / elevenlabs integration probes.
+func pcm16RMS(b []byte) float64 {
+	if len(b) < 2 {
+		return 0
+	}
+	n := len(b) / 2
+	var sumSq float64
+	for i := 0; i < n; i++ {
+		sample := int16(b[2*i]) | int16(b[2*i+1])<<8
+		f := float64(sample)
+		sumSq += f * f
+	}
+	return math.Sqrt(sumSq / float64(n))
+}
+
+// pcm16Peak returns the absolute maximum sample magnitude of a
+// little-endian signed 16-bit PCM buffer. Useful complement to RMS:
+// peak tracks instantaneous loudness while RMS averages it.
+func pcm16Peak(b []byte) int {
+	if len(b) < 2 {
+		return 0
+	}
+	n := len(b) / 2
+	peak := 0
+	for i := 0; i < n; i++ {
+		sample := int(int16(b[2*i]) | int16(b[2*i+1])<<8)
+		if sample < 0 {
+			sample = -sample
+		}
+		if sample > peak {
+			peak = sample
+		}
+	}
+	return peak
+}

--- a/tools/arena/engine/duplex_executor_turns_integration.go
+++ b/tools/arena/engine/duplex_executor_turns_integration.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -640,8 +642,30 @@ func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 		return fmt.Errorf("failed to get content generator for turn %d: %w", turnIdx, err)
 	}
 
-	// Collect conversation history from state store
-	history := de.getConversationHistory(ctx, req)
+	// Wire the TTS provider's persona rubric into the text generator so
+	// the selfplay LLM sees the [shouts]/[sighs] vocabulary in its system
+	// prompt. The audio path through GetAudioContentGenerator does this
+	// for free; the duplex executor splits text generation and synthesis
+	// across two registry calls, so we have to mirror the wiring here or
+	// the rubric never reaches the LLM and the persona's `expressive: true`
+	// opt-in is silently a no-op.
+	if cg, ok := textGen.(*selfplay.ContentGenerator); ok {
+		if ttsService, terr := de.selfPlayRegistry.GetTTSRegistry().GetWithConfig(ttsConfig); terr == nil {
+			if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
+				cg.WithProviderRubric(rp.PersonaRubric())
+			}
+		}
+	}
+
+	// Collect conversation history from state store and trim it to what
+	// the selfplay LLM actually needs: spoken turns only. Without this
+	// trim the LLM sees the agent's full system prompt, tool descriptors,
+	// tool-result JSON, and every internal flag on the agent messages.
+	// Two consequences: it bloats token count (we observed >1000 tokens
+	// of input on turn 4 of a 4-turn scenario, ≈90% of which is noise
+	// the persona was never told to ignore) and it bleeds non-persona
+	// context into the LLM's output ("stuff that isn't in the prompt").
+	history := selfplayHistoryView(de.getConversationHistory(ctx, req))
 
 	// Generate text. Pass the selfplay turn number so the mock provider gets the
 	// correct turn response.
@@ -667,6 +691,15 @@ func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 		"persona":             turn.Persona,
 		"selfplay_turn_index": selfplayTurnNum,
 	}
+
+	// Surface the persona definition and the resolved system prompt on the
+	// user message so the arena dev panel can show "what drove this turn?"
+	// alongside the generated text. Two distinct keys keep concerns
+	// separated: _persona_yaml is the source-of-truth spec; _selfplay_prompt
+	// is the rubric-prefixed, variable-substituted string actually sent to
+	// the selfplay LLM. Underscore prefix matches the existing convention
+	// for dev-only metadata that downstream consumers should ignore.
+	stampSelfplayDevMeta(turnMeta, de.selfPlayRegistry, turn.Persona, textResult.Metadata)
 
 	// Copy only relevant metadata from the text generation result. Avoid copying
 	// pipeline internal fields like system_prompt, base_variables, etc.
@@ -1023,6 +1056,84 @@ func (de *DuplexConversationExecutor) sendUserMessage(
 
 // stampTTSCostInMeta writes the TTS cost for a synthesized turn into
 // turnMeta under ttsCostMetaKey. The value shape mirrors the self_play_cost
+// selfplayHistoryView trims the agent-side conversation history down to
+// the minimum the selfplay LLM needs to plan its next reply: the spoken
+// content of prior user and assistant turns, in order, with every other
+// kind of message dropped.
+//
+// What we strip and why:
+//   - system messages — the agent's system prompt is irrelevant to the
+//     selfplay persona; it's also the largest single noise source
+//   - tool messages — tool results (often long JSON) aren't part of the
+//     spoken conversation; the persona only reacts to what was *said*
+//   - assistant messages with no text content — pure-tool-call rounds
+//     that produce nothing audible
+//
+// We also strip media parts and tool-call metadata from the kept
+// messages, leaving only Role + Content. Anything in the original
+// state-store Message that the selfplay LLM might over-interpret
+// (latency, cost info, audio refs, finish reasons) is dropped.
+//
+// Order is preserved so role swapping in the downstream
+// HistoryInjectionStageSwapped keeps producing a coherent dialog
+// from the selfplay LLM's perspective.
+func selfplayHistoryView(history []types.Message) []types.Message {
+	if len(history) == 0 {
+		return nil
+	}
+	out := make([]types.Message, 0, len(history))
+	for i := range history {
+		m := history[i]
+		role := strings.ToLower(m.Role)
+		if role != roleUser && role != roleAssistant {
+			continue
+		}
+		text := strings.TrimSpace(m.Content)
+		if text == "" {
+			continue
+		}
+		out = append(out, types.Message{Role: m.Role, Content: text})
+	}
+	return out
+}
+
+// stampSelfplayDevMeta surfaces dev-only metadata for the arena UI:
+// the persona's source spec (marshaled to YAML) and the resolved system
+// prompt that drove the selfplay LLM call. Both go on the user message
+// under underscore-prefixed keys so downstream consumers (cost rollup,
+// assertion eval, exporters) ignore them as internal-only.
+//
+// Errors are swallowed: a missing persona or marshal failure must never
+// abort the turn. The user just won't see the corresponding dev panel
+// tab — same fail-soft contract as stampTTSCostInMeta.
+func stampSelfplayDevMeta(
+	turnMeta map[string]any,
+	registry *selfplay.Registry,
+	personaID string,
+	textResultMetadata map[string]interface{},
+) {
+	if turnMeta == nil {
+		return
+	}
+	if textResultMetadata != nil {
+		if sp, ok := textResultMetadata["system_prompt"].(string); ok && sp != "" {
+			turnMeta["_selfplay_prompt"] = sp
+		}
+	}
+	if registry == nil || personaID == "" {
+		return
+	}
+	persona := registry.GetPersona(personaID)
+	if persona == nil {
+		return
+	}
+	yamlBytes, err := yaml.Marshal(persona)
+	if err != nil {
+		return
+	}
+	turnMeta["_persona_yaml"] = string(yamlBytes)
+}
+
 // entry so addAncillaryCostFromMeta can fold it into the total without
 // special-casing.
 //

--- a/tools/arena/selfplay/generator.go
+++ b/tools/arena/selfplay/generator.go
@@ -282,6 +282,14 @@ func (cg *ContentGenerator) NextUserTurn(
 	result.Metadata["persona"] = cg.persona.ID
 	result.Metadata["role"] = "self-play-user"
 	result.Metadata["self_play_provider"] = cg.provider.ID()
+	// Surface the resolved system prompt so the duplex executor can stamp
+	// it on the user message for the arena dev panel's Self-Play tab. The
+	// PersonaAssemblyStage writes it into turnState during pipeline execution;
+	// reading from turnState here is safe because ExecuteSync above has
+	// returned, so no stage is still mutating turnState.
+	if turnState.SystemPrompt != "" {
+		result.Metadata["system_prompt"] = turnState.SystemPrompt
+	}
 
 	return result, nil
 }

--- a/tools/arena/selfplay/registry.go
+++ b/tools/arena/selfplay/registry.go
@@ -63,6 +63,18 @@ func NewRegistryWithTTS(
 	return reg
 }
 
+// GetPersona returns the parsed persona pack for the given ID, or nil
+// if no persona by that ID is registered. Used by the duplex executor
+// to surface the persona definition on selfplay user messages so the
+// arena UI can show "what drove this turn?" alongside the generated
+// text.
+func (r *Registry) GetPersona(personaID string) *config.UserPersonaPack {
+	if personaID == "" {
+		return nil
+	}
+	return r.personas[personaID]
+}
+
 // GetContentGenerator implements Provider interface
 // Returns a Generator for the given role and persona (cached for efficiency).
 // Uses double-check locking to prevent duplicate creation under concurrency.

--- a/tools/arena/web/frontend/src/components/DevToolsPanel.tsx
+++ b/tools/arena/web/frontend/src/components/DevToolsPanel.tsx
@@ -12,7 +12,7 @@ interface DevToolsPanelProps {
   onClose: () => void;
 }
 
-type TabId = "info" | "workflow" | "metrics" | "tools" | "prompt" | "selfplay" | "request" | "response" | "trace" | "assertions" | "evals" | "validators" | "raw";
+type TabId = "info" | "workflow" | "metrics" | "tools" | "prompt" | "selfplay" | "persona" | "request" | "response" | "trace" | "assertions" | "evals" | "validators" | "raw";
 
 interface TabDef {
   id: TabId;
@@ -28,7 +28,13 @@ function buildTabs(message?: Message, allMessages?: Message[]): TabDef[] {
   const meta = message.meta || {};
 
   if (meta._workflow_state) tabs.push({ id: "workflow", label: "Workflow", icon: "⚡" });
-  if (message.cost_info) tabs.push({ id: "metrics", label: "Metrics", icon: "📊" });
+  // Show Metrics for any cost surface — agent LLM (cost_info), selfplay
+  // LLM (meta.self_play_cost), or TTS (meta.tts_cost). Selfplay user
+  // turns don't have cost_info but DO have selfplay+TTS spend that the
+  // user needs to see for budgeting.
+  if (message.cost_info || meta.self_play_cost || meta.tts_cost) {
+    tabs.push({ id: "metrics", label: "Metrics", icon: "📊" });
+  }
 
   const toolCalls = message.tool_calls || [];
   const toolDescs = meta._tool_descriptors as unknown[] | undefined;
@@ -37,6 +43,7 @@ function buildTabs(message?: Message, allMessages?: Message[]): TabDef[] {
   }
 
   if (message.role === "system" || meta.system_prompt) tabs.push({ id: "prompt", label: "Prompt", icon: "📝" });
+  if (meta._persona_yaml) tabs.push({ id: "persona", label: "Persona", icon: "🎭" });
   if (meta._selfplay_prompt) tabs.push({ id: "selfplay", label: "Self-Play", icon: "🤖" });
   if (meta._llm_raw_request) tabs.push({ id: "request", label: "Request", icon: "📡" });
   if (meta._llm_raw_response) tabs.push({ id: "response", label: "Response", icon: "📥" });
@@ -132,6 +139,7 @@ export function DevToolsPanel({ message, messageIndex, allMessages, run, open, o
           {currentTab === "metrics" && <MetricsTab message={message} />}
           {currentTab === "tools" && <ToolsTab message={message} />}
           {currentTab === "prompt" && <PromptTab message={message} />}
+          {currentTab === "persona" && <YamlTab message={message} metaKey="_persona_yaml" />}
           {currentTab === "selfplay" && <MetaTextTab message={message} metaKey="_selfplay_prompt" />}
           {currentTab === "request" && <MetaJsonTab message={message} metaKey="_llm_raw_request" />}
           {currentTab === "response" && <MetaJsonTab message={message} metaKey="_llm_raw_response" />}
@@ -169,20 +177,79 @@ function InfoTab({ message, run }: { message?: Message; run?: ActiveRun }) {
   );
 }
 
+// formatCostUSD renders a fractional USD cost compactly. Sub-cent values
+// keep enough significant digits to be useful at the per-turn scale
+// (selfplay turns often cost <$0.001) without overflowing the row.
+function formatCostUSD(value: number): string {
+  if (!Number.isFinite(value) || value === 0) return "$0";
+  if (value < 0.0001) return `$${value.toExponential(2)}`;
+  return `$${value.toFixed(6)}`;
+}
+
+type CostShape = {
+  input_tokens?: number;
+  output_tokens?: number;
+  cached_tokens?: number;
+  input_cost_usd?: number;
+  output_cost_usd?: number;
+  total_cost_usd?: number;
+};
+
+type TTSCostShape = {
+  provider_name?: string;
+  total_cost_usd?: number;
+  quantities?: Record<string, number>;
+};
+
 function MetricsTab({ message }: { message?: Message }) {
-  if (!message?.cost_info) {
+  if (!message) return <Empty>No metrics available</Empty>;
+  const meta = (message.meta || {}) as Record<string, unknown>;
+  const c = message.cost_info;
+  const sp = meta.self_play_cost as CostShape | undefined;
+  const tts = meta.tts_cost as TTSCostShape | undefined;
+
+  if (!c && !sp && !tts && message.latency_ms == null) {
     return <Empty>No metrics available</Empty>;
   }
-  const c = message.cost_info;
+
   return (
-    <div className="space-y-3">
-      {message.latency_ms != null && <MetricRow label="Latency" value={`${message.latency_ms}ms`} />}
-      <MetricRow label="Input Tokens" value={c.input_tokens.toLocaleString()} />
-      <MetricRow label="Output Tokens" value={c.output_tokens.toLocaleString()} />
-      {c.cached_tokens != null && <MetricRow label="Cached Tokens" value={c.cached_tokens.toLocaleString()} />}
-      <MetricRow label="Input Cost" value={`$${c.input_cost_usd.toFixed(6)}`} />
-      <MetricRow label="Output Cost" value={`$${c.output_cost_usd.toFixed(6)}`} />
-      <MetricRow label="Total Cost" value={`$${c.total_cost_usd.toFixed(6)}`} />
+    <div className="space-y-4">
+      {(c || message.latency_ms != null) && (
+        <Section title="Agent LLM">
+          {message.latency_ms != null && <MetricRow label="Latency" value={`${message.latency_ms}ms`} />}
+          {c && (
+            <>
+              <MetricRow label="Input Tokens" value={c.input_tokens.toLocaleString()} />
+              <MetricRow label="Output Tokens" value={c.output_tokens.toLocaleString()} />
+              {c.cached_tokens != null && <MetricRow label="Cached Tokens" value={c.cached_tokens.toLocaleString()} />}
+              <MetricRow label="Input Cost" value={formatCostUSD(c.input_cost_usd)} />
+              <MetricRow label="Output Cost" value={formatCostUSD(c.output_cost_usd)} />
+              <MetricRow label="Total Cost" value={formatCostUSD(c.total_cost_usd)} />
+            </>
+          )}
+        </Section>
+      )}
+      {sp && (
+        <Section title="Self-Play LLM">
+          {sp.input_tokens != null && <MetricRow label="Input Tokens" value={sp.input_tokens.toLocaleString()} />}
+          {sp.output_tokens != null && <MetricRow label="Output Tokens" value={sp.output_tokens.toLocaleString()} />}
+          {sp.cached_tokens != null && sp.cached_tokens > 0 && (
+            <MetricRow label="Cached Tokens" value={sp.cached_tokens.toLocaleString()} />
+          )}
+          {sp.input_cost_usd != null && <MetricRow label="Input Cost" value={formatCostUSD(sp.input_cost_usd)} />}
+          {sp.output_cost_usd != null && <MetricRow label="Output Cost" value={formatCostUSD(sp.output_cost_usd)} />}
+          {sp.total_cost_usd != null && <MetricRow label="Total Cost" value={formatCostUSD(sp.total_cost_usd)} />}
+        </Section>
+      )}
+      {tts && (
+        <Section title={`TTS${tts.provider_name ? ` (${tts.provider_name})` : ""}`}>
+          {tts.quantities &&
+            Object.entries(tts.quantities).map(([unit, qty]) => (
+              <MetricRow key={unit} label={unit.charAt(0).toUpperCase() + unit.slice(1) + "s"} value={qty.toLocaleString()} />
+            ))}
+          {tts.total_cost_usd != null && <MetricRow label="Total Cost" value={formatCostUSD(tts.total_cost_usd)} />}
+        </Section>
+      )}
     </div>
   );
 }
@@ -235,6 +302,135 @@ function MetaTextTab({ message, metaKey }: { message?: Message; metaKey: string 
   const text = message?.meta?.[metaKey] as string | undefined;
   if (!text) return <Empty>No data</Empty>;
   return <pre className="text-xs font-mono text-[#cdd6f4] whitespace-pre-wrap leading-relaxed">{text}</pre>;
+}
+
+// YamlTab renders a YAML string with light syntax coloring so persona
+// definitions are easier to scan than a flat <pre>. Tokenizer is
+// line-based and intentionally simple — works on the YAML shape arena
+// emits (keys, scalars, block strings via |, list items, comments).
+// Anything outside that shape passes through uncoloured.
+function YamlTab({ message, metaKey }: { message?: Message; metaKey: string }) {
+  const text = message?.meta?.[metaKey] as string | undefined;
+  if (!text) return <Empty>No data</Empty>;
+  return (
+    <pre className="text-xs font-mono whitespace-pre-wrap leading-relaxed">
+      {text.split("\n").map((line, idx) => (
+        <YamlLine key={idx} line={line} />
+      ))}
+    </pre>
+  );
+}
+
+const yamlColor = {
+  key: "#89b4fa",      // blue
+  string: "#a6e3a1",   // green
+  literal: "#fab387",  // peach (numbers, booleans, null)
+  comment: "#6c7086",  // muted
+  punct: "#cba6f7",    // mauve (|, >, -)
+  text: "#cdd6f4",     // default
+} as const;
+
+function YamlLine({ line }: { line: string }) {
+  // Whole-line comment.
+  const trimmed = line.trimStart();
+  const indent = line.slice(0, line.length - trimmed.length);
+  if (trimmed.startsWith("#")) {
+    return (
+      <div>
+        {indent}
+        <span style={{ color: yamlColor.comment }}>{trimmed}</span>
+        {"\n"}
+      </div>
+    );
+  }
+  if (trimmed === "") return <div>{"\n"}</div>;
+
+  // List item ("- foo: bar" or "- foo")
+  let cursor = trimmed;
+  let bullet: React.ReactNode = null;
+  if (cursor.startsWith("- ")) {
+    bullet = <span style={{ color: yamlColor.punct }}>- </span>;
+    cursor = cursor.slice(2);
+  } else if (cursor === "-") {
+    bullet = <span style={{ color: yamlColor.punct }}>-</span>;
+    cursor = "";
+  }
+
+  // key: value pattern
+  const m = /^([^\s:][^:]*?):(\s*)(.*)$/.exec(cursor);
+  if (m) {
+    const [, key, gap, rest] = m;
+    return (
+      <div>
+        {indent}
+        {bullet}
+        <span style={{ color: yamlColor.key }}>{key}</span>
+        <span style={{ color: yamlColor.punct }}>:</span>
+        {gap}
+        <YamlScalar value={rest} />
+        {"\n"}
+      </div>
+    );
+  }
+
+  // Plain continuation of a block scalar / unrecognised line.
+  return (
+    <div>
+      {indent}
+      {bullet}
+      <span style={{ color: yamlColor.text }}>{cursor}</span>
+      {"\n"}
+    </div>
+  );
+}
+
+function YamlScalar({ value }: { value: string }) {
+  if (value === "") return null;
+  // Block scalar indicators take whatever follows (or comment).
+  if (value === "|" || value === ">" || value.startsWith("|-") || value.startsWith(">-")) {
+    return <span style={{ color: yamlColor.punct }}>{value}</span>;
+  }
+  // Trailing comment on a value: "foo  # note"
+  const hashIdx = inlineCommentStart(value);
+  if (hashIdx >= 0) {
+    return (
+      <>
+        <YamlScalar value={value.slice(0, hashIdx).trimEnd()} />
+        <span>{value.slice(hashIdx - 0).match(/^(\s*)/)?.[0] ?? ""}</span>
+        <span style={{ color: yamlColor.comment }}>{value.slice(hashIdx)}</span>
+      </>
+    );
+  }
+  if (/^(true|false|null|~)$/.test(value)) {
+    return <span style={{ color: yamlColor.literal }}>{value}</span>;
+  }
+  if (/^-?\d+(\.\d+)?$/.test(value)) {
+    return <span style={{ color: yamlColor.literal }}>{value}</span>;
+  }
+  return <span style={{ color: yamlColor.string }}>{value}</span>;
+}
+
+// inlineCommentStart returns the index of the start of an inline
+// `# comment` on a YAML scalar line, or -1 if none. Skips `#` inside
+// single- or double-quoted strings so values like 'order-#42' don't
+// trigger a false positive.
+function inlineCommentStart(s: string): number {
+  let q: "'" | '"' | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (q) {
+      if (c === q) q = null;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      q = c as "'" | '"';
+      continue;
+    }
+    if (c === "#" && (i === 0 || s[i - 1] === " " || s[i - 1] === "\t")) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 function AssertionsTab({ message, allMessages }: { message?: Message; allMessages?: Message[] }) {

--- a/tools/arena/web/sse_latency_test.go
+++ b/tools/arena/web/sse_latency_test.go
@@ -1,0 +1,106 @@
+package web
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	arenaaudio "github.com/AltairaLabs/PromptKit/tools/arena/audio"
+)
+
+// TestSSELatency_PublishToWrite is a diagnostic probe. It measures the gap
+// between AudioRouter.Publish (server emits a frame) and the moment the
+// SSE writer flushes it to the wire. If gaps are sub-ms, server-side
+// batching can be ruled out as the source of inter-turn playback offset
+// on the live demo. If gaps are large, the SSE relay is buffering.
+//
+// Not strictly a regression-locking test; failure thresholds are
+// generous. Run with -v to read the per-frame measurements.
+func TestSSELatency_PublishToWrite(t *testing.T) {
+	router := arenaaudio.NewAudioRouter(arenaaudio.Rate24k)
+	defer router.Close()
+
+	adapter := NewEventAdapter()
+	adapter.AttachAudioRouter("probe", router, arenaaudio.Rate24k)
+
+	srv := NewServer(adapter, nil, nil, "")
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/events?audio=1", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("SSE connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the initial keepalive so the handler has fully registered the
+	// client before we start publishing. Without this the first few
+	// frames can race the Register call.
+	reader := bufio.NewReader(resp.Body)
+	for {
+		line, rerr := reader.ReadString('\n')
+		if rerr != nil {
+			t.Fatalf("initial read: %v", rerr)
+		}
+		if strings.HasPrefix(line, ": connected") {
+			break
+		}
+	}
+
+	const nFrames = 30
+	const interval = 20 * time.Millisecond
+	publishTimes := make([]time.Time, nFrames)
+
+	go func() {
+		for i := 0; i < nFrames; i++ {
+			publishTimes[i] = time.Now()
+			router.Publish(arenaaudio.Frame{
+				Direction: arenaaudio.DirectionOutput,
+				Samples:   make([]int16, 480), // 20ms @ 24kHz mono
+				Timestamp: publishTimes[i],
+			})
+			time.Sleep(interval)
+		}
+	}()
+
+	received := 0
+	var maxLatency, sumLatency time.Duration
+	for received < nFrames {
+		line, rerr := reader.ReadString('\n')
+		if rerr != nil {
+			t.Fatalf("read after %d frames: %v", received, rerr)
+		}
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		now := time.Now()
+		// The line includes the frame's JSON payload. We don't decode it —
+		// we only care that bytes arrived on the wire at `now`.
+		if received < len(publishTimes) {
+			latency := now.Sub(publishTimes[received])
+			if latency > maxLatency {
+				maxLatency = latency
+			}
+			sumLatency += latency
+			t.Logf("frame %d publish→client %v", received, latency)
+		}
+		received++
+	}
+
+	avg := sumLatency / time.Duration(nFrames)
+	t.Logf("SUMMARY frames=%d avg=%v max=%v", nFrames, avg, maxLatency)
+
+	// Generous bound: if average exceeds half a chunk-duration (10ms),
+	// there's a noticeable batching effect worth investigating.
+	if avg > 50*time.Millisecond {
+		t.Errorf("average publish→client latency %v exceeds 50ms — SSE relay is batching", avg)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix the audio pacing stage so realtime providers don't accumulate multi-second SSE buffer overrun via spurious mid-utterance preroll re-arms.
- Update Cartesia to the current `generation_config.{emotion,volume}` API (the legacy `__experimental_controls` was silently dropped on sonic-2+); `[shouts]` now actually shouts on sonic-3.
- Wire the TTS persona rubric onto the duplex selfplay path — `style.expressive: true` was previously a no-op there, so the LLM never saw the `[shouts]`/`[sighs]` vocabulary.
- Trim conversation history before injection so the selfplay LLM stops seeing the agent's system prompt + tool descriptors + tool-result JSON as context.
- Surface persona spec, resolved selfplay prompt, and selfplay+TTS cost on user messages in the arena dev panel.
- New `anxious-delivery` scenario + `anxious-recipient` persona paired with ElevenLabs v3 / Arnold; simplified `aggressive-entitled` persona now that the rubric is actually injected.
- Cartesia + ElevenLabs probe harnesses (tag-gated integration tests; no OpenAI cost) calibrate the voice ↔ tag mappings.

## Test plan

- [x] `go test ./runtime/pipeline/stage/...` — pacing regression guards
- [x] `go test ./runtime/tts/...` — cartesia request shape, generation_config wiring
- [x] `go test ./runtime/providers/mock/...` — tool_calls turn emission
- [x] `go test ./tools/arena/engine/... ./tools/arena/selfplay/... ./tools/arena/web/...`
- [x] Manual: aggressive-refund × aggressive-entitled × Cartesia/openai-gpt4o-realtime → audible shouting
- [x] Manual: anxious-delivery × anxious-recipient × ElevenLabs/openai-gpt4o-realtime → audible whispers/sighs
- [x] Manual: dev panel Persona + Self-Play + Metrics tabs populate on user messages
- [ ] `CARTESIA_API_KEY=… go test -tags=cartesia_integration ./runtime/tts/...` (manual, costs Cartesia credits)
- [ ] `ELEVENLABS_API_KEY=… go test -tags=elevenlabs_integration ./runtime/tts/...` (manual, costs ElevenLabs credits)
