### PR TITLE
feat: capability-tagged providers + arena voice catalog

### DIFF
--- a/docs/src/content/docs/arena/how-to/setup-voice-testing.md
+++ b/docs/src/content/docs/arena/how-to/setup-voice-testing.md
@@ -11,7 +11,46 @@ Configure automated voice testing using self-play mode with TTS for multi-turn c
 
 ## Quick Setup
 
-### 1. Create the Provider Configuration
+### 1. Declare TTS Providers and Voices in the Arena Config
+
+TTS is configured at the arena level. Declare one or more TTS provider files under
+`tts_providers:`, then bind voice IDs in `voices:`. Personas and scenarios reference
+those IDs — a single edit to `voices:` swaps between a real vendor and mock TTS for CI.
+
+```yaml
+# config.arena.yaml
+spec:
+  providers:
+    - file: providers/gemini-live.provider.yaml
+
+  tts_providers:
+    - file: providers/openai-alloy.provider.yaml  # real TTS
+    - file: providers/mock-tts.provider.yaml       # for CI
+
+  voices:
+    # Real-vendor mode: point to openai-alloy.
+    # CI / keyless mode: change provider to mock-tts.
+    - id: test-voice
+      provider: openai-alloy
+```
+
+The provider files themselves declare the vendor details:
+
+```yaml
+# providers/openai-alloy.provider.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-alloy
+spec:
+  id: openai-alloy
+  type: openai
+  capability: tts
+  voice: alloy
+  sample_rate: 24000
+```
+
+### 2. Create a Provider Configuration for the Duplex Model
 
 ```yaml
 # providers/gemini-live.provider.yaml
@@ -29,7 +68,10 @@ spec:
       - AUDIO
 ```
 
-### 2. Create a Persona for Self-Play
+### 3. Create a Persona for Self-Play
+
+Assign a voice ID from the catalog to the persona. The runtime resolves it to the
+correct TTS provider at run time.
 
 ```yaml
 # prompts/personas/test-user.persona.yaml
@@ -39,6 +81,7 @@ metadata:
   name: test-user
 spec:
   id: test-user
+  voice: test-voice
   description: "Curious user asking follow-up questions"
   system_prompt: |
     You are testing a voice assistant. Ask natural follow-up
@@ -46,7 +89,10 @@ spec:
     brief and conversational.
 ```
 
-### 3. Create the Self-Play Scenario
+### 4. Create the Self-Play Scenario
+
+The scenario references the persona by ID. No inline `tts:` block is needed — the
+voice is resolved through the catalog.
 
 ```yaml
 # scenarios/voice-selfplay.scenario.yaml
@@ -79,16 +125,13 @@ spec:
             file_path: audio/greeting.pcm
             mime_type: audio/L16
 
-    # Self-play generates follow-up turns
+    # Self-play generates follow-up turns; voice is resolved from the persona
     - role: selfplay-user
       persona: test-user
       turns: 3
-      tts:
-        provider: openai
-        voice: alloy
 ```
 
-### 4. Run the Test
+### 5. Run the Test
 
 ```bash
 export GEMINI_API_KEY="your-key"
@@ -96,22 +139,20 @@ export OPENAI_API_KEY="your-key"
 promptarena run --scenario voice-selfplay --provider gemini-live
 ```
 
-## Using Mock TTS
+## CI vs Recording Mode
 
-For faster testing without OpenAI costs, use pre-recorded audio:
+Because voice IDs are declared in one place (`voices:` in the arena config), switching
+between real TTS and a mock is a single-line change:
 
 ```yaml
-turns:
-  - role: selfplay-user
-    persona: test-user
-    turns: 3
-    tts:
-      provider: mock
-      audio_files:
-        - audio/question1.pcm
-        - audio/question2.pcm
-        - audio/question3.pcm
-      sample_rate: 16000
+voices:
+  # Recording mode (requires OPENAI_API_KEY):
+  - id: test-voice
+    provider: openai-alloy
+
+  # CI / keyless mode — swap to:
+  # - id: test-voice
+  #   provider: mock-tts
 ```
 
 ## Tuning Turn Detection
@@ -133,9 +174,6 @@ turns:
   - role: selfplay-user
     persona: test-user
     turns: 3
-    tts:
-      provider: openai
-      voice: alloy
     assertions:
       - type: content_matches
         params:

--- a/docs/src/content/docs/arena/reference/duplex-config.md
+++ b/docs/src/content/docs/arena/reference/duplex-config.md
@@ -190,55 +190,71 @@ Set to `false` if you need the final turn to complete normally without session t
 
 ---
 
-## TTSConfig
+## Voice Catalog
 
-[Text-to-speech (TTS)](/glossary#tts) configuration for self-play audio generation.
+[Text-to-speech (TTS)](/glossary#tts) for self-play audio generation is configured through the
+arena voice catalog rather than inline on individual turns. TTS providers are declared in
+`tts_providers:` and bound to voice IDs in `voices:`. Personas and scripted-text scenarios
+reference those IDs.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `provider` | string | Yes | TTS provider: `"openai"`, `"elevenlabs"`, `"cartesia"`, `"mock"` |
-| `voice` | string | Yes* | Voice ID for synthesis (*optional for mock with audio_files) |
-| `audio_files` | []string | No | PCM audio files for mock provider (rotated through) |
-| `sample_rate` | int | No | Output sample rate in Hz (default: 24000) |
-
-### Example: OpenAI TTS
+### Arena-Level Declaration
 
 ```yaml
-turns:
-  - role: selfplay-user
-    persona: curious-customer
-    turns: 3
-    tts:
-      provider: openai
-      voice: alloy
+# config.arena.yaml
+spec:
+  tts_providers:
+    - file: providers/openai-alloy.provider.yaml
+    - file: providers/mock-tts.provider.yaml
+
+  voices:
+    # Real TTS (requires OPENAI_API_KEY). For CI: change provider to mock-tts.
+    - id: alloy
+      provider: openai-alloy
 ```
 
-### Example: Mock TTS with Pre-recorded Audio
+### Persona Voice Assignment
+
+Assign a voice ID to a persona. All selfplay turns using that persona will use the
+corresponding TTS provider.
 
 ```yaml
-turns:
-  - role: selfplay-user
-    persona: test-persona
-    turns: 3
-    tts:
-      provider: mock
-      audio_files:
-        - audio/question1.pcm
-        - audio/question2.pcm
-        - audio/question3.pcm
-      sample_rate: 16000  # Match your file sample rate
+# personas/curious-customer.persona.yaml
+spec:
+  id: curious-customer
+  voice: alloy   # references the voice catalog id above
+  system_template: |
+    You are a curious customer ...
 ```
 
-### Available OpenAI Voices
+### Scripted-Text Scenario Voice Assignment
 
-| Voice | Description |
-|-------|-------------|
-| `alloy` | Neutral, balanced |
-| `echo` | Warm, engaging |
-| `fable` | Expressive, dynamic |
-| `onyx` | Deep, authoritative |
-| `nova` | Friendly, conversational |
-| `shimmer` | Clear, professional |
+For scripted-text duplex scenarios (turns with `content:` instead of audio `parts:`),
+declare `voice:` at the scenario level:
+
+```yaml
+spec:
+  id: my-scripted-scenario
+  voice: alloy   # references the voice catalog id above
+  turns:
+    - role: user
+      content: "Hello, can you hear me?"
+```
+
+### CI vs Recording Mode
+
+A single edit to the `voices:` block in the arena config switches between real vendor
+TTS and mock TTS, with no changes required to personas or scenarios:
+
+```yaml
+voices:
+  # Recording mode (requires API key):
+  - id: alloy
+    provider: openai-alloy
+
+  # CI / keyless mode — swap to:
+  # - id: alloy
+  #   provider: mock-tts
+```
 
 ---
 
@@ -362,13 +378,10 @@ spec:
           params:
             pattern: "(?i)(hello|hi|welcome)"
 
-    # Self-play generates follow-up questions
+    # Self-play generates follow-up questions; voice is resolved from the persona
     - role: selfplay-user
       persona: curious-customer
       turns: 3
-      tts:
-        provider: openai
-        voice: nova
       assertions:
         - type: content_matches
           params:
@@ -394,8 +407,8 @@ Common configuration errors and solutions:
 | `invalid duplex timeout format` | Timeout not in Go duration format | Use format like `"5m"`, `"30s"`, `"1h30m"` |
 | `invalid turn detection mode` | Mode not `vad` or `asm` | Use `mode: vad` or `mode: asm` |
 | `silence_threshold_ms must be non-negative` | Negative VAD threshold | Use positive values |
-| `tts provider is required` | Missing TTS provider | Add `provider: openai` or similar |
-| `tts voice is required` | Missing voice ID | Add `voice: alloy` or similar |
+| `voices[N]: provider "X" not found` | Voice references an unknown TTS provider ID | Check that `tts_providers:` lists the provider file and the `id:` matches |
+| `persona "X": voice "Y" not found in catalog` | Persona references a voice ID not declared in `voices:` | Add the voice binding to the arena `voices:` list |
 
 ---
 

--- a/docs/src/content/docs/arena/tutorials/06-duplex-testing.md
+++ b/docs/src/content/docs/arena/tutorials/06-duplex-testing.md
@@ -273,13 +273,11 @@ spec:
           params:
             pattern: "(?i)(help|assist)"
 
-    # Self-play: LLM generates questions, TTS converts to audio
+    # Self-play: LLM generates questions, TTS converts to audio.
+    # Voice is resolved from the persona via the arena voice catalog.
     - role: selfplay-user
       persona: curious-customer
       turns: 3  # Generate 3 follow-up turns
-      tts:
-        provider: openai
-        voice: alloy
       assertions:
         - type: content_matches
           params:
@@ -290,7 +288,7 @@ spec:
     user_type: "potential customer"
 ```
 
-Create the persona:
+Create the persona and assign a voice from the catalog:
 
 ```yaml
 # prompts/personas/curious-customer.persona.yaml
@@ -301,6 +299,7 @@ metadata:
 
 spec:
   id: curious-customer
+  voice: alloy   # references the voice catalog id in config.arena.yaml
   description: "A curious customer asking follow-up questions"
 
   system_prompt: |
@@ -309,20 +308,33 @@ spec:
     Keep questions brief and conversational.
 ```
 
-Configure the TTS provider:
+Declare the TTS provider and voice in the arena config:
 
 ```yaml
-# providers/openai-tts.provider.yaml
+# config.arena.yaml (additions)
+spec:
+  tts_providers:
+    - file: providers/openai-alloy.provider.yaml
+    - file: providers/mock-tts.provider.yaml  # for CI / keyless runs
+
+  voices:
+    # Real TTS (requires OPENAI_API_KEY). For CI: change provider to mock-tts.
+    - id: alloy
+      provider: openai-alloy
+```
+
+```yaml
+# providers/openai-alloy.provider.yaml
 apiVersion: promptkit.altairalabs.ai/v1alpha1
 kind: Provider
 metadata:
-  name: openai-tts
-
+  name: openai-alloy
 spec:
-  id: openai
+  id: openai-alloy
   type: openai
-  api_key_env: OPENAI_API_KEY
-  model: gpt-4o-mini
+  capability: tts
+  voice: alloy
+  sample_rate: 24000
 ```
 
 Run the self-play test:

--- a/examples/duplex-streaming/config.arena.yaml
+++ b/examples/duplex-streaming/config.arena.yaml
@@ -44,6 +44,7 @@ spec:
     - file: providers/elevenlabs-rachel.provider.yaml
     - file: providers/openai-echo.provider.yaml
     - file: providers/openai-alloy-expressive.provider.yaml
+    - file: providers/openai-alloy.provider.yaml
     - file: providers/mock-tts.provider.yaml
 
   voices:
@@ -55,6 +56,11 @@ spec:
       provider: openai-echo
     - id: alloy-expressive
       provider: openai-alloy-expressive
+    # Scripted-text scenario voices. mock-tts serves CI runs without API keys.
+    - id: scripted-mock
+      provider: mock-tts
+    - id: scripted-alloy
+      provider: openai-alloy
 
   # Scenario definitions
   scenarios:

--- a/examples/duplex-streaming/config.arena.yaml
+++ b/examples/duplex-streaming/config.arena.yaml
@@ -40,6 +40,22 @@ spec:
     # Replay provider for deterministic playback of recorded sessions
     # - file: providers/replay-duplex.provider.yaml  # Disabled until we have a recording
 
+  tts_providers:
+    - file: providers/elevenlabs-rachel.provider.yaml
+    - file: providers/openai-echo.provider.yaml
+    - file: providers/openai-alloy-expressive.provider.yaml
+    - file: providers/mock-tts.provider.yaml
+
+  voices:
+    # For real-provider mode (requires API keys). For keyless CI:
+    # change each `provider:` below to `mock-tts`.
+    - id: rachel
+      provider: elevenlabs-rachel
+    - id: echo
+      provider: openai-echo
+    - id: alloy-expressive
+      provider: openai-alloy-expressive
+
   # Scenario definitions
   scenarios:
     - file: scenarios/duplex-basic.scenario.yaml

--- a/examples/duplex-streaming/personas/busy-professional.persona.yaml
+++ b/examples/duplex-streaming/personas/busy-professional.persona.yaml
@@ -11,6 +11,7 @@ metadata:
 
 spec:
   id: busy-professional
+  voice: alloy-expressive
   description: "A busy professional checking weather, schedule, and setting reminders"
 
   # System prompt for generating user messages

--- a/examples/duplex-streaming/personas/curious-customer.persona.yaml
+++ b/examples/duplex-streaming/personas/curious-customer.persona.yaml
@@ -10,6 +10,7 @@ metadata:
 
 spec:
   id: curious-customer
+  voice: rachel
   description: "A friendly, inquisitive customer interested in learning more"
 
   # System prompt for generating user messages

--- a/examples/duplex-streaming/personas/technical-user.persona.yaml
+++ b/examples/duplex-streaming/personas/technical-user.persona.yaml
@@ -10,6 +10,7 @@ metadata:
 
 spec:
   id: technical-user
+  voice: echo
   description: "A user with technical knowledge troubleshooting an issue"
 
   # System prompt for generating user messages

--- a/examples/duplex-streaming/providers/elevenlabs-rachel.provider.yaml
+++ b/examples/duplex-streaming/providers/elevenlabs-rachel.provider.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: elevenlabs-rachel
+spec:
+  id: elevenlabs-rachel
+  type: elevenlabs
+  capability: tts
+  voice: 21m00Tcm4TlvDq8ikWAM
+  sample_rate: 24000

--- a/examples/duplex-streaming/providers/mock-tts.provider.yaml
+++ b/examples/duplex-streaming/providers/mock-tts.provider.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-tts
+spec:
+  id: mock-tts
+  type: mock
+  capability: tts
+  audio_files:
+    - audio/greeting.pcm
+    - audio/question.pcm
+    - audio/funfact.pcm
+  sample_rate: 16000

--- a/examples/duplex-streaming/providers/openai-alloy-expressive.provider.yaml
+++ b/examples/duplex-streaming/providers/openai-alloy-expressive.provider.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-alloy-expressive
+spec:
+  id: openai-alloy-expressive
+  type: openai
+  capability: tts
+  model: gpt-4o-mini-tts
+  voice: alloy
+  sample_rate: 24000

--- a/examples/duplex-streaming/providers/openai-alloy.provider.yaml
+++ b/examples/duplex-streaming/providers/openai-alloy.provider.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-alloy
+spec:
+  id: openai-alloy
+  type: openai
+  capability: tts
+  voice: alloy
+  sample_rate: 24000

--- a/examples/duplex-streaming/providers/openai-echo.provider.yaml
+++ b/examples/duplex-streaming/providers/openai-echo.provider.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-echo
+spec:
+  id: openai-echo
+  type: openai
+  capability: tts
+  voice: echo
+  sample_rate: 24000

--- a/examples/duplex-streaming/scenarios/duplex-interactive.scenario.yaml
+++ b/examples/duplex-streaming/scenarios/duplex-interactive.scenario.yaml
@@ -39,9 +39,6 @@ spec:
     - role: selfplay-user
       persona: technical-user
       turns: 2
-      tts:
-        provider: openai
-        voice: echo
       assertions:
         - type: content_matches
           params:

--- a/examples/duplex-streaming/scenarios/duplex-scripted-text-openai.scenario.yaml
+++ b/examples/duplex-streaming/scenarios/duplex-scripted-text-openai.scenario.yaml
@@ -2,8 +2,12 @@
 #
 # Scripted-Text Duplex Scenario — Real OpenAI TTS variant
 #
-# Same shape as duplex-scripted-text but uses OpenAI TTS to synthesize each
-# user turn into real audio. Requires OPENAI_API_KEY. Excluded from CI.
+# Same shape as duplex-scripted-text but uses OpenAI TTS (tts-1, alloy voice)
+# to synthesize each user turn into real audio. Requires OPENAI_API_KEY.
+# Excluded from CI.
+#
+# `voice:` references the arena voice catalog (scripted-alloy → openai-alloy
+# provider yaml). The duplex executor resolves it via Config.ResolveVoice.
 #
 apiVersion: promptkit.altairalabs.ai/v1alpha1
 kind: Scenario
@@ -15,17 +19,15 @@ spec:
   task_type: voice-assistant
   description: "Scripted text user turns routed through real OpenAI TTS"
 
+  # Voice catalog reference — resolved to openai-alloy provider at runtime.
+  voice: scripted-alloy
+
   duplex:
     timeout: "30s"
     turn_detection:
       mode: asm
 
   streaming: true
-
-  tts:
-    provider: openai
-    voice: alloy
-    sample_rate: 24000
 
   turns:
     - role: user

--- a/examples/duplex-streaming/scenarios/duplex-scripted-text.scenario.yaml
+++ b/examples/duplex-streaming/scenarios/duplex-scripted-text.scenario.yaml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/scenario.json
 #
-# Scripted-Text Duplex Scenario (Change 1 demo)
+# Scripted-Text Duplex Scenario
 #
 # Demonstrates text-only user turns in duplex mode. Each turn's `content` is
 # routed through TTS to produce audio that's streamed to the duplex provider.
 # Uses mock TTS so the example runs without OPENAI_API_KEY / ElevenLabs keys.
 #
-# Scenario-level `tts:` block applies to every turn (the layered-config feature
-# from Change 1) — no need to repeat tts on each turn.
+# `voice:` references the arena voice catalog; the duplex executor resolves
+# it via Config.ResolveVoice and routes through the provider-yaml path.
 #
 apiVersion: promptkit.altairalabs.ai/v1alpha1
 kind: Scenario
@@ -19,24 +19,16 @@ spec:
   task_type: voice-assistant
   description: "Scripted text user turns routed through TTS"
 
+  # Voice catalog reference — resolved to mock-tts at runtime.
+  # For real audio: change to a voice id backed by an OpenAI or ElevenLabs provider.
+  voice: scripted-mock
+
   duplex:
     timeout: "30s"
     turn_detection:
       mode: asm
 
   streaming: true
-
-  # Scenario-level TTS default. Without this each turn would need its own
-  # tts: block. Mock TTS loads pre-recorded PCM in lieu of synthesizing —
-  # the audio output isn't faithful to the text but exercises the wire path.
-  tts:
-    provider: mock
-    voice: mock-alloy
-    audio_files:
-      - audio/greeting.pcm
-      - audio/question.pcm
-      - audio/funfact.pcm
-    sample_rate: 16000
 
   turns:
     - role: user

--- a/examples/duplex-streaming/scenarios/duplex-selfplay-mock.scenario.yaml
+++ b/examples/duplex-streaming/scenarios/duplex-selfplay-mock.scenario.yaml
@@ -54,14 +54,6 @@ spec:
     - role: selfplay-user
       persona: curious-customer
       turns: 2
-      tts:
-        provider: mock
-        voice: mock-alloy
-        audio_files:
-          - audio/greeting.pcm
-          - audio/question.pcm
-          - audio/funfact.pcm
-        sample_rate: 16000  # Match the actual PCM file rate (no resampling needed)
       assertions:
         - type: content_matches
           params:

--- a/examples/duplex-streaming/scenarios/duplex-selfplay.scenario.yaml
+++ b/examples/duplex-streaming/scenarios/duplex-selfplay.scenario.yaml
@@ -49,12 +49,6 @@ spec:
     - role: selfplay-user
       persona: curious-customer
       turns: 3
-      tts:
-        provider: elevenlabs
-        # ElevenLabs voice ID. Default below is "Rachel".
-        # Browse voices at https://elevenlabs.io/voice-library
-        voice: "21m00Tcm4TlvDq8ikWAM"
-        sample_rate: 24000
       assertions:
         - type: content_matches
           params:

--- a/examples/duplex-streaming/scenarios/duplex-tools.scenario.yaml
+++ b/examples/duplex-streaming/scenarios/duplex-tools.scenario.yaml
@@ -56,13 +56,6 @@ spec:
     - role: selfplay-user
       persona: busy-professional
       turns: 4
-      tts:
-        # gpt-4o-mini-tts honors expressive instructions, so the
-        # busy-professional persona's "[sighs]" / "[smile]" markup
-        # gets passed through as delivery cues.
-        provider: openai
-        model: gpt-4o-mini-tts
-        voice: alloy
       assertions:
         # Each turn should get a substantive response
         - type: content_matches

--- a/examples/voice-refund-demo/config.arena.yaml
+++ b/examples/voice-refund-demo/config.arena.yaml
@@ -21,6 +21,25 @@ spec:
     - file: providers/mock-duplex.provider.yaml
     - file: providers/openai-gpt4o-mini-text.provider.yaml
 
+  tts_providers:
+    - file: providers/cartesia-confident-man.provider.yaml
+    - file: providers/cartesia-friendly-woman.provider.yaml
+    - file: providers/elevenlabs-arnold.provider.yaml
+    - file: providers/openai-nova.provider.yaml
+    - file: providers/mock-tts.provider.yaml
+
+  voices:
+    # For real-provider recording mode: each id binds to a vendor TTS provider.
+    # For keyless CI: re-point all four `provider:` lines below to `mock-tts`.
+    - id: confident-man
+      provider: cartesia-confident-man
+    - id: friendly-woman
+      provider: cartesia-friendly-woman
+    - id: arnold-expressive
+      provider: elevenlabs-arnold
+    - id: nova
+      provider: openai-nova
+
   scenarios:
     - file: scenarios/aggressive-refund.scenario.yaml
     - file: scenarios/impersonator-refund.scenario.yaml

--- a/examples/voice-refund-demo/personas/aggressive-entitled.persona.yaml
+++ b/examples/voice-refund-demo/personas/aggressive-entitled.persona.yaml
@@ -6,6 +6,7 @@ metadata:
 
 spec:
   id: aggressive-entitled
+  voice: confident-man
   description: "Angry customer who shifts manipulation tactics across the call"
 
   system_template: |

--- a/examples/voice-refund-demo/personas/anxious-recipient.persona.yaml
+++ b/examples/voice-refund-demo/personas/anxious-recipient.persona.yaml
@@ -6,6 +6,7 @@ metadata:
 
 spec:
   id: anxious-recipient
+  voice: arnold-expressive
   description: "Anxious customer worried a parcel hasn't arrived; emotional, not hostile"
 
   system_template: |

--- a/examples/voice-refund-demo/personas/impersonator.persona.yaml
+++ b/examples/voice-refund-demo/personas/impersonator.persona.yaml
@@ -6,6 +6,7 @@ metadata:
 
 spec:
   id: impersonator
+  voice: friendly-woman
   description: "A caller claiming an order ID that doesn't exist, attempting to extract a refund"
 
   system_template: |

--- a/examples/voice-refund-demo/personas/patient-customer.persona.yaml
+++ b/examples/voice-refund-demo/personas/patient-customer.persona.yaml
@@ -6,6 +6,7 @@ metadata:
 
 spec:
   id: patient-customer
+  voice: nova
   description: "A genuine customer with a legitimate refund request — control case for the demo"
 
   system_template: |

--- a/examples/voice-refund-demo/providers/cartesia-confident-man.provider.yaml
+++ b/examples/voice-refund-demo/providers/cartesia-confident-man.provider.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: cartesia-confident-man
+spec:
+  id: cartesia-confident-man
+  type: cartesia
+  capability: tts
+  voice: bf991597-6c13-47e4-8411-91ec2de5c466
+  sample_rate: 24000

--- a/examples/voice-refund-demo/providers/cartesia-friendly-woman.provider.yaml
+++ b/examples/voice-refund-demo/providers/cartesia-friendly-woman.provider.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: cartesia-friendly-woman
+spec:
+  id: cartesia-friendly-woman
+  type: cartesia
+  capability: tts
+  voice: 9121c0ae-12a6-4012-8158-6e4a72e6da91
+  sample_rate: 24000

--- a/examples/voice-refund-demo/providers/elevenlabs-arnold.provider.yaml
+++ b/examples/voice-refund-demo/providers/elevenlabs-arnold.provider.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: elevenlabs-arnold
+spec:
+  id: elevenlabs-arnold
+  type: elevenlabs
+  capability: tts
+  voice: VR6AewLTigWG4xSOukaG
+  model: eleven_v3
+  sample_rate: 24000

--- a/examples/voice-refund-demo/providers/mock-tts.provider.yaml
+++ b/examples/voice-refund-demo/providers/mock-tts.provider.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-tts
+spec:
+  id: mock-tts
+  type: mock
+  capability: tts
+  audio_files:
+    - audio/greeting.pcm
+    - audio/question.pcm
+    - audio/funfact.pcm
+  sample_rate: 24000

--- a/examples/voice-refund-demo/providers/openai-nova.provider.yaml
+++ b/examples/voice-refund-demo/providers/openai-nova.provider.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-nova
+spec:
+  id: openai-nova
+  type: openai
+  capability: tts
+  voice: nova
+  sample_rate: 24000

--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -38,14 +38,6 @@ spec:
     - role: selfplay-user
       persona: aggressive-entitled
       turns: 4
-      tts:
-        # Cartesia: sub-second TTFB (won't blow the 30s HTTP timeout) AND the
-        # markup parser ports the aggressive-entitled persona's `[shouts]` /
-        # `[sighs]` tags into Cartesia's emotion-array characterization.
-        # Voice: Confident Man (documented in runtime/tts/cartesia.go).
-        provider: cartesia
-        voice: bf991597-6c13-47e4-8411-91ec2de5c466
-        sample_rate: 24000
       assertions:
         - type: content_matches
           params:

--- a/examples/voice-refund-demo/scenarios/anxious-delivery.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/anxious-delivery.scenario.yaml
@@ -41,18 +41,6 @@ spec:
     - role: selfplay-user
       persona: anxious-recipient
       turns: 4
-      tts:
-        # ElevenLabs eleven_v3 unlocks inline characterization tags
-        # (RubricExpressiveFull) — the persona LLM can use [whispers],
-        # [sighs], [shouts], etc. Arnold (American, deep, professional)
-        # was picked via TestElevenLabsLive_ExpressiveTagsProbe: 1.5x
-        # whisper→shout dynamic range with a grounded delivery — none
-        # of the cartoon overshoot we got from Elli, none of the
-        # narrow-range monotone from Josh / Sam.
-        provider: elevenlabs
-        model: eleven_v3
-        voice: VR6AewLTigWG4xSOukaG
-        sample_rate: 24000
       assertions:
         - type: content_matches
           params:

--- a/examples/voice-refund-demo/scenarios/impersonator-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/impersonator-refund.scenario.yaml
@@ -38,14 +38,6 @@ spec:
     - role: selfplay-user
       persona: impersonator
       turns: 4
-      tts:
-        # Cartesia: sub-second TTFB (won't blow the 30s HTTP timeout) AND the
-        # markup parser ports the impersonator persona's contrast tags into
-        # Cartesia's emotion-array characterization. Voice: Friendly Woman
-        # (documented in runtime/tts/cartesia.go).
-        provider: cartesia
-        voice: 9121c0ae-12a6-4012-8158-6e4a72e6da91
-        sample_rate: 24000
       assertions:
         - type: content_matches
           params:

--- a/examples/voice-refund-demo/scenarios/patient-baseline.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/patient-baseline.scenario.yaml
@@ -38,10 +38,6 @@ spec:
     - role: selfplay-user
       persona: patient-customer
       turns: 3
-      tts:
-        provider: openai
-        voice: nova
-        sample_rate: 24000
       assertions:
         - type: content_matches
           params:

--- a/pkg/config/capability.go
+++ b/pkg/config/capability.go
@@ -1,0 +1,41 @@
+package config
+
+import "fmt"
+
+// Capability values for the Provider.Capability field. Defaults to LLM
+// when unset so existing provider yamls (which predate the field) keep
+// working with no migration.
+const (
+	CapabilityLLM = "llm"
+	CapabilityTTS = "tts"
+	CapabilitySTT = "stt"
+)
+
+// knownCapabilities is the set accepted by ValidateCapability. An empty
+// string is also accepted (treated as LLM by GetCapability).
+var knownCapabilities = map[string]struct{}{
+	CapabilityLLM: {},
+	CapabilityTTS: {},
+	CapabilitySTT: {},
+}
+
+// GetCapability returns the provider's capability, defaulting to "llm".
+func (p *Provider) GetCapability() string {
+	if p == nil || p.Capability == "" {
+		return CapabilityLLM
+	}
+	return p.Capability
+}
+
+// ValidateCapability returns an error if Capability is set to an
+// unrecognized value. Empty is treated as LLM and accepted.
+func (p *Provider) ValidateCapability() error {
+	if p == nil || p.Capability == "" {
+		return nil
+	}
+	if _, ok := knownCapabilities[p.Capability]; !ok {
+		return fmt.Errorf("unknown provider capability %q (valid: %s, %s, %s)",
+			p.Capability, CapabilityLLM, CapabilityTTS, CapabilitySTT)
+	}
+	return nil
+}

--- a/pkg/config/capability_test.go
+++ b/pkg/config/capability_test.go
@@ -1,0 +1,33 @@
+package config
+
+import "testing"
+
+func TestProviderCapability_DefaultsToLLM(t *testing.T) {
+	p := &Provider{}
+	if got := p.GetCapability(); got != CapabilityLLM {
+		t.Fatalf("expected default %q, got %q", CapabilityLLM, got)
+	}
+}
+
+func TestProviderCapability_ExplicitTTS(t *testing.T) {
+	p := &Provider{Capability: "tts"}
+	if got := p.GetCapability(); got != CapabilityTTS {
+		t.Fatalf("expected %q, got %q", CapabilityTTS, got)
+	}
+}
+
+func TestProviderCapability_UnknownRejected(t *testing.T) {
+	p := &Provider{Capability: "garbage"}
+	if err := p.ValidateCapability(); err == nil {
+		t.Fatal("expected validation error for unknown capability")
+	}
+}
+
+func TestProviderCapability_KnownAccepted(t *testing.T) {
+	for _, c := range []string{"", "llm", "tts", "stt"} {
+		p := &Provider{Capability: c}
+		if err := p.ValidateCapability(); err != nil {
+			t.Fatalf("capability %q rejected unexpectedly: %v", c, err)
+		}
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1564,6 +1564,51 @@ spec:
 	}
 }
 
+func TestLoadConfig_RejectsUnknownProviderCapability(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	arenaPath := filepath.Join(tmp, "config.arena.yaml")
+	providerPath := filepath.Join(tmp, "p.provider.yaml")
+
+	if err := os.WriteFile(providerPath, []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: bad
+spec:
+  id: bad
+  type: openai
+  model: gpt-4o-mini
+  capability: not-a-capability
+  defaults:
+    temperature: 0.7
+    top_p: 1.0
+    max_tokens: 1000
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(arenaPath, []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  defaults:
+    concurrency: 1
+  providers:
+    - file: p.provider.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(arenaPath)
+	if err == nil {
+		t.Fatal("expected load error for unknown capability")
+	}
+	if !strings.Contains(err.Error(), "capability") {
+		t.Fatalf("expected error mentioning capability, got: %v", err)
+	}
+}
+
 func TestLoadPackFile_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 	packPath := filepath.Join(tmpDir, "test.pack.json")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1976,6 +1976,44 @@ spec:
 	}
 }
 
+func TestLoadConfig_RejectsTTSProviderInLLMProvidersList(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "wrong.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: wrong
+spec:
+  id: wrong
+  type: cartesia
+  capability: tts
+  voice: vid-1
+  sample_rate: 24000
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  defaults:
+    concurrency: 1
+  providers:
+    - file: wrong.provider.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected error: tts provider in spec.providers list")
+	}
+	if !strings.Contains(err.Error(), "capability") {
+		t.Fatalf("expected error mentioning capability, got: %v", err)
+	}
+}
+
 func TestLoadConfig_AcceptsScenarioWithoutVoice(t *testing.T) {
 	// Scenarios without a voice field are allowed.
 	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1710,3 +1710,111 @@ func TestLoadConfig_SkillsPathTraversal(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "path traversal")
 }
+
+func TestLoadConfig_LoadsTTSProviders(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "voice.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: cartesia-confident-man
+spec:
+  id: cartesia-confident-man
+  type: cartesia
+  capability: tts
+  voice: vid-1
+  sample_rate: 24000
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers: []
+  defaults:
+    concurrency: 1
+  tts_providers:
+    - file: voice.provider.yaml
+  voices:
+    - id: confident-man
+      provider: cartesia-confident-man
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.LoadedTTSProviders) != 1 {
+		t.Fatalf("expected 1 loaded TTS provider, got %d", len(cfg.LoadedTTSProviders))
+	}
+	p, err := cfg.ResolveVoice("confident-man")
+	if err != nil {
+		t.Fatalf("ResolveVoice: %v", err)
+	}
+	if p.Voice != "vid-1" {
+		t.Fatalf("resolved voice: got %q", p.Voice)
+	}
+}
+
+func TestLoadConfig_RejectsTTSProviderWithLLMCapability(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "wrong.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: wrong
+spec:
+  id: wrong
+  type: openai
+  model: gpt-4o-mini
+  capability: llm
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers: []
+  defaults:
+    concurrency: 1
+  tts_providers:
+    - file: wrong.provider.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected error: tts_providers entry has capability=llm")
+	}
+}
+
+func TestLoadConfig_RejectsVoiceBindingToUnknownProvider(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers: []
+  defaults:
+    concurrency: 1
+  voices:
+    - id: dangling
+      provider: ghost
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected error: voice binds to unloaded provider id")
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1922,3 +1922,105 @@ spec:
 		t.Fatalf("expected success for persona without voice, got: %v", err)
 	}
 }
+
+func TestLoadConfig_RejectsScenarioWithUnknownVoice(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "s.scenario.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: s
+spec:
+  id: s
+  task_type: voice-assistant
+  description: "test scenario"
+  voice: nonexistent-voice
+  turns:
+    - role: user
+      content: hello
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "llm.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: llm
+spec:
+  id: llm
+  type: openai
+  model: gpt-4o-mini
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  defaults:
+    concurrency: 1
+  providers:
+    - file: llm.provider.yaml
+  scenarios:
+    - file: s.scenario.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected error: scenario references unknown voice id")
+	}
+	if !strings.Contains(err.Error(), "voice") {
+		t.Fatalf("expected error mentioning voice, got: %v", err)
+	}
+}
+
+func TestLoadConfig_AcceptsScenarioWithoutVoice(t *testing.T) {
+	// Scenarios without a voice field are allowed.
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "s.scenario.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: s
+spec:
+  id: s
+  task_type: voice-assistant
+  description: "test scenario"
+  turns:
+    - role: user
+      content: hello
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "llm.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: llm
+spec:
+  id: llm
+  type: openai
+  model: gpt-4o-mini
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  defaults:
+    concurrency: 1
+  providers:
+    - file: llm.provider.yaml
+  scenarios:
+    - file: s.scenario.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml")); err != nil {
+		t.Fatalf("expected success for scenario without voice, got: %v", err)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1818,3 +1818,107 @@ spec:
 		t.Fatal("expected error: voice binds to unloaded provider id")
 	}
 }
+
+func TestLoadConfig_RejectsPersonaWithUnknownVoice(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "p.persona.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Persona
+metadata:
+  name: p
+spec:
+  id: p
+  description: test
+  system_prompt: "You are a helpful assistant"
+  voice: nonexistent-voice
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "llm.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: llm
+spec:
+  id: llm
+  type: openai
+  model: gpt-4o-mini
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  defaults:
+    concurrency: 1
+  providers:
+    - file: llm.provider.yaml
+  self_play:
+    personas:
+      - file: p.persona.yaml
+    roles:
+      - id: u
+        provider: llm
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected error: persona references unknown voice id")
+	}
+	if !strings.Contains(err.Error(), "voice") {
+		t.Fatalf("expected error mentioning voice, got: %v", err)
+	}
+}
+
+func TestLoadConfig_AcceptsPersonaWithoutVoice(t *testing.T) {
+	// Personas without a voice are allowed — used by text-only scenarios.
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "p.persona.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Persona
+metadata:
+  name: p
+spec:
+  id: p
+  description: test
+  system_prompt: "You are a helpful assistant"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "llm.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: llm
+spec:
+  id: llm
+  type: openai
+  model: gpt-4o-mini
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  defaults:
+    concurrency: 1
+  providers:
+    - file: llm.provider.yaml
+  self_play:
+    personas:
+      - file: p.persona.yaml
+    roles:
+      - id: u
+        provider: llm
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml")); err != nil {
+		t.Fatalf("expected success for persona without voice, got: %v", err)
+	}
+}

--- a/pkg/config/duplex_config_test.go
+++ b/pkg/config/duplex_config_test.go
@@ -190,60 +190,6 @@ func TestDuplexConfig_GetTimeoutDuration(t *testing.T) {
 	}
 }
 
-func TestTTSConfig_Validate(t *testing.T) {
-	tests := []struct {
-		name    string
-		config  *TTSConfig
-		wantErr bool
-		errMsg  string
-	}{
-		{
-			name:    "nil config is valid",
-			config:  nil,
-			wantErr: false,
-		},
-		{
-			name: "valid config",
-			config: &TTSConfig{
-				Provider: "openai",
-				Voice:    "nova",
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing provider",
-			config: &TTSConfig{
-				Voice: "nova",
-			},
-			wantErr: true,
-			errMsg:  "tts provider is required",
-		},
-		{
-			name: "missing voice",
-			config: &TTSConfig{
-				Provider: "openai",
-			},
-			wantErr: true,
-			errMsg:  "tts voice is required",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.Validate()
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("Validate() expected error containing %q, got nil", tt.errMsg)
-				} else if tt.errMsg != "" && !containsStr(err.Error(), tt.errMsg) {
-					t.Errorf("Validate() error = %v, want error containing %q", err, tt.errMsg)
-				}
-			} else if err != nil {
-				t.Errorf("Validate() unexpected error = %v", err)
-			}
-		})
-	}
-}
-
 func TestScenario_DuplexParsing(t *testing.T) {
 	yamlContent := `
 id: voice-interview-test
@@ -309,52 +255,6 @@ turns:
 	}
 }
 
-func TestTurnDefinition_TTSParsing(t *testing.T) {
-	yamlContent := `
-id: selfplay-voice-test
-task_type: interviewer
-description: "Self-play voice interview"
-duplex:
-  timeout: "15m"
-  turn_detection:
-    mode: vad
-turns:
-  - role: gemini-user
-    persona: senior-engineer
-    turns: 5
-    tts:
-      provider: openai
-      voice: nova
-`
-
-	var scenario Scenario
-	err := yaml.Unmarshal([]byte(yamlContent), &scenario)
-	if err != nil {
-		t.Fatalf("Failed to parse scenario: %v", err)
-	}
-
-	if len(scenario.Turns) != 1 {
-		t.Fatalf("Expected 1 turn, got %d", len(scenario.Turns))
-	}
-
-	turn := scenario.Turns[0]
-	if turn.TTS == nil {
-		t.Fatal("Expected TTS config to be parsed")
-	}
-
-	if turn.TTS.Provider != "openai" {
-		t.Errorf("Expected provider 'openai', got %q", turn.TTS.Provider)
-	}
-	if turn.TTS.Voice != "nova" {
-		t.Errorf("Expected voice 'nova', got %q", turn.TTS.Voice)
-	}
-
-	// Validate the TTS config
-	if err := turn.TTS.Validate(); err != nil {
-		t.Errorf("Parsed TTS config validation failed: %v", err)
-	}
-}
-
 func TestScenario_BackwardCompatibility(t *testing.T) {
 	// Ensure scenarios without duplex config still parse correctly
 	yamlContent := `
@@ -380,9 +280,6 @@ turns:
 		t.Errorf("Expected 1 turn, got %d", len(scenario.Turns))
 	}
 
-	if scenario.Turns[0].TTS != nil {
-		t.Error("Expected TTS to be nil for standard turn")
-	}
 }
 
 func TestDuplexConfig_GetResilience(t *testing.T) {
@@ -887,39 +784,6 @@ func TestScenario_Validate(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "silence_threshold_ms must be non-negative",
-		},
-		{
-			name: "scenario with invalid TTS config in turn",
-			config: &Scenario{
-				ID: "test-scenario",
-				Turns: []TurnDefinition{
-					{
-						Role: "user",
-						TTS: &TTSConfig{
-							// Provider is required
-							Voice: "alloy",
-						},
-					},
-				},
-			},
-			wantErr: true,
-			errMsg:  "tts provider is required",
-		},
-		{
-			name: "scenario with valid TTS config in turn",
-			config: &Scenario{
-				ID: "test-scenario",
-				Turns: []TurnDefinition{
-					{
-						Role: "user",
-						TTS: &TTSConfig{
-							Provider: "openai",
-							Voice:    "alloy",
-						},
-					},
-				},
-			},
-			wantErr: false,
 		},
 	}
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -443,6 +443,9 @@ func (c *Config) loadProviders(configPath string) error {
 		if err != nil {
 			return fmt.Errorf("failed to load provider %s: %w", ref.File, err)
 		}
+		if err := provider.ValidateCapability(); err != nil {
+			return fmt.Errorf("provider %s: %w", provider.ID, err)
+		}
 		c.LoadedProviders[provider.ID] = provider
 		group := ref.Group
 		if group == "" {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -257,6 +257,12 @@ func LoadConfig(filename string) (*Config, error) {
 		if err := cfg.loadSelfPlayResources(filename); err != nil {
 			return nil, err
 		}
+		// Validate that every persona's voice (when set) resolves to an arena
+		// voice binding. Voice bindings were already validated above, so
+		// ResolveVoice will work correctly for valid persona voices.
+		if err := cfg.validatePersonaVoices(); err != nil {
+			return nil, err
+		}
 	}
 
 	// Validate judge references against provider registry (mirrors self-play validation)
@@ -527,6 +533,21 @@ func (c *Config) validateVoiceBindings() error {
 		if _, ok := c.LoadedTTSProviders[binding.Provider]; !ok {
 			return fmt.Errorf("voices[%s]: provider id %q not found in tts_providers",
 				binding.ID, binding.Provider)
+		}
+	}
+	return nil
+}
+
+// validatePersonaVoices checks that every persona's voice (when set) resolves
+// to a valid arena voice binding. Personas without a voice field are allowed
+// (used by text-only scenarios).
+func (c *Config) validatePersonaVoices() error {
+	for name, persona := range c.LoadedPersonas {
+		if persona.Voice == "" {
+			continue
+		}
+		if _, err := c.ResolveVoice(persona.Voice); err != nil {
+			return fmt.Errorf("persona %s: %w", name, err)
 		}
 	}
 	return nil

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -236,6 +236,12 @@ func LoadConfig(filename string) (*Config, error) {
 	if err := cfg.mergeScenarioSpecs(); err != nil {
 		return nil, err
 	}
+	// Validate that every scenario's voice (when set) resolves to an arena
+	// voice binding. Voice bindings were already validated above, so
+	// ResolveVoice will work correctly for valid scenario voices.
+	if err := cfg.validateScenarioVoices(); err != nil {
+		return nil, err
+	}
 	if err := cfg.loadEvals(filename); err != nil {
 		return nil, err
 	}
@@ -533,6 +539,22 @@ func (c *Config) validateVoiceBindings() error {
 		if _, ok := c.LoadedTTSProviders[binding.Provider]; !ok {
 			return fmt.Errorf("voices[%s]: provider id %q not found in tts_providers",
 				binding.ID, binding.Provider)
+		}
+	}
+	return nil
+}
+
+// validateScenarioVoices checks that every scenario's voice (when set) resolves
+// to a valid arena voice binding. Scenarios without a voice field are allowed —
+// they use either persona-driven voices (selfplay) or the legacy scenario.TTS
+// field (scripted text, deprecated and removed in Phase 5).
+func (c *Config) validateScenarioVoices() error {
+	for name, scenario := range c.LoadedScenarios {
+		if scenario.Voice == "" {
+			continue
+		}
+		if _, err := c.ResolveVoice(scenario.Voice); err != nil {
+			return fmt.Errorf("scenario %s: %w", name, err)
 		}
 	}
 	return nil

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -546,8 +546,7 @@ func (c *Config) validateVoiceBindings() error {
 
 // validateScenarioVoices checks that every scenario's voice (when set) resolves
 // to a valid arena voice binding. Scenarios without a voice field are allowed —
-// they use either persona-driven voices (selfplay) or the legacy scenario.TTS
-// field (scripted text, deprecated and removed in Phase 5).
+// they use persona-driven voices (selfplay) resolved via the arena voice catalog.
 func (c *Config) validateScenarioVoices() error {
 	for name, scenario := range c.LoadedScenarios {
 		if scenario.Voice == "" {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -203,6 +203,8 @@ func LoadConfig(filename string) (*Config, error) {
 	cfg.LoadedEvals = make(map[string]*Eval, len(cfg.Evals))
 	cfg.LoadedTools = make([]ToolData, 0, len(cfg.Tools))
 	cfg.LoadedPersonas = make(map[string]*UserPersonaPack)
+	cfg.LoadedTTSProviders = make(map[string]*Provider, len(cfg.TTSProviders))
+	cfg.LoadedSTTProviders = make(map[string]*Provider, len(cfg.STTProviders))
 	cfg.ProviderGroups = make(map[string]string)
 	cfg.ProviderCapabilities = make(map[string][]string)
 
@@ -211,6 +213,15 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, err
 	}
 	if err := cfg.mergeProviderSpecs(); err != nil {
+		return nil, err
+	}
+	if err := cfg.loadTTSProviders(filename); err != nil {
+		return nil, err
+	}
+	if err := cfg.loadSTTProviders(filename); err != nil {
+		return nil, err
+	}
+	if err := cfg.validateVoiceBindings(); err != nil {
 		return nil, err
 	}
 	if err := cfg.loadPromptConfigs(filename); err != nil {
@@ -455,6 +466,67 @@ func (c *Config) loadProviders(configPath string) error {
 		// Populate provider capabilities from the provider spec
 		if len(provider.Capabilities) > 0 {
 			c.ProviderCapabilities[provider.ID] = provider.Capabilities
+		}
+	}
+	return nil
+}
+
+// loadTTSProviders loads all referenced TTS providers and validates that each
+// declares capability: tts.
+func (c *Config) loadTTSProviders(configPath string) error {
+	for _, ref := range c.TTSProviders {
+		fullPath := ResolveFilePath(configPath, ref.File)
+		provider, err := LoadProvider(fullPath)
+		if err != nil {
+			return fmt.Errorf("loading tts_providers[%s]: %w", ref.File, err)
+		}
+		if err := provider.ValidateCapability(); err != nil {
+			return fmt.Errorf("tts_providers[%s]: %w", ref.File, err)
+		}
+		if provider.GetCapability() != CapabilityTTS {
+			return fmt.Errorf("tts_providers[%s]: capability must be %q, got %q",
+				ref.File, CapabilityTTS, provider.GetCapability())
+		}
+		c.LoadedTTSProviders[provider.ID] = provider
+	}
+	return nil
+}
+
+// loadSTTProviders loads all referenced STT providers and validates that each
+// declares capability: stt.
+func (c *Config) loadSTTProviders(configPath string) error {
+	for _, ref := range c.STTProviders {
+		fullPath := ResolveFilePath(configPath, ref.File)
+		provider, err := LoadProvider(fullPath)
+		if err != nil {
+			return fmt.Errorf("loading stt_providers[%s]: %w", ref.File, err)
+		}
+		if err := provider.ValidateCapability(); err != nil {
+			return fmt.Errorf("stt_providers[%s]: %w", ref.File, err)
+		}
+		if provider.GetCapability() != CapabilitySTT {
+			return fmt.Errorf("stt_providers[%s]: capability must be %q, got %q",
+				ref.File, CapabilitySTT, provider.GetCapability())
+		}
+		c.LoadedSTTProviders[provider.ID] = provider
+	}
+	return nil
+}
+
+// validateVoiceBindings checks that every entry in spec.voices references a
+// provider id that was loaded into LoadedTTSProviders.
+func (c *Config) validateVoiceBindings() error {
+	for i := range c.Voices {
+		binding := &c.Voices[i]
+		if binding.ID == "" {
+			return fmt.Errorf("voices[%d]: id is required", i)
+		}
+		if binding.Provider == "" {
+			return fmt.Errorf("voices[%s]: provider is required", binding.ID)
+		}
+		if _, ok := c.LoadedTTSProviders[binding.Provider]; !ok {
+			return fmt.Errorf("voices[%s]: provider id %q not found in tts_providers",
+				binding.ID, binding.Provider)
 		}
 	}
 	return nil

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -469,6 +469,11 @@ func (c *Config) loadProviders(configPath string) error {
 		if err := provider.ValidateCapability(); err != nil {
 			return fmt.Errorf("provider %s: %w", provider.ID, err)
 		}
+		if provCap := provider.GetCapability(); provCap != CapabilityLLM {
+			return fmt.Errorf("providers[%s]: capability must be %q (or empty), got %q; "+
+				"TTS providers belong under tts_providers, STT under stt_providers",
+				ref.File, CapabilityLLM, provCap)
+		}
 		c.LoadedProviders[provider.ID] = provider
 		group := ref.Group
 		if group == "" {

--- a/pkg/config/persona.go
+++ b/pkg/config/persona.go
@@ -42,10 +42,15 @@ type UserPersonaPack struct {
 	// LEGACY: Backward compatibility
 	SystemPrompt string `json:"system_prompt,omitempty" yaml:"system_prompt,omitempty"` // Plain text system prompt (no variables)
 
-	Goals       []string        `json:"goals" yaml:"goals"`
-	Constraints []string        `json:"constraints" yaml:"constraints"`
-	Style       PersonaStyle    `json:"style,omitempty" yaml:"style,omitempty"`
-	Defaults    PersonaDefaults `json:"defaults,omitempty" yaml:"defaults,omitempty"`
+	Goals       []string     `json:"goals" yaml:"goals"`
+	Constraints []string     `json:"constraints" yaml:"constraints"`
+	Style       PersonaStyle `json:"style,omitempty" yaml:"style,omitempty"`
+	// Voice references an arena-level voice id (see Config.Voices). When
+	// set, selfplay synthesis routes this persona's text through the bound
+	// TTS provider. Empty means the arena falls back to its default voice
+	// or fails fast if no default is configured.
+	Voice    string          `json:"voice,omitempty" yaml:"voice,omitempty"`
+	Defaults PersonaDefaults `json:"defaults,omitempty" yaml:"defaults,omitempty"`
 }
 
 // FragmentRef references a reusable prompt fragment

--- a/pkg/config/tts_provider_test.go
+++ b/pkg/config/tts_provider_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestProvider_TTSFieldsRoundTrip(t *testing.T) {
+	src := `id: cartesia-confident-man
+type: cartesia
+capability: tts
+voice: bf991597-6c13-47e4-8411-91ec2de5c466
+sample_rate: 24000
+`
+	var p Provider
+	if err := yaml.Unmarshal([]byte(src), &p); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if p.GetCapability() != CapabilityTTS {
+		t.Fatalf("capability: got %q, want tts", p.GetCapability())
+	}
+	if p.Voice != "bf991597-6c13-47e4-8411-91ec2de5c466" {
+		t.Fatalf("voice: got %q", p.Voice)
+	}
+	if p.SampleRate != 24000 {
+		t.Fatalf("sample_rate: got %d, want 24000", p.SampleRate)
+	}
+}
+
+func TestProvider_MockTTSAudioFiles(t *testing.T) {
+	src := `id: mock-tts
+type: mock
+capability: tts
+audio_files:
+  - audio/a.pcm
+  - audio/b.pcm
+`
+	var p Provider
+	if err := yaml.Unmarshal([]byte(src), &p); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(p.AudioFiles) != 2 {
+		t.Fatalf("audio_files: got %d entries, want 2", len(p.AudioFiles))
+	}
+}
+
+func TestPersona_VoiceField(t *testing.T) {
+	src := `id: aggressive-entitled
+description: hostile caller
+voice: confident-man
+`
+	var pp UserPersonaPack
+	if err := yaml.Unmarshal([]byte(src), &pp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if pp.Voice != "confident-man" {
+		t.Fatalf("voice: got %q, want confident-man", pp.Voice)
+	}
+}

--- a/pkg/config/tts_provider_test.go
+++ b/pkg/config/tts_provider_test.go
@@ -45,6 +45,30 @@ audio_files:
 	}
 }
 
+func TestScenario_VoiceFieldRoundTrip(t *testing.T) {
+	src := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: t
+spec:
+  id: t
+  task_type: voice-assistant
+  voice: alloy
+  turns:
+    - role: user
+      content: hi
+`
+	var sc struct {
+		Spec Scenario `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal([]byte(src), &sc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if sc.Spec.Voice != "alloy" {
+		t.Fatalf("voice: got %q, want alloy", sc.Spec.Voice)
+	}
+}
+
 func TestPersona_VoiceField(t *testing.T) {
 	src := `id: aggressive-entitled
 description: hostile caller

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -128,9 +128,26 @@ type Config struct {
 	// ProviderCapabilities maps provider ID to its capabilities (populated during load)
 	ProviderCapabilities map[string][]string `yaml:"-" json:"provider_capabilities,omitempty"`
 
+	// TTSProviders lists provider files where Spec.Capability == "tts".
+	// Loaded but NOT included in the agent-under-test matrix.
+	TTSProviders []ProviderRef `yaml:"tts_providers,omitempty" json:"tts_providers,omitempty"`
+
+	// STTProviders lists provider files where Spec.Capability == "stt".
+	// Same matrix-exclusion as TTSProviders. No STT consumers exist yet;
+	// the field is present so STT can land later without a schema change.
+	STTProviders []ProviderRef `yaml:"stt_providers,omitempty" json:"stt_providers,omitempty"`
+
+	// Voices binds voice IDs to loaded TTS provider IDs. Personas reference
+	// voice IDs (not provider IDs) so the same persona can run against a
+	// real Cartesia voice in recording mode and a mock TTS provider in CI
+	// just by editing this list.
+	Voices []VoiceBinding `yaml:"voices,omitempty" json:"voices,omitempty"`
+
 	// Loaded resources (populated by LoadConfig, included in JSON for adapter consumption)
 	LoadedPromptConfigs map[string]*PromptConfigData `yaml:"-" json:"loaded_prompt_configs,omitempty"`
 	LoadedProviders     map[string]*Provider         `yaml:"-" json:"loaded_providers,omitempty"`
+	LoadedTTSProviders  map[string]*Provider         `yaml:"-" json:"loaded_tts_providers,omitempty"`
+	LoadedSTTProviders  map[string]*Provider         `yaml:"-" json:"loaded_stt_providers,omitempty"`
 	LoadedJudges        map[string]*JudgeTarget      `yaml:"-" json:"loaded_judges,omitempty"`
 	LoadedScenarios     map[string]*Scenario         `yaml:"-" json:"loaded_scenarios,omitempty"`
 	LoadedEvals         map[string]*Eval             `yaml:"-" json:"loaded_evals,omitempty"`

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1165,12 +1165,25 @@ type Provider struct {
 	ID    string `json:"id,omitempty" yaml:"id,omitempty"`
 	Type  string `json:"type" yaml:"type"`
 	Model string `json:"model" yaml:"model"`
+	// Voice is the vendor-specific voice identifier used when Capability is
+	// "tts". For Cartesia it's the voice UUID; for ElevenLabs the voice ID;
+	// for OpenAI the voice name (alloy, nova, etc.). Ignored for LLM/STT
+	// providers.
+	Voice string `json:"voice,omitempty" yaml:"voice,omitempty"`
+	// SampleRate is the audio sample rate in Hz for TTS providers. Common
+	// values: 16000 (telephony), 24000 (default for most TTS vendors),
+	// 48000 (high quality). Ignored for non-TTS providers.
+	SampleRate int `json:"sample_rate,omitempty" yaml:"sample_rate,omitempty"`
+	// AudioFiles is the list of PCM fixtures used by the mock TTS provider
+	// (capability=tts, type=mock). The mock service rotates through these
+	// files on each Synthesize() call. Paths are relative to the arena
+	// config directory. Ignored when type != "mock" or capability != "tts".
+	AudioFiles []string `json:"audio_files,omitempty" yaml:"audio_files,omitempty"`
 	// Capability tags the role this provider fills in the arena. One of "llm"
 	// (default), "tts", or "stt". The arena uses this to route the provider
 	// to the correct registry and to skip non-llm providers when building the
 	// agent-under-test matrix. Note: distinct from the older Capabilities
 	// field which lists per-model feature flags (vision, tools, etc.).
-	//nolint:lll // jsonschema tags require single line
 	Capability string `json:"capability,omitempty" yaml:"capability,omitempty" jsonschema:"enum=llm,enum=tts,enum=stt"`
 	BaseURL    string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	// Headers specifies custom HTTP headers to include in every request to

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1170,7 +1170,8 @@ type Provider struct {
 	// to the correct registry and to skip non-llm providers when building the
 	// agent-under-test matrix. Note: distinct from the older Capabilities
 	// field which lists per-model feature flags (vision, tools, etc.).
-	Capability string `json:"capability,omitempty" yaml:"capability,omitempty"`
+	//nolint:lll // jsonschema tags require single line
+	Capability string `json:"capability,omitempty" yaml:"capability,omitempty" jsonschema:"enum=llm,enum=tts,enum=stt"`
 	BaseURL    string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	// Headers specifies custom HTTP headers to include in every request to
 	// this provider. Useful for OpenAI-compatible gateways (OpenRouter,

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1162,10 +1162,16 @@ type ProviderConfigK8s struct {
 
 // Provider defines API connection and defaults
 type Provider struct {
-	ID      string `json:"id,omitempty" yaml:"id,omitempty"`
-	Type    string `json:"type" yaml:"type"`
-	Model   string `json:"model" yaml:"model"`
-	BaseURL string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	ID    string `json:"id,omitempty" yaml:"id,omitempty"`
+	Type  string `json:"type" yaml:"type"`
+	Model string `json:"model" yaml:"model"`
+	// Capability tags the role this provider fills in the arena. One of "llm"
+	// (default), "tts", or "stt". The arena uses this to route the provider
+	// to the correct registry and to skip non-llm providers when building the
+	// agent-under-test matrix. Note: distinct from the older Capabilities
+	// field which lists per-model feature flags (vision, tools, etc.).
+	Capability string `json:"capability,omitempty" yaml:"capability,omitempty"`
+	BaseURL    string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	// Headers specifies custom HTTP headers to include in every request to
 	// this provider. Useful for OpenAI-compatible gateways (OpenRouter,
 	// LiteLLM, etc.) that require app attribution or custom auth headers.

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1181,7 +1181,7 @@ type ProviderConfigK8s struct {
 type Provider struct {
 	ID    string `json:"id,omitempty" yaml:"id,omitempty"`
 	Type  string `json:"type" yaml:"type"`
-	Model string `json:"model" yaml:"model"`
+	Model string `json:"model,omitempty" yaml:"model,omitempty"`
 	// Voice is the vendor-specific voice identifier used when Capability is
 	// "tts". For Cartesia it's the voice UUID; for ElevenLabs the voice ID;
 	// for OpenAI the voice name (alloy, nova, etc.). Ignored for LLM/STT

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -462,11 +462,6 @@ type Defaults struct {
 	// Monitor groups runtime-monitor configuration (audio, future surfaces).
 	Monitor *MonitorSection `yaml:"monitor,omitempty" json:"monitor,omitempty"`
 
-	// TTS configures arena-wide default text-to-speech settings used to convert
-	// scripted-text user turns into audio in duplex scenarios. Per-turn and
-	// per-scenario TTS configs take precedence over this default.
-	TTS *TTSConfig `yaml:"tts,omitempty" json:"tts,omitempty"`
-
 	// Deprecated fields for backward compatibility (will be removed)
 	HTMLReport     string          `yaml:"html_report,omitempty" json:"html_report,omitempty"`
 	OutDir         string          `yaml:"out_dir,omitempty" json:"out_dir,omitempty"`
@@ -692,18 +687,11 @@ type Scenario struct {
 
 	// Voice references an arena-level voice id (see Config.Voices) used to
 	// synthesize this scenario's scripted-text user turns. The duplex executor
-	// resolves the voice via Config.ResolveVoice. Mutually exclusive with TTS
-	// — if both are set, Voice wins.
+	// resolves the voice via Config.ResolveVoice.
 	//
 	// For selfplay scenarios (turns with role: selfplay-user) the persona owns
 	// voice choice; Scenario.Voice is ignored.
 	Voice string `yaml:"voice,omitempty" json:"voice,omitempty"`
-
-	// TTS configures the scenario-level default text-to-speech settings used to
-	// convert scripted-text user turns into audio in duplex scenarios. A
-	// per-turn TTS config takes precedence over this; arena defaults fill in
-	// when both this and per-turn TTS are absent.
-	TTS *TTSConfig `json:"tts,omitempty" yaml:"tts,omitempty"`
 
 	// Variables are injected into the pack's template variables.
 	Variables map[string]string `json:"variables,omitempty" yaml:"variables,omitempty" jsonschema:"description=Template variables to inject into the pack"` //nolint:lll
@@ -758,22 +746,6 @@ func (s *Scenario) Validate() error {
 	if s.ContextPolicy != nil && s.ContextPolicy.Relevance != nil {
 		if err := s.ContextPolicy.Relevance.Validate(); err != nil {
 			return fmt.Errorf("scenario %s context policy: %w", s.ID, err)
-		}
-	}
-
-	// Validate scenario-level TTS config if present
-	if s.TTS != nil {
-		if err := s.TTS.Validate(); err != nil {
-			return fmt.Errorf("scenario %s tts: %w", s.ID, err)
-		}
-	}
-
-	// Validate TTS configs in turns
-	for i := range s.Turns {
-		if s.Turns[i].TTS != nil {
-			if err := s.Turns[i].TTS.Validate(); err != nil {
-				return fmt.Errorf("scenario %s turn %d: %w", s.ID, i, err)
-			}
 		}
 	}
 
@@ -933,30 +905,6 @@ type VADConfig struct {
 	MaxTurnDurationS int `json:"max_turn_duration_s,omitempty" yaml:"max_turn_duration_s,omitempty"`
 }
 
-// TTSConfig configures text-to-speech for self-play audio generation in duplex mode.
-type TTSConfig struct {
-	// Provider is the TTS provider (e.g., "openai", "elevenlabs", "cartesia", "mock").
-	Provider string `json:"provider" yaml:"provider"`
-	// Voice is the voice ID to use for synthesis.
-	Voice string `json:"voice" yaml:"voice"`
-	// Model overrides the provider's default TTS model. Examples:
-	//   openai: "tts-1", "tts-1-hd", "gpt-4o-mini-tts"
-	//   elevenlabs: "eleven_v3", "eleven_multilingual_v2", "eleven_turbo_v2_5"
-	//   cartesia: "sonic-3"
-	// When empty, each provider's adapter falls back to its own default.
-	// Picking gpt-4o-mini-tts / eleven_v3 also unlocks the persona
-	// characterization rubric (see PersonaStyle.Expressive).
-	Model string `json:"model,omitempty" yaml:"model,omitempty"`
-	// AudioFiles is a list of PCM audio files to use for mock TTS provider.
-	// When provider is "mock", these files are loaded and rotated through for each synthesis call.
-	// Paths are relative to the scenario file location.
-	AudioFiles []string `json:"audio_files,omitempty" yaml:"audio_files,omitempty"`
-	// SampleRate is the sample rate of the TTS output in Hz.
-	// Default is 24000 for most TTS providers. For mock provider with pre-recorded files,
-	// set this to match the actual file sample rate (e.g., 16000 for 16kHz PCM files).
-	SampleRate int `json:"sample_rate,omitempty" yaml:"sample_rate,omitempty"`
-}
-
 // Validate validates the DuplexConfig settings.
 func (d *DuplexConfig) Validate() error {
 	if d == nil {
@@ -1073,23 +1021,6 @@ func (v *VADConfig) Validate() error {
 	return nil
 }
 
-// Validate validates the TTSConfig settings.
-func (t *TTSConfig) Validate() error {
-	if t == nil {
-		return nil
-	}
-
-	if t.Provider == "" {
-		return fmt.Errorf("tts provider is required")
-	}
-	// Voice is optional for mock provider when audio_files are specified
-	if t.Voice == "" && t.Provider != "mock" {
-		return fmt.Errorf("tts voice is required")
-	}
-
-	return nil
-}
-
 // TurnDefinition represents a single conversation turn definition
 type TurnDefinition struct {
 	Role    string `json:"role" yaml:"role"` // "user", "assistant", or provider selector like "claude-user" (only for self-play turns)
@@ -1108,10 +1039,6 @@ type TurnDefinition struct {
 	AssistantTemp float32 `json:"assistant_temp,omitempty" yaml:"assistant_temp,omitempty"` // Override assistant temperature
 	UserTemp      float32 `json:"user_temp,omitempty" yaml:"user_temp,omitempty"`           // Override user temperature
 	Seed          int     `json:"seed,omitempty" yaml:"seed,omitempty"`                     // Override seed
-
-	// TTS configures text-to-speech for self-play audio generation in duplex mode.
-	// When set, self-play generates audio responses instead of text.
-	TTS *TTSConfig `json:"tts,omitempty" yaml:"tts,omitempty"`
 
 	// Streaming control - if nil, uses scenario-level streaming setting
 	Streaming *bool `json:"streaming,omitempty" yaml:"streaming,omitempty"` // Override streaming for this turn

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -690,6 +690,15 @@ type Scenario struct {
 	// Duplex enables bidirectional streaming mode for voice/audio scenarios.
 	Duplex *DuplexConfig `json:"duplex,omitempty" yaml:"duplex,omitempty"`
 
+	// Voice references an arena-level voice id (see Config.Voices) used to
+	// synthesize this scenario's scripted-text user turns. The duplex executor
+	// resolves the voice via Config.ResolveVoice. Mutually exclusive with TTS
+	// — if both are set, Voice wins.
+	//
+	// For selfplay scenarios (turns with role: selfplay-user) the persona owns
+	// voice choice; Scenario.Voice is ignored.
+	Voice string `yaml:"voice,omitempty" json:"voice,omitempty"`
+
 	// TTS configures the scenario-level default text-to-speech settings used to
 	// convert scripted-text user turns into audio in duplex scenarios. A
 	// per-turn TTS config takes precedence over this; arena defaults fill in

--- a/pkg/config/voice.go
+++ b/pkg/config/voice.go
@@ -1,0 +1,32 @@
+package config
+
+import "fmt"
+
+// VoiceBinding binds a voice id (the namespace personas reference) to a
+// loaded TTS provider id. Parallel to SelfPlayRoleGroup's id→provider
+// shape.
+type VoiceBinding struct {
+	ID       string `yaml:"id" json:"id"`             // Voice id used by personas
+	Provider string `yaml:"provider" json:"provider"` // TTS provider id (must exist in spec.tts_providers)
+}
+
+// ResolveVoice returns the TTS provider config bound to the given voice id.
+// Returns an error if the voice id is not in spec.voices, or if the binding
+// points to a provider that wasn't loaded.
+func (c *Config) ResolveVoice(voiceID string) (*Provider, error) {
+	if c == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+	for i := range c.Voices {
+		if c.Voices[i].ID != voiceID {
+			continue
+		}
+		providerID := c.Voices[i].Provider
+		if p, ok := c.LoadedTTSProviders[providerID]; ok && p != nil {
+			return p, nil
+		}
+		return nil, fmt.Errorf("voice %q binds to provider %q which is not loaded in spec.tts_providers",
+			voiceID, providerID)
+	}
+	return nil, fmt.Errorf("voice id %q not found in spec.voices", voiceID)
+}

--- a/pkg/config/voice_test.go
+++ b/pkg/config/voice_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestArenaSpec_TTSProvidersAndVoices(t *testing.T) {
+	src := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers:
+    - file: providers/llm.provider.yaml
+  tts_providers:
+    - file: providers/cartesia-confident-man.provider.yaml
+    - file: providers/mock-tts.provider.yaml
+  stt_providers: []
+  voices:
+    - id: confident-man
+      provider: cartesia-confident-man
+`
+	var arena struct {
+		Spec Config `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal([]byte(src), &arena); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(arena.Spec.TTSProviders) != 2 {
+		t.Fatalf("tts_providers: got %d entries, want 2", len(arena.Spec.TTSProviders))
+	}
+	if len(arena.Spec.Voices) != 1 {
+		t.Fatalf("voices: got %d entries, want 1", len(arena.Spec.Voices))
+	}
+	if arena.Spec.Voices[0].ID != "confident-man" {
+		t.Fatalf("voices[0].id: got %q", arena.Spec.Voices[0].ID)
+	}
+	if arena.Spec.Voices[0].Provider != "cartesia-confident-man" {
+		t.Fatalf("voices[0].provider: got %q", arena.Spec.Voices[0].Provider)
+	}
+}
+
+func TestConfig_ResolveVoice(t *testing.T) {
+	cfg := &Config{
+		Voices: []VoiceBinding{{ID: "confident-man", Provider: "cartesia-confident-man"}},
+		LoadedTTSProviders: map[string]*Provider{
+			"cartesia-confident-man": {ID: "cartesia-confident-man", Type: "cartesia", Voice: "vid-1", Capability: "tts"},
+		},
+	}
+	p, err := cfg.ResolveVoice("confident-man")
+	if err != nil {
+		t.Fatalf("ResolveVoice: %v", err)
+	}
+	if p.Voice != "vid-1" {
+		t.Fatalf("provider voice: got %q", p.Voice)
+	}
+}
+
+func TestConfig_ResolveVoice_UnknownID(t *testing.T) {
+	cfg := &Config{}
+	if _, err := cfg.ResolveVoice("nope"); err == nil {
+		t.Fatal("expected error for unknown voice id")
+	}
+}
+
+func TestConfig_ResolveVoice_BindingMissingProvider(t *testing.T) {
+	cfg := &Config{
+		Voices:             []VoiceBinding{{ID: "confident-man", Provider: "ghost"}},
+		LoadedTTSProviders: map[string]*Provider{},
+	}
+	if _, err := cfg.ResolveVoice("confident-man"); err == nil {
+		t.Fatal("expected error when binding's provider is not loaded")
+	}
+}

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -492,24 +492,6 @@
         "defaults"
       ]
     },
-    "VoiceBinding": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Voice id used by personas"
-        },
-        "provider": {
-          "type": "string",
-          "description": "TTS provider id (must exist in spec.tts_providers)"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "id",
-        "provider"
-      ]
-    },
     "ContextMetadata": {
       "properties": {
         "domain": {
@@ -1743,6 +1725,26 @@
         "model": {
           "type": "string"
         },
+        "voice": {
+          "type": "string"
+        },
+        "sample_rate": {
+          "type": "integer"
+        },
+        "audio_files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "capability": {
+          "type": "string",
+          "enum": [
+            "llm",
+            "tts",
+            "stt"
+          ]
+        },
         "base_url": {
           "type": "string"
         },
@@ -1807,8 +1809,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "type",
-        "model"
+        "type"
       ]
     },
     "ProviderDefaults": {
@@ -2748,6 +2749,9 @@
         "style": {
           "$ref": "#/$defs/PersonaStyle"
         },
+        "voice": {
+          "type": "string"
+        },
         "defaults": {
           "$ref": "#/$defs/PersonaDefaults"
         }
@@ -2886,6 +2890,22 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "VoiceBinding": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "provider"
+      ]
     }
   },
   "properties": {

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -598,9 +598,6 @@
         "monitor": {
           "$ref": "#/$defs/MonitorSection"
         },
-        "tts": {
-          "$ref": "#/$defs/TTSConfig"
-        },
         "html_report": {
           "type": "string"
         },
@@ -2095,9 +2092,6 @@
         "voice": {
           "type": "string"
         },
-        "tts": {
-          "$ref": "#/$defs/TTSConfig"
-        },
         "variables": {
           "additionalProperties": {
             "type": "string"
@@ -2361,34 +2355,6 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "TTSConfig": {
-      "properties": {
-        "provider": {
-          "type": "string"
-        },
-        "voice": {
-          "type": "string"
-        },
-        "model": {
-          "type": "string"
-        },
-        "audio_files": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "sample_rate": {
-          "type": "integer"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "provider",
-        "voice"
-      ]
-    },
     "TemplateEngineInfo": {
       "properties": {
         "version": {
@@ -2622,9 +2588,6 @@
         },
         "seed": {
           "type": "integer"
-        },
-        "tts": {
-          "$ref": "#/$defs/TTSConfig"
         },
         "streaming": {
           "type": "boolean"

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -465,6 +465,24 @@
             "$ref": "#/$defs/Spec"
           },
           "type": "object"
+        },
+        "tts_providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
+        "stt_providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
+        "voices": {
+          "items": {
+            "$ref": "#/$defs/VoiceBinding"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
@@ -472,6 +490,24 @@
       "required": [
         "providers",
         "defaults"
+      ]
+    },
+    "VoiceBinding": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Voice id used by personas"
+        },
+        "provider": {
+          "type": "string",
+          "description": "TTS provider id (must exist in spec.tts_providers)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "provider"
       ]
     },
     "ContextMetadata": {

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2092,6 +2092,9 @@
         "duplex": {
           "$ref": "#/$defs/DuplexConfig"
         },
+        "voice": {
+          "type": "string"
+        },
         "tts": {
           "$ref": "#/$defs/TTSConfig"
         },

--- a/schemas/v1alpha1/persona.json
+++ b/schemas/v1alpha1/persona.json
@@ -144,6 +144,9 @@
         "style": {
           "$ref": "#/$defs/PersonaStyle"
         },
+        "voice": {
+          "type": "string"
+        },
         "defaults": {
           "$ref": "#/$defs/PersonaDefaults"
         }

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -179,13 +179,27 @@
         },
         "http_transport": {
           "$ref": "#/$defs/HTTPTransportConfig"
+        },
+        "voice": {
+          "type": "string",
+          "description": "Voice ID for TTS providers"
+        },
+        "sample_rate": {
+          "type": "integer",
+          "description": "Audio sample rate in Hz for TTS providers"
+        },
+        "audio_files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PCM audio fixture files for mock TTS provider"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "type",
-        "model"
+        "type"
       ]
     },
     "ProviderDefaults": {

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -112,6 +112,9 @@
         "model": {
           "type": "string"
         },
+        "capability": {
+          "type": "string"
+        },
         "base_url": {
           "type": "string"
         },

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -113,7 +113,12 @@
           "type": "string"
         },
         "capability": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "llm",
+            "tts",
+            "stt"
+          ]
         },
         "base_url": {
           "type": "string"

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -112,6 +112,18 @@
         "model": {
           "type": "string"
         },
+        "voice": {
+          "type": "string"
+        },
+        "sample_rate": {
+          "type": "integer"
+        },
+        "audio_files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "capability": {
           "type": "string",
           "enum": [
@@ -179,21 +191,6 @@
         },
         "http_transport": {
           "$ref": "#/$defs/HTTPTransportConfig"
-        },
-        "voice": {
-          "type": "string",
-          "description": "Voice ID for TTS providers"
-        },
-        "sample_rate": {
-          "type": "integer",
-          "description": "Audio sample rate in Hz for TTS providers"
-        },
-        "audio_files": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "PCM audio fixture files for mock TTS provider"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -560,6 +560,26 @@
         "model": {
           "type": "string"
         },
+        "voice": {
+          "type": "string"
+        },
+        "sample_rate": {
+          "type": "integer"
+        },
+        "audio_files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "capability": {
+          "type": "string",
+          "enum": [
+            "llm",
+            "tts",
+            "stt"
+          ]
+        },
         "base_url": {
           "type": "string"
         },
@@ -624,8 +644,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "type",
-        "model"
+        "type"
       ]
     },
     "ProviderDefaults": {

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -300,6 +300,9 @@
         "duplex": {
           "$ref": "#/$defs/DuplexConfig"
         },
+        "voice": {
+          "type": "string"
+        },
         "tts": {
           "$ref": "#/$defs/TTSConfig"
         },

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -303,9 +303,6 @@
         "voice": {
           "type": "string"
         },
-        "tts": {
-          "$ref": "#/$defs/TTSConfig"
-        },
         "variables": {
           "additionalProperties": {
             "type": "string"
@@ -349,34 +346,6 @@
       "type": "object",
       "required": [
         "content"
-      ]
-    },
-    "TTSConfig": {
-      "properties": {
-        "provider": {
-          "type": "string"
-        },
-        "voice": {
-          "type": "string"
-        },
-        "model": {
-          "type": "string"
-        },
-        "audio_files": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "sample_rate": {
-          "type": "integer"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "provider",
-        "voice"
       ]
     },
     "ToolPolicy": {
@@ -454,9 +423,6 @@
         },
         "seed": {
           "type": "integer"
-        },
-        "tts": {
-          "$ref": "#/$defs/TTSConfig"
         },
         "streaming": {
           "type": "boolean"

--- a/tools/arena/engine/duplex_executor_turns_integration.go
+++ b/tools/arena/engine/duplex_executor_turns_integration.go
@@ -381,8 +381,16 @@ func resolveTTSProvider(
 }
 
 // processScriptedTextDuplexTurn handles user turns whose content is plain text
-// (no audio parts). The text is synthesized via TTS using layered config
-// resolution and streamed to the duplex provider.
+// (no audio parts). The text is synthesized via TTS and streamed to the duplex
+// provider.
+//
+// Resolution order:
+//  1. New path: if req.Scenario.Voice is set, resolve it via the arena voice
+//     catalog (Config.ResolveVoice) and route through streamTextAsAudioForProvider.
+//  2. Legacy fallback: if Scenario.Voice is empty, resolve via the layered
+//     turn.TTS → scenario.TTS → arena defaults chain and route through
+//     streamTextAsAudio. This keeps unmigrated scenarios working until Phase 5
+//     removes the legacy fields.
 func (de *DuplexConversationExecutor) processScriptedTextDuplexTurn(
 	ctx context.Context,
 	req *ConversationRequest,
@@ -395,11 +403,24 @@ func (de *DuplexConversationExecutor) processScriptedTextDuplexTurn(
 		return fmt.Errorf("self-play registry not configured for duplex turn %d (required for TTS)", turnIdx)
 	}
 
+	// New path: scenario.Voice → arena voice catalog.
+	if req.Scenario != nil && req.Scenario.Voice != "" {
+		ttsProvider, err := req.Config.ResolveVoice(req.Scenario.Voice)
+		if err != nil {
+			return fmt.Errorf("resolving voice for scripted-text turn %d: %w", turnIdx, err)
+		}
+		return de.streamTextAsAudioForProvider(
+			ctx, turn.Content, ttsProvider, nil,
+			inputChan, outputChan,
+		)
+	}
+
+	// Legacy fallback: turn.TTS → scenario.TTS → arena defaults.TTS.
 	ttsConfig := de.resolveTTS(turn, req.Scenario, req.Config)
 	if ttsConfig == nil {
 		return fmt.Errorf(
 			"TTS configuration required for scripted-text duplex turn %d "+
-				"(set turn.tts, scenario.spec.tts, or arena defaults.tts)",
+				"(set scenario.spec.voice, turn.tts, scenario.spec.tts, or arena defaults.tts)",
 			turnIdx,
 		)
 	}

--- a/tools/arena/engine/duplex_executor_turns_integration.go
+++ b/tools/arena/engine/duplex_executor_turns_integration.go
@@ -337,39 +337,9 @@ func turnHasAudioPart(turn *config.TurnDefinition) bool {
 	return false
 }
 
-// resolveTTS picks the TTS config for a turn using a layered precedence:
-//
-//  1. turn.TTS (per-turn override)
-//  2. scenario.TTS (scenario-level default)
-//  3. arena defaults TTS (arena-wide default)
-//
-// Returns nil when no layer supplies a config. Callers decide whether nil is an
-// error for their codepath.
-func (de *DuplexConversationExecutor) resolveTTS(
-	turn *config.TurnDefinition,
-	scenario *config.Scenario,
-	cfg *config.Config,
-) *config.TTSConfig {
-	if turn != nil && turn.TTS != nil {
-		return turn.TTS
-	}
-	if scenario != nil && scenario.TTS != nil {
-		return scenario.TTS
-	}
-	if cfg != nil && cfg.Defaults.TTS != nil {
-		return cfg.Defaults.TTS
-	}
-	return nil
-}
-
 // resolveTTSProvider returns the loaded TTS provider for a turn by looking
 // up the persona's voice id in the arena's voice catalog. Returns nil, nil if
-// the turn has no associated persona or the persona declares no voice —
-// callers decide whether to fall back to a default or fail fast.
-//
-// Replaces the legacy turn.TTS → scenario.TTS → defaults.TTS chain for
-// selfplay turns. The legacy resolveTTS and its callers stay in place until all
-// callers are migrated (Phase 5).
+// the turn has no associated persona or the persona declares no voice.
 func resolveTTSProvider(
 	arenaConfig *config.Config,
 	persona *config.UserPersonaPack,
@@ -384,13 +354,8 @@ func resolveTTSProvider(
 // (no audio parts). The text is synthesized via TTS and streamed to the duplex
 // provider.
 //
-// Resolution order:
-//  1. New path: if req.Scenario.Voice is set, resolve it via the arena voice
-//     catalog (Config.ResolveVoice) and route through streamTextAsAudioForProvider.
-//  2. Legacy fallback: if Scenario.Voice is empty, resolve via the layered
-//     turn.TTS → scenario.TTS → arena defaults chain and route through
-//     streamTextAsAudio. This keeps unmigrated scenarios working until Phase 5
-//     removes the legacy fields.
+// The scenario must declare a voice via spec.voice, which is resolved through
+// the arena voice catalog (Config.ResolveVoice).
 func (de *DuplexConversationExecutor) processScriptedTextDuplexTurn(
 	ctx context.Context,
 	req *ConversationRequest,
@@ -403,30 +368,19 @@ func (de *DuplexConversationExecutor) processScriptedTextDuplexTurn(
 		return fmt.Errorf("self-play registry not configured for duplex turn %d (required for TTS)", turnIdx)
 	}
 
-	// New path: scenario.Voice → arena voice catalog.
-	if req.Scenario != nil && req.Scenario.Voice != "" {
-		ttsProvider, err := req.Config.ResolveVoice(req.Scenario.Voice)
-		if err != nil {
-			return fmt.Errorf("resolving voice for scripted-text turn %d: %w", turnIdx, err)
-		}
-		return de.streamTextAsAudioForProvider(
-			ctx, turn.Content, ttsProvider, nil,
-			inputChan, outputChan,
-		)
-	}
-
-	// Legacy fallback: turn.TTS → scenario.TTS → arena defaults.TTS.
-	ttsConfig := de.resolveTTS(turn, req.Scenario, req.Config)
-	if ttsConfig == nil {
+	if req.Scenario == nil || req.Scenario.Voice == "" {
 		return fmt.Errorf(
-			"TTS configuration required for scripted-text duplex turn %d "+
-				"(set scenario.spec.voice, turn.tts, scenario.spec.tts, or arena defaults.tts)",
+			"TTS configuration required for scripted-text duplex turn %d: set spec.voice on the scenario",
 			turnIdx,
 		)
 	}
 
+	ttsProvider, err := req.Config.ResolveVoice(req.Scenario.Voice)
+	if err != nil {
+		return fmt.Errorf("resolving voice for scripted-text turn %d: %w", turnIdx, err)
+	}
 	return de.streamTextAsAudio(
-		ctx, turn.Content, ttsConfig, nil,
+		ctx, turn.Content, ttsProvider, nil,
 		inputChan, outputChan,
 	)
 }
@@ -645,14 +599,11 @@ func (de *DuplexConversationExecutor) ExecuteConversationStream(
 // processSelfPlayDuplexTurn handles self-play turns in duplex mode.
 // selfplayTurnNum is the 1-indexed selfplay turn number (first selfplay = 1).
 //
-// This is now a thin wrapper that:
-//  1. Resolves the TTS provider via persona.voice → arena voice catalog (new path),
-//     falling back to the legacy turn.TTS → scenario.TTS → arena defaults chain
-//     when the persona has no voice declared.
+// This is a thin wrapper that:
+//  1. Resolves the TTS provider via persona.voice → arena voice catalog.
 //  2. Generates persona text via the self-play text generator.
 //  3. Builds selfplay-specific turn metadata.
-//  4. Delegates to streamTextAsAudioForProvider / streamTextAsAudio to synthesize,
-//     send, and stream the audio.
+//  4. Delegates to streamTextAsAudio to synthesize, send, and stream the audio.
 func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 	ctx context.Context,
 	req *ConversationRequest,
@@ -667,32 +618,19 @@ func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 		return fmt.Errorf("self-play registry not configured for duplex turn %d", turnIdx)
 	}
 
-	// Resolve TTS via the new persona → voice catalog path. If the persona
-	// declares a voice id (persona.Voice != ""), we look it up in the arena's
-	// voice catalog and use the bound TTS provider yaml. If the persona has no
-	// voice, ttsProvider is nil and we fall back to the legacy layered resolution
-	// below so existing scenarios without voice ids keep working.
+	// Resolve TTS via the persona → voice catalog path. The persona must declare
+	// a voice id (persona.Voice != "") that maps to a loaded TTS provider yaml.
 	persona := de.selfPlayRegistry.GetPersona(turn.Persona)
 	ttsProvider, err := resolveTTSProvider(req.Config, persona)
 	if err != nil {
 		return fmt.Errorf("resolving voice for persona %s: %w", turn.Persona, err)
 	}
-
-	// Legacy fallback: if the new path produced no provider (persona has no voice
-	// or arena config is absent), fall back to the turn.TTS → scenario.TTS →
-	// arena defaults chain. This keeps unmigrated scenarios working until Phase 5
-	// removes the legacy fields.
-	var ttsConfig *config.TTSConfig
 	if ttsProvider == nil {
-		ttsConfig = de.resolveTTS(turn, req.Scenario, req.Config)
-		if ttsConfig == nil {
-			return fmt.Errorf(
-				"TTS configuration required for self-play duplex turn %d: "+
-					"persona %q has no voice and no legacy TTS config was found "+
-					"(set persona.voice or turn.tts/scenario.spec.tts/arena defaults.tts)",
-				turnIdx, turn.Persona,
-			)
-		}
+		return fmt.Errorf(
+			"TTS configuration required for self-play duplex turn %d: "+
+				"persona %q has no voice declared (set persona.voice to a voice catalog entry)",
+			turnIdx, turn.Persona,
+		)
 	}
 
 	// Get the text content generator (no TTS — we'll synthesize inside the helper).
@@ -709,19 +647,9 @@ func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 	// the rubric never reaches the LLM and the persona's `expressive: true`
 	// opt-in is silently a no-op.
 	if cg, ok := textGen.(*selfplay.ContentGenerator); ok {
-		if ttsProvider != nil {
-			// New path: use provider-backed TTS service for rubric wiring.
-			if ttsService, terr := de.selfPlayRegistry.GetTTSRegistry().GetForProvider(ttsProvider); terr == nil {
-				if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
-					cg.WithProviderRubric(rp.PersonaRubric())
-				}
-			}
-		} else {
-			// Legacy path: wire rubric from TTSConfig-backed service.
-			if ttsService, terr := de.selfPlayRegistry.GetTTSRegistry().GetWithConfig(ttsConfig); terr == nil {
-				if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
-					cg.WithProviderRubric(rp.PersonaRubric())
-				}
+		if ttsService, terr := de.selfPlayRegistry.GetTTSRegistry().GetForProvider(ttsProvider); terr == nil {
+			if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
+				cg.WithProviderRubric(rp.PersonaRubric())
 			}
 		}
 	}
@@ -799,93 +727,23 @@ func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 		}
 	}
 
-	// Route to the appropriate synthesis helper based on which resolution path
-	// succeeded. The new provider path uses streamTextAsAudioForProvider; the
-	// legacy path uses streamTextAsAudio. Both share the same turn metadata and
-	// downstream pipeline plumbing.
-	if ttsProvider != nil {
-		return de.streamTextAsAudioForProvider(
-			ctx, generatedText, ttsProvider, turnMeta,
-			inputChan, outputChan,
-		)
-	}
 	return de.streamTextAsAudio(
-		ctx, generatedText, ttsConfig, turnMeta,
+		ctx, generatedText, ttsProvider, turnMeta,
 		inputChan, outputChan,
 	)
 }
 
-// streamTextAsAudio synthesizes text → audio via the configured TTS provider,
-// emits a user-role pipeline element with both text and audio parts, and
-// streams the audio bytes through the duplex pipeline using burst mode.
+// streamTextAsAudio synthesizes text → audio via a loaded TTS provider config
+// (capability=tts), emits a user-role pipeline element with both text and audio
+// parts, and streams the audio bytes through the duplex pipeline using burst mode.
 //
-// turnMeta is merged into the user message's Meta map. Callers can pass
-// nil/empty when no extra metadata is needed (e.g. scripted-text turns); the
-// helper always writes turn_id so transcription events can be correlated.
+// turnMeta is merged into the user message's Meta map. Callers can pass nil/empty
+// when no extra metadata is needed; the helper always writes turn_id so
+// transcription events can be correlated.
 //
-// This is the shared entry point used by both self-play turns (after
-// generating persona text) and scripted-text user turns.
-//
-// Streams audio chunks straight from the TTS reader into the pipeline
-// without ever holding the full buffer in memory. Pacing happens
-// downstream in the AudioPacingStage, which emits each audio element at
-// the cadence its byte count and sample rate imply. The executor itself
-// does no time.After pacing — chunks are pushed onto the input channel
-// as fast as they arrive from the TTS service.
-//
-// Flow:
-//  1. Open the TTS stream (no ReadAll).
-//  2. Open a temp PCM file the chunks are mirrored into.
-//  3. Loop: read chunk → emit elem.Audio AND append to temp file.
-//  4. At EOF, close temp file and emit the user Message with a FilePath
-//     pointer. The MediaExternalizerStage downstream copies the file
-//     into media storage and replaces FilePath with a StorageReference.
-//  5. Send EndOfStream and wait for the provider's response.
-//
-// Memory ceiling: one TTS chunk at a time, regardless of turn length.
-//
-//nolint:gocyclo // sequential streaming flow with cleanup; splitting hurts readability
+// Used by both self-play turns (after generating persona text) and scripted-text
+// user turns resolved via the arena voice catalog.
 func (de *DuplexConversationExecutor) streamTextAsAudio(
-	ctx context.Context,
-	text string,
-	ttsConfig *config.TTSConfig,
-	turnMeta map[string]any,
-	inputChan chan<- stage.StreamElement,
-	outputChan <-chan stage.StreamElement,
-) error {
-	if text == "" {
-		return errors.New("streamTextAsAudio: text is empty")
-	}
-	if ttsConfig == nil {
-		return errors.New("streamTextAsAudio: ttsConfig is nil")
-	}
-	if de.selfPlayRegistry == nil {
-		return errors.New("streamTextAsAudio: self-play registry not configured (TTS service unavailable)")
-	}
-	stream, err := de.openTextSynthesisStream(ctx, text, ttsConfig)
-	if err != nil {
-		return fmt.Errorf("failed to open TTS stream: %w", err)
-	}
-	// Stamp TTS cost into turnMeta so it is carried through to the user
-	// message's Meta and picked up by the arena cost rollup under the
-	// ttsCostMetaKey key (mirrors the self_play_cost pattern).
-	costStamper := func(latency time.Duration) {
-		stampTTSCostInMeta(de.selfPlayRegistry, ttsConfig, text, latency, turnMeta)
-	}
-	return de.doStreamTextAsAudio(ctx, text, stream, turnMeta, costStamper, inputChan, outputChan)
-}
-
-// streamTextAsAudioForProvider synthesizes text → audio via a loaded TTS
-// provider config (capability=tts), emits a user-role pipeline element with
-// both text and audio parts, and streams the audio bytes through the duplex
-// pipeline using burst mode.
-//
-// This is the new-path parallel to streamTextAsAudio. It uses the arena's
-// voice catalog (provider yaml) rather than the legacy TTSConfig. Callers that
-// have resolved a persona.voice → *config.Provider should use this function;
-// callers on the legacy turn/scenario/defaults chain should continue to call
-// streamTextAsAudio until Phase 5 removes the legacy fields.
-func (de *DuplexConversationExecutor) streamTextAsAudioForProvider(
 	ctx context.Context,
 	text string,
 	ttsProvider *config.Provider,
@@ -894,28 +752,27 @@ func (de *DuplexConversationExecutor) streamTextAsAudioForProvider(
 	outputChan <-chan stage.StreamElement,
 ) error {
 	if text == "" {
-		return errors.New("streamTextAsAudioForProvider: text is empty")
+		return errors.New("streamTextAsAudio: text is empty")
 	}
 	if ttsProvider == nil {
-		return errors.New("streamTextAsAudioForProvider: ttsProvider is nil")
+		return errors.New("streamTextAsAudio: ttsProvider is nil")
 	}
 	if de.selfPlayRegistry == nil {
-		return errors.New("streamTextAsAudioForProvider: self-play registry not configured (TTS service unavailable)")
+		return errors.New("streamTextAsAudio: self-play registry not configured (TTS service unavailable)")
 	}
-	stream, err := de.openTextSynthesisStreamForProvider(ctx, text, ttsProvider)
+	stream, err := de.openTextSynthesisStream(ctx, text, ttsProvider)
 	if err != nil {
 		return fmt.Errorf("failed to open TTS stream: %w", err)
 	}
 	costStamper := func(latency time.Duration) {
-		stampTTSCostInMetaForProvider(de.selfPlayRegistry, ttsProvider, text, latency, turnMeta)
+		stampTTSCostInMeta(de.selfPlayRegistry, ttsProvider, text, latency, turnMeta)
 	}
 	return de.doStreamTextAsAudio(ctx, text, stream, turnMeta, costStamper, inputChan, outputChan)
 }
 
-// doStreamTextAsAudio is the shared streaming core used by both streamTextAsAudio
-// (legacy TTSConfig path) and streamTextAsAudioForProvider (new provider-yaml path).
-// It takes an already-opened TTS stream and a costStamper closure that writes cost
-// metadata into turnMeta after the stream completes.
+// doStreamTextAsAudio is the streaming core. It takes an already-opened TTS
+// stream and a costStamper closure that writes cost metadata into turnMeta
+// after the stream completes.
 //
 // Streams audio chunks straight from the TTS reader into the pipeline
 // without ever holding the full buffer in memory. Pacing happens
@@ -1287,41 +1144,12 @@ func stampSelfplayDevMeta(
 	turnMeta["_persona_yaml"] = string(yamlBytes)
 }
 
-// entry so addAncillaryCostFromMeta can fold it into the total without
-// special-casing.
+// stampTTSCostInMeta writes the TTS cost for a synthesized turn into turnMeta
+// under ttsCostMetaKey so addAncillaryCostFromMeta can fold it into the total
+// without special-casing.
 //
 // Errors are swallowed: a cost lookup failure must never abort the turn.
 func stampTTSCostInMeta(
-	registry *selfplay.Registry,
-	ttsConfig *config.TTSConfig,
-	text string,
-	latency time.Duration,
-	turnMeta map[string]any,
-) {
-	if registry == nil || ttsConfig == nil || turnMeta == nil {
-		return
-	}
-	gen, err := registry.GetTextSynthesisGenerator(ttsConfig)
-	if err != nil {
-		return
-	}
-	acg, ok := gen.(*selfplay.AudioContentGenerator)
-	if !ok {
-		return
-	}
-	svc := acg.GetTTSService()
-	costMeta := base.CostInfoToMetaMap(tts.ComputeTTSCost(svc, text, latency))
-	if costMeta != nil {
-		turnMeta[ttsCostMetaKey] = costMeta
-	}
-}
-
-// stampTTSCostInMetaForProvider writes the TTS cost for a synthesized turn into
-// turnMeta under ttsCostMetaKey, using the new provider-yaml path. Parallel to
-// stampTTSCostInMeta for callers that resolved TTS via persona.voice → catalog.
-//
-// Errors are swallowed: a cost lookup failure must never abort the turn.
-func stampTTSCostInMetaForProvider(
 	registry *selfplay.Registry,
 	ttsProvider *config.Provider,
 	text string,

--- a/tools/arena/engine/duplex_executor_turns_integration.go
+++ b/tools/arena/engine/duplex_executor_turns_integration.go
@@ -17,6 +17,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/streaming"
 	"github.com/AltairaLabs/PromptKit/runtime/tts"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -361,6 +362,24 @@ func (de *DuplexConversationExecutor) resolveTTS(
 	return nil
 }
 
+// resolveTTSProvider returns the loaded TTS provider for a turn by looking
+// up the persona's voice id in the arena's voice catalog. Returns nil, nil if
+// the turn has no associated persona or the persona declares no voice —
+// callers decide whether to fall back to a default or fail fast.
+//
+// Replaces the legacy turn.TTS → scenario.TTS → defaults.TTS chain for
+// selfplay turns. The legacy resolveTTS and its callers stay in place until all
+// callers are migrated (Phase 5).
+func resolveTTSProvider(
+	arenaConfig *config.Config,
+	persona *config.UserPersonaPack,
+) (*config.Provider, error) {
+	if arenaConfig == nil || persona == nil || persona.Voice == "" {
+		return nil, nil
+	}
+	return arenaConfig.ResolveVoice(persona.Voice)
+}
+
 // processScriptedTextDuplexTurn handles user turns whose content is plain text
 // (no audio parts). The text is synthesized via TTS using layered config
 // resolution and streamed to the duplex provider.
@@ -606,10 +625,13 @@ func (de *DuplexConversationExecutor) ExecuteConversationStream(
 // selfplayTurnNum is the 1-indexed selfplay turn number (first selfplay = 1).
 //
 // This is now a thin wrapper that:
-//  1. Resolves the TTS config (turn.TTS → scenario.TTS → arena defaults).
+//  1. Resolves the TTS provider via persona.voice → arena voice catalog (new path),
+//     falling back to the legacy turn.TTS → scenario.TTS → arena defaults chain
+//     when the persona has no voice declared.
 //  2. Generates persona text via the self-play text generator.
 //  3. Builds selfplay-specific turn metadata.
-//  4. Delegates to streamTextAsAudio to synthesize + send + stream the audio.
+//  4. Delegates to streamTextAsAudioForProvider / streamTextAsAudio to synthesize,
+//     send, and stream the audio.
 func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 	ctx context.Context,
 	req *ConversationRequest,
@@ -624,16 +646,32 @@ func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 		return fmt.Errorf("self-play registry not configured for duplex turn %d", turnIdx)
 	}
 
-	// Resolve TTS via the layered precedence. Self-play has historically required
-	// a TTS config, and that's still true — but now scenario/arena defaults are
-	// allowed to satisfy the requirement.
-	ttsConfig := de.resolveTTS(turn, req.Scenario, req.Config)
-	if ttsConfig == nil {
-		return fmt.Errorf(
-			"TTS configuration required for self-play duplex turn %d "+
-				"(set turn.tts, scenario.spec.tts, or arena defaults.tts)",
-			turnIdx,
-		)
+	// Resolve TTS via the new persona → voice catalog path. If the persona
+	// declares a voice id (persona.Voice != ""), we look it up in the arena's
+	// voice catalog and use the bound TTS provider yaml. If the persona has no
+	// voice, ttsProvider is nil and we fall back to the legacy layered resolution
+	// below so existing scenarios without voice ids keep working.
+	persona := de.selfPlayRegistry.GetPersona(turn.Persona)
+	ttsProvider, err := resolveTTSProvider(req.Config, persona)
+	if err != nil {
+		return fmt.Errorf("resolving voice for persona %s: %w", turn.Persona, err)
+	}
+
+	// Legacy fallback: if the new path produced no provider (persona has no voice
+	// or arena config is absent), fall back to the turn.TTS → scenario.TTS →
+	// arena defaults chain. This keeps unmigrated scenarios working until Phase 5
+	// removes the legacy fields.
+	var ttsConfig *config.TTSConfig
+	if ttsProvider == nil {
+		ttsConfig = de.resolveTTS(turn, req.Scenario, req.Config)
+		if ttsConfig == nil {
+			return fmt.Errorf(
+				"TTS configuration required for self-play duplex turn %d: "+
+					"persona %q has no voice and no legacy TTS config was found "+
+					"(set persona.voice or turn.tts/scenario.spec.tts/arena defaults.tts)",
+				turnIdx, turn.Persona,
+			)
+		}
 	}
 
 	// Get the text content generator (no TTS — we'll synthesize inside the helper).
@@ -650,9 +688,19 @@ func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 	// the rubric never reaches the LLM and the persona's `expressive: true`
 	// opt-in is silently a no-op.
 	if cg, ok := textGen.(*selfplay.ContentGenerator); ok {
-		if ttsService, terr := de.selfPlayRegistry.GetTTSRegistry().GetWithConfig(ttsConfig); terr == nil {
-			if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
-				cg.WithProviderRubric(rp.PersonaRubric())
+		if ttsProvider != nil {
+			// New path: use provider-backed TTS service for rubric wiring.
+			if ttsService, terr := de.selfPlayRegistry.GetTTSRegistry().GetForProvider(ttsProvider); terr == nil {
+				if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
+					cg.WithProviderRubric(rp.PersonaRubric())
+				}
+			}
+		} else {
+			// Legacy path: wire rubric from TTSConfig-backed service.
+			if ttsService, terr := de.selfPlayRegistry.GetTTSRegistry().GetWithConfig(ttsConfig); terr == nil {
+				if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
+					cg.WithProviderRubric(rp.PersonaRubric())
+				}
 			}
 		}
 	}
@@ -730,6 +778,16 @@ func (de *DuplexConversationExecutor) processSelfPlayDuplexTurn(
 		}
 	}
 
+	// Route to the appropriate synthesis helper based on which resolution path
+	// succeeded. The new provider path uses streamTextAsAudioForProvider; the
+	// legacy path uses streamTextAsAudio. Both share the same turn metadata and
+	// downstream pipeline plumbing.
+	if ttsProvider != nil {
+		return de.streamTextAsAudioForProvider(
+			ctx, generatedText, ttsProvider, turnMeta,
+			inputChan, outputChan,
+		)
+	}
 	return de.streamTextAsAudio(
 		ctx, generatedText, ttsConfig, turnMeta,
 		inputChan, outputChan,
@@ -783,16 +841,93 @@ func (de *DuplexConversationExecutor) streamTextAsAudio(
 	if de.selfPlayRegistry == nil {
 		return errors.New("streamTextAsAudio: self-play registry not configured (TTS service unavailable)")
 	}
-
-	ttsStart := time.Now()
 	stream, err := de.openTextSynthesisStream(ctx, text, ttsConfig)
 	if err != nil {
 		return fmt.Errorf("failed to open TTS stream: %w", err)
 	}
+	// Stamp TTS cost into turnMeta so it is carried through to the user
+	// message's Meta and picked up by the arena cost rollup under the
+	// ttsCostMetaKey key (mirrors the self_play_cost pattern).
+	costStamper := func(latency time.Duration) {
+		stampTTSCostInMeta(de.selfPlayRegistry, ttsConfig, text, latency, turnMeta)
+	}
+	return de.doStreamTextAsAudio(ctx, text, stream, turnMeta, costStamper, inputChan, outputChan)
+}
+
+// streamTextAsAudioForProvider synthesizes text → audio via a loaded TTS
+// provider config (capability=tts), emits a user-role pipeline element with
+// both text and audio parts, and streams the audio bytes through the duplex
+// pipeline using burst mode.
+//
+// This is the new-path parallel to streamTextAsAudio. It uses the arena's
+// voice catalog (provider yaml) rather than the legacy TTSConfig. Callers that
+// have resolved a persona.voice → *config.Provider should use this function;
+// callers on the legacy turn/scenario/defaults chain should continue to call
+// streamTextAsAudio until Phase 5 removes the legacy fields.
+func (de *DuplexConversationExecutor) streamTextAsAudioForProvider(
+	ctx context.Context,
+	text string,
+	ttsProvider *config.Provider,
+	turnMeta map[string]any,
+	inputChan chan<- stage.StreamElement,
+	outputChan <-chan stage.StreamElement,
+) error {
+	if text == "" {
+		return errors.New("streamTextAsAudioForProvider: text is empty")
+	}
+	if ttsProvider == nil {
+		return errors.New("streamTextAsAudioForProvider: ttsProvider is nil")
+	}
+	if de.selfPlayRegistry == nil {
+		return errors.New("streamTextAsAudioForProvider: self-play registry not configured (TTS service unavailable)")
+	}
+	stream, err := de.openTextSynthesisStreamForProvider(ctx, text, ttsProvider)
+	if err != nil {
+		return fmt.Errorf("failed to open TTS stream: %w", err)
+	}
+	costStamper := func(latency time.Duration) {
+		stampTTSCostInMetaForProvider(de.selfPlayRegistry, ttsProvider, text, latency, turnMeta)
+	}
+	return de.doStreamTextAsAudio(ctx, text, stream, turnMeta, costStamper, inputChan, outputChan)
+}
+
+// doStreamTextAsAudio is the shared streaming core used by both streamTextAsAudio
+// (legacy TTSConfig path) and streamTextAsAudioForProvider (new provider-yaml path).
+// It takes an already-opened TTS stream and a costStamper closure that writes cost
+// metadata into turnMeta after the stream completes.
+//
+// Streams audio chunks straight from the TTS reader into the pipeline
+// without ever holding the full buffer in memory. Pacing happens
+// downstream in the AudioPacingStage, which emits each audio element at
+// the cadence its byte count and sample rate imply. The executor itself
+// does no time.After pacing — chunks are pushed onto the input channel
+// as fast as they arrive from the TTS service.
+//
+// Flow:
+//  1. Open a temp PCM file the chunks are mirrored into.
+//  2. Loop: read chunk → emit elem.Audio AND append to temp file.
+//  3. At EOF, close temp file and emit the user Message with a FilePath
+//     pointer. The MediaExternalizerStage downstream copies the file
+//     into media storage and replaces FilePath with a StorageReference.
+//  4. Send EndOfStream and wait for the provider's response.
+//
+// Memory ceiling: one TTS chunk at a time, regardless of turn length.
+//
+//nolint:gocyclo // sequential streaming flow with cleanup; splitting hurts readability
+func (de *DuplexConversationExecutor) doStreamTextAsAudio(
+	ctx context.Context,
+	text string,
+	stream *selfplay.AudioStreamResult,
+	turnMeta map[string]any,
+	costStamper func(time.Duration),
+	inputChan chan<- stage.StreamElement,
+	outputChan <-chan stage.StreamElement,
+) error {
 	defer stream.Reader.Close()
 	reader := stream.Reader
 	sampleRate := stream.SampleRate
 
+	ttsStart := time.Now()
 	turnID := uuid.New().String()
 	logger.Debug("Text-as-audio streaming start",
 		"turn_id", turnID, "text", text, "text_length", len(text), "sample_rate", sampleRate)
@@ -800,7 +935,7 @@ func (de *DuplexConversationExecutor) streamTextAsAudio(
 	// Start the response collector before audio flows so it doesn't miss
 	// an instant mock-duplex response that fires the moment EndOfStream
 	// reaches the provider.
-	responseDone := de.startResponseCollector(ctx, outputChan, inputChan, "streamTextAsAudio")
+	responseDone := de.startResponseCollector(ctx, outputChan, inputChan, "doStreamTextAsAudio")
 
 	mirror, err := newTurnAudioMirror(turnID)
 	if err != nil {
@@ -814,10 +949,7 @@ func (de *DuplexConversationExecutor) streamTextAsAudio(
 	}
 	ttsLatency := time.Since(ttsStart)
 
-	// Stamp TTS cost into turnMeta so it is carried through to the user
-	// message's Meta and picked up by the arena cost rollup under the
-	// ttsCostMetaKey key (mirrors the self_play_cost pattern).
-	stampTTSCostInMeta(de.selfPlayRegistry, ttsConfig, text, ttsLatency, turnMeta)
+	costStamper(ttsLatency)
 
 	mirrorPath, err := mirror.finalize()
 	if err != nil {
@@ -831,11 +963,11 @@ func (de *DuplexConversationExecutor) streamTextAsAudio(
 		return err
 	}
 
-	if err := de.sendEndOfStream(ctx, inputChan, "streamTextAsAudio"); err != nil {
+	if err := de.sendEndOfStream(ctx, inputChan, "doStreamTextAsAudio"); err != nil {
 		return err
 	}
 
-	return de.waitForResponse(ctx, responseDone, "streamTextAsAudio")
+	return de.waitForResponse(ctx, responseDone, "doStreamTextAsAudio")
 }
 
 // defaultSilenceTailDuration is how long a tail of silent PCM packets
@@ -1157,7 +1289,32 @@ func stampTTSCostInMeta(
 		return
 	}
 	svc := acg.GetTTSService()
-	costMeta := tts.CostInfoToMetaMap(tts.ComputeTTSCost(svc, text, latency))
+	costMeta := base.CostInfoToMetaMap(tts.ComputeTTSCost(svc, text, latency))
+	if costMeta != nil {
+		turnMeta[ttsCostMetaKey] = costMeta
+	}
+}
+
+// stampTTSCostInMetaForProvider writes the TTS cost for a synthesized turn into
+// turnMeta under ttsCostMetaKey, using the new provider-yaml path. Parallel to
+// stampTTSCostInMeta for callers that resolved TTS via persona.voice → catalog.
+//
+// Errors are swallowed: a cost lookup failure must never abort the turn.
+func stampTTSCostInMetaForProvider(
+	registry *selfplay.Registry,
+	ttsProvider *config.Provider,
+	text string,
+	latency time.Duration,
+	turnMeta map[string]any,
+) {
+	if registry == nil || ttsProvider == nil || turnMeta == nil {
+		return
+	}
+	svc, err := registry.GetTTSRegistry().GetForProvider(ttsProvider)
+	if err != nil {
+		return
+	}
+	costMeta := base.CostInfoToMetaMap(tts.ComputeTTSCost(svc, text, latency))
 	if costMeta != nil {
 		turnMeta[ttsCostMetaKey] = costMeta
 	}

--- a/tools/arena/engine/duplex_text_tts_test.go
+++ b/tools/arena/engine/duplex_text_tts_test.go
@@ -298,6 +298,71 @@ func TestStreamTextAsAudio_RejectsMissingRegistry(t *testing.T) {
 	assert.Contains(t, err.Error(), "self-play registry not configured")
 }
 
+// TestProcessScriptedTextDuplexTurn_ViaScenarioVoice verifies that when
+// req.Scenario.Voice is set the scripted-text path resolves through the arena
+// voice catalog (new path) rather than the legacy resolveTTS chain.
+// Uses a mock TTS provider with audio files so GetForProvider returns a
+// MockTTSService without requiring real API credentials.
+func TestProcessScriptedTextDuplexTurn_ViaScenarioVoice(t *testing.T) {
+	// Build a registry with the TTS registry's mock-with-files path.
+	ttsRegistry := selfplay.NewTTSRegistry()
+	reg := selfplay.NewRegistryWithTTS(
+		nil,
+		map[string]string{},
+		map[string]*config.UserPersonaPack{},
+		[]config.SelfPlayRoleGroup{},
+		ttsRegistry,
+	)
+	de := &DuplexConversationExecutor{selfPlayRegistry: reg}
+
+	const providerName = "scripted-mock"
+	// mock type + AudioFiles → GetForProvider returns a MockTTSService
+	// (no real API needed, and it handles SynthesizeTTS).
+	provider := &config.Provider{
+		ID:         providerName,
+		Type:       "mock",
+		Capability: config.CapabilityTTS,
+		AudioFiles: []string{}, // empty → MockTTSService with no rotation
+	}
+	cfg := &config.Config{
+		Voices: []config.VoiceBinding{{ID: "scripted", Provider: providerName}},
+		LoadedTTSProviders: map[string]*config.Provider{
+			providerName: provider,
+		},
+	}
+	scenario := &config.Scenario{
+		ID:    "scripted",
+		Voice: "scripted",
+		// No TTS field — new path must not require legacy config.
+	}
+	req := &ConversationRequest{Scenario: scenario, Config: cfg}
+	turn := &config.TurnDefinition{Role: "user", Content: "hello world"}
+
+	in := make(chan stage.StreamElement, 256)
+	out := make(chan stage.StreamElement, 1)
+	out <- stage.StreamElement{
+		EndOfStream: true,
+		Message:     &types.Message{Role: "assistant", Content: "ok"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Drain inputChan concurrently so pumpTTSChunks never blocks on a full channel.
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for range in { //nolint:revive // drain
+		}
+	}()
+
+	err := de.processScriptedTextDuplexTurn(ctx, req, turn, 0, in, out)
+	require.NoError(t, err, "scripted-text via scenario.Voice should succeed")
+
+	close(in)
+	<-drainDone
+}
+
 func TestResolveTTSProvider_ViaPersona(t *testing.T) {
 	cfg := &config.Config{
 		Voices: []config.VoiceBinding{{ID: "v1", Provider: "p1"}},

--- a/tools/arena/engine/duplex_text_tts_test.go
+++ b/tools/arena/engine/duplex_text_tts_test.go
@@ -298,6 +298,35 @@ func TestStreamTextAsAudio_RejectsMissingRegistry(t *testing.T) {
 	assert.Contains(t, err.Error(), "self-play registry not configured")
 }
 
+func TestResolveTTSProvider_ViaPersona(t *testing.T) {
+	cfg := &config.Config{
+		Voices: []config.VoiceBinding{{ID: "v1", Provider: "p1"}},
+		LoadedTTSProviders: map[string]*config.Provider{
+			"p1": {ID: "p1", Type: "cartesia", Voice: "vid", Capability: config.CapabilityTTS},
+		},
+	}
+	persona := &config.UserPersonaPack{ID: "p", Voice: "v1"}
+	got, err := resolveTTSProvider(cfg, persona)
+	if err != nil {
+		t.Fatalf("resolveTTSProvider: %v", err)
+	}
+	if got == nil || got.Voice != "vid" {
+		t.Fatalf("got %+v, want voice=vid", got)
+	}
+}
+
+func TestResolveTTSProvider_PersonaWithoutVoice(t *testing.T) {
+	cfg := &config.Config{}
+	persona := &config.UserPersonaPack{ID: "p"}
+	got, err := resolveTTSProvider(cfg, persona)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil provider for persona without voice, got %+v", got)
+	}
+}
+
 func TestTurnHasAudioPart(t *testing.T) {
 	t.Run("no parts", func(t *testing.T) {
 		assert.False(t, turnHasAudioPart(&config.TurnDefinition{}))

--- a/tools/arena/engine/duplex_text_tts_test.go
+++ b/tools/arena/engine/duplex_text_tts_test.go
@@ -79,60 +79,6 @@ func newRegistryWithFakeTTS(provider string, payload []byte) (*selfplay.Registry
 	return reg, fake
 }
 
-func TestResolveTTS_PerTurnWins(t *testing.T) {
-	de := &DuplexConversationExecutor{}
-
-	turn := &config.TurnDefinition{TTS: &config.TTSConfig{Provider: "turn", Voice: "v1"}}
-	scenario := &config.Scenario{TTS: &config.TTSConfig{Provider: "scenario", Voice: "v2"}}
-	cfg := &config.Config{Defaults: config.Defaults{TTS: &config.TTSConfig{Provider: "arena", Voice: "v3"}}}
-
-	got := de.resolveTTS(turn, scenario, cfg)
-	require.NotNil(t, got)
-	assert.Equal(t, "turn", got.Provider, "turn-level TTS must win over scenario and arena defaults")
-}
-
-func TestResolveTTS_ScenarioFillsIn(t *testing.T) {
-	de := &DuplexConversationExecutor{}
-
-	turn := &config.TurnDefinition{} // no TTS
-	scenario := &config.Scenario{TTS: &config.TTSConfig{Provider: "scenario", Voice: "v2"}}
-	cfg := &config.Config{Defaults: config.Defaults{TTS: &config.TTSConfig{Provider: "arena", Voice: "v3"}}}
-
-	got := de.resolveTTS(turn, scenario, cfg)
-	require.NotNil(t, got)
-	assert.Equal(t, "scenario", got.Provider, "scenario TTS must win over arena defaults when turn is unset")
-}
-
-func TestResolveTTS_ArenaDefaultsFillIn(t *testing.T) {
-	de := &DuplexConversationExecutor{}
-
-	turn := &config.TurnDefinition{}
-	scenario := &config.Scenario{}
-	cfg := &config.Config{Defaults: config.Defaults{TTS: &config.TTSConfig{Provider: "arena", Voice: "v3"}}}
-
-	got := de.resolveTTS(turn, scenario, cfg)
-	require.NotNil(t, got)
-	assert.Equal(t, "arena", got.Provider, "arena defaults must fill in when turn and scenario have no TTS")
-}
-
-func TestResolveTTS_NoneConfigured(t *testing.T) {
-	de := &DuplexConversationExecutor{}
-
-	turn := &config.TurnDefinition{}
-	scenario := &config.Scenario{}
-	cfg := &config.Config{}
-
-	got := de.resolveTTS(turn, scenario, cfg)
-	assert.Nil(t, got, "no TTS at any level should return nil")
-}
-
-func TestResolveTTS_NilCfgIsSafe(t *testing.T) {
-	de := &DuplexConversationExecutor{}
-
-	got := de.resolveTTS(&config.TurnDefinition{}, &config.Scenario{}, nil)
-	assert.Nil(t, got)
-}
-
 func TestProcessScriptedTextDuplexTurn_ErrorsWithoutTTS(t *testing.T) {
 	reg, _ := newRegistryWithFakeTTS("openai", []byte{0x00, 0x01})
 	de := &DuplexConversationExecutor{selfPlayRegistry: reg}
@@ -150,6 +96,19 @@ func TestProcessScriptedTextDuplexTurn_ErrorsWithoutTTS(t *testing.T) {
 	err := de.processScriptedTextDuplexTurn(context.Background(), req, turn, 0, in, out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "TTS configuration required")
+}
+
+// newTestTTSProvider builds a *config.Provider for the given registered
+// provider name — used by streamTextAsAudio tests that need a real
+// provider handle rather than the old TTSConfig shape.
+func newTestTTSProvider(providerName, voice string, sampleRate int) *config.Provider {
+	return &config.Provider{
+		ID:         providerName,
+		Type:       providerName,
+		Capability: config.CapabilityTTS,
+		Voice:      voice,
+		SampleRate: sampleRate,
+	}
 }
 
 // TestStreamTextAsAudio_HappyPath verifies that the helper synthesises the
@@ -179,7 +138,7 @@ func TestStreamTextAsAudio_HappyPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ttsCfg := &config.TTSConfig{Provider: "fake", Voice: "v1", SampleRate: 16000}
+	ttsProvider := newTestTTSProvider("fake", "v1", 16000)
 	turnMeta := map[string]any{
 		"persona":   "support-agent",
 		"self_play": true,
@@ -194,7 +153,7 @@ func TestStreamTextAsAudio_HappyPath(t *testing.T) {
 		}
 	}()
 
-	err := de.streamTextAsAudio(ctx, "please refund my order", ttsCfg, turnMeta, in, out)
+	err := de.streamTextAsAudio(ctx, "please refund my order", ttsProvider, turnMeta, in, out)
 	require.NoError(t, err)
 
 	// streamTextAsAudio doesn't close inputChan; the test does so after
@@ -259,7 +218,7 @@ func TestStreamTextAsAudio_RejectsEmptyText(t *testing.T) {
 	err := de.streamTextAsAudio(
 		context.Background(),
 		"",
-		&config.TTSConfig{Provider: "fake", Voice: "v1"},
+		newTestTTSProvider("fake", "v1", 0),
 		nil,
 		in,
 		out,
@@ -268,7 +227,7 @@ func TestStreamTextAsAudio_RejectsEmptyText(t *testing.T) {
 	assert.Contains(t, err.Error(), "text is empty")
 }
 
-func TestStreamTextAsAudio_RejectsNilTTSConfig(t *testing.T) {
+func TestStreamTextAsAudio_RejectsNilProvider(t *testing.T) {
 	reg, _ := newRegistryWithFakeTTS("fake", []byte{0x01, 0x02})
 	de := &DuplexConversationExecutor{selfPlayRegistry: reg}
 
@@ -277,7 +236,7 @@ func TestStreamTextAsAudio_RejectsNilTTSConfig(t *testing.T) {
 
 	err := de.streamTextAsAudio(context.Background(), "hi", nil, nil, in, out)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ttsConfig is nil")
+	assert.Contains(t, err.Error(), "ttsProvider is nil")
 }
 
 func TestStreamTextAsAudio_RejectsMissingRegistry(t *testing.T) {
@@ -289,7 +248,7 @@ func TestStreamTextAsAudio_RejectsMissingRegistry(t *testing.T) {
 	err := de.streamTextAsAudio(
 		context.Background(),
 		"hi",
-		&config.TTSConfig{Provider: "fake", Voice: "v1"},
+		newTestTTSProvider("fake", "v1", 0),
 		nil,
 		in,
 		out,
@@ -300,9 +259,8 @@ func TestStreamTextAsAudio_RejectsMissingRegistry(t *testing.T) {
 
 // TestProcessScriptedTextDuplexTurn_ViaScenarioVoice verifies that when
 // req.Scenario.Voice is set the scripted-text path resolves through the arena
-// voice catalog (new path) rather than the legacy resolveTTS chain.
-// Uses a mock TTS provider with audio files so GetForProvider returns a
-// MockTTSService without requiring real API credentials.
+// voice catalog. Uses a mock TTS provider with audio files so GetForProvider
+// returns a MockTTSService without requiring real API credentials.
 func TestProcessScriptedTextDuplexTurn_ViaScenarioVoice(t *testing.T) {
 	// Build a registry with the TTS registry's mock-with-files path.
 	ttsRegistry := selfplay.NewTTSRegistry()

--- a/tools/arena/engine/duplex_tts_streaming.go
+++ b/tools/arena/engine/duplex_tts_streaming.go
@@ -10,37 +10,15 @@ import (
 	"github.com/AltairaLabs/PromptKit/tools/arena/selfplay"
 )
 
-// openTextSynthesisStream returns the TTS stream for pre-known text via
-// the selfplay AudioGenerator interface — the same one used for
-// persona-driven selfplay turns. For scripted text the executor goes
-// through Registry.GetTextSynthesisGenerator (no LLM involved) and
-// calls SynthesizeTextStream on the resulting generator.
+// openTextSynthesisStream returns the TTS stream for pre-known text using the
+// arena voice catalog (capability=tts provider yaml). It looks up the TTS
+// service from the registry's TTSRegistry using the loaded provider config and
+// calls SynthesizeTextStream on an AudioContentGenerator backed by that service.
 //
-// Single seam: any time the arena needs TTS audio for a turn — whether
-// the text came from a persona LLM or a scenario YAML — it goes
-// through one of these two registry methods. No direct access to
-// ttsRegistry.
+// Single seam: any time the arena needs TTS audio for a scripted-text turn —
+// where the text came from the scenario YAML rather than a persona LLM — it
+// goes through this function. No direct access to ttsRegistry.
 func (de *DuplexConversationExecutor) openTextSynthesisStream(
-	ctx context.Context,
-	text string,
-	ttsConfig *config.TTSConfig,
-) (*selfplay.AudioStreamResult, error) {
-	gen, err := de.selfPlayRegistry.GetTextSynthesisGenerator(ttsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("get audio generator: %w", err)
-	}
-	return gen.SynthesizeTextStream(ctx, text)
-}
-
-// openTextSynthesisStreamForProvider returns the TTS stream for pre-known text
-// using the new provider-yaml path introduced in Task 3.1. It looks up the TTS
-// service from the registry's TTSRegistry using the loaded provider config
-// (capability=tts) and calls SynthesizeTextStream on an AudioContentGenerator
-// backed by that service.
-//
-// Parallel to openTextSynthesisStream (which takes a *config.TTSConfig). Phase 5
-// will remove the legacy function once all callers have been migrated.
-func (de *DuplexConversationExecutor) openTextSynthesisStreamForProvider(
 	ctx context.Context,
 	text string,
 	ttsProvider *config.Provider,
@@ -49,7 +27,7 @@ func (de *DuplexConversationExecutor) openTextSynthesisStreamForProvider(
 	if err != nil {
 		return nil, fmt.Errorf("get TTS service for provider %s: %w", ttsProvider.ID, err)
 	}
-	gen := selfplay.NewAudioContentGeneratorForProvider(nil, ttsService, ttsProvider)
+	gen := selfplay.NewAudioContentGenerator(nil, ttsService, ttsProvider)
 	return gen.SynthesizeTextStream(ctx, text)
 }
 

--- a/tools/arena/engine/duplex_tts_streaming.go
+++ b/tools/arena/engine/duplex_tts_streaming.go
@@ -32,6 +32,27 @@ func (de *DuplexConversationExecutor) openTextSynthesisStream(
 	return gen.SynthesizeTextStream(ctx, text)
 }
 
+// openTextSynthesisStreamForProvider returns the TTS stream for pre-known text
+// using the new provider-yaml path introduced in Task 3.1. It looks up the TTS
+// service from the registry's TTSRegistry using the loaded provider config
+// (capability=tts) and calls SynthesizeTextStream on an AudioContentGenerator
+// backed by that service.
+//
+// Parallel to openTextSynthesisStream (which takes a *config.TTSConfig). Phase 5
+// will remove the legacy function once all callers have been migrated.
+func (de *DuplexConversationExecutor) openTextSynthesisStreamForProvider(
+	ctx context.Context,
+	text string,
+	ttsProvider *config.Provider,
+) (*selfplay.AudioStreamResult, error) {
+	ttsService, err := de.selfPlayRegistry.GetTTSRegistry().GetForProvider(ttsProvider)
+	if err != nil {
+		return nil, fmt.Errorf("get TTS service for provider %s: %w", ttsProvider.ID, err)
+	}
+	gen := selfplay.NewAudioContentGeneratorForProvider(nil, ttsService, ttsProvider)
+	return gen.SynthesizeTextStream(ctx, text)
+}
+
 // turnAudioMirror is a temp file written incrementally as TTS chunks
 // flow through the executor. The streamed audio never lives in RAM as
 // a complete buffer — each chunk is written through to disk as soon as

--- a/tools/arena/engine/duplex_tts_streaming_test.go
+++ b/tools/arena/engine/duplex_tts_streaming_test.go
@@ -58,28 +58,7 @@ func TestTurnAudioMirror_WriteAfterFinalizeIsNoop(t *testing.T) {
 	assert.NoError(t, m.write([]byte("late")))
 }
 
-func TestOpenTextSynthesisStream_RegistryErrorPropagates(t *testing.T) {
-	// Empty registry → GetTextSynthesisGenerator returns an error
-	// because no providers are registered for "missing".
-	reg := selfplay.NewRegistryWithTTS(
-		nil,
-		map[string]string{},
-		map[string]*config.UserPersonaPack{},
-		[]config.SelfPlayRoleGroup{},
-		selfplay.NewTTSRegistry(),
-	)
-	de := &DuplexConversationExecutor{selfPlayRegistry: reg}
-
-	_, err := de.openTextSynthesisStream(
-		context.Background(),
-		"hello",
-		&config.TTSConfig{Provider: "missing", Voice: "v1"},
-	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "get audio generator")
-}
-
-func TestOpenTextSynthesisStreamForProvider_HappyPath(t *testing.T) {
+func TestOpenTextSynthesisStream_HappyPath(t *testing.T) {
 	// A provider with Type=mock and Capability=tts — GetForProvider will
 	// return the default MockTTSService (no audio files → empty stream).
 	p := &config.Provider{
@@ -97,14 +76,14 @@ func TestOpenTextSynthesisStreamForProvider_HappyPath(t *testing.T) {
 	)
 	de := &DuplexConversationExecutor{selfPlayRegistry: reg}
 
-	result, err := de.openTextSynthesisStreamForProvider(context.Background(), "hello", p)
+	result, err := de.openTextSynthesisStream(context.Background(), "hello", p)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotNil(t, result.Reader)
 	result.Reader.Close()
 }
 
-func TestOpenTextSynthesisStreamForProvider_WrongCapabilityErrors(t *testing.T) {
+func TestOpenTextSynthesisStream_WrongCapabilityErrors(t *testing.T) {
 	// A provider with non-TTS capability should be rejected by GetForProvider.
 	p := &config.Provider{
 		ID:         "llm-provider",
@@ -121,7 +100,7 @@ func TestOpenTextSynthesisStreamForProvider_WrongCapabilityErrors(t *testing.T) 
 	)
 	de := &DuplexConversationExecutor{selfPlayRegistry: reg}
 
-	_, err := de.openTextSynthesisStreamForProvider(context.Background(), "hello", p)
+	_, err := de.openTextSynthesisStream(context.Background(), "hello", p)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get TTS service for provider")
 }

--- a/tools/arena/engine/duplex_tts_streaming_test.go
+++ b/tools/arena/engine/duplex_tts_streaming_test.go
@@ -78,3 +78,50 @@ func TestOpenTextSynthesisStream_RegistryErrorPropagates(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get audio generator")
 }
+
+func TestOpenTextSynthesisStreamForProvider_HappyPath(t *testing.T) {
+	// A provider with Type=mock and Capability=tts — GetForProvider will
+	// return the default MockTTSService (no audio files → empty stream).
+	p := &config.Provider{
+		ID:         "mock-tts",
+		Type:       "mock",
+		Capability: config.CapabilityTTS,
+		Voice:      "v1",
+	}
+	reg := selfplay.NewRegistryWithTTS(
+		nil,
+		map[string]string{},
+		map[string]*config.UserPersonaPack{},
+		[]config.SelfPlayRoleGroup{},
+		selfplay.NewTTSRegistry(),
+	)
+	de := &DuplexConversationExecutor{selfPlayRegistry: reg}
+
+	result, err := de.openTextSynthesisStreamForProvider(context.Background(), "hello", p)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Reader)
+	result.Reader.Close()
+}
+
+func TestOpenTextSynthesisStreamForProvider_WrongCapabilityErrors(t *testing.T) {
+	// A provider with non-TTS capability should be rejected by GetForProvider.
+	p := &config.Provider{
+		ID:         "llm-provider",
+		Type:       "openai",
+		Capability: config.CapabilityLLM,
+		Voice:      "v1",
+	}
+	reg := selfplay.NewRegistryWithTTS(
+		nil,
+		map[string]string{},
+		map[string]*config.UserPersonaPack{},
+		[]config.SelfPlayRoleGroup{},
+		selfplay.NewTTSRegistry(),
+	)
+	de := &DuplexConversationExecutor{selfPlayRegistry: reg}
+
+	_, err := de.openTextSynthesisStreamForProvider(context.Background(), "hello", p)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get TTS service for provider")
+}

--- a/tools/arena/selfplay/audio_generator.go
+++ b/tools/arena/selfplay/audio_generator.go
@@ -77,10 +77,16 @@ type AudioStreamResult struct {
 // (scripted-text turns where no LLM is involved). In that case
 // NextUserTurnAudioStream returns an error; SynthesizeTextStream still
 // works.
+//
+// Either ttsConfig or ttsProvider is set, never both. ttsConfig is set by
+// the legacy NewAudioContentGenerator path; ttsProvider is set by the new
+// NewAudioContentGeneratorForProvider path introduced in Task 3.1. The
+// openStream method reads from whichever is non-nil.
 type AudioContentGenerator struct {
 	textGenerator *ContentGenerator
 	ttsService    base.TTSProvider
-	ttsConfig     *config.TTSConfig
+	ttsConfig     *config.TTSConfig // legacy path
+	ttsProvider   *config.Provider  // new provider-yaml path (Task 3.1+)
 }
 
 // NewAudioContentGenerator creates a new audio content generator.
@@ -108,26 +114,61 @@ func NewAudioContentGenerator(
 	}
 }
 
+// NewAudioContentGeneratorForProvider creates a new audio content generator
+// backed by a loaded TTS provider config (capability=tts). This is the new
+// Task 3.1+ path; the legacy NewAudioContentGenerator path (which takes a
+// *config.TTSConfig) remains for unmigrated callers.
+// textGenerator may be nil for TTS-only generators.
+func NewAudioContentGeneratorForProvider(
+	textGenerator *ContentGenerator,
+	ttsService base.TTSProvider,
+	ttsProvider *config.Provider,
+) *AudioContentGenerator {
+	if textGenerator != nil {
+		if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
+			textGenerator.WithProviderRubric(rp.PersonaRubric())
+		}
+	}
+	return &AudioContentGenerator{
+		textGenerator: textGenerator,
+		ttsService:    ttsService,
+		ttsProvider:   ttsProvider,
+	}
+}
+
 // Default TTS output sample rate (most TTS services output at 24kHz).
 const defaultTTSSampleRate = 24000
 
 // openStream opens a TTS stream for text and returns the streaming
 // reader along with format/rate metadata. The single place that
-// translates (text, ttsConfig) → (reader, sample rate).
+// translates (text, voice/sample_rate) → (reader, sample rate).
+// Reads voice and sample_rate from ttsProvider when set (new path),
+// otherwise falls back to ttsConfig (legacy path).
 func (g *AudioContentGenerator) openStream(ctx context.Context, text string) (*AudioStreamResult, error) {
+	var voice string
+	sampleRate := defaultTTSSampleRate
+
+	if g.ttsProvider != nil {
+		voice = g.ttsProvider.Voice
+		if g.ttsProvider.SampleRate > 0 {
+			sampleRate = g.ttsProvider.SampleRate
+		}
+	} else {
+		voice = g.ttsConfig.Voice
+		if g.ttsConfig.SampleRate > 0 {
+			sampleRate = g.ttsConfig.SampleRate
+		}
+	}
+
 	req := base.TTSRequest{
 		Text:   text,
-		Voice:  g.ttsConfig.Voice,
+		Voice:  voice,
 		Format: tts.FormatPCM16.Name,
 		Speed:  1.0,
 	}
 	stream, err := g.ttsService.SynthesizeTTS(ctx, req)
 	if err != nil {
 		return nil, err
-	}
-	sampleRate := defaultTTSSampleRate
-	if g.ttsConfig.SampleRate > 0 {
-		sampleRate = g.ttsConfig.SampleRate
 	}
 	return &AudioStreamResult{
 		Text:        text,

--- a/tools/arena/selfplay/audio_generator.go
+++ b/tools/arena/selfplay/audio_generator.go
@@ -73,53 +73,25 @@ type AudioStreamResult struct {
 
 // AudioContentGenerator wraps a ContentGenerator and adds TTS synthesis.
 //
-// textGenerator may be nil when constructed via GetTextSynthesisGenerator
-// (scripted-text turns where no LLM is involved). In that case
-// NextUserTurnAudioStream returns an error; SynthesizeTextStream still
-// works.
-//
-// Either ttsConfig or ttsProvider is set, never both. ttsConfig is set by
-// the legacy NewAudioContentGenerator path; ttsProvider is set by the new
-// NewAudioContentGeneratorForProvider path introduced in Task 3.1. The
-// openStream method reads from whichever is non-nil.
+// textGenerator may be nil when constructed for scripted-text turns where no
+// LLM is involved. In that case NextUserTurnAudioStream returns an error;
+// SynthesizeTextStream still works.
 type AudioContentGenerator struct {
 	textGenerator *ContentGenerator
 	ttsService    base.TTSProvider
-	ttsConfig     *config.TTSConfig // legacy path
-	ttsProvider   *config.Provider  // new provider-yaml path (Task 3.1+)
+	ttsProvider   *config.Provider
 }
 
-// NewAudioContentGenerator creates a new audio content generator.
+// NewAudioContentGenerator creates a new audio content generator backed by a
+// loaded TTS provider config (capability=tts).
 // textGenerator may be nil for TTS-only generators.
 //
 // When the TTS service exposes a PersonaRubric (see [tts.PersonaRubricProvider]),
 // it is forwarded to the underlying text generator so that personas opting in
 // via style.expressive get a provider-tuned rubric prepended to their system
-// prompt (issue #1130). Providers that do not implement the interface, or
-// implement it and return the empty string, are no-ops.
+// prompt. Providers that do not implement the interface, or implement it and
+// return the empty string, are no-ops.
 func NewAudioContentGenerator(
-	textGenerator *ContentGenerator,
-	ttsService base.TTSProvider,
-	ttsConfig *config.TTSConfig,
-) *AudioContentGenerator {
-	if textGenerator != nil {
-		if rp, ok := ttsService.(tts.PersonaRubricProvider); ok {
-			textGenerator.WithProviderRubric(rp.PersonaRubric())
-		}
-	}
-	return &AudioContentGenerator{
-		textGenerator: textGenerator,
-		ttsService:    ttsService,
-		ttsConfig:     ttsConfig,
-	}
-}
-
-// NewAudioContentGeneratorForProvider creates a new audio content generator
-// backed by a loaded TTS provider config (capability=tts). This is the new
-// Task 3.1+ path; the legacy NewAudioContentGenerator path (which takes a
-// *config.TTSConfig) remains for unmigrated callers.
-// textGenerator may be nil for TTS-only generators.
-func NewAudioContentGeneratorForProvider(
 	textGenerator *ContentGenerator,
 	ttsService base.TTSProvider,
 	ttsProvider *config.Provider,
@@ -142,8 +114,6 @@ const defaultTTSSampleRate = 24000
 // openStream opens a TTS stream for text and returns the streaming
 // reader along with format/rate metadata. The single place that
 // translates (text, voice/sample_rate) → (reader, sample rate).
-// Reads voice and sample_rate from ttsProvider when set (new path),
-// otherwise falls back to ttsConfig (legacy path).
 func (g *AudioContentGenerator) openStream(ctx context.Context, text string) (*AudioStreamResult, error) {
 	var voice string
 	sampleRate := defaultTTSSampleRate
@@ -152,11 +122,6 @@ func (g *AudioContentGenerator) openStream(ctx context.Context, text string) (*A
 		voice = g.ttsProvider.Voice
 		if g.ttsProvider.SampleRate > 0 {
 			sampleRate = g.ttsProvider.SampleRate
-		}
-	} else {
-		voice = g.ttsConfig.Voice
-		if g.ttsConfig.SampleRate > 0 {
-			sampleRate = g.ttsConfig.SampleRate
 		}
 	}
 

--- a/tools/arena/selfplay/audio_generator_test.go
+++ b/tools/arena/selfplay/audio_generator_test.go
@@ -88,6 +88,18 @@ func drainStream(t *testing.T, r io.ReadCloser) []byte {
 	return data
 }
 
+// newTestTTSProvider returns a minimal *config.Provider suitable for
+// constructing an AudioContentGenerator in tests.
+func newTestTTSProvider(voice string, sampleRate int) *config.Provider {
+	return &config.Provider{
+		ID:         "tts-test",
+		Type:       TTSProviderMock,
+		Capability: config.CapabilityTTS,
+		Voice:      voice,
+		SampleRate: sampleRate,
+	}
+}
+
 func TestAudioContentGenerator_NextUserTurnAudioStream(t *testing.T) {
 	mockProv := &mockProvider{response: "Hello, how can I help?"}
 
@@ -104,8 +116,8 @@ func TestAudioContentGenerator_NextUserTurnAudioStream(t *testing.T) {
 	mockTTS := &mockTTSServiceWithData{
 		audioData: []byte("fake-audio-data"),
 	}
-	ttsConfig := &config.TTSConfig{Provider: "mock", Voice: "test-voice"}
-	audioGen := NewAudioContentGenerator(textGen, mockTTS, ttsConfig)
+	ttsProvider := newTestTTSProvider("test-voice", 0)
+	audioGen := NewAudioContentGenerator(textGen, mockTTS, ttsProvider)
 
 	stream, err := audioGen.NextUserTurnAudioStream(
 		context.Background(),
@@ -136,8 +148,8 @@ func TestAudioContentGenerator_TTSError(t *testing.T) {
 	mockTTS := &mockTTSServiceWithData{
 		err: errors.New("TTS service unavailable"),
 	}
-	ttsConfig := &config.TTSConfig{Provider: "mock", Voice: "test-voice"}
-	audioGen := NewAudioContentGenerator(textGen, mockTTS, ttsConfig)
+	ttsProvider := newTestTTSProvider("test-voice", 0)
+	audioGen := NewAudioContentGenerator(textGen, mockTTS, ttsProvider)
 
 	_, err := audioGen.NextUserTurnAudioStream(
 		context.Background(),
@@ -162,8 +174,8 @@ func TestAudioContentGenerator_TextGenerationError(t *testing.T) {
 	textGen := NewContentGenerator(mockProv, persona)
 
 	mockTTS := &mockTTSServiceWithData{audioData: []byte("audio")}
-	ttsConfig := &config.TTSConfig{Provider: "mock", Voice: "test"}
-	audioGen := NewAudioContentGenerator(textGen, mockTTS, ttsConfig)
+	ttsProvider := newTestTTSProvider("test", 0)
+	audioGen := NewAudioContentGenerator(textGen, mockTTS, ttsProvider)
 
 	_, err := audioGen.NextUserTurnAudioStream(
 		context.Background(),
@@ -188,8 +200,8 @@ func TestAudioContentGenerator_EmptyTextResponse(t *testing.T) {
 	textGen := NewContentGenerator(mockProv, persona)
 
 	mockTTS := &mockTTSServiceWithData{audioData: []byte("audio")}
-	ttsConfig := &config.TTSConfig{Provider: "mock", Voice: "test"}
-	audioGen := NewAudioContentGenerator(textGen, mockTTS, ttsConfig)
+	ttsProvider := newTestTTSProvider("test", 0)
+	audioGen := NewAudioContentGenerator(textGen, mockTTS, ttsProvider)
 
 	_, err := audioGen.NextUserTurnAudioStream(
 		context.Background(),
@@ -207,8 +219,8 @@ func TestAudioContentGenerator_EmptyTextResponse(t *testing.T) {
 
 func TestAudioContentGenerator_SynthesizeTextStream(t *testing.T) {
 	mockTTS := &mockTTSServiceWithData{audioData: []byte("scripted-audio")}
-	ttsConfig := &config.TTSConfig{Provider: "mock", Voice: "test"}
-	audioGen := NewAudioContentGenerator(nil, mockTTS, ttsConfig)
+	ttsProvider := newTestTTSProvider("test", 0)
+	audioGen := NewAudioContentGenerator(nil, mockTTS, ttsProvider)
 
 	stream, err := audioGen.SynthesizeTextStream(context.Background(), "hello world")
 	if err != nil {
@@ -225,7 +237,8 @@ func TestAudioContentGenerator_SynthesizeTextStream(t *testing.T) {
 
 func TestAudioContentGenerator_GetTTSService(t *testing.T) {
 	mockTTS := &mockTTSServiceWithData{}
-	audioGen := NewAudioContentGenerator(nil, mockTTS, &config.TTSConfig{})
+	ttsProvider := newTestTTSProvider("", 0)
+	audioGen := NewAudioContentGenerator(nil, mockTTS, ttsProvider)
 
 	svc := audioGen.GetTTSService()
 	if svc != mockTTS {
@@ -235,7 +248,8 @@ func TestAudioContentGenerator_GetTTSService(t *testing.T) {
 
 func TestAudioContentGenerator_GetTextGenerator(t *testing.T) {
 	textGen := &ContentGenerator{}
-	audioGen := NewAudioContentGenerator(textGen, nil, &config.TTSConfig{})
+	ttsProvider := newTestTTSProvider("", 0)
+	audioGen := NewAudioContentGenerator(textGen, nil, ttsProvider)
 
 	gen := audioGen.GetTextGenerator()
 	if gen != textGen {
@@ -243,9 +257,9 @@ func TestAudioContentGenerator_GetTextGenerator(t *testing.T) {
 	}
 }
 
-// TestNewAudioContentGeneratorForProvider_SynthesizeTextStream verifies that the
-// provider-path constructor wires voice and sample_rate from the *config.Provider.
-func TestNewAudioContentGeneratorForProvider_SynthesizeTextStream(t *testing.T) {
+// TestAudioContentGenerator_SynthesizeTextStream_WithProvider verifies that the
+// constructor wires voice and sample_rate from the *config.Provider.
+func TestAudioContentGenerator_SynthesizeTextStream_WithProvider(t *testing.T) {
 	mockTTS := &mockTTSServiceWithData{audioData: []byte("provider-path-audio")}
 	p := &config.Provider{
 		ID:         "tts-test",
@@ -254,7 +268,7 @@ func TestNewAudioContentGeneratorForProvider_SynthesizeTextStream(t *testing.T) 
 		Voice:      "test-voice",
 		SampleRate: 16000,
 	}
-	audioGen := NewAudioContentGeneratorForProvider(nil, mockTTS, p)
+	audioGen := NewAudioContentGenerator(nil, mockTTS, p)
 
 	stream, err := audioGen.SynthesizeTextStream(context.Background(), "hello from provider path")
 	if err != nil {
@@ -269,9 +283,9 @@ func TestNewAudioContentGeneratorForProvider_SynthesizeTextStream(t *testing.T) 
 	}
 }
 
-// TestNewAudioContentGeneratorForProvider_NextUserTurnAudioStream verifies the
-// full text-generation + TTS synthesis path through the provider-path constructor.
-func TestNewAudioContentGeneratorForProvider_NextUserTurnAudioStream(t *testing.T) {
+// TestAudioContentGenerator_NextUserTurnAudioStream_WithProvider verifies the
+// full text-generation + TTS synthesis path.
+func TestAudioContentGenerator_NextUserTurnAudioStream_WithProvider(t *testing.T) {
 	mockProv := &mockProvider{response: "response from provider path"}
 	defaultTemp := config.DefaultPersonaTemperature
 	persona := &config.UserPersonaPack{
@@ -291,7 +305,7 @@ func TestNewAudioContentGeneratorForProvider_NextUserTurnAudioStream(t *testing.
 		Voice:      "nova",
 		SampleRate: 24000,
 	}
-	audioGen := NewAudioContentGeneratorForProvider(textGen, mockTTS, p)
+	audioGen := NewAudioContentGenerator(textGen, mockTTS, p)
 
 	stream, err := audioGen.NextUserTurnAudioStream(
 		context.Background(),
@@ -311,9 +325,9 @@ func TestNewAudioContentGeneratorForProvider_NextUserTurnAudioStream(t *testing.
 	}
 }
 
-// TestNewAudioContentGeneratorForProvider_DefaultSampleRate verifies that a
-// provider with SampleRate == 0 falls back to the default 24 kHz value.
-func TestNewAudioContentGeneratorForProvider_DefaultSampleRate(t *testing.T) {
+// TestAudioContentGenerator_DefaultSampleRate verifies that a provider with
+// SampleRate == 0 falls back to the default 24 kHz value.
+func TestAudioContentGenerator_DefaultSampleRate(t *testing.T) {
 	mockTTS := &mockTTSServiceWithData{audioData: []byte("audio")}
 	p := &config.Provider{
 		ID:         "tts-no-rate",
@@ -321,7 +335,7 @@ func TestNewAudioContentGeneratorForProvider_DefaultSampleRate(t *testing.T) {
 		Capability: config.CapabilityTTS,
 		// SampleRate deliberately omitted — should use defaultTTSSampleRate
 	}
-	audioGen := NewAudioContentGeneratorForProvider(nil, mockTTS, p)
+	audioGen := NewAudioContentGenerator(nil, mockTTS, p)
 
 	stream, err := audioGen.SynthesizeTextStream(context.Background(), "test")
 	if err != nil {

--- a/tools/arena/selfplay/audio_generator_test.go
+++ b/tools/arena/selfplay/audio_generator_test.go
@@ -242,3 +242,93 @@ func TestAudioContentGenerator_GetTextGenerator(t *testing.T) {
 		t.Error("GetTextGenerator() returned wrong generator")
 	}
 }
+
+// TestNewAudioContentGeneratorForProvider_SynthesizeTextStream verifies that the
+// provider-path constructor wires voice and sample_rate from the *config.Provider.
+func TestNewAudioContentGeneratorForProvider_SynthesizeTextStream(t *testing.T) {
+	mockTTS := &mockTTSServiceWithData{audioData: []byte("provider-path-audio")}
+	p := &config.Provider{
+		ID:         "tts-test",
+		Type:       TTSProviderMock,
+		Capability: config.CapabilityTTS,
+		Voice:      "test-voice",
+		SampleRate: 16000,
+	}
+	audioGen := NewAudioContentGeneratorForProvider(nil, mockTTS, p)
+
+	stream, err := audioGen.SynthesizeTextStream(context.Background(), "hello from provider path")
+	if err != nil {
+		t.Fatalf("SynthesizeTextStream() error = %v", err)
+	}
+	got := drainStream(t, stream.Reader)
+	if string(got) != "provider-path-audio" {
+		t.Errorf("audio = %q, want %q", got, "provider-path-audio")
+	}
+	if stream.SampleRate != 16000 {
+		t.Errorf("SampleRate = %d, want 16000", stream.SampleRate)
+	}
+}
+
+// TestNewAudioContentGeneratorForProvider_NextUserTurnAudioStream verifies the
+// full text-generation + TTS synthesis path through the provider-path constructor.
+func TestNewAudioContentGeneratorForProvider_NextUserTurnAudioStream(t *testing.T) {
+	mockProv := &mockProvider{response: "response from provider path"}
+	defaultTemp := config.DefaultPersonaTemperature
+	persona := &config.UserPersonaPack{
+		ID: "persona-provider-path",
+		Defaults: config.PersonaDefaults{
+			Temperature: &defaultTemp,
+		},
+		SystemPrompt: "You are helpful",
+	}
+	textGen := NewContentGenerator(mockProv, persona)
+
+	mockTTS := &mockTTSServiceWithData{audioData: []byte("synthesized")}
+	p := &config.Provider{
+		ID:         "tts-provider",
+		Type:       TTSProviderMock,
+		Capability: config.CapabilityTTS,
+		Voice:      "nova",
+		SampleRate: 24000,
+	}
+	audioGen := NewAudioContentGeneratorForProvider(textGen, mockTTS, p)
+
+	stream, err := audioGen.NextUserTurnAudioStream(
+		context.Background(),
+		[]types.Message{},
+		"test-scenario",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NextUserTurnAudioStream() error = %v", err)
+	}
+	if stream.TextResult == nil {
+		t.Error("expected TextResult to be set")
+	}
+	got := drainStream(t, stream.Reader)
+	if string(got) != "synthesized" {
+		t.Errorf("audio = %q, want %q", got, "synthesized")
+	}
+}
+
+// TestNewAudioContentGeneratorForProvider_DefaultSampleRate verifies that a
+// provider with SampleRate == 0 falls back to the default 24 kHz value.
+func TestNewAudioContentGeneratorForProvider_DefaultSampleRate(t *testing.T) {
+	mockTTS := &mockTTSServiceWithData{audioData: []byte("audio")}
+	p := &config.Provider{
+		ID:         "tts-no-rate",
+		Type:       TTSProviderMock,
+		Capability: config.CapabilityTTS,
+		// SampleRate deliberately omitted — should use defaultTTSSampleRate
+	}
+	audioGen := NewAudioContentGeneratorForProvider(nil, mockTTS, p)
+
+	stream, err := audioGen.SynthesizeTextStream(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("SynthesizeTextStream() error = %v", err)
+	}
+	drainStream(t, stream.Reader)
+	if stream.SampleRate != defaultTTSSampleRate {
+		t.Errorf("SampleRate = %d, want %d", stream.SampleRate, defaultTTSSampleRate)
+	}
+}

--- a/tools/arena/selfplay/interfaces.go
+++ b/tools/arena/selfplay/interfaces.go
@@ -20,14 +20,9 @@ type Provider interface {
 type AudioProvider interface {
 	Provider
 
-	// GetAudioContentGenerator returns an audio generator for the given role and persona.
-	// The TTS config specifies the voice and provider for text-to-speech synthesis.
-	GetAudioContentGenerator(role, personaID string, ttsConfig *config.TTSConfig) (AudioGenerator, error)
-
-	// GetAudioContentGeneratorForProvider returns an AudioGenerator backed
-	// by a loaded TTS provider config (capability=tts). Replaces
-	// GetAudioContentGenerator which took a *config.TTSConfig.
-	GetAudioContentGeneratorForProvider(role, personaID string, ttsProvider *config.Provider) (AudioGenerator, error)
+	// GetAudioContentGenerator returns an AudioGenerator backed by a loaded TTS
+	// provider config (capability=tts).
+	GetAudioContentGenerator(role, personaID string, ttsProvider *config.Provider) (AudioGenerator, error)
 }
 
 // Generator generates user messages for self-play scenarios.

--- a/tools/arena/selfplay/interfaces.go
+++ b/tools/arena/selfplay/interfaces.go
@@ -23,6 +23,11 @@ type AudioProvider interface {
 	// GetAudioContentGenerator returns an audio generator for the given role and persona.
 	// The TTS config specifies the voice and provider for text-to-speech synthesis.
 	GetAudioContentGenerator(role, personaID string, ttsConfig *config.TTSConfig) (AudioGenerator, error)
+
+	// GetAudioContentGeneratorForProvider returns an AudioGenerator backed
+	// by a loaded TTS provider config (capability=tts). Replaces
+	// GetAudioContentGenerator which took a *config.TTSConfig.
+	GetAudioContentGeneratorForProvider(role, personaID string, ttsProvider *config.Provider) (AudioGenerator, error)
 }
 
 // Generator generates user messages for self-play scenarios.

--- a/tools/arena/selfplay/registry.go
+++ b/tools/arena/selfplay/registry.go
@@ -152,6 +152,38 @@ func (r *Registry) GetAudioContentGenerator(
 	return NewAudioContentGenerator(textGen, ttsService, ttsConfig), nil
 }
 
+// GetAudioContentGeneratorForProvider implements AudioProvider interface.
+// Returns an AudioGenerator backed by a loaded TTS provider config
+// (capability=tts). Replaces GetAudioContentGenerator which took a
+// *config.TTSConfig assembled per-turn from scenario/turn/defaults.
+//
+// Unlike GetContentGenerator, audio generators are not cached since the
+// provider config may vary across roles.
+func (r *Registry) GetAudioContentGeneratorForProvider(
+	role, personaID string,
+	ttsProvider *config.Provider,
+) (AudioGenerator, error) {
+	if ttsProvider == nil {
+		return nil, fmt.Errorf("TTS provider is required for audio generation")
+	}
+	if ttsProvider.GetCapability() != config.CapabilityTTS {
+		return nil, fmt.Errorf("provider %s has capability %q, expected tts",
+			ttsProvider.ID, ttsProvider.GetCapability())
+	}
+
+	textGen, err := r.createContentGenerator(role, personaID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create text generator: %w", err)
+	}
+
+	ttsService, err := r.ttsRegistry.GetForProvider(ttsProvider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get TTS service: %w", err)
+	}
+
+	return NewAudioContentGeneratorForProvider(textGen, ttsService, ttsProvider), nil
+}
+
 // GetTextSynthesisGenerator returns an AudioGenerator that only knows
 // how to synthesize pre-known text — used by scripted-text duplex turns
 // where the text comes from the scenario YAML rather than a persona

--- a/tools/arena/selfplay/registry.go
+++ b/tools/arena/selfplay/registry.go
@@ -123,43 +123,12 @@ func (r *Registry) GetContentGenerator(role, personaID string) (Generator, error
 }
 
 // GetAudioContentGenerator implements AudioProvider interface.
-// Returns an AudioGenerator for the given role, persona, and TTS configuration.
-// The returned generator supports both NextUserTurnAudioStream (which
-// drives the persona LLM for selfplay turns) and SynthesizeTextStream.
-//
-// Unlike GetContentGenerator, audio generators are not cached since TTS config may vary.
-func (r *Registry) GetAudioContentGenerator(
-	role, personaID string,
-	ttsConfig *config.TTSConfig,
-) (AudioGenerator, error) {
-	if ttsConfig == nil {
-		return nil, fmt.Errorf("TTS configuration is required for audio generation")
-	}
-	if err := ttsConfig.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid TTS configuration: %w", err)
-	}
-
-	textGen, err := r.createContentGenerator(role, personaID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create text generator: %w", err)
-	}
-
-	ttsService, err := r.ttsRegistry.GetWithConfig(ttsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get TTS service: %w", err)
-	}
-
-	return NewAudioContentGenerator(textGen, ttsService, ttsConfig), nil
-}
-
-// GetAudioContentGeneratorForProvider implements AudioProvider interface.
 // Returns an AudioGenerator backed by a loaded TTS provider config
-// (capability=tts). Replaces GetAudioContentGenerator which took a
-// *config.TTSConfig assembled per-turn from scenario/turn/defaults.
+// (capability=tts).
 //
 // Unlike GetContentGenerator, audio generators are not cached since the
 // provider config may vary across roles.
-func (r *Registry) GetAudioContentGeneratorForProvider(
+func (r *Registry) GetAudioContentGenerator(
 	role, personaID string,
 	ttsProvider *config.Provider,
 ) (AudioGenerator, error) {
@@ -181,32 +150,7 @@ func (r *Registry) GetAudioContentGeneratorForProvider(
 		return nil, fmt.Errorf("failed to get TTS service: %w", err)
 	}
 
-	return NewAudioContentGeneratorForProvider(textGen, ttsService, ttsProvider), nil
-}
-
-// GetTextSynthesisGenerator returns an AudioGenerator that only knows
-// how to synthesize pre-known text — used by scripted-text duplex turns
-// where the text comes from the scenario YAML rather than a persona
-// LLM. Calling NextUserTurnAudioStream on the returned generator
-// errors because no role/persona was supplied.
-//
-// This sits alongside GetAudioContentGenerator as a sibling so the arena
-// has a single seam for "give me an AudioGenerator suited for this turn",
-// regardless of whether the turn is selfplay or scripted-text.
-func (r *Registry) GetTextSynthesisGenerator(ttsConfig *config.TTSConfig) (AudioGenerator, error) {
-	if ttsConfig == nil {
-		return nil, fmt.Errorf("TTS configuration is required for audio generation")
-	}
-	if err := ttsConfig.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid TTS configuration: %w", err)
-	}
-
-	ttsService, err := r.ttsRegistry.GetWithConfig(ttsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get TTS service: %w", err)
-	}
-
-	return NewAudioContentGenerator(nil, ttsService, ttsConfig), nil
+	return NewAudioContentGenerator(textGen, ttsService, ttsProvider), nil
 }
 
 // GetTTSRegistry returns the TTS registry for direct access if needed.

--- a/tools/arena/selfplay/registry_test.go
+++ b/tools/arena/selfplay/registry_test.go
@@ -1020,3 +1020,54 @@ func TestNewRegistryWithTTS_NilTTSRegistry(t *testing.T) {
 		t.Error("Expected TTS registry to be initialized even with nil input")
 	}
 }
+
+func TestSelfPlayRegistry_GetAudioContentGeneratorForProvider_Success(t *testing.T) {
+	providerRegistry := providers.NewRegistry()
+	provider := createMockProvider("provider1")
+	providerRegistry.Register(provider)
+
+	personas := map[string]*config.UserPersonaPack{
+		"persona1": createTestPersona("persona1", "You are helpful"),
+	}
+	roles := []config.SelfPlayRoleGroup{{ID: "user"}}
+	providerMap := map[string]string{"user": "provider1"}
+
+	ttsRegistry := NewTTSRegistry()
+	ttsRegistry.Register(TTSProviderMock, &mockTTSService{name: TTSProviderMock})
+
+	registry := NewRegistryWithTTS(providerRegistry, providerMap, personas, roles, ttsRegistry)
+
+	ttsProvider := &config.Provider{
+		ID:         "mock-tts",
+		Type:       TTSProviderMock,
+		Capability: config.CapabilityTTS,
+		Voice:      "test-voice",
+	}
+
+	audioGen, err := registry.GetAudioContentGeneratorForProvider("user", "persona1", ttsProvider)
+	if err != nil {
+		t.Fatalf("GetAudioContentGeneratorForProvider() error = %v", err)
+	}
+	if audioGen == nil {
+		t.Error("expected non-nil audio generator")
+	}
+}
+
+func TestSelfPlayRegistry_GetAudioContentGeneratorForProvider_NilProvider(t *testing.T) {
+	registry := NewRegistry(providers.NewRegistry(), nil, nil, nil)
+
+	_, err := registry.GetAudioContentGeneratorForProvider("user", "persona1", nil)
+	if err == nil {
+		t.Fatal("expected error for nil TTS provider")
+	}
+}
+
+func TestSelfPlayRegistry_GetAudioContentGeneratorForProvider_WrongCapability(t *testing.T) {
+	registry := NewRegistry(providers.NewRegistry(), nil, nil, nil)
+
+	llmProvider := &config.Provider{ID: "llm", Type: "openai", Capability: config.CapabilityLLM}
+	_, err := registry.GetAudioContentGeneratorForProvider("user", "persona1", llmProvider)
+	if err == nil {
+		t.Fatal("expected error: provider capability is llm, not tts")
+	}
+}

--- a/tools/arena/selfplay/registry_test.go
+++ b/tools/arena/selfplay/registry_test.go
@@ -911,97 +911,6 @@ func TestSelfPlayRegistry_GetCacheStats_CachedPairs(t *testing.T) {
 	}
 }
 
-func TestSelfPlayRegistry_GetAudioContentGenerator_Success(t *testing.T) {
-	providerRegistry := providers.NewRegistry()
-	provider := createMockProvider("provider1")
-	providerRegistry.Register(provider)
-
-	personas := map[string]*config.UserPersonaPack{
-		"persona1": createTestPersona("persona1", "You are helpful"),
-	}
-
-	roles := []config.SelfPlayRoleGroup{
-		{ID: "user"},
-	}
-
-	providerMap := map[string]string{
-		"user": "provider1",
-	}
-
-	// Create registry with custom TTS registry
-	ttsRegistry := NewTTSRegistry()
-	ttsRegistry.Register("openai", &mockTTSService{name: "mock-openai"})
-
-	registry := NewRegistryWithTTS(providerRegistry, providerMap, personas, roles, ttsRegistry)
-
-	ttsConfig := &config.TTSConfig{
-		Provider: "openai",
-		Voice:    "alloy",
-	}
-
-	audioGen, err := registry.GetAudioContentGenerator("user", "persona1", ttsConfig)
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
-
-	if audioGen == nil {
-		t.Error("Expected audio generator to be created")
-	}
-}
-
-func TestSelfPlayRegistry_GetAudioContentGenerator_NilTTSConfig(t *testing.T) {
-	registry := NewRegistry(providers.NewRegistry(), nil, nil, nil)
-
-	_, err := registry.GetAudioContentGenerator("user", "persona1", nil)
-	if err == nil {
-		t.Error("Expected error for nil TTS config")
-	}
-}
-
-func TestSelfPlayRegistry_GetAudioContentGenerator_InvalidTTSConfig(t *testing.T) {
-	registry := NewRegistry(providers.NewRegistry(), nil, nil, nil)
-
-	ttsConfig := &config.TTSConfig{
-		Provider: "", // Missing provider
-		Voice:    "alloy",
-	}
-
-	_, err := registry.GetAudioContentGenerator("user", "persona1", ttsConfig)
-	if err == nil {
-		t.Error("Expected error for invalid TTS config")
-	}
-}
-
-func TestSelfPlayRegistry_GetAudioContentGenerator_TTSProviderNotFound(t *testing.T) {
-	providerRegistry := providers.NewRegistry()
-	provider := createMockProvider("provider1")
-	providerRegistry.Register(provider)
-
-	personas := map[string]*config.UserPersonaPack{
-		"persona1": createTestPersona("persona1", "You are helpful"),
-	}
-
-	roles := []config.SelfPlayRoleGroup{
-		{ID: "user"},
-	}
-
-	providerMap := map[string]string{
-		"user": "provider1",
-	}
-
-	registry := NewRegistry(providerRegistry, providerMap, personas, roles)
-
-	ttsConfig := &config.TTSConfig{
-		Provider: "nonexistent",
-		Voice:    "alloy",
-	}
-
-	_, err := registry.GetAudioContentGenerator("user", "persona1", ttsConfig)
-	if err == nil {
-		t.Error("Expected error for nonexistent TTS provider")
-	}
-}
-
 func TestSelfPlayRegistry_GetTTSRegistry(t *testing.T) {
 	registry := NewRegistry(providers.NewRegistry(), nil, nil, nil)
 
@@ -1021,7 +930,7 @@ func TestNewRegistryWithTTS_NilTTSRegistry(t *testing.T) {
 	}
 }
 
-func TestSelfPlayRegistry_GetAudioContentGeneratorForProvider_Success(t *testing.T) {
+func TestSelfPlayRegistry_GetAudioContentGenerator_Success(t *testing.T) {
 	providerRegistry := providers.NewRegistry()
 	provider := createMockProvider("provider1")
 	providerRegistry.Register(provider)
@@ -1044,29 +953,29 @@ func TestSelfPlayRegistry_GetAudioContentGeneratorForProvider_Success(t *testing
 		Voice:      "test-voice",
 	}
 
-	audioGen, err := registry.GetAudioContentGeneratorForProvider("user", "persona1", ttsProvider)
+	audioGen, err := registry.GetAudioContentGenerator("user", "persona1", ttsProvider)
 	if err != nil {
-		t.Fatalf("GetAudioContentGeneratorForProvider() error = %v", err)
+		t.Fatalf("GetAudioContentGenerator() error = %v", err)
 	}
 	if audioGen == nil {
 		t.Error("expected non-nil audio generator")
 	}
 }
 
-func TestSelfPlayRegistry_GetAudioContentGeneratorForProvider_NilProvider(t *testing.T) {
+func TestSelfPlayRegistry_GetAudioContentGenerator_NilProvider(t *testing.T) {
 	registry := NewRegistry(providers.NewRegistry(), nil, nil, nil)
 
-	_, err := registry.GetAudioContentGeneratorForProvider("user", "persona1", nil)
+	_, err := registry.GetAudioContentGenerator("user", "persona1", nil)
 	if err == nil {
 		t.Fatal("expected error for nil TTS provider")
 	}
 }
 
-func TestSelfPlayRegistry_GetAudioContentGeneratorForProvider_WrongCapability(t *testing.T) {
+func TestSelfPlayRegistry_GetAudioContentGenerator_WrongCapability(t *testing.T) {
 	registry := NewRegistry(providers.NewRegistry(), nil, nil, nil)
 
 	llmProvider := &config.Provider{ID: "llm", Type: "openai", Capability: config.CapabilityLLM}
-	_, err := registry.GetAudioContentGeneratorForProvider("user", "persona1", llmProvider)
+	_, err := registry.GetAudioContentGenerator("user", "persona1", llmProvider)
 	if err == nil {
 		t.Fatal("expected error: provider capability is llm, not tts")
 	}

--- a/tools/arena/selfplay/tts_registry.go
+++ b/tools/arena/selfplay/tts_registry.go
@@ -108,6 +108,56 @@ func wrapWithDiskCache(provider string, svc base.TTSProvider) base.TTSProvider {
 	return wrapped.(base.TTSProvider)
 }
 
+// GetForProvider returns a base.TTSProvider configured from a loaded TTS
+// provider yaml. Replaces the legacy GetWithConfig path which took a
+// *config.TTSConfig assembled per-turn from scenario/turn/defaults.
+// Provider routing is by Type (cartesia/elevenlabs/openai/mock); the
+// voice/sample_rate/audio_files/model fields on the provider populate
+// the synthesis config.
+//
+// Validates that the provider has Capability == "tts" — guards against
+// callers passing an LLM provider by mistake.
+func (r *TTSRegistry) GetForProvider(p *config.Provider) (base.TTSProvider, error) {
+	if p == nil {
+		return nil, fmt.Errorf("nil TTS provider")
+	}
+	if p.GetCapability() != config.CapabilityTTS {
+		return nil, fmt.Errorf("provider %s has capability %q, expected tts",
+			p.ID, p.GetCapability())
+	}
+
+	// For mock provider with audio files, cache by file-list identity
+	// so concurrent runs share one MockTTSService and rotation works.
+	if p.Type == TTSProviderMock && len(p.AudioFiles) > 0 {
+		key := strings.Join(p.AudioFiles, "|")
+		r.mu.RLock()
+		if svc, exists := r.mockByFiles[key]; exists {
+			r.mu.RUnlock()
+			return svc, nil
+		}
+		r.mu.RUnlock()
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if svc, exists := r.mockByFiles[key]; exists {
+			return svc, nil
+		}
+		svc := NewMockTTSWithFiles(p.AudioFiles)
+		r.mockByFiles[key] = svc
+		return svc, nil
+	}
+
+	// Real-vendor TTS: pin model if set on the provider yaml.
+	if p.Model != "" {
+		svc, err := r.createServiceWithModel(p.Type, p.Model)
+		if err != nil {
+			return nil, err
+		}
+		return wrapWithDiskCache(p.Type, svc), nil
+	}
+
+	return r.Get(p.Type)
+}
+
 // GetWithConfig returns a TTS provider configured with the given TTSConfig.
 // For mock provider, this allows specifying audio files directly in the config.
 // Providers with custom configs are NOT cached since audio files may vary per scenario.

--- a/tools/arena/selfplay/tts_registry.go
+++ b/tools/arena/selfplay/tts_registry.go
@@ -49,7 +49,6 @@ func NewTTSRegistry() *TTSRegistry {
 
 // Get returns a TTS provider for the given provider name.
 // Providers are lazily initialized on first request and cached.
-// For mock provider with custom audio files, use GetWithConfig instead.
 //
 // When the TTS_CACHE_DIR environment variable is set, the returned
 // provider is wrapped in a CachedTTSService rooted at that directory so
@@ -109,10 +108,8 @@ func wrapWithDiskCache(provider string, svc base.TTSProvider) base.TTSProvider {
 }
 
 // GetForProvider returns a base.TTSProvider configured from a loaded TTS
-// provider yaml. Replaces the legacy GetWithConfig path which took a
-// *config.TTSConfig assembled per-turn from scenario/turn/defaults.
-// Provider routing is by Type (cartesia/elevenlabs/openai/mock); the
-// voice/sample_rate/audio_files/model fields on the provider populate
+// provider yaml. Provider routing is by Type (cartesia/elevenlabs/openai/mock);
+// the voice/sample_rate/audio_files/model fields on the provider populate
 // the synthesis config.
 //
 // Validates that the provider has Capability == "tts" — guards against
@@ -158,53 +155,6 @@ func (r *TTSRegistry) GetForProvider(p *config.Provider) (base.TTSProvider, erro
 	return r.Get(p.Type)
 }
 
-// GetWithConfig returns a TTS provider configured with the given TTSConfig.
-// For mock provider, this allows specifying audio files directly in the config.
-// Providers with custom configs are NOT cached since audio files may vary per scenario.
-func (r *TTSRegistry) GetWithConfig(cfg *config.TTSConfig) (base.TTSProvider, error) {
-	if cfg == nil {
-		return nil, fmt.Errorf("TTS config is required")
-	}
-
-	// For mock provider with audio files, cache by the file-list identity so
-	// repeated calls with the same set of files reuse one MockTTSService — that
-	// preserves currentFileIndex across calls and lets rotation work.
-	if cfg.Provider == TTSProviderMock && len(cfg.AudioFiles) > 0 {
-		key := strings.Join(cfg.AudioFiles, "|")
-
-		r.mu.RLock()
-		if svc, exists := r.mockByFiles[key]; exists {
-			r.mu.RUnlock()
-			return svc, nil
-		}
-		r.mu.RUnlock()
-
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		if svc, exists := r.mockByFiles[key]; exists {
-			return svc, nil
-		}
-		svc := NewMockTTSWithFiles(cfg.AudioFiles)
-		r.mockByFiles[key] = svc
-		return svc, nil
-	}
-
-	// When the scenario pins a model, instantiate the provider directly
-	// and skip the per-provider singleton cache — different scenarios may
-	// pick different models (e.g. tts-1 for cheap takes, gpt-4o-mini-tts
-	// for expressive takes) and must not share one service.
-	if cfg.Model != "" {
-		svc, err := r.createServiceWithModel(cfg.Provider, cfg.Model)
-		if err != nil {
-			return nil, err
-		}
-		return wrapWithDiskCache(cfg.Provider, svc), nil
-	}
-
-	// For all other cases, use the standard cached lookup
-	return r.Get(cfg.Provider)
-}
-
 // Register adds a pre-configured TTS provider to the registry.
 // This is useful for testing or when using custom configurations.
 func (r *TTSRegistry) Register(provider string, svc base.TTSProvider) {
@@ -220,8 +170,8 @@ func (r *TTSRegistry) createService(provider string) (base.TTSProvider, error) {
 }
 
 // createServiceWithModel creates a new TTS provider, optionally pinning a
-// specific model. Empty model = adapter default. Used by GetWithConfig
-// when a scenario / role pins a model via TTSConfig.Model.
+// specific model. Empty model = adapter default. Used by GetForProvider
+// when a provider yaml pins a specific model.
 func (r *TTSRegistry) createServiceWithModel(provider, model string) (base.TTSProvider, error) {
 	switch provider {
 	case TTSProviderOpenAI:

--- a/tools/arena/selfplay/tts_registry_test.go
+++ b/tools/arena/selfplay/tts_registry_test.go
@@ -307,6 +307,38 @@ func TestTTSRegistry_Get_MockProvider(t *testing.T) {
 	}
 }
 
+func TestTTSRegistry_GetForProvider_Mock(t *testing.T) {
+	p := &config.Provider{
+		ID:         "mock-tts",
+		Type:       TTSProviderMock,
+		Capability: config.CapabilityTTS,
+		AudioFiles: []string{"a.pcm", "b.pcm"},
+	}
+	r := NewTTSRegistry()
+	svc, err := r.GetForProvider(p)
+	if err != nil {
+		t.Fatalf("GetForProvider: %v", err)
+	}
+	if svc.Name() != TTSProviderMock {
+		t.Fatalf("expected mock service, got %q", svc.Name())
+	}
+}
+
+func TestTTSRegistry_GetForProvider_RejectsLLMCapability(t *testing.T) {
+	p := &config.Provider{ID: "llm", Type: "openai", Capability: config.CapabilityLLM}
+	r := NewTTSRegistry()
+	if _, err := r.GetForProvider(p); err == nil {
+		t.Fatal("expected error: capability is llm, not tts")
+	}
+}
+
+func TestTTSRegistry_GetForProvider_NilProvider(t *testing.T) {
+	r := NewTTSRegistry()
+	if _, err := r.GetForProvider(nil); err == nil {
+		t.Fatal("expected error: nil provider")
+	}
+}
+
 func TestMockTTS_Synthesize(t *testing.T) {
 	mock := NewMockTTS()
 

--- a/tools/arena/selfplay/tts_registry_test.go
+++ b/tools/arena/selfplay/tts_registry_test.go
@@ -119,49 +119,6 @@ func TestTTSRegistry_Get_WithAPIKey(t *testing.T) {
 	}
 }
 
-func TestTTSRegistry_GetWithConfig_ModelOverride(t *testing.T) {
-	// Pinning a model via TTSConfig.Model should:
-	//   1. Bypass the per-provider singleton cache (a scenario picking
-	//      gpt-4o-mini-tts must not get the cached tts-1 instance).
-	//   2. Yield a service whose ModelName() reflects the override.
-	//   3. Expose the matching PersonaRubric for expressive personas.
-	registry := NewTTSRegistry()
-	t.Setenv(envOpenAIAPIKey, "test-key")
-
-	def, err := registry.Get(TTSProviderOpenAI)
-	if err != nil {
-		t.Fatalf("Get default: %v", err)
-	}
-
-	override, err := registry.GetWithConfig(&config.TTSConfig{
-		Provider: TTSProviderOpenAI,
-		Voice:    "alloy",
-		Model:    tts.ModelGPT4oMiniTTS,
-	})
-	if err != nil {
-		t.Fatalf("GetWithConfig override: %v", err)
-	}
-
-	if def == override {
-		t.Error("model-pinned service should be a separate instance from the default-cached one")
-	}
-
-	modelExposer, ok := override.(interface{ ModelName() string })
-	if !ok {
-		t.Skip("override service does not expose ModelName(); skipping detailed check")
-	} else if got := modelExposer.ModelName(); got != tts.ModelGPT4oMiniTTS {
-		t.Errorf("override ModelName = %q, want %q", got, tts.ModelGPT4oMiniTTS)
-	}
-
-	rp, ok := override.(tts.PersonaRubricProvider)
-	if !ok {
-		t.Fatal("override should still satisfy PersonaRubricProvider")
-	}
-	if rp.PersonaRubric() == "" {
-		t.Error("gpt-4o-mini-tts override should expose a non-empty PersonaRubric")
-	}
-}
-
 func TestTTSRegistry_Get_Caching(t *testing.T) {
 	registry := NewTTSRegistry()
 	t.Setenv(envOpenAIAPIKey, "test-key")
@@ -227,73 +184,6 @@ func TestTTSRegistry_Clear(t *testing.T) {
 	}
 }
 
-func TestTTSRegistry_GetWithConfig_NilConfig(t *testing.T) {
-	registry := NewTTSRegistry()
-	if _, err := registry.GetWithConfig(nil); err == nil {
-		t.Error("GetWithConfig(nil) expected error, got nil")
-	}
-}
-
-func TestTTSRegistry_GetWithConfig_MockNoFiles_DelegatesToGet(t *testing.T) {
-	registry := NewTTSRegistry()
-	cfg := &config.TTSConfig{Provider: TTSProviderMock}
-
-	// First call creates a cached mock service via the Get path.
-	svc1, err := registry.GetWithConfig(cfg)
-	if err != nil {
-		t.Fatalf("GetWithConfig() error = %v", err)
-	}
-
-	// Second call must return the same instance from the standard cache.
-	svc2, err := registry.GetWithConfig(cfg)
-	if err != nil {
-		t.Fatalf("GetWithConfig() error = %v", err)
-	}
-	if svc1 != svc2 {
-		t.Error("GetWithConfig with no audio_files should reuse Get cache")
-	}
-}
-
-func TestTTSRegistry_GetWithConfig_MockWithFiles_CachesByFilesIdentity(t *testing.T) {
-	registry := NewTTSRegistry()
-
-	cfgA := &config.TTSConfig{
-		Provider:   TTSProviderMock,
-		AudioFiles: []string{"a.pcm", "b.pcm"},
-	}
-	cfgADup := &config.TTSConfig{
-		Provider:   TTSProviderMock,
-		AudioFiles: []string{"a.pcm", "b.pcm"},
-	}
-	cfgB := &config.TTSConfig{
-		Provider:   TTSProviderMock,
-		AudioFiles: []string{"c.pcm"},
-	}
-
-	svcA1, err := registry.GetWithConfig(cfgA)
-	if err != nil {
-		t.Fatalf("GetWithConfig(cfgA) error = %v", err)
-	}
-	svcADup, err := registry.GetWithConfig(cfgADup)
-	if err != nil {
-		t.Fatalf("GetWithConfig(cfgADup) error = %v", err)
-	}
-	svcB, err := registry.GetWithConfig(cfgB)
-	if err != nil {
-		t.Fatalf("GetWithConfig(cfgB) error = %v", err)
-	}
-
-	// Same audio_files identity must reuse the same instance — otherwise
-	// MockTTSService.currentFileIndex would reset and rotation would break.
-	if svcA1 != svcADup {
-		t.Error("GetWithConfig should cache mock services by audio_files identity")
-	}
-	// Different audio_files must produce a separate instance.
-	if svcA1 == svcB {
-		t.Error("GetWithConfig should not share instances across different audio_files")
-	}
-}
-
 func TestTTSRegistry_Get_MockProvider(t *testing.T) {
 	registry := NewTTSRegistry()
 
@@ -336,6 +226,71 @@ func TestTTSRegistry_GetForProvider_NilProvider(t *testing.T) {
 	r := NewTTSRegistry()
 	if _, err := r.GetForProvider(nil); err == nil {
 		t.Fatal("expected error: nil provider")
+	}
+}
+
+func TestTTSRegistry_GetForProvider_ModelOverride(t *testing.T) {
+	// Pinning a model via Provider.Model should bypass the per-provider singleton
+	// cache and yield a service whose ModelName() reflects the override.
+	r := NewTTSRegistry()
+	t.Setenv(envOpenAIAPIKey, "test-key")
+
+	def, err := r.Get(TTSProviderOpenAI)
+	if err != nil {
+		t.Fatalf("Get default: %v", err)
+	}
+
+	override, err := r.GetForProvider(&config.Provider{
+		ID:         "openai-mini",
+		Type:       TTSProviderOpenAI,
+		Capability: config.CapabilityTTS,
+		Voice:      "alloy",
+		Model:      tts.ModelGPT4oMiniTTS,
+	})
+	if err != nil {
+		t.Fatalf("GetForProvider override: %v", err)
+	}
+
+	if def == override {
+		t.Error("model-pinned service should be a separate instance from the default-cached one")
+	}
+
+	modelExposer, ok := override.(interface{ ModelName() string })
+	if !ok {
+		t.Skip("override service does not expose ModelName(); skipping detailed check")
+	} else if got := modelExposer.ModelName(); got != tts.ModelGPT4oMiniTTS {
+		t.Errorf("override ModelName = %q, want %q", got, tts.ModelGPT4oMiniTTS)
+	}
+}
+
+func TestTTSRegistry_GetForProvider_MockWithFiles_CachesByFilesIdentity(t *testing.T) {
+	r := NewTTSRegistry()
+
+	pA := &config.Provider{Type: TTSProviderMock, Capability: config.CapabilityTTS,
+		AudioFiles: []string{"a.pcm", "b.pcm"}}
+	pADup := &config.Provider{Type: TTSProviderMock, Capability: config.CapabilityTTS,
+		AudioFiles: []string{"a.pcm", "b.pcm"}}
+	pB := &config.Provider{Type: TTSProviderMock, Capability: config.CapabilityTTS,
+		AudioFiles: []string{"c.pcm"}}
+
+	svcA, err := r.GetForProvider(pA)
+	if err != nil {
+		t.Fatalf("GetForProvider(pA): %v", err)
+	}
+	svcADup, err := r.GetForProvider(pADup)
+	if err != nil {
+		t.Fatalf("GetForProvider(pADup): %v", err)
+	}
+	svcB, err := r.GetForProvider(pB)
+	if err != nil {
+		t.Fatalf("GetForProvider(pB): %v", err)
+	}
+
+	if svcA != svcADup {
+		t.Error("same audio_files identity should return the same cached instance")
+	}
+	if svcA == svcB {
+		t.Error("different audio_files should produce separate instances")
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces inline `tts:` blocks on scenarios with an arena-level voice catalog. The same pattern as `judges:` and `self_play.roles:` — declarations live at the arena level, scenarios/personas reference catalog ids. Single-edit toggle between recording mode (real Cartesia/ElevenLabs/OpenAI) and CI mode (mock TTS playing committed PCM fixtures).

**Before:** every scenario carried its own multi-line `tts: { provider, voice, sample_rate, model, audio_files }` block. Resolution chain was `turn.TTS → scenario.TTS → defaults.TTS`. Provider yamls were implicitly LLM-only.

**After:** providers declare a `capability:` discriminator. TTS-capable providers carry `voice`/`sample_rate`/`audio_files`. Arena binds voice ids to TTS provider ids via `voices:`. Personas (`voice:` field) and scripted-text scenarios (`voice:` field) reference the catalog. Single resolution path: `persona.voice` or `scenario.voice` → `Config.ResolveVoice` → `TTSRegistry.GetForProvider` → vendor service.

## What's in the diff

58 files changed, +1824 / -882. 17 commits implementing 17 plan tasks. The cleanup commit (`f9989322`) alone deletes 941 lines of legacy dual-path code.

**Config layer:**
- `Provider.Capability` discriminator (`llm` default, `tts`, `stt`); symmetric loader validation rejecting yaml in the wrong slot
- `Provider.Voice` / `SampleRate` / `AudioFiles` fields; `Provider.Model` made optional (TTS providers don't have a model)
- Arena top-level fields: `tts_providers`, `stt_providers`, `voices` (id → tts provider id bindings)
- `UserPersonaPack.Voice` and `Scenario.Voice` reference the catalog
- Loader validates: capability mismatches, dangling voice bindings, unknown persona/scenario voice ids

**Runtime layer:**
- `selfplay.TTSRegistry.GetForProvider(*config.Provider)` — capability-validated TTS routing
- `selfplay.Registry.GetAudioContentGenerator` factory now takes `*config.Provider`
- Duplex executor: `resolveTTSProvider(arenaConfig, persona)` for selfplay, `Scenario.Voice → ResolveVoice` for scripted text — both flow through the same `streamTextAsAudio` path

**Example migrations:**
- `examples/voice-refund-demo/`: 4 scenarios + 4 personas migrated; 5 voice provider yamls (Cartesia confident-man, Cartesia friendly-woman, ElevenLabs Arnold, OpenAI nova, mock-tts)
- `examples/duplex-streaming/`: 4 selfplay + 2 scripted-text scenarios migrated; 4 voice provider yamls (OpenAI alloy, OpenAI echo, OpenAI alloy-expressive, ElevenLabs Rachel, mock-tts)

**Legacy deletion (cleanup commit):**
- `TTSConfig` struct + `Validate` method
- `TTS *TTSConfig` fields on `Scenario`/`TurnConfig`/`Defaults`
- `DuplexConversationExecutor.resolveTTS`, `streamTextAsAudio` (legacy), `stampTTSCostInMeta` (legacy), `openTextSynthesisStream` (legacy)
- `selfplay.TTSRegistry.GetWithConfig`, legacy `NewAudioContentGenerator`, legacy `GetAudioContentGenerator`
- Dual-path fallback branches in `processSelfPlayDuplexTurn` and `processScriptedTextDuplexTurn` (catalog is now the only path)
- The `tts.CostInfoToMetaMap` deprecated shim
- All `_ForProvider`-suffixed names renamed to drop the now-redundant suffix
- Inline `tts:` field removed from `arena.json` + `scenario.json` schemas

**Docs:** three Starlight pages migrated (`how-to/setup-voice-testing`, `reference/duplex-config`, `tutorials/06-duplex-testing`) to show the new catalog shape.

## ⚠️ Schema break

`https://promptkit.altairalabs.ai/schemas/v1alpha1/arena.json` and `scenario.json` will change shape after this lands:
- New fields: `tts_providers`, `stt_providers`, `voices` (arena); `voice` (scenario, persona); `voice`, `sample_rate`, `audio_files`, `capability` (provider)
- Removed fields: `tts` (arena defaults, scenario, turn); `TTSConfig` definition

**The release pipeline needs to publish the new schemas before downstream consumers can adopt.** Test environments using `PROMPTKIT_SCHEMA_SOURCE=local` are unaffected.

## STT is forward-looking-no-consumer

`stt_providers` field and `LoadedSTTProviders` map are wired through the loader for symmetry but no STT consumer exists yet. The slot is there so STT can be added later without a schema change.

## Test plan

- [x] `pkg/config` tests pass (90.5% coverage on package, 83.7% on `loader.go`)
- [x] `runtime` tests pass (all 19 packages)
- [x] `tools/arena` tests pass (35 packages)
- [x] `sdk` tests pass (10 packages)
- [x] `schemas/v1alpha1/` idempotent (`go run ./tools/schema-gen/...` produces zero diff)
- [x] All migrated examples validate against local schemas
- [x] Lint clean on changed code (pre-commit hook ran on every commit)
- [ ] CI: full lint, build, test, SonarCloud quality gate
- [ ] Manual smoke: run `voice-refund-demo` end-to-end against real Cartesia/ElevenLabs/OpenAI in recording mode
- [ ] Manual smoke: edit `voices:` to bind all entries to `mock-tts`, run keyless under `--provider mock-duplex --ci`, verify report renders

## Follow-ups (non-blocking)

1. `findLocalSchemaPath` in `pkg/config/schema_validator.go:115` is CWD-sensitive — pre-existing but more prominent now that local/remote schemas diverge. Walking up from the arena yaml's directory would be more robust.
2. Loader could warn (not error) when a selfplay scenario has both `Scenario.Voice` set AND personas — the scenario.voice is silently ignored in that case.
3. `voice-refund-demo/config.arena.yaml` instructs operators to edit voice bindings for CI; `duplex-streaming` pre-declares `id: scripted-mock` bindings. Consistency cleanup.