### PR TITLE
chore(examples,docs): drop PROMPTKIT_SCHEMA_SOURCE=local from shipped surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ After building with `make build-arena`, run examples from their directory:
 ```bash
 # Run an example with mock provider (no API keys needed)
 cd examples/guardrails-test
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --mock-provider --mock-config mock-responses.yaml --ci --formats html,json
+../../bin/promptarena run --mock-provider --mock-config mock-responses.yaml --ci --formats html,json
 
 # Open the HTML report
 open out/report.html
@@ -83,18 +83,18 @@ open out/report.html
 # Examples with pre-configured mock providers (have their own providers/mock-provider.yaml):
 # Do NOT use --mock-provider flag — just run directly
 cd examples/customer-support
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+../../bin/promptarena run --ci --format html
 
-# Workflow examples (require local schema source)
+# Workflow examples run against published schemas as well
 cd examples/workflow-support
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+../../bin/promptarena run --ci --format html
 ```
 
 Key flags:
 - `--mock-provider`: Replaces all providers with generic mock (use `--mock-config` to specify response file)
 - `--ci`: Non-interactive mode, exits with code 0/1
 - `--formats html,json`: Output format(s)
-- `PROMPTKIT_SCHEMA_SOURCE=local`: Use local schemas instead of remote (needed when schema is ahead of published)
+- `PROMPTKIT_SCHEMA_SOURCE=local`: Only needed when developing schema fields that haven't been published yet. Shipped examples must validate against the published remote schemas without this flag.
 
 ## SDK Architecture
 
@@ -119,21 +119,21 @@ Interfaces like `Conversation` and `StreamingConversation` are defined in `a2a`;
 
 ### Running examples
 ```bash
-# Workflow examples (require PROMPTKIT_SCHEMA_SOURCE=local until remote schemas are updated)
 cd examples/workflow-support
-PROMPTKIT_SCHEMA_SOURCE=local promptarena run --ci --format html
+promptarena run --ci --format html
 
 cd examples/workflow-order-processing
-PROMPTKIT_SCHEMA_SOURCE=local promptarena run --ci --format html
+promptarena run --ci --format html
 
-# Regular examples (use remote schema)
 cd examples/customer-support
 promptarena run --ci --format html
 ```
 
+All shipped examples must validate against the published remote schemas without `PROMPTKIT_SCHEMA_SOURCE=local`. If you add a new example that requires the flag, the corresponding schema changes must be released before the example is merged.
+
 ### Schema validation
 - PromptArena validates scenario files against JSON schemas fetched from `https://promptkit.altairalabs.ai/schemas/v1alpha1/`
-- If new fields aren't published to the remote schema yet, set `PROMPTKIT_SCHEMA_SOURCE=local` to validate against local `schemas/v1alpha1/` files
+- `PROMPTKIT_SCHEMA_SOURCE=local` is a development tool for validating new fields against in-repo `schemas/v1alpha1/` before they are published. It should never appear in shipped example READMEs or docs.
 - Test init files (`engine/test_init.go`, `cmd/promptarena/test_init.go`) disable schema validation for unit tests
 
 ### Mock providers

--- a/docs/src/content/docs/arena/reference/cli-commands.md
+++ b/docs/src/content/docs/arena/reference/cli-commands.md
@@ -580,7 +580,7 @@ promptarena export | jq '.prompts | keys'
 ### Notes
 
 - The config must contain `prompt_configs` (inline prompts). Configs that reference pre-built pack files cannot be exported.
-- Schema validation is performed against the embedded PromptPack schema. Set `PROMPTKIT_SCHEMA_SOURCE=local` to use local schemas during development.
+- Schema validation is performed against the embedded PromptPack schema. The `PROMPTKIT_SCHEMA_SOURCE=local` environment variable can be used to validate against in-repo schemas when developing new fields that have not yet been published to the hosted schema location.
 - Skill validation and workflow validation are run automatically. Errors are fatal; warnings are printed to stderr.
 
 ---
@@ -976,9 +976,6 @@ promptarena serve ./examples/guardrails-test
 
 # Use a custom port and auto-open the browser
 promptarena serve -p 3000 --open
-
-# With local schema validation (for development)
-PROMPTKIT_SCHEMA_SOURCE=local promptarena serve ./my-scenario
 ```
 
 ### REST API

--- a/docs/src/content/docs/arena/tutorials/08-client-tools.md
+++ b/docs/src/content/docs/arena/tutorials/08-client-tools.md
@@ -211,7 +211,7 @@ The `tools` section references the client-mode tool file. Arena registers the to
 Run the tests from your project directory:
 
 ```bash
-PROMPTKIT_SCHEMA_SOURCE=local promptarena run --ci --format html
+promptarena run --ci --format html
 ```
 
 You should see output indicating both scenarios were executed:

--- a/examples/codegen-anthropic/README.md
+++ b/examples/codegen-anthropic/README.md
@@ -25,7 +25,7 @@ make -C ../.. build-arena
 ## Run
 
 ```bash
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+../../bin/promptarena run --ci --format html
 open out/report.html
 ```
 

--- a/examples/codegen-anthropic/config.arena.yaml
+++ b/examples/codegen-anthropic/config.arena.yaml
@@ -13,7 +13,7 @@ metadata:
         make build-arena
         docker pull ghcr.io/altairalabs/codegen-sandbox:latest
         cd examples/codegen-anthropic
-        PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+        ../../bin/promptarena run --ci --format html
 
 spec:
   prompt_configs:

--- a/examples/codegen-sandbox/README.md
+++ b/examples/codegen-sandbox/README.md
@@ -19,7 +19,7 @@ A runnable demo of an agent doing real codegen inside a
 ```bash
 make -C ../.. build-arena
 docker pull ghcr.io/altairalabs/codegen-sandbox:latest
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+../../bin/promptarena run --ci --format html
 open out/report.html
 ```
 
@@ -39,7 +39,7 @@ What happens:
 ## Offline (CI) demo
 
 ```bash
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --mock-provider --ci --format html
+../../bin/promptarena run --mock-provider --ci --format html
 ```
 
 Uses `mock-responses.yaml` to simulate the LLM's decisions. The

--- a/examples/codegen-sandbox/config.arena.yaml
+++ b/examples/codegen-sandbox/config.arena.yaml
@@ -10,10 +10,10 @@ metadata:
         make build-arena
         docker pull ghcr.io/altairalabs/codegen-sandbox:latest
         cd examples/codegen-sandbox
-        PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --format html
+        ../../bin/promptarena run --ci --format html
 
       Offline / CI (mock provider, no sandbox):
-        PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --mock-provider --ci --format html
+        ../../bin/promptarena run --mock-provider --ci --format html
 
 spec:
   prompt_configs:

--- a/examples/duplex-streaming/sweep-silence-tail.sh
+++ b/examples/duplex-streaming/sweep-silence-tail.sh
@@ -70,7 +70,6 @@ for ms in "${SILENCES[@]}"; do
     # turn-complete + Gemini message lines. Discard stdout (TUI / progress).
     if PROMPTKIT_SILENCE_TAIL_MS="$ms" \
         TTS_CACHE_DIR="$(dirname "$0")/.tts-cache" \
-        PROMPTKIT_SCHEMA_SOURCE=local \
         "$ARENA" run \
         --scenario "$SCENARIO" \
         --provider "$PROVIDER" \

--- a/examples/eval-test/README.md
+++ b/examples/eval-test/README.md
@@ -20,13 +20,11 @@ The Eval config type allows you to:
 
 ```bash
 # From repo root, validate the eval config
-PROMPTKIT_SCHEMA_SOURCE=local ./bin/promptarena validate examples/eval-test/config.arena.yaml
+./bin/promptarena validate examples/eval-test/config.arena.yaml
 
 # Validate the eval file directly
-PROMPTKIT_SCHEMA_SOURCE=local ./bin/promptarena validate --type eval examples/eval-test/evals/basic-eval.eval.yaml
+./bin/promptarena validate --type eval examples/eval-test/evals/basic-eval.eval.yaml
 ```
-
-**Note:** Use `PROMPTKIT_SCHEMA_SOURCE=local` during development until schemas are published to the hosted location.
 
 ## Eval Configuration Format
 

--- a/examples/memory-agent/README.md
+++ b/examples/memory-agent/README.md
@@ -15,14 +15,14 @@ With a real provider (API key required):
 
 ```bash
 cd examples/memory-agent
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --formats html,json
+../../bin/promptarena run --ci --formats html,json
 ```
 
 With mock provider (no API key, assertions will fail since mock doesn't call tools):
 
 ```bash
 cd examples/memory-agent
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --mock-provider --ci --formats json
+../../bin/promptarena run --mock-provider --ci --formats json
 ```
 
 ## Scenarios

--- a/examples/multimodal-tool-results/README.md
+++ b/examples/multimodal-tool-results/README.md
@@ -20,7 +20,7 @@ Demonstrates tools that return **multimodal content** (text + images) alongside 
 
 ```bash
 # From this directory:
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --formats html,json
+../../bin/promptarena run --ci --formats html,json
 
 # Open the report to see media badges on tool results:
 open out/report.html

--- a/examples/resilience-testing/README.md
+++ b/examples/resilience-testing/README.md
@@ -22,7 +22,7 @@ for the complete list of supported assertion types.
 
 ```bash
 make build-arena
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --formats html,json \
+../../bin/promptarena run --ci --formats html,json \
   -c examples/resilience-testing/config.arena.yaml \
   -o examples/resilience-testing/out
 open examples/resilience-testing/out/report.html

--- a/examples/voice-refund-demo/README.md
+++ b/examples/voice-refund-demo/README.md
@@ -38,7 +38,7 @@ export OPENAI_API_KEY="..."
 export CARTESIA_API_KEY="..."   # for aggressive + impersonator
 export ELEVENLABS_API_KEY="..." # for anxious-delivery
 
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run \
+../../bin/promptarena run \
   --provider mock-duplex \
   --ci \
   --formats html,json

--- a/examples/workflow-agent-loops/README.md
+++ b/examples/workflow-agent-loops/README.md
@@ -25,7 +25,7 @@ make build-arena
 
 # Run the example
 cd examples/workflow-agent-loops
-PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --formats html,json
+../../bin/promptarena run --ci --formats html,json
 
 # Open the HTML report
 open out/report.html

--- a/examples/workflow-skills/README.md
+++ b/examples/workflow-skills/README.md
@@ -67,7 +67,6 @@ Skills can only grant tools that the pack declares. The pack is the ceiling.
 ## Running
 
 ```bash
-# Requires PROMPTKIT_SCHEMA_SOURCE=local until remote schemas are updated
 cd examples/workflow-skills
-PROMPTKIT_SCHEMA_SOURCE=local promptarena run --ci --format html
+promptarena run --ci --format html
 ```


### PR DESCRIPTION
## Summary

- All in-tree examples now validate cleanly against the published remote schemas without `PROMPTKIT_SCHEMA_SOURCE=local`. Removed the unnecessary prefix from 12 example READMEs/configs/scripts plus the tutorial and CLI reference docs.
- `CLAUDE.md` updated with the explicit policy: shipped examples must validate against published schemas; the env var is a development-only tool for validating new schema fields before publication.

## Test plan

- [x] Verified each previously-flagged example validates clean against remote schemas without the env var
- [x] Ran one example (`workflow-agent-loops`) end-to-end without the env var; exit 0
- [ ] CI passes
