### PR TITLE
feat(evals): RAG eval handlers — faithfulness, answer_relevancy, contextual_*, hallucination

### DIFF
--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -313,6 +313,106 @@ assertions:
 
 ---
 
+## RAG Checks
+
+RAG checks are named eval primitives for retrieval-augmented generation: they score the answer against retrieved context (`faithfulness`, `hallucination`), the answer against the question (`answer_relevancy`), or the retrieved chunks against the question / ground truth (`contextual_precision`, `contextual_recall`, `contextual_relevancy`).
+
+Each handler is a thin wrapper over `llm_judge` with a hardened default prompt drawn from public DeepEval / Ragas reference implementations (Apache 2.0). The standard judge params (`rubric`, `model`, `system_prompt`, `min_score`, `extra`) all apply; supplying `system_prompt` or `criteria` overrides the default.
+
+**Context sources** — every handler that needs retrieved chunks accepts them in three forms:
+
+| Form | Example |
+|------|---------|
+| `contexts: ["chunk-1", "chunk-2"]` | Canonical list form |
+| `context: "single chunk"` | Convenience form for one chunk |
+| `context_field: retrieved_chunks` | Looks up the named key in `evalCtx.Metadata` — use this when a retrieval tool writes chunks to metadata at runtime |
+
+### `faithfulness`
+
+Scores how directly the answer is supported by the supplied context. Equivalent in name to DeepEval / Ragas `faithfulness`.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `contexts` \| `context` \| `context_field` | string[] / string / string | Yes (one of) | Retrieved context the answer should be grounded in |
+
+Plus standard judge params. **Surfaces:** A E
+
+```yaml
+assertions:
+  - type: faithfulness
+    params:
+      context_field: retrieved_chunks
+      min_score: 0.8
+```
+
+### `answer_relevancy`
+
+Scores how directly the answer addresses the user's question. Equivalent in name to DeepEval / Ragas `answer_relevancy`.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `question` | string | No | Defaults to the last user turn in the session |
+
+Plus standard judge params. **Surfaces:** A E
+
+### `contextual_precision`
+
+Scores the fraction of retrieved chunks that are relevant to the question (relevant chunks / total chunks). Equivalent in name to DeepEval `contextual_precision`.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `contexts` \| `context` \| `context_field` | — | Yes | Retrieved chunks |
+| `question` | string | No | Defaults to the last user turn |
+
+Plus standard judge params. **Surfaces:** A E
+
+### `contextual_recall`
+
+Scores how completely the retrieved chunks cover the information the ground-truth answer relies on. Equivalent in name to DeepEval / Ragas `contextual_recall`.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `contexts` \| `context` \| `context_field` | — | Yes | Retrieved chunks |
+| `reference` \| `expected_output` | string | Yes | Ground-truth answer |
+
+Plus standard judge params. **Surfaces:** A E
+
+### `contextual_relevancy`
+
+Scores the mean per-chunk relevance of retrieved chunks to the question (distinct from `contextual_precision`: precision is binary relevant/not; relevancy is the mean of graded scores). Equivalent in name to DeepEval `contextual_relevancy`.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `contexts` \| `context` \| `context_field` | — | Yes | Retrieved chunks |
+| `question` | string | No | Defaults to the last user turn |
+
+Plus standard judge params. **Surfaces:** A E
+
+### `hallucination`
+
+Scores how free the answer is of unsupported / contradicting claims relative to the context — the inverse framing of `faithfulness`, kept as a distinct handler so users coming from DeepEval find the vocabulary they expect. 1.0 = no hallucination; 0.0 = entirely hallucinated. Equivalent in name to DeepEval `hallucination`.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `contexts` \| `context` \| `context_field` | — | Yes | Retrieved context the answer should be grounded in |
+
+Plus standard judge params. **Surfaces:** A E
+
+```yaml
+assertions:
+  - type: hallucination
+    params:
+      contexts:
+        - "Paris is the capital of France."
+      min_score: 0.9
+```
+
+:::note[Three-role model]
+RAG checks are eval primitives invoked as assertions. They can also be wired as monitor-only guardrails via `runtime/hooks/guardrails/factory.go` — but for retrieval quality, the assertion shape is the natural default. See the [Validators reference](/arena/reference/validators/) for the guardrail-side wiring.
+:::
+
+---
+
 ## External Checks
 
 External checks delegate evaluation to HTTP endpoints or A2A agents. These are the no-code extensibility points for teams that want custom evaluation logic without writing Go.

--- a/runtime/evals/handlers/answer_relevancy.go
+++ b/runtime/evals/handlers/answer_relevancy.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// AnswerRelevancyHandler scores how directly the assistant's answer
+// addresses the user's question. Equivalent in name to DeepEval /
+// Ragas `answer_relevancy`.
+//
+// Default prompts adapted from the public DeepEval / Ragas reference
+// implementations (Apache 2.0). Override per-call by passing
+// system_prompt or criteria in params.
+//
+// Params (all optional):
+//   - question (string): override the auto-extracted last user turn
+//   - min_score (float): pass threshold
+//   - rubric, model, system_prompt: standard llm_judge knobs
+type AnswerRelevancyHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *AnswerRelevancyHandler) Type() string { return "answer_relevancy" }
+
+// Eval scores the current assistant output against the question for
+// on-topic focus and directness.
+func (h *AnswerRelevancyHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	in := buildRAGInputs(evalCtx, params)
+	if in.question == "" {
+		return ragErrorResult(
+			h.Type(),
+			"no question found: supply 'question' param or include a user turn in the session",
+		), nil
+	}
+
+	content := fmt.Sprintf(
+		"QUESTION:\n%s\n\nANSWER:\n%s",
+		in.question, in.answer,
+	)
+	return ragJudgeCall(
+		ctx, evalCtx, h.Type(), params, content,
+		answerRelevancySystemPrompt, answerRelevancyCriteria,
+	)
+}
+
+const answerRelevancySystemPrompt = "You are an answer-relevancy evaluator. " +
+	"You will be shown a QUESTION and an ANSWER. " +
+	"Decide how directly and on-topic the answer addresses the question. " +
+	"\n\n" +
+	"Score on [0, 1]: " +
+	"1.0 — the answer directly and entirely addresses the question. " +
+	"0.0 — the answer is entirely off-topic or evasive. " +
+	"Partial credit for answers that address the question with significant off-topic content. " +
+	"\n\n" +
+	"Respond with JSON: {\"passed\": bool, \"score\": float in [0,1], " +
+	"\"reasoning\": string}. " +
+	"In your reasoning, identify any off-topic content." +
+	"\n\n" +
+	"(Prompt adapted from Ragas / DeepEval reference implementations, Apache 2.0.)"
+
+const answerRelevancyCriteria = "Score the ANSWER's relevance to the QUESTION."

--- a/runtime/evals/handlers/contextual_precision.go
+++ b/runtime/evals/handlers/contextual_precision.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ContextualPrecisionHandler scores the fraction of retrieved chunks
+// that are actually relevant to the question. Equivalent in name to
+// DeepEval `contextual_precision`.
+//
+// Default prompts adapted from the public DeepEval reference
+// implementation (Apache 2.0). Override per-call by passing
+// system_prompt or criteria in params.
+//
+// Params (all optional):
+//   - contexts ([]string) | context (string) | context_field (string):
+//     retrieved chunks
+//   - question (string): override the auto-extracted last user turn
+//   - min_score (float): pass threshold
+//   - rubric, model, system_prompt: standard llm_judge knobs
+type ContextualPrecisionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ContextualPrecisionHandler) Type() string { return "contextual_precision" }
+
+// Eval scores the precision of retrieved chunks relative to the question.
+func (h *ContextualPrecisionHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return evalChunkContext(ctx, evalCtx, h.Type(), params, chunkContextSpec{
+		otherLabel:   chunkLabelQuestion,
+		otherValueFn: func(in ragInputs) string { return in.question },
+		otherMissing: ragNoQuestionMessage,
+		systemPrompt: contextualPrecisionSystemPrompt,
+		criteria:     contextualPrecisionCriteria,
+	})
+}
+
+const contextualPrecisionSystemPrompt = "You are a retrieval-precision evaluator. " +
+	"You will be shown a QUESTION and a numbered list of RETRIEVED CHUNKS. " +
+	"For each chunk, decide whether it is relevant to answering the question. " +
+	"Compute precision = (relevant chunks) / (total chunks)." +
+	"\n\n" +
+	"Score on [0, 1]: " +
+	"1.0 — every retrieved chunk is relevant. " +
+	"0.0 — none of the retrieved chunks are relevant. " +
+	"\n\n" +
+	"Respond with JSON: {\"passed\": bool, \"score\": float in [0,1], " +
+	"\"reasoning\": string}. " +
+	"In your reasoning, mark each chunk as relevant or irrelevant and explain why." +
+	"\n\n" +
+	"(Prompt adapted from DeepEval reference implementation, Apache 2.0.)"
+
+const contextualPrecisionCriteria = "Compute the precision of the RETRIEVED CHUNKS relative to the QUESTION."

--- a/runtime/evals/handlers/contextual_recall.go
+++ b/runtime/evals/handlers/contextual_recall.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ContextualRecallHandler scores how completely the retrieved chunks
+// cover the information needed for the ground-truth answer. Equivalent
+// in name to DeepEval / Ragas `contextual_recall`.
+//
+// Default prompts adapted from the public DeepEval / Ragas reference
+// implementations (Apache 2.0). Override per-call by passing
+// system_prompt or criteria in params.
+//
+// Params:
+//   - contexts ([]string) | context (string) | context_field (string):
+//     retrieved chunks (required)
+//   - reference (string) | expected_output (string): the ground-truth
+//     answer (required)
+//   - question (string): override the auto-extracted last user turn
+//   - min_score (float): pass threshold
+//   - rubric, model, system_prompt: standard llm_judge knobs
+type ContextualRecallHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ContextualRecallHandler) Type() string { return "contextual_recall" }
+
+// Eval scores how completely the retrieved chunks cover the information
+// the ground-truth answer relies on.
+func (h *ContextualRecallHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return evalChunkContext(ctx, evalCtx, h.Type(), params, chunkContextSpec{
+		otherLabel:   "REFERENCE ANSWER",
+		otherValueFn: func(in ragInputs) string { return in.reference },
+		otherMissing: ragNoReferenceMessage,
+		systemPrompt: contextualRecallSystemPrompt,
+		criteria:     contextualRecallCriteria,
+	})
+}
+
+const contextualRecallSystemPrompt = "You are a retrieval-recall evaluator. " +
+	"You will be shown a REFERENCE ANSWER (ground truth) and a list of RETRIEVED CHUNKS. " +
+	"Decide what fraction of the information the reference answer relies on is present in the chunks." +
+	"\n\n" +
+	"Score on [0, 1]: " +
+	"1.0 — every claim in the reference answer is supported by the retrieved chunks. " +
+	"0.0 — none of the reference answer's claims are supported by the chunks. " +
+	"Partial credit by claim count." +
+	"\n\n" +
+	"Respond with JSON: {\"passed\": bool, \"score\": float in [0,1], " +
+	"\"reasoning\": string}. " +
+	"In your reasoning, list reference-answer claims that are missing from the chunks." +
+	"\n\n" +
+	"(Prompt adapted from Ragas / DeepEval reference implementations, Apache 2.0.)"
+
+const contextualRecallCriteria = "Compute the recall of the RETRIEVED CHUNKS against the REFERENCE ANSWER."

--- a/runtime/evals/handlers/contextual_relevancy.go
+++ b/runtime/evals/handlers/contextual_relevancy.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// ContextualRelevancyHandler scores the average per-chunk relevance of
+// the retrieved chunks to the question. Equivalent in name to DeepEval
+// `contextual_relevancy`.
+//
+// Distinct from `contextual_precision`: precision is a binary
+// relevant/not-relevant ratio; relevancy is the mean of graded scores.
+//
+// Default prompts adapted from the public DeepEval reference
+// implementation (Apache 2.0). Override per-call by passing
+// system_prompt or criteria in params.
+//
+// Params (all optional):
+//   - contexts ([]string) | context (string) | context_field (string)
+//   - question (string)
+//   - min_score (float)
+//   - rubric, model, system_prompt
+type ContextualRelevancyHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *ContextualRelevancyHandler) Type() string { return "contextual_relevancy" }
+
+// Eval scores the mean relevance of retrieved chunks to the question.
+func (h *ContextualRelevancyHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	return evalChunkContext(ctx, evalCtx, h.Type(), params, chunkContextSpec{
+		otherLabel:   chunkLabelQuestion,
+		otherValueFn: func(in ragInputs) string { return in.question },
+		otherMissing: ragNoQuestionMessage,
+		systemPrompt: contextualRelevancySystemPrompt,
+		criteria:     contextualRelevancyCriteria,
+	})
+}
+
+const contextualRelevancySystemPrompt = "You are a retrieval-relevancy evaluator. " +
+	"You will be shown a QUESTION and a numbered list of RETRIEVED CHUNKS. " +
+	"For each chunk, score its relevance to the question on [0, 1] " +
+	"(1.0 = directly relevant, 0.0 = irrelevant, partial credit allowed). " +
+	"Return the mean of the per-chunk scores." +
+	"\n\n" +
+	"Respond with JSON: {\"passed\": bool, \"score\": float in [0,1], " +
+	"\"reasoning\": string}. " +
+	"In your reasoning, include the per-chunk score for each chunk." +
+	"\n\n" +
+	"(Prompt adapted from DeepEval reference implementation, Apache 2.0.)"
+
+const contextualRelevancyCriteria = "Score the mean per-chunk relevance of the RETRIEVED CHUNKS to the QUESTION."

--- a/runtime/evals/handlers/faithfulness.go
+++ b/runtime/evals/handlers/faithfulness.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// FaithfulnessHandler scores how well the answer is supported by the
+// provided context. A faithful answer makes only claims backed by the
+// context; an unfaithful answer asserts facts the context does not
+// support. Equivalent in name to DeepEval / Ragas `faithfulness`.
+//
+// Default prompts adapted from the public DeepEval / Ragas reference
+// implementations (Apache 2.0). Override per-call by passing
+// system_prompt or criteria in params.
+//
+// Params (all optional):
+//   - contexts ([]string) | context (string) | context_field (string):
+//     retrieved chunks the answer should be grounded in
+//   - min_score (float): pass threshold
+//   - rubric, model, system_prompt: standard llm_judge knobs
+type FaithfulnessHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *FaithfulnessHandler) Type() string { return "faithfulness" }
+
+// Eval scores the current assistant output against the supplied
+// context for factual consistency.
+func (h *FaithfulnessHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	in := buildRAGInputs(evalCtx, params)
+	if len(in.contexts) == 0 {
+		return ragErrorResult(h.Type(), ragNoContextMessage), nil
+	}
+
+	content := fmt.Sprintf(
+		"CONTEXT:\n%s\n\nANSWER:\n%s",
+		formatContexts(in.contexts), in.answer,
+	)
+	return ragJudgeCall(
+		ctx, evalCtx, h.Type(), params, content,
+		faithfulnessSystemPrompt, faithfulnessCriteria,
+	)
+}
+
+const faithfulnessSystemPrompt = "You are a faithfulness evaluator. " +
+	"You will be shown a CONTEXT and an ANSWER. " +
+	"Decide how well each factual claim in the ANSWER is supported by the CONTEXT. " +
+	"\n\n" +
+	"Score on [0, 1]: " +
+	"1.0 — every factual claim in the answer is directly supported by the context. " +
+	"0.0 — the answer's claims are entirely unsupported or contradicted by the context. " +
+	"For partial credit, return the proportion of supported claims. " +
+	"\n\n" +
+	"Respond with JSON: {\"passed\": bool, \"score\": float in [0,1], " +
+	"\"reasoning\": string}. " +
+	"In your reasoning, list any unsupported or contradicted claims." +
+	"\n\n" +
+	"(Prompt adapted from Ragas / DeepEval reference implementations, Apache 2.0.)"
+
+const faithfulnessCriteria = "Score the ANSWER's faithfulness to the CONTEXT."

--- a/runtime/evals/handlers/hallucination.go
+++ b/runtime/evals/handlers/hallucination.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// HallucinationHandler scores how free the answer is of claims that
+// are not supported by, or contradict, the provided context. The
+// inverse framing of `faithfulness` — kept as a separate handler so
+// users coming from DeepEval find the vocabulary they expect.
+//
+// A score of 1.0 means no hallucination (matches faithfulness=1.0); a
+// score of 0.0 means entirely hallucinated.
+//
+// Default prompts adapted from the public DeepEval reference
+// implementation (Apache 2.0). Override per-call by passing
+// system_prompt or criteria in params.
+//
+// Params (all optional):
+//   - contexts ([]string) | context (string) | context_field (string)
+//   - min_score (float): pass threshold
+//   - rubric, model, system_prompt: standard llm_judge knobs
+type HallucinationHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *HallucinationHandler) Type() string { return "hallucination" }
+
+// Eval scores the current assistant output for hallucinations relative
+// to the supplied context.
+func (h *HallucinationHandler) Eval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	in := buildRAGInputs(evalCtx, params)
+	if len(in.contexts) == 0 {
+		return ragErrorResult(h.Type(), ragNoContextMessage), nil
+	}
+
+	content := fmt.Sprintf(
+		"CONTEXT:\n%s\n\nANSWER:\n%s",
+		formatContexts(in.contexts), in.answer,
+	)
+	return ragJudgeCall(
+		ctx, evalCtx, h.Type(), params, content,
+		hallucinationSystemPrompt, hallucinationCriteria,
+	)
+}
+
+const hallucinationSystemPrompt = "You are a hallucination detector. " +
+	"You will be shown a CONTEXT and an ANSWER. " +
+	"Identify claims in the answer that are not supported by, or contradict, the context. " +
+	"\n\n" +
+	"Score on [0, 1]: " +
+	"1.0 — no hallucinated claims (every claim is grounded in the context). " +
+	"0.0 — every claim is hallucinated. " +
+	"Partial credit for answers where some claims are grounded and others are not. " +
+	"\n\n" +
+	"Respond with JSON: {\"passed\": bool, \"score\": float in [0,1], " +
+	"\"reasoning\": string}. " +
+	"In your reasoning, list each hallucinated or contradicting claim." +
+	"\n\n" +
+	"(Prompt adapted from DeepEval reference implementation, Apache 2.0.)"
+
+const hallucinationCriteria = "Score the ANSWER for absence of hallucination relative to the CONTEXT " +
+	"(1.0 = no hallucination)."

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -1481,6 +1481,14 @@ func TestRegisterInit(t *testing.T) {
 		"llm_judge_session",
 		"llm_judge_tool_calls",
 
+		// RAG-shape eval handlers
+		"faithfulness",
+		"answer_relevancy",
+		"contextual_precision",
+		"contextual_recall",
+		"contextual_relevancy",
+		"hallucination",
+
 		// External eval handlers
 		"rest_eval",
 		"rest_eval_session",

--- a/runtime/evals/handlers/rag_handlers_test.go
+++ b/runtime/evals/handlers/rag_handlers_test.go
@@ -1,0 +1,579 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// --- shared helpers used by every RAG handler test ---
+
+func newRAGEvalCtx(mock *llmJudgeMock, output string) *evals.EvalContext {
+	return &evals.EvalContext{
+		CurrentOutput: output,
+		Messages: []types.Message{
+			{Role: "user", Content: "What is the capital of France?"},
+		},
+		Metadata: map[string]any{
+			"judge_provider": mock,
+		},
+	}
+}
+
+func passMock(score float64, reasoning string) *llmJudgeMock {
+	return &llmJudgeMock{
+		result: &JudgeResult{
+			Passed:    true,
+			Score:     score,
+			Reasoning: reasoning,
+		},
+	}
+}
+
+func failMock(reasoning string) *llmJudgeMock {
+	return &llmJudgeMock{
+		result: &JudgeResult{
+			Passed:    false,
+			Score:     0.0,
+			Reasoning: reasoning,
+		},
+	}
+}
+
+// --- faithfulness ---
+
+func TestFaithfulnessHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &FaithfulnessHandler{}
+	if h.Type() != "faithfulness" {
+		t.Errorf("got %q, want %q", h.Type(), "faithfulness")
+	}
+}
+
+func TestFaithfulnessHandler_Pass(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.95, "answer fully supported")
+	h := &FaithfulnessHandler{}
+	evalCtx := newRAGEvalCtx(mock, "Paris is the capital of France.")
+	params := map[string]any{
+		"contexts":  []string{"Paris is the capital of France."},
+		"min_score": 0.8,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil || *result.Score != 0.95 {
+		t.Errorf("score=%v, want 0.95", result.Score)
+	}
+	if !strings.Contains(mock.opts.Content, "Paris is the capital of France.") {
+		t.Errorf("context not included in judge content: %q", mock.opts.Content)
+	}
+	if !strings.Contains(mock.opts.SystemPrompt, "faithfulness evaluator") {
+		t.Errorf("default system prompt missing: %q", mock.opts.SystemPrompt)
+	}
+}
+
+func TestFaithfulnessHandler_Fail_NoContext(t *testing.T) {
+	t.Parallel()
+	mock := passMock(1.0, "should not be called")
+	h := &FaithfulnessHandler{}
+	evalCtx := newRAGEvalCtx(mock, "any answer")
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil || *result.Score != 0.0 {
+		t.Errorf("score=%v, want 0.0", result.Score)
+	}
+	if !strings.Contains(result.Explanation, "no context provided") {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestFaithfulnessHandler_ContextField(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.9, "")
+	h := &FaithfulnessHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "answer",
+		Metadata: map[string]any{
+			"judge_provider":   mock,
+			"retrieved_chunks": []string{"chunk-a", "chunk-b"},
+		},
+	}
+	params := map[string]any{"context_field": "retrieved_chunks"}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil {
+		t.Fatal("expected score, got nil")
+	}
+	if !strings.Contains(mock.opts.Content, "chunk-a") {
+		t.Errorf("context_field chunks not included: %q", mock.opts.Content)
+	}
+}
+
+func TestFaithfulnessHandler_UserOverridesSystemPrompt(t *testing.T) {
+	t.Parallel()
+	mock := passMock(1.0, "")
+	h := &FaithfulnessHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	params := map[string]any{
+		"contexts":      []string{"ctx"},
+		"system_prompt": "custom",
+	}
+
+	_, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.opts.SystemPrompt != "custom" {
+		t.Errorf("user system_prompt not respected: %q", mock.opts.SystemPrompt)
+	}
+}
+
+// --- answer_relevancy ---
+
+func TestAnswerRelevancyHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &AnswerRelevancyHandler{}
+	if h.Type() != "answer_relevancy" {
+		t.Errorf("got %q, want %q", h.Type(), "answer_relevancy")
+	}
+}
+
+func TestAnswerRelevancyHandler_Pass(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.9, "directly addresses")
+	h := &AnswerRelevancyHandler{}
+	evalCtx := newRAGEvalCtx(mock, "Paris.")
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{"min_score": 0.7})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil || *result.Score != 0.9 {
+		t.Errorf("score=%v, want 0.9", result.Score)
+	}
+	if !strings.Contains(mock.opts.Content, "QUESTION:") || !strings.Contains(mock.opts.Content, "ANSWER:") {
+		t.Errorf("content missing structured sections: %q", mock.opts.Content)
+	}
+}
+
+func TestAnswerRelevancyHandler_NoQuestion(t *testing.T) {
+	t.Parallel()
+	mock := passMock(1.0, "")
+	h := &AnswerRelevancyHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "answer",
+		Metadata:      map[string]any{"judge_provider": mock},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Explanation, "no question") {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestAnswerRelevancyHandler_ExplicitQuestion(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.8, "")
+	h := &AnswerRelevancyHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "Paris",
+		Metadata:      map[string]any{"judge_provider": mock},
+	}
+	params := map[string]any{"question": "Which French city?"}
+
+	_, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(mock.opts.Content, "Which French city?") {
+		t.Errorf("explicit question not used: %q", mock.opts.Content)
+	}
+}
+
+// --- contextual_precision ---
+
+func TestContextualPrecisionHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &ContextualPrecisionHandler{}
+	if h.Type() != "contextual_precision" {
+		t.Errorf("got %q, want %q", h.Type(), "contextual_precision")
+	}
+}
+
+func TestContextualPrecisionHandler_Pass(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.75, "3 of 4 chunks relevant")
+	h := &ContextualPrecisionHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	params := map[string]any{
+		"contexts": []string{"relevant-a", "relevant-b", "noise", "relevant-c"},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil || *result.Score != 0.75 {
+		t.Errorf("score=%v, want 0.75", result.Score)
+	}
+	for _, want := range []string{"chunk 1", "chunk 2", "chunk 3", "chunk 4"} {
+		if !strings.Contains(mock.opts.Content, want) {
+			t.Errorf("missing chunk label %q in content: %q", want, mock.opts.Content)
+		}
+	}
+}
+
+func TestContextualPrecisionHandler_NoContext(t *testing.T) {
+	t.Parallel()
+	mock := failMock("")
+	h := &ContextualPrecisionHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Explanation, "no context provided") {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+// --- contextual_recall ---
+
+func TestContextualRecallHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &ContextualRecallHandler{}
+	if h.Type() != "contextual_recall" {
+		t.Errorf("got %q, want %q", h.Type(), "contextual_recall")
+	}
+}
+
+func TestContextualRecallHandler_Pass(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.9, "all reference claims supported")
+	h := &ContextualRecallHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	params := map[string]any{
+		"contexts":  []string{"Paris is the capital of France."},
+		"reference": "Paris is the capital of France.",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil || *result.Score != 0.9 {
+		t.Errorf("score=%v, want 0.9", result.Score)
+	}
+	if !strings.Contains(mock.opts.Content, "REFERENCE ANSWER") {
+		t.Errorf("REFERENCE ANSWER section missing: %q", mock.opts.Content)
+	}
+}
+
+func TestContextualRecallHandler_NoReference(t *testing.T) {
+	t.Parallel()
+	mock := failMock("")
+	h := &ContextualRecallHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	params := map[string]any{"contexts": []string{"x"}}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Explanation, "ground-truth") {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestContextualRecallHandler_ExpectedOutputAlias(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.5, "")
+	h := &ContextualRecallHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	params := map[string]any{
+		"contexts":        []string{"x"},
+		"expected_output": "y",
+	}
+	_, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(mock.opts.Content, "y") {
+		t.Errorf("expected_output not used as reference: %q", mock.opts.Content)
+	}
+}
+
+// --- contextual_relevancy ---
+
+func TestContextualRelevancyHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &ContextualRelevancyHandler{}
+	if h.Type() != "contextual_relevancy" {
+		t.Errorf("got %q, want %q", h.Type(), "contextual_relevancy")
+	}
+}
+
+func TestContextualRelevancyHandler_Pass(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.65, "mean relevance 0.65")
+	h := &ContextualRelevancyHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	params := map[string]any{
+		"contexts": []string{"a", "b"},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil || *result.Score != 0.65 {
+		t.Errorf("score=%v, want 0.65", result.Score)
+	}
+}
+
+func TestContextualRelevancyHandler_NoContext(t *testing.T) {
+	t.Parallel()
+	mock := failMock("")
+	h := &ContextualRelevancyHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Explanation, "no context provided") {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+func TestContextualRelevancyHandler_NoQuestion(t *testing.T) {
+	t.Parallel()
+	mock := failMock("")
+	h := &ContextualRelevancyHandler{}
+	evalCtx := &evals.EvalContext{
+		CurrentOutput: "answer",
+		Metadata:      map[string]any{"judge_provider": mock},
+	}
+	params := map[string]any{"contexts": []string{"a"}}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Explanation, "no question") {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+// --- hallucination ---
+
+func TestHallucinationHandler_Type(t *testing.T) {
+	t.Parallel()
+	h := &HallucinationHandler{}
+	if h.Type() != "hallucination" {
+		t.Errorf("got %q, want %q", h.Type(), "hallucination")
+	}
+}
+
+func TestHallucinationHandler_Pass_NoHallucination(t *testing.T) {
+	t.Parallel()
+	mock := passMock(1.0, "no hallucination detected")
+	h := &HallucinationHandler{}
+	evalCtx := newRAGEvalCtx(mock, "Paris is the capital of France.")
+	params := map[string]any{
+		"contexts": []string{"Paris is the capital of France."},
+	}
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil || *result.Score != 1.0 {
+		t.Errorf("score=%v, want 1.0", result.Score)
+	}
+}
+
+func TestHallucinationHandler_Fail(t *testing.T) {
+	t.Parallel()
+	mock := passMock(0.2, "two unsupported claims")
+	h := &HallucinationHandler{}
+	evalCtx := newRAGEvalCtx(mock, "Paris is the capital of France and has 100M residents.")
+	params := map[string]any{
+		"contexts":  []string{"Paris is the capital of France."},
+		"min_score": 0.9,
+	}
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Score == nil || *result.Score != 0.2 {
+		t.Errorf("score=%v, want 0.2", result.Score)
+	}
+}
+
+// --- shared handling: missing provider, judge error ---
+
+func TestRAGHandlers_MissingProvider(t *testing.T) {
+	t.Parallel()
+	handlers := []evals.EvalTypeHandler{
+		&FaithfulnessHandler{},
+		&AnswerRelevancyHandler{},
+		&ContextualPrecisionHandler{},
+		&ContextualRecallHandler{},
+		&ContextualRelevancyHandler{},
+		&HallucinationHandler{},
+	}
+	for _, h := range handlers {
+		t.Run(h.Type(), func(t *testing.T) {
+			t.Parallel()
+			evalCtx := &evals.EvalContext{CurrentOutput: "x"}
+			result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+				"contexts":  []string{"ctx"},
+				"reference": "ref",
+				"question":  "q",
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(result.Explanation, "judge_provider not found") {
+				t.Errorf("unexpected explanation: %s", result.Explanation)
+			}
+		})
+	}
+}
+
+func TestRAGHandlers_JudgeError(t *testing.T) {
+	t.Parallel()
+	mock := &llmJudgeMock{err: errors.New("LLM unavailable")}
+	h := &FaithfulnessHandler{}
+	evalCtx := newRAGEvalCtx(mock, "answer")
+	params := map[string]any{"contexts": []string{"ctx"}}
+
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Explanation, "judge error: LLM unavailable") {
+		t.Errorf("unexpected explanation: %s", result.Explanation)
+	}
+}
+
+// --- rag_helpers tests ---
+
+func TestExtractRAGContexts_PreferenceOrder(t *testing.T) {
+	t.Parallel()
+	evalCtx := &evals.EvalContext{
+		Metadata: map[string]any{"chunks": []string{"meta-a"}},
+	}
+	// contexts takes precedence over context, which takes precedence over context_field
+	got := extractRAGContexts(evalCtx, map[string]any{
+		"contexts":      []string{"params-a", "params-b"},
+		"context":       "ignored",
+		"context_field": "chunks",
+	})
+	if len(got) != 2 || got[0] != "params-a" {
+		t.Errorf("contexts param ignored: %v", got)
+	}
+	// context (singular) when contexts absent
+	got = extractRAGContexts(evalCtx, map[string]any{
+		"context":       "single",
+		"context_field": "chunks",
+	})
+	if len(got) != 1 || got[0] != "single" {
+		t.Errorf("context param ignored: %v", got)
+	}
+	// context_field fallback
+	got = extractRAGContexts(evalCtx, map[string]any{
+		"context_field": "chunks",
+	})
+	if len(got) != 1 || got[0] != "meta-a" {
+		t.Errorf("context_field not consulted: %v", got)
+	}
+	// nothing
+	got = extractRAGContexts(evalCtx, map[string]any{})
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestCoerceContextSlice(t *testing.T) {
+	t.Parallel()
+	if got := coerceContextSlice([]string{"a", "b"}); len(got) != 2 {
+		t.Errorf("[]string: %v", got)
+	}
+	if got := coerceContextSlice([]any{"a", 42, "b"}); len(got) != 2 {
+		t.Errorf("[]any with non-strings: %v", got)
+	}
+	if got := coerceContextSlice("single"); len(got) != 1 || got[0] != "single" {
+		t.Errorf("string: %v", got)
+	}
+	if got := coerceContextSlice(""); got != nil {
+		t.Errorf("empty string: %v", got)
+	}
+	if got := coerceContextSlice(123); got != nil {
+		t.Errorf("int: %v", got)
+	}
+}
+
+func TestExtractRAGQuestion_FromMessages(t *testing.T) {
+	t.Parallel()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "first"},
+			{Role: "assistant", Content: "reply"},
+			{Role: "user", Content: "second"},
+		},
+	}
+	got := extractRAGQuestion(evalCtx, map[string]any{})
+	if got != "second" {
+		t.Errorf("got %q, want %q", got, "second")
+	}
+}
+
+func TestExtractRAGQuestion_ExplicitOverride(t *testing.T) {
+	t.Parallel()
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{{Role: "user", Content: "msg"}},
+	}
+	got := extractRAGQuestion(evalCtx, map[string]any{"question": "explicit"})
+	if got != "explicit" {
+		t.Errorf("got %q, want %q", got, "explicit")
+	}
+}
+
+func TestExtractRAGReference(t *testing.T) {
+	t.Parallel()
+	got := extractRAGReference(map[string]any{"reference": "a"})
+	if got != "a" {
+		t.Errorf("got %q, want %q", got, "a")
+	}
+	got = extractRAGReference(map[string]any{"expected_output": "b"})
+	if got != "b" {
+		t.Errorf("got %q, want %q", got, "b")
+	}
+	got = extractRAGReference(map[string]any{})
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestFormatContexts(t *testing.T) {
+	t.Parallel()
+	got := formatContexts([]string{"a", "b"})
+	if !strings.Contains(got, "[chunk 1] a") || !strings.Contains(got, "[chunk 2] b") {
+		t.Errorf("unexpected format: %q", got)
+	}
+	if got := formatContexts(nil); got != "(none)" {
+		t.Errorf("nil case: %q", got)
+	}
+}

--- a/runtime/evals/handlers/rag_helpers.go
+++ b/runtime/evals/handlers/rag_helpers.go
@@ -1,0 +1,240 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// RAG-shaped eval handlers (faithfulness, answer_relevancy,
+// contextual_precision/recall/relevancy, hallucination) all delegate to
+// the same JudgeProvider as `llm_judge`. The only differences are the
+// default system prompt, default criteria, and the structured input
+// they assemble from the EvalContext.
+//
+// Default prompts are adapted from the public DeepEval and Ragas
+// reference implementations (both Apache 2.0). Users can override
+// either by setting `system_prompt` or `criteria` in params.
+
+// ragInputs collects all RAG-relevant inputs that handlers may need.
+type ragInputs struct {
+	question string
+	answer   string
+	contexts []string
+	// reference is the ground-truth answer, used by contextual_recall.
+	reference string
+}
+
+// extractRAGContexts pulls retrieved chunks from params or metadata.
+// Supports three forms in order of preference:
+//
+//  1. params["contexts"] — list of strings, the canonical form
+//  2. params["context"]  — single string convenience form
+//  3. params["context_field"] — names a key in evalCtx.Metadata to read;
+//     value may be a []string, []any, or a single string
+//
+// Returns nil if no context is found.
+func extractRAGContexts(
+	evalCtx *evals.EvalContext, params map[string]any,
+) []string {
+	if list := extractStringSlice(params, "contexts"); len(list) > 0 {
+		return list
+	}
+	if s, ok := params["context"].(string); ok && s != "" {
+		return []string{s}
+	}
+	if field, ok := params["context_field"].(string); ok && field != "" {
+		if evalCtx != nil && evalCtx.Metadata != nil {
+			return coerceContextSlice(evalCtx.Metadata[field])
+		}
+	}
+	return nil
+}
+
+// coerceContextSlice handles []string, []any, and string values
+// from arbitrary metadata.
+func coerceContextSlice(v any) []string {
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	case string:
+		if t != "" {
+			return []string{t}
+		}
+	}
+	return nil
+}
+
+// extractRAGQuestion returns the last user message text, or the value
+// of params["question"] if explicitly supplied. Used by handlers that
+// need to evaluate answer relevance to a question.
+func extractRAGQuestion(
+	evalCtx *evals.EvalContext, params map[string]any,
+) string {
+	if q, ok := params["question"].(string); ok && q != "" {
+		return q
+	}
+	if evalCtx == nil {
+		return ""
+	}
+	for i := len(evalCtx.Messages) - 1; i >= 0; i-- {
+		if strings.EqualFold(evalCtx.Messages[i].Role, "user") {
+			return evalCtx.Messages[i].GetContent()
+		}
+	}
+	return ""
+}
+
+// extractRAGReference returns the ground-truth answer from
+// params["reference"] or params["expected_output"], or empty string.
+func extractRAGReference(params map[string]any) string {
+	if v, ok := params["reference"].(string); ok && v != "" {
+		return v
+	}
+	if v, ok := params["expected_output"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// buildRAGInputs is the unified collector used by every RAG handler.
+func buildRAGInputs(
+	evalCtx *evals.EvalContext, params map[string]any,
+) ragInputs {
+	answer := ""
+	if evalCtx != nil {
+		answer = evalCtx.CurrentOutput
+	}
+	return ragInputs{
+		question:  extractRAGQuestion(evalCtx, params),
+		answer:    answer,
+		contexts:  extractRAGContexts(evalCtx, params),
+		reference: extractRAGReference(params),
+	}
+}
+
+// formatContexts joins context chunks into a numbered block for the
+// judge prompt.
+func formatContexts(contexts []string) string {
+	if len(contexts) == 0 {
+		return "(none)"
+	}
+	var b strings.Builder
+	for i, c := range contexts {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "[chunk %d] %s", i+1, c)
+	}
+	return b.String()
+}
+
+// ragJudgeCall runs the LLM judge with the supplied content and default
+// system prompt / criteria, falling back to user overrides when present.
+// All RAG handlers funnel through here to keep their bodies trivial.
+func ragJudgeCall(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	evalType string,
+	params map[string]any,
+	content string,
+	defaultSystemPrompt string,
+	defaultCriteria string,
+) (*evals.EvalResult, error) {
+	provider, extractErr := extractJudgeProvider(evalCtx)
+	if extractErr != nil {
+		return ragErrorResult(evalType, extractErr.Error()), nil
+	}
+
+	opts := buildJudgeOpts(content, params)
+	opts.Emitter = emitterFromEvalCtx(evalCtx)
+	if opts.SystemPrompt == "" {
+		opts.SystemPrompt = defaultSystemPrompt
+	}
+	if opts.Criteria == "" {
+		opts.Criteria = defaultCriteria
+	}
+
+	judgeResult, judgeErr := provider.Judge(ctx, opts)
+	if judgeErr != nil {
+		return ragErrorResult(
+			evalType, fmt.Sprintf("judge error: %v", judgeErr),
+		), nil
+	}
+
+	return buildEvalResult(evalType, judgeResult), nil
+}
+
+// ragErrorResult produces a standardized failure result with a score
+// of zero so any pass_threshold treats the eval as failed.
+func ragErrorResult(evalType, msg string) *evals.EvalResult {
+	return &evals.EvalResult{
+		Type:        evalType,
+		Score:       boolScore(false),
+		Explanation: msg,
+	}
+}
+
+// ragNoContextMessage is the standard explanation when a handler that
+// needs retrieved context wasn't supplied any.
+const ragNoContextMessage = "no context provided: supply 'contexts' ([]string), " +
+	"'context' (string), or 'context_field' (metadata key)"
+
+// chunkContextSpec describes a "score retrieved chunks against some
+// other text" handler. ContextualPrecisionHandler, ContextualRecallHandler,
+// and ContextualRelevancyHandler all collapse to a single call against
+// evalChunkContext with different spec values.
+type chunkContextSpec struct {
+	otherLabel   string // "QUESTION", "REFERENCE ANSWER", …
+	otherValueFn func(ragInputs) string
+	otherMissing string // explanation when the required other-field is empty
+	systemPrompt string
+	criteria     string
+}
+
+// evalChunkContext is the shared body for the three chunk-vs-other-text
+// RAG handlers. Keeps each concrete handler trivial so dupl has no
+// near-identical bodies to flag.
+func evalChunkContext(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	evalType string,
+	params map[string]any,
+	spec chunkContextSpec,
+) (*evals.EvalResult, error) {
+	in := buildRAGInputs(evalCtx, params)
+	if len(in.contexts) == 0 {
+		return ragErrorResult(evalType, ragNoContextMessage), nil
+	}
+	other := spec.otherValueFn(in)
+	if other == "" {
+		return ragErrorResult(evalType, spec.otherMissing), nil
+	}
+
+	content := fmt.Sprintf(
+		"%s:\n%s\n\nRETRIEVED CHUNKS:\n%s",
+		spec.otherLabel, other, formatContexts(in.contexts),
+	)
+	return ragJudgeCall(
+		ctx, evalCtx, evalType, params, content,
+		spec.systemPrompt, spec.criteria,
+	)
+}
+
+const ragNoQuestionMessage = "no question found: supply 'question' param or include a user turn in the session"
+const ragNoReferenceMessage = "no ground-truth answer: supply 'reference' (or 'expected_output') in params"
+
+// chunkLabelQuestion is the otherLabel value used by chunk-vs-question
+// handlers (contextual_precision, contextual_relevancy). Hoisted to a
+// const so goconst stops complaining about the repeated literal.
+const chunkLabelQuestion = "QUESTION"

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -73,6 +73,15 @@ func init() {
 	evals.RegisterDefault(&LLMJudgeSessionHandler{})
 	evals.RegisterDefault(&LLMJudgeToolCallsHandler{})
 
+	// RAG-shape eval handlers — thin wrappers over llm_judge with
+	// hardened default prompts. See rag_helpers.go.
+	evals.RegisterDefault(&FaithfulnessHandler{})
+	evals.RegisterDefault(&AnswerRelevancyHandler{})
+	evals.RegisterDefault(&ContextualPrecisionHandler{})
+	evals.RegisterDefault(&ContextualRecallHandler{})
+	evals.RegisterDefault(&ContextualRelevancyHandler{})
+	evals.RegisterDefault(&HallucinationHandler{})
+
 	// Length validation handlers
 	evals.RegisterDefault(&MinLengthHandler{})
 	evals.RegisterDefault(&MaxLengthHandler{})


### PR DESCRIPTION
## Summary

Adds six named eval handlers for retrieval-augmented generation testing — closes the named-primitive gap vs DeepEval / Ragas. Implements #1145.

- `faithfulness` — does the answer claim only what the context supports
- `answer_relevancy` — does the answer address the user's question
- `contextual_precision` — fraction of retrieved chunks that are relevant
- `contextual_recall` — fraction of ground-truth information present in the chunks
- `contextual_relevancy` — mean per-chunk relevance score
- `hallucination` — inverse of faithfulness, kept distinct for buyer discoverability

All six are thin wrappers over the existing `llm_judge` infrastructure with hardened default prompts derived from public DeepEval / Ragas reference implementations (Apache 2.0). The three "chunk-vs-other-text" handlers share an `evalChunkContext` helper so their bodies stay trivial.

Context flows in three forms (preference order): `params["contexts"]` ([]string), `params["context"]` (string), or `params["context_field"]` naming a key in `evalCtx.Metadata` — the third form supports live agents writing retrieval results to metadata at runtime.

**No parallel mechanisms added.** Each handler is role-neutral: invoked as a scenario assertion with `min_score` is the demo default; the existing `runtime/hooks/guardrails/factory.go` adapter automatically wraps any of them as a monitor-only guardrail if a user wires it that way.

Reference-doc entries added under `## RAG Checks` in `docs/src/content/docs/reference/checks.md`, plus a note clarifying the three-role model (eval / guardrail / assertion).

Closes #1145.

## Test plan

- [x] Golden-case tests for each handler (pass / fail / missing-context / missing-other-field / judge-error branches)
- [x] `TestRegisterInit` updated to include the six new types
- [x] `go test ./evals/... -race -count=1` green
- [x] `golangci-lint` clean
- [x] Coverage ≥ 80% on every new file
- [ ] CI passes
