### PR TITLE
feat(arena,examples,docs): voice latency budget demo + LatencyMs eval bridge

### DIFF
--- a/docs/src/content/docs/arena/how-to/index.md
+++ b/docs/src/content/docs/arena/how-to/index.md
@@ -66,6 +66,11 @@ Walk through `examples/voice-refund-demo/`: four scripted personas (hostile, imp
 Walk through `examples/voice-ivr/`: a workflow-driven bank IVR that routes callers via state transitions to self-service or human handoff. Pairs the workflow primitive with the voice harness and asserts the tool-call pattern of each path.
 </div>
 
+<div class="code-example" markdown="1">
+### [Assert per-turn latency budgets](/arena/how-to/voice-latency-budget/)
+Walk through `examples/voice-latency-budget/`: gate every turn against a `max_ms` budget. Arena bridges the assistant message's `LatencyMs` into eval context, so `latency_budget` reads real provider timing with no custom plumbing.
+</div>
+
 ## Session Recording
 
 <div class="code-example" markdown="1">

--- a/docs/src/content/docs/arena/how-to/voice-latency-budget.md
+++ b/docs/src/content/docs/arena/how-to/voice-latency-budget.md
@@ -1,0 +1,96 @@
+---
+title: Assert per-turn latency budgets
+description: Gate scenarios on real provider latency. Arena bridges the assistant message's LatencyMs into eval context, so the latency_budget assertion just works.
+---
+
+This how-to walks through `examples/voice-latency-budget/` — a small scenario that asserts every turn's provider latency against an explicit `max_ms` budget. Useful for gating deploys on regressions, comparing providers on the same scenario, and proving an agent stays inside a real-time budget.
+
+## What it proves
+
+LLM-driven systems silently slow down: a small prompt change adds a hidden retrieval step, a provider quietly degrades, a tool call gets retried, an agent loops one extra round. Pure single-turn eval misses this — the response looks right, it's just slow. PromptArena makes latency a first-class signal:
+
+- The provider stage records `LatencyMs` on every assistant message (LLM round-trip including any in-turn tool-call rounds).
+- Arena bridges `LatencyMs` into the eval context metadata as `latency_ms` so the standard `latency_budget` assertion reads it without any custom plumbing.
+- Scenarios gate each turn: `max_ms: 1000` fails any reply slower than a second.
+
+## The assertion shape
+
+```yaml
+turns:
+  - role: user
+    content: "Hi, I need help with my account."
+    assertions:
+      - type: latency_budget
+        params:
+          max_ms: 1000
+        message: "Turn must respond within 1000ms"
+```
+
+`latency_budget` returns a score normalised to the budget: `min(1.0, max_ms / latency_ms)`. A reply within budget scores 1.0; a reply at 2× the budget scores 0.5. The HTML report shows the exact `latency_ms` vs `budget_ms` per turn.
+
+## Run it
+
+```bash
+cd examples/voice-latency-budget
+promptarena serve
+```
+
+`serve` loads the scenario into the web UI; the timeline view shows the latency assertion alongside the conversation. Headless:
+
+```bash
+promptarena run --ci --formats html,json
+open out/report.html
+```
+
+The default config runs against a text mock provider — sub-millisecond responses, so the budget passes trivially. The interesting signal comes from real providers.
+
+## Comparing providers
+
+Add multiple provider files and re-register them in `config.arena.yaml`. Arena fans out the scenario across every registered provider; the HTML report shows the per-provider `latency_ms` distribution side by side. Use this for migration testing ("does Claude Haiku stay inside our 800ms budget on this prompt?") or for cross-provider bake-offs.
+
+## What's measured today
+
+`latency_budget` checks the **total provider-call duration per turn**: LLM round-trip time, including any tool-call rounds that happen within that turn. It's a coarse "is this turn fast enough" signal — well-suited to gating regressions.
+
+What richer voice testing wants — and what's coming next — is per-metric capture:
+
+- **TTFB** — time to first token / first audio frame
+- **First-audio** — time from user-input-end to first audio-out (duplex providers)
+- **End-of-turn delta** — silence-detection latency between generation-complete and turn-complete
+
+Provider stages capture some of these timings internally; they just don't yet flow into the eval context as named metadata keys. When they do, `latency_budget` will accept per-metric thresholds (`max_ttfb_ms`, `max_first_audio_ms`, …); the existing single-metric usage continues to work.
+
+## CI gate
+
+The mock-provider path runs keyless, so the demo fits a fork-safe CI job:
+
+```yaml
+# .github/workflows/voice-latency-budget.yml
+name: Voice latency budget
+
+on:
+  pull_request:
+    paths:
+      - 'examples/voice-latency-budget/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - run: make build-arena
+      - name: Run latency-budget scenarios
+        working-directory: examples/voice-latency-budget
+        run: ../../bin/promptarena run --ci --formats json
+```
+
+For real-provider runs, gate on the same step with provider keys via `secrets:`, and bump `max_ms` to a value that reflects your production budget.
+
+## Extending it
+
+- **Tighter budgets per turn**: vary `max_ms` per turn — the greeting might be fast, the tool-using turn slower.
+- **Mix with content assertions**: combine `latency_budget` with `content_includes` / `llm_judge` to test both correctness and speed.
+- **Per-provider thresholds**: when running across providers, the assertion config can include `when:` clauses to apply different budgets per provider.

--- a/examples/voice-latency-budget/README.md
+++ b/examples/voice-latency-budget/README.md
@@ -1,0 +1,97 @@
+# Voice Latency Budget Demo
+
+Assert per-turn provider latency against an explicit budget. The scenario fails when an LLM call takes longer than the threshold — the same way you'd gate a deploy on latency regressions.
+
+## What it tests
+
+A three-turn support exchange with a `latency_budget` assertion on every turn:
+
+```yaml
+assertions:
+  - type: latency_budget
+    params:
+      max_ms: 1000
+```
+
+Arena bridges the assistant message's `LatencyMs` (set by the provider stage) into the eval context metadata, so the assertion reads real per-turn timing without any custom plumbing.
+
+## Running
+
+The default config runs deterministically against an in-process text mock provider — sub-millisecond responses, so the 1000ms budget passes trivially. Real signal arrives when you swap in a real provider:
+
+```bash
+cd examples/voice-latency-budget
+../../bin/promptarena run --ci --formats html,json
+open out/report.html
+```
+
+For the live dev loop:
+
+```bash
+../../bin/promptarena serve
+../../bin/promptarena run --tui
+```
+
+## Switching to live providers
+
+Add a real provider config and re-register it in `config.arena.yaml`:
+
+```yaml
+providers:
+  - file: providers/openai-gpt4o-mini.provider.yaml
+  - file: providers/claude-haiku.provider.yaml
+  - file: providers/gemini-flash.provider.yaml
+```
+
+Then run with provider keys in your environment. The HTML report shows the per-turn `latency_ms` recorded against each provider so you can compare them side by side.
+
+## What `latency_budget` measures today
+
+`latency_budget` reads the **total provider-call duration for the current turn** (LLM round-trip time, including any tool-call rounds within that turn). It's a coarse "is this turn fast enough?" signal — useful for gating deploys against regressions and for cross-provider comparisons.
+
+What it doesn't yet capture (tracked separately):
+
+- **TTFB** — time to first token / first audio frame
+- **First-audio** — time from user-input-end to first audio-out for duplex providers
+- **End-of-turn delta** — provider-side silence-detection latency between generation-complete and turn-complete
+
+These need richer metric capture in the provider stages. When that lands, the assertion will gain per-metric thresholds; the demo's shape stays the same.
+
+## CI gate
+
+This demo runs keyless against the mock provider, so it fits a fork-safe CI job:
+
+```yaml
+# .github/workflows/voice-latency-budget.yml
+name: Voice latency budget
+
+on:
+  pull_request:
+    paths:
+      - 'examples/voice-latency-budget/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - run: make build-arena
+      - name: Run latency-budget scenarios
+        working-directory: examples/voice-latency-budget
+        run: ../../bin/promptarena run --ci --formats json
+```
+
+## File layout
+
+```
+voice-latency-budget/
+├── README.md
+├── config.arena.yaml
+├── mock-responses.yaml
+├── prompts/support-agent.yaml
+├── providers/mock-provider.yaml
+└── scenarios/turn-budget.scenario.yaml
+```

--- a/examples/voice-latency-budget/config.arena.yaml
+++ b/examples/voice-latency-budget/config.arena.yaml
@@ -1,0 +1,33 @@
+# Voice Latency Budget Demo
+#
+# Assert per-turn provider latency against an explicit budget. Runs the
+# same scenario across providers (text mock for CI, real duplex
+# providers for live measurement).
+#
+# The latency_budget assertion reads `latency_ms` from the eval context
+# metadata. Arena bridges the per-turn provider latency from the
+# assistant message into the metadata so the assertion can read it
+# without any custom plumbing.
+#
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: voice-latency-budget
+
+spec:
+  prompt_configs:
+    - id: support-agent
+      file: prompts/support-agent.yaml
+
+  providers:
+    - file: providers/mock-provider.yaml
+
+  scenarios:
+    - file: scenarios/turn-budget.scenario.yaml
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 256
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/voice-latency-budget/mock-responses.yaml
+++ b/examples/voice-latency-budget/mock-responses.yaml
@@ -1,0 +1,6 @@
+scenarios:
+  turn-budget:
+    turns:
+      1: "Hi, I'd be happy to help. What's the issue?"
+      2: "Got it. Let me look that up for you."
+      3: "All set — anything else?"

--- a/examples/voice-latency-budget/prompts/support-agent.yaml
+++ b/examples/voice-latency-budget/prompts/support-agent.yaml
@@ -1,0 +1,12 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: support-agent
+spec:
+  task_type: "support"
+  version: "v1.0.0"
+  description: "Short-turn support agent. Latency budget demo."
+
+  system_template: |
+    You are a customer support agent. Keep replies to one short sentence
+    so per-turn latency stays predictable.

--- a/examples/voice-latency-budget/providers/mock-provider.yaml
+++ b/examples/voice-latency-budget/providers/mock-provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-fast
+spec:
+  id: mock-fast
+  type: mock
+  model: mock-model
+  additional_config:
+    mock_config: mock-responses.yaml
+  defaults:
+    temperature: 0.1
+    max_tokens: 256
+    top_p: 1.0

--- a/examples/voice-latency-budget/scenarios/turn-budget.scenario.yaml
+++ b/examples/voice-latency-budget/scenarios/turn-budget.scenario.yaml
@@ -1,0 +1,31 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: turn-budget
+spec:
+  id: turn-budget
+  task_type: support
+  description: "Assert each turn stays under a 1s budget."
+
+  turns:
+    - role: user
+      content: "Hi, I need help with my account."
+      assertions:
+        - type: latency_budget
+          params:
+            max_ms: 1000
+          message: "Turn must respond within 1000ms"
+
+    - role: user
+      content: "My account ID is ACC-12345."
+      assertions:
+        - type: latency_budget
+          params:
+            max_ms: 1000
+
+    - role: user
+      content: "Great, thank you."
+      assertions:
+        - type: latency_budget
+          params:
+            max_ms: 1000

--- a/tools/arena/engine/eval_orchestrator.go
+++ b/tools/arena/engine/eval_orchestrator.go
@@ -246,10 +246,11 @@ func (h *EvalOrchestrator) buildEvalContext(
 	turnIndex int,
 	sessionID string,
 ) *evals.EvalContext {
+	latencyMs, haveLatency := latestAssistantLatencyMs(messages)
 	metadata := h.metadata
-	needsCopy := h.eventBus != nil || h.workflowMetaProvider != nil
+	needsCopy := h.eventBus != nil || h.workflowMetaProvider != nil || haveLatency
 	if needsCopy {
-		merged := make(map[string]any, len(metadata)+4) //nolint:mnd // extra capacity for emitter + workflow keys
+		merged := make(map[string]any, len(metadata)+4) //nolint:mnd // extra capacity for emitter + workflow + latency keys
 		for k, v := range metadata {
 			merged[k] = v
 		}
@@ -267,9 +268,29 @@ func (h *EvalOrchestrator) buildEvalContext(
 				merged[k] = v
 			}
 		}
+		if haveLatency {
+			// Bridge per-turn provider latency from the assistant message
+			// into metadata so the latency_budget assertion can read it.
+			merged["latency_ms"] = float64(latencyMs)
+		}
 		metadata = merged
 	}
 	return evals.BuildEvalContext(messages, turnIndex, sessionID, h.taskType, metadata)
+}
+
+// latestAssistantLatencyMs returns the LatencyMs of the most recent
+// assistant message, and a flag indicating whether one was found.
+// The boolean lets callers distinguish a measured 0 ms (sub-millisecond
+// in-process mock) from "no latency available". Used to bridge per-turn
+// provider latency into the eval metadata for the latency_budget
+// assertion.
+func latestAssistantLatencyMs(messages []types.Message) (int64, bool) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == roleAssistant {
+			return messages[i].LatencyMs, true
+		}
+	}
+	return 0, false
 }
 
 // filterEvalDefs filters eval defs to only include types in the filter list.

--- a/tools/arena/engine/eval_orchestrator_test.go
+++ b/tools/arena/engine/eval_orchestrator_test.go
@@ -130,6 +130,95 @@ func TestBuildEvalContext_ExtractsLastAssistantMessage(t *testing.T) {
 	assert.Len(t, evalCtx.Messages, 4)
 }
 
+func TestBuildEvalContext_BridgesLatencyMs(t *testing.T) {
+	hook := NewEvalOrchestrator(newTestRegistry(), nil, false, nil, "chat")
+	messages := []types.Message{
+		types.NewUserMessage("hello"),
+		{Role: "assistant", Content: "reply", LatencyMs: 432},
+	}
+
+	evalCtx := hook.buildEvalContext(messages, 1, "session-1")
+
+	require.NotNil(t, evalCtx.Metadata)
+	assert.Equal(t, float64(432), evalCtx.Metadata["latency_ms"],
+		"buildEvalContext should bridge latest assistant LatencyMs into metadata so latency_budget can read it")
+}
+
+func TestBuildEvalContext_BridgesZeroLatency(t *testing.T) {
+	// Sub-millisecond mock provider calls produce LatencyMs == 0 but the
+	// metadata key should still be present — handlers may want to assert
+	// "latency was measured" distinct from "latency was over budget".
+	hook := NewEvalOrchestrator(newTestRegistry(), nil, false, nil, "chat")
+	messages := []types.Message{
+		types.NewUserMessage("hello"),
+		{Role: "assistant", Content: "reply", LatencyMs: 0},
+	}
+
+	evalCtx := hook.buildEvalContext(messages, 1, "session-1")
+
+	require.NotNil(t, evalCtx.Metadata)
+	assert.Equal(t, float64(0), evalCtx.Metadata["latency_ms"])
+}
+
+func TestBuildEvalContext_NoAssistantNoLatency(t *testing.T) {
+	hook := NewEvalOrchestrator(newTestRegistry(), nil, false, nil, "chat")
+	messages := []types.Message{types.NewUserMessage("hello")}
+
+	evalCtx := hook.buildEvalContext(messages, 0, "session-1")
+
+	if evalCtx.Metadata != nil {
+		_, has := evalCtx.Metadata["latency_ms"]
+		assert.False(t, has, "no latency should be reported when no assistant message exists")
+	}
+}
+
+func TestLatestAssistantLatencyMs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		msgs    []types.Message
+		wantMs  int64
+		wantHas bool
+	}{
+		{name: "empty", msgs: nil, wantHas: false},
+		{
+			name: "no assistant",
+			msgs: []types.Message{types.NewUserMessage("u")},
+		},
+		{
+			name:    "single assistant",
+			msgs:    []types.Message{{Role: "assistant", LatencyMs: 250}},
+			wantMs:  250,
+			wantHas: true,
+		},
+		{
+			name: "uses latest assistant",
+			msgs: []types.Message{
+				{Role: "assistant", LatencyMs: 100},
+				types.NewUserMessage("u"),
+				{Role: "assistant", LatencyMs: 800},
+			},
+			wantMs:  800,
+			wantHas: true,
+		},
+		{
+			name:    "zero latency still reports has",
+			msgs:    []types.Message{{Role: "assistant", LatencyMs: 0}},
+			wantMs:  0,
+			wantHas: true,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotMs, gotHas := latestAssistantLatencyMs(tc.msgs)
+			assert.Equal(t, tc.wantMs, gotMs)
+			assert.Equal(t, tc.wantHas, gotHas)
+		})
+	}
+}
+
 func TestBuildEvalContext_NoMessages(t *testing.T) {
 	defs := []evals.EvalDef{
 		{ID: "eval-1", Type: "test_handler", Trigger: evals.TriggerEveryTurn},


### PR DESCRIPTION
## Summary

Adds the third headline-trio cell of the voice beachhead matrix: `examples/voice-latency-budget/`, a three-turn scenario that asserts every turn's provider latency against an explicit `max_ms` budget. Implements #1149.

Includes a minimal runtime bridge so the assertion reads real signal.

## What's in the bridge

`EvalOrchestrator.buildEvalContext` now extracts the most recent assistant message's `LatencyMs` (already set by the provider stage on every LLM call) and injects it into the eval context metadata as `latency_ms`. The existing `latency_budget` handler reads this key — previously it always returned "latency_ms not found in metadata" because no path populated it, so the handler was effectively dead code.

The bridge fires whenever an assistant message exists, including the `LatencyMs == 0` case (sub-millisecond in-process mock providers). Handlers may want to assert "latency was measured" distinct from "latency was over budget"; the boolean return on the helper lets future callers make that distinction explicit.

## Scope decisions worth flagging

- **Single metric for now.** `latency_budget` checks total provider-call duration per turn (LLM round-trip including in-turn tool-call rounds). It's a coarse "is this turn fast enough" signal — good for regression gates and cross-provider comparison.
- **TTFB / first-audio / end-of-turn** would each need their own metric capture in the provider stages plus a richer assertion shape. Flagged in the how-to as a follow-up rather than blocking this PR.

## Surfaces covered

- **`serve`** — primary marketing surface; doc opens with "run `promptarena serve` in this directory."
- **TUI** — `run --tui` documented as the dev loop.
- **`run --ci`** — headless + HTML report; CI snippet uses this path (keyless, fork-safe).

## Test plan

- [x] `latency_budget` assertion now passes against any provider that sets `LatencyMs` (all of them, via the standard provider stage timing)
- [x] Three new unit tests: bridges positive `LatencyMs`, bridges `LatencyMs == 0`, and reports "not present" when no assistant message exists
- [x] One test for the `latestAssistantLatencyMs` helper covering empty, no-assistant, single-assistant, multi-assistant (uses latest), and zero-latency cases
- [x] `promptarena run --ci` passes with all 3 latency assertions green
- [x] Lint clean
- [x] Coverage 88% on `eval_orchestrator.go`
- [ ] CI passes
