### PR TITLE
feat(examples,docs): voice provider bake-off demo

### DIFF
--- a/docs/src/content/docs/arena/how-to/index.md
+++ b/docs/src/content/docs/arena/how-to/index.md
@@ -81,6 +81,11 @@ Walk through `examples/duplex-streaming/scenarios/duplex-tools.scenario.yaml`: a
 Walk through `examples/voice-red-team/`: `pii_leakage` wired as a guardrail in the pack, scenarios assert the firing via `guardrail_triggered`. Same primitive enforces in production AND fires as a test signal — the three-role pattern (eval / guardrail / assertion) end-to-end.
 </div>
 
+<div class="code-example" markdown="1">
+### [Run the same scenario across multiple providers](/arena/how-to/voice-bake-off/)
+Walk through `examples/voice-bake-off/`: one scenario, two providers, side-by-side report. Adding a provider is one YAML line; per-provider thresholds use `when:` clauses. The fan-out shape stays the same whether you're comparing mocks or real duplex providers.
+</div>
+
 ## Session Recording
 
 <div class="code-example" markdown="1">

--- a/docs/src/content/docs/arena/how-to/voice-bake-off.md
+++ b/docs/src/content/docs/arena/how-to/voice-bake-off.md
@@ -1,0 +1,120 @@
+---
+title: Run the same scenario across multiple providers
+description: Side-by-side provider comparison without leaving the scenario file. One scenario, N providers, one report — pick the winner on real metrics.
+---
+
+This how-to walks through `examples/voice-bake-off/` — the same three-turn support call registered twice (`mock-fast`, `mock-slow`), with per-turn `latency_budget` and `max_length` assertions on each. Arena fans the scenario out automatically; the HTML report shows the providers side by side.
+
+## What it proves
+
+Provider selection for voice is hard because the failure modes are model-specific: one provider is faster but rambles; another is slower but tighter; a third is great at tool calls but slow on first-audio. Static comparison charts go stale; running the same scenario across providers is the only way to evaluate them on *your* prompt, *your* tools, *your* assertions.
+
+PromptArena makes that a one-line change. Register multiple providers in `config.arena.yaml`; every scenario fans out across all of them. Assertions run per-provider, the report shows them on one axis, and you can tune thresholds per provider with `when:` clauses.
+
+## Run it
+
+```bash
+cd examples/voice-bake-off
+promptarena serve
+```
+
+The web UI loads the scenario and shows runs grouped by provider. Click each provider to see its responses and metrics in the timeline view.
+
+Headless:
+
+```bash
+promptarena run --ci --formats html,json
+open out/report.html
+```
+
+The HTML report's run table groups by provider. Expand each turn to see the response and the per-turn `latency_ms` / response length from each provider — the side-by-side comparison.
+
+## The fan-out
+
+In `config.arena.yaml`:
+
+```yaml
+providers:
+  - file: providers/mock-fast.provider.yaml
+  - file: providers/mock-slow.provider.yaml
+```
+
+That's it. The scenario doesn't mention providers; Arena pairs every scenario with every registered provider and runs each combination. To add a third provider, drop in a new provider YAML file and add one more line.
+
+## Per-provider thresholds
+
+If a provider has tighter or looser real-world limits, narrow the assertion with `when:`:
+
+```yaml
+- type: latency_budget
+  params:
+    max_ms: 800
+  when:
+    provider: openai-realtime
+- type: latency_budget
+  params:
+    max_ms: 1500
+  when:
+    provider: gemini-live
+```
+
+Useful for migration testing ("we're moving from Gemini Live to OpenAI Realtime — does the new provider stay inside the same budget on our actual prompts?") and for cross-provider bake-offs where each has a different baseline.
+
+## Adding real voice providers
+
+The default config uses text mock providers so the demo runs keyless. To run across real voice providers:
+
+1. Add provider configs — e.g. `providers/openai-realtime.provider.yaml`:
+
+   ```yaml
+   apiVersion: promptkit.altairalabs.ai/v1alpha1
+   kind: Provider
+   metadata:
+     name: openai-realtime
+   spec:
+     id: openai-realtime
+     type: openai
+     model: gpt-4o-realtime-preview
+     audio_modality: true
+   ```
+
+2. Register them in `config.arena.yaml` under `providers:`.
+3. Add a `duplex:` block to the scenario (see `examples/voice-refund-demo/scenarios/*.yaml`).
+4. Run with provider keys.
+
+## CI gate
+
+```yaml
+# .github/workflows/voice-bake-off.yml
+name: Voice bake-off
+
+on:
+  pull_request:
+    paths:
+      - 'examples/voice-bake-off/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - run: make build-arena
+      - name: Run bake-off scenarios
+        working-directory: examples/voice-bake-off
+        run: ../../bin/promptarena run --ci --formats html,json
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bake-off-report
+          path: examples/voice-bake-off/out/
+```
+
+Uploading the report as an artifact lets reviewers eyeball the per-provider responses on the PR — useful when "did the migration regress on prompt X?" is the question.
+
+## Why this matters
+
+Most eval frameworks treat "compare providers" as a separate workflow with its own UI. PromptArena treats it as a property of the scenario set: one scenario, N providers, one report. Adding a provider is one YAML line. The fan-out shape is the same whether you have two mock providers (this demo) or three real duplex providers (the live version). The scenarios don't change as you move from synthetic to real to migration testing — only the registered providers list does.

--- a/examples/voice-bake-off/README.md
+++ b/examples/voice-bake-off/README.md
@@ -1,0 +1,67 @@
+# Voice Provider Bake-Off Demo
+
+Run the same scenario across multiple providers side by side. Arena fans out the scenario over every registered provider; the HTML report shows per-provider response, latency, and assertion outcomes on one axis.
+
+## What it tests
+
+One three-turn support call, registered twice with different providers (`mock-fast`, `mock-slow`). Both run; both produce per-turn `latency_budget` and `max_length` outcomes. The report puts them side by side — same scenario, different providers, observable difference in response style, length, and timing.
+
+## Running
+
+```bash
+cd examples/voice-bake-off
+../../bin/promptarena run --ci --formats html,json
+open out/report.html
+```
+
+The report's run table groups by provider; expand each turn to see the response and the per-turn metrics from each provider.
+
+Live dev loop:
+
+```bash
+../../bin/promptarena serve   # web UI with side-by-side timeline
+../../bin/promptarena run --tui
+```
+
+## Adding real providers
+
+The default config uses text mock providers so the demo runs keyless. To run the bake-off across real voice providers:
+
+1. Add provider configs (`providers/openai-realtime.provider.yaml`, `providers/gemini-live.provider.yaml`, `providers/cartesia.provider.yaml`).
+2. Register them in `config.arena.yaml` under `providers:`.
+3. Add a `duplex:` block to `scenarios/standard-call.scenario.yaml` (see `examples/voice-refund-demo/scenarios/*.yaml` for the shape).
+4. Run with provider keys in your environment.
+
+The scenario stays the same; the I/O layer changes. The report's side-by-side view scales with the number of registered providers.
+
+## Per-provider thresholds
+
+If a provider has tighter or looser real-world limits than the rest, narrow the assertion with `when:`:
+
+```yaml
+- type: latency_budget
+  params:
+    max_ms: 800
+  when:
+    provider: openai-realtime
+- type: latency_budget
+  params:
+    max_ms: 1500
+  when:
+    provider: gemini-live
+```
+
+## File layout
+
+```
+voice-bake-off/
+├── README.md
+├── config.arena.yaml              # both providers registered here
+├── mock-responses-fast.yaml       # short, snappy responses
+├── mock-responses-slow.yaml       # longer, more conversational
+├── prompts/support-agent.yaml
+├── providers/
+│   ├── mock-fast.provider.yaml
+│   └── mock-slow.provider.yaml
+└── scenarios/standard-call.scenario.yaml
+```

--- a/examples/voice-bake-off/config.arena.yaml
+++ b/examples/voice-bake-off/config.arena.yaml
@@ -1,0 +1,36 @@
+# Voice Provider Bake-Off Demo
+#
+# Run the same scenario across multiple providers and compare them
+# side by side. Arena fans out the scenario over every registered
+# provider; the HTML report shows per-provider response, latency, and
+# assertion outcomes on one axis.
+#
+# Default config uses two text mock providers (mock-fast, mock-slow)
+# so the demo runs deterministically without API keys. To run the
+# bake-off across real voice providers (OpenAI Realtime, Gemini Live,
+# Cartesia), see the how-to — swapping in duplex providers + a
+# duplex: block in the scenario is the only change needed.
+#
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: voice-bake-off
+
+spec:
+  prompt_configs:
+    - id: support-agent
+      file: prompts/support-agent.yaml
+
+  providers:
+    - file: providers/mock-fast.provider.yaml
+    - file: providers/mock-slow.provider.yaml
+
+  scenarios:
+    - file: scenarios/standard-call.scenario.yaml
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 256
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/voice-bake-off/mock-responses-fast.yaml
+++ b/examples/voice-bake-off/mock-responses-fast.yaml
@@ -1,0 +1,6 @@
+scenarios:
+  standard-call:
+    turns:
+      1: "Hi, I'd be glad to help. What's the issue?"
+      2: "Understood — let me check that for you."
+      3: "All sorted. Anything else?"

--- a/examples/voice-bake-off/mock-responses-slow.yaml
+++ b/examples/voice-bake-off/mock-responses-slow.yaml
@@ -1,0 +1,6 @@
+scenarios:
+  standard-call:
+    turns:
+      1: "Hello there, and welcome to our customer support service! I'm so glad you reached out today, and I'm absolutely here to help you with whatever you need assistance with. Before we get started, could you please share a little more detail about the specific issue you're experiencing today so I can make sure we get this sorted out for you efficiently?"
+      2: "Thank you so much for sharing those details with me. Let me take a careful look at your account and the situation surrounding the issue you've described. This might take just a brief moment as I want to make absolutely sure I get this right for you and provide the most accurate information possible."
+      3: "Wonderful, I'm so pleased we were able to get this sorted out together! Please don't hesitate to reach back out to us if there's anything else you need help with going forward. Have a truly fantastic rest of your day, and thank you so much for choosing us!"

--- a/examples/voice-bake-off/prompts/support-agent.yaml
+++ b/examples/voice-bake-off/prompts/support-agent.yaml
@@ -1,0 +1,11 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: support-agent
+spec:
+  task_type: "support"
+  version: "v1.0.0"
+  description: "Short-turn support agent driven across multiple providers."
+
+  system_template: |
+    You are a customer support agent. Keep replies concise and polite.

--- a/examples/voice-bake-off/providers/mock-fast.provider.yaml
+++ b/examples/voice-bake-off/providers/mock-fast.provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-fast
+spec:
+  id: mock-fast
+  type: mock
+  model: mock-fast-1
+  additional_config:
+    mock_config: mock-responses-fast.yaml
+  defaults:
+    temperature: 0.1
+    max_tokens: 256
+    top_p: 1.0

--- a/examples/voice-bake-off/providers/mock-slow.provider.yaml
+++ b/examples/voice-bake-off/providers/mock-slow.provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-slow
+spec:
+  id: mock-slow
+  type: mock
+  model: mock-slow-1
+  additional_config:
+    mock_config: mock-responses-slow.yaml
+  defaults:
+    temperature: 0.1
+    max_tokens: 256
+    top_p: 1.0

--- a/examples/voice-bake-off/scenarios/standard-call.scenario.yaml
+++ b/examples/voice-bake-off/scenarios/standard-call.scenario.yaml
@@ -1,0 +1,41 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: standard-call
+spec:
+  id: standard-call
+  task_type: support
+  description: "Standard 3-turn call. Run side-by-side across registered providers; the report shows per-provider response + latency + assertion outcomes on one axis."
+
+  turns:
+    - role: user
+      content: "Hi, I need help with my account."
+      assertions:
+        - type: latency_budget
+          params:
+            max_ms: 2000
+          message: "Turn must respond within 2s"
+        - type: max_length
+          params:
+            max_characters: 600
+          message: "Reply should stay within 600 chars — voice replies over this start to feel robotic"
+
+    - role: user
+      content: "My account ID is ACC-12345."
+      assertions:
+        - type: latency_budget
+          params:
+            max_ms: 2000
+        - type: max_length
+          params:
+            max_characters: 600
+
+    - role: user
+      content: "Great, thank you."
+      assertions:
+        - type: latency_budget
+          params:
+            max_ms: 2000
+        - type: max_length
+          params:
+            max_characters: 600


### PR DESCRIPTION
## Summary

Adds `examples/voice-bake-off/` — one scenario, two providers, side-by-side report. Implements #1152.

Two mock providers (`mock-fast`, `mock-slow`) with different response styles drive the same three-turn support call. Arena fans the scenario out automatically; the HTML report shows both providers' responses + per-turn `latency_ms` + per-turn response length on one axis.

## What's documented

- The fan-out shape: register N providers, scenario runs N times.
- Per-provider thresholds via the `when:` clause.
- The swap to real duplex providers (OpenAI Realtime, Gemini Live, Cartesia) — provider YAML + duplex block, scenario stays the same.

## Test plan

- [x] `promptarena run --ci` passes with both providers, all assertions green
- [x] HTML report renders both providers side by side
- [x] Cross-link added to the voice section of the how-to index
- [x] No Go changes
- [ ] CI passes
