### PR TITLE
feat(examples,docs): text negotiation demo

### DIFF
--- a/docs/src/content/docs/arena/how-to/index.md
+++ b/docs/src/content/docs/arena/how-to/index.md
@@ -117,6 +117,13 @@ Configure MCP servers in Arena for integration testing with tool filtering, time
 Test agent-to-agent delegation with mock or remote A2A agents, including authentication, headers, and skill filtering.
 </div>
 
+## Multi-Turn Testing
+
+<div class="code-example" markdown="1">
+### [Test agent negotiation with scripted or self-play opponents](/arena/how-to/text-negotiation/)
+Walk through `examples/text-negotiation/`: a four-turn rental-price negotiation with conversation-outcome assertions. Default runs deterministically against a mock landlord; the how-to documents the swap to real LLM-driven self-play via `role: selfplay-user` and a persona.
+</div>
+
 ## Automation
 
 <div class="code-example" markdown="1">

--- a/docs/src/content/docs/arena/how-to/text-negotiation.md
+++ b/docs/src/content/docs/arena/how-to/text-negotiation.md
@@ -1,0 +1,156 @@
+---
+title: Test agent negotiation with scripted or self-play opponents
+description: Two agents over many turns, with conversation-outcome assertions. Same scenario shape works for scripted CI and real LLM-driven self-play.
+---
+
+This how-to walks through `examples/text-negotiation/` — a four-turn rental-price negotiation. The default config runs deterministically against a mock landlord; the how-to documents the swap to real LLM-driven self-play.
+
+## What it proves
+
+Single-turn eval misses negotiation entirely: the failure mode is *trajectory*, not response quality. Did the agent cave under pressure? Did it secure the term commitment? Did it stop above its reservation price?
+
+PromptArena tests negotiations as conversations:
+
+- **Both sides** are first-class. The tenant side is either scripted (deterministic CI) or `selfplay-user` with a persona (real LLM-driven). The landlord side is your prompt config.
+- **Multi-turn** is the default. Scenarios encode a sequence of user turns; conversation_assertions evaluate the end state.
+- **Outcome assertions** catch what matters: did the deal land above the reservation, did the term commitment get secured, did either side make a forbidden capitulation move.
+
+## Run it
+
+```bash
+cd examples/text-negotiation
+promptarena serve
+```
+
+`serve` loads the scenario. The TUI is good for the dev loop:
+
+```bash
+promptarena run --tui
+```
+
+Headless / CI:
+
+```bash
+promptarena run --ci --formats html,json
+open out/report.html
+```
+
+Keyless: the default config uses a mock landlord with scripted responses.
+
+## The assertion shape
+
+```yaml
+conversation_assertions:
+  - type: content_includes
+    params:
+      patterns: ["twenty-four fifty"]
+    message: "Final deal must land at the negotiated price"
+
+  - type: content_includes
+    params:
+      patterns: ["twelve-month"]
+    message: "Final deal must include the 12-month commitment"
+
+  - type: content_excludes
+    params:
+      patterns: ["I accept twenty-three hundred", "twenty-three hundred works"]
+    message: "Landlord must not capitulate on the below-reservation offer"
+```
+
+All three at conversation level — they check the *end state*, not per-turn behaviour. Negotiations succeed or fail by the deal that lands; per-turn checks tend to over-constrain the agent.
+
+For stricter contracts, layer in `llm_judge_session` with criteria over the full conversation:
+
+```yaml
+- type: llm_judge_session
+  params:
+    criteria: |
+      Did the landlord maintain a professional negotiation posture
+      across all turns, avoiding capitulation while reaching an
+      acceptable deal? Score 1.0 if yes.
+    judge: default
+    min_score: 0.8
+```
+
+(That assertion needs a judge provider — see [the assertion catalog](/reference/checks/) for the standard judge params.)
+
+## Switching to real self-play
+
+The default scenario uses scripted user turns. To run with a real LLM driving the tenant side:
+
+1. Add a persona file:
+
+   ```yaml
+   # personas/savvy-tenant.persona.yaml
+   apiVersion: promptkit.altairalabs.ai/v1alpha1
+   kind: Persona
+   metadata:
+     name: savvy-tenant
+   spec:
+     id: savvy-tenant
+     description: "Cost-conscious tenant negotiating rent."
+     system_template: |
+       You are a tenant negotiating monthly rent. Target $2300/month
+       with a 12-month lease. Be polite but firm; don't accept above
+       $2500. If the landlord won't budge below $2500, walk away.
+   ```
+
+2. Add a real text-LLM provider:
+
+   ```yaml
+   # providers/openai-gpt4o-mini-text.provider.yaml
+   apiVersion: promptkit.altairalabs.ai/v1alpha1
+   kind: Provider
+   metadata:
+     name: openai-gpt4o-mini-text
+   spec:
+     id: openai-gpt4o-mini-text
+     type: openai
+     model: gpt-4o-mini
+   ```
+
+3. Replace the scripted user turns with a `selfplay-user` block:
+
+   ```yaml
+   turns:
+     - role: selfplay-user
+       persona: savvy-tenant
+       turns: 4
+   ```
+
+4. Run with `OPENAI_API_KEY` in your environment.
+
+The assertions stay the same. The persona-driver LLM generates new content per turn; the landlord responds; the conversation evolves dynamically. The report shows each persona-driven turn — useful for spotting cases where the persona behaves unexpectedly.
+
+## CI gate
+
+```yaml
+# .github/workflows/text-negotiation.yml
+name: Text negotiation
+
+on:
+  pull_request:
+    paths:
+      - 'examples/text-negotiation/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - run: make build-arena
+      - name: Run text-negotiation
+        working-directory: examples/text-negotiation
+        run: ../../bin/promptarena run --ci --formats json
+```
+
+Keyless and fork-safe with the default scripted config.
+
+## Extending it
+
+- **Reservation-price assertions**: instead of asserting on specific phrases, parse the final agreed amount and assert numerically. `tool_calls_with_args` works well if the agent ends the negotiation with a `record_agreement(amount: ...)` tool call.
+- **Walk-away scenarios**: scripted tenant offers $2000; assert the landlord ends the conversation. `content_includes` with words like "won't be able to make this work" / "not the right fit."
+- **Adversarial tenants**: persona variants — aggressive, indecisive, deadline-pressured. Same landlord, different self-play personas, different outcome profiles.

--- a/examples/text-negotiation/README.md
+++ b/examples/text-negotiation/README.md
@@ -1,0 +1,61 @@
+# Text Negotiation Demo
+
+Multi-turn text negotiation: a tenant probes a landlord agent over four turns of rent haggling. The default config runs deterministically against a mock provider (scripted landlord responses) — assertions check that the deal lands at the right price with the right commitment.
+
+## What it tests
+
+A `rental-negotiation` scenario, four turns: tenant opens with an interest question, lowballs at $2300 (below the landlord's $2400 reservation), counter-offers at $2400, then accepts $2450. The mock landlord stays above the reservation price and secures the 12-month lease.
+
+Conversation-level assertions:
+
+- **Outcome** — final deal contains "$2450" (deal lands above reservation).
+- **Commitment** — "twelve-month" appears (lease term secured).
+- **Hygiene** — no explicit capitulation phrases like "I accept twenty-three hundred."
+
+## Running
+
+```bash
+cd examples/text-negotiation
+../../bin/promptarena run --ci --formats html,json
+open out/report.html
+```
+
+Live dev loop:
+
+```bash
+../../bin/promptarena serve
+../../bin/promptarena run --tui
+```
+
+## Switching to real self-play
+
+The default scenario uses **scripted user turns** for the tenant — a faithful four-turn negotiation script. Real self-play uses `role: selfplay-user` (or `role: gemini-user` etc.) with a persona, driven by a real text LLM that sees the conversation and generates new content per turn.
+
+To convert the demo:
+
+1. Add a persona (`personas/savvy-tenant.persona.yaml`) describing the negotiator's strategy.
+2. Add a provider for the persona's LLM (real text provider — `providers/openai-gpt4o-mini-text.provider.yaml`).
+3. Replace the scripted user turns with one `selfplay-user` block:
+
+```yaml
+turns:
+  - role: selfplay-user
+    persona: savvy-tenant
+    turns: 4
+```
+
+4. Run with `OPENAI_API_KEY` (or equivalent) in your environment. Each persona-side turn becomes LLM-generated, the landlord (still mock or also a real LLM) responds, and the conversation evolves dynamically.
+
+The assertions stay the same — they check the conversation's outcome, not which path got there.
+
+## File layout
+
+```
+text-negotiation/
+├── README.md
+├── config.arena.yaml
+├── mock-responses.yaml
+├── prompts/landlord-agent.yaml
+├── providers/mock-provider.yaml
+└── scenarios/rental-negotiation.scenario.yaml
+```

--- a/examples/text-negotiation/config.arena.yaml
+++ b/examples/text-negotiation/config.arena.yaml
@@ -1,0 +1,31 @@
+# Text Self-Play Negotiation Demo
+#
+# A multi-turn rental-price negotiation. The default config uses a
+# mock provider for the counterparty (deterministic CI) and scripted
+# user turns for the negotiator side, so the scenario runs without
+# provider keys. The how-to documents the swap to a real LLM-driven
+# persona (role: selfplay-user with a real-text provider) for true
+# self-play.
+#
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: text-negotiation
+
+spec:
+  prompt_configs:
+    - id: landlord-agent
+      file: prompts/landlord-agent.yaml
+
+  providers:
+    - file: providers/mock-provider.yaml
+
+  scenarios:
+    - file: scenarios/rental-negotiation.scenario.yaml
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 256
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/text-negotiation/mock-responses.yaml
+++ b/examples/text-negotiation/mock-responses.yaml
@@ -1,0 +1,11 @@
+# Scripted landlord responses across a four-turn negotiation. Models a
+# competent counterparty who refuses to crater on price and lands the
+# deal at $2450 with a 12-month commitment — meeting the reservation
+# price ($2400) with margin.
+scenarios:
+  rental-negotiation:
+    turns:
+      1: "Thanks for your interest in the unit. We're listing at twenty-six hundred a month on a twelve-month lease. The location is excellent and we have other applicants — what works for you?"
+      2: "I appreciate the offer, but twenty-three hundred is below where I can land. I could come down to twenty-five hundred on a twelve-month lease — that's already a hundred off list."
+      3: "Twenty-four hundred is too thin for me to make work given utility and maintenance costs. I can do twenty-four fifty on a twelve-month with the first month due at signing. Final position."
+      4: "Wonderful — let's get the paperwork started. Twenty-four fifty a month, twelve-month lease, first month due at signing. I'll send the agreement over within the hour."

--- a/examples/text-negotiation/prompts/landlord-agent.yaml
+++ b/examples/text-negotiation/prompts/landlord-agent.yaml
@@ -1,0 +1,21 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: landlord-agent
+spec:
+  task_type: "negotiation"
+  version: "v1.0.0"
+  description: "Landlord agent negotiating rent. Reservation price $2400, walks below $2200."
+
+  system_template: |
+    You are a landlord negotiating monthly rent for a 2-bedroom unit.
+
+    Constraints:
+      - Listed at $2600/month.
+      - Reservation price: $2400/month (anything below this is unacceptable).
+      - You'll walk away if the prospective tenant asks below $2200.
+      - Try to get the tenant to commit to a 12-month lease at the highest
+        rate they'll accept.
+      - Be polite but firm. Never reveal your reservation price.
+
+    Reply with one short paragraph per turn — concise, business-like.

--- a/examples/text-negotiation/providers/mock-provider.yaml
+++ b/examples/text-negotiation/providers/mock-provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-landlord
+spec:
+  id: mock-landlord
+  type: mock
+  model: mock-model
+  additional_config:
+    mock_config: mock-responses.yaml
+  defaults:
+    temperature: 0.1
+    max_tokens: 256
+    top_p: 1.0

--- a/examples/text-negotiation/scenarios/rental-negotiation.scenario.yaml
+++ b/examples/text-negotiation/scenarios/rental-negotiation.scenario.yaml
@@ -1,0 +1,45 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: rental-negotiation
+spec:
+  id: rental-negotiation
+  task_type: negotiation
+  description: "Four-turn rent negotiation. Asserts that the landlord stays above $2400 and the deal lands on a 12-month commitment."
+
+  turns:
+    - role: user
+      content: "Hi, I'm interested in the listing. What's the asking price?"
+      assertions:
+        - type: content_includes
+          params:
+            patterns: ["twenty-six hundred"]
+          message: "Landlord must open at the listed price"
+
+    - role: user
+      content: "That's above my budget. I could do twenty-three hundred on a twelve-month lease."
+
+    - role: user
+      content: "Could we meet in the middle at twenty-four hundred?"
+
+    - role: user
+      content: "Twenty-four fifty works for me. Let's proceed."
+
+  conversation_assertions:
+    # Outcome: deal landed above the reservation price.
+    - type: content_includes
+      params:
+        patterns: ["twenty-four fifty"]
+      message: "Final deal must land at the negotiated price"
+
+    # Outcome: twelve-month commitment secured.
+    - type: content_includes
+      params:
+        patterns: ["twelve-month"]
+      message: "Final deal must include the 12-month commitment"
+
+    # Negotiation hygiene: landlord didn't crater under offer.
+    - type: content_excludes
+      params:
+        patterns: ["I accept twenty-three hundred", "twenty-three hundred works"]
+      message: "Landlord must not capitulate on the below-reservation offer"


### PR DESCRIPTION
## Summary

Adds `examples/text-negotiation/` — a four-turn rental-price negotiation with conversation-level outcome assertions. Implements #1155 (Phase 2 first cell).

Default config uses a mock landlord with scripted responses (deterministic CI). The how-to documents the swap to real LLM-driven self-play via `role: selfplay-user` and a persona — the assertions stay the same.

## Test plan

- [x] `promptarena run --ci` passes with all three conversation-level assertions green
- [x] Cross-link added to a new "Multi-Turn Testing" section in the how-to index
- [x] No Go changes
- [ ] CI passes
