### PR TITLE
feat(examples,docs): model migration regression demo

### DIFF
--- a/docs/src/content/docs/arena/how-to/index.md
+++ b/docs/src/content/docs/arena/how-to/index.md
@@ -49,6 +49,11 @@ Use assertions and custom validators to verify LLM response quality.
 Turn recorded Arena runs into mock provider YAML for deterministic, cost-free replays.
 </div>
 
+<div class="code-example" markdown="1">
+### [Gate model migrations on a regression suite](/arena/how-to/model-migration/)
+Walk through `examples/model-migration/`: run the same scenarios against the old and new model side by side. CI exits non-zero if the new model breaks an assertion the old one passed.
+</div>
+
 ## Voice Testing
 
 <div class="code-example" markdown="1">

--- a/docs/src/content/docs/arena/how-to/model-migration.md
+++ b/docs/src/content/docs/arena/how-to/model-migration.md
@@ -1,0 +1,111 @@
+---
+title: Gate model migrations on a regression suite
+description: Run the same scenarios against the old and new model side by side. CI fails if the new model breaks an assertion the old one passed.
+---
+
+This how-to walks through `examples/model-migration/` — a small regression suite that runs the same scenarios against two mock providers simulating a model upgrade. The pattern works for any "did this swap break anything" question: GPT-4o → 4o-mini, Claude 3.5 → 4, OpenAI → Anthropic.
+
+## What it proves
+
+Migration testing has a sneaky failure mode: most prompts still work after a model swap, so you trust the change. The 5% that broke produce subtly wrong outputs that pass visual review and only get caught in production.
+
+PromptArena makes migration a real gate:
+
+- One scenario set, multiple providers registered, one report.
+- Identical assertions per scenario; each must pass on every registered model.
+- If any model fails an assertion the others passed, the report flags it and `run --ci` exits non-zero.
+- Pin the suite in CI before the migration PR can merge.
+
+## Run it
+
+```bash
+cd examples/model-migration
+promptarena serve
+```
+
+The web UI groups runs by provider; expand a scenario to see each model's output and assertion results.
+
+Headless / CI:
+
+```bash
+promptarena run --ci --formats html,json
+open out/report.html
+```
+
+Keyless: both providers are mock. The report shows side-by-side results.
+
+## What a regression looks like
+
+The default config has both mock providers passing all assertions. To see how a regression surfaces, edit `mock-responses-v2.yaml` to make the new model break the one-word format:
+
+```yaml
+# Was: "technical"
+# Now: model adds explanation despite the prompt's instruction
+tech-inquiry:
+  turns:
+    1: "This sounds like a technical issue with the application."
+```
+
+Re-run: the `max_length` assertion fires on v2 but not v1 — the regression is caught:
+
+```
+v1 / billing-inquiry: ✓ content_includes(billing) ✓ max_length(<30)
+v1 / tech-inquiry:    ✓ content_includes(technical) ✓ max_length(<30)
+v2 / billing-inquiry: ✓ content_includes(billing) ✓ max_length(<30)
+v2 / tech-inquiry:    ✓ content_includes(technical) ✗ max_length(60 > 30)
+Error: execution failed: 1 runs had errors
+```
+
+The CI snippet below uses `set -e` so the migration PR fails until the prompt is reworked or the new model swapped out.
+
+## Adding real models
+
+Swap the mock providers in `config.arena.yaml`:
+
+```yaml
+providers:
+  - file: providers/openai-gpt4o.provider.yaml         # incumbent
+  - file: providers/openai-gpt4o-mini.provider.yaml    # candidate
+  - file: providers/anthropic-claude-haiku.provider.yaml  # alternate candidate
+```
+
+Same scenarios, same assertions. The report fans out across every provider; CI gates on all of them passing.
+
+## CI gate
+
+```yaml
+# .github/workflows/model-migration.yml
+name: Model migration regression
+
+on:
+  pull_request:
+    paths:
+      - 'examples/model-migration/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - run: make build-arena
+      - name: Run migration regression suite
+        working-directory: examples/model-migration
+        run: ../../bin/promptarena run --ci --formats html,json
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: model-migration-report
+          path: examples/model-migration/out/
+```
+
+Uploading the report as an artifact lets reviewers eyeball the per-model output on the PR — useful when the question is "did this prompt regress on the new model?" rather than just "did anything fail?"
+
+## Extending it
+
+- **Add a third model**: drop in `providers/anthropic-claude-haiku.provider.yaml`, register it, run. The fan-out scales automatically.
+- **Behavior-equivalent assertions**: `outcome_equivalent` lets you assert that the agent's tool-call pattern (or workflow state, or content hash) matches an expected outcome — useful for migrating between models without the prompt changing.
+- **Per-model thresholds**: if a new model has known stricter / looser behaviour on certain assertions, use `when:` clauses to scope thresholds per provider (see [the bake-off how-to](/arena/how-to/voice-bake-off/) for the pattern).

--- a/examples/model-migration/README.md
+++ b/examples/model-migration/README.md
@@ -1,0 +1,56 @@
+# Model Migration Regression Demo
+
+Run the same scenarios against multiple model versions; gate on a common assertion bar. If any model fails an assertion the others pass, the migration introduced a regression.
+
+## What it tests
+
+Two scenarios (`billing-inquiry`, `tech-inquiry`) registered with two mock providers simulating an upgrade (`gpt-4o-2024-08` → `gpt-4o-mini-2024-12`). Each scenario classifies a support query into a single category word; assertions check the right category appears AND the response is short (no explanation).
+
+Both providers pass in the default config. The how-to walks through what a regression would look like (e.g., a newer model that adds explanatory text despite the one-word instruction) and how to catch it in CI.
+
+## Running
+
+```bash
+cd examples/model-migration
+../../bin/promptarena run --ci --formats html,json
+open out/report.html
+```
+
+The HTML report groups runs by provider. Expand each scenario to see the per-model output. A regression shows as a red cell on one model and a green cell on the others.
+
+Live dev loop:
+
+```bash
+../../bin/promptarena serve
+../../bin/promptarena run --tui
+```
+
+## Adding real models
+
+Swap the mock providers for real ones to gate a real migration:
+
+```yaml
+providers:
+  - file: providers/openai-gpt4o.provider.yaml
+  - file: providers/openai-gpt4o-mini.provider.yaml
+  - file: providers/anthropic-claude-haiku.provider.yaml
+```
+
+Same scenarios, same assertions. The report shows which model passes which test; CI exits non-zero if any cell fails.
+
+## File layout
+
+```
+model-migration/
+├── README.md
+├── config.arena.yaml
+├── mock-responses-v1.yaml         # gpt-4o-2024-08 baseline
+├── mock-responses-v2.yaml         # gpt-4o-mini-2024-12 candidate
+├── prompts/support-classifier.yaml
+├── providers/
+│   ├── model-v1.provider.yaml
+│   └── model-v2.provider.yaml
+└── scenarios/
+    ├── billing-inquiry.scenario.yaml
+    └── tech-inquiry.scenario.yaml
+```

--- a/examples/model-migration/config.arena.yaml
+++ b/examples/model-migration/config.arena.yaml
@@ -1,0 +1,33 @@
+# Model Migration Regression Demo
+#
+# Run the same scenario set against multiple model versions and gate
+# on a common assertion bar. If any model fails an assertion that
+# the others pass, you've caught a regression introduced by the model
+# swap. The default config uses two mock providers simulating an
+# upgrade ("gpt-4o" -> "gpt-4o-mini"); the how-to documents the
+# swap to real providers.
+#
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: model-migration
+
+spec:
+  prompt_configs:
+    - id: support-classifier
+      file: prompts/support-classifier.yaml
+
+  providers:
+    - file: providers/model-v1.provider.yaml
+    - file: providers/model-v2.provider.yaml
+
+  scenarios:
+    - file: scenarios/billing-inquiry.scenario.yaml
+    - file: scenarios/tech-inquiry.scenario.yaml
+
+  defaults:
+    temperature: 0.0
+    max_tokens: 64
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/model-migration/mock-responses-v1.yaml
+++ b/examples/model-migration/mock-responses-v1.yaml
@@ -1,0 +1,9 @@
+# v1 (gpt-4o-2024-08) — well-behaved baseline. Classifies cleanly with
+# the one-word format the prompt asks for.
+scenarios:
+  billing-inquiry:
+    turns:
+      1: "billing"
+  tech-inquiry:
+    turns:
+      1: "technical"

--- a/examples/model-migration/mock-responses-v2.yaml
+++ b/examples/model-migration/mock-responses-v2.yaml
@@ -1,0 +1,12 @@
+# v2 (gpt-4o-mini-2024-12) — newer/cheaper model. Both responses pass
+# the assertion bar; the report shows the per-model results side by
+# side. The how-to walks through what a regression would look like —
+# remove "technical" from the tech-inquiry response, for instance —
+# and how CI would flag it.
+scenarios:
+  billing-inquiry:
+    turns:
+      1: "billing"
+  tech-inquiry:
+    turns:
+      1: "technical"

--- a/examples/model-migration/prompts/support-classifier.yaml
+++ b/examples/model-migration/prompts/support-classifier.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: support-classifier
+spec:
+  task_type: "classify"
+  version: "v1.0.0"
+  description: "Classify support queries into one of: billing, technical, general. One word reply."
+
+  system_template: |
+    Classify the incoming support query into one of these categories:
+    billing, technical, general
+
+    Reply with the single category name in lowercase. No other words.

--- a/examples/model-migration/providers/model-v1.provider.yaml
+++ b/examples/model-migration/providers/model-v1.provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: model-v1
+spec:
+  id: model-v1
+  type: mock
+  model: gpt-4o-2024-08
+  additional_config:
+    mock_config: mock-responses-v1.yaml
+  defaults:
+    temperature: 0.0
+    max_tokens: 64
+    top_p: 1.0

--- a/examples/model-migration/providers/model-v2.provider.yaml
+++ b/examples/model-migration/providers/model-v2.provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: model-v2
+spec:
+  id: model-v2
+  type: mock
+  model: gpt-4o-mini-2024-12
+  additional_config:
+    mock_config: mock-responses-v2.yaml
+  defaults:
+    temperature: 0.0
+    max_tokens: 64
+    top_p: 1.0

--- a/examples/model-migration/scenarios/billing-inquiry.scenario.yaml
+++ b/examples/model-migration/scenarios/billing-inquiry.scenario.yaml
@@ -1,0 +1,21 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: billing-inquiry
+spec:
+  id: billing-inquiry
+  task_type: classify
+  description: "Both models should classify billing inquiry as 'billing' and return one word."
+
+  turns:
+    - role: user
+      content: "I was double-charged on my last invoice."
+      assertions:
+        - type: content_includes
+          params:
+            patterns: ["billing"]
+          message: "Output must classify as billing"
+        - type: max_length
+          params:
+            max_characters: 30
+          message: "Output must be a single category word (no explanation)"

--- a/examples/model-migration/scenarios/tech-inquiry.scenario.yaml
+++ b/examples/model-migration/scenarios/tech-inquiry.scenario.yaml
@@ -1,0 +1,21 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: tech-inquiry
+spec:
+  id: tech-inquiry
+  task_type: classify
+  description: "Both models should classify a technical inquiry as 'technical' and return one word."
+
+  turns:
+    - role: user
+      content: "The mobile app crashes every time I open it."
+      assertions:
+        - type: content_includes
+          params:
+            patterns: ["technical"]
+          message: "Output must classify as technical"
+        - type: max_length
+          params:
+            max_characters: 30
+          message: "Output must be a single category word (no explanation)"


### PR DESCRIPTION
## Summary

Adds `examples/model-migration/` — same scenarios fanned across two mock providers simulating a model upgrade. Implements #1158.

Two scenarios (`billing-inquiry`, `tech-inquiry`) registered with two providers (`model-v1: gpt-4o-2024-08` and `model-v2: gpt-4o-mini-2024-12`). Common assertion bar: classify into the right category AND respond in one word (`max_length: 30`).

Both mock providers pass in the default config — the demo's CI exits 0. The how-to walks through what a regression looks like (newer model adds explanatory text despite the prompt's instruction; `max_length` fires on v2 but not v1) and the CI pattern that catches it.

## Test plan

- [x] `promptarena run --ci` passes with both providers green
- [x] Cross-link added to Testing Strategies in the how-to index
- [x] No Go changes
- [ ] CI passes
