### PR TITLE
feat(examples,docs): RAG agent assertions demo

### DIFF
--- a/docs/src/content/docs/arena/how-to/rag-agent.md
+++ b/docs/src/content/docs/arena/how-to/rag-agent.md
@@ -1,0 +1,141 @@
+---
+title: Test RAG agents with the standard primitive suite
+description: Exercise faithfulness, answer_relevancy, contextual_precision/recall/relevancy, and hallucination as scenario assertions. Keyless CI via a mock judge; real LLM judge for production runs.
+---
+
+This how-to walks through `examples/rag-agent/` — the full named RAG primitive suite (`faithfulness`, `answer_relevancy`, `contextual_precision`, `contextual_recall`, `contextual_relevancy`, `hallucination`) exercised as scenario assertions. The vocabulary buyers from DeepEval / Ragas expect, wired in PromptArena.
+
+## What it proves
+
+RAG eval frameworks compete on the primitive catalog: faithfulness, answer relevancy, contextual recall, hallucination. PromptArena ships those primitives in `runtime/evals/handlers/` (added in #1145) as thin wrappers over `llm_judge` with hardened default prompts adapted from public DeepEval / Ragas references (Apache 2.0).
+
+Each primitive is invokable as a scenario assertion with `min_score`. The demo runs all six against a single question + answer + retrieved context, with a mock LLM judge for keyless CI.
+
+## The assertion shape
+
+```yaml
+turns:
+  - role: user
+    content: "What is the capital of France?"
+    assertions:
+      - type: faithfulness
+        params:
+          contexts:
+            - "Paris is the capital and most populous city of France."
+            - "Located on the Seine River in north-central France."
+          judge: rag-judge
+          min_score: 0.8
+
+      - type: answer_relevancy
+        params:
+          judge: rag-judge
+          min_score: 0.8
+
+      - type: contextual_precision
+        params:
+          contexts: [...]
+          judge: rag-judge
+          min_score: 0.5
+
+      # ... contextual_recall, contextual_relevancy, hallucination
+```
+
+All six assertions share the same shape — the eval handler does the work; the assertion config supplies thresholds and (for the chunk-based primitives) the context.
+
+## Three context sources
+
+Every RAG handler accepts retrieved context in three forms (preference order):
+
+1. **`contexts: [...]`** — the canonical inline list (used in the demo).
+2. **`context: "..."`** — single-chunk shorthand.
+3. **`context_field: <metadata-key>`** — look up the chunks from `evalCtx.Metadata`. Use this when a retrieval tool writes results to metadata at runtime; the assertion reads them back.
+
+For a live RAG agent, the dynamic `context_field` form is the right shape:
+
+```yaml
+- type: faithfulness
+  params:
+    context_field: retrieved_chunks
+    judge: rag-judge
+    min_score: 0.8
+```
+
+Wire your retrieval tool to set `metadata["retrieved_chunks"]` on each turn and the assertion auto-picks-up the chunks.
+
+## Run it
+
+```bash
+cd examples/rag-agent
+promptarena serve
+```
+
+Headless / CI:
+
+```bash
+promptarena run --ci --formats html,json
+open out/report.html
+```
+
+Keyless: both the RAG assistant and the LLM judge are mock providers. The mock judge returns `{"passed": true, "score": 0.92, "reasoning": "..."}` for every call; all six assertions pass with the default `min_score` thresholds.
+
+## Swapping in a real judge
+
+Replace the mock judge with a real LLM provider:
+
+```yaml
+# providers/openai-judge.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-judge
+spec:
+  id: openai-judge
+  type: openai
+  model: gpt-4o-mini
+```
+
+Update `judges:` in `config.arena.yaml`:
+
+```yaml
+judges:
+  - name: rag-judge
+    provider: openai-judge
+```
+
+Run with `OPENAI_API_KEY` set. The mock assistant can stay or get swapped too — the assertions don't care which provider produced the answer.
+
+## CI gate
+
+```yaml
+# .github/workflows/rag-agent.yml
+name: RAG agent
+
+on:
+  pull_request:
+    paths:
+      - 'examples/rag-agent/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - run: make build-arena
+      - name: Run RAG scenarios
+        working-directory: examples/rag-agent
+        run: ../../bin/promptarena run --ci --formats json
+```
+
+The default config is keyless. Swap the mock judge for a real one when you want to grade real outputs.
+
+## Naming and credit
+
+The handler default prompts are adapted from public DeepEval and Ragas reference implementations (Apache 2.0). Attribution lives in each handler's docstring. The name choices (`faithfulness`, `answer_relevancy`, `contextual_*`, `hallucination`) match the buyer-facing vocabulary in the comparison-sheet bake-offs.
+
+## Related how-tos
+
+- The [Checks Reference](/reference/checks/) has the full parameter list and surface notes for each RAG primitive.
+- The [Validate Outputs](/arena/how-to/validate-outputs/) how-to covers the broader assertion mechanism.

--- a/examples/rag-agent/README.md
+++ b/examples/rag-agent/README.md
@@ -1,0 +1,84 @@
+# RAG Agent Assertions Demo
+
+Demonstrates the full named-primitive RAG suite — `faithfulness`, `answer_relevancy`, `contextual_precision`, `contextual_recall`, `contextual_relevancy`, `hallucination` — exercised as scenario assertions against a mock RAG assistant + mock LLM judge. Keyless and deterministic; the same scenarios work against real providers with one config swap.
+
+## What it tests
+
+One scenario, one question, six RAG-specific assertions on the answer:
+
+- **`faithfulness`** — is the answer grounded in the retrieved context?
+- **`answer_relevancy`** — does the answer address the user's question?
+- **`contextual_precision`** — what fraction of retrieved chunks are relevant?
+- **`contextual_recall`** — do retrieved chunks cover the ground-truth answer?
+- **`contextual_relevancy`** — what's the mean per-chunk relevance?
+- **`hallucination`** — is the answer free of unsupported claims (1.0 = no hallucination)?
+
+Each is a thin wrapper over `llm_judge` with a hardened default prompt derived from public DeepEval / Ragas references (Apache 2.0). Default scoring is on `[0, 1]`; each assertion uses `min_score` for the pass threshold.
+
+## Running
+
+```bash
+cd examples/rag-agent
+../../bin/promptarena run --ci --formats html,json
+open out/report.html
+```
+
+Keyless: the agent is a mock provider; the judge is a mock provider too (returns a canned score of 0.92 for every call).
+
+## Swapping in a real judge
+
+For real RAG evaluation, replace the mock judge with an OpenAI / Anthropic / Gemini judge:
+
+```yaml
+# providers/openai-judge.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-judge
+spec:
+  id: openai-judge
+  type: openai
+  model: gpt-4o-mini
+```
+
+Register it in `config.arena.yaml` and update the `judges:` entry:
+
+```yaml
+judges:
+  - name: rag-judge
+    provider: openai-judge
+```
+
+Run with `OPENAI_API_KEY` in your environment. Each assertion now goes to the real LLM judge.
+
+## Dynamic retrieval
+
+The demo passes contexts inline in the scenario assertions. For a live RAG agent that decides what to retrieve at runtime, pass the chunks through metadata:
+
+1. The retrieval tool writes its results to `evalCtx.Metadata` (e.g. `metadata["retrieved_chunks"]`).
+2. The assertion uses `context_field`:
+
+```yaml
+- type: faithfulness
+  params:
+    context_field: retrieved_chunks
+    judge: rag-judge
+    min_score: 0.8
+```
+
+The RAG handlers all support three context forms in priority order: `contexts` (`[]string`), `context` (string), `context_field` (metadata key).
+
+## File layout
+
+```
+rag-agent/
+├── README.md
+├── config.arena.yaml
+├── mock-responses-assistant.yaml      # canned RAG assistant response
+├── mock-responses-judge.yaml          # canned judge JSON (score 0.92)
+├── prompts/rag-assistant.yaml
+├── providers/
+│   ├── mock-assistant.yaml
+│   └── mock-judge.yaml
+└── scenarios/paris-capital.scenario.yaml
+```

--- a/examples/rag-agent/config.arena.yaml
+++ b/examples/rag-agent/config.arena.yaml
@@ -1,0 +1,40 @@
+# RAG Agent Assertions Demo
+#
+# Exercises the named RAG primitives (faithfulness, answer_relevancy,
+# contextual_precision/recall/relevancy, hallucination) as scenario
+# assertions. The agent's answer is judged against retrieved context
+# passed inline in the scenario's assertion params.
+#
+# Runs keyless against a mock agent provider and a mock LLM judge.
+# Swap the mock judge for a real judge provider (judge_targets with
+# type: openai) for production runs against your real RAG agent.
+#
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: rag-agent
+
+spec:
+  prompt_configs:
+    - id: rag-assistant
+      file: prompts/rag-assistant.yaml
+
+  providers:
+    - file: providers/mock-assistant.yaml
+      group: default
+    - file: providers/mock-judge.yaml
+      group: judge
+
+  judges:
+    - name: rag-judge
+      provider: mock-judge
+
+  scenarios:
+    - file: scenarios/paris-capital.scenario.yaml
+
+  defaults:
+    temperature: 0.0
+    max_tokens: 256
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/rag-agent/mock-responses-assistant.yaml
+++ b/examples/rag-agent/mock-responses-assistant.yaml
@@ -1,0 +1,4 @@
+scenarios:
+  paris-capital:
+    turns:
+      1: "Paris is the capital of France."

--- a/examples/rag-agent/mock-responses-judge.yaml
+++ b/examples/rag-agent/mock-responses-judge.yaml
@@ -1,0 +1,6 @@
+# Mock LLM judge — returns a high score for every RAG assertion. Each
+# of the named RAG primitives (faithfulness, answer_relevancy,
+# contextual_precision/recall/relevancy, hallucination) wraps llm_judge
+# with a hardened default prompt; the judge sees the rendered content
+# and returns JSON.
+defaultResponse: '{"passed": true, "score": 0.92, "reasoning": "Answer is grounded in the context with no unsupported claims."}'

--- a/examples/rag-agent/prompts/rag-assistant.yaml
+++ b/examples/rag-agent/prompts/rag-assistant.yaml
@@ -1,0 +1,13 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: rag-assistant
+spec:
+  task_type: "rag"
+  version: "v1.0.0"
+  description: "RAG assistant — answers using retrieved context. Demo target for the faithfulness / answer_relevancy / contextual_* / hallucination assertions."
+
+  system_template: |
+    You are a research assistant. Answer the user's question using only
+    the supplied context. If the context does not contain the answer,
+    say so. Quote relevant snippets when useful.

--- a/examples/rag-agent/providers/mock-assistant.yaml
+++ b/examples/rag-agent/providers/mock-assistant.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-rag-assistant
+spec:
+  id: mock-rag-assistant
+  type: mock
+  model: mock-rag-model
+  additional_config:
+    mock_config: mock-responses-assistant.yaml
+  defaults:
+    temperature: 0.0
+    max_tokens: 256
+    top_p: 1.0

--- a/examples/rag-agent/providers/mock-judge.yaml
+++ b/examples/rag-agent/providers/mock-judge.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-judge
+spec:
+  id: mock-judge
+  type: mock
+  model: mock-judge-model
+  defaults:
+    temperature: 0.0
+    top_p: 1.0
+    max_tokens: 128
+  additional_config:
+    mock_config: mock-responses-judge.yaml

--- a/examples/rag-agent/scenarios/paris-capital.scenario.yaml
+++ b/examples/rag-agent/scenarios/paris-capital.scenario.yaml
@@ -1,0 +1,64 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: paris-capital
+spec:
+  id: paris-capital
+  task_type: rag
+  description: "Single-turn RAG question with the full named-primitive suite asserted on the answer."
+
+  turns:
+    - role: user
+      content: "What is the capital of France?"
+      assertions:
+        - type: faithfulness
+          params:
+            contexts:
+              - "Paris is the capital and most populous city of France."
+              - "Located on the Seine River in north-central France."
+            judge: rag-judge
+            min_score: 0.8
+          message: "Answer must be grounded in the retrieved context"
+
+        - type: answer_relevancy
+          params:
+            judge: rag-judge
+            min_score: 0.8
+          message: "Answer must directly address the question"
+
+        - type: contextual_precision
+          params:
+            contexts:
+              - "Paris is the capital and most populous city of France."
+              - "Located on the Seine River in north-central France."
+            judge: rag-judge
+            min_score: 0.5
+          message: "Retrieved chunks must be relevant to the question"
+
+        - type: contextual_recall
+          params:
+            contexts:
+              - "Paris is the capital and most populous city of France."
+              - "Located on the Seine River in north-central France."
+            reference: "Paris is the capital of France."
+            judge: rag-judge
+            min_score: 0.8
+          message: "Retrieved chunks must cover the reference answer"
+
+        - type: contextual_relevancy
+          params:
+            contexts:
+              - "Paris is the capital and most populous city of France."
+              - "Located on the Seine River in north-central France."
+            judge: rag-judge
+            min_score: 0.5
+          message: "Average per-chunk relevance must clear the threshold"
+
+        - type: hallucination
+          params:
+            contexts:
+              - "Paris is the capital and most populous city of France."
+              - "Located on the Seine River in north-central France."
+            judge: rag-judge
+            min_score: 0.8
+          message: "Answer must be free of hallucinated claims (1.0 = no hallucination)"


### PR DESCRIPTION
## Summary

Adds `examples/rag-agent/` — exercises all six named RAG primitives as scenario assertions. Implements #1161, depends on the RAG handlers from #1145 (already merged).

`faithfulness`, `answer_relevancy`, `contextual_precision`, `contextual_recall`, `contextual_relevancy`, `hallucination` — all six wired against a mock RAG assistant + mock LLM judge. Keyless and deterministic.

The how-to documents three context source forms (`contexts`, `context`, `context_field`), the swap to a real LLM judge, the dynamic-retrieval pattern via `context_field` reading from `evalCtx.Metadata`, and the CI gate pattern.

## Test plan

- [x] `promptarena run --ci` passes with all 6 RAG assertions green (mock judge returns 0.92)
- [x] How-to renders as Markdown
- [x] Cross-link to follow once the guardrails-as-signals merge lands (#1179)
- [x] No Go changes
- [ ] CI passes
