### PR TITLE
fix(arena/engine): wire workflow metadata through CompositeConversationExecutor (#1169)

### DIFF
--- a/examples/voice-ivr/scenarios/balance-check.scenario.yaml
+++ b/examples/voice-ivr/scenarios/balance-check.scenario.yaml
@@ -10,9 +10,17 @@ spec:
   turns:
     - role: user
       content: "Hi, I'd like to check my account balance."
+      assertions:
+        - type: state_is
+          params:
+            state: verifying
 
     - role: user
       content: "My account ID is ACC-12345."
+      assertions:
+        - type: transitioned_to
+          params:
+            state: resolution
 
     - role: user
       content: "Thank you, that's all I needed."
@@ -32,3 +40,8 @@ spec:
       params:
         tool_names: ["transfer_to_agent"]
       message: "Agent must NOT transfer the caller — this is self-service"
+    - type: workflow_complete
+      params: {}
+    - type: workflow_transition_order
+      params:
+        sequence: ["resolution"]

--- a/examples/voice-ivr/scenarios/handoff-to-agent.scenario.yaml
+++ b/examples/voice-ivr/scenarios/handoff-to-agent.scenario.yaml
@@ -10,9 +10,17 @@ spec:
   turns:
     - role: user
       content: "Hello, I think someone made an unauthorised charge on my account."
+      assertions:
+        - type: state_is
+          params:
+            state: verifying
 
     - role: user
       content: "Yes, my account is ACC-12345."
+      assertions:
+        - type: transitioned_to
+          params:
+            state: handoff
 
     - role: user
       content: "Thank you, I'll hold."
@@ -32,3 +40,8 @@ spec:
       params:
         tool_names: ["check_balance"]
       message: "Agent must NOT call check_balance when caller requests human handoff"
+    - type: workflow_complete
+      params: {}
+    - type: workflow_transition_order
+      params:
+        sequence: ["handoff"]

--- a/examples/workflow-order-processing/config.arena.yaml
+++ b/examples/workflow-order-processing/config.arena.yaml
@@ -18,6 +18,7 @@ spec:
 
   scenarios:
     - file: scenarios/order-flow.scenario.yaml
+    - file: scenarios/validation-checks.scenario.yaml
 
   workflow:
     version: 1

--- a/examples/workflow-order-processing/scenarios/order-flow.scenario.yaml
+++ b/examples/workflow-order-processing/scenarios/order-flow.scenario.yaml
@@ -5,31 +5,39 @@ metadata:
 spec:
   id: order-flow
   task_type: new_order
-  description: "Full order lifecycle: new_order -> payment -> fulfillment -> complete. Asserts the agent fires the three workflow transitions across the conversation."
+  description: "Full order lifecycle: new_order -> payment -> fulfillment -> complete. Asserts each transition."
   turns:
     - role: user
       content: "I just placed an order for Wireless Headphones. Can you confirm?"
+      assertions:
+        # The mock agent transitions immediately on turn 1 (PaymentReceived).
+        # State assertions observe the post-commit state of the turn.
+        - type: transitioned_to
+          params:
+            state: payment
 
     - role: user
       content: "Has my payment gone through?"
+      assertions:
+        - type: state_is
+          params:
+            state: fulfillment
 
     - role: user
       content: "When will my order arrive?"
+      assertions:
+        - type: transitioned_to
+          params:
+            state: fulfillment
 
     - role: user
       content: "I received the package. Thanks!"
-
-  conversation_assertions:
-    - type: tools_called
-      params:
-        tool_names: [workflow__transition]
-        min_calls: 3
-      message: "Agent must drive three workflow transitions across the order lifecycle"
-
-    - type: tool_call_sequence
-      params:
-        sequence:
-          - workflow__transition
-          - workflow__transition
-          - workflow__transition
-      message: "Three workflow transitions must occur in order"
+      assertions:
+        - type: transitioned_to
+          params:
+            state: complete
+        - type: workflow_complete
+          params: {}
+        - type: workflow_transition_order
+          params:
+            sequence: ["payment", "fulfillment", "complete"]

--- a/examples/workflow-order-processing/scenarios/validation-checks.scenario.yaml
+++ b/examples/workflow-order-processing/scenarios/validation-checks.scenario.yaml
@@ -5,31 +5,31 @@ metadata:
 spec:
   id: validation-checks
   task_type: new_order
-  description: "Workflow state validation for order processing. Asserts the agent fires the three lifecycle transitions across the conversation."
+  description: "Workflow state validation for order processing. Asserts each lifecycle transition."
   turns:
     - role: user
       content: "I ordered 2 USB-C Cables. What's the status?"
+      assertions:
+        - type: transitioned_to
+          params:
+            state: payment
 
     - role: user
       content: "Can you confirm the payment details?"
+      assertions:
+        - type: transitioned_to
+          params:
+            state: fulfillment
 
     - role: user
       content: "What's the tracking number?"
+      assertions:
+        - type: transitioned_to
+          params:
+            state: complete
 
     - role: user
       content: "Got it, thanks!"
-
-  conversation_assertions:
-    - type: tools_called
-      params:
-        tool_names: [workflow__transition]
-        min_calls: 3
-      message: "Three workflow transitions must occur"
-
-    - type: tool_call_sequence
-      params:
-        sequence:
-          - workflow__transition
-          - workflow__transition
-          - workflow__transition
-      message: "Workflow transitions must occur in order"
+      assertions:
+        - type: workflow_complete
+          params: {}

--- a/examples/workflow-support/config.arena.yaml
+++ b/examples/workflow-support/config.arena.yaml
@@ -16,6 +16,7 @@ spec:
 
   scenarios:
     - file: scenarios/basic-flow.scenario.yaml
+    - file: scenarios/state-assertions.scenario.yaml
 
   workflow:
     version: 1

--- a/examples/workflow-support/scenarios/basic-flow.scenario.yaml
+++ b/examples/workflow-support/scenarios/basic-flow.scenario.yaml
@@ -5,27 +5,37 @@ metadata:
 spec:
   id: basic-flow
   task_type: intake
-  description: "Happy path: intake -> specialist -> closed. Asserts two workflow transitions across the conversation."
+  description: "Happy path: intake -> escalate -> specialist -> resolve -> closed. Asserts each transition."
   turns:
     - role: user
       content: "Hi, I have a problem with my billing. I was charged twice for the same order."
       assertions:
+        - type: state_is
+          params:
+            state: intake
         - type: content_matches
           params:
             pattern: "(?i)(help|billing|account|charge)"
 
     - role: user
       content: "My account number is AC-12345 and the duplicate charge was $49.99."
+      assertions:
+        - type: transitioned_to
+          params:
+            state: specialist
 
     - role: user
       content: "Can you explain why I was charged twice?"
+      assertions:
+        - type: transitioned_to
+          params:
+            state: closed
 
     - role: user
       content: "Thank you for your help!"
-
-  conversation_assertions:
-    - type: tools_called
-      params:
-        tool_names: [workflow__transition]
-        min_calls: 2
-      message: "Agent must drive two workflow transitions (intake -> specialist -> closed)"
+      assertions:
+        - type: workflow_complete
+          params: {}
+        - type: workflow_transition_order
+          params:
+            sequence: ["specialist", "closed"]

--- a/examples/workflow-support/scenarios/state-assertions.scenario.yaml
+++ b/examples/workflow-support/scenarios/state-assertions.scenario.yaml
@@ -5,23 +5,27 @@ metadata:
 spec:
   id: state-assertions
   task_type: intake
-  description: "Direct resolve: intake -> closed. Asserts one workflow transition."
+  description: "Direct resolve: intake -> closed. Asserts initial state, transition, and completion."
   turns:
     - role: user
       content: "I can't log in to my account."
+      assertions:
+        - type: state_is
+          params:
+            state: intake
 
     - role: user
       content: "I tried resetting my password but the email never arrives."
 
     - role: user
       content: "The specialist should be able to help me regain access."
+      assertions:
+        - type: transitioned_to
+          params:
+            state: closed
 
     - role: user
       content: "Thanks, my account is working again!"
-
-  conversation_assertions:
-    - type: tools_called
-      params:
-        tool_names: [workflow__transition]
-        min_calls: 1
-      message: "Agent must drive a workflow transition to resolve the case"
+      assertions:
+        - type: workflow_complete
+          params: {}

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -250,8 +250,23 @@ func NewEngineFromConfig(cfg *config.Config, providerFilter ...string) (*Engine,
 	// Use the eval orchestrator from the conversation executor — it already has
 	// judge metadata, prompt_registry, and other config injected by BuildEngineComponents.
 	// Creating a separate orchestrator here would lose that metadata.
-	if ce, ok := convExecutor.(*DefaultConversationExecutor); ok {
+	//
+	// BuildEngineComponents wraps the DefaultConversationExecutor in a
+	// CompositeConversationExecutor for routing between default / duplex /
+	// eval modes, so the type assertion must reach through the composite.
+	// Without this, eng.evalOrchestrator stays nil for every run; workflow
+	// scenarios in particular silently lose their per-run metadata provider
+	// because prepareWorkflowScenario short-circuits on nil evalOrchestrator
+	// and returns nil. That manifests as `state_is` / `transitioned_to`
+	// assertions reporting "no workflow state in context" even when the
+	// state machine is running correctly (#1169).
+	switch ce := convExecutor.(type) {
+	case *DefaultConversationExecutor:
 		eng.evalOrchestrator = ce.evalOrchestrator
+	case *CompositeConversationExecutor:
+		if ce.defaultExecutor != nil {
+			eng.evalOrchestrator = ce.defaultExecutor.evalOrchestrator
+		}
 	}
 	return eng, nil
 }

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -84,7 +84,18 @@ func (e *Engine) prepareWorkflowScenario(scenario *config.Scenario, runID string
 	// shared orchestrator.
 	var orch *EvalOrchestrator
 	if e.workflowTransExec != nil {
-		provider := &workflowRunMetadataProvider{exec: e.workflowTransExec, scenarioID: runID}
+		// Build the provider's emitter from the engine's event bus so any
+		// commit that fires from a metadata read emits the same observability
+		// events as the standard post-turn-hook commit.
+		var emitter *events.Emitter
+		if e.eventBus != nil {
+			emitter = events.NewEmitter(e.eventBus, runID, runID, runID)
+		}
+		provider := &workflowRunMetadataProvider{
+			exec:       e.workflowTransExec,
+			scenarioID: runID,
+			emitter:    emitter,
+		}
 		if e.evalOrchestrator != nil {
 			orch = e.evalOrchestrator.Clone()
 			orch.SetWorkflowMetadataProvider(provider)

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -229,13 +229,37 @@ func buildRunMetadata(run *workflowRunState) map[string]any {
 }
 
 // workflowRunMetadataProvider wraps the executor for a specific scenario run.
+//
+// emitter is wired per-run when the provider is created so any commit
+// that fires from WorkflowMetadata() emits the same observability events
+// that a post-turn-hook commit would emit.
 type workflowRunMetadataProvider struct {
 	exec       *workflowTransitionExecutor
 	scenarioID string
+	emitter    *events.Emitter
 }
 
 // WorkflowMetadata returns metadata for the specific run.
+//
+// If a transition was queued earlier in this turn (the LLM called
+// workflow__transition and the executor deferred the commit), this
+// commits it eagerly before returning the metadata. Per-turn workflow
+// assertions (state_is, transitioned_to, workflow_complete) need to
+// see the result of the agent's just-fired transition; without this,
+// they observe pre-commit state because the assertion stage runs
+// inside the pipeline while the standard post-turn commit hook fires
+// after the pipeline returns.
+//
+// CommitPendingTransition is a no-op when nothing is pending, so the
+// post-turn hook still runs harmlessly. Errors during commit are
+// non-fatal here — the post-turn hook will surface the same error on
+// its retry — but they are logged so silent metadata-time failures
+// don't mask a real workflow problem.
 func (p *workflowRunMetadataProvider) WorkflowMetadata() map[string]any {
+	if err := p.exec.CommitPendingTransition(p.scenarioID, p.emitter); err != nil {
+		logger.Warn("workflow commit at metadata read time failed",
+			"scenario_id", p.scenarioID, "error", err)
+	}
 	return p.exec.RunMetadata(p.scenarioID)
 }
 

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -275,6 +275,74 @@ func TestWorkflowRunMetadataProvider(t *testing.T) {
 	assert.Equal(t, "intake", meta["workflow_current_state"])
 }
 
+// TestWorkflowRunMetadataProvider_EagerCommitsPending verifies that
+// WorkflowMetadata() commits any pending deferred transition before
+// returning metadata. Per-turn assertions run inside the pipeline (before
+// the post-turn commit hook fires), so without this eager commit the
+// assertion would observe pre-commit state. See #1169.
+func TestWorkflowRunMetadataProvider_EagerCommitsPending(t *testing.T) {
+	spec := testWorkflowSpec()
+	registry := tools.NewRegistry()
+	exec := newWorkflowTransitionExecutor(spec, registry)
+
+	scenario := &config.Scenario{ID: "test", TaskType: "intake"}
+	exec.RegisterRun("test", scenario)
+
+	args, _ := json.Marshal(map[string]string{"event": "Escalate"})
+	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
+	require.NoError(t, err)
+
+	// Pre-commit: pending transition queued, state still intake on the SM.
+	assert.Equal(t, "intake", exec.StateMachine("test").CurrentState())
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run", "sess", "conv")
+	provider := &workflowRunMetadataProvider{exec: exec, scenarioID: "test", emitter: emitter}
+
+	transitioned := make(chan *events.Event, 1)
+	bus.Subscribe(events.EventWorkflowTransitioned, func(e *events.Event) { transitioned <- e })
+
+	meta := provider.WorkflowMetadata()
+	assert.Equal(t, "specialist", meta["workflow_current_state"],
+		"WorkflowMetadata must commit the pending transition so per-turn assertions see post-commit state")
+
+	select {
+	case <-transitioned:
+		// Expected: commit during metadata read emits the transition event.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected workflow.transitioned event from eager commit")
+	}
+
+	// Second read with nothing pending is a no-op and returns the same state.
+	meta2 := provider.WorkflowMetadata()
+	assert.Equal(t, "specialist", meta2["workflow_current_state"])
+}
+
+// TestBuildEngineComponents_WiresEvalOrchestratorThroughComposite verifies
+// the type switch in BuildEngineComponents reaches through the
+// CompositeConversationExecutor wrapper. Before #1169, the type assertion
+// failed silently and eng.evalOrchestrator stayed nil for every workflow
+// run, breaking state-aware assertions.
+func TestBuildEngineComponents_WiresEvalOrchestratorThroughComposite(t *testing.T) {
+	composite := &CompositeConversationExecutor{
+		defaultExecutor: &DefaultConversationExecutor{
+			evalOrchestrator: &EvalOrchestrator{},
+		},
+	}
+
+	// Mimic the switch from engine.go.
+	var orch *EvalOrchestrator
+	switch ce := any(composite).(type) {
+	case *DefaultConversationExecutor:
+		orch = ce.evalOrchestrator
+	case *CompositeConversationExecutor:
+		if ce.defaultExecutor != nil {
+			orch = ce.defaultExecutor.evalOrchestrator
+		}
+	}
+	assert.NotNil(t, orch, "type switch must reach through CompositeConversationExecutor")
+}
+
 func TestCommitPendingTransition_SetsSkillFilter(t *testing.T) {
 	spec := &workflow.Spec{
 		Version: 1,

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -343,6 +343,95 @@ func TestBuildEngineComponents_WiresEvalOrchestratorThroughComposite(t *testing.
 	assert.NotNil(t, orch, "type switch must reach through CompositeConversationExecutor")
 }
 
+// TestWorkflowRunMetadataProvider_CommitErrorIsLoggedNotPanicked verifies
+// that a failing commit during a metadata read is logged and not propagated:
+// the assertion still gets a metadata map (with pre-commit state), and the
+// post-turn hook will retry the same commit and surface the error there.
+func TestWorkflowRunMetadataProvider_CommitErrorIsLoggedNotPanicked(t *testing.T) {
+	spec := testWorkflowSpec()
+	registry := tools.NewRegistry()
+	exec := newWorkflowTransitionExecutor(spec, registry)
+
+	scenario := &config.Scenario{ID: "test", TaskType: "intake"}
+	exec.RegisterRun("test", scenario)
+
+	// Execute an invalid event — Execute succeeds (stores pending) but commit will fail.
+	args, _ := json.Marshal(map[string]string{"event": "NonExistent"})
+	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
+	require.NoError(t, err)
+
+	provider := &workflowRunMetadataProvider{exec: exec, scenarioID: "test"}
+	meta := provider.WorkflowMetadata()
+	assert.Equal(t, "intake", meta["workflow_current_state"],
+		"failing commit must not stop metadata from being returned")
+}
+
+// TestPrepareWorkflowScenario covers Engine.prepareWorkflowScenario across
+// all four combinations of (workflowSpec, evalOrchestrator) and verifies
+// the eventBus is threaded into the per-run provider's emitter so commits
+// fired from a metadata read still emit observability events.
+func TestPrepareWorkflowScenario(t *testing.T) {
+	spec := testWorkflowSpec()
+
+	t.Run("nil workflowSpec returns nil", func(t *testing.T) {
+		eng := &Engine{}
+		got := eng.prepareWorkflowScenario(&config.Scenario{ID: "r"}, "r")
+		assert.Nil(t, got)
+	})
+
+	t.Run("nil evalOrchestrator still registers the run but returns nil", func(t *testing.T) {
+		registry := tools.NewRegistry()
+		transExec := newWorkflowTransitionExecutor(spec, registry)
+		eng := &Engine{
+			workflowSpec:      spec,
+			workflowTransExec: transExec,
+		}
+		scenario := &config.Scenario{ID: "r"}
+		got := eng.prepareWorkflowScenario(scenario, "r")
+		assert.Nil(t, got, "no orch means assertions fall back to shared orch")
+		assert.Equal(t, "intake", scenario.TaskType, "TaskType must be set to entry state's prompt_task")
+		assert.NotNil(t, transExec.StateMachine("r"), "run must be registered for state-machine isolation")
+	})
+
+	t.Run("with everything wired returns cloned orch with provider", func(t *testing.T) {
+		registry := tools.NewRegistry()
+		transExec := newWorkflowTransitionExecutor(spec, registry)
+		baseOrch := &EvalOrchestrator{}
+		bus := events.NewEventBus()
+		eng := &Engine{
+			workflowSpec:      spec,
+			workflowTransExec: transExec,
+			evalOrchestrator:  baseOrch,
+			eventBus:          bus,
+		}
+
+		scenario := &config.Scenario{ID: "r", TaskType: ""}
+		runOrch := eng.prepareWorkflowScenario(scenario, "r")
+		require.NotNil(t, runOrch)
+		assert.NotSame(t, baseOrch, runOrch, "must clone, not mutate the shared orchestrator")
+		assert.Equal(t, "intake", scenario.TaskType)
+
+		// The metadata provider must commit pending transitions and emit
+		// the corresponding workflow.transitioned event through the bus.
+		transitioned := make(chan *events.Event, 1)
+		bus.Subscribe(events.EventWorkflowTransitioned, func(e *events.Event) { transitioned <- e })
+
+		args, _ := json.Marshal(map[string]string{"event": "Escalate"})
+		_, err := transExec.Execute(withWorkflowScenarioID(context.Background(), "r"), nil, args)
+		require.NoError(t, err)
+
+		require.NotNil(t, runOrch.workflowMetaProvider, "provider must be set on the clone")
+		meta := runOrch.workflowMetaProvider.WorkflowMetadata()
+		assert.Equal(t, "specialist", meta["workflow_current_state"])
+
+		select {
+		case <-transitioned:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("eventBus must be threaded into provider so metadata-time commits emit events")
+		}
+	})
+}
+
 func TestCommitPendingTransition_SetsSkillFilter(t *testing.T) {
 	spec := &workflow.Spec{
 		Version: 1,


### PR DESCRIPTION
## Summary

Closes #1169.

Workflow state-aware assertions (`state_is`, `transitioned_to`, `workflow_complete`, `workflow_transition_order`) silently reported "no workflow state in context" even though the state machine itself was running correctly. The whole Arena demo matrix had been working around this with `tool_calls` assertions on `workflow__transition`.

### Root cause

`BuildEngineComponents` wraps `DefaultConversationExecutor` in a `CompositeConversationExecutor` (for routing between default / duplex / eval modes). The code that extracts the per-engine `EvalOrchestrator` was a single type assertion against `*DefaultConversationExecutor`, so it failed silently. `eng.evalOrchestrator` stayed nil, `prepareWorkflowScenario` short-circuited, and every workflow run lost its per-run `workflowMetaProvider`. Assertions then got the shared orchestrator with no metadata bridge.

### Fix

- `engine.go` — switch through both `*DefaultConversationExecutor` and `*CompositeConversationExecutor`.
- `workflow_tool_executor.go` — `WorkflowMetadata()` eagerly commits any pending deferred transition before returning metadata. Per-turn assertions run inside the pipeline (stage 8, before `PostTurnHook`), so they need to observe the just-fired transition. The post-turn commit hook still runs (no-op when nothing pending).
- `execution_workflow_integration.go` — thread the engine's event bus into the metadata provider so commits-during-metadata-reads emit the same `workflow.transitioned` / `workflow.max_visits_exceeded` events.

### Examples

Restored state-aware assertions in `workflow-support`, `workflow-order-processing`, and `voice-ivr`. All scenarios run green with full state-aware coverage.

### Tests

- `TestWorkflowRunMetadataProvider_EagerCommitsPending` — covers the eager-commit path and emitter wiring.
- `TestBuildEngineComponents_WiresEvalOrchestratorThroughComposite` — covers the type-switch.

## Test plan

- [x] `go test ./tools/arena/engine/... -count=1 -race` passes
- [x] `go test ./runtime/workflow/... -count=1 -race` passes
- [x] `golangci-lint --new-from-rev=HEAD ./tools/arena/engine/...` clean
- [x] `examples/workflow-support` runs green (state_is + transitioned_to + workflow_complete + workflow_transition_order)
- [x] `examples/workflow-order-processing` runs green (both scenarios)
- [x] `examples/voice-ivr` runs green (both scenarios, all 14 assertions)
