### PR TITLE
feat(workflow): control: user|agent property for multi-transition turns

### DIFF
--- a/runtime/workflow/transition_executor.go
+++ b/runtime/workflow/transition_executor.go
@@ -19,16 +19,21 @@ type PendingTransition struct {
 }
 
 // TransitionExecutor implements tools.Executor for workflow__transition.
-// It defers the actual state transition (ProcessEvent) until CommitPending
-// is called, ensuring the full pipeline completes before state changes.
 //
-// Both SDK and Arena use this executor. After pipeline/turn execution,
-// the consumer calls CommitPending() to apply the transition.
+// By default it defers the state transition (ProcessEvent) until CommitPending
+// is called, ensuring the full pipeline completes before state changes. When
+// the transition target state has Control == ControlModeAgent the transition
+// commits eagerly inside Execute so the next LLM call in the same pipeline
+// turn sees the new state's events. The optional OnCommit callback is invoked
+// for both eager and deferred commits so consumers (Arena, SDK) can run their
+// post-commit work (re-register tool descriptor, update scenario TaskType,
+// emit observability events) from a single hook.
 type TransitionExecutor struct {
-	mu      sync.Mutex
-	sm      *StateMachine
-	spec    *Spec
-	pending *PendingTransition
+	mu       sync.Mutex
+	sm       *StateMachine
+	spec     *Spec
+	pending  *PendingTransition
+	onCommit func(*TransitionResult)
 }
 
 // NewTransitionExecutor creates a TransitionExecutor for the given state machine.
@@ -36,12 +41,30 @@ func NewTransitionExecutor(sm *StateMachine, spec *Spec) *TransitionExecutor {
 	return &TransitionExecutor{sm: sm, spec: spec}
 }
 
+// SetOnCommit registers a callback fired after every successful commit
+// (eager or deferred). Pass nil to clear.
+//
+// Callbacks run while the executor's internal lock is held; they must not
+// re-enter the executor's public methods (Execute / CommitPending / etc.).
+func (e *TransitionExecutor) SetOnCommit(fn func(*TransitionResult)) {
+	e.mu.Lock()
+	e.onCommit = fn
+	e.mu.Unlock()
+}
+
 // Name implements tools.Executor. Returns the mode name for registry routing.
 func (e *TransitionExecutor) Name() string { return TransitionExecutorMode }
 
-// Execute implements tools.Executor. Stores the transition request and returns
-// a confirmation to the LLM. Does NOT call ProcessEvent — that happens in
-// CommitPending after the pipeline completes.
+// Execute implements tools.Executor.
+//
+// If the event's target state declares Control == ControlModeAgent the
+// transition is committed immediately (ProcessEvent + OnCommit) and the
+// returned response carries the new state's prompt_task, description, and
+// available events so the LLM's next tool-loop iteration can act on them.
+//
+// Otherwise the request is stored as pending and CommitPending applies it
+// after the pipeline turn finishes. This is the historical (default)
+// behavior and matches RFC 0005's deferred-commit pattern.
 func (e *TransitionExecutor) Execute(
 	_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage,
 ) (json.RawMessage, error) {
@@ -54,15 +77,43 @@ func (e *TransitionExecutor) Execute(
 	}
 
 	e.mu.Lock()
-	e.pending = &PendingTransition{Event: a.Event, ContextSummary: a.Context}
-	e.mu.Unlock()
+	defer e.mu.Unlock()
 
+	if e.isAgentControlledTargetLocked(a.Event) {
+		tr, err := e.sm.ProcessEvent(a.Event)
+		if err != nil {
+			return nil, fmt.Errorf("agent-controlled transition failed: %w", err)
+		}
+		if e.onCommit != nil {
+			e.onCommit(tr)
+		}
+		return json.Marshal(buildEagerTransitionResponse(tr, e.spec))
+	}
+
+	e.pending = &PendingTransition{Event: a.Event, ContextSummary: a.Context}
 	return json.Marshal(buildTransitionResponse(a.Event, e.spec))
+}
+
+// isAgentControlledTargetLocked looks up the target state for event on the
+// current source state and reports whether it declares Control == ControlModeAgent.
+// Returns false for unknown events; ProcessEvent will surface the error on commit.
+// Caller must hold e.mu.
+func (e *TransitionExecutor) isAgentControlledTargetLocked(event string) bool {
+	current := e.sm.CurrentState()
+	src, ok := e.spec.States[current]
+	if !ok || src == nil {
+		return false
+	}
+	target, ok := src.OnEvent[event]
+	if !ok {
+		return false
+	}
+	return e.spec.States[target].IsAgentControlled()
 }
 
 // CommitPending applies the pending transition by calling ProcessEvent.
 // Returns nil, nil if no transition is pending. After commit, the pending
-// state is cleared. Thread-safe.
+// state is cleared. Thread-safe. Fires OnCommit on success.
 func (e *TransitionExecutor) CommitPending() (*TransitionResult, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -74,7 +125,14 @@ func (e *TransitionExecutor) CommitPending() (*TransitionResult, error) {
 	pt := e.pending
 	e.pending = nil
 
-	return e.sm.ProcessEvent(pt.Event)
+	tr, err := e.sm.ProcessEvent(pt.Event)
+	if err != nil {
+		return nil, err
+	}
+	if e.onCommit != nil {
+		e.onCommit(tr)
+	}
+	return tr, nil
 }
 
 // Pending returns the current pending transition, or nil if none.
@@ -123,6 +181,39 @@ func buildTransitionResponse(event string, spec *Spec) map[string]string {
 		if target, ok := state.OnEvent[event]; ok {
 			result["target_state"] = target
 			break
+		}
+	}
+	return result
+}
+
+// buildEagerTransitionResponse creates the LLM-facing response for an
+// already-committed (agent-controlled) transition. It carries the new
+// state's prompt_task, description, and available events so the LLM
+// can act on them in the same pipeline turn.
+func buildEagerTransitionResponse(tr *TransitionResult, spec *Spec) map[string]any {
+	result := map[string]any{
+		"status": "transitioned",
+		"from":   tr.From,
+		"to":     tr.To,
+		"event":  tr.Event,
+	}
+	if tr.Redirected {
+		result["redirected"] = true
+		result["redirect_reason"] = tr.RedirectReason
+		result["original_target"] = tr.OriginalTarget
+	}
+	if newState := spec.States[tr.To]; newState != nil {
+		if newState.PromptTask != "" {
+			result["prompt_task"] = newState.PromptTask
+		}
+		if newState.Description != "" {
+			result["description"] = newState.Description
+		}
+		if len(newState.OnEvent) > 0 {
+			result["available_events"] = SortedEvents(newState.OnEvent)
+		}
+		if newState.Terminal || len(newState.OnEvent) == 0 {
+			result["terminal"] = true
 		}
 	}
 	return result

--- a/runtime/workflow/transition_executor_test.go
+++ b/runtime/workflow/transition_executor_test.go
@@ -233,3 +233,162 @@ func newTestRegistry(t *testing.T) *tools.Registry {
 	t.Helper()
 	return tools.NewRegistry()
 }
+
+func TestTransitionExecutor_AgentControlEagerCommit(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t-a", OnEvent: map[string]string{"Go": "b"}},
+			"b": {
+				PromptTask:  "t-b",
+				Description: "B is agent-controlled — keep the turn",
+				Control:     ControlModeAgent,
+				OnEvent:     map[string]string{"Finish": "done"},
+			},
+			"done": {PromptTask: "t-done", Terminal: true},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	var committed []*TransitionResult
+	exec.SetOnCommit(func(tr *TransitionResult) {
+		committed = append(committed, tr)
+	})
+
+	args, _ := json.Marshal(map[string]string{"event": "Go", "context": "test"})
+	raw, err := exec.Execute(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if sm.CurrentState() != "b" {
+		t.Errorf("state after eager commit = %q, want 'b'", sm.CurrentState())
+	}
+	if exec.Pending() != nil {
+		t.Error("pending must be nil after eager commit")
+	}
+	if len(committed) != 1 || committed[0].To != "b" {
+		t.Errorf("onCommit not fired correctly: %+v", committed)
+	}
+
+	// CommitPending must be a no-op now.
+	tr, err := exec.CommitPending()
+	if err != nil {
+		t.Fatalf("CommitPending: %v", err)
+	}
+	if tr != nil {
+		t.Errorf("CommitPending must return nil after eager commit, got %+v", tr)
+	}
+
+	// Response must include the new state's metadata so the LLM can act on it.
+	var resp map[string]any
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["status"] != "transitioned" {
+		t.Errorf("status = %q, want 'transitioned'", resp["status"])
+	}
+	if resp["to"] != "b" {
+		t.Errorf("to = %q, want 'b'", resp["to"])
+	}
+	if resp["prompt_task"] != "t-b" {
+		t.Errorf("prompt_task = %v, want 't-b'", resp["prompt_task"])
+	}
+	if resp["description"] == nil {
+		t.Errorf("description must be populated")
+	}
+	events, ok := resp["available_events"].([]any)
+	if !ok || len(events) != 1 || events[0] != "Finish" {
+		t.Errorf("available_events = %v, want ['Finish']", resp["available_events"])
+	}
+}
+
+func TestTransitionExecutor_UserControlStillDefers(t *testing.T) {
+	// Default Control ("") must behave exactly like the deferred-commit path.
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"}, // Control == "" → user (default)
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	var committed int
+	exec.SetOnCommit(func(*TransitionResult) { committed++ })
+
+	args, _ := json.Marshal(map[string]string{"event": "Go", "context": ""})
+	_, err := exec.Execute(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if sm.CurrentState() != "a" {
+		t.Errorf("state must not advance during deferred Execute")
+	}
+	if exec.Pending() == nil {
+		t.Error("pending must be set for user-controlled target")
+	}
+	if committed != 0 {
+		t.Errorf("onCommit must not fire on Execute for user-controlled targets, fired %d times", committed)
+	}
+
+	if _, err := exec.CommitPending(); err != nil {
+		t.Fatalf("CommitPending: %v", err)
+	}
+	if committed != 1 {
+		t.Errorf("onCommit must fire on CommitPending, fired %d times", committed)
+	}
+	if sm.CurrentState() != "b" {
+		t.Errorf("state after CommitPending = %q, want 'b'", sm.CurrentState())
+	}
+}
+
+func TestTransitionExecutor_AgentControlChainedTransitions(t *testing.T) {
+	// Two agent-controlled transitions in sequence — proves the executor stays
+	// usable after an eager commit and the second call uses the post-commit
+	// source state to resolve its target.
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"ToB": "b"}},
+			"b": {
+				PromptTask: "t",
+				Control:    ControlModeAgent,
+				OnEvent:    map[string]string{"ToC": "c"},
+			},
+			"c": {
+				PromptTask: "t",
+				Control:    ControlModeAgent,
+				OnEvent:    map[string]string{"ToDone": "done"},
+			},
+			"done": {PromptTask: "t", Terminal: true},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	first, _ := json.Marshal(map[string]string{"event": "ToB"})
+	if _, err := exec.Execute(context.Background(), nil, first); err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	if sm.CurrentState() != "b" {
+		t.Fatalf("after first eager commit, state = %q want 'b'", sm.CurrentState())
+	}
+
+	second, _ := json.Marshal(map[string]string{"event": "ToC"})
+	if _, err := exec.Execute(context.Background(), nil, second); err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	if sm.CurrentState() != "c" {
+		t.Fatalf("after second eager commit, state = %q want 'c'", sm.CurrentState())
+	}
+	if exec.Pending() != nil {
+		t.Error("pending must remain nil across chained eager commits")
+	}
+}

--- a/runtime/workflow/types.go
+++ b/runtime/workflow/types.go
@@ -122,6 +122,7 @@ type State struct {
 	OnEvent       map[string]string       `json:"on_event,omitempty"`
 	Persistence   Persistence             `json:"persistence,omitempty"`
 	Orchestration Orchestration           `json:"orchestration,omitempty"`
+	Control       ControlMode             `json:"control,omitempty"` // user (default) or agent
 	Skills        string                  `json:"skills,omitempty"`
 	Terminal      bool                    `json:"terminal,omitempty"`      // RFC 0009: explicit terminal marker
 	MaxVisits     int                     `json:"max_visits,omitempty"`    // RFC 0009: max times this state can be entered
@@ -168,6 +169,29 @@ const (
 	OrchestrationExternal Orchestration = "external"
 	OrchestrationHybrid   Orchestration = "hybrid"
 )
+
+// ControlMode describes who holds control after a transition into this state.
+//
+//   - ControlModeUser (default, "" or "user"): the agent's turn ends after the
+//     transition. The user (or selfplay/scripted driver) speaks next.
+//   - ControlModeAgent ("agent"): the agent keeps the turn after transitioning.
+//     The transition commits immediately so subsequent tool-loop iterations in
+//     the same pipeline turn see the new state's events. This unlocks
+//     multi-transition turns (e.g., routing → handoff in one go) without
+//     waiting for a user input that will never come.
+type ControlMode string
+
+// ControlMode values.
+const (
+	ControlModeUser  ControlMode = "user"
+	ControlModeAgent ControlMode = "agent"
+)
+
+// IsAgentControlled reports whether s yields the turn to the agent after
+// a transition is committed. The empty string is treated as user-controlled.
+func (s *State) IsAgentControlled() bool {
+	return s != nil && s.Control == ControlModeAgent
+}
 
 // Context holds the runtime state of a workflow execution.
 type Context struct {

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -74,9 +74,18 @@ func (e *Engine) prepareWorkflowScenario(scenario *config.Scenario, runID string
 		scenario.TaskType = entryState.PromptTask
 	}
 
+	// Build the per-run emitter once and reuse it for both the
+	// workflowTransitionExecutor (which fires events on every commit, eager
+	// or deferred) and the workflow metadata provider (which may eager-commit
+	// during a metadata read).
+	var emitter *events.Emitter
+	if e.eventBus != nil {
+		emitter = events.NewEmitter(e.eventBus, runID, runID, runID)
+	}
+
 	// Register a per-run state machine for concurrent scenario execution
 	if e.workflowTransExec != nil {
-		e.workflowTransExec.RegisterRun(runID, scenario)
+		e.workflowTransExec.RegisterRunWithEmitter(runID, scenario, emitter)
 	}
 
 	// Clone the eval orchestrator for this run with per-run workflow metadata.
@@ -84,13 +93,6 @@ func (e *Engine) prepareWorkflowScenario(scenario *config.Scenario, runID string
 	// shared orchestrator.
 	var orch *EvalOrchestrator
 	if e.workflowTransExec != nil {
-		// Build the provider's emitter from the engine's event bus so any
-		// commit that fires from a metadata read emits the same observability
-		// events as the standard post-turn-hook commit.
-		var emitter *events.Emitter
-		if e.eventBus != nil {
-			emitter = events.NewEmitter(e.eventBus, runID, runID, runID)
-		}
 		provider := &workflowRunMetadataProvider{
 			exec:       e.workflowTransExec,
 			scenarioID: runID,

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -39,6 +39,7 @@ type workflowRunState struct {
 	scenario    *config.Scenario
 	transitions []map[string]any
 	skillFilter string // current skill glob filter for this run
+	emitter     *events.Emitter
 }
 
 // workflowTransitionExecutor routes workflow__transition tool calls to per-run
@@ -67,15 +68,36 @@ func newWorkflowTransitionExecutor(
 // Name implements tools.Executor.
 func (e *workflowTransitionExecutor) Name() string { return workflow.TransitionExecutorMode }
 
-// RegisterRun creates a fresh TransitionExecutor for a scenario run.
+// RegisterRun creates a fresh TransitionExecutor for a scenario run with no
+// observability emitter. Use RegisterRunWithEmitter when events should be
+// emitted on commits.
 func (e *workflowTransitionExecutor) RegisterRun(runID string, scenario *config.Scenario) {
+	e.RegisterRunWithEmitter(runID, scenario, nil)
+}
+
+// RegisterRunWithEmitter creates a fresh TransitionExecutor for a scenario run
+// and captures the per-run emitter.
+//
+// The emitter is shared between the eager (agent-controlled, fires inside
+// Execute) and deferred (user-controlled, fires from CommitPendingTransition)
+// commit paths through the OnCommit hook wired here. Pass nil for runs that
+// don't need observability events.
+func (e *workflowTransitionExecutor) RegisterRunWithEmitter(
+	runID string, scenario *config.Scenario, emitter *events.Emitter,
+) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	sm := workflow.NewStateMachine(e.wfSpec)
-	e.runs[runID] = &workflowRunState{
-		transExec: workflow.NewTransitionExecutor(sm, e.wfSpec),
+	transExec := workflow.NewTransitionExecutor(sm, e.wfSpec)
+	run := &workflowRunState{
+		transExec: transExec,
 		scenario:  scenario,
+		emitter:   emitter,
 	}
+	e.runs[runID] = run
+	transExec.SetOnCommit(func(tr *workflow.TransitionResult) {
+		e.applyPostCommit(runID, tr)
+	})
 }
 
 // Execute routes the tool call to the per-run TransitionExecutor.
@@ -96,15 +118,18 @@ func (e *workflowTransitionExecutor) Execute(
 	return run.transExec.Execute(ctx, desc, args)
 }
 
-// CommitPendingTransition commits the deferred transition for a run.
-// Called after the turn/pipeline completes. Updates scenario TaskType and
-// re-registers the transition tool for the new state's events.
+// CommitPendingTransition commits any pending deferred transition for a run.
+// Called from the PostTurnHook after the pipeline turn completes (user-control
+// path) and eagerly from WorkflowMetadata reads inside the pipeline. Returns
+// nil and is a no-op when nothing is pending.
 //
-// When emitter is non-nil, emits workflow observability events:
-// workflow.transitioned on every commit, workflow.max_visits_exceeded when
-// the transition redirected or a max-visits cap terminated the workflow,
-// workflow.budget_exhausted when a budget limit tripped, and
-// workflow.completed when the new state is terminal.
+// Post-commit work (transition history, observability events, scenario
+// TaskType update, tool re-registration, skill filter) runs via the
+// OnCommit hook wired in RegisterRun, so it is shared with the agent-control
+// path where the commit fires inside Execute.
+//
+// The emitter parameter is honored only when reporting commit errors. The
+// emitter for successful events is whichever was passed at RegisterRun time.
 func (e *workflowTransitionExecutor) CommitPendingTransition(
 	runID string, emitter *events.Emitter,
 ) error {
@@ -117,17 +142,35 @@ func (e *workflowTransitionExecutor) CommitPendingTransition(
 	}
 
 	pending := run.transExec.Pending()
-	tr, err := run.transExec.CommitPending()
-	if err != nil {
+	if _, err := run.transExec.CommitPending(); err != nil {
 		e.emitWorkflowError(run, emitter, pending.Event, err)
 		return fmt.Errorf("transition commit failed: %w", err)
 	}
+	return nil
+}
+
+// applyPostCommit runs the work that's common to every successful commit
+// (eager or deferred): record the transition, log it, fire observability
+// events, update scenario TaskType, re-register the transition tool for
+// the new state's events, and store the new state's skill filter.
+//
+// Wired into the runtime TransitionExecutor's OnCommit hook from RegisterRun
+// so both control paths (eager from Execute, deferred from CommitPending)
+// run the same post-commit logic.
+func (e *workflowTransitionExecutor) applyPostCommit(
+	runID string, tr *workflow.TransitionResult,
+) {
 	if tr == nil {
-		return nil
+		return
 	}
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
+
+	run := e.runs[runID]
+	if run == nil {
+		return
+	}
 
 	transitionRecord := map[string]any{
 		"from": tr.From, "to": tr.To, "event": tr.Event,
@@ -141,11 +184,9 @@ func (e *workflowTransitionExecutor) CommitPendingTransition(
 	logger.Info("workflow state transition", "from", tr.From, "to", tr.To,
 		"event", tr.Event, "redirected", tr.Redirected)
 
-	// Emit transition observability events before mutating state below, so
-	// listeners see the transition and any max_visits redirect in order.
-	if emitter != nil {
+	if run.emitter != nil {
 		if tr.Redirected {
-			emitter.WorkflowMaxVisitsExceeded(&events.WorkflowMaxVisitsExceededData{
+			run.emitter.WorkflowMaxVisitsExceeded(&events.WorkflowMaxVisitsExceededData{
 				FromState:      tr.From,
 				OriginalTarget: tr.OriginalTarget,
 				Event:          tr.Event,
@@ -155,26 +196,21 @@ func (e *workflowTransitionExecutor) CommitPendingTransition(
 				Terminated:     false,
 			})
 		}
-		emitter.WorkflowTransitioned(tr.From, tr.To, tr.Event, "")
+		run.emitter.WorkflowTransitioned(tr.From, tr.To, tr.Event, "")
 		if newState := e.wfSpec.States[tr.To]; newState != nil &&
 			(newState.Terminal || len(newState.OnEvent) == 0) {
-			emitter.WorkflowCompleted(
+			run.emitter.WorkflowCompleted(
 				tr.To, run.transExec.StateMachine().Context().TransitionCount())
 		}
 	}
 
-	// Update scenario TaskType and re-register tool for the new state
 	if newState := e.wfSpec.States[tr.To]; newState != nil {
 		if run.scenario != nil {
 			run.scenario.TaskType = newState.PromptTask
 		}
 		run.transExec.RegisterForState(e.registry, newState)
-
-		// Store skill filter for this run (applied via context, not globally)
 		run.skillFilter = newState.Skills
 	}
-
-	return nil
 }
 
 // StateMachine returns the per-run state machine for direct access (e.g., metadata).

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -285,8 +285,11 @@ func TestWorkflowRunMetadataProvider_EagerCommitsPending(t *testing.T) {
 	registry := tools.NewRegistry()
 	exec := newWorkflowTransitionExecutor(spec, registry)
 
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run", "sess", "conv")
+
 	scenario := &config.Scenario{ID: "test", TaskType: "intake"}
-	exec.RegisterRun("test", scenario)
+	exec.RegisterRunWithEmitter("test", scenario, emitter)
 
 	args, _ := json.Marshal(map[string]string{"event": "Escalate"})
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "test"), nil, args)
@@ -295,8 +298,6 @@ func TestWorkflowRunMetadataProvider_EagerCommitsPending(t *testing.T) {
 	// Pre-commit: pending transition queued, state still intake on the SM.
 	assert.Equal(t, "intake", exec.StateMachine("test").CurrentState())
 
-	bus := events.NewEventBus()
-	emitter := events.NewEmitter(bus, "run", "sess", "conv")
 	provider := &workflowRunMetadataProvider{exec: exec, scenarioID: "test", emitter: emitter}
 
 	transitioned := make(chan *events.Event, 1)
@@ -584,6 +585,71 @@ func TestEmitWorkflowError_Arena(t *testing.T) {
 	}
 }
 
+// TestWorkflowTransitionExecutor_AgentControlAppliesPostCommitInline verifies
+// the arena-side wiring of the runtime executor's OnCommit hook: an
+// agent-controlled transition fires Execute, which commits inline, which
+// runs applyPostCommit — emitting events, updating scenario.TaskType, and
+// re-registering the transition tool for the new state — all without
+// CommitPendingTransition being called.
+func TestWorkflowTransitionExecutor_AgentControlAppliesPostCommitInline(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "intake",
+		States: map[string]*workflow.State{
+			"intake": {
+				PromptTask: "intake",
+				OnEvent:    map[string]string{"Route": "agent_step"},
+			},
+			"agent_step": {
+				PromptTask: "agent-prompt",
+				Control:    workflow.ControlModeAgent,
+				OnEvent:    map[string]string{"Done": "closed"},
+			},
+			"closed": {PromptTask: "closed", Terminal: true},
+		},
+	}
+	registry := tools.NewRegistry()
+	exec := newWorkflowTransitionExecutor(spec, registry)
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "run", "sess", "conv")
+	transitioned := make(chan *events.Event, 1)
+	bus.Subscribe(events.EventWorkflowTransitioned, func(e *events.Event) { transitioned <- e })
+
+	scenario := &config.Scenario{ID: "r", TaskType: "intake"}
+	exec.RegisterRunWithEmitter("r", scenario, emitter)
+
+	args, _ := json.Marshal(map[string]string{"event": "Route"})
+	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "r"), nil, args)
+	require.NoError(t, err)
+
+	// State advanced — no deferred commit needed.
+	assert.Equal(t, "agent_step", exec.StateMachine("r").CurrentState())
+
+	// scenario.TaskType reflects the new state's prompt_task so the next
+	// pipeline turn (or in-turn LLM call) renders the right system prompt.
+	assert.Equal(t, "agent-prompt", scenario.TaskType)
+
+	// Event fired through the per-run emitter wired at RegisterRun time.
+	select {
+	case e := <-transitioned:
+		assert.Equal(t, events.EventWorkflowTransitioned, e.Type)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("agent-controlled eager commit must emit workflow.transitioned")
+	}
+
+	// Transition recorded in the per-run metadata for workflow assertions.
+	meta := exec.RunMetadata("r")
+	transitions, ok := meta["workflow_transitions"].([]any)
+	require.True(t, ok)
+	require.Len(t, transitions, 1)
+	tr := transitions[0].(map[string]any)
+	assert.Equal(t, "agent_step", tr["to"])
+
+	// CommitPendingTransition is a no-op (nothing pending after eager commit).
+	require.NoError(t, exec.CommitPendingTransition("r", nil))
+}
+
 // TestCommitPendingTransition_EmitsRedirectedEvent verifies that a commit
 // that redirects (max_visits cap hit with on_max_visits fallback) emits
 // workflow.max_visits_exceeded alongside workflow.transitioned.
@@ -604,11 +670,11 @@ func TestCommitPendingTransition_EmitsRedirectedEvent(t *testing.T) {
 	registry := tools.NewRegistry()
 	exec := newWorkflowTransitionExecutor(spec, registry)
 
-	scenario := &config.Scenario{ID: "r", TaskType: "loop"}
-	exec.RegisterRun("r", scenario)
-
 	bus := events.NewEventBus()
 	emitter := events.NewEmitter(bus, "run", "sess", "conv")
+
+	scenario := &config.Scenario{ID: "r", TaskType: "loop"}
+	exec.RegisterRunWithEmitter("r", scenario, emitter)
 
 	received := make(chan *events.Event, 4)
 	bus.Subscribe(events.EventWorkflowMaxVisitsExceeded, func(e *events.Event) {
@@ -619,12 +685,12 @@ func TestCommitPendingTransition_EmitsRedirectedEvent(t *testing.T) {
 	args, _ := json.Marshal(map[string]string{"event": "Again"})
 	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "r"), nil, args)
 	require.NoError(t, err)
-	require.NoError(t, exec.CommitPendingTransition("r", emitter))
+	require.NoError(t, exec.CommitPendingTransition("r", nil))
 
 	// Second transition: visits[loop]=1 == MaxVisits, should redirect to exit.
 	_, err = exec.Execute(withWorkflowScenarioID(context.Background(), "r"), nil, args)
 	require.NoError(t, err)
-	require.NoError(t, exec.CommitPendingTransition("r", emitter))
+	require.NoError(t, exec.CommitPendingTransition("r", nil))
 
 	select {
 	case e := <-received:


### PR DESCRIPTION
## Summary

Adds a `control` property to workflow states that determines whether the agent yields the turn after a transition (default, `user`) or keeps it (`agent`) so it can fire further transitions inside the same pipeline turn. Today's deferred-commit behavior remains the default.

This unblocks scenarios like router → handoff or planner → executor that should not wait for an interleaved user input that will never come.

Spec proposal: AltairaLabs/promptpack-spec#45. The Arena schema (`arena.json: "workflow": true`) is already open, so this lands without a schema change.

## Runtime changes

- `State.Control` + `ControlMode` type with `ControlModeUser` / `ControlModeAgent`.
- `TransitionExecutor.Execute` checks the target state's `Control`. Agent-controlled targets commit inline via `ProcessEvent` and return a richer tool response (`status: transitioned`, `prompt_task`, `description`, `available_events`) so the LLM's next tool-loop iteration has actionable context for the new state.
- `SetOnCommit(fn)` hook fires for every successful commit, eager or deferred. Consumers wire their post-commit work through it.

## Arena changes

- `workflowTransitionExecutor.RegisterRunWithEmitter` captures the per-run emitter at registration and wires `SetOnCommit` to a shared `applyPostCommit` helper. The no-emitter `RegisterRun` is preserved for existing tests.
- `CommitPendingTransition` now only handles the commit-and-report-errors path; all post-commit work (history, events, scenario.TaskType, tool re-registration, skill filter) flows through `applyPostCommit` so eager and deferred paths run identical logic.

## What's not in this PR

- SDK wiring (the SDK uses `workflow.NewTransitionExecutor` directly and will register its own OnCommit hook in a follow-up).
- An end-to-end example pack + selfplay scenario demonstrating multi-transition turns.

Those come next so this PR can be reviewed without scope creep.

## Test plan

- [x] `go test ./runtime/workflow/... -count=1 -race` (3 new tests covering eager commit, default-defer, chained agent transitions)
- [x] `go test ./tools/arena/engine/... -count=1 -race` (1 new test covering arena's OnCommit wiring end-to-end)
- [x] `golangci-lint --new-from-rev=HEAD ./runtime/workflow/... ./tools/arena/engine/...` clean
- [x] Pre-commit hook (lint + build + tests + coverage) green: runtime/workflow 92.5%, transition_executor.go 86.7%, workflow_tool_executor.go 93.5%
