### PR TITLE
feat(examples/workflow-router): control: agent demo with multi-transition turns

### DIFF
--- a/examples/workflow-router/README.md
+++ b/examples/workflow-router/README.md
@@ -1,0 +1,45 @@
+# workflow-router
+
+Demonstrates `control: agent` workflow states for multi-transition turns.
+
+The triage agent reads the user's first message and decides whether to send
+them to billing or technical support — but the routing requires two
+transitions: `triage → routed` and then `routed → billing` (or
+`routed → technical`). Without an agent-controlled state, the second
+transition would have to wait for an extra user message that never comes.
+
+`routed` is declared `control: agent`, so when the agent fires the first
+transition the state machine commits eagerly and the agent keeps the turn,
+firing the destination transition in the same pipeline tool loop.
+
+## Workflow
+
+```
+                     ┌──────────────┐
+        Routed       │   routed     │   ToBilling
+       ───────────►  │ control:agent│  ───────────► billing (terminal)
+                     │              │
+                     │              │   ToTechnical
+                     │              │  ───────────► technical (terminal)
+                     └──────────────┘
+                            ▲
+        ┌────────┐  Routed  │
+   ──►  │ triage │ ─────────┘
+        └────────┘
+```
+
+## Run
+
+```bash
+cd examples/workflow-router
+promptarena run --ci --formats html,json
+```
+
+Both scenarios produce two transitions per opening pipeline turn:
+
+- `route-to-billing`: routed (eager) + billing (deferred)
+- `route-to-technical`: routed (eager) + technical (deferred)
+
+State-aware assertions verify that `state_is` and `transitioned_to` see
+the committed destination, and `workflow_transition_order` confirms both
+transitions fired in the expected sequence inside a single turn.

--- a/examples/workflow-router/config.arena.yaml
+++ b/examples/workflow-router/config.arena.yaml
@@ -1,0 +1,68 @@
+# workflow-router — demonstrates `control: agent` for multi-transition turns.
+#
+# The agent triages the user's message in `triage`, transitions into the
+# transient `routed` state (control: agent — commit fires eagerly so the
+# agent keeps the turn), then immediately fires the appropriate routing
+# transition to `billing` or `technical` in the same pipeline turn.
+#
+# Without control: agent the routing transition would defer to end-of-turn
+# and the agent would have to wait for an extra user message that never
+# comes — `routed` exists purely to give the agent a moment to decide where
+# to send the conversation next.
+#
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: workflow-router-arena
+spec:
+  prompt_configs:
+    - id: triage
+      file: prompts/triage.yaml
+    - id: routed
+      file: prompts/routed.yaml
+    - id: billing
+      file: prompts/billing.yaml
+    - id: technical
+      file: prompts/technical.yaml
+
+  providers:
+    - file: providers/mock-provider.yaml
+
+  scenarios:
+    - file: scenarios/route-to-billing.scenario.yaml
+    - file: scenarios/route-to-technical.scenario.yaml
+
+  workflow:
+    version: 1
+    entry: triage
+    states:
+      triage:
+        prompt_task: triage
+        description: "Read the user's message and pick a route."
+        on_event:
+          Routed: routed
+
+      routed:
+        prompt_task: routed
+        control: agent
+        description: "Transient state — agent picks the destination immediately."
+        on_event:
+          ToBilling: billing
+          ToTechnical: technical
+
+      billing:
+        prompt_task: billing
+        description: "Billing specialist."
+        terminal: true
+
+      technical:
+        prompt_task: technical
+        description: "Technical specialist."
+        terminal: true
+
+  defaults:
+    temperature: 0.1
+    max_tokens: 512
+    output:
+      dir: out
+      formats: ["json", "html"]

--- a/examples/workflow-router/mock-responses.yaml
+++ b/examples/workflow-router/mock-responses.yaml
@@ -1,0 +1,57 @@
+# Mock responses for the workflow-router example.
+#
+# Each scenario exercises two workflow transitions inside a single pipeline
+# turn: the first into `routed` (control: agent — commits eagerly) and the
+# second out to the destination (`billing` or `technical`, control: user —
+# defers to end of turn). The mock LLM keeps producing tool calls until the
+# pipeline tool loop sees a plain text response.
+
+scenarios:
+  route-to-billing:
+    turns:
+      # --- Pipeline turn 1: triage routes to billing ---
+      1:
+        # Triage agent picks the routing path. workflow__transition(Routed)
+        # targets the routed state (control: agent) — the runtime commits
+        # eagerly and the tool response carries routed's available_events.
+        response: ""
+        tool_calls:
+          - name: workflow__transition
+            arguments:
+              event: Routed
+              context: "User reports a duplicate charge — routing for specialist handoff."
+      2:
+        # Same turn, now in routed: agent picks billing. ToBilling targets
+        # a user-controlled state so the transition defers to end-of-turn.
+        response: ""
+        tool_calls:
+          - name: workflow__transition
+            arguments:
+              event: ToBilling
+              context: "Duplicate-charge issue — billing specialist."
+      3: "I've routed you to our billing specialist who will help with the duplicate charge."
+
+      # --- Pipeline turn 2: billing specialist takes over ---
+      4: "Hello, I'm the billing specialist. Could you share the account number and the date of the duplicate charge?"
+
+  route-to-technical:
+    turns:
+      # --- Pipeline turn 1: triage routes to technical ---
+      1:
+        response: ""
+        tool_calls:
+          - name: workflow__transition
+            arguments:
+              event: Routed
+              context: "User reports a crash on launch — routing for technical handoff."
+      2:
+        response: ""
+        tool_calls:
+          - name: workflow__transition
+            arguments:
+              event: ToTechnical
+              context: "Crash-on-launch issue — technical specialist."
+      3: "I've connected you to our technical specialist who will help with the crash."
+
+      # --- Pipeline turn 2: technical specialist takes over ---
+      4: "Hello, I'm the technical specialist. What error or behavior are you seeing when the app launches?"

--- a/examples/workflow-router/prompts/billing.yaml
+++ b/examples/workflow-router/prompts/billing.yaml
@@ -1,0 +1,16 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: billing
+spec:
+  task_type: "billing"
+  version: "v1.0.0"
+  description: "Billing specialist."
+
+  system_template: |
+    You are the billing specialist at TechCo. The triage agent has routed
+    this conversation to you because the user has a billing concern.
+
+    - Acknowledge that you're the billing specialist now handling the case.
+    - Ask for any specifics you need (account ID, charge amount, dates).
+    - Resolve the issue with concrete next steps.

--- a/examples/workflow-router/prompts/routed.yaml
+++ b/examples/workflow-router/prompts/routed.yaml
@@ -1,0 +1,20 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: routed
+spec:
+  task_type: "routed"
+  version: "v1.0.0"
+  description: "Transient routing state. The agent never speaks here."
+
+  # Agent-controlled state: the previous turn's eager-commit places the
+  # agent here, and the agent is expected to immediately fire the next
+  # transition (ToBilling / ToTechnical) inside the same pipeline turn.
+  #
+  # If a user message ever arrives while the workflow is in this state,
+  # something has gone wrong with routing; remind the agent to pick a
+  # destination and continue.
+  system_template: |
+    You are in the transient routing state. Choose a destination by calling
+    workflow__transition with either "ToBilling" or "ToTechnical". Do not
+    reply to the user from this state.

--- a/examples/workflow-router/prompts/technical.yaml
+++ b/examples/workflow-router/prompts/technical.yaml
@@ -1,0 +1,16 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: technical
+spec:
+  task_type: "technical"
+  version: "v1.0.0"
+  description: "Technical specialist."
+
+  system_template: |
+    You are the technical specialist at TechCo. The triage agent has routed
+    this conversation to you because the user has a technical issue.
+
+    - Acknowledge that you're the technical specialist now handling the case.
+    - Ask for any specifics you need (error message, steps to reproduce, OS).
+    - Walk the user through troubleshooting.

--- a/examples/workflow-router/prompts/triage.yaml
+++ b/examples/workflow-router/prompts/triage.yaml
@@ -1,0 +1,24 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: triage
+spec:
+  task_type: "triage"
+  version: "v1.0.0"
+  description: "Read the user's message and decide where to route them."
+
+  system_template: |
+    You are the triage agent at TechCo. Decide whether the user needs the
+    billing specialist or the technical specialist, then route the
+    conversation.
+
+    Process:
+    1. Read the user's message.
+    2. Call workflow__transition with event "Routed" to enter the routing
+       state (this fires eagerly because the routed state is agent-controlled).
+    3. Inside the same turn, call workflow__transition again with either
+       "ToBilling" or "ToTechnical" depending on the issue.
+    4. Reply to the user with a brief handoff acknowledgement.
+
+    Do not ask the user follow-up questions in this state — pick a route
+    and hand off.

--- a/examples/workflow-router/providers/mock-provider.yaml
+++ b/examples/workflow-router/providers/mock-provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-router
+spec:
+  id: mock-router
+  type: mock
+  model: mock-model
+  additional_config:
+    mock_config: mock-responses.yaml
+  defaults:
+    temperature: 0.1
+    max_tokens: 512
+    top_p: 1.0

--- a/examples/workflow-router/scenarios/route-to-billing.scenario.yaml
+++ b/examples/workflow-router/scenarios/route-to-billing.scenario.yaml
@@ -1,0 +1,35 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: route-to-billing
+spec:
+  id: route-to-billing
+  task_type: triage
+  description: "Triage agent routes a billing complaint through routed (control: agent) to billing in a single pipeline turn."
+  turns:
+    - role: user
+      content: "Hi, I was charged twice for my subscription this month."
+      assertions:
+        # End-of-turn state observes the committed end state (billing).
+        # The eager commit to `routed` already happened during the turn, so
+        # state_is sees the final destination, not the transient state.
+        - type: state_is
+          params:
+            state: billing
+        - type: transitioned_to
+          params:
+            state: billing
+
+    - role: user
+      content: "Account AC-12345, both charges on the 14th."
+      assertions:
+        - type: content_matches
+          params:
+            pattern: "(?i)(billing|account|charge)"
+
+  conversation_assertions:
+    # Both transitions fire in turn 1; turn 2 fires no transitions. The
+    # transition order proves multi-transition turns committed correctly.
+    - type: workflow_transition_order
+      params:
+        sequence: ["routed", "billing"]

--- a/examples/workflow-router/scenarios/route-to-technical.scenario.yaml
+++ b/examples/workflow-router/scenarios/route-to-technical.scenario.yaml
@@ -1,0 +1,30 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: route-to-technical
+spec:
+  id: route-to-technical
+  task_type: triage
+  description: "Triage agent routes a technical issue through routed (control: agent) to technical in a single pipeline turn."
+  turns:
+    - role: user
+      content: "Hi, the app crashes immediately every time I open it."
+      assertions:
+        - type: state_is
+          params:
+            state: technical
+        - type: transitioned_to
+          params:
+            state: technical
+
+    - role: user
+      content: "macOS 14.5, the splash screen flashes once then it quits."
+      assertions:
+        - type: content_matches
+          params:
+            pattern: "(?i)(error|crash|launch|app|technical)"
+
+  conversation_assertions:
+    - type: workflow_transition_order
+      params:
+        sequence: ["routed", "technical"]

--- a/runtime/prompt/schema/promptpack.schema.json
+++ b/runtime/prompt/schema/promptpack.schema.json
@@ -1270,6 +1270,11 @@
           "description": "How this state is orchestrated: internal (runtime manages), external (caller manages), or hybrid.",
           "enum": ["internal", "external", "hybrid"]
         },
+        "control": {
+          "type": "string",
+          "description": "Who holds control after a transition into this state. 'user' (default) ends the agent's turn; 'agent' lets the agent keep the turn so it can fire further transitions inside the same pipeline turn.",
+          "enum": ["user", "agent"]
+        },
         "skills": {
           "type": "string",
           "description": "Skill filter for this workflow state. A path to a skill directory/file that scopes which skills are available in this state, or the literal 'none' to disable skills.",


### PR DESCRIPTION
## Summary

End-to-end example demonstrating the `control: agent` workflow property landed in #1185. The triage agent reads a single user message and routes through a transient agent-controlled state into billing or technical specialists — two workflow transitions inside one pipeline turn, no extra user message required.

## Workflow

```
                     ┌──────────────┐
        Routed       │   routed     │   ToBilling
       ───────────►  │ control:agent│  ───────────► billing (terminal)
                     │              │
                     │              │   ToTechnical
                     │              │  ───────────► technical (terminal)
                     └──────────────┘
                            ▲
        ┌────────┐  Routed  │
   ──►  │ triage │ ─────────┘
        └────────┘
```

## What this proves

- `control: agent` actually fires eager commits in the runtime + arena bridge.
- The transition tool descriptor is re-registered for the new state's events between tool-loop iterations (otherwise `ToBilling` / `ToTechnical` would be rejected as invalid against `routed`'s events).
- Per-turn workflow assertions read the final post-commit state, so `state_is(billing)` and `transitioned_to(billing)` hold even though the eager commit landed on `routed` first.
- `workflow_transition_order(["routed", "billing"])` confirms both transitions fired inside a single pipeline turn.

## Test plan

- [x] `cd examples/workflow-router && promptarena run --ci --formats json` — both scenarios pass all assertions (state_is, transitioned_to, content_matches, workflow_transition_order)
- [x] Mock provider scripts the LLM through two `workflow__transition` calls in turn 1; turn 2 runs in the destination state (billing/technical) with no further transitions
- [x] No API keys required
