### PR TITLE
test(arena/web): fix data race in TestStartRun_PersistsEachRunBeforeExecuteRunsReturns

### DIFF
--- a/tools/arena/web/server_test.go
+++ b/tools/arena/web/server_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -373,7 +374,12 @@ func TestStartRun_PersistsEachRunBeforeExecuteRunsReturns(t *testing.T) {
 	runID := "run-per-hook-1"
 
 	expected := filepath.Join(tmpDir, runID+".json")
-	var sawOnDiskBeforeReturn bool
+	// preReturn runs on the server's background goroutine; the test polls
+	// from the goroutine running the test body. Use atomic.Bool so the read
+	// has happens-before with the write — without it the race detector
+	// rightly fires even when the file's existence proves the persistence
+	// hook ordering.
+	var sawOnDiskBeforeReturn atomic.Bool
 
 	mock := &persistingMockEngine{
 		plan: &engine.RunPlan{
@@ -383,7 +389,7 @@ func TestStartRun_PersistsEachRunBeforeExecuteRunsReturns(t *testing.T) {
 		runID: runID,
 		preReturn: func() {
 			if _, err := os.Stat(expected); err == nil {
-				sawOnDiskBeforeReturn = true
+				sawOnDiskBeforeReturn.Store(true)
 			}
 		},
 	}
@@ -406,7 +412,7 @@ func TestStartRun_PersistsEachRunBeforeExecuteRunsReturns(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if !sawOnDiskBeforeReturn {
+	if !sawOnDiskBeforeReturn.Load() {
 		t.Errorf("expected %s to exist before ExecuteRuns returned, but it didn't", expected)
 	}
 }


### PR DESCRIPTION
## Summary

The test wrote `sawOnDiskBeforeReturn` from the server's background goroutine (via the mock's `preReturn` callback) and read it from the test body goroutine with no synchronization. The file-existence check provided observational ordering but no memory-model guarantee, so the race detector rightly fired on every run with `-race`.

Make the flag `atomic.Bool`. The fix is internal to the test — the production code already orders persistence correctly via `RunCompletedHook`.

The race was introduced with the original test in #1138 and has flaked CI on #1184 and #1186; it's not workflow- or `control: agent`-related.

## Test plan

- [x] Reproduced the race with `go test ./tools/arena/web/ -run TestStartRun_PersistsEachRunBeforeExecuteRunsReturns -race -count=1`
- [x] Fixed test passes 5× in a row with `-race -count=5`
- [x] Pre-commit lint + build + arena test suite green
