### PR TITLE
feat(sdk/workflow): wire control: agent for multi-transition Sends

### DIFF
--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -347,11 +347,31 @@ func (wc *WorkflowConversation) reconcileActiveConv(contextSummary string) error
 	if wc.activeConv.promptName == targetPrompt {
 		return nil
 	}
-	_ = wc.activeConv.Close()
+	return wc.openConvForCurrentState(contextSummary)
+}
+
+// openConvForCurrentState closes the active conversation (if any) and opens
+// a new one for the workflow machine's current prompt_task. The new conv
+// receives carry-forward context (when non-empty) and artifact values as
+// template variables, and workflow tools are re-registered on its registry.
+//
+// Shared between applyTransition (manual Transition path) and
+// reconcileActiveConv (post-Send / post-CommitPending). The two paths
+// differ only in what they do AFTER the conv is opened — applyTransition
+// also fires transition events and persists context, since it bypasses
+// the OnCommit hook. reconcileActiveConv relies on the hook having
+// already done that work.
+//
+// Caller must hold wc.mu.
+func (wc *WorkflowConversation) openConvForCurrentState(contextSummary string) error {
+	targetPrompt := wc.machine.CurrentPromptTask()
+	if wc.activeConv != nil {
+		_ = wc.activeConv.Close()
+	}
 
 	opts := wc.opts
 	if contextSummary != "" {
-		opts = append(append([]Option{}, wc.opts...), WithVariables(map[string]string{
+		opts = append(append([]Option{}, opts...), WithVariables(map[string]string{
 			workflowContextVar: contextSummary,
 		}))
 	}
@@ -458,56 +478,26 @@ func (wc *WorkflowConversation) onTransitionCommitted(result *workflow.Transitio
 	}
 }
 
-// applyTransition handles post-commit transition logic: close old conversation,
-// open new one, re-register tools, persist context, emit events.
+// applyTransition handles post-commit transition logic for the manual
+// Transition() path: open a fresh conversation for the new state, persist
+// the workflow context, and emit transition events.
+//
+// Only the manual path (Transition / transitionInternal) goes through here
+// because it bypasses the TransitionExecutor (calls ProcessEvent directly),
+// so the OnCommit hook never fires. The LLM-initiated path
+// (commitDeferredTransition) flows through onTransitionCommitted +
+// reconcileActiveConv instead.
 func (wc *WorkflowConversation) applyTransition(
 	result *workflow.TransitionResult, contextSummary string,
 ) (string, error) {
 	toState := result.To
-
-	// Close old conversation
-	if wc.activeConv != nil {
-		_ = wc.activeConv.Close()
+	if err := wc.openConvForCurrentState(contextSummary); err != nil {
+		return "", err
 	}
-
-	// Build options, injecting context as a template variable if available
-	opts := wc.opts
-	if contextSummary != "" {
-		opts = append(append([]Option{}, wc.opts...), WithVariables(map[string]string{
-			workflowContextVar: contextSummary,
-		}))
-	}
-
-	// Inject artifact values as template variables
-	if arts := wc.machine.Artifacts(); len(arts) > 0 {
-		artVars := make(map[string]string, len(arts))
-		for k, v := range arts {
-			artVars["artifacts."+k] = v
-		}
-		opts = append(append([]Option{}, opts...), WithVariables(artVars))
-	}
-
-	// Open new conversation for the new state
-	promptName := wc.machine.CurrentPromptTask()
-	conv, err := Open(wc.packPath, promptName, opts...)
-	if err != nil {
-		return "", fmt.Errorf("failed to open conversation for state %q (prompt %q): %w",
-			toState, promptName, err)
-	}
-	wc.activeConv = conv
-
-	// Re-register workflow tools for the new state
-	wc.registerWorkflowTools()
-
-	// Persist workflow context if state store is configured
 	if wc.stateStore != nil && wc.workflowID != "" {
 		wc.persistWorkflowContext()
 	}
-
-	// Emit transition events (transitioned, max_visits_exceeded if this was
-	// a redirect, and completed if the new state is terminal).
-	wc.emitTransitionEvents(result, toState, promptName)
-
+	wc.emitTransitionEvents(result, toState, wc.machine.CurrentPromptTask())
 	return toState, nil
 }
 

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -27,6 +27,9 @@ const (
 	workflowCurrentKey       = "workflow.current"
 	workflowHistoryListName  = "workflow.history"
 	workflowArtifactListName = "workflow.artifact_history"
+	// workflowContextVar is the template variable name that carries the
+	// previous state's conversation summary into the new state's prompt.
+	workflowContextVar = "workflow_context"
 )
 
 // WorkflowConversation manages a stateful workflow that transitions between
@@ -292,30 +295,81 @@ func (wc *WorkflowConversation) Send(ctx context.Context, message any, opts ...S
 	return resp, nil
 }
 
-// commitDeferredTransition commits any pending transition recorded by the
-// workflow__transition tool during the just-completed Send. Errors from
-// ProcessEvent are routed through emitWorkflowError before being returned
-// so observability events fire even when the transition aborts. Caller
-// must hold wc.mu.
+// commitDeferredTransition finalizes any workflow transitions that fired
+// during the just-completed Send. Two paths converge here:
+//
+//   - control: user (default) — the workflow__transition tool stored a
+//     pending transition during the pipeline; CommitPending now runs
+//     ProcessEvent and fires the OnCommit hook.
+//   - control: agent — the transition already committed eagerly inside
+//     Execute and the OnCommit hook has already run; CommitPending is a
+//     no-op.
+//
+// Either way, if the machine has moved past the active conversation's
+// prompt task, reconcileActiveConv closes the old conv and opens a new
+// one for the destination state's prompt. Errors from ProcessEvent are
+// routed through emitWorkflowError so observability events fire even
+// when a deferred transition aborts on commit. Caller must hold wc.mu.
 func (wc *WorkflowConversation) commitDeferredTransition() error {
 	if wc.transExec == nil {
 		return nil
 	}
-	pending := wc.transExec.Pending()
-	if pending == nil {
-		return nil
-	}
-	contextSummary := pending.ContextSummary
-	result, commitErr := wc.transExec.CommitPending()
-	if commitErr != nil {
-		wc.emitWorkflowError(pending.Event, commitErr)
-		return commitErr
-	}
-	if result != nil {
-		if _, transErr := wc.applyTransition(result, contextSummary); transErr != nil {
-			return transErr
+	var contextSummary string
+	if pending := wc.transExec.Pending(); pending != nil {
+		contextSummary = pending.ContextSummary
+		if _, commitErr := wc.transExec.CommitPending(); commitErr != nil {
+			wc.emitWorkflowError(pending.Event, commitErr)
+			return commitErr
 		}
 	}
+	return wc.reconcileActiveConv(contextSummary)
+}
+
+// reconcileActiveConv brings the active conversation in line with the
+// workflow machine's current state. If they already match (no transition
+// happened during the just-completed Send) this is a no-op. Otherwise the
+// active conv is closed and a new one is opened for the destination
+// state's prompt_task, with the optional context summary injected as the
+// {{workflow_context}} template variable.
+//
+// Multi-transition Sends (the agent fired one or more control: agent
+// eager commits and possibly a final deferred commit) all funnel through
+// here once at end-of-Send; intermediate states never get their own
+// conversation, which is the whole point of control: agent.
+func (wc *WorkflowConversation) reconcileActiveConv(contextSummary string) error {
+	if wc.activeConv == nil {
+		return nil
+	}
+	targetPrompt := wc.machine.CurrentPromptTask()
+	if targetPrompt == "" {
+		return nil
+	}
+	if wc.activeConv.promptName == targetPrompt {
+		return nil
+	}
+	_ = wc.activeConv.Close()
+
+	opts := wc.opts
+	if contextSummary != "" {
+		opts = append(append([]Option{}, wc.opts...), WithVariables(map[string]string{
+			workflowContextVar: contextSummary,
+		}))
+	}
+	if arts := wc.machine.Artifacts(); len(arts) > 0 {
+		artVars := make(map[string]string, len(arts))
+		for k, v := range arts {
+			artVars["artifacts."+k] = v
+		}
+		opts = append(append([]Option{}, opts...), WithVariables(artVars))
+	}
+
+	conv, err := Open(wc.packPath, targetPrompt, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to open conversation for state %q (prompt %q): %w",
+			wc.machine.CurrentState(), targetPrompt, err)
+	}
+	wc.activeConv = conv
+	wc.registerWorkflowTools()
 	return nil
 }
 
@@ -351,6 +405,18 @@ func (wc *WorkflowConversation) Transition(event string) (string, error) {
 
 // registerWorkflowTools registers the workflow tool executors and descriptors
 // for the current state on the active conversation's tool registry.
+//
+// Also installs the OnCommit hook on the TransitionExecutor so post-commit
+// work (re-register transition tool for new state events, emit observability
+// events, persist workflow context) runs from a single place regardless of
+// whether the commit was eager (control: agent target, fires inside Execute)
+// or deferred (control: user target, fires from CommitPending after Send).
+//
+// The hook updates the active conversation's tool registry in place; the
+// active conv itself stays unchanged for the rest of the Send so the
+// pipeline tool loop can keep looking up the same registry. The post-Send
+// reconcileActiveConv step opens a new conversation if the workflow has
+// moved on.
 func (wc *WorkflowConversation) registerWorkflowTools() {
 	registry := wc.activeConv.ToolRegistry()
 	state := wc.workflowSpec.States[wc.machine.CurrentState()]
@@ -359,11 +425,37 @@ func (wc *WorkflowConversation) registerWorkflowTools() {
 	wc.transExec = workflow.NewTransitionExecutor(wc.machine, wc.workflowSpec)
 	registry.RegisterExecutor(wc.transExec)
 	wc.transExec.RegisterForState(registry, state)
+	wc.transExec.SetOnCommit(wc.onTransitionCommitted)
 
 	// Create and register artifact executor if spec declares artifacts
 	wc.artifactExec = workflow.NewArtifactExecutor(wc.machine)
 	registry.RegisterExecutor(wc.artifactExec)
 	workflow.RegisterArtifactTool(registry, wc.workflowSpec)
+}
+
+// onTransitionCommitted runs the post-commit work shared between eager and
+// deferred commits. It updates the active conversation's transition tool
+// for the new state's events so subsequent tool-loop iterations in the same
+// pipeline turn can use them, fires observability events, and persists the
+// updated workflow context.
+//
+// Closing the active conversation and opening a new one for the destination
+// state's prompt is deferred to reconcileActiveConv, which runs once at the
+// end of Send / Transition so multi-transition pipeline turns don't churn
+// through intermediate convs.
+func (wc *WorkflowConversation) onTransitionCommitted(result *workflow.TransitionResult) {
+	if result == nil {
+		return
+	}
+	if wc.activeConv != nil && wc.transExec != nil {
+		if newState := wc.workflowSpec.States[result.To]; newState != nil {
+			wc.transExec.RegisterForState(wc.activeConv.ToolRegistry(), newState)
+		}
+	}
+	wc.emitTransitionEvents(result, result.To, wc.machine.CurrentPromptTask())
+	if wc.stateStore != nil && wc.workflowID != "" {
+		wc.persistWorkflowContext()
+	}
 }
 
 // applyTransition handles post-commit transition logic: close old conversation,
@@ -382,7 +474,7 @@ func (wc *WorkflowConversation) applyTransition(
 	opts := wc.opts
 	if contextSummary != "" {
 		opts = append(append([]Option{}, wc.opts...), WithVariables(map[string]string{
-			"workflow_context": contextSummary,
+			workflowContextVar: contextSummary,
 		}))
 	}
 

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -1842,3 +1842,114 @@ func TestHydrateWorkflowContextLists_RebuildsFromLists(t *testing.T) {
 	require.Len(t, wfCtx.ArtifactHistory, 1)
 	assert.Equal(t, "a", wfCtx.ArtifactHistory[0].FromState)
 }
+
+// TestReconcileActiveConv_NoOpOnMatchingState verifies that when the
+// workflow machine's current prompt_task already matches the active
+// conversation's prompt name, reconcileActiveConv is a no-op — it must
+// not close the active conv or attempt to open a new one. This is the
+// hot path during normal Sends that don't trigger a transition.
+func TestReconcileActiveConv_NoOpOnMatchingState(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*workflow.State{
+			"a": {PromptTask: "task-a", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "task-b"},
+		},
+	}
+	wc := &WorkflowConversation{
+		machine:      workflow.NewStateMachine(spec),
+		workflowSpec: spec,
+		// activeConv already at task-a — matches machine's current prompt_task.
+		activeConv: &Conversation{promptName: "task-a"},
+		packPath:   "/nonexistent/pack.json", // would fail Open if reconcile tried
+	}
+	require.NoError(t, wc.reconcileActiveConv(""))
+	assert.False(t, wc.activeConv.closed, "active conv must remain open when no transition occurred")
+	assert.Equal(t, "task-a", wc.activeConv.promptName)
+}
+
+// TestReconcileActiveConv_NoActiveConv verifies the helper returns nil
+// when there is no active conversation yet (e.g., during initial open).
+func TestReconcileActiveConv_NoActiveConv(t *testing.T) {
+	spec := &workflow.Spec{Version: 1, Entry: "a", States: map[string]*workflow.State{
+		"a": {PromptTask: "task-a"},
+	}}
+	wc := &WorkflowConversation{
+		machine:      workflow.NewStateMachine(spec),
+		workflowSpec: spec,
+	}
+	require.NoError(t, wc.reconcileActiveConv(""))
+}
+
+// TestOnTransitionCommitted_EmitsEvent verifies the hook fires
+// workflow.transitioned for both eager (in-Send) and deferred (post-Send)
+// commits. This is the same signal Arena emits and what observability
+// consumers subscribe to.
+func TestOnTransitionCommitted_EmitsEvent(t *testing.T) {
+	bus := events.NewEventBus()
+	transitioned := make(chan *events.Event, 4)
+	bus.Subscribe(events.EventWorkflowTransitioned, func(e *events.Event) { transitioned <- e })
+
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*workflow.State{
+			"a": {PromptTask: "p-a", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "p-b"},
+		},
+	}
+	wc := &WorkflowConversation{
+		machine:      workflow.NewStateMachine(spec),
+		workflowSpec: spec,
+		emitter:      events.NewEmitter(bus, "", "", ""),
+	}
+	wc.onTransitionCommitted(&workflow.TransitionResult{From: "a", To: "b", Event: "Go"})
+
+	select {
+	case e := <-transitioned:
+		assert.Equal(t, events.EventWorkflowTransitioned, e.Type)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected workflow.transitioned event")
+	}
+}
+
+// TestOnTransitionCommitted_NilResultIsNoOp verifies the hook does
+// nothing when called with a nil TransitionResult (matches CommitPending's
+// nil-on-noop semantics).
+func TestOnTransitionCommitted_NilResultIsNoOp(t *testing.T) {
+	wc := &WorkflowConversation{}
+	wc.onTransitionCommitted(nil) // must not panic
+}
+
+// TestReconcileActiveConv_StateDivergedOpenError verifies that when the
+// machine has moved past the active conv but Open() fails (e.g., bad
+// pack path), reconcileActiveConv closes the old conv and returns the
+// open error. This is the only failure surface added by the refactor —
+// the no-op path is the hot path and is covered separately.
+func TestReconcileActiveConv_StateDivergedOpenError(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 1,
+		Entry:   "a",
+		States: map[string]*workflow.State{
+			"a": {PromptTask: "task-a", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "task-b"},
+		},
+	}
+	machine := workflow.NewStateMachine(spec)
+	// Advance machine to "b" so its CurrentPromptTask diverges from the
+	// active conv's promptName.
+	_, err := machine.ProcessEvent("Go")
+	require.NoError(t, err)
+
+	wc := &WorkflowConversation{
+		machine:      machine,
+		workflowSpec: spec,
+		activeConv:   &Conversation{promptName: "task-a"},
+		packPath:     "/nonexistent/pack.json",
+	}
+	err = wc.reconcileActiveConv("a summary")
+	require.Error(t, err, "Open against a missing pack path must surface its error")
+	assert.Contains(t, err.Error(), "task-b")
+	assert.True(t, wc.activeConv.closed, "old conv must be closed even when opening the new one fails")
+}


### PR DESCRIPTION
## Summary

Step 3 of the `control: agent` feature. The runtime and Arena landed it in #1185; SDK consumers couldn't use the feature because the SDK still ran a one-conv-per-state flow that closed and reopened conversations from inside `CommitPending` — incompatible with eager commits firing mid-Send.

## Refactor

- `registerWorkflowTools` installs an `OnCommit` hook on the runtime `TransitionExecutor`. The hook handles the in-process post-commit work shared between eager and deferred paths: re-register the `workflow__transition` descriptor for the new state's events on the active conv's tool registry, emit transition events, persist workflow context.
- `commitDeferredTransition` no longer drives conv close/reopen. It captures `pending.ContextSummary`, calls `CommitPending` (which fires `OnCommit`), then calls `reconcileActiveConv` to bring the active conv in line with the machine's current state.
- `reconcileActiveConv` is a new method that closes the old conv and opens a new one for `machine.CurrentPromptTask()` when (and only when) the workflow has actually moved on. Multi-transition Sends funnel through it once at end-of-Send — intermediate states never get their own conversation, which is the whole point of `control: agent`.

The manual `Transition()` path is untouched: it bypasses the `TransitionExecutor` (calls `ProcessEvent` directly), so the `OnCommit` hook doesn't fire there and the existing `applyTransition` flow still applies.

## Tests

- `reconcileActiveConv` no-op when current state matches active conv's prompt
- `reconcileActiveConv` no-op when there's no active conv
- `reconcileActiveConv` closes old conv and surfaces error when `Open` fails on the new state's prompt
- `onTransitionCommitted` emits `workflow.transitioned` for both eager and deferred commits
- `onTransitionCommitted` nil-result-safe

## Test plan

- [x] `go test ./sdk/... -count=1 -race` — full suite passes
- [x] `golangci-lint --new-from-rev=HEAD ./sdk/...` clean
- [x] Pre-commit hook: lint + build + tests + coverage (sdk/workflow.go 81.1%) all green
