### PR TITLE
docs(concepts): document workflow control: user|agent property

### DIFF
--- a/docs/src/content/docs/concepts/state-management.md
+++ b/docs/src/content/docs/concepts/state-management.md
@@ -218,6 +218,47 @@ wf, _ := sdk.OpenWorkflow("./support.pack.json",
 )
 ```
 
+### Agent vs User Control
+
+Each workflow state can declare who holds control after a transition into it:
+
+```json
+{
+  "states": {
+    "triage": {
+      "prompt_task": "triage",
+      "on_event": { "Routed": "routed" }
+    },
+    "routed": {
+      "prompt_task": "routed",
+      "control": "agent",
+      "on_event": {
+        "ToBilling": "billing",
+        "ToTechnical": "technical"
+      }
+    },
+    "billing":   { "prompt_task": "billing",   "terminal": true },
+    "technical": { "prompt_task": "technical", "terminal": true }
+  }
+}
+```
+
+- **`control: user`** (default) — the agent's turn ends after the transition. The state machine commits at end-of-pipeline-turn and the user (or selfplay driver) speaks next.
+- **`control: agent`** — the agent keeps the turn after the transition. The state machine commits eagerly inside the pipeline tool loop so subsequent LLM calls in the same turn see the new state's events and can fire further transitions.
+
+In the example above, the agent reads the user's first message in `triage`, fires `Routed` to enter `routed` (eager commit, agent keeps the turn), then immediately fires `ToBilling` or `ToTechnical` to land in the specialist state — two transitions, one pipeline turn, no extra user message required. See the [`workflow-router`](https://github.com/AltairaLabs/PromptKit/tree/main/examples/workflow-router) example for the full pack.
+
+When to use which:
+
+| Scenario                                                  | Use            |
+|-----------------------------------------------------------|----------------|
+| Standard conversational state (intake → reply → next msg) | `user` (default) |
+| Transient routing state (router → destination)            | `agent`        |
+| Planner → executor chain inside a single turn             | `agent` on the intermediate |
+| User must reply before the next state can run             | `user`         |
+
+The destination state's `control` is what determines behavior, not the source. A user-controlled state may transition into an agent-controlled state and vice versa.
+
 ## Best Practices
 
 ### Do's


### PR DESCRIPTION
## Summary

Adds an "Agent vs User Control" section under Workflow State in the state-management concepts page covering:

- The property's two values (`user` is default, `agent` enables eager commit)
- A worked example with a transient routing state
- A use-case decision table
- Link to the workflow-router example

The example pages under `arena/examples/` are auto-generated by `scripts/prepare-examples-docs.sh` from each example's README.md, so the workflow-router README shipping in #1186 already produces that example page. This PR only updates the conceptual docs.

## Test plan

- [x] Markdown-only change; internal anchor matches the heading slug
