### PR TITLE
fix(capability-matrix): handle zero-error runs in summary parsing

### DIFF
--- a/.github/workflows/capability-matrix.yml
+++ b/.github/workflows/capability-matrix.yml
@@ -76,8 +76,11 @@ jobs:
         RUN_EXIT=$?
         set -e
 
-        # Count errors
-        ERROR_COUNT=$(grep -c 'level=ERROR.*Turn execution failed' run.log || echo "0")
+        # Count errors. `grep -c` prints 0 AND exits 1 on no matches, so
+        # `grep -c ... || echo 0` produces "0\n0" (two values), which then
+        # breaks the arithmetic and -gt comparison below. Use a pipe to wc
+        # so the count is always a single integer and exit code is 0.
+        ERROR_COUNT=$(grep 'level=ERROR.*Turn execution failed' run.log | wc -l | tr -d ' ')
         TOTAL=$(grep -oP 'Generated \K[0-9]+' run.log || echo "0")
         PASSED=$((TOTAL - ERROR_COUNT))
         echo "error_count=$ERROR_COUNT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The scheduled Provider Capability Matrix workflow has been failing for three weeks (since 2026-04-26 — runs 24950978460, 25273490052, 25623452425, 25985499162 all failed with the same error). Every run now reports zero errors, which is exactly the case the summary-parsing script doesn't handle.

## Root cause

```bash
ERROR_COUNT=$(grep -c 'level=ERROR.*Turn execution failed' run.log || echo "0")
```

`grep -c PATTERN file` prints `0` on stdout AND exits 1 when there are no matches. The `|| echo "0"` then writes another `0`, so `$ERROR_COUNT` ends up holding `"0\n0"`. The subsequent arithmetic and -gt comparison both blow up:

```
Total: 175 | Passed:  | Errors: 0
0: integer expression expected
```

## Fix

Switch to `grep … | wc -l | tr -d ' '`. The pipe always exits 0; `wc -l` always returns a single integer (including 0 for no matches).

## Test plan

- [x] Reproduced the buggy "0\n0" output locally with the original form and confirmed it makes the arithmetic fail
- [x] New form returns `0` for no matches and `N` for N matches when tested against synthetic logs
- [x] Workflow itself can't run on a PR (it's scheduled-only) — next Sunday's cron will confirm
