### PR TITLE
test(runtime/providers): fix timing flakes in streaming and retry-budget tests

### DIFF
--- a/runtime/providers/stream_retry_test.go
+++ b/runtime/providers/stream_retry_test.go
@@ -598,7 +598,12 @@ func TestOpenStreamWithRetryRequest_BudgetAllowsRetry(t *testing.T) {
 	})
 	defer srv.Close()
 
-	budget := NewRetryBudget(100, 10)
+	// rate=1/s, burst=10 keeps the refill slow enough that CI scheduling
+	// delay between the retry returning and the Available() assertion
+	// can't refill enough tokens to mask the decrement. A faster rate
+	// (e.g. 100/s = 1 token / 10ms) reliably pushed Available() above
+	// 9.5 on slow runners.
+	budget := NewRetryBudget(1, 10)
 
 	result, err := OpenStreamWithRetryRequest(context.Background(), &StreamRetryRequest{
 		Policy: StreamRetryPolicy{

--- a/runtime/providers/streaming_mock_test.go
+++ b/runtime/providers/streaming_mock_test.go
@@ -3,7 +3,6 @@ package providers_test
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -235,17 +234,26 @@ func TestStreamContextCancellation(t *testing.T) {
 		t.Fatalf("PredictStream failed: %v", err)
 	}
 
+	// The chunk error after context cancellation is implementation- and
+	// transport-specific: net/http2 may surface DeadlineExceeded,
+	// io.ErrUnexpectedEOF, "http2: response body closed", or similar. The
+	// test only cares that the stream was interrupted as a consequence of
+	// the context's deadline. Treat "any chunk-level error while ctx is
+	// done" as proof of cancellation, plus the explicit FinishReason path
+	// when the provider surfaces it directly.
 	gotCancellation := false
 	for chunk := range stream {
-		if chunk.Error != nil {
-			if errors.Is(chunk.Error, context.DeadlineExceeded) || chunk.FinishReason != nil && *chunk.FinishReason == "cancelled" {
-				gotCancellation = true
-			}
+		if chunk.FinishReason != nil && *chunk.FinishReason == "cancelled" {
+			gotCancellation = true
+			continue
+		}
+		if chunk.Error != nil && ctx.Err() != nil {
+			gotCancellation = true
 		}
 	}
 
 	if !gotCancellation {
-		t.Error("Expected context cancellation to be detected")
+		t.Errorf("Expected context cancellation to be detected (ctx.Err()=%v)", ctx.Err())
 	}
 }
 


### PR DESCRIPTION
## Summary

Two flakes surfaced during the SDK `control: agent` PR's CI; both were pre-existing in `runtime/providers/`.

### TestStreamContextCancellation

Expected the chunk-level error after a context-cancelled stream to be exactly `errors.Is(ctx.DeadlineExceeded)` or `FinishReason == "cancelled"`. In practice `net/http2` surfaces a mix of errors (`io.ErrUnexpectedEOF`, `"http2: response body closed"`, `DeadlineExceeded`) depending on which goroutine wins. Replace the specific-error check with "any chunk error while `ctx.Err() != nil`" — the test only cares that the stream was interrupted as a consequence of the deadline.

### TestOpenStreamWithRetryRequest_BudgetAllowsRetry

Created the budget at `rate=100/s, burst=10` (1 token refill every 10ms). The assertion `Available() > 9.5` between the retry call and the check could see the refill catch up on slow runners, so a real decrement looked like none. Drop the rate to `1/s` so the refill is irrelevant on any plausible test timing.

## Test plan

- [x] Both tests pass 10× in a row locally with `-race`
- [x] Full `runtime/providers` test suite green
