### PR TITLE
feat(workflow): emit events for eager-commit failures + review followups

### DIFF
--- a/.github/workflows/capability-matrix.yml
+++ b/.github/workflows/capability-matrix.yml
@@ -81,6 +81,9 @@ jobs:
         # breaks the arithmetic and -gt comparison below. Use a pipe to wc
         # so the count is always a single integer and exit code is 0.
         ERROR_COUNT=$(grep 'level=ERROR.*Turn execution failed' run.log | wc -l | tr -d ' ')
+        # TOTAL uses grep -oP (no -c): on no match grep prints nothing and
+        # exits 1, so the `|| echo "0"` substitutes a clean single "0" — the
+        # specific footgun that bit ERROR_COUNT (above) doesn't apply here.
         TOTAL=$(grep -oP 'Generated \K[0-9]+' run.log || echo "0")
         PASSED=$((TOTAL - ERROR_COUNT))
         echo "error_count=$ERROR_COUNT" >> "$GITHUB_OUTPUT"

--- a/docs/src/content/docs/concepts/state-management.md
+++ b/docs/src/content/docs/concepts/state-management.md
@@ -259,6 +259,8 @@ When to use which:
 
 The destination state's `control` is what determines behavior, not the source. A user-controlled state may transition into an agent-controlled state and vice versa.
 
+**System-prompt scope inside an agent-controlled chain.** Because eager commits happen inside the pipeline tool loop, the LLM's *system prompt* stays anchored to the source state for the duration of the chain — the new state's `prompt_task`, `description`, and available events are surfaced to the model via the `workflow__transition` tool result, not by re-templating the system prompt. Treat agent-controlled states as transient: don't put substantive persona or behavior in their `prompt_task`. The conversation only opens a fresh prompt for the state the chain finally lands in (the first user-controlled state, or a terminal state).
+
 ## Best Practices
 
 ### Do's

--- a/runtime/workflow/transition_executor.go
+++ b/runtime/workflow/transition_executor.go
@@ -29,11 +29,12 @@ type PendingTransition struct {
 // post-commit work (re-register tool descriptor, update scenario TaskType,
 // emit observability events) from a single hook.
 type TransitionExecutor struct {
-	mu       sync.Mutex
-	sm       *StateMachine
-	spec     *Spec
-	pending  *PendingTransition
-	onCommit func(*TransitionResult)
+	mu            sync.Mutex
+	sm            *StateMachine
+	spec          *Spec
+	pending       *PendingTransition
+	onCommit      func(*TransitionResult)
+	onCommitError func(event string, err error)
 }
 
 // NewTransitionExecutor creates a TransitionExecutor for the given state machine.
@@ -49,6 +50,20 @@ func NewTransitionExecutor(sm *StateMachine, spec *Spec) *TransitionExecutor {
 func (e *TransitionExecutor) SetOnCommit(fn func(*TransitionResult)) {
 	e.mu.Lock()
 	e.onCommit = fn
+	e.mu.Unlock()
+}
+
+// SetOnCommitError registers a callback fired when ProcessEvent fails on
+// either commit path (eager from Execute, deferred from CommitPending).
+// Consumers wire their workflow observability error emit (e.g.,
+// workflow.max_visits_exceeded, workflow.budget_exhausted) through this
+// hook so eager-control failures are observable too. Pass nil to clear.
+//
+// Same locking contract as SetOnCommit: the callback runs while the
+// executor's internal lock is held; do not re-enter the executor.
+func (e *TransitionExecutor) SetOnCommitError(fn func(event string, err error)) {
+	e.mu.Lock()
+	e.onCommitError = fn
 	e.mu.Unlock()
 }
 
@@ -82,6 +97,9 @@ func (e *TransitionExecutor) Execute(
 	if e.isAgentControlledTargetLocked(a.Event) {
 		tr, err := e.sm.ProcessEvent(a.Event)
 		if err != nil {
+			if e.onCommitError != nil {
+				e.onCommitError(a.Event, err)
+			}
 			return nil, fmt.Errorf("agent-controlled transition failed: %w", err)
 		}
 		if e.onCommit != nil {
@@ -127,6 +145,9 @@ func (e *TransitionExecutor) CommitPending() (*TransitionResult, error) {
 
 	tr, err := e.sm.ProcessEvent(pt.Event)
 	if err != nil {
+		if e.onCommitError != nil {
+			e.onCommitError(pt.Event, err)
+		}
 		return nil, err
 	}
 	if e.onCommit != nil {

--- a/runtime/workflow/transition_executor_test.go
+++ b/runtime/workflow/transition_executor_test.go
@@ -348,6 +348,85 @@ func TestTransitionExecutor_UserControlStillDefers(t *testing.T) {
 	}
 }
 
+func TestTransitionExecutor_OnCommitErrorFiresOnEagerFailure(t *testing.T) {
+	// agent-controlled state "loop" with max_visits=1 (no on_max_visits).
+	// Entry to "loop" via a→loop consumes the only visit; a second eager
+	// loop→loop trips max_visits and surfaces via OnCommitError.
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Enter": "loop"}},
+			"loop": {
+				PromptTask: "t",
+				MaxVisits:  1,
+				Control:    ControlModeAgent,
+				OnEvent:    map[string]string{"Again": "loop"},
+			},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	type capture struct {
+		event string
+		err   error
+	}
+	var got []capture
+	exec.SetOnCommitError(func(event string, err error) {
+		got = append(got, capture{event, err})
+	})
+
+	enter, _ := json.Marshal(map[string]string{"event": "Enter"})
+	if _, err := exec.Execute(context.Background(), nil, enter); err != nil {
+		t.Fatalf("entering loop: %v", err)
+	}
+	// Second eager attempt loops back to "loop" — trips max_visits.
+	again, _ := json.Marshal(map[string]string{"event": "Again"})
+	if _, err := exec.Execute(context.Background(), nil, again); err == nil {
+		t.Fatal("expected eager re-entry to fail")
+	}
+	if len(got) != 1 || got[0].event != "Again" {
+		t.Fatalf("OnCommitError must fire once with event=Again, got %+v", got)
+	}
+	if !errors.Is(got[0].err, ErrMaxVisitsExceeded) {
+		t.Errorf("expected ErrMaxVisitsExceeded, got %v", got[0].err)
+	}
+}
+
+func TestTransitionExecutor_OnCommitErrorFiresOnDeferredFailure(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a": {PromptTask: "t", OnEvent: map[string]string{"Go": "b"}},
+			"b": {PromptTask: "t"},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+
+	var fired int
+	var capturedEvent string
+	exec.SetOnCommitError(func(event string, _ error) {
+		fired++
+		capturedEvent = event
+	})
+
+	// Store a bad event (deferred path — target lookup at commit time
+	// would fail because "BadEvent" isn't in OnEvent).
+	args, _ := json.Marshal(map[string]string{"event": "BadEvent"})
+	if _, err := exec.Execute(context.Background(), nil, args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if _, err := exec.CommitPending(); err == nil {
+		t.Fatal("expected commit to fail for invalid event")
+	}
+	if fired != 1 || capturedEvent != "BadEvent" {
+		t.Errorf("OnCommitError must fire once with event=BadEvent, got fired=%d event=%q", fired, capturedEvent)
+	}
+}
+
 func TestTransitionExecutor_AgentControlChainedTransitions(t *testing.T) {
 	// Two agent-controlled transitions in sequence — proves the executor stays
 	// usable after an eager commit and the second call uses the post-commit

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -300,16 +300,20 @@ func (wc *WorkflowConversation) Send(ctx context.Context, message any, opts ...S
 //
 //   - control: user (default) — the workflow__transition tool stored a
 //     pending transition during the pipeline; CommitPending now runs
-//     ProcessEvent and fires the OnCommit hook.
+//     ProcessEvent and fires OnCommit (or OnCommitError on failure).
 //   - control: agent — the transition already committed eagerly inside
-//     Execute and the OnCommit hook has already run; CommitPending is a
-//     no-op.
+//     Execute and the hooks have already run; CommitPending is a no-op.
 //
 // Either way, if the machine has moved past the active conversation's
 // prompt task, reconcileActiveConv closes the old conv and opens a new
-// one for the destination state's prompt. Errors from ProcessEvent are
-// routed through emitWorkflowError so observability events fire even
-// when a deferred transition aborts on commit. Caller must hold wc.mu.
+// one for the destination state's prompt. Failure observability events
+// are emitted by the OnCommitError hook wired in registerWorkflowTools,
+// not from this function. Caller must hold wc.mu.
+//
+// Note: capturing pending.ContextSummary before CommitPending is safe —
+// the caller holds wc.mu and the runtime executor's only mutator under
+// its own lock is Execute, which can only be invoked by the pipeline
+// tool loop, and the pipeline is no longer running at this point.
 func (wc *WorkflowConversation) commitDeferredTransition() error {
 	if wc.transExec == nil {
 		return nil
@@ -318,7 +322,6 @@ func (wc *WorkflowConversation) commitDeferredTransition() error {
 	if pending := wc.transExec.Pending(); pending != nil {
 		contextSummary = pending.ContextSummary
 		if _, commitErr := wc.transExec.CommitPending(); commitErr != nil {
-			wc.emitWorkflowError(pending.Event, commitErr)
 			return commitErr
 		}
 	}
@@ -446,6 +449,10 @@ func (wc *WorkflowConversation) registerWorkflowTools() {
 	registry.RegisterExecutor(wc.transExec)
 	wc.transExec.RegisterForState(registry, state)
 	wc.transExec.SetOnCommit(wc.onTransitionCommitted)
+	// OnCommitError covers both eager (control: agent) and deferred
+	// (control: user) ProcessEvent failures so max_visits_exceeded /
+	// budget_exhausted observability events fire regardless of path.
+	wc.transExec.SetOnCommitError(wc.emitWorkflowError)
 
 	// Create and register artifact executor if spec declares artifacts
 	wc.artifactExec = workflow.NewArtifactExecutor(wc.machine)

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -1388,6 +1388,9 @@ func TestCommitDeferredTransition_FiresErrorEvent(t *testing.T) {
 		emitter:      events.NewEmitter(bus, "", "", ""),
 		transExec:    transExec,
 	}
+	// Production code wires this in registerWorkflowTools; mirror that
+	// here since the test bypasses Open and constructs the executor directly.
+	transExec.SetOnCommitError(wc.emitWorkflowError)
 
 	args, _ := json.Marshal(map[string]string{"event": "Go"})
 	_, err := transExec.Execute(context.Background(), nil, args)

--- a/tools/arena/engine/engine.go
+++ b/tools/arena/engine/engine.go
@@ -247,28 +247,38 @@ func NewEngineFromConfig(cfg *config.Config, providerFilter ...string) (*Engine,
 		return nil, fmt.Errorf("failed to initialize memory: %w", err)
 	}
 
-	// Use the eval orchestrator from the conversation executor — it already has
-	// judge metadata, prompt_registry, and other config injected by BuildEngineComponents.
-	// Creating a separate orchestrator here would lose that metadata.
-	//
-	// BuildEngineComponents wraps the DefaultConversationExecutor in a
-	// CompositeConversationExecutor for routing between default / duplex /
-	// eval modes, so the type assertion must reach through the composite.
-	// Without this, eng.evalOrchestrator stays nil for every run; workflow
-	// scenarios in particular silently lose their per-run metadata provider
-	// because prepareWorkflowScenario short-circuits on nil evalOrchestrator
-	// and returns nil. That manifests as `state_is` / `transitioned_to`
-	// assertions reporting "no workflow state in context" even when the
-	// state machine is running correctly (#1169).
-	switch ce := convExecutor.(type) {
+	// Use the eval orchestrator from the conversation executor — it already
+	// has judge metadata, prompt_registry, and other config injected by
+	// BuildEngineComponents. Creating a separate orchestrator here would
+	// lose that metadata.
+	eng.evalOrchestrator = evalOrchestratorFrom(convExecutor)
+	return eng, nil
+}
+
+// evalOrchestratorFrom extracts the EvalOrchestrator out of whatever
+// ConversationExecutor shape BuildEngineComponents returned.
+//
+// BuildEngineComponents wraps the DefaultConversationExecutor in a
+// CompositeConversationExecutor for routing between default / duplex /
+// eval modes, so the type assertion must reach through the composite.
+// Without this, eng.evalOrchestrator stays nil for every run; workflow
+// scenarios in particular silently lose their per-run metadata provider
+// because prepareWorkflowScenario short-circuits on nil evalOrchestrator
+// and returns nil. That manifests as `state_is` / `transitioned_to`
+// assertions reporting "no workflow state in context" even when the
+// state machine is running correctly (#1169).
+//
+// Returns nil if no orchestrator can be reached — callers must guard.
+func evalOrchestratorFrom(executor ConversationExecutor) *EvalOrchestrator {
+	switch ce := executor.(type) {
 	case *DefaultConversationExecutor:
-		eng.evalOrchestrator = ce.evalOrchestrator
+		return ce.evalOrchestrator
 	case *CompositeConversationExecutor:
 		if ce.defaultExecutor != nil {
-			eng.evalOrchestrator = ce.defaultExecutor.evalOrchestrator
+			return ce.defaultExecutor.evalOrchestrator
 		}
 	}
-	return eng, nil
+	return nil
 }
 
 // NewEngine creates a new simulation engine from pre-built components.

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -98,6 +98,18 @@ func (e *workflowTransitionExecutor) RegisterRunWithEmitter(
 	transExec.SetOnCommit(func(tr *workflow.TransitionResult) {
 		e.applyPostCommit(runID, tr)
 	})
+	// OnCommitError fires for both eager (control: agent) and deferred
+	// (control: user) ProcessEvent failures, so max_visits_exceeded /
+	// budget_exhausted events emit regardless of which path tripped them.
+	transExec.SetOnCommitError(func(event string, err error) {
+		e.mu.Lock()
+		run := e.runs[runID]
+		e.mu.Unlock()
+		if run == nil {
+			return
+		}
+		e.emitWorkflowError(run, run.emitter, event, err)
+	})
 }
 
 // Execute routes the tool call to the per-run TransitionExecutor.
@@ -124,14 +136,16 @@ func (e *workflowTransitionExecutor) Execute(
 // nil and is a no-op when nothing is pending.
 //
 // Post-commit work (transition history, observability events, scenario
-// TaskType update, tool re-registration, skill filter) runs via the
-// OnCommit hook wired in RegisterRun, so it is shared with the agent-control
-// path where the commit fires inside Execute.
+// TaskType update, tool re-registration, skill filter) runs via the OnCommit
+// hook wired in RegisterRunWithEmitter, so it is shared with the agent-control
+// path where the commit fires inside Execute. OnCommitError handles the
+// failure-path observability symmetrically.
 //
-// The emitter parameter is honored only when reporting commit errors. The
-// emitter for successful events is whichever was passed at RegisterRun time.
+// The emitter parameter is kept for source compatibility with older callers
+// but is no longer consulted — the per-run emitter captured at registration
+// is used for both success and failure events.
 func (e *workflowTransitionExecutor) CommitPendingTransition(
-	runID string, emitter *events.Emitter,
+	runID string, _ *events.Emitter,
 ) error {
 	e.mu.Lock()
 	run := e.runs[runID]
@@ -141,9 +155,9 @@ func (e *workflowTransitionExecutor) CommitPendingTransition(
 		return nil
 	}
 
-	pending := run.transExec.Pending()
 	if _, err := run.transExec.CommitPending(); err != nil {
-		e.emitWorkflowError(run, emitter, pending.Event, err)
+		// OnCommitError already emitted the observability event; just wrap
+		// the underlying error for the caller.
 		return fmt.Errorf("transition commit failed: %w", err)
 	}
 	return nil

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -319,29 +319,31 @@ func TestWorkflowRunMetadataProvider_EagerCommitsPending(t *testing.T) {
 	assert.Equal(t, "specialist", meta2["workflow_current_state"])
 }
 
-// TestBuildEngineComponents_WiresEvalOrchestratorThroughComposite verifies
-// the type switch in BuildEngineComponents reaches through the
-// CompositeConversationExecutor wrapper. Before #1169, the type assertion
-// failed silently and eng.evalOrchestrator stayed nil for every workflow
-// run, breaking state-aware assertions.
-func TestBuildEngineComponents_WiresEvalOrchestratorThroughComposite(t *testing.T) {
-	composite := &CompositeConversationExecutor{
-		defaultExecutor: &DefaultConversationExecutor{
-			evalOrchestrator: &EvalOrchestrator{},
-		},
-	}
+// TestEvalOrchestratorFrom_ReachesThroughComposite verifies that the
+// extractor used by NewEngineFromConfig reaches the orchestrator through
+// both shapes BuildEngineComponents may return. Before #1169 the extraction
+// was a bare type assertion against *DefaultConversationExecutor only, so
+// the composite path returned nil and every workflow run lost its per-run
+// metadata provider.
+func TestEvalOrchestratorFrom_ReachesThroughComposite(t *testing.T) {
+	orch := &EvalOrchestrator{}
 
-	// Mimic the switch from engine.go.
-	var orch *EvalOrchestrator
-	switch ce := any(composite).(type) {
-	case *DefaultConversationExecutor:
-		orch = ce.evalOrchestrator
-	case *CompositeConversationExecutor:
-		if ce.defaultExecutor != nil {
-			orch = ce.defaultExecutor.evalOrchestrator
-		}
+	// Composite is what BuildEngineComponents returns today.
+	composite := &CompositeConversationExecutor{
+		defaultExecutor: &DefaultConversationExecutor{evalOrchestrator: orch},
 	}
-	assert.NotNil(t, orch, "type switch must reach through CompositeConversationExecutor")
+	assert.Same(t, orch, evalOrchestratorFrom(composite),
+		"must reach through CompositeConversationExecutor")
+
+	// Bare default executor is the historical shape; the extractor must
+	// keep handling it for tests and callers that wire executors directly.
+	bare := &DefaultConversationExecutor{evalOrchestrator: orch}
+	assert.Same(t, orch, evalOrchestratorFrom(bare),
+		"must handle bare DefaultConversationExecutor")
+
+	// Composite with no inner default → nil (callers must guard).
+	assert.Nil(t, evalOrchestratorFrom(&CompositeConversationExecutor{}),
+		"composite without defaultExecutor returns nil, not panic")
 }
 
 // TestWorkflowRunMetadataProvider_CommitErrorIsLoggedNotPanicked verifies


### PR DESCRIPTION
## Summary

Followups from the post-merge code review of #1184-#1190 (workflow `control: user|agent` work).

### Substantive: eager-commit failure observability (M1)

Before this change, `ProcessEvent` failures on the eager (control:agent) path silently bypassed `workflow.max_visits_exceeded` / `workflow.budget_exhausted` events because the existing `emitWorkflowError` plumbing only fired from `CommitPendingTransition`/`commitDeferredTransition`, both deferred-only.

Adds `SetOnCommitError(fn func(event, err))` to the runtime `TransitionExecutor`. Fires from both `Execute` (eager) and `CommitPending` (deferred). Both Arena and SDK wire it to their existing `emitWorkflowError` helper, and both drop the now-redundant explicit emit in their commit-error paths. The deferred path remains identical in behavior; the eager path now emits the same events the deferred path always did.

### Cleanups from the review

- **L1**: the type-switch test was replicating engine.go's switch in-test rather than exercising the real code. Extracted the switch into a named `evalOrchestratorFrom` helper and updated the test to call it directly across both shapes (composite, bare default, composite-without-default).
- **L2**: state-management.md gains a paragraph clarifying that an agent-controlled chain keeps the *source* state's system prompt — the destination's metadata is surfaced via the `workflow__transition` tool result, not via re-templating mid-chain.
- **N2**: `commitDeferredTransition` comment now justifies the pending-capture-before-commit ordering.
- **N4**: capability-matrix.yml comment explains why `ERROR_COUNT`'s pipe form is needed but `TOTAL`'s `grep -oP || echo 0` is safe — the `-c` + `||` footgun is specific to the count flag.

## Tests

- Runtime: two new tests cover the OnCommitError fire-points (eager `max_visits_exceeded`, deferred invalid-event).
- Arena: unchanged tests cover the wiring through `RegisterRunWithEmitter`.
- SDK: `TestCommitDeferredTransition_FiresErrorEvent` updated to mirror production (wire the hook through `SetOnCommitError`).
- Arena `TestEvalOrchestratorFrom_ReachesThroughComposite` replaces the in-test replica.

## Test plan

- [x] `go test ./runtime/workflow/... -count=1 -race`
- [x] `go test ./tools/arena/engine/... -count=1 -race`
- [x] `go test ./sdk/... -count=1 -race`
- [x] `golangci-lint --new-from-rev=HEAD ./runtime/workflow/... ./tools/arena/engine/... ./sdk/...`
