### PR TITLE
feat(workflow): tear down stale tool descriptor on terminal entry + SDK Send heals state drift

### DIFF
--- a/runtime/tools/registry.go
+++ b/runtime/tools/registry.go
@@ -173,6 +173,29 @@ func (r *Registry) Register(descriptor *ToolDescriptor) error {
 	return nil
 }
 
+// Unregister removes a tool descriptor from the in-memory cache by name.
+// Returns true if a descriptor was removed, false if none was registered.
+//
+// Used when a workflow state machine transitions into a terminal state:
+// the previous state's workflow__transition descriptor (with its
+// now-stale enum of events) must be torn down so the LLM can't call it
+// against a dead state. Safe to call concurrently with Get/List.
+//
+// Note: tools persisted to a repository (file-loaded YAML/JSON tools)
+// will be re-loaded by Get on next lookup. Unregister is intended for
+// dynamically-registered descriptors like workflow__transition that
+// don't go through the repository path.
+func (r *Registry) Unregister(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, existed := r.tools[name]
+	if existed {
+		delete(r.tools, name)
+	}
+	return existed
+}
+
 // Get retrieves a tool descriptor by name with repository fallback.
 func (r *Registry) Get(name string) *ToolDescriptor {
 	// Check cache first

--- a/runtime/tools/registry_test.go
+++ b/runtime/tools/registry_test.go
@@ -53,6 +53,44 @@ func TestRegister(t *testing.T) {
 	}
 }
 
+// TestUnregister verifies Unregister removes a previously registered tool
+// and reports whether anything was actually torn down. Used by the workflow
+// transition executor to clear stale workflow__transition descriptors when
+// entering a terminal state.
+func TestUnregister(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	descriptor := &tools.ToolDescriptor{
+		Name:         "to_remove",
+		Description:  "doomed",
+		InputSchema:  json.RawMessage(`{"type": "object"}`),
+		OutputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:         "mock",
+	}
+	if err := registry.Register(descriptor); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if registry.Get("to_remove") == nil {
+		t.Fatal("precondition: tool should be registered")
+	}
+
+	// First call removes and reports true.
+	if !registry.Unregister("to_remove") {
+		t.Error("Unregister should return true when a tool was removed")
+	}
+	if registry.Get("to_remove") != nil {
+		t.Error("tool should no longer be retrievable after Unregister")
+	}
+
+	// Second call is a no-op and reports false.
+	if registry.Unregister("to_remove") {
+		t.Error("Unregister should return false when nothing was registered")
+	}
+	if registry.Unregister("never_existed") {
+		t.Error("Unregister of an unknown name should return false")
+	}
+}
+
 // TestGet verifies tool retrieval
 func TestGet(t *testing.T) {
 	registry := tools.NewRegistry()

--- a/runtime/workflow/transition_executor.go
+++ b/runtime/workflow/transition_executor.go
@@ -80,6 +80,17 @@ func (e *TransitionExecutor) Name() string { return TransitionExecutorMode }
 // Otherwise the request is stored as pending and CommitPending applies it
 // after the pipeline turn finishes. This is the historical (default)
 // behavior and matches RFC 0005's deferred-commit pattern.
+//
+// Context-summary handling differs between paths:
+//   - Deferred (control: user): the LLM's `context` argument is stored on
+//     the PendingTransition and surfaced to the new conversation as the
+//     `workflow_context` template variable when the consumer opens it.
+//   - Eager (control: agent): the `context` argument is **discarded**.
+//     Agent-controlled states are transient — the conversation never
+//     reopens for them — so there's no destination prompt to seed. If
+//     you need the LLM to summarize before handing off to a terminal
+//     state, do it on the *user-controlled* transition that ends the
+//     chain, not on the agent-controlled hops along the way.
 func (e *TransitionExecutor) Execute(
 	_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage,
 ) (json.RawMessage, error) {
@@ -177,12 +188,23 @@ func (e *TransitionExecutor) ClearPending() {
 
 // RegisterForState registers the workflow__transition tool in the given
 // registry for the specified state, with Mode set for executor routing.
-// Skips terminal states and externally orchestrated states.
+//
+// When called with a terminal state (Terminal: true OR no on_event), the
+// previous descriptor — if any — is removed from the registry instead of
+// re-registered. Without this, the LLM would still see workflow__transition
+// in the tool list after entering a terminal state and could call it with
+// the previous state's now-stale events. Externally orchestrated states
+// skip both register and unregister: the caller owns the descriptor's
+// lifecycle.
 func (e *TransitionExecutor) RegisterForState(registry *tools.Registry, state *State) {
-	if registry == nil || state == nil || len(state.OnEvent) == 0 {
+	if registry == nil || state == nil {
 		return
 	}
-	if state.Terminal || state.Orchestration == OrchestrationExternal {
+	if state.Orchestration == OrchestrationExternal {
+		return
+	}
+	if state.Terminal || len(state.OnEvent) == 0 {
+		registry.Unregister(TransitionToolName)
 		return
 	}
 	evts := SortedEvents(state.OnEvent)

--- a/runtime/workflow/transition_executor_test.go
+++ b/runtime/workflow/transition_executor_test.go
@@ -188,6 +188,38 @@ func TestTransitionExecutor_SkipsTerminalState(t *testing.T) {
 	}
 }
 
+// TestTransitionExecutor_UnregistersOnTerminalEntry verifies that
+// transitioning into a terminal state tears down the previous state's
+// workflow__transition descriptor. Without this, the LLM would still
+// see the stale tool (with the prior state's event enum) on the next
+// turn and try to call it against a state with no exits.
+func TestTransitionExecutor_UnregistersOnTerminalEntry(t *testing.T) {
+	spec := &Spec{
+		Version: 2,
+		Entry:   "a",
+		States: map[string]*State{
+			"a":    {PromptTask: "t", OnEvent: map[string]string{"Finish": "done"}},
+			"done": {PromptTask: "t", Terminal: true},
+		},
+	}
+	sm := NewStateMachine(spec)
+	exec := NewTransitionExecutor(sm, spec)
+	registry := newTestRegistry(t)
+
+	// First register for the entry state — descriptor lands in the registry.
+	exec.RegisterForState(registry, spec.States["a"])
+	if registry.Get(TransitionToolName) == nil {
+		t.Fatal("transition tool should be registered for state a")
+	}
+
+	// Now register for the terminal state — the descriptor must be torn
+	// down so the LLM can't see it on the next turn.
+	exec.RegisterForState(registry, spec.States["done"])
+	if registry.Get(TransitionToolName) != nil {
+		t.Error("transition tool should be unregistered after entering terminal state")
+	}
+}
+
 func TestTransitionExecutor_MaxVisitsRedirect(t *testing.T) {
 	spec := &Spec{
 		Version: 2,

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -271,10 +271,21 @@ func (wc *WorkflowConversation) Send(ctx context.Context, message any, opts ...S
 		wc.mu.Unlock()
 		return nil, ErrWorkflowClosed
 	}
-	conv := wc.activeConv
 	if wc.transExec != nil {
 		wc.transExec.ClearPending()
 	}
+	// Heal any state-machine / active-conv drift left over from a prior
+	// Send that errored mid-pipeline after an eager (control: agent)
+	// commit. Without this, the next Send runs in the stale conv for
+	// one full turn before end-of-Send reconciliation kicks in.
+	// Carry-forward summary intentionally empty here: the prior Send's
+	// conv history is what would have been summarized, and we don't
+	// retroactively rebuild it on the recovery path.
+	if err := wc.reconcileActiveConv(""); err != nil {
+		wc.mu.Unlock()
+		return nil, err
+	}
+	conv := wc.activeConv
 	wc.mu.Unlock()
 
 	resp, err := conv.Send(ctx, message, opts...)
@@ -341,6 +352,13 @@ func (wc *WorkflowConversation) commitDeferredTransition() error {
 // conversation, which is the whole point of control: agent.
 func (wc *WorkflowConversation) reconcileActiveConv(contextSummary string) error {
 	if wc.activeConv == nil {
+		return nil
+	}
+	// A closed activeConv is its own failure mode — the caller (typically
+	// Send) will observe ErrConversationClosed from the next operation.
+	// Don't conflate that with state drift; reconcile only when the conv
+	// is open but its prompt has fallen behind the machine.
+	if wc.activeConv.closed {
 		return nil
 	}
 	targetPrompt := wc.machine.CurrentPromptTask()


### PR DESCRIPTION
## Summary

Addresses the remaining substantive findings from the post-merge code review of the `control: user|agent` work — **M2** plus the two **Lows** that were worth doing.

### M2 — unregister workflow__transition on terminal entry

Before this change, the previous state's `workflow__transition` descriptor stayed in the registry after transitioning into a terminal state. The LLM would still see the stale tool on the next turn (with the old state's event enum) and could call it against a state with no exits, eventually getting a delayed `ErrTerminalState` back.

- Add `tools.Registry.Unregister(name)` that drops a descriptor from the in-memory cache. Returns whether anything was removed.
- `runtime/workflow.TransitionExecutor.RegisterForState` now calls `Unregister` when handed a terminal (or eventless) state instead of bailing silently. Externally-orchestrated states still skip both — the caller owns those.

### L3 — document context-summary discard on the eager path

The LLM's `context` argument is silently discarded on the eager (`control: agent`) commit path. This is correct — agent-controlled states are transient, no destination conv to seed — but was undocumented. `TransitionExecutor.Execute` docstring now explains the asymmetry and recommends summarizing on the user-controlled transition that ends the chain rather than on the intermediate hops.

### L4 — SDK Send reconciles at start

SDK `Send` now reconciles `activeConv` to the machine's current prompt task at the *start* of Send, not just at end-of-Send. A prior Send that errored mid-pipeline after an eager commit used to leave `activeConv` running under the source state's prompt for one full turn. The reconcile is skipped when `activeConv.closed` — that's its own failure mode and `Send`'s next operation will surface `ErrConversationClosed` unchanged (so existing tests stay valid).

## Test plan

- [x] `TestUnregister` covers remove-once / no-op-on-second-call / unknown-name in `runtime/tools/`
- [x] `TestTransitionExecutor_UnregistersOnTerminalEntry` proves the descriptor goes from registered to absent when re-registering for a terminal state
- [x] Existing SDK tests `TestWorkflowConversation_SendDelegatesToConversation` and `TestSend_ClearsPendingTransitionBeforeSend` continue to assert `ErrConversationClosed` flows through unchanged (reconcile is a no-op when `activeConv.closed`)
- [x] Full `runtime/` and `sdk/` test suites pass with `-race`
- [x] `golangci-lint --new-from-rev=HEAD` clean; coverage on changed files >80%
