### PR TITLE
feat(evals/tools_called): add max_calls param for upper-bound assertions

### DIFF
--- a/docs/src/content/docs/arena/reference/assertions.md
+++ b/docs/src/content/docs/arena/reference/assertions.md
@@ -129,28 +129,48 @@ Assert that the LLM invoked the right tool (and, optionally, with a minimum freq
       message: "Should call the weather tool"
 ```
 
-`tools_called` accepts `min_calls` (default `1`), `ignore_validation`, and `require_args` — see the [Checks Reference](/reference/checks/#tool-checks-turn-level) for full param list.
+`tools_called` accepts these parameters:
 
-### Negative tool usage check
+| Param | Type | Default | Meaning |
+|---|---|---|---|
+| `tool_names` (or `tools`) | `[]string` | required | Names of tools to check |
+| `min_calls` | `int` | `1` | Minimum calls per tool. Under-called tools fail proportionally (ratio score). |
+| `max_calls` | `int` | unbounded | Maximum calls per tool. Over-called tools fail **hard** (score 0, regardless of `min_calls`). Use `max_calls: 0` to forbid a tool inline alongside positive expectations. |
+| `ignore_validation` | `bool` | `false` | Count argument-validation failures as successful calls |
+| `require_args` | `bool` | `false` | Only count calls with non-empty arguments |
 
-To assert that an agent did **not** call a forbidden tool — e.g. a refund agent that should escalate rather than process an unauthorized refund — use `tools_not_called`:
+See the [Checks Reference](/reference/checks/#tool-checks-turn-level) for the full surface.
+
+### Bounded tool usage with `max_calls`
+
+`max_calls` lets you express "at most N calls" inline with a positive expectation on the same assertion. The common case is `max_calls: 0` for a forbidden tool:
 
 ```yaml
 conversation_assertions:
-  # Agent must escalate
+  # Agent must escalate AND must not issue a refund — both in one assertion
   - type: tools_called
     params:
       tool_names: ["escalate_to_human"]
       min_calls: 1
     message: "Agent should escalate when policy blocks the request"
-  # Agent must NOT issue refund without verification
+  - type: tools_called
+    params:
+      tool_names: ["issue_refund"]
+      min_calls: 0
+      max_calls: 0
+    message: "Agent must NOT issue refund without warranty verification"
+```
+
+Equivalently, the dedicated `tools_not_called` assertion expresses the forbidden case alone:
+
+```yaml
   - type: tools_not_called
     params:
       tool_names: ["issue_refund"]
-    message: "Agent should not issue refund when warranty check fails"
+    message: "Agent must NOT issue refund without warranty verification"
 ```
 
-For rate-limit-style bounds ("at most N calls"), use `tool_call_count` with `min`/`max` — see [Tool Checks reference](/reference/checks/#tool-checks-turn-level).
+Pick whichever reads better. `max_calls > 0` (e.g. "at most 3 lookups per turn") is only available on `tools_called`.
 
 ### LLM judge
 

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
@@ -474,6 +475,135 @@ func TestToolsCalledHandler_MinCalls(t *testing.T) {
 	if result.Score != nil && *result.Score >= 1.0 {
 		t.Fatal("expected fail: only 1 call, need 3")
 	}
+}
+
+// TestToolsCalledHandler_MaxCalls verifies that a tool called within the
+// max_calls bound passes the assertion.
+func TestToolsCalledHandler_MaxCalls(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "search"},
+			{ToolName: "search"},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"search"},
+		"min_calls":  float64(1),
+		"max_calls":  float64(3),
+	}
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score == nil || *result.Score < 1.0 {
+		t.Fatalf("expected pass (2 calls, max 3), got score %v", result.Score)
+	}
+}
+
+// TestToolsCalledHandler_MaxCallsExceeded verifies that exceeding max_calls
+// fails hard with score 0 even when min_calls is satisfied, and that the
+// over-limit tool is named in the explanation.
+func TestToolsCalledHandler_MaxCallsExceeded(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			{ToolName: "issue_refund"},
+			{ToolName: "issue_refund"},
+			{ToolName: "issue_refund"},
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"issue_refund"},
+		"min_calls":  float64(1),
+		"max_calls":  float64(2),
+	}
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score == nil || *result.Score != 0 {
+		t.Fatalf("expected hard fail score 0, got %v", result.Score)
+	}
+	if !strings.Contains(result.Explanation, "issue_refund") {
+		t.Errorf("explanation must name the offending tool, got %q", result.Explanation)
+	}
+	overLimit, ok := result.Value.(map[string]any)["over_limit"].([]string)
+	if !ok || len(overLimit) != 1 {
+		t.Errorf("over_limit value should list one tool, got %v", result.Value)
+	}
+}
+
+// TestToolsCalledHandler_MinAndMax verifies both constraints are honored
+// simultaneously: under-called fails, over-called also fails, the
+// explanation mentions both directions.
+func TestToolsCalledHandler_MinAndMax(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	evalCtx := &evals.EvalContext{
+		ToolCalls: []evals.ToolCallRecord{
+			// search is called 4 times (over max 2)
+			{ToolName: "search"}, {ToolName: "search"},
+			{ToolName: "search"}, {ToolName: "search"},
+			// escalate is never called (under min 1)
+		},
+	}
+	params := map[string]any{
+		"tool_names": []any{"search", "escalate"},
+		"min_calls":  float64(1),
+		"max_calls":  float64(2),
+	}
+	result, err := h.Eval(context.Background(), evalCtx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score == nil || *result.Score != 0 {
+		t.Fatalf("expected hard fail (over-limit wins), got %v", result.Score)
+	}
+	if !strings.Contains(result.Explanation, "search") ||
+		!strings.Contains(result.Explanation, "escalate") {
+		t.Errorf("explanation must mention both tools, got %q", result.Explanation)
+	}
+}
+
+// TestToolsCalledHandler_MaxCallsZero verifies the primary use case:
+// max_calls: 0 means "must NOT be called." Same semantics as
+// tools_not_called but expressible inline alongside min_calls assertions.
+func TestToolsCalledHandler_MaxCallsZero(t *testing.T) {
+	h := &ToolsCalledHandler{}
+	t.Run("tool not called passes", func(t *testing.T) {
+		evalCtx := &evals.EvalContext{
+			ToolCalls: []evals.ToolCallRecord{{ToolName: "lookup"}},
+		}
+		params := map[string]any{
+			"tool_names": []any{"issue_refund"},
+			"min_calls":  float64(0),
+			"max_calls":  float64(0),
+		}
+		result, err := h.Eval(context.Background(), evalCtx, params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Score == nil || *result.Score < 1.0 {
+			t.Fatalf("max_calls: 0 with zero calls should pass, got %v", result.Score)
+		}
+	})
+	t.Run("single call fails", func(t *testing.T) {
+		evalCtx := &evals.EvalContext{
+			ToolCalls: []evals.ToolCallRecord{{ToolName: "issue_refund"}},
+		}
+		params := map[string]any{
+			"tool_names": []any{"issue_refund"},
+			"min_calls":  float64(0),
+			"max_calls":  float64(0),
+		}
+		result, err := h.Eval(context.Background(), evalCtx, params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Score == nil || *result.Score != 0 {
+			t.Fatalf("max_calls: 0 with one call must fail, got %v", result.Score)
+		}
+	})
 }
 
 func TestToolsCalledHandler_NoToolNames(t *testing.T) {

--- a/runtime/evals/handlers/tools_called.go
+++ b/runtime/evals/handlers/tools_called.go
@@ -17,9 +17,24 @@ import (
 // Params:
 //   - tool_names/tools []string — required tool names
 //   - min_calls int — minimum calls per tool (default 1)
+//   - max_calls int — maximum calls per tool (default unbounded, use 0 to forbid).
+//     When any listed tool exceeds max_calls the assertion fails hard with
+//     score 0, regardless of min_calls satisfaction.
 //   - ignore_validation bool — count validation failures as successful (default false)
 //   - require_args bool — only count calls with non-empty arguments (default false)
 type ToolsCalledHandler struct{}
+
+// maxCallsUnbounded is the sentinel meaning "no max_calls constraint."
+// Chosen as -1 so callers can pass 0 to mean "tool must not be called."
+const maxCallsUnbounded = -1
+
+// Result-value map keys for the ToolsCalledHandler result.
+const (
+	keyFound     = "found"
+	keyExpected  = "expected"
+	keyMissing   = "missing"
+	keyOverLimit = "over_limit"
+)
 
 // Type returns the eval type identifier.
 func (h *ToolsCalledHandler) Type() string { return "tools_called" }
@@ -43,33 +58,52 @@ func (h *ToolsCalledHandler) Eval(
 	}
 
 	minCalls := extractInt(params, "min_calls", 1)
+	maxCalls := extractInt(params, "max_calls", maxCallsUnbounded)
 	ignoreValidation := extractBool(params, "ignore_validation")
 	requireArgs := extractBool(params, "require_args")
 	callCounts := buildCallCounts(evalCtx.ToolCalls, ignoreValidation, requireArgs)
 
-	return h.checkToolCalls(toolNames, callCounts, minCalls)
+	return h.checkToolCalls(toolNames, callCounts, minCalls, maxCalls)
 }
 
-// checkToolCalls verifies each tool was called the minimum number
-// of times.
+// checkToolCalls verifies each tool was called within the configured
+// min/max bounds. min_calls is a ratio-scored check (partial credit);
+// max_calls is a hard pass/fail (any exceeded tool → score 0).
 func (h *ToolsCalledHandler) checkToolCalls(
 	toolNames []string,
 	callCounts map[string]int,
-	minCalls int,
+	minCalls, maxCalls int,
 ) (result *evals.EvalResult, err error) {
-	var missing []string
+	var missing, overLimit []string
 	for _, name := range toolNames {
-		if callCounts[name] < minCalls {
+		count := callCounts[name]
+		if count < minCalls {
 			missing = append(missing, fmt.Sprintf(
 				"%s (called %d, need %d)",
-				name, callCounts[name], minCalls,
+				name, count, minCalls,
+			))
+		}
+		if maxCalls >= 0 && count > maxCalls {
+			overLimit = append(overLimit, fmt.Sprintf(
+				"%s (called %d, max %d)",
+				name, count, maxCalls,
 			))
 		}
 	}
 
-	passed := len(missing) == 0
-	explanation := "all expected tools were called"
-	if !passed {
+	explanation := "all expected tools were called within bounds"
+	switch {
+	case len(overLimit) > 0 && len(missing) > 0:
+		explanation = fmt.Sprintf(
+			"tools called outside bounds: under min: %s; over max: %s",
+			strings.Join(missing, ", "), strings.Join(overLimit, ", "),
+		)
+	case len(overLimit) > 0:
+		explanation = fmt.Sprintf(
+			"tools called too many times: %s",
+			strings.Join(overLimit, ", "),
+		)
+	case len(missing) > 0:
 		explanation = fmt.Sprintf(
 			"tools not called enough: %s",
 			strings.Join(missing, ", "),
@@ -77,15 +111,23 @@ func (h *ToolsCalledHandler) checkToolCalls(
 	}
 
 	found := len(toolNames) - len(missing)
+	// Over-limit is a hard fail regardless of how many min_calls were
+	// satisfied — exceeding the cap means the agent did the wrong thing,
+	// not a partially-correct thing.
+	score := ratioScore(found, len(toolNames))
+	if len(overLimit) > 0 {
+		score = boolScore(false)
+	}
 
 	return &evals.EvalResult{
 		Type:        h.Type(),
-		Score:       ratioScore(found, len(toolNames)),
+		Score:       score,
 		Explanation: explanation,
 		Value: map[string]any{
-			"found":    found,
-			"expected": len(toolNames),
-			"missing":  missing,
+			keyFound:     found,
+			keyExpected:  len(toolNames),
+			keyMissing:   missing,
+			keyOverLimit: overLimit,
 		},
 	}, nil
 }


### PR DESCRIPTION
## Summary

Completes deliverable #2 from the 2026-04-30 voice-refund-demo design spec (`docs/superpowers/specs/2026-04-30-voice-refund-demo-design.md`). The example shipped via #1141 used `tools_not_called` for the "agent must not issue refund" case, so the spec's primary use case (`max_calls: 0`) was already covered. This change closes the remaining gap: bounded counts like "at most N calls per tool" inline alongside positive expectations on the same assertion.

## Runtime

- `ToolsCalledHandler.Eval` reads optional `max_calls` param (sentinel `-1` = unbounded, matching the existing `extractInt` pattern).
- `checkToolCalls` now collects an `over_limit []string` alongside `missing`.
- `Result.Value` gains an `over_limit` key.
- **Scoring**: any over-limit tool is a hard fail (`score: 0`) regardless of `min_calls` satisfaction — exceeding the cap means the agent did the *wrong* thing, not a partially-correct thing. The `min_calls` ratio score is preserved for the under-called-only case (existing behaviour).
- Value-map keys extracted as package-private constants to dedupe.

## Tests

- `TestToolsCalledHandler_MaxCalls` — within bound passes
- `TestToolsCalledHandler_MaxCallsExceeded` — over bound fails hard, explanation names the offending tool, `Value.over_limit` lists it
- `TestToolsCalledHandler_MinAndMax` — both constraints honored simultaneously, explanation mentions both directions
- `TestToolsCalledHandler_MaxCallsZero` — primary use case (must-not-be-called) verified pass and fail cases

## Docs

`arena/reference/assertions.md` gains a parameter table for `tools_called` including `max_calls` semantics, plus a worked example showing `min_calls` + `max_calls` on separate assertions. Notes equivalence with `tools_not_called` for the `max_calls: 0` case and recommends picking whichever reads better.

## Backwards compatibility

Pure additive. Scenarios that don't set `max_calls` get the `-1` sentinel ⇒ unbounded ⇒ identical results to today.

## Test plan

- [x] `go test ./runtime/evals/handlers/ -count=1 -race` — 4 new tests pass, full handlers suite green
- [x] `golangci-lint --new-from-rev=HEAD ./runtime/evals/handlers/...` clean
- [x] Pre-commit hook green; coverage on `tools_called.go` 95.8%
