### PR TITLE
feat(config): expose embedding + image as first-class provider roles

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1760,6 +1760,142 @@ spec:
 	}
 }
 
+func TestLoadConfig_LoadsEmbeddingAndImageProviders(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "embed.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: voyage-embed
+spec:
+  id: voyage-embed
+  type: voyageai
+  role: embedding
+  model: voyage-3
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "image.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: imagen-test
+spec:
+  id: imagen-test
+  type: imagen
+  role: image
+  model: imagen-4.0-generate-001
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers: []
+  defaults:
+    concurrency: 1
+  embedding_providers:
+    - file: embed.provider.yaml
+  image_providers:
+    - file: image.provider.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.LoadedEmbeddingProviders) != 1 {
+		t.Fatalf("expected 1 loaded embedding provider, got %d", len(cfg.LoadedEmbeddingProviders))
+	}
+	if _, ok := cfg.LoadedEmbeddingProviders["voyage-embed"]; !ok {
+		t.Errorf("embedding provider not indexed by id")
+	}
+	if len(cfg.LoadedImageProviders) != 1 {
+		t.Fatalf("expected 1 loaded image provider, got %d", len(cfg.LoadedImageProviders))
+	}
+	if _, ok := cfg.LoadedImageProviders["imagen-test"]; !ok {
+		t.Errorf("image provider not indexed by id")
+	}
+}
+
+func TestLoadConfig_RejectsEmbeddingProviderInLLMList(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "embed.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: voyage-embed
+spec:
+  id: voyage-embed
+  type: voyageai
+  role: embedding
+  model: voyage-3
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers:
+    - file: embed.provider.yaml
+  defaults:
+    concurrency: 1
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected role mismatch error for embedding provider in providers: list")
+	}
+	if !strings.Contains(err.Error(), "embedding_providers") {
+		t.Errorf("error message must guide user to embedding_providers list; got: %v", err)
+	}
+}
+
+func TestLoadConfig_RejectsImageProviderWithLLMRole(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "image.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: imagen-bad
+spec:
+  id: imagen-bad
+  type: imagen
+  role: llm
+  model: imagen-4.0-generate-001
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers: []
+  defaults:
+    concurrency: 1
+  image_providers:
+    - file: image.provider.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected image_providers role validation error")
+	}
+	if !strings.Contains(err.Error(), "image_providers") || !strings.Contains(err.Error(), "image") {
+		t.Errorf("error must mention image_providers and required role; got: %v", err)
+	}
+}
+
 func TestLoadConfig_RejectsTTSProviderWithLLMCapability(t *testing.T) {
 	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
 	tmp := t.TempDir()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1858,6 +1858,95 @@ spec:
 	}
 }
 
+func TestLoadConfig_RejectsEmbeddingProviderMissingFile(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers: []
+  defaults:
+    concurrency: 1
+  embedding_providers:
+    - file: nope.provider.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing embedding provider file")
+	}
+	if !strings.Contains(err.Error(), "embedding_providers") {
+		t.Errorf("error must name embedding_providers; got: %v", err)
+	}
+}
+
+func TestLoadConfig_RejectsImageProviderMissingFile(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers: []
+  defaults:
+    concurrency: 1
+  image_providers:
+    - file: nope.provider.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing image provider file")
+	}
+	if !strings.Contains(err.Error(), "image_providers") {
+		t.Errorf("error must name image_providers; got: %v", err)
+	}
+}
+
+func TestLoadConfig_RejectsEmbeddingProviderInvalidRole(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "embed.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: bad-embed
+spec:
+  id: bad-embed
+  type: voyageai
+  role: gibberish
+  model: voyage-3
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers: []
+  defaults:
+    concurrency: 1
+  embedding_providers:
+    - file: embed.provider.yaml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err == nil {
+		t.Fatal("expected error for unknown role")
+	}
+	// "gibberish" fails schema validation at provider load time; the error
+	// is wrapped by the embedding loader.
+	if !strings.Contains(err.Error(), "embedding_providers") {
+		t.Errorf("error must name embedding_providers; got: %v", err)
+	}
+}
+
 func TestLoadConfig_RejectsImageProviderWithLLMRole(t *testing.T) {
 	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
 	tmp := t.TempDir()

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -205,6 +205,8 @@ func LoadConfig(filename string) (*Config, error) {
 	cfg.LoadedPersonas = make(map[string]*UserPersonaPack)
 	cfg.LoadedTTSProviders = make(map[string]*Provider, len(cfg.TTSProviders))
 	cfg.LoadedSTTProviders = make(map[string]*Provider, len(cfg.STTProviders))
+	cfg.LoadedEmbeddingProviders = make(map[string]*Provider, len(cfg.EmbeddingProviders))
+	cfg.LoadedImageProviders = make(map[string]*Provider, len(cfg.ImageProviders))
 	cfg.ProviderGroups = make(map[string]string)
 	cfg.ProviderCapabilities = make(map[string][]string)
 
@@ -219,6 +221,12 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, err
 	}
 	if err := cfg.loadSTTProviders(filename); err != nil {
+		return nil, err
+	}
+	if err := cfg.loadEmbeddingProviders(filename); err != nil {
+		return nil, err
+	}
+	if err := cfg.loadImageProviders(filename); err != nil {
 		return nil, err
 	}
 	if err := cfg.validateVoiceBindings(); err != nil {
@@ -471,7 +479,8 @@ func (c *Config) loadProviders(configPath string) error {
 		}
 		if role := provider.GetRole(); role != RoleLLM {
 			return fmt.Errorf("providers[%s]: role must be %q (or empty), got %q; "+
-				"TTS providers belong under tts_providers, STT under stt_providers",
+				"TTS providers belong under tts_providers, STT under stt_providers, "+
+				"embedding under embedding_providers, image under image_providers",
 				ref.File, RoleLLM, role)
 		}
 		c.LoadedProviders[provider.ID] = provider
@@ -526,6 +535,48 @@ func (c *Config) loadSTTProviders(configPath string) error {
 				ref.File, RoleSTT, provider.GetRole())
 		}
 		c.LoadedSTTProviders[provider.ID] = provider
+	}
+	return nil
+}
+
+// loadEmbeddingProviders loads all referenced embedding providers and
+// validates that each declares role: embedding.
+func (c *Config) loadEmbeddingProviders(configPath string) error {
+	for _, ref := range c.EmbeddingProviders {
+		fullPath := ResolveFilePath(configPath, ref.File)
+		provider, err := LoadProvider(fullPath)
+		if err != nil {
+			return fmt.Errorf("loading embedding_providers[%s]: %w", ref.File, err)
+		}
+		if err := provider.ValidateRole(); err != nil {
+			return fmt.Errorf("embedding_providers[%s]: %w", ref.File, err)
+		}
+		if provider.GetRole() != RoleEmbedding {
+			return fmt.Errorf("embedding_providers[%s]: role must be %q, got %q",
+				ref.File, RoleEmbedding, provider.GetRole())
+		}
+		c.LoadedEmbeddingProviders[provider.ID] = provider
+	}
+	return nil
+}
+
+// loadImageProviders loads all referenced image providers and validates that
+// each declares role: image.
+func (c *Config) loadImageProviders(configPath string) error {
+	for _, ref := range c.ImageProviders {
+		fullPath := ResolveFilePath(configPath, ref.File)
+		provider, err := LoadProvider(fullPath)
+		if err != nil {
+			return fmt.Errorf("loading image_providers[%s]: %w", ref.File, err)
+		}
+		if err := provider.ValidateRole(); err != nil {
+			return fmt.Errorf("image_providers[%s]: %w", ref.File, err)
+		}
+		if provider.GetRole() != RoleImage {
+			return fmt.Errorf("image_providers[%s]: role must be %q, got %q",
+				ref.File, RoleImage, provider.GetRole())
+		}
+		c.LoadedImageProviders[provider.ID] = provider
 	}
 	return nil
 }

--- a/pkg/config/role.go
+++ b/pkg/config/role.go
@@ -11,17 +11,23 @@ import "fmt"
 // can this provider do" — the older name collided with the per-model
 // feature-flag list (Provider.Capabilities). One word per concept now.
 const (
-	RoleLLM = "llm"
-	RoleTTS = "tts"
-	RoleSTT = "stt"
+	RoleLLM       = "llm"
+	RoleTTS       = "tts"
+	RoleSTT       = "stt"
+	RoleEmbedding = "embedding"
+	RoleImage     = "image"
 )
 
 // knownRoles is the set accepted by ValidateRole. An empty string is
-// also accepted (treated as LLM by GetRole).
+// also accepted (treated as LLM by GetRole). The internal
+// runtime/providers/base.ProviderType enum already covers all five
+// values — these are the public-facing names the spec accepts.
 var knownRoles = map[string]struct{}{
-	RoleLLM: {},
-	RoleTTS: {},
-	RoleSTT: {},
+	RoleLLM:       {},
+	RoleTTS:       {},
+	RoleSTT:       {},
+	RoleEmbedding: {},
+	RoleImage:     {},
 }
 
 // GetRole returns the provider's role, defaulting to "llm".
@@ -39,8 +45,8 @@ func (p *Provider) ValidateRole() error {
 		return nil
 	}
 	if _, ok := knownRoles[p.Role]; !ok {
-		return fmt.Errorf("unknown provider role %q (valid: %s, %s, %s)",
-			p.Role, RoleLLM, RoleTTS, RoleSTT)
+		return fmt.Errorf("unknown provider role %q (valid: %s, %s, %s, %s, %s)",
+			p.Role, RoleLLM, RoleTTS, RoleSTT, RoleEmbedding, RoleImage)
 	}
 	return nil
 }

--- a/pkg/config/role_test.go
+++ b/pkg/config/role_test.go
@@ -24,10 +24,22 @@ func TestProviderRole_UnknownRejected(t *testing.T) {
 }
 
 func TestProviderRole_KnownAccepted(t *testing.T) {
-	for _, c := range []string{"", "llm", "tts", "stt"} {
+	for _, c := range []string{"", "llm", "tts", "stt", "embedding", "image"} {
 		p := &Provider{Role: c}
 		if err := p.ValidateRole(); err != nil {
 			t.Fatalf("role %q rejected unexpectedly: %v", c, err)
+		}
+	}
+}
+
+func TestProviderRole_EmbeddingAndImageGetRole(t *testing.T) {
+	for _, c := range []struct{ in, want string }{
+		{"embedding", RoleEmbedding},
+		{"image", RoleImage},
+	} {
+		p := &Provider{Role: c.in}
+		if got := p.GetRole(); got != c.want {
+			t.Errorf("GetRole for %q = %q, want %q", c.in, got, c.want)
 		}
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -132,10 +132,20 @@ type Config struct {
 	// Loaded but NOT included in the agent-under-test matrix.
 	TTSProviders []ProviderRef `yaml:"tts_providers,omitempty" json:"tts_providers,omitempty"`
 
-	// STTProviders lists provider files where Spec.Capability == "stt".
+	// STTProviders lists provider files where Spec.Role == "stt".
 	// Same matrix-exclusion as TTSProviders. No STT consumers exist yet;
 	// the field is present so STT can land later without a schema change.
 	STTProviders []ProviderRef `yaml:"stt_providers,omitempty" json:"stt_providers,omitempty"`
+
+	// EmbeddingProviders lists provider files where Spec.Role == "embedding".
+	// Loaded but NOT included in the agent-under-test matrix. Voyageai,
+	// OpenAI text-embedding-3, Gemini embedding, etc. live here.
+	EmbeddingProviders []ProviderRef `yaml:"embedding_providers,omitempty" json:"embedding_providers,omitempty"`
+
+	// ImageProviders lists provider files where Spec.Role == "image".
+	// Loaded but NOT included in the agent-under-test matrix. Imagen,
+	// OpenAI Images, future Stable Diffusion adapters live here.
+	ImageProviders []ProviderRef `yaml:"image_providers,omitempty" json:"image_providers,omitempty"`
 
 	// Voices binds voice IDs to loaded TTS provider IDs. Personas reference
 	// voice IDs (not provider IDs) so the same persona can run against a
@@ -144,17 +154,19 @@ type Config struct {
 	Voices []VoiceBinding `yaml:"voices,omitempty" json:"voices,omitempty"`
 
 	// Loaded resources (populated by LoadConfig, included in JSON for adapter consumption)
-	LoadedPromptConfigs map[string]*PromptConfigData `yaml:"-" json:"loaded_prompt_configs,omitempty"`
-	LoadedProviders     map[string]*Provider         `yaml:"-" json:"loaded_providers,omitempty"`
-	LoadedTTSProviders  map[string]*Provider         `yaml:"-" json:"loaded_tts_providers,omitempty"`
-	LoadedSTTProviders  map[string]*Provider         `yaml:"-" json:"loaded_stt_providers,omitempty"`
-	LoadedJudges        map[string]*JudgeTarget      `yaml:"-" json:"loaded_judges,omitempty"`
-	LoadedScenarios     map[string]*Scenario         `yaml:"-" json:"loaded_scenarios,omitempty"`
-	LoadedEvals         map[string]*Eval             `yaml:"-" json:"loaded_evals,omitempty"`
-	LoadedTools         []ToolData                   `yaml:"-" json:"loaded_tools,omitempty"`
-	LoadedSkillSources  []prompt.SkillSourceConfig   `yaml:"-" json:"loaded_skill_sources,omitempty"`
-	LoadedPersonas      map[string]*UserPersonaPack  `yaml:"-" json:"loaded_personas,omitempty"`
-	LoadedPack          *prompt.Pack                 `yaml:"-" json:"loaded_pack,omitempty"`
+	LoadedPromptConfigs      map[string]*PromptConfigData `yaml:"-" json:"loaded_prompt_configs,omitempty"`
+	LoadedProviders          map[string]*Provider         `yaml:"-" json:"loaded_providers,omitempty"`
+	LoadedTTSProviders       map[string]*Provider         `yaml:"-" json:"loaded_tts_providers,omitempty"`
+	LoadedSTTProviders       map[string]*Provider         `yaml:"-" json:"loaded_stt_providers,omitempty"`
+	LoadedEmbeddingProviders map[string]*Provider         `yaml:"-" json:"loaded_embedding_providers,omitempty"`
+	LoadedImageProviders     map[string]*Provider         `yaml:"-" json:"loaded_image_providers,omitempty"`
+	LoadedJudges             map[string]*JudgeTarget      `yaml:"-" json:"loaded_judges,omitempty"`
+	LoadedScenarios          map[string]*Scenario         `yaml:"-" json:"loaded_scenarios,omitempty"`
+	LoadedEvals              map[string]*Eval             `yaml:"-" json:"loaded_evals,omitempty"`
+	LoadedTools              []ToolData                   `yaml:"-" json:"loaded_tools,omitempty"`
+	LoadedSkillSources       []prompt.SkillSourceConfig   `yaml:"-" json:"loaded_skill_sources,omitempty"`
+	LoadedPersonas           map[string]*UserPersonaPack  `yaml:"-" json:"loaded_personas,omitempty"`
+	LoadedPack               *prompt.Pack                 `yaml:"-" json:"loaded_pack,omitempty"`
 
 	// Pack eval settings (set by CLI flags, not serialized)
 	SkipPackEvals  bool     `yaml:"-" json:"-"` // Disable pack eval execution
@@ -1141,7 +1153,7 @@ type Provider struct {
 	// Renamed from "capability" 2026-05-18 to avoid singular/plural
 	// collision with Capabilities. The field is required for tts/stt
 	// providers; defaults to "llm" when empty.
-	Role    string `json:"role,omitempty" yaml:"role,omitempty" jsonschema:"enum=llm,enum=tts,enum=stt"`
+	Role    string `json:"role,omitempty" yaml:"role,omitempty" jsonschema:"enum=llm,enum=tts,enum=stt,enum=embedding,enum=image"` //nolint:lll // enum list can't be split inside a struct tag
 	BaseURL string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	// Headers specifies custom HTTP headers to include in every request to
 	// this provider. Useful for OpenAI-compatible gateways (OpenRouter,

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -478,6 +478,18 @@
           },
           "type": "array"
         },
+        "embedding_providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
+        "image_providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
         "voices": {
           "items": {
             "$ref": "#/$defs/VoiceBinding"
@@ -1739,7 +1751,9 @@
           "enum": [
             "llm",
             "tts",
-            "stt"
+            "stt",
+            "embedding",
+            "image"
           ]
         },
         "base_url": {

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -129,7 +129,9 @@
           "enum": [
             "llm",
             "tts",
-            "stt"
+            "stt",
+            "embedding",
+            "image"
           ]
         },
         "base_url": {

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -577,7 +577,9 @@
           "enum": [
             "llm",
             "tts",
-            "stt"
+            "stt",
+            "embedding",
+            "image"
           ]
         },
         "base_url": {


### PR DESCRIPTION
## Summary

The public `Provider.Role` enum only had `llm`, `tts`, `stt` — three of the five values that `runtime/providers/base.ProviderType` already defines internally. Embedding providers (voyageai, OpenAI text-embedding, Gemini embedding) and image providers (Imagen, future DALL-E) had no way to declare their role, so today they get authored as if they were LLM providers and silently end up in the agent-under-test matrix.

This PR closes the gap.

## Changes

- `RoleEmbedding = \"embedding\"` and `RoleImage = \"image\"` added to `pkg/config/role.go`. `Provider.Role` jsonschema enum extended; `ValidateRole` accepts both.
- `arena.Spec.EmbeddingProviders []ProviderRef` and `arena.Spec.ImageProviders []ProviderRef` mirror the existing `tts_providers:` / `stt_providers:` pattern — declared in arena YAML, loaded into `LoadedEmbeddingProviders` / `LoadedImageProviders` maps, excluded from the LLM matrix.
- Loader validates each referenced provider declares the matching role.
- Main `providers:` loader's error message now lists embedding/image as recognized destinations.

## Test plan

- [x] `go test ./pkg/config/...` — 569 pass, all new fields exercised
- [x] New tests: `TestLoadConfig_LoadsEmbeddingAndImageProviders`, `TestLoadConfig_RejectsEmbeddingProviderInLLMList`, `TestLoadConfig_RejectsImageProviderWithLLMRole`
- [x] `go test ./pkg/config/... ./tools/arena/... ./runtime/... ./sdk/...` — 13934 pass
- [x] Coverage on `pkg/config/loader.go`: 83.4% (above 80% threshold)
- [x] Schemas regenerated (`make schemas`)

## Deferred to follow-up PRs

- Migrating existing examples (e.g. `examples/arena-media-test/`) to use `image_providers:` for Imagen. Shipped examples must validate against the published remote schema, so the migration has to wait until this PR's schema lands in a release.
- Voyageai exposed via `embedding_providers:` (currently only configurable via the parallel `RuntimeConfig.EmbeddingProviders` block in SDK config). Deprecating the parallel slot is its own change.
- Lifting Imagen out of the LLM provider registry's `case \"imagen\"` baseURL default. That's a runtime/providers refactor — orthogonal to the config-level role exposure here.