### PR TITLE
refactor(providers): drop imagen baseURL case from LLM registry switch

### DIFF
--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -284,8 +284,6 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 				spec.Platform != "bedrock" {
 				baseURL = "https://api.anthropic.com"
 			}
-		case "imagen":
-			baseURL = DefaultGeminiBaseURL
 		case "ollama":
 			baseURL = "http://localhost:11434"
 		case "vllm":

--- a/runtime/providers/registry_extended_test.go
+++ b/runtime/providers/registry_extended_test.go
@@ -153,7 +153,10 @@ func TestCreateProviderFromSpecDefaultBaseURLs(t *testing.T) {
 		{"openai default", "openai", "https://api.openai.com/v1"},
 		{"gemini default", "gemini", "https://generativelanguage.googleapis.com/v1beta"},
 		{"claude default", "claude", "https://api.anthropic.com"},
-		{"imagen default", "imagen", "https://generativelanguage.googleapis.com/v1beta"},
+		// imagen's default baseURL is set inside imagen.NewProvider (not the
+		// LLM registry switch), so spec.BaseURL reaches the factory empty.
+		// imagen_test.go covers the in-factory default — there's nothing for
+		// the LLM-registry-level test to assert.
 		{"ollama default", "ollama", "http://localhost:11434"},
 		{"vllm default", "vllm", "http://localhost:8000"},
 		{"mock default", "mock", ""},


### PR DESCRIPTION
## Summary

The LLM provider registry's baseURL-default switch had a hard-coded `case \"imagen\": baseURL = DefaultGeminiBaseURL`. That was redundant — imagen's own `NewProvider` already defaults BaseURL to the same value when the spec arrives with it empty. The case in the central LLM registry was an inconsistency: most provider packages own their own defaults; imagen alone leaked into the LLM registry.

After this change, imagen is reachable through the universal `RegisterProviderFactory` mechanism just like every other provider type — its image-vs-LLM classification lives entirely in `Provider.Type()` (returns `base.ProviderTypeImage`) and in the config-level `role: image` from PR #1197.

## Why no \"image factory\" package was added

Image providers use the standard `Provider.Predict()` interface (image bytes returned in the response). Per-role factory registries (`RegisterEmbeddingProviderFactory`, etc.) only exist where the interface diverges from Predict — `Embed()` for embeddings, `Synthesize()` for TTS, `Transcribe()` for STT. An \"image factory\" would be infrastructure parallel to the existing universal factory with no functional difference.

## Test plan

- [x] `go test ./runtime/providers/...` — 2945 pass
- [x] In-factory baseURL defaulting verified by existing `imagen_test.go`
- [x] Removed the now-stale \"imagen default\" entry from `TestCreateProviderFromSpecDefaultBaseURLs` (the LLM registry no longer special-cases the type)