### PR TITLE
feat(config): route providers: by role; deprecate role-specific slots

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1863,6 +1863,86 @@ spec:
 	}
 }
 
+func TestLoadConfig_UnifiedProvidersList_RoutesImageRole(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "image.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: imagen-routed
+spec:
+  id: imagen-routed
+  type: imagen
+  role: image
+  model: imagen-4.0-generate-001
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers:
+    - file: image.provider.yaml
+  defaults:
+    concurrency: 1
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if _, inLLM := cfg.LoadedProviders["imagen-routed"]; inLLM {
+		t.Errorf("image provider must not appear in LoadedProviders (LLM matrix)")
+	}
+	if _, ok := cfg.LoadedImageProviders["imagen-routed"]; !ok {
+		t.Errorf("image provider must be routed into LoadedImageProviders")
+	}
+}
+
+func TestLoadConfig_UnifiedProvidersList_RoutesSTTRole(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "stt.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: whisper-routed
+spec:
+  id: whisper-routed
+  type: openai
+  role: stt
+  model: whisper-1
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config.arena.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: t
+spec:
+  providers:
+    - file: stt.provider.yaml
+  defaults:
+    concurrency: 1
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if _, inLLM := cfg.LoadedProviders["whisper-routed"]; inLLM {
+		t.Errorf("stt provider must not appear in LoadedProviders (LLM matrix)")
+	}
+	if _, ok := cfg.LoadedSTTProviders["whisper-routed"]; !ok {
+		t.Errorf("stt provider must be routed into LoadedSTTProviders")
+	}
+}
+
 func TestLoadConfig_RejectsEmbeddingProviderMissingFile(t *testing.T) {
 	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
 	tmp := t.TempDir()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1821,7 +1821,7 @@ spec:
 	}
 }
 
-func TestLoadConfig_RejectsEmbeddingProviderInLLMList(t *testing.T) {
+func TestLoadConfig_UnifiedProvidersList_RoutesByRole(t *testing.T) {
 	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "embed.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
@@ -1849,12 +1849,17 @@ spec:
 		t.Fatal(err)
 	}
 
-	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
-	if err == nil {
-		t.Fatal("expected role mismatch error for embedding provider in providers: list")
+	cfg, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
 	}
-	if !strings.Contains(err.Error(), "embedding_providers") {
-		t.Errorf("error message must guide user to embedding_providers list; got: %v", err)
+	// role=embedding entry in unified providers: list must NOT enter the LLM
+	// matrix — it routes into LoadedEmbeddingProviders.
+	if _, inLLM := cfg.LoadedProviders["voyage-embed"]; inLLM {
+		t.Errorf("embedding provider must not appear in LoadedProviders (LLM matrix)")
+	}
+	if _, ok := cfg.LoadedEmbeddingProviders["voyage-embed"]; !ok {
+		t.Errorf("embedding provider must be routed into LoadedEmbeddingProviders")
 	}
 }
 
@@ -2201,15 +2206,15 @@ spec:
 	}
 }
 
-func TestLoadConfig_RejectsTTSProviderInLLMProvidersList(t *testing.T) {
+func TestLoadConfig_TTSProviderInUnifiedProvidersList(t *testing.T) {
 	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
 	tmp := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmp, "wrong.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+	if err := os.WriteFile(filepath.Join(tmp, "voice.provider.yaml"), []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
 kind: Provider
 metadata:
-  name: wrong
+  name: cartesia-voice
 spec:
-  id: wrong
+  id: cartesia-voice
   type: cartesia
   role: tts
   voice: vid-1
@@ -2225,17 +2230,22 @@ spec:
   defaults:
     concurrency: 1
   providers:
-    - file: wrong.provider.yaml
+    - file: voice.provider.yaml
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
-	if err == nil {
-		t.Fatal("expected error: tts provider in spec.providers list")
+	cfg, err := LoadConfig(filepath.Join(tmp, "config.arena.yaml"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
 	}
-	if !strings.Contains(err.Error(), "role") {
-		t.Fatalf("expected error mentioning role, got: %v", err)
+	// role=tts in the unified providers: list routes into LoadedTTSProviders
+	// (not LoadedProviders / the LLM matrix).
+	if _, inLLM := cfg.LoadedProviders["cartesia-voice"]; inLLM {
+		t.Errorf("tts provider must not appear in LoadedProviders (LLM matrix)")
+	}
+	if _, ok := cfg.LoadedTTSProviders["cartesia-voice"]; !ok {
+		t.Errorf("tts provider must be routed into LoadedTTSProviders")
 	}
 }
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -466,7 +466,18 @@ func (c *Config) loadEvals(configPath string) error {
 	)
 }
 
-// loadProviders loads all referenced providers
+// loadProviders loads all referenced providers from the unified
+// `providers:` list and routes each into the appropriate Loaded* map
+// based on its `role:` value. role=llm (default) goes into the
+// agent-under-test matrix; non-llm roles populate role-specific
+// maps that consumers (TTS resolver, embedding bridge, etc.) look up
+// by ID.
+//
+// The dedicated `tts_providers:` / `stt_providers:` / `embedding_providers:`
+// / `image_providers:` slots are still honored for backward
+// compatibility and load via loadTTSProviders et al; pack authors are
+// encouraged to put every provider in the unified `providers:` list and
+// let role routing do the work.
 func (c *Config) loadProviders(configPath string) error {
 	for _, ref := range c.Providers {
 		fullPath := ResolveFilePath(configPath, ref.File)
@@ -477,21 +488,27 @@ func (c *Config) loadProviders(configPath string) error {
 		if err := provider.ValidateRole(); err != nil {
 			return fmt.Errorf("provider %s: %w", provider.ID, err)
 		}
-		if role := provider.GetRole(); role != RoleLLM {
-			return fmt.Errorf("providers[%s]: role must be %q (or empty), got %q; "+
-				"TTS providers belong under tts_providers, STT under stt_providers, "+
-				"embedding under embedding_providers, image under image_providers",
-				ref.File, RoleLLM, role)
-		}
-		c.LoadedProviders[provider.ID] = provider
-		group := ref.Group
-		if group == "" {
-			group = defaultProviderGroup
-		}
-		c.ProviderGroups[provider.ID] = group
-		// Populate provider capabilities from the provider spec
-		if len(provider.Capabilities) > 0 {
-			c.ProviderCapabilities[provider.ID] = provider.Capabilities
+		switch provider.GetRole() {
+		case RoleLLM:
+			c.LoadedProviders[provider.ID] = provider
+			group := ref.Group
+			if group == "" {
+				group = defaultProviderGroup
+			}
+			c.ProviderGroups[provider.ID] = group
+			if len(provider.Capabilities) > 0 {
+				c.ProviderCapabilities[provider.ID] = provider.Capabilities
+			}
+		case RoleTTS:
+			c.LoadedTTSProviders[provider.ID] = provider
+		case RoleSTT:
+			c.LoadedSTTProviders[provider.ID] = provider
+		case RoleEmbedding:
+			c.LoadedEmbeddingProviders[provider.ID] = provider
+		case RoleImage:
+			c.LoadedImageProviders[provider.ID] = provider
+		default:
+			return fmt.Errorf("providers[%s]: unhandled role %q", ref.File, provider.GetRole())
 		}
 	}
 	return nil

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -128,24 +128,17 @@ type Config struct {
 	// ProviderCapabilities maps provider ID to its capabilities (populated during load)
 	ProviderCapabilities map[string][]string `yaml:"-" json:"provider_capabilities,omitempty"`
 
-	// TTSProviders lists provider files where Spec.Capability == "tts".
-	// Loaded but NOT included in the agent-under-test matrix.
-	TTSProviders []ProviderRef `yaml:"tts_providers,omitempty" json:"tts_providers,omitempty"`
-
-	// STTProviders lists provider files where Spec.Role == "stt".
-	// Same matrix-exclusion as TTSProviders. No STT consumers exist yet;
-	// the field is present so STT can land later without a schema change.
-	STTProviders []ProviderRef `yaml:"stt_providers,omitempty" json:"stt_providers,omitempty"`
-
-	// EmbeddingProviders lists provider files where Spec.Role == "embedding".
-	// Loaded but NOT included in the agent-under-test matrix. Voyageai,
-	// OpenAI text-embedding-3, Gemini embedding, etc. live here.
+	// TTSProviders / STTProviders / EmbeddingProviders / ImageProviders are
+	// the legacy role-specific slots. They still load correctly — every
+	// entry's `role:` is validated against the slot — but the preferred
+	// shape is a single unified `providers:` list where the loader routes
+	// each provider into the right Loaded* map based on its `role:` value.
+	// Mixing the legacy slots and the unified list is supported during
+	// migration; both populate the same Loaded* maps.
+	TTSProviders       []ProviderRef `yaml:"tts_providers,omitempty" json:"tts_providers,omitempty"`
+	STTProviders       []ProviderRef `yaml:"stt_providers,omitempty" json:"stt_providers,omitempty"`
 	EmbeddingProviders []ProviderRef `yaml:"embedding_providers,omitempty" json:"embedding_providers,omitempty"`
-
-	// ImageProviders lists provider files where Spec.Role == "image".
-	// Loaded but NOT included in the agent-under-test matrix. Imagen,
-	// OpenAI Images, future Stable Diffusion adapters live here.
-	ImageProviders []ProviderRef `yaml:"image_providers,omitempty" json:"image_providers,omitempty"`
+	ImageProviders     []ProviderRef `yaml:"image_providers,omitempty" json:"image_providers,omitempty"`
 
 	// Voices binds voice IDs to loaded TTS provider IDs. Personas reference
 	// voice IDs (not provider IDs) so the same persona can run against a


### PR DESCRIPTION
## Summary

The arena config historically grew separate top-level slots for each non-LLM provider role: `tts_providers:`, `stt_providers:`, `embedding_providers:`, `image_providers:`. Each list required entries whose YAML `role:` matched the slot. That meant declaring a provider's type *twice* — once via slot choice, once via the `role:` field on the provider yaml.

This PR lets the unified `providers:` list contain providers of any role. `pkg/config.loadProviders` now switches on each provider's `role:` and routes into the appropriate `Loaded*Providers` map:

| `role:` | Routed into | LLM matrix? |
|---|---|---|
| (unset) or `llm` | `LoadedProviders` | ✅ included |
| `tts` | `LoadedTTSProviders` | ❌ excluded |
| `stt` | `LoadedSTTProviders` | ❌ excluded |
| `embedding` | `LoadedEmbeddingProviders` | ❌ excluded |
| `image` | `LoadedImageProviders` | ❌ excluded |

The legacy slots still work — they're documented as such in the `Spec` struct. Mixing the legacy slots with the unified list during migration is supported; both populate the same Loaded* maps and downstream consumers can't tell the difference.

## Why this matters

Groups are the natural unit for cross-role matrix composition. A group like `image-gen-candidates` can contain an `role: image` Imagen provider AND a `role: llm` Gemini provider that supports image output as a model capability. A scenario targeting that group gets both as candidates. With separate YAML slots, the same group ID spread across slots was awkward; with the unified list, group + role compose cleanly.

## Test plan

- [x] `go test ./pkg/config/...` — 566 pass, including two rewritten tests that pin the new routing semantics
- [x] `go test ./pkg/config/... ./runtime/... ./sdk/... ./tools/arena/...` — 13939 pass
- [x] Coverage on `pkg/config/loader.go`: 83.6% (above 80% threshold)
- [x] Schemas regenerate cleanly with no diff (the schema already supports the unified pattern)

## Migration

No example changes in this PR — existing shipped packs still validate against the published schema, and the legacy slots still load. Migration of examples (`tts_providers:` → unified `providers:`) and SDK-side loading of role-tagged provider files is queued as a follow-up.