### PR TITLE
feat(config,imagen): predict-compatible roles flow through the matrix

### DIFF
--- a/examples/arena-media-test/providers/imagen-provider.provider.yaml
+++ b/examples/arena-media-test/providers/imagen-provider.provider.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   id: "imagen-provider"
   type: imagen
+  role: image
   model: imagen-4.0-generate-001

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1895,11 +1895,13 @@ spec:
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if _, inLLM := cfg.LoadedProviders["imagen-routed"]; inLLM {
-		t.Errorf("image provider must not appear in LoadedProviders (LLM matrix)")
+	// image is Predict-compatible — eligible for the matrix AND indexed
+	// in the typed image map.
+	if _, inMatrix := cfg.LoadedProviders["imagen-routed"]; !inMatrix {
+		t.Errorf("image provider must appear in LoadedProviders (matrix); image is Predict-compatible")
 	}
 	if _, ok := cfg.LoadedImageProviders["imagen-routed"]; !ok {
-		t.Errorf("image provider must be routed into LoadedImageProviders")
+		t.Errorf("image provider must also be routed into LoadedImageProviders")
 	}
 }
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 )
 
@@ -468,10 +469,16 @@ func (c *Config) loadEvals(configPath string) error {
 
 // loadProviders loads all referenced providers from the unified
 // `providers:` list and routes each into the appropriate Loaded* map
-// based on its `role:` value. role=llm (default) goes into the
-// agent-under-test matrix; non-llm roles populate role-specific
-// maps that consumers (TTS resolver, embedding bridge, etc.) look up
-// by ID.
+// based on its `role:` value.
+//
+// Matrix membership is by interface compatibility with the LLM-shaped
+// ProviderStage: role=llm and role=image both implement Predict and
+// flow through ProviderStage normally, so both go into LoadedProviders
+// (the agent-under-test matrix) AND each role's typed map. role=tts,
+// role=stt, role=embedding use different interfaces (Synthesize,
+// Transcribe, Embed) and never reach ProviderStage — they're routed
+// only to their typed map and a one-line warning is emitted explaining
+// they were loaded but excluded from the matrix.
 //
 // The dedicated `tts_providers:` / `stt_providers:` / `embedding_providers:`
 // / `image_providers:` slots are still honored for backward
@@ -488,8 +495,10 @@ func (c *Config) loadProviders(configPath string) error {
 		if err := provider.ValidateRole(); err != nil {
 			return fmt.Errorf("provider %s: %w", provider.ID, err)
 		}
-		switch provider.GetRole() {
-		case RoleLLM:
+		role := provider.GetRole()
+		switch role {
+		case RoleLLM, RoleImage:
+			// Predict-compatible — eligible for the agent-under-test matrix.
 			c.LoadedProviders[provider.ID] = provider
 			group := ref.Group
 			if group == "" {
@@ -499,16 +508,26 @@ func (c *Config) loadProviders(configPath string) error {
 			if len(provider.Capabilities) > 0 {
 				c.ProviderCapabilities[provider.ID] = provider.Capabilities
 			}
+			if role == RoleImage {
+				c.LoadedImageProviders[provider.ID] = provider
+			}
 		case RoleTTS:
 			c.LoadedTTSProviders[provider.ID] = provider
+			logger.Warn("Provider loaded but excluded from matrix",
+				"provider", provider.ID, "role", role,
+				"reason", "TTS uses Synthesize() interface, not Predict()")
 		case RoleSTT:
 			c.LoadedSTTProviders[provider.ID] = provider
+			logger.Warn("Provider loaded but excluded from matrix",
+				"provider", provider.ID, "role", role,
+				"reason", "STT uses Transcribe() interface, not Predict()")
 		case RoleEmbedding:
 			c.LoadedEmbeddingProviders[provider.ID] = provider
-		case RoleImage:
-			c.LoadedImageProviders[provider.ID] = provider
+			logger.Warn("Provider loaded but excluded from matrix",
+				"provider", provider.ID, "role", role,
+				"reason", "embedding providers use Embed() interface, not Predict()")
 		default:
-			return fmt.Errorf("providers[%s]: unhandled role %q", ref.File, provider.GetRole())
+			return fmt.Errorf("providers[%s]: unhandled role %q", ref.File, role)
 		}
 	}
 	return nil

--- a/runtime/providers/imagen/factory.go
+++ b/runtime/providers/imagen/factory.go
@@ -2,7 +2,6 @@
 package imagen
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -10,13 +9,16 @@ import (
 
 func init() {
 	providers.RegisterProviderFactory("imagen", func(spec providers.ProviderSpec) (providers.Provider, error) {
-		// Get API key from environment
+		// Resolve API key. Construction must not fail when the key is
+		// absent — the provider is registered in the engine's provider
+		// registry at startup regardless of whether anyone will use it.
+		// Tooling that swaps in a mock (e.g. `promptarena run --mock-provider`)
+		// or scenarios that don't target imagen would otherwise be blocked
+		// by a key check for a provider they'll never call. Predict()
+		// surfaces the missing-key error when imagen is actually invoked.
 		apiKey := os.Getenv("GOOGLE_API_KEY")
 		if apiKey == "" {
 			apiKey = os.Getenv("GEMINI_API_KEY")
-		}
-		if apiKey == "" {
-			return nil, fmt.Errorf("GOOGLE_API_KEY or GEMINI_API_KEY environment variable not set")
 		}
 
 		// Project ID and location are no longer required when using Gemini API endpoint

--- a/runtime/providers/imagen/imagen.go
+++ b/runtime/providers/imagen/imagen.go
@@ -166,6 +166,11 @@ func extractPrompt(req providers.PredictionRequest) (string, error) {
 func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest) (providers.PredictionResponse, error) {
 	start := time.Now()
 
+	if p.ApiKey == "" {
+		return providers.PredictionResponse{}, fmt.Errorf(
+			"imagen: GOOGLE_API_KEY or GEMINI_API_KEY environment variable not set")
+	}
+
 	prompt, err := extractPrompt(req)
 	if err != nil {
 		return providers.PredictionResponse{}, err

--- a/runtime/providers/imagen/imagen_test.go
+++ b/runtime/providers/imagen/imagen_test.go
@@ -121,20 +121,10 @@ func TestProviderIDFromFactory(t *testing.T) {
 			wantID:  "my-imagen-gen",
 			wantErr: false,
 		},
-		{
-			name: "missing API key",
-			spec: providers.ProviderSpec{
-				ID:      "test-imagen",
-				Type:    "imagen",
-				Model:   "imagen-4.0-generate-001",
-				BaseURL: "https://aiplatform.googleapis.com/v1",
-				AdditionalConfig: map[string]interface{}{
-					"project_id": "test-project",
-				},
-			},
-			wantID:  "",
-			wantErr: true,
-		},
+		// (Construction without an API key is verified by
+		// TestProviderFactory_MissingAPIKeyConstructsOK below — covering
+		// the explicit "no env vars" setup that this table-driven test's
+		// shared setup can't express without conditional branching.)
 		{
 			name: "project_id now optional",
 			spec: providers.ProviderSpec{
@@ -180,6 +170,33 @@ func TestProviderIDFromFactory(t *testing.T) {
 				t.Errorf("Expected provider ID %q, got %q", tt.wantID, provider.ID())
 			}
 		})
+	}
+}
+
+// TestProviderFactory_MissingAPIKeyConstructsOK pins the contract that
+// imagen's factory must not fail on a missing API key. Engines (e.g.
+// arena's --mock-provider mode) register every declared provider in
+// the matrix at startup; if any factory fails fast on credentials,
+// the whole engine fails to come up — even when nobody will actually
+// invoke that provider. The error is deferred to Predict() instead.
+func TestProviderFactory_MissingAPIKeyConstructsOK(t *testing.T) {
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+
+	provider, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
+		ID:    "imagen-no-key",
+		Type:  "imagen",
+		Model: "imagen-4.0-generate-001",
+	})
+	if err != nil {
+		t.Fatalf("factory must not fail on missing API key; got: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("provider must be non-nil even without API key")
+	}
+	if provider.ID() != "imagen-no-key" {
+		t.Errorf("provider ID = %q, want %q", provider.ID(), "imagen-no-key")
 	}
 }
 


### PR DESCRIPTION
## Summary

This change clarifies the matrix-membership rule and unblocks the imagen example migration.

**Rule**: a provider role joins the agent-under-test matrix iff its provider interface is compatible with \`ProviderStage\` — i.e. it implements \`Predict()\`. That's \`role: llm\` and \`role: image\` (Imagen happens to satisfy \`Predict\` with image bytes in the response). \`tts\` / \`stt\` / \`embedding\` use different interfaces (Synthesize / Transcribe / Embed) and never reach ProviderStage, so they load into their typed map and emit a one-line warning.

\`pkg/config.loadProviders\` switch is updated accordingly:

| role:    | Routed into                                  | Matrix? |
|----------|----------------------------------------------|---------|
| llm      | LoadedProviders                              | ✅       |
| image    | LoadedProviders + LoadedImageProviders       | ✅       |
| tts      | LoadedTTSProviders (warning logged)          | ❌       |
| stt      | LoadedSTTProviders (warning logged)          | ❌       |
| embedding| LoadedEmbeddingProviders (warning logged)    | ❌       |

The arena-media-test example imagen-provider gains \`role: image\` so it's correctly classified. Matrix sizing confirms behaviour parity: 24 mock runs (6 scenarios × 4 providers including imagen) — same as the pre-PR behaviour where imagen-as-default-llm was already matrix-eligible.

## Two follow-on fixes the migration depended on

1. **\`imagen\` factory no longer fails on missing API key.** Engines (notably arena's \`--mock-provider\` mode) register every declared provider before mocking; a keyless factory crashed engine init even when nobody would invoke the provider. Now construction succeeds; \`Predict()\` surfaces the missing-key error when (and only when) imagen is actually called.
2. **Test refactor**: \`TestProviderIDFromFactory/missing_API_key\` pinned the old construction-fail behaviour. Replaced with a dedicated \`TestProviderFactory_MissingAPIKeyConstructsOK\` covering the new contract.

## Test plan

- [x] \`go test ./pkg/config/... ./runtime/... ./sdk/... ./tools/arena/...\` — 13941 pass
- [x] \`examples/arena-media-test/\` runs with \`--mock-provider\` against published schemas (no \`PROMPTKIT_SCHEMA_SOURCE=local\` needed thanks to v1.4.9 release)
- [x] Coverage thresholds: \`pkg/config/loader.go\` 84.4%, \`imagen/factory.go\` 100%, \`imagen/imagen.go\` 94.3%