### PR TITLE
chore(examples): migrate tts_providers blocks to unified providers list

### DIFF
--- a/examples/duplex-streaming/config.arena.yaml
+++ b/examples/duplex-streaming/config.arena.yaml
@@ -21,7 +21,9 @@ spec:
     - id: voice-assistant-tools
       file: prompts/voice-assistant-tools.prompt.yaml
 
-  # Provider configurations
+  # All providers — LLM and TTS — live in the unified `providers:` list.
+  # The loader routes each entry by its `role:` field; TTS entries skip
+  # the agent-under-test matrix and are looked up by voice bindings below.
   providers:
     # Real providers for local testing (require API keys)
     - file: providers/gemini-2-flash.provider.yaml
@@ -39,8 +41,7 @@ spec:
     - file: providers/mock-duplex-simulate.provider.yaml
     # Replay provider for deterministic playback of recorded sessions
     # - file: providers/replay-duplex.provider.yaml  # Disabled until we have a recording
-
-  tts_providers:
+    # TTS providers (role: tts) — bound to voice IDs below.
     - file: providers/elevenlabs-rachel.provider.yaml
     - file: providers/openai-echo.provider.yaml
     - file: providers/openai-alloy-expressive.provider.yaml

--- a/examples/voice-refund-demo/config.arena.yaml
+++ b/examples/voice-refund-demo/config.arena.yaml
@@ -15,13 +15,14 @@ spec:
     - id: refund-agent
       file: prompts/refund-agent.prompt.yaml
 
+  # All providers — LLM and TTS — live in the unified `providers:` list.
+  # The loader routes each entry by its `role:` field; TTS entries skip the
+  # agent-under-test matrix and are looked up by voice bindings below.
   providers:
     - file: providers/gemini-2-flash.provider.yaml
     - file: providers/openai-gpt4o-realtime.provider.yaml
     - file: providers/mock-duplex.provider.yaml
     - file: providers/openai-gpt4o-mini-text.provider.yaml
-
-  tts_providers:
     - file: providers/cartesia-confident-man.provider.yaml
     - file: providers/cartesia-friendly-woman.provider.yaml
     - file: providers/elevenlabs-arnold.provider.yaml


### PR DESCRIPTION
## Summary

\`voice-refund-demo\` and \`duplex-streaming\` were the last shipped examples still using the legacy \`tts_providers:\` slot. After PR #1199's unified-routing landed, TTS providers can live in the standard \`providers:\` list — the loader switches on each entry's \`role:\` and skips TTS entries from the agent-under-test matrix automatically.

Same loaded state, fewer YAML keys, cleaner pattern for new pack authors to copy.

## Compatibility

The legacy \`tts_providers:\` / \`stt_providers:\` / \`embedding_providers:\` / \`image_providers:\` slots remain supported — the loader still honors them. This PR just stops shipping examples that use them. Existing user packs continue to work unchanged.

## Test plan

- [x] Both example arena configs validate against the published v1.4.9 schemas (no \`PROMPTKIT_SCHEMA_SOURCE=local\` needed)
- [x] \`promptarena run\` loads both configs cleanly with the migrated layout
- [x] \`go test ./pkg/config/... ./tools/arena/...\` — 3930 pass