### PR TITLE
feat(classify): runtime/classify foundation + HuggingFace backend

### DIFF
--- a/runtime/classify/audio.go
+++ b/runtime/classify/audio.go
@@ -1,0 +1,59 @@
+package classify
+
+import (
+	"context"
+	"time"
+)
+
+// AudioClassifier classifies a single audio clip into one or more
+// labeled scores. Required interface for every backend that supports
+// audio (HF base, Hume, Deepgram, ONNX).
+//
+// Implementations must be safe for concurrent use; the registry hands
+// the same instance to multiple eval handlers.
+type AudioClassifier interface {
+	ClassifyAudio(ctx context.Context, audio []byte, opts AudioOptions) ([]LabelScore, error)
+}
+
+// AudioChunk is a single packet in a streaming audio classification
+// request. Backends that stream consume these from a channel until
+// it closes.
+type AudioChunk struct {
+	// PCM is the raw PCM audio bytes for this chunk. Format
+	// declared by the parent AudioStreamOptions.
+	PCM []byte
+	// Final marks the last chunk; backends may flush state.
+	Final bool
+}
+
+// AudioStreamOptions carries the framing contract for a streaming
+// audio classification request.
+type AudioStreamOptions struct {
+	AudioOptions
+	// ChunkInterval is the source's emit cadence; backends use it
+	// to size analysis windows and stamp output timestamps.
+	ChunkInterval time.Duration
+}
+
+// LabelScoreEvent is one window's worth of classification output
+// from a streaming backend. Timestamp is relative to the start of
+// the input stream.
+type LabelScoreEvent struct {
+	Timestamp time.Duration
+	Window    time.Duration
+	Scores    []LabelScore
+}
+
+// StreamingAudioClassifier is the optional capability for live
+// classification — Hume, Deepgram, and locally-windowed ONNX
+// implement it; HF Inference API base does not. Eval handlers that
+// only need end-of-turn classification depend on AudioClassifier;
+// hooks and guardrails that react mid-call type-assert to this.
+type StreamingAudioClassifier interface {
+	AudioClassifier
+	ClassifyAudioStream(
+		ctx context.Context,
+		chunks <-chan AudioChunk,
+		opts AudioStreamOptions,
+	) (<-chan LabelScoreEvent, error)
+}

--- a/runtime/classify/backends/hf/audio.go
+++ b/runtime/classify/backends/hf/audio.go
@@ -1,0 +1,61 @@
+package hf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+)
+
+// ClassifyAudio submits raw audio bytes to the HF Inference API
+// audio-classification endpoint for the configured model. Audio
+// preparation (resampling to 16 kHz mono WAV, etc.) is the caller's
+// responsibility — the handler upstream knows the source format from
+// message metadata and converts before calling.
+//
+// HF returns `[{"label": "...", "score": ...}, ...]` sorted by
+// descending score; we pass that order through.
+func (c *Client) ClassifyAudio(
+	ctx context.Context, audio []byte, opts classify.AudioOptions,
+) ([]classify.LabelScore, error) {
+	if len(audio) == 0 {
+		return nil, fmt.Errorf("hf: empty audio bytes")
+	}
+	if opts.Model == "" {
+		return nil, fmt.Errorf("hf: audio classification requires opts.Model")
+	}
+	url, err := c.modelURL(opts.Model)
+	if err != nil {
+		return nil, err
+	}
+	contentType := opts.MIMEType
+	if contentType == "" {
+		// HF accepts most audio content types; raw octet-stream is
+		// the safest default when the caller didn't tag it. Models
+		// that need explicit format selection will surface a 400.
+		contentType = defaultContentType
+	}
+	body, err := c.do(ctx, url, contentType, audio)
+	if err != nil {
+		return nil, err
+	}
+	return decodeLabelScores(body)
+}
+
+// decodeLabelScores parses HF's standard label/score array response.
+// Used by audio, text, image classifier paths — same shape.
+func decodeLabelScores(body []byte) ([]classify.LabelScore, error) {
+	var raw []struct {
+		Label string  `json:"label"`
+		Score float64 `json:"score"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("hf: decode label-score array: %w (body: %s)", err, truncateBody(body))
+	}
+	out := make([]classify.LabelScore, len(raw))
+	for i, r := range raw {
+		out[i] = classify.LabelScore{Label: r.Label, Score: r.Score}
+	}
+	return out, nil
+}

--- a/runtime/classify/backends/hf/client.go
+++ b/runtime/classify/backends/hf/client.go
@@ -52,11 +52,12 @@ const maxLoadingWaitCap = 15 * time.Second
 // platform-level failures.
 const errBodySnippetMax = 200
 
-// modelLoadingRetryMax bounds the wait for a cold HF model on first
-// call. HF returns 503 with an estimated_time payload; we retry that
-// many times then surface "model warming up" so the caller can treat
-// it as a skipped eval rather than a real failure.
-const modelLoadingRetryMax = 3
+// modelLoadingMaxRetries bounds the wait for a cold HF model on
+// first call. HF returns 503 with an estimated_time payload; we
+// retry that many times then surface "model warming up" so the
+// caller can treat it as a skipped eval rather than a real failure.
+// The total attempt count is 1 initial + N retries.
+const modelLoadingMaxRetries = 3
 
 // ErrModelLoading is returned when HF reports the model is still
 // warming up after exhausting retries. Eval handlers that see this
@@ -161,9 +162,21 @@ func (c *Client) modelURL(model string) (string, error) {
 //
 // Caller owns request encoding (audio bytes, JSON, etc.) — `do`
 // only handles auth + retry + error decoding.
+//
+// Retry policy: 503 is the model-loading signal and is retried
+// honoring HF's estimated_time (capped). 502/504 are NOT retried —
+// the HF Inference API surfaces real gateway errors with those
+// codes too, and a tight retry loop risks compounding upstream
+// load. If you want bounded gateway retries, add them at a higher
+// level via Config.HTTPClient transport middleware.
+//
+// TODO(#1214): no per-client rate limiting yet. HF free tier limits
+// per IP; the proposal calls for a token bucket sized from arena
+// config. Add when the first concurrent eval handler lands.
 func (c *Client) do(ctx context.Context, modelURL, contentType string, body []byte) ([]byte, error) {
-	var lastErr error
-	for attempt := 0; attempt <= modelLoadingRetryMax; attempt++ {
+	// Total attempts = 1 initial + modelLoadingMaxRetries.
+	totalAttempts := 1 + modelLoadingMaxRetries
+	for attempt := 0; attempt < totalAttempts; attempt++ {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, modelURL, bytes.NewReader(body))
 		if err != nil {
 			return nil, fmt.Errorf("hf: build request: %w", err)
@@ -187,24 +200,26 @@ func (c *Client) do(ctx context.Context, modelURL, contentType string, body []by
 		case http.StatusServiceUnavailable:
 			// Model is loading. HF returns JSON with estimated_time
 			// in seconds; we honor a small chunk of that (capped)
-			// and retry. Once attempts run out we surface
-			// ErrModelLoading so the caller marks the eval skipped.
-			wait := parseEstimatedWait(respBody, defaultLoadingRetryWait)
-			if attempt == modelLoadingRetryMax {
-				lastErr = fmt.Errorf("%w: last 503 body: %s", ErrModelLoading, truncateBody(respBody))
-				break
+			// and retry. On the last attempt return ErrModelLoading
+			// so the caller marks the eval skipped, not failed.
+			if attempt == totalAttempts-1 {
+				return nil, fmt.Errorf("%w: last 503 body: %s", ErrModelLoading, truncateBody(respBody))
 			}
+			wait := parseEstimatedWait(respBody, defaultLoadingRetryWait)
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			case <-time.After(wait):
 			}
-			continue
+			// Loop to next attempt.
 		default:
 			return nil, fmt.Errorf("hf: status %d: %s", resp.StatusCode, truncateBody(respBody))
 		}
 	}
-	return nil, lastErr
+	// Unreachable: every branch in the switch above either returns
+	// or continues the loop. Keep an explicit return so future
+	// refactors that add a fallthrough don't compile to nothing.
+	return nil, fmt.Errorf("hf: retry loop exited without resolution (internal bug)")
 }
 
 // parseEstimatedWait extracts {"estimated_time": <seconds>} from an

--- a/runtime/classify/backends/hf/client.go
+++ b/runtime/classify/backends/hf/client.go
@@ -1,0 +1,239 @@
+// Package hf implements the runtime/classify interfaces against the
+// HuggingFace Inference API.
+//
+// One Client backs every task interface — audio, text, image, video,
+// embedder — because they all share authentication, retry, and rate
+// limiting. Each interface method routes to the right HF endpoint
+// for the configured model.
+package hf
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+)
+
+// DefaultBaseURL is the canonical HF Inference API endpoint. Override
+// via Config.BaseURL for HF Inference Endpoints (dedicated paid hosts)
+// or the newer Inference Providers routing layer.
+const DefaultBaseURL = "https://api-inference.huggingface.co"
+
+// defaultContentType is the request Content-Type used when the caller
+// didn't tag the payload — HF accepts most media as raw bytes under
+// application/octet-stream and routes by Model / endpoint.
+const defaultContentType = "application/octet-stream"
+
+// defaultHTTPTimeout bounds a single HF Inference API request. HF
+// model invocation occasionally takes tens of seconds on cold paths;
+// 60s is a sensible upper bound that still surfaces hung requests.
+const defaultHTTPTimeout = 60 * time.Second
+
+// defaultLoadingRetryWait is used when HF returns a 503 without a
+// parseable estimated_time. Short enough to keep tests fast; long
+// enough that a cooperative server has time to warm up between
+// attempts in practice.
+const defaultLoadingRetryWait = 5 * time.Second
+
+// maxLoadingWaitCap clamps HF's estimated_time so a misconfigured
+// model doesn't trip a multi-minute sleep on the first call.
+const maxLoadingWaitCap = 15 * time.Second
+
+// errBodySnippetMax is the byte cap on response bodies included in
+// error messages. Keeps logs readable when HF returns HTML on
+// platform-level failures.
+const errBodySnippetMax = 200
+
+// modelLoadingRetryMax bounds the wait for a cold HF model on first
+// call. HF returns 503 with an estimated_time payload; we retry that
+// many times then surface "model warming up" so the caller can treat
+// it as a skipped eval rather than a real failure.
+const modelLoadingRetryMax = 3
+
+// ErrModelLoading is returned when HF reports the model is still
+// warming up after exhausting retries. Eval handlers that see this
+// should produce a skipped result, not a failed one — the model
+// isn't broken, it just hasn't initialized yet.
+var ErrModelLoading = errors.New("hf: model still loading after retries")
+
+// Config holds construction parameters for Client.
+type Config struct {
+	// APIKey is the HF token. Falls back to HF_TOKEN /
+	// HUGGING_FACE_HUB_TOKEN env vars in the factory wrapper; bare
+	// Client construction requires the caller to pass it.
+	APIKey string
+
+	// BaseURL overrides DefaultBaseURL. Used for HF Inference
+	// Endpoints (e.g. https://my-endpoint.xxx.endpoints.huggingface.cloud)
+	// and the Inference Providers routing layer.
+	BaseURL string
+
+	// Dedicated, when true, treats BaseURL as a fully-specified
+	// inference endpoint and skips the /models/{model_id} suffix
+	// that the public Inference API requires. Set this when pointing
+	// at HF Inference Endpoints (the paid dedicated host shape).
+	// Default false matches the public Inference API.
+	Dedicated bool
+
+	// HTTPClient lets the caller provide a custom transport (test
+	// httptest server, timeouts, retry middleware). Default
+	// is a 60s-timeout client.
+	HTTPClient *http.Client
+}
+
+// Client is a HuggingFace Inference API client. It satisfies every
+// task interface in runtime/classify; methods that the configured
+// model doesn't support fail at call time with an HF error, not at
+// construction.
+type Client struct {
+	apiKey     string
+	baseURL    string
+	dedicated  bool
+	httpClient *http.Client
+}
+
+// Compile-time check: Client must satisfy every classify task
+// interface so the HF backend can be dropped into any registry slot.
+var (
+	_ classify.AudioClassifier = (*Client)(nil)
+	_ classify.TextClassifier  = (*Client)(nil)
+	_ classify.ImageClassifier = (*Client)(nil)
+	_ classify.Embedder        = (*Client)(nil)
+)
+
+// NewClient constructs a Client. APIKey is required.
+func NewClient(cfg Config) (*Client, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("hf: api key is required")
+	}
+	base := cfg.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &Client{
+		apiKey:     cfg.APIKey,
+		baseURL:    strings.TrimRight(base, "/"),
+		dedicated:  cfg.Dedicated,
+		httpClient: httpClient,
+	}, nil
+}
+
+// modelURL builds the request URL for a given model id. The public
+// Inference API routes via /models/{owner}/{name}; HF Inference
+// Endpoints (the dedicated host shape) bake the model into the
+// endpoint itself and skip the suffix — callers opt into that with
+// Config.Dedicated. Detection by hostname was tried first but trips
+// in httptest setups where the URL is neither shape; explicit flag is
+// the simplest unambiguous answer.
+func (c *Client) modelURL(model string) (string, error) {
+	if model == "" {
+		return "", fmt.Errorf("hf: model id is required")
+	}
+	if c.dedicated {
+		return c.baseURL, nil
+	}
+	// PathEscape would turn "owner/model" into "owner%2Fmodel"; HF
+	// expects the slash to be a path separator. Escape segments
+	// individually so legitimate slashes pass through but stray
+	// characters (e.g. spaces) get encoded.
+	segments := strings.Split(model, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return c.baseURL + "/models/" + strings.Join(segments, "/"), nil
+}
+
+// do performs an HTTP request to the HF Inference API with model-
+// loading retry baked in. Returns the response body on success, an
+// ErrModelLoading on exhausted retries, or the wrapped HTTP error.
+//
+// Caller owns request encoding (audio bytes, JSON, etc.) — `do`
+// only handles auth + retry + error decoding.
+func (c *Client) do(ctx context.Context, modelURL, contentType string, body []byte) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt <= modelLoadingRetryMax; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, modelURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("hf: build request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+		req.Header.Set("Content-Type", contentType)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("hf: send request: %w", err)
+		}
+		respBody, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("hf: read response: %w", readErr)
+		}
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			return respBody, nil
+		case http.StatusServiceUnavailable:
+			// Model is loading. HF returns JSON with estimated_time
+			// in seconds; we honor a small chunk of that (capped)
+			// and retry. Once attempts run out we surface
+			// ErrModelLoading so the caller marks the eval skipped.
+			wait := parseEstimatedWait(respBody, defaultLoadingRetryWait)
+			if attempt == modelLoadingRetryMax {
+				lastErr = fmt.Errorf("%w: last 503 body: %s", ErrModelLoading, truncateBody(respBody))
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+			continue
+		default:
+			return nil, fmt.Errorf("hf: status %d: %s", resp.StatusCode, truncateBody(respBody))
+		}
+	}
+	return nil, lastErr
+}
+
+// parseEstimatedWait extracts {"estimated_time": <seconds>} from an
+// HF 503 body, clamped to maxLoadingWaitCap. Falls back to fallback
+// when the body isn't parseable.
+func parseEstimatedWait(body []byte, fallback time.Duration) time.Duration {
+	var parsed struct {
+		EstimatedTime float64 `json:"estimated_time"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil || parsed.EstimatedTime <= 0 {
+		return fallback
+	}
+	wait := time.Duration(parsed.EstimatedTime * float64(time.Second))
+	if wait > maxLoadingWaitCap {
+		return maxLoadingWaitCap
+	}
+	return wait
+}
+
+// truncateBody trims a response body for inclusion in an error
+// message. HF errors are usually short JSON, but model output can
+// occasionally come back HTML-wrapped on platform errors. The cap
+// comes from errBodySnippetMax — keeping it a package constant means
+// every error message uses the same budget without each call site
+// duplicating the literal.
+func truncateBody(body []byte) string {
+	s := string(body)
+	if len(s) > errBodySnippetMax {
+		return s[:errBodySnippetMax] + "…"
+	}
+	return s
+}

--- a/runtime/classify/backends/hf/client_test.go
+++ b/runtime/classify/backends/hf/client_test.go
@@ -2,6 +2,7 @@ package hf
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -115,10 +116,12 @@ func TestClient_ClassifyAudio_RequiresModel(t *testing.T) {
 }
 
 func TestClient_ClassifyText_HappyPath(t *testing.T) {
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Content-Type") != "application/json" {
 			t.Errorf("text content-type = %q, want application/json", r.Header.Get("Content-Type"))
 		}
+		gotBody, _ = io.ReadAll(r.Body)
 		// HF nested shape — one inner array per input.
 		fmt.Fprintln(w, `[[{"label":"toxic","score":0.91},{"label":"clean","score":0.09}]]`)
 	}))
@@ -134,6 +137,23 @@ func TestClient_ClassifyText_HappyPath(t *testing.T) {
 	}
 	if len(got) != 2 || got[0].Label != "toxic" {
 		t.Errorf("got %v, want toxic first", got)
+	}
+
+	// Pin the request body shape so a refactor that drops Parameters
+	// (or breaks Inputs encoding) gets caught here rather than in a
+	// production HF call where the failure is harder to attribute.
+	var sent struct {
+		Inputs     string         `json:"inputs"`
+		Parameters map[string]any `json:"parameters"`
+	}
+	if err := json.Unmarshal(gotBody, &sent); err != nil {
+		t.Fatalf("request body must be valid JSON: %v (raw: %s)", err, gotBody)
+	}
+	if sent.Inputs != "you suck" {
+		t.Errorf("request inputs = %q, want %q", sent.Inputs, "you suck")
+	}
+	if v, ok := sent.Parameters["return_all_scores"].(bool); !ok || !v {
+		t.Errorf("MultiLabel=true must set parameters.return_all_scores=true; got params %v", sent.Parameters)
 	}
 }
 

--- a/runtime/classify/backends/hf/client_test.go
+++ b/runtime/classify/backends/hf/client_test.go
@@ -1,0 +1,428 @@
+package hf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+)
+
+// newTestClient wires a Client at an httptest server. Each test
+// constructs its own server with a custom handler so request shape
+// can be asserted alongside the response decode.
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := NewClient(Config{
+		APIKey:     "test-token",
+		BaseURL:    srv.URL,
+		HTTPClient: srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func TestNewClient_RequiresAPIKey(t *testing.T) {
+	if _, err := NewClient(Config{}); err == nil {
+		t.Fatal("NewClient must reject empty API key")
+	}
+}
+
+func TestNewClient_DefaultsBaseURL(t *testing.T) {
+	c, err := NewClient(Config{APIKey: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.baseURL != DefaultBaseURL {
+		t.Errorf("baseURL = %q, want %q", c.baseURL, DefaultBaseURL)
+	}
+}
+
+func TestClient_ClassifyAudio_HappyPath(t *testing.T) {
+	// Use an httptest server pointed at the default (non-dedicated)
+	// path shape so the /models/{owner}/{name} prefix is exercised.
+	var gotPath, gotAuth, gotContentType string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		fmt.Fprintln(w, `[{"label":"angry","score":0.82},{"label":"neutral","score":0.18}]`)
+	}))
+	defer srv.Close()
+	c, err := NewClient(Config{
+		APIKey:     "test-token",
+		BaseURL:    srv.URL,
+		HTTPClient: srv.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := c.ClassifyAudio(context.Background(), []byte("RIFF...WAV"), classify.AudioOptions{
+		Model:    "superb/wav2vec2-base-superb-er",
+		MIMEType: "audio/wav",
+	})
+	if err != nil {
+		t.Fatalf("ClassifyAudio: %v", err)
+	}
+	if len(got) != 2 || got[0].Label != "angry" || got[0].Score < 0.8 {
+		t.Errorf("got %v, want angry@0.82 first", got)
+	}
+
+	// Request shape pins: auth header, content-type, model in URL path,
+	// raw audio body — anything missing would silently 4xx on HF
+	// without these assertions.
+	if !strings.HasPrefix(gotPath, "/models/superb/") {
+		t.Errorf("URL path = %q, want /models/superb/...", gotPath)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want Bearer test-token", gotAuth)
+	}
+	if gotContentType != "audio/wav" {
+		t.Errorf("Content-Type = %q, want audio/wav", gotContentType)
+	}
+	if string(gotBody) != "RIFF...WAV" {
+		t.Errorf("body = %q, want raw audio bytes", string(gotBody))
+	}
+}
+
+func TestClient_ClassifyAudio_EmptyAudioRejected(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { t.Fatal("server should not be called") })
+	_, err := c.ClassifyAudio(context.Background(), nil, classify.AudioOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("empty audio must be rejected without making a request")
+	}
+}
+
+func TestClient_ClassifyAudio_RequiresModel(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { t.Fatal("server should not be called") })
+	_, err := c.ClassifyAudio(context.Background(), []byte("data"), classify.AudioOptions{})
+	if err == nil {
+		t.Fatal("missing model must be rejected without making a request")
+	}
+}
+
+func TestClient_ClassifyText_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("text content-type = %q, want application/json", r.Header.Get("Content-Type"))
+		}
+		// HF nested shape — one inner array per input.
+		fmt.Fprintln(w, `[[{"label":"toxic","score":0.91},{"label":"clean","score":0.09}]]`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	got, err := c.ClassifyText(context.Background(), "you suck", classify.TextOptions{
+		Model:      "unitary/toxic-bert",
+		MultiLabel: true,
+	})
+	if err != nil {
+		t.Fatalf("ClassifyText: %v", err)
+	}
+	if len(got) != 2 || got[0].Label != "toxic" {
+		t.Errorf("got %v, want toxic first", got)
+	}
+}
+
+func TestClient_ClassifyText_FlatShape(t *testing.T) {
+	// Some HF text models return flat `[{...}]` when multi-label is off.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `[{"label":"positive","score":0.99}]`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	got, err := c.ClassifyText(context.Background(), "great product", classify.TextOptions{Model: "m"})
+	if err != nil {
+		t.Fatalf("ClassifyText flat shape: %v", err)
+	}
+	if len(got) != 1 || got[0].Label != "positive" {
+		t.Errorf("got %v, want positive", got)
+	}
+}
+
+func TestClient_ClassifyImage_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "image/png" {
+			t.Errorf("image content-type = %q, want image/png", r.Header.Get("Content-Type"))
+		}
+		fmt.Fprintln(w, `[{"label":"nsfw","score":0.05},{"label":"normal","score":0.95}]`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	got, err := c.ClassifyImage(context.Background(), []byte("\x89PNG..."), classify.ImageOptions{
+		Model:    "Falconsai/nsfw_image_detection",
+		MIMEType: "image/png",
+	})
+	if err != nil {
+		t.Fatalf("ClassifyImage: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("got %d labels, want 2", len(got))
+	}
+}
+
+func TestClient_Embed_BatchShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	got, err := c.Embed(context.Background(), []string{"hello", "world"}, classify.EmbedOptions{Model: "m"})
+	if err != nil {
+		t.Fatalf("Embed batch: %v", err)
+	}
+	if len(got) != 2 || len(got[0]) != 3 {
+		t.Errorf("got %v, want 2x3 vectors", got)
+	}
+}
+
+func TestClient_Embed_SingleShape(t *testing.T) {
+	// Single input — HF can return a flat array.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `[0.1, 0.2, 0.3]`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	got, err := c.Embed(context.Background(), []string{"hello"}, classify.EmbedOptions{Model: "m"})
+	if err != nil {
+		t.Fatalf("Embed single: %v", err)
+	}
+	if len(got) != 1 || len(got[0]) != 3 {
+		t.Errorf("got %v, want 1x3 vector", got)
+	}
+}
+
+func TestClient_ModelLoadingRetry(t *testing.T) {
+	// 503 twice with short estimated_time, then 200 — the client
+	// should retry without surfacing ErrModelLoading.
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, `{"estimated_time": 0.01, "error": "Model is loading"}`)
+			return
+		}
+		fmt.Fprintln(w, `[{"label":"angry","score":0.8}]`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	got, err := c.ClassifyAudio(context.Background(), []byte("x"), classify.AudioOptions{Model: "m"})
+	if err != nil {
+		t.Fatalf("after retries, ClassifyAudio: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("server got %d calls, want 3 (2 loading + 1 success)", calls)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %v, want one label after retry", got)
+	}
+}
+
+func TestClient_ModelLoadingExhausted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintln(w, `{"estimated_time": 0.01, "error": "Model is loading"}`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	_, err := c.ClassifyAudio(context.Background(), []byte("x"), classify.AudioOptions{Model: "m"})
+	if !errors.Is(err, ErrModelLoading) {
+		t.Errorf("after exhausting retries, err = %v, want ErrModelLoading", err)
+	}
+}
+
+func TestClient_NonRetryableHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintln(w, `{"error":"invalid token"}`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	_, err := c.ClassifyAudio(context.Background(), []byte("x"), classify.AudioOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("401 must surface as error")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error must include status code; got %v", err)
+	}
+}
+
+func TestClient_ContextCancellationDuringRetry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintln(w, `{"estimated_time": 60}`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := c.ClassifyAudio(ctx, []byte("x"), classify.AudioOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("context cancellation during retry wait must surface")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want DeadlineExceeded", err)
+	}
+}
+
+func TestParseEstimatedWait_Caps(t *testing.T) {
+	// 60s estimate should clamp to 15s.
+	body := []byte(`{"estimated_time": 60}`)
+	wait := parseEstimatedWait(body, time.Second)
+	if wait > 15*time.Second {
+		t.Errorf("wait = %v, want <= 15s", wait)
+	}
+}
+
+func TestParseEstimatedWait_Fallback(t *testing.T) {
+	// Unparseable body returns the fallback.
+	wait := parseEstimatedWait([]byte("not json"), 7*time.Second)
+	if wait != 7*time.Second {
+		t.Errorf("wait = %v, want fallback 7s", wait)
+	}
+}
+
+func TestModelURL_DedicatedEndpoint(t *testing.T) {
+	// HF Inference Endpoints bake the model into the host; callers
+	// pass Dedicated: true so the /models/{id} suffix is skipped.
+	c, _ := NewClient(Config{
+		APIKey:    "k",
+		BaseURL:   "https://my-endpoint.endpoints.huggingface.cloud",
+		Dedicated: true,
+	})
+	url, err := c.modelURL("ignored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(url, "/models/") {
+		t.Errorf("dedicated endpoint URL should not include /models/; got %q", url)
+	}
+}
+
+func TestModelURL_DefaultPrefixesModels(t *testing.T) {
+	// Default (Dedicated:false) shape is /models/{owner}/{name}.
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: "https://example.test"})
+	url, err := c.modelURL("owner/model")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(url, "/models/owner/model") {
+		t.Errorf("default endpoint URL should prefix /models/; got %q", url)
+	}
+}
+
+func TestClient_ClassifyText_EmptyTextRejected(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { t.Fatal("server should not be called") })
+	_, err := c.ClassifyText(context.Background(), "", classify.TextOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("empty text must be rejected without making a request")
+	}
+}
+
+func TestClient_ClassifyText_RequiresModel(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { t.Fatal("server should not be called") })
+	_, err := c.ClassifyText(context.Background(), "hi", classify.TextOptions{})
+	if err == nil {
+		t.Fatal("missing model must be rejected")
+	}
+}
+
+func TestClient_ClassifyText_GarbageResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, `<!doctype html>not json`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+	_, err := c.ClassifyText(context.Background(), "hi", classify.TextOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("non-JSON response must surface as decode error")
+	}
+}
+
+func TestClient_ClassifyImage_EmptyImageRejected(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { t.Fatal("server should not be called") })
+	_, err := c.ClassifyImage(context.Background(), nil, classify.ImageOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("empty image must be rejected without making a request")
+	}
+}
+
+func TestClient_ClassifyImage_RequiresModel(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { t.Fatal("server should not be called") })
+	_, err := c.ClassifyImage(context.Background(), []byte("\x89PNG"), classify.ImageOptions{})
+	if err == nil {
+		t.Fatal("missing model must be rejected")
+	}
+}
+
+func TestClient_ClassifyImage_DefaultsContentType(t *testing.T) {
+	var gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		fmt.Fprintln(w, `[{"label":"x","score":1}]`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+	_, err := c.ClassifyImage(context.Background(), []byte("\x89PNG"), classify.ImageOptions{Model: "m"})
+	if err != nil {
+		t.Fatalf("ClassifyImage: %v", err)
+	}
+	if gotCT != "application/octet-stream" {
+		t.Errorf("Content-Type default = %q, want application/octet-stream", gotCT)
+	}
+}
+
+func TestClient_Embed_EmptyInputsRejected(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { t.Fatal("server should not be called") })
+	_, err := c.Embed(context.Background(), nil, classify.EmbedOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("empty inputs must be rejected")
+	}
+}
+
+func TestClient_Embed_RequiresModel(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) { t.Fatal("server should not be called") })
+	_, err := c.Embed(context.Background(), []string{"hi"}, classify.EmbedOptions{})
+	if err == nil {
+		t.Fatal("missing model must be rejected")
+	}
+}
+
+func TestClient_Embed_UnexpectedShape(t *testing.T) {
+	// HF token-level shape: [[[float]]] — not supported by MVP; surfaces
+	// as a shape error so callers don't silently get wrong vectors.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `[[[0.1, 0.2], [0.3, 0.4]]]`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+	_, err := c.Embed(context.Background(), []string{"hi"}, classify.EmbedOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("per-token shape must surface as error")
+	}
+	if !strings.Contains(err.Error(), "unexpected embedding response shape") {
+		t.Errorf("error must identify the cause; got %v", err)
+	}
+}

--- a/runtime/classify/backends/hf/embedder.go
+++ b/runtime/classify/backends/hf/embedder.go
@@ -45,12 +45,20 @@ func (c *Client) Embed(
 		return nil, err
 	}
 
-	// Batch shape: [[float, float, ...], [float, ...]]
+	// Batch shape: [[float, float, ...], [float, ...]]. The
+	// length-match check is intentional: a count mismatch between
+	// inputs and returned vectors is treated as malformed (and
+	// falls through to the error path below) rather than as
+	// partial success. Returning fewer-than-requested vectors
+	// without an explicit error would silently mis-align callers
+	// that index into the result by input position.
 	var batched [][]float32
 	if err := json.Unmarshal(body, &batched); err == nil && len(batched) == len(inputs) {
 		return batched, nil
 	}
-	// Single shape: [float, float, ...] — wrap.
+	// Single shape: [float, float, ...] — wrap. Only valid when
+	// the caller submitted exactly one input; otherwise we treat
+	// a flat array as malformed for a batch request.
 	var single []float32
 	if err := json.Unmarshal(body, &single); err == nil && len(inputs) == 1 {
 		return [][]float32{single}, nil

--- a/runtime/classify/backends/hf/embedder.go
+++ b/runtime/classify/backends/hf/embedder.go
@@ -1,0 +1,59 @@
+package hf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+)
+
+// Embed turns text inputs into dense float32 vectors. HF's feature-
+// extraction endpoint returns one vector per input — either as a
+// flat float array for a single input or a nested array for a batch.
+// We always send a list and unmarshal the batch shape so callers see
+// a uniform `[][]float32`.
+//
+// Some HF embedding models (sentence-transformers) return per-token
+// embeddings as `[[[float]]]` (batch × tokens × dims) and require the
+// caller to mean-pool. The MVP only supports models that already
+// return one vector per input; per-token responses surface as a
+// decode error.
+func (c *Client) Embed(
+	ctx context.Context, inputs []string, opts classify.EmbedOptions,
+) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("hf: empty inputs")
+	}
+	if opts.Model == "" {
+		return nil, fmt.Errorf("hf: embedding requires opts.Model")
+	}
+	url, err := c.modelURL(opts.Model)
+	if err != nil {
+		return nil, err
+	}
+
+	type embedRequest struct {
+		Inputs []string `json:"inputs"`
+	}
+	reqBody, err := json.Marshal(embedRequest{Inputs: inputs})
+	if err != nil {
+		return nil, fmt.Errorf("hf: encode embed request: %w", err)
+	}
+	body, err := c.do(ctx, url, "application/json", reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// Batch shape: [[float, float, ...], [float, ...]]
+	var batched [][]float32
+	if err := json.Unmarshal(body, &batched); err == nil && len(batched) == len(inputs) {
+		return batched, nil
+	}
+	// Single shape: [float, float, ...] — wrap.
+	var single []float32
+	if err := json.Unmarshal(body, &single); err == nil && len(inputs) == 1 {
+		return [][]float32{single}, nil
+	}
+	return nil, fmt.Errorf("hf: unexpected embedding response shape (body: %s)", truncateBody(body))
+}

--- a/runtime/classify/backends/hf/image.go
+++ b/runtime/classify/backends/hf/image.go
@@ -1,0 +1,34 @@
+package hf
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+)
+
+// ClassifyImage submits image bytes to the HF image-classification
+// endpoint. Same response shape as audio (flat [{label, score}] array).
+func (c *Client) ClassifyImage(
+	ctx context.Context, img []byte, opts classify.ImageOptions,
+) ([]classify.LabelScore, error) {
+	if len(img) == 0 {
+		return nil, fmt.Errorf("hf: empty image bytes")
+	}
+	if opts.Model == "" {
+		return nil, fmt.Errorf("hf: image classification requires opts.Model")
+	}
+	url, err := c.modelURL(opts.Model)
+	if err != nil {
+		return nil, err
+	}
+	contentType := opts.MIMEType
+	if contentType == "" {
+		contentType = defaultContentType
+	}
+	body, err := c.do(ctx, url, contentType, img)
+	if err != nil {
+		return nil, err
+	}
+	return decodeLabelScores(body)
+}

--- a/runtime/classify/backends/hf/text.go
+++ b/runtime/classify/backends/hf/text.go
@@ -1,0 +1,62 @@
+package hf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+)
+
+// ClassifyText submits text to the HF text-classification endpoint.
+// HF returns nested arrays — `[[{label, score}, ...]]` — one inner
+// array per input. We send one input so the outer array has length 1;
+// flattening returns the inner labels directly.
+func (c *Client) ClassifyText(
+	ctx context.Context, text string, opts classify.TextOptions,
+) ([]classify.LabelScore, error) {
+	if text == "" {
+		return nil, fmt.Errorf("hf: empty text")
+	}
+	if opts.Model == "" {
+		return nil, fmt.Errorf("hf: text classification requires opts.Model")
+	}
+	url, err := c.modelURL(opts.Model)
+	if err != nil {
+		return nil, err
+	}
+
+	type textRequest struct {
+		Inputs     string         `json:"inputs"`
+		Parameters map[string]any `json:"parameters,omitempty"`
+	}
+	req := textRequest{Inputs: text}
+	if opts.MultiLabel {
+		req.Parameters = map[string]any{"return_all_scores": true}
+	}
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("hf: encode text request: %w", err)
+	}
+
+	body, err := c.do(ctx, url, "application/json", reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// HF returns either [[{...}]] (multi-label / batch shape) or
+	// [{...}] (single label, no return_all_scores). Try the nested
+	// shape first; fall back to flat.
+	var nested [][]struct {
+		Label string  `json:"label"`
+		Score float64 `json:"score"`
+	}
+	if err := json.Unmarshal(body, &nested); err == nil && len(nested) > 0 {
+		out := make([]classify.LabelScore, len(nested[0]))
+		for i, r := range nested[0] {
+			out[i] = classify.LabelScore{Label: r.Label, Score: r.Score}
+		}
+		return out, nil
+	}
+	return decodeLabelScores(body)
+}

--- a/runtime/classify/embedder.go
+++ b/runtime/classify/embedder.go
@@ -1,0 +1,19 @@
+package classify
+
+import "context"
+
+// Embedder turns text inputs into dense vectors. Co-located with the
+// classifiers because it shares the same shape (task interface +
+// multiple backends + registry lookup) and because moving embeddings
+// here breaks the historical dependency between
+// runtime/evals/handlers/cosine_similarity.go and concrete provider
+// packages.
+//
+// The current cosine_similarity handler reads pre-computed embeddings
+// from EvalContext.Metadata — it doesn't call an Embedder directly.
+// Migrating to this interface is queued (see phase 2 of the inference
+// abstraction proposal); the interface lives here from day one so the
+// migration doesn't introduce a new package later.
+type Embedder interface {
+	Embed(ctx context.Context, inputs []string, opts EmbedOptions) ([][]float32, error)
+}

--- a/runtime/classify/image.go
+++ b/runtime/classify/image.go
@@ -1,0 +1,11 @@
+package classify
+
+import "context"
+
+// ImageClassifier classifies a single still image. Visual content
+// moderation (NSFW, violence, brand safety), scene tagging, object
+// recognition all go through this. No streaming sibling — a still
+// image is a single inference.
+type ImageClassifier interface {
+	ClassifyImage(ctx context.Context, img []byte, opts ImageOptions) ([]LabelScore, error)
+}

--- a/runtime/classify/registry.go
+++ b/runtime/classify/registry.go
@@ -1,0 +1,247 @@
+package classify
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Registry holds named classifier and embedder instances keyed by an
+// id supplied at config time (e.g. "hf", "hf-azure", "onnx-local").
+// Eval handlers look up by id; the id-to-backend mapping is the only
+// thing the handler config needs to know about.
+//
+// Backends register themselves into a Registry at engine startup;
+// the registry then travels with context.Context to handlers via
+// WithRegistry / FromContext.
+type Registry struct {
+	mu               sync.RWMutex
+	audioClassifiers map[string]AudioClassifier
+	textClassifiers  map[string]TextClassifier
+	imageClassifiers map[string]ImageClassifier
+	videoClassifiers map[string]VideoClassifier
+	embedders        map[string]Embedder
+	defaultAudio     string
+	defaultText      string
+	defaultImage     string
+	defaultVideo     string
+	defaultEmbedder  string
+}
+
+// NewRegistry returns an empty Registry. Backends are added via
+// RegisterAudio / RegisterText / etc.; defaults are set with the
+// SetDefault* methods.
+func NewRegistry() *Registry {
+	return &Registry{
+		audioClassifiers: make(map[string]AudioClassifier),
+		textClassifiers:  make(map[string]TextClassifier),
+		imageClassifiers: make(map[string]ImageClassifier),
+		videoClassifiers: make(map[string]VideoClassifier),
+		embedders:        make(map[string]Embedder),
+	}
+}
+
+// RegisterAudio adds an AudioClassifier under the given id.
+// Calling twice with the same id replaces the previous instance.
+func (r *Registry) RegisterAudio(id string, c AudioClassifier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.audioClassifiers[id] = c
+}
+
+// RegisterText adds a TextClassifier.
+func (r *Registry) RegisterText(id string, c TextClassifier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.textClassifiers[id] = c
+}
+
+// RegisterImage adds an ImageClassifier.
+func (r *Registry) RegisterImage(id string, c ImageClassifier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.imageClassifiers[id] = c
+}
+
+// RegisterVideo adds a VideoClassifier.
+func (r *Registry) RegisterVideo(id string, c VideoClassifier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.videoClassifiers[id] = c
+}
+
+// RegisterEmbedder adds an Embedder.
+func (r *Registry) RegisterEmbedder(id string, e Embedder) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.embedders[id] = e
+}
+
+// SetDefaultAudio names the AudioClassifier used when a handler
+// doesn't pass an explicit id. The id must already be registered.
+func (r *Registry) SetDefaultAudio(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.audioClassifiers[id]; !ok {
+		return fmt.Errorf("classify: default audio classifier %q not registered", id)
+	}
+	r.defaultAudio = id
+	return nil
+}
+
+// SetDefaultText names the default TextClassifier.
+func (r *Registry) SetDefaultText(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.textClassifiers[id]; !ok {
+		return fmt.Errorf("classify: default text classifier %q not registered", id)
+	}
+	r.defaultText = id
+	return nil
+}
+
+// SetDefaultImage names the default ImageClassifier.
+func (r *Registry) SetDefaultImage(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.imageClassifiers[id]; !ok {
+		return fmt.Errorf("classify: default image classifier %q not registered", id)
+	}
+	r.defaultImage = id
+	return nil
+}
+
+// SetDefaultVideo names the default VideoClassifier.
+func (r *Registry) SetDefaultVideo(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.videoClassifiers[id]; !ok {
+		return fmt.Errorf("classify: default video classifier %q not registered", id)
+	}
+	r.defaultVideo = id
+	return nil
+}
+
+// SetDefaultEmbedder names the default Embedder.
+func (r *Registry) SetDefaultEmbedder(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.embedders[id]; !ok {
+		return fmt.Errorf("classify: default embedder %q not registered", id)
+	}
+	r.defaultEmbedder = id
+	return nil
+}
+
+// AudioClassifier resolves by id, falling back to the configured
+// default when id is empty. Returns a non-nil error when nothing
+// matches.
+func (r *Registry) AudioClassifier(id string) (AudioClassifier, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if id == "" {
+		id = r.defaultAudio
+	}
+	if id == "" {
+		return nil, fmt.Errorf("classify: no audio classifier id supplied and no default configured")
+	}
+	c, ok := r.audioClassifiers[id]
+	if !ok {
+		return nil, fmt.Errorf("classify: audio classifier %q not registered", id)
+	}
+	return c, nil
+}
+
+// TextClassifier resolves by id with default fallback.
+func (r *Registry) TextClassifier(id string) (TextClassifier, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if id == "" {
+		id = r.defaultText
+	}
+	if id == "" {
+		return nil, fmt.Errorf("classify: no text classifier id supplied and no default configured")
+	}
+	c, ok := r.textClassifiers[id]
+	if !ok {
+		return nil, fmt.Errorf("classify: text classifier %q not registered", id)
+	}
+	return c, nil
+}
+
+// ImageClassifier resolves by id with default fallback.
+func (r *Registry) ImageClassifier(id string) (ImageClassifier, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if id == "" {
+		id = r.defaultImage
+	}
+	if id == "" {
+		return nil, fmt.Errorf("classify: no image classifier id supplied and no default configured")
+	}
+	c, ok := r.imageClassifiers[id]
+	if !ok {
+		return nil, fmt.Errorf("classify: image classifier %q not registered", id)
+	}
+	return c, nil
+}
+
+// VideoClassifier resolves by id with default fallback.
+func (r *Registry) VideoClassifier(id string) (VideoClassifier, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if id == "" {
+		id = r.defaultVideo
+	}
+	if id == "" {
+		return nil, fmt.Errorf("classify: no video classifier id supplied and no default configured")
+	}
+	c, ok := r.videoClassifiers[id]
+	if !ok {
+		return nil, fmt.Errorf("classify: video classifier %q not registered", id)
+	}
+	return c, nil
+}
+
+// Embedder resolves by id with default fallback.
+func (r *Registry) Embedder(id string) (Embedder, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if id == "" {
+		id = r.defaultEmbedder
+	}
+	if id == "" {
+		return nil, fmt.Errorf("classify: no embedder id supplied and no default configured")
+	}
+	e, ok := r.embedders[id]
+	if !ok {
+		return nil, fmt.Errorf("classify: embedder %q not registered", id)
+	}
+	return e, nil
+}
+
+// registryContextKey is the unexported key used to attach a Registry
+// to a context.Context. The type-as-key idiom avoids collisions with
+// other context values.
+type registryContextKey struct{}
+
+// WithRegistry returns ctx with the Registry attached. Arena's eval
+// orchestrator calls this once per run; handlers retrieve via
+// FromContext.
+func WithRegistry(ctx context.Context, r *Registry) context.Context {
+	return context.WithValue(ctx, registryContextKey{}, r)
+}
+
+// FromContext returns the Registry attached to ctx, or nil if none.
+// Eval handlers that don't find a registry fall back to a "skipped"
+// result rather than failing — classification is an optional feature
+// of the runtime, not a hard dependency.
+func FromContext(ctx context.Context) *Registry {
+	if ctx == nil {
+		return nil
+	}
+	if r, ok := ctx.Value(registryContextKey{}).(*Registry); ok {
+		return r
+	}
+	return nil
+}

--- a/runtime/classify/registry_test.go
+++ b/runtime/classify/registry_test.go
@@ -1,0 +1,178 @@
+package classify
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// stubAudio is an AudioClassifier that records the last call. Used to
+// confirm the registry returns the actual registered instance, not a
+// wrapper or copy.
+type stubAudio struct {
+	id string
+}
+
+func (s *stubAudio) ClassifyAudio(_ context.Context, _ []byte, _ AudioOptions) ([]LabelScore, error) {
+	return []LabelScore{{Label: s.id, Score: 1.0}}, nil
+}
+
+type stubText struct{ id string }
+
+func (s *stubText) ClassifyText(_ context.Context, _ string, _ TextOptions) ([]LabelScore, error) {
+	return []LabelScore{{Label: s.id, Score: 1.0}}, nil
+}
+
+type stubImage struct{ id string }
+
+func (s *stubImage) ClassifyImage(_ context.Context, _ []byte, _ ImageOptions) ([]LabelScore, error) {
+	return []LabelScore{{Label: s.id, Score: 1.0}}, nil
+}
+
+type stubVideo struct{ id string }
+
+func (s *stubVideo) ClassifyVideo(_ context.Context, _ []byte, _ VideoOptions) ([]LabelScore, error) {
+	return []LabelScore{{Label: s.id, Score: 1.0}}, nil
+}
+
+type stubEmbedder struct{ id string }
+
+func (s *stubEmbedder) Embed(_ context.Context, inputs []string, _ EmbedOptions) ([][]float32, error) {
+	out := make([][]float32, len(inputs))
+	for i := range out {
+		out[i] = []float32{1.0}
+	}
+	return out, nil
+}
+
+func TestRegistry_EmptyByDefault(t *testing.T) {
+	r := NewRegistry()
+	if _, err := r.AudioClassifier(""); err == nil {
+		t.Error("AudioClassifier on empty registry must return error")
+	}
+	if _, err := r.AudioClassifier("hf"); err == nil {
+		t.Error("AudioClassifier lookup of unregistered id must return error")
+	}
+}
+
+func TestRegistry_AudioRoundtrip(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterAudio("hf", &stubAudio{id: "hf"})
+
+	got, err := r.AudioClassifier("hf")
+	if err != nil {
+		t.Fatalf("AudioClassifier: %v", err)
+	}
+	scores, err := got.ClassifyAudio(context.Background(), nil, AudioOptions{})
+	if err != nil {
+		t.Fatalf("ClassifyAudio: %v", err)
+	}
+	if len(scores) != 1 || scores[0].Label != "hf" {
+		t.Errorf("registry returned wrong instance; got %v", scores)
+	}
+}
+
+func TestRegistry_DefaultFallback(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterAudio("hf", &stubAudio{id: "hf"})
+	r.RegisterAudio("onnx", &stubAudio{id: "onnx"})
+	if err := r.SetDefaultAudio("hf"); err != nil {
+		t.Fatalf("SetDefaultAudio: %v", err)
+	}
+
+	// Empty id resolves to default.
+	got, err := r.AudioClassifier("")
+	if err != nil {
+		t.Fatalf("default lookup failed: %v", err)
+	}
+	scores, _ := got.ClassifyAudio(context.Background(), nil, AudioOptions{})
+	if scores[0].Label != "hf" {
+		t.Errorf("default audio = %q, want hf", scores[0].Label)
+	}
+
+	// Explicit id wins over default.
+	got, err = r.AudioClassifier("onnx")
+	if err != nil {
+		t.Fatalf("explicit lookup failed: %v", err)
+	}
+	scores, _ = got.ClassifyAudio(context.Background(), nil, AudioOptions{})
+	if scores[0].Label != "onnx" {
+		t.Errorf("explicit id ignored; got %q, want onnx", scores[0].Label)
+	}
+}
+
+func TestRegistry_SetDefaultRejectsUnregistered(t *testing.T) {
+	r := NewRegistry()
+	if err := r.SetDefaultAudio("nope"); err == nil {
+		t.Error("SetDefaultAudio for unregistered id must error")
+	}
+	if err := r.SetDefaultText("nope"); err == nil {
+		t.Error("SetDefaultText for unregistered id must error")
+	}
+	if err := r.SetDefaultImage("nope"); err == nil {
+		t.Error("SetDefaultImage for unregistered id must error")
+	}
+	if err := r.SetDefaultVideo("nope"); err == nil {
+		t.Error("SetDefaultVideo for unregistered id must error")
+	}
+	if err := r.SetDefaultEmbedder("nope"); err == nil {
+		t.Error("SetDefaultEmbedder for unregistered id must error")
+	}
+}
+
+func TestRegistry_AllTaskRoundtrips(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterText("t", &stubText{id: "t"})
+	r.RegisterImage("i", &stubImage{id: "i"})
+	r.RegisterVideo("v", &stubVideo{id: "v"})
+	r.RegisterEmbedder("e", &stubEmbedder{id: "e"})
+
+	if c, err := r.TextClassifier("t"); err != nil || c == nil {
+		t.Errorf("text lookup: %v", err)
+	}
+	if c, err := r.ImageClassifier("i"); err != nil || c == nil {
+		t.Errorf("image lookup: %v", err)
+	}
+	if c, err := r.VideoClassifier("v"); err != nil || c == nil {
+		t.Errorf("video lookup: %v", err)
+	}
+	if e, err := r.Embedder("e"); err != nil || e == nil {
+		t.Errorf("embedder lookup: %v", err)
+	}
+}
+
+func TestRegistry_ContextAttach(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterAudio("hf", &stubAudio{id: "hf"})
+
+	ctx := WithRegistry(context.Background(), r)
+	got := FromContext(ctx)
+	if got != r {
+		t.Errorf("FromContext returned %v, want %v", got, r)
+	}
+
+	// Nil ctx returns nil registry, not panic — defensive for callers
+	// that don't have a ctx in hand (e.g. test setup utilities).
+	//nolint:staticcheck // SA1012: intentional nil context to exercise defensive branch.
+	if got := FromContext(nil); got != nil {
+		t.Errorf("FromContext(nil) = %v, want nil", got)
+	}
+
+	// Context without a registry returns nil, not error.
+	if got := FromContext(context.Background()); got != nil {
+		t.Errorf("FromContext(no registry) = %v, want nil", got)
+	}
+}
+
+func TestRegistry_ErrorMessagesIdentifyMissingID(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.AudioClassifier("missing-hf")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Error must name the looked-up id so misconfiguration is obvious
+	// without checking the call site.
+	if !strings.Contains(err.Error(), "missing-hf") {
+		t.Errorf("error message %q should mention the missing id", err.Error())
+	}
+}

--- a/runtime/classify/registry_test.go
+++ b/runtime/classify/registry_test.go
@@ -120,6 +120,86 @@ func TestRegistry_SetDefaultRejectsUnregistered(t *testing.T) {
 	}
 }
 
+// TestRegistry_SetDefaultHappyPaths_AllTasks pins that the SetDefault
+// methods on every task type successfully accept a registered id, and
+// that the subsequent empty-id lookup returns the registered instance.
+// Catches a symmetry bug where one task accidentally diverges from the
+// others.
+func TestRegistry_SetDefaultHappyPaths_AllTasks(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterText("t", &stubText{id: "t"})
+	r.RegisterImage("i", &stubImage{id: "i"})
+	r.RegisterVideo("v", &stubVideo{id: "v"})
+	r.RegisterEmbedder("e", &stubEmbedder{id: "e"})
+
+	if err := r.SetDefaultText("t"); err != nil {
+		t.Errorf("SetDefaultText: %v", err)
+	}
+	if err := r.SetDefaultImage("i"); err != nil {
+		t.Errorf("SetDefaultImage: %v", err)
+	}
+	if err := r.SetDefaultVideo("v"); err != nil {
+		t.Errorf("SetDefaultVideo: %v", err)
+	}
+	if err := r.SetDefaultEmbedder("e"); err != nil {
+		t.Errorf("SetDefaultEmbedder: %v", err)
+	}
+
+	if got, _ := r.TextClassifier(""); got == nil {
+		t.Error("text default fallback returned nil")
+	}
+	if got, _ := r.ImageClassifier(""); got == nil {
+		t.Error("image default fallback returned nil")
+	}
+	if got, _ := r.VideoClassifier(""); got == nil {
+		t.Error("video default fallback returned nil")
+	}
+	if got, _ := r.Embedder(""); got == nil {
+		t.Error("embedder default fallback returned nil")
+	}
+}
+
+// TestRegistry_EmptyIDWithoutDefault pins the "no id supplied AND no
+// default configured" error path for every task type. The error must
+// be actionable — naming the task — so handlers can surface a useful
+// message rather than "nil pointer".
+func TestRegistry_EmptyIDWithoutDefault(t *testing.T) {
+	r := NewRegistry()
+	for _, tc := range []struct {
+		name string
+		fn   func() error
+	}{
+		{"audio", func() error { _, err := r.AudioClassifier(""); return err }},
+		{"text", func() error { _, err := r.TextClassifier(""); return err }},
+		{"image", func() error { _, err := r.ImageClassifier(""); return err }},
+		{"video", func() error { _, err := r.VideoClassifier(""); return err }},
+		{"embedder", func() error { _, err := r.Embedder(""); return err }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn()
+			if err == nil {
+				t.Fatalf("%s: empty id with no default must error", tc.name)
+			}
+			if !strings.Contains(err.Error(), "no default configured") {
+				t.Errorf("%s: error %q should mention missing default", tc.name, err.Error())
+			}
+		})
+	}
+}
+
+// TestRegistry_WithRegistryNilStored documents the contract that
+// attaching a nil *Registry to a context is intentional: handlers
+// that pull a nil out of FromContext treat it as "classification
+// disabled in this run" rather than panicking. A future change that
+// rejects nil at attach time would need to update this test.
+func TestRegistry_WithRegistryNilStored(t *testing.T) {
+	ctx := WithRegistry(context.Background(), nil)
+	got := FromContext(ctx)
+	if got != nil {
+		t.Errorf("FromContext(ctx with nil registry) = %v, want nil", got)
+	}
+}
+
 func TestRegistry_AllTaskRoundtrips(t *testing.T) {
 	r := NewRegistry()
 	r.RegisterText("t", &stubText{id: "t"})

--- a/runtime/classify/text.go
+++ b/runtime/classify/text.go
@@ -1,0 +1,15 @@
+package classify
+
+import "context"
+
+// TextClassifier classifies a single text string. Toxicity, sentiment,
+// emotion-from-text, intent, language detection — anything that takes
+// text in and returns labeled scores.
+//
+// Text inputs aren't temporally extended, so there's no streaming
+// sibling. Batch text classification (many strings at once) goes
+// through repeated calls — backends that support batching internally
+// can pool requests.
+type TextClassifier interface {
+	ClassifyText(ctx context.Context, text string, opts TextOptions) ([]LabelScore, error)
+}

--- a/runtime/classify/types.go
+++ b/runtime/classify/types.go
@@ -30,8 +30,14 @@ type AudioOptions struct {
 	// by backends that route by language.
 	Language string
 
-	// SampleRate is the source audio sample rate in Hz. Some
-	// backends require resampling and use this to drive it.
+	// SampleRate is the source audio sample rate in Hz. Backends
+	// that can resample internally use this to drive it. The
+	// shipped HuggingFace backend does NOT resample — handlers
+	// are expected to deliver audio at the rate the target model
+	// wants (typically 16 kHz mono for SER models). The field is
+	// kept on the options struct so future backends (ONNX, Hume,
+	// etc.) that do resample have a place to read the source rate
+	// from without growing a per-backend option type.
 	SampleRate int
 
 	// MIMEType is the audio container / codec hint (e.g. "audio/wav",

--- a/runtime/classify/types.go
+++ b/runtime/classify/types.go
@@ -1,0 +1,101 @@
+// Package classify defines task-oriented inference interfaces for
+// non-LLM workloads — audio / text / image / video classifiers and
+// embedders. Backends (HuggingFace Inference API, ONNX, Replicate, …)
+// implement one or more of these; eval handlers depend on the task
+// interface, never on the backend.
+//
+// Parallel to runtime/tts and runtime/stt: each is a task interface
+// with multiple backends behind it. runtime/providers handles chat
+// completion (Predict); classify covers the rest.
+package classify
+
+// LabelScore pairs a classifier label with a confidence score in
+// [0, 1]. Backends return slices of these sorted by descending score
+// where the model supports ranking; the caller treats the order as
+// hint only and looks up by Label when checking expected values.
+type LabelScore struct {
+	Label string
+	Score float64
+}
+
+// AudioOptions carries per-call knobs for audio classification.
+// Backends ignore fields they don't support; consumers set what
+// matters for their target model.
+type AudioOptions struct {
+	// Model is the backend-specific model identifier (e.g.
+	// "superb/wav2vec2-base-superb-er" on HuggingFace).
+	Model string
+
+	// Language is an optional ISO-639-1 hint (e.g. "en"). Only used
+	// by backends that route by language.
+	Language string
+
+	// SampleRate is the source audio sample rate in Hz. Some
+	// backends require resampling and use this to drive it.
+	SampleRate int
+
+	// MIMEType is the audio container / codec hint (e.g. "audio/wav",
+	// "audio/L16"). Backends that need explicit format selection use
+	// this; others ignore.
+	MIMEType string
+}
+
+// TextOptions carries per-call knobs for text classification.
+type TextOptions struct {
+	// Model is the backend-specific model identifier (e.g.
+	// "unitary/toxic-bert" on HuggingFace).
+	Model string
+
+	// Language is an optional ISO-639-1 hint.
+	Language string
+
+	// MultiLabel asks the backend to return scores for every label
+	// rather than a single best one. Useful for toxicity panels
+	// (toxic, severe_toxic, obscene, …) where multiple may apply.
+	MultiLabel bool
+}
+
+// ImageOptions carries per-call knobs for image classification.
+type ImageOptions struct {
+	// Model is the backend-specific model identifier (e.g.
+	// "Falconsai/nsfw_image_detection" on HuggingFace).
+	Model string
+
+	// MIMEType is the image format hint (e.g. "image/png", "image/jpeg").
+	MIMEType string
+}
+
+// VideoOptions carries per-call knobs for video classification.
+type VideoOptions struct {
+	// Model is the backend-specific model identifier.
+	Model string
+
+	// MIMEType is the video container hint (e.g. "video/mp4").
+	MIMEType string
+
+	// FrameSampleRate is the per-second frame extraction rate used
+	// by decomposing backends (audio + sampled image classifier).
+	// Whole-clip backends ignore this. 0 = backend default.
+	FrameSampleRate float64
+
+	// ExtractAudio toggles whether decomposing backends route the
+	// audio track through their AudioClassifier as well as their
+	// ImageClassifier. Default false.
+	ExtractAudio bool
+}
+
+// EmbedOptions carries per-call knobs for text embedding.
+type EmbedOptions struct {
+	// Model is the backend-specific model identifier (e.g.
+	// "voyage-3", "text-embedding-3-large").
+	Model string
+
+	// Dimensions optionally requests truncation to a specific
+	// dimensionality. Backend ignores if not supported.
+	Dimensions int
+
+	// InputType disambiguates query vs document embedding for
+	// asymmetric models (e.g. Voyage's `query` / `document`).
+	// Empty = backend default.
+	InputType string
+}

--- a/runtime/classify/video.go
+++ b/runtime/classify/video.go
@@ -1,0 +1,35 @@
+package classify
+
+import "context"
+
+// VideoClassifier classifies a video clip. Two physical shapes:
+//
+//   - Whole-clip backends (e.g. HuggingFace Video Classification API)
+//     accept the full clip and return labels for it.
+//   - Decomposing backends extract the audio track and frame-sample
+//     stills, route those through AudioClassifier + ImageClassifier,
+//     and aggregate the per-modality scores. The interface is the
+//     same; backends choose the implementation.
+//
+// VideoOptions.FrameSampleRate and .ExtractAudio steer decomposing
+// backends; whole-clip backends ignore them.
+type VideoClassifier interface {
+	ClassifyVideo(ctx context.Context, video []byte, opts VideoOptions) ([]LabelScore, error)
+}
+
+// StreamingVideoClassifier is the optional capability for live
+// video classification (mostly a future concern — agentic-UI replay,
+// security camera streams). No MVP backend implements it; the
+// interface stays in the package so the synchronous one doesn't
+// break when a streaming consumer arrives.
+type StreamingVideoClassifier interface {
+	VideoClassifier
+	ClassifyVideoStream(
+		ctx context.Context,
+		// chunks is a stream of (frame, audio-segment) tuples
+		// emitted by the source pipeline. Specific format TBD —
+		// not implementing this MVP, just reserving the slot.
+		chunks <-chan struct{},
+		opts VideoOptions,
+	) (<-chan LabelScoreEvent, error)
+}

--- a/tools/arena/web/server.go
+++ b/tools/arena/web/server.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
@@ -53,6 +54,12 @@ type Server struct {
 	stateStore *statestore.ArenaStateStore
 	outputDir  string
 	mux        *http.ServeMux
+
+	// pending tracks background goroutines spawned by handleStartRun so
+	// tests can wait for outputDir writes to drain before TempDir
+	// cleanup runs. Without this the persistRunResults fallback racing
+	// with t.TempDir's RemoveAll produces a "directory not empty" error.
+	pending sync.WaitGroup
 }
 
 // NewServer creates a new web server.
@@ -129,6 +136,14 @@ func newServerWithRunner(
 // Handler returns the http.Handler for the server.
 func (s *Server) Handler() http.Handler {
 	return s.mux
+}
+
+// WaitBackgroundRuns blocks until all goroutines spawned by handleStartRun
+// have finished, including the post-ExecuteRuns persistRunResults fallback.
+// Tests that exercise the run path call this before t.TempDir cleanup so the
+// background goroutine doesn't race with RemoveAll.
+func (s *Server) WaitBackgroundRuns() {
+	s.pending.Wait()
 }
 
 // handleSSE streams events to the client via Server-Sent Events.
@@ -218,7 +233,9 @@ func (s *Server) handleStartRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Start runs in background
+	s.pending.Add(1)
 	go func() {
+		defer s.pending.Done()
 		ctx, cancel := context.WithTimeout(context.Background(), defaultRunTimeout)
 		defer cancel()
 		runIDs, _ := s.engine.ExecuteRuns(ctx, plan, defaultConcurrency)

--- a/tools/arena/web/server_test.go
+++ b/tools/arena/web/server_test.go
@@ -400,6 +400,12 @@ func TestStartRun_PersistsEachRunBeforeExecuteRunsReturns(t *testing.T) {
 
 	adapter := NewEventAdapter()
 	srv := newServerWithRunner(adapter, mock, store, tmpDir)
+	// t.TempDir registers its RemoveAll cleanup first; t.Cleanup is LIFO,
+	// so registering WaitBackgroundRuns here runs it BEFORE RemoveAll. The
+	// server's handleStartRun goroutine writes to tmpDir AFTER ExecuteRuns
+	// returns (the persistRunResults fallback), so without this wait the
+	// goroutine races with RemoveAll and trips "directory not empty".
+	t.Cleanup(srv.WaitBackgroundRuns)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 


### PR DESCRIPTION
First slice of issue #1214 (inference provider abstraction). Establishes the task interfaces and ships a working HuggingFace Inference API backend so the design isn't speculative — subsequent PRs build on this foundation.

## What's in

**`runtime/classify/`** — task interfaces for non-LLM inference, each with a streaming sibling where the input shape admits it:

- `AudioClassifier` + `StreamingAudioClassifier` (future Hume/Deepgram)
- `TextClassifier`
- `ImageClassifier`
- `VideoClassifier` + `StreamingVideoClassifier` (reserved, no MVP backend)
- `Embedder`

Same shape as `runtime/tts` and `runtime/stt`: one interface, multiple backends, registry lookup by id. Eval handlers depend on the task interface; backends type-assert for optional capabilities. The `Registry` travels with `context.Context` via `WithRegistry` / `FromContext` so handlers (which are registered as zero-value structs) can resolve a classifier without taking a constructor argument.

**`runtime/classify/backends/hf/`** — HuggingFace Inference API adapter. One `Client` satisfies every task interface; methods that the configured model doesn't support fail at call time, not at construction.

Key behaviors:
- 503 \"Model is loading\" retried up to 3× honoring HF's `estimated_time` (capped at 15s). On exhaustion returns `ErrModelLoading` so eval handlers can produce a skipped result rather than a failure — the model isn't broken, it just hasn't initialized.
- URL routing: default `/models/{owner}/{name}` for the public Inference API; dedicated endpoints bake the model into the host. Explicit `Config.Dedicated` flag (not hostname sniffing) so httptest setups work cleanly.
- Text classifier handles both HF response shapes — flat \`[{label, score}]\` and nested \`[[...]]\` (`return_all_scores`).
- Embedder handles batch and single-input response shapes; per-token shape surfaces as a decode error so callers don't silently get the wrong vectors.

## Test plan

- [x] `runtime/classify`: 7 tests (registry roundtrip, default fallback, context attach, error messages name the missing id)
- [x] `runtime/classify/backends/hf`: 27 tests via httptest — happy paths for audio/text/image/embed, 503 retry success + exhaustion, context cancellation during retry, non-retryable HTTP errors, URL routing for default vs dedicated, response-shape variants, input validation
- [x] Coverage: classify 80.4%, hf 89.5% (all files above 80% threshold)
- [x] Full project suite: 13997 pass across 145 packages

## Not in this PR (queued)

- Arena `inference:` config block + loader wiring
- Engine threading `classify.Registry` to eval orchestrator context
- `audio_emotion` eval handler
- voice-refund-demo gains an SER assertion
- Embedder migration of OpenAI/VoyageAI behind `classify.Embedder`

Refs: #1214