### PR TITLE
feat(arena): inference: config block + classify.Registry wiring

### DIFF
--- a/pkg/config/inference_test.go
+++ b/pkg/config/inference_test.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// freshConfig returns a Config with LoadedInference initialized, matching
+// the state LoadConfig hands to loadInference. The other Loaded* maps are
+// not needed by loadInference.
+func freshConfig() *Config {
+	return &Config{
+		LoadedInference: make(map[string]*InferenceConfig),
+	}
+}
+
+func TestLoadInference_EmptyList(t *testing.T) {
+	c := freshConfig()
+	if err := c.loadInference(); err != nil {
+		t.Fatalf("loadInference: %v", err)
+	}
+	if len(c.LoadedInference) != 0 {
+		t.Errorf("LoadedInference = %d entries, want 0", len(c.LoadedInference))
+	}
+}
+
+func TestLoadInference_SingleEntryPopulatesMap(t *testing.T) {
+	c := freshConfig()
+	c.Inference = []InferenceConfig{
+		{ID: "hf", Type: "huggingface", APIKeyEnv: "HF_TOKEN"},
+	}
+	if err := c.loadInference(); err != nil {
+		t.Fatalf("loadInference: %v", err)
+	}
+	got, ok := c.LoadedInference["hf"]
+	if !ok {
+		t.Fatal("LoadedInference[hf] missing")
+	}
+	if got.Type != "huggingface" {
+		t.Errorf("Type = %q, want huggingface", got.Type)
+	}
+	if got.APIKeyEnv != "HF_TOKEN" {
+		t.Errorf("APIKeyEnv = %q, want HF_TOKEN", got.APIKeyEnv)
+	}
+}
+
+func TestLoadInference_MultipleEntries(t *testing.T) {
+	c := freshConfig()
+	c.Inference = []InferenceConfig{
+		{ID: "hf", Type: "huggingface"},
+		{ID: "hf-dedicated", Type: "huggingface", BaseURL: "https://my-endpoint.huggingface.cloud", Dedicated: true},
+	}
+	if err := c.loadInference(); err != nil {
+		t.Fatalf("loadInference: %v", err)
+	}
+	if len(c.LoadedInference) != 2 {
+		t.Fatalf("LoadedInference = %d entries, want 2", len(c.LoadedInference))
+	}
+	if !c.LoadedInference["hf-dedicated"].Dedicated {
+		t.Error("Dedicated flag not preserved on the dedicated entry")
+	}
+}
+
+func TestLoadInference_MissingIDRejected(t *testing.T) {
+	c := freshConfig()
+	c.Inference = []InferenceConfig{{Type: "huggingface"}}
+	err := c.loadInference()
+	if err == nil {
+		t.Fatal("expected error for empty id")
+	}
+	if !strings.Contains(err.Error(), "id is required") {
+		t.Errorf("error %q should mention missing id", err.Error())
+	}
+}
+
+func TestLoadInference_MissingTypeRejected(t *testing.T) {
+	c := freshConfig()
+	c.Inference = []InferenceConfig{{ID: "hf"}}
+	err := c.loadInference()
+	if err == nil {
+		t.Fatal("expected error for empty type")
+	}
+	if !strings.Contains(err.Error(), "type is required") {
+		t.Errorf("error %q should mention missing type", err.Error())
+	}
+}
+
+func TestLoadInference_DuplicateIDRejected(t *testing.T) {
+	c := freshConfig()
+	c.Inference = []InferenceConfig{
+		{ID: "hf", Type: "huggingface"},
+		{ID: "hf", Type: "huggingface"},
+	}
+	err := c.loadInference()
+	if err == nil {
+		t.Fatal("expected error for duplicate id")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error %q should mention duplicate", err.Error())
+	}
+}
+
+func TestLoadInference_DefaultsAcceptKnownIDs(t *testing.T) {
+	c := freshConfig()
+	c.Inference = []InferenceConfig{{ID: "hf", Type: "huggingface"}}
+	c.Defaults.Inference = &InferenceDefaults{
+		AudioClassifier: "hf",
+		TextClassifier:  "hf",
+		ImageClassifier: "hf",
+		VideoClassifier: "hf",
+		Embedder:        "hf",
+	}
+	if err := c.loadInference(); err != nil {
+		t.Fatalf("loadInference: %v", err)
+	}
+}
+
+func TestLoadInference_DefaultsRejectUnknownID(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(d *InferenceDefaults)
+		errSubs string
+	}{
+		{"audio", func(d *InferenceDefaults) { d.AudioClassifier = "nope" }, "audio_classifier"},
+		{"text", func(d *InferenceDefaults) { d.TextClassifier = "nope" }, "text_classifier"},
+		{"image", func(d *InferenceDefaults) { d.ImageClassifier = "nope" }, "image_classifier"},
+		{"video", func(d *InferenceDefaults) { d.VideoClassifier = "nope" }, "video_classifier"},
+		{"embedder", func(d *InferenceDefaults) { d.Embedder = "nope" }, "embedder"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := freshConfig()
+			c.Inference = []InferenceConfig{{ID: "hf", Type: "huggingface"}}
+			d := &InferenceDefaults{}
+			tc.mutate(d)
+			c.Defaults.Inference = d
+			err := c.loadInference()
+			if err == nil {
+				t.Fatalf("expected error for unknown %s id", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.errSubs) {
+				t.Errorf("error %q should mention %q", err.Error(), tc.errSubs)
+			}
+			if !strings.Contains(err.Error(), "nope") {
+				t.Errorf("error %q should name the offending id", err.Error())
+			}
+		})
+	}
+}
+
+func TestLoadInference_EmptyDefaultsAreAccepted(t *testing.T) {
+	c := freshConfig()
+	c.Inference = []InferenceConfig{{ID: "hf", Type: "huggingface"}}
+	c.Defaults.Inference = &InferenceDefaults{} // all fields empty
+	if err := c.loadInference(); err != nil {
+		t.Fatalf("loadInference rejected zero-value defaults: %v", err)
+	}
+}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -208,6 +208,7 @@ func LoadConfig(filename string) (*Config, error) {
 	cfg.LoadedSTTProviders = make(map[string]*Provider, len(cfg.STTProviders))
 	cfg.LoadedEmbeddingProviders = make(map[string]*Provider, len(cfg.EmbeddingProviders))
 	cfg.LoadedImageProviders = make(map[string]*Provider, len(cfg.ImageProviders))
+	cfg.LoadedInference = make(map[string]*InferenceConfig, len(cfg.Inference))
 	cfg.ProviderGroups = make(map[string]string)
 	cfg.ProviderCapabilities = make(map[string][]string)
 
@@ -228,6 +229,9 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, err
 	}
 	if err := cfg.loadImageProviders(filename); err != nil {
+		return nil, err
+	}
+	if err := cfg.loadInference(); err != nil {
 		return nil, err
 	}
 	if err := cfg.validateVoiceBindings(); err != nil {
@@ -592,6 +596,58 @@ func (c *Config) loadEmbeddingProviders(configPath string) error {
 				ref.File, RoleEmbedding, provider.GetRole())
 		}
 		c.LoadedEmbeddingProviders[provider.ID] = provider
+	}
+	return nil
+}
+
+// loadInference validates the inline inference list and populates
+// LoadedInference. Unlike providers/scenarios/evals, inference entries are
+// always inline (no file-ref shape) — they're small enough that splitting
+// them into separate YAML files would be ceremony without benefit. Default
+// references in cfg.Defaults.Inference are validated here too so unknown
+// ids fail at load time, not at first use.
+func (c *Config) loadInference() error {
+	for i := range c.Inference {
+		entry := &c.Inference[i]
+		if err := c.registerInferenceEntry(i, entry); err != nil {
+			return err
+		}
+	}
+	return c.validateInferenceDefaults()
+}
+
+func (c *Config) registerInferenceEntry(index int, entry *InferenceConfig) error {
+	if entry.ID == "" {
+		return fmt.Errorf("inference[%d]: id is required", index)
+	}
+	if entry.Type == "" {
+		return fmt.Errorf("inference[%s]: type is required", entry.ID)
+	}
+	if _, exists := c.LoadedInference[entry.ID]; exists {
+		return fmt.Errorf("inference[%s]: duplicate id", entry.ID)
+	}
+	c.LoadedInference[entry.ID] = entry
+	return nil
+}
+
+func (c *Config) validateInferenceDefaults() error {
+	if c.Defaults.Inference == nil {
+		return nil
+	}
+	defaults := c.Defaults.Inference
+	for label, id := range map[string]string{
+		"audio_classifier": defaults.AudioClassifier,
+		"text_classifier":  defaults.TextClassifier,
+		"image_classifier": defaults.ImageClassifier,
+		"video_classifier": defaults.VideoClassifier,
+		"embedder":         defaults.Embedder,
+	} {
+		if id == "" {
+			continue
+		}
+		if _, ok := c.LoadedInference[id]; !ok {
+			return fmt.Errorf("defaults.inference.%s: unknown inference id %q", label, id)
+		}
 	}
 	return nil
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -115,6 +115,11 @@ type Config struct {
 	SelfPlay   *SelfPlayConfig   `yaml:"self_play,omitempty" json:"self_play,omitempty"`
 	PackFile   string            `yaml:"pack_file,omitempty" json:"pack_file,omitempty"`
 
+	// Inference declares non-LLM inference clients used by assertion/eval
+	// handlers (audio_emotion, text_toxicity, ...). Backends implement the
+	// runtime/classify task interfaces. See InferenceConfig for the shape.
+	Inference []InferenceConfig `yaml:"inference,omitempty" json:"inference,omitempty"`
+
 	// Inline resource specs (alternative to file refs, merged into LoadedX during load)
 	ProviderSpecs map[string]*Provider    `yaml:"provider_specs,omitempty" json:"provider_specs,omitempty"`
 	ScenarioSpecs map[string]*Scenario    `yaml:"scenario_specs,omitempty" json:"scenario_specs,omitempty"`
@@ -153,6 +158,7 @@ type Config struct {
 	LoadedSTTProviders       map[string]*Provider         `yaml:"-" json:"loaded_stt_providers,omitempty"`
 	LoadedEmbeddingProviders map[string]*Provider         `yaml:"-" json:"loaded_embedding_providers,omitempty"`
 	LoadedImageProviders     map[string]*Provider         `yaml:"-" json:"loaded_image_providers,omitempty"`
+	LoadedInference          map[string]*InferenceConfig  `yaml:"-" json:"loaded_inference,omitempty"`
 	LoadedJudges             map[string]*JudgeTarget      `yaml:"-" json:"loaded_judges,omitempty"`
 	LoadedScenarios          map[string]*Scenario         `yaml:"-" json:"loaded_scenarios,omitempty"`
 	LoadedEvals              map[string]*Eval             `yaml:"-" json:"loaded_evals,omitempty"`
@@ -467,11 +473,50 @@ type Defaults struct {
 	// Monitor groups runtime-monitor configuration (audio, future surfaces).
 	Monitor *MonitorSection `yaml:"monitor,omitempty" json:"monitor,omitempty"`
 
+	// Inference selects which configured inference client (under
+	// spec.inference) serves each task when an assertion or handler doesn't
+	// pin one explicitly. IDs reference entries in cfg.Inference.
+	Inference *InferenceDefaults `yaml:"inference,omitempty" json:"inference,omitempty"`
+
 	// Deprecated fields for backward compatibility (will be removed)
 	HTMLReport     string          `yaml:"html_report,omitempty" json:"html_report,omitempty"`
 	OutDir         string          `yaml:"out_dir,omitempty" json:"out_dir,omitempty"`
 	OutputFormats  []string        `yaml:"output_formats,omitempty" json:"output_formats,omitempty"`
 	MarkdownConfig *MarkdownConfig `yaml:"markdown_config,omitempty" json:"markdown_config,omitempty"`
+}
+
+// InferenceConfig declares a non-LLM inference client (audio/text/image
+// classifier or embedder) backing the runtime/classify task interfaces.
+// Eval handlers depend on the task interface; the backend is chosen by id.
+// Today the only supported Type is "huggingface".
+type InferenceConfig struct {
+	ID   string `yaml:"id" json:"id"`
+	Type string `yaml:"type" json:"type"`
+
+	// APIKey is the literal token. Prefer APIKeyEnv so secrets stay out of
+	// committed YAML; APIKey wins when both are set.
+	APIKey    string `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	APIKeyEnv string `yaml:"api_key_env,omitempty" json:"api_key_env,omitempty"`
+
+	// BaseURL overrides the backend's default endpoint. Used for HF
+	// Inference Endpoints (dedicated paid hosts) and the newer Inference
+	// Providers routing layer.
+	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty"`
+
+	// Dedicated, when true, treats BaseURL as a fully-specified inference
+	// endpoint and skips the /models/{id} suffix that the public HF
+	// Inference API requires. Set for HF Inference Endpoints.
+	Dedicated bool `yaml:"dedicated,omitempty" json:"dedicated,omitempty"`
+}
+
+// InferenceDefaults pins which inference client id serves each
+// classify task by default. Handlers may override per-call.
+type InferenceDefaults struct {
+	AudioClassifier string `yaml:"audio_classifier,omitempty" json:"audio_classifier,omitempty"`
+	TextClassifier  string `yaml:"text_classifier,omitempty" json:"text_classifier,omitempty"`
+	ImageClassifier string `yaml:"image_classifier,omitempty" json:"image_classifier,omitempty"`
+	VideoClassifier string `yaml:"video_classifier,omitempty" json:"video_classifier,omitempty"`
+	Embedder        string `yaml:"embedder,omitempty" json:"embedder,omitempty"`
 }
 
 // MonitorSection groups runtime-monitor configuration. Today only audio is

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -430,6 +430,12 @@
         "pack_file": {
           "type": "string"
         },
+        "inference": {
+          "items": {
+            "$ref": "#/$defs/InferenceConfig"
+          },
+          "type": "array"
+        },
         "provider_specs": {
           "additionalProperties": {
             "$ref": "#/$defs/Provider"
@@ -609,6 +615,9 @@
         },
         "monitor": {
           "$ref": "#/$defs/MonitorSection"
+        },
+        "inference": {
+          "$ref": "#/$defs/InferenceDefaults"
         },
         "html_report": {
           "type": "string"
@@ -1065,6 +1074,55 @@
         },
         "max_images_per_msg": {
           "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "InferenceConfig": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "api_key": {
+          "type": "string"
+        },
+        "api_key_env": {
+          "type": "string"
+        },
+        "base_url": {
+          "type": "string"
+        },
+        "dedicated": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ]
+    },
+    "InferenceDefaults": {
+      "properties": {
+        "audio_classifier": {
+          "type": "string"
+        },
+        "text_classifier": {
+          "type": "string"
+        },
+        "image_classifier": {
+          "type": "string"
+        },
+        "video_classifier": {
+          "type": "string"
+        },
+        "embedder": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -158,6 +158,20 @@ func BuildEngineComponents(cfg *config.Config, providerFilter []string) (
 			metadata["tool_registry"] = toolRegistry
 		}
 		evalOrchestrator.SetMetadata(metadata)
+
+		// Build the classify.Registry from cfg.Inference and inject it into
+		// the orchestrator so eval/assertion handlers can pull a classifier
+		// via classify.FromContext. Construction errors are non-fatal — an
+		// unparseable HF entry would block every run, even ones that don't
+		// touch classify, so we log and continue with an empty registry.
+		// Handlers that need one will surface a clean "no classifier
+		// configured" error rather than panic.
+		classifyReg, classifyErr := buildClassifyRegistry(cfg)
+		if classifyErr != nil {
+			logger.Warn("classify registry build failed; classify-backed handlers unavailable",
+				"error", classifyErr)
+		}
+		evalOrchestrator.SetClassifyRegistry(classifyReg)
 	}
 
 	// Build conversation executor (engine-specific, stays here)

--- a/tools/arena/engine/classify_registry.go
+++ b/tools/arena/engine/classify_registry.go
@@ -1,0 +1,124 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+)
+
+// inferenceTypeHuggingFace is the type string for HuggingFace Inference API
+// entries in arena's `inference:` block. It's the only backend kind that
+// ships in this slice; ONNX and others are queued behind separate issues.
+const inferenceTypeHuggingFace = "huggingface"
+
+// buildClassifyRegistry constructs a classify.Registry populated with the
+// task-interface implementations declared in cfg.Inference. Each loaded
+// entry instantiates one backend Client and registers it against every
+// task interface that backend implements (HF's Client satisfies all five —
+// audio/text/image classifiers + embedder). cfg.Defaults.Inference is then
+// applied to pin which id wins when a handler doesn't specify one.
+//
+// Returns (nil, nil) when no inference entries are configured — handlers
+// that need a classifier will surface their own "no classifier configured"
+// error via classify.FromContext returning nil, which is the desired
+// behavior: arenas that don't use classify-backed assertions shouldn't
+// require an HF_TOKEN.
+//
+// Returns a non-nil error only when a configured entry is malformed
+// (unsupported type, missing api key). The caller logs and continues —
+// one broken entry must not block a run that doesn't reach a
+// classify-dependent handler.
+func buildClassifyRegistry(cfg *config.Config) (*classify.Registry, error) {
+	if cfg == nil || len(cfg.LoadedInference) == 0 {
+		return nil, nil
+	}
+	reg := classify.NewRegistry()
+	for id, entry := range cfg.LoadedInference {
+		if err := registerInferenceEntry(reg, id, entry); err != nil {
+			return reg, err
+		}
+	}
+	if err := applyInferenceDefaults(reg, cfg.Defaults.Inference); err != nil {
+		return reg, err
+	}
+	return reg, nil
+}
+
+func registerInferenceEntry(reg *classify.Registry, id string, entry *config.InferenceConfig) error {
+	switch entry.Type {
+	case inferenceTypeHuggingFace:
+		apiKey, err := resolveInferenceAPIKey(entry)
+		if err != nil {
+			return fmt.Errorf("inference[%s]: %w", id, err)
+		}
+		client, err := classifyhf.NewClient(classifyhf.Config{
+			APIKey:    apiKey,
+			BaseURL:   entry.BaseURL,
+			Dedicated: entry.Dedicated,
+		})
+		if err != nil {
+			return fmt.Errorf("inference[%s]: %w", id, err)
+		}
+		// HF Client implements every task interface (compile-time checked in
+		// runtime/classify/backends/hf/client.go). Register against each so
+		// handlers asking for any task get this backend by id.
+		reg.RegisterAudio(id, client)
+		reg.RegisterText(id, client)
+		reg.RegisterImage(id, client)
+		reg.RegisterEmbedder(id, client)
+		// VideoClassifier deliberately not registered: HF doesn't ship a
+		// general video classification endpoint and the decomposing default
+		// (audio + frame-sampled images) is queued in #1214 Phase 5.
+		return nil
+	default:
+		return fmt.Errorf("inference[%s]: unsupported type %q (supported: %s)", id, entry.Type, inferenceTypeHuggingFace)
+	}
+}
+
+func resolveInferenceAPIKey(entry *config.InferenceConfig) (string, error) {
+	if entry.APIKey != "" {
+		return entry.APIKey, nil
+	}
+	if entry.APIKeyEnv != "" {
+		if v := os.Getenv(entry.APIKeyEnv); v != "" {
+			return v, nil
+		}
+		return "", fmt.Errorf("env var %s is empty or unset", entry.APIKeyEnv)
+	}
+	// HF canonical env var fallback so arenas with a single inference entry
+	// don't need an explicit api_key_env. HF_TOKEN is the documented name;
+	// HUGGING_FACE_HUB_TOKEN is the legacy alias that some CI runners use.
+	for _, name := range []string{"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"} {
+		if v := os.Getenv(name); v != "" {
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("api_key or api_key_env required (HF_TOKEN / HUGGING_FACE_HUB_TOKEN also accepted as fallback)")
+}
+
+func applyInferenceDefaults(reg *classify.Registry, defaults *config.InferenceDefaults) error {
+	if defaults == nil {
+		return nil
+	}
+	for label, pair := range map[string]struct {
+		id  string
+		set func(string) error
+	}{
+		"audio_classifier": {defaults.AudioClassifier, reg.SetDefaultAudio},
+		"text_classifier":  {defaults.TextClassifier, reg.SetDefaultText},
+		"image_classifier": {defaults.ImageClassifier, reg.SetDefaultImage},
+		"video_classifier": {defaults.VideoClassifier, reg.SetDefaultVideo},
+		"embedder":         {defaults.Embedder, reg.SetDefaultEmbedder},
+	} {
+		if pair.id == "" {
+			continue
+		}
+		if err := pair.set(pair.id); err != nil {
+			return fmt.Errorf("defaults.inference.%s: %w", label, err)
+		}
+	}
+	return nil
+}

--- a/tools/arena/engine/classify_registry_test.go
+++ b/tools/arena/engine/classify_registry_test.go
@@ -1,0 +1,176 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+func TestBuildClassifyRegistry_NoInferenceReturnsNil(t *testing.T) {
+	cfg := &config.Config{}
+	reg, err := buildClassifyRegistry(cfg)
+	if err != nil {
+		t.Fatalf("buildClassifyRegistry: %v", err)
+	}
+	if reg != nil {
+		t.Errorf("expected nil registry when no inference entries; got %v", reg)
+	}
+}
+
+func TestBuildClassifyRegistry_NilConfigReturnsNil(t *testing.T) {
+	reg, err := buildClassifyRegistry(nil)
+	if err != nil {
+		t.Fatalf("buildClassifyRegistry(nil): %v", err)
+	}
+	if reg != nil {
+		t.Error("expected nil registry for nil config")
+	}
+}
+
+func TestBuildClassifyRegistry_HFEntryRegistersAllTasks(t *testing.T) {
+	t.Setenv("HF_TOKEN", "test-token")
+	cfg := &config.Config{
+		LoadedInference: map[string]*config.InferenceConfig{
+			"hf": {ID: "hf", Type: "huggingface"},
+		},
+	}
+	reg, err := buildClassifyRegistry(cfg)
+	if err != nil {
+		t.Fatalf("buildClassifyRegistry: %v", err)
+	}
+	if reg == nil {
+		t.Fatal("expected non-nil registry")
+	}
+	// HF Client implements every task interface; the registry should
+	// resolve the id for each. Video deliberately omitted (no HF endpoint).
+	for _, lookup := range []struct {
+		name string
+		fn   func() error
+	}{
+		{"audio", func() error { _, err := reg.AudioClassifier("hf"); return err }},
+		{"text", func() error { _, err := reg.TextClassifier("hf"); return err }},
+		{"image", func() error { _, err := reg.ImageClassifier("hf"); return err }},
+		{"embedder", func() error { _, err := reg.Embedder("hf"); return err }},
+	} {
+		if err := lookup.fn(); err != nil {
+			t.Errorf("%s lookup: %v", lookup.name, err)
+		}
+	}
+	// Video classifier should NOT be registered — HF has no general endpoint.
+	if _, err := reg.VideoClassifier("hf"); err == nil {
+		t.Error("video should not be registered for HF backend")
+	}
+}
+
+func TestBuildClassifyRegistry_LiteralAPIKeyWinsOverEnv(t *testing.T) {
+	t.Setenv("HF_TOKEN", "env-token")
+	cfg := &config.Config{
+		LoadedInference: map[string]*config.InferenceConfig{
+			"hf": {ID: "hf", Type: "huggingface", APIKey: "literal-token"},
+		},
+	}
+	if _, err := buildClassifyRegistry(cfg); err != nil {
+		t.Errorf("literal api key should succeed without HF_TOKEN: %v", err)
+	}
+}
+
+func TestBuildClassifyRegistry_MissingAPIKeyErrors(t *testing.T) {
+	// Clear inherited values so the canonical fallback can't accidentally
+	// supply a token in CI environments where HF_TOKEN is exported.
+	t.Setenv("HF_TOKEN", "")
+	t.Setenv("HUGGING_FACE_HUB_TOKEN", "")
+	cfg := &config.Config{
+		LoadedInference: map[string]*config.InferenceConfig{
+			"hf": {ID: "hf", Type: "huggingface"},
+		},
+	}
+	_, err := buildClassifyRegistry(cfg)
+	if err == nil {
+		t.Fatal("expected error when no api key resolvable")
+	}
+	if !strings.Contains(err.Error(), "api_key") {
+		t.Errorf("error %q should mention api_key", err.Error())
+	}
+}
+
+func TestBuildClassifyRegistry_NamedEnvVarMustBeSet(t *testing.T) {
+	t.Setenv("HF_TOKEN", "fallback-should-not-be-used")
+	t.Setenv("MY_HF_KEY", "") // explicitly empty
+	cfg := &config.Config{
+		LoadedInference: map[string]*config.InferenceConfig{
+			"hf": {ID: "hf", Type: "huggingface", APIKeyEnv: "MY_HF_KEY"},
+		},
+	}
+	_, err := buildClassifyRegistry(cfg)
+	if err == nil {
+		t.Fatal("when api_key_env is set, the named var being empty should error (don't silently fall through to HF_TOKEN)")
+	}
+	if !strings.Contains(err.Error(), "MY_HF_KEY") {
+		t.Errorf("error %q should name the configured env var", err.Error())
+	}
+}
+
+func TestBuildClassifyRegistry_UnsupportedTypeErrors(t *testing.T) {
+	cfg := &config.Config{
+		LoadedInference: map[string]*config.InferenceConfig{
+			"x": {ID: "x", Type: "bogus"},
+		},
+	}
+	_, err := buildClassifyRegistry(cfg)
+	if err == nil {
+		t.Fatal("expected error for unsupported type")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error %q should name the offending type", err.Error())
+	}
+}
+
+func TestBuildClassifyRegistry_DefaultsAppliedToRegistry(t *testing.T) {
+	t.Setenv("HF_TOKEN", "test-token")
+	cfg := &config.Config{
+		LoadedInference: map[string]*config.InferenceConfig{
+			"hf": {ID: "hf", Type: "huggingface"},
+		},
+		Defaults: config.Defaults{
+			Inference: &config.InferenceDefaults{
+				AudioClassifier: "hf",
+				TextClassifier:  "hf",
+				ImageClassifier: "hf",
+				Embedder:        "hf",
+			},
+		},
+	}
+	reg, err := buildClassifyRegistry(cfg)
+	if err != nil {
+		t.Fatalf("buildClassifyRegistry: %v", err)
+	}
+	// Empty-id lookup should now resolve via the configured default.
+	if _, err := reg.AudioClassifier(""); err != nil {
+		t.Errorf("audio default not applied: %v", err)
+	}
+	if _, err := reg.TextClassifier(""); err != nil {
+		t.Errorf("text default not applied: %v", err)
+	}
+}
+
+func TestBuildClassifyRegistry_DefaultsReferencingUnregisteredID(t *testing.T) {
+	t.Setenv("HF_TOKEN", "test-token")
+	cfg := &config.Config{
+		LoadedInference: map[string]*config.InferenceConfig{
+			"hf": {ID: "hf", Type: "huggingface"},
+		},
+		Defaults: config.Defaults{
+			Inference: &config.InferenceDefaults{
+				AudioClassifier: "doesnotexist",
+			},
+		},
+	}
+	_, err := buildClassifyRegistry(cfg)
+	if err == nil {
+		t.Fatal("expected error when default references an unknown id")
+	}
+	if !strings.Contains(err.Error(), "audio_classifier") {
+		t.Errorf("error %q should identify which default failed", err.Error())
+	}
+}

--- a/tools/arena/engine/eval_orchestrator.go
+++ b/tools/arena/engine/eval_orchestrator.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -23,6 +24,13 @@ type EvalOrchestrator struct {
 	metadata             map[string]any           // injected into every EvalContext (e.g. judge_targets)
 	eventBus             events.Bus               // optional event bus for provider call telemetry in evals
 	workflowMetaProvider WorkflowMetadataProvider // optional workflow state provider
+	// classifyRegistry, when non-nil, is attached to the context passed to
+	// every eval/assertion handler invocation via classify.WithRegistry.
+	// Handlers that need a classifier (audio_emotion, text_toxicity, ...)
+	// pull it back out with classify.FromContext. Nil registry is fine —
+	// classify.WithRegistry/FromContext are nil-safe and handlers that
+	// require one surface an explanatory error.
+	classifyRegistry *classify.Registry
 }
 
 // NewEvalOrchestrator creates a hook for executing pack evals during Arena runs.
@@ -84,6 +92,29 @@ func (h *EvalOrchestrator) SetMetadata(metadata map[string]any) {
 	h.metadata = metadata
 }
 
+// SetClassifyRegistry sets the classify.Registry that will be attached to the
+// context passed to every eval/assertion handler. Handlers that need a
+// classifier (audio_emotion, text_toxicity, ...) read it via
+// classify.FromContext. Safe to call with nil — the context attach is a no-op
+// and FromContext returns nil for handlers to surface their own error.
+func (h *EvalOrchestrator) SetClassifyRegistry(r *classify.Registry) {
+	if h == nil {
+		return
+	}
+	h.classifyRegistry = r
+}
+
+// withClassify returns ctx wrapped with the orchestrator's classify.Registry,
+// or the original ctx when no registry is configured. Called from every Run*
+// entry point so a handler's classify.FromContext lookup succeeds without
+// each caller plumbing the registry through manually.
+func (h *EvalOrchestrator) withClassify(ctx context.Context) context.Context {
+	if h == nil || h.classifyRegistry == nil {
+		return ctx
+	}
+	return classify.WithRegistry(ctx, h.classifyRegistry)
+}
+
 // SetEventBus configures the event bus for provider call telemetry in eval handlers.
 // When set, an emitter is injected into each EvalContext's metadata so that
 // LLM judge provider calls emit ProviderCallStarted/Completed/Failed events.
@@ -115,7 +146,7 @@ func (h *EvalOrchestrator) RunTurnEvals(
 	}
 
 	evalCtx := h.buildEvalContext(messages, turnIndex, sessionID)
-	results := h.runner.RunTurnEvals(ctx, h.defs, evalCtx)
+	results := h.runner.RunTurnEvals(h.withClassify(ctx), h.defs, evalCtx)
 	return assertions.ConvertEvalResults(results)
 }
 
@@ -139,7 +170,7 @@ func (h *EvalOrchestrator) RunSessionEvals(
 		turnIndex = 0
 	}
 	evalCtx := h.buildEvalContext(messages, turnIndex, sessionID)
-	return h.runner.RunSessionEvals(ctx, h.defs, evalCtx)
+	return h.runner.RunSessionEvals(h.withClassify(ctx), h.defs, evalCtx)
 }
 
 // RunConversationEvals runs conversation-complete evals after all turns finish.
@@ -158,7 +189,7 @@ func (h *EvalOrchestrator) RunConversationEvals(
 		turnIndex = 0
 	}
 	evalCtx := h.buildEvalContext(messages, turnIndex, sessionID)
-	results := h.runner.RunConversationEvals(ctx, h.defs, evalCtx)
+	results := h.runner.RunConversationEvals(h.withClassify(ctx), h.defs, evalCtx)
 	return assertions.ConvertEvalResults(results)
 }
 
@@ -189,14 +220,15 @@ func (h *EvalOrchestrator) RunAssertionsAsEvals(
 	}
 
 	evalCtx := h.buildEvalContext(messages, turnIndex, sessionID)
+	classifyCtx := h.withClassify(ctx)
 
 	switch trigger { //nolint:exhaustive // Only conversation and turn triggers are meaningful here
 	case evals.TriggerOnConversationComplete:
-		return h.runner.RunConversationEvals(ctx, defs, evalCtx)
+		return h.runner.RunConversationEvals(classifyCtx, defs, evalCtx)
 	case evals.TriggerEveryTurn:
-		return h.runner.RunTurnEvals(ctx, defs, evalCtx)
+		return h.runner.RunTurnEvals(classifyCtx, defs, evalCtx)
 	default:
-		return h.runner.RunTurnEvals(ctx, defs, evalCtx)
+		return h.runner.RunTurnEvals(classifyCtx, defs, evalCtx)
 	}
 }
 

--- a/tools/arena/engine/eval_orchestrator_test.go
+++ b/tools/arena/engine/eval_orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -534,6 +535,59 @@ func TestEvalOrchestrator_Clone_WithEventBus(t *testing.T) {
 func TestEvalOrchestrator_Clone_Nil(t *testing.T) {
 	var orch *EvalOrchestrator
 	assert.Nil(t, orch.Clone())
+}
+
+// classifyObservingHandler captures whatever classify.Registry is reachable
+// from the context at eval time. Used to verify the orchestrator threads the
+// registry from SetClassifyRegistry through to handlers.
+type classifyObservingHandler struct {
+	seen *classify.Registry
+}
+
+func (h *classifyObservingHandler) Type() string { return "classify_probe" }
+
+func (h *classifyObservingHandler) Eval(
+	ctx context.Context, _ *evals.EvalContext, _ map[string]any,
+) (*evals.EvalResult, error) {
+	h.seen = classify.FromContext(ctx)
+	return &evals.EvalResult{EvalID: "probe", Type: "classify_probe", Value: true}, nil
+}
+
+func TestEvalOrchestrator_ClassifyRegistryReachableFromHandlerContext(t *testing.T) {
+	probe := &classifyObservingHandler{}
+	reg := evals.NewEvalTypeRegistry()
+	reg.Register(probe)
+
+	defs := []evals.EvalDef{{ID: "probe", Type: "classify_probe", Trigger: evals.TriggerEveryTurn}}
+	orch := NewEvalOrchestrator(reg, defs, false, nil, "test")
+
+	want := classify.NewRegistry()
+	orch.SetClassifyRegistry(want)
+
+	results := orch.RunTurnEvals(context.Background(),
+		[]types.Message{{Role: "assistant", Content: "hi"}}, 0, "s1")
+	require.NotEmpty(t, results)
+	assert.Same(t, want, probe.seen, "handler must see the registry the orchestrator was configured with")
+}
+
+func TestEvalOrchestrator_NoClassifyRegistryLeavesContextUnchanged(t *testing.T) {
+	probe := &classifyObservingHandler{}
+	reg := evals.NewEvalTypeRegistry()
+	reg.Register(probe)
+
+	defs := []evals.EvalDef{{ID: "probe", Type: "classify_probe", Trigger: evals.TriggerEveryTurn}}
+	orch := NewEvalOrchestrator(reg, defs, false, nil, "test")
+	// No SetClassifyRegistry call.
+
+	orch.RunTurnEvals(context.Background(),
+		[]types.Message{{Role: "assistant", Content: "hi"}}, 0, "s1")
+	assert.Nil(t, probe.seen, "FromContext on an unconfigured orchestrator must return nil so handlers can produce a clean error")
+}
+
+func TestEvalOrchestrator_SetClassifyRegistry_NilReceiverSafe(t *testing.T) {
+	var orch *EvalOrchestrator
+	// Must not panic.
+	orch.SetClassifyRegistry(classify.NewRegistry())
 }
 
 func TestEvalOrchestrator_NilReceiver(t *testing.T) {


### PR DESCRIPTION
Second slice of #1214. Plumbs the classify foundation (#1215, merged on `13afe89f`) into arena's config + execution path so eval/assertion handlers can resolve a classifier without each one carrying constructor state.

## What's in

**Config (pkg/config)**
- New top-level `inference:` block and `defaults.inference` sub-block.
- Each entry declares a non-LLM inference client: `id`, `type`, `api_key` / `api_key_env`, `base_url`, `dedicated`.
- Loader populates `cfg.LoadedInference`, rejects duplicates and missing id/type, validates default refs at load time.

**Arena engine wiring**
- `buildClassifyRegistry(cfg)` instantiates the HF backend for each entry and registers it against every task interface the backend implements — audio, text, image, embedder. Video deliberately not registered (HF has no general endpoint; the decomposing default is queued in #1214 Phase 5).
- API key resolves literal first, then named env var, then `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` canonical fallback.
- `EvalOrchestrator` gains `classifyRegistry` + `SetClassifyRegistry`. Every `Run*` entry point wraps ctx via `classify.WithRegistry` so handlers pull it back via `classify.FromContext`. Nil registry leaves ctx untouched.

## YAML example

```yaml
spec:
  inference:
    - id: hf
      type: huggingface
      api_key_env: HF_TOKEN

  defaults:
    inference:
      audio_classifier: hf
      text_classifier: hf
```

## Why ship wiring before the first handler

The next slice — `audio_emotion` handler — depends on this plumbing existing. Landing it standalone keeps that PR purely additive and small. The wiring itself is exercised by context-threading tests (probe handler reads `classify.FromContext` and asserts on the registry identity).

## Test plan

- [x] `pkg/config`: 9 new tests on `loadInference` covering empty list, duplicates, missing id/type, unknown default ids, all-task defaults.
- [x] `tools/arena/engine`: 8 tests on `buildClassifyRegistry` (HF entry registers all five task interfaces, literal key wins over env, named env var must be set, unsupported type errors, defaults applied/rejected) + 3 on orchestrator ctx wiring (registry reaches handler ctx; missing registry leaves ctx untouched; nil receiver is safe).
- [x] Schemas regenerated; arena.json gains the `inference` + `defaults.inference` shapes.
- [x] `go test -race` across `pkg/config`, `tools/arena/engine`, `runtime/classify` all green.
- [x] Coverage: pkg/config 90.4%, classify_registry.go 95%, eval_orchestrator.go 88.8%.

## Not in this PR (queued)

- `audio_emotion` eval handler (calls `AudioClassifier` from `classify.FromContext`).
- voice-refund-demo SER assertion.
- Embedder migration of OpenAI/VoyageAI behind `classify.Embedder`.

Refs: #1214
