### PR TITLE
refactor(arena): fold inference: into providers: with role: inference

### DIFF
--- a/pkg/config/inference_test.go
+++ b/pkg/config/inference_test.go
@@ -5,104 +5,44 @@ import (
 	"testing"
 )
 
-// freshConfig returns a Config with LoadedInference initialized, matching
-// the state LoadConfig hands to loadInference. The other Loaded* maps are
-// not needed by loadInference.
-func freshConfig() *Config {
+// freshInferenceConfig returns a Config with LoadedInferenceProviders
+// pre-initialized, matching the state LoadConfig hands to
+// validateInferenceDefaults.
+func freshInferenceConfig() *Config {
 	return &Config{
-		LoadedInference: make(map[string]*InferenceConfig),
+		LoadedInferenceProviders: make(map[string]*Provider),
 	}
 }
 
-func TestLoadInference_EmptyList(t *testing.T) {
-	c := freshConfig()
-	if err := c.loadInference(); err != nil {
-		t.Fatalf("loadInference: %v", err)
+func TestRoleInference_AcceptedByValidator(t *testing.T) {
+	p := &Provider{Role: RoleInference}
+	if err := p.ValidateRole(); err != nil {
+		t.Fatalf("role: inference must validate cleanly: %v", err)
 	}
-	if len(c.LoadedInference) != 0 {
-		t.Errorf("LoadedInference = %d entries, want 0", len(c.LoadedInference))
-	}
-}
-
-func TestLoadInference_SingleEntryPopulatesMap(t *testing.T) {
-	c := freshConfig()
-	c.Inference = []InferenceConfig{
-		{ID: "hf", Type: "huggingface", APIKeyEnv: "HF_TOKEN"},
-	}
-	if err := c.loadInference(); err != nil {
-		t.Fatalf("loadInference: %v", err)
-	}
-	got, ok := c.LoadedInference["hf"]
-	if !ok {
-		t.Fatal("LoadedInference[hf] missing")
-	}
-	if got.Type != "huggingface" {
-		t.Errorf("Type = %q, want huggingface", got.Type)
-	}
-	if got.APIKeyEnv != "HF_TOKEN" {
-		t.Errorf("APIKeyEnv = %q, want HF_TOKEN", got.APIKeyEnv)
+	if p.GetRole() != RoleInference {
+		t.Errorf("GetRole = %q, want %q", p.GetRole(), RoleInference)
 	}
 }
 
-func TestLoadInference_MultipleEntries(t *testing.T) {
-	c := freshConfig()
-	c.Inference = []InferenceConfig{
-		{ID: "hf", Type: "huggingface"},
-		{ID: "hf-dedicated", Type: "huggingface", BaseURL: "https://my-endpoint.huggingface.cloud", Dedicated: true},
-	}
-	if err := c.loadInference(); err != nil {
-		t.Fatalf("loadInference: %v", err)
-	}
-	if len(c.LoadedInference) != 2 {
-		t.Fatalf("LoadedInference = %d entries, want 2", len(c.LoadedInference))
-	}
-	if !c.LoadedInference["hf-dedicated"].Dedicated {
-		t.Error("Dedicated flag not preserved on the dedicated entry")
+func TestValidateInferenceDefaults_NilSectionAccepted(t *testing.T) {
+	c := freshInferenceConfig()
+	// No Defaults.Inference set — must not error.
+	if err := c.validateInferenceDefaults(); err != nil {
+		t.Fatalf("validateInferenceDefaults: %v", err)
 	}
 }
 
-func TestLoadInference_MissingIDRejected(t *testing.T) {
-	c := freshConfig()
-	c.Inference = []InferenceConfig{{Type: "huggingface"}}
-	err := c.loadInference()
-	if err == nil {
-		t.Fatal("expected error for empty id")
-	}
-	if !strings.Contains(err.Error(), "id is required") {
-		t.Errorf("error %q should mention missing id", err.Error())
+func TestValidateInferenceDefaults_EmptyIDsAccepted(t *testing.T) {
+	c := freshInferenceConfig()
+	c.Defaults.Inference = &InferenceDefaults{} // all task fields empty
+	if err := c.validateInferenceDefaults(); err != nil {
+		t.Fatalf("zero-value InferenceDefaults must validate: %v", err)
 	}
 }
 
-func TestLoadInference_MissingTypeRejected(t *testing.T) {
-	c := freshConfig()
-	c.Inference = []InferenceConfig{{ID: "hf"}}
-	err := c.loadInference()
-	if err == nil {
-		t.Fatal("expected error for empty type")
-	}
-	if !strings.Contains(err.Error(), "type is required") {
-		t.Errorf("error %q should mention missing type", err.Error())
-	}
-}
-
-func TestLoadInference_DuplicateIDRejected(t *testing.T) {
-	c := freshConfig()
-	c.Inference = []InferenceConfig{
-		{ID: "hf", Type: "huggingface"},
-		{ID: "hf", Type: "huggingface"},
-	}
-	err := c.loadInference()
-	if err == nil {
-		t.Fatal("expected error for duplicate id")
-	}
-	if !strings.Contains(err.Error(), "duplicate") {
-		t.Errorf("error %q should mention duplicate", err.Error())
-	}
-}
-
-func TestLoadInference_DefaultsAcceptKnownIDs(t *testing.T) {
-	c := freshConfig()
-	c.Inference = []InferenceConfig{{ID: "hf", Type: "huggingface"}}
+func TestValidateInferenceDefaults_KnownIDsAccepted(t *testing.T) {
+	c := freshInferenceConfig()
+	c.LoadedInferenceProviders["hf"] = &Provider{ID: "hf", Type: "huggingface", Role: RoleInference}
 	c.Defaults.Inference = &InferenceDefaults{
 		AudioClassifier: "hf",
 		TextClassifier:  "hf",
@@ -110,12 +50,12 @@ func TestLoadInference_DefaultsAcceptKnownIDs(t *testing.T) {
 		VideoClassifier: "hf",
 		Embedder:        "hf",
 	}
-	if err := c.loadInference(); err != nil {
-		t.Fatalf("loadInference: %v", err)
+	if err := c.validateInferenceDefaults(); err != nil {
+		t.Fatalf("validateInferenceDefaults: %v", err)
 	}
 }
 
-func TestLoadInference_DefaultsRejectUnknownID(t *testing.T) {
+func TestValidateInferenceDefaults_UnknownIDRejected(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		mutate  func(d *InferenceDefaults)
@@ -128,12 +68,12 @@ func TestLoadInference_DefaultsRejectUnknownID(t *testing.T) {
 		{"embedder", func(d *InferenceDefaults) { d.Embedder = "nope" }, "embedder"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := freshConfig()
-			c.Inference = []InferenceConfig{{ID: "hf", Type: "huggingface"}}
+			c := freshInferenceConfig()
+			c.LoadedInferenceProviders["hf"] = &Provider{ID: "hf", Type: "huggingface", Role: RoleInference}
 			d := &InferenceDefaults{}
 			tc.mutate(d)
 			c.Defaults.Inference = d
-			err := c.loadInference()
+			err := c.validateInferenceDefaults()
 			if err == nil {
 				t.Fatalf("expected error for unknown %s id", tc.name)
 			}
@@ -143,15 +83,9 @@ func TestLoadInference_DefaultsRejectUnknownID(t *testing.T) {
 			if !strings.Contains(err.Error(), "nope") {
 				t.Errorf("error %q should name the offending id", err.Error())
 			}
+			if !strings.Contains(err.Error(), "role: inference") {
+				t.Errorf("error %q should mention role: inference so users know how to fix", err.Error())
+			}
 		})
-	}
-}
-
-func TestLoadInference_EmptyDefaultsAreAccepted(t *testing.T) {
-	c := freshConfig()
-	c.Inference = []InferenceConfig{{ID: "hf", Type: "huggingface"}}
-	c.Defaults.Inference = &InferenceDefaults{} // all fields empty
-	if err := c.loadInference(); err != nil {
-		t.Fatalf("loadInference rejected zero-value defaults: %v", err)
 	}
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -208,7 +208,7 @@ func LoadConfig(filename string) (*Config, error) {
 	cfg.LoadedSTTProviders = make(map[string]*Provider, len(cfg.STTProviders))
 	cfg.LoadedEmbeddingProviders = make(map[string]*Provider, len(cfg.EmbeddingProviders))
 	cfg.LoadedImageProviders = make(map[string]*Provider, len(cfg.ImageProviders))
-	cfg.LoadedInference = make(map[string]*InferenceConfig, len(cfg.Inference))
+	cfg.LoadedInferenceProviders = make(map[string]*Provider)
 	cfg.ProviderGroups = make(map[string]string)
 	cfg.ProviderCapabilities = make(map[string][]string)
 
@@ -231,7 +231,9 @@ func LoadConfig(filename string) (*Config, error) {
 	if err := cfg.loadImageProviders(filename); err != nil {
 		return nil, err
 	}
-	if err := cfg.loadInference(); err != nil {
+	// validateInferenceDefaults must run AFTER loadProviders so the role:
+	// inference entries are already in LoadedInferenceProviders.
+	if err := cfg.validateInferenceDefaults(); err != nil {
 		return nil, err
 	}
 	if err := cfg.validateVoiceBindings(); err != nil {
@@ -530,6 +532,11 @@ func (c *Config) loadProviders(configPath string) error {
 			logger.Warn("Provider loaded but excluded from matrix",
 				"provider", provider.ID, "role", role,
 				"reason", "embedding providers use Embed() interface, not Predict()")
+		case RoleInference:
+			c.LoadedInferenceProviders[provider.ID] = provider
+			logger.Warn("Provider loaded but excluded from matrix",
+				"provider", provider.ID, "role", role,
+				"reason", "inference providers use runtime/classify task interfaces, not Predict()")
 		default:
 			return fmt.Errorf("providers[%s]: unhandled role %q", ref.File, role)
 		}
@@ -600,36 +607,11 @@ func (c *Config) loadEmbeddingProviders(configPath string) error {
 	return nil
 }
 
-// loadInference validates the inline inference list and populates
-// LoadedInference. Unlike providers/scenarios/evals, inference entries are
-// always inline (no file-ref shape) — they're small enough that splitting
-// them into separate YAML files would be ceremony without benefit. Default
-// references in cfg.Defaults.Inference are validated here too so unknown
-// ids fail at load time, not at first use.
-func (c *Config) loadInference() error {
-	for i := range c.Inference {
-		entry := &c.Inference[i]
-		if err := c.registerInferenceEntry(i, entry); err != nil {
-			return err
-		}
-	}
-	return c.validateInferenceDefaults()
-}
-
-func (c *Config) registerInferenceEntry(index int, entry *InferenceConfig) error {
-	if entry.ID == "" {
-		return fmt.Errorf("inference[%d]: id is required", index)
-	}
-	if entry.Type == "" {
-		return fmt.Errorf("inference[%s]: type is required", entry.ID)
-	}
-	if _, exists := c.LoadedInference[entry.ID]; exists {
-		return fmt.Errorf("inference[%s]: duplicate id", entry.ID)
-	}
-	c.LoadedInference[entry.ID] = entry
-	return nil
-}
-
+// validateInferenceDefaults ensures every id referenced by
+// cfg.Defaults.Inference resolves to an entry in LoadedInferenceProviders
+// (populated by loadProviders for entries declaring role: inference).
+// Called from LoadConfig after all providers are loaded so unknown ids
+// surface at load time, not at first eval.
 func (c *Config) validateInferenceDefaults() error {
 	if c.Defaults.Inference == nil {
 		return nil
@@ -645,8 +627,10 @@ func (c *Config) validateInferenceDefaults() error {
 		if id == "" {
 			continue
 		}
-		if _, ok := c.LoadedInference[id]; !ok {
-			return fmt.Errorf("defaults.inference.%s: unknown inference id %q", label, id)
+		if _, ok := c.LoadedInferenceProviders[id]; !ok {
+			return fmt.Errorf(
+				"defaults.inference.%s: unknown provider id %q (expected providers: entry with role: inference)",
+				label, id)
 		}
 	}
 	return nil

--- a/pkg/config/role.go
+++ b/pkg/config/role.go
@@ -16,18 +16,25 @@ const (
 	RoleSTT       = "stt"
 	RoleEmbedding = "embedding"
 	RoleImage     = "image"
+	// RoleInference covers providers implementing the runtime/classify task
+	// interfaces (audio/text/image/video classifiers + embedders). A single
+	// inference provider can satisfy several of them — the HuggingFace
+	// backend covers four — so engine wiring registers each backend against
+	// every interface it implements rather than per-role-per-task.
+	RoleInference = "inference"
 )
 
 // knownRoles is the set accepted by ValidateRole. An empty string is
 // also accepted (treated as LLM by GetRole). The internal
 // runtime/providers/base.ProviderType enum already covers all five
-// values — these are the public-facing names the spec accepts.
+// LLM-compatible values — these are the public-facing names the spec accepts.
 var knownRoles = map[string]struct{}{
 	RoleLLM:       {},
 	RoleTTS:       {},
 	RoleSTT:       {},
 	RoleEmbedding: {},
 	RoleImage:     {},
+	RoleInference: {},
 }
 
 // GetRole returns the provider's role, defaulting to "llm".
@@ -45,8 +52,8 @@ func (p *Provider) ValidateRole() error {
 		return nil
 	}
 	if _, ok := knownRoles[p.Role]; !ok {
-		return fmt.Errorf("unknown provider role %q (valid: %s, %s, %s, %s, %s)",
-			p.Role, RoleLLM, RoleTTS, RoleSTT, RoleEmbedding, RoleImage)
+		return fmt.Errorf("unknown provider role %q (valid: %s, %s, %s, %s, %s, %s)",
+			p.Role, RoleLLM, RoleTTS, RoleSTT, RoleEmbedding, RoleImage, RoleInference)
 	}
 	return nil
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -115,11 +115,6 @@ type Config struct {
 	SelfPlay   *SelfPlayConfig   `yaml:"self_play,omitempty" json:"self_play,omitempty"`
 	PackFile   string            `yaml:"pack_file,omitempty" json:"pack_file,omitempty"`
 
-	// Inference declares non-LLM inference clients used by assertion/eval
-	// handlers (audio_emotion, text_toxicity, ...). Backends implement the
-	// runtime/classify task interfaces. See InferenceConfig for the shape.
-	Inference []InferenceConfig `yaml:"inference,omitempty" json:"inference,omitempty"`
-
 	// Inline resource specs (alternative to file refs, merged into LoadedX during load)
 	ProviderSpecs map[string]*Provider    `yaml:"provider_specs,omitempty" json:"provider_specs,omitempty"`
 	ScenarioSpecs map[string]*Scenario    `yaml:"scenario_specs,omitempty" json:"scenario_specs,omitempty"`
@@ -158,7 +153,7 @@ type Config struct {
 	LoadedSTTProviders       map[string]*Provider         `yaml:"-" json:"loaded_stt_providers,omitempty"`
 	LoadedEmbeddingProviders map[string]*Provider         `yaml:"-" json:"loaded_embedding_providers,omitempty"`
 	LoadedImageProviders     map[string]*Provider         `yaml:"-" json:"loaded_image_providers,omitempty"`
-	LoadedInference          map[string]*InferenceConfig  `yaml:"-" json:"loaded_inference,omitempty"`
+	LoadedInferenceProviders map[string]*Provider         `yaml:"-" json:"loaded_inference_providers,omitempty"`
 	LoadedJudges             map[string]*JudgeTarget      `yaml:"-" json:"loaded_judges,omitempty"`
 	LoadedScenarios          map[string]*Scenario         `yaml:"-" json:"loaded_scenarios,omitempty"`
 	LoadedEvals              map[string]*Eval             `yaml:"-" json:"loaded_evals,omitempty"`
@@ -485,32 +480,10 @@ type Defaults struct {
 	MarkdownConfig *MarkdownConfig `yaml:"markdown_config,omitempty" json:"markdown_config,omitempty"`
 }
 
-// InferenceConfig declares a non-LLM inference client (audio/text/image
-// classifier or embedder) backing the runtime/classify task interfaces.
-// Eval handlers depend on the task interface; the backend is chosen by id.
-// Today the only supported Type is "huggingface".
-type InferenceConfig struct {
-	ID   string `yaml:"id" json:"id"`
-	Type string `yaml:"type" json:"type"`
-
-	// APIKey is the literal token. Prefer APIKeyEnv so secrets stay out of
-	// committed YAML; APIKey wins when both are set.
-	APIKey    string `yaml:"api_key,omitempty" json:"api_key,omitempty"`
-	APIKeyEnv string `yaml:"api_key_env,omitempty" json:"api_key_env,omitempty"`
-
-	// BaseURL overrides the backend's default endpoint. Used for HF
-	// Inference Endpoints (dedicated paid hosts) and the newer Inference
-	// Providers routing layer.
-	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty"`
-
-	// Dedicated, when true, treats BaseURL as a fully-specified inference
-	// endpoint and skips the /models/{id} suffix that the public HF
-	// Inference API requires. Set for HF Inference Endpoints.
-	Dedicated bool `yaml:"dedicated,omitempty" json:"dedicated,omitempty"`
-}
-
-// InferenceDefaults pins which inference client id serves each
-// classify task by default. Handlers may override per-call.
+// InferenceDefaults pins which inference provider id serves each
+// runtime/classify task by default. Ids resolve into
+// cfg.LoadedInferenceProviders (populated from `providers:` entries
+// declaring `role: inference`). Handlers may override per-call.
 type InferenceDefaults struct {
 	AudioClassifier string `yaml:"audio_classifier,omitempty" json:"audio_classifier,omitempty"`
 	TextClassifier  string `yaml:"text_classifier,omitempty" json:"text_classifier,omitempty"`
@@ -1191,7 +1164,7 @@ type Provider struct {
 	// Renamed from "capability" 2026-05-18 to avoid singular/plural
 	// collision with Capabilities. The field is required for tts/stt
 	// providers; defaults to "llm" when empty.
-	Role    string `json:"role,omitempty" yaml:"role,omitempty" jsonschema:"enum=llm,enum=tts,enum=stt,enum=embedding,enum=image"` //nolint:lll // enum list can't be split inside a struct tag
+	Role    string `json:"role,omitempty" yaml:"role,omitempty" jsonschema:"enum=llm,enum=tts,enum=stt,enum=embedding,enum=image,enum=inference"` //nolint:lll // enum list can't be split inside a struct tag
 	BaseURL string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	// Headers specifies custom HTTP headers to include in every request to
 	// this provider. Useful for OpenAI-compatible gateways (OpenRouter,

--- a/runtime/credentials/resolver.go
+++ b/runtime/credentials/resolver.go
@@ -24,6 +24,10 @@ var DefaultEnvVars = map[string][]string{
 	"openai": {"OPENAI_API_KEY", "OPENAI_TOKEN"},
 	"gemini": {"GEMINI_API_KEY", "GOOGLE_API_KEY"},
 	"imagen": {"GEMINI_API_KEY", "GOOGLE_API_KEY"},
+	// classify backends authenticate the same way as LLM providers, so
+	// they share this map. HF_TOKEN is canonical; HUGGING_FACE_HUB_TOKEN
+	// is the legacy alias that some CI runners use.
+	"huggingface": {"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"},
 }
 
 // ProviderHeaderConfig maps provider types to their API key header configuration.

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -430,12 +430,6 @@
         "pack_file": {
           "type": "string"
         },
-        "inference": {
-          "items": {
-            "$ref": "#/$defs/InferenceConfig"
-          },
-          "type": "array"
-        },
         "provider_specs": {
           "additionalProperties": {
             "$ref": "#/$defs/Provider"
@@ -1078,34 +1072,6 @@
       },
       "additionalProperties": false,
       "type": "object"
-    },
-    "InferenceConfig": {
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "api_key": {
-          "type": "string"
-        },
-        "api_key_env": {
-          "type": "string"
-        },
-        "base_url": {
-          "type": "string"
-        },
-        "dedicated": {
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "id",
-        "type"
-      ]
     },
     "InferenceDefaults": {
       "properties": {
@@ -1811,7 +1777,8 @@
             "tts",
             "stt",
             "embedding",
-            "image"
+            "image",
+            "inference"
           ]
         },
         "base_url": {

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -131,7 +131,8 @@
             "tts",
             "stt",
             "embedding",
-            "image"
+            "image",
+            "inference"
           ]
         },
         "base_url": {

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -579,7 +579,8 @@
             "tts",
             "stt",
             "embedding",
-            "image"
+            "image",
+            "inference"
           ]
         },
         "base_url": {

--- a/tools/arena/engine/classify_registry.go
+++ b/tools/arena/engine/classify_registry.go
@@ -1,43 +1,45 @@
 package engine
 
 import (
+	"context"
 	"fmt"
-	"os"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
 )
 
 // inferenceTypeHuggingFace is the type string for HuggingFace Inference API
-// entries in arena's `inference:` block. It's the only backend kind that
-// ships in this slice; ONNX and others are queued behind separate issues.
+// providers in arena's `providers:` list (role: inference). It's the only
+// backend kind that ships in this slice; ONNX and others are queued behind
+// separate issues.
 const inferenceTypeHuggingFace = "huggingface"
 
 // buildClassifyRegistry constructs a classify.Registry populated with the
-// task-interface implementations declared in cfg.Inference. Each loaded
-// entry instantiates one backend Client and registers it against every
-// task interface that backend implements (HF's Client satisfies all five —
-// audio/text/image classifiers + embedder). cfg.Defaults.Inference is then
-// applied to pin which id wins when a handler doesn't specify one.
+// task-interface implementations declared in cfg.LoadedInferenceProviders
+// (every `providers:` entry with `role: inference`). Each loaded provider
+// instantiates one backend Client and registers against every classify
+// task interface that backend implements (the HF backend covers four —
+// audio/text/image classifiers + embedder). cfg.Defaults.Inference is
+// then applied to pin which id wins when a handler doesn't specify one.
 //
-// Returns (nil, nil) when no inference entries are configured — handlers
-// that need a classifier will surface their own "no classifier configured"
-// error via classify.FromContext returning nil, which is the desired
-// behavior: arenas that don't use classify-backed assertions shouldn't
-// require an HF_TOKEN.
+// Returns (nil, nil) when no inference providers are configured. Handlers
+// that need a classifier will surface "no classifier configured" via
+// classify.FromContext returning nil — arenas that don't use
+// classify-backed assertions shouldn't require an HF token.
 //
-// Returns a non-nil error only when a configured entry is malformed
-// (unsupported type, missing api key). The caller logs and continues —
-// one broken entry must not block a run that doesn't reach a
-// classify-dependent handler.
+// Returns a non-nil error only when a configured provider is malformed
+// (unsupported type, unresolvable credential, missing api key). The
+// caller logs and continues — one broken entry must not block a run
+// that doesn't reach a classify-dependent handler.
 func buildClassifyRegistry(cfg *config.Config) (*classify.Registry, error) {
-	if cfg == nil || len(cfg.LoadedInference) == 0 {
+	if cfg == nil || len(cfg.LoadedInferenceProviders) == 0 {
 		return nil, nil
 	}
 	reg := classify.NewRegistry()
-	for id, entry := range cfg.LoadedInference {
-		if err := registerInferenceEntry(reg, id, entry); err != nil {
+	for id, provider := range cfg.LoadedInferenceProviders {
+		if err := registerInferenceProvider(reg, id, provider, cfg.ConfigDir); err != nil {
 			return reg, err
 		}
 	}
@@ -47,20 +49,20 @@ func buildClassifyRegistry(cfg *config.Config) (*classify.Registry, error) {
 	return reg, nil
 }
 
-func registerInferenceEntry(reg *classify.Registry, id string, entry *config.InferenceConfig) error {
-	switch entry.Type {
+func registerInferenceProvider(reg *classify.Registry, id string, provider *config.Provider, configDir string) error {
+	switch provider.Type {
 	case inferenceTypeHuggingFace:
-		apiKey, err := resolveInferenceAPIKey(entry)
+		apiKey, err := resolveProviderAPIKey(provider, configDir)
 		if err != nil {
-			return fmt.Errorf("inference[%s]: %w", id, err)
+			return fmt.Errorf("inference provider %s: %w", id, err)
 		}
 		client, err := classifyhf.NewClient(classifyhf.Config{
 			APIKey:    apiKey,
-			BaseURL:   entry.BaseURL,
-			Dedicated: entry.Dedicated,
+			BaseURL:   provider.BaseURL,
+			Dedicated: providerBoolFromConfig(provider, "dedicated"),
 		})
 		if err != nil {
-			return fmt.Errorf("inference[%s]: %w", id, err)
+			return fmt.Errorf("inference provider %s: %w", id, err)
 		}
 		// HF Client implements every task interface (compile-time checked in
 		// runtime/classify/backends/hf/client.go). Register against each so
@@ -74,29 +76,47 @@ func registerInferenceEntry(reg *classify.Registry, id string, entry *config.Inf
 		// (audio + frame-sampled images) is queued in #1214 Phase 5.
 		return nil
 	default:
-		return fmt.Errorf("inference[%s]: unsupported type %q (supported: %s)", id, entry.Type, inferenceTypeHuggingFace)
+		return fmt.Errorf("inference provider %s: unsupported type %q (supported: %s)",
+			id, provider.Type, inferenceTypeHuggingFace)
 	}
 }
 
-func resolveInferenceAPIKey(entry *config.InferenceConfig) (string, error) {
-	if entry.APIKey != "" {
-		return entry.APIKey, nil
+// resolveProviderAPIKey runs the configured credential through the shared
+// resolver and extracts the raw API key. Non-APIKey credentials (NoOp,
+// cloud platform credentials) are rejected — the classify backends today
+// need a bearer token, not a signed request.
+func resolveProviderAPIKey(provider *config.Provider, configDir string) (string, error) {
+	cred, err := credentials.Resolve(context.Background(), credentials.ResolverConfig{
+		ProviderType:     provider.Type,
+		CredentialConfig: provider.Credential,
+		ConfigDir:        configDir,
+	})
+	if err != nil {
+		return "", err
 	}
-	if entry.APIKeyEnv != "" {
-		if v := os.Getenv(entry.APIKeyEnv); v != "" {
-			return v, nil
-		}
-		return "", fmt.Errorf("env var %s is empty or unset", entry.APIKeyEnv)
+	// Resolver returns NoOpCredential when no key is configured AND no
+	// default env var is set. For HF we always need a bearer token —
+	// surface a message that names every resolvable source.
+	apiKey, ok := cred.(*credentials.APIKeyCredential)
+	if !ok || apiKey.APIKey() == "" {
+		return "", fmt.Errorf(
+			"no api key configured (set credential.api_key, credential.credential_env, " +
+				"or export HF_TOKEN / HUGGING_FACE_HUB_TOKEN)")
 	}
-	// HF canonical env var fallback so arenas with a single inference entry
-	// don't need an explicit api_key_env. HF_TOKEN is the documented name;
-	// HUGGING_FACE_HUB_TOKEN is the legacy alias that some CI runners use.
-	for _, name := range []string{"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"} {
-		if v := os.Getenv(name); v != "" {
-			return v, nil
-		}
+	return apiKey.APIKey(), nil
+}
+
+// providerBoolFromConfig pulls a boolean flag out of Provider.AdditionalConfig.
+// Returns false when the key is absent or the value isn't a bool — the
+// backends already validate their own knobs at request time, so passing
+// through "false" for a misspelled flag won't cause a silent breakage in
+// practice (an unset Dedicated still hits the public HF endpoint).
+func providerBoolFromConfig(provider *config.Provider, key string) bool {
+	if provider == nil || provider.AdditionalConfig == nil {
+		return false
 	}
-	return "", fmt.Errorf("api_key or api_key_env required (HF_TOKEN / HUGGING_FACE_HUB_TOKEN also accepted as fallback)")
+	v, ok := provider.AdditionalConfig[key].(bool)
+	return ok && v
 }
 
 func applyInferenceDefaults(reg *classify.Registry, defaults *config.InferenceDefaults) error {

--- a/tools/arena/engine/classify_registry_test.go
+++ b/tools/arena/engine/classify_registry_test.go
@@ -14,7 +14,7 @@ func TestBuildClassifyRegistry_NoInferenceReturnsNil(t *testing.T) {
 		t.Fatalf("buildClassifyRegistry: %v", err)
 	}
 	if reg != nil {
-		t.Errorf("expected nil registry when no inference entries; got %v", reg)
+		t.Errorf("expected nil registry when no inference providers; got %v", reg)
 	}
 }
 
@@ -28,11 +28,25 @@ func TestBuildClassifyRegistry_NilConfigReturnsNil(t *testing.T) {
 	}
 }
 
+// hfProvider returns a Provider with role: inference + a literal credential
+// so resolveProviderAPIKey succeeds without env-var setup. The literal-key
+// path is the cleanest seam in tests; env-var resolution is covered by
+// the credentials package's own tests.
+func hfProvider(id string) *config.Provider {
+	return &config.Provider{
+		ID:   id,
+		Type: "huggingface",
+		Role: config.RoleInference,
+		Credential: &config.CredentialConfig{
+			APIKey: "test-token",
+		},
+	}
+}
+
 func TestBuildClassifyRegistry_HFEntryRegistersAllTasks(t *testing.T) {
-	t.Setenv("HF_TOKEN", "test-token")
 	cfg := &config.Config{
-		LoadedInference: map[string]*config.InferenceConfig{
-			"hf": {ID: "hf", Type: "huggingface"},
+		LoadedInferenceProviders: map[string]*config.Provider{
+			"hf": hfProvider("hf"),
 		},
 	}
 	reg, err := buildClassifyRegistry(cfg)
@@ -42,8 +56,6 @@ func TestBuildClassifyRegistry_HFEntryRegistersAllTasks(t *testing.T) {
 	if reg == nil {
 		t.Fatal("expected non-nil registry")
 	}
-	// HF Client implements every task interface; the registry should
-	// resolve the id for each. Video deliberately omitted (no HF endpoint).
 	for _, lookup := range []struct {
 		name string
 		fn   func() error
@@ -57,64 +69,49 @@ func TestBuildClassifyRegistry_HFEntryRegistersAllTasks(t *testing.T) {
 			t.Errorf("%s lookup: %v", lookup.name, err)
 		}
 	}
-	// Video classifier should NOT be registered — HF has no general endpoint.
+	// Video classifier deliberately not registered — HF has no general endpoint.
 	if _, err := reg.VideoClassifier("hf"); err == nil {
 		t.Error("video should not be registered for HF backend")
 	}
 }
 
-func TestBuildClassifyRegistry_LiteralAPIKeyWinsOverEnv(t *testing.T) {
-	t.Setenv("HF_TOKEN", "env-token")
+func TestBuildClassifyRegistry_CanonicalEnvVarFallback(t *testing.T) {
+	// No literal credential — must fall through to HF_TOKEN via the
+	// credentials package's DefaultEnvVars for provider type "huggingface".
+	t.Setenv("HF_TOKEN", "from-env")
 	cfg := &config.Config{
-		LoadedInference: map[string]*config.InferenceConfig{
-			"hf": {ID: "hf", Type: "huggingface", APIKey: "literal-token"},
+		LoadedInferenceProviders: map[string]*config.Provider{
+			"hf": {ID: "hf", Type: "huggingface", Role: config.RoleInference},
 		},
 	}
 	if _, err := buildClassifyRegistry(cfg); err != nil {
-		t.Errorf("literal api key should succeed without HF_TOKEN: %v", err)
+		t.Errorf("HF_TOKEN fallback should succeed: %v", err)
 	}
 }
 
 func TestBuildClassifyRegistry_MissingAPIKeyErrors(t *testing.T) {
-	// Clear inherited values so the canonical fallback can't accidentally
-	// supply a token in CI environments where HF_TOKEN is exported.
+	// No literal credential, no env vars — must fail with a message that
+	// points the user at where to fix it.
 	t.Setenv("HF_TOKEN", "")
 	t.Setenv("HUGGING_FACE_HUB_TOKEN", "")
 	cfg := &config.Config{
-		LoadedInference: map[string]*config.InferenceConfig{
-			"hf": {ID: "hf", Type: "huggingface"},
+		LoadedInferenceProviders: map[string]*config.Provider{
+			"hf": {ID: "hf", Type: "huggingface", Role: config.RoleInference},
 		},
 	}
 	_, err := buildClassifyRegistry(cfg)
 	if err == nil {
-		t.Fatal("expected error when no api key resolvable")
+		t.Fatal("expected error when no credential resolvable")
 	}
-	if !strings.Contains(err.Error(), "api_key") {
-		t.Errorf("error %q should mention api_key", err.Error())
-	}
-}
-
-func TestBuildClassifyRegistry_NamedEnvVarMustBeSet(t *testing.T) {
-	t.Setenv("HF_TOKEN", "fallback-should-not-be-used")
-	t.Setenv("MY_HF_KEY", "") // explicitly empty
-	cfg := &config.Config{
-		LoadedInference: map[string]*config.InferenceConfig{
-			"hf": {ID: "hf", Type: "huggingface", APIKeyEnv: "MY_HF_KEY"},
-		},
-	}
-	_, err := buildClassifyRegistry(cfg)
-	if err == nil {
-		t.Fatal("when api_key_env is set, the named var being empty should error (don't silently fall through to HF_TOKEN)")
-	}
-	if !strings.Contains(err.Error(), "MY_HF_KEY") {
-		t.Errorf("error %q should name the configured env var", err.Error())
+	if !strings.Contains(err.Error(), "api key") {
+		t.Errorf("error %q should mention api key", err.Error())
 	}
 }
 
 func TestBuildClassifyRegistry_UnsupportedTypeErrors(t *testing.T) {
 	cfg := &config.Config{
-		LoadedInference: map[string]*config.InferenceConfig{
-			"x": {ID: "x", Type: "bogus"},
+		LoadedInferenceProviders: map[string]*config.Provider{
+			"x": {ID: "x", Type: "bogus", Role: config.RoleInference},
 		},
 	}
 	_, err := buildClassifyRegistry(cfg)
@@ -127,10 +124,9 @@ func TestBuildClassifyRegistry_UnsupportedTypeErrors(t *testing.T) {
 }
 
 func TestBuildClassifyRegistry_DefaultsAppliedToRegistry(t *testing.T) {
-	t.Setenv("HF_TOKEN", "test-token")
 	cfg := &config.Config{
-		LoadedInference: map[string]*config.InferenceConfig{
-			"hf": {ID: "hf", Type: "huggingface"},
+		LoadedInferenceProviders: map[string]*config.Provider{
+			"hf": hfProvider("hf"),
 		},
 		Defaults: config.Defaults{
 			Inference: &config.InferenceDefaults{
@@ -155,10 +151,9 @@ func TestBuildClassifyRegistry_DefaultsAppliedToRegistry(t *testing.T) {
 }
 
 func TestBuildClassifyRegistry_DefaultsReferencingUnregisteredID(t *testing.T) {
-	t.Setenv("HF_TOKEN", "test-token")
 	cfg := &config.Config{
-		LoadedInference: map[string]*config.InferenceConfig{
-			"hf": {ID: "hf", Type: "huggingface"},
+		LoadedInferenceProviders: map[string]*config.Provider{
+			"hf": hfProvider("hf"),
 		},
 		Defaults: config.Defaults{
 			Inference: &config.InferenceDefaults{
@@ -172,5 +167,33 @@ func TestBuildClassifyRegistry_DefaultsReferencingUnregisteredID(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "audio_classifier") {
 		t.Errorf("error %q should identify which default failed", err.Error())
+	}
+}
+
+func TestBuildClassifyRegistry_DedicatedFlagFromAdditionalConfig(t *testing.T) {
+	// Construction should accept Dedicated true: a Provider with no BaseURL
+	// + Dedicated true would normally fail (NewClient rejects bare-relative
+	// dedicated URL), but Dedicated=false (the default) lets the client
+	// build successfully against the public Inference API. This test
+	// pins the AdditionalConfig path itself — that a "dedicated: true"
+	// bool flag in the YAML is read through.
+	cfg := &config.Config{
+		LoadedInferenceProviders: map[string]*config.Provider{
+			"hf": {
+				ID:      "hf",
+				Type:    "huggingface",
+				Role:    config.RoleInference,
+				BaseURL: "https://my-endpoint.huggingface.cloud",
+				Credential: &config.CredentialConfig{
+					APIKey: "test-token",
+				},
+				AdditionalConfig: map[string]interface{}{
+					"dedicated": true,
+				},
+			},
+		},
+	}
+	if _, err := buildClassifyRegistry(cfg); err != nil {
+		t.Errorf("dedicated provider should build: %v", err)
 	}
 }


### PR DESCRIPTION
Aligns the classify foundation with the unified `providers:` model established in #1199. After this, every provider type — LLM, TTS, STT, embedding, image, **and now inference** — flows through a single `providers:` list with role-based routing and the shared credential resolver chain.

The previous `inference:` block (shipped in #1216) was correct in shape but inconsistent with the rest of the spec. Folding it before the first handler lands keeps the migration cheap — only the test fixtures touched in this PR needed updating.

## YAML migration

```diff
 spec:
   providers:
+    - id: hf
+      file: providers/hf.yaml

-  inference:
-    - id: hf
-      type: huggingface
-      api_key_env: HF_TOKEN
```

```yaml
# providers/hf.yaml
spec:
  type: huggingface
  role: inference
  credential:
    credential_env: HF_TOKEN
```

`defaults.inference:` stays in place (it still pins per-task default ids), but now points at `LoadedInferenceProviders` and its error message guides users to the unified shape.

## What changed

**Removed**
- Top-level `inference:` block and `InferenceConfig` type.
- The bespoke `api_key` / `api_key_env` / `HF_TOKEN` fallback in `classify_registry.go`. Credential resolution now flows through `runtime/credentials.Resolve` like every other provider.
- The `loadInference()` loader pass. Routing happens in `loadProviders`' existing role switch.

**Added**
- `RoleInference` constant + validator entry. Provider jsonschema enum gains `"inference"`.
- `LoadedInferenceProviders map[string]*Provider` on `Config`.
- `credentials.DefaultEnvVars` gains `"huggingface" => HF_TOKEN / HUGGING_FACE_HUB_TOKEN` so providers without an explicit credential block still resolve the canonical token.
- `buildClassifyRegistry` reads `*Provider` entries, runs them through `credentials.Resolve`, extracts the raw key via `APIKeyCredential.APIKey()`, and pulls `dedicated` out of `AdditionalConfig`.

## Test plan

- [x] `pkg/config`: 5 new tests (role: inference validates; defaults nil/empty accepted; known/unknown ids accepted/rejected with messages pointing at the unified shape).
- [x] `tools/arena/engine`: 8 `buildClassifyRegistry` tests reframed around `*Provider` entries (HF registers all four implemented task interfaces; HF_TOKEN canonical fallback works; missing key errors with a useful message; unsupported type errors; defaults applied / rejected; dedicated flag from AdditionalConfig is read through).
- [x] Schemas regenerated: `arena.json` loses the inference block; `provider.json` + `runtime-config.json` gain `inference` in the role enum.
- [x] `go test -race` across `pkg/config`, `tools/arena/engine`, `runtime/classify`, `runtime/credentials` all green.

## Net change

`10 files changed, 208 insertions(+), 294 deletions(-)` — the unified shape is smaller in addition to being more consistent.

Refs: #1214
