### PR TITLE
feat(evals): audio_emotion handler + inference provider docs

### DIFF
--- a/docs/src/content/docs/arena/how-to/configure-providers.md
+++ b/docs/src/content/docs/arena/how-to/configure-providers.md
@@ -385,6 +385,82 @@ spec:
     guided_choice: ["yes", "no", "maybe"]
 ```
 
+## Inference Providers (Audio / Text / Image Classification + Embedding)
+
+Inference providers back the `runtime/classify` task interfaces — audio,
+text, image, and video classifiers, plus embedders. They power assertion
+handlers like `audio_emotion` that score model output against a target
+label, and don't participate in the LLM run matrix.
+
+Today the only shipped backend is the HuggingFace Inference API; the
+same shape extends to ONNX and other backends as they land.
+
+### HuggingFace Inference API
+
+```yaml
+# providers/hf.yaml
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: hf
+
+spec:
+  type: huggingface
+  role: inference                # routes into the classify registry
+  credential:
+    credential_env: HF_TOKEN     # or HUGGING_FACE_HUB_TOKEN
+```
+
+Reference it from the arena config like any other provider:
+
+```yaml
+# arena.yaml
+spec:
+  providers:
+    - id: hf
+      file: providers/hf.yaml
+
+  defaults:
+    inference:
+      audio_classifier: hf       # used when an assertion omits classifier_id
+      text_classifier: hf
+      image_classifier: hf
+      embedder: hf
+```
+
+Then use it in a scenario:
+
+```yaml
+conversation_assertions:
+  - type: audio_emotion
+    params:
+      model: superb/wav2vec2-base-superb-er
+      expected_label: angry
+      min_score: 0.6
+```
+
+When HuggingFace returns a 503 "model is loading" the assertion is
+recorded as **skipped**, not failed — the model isn't broken, it just
+hasn't initialized. Reruns after the model warms up will score normally.
+
+### Dedicated endpoints
+
+For HuggingFace [Inference Endpoints](https://huggingface.co/inference-endpoints)
+(dedicated paid hosts), set `dedicated: true` and point `base_url` at
+the endpoint URL. The classify client then skips the
+`/models/{owner}/{name}` suffix that the public Inference API requires.
+
+```yaml
+spec:
+  type: huggingface
+  role: inference
+  base_url: https://my-endpoint.huggingface.cloud
+  additional_config:
+    dedicated: true
+  credential:
+    credential_env: HF_TOKEN
+```
+
 ## OpenAI-Compatible Gateways
 
 Many third-party services expose an OpenAI-compatible API: **OpenRouter**, **Groq**, **Together AI**, **Fireworks AI**, **LiteLLM**, and self-hosted proxies. You can point the built-in `openai` provider at any of them with `base_url` and (optionally) `headers`.

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -36,6 +36,30 @@ A **provider** is an LLM service (OpenAI, Anthropic, Google) that generates text
 - **Features**: Function calling, vision, streaming, guided decoding, beam search, GPU-accelerated high-throughput
 - **Pricing**: Free (self-hosted, no API costs)
 
+## Provider Roles
+
+Every provider declares a `role:` that tells the runtime which interface
+it implements:
+
+- `llm` (default) — chat completion via `Predict()`. The matrix of
+  agents-under-test in arena scenarios is built from these.
+- `tts` — text-to-speech via `Synthesize()`.
+- `stt` — speech-to-text via `Transcribe()`.
+- `embedding` — vector embeddings via `Embed()`.
+- `image` — image generation; Predict-compatible, so eligible for the
+  arena matrix alongside `llm`.
+- `inference` — non-LLM inference (audio/text/image classifiers,
+  embedders) via the `runtime/classify` task interfaces. Powers
+  assertion handlers like `audio_emotion`. Today the only shipped
+  backend is HuggingFace; see
+  [Inference Providers](/arena/how-to/configure-providers/#inference-providers-audio--text--image-classification--embedding)
+  in the configure-providers how-to.
+
+Providers route into role-specific registries at load time. One backend
+can satisfy several roles if it implements multiple interfaces (e.g.
+the HuggingFace inference backend registers as audio, text, image, and
+embedder simultaneously).
+
 ## Platform Support
 
 PromptKit supports running models on cloud hyperscaler platforms in addition to direct API access:

--- a/docs/src/content/docs/glossary.md
+++ b/docs/src/content/docs/glossary.md
@@ -65,6 +65,9 @@ A publish-subscribe system that distributes execution events to listeners. Used 
 ### Guardrail
 A validator that enforces policies on LLM outputs in real-time. Guardrails can detect and prevent policy violations (banned content, PII exposure, etc.) and abort responses early. Different from [assertions](#assertion), which are test-time checks.
 
+### Inference Provider
+A [provider](#provider) declared with `role: inference` that backs the non-LLM `runtime/classify` task interfaces — audio, text, image, and video classifiers, plus embedders. Powers assertion handlers such as `audio_emotion` (does the audio sound angry?), `text_toxicity`, etc. The HuggingFace Inference API backend ships today; ONNX and others are queued. Inference providers don't participate in the [agent-under-test](#provider) matrix because they don't implement `Predict()`.
+
 ### Middleware
 Historically referred to pluggable processing components in the pipeline. The current architecture uses a **stage-based** design (see [Stage](#stage)), where each stage is a discrete processing step in a [DAG](#dag) pipeline. The term "middleware" may still appear in event names and some documentation for backward compatibility.
 

--- a/runtime/evals/handlers/audio_emotion.go
+++ b/runtime/evals/handlers/audio_emotion.go
@@ -1,0 +1,281 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+const (
+	audioEmotionDefaultMinScore = 0.5
+	audioEmotionDefaultRole     = "user"
+
+	// keys reused in result Value / Details maps. Extracted so the
+	// linter doesn't flag duplication and so a future schema change
+	// (e.g. renaming "expected_label" to "label") only edits one
+	// place.
+	audioEmotionKeyExpectedLabel = "expected_label"
+	audioEmotionKeyMinScore      = "min_score"
+	audioEmotionKeyScores        = "scores"
+)
+
+// AudioEmotionHandler scores whether the audio in a chosen message contains
+// a target emotion (e.g. "angry") above a configurable confidence
+// threshold. It calls the AudioClassifier resolved from the orchestrator's
+// classify registry, so the model/backend are arena-config decisions, not
+// handler decisions.
+//
+// Params:
+//   - model           string  (required) — backend model id, e.g. "superb/wav2vec2-base-superb-er"
+//   - expected_label  string  (required) — label that must appear with score >= min_score
+//   - min_score       float   (optional, default 0.5) — confidence threshold for pass
+//   - message_role    string  (optional, default "user") — which speaker's audio to score
+//   - message_index   int     (optional, default -1 = latest match) — pick a specific audio message
+//   - classifier_id   string  (optional) — explicit registry id; empty uses the configured default
+type AudioEmotionHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *AudioEmotionHandler) Type() string { return "audio_emotion" }
+
+// Eval pulls the AudioClassifier out of context, locates the target audio
+// part in the conversation, runs classification, and grades the requested
+// label against the configured threshold.
+func (h *AudioEmotionHandler) Eval(
+	ctx context.Context, evalCtx *evals.EvalContext, params map[string]any,
+) (*evals.EvalResult, error) {
+	cfg, cfgErr := parseAudioEmotionParams(params)
+	if cfgErr != nil {
+		return errorResult(h.Type(), cfgErr.Error()), nil
+	}
+
+	classifier, classifierErr := resolveAudioClassifier(ctx, cfg.classifierID)
+	if classifierErr != nil {
+		return errorResult(h.Type(), classifierErr.Error()), nil
+	}
+
+	media, partErr := findAudioMessageMedia(evalCtx.Messages, cfg.messageRole, cfg.messageIndex)
+	if partErr != nil {
+		return errorResult(h.Type(), partErr.Error()), nil
+	}
+
+	audioBytes, readErr := readMediaBytes(media)
+	if readErr != nil {
+		return errorResult(h.Type(), readErr.Error()), nil
+	}
+
+	opts := classify.AudioOptions{
+		Model:    cfg.model,
+		MIMEType: media.MIMEType,
+	}
+	scores, classifyErr := classifier.ClassifyAudio(ctx, audioBytes, opts)
+	if classifyErr != nil {
+		if errors.Is(classifyErr, classifyhf.ErrModelLoading) {
+			return &evals.EvalResult{
+				Type:       h.Type(),
+				Score:      boolScore(true),
+				Skipped:    true,
+				SkipReason: "model still loading after retries",
+			}, nil
+		}
+		return errorResult(h.Type(), fmt.Sprintf("classify failed: %v", classifyErr)), nil
+	}
+
+	return gradeAudioEmotion(h.Type(), &cfg, scores), nil
+}
+
+// audioEmotionConfig holds the validated params after parsing. Keeping it
+// separate from the YAML map lets later handlers reuse the same struct
+// shape without each one re-doing the key/type dance.
+type audioEmotionConfig struct {
+	model         string
+	expectedLabel string
+	minScore      float64
+	messageRole   string
+	messageIndex  int
+	classifierID  string
+}
+
+func parseAudioEmotionParams(params map[string]any) (audioEmotionConfig, error) {
+	cfg := audioEmotionConfig{
+		minScore:     audioEmotionDefaultMinScore,
+		messageRole:  audioEmotionDefaultRole,
+		messageIndex: -1,
+	}
+	model, _ := params["model"].(string)
+	if model == "" {
+		return cfg, errors.New("model is required (e.g. superb/wav2vec2-base-superb-er)")
+	}
+	cfg.model = model
+
+	expected, _ := params[audioEmotionKeyExpectedLabel].(string)
+	if expected == "" {
+		return cfg, errors.New("expected_label is required")
+	}
+	cfg.expectedLabel = expected
+
+	if v, ok := extractFloat64(params, "min_score"); ok {
+		cfg.minScore = v
+	}
+	if v, ok := params["message_role"].(string); ok && v != "" {
+		cfg.messageRole = v
+	}
+	if v, ok := params["message_index"].(int); ok {
+		cfg.messageIndex = v
+	} else if v, ok := extractFloat64(params, "message_index"); ok {
+		cfg.messageIndex = int(v)
+	}
+	if v, ok := params["classifier_id"].(string); ok {
+		cfg.classifierID = v
+	}
+	return cfg, nil
+}
+
+// resolveAudioClassifier pulls the registry out of context and looks up the
+// requested classifier id. An empty id resolves the configured default, so
+// arenas with `defaults.inference.audio_classifier` set don't need to repeat
+// the id on every handler.
+func resolveAudioClassifier(ctx context.Context, id string) (classify.AudioClassifier, error) {
+	reg := classify.FromContext(ctx)
+	if reg == nil {
+		return nil, errors.New(
+			"no classify registry configured; add a providers: entry with role: inference " +
+				"and either defaults.inference.audio_classifier or params.classifier_id")
+	}
+	return reg.AudioClassifier(id)
+}
+
+// findAudioMessageMedia locates the audio part the handler should classify.
+// Walks messages in reverse so message_index = -1 picks the most recent.
+// Non-negative indices count forward through audio parts of the matching
+// role.
+func findAudioMessageMedia(messages []types.Message, role string, index int) (*types.MediaContent, error) {
+	audioParts := collectAudioPartsByRole(messages, role)
+	if len(audioParts) == 0 {
+		return nil, fmt.Errorf("no audio part found with role %q", role)
+	}
+	if index < 0 {
+		return audioParts[len(audioParts)-1], nil
+	}
+	if index >= len(audioParts) {
+		return nil, fmt.Errorf("message_index %d out of range (found %d audio parts with role %q)",
+			index, len(audioParts), role)
+	}
+	return audioParts[index], nil
+}
+
+func collectAudioPartsByRole(messages []types.Message, role string) []*types.MediaContent {
+	var out []*types.MediaContent
+	for i := range messages {
+		if messages[i].Role != role {
+			continue
+		}
+		for j := range messages[i].Parts {
+			part := &messages[i].Parts[j]
+			if part.Type == types.ContentTypeAudio && part.Media != nil {
+				out = append(out, part.Media)
+			}
+		}
+	}
+	return out
+}
+
+// readMediaBytes pulls the raw audio bytes out of a MediaContent. We
+// already require the data to be available locally (base64 inline or
+// file path) — URL / storage-reference parts would need a MediaLoader
+// and aren't supported here yet. Surfacing a clear error is better than
+// silently passing or failing the eval.
+func readMediaBytes(media *types.MediaContent) ([]byte, error) {
+	if media.URL != nil || media.StorageReference != nil {
+		return nil, errors.New(
+			"audio_emotion needs inline base64 data or a local file path; " +
+				"URL and storage-reference sources are not yet supported")
+	}
+	reader, err := media.ReadData()
+	if err != nil {
+		return nil, fmt.Errorf("read audio: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read audio body: %w", err)
+	}
+	if len(body) == 0 {
+		return nil, errors.New("audio payload is empty")
+	}
+	return body, nil
+}
+
+// gradeAudioEmotion looks up the requested label in the classifier's
+// scored output, applies the threshold, and assembles the result. The
+// Value/Details payload keeps every score the model returned so debug
+// reports can show why a 0.4-confidence "angry" missed a 0.6 threshold.
+func gradeAudioEmotion(
+	handlerType string, cfg *audioEmotionConfig, scores []classify.LabelScore,
+) *evals.EvalResult {
+	var foundScore float64
+	var foundLabel string
+	for _, s := range scores {
+		if strings.EqualFold(s.Label, cfg.expectedLabel) {
+			foundScore = s.Score
+			foundLabel = s.Label
+			break
+		}
+	}
+	if foundLabel == "" {
+		allLabels := strings.Join(labelsFromScores(scores), ", ")
+		return &evals.EvalResult{
+			Type:  handlerType,
+			Score: boolScore(false),
+			Value: map[string]any{
+				audioEmotionKeyExpectedLabel: cfg.expectedLabel,
+				audioEmotionKeyMinScore:      cfg.minScore,
+				keyFound:                     false,
+			},
+			Explanation: fmt.Sprintf("label %q not returned by model; got: %s", cfg.expectedLabel, allLabels),
+			Details:     map[string]any{audioEmotionKeyScores: scores},
+		}
+	}
+	passed := foundScore >= cfg.minScore
+	scoreCopy := foundScore
+	return &evals.EvalResult{
+		Type:        handlerType,
+		Score:       &scoreCopy,
+		MetricValue: &scoreCopy,
+		Value: map[string]any{
+			audioEmotionKeyExpectedLabel: cfg.expectedLabel,
+			audioEmotionKeyMinScore:      cfg.minScore,
+			"actual_score":               foundScore,
+			"passed":                     passed,
+		},
+		Explanation: fmt.Sprintf("%s score %.3f (threshold %.3f)", foundLabel, foundScore, cfg.minScore),
+		Details:     map[string]any{audioEmotionKeyScores: scores},
+	}
+}
+
+func labelsFromScores(scores []classify.LabelScore) []string {
+	out := make([]string, len(scores))
+	for i, s := range scores {
+		out[i] = s.Label
+	}
+	return out
+}
+
+// errorResult builds an EvalResult that records the failure reason
+// without ever returning a Go error to the runner. Eval handlers that
+// return errors short-circuit the batch; we'd rather let other evals
+// still run and surface this one as failed with a clear explanation.
+func errorResult(handlerType, msg string) *evals.EvalResult {
+	return &evals.EvalResult{
+		Type:        handlerType,
+		Score:       boolScore(false),
+		Error:       msg,
+		Explanation: msg,
+	}
+}

--- a/runtime/evals/handlers/audio_emotion_test.go
+++ b/runtime/evals/handlers/audio_emotion_test.go
@@ -1,0 +1,277 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// hfTestServer returns an httptest.Server that hands back the provided
+// HF audio-classification response JSON (or a 503 model-loading payload
+// when loading is true). Keeping the helper close to the handler tests
+// avoids reaching into the hf package's test fixtures.
+func hfTestServer(t *testing.T, scores []classify.LabelScore, loading bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if loading {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]any{"estimated_time": 0.05})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// HF audio-classification returns the flat [{label, score}] shape.
+		_ = json.NewEncoder(w).Encode(scores)
+	}))
+}
+
+func ctxWithRegistry(t *testing.T, srvURL string) context.Context {
+	t.Helper()
+	client, err := classifyhf.NewClient(classifyhf.Config{
+		APIKey:  "test-token",
+		BaseURL: srvURL,
+	})
+	if err != nil {
+		t.Fatalf("hf client: %v", err)
+	}
+	reg := classify.NewRegistry()
+	reg.RegisterAudio("hf", client)
+	if err := reg.SetDefaultAudio("hf"); err != nil {
+		t.Fatalf("SetDefaultAudio: %v", err)
+	}
+	return classify.WithRegistry(context.Background(), reg)
+}
+
+// audioMessage returns a single user message carrying base64-encoded
+// audio. Content is opaque (the httptest server doesn't decode it) so a
+// short literal is enough.
+func audioMessage(role, body string) types.Message {
+	encoded := base64.StdEncoding.EncodeToString([]byte(body))
+	return types.Message{
+		Role: role,
+		Parts: []types.ContentPart{{
+			Type: types.ContentTypeAudio,
+			Media: &types.MediaContent{
+				Data:     &encoded,
+				MIMEType: "audio/wav",
+			},
+		}},
+	}
+}
+
+func TestAudioEmotion_PassesWhenLabelMeetsThreshold(t *testing.T) {
+	srv := hfTestServer(t, []classify.LabelScore{
+		{Label: "angry", Score: 0.82},
+		{Label: "neutral", Score: 0.10},
+	}, false)
+	defer srv.Close()
+
+	ctx := ctxWithRegistry(t, srv.URL)
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{audioMessage("user", "rawaudio")},
+	}
+	h := &AudioEmotionHandler{}
+	res, err := h.Eval(ctx, evalCtx, map[string]any{
+		"model":          "superb/wav2vec2-base-superb-er",
+		"expected_label": "angry",
+		"min_score":      0.6,
+	})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("expected pass, got skipped: %s", res.SkipReason)
+	}
+	if res.Error != "" {
+		t.Fatalf("expected pass, got error: %s", res.Error)
+	}
+	if res.Score == nil || *res.Score < 0.6 {
+		t.Errorf("score = %v, want >= 0.6", res.Score)
+	}
+}
+
+func TestAudioEmotion_FailsWhenLabelBelowThreshold(t *testing.T) {
+	srv := hfTestServer(t, []classify.LabelScore{
+		{Label: "angry", Score: 0.3},
+		{Label: "neutral", Score: 0.7},
+	}, false)
+	defer srv.Close()
+
+	ctx := ctxWithRegistry(t, srv.URL)
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{audioMessage("user", "rawaudio")},
+	}
+	h := &AudioEmotionHandler{}
+	res, _ := h.Eval(ctx, evalCtx, map[string]any{
+		"model":          "superb/wav2vec2-base-superb-er",
+		"expected_label": "angry",
+		"min_score":      0.6,
+	})
+	if res.Score == nil || *res.Score >= 0.6 {
+		t.Errorf("score = %v, want < 0.6 (model returned 0.3)", res.Score)
+	}
+	// Even when the label is found but below threshold, we want the
+	// actual model score surfaced in Value so the report explains why.
+	val, _ := res.Value.(map[string]any)
+	if val["actual_score"].(float64) != 0.3 {
+		t.Errorf("actual_score = %v, want 0.3", val["actual_score"])
+	}
+}
+
+func TestAudioEmotion_FailsWhenLabelNotReturned(t *testing.T) {
+	srv := hfTestServer(t, []classify.LabelScore{
+		{Label: "happy", Score: 0.9},
+	}, false)
+	defer srv.Close()
+
+	ctx := ctxWithRegistry(t, srv.URL)
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{audioMessage("user", "rawaudio")},
+	}
+	h := &AudioEmotionHandler{}
+	res, _ := h.Eval(ctx, evalCtx, map[string]any{
+		"model":          "superb/wav2vec2-base-superb-er",
+		"expected_label": "angry",
+	})
+	if !strings.Contains(res.Explanation, "not returned by model") {
+		t.Errorf("explanation %q should call out missing label", res.Explanation)
+	}
+	if !strings.Contains(res.Explanation, "happy") {
+		t.Errorf("explanation %q should list the labels the model did return", res.Explanation)
+	}
+}
+
+func TestAudioEmotion_SkippedOnModelLoading(t *testing.T) {
+	srv := hfTestServer(t, nil, true)
+	defer srv.Close()
+
+	ctx := ctxWithRegistry(t, srv.URL)
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{audioMessage("user", "rawaudio")},
+	}
+	h := &AudioEmotionHandler{}
+	res, err := h.Eval(ctx, evalCtx, map[string]any{
+		"model":          "superb/wav2vec2-base-superb-er",
+		"expected_label": "angry",
+	})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if !res.Skipped {
+		t.Fatalf("expected skipped, got %+v", res)
+	}
+	if !strings.Contains(res.SkipReason, "loading") {
+		t.Errorf("SkipReason %q should mention loading", res.SkipReason)
+	}
+}
+
+func TestAudioEmotion_MissingModelParam(t *testing.T) {
+	ctx := classify.WithRegistry(context.Background(), classify.NewRegistry())
+	h := &AudioEmotionHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{}, map[string]any{
+		"expected_label": "angry",
+	})
+	if !strings.Contains(res.Error, "model is required") {
+		t.Errorf("error %q should mention model required", res.Error)
+	}
+}
+
+func TestAudioEmotion_MissingExpectedLabelParam(t *testing.T) {
+	ctx := classify.WithRegistry(context.Background(), classify.NewRegistry())
+	h := &AudioEmotionHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{}, map[string]any{
+		"model": "some/model",
+	})
+	if !strings.Contains(res.Error, "expected_label is required") {
+		t.Errorf("error %q should mention expected_label required", res.Error)
+	}
+}
+
+func TestAudioEmotion_NoRegistryInContext(t *testing.T) {
+	// Plain context with no classify.Registry attached. The handler must
+	// surface this as a failed eval with a helpful explanation, not as a
+	// panic or a Go error to the runner.
+	h := &AudioEmotionHandler{}
+	res, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
+		"model":          "x/y",
+		"expected_label": "angry",
+	})
+	if err != nil {
+		t.Fatalf("Eval should not return Go error; got %v", err)
+	}
+	if !strings.Contains(res.Error, "no classify registry configured") {
+		t.Errorf("error %q should point users at the missing wiring", res.Error)
+	}
+}
+
+func TestAudioEmotion_NoAudioInMessages(t *testing.T) {
+	srv := hfTestServer(t, nil, false)
+	defer srv.Close()
+
+	ctx := ctxWithRegistry(t, srv.URL)
+	textOnly := types.Message{
+		Role:  "user",
+		Parts: []types.ContentPart{{Type: types.ContentTypeText, Text: ptrString("hi")}},
+	}
+	h := &AudioEmotionHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{textOnly}}, map[string]any{
+		"model":          "x/y",
+		"expected_label": "angry",
+	})
+	if !strings.Contains(res.Error, "no audio part") {
+		t.Errorf("error %q should explain why no audio was scored", res.Error)
+	}
+}
+
+func TestAudioEmotion_MessageIndexPicksSpecificPart(t *testing.T) {
+	// Two audio messages with different scores. message_index 0 should
+	// pick the first; -1 picks the last. We test by using two scores per
+	// label tied to physical position via the body bytes (httptest
+	// server returns the same scores for any call, so verify selection
+	// indirectly by asserting we read SOME audio without erroring).
+	srv := hfTestServer(t, []classify.LabelScore{{Label: "angry", Score: 0.9}}, false)
+	defer srv.Close()
+	ctx := ctxWithRegistry(t, srv.URL)
+	msgs := []types.Message{
+		audioMessage("user", "first"),
+		audioMessage("user", "second"),
+	}
+	h := &AudioEmotionHandler{}
+	for _, idx := range []int{0, 1, -1} {
+		res, _ := h.Eval(ctx, &evals.EvalContext{Messages: msgs}, map[string]any{
+			"model":          "x/y",
+			"expected_label": "angry",
+			"message_index":  idx,
+			"min_score":      0.5,
+		})
+		if res.Error != "" {
+			t.Errorf("idx=%d unexpected error: %s", idx, res.Error)
+		}
+	}
+}
+
+func TestAudioEmotion_MessageIndexOutOfRange(t *testing.T) {
+	srv := hfTestServer(t, []classify.LabelScore{{Label: "angry", Score: 0.9}}, false)
+	defer srv.Close()
+	ctx := ctxWithRegistry(t, srv.URL)
+	h := &AudioEmotionHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{audioMessage("user", "one")}},
+		map[string]any{
+			"model":          "x/y",
+			"expected_label": "angry",
+			"message_index":  5,
+		})
+	if !strings.Contains(res.Error, "out of range") {
+		t.Errorf("error %q should explain index is out of range", res.Error)
+	}
+}
+
+func ptrString(s string) *string { return &s }

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -1606,6 +1606,9 @@ func TestRegisterInit(t *testing.T) {
 		"video_duration",
 		"video_resolution",
 
+		// Classify-backed media handlers
+		"audio_emotion",
+
 		// LLM judge handlers
 		"llm_judge",
 		"llm_judge_session",

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -68,6 +68,10 @@ func init() {
 	evals.RegisterDefault(&VideoDurationHandler{})
 	evals.RegisterDefault(&VideoResolutionHandler{})
 
+	// Classify-backed media handlers — score model output (audio emotion,
+	// text toxicity, ...) using the classify.Registry from context.
+	evals.RegisterDefault(&AudioEmotionHandler{})
+
 	// LLM judge handlers
 	evals.RegisterDefault(&LLMJudgeHandler{})
 	evals.RegisterDefault(&LLMJudgeSessionHandler{})

--- a/sdk/integration/metrics_test.go
+++ b/sdk/integration/metrics_test.go
@@ -30,11 +30,14 @@ func TestMetrics_ProviderRequestsTotal(t *testing.T) {
 	_, err := conv.Send(context.Background(), "Hello")
 	require.NoError(t, err)
 
-	// Allow async event dispatch to metrics collector.
-	waitForMetric(t, reg, "test_provider_requests_total", 2*time.Second)
+	// Wait for the {status=success} counter to land — matches the assertion
+	// below so we don't observe the half-state between WithLabelValues and Inc.
+	successLabels := map[string]string{"status": "success"}
+	waitForMetric(t, reg, "test_provider_requests_total",
+		counterReadyWithLabels(successLabels, 1), 2*time.Second)
 
 	family := mustGetMetricFamily(t, reg, "test_provider_requests_total")
-	val := counterValueWithLabels(family, map[string]string{"status": "success"})
+	val := counterValueWithLabels(family, successLabels)
 	assert.Equal(t, 1.0, val, "provider_requests_total{status=success} should be 1")
 }
 
@@ -49,7 +52,8 @@ func TestMetrics_ProviderRequestDuration(t *testing.T) {
 	_, err := conv.Send(context.Background(), "Hello")
 	require.NoError(t, err)
 
-	waitForMetric(t, reg, "test_provider_request_duration_seconds", 2*time.Second)
+	waitForMetric(t, reg, "test_provider_request_duration_seconds",
+		histogramReady(1), 2*time.Second)
 
 	family := mustGetMetricFamily(t, reg, "test_provider_request_duration_seconds")
 	assert.Greater(t, histogramCount(family), uint64(0), "should have at least one observation")
@@ -66,7 +70,13 @@ func TestMetrics_TokenCounters(t *testing.T) {
 	_, err := conv.Send(context.Background(), "Hello")
 	require.NoError(t, err)
 
-	waitForMetric(t, reg, "test_provider_input_tokens_total", 2*time.Second)
+	// Wait for BOTH token counters since the test asserts on both. The
+	// completion handler increments them back-to-back, but waiting on
+	// just one would race against the second.
+	waitForMetric(t, reg, "test_provider_input_tokens_total",
+		counterReady(1), 2*time.Second)
+	waitForMetric(t, reg, "test_provider_output_tokens_total",
+		counterReady(1), 2*time.Second)
 
 	inputFamily := mustGetMetricFamily(t, reg, "test_provider_input_tokens_total")
 	assert.Greater(t, counterValue(inputFamily), 0.0, "input tokens should be > 0")
@@ -86,7 +96,8 @@ func TestMetrics_PipelineDuration(t *testing.T) {
 	_, err := conv.Send(context.Background(), "Hello")
 	require.NoError(t, err)
 
-	waitForMetric(t, reg, "test_pipeline_duration_seconds", 2*time.Second)
+	waitForMetric(t, reg, "test_pipeline_duration_seconds",
+		histogramReady(1), 2*time.Second)
 
 	family := mustGetMetricFamily(t, reg, "test_pipeline_duration_seconds")
 	assert.Greater(t, histogramCount(family), uint64(0), "should have at least one observation")
@@ -106,10 +117,12 @@ func TestMetrics_MultipleCallsAccumulate(t *testing.T) {
 	_, err = conv.Send(ctx, "Second")
 	require.NoError(t, err)
 
-	waitForMetric(t, reg, "test_provider_requests_total", 2*time.Second)
+	successLabels := map[string]string{"status": "success"}
+	waitForMetric(t, reg, "test_provider_requests_total",
+		counterReadyWithLabels(successLabels, 2), 2*time.Second)
 
 	family := mustGetMetricFamily(t, reg, "test_provider_requests_total")
-	val := counterValueWithLabels(family, map[string]string{"status": "success"})
+	val := counterValueWithLabels(family, successLabels)
 	assert.Equal(t, 2.0, val, "provider_requests_total should be 2 after two sends")
 }
 
@@ -146,10 +159,12 @@ func TestMetrics_ToolCallsTotal(t *testing.T) {
 	_, err := conv.Send(context.Background(), "What is the weather?")
 	require.NoError(t, err)
 
-	waitForMetric(t, reg, "test_tool_calls_total", 2*time.Second)
+	successLabels := map[string]string{"tool": "get_weather", "status": "success"}
+	waitForMetric(t, reg, "test_tool_calls_total",
+		counterReadyWithLabels(successLabels, 1), 2*time.Second)
 
 	family := mustGetMetricFamily(t, reg, "test_tool_calls_total")
-	val := counterValueWithLabels(family, map[string]string{"tool": "get_weather", "status": "success"})
+	val := counterValueWithLabels(family, successLabels)
 	assert.Equal(t, 1.0, val, "tool_calls_total{tool=get_weather,status=success} should be 1")
 }
 
@@ -182,7 +197,8 @@ func TestMetrics_ToolCallDuration(t *testing.T) {
 	_, err := conv.Send(context.Background(), "Weather in Paris?")
 	require.NoError(t, err)
 
-	waitForMetric(t, reg, "test_tool_call_duration_seconds", 2*time.Second)
+	waitForMetric(t, reg, "test_tool_call_duration_seconds",
+		histogramReady(1), 2*time.Second)
 
 	family := mustGetMetricFamily(t, reg, "test_tool_call_duration_seconds")
 	assert.Greater(t, histogramCount(family), uint64(0), "should have at least one tool call duration observation")
@@ -208,7 +224,10 @@ func TestMetrics_EvalResultMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	// Eval metrics are recorded asynchronously after pipeline completes.
-	waitForMetric(t, reg, "test_eval_response_length", 3*time.Second)
+	// gaugeReady(0) waits until the gauge has been set to a positive value,
+	// not just registered (a gauge that exists with value 0 is the race we
+	// hit when only the family's appearance was being checked).
+	waitForMetric(t, reg, "test_eval_response_length", gaugeReady(0), 3*time.Second)
 
 	// Explicit metric: the pack defines response_length as a gauge.
 	lengthFam := mustGetMetricFamily(t, reg, "test_eval_response_length")
@@ -231,8 +250,10 @@ func TestMetrics_EvalResultMetrics_AutoGenerated(t *testing.T) {
 	_, err := conv.Send(context.Background(), "Hello")
 	require.NoError(t, err)
 
-	// Auto-generated metrics use the eval ID as the metric name.
-	waitForMetric(t, reg, "test_eval_check-response-length", 3*time.Second)
+	// Auto-generated metrics use the eval ID as the metric name. Wait for
+	// the gauge value > 0 directly so we don't race the auto-generation
+	// path setting it.
+	waitForMetric(t, reg, "test_eval_check-response-length", gaugeReady(0), 3*time.Second)
 
 	family := mustGetMetricFamily(t, reg, "test_eval_check-response-length")
 	assert.Greater(t, gaugeValue(family), 0.0,
@@ -265,21 +286,66 @@ const evalsPackWithMetricsJSON = `{
 	]
 }`
 
-// waitForMetric polls until the named metric appears in the registry or timeout expires.
+// waitForMetric polls reg.Gather() until the named metric family appears AND
+// the given predicate returns true, or t.Fatal's when the timeout expires.
+//
+// A predicate is required because the prometheus client's `WithLabelValues(...)`
+// materializes a child in the metric vec's children map BEFORE `.Observe(x)` /
+// `.Inc()` is called. If a concurrent `Gather()` interleaves between those two
+// operations, the family appears with the new child but its sampleCount /
+// counter value is still zero — the previous "wait until family exists"
+// pattern races with the very observation each test relies on. Passing a
+// predicate that mirrors the test's assertion (e.g. "sampleCount > 0") closes
+// that window.
+//
+// Failing on timeout (rather than silently returning, as the older shape did)
+// turns "metric never appeared" into a clear test failure instead of a
+// confusing assertion-on-zero a few lines down.
 func waitForMetric(t *testing.T, reg interface {
 	Gather() ([]*io_prometheus_client.MetricFamily, error)
-}, name string, timeout time.Duration) {
+}, name string, ready func(*io_prometheus_client.MetricFamily) bool, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		families, err := reg.Gather()
 		if err == nil {
 			for _, f := range families {
-				if f.GetName() == name {
+				if f.GetName() == name && (ready == nil || ready(f)) {
 					return
 				}
 			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	t.Fatalf("metric %q did not satisfy readiness predicate within %s", name, timeout)
+}
+
+// histogramReady returns a predicate that fires once the histogram has
+// recorded at least n observations. Used by tests that assert
+// histogramCount(family) > 0.
+func histogramReady(n uint64) func(*io_prometheus_client.MetricFamily) bool {
+	return func(f *io_prometheus_client.MetricFamily) bool { return histogramCount(f) >= n }
+}
+
+// counterReady returns a predicate that fires once the counter — summed
+// across all label sets — reaches at least v. Used by tests that compare
+// counterValue(family) to a known target.
+func counterReady(v float64) func(*io_prometheus_client.MetricFamily) bool {
+	return func(f *io_prometheus_client.MetricFamily) bool { return counterValue(f) >= v }
+}
+
+// counterReadyWithLabels returns a predicate that fires once the counter
+// child matching the given labels reaches at least v. Used by tests that
+// scope their assertion to a specific label combination.
+func counterReadyWithLabels(labels map[string]string, v float64) func(*io_prometheus_client.MetricFamily) bool {
+	return func(f *io_prometheus_client.MetricFamily) bool {
+		return counterValueWithLabels(f, labels) >= v
+	}
+}
+
+// gaugeReady returns a predicate that fires once the gauge value is > v.
+// Useful for tests asserting an eval gauge was populated (default zero
+// makes "set" indistinguishable from "unset" without a positive value).
+func gaugeReady(v float64) func(*io_prometheus_client.MetricFamily) bool {
+	return func(f *io_prometheus_client.MetricFamily) bool { return gaugeValue(f) > v }
 }


### PR DESCRIPTION
Third slice of #1214. Adds the first eval handler that consumes `runtime/classify`, plus the public docs that explain how to declare an inference provider and wire one into a scenario.

This closes the loop on the classify foundation: a user can now declare a `role: inference` provider, point `defaults.inference.audio_classifier` at it, and assert on speech-emotion-recognition output in a scenario — no Go code required.

## `audio_emotion` handler

Scores whether the audio in a chosen message contains a target emotion above a configurable threshold. Calls the `AudioClassifier` resolved from the orchestrator's classify registry, so model + backend are arena-config decisions, not handler decisions.

```yaml
conversation_assertions:
  - type: audio_emotion
    params:
      model: superb/wav2vec2-base-superb-er
      expected_label: angry
      min_score: 0.6
      # message_role: user      (default)
      # message_index: -1       (default — latest matching audio part)
      # classifier_id: ""       (default — falls back to defaults.inference.audio_classifier)
```

**Behaviour:**
- HF `ErrModelLoading` (503 after retry exhaustion) → `Skipped: true` with reason "model still loading after retries". The model isn't broken, it just hasn't warmed up.
- Missing registry / missing classifier / missing params / no audio in messages → failed eval with `Error` explanation. Eval handlers that return Go errors short-circuit the batch; we'd rather let sibling evals run and surface this one cleanly.
- URL / storage-reference media sources currently unsupported (surface clear error); base64 inline + local file path work.

## Docs

- New **"Inference Providers"** subsection in `arena/how-to/configure-providers.md` — full HF YAML, `defaults.inference` block, scenario showing `audio_emotion` consuming both. Dedicated-endpoint variant included.
- `concepts/providers.md` gains a **"Provider Roles"** section enumerating every role and linking to the inference how-to.
- `glossary.md` gains an **"Inference Provider"** entry.

## Test plan

- [x] 10 new handler tests covering pass / fail above & below threshold, missing label in model output, model-loading skip path, missing required params, no registry in context, no audio in messages, `message_index` selection, `message_index` out of range. All use an httptest HF server — no network, no `HF_TOKEN`.
- [x] `handlers_test.go` expected-types list updated.
- [x] `go test -race ./runtime/evals/handlers/...` green.
- [x] Coverage: `audio_emotion.go` 89.1%.

Refs: #1214
