### PR TITLE
docs(classify): scope embedder as a convenience, not a migration path

### DIFF
--- a/runtime/classify/types.go
+++ b/runtime/classify/types.go
@@ -1,12 +1,27 @@
 // Package classify defines task-oriented inference interfaces for
-// non-LLM workloads — audio / text / image / video classifiers and
-// embedders. Backends (HuggingFace Inference API, ONNX, Replicate, …)
-// implement one or more of these; eval handlers depend on the task
-// interface, never on the backend.
+// non-LLM workloads. The primary surface is classifier interfaces —
+// audio / text / image / video — that each take input bytes and
+// return []LabelScore (categorical, ranked by confidence). Backends
+// (HuggingFace Inference API, ONNX, Replicate, …) implement one or
+// more of these; eval handlers depend on the task interface, never
+// on the backend.
 //
 // Parallel to runtime/tts and runtime/stt: each is a task interface
 // with multiple backends behind it. runtime/providers handles chat
-// completion (Predict); classify covers the rest.
+// completion (Predict); classify covers classification.
+//
+// Embedder lives here for convenience — the HuggingFace Inference
+// API exposes embedding (feature-extraction) models through the same
+// endpoint family as classification models, so the HF backend
+// satisfies Embedder as a side effect. It is NOT the canonical home
+// for embedding providers. OpenAI, VoyageAI, and similar dedicated
+// embedding APIs continue to register under `role: embedding` via
+// the runtime/providers Embed() interface; cosine-similarity-style
+// handlers depend on that path. Future embedder backends that
+// happen to live in runtime/classify (e.g. an HF-hosted embedding
+// model) are bridged into the same handler path via adapters, not
+// by relocating providers. Treat Embedder here as a convenience
+// surface, not a migration target.
 package classify
 
 // LabelScore pairs a classifier label with a confidence score in


### PR DESCRIPTION
Aligns the `runtime/classify` package doc with the decision to drop "Embedder migration" from the #1214 roadmap.

## What changed

Updated the package doc on `runtime/classify/types.go` to explicitly call out that:

- The package's primary surface is classifier interfaces (audio / text / image / video → `[]LabelScore`).
- `Embedder` lives here because the HuggingFace Inference API serves classification and feature-extraction models from the same endpoint family, so the HF backend satisfies it as a side effect.
- The canonical home for embedding providers remains `runtime/providers` with `role: embedding`; `CosineSimilarityHandler` and similar handlers stay on that path.
- New embedder backends shouldn't be added to `runtime/classify` — bridge with adapters if needed.

## Why

`Embedder.Embed(strings) → vectors` is a different shape from `Classify*(bytes) → []LabelScore`. They share a package only because of HF's API convenience, not because the abstraction belongs there. Without this note, future contributors might mistake the presence of `Embedder` in `classify` for endorsement of moving OpenAI / VoyageAI / etc. there too.

## Out of scope

- Removing `classify.Embedder` or `HF.Embed`. They were shipped in #1215 and any consumer wanting an HF-hosted embedding model can use them. This PR is doc-only.

Refs: #1214
