### PR TITLE
refactor(evals): route audio_emotion infrastructure absence as Skipped

### DIFF
--- a/runtime/evals/handlers/audio_emotion.go
+++ b/runtime/evals/handlers/audio_emotion.go
@@ -47,6 +47,20 @@ func (h *AudioEmotionHandler) Type() string { return "audio_emotion" }
 // Eval pulls the AudioClassifier out of context, locates the target audio
 // part in the conversation, runs classification, and grades the requested
 // label against the configured threshold.
+//
+// Skipped vs Error distinction:
+//   - Skipped — the assertion couldn't run because preconditions weren't met.
+//     Used for infrastructure absence: no classify registry configured (e.g.
+//     CI runs without HF_TOKEN), no audio parts in the message log (e.g. a
+//     mock provider that doesn't emit audio), or HF returned ErrModelLoading.
+//     These are configuration / environment shapes, not assertion failures.
+//   - Error — the assertion is misconfigured at the call site (missing
+//     required param) or the classifier call failed at runtime. The user
+//     should fix something.
+//
+// The split lets a single arena config sit happily under both real-provider
+// runs (assertion exercises a real model) and keyless CI runs (assertion
+// skips cleanly) without needing per-environment scenario forks.
 func (h *AudioEmotionHandler) Eval(
 	ctx context.Context, evalCtx *evals.EvalContext, params map[string]any,
 ) (*evals.EvalResult, error) {
@@ -57,11 +71,21 @@ func (h *AudioEmotionHandler) Eval(
 
 	classifier, classifierErr := resolveAudioClassifier(ctx, cfg.classifierID)
 	if classifierErr != nil {
-		return errorResult(h.Type(), classifierErr.Error()), nil
+		return skippedResult(h.Type(), classifierErr.Error()), nil
 	}
 
-	media, partErr := findAudioMessageMedia(evalCtx.Messages, cfg.messageRole, cfg.messageIndex)
+	audioParts := collectAudioPartsByRole(evalCtx.Messages, cfg.messageRole)
+	if len(audioParts) == 0 {
+		// No audio at all in the chosen role's turns is an infrastructure
+		// shape (mock provider, text-only scenario), not a config error.
+		return skippedResult(h.Type(),
+			fmt.Sprintf("no audio part found with role %q", cfg.messageRole)), nil
+	}
+	media, partErr := pickAudioPart(audioParts, cfg.messageIndex)
 	if partErr != nil {
+		// Audio exists but the user picked a specific index that's out of
+		// range — that's a misconfiguration at the assertion call site,
+		// not an environmental absence. Fail with a clear message.
 		return errorResult(h.Type(), partErr.Error()), nil
 	}
 
@@ -77,17 +101,25 @@ func (h *AudioEmotionHandler) Eval(
 	scores, classifyErr := classifier.ClassifyAudio(ctx, audioBytes, opts)
 	if classifyErr != nil {
 		if errors.Is(classifyErr, classifyhf.ErrModelLoading) {
-			return &evals.EvalResult{
-				Type:       h.Type(),
-				Score:      boolScore(true),
-				Skipped:    true,
-				SkipReason: "model still loading after retries",
-			}, nil
+			return skippedResult(h.Type(), "model still loading after retries"), nil
 		}
 		return errorResult(h.Type(), fmt.Sprintf("classify failed: %v", classifyErr)), nil
 	}
 
 	return gradeAudioEmotion(h.Type(), &cfg, scores), nil
+}
+
+// skippedResult builds an EvalResult that records "didn't run, didn't fail"
+// — the SkipReason carries the actual cause so reports can show it. Score is
+// set to a pass-shaped boolean so any downstream consumer that pre-filters
+// on Score-passes treats skipped as non-failing.
+func skippedResult(handlerType, reason string) *evals.EvalResult {
+	return &evals.EvalResult{
+		Type:       handlerType,
+		Score:      boolScore(true),
+		Skipped:    true,
+		SkipReason: reason,
+	}
 }
 
 // audioEmotionConfig holds the validated params after parsing. Keeping it
@@ -151,21 +183,17 @@ func resolveAudioClassifier(ctx context.Context, id string) (classify.AudioClass
 	return reg.AudioClassifier(id)
 }
 
-// findAudioMessageMedia locates the audio part the handler should classify.
-// Walks messages in reverse so message_index = -1 picks the most recent.
-// Non-negative indices count forward through audio parts of the matching
-// role.
-func findAudioMessageMedia(messages []types.Message, role string, index int) (*types.MediaContent, error) {
-	audioParts := collectAudioPartsByRole(messages, role)
-	if len(audioParts) == 0 {
-		return nil, fmt.Errorf("no audio part found with role %q", role)
-	}
+// pickAudioPart selects one part from a non-empty slice of audio parts. A
+// negative index picks the most recent (-1 → last). Caller is responsible
+// for the empty-slice case so the absence-vs-out-of-range distinction can
+// be surfaced at the right semantic level (Skipped vs Error).
+func pickAudioPart(audioParts []*types.MediaContent, index int) (*types.MediaContent, error) {
 	if index < 0 {
 		return audioParts[len(audioParts)-1], nil
 	}
 	if index >= len(audioParts) {
-		return nil, fmt.Errorf("message_index %d out of range (found %d audio parts with role %q)",
-			index, len(audioParts), role)
+		return nil, fmt.Errorf("message_index %d out of range (found %d audio parts)",
+			index, len(audioParts))
 	}
 	return audioParts[index], nil
 }

--- a/runtime/evals/handlers/audio_emotion_test.go
+++ b/runtime/evals/handlers/audio_emotion_test.go
@@ -196,9 +196,11 @@ func TestAudioEmotion_MissingExpectedLabelParam(t *testing.T) {
 }
 
 func TestAudioEmotion_NoRegistryInContext(t *testing.T) {
-	// Plain context with no classify.Registry attached. The handler must
-	// surface this as a failed eval with a helpful explanation, not as a
-	// panic or a Go error to the runner.
+	// Plain context with no classify.Registry attached. Infrastructure
+	// absence (no inference provider declared) is Skipped — the assertion
+	// couldn't run, but nothing is broken. This is the keyless-CI path:
+	// the demo declares an HF provider but HF_TOKEN isn't set, so the
+	// engine never populates the registry, and the assertion skips.
 	h := &AudioEmotionHandler{}
 	res, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
 		"model":          "x/y",
@@ -207,8 +209,11 @@ func TestAudioEmotion_NoRegistryInContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Eval should not return Go error; got %v", err)
 	}
-	if !strings.Contains(res.Error, "no classify registry configured") {
-		t.Errorf("error %q should point users at the missing wiring", res.Error)
+	if !res.Skipped {
+		t.Fatalf("expected Skipped when no registry; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "no classify registry configured") {
+		t.Errorf("SkipReason %q should point users at the missing wiring", res.SkipReason)
 	}
 }
 
@@ -226,8 +231,14 @@ func TestAudioEmotion_NoAudioInMessages(t *testing.T) {
 		"model":          "x/y",
 		"expected_label": "angry",
 	})
-	if !strings.Contains(res.Error, "no audio part") {
-		t.Errorf("error %q should explain why no audio was scored", res.Error)
+	// Mock providers without audio output (or scenarios where the chosen
+	// role never speaks) should skip cleanly. The user can still see WHY
+	// via SkipReason.
+	if !res.Skipped {
+		t.Fatalf("expected Skipped when no audio in messages; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "no audio part") {
+		t.Errorf("SkipReason %q should explain why no audio was scored", res.SkipReason)
 	}
 }
 


### PR DESCRIPTION
Prep for the voice-refund-demo SER assertion. The audio_emotion handler previously returned `Error` for three distinct conditions:

1. No `classify.Registry` attached to context
2. Classifier id not found in the registry
3. No audio part in the message log for the chosen role

Conflating these with real misconfigurations (missing required params, transient classify call failures) makes it hard for the same scenario to behave well across both "real provider with `HF_TOKEN`" and "keyless CI" runs — the latter would always surface as red.

## Result-space split

| Outcome | When |
|---|---|
| **Skipped** | Infrastructure absence: no registry, no classifier id, no audio in messages, HF `ErrModelLoading`. `SkipReason` carries the cause. |
| **Error** | Misconfiguration at the call site (missing `model` / `expected_label`), out-of-range `message_index`, or classifier call failure at runtime. |

Also split `findAudioMessageMedia` into `collectAudioPartsByRole` + `pickAudioPart` so the caller routes "no audio at all" (Skipped) separately from "out-of-range message_index" (Error — user asked for a specific index that doesn't exist).

## Why this is its own PR

The next item on the roadmap is wiring `audio_emotion` into the voice-refund-demo aggressive scenario. With this routing, that scenario can declare the assertion unconditionally and it'll skip cleanly in keyless CI runs while exercising the real model when `HF_TOKEN` is set — no per-environment scenario forks needed.

That demo PR is **blocked on a release**: it needs `role: inference` and the `audio_emotion` shape live in the published schemas, which today are still on whatever the last tag was. This handler refactor has no schema dependency, so it ships independently and unblocks the demo PR the moment the next release is out.

## Test plan

- [x] 10 existing audio_emotion tests updated to reflect the new routing — no-registry / no-audio cases now assert `Skipped` + `SkipReason`, out-of-range still asserts `Error`.
- [x] `go test -race ./runtime/evals/handlers/...` green.
- [x] Lint clean.

Refs: #1214
