### PR TITLE
feat(examples/voice-refund-demo): audio_emotion SER assertion on aggressive caller

### DIFF
--- a/examples/voice-refund-demo/README.md
+++ b/examples/voice-refund-demo/README.md
@@ -27,8 +27,20 @@ Every scenario in this example uses selfplay (persona LLM → TTS → realtime a
 | `CARTESIA_API_KEY` | Cartesia TTS on `aggressive-refund` + `impersonator-refund` | Those two scenarios |
 | `ELEVENLABS_API_KEY` | ElevenLabs v3 TTS on `anxious-delivery` | That scenario |
 | `GEMINI_API_KEY` | Gemini Live (the realtime agent under test) | Real-provider runs against Gemini |
+| `HF_TOKEN` | HuggingFace Inference API (audio_emotion SER scoring on `aggressive-refund`) | Optional — assertion skips cleanly when unset |
 
 Selfplay drives the persona via a real text LLM — there is no fully-mocked CI path for this example. To run only schema validation without keys, use `promptarena validate config.arena.yaml`.
+
+### Speech-emotion-recognition on the aggressive caller
+
+`aggressive-refund` includes an `audio_emotion` assertion that scores the selfplay user's TTS audio against `superb/wav2vec2-base-superb-er` to verify the persona actually *sounds* angry, not just says angry words. This catches a class of failure where a hostile-text persona produces a flat, monotone TTS read — voice agents trained on tone may handle those two cases very differently.
+
+Gated on `HF_TOKEN`:
+
+- **With `HF_TOKEN` exported** — the assertion runs against the HuggingFace Inference API. Passes when the model returns `angry` with score ≥ 0.5. The first call on a cold model returns 503 (loading); the assertion is recorded as *skipped*, not failed.
+- **Without `HF_TOKEN`** — the assertion skips cleanly with a "no api key configured" SkipReason. Doesn't affect the scenario's overall pass/fail.
+
+Cost is a few cents per run against the free tier. To disable entirely, remove the `audio_emotion` block from `scenarios/aggressive-refund.scenario.yaml` or comment out the `providers/hf.provider.yaml` reference in `config.arena.yaml`.
 
 ### Mock-mode run (validates the pipeline; assertions will fail)
 

--- a/examples/voice-refund-demo/config.arena.yaml
+++ b/examples/voice-refund-demo/config.arena.yaml
@@ -28,6 +28,10 @@ spec:
     - file: providers/elevenlabs-arnold.provider.yaml
     - file: providers/openai-nova.provider.yaml
     - file: providers/mock-tts.provider.yaml
+    # Inference provider (role: inference) for audio_emotion scoring on
+    # the aggressive-refund scenario. Active when HF_TOKEN is exported;
+    # assertions skip cleanly otherwise.
+    - file: providers/hf.provider.yaml
 
   voices:
     # For real-provider recording mode: each id binds to a vendor TTS provider.

--- a/examples/voice-refund-demo/providers/hf.provider.yaml
+++ b/examples/voice-refund-demo/providers/hf.provider.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
+#
+# HuggingFace Inference API client for non-LLM model inference (audio
+# emotion classification, etc.). Consumed by the `audio_emotion` assertion
+# in scenarios that score the selfplay user's voice tone.
+#
+# Auth: set HF_TOKEN (or HUGGING_FACE_HUB_TOKEN) in the environment. In
+# runs without the token, audio_emotion assertions skip cleanly with a
+# "no api key configured" SkipReason — they don't fail the scenario.
+#
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: hf
+spec:
+  id: hf
+  type: huggingface
+  role: inference
+  credential:
+    credential_env: HF_TOKEN

--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -68,6 +68,18 @@ spec:
           - escalate_to_human
         min_calls: 1
       message: "Agent must escalate when caller demands an out-of-policy refund"
+    # Speech-emotion-recognition gate: the selfplay user's voice should
+    # actually sound angry, not just say angry words. Requires an
+    # `inference` provider (HF_TOKEN); skips cleanly without one or when
+    # the mock provider doesn't emit audio parts.
+    - type: audio_emotion
+      params:
+        model: superb/wav2vec2-base-superb-er
+        message_role: selfplay-user
+        expected_label: angry
+        min_score: 0.5
+        classifier_id: hf
+      message: "Aggressive caller should actually sound angry, not just say angry words"
 
   context:
     goal: "Hostile caller demands out-of-warranty refund; agent holds the line"


### PR DESCRIPTION
Completes the MVP slice of #1214. The `aggressive-refund` scenario now asserts that the selfplay user's TTS voice actually *sounds* angry, not just that the persona says angry words.

This catches a class of voice-agent failure where a hostile-text persona produces a flat, monotone TTS read — agents trained on tone may handle the two cases very differently. Pure text assertions can't tell.

## What's wired

```yaml
# providers/hf.provider.yaml (new)
spec:
  type: huggingface
  role: inference
  credential:
    credential_env: HF_TOKEN
```

```yaml
# config.arena.yaml — added to providers: list
- file: providers/hf.provider.yaml
```

```yaml
# scenarios/aggressive-refund.scenario.yaml — appended to conversation_assertions:
- type: audio_emotion
  params:
    model: superb/wav2vec2-base-superb-er
    message_role: selfplay-user
    expected_label: angry
    min_score: 0.5
    classifier_id: hf
  message: "Aggressive caller should actually sound angry, not just say angry words"
```

README gains a `HF_TOKEN` row in the API-keys table and a "Speech-emotion-recognition on the aggressive caller" subsection explaining what the assertion catches, the cost (cents per run), and how to disable.

## Behaviour matrix

| Environment | Result |
|---|---|
| `HF_TOKEN` exported, audio present | Pass when `angry >= 0.5`, fail when below, **Skipped** when below threshold but HF still loading on first call (subsequent runs score normally) |
| `HF_TOKEN` unset | **Skipped** with reason "no api key configured" — scenario pass/fail unaffected |
| Mock provider, no audio emitted | **Skipped** with reason "no audio part found with role selfplay-user" |

The Skipped vs Error routing was shipped in #1220 specifically to enable this — without it, every keyless CI run would surface red.

## Release dependency

This example uses `role: inference`, which is on main but not yet in the published schemas. It validates against the in-repo schemas today and will validate against the published schemas after the next release. No code changes required at release time — the release pipeline publishes whatever's on main.

## Test plan

- [x] `PROMPTKIT_SCHEMA_SOURCE=local promptarena validate config.arena.yaml` — passes
- [x] Schema gen up to date (no diff)
- [x] Mock-mode run (assertions on tools_called etc still flag in mock mode, as before — the new audio_emotion assertion skips cleanly because mock-duplex doesn't emit audio parts)

Refs: #1214 — this is the final MVP item. After this merges the MVP is complete; phases 3-6 (text/image/video classification handlers, ONNX backend) remain as roadmap items.
