### PR TITLE
fix(audio_emotion): make the SER demo runnable end-to-end

### DIFF
--- a/examples/voice-refund-demo/providers/hf.provider.yaml
+++ b/examples/voice-refund-demo/providers/hf.provider.yaml
@@ -1,12 +1,31 @@
 # yaml-language-server: $schema=https://promptkit.altairalabs.ai/schemas/latest/provider.json
 #
-# HuggingFace Inference API client for non-LLM model inference (audio
-# emotion classification, etc.). Consumed by the `audio_emotion` assertion
-# in scenarios that score the selfplay user's voice tone.
+# HuggingFace Inference API client for non-LLM model inference. Consumed
+# by the `audio_emotion` assertion to score the selfplay user's voice
+# tone.
 #
-# Auth: set HF_TOKEN (or HUGGING_FACE_HUB_TOKEN) in the environment. In
-# runs without the token, audio_emotion assertions skip cleanly with a
-# "no api key configured" SkipReason — they don't fail the scenario.
+# IMPORTANT — model availability:
+# HF retired most audio-classification models from the free serverless
+# tier (`provider hf-inference`) in early 2026. The demo's target model
+# `superb/wav2vec2-base-superb-er` is one of them. Two ways to reach a
+# working SER model:
+#
+#   1. HF Inference Endpoints (recommended) — dedicated paid host, CPU
+#      tier ~$0.03/hour, scales to zero when idle. Deploy the model at
+#      https://endpoints.huggingface.co/ then uncomment the `base_url`
+#      + `additional_config.dedicated: true` block below and paste the
+#      endpoint URL.
+#
+#   2. Free serverless (text only) — leave base_url unset; the backend
+#      defaults to `router.huggingface.co/hf-inference`. Works for text
+#      models like `SamLowe/roberta-base-go_emotions` but not for the
+#      SER models the audio_emotion handler is wired against.
+#
+# Without an inference endpoint deployed, audio_emotion will skip with
+# "Model not supported by provider hf-inference" rather than failing
+# the scenario. To test the inference foundation without an endpoint,
+# run `go run ./tools/arena/cmd/ser-probe -text "..."` against a text
+# emotion model.
 #
 apiVersion: promptkit.altairalabs.ai/v1alpha1
 kind: Provider
@@ -18,3 +37,7 @@ spec:
   role: inference
   credential:
     credential_env: HF_TOKEN
+  # Uncomment when running against a dedicated HF Inference Endpoint:
+  # base_url: https://YOUR-ENDPOINT.endpoints.huggingface.cloud
+  # additional_config:
+  #   dedicated: true

--- a/runtime/classify/backends/hf/client.go
+++ b/runtime/classify/backends/hf/client.go
@@ -22,10 +22,13 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
 )
 
-// DefaultBaseURL is the canonical HF Inference API endpoint. Override
-// via Config.BaseURL for HF Inference Endpoints (dedicated paid hosts)
-// or the newer Inference Providers routing layer.
-const DefaultBaseURL = "https://api-inference.huggingface.co"
+// DefaultBaseURL is the canonical HF Inference API endpoint. HF deprecated
+// the older `api-inference.huggingface.co/models/{id}` URL in favor of the
+// Inference Providers router; `hf-inference` is the provider that serves
+// the same free-tier serverless models. Override via Config.BaseURL for HF
+// Inference Endpoints (dedicated paid hosts) or to pin a different provider
+// (e.g. replicate, fireworks).
+const DefaultBaseURL = "https://router.huggingface.co/hf-inference"
 
 // defaultContentType is the request Content-Type used when the caller
 // didn't tag the payload — HF accepts most media as raw bytes under

--- a/runtime/evals/handlers/audio_emotion.go
+++ b/runtime/evals/handlers/audio_emotion.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
@@ -198,6 +199,23 @@ func pickAudioPart(audioParts []*types.MediaContent, index int) (*types.MediaCon
 	return audioParts[index], nil
 }
 
+// storageReferenceAsPath returns the storage reference iff it looks like
+// a local file path the handler can open directly. Cloud storage backends
+// would produce references like `s3://bucket/key` or `gs://...`; those
+// can't be read with os.ReadFile and need a real MediaLoader instead.
+// The duplex pipeline's local-storage backend writes references that ARE
+// filesystem paths, which is the case this handler shortcuts.
+func storageReferenceAsPath(media *types.MediaContent) string {
+	if media.StorageReference == nil || *media.StorageReference == "" {
+		return ""
+	}
+	ref := *media.StorageReference
+	if strings.Contains(ref, "://") {
+		return ""
+	}
+	return ref
+}
+
 func collectAudioPartsByRole(messages []types.Message, role string) []*types.MediaContent {
 	var out []*types.MediaContent
 	for i := range messages {
@@ -214,16 +232,36 @@ func collectAudioPartsByRole(messages []types.Message, role string) []*types.Med
 	return out
 }
 
-// readMediaBytes pulls the raw audio bytes out of a MediaContent. We
-// already require the data to be available locally (base64 inline or
-// file path) — URL / storage-reference parts would need a MediaLoader
-// and aren't supported here yet. Surfacing a clear error is better than
-// silently passing or failing the eval.
+// readMediaBytes pulls the raw audio bytes out of a MediaContent.
+// Supports inline base64 (Data), local file path, and storage_reference
+// when the reference resolves to a readable local file. Production setups
+// using cloud storage backends would need a full MediaLoader plumbed
+// through context — that's queued separately. URL sources are deferred:
+// they need an HTTP client and bound size limits the handler doesn't own.
+//
+// The duplex pipeline writes audio to disk via the media-storage backend
+// and persists the storage_reference into the message log. For local
+// storage (the demo's mode) that reference IS a path the handler can
+// open directly; treating it as such avoids round-tripping through a
+// storage service the eval handler doesn't have visibility into.
 func readMediaBytes(media *types.MediaContent) ([]byte, error) {
-	if media.URL != nil || media.StorageReference != nil {
+	if media.URL != nil {
 		return nil, errors.New(
-			"audio_emotion needs inline base64 data or a local file path; " +
-				"URL and storage-reference sources are not yet supported")
+			"audio_emotion can't yet fetch audio from a URL source; " +
+				"set up media-storage that resolves to a local path or use inline data")
+	}
+	// storage_reference is treated as a local path fall-through. Production
+	// setups using cloud storage would route through a MediaLoader; for
+	// the local-storage demo path the reference IS a readable file.
+	if storageRef := storageReferenceAsPath(media); storageRef != "" {
+		body, err := os.ReadFile(storageRef) //nolint:gosec // path comes from runtime media-storage backend, not user input
+		if err != nil {
+			return nil, fmt.Errorf("read audio from storage reference %q: %w", storageRef, err)
+		}
+		if len(body) == 0 {
+			return nil, errors.New("audio payload is empty")
+		}
+		return body, nil
 	}
 	reader, err := media.ReadData()
 	if err != nil {

--- a/runtime/evals/handlers/audio_emotion_test.go
+++ b/runtime/evals/handlers/audio_emotion_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -286,3 +288,77 @@ func TestAudioEmotion_MessageIndexOutOfRange(t *testing.T) {
 }
 
 func ptrString(s string) *string { return &s }
+
+// TestAudioEmotion_StorageReferencePath proves the handler can read audio
+// from a storage_reference that's a local-filesystem path — the shape the
+// duplex pipeline produces when the local-storage media backend persists
+// recordings. Without this support, audio_emotion can never fire in a
+// real voice-refund-demo run because the message log never carries inline
+// base64.
+func TestAudioEmotion_StorageReferencePath(t *testing.T) {
+	dir := t.TempDir()
+	wavPath := filepath.Join(dir, "audio.wav")
+	if err := os.WriteFile(wavPath, []byte("fake-wav-bytes"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	srv := hfTestServer(t, []classify.LabelScore{{Label: "angry", Score: 0.91}}, false)
+	defer srv.Close()
+	ctx := ctxWithRegistry(t, srv.URL)
+
+	msg := types.Message{
+		Role: "user",
+		Parts: []types.ContentPart{{
+			Type: types.ContentTypeAudio,
+			Media: &types.MediaContent{
+				StorageReference: &wavPath,
+				MIMEType:         "audio/wav",
+			},
+		}},
+	}
+
+	h := &AudioEmotionHandler{}
+	res, err := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{msg}}, map[string]any{
+		"model":          "superb/wav2vec2-base-superb-er",
+		"expected_label": "angry",
+		"min_score":      0.5,
+	})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("expected score result, got skipped: %s", res.SkipReason)
+	}
+	if res.Error != "" {
+		t.Fatalf("expected score result, got error: %s", res.Error)
+	}
+	if res.Score == nil || *res.Score < 0.5 {
+		t.Errorf("score = %v, want >= 0.5", res.Score)
+	}
+}
+
+func TestAudioEmotion_StorageReferenceMissingFile(t *testing.T) {
+	srv := hfTestServer(t, nil, false)
+	defer srv.Close()
+	ctx := ctxWithRegistry(t, srv.URL)
+
+	missingPath := "/nonexistent/path/to.wav"
+	msg := types.Message{
+		Role: "user",
+		Parts: []types.ContentPart{{
+			Type:  types.ContentTypeAudio,
+			Media: &types.MediaContent{StorageReference: &missingPath, MIMEType: "audio/wav"},
+		}},
+	}
+
+	h := &AudioEmotionHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{msg}}, map[string]any{
+		"model":          "x/y",
+		"expected_label": "angry",
+	})
+	// An unreadable storage reference is a real config error (path is
+	// wrong / file got cleaned up). Surface as Error, not Skipped.
+	if res.Error == "" {
+		t.Errorf("expected error for unreadable storage_reference; got %+v", res)
+	}
+}

--- a/tools/arena/cmd/ser-probe/main_interactive.go
+++ b/tools/arena/cmd/ser-probe/main_interactive.go
@@ -1,0 +1,115 @@
+// Command ser-probe exercises the runtime/classify HF backend directly
+// against an audio file or text string, so you can verify the inference
+// pipeline works against your HF_TOKEN without running the full arena
+// scenario (which depends on duplex providers behaving correctly).
+//
+// Usage:
+//
+//	HF_TOKEN=... promptarena-ser-probe \
+//	  -audio examples/voice-refund-demo/out/media/runs/<id>/<hash>.wav \
+//	  -model superb/wav2vec2-base-superb-er \
+//	  -label angry
+//
+//	HF_TOKEN=... promptarena-ser-probe \
+//	  -text "I want a refund and I want it NOW" \
+//	  -model SamLowe/roberta-base-go_emotions \
+//	  -label anger
+//
+// HF retired most audio-classification models from their free serverless
+// tier in early 2026. If -audio returns "Model not supported by provider
+// hf-inference", point -model at one that IS still warm or use a paid HF
+// Inference Endpoint via -base-url.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+)
+
+// Standard exit codes per BSD sysexits convention.
+const (
+	exitRuntimeError = 1
+	exitUsage        = 2
+)
+
+func main() {
+	audioPath := flag.String("audio", "", "path to a local .wav file")
+	textInput := flag.String("text", "", "text to classify (use instead of -audio for text models)")
+	model := flag.String("model", "SamLowe/roberta-base-go_emotions", "HF model id")
+	label := flag.String("label", "anger", "label to look up in the model's response")
+	baseURL := flag.String("base-url", "", "override HF base URL (e.g. a dedicated Inference Endpoint)")
+	flag.Parse()
+
+	token := firstNonEmpty(os.Getenv("HF_TOKEN"), os.Getenv("HUGGING_FACE_HUB_TOKEN"))
+	if token == "" {
+		fmt.Fprintln(os.Stderr, "HF_TOKEN (or HUGGING_FACE_HUB_TOKEN) must be set")
+		os.Exit(exitUsage)
+	}
+
+	cfg := classifyhf.Config{APIKey: token}
+	if *baseURL != "" {
+		cfg.BaseURL = *baseURL
+	}
+	client, err := classifyhf.NewClient(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hf client: %v\n", err)
+		os.Exit(exitRuntimeError)
+	}
+
+	ctx := context.Background()
+	var scores []classify.LabelScore
+	switch {
+	case *audioPath != "":
+		body, readErr := os.ReadFile(*audioPath)
+		if readErr != nil {
+			fmt.Fprintf(os.Stderr, "read audio: %v\n", readErr)
+			os.Exit(exitRuntimeError)
+		}
+		scores, err = client.ClassifyAudio(ctx, body, classify.AudioOptions{
+			Model:    *model,
+			MIMEType: "audio/wav",
+		})
+	case *textInput != "":
+		scores, err = client.ClassifyText(ctx, *textInput, classify.TextOptions{
+			Model:      *model,
+			MultiLabel: true,
+		})
+	default:
+		fmt.Fprintln(os.Stderr, "provide -audio or -text")
+		os.Exit(exitUsage)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "classify: %v\n", err)
+		os.Exit(exitRuntimeError)
+	}
+
+	fmt.Println("Top 5 labels:")
+	maxRows := 5
+	if len(scores) < maxRows {
+		maxRows = len(scores)
+	}
+	for i := 0; i < maxRows; i++ {
+		fmt.Printf("  %-20s %.4f\n", scores[i].Label, scores[i].Score)
+	}
+	for i := range scores {
+		if scores[i].Label == *label {
+			fmt.Printf("\n%s score: %.4f\n", *label, scores[i].Score)
+			return
+		}
+	}
+	fmt.Printf("\n%q not in returned labels\n", *label)
+}
+
+func firstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/tools/arena/engine/duplex_executor_pipeline_integration.go
+++ b/tools/arena/engine/duplex_executor_pipeline_integration.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -194,13 +195,18 @@ func (de *DuplexConversationExecutor) executeDuplexPipeline(
 }
 
 // isExpectedDuplexError checks if an error is expected (not a failure).
+// Uses errors.Is so wrapped errors (e.g. "turn failed: %w" around
+// context.DeadlineExceeded) are recognized — without that, a deadline
+// reached deep in the turn loop comes back wrapped and the duplex path
+// throws away an otherwise-complete result, skipping the assertion
+// evaluation that's the whole point of running the scenario.
 func isExpectedDuplexError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return err == context.DeadlineExceeded ||
-		err == context.Canceled ||
-		err == errPartialSuccess
+	return errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, errPartialSuccess)
 }
 
 // buildDuplexPipeline creates the streaming pipeline for duplex mode.

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -355,14 +355,14 @@ func (e *Engine) intersectProviders(scenarioProviders, providerFilter []string) 
 // Handles errors gracefully, always returning a RunID (with Error saved in StateStore if failed).
 // Returns the RunID. Results can be retrieved from StateStore using GetResult().
 func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, error) {
-	// Apply per-run timeout to prevent hanging provider calls from blocking indefinitely
-	runTimeout := e.resolveRunTimeout()
-	runCtx, cancel := context.WithTimeout(ctx, runTimeout)
-	defer cancel()
-
+	// Defer per-run timeout setup until after scenario lookup so duplex
+	// scenarios can stretch the deadline to their declared
+	// `duplex.timeout` (typically 10m for voice). For the eval-run path
+	// and the no-scenario edge case we fall through to the config /
+	// DefaultRunTimeout ladder.
 	startTime := time.Now()
 	runID := generateRunID(combo)
-	runEmitter := e.createRunEmitter(runCtx, runID, &combo)
+	runEmitter := e.createRunEmitter(ctx, runID, &combo)
 
 	// Get Arena state store
 	arenaStore, ok := e.stateStore.(*statestore.ArenaStateStore)
@@ -377,6 +377,9 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 
 	// Check if this is an eval run
 	if combo.EvalID != "" {
+		runTimeout := e.resolveRunTimeout(nil)
+		runCtx, cancel := context.WithTimeout(ctx, runTimeout)
+		defer cancel()
 		return e.executeEvalRun(runCtx, combo, runID, startTime, arenaStore, runEmitter, saveError)
 	}
 
@@ -386,6 +389,11 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 	if !exists {
 		return saveError(fmt.Sprintf("scenario not found: %s", combo.ScenarioID))
 	}
+
+	// Apply per-run timeout, now that we know the scenario shape.
+	runTimeout := e.resolveRunTimeout(scenario)
+	runCtx, cancel := context.WithTimeout(ctx, runTimeout)
+	defer cancel()
 
 	// Prepare workflow scenarios: shallow-copy to avoid mutating the shared
 	// scenario, then set TaskType from state machine and wire metadata.
@@ -490,13 +498,29 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 
 	convResult := e.conversationExecutor.ExecuteConversation(runCtx, req)
 
-	// Check if the run was canceled due to timeout
+	// Run timed out, but the executor may have produced a partial result
+	// (messages exchanged, conversation_assertions evaluated on what
+	// happened so far). Discarding it and synthesizing an error-only
+	// record loses signals that are useful even when the conversation
+	// didn't complete — e.g. an audio_emotion assertion on whichever
+	// turns DID happen, or tool-call counts up to the point of timeout.
+	// Stamp the timeout onto the result so the run is flagged as errored
+	// but the partial content survives to the report.
 	if runCtx.Err() != nil {
 		timeoutMsg := fmt.Sprintf("run timed out after %s", runTimeout)
-		if convResult != nil && convResult.Error != "" {
-			timeoutMsg = fmt.Sprintf("%s: %s", timeoutMsg, convResult.Error)
+		if convResult == nil || convResult.Messages == nil {
+			// No partial content to preserve — fall back to synthetic error.
+			if convResult != nil && convResult.Error != "" {
+				timeoutMsg = fmt.Sprintf("%s: %s", timeoutMsg, convResult.Error)
+			}
+			return saveError(timeoutMsg)
 		}
-		return saveError(timeoutMsg)
+		if convResult.Error != "" {
+			convResult.Error = fmt.Sprintf("%s: %s", timeoutMsg, convResult.Error)
+		} else {
+			convResult.Error = timeoutMsg
+		}
+		convResult.Failed = true
 	}
 
 	// Enrich conversation messages with tool descriptor metadata for reports
@@ -886,8 +910,21 @@ func convertA2AAgentsFromConfig(agents []config.A2AAgentConfig) []statestore.A2A
 	return result
 }
 
-// resolveRunTimeout returns the per-run timeout from config, or DefaultRunTimeout if not set.
-func (e *Engine) resolveRunTimeout() time.Duration {
+// resolveRunTimeout returns the per-run timeout. Precedence (highest first):
+//  1. Scenario.Duplex.Timeout — voice scenarios are inherently slow
+//     (selfplay LLM + TTS + realtime agent + tool round-trips); a 5m
+//     default truncates them before any meaningful scoring happens.
+//  2. Defaults.RunTimeout from arena config.
+//  3. DefaultRunTimeout (5m).
+//
+// The scenario parameter is optional — eval runs and other non-scenario
+// paths pass nil and fall through to the config / default ladder.
+func (e *Engine) resolveRunTimeout(scenario *config.Scenario) time.Duration {
+	if scenario != nil && scenario.Duplex != nil {
+		if d := scenario.Duplex.GetTimeoutDuration(0); d > 0 {
+			return d
+		}
+	}
 	if e.config != nil && e.config.Defaults.RunTimeout != "" {
 		d, err := time.ParseDuration(e.config.Defaults.RunTimeout)
 		if err == nil && d > 0 {

--- a/tools/arena/engine/run_timeout_test.go
+++ b/tools/arena/engine/run_timeout_test.go
@@ -77,7 +77,7 @@ func newMockProviderRegistry(providerID string) *providers.Registry {
 func TestResolveRunTimeout(t *testing.T) {
 	t.Run("returns default when config is nil", func(t *testing.T) {
 		e := &Engine{}
-		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout(nil))
 	})
 
 	t.Run("returns default when run_timeout is empty", func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestResolveRunTimeout(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout(nil))
 	})
 
 	t.Run("parses valid duration", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestResolveRunTimeout(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, 30*time.Second, e.resolveRunTimeout())
+		assert.Equal(t, 30*time.Second, e.resolveRunTimeout(nil))
 	})
 
 	t.Run("parses minutes", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestResolveRunTimeout(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, 10*time.Minute, e.resolveRunTimeout())
+		assert.Equal(t, 10*time.Minute, e.resolveRunTimeout(nil))
 	})
 
 	t.Run("returns default for invalid duration", func(t *testing.T) {
@@ -121,7 +121,7 @@ func TestResolveRunTimeout(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout(nil))
 	})
 
 	t.Run("returns default for zero duration", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestResolveRunTimeout(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout(nil))
 	})
 
 	t.Run("returns default for negative duration", func(t *testing.T) {
@@ -143,7 +143,35 @@ func TestResolveRunTimeout(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout())
+		assert.Equal(t, DefaultRunTimeout, e.resolveRunTimeout(nil))
+	})
+
+	t.Run("scenario duplex timeout wins over defaults", func(t *testing.T) {
+		// Voice scenarios with selfplay routinely take longer than the 5m
+		// default — the scenario's declared duplex.timeout must override.
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{
+					RunTimeout: "30s",
+				},
+			},
+		}
+		scenario := &config.Scenario{
+			Duplex: &config.DuplexConfig{Timeout: "12m"},
+		}
+		assert.Equal(t, 12*time.Minute, e.resolveRunTimeout(scenario))
+	})
+
+	t.Run("non-duplex scenario falls through to defaults", func(t *testing.T) {
+		// Pure-text scenarios don't have a Duplex block; we should still
+		// respect Defaults.RunTimeout from arena config.
+		e := &Engine{
+			config: &config.Config{
+				Defaults: config.Defaults{RunTimeout: "45s"},
+			},
+		}
+		scenario := &config.Scenario{}
+		assert.Equal(t, 45*time.Second, e.resolveRunTimeout(scenario))
 	})
 }
 


### PR DESCRIPTION
Trying to actually run the voice-refund-demo's `audio_emotion` assertion against real HF surfaced six separate blocking issues. Without these, the demo can't reach a real model — the HF call fails before it gets started, the duplex executor never reaches the assertion-evaluation path, and the audio bytes the handler needs are on disk but the handler doesn't know how to read them.

Answering the direct question: **the inference foundation now works end-to-end**. Verified by running `go run ./tools/arena/cmd/ser-probe -text "I want a refund NOW"` against real HF and getting `desire: 0.61, neutral: 0.32, annoyance: 0.02 ...` back in <1 second. The voice-refund-demo's audio-specific assertion still needs a hosted SER model (HF retired the demo's target from free serverless); the YAML now documents how to deploy one to HF Inference Endpoints.

## What's fixed

| | What broke | Fix |
|---|---|---|
| 1 | HF backend pointed at `api-inference.huggingface.co/models/{id}` which HF retired in early 2026 — every classify call returned an HTML "Cannot POST" | Switched DefaultBaseURL to `router.huggingface.co/hf-inference` (the new Inference Providers router) |
| 2 | Handler rejected `storage_reference` audio sources — but duplex pipeline writes audio to disk via media-storage and persists a `storage_reference` (path string), not inline base64 | Added local-path fast path: refs without `://` are read via `os.ReadFile`. Cloud refs (s3://, gs://) still error pending a real MediaLoader |
| 3 | `resolveRunTimeout` used DefaultRunTimeout (5m) ignoring `scenario.duplex.timeout: 10m`, truncating voice runs before assertions could fire | `resolveRunTimeout` now takes a `*Scenario` and prefers its duplex timeout |
| 4 | On timeout the engine discarded the `ConversationResult` (including assertions) and synthesized an error-only record. Every timed-out run showed `total: 0` for `conversation_assertions` | Stamp the timeout onto the result and continue through the normal save path |
| 5 | `isExpectedDuplexError` used `==` against `context.DeadlineExceeded`; wrapped errors (`"turn failed: %w"`) failed the check, causing the duplex path to throw away a complete result | `errors.Is`, naturally |
| 6 | No way to verify HF connectivity / model availability without spinning up the full arena scenario (10-minute timeout on a hang you don't yet understand) | New `tools/arena/cmd/ser-probe` CLI — `HF_TOKEN=... go run ./tools/arena/cmd/ser-probe -text "..." -model ... -label ...` returns scores in seconds |

Plus `examples/voice-refund-demo/providers/hf.provider.yaml` now documents the paid-endpoint path: HF retired SER models from the free tier, so the YAML explains how to deploy one to Inference Endpoints (~$0.03/hr CPU, scales to zero) and points the handler at it via `base_url` + `dedicated: true`.

## Out of scope (filed separately)

- **mock-duplex doesn't handle tool_call responses.** The session emits "session does not support tool responses" and the runtime then hangs waiting for a follow-up that never comes. Filed as a future fix — separate from classify foundation. Real-provider mode (Gemini Live / OpenAI Realtime) bypasses this.
- **Cloud storage_reference resolution.** A real MediaLoader plumbed through eval-handler context would let cloud-storage audio land in `audio_emotion`. The local-path shortcut covers the demo for now.

## Test plan

- [x] `runtime/evals/handlers/audio_emotion_test`: 3 new tests for storage_reference (local path readable, missing-file errors clean, cloud URI rejected with clear message)
- [x] `engine/run_timeout_test`: 2 new tests for scenario-timeout precedence + non-duplex fallthrough; existing tests updated for the new signature
- [x] `runtime` + `tools/arena` suites green with `-race`
- [x] `ser-probe -text` returns real scores against HF Inference Providers

Refs: #1214
