### PR TITLE
fix(mock-duplex): implement ToolResponseSupport on MockStreamSession

### DIFF
--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -75,7 +75,10 @@ spec:
     - type: audio_emotion
       params:
         model: superb/wav2vec2-base-superb-er
-        message_role: selfplay-user
+        # Selfplay turns land in the message log as role: user (the
+        # runtime collapses selfplay-user into user after the persona
+        # LLM generates the text and TTS synthesizes the audio).
+        message_role: user
         expected_label: angry
         min_score: 0.5
         classifier_id: hf

--- a/runtime/providers/mock/mock_streaming_interactive.go
+++ b/runtime/providers/mock/mock_streaming_interactive.go
@@ -106,6 +106,14 @@ type MockStreamSession struct {
 	// Simulation: Session closure (mimics Gemini dropping connection unexpectedly)
 	closeAfterTurns int  // If > 0, close session after this many turns
 	closeNoResponse bool // If true with closeAfterTurns, close WITHOUT sending final response
+
+	// toolResponses collects every tool execution result the runtime has
+	// fed back into this session via SendToolResponse(s). Lets tests
+	// verify the runtime delivered the expected payload for a scripted
+	// tool_call. Implementation lives in mock_streaming_tools_integration.go
+	// so the file scoping makes the dependency on ToolResponseSupport
+	// obvious from the directory listing.
+	toolResponses []providers.ToolResponse
 }
 
 // NewMockStreamSession creates a new mock stream session.

--- a/runtime/providers/mock/mock_streaming_tools_integration.go
+++ b/runtime/providers/mock/mock_streaming_tools_integration.go
@@ -1,0 +1,74 @@
+package mock
+
+import (
+	"context"
+	"errors"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// Compile-time interface check — MockStreamSession is the optional
+// tool-response surface advertised by ToolResponseSupport, which the
+// duplex provider stage uses to feed tool execution results back into
+// the streaming session. Without this, every duplex scenario with a
+// scripted tool_call hangs: the runtime emits "session does not support
+// tool responses" and waits forever for a follow-up the mock never
+// produces.
+var _ providers.ToolResponseSupport = (*MockStreamSession)(nil)
+
+// SendToolResponse records a single tool result on the mock session and
+// triggers the next scripted turn so the conversation can advance.
+//
+// Real streaming providers (OpenAI Realtime, Gemini Live) handle tool
+// responses by sending a `function_call_output` event followed by a
+// `response.create` trigger that wakes the model up to produce its
+// continuation. The mock equivalent is: store the response for test
+// introspection, then call emitAutoResponse — which advances
+// responseCount and emits whatever the repository has scripted as the
+// next turn (typically the agent's text follow-up after the tool result).
+func (m *MockStreamSession) SendToolResponse(ctx context.Context, toolCallID, result string) error {
+	return m.SendToolResponses(ctx, []providers.ToolResponse{
+		{ToolCallID: toolCallID, Result: result},
+	})
+}
+
+// SendToolResponses records a batch of tool results and triggers a
+// single continuation. Parallel tool calls in one agent turn produce
+// one batch; the mock collapses them into a single emit just like the
+// real providers do (one `response.create` after all function_call_output
+// items have been queued).
+func (m *MockStreamSession) SendToolResponses(_ context.Context, responses []providers.ToolResponse) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.closeCalled {
+		return errors.New(errSessionClosed)
+	}
+
+	m.toolResponses = append(m.toolResponses, responses...)
+	logger.Debug("MockStreamSession.SendToolResponses: received tool results",
+		"count", len(responses), "total_received", len(m.toolResponses))
+
+	// Tool results from a real provider unconditionally trigger
+	// continuation — there's no separate "should I respond now?" flag,
+	// the response.create event IS the trigger. Mirror that: emit the
+	// next turn even when autoRespond is off, because if a test is
+	// driving tool responses at all it's expecting the agent to react
+	// to them. Tests that want to inspect tool_responses without
+	// triggering can use the (unexported) field directly.
+	m.emitAutoResponse()
+	return nil
+}
+
+// ReceivedToolResponses returns a snapshot of every tool response the
+// session has received via SendToolResponse/SendToolResponses. Tests
+// use this to verify the runtime sent back the expected payload for a
+// scripted tool_call.
+func (m *MockStreamSession) ReceivedToolResponses() []providers.ToolResponse {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]providers.ToolResponse, len(m.toolResponses))
+	copy(out, m.toolResponses)
+	return out
+}

--- a/runtime/providers/mock/mock_streaming_tools_integration.go
+++ b/runtime/providers/mock/mock_streaming_tools_integration.go
@@ -24,9 +24,22 @@ var _ providers.ToolResponseSupport = (*MockStreamSession)(nil)
 // responses by sending a `function_call_output` event followed by a
 // `response.create` trigger that wakes the model up to produce its
 // continuation. The mock equivalent is: store the response for test
-// introspection, then call emitAutoResponse — which advances
-// responseCount and emits whatever the repository has scripted as the
-// next turn (typically the agent's text follow-up after the tool result).
+// introspection, then call emitAutoResponse.
+//
+// Note: this delegates to the batch method intentionally. Real providers
+// send two separate websocket events per single-response call (one item
+// + one response.create) — assertion-wise a tester observing the mock
+// can't tell the difference, but a future contributor reading just this
+// function should know it's not a behavioral divergence.
+//
+// Scripted-turn convention: emitAutoResponse increments responseCount,
+// so a tool-result continuation occupies its OWN slot in the scenario's
+// scripted-turn space (different from real providers where the tool
+// continuation extends the original agent turn). Scenarios that script
+// tool flows against the mock should treat each tool round-trip as a
+// discrete scripted entry: e.g. turn 1 = agent emits text+tool_call,
+// turn 2 = agent's continuation after the tool result, turn 3 = agent's
+// response to the next user turn.
 func (m *MockStreamSession) SendToolResponse(ctx context.Context, toolCallID, result string) error {
 	return m.SendToolResponses(ctx, []providers.ToolResponse{
 		{ToolCallID: toolCallID, Result: result},

--- a/runtime/providers/mock/mock_streaming_tools_test.go
+++ b/runtime/providers/mock/mock_streaming_tools_test.go
@@ -1,0 +1,117 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+func TestMockStreamSession_SendToolResponse_RecordsAndContinues(t *testing.T) {
+	session := NewMockStreamSession().WithAutoRespond("continued after tool")
+
+	// Emit turn 1 first (simulates user speech triggering the initial
+	// agent response that contained the tool_call).
+	if err := session.SendText(context.Background(), "hi"); err != nil {
+		t.Fatalf("SendText turn 1: %v", err)
+	}
+	drainOne(t, session, "turn 1")
+
+	// Runtime executes the tool and sends the result back. Without
+	// MockStreamSession implementing ToolResponseSupport, this call
+	// would silently no-op via type-assertion failure in
+	// DuplexProviderStage and the conversation would hang.
+	if err := session.SendToolResponse(context.Background(), "call_0_lookup", `{"order":"ok"}`); err != nil {
+		t.Fatalf("SendToolResponse: %v", err)
+	}
+
+	// The session should have emitted the next scripted turn in
+	// response. Drain it so a follow-up SendText could trigger turn 3.
+	chunk := drainOne(t, session, "turn 2 (continuation)")
+	if chunk.Content == "" && chunk.Delta == "" {
+		t.Errorf("turn 2 chunk had no content; got %+v", chunk)
+	}
+
+	got := session.ReceivedToolResponses()
+	if len(got) != 1 {
+		t.Fatalf("ReceivedToolResponses len = %d, want 1", len(got))
+	}
+	if got[0].ToolCallID != "call_0_lookup" {
+		t.Errorf("ToolCallID = %q, want call_0_lookup", got[0].ToolCallID)
+	}
+	if got[0].Result != `{"order":"ok"}` {
+		t.Errorf("Result = %q, want %q", got[0].Result, `{"order":"ok"}`)
+	}
+}
+
+func TestMockStreamSession_SendToolResponses_BatchTriggersOneContinuation(t *testing.T) {
+	session := NewMockStreamSession().WithAutoRespond("after parallel tools")
+
+	// Prime the response counter so emitAutoResponse picks turn 2.
+	if err := session.SendText(context.Background(), "hi"); err != nil {
+		t.Fatalf("SendText prime: %v", err)
+	}
+	drainOne(t, session, "prime")
+
+	batch := []providers.ToolResponse{
+		{ToolCallID: "call_0_a", Result: "1"},
+		{ToolCallID: "call_1_b", Result: "2"},
+	}
+	if err := session.SendToolResponses(context.Background(), batch); err != nil {
+		t.Fatalf("SendToolResponses: %v", err)
+	}
+
+	// Two tool responses, one continuation — matches the real-provider
+	// pattern (queue function_call_output items, then one response.create).
+	drainOne(t, session, "continuation")
+	assertNoMoreChunks(t, session)
+
+	got := session.ReceivedToolResponses()
+	if len(got) != 2 {
+		t.Fatalf("ReceivedToolResponses len = %d, want 2", len(got))
+	}
+}
+
+func TestMockStreamSession_SendToolResponse_ClosedSessionErrors(t *testing.T) {
+	session := NewMockStreamSession()
+	_ = session.Close()
+
+	err := session.SendToolResponse(context.Background(), "x", "y")
+	if err == nil {
+		t.Fatal("expected error sending tool response on closed session")
+	}
+}
+
+func TestMockStreamSession_InterfaceAssertion(t *testing.T) {
+	// Compile-time check is in production code; this is the runtime
+	// check that DuplexProviderStage performs. If the assertion ever
+	// stopped passing, every duplex tool scenario would silently fail
+	// the same way that motivated this file in the first place.
+	var session providers.StreamInputSession = NewMockStreamSession()
+	if _, ok := session.(providers.ToolResponseSupport); !ok {
+		t.Fatal("MockStreamSession must satisfy providers.ToolResponseSupport")
+	}
+}
+
+func drainOne(t *testing.T, session *MockStreamSession, label string) providers.StreamChunk {
+	t.Helper()
+	select {
+	case chunk, ok := <-session.Response():
+		if !ok {
+			t.Fatalf("%s: response channel closed", label)
+		}
+		return chunk
+	default:
+		t.Fatalf("%s: no chunk on response channel", label)
+	}
+	return providers.StreamChunk{}
+}
+
+func assertNoMoreChunks(t *testing.T, session *MockStreamSession) {
+	t.Helper()
+	select {
+	case chunk := <-session.Response():
+		t.Errorf("unexpected extra chunk on response channel: %+v", chunk)
+	default:
+	}
+}

--- a/runtime/providers/mock/mock_streaming_tools_test.go
+++ b/runtime/providers/mock/mock_streaming_tools_test.go
@@ -3,9 +3,18 @@ package mock
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
+
+// drainChunkTimeout is the wall-clock budget for the producer to land a
+// chunk on the response channel. Today emitAutoResponse runs synchronously
+// under m.mu before SendText / SendToolResponses returns, so chunks are
+// already queued by the time the test reads — but encoding a small timeout
+// keeps the tests resilient if a future refactor moves emit to a goroutine
+// to model network jitter.
+const drainChunkTimeout = 50 * time.Millisecond
 
 func TestMockStreamSession_SendToolResponse_RecordsAndContinues(t *testing.T) {
 	session := NewMockStreamSession().WithAutoRespond("continued after tool")
@@ -82,6 +91,25 @@ func TestMockStreamSession_SendToolResponse_ClosedSessionErrors(t *testing.T) {
 	}
 }
 
+// TestMockStreamSession_SendToolResponse_TriggersWithoutAutoRespond pins
+// the documented behaviour that tool responses unconditionally trigger a
+// continuation, regardless of the autoRespond flag. Real providers don't
+// have a "should I respond" knob — the response.create event IS the
+// trigger — and the mock mirrors that. A previous version of this file
+// had the comment but no test; comments without tests rot.
+func TestMockStreamSession_SendToolResponse_TriggersWithoutAutoRespond(t *testing.T) {
+	// No WithAutoRespond — autoRespond stays false.
+	session := NewMockStreamSession()
+
+	if err := session.SendToolResponse(context.Background(), "call_0", "{}"); err != nil {
+		t.Fatalf("SendToolResponse: %v", err)
+	}
+
+	// A chunk should land even though autoRespond=false because the
+	// tool result itself is the trigger.
+	drainOne(t, session, "continuation without auto-respond")
+}
+
 func TestMockStreamSession_InterfaceAssertion(t *testing.T) {
 	// Compile-time check is in production code; this is the runtime
 	// check that DuplexProviderStage performs. If the assertion ever
@@ -101,8 +129,8 @@ func drainOne(t *testing.T, session *MockStreamSession, label string) providers.
 			t.Fatalf("%s: response channel closed", label)
 		}
 		return chunk
-	default:
-		t.Fatalf("%s: no chunk on response channel", label)
+	case <-time.After(drainChunkTimeout):
+		t.Fatalf("%s: no chunk on response channel within %s", label, drainChunkTimeout)
 	}
 	return providers.StreamChunk{}
 }


### PR DESCRIPTION
Answering "is it limited to duplex?" — yes. The non-duplex mock provider handles tool calls via request/response (`PredictWithTools` returns the call, then receives the result in the next call's message history). The duplex streaming session needs an explicit back-channel: `providers.ToolResponseSupport` with `SendToolResponse` / `SendToolResponses`. The streaming providers (OpenAI Realtime, Gemini Live) both implement it. `MockStreamSession` didn't, so the runtime logged `session does not support tool responses` and dropped the tool results, hanging until the deadline.

## What's new

| File | What |
|---|---|
| `runtime/providers/mock/mock_streaming_tools_integration.go` | `SendToolResponse` + `SendToolResponses` on `MockStreamSession`. Each records the responses for test introspection and triggers `emitAutoResponse` so the agent emits its scripted continuation — equivalent to the real providers' `function_call_output` event + `response.create` trigger. |
| `runtime/providers/mock/mock_streaming_interactive.go` | Added `toolResponses` field for the internal buffer + `ReceivedToolResponses()` accessor. |
| `runtime/providers/mock/mock_streaming_tools_test.go` | 4 tests: single-response continuation, batched parallel-tool responses → single continuation, closed-session error, runtime interface assertion (the same one `DuplexProviderStage` does at dispatch). |
| `examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml` | `message_role` corrected from `selfplay-user` → `user`. The runtime collapses selfplay-driven turns into `role: user` after the persona LLM generates text and TTS synthesizes audio. The handler matches roles literally, so `selfplay-user` silently produced zero audio parts every run. |

## End-to-end verification

With this fix, voice-refund-demo's `aggressive-refund` scenario:

- **Before**: hung for 10 minutes waiting for tool follow-up that never came, `total: 0` for `conversation_assertions`
- **After**: completes in **~5 seconds**, all five conversation assertions evaluate, `audio_emotion` extracts captured TTS audio, POSTs to HF, and surfaces the real response

```json
{
  "type": "audio_emotion",
  "passed": false,
  "message": "classify failed: hf: status 400: {\"error\":\"Model not supported by provider hf-inference\"}"
}
```

That last failure is the documented HF free-tier limitation (the `superb/wav2vec2-base-superb-er` SER model was retired from `hf-inference`), not a defect in the integration. Pointing `hf.provider.yaml` at a deployed HF Inference Endpoint per the YAML's instructions flips this from "fail" to "score".

## Test plan

- [x] Single tool response triggers exactly one continuation chunk
- [x] Batched parallel tool responses trigger one continuation (matches `response.create` semantics)
- [x] Closed-session SendToolResponse returns clean error
- [x] Compile-time + runtime interface checks pin `*MockStreamSession` to `ToolResponseSupport`
- [x] Real run against the demo: ~5s, all 5 assertions evaluate, audio scoring reaches HF with actual model error

Refs: #1214
