### PR TITLE
docs(voice-refund-demo): note dedicated-endpoint hang + correct SER label

### DIFF
--- a/examples/voice-refund-demo/providers/hf.provider.yaml
+++ b/examples/voice-refund-demo/providers/hf.provider.yaml
@@ -41,3 +41,12 @@ spec:
   # base_url: https://YOUR-ENDPOINT.endpoints.huggingface.cloud
   # additional_config:
   #   dedicated: true
+  #
+  # KNOWN ISSUE: setting base_url currently causes the duplex pipeline
+  # to hang on turn 1 against mock-duplex (any non-empty value triggers
+  # it, even an unreachable URL). Tracked separately; real-provider mode
+  # (Gemini Live / OpenAI Realtime) is unaffected. Use `ser-probe` to
+  # verify your endpoint's SER scoring directly:
+  #   HF_TOKEN=... go run ./tools/arena/cmd/ser-probe \
+  #     -audio <wav-file> -model superb/wav2vec2-base-superb-er \
+  #     -label ang -base-url <endpoint-url>

--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -79,7 +79,10 @@ spec:
         # runtime collapses selfplay-user into user after the persona
         # LLM generates the text and TTS synthesizes the audio).
         message_role: user
-        expected_label: angry
+        # The model's label set is truncated: ang / neu / hap / sad.
+        # Not "angry" / "neutral" / etc. Verify against the model's
+        # config.json if you swap to a different SER model.
+        expected_label: ang
         min_score: 0.5
         classifier_id: hf
       message: "Aggressive caller should actually sound angry, not just say angry words"


### PR DESCRIPTION
Two YAML doc tweaks, no code changes.

## `providers/hf.provider.yaml`

Documents #1224 inline: setting `base_url` on the inference provider currently hangs the duplex pipeline against mock-duplex (any non-empty value triggers it, even an unreachable URL — confirmed with `127.0.0.1:1` repro). Real-provider mode (Gemini Live / OpenAI Realtime) is likely unaffected.

Points users at `tools/arena/cmd/ser-probe` as the alternative verification path until the duplex bug is fixed:

```bash
HF_TOKEN=... go run ./tools/arena/cmd/ser-probe \
  -audio <wav-file> -model superb/wav2vec2-base-superb-er \
  -label ang -base-url <endpoint-url>
```

## `scenarios/aggressive-refund.scenario.yaml`

`expected_label` corrected from `angry` → `ang`. The model's label set is truncated (`ang` / `neu` / `hap` / `sad`), confirmed against a live deployment of `superb/wav2vec2-base-superb-er` where the aggressive caller's TTS audio scored `ang=0.609`.

Refs: #1214 #1224
