### PR TITLE
fix(mock): block on FinishReason send so MockStreamSession can't deadlock duplex pipeline

### DIFF
--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -79,7 +79,10 @@ spec:
         # runtime collapses selfplay-user into user after the persona
         # LLM generates the text and TTS synthesizes the audio).
         message_role: user
-        expected_label: angry
+        # The superb/wav2vec2-base-superb-er label set is truncated:
+        # ang / neu / hap / sad. Confirmed against a live deployment
+        # where the aggressive caller's TTS audio scored ang=0.609.
+        expected_label: ang
         min_score: 0.5
         classifier_id: hf
       message: "Aggressive caller should actually sound angry, not just say angry words"

--- a/runtime/providers/mock/mock_streaming_interactive.go
+++ b/runtime/providers/mock/mock_streaming_interactive.go
@@ -461,11 +461,13 @@ func (m *MockStreamSession) emitTurnResponse(turnNumber int) {
 		ToolCalls:    toolCalls,
 		FinishReason: &finishReason,
 	}
+	// Block on send (matching emitAudioChunks): the FinishReason chunk is
+	// the only signal the consumer has that the turn ended. Dropping it on
+	// a full buffer races into a deadlock — DuplexProviderStage parks on
+	// the response channel forever after draining the queued audio chunks.
 	select {
 	case m.responses <- chunk:
-		// Sent successfully
-	default:
-		// Channel full or closed - this shouldn't happen with buffered channel
+	case <-m.doneCh:
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related fixes that together let the voice-refund-demo's `aggressive-refund` scenario actually run end-to-end against `mock-duplex`:

1. **MockStreamSession FinishReason deadlock** (`runtime/providers/mock/mock_streaming_interactive.go`)
   - `emitTurnResponse` sent its final `FinishReason` chunk via a non-blocking `select { ...; default: }`. With the 10-element buffered `responses` channel and the agent's canned audio fixtures emitting many `MediaData` chunks first, there's a window where the buffer is full when the FinishReason fires — the default branch silently drops the chunk and `DuplexProviderStage` parks on the response channel forever.
   - Switched the send to a blocking `select { case m.responses <- chunk: case <-m.doneCh: }`, matching the pattern `emitAudioChunks` already uses. The turn-complete signal can no longer be dropped.
   - Real duplex providers (OpenAI Realtime, Gemini Live) are unaffected — they signal turn-complete over their WebSocket protocol, not via a Go channel that can drop.

2. **audio_emotion `expected_label`** (`examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml`)
   - `superb/wav2vec2-base-superb-er` emits a truncated label set: `ang` / `neu` / `hap` / `sad`. The scenario was asserting `"angry"`, which the model never returns. Confirmed against a live HF Inference Endpoint deployment where the aggressive caller's TTS audio scored `ang=0.609`.

## Why the deadlock surfaced now

Voice-refund-demo's `mock-responses.yaml` puts substantial canned audio in the agent's turn-4 fixture. Earlier mock-duplex scenarios didn't emit large audio fixtures from the agent side, so the buffer rarely filled at the FinishReason moment. Once we wired audio fixtures into the demo, the hang became reliably reproducible (5/5 hangs against `aggressive-refund`).

Diagnosed by SIGQUIT goroutine dump: `forwardResponseElements` parked at the responseChannel select while `forwardInputElements` had already finished, `EndInput()` had fired, and the response channel was empty.

## Test plan
- [x] `go test ./runtime/providers/mock/... -count=1` — passes
- [x] Full `runtime` module test suite — passes (via pre-commit hook)
- [x] `voice-refund-demo` aggressive-refund scenario — 5/5 successes (was 5/5 hangs)
- [ ] CI green
- [x] Close #1225 (the docs-only workaround PR is obsolete)

Closes #1224