### PR TITLE
refactor(evals): classify-backed handlers are pure eval primitives

### DIFF
--- a/docs/src/content/docs/arena/how-to/configure-providers.md
+++ b/docs/src/content/docs/arena/how-to/configure-providers.md
@@ -428,16 +428,22 @@ spec:
       embedder: hf
 ```
 
-Then use it in a scenario:
+Then use it in a scenario. The classify-backed handler is a pure
+eval primitive that emits the model's score for `expected_label`;
+wrap it in `type: assertion` to apply the pass/fail threshold:
 
 ```yaml
 conversation_assertions:
-  - type: audio_emotion
+  - type: assertion
     params:
-      model: superb/wav2vec2-base-superb-er
-      expected_label: angry
+      eval_type: audio_emotion
+      eval_params:
+        model: superb/wav2vec2-base-superb-er
+        expected_label: angry
       min_score: 0.6
 ```
+
+(See [Classify-backed Checks](/reference/checks/#classify-backed-checks) for the full convention.)
 
 When HuggingFace returns a 503 "model is loading" the assertion is
 recorded as **skipped**, not failed — the model isn't broken, it just

--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -267,87 +267,123 @@ assertions:
 
 ## Classify-backed Checks
 
-These checks call an `inference` provider (HuggingFace today; ONNX in flight) via the `runtime/classify` task interfaces and grade the result against a configurable threshold. They depend on a provider with `role: inference` being declared in the arena config; without one — for example a keyless CI run with no `HF_TOKEN` — the check **skips cleanly** rather than failing.
+These eval primitives call an `inference` provider (HuggingFace today; ONNX in flight) via the `runtime/classify` task interfaces and emit the model's score for a configured label. They are **pure eval primitives** — they do **NOT** apply pass/fail thresholds themselves. Threshold judgment lives on the [`assertion`](#assertion-wrapper) wrapper.
 
-Common params (shared across the family):
+They depend on a provider with `role: inference` being declared in the arena config; without one — for example a keyless CI run with no `HF_TOKEN` — the check **skips cleanly** rather than failing.
+
+**Two declaration sites:**
+
+```yaml
+# As a pack-level runtime eval — emits the raw signal as a metric every turn.
+evals:
+  - id: response-toxicity
+    type: text_toxicity
+    trigger: every_turn
+    params: { model: unitary/toxic-bert, expected_label: toxic }
+
+# As an Arena assertion — wrap with `type: assertion` to apply a threshold.
+conversation_assertions:
+  - type: assertion
+    params:
+      eval_type: text_toxicity
+      eval_params: { model: unitary/toxic-bert, expected_label: toxic }
+      max_score: 0.3
+```
+
+Putting `min_score` or `max_score` directly on a classify-backed handler is rejected at parse time; the error points at the wrapper. This stops the eval and assertion roles from drifting into one undifferentiated blob.
+
+**Common params** (shared across the family):
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `model` | string | Yes | Backend model id (e.g. `unitary/toxic-bert`, `superb/wav2vec2-base-superb-er`) |
-| `expected_label` | string | Yes | Label to grade against |
-| `min_score` | float | No (default 0.5) | Pass when label score is at-or-above threshold |
+| `expected_label` | string | Yes | Label whose score is emitted |
 | `message_role` | string | No | Whose messages to score (`user` for audio, `assistant` for text by default) |
 | `message_index` | int | No (default -1) | Pick a specific message (`-1` = latest) |
 | `classifier_id` | string | No | Explicit registry id; empty uses `defaults.inference.<task>_classifier` |
 
 ### `audio_emotion`
 
-Speech-emotion-recognition gate. Picks an audio part from the chosen role's messages, runs it through an `AudioClassifier`, and grades the configured emotion label. Used in the voice-refund-demo to verify aggressive selfplay callers actually sound aggressive in their TTS audio.
+Speech-emotion-recognition gate. Picks an audio part from the chosen role's messages, runs it through an `AudioClassifier`, and emits the model's score for the chosen emotion label. Used in the voice-refund-demo (wrapped in `type: assertion`) to verify aggressive selfplay callers actually sound aggressive in their TTS audio.
 
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| (common params above) | | | |
+**Surfaces:** A E (conversation assertion when wrapped; runtime eval when declared in `evals:`)
 
-**Surfaces:** A E (conversation assertion)
-
-**Example:**
+**Example (Arena assertion with threshold):**
 
 ```yaml
 conversation_assertions:
-  - type: audio_emotion
+  - type: assertion
     params:
-      model: superb/wav2vec2-base-superb-er
-      message_role: user
-      expected_label: ang     # this model emits truncated labels: ang/neu/hap/sad
+      eval_type: audio_emotion
+      eval_params:
+        model: superb/wav2vec2-base-superb-er
+        message_role: user
+        expected_label: ang     # this model emits truncated labels: ang/neu/hap/sad
+        classifier_id: hf
       min_score: 0.5
-      classifier_id: hf
 ```
 
 ### `text_toxicity`
 
-Classifier-backed toxicity check. Distinct from the LLM-judge [`toxicity`](#toxicity) — `text_toxicity` is the deterministic path through a HuggingFace text-classification model. Supports two grading modes:
-
-- **`max_score`** (typical for safety assertions): pass when `expected_label` scores **below** the threshold. Natural framing for "this output should NOT be toxic".
-- **`min_score`** (inherited from the shared shape): pass when `expected_label` scores **at or above** the threshold. Useful when the model emits a positive label like `neutral` (e.g. `s-nlp/roberta_toxicity_classifier`).
-
-Specifying both `min_score` and `max_score` is rejected — pick one mode.
+Classifier-backed toxicity eval. Distinct from the LLM-judge [`toxicity`](#toxicity) — `text_toxicity` is the deterministic path through a HuggingFace text-classification model. Emits the model's score for `expected_label`; the `assertion` wrapper decides pass/fail based on `min_score` or `max_score`:
 
 **Surfaces:** A E
 
 **Examples:**
 
 ```yaml
-# Negative framing: toxic score must stay below 0.3
-- type: text_toxicity
+# Negative framing — "this output should NOT be toxic"
+- type: assertion
   params:
-    model: unitary/toxic-bert
-    expected_label: toxic
+    eval_type: text_toxicity
+    eval_params:
+      model: unitary/toxic-bert
+      expected_label: toxic
     max_score: 0.3
 
-# Positive framing: neutral score must stay at or above 0.7
-- type: text_toxicity
+# Positive framing — "this output should sit in the neutral class"
+- type: assertion
   params:
-    model: s-nlp/roberta_toxicity_classifier
-    expected_label: neutral
+    eval_type: text_toxicity
+    eval_params:
+      model: s-nlp/roberta_toxicity_classifier
+      expected_label: neutral
     min_score: 0.7
 ```
 
 ### `text_sentiment`
 
-Classifier-backed sentiment check. Mirrors `audio_emotion` exactly: pass when `expected_label` scores at-or-above `min_score`. The lower-bound framing fits "the assistant should sound positive" naturally; for inverse assertions, point at the opposing label and keep the same `min_score`.
+Classifier-backed sentiment eval. Emits the model's score for `expected_label`. Wrap with `type: assertion` and `min_score` for the typical "assistant should sound positive" framing; for inverse assertions point at the opposing label.
 
 **Surfaces:** A E
 
 **Example:**
 
 ```yaml
-- type: text_sentiment
+- type: assertion
   params:
-    model: cardiffnlp/twitter-roberta-base-sentiment-latest
-    message_role: assistant
-    expected_label: positive
+    eval_type: text_sentiment
+    eval_params:
+      model: cardiffnlp/twitter-roberta-base-sentiment-latest
+      message_role: assistant
+      expected_label: positive
     min_score: 0.7
 ```
+
+### `assertion` (wrapper) {#assertion-wrapper}
+
+Generic wrapper that turns any eval primitive into a thresholded pass/fail. Cleanest way to use any classify-backed eval as a scenario assertion.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `eval_type` | string | Yes | The inner eval handler's type (e.g. `text_toxicity`, `audio_emotion`, `cosine_similarity`) |
+| `eval_params` | object | Yes | Params passed verbatim to the inner eval |
+| `min_score` | float | No | Pass when inner Score is at-or-above this |
+| `max_score` | float | No | Pass when inner Score is at-or-below this |
+
+If both `min_score` and `max_score` are set, both must hold. If neither is set, the default is `min_score: 1.0` (inner eval must fully pass).
+
+Parallel handler: `guardrail` — same shape but consumes the eval at runtime to block, not assert.
 
 ---
 

--- a/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
+++ b/examples/voice-refund-demo/scenarios/aggressive-refund.scenario.yaml
@@ -72,19 +72,26 @@ spec:
     # actually sound angry, not just say angry words. Requires an
     # `inference` provider (HF_TOKEN); skips cleanly without one or when
     # the mock provider doesn't emit audio parts.
-    - type: audio_emotion
+    #
+    # Pattern: the inner audio_emotion is a pure eval primitive that
+    # emits the model's score for `expected_label`. The outer
+    # `type: assertion` wrapper applies the threshold judgment. See
+    # runtime/evals/handlers/CLAUDE.md.
+    - type: assertion
       params:
-        model: superb/wav2vec2-base-superb-er
-        # Selfplay turns land in the message log as role: user (the
-        # runtime collapses selfplay-user into user after the persona
-        # LLM generates the text and TTS synthesizes the audio).
-        message_role: user
-        # The superb/wav2vec2-base-superb-er label set is truncated:
-        # ang / neu / hap / sad. Confirmed against a live deployment
-        # where the aggressive caller's TTS audio scored ang=0.609.
-        expected_label: ang
+        eval_type: audio_emotion
+        eval_params:
+          model: superb/wav2vec2-base-superb-er
+          # Selfplay turns land in the message log as role: user (the
+          # runtime collapses selfplay-user into user after the persona
+          # LLM generates the text and TTS synthesizes the audio).
+          message_role: user
+          # The superb/wav2vec2-base-superb-er label set is truncated:
+          # ang / neu / hap / sad. Confirmed against a live deployment
+          # where the aggressive caller's TTS audio scored ang=0.609.
+          expected_label: ang
+          classifier_id: hf
         min_score: 0.5
-        classifier_id: hf
       message: "Aggressive caller should actually sound angry, not just say angry words"
 
   context:

--- a/runtime/evals/handlers/CLAUDE.md
+++ b/runtime/evals/handlers/CLAUDE.md
@@ -1,0 +1,44 @@
+# Evals Handlers — Conventions
+
+## The eval / assertion / guardrail split
+
+Three roles share the same eval primitives. Keep them separated:
+
+| Role | Where it lives | What it does |
+|------|----------------|--------------|
+| **Eval** | `runtime/evals/handlers/*.go` | Computes a signal. Emits `EvalResult.Score` = raw metric. No threshold logic. |
+| **Assertion** | `type: assertion` wrapper (`runtime/evals/wrappers.go`) | Wraps an eval. Applies `min_score` / `max_score`. Decides pass/fail. |
+| **Guardrail** | `type: guardrail` wrapper (`runtime/evals/wrappers.go`) | Wraps an eval. Decides whether to fire at runtime. |
+
+The wrappers route to inner evals via the `EvalTypeRegistry`. One inner eval primitive can be reused by all three callers.
+
+## Eval-primitive contract
+
+Every handler in this package that takes a measurement (classify-backed, embedding-based, llm-judge, …) MUST:
+
+1. **Emit `Score` as the raw signal.** For classifiers: the model's score for the chosen label. For embedders: the similarity. For LLM judges: the judge's numerical score. Score in `[0, 1]` by convention.
+2. **Set `MetricValue` to the same value.** Reports use `MetricValue` for trend plots.
+3. **Put structured detail in `Details`.** Anything the report or downstream consumer needs (the full label table, the embedding shape, the judge's reasoning) lives here, never in `Value`.
+4. **Leave `Value` unset.** The assertion wrapper overwrites `Value` with a `bool` for pass/fail. Setting `Value` on the inner handler will be clobbered when wrapped — and confuses bare-eval usage in pack `evals:` blocks.
+5. **REJECT `min_score` / `max_score`** at param-parse time. These are threshold params; they belong on the wrapper. Silently accepting them is a config-mistake trap. Use `parseClassifyConfig` (or the equivalent helper for your handler family) — it already enforces this.
+6. **Skipped vs Error split.** Use `skippedResult` for infrastructure absence (no registry in context, no media of the right kind in the messages). Use `errorResult` for misconfigurations the user can fix (missing required param, out-of-range index). Skipped passes for free; Error fails the assertion.
+
+## How to wire a new eval handler
+
+1. Define the handler struct + `Type()` + `Eval()` in its own file.
+2. Use the appropriate `parseXxxConfig` helper. For classify-backed handlers that's `parseClassifyConfig`.
+3. Emit `Score`, `MetricValue`, `Details`. Never set `Value`. Never apply a threshold.
+4. Register in `register.go` under the matching section.
+5. Write the test pair: one happy path (Score is the expected value), one threshold-rejection test (`min_score: 0.5` returns an Error pointing at `type: assertion`).
+6. Document in `docs/src/content/docs/reference/checks.md` under "Classify-backed Checks" (or the appropriate section) with the **two declaration sites** pattern: pack-level `evals:` example AND `type: assertion`-wrapped example.
+
+## Anti-patterns — don't repeat these
+
+- **Self-grading handlers.** Putting `min_score` / `max_score` logic inside the handler conflates the eval with the assertion. Audio_emotion / text_toxicity / text_sentiment were shipped that way originally; the cleanup landed in #1232. Don't reintroduce. The classify_handler_base.go param parser actively rejects threshold params on the eval — the test `TestAudioEmotion_RejectsThresholdParams` pins this behaviour.
+- **Setting `Value` on the inner handler.** Wrapper overwrites it. Use `Details` instead.
+- **Bundling "passed" boolean into the inner result.** Same problem — the wrapper decides pass/fail.
+- **Two thresholds modes on the same handler** (`min_score` AND `max_score` selectable via flag). Pick neither — both are wrapper concerns.
+
+## Legacy exceptions (do not propagate)
+
+The LLM-judge family (`bias`, `toxicity`, `pii_leakage`, `role_violation`) accepts `min_score` as a param, but only passes it through to the judge model as metadata for the model's own reasoning — they do not threshold the score themselves. This is grandfathered; do not add new self-grading handlers in this style.

--- a/runtime/evals/handlers/audio_emotion.go
+++ b/runtime/evals/handlers/audio_emotion.go
@@ -19,19 +19,32 @@ import (
 // text scoring which targets the assistant.
 const audioEmotionDefaultRole = "user"
 
-// AudioEmotionHandler scores whether the audio in a chosen message contains
-// a target emotion (e.g. "angry") above a configurable confidence
-// threshold. It calls the AudioClassifier resolved from the orchestrator's
-// classify registry, so the model/backend are arena-config decisions, not
-// handler decisions.
+// AudioEmotionHandler is a pure eval primitive: it calls the
+// AudioClassifier resolved from the orchestrator's classify registry,
+// picks the score for the chosen expected_label, and emits it as
+// EvalResult.Score. Threshold judgment (min_score / max_score) lives
+// on `type: assertion` wrappers — NOT on this handler.
+//
+// Wrap with `type: assertion` to assert against a threshold:
+//
+//   - type: assertion
+//     params:
+//     eval_type: audio_emotion
+//     eval_params: { model: "...", expected_label: "ang", message_role: user }
+//     min_score: 0.5
+//
+// Use directly in pack `evals:` to emit the raw signal at runtime
+// (for metrics / observability).
 //
 // Params:
 //   - model           string  (required) — backend model id, e.g. "superb/wav2vec2-base-superb-er"
-//   - expected_label  string  (required) — label that must appear with score >= min_score
-//   - min_score       float   (optional, default 0.5) — confidence threshold for pass
+//   - expected_label  string  (required) — label whose score is emitted
 //   - message_role    string  (optional, default "user") — which speaker's audio to score
 //   - message_index   int     (optional, default -1 = latest match) — pick a specific audio message
 //   - classifier_id   string  (optional) — explicit registry id; empty uses the configured default
+//
+// Putting min_score / max_score on this handler is rejected — the
+// assertion wrapper is the canonical home for thresholds.
 type AudioEmotionHandler struct{}
 
 // Type returns the eval type identifier.
@@ -232,42 +245,45 @@ func readMediaBytes(media *types.MediaContent) ([]byte, error) {
 }
 
 // gradeAudioEmotion looks up the requested label in the classifier's
-// scored output, applies the threshold, and assembles the result.
-// Wraps the shared label-lookup helper with audio-specific result
-// keys so reports remain stable for consumers that index by
-// `expected_label` / `min_score` / `actual_score`.
+// scored output and emits its score. Pure eval primitive: no
+// threshold judgment — that lives on the `type: assertion` wrapper.
+//
+// When the expected_label is absent from the classifier's output we
+// emit Score = 0 (the label's effective confidence is zero) plus a
+// clear Explanation; consumers comparing the resulting Score against
+// a wrapper-supplied threshold get the right outcome (any positive
+// min_score fails; "label not returned" is louder in the report).
 func gradeAudioEmotion(
 	handlerType string, cfg *classifyConfig, scores []classify.LabelScore,
 ) *evals.EvalResult {
 	foundScore, foundLabel := findExpectedLabel(scores, cfg.expectedLabel)
 	if foundLabel == "" {
+		zero := 0.0
 		allLabels := strings.Join(labelsFromScores(scores), ", ")
 		return &evals.EvalResult{
-			Type:  handlerType,
-			Score: boolScore(false),
-			Value: map[string]any{
+			Type:        handlerType,
+			Score:       &zero,
+			MetricValue: &zero,
+			Explanation: fmt.Sprintf("label %q not returned by model; got: %s", cfg.expectedLabel, allLabels),
+			Details: map[string]any{
 				classifyKeyExpectedLabel: cfg.expectedLabel,
-				classifyKeyMinScore:      cfg.minScore,
+				classifyKeyActualScore:   0.0,
+				classifyKeyScores:        scores,
 				keyFound:                 false,
 			},
-			Explanation: fmt.Sprintf("label %q not returned by model; got: %s", cfg.expectedLabel, allLabels),
-			Details:     map[string]any{classifyKeyScores: scores},
 		}
 	}
-	passed := foundScore >= cfg.minScore
 	scoreCopy := foundScore
 	return &evals.EvalResult{
 		Type:        handlerType,
 		Score:       &scoreCopy,
 		MetricValue: &scoreCopy,
-		Value: map[string]any{
+		Explanation: fmt.Sprintf("%s score %.3f", foundLabel, foundScore),
+		Details: map[string]any{
 			classifyKeyExpectedLabel: cfg.expectedLabel,
-			classifyKeyMinScore:      cfg.minScore,
 			classifyKeyActualScore:   foundScore,
-			classifyKeyPassed:        passed,
+			classifyKeyScores:        scores,
 		},
-		Explanation: fmt.Sprintf("%s score %.3f (threshold %.3f)", foundLabel, foundScore, cfg.minScore),
-		Details:     map[string]any{classifyKeyScores: scores},
 	}
 }
 

--- a/runtime/evals/handlers/audio_emotion_test.go
+++ b/runtime/evals/handlers/audio_emotion_test.go
@@ -17,6 +17,19 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// audio_emotion is a PURE EVAL PRIMITIVE — it emits the score for the
+// configured expected_label and never applies a threshold. Threshold
+// judgment is the job of `type: assertion` wrappers; see
+// runtime/evals/wrappers.go and runtime/evals/handlers/CLAUDE.md.
+//
+// These tests assert the pure-eval contract:
+//   - Score = raw model score for expected_label (or 0 when absent)
+//   - Details carries the structured info (expected_label, actual_score, all scores)
+//   - min_score / max_score on the handler params is rejected
+//
+// Wrapper-driven pass/fail is exercised separately via the
+// AssertionEvalHandler tests (runtime/evals/wrappers_test.go).
+
 // hfTestServer returns an httptest.Server that hands back the provided
 // HF audio-classification response JSON (or a 503 model-loading payload
 // when loading is true). Keeping the helper close to the handler tests
@@ -69,7 +82,7 @@ func audioMessage(role, body string) types.Message {
 	}
 }
 
-func TestAudioEmotion_PassesWhenLabelMeetsThreshold(t *testing.T) {
+func TestAudioEmotion_EmitsScoreForExpectedLabel(t *testing.T) {
 	srv := hfTestServer(t, []classify.LabelScore{
 		{Label: "angry", Score: 0.82},
 		{Label: "neutral", Score: 0.10},
@@ -84,51 +97,31 @@ func TestAudioEmotion_PassesWhenLabelMeetsThreshold(t *testing.T) {
 	res, err := h.Eval(ctx, evalCtx, map[string]any{
 		"model":          "superb/wav2vec2-base-superb-er",
 		"expected_label": "angry",
-		"min_score":      0.6,
 	})
 	if err != nil {
 		t.Fatalf("Eval: %v", err)
 	}
 	if res.Skipped {
-		t.Fatalf("expected pass, got skipped: %s", res.SkipReason)
+		t.Fatalf("expected emit, got skipped: %s", res.SkipReason)
 	}
 	if res.Error != "" {
-		t.Fatalf("expected pass, got error: %s", res.Error)
+		t.Fatalf("expected emit, got error: %s", res.Error)
 	}
-	if res.Score == nil || *res.Score < 0.6 {
-		t.Errorf("score = %v, want >= 0.6", res.Score)
+	if res.Score == nil || *res.Score != 0.82 {
+		t.Errorf("Score = %v, want 0.82 (raw model score for the expected label)", res.Score)
 	}
-}
-
-func TestAudioEmotion_FailsWhenLabelBelowThreshold(t *testing.T) {
-	srv := hfTestServer(t, []classify.LabelScore{
-		{Label: "angry", Score: 0.3},
-		{Label: "neutral", Score: 0.7},
-	}, false)
-	defer srv.Close()
-
-	ctx := ctxWithRegistry(t, srv.URL)
-	evalCtx := &evals.EvalContext{
-		Messages: []types.Message{audioMessage("user", "rawaudio")},
+	if res.MetricValue == nil || *res.MetricValue != 0.82 {
+		t.Errorf("MetricValue = %v, want 0.82", res.MetricValue)
 	}
-	h := &AudioEmotionHandler{}
-	res, _ := h.Eval(ctx, evalCtx, map[string]any{
-		"model":          "superb/wav2vec2-base-superb-er",
-		"expected_label": "angry",
-		"min_score":      0.6,
-	})
-	if res.Score == nil || *res.Score >= 0.6 {
-		t.Errorf("score = %v, want < 0.6 (model returned 0.3)", res.Score)
+	if res.Details["expected_label"] != "angry" {
+		t.Errorf("Details.expected_label = %v, want angry", res.Details["expected_label"])
 	}
-	// Even when the label is found but below threshold, we want the
-	// actual model score surfaced in Value so the report explains why.
-	val, _ := res.Value.(map[string]any)
-	if val["actual_score"].(float64) != 0.3 {
-		t.Errorf("actual_score = %v, want 0.3", val["actual_score"])
+	if res.Details["actual_score"].(float64) != 0.82 {
+		t.Errorf("Details.actual_score = %v, want 0.82", res.Details["actual_score"])
 	}
 }
 
-func TestAudioEmotion_FailsWhenLabelNotReturned(t *testing.T) {
+func TestAudioEmotion_EmitsZeroWhenLabelNotReturned(t *testing.T) {
 	srv := hfTestServer(t, []classify.LabelScore{
 		{Label: "happy", Score: 0.9},
 	}, false)
@@ -143,6 +136,13 @@ func TestAudioEmotion_FailsWhenLabelNotReturned(t *testing.T) {
 		"model":          "superb/wav2vec2-base-superb-er",
 		"expected_label": "angry",
 	})
+	// Label absent from the model output → emit Score = 0 (raw signal:
+	// the label's effective confidence is zero). Wrapper-supplied
+	// thresholds (any positive min_score) will compute pass/fail
+	// correctly from the zero.
+	if res.Score == nil || *res.Score != 0 {
+		t.Errorf("Score = %v, want 0 (label not returned)", res.Score)
+	}
 	if !strings.Contains(res.Explanation, "not returned by model") {
 		t.Errorf("explanation %q should call out missing label", res.Explanation)
 	}
@@ -175,6 +175,28 @@ func TestAudioEmotion_SkippedOnModelLoading(t *testing.T) {
 	}
 }
 
+func TestAudioEmotion_RejectsThresholdParams(t *testing.T) {
+	// Threshold judgment is the job of `type: assertion`. Putting
+	// min_score / max_score on the eval handler itself is a config
+	// mistake; the handler should surface it loudly, not silently
+	// accept a no-op param.
+	ctx := classify.WithRegistry(context.Background(), classify.NewRegistry())
+	h := &AudioEmotionHandler{}
+	for _, banned := range []string{"min_score", "max_score"} {
+		res, _ := h.Eval(ctx, &evals.EvalContext{}, map[string]any{
+			"model":          "superb/wav2vec2-base-superb-er",
+			"expected_label": "angry",
+			banned:           0.5,
+		})
+		if !strings.Contains(res.Error, banned+" is not a valid param") {
+			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
+		}
+		if !strings.Contains(res.Error, "type: assertion") {
+			t.Errorf("error should point to the assertion wrapper: %q", res.Error)
+		}
+	}
+}
+
 func TestAudioEmotion_MissingModelParam(t *testing.T) {
 	ctx := classify.WithRegistry(context.Background(), classify.NewRegistry())
 	h := &AudioEmotionHandler{}
@@ -198,11 +220,8 @@ func TestAudioEmotion_MissingExpectedLabelParam(t *testing.T) {
 }
 
 func TestAudioEmotion_NoRegistryInContext(t *testing.T) {
-	// Plain context with no classify.Registry attached. Infrastructure
-	// absence (no inference provider declared) is Skipped — the assertion
-	// couldn't run, but nothing is broken. This is the keyless-CI path:
-	// the demo declares an HF provider but HF_TOKEN isn't set, so the
-	// engine never populates the registry, and the assertion skips.
+	// Keyless-CI path: no inference provider declared, registry is nil,
+	// assertion skips cleanly with a pointer at the missing wiring.
 	h := &AudioEmotionHandler{}
 	res, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
 		"model":          "x/y",
@@ -233,9 +252,6 @@ func TestAudioEmotion_NoAudioInMessages(t *testing.T) {
 		"model":          "x/y",
 		"expected_label": "angry",
 	})
-	// Mock providers without audio output (or scenarios where the chosen
-	// role never speaks) should skip cleanly. The user can still see WHY
-	// via SkipReason.
 	if !res.Skipped {
 		t.Fatalf("expected Skipped when no audio in messages; got Error=%q", res.Error)
 	}
@@ -245,11 +261,6 @@ func TestAudioEmotion_NoAudioInMessages(t *testing.T) {
 }
 
 func TestAudioEmotion_MessageIndexPicksSpecificPart(t *testing.T) {
-	// Two audio messages with different scores. message_index 0 should
-	// pick the first; -1 picks the last. We test by using two scores per
-	// label tied to physical position via the body bytes (httptest
-	// server returns the same scores for any call, so verify selection
-	// indirectly by asserting we read SOME audio without erroring).
 	srv := hfTestServer(t, []classify.LabelScore{{Label: "angry", Score: 0.9}}, false)
 	defer srv.Close()
 	ctx := ctxWithRegistry(t, srv.URL)
@@ -263,7 +274,6 @@ func TestAudioEmotion_MessageIndexPicksSpecificPart(t *testing.T) {
 			"model":          "x/y",
 			"expected_label": "angry",
 			"message_index":  idx,
-			"min_score":      0.5,
 		})
 		if res.Error != "" {
 			t.Errorf("idx=%d unexpected error: %s", idx, res.Error)
@@ -292,9 +302,7 @@ func ptrString(s string) *string { return &s }
 // TestAudioEmotion_StorageReferencePath proves the handler can read audio
 // from a storage_reference that's a local-filesystem path — the shape the
 // duplex pipeline produces when the local-storage media backend persists
-// recordings. Without this support, audio_emotion can never fire in a
-// real voice-refund-demo run because the message log never carries inline
-// base64.
+// recordings.
 func TestAudioEmotion_StorageReferencePath(t *testing.T) {
 	dir := t.TempDir()
 	wavPath := filepath.Join(dir, "audio.wav")
@@ -321,7 +329,6 @@ func TestAudioEmotion_StorageReferencePath(t *testing.T) {
 	res, err := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{msg}}, map[string]any{
 		"model":          "superb/wav2vec2-base-superb-er",
 		"expected_label": "angry",
-		"min_score":      0.5,
 	})
 	if err != nil {
 		t.Fatalf("Eval: %v", err)
@@ -332,8 +339,8 @@ func TestAudioEmotion_StorageReferencePath(t *testing.T) {
 	if res.Error != "" {
 		t.Fatalf("expected score result, got error: %s", res.Error)
 	}
-	if res.Score == nil || *res.Score < 0.5 {
-		t.Errorf("score = %v, want >= 0.5", res.Score)
+	if res.Score == nil || *res.Score != 0.91 {
+		t.Errorf("Score = %v, want 0.91", res.Score)
 	}
 }
 
@@ -356,8 +363,6 @@ func TestAudioEmotion_StorageReferenceMissingFile(t *testing.T) {
 		"model":          "x/y",
 		"expected_label": "angry",
 	})
-	// An unreadable storage reference is a real config error (path is
-	// wrong / file got cleaned up). Surface as Error, not Skipped.
 	if res.Error == "" {
 		t.Errorf("expected error for unreadable storage_reference; got %+v", res)
 	}

--- a/runtime/evals/handlers/classify_handler_base.go
+++ b/runtime/evals/handlers/classify_handler_base.go
@@ -9,33 +9,37 @@ import (
 
 // Shared infrastructure for every classify-backed eval handler
 // (audio_emotion, text_toxicity, text_sentiment, … and the image /
-// video handlers queued behind #1228 / #1229). All of them take the
-// same shape of params — model + expected_label + min_score +
-// message_role + message_index + classifier_id — and the same
-// label-lookup logic, so factoring once keeps the per-handler files
-// down to "wire up the right task interface and call the registry".
+// video handlers queued behind #1228 / #1229).
+//
+// Convention — classify-backed handlers are PURE EVAL PRIMITIVES:
+// they call the configured TextClassifier / AudioClassifier / ...,
+// pick the score for the expected label, and emit it as
+// EvalResult.Score. They do NOT apply min_score / max_score
+// thresholds — that is the job of the `type: assertion` wrapper
+// (see runtime/evals/wrappers.go) which composes the eval with
+// pass/fail judgment. Threshold logic on the eval handler itself
+// is wrong: it conflates the eval and assertion roles and stops
+// the same handler from being declared in a pack's `evals:` block
+// (where it should emit a metric, not a verdict).
+//
+// See runtime/evals/handlers/CLAUDE.md for the full convention.
 
 // Param-map keys reused across handler Value / Details maps and
 // during param parsing. Hoisted so goconst stays happy and so a
 // future schema rename touches one place.
 const (
 	classifyKeyExpectedLabel = "expected_label"
-	classifyKeyMinScore      = "min_score"
-	classifyKeyMaxScore      = "max_score"
-	classifyKeyScores        = "scores"
 	classifyKeyActualScore   = "actual_score"
-	classifyKeyPassed        = "passed"
-
-	classifyDefaultMinScore = 0.5
+	classifyKeyScores        = "scores"
 )
 
 // classifyConfig is the validated, shared shape consumed by every
 // classify-backed handler. Per-handler configs embed this and add
-// their own deltas (e.g. text_toxicity's max_score upper-bound mode).
+// their own deltas (today: none; reserved for future handler-
+// specific params like sample_rate on audio).
 type classifyConfig struct {
 	model         string
 	expectedLabel string
-	minScore      float64
 	messageRole   string
 	messageIndex  int
 	classifierID  string
@@ -46,9 +50,11 @@ type classifyConfig struct {
 // (scoring the caller's speech) and text-shaped handlers default to
 // "assistant" (scoring the model's output) without each handler
 // re-doing the YAML map dance.
+//
+// Threshold params (min_score / max_score) are deliberately NOT
+// parsed here — see the package convention note above.
 func parseClassifyConfig(params map[string]any, defaultRole string) (classifyConfig, error) {
 	cfg := classifyConfig{
-		minScore:     classifyDefaultMinScore,
 		messageRole:  defaultRole,
 		messageIndex: -1,
 	}
@@ -64,9 +70,6 @@ func parseClassifyConfig(params map[string]any, defaultRole string) (classifyCon
 	}
 	cfg.expectedLabel = expected
 
-	if v, ok := extractFloat64(params, classifyKeyMinScore); ok {
-		cfg.minScore = v
-	}
 	if v, ok := params["message_role"].(string); ok && v != "" {
 		cfg.messageRole = v
 	}
@@ -78,13 +81,26 @@ func parseClassifyConfig(params map[string]any, defaultRole string) (classifyCon
 	if v, ok := params["classifier_id"].(string); ok {
 		cfg.classifierID = v
 	}
+
+	// Surface a clear error if the caller put a threshold on the
+	// inner eval. Threshold judgment lives on the assertion wrapper,
+	// not on the eval primitive — silently accepting a no-op param
+	// would hide a config mistake the user expected to be enforced.
+	for _, banned := range []string{"min_score", "max_score"} {
+		if _, present := params[banned]; present {
+			return cfg, errors.New(
+				banned + " is not a valid param on a classify-backed eval; " +
+					"wrap with `type: assertion` and put the threshold there " +
+					"(see runtime/evals/wrappers.go)")
+		}
+	}
 	return cfg, nil
 }
 
 // findExpectedLabel walks the classifier's scored output looking for
 // the configured expected_label (case-insensitive). foundLabel is empty
 // when the model didn't emit that label at all (a distinct outcome
-// from "found but below threshold").
+// from "found but low score").
 func findExpectedLabel(
 	scores []classify.LabelScore, expectedLabel string,
 ) (foundScore float64, foundLabel string) {

--- a/runtime/evals/handlers/text_classify_helpers.go
+++ b/runtime/evals/handlers/text_classify_helpers.go
@@ -12,52 +12,14 @@ import (
 )
 
 // Text-specific infrastructure on top of classify_handler_base.go.
-// The shared base owns the model + expected_label + min_score +
-// message_role + message_index + classifier_id parsing and the label
-// lookup; this file adds the text-specific deltas: max_score
-// upper-bound mode (for toxicity-style "stay below X" framings) and
-// text extraction from the message log.
+// Pure eval primitives — see the convention note in
+// classify_handler_base.go: threshold judgment lives on the
+// `type: assertion` wrapper, not on these handlers.
 
 // textClassifyDefaultRole defaults text scoring to the assistant's
 // output. Toxicity and sentiment assertions are almost always about
 // what the model said, not what the user said.
 const textClassifyDefaultRole = "assistant"
-
-// textClassifyConfig extends the shared classifyConfig with the
-// max_score upper-bound mode. Only text_toxicity opts into it; sentiment
-// keeps the inherited min_score-only shape.
-type textClassifyConfig struct {
-	classifyConfig
-	maxScore    float64
-	hasMaxScore bool
-}
-
-// parseTextClassifyParams runs the shared classify-config parser, then
-// reads the text-specific max_score knob. allowMaxScore gates whether
-// max_score is even read — sentiment-style handlers reject it to keep
-// the param surface unambiguous. Combining min_score with max_score is
-// also rejected.
-func parseTextClassifyParams(params map[string]any, allowMaxScore bool) (textClassifyConfig, error) {
-	base, err := parseClassifyConfig(params, textClassifyDefaultRole)
-	if err != nil {
-		return textClassifyConfig{}, err
-	}
-	cfg := textClassifyConfig{classifyConfig: base}
-
-	_, minProvided := extractFloat64(params, classifyKeyMinScore)
-	_, maxProvided := extractFloat64(params, classifyKeyMaxScore)
-	if maxProvided && !allowMaxScore {
-		return cfg, errors.New("max_score is not supported for this handler; use min_score")
-	}
-	if minProvided && maxProvided {
-		return cfg, errors.New("min_score and max_score are mutually exclusive")
-	}
-	if v, ok := extractFloat64(params, classifyKeyMaxScore); ok {
-		cfg.maxScore = v
-		cfg.hasMaxScore = true
-	}
-	return cfg, nil
-}
 
 // resolveTextClassifier pulls the classify.Registry out of context and
 // looks up the requested classifier. An empty id resolves the
@@ -121,76 +83,59 @@ func pickText(texts []string, index int) (string, error) {
 	return texts[index], nil
 }
 
-// gradeTextClassify looks up the expected label in the classifier's
-// scored output and applies the configured threshold. With hasMaxScore
-// set the assertion passes when score < maxScore (upper-bound mode);
-// otherwise it passes when score >= minScore (the standard mode).
+// gradeTextClassify looks up the expected_label in the classifier's
+// scored output and emits its score. Pure eval primitive: no
+// threshold judgment — that lives on the `type: assertion` wrapper.
+//
+// "label not returned by model" emits Score = 0 with a louder
+// Explanation; downstream wrapper-driven thresholds compute the right
+// pass/fail outcome from the zero.
 func gradeTextClassify(
-	handlerType string, cfg *textClassifyConfig, scores []classify.LabelScore,
+	handlerType string, cfg *classifyConfig, scores []classify.LabelScore,
 ) *evals.EvalResult {
 	foundScore, foundLabel := findExpectedLabel(scores, cfg.expectedLabel)
 	if foundLabel == "" {
+		zero := 0.0
 		allLabels := strings.Join(labelsFromScores(scores), ", ")
 		return &evals.EvalResult{
-			Type:  handlerType,
-			Score: boolScore(false),
-			Value: map[string]any{
-				classifyKeyExpectedLabel: cfg.expectedLabel,
-				keyFound:                 false,
-			},
+			Type:        handlerType,
+			Score:       &zero,
+			MetricValue: &zero,
 			Explanation: fmt.Sprintf("label %q not returned by model; got: %s",
 				cfg.expectedLabel, allLabels),
-			Details: map[string]any{classifyKeyScores: scores},
+			Details: map[string]any{
+				classifyKeyExpectedLabel: cfg.expectedLabel,
+				classifyKeyActualScore:   0.0,
+				classifyKeyScores:        scores,
+				keyFound:                 false,
+			},
 		}
 	}
-
-	var (
-		passed      bool
-		threshold   float64
-		comparison  string
-		thresholdKy string
-	)
-	if cfg.hasMaxScore {
-		passed = foundScore < cfg.maxScore
-		threshold = cfg.maxScore
-		comparison = "<"
-		thresholdKy = classifyKeyMaxScore
-	} else {
-		passed = foundScore >= cfg.minScore
-		threshold = cfg.minScore
-		comparison = ">="
-		thresholdKy = classifyKeyMinScore
-	}
-
 	scoreCopy := foundScore
 	return &evals.EvalResult{
 		Type:        handlerType,
 		Score:       &scoreCopy,
 		MetricValue: &scoreCopy,
-		Value: map[string]any{
+		Explanation: fmt.Sprintf("%s score %.3f", foundLabel, foundScore),
+		Details: map[string]any{
 			classifyKeyExpectedLabel: cfg.expectedLabel,
-			thresholdKy:              threshold,
 			classifyKeyActualScore:   foundScore,
-			classifyKeyPassed:        passed,
+			classifyKeyScores:        scores,
 		},
-		Explanation: fmt.Sprintf("%s score %.3f (threshold %s %.3f)",
-			foundLabel, foundScore, comparison, threshold),
-		Details: map[string]any{classifyKeyScores: scores},
 	}
 }
 
 // runTextClassifyEval is the shared body for both text handlers. It
 // resolves the classifier, picks the target text, calls the backend,
-// and grades. Splitting into a helper keeps the per-handler files to
-// thin wrappers that just nominate the eval type and param mode.
+// and emits the score. Splits into a helper so per-handler files stay
+// thin wrappers that just nominate the eval type.
 func runTextClassifyEval(
 	ctx context.Context,
 	evalCtx *evals.EvalContext,
 	handlerType string,
 	params map[string]any,
-	allowMaxScore bool,
 ) *evals.EvalResult {
-	cfg, cfgErr := parseTextClassifyParams(params, allowMaxScore)
+	cfg, cfgErr := parseClassifyConfig(params, textClassifyDefaultRole)
 	if cfgErr != nil {
 		return errorResult(handlerType, cfgErr.Error())
 	}
@@ -221,7 +166,7 @@ func runTextClassifyEval(
 
 	opts := classify.TextOptions{
 		Model:      cfg.model,
-		MultiLabel: true, // request scores for every label so we can grade any expected_label
+		MultiLabel: true, // request scores for every label so any expected_label can be looked up
 	}
 	scores, classifyErr := classifier.ClassifyText(ctx, text, opts)
 	if classifyErr != nil {

--- a/runtime/evals/handlers/text_classify_test.go
+++ b/runtime/evals/handlers/text_classify_test.go
@@ -14,6 +14,16 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// text_toxicity / text_sentiment are PURE EVAL PRIMITIVES — they emit
+// the score for the configured expected_label and never apply a
+// threshold. Threshold judgment is the job of `type: assertion`
+// wrappers; see runtime/evals/handlers/CLAUDE.md.
+//
+// These tests exercise the pure-eval contract: Score = raw model score
+// for expected_label (or 0 when absent), threshold params rejected,
+// pure plumbing (registry resolution, role-based message selection,
+// text extraction).
+
 // hfTextTestServer mints an httptest.Server that returns the supplied
 // labels in the nested HF text-classification shape — `[[{label, score},
 // ...]]`. That matches what HF emits when `return_all_scores: true` is
@@ -44,14 +54,11 @@ func ctxWithTextRegistry(t *testing.T, srvURL string) context.Context {
 }
 
 // textMessage returns a single message carrying inline text content.
-// Uses the Content field (the common shape produced by chat providers)
-// rather than a Parts entry so the test exercises the merged extraction
-// path.
 func textMessage(role, body string) types.Message {
 	return types.Message{Role: role, Content: body}
 }
 
-func TestTextSentiment_PassesWhenLabelMeetsThreshold(t *testing.T) {
+func TestTextSentiment_EmitsScoreForExpectedLabel(t *testing.T) {
 	srv := hfTextTestServer(t, []classify.LabelScore{
 		{Label: "POSITIVE", Score: 0.91},
 		{Label: "NEGATIVE", Score: 0.09},
@@ -65,155 +72,75 @@ func TestTextSentiment_PassesWhenLabelMeetsThreshold(t *testing.T) {
 	}, map[string]any{
 		"model":          "distilbert-base-uncased-finetuned-sst-2-english",
 		"expected_label": "POSITIVE",
-		"min_score":      0.7,
 	})
 	if err != nil {
 		t.Fatalf("Eval: %v", err)
 	}
 	if res.Skipped {
-		t.Fatalf("expected pass, got skipped: %s", res.SkipReason)
+		t.Fatalf("expected emit, got skipped: %s", res.SkipReason)
 	}
 	if res.Error != "" {
-		t.Fatalf("expected pass, got error: %s", res.Error)
+		t.Fatalf("expected emit, got error: %s", res.Error)
 	}
-	if res.Score == nil || *res.Score < 0.7 {
-		t.Errorf("score = %v, want >= 0.7", res.Score)
+	if res.Score == nil || *res.Score != 0.91 {
+		t.Errorf("Score = %v, want 0.91", res.Score)
+	}
+	if res.Details["actual_score"].(float64) != 0.91 {
+		t.Errorf("Details.actual_score = %v, want 0.91", res.Details["actual_score"])
 	}
 }
 
-func TestTextSentiment_FailsBelowThreshold(t *testing.T) {
+func TestTextToxicity_EmitsScoreForExpectedLabel(t *testing.T) {
 	srv := hfTextTestServer(t, []classify.LabelScore{
-		{Label: "POSITIVE", Score: 0.40},
-		{Label: "NEGATIVE", Score: 0.60},
-	})
-	defer srv.Close()
-
-	ctx := ctxWithTextRegistry(t, srv.URL)
-	h := &TextSentimentHandler{}
-	res, _ := h.Eval(ctx, &evals.EvalContext{
-		Messages: []types.Message{textMessage("assistant", "Whatever, I tried.")},
-	}, map[string]any{
-		"model":          "x/y",
-		"expected_label": "POSITIVE",
-		"min_score":      0.7,
-	})
-	val, _ := res.Value.(map[string]any)
-	if val["actual_score"].(float64) != 0.40 {
-		t.Errorf("actual_score = %v, want 0.40", val["actual_score"])
-	}
-	if passed, _ := val["passed"].(bool); passed {
-		t.Errorf("passed=true when score 0.40 < threshold 0.70")
-	}
-}
-
-func TestTextSentiment_RejectsMaxScore(t *testing.T) {
-	ctx := classify.WithRegistry(context.Background(), classify.NewRegistry())
-	h := &TextSentimentHandler{}
-	res, _ := h.Eval(ctx, &evals.EvalContext{}, map[string]any{
-		"model":          "x/y",
-		"expected_label": "POSITIVE",
-		"max_score":      0.5,
-	})
-	if !strings.Contains(res.Error, "max_score is not supported") {
-		t.Errorf("error %q should reject max_score for sentiment", res.Error)
-	}
-}
-
-func TestTextToxicity_PassesWhenBelowMaxScore(t *testing.T) {
-	srv := hfTextTestServer(t, []classify.LabelScore{
-		{Label: "toxic", Score: 0.05},
-		{Label: "severe_toxic", Score: 0.01},
+		{Label: "toxic", Score: 0.84},
+		{Label: "severe_toxic", Score: 0.41},
 	})
 	defer srv.Close()
 
 	ctx := ctxWithTextRegistry(t, srv.URL)
 	h := &TextToxicityHandler{}
 	res, err := h.Eval(ctx, &evals.EvalContext{
-		Messages: []types.Message{textMessage("assistant", "Here is the information you requested.")},
-	}, map[string]any{
-		"model":          "unitary/toxic-bert",
-		"expected_label": "toxic",
-		"max_score":      0.3,
-	})
-	if err != nil {
-		t.Fatalf("Eval: %v", err)
-	}
-	if res.Skipped {
-		t.Fatalf("expected pass, got skipped: %s", res.SkipReason)
-	}
-	val, _ := res.Value.(map[string]any)
-	if passed, _ := val["passed"].(bool); !passed {
-		t.Errorf("expected passed=true (toxic 0.05 < max 0.30); got %+v", val)
-	}
-	if !strings.Contains(res.Explanation, "<") {
-		t.Errorf("explanation should use < comparator for max_score mode: %q", res.Explanation)
-	}
-}
-
-func TestTextToxicity_FailsWhenAboveMaxScore(t *testing.T) {
-	srv := hfTextTestServer(t, []classify.LabelScore{
-		{Label: "toxic", Score: 0.84},
-	})
-	defer srv.Close()
-
-	ctx := ctxWithTextRegistry(t, srv.URL)
-	h := &TextToxicityHandler{}
-	res, _ := h.Eval(ctx, &evals.EvalContext{
 		Messages: []types.Message{textMessage("assistant", "You are awful.")},
 	}, map[string]any{
 		"model":          "unitary/toxic-bert",
 		"expected_label": "toxic",
-		"max_score":      0.3,
 	})
-	val, _ := res.Value.(map[string]any)
-	if passed, _ := val["passed"].(bool); passed {
-		t.Errorf("expected passed=false (toxic 0.84 > max 0.30); got %+v", val)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
 	}
 	if res.Score == nil || *res.Score != 0.84 {
-		t.Errorf("score = %v, want 0.84 (the actual model score)", res.Score)
+		t.Errorf("Score = %v, want 0.84", res.Score)
 	}
 }
 
-func TestTextToxicity_MinScoreModeAlsoWorks(t *testing.T) {
-	// s-nlp/roberta_toxicity_classifier emits "neutral"/"toxic" — the
-	// natural framing is "neutral score must be high", which uses the
-	// inherited min_score path.
-	srv := hfTextTestServer(t, []classify.LabelScore{
-		{Label: "neutral", Score: 0.88},
-		{Label: "toxic", Score: 0.12},
-	})
-	defer srv.Close()
-
-	ctx := ctxWithTextRegistry(t, srv.URL)
-	h := &TextToxicityHandler{}
-	res, _ := h.Eval(ctx, &evals.EvalContext{
-		Messages: []types.Message{textMessage("assistant", "Here is your answer.")},
-	}, map[string]any{
-		"model":          "s-nlp/roberta_toxicity_classifier",
-		"expected_label": "neutral",
-		"min_score":      0.7,
-	})
-	val, _ := res.Value.(map[string]any)
-	if passed, _ := val["passed"].(bool); !passed {
-		t.Errorf("expected passed=true (neutral 0.88 >= 0.70); got %+v", val)
-	}
-}
-
-func TestTextToxicity_RejectsBothMinAndMaxScore(t *testing.T) {
+func TestTextClassify_RejectsThresholdParams(t *testing.T) {
+	// Threshold judgment is the job of `type: assertion`. Putting
+	// min_score / max_score on the eval handler itself is a config
+	// mistake; both classify-backed text handlers surface it loudly.
 	ctx := classify.WithRegistry(context.Background(), classify.NewRegistry())
-	h := &TextToxicityHandler{}
-	res, _ := h.Eval(ctx, &evals.EvalContext{}, map[string]any{
-		"model":          "x/y",
-		"expected_label": "toxic",
-		"min_score":      0.5,
-		"max_score":      0.5,
-	})
-	if !strings.Contains(res.Error, "mutually exclusive") {
-		t.Errorf("error %q should reject combining min_score and max_score", res.Error)
+	type fixture struct {
+		name string
+		h    evals.EvalTypeHandler
+	}
+	for _, f := range []fixture{
+		{name: "text_sentiment", h: &TextSentimentHandler{}},
+		{name: "text_toxicity", h: &TextToxicityHandler{}},
+	} {
+		for _, banned := range []string{"min_score", "max_score"} {
+			res, _ := f.h.Eval(ctx, &evals.EvalContext{}, map[string]any{
+				"model":          "x/y",
+				"expected_label": "POSITIVE",
+				banned:           0.5,
+			})
+			if !strings.Contains(res.Error, banned+" is not a valid param") {
+				t.Errorf("%s with %s should be rejected; got Error=%q",
+					f.name, banned, res.Error)
+			}
+		}
 	}
 }
 
-func TestTextClassify_LabelMissingFromModelOutput(t *testing.T) {
+func TestTextClassify_LabelMissingFromModelOutputEmitsZero(t *testing.T) {
 	srv := hfTextTestServer(t, []classify.LabelScore{
 		{Label: "neutral", Score: 0.95},
 	})
@@ -227,6 +154,9 @@ func TestTextClassify_LabelMissingFromModelOutput(t *testing.T) {
 		"model":          "x/y",
 		"expected_label": "POSITIVE",
 	})
+	if res.Score == nil || *res.Score != 0 {
+		t.Errorf("Score = %v, want 0 (label not returned)", res.Score)
+	}
 	if !strings.Contains(res.Explanation, "not returned by model") {
 		t.Errorf("explanation %q should call out missing label", res.Explanation)
 	}
@@ -314,7 +244,6 @@ func TestTextClassify_MessageIndexPicksSpecificMessage(t *testing.T) {
 			"model":          "x/y",
 			"expected_label": "POSITIVE",
 			"message_index":  idx,
-			"min_score":      0.5,
 		})
 		if res.Error != "" {
 			t.Errorf("idx=%d unexpected error: %s", idx, res.Error)
@@ -342,7 +271,8 @@ func TestTextClassify_MessageIndexOutOfRangeErrors(t *testing.T) {
 func TestTextClassify_MultipartTextMerged(t *testing.T) {
 	// Multi-part message: Content + a ContentTypeText part. Verify both
 	// contribute by sending a model that always returns POSITIVE 0.99
-	// regardless of input — we're just asserting no Error path is hit.
+	// regardless of input — we're just asserting no Error path is hit
+	// and the score flows through.
 	srv := hfTextTestServer(t, []classify.LabelScore{{Label: "POSITIVE", Score: 0.99}})
 	defer srv.Close()
 	ctx := ctxWithTextRegistry(t, srv.URL)
@@ -359,12 +289,14 @@ func TestTextClassify_MultipartTextMerged(t *testing.T) {
 	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{msg}}, map[string]any{
 		"model":          "x/y",
 		"expected_label": "POSITIVE",
-		"min_score":      0.5,
 	})
 	if res.Error != "" {
 		t.Fatalf("unexpected error: %s", res.Error)
 	}
 	if res.Skipped {
-		t.Fatalf("expected pass, got skipped: %s", res.SkipReason)
+		t.Fatalf("expected emit, got skipped: %s", res.SkipReason)
+	}
+	if res.Score == nil || *res.Score != 0.99 {
+		t.Errorf("Score = %v, want 0.99", res.Score)
 	}
 }

--- a/runtime/evals/handlers/text_sentiment.go
+++ b/runtime/evals/handlers/text_sentiment.go
@@ -6,34 +6,46 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// TextSentimentHandler scores text against a sentiment classification
-// model (e.g. `cardiffnlp/twitter-roberta-base-sentiment-latest`,
-// `distilbert-base-uncased-finetuned-sst-2-english`) and grades against
-// a configurable threshold.
+// TextSentimentHandler is a pure eval primitive: it scores text against
+// a sentiment classification model (e.g.
+// `cardiffnlp/twitter-roberta-base-sentiment-latest`,
+// `distilbert-base-uncased-finetuned-sst-2-english`) and emits the
+// score for the chosen expected_label.
 //
-// Mirrors `audio_emotion` exactly: the assertion passes when the chosen
-// label's score is at-or-above `min_score`. No max_score support —
-// "this output should have positive sentiment" is the canonical use
-// case, and the lower-bound framing is what naturally fits. If the
-// inverse is wanted (avoid a label), point the assertion at the
-// opposing label and keep the same min_score semantics.
+// Threshold judgment lives on the `type: assertion` wrapper:
+//
+//   - type: assertion
+//     params:
+//     eval_type: text_sentiment
+//     eval_params:
+//     model: cardiffnlp/twitter-roberta-base-sentiment-latest
+//     expected_label: positive
+//     min_score: 0.7
+//
+// Pack-level runtime eval (emits raw signal, no judgment):
+//
+//	evals:
+//	  - id: response-sentiment
+//	    type: text_sentiment
+//	    trigger: every_turn
+//	    params:
+//	      model: cardiffnlp/twitter-roberta-base-sentiment-latest
+//	      expected_label: positive
 //
 // Params:
-//   - model         string  (required) — backend model id
-//   - expected_label string (required) — label that must score >= min_score
-//   - min_score     float   (optional, default 0.5)
+//   - model         string  (required)
+//   - expected_label string (required)
 //   - message_role  string  (optional, default "assistant")
-//   - message_index int     (optional, default -1 = latest match)
+//   - message_index int     (optional, default -1)
 //   - classifier_id string  (optional)
 type TextSentimentHandler struct{}
 
 // Type returns the eval type identifier.
 func (h *TextSentimentHandler) Type() string { return "text_sentiment" }
 
-// Eval runs the shared text-classify pipeline with max_score disallowed
-// so the parameter surface stays unambiguous.
+// Eval runs the shared text-classify pipeline.
 func (h *TextSentimentHandler) Eval(
 	ctx context.Context, evalCtx *evals.EvalContext, params map[string]any,
 ) (*evals.EvalResult, error) {
-	return runTextClassifyEval(ctx, evalCtx, h.Type(), params, false), nil
+	return runTextClassifyEval(ctx, evalCtx, h.Type(), params), nil
 }

--- a/runtime/evals/handlers/text_toxicity.go
+++ b/runtime/evals/handlers/text_toxicity.go
@@ -6,42 +6,52 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// TextToxicityHandler scores text against a toxicity classification model
-// (e.g. `unitary/toxic-bert`, `s-nlp/roberta_toxicity_classifier`) and
-// grades against a configurable threshold. Distinct from the legacy
-// `toxicity` handler, which is an LLM-judge with the same name —
-// `text_toxicity` is the deterministic classifier path that depends on
+// TextToxicityHandler is a pure eval primitive: it scores text
+// against a toxicity classification model (e.g. `unitary/toxic-bert`,
+// `s-nlp/roberta_toxicity_classifier`) and emits the score for the
+// chosen expected_label. Distinct from the legacy `toxicity` handler,
+// which is an LLM-judge with the same name — `text_toxicity` is the
+// deterministic classifier path that depends on
 // `classify.TextClassifier` and an `inference` provider.
 //
-// The handler supports two grading modes:
-//   - max_score (default usage): pass when the expected label's score
-//     stays BELOW the threshold. Natural for "this output should NOT be
-//     toxic" assertions, e.g. `expected_label: toxic, max_score: 0.3`.
-//   - min_score: pass when the expected label's score is at-or-above the
-//     threshold. Useful when the model emits a positive label like
-//     "neutral" (s-nlp/roberta_toxicity_classifier) and the assertion
-//     wants `expected_label: neutral, min_score: 0.7`.
+// Threshold judgment lives on the `type: assertion` wrapper:
 //
-// Specifying both min_score and max_score is rejected — pick one mode.
+//	# "this output should NOT be toxic"
+//	- type: assertion
+//	  params:
+//	    eval_type: text_toxicity
+//	    eval_params: { model: unitary/toxic-bert, expected_label: toxic }
+//	    max_score: 0.3
+//
+//	# "this output should sit in the neutral class"
+//	- type: assertion
+//	  params:
+//	    eval_type: text_toxicity
+//	    eval_params: { model: s-nlp/roberta_toxicity_classifier, expected_label: neutral }
+//	    min_score: 0.7
+//
+// Pack-level runtime eval (emits the raw signal, no judgment):
+//
+//	evals:
+//	  - id: response-toxicity
+//	    type: text_toxicity
+//	    trigger: every_turn
+//	    params: { model: unitary/toxic-bert, expected_label: toxic }
 //
 // Params:
 //   - model         string  (required) — backend model id
-//   - expected_label string (required) — label to grade
-//   - max_score     float   (optional) — pass when label score < max_score
-//   - min_score     float   (optional, default 0.5) — pass when label score >= min_score
-//   - message_role  string  (optional, default "assistant") — which speaker's text to score
-//   - message_index int     (optional, default -1 = latest match)
-//   - classifier_id string  (optional) — explicit registry id; empty uses configured default
+//   - expected_label string (required) — label whose score is emitted
+//   - message_role  string  (optional, default "assistant")
+//   - message_index int     (optional, default -1)
+//   - classifier_id string  (optional)
 type TextToxicityHandler struct{}
 
 // Type returns the eval type identifier.
 func (h *TextToxicityHandler) Type() string { return "text_toxicity" }
 
-// Eval runs the shared text-classify pipeline with max_score allowed —
-// toxicity assertions almost always want the "stay below X" framing,
-// but the upper-bound form is purely an opt-in.
+// Eval runs the shared text-classify pipeline.
 func (h *TextToxicityHandler) Eval(
 	ctx context.Context, evalCtx *evals.EvalContext, params map[string]any,
 ) (*evals.EvalResult, error) {
-	return runTextClassifyEval(ctx, evalCtx, h.Type(), params, true), nil
+	return runTextClassifyEval(ctx, evalCtx, h.Type(), params), nil
 }


### PR DESCRIPTION
## Summary

PromptKit's `runtime/evals/` has a three-role split — **eval** primitives, **assertion** wrappers (`type: assertion`), **guardrail** wrappers (`type: guardrail`) — that all consume the same inner eval handler via the `EvalTypeRegistry`. The split lets one inner eval be declared once in a pack's `evals:` block (emits a metric every turn), reused as an Arena assertion (graded against a threshold), and fired as a runtime guardrail (blocks at runtime).

The classify-backed handlers I shipped in #1218 and #1231 (`audio_emotion`, `text_toxicity`, `text_sentiment`) bypassed the wrapper and applied `min_score` / `max_score` thresholds inside the inner handler. That conflated eval and assertion in one call, shadowed the existing `assertion` wrapper, and stopped these handlers from being used cleanly in pack `evals:` blocks for metric-style runtime observation.

## What changes

- **Strip threshold logic** from `audio_emotion`, `text_toxicity`, `text_sentiment`. They emit `Score` = raw model score for `expected_label` (or 0 if the label is absent), `MetricValue` = same, structured info in `Details`. No `Value` field, no `passed` flag — the assertion wrapper handles those.
- **Actively reject** `min_score` / `max_score` on the inner-eval params at parse time. `parseClassifyConfig` returns an error pointing at `type: assertion` so the conflation can't sneak back in.
- **Migrate** `examples/voice-refund-demo` to wrap with `type: assertion` (the canonical scenario shape).
- **Rewrite** the reference docs (Classify-backed Checks section) to show the two declaration sites — pack-level `evals:` for the raw signal, `type: assertion` for graded scenario assertions. Document the `assertion` wrapper as a first-class reference entry.
- **Add `runtime/evals/handlers/CLAUDE.md`** codifying the convention so future handlers don't drift. Enumerates the anti-patterns (self-grading, setting `Value` on the inner result, dual thresholds modes) and grandfathers the legacy LLM-judge family.
- **Memory note** for future agent sessions: `feedback_eval_primitives_no_self_grading.md`.

## What doesn't change

- No new public type. No API breakage at the scenario YAML layer once you migrate to the wrapper.
- Behaviour at runtime is identical when wrapped: the wrapper produces the same pass/fail outcome the inner handler used to compute.
- The `assertion` and `guardrail` wrappers already existed in `runtime/evals/wrappers.go`; this PR adopts them rather than introducing them.

## Test plan
- [x] `go test ./runtime/evals/... -count=1 -race` — passes (14 new/updated tests including `TestAudioEmotion_RejectsThresholdParams` and `TestTextClassify_RejectsThresholdParams`)
- [x] Coverage on new files: 89.6% / 89.7% / 96.1% / 100% / 100%
- [x] `golangci-lint run ./evals/handlers/...` — clean
- [x] `npm run build` in `docs/` — clean
- [x] `voice-refund-demo` aggressive-refund — `assertion_4_assertion` runs through the wrapper, threshold judgment applied correctly
- [ ] CI green

Refs the eval/assertion/guardrail split established in #1196 and the classify foundation shipped in #1215-#1222.