### PR TITLE
fix(hf): treat 'model not supported' responses as Skipped, not Error

### DIFF
--- a/examples/voice-refund-demo/providers/hf.provider.yaml
+++ b/examples/voice-refund-demo/providers/hf.provider.yaml
@@ -21,10 +21,13 @@
 #      models like `SamLowe/roberta-base-go_emotions` but not for the
 #      SER models the audio_emotion handler is wired against.
 #
-# Without an inference endpoint deployed, audio_emotion will skip with
-# "Model not supported by provider hf-inference" rather than failing
-# the scenario. To test the inference foundation without an endpoint,
-# run `go run ./tools/arena/cmd/ser-probe -text "..."` against a text
+# Without an inference endpoint deployed, audio_emotion skips with
+# "model not supported by the configured inference path" rather than
+# failing the scenario (the HF backend's ErrModelNotSupported sentinel
+# routes the response through Skipped — see runtime/classify/backends/
+# hf/client.go and runtime/evals/handlers/audio_emotion.go). To test
+# the inference foundation without an endpoint, run
+# `go run ./tools/arena/cmd/ser-probe -text "..."` against a text
 # emotion model.
 #
 apiVersion: promptkit.altairalabs.ai/v1alpha1

--- a/runtime/classify/backends/hf/client.go
+++ b/runtime/classify/backends/hf/client.go
@@ -68,6 +68,17 @@ const modelLoadingMaxRetries = 3
 // isn't broken, it just hasn't initialized yet.
 var ErrModelLoading = errors.New("hf: model still loading after retries")
 
+// ErrModelNotSupported is returned when HF rejects the request
+// because the configured model isn't supported on the targeted
+// inference path — typically a retired free-tier audio model on
+// `router.huggingface.co/hf-inference` (HF retired most audio
+// classifiers from serverless in early 2026). Distinct from
+// ErrModelLoading: the model isn't going to become available by
+// waiting. Eval handlers should treat it as Skipped so demos run
+// cleanly when no Inference Endpoint is deployed, rather than
+// failing the scenario.
+var ErrModelNotSupported = errors.New("hf: model not supported by the configured inference path")
+
 // Config holds construction parameters for Client.
 type Config struct {
 	// APIKey is the HF token. Falls back to HF_TOKEN /
@@ -216,6 +227,18 @@ func (c *Client) do(ctx context.Context, modelURL, contentType string, body []by
 			}
 			// Loop to next attempt.
 		default:
+			// Detect "model not supported by the configured inference
+			// path" responses up front. HF returns a structured 4xx
+			// body shape — the exact wording drifts over time, so we
+			// match on the error-message substring rather than the
+			// status code alone. Surfacing as a sentinel error lets
+			// eval handlers route this through Skipped instead of
+			// Error, which matters for keyless / free-tier demos
+			// where the user can't fix the underlying model
+			// availability.
+			if isUnsupportedModelResponse(respBody) {
+				return nil, fmt.Errorf("%w: %s", ErrModelNotSupported, truncateBody(respBody))
+			}
 			return nil, fmt.Errorf("hf: status %d: %s", resp.StatusCode, truncateBody(respBody))
 		}
 	}
@@ -240,6 +263,31 @@ func parseEstimatedWait(body []byte, fallback time.Duration) time.Duration {
 		return maxLoadingWaitCap
 	}
 	return wait
+}
+
+// isUnsupportedModelResponse heuristically detects HF responses that
+// mean "this model isn't routable on the configured inference path"
+// rather than "this is a real backend error". The known shapes (as
+// of 2026-05) are 4xx responses with a JSON body whose `error` field
+// contains "not supported" — for retired-from-serverless models this
+// is the canonical HF reply on the public router endpoint. We match
+// case-insensitively on the substring to absorb minor wording drift.
+//
+// Conservative on purpose: real backend errors (5xx, timeouts, auth
+// failures) don't carry "not supported" in the body and continue to
+// surface as Error so the user sees them. Two heuristics share the
+// detection budget — the JSON-typed `error` field and a raw-text
+// fallback for non-JSON bodies (HF occasionally returns plaintext on
+// platform errors).
+func isUnsupportedModelResponse(body []byte) bool {
+	const marker = "not supported"
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Error != "" {
+		return strings.Contains(strings.ToLower(parsed.Error), marker)
+	}
+	return strings.Contains(strings.ToLower(string(body)), marker)
 }
 
 // truncateBody trims a response body for inclusion in an error

--- a/runtime/classify/backends/hf/client_test.go
+++ b/runtime/classify/backends/hf/client_test.go
@@ -288,6 +288,63 @@ func TestClient_NonRetryableHTTPError(t *testing.T) {
 	}
 }
 
+func TestClient_ModelNotSupported_JSONErrorBody(t *testing.T) {
+	// HF's canonical "this model isn't routable on the configured
+	// inference path" response: a 4xx with `{"error":"Model ... is
+	// not supported ..."}`. Routes through ErrModelNotSupported so
+	// eval handlers can map it to Skipped.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintln(w, `{"error":"Model superb/wav2vec2-base-superb-er is not supported for task audio-classification on provider hf-inference"}`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	_, err := c.ClassifyAudio(context.Background(), []byte("x"), classify.AudioOptions{Model: "superb/wav2vec2-base-superb-er"})
+	if !errors.Is(err, ErrModelNotSupported) {
+		t.Fatalf("err = %v, want ErrModelNotSupported", err)
+	}
+}
+
+func TestClient_ModelNotSupported_PlaintextBody(t *testing.T) {
+	// Fallback path: HF occasionally returns plaintext on platform
+	// errors. The marker-substring check applies to the raw body too.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintln(w, "Model not supported")
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	_, err := c.ClassifyAudio(context.Background(), []byte("x"), classify.AudioOptions{Model: "m"})
+	if !errors.Is(err, ErrModelNotSupported) {
+		t.Fatalf("err = %v, want ErrModelNotSupported", err)
+	}
+}
+
+func TestClient_GenericHTTPError_StaysAsError(t *testing.T) {
+	// Real backend errors (auth failures, etc.) don't contain "not
+	// supported" — they must continue to surface as Error so the user
+	// sees them, not get hidden by the unsupported-model heuristic.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintln(w, `{"error":"invalid token"}`)
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Config{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+
+	_, err := c.ClassifyAudio(context.Background(), []byte("x"), classify.AudioOptions{Model: "m"})
+	if err == nil {
+		t.Fatal("401 must surface as error")
+	}
+	if errors.Is(err, ErrModelNotSupported) {
+		t.Errorf("401 'invalid token' must NOT be classified as ErrModelNotSupported: %v", err)
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error must include status code; got %v", err)
+	}
+}
+
 func TestClient_ContextCancellationDuringRetry(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/runtime/evals/handlers/audio_emotion.go
+++ b/runtime/evals/handlers/audio_emotion.go
@@ -109,6 +109,17 @@ func (h *AudioEmotionHandler) Eval(
 		if errors.Is(classifyErr, classifyhf.ErrModelLoading) {
 			return skippedResult(h.Type(), "model still loading after retries"), nil
 		}
+		if errors.Is(classifyErr, classifyhf.ErrModelNotSupported) {
+			// The configured model can't be served on the configured
+			// inference path — typically a retired free-tier SER model
+			// on `router.huggingface.co/hf-inference`. Skip cleanly so
+			// keyless / free-tier demo runs don't fail the scenario;
+			// the user fixes the config by deploying an Inference
+			// Endpoint or picking a model the path supports.
+			return skippedResult(h.Type(),
+				"model not supported by the configured inference path "+
+					"(deploy an HF Inference Endpoint or pick a supported model)"), nil
+		}
 		return errorResult(h.Type(), fmt.Sprintf("classify failed: %v", classifyErr)), nil
 	}
 

--- a/runtime/evals/handlers/audio_emotion_test.go
+++ b/runtime/evals/handlers/audio_emotion_test.go
@@ -175,6 +175,37 @@ func TestAudioEmotion_SkippedOnModelLoading(t *testing.T) {
 	}
 }
 
+func TestAudioEmotion_SkippedOnModelNotSupported(t *testing.T) {
+	// HF retired most audio-classification models from the free
+	// serverless tier in early 2026. The HF client surfaces those
+	// as ErrModelNotSupported; the handler must route it to
+	// Skipped so keyless / free-tier demo runs don't fail the
+	// scenario (see #1234).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"Model superb/wav2vec2-base-superb-er is not supported for task audio-classification on provider hf-inference"}`))
+	}))
+	defer srv.Close()
+
+	ctx := ctxWithRegistry(t, srv.URL)
+	h := &AudioEmotionHandler{}
+	res, err := h.Eval(ctx, &evals.EvalContext{
+		Messages: []types.Message{audioMessage("user", "rawaudio")},
+	}, map[string]any{
+		"model":          "superb/wav2vec2-base-superb-er",
+		"expected_label": "angry",
+	})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if !res.Skipped {
+		t.Fatalf("expected Skipped on model-not-supported; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "not supported") {
+		t.Errorf("SkipReason %q should explain the model isn't supported", res.SkipReason)
+	}
+}
+
 func TestAudioEmotion_RejectsThresholdParams(t *testing.T) {
 	// Threshold judgment is the job of `type: assertion`. Putting
 	// min_score / max_score on the eval handler itself is a config

--- a/runtime/evals/handlers/text_classify_helpers.go
+++ b/runtime/evals/handlers/text_classify_helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -170,6 +171,18 @@ func runTextClassifyEval(
 	}
 	scores, classifyErr := classifier.ClassifyText(ctx, text, opts)
 	if classifyErr != nil {
+		if errors.Is(classifyErr, classifyhf.ErrModelLoading) {
+			return skippedResult(handlerType, "model still loading after retries")
+		}
+		if errors.Is(classifyErr, classifyhf.ErrModelNotSupported) {
+			// Symmetric with audio_emotion's handling — when the
+			// configured model can't be served on the configured
+			// inference path, skip cleanly so keyless / free-tier
+			// demo runs don't fail the scenario.
+			return skippedResult(handlerType,
+				"model not supported by the configured inference path "+
+					"(deploy an HF Inference Endpoint or pick a supported model)")
+		}
 		return errorResult(handlerType, fmt.Sprintf("classify failed: %v", classifyErr))
 	}
 

--- a/runtime/evals/handlers/text_classify_test.go
+++ b/runtime/evals/handlers/text_classify_test.go
@@ -184,6 +184,32 @@ func TestTextClassify_NoRegistryInContextSkips(t *testing.T) {
 	}
 }
 
+func TestTextClassify_SkippedOnModelNotSupported(t *testing.T) {
+	// Symmetric with audio_emotion: when HF surfaces ErrModelNotSupported,
+	// the handler must route it to Skipped so keyless / free-tier demos
+	// stay clean (see #1234).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"Model x/y is not supported for task text-classification on provider hf-inference"}`))
+	}))
+	defer srv.Close()
+	ctx := ctxWithTextRegistry(t, srv.URL)
+
+	h := &TextToxicityHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{
+		Messages: []types.Message{textMessage("assistant", "hello")},
+	}, map[string]any{
+		"model":          "x/y",
+		"expected_label": "toxic",
+	})
+	if !res.Skipped {
+		t.Fatalf("expected Skipped on model-not-supported; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "not supported") {
+		t.Errorf("SkipReason %q should explain the model isn't supported", res.SkipReason)
+	}
+}
+
 func TestTextClassify_NoTextInMessagesSkips(t *testing.T) {
 	srv := hfTextTestServer(t, []classify.LabelScore{{Label: "POSITIVE", Score: 0.9}})
 	defer srv.Close()


### PR DESCRIPTION
## Summary

`examples/voice-refund-demo/providers/hf.provider.yaml` documented that `audio_emotion` would skip cleanly when the configured HF model isn't supported on the configured inference path (the typical case after HF retired most audio-classification models from the free serverless tier in early 2026). The code didn't honor the promise — the HF client surfaced "Model X is not supported for task Y on provider hf-inference" as a generic HTTP error, the eval handler routed it through Error, and the assertion failed.

## Changes

- **New sentinel `ErrModelNotSupported`** in `runtime/classify/backends/hf/client.go`. `isUnsupportedModelResponse(body)` checks the response body (JSON `.error` field then raw text fallback) for "not supported" case-insensitively before falling through to the generic HTTP error path. Conservative heuristic — real backend errors (auth, gateway, payload-too-large) don't contain that substring.
- **Handler routing** in `runtime/evals/handlers/audio_emotion.go` and `runtime/evals/handlers/text_classify_helpers.go`: route `ErrModelNotSupported` through `skippedResult(...)` with a clear reason. Symmetric handling sits next to the existing `ErrModelLoading` branch.
- **Symmetry fix in scope**: the text-classify path was previously missing the `ErrModelLoading` routing entirely (pre-existing latent bug — a 503-during-warmup would fail the assertion). Fixed alongside the new wiring since both errors travel the same path.
- **Demo commentary** in `examples/voice-refund-demo/providers/hf.provider.yaml` updated to match the now-true behavior.

## Test plan
- [x] `go test ./runtime/classify/... ./runtime/evals/handlers/... -count=1 -race` — passes
- [x] Three new client tests: JSON-error body, plaintext fallback, **and a negative test** pinning that 401 'invalid token' does NOT get classified as `ErrModelNotSupported`
- [x] One new handler-level Skipped test for each call site (`TestAudioEmotion_SkippedOnModelNotSupported`, `TestTextClassify_SkippedOnModelNotSupported`)
- [x] `golangci-lint run ./classify/... ./evals/handlers/...` from `runtime/` — clean
- [x] Coverage on changed files: 89.7% / 89.9% / 94.5%
- [x] Code-reviewer agent pass: clean
- [ ] CI green

Closes #1234