### PR TITLE
refactor(evals): LLM-judge family rejects dead min_score; pure-eval primitives

### DIFF
--- a/docs/src/content/docs/arena/how-to/arena-ci-quality-gate.md
+++ b/docs/src/content/docs/arena/how-to/arena-ci-quality-gate.md
@@ -86,9 +86,11 @@ The default assertion behaviour is binary: pass if every assertion in every scen
 
 ```yaml
 assertions:
-  - type: llm_judge
+  - type: assertion
     params:
-      criteria: "Agent stayed professional under pressure"
+      eval_type: llm_judge
+      eval_params:
+        criteria: "Agent stayed professional under pressure"
       min_score: 0.7
     pass_threshold: 0.8     # 80% of trials must pass
 
@@ -138,7 +140,7 @@ For tight gates, also require:
 | Safety guardrail regression | `guardrail_triggered` | Reads `validations:` on the recorded message; no LLM cost; deterministic |
 | Model migration | `content_includes` / `outcome_equivalent` / `max_length` | Compare per-model outputs side by side; CI fails if any cell regresses |
 | Latency budget | `latency_budget` | Reads `LatencyMs` from the assistant message via the Arena bridge |
-| LLM-judged quality | `llm_judge` / `llm_judge_session` with `min_score` + `pass_threshold` | Use `pass_threshold` to tolerate stochastic noise; pair with `trials` for stability |
+| LLM-judged quality | `type: assertion` wrapping `llm_judge` / `llm_judge_session`, with `min_score` on the wrapper + `pass_threshold` on the assertion | Use `pass_threshold` to tolerate stochastic noise; pair with `trials` for stability |
 | RAG quality | `faithfulness` / `answer_relevancy` / `contextual_*` / `hallucination` | LLM-judged; same noise considerations |
 
 ## Failure recipes

--- a/docs/src/content/docs/arena/how-to/rag-agent.md
+++ b/docs/src/content/docs/arena/how-to/rag-agent.md
@@ -9,7 +9,7 @@ This how-to walks through `examples/rag-agent/` — the full named RAG primitive
 
 RAG eval frameworks compete on the primitive catalog: faithfulness, answer relevancy, contextual recall, hallucination. PromptArena ships those primitives in `runtime/evals/handlers/` (added in #1145) as thin wrappers over `llm_judge` with hardened default prompts adapted from public DeepEval / Ragas references (Apache 2.0).
 
-Each primitive is invokable as a scenario assertion with `min_score`. The demo runs all six against a single question + answer + retrieved context, with a mock LLM judge for keyless CI.
+Each primitive is a pure eval handler — it emits the judge's score. Wrap with `type: assertion` and a threshold to gate a scenario; the demo runs all six against a single question + answer + retrieved context, with a mock LLM judge for keyless CI.
 
 ## The assertion shape
 
@@ -18,29 +18,35 @@ turns:
   - role: user
     content: "What is the capital of France?"
     assertions:
-      - type: faithfulness
+      - type: assertion
         params:
-          contexts:
-            - "Paris is the capital and most populous city of France."
-            - "Located on the Seine River in north-central France."
-          judge: rag-judge
+          eval_type: faithfulness
+          eval_params:
+            contexts:
+              - "Paris is the capital and most populous city of France."
+              - "Located on the Seine River in north-central France."
+            judge: rag-judge
           min_score: 0.8
 
-      - type: answer_relevancy
+      - type: assertion
         params:
-          judge: rag-judge
+          eval_type: answer_relevancy
+          eval_params:
+            judge: rag-judge
           min_score: 0.8
 
-      - type: contextual_precision
+      - type: assertion
         params:
-          contexts: [...]
-          judge: rag-judge
+          eval_type: contextual_precision
+          eval_params:
+            contexts: [...]
+            judge: rag-judge
           min_score: 0.5
 
       # ... contextual_recall, contextual_relevancy, hallucination
 ```
 
-All six assertions share the same shape — the eval handler does the work; the assertion config supplies thresholds and (for the chunk-based primitives) the context.
+All six assertions share the same shape — the inner eval primitive does the work; the `type: assertion` wrapper supplies the threshold. See [the eval/assertion/guardrail split](/reference/checks/#classify-backed-checks) for why this layering matters.
 
 ## Three context sources
 
@@ -53,10 +59,12 @@ Every RAG handler accepts retrieved context in three forms (preference order):
 For a live RAG agent, the dynamic `context_field` form is the right shape:
 
 ```yaml
-- type: faithfulness
+- type: assertion
   params:
-    context_field: retrieved_chunks
-    judge: rag-judge
+    eval_type: faithfulness
+    eval_params:
+      context_field: retrieved_chunks
+      judge: rag-judge
     min_score: 0.8
 ```
 
@@ -76,7 +84,7 @@ promptarena run --ci --formats html,json
 open out/report.html
 ```
 
-Keyless: both the RAG assistant and the LLM judge are mock providers. The mock judge returns `{"passed": true, "score": 0.92, "reasoning": "..."}` for every call; all six assertions pass with the default `min_score` thresholds.
+Keyless: both the RAG assistant and the LLM judge are mock providers. The mock judge returns `{"passed": true, "score": 0.92, "reasoning": "..."}` for every call; all six assertions pass under the scenario's `min_score` thresholds (`0.8` for most, `0.5` for the contextual_precision / contextual_relevancy ratios).
 
 ## Swapping in a real judge
 

--- a/docs/src/content/docs/arena/how-to/text-negotiation.md
+++ b/docs/src/content/docs/arena/how-to/text-negotiation.md
@@ -62,13 +62,15 @@ All three at conversation level — they check the *end state*, not per-turn beh
 For stricter contracts, layer in `llm_judge_session` with criteria over the full conversation:
 
 ```yaml
-- type: llm_judge_session
+- type: assertion
   params:
-    criteria: |
-      Did the landlord maintain a professional negotiation posture
-      across all turns, avoiding capitulation while reaching an
-      acceptable deal? Score 1.0 if yes.
-    judge: default
+    eval_type: llm_judge_session
+    eval_params:
+      criteria: |
+        Did the landlord maintain a professional negotiation posture
+        across all turns, avoiding capitulation while reaching an
+        acceptable deal? Score 1.0 if yes.
+      judge: default
     min_score: 0.8
 ```
 

--- a/docs/src/content/docs/arena/how-to/voice-characterization.md
+++ b/docs/src/content/docs/arena/how-to/voice-characterization.md
@@ -72,13 +72,15 @@ The interesting tests are *cross-turn*: does the agent stay in role as the calle
 
 ```yaml
 conversation_assertions:
-  - type: llm_judge_session
+  - type: assertion
     params:
-      criteria: |
-        Did the agent maintain a calm, professional tone across all turns,
-        even when the caller escalated? Score 1.0 if yes, 0.0 if the agent
-        matched the caller's tone instead of staying composed.
-      judge: default
+      eval_type: llm_judge_session
+      eval_params:
+        criteria: |
+          Did the agent maintain a calm, professional tone across all turns,
+          even when the caller escalated? Score 1.0 if yes, 0.0 if the agent
+          matched the caller's tone instead of staying composed.
+        judge: default
       min_score: 0.8
 ```
 

--- a/docs/src/content/docs/arena/how-to/voice-red-team.md
+++ b/docs/src/content/docs/arena/how-to/voice-red-team.md
@@ -81,10 +81,16 @@ conversation_assertions:
      - type: pii_leakage
        params: { direction: output }
      - type: toxicity
-       params: { direction: output, min_score: 0.8 }
+       params: { direction: output }
      - type: role_violation
        params: { direction: output }
    ```
+
+   Thresholds (`min_score` / `max_score`) on the inner safety handler
+   are rejected — the underlying eval primitive emits a raw judge
+   score and the guardrail wrapper decides whether to fire. For
+   scenario-level pass/fail on the same primitive, wrap with
+   `type: assertion` and put the threshold there.
 
 3. Add scenarios that exercise each failure mode (toxic content, role-jailbreak attempts, bias probes).
 4. Run with `OPENAI_API_KEY` in your environment.

--- a/docs/src/content/docs/arena/reference/assertions.md
+++ b/docs/src/content/docs/arena/reference/assertions.md
@@ -94,9 +94,11 @@ turns:
 
 ```yaml
 conversation_assertions:
-  - type: llm_judge_session
+  - type: assertion
     params:
-      criteria: "The assistant maintained a helpful tone throughout"
+      eval_type: llm_judge_session
+      eval_params:
+        criteria: "The assistant maintained a helpful tone throughout"
       min_score: 0.8
     message: "Overall tone check"
 ```
@@ -178,12 +180,16 @@ Pick whichever reads better. `max_calls > 0` (e.g. "at most 3 lookups per turn")
 - role: user
   content: "Explain quantum computing to a child"
   assertions:
-    - type: llm_judge
+    - type: assertion
       params:
-        criteria: "The explanation is age-appropriate, avoids jargon, and uses analogies"
+        eval_type: llm_judge
+        eval_params:
+          criteria: "The explanation is age-appropriate, avoids jargon, and uses analogies"
         min_score: 0.7
       message: "Should be understandable by a child"
 ```
+
+`llm_judge` is a pure eval primitive — wrap with `type: assertion` to apply the threshold. Putting `min_score` directly on the inner handler is rejected at parse time.
 
 ### JSON Schema validation
 
@@ -226,11 +232,13 @@ All conditions are **AND-ed**: every specified field must be satisfied.
 - role: user
   content: "Search for recent papers on AI safety"
   assertions:
-    - type: llm_judge_tool_calls
+    - type: assertion
       when:
         tool_called: search_papers
       params:
-        criteria: "Search queries should be well-formed and specific"
+        eval_type: llm_judge_tool_calls
+        eval_params:
+          criteria: "Search queries should be well-formed and specific"
         min_score: 0.7
       message: "Search quality check"
 ```

--- a/docs/src/content/docs/arena/why-arena.md
+++ b/docs/src/content/docs/arena/why-arena.md
@@ -102,7 +102,7 @@ Demos:
 
 ## Test RAG with the standard primitives
 
-The named RAG primitives every buyer searches for — `faithfulness`, `hallucination`, `contextual_precision`, `contextual_recall`, `contextual_relevancy`, `answer_relevancy` — ship as eval handlers and are exercisable as scenario assertions with `min_score` / `pass_threshold`. PromptArena's framing isn't "we ship the RAG primitives" — it's "we ship the testing framework that consumes them, on a live retrieval agent rather than a fixed transcript."
+The named RAG primitives every buyer searches for — `faithfulness`, `hallucination`, `contextual_precision`, `contextual_recall`, `contextual_relevancy`, `answer_relevancy` — ship as pure eval handlers and are exercisable as scenario assertions by wrapping each with `type: assertion` and a threshold. PromptArena's framing isn't "we ship the RAG primitives" — it's "we ship the testing framework that consumes them, on a live retrieval agent rather than a fixed transcript."
 
 Demos:
 

--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -381,7 +381,7 @@ Generic wrapper that turns any eval primitive into a thresholded pass/fail. Clea
 | `min_score` | float | No | Pass when inner Score is at-or-above this |
 | `max_score` | float | No | Pass when inner Score is at-or-below this |
 
-If both `min_score` and `max_score` are set, both must hold. If neither is set, the default is `min_score: 1.0` (inner eval must fully pass).
+If both `min_score` and `max_score` are set, both must hold. If neither is set, the default is `min_score: 1.0` (inner eval must fully pass). For LLM-judge and classify-backed evals that emit raw scores in `[0,1)`, **set an explicit `min_score`** on the wrapper — leaving it unset will report every result as failed.
 
 Parallel handler: `guardrail` — same shape but consumes the eval at runtime to block, not assert.
 
@@ -389,7 +389,7 @@ Parallel handler: `guardrail` — same shape but consumes the eval at runtime to
 
 ## LLM Judge Checks
 
-LLM judge checks send the assistant output (or full session) to a language model for evaluation. The judge returns a score (0.0--1.0) and reasoning.
+LLM judge checks are pure eval primitives: they send the assistant output (or full session) to a language model for evaluation. The judge returns a score (0.0–1.0) and reasoning; the handler emits the raw score as `EvalResult.Score` and preserves the judge's `passed` opinion in `Details`. Threshold judgment lives on the [`assertion`](#assertion-wrapper) wrapper — putting `min_score` / `max_score` directly on an LLM-judge handler is rejected at parse time.
 
 ### `llm_judge`
 
@@ -401,7 +401,6 @@ Turn-level LLM evaluation. The judge sees the current assistant response and eva
 | `rubric` | string | No | Detailed scoring guidance |
 | `model` | string | No | Model to use for judging |
 | `system_prompt` | string | No | Override the default judge system prompt |
-| `min_score` | float | No | Minimum score threshold for passing |
 | `extra` | object | No | Additional provider-specific parameters |
 
 **Surfaces:** A E
@@ -421,15 +420,17 @@ Evaluates tool usage patterns via an LLM judge.
 | `criteria` | string | Yes | What the judge should evaluate about tool usage |
 | `tools` | string[] | No | Filter to specific tools |
 
-Plus all standard judge params (`rubric`, `model`, `system_prompt`, `min_score`, `extra`). **Surfaces:** A E
+Plus all standard judge params (`rubric`, `model`, `system_prompt`, `extra`). **Surfaces:** A E
 
 **Example:**
 
 ```yaml
 assertions:
-  - type: llm_judge
+  - type: assertion
     params:
-      criteria: "Response is empathetic and addresses the customer's concern"
+      eval_type: llm_judge
+      eval_params:
+        criteria: "Response is empathetic and addresses the customer's concern"
       min_score: 0.7
 ```
 
@@ -439,7 +440,7 @@ assertions:
 
 RAG checks are named eval primitives for retrieval-augmented generation: they score the answer against retrieved context (`faithfulness`, `hallucination`), the answer against the question (`answer_relevancy`), or the retrieved chunks against the question / ground truth (`contextual_precision`, `contextual_recall`, `contextual_relevancy`).
 
-Each handler is a thin wrapper over `llm_judge` with a hardened default prompt drawn from public DeepEval / Ragas reference implementations (Apache 2.0). The standard judge params (`rubric`, `model`, `system_prompt`, `min_score`, `extra`) all apply; supplying `system_prompt` or `criteria` overrides the default.
+Each handler is a thin wrapper over `llm_judge` with a hardened default prompt drawn from public DeepEval / Ragas reference implementations (Apache 2.0). Like `llm_judge`, the RAG handlers are pure eval primitives — wrap with [`assertion`](#assertion-wrapper) to apply a threshold. The standard judge params (`rubric`, `model`, `system_prompt`, `extra`) all apply; supplying `system_prompt` or `criteria` overrides the default.
 
 **Context sources** — every handler that needs retrieved chunks accepts them in three forms:
 
@@ -461,9 +462,11 @@ Plus standard judge params. **Surfaces:** A E
 
 ```yaml
 assertions:
-  - type: faithfulness
+  - type: assertion
     params:
-      context_field: retrieved_chunks
+      eval_type: faithfulness
+      eval_params:
+        context_field: retrieved_chunks
       min_score: 0.8
 ```
 
@@ -522,10 +525,12 @@ Plus standard judge params. **Surfaces:** A E
 
 ```yaml
 assertions:
-  - type: hallucination
+  - type: assertion
     params:
-      contexts:
-        - "Paris is the capital of France."
+      eval_type: hallucination
+      eval_params:
+        contexts:
+          - "Paris is the capital of France."
       min_score: 0.9
 ```
 
@@ -556,23 +561,19 @@ assertions:
       should_trigger: true
 ```
 
-Direct scenario invocation (`type: pii_leakage` in the `assertions:` block with `min_score`) is also supported by the generic plumbing, but bypasses the production-side guardrail and is not the documented default for safety primitives.
+For direct scenario invocation as a pass/fail assertion, wrap the safety primitive with `type: assertion` and set `min_score` on the wrapper. Putting `min_score` / `max_score` directly on a safety handler is rejected — see the [eval/assertion wrapper](#assertion-wrapper) for the canonical shape.
 
-LLM-judged safety checks (`bias`, `toxicity`, `role_violation`, and the LLM-judged path of `pii_leakage`) carry a known false-positive rate. Tune `min_score` for your scenarios and prefer the regex pre-pass for high-confidence patterns.
+LLM-judged safety checks (`bias`, `toxicity`, `role_violation`, and the LLM-judged path of `pii_leakage`) carry a known false-positive rate. Tune the wrapper's `min_score` for your scenarios and prefer the regex pre-pass (`pii_leakage`) for high-confidence patterns.
 
 ### `bias`
 
 Scores the answer for demographic, stereotype, gender, racial, or religious bias. Equivalent in name to DeepEval `bias`.
 
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| `min_score` | float | No | Pass threshold |
-
-Plus standard judge params (`rubric`, `model`, `system_prompt`, `criteria`, `extra`). **Surfaces:** A G E
+Standard judge params (`rubric`, `model`, `system_prompt`, `criteria`, `extra`) — all optional. **Surfaces:** A G E
 
 ### `toxicity`
 
-Scores the answer for toxic content: insults, harassment, threats, hate speech. Equivalent in name to DeepEval `toxicity`.
+Scores the answer for toxic content: insults, harassment, threats, hate speech. Equivalent in name to DeepEval `toxicity`. Distinct from the classifier-backed [`text_toxicity`](#text_toxicity); `toxicity` is the LLM-judge path.
 
 Same params as `bias`. **Surfaces:** A G E
 
@@ -593,7 +594,6 @@ The judge sees the active agent role (sourced in priority order from `params["ag
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `agent_role` | string | No | The persona / system prompt the answer should follow. Distinct from the standard `system_prompt` param, which controls the JUDGE's prompt. |
-| `min_score` | float | No | Pass threshold |
 
 Plus standard judge params. **Surfaces:** A G E
 

--- a/examples/eval-test/evals/basic-eval.eval.yaml
+++ b/examples/eval-test/evals/basic-eval.eval.yaml
@@ -27,11 +27,13 @@ spec:
           - "apologize"
         case_sensitive: false
     
-    - type: llm_judge_session
+    - type: assertion
       message: "Agent maintains professional tone throughout"
       params:
-        criteria: "Does the customer support agent maintain a professional, helpful, and courteous tone throughout the conversation?"
-        judge: gpt-4o-judge
+        eval_type: llm_judge_session
+        eval_params:
+          criteria: "Does the customer support agent maintain a professional, helpful, and courteous tone throughout the conversation?"
+          judge: gpt-4o-judge
         min_score: 0.8
   
   tags:

--- a/examples/llm-judge/scenarios/helpfulness.yaml
+++ b/examples/llm-judge/scenarios/helpfulness.yaml
@@ -11,20 +11,27 @@ spec:
     - role: user
       content: "How do I reset my device?"
       assertions:
-        - type: llm_judge
+        # llm_judge is a pure eval primitive — it emits the judge's
+        # score. `type: assertion` wraps it to apply the threshold.
+        # See runtime/evals/handlers/CLAUDE.md.
+        - type: assertion
           params:
-            criteria: |
-              Response gives clear, concise, actionable reset steps.
-            judge: mock-judge
-            prompt: judge-evidence
+            eval_type: llm_judge
+            eval_params:
+              criteria: |
+                Response gives clear, concise, actionable reset steps.
+              judge: mock-judge
+              prompt: judge-evidence
             min_score: 0.8
           message: "Assistant response should be helpful and actionable"
 
   conversation_assertions:
-    - type: llm_judge_conversation
+    - type: assertion
       params:
-        judge: mock-judge
-        criteria: |
-          Across the conversation, the assistant should stay on-topic and give a usable answer.
+        eval_type: llm_judge_conversation
+        eval_params:
+          judge: mock-judge
+          criteria: |
+            Across the conversation, the assistant should stay on-topic and give a usable answer.
         min_score: 0.8
       message: "Conversation should be helpful overall"

--- a/examples/rag-agent/scenarios/paris-capital.scenario.yaml
+++ b/examples/rag-agent/scenarios/paris-capital.scenario.yaml
@@ -7,58 +7,74 @@ spec:
   task_type: rag
   description: "Single-turn RAG question with the full named-primitive suite asserted on the answer."
 
+  # The RAG primitives (faithfulness, answer_relevancy, contextual_*,
+  # hallucination) are pure eval primitives that emit the judge's score.
+  # `type: assertion` wraps each with a threshold.
+  # See runtime/evals/handlers/CLAUDE.md for the pattern.
   turns:
     - role: user
       content: "What is the capital of France?"
       assertions:
-        - type: faithfulness
+        - type: assertion
           params:
-            contexts:
-              - "Paris is the capital and most populous city of France."
-              - "Located on the Seine River in north-central France."
-            judge: rag-judge
+            eval_type: faithfulness
+            eval_params:
+              contexts:
+                - "Paris is the capital and most populous city of France."
+                - "Located on the Seine River in north-central France."
+              judge: rag-judge
             min_score: 0.8
           message: "Answer must be grounded in the retrieved context"
 
-        - type: answer_relevancy
+        - type: assertion
           params:
-            judge: rag-judge
+            eval_type: answer_relevancy
+            eval_params:
+              judge: rag-judge
             min_score: 0.8
           message: "Answer must directly address the question"
 
-        - type: contextual_precision
+        - type: assertion
           params:
-            contexts:
-              - "Paris is the capital and most populous city of France."
-              - "Located on the Seine River in north-central France."
-            judge: rag-judge
+            eval_type: contextual_precision
+            eval_params:
+              contexts:
+                - "Paris is the capital and most populous city of France."
+                - "Located on the Seine River in north-central France."
+              judge: rag-judge
             min_score: 0.5
           message: "Retrieved chunks must be relevant to the question"
 
-        - type: contextual_recall
+        - type: assertion
           params:
-            contexts:
-              - "Paris is the capital and most populous city of France."
-              - "Located on the Seine River in north-central France."
-            reference: "Paris is the capital of France."
-            judge: rag-judge
+            eval_type: contextual_recall
+            eval_params:
+              contexts:
+                - "Paris is the capital and most populous city of France."
+                - "Located on the Seine River in north-central France."
+              reference: "Paris is the capital of France."
+              judge: rag-judge
             min_score: 0.8
           message: "Retrieved chunks must cover the reference answer"
 
-        - type: contextual_relevancy
+        - type: assertion
           params:
-            contexts:
-              - "Paris is the capital and most populous city of France."
-              - "Located on the Seine River in north-central France."
-            judge: rag-judge
+            eval_type: contextual_relevancy
+            eval_params:
+              contexts:
+                - "Paris is the capital and most populous city of France."
+                - "Located on the Seine River in north-central France."
+              judge: rag-judge
             min_score: 0.5
           message: "Average per-chunk relevance must clear the threshold"
 
-        - type: hallucination
+        - type: assertion
           params:
-            contexts:
-              - "Paris is the capital and most populous city of France."
-              - "Located on the Seine River in north-central France."
-            judge: rag-judge
+            eval_type: hallucination
+            eval_params:
+              contexts:
+                - "Paris is the capital and most populous city of France."
+                - "Located on the Seine River in north-central France."
+              judge: rag-judge
             min_score: 0.8
           message: "Answer must be free of hallucinated claims (1.0 = no hallucination)"

--- a/runtime/evals/handlers/CLAUDE.md
+++ b/runtime/evals/handlers/CLAUDE.md
@@ -39,6 +39,6 @@ Every handler in this package that takes a measurement (classify-backed, embeddi
 - **Bundling "passed" boolean into the inner result.** Same problem — the wrapper decides pass/fail.
 - **Two thresholds modes on the same handler** (`min_score` AND `max_score` selectable via flag). Pick neither — both are wrapper concerns.
 
-## Legacy exceptions (do not propagate)
+## Legacy exceptions (none currently)
 
-The LLM-judge family (`bias`, `toxicity`, `pii_leakage`, `role_violation`) accepts `min_score` as a param, but only passes it through to the judge model as metadata for the model's own reasoning — they do not threshold the score themselves. This is grandfathered; do not add new self-grading handlers in this style.
+The LLM-judge family (`bias`, `toxicity`, `pii_leakage`, `role_violation`, `llm_judge`, `llm_judge_session`, the RAG primitives) used to accept `min_score` as a no-op param. That was cleaned up in #1233 — they now reject threshold params at parse time like every other classify-backed handler. There are no current exceptions to the convention.

--- a/runtime/evals/handlers/answer_relevancy.go
+++ b/runtime/evals/handlers/answer_relevancy.go
@@ -17,8 +17,10 @@ import (
 //
 // Params (all optional):
 //   - question (string): override the auto-extracted last user turn
-//   - min_score (float): pass threshold
 //   - rubric, model, system_prompt: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected — wrap
+// with `type: assertion` and set the threshold on the wrapper.
 type AnswerRelevancyHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/answer_relevancy.go
+++ b/runtime/evals/handlers/answer_relevancy.go
@@ -18,9 +18,6 @@ import (
 // Params (all optional):
 //   - question (string): override the auto-extracted last user turn
 //   - rubric, model, system_prompt: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected — wrap
-// with `type: assertion` and set the threshold on the wrapper.
 type AnswerRelevancyHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/bias.go
+++ b/runtime/evals/handlers/bias.go
@@ -6,19 +6,20 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// BiasHandler scores whether the assistant output contains demographic
-// or stereotype bias. Equivalent in name to DeepEval `bias`. Default
-// wiring in this codebase is as a guardrail (pack `validators:`
-// block); scenarios observe firing via `guardrail_triggered`. Direct
-// scenario invocation works too via the generic eval plumbing.
+// BiasHandler is a pure eval primitive that scores whether the assistant
+// output contains demographic or stereotype bias. Equivalent in name to
+// DeepEval `bias`. Default wiring in this codebase is as a guardrail
+// (pack `validators:` block); scenarios observe firing via
+// `guardrail_triggered`. For direct scenario use, wrap with
+// `type: assertion` and set min_score on the wrapper.
 //
 // Default prompts adapted from the public DeepEval reference
-// implementation (Apache 2.0). LLM-judged checks have a known
-// false-positive rate; tune `min_score` accordingly.
+// implementation (Apache 2.0).
 //
 // Params (all optional):
-//   - min_score (float): pass threshold
 //   - rubric, model, system_prompt, criteria: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected.
 type BiasHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/bias.go
+++ b/runtime/evals/handlers/bias.go
@@ -6,20 +6,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// BiasHandler is a pure eval primitive that scores whether the assistant
-// output contains demographic or stereotype bias. Equivalent in name to
-// DeepEval `bias`. Default wiring in this codebase is as a guardrail
-// (pack `validators:` block); scenarios observe firing via
-// `guardrail_triggered`. For direct scenario use, wrap with
-// `type: assertion` and set min_score on the wrapper.
-//
-// Default prompts adapted from the public DeepEval reference
-// implementation (Apache 2.0).
-//
-// Params (all optional):
-//   - rubric, model, system_prompt, criteria: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected.
+// BiasHandler scores assistant output for demographic / stereotype
+// bias via the LLM judge. DeepEval-equivalent name; default-wired as
+// a guardrail. Params: standard llm_judge knobs.
 type BiasHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/classify_handler_base.go
+++ b/runtime/evals/handlers/classify_handler_base.go
@@ -82,17 +82,8 @@ func parseClassifyConfig(params map[string]any, defaultRole string) (classifyCon
 		cfg.classifierID = v
 	}
 
-	// Surface a clear error if the caller put a threshold on the
-	// inner eval. Threshold judgment lives on the assertion wrapper,
-	// not on the eval primitive — silently accepting a no-op param
-	// would hide a config mistake the user expected to be enforced.
-	for _, banned := range []string{"min_score", "max_score"} {
-		if _, present := params[banned]; present {
-			return cfg, errors.New(
-				banned + " is not a valid param on a classify-backed eval; " +
-					"wrap with `type: assertion` and put the threshold there " +
-					"(see runtime/evals/wrappers.go)")
-		}
+	if msg := rejectThresholdParams(params); msg != "" {
+		return cfg, errors.New(msg)
 	}
 	return cfg, nil
 }

--- a/runtime/evals/handlers/contextual_precision.go
+++ b/runtime/evals/handlers/contextual_precision.go
@@ -19,9 +19,6 @@ import (
 //     retrieved chunks
 //   - question (string): override the auto-extracted last user turn
 //   - rubric, model, system_prompt: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected — wrap
-// with `type: assertion` and set the threshold on the wrapper.
 type ContextualPrecisionHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/contextual_precision.go
+++ b/runtime/evals/handlers/contextual_precision.go
@@ -18,8 +18,10 @@ import (
 //   - contexts ([]string) | context (string) | context_field (string):
 //     retrieved chunks
 //   - question (string): override the auto-extracted last user turn
-//   - min_score (float): pass threshold
 //   - rubric, model, system_prompt: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected — wrap
+// with `type: assertion` and set the threshold on the wrapper.
 type ContextualPrecisionHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/contextual_recall.go
+++ b/runtime/evals/handlers/contextual_recall.go
@@ -20,8 +20,10 @@ import (
 //   - reference (string) | expected_output (string): the ground-truth
 //     answer (required)
 //   - question (string): override the auto-extracted last user turn
-//   - min_score (float): pass threshold
 //   - rubric, model, system_prompt: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected — wrap
+// with `type: assertion` and set the threshold on the wrapper.
 type ContextualRecallHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/contextual_recall.go
+++ b/runtime/evals/handlers/contextual_recall.go
@@ -21,9 +21,6 @@ import (
 //     answer (required)
 //   - question (string): override the auto-extracted last user turn
 //   - rubric, model, system_prompt: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected — wrap
-// with `type: assertion` and set the threshold on the wrapper.
 type ContextualRecallHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/contextual_relevancy.go
+++ b/runtime/evals/handlers/contextual_relevancy.go
@@ -20,8 +20,10 @@ import (
 // Params (all optional):
 //   - contexts ([]string) | context (string) | context_field (string)
 //   - question (string)
-//   - min_score (float)
 //   - rubric, model, system_prompt
+//
+// Putting min_score / max_score on this handler is rejected — wrap
+// with `type: assertion` and set the threshold on the wrapper.
 type ContextualRelevancyHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/contextual_relevancy.go
+++ b/runtime/evals/handlers/contextual_relevancy.go
@@ -21,9 +21,6 @@ import (
 //   - contexts ([]string) | context (string) | context_field (string)
 //   - question (string)
 //   - rubric, model, system_prompt
-//
-// Putting min_score / max_score on this handler is rejected — wrap
-// with `type: assertion` and set the threshold on the wrapper.
 type ContextualRelevancyHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/faithfulness.go
+++ b/runtime/evals/handlers/faithfulness.go
@@ -20,9 +20,6 @@ import (
 //   - contexts ([]string) | context (string) | context_field (string):
 //     retrieved chunks the answer should be grounded in
 //   - rubric, model, system_prompt: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected — wrap
-// with `type: assertion` and set the threshold on the wrapper.
 type FaithfulnessHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/faithfulness.go
+++ b/runtime/evals/handlers/faithfulness.go
@@ -19,8 +19,10 @@ import (
 // Params (all optional):
 //   - contexts ([]string) | context (string) | context_field (string):
 //     retrieved chunks the answer should be grounded in
-//   - min_score (float): pass threshold
 //   - rubric, model, system_prompt: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected — wrap
+// with `type: assertion` and set the threshold on the wrapper.
 type FaithfulnessHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/hallucination.go
+++ b/runtime/evals/handlers/hallucination.go
@@ -21,8 +21,10 @@ import (
 //
 // Params (all optional):
 //   - contexts ([]string) | context (string) | context_field (string)
-//   - min_score (float): pass threshold
 //   - rubric, model, system_prompt: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected — wrap
+// with `type: assertion` and set the threshold on the wrapper.
 type HallucinationHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/hallucination.go
+++ b/runtime/evals/handlers/hallucination.go
@@ -22,9 +22,6 @@ import (
 // Params (all optional):
 //   - contexts ([]string) | context (string) | context_field (string)
 //   - rubric, model, system_prompt: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected — wrap
-// with `type: assertion` and set the threshold on the wrapper.
 type HallucinationHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/helpers_test.go
+++ b/runtime/evals/handlers/helpers_test.go
@@ -1,8 +1,44 @@
 package handlers
 
 import (
+	"context"
+	"strings"
 	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
+
+// assertHandlerRejectsThresholdParams calls h.Eval twice — once with
+// `min_score` and once with `max_score` mixed into baseParams — and
+// verifies both surface the "wrap with type: assertion" error.
+// Shared by every test that pins the eval/assertion separation
+// (TestLLMJudgeHandler_RejectsThresholdParams, the safety-family
+// representative, the RAG-family representative, etc.). Centralising
+// the assertion shape also stops Sonar's duplicated-lines detector
+// flagging the otherwise-identical bodies.
+func assertHandlerRejectsThresholdParams(
+	t *testing.T,
+	h evals.EvalTypeHandler,
+	evalCtx *evals.EvalContext,
+	baseParams map[string]any,
+) {
+	t.Helper()
+	for _, banned := range []string{"min_score", "max_score"} {
+		params := map[string]any{}
+		for k, v := range baseParams {
+			params[k] = v
+		}
+		params[banned] = 0.5
+		res, _ := h.Eval(context.Background(), evalCtx, params)
+		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
+			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
+		}
+		if !strings.Contains(res.Error, "type: assertion") {
+			t.Errorf("%s rejection should point users at the assertion wrapper: %q",
+				banned, res.Error)
+		}
+	}
+}
 
 func TestAsString_NonString(t *testing.T) {
 	// Cover the fmt.Sprintf branch for non-string values.

--- a/runtime/evals/handlers/judge_provider.go
+++ b/runtime/evals/handlers/judge_provider.go
@@ -22,7 +22,10 @@ const (
 	// judgeMaxTokens is the maximum token limit for judge LLM calls.
 	judgeMaxTokens = 1024
 
-	// defaultPassThreshold is the default score threshold when no explicit passed field or minScore is set.
+	// defaultPassThreshold is the score threshold used as the fallback
+	// when the judge model didn't include an explicit `passed` field in
+	// its response. Threshold judgment proper lives on the
+	// `type: assertion` wrapper, not here.
 	defaultPassThreshold = 0.5
 )
 
@@ -37,9 +40,13 @@ type JudgeProvider interface {
 }
 
 // parseJudgeResponse parses the LLM judge response into a JudgeResult.
+// The handler emits Score = jr.Score as a pure eval primitive; threshold
+// judgment lives on the `type: assertion` wrapper, not here. We still
+// record jr.Passed when the model returned it so consumers that inspect
+// Details can see the model's own opinion alongside the score.
 //
 //nolint:unparam // error return kept for future extensibility
-func parseJudgeResponse(raw string, minScore *float64) (*JudgeResult, error) {
+func parseJudgeResponse(raw string) (*JudgeResult, error) {
 	var parsed struct {
 		Passed    *bool   `json:"passed"`
 		Score     float64 `json:"score"`
@@ -69,10 +76,11 @@ func parseJudgeResponse(raw string, minScore *float64) (*JudgeResult, error) {
 		Raw:       raw,
 	}
 
+	// Honor the model's explicit verdict when present; otherwise fall
+	// back to the default pass threshold (kept for reporting only —
+	// EvalResult.Score carries the raw signal to the wrapper).
 	if parsed.Passed != nil {
 		result.Passed = *parsed.Passed
-	} else if minScore != nil {
-		result.Passed = parsed.Score >= *minScore
 	} else {
 		result.Passed = parsed.Score >= defaultPassThreshold
 	}
@@ -96,9 +104,6 @@ type JudgeOpts struct {
 
 	// SystemPrompt overrides the default judge system prompt (optional).
 	SystemPrompt string
-
-	// MinScore is the minimum score threshold for passing (optional).
-	MinScore *float64
 
 	// Extra holds additional parameters for provider-specific features.
 	Extra map[string]any
@@ -206,7 +211,7 @@ func (sp *SpecJudgeProvider) Judge(ctx context.Context, opts JudgeOpts) (*JudgeR
 		opts.Emitter.ProviderCallCompletedCtx(ctx, completedData)
 	}
 
-	return parseJudgeResponse(resp.Content, opts.MinScore)
+	return parseJudgeResponse(resp.Content)
 }
 
 // Ensure SpecJudgeProvider implements JudgeProvider.

--- a/runtime/evals/handlers/judge_provider_test.go
+++ b/runtime/evals/handlers/judge_provider_test.go
@@ -55,22 +55,17 @@ func TestJudgeProviderInterface(t *testing.T) {
 }
 
 func TestJudgeOptsFields(t *testing.T) {
-	minScore := 0.8
 	opts := JudgeOpts{
 		Content:      "test content",
 		Criteria:     "be helpful",
 		Rubric:       "detailed rubric",
 		Model:        "claude-sonnet-4-5-20250929",
 		SystemPrompt: "You are a judge",
-		MinScore:     &minScore,
 		Extra:        map[string]any{"temperature": 0.0},
 	}
 
 	if opts.Content != "test content" {
 		t.Error("Content not set correctly")
-	}
-	if opts.MinScore == nil || *opts.MinScore != 0.8 {
-		t.Error("MinScore not set correctly")
 	}
 	if opts.Extra["temperature"] != 0.0 {
 		t.Error("Extra not set correctly")
@@ -95,7 +90,7 @@ func TestJudgeProviderError(t *testing.T) {
 func TestParseJudgeResponse_ValidJSON(t *testing.T) {
 	t.Parallel()
 	raw := `{"passed": true, "score": 0.92, "reasoning": "Good quality"}`
-	result, err := parseJudgeResponse(raw, nil)
+	result, err := parseJudgeResponse(raw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -113,7 +108,7 @@ func TestParseJudgeResponse_ValidJSON(t *testing.T) {
 func TestParseJudgeResponse_WrappedInMarkdown(t *testing.T) {
 	t.Parallel()
 	raw := "```json\n{\"passed\": false, \"score\": 0.3, \"reasoning\": \"Poor\"}\n```"
-	result, err := parseJudgeResponse(raw, nil)
+	result, err := parseJudgeResponse(raw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -125,23 +120,10 @@ func TestParseJudgeResponse_WrappedInMarkdown(t *testing.T) {
 	}
 }
 
-func TestParseJudgeResponse_NoPassed_UsesMinScore(t *testing.T) {
-	t.Parallel()
-	raw := `{"score": 0.6, "reasoning": "OK"}`
-	minScore := 0.7
-	result, err := parseJudgeResponse(raw, &minScore)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.Passed {
-		t.Error("expected Passed=false (0.6 < 0.7)")
-	}
-}
-
 func TestParseJudgeResponse_NoPassed_UsesDefaultThreshold(t *testing.T) {
 	t.Parallel()
 	raw := `{"score": 0.6, "reasoning": "OK"}`
-	result, err := parseJudgeResponse(raw, nil)
+	result, err := parseJudgeResponse(raw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -153,7 +135,7 @@ func TestParseJudgeResponse_NoPassed_UsesDefaultThreshold(t *testing.T) {
 func TestParseJudgeResponse_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	raw := "This is not JSON at all"
-	result, err := parseJudgeResponse(raw, nil)
+	result, err := parseJudgeResponse(raw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/runtime/evals/handlers/llm_judge.go
+++ b/runtime/evals/handlers/llm_judge.go
@@ -9,16 +9,27 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
-// LLMJudgeHandler evaluates a single assistant turn using an
-// LLM judge. The JudgeProvider must be supplied in
-// evalCtx.Metadata["judge_provider"].
+// LLMJudgeHandler evaluates a single assistant turn using an LLM judge
+// as a pure eval primitive. It emits the judge's `score` field as
+// EvalResult.Score and the judge's reasoning + `passed` opinion in
+// Details. Threshold judgment lives on the `type: assertion` wrapper:
+//
+//   - type: assertion
+//     params:
+//     eval_type: llm_judge
+//     eval_params: { criteria: "...", judge: my-judge }
+//     min_score: 0.7
+//
+// The JudgeProvider must be supplied in evalCtx.Metadata["judge_provider"].
 //
 // Params:
 //   - criteria (string, required): what to evaluate
 //   - rubric (string, optional): detailed scoring guidance
 //   - model (string, optional): model override for the judge
 //   - system_prompt (string, optional): override default system prompt
-//   - min_score (float64, optional): minimum score to pass
+//
+// Putting min_score / max_score on this handler is rejected — the
+// assertion wrapper is the canonical home for thresholds.
 type LLMJudgeHandler struct{}
 
 // Type returns the eval type identifier.
@@ -30,6 +41,9 @@ func (h *LLMJudgeHandler) Eval(
 	evalCtx *evals.EvalContext,
 	params map[string]any,
 ) (result *evals.EvalResult, err error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(h.Type(), msg), nil
+	}
 	provider, extractErr := extractJudgeProvider(evalCtx)
 	if extractErr != nil {
 		return &evals.EvalResult{
@@ -154,25 +168,53 @@ func buildJudgeOpts(
 	if v, ok := params["system_prompt"].(string); ok {
 		opts.SystemPrompt = v
 	}
-	if v, ok := params["min_score"].(float64); ok {
-		opts.MinScore = &v
-	}
 
 	return opts
 }
 
-// buildEvalResult converts a JudgeResult into an EvalResult,
-// applying the min_score threshold when provided.
+// buildEvalResult converts a JudgeResult into an EvalResult. The
+// handler is a pure eval primitive: it emits the judge's raw `score`
+// as EvalResult.Score and preserves the judge's `passed` opinion and
+// reasoning in Details for reporting. Threshold judgment lives on the
+// `type: assertion` wrapper, not here.
 func buildEvalResult(
 	evalType string,
 	jr *JudgeResult,
 ) *evals.EvalResult {
 	score := jr.Score
-
 	return &evals.EvalResult{
 		Type:        evalType,
 		Score:       &score,
+		MetricValue: &score,
 		Explanation: jr.Reasoning,
-		Value:       map[string]any{"score": score, "reasoning": jr.Reasoning},
+		Details: map[string]any{
+			resultFieldScore:     score,
+			"passed":             jr.Passed,
+			resultFieldReasoning: jr.Reasoning,
+		},
 	}
+}
+
+// keyMinScore / keyMaxScore are the threshold-key constants the
+// rejection guard checks. Both keys are scenario-config sugar that
+// belong on the `type: assertion` wrapper, never on an eval handler.
+const (
+	keyMinScore = "min_score"
+	keyMaxScore = "max_score"
+)
+
+// rejectThresholdParams surfaces a clear Error when callers put
+// min_score / max_score on the inner eval. Threshold judgment
+// belongs on the `type: assertion` wrapper; silently accepting a
+// no-op param hides a config mistake. Returns "" when the params
+// pass.
+func rejectThresholdParams(params map[string]any) string {
+	for _, banned := range []string{keyMinScore, keyMaxScore} {
+		if _, present := params[banned]; present {
+			return banned + " is not a valid param on an LLM-judge eval; " +
+				"wrap with `type: assertion` and put the threshold there " +
+				"(see runtime/evals/wrappers.go)"
+		}
+	}
+	return ""
 }

--- a/runtime/evals/handlers/llm_judge.go
+++ b/runtime/evals/handlers/llm_judge.go
@@ -9,27 +9,16 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
-// LLMJudgeHandler evaluates a single assistant turn using an LLM judge
-// as a pure eval primitive. It emits the judge's `score` field as
-// EvalResult.Score and the judge's reasoning + `passed` opinion in
-// Details. Threshold judgment lives on the `type: assertion` wrapper:
-//
-//   - type: assertion
-//     params:
-//     eval_type: llm_judge
-//     eval_params: { criteria: "...", judge: my-judge }
-//     min_score: 0.7
-//
-// The JudgeProvider must be supplied in evalCtx.Metadata["judge_provider"].
+// LLMJudgeHandler evaluates a single assistant turn using an LLM judge.
+// Pure eval primitive (see docs/reference/checks.md for the
+// `type: assertion` wrapper pattern that adds thresholds). The
+// JudgeProvider must be supplied in evalCtx.Metadata["judge_provider"].
 //
 // Params:
 //   - criteria (string, required): what to evaluate
 //   - rubric (string, optional): detailed scoring guidance
 //   - model (string, optional): model override for the judge
 //   - system_prompt (string, optional): override default system prompt
-//
-// Putting min_score / max_score on this handler is rejected — the
-// assertion wrapper is the canonical home for thresholds.
 type LLMJudgeHandler struct{}
 
 // Type returns the eval type identifier.
@@ -195,23 +184,20 @@ func buildEvalResult(
 	}
 }
 
-// keyMinScore / keyMaxScore are the threshold-key constants the
-// rejection guard checks. Both keys are scenario-config sugar that
-// belong on the `type: assertion` wrapper, never on an eval handler.
-const (
-	keyMinScore = "min_score"
-	keyMaxScore = "max_score"
-)
-
-// rejectThresholdParams surfaces a clear Error when callers put
-// min_score / max_score on the inner eval. Threshold judgment
-// belongs on the `type: assertion` wrapper; silently accepting a
-// no-op param hides a config mistake. Returns "" when the params
-// pass.
+// rejectThresholdParams surfaces a clear Error when callers put a
+// threshold (min_score / max_score) on an eval handler. Threshold
+// judgment lives on the `type: assertion` wrapper — see
+// runtime/evals/wrappers.go and runtime/evals/handlers/CLAUDE.md.
+// Returns "" when the params pass.
+//
+// Shared by every eval handler family (classify-backed,
+// llm_judge, safety, RAG) — see parseClassifyConfig for the
+// classify-backed call site and llm_judge.go / ragJudgeCall /
+// evalSafetyOutput for the others.
 func rejectThresholdParams(params map[string]any) string {
-	for _, banned := range []string{keyMinScore, keyMaxScore} {
+	for _, banned := range []string{"min_score", "max_score"} {
 		if _, present := params[banned]; present {
-			return banned + " is not a valid param on an LLM-judge eval; " +
+			return banned + " is not a valid param on an eval handler; " +
 				"wrap with `type: assertion` and put the threshold there " +
 				"(see runtime/evals/wrappers.go)"
 		}

--- a/runtime/evals/handlers/llm_judge.go
+++ b/runtime/evals/handlers/llm_judge.go
@@ -30,31 +30,50 @@ func (h *LLMJudgeHandler) Eval(
 	evalCtx *evals.EvalContext,
 	params map[string]any,
 ) (result *evals.EvalResult, err error) {
+	return runJudgeEval(ctx, evalCtx, h.Type(), params, evalCtx.CurrentOutput), nil
+}
+
+// runJudgeEval is the shared body for every LLM-judge eval: reject
+// threshold params, resolve the JudgeProvider from context, build the
+// judge request, call it, and convert the JudgeResult to an EvalResult.
+// Handlers that need preprocessing (filtering tool calls, picking a
+// session-level content view) build the `content` arg and call this.
+//
+// Centralizing here keeps the three judge handlers (llm_judge,
+// llm_judge_session, llm_judge_tool_calls) from drifting and stops
+// Sonar's CPD flagging the otherwise-identical Eval bodies.
+func runJudgeEval(
+	ctx context.Context,
+	evalCtx *evals.EvalContext,
+	handlerType string,
+	params map[string]any,
+	content string,
+) *evals.EvalResult {
 	if msg := rejectThresholdParams(params); msg != "" {
-		return errorResult(h.Type(), msg), nil
+		return errorResult(handlerType, msg)
 	}
 	provider, extractErr := extractJudgeProvider(evalCtx)
 	if extractErr != nil {
 		return &evals.EvalResult{
-			Type:        h.Type(),
+			Type:        handlerType,
 			Score:       boolScore(false),
 			Explanation: extractErr.Error(),
-		}, nil
+		}
 	}
 
-	opts := buildJudgeOpts(evalCtx.CurrentOutput, params)
+	opts := buildJudgeOpts(content, params)
 	opts.Emitter = emitterFromEvalCtx(evalCtx)
 
 	judgeResult, judgeErr := provider.Judge(ctx, opts)
 	if judgeErr != nil {
 		return &evals.EvalResult{
-			Type:        h.Type(),
+			Type:        handlerType,
 			Score:       boolScore(false),
 			Explanation: fmt.Sprintf("judge error: %v", judgeErr),
-		}, nil
+		}
 	}
 
-	return buildEvalResult(h.Type(), judgeResult), nil
+	return buildEvalResult(handlerType, judgeResult)
 }
 
 // extractJudgeProvider retrieves the JudgeProvider from eval context metadata.

--- a/runtime/evals/handlers/llm_judge_session.go
+++ b/runtime/evals/handlers/llm_judge_session.go
@@ -9,8 +9,11 @@ import (
 )
 
 // LLMJudgeSessionHandler evaluates an entire conversation using
-// an LLM judge. It concatenates all assistant messages into a
-// single content string for evaluation.
+// an LLM judge as a pure eval primitive. It concatenates all
+// assistant messages into a single content string, runs the judge,
+// and emits the judge's `score` as EvalResult.Score. Threshold
+// judgment lives on the `type: assertion` wrapper — see
+// LLMJudgeHandler for the full pattern.
 //
 // The JudgeProvider must be supplied in
 // evalCtx.Metadata["judge_provider"].
@@ -20,7 +23,8 @@ import (
 //   - rubric (string, optional): detailed scoring guidance
 //   - model (string, optional): model override for the judge
 //   - system_prompt (string, optional): override default system prompt
-//   - min_score (float64, optional): minimum score to pass
+//
+// Putting min_score / max_score on this handler is rejected.
 type LLMJudgeSessionHandler struct{}
 
 // Type returns the eval type identifier.
@@ -34,6 +38,9 @@ func (h *LLMJudgeSessionHandler) Eval(
 	evalCtx *evals.EvalContext,
 	params map[string]any,
 ) (result *evals.EvalResult, err error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(h.Type(), msg), nil
+	}
 	provider, extractErr := extractJudgeProvider(evalCtx)
 	if extractErr != nil {
 		return &evals.EvalResult{

--- a/runtime/evals/handlers/llm_judge_session.go
+++ b/runtime/evals/handlers/llm_judge_session.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
@@ -24,32 +23,7 @@ func (h *LLMJudgeSessionHandler) Eval(
 	evalCtx *evals.EvalContext,
 	params map[string]any,
 ) (result *evals.EvalResult, err error) {
-	if msg := rejectThresholdParams(params); msg != "" {
-		return errorResult(h.Type(), msg), nil
-	}
-	provider, extractErr := extractJudgeProvider(evalCtx)
-	if extractErr != nil {
-		return &evals.EvalResult{
-			Type:        h.Type(),
-			Score:       boolScore(false),
-			Explanation: extractErr.Error(),
-		}, nil
-	}
-
-	content := collectAssistantContent(evalCtx)
-	opts := buildJudgeOpts(content, params)
-	opts.Emitter = emitterFromEvalCtx(evalCtx)
-
-	judgeResult, judgeErr := provider.Judge(ctx, opts)
-	if judgeErr != nil {
-		return &evals.EvalResult{
-			Type:        h.Type(),
-			Score:       boolScore(false),
-			Explanation: fmt.Sprintf("judge error: %v", judgeErr),
-		}, nil
-	}
-
-	return buildEvalResult(h.Type(), judgeResult), nil
+	return runJudgeEval(ctx, evalCtx, h.Type(), params, collectAssistantContent(evalCtx)), nil
 }
 
 // collectAssistantContent concatenates all assistant message

--- a/runtime/evals/handlers/llm_judge_session.go
+++ b/runtime/evals/handlers/llm_judge_session.go
@@ -8,23 +8,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// LLMJudgeSessionHandler evaluates an entire conversation using
-// an LLM judge as a pure eval primitive. It concatenates all
-// assistant messages into a single content string, runs the judge,
-// and emits the judge's `score` as EvalResult.Score. Threshold
-// judgment lives on the `type: assertion` wrapper — see
-// LLMJudgeHandler for the full pattern.
-//
-// The JudgeProvider must be supplied in
-// evalCtx.Metadata["judge_provider"].
-//
-// Params:
-//   - criteria (string, required): what to evaluate
-//   - rubric (string, optional): detailed scoring guidance
-//   - model (string, optional): model override for the judge
-//   - system_prompt (string, optional): override default system prompt
-//
-// Putting min_score / max_score on this handler is rejected.
+// LLMJudgeSessionHandler is the session-level counterpart of
+// LLMJudgeHandler — concatenates all assistant messages and runs the
+// judge once over the lot. Same params, same conventions.
 type LLMJudgeSessionHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/llm_judge_test.go
+++ b/runtime/evals/handlers/llm_judge_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
@@ -164,8 +165,7 @@ func TestLLMJudgeHandler_ReturnsRawScore(t *testing.T) {
 				},
 			}
 			params := map[string]any{
-				"criteria":  "test",
-				"min_score": 0.7,
+				"criteria": "test",
 			}
 
 			result, err := h.Eval(
@@ -350,7 +350,9 @@ func TestLLMJudgeSessionHandler_JudgeError(t *testing.T) {
 	}
 }
 
-func TestLLMJudgeSessionHandler_MinScore(t *testing.T) {
+func TestLLMJudgeSessionHandler_EmitsScore(t *testing.T) {
+	// Session-level eval emits the judge's raw score; threshold judgment
+	// lives on the type: assertion wrapper.
 	t.Parallel()
 	mock := &llmJudgeMock{
 		result: &JudgeResult{
@@ -368,8 +370,7 @@ func TestLLMJudgeSessionHandler_MinScore(t *testing.T) {
 		},
 	}
 	params := map[string]any{
-		"criteria":  "quality",
-		"min_score": 0.7,
+		"criteria": "quality",
 	}
 
 	result, err := h.Eval(context.Background(), evalCtx, params)
@@ -381,6 +382,43 @@ func TestLLMJudgeSessionHandler_MinScore(t *testing.T) {
 	}
 	if result.Score == nil || *result.Score != 0.5 {
 		t.Errorf("expected score 0.5, got %v", result.Score)
+	}
+}
+
+func TestLLMJudgeHandler_RejectsThresholdParams(t *testing.T) {
+	// Threshold judgment is the job of `type: assertion`. Putting
+	// min_score / max_score on the eval handler itself is a config
+	// mistake; the handler surfaces it loudly per the package
+	// convention (runtime/evals/handlers/CLAUDE.md).
+	t.Parallel()
+	h := &LLMJudgeHandler{}
+	evalCtx := &evals.EvalContext{CurrentOutput: "x", Metadata: map[string]any{}}
+	for _, banned := range []string{"min_score", "max_score"} {
+		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{
+			"criteria": "test",
+			banned:     0.5,
+		})
+		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
+			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
+		}
+		if !strings.Contains(res.Error, "type: assertion") {
+			t.Errorf("error should point to the assertion wrapper: %q", res.Error)
+		}
+	}
+}
+
+func TestLLMJudgeSessionHandler_RejectsThresholdParams(t *testing.T) {
+	t.Parallel()
+	h := &LLMJudgeSessionHandler{}
+	evalCtx := &evals.EvalContext{Metadata: map[string]any{}}
+	for _, banned := range []string{"min_score", "max_score"} {
+		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{
+			"criteria": "test",
+			banned:     0.5,
+		})
+		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
+			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
+		}
 	}
 }
 

--- a/runtime/evals/handlers/llm_judge_test.go
+++ b/runtime/evals/handlers/llm_judge_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
@@ -391,35 +390,16 @@ func TestLLMJudgeHandler_RejectsThresholdParams(t *testing.T) {
 	// mistake; the handler surfaces it loudly per the package
 	// convention (runtime/evals/handlers/CLAUDE.md).
 	t.Parallel()
-	h := &LLMJudgeHandler{}
-	evalCtx := &evals.EvalContext{CurrentOutput: "x", Metadata: map[string]any{}}
-	for _, banned := range []string{"min_score", "max_score"} {
-		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{
-			"criteria": "test",
-			banned:     0.5,
-		})
-		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
-			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
-		}
-		if !strings.Contains(res.Error, "type: assertion") {
-			t.Errorf("error should point to the assertion wrapper: %q", res.Error)
-		}
-	}
+	assertHandlerRejectsThresholdParams(t, &LLMJudgeHandler{},
+		&evals.EvalContext{CurrentOutput: "x", Metadata: map[string]any{}},
+		map[string]any{"criteria": "test"})
 }
 
 func TestLLMJudgeSessionHandler_RejectsThresholdParams(t *testing.T) {
 	t.Parallel()
-	h := &LLMJudgeSessionHandler{}
-	evalCtx := &evals.EvalContext{Metadata: map[string]any{}}
-	for _, banned := range []string{"min_score", "max_score"} {
-		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{
-			"criteria": "test",
-			banned:     0.5,
-		})
-		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
-			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
-		}
-	}
+	assertHandlerRejectsThresholdParams(t, &LLMJudgeSessionHandler{},
+		&evals.EvalContext{Metadata: map[string]any{}},
+		map[string]any{"criteria": "test"})
 }
 
 func TestLLMJudgeSessionHandler_NoAssistantMessages(t *testing.T) {

--- a/runtime/evals/handlers/llm_judge_tool_calls.go
+++ b/runtime/evals/handlers/llm_judge_tool_calls.go
@@ -9,19 +9,10 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// LLMJudgeToolCallsHandler evaluates tool call behavior via an LLM judge
-// as a pure eval primitive. Instead of judging the assistant's text
-// response, it feeds tool call data (names, arguments, results) to the
-// judge and emits the judge's raw score. Threshold judgment lives on
-// the `type: assertion` wrapper — see LLMJudgeHandler.
-//
-// Params:
-//   - tools []string (optional): filter to specific tool names
-//   - criteria string: what to evaluate
-//   - rubric string (optional): detailed scoring guidance
-//   - model string (optional): model override
-//
-// Putting min_score / max_score on this handler is rejected.
+// LLMJudgeToolCallsHandler is the tool-call counterpart of
+// LLMJudgeHandler — feeds tool call data (names, args, results)
+// instead of the assistant's text. Accepts the same base params plus
+// `tools []string` to filter to specific tool names.
 type LLMJudgeToolCallsHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/llm_judge_tool_calls.go
+++ b/runtime/evals/handlers/llm_judge_tool_calls.go
@@ -27,15 +27,6 @@ func (h *LLMJudgeToolCallsHandler) Eval(
 	if msg := rejectThresholdParams(params); msg != "" {
 		return errorResult(h.Type(), msg), nil
 	}
-	provider, extractErr := extractJudgeProvider(evalCtx)
-	if extractErr != nil {
-		return &evals.EvalResult{
-			Type:        h.Type(),
-			Score:       boolScore(false),
-			Explanation: extractErr.Error(),
-		}, nil
-	}
-
 	filtered := filterToolCallViews(evalCtx.ToolCalls, extractStringSlice(params, "tools"))
 	if len(filtered) == 0 {
 		return &evals.EvalResult{
@@ -46,19 +37,7 @@ func (h *LLMJudgeToolCallsHandler) Eval(
 			SkipReason:  "no matching tool calls",
 		}, nil
 	}
-
-	opts := buildJudgeOpts(formatToolCallViews(filtered), params)
-	opts.Emitter = emitterFromEvalCtx(evalCtx)
-	judgeResult, judgeErr := provider.Judge(ctx, opts)
-	if judgeErr != nil {
-		return &evals.EvalResult{
-			Type:        h.Type(),
-			Score:       boolScore(false),
-			Explanation: fmt.Sprintf("judge error: %v", judgeErr),
-		}, nil
-	}
-
-	result := buildEvalResult(h.Type(), judgeResult)
+	result := runJudgeEval(ctx, evalCtx, h.Type(), params, formatToolCallViews(filtered))
 	// Augment the shared judge Details with the tool-call count;
 	// merge (don't overwrite) so the standard score/passed/reasoning
 	// payload survives.

--- a/runtime/evals/handlers/llm_judge_tool_calls.go
+++ b/runtime/evals/handlers/llm_judge_tool_calls.go
@@ -9,15 +9,19 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// LLMJudgeToolCallsHandler evaluates tool call behavior via an LLM judge.
-// Instead of judging the assistant's text response, it feeds tool call data
-// (names, arguments, results) to the judge for evaluation.
+// LLMJudgeToolCallsHandler evaluates tool call behavior via an LLM judge
+// as a pure eval primitive. Instead of judging the assistant's text
+// response, it feeds tool call data (names, arguments, results) to the
+// judge and emits the judge's raw score. Threshold judgment lives on
+// the `type: assertion` wrapper — see LLMJudgeHandler.
+//
 // Params:
 //   - tools []string (optional): filter to specific tool names
 //   - criteria string: what to evaluate
 //   - rubric string (optional): detailed scoring guidance
 //   - model string (optional): model override
-//   - min_score float64 (optional): minimum score to pass
+//
+// Putting min_score / max_score on this handler is rejected.
 type LLMJudgeToolCallsHandler struct{}
 
 // Type returns the eval type identifier.
@@ -29,6 +33,9 @@ func (h *LLMJudgeToolCallsHandler) Eval(
 	evalCtx *evals.EvalContext,
 	params map[string]any,
 ) (*evals.EvalResult, error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(h.Type(), msg), nil
+	}
 	provider, extractErr := extractJudgeProvider(evalCtx)
 	if extractErr != nil {
 		return &evals.EvalResult{
@@ -61,9 +68,13 @@ func (h *LLMJudgeToolCallsHandler) Eval(
 	}
 
 	result := buildEvalResult(h.Type(), judgeResult)
-	result.Details = map[string]any{
-		"tool_calls_sent": len(filtered),
+	// Augment the shared judge Details with the tool-call count;
+	// merge (don't overwrite) so the standard score/passed/reasoning
+	// payload survives.
+	if result.Details == nil {
+		result.Details = map[string]any{}
 	}
+	result.Details["tool_calls_sent"] = len(filtered)
 	return result, nil
 }
 

--- a/runtime/evals/handlers/llm_judge_tool_calls_test.go
+++ b/runtime/evals/handlers/llm_judge_tool_calls_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
@@ -19,17 +18,9 @@ func TestLLMJudgeToolCallsHandler_RejectsThresholdParams(t *testing.T) {
 	// Same convention as llm_judge / llm_judge_session: threshold judgment
 	// lives on the `type: assertion` wrapper, not on the eval handler.
 	t.Parallel()
-	h := &LLMJudgeToolCallsHandler{}
-	evalCtx := &evals.EvalContext{Metadata: map[string]any{}}
-	for _, banned := range []string{"min_score", "max_score"} {
-		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{
-			"criteria": "test",
-			banned:     0.5,
-		})
-		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
-			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
-		}
-	}
+	assertHandlerRejectsThresholdParams(t, &LLMJudgeToolCallsHandler{},
+		&evals.EvalContext{Metadata: map[string]any{}},
+		map[string]any{"criteria": "test"})
 }
 
 func TestLLMJudgeToolCallsHandler_NoProvider(t *testing.T) {

--- a/runtime/evals/handlers/llm_judge_tool_calls_test.go
+++ b/runtime/evals/handlers/llm_judge_tool_calls_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
@@ -11,6 +12,23 @@ func TestLLMJudgeToolCallsHandler_Type(t *testing.T) {
 	h := &LLMJudgeToolCallsHandler{}
 	if h.Type() != "llm_judge_tool_calls" {
 		t.Fatalf("unexpected type: %s", h.Type())
+	}
+}
+
+func TestLLMJudgeToolCallsHandler_RejectsThresholdParams(t *testing.T) {
+	// Same convention as llm_judge / llm_judge_session: threshold judgment
+	// lives on the `type: assertion` wrapper, not on the eval handler.
+	t.Parallel()
+	h := &LLMJudgeToolCallsHandler{}
+	evalCtx := &evals.EvalContext{Metadata: map[string]any{}}
+	for _, banned := range []string{"min_score", "max_score"} {
+		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{
+			"criteria": "test",
+			banned:     0.5,
+		})
+		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
+			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
+		}
 	}
 }
 

--- a/runtime/evals/handlers/pii_leakage.go
+++ b/runtime/evals/handlers/pii_leakage.go
@@ -24,8 +24,10 @@ import (
 // implementation (Apache 2.0).
 //
 // Params (all optional):
-//   - min_score (float): pass threshold
 //   - rubric, model, system_prompt, criteria: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected — wrap
+// with `type: assertion` and set the threshold on the wrapper.
 type PIILeakageHandler struct{}
 
 // piiLeakageType is the canonical eval type identifier for

--- a/runtime/evals/handlers/pii_leakage.go
+++ b/runtime/evals/handlers/pii_leakage.go
@@ -25,9 +25,6 @@ import (
 //
 // Params (all optional):
 //   - rubric, model, system_prompt, criteria: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected — wrap
-// with `type: assertion` and set the threshold on the wrapper.
 type PIILeakageHandler struct{}
 
 // piiLeakageType is the canonical eval type identifier for

--- a/runtime/evals/handlers/rag_handlers_test.go
+++ b/runtime/evals/handlers/rag_handlers_test.go
@@ -12,6 +12,26 @@ import (
 
 // --- shared helpers used by every RAG handler test ---
 
+// TestRAGHandlers_RejectThresholdParams pins the rejection on the
+// shared ragJudgeCall path that every RAG handler funnels through.
+// Faithfulness is the representative — answer_relevancy / contextual_*
+// / hallucination all flow through the same helper.
+func TestRAGHandlers_RejectThresholdParams(t *testing.T) {
+	t.Parallel()
+	h := &FaithfulnessHandler{}
+	evalCtx := newRAGEvalCtx(passMock(1.0, ""), "answer")
+	for _, banned := range []string{"min_score", "max_score"} {
+		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{
+			"contexts": []string{"context"},
+			banned:     0.5,
+		})
+		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
+			t.Errorf("%s should be rejected at the rag helper layer; got Error=%q",
+				banned, res.Error)
+		}
+	}
+}
+
 func newRAGEvalCtx(mock *llmJudgeMock, output string) *evals.EvalContext {
 	return &evals.EvalContext{
 		CurrentOutput: output,
@@ -60,8 +80,7 @@ func TestFaithfulnessHandler_Pass(t *testing.T) {
 	h := &FaithfulnessHandler{}
 	evalCtx := newRAGEvalCtx(mock, "Paris is the capital of France.")
 	params := map[string]any{
-		"contexts":  []string{"Paris is the capital of France."},
-		"min_score": 0.8,
+		"contexts": []string{"Paris is the capital of France."},
 	}
 
 	result, err := h.Eval(context.Background(), evalCtx, params)
@@ -155,7 +174,7 @@ func TestAnswerRelevancyHandler_Pass(t *testing.T) {
 	mock := passMock(0.9, "directly addresses")
 	h := &AnswerRelevancyHandler{}
 	evalCtx := newRAGEvalCtx(mock, "Paris.")
-	result, err := h.Eval(context.Background(), evalCtx, map[string]any{"min_score": 0.7})
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -409,8 +428,7 @@ func TestHallucinationHandler_Fail(t *testing.T) {
 	h := &HallucinationHandler{}
 	evalCtx := newRAGEvalCtx(mock, "Paris is the capital of France and has 100M residents.")
 	params := map[string]any{
-		"contexts":  []string{"Paris is the capital of France."},
-		"min_score": 0.9,
+		"contexts": []string{"Paris is the capital of France."},
 	}
 	result, err := h.Eval(context.Background(), evalCtx, params)
 	if err != nil {

--- a/runtime/evals/handlers/rag_handlers_test.go
+++ b/runtime/evals/handlers/rag_handlers_test.go
@@ -18,18 +18,9 @@ import (
 // / hallucination all flow through the same helper.
 func TestRAGHandlers_RejectThresholdParams(t *testing.T) {
 	t.Parallel()
-	h := &FaithfulnessHandler{}
-	evalCtx := newRAGEvalCtx(passMock(1.0, ""), "answer")
-	for _, banned := range []string{"min_score", "max_score"} {
-		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{
-			"contexts": []string{"context"},
-			banned:     0.5,
-		})
-		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
-			t.Errorf("%s should be rejected at the rag helper layer; got Error=%q",
-				banned, res.Error)
-		}
-	}
+	assertHandlerRejectsThresholdParams(t, &FaithfulnessHandler{},
+		newRAGEvalCtx(passMock(1.0, ""), "answer"),
+		map[string]any{"contexts": []string{"context"}})
 }
 
 func newRAGEvalCtx(mock *llmJudgeMock, output string) *evals.EvalContext {

--- a/runtime/evals/handlers/rag_helpers.go
+++ b/runtime/evals/handlers/rag_helpers.go
@@ -151,6 +151,9 @@ func ragJudgeCall(
 	defaultSystemPrompt string,
 	defaultCriteria string,
 ) (*evals.EvalResult, error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(evalType, msg), nil
+	}
 	provider, extractErr := extractJudgeProvider(evalCtx)
 	if extractErr != nil {
 		return ragErrorResult(evalType, extractErr.Error()), nil

--- a/runtime/evals/handlers/role_violation.go
+++ b/runtime/evals/handlers/role_violation.go
@@ -26,8 +26,10 @@ import (
 //   - system_prompt (string): the role / persona the answer should adhere
 //     to; overrides metadata. Distinct from the standard llm_judge
 //     `system_prompt` which controls the JUDGE's prompt.
-//   - min_score (float): pass threshold
 //   - rubric, model, criteria: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected — wrap
+// with `type: assertion` and set the threshold on the wrapper.
 type RoleViolationHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/role_violation.go
+++ b/runtime/evals/handlers/role_violation.go
@@ -27,9 +27,6 @@ import (
 //     to; overrides metadata. Distinct from the standard llm_judge
 //     `system_prompt` which controls the JUDGE's prompt.
 //   - rubric, model, criteria: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected — wrap
-// with `type: assertion` and set the threshold on the wrapper.
 type RoleViolationHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/safety_handlers_test.go
+++ b/runtime/evals/handlers/safety_handlers_test.go
@@ -19,12 +19,29 @@ func TestBiasHandler_Type(t *testing.T) {
 	}
 }
 
+// TestSafetyHandlers_RejectThresholdParams pins the rejection on the
+// shared evalSafetyOutput path that every safety handler goes through.
+// Bias is the representative — toxicity/pii_leakage/role_violation all
+// funnel through the same helper, so they all inherit the rejection.
+func TestSafetyHandlers_RejectThresholdParams(t *testing.T) {
+	t.Parallel()
+	h := &BiasHandler{}
+	evalCtx := newRAGEvalCtx(passMock(1.0, ""), "any")
+	for _, banned := range []string{"min_score", "max_score"} {
+		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{banned: 0.5})
+		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
+			t.Errorf("%s should be rejected at the safety helper layer; got Error=%q",
+				banned, res.Error)
+		}
+	}
+}
+
 func TestBiasHandler_Pass(t *testing.T) {
 	t.Parallel()
 	mock := passMock(0.95, "no bias detected")
 	h := &BiasHandler{}
 	evalCtx := newRAGEvalCtx(mock, "All applicants are evaluated on merit.")
-	params := map[string]any{"min_score": 0.8}
+	params := map[string]any{}
 
 	result, err := h.Eval(context.Background(), evalCtx, params)
 	if err != nil {
@@ -44,7 +61,7 @@ func TestBiasHandler_Fail(t *testing.T) {
 	h := &BiasHandler{}
 	evalCtx := newRAGEvalCtx(mock, "stereotyped response")
 
-	result, err := h.Eval(context.Background(), evalCtx, map[string]any{"min_score": 0.8})
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -234,7 +251,6 @@ func TestRoleViolationHandler_Pass_WithExplicitRole(t *testing.T) {
 	evalCtx := newRAGEvalCtx(mock, "I can help with your refund. Let me look up your order.")
 	params := map[string]any{
 		"agent_role": "You are a refund support agent.",
-		"min_score":  0.8,
 	}
 
 	result, err := h.Eval(context.Background(), evalCtx, params)

--- a/runtime/evals/handlers/safety_handlers_test.go
+++ b/runtime/evals/handlers/safety_handlers_test.go
@@ -25,15 +25,9 @@ func TestBiasHandler_Type(t *testing.T) {
 // funnel through the same helper, so they all inherit the rejection.
 func TestSafetyHandlers_RejectThresholdParams(t *testing.T) {
 	t.Parallel()
-	h := &BiasHandler{}
-	evalCtx := newRAGEvalCtx(passMock(1.0, ""), "any")
-	for _, banned := range []string{"min_score", "max_score"} {
-		res, _ := h.Eval(context.Background(), evalCtx, map[string]any{banned: 0.5})
-		if res.Error == "" || !strings.Contains(res.Error, banned+" is not a valid param") {
-			t.Errorf("%s should be rejected at the safety helper layer; got Error=%q",
-				banned, res.Error)
-		}
-	}
+	assertHandlerRejectsThresholdParams(t, &BiasHandler{},
+		newRAGEvalCtx(passMock(1.0, ""), "any"),
+		map[string]any{})
 }
 
 func TestBiasHandler_Pass(t *testing.T) {

--- a/runtime/evals/handlers/safety_helpers.go
+++ b/runtime/evals/handlers/safety_helpers.go
@@ -30,6 +30,9 @@ func evalSafetyOutput(
 	params map[string]any,
 	systemPrompt, criteria string,
 ) (*evals.EvalResult, error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(evalType, msg), nil
+	}
 	output := ""
 	if evalCtx != nil {
 		output = evalCtx.CurrentOutput

--- a/runtime/evals/handlers/toxicity.go
+++ b/runtime/evals/handlers/toxicity.go
@@ -6,22 +6,10 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// ToxicityHandler is a pure eval primitive that scores whether the
-// assistant output contains toxic content — insults, harassment,
-// threats, hate speech. Equivalent in name to DeepEval `toxicity`.
-// Default wiring in this codebase is as a guardrail (pack
-// `validators:` block); scenarios observe firing via
-// `guardrail_triggered`. For direct scenario use, wrap with
-// `type: assertion` and set min_score on the wrapper. Distinct from
-// the classifier-backed `text_toxicity` handler.
-//
-// Default prompts adapted from the public DeepEval reference
-// implementation (Apache 2.0).
-//
-// Params (all optional):
-//   - rubric, model, system_prompt, criteria: standard llm_judge knobs
-//
-// Putting min_score / max_score on this handler is rejected.
+// ToxicityHandler scores the assistant output for insults, harassment,
+// threats, hate speech via the LLM judge. DeepEval-equivalent name;
+// distinct from the classifier-backed text_toxicity. Default-wired as a
+// guardrail. Standard llm_judge params.
 type ToxicityHandler struct{}
 
 // Type returns the eval type identifier.

--- a/runtime/evals/handlers/toxicity.go
+++ b/runtime/evals/handlers/toxicity.go
@@ -6,20 +6,22 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
-// ToxicityHandler scores whether the assistant output contains toxic
-// content — insults, harassment, threats, hate speech. Equivalent in
-// name to DeepEval `toxicity`. Default wiring in this codebase is as
-// a guardrail (pack `validators:` block); scenarios observe firing
-// via `guardrail_triggered`. Direct scenario invocation works too via
-// the generic eval plumbing.
+// ToxicityHandler is a pure eval primitive that scores whether the
+// assistant output contains toxic content — insults, harassment,
+// threats, hate speech. Equivalent in name to DeepEval `toxicity`.
+// Default wiring in this codebase is as a guardrail (pack
+// `validators:` block); scenarios observe firing via
+// `guardrail_triggered`. For direct scenario use, wrap with
+// `type: assertion` and set min_score on the wrapper. Distinct from
+// the classifier-backed `text_toxicity` handler.
 //
 // Default prompts adapted from the public DeepEval reference
-// implementation (Apache 2.0). LLM-judged checks have a known
-// false-positive rate; tune `min_score` accordingly.
+// implementation (Apache 2.0).
 //
 // Params (all optional):
-//   - min_score (float): pass threshold
 //   - rubric, model, system_prompt, criteria: standard llm_judge knobs
+//
+// Putting min_score / max_score on this handler is rejected.
 type ToxicityHandler struct{}
 
 // Type returns the eval type identifier.


### PR DESCRIPTION
## Summary

Closes #1233.

`llm_judge`, `llm_judge_session`, `llm_judge_tool_calls`, the four safety handlers (`bias` / `toxicity` / `pii_leakage` / `role_violation`), and the six RAG primitives (`faithfulness` / `answer_relevancy` / `contextual_precision` / `contextual_recall` / `contextual_relevancy` / `hallucination`) all accepted `min_score` in their params and documented it as "minimum score to pass". The value was **dead code**:

1. `buildJudgeOpts` read `params["min_score"]` and set `opts.MinScore`.
2. `parseJudgeResponse(raw, minScore)` used it as a fallback threshold to set `JudgeResult.Passed` when the model didn't include `passed`.
3. `buildEvalResult` ignored `JudgeResult.Passed` entirely — it emitted `Value = map[string]any{...}`.
4. The runtime emit logic saw `Value` was not a `bool`, fell back to `Score >= 1.0`, and reported failed.

Net effect: judge scores almost never reach 1.0, so every unwrapped LLM-judge assertion looked failed regardless of `min_score`. The four shipped examples that used the old shape happened to score 0.92 from a mock judge — which still missed the implied 1.0 cutoff — and were quietly producing wrong reports.

This commit applies the convention established for the classify-backed handlers in #1232: pure-eval primitives that emit raw `Score`, with threshold judgment on the `type: assertion` wrapper. **The convention now covers every eval handler in `runtime/evals/handlers/`.**

## Runtime changes

- Removed `MinScore` from `JudgeOpts`; `parseJudgeResponse` no longer takes `minScore` (always defers to the model's `passed`, defaults to `defaultPassThreshold` otherwise).
- `buildEvalResult` now emits `Score = jr.Score`, `MetricValue = jr.Score`, and puts the structured payload (score, passed, reasoning) in `Details`. `Value` stays unset so the `type: assertion` wrapper can overwrite it cleanly with its own pass/fail bool.
- New helper `rejectThresholdParams(params)` returns a clear Error pointing at the wrapper. Called from `LLMJudgeHandler.Eval`, `LLMJudgeSessionHandler.Eval`, `LLMJudgeToolCallsHandler.Eval`, `evalSafetyOutput` (covers all 4 safety handlers), and `ragJudgeCall` (covers all 6 RAG handlers) — one rejection point per shared helper, full coverage.
- `llm_judge_tool_calls.go` now merges into the standard `Details` map instead of overwriting it, so the score/passed/reasoning payload survives alongside `tool_calls_sent`.
- GoDoc updated on every affected handler; `runtime/evals/handlers/CLAUDE.md` removes the legacy-exception footnote since none remain.

## Tests

- Strip `MinScore` from JudgeOpts literal in `judge_provider_test.go`; drop `TestParseJudgeResponse_NoPassed_UsesMinScore`; trim minScore arg from every other `parseJudgeResponse` call.
- Strip in-line `min_score` from `rag_handlers_test.go` (3 fixtures), `safety_handlers_test.go` (3 fixtures), `llm_judge_test.go` (2 fixtures).
- **New rejection tests pin the contract**: `TestLLMJudgeHandler_`, `TestLLMJudgeSessionHandler_`, `TestLLMJudgeToolCallsHandler_`, `TestSafetyHandlers_`, `TestRAGHandlers_RejectThresholdParams`. The shared-helper tests catch any future drift on the rag/safety paths.

## Examples migrated to `type: assertion` wrapping

- `examples/llm-judge/scenarios/helpfulness.yaml`
- `examples/rag-agent/scenarios/paris-capital.scenario.yaml` (six RAG assertions)
- `examples/eval-test/evals/basic-eval.eval.yaml`

## Docs

- `reference/checks.md`: rewrote LLM Judge and RAG sections; removed `min_score` from llm_judge / llm_judge_session / llm_judge_tool_calls / bias / role_violation param tables; updated `faithfulness` / `hallucination` examples to use the wrapper; added a note about the wrapper's `min_score: 1.0` default and the set-an-explicit-threshold gotcha for score evals.
- Six shipped docs pages (`assertions.md`, `rag-agent.md`, `arena-ci-quality-gate.md`, `text-negotiation.md`, `voice-characterization.md`, `voice-red-team.md`, `why-arena.md`) had every old direct-shape example migrated to the wrapper.

## Test plan
- [x] `go test ./runtime/evals/... -count=1 -race` — passes
- [x] `golangci-lint run ./evals/handlers/...` from `runtime/` — clean
- [x] `npm run build` in `docs/` — 304 pages, clean
- [x] Code-reviewer agent — verified all reviewer-flagged items addressed
- [ ] CI green

Closes #1233