### PR TITLE
feat(mcp): add Streamable HTTP transport (opt-in)

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -541,6 +541,44 @@ func (s *RuntimeConfigSpec) validateMCPServers() error {
 				}
 			}
 		}
+		if err := validateMCPTransportField(i, &m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+const (
+	mcpTransportStdio          = "stdio"
+	mcpTransportSSE            = "sse"
+	mcpTransportStreamableHTTP = "streamable_http"
+)
+
+func validateMCPTransportField(i int, m *MCPServerConfig) error {
+	switch m.Transport {
+	case "", mcpTransportStdio, mcpTransportSSE, mcpTransportStreamableHTTP:
+		// ok
+	default:
+		return &ValidationError{
+			Field:   fmt.Sprintf("mcp_servers[%d].transport", i),
+			Message: fmt.Sprintf("unknown transport %q; expected one of: stdio, sse, streamable_http", m.Transport),
+		}
+	}
+	switch m.Transport {
+	case mcpTransportSSE, mcpTransportStreamableHTTP:
+		if m.URL == "" {
+			return &ValidationError{
+				Field:   fmt.Sprintf("mcp_servers[%d]", i),
+				Message: fmt.Sprintf("transport: %s requires url", m.Transport),
+			}
+		}
+	case mcpTransportStdio:
+		if m.Command == "" {
+			return &ValidationError{
+				Field:   fmt.Sprintf("mcp_servers[%d]", i),
+				Message: "transport: stdio requires command",
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -741,6 +742,80 @@ func TestRuntimeConfigSpec_Validate_MCPServerRejectsMultipleTransports(t *testin
 	err := s.Validate()
 	if err == nil {
 		t.Fatal("expected error for multiple transports")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPStreamableHTTP_Valid(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{
+			Name:      "weather",
+			URL:       "http://weather.local/mcp",
+			Transport: "streamable_http",
+		}},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("unexpected error for streamable_http config: %v", err)
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPStreamableHTTP_RequiresURL(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{
+			Name:      "weather",
+			Command:   "echo",
+			Transport: "streamable_http",
+		}},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("expected error when transport=streamable_http without url")
+	}
+	if !strings.Contains(err.Error(), "streamable_http") {
+		t.Errorf("error %q should mention streamable_http", err.Error())
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPTransport_RejectsUnknown(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{
+			Name:      "weather",
+			URL:       "http://weather.local/mcp",
+			Transport: "websocket",
+		}},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("expected error for unknown transport")
+	}
+	if !strings.Contains(err.Error(), "transport") {
+		t.Errorf("error %q should mention transport", err.Error())
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPTransport_SSEExplicit(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{
+			Name:      "legacy",
+			URL:       "http://legacy.local",
+			Transport: "sse",
+		}},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("unexpected error for explicit sse config: %v", err)
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_MCPTransport_StdioRequiresCommand(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		MCPServers: []MCPServerConfig{{
+			Name:      "weather",
+			URL:       "http://weather.local",
+			Transport: "stdio",
+		}},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("expected error when transport=stdio without command")
 	}
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -213,7 +213,9 @@ type MCPToolFilter struct {
 //
 // Exactly one transport must be specified:
 //   - Command: stdio (PromptKit spawns a local subprocess).
-//   - URL:     HTTP+SSE (connect to a running server).
+//   - URL:     HTTP transport — by default the legacy SSE adapter is
+//     used. Set Transport to "streamable_http" to opt into the modern
+//     Streamable HTTP transport (MCP 2025-03-26).
 //   - Source:  host-provisioned (a named MCPSource opens the endpoint at
 //     a scope boundary). Requires Scope.
 type MCPServerConfig struct {
@@ -224,6 +226,8 @@ type MCPServerConfig struct {
 	WorkingDir string            `yaml:"working_dir,omitempty" json:"working_dir,omitempty"`
 	URL        string            `yaml:"url,omitempty" json:"url,omitempty"`
 	Headers    map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	//nolint:lll // jsonschema tags require single line
+	Transport string `yaml:"transport,omitempty" json:"transport,omitempty" jsonschema:"title=MCP Transport,description=Explicit transport adapter. Defaults: url→sse for back-compat; command→stdio. Set to 'streamable_http' to opt into the MCP 2025-03-26 Streamable HTTP transport.,enum=,enum=stdio,enum=sse,enum=streamable_http"`
 	//nolint:lll // jsonschema tags require single line
 	Source string `yaml:"source,omitempty" json:"source,omitempty" jsonschema:"title=MCPSource Name,description=Name of a host-registered MCPSource that provisions the endpoint per scope (e.g. 'docker'). Mutually exclusive with command and url."`
 	//nolint:lll // jsonschema tags require single line

--- a/runtime/mcp/registry.go
+++ b/runtime/mcp/registry.go
@@ -564,15 +564,16 @@ func (r *RegistryImpl) GetToolSchema(ctx context.Context, toolName string) (*Too
 // isn't on ServerConfig (or vice versa) breaks the direct conversion used in
 // NewRegistryWithServers.
 type ServerConfigData struct {
-	Name       string
-	Command    string
-	Args       []string
-	Env        map[string]string
-	WorkingDir string
-	URL        string
-	Headers    map[string]string
-	TimeoutMs  int
-	ToolFilter *ToolFilter
+	Name          string
+	Command       string
+	Args          []string
+	Env           map[string]string
+	WorkingDir    string
+	URL           string
+	Headers       map[string]string
+	TransportName Transport
+	TimeoutMs     int
+	ToolFilter    *ToolFilter
 }
 
 // NewRegistryWithServers creates a registry and registers multiple servers.

--- a/runtime/mcp/registry.go
+++ b/runtime/mcp/registry.go
@@ -78,8 +78,16 @@ func newClientAdapter(config *ServerConfig) Client {
 	if config.TimeoutMs > 0 {
 		opts.RequestTimeout = time.Duration(config.TimeoutMs) * time.Millisecond
 	}
-	if config.Transport() == TransportSSE {
+	switch config.Transport() {
+	case TransportStreamableHTTP:
+		return NewStreamableClientWithOptions(*config, opts)
+	case TransportSSE:
 		return NewSSEClientWithOptions(*config, opts)
+	case TransportStdio, TransportUnknown:
+		// TransportUnknown falls through to stdio so the caller will see a
+		// clear error from StdioClient.Initialize. Upstream validation should
+		// prevent the unknown case from ever reaching here.
+		return NewStdioClientWithOptions(*config, opts)
 	}
 	return NewStdioClientWithOptions(*config, opts)
 }

--- a/runtime/mcp/registry_test.go
+++ b/runtime/mcp/registry_test.go
@@ -834,6 +834,11 @@ func TestRegistry_NewClientFunc_DispatchesByTransport(t *testing.T) {
 	c = reg.newClientFunc(ServerConfig{Name: "x"})
 	_, ok = c.(*StdioClient)
 	assert.True(t, ok, "expected *StdioClient fallback, got %T", c)
+
+	// Explicit streamable_http transport yields a *StreamableClient.
+	c = reg.newClientFunc(ServerConfig{Name: "sh", URL: "https://x", TransportName: TransportStreamableHTTP})
+	_, ok = c.(*StreamableClient)
+	assert.True(t, ok, "expected *StreamableClient, got %T", c)
 }
 
 func TestRegistry_UnregisterServer(t *testing.T) {

--- a/runtime/mcp/streamable_client.go
+++ b/runtime/mcp/streamable_client.go
@@ -1,0 +1,157 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+)
+
+// streamableClientImplName / streamableClientImplVersion identify this
+// implementation in the MCP initialize handshake's ClientInfo.
+const (
+	streamableClientImplName    = "promptkit"
+	streamableClientImplVersion = "0.1.0"
+)
+
+// StreamableClient is the MCP 2025-03-26 Streamable HTTP transport
+// implementation of the Client interface. Wire-level details live in
+// streamable_transport.go; this file owns the public lifecycle.
+type StreamableClient struct {
+	config  ServerConfig
+	options ClientOptions
+
+	tr         *streamableTransport
+	serverInfo *InitializeResponse
+
+	mu      sync.Mutex
+	started bool
+	closed  bool
+}
+
+// NewStreamableClient creates an MCP client using the Streamable HTTP transport.
+//
+//nolint:gocritic // matches existing Client constructor signatures
+func NewStreamableClient(config ServerConfig) *StreamableClient {
+	return NewStreamableClientWithOptions(config, DefaultClientOptions())
+}
+
+// NewStreamableClientWithOptions creates a Streamable HTTP client with custom options.
+//
+//nolint:gocritic // matches existing Client constructor signatures
+func NewStreamableClientWithOptions(config ServerConfig, options ClientOptions) *StreamableClient {
+	return &StreamableClient{config: config, options: options}
+}
+
+// Initialize sends the initialize request and negotiates capabilities.
+func (c *StreamableClient) Initialize(ctx context.Context) (*InitializeResponse, error) {
+	c.mu.Lock()
+	if c.started {
+		resp := c.serverInfo
+		c.mu.Unlock()
+		return resp, nil
+	}
+	if c.closed {
+		c.mu.Unlock()
+		return nil, ErrClientClosed
+	}
+	c.tr = newStreamableTransport(c.config, c.options)
+	c.mu.Unlock()
+
+	initCtx, cancel := context.WithTimeout(ctx, c.options.InitTimeout)
+	defer cancel()
+	req := InitializeRequest{
+		ProtocolVersion: ProtocolVersion,
+		Capabilities: ClientCapabilities{
+			Elicitation: &ElicitationCapability{},
+		},
+		ClientInfo: Implementation{Name: streamableClientImplName, Version: streamableClientImplVersion},
+	}
+	var resp InitializeResponse
+	if err := c.tr.sendRequest(initCtx, "initialize", req, &resp); err != nil {
+		c.tr.close()
+		return nil, fmt.Errorf("mcp/streamable: initialize: %w", err)
+	}
+
+	c.mu.Lock()
+	c.serverInfo = &resp
+	c.started = true
+	c.mu.Unlock()
+	return &resp, nil
+}
+
+// ListTools retrieves all available tools from the server.
+func (c *StreamableClient) ListTools(ctx context.Context) ([]Tool, error) {
+	if err := c.checkAlive(); err != nil {
+		return nil, err
+	}
+	var resp ToolsListResponse
+	if err := c.tr.sendRequest(ctx, "tools/list", nil, &resp); err != nil {
+		if c.options.EnableGracefulDegradation {
+			logger.Warn("MCP/Streamable tools/list failed, using graceful degradation",
+				"server", c.config.Name, "error", err)
+			return []Tool{}, nil
+		}
+		return nil, fmt.Errorf("mcp/streamable: tools/list: %w", err)
+	}
+	return resp.Tools, nil
+}
+
+// CallTool executes a tool with the given arguments.
+func (c *StreamableClient) CallTool(
+	ctx context.Context, name string, arguments json.RawMessage,
+) (*ToolCallResponse, error) {
+	if err := c.checkAlive(); err != nil {
+		return nil, err
+	}
+	req := ToolCallRequest{Name: name, Arguments: arguments}
+	var resp ToolCallResponse
+	if err := c.tr.sendRequest(ctx, "tools/call", req, &resp); err != nil {
+		return nil, fmt.Errorf("mcp/streamable: tools/call: %w", err)
+	}
+	return &resp, nil
+}
+
+// Close marks the client closed. Idempotent.
+func (c *StreamableClient) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	tr := c.tr
+	c.mu.Unlock()
+	if tr != nil {
+		tr.close()
+	}
+	return nil
+}
+
+// IsAlive reports whether the transport has completed at least one
+// successful request since the last close.
+func (c *StreamableClient) IsAlive() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || c.tr == nil {
+		return false
+	}
+	return c.tr.alive.Load()
+}
+
+func (c *StreamableClient) checkAlive() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ErrClientClosed
+	}
+	if !c.started {
+		return ErrClientNotInitialized
+	}
+	if !c.tr.alive.Load() {
+		return ErrServerUnresponsive
+	}
+	return nil
+}

--- a/runtime/mcp/streamable_client_test.go
+++ b/runtime/mcp/streamable_client_test.go
@@ -1,0 +1,156 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func streamableClientTestServer(t *testing.T, handle func(req JSONRPCMessage) JSONRPCMessage) (string, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req JSONRPCMessage
+		_ = json.Unmarshal(body, &req)
+		resp := handle(req)
+		if resp.JSONRPC == "" {
+			resp.JSONRPC = "2.0"
+		}
+		resp.ID = req.ID
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	return srv.URL + "/mcp", srv.Close
+}
+
+func TestStreamableClient_Initialize_Succeeds(t *testing.T) {
+	url, cleanup := streamableClientTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		if req.Method == "initialize" {
+			return JSONRPCMessage{Result: json.RawMessage(`{
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake", "version": "0.1"}
+            }`)}
+		}
+		return JSONRPCMessage{Error: &JSONRPCError{Code: -32601, Message: "not found"}}
+	})
+	defer cleanup()
+
+	c := NewStreamableClient(ServerConfig{Name: "x", URL: url, TransportName: TransportStreamableHTTP})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := c.Initialize(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "fake", resp.ServerInfo.Name)
+	assert.True(t, c.IsAlive())
+	require.NoError(t, c.Close())
+	assert.False(t, c.IsAlive())
+}
+
+func TestStreamableClient_ListTools(t *testing.T) {
+	url, cleanup := streamableClientTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		switch req.Method {
+		case "initialize":
+			return JSONRPCMessage{Result: json.RawMessage(`{
+                "protocolVersion": "2025-06-18","capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake","version": "0.1"}}`)}
+		case "tools/list":
+			return JSONRPCMessage{Result: json.RawMessage(`{"tools":[{"name":"Read","inputSchema":{}}]}`)}
+		}
+		return JSONRPCMessage{Error: &JSONRPCError{Code: -32601, Message: "not found"}}
+	})
+	defer cleanup()
+
+	c := NewStreamableClient(ServerConfig{Name: "x", URL: url, TransportName: TransportStreamableHTTP})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := c.Initialize(ctx)
+	require.NoError(t, err)
+
+	tools, err := c.ListTools(ctx)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "Read", tools[0].Name)
+	require.NoError(t, c.Close())
+}
+
+func TestStreamableClient_CallTool(t *testing.T) {
+	url, cleanup := streamableClientTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		switch req.Method {
+		case "initialize":
+			return JSONRPCMessage{Result: json.RawMessage(`{
+                "protocolVersion": "2025-06-18","capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake","version": "0.1"}}`)}
+		case "tools/call":
+			return JSONRPCMessage{Result: json.RawMessage(
+				`{"content":[{"type":"text","text":"hello"}],"isError":false}`,
+			)}
+		}
+		return JSONRPCMessage{Error: &JSONRPCError{Code: -32601, Message: "not found"}}
+	})
+	defer cleanup()
+
+	c := NewStreamableClient(ServerConfig{Name: "x", URL: url, TransportName: TransportStreamableHTTP})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := c.Initialize(ctx)
+	require.NoError(t, err)
+
+	resp, err := c.CallTool(ctx, "Read", json.RawMessage(`{"path":"/foo"}`))
+	require.NoError(t, err)
+	require.Len(t, resp.Content, 1)
+	assert.Equal(t, "hello", resp.Content[0].Text)
+	require.NoError(t, c.Close())
+}
+
+func TestStreamableClient_NotInitialized(t *testing.T) {
+	c := NewStreamableClient(ServerConfig{Name: "x", URL: "http://localhost:0", TransportName: TransportStreamableHTTP})
+	_, err := c.ListTools(context.Background())
+	assert.ErrorIs(t, err, ErrClientNotInitialized)
+	_, err = c.CallTool(context.Background(), "x", json.RawMessage(`{}`))
+	assert.ErrorIs(t, err, ErrClientNotInitialized)
+}
+
+func TestStreamableClient_Initialize_AfterClose(t *testing.T) {
+	c := NewStreamableClient(ServerConfig{Name: "x", URL: "http://x", TransportName: TransportStreamableHTTP})
+	require.NoError(t, c.Close())
+	_, err := c.Initialize(context.Background())
+	assert.ErrorIs(t, err, ErrClientClosed)
+}
+
+func TestStreamableClient_Initialize_Idempotent(t *testing.T) {
+	url, cleanup := streamableClientTestServer(t, func(_ JSONRPCMessage) JSONRPCMessage {
+		return JSONRPCMessage{Result: json.RawMessage(`{
+            "protocolVersion":"2025-06-18","capabilities":{},
+            "serverInfo":{"name":"fake","version":"0.1"}}`)}
+	})
+	defer cleanup()
+
+	c := NewStreamableClient(ServerConfig{Name: "x", URL: url, TransportName: TransportStreamableHTTP})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r1, err := c.Initialize(ctx)
+	require.NoError(t, err)
+	r2, err := c.Initialize(ctx)
+	require.NoError(t, err)
+	assert.Same(t, r1, r2)
+	require.NoError(t, c.Close())
+}
+
+func TestStreamableClient_Close_Idempotent(t *testing.T) {
+	c := NewStreamableClient(ServerConfig{Name: "x", URL: "http://x", TransportName: TransportStreamableHTTP})
+	require.NoError(t, c.Close())
+	require.NoError(t, c.Close())
+	assert.False(t, c.IsAlive())
+}

--- a/runtime/mcp/streamable_integration_test.go
+++ b/runtime/mcp/streamable_integration_test.go
@@ -1,0 +1,74 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamableHTTP_EndToEnd_ViaRegistry verifies that a ServerConfig with
+// TransportName=streamable_http drives the registry to dispatch to a
+// StreamableClient that can complete the full Initialize/ListTools/CallTool
+// cycle against a Streamable HTTP server.
+func TestStreamableHTTP_EndToEnd_ViaRegistry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req JSONRPCMessage
+		_ = json.Unmarshal(body, &req)
+
+		var resp JSONRPCMessage
+		resp.JSONRPC = "2.0"
+		resp.ID = req.ID
+		switch req.Method {
+		case "initialize":
+			resp.Result = json.RawMessage(
+				`{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},` +
+					`"serverInfo":{"name":"fake","version":"0.1"}}`,
+			)
+		case "tools/list":
+			resp.Result = json.RawMessage(`{"tools":[{"name":"weather","inputSchema":{}}]}`)
+		case "tools/call":
+			resp.Result = json.RawMessage(`{"content":[{"type":"text","text":"sunny"}],"isError":false}`)
+		default:
+			resp.Error = &JSONRPCError{Code: -32601, Message: "not found"}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	reg := NewRegistry()
+	defer func() { _ = reg.Close() }()
+
+	require.NoError(t, reg.RegisterServer(ServerConfig{
+		Name:          "weather",
+		URL:           srv.URL,
+		TransportName: TransportStreamableHTTP,
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, err := reg.GetClient(ctx, "weather")
+	require.NoError(t, err)
+	_, ok := client.(*StreamableClient)
+	require.True(t, ok, "registry dispatched to %T, expected *StreamableClient", client)
+
+	tools, err := client.ListTools(ctx)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "weather", tools[0].Name)
+
+	result, err := client.CallTool(ctx, "weather", json.RawMessage(`{"latitude":51.5,"longitude":-0.1}`))
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "sunny", result.Content[0].Text)
+}

--- a/runtime/mcp/streamable_transport.go
+++ b/runtime/mcp/streamable_transport.go
@@ -1,0 +1,218 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// jsonRPCVersion is the JSON-RPC envelope version used by all MCP messages.
+const jsonRPCVersion = "2.0"
+
+// sseEventMessage is the SSE event name carrying JSON-RPC payloads.
+const sseEventMessage = "message"
+
+// streamableTransport implements the MCP 2025-03-26 Streamable HTTP transport.
+//
+// One POST per JSON-RPC request; the response is delivered inline on the same
+// POST as either application/json (one-shot) or text/event-stream (SSE-framed
+// JSON-RPC messages). The transport is request-scoped — no persistent stream
+// is held between calls.
+type streamableTransport struct {
+	config  ServerConfig
+	options ClientOptions
+
+	httpClient *http.Client
+	url        string
+
+	nextID atomic.Int64
+
+	mu        sync.Mutex
+	sessionID string // populated from Mcp-Session-Id on Initialize response
+
+	closed atomic.Bool
+	alive  atomic.Bool
+}
+
+// newStreamableTransport constructs a Streamable HTTP transport. The transport
+// is considered "alive" once the first successful request has completed.
+//
+//nolint:gocritic // config matches existing Client constructor signatures
+func newStreamableTransport(config ServerConfig, options ClientOptions) *streamableTransport {
+	return &streamableTransport{
+		config:     config,
+		options:    options,
+		httpClient: &http.Client{}, //nolint:exhaustruct // stdlib defaults are fine
+		url:        config.URL,
+	}
+}
+
+// close marks the transport closed. Idempotent. The Streamable HTTP transport
+// holds no persistent connection, so there is nothing to tear down beyond
+// flipping the flag.
+func (t *streamableTransport) close() {
+	if t.closed.Swap(true) {
+		return
+	}
+	t.alive.Store(false)
+}
+
+// sendRequest issues a single JSON-RPC request and unmarshals the response
+// into out. It dispatches on the response Content-Type:
+//   - application/json: one-shot JSON-RPC response.
+//   - text/event-stream: SSE stream; the first JSON-RPC message with a
+//     matching id is the response.
+func (t *streamableTransport) sendRequest(ctx context.Context, method string, params, out any) error {
+	if t.closed.Load() {
+		return ErrClientClosed
+	}
+	id := t.nextID.Add(1)
+
+	body, err := t.buildRequestBody(id, method, params)
+	if err != nil {
+		return err
+	}
+
+	req, err := t.buildHTTPRequest(ctx, body)
+	if err != nil {
+		return err
+	}
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("mcp/streamable: POST: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusAccepted {
+		// 202 with no body: notification/empty response. No correlation needed.
+		t.captureSession(resp)
+		t.alive.Store(true)
+		return nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("mcp/streamable: POST status %d", resp.StatusCode)
+	}
+
+	t.captureSession(resp)
+
+	contentType := resp.Header.Get("Content-Type")
+	switch {
+	case strings.HasPrefix(contentType, "application/json"):
+		var msg JSONRPCMessage
+		if derr := json.NewDecoder(resp.Body).Decode(&msg); derr != nil {
+			return fmt.Errorf("mcp/streamable: decode json response: %w", derr)
+		}
+		t.alive.Store(true)
+		return unmarshalStreamableReply(&msg, out)
+	case strings.HasPrefix(contentType, "text/event-stream"):
+		msg, rerr := readSSEUntilResponse(resp.Body, id)
+		if rerr != nil {
+			return rerr
+		}
+		t.alive.Store(true)
+		return unmarshalStreamableReply(msg, out)
+	default:
+		return fmt.Errorf("mcp/streamable: unexpected content type %q", contentType)
+	}
+}
+
+func (t *streamableTransport) buildRequestBody(id int64, method string, params any) ([]byte, error) {
+	var paramBytes json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			return nil, fmt.Errorf("mcp/streamable: marshal params: %w", err)
+		}
+		paramBytes = b
+	}
+	body, err := json.Marshal(JSONRPCMessage{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Method:  method,
+		Params:  paramBytes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mcp/streamable: marshal request: %w", err)
+	}
+	return body, nil
+}
+
+func (t *streamableTransport) buildHTTPRequest(ctx context.Context, body []byte) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("mcp/streamable: build POST: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", ProtocolVersion)
+	for k, v := range t.config.Headers {
+		req.Header.Set(k, v)
+	}
+	t.mu.Lock()
+	if t.sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", t.sessionID)
+	}
+	t.mu.Unlock()
+	return req, nil
+}
+
+func (t *streamableTransport) captureSession(resp *http.Response) {
+	sid := resp.Header.Get("Mcp-Session-Id")
+	if sid == "" {
+		return
+	}
+	t.mu.Lock()
+	t.sessionID = sid
+	t.mu.Unlock()
+}
+
+// readSSEUntilResponse reads SSE frames from body until it finds a JSON-RPC
+// message with the given id, then returns it. Frames whose data does not
+// parse as a JSON-RPC message, or whose id does not match, are skipped
+// (they may be server-initiated notifications or unrelated responses).
+func readSSEUntilResponse(body io.Reader, wantID int64) (*JSONRPCMessage, error) {
+	reader := bufio.NewReader(body)
+	for {
+		ev, err := readSSEEvent(reader)
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("mcp/streamable: SSE stream closed without matching response")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("mcp/streamable: read SSE: %w", err)
+		}
+		if ev.event != "" && ev.event != sseEventMessage {
+			continue
+		}
+		var msg JSONRPCMessage
+		if jerr := json.Unmarshal([]byte(ev.data), &msg); jerr != nil {
+			continue
+		}
+		gotID, ok := coerceID(msg.ID)
+		if !ok || gotID != wantID {
+			continue
+		}
+		return &msg, nil
+	}
+}
+
+func unmarshalStreamableReply(reply *JSONRPCMessage, out any) error {
+	if reply.Error != nil {
+		return fmt.Errorf("mcp/streamable: rpc error %d: %s", reply.Error.Code, reply.Error.Message)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(reply.Result, out); err != nil {
+		return fmt.Errorf("mcp/streamable: unmarshal result: %w", err)
+	}
+	return nil
+}

--- a/runtime/mcp/streamable_transport_test.go
+++ b/runtime/mcp/streamable_transport_test.go
@@ -1,0 +1,334 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// streamableTestServer spins up a single-endpoint MCP server that responds
+// with application/json. handle is invoked once per POST.
+func streamableTestServer(t *testing.T, handle func(req JSONRPCMessage) JSONRPCMessage) (string, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var req JSONRPCMessage
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp := handle(req)
+		if resp.JSONRPC == "" {
+			resp.JSONRPC = "2.0"
+		}
+		resp.ID = req.ID
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	return srv.URL + "/mcp", srv.Close
+}
+
+func TestStreamableTransport_SendRequest_JSONResponse(t *testing.T) {
+	url, cleanup := streamableTestServer(t, func(req JSONRPCMessage) JSONRPCMessage {
+		if req.Method == "tools/list" {
+			return JSONRPCMessage{Result: json.RawMessage(`{"tools":[{"name":"Read","inputSchema":{}}]}`)}
+		}
+		return JSONRPCMessage{Error: &JSONRPCError{Code: -32601, Message: "not found"}}
+	})
+	defer cleanup()
+
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: url, TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	defer tr.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var out ToolsListResponse
+	err := tr.sendRequest(ctx, "tools/list", nil, &out)
+	require.NoError(t, err)
+	require.Len(t, out.Tools, 1)
+	assert.Equal(t, "Read", out.Tools[0].Name)
+}
+
+// streamableSSETestServer responds to the matching method with an SSE body
+// containing exactly one JSON-RPC response message keyed to the request id.
+func streamableSSETestServer(t *testing.T, method string, result json.RawMessage) (string, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req JSONRPCMessage
+		_ = json.Unmarshal(body, &req)
+		if req.Method != method {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(JSONRPCMessage{
+				JSONRPC: "2.0", ID: req.ID,
+				Error: &JSONRPCError{Code: -32601, Message: "not found"},
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		resp := JSONRPCMessage{JSONRPC: "2.0", ID: req.ID, Result: result}
+		payload, _ := json.Marshal(resp)
+		_, _ = w.Write([]byte("event: message\ndata: "))
+		_, _ = w.Write(payload)
+		_, _ = w.Write([]byte("\n\n"))
+		w.(http.Flusher).Flush()
+	})
+	srv := httptest.NewServer(mux)
+	return srv.URL + "/mcp", srv.Close
+}
+
+func TestStreamableTransport_SendRequest_SSEResponse(t *testing.T) {
+	url, cleanup := streamableSSETestServer(t, "tools/call",
+		json.RawMessage(`{"content":[{"type":"text","text":"hi"}],"isError":false}`))
+	defer cleanup()
+
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: url, TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	defer tr.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var out ToolCallResponse
+	err := tr.sendRequest(ctx, "tools/call", ToolCallRequest{Name: "Read"}, &out)
+	require.NoError(t, err)
+	require.Len(t, out.Content, 1)
+	assert.Equal(t, "hi", out.Content[0].Text)
+}
+
+func TestStreamableTransport_SendRequest_SSESkipsUnrelatedMessages(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req JSONRPCMessage
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Notification (no id) — should be skipped.
+		_, _ = w.Write([]byte(
+			"event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\"}\n\n",
+		))
+		// Response for the request.
+		resp := JSONRPCMessage{JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`{"tools":[]}`)}
+		payload, _ := json.Marshal(resp)
+		_, _ = w.Write([]byte("event: message\ndata: "))
+		_, _ = w.Write(payload)
+		_, _ = w.Write([]byte("\n\n"))
+		w.(http.Flusher).Flush()
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: srv.URL + "/mcp", TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	defer tr.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var out ToolsListResponse
+	err := tr.sendRequest(ctx, "tools/list", nil, &out)
+	require.NoError(t, err)
+	assert.Empty(t, out.Tools)
+}
+
+func TestStreamableTransport_SessionIDRoundTrip(t *testing.T) {
+	var mu sync.Mutex
+	var sawSessionOn2 string
+	calls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+
+		body, _ := io.ReadAll(r.Body)
+		var req JSONRPCMessage
+		_ = json.Unmarshal(body, &req)
+
+		if n == 1 {
+			w.Header().Set("Mcp-Session-Id", "sess-abc")
+		} else {
+			mu.Lock()
+			sawSessionOn2 = r.Header.Get("Mcp-Session-Id")
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(JSONRPCMessage{
+			JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`{}`),
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: srv.URL + "/mcp", TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	defer tr.close()
+	ctx := context.Background()
+
+	require.NoError(t, tr.sendRequest(ctx, "initialize", nil, nil))
+	require.NoError(t, tr.sendRequest(ctx, "tools/list", nil, nil))
+
+	mu.Lock()
+	assert.Equal(t, "sess-abc", sawSessionOn2)
+	mu.Unlock()
+}
+
+func TestStreamableTransport_CustomHeadersAndProtocolVersion(t *testing.T) {
+	var seenAuth, seenVersion, seenAccept string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		seenVersion = r.Header.Get("MCP-Protocol-Version")
+		seenAccept = r.Header.Get("Accept")
+		body, _ := io.ReadAll(r.Body)
+		var req JSONRPCMessage
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(JSONRPCMessage{
+			JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`{}`),
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := ServerConfig{
+		Name:          "x",
+		URL:           srv.URL + "/mcp",
+		TransportName: TransportStreamableHTTP,
+		Headers:       map[string]string{"Authorization": "Bearer tok"},
+	}
+	tr := newStreamableTransport(cfg, DefaultClientOptions())
+	defer tr.close()
+
+	require.NoError(t, tr.sendRequest(context.Background(), "initialize", nil, nil))
+	assert.Equal(t, "Bearer tok", seenAuth)
+	assert.Equal(t, ProtocolVersion, seenVersion)
+	assert.Contains(t, seenAccept, "application/json")
+	assert.Contains(t, seenAccept, "text/event-stream")
+}
+
+func TestStreamableTransport_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: srv.URL, TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	defer tr.close()
+	err := tr.sendRequest(context.Background(), "initialize", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+}
+
+func TestStreamableTransport_UnexpectedContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: srv.URL, TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	defer tr.close()
+	err := tr.sendRequest(context.Background(), "initialize", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected content type")
+}
+
+func TestStreamableTransport_JSONRPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req JSONRPCMessage
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(JSONRPCMessage{
+			JSONRPC: "2.0", ID: req.ID,
+			Error: &JSONRPCError{Code: -32601, Message: "method not found"},
+		})
+	}))
+	defer srv.Close()
+
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: srv.URL, TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	defer tr.close()
+	err := tr.sendRequest(context.Background(), "tools/list", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "method not found")
+}
+
+func TestStreamableTransport_AcceptedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: srv.URL, TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	defer tr.close()
+	err := tr.sendRequest(context.Background(), "notifications/initialized", nil, nil)
+	require.NoError(t, err)
+}
+
+func TestStreamableTransport_Close_Idempotent(t *testing.T) {
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: "http://x", TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	tr.close()
+	tr.close() // must not panic
+	assert.False(t, tr.alive.Load())
+}
+
+func TestStreamableTransport_SendAfterClose(t *testing.T) {
+	tr := newStreamableTransport(
+		ServerConfig{Name: "x", URL: "http://x", TransportName: TransportStreamableHTTP},
+		DefaultClientOptions(),
+	)
+	tr.close()
+	err := tr.sendRequest(context.Background(), "x", nil, nil)
+	assert.ErrorIs(t, err, ErrClientClosed)
+}

--- a/runtime/mcp/types.go
+++ b/runtime/mcp/types.go
@@ -170,10 +170,12 @@ func (f ToolFilter) Includes(name string) bool {
 //
 // Exactly one transport should be specified:
 //   - Command: stdio transport — PromptKit spawns a local subprocess.
-//   - URL:     HTTP+SSE transport — PromptKit connects to a running server.
+//   - URL:     HTTP transport — by default the legacy SSE adapter is used.
+//     Set TransportName to TransportStreamableHTTP to opt into the
+//     modern Streamable HTTP transport (MCP 2025-03-26).
 //
-// The registry selects the adapter via Transport(). Headers applies only to
-// the SSE transport.
+// The registry selects the adapter via Transport(). Headers applies to all
+// HTTP transports (SSE and Streamable HTTP).
 type ServerConfig struct {
 	Name    string            `json:"name" yaml:"name"`
 	Command string            `json:"command,omitempty" yaml:"command,omitempty"`
@@ -181,11 +183,18 @@ type ServerConfig struct {
 	Env     map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	// WorkingDir sets the working directory for the server process (stdio only).
 	WorkingDir string `json:"working_dir,omitempty" yaml:"working_dir,omitempty"`
-	// URL is the base URL for HTTP+SSE servers. When set, the registry uses
-	// the SSE adapter and Command is ignored.
+	// URL is the base URL for an HTTP MCP server. When set without an
+	// explicit TransportName, the registry uses the legacy SSE adapter for
+	// back-compat. Set TransportName to TransportStreamableHTTP to opt into
+	// the modern transport.
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
-	// Headers are sent on both the initial GET /sse and subsequent POSTs.
+	// Headers are sent on HTTP transports (both SSE and Streamable HTTP).
 	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	// TransportName selects the transport adapter explicitly. When empty, the
+	// legacy inference applies (URL → SSE, Command → Stdio) for back-compat.
+	// Set to TransportStreamableHTTP to opt into the modern Streamable HTTP
+	// transport against a URL.
+	TransportName Transport `json:"transport,omitempty" yaml:"transport,omitempty"`
 	// TimeoutMs sets the per-request timeout in milliseconds.
 	TimeoutMs int `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
 	// ToolFilter controls which tools from this server are exposed.
@@ -200,15 +209,21 @@ const (
 	TransportUnknown Transport = ""
 	// TransportStdio is the local-subprocess transport.
 	TransportStdio Transport = "stdio"
-	// TransportSSE is the HTTP+SSE transport.
+	// TransportSSE is the legacy HTTP+SSE transport (MCP 2024-11-05 spec).
 	TransportSSE Transport = "sse"
+	// TransportStreamableHTTP is the Streamable HTTP transport
+	// (MCP 2025-03-26 spec). A single POST endpoint that returns either
+	// application/json or text/event-stream.
+	TransportStreamableHTTP Transport = "streamable_http"
 )
 
-// Transport returns the transport derived from which fields are populated.
-// URL takes precedence over Command; config validation upstream should
-// prevent both being set, but this function returns a deterministic answer
-// either way. Pointer receiver to avoid copying the (~120-byte) struct.
+// Transport returns the resolved transport. An explicit TransportName field
+// wins; otherwise URL → TransportSSE (back-compat), Command → TransportStdio.
+// Pointer receiver to avoid copying the (~120-byte) struct.
 func (c *ServerConfig) Transport() Transport {
+	if c.TransportName != "" {
+		return c.TransportName
+	}
 	if c.URL != "" {
 		return TransportSSE
 	}

--- a/runtime/mcp/types_test.go
+++ b/runtime/mcp/types_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestServerConfig_Transport_Stdio(t *testing.T) {
@@ -32,4 +34,25 @@ func TestServerConfig_Transport_Unknown(t *testing.T) {
 	if got := cfg.Transport(); got != TransportUnknown {
 		t.Errorf("Transport() = %q, want %q", got, TransportUnknown)
 	}
+}
+
+func TestServerConfig_Transport_ExplicitStreamable(t *testing.T) {
+	cfg := ServerConfig{Name: "x", URL: "http://h", TransportName: TransportStreamableHTTP}
+	assert.Equal(t, TransportStreamableHTTP, cfg.Transport())
+}
+
+func TestServerConfig_Transport_ExplicitSSE(t *testing.T) {
+	cfg := ServerConfig{Name: "x", URL: "http://h", TransportName: TransportSSE}
+	assert.Equal(t, TransportSSE, cfg.Transport())
+}
+
+func TestServerConfig_Transport_URLDefaultsToSSE_ForBackCompat(t *testing.T) {
+	cfg := ServerConfig{Name: "x", URL: "http://h"}
+	assert.Equal(t, TransportSSE, cfg.Transport())
+}
+
+func TestServerConfig_Transport_ExplicitStdioWithURL_HonoursExplicit(t *testing.T) {
+	// If a caller explicitly opts into stdio, that wins over URL inference.
+	cfg := ServerConfig{Name: "x", URL: "http://h", Command: "./foo", TransportName: TransportStdio}
+	assert.Equal(t, TransportStdio, cfg.Transport())
 }

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1186,6 +1186,17 @@
           },
           "type": "object"
         },
+        "transport": {
+          "type": "string",
+          "enum": [
+            "",
+            "stdio",
+            "sse",
+            "streamable_http"
+          ],
+          "title": "MCP Transport",
+          "description": "Explicit transport adapter. Defaults: url→sse for back-compat; command→stdio. Set to 'streamable_http' to opt into the MCP 2025-03-26 Streamable HTTP transport."
+        },
         "source": {
           "type": "string",
           "title": "MCPSource Name",

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -331,6 +331,17 @@
           },
           "type": "object"
         },
+        "transport": {
+          "type": "string",
+          "enum": [
+            "",
+            "stdio",
+            "sse",
+            "streamable_http"
+          ],
+          "title": "MCP Transport",
+          "description": "Explicit transport adapter. Defaults: url→sse for back-compat; command→stdio. Set to 'streamable_http' to opt into the MCP 2025-03-26 Streamable HTTP transport."
+        },
         "source": {
           "type": "string",
           "title": "MCPSource Name",

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -171,12 +171,15 @@ func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 	// Apply MCP servers
 	for _, mcpCfg := range spec.MCPServers {
 		serverCfg := mcp.ServerConfig{
-			Name:       mcpCfg.Name,
-			Command:    mcpCfg.Command,
-			Args:       mcpCfg.Args,
-			Env:        mcpCfg.Env,
-			WorkingDir: mcpCfg.WorkingDir,
-			TimeoutMs:  mcpCfg.TimeoutMs,
+			Name:          mcpCfg.Name,
+			Command:       mcpCfg.Command,
+			Args:          mcpCfg.Args,
+			Env:           mcpCfg.Env,
+			WorkingDir:    mcpCfg.WorkingDir,
+			URL:           mcpCfg.URL,
+			Headers:       mcpCfg.Headers,
+			TransportName: mcp.Transport(mcpCfg.Transport),
+			TimeoutMs:     mcpCfg.TimeoutMs,
 		}
 		if mcpCfg.ToolFilter != nil {
 			serverCfg.ToolFilter = &mcp.ToolFilter{

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -94,6 +94,47 @@ func TestApplyRuntimeConfig_MCPServers_AppendToExisting(t *testing.T) {
 	assert.Equal(t, "new-server", c.mcpServers[1].Name)
 }
 
+func TestApplyRuntimeConfig_MCPStreamableHTTP_Propagates(t *testing.T) {
+	spec := &pkgconfig.RuntimeConfigSpec{
+		MCPServers: []pkgconfig.MCPServerConfig{{
+			Name:      "weather",
+			URL:       "http://weather.local/mcp",
+			Transport: "streamable_http",
+			Headers:   map[string]string{"Authorization": "Bearer tok"},
+		}},
+	}
+	c := &config{}
+	require.NoError(t, applyRuntimeConfig(c, spec))
+	require.Len(t, c.mcpServers, 1)
+	got := c.mcpServers[0]
+	assert.Equal(t, "weather", got.Name)
+	assert.Equal(t, "http://weather.local/mcp", got.URL)
+	assert.Equal(t, mcp.TransportStreamableHTTP, got.TransportName)
+	assert.Equal(t, "Bearer tok", got.Headers["Authorization"])
+}
+
+func TestApplyRuntimeConfig_MCPSSEDefault_PropagatesURLAndHeaders(t *testing.T) {
+	// Without an explicit Transport, URL-only configs continue to default to
+	// the legacy SSE adapter. The previous SDK code dropped URL and Headers
+	// on the floor here; this test guards against regression.
+	spec := &pkgconfig.RuntimeConfigSpec{
+		MCPServers: []pkgconfig.MCPServerConfig{{
+			Name:    "legacy",
+			URL:     "http://legacy.local",
+			Headers: map[string]string{"X-Custom": "v"},
+		}},
+	}
+	c := &config{}
+	require.NoError(t, applyRuntimeConfig(c, spec))
+	require.Len(t, c.mcpServers, 1)
+	got := c.mcpServers[0]
+	assert.Equal(t, "http://legacy.local", got.URL)
+	assert.Equal(t, "v", got.Headers["X-Custom"])
+	assert.Equal(t, mcp.Transport(""), got.TransportName)
+	// Resolution falls back to SSE per ServerConfig.Transport().
+	assert.Equal(t, mcp.TransportSSE, got.Transport())
+}
+
 func TestApplyRuntimeConfig_StateStore_Memory(t *testing.T) {
 	spec := &pkgconfig.RuntimeConfigSpec{
 		StateStore: &pkgconfig.StateStoreConfig{Type: "memory"},


### PR DESCRIPTION
## Summary

Adds the MCP 2025-03-26 Streamable HTTP transport to `runtime/mcp/` as an **explicit opt-in** alongside the existing legacy HTTP+SSE adapter. Unblocks Omnia's MCP facade consumer path (Omnia #1131) and any PromptKit pack that wants to talk to a modern MCP server.

- New `TransportStreamableHTTP` constant and explicit `TransportName` field on `mcp.ServerConfig`. URL-only configs continue to default to SSE for back-compat — Streamable HTTP is opt-in via `transport: streamable_http`.
- New `StreamableClient` + `streamableTransport`: one POST per request, response delivered inline as either `application/json` or `text/event-stream` (SSE upgrade). `Mcp-Session-Id` round-trip, `MCP-Protocol-Version` header, custom `Headers` propagation, `Accept` covering both response variants.
- Registry dispatch extended; `pkg/config` exposes the new `transport` field with full validation; JSON schemas regenerated.
- Pre-existing bug fix on the way: `sdk/runtime_config.go` was silently dropping `URL`/`Headers` from MCP runtime-config entries — Streamable HTTP can't work without that, and the SSE-via-runtime-config path is restored as a bonus.

**Out of scope (follow-ups):** optional `GET /mcp` for server-initiated messages, `Last-Event-ID` resumption, explicit `DELETE /mcp` session termination, and cleanup of the dead `tools/arena/mcp/config.go` `NewRegistryFromConfig` path (no live callers).

Closes #1238.

## Test plan

- [x] `go -C runtime test ./mcp/... -count=1 -race` — all transport, client, registry, and integration tests pass
- [x] `go -C pkg test ./config/... -count=1 -race` — validation tests pass
- [x] `go -C sdk test ./... -count=1` — runtime config propagation tests pass
- [x] `go -C tools/arena test ./... -count=1` — no arena regressions
- [x] `golangci-lint` clean on each module
- [ ] SonarCloud quality gate green