### PR TITLE
feat(statestore): RedisStore implements MessageLog for mid-loop persistence

### DIFF
--- a/runtime/statestore/message_log.go
+++ b/runtime/statestore/message_log.go
@@ -14,6 +14,11 @@ import (
 // The sequence number is the message index in the conversation (0-based).
 // AppendMessages with startSeq < current length skips already-persisted messages,
 // making retries safe.
+//
+// Implementations are not required to be safe against concurrent LogAppend
+// calls targeting the same conversation id. Callers must serialize writes
+// per conversation — the ProviderStage tool loop already does this via
+// per-conversation single-threading.
 type MessageLog interface {
 	// LogAppend appends messages starting at the given sequence number.
 	// If startSeq < current message count, the first (current - startSeq) input

--- a/runtime/statestore/redis.go
+++ b/runtime/statestore/redis.go
@@ -175,15 +175,7 @@ func (s *RedisStore) loadMessagesList(ctx context.Context, id string) ([]types.M
 	if err != nil && !errors.Is(err, redis.Nil) {
 		return nil, fmt.Errorf("redis lrange messages failed: %w", err)
 	}
-	messages := make([]types.Message, 0, len(vals))
-	for _, v := range vals {
-		var msg types.Message
-		if unmarshalErr := json.Unmarshal([]byte(v), &msg); unmarshalErr != nil {
-			return nil, fmt.Errorf("failed to unmarshal message: %w", unmarshalErr)
-		}
-		messages = append(messages, msg)
-	}
-	return messages, nil
+	return unmarshalMessages(vals)
 }
 
 // loadSummariesList loads summaries from a Redis list key.
@@ -327,6 +319,20 @@ func stateToMeta(state *ConversationState) redisStateMeta {
 		TokenCount:     state.TokenCount,
 		LastAccessedAt: state.LastAccessedAt,
 	}
+}
+
+// unmarshalMessages decodes a slice of JSON-encoded message strings (as
+// returned by Redis LRange against a messagesKey list).
+func unmarshalMessages(vals []string) ([]types.Message, error) {
+	msgs := make([]types.Message, 0, len(vals))
+	for _, v := range vals {
+		var m types.Message
+		if err := json.Unmarshal([]byte(v), &m); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal message: %w", err)
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, nil
 }
 
 // marshalMessages serializes messages to a list of JSON byte slices.
@@ -901,16 +907,7 @@ func (s *RedisStore) LoadRecentMessages(ctx context.Context, id string, n int) (
 		return nil, fmt.Errorf("redis lrange failed: %w", err)
 	}
 
-	messages := make([]types.Message, 0, len(vals))
-	for _, v := range vals {
-		var msg types.Message
-		if err := json.Unmarshal([]byte(v), &msg); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal message: %w", err)
-		}
-		messages = append(messages, msg)
-	}
-
-	return messages, nil
+	return unmarshalMessages(vals)
 }
 
 // MessageCount returns the total number of messages.
@@ -1312,4 +1309,91 @@ func sortStatesByField(states []stateWithID, sortBy string, ascending bool) {
 		}
 		return !less
 	})
+}
+
+// LogAppend appends messages with sequence-based idempotent deduplication.
+// The on-disk layout matches what Save writes (a Redis list at messagesKey(id))
+// so messages persisted via the tool-loop write-through path are loaded back
+// transparently by Load. A minimal meta stub is written via SETNX so a
+// subsequent Load(id) does not return ErrNotFound after a crash recovery
+// before the end-of-turn Save has run; the next Save overwrites it.
+func (s *RedisStore) LogAppend(
+	ctx context.Context, id string, startSeq int, messages []types.Message,
+) (int, error) {
+	if id == "" {
+		return 0, ErrInvalidID
+	}
+
+	msgKey := s.messagesKey(id)
+	currentLen, err := s.client.LLen(ctx, msgKey).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return 0, fmt.Errorf("redis llen failed: %w", err)
+	}
+
+	// Clamp startSeq to current length (handles startSeq > currentLen gracefully)
+	// and skip the messages already persisted (idempotent dedup on retry).
+	skip := int(currentLen) - startSeq
+	if skip < 0 {
+		skip = 0
+	}
+	if skip >= len(messages) {
+		return int(currentLen), nil
+	}
+	delta := messages[skip:]
+
+	vals, err := marshalMessageSlice(delta)
+	if err != nil {
+		return 0, err
+	}
+
+	metaStub := redisStateMeta{ID: id, LastAccessedAt: time.Now()}
+	metaData, err := json.Marshal(metaStub)
+	if err != nil {
+		return 0, fmt.Errorf("marshal meta stub: %w", err)
+	}
+
+	pipe := s.client.Pipeline()
+	pipe.RPush(ctx, msgKey, vals...)
+	if s.ttl > 0 {
+		pipe.Expire(ctx, msgKey, s.ttl)
+	}
+	// SETNX so we never clobber a real meta written by a prior Save.
+	pipe.SetNX(ctx, s.metaKey(id), metaData, s.ttl)
+	s.pipeUpdateGlobalIndex(ctx, pipe, id)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return 0, fmt.Errorf("redis logappend pipeline failed: %w", err)
+	}
+
+	return int(currentLen) + len(delta), nil
+}
+
+// LogLoad returns messages for the conversation. Empty (not an error) when
+// the conversation doesn't exist. With recent > 0, returns only the last N.
+func (s *RedisStore) LogLoad(ctx context.Context, id string, recent int) ([]types.Message, error) {
+	msgKey := s.messagesKey(id)
+	var start int64
+	if recent > 0 {
+		start = int64(-recent)
+	}
+	vals, err := s.client.LRange(ctx, msgKey, start, -1).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("redis lrange messages failed: %w", err)
+	}
+	if len(vals) == 0 {
+		return nil, nil
+	}
+	return unmarshalMessages(vals)
+}
+
+// LogLen returns the message count for the conversation, or 0 if absent.
+func (s *RedisStore) LogLen(ctx context.Context, id string) (int, error) {
+	n, err := s.client.LLen(ctx, s.messagesKey(id)).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("redis llen failed: %w", err)
+	}
+	return int(n), nil
 }

--- a/runtime/statestore/redis_test.go
+++ b/runtime/statestore/redis_test.go
@@ -2269,3 +2269,213 @@ func TestRedisStore_MergeMetadata_ConcurrentMergesAllLand(t *testing.T) {
 		assert.Equal(t, float64(i), got[fmt.Sprintf("k%d", i)])
 	}
 }
+
+// MessageLog contract — mirrors TestMemoryStore_MessageLog_* in memory_test.go
+// so the two MessageLog implementations agree on semantics. The tool-loop
+// write-through path in ProviderStage relies on these holding identically
+// regardless of which backend is configured.
+
+func TestRedisStore_MessageLog_Append(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	msgs := []types.Message{
+		makeMsg("user", "hello"),
+		makeMsg("assistant", "hi"),
+		makeMsg("user", "how are you"),
+	}
+
+	total, err := store.LogAppend(ctx, "conv-1", 0, msgs)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	length, err := store.LogLen(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Equal(t, 3, length)
+
+	loaded, err := store.LogLoad(ctx, "conv-1", 0)
+	require.NoError(t, err)
+	require.Len(t, loaded, 3)
+	assert.Equal(t, "hello", loaded[0].Content)
+	assert.Equal(t, "hi", loaded[1].Content)
+	assert.Equal(t, "how are you", loaded[2].Content)
+}
+
+func TestRedisStore_MessageLog_AppendIdempotent(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	msgs1 := []types.Message{
+		makeMsg("user", "a"),
+		makeMsg("assistant", "b"),
+		makeMsg("user", "c"),
+	}
+	total, err := store.LogAppend(ctx, "conv-1", 0, msgs1)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	// Retry: same startSeq, partially overlapping payload. The first three
+	// must be deduplicated; only "d" and "e" should land.
+	msgs2 := []types.Message{
+		makeMsg("user", "a"),
+		makeMsg("assistant", "b"),
+		makeMsg("user", "c"),
+		makeMsg("assistant", "d"),
+		makeMsg("user", "e"),
+	}
+	total, err = store.LogAppend(ctx, "conv-1", 0, msgs2)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total, "should have 5 total, not 8 (first 3 deduplicated)")
+
+	loaded, err := store.LogLoad(ctx, "conv-1", 0)
+	require.NoError(t, err)
+	require.Len(t, loaded, 5)
+	assert.Equal(t, "d", loaded[3].Content)
+	assert.Equal(t, "e", loaded[4].Content)
+}
+
+func TestRedisStore_MessageLog_AppendDelta(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	msgs1 := []types.Message{makeMsg("user", "a"), makeMsg("assistant", "b"), makeMsg("user", "c")}
+	total, err := store.LogAppend(ctx, "conv-1", 0, msgs1)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	msgs2 := []types.Message{makeMsg("assistant", "d"), makeMsg("user", "e")}
+	total, err = store.LogAppend(ctx, "conv-1", 3, msgs2)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+}
+
+func TestRedisStore_MessageLog_AppendClampsHighStartSeq(t *testing.T) {
+	// If a caller passes startSeq beyond the current length (e.g. crash
+	// recovery where the caller thinks more was persisted than actually was),
+	// behaviour mirrors MemoryStore: clamp to current length and append all.
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	_, err := store.LogAppend(ctx, "conv-1", 0, []types.Message{makeMsg("user", "a")})
+	require.NoError(t, err)
+
+	total, err := store.LogAppend(ctx, "conv-1", 99, []types.Message{makeMsg("user", "b")})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+}
+
+func TestRedisStore_MessageLog_LoadRecent(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	msgs := make([]types.Message, 10)
+	for i := range msgs {
+		msgs[i] = makeMsg("user", fmt.Sprintf("msg-%d", i))
+	}
+	_, err := store.LogAppend(ctx, "conv-1", 0, msgs)
+	require.NoError(t, err)
+
+	recent, err := store.LogLoad(ctx, "conv-1", 3)
+	require.NoError(t, err)
+	require.Len(t, recent, 3)
+	assert.Equal(t, "msg-7", recent[0].Content)
+	assert.Equal(t, "msg-8", recent[1].Content)
+	assert.Equal(t, "msg-9", recent[2].Content)
+}
+
+func TestRedisStore_MessageLog_EmptyConversation(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	loaded, err := store.LogLoad(ctx, "nonexistent", 0)
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+
+	length, err := store.LogLen(ctx, "nonexistent")
+	require.NoError(t, err)
+	assert.Equal(t, 0, length)
+}
+
+func TestRedisStore_MessageLog_AppendInvalidID(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	_, err := store.LogAppend(context.Background(), "", 0, []types.Message{makeMsg("user", "x")})
+	assert.ErrorIs(t, err, ErrInvalidID)
+}
+
+func TestRedisStore_MessageLog_SurvivesCrashThenLoad(t *testing.T) {
+	// The whole point: mid-loop appends must be visible to Load() after a
+	// restart, without the end-of-turn Save having ever run. We simulate the
+	// "restart" by allocating a fresh RedisStore against the same miniredis
+	// instance — no in-process state is preserved across the boundary.
+	store, mr := setupRedisStore(t)
+	ctx := context.Background()
+
+	_, err := store.LogAppend(ctx, "conv-1", 0, []types.Message{
+		makeMsg("user", "hello"),
+		makeMsg("assistant", "hi"),
+	})
+	require.NoError(t, err)
+
+	// Simulate process restart: new client + new store against same miniredis.
+	freshClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	freshStore := NewRedisStore(freshClient)
+
+	loaded, err := freshStore.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Len(t, loaded.Messages, 2)
+	assert.Equal(t, "hello", loaded.Messages[0].Content)
+	assert.Equal(t, "hi", loaded.Messages[1].Content)
+}
+
+func TestRedisStore_MessageLog_TTLApplied(t *testing.T) {
+	store, mr := setupRedisStore(t, WithTTL(10*time.Minute))
+	ctx := context.Background()
+
+	_, err := store.LogAppend(ctx, "conv-1", 0, []types.Message{makeMsg("user", "x")})
+	require.NoError(t, err)
+
+	msgTTL := mr.TTL(store.messagesKey("conv-1"))
+	assert.Greater(t, msgTTL.Seconds(), 0.0, "messages key should expire under WithTTL")
+
+	// The SETNX meta stub must also expire — otherwise an abandoned
+	// half-persisted conversation leaks the meta key indefinitely.
+	metaTTL := mr.TTL(store.metaKey("conv-1"))
+	assert.Greater(t, metaTTL.Seconds(), 0.0, "meta stub key should expire under WithTTL")
+}
+
+// LogAppend must coexist with the end-of-turn Save: after a write-through
+// append, a Save with the in-memory state (which knows about all the
+// already-persisted messages) must not duplicate them in Redis. Pins the
+// delta-append branch in Save (existingCount <= newCount) interoperating
+// with LogAppend's RPUSH.
+func TestRedisStore_MessageLog_AppendThenSaveNoDup(t *testing.T) {
+	store, _ := setupRedisStore(t)
+	ctx := context.Background()
+
+	persisted := []types.Message{
+		makeMsg("user", "a"),
+		makeMsg("assistant", "b"),
+		makeMsg("user", "c"),
+	}
+	total, err := store.LogAppend(ctx, "conv-1", 0, persisted)
+	require.NoError(t, err)
+	require.Equal(t, 3, total)
+
+	state := &ConversationState{
+		ID:     "conv-1",
+		UserID: "user-1",
+		Messages: append(persisted,
+			makeMsg("assistant", "d"),
+			makeMsg("user", "e"),
+		),
+	}
+	require.NoError(t, store.Save(ctx, state))
+
+	loaded, err := store.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	require.Len(t, loaded.Messages, 5, "Save must not duplicate already-persisted messages")
+	assert.Equal(t, "e", loaded.Messages[4].Content)
+	// Save also fills in the user-id; the LogAppend meta stub had none.
+	assert.Equal(t, "user-1", loaded.UserID)
+}


### PR DESCRIPTION
## Summary

ProviderStage's per-round write-through (`runtime/pipeline/stage/stages_provider.go:540`) was a no-op against `RedisStore` — only `MemoryStore` implemented `MessageLog`. Long-running tool loops on Redis lost everything since the last end-of-turn `Save` if the process died mid-loop.

This adds `LogAppend` / `LogLoad` / `LogLen` on `RedisStore`:

- **`LogAppend`**: `LLEN` → clamp-and-skip dedup → pipelined `RPUSH` + `EXPIRE` + `SETNX(meta stub)` + global-index `SADD`. The SETNX stub means `Load(id)` resolves after a crash before the end-of-turn `Save` runs. Semantics match `MemoryStore.LogAppend` exactly.
- **`LogLoad`**: `LRANGE` with optional `recent`-tail; reuses the new `unmarshalMessages` helper.
- **`LogLen`**: `LLEN` wrapper, returns 0 on missing.
- Three near-identical message-unmarshal loops (in `loadMessagesList`, `LoadRecentMessages`, and the new `LogLoad`) collapsed into a single helper.
- `MessageLog` interface doc now states the concurrency contract: callers must serialize writes per conversation. The ProviderStage tool loop already does this.

The on-disk layout is unchanged — `LogAppend` writes the same per-message JSON envelope to the same `messagesKey(id)` Redis list that `Save` already uses. `Save`'s delta-append branch interoperates correctly (no duplication); pinned by a new test.

## Test plan

- [x] `go test ./runtime/statestore/... -count=1 -race` — all existing tests pass, 11 new `TestRedisStore_MessageLog_*` tests pass.
- [x] `golangci-lint` clean.
- [x] Coverage: 84.9% on `runtime/statestore/redis.go` (the changed file), 90.3% on package.
- [ ] SonarCloud quality gate green.

Coverage of the new contract includes: fresh append, idempotent retry, delta append, `startSeq > currentLen` clamp, `recent`-N load, missing conv, invalid id, crash → reload via a fresh client against the same miniredis, TTL on both messages and meta-stub keys, and the `LogAppend → Save` interleave.

Closes #1241.