### PR TITLE
feat(statestore): file-backed durable statestore (single-machine)

### DIFF
--- a/docs/src/content/docs/runtime/reference/statestore.md
+++ b/docs/src/content/docs/runtime/reference/statestore.md
@@ -16,9 +16,20 @@ State stores provide persistent storage for conversation history, enabling:
 
 ## Supported Backends
 
-- **Redis**: Production-ready distributed state
-- **In-memory**: Development and testing
-- **Custom**: Implement `Store` interface
+- **Redis**: Production-ready distributed state.
+- **File**: Single-machine durable state, no daemon required (see [File-Backed Store](#file-backed-store)).
+- **In-memory**: Development and testing.
+- **Custom**: Implement `Store` interface.
+
+### Choosing a backend
+
+| Backend  | Durable across restarts | Multi-process | Ops surface          |
+|----------|-------------------------|---------------|----------------------|
+| In-memory | No                      | No            | None                 |
+| File     | Yes                      | No (single process per root) | Local disk only      |
+| Redis    | Yes                      | Yes           | Redis server         |
+
+File-backed state closes the gap between volatile memory and a network-attached Redis: solo developers, single-box deployments, and one-process-per-agent setups (e.g. Omnia function-mode AgentRuntimes) get crash-survivable mid-tool-loop state without standing up Redis. Two processes pointed at the same root will corrupt each other's data — use Redis for horizontally-scaled deployments.
 
 ## Core Interface
 
@@ -185,6 +196,57 @@ if err != nil {
     log.Fatal(err)
 }
 ```
+
+## File-Backed Store
+
+`statestore/file` persists each conversation to disk as a small `state.json` snapshot plus append-only JSONL files for messages, summaries, and `ListAccessor` lists. Single-machine durable, no daemon. Implements every interface (`Store`, `BulkWriter`, `MessageLog`, `MessageReader`, `MessageAppender`, `MetadataAccessor`, `SummaryAccessor`, `ListAccessor`).
+
+### Constructor
+
+```go
+import "github.com/AltairaLabs/PromptKit/runtime/statestore/file"
+
+store, err := file.NewStore(file.Options{
+    Root:  "/var/lib/promptkit/conversations",
+    FSync: file.FSyncOnSave,    // off | on-save (default) | on-append
+    TTL:   30 * 24 * time.Hour, // optional; cleanup sweep at NewStore time
+})
+```
+
+### Configuration via RuntimeConfig
+
+```yaml
+state_store:
+  type: file
+  file:
+    root: /var/lib/promptkit/conversations
+    fsync: on-save
+    ttl_days: 30
+```
+
+### On-disk layout
+
+```
+<root>/
+  conv-<id>/
+    state.json
+    messages.jsonl
+    summaries.jsonl
+    lists/
+      <list-name>.jsonl
+```
+
+Files are plaintext — `cat`-friendly for debugging.
+
+### When to use
+
+- Solo developer / single-box deployments where Redis is overkill.
+- Per-process agents (e.g. Omnia function-mode AgentRuntimes) on a node with a persistent volume.
+- Anywhere mid-tool-loop crash recovery matters more than horizontal scale.
+
+### When NOT to use
+
+- Two PromptKit processes pointed at the same `Root` — undefined behaviour. Use Redis for horizontally-scaled state. A future revision may add OS-level file locking.
 
 ## In-Memory State Store
 

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -277,6 +277,7 @@ type ExecHook struct {
 const (
 	storeTypeMemory = "memory"
 	storeTypeRedis  = "redis"
+	storeTypeFile   = "file"
 )
 
 // LoadRuntimeConfig loads and validates a RuntimeConfig from a YAML file.
@@ -373,10 +374,13 @@ func (s *RuntimeConfigSpec) validateStateStore() error {
 	if s.StateStore == nil {
 		return nil
 	}
-	if s.StateStore.Type != "" && s.StateStore.Type != storeTypeMemory && s.StateStore.Type != storeTypeRedis {
+	switch s.StateStore.Type {
+	case "", storeTypeMemory, storeTypeRedis, storeTypeFile:
+		// ok
+	default:
 		return &ValidationError{
 			Field:   "state_store.type",
-			Message: "must be one of: memory, redis",
+			Message: "must be one of: memory, redis, file",
 			Value:   s.StateStore.Type,
 		}
 	}
@@ -384,6 +388,14 @@ func (s *RuntimeConfigSpec) validateStateStore() error {
 		return &ValidationError{
 			Field:   "state_store.redis",
 			Message: "redis configuration is required when type is redis",
+		}
+	}
+	if s.StateStore.Type == storeTypeFile {
+		if s.StateStore.File == nil || s.StateStore.File.Root == "" {
+			return &ValidationError{
+				Field:   "state_store.file.root",
+				Message: "state_store.file.root is required when type is file",
+			}
 		}
 	}
 	return nil

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -845,3 +845,46 @@ func TestRuntimeConfigSpec_Validate_MCPServerAcceptsSource(t *testing.T) {
 		t.Fatalf("unexpected error for source+scope config: %v", err)
 	}
 }
+
+func TestRuntimeConfigSpec_Validate_StateStoreFile_Valid(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		StateStore: &StateStoreConfig{
+			Type: "file",
+			File: &FileStateStoreConfig{Root: "/tmp/promptkit"},
+		},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_StateStoreFile_RequiresRoot(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		StateStore: &StateStoreConfig{Type: "file", File: &FileStateStoreConfig{}},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("expected error when root is missing")
+	}
+	if !strings.Contains(err.Error(), "root") {
+		t.Errorf("error %q should mention root", err.Error())
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_StateStoreFile_RequiresFileBlock(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		StateStore: &StateStoreConfig{Type: "file"},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error when file block is missing")
+	}
+}
+
+func TestRuntimeConfigSpec_Validate_StateStore_RejectsUnknownType(t *testing.T) {
+	s := &RuntimeConfigSpec{
+		StateStore: &StateStoreConfig{Type: "sqlite"},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("expected error for unknown store type")
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -324,11 +324,30 @@ type A2APartConfig struct {
 
 // StateStoreConfig represents configuration for conversation state storage
 type StateStoreConfig struct {
-	// Type specifies the state store implementation: "memory" or "redis"
+	// Type specifies the state store implementation: "memory", "redis", or "file"
 	Type string `yaml:"type" json:"type"`
 
 	// Redis configuration (only used when Type is "redis")
 	Redis *RedisConfig `yaml:"redis,omitempty" json:"redis,omitempty"`
+
+	// File configuration (only used when Type is "file")
+	File *FileStateStoreConfig `yaml:"file,omitempty" json:"file,omitempty"`
+}
+
+// FileStateStoreConfig configures the filesystem-backed statestore.
+// Required when StateStoreConfig.Type == "file".
+type FileStateStoreConfig struct {
+	// Root is the directory under which per-conversation directories live.
+	// Required. Created if absent.
+	Root string `yaml:"root" json:"root"`
+
+	// FSync controls fsync behavior: "off", "on-save" (default), "on-append".
+	//nolint:lll // jsonschema tags require single line
+	FSync string `yaml:"fsync,omitempty" json:"fsync,omitempty" jsonschema:"title=FSync Policy,enum=,enum=off,enum=on-save,enum=on-append"`
+
+	// TTLDays, if non-zero, removes conversation directories whose state.json
+	// mtime is older than now-TTLDays days at startup.
+	TTLDays int `yaml:"ttl_days,omitempty" json:"ttl_days,omitempty"`
 }
 
 // RedisConfig contains Redis-specific configuration

--- a/runtime/statestore/file/atomicio.go
+++ b/runtime/statestore/file/atomicio.go
@@ -1,0 +1,154 @@
+package file
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// scanLineMax is the maximum SSE-style line size accepted when streaming
+// JSONL files. Some messages contain tool-result blobs that exceed the default
+// 64 KiB bufio limit; beyond 8 MiB JSONL is the wrong storage format.
+const scanLineMax = 8 * 1024 * 1024
+
+// writeFileAtomic writes data to a temp file in the same directory then
+// renames it over dst. With fsync >= FSyncOnSave, the temp file is fsynced
+// before the rename so the rename can't outrun the data flush.
+func writeFileAtomic(dst string, data []byte, fsync FSyncPolicy) error {
+	if err := os.MkdirAll(filepath.Dir(dst), dirMode); err != nil {
+		return fmt.Errorf("filestore: mkdir parent: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("filestore: create tmp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // no-op when rename succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("filestore: write tmp: %w", err)
+	}
+	if fsync >= FSyncOnSave {
+		if err := tmp.Sync(); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("filestore: fsync tmp: %w", err)
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("filestore: close tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		return fmt.Errorf("filestore: rename: %w", err)
+	}
+	return nil
+}
+
+// appendJSONLine marshals v and appends it to path as a single line.
+// Creates parent dirs and the file as needed.
+func appendJSONLine(path string, v any, fsync FSyncPolicy) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("filestore: marshal jsonl: %w", err)
+	}
+	return appendJSONBytes(path, data, fsync)
+}
+
+// appendJSONBytes appends pre-marshaled JSON bytes plus a newline.
+func appendJSONBytes(path string, data []byte, fsync FSyncPolicy) error {
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return fmt.Errorf("filestore: mkdir parent: %w", err)
+	}
+	//nolint:gosec // path is built from store-controlled convDir + constant filenames
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, fileMode)
+	if err != nil {
+		return fmt.Errorf("filestore: open append: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("filestore: append write: %w", err)
+	}
+	if _, err := f.Write([]byte{'\n'}); err != nil {
+		return fmt.Errorf("filestore: append newline: %w", err)
+	}
+	if fsync >= FSyncOnAppend {
+		if err := f.Sync(); err != nil {
+			return fmt.Errorf("filestore: fsync append: %w", err)
+		}
+	}
+	return nil
+}
+
+// scanJSONLines streams lines from path, decoding each into a fresh T.
+// Returns (nil, nil) when the file doesn't exist. Stops at the first decode
+// error.
+func scanJSONLines[T any](path string) ([]T, error) {
+	//nolint:gosec // path is built from store-controlled convDir + constant filenames
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("filestore: open scan: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	out := []T{}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), scanLineMax)
+	for scanner.Scan() {
+		var v T
+		if err := json.Unmarshal(scanner.Bytes(), &v); err != nil {
+			return nil, fmt.Errorf("filestore: decode jsonl: %w", err)
+		}
+		out = append(out, v)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("filestore: scan jsonl: %w", err)
+	}
+	return out, nil
+}
+
+// countLines returns the number of \n-terminated lines in path, treating a
+// final line without trailing newline as one line. 0 when the file is absent.
+func countLines(path string) (int, error) {
+	//nolint:gosec // path is built from store-controlled convDir + constant filenames
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("filestore: open count: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var (
+		buf           [bufio.MaxScanTokenSize]byte
+		count         int
+		endsWithNewLF = true // true ↔ file is empty OR ends in '\n'
+	)
+	for {
+		n, err := f.Read(buf[:])
+		if n > 0 {
+			chunk := buf[:n]
+			count += bytes.Count(chunk, []byte{'\n'})
+			endsWithNewLF = chunk[len(chunk)-1] == '\n'
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return 0, fmt.Errorf("filestore: read count: %w", err)
+		}
+	}
+	if !endsWithNewLF {
+		count++
+	}
+	return count, nil
+}

--- a/runtime/statestore/file/atomicio_test.go
+++ b/runtime/statestore/file/atomicio_test.go
@@ -1,0 +1,178 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteFileAtomic_NoLeftoverTemp(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "state.json")
+
+	require.NoError(t, writeFileAtomic(dst, []byte(`{"x":1}`), FSyncOnSave))
+
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, `{"x":1}`, string(got))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "no .tmp leftovers")
+}
+
+func TestAppendJSONLine_AppendsOnePerLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log.jsonl")
+
+	require.NoError(t, appendJSONLine(path, map[string]any{"a": 1}, FSyncOff))
+	require.NoError(t, appendJSONLine(path, map[string]any{"a": 2}, FSyncOff))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, `{"a":1}`+"\n"+`{"a":2}`+"\n", string(data))
+}
+
+func TestCountLines_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log.jsonl")
+	n, err := countLines(path)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestCountLines_ManyLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("a\nb\nc\n"), fileMode))
+	n, err := countLines(path)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+}
+
+func TestCountLines_LastLineNoNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("a\nb\nc"), fileMode))
+	n, err := countLines(path)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n, "trailing-newline-less file still counts last line")
+}
+
+func TestScanJSONLines_MissingFileReturnsNil(t *testing.T) {
+	got, err := scanJSONLines[map[string]any](filepath.Join(t.TempDir(), "nope.jsonl"))
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestScanJSONLines_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log.jsonl")
+	require.NoError(t, appendJSONLine(path, map[string]any{"i": 1}, FSyncOff))
+	require.NoError(t, appendJSONLine(path, map[string]any{"i": 2}, FSyncOff))
+
+	got, err := scanJSONLines[map[string]any](path)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, float64(1), got[0]["i"])
+	assert.Equal(t, float64(2), got[1]["i"])
+}
+
+func TestAppendJSONBytes_CreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deep", "log.jsonl")
+
+	require.NoError(t, appendJSONBytes(path, []byte("hello"), FSyncOff))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", string(data))
+}
+
+func TestWriteFileAtomic_FSyncOff(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "x.json")
+	require.NoError(t, writeFileAtomic(dst, []byte(`{}`), FSyncOff))
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(got))
+}
+
+func TestCountLines_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	require.NoError(t, os.WriteFile(path, nil, fileMode))
+	n, err := countLines(path)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "empty file counts as zero lines")
+}
+
+func TestAppendJSONLine_UnmarshallableValue(t *testing.T) {
+	// A channel cannot be JSON-marshalled.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log.jsonl")
+	err := appendJSONLine(path, make(chan int), FSyncOff)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal")
+}
+
+func TestWriteFileAtomic_RenameFails(t *testing.T) {
+	// Renaming over a non-empty directory fails on most platforms; use that
+	// to drive the rename error branch.
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "subdir")
+	require.NoError(t, os.MkdirAll(filepath.Join(dst, "child"), dirMode))
+	err := writeFileAtomic(dst, []byte("x"), FSyncOff)
+	require.Error(t, err)
+}
+
+func TestWriteFileAtomic_MkdirFails(t *testing.T) {
+	dir := t.TempDir()
+	clash := filepath.Join(dir, "not-a-dir")
+	require.NoError(t, os.WriteFile(clash, []byte("blocker"), fileMode))
+	err := writeFileAtomic(filepath.Join(clash, "child", "x.json"), []byte("x"), FSyncOff)
+	require.Error(t, err)
+}
+
+func TestAppendJSONBytes_OnUnwriteableDir(t *testing.T) {
+	dir := t.TempDir()
+	// Create a regular file where the parent dir is expected — appendJSONBytes
+	// will try to MkdirAll, which will refuse to overwrite the file as a dir.
+	clash := filepath.Join(dir, "not-a-dir")
+	require.NoError(t, os.WriteFile(clash, []byte("blocker"), fileMode))
+	err := appendJSONBytes(filepath.Join(clash, "log.jsonl"), []byte("x"), FSyncOff)
+	require.Error(t, err)
+}
+
+func TestScanJSONLines_DecodeError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("not-json\n"), fileMode))
+	_, err := scanJSONLines[map[string]any](path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+func TestCountLines_SingleLineWithoutNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("solo"), fileMode))
+	n, err := countLines(path)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+}
+
+func TestConvLock_StableIdentity(t *testing.T) {
+	s, err := NewStore(Options{Root: t.TempDir()})
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	l1 := s.convLock("conv-1")
+	l2 := s.convLock("conv-1")
+	assert.Same(t, l1, l2, "convLock returns the same mutex for the same id")
+	l3 := s.convLock("conv-2")
+	assert.NotSame(t, l1, l3, "different ids get different mutexes")
+}

--- a/runtime/statestore/file/fork_delete_list.go
+++ b/runtime/statestore/file/fork_delete_list.go
@@ -1,0 +1,182 @@
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+)
+
+const defaultListLimit = 100
+
+// Fork copies all files in <root>/conv-<sourceID>/ to <root>/conv-<newID>/.
+// Returns ErrNotFound when source is missing.
+func (s *Store) Fork(_ context.Context, sourceID, newID string) error {
+	if sourceID == "" || newID == "" {
+		return statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+
+	// Lock in stable order so two goroutines forking in opposite directions
+	// can't deadlock.
+	first, second := sourceID, newID
+	if first > second {
+		first, second = second, first
+	}
+	l1, l2 := s.convLock(first), s.convLock(second)
+	l1.Lock()
+	defer l1.Unlock()
+	if first != second {
+		l2.Lock()
+		defer l2.Unlock()
+	}
+
+	if _, err := os.Stat(s.stateFile(sourceID)); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return statestore.ErrNotFound
+		}
+		return fmt.Errorf("filestore: stat source: %w", err)
+	}
+
+	dstDir := s.convDir(newID)
+	if err := os.MkdirAll(dstDir, dirMode); err != nil {
+		return fmt.Errorf("filestore: mkdir dest: %w", err)
+	}
+	return copyDirContents(s.convDir(sourceID), dstDir, newID)
+}
+
+// Delete removes the entire conv-<id> directory. No-op when absent.
+func (s *Store) Delete(_ context.Context, id string) error {
+	if id == "" {
+		return statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	lock := s.convLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := os.RemoveAll(s.convDir(id)); err != nil {
+		return fmt.Errorf("filestore: remove conv: %w", err)
+	}
+	s.mu.Lock()
+	delete(s.locks, id)
+	s.mu.Unlock()
+	return nil
+}
+
+// List returns conversation IDs filtered by ListOptions. The UserID filter
+// reads each candidate's state.json (no separate user index in v1; ample for
+// typical scales).
+func (s *Store) List(_ context.Context, opts statestore.ListOptions) ([]string, error) {
+	if err := s.checkOpen(); err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return nil, fmt.Errorf("filestore: read root: %w", err)
+	}
+
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), convDirPrefix) {
+			continue
+		}
+		id := strings.TrimPrefix(e.Name(), convDirPrefix)
+		if opts.UserID != "" {
+			snap, rerr := s.readStateSnapshot(id)
+			if rerr != nil || snap.UserID != opts.UserID {
+				continue
+			}
+		}
+		out = append(out, id)
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultListLimit
+	}
+	if opts.Offset >= len(out) {
+		return []string{}, nil
+	}
+	out = out[opts.Offset:]
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func copyDirContents(srcDir, dstDir, newID string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("filestore: read src: %w", err)
+	}
+	for _, e := range entries {
+		srcPath := filepath.Join(srcDir, e.Name())
+		dstPath := filepath.Join(dstDir, e.Name())
+		if e.IsDir() {
+			if mkErr := os.MkdirAll(dstPath, dirMode); mkErr != nil {
+				return fmt.Errorf("filestore: mkdir nested: %w", mkErr)
+			}
+			if recErr := copyDirContents(srcPath, dstPath, newID); recErr != nil {
+				return recErr
+			}
+			continue
+		}
+		if cpErr := copyFile(srcPath, dstPath); cpErr != nil {
+			return cpErr
+		}
+	}
+	return rewriteForkedStateID(dstDir, newID)
+}
+
+func copyFile(src, dst string) error {
+	//nolint:gosec // src is built from store-controlled convDir + listed entries
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("filestore: open src file: %w", err)
+	}
+	defer func() { _ = in.Close() }()
+
+	//nolint:gosec // dst is built from store-controlled convDir + listed entries
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
+	if err != nil {
+		return fmt.Errorf("filestore: create dst file: %w", err)
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("filestore: copy file: %w", err)
+	}
+	return nil
+}
+
+// rewriteForkedStateID updates the ID inside the forked state.json so a
+// subsequent Load(newID) returns a state whose ID matches the new conv.
+func rewriteForkedStateID(dstDir, newID string) error {
+	statePath := filepath.Join(dstDir, stateFilename)
+	//nolint:gosec // statePath is built from store-controlled convDir + constant filename
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		return fmt.Errorf("filestore: read forked state: %w", err)
+	}
+	var snap stateSnapshot
+	if uerr := json.Unmarshal(data, &snap); uerr != nil {
+		return fmt.Errorf("filestore: unmarshal forked state: %w", uerr)
+	}
+	snap.ID = newID
+	out, err := json.Marshal(&snap)
+	if err != nil {
+		return fmt.Errorf("filestore: marshal forked state: %w", err)
+	}
+	return os.WriteFile(statePath, out, fileMode)
+}

--- a/runtime/statestore/file/fork_delete_list_test.go
+++ b/runtime/statestore/file/fork_delete_list_test.go
@@ -1,0 +1,170 @@
+package file
+
+import (
+	"context"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_Fork(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID: "src", UserID: "alice",
+		Messages: []types.Message{makeMsg("user", "a")},
+	}))
+
+	require.NoError(t, s.Fork(ctx, "src", "dst"))
+
+	loaded, err := s.Load(ctx, "dst")
+	require.NoError(t, err)
+	assert.Equal(t, "dst", loaded.ID)
+	require.Len(t, loaded.Messages, 1)
+	assert.Equal(t, "a", loaded.Messages[0].Content)
+
+	src, err := s.Load(ctx, "src")
+	require.NoError(t, err)
+	assert.Equal(t, "src", src.ID)
+}
+
+func TestStore_Fork_SourceMissing(t *testing.T) {
+	s := newTestStore(t)
+	err := s.Fork(context.Background(), "missing", "dst")
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+func TestStore_Fork_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	assert.ErrorIs(t, s.Fork(context.Background(), "", "dst"), statestore.ErrInvalidID)
+	assert.ErrorIs(t, s.Fork(context.Background(), "src", ""), statestore.ErrInvalidID)
+}
+
+func TestStore_Fork_AfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	err := s.Fork(context.Background(), "src", "dst")
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}
+
+func TestStore_Delete(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{ID: "conv-1"}))
+
+	require.NoError(t, s.Delete(ctx, "conv-1"))
+
+	_, err := s.Load(ctx, "conv-1")
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+func TestStore_Delete_Missing(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Delete(context.Background(), "missing"))
+}
+
+func TestStore_Delete_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	err := s.Delete(context.Background(), "")
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_Delete_AfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	err := s.Delete(context.Background(), "conv-1")
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}
+
+func TestStore_List_All(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	for _, id := range []string{"a", "b", "c"} {
+		require.NoError(t, s.Save(ctx, &statestore.ConversationState{ID: id}))
+	}
+
+	got, err := s.List(ctx, statestore.ListOptions{})
+	require.NoError(t, err)
+	sort.Strings(got)
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}
+
+func TestStore_List_FilterByUser(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{ID: "a", UserID: "alice"}))
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{ID: "b", UserID: "bob"}))
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{ID: "c", UserID: "alice"}))
+
+	got, err := s.List(ctx, statestore.ListOptions{UserID: "alice"})
+	require.NoError(t, err)
+	sort.Strings(got)
+	assert.Equal(t, []string{"a", "c"}, got)
+}
+
+func TestStore_List_PaginationOffsetBeyondLen(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{ID: "a"}))
+
+	got, err := s.List(ctx, statestore.ListOptions{Offset: 5})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestStore_List_RespectsLimit(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	for _, id := range []string{"a", "b", "c"} {
+		require.NoError(t, s.Save(ctx, &statestore.ConversationState{ID: id}))
+	}
+	got, err := s.List(ctx, statestore.ListOptions{Limit: 2})
+	require.NoError(t, err)
+	assert.Len(t, got, 2)
+}
+
+func TestStore_List_AfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	_, err := s.List(context.Background(), statestore.ListOptions{})
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}
+
+func TestStore_TTLSweep_RemovesStaleConvs(t *testing.T) {
+	root := t.TempDir()
+
+	s1, err := NewStore(Options{Root: root})
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, s1.Save(ctx, &statestore.ConversationState{ID: "fresh"}))
+	require.NoError(t, s1.Save(ctx, &statestore.ConversationState{ID: "stale"}))
+	stalePath := s1.stateFile("stale")
+	require.NoError(t, s1.Close())
+
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(stalePath, old, old))
+
+	s2, err := NewStore(Options{Root: root, TTL: 24 * time.Hour})
+	require.NoError(t, err)
+	defer func() { _ = s2.Close() }()
+
+	_, err = s2.Load(ctx, "fresh")
+	require.NoError(t, err)
+	_, err = s2.Load(ctx, "stale")
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+func TestStore_TTLSweep_NoTTL_KeepsEverything(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{ID: "x"}))
+	require.NoError(t, s.sweepStale(time.Now()))
+	_, err := s.Load(ctx, "x")
+	require.NoError(t, err)
+}

--- a/runtime/statestore/file/lists.go
+++ b/runtime/statestore/file/lists.go
@@ -1,0 +1,89 @@
+package file
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+)
+
+const listsDirname = "lists"
+
+// listFile returns the path of the named list file for a conversation.
+func (s *Store) listFile(id, listName string) string {
+	return filepath.Join(s.convDir(id), listsDirname, listName+".jsonl")
+}
+
+// AppendList appends opaque-byte items to the named list. Each item becomes
+// one line in lists/<listName>.jsonl. Auto-creates the conversation and list.
+func (s *Store) AppendList(
+	_ context.Context, id, listName string, items [][]byte,
+) error {
+	if id == "" {
+		return statestore.ErrInvalidID
+	}
+	if listName == "" {
+		return fmt.Errorf("filestore: list name is required")
+	}
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	lock := s.convLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := os.MkdirAll(s.convDir(id), dirMode); err != nil {
+		return fmt.Errorf("filestore: mkdir conv: %w", err)
+	}
+	if err := s.ensureStateStub(id); err != nil {
+		return err
+	}
+	for _, item := range items {
+		if err := appendJSONBytes(s.listFile(id, listName), item, s.fsync); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// LoadList returns all items of the named list in append order. Returns
+// (nil, nil) when the list is empty or missing.
+func (s *Store) LoadList(
+	_ context.Context, id, listName string,
+) ([][]byte, error) {
+	if id == "" {
+		return nil, statestore.ErrInvalidID
+	}
+	f, err := os.Open(s.listFile(id, listName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("filestore: open list: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var out [][]byte
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), scanLineMax)
+	for scanner.Scan() {
+		b := append([]byte(nil), scanner.Bytes()...)
+		out = append(out, b)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("filestore: scan list: %w", err)
+	}
+	return out, nil
+}
+
+// ListLen returns the number of items in the named list. 0 for missing.
+func (s *Store) ListLen(_ context.Context, id, listName string) (int, error) {
+	if id == "" {
+		return 0, statestore.ErrInvalidID
+	}
+	return countLines(s.listFile(id, listName))
+}

--- a/runtime/statestore/file/lists_test.go
+++ b/runtime/statestore/file/lists_test.go
@@ -1,0 +1,85 @@
+package file
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_ListAccessor_AppendAndLoad(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.AppendList(ctx, "conv-1", "workflow.history",
+		[][]byte{[]byte(`{"step":1}`), []byte(`{"step":2}`)}))
+	require.NoError(t, s.AppendList(ctx, "conv-1", "workflow.history",
+		[][]byte{[]byte(`{"step":3}`)}))
+
+	items, err := s.LoadList(ctx, "conv-1", "workflow.history")
+	require.NoError(t, err)
+	require.Len(t, items, 3)
+	assert.Equal(t, `{"step":1}`, string(items[0]))
+	assert.Equal(t, `{"step":3}`, string(items[2]))
+
+	n, err := s.ListLen(ctx, "conv-1", "workflow.history")
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+}
+
+func TestStore_ListAccessor_LoadEmpty(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.LoadList(context.Background(), "missing", "x")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	n, err := s.ListLen(context.Background(), "missing", "x")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestStore_ListAccessor_PerListIsolated(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.AppendList(ctx, "conv-1", "a", [][]byte{[]byte("1")}))
+	require.NoError(t, s.AppendList(ctx, "conv-1", "b", [][]byte{[]byte("9")}))
+
+	a, err := s.LoadList(ctx, "conv-1", "a")
+	require.NoError(t, err)
+	require.Len(t, a, 1)
+	assert.Equal(t, "1", string(a[0]))
+
+	b, err := s.LoadList(ctx, "conv-1", "b")
+	require.NoError(t, err)
+	require.Len(t, b, 1)
+	assert.Equal(t, "9", string(b[0]))
+}
+
+func TestStore_ListAccessor_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	err := s.AppendList(context.Background(), "", "x", [][]byte{[]byte("1")})
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+
+	_, err = s.LoadList(context.Background(), "", "x")
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+
+	_, err = s.ListLen(context.Background(), "", "x")
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_ListAccessor_EmptyListName(t *testing.T) {
+	s := newTestStore(t)
+	err := s.AppendList(context.Background(), "conv-1", "", [][]byte{[]byte("1")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list name")
+}
+
+func TestStore_AppendList_AfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	err := s.AppendList(context.Background(), "conv-1", "x", [][]byte{[]byte("1")})
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}

--- a/runtime/statestore/file/locks.go
+++ b/runtime/statestore/file/locks.go
@@ -1,0 +1,17 @@
+package file
+
+import "sync"
+
+// convLock returns a per-conv mutex. The lock map itself is guarded by s.mu;
+// the map mutex is held only long enough to fetch/create the inner mutex.
+// Callers actually hold the inner mutex during file IO.
+func (s *Store) convLock(id string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if m, ok := s.locks[id]; ok {
+		return m
+	}
+	m := &sync.Mutex{}
+	s.locks[id] = m
+	return m
+}

--- a/runtime/statestore/file/messages.go
+++ b/runtime/statestore/file/messages.go
@@ -1,0 +1,175 @@
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// LogAppend appends messages with clamp-and-skip idempotent dedup. Mirrors
+// MemoryStore.LogAppend / RedisStore.LogAppend semantics exactly. Also writes
+// a minimal state.json stub on first append so Load(id) works during crash
+// recovery before the end-of-turn Save runs.
+func (s *Store) LogAppend(
+	_ context.Context, id string, startSeq int, messages []types.Message,
+) (int, error) {
+	if id == "" {
+		return 0, statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return 0, err
+	}
+
+	lock := s.convLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	current, err := countLines(s.messagesFile(id))
+	if err != nil {
+		return 0, err
+	}
+	skip := current - startSeq
+	if skip < 0 {
+		skip = 0
+	}
+	if skip >= len(messages) {
+		return current, nil
+	}
+	delta := messages[skip:]
+
+	if err := os.MkdirAll(s.convDir(id), dirMode); err != nil {
+		return 0, fmt.Errorf("filestore: mkdir conv: %w", err)
+	}
+	if err := s.ensureStateStub(id); err != nil {
+		return 0, err
+	}
+	for i := range delta {
+		if appendErr := appendJSONLine(s.messagesFile(id), &delta[i], s.fsync); appendErr != nil {
+			return 0, appendErr
+		}
+	}
+	return current + len(delta), nil
+}
+
+// LogLoad returns messages for the conversation. If recent > 0, returns only
+// the last N. Returns nil (not an error) when the file doesn't exist.
+func (s *Store) LogLoad(_ context.Context, id string, recent int) ([]types.Message, error) {
+	if id == "" {
+		return nil, statestore.ErrInvalidID
+	}
+	all, err := scanJSONLines[types.Message](s.messagesFile(id))
+	if err != nil {
+		return nil, err
+	}
+	if recent > 0 && recent < len(all) {
+		return all[len(all)-recent:], nil
+	}
+	return all, nil
+}
+
+// LogLen returns the message count, or 0 if absent.
+func (s *Store) LogLen(_ context.Context, id string) (int, error) {
+	if id == "" {
+		return 0, statestore.ErrInvalidID
+	}
+	return countLines(s.messagesFile(id))
+}
+
+// LoadRecentMessages returns the last n messages. Returns ErrNotFound if the
+// conversation has no state.json (the caller asked about a conv that doesn't
+// exist).
+func (s *Store) LoadRecentMessages(
+	ctx context.Context, id string, n int,
+) ([]types.Message, error) {
+	if id == "" {
+		return nil, statestore.ErrInvalidID
+	}
+	exists, err := s.convExists(id)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, statestore.ErrNotFound
+	}
+	return s.LogLoad(ctx, id, n)
+}
+
+// MessageCount returns the total number of messages. Returns ErrNotFound when
+// the conversation has no state.json.
+func (s *Store) MessageCount(_ context.Context, id string) (int, error) {
+	if id == "" {
+		return 0, statestore.ErrInvalidID
+	}
+	exists, err := s.convExists(id)
+	if err != nil {
+		return 0, err
+	}
+	if !exists {
+		return 0, statestore.ErrNotFound
+	}
+	return countLines(s.messagesFile(id))
+}
+
+// AppendMessages appends without dedup. Auto-creates the conversation.
+// Differs from LogAppend in that it takes no startSeq — used by pipeline
+// paths that already track their own offset.
+func (s *Store) AppendMessages(
+	_ context.Context, id string, messages []types.Message,
+) error {
+	if id == "" {
+		return statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	lock := s.convLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := os.MkdirAll(s.convDir(id), dirMode); err != nil {
+		return fmt.Errorf("filestore: mkdir conv: %w", err)
+	}
+	if err := s.ensureStateStub(id); err != nil {
+		return err
+	}
+	for i := range messages {
+		if appendErr := appendJSONLine(s.messagesFile(id), &messages[i], s.fsync); appendErr != nil {
+			return appendErr
+		}
+	}
+	return nil
+}
+
+// ensureStateStub writes a minimal state.json if none exists, so Load(id)
+// resolves after a crash before any Save has run. Idempotent — Save will
+// overwrite the stub with the full state.
+func (s *Store) ensureStateStub(id string) error {
+	path := s.stateFile(id)
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	snap := stateSnapshot{ID: id, LastAccessedAt: time.Now()}
+	data, err := json.Marshal(&snap)
+	if err != nil {
+		return fmt.Errorf("filestore: marshal stub: %w", err)
+	}
+	return writeFileAtomic(path, data, s.fsync)
+}
+
+// convExists reports whether a state.json exists for id.
+func (s *Store) convExists(id string) (bool, error) {
+	_, err := os.Stat(s.stateFile(id))
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("filestore: stat state: %w", err)
+}

--- a/runtime/statestore/file/messages_test.go
+++ b/runtime/statestore/file/messages_test.go
@@ -1,0 +1,218 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_MessageLog_Append(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	msgs := []types.Message{
+		makeMsg("user", "hello"),
+		makeMsg("assistant", "hi"),
+		makeMsg("user", "how are you"),
+	}
+	total, err := s.LogAppend(ctx, "conv-1", 0, msgs)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	n, err := s.LogLen(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	loaded, err := s.LogLoad(ctx, "conv-1", 0)
+	require.NoError(t, err)
+	require.Len(t, loaded, 3)
+	assert.Equal(t, "hello", loaded[0].Content)
+	assert.Equal(t, "how are you", loaded[2].Content)
+}
+
+func TestStore_MessageLog_AppendIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	first := []types.Message{
+		makeMsg("user", "a"),
+		makeMsg("assistant", "b"),
+		makeMsg("user", "c"),
+	}
+	total, err := s.LogAppend(ctx, "conv-1", 0, first)
+	require.NoError(t, err)
+	require.Equal(t, 3, total)
+
+	retry := []types.Message{
+		makeMsg("user", "a"),
+		makeMsg("assistant", "b"),
+		makeMsg("user", "c"),
+		makeMsg("assistant", "d"),
+		makeMsg("user", "e"),
+	}
+	total, err = s.LogAppend(ctx, "conv-1", 0, retry)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+
+	loaded, err := s.LogLoad(ctx, "conv-1", 0)
+	require.NoError(t, err)
+	require.Len(t, loaded, 5)
+	assert.Equal(t, "d", loaded[3].Content)
+}
+
+func TestStore_MessageLog_AppendDelta(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.LogAppend(ctx, "conv-1", 0, []types.Message{
+		makeMsg("user", "a"), makeMsg("assistant", "b"), makeMsg("user", "c"),
+	})
+	require.NoError(t, err)
+
+	total, err := s.LogAppend(ctx, "conv-1", 3, []types.Message{
+		makeMsg("assistant", "d"), makeMsg("user", "e"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+}
+
+func TestStore_MessageLog_AppendClampsHighStartSeq(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.LogAppend(ctx, "conv-1", 0, []types.Message{makeMsg("user", "a")})
+	require.NoError(t, err)
+
+	total, err := s.LogAppend(ctx, "conv-1", 99, []types.Message{makeMsg("user", "b")})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+}
+
+func TestStore_MessageLog_LoadRecent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	msgs := make([]types.Message, 10)
+	for i := range msgs {
+		msgs[i] = makeMsg("user", fmt.Sprintf("msg-%d", i))
+	}
+	_, err := s.LogAppend(ctx, "conv-1", 0, msgs)
+	require.NoError(t, err)
+
+	recent, err := s.LogLoad(ctx, "conv-1", 3)
+	require.NoError(t, err)
+	require.Len(t, recent, 3)
+	assert.Equal(t, "msg-7", recent[0].Content)
+	assert.Equal(t, "msg-9", recent[2].Content)
+}
+
+func TestStore_MessageLog_EmptyConversation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	loaded, err := s.LogLoad(ctx, "missing", 0)
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+
+	n, err := s.LogLen(ctx, "missing")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestStore_MessageLog_AppendInvalidID(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.LogAppend(context.Background(), "", 0, []types.Message{makeMsg("user", "x")})
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_MessageLog_AppendAfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	_, err := s.LogAppend(context.Background(), "conv-1", 0,
+		[]types.Message{makeMsg("user", "x")})
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}
+
+func TestStore_MessageLog_LoadInvalidID(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.LogLoad(context.Background(), "", 0)
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+	_, err = s.LogLen(context.Background(), "")
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_LogAppend_AllSkipped(t *testing.T) {
+	// startSeq matches current length and payload already fits — full skip.
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.LogAppend(ctx, "conv-1", 0, []types.Message{makeMsg("user", "a")})
+	require.NoError(t, err)
+	total, err := s.LogAppend(ctx, "conv-1", 0, []types.Message{makeMsg("user", "a")})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+}
+
+func TestStore_MessageReader(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	_, err := s.LogAppend(ctx, "conv-1", 0, []types.Message{
+		makeMsg("user", "a"), makeMsg("assistant", "b"), makeMsg("user", "c"),
+	})
+	require.NoError(t, err)
+
+	n, err := s.MessageCount(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	recent, err := s.LoadRecentMessages(ctx, "conv-1", 2)
+	require.NoError(t, err)
+	require.Len(t, recent, 2)
+	assert.Equal(t, "b", recent[0].Content)
+}
+
+func TestStore_MessageReader_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.MessageCount(context.Background(), "missing")
+	require.ErrorIs(t, err, statestore.ErrNotFound)
+
+	_, err = s.LoadRecentMessages(context.Background(), "missing", 5)
+	require.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+func TestStore_MessageReader_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.MessageCount(context.Background(), "")
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+	_, err = s.LoadRecentMessages(context.Background(), "", 1)
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_AppendMessages(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.AppendMessages(ctx, "conv-1", []types.Message{
+		makeMsg("user", "x"), makeMsg("assistant", "y"),
+	}))
+	loaded, err := s.LogLoad(ctx, "conv-1", 0)
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+}
+
+func TestStore_AppendMessages_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	err := s.AppendMessages(context.Background(), "", []types.Message{makeMsg("user", "x")})
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_AppendMessages_AfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	err := s.AppendMessages(context.Background(), "conv-1", []types.Message{makeMsg("user", "x")})
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}

--- a/runtime/statestore/file/metadata.go
+++ b/runtime/statestore/file/metadata.go
@@ -1,0 +1,78 @@
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+)
+
+// LoadMetadata returns the metadata map for the conversation. Returns
+// ErrNotFound if no state.json exists for the conv. The returned map is a
+// deep copy safe for caller mutation.
+func (s *Store) LoadMetadata(_ context.Context, id string) (map[string]any, error) {
+	if id == "" {
+		return nil, statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return nil, err
+	}
+	lock := s.convLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	snap, err := s.readStateSnapshot(id)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]any, len(snap.Metadata))
+	for k, v := range snap.Metadata {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// MergeMetadata atomically merges updates into the conversation's metadata.
+// Auto-creates the conversation. Read-modify-write under the per-conv lock.
+func (s *Store) MergeMetadata(
+	_ context.Context, id string, updates map[string]any,
+) error {
+	if id == "" {
+		return statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	lock := s.convLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := os.MkdirAll(s.convDir(id), dirMode); err != nil {
+		return fmt.Errorf("filestore: mkdir conv: %w", err)
+	}
+
+	snap, err := s.readStateSnapshot(id)
+	if err != nil && !errors.Is(err, statestore.ErrNotFound) {
+		return err
+	}
+	if snap == nil {
+		snap = &stateSnapshot{ID: id}
+	}
+	if snap.Metadata == nil {
+		snap.Metadata = make(map[string]any, len(updates))
+	}
+	for k, v := range updates {
+		snap.Metadata[k] = v
+	}
+	snap.LastAccessedAt = time.Now()
+
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("filestore: marshal snapshot: %w", err)
+	}
+	return writeFileAtomic(s.stateFile(id), data, s.fsync)
+}

--- a/runtime/statestore/file/metadata_test.go
+++ b/runtime/statestore/file/metadata_test.go
@@ -1,0 +1,76 @@
+package file
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_MergeMetadata_FreshConv(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.MergeMetadata(ctx, "conv-1", map[string]any{"a": 1, "b": "x"}))
+
+	got, err := s.LoadMetadata(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), got["a"])
+	assert.Equal(t, "x", got["b"])
+}
+
+func TestStore_MergeMetadata_OverwritesAndAdds(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.MergeMetadata(ctx, "conv-1", map[string]any{"a": 1, "b": "x"}))
+	require.NoError(t, s.MergeMetadata(ctx, "conv-1", map[string]any{"b": "y", "c": true}))
+
+	got, err := s.LoadMetadata(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), got["a"])
+	assert.Equal(t, "y", got["b"])
+	assert.Equal(t, true, got["c"])
+}
+
+func TestStore_LoadMetadata_Missing(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.LoadMetadata(context.Background(), "missing")
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+func TestStore_LoadMetadata_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.LoadMetadata(context.Background(), "")
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_MergeMetadata_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	err := s.MergeMetadata(context.Background(), "", map[string]any{"a": 1})
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_MergeMetadata_AfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	err := s.MergeMetadata(context.Background(), "conv-1", map[string]any{"a": 1})
+	assert.ErrorIs(t, err, ErrStoreClosed)
+
+	_, err = s.LoadMetadata(context.Background(), "conv-1")
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}
+
+func TestStore_LoadMetadata_ReturnsDeepCopy(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.MergeMetadata(ctx, "conv-1", map[string]any{"a": 1}))
+
+	got, err := s.LoadMetadata(ctx, "conv-1")
+	require.NoError(t, err)
+	got["a"] = 999
+
+	got2, err := s.LoadMetadata(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), got2["a"], "caller mutations must not leak into the store")
+}

--- a/runtime/statestore/file/paths.go
+++ b/runtime/statestore/file/paths.go
@@ -1,0 +1,29 @@
+package file
+
+import (
+	"path/filepath"
+)
+
+const (
+	convDirPrefix     = "conv-"
+	stateFilename     = "state.json"
+	messagesFilename  = "messages.jsonl"
+	summariesFilename = "summaries.jsonl"
+)
+
+// convDir returns the per-conversation directory: <root>/conv-<id>/.
+func (s *Store) convDir(id string) string {
+	return filepath.Join(s.root, convDirPrefix+id)
+}
+
+func (s *Store) stateFile(id string) string {
+	return filepath.Join(s.convDir(id), stateFilename)
+}
+
+func (s *Store) messagesFile(id string) string {
+	return filepath.Join(s.convDir(id), messagesFilename)
+}
+
+func (s *Store) summariesFile(id string) string {
+	return filepath.Join(s.convDir(id), summariesFilename)
+}

--- a/runtime/statestore/file/provider_smoke_test.go
+++ b/runtime/statestore/file/provider_smoke_test.go
@@ -1,0 +1,59 @@
+package file
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStore_AsMessageLog_DropIn asserts that *Store satisfies the
+// statestore.MessageLog interface and that LogAppend → reload via Load
+// returns the messages — the exact pattern the ProviderStage write-through
+// relies on.
+func TestStore_AsMessageLog_DropIn(t *testing.T) {
+	root := t.TempDir()
+	s1, err := NewStore(Options{Root: root})
+	require.NoError(t, err)
+
+	var ml statestore.MessageLog = s1 // compile-time interface check
+	ctx := context.Background()
+	_, err = ml.LogAppend(ctx, "conv-1", 0, []types.Message{
+		makeMsg("user", "hello"),
+		makeMsg("assistant", "hi"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, s1.Close())
+
+	// Simulate process restart with a fresh store against the same root.
+	s2, err := NewStore(Options{Root: root})
+	require.NoError(t, err)
+	defer func() { _ = s2.Close() }()
+
+	loaded, err := s2.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	require.Len(t, loaded.Messages, 2)
+	assert.Equal(t, "hello", loaded.Messages[0].Content)
+	assert.Equal(t, "hi", loaded.Messages[1].Content)
+}
+
+// TestStore_SatisfiesStoreInterfaces is a compile-time assertion that *Store
+// implements every interface the SDK type-asserts. If this stops compiling,
+// the file store has fallen out of step with the statestore contract.
+func TestStore_SatisfiesStoreInterfaces(t *testing.T) {
+	s, err := NewStore(Options{Root: t.TempDir()})
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	var _ statestore.Store = s
+	var _ statestore.BulkWriter = s
+	var _ statestore.MessageLog = s
+	var _ statestore.MessageReader = s
+	var _ statestore.MessageAppender = s
+	var _ statestore.MetadataAccessor = s
+	var _ statestore.SummaryAccessor = s
+	var _ statestore.ListAccessor = s
+}

--- a/runtime/statestore/file/save_load.go
+++ b/runtime/statestore/file/save_load.go
@@ -1,0 +1,216 @@
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// stateSnapshot is the on-disk representation of state.json. Messages live in
+// messages.jsonl, summaries in summaries.jsonl — both are excluded here so
+// state.json stays small and append-only updates to messages/summaries are
+// cheap.
+type stateSnapshot struct {
+	ID             string         `json:"id"`
+	UserID         string         `json:"user_id,omitempty"`
+	SystemPrompt   string         `json:"system_prompt,omitempty"`
+	TokenCount     int            `json:"token_count,omitempty"`
+	LastAccessedAt time.Time      `json:"last_accessed_at"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
+}
+
+// Save atomically writes state.json and reconciles messages.jsonl /
+// summaries.jsonl with the provided state. When the on-disk message log is
+// shorter than state.Messages, only the delta is appended (matches the Redis
+// delta-append branch). When it is longer, the file is rewritten in full.
+func (s *Store) Save(_ context.Context, state *statestore.ConversationState) error {
+	if state == nil {
+		return statestore.ErrInvalidState
+	}
+	if state.ID == "" {
+		return statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+
+	lock := s.convLock(state.ID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := os.MkdirAll(s.convDir(state.ID), dirMode); err != nil {
+		return fmt.Errorf("filestore: mkdir conv: %w", err)
+	}
+	if err := s.writeStateSnapshot(state); err != nil {
+		return err
+	}
+	if err := s.reconcileMessagesOnDisk(state.ID, state.Messages); err != nil {
+		return err
+	}
+	return s.reconcileSummariesOnDisk(state.ID, state.Summaries)
+}
+
+func (s *Store) writeStateSnapshot(state *statestore.ConversationState) error {
+	snap := stateSnapshot{
+		ID:             state.ID,
+		UserID:         state.UserID,
+		SystemPrompt:   state.SystemPrompt,
+		TokenCount:     state.TokenCount,
+		LastAccessedAt: time.Now(),
+		Metadata:       state.Metadata,
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("filestore: marshal snapshot: %w", err)
+	}
+	return writeFileAtomic(s.stateFile(state.ID), data, s.fsync)
+}
+
+func (s *Store) reconcileMessagesOnDisk(id string, msgs []types.Message) error {
+	path := s.messagesFile(id)
+	onDisk, err := countLines(path)
+	if err != nil {
+		return err
+	}
+	want := len(msgs)
+	switch {
+	case onDisk == want:
+		return nil
+	case onDisk < want:
+		for i := onDisk; i < want; i++ {
+			if appendErr := appendJSONLine(path, &msgs[i], s.fsync); appendErr != nil {
+				return appendErr
+			}
+		}
+		return nil
+	default:
+		return s.rewriteMessages(id, msgs)
+	}
+}
+
+func (s *Store) rewriteMessages(id string, msgs []types.Message) error {
+	if len(msgs) == 0 {
+		return writeFileAtomic(s.messagesFile(id), nil, s.fsync)
+	}
+	buf := make([]byte, 0, perMessageBufHint*len(msgs))
+	for i := range msgs {
+		line, err := json.Marshal(&msgs[i])
+		if err != nil {
+			return fmt.Errorf("filestore: marshal message: %w", err)
+		}
+		buf = append(buf, line...)
+		buf = append(buf, '\n')
+	}
+	return writeFileAtomic(s.messagesFile(id), buf, s.fsync)
+}
+
+func (s *Store) reconcileSummariesOnDisk(id string, sums []statestore.Summary) error {
+	path := s.summariesFile(id)
+	onDisk, err := countLines(path)
+	if err != nil {
+		return err
+	}
+	want := len(sums)
+	switch {
+	case onDisk == want:
+		return nil
+	case onDisk < want:
+		for i := onDisk; i < want; i++ {
+			if appendErr := appendJSONLine(path, &sums[i], s.fsync); appendErr != nil {
+				return appendErr
+			}
+		}
+		return nil
+	default:
+		if len(sums) == 0 {
+			return writeFileAtomic(path, nil, s.fsync)
+		}
+		buf := make([]byte, 0, perMessageBufHint*len(sums))
+		for i := range sums {
+			line, err := json.Marshal(&sums[i])
+			if err != nil {
+				return fmt.Errorf("filestore: marshal summary: %w", err)
+			}
+			buf = append(buf, line...)
+			buf = append(buf, '\n')
+		}
+		return writeFileAtomic(path, buf, s.fsync)
+	}
+}
+
+// Load reads state.json + messages.jsonl + summaries.jsonl into a
+// ConversationState. Returns ErrNotFound when state.json is absent.
+func (s *Store) Load(_ context.Context, id string) (*statestore.ConversationState, error) {
+	if id == "" {
+		return nil, statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return nil, err
+	}
+
+	lock := s.convLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	snap, err := s.readStateSnapshot(id)
+	if err != nil {
+		return nil, err
+	}
+	messages, err := scanJSONLines[types.Message](s.messagesFile(id))
+	if err != nil {
+		return nil, err
+	}
+	summaries, err := scanJSONLines[statestore.Summary](s.summariesFile(id))
+	if err != nil {
+		return nil, err
+	}
+
+	return &statestore.ConversationState{
+		ID:             snap.ID,
+		UserID:         snap.UserID,
+		SystemPrompt:   snap.SystemPrompt,
+		TokenCount:     snap.TokenCount,
+		LastAccessedAt: snap.LastAccessedAt,
+		Messages:       messages,
+		Summaries:      summaries,
+		Metadata:       snap.Metadata,
+	}, nil
+}
+
+// readStateSnapshot reads state.json. Returns ErrNotFound when absent.
+// Caller must hold the per-conv lock.
+func (s *Store) readStateSnapshot(id string) (*stateSnapshot, error) {
+	data, err := os.ReadFile(s.stateFile(id))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, statestore.ErrNotFound
+		}
+		return nil, fmt.Errorf("filestore: read state: %w", err)
+	}
+	var snap stateSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("filestore: unmarshal state: %w", err)
+	}
+	return &snap, nil
+}
+
+// checkOpen returns ErrStoreClosed if the store has been closed.
+func (s *Store) checkOpen() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return ErrStoreClosed
+	}
+	return nil
+}
+
+// perMessageBufHint is a rough initial-buffer hint for rewriting messages.
+// Picked to comfortably fit a typical short message without re-allocs; the
+// slice grows as needed for longer messages.
+const perMessageBufHint = 256

--- a/runtime/statestore/file/save_load_test.go
+++ b/runtime/statestore/file/save_load_test.go
@@ -1,0 +1,217 @@
+package file
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMsg(role, content string) types.Message {
+	return types.Message{Role: role, Content: content}
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := NewStore(Options{Root: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestStore_SaveAndLoad(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	state := &statestore.ConversationState{
+		ID:           "conv-1",
+		UserID:       "alice",
+		SystemPrompt: "you are helpful",
+		TokenCount:   42,
+		Messages: []types.Message{
+			makeMsg("user", "hi"),
+			makeMsg("assistant", "hello"),
+		},
+		Metadata: map[string]any{"k": "v"},
+	}
+	require.NoError(t, s.Save(ctx, state))
+
+	got, err := s.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "conv-1", got.ID)
+	assert.Equal(t, "alice", got.UserID)
+	assert.Equal(t, "you are helpful", got.SystemPrompt)
+	assert.Equal(t, 42, got.TokenCount)
+	require.Len(t, got.Messages, 2)
+	assert.Equal(t, "hello", got.Messages[1].Content)
+	assert.Equal(t, "v", got.Metadata["k"])
+}
+
+func TestStore_Load_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Load(context.Background(), "missing")
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+func TestStore_Load_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Load(context.Background(), "")
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_Save_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	err := s.Save(context.Background(), &statestore.ConversationState{ID: ""})
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_Save_NilState(t *testing.T) {
+	s := newTestStore(t)
+	err := s.Save(context.Background(), nil)
+	assert.ErrorIs(t, err, statestore.ErrInvalidState)
+}
+
+func TestStore_Save_AfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	err := s.Save(context.Background(), &statestore.ConversationState{ID: "x"})
+	assert.ErrorIs(t, err, ErrStoreClosed)
+
+	_, err = s.Load(context.Background(), "x")
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}
+
+func TestStore_Save_AtomicReplaces(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID:       "conv-1",
+		Messages: []types.Message{makeMsg("user", "v1")},
+	}))
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID:       "conv-1",
+		Messages: []types.Message{makeMsg("user", "v1"), makeMsg("assistant", "v2")},
+	}))
+
+	got, err := s.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	require.Len(t, got.Messages, 2)
+	assert.Equal(t, "v2", got.Messages[1].Content)
+}
+
+func TestStore_Save_TruncatesMessages(t *testing.T) {
+	// On-disk longer than the in-memory state → full rewrite.
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID: "conv-1",
+		Messages: []types.Message{
+			makeMsg("user", "a"), makeMsg("assistant", "b"), makeMsg("user", "c"),
+		},
+	}))
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID:       "conv-1",
+		Messages: []types.Message{makeMsg("user", "only")},
+	}))
+
+	got, err := s.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	require.Len(t, got.Messages, 1)
+	assert.Equal(t, "only", got.Messages[0].Content)
+}
+
+func TestStore_Save_TruncatesToEmpty(t *testing.T) {
+	// On-disk has messages, in-memory state has zero → rewrite to empty file.
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID:       "conv-1",
+		Messages: []types.Message{makeMsg("user", "a"), makeMsg("assistant", "b")},
+	}))
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID:       "conv-1",
+		Messages: nil,
+	}))
+
+	got, err := s.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Empty(t, got.Messages)
+}
+
+func TestStore_Save_RoundTripsSummaries(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID: "conv-1",
+		Summaries: []statestore.Summary{
+			{StartTurn: 0, EndTurn: 5, Content: "first", TokenCount: 10},
+			{StartTurn: 5, EndTurn: 10, Content: "second", TokenCount: 12},
+		},
+	}))
+
+	got, err := s.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	require.Len(t, got.Summaries, 2)
+	assert.Equal(t, "first", got.Summaries[0].Content)
+	assert.Equal(t, "second", got.Summaries[1].Content)
+}
+
+func TestStore_Save_TruncatesSummaries(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID: "conv-1",
+		Summaries: []statestore.Summary{
+			{Content: "a"}, {Content: "b"}, {Content: "c"},
+		},
+	}))
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID:        "conv-1",
+		Summaries: []statestore.Summary{{Content: "only"}},
+	}))
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID: "conv-1",
+	}))
+
+	got, err := s.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	assert.Empty(t, got.Summaries)
+}
+
+func TestStore_FSyncOff_Roundtrips(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(Options{Root: dir, FSync: FSyncOff})
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+	require.NoError(t, s.Save(ctx, &statestore.ConversationState{
+		ID: "conv-1", Messages: []types.Message{makeMsg("user", "a")},
+	}))
+	got, err := s.Load(ctx, "conv-1")
+	require.NoError(t, err)
+	require.Len(t, got.Messages, 1)
+}
+
+func TestStore_Save_NoTempLeftovers(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Save(context.Background(), &statestore.ConversationState{
+		ID: "conv-1", Messages: []types.Message{makeMsg("user", "a")},
+	}))
+	entries, err := os.ReadDir(filepath.Join(s.root, "conv-conv-1"))
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasPrefix(e.Name(), ".tmp"), "no .tmp leftovers: %s", e.Name())
+	}
+}

--- a/runtime/statestore/file/store.go
+++ b/runtime/statestore/file/store.go
@@ -83,6 +83,11 @@ func NewStore(opts Options) (*Store, error) {
 		ttl:   opts.TTL,
 		locks: make(map[string]*sync.Mutex),
 	}
+	if opts.TTL > 0 {
+		if err := s.sweepStale(time.Now()); err != nil {
+			return nil, err
+		}
+	}
 	return s, nil
 }
 

--- a/runtime/statestore/file/store.go
+++ b/runtime/statestore/file/store.go
@@ -1,0 +1,99 @@
+// Package file provides a filesystem-backed statestore implementation.
+//
+// One directory per conversation under Options.Root holds:
+//
+//	state.json       — atomically-rewritten snapshot of meta + metadata
+//	messages.jsonl   — append-only message log (one types.Message per line)
+//	summaries.jsonl  — append-only summary log
+//	lists/<name>.jsonl — opaque-byte append-only lists for ListAccessor
+//
+// The store is single-process: pointing two stores at the same Root is
+// undefined behavior. A future revision may add an OS-level lock file.
+package file
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// dirMode is the permission applied to all directories created by the store.
+// fileMode is the permission applied to all data files. Kept on the
+// restrictive side because conversation contents may include user data.
+const (
+	dirMode  os.FileMode = 0o750
+	fileMode os.FileMode = 0o640
+)
+
+// FSyncPolicy controls when on-disk writes are fsync'd.
+type FSyncPolicy int
+
+const (
+	// FSyncOff matches MemoryStore durability semantics: writes are buffered
+	// by the OS and may be lost on power-loss / kernel panic.
+	FSyncOff FSyncPolicy = iota
+	// FSyncOnSave fsyncs only on Save (the atomic rename of state.json).
+	// Mid-loop message-log appends are not fsync'd. Default.
+	FSyncOnSave
+	// FSyncOnAppend fsyncs on every JSONL append (slowest, most durable).
+	FSyncOnAppend
+)
+
+// Options configures the file-backed store.
+type Options struct {
+	// Root is the directory under which per-conversation directories live.
+	// Created if absent. Required.
+	Root string
+
+	// FSync controls fsync behavior. Defaults to FSyncOnSave.
+	FSync FSyncPolicy
+
+	// TTL, if non-zero, removes conversation directories whose state.json
+	// mtime is older than now-TTL at NewStore time.
+	TTL time.Duration
+}
+
+// Store is a filesystem-backed implementation of statestore.Store and the
+// optional MessageLog / MessageReader / MessageAppender / MetadataAccessor /
+// SummaryAccessor / ListAccessor interfaces.
+type Store struct {
+	root  string
+	fsync FSyncPolicy
+	ttl   time.Duration
+
+	mu     sync.Mutex
+	locks  map[string]*sync.Mutex // per-conv locks
+	closed bool
+}
+
+// NewStore opens (or creates) a file-backed store at opts.Root. Returns an
+// error if Root is empty or the directory cannot be created.
+func NewStore(opts Options) (*Store, error) {
+	if opts.Root == "" {
+		return nil, errors.New("filestore: Options.Root is required")
+	}
+	if err := os.MkdirAll(opts.Root, dirMode); err != nil {
+		return nil, fmt.Errorf("filestore: create root: %w", err)
+	}
+	s := &Store{
+		root:  opts.Root,
+		fsync: opts.FSync,
+		ttl:   opts.TTL,
+		locks: make(map[string]*sync.Mutex),
+	}
+	return s, nil
+}
+
+// Close releases in-memory resources. Idempotent. Outstanding handles to the
+// store after Close return ErrStoreClosed.
+func (s *Store) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+// ErrStoreClosed is returned from any method called after Close.
+var ErrStoreClosed = errors.New("filestore: store closed")

--- a/runtime/statestore/file/store_test.go
+++ b/runtime/statestore/file/store_test.go
@@ -1,0 +1,37 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_RequiresRoot(t *testing.T) {
+	_, err := NewStore(Options{})
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "root")
+}
+
+func TestNewStore_CreatesRoot(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "store")
+
+	s, err := NewStore(Options{Root: root})
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	info, err := os.Stat(root)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestFileStore_Close_Idempotent(t *testing.T) {
+	s, err := NewStore(Options{Root: t.TempDir()})
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+	require.NoError(t, s.Close())
+}

--- a/runtime/statestore/file/summaries.go
+++ b/runtime/statestore/file/summaries.go
@@ -1,0 +1,38 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+)
+
+// LoadSummaries returns all summaries for the conversation, or nil if none.
+func (s *Store) LoadSummaries(_ context.Context, id string) ([]statestore.Summary, error) {
+	if id == "" {
+		return nil, statestore.ErrInvalidID
+	}
+	return scanJSONLines[statestore.Summary](s.summariesFile(id))
+}
+
+// SaveSummary appends a summary to summaries.jsonl. Auto-creates the conv.
+func (s *Store) SaveSummary(_ context.Context, id string, summary statestore.Summary) error {
+	if id == "" {
+		return statestore.ErrInvalidID
+	}
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	lock := s.convLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := os.MkdirAll(s.convDir(id), dirMode); err != nil {
+		return fmt.Errorf("filestore: mkdir conv: %w", err)
+	}
+	if err := s.ensureStateStub(id); err != nil {
+		return err
+	}
+	return appendJSONLine(s.summariesFile(id), &summary, s.fsync)
+}

--- a/runtime/statestore/file/summaries_test.go
+++ b/runtime/statestore/file/summaries_test.go
@@ -1,0 +1,54 @@
+package file
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_SaveSummary_AndLoad(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.SaveSummary(ctx, "conv-1", statestore.Summary{
+		StartTurn: 0, EndTurn: 5, Content: "first", TokenCount: 10,
+	}))
+	require.NoError(t, s.SaveSummary(ctx, "conv-1", statestore.Summary{
+		StartTurn: 5, EndTurn: 10, Content: "second", TokenCount: 12,
+	}))
+
+	got, err := s.LoadSummaries(ctx, "conv-1")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "first", got[0].Content)
+	assert.Equal(t, "second", got[1].Content)
+}
+
+func TestStore_LoadSummaries_Empty(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.LoadSummaries(context.Background(), "missing")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestStore_SaveSummary_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	err := s.SaveSummary(context.Background(), "", statestore.Summary{})
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_LoadSummaries_InvalidID(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.LoadSummaries(context.Background(), "")
+	assert.ErrorIs(t, err, statestore.ErrInvalidID)
+}
+
+func TestStore_SaveSummary_AfterClose(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Close())
+	err := s.SaveSummary(context.Background(), "conv-1", statestore.Summary{})
+	assert.ErrorIs(t, err, ErrStoreClosed)
+}

--- a/runtime/statestore/file/sweep.go
+++ b/runtime/statestore/file/sweep.go
@@ -1,0 +1,38 @@
+package file
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// sweepStale removes per-conversation directories whose state.json mtime is
+// older than now-ttl. Called from NewStore when Options.TTL > 0. Errors on
+// individual conv dirs are not fatal — partial cleanup beats none.
+func (s *Store) sweepStale(now time.Time) error {
+	if s.ttl <= 0 {
+		return nil
+	}
+	cutoff := now.Add(-s.ttl)
+
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return fmt.Errorf("filestore: sweep read root: %w", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), convDirPrefix) {
+			continue
+		}
+		statePath := filepath.Join(s.root, e.Name(), stateFilename)
+		info, statErr := os.Stat(statePath)
+		if statErr != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			_ = os.RemoveAll(filepath.Join(s.root, e.Name()))
+		}
+	}
+	return nil
+}

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -947,6 +947,31 @@
         "command"
       ]
     },
+    "FileStateStoreConfig": {
+      "properties": {
+        "root": {
+          "type": "string"
+        },
+        "fsync": {
+          "type": "string",
+          "enum": [
+            "",
+            "off",
+            "on-save",
+            "on-append"
+          ],
+          "title": "FSync Policy"
+        },
+        "ttl_days": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "root"
+      ]
+    },
     "FragmentRef": {
       "properties": {
         "name": {
@@ -2361,6 +2386,9 @@
         },
         "redis": {
           "$ref": "#/$defs/RedisConfig"
+        },
+        "file": {
+          "$ref": "#/$defs/FileStateStoreConfig"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -192,6 +192,31 @@
         "hook"
       ]
     },
+    "FileStateStoreConfig": {
+      "properties": {
+        "root": {
+          "type": "string"
+        },
+        "fsync": {
+          "type": "string",
+          "enum": [
+            "",
+            "off",
+            "on-save",
+            "on-append"
+          ],
+          "title": "FSync Policy"
+        },
+        "ttl_days": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "root"
+      ]
+    },
     "HTTPConfig": {
       "properties": {
         "url": {
@@ -992,6 +1017,9 @@
         },
         "redis": {
           "$ref": "#/$defs/RedisConfig"
+        },
+        "file": {
+          "$ref": "#/$defs/FileStateStoreConfig"
         }
       },
       "additionalProperties": false,

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
 	"github.com/AltairaLabs/PromptKit/runtime/selection"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/statestore/file"
 	"github.com/AltairaLabs/PromptKit/runtime/stt"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/tts"
@@ -604,7 +605,34 @@ func createStateStoreFromConfig(cfg *pkgconfig.StateStoreConfig) (statestore.Sto
 			opts = append(opts, statestore.WithPrefix(cfg.Redis.Prefix))
 		}
 		return statestore.NewRedisStore(client, opts...), nil
+	case "file":
+		return createFileStateStore(cfg.File)
 	default:
 		return nil, fmt.Errorf("unsupported state store type: %s", cfg.Type)
 	}
+}
+
+const hoursPerDay = 24
+
+// createFileStateStore builds a file-backed statestore from FileStateStoreConfig.
+func createFileStateStore(cfg *pkgconfig.FileStateStoreConfig) (statestore.Store, error) {
+	if cfg == nil || cfg.Root == "" {
+		return nil, fmt.Errorf("state_store.file.root is required when type is 'file'")
+	}
+	var fsync file.FSyncPolicy
+	switch cfg.FSync {
+	case "", "on-save":
+		fsync = file.FSyncOnSave
+	case "off":
+		fsync = file.FSyncOff
+	case "on-append":
+		fsync = file.FSyncOnAppend
+	default:
+		return nil, fmt.Errorf("unknown fsync policy %q (want off|on-save|on-append)", cfg.FSync)
+	}
+	return file.NewStore(file.Options{
+		Root:  cfg.Root,
+		FSync: fsync,
+		TTL:   time.Duration(cfg.TTLDays) * hoursPerDay * time.Hour,
+	})
 }

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -332,6 +332,34 @@ func TestCreateStateStoreFromConfig_InvalidTTL(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid TTL duration")
 }
 
+func TestCreateStateStoreFromConfig_File(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &pkgconfig.StateStoreConfig{
+		Type: "file",
+		File: &pkgconfig.FileStateStoreConfig{Root: dir, FSync: "on-save", TTLDays: 7},
+	}
+	store, err := createStateStoreFromConfig(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}
+
+func TestCreateStateStoreFromConfig_File_MissingRoot(t *testing.T) {
+	cfg := &pkgconfig.StateStoreConfig{Type: "file", File: &pkgconfig.FileStateStoreConfig{}}
+	_, err := createStateStoreFromConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestCreateStateStoreFromConfig_File_UnknownFSync(t *testing.T) {
+	cfg := &pkgconfig.StateStoreConfig{
+		Type: "file",
+		File: &pkgconfig.FileStateStoreConfig{Root: t.TempDir(), FSync: "bogus"},
+	}
+	_, err := createStateStoreFromConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fsync")
+}
+
 func TestApplyRuntimeConfig_ExecTools(t *testing.T) {
 	spec := &pkgconfig.RuntimeConfigSpec{
 		Tools: map[string]*pkgconfig.ToolSpec{


### PR DESCRIPTION
## Summary

Adds a third statestore implementation alongside `MemoryStore` and `RedisStore`: `statestore/file` persists each conversation to disk as a `state.json` snapshot plus append-only JSONL files for messages, summaries, and `ListAccessor` lists. Closes the durability gap between volatile memory and a network-attached Redis for solo dev, single-box, and one-process-per-agent (Omnia function-mode) use cases.

- Implements `Store` + every optional interface (`BulkWriter`, `MessageLog`, `MessageReader`, `MessageAppender`, `MetadataAccessor`, `SummaryAccessor`, `ListAccessor`). Compile-time check pins drop-in compatibility.
- Atomic `state.json` rewrites via write-temp + rename. Append-only JSONL hot path. Per-conversation in-process mutex.
- Configurable root, fsync policy (`off` / `on-save` default / `on-append`), TTL-days for startup cleanup sweep.
- Wired into `RuntimeConfig` (`state_store.type: file`) and the SDK factory.
- Reference page in the docs covers chooser table, on-disk layout, and the single-process caveat.

**Out of scope (deferred):** OS-level cross-process locking, encryption at rest, per-turn log compaction.

Closes #1243.

## Test plan

- [x] `go test ./runtime/statestore/file/... -count=1 -race` — full coverage of every method, TTL sweep, compile-time interface checks, LogAppend → restart → Load smoke.
- [x] `go test ./pkg/config/... -count=1 -race` — validation tests pass.
- [x] `go test ./sdk/... -count=1` — factory tests pass.
- [x] `golangci-lint` clean.
- [ ] SonarCloud quality gate green.