### PR TITLE
chore(actions): bump runtime to node24

### DIFF
--- a/.github/actions/packc-action/action.yml
+++ b/.github/actions/packc-action/action.yml
@@ -72,5 +72,5 @@ outputs:
     description: 'Cosign signature reference (if signed)'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/actions/promptarena-action/action.yml
+++ b/.github/actions/promptarena-action/action.yml
@@ -58,5 +58,5 @@ outputs:
     description: 'Path to generated HTML report'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary

- Switches `promptarena-action` and `packc-action` from `using: 'node20'` to `using: 'node24'`
- Silences the *"Node.js 20 actions are deprecated"* warning that fires on every consumer run today
- GitHub will hard-enforce this from **2026-06-02**

## Why

Consumer repos using these actions (e.g. `AltairaLabs/promptpack-demo`) currently see a deprecation warning attached to every CI run:

```
##[warning]Node.js 20 actions are deprecated. The following actions
are running on Node.js 20 and may not work as expected:
AltairaLabs/PromptKit/.github/actions/promptarena-action@actions/promptarena/v1
```

The compiled `dist/index.js` bundles are runtime-agnostic — no rebuild needed. The change is a two-line YAML update.

## Test plan

- [x] Local diff: two `using:` lines change from `node20` → `node24`, nothing else touched
- [ ] CI on this branch passes (matrix tests + integration tests with the action under its own pipeline)
- [ ] Re-run `promptpack-demo` CI against this branch's actions tags after merge — Node 20 deprecation warning should disappear

## Related

- Consumer repo seeing the warning: https://github.com/AltairaLabs/promptpack-demo
- GitHub announcement: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/