### PR TITLE
fix(packc): auto-create output directory for `compile -o`

### DIFF
--- a/tools/packc/main.go
+++ b/tools/packc/main.go
@@ -11,11 +11,26 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 )
 
-const outputFilePerm = 0o600
+const (
+	outputFilePerm = 0o600
+	outputDirPerm  = 0o755
+)
 
 var version = "dev" //nolint:gochecknoglobals // overridden via ldflags at build time
 
 const warningFormat = "  - %s\n"
+
+// writePackFile writes data to path, creating the parent directory if it
+// does not already exist. Matches the behavior of `go build -o` so that
+// `packc compile -o dist/foo.pack.json` works in fresh CI checkouts.
+func writePackFile(path string, data []byte) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, outputDirPerm); err != nil {
+			return fmt.Errorf("creating output directory %s: %w", dir, err)
+		}
+	}
+	return os.WriteFile(path, data, outputFilePerm)
+}
 
 func buildMemoryRepo(cfg *config.Config) (*memory.PromptRepository, error) {
 	memRepo := memory.NewPromptRepository()

--- a/tools/packc/main_interactive.go
+++ b/tools/packc/main_interactive.go
@@ -188,7 +188,7 @@ func compileCommand() {
 	}
 
 	// Write the output file
-	if err := os.WriteFile(flags.outputFile, result.JSON, outputFilePerm); err != nil {
+	if err := writePackFile(flags.outputFile, result.JSON); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to write pack file: %v\n", err)
 		os.Exit(1)
 	}

--- a/tools/packc/main_test.go
+++ b/tools/packc/main_test.go
@@ -978,6 +978,30 @@ func TestPrintPackSummary(t *testing.T) {
 	})
 }
 
+func TestWritePackFile_CreatesMissingParentDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "nested", "deeper", "out.pack.json")
+	data := []byte(`{"id":"test"}`)
+
+	require.NoError(t, writePackFile(outPath, data))
+
+	got, err := os.ReadFile(outPath) //nolint:gosec // test file under t.TempDir
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestWritePackFile_ExistingDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "out.pack.json")
+	data := []byte(`{"id":"test"}`)
+
+	require.NoError(t, writePackFile(outPath, data))
+
+	got, err := os.ReadFile(outPath) //nolint:gosec // test file under t.TempDir
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
 func TestPrintAgents_Deterministic(t *testing.T) {
 	pack := &prompt.Pack{
 		Agents: &prompt.AgentsConfig{


### PR DESCRIPTION
## Summary

- `packc compile -o dist/foo.pack.json` now `MkdirAll`s the parent directory before writing, matching `go build -o` and most Unix tools that take an output path.
- Fixes the friction documented in #1253: fresh CI checkouts hit `Failed to write pack file: open dist/...: no such file or directory` and had to add a separate `mkdir -p` step before the action.
- Extracts a small `writePackFile` helper in `tools/packc/main.go`; `compileCommand` calls it instead of `os.WriteFile` directly.

Scope is intentionally narrow — only `packc compile` is touched. `compile-prompt` goes through `runtime/prompt.PackCompiler.CompileToFile`, which is a separate code path the issue doesn't mention; I left it alone to avoid changing runtime semantics for other callers.

Closes #1253. Supersedes the empty #1257 (copilot placeholder).

## Test plan

- [x] `go -C tools/packc test -race -count=1 ./...` — new `TestWritePackFile_CreatesMissingParentDir` + `TestWritePackFile_ExistingDir` pass; existing suite green.
- [x] Pre-commit hook clean (lint + build + coverage 98.1% on touched file).
- [ ] CI green on PR.