### PR TITLE
fix(arena): suggest valid alternatives for schema validation errors

### DIFF
--- a/pkg/config/schema_validator.go
+++ b/pkg/config/schema_validator.go
@@ -1,10 +1,14 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -152,6 +156,15 @@ type SchemaValidationError struct {
 	Field       string
 	Description string
 	Value       interface{}
+
+	// Keyword mirrors runtime/prompt/schema.ValidationError.Keyword
+	// (e.g. "enum", "additional_property_not_allowed").
+	Keyword string
+	// ValidValues lists valid alternatives when computable — enum allowed
+	// values, or sibling property names for additionalProperties.
+	ValidValues []string
+	// Suggestions are nearest-match candidates from ValidValues.
+	Suggestions []string
 }
 
 // Error implements the error interface
@@ -195,7 +208,7 @@ func validateWithSchemaSource(yamlData []byte, configType ConfigType, schemaDir 
 		return nil, err
 	}
 
-	return validateJSONWithSchema(jsonData, schema)
+	return validateJSONWithSchema(jsonData, schema, schemaKey)
 }
 
 func convertYAMLToJSON(yamlData []byte) ([]byte, error) {
@@ -282,7 +295,11 @@ func tryLocalSchemaFallback(configType ConfigType) (*gojsonschema.Schema, error)
 	return gojsonschema.NewSchema(localLoader)
 }
 
-func validateJSONWithSchema(jsonData []byte, compiledSchema *gojsonschema.Schema) (*SchemaValidationResult, error) {
+func validateJSONWithSchema(
+	jsonData []byte,
+	compiledSchema *gojsonschema.Schema,
+	schemaKey string,
+) (*SchemaValidationResult, error) {
 	// Use the compiled schema as a loader via its internal reference.
 	// For pre-compiled schemas we still need to call Validate on the schema directly.
 	documentLoader := gojsonschema.NewBytesLoader(jsonData)
@@ -292,24 +309,171 @@ func validateJSONWithSchema(jsonData []byte, compiledSchema *gojsonschema.Schema
 		return nil, fmt.Errorf("schema validation failed: %w", err)
 	}
 
-	return convertSharedResult(result), nil
+	return convertSharedResult(result, schemaKey), nil
 }
 
-// convertSharedResult converts a promptschema.ValidationResult to a config SchemaValidationResult.
-func convertSharedResult(result *gojsonschema.Result) *SchemaValidationResult {
+// convertSharedResult converts a promptschema.ValidationResult to a config
+// SchemaValidationResult and enriches additionalProperty/enum errors with
+// valid alternatives from the raw schema at schemaKey.
+func convertSharedResult(result *gojsonschema.Result, schemaKey string) *SchemaValidationResult {
 	shared := promptschema.ConvertResult(result)
 	out := &SchemaValidationResult{
 		Valid:  shared.Valid,
 		Errors: make([]SchemaValidationError, 0, len(shared.Errors)),
 	}
+
+	var rawSchema map[string]any
+	loaded := false
+
 	for _, e := range shared.Errors {
-		out.Errors = append(out.Errors, SchemaValidationError{
+		converted := SchemaValidationError{
 			Field:       e.Field,
 			Description: e.Description,
 			Value:       e.Value,
-		})
+			Keyword:     e.Keyword,
+			ValidValues: e.ValidValues,
+			Suggestions: e.Suggestions,
+		}
+		switch e.Keyword {
+		case keywordAdditionalProperty, keywordEnum:
+			if !loaded {
+				rawSchema = loadRawSchemaForKey(schemaKey)
+				loaded = true
+			}
+			enrichFromSchema(&converted, rawSchema)
+		}
+		out.Errors = append(out.Errors, converted)
 	}
 	return out
+}
+
+// enrichFromSchema populates ValidValues and Suggestions on an error using
+// the parsed raw schema. No-op if rawSchema is nil.
+func enrichFromSchema(e *SchemaValidationError, rawSchema map[string]any) {
+	if rawSchema == nil {
+		return
+	}
+	switch e.Keyword {
+	case keywordAdditionalProperty:
+		enrichAdditionalProperty(e, rawSchema)
+	case keywordEnum:
+		enrichEnum(e, rawSchema)
+	}
+}
+
+func enrichAdditionalProperty(e *SchemaValidationError, rawSchema map[string]any) {
+	const prefix = "Additional property "
+	const suffix = " is not allowed"
+	offending := ""
+	if strings.HasPrefix(e.Description, prefix) && strings.HasSuffix(e.Description, suffix) {
+		offending = strings.TrimSuffix(strings.TrimPrefix(e.Description, prefix), suffix)
+	}
+	valid := promptschema.LookupProperties(rawSchema, e.Field)
+	if len(valid) == 0 {
+		return
+	}
+	if offending != "" {
+		e.Suggestions = promptschema.NearestMatches(offending, valid)
+	}
+	e.ValidValues = truncateValidValues(valid, maxValidValuesShown)
+}
+
+func enrichEnum(e *SchemaValidationError, rawSchema map[string]any) {
+	allowed := promptschema.LookupEnumValues(rawSchema, e.Field)
+	if len(allowed) == 0 {
+		return
+	}
+	e.ValidValues = allowed
+	if s, ok := e.Value.(string); ok {
+		e.Suggestions = promptschema.NearestMatches(s, allowed)
+	}
+}
+
+const (
+	maxValidValuesShown       = 8
+	keywordAdditionalProperty = "additional_property_not_allowed"
+	keywordEnum               = "enum"
+)
+
+// truncateValidValues caps the displayed valid set and appends a "+N more"
+// sentinel. Sorts lexicographically for determinism.
+func truncateValidValues(values []string, limit int) []string {
+	sorted := make([]string, len(values))
+	copy(sorted, values)
+	sort.Strings(sorted)
+	if len(sorted) <= limit {
+		return sorted
+	}
+	out := make([]string, 0, limit+1)
+	out = append(out, sorted[:limit]...)
+	out = append(out, fmt.Sprintf("+%d more", len(sorted)-limit))
+	return out
+}
+
+// rawSchemaCacheStore holds parsed-JSON schema documents keyed by schemaKey.
+// Separate from schemaCache (which holds compiled gojsonschema schemas)
+// because the raw doc is only needed for error enrichment on the invalid
+// path, not on every Validate call.
+type rawSchemaCacheStore struct {
+	mu   sync.Mutex
+	docs map[string]map[string]any
+}
+
+func (c *rawSchemaCacheStore) get(key string) map[string]any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.docs[key]
+}
+
+func (c *rawSchemaCacheStore) set(key string, doc map[string]any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.docs[key] = doc
+}
+
+var rawSchemaCache = &rawSchemaCacheStore{docs: make(map[string]map[string]any)}
+
+// loadRawSchemaForKey fetches and parses the raw schema document for the
+// given schemaKey (file:// or https:// URL). Returns nil on any error so
+// callers degrade gracefully.
+func loadRawSchemaForKey(schemaKey string) map[string]any {
+	if cached := rawSchemaCache.get(schemaKey); cached != nil {
+		return cached
+	}
+	bytes, err := fetchSchemaBytes(schemaKey)
+	if err != nil {
+		return nil
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(bytes, &doc); err != nil {
+		return nil
+	}
+	rawSchemaCache.set(schemaKey, doc)
+	return doc
+}
+
+func fetchSchemaBytes(schemaKey string) ([]byte, error) {
+	switch {
+	case strings.HasPrefix(schemaKey, "file://"):
+		path := strings.TrimPrefix(schemaKey, "file://")
+		return os.ReadFile(path) //nolint:gosec // path comes from configured schemaDir
+	case strings.HasPrefix(schemaKey, "http://"), strings.HasPrefix(schemaKey, "https://"):
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, schemaKey, http.NoBody)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("status %d", resp.StatusCode)
+		}
+		return io.ReadAll(resp.Body)
+	default:
+		return nil, fmt.Errorf("unsupported schema source: %s", schemaKey)
+	}
 }
 
 // ValidateConfig validates YAML data against the JSON schema for the given ConfigType.

--- a/pkg/config/schema_validator_suggest_test.go
+++ b/pkg/config/schema_validator_suggest_test.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSchemaFixture(t *testing.T, schemaJSON string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	schemaDir := filepath.Join(tmpDir, "schemas", "v1alpha1")
+	require.NoError(t, os.MkdirAll(schemaDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(schemaDir, "arena.json"),
+		[]byte(schemaJSON), 0o600,
+	))
+	return schemaDir
+}
+
+func TestSchemaValidationError_AdditionalPropertyEnriched(t *testing.T) {
+	schemaDir := writeSchemaFixture(t, `{
+		"$schema":"http://json-schema.org/draft-07/schema#",
+		"type":"object",
+		"properties":{
+			"spec":{
+				"type":"object",
+				"additionalProperties":false,
+				"properties":{
+					"prompt":{"type":"string"},
+					"model":{"type":"string"}
+				}
+			}
+		}
+	}`)
+
+	yamlData := []byte("spec:\n  judge: foo\n")
+
+	result, err := ValidateWithLocalSchema(yamlData, ConfigTypeArena, schemaDir)
+	require.NoError(t, err)
+	require.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+
+	var addPropErr *SchemaValidationError
+	for i, e := range result.Errors {
+		if e.Keyword == "additional_property_not_allowed" {
+			addPropErr = &result.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, addPropErr, "expected additional_property_not_allowed error, got %+v", result.Errors)
+	assert.ElementsMatch(t, []string{"model", "prompt"}, addPropErr.ValidValues)
+	// "judge" vs "prompt" distance 5; "judge" vs "model" distance 5; no close match.
+	assert.Nil(t, addPropErr.Suggestions)
+}
+
+func TestSchemaValidationError_AdditionalPropertyWithCloseMatch(t *testing.T) {
+	schemaDir := writeSchemaFixture(t, `{
+		"$schema":"http://json-schema.org/draft-07/schema#",
+		"type":"object",
+		"additionalProperties":false,
+		"properties":{
+			"prompt":{"type":"string"},
+			"prompts":{"type":"array"}
+		}
+	}`)
+
+	yamlData := []byte("promp: x\n")
+
+	result, err := ValidateWithLocalSchema(yamlData, ConfigTypeArena, schemaDir)
+	require.NoError(t, err)
+	require.False(t, result.Valid)
+
+	var addPropErr *SchemaValidationError
+	for i, e := range result.Errors {
+		if e.Keyword == "additional_property_not_allowed" {
+			addPropErr = &result.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, addPropErr)
+	assert.Equal(t, []string{"prompt", "prompts"}, addPropErr.Suggestions)
+}
+
+func TestSchemaValidationError_EnumEnriched(t *testing.T) {
+	schemaDir := writeSchemaFixture(t, `{
+		"$schema":"http://json-schema.org/draft-07/schema#",
+		"type":"object",
+		"properties":{
+			"provider":{"type":"string","enum":["openai","anthropic","mock"]}
+		}
+	}`)
+
+	yamlData := []byte("provider: anthrop\n")
+
+	result, err := ValidateWithLocalSchema(yamlData, ConfigTypeArena, schemaDir)
+	require.NoError(t, err)
+	require.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+
+	var enumErr *SchemaValidationError
+	for i, e := range result.Errors {
+		if e.Keyword == "enum" {
+			enumErr = &result.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, enumErr)
+	assert.Equal(t, []string{"openai", "anthropic", "mock"}, enumErr.ValidValues)
+	assert.Equal(t, []string{"anthropic"}, enumErr.Suggestions)
+}
+
+func TestTruncateValidValues(t *testing.T) {
+	t.Run("under limit", func(t *testing.T) {
+		got := truncateValidValues([]string{"b", "a", "c"}, 8)
+		assert.Equal(t, []string{"a", "b", "c"}, got)
+	})
+	t.Run("over limit", func(t *testing.T) {
+		got := truncateValidValues([]string{"a", "b", "c", "d", "e"}, 3)
+		assert.Equal(t, []string{"a", "b", "c", "+2 more"}, got)
+	})
+}

--- a/runtime/prompt/schema/suggest.go
+++ b/runtime/prompt/schema/suggest.go
@@ -1,0 +1,221 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	maxSuggestionDistance = 2
+	shortTargetLen        = 3
+)
+
+// levenshtein computes the edit distance between a and b using the classic
+// dynamic-programming algorithm.
+func levenshtein(a, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			m := del
+			if ins < m {
+				m = ins
+			}
+			if sub < m {
+				m = sub
+			}
+			curr[j] = m
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(br)]
+}
+
+// nearestMatches returns candidates within Levenshtein distance of target,
+// sorted by distance ascending then lexicographically. Targets of length
+// <= shortTargetLen require distance <= 1.
+func nearestMatches(target string, candidates []string) []string {
+	if target == "" || len(candidates) == 0 {
+		return nil
+	}
+	limit := maxSuggestionDistance
+	if len(target) <= shortTargetLen {
+		limit = 1
+	}
+	type scored struct {
+		name string
+		dist int
+	}
+	matches := make([]scored, 0, len(candidates))
+	for _, c := range candidates {
+		d := levenshtein(target, c)
+		if d > 0 && d <= limit {
+			matches = append(matches, scored{name: c, dist: d})
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].dist != matches[j].dist {
+			return matches[i].dist < matches[j].dist
+		}
+		return matches[i].name < matches[j].name
+	})
+	out := make([]string, len(matches))
+	for i, m := range matches {
+		out[i] = m.name
+	}
+	return out
+}
+
+// lookupProperties returns the names of properties valid at fieldPath in the
+// given parsed schema document. fieldPath uses the gojsonschema convention:
+// "(root)" for the document root, dot-separated for nested paths. Resolves
+// single-layer $ref pointers to #/definitions/X and #/$defs/X. Returns nil
+// when the path cannot be resolved (oneOf/anyOf/allOf, unknown $ref, or
+// missing intermediate node).
+func lookupProperties(root map[string]any, fieldPath string) []string {
+	node, ok := resolveSchemaAt(root, fieldPath)
+	if !ok {
+		return nil
+	}
+	props, ok := node["properties"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(props))
+	for name := range props {
+		names = append(names, name)
+	}
+	return names
+}
+
+// lookupEnumValues returns the enum allowed-set at fieldPath as strings.
+// Numeric and other JSON values are coerced via fmt.Sprint. Returns nil if
+// the path cannot be resolved or the node lacks an `enum` array.
+func lookupEnumValues(root map[string]any, fieldPath string) []string {
+	node, ok := resolveSchemaAt(root, fieldPath)
+	if !ok {
+		return nil
+	}
+	raw, ok := node["enum"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		out = append(out, fmt.Sprint(v))
+	}
+	return out
+}
+
+// resolveSchemaAt navigates root by dot-separated fieldPath and returns the
+// schema node at that location, with $ref resolved. Reports false when the
+// path cannot be resolved.
+func resolveSchemaAt(root map[string]any, fieldPath string) (map[string]any, bool) {
+	current := root
+	if fieldPath != "(root)" && fieldPath != "" {
+		for _, seg := range strings.Split(fieldPath, ".") {
+			next, ok := descendInto(root, current, seg)
+			if !ok {
+				return nil, false
+			}
+			current = next
+		}
+	}
+	return resolveRef(root, current)
+}
+
+// descendInto returns the schema node for property `name` within `node`.
+// Resolves $ref on `node` first, then rejects conditional schemas
+// (oneOf/anyOf/allOf) because we can't pick a branch unambiguously.
+func descendInto(root, node map[string]any, name string) (map[string]any, bool) {
+	resolved, ok := resolveRef(root, node)
+	if !ok {
+		return nil, false
+	}
+	for _, k := range []string{"oneOf", "anyOf", "allOf"} {
+		if _, has := resolved[k]; has {
+			return nil, false
+		}
+	}
+	props, ok := resolved["properties"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	child, ok := props[name].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	return child, true
+}
+
+// resolveRef follows a single layer of $ref pointing at #/definitions/X or
+// #/$defs/X. Returns (node, true) unchanged when there is no $ref. Returns
+// (nil, false) when the ref is present but unresolvable.
+func resolveRef(root, node map[string]any) (map[string]any, bool) {
+	ref, ok := node["$ref"].(string)
+	if !ok {
+		return node, true
+	}
+	const (
+		defsPrefix       = "#/definitions/"
+		dollarDefsPrefix = "#/$defs/"
+	)
+	var name, bucket string
+	switch {
+	case strings.HasPrefix(ref, defsPrefix):
+		name = strings.TrimPrefix(ref, defsPrefix)
+		bucket = "definitions"
+	case strings.HasPrefix(ref, dollarDefsPrefix):
+		name = strings.TrimPrefix(ref, dollarDefsPrefix)
+		bucket = "$defs"
+	default:
+		return nil, false
+	}
+	bucketMap, ok := root[bucket].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	target, ok := bucketMap[name].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	return target, true
+}
+
+// LookupProperties is the exported wrapper for cross-package callers.
+func LookupProperties(root map[string]any, fieldPath string) []string {
+	return lookupProperties(root, fieldPath)
+}
+
+// LookupEnumValues is the exported wrapper for cross-package callers.
+func LookupEnumValues(root map[string]any, fieldPath string) []string {
+	return lookupEnumValues(root, fieldPath)
+}
+
+// NearestMatches is the exported wrapper for cross-package callers.
+func NearestMatches(target string, candidates []string) []string {
+	return nearestMatches(target, candidates)
+}

--- a/runtime/prompt/schema/suggest_test.go
+++ b/runtime/prompt/schema/suggest_test.go
@@ -1,0 +1,204 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevenshtein(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"kitten", "sitting", 3},
+		{"judge", "prompt", 6},
+		{"judge", "judges", 1},
+		{"prompt", "promp", 1},
+		{"anthrop", "anthropic", 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.a+"_vs_"+tc.b, func(t *testing.T) {
+			assert.Equal(t, tc.want, levenshtein(tc.a, tc.b))
+			assert.Equal(t, tc.want, levenshtein(tc.b, tc.a), "should be symmetric")
+		})
+	}
+}
+
+func TestNearestMatches(t *testing.T) {
+	t.Run("returns close match sorted by distance then name", func(t *testing.T) {
+		got := nearestMatches("promp", []string{"prompt", "prompts", "model"})
+		assert.Equal(t, []string{"prompt", "prompts"}, got)
+	})
+
+	t.Run("returns single best match", func(t *testing.T) {
+		got := nearestMatches("anthrop", []string{"openai", "anthropic", "mock"})
+		assert.Equal(t, []string{"anthropic"}, got)
+	})
+
+	t.Run("no candidates within distance 2", func(t *testing.T) {
+		got := nearestMatches("judge", []string{"prompt", "model", "temperature"})
+		assert.Empty(t, got)
+	})
+
+	t.Run("short target with unrelated candidates returns empty", func(t *testing.T) {
+		got := nearestMatches("xyz", []string{"abc", "def", "ghi"})
+		assert.Empty(t, got)
+	})
+
+	t.Run("short target with close match still returns it", func(t *testing.T) {
+		got := nearestMatches("abc", []string{"abd"})
+		assert.Equal(t, []string{"abd"}, got)
+	})
+
+	t.Run("empty target returns empty", func(t *testing.T) {
+		assert.Empty(t, nearestMatches("", []string{"a", "b"}))
+	})
+
+	t.Run("empty candidates returns empty", func(t *testing.T) {
+		assert.Empty(t, nearestMatches("foo", nil))
+	})
+}
+
+func parseSchema(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return m
+}
+
+func TestLookupProperties(t *testing.T) {
+	t.Run("direct properties on root", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{"a":{"type":"string"},"b":{"type":"number"}}
+		}`)
+		got := lookupProperties(schema, "(root)")
+		assert.ElementsMatch(t, []string{"a", "b"}, got)
+	})
+
+	t.Run("nested direct properties", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{
+				"spec":{"type":"object","properties":{"x":{},"y":{}}}
+			}
+		}`)
+		got := lookupProperties(schema, "spec")
+		assert.ElementsMatch(t, []string{"x", "y"}, got)
+	})
+
+	t.Run("ref to definitions", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{"spec":{"$ref":"#/definitions/Spec"}},
+			"definitions":{"Spec":{"type":"object","properties":{"p":{},"q":{}}}}
+		}`)
+		got := lookupProperties(schema, "spec")
+		assert.ElementsMatch(t, []string{"p", "q"}, got)
+	})
+
+	t.Run("ref to $defs", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{"spec":{"$ref":"#/$defs/Spec"}},
+			"$defs":{"Spec":{"type":"object","properties":{"m":{},"n":{}}}}
+		}`)
+		got := lookupProperties(schema, "spec")
+		assert.ElementsMatch(t, []string{"m", "n"}, got)
+	})
+
+	t.Run("two-level path through ref", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{"spec":{"$ref":"#/definitions/Spec"}},
+			"definitions":{
+				"Spec":{"type":"object","properties":{"judge_defaults":{"type":"object","properties":{"prompt":{}}}}}
+			}
+		}`)
+		got := lookupProperties(schema, "spec.judge_defaults")
+		assert.ElementsMatch(t, []string{"prompt"}, got)
+	})
+
+	t.Run("oneOf returns nil", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{
+				"spec":{"oneOf":[
+					{"properties":{"a":{}}},
+					{"properties":{"b":{}}}
+				]}
+			}
+		}`)
+		got := lookupProperties(schema, "spec")
+		assert.Nil(t, got)
+	})
+
+	t.Run("missing path returns nil", func(t *testing.T) {
+		schema := parseSchema(t, `{"type":"object","properties":{"a":{}}}`)
+		got := lookupProperties(schema, "nonexistent.deep.path")
+		assert.Nil(t, got)
+	})
+
+	t.Run("unresolvable ref returns nil", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{"spec":{"$ref":"#/definitions/Missing"}}
+		}`)
+		got := lookupProperties(schema, "spec")
+		assert.Nil(t, got)
+	})
+}
+
+func TestLookupEnumValues(t *testing.T) {
+	t.Run("direct enum on root property", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{
+				"provider":{"type":"string","enum":["openai","anthropic","mock"]}
+			}
+		}`)
+		got := lookupEnumValues(schema, "provider")
+		assert.Equal(t, []string{"openai", "anthropic", "mock"}, got)
+	})
+
+	t.Run("enum behind ref", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{"spec":{"$ref":"#/definitions/Spec"}},
+			"definitions":{
+				"Spec":{"type":"object","properties":{
+					"mode":{"type":"string","enum":["fast","slow"]}
+				}}
+			}
+		}`)
+		got := lookupEnumValues(schema, "spec.mode")
+		assert.Equal(t, []string{"fast", "slow"}, got)
+	})
+
+	t.Run("numeric enum coerced to strings", func(t *testing.T) {
+		schema := parseSchema(t, `{
+			"type":"object",
+			"properties":{"version":{"enum":[1,2,3]}}
+		}`)
+		got := lookupEnumValues(schema, "version")
+		assert.Equal(t, []string{"1", "2", "3"}, got)
+	})
+
+	t.Run("missing field returns nil", func(t *testing.T) {
+		schema := parseSchema(t, `{"type":"object","properties":{"a":{}}}`)
+		assert.Nil(t, lookupEnumValues(schema, "nonexistent"))
+	})
+
+	t.Run("field without enum returns nil", func(t *testing.T) {
+		schema := parseSchema(t, `{"type":"object","properties":{"a":{"type":"string"}}}`)
+		assert.Nil(t, lookupEnumValues(schema, "a"))
+	})
+}

--- a/runtime/prompt/schema/validate.go
+++ b/runtime/prompt/schema/validate.go
@@ -12,6 +12,17 @@ type ValidationError struct {
 	Field       string
 	Description string
 	Value       interface{}
+
+	// Keyword is the JSON-schema keyword that failed (e.g. "enum",
+	// "additional_property_not_allowed", "required"). Sourced from
+	// gojsonschema's ResultError.Type(). Empty if unavailable.
+	Keyword string
+	// ValidValues lists allowed values when computable. Populated by
+	// higher-level callers that hold the raw schema document. Nil when
+	// not enumerable at this layer.
+	ValidValues []string
+	// Suggestions are nearest-match candidates from ValidValues.
+	Suggestions []string
 }
 
 // Error implements the error interface.
@@ -55,6 +66,7 @@ func ConvertResult(result *gojsonschema.Result) *ValidationResult {
 				Field:       e.Field(),
 				Description: e.Description(),
 				Value:       e.Value(),
+				Keyword:     e.Type(),
 			})
 		}
 	}

--- a/runtime/prompt/schema/validate_test.go
+++ b/runtime/prompt/schema/validate_test.go
@@ -104,6 +104,39 @@ func TestConvertResult_Valid(t *testing.T) {
 	assert.Empty(t, vr.Errors)
 }
 
+func TestConvertResult_KeywordPopulated(t *testing.T) {
+	schemaJSON := `{
+		"type":"object",
+		"properties":{"name":{"type":"string"}},
+		"additionalProperties":false
+	}`
+	schemaLoader := gojsonschema.NewStringLoader(schemaJSON)
+	documentLoader := gojsonschema.NewStringLoader(`{"name":"x","extra":"y"}`)
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	require.NoError(t, err)
+
+	vr := ConvertResult(result)
+	require.NotEmpty(t, vr.Errors)
+	assert.Equal(t, "additional_property_not_allowed", vr.Errors[0].Keyword)
+}
+
+func TestConvertResult_EnumKeyword(t *testing.T) {
+	schemaJSON := `{
+		"type":"object",
+		"properties":{"provider":{"type":"string","enum":["openai","mock"]}}
+	}`
+	schemaLoader := gojsonschema.NewStringLoader(schemaJSON)
+	documentLoader := gojsonschema.NewStringLoader(`{"provider":"anthrop"}`)
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	require.NoError(t, err)
+
+	vr := ConvertResult(result)
+	require.NotEmpty(t, vr.Errors)
+	assert.Equal(t, "enum", vr.Errors[0].Keyword)
+}
+
 func TestConvertResult_Invalid(t *testing.T) {
 	schemaJSON := `{
 		"type": "object",

--- a/tools/arena/cmd/promptarena/validate.go
+++ b/tools/arena/cmd/promptarena/validate.go
@@ -196,17 +196,49 @@ func displayErrors(errors []config.SchemaValidationError, verbose bool) {
 }
 
 func displayError(err config.SchemaValidationError) {
-	// Clean up the field path for better readability
 	field := err.Field
 	field = strings.TrimPrefix(field, "(root).")
 	if field == "(root)" {
 		field = "root"
 	}
 
-	// Format the error message
+	switch {
+	case err.Keyword == "additional_property_not_allowed" && len(err.ValidValues) > 0:
+		offending := extractAdditionalPropertyName(err.Description)
+		if offending == "" {
+			displayDefault(field, &err)
+			return
+		}
+		header := fmt.Sprintf("  - %s: unknown property '%s'", field, offending)
+		if len(err.Suggestions) > 0 {
+			header += fmt.Sprintf(". Did you mean '%s'?", err.Suggestions[0])
+		}
+		fmt.Println(header)
+		fmt.Printf("      Valid keys: %s\n", strings.Join(err.ValidValues, ", "))
+
+	case len(err.Suggestions) > 0:
+		displayDefault(field, &err)
+		fmt.Printf("      Did you mean: %s\n", strings.Join(err.Suggestions, ", "))
+
+	default:
+		displayDefault(field, &err)
+	}
+}
+
+func displayDefault(field string, err *config.SchemaValidationError) {
 	if err.Value != nil {
 		fmt.Printf("  - %s: %s (value: %v)\n", field, err.Description, err.Value)
 	} else {
 		fmt.Printf("  - %s: %s\n", field, err.Description)
 	}
+}
+
+// extractAdditionalPropertyName pulls X out of "Additional property X is not allowed".
+func extractAdditionalPropertyName(desc string) string {
+	const prefix = "Additional property "
+	const suffix = " is not allowed"
+	if !strings.HasPrefix(desc, prefix) || !strings.HasSuffix(desc, suffix) {
+		return ""
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(desc, prefix), suffix)
 }

--- a/tools/arena/cmd/promptarena/validate_test.go
+++ b/tools/arena/cmd/promptarena/validate_test.go
@@ -85,6 +85,64 @@ func TestDisplayError_EnumWithSuggestion(t *testing.T) {
 	assert.Contains(t, out, "Did you mean: anthropic")
 }
 
+func TestPerformSchemaValidation_AdditionalPropertyHint(t *testing.T) {
+	// This package disables schema validation in tests (see
+	// schema_disable_init_test.go). Re-enable for this case so the real
+	// validator runs against the fixture schema.
+	config.SchemaValidationDisabled.Store(false)
+	t.Cleanup(func() { config.SchemaValidationDisabled.Store(true) })
+
+	// Reproduces the exemplar from issue #1251: judge_defaults.judge typo
+	// where the valid key is "prompt".
+	tmpDir := t.TempDir()
+	schemaDir := filepath.Join(tmpDir, "schemas", "v1alpha1")
+	require.NoError(t, os.MkdirAll(schemaDir, 0o755))
+	schemaJSON := `{
+		"$schema":"http://json-schema.org/draft-07/schema#",
+		"type":"object",
+		"properties":{
+			"spec":{
+				"type":"object",
+				"properties":{
+					"judge_defaults":{
+						"type":"object",
+						"additionalProperties":false,
+						"properties":{"prompt":{"type":"string"}}
+					}
+				}
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(schemaDir, "arena.json"),
+		[]byte(schemaJSON), 0o600,
+	))
+
+	yamlData := []byte("spec:\n  judge_defaults:\n    judge: tone-judge\n")
+
+	result, err := config.ValidateWithLocalSchema(yamlData, config.ConfigTypeArena, schemaDir)
+	require.NoError(t, err)
+	require.False(t, result.Valid)
+
+	var addPropErr *config.SchemaValidationError
+	for i, e := range result.Errors {
+		if e.Keyword == "additional_property_not_allowed" {
+			addPropErr = &result.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, addPropErr, "expected additional_property_not_allowed error, got %+v", result.Errors)
+
+	out := captureStdout(t, func() { displayError(*addPropErr) })
+	// "judge" vs "prompt" Levenshtein distance is 6 — far beyond the
+	// did-you-mean threshold — so the valid-keys line is the helpful
+	// output for this exemplar. The did-you-mean is verified separately
+	// in TestSchemaValidationError_AdditionalPropertyWithCloseMatch.
+	assert.Contains(t, out, "unknown property 'judge'", "expected unknown-property phrase: %s", out)
+	assert.Contains(t, out, "Valid keys: prompt", "expected valid keys line: %s", out)
+	assert.NotContains(t, out, "Did you mean", "no close match exists for 'judge' vs 'prompt'")
+}
+
 func TestDisplayError_PassthroughForOtherKeywords(t *testing.T) {
 	e := config.SchemaValidationError{
 		Field:       "spec.name",

--- a/tools/arena/cmd/promptarena/validate_test.go
+++ b/tools/arena/cmd/promptarena/validate_test.go
@@ -7,7 +7,96 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	_ = w.Close()
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func TestDisplayError_AdditionalPropertyWithSuggestion(t *testing.T) {
+	e := config.SchemaValidationError{
+		Field:       "spec.judge_defaults",
+		Description: "Additional property judge is not allowed",
+		Value:       "tone-judge",
+		Keyword:     "additional_property_not_allowed",
+		ValidValues: []string{"prompt"},
+		Suggestions: []string{"prompt"},
+	}
+	out := captureStdout(t, func() { displayError(e) })
+	assert.Contains(t, out, "unknown property 'judge'. Did you mean 'prompt'?")
+	assert.Contains(t, out, "Valid keys: prompt")
+	assert.NotContains(t, out, "(value: tone-judge)", "old format should not appear")
+}
+
+func TestDisplayError_AdditionalPropertyNoSuggestionStillListsKeys(t *testing.T) {
+	e := config.SchemaValidationError{
+		Field:       "spec.judge_defaults",
+		Description: "Additional property xyz is not allowed",
+		Value:       "v",
+		Keyword:     "additional_property_not_allowed",
+		ValidValues: []string{"model", "prompt"},
+		Suggestions: nil,
+	}
+	out := captureStdout(t, func() { displayError(e) })
+	assert.Contains(t, out, "unknown property 'xyz'")
+	assert.NotContains(t, out, "Did you mean")
+	assert.Contains(t, out, "Valid keys: model, prompt")
+}
+
+func TestDisplayError_AdditionalPropertyDegraded(t *testing.T) {
+	// ValidValues nil → navigator couldn't resolve. Fall back to today's message.
+	e := config.SchemaValidationError{
+		Field:       "spec.judge_defaults",
+		Description: "Additional property judge is not allowed",
+		Value:       "tone-judge",
+		Keyword:     "additional_property_not_allowed",
+		ValidValues: nil,
+		Suggestions: nil,
+	}
+	out := captureStdout(t, func() { displayError(e) })
+	assert.Contains(t, out, "Additional property judge is not allowed")
+	assert.Contains(t, out, "(value: tone-judge)")
+}
+
+func TestDisplayError_EnumWithSuggestion(t *testing.T) {
+	e := config.SchemaValidationError{
+		Field:       "spec.provider",
+		Description: `spec.provider must be one of the following: "openai", "anthropic", "mock"`,
+		Value:       "anthrop",
+		Keyword:     "enum",
+		ValidValues: []string{"openai", "anthropic", "mock"},
+		Suggestions: []string{"anthropic"},
+	}
+	out := captureStdout(t, func() { displayError(e) })
+	assert.Contains(t, out, e.Description)
+	assert.Contains(t, out, "Did you mean: anthropic")
+}
+
+func TestDisplayError_PassthroughForOtherKeywords(t *testing.T) {
+	e := config.SchemaValidationError{
+		Field:       "spec.name",
+		Description: "spec.name is required",
+		Value:       nil,
+		Keyword:     "required",
+	}
+	out := captureStdout(t, func() { displayError(e) })
+	assert.Contains(t, out, "spec.name is required")
+	assert.NotContains(t, out, "Did you mean")
+	assert.NotContains(t, out, "Valid keys")
+}
 
 func TestPrepareValidation(t *testing.T) {
 	// Create a temporary test file


### PR DESCRIPTION
## Summary

- Schema validation errors for `additionalProperties` violations now include `unknown property 'X'. Did you mean 'Y'?` and a `Valid keys: …` line when the parent schema's properties can be enumerated.
- Schema validation errors for `enum` violations include a `Did you mean: …` line when the offending string value is a close match (Levenshtein ≤ 2) to one of the allowed values.
- All other keywords render exactly as before. When the navigator can't resolve a schema path (e.g. through `oneOf`), additionalProperties errors fall back to today's message.

Closes #1251.

## Implementation

- Adds `Keyword`, `ValidValues`, `Suggestions` to `runtime/prompt/schema.ValidationError` and `pkg/config.SchemaValidationError`.
- `runtime/prompt/schema/suggest.go` houses pure helpers: `levenshtein`, `nearestMatches`, `lookupProperties`/`lookupEnumValues` (resolves `$ref` to `#/definitions/X` and `#/$defs/X`, returns nil on conditional schemas).
- `pkg/config` lazily fetches and caches the raw schema document for the active `schemaKey`; only paid on the invalid path.
- Arena's `displayError` switches on `Keyword` to render the new shape; today's format is preserved for everything else.

Note: gojsonschema v1.2.0 returns the enum allowed-set as a joined string in error details, so the implementation reads the raw schema directly to enumerate values (same pattern as additionalProperties) rather than parsing the description string.

## Test plan

- [x] `go test ./runtime/prompt/schema/...` — unit tests for Levenshtein, nearestMatches, lookupProperties, lookupEnumValues, keyword population.
- [x] `go test ./pkg/config/...` — additionalProperties enrichment with and without a close match, enum enrichment, truncation, all using local schema fixtures.
- [x] `go test ./tools/arena/cmd/promptarena/...` — 5 display unit tests + integration regression test reproducing the #1251 exemplar.
- [x] Pre-commit hook clean (lint + build + coverage ≥80% on all touched files; suggest.go 91.8%, validate.go 100%, pkg/config 89.1%, arena validate.go 85.0%).
- [ ] CI green on PR.