### PR TITLE
fix(prompt): only warn on missing variables when template uses them

### DIFF
--- a/runtime/prompt/pack.go
+++ b/runtime/prompt/pack.go
@@ -769,8 +769,9 @@ func validatePrompt(taskType string, prompt *PackPrompt) []string {
 	if prompt.SystemTemplate == "" {
 		warnings = append(warnings, fmt.Sprintf("prompt '%s': missing system_template", taskType))
 	}
-	if len(prompt.Variables) == 0 {
-		warnings = append(warnings, fmt.Sprintf("prompt '%s': no variables defined", taskType))
+	if len(prompt.Variables) == 0 && strings.Contains(prompt.SystemTemplate, "{{") {
+		msg := "prompt '%s': system_template references variables, but none are declared"
+		warnings = append(warnings, fmt.Sprintf(msg, taskType))
 	}
 	if prompt.Version == "" {
 		warnings = append(warnings, fmt.Sprintf("prompt '%s': missing version", taskType))

--- a/runtime/prompt/pack_test.go
+++ b/runtime/prompt/pack_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,6 +136,53 @@ func TestPack_Validate(t *testing.T) {
 			} else {
 				// For invalid packs, should have at least the expected warnings
 				assert.GreaterOrEqual(t, len(warnings), tt.expectedErrors, "should have at least the expected warnings")
+			}
+		})
+	}
+}
+
+func TestValidatePrompt_VariablesWarning(t *testing.T) {
+	tests := []struct {
+		name       string
+		prompt     *PackPrompt
+		expectWarn bool
+	}{
+		{
+			name: "no variables, no placeholders — should not warn",
+			prompt: &PackPrompt{
+				SystemTemplate: "You are a judge. Score the user message from 0 to 1.",
+				Version:        "1.0.0",
+			},
+			expectWarn: false,
+		},
+		{
+			name: "no variables, template uses placeholders — should warn",
+			prompt: &PackPrompt{
+				SystemTemplate: "Hello {{name}}",
+				Version:        "1.0.0",
+			},
+			expectWarn: true,
+		},
+		{
+			name: "variables declared, template uses placeholders — should not warn",
+			prompt: &PackPrompt{
+				SystemTemplate: "Hello {{name}}",
+				Version:        "1.0.0",
+				Variables:      []VariableMetadata{{Name: "name", Required: true}},
+			},
+			expectWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := validatePrompt("test", tt.prompt)
+			joined := strings.Join(warnings, "\n")
+			if tt.expectWarn {
+				assert.Contains(t, joined, "system_template references variables, but none are declared")
+			} else {
+				assert.NotContains(t, joined, "no variables defined")
+				assert.NotContains(t, joined, "references variables, but none are declared")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Restricts the "no variables defined" pack-validation warning to the case it was meant to catch: `system_template` references `{{...}}` placeholders but `Variables` is empty.
- A prompt with no variables is perfectly valid — judge prompts, system instructions where the user message *is* the input, single-purpose prompts that don't template anything. The previous unconditional warning false-positived on all of them.
- New wording makes the intent explicit: *"system_template references variables, but none are declared"*.

Fixes #1261.

## Repro (before)

`AltairaLabs/promptpack-demo` CI surfaced 4 noisy `##[warning]` annotations on every run, one per prompt — even though none of the prompts reference any template variables.

## Change

`runtime/prompt/pack.go`:

```diff
-if len(prompt.Variables) == 0 {
-    warnings = append(warnings, fmt.Sprintf("prompt '%s': no variables defined", taskType))
-}
+if len(prompt.Variables) == 0 && strings.Contains(prompt.SystemTemplate, "{{") {
+    msg := "prompt '%s': system_template references variables, but none are declared"
+    warnings = append(warnings, fmt.Sprintf(msg, taskType))
+}
```

## Test plan

- [x] Local `go test ./runtime/prompt/` passes
- [x] New `TestValidatePrompt_VariablesWarning` covers three cases:
  - No variables, no placeholders → no warning (the fix)
  - No variables, template has `{{name}}` → warning fires with new wording
  - Variables declared, template has `{{name}}` → no warning
- [x] Existing `TestPack_Validate` "valid pack" case still passes (template uses `{{name}}` and declares it)
- [ ] CI on this branch passes
- [ ] After merge, re-run `promptpack-demo` CI — yellow-banner warnings should disappear

## Related

- Consumer hitting this: https://github.com/AltairaLabs/promptpack-demo