### PR TITLE
fix(release): fetch remote tags before idempotency checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,11 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-    
+
+    - name: Fetch remote tags
+      # See update-tools/Fetch remote tags for rationale.
+      run: git fetch --tags --force origin
+
     - name: Tag runtime
       env:
         VERSION: ${{ needs.validate.outputs.version }}
@@ -264,6 +268,14 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Fetch remote tags
+      # Ensure local tag state reflects the remote. Without this, the per-tag
+      # `git rev-parse "<tag>" >/dev/null 2>&1` checks miss tags that exist on
+      # remote but weren't pulled into the local clone — which causes the
+      # workflow to try to create+push tags that already exist remotely and
+      # fail with "remote rejected" / "remote: fatal error in commit_refs".
+      run: git fetch --tags --force origin
 
     - name: Create release branch
       env:


### PR DESCRIPTION
## Summary

The release workflow's tag-creation steps each use:

```bash
if git rev-parse "<tag>" >/dev/null 2>&1; then
  echo "⚠ Tag already exists, skipping"
else
  git tag -a ...
  git push origin ...
fi
```

`git rev-parse` only checks the **local** clone. A fresh `actions/checkout` doesn't always have all the tags that exist on origin — especially after a prior partial failure that created some tags on the remote but couldn't roll the floating major. The guard falls through, the workflow creates the tag locally pointing at the runner's HEAD, then the non-force `git push origin <tag>` collides with the existing remote tag and dies with:

```
! [remote rejected]   tools/arena/v1.4.12 -> tools/arena/v1.4.12 (failure)
error: failed to push some refs
```

## Fix

Add a single `git fetch --tags --force origin` step at the start of both jobs that do tagging (`tag-dependencies` and `update-tools`) so the local rev-parse guards see actual remote state.

Minimal, surgical, doesn't redesign the workflow. Doesn't address the deeper "should the specific-version tag use force-with-lease?" question — but unblocks re-runs after a partial failure, which is the immediate need.

## How this came up

The `v1.4.12` release run failed on tag push, leaving partial state (some v1.4.12 tags exist, some don't, floating majors still stale). Re-running hit the same failure because the local guards didn't see the remote tags from run 1.

## Test plan

- [ ] CI on this branch passes
- [ ] After merge: clean up the partial `v1.4.12` state (delete tags + branch), re-run release with v1.4.12, confirm it completes