### PR TITLE
refactor(config): collapse judge model into provider (#1264)

### DIFF
--- a/docs/src/content/docs/arena/reference/config-schema.md
+++ b/docs/src/content/docs/arena/reference/config-schema.md
@@ -80,11 +80,10 @@ spec:
     - file: evals/customer-support-eval.yaml
     - file: evals/regression-eval.yaml
 
-  # Optional: Judges (map judge name -> provider)
+  # Optional: Judges (map judge name -> provider; judge inherits the provider's model)
   judges:
     - name: mock-judge
       provider: mock-judge
-      model: judge-model
   judge_defaults:
     prompt: judge-simple
     prompt_registry: ./prompts

--- a/examples/llm-judge/config.arena.yaml
+++ b/examples/llm-judge/config.arena.yaml
@@ -22,11 +22,10 @@ spec:
     - file: providers/mock-judge.yaml
       group: judge
 
-  # Judges map names to provider IDs and optional model overrides
+  # Judges map names to provider IDs; the judge inherits the provider's model
   judges:
     - name: mock-judge
       provider: mock-judge
-      model: judge-model
   judge_defaults:
     prompt: judge-simple
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -76,7 +76,6 @@ spec:
   judges:
     - name: test-judge
       provider: provider1
-      model: gpt-4o-mini
   judge_defaults:
     prompt: judge-simple-criteria
     prompt_registry: ./prompts
@@ -122,8 +121,8 @@ spec:
 		t.Errorf("Expected 1 loaded judge, got %d", len(config.LoadedJudges))
 	} else {
 		j := config.LoadedJudges["test-judge"]
-		if j == nil || j.Model != "gpt-4o-mini" {
-			t.Errorf("Expected loaded judge to resolve model override, got %#v", j)
+		if j == nil || j.Provider == nil || j.Provider.Model != "gpt-4" {
+			t.Errorf("Expected loaded judge to inherit provider model, got %#v", j)
 		}
 	}
 

--- a/pkg/config/inline_specs_test.go
+++ b/pkg/config/inline_specs_test.go
@@ -189,7 +189,6 @@ func TestInlineJudgeSpecs(t *testing.T) {
   judge_specs:
     quality:
       provider: judge-provider
-      model: gpt-4o-mini
   defaults:
     concurrency: 1
 `)
@@ -200,33 +199,9 @@ func TestInlineJudgeSpecs(t *testing.T) {
 	j, ok := cfg.LoadedJudges["quality"]
 	require.True(t, ok)
 	assert.Equal(t, "quality", j.Name)
-	assert.Equal(t, "gpt-4o-mini", j.Model)
-	assert.NotNil(t, j.Provider)
+	require.NotNil(t, j.Provider)
 	assert.Equal(t, "judge-provider", j.Provider.ID)
-}
-
-func TestInlineJudgeSpecs_FallbackToProviderModel(t *testing.T) {
-	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
-	dir := t.TempDir()
-
-	configPath := writeArenaConfig(t, dir, `  providers: []
-  provider_specs:
-    jp:
-      type: openai
-      model: gpt-4o
-  judge_specs:
-    j1:
-      provider: jp
-  defaults:
-    concurrency: 1
-`)
-
-	cfg, err := LoadConfig(configPath)
-	require.NoError(t, err)
-
-	j, ok := cfg.LoadedJudges["j1"]
-	require.True(t, ok)
-	assert.Equal(t, "gpt-4o", j.Model, "should fall back to provider model")
+	assert.Equal(t, "gpt-4o", j.Provider.Model, "judge inherits the provider model")
 }
 
 func TestInlinePromptSpecs(t *testing.T) {
@@ -463,15 +438,15 @@ func TestMergeJudgeSpecs_Unit(t *testing.T) {
 		LoadedProviders: map[string]*Provider{"jp": provider},
 		LoadedJudges:    map[string]*JudgeTarget{},
 		JudgeSpecs: map[string]*JudgeSpec{
-			"j1": {Provider: "jp", Model: "gpt-4o-mini"},
+			"j1": {Provider: "jp"},
 		},
 	}
 
 	require.NoError(t, cfg.mergeJudgeSpecs())
 	j := cfg.LoadedJudges["j1"]
 	require.NotNil(t, j)
-	assert.Equal(t, "gpt-4o-mini", j.Model)
 	assert.Equal(t, provider, j.Provider)
+	assert.Equal(t, "gpt-4", j.Provider.Model, "judge inherits the provider model")
 }
 
 func TestMergePromptSpecs_Unit(t *testing.T) {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -133,14 +133,9 @@ func (c *Config) mergeJudgeSpecs() error {
 		if !ok {
 			return fmt.Errorf("judge_specs %q references unknown provider %q", name, spec.Provider)
 		}
-		model := spec.Model
-		if model == "" {
-			model = provider.Model
-		}
 		c.LoadedJudges[name] = &JudgeTarget{
 			Name:     name,
 			Provider: provider,
-			Model:    model,
 		}
 	}
 	return nil
@@ -847,7 +842,8 @@ func (c *Config) validateJudgeReferences() error {
 	return nil
 }
 
-// buildJudgeTargets resolves judge references to provider configs and effective models.
+// buildJudgeTargets resolves judge references to their provider configs.
+// The judge's model is the provider's model.
 func (c *Config) buildJudgeTargets() error {
 	for _, judge := range c.Judges {
 		provider, exists := c.LoadedProviders[judge.Provider]
@@ -856,15 +852,9 @@ func (c *Config) buildJudgeTargets() error {
 				judge.Name, judge.Provider)
 		}
 
-		model := provider.Model
-		if judge.Model != "" {
-			model = judge.Model
-		}
-
 		c.LoadedJudges[judge.Name] = &JudgeTarget{
 			Name:     judge.Name,
 			Provider: provider,
-			Model:    model,
 		}
 	}
 	return nil

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -406,23 +406,23 @@ type ProviderRef struct {
 
 // JudgeRef references a judge configuration mapped to a provider.
 // Mirrors self-play role/provider mapping to allow multiple judge targets.
+// The judge inherits its model from the referenced provider.
 type JudgeRef struct {
-	Name     string `yaml:"name" json:"name"`                       // Judge identifier used in assertions
-	Provider string `yaml:"provider" json:"provider"`               // Provider ID reference (must exist in spec.providers)
-	Model    string `yaml:"model,omitempty" json:"model,omitempty"` // Optional model override for the judge
+	Name     string `yaml:"name" json:"name"`         // Judge identifier used in assertions
+	Provider string `yaml:"provider" json:"provider"` // Provider ID reference (must exist in spec.providers)
 }
 
-// JudgeSpec defines an inline judge configuration.
+// JudgeSpec defines an inline judge configuration. The judge inherits its
+// model from the referenced provider.
 type JudgeSpec struct {
-	Provider string `yaml:"provider" json:"provider"`               // Provider ID reference
-	Model    string `yaml:"model,omitempty" json:"model,omitempty"` // Optional model override
+	Provider string `yaml:"provider" json:"provider"` // Provider ID reference
 }
 
-// JudgeTarget is a resolved judge reference with provider config and effective model.
+// JudgeTarget is a resolved judge reference with its provider config.
+// The effective model is the provider's model (Provider.Model).
 type JudgeTarget struct {
 	Name     string    `json:"name"`               // Judge identifier
-	Provider *Provider `json:"provider,omitempty"` // Resolved provider config
-	Model    string    `json:"model"`              // Effective model (judge override or provider model)
+	Provider *Provider `json:"provider,omitempty"` // Resolved provider config (carries the model)
 }
 
 // ScenarioRef references a scenario file

--- a/pkg/config/types_json_test.go
+++ b/pkg/config/types_json_test.go
@@ -21,7 +21,7 @@ func TestConfig_JSONRoundTrip(t *testing.T) {
 			{File: "providers/openai.yaml", Group: "default"},
 		},
 		Judges: []JudgeRef{
-			{Name: "quality", Provider: "openai", Model: "gpt-4"},
+			{Name: "quality", Provider: "openai"},
 		},
 		JudgeDefaults: &JudgeDefaults{
 			Prompt:         "default-judge",
@@ -82,7 +82,7 @@ func TestConfig_JSONRoundTrip(t *testing.T) {
 			"inline-t": {Name: "inline-t", Description: "Inline tool", Mode: "mock"},
 		},
 		JudgeSpecs: map[string]*JudgeSpec{
-			"inline-j": {Provider: "openai", Model: "gpt-4o-mini"},
+			"inline-j": {Provider: "openai"},
 		},
 		PromptSpecs: map[string]*prompt.Spec{
 			"chat": {TaskType: "chat", SystemTemplate: "Hello"},
@@ -98,7 +98,7 @@ func TestConfig_JSONRoundTrip(t *testing.T) {
 			"openai": {ID: "openai", Type: "openai", Model: "gpt-4"},
 		},
 		LoadedJudges: map[string]*JudgeTarget{
-			"quality": {Name: "quality", Model: "gpt-4"},
+			"quality": {Name: "quality", Provider: &Provider{ID: "openai", Type: "openai", Model: "gpt-4"}},
 		},
 		LoadedTools: []ToolData{
 			{FilePath: "tools/t1.yaml", Data: []byte(`{"name":"tool1"}`)},
@@ -132,7 +132,8 @@ func TestConfig_JSONRoundTrip(t *testing.T) {
 	require.NotNil(t, restored.LoadedProviders["openai"])
 	assert.Equal(t, "gpt-4", restored.LoadedProviders["openai"].Model)
 	require.NotNil(t, restored.LoadedJudges["quality"])
-	assert.Equal(t, "gpt-4", restored.LoadedJudges["quality"].Model)
+	require.NotNil(t, restored.LoadedJudges["quality"].Provider)
+	assert.Equal(t, "gpt-4", restored.LoadedJudges["quality"].Provider.Model)
 	require.Len(t, restored.LoadedTools, 1)
 	assert.Equal(t, "tools/t1.yaml", restored.LoadedTools[0].FilePath)
 

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -1152,9 +1152,6 @@
         },
         "provider": {
           "type": "string"
-        },
-        "model": {
-          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -1167,9 +1164,6 @@
     "JudgeSpec": {
       "properties": {
         "provider": {
-          "type": "string"
-        },
-        "model": {
           "type": "string"
         }
       },

--- a/tools/arena/cmd/promptarena/config_inspect_collector_interactive.go
+++ b/tools/arena/cmd/promptarena/config_inspect_collector_interactive.go
@@ -283,15 +283,19 @@ func collectPersonas(cfg *config.Config) []PersonaInspectData {
 	return personas
 }
 
-// collectJudges extracts judge configuration details
+// collectJudges extracts judge configuration details. The judge's model is
+// inherited from its provider, surfaced here via the resolved judge target.
 func collectJudges(cfg *config.Config) []JudgeInspectData {
 	var judges []JudgeInspectData
 	for _, j := range cfg.Judges {
-		judges = append(judges, JudgeInspectData{
+		data := JudgeInspectData{
 			Name:     j.Name,
 			Provider: j.Provider,
-			Model:    j.Model,
-		})
+		}
+		if jt := cfg.LoadedJudges[j.Name]; jt != nil && jt.Provider != nil {
+			data.Model = jt.Provider.Model
+		}
+		judges = append(judges, data)
 	}
 	return judges
 }

--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -666,7 +666,7 @@ func attachJudgeMetadata(metadata map[string]interface{}, cfg *config.Config) {
 			if jt == nil || jt.Provider == nil {
 				continue
 			}
-			targets[name] = providerSpecFromConfig(jt.Provider, jt.Model)
+			targets[name] = providerSpecFromConfig(jt.Provider)
 		}
 		if len(targets) > 0 {
 			metadata["judge_targets"] = targets
@@ -680,16 +680,12 @@ func attachJudgeMetadata(metadata map[string]interface{}, cfg *config.Config) {
 	}
 }
 
-// providerSpecFromConfig converts config.Provider to providers.ProviderSpec with optional model override.
-func providerSpecFromConfig(p *config.Provider, overrideModel string) providers.ProviderSpec {
-	model := p.Model
-	if overrideModel != "" {
-		model = overrideModel
-	}
+// providerSpecFromConfig converts config.Provider to providers.ProviderSpec.
+func providerSpecFromConfig(p *config.Provider) providers.ProviderSpec {
 	return providers.ProviderSpec{
 		ID:               p.ID,
 		Type:             p.Type,
-		Model:            model,
+		Model:            p.Model,
 		BaseURL:          p.BaseURL,
 		Headers:          p.Headers,
 		IncludeRawOutput: p.IncludeRawOutput,

--- a/tools/arena/engine/conversation_executor_test.go
+++ b/tools/arena/engine/conversation_executor_test.go
@@ -80,7 +80,6 @@ func TestBuildConversationContext_IncludesExtras(t *testing.T) {
 					Type:  "mock",
 					Model: "judge-model",
 				},
-				Model: "judge-model",
 			},
 		},
 		JudgeDefaults: &config.JudgeDefaults{Prompt: "p", PromptRegistry: "./prompts"},


### PR DESCRIPTION
## Summary

Removes the per-reference judge model override so a judge inherits its model from its provider — the same way `SelfPlayRoleGroup` already does. This eliminates a second source of truth for "what model a provider runs."

Why it matters: once invocation-time provider substitution lands (the companion `--override-provider` work), a stale `model:` override would point at the *old* provider's model and produce an invalid request (e.g. asking Claude for `judge-model`). Model belongs with the provider.

Behavioral no-op today: the only configs that set the override pinned the provider's own model.

## Changes

- Remove `JudgeRef.Model`, `JudgeSpec.Model`, and the resolved `JudgeTarget.Model` (`pkg/config/types.go`)
- `buildJudgeTargets` / `mergeJudgeSpecs` always resolve to `provider.Model` (`pkg/config/loader.go`)
- Drop the dead `overrideModel` parameter from `providerSpecFromConfig` (`tools/arena/engine/conversation_executor.go`)
- `config-inspect` now surfaces the judge's effective model by reading it from the resolved provider (`config_inspect_collector_interactive.go`)
- Regenerate `schemas/v1alpha1/arena.json` (`model` removed from `judges` / `judge_specs`)
- Drop `model: judge-model` from the `llm-judge` example and the config-schema docs

## Note on `JudgeTarget.Model`

The issue invited a decision on whether to keep this field. I **removed** it rather than keep a copy of `provider.Model`, since a derived duplicate is exactly the second-source-of-truth the issue is solving. This changes the serialized `loaded_judges` JSON shape — the effective model now lives only under `.provider.model`. Easy to revert if a downstream consumer relies on the old top-level field.

## Compatibility

Breaking schema change, but low impact: the field previously had to equal a model the provider could serve, and both known configs set it to the provider's own model. Removing it is a no-op for them.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/config/... ./tools/arena/...`
- [x] `golangci-lint run` (changed packages) — clean
- [x] `go run ./tools/schema-gen/... -check` — schemas up to date
- [x] `llm-judge` example runs clean against the published schema (judge resolves, eval score 0.85, exit 0)

Closes #1264
