### PR TITLE
feat(arena): add --override-provider from=to to promptarena run (#1265)

### DIFF
--- a/docs/src/content/docs/arena/how-to/use-mock-providers.md
+++ b/docs/src/content/docs/arena/how-to/use-mock-providers.md
@@ -209,6 +209,32 @@ Run side-by-side:
 promptarena run --scenario customer-support
 ```
 
+## Substituting a Single Provider
+
+`--mock-provider` replaces *every* provider with a generic mock. When you need to
+swap just one configured provider for another at run time — without editing config —
+use `--override-provider from=to` (repeatable). It rewrites the `from` provider with
+the spec of the `to` provider, so every reference to `from` (candidate selection,
+self-play roles, **and judges**) picks up the new implementation.
+
+```bash
+# Tiered CI: mock judge in the cheap gate, real judge in the drift check —
+# same config, different invocation.
+promptarena run                                         # cheap tier: judge uses its mock provider
+promptarena run --override-provider mock-judge=claude   # drift tier: judge runs for real
+
+# Swap a self-play user-simulation model, or isolate one provider behind a mock
+promptarena run --override-provider mock-user=claude
+promptarena run --override-provider claude=mock         # requires a defined `mock` provider
+```
+
+Both `from` and `to` must be providers defined in `spec.providers`. A typo
+hard-errors rather than silently leaving the original provider in place:
+
+```
+--override-provider mock-judge=nonexistent: unknown target provider "nonexistent" (must be defined in spec.providers)
+```
+
 ## Development Workflow
 
 ### Phase 1: Build with Mocks

--- a/tools/arena/cmd/promptarena/provider_override.go
+++ b/tools/arena/cmd/promptarena/provider_override.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+// applyProviderOverrides rewrites each `from` provider in cfg.LoadedProviders
+// with the spec of its `to` provider, in place, keeping the original ID/key.
+// Both ids must be defined providers; a typo hard-errors rather than silently
+// leaving the original provider in place.
+func applyProviderOverrides(cfg *config.Config, pairs []string) error {
+	for _, p := range pairs {
+		from, to, err := parseOverridePair(p)
+		if err != nil {
+			return err
+		}
+		dst, ok := cfg.LoadedProviders[from]
+		if !ok {
+			return fmt.Errorf(
+				"--override-provider %s=%s: unknown source provider %q (must be defined in spec.providers)",
+				from, to, from)
+		}
+		src, ok := cfg.LoadedProviders[to]
+		if !ok {
+			return fmt.Errorf(
+				"--override-provider %s=%s: unknown target provider %q (must be defined in spec.providers)",
+				from, to, to)
+		}
+		overrideProviderSpec(dst, src)
+	}
+	return nil
+}
+
+// parseOverridePair splits a "from=to" string into its two non-empty halves.
+func parseOverridePair(s string) (from, to string, err error) {
+	from, to, found := strings.Cut(s, "=")
+	if !found || from == "" || to == "" {
+		return "", "", fmt.Errorf("invalid --override-provider %q: expected from=to", s)
+	}
+	return from, to, nil
+}
+
+// overrideProviderSpec copies src's spec into dst in place, keeping dst's ID.
+func overrideProviderSpec(dst, src *config.Provider) {
+	id := dst.ID
+	*dst = *src
+	dst.ID = id
+}

--- a/tools/arena/cmd/promptarena/provider_override_test.go
+++ b/tools/arena/cmd/promptarena/provider_override_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+func TestExtractOverrideFlags_CollectsRepeatedPairs(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringArray("override-provider", nil, "")
+	require.NoError(t, cmd.Flags().Set("override-provider", "mock-judge=claude"))
+	require.NoError(t, cmd.Flags().Set("override-provider", "mock-user=claude"))
+
+	params := &RunParameters{}
+	require.NoError(t, extractOverrideFlags(cmd, params))
+
+	assert.Equal(t, []string{"mock-judge=claude", "mock-user=claude"}, params.ProviderOverrides)
+}
+
+func TestApplyProviderOverrides_CopiesTargetSpecKeepingFromID(t *testing.T) {
+	cfg := &config.Config{
+		LoadedProviders: map[string]*config.Provider{
+			"mock-judge": {ID: "mock-judge", Type: "mock", Model: "judge-model"},
+			"claude":     {ID: "claude", Type: "anthropic", Model: "claude-haiku"},
+		},
+	}
+
+	err := applyProviderOverrides(cfg, []string{"mock-judge=claude"})
+	require.NoError(t, err)
+
+	got := cfg.LoadedProviders["mock-judge"]
+	require.NotNil(t, got)
+	assert.Equal(t, "mock-judge", got.ID, "keeps the original key/id")
+	assert.Equal(t, "anthropic", got.Type, "takes target type")
+	assert.Equal(t, "claude-haiku", got.Model, "takes target model")
+}
+
+func TestApplyProviderOverrides_UnknownTargetErrors(t *testing.T) {
+	cfg := &config.Config{
+		LoadedProviders: map[string]*config.Provider{
+			"mock-judge": {ID: "mock-judge", Type: "mock", Model: "judge-model"},
+		},
+	}
+
+	err := applyProviderOverrides(cfg, []string{"mock-judge=nope"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nope")
+}
+
+func TestApplyProviderOverrides_UnknownSourceErrors(t *testing.T) {
+	cfg := &config.Config{
+		LoadedProviders: map[string]*config.Provider{
+			"claude": {ID: "claude", Type: "anthropic", Model: "claude-haiku"},
+		},
+	}
+
+	err := applyProviderOverrides(cfg, []string{"nope=claude"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nope")
+}
+
+func TestApplyProviderOverrides_MalformedPairErrors(t *testing.T) {
+	cfg := &config.Config{
+		LoadedProviders: map[string]*config.Provider{
+			"claude": {ID: "claude", Type: "anthropic", Model: "claude-haiku"},
+		},
+	}
+
+	for _, bad := range []string{"no-equals", "=claude", "claude="} {
+		err := applyProviderOverrides(cfg, []string{bad})
+		require.Errorf(t, err, "expected error for %q", bad)
+	}
+}
+
+func TestApplyProviderOverrides_MultiplePairs(t *testing.T) {
+	cfg := &config.Config{
+		LoadedProviders: map[string]*config.Provider{
+			"mock-judge": {ID: "mock-judge", Type: "mock", Model: "judge-model"},
+			"mock-user":  {ID: "mock-user", Type: "mock", Model: "user-model"},
+			"claude":     {ID: "claude", Type: "anthropic", Model: "claude-haiku"},
+		},
+	}
+
+	err := applyProviderOverrides(cfg, []string{"mock-judge=claude", "mock-user=claude"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "anthropic", cfg.LoadedProviders["mock-judge"].Type)
+	assert.Equal(t, "anthropic", cfg.LoadedProviders["mock-user"].Type)
+	assert.Equal(t, "mock-user", cfg.LoadedProviders["mock-user"].ID, "keeps its own id")
+}
+
+func TestApplyProviderOverrides_NoPairsIsNoOp(t *testing.T) {
+	orig := &config.Provider{ID: "claude", Type: "anthropic", Model: "claude-haiku"}
+	cfg := &config.Config{
+		LoadedProviders: map[string]*config.Provider{"claude": orig},
+	}
+
+	require.NoError(t, applyProviderOverrides(cfg, nil))
+
+	assert.Same(t, orig, cfg.LoadedProviders["claude"], "untouched when no overrides")
+	assert.Equal(t, "anthropic", cfg.LoadedProviders["claude"].Type)
+}
+
+// The override must mutate the provider in place so consumers that already hold
+// a pointer to it — notably resolved judge targets (JudgeTarget.Provider, since
+// #1264) — transparently see the new spec without re-resolution.
+func TestApplyProviderOverrides_ReachesResolvedJudgeTarget(t *testing.T) {
+	judgeProvider := &config.Provider{ID: "mock-judge", Type: "mock", Model: "judge-model"}
+	cfg := &config.Config{
+		LoadedProviders: map[string]*config.Provider{
+			"mock-judge": judgeProvider,
+			"claude":     {ID: "claude", Type: "anthropic", Model: "claude-haiku"},
+		},
+		// Mirrors post-LoadConfig state: the judge target shares the provider pointer.
+		LoadedJudges: map[string]*config.JudgeTarget{
+			"quality": {Name: "quality", Provider: judgeProvider},
+		},
+	}
+
+	require.NoError(t, applyProviderOverrides(cfg, []string{"mock-judge=claude"}))
+
+	jt := cfg.LoadedJudges["quality"]
+	require.NotNil(t, jt.Provider)
+	assert.Equal(t, "anthropic", jt.Provider.Type, "judge target sees the substituted provider")
+	assert.Equal(t, "claude-haiku", jt.Provider.Model)
+	assert.Equal(t, "mock-judge", jt.Provider.ID, "judge still resolves under its original id")
+}

--- a/tools/arena/cmd/promptarena/run.go
+++ b/tools/arena/cmd/promptarena/run.go
@@ -125,6 +125,10 @@ func init() {
 	runCmd.Flags().Bool("mock-provider", false, "Replace all providers with MockProvider (for CI/testing)")
 	runCmd.Flags().String("mock-config", "", "Path to mock provider configuration file (YAML)")
 
+	// Provider substitution: swap one configured provider's spec for another (repeatable)
+	runCmd.Flags().StringArray("override-provider", nil,
+		"Substitute a configured provider with another: from=to (repeatable)")
+
 	// Pack eval settings
 	runCmd.Flags().Bool("skip-pack-evals", false, "Disable pack eval execution")
 	runCmd.Flags().StringSlice("eval-types", []string{}, "Filter to specific eval types (e.g., contains,regex)")
@@ -174,10 +178,13 @@ type RunParameters struct {
 	MarkdownFile   string   // New: Markdown output file
 	MockProvider   bool     // Enable mock provider mode
 	MockConfig     string   // Path to mock provider configuration
-	SkipPackEvals  bool     // Disable pack eval execution
-	EvalTypes      []string // Filter to specific eval types
-	ConfigFile     string   // Configuration file name for TUI display
-	TotalRuns      int      // Total number of runs for TUI progress
+	// ProviderOverrides holds raw "from=to" pairs from --override-provider,
+	// substituting one configured provider's spec for another at invocation time.
+	ProviderOverrides []string
+	SkipPackEvals     bool     // Disable pack eval execution
+	EvalTypes         []string // Filter to specific eval types
+	ConfigFile        string   // Configuration file name for TUI display
+	TotalRuns         int      // Total number of runs for TUI progress
 
 	// Audio monitor settings (real-time duplex audio)
 	AudioMonitorMode string // "auto" | "on" | "off"
@@ -196,6 +203,11 @@ func extractRunParameters(cmd *cobra.Command, cfg *config.Config) (*RunParameter
 
 	// Extract mock provider flags
 	if err := extractMockFlags(cmd, params); err != nil {
+		return nil, err
+	}
+
+	// Extract provider override flags
+	if err := extractOverrideFlags(cmd, params); err != nil {
 		return nil, err
 	}
 
@@ -287,6 +299,17 @@ func extractMockFlags(cmd *cobra.Command, params *RunParameters) error {
 	if params.MockConfig, err = cmd.Flags().GetString("mock-config"); err != nil {
 		return fmt.Errorf("failed to get mock-config flag: %w", err)
 	}
+	return nil
+}
+
+// extractOverrideFlags extracts the repeatable --override-provider pairs.
+// Pairs are validated against the loaded providers later, in applyProviderOverrides.
+func extractOverrideFlags(cmd *cobra.Command, params *RunParameters) error {
+	overrides, err := cmd.Flags().GetStringArray("override-provider")
+	if err != nil {
+		return fmt.Errorf("failed to get override-provider flag: %w", err)
+	}
+	params.ProviderOverrides = overrides
 	return nil
 }
 

--- a/tools/arena/cmd/promptarena/run_interactive.go
+++ b/tools/arena/cmd/promptarena/run_interactive.go
@@ -189,6 +189,13 @@ func setupEngine(cfg *config.Config, params *RunParameters) (*engine.Engine, *en
 	cfg.SkipPackEvals = params.SkipPackEvals
 	cfg.EvalTypeFilter = params.EvalTypes
 
+	// Apply provider substitutions before building the engine, so the new specs
+	// reach the candidate registry, self-play, and judges (which hold the cfg
+	// provider pointer) alike.
+	if err := applyProviderOverrides(cfg, params.ProviderOverrides); err != nil {
+		return nil, nil, err
+	}
+
 	eng, err := engine.NewEngineFromConfig(cfg, params.Providers...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create engine: %w", err)

--- a/tools/arena/cmd/promptarena/yaml_config_test.go
+++ b/tools/arena/cmd/promptarena/yaml_config_test.go
@@ -355,6 +355,7 @@ func setupTestFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("verbose", false, "Verbose mode")
 	cmd.Flags().Bool("mock-provider", false, "Use mock provider")
 	cmd.Flags().String("mock-config", "", "Mock config file")
+	cmd.Flags().StringArray("override-provider", nil, "Substitute a configured provider: from=to")
 	cmd.Flags().StringSlice("format", []string{}, "Output formats")
 	cmd.Flags().String("junit-file", "", "JUnit XML output file")
 	cmd.Flags().String("html-file", "", "HTML report output file")


### PR DESCRIPTION
## Summary

Adds a repeatable `--override-provider from=to` flag to `promptarena run` that substitutes one configured provider's spec for another at invocation time — without editing config. Precise, pointed alternative to the all-or-nothing `--mock-provider`.

```bash
# Tiered CI: mock judge in the cheap gate, real judge in the drift check — same config
promptarena run                                       # cheap tier: judge uses its mock provider
promptarena run --override-provider mock-judge=claude # drift tier: judge runs for real
```

## How it works

`applyProviderOverrides` rewrites `cfg.LoadedProviders[from]` **in place** with the spec of `to` (keeping the `from` key), applied in `setupEngine` **before** `NewEngineFromConfig`. One mutation reaches all three consumers:

- **Candidates** + **self-play** — their registries are built from cfg afterward.
- **Judges** — the resolved `JudgeTarget` holds the cfg provider pointer (since #1264), so it reads the new spec at execution time. No re-resolution needed; the issue's "must run before `buildJudgeTargets`" concern dissolves because of #1264.

Strict validation: both `from` and `to` must be defined in `spec.providers`; a typo hard-errors (`unknown target provider "x" (must be defined in spec.providers)`) rather than silently leaving the original in place.

## `--mock-provider` left unchanged

Per design review: `--mock-provider`'s candidate-only scope is *structural* — it replaces the engine provider registry wholesale and never touches judges or self-play. Forcing it through the cfg-level path would require excluding two provider sets and still couldn't reproduce a provider used as both candidate and judge. So it stays at the registry layer; `--override-provider` is the general substitution mechanism.

## Test plan

- [x] Unit tests (`provider_override_test.go`, 100% coverage of the new file): copies target spec keeping `from` id; unknown `from`/`to` hard-error; malformed pair errors; multiple pairs; no-op when absent; reaches a resolved judge target via the shared pointer; flag extraction collects repeated pairs.
- [x] `go build ./...`, full `tools/arena` test suite, `golangci-lint` (new code clean).
- [x] End-to-end: `llm-judge` example with `--override-provider mock-judge=mock-assistant` → exit 0 (judge resolves through the substitute); with an unknown target → exit 1 + clear error.

Closes #1265
