### PR TITLE
ci: skip npm publish when version already on the registry

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -67,7 +67,20 @@ jobs:
         run: |
           npm pack --dry-run
 
+      - name: Check if version already published
+        id: published
+        run: |
+          PKG="@altairalabs/${{ matrix.package }}"
+          VER="${{ steps.version.outputs.version }}"
+          if npm view "${PKG}@${VER}" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::${PKG}@${VER} is already published — skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
+        if: steps.published.outputs.exists != 'true'
         working-directory: npm/${{ matrix.package }}
         run: npm publish --access public
         env:
@@ -75,7 +88,11 @@ jobs:
 
       - name: Create summary
         run: |
-          echo "### ✅ Published @altairalabs/${{ matrix.package }}@${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.published.outputs.exists }}" = "true" ]; then
+            echo "### ⏭️ Skipped @altairalabs/${{ matrix.package }}@${{ steps.version.outputs.version }} (already published)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ✅ Published @altairalabs/${{ matrix.package }}@${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Package:** \`@altairalabs/${{ matrix.package }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Makes the `Publish npm Packages` workflow idempotent. When the target version is already on the npm registry, it skips the publish step instead of failing with `E403 — cannot publish over previously published versions`.

## Why

v1.4.12 surfaced this: a `tools-only` release on 2026-05-27 published the npm wrappers (`@altairalabs/promptarena@1.4.12`, `@altairalabs/packc@1.4.12`), but skipped the lib tags / GitHub release. The follow-up `phase=full` release on 2026-05-28 completed those, but its release-triggered npm publish hit `E403` because 1.4.12 was already on npm — a spurious red on an otherwise complete, correct release.

## Change

- New `Check if version already published` step queries `npm view <pkg>@<ver>` and sets `exists`.
- `Publish to npm` is gated on `steps.published.outputs.exists != 'true'`.
- The summary reports `⏭️ Skipped (already published)` vs `✅ Published`.

Idempotent across re-runs and overlapping release phases; no behavior change when the version doesn't yet exist.

## Test plan

- [x] `yaml.safe_load` parses the workflow.
- [ ] On merge, the next release (or a `workflow_dispatch` with an existing version) shows the publish step skipped rather than failing.

Note: edits `.github/workflows/`, so please merge via the GitHub UI (the `gh` token here lacks the `workflow` scope to merge workflow-touching PRs).
