### PR TITLE
feat(arena): let scenarios pin a workflow stage via task_type (#1271)

### DIFF
--- a/docs/src/content/docs/arena/how-to/workflow-regression.md
+++ b/docs/src/content/docs/arena/how-to/workflow-regression.md
@@ -101,6 +101,32 @@ jobs:
 
 Keyless: both examples use mock providers with scripted `workflow__transition` calls.
 
+## Unit-testing a single stage
+
+The scenarios above drive the whole lifecycle from the entry state. To exercise
+**one** stage in isolation — without first walking the agent through every earlier
+transition — pin the scenario's `task_type` to that stage's `prompt_task`:
+
+```yaml
+spec:
+  id: unit-fulfillment-stage
+  task_type: fulfillment   # start in the non-entry 'fulfillment' stage
+  turns:
+    - role: user
+      content: "Where is my package?"
+      assertions:
+        - type: state_is
+          params:
+            state: fulfillment
+```
+
+The per-run state machine starts in that stage instead of the workflow entry, so
+the turn runs the `fulfillment` prompt directly. Full-lifecycle scenarios (no
+`task_type`, or `task_type` set to the entry) and single-stage unit tests can live
+in the same config. A `task_type` that names no workflow state's `prompt_task` is a
+hard error at run time — it is never silently rerouted through the entry. See
+`examples/workflow-order-processing` for both shapes side by side.
+
 ## Extending it
 
 - **Add a new state**: drop it in the pack's `workflow:` block with `on_event:` mappings. Add a scenario that exercises the new path. Assertion shape stays the same — extend `min_calls` and the `sequence` to match.

--- a/examples/workflow-order-processing/config.arena.yaml
+++ b/examples/workflow-order-processing/config.arena.yaml
@@ -19,6 +19,7 @@ spec:
   scenarios:
     - file: scenarios/order-flow.scenario.yaml
     - file: scenarios/validation-checks.scenario.yaml
+    - file: scenarios/unit-fulfillment-stage.scenario.yaml
 
   workflow:
     version: 1

--- a/examples/workflow-order-processing/mock-responses.yaml
+++ b/examples/workflow-order-processing/mock-responses.yaml
@@ -42,6 +42,12 @@ scenarios:
       # Pipeline turn 4: Customer confirms
       7: "Thank you for shopping with ShopCo! We hope you enjoy your Wireless Headphones. If you need anything, we're here to help."
 
+  # Single-turn stage unit test. No transition — the turn stays in the pinned
+  # 'fulfillment' stage so the state_is assertion can observe it directly.
+  unit-fulfillment-stage:
+    turns:
+      1: "Your package has shipped and is on its way! Tracking number: TRACK-33333. Estimated delivery: 2-3 business days."
+
   validation-checks:
     turns:
       # Pipeline turn 1: Order placed -> transition to payment

--- a/examples/workflow-order-processing/scenarios/unit-fulfillment-stage.scenario.yaml
+++ b/examples/workflow-order-processing/scenarios/unit-fulfillment-stage.scenario.yaml
@@ -1,0 +1,20 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: unit-fulfillment-stage
+spec:
+  id: unit-fulfillment-stage
+  # Unit-test a single workflow stage in isolation. Pinning task_type to a
+  # non-entry stage starts the per-run state machine there instead of the
+  # workflow entry, so this turn exercises the `fulfillment` prompt directly —
+  # no need to drive the whole new_order -> payment -> fulfillment flow first.
+  task_type: fulfillment
+  description: "Single-stage unit test: pins the non-entry 'fulfillment' stage."
+  turns:
+    - role: user
+      content: "Where is my package?"
+      assertions:
+        # Proves the scenario started in 'fulfillment', not the entry 'new_order'.
+        - type: state_is
+          params:
+            state: fulfillment

--- a/tools/arena/engine/execution.go
+++ b/tools/arena/engine/execution.go
@@ -409,7 +409,11 @@ func (e *Engine) executeRun(ctx context.Context, combo RunCombination) (string, 
 	if e.workflowSpec != nil {
 		wfScenario := *scenario
 		scenario = &wfScenario
-		workflowOrch = e.prepareWorkflowScenario(scenario, runID)
+		var prepErr error
+		workflowOrch, prepErr = e.prepareWorkflowScenario(scenario, runID)
+		if prepErr != nil {
+			return saveError(prepErr.Error())
+		}
 		runCtx = withWorkflowScenarioID(runCtx, runID)
 		defer e.workflowTransExec.UnregisterRun(runID)
 	}

--- a/tools/arena/engine/execution_integration_test.go
+++ b/tools/arena/engine/execution_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	runtimestore "github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
 )
 
@@ -64,6 +65,31 @@ func TestEngine_ExecuteRun_ScenarioNotFound(t *testing.T) {
 	result, err := e.stateStore.(*statestore.ArenaStateStore).GetResult(ctx, runID)
 	require.NoError(t, err)
 	assert.Contains(t, result.Error, "scenario not found: missing-scenario")
+}
+
+func TestEngine_ExecuteRun_WorkflowBadTaskTypeFailsLoudly(t *testing.T) {
+	ctx := context.Background()
+	spec := testWorkflowSpec() // entry "intake"; states intake/specialist/closed
+	e := &Engine{
+		config:            &config.Config{},
+		scenarios:         map[string]*config.Scenario{"sc": {ID: "sc", TaskType: "bogus"}},
+		evals:             make(map[string]*config.Eval),
+		providers:         make(map[string]*config.Provider),
+		providerRegistry:  providers.NewRegistry(),
+		stateStore:        statestore.NewArenaStateStore(),
+		eventBus:          events.NewEventBus(),
+		workflowSpec:      spec,
+		workflowTransExec: newWorkflowTransitionExecutor(spec, tools.NewRegistry()),
+	}
+
+	combo := RunCombination{ScenarioID: "sc", ProviderID: "p", Region: "default"}
+	runID, err := e.executeRun(ctx, combo)
+	require.NoError(t, err) // resolution error is saved as a failed result, not returned
+	assert.NotEmpty(t, runID)
+
+	result, err := e.stateStore.(*statestore.ArenaStateStore).GetResult(ctx, runID)
+	require.NoError(t, err)
+	assert.Contains(t, result.Error, "bogus", "unknown task_type must surface as a run error, not a silent reroute")
 }
 
 func TestEngine_ExecuteRun_ProviderNotFound(t *testing.T) {

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -3,6 +3,9 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -14,6 +17,62 @@ import (
 )
 
 const roleSystem = "system"
+
+// resolveWorkflowStartState maps a scenario's task_type to the workflow state it
+// should start in. An empty task_type defaults to the workflow entry. A task_type
+// matching the entry state's prompt_task resolves to the entry (which also
+// disambiguates when several states share a prompt_task). A task_type matching
+// exactly one non-entry state pins that state — enabling single-stage unit tests.
+// No match, or an ambiguous non-entry match, is a hard error so the previously
+// silent override surfaces as a clear config failure.
+func resolveWorkflowStartState(spec *workflow.Spec, taskType string) (string, error) {
+	if taskType == "" {
+		return spec.Entry, nil
+	}
+	if entry := spec.States[spec.Entry]; entry != nil && entry.PromptTask == taskType {
+		return spec.Entry, nil
+	}
+
+	var matches []string
+	for name, st := range spec.States {
+		if st != nil && st.PromptTask == taskType {
+			matches = append(matches, name)
+		}
+	}
+	sort.Strings(matches)
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf(
+			"scenario task_type %q matches no workflow state's prompt_task (valid: %s)",
+			taskType, strings.Join(workflowPromptTasks(spec), ", "))
+	default:
+		return "", fmt.Errorf(
+			"scenario task_type %q is ambiguous: matches workflow states %s (give them distinct prompt_task values)",
+			taskType, strings.Join(matches, ", "))
+	}
+}
+
+// workflowPromptTasks returns the sorted, de-duplicated prompt_task values
+// declared across a workflow spec's states, for error diagnostics.
+func workflowPromptTasks(spec *workflow.Spec) []string {
+	seen := make(map[string]struct{}, len(spec.States))
+	tasks := make([]string, 0, len(spec.States))
+	for _, st := range spec.States {
+		if st == nil {
+			continue
+		}
+		if _, ok := seen[st.PromptTask]; ok {
+			continue
+		}
+		seen[st.PromptTask] = struct{}{}
+		tasks = append(tasks, st.PromptTask)
+	}
+	sort.Strings(tasks)
+	return tasks
+}
 
 // initWorkflow parses the workflow config and registers the workflow__transition
 // tool in the tool registry. Called during engine initialization when config.Workflow
@@ -64,14 +123,21 @@ func (e *Engine) initWorkflow() error {
 // Called from executeRun before ConversationExecutor.ExecuteConversation().
 // prepareWorkflowScenario returns a per-run EvalOrchestrator clone with the
 // workflow metadata provider set. The caller should set it on the ConversationRequest.
-func (e *Engine) prepareWorkflowScenario(scenario *config.Scenario, runID string) *EvalOrchestrator {
+func (e *Engine) prepareWorkflowScenario(scenario *config.Scenario, runID string) (*EvalOrchestrator, error) {
 	if e.workflowSpec == nil {
-		return nil
+		return nil, nil
 	}
 
-	// Set TaskType to entry state's prompt_task
-	if entryState := e.workflowSpec.States[e.workflowSpec.Entry]; entryState != nil {
-		scenario.TaskType = entryState.PromptTask
+	// Resolve which workflow state this scenario starts in. An explicit
+	// task_type pins a stage (enabling single-stage unit tests); empty defaults
+	// to the entry. A task_type that names no state is a hard error rather than
+	// a silent reroute through the entry.
+	startState, err := resolveWorkflowStartState(e.workflowSpec, scenario.TaskType)
+	if err != nil {
+		return nil, fmt.Errorf("scenario %q: %w", scenario.ID, err)
+	}
+	if st := e.workflowSpec.States[startState]; st != nil {
+		scenario.TaskType = st.PromptTask
 	}
 
 	// Build the per-run emitter once and reuse it for both the
@@ -83,9 +149,10 @@ func (e *Engine) prepareWorkflowScenario(scenario *config.Scenario, runID string
 		emitter = events.NewEmitter(e.eventBus, runID, runID, runID)
 	}
 
-	// Register a per-run state machine for concurrent scenario execution
+	// Register a per-run state machine for concurrent scenario execution,
+	// started at the resolved stage.
 	if e.workflowTransExec != nil {
-		e.workflowTransExec.RegisterRunWithEmitter(runID, scenario, emitter)
+		e.workflowTransExec.RegisterRunAtState(runID, scenario, emitter, startState)
 	}
 
 	// Clone the eval orchestrator for this run with per-run workflow metadata.
@@ -104,7 +171,7 @@ func (e *Engine) prepareWorkflowScenario(scenario *config.Scenario, runID string
 		}
 	}
 
-	return orch
+	return orch, nil
 }
 
 // enrichMessagesWithWorkflowState adds _workflow_state metadata to assistant messages

--- a/tools/arena/engine/workflow_start_state_test.go
+++ b/tools/arena/engine/workflow_start_state_test.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/workflow"
+)
+
+func threeStageSpec() *workflow.Spec {
+	return &workflow.Spec{
+		Entry: "extract",
+		States: map[string]*workflow.State{
+			"extract":    {PromptTask: "extract"},
+			"categorize": {PromptTask: "categorize"},
+			"compose":    {PromptTask: "compose"},
+		},
+	}
+}
+
+func TestResolveWorkflowStartState_EmptyTaskTypeDefaultsToEntry(t *testing.T) {
+	got, err := resolveWorkflowStartState(threeStageSpec(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "extract", got)
+}
+
+func TestResolveWorkflowStartState_EntryMatch(t *testing.T) {
+	got, err := resolveWorkflowStartState(threeStageSpec(), "extract")
+	require.NoError(t, err)
+	assert.Equal(t, "extract", got)
+}
+
+func TestResolveWorkflowStartState_NonEntryStage(t *testing.T) {
+	got, err := resolveWorkflowStartState(threeStageSpec(), "compose")
+	require.NoError(t, err)
+	assert.Equal(t, "compose", got, "should pin the non-entry stage")
+}
+
+func TestResolveWorkflowStartState_NoMatchErrors(t *testing.T) {
+	_, err := resolveWorkflowStartState(threeStageSpec(), "composer") // typo
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "composer")
+}
+
+// Entry match wins even when another state shares the entry's prompt_task,
+// keeping the common case unambiguous.
+func TestResolveWorkflowStartState_EntryWinsOnSharedPromptTask(t *testing.T) {
+	spec := &workflow.Spec{
+		Entry: "extract",
+		States: map[string]*workflow.State{
+			"extract": {PromptTask: "shared"},
+			"other":   {PromptTask: "shared"},
+		},
+	}
+	got, err := resolveWorkflowStartState(spec, "shared")
+	require.NoError(t, err)
+	assert.Equal(t, "extract", got)
+}
+
+func TestResolveWorkflowStartState_AmbiguousNonEntryErrors(t *testing.T) {
+	spec := &workflow.Spec{
+		Entry: "extract",
+		States: map[string]*workflow.State{
+			"extract": {PromptTask: "extract"},
+			"a":       {PromptTask: "dup"},
+			"b":       {PromptTask: "dup"},
+		},
+	}
+	_, err := resolveWorkflowStartState(spec, "dup")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -85,9 +86,19 @@ func (e *workflowTransitionExecutor) RegisterRun(runID string, scenario *config.
 func (e *workflowTransitionExecutor) RegisterRunWithEmitter(
 	runID string, scenario *config.Scenario, emitter *events.Emitter,
 ) {
+	e.RegisterRunAtState(runID, scenario, emitter, e.wfSpec.Entry)
+}
+
+// RegisterRunAtState is like RegisterRunWithEmitter but starts the per-run state
+// machine at startState instead of the workflow entry. Used to pin a scenario to
+// a single stage for unit testing. Passing the entry is equivalent to
+// RegisterRunWithEmitter.
+func (e *workflowTransitionExecutor) RegisterRunAtState(
+	runID string, scenario *config.Scenario, emitter *events.Emitter, startState string,
+) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sm := workflow.NewStateMachine(e.wfSpec)
+	sm := workflow.NewStateMachineFromContext(e.wfSpec, workflow.NewContext(startState, time.Now()))
 	transExec := workflow.NewTransitionExecutor(sm, e.wfSpec)
 	run := &workflowRunState{
 		transExec: transExec,

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -378,7 +378,8 @@ func TestPrepareWorkflowScenario(t *testing.T) {
 
 	t.Run("nil workflowSpec returns nil", func(t *testing.T) {
 		eng := &Engine{}
-		got := eng.prepareWorkflowScenario(&config.Scenario{ID: "r"}, "r")
+		got, err := eng.prepareWorkflowScenario(&config.Scenario{ID: "r"}, "r")
+		require.NoError(t, err)
 		assert.Nil(t, got)
 	})
 
@@ -390,7 +391,8 @@ func TestPrepareWorkflowScenario(t *testing.T) {
 			workflowTransExec: transExec,
 		}
 		scenario := &config.Scenario{ID: "r"}
-		got := eng.prepareWorkflowScenario(scenario, "r")
+		got, err := eng.prepareWorkflowScenario(scenario, "r")
+		require.NoError(t, err)
 		assert.Nil(t, got, "no orch means assertions fall back to shared orch")
 		assert.Equal(t, "intake", scenario.TaskType, "TaskType must be set to entry state's prompt_task")
 		assert.NotNil(t, transExec.StateMachine("r"), "run must be registered for state-machine isolation")
@@ -409,7 +411,8 @@ func TestPrepareWorkflowScenario(t *testing.T) {
 		}
 
 		scenario := &config.Scenario{ID: "r", TaskType: ""}
-		runOrch := eng.prepareWorkflowScenario(scenario, "r")
+		runOrch, prepErr := eng.prepareWorkflowScenario(scenario, "r")
+		require.NoError(t, prepErr)
 		require.NotNil(t, runOrch)
 		assert.NotSame(t, baseOrch, runOrch, "must clone, not mutate the shared orchestrator")
 		assert.Equal(t, "intake", scenario.TaskType)
@@ -433,6 +436,35 @@ func TestPrepareWorkflowScenario(t *testing.T) {
 			t.Fatal("eventBus must be threaded into provider so metadata-time commits emit events")
 		}
 	})
+}
+
+func TestPrepareWorkflowScenario_PinsNonEntryStage(t *testing.T) {
+	spec := testWorkflowSpec() // entry "intake"; states intake/specialist/closed
+	registry := tools.NewRegistry()
+	transExec := newWorkflowTransitionExecutor(spec, registry)
+	eng := &Engine{workflowSpec: spec, workflowTransExec: transExec}
+
+	scenario := &config.Scenario{ID: "r", TaskType: "specialist"}
+	_, err := eng.prepareWorkflowScenario(scenario, "r")
+	require.NoError(t, err)
+
+	assert.Equal(t, "specialist", scenario.TaskType, "honors the pinned stage")
+	require.NotNil(t, transExec.StateMachine("r"))
+	assert.Equal(t, "specialist", transExec.StateMachine("r").CurrentState(),
+		"state machine starts at the pinned stage, not the entry")
+}
+
+func TestPrepareWorkflowScenario_UnknownTaskTypeErrors(t *testing.T) {
+	spec := testWorkflowSpec()
+	registry := tools.NewRegistry()
+	transExec := newWorkflowTransitionExecutor(spec, registry)
+	eng := &Engine{workflowSpec: spec, workflowTransExec: transExec}
+
+	scenario := &config.Scenario{ID: "r", TaskType: "bogus"}
+	_, err := eng.prepareWorkflowScenario(scenario, "r")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bogus")
+	assert.Nil(t, transExec.StateMachine("r"), "must not register the run on resolution failure")
 }
 
 func TestCommitPendingTransition_SetsSkillFilter(t *testing.T) {


### PR DESCRIPTION
## Summary

When a config defines a `workflow:`, every scenario was forced to start at the workflow entry and its `task_type` was **silently discarded** (`execution_workflow_integration.go`). You couldn't unit-test a single non-entry stage, and a scenario could appear to test one stage while actually evaluating another (the promptpack-demo incident: `task_type: compose` scenarios silently ran through `extract`, mock-masked).

This honors the scenario's `task_type` as its workflow **start stage**.

## How it works

`task_type` already *is* the per-turn stage selector — the workflow sets `scenario.TaskType = state.PromptTask` on entry and every transition — so no new field is introduced (per design discussion, a separate `start_state` would just duplicate it).

- **`resolveWorkflowStartState`** maps `task_type` → the state whose `prompt_task` matches. Empty → entry (unchanged). Entry-match → entry (covers the common case where scenarios pin the entry, and disambiguates shared prompt_tasks).
- The per-run **state machine starts in that stage** (`RegisterRunAtState` → `NewStateMachineFromContext`), so `state_is`/`transitioned_to` stay truthful rather than reporting the entry while running another stage's prompt.
- **Fail loud**: a `task_type` that names no state's `prompt_task` is a hard error at run time (and ambiguous non-entry matches error too) — the previously silent override now surfaces as a clear failure.

Full-lifecycle and single-stage scenarios coexist in one config.

## Tests / verification

- Unit: `resolveWorkflowStartState` (6 cases), `prepareWorkflowScenario` pinning + fail-loud (drives the real state machine), and `executeRun` fail-loud propagation.
- `go build ./...`, full `tools/arena/engine` suite, `golangci-lint` — clean; execution.go coverage 81.4%.
- End-to-end: new `unit-fulfillment-stage` scenario in `workflow-order-processing` pins the non-entry `fulfillment` stage with a `state_is: fulfillment` assertion — passes deterministically (3/3) against the published schema. Confirmed the pre-existing multi-turn flakiness in that example is unrelated (clean `main` flakes at the same rate).
- Docs: added a "Unit-testing a single stage" section to the workflow-regression how-to.

Closes #1271
