### PR TITLE
fix(providers): surface Gemini terminal finish reasons; drop tools when tool_choice=none

### DIFF
--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -26,6 +26,7 @@ const (
 	defaultMaxRounds            = 50
 	defaultMaxParallelToolCalls = 10
 	toolChoiceAuto              = "auto"
+	toolChoiceNone              = "none"
 )
 
 // ProviderStage implementation notes:
@@ -1590,6 +1591,15 @@ func (s *ProviderStage) buildProviderTools(
 	// Check if provider supports tools
 	toolProvider, ok := s.provider.(providers.ToolSupport)
 	if !ok {
+		return nil, "", nil
+	}
+
+	// When tool calling is disabled for this turn (tool_choice: none), send no
+	// tool declarations at all. The model cannot call them, so shipping the
+	// declarations only wastes input tokens and — on some models — primes
+	// spurious tool calls. Returning nil routes the provider to its non-tool
+	// path, which omits both the declarations and any tool_config.
+	if s.toolPolicy != nil && s.toolPolicy.ToolChoice == toolChoiceNone {
 		return nil, "", nil
 	}
 

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -1366,6 +1366,28 @@ func TestProviderStage_BuildProviderTools_EmptyAllowedTools(t *testing.T) {
 	assert.Empty(t, toolChoice)
 }
 
+func TestProviderStage_BuildProviderTools_ToolChoiceNoneSendsNoTools(t *testing.T) {
+	// tool_choice: none means the model cannot call tools this turn. Sending
+	// the tool declarations anyway wastes tokens and, on some models, primes
+	// spurious tool calls. buildProviderTools must return nil so the provider
+	// uses the non-tool path and sends no declarations / tool_config.
+	registry := tools.NewRegistry()
+	registry.Register(&tools.ToolDescriptor{
+		Name:        "test_tool",
+		Description: "Test",
+		InputSchema: []byte(`{"type": "object"}`),
+	})
+
+	provider := mock.NewToolProvider("test", "model", false, nil)
+	toolPolicy := &pipeline.ToolPolicy{ToolChoice: "none"}
+	stage := NewProviderStage(provider, registry, toolPolicy, nil)
+
+	providerTools, _, err := stage.buildProviderTools([]string{"test_tool"}, nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, providerTools, "tool_choice=none must not send tool declarations")
+}
+
 func TestProviderStage_BuildProviderTools_NilRegistry(t *testing.T) {
 	// Test that nil registry returns nil tools
 	provider := mock.NewToolProvider("test", "model", false, nil)

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -84,11 +84,9 @@ func (p *Provider) processGeminiStreamChunk(
 	}
 
 	candidate := chunk.Candidates[0]
-	if len(candidate.Content.Parts) == 0 {
-		return totalTokens, toolCalls, false
-	}
 
-	// Process all parts in the candidate
+	// Process all parts in the candidate (a no-op when Parts is empty — an
+	// empty-parts chunk may still carry a terminal finishReason, handled below).
 	for i, part := range candidate.Content.Parts {
 		// Handle text content
 		if part.Text != "" {
@@ -124,6 +122,23 @@ func (p *Provider) processGeminiStreamChunk(
 	}
 
 	if candidate.FinishReason != "" {
+		// A terminal chunk that produced no text and no tool calls across the
+		// whole stream means the model was blocked or refused (SAFETY,
+		// RECITATION, MAX_TOKENS, UNEXPECTED_TOOL_CALL, ...). Surface it as an
+		// error instead of silently emitting an empty success — this mirrors
+		// the non-streaming handleGeminiFinishReason path, which already errors
+		// on a content-less terminal response.
+		if sb.Len() == 0 && len(toolCalls) == 0 {
+			outChan <- providers.StreamChunk{
+				Error: fmt.Errorf(
+					"gemini stream ended with finish reason %q and no content",
+					candidate.FinishReason,
+				),
+				FinishReason: &candidate.FinishReason,
+			}
+			return totalTokens, toolCalls, true
+		}
+
 		finalChunk := providers.StreamChunk{
 			Content:      sb.String(),
 			TokenCount:   totalTokens,

--- a/runtime/providers/gemini/gemini_streaming_test.go
+++ b/runtime/providers/gemini/gemini_streaming_test.go
@@ -257,6 +257,44 @@ func TestStreamResponse_IncrementalParsing(t *testing.T) {
 		}
 	})
 
+	// Regression: a terminal chunk that carries a finishReason but no content
+	// parts must surface as an error, not a silent empty success. Gemini emits
+	// this for UNEXPECTED_TOOL_CALL / SAFETY / RECITATION / MAX_TOKENS. The
+	// non-streaming path (handleGeminiFinishReason) already errors on these;
+	// the streaming path used to swallow them.
+	t.Run("terminal finish reason with no content surfaces an error", func(t *testing.T) {
+		for _, reason := range []string{"UNEXPECTED_TOOL_CALL", "SAFETY", "RECITATION", "MAX_TOKENS"} {
+			t.Run(reason, func(t *testing.T) {
+				responses := []geminiResponse{
+					{
+						Candidates:    []geminiCandidate{{FinishReason: reason}},
+						UsageMetadata: &geminiUsage{PromptTokenCount: 224},
+					},
+				}
+				body := marshalJSONArray(t, responses)
+				outChan := make(chan providers.StreamChunk, 10)
+
+				provider.streamResponse(context.Background(), io.NopCloser(body), outChan)
+
+				chunks := collectChunks(t, outChan)
+
+				var errChunk *providers.StreamChunk
+				for i := range chunks {
+					if chunks[i].Error != nil {
+						errChunk = &chunks[i]
+					}
+				}
+				if errChunk == nil {
+					t.Fatalf("expected an error chunk for content-less %s, got %d chunks: %+v", reason, len(chunks), chunks)
+				}
+				// The surfaced error must name the finish reason for diagnosis.
+				if !strings.Contains(errChunk.Error.Error(), reason) {
+					t.Errorf("error should name finish reason %q, got: %v", reason, errChunk.Error)
+				}
+			})
+		}
+	})
+
 	t.Run("handles tool calls", func(t *testing.T) {
 		responses := []geminiResponse{
 			{


### PR DESCRIPTION
## Why

While verifying the capability-matrix refresh (#1290), `gemini-2.5-flash` audio started failing intermittently. Investigation (timeline from CI artifacts + a controlled direct-API experiment) showed the **model regressed on Google's side** between 2026-05-24 and 2026-05-31 — it now returns `finishReason: UNEXPECTED_TOOL_CALL` on prompts it previously transcribed (`gemini-2.5-flash-lite` and `-pro` are unaffected with the identical request). That model change is outside our code, but it **exposed two genuine latent PromptKit defects** that this PR fixes.

## 1. Gemini streaming silently swallowed terminal finish reasons

`processGeminiStreamChunk` returned early on a candidate with empty content parts **before** checking `finishReason`. So a terminal chunk carrying `UNEXPECTED_TOOL_CALL` / `SAFETY` / `RECITATION` / `MAX_TOKENS` with no content was dropped, and an **empty string was emitted as a `finishReason: "stop"` success.** The non-streaming path (`handleGeminiFinishReason`) already errors on these — only streaming had the gap.

This affected **any SDK caller streaming from Gemini**: safety/recitation/token-limit terminations silently returned empty instead of a clear error. The fix surfaces the reason as an error (named, for diagnosis).

## 2. Tool declarations were sent even when `tool_choice: none`

`buildProviderTools` built and sent the function declarations regardless of tool choice. For a `tool_choice: none` turn the model can't call them — so it was pure **wasted input tokens**, and on some models it primed spurious tool calls (raising the `UNEXPECTED_TOOL_CALL` rate). It now returns nil for `tool_choice: none`, routing the provider to its non-tool path so neither the declarations nor `tool_config` are sent.

## Notes
- Neither fix is the *cause* of the matrix failure (that's Google's model regression); they're real correctness/efficiency defects the regression surfaced. After the fix, the model's behaviour shows up as a **clear `UNEXPECTED_TOOL_CALL` error** instead of a silent empty.
- New unit tests cover both paths (all four terminal reasons; `tool_choice: none` sends no tools). Full provider / pipeline / workflow / sdk / arena suites green; changed-file coverage 89.5% / 93.5%.
