### PR TITLE
fix(openai): de-hardcode model selection — max_completion_tokens, Responses routing, config-first api_mode

### DIFF
--- a/examples/capability-matrix/providers/openai-gpt5-pro.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt5-pro.provider.yaml
@@ -15,6 +15,10 @@ spec:
   unsupported_params:
     - temperature
     - top_p
+  # gpt-5-pro is only served by the Responses API; declare it rather than
+  # relying on the provider's model-name fallback.
+  additional_config:
+    api_mode: responses
   defaults:
     temperature: 0.1
     max_tokens: 100

--- a/examples/capability-matrix/providers/openai-gpt52-pro.provider.yaml
+++ b/examples/capability-matrix/providers/openai-gpt52-pro.provider.yaml
@@ -15,6 +15,10 @@ spec:
   unsupported_params:
     - temperature
     - top_p
+  # gpt-5.2-pro is only served by the Responses API; declare it rather than
+  # relying on the provider's model-name fallback.
+  additional_config:
+    api_mode: responses
   defaults:
     temperature: 0.1
     max_tokens: 100

--- a/examples/capability-matrix/providers/openai-o1-pro.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o1-pro.provider.yaml
@@ -6,6 +6,14 @@ spec:
   id: openai-o1-pro
   type: openai
   model: o1-pro
+  # Declared explicitly so behavior is data-driven, not reliant on the provider's
+  # model-name fallbacks: o-series reject temperature/top_p, and the pro models
+  # are only served by the Responses API.
+  unsupported_params:
+    - temperature
+    - top_p
+  additional_config:
+    api_mode: responses
   capabilities:
     - text
     - streaming

--- a/examples/capability-matrix/providers/openai-o1.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o1.provider.yaml
@@ -6,6 +6,10 @@ spec:
   id: openai-o1
   type: openai
   model: o1
+  # o-series reject temperature/top_p (declared, not relying on the model-name fallback).
+  unsupported_params:
+    - temperature
+    - top_p
   capabilities:
     - text
     - streaming

--- a/examples/capability-matrix/providers/openai-o3-mini.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o3-mini.provider.yaml
@@ -6,6 +6,10 @@ spec:
   id: openai-o3-mini
   type: openai
   model: o3-mini
+  # o-series reject temperature/top_p (declared, not relying on the model-name fallback).
+  unsupported_params:
+    - temperature
+    - top_p
   capabilities:
     - text
     - streaming

--- a/examples/capability-matrix/providers/openai-o3.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o3.provider.yaml
@@ -6,6 +6,10 @@ spec:
   id: openai-o3
   type: openai
   model: o3
+  # o-series reject temperature/top_p (declared, not relying on the model-name fallback).
+  unsupported_params:
+    - temperature
+    - top_p
   capabilities:
     - text
     - streaming

--- a/examples/capability-matrix/providers/openai-o4-mini.provider.yaml
+++ b/examples/capability-matrix/providers/openai-o4-mini.provider.yaml
@@ -6,6 +6,10 @@ spec:
   id: openai-o4-mini
   type: openai
   model: o4-mini
+  # o-series reject temperature/top_p (declared, not relying on the model-name fallback).
+  unsupported_params:
+    - temperature
+    - top_p
   capabilities:
     - text
     - streaming

--- a/runtime/providers/openai/bedrock_unit_test.go
+++ b/runtime/providers/openai/bedrock_unit_test.go
@@ -126,10 +126,11 @@ func TestNewProviderFromConfig_Bedrock(t *testing.T) {
 		}
 	})
 
-	t.Run("auto-adds max_tokens and top_p to unsupportedParams", func(t *testing.T) {
-		// max_tokens — Bedrock OpenAI uses max_completion_tokens.
-		// top_p    — gpt-oss rejects 0.0 and the framework default is 0;
-		//            skipping leaves the model default in place.
+	t.Run("auto-adds top_p to unsupportedParams", func(t *testing.T) {
+		// top_p — gpt-oss rejects 0.0 and the framework default is 0; skipping
+		//         leaves the model default in place.
+		// (The token limit is sent as max_completion_tokens by default for all
+		// OpenAI requests, so it no longer needs to be flagged here.)
 		p := NewProviderFromConfig(&ProviderConfig{
 			ID:       "test",
 			Model:    "openai.gpt-oss-20b-1:0",
@@ -139,11 +140,11 @@ func TestNewProviderFromConfig_Bedrock(t *testing.T) {
 			},
 			Credential: cred,
 		})
-		for _, param := range []string{"max_tokens", "top_p"} {
-			if !hasUnsupportedParam(p.unsupportedParams, param) {
-				t.Errorf("Bedrock provider must mark %s unsupported, got %v",
-					param, p.unsupportedParams)
-			}
+		if !hasUnsupportedParam(p.unsupportedParams, "top_p") {
+			t.Errorf("Bedrock provider must mark top_p unsupported, got %v", p.unsupportedParams)
+		}
+		if hasUnsupportedParam(p.unsupportedParams, "max_tokens") {
+			t.Errorf("Bedrock provider should no longer flag max_tokens, got %v", p.unsupportedParams)
 		}
 	})
 

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -595,6 +595,12 @@ func (p *Provider) convertResponseFormat(rf *providers.ResponseFormat) *openAIRe
 
 // Predict sends a predict request to OpenAI
 func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest) (providers.PredictionResponse, error) {
+	// Responses-only models (gpt-5-pro, o1-pro, ...) 404 on chat/completions.
+	if requiresResponsesAPI(p.model) {
+		resp, _, err := p.predictWithResponses(ctx, req, nil, "")
+		return resp, err
+	}
+
 	// Convert messages to OpenAI format
 	messages, err := p.prepareOpenAIMessages(req)
 	if err != nil {
@@ -670,6 +676,13 @@ func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.Co
 func (p *Provider) PredictStream(ctx context.Context, req providers.PredictionRequest) (<-chan providers.StreamChunk, error) {
 	if p.isBedrock() {
 		return p.predictStreamBedrockFallback(ctx, req)
+	}
+
+	// Responses-only models (gpt-5-pro, o1-pro, ...) 404 on chat/completions,
+	// so the non-tool streaming path must use the Responses API for them too
+	// (the tool path already does).
+	if requiresResponsesAPI(p.model) {
+		return p.predictStreamWithResponses(ctx, req, nil, "")
 	}
 
 	// Convert messages to OpenAI format

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -61,13 +61,17 @@ func hasUnsupportedParam(unsupported []string, param string) bool {
 	return false
 }
 
-// addMaxTokensToRequest adds the appropriate max tokens parameter to the request.
-// If "max_tokens" is in unsupportedParams, uses "max_completion_tokens" instead.
+// addMaxTokensToRequest sets the output-token limit using OpenAI's current
+// parameter name, "max_completion_tokens". Newer models (GPT-5, o-series)
+// require it and every current model accepts it, so it is the default rather
+// than something gated on a hardcoded model-family check. Legacy or
+// OpenAI-compatible backends that only accept the deprecated "max_tokens" opt
+// out via unsupported_params: ["max_completion_tokens"].
 func addMaxTokensToRequest(req map[string]interface{}, unsupportedParams []string, maxTokens int) {
-	if hasUnsupportedParam(unsupportedParams, "max_tokens") {
-		req["max_completion_tokens"] = maxTokens
-	} else {
+	if hasUnsupportedParam(unsupportedParams, "max_completion_tokens") {
 		req["max_tokens"] = maxTokens
+	} else {
+		req["max_completion_tokens"] = maxTokens
 	}
 }
 
@@ -179,18 +183,18 @@ func NewProviderFromConfig(cfg *ProviderConfig) *Provider {
 	}
 
 	unsupported := cfg.UnsupportedParams
+	// o-series reasoning models don't accept temperature/top_p. (The output
+	// token limit is handled uniformly by addMaxTokensToRequest, which already
+	// defaults to max_completion_tokens, so it's not listed here.)
 	if len(unsupported) == 0 && isOSeriesModel(cfg.Model) {
-		unsupported = []string{"temperature", "top_p", "max_tokens"}
+		unsupported = []string{"temperature", "top_p"}
 	}
-	// Bedrock-hosted OpenAI (gpt-oss family) requires max_completion_tokens
-	// instead of max_tokens, and rejects `top_p: 0.0` (must be in (0, 1]).
-	// Skip both fields by default so the model picks its own; operators
-	// can still override the full unsupported set via UnsupportedParams.
+	// Bedrock-hosted OpenAI (gpt-oss family) rejects `top_p: 0.0` (must be in
+	// (0, 1]). Skip it by default so the model picks its own; operators can
+	// still override the full unsupported set via UnsupportedParams.
 	if len(cfg.UnsupportedParams) == 0 && cfg.Platform == bedrockPlatform {
-		for _, param := range []string{"max_tokens", "top_p"} {
-			if !hasUnsupportedParam(unsupported, param) {
-				unsupported = append(unsupported, param)
-			}
+		if !hasUnsupportedParam(unsupported, "top_p") {
+			unsupported = append(unsupported, "top_p")
 		}
 	}
 

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -43,7 +43,8 @@ const (
 const oSeriesMinLen = 2
 
 // isOSeriesModel checks if a model is an OpenAI o-series reasoning model.
-// O-series models (o1, o3, o4, etc.) don't support temperature, top_p, or max_tokens.
+// O-series models (o1, o3, o4, etc.) don't support temperature or top_p. Used
+// only as a fallback when a provider config doesn't declare unsupported_params.
 func isOSeriesModel(model string) bool {
 	if len(model) < oSeriesMinLen {
 		return false
@@ -183,9 +184,11 @@ func NewProviderFromConfig(cfg *ProviderConfig) *Provider {
 	}
 
 	unsupported := cfg.UnsupportedParams
-	// o-series reasoning models don't accept temperature/top_p. (The output
-	// token limit is handled uniformly by addMaxTokensToRequest, which already
-	// defaults to max_completion_tokens, so it's not listed here.)
+	// Fallback for configs that don't declare unsupported_params: o-series
+	// reasoning models don't accept temperature/top_p. Prefer declaring this in
+	// the provider config; the model-name check is only a best-effort default.
+	// (The output token limit is handled uniformly by addMaxTokensToRequest,
+	// which defaults to max_completion_tokens, so it's not listed here.)
 	if len(unsupported) == 0 && isOSeriesModel(cfg.Model) {
 		unsupported = []string{"temperature", "top_p"}
 	}
@@ -595,8 +598,10 @@ func (p *Provider) convertResponseFormat(rf *providers.ResponseFormat) *openAIRe
 
 // Predict sends a predict request to OpenAI
 func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest) (providers.PredictionResponse, error) {
-	// Responses-only models (gpt-5-pro, o1-pro, ...) 404 on chat/completions.
-	if requiresResponsesAPI(p.model) {
+	// Route to the Responses API when selected (config or the requiresResponsesAPI
+	// fallback, via getAPIMode), mirroring PredictWithTools. Responses-only
+	// models (gpt-5-pro, o1-pro, ...) 404 on chat/completions.
+	if p.apiMode == APIModeResponses {
 		resp, _, err := p.predictWithResponses(ctx, req, nil, "")
 		return resp, err
 	}
@@ -678,10 +683,10 @@ func (p *Provider) PredictStream(ctx context.Context, req providers.PredictionRe
 		return p.predictStreamBedrockFallback(ctx, req)
 	}
 
-	// Responses-only models (gpt-5-pro, o1-pro, ...) 404 on chat/completions,
-	// so the non-tool streaming path must use the Responses API for them too
-	// (the tool path already does).
-	if requiresResponsesAPI(p.model) {
+	// Route to the Responses API when selected (config or the requiresResponsesAPI
+	// fallback, via getAPIMode), mirroring PredictStreamWithTools. Responses-only
+	// models (gpt-5-pro, o1-pro, ...) 404 on chat/completions.
+	if p.apiMode == APIModeResponses {
 		return p.predictStreamWithResponses(ctx, req, nil, "")
 	}
 

--- a/runtime/providers/openai/openai_helpers_test.go
+++ b/runtime/providers/openai/openai_helpers_test.go
@@ -755,18 +755,27 @@ func TestAddMaxTokensToRequest(t *testing.T) {
 		unsupportedParams []string
 		maxTokens         int
 		wantKey           string
+		absentKey         string
 	}{
 		{
-			name:              "no unsupported params — uses max_tokens",
+			// max_completion_tokens is OpenAI's current token param: newer
+			// models (GPT-5, o-series) require it and every current model
+			// accepts it. It is the default so we don't have to enumerate
+			// model families.
+			name:              "default — uses max_completion_tokens",
 			unsupportedParams: nil,
 			maxTokens:         500,
-			wantKey:           "max_tokens",
+			wantKey:           "max_completion_tokens",
+			absentKey:         "max_tokens",
 		},
 		{
-			name:              "max_tokens unsupported — uses max_completion_tokens",
-			unsupportedParams: []string{"max_tokens"},
+			// Legacy / OpenAI-compatible backends that only speak max_tokens
+			// opt out explicitly.
+			name:              "max_completion_tokens opted out — uses legacy max_tokens",
+			unsupportedParams: []string{"max_completion_tokens"},
 			maxTokens:         500,
-			wantKey:           "max_completion_tokens",
+			wantKey:           "max_tokens",
+			absentKey:         "max_completion_tokens",
 		},
 	}
 
@@ -780,6 +789,9 @@ func TestAddMaxTokensToRequest(t *testing.T) {
 			}
 			if req[tt.wantKey] != tt.maxTokens {
 				t.Errorf("%s = %v, want %d", tt.wantKey, req[tt.wantKey], tt.maxTokens)
+			}
+			if _, ok := req[tt.absentKey]; ok {
+				t.Errorf("did not expect key %q in request, got keys: %v", tt.absentKey, req)
 			}
 		})
 	}

--- a/runtime/providers/openai/openai_multimodal_test.go
+++ b/runtime/providers/openai/openai_multimodal_test.go
@@ -1234,30 +1234,46 @@ func TestOpenAIProvider_AudioNotSupportedOnNonAudioModel(t *testing.T) {
 func TestOpenAIProvider_APIMode_Configuration(t *testing.T) {
 	tests := []struct {
 		name             string
+		model            string
 		additionalConfig map[string]any
 		expectedAPIMode  string
 	}{
 		{
-			name:             "default is responses",
+			name:             "default is legacy completions when undeclared",
+			model:            "gpt-4o",
 			additionalConfig: nil,
-			expectedAPIMode:  "responses",
+			expectedAPIMode:  "completions",
 		},
 		{
 			name:             "explicit completions",
+			model:            "gpt-4o",
 			additionalConfig: map[string]any{"api_mode": "completions"},
 			expectedAPIMode:  "completions",
 		},
 		{
 			name:             "explicit responses",
+			model:            "gpt-4o",
 			additionalConfig: map[string]any{"api_mode": "responses"},
 			expectedAPIMode:  "responses",
+		},
+		{
+			name:             "responses-only model falls back to responses when undeclared",
+			model:            "gpt-5-pro",
+			additionalConfig: nil,
+			expectedAPIMode:  "responses",
+		},
+		{
+			name:             "explicit config wins over the model fallback",
+			model:            "gpt-5-pro",
+			additionalConfig: map[string]any{"api_mode": "completions"},
+			expectedAPIMode:  "completions",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := NewProviderWithConfig(
-				"test", "gpt-4o", "https://api.openai.com/v1",
+				"test", tt.model, "https://api.openai.com/v1",
 				providers.ProviderDefaults{}, false,
 				tt.additionalConfig,
 			)

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -53,11 +53,13 @@ const (
 // APIMode represents the OpenAI API mode to use
 type APIMode string
 
-// requiresResponsesAPI returns true if the model only works with the Responses API.
-// Some models like o1-pro are only available via v1/responses.
+// requiresResponsesAPI returns true if the model is only served by the Responses
+// API. OpenAI's "pro" reasoning models (o1-pro, gpt-5-pro, gpt-5.2-pro, ...) all
+// 404 on v1/chat/completions and must use v1/responses. This is a genuine,
+// OpenAI-defined model property (not a behavior we can default), so it's keyed
+// off the "-pro" suffix that those models share rather than enumerated one by one.
 func requiresResponsesAPI(model string) bool {
-	// o1-pro requires the Responses API
-	return model == "o1-pro"
+	return strings.HasSuffix(model, "-pro")
 }
 
 // transformToResponsesCallID converts a call ID to Responses API format.

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -78,18 +78,15 @@ func transformToResponsesCallID(callID string) string {
 	return "fc_" + callID
 }
 
-// getAPIMode determines which API to use based on config and model.
-// Priority:
-//  1. Model requirement (o1-pro requires responses)
-//  2. Explicit config setting
-//  3. Default to Responses API
+// getAPIMode determines which OpenAI API to use. Priority:
+//  1. Explicit config (additional_config.api_mode) — data-driven, always wins.
+//  2. requiresResponsesAPI fallback — for Responses-only models when the
+//     config doesn't declare a mode.
+//  3. Default to the legacy Chat Completions API.
+//
+// Config-first ordering means a provider config is the source of truth; the
+// model-name heuristic is only a best-effort default for undeclared configs.
 func getAPIMode(model string, additionalConfig map[string]any) APIMode {
-	// If model requires Responses API, use it regardless of config
-	if requiresResponsesAPI(model) {
-		return APIModeResponses
-	}
-
-	// Check explicit config for legacy API
 	if additionalConfig != nil {
 		if mode, ok := additionalConfig["api_mode"].(string); ok {
 			switch strings.ToLower(mode) {
@@ -101,8 +98,11 @@ func getAPIMode(model string, additionalConfig map[string]any) APIMode {
 		}
 	}
 
-	// Default to Responses API
-	return APIModeResponses
+	if requiresResponsesAPI(model) {
+		return APIModeResponses
+	}
+
+	return APIModeCompletions
 }
 
 // Responses API response structures

--- a/runtime/providers/openai/openai_responses_integration_test.go
+++ b/runtime/providers/openai/openai_responses_integration_test.go
@@ -6,12 +6,58 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// TestPredictStream_RoutesToResponsesAPI verifies that the non-tool streaming
+// path honors api_mode: responses and hits /responses, not /chat/completions.
+// Regression: Responses-only models (gpt5-pro, o1-pro) 404 on chat/completions,
+// and PredictStream (unlike PredictStreamWithTools) never routed to Responses.
+func TestPredictStream_RoutesToResponsesAPI(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n")
+	}))
+	defer server.Close()
+
+	provider := NewProviderWithConfig(
+		"test", "gpt-5-pro", server.URL,
+		providers.ProviderDefaults{MaxTokens: 100}, false,
+		map[string]any{"api_mode": "responses"},
+	)
+
+	ch, err := provider.PredictStream(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream: %v", err)
+	}
+	var content string
+	for chunk := range ch {
+		if chunk.Content != "" {
+			content = chunk.Content
+		}
+	}
+
+	if gotPath != "/responses" {
+		t.Errorf("expected request to /responses, got %q", gotPath)
+	}
+	if content != "hi" {
+		t.Errorf("expected content %q, got %q", "hi", content)
+	}
+}
 
 // TestBuildResponsesRequest_ReasoningEffort verifies that reasoning_effort
 // configured via additional_config is sent as reasoning.effort in Responses

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -767,8 +767,8 @@ func TestOpenAIToolProvider_BuildToolRequest_AppliesDefaults(t *testing.T) {
 				t.Errorf("Expected top_p %.2f, got %v", tt.expectedTopP, request["top_p"])
 			}
 
-			if maxTokens, ok := request["max_tokens"].(int); !ok || maxTokens != tt.expectedMaxTokens {
-				t.Errorf("Expected max_tokens %d, got %v", tt.expectedMaxTokens, request["max_tokens"])
+			if maxTokens, ok := request["max_completion_tokens"].(int); !ok || maxTokens != tt.expectedMaxTokens {
+				t.Errorf("Expected max_completion_tokens %d, got %v", tt.expectedMaxTokens, request["max_completion_tokens"])
 			}
 		})
 	}


### PR DESCRIPTION
The capability matrix (run on main after the Gemini fixes) surfaced two OpenAI API drifts, both rooted in **hardcoded model selection**. This PR fixes them and then removes the broader class of model-name guessing in the provider.

## 1. Token param → `max_completion_tokens` (29 matrix errors)
GPT-5 family failed: `Unsupported parameter: 'max_tokens' … use 'max_completion_tokens'`. The provider only switched when `isOSeriesModel` (`o[0-9]…`) matched, so GPT-5 fell through to the deprecated `max_tokens`. **Fix:** default to `max_completion_tokens` (accepted by gpt-4o/4.1/5/o3-mini alike); opt out via `unsupported_params:[max_completion_tokens]`. There *is* a universal answer here, so no model selection is needed at all.

## 2. Responses-API routing for pro models (11 matrix errors)
`gpt-5-pro`/`gpt-5.2-pro`/`o1-pro` now 404 on chat/completions. The tool paths already used the (existing) Responses-API implementation; non-tool `Predict`/`PredictStream` didn't. **Fix:** route them too.

## 3. De-hardcode: config-first API-mode selection
There's no universal answer for "which models are Responses-only" or "which reject temperature" — OpenAI doesn't expose it — so the choice is *smart-but-stale heuristic* vs *explicit config*. This makes **config the source of truth**:
- `getAPIMode` resolves `additional_config.api_mode` FIRST, then the `requiresResponsesAPI` fallback, then defaults to **Chat Completions** (was: default Responses, which made the heuristic un-overridable).
- `Predict`/`PredictStream` route on the resolved `apiMode`, like the tool paths.
- `isOSeriesModel` / `requiresResponsesAPI` are relabeled as fallbacks-when-undeclared.
- The capability-matrix o-series configs declare `unsupported_params:[temperature, top_p]`; pro configs declare `api_mode: responses`. Matrix behavior is now data-driven and won't silently break when a heuristic goes stale — the exact failure mode that started this.

Remaining model-name logic is documented as fallback-only (audio `isAudioModel` is already superseded by declared `capabilities`; `CalculateCost`/embedding switches are pricing fallbacks, not behavior).

## Verified
Direct API + live through PromptKit: gpt-5 / gpt-5.5 / gpt-4o (incl. tools) via chat/completions; gpt-5-pro / gpt-5.2-pro / o1-pro / o1 / o3-mini via v1/responses — all pass. Unit tests for token-param, PredictStream→/responses routing, and config-first apiMode. Full provider suite green; coverage 91%.

Resolves 40 of 42 matrix errors; residual ~2 are flaky Gemini content assertions.
