### PR TITLE
fix(arena): per-scenario template variables reach the system prompt (#1292)

### DIFF
--- a/runtime/prompt/registry.go
+++ b/runtime/prompt/registry.go
@@ -630,11 +630,14 @@ func (r *Registry) mergeVars(config *Config, vars map[string]string) map[string]
 	// Pre-allocate with known capacity for better performance
 	result := make(map[string]string, len(config.Spec.Variables)+len(vars))
 
-	// Start with variable defaults
+	// Start with variable defaults. An optional variable with an explicitly-set
+	// default (including an empty string) registers so a {{var}} reference
+	// renders to that value instead of the renderer hard-erroring on an
+	// unresolved placeholder. A nil Default means "no default given" and is
+	// skipped.
 	for _, v := range config.Spec.Variables {
 		if !v.Required && v.Default != nil {
-			// Convert default value to string (skip empty strings)
-			if defaultStr, ok := v.Default.(string); ok && defaultStr != "" {
+			if defaultStr, ok := v.Default.(string); ok {
 				result[v.Name] = defaultStr
 			}
 		}

--- a/runtime/prompt/registry_test.go
+++ b/runtime/prompt/registry_test.go
@@ -716,6 +716,28 @@ func TestRegistry_MergeVars(t *testing.T) {
 				"var1": "value1",
 			},
 		},
+		{
+			// Issue #1292: an optional var with an explicit empty-string
+			// default must register (as empty), so a {{var}} reference renders
+			// to "" instead of the renderer hard-erroring on an unresolved
+			// placeholder. A var with no default at all (nil) still doesn't
+			// register.
+			name: "optional var with empty-string default registers as empty",
+			config: &Config{
+				Spec: Spec{
+					Variables: []VariableMetadata{
+						{Name: "opt_empty", Required: false, Type: "string", Default: ""},
+						{Name: "opt_nodefault", Required: false, Type: "string"},
+						{Name: "opt_set", Required: false, Type: "string", Default: "x"},
+					},
+				},
+			},
+			vars: map[string]string{},
+			expected: map[string]string{
+				"opt_empty": "",
+				"opt_set":   "x",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -298,14 +298,28 @@ func (ce *DefaultConversationExecutor) buildTurnRequest(req ConversationRequest,
 		maxTokens = 0
 	}
 
-	// Look up variable overrides from arena.yaml for this scenario's task_type
+	// Build template vars: arena.yaml prompt-config vars (matched by task_type)
+	// overlaid with the scenario's own Variables block (scenario wins). Issue
+	// #1292: Scenario.Variables was previously ignored here. Copy into a fresh
+	// map so the shared LoadedPromptConfigs vars are never mutated.
 	var promptVars map[string]string
 	if req.Config != nil && req.Scenario != nil {
 		for _, promptConfigData := range req.Config.LoadedPromptConfigs {
 			if promptConfigData.TaskType == req.Scenario.TaskType {
-				promptVars = promptConfigData.Vars
+				promptVars = make(map[string]string, len(promptConfigData.Vars))
+				for k, v := range promptConfigData.Vars {
+					promptVars[k] = v
+				}
 				break
 			}
+		}
+	}
+	if scenarioVars := scenarioVariables(req.Scenario); len(scenarioVars) > 0 {
+		if promptVars == nil {
+			promptVars = make(map[string]string, len(scenarioVars))
+		}
+		for k, v := range scenarioVars {
+			promptVars[k] = v
 		}
 	}
 

--- a/tools/arena/engine/conversation_executor_vars_test.go
+++ b/tools/arena/engine/conversation_executor_vars_test.go
@@ -381,6 +381,70 @@ func TestBuildTurnRequest_StateStoreConfig(t *testing.T) {
 	}
 }
 
+// TestBuildTurnRequest_ScenarioVariablesMerged covers issue #1292: a scenario's
+// own Variables block must be merged into the render vars (scenario wins over
+// arena prompt-config vars), including empty-string values — which is how a
+// prompt fragment gets scoped to specific scenarios.
+func TestBuildTurnRequest_ScenarioVariablesMerged(t *testing.T) {
+	executor := NewDefaultConversationExecutor(nil, nil, nil, createTestPromptRegistry(t), nil)
+
+	tests := []struct {
+		name          string
+		loadedConfigs map[string]*config.PromptConfigData
+		taskType      string
+		scenarioVars  map[string]string
+		expectedVars  map[string]string
+	}{
+		{
+			name: "scenario variables override arena prompt-config vars",
+			loadedConfigs: map[string]*config.PromptConfigData{
+				"support": {TaskType: "support", Vars: map[string]string{
+					"tone":    "formal",
+					"product": "CloudSync",
+				}},
+			},
+			taskType:     "support",
+			scenarioVars: map[string]string{"tone": "casual", "extra": "y"},
+			expectedVars: map[string]string{"tone": "casual", "product": "CloudSync", "extra": "y"},
+		},
+		{
+			name:          "scenario variables apply with no arena prompt-config (incl. empty value)",
+			loadedConfigs: map[string]*config.PromptConfigData{},
+			taskType:      "support",
+			scenarioVars:  map[string]string{"tool_instructions": ""},
+			expectedVars:  map[string]string{"tool_instructions": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ConversationRequest{
+				Config: &config.Config{
+					LoadedPromptConfigs: tt.loadedConfigs,
+					ConfigDir:           "/test",
+					Defaults:            config.Defaults{Temperature: 0.7},
+				},
+				Scenario: &config.Scenario{
+					TaskType:  tt.taskType,
+					Variables: tt.scenarioVars,
+				},
+				Provider: &MockProvider{id: "test"},
+			}
+
+			turnReq := executor.buildTurnRequest(req, config.TurnDefinition{Role: "user", Content: "x"})
+
+			if len(turnReq.PromptVars) != len(tt.expectedVars) {
+				t.Fatalf("expected %d vars, got %d (%v)", len(tt.expectedVars), len(turnReq.PromptVars), turnReq.PromptVars)
+			}
+			for k, v := range tt.expectedVars {
+				if got, ok := turnReq.PromptVars[k]; !ok || got != v {
+					t.Errorf("var %q: expected %q, got %q (present=%v)", k, v, got, ok)
+				}
+			}
+		})
+	}
+}
+
 // MockProvider for testing (reuse from conversation_executor_test.go)
 var _ providers.Provider = (*MockTestProvider)(nil)
 


### PR DESCRIPTION
Closes #1292.

Two independent defects meant "declare an optional variable and set it per scenario" silently failed in the main conversation path (discovered scoping a tool-calling instruction to only tool scenarios during the capability-matrix work; worked around there with a separate prompt file).

## Bug 1 — empty-string defaults dropped (`runtime/prompt/registry.go`)
`mergeVars` only registered an optional var's default when it was non-empty, so a `{{var}}` reference to an optional var with `default: ""` hard-errored as an unresolved placeholder. Now an explicitly-set default (including `""`) registers; a nil default (none given) is still skipped.

## Bug 2 — `Scenario.Variables` not wired (`tools/arena/engine/conversation_executor.go`)
`buildTurnRequest` built render vars only from the arena prompt-config (matched by `task_type`) and ignored `Scenario.Variables` — even though the MCP-source path consumes it. It now merges `Scenario.Variables` over the prompt-config vars (**scenario wins**), copying into a fresh map so the shared `LoadedPromptConfigs` vars are never mutated.

## Result
A prompt fragment can now be scoped to specific scenarios via a variable, as the API documents.

## Tests
- `runtime/prompt`: `TestRegistry_MergeVars` — new case for empty-string default registering (and nil default still skipped).
- `tools/arena/engine`: `TestBuildTurnRequest_ScenarioVariablesMerged` — scenario vars override arena vars; scenario vars apply with no prompt-config, including an empty value.

Changed-file coverage 86.7% / 88.1%; full runtime + arena suites green.
