### PR TITLE
feat(arena/templates): raw file support for binary fixtures (audio/images)

### DIFF
--- a/tools/arena/templates/generator.go
+++ b/tools/arena/templates/generator.go
@@ -248,6 +248,14 @@ func (g *Generator) resolveSourceContent(
 		return "", err
 	}
 
+	// Raw sources (binary fixtures: audio, images) are copied byte-for-byte.
+	// Go strings preserve arbitrary bytes, and os.WriteFile writes them back
+	// verbatim, so this round-trip is lossless — unlike template rendering,
+	// which would mangle non-UTF-8 bytes and misparse any {{ }} sequences.
+	if fileSpec.Raw {
+		return string(data), nil
+	}
+
 	content, err := g.renderTemplate("source", string(data), vars)
 	if err != nil {
 		return "", fmt.Errorf("failed to render source content for %s: %w", outputPath, err)

--- a/tools/arena/templates/templates_test.go
+++ b/tools/arena/templates/templates_test.go
@@ -422,6 +422,46 @@ spec:
 	assert.Equal(t, "Hello world", string(data))
 }
 
+func TestGenerator_RawBinarySource(t *testing.T) {
+	dir := t.TempDir()
+	// Bytes that text/template would corrupt or outright fail to parse: a
+	// template action, invalid UTF-8, a NUL byte, and an unterminated "{{".
+	// With raw:true the file must be copied byte-for-byte regardless.
+	blob := []byte("{{.name}}\xff\xfe\x00 binary tail {{")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "blob.bin"), blob, 0o644))
+
+	templateContent := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Template
+metadata:
+  name: raw-test
+spec:
+  files:
+    - path: blob.bin
+      source: blob.bin
+      raw: true
+`
+	templatePath := filepath.Join(dir, "template.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(templateContent), 0o644))
+
+	loader := NewLoader("")
+	tmpl, err := loader.LoadFromFile(templatePath)
+	require.NoError(t, err)
+
+	generator := NewGenerator(tmpl, loader)
+	result, err := generator.Generate(&TemplateConfig{
+		ProjectName: "proj",
+		OutputDir:   dir,
+		Variables:   map[string]interface{}{"name": "world"},
+		Template:    tmpl,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Success)
+
+	got, err := os.ReadFile(filepath.Join(dir, "proj", "blob.bin"))
+	require.NoError(t, err)
+	assert.Equal(t, blob, got, "raw source must be copied byte-for-byte")
+}
+
 func TestGenerator_Hooks(t *testing.T) {
 	tmpl := &Template{
 		APIVersion: "promptkit.altairalabs.ai/v1alpha1",

--- a/tools/arena/templates/types.go
+++ b/tools/arena/templates/types.go
@@ -95,6 +95,10 @@ type FileSpec struct {
 	ForEach    string            `yaml:"foreach,omitempty" json:"foreach,omitempty"`
 	Variables  map[string]string `yaml:"variables,omitempty" json:"variables,omitempty"`
 	Executable bool              `yaml:"executable,omitempty" json:"executable,omitempty"`
+	// Raw copies the Source file's bytes verbatim, skipping Go-template
+	// rendering. Use for binary fixtures (audio, images) that text templating
+	// would corrupt.
+	Raw bool `yaml:"raw,omitempty" json:"raw,omitempty"`
 }
 
 // HookSet defines pre and post generation hooks


### PR DESCRIPTION
## Why
`promptarena init` rendered **every** template source file through Go `text/template` and wrote it as a string (`generator.go` `resolveSourceContent`). That corrupts binary content — non-UTF-8 bytes get mangled and `{{`/`}}` byte sequences are misparsed (or error). So templates couldn't ship binary fixtures (audio, images), which blocks a voice-agent template that needs PCM audio.

## Change
Add `raw: true` to a file spec. When set, the Source bytes are copied verbatim (templating skipped). The round-trip through a Go string is lossless, so output is byte-identical to source. Mirrors the existing `executable: true` flag.

```yaml
files:
  - path: audio/greeting.pcm
    source: audio/greeting.pcm
    raw: true
```

## Test
`TestGenerator_RawBinarySource` writes a source containing a template action, invalid UTF-8, a NUL, and an unterminated `{{` (which would *fail to parse* through the templating path), marks it `raw: true`, and asserts the generated file is byte-for-byte identical. Full templates suite green; changed-file coverage 84.1%.
