### PR TITLE
feat(arena/templates): enforce spec.requires.cli_version (clear error vs broken scaffold)

### DIFF
--- a/tools/arena/templates/generator.go
+++ b/tools/arena/templates/generator.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/version"
 )
 
 // Generator handles template generation and file creation
@@ -34,6 +36,17 @@ func (g *Generator) Generate(config *TemplateConfig) (*GenerationResult, error) 
 	result := g.initializeResult(config)
 	g.config = config
 
+	// Fail fast — before creating anything — if this promptarena is too old for
+	// the template (e.g. lacks raw-file support). Better a clear error than a
+	// silently broken scaffold.
+	if g.template.Spec.Requires != nil {
+		if err := checkVersionRequirement(g.template.Spec.Requires.CLIVersion, version.GetVersion()); err != nil {
+			result.Errors = append(result.Errors, err)
+			result.Duration = time.Since(startTime)
+			return result, err
+		}
+	}
+
 	if err := g.createProjectDirectory(result); err != nil {
 		result.Duration = time.Since(startTime)
 		return result, err
@@ -48,6 +61,29 @@ func (g *Generator) Generate(config *TemplateConfig) (*GenerationResult, error) 
 	result.Success = len(result.Errors) == 0
 
 	return result, nil
+}
+
+// checkVersionRequirement returns an error when the running promptarena version
+// is older than the template's required minimum (spec.requires.cli_version).
+// An empty requirement is satisfied. A dev / untagged / pseudo / pre-release
+// current version can't be compared cleanly, so it's allowed rather than risk a
+// false rejection. The requirement may be a bare "1.5.0" or ">=1.5.0".
+func checkVersionRequirement(required, current string) error {
+	required = strings.TrimSpace(required)
+	if required == "" {
+		return nil
+	}
+	if current == "" || strings.Contains(current, "dev") || strings.Contains(current, "-") {
+		return nil
+	}
+	minVer := strings.TrimPrefix(strings.TrimSpace(strings.TrimPrefix(required, ">=")), "v")
+	cur := strings.TrimPrefix(current, "v")
+	if compareSemver(cur, minVer) < 0 {
+		return fmt.Errorf(
+			"this template requires promptarena >= %s, but the current version is %s; please upgrade promptarena",
+			minVer, current)
+	}
+	return nil
 }
 
 func (g *Generator) initializeResult(config *TemplateConfig) *GenerationResult {

--- a/tools/arena/templates/templates_test.go
+++ b/tools/arena/templates/templates_test.go
@@ -422,6 +422,39 @@ spec:
 	assert.Equal(t, "Hello world", string(data))
 }
 
+func TestCheckVersionRequirement(t *testing.T) {
+	tests := []struct {
+		name      string
+		required  string
+		current   string
+		wantError bool
+	}{
+		{"no requirement", "", "1.0.0", false},
+		{"equal", "1.5.0", "1.5.0", false},
+		{"current newer", "1.5.0", "1.6.0", false},
+		{"current newer patch", "1.5.0", "1.5.1", false},
+		{"current older", "1.5.0", "1.4.12", true},
+		{"current older minor", "1.5.0", "1.4.99", true},
+		{">= prefix, older", ">=1.5.0", "1.4.0", true},
+		{">= prefix, satisfied", ">=1.5.0", "1.5.0", false},
+		{"v prefix on current", "1.5.0", "v1.5.0", false},
+		{"v prefix on both, older", "v1.5.0", "v1.4.0", true},
+		{"dev build passes", "1.5.0", "dev", false},
+		{"pseudo/pre-release passes", "1.5.0", "v0.0.0-20240101000000-abcdef", false},
+		{"empty current passes", "1.5.0", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkVersionRequirement(tt.required, tt.current)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestGenerator_RawBinarySource(t *testing.T) {
 	dir := t.TempDir()
 	// Bytes that text/template would corrupt or outright fail to parse: a


### PR DESCRIPTION
## Why
Templates can declare `spec.requires.cli_version`, but **nothing enforced it** — it was a dead field. So a template that needs a newer promptarena (e.g. one using the new `raw:` file flag, #1296) would silently produce a broken scaffold on an older build instead of telling the user to upgrade.

## Change
`Generate()` now checks `requires.cli_version` against the running version **before creating any files**, and fails fast with:

> `this template requires promptarena >= 1.5.0, but the current version is 1.4.12; please upgrade promptarena`

Dev / untagged / pseudo / pre-release builds can't be compared cleanly and pass through (no false rejections). Accepts a bare `1.5.0` or `>=1.5.0`, with or without a `v` prefix.

## Note on scope
This protects clients **from this release forward** — a build old enough to lack a feature is also old enough to lack this check, so it can't retroactively guard pre-release clients. It's the right primitive for all future templates (binary fixtures, new fields, etc.), and makes the failure clear rather than silent.

## Test
`TestCheckVersionRequirement` covers older/equal/newer, minor/patch, `>=`, `v`-prefix, and dev/pseudo pass-through. Full templates suite green; changed-file coverage 83.3%.
