### PR TITLE
feat(providers): embedding platform/auth parity (keyless Azure)

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -166,6 +166,11 @@ type EmbeddingProviderConfig struct {
 	// chat-provider credential block.
 	//nolint:lll // jsonschema tags require single line
 	Credential *CredentialConfig `yaml:"credential,omitempty" json:"credential,omitempty" jsonschema:"title=Credential,description=API key resolution"`
+	// Platform identifies hyperscaler hosting (azure/bedrock/vertex) for
+	// keyless auth, mirroring the chat Provider.Platform block. Only
+	// "azure" (with an OpenAI-wire provider) is functional today.
+	//nolint:lll // jsonschema tags require single line
+	Platform *PlatformConfig `yaml:"platform,omitempty" json:"platform,omitempty" jsonschema:"title=Platform,description=Hyperscaler platform hosting for keyless auth (azure/bedrock/vertex)"`
 	// AdditionalConfig carries provider-specific extras (e.g. VoyageAI
 	// dimensions, input_type). Each provider documents its own keys.
 	//nolint:lll // jsonschema tags require single line

--- a/runtime/providers/base_embedding.go
+++ b/runtime/providers/base_embedding.go
@@ -29,6 +29,10 @@ type BaseEmbeddingProvider struct {
 	Dimensions    int
 	ProviderID    string
 	BatchSize     int
+	// PlatformAuth indicates the HTTPClient's transport applies
+	// hyperscaler-platform auth (Azure Bearer, etc.) per request, so the
+	// per-provider empty-API-key guard must be skipped.
+	PlatformAuth bool
 }
 
 // NewBaseEmbeddingProvider creates a base embedding provider with defaults.

--- a/runtime/providers/embedding_factory.go
+++ b/runtime/providers/embedding_factory.go
@@ -79,14 +79,17 @@ func CreateEmbeddingProviderFromSpec(spec EmbeddingProviderSpec) (EmbeddingProvi
 // ResolveEmbeddingCredential resolves an embedding provider's
 // credential block into a concrete Credential, applying the same
 // fallback chain as chat providers (api_key → file → env → default
-// env vars). Exposed as a helper for the SDK runtime-config layer.
+// env vars). When platform is non-empty, the platform branch produces a
+// platform credential (e.g. AzureCredential) instead of an API key.
+// Exposed as a helper for the SDK runtime-config layer.
 func ResolveEmbeddingCredential(ctx context.Context, providerType string,
-	cfgDir string, cred *credentials.CredentialConfig,
+	cfgDir string, cred *credentials.CredentialConfig, platform *credentials.PlatformConfig,
 ) (credentials.Credential, error) {
 	return credentials.Resolve(ctx, credentials.ResolverConfig{
 		ProviderType:     providerType,
 		CredentialConfig: cred,
 		ConfigDir:        cfgDir,
+		PlatformConfig:   platform,
 	})
 }
 

--- a/runtime/providers/embedding_factory.go
+++ b/runtime/providers/embedding_factory.go
@@ -29,6 +29,13 @@ type EmbeddingProviderSpec struct {
 	// AdditionalConfig carries provider-specific extras (voyage
 	// dimensions/input_type, etc.). Unknown keys are ignored.
 	AdditionalConfig map[string]any
+	// Platform identifies the hosting platform ("azure", "bedrock",
+	// "vertex"). Empty means direct API access via Credential. Mirrors
+	// ProviderSpec.Platform on the chat path.
+	Platform string
+	// PlatformConfig holds platform-specific settings (endpoint, region,
+	// api_version). Only set when Platform != "".
+	PlatformConfig *PlatformConfig
 }
 
 // EmbeddingProviderFactory builds an EmbeddingProvider from a spec.

--- a/runtime/providers/embedding_factory_test.go
+++ b/runtime/providers/embedding_factory_test.go
@@ -203,7 +203,7 @@ func TestIntFromConfig(t *testing.T) {
 
 func TestResolveEmbeddingCredential_FromEnv(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-env-test")
-	cred, err := providers.ResolveEmbeddingCredential(context.Background(), "openai", "", nil)
+	cred, err := providers.ResolveEmbeddingCredential(context.Background(), "openai", "", nil, nil)
 	if err != nil {
 		t.Fatalf("ResolveEmbeddingCredential: %v", err)
 	}

--- a/runtime/providers/embedding_transport.go
+++ b/runtime/providers/embedding_transport.go
@@ -1,0 +1,132 @@
+package providers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+)
+
+// Embedding platform identifiers and the provider type that speaks the
+// OpenAI embeddings wire format (the only one Azure hosting supports).
+const (
+	platformAzure       = "azure"
+	platformBedrock     = "bedrock"
+	platformVertex      = "vertex"
+	embeddingTypeOpenAI = "openai"
+)
+
+// EmbeddingTransport is the resolved HTTP wiring for a vendor embedding
+// factory. Exactly one of the two modes is populated:
+//   - static key: Client==nil, PlatformAuth==false, APIKey may be set
+//   - platform:   Client!=nil, PlatformAuth==true, APIKey==""
+//
+// BaseURL is the platform-resolved endpoint, or the spec's BaseURL
+// override, or "" (provider keeps its built-in default).
+type EmbeddingTransport struct {
+	Client       *http.Client
+	BaseURL      string
+	APIKey       string
+	PlatformAuth bool
+}
+
+// ResolveEmbeddingTransport decides between the static-API-key path and a
+// hyperscaler-platform path for an embedding provider. It is the single
+// place embedding factories consult, mirroring the chat path's
+// credential/platform handling.
+//
+//nolint:gocritic // spec is a value-semantics builder; callers assemble inline.
+func ResolveEmbeddingTransport(spec EmbeddingProviderSpec) (EmbeddingTransport, error) {
+	if spec.Platform == "" {
+		return EmbeddingTransport{
+			BaseURL: spec.BaseURL,
+			APIKey:  APIKeyFromCredential(spec.Credential),
+		}, nil
+	}
+
+	client, baseURL, err := buildPlatformEmbeddingClient(
+		spec.Credential, spec.Platform, spec.Type, spec.Model, spec.PlatformConfig)
+	if err != nil {
+		return EmbeddingTransport{}, err
+	}
+	return EmbeddingTransport{
+		Client:       client,
+		BaseURL:      baseURL,
+		PlatformAuth: true,
+	}, nil
+}
+
+// buildPlatformEmbeddingClient resolves the platform endpoint and an HTTP
+// client whose transport applies the credential per request. Azure is
+// implemented; Bedrock/Vertex are gated until a platform-native embedding
+// provider type exists (their wire format differs from OpenAI's).
+func buildPlatformEmbeddingClient(
+	cred credentials.Credential, platform, providerType, model string, pc *PlatformConfig,
+) (*http.Client, string, error) {
+	switch strings.ToLower(platform) {
+	case platformAzure:
+		if providerType != embeddingTypeOpenAI {
+			return nil, "", fmt.Errorf(
+				"embedding platform %q requires an OpenAI-wire-format provider (type=openai), got %q",
+				platform, providerType)
+		}
+		if pc == nil || pc.Endpoint == "" {
+			return nil, "", fmt.Errorf("embedding platform %q requires platform.endpoint", platform)
+		}
+		rt := &platformEmbeddingRoundTripper{
+			base:       http.DefaultTransport,
+			cred:       cred,
+			apiVersion: azureEmbeddingAPIVersion(pc),
+		}
+		return &http.Client{Transport: rt}, credentials.AzureOpenAIEndpoint(pc.Endpoint, model), nil
+	case platformBedrock, platformVertex:
+		return nil, "", fmt.Errorf(
+			"embedding platform %q is not yet supported: it requires a platform-native embedding "+
+				"provider type (Titan/Vertex body shapes), which is not implemented", platform)
+	default:
+		return nil, "", fmt.Errorf("unsupported embedding platform: %q", platform)
+	}
+}
+
+// azureEmbeddingAPIVersion mirrors the chat path: prefer an explicit
+// platform.additional_config.api_version, else the package default.
+func azureEmbeddingAPIVersion(pc *PlatformConfig) string {
+	if pc != nil {
+		if v, ok := pc.AdditionalConfig["api_version"].(string); ok && v != "" {
+			return v
+		}
+	}
+	return credentials.DefaultAzureAPIVersion
+}
+
+// platformEmbeddingRoundTripper applies a credential (and, for Azure, the
+// api-version query param) to every embedding request before delegating.
+type platformEmbeddingRoundTripper struct {
+	base       http.RoundTripper
+	cred       credentials.Credential
+	apiVersion string // non-empty only for Azure
+}
+
+// RoundTrip applies the api-version query param (Azure) and the credential
+// to a cloned request before delegating to the base transport.
+func (rt *platformEmbeddingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone before mutating: the RoundTripper contract forbids modifying
+	// the caller's request.
+	r := req.Clone(req.Context())
+	if rt.apiVersion != "" && r.URL.Query().Get("api-version") == "" {
+		q := r.URL.Query()
+		q.Set("api-version", rt.apiVersion)
+		r.URL.RawQuery = q.Encode()
+	}
+	if rt.cred != nil {
+		if err := rt.cred.Apply(r.Context(), r); err != nil {
+			return nil, err
+		}
+	}
+	base := rt.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(r)
+}

--- a/runtime/providers/embedding_transport_test.go
+++ b/runtime/providers/embedding_transport_test.go
@@ -1,6 +1,14 @@
 package providers
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+)
 
 func TestEmbeddingProviderSpec_CarriesPlatform(t *testing.T) {
 	spec := EmbeddingProviderSpec{
@@ -21,5 +29,159 @@ func TestBaseEmbeddingProvider_PlatformAuthFlag(t *testing.T) {
 	b.PlatformAuth = true
 	if !b.PlatformAuth {
 		t.Fatal("PlatformAuth not settable")
+	}
+}
+
+// fakeCred records that Apply ran and injects a static bearer token,
+// standing in for AzureCredential without needing real Azure auth.
+type fakeCred struct{ applied bool }
+
+func (f *fakeCred) Apply(_ context.Context, req *http.Request) error {
+	f.applied = true
+	req.Header.Set("Authorization", "Bearer faketoken")
+	return nil
+}
+func (f *fakeCred) Type() string { return "fake" }
+
+func TestResolveEmbeddingTransport_StaticKey(t *testing.T) {
+	tr, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:       "openai",
+		BaseURL:    "https://custom.example/v1",
+		Credential: credentials.NewAPIKeyCredential("sk-static"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.Client != nil {
+		t.Fatal("static path must not build an HTTP client")
+	}
+	if tr.PlatformAuth {
+		t.Fatal("static path must not set PlatformAuth")
+	}
+	if tr.BaseURL != "https://custom.example/v1" {
+		t.Fatalf("BaseURL = %q", tr.BaseURL)
+	}
+	if tr.APIKey != "sk-static" {
+		t.Fatalf("APIKey = %q", tr.APIKey)
+	}
+}
+
+func TestResolveEmbeddingTransport_Azure(t *testing.T) {
+	var gotAuth, gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cred := &fakeCred{}
+	tr, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "openai",
+		Model:          "text-embedding-3-small",
+		Platform:       "azure",
+		PlatformConfig: &PlatformConfig{Type: "azure", Endpoint: srv.URL},
+		Credential:     cred,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.Client == nil {
+		t.Fatal("azure path must build an HTTP client")
+	}
+	if !tr.PlatformAuth {
+		t.Fatal("azure path must set PlatformAuth")
+	}
+	if tr.APIKey != "" {
+		t.Fatalf("azure path must not carry a static key, got %q", tr.APIKey)
+	}
+	wantBase := srv.URL + "/openai/deployments/text-embedding-3-small"
+	if tr.BaseURL != wantBase {
+		t.Fatalf("BaseURL = %q, want %q", tr.BaseURL, wantBase)
+	}
+
+	// Drive a request through the client; the RoundTripper must inject
+	// the bearer token and api-version.
+	req, _ := http.NewRequest(http.MethodPost, tr.BaseURL+"/embeddings", strings.NewReader("{}"))
+	resp, err := tr.Client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+	if !cred.applied {
+		t.Fatal("credential.Apply was not called")
+	}
+	if gotAuth != "Bearer faketoken" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotPath != "/openai/deployments/text-embedding-3-small/embeddings" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if !strings.Contains(gotQuery, "api-version="+credentials.DefaultAzureAPIVersion) {
+		t.Fatalf("query = %q, want api-version=%s", gotQuery, credentials.DefaultAzureAPIVersion)
+	}
+}
+
+func TestResolveEmbeddingTransport_AzureCustomAPIVersion(t *testing.T) {
+	tr, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:     "openai",
+		Model:    "text-embedding-3-small",
+		Platform: "azure",
+		PlatformConfig: &PlatformConfig{
+			Type:             "azure",
+			Endpoint:         "https://x.openai.azure.com/",
+			AdditionalConfig: map[string]interface{}{"api_version": "2099-01-01"},
+		},
+		Credential: &fakeCred{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rt, ok := tr.Client.Transport.(*platformEmbeddingRoundTripper)
+	if !ok {
+		t.Fatalf("transport type = %T", tr.Client.Transport)
+	}
+	if rt.apiVersion != "2099-01-01" {
+		t.Fatalf("apiVersion = %q, want 2099-01-01", rt.apiVersion)
+	}
+}
+
+func TestResolveEmbeddingTransport_AzureRequiresEndpoint(t *testing.T) {
+	_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "openai",
+		Platform:       "azure",
+		PlatformConfig: &PlatformConfig{Type: "azure"},
+		Credential:     &fakeCred{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "endpoint") {
+		t.Fatalf("err = %v, want endpoint error", err)
+	}
+}
+
+func TestResolveEmbeddingTransport_AzureRequiresOpenAIWire(t *testing.T) {
+	_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "gemini",
+		Platform:       "azure",
+		PlatformConfig: &PlatformConfig{Type: "azure", Endpoint: "https://x"},
+		Credential:     &fakeCred{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "OpenAI-wire") {
+		t.Fatalf("err = %v, want OpenAI-wire guard error", err)
+	}
+}
+
+func TestResolveEmbeddingTransport_BedrockVertexGated(t *testing.T) {
+	for _, p := range []string{"bedrock", "vertex"} {
+		_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+			Type:           "openai",
+			Platform:       p,
+			PlatformConfig: &PlatformConfig{Type: p},
+			Credential:     &fakeCred{},
+		})
+		if err == nil || !strings.Contains(err.Error(), "not yet supported") {
+			t.Fatalf("platform %s: err = %v, want 'not yet supported'", p, err)
+		}
 	}
 }

--- a/runtime/providers/embedding_transport_test.go
+++ b/runtime/providers/embedding_transport_test.go
@@ -1,0 +1,25 @@
+package providers
+
+import "testing"
+
+func TestEmbeddingProviderSpec_CarriesPlatform(t *testing.T) {
+	spec := EmbeddingProviderSpec{
+		Type:           "openai",
+		Platform:       "azure",
+		PlatformConfig: &PlatformConfig{Type: "azure", Endpoint: "https://example.openai.azure.com/"},
+	}
+	if spec.Platform != "azure" {
+		t.Fatalf("Platform = %q, want azure", spec.Platform)
+	}
+	if spec.PlatformConfig == nil || spec.PlatformConfig.Endpoint == "" {
+		t.Fatal("PlatformConfig not carried")
+	}
+}
+
+func TestBaseEmbeddingProvider_PlatformAuthFlag(t *testing.T) {
+	b := &BaseEmbeddingProvider{}
+	b.PlatformAuth = true
+	if !b.PlatformAuth {
+		t.Fatal("PlatformAuth not settable")
+	}
+}

--- a/runtime/providers/gemini/embedding.go
+++ b/runtime/providers/gemini/embedding.go
@@ -80,6 +80,14 @@ func WithGeminiEmbeddingHTTPClient(client *http.Client) EmbeddingOption {
 	}
 }
 
+// WithGeminiEmbeddingPlatformAuth marks the provider as authenticated by
+// its HTTP client's transport, skipping the empty-API-key guard.
+func WithGeminiEmbeddingPlatformAuth() EmbeddingOption {
+	return func(p *EmbeddingProvider) {
+		p.PlatformAuth = true
+	}
+}
+
 // NewEmbeddingProvider creates a Gemini embedding provider.
 func NewEmbeddingProvider(opts ...EmbeddingOption) (*EmbeddingProvider, error) {
 	p := &EmbeddingProvider{
@@ -98,14 +106,16 @@ func NewEmbeddingProvider(opts ...EmbeddingOption) (*EmbeddingProvider, error) {
 		opt(p)
 	}
 
-	// Get API key from environment if not set
-	if p.APIKey == "" {
-		_, apiKey := providers.NewBaseProviderWithAPIKey("", false, "GEMINI_API_KEY", "GOOGLE_API_KEY")
-		p.APIKey = apiKey
-	}
-
-	if p.APIKey == "" {
-		return nil, fmt.Errorf("gemini API key not found: set GEMINI_API_KEY environment variable")
+	// Platform auth is applied by the HTTP client's transport; static key
+	// path only applies when not in platform mode.
+	if !p.PlatformAuth {
+		if p.APIKey == "" {
+			_, apiKey := providers.NewBaseProviderWithAPIKey("", false, "GEMINI_API_KEY", "GOOGLE_API_KEY")
+			p.APIKey = apiKey
+		}
+		if p.APIKey == "" {
+			return nil, fmt.Errorf("gemini API key not found: set GEMINI_API_KEY environment variable")
+		}
 	}
 
 	return p, nil

--- a/runtime/providers/gemini/embedding_platform_test.go
+++ b/runtime/providers/gemini/embedding_platform_test.go
@@ -1,0 +1,21 @@
+package gemini
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGeminiNewEmbeddingProvider_PlatformAuthSkipsKeyGuard(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	p, err := NewEmbeddingProvider(
+		WithGeminiEmbeddingHTTPClient(&http.Client{}),
+		WithGeminiEmbeddingPlatformAuth(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("provider is nil")
+	}
+}

--- a/runtime/providers/gemini/embedding_register.go
+++ b/runtime/providers/gemini/embedding_register.go
@@ -6,15 +6,25 @@ import "github.com/AltairaLabs/PromptKit/runtime/providers"
 func init() {
 	providers.RegisterEmbeddingProviderFactory("gemini",
 		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			tr, err := providers.ResolveEmbeddingTransport(spec)
+			if err != nil {
+				return nil, err
+			}
 			opts := []EmbeddingOption{}
 			if spec.Model != "" {
 				opts = append(opts, WithGeminiEmbeddingModel(spec.Model))
 			}
-			if spec.BaseURL != "" {
-				opts = append(opts, WithGeminiEmbeddingBaseURL(spec.BaseURL))
+			if tr.BaseURL != "" {
+				opts = append(opts, WithGeminiEmbeddingBaseURL(tr.BaseURL))
 			}
-			if k := providers.APIKeyFromCredential(spec.Credential); k != "" {
-				opts = append(opts, WithGeminiEmbeddingAPIKey(k))
+			if tr.Client != nil {
+				opts = append(opts, WithGeminiEmbeddingHTTPClient(tr.Client))
+			}
+			if tr.APIKey != "" {
+				opts = append(opts, WithGeminiEmbeddingAPIKey(tr.APIKey))
+			}
+			if tr.PlatformAuth {
+				opts = append(opts, WithGeminiEmbeddingPlatformAuth())
 			}
 			return NewEmbeddingProvider(opts...)
 		},

--- a/runtime/providers/openai/embedding.go
+++ b/runtime/providers/openai/embedding.go
@@ -83,6 +83,15 @@ func WithEmbeddingHTTPClient(client *http.Client) EmbeddingOption {
 	}
 }
 
+// WithEmbeddingPlatformAuth marks the provider as authenticated by its
+// HTTP client's transport (hyperscaler platform auth), so the empty-API-key
+// guard in NewEmbeddingProvider is skipped.
+func WithEmbeddingPlatformAuth() EmbeddingOption {
+	return func(p *EmbeddingProvider) {
+		p.PlatformAuth = true
+	}
+}
+
 // NewEmbeddingProvider creates an OpenAI embedding provider.
 func NewEmbeddingProvider(opts ...EmbeddingOption) (*EmbeddingProvider, error) {
 	p := &EmbeddingProvider{
@@ -101,14 +110,16 @@ func NewEmbeddingProvider(opts ...EmbeddingOption) (*EmbeddingProvider, error) {
 		opt(p)
 	}
 
-	// Get API key from environment if not set
-	if p.APIKey == "" {
-		_, apiKey := providers.NewBaseProviderWithAPIKey("", false, "OPENAI_API_KEY", "OPENAI_TOKEN")
-		p.APIKey = apiKey
-	}
-
-	if p.APIKey == "" {
-		return nil, fmt.Errorf("OpenAI API key not found: set OPENAI_API_KEY environment variable")
+	// Platform auth is applied by the HTTP client's transport; the static
+	// key path (env fallback + guard) only applies when not in platform mode.
+	if !p.PlatformAuth {
+		if p.APIKey == "" {
+			_, apiKey := providers.NewBaseProviderWithAPIKey("", false, "OPENAI_API_KEY", "OPENAI_TOKEN")
+			p.APIKey = apiKey
+		}
+		if p.APIKey == "" {
+			return nil, fmt.Errorf("OpenAI API key not found: set OPENAI_API_KEY environment variable")
+		}
 	}
 
 	return p, nil

--- a/runtime/providers/openai/embedding_azure_integration_test.go
+++ b/runtime/providers/openai/embedding_azure_integration_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+// Azure OpenAI embedding integration tests.
+//
+// These exercise the openai embedding provider against a REAL Azure OpenAI
+// deployment using Azure AD token auth (no API key) — the keyless path added
+// for the SharePoint RAG demo. They share the gating helpers (azureEndpoint,
+// skipIfNoAzure, azureAPIVersionOverride) defined in azure_integration_test.go
+// and are skipped unless an Azure token can actually be acquired.
+//
+// Run locally against the demo resource:
+//
+//	az login --scope https://cognitiveservices.azure.com/.default
+//	export AZURE_OPENAI_ENDPOINT=https://aoai-omnia-demo-33eebkdcvsi4a.cognitiveservices.azure.com
+//	export AZURE_OPENAI_EMBEDDING_DEPLOYMENT=text-embedding-3-small
+//	go test -tags=integration ./runtime/providers/openai/... -run AzureEmbedding -v
+//
+// Optional:
+//
+//	AZURE_OPENAI_API_VERSION  api-version query param (default: credentials.DefaultAzureAPIVersion)
+package openai
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// azureEmbeddingDeployment returns the embedding deployment to address. Azure
+// routes by deployment name, not model name. Defaults to the demo resource's
+// text-embedding-3-small deployment.
+func azureEmbeddingDeployment() string {
+	if d := os.Getenv("AZURE_OPENAI_EMBEDDING_DEPLOYMENT"); d != "" {
+		return d
+	}
+	return "text-embedding-3-small"
+}
+
+// azureEmbeddingSpec builds the production EmbeddingProviderSpec for a keyless
+// Azure deployment: a real AzureCredential + platform=azure, exactly as the
+// SDK/memory-api paths assemble it.
+func azureEmbeddingSpec(t *testing.T) providers.EmbeddingProviderSpec {
+	t.Helper()
+	skipIfNoAzure(t)
+
+	cred, err := credentials.NewAzureCredential(context.Background(), azureEndpoint())
+	if err != nil {
+		t.Fatalf("failed to create Azure credential: %v", err)
+	}
+
+	pc := &providers.PlatformConfig{Type: "azure", Endpoint: azureEndpoint()}
+	if v := azureAPIVersionOverride(); v != "" {
+		pc.AdditionalConfig = map[string]any{"api_version": v}
+	}
+
+	return providers.EmbeddingProviderSpec{
+		ID:             "azure-openai-embedding-test",
+		Type:           "openai",
+		Model:          azureEmbeddingDeployment(),
+		Platform:       "azure",
+		PlatformConfig: pc,
+		Credential:     cred,
+	}
+}
+
+// TestAzureEmbedding_FactoryBuildsDeploymentURL confirms the factory resolves
+// the Azure deployment base URL from PlatformConfig (no api.openai.com default).
+func TestAzureEmbedding_FactoryBuildsDeploymentURL(t *testing.T) {
+	skipIfNoAzure(t)
+
+	tr, err := providers.ResolveEmbeddingTransport(azureEmbeddingSpec(t))
+	if err != nil {
+		t.Fatalf("ResolveEmbeddingTransport failed: %v", err)
+	}
+	want := credentials.AzureOpenAIEndpoint(azureEndpoint(), azureEmbeddingDeployment())
+	if tr.BaseURL != want {
+		t.Fatalf("BaseURL = %q, want %q", tr.BaseURL, want)
+	}
+	if tr.Client == nil || !tr.PlatformAuth {
+		t.Fatalf("expected platform client + PlatformAuth, got client=%v platformAuth=%v", tr.Client != nil, tr.PlatformAuth)
+	}
+}
+
+// TestAzureEmbedding_Embed is the real end-to-end proof: it sends an embedding
+// request to a live Azure OpenAI deployment authenticated with an Azure AD
+// token (no API key) and asserts real vectors come back.
+func TestAzureEmbedding_Embed(t *testing.T) {
+	emb, err := providers.CreateEmbeddingProviderFromSpec(azureEmbeddingSpec(t))
+	if err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec failed: %v", err)
+	}
+
+	ctx := context.Background()
+	resp, err := emb.Embed(ctx, providers.EmbeddingRequest{
+		Texts: []string{"PromptKit keyless Azure embedding works."},
+	})
+	if err != nil {
+		t.Fatalf("Embed failed against live Azure: %v", err)
+	}
+
+	if len(resp.Embeddings) != 1 {
+		t.Fatalf("expected 1 embedding, got %d", len(resp.Embeddings))
+	}
+	vec := resp.Embeddings[0]
+	if len(vec) == 0 {
+		t.Fatal("expected a non-empty embedding vector")
+	}
+	if len(vec) != emb.EmbeddingDimensions() {
+		t.Errorf("vector length = %d, want provider dimensions %d", len(vec), emb.EmbeddingDimensions())
+	}
+
+	// A real embedding is not all-zeros.
+	var nonZero bool
+	for _, f := range vec {
+		if f != 0 {
+			nonZero = true
+			break
+		}
+	}
+	if !nonZero {
+		t.Fatal("embedding vector is all zeros — likely not a real response")
+	}
+
+	t.Logf("Azure embedding OK: model=%s dims=%d", resp.Model, len(vec))
+}
+
+// TestAzureEmbedding_BatchEmbed confirms multi-text requests return aligned
+// vectors over the live deployment.
+func TestAzureEmbedding_BatchEmbed(t *testing.T) {
+	emb, err := providers.CreateEmbeddingProviderFromSpec(azureEmbeddingSpec(t))
+	if err != nil {
+		t.Fatalf("CreateEmbeddingProviderFromSpec failed: %v", err)
+	}
+
+	ctx := context.Background()
+	texts := []string{"first document", "second document", "third document"}
+	resp, err := emb.Embed(ctx, providers.EmbeddingRequest{Texts: texts})
+	if err != nil {
+		t.Fatalf("batch Embed failed against live Azure: %v", err)
+	}
+
+	if len(resp.Embeddings) != len(texts) {
+		t.Fatalf("expected %d embeddings, got %d", len(texts), len(resp.Embeddings))
+	}
+	for i, vec := range resp.Embeddings {
+		if len(vec) == 0 {
+			t.Fatalf("embedding %d is empty", i)
+		}
+	}
+}

--- a/runtime/providers/openai/embedding_platform_test.go
+++ b/runtime/providers/openai/embedding_platform_test.go
@@ -1,0 +1,81 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+type fakeCred struct{ applied bool }
+
+func (f *fakeCred) Apply(_ context.Context, req *http.Request) error {
+	f.applied = true
+	req.Header.Set("Authorization", "Bearer faketoken")
+	return nil
+}
+func (f *fakeCred) Type() string { return "fake" }
+
+// NewEmbeddingProvider must succeed with no API key when platform auth is active.
+func TestNewEmbeddingProvider_PlatformAuthSkipsKeyGuard(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_TOKEN", "")
+	p, err := NewEmbeddingProvider(
+		WithEmbeddingBaseURL("https://x/openai/deployments/m"),
+		WithEmbeddingHTTPClient(&http.Client{}),
+		WithEmbeddingPlatformAuth(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("provider is nil")
+	}
+}
+
+// Without platform auth and without a key, the guard still fires.
+func TestNewEmbeddingProvider_NoKeyStillErrors(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_TOKEN", "")
+	if _, err := NewEmbeddingProvider(); err == nil {
+		t.Fatal("expected API-key-not-found error")
+	}
+}
+
+// The openai factory, given an Azure platform spec, produces a provider
+// that injects the credential's bearer token + api-version on Embed().
+func TestOpenAIEmbeddingFactory_AzurePlatform(t *testing.T) {
+	var gotAuth, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}],"model":"text-embedding-3-small","usage":{"prompt_tokens":1,"total_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	emb, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:           "openai",
+		Model:          "text-embedding-3-small",
+		Platform:       "azure",
+		PlatformConfig: &providers.PlatformConfig{Type: "azure", Endpoint: srv.URL},
+		Credential:     &fakeCred{},
+	})
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+
+	_, err = emb.Embed(context.Background(), providers.EmbeddingRequest{Texts: []string{"hello"}})
+	if err != nil {
+		t.Fatalf("Embed error: %v", err)
+	}
+	if gotAuth != "Bearer faketoken" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if !strings.Contains(gotQuery, "api-version=") {
+		t.Fatalf("query = %q, want api-version", gotQuery)
+	}
+}

--- a/runtime/providers/openai/embedding_register.go
+++ b/runtime/providers/openai/embedding_register.go
@@ -6,15 +6,25 @@ import "github.com/AltairaLabs/PromptKit/runtime/providers"
 func init() {
 	providers.RegisterEmbeddingProviderFactory("openai",
 		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			tr, err := providers.ResolveEmbeddingTransport(spec)
+			if err != nil {
+				return nil, err
+			}
 			opts := []EmbeddingOption{}
 			if spec.Model != "" {
 				opts = append(opts, WithEmbeddingModel(spec.Model))
 			}
-			if spec.BaseURL != "" {
-				opts = append(opts, WithEmbeddingBaseURL(spec.BaseURL))
+			if tr.BaseURL != "" {
+				opts = append(opts, WithEmbeddingBaseURL(tr.BaseURL))
 			}
-			if k := providers.APIKeyFromCredential(spec.Credential); k != "" {
-				opts = append(opts, WithEmbeddingAPIKey(k))
+			if tr.Client != nil {
+				opts = append(opts, WithEmbeddingHTTPClient(tr.Client))
+			}
+			if tr.APIKey != "" {
+				opts = append(opts, WithEmbeddingAPIKey(tr.APIKey))
+			}
+			if tr.PlatformAuth {
+				opts = append(opts, WithEmbeddingPlatformAuth())
 			}
 			return NewEmbeddingProvider(opts...)
 		},

--- a/runtime/providers/voyageai/embedding.go
+++ b/runtime/providers/voyageai/embedding.go
@@ -105,6 +105,14 @@ func WithHTTPClient(client *http.Client) EmbeddingOption {
 	}
 }
 
+// WithPlatformAuth marks the provider as authenticated by its HTTP
+// client's transport, skipping the empty-API-key guard.
+func WithPlatformAuth() EmbeddingOption {
+	return func(p *EmbeddingProvider) {
+		p.PlatformAuth = true
+	}
+}
+
 // WithInputType sets the input type for retrieval optimization.
 // Use "query" for search queries and "document" for documents to be indexed.
 func WithInputType(inputType string) EmbeddingOption {
@@ -131,13 +139,15 @@ func NewEmbeddingProvider(opts ...EmbeddingOption) (*EmbeddingProvider, error) {
 		opt(p)
 	}
 
-	// Get API key from environment if not set
-	if p.APIKey == "" {
-		p.APIKey = os.Getenv("VOYAGE_API_KEY")
-	}
-
-	if p.APIKey == "" {
-		return nil, fmt.Errorf("voyage AI API key not found: set VOYAGE_API_KEY environment variable")
+	// Platform auth is applied by the HTTP client's transport; static key
+	// path only applies when not in platform mode.
+	if !p.PlatformAuth {
+		if p.APIKey == "" {
+			p.APIKey = os.Getenv("VOYAGE_API_KEY")
+		}
+		if p.APIKey == "" {
+			return nil, fmt.Errorf("voyage AI API key not found: set VOYAGE_API_KEY environment variable")
+		}
 	}
 
 	return p, nil

--- a/runtime/providers/voyageai/embedding_platform_test.go
+++ b/runtime/providers/voyageai/embedding_platform_test.go
@@ -1,0 +1,20 @@
+package voyageai
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestVoyageNewEmbeddingProvider_PlatformAuthSkipsKeyGuard(t *testing.T) {
+	t.Setenv("VOYAGE_API_KEY", "")
+	p, err := NewEmbeddingProvider(
+		WithHTTPClient(&http.Client{}),
+		WithPlatformAuth(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("provider is nil")
+	}
+}

--- a/runtime/providers/voyageai/embedding_register.go
+++ b/runtime/providers/voyageai/embedding_register.go
@@ -6,15 +6,25 @@ import "github.com/AltairaLabs/PromptKit/runtime/providers"
 func init() {
 	providers.RegisterEmbeddingProviderFactory("voyageai",
 		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			tr, err := providers.ResolveEmbeddingTransport(spec)
+			if err != nil {
+				return nil, err
+			}
 			opts := []EmbeddingOption{}
 			if spec.Model != "" {
 				opts = append(opts, WithModel(spec.Model))
 			}
-			if spec.BaseURL != "" {
-				opts = append(opts, WithBaseURL(spec.BaseURL))
+			if tr.BaseURL != "" {
+				opts = append(opts, WithBaseURL(tr.BaseURL))
 			}
-			if k := providers.APIKeyFromCredential(spec.Credential); k != "" {
-				opts = append(opts, WithAPIKey(k))
+			if tr.Client != nil {
+				opts = append(opts, WithHTTPClient(tr.Client))
+			}
+			if tr.APIKey != "" {
+				opts = append(opts, WithAPIKey(tr.APIKey))
+			}
+			if tr.PlatformAuth {
+				opts = append(opts, WithPlatformAuth())
 			}
 			if dims, ok := providers.IntFromConfig(spec.AdditionalConfig, "dimensions"); ok {
 				opts = append(opts, WithDimensions(dims))

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -50,6 +50,11 @@
           "title": "Credential",
           "description": "API key resolution"
         },
+        "platform": {
+          "$ref": "#/$defs/PlatformConfig",
+          "title": "Platform",
+          "description": "Hyperscaler platform hosting for keyless auth (azure/bedrock/vertex)"
+        },
         "additional_config": {
           "type": "object",
           "title": "Additional Config",

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+
 	// Side-effect imports register embedding-provider factories so
 	// CreateEmbeddingProviderFromSpec can resolve declarative entries.
 	// Chat-provider factories register through other SDK paths.
@@ -324,7 +325,11 @@ func applyEmbeddingProviders(c *config, specs []pkgconfig.EmbeddingProviderConfi
 		if _, exists := c.embeddingProviders[id]; exists {
 			return fmt.Errorf("embedding provider %q: duplicate ID", id)
 		}
-		cred, err := providers.ResolveEmbeddingCredential(context.Background(), ep.Type, "", ep.Credential)
+		var platform string
+		if ep.Platform != nil {
+			platform = ep.Platform.Type
+		}
+		cred, err := providers.ResolveEmbeddingCredential(context.Background(), ep.Type, "", ep.Credential, ep.Platform)
 		if err != nil {
 			return fmt.Errorf("embedding provider %q: resolving credential: %w", id, err)
 		}
@@ -334,6 +339,8 @@ func applyEmbeddingProviders(c *config, specs []pkgconfig.EmbeddingProviderConfi
 			Model:            ep.Model,
 			BaseURL:          ep.BaseURL,
 			Credential:       cred,
+			Platform:         platform,
+			PlatformConfig:   ep.Platform,
 			AdditionalConfig: ep.AdditionalConfig,
 		})
 		if err != nil {

--- a/sdk/runtime_config_embedding_platform_test.go
+++ b/sdk/runtime_config_embedding_platform_test.go
@@ -1,0 +1,40 @@
+package sdk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+// A declarative embedding provider with platform=azure must build a
+// platform-aware provider (no API key required). We assert construction
+// succeeds with no credentials set — the static path would error
+// "API key not found".
+func TestApplyEmbeddingProviders_AzurePlatform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_TOKEN", "")
+
+	c := &config{}
+	err := applyEmbeddingProviders(c, []pkgconfig.EmbeddingProviderConfig{{
+		ID:    "rag",
+		Type:  "openai",
+		Model: "text-embedding-3-small",
+		Platform: &pkgconfig.PlatformConfig{
+			Type:     "azure",
+			Endpoint: srv.URL,
+		},
+	}})
+	if err != nil {
+		t.Fatalf("applyEmbeddingProviders error: %v", err)
+	}
+	if _, ok := c.embeddingProviders["rag"]; !ok {
+		t.Fatal("embedding provider not registered")
+	}
+}


### PR DESCRIPTION
## What

Embedding providers now honour the same `Platform` + `Credential` machinery
chat providers have. A shared `providers.ResolveEmbeddingTransport` decides
between the static-API-key path and a platform path whose HTTP client applies
`Credential.Apply` per request (Azure Bearer + token refresh, reusing the
existing `credentials.AzureCredential`). Azure OpenAI embeddings work keyless
(Workload Identity / Managed Identity); the SDK declarative config threads a
new `platform:` block.

## Scope

- **Azure**: implemented end-to-end against the `openai` (OpenAI-wire) provider.
- **Bedrock/Vertex**: the credential/transport layer is generic, but resolution
  is **gated** with a clear error — they need net-new body-shape provider types
  (Titan / Vertex predict), tracked separately. The chat endpoint helpers don't
  generalize (`VertexEndpoint` hardcodes `/publishers/anthropic/models`) and the
  request/response bodies differ from the OpenAI wire format the existing
  embedding providers emit.

## Why

Unblocks the SharePoint RAG hero demo on AKS, which needs keyless Azure OpenAI
embeddings. Downstream Omnia wiring (Provider CRD + memory-api + chart) lands
after this releases.

## Design

One consolidated `ResolveEmbeddingTransport(spec)` owns the static-vs-platform
decision; each vendor factory (openai/gemini/voyageai) maps the result to its
own option names uniformly. A `PlatformAuth` flag on `BaseEmbeddingProvider`
skips the empty-API-key guard when auth lives in the transport.

## Tests

- `runtime/providers`: transport resolver — azure success (token + api-version
  injected), custom api-version, endpoint-required, OpenAI-wire guard, BR/VX
  gated, static path unchanged
- `runtime/providers/openai`: factory builds a token-injecting Azure provider;
  empty-key guard skipped under platform auth, still fires otherwise
- `runtime/providers/{gemini,voyageai}`: guard-skip + static path unchanged
- `sdk`: declarative `platform: azure` embedding config builds keyless

Schema regen: additive optional `platform` property on the embedding config.
