### PR TITLE
fix(arena): stop reporting idle-timeout aborts as false-green PASS (#1311)

### DIFF
--- a/runtime/providers/errors.go
+++ b/runtime/providers/errors.go
@@ -51,6 +51,12 @@ func IsTransient(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
+	// A stream idle timeout is a deadline, not a retryable infra blip. Treating
+	// it as transient causes Arena to skip the aborted turn and report a false
+	// green, so it must never be classified as transient.
+	if IsStreamIdleTimeout(err) {
+		return false
+	}
 	var httpErr *ProviderHTTPError
 	if errors.As(err, &httpErr) {
 		return IsRetryableStreamStatus(httpErr.StatusCode)

--- a/runtime/providers/errors_test.go
+++ b/runtime/providers/errors_test.go
@@ -235,6 +235,29 @@ func TestIsTransient_ContextErrorsNeverTransient(t *testing.T) {
 	}
 }
 
+func TestIsTransient_IdleTimeoutNeverTransient(t *testing.T) {
+	t.Parallel()
+	// A stream idle timeout is a deadline, not a retryable infra blip. It must
+	// never be classified as transient — otherwise Arena skips the aborted turn,
+	// clears the error, and reports a green PASS for a run that never executed.
+	if IsTransient(ErrStreamIdleTimeout) {
+		t.Error("IsTransient(ErrStreamIdleTimeout) = true, want false")
+	}
+
+	// The idle timeout reaches the executor wrapped as a ProviderTransportError
+	// (the stream classifier wraps the read failure). It must still be non-transient.
+	wrapped := &ProviderTransportError{Cause: ErrStreamIdleTimeout, Provider: "openai"}
+	if IsTransient(wrapped) {
+		t.Error("IsTransient(ErrStreamIdleTimeout wrapped in ProviderTransportError) = true, want false")
+	}
+
+	// Double-wrapped should also not be transient.
+	doubleWrapped := fmt.Errorf("stream read failed: %w", wrapped)
+	if IsTransient(doubleWrapped) {
+		t.Error("IsTransient(double-wrapped ErrStreamIdleTimeout) = true, want false")
+	}
+}
+
 func TestIsTransient_WrappedErrors(t *testing.T) {
 	t.Parallel()
 	httpErr := fmt.Errorf("outer: %w", &ProviderHTTPError{StatusCode: 503})

--- a/runtime/providers/idle_timeout.go
+++ b/runtime/providers/idle_timeout.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -18,8 +19,9 @@ type IdleTimeoutReader struct {
 	timeout time.Duration
 	timer   *time.Timer
 
-	mu     sync.Mutex
-	closed bool
+	mu       sync.Mutex
+	closed   bool
+	timedOut bool
 }
 
 // NewIdleTimeoutReader wraps the given reader with idle timeout detection.
@@ -37,6 +39,7 @@ func NewIdleTimeoutReader(r io.ReadCloser, timeout time.Duration) *IdleTimeoutRe
 		defer itr.mu.Unlock()
 		if !itr.closed {
 			itr.closed = true
+			itr.timedOut = true
 			itr.inner.Close()
 		}
 	})
@@ -45,10 +48,21 @@ func NewIdleTimeoutReader(r io.ReadCloser, timeout time.Duration) *IdleTimeoutRe
 }
 
 // Read reads from the underlying reader and resets the idle timer on success.
+// If the idle timer fired and closed the underlying reader, the resulting read
+// error is reported as ErrStreamIdleTimeout so callers can distinguish a
+// deliberate idle abort from a transient network drop.
 func (r *IdleTimeoutReader) Read(p []byte) (int, error) {
 	n, err := r.inner.Read(p)
 	if n > 0 {
 		r.timer.Reset(r.timeout)
+	}
+	if err != nil {
+		r.mu.Lock()
+		timedOut := r.timedOut
+		r.mu.Unlock()
+		if timedOut {
+			return n, fmt.Errorf("%w: %v", ErrStreamIdleTimeout, err)
+		}
 	}
 	return n, err
 }

--- a/runtime/providers/idle_timeout_test.go
+++ b/runtime/providers/idle_timeout_test.go
@@ -79,6 +79,41 @@ func TestIdleTimeoutReader_TimeoutClosesBody(t *testing.T) {
 	}
 }
 
+func TestIdleTimeoutReader_TimeoutReturnsIdleTimeoutError(t *testing.T) {
+	sr := newSlowReader()
+	reader := NewIdleTimeoutReader(sr, 50*time.Millisecond)
+	defer reader.Close()
+
+	// No data arrives: the timer fires and closes the body. The resulting read
+	// error must be identifiable as a stream idle timeout, so it can be
+	// classified non-transient rather than mistaken for a retryable network drop.
+	buf := make([]byte, 1024)
+	_, err := reader.Read(buf)
+	if err == nil {
+		t.Fatal("expected error from idle timeout, got nil")
+	}
+	if !IsStreamIdleTimeout(err) {
+		t.Fatalf("expected error to be identifiable as ErrStreamIdleTimeout, got %v", err)
+	}
+}
+
+func TestIdleTimeoutReader_CleanEOFIsNotIdleTimeout(t *testing.T) {
+	// A normal end-of-stream (inner returns io.EOF without the timer firing)
+	// must NOT be reported as an idle timeout.
+	inner := nopCloser{strings.NewReader("")}
+	reader := NewIdleTimeoutReader(inner, 5*time.Second)
+	defer reader.Close()
+
+	buf := make([]byte, 16)
+	_, err := reader.Read(buf)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+	if IsStreamIdleTimeout(err) {
+		t.Fatal("clean EOF must not be reported as an idle timeout")
+	}
+}
+
 func TestIdleTimeoutReader_ResetOnData(t *testing.T) {
 	sr := newSlowReader()
 	reader := NewIdleTimeoutReader(sr, 100*time.Millisecond)

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -734,8 +734,12 @@ func (p *Provider) predictStreamBedrockFallback(
 type openAIStreamChunk struct {
 	Choices []struct {
 		Delta struct {
-			Content   string `json:"content"`
-			ToolCalls []struct {
+			Content string `json:"content"`
+			// ReasoningContent carries reasoning/thinking tokens streamed by
+			// reasoning models (o-series) before any visible content. Parsing
+			// it lets us emit keepalives that reset the idle timer.
+			ReasoningContent string `json:"reasoning_content"`
+			ToolCalls        []struct {
 				Index    int    `json:"index"`
 				ID       string `json:"id,omitempty"`
 				Type     string `json:"type,omitempty"`
@@ -879,6 +883,19 @@ func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outCh
 		}
 
 		choice := chunk.Choices[0]
+
+		// Handle reasoning deltas: reasoning models stream reasoning_content
+		// before any visible token. Emit a keepalive carrying the current
+		// content snapshot (no visible Delta) so the pipeline idle timer is
+		// reset and a long reasoning phase does not trip the idle timeout.
+		if choice.Delta.ReasoningContent != "" {
+			outChan <- providers.StreamChunk{
+				Content:    sb.String(),
+				ToolCalls:  accumulatedToolCalls,
+				TokenCount: totalTokens,
+				Reasoning:  choice.Delta.ReasoningContent,
+			}
+		}
 
 		// Handle content delta
 		if choice.Delta.Content != "" {

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +16,51 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+func TestStreamResponse_ReasoningContentEmitsKeepalive(t *testing.T) {
+	// Reasoning models (o-series) stream reasoning_content deltas before any
+	// visible token. The provider must surface these as keepalive chunks so the
+	// pipeline idle timer is reset — otherwise a >30s reasoning phase trips the
+	// idle timeout and aborts the run. Reasoning deltas carry no visible text,
+	// so they must not pollute the content stream.
+	sse := strings.Join([]string{
+		`data: {"choices":[{"delta":{"reasoning_content":"Let me "}}]}`,
+		``,
+		`data: {"choices":[{"delta":{"reasoning_content":"think."}}]}`,
+		``,
+		`data: {"choices":[{"delta":{"content":"Answer"}}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+		``,
+	}, "\n")
+
+	p := NewProvider("test", "o1", "https://api.openai.com/v1", providers.ProviderDefaults{}, false)
+	out := make(chan providers.StreamChunk, 16)
+	go p.streamResponse(context.Background(), io.NopCloser(strings.NewReader(sse)), out)
+
+	var reasoningChunks int
+	var lastContent string
+	for c := range out {
+		if c.Reasoning != "" {
+			reasoningChunks++
+			// A reasoning keepalive must not introduce visible text deltas.
+			if c.Delta != "" {
+				t.Errorf("reasoning keepalive carried a visible delta %q", c.Delta)
+			}
+		}
+		if c.Content != "" {
+			lastContent = c.Content
+		}
+	}
+
+	if reasoningChunks != 2 {
+		t.Fatalf("expected 2 reasoning keepalive chunks, got %d", reasoningChunks)
+	}
+	if lastContent != "Answer" {
+		t.Fatalf("expected accumulated content %q, got %q", "Answer", lastContent)
+	}
+}
 
 func TestNewProvider(t *testing.T) {
 	defaults := providers.ProviderDefaults{

--- a/runtime/providers/streaming.go
+++ b/runtime/providers/streaming.go
@@ -54,6 +54,12 @@ type StreamChunk struct {
 	// Delta is the new content in this chunk
 	Delta string `json:"delta"`
 
+	// Reasoning carries reasoning/thinking tokens emitted by reasoning models
+	// (e.g. OpenAI o-series) before any visible content. Reasoning chunks act
+	// as keepalives that reset the idle timer; they carry no visible Delta and
+	// must not be appended to the content stream.
+	Reasoning string `json:"reasoning,omitempty"`
+
 	// MediaData contains raw streaming media bytes (audio, video, images).
 	// Data is always raw bytes, never base64. Providers decode at source.
 	MediaData *StreamMediaData `json:"-"`

--- a/tools/arena/engine/conversation_executor_test.go
+++ b/tools/arena/engine/conversation_executor_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
@@ -67,6 +68,26 @@ func TestConversationExecutor_HandleTurnExecutionError_NonTransientFails(t *test
 	require.False(t, result.Skipped, "non-transient error should not mark result as skipped")
 	require.Equal(t, "validation failed", result.Error)
 	require.Empty(t, result.SkipReason)
+}
+
+func TestConversationExecutor_HandleTurnExecutionError_IdleTimeoutFails(t *testing.T) {
+	// Regression guard for the false-green bug: a stream idle timeout (e.g. a
+	// reasoning model that stalled past the idle window) reaches the executor
+	// wrapped as a ProviderTransportError. It must be treated as a real failure
+	// — NOT skipped — otherwise the error is cleared and a run that never
+	// executed is reported as a green PASS.
+	ce := &DefaultConversationExecutor{}
+	req := ConversationRequest{Scenario: &config.Scenario{}}
+	idleErr := &providers.ProviderTransportError{
+		Cause:    fmt.Errorf("%w: use of closed network connection", providers.ErrStreamIdleTimeout),
+		Provider: "openai",
+	}
+
+	result := ce.handleTurnExecutionError(context.Background(), &req, idleErr, 0, config.TurnDefinition{Role: "user"})
+
+	require.True(t, result.Failed, "idle timeout must mark result as failed")
+	require.False(t, result.Skipped, "idle timeout must not be skipped (that is the false green)")
+	require.NotEmpty(t, result.Error, "idle timeout must set the Error field")
 }
 
 func TestBuildConversationContext_IncludesExtras(t *testing.T) {

--- a/tools/arena/results/utils.go
+++ b/tools/arena/results/utils.go
@@ -53,6 +53,7 @@ func (b *SummaryBuilder) BuildSummary(results []engine.RunResult) *ResultSummary
 
 	// Count results by status
 	passed, failed := CountResultsByStatus(results)
+	skipped := CountSkipped(results)
 	totalTests := len(results)
 
 	// Calculate performance metrics
@@ -74,7 +75,7 @@ func (b *SummaryBuilder) BuildSummary(results []engine.RunResult) *ResultSummary
 		Passed:        passed,
 		Failed:        failed,
 		Errors:        0, // Arena doesn't distinguish between failures and errors currently
-		Skipped:       0, // Arena doesn't have skipped tests currently
+		Skipped:       skipped,
 		TotalDuration: totalDuration,
 		AverageCost:   averageCost,
 		TotalCost:     totalCost,
@@ -101,6 +102,13 @@ func (b *SummaryBuilder) BuildSummary(results []engine.RunResult) *ResultSummary
 //  3. There are violations AND some assertions fail
 func CountResultsByStatus(results []engine.RunResult) (passed, failed int) {
 	for _, result := range results {
+		if result.Skipped {
+			// Skipped runs produced no result. They are neither a pass nor a
+			// hard failure — counting them as passed is the false-green that
+			// hides aborted runs. They are surfaced separately as skipped.
+			continue
+		}
+
 		if result.Error != "" {
 			// Any error = failed
 			failed++
@@ -122,6 +130,19 @@ func CountResultsByStatus(results []engine.RunResult) (passed, failed int) {
 		}
 	}
 	return passed, failed
+}
+
+// CountSkipped counts results that were skipped (e.g. a transient provider
+// error that was deliberately skipped rather than failed). Skipped runs are
+// reported separately so they are never silently folded into the pass count.
+func CountSkipped(results []engine.RunResult) int {
+	skipped := 0
+	for i := range results {
+		if results[i].Skipped {
+			skipped++
+		}
+	}
+	return skipped
 }
 
 // AllAssertionsPassed checks if all assertions in the result passed.

--- a/tools/arena/results/utils_test.go
+++ b/tools/arena/results/utils_test.go
@@ -138,6 +138,34 @@ func TestCountResultsByStatus(t *testing.T) {
 	assert.Equal(t, 3, failed)
 }
 
+func TestCountResultsByStatus_SkippedNotCountedAsPassed(t *testing.T) {
+	// A skipped run (e.g. a transient provider error that was deliberately
+	// skipped) produced no result. It must NOT be counted as a clean pass —
+	// that is the false-green that hides aborted runs. It is also not a hard
+	// failure; it belongs in its own skipped bucket.
+	testResults := []engine.RunResult{
+		{Error: "", Skipped: true, SkipReason: "provider returned 503"},
+	}
+
+	passed, failed := results.CountResultsByStatus(testResults)
+
+	assert.Equal(t, 0, passed, "a skipped run must not be counted as passed")
+	assert.Equal(t, 0, failed, "a transient skip is not a hard failure")
+}
+
+func TestSummaryBuilder_BuildSummary_SkippedSurfaced(t *testing.T) {
+	testResults := []engine.RunResult{
+		{RunID: "r1", ScenarioID: "s1", ProviderID: "openai", Error: ""},                        // pass
+		{RunID: "r2", ScenarioID: "s1", ProviderID: "openai", Skipped: true, SkipReason: "503"}, // skipped
+	}
+
+	summary := results.NewSummaryBuilder("c.yaml").BuildSummary(testResults)
+
+	assert.Equal(t, 1, summary.Passed, "only the non-skipped run passed")
+	assert.Equal(t, 0, summary.Failed)
+	assert.Equal(t, 1, summary.Skipped, "the skipped run must be surfaced as skipped, not passed")
+}
+
 func TestCountResultsByStatus_ViolationsWithPassingAssertions(t *testing.T) {
 	// Tests the guardrail scenario: violations exist but assertions passed (guardrail_triggered)
 	testResults := []engine.RunResult{


### PR DESCRIPTION
## Summary

Closes #1311.

A reasoning model that thinks past the 30s stream idle timeout was aborted — and the aborted run was reported as a ✅ **PASS with zero assertions**, silently hiding every other result in CI. This was a two-bug compound; fixed in four parts plus a regression guard.

## The false-green chain (now broken)

Before: idle timeout closes the body → read returns `"use of closed network connection"` → matched as a retryable transient → wrapped `ProviderTransportError` → `IsTransient` = true → executor **skips** the turn and clears the error → a run with `Error == ""` and 0 violations counts as **passed**.

## Changes

**Stop the false-green (the P0):**
- `IdleTimeoutReader` now surfaces `ErrStreamIdleTimeout` when *it* closed the stream, so an idle abort is distinguishable from a genuine network drop.
- `IsTransient` treats a stream idle timeout as **non-transient** (like a context deadline). The executor no longer skips it — the run fails and CI goes red. Genuine transient 503 / h2 drops still skip as before.
- Arena result scoring surfaces skipped runs in their own bucket (`summary.Skipped`) and **never** counts a skipped run as a clean PASS.

**Make reasoning models actually work:**
- Parse `reasoning_content` in the OpenAI streaming delta and emit a keepalive chunk that resets the pipeline idle timer, so a long reasoning phase no longer trips the idle timeout. Keepalives carry no visible delta, so they don't pollute the content stream.

## Tests (TDD)

| Test | Guards |
|------|--------|
| `TestIsTransient_IdleTimeoutNeverTransient` | idle timeout (incl. wrapped) is non-transient |
| `TestIdleTimeoutReader_TimeoutReturnsIdleTimeoutError` / `_CleanEOFIsNotIdleTimeout` | reader surfaces the right error; clean EOF isn't misclassified |
| `TestCountResultsByStatus_SkippedNotCountedAsPassed` / `TestSummaryBuilder_BuildSummary_SkippedSurfaced` | skipped ≠ passed; surfaced honestly |
| `TestStreamResponse_ReasoningContentEmitsKeepalive` | reasoning deltas emit keepalives, no visible delta |
| `TestConversationExecutor_HandleTurnExecutionError_IdleTimeoutFails` | regression guard at the exact false-green boundary |

Existing transient-503-skip behavior is preserved (`TestConversationExecutor_HandleTurnExecutionError_TransientSkipped` unchanged).

## Out of scope

Full reasoning **token/cost tracking** (`reasoning_tokens` / `completion_tokens_details`) is intentionally deferred to a separate follow-up; this PR only does the minimal keepalive needed to keep reasoning models from being aborted.
