### PR TITLE
fix(providers): report zero cost for unknown/local models, not GPT-4o rates (#1317)

### DIFF
--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -627,9 +627,6 @@ func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.Co
 		// Assume cached tokens cost 50% of input tokens
 		cachedCostPer1K = inputCostPer1K * 0.5
 	} else {
-		// Fallback to hardcoded pricing with warning
-		logger.Warn("No pricing configured, using fallback pricing", "provider", p.ID(), "model", p.model)
-
 		switch p.model {
 		case "gpt-4":
 			inputCostPer1K = 0.03   // $0.03 per 1K input tokens
@@ -644,12 +641,19 @@ func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.Co
 			outputCostPer1K = 0.002   // $0.002 per 1K output tokens
 			cachedCostPer1K = 0.00075 // $0.00075 per 1K cached tokens (50% discount)
 		case "gpt-4o":
-			fallthrough // Use default GPT-4o pricing
-		default:
-			// Default to GPT-4o pricing for unknown models
 			inputCostPer1K = defaultInputCostPer1K
 			outputCostPer1K = defaultOutputCostPer1K
 			cachedCostPer1K = defaultCachedCostPer1K
+		default:
+			// Unknown model (e.g. a local/self-hosted server behind a custom
+			// base_url): there is no reliable price. Report zero rather than
+			// fabricate a cost from GPT-4o rates. Configure `pricing` on the
+			// provider to get real cost numbers for unrecognized models.
+			logger.Warn("No pricing configured for unknown model; reporting zero cost",
+				"provider", p.ID(), "model", p.model)
+			inputCostPer1K = 0
+			outputCostPer1K = 0
+			cachedCostPer1K = 0
 		}
 	}
 

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -1085,6 +1085,39 @@ func findSubstring(s, substr string) bool {
 	return false
 }
 
+func TestCalculateCost_UnknownModelReportsZero(t *testing.T) {
+	// A local / self-hosted model (custom base_url, unknown model name, no
+	// pricing configured) has no real per-token cost. Reporting a fabricated
+	// dollar figure from GPT-4o rates is misleading — it must report zero.
+	provider := NewProvider("local", "llama-3.1-70b-instruct", "http://localhost:8000/v1", providers.ProviderDefaults{}, false)
+
+	cost := provider.CalculateCost(1000, 1000, 0)
+
+	if cost.TotalCost != 0 {
+		t.Errorf("expected zero cost for unknown/local model, got %v", cost.TotalCost)
+	}
+	if cost.InputCostUSD != 0 || cost.OutputCostUSD != 0 {
+		t.Errorf("expected zero input/output cost, got in=%v out=%v", cost.InputCostUSD, cost.OutputCostUSD)
+	}
+	// Token accounting must still be correct.
+	if cost.InputTokens != 1000 || cost.OutputTokens != 1000 {
+		t.Errorf("token accounting wrong: in=%d out=%d", cost.InputTokens, cost.OutputTokens)
+	}
+}
+
+func TestCalculateCost_KnownGPT4oStillPriced(t *testing.T) {
+	// Regression guard: gpt-4o is a known model and must keep real pricing even
+	// though it previously shared the unknown-model default branch.
+	provider := NewProvider("test", "gpt-4o", "https://api.openai.com/v1", providers.ProviderDefaults{}, false)
+
+	cost := provider.CalculateCost(1000, 1000, 0)
+
+	expected := 0.0025 + 0.01
+	if diff := cost.TotalCost - expected; diff < -0.0001 || diff > 0.0001 {
+		t.Errorf("gpt-4o TotalCost = %v, want %v", cost.TotalCost, expected)
+	}
+}
+
 func TestCalculateCost_FallbackPricing(t *testing.T) {
 	// Test fallback pricing for different models (no pricing configured)
 	tests := []struct {
@@ -1128,12 +1161,12 @@ func TestCalculateCost_FallbackPricing(t *testing.T) {
 			expectedTotal: 0.0025 + 0.01, // default pricing
 		},
 		{
-			name:          "unknown model uses default pricing",
+			name:          "unknown model reports zero (no fabricated pricing)",
 			model:         "unknown-model",
 			inputTokens:   1000,
 			outputTokens:  1000,
 			cachedTokens:  0,
-			expectedTotal: 0.0025 + 0.01, // default pricing
+			expectedTotal: 0, // unknown models have no reliable price; report zero
 		},
 		{
 			name:          "gpt-4 with cached tokens",


### PR DESCRIPTION
## Summary

Closes #1317.

`CalculateCost` fell through to **GPT-4o pricing** for any unrecognized model name. A local/self-hosted model (custom `base_url`, unknown model name, no `pricing` configured) was therefore reported with a fabricated dollar cost.

## Change

- Unknown models now report **zero cost** (with a warning to configure `pricing` for real numbers) instead of fabricating GPT-4o rates.
- `gpt-4o` is split into its own explicit case so it keeps real pricing — it previously shared the unknown-model `default` branch.
- Configured `pricing` and the `gpt-4`/`gpt-4o-mini`/`gpt-3.5-turbo` fallbacks are unchanged.

## Tests (TDD)

- `TestCalculateCost_UnknownModelReportsZero` — local/unknown model → `TotalCost == 0`, token accounting still correct.
- `TestCalculateCost_KnownGPT4oStillPriced` — regression guard that `gpt-4o` keeps real pricing.
- Updated the stale `TestCalculateCost_FallbackPricing` case that asserted "unknown model uses default pricing" — it documented the bug; it now asserts zero.
