### PR TITLE
fix(build): inject real version into CLIs instead of "dev" (#1313)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,9 +19,10 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/AltairaLabs/PromptKit/tools/arena/cmd/promptarena/version.Version={{.Version}}
-      - -X github.com/AltairaLabs/PromptKit/tools/arena/cmd/promptarena/version.Commit={{.Commit}}
-      - -X github.com/AltairaLabs/PromptKit/tools/arena/cmd/promptarena/version.Date={{.Date}}
+      # main package vars (linker names package main as "main" regardless of import path)
+      - -X main.version={{.Version}}
+      - -X main.gitCommit={{.Commit}}
+      - -X main.buildDate={{.Date}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 
   - id: packc
@@ -38,9 +39,8 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/AltairaLabs/PromptKit/tools/packc/version.Version={{.Version}}
-      - -X github.com/AltairaLabs/PromptKit/tools/packc/version.Commit={{.Commit}}
-      - -X github.com/AltairaLabs/PromptKit/tools/packc/version.Date={{.Date}}
+      # packc only declares main.version (no commit/date vars)
+      - -X main.version={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 
 # Archive configuration

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,16 @@ build-arena: ## Build promptarena CLI (includes frontend if node_modules present
 
 build-packc: ## Build packc CLI
 	@echo "Building packc..."
-	@cd tools/packc && go build -o ../../bin/packc .
+	@COMMIT=$$(git rev-parse --short HEAD 2>/dev/null || echo "unknown"); \
+	BRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown"); \
+	LATEST_TAG=$$(git tag -l "tools/packc/v*" --sort=-v:refname | head -1 | sed 's|^tools/packc/||'); \
+	if git describe --tags --match "tools/packc/v*" --dirty 2>/dev/null | grep -q "tools/packc"; then \
+		VERSION=$$(git describe --tags --match "tools/packc/v*" --dirty 2>/dev/null | sed 's|^tools/packc/||'); \
+	else \
+		DIRTY=$$(git diff --quiet 2>/dev/null || echo "-dirty"); \
+		VERSION="$$LATEST_TAG-$$BRANCH+$$COMMIT$$DIRTY"; \
+	fi; \
+	cd tools/packc && go build -ldflags "-X main.version=$$VERSION" -o ../../bin/packc .
 	@echo "packc built successfully -> bin/packc"
 
 build-inspect-state: ## Build inspect-state utility


### PR DESCRIPTION
## Summary

Closes #1313.

Installed CLIs self-reported version `dev`. Two independent injection bugs:

1. **`make build-packc`** did a plain `go build` with no ldflags, so packc never got a version (`build-arena` already injected one correctly).
2. **`.goreleaser.yml`** targeted a non-existent symbol path — `.../cmd/promptarena/version.Version` and `.../tools/packc/version.Version`. The vars actually live in `package main` (`main.version`, `main.gitCommit`, `main.buildDate`), and the Go linker **always names the main package `main`** for `-X` regardless of import path. So even release binaries reported `dev`.

## Change

- `build-packc` now computes a version from `tools/packc/v*` tags and injects `-X main.version=...` (mirrors `build-arena`).
- goreleaser ldflags fixed to `-X main.version` / `main.gitCommit` / `main.buildDate` for promptarena, and `-X main.version` for packc (packc has no commit/date vars).

## Verification

- `make build-packc` → `packc version` reports `v1.4.14-…` (was `dev`). Confirmed the symbol is `main.version` via `go tool nm`.
- `goreleaser check` validates the config.

No Go source changed.
