### PR TITLE
fix(schema-gen): --format preserves key order instead of alphabetizing

### DIFF
--- a/tools/schema-gen/main.go
+++ b/tools/schema-gen/main.go
@@ -245,17 +245,19 @@ func formatExistingSchemas(outputPath string) error {
 			return fmt.Errorf("failed to read %s: %w", file, err)
 		}
 
-		var schema interface{}
-		if unmarshalErr := json.Unmarshal(data, &schema); unmarshalErr != nil {
-			return fmt.Errorf("failed to parse %s: %w", file, unmarshalErr)
+		// Re-indent in place with json.Indent, which preserves the original key
+		// order. Round-tripping through a map (Unmarshal → MarshalIndent) sorts
+		// keys alphabetically, which diverges from the canonical invopop-ordered
+		// generate output and silently rewrites every schema — breaking the
+		// `--check` CI guard.
+		var buf bytes.Buffer
+		if indentErr := json.Indent(&buf, data, "", "  "); indentErr != nil {
+			return fmt.Errorf("failed to format %s: %w", file, indentErr)
 		}
-
-		formatted, err := json.MarshalIndent(schema, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to format %s: %w", file, err)
-		}
-
-		formatted = append(formatted, '\n')
+		// json.Indent preserves any trailing newline from the source; normalise
+		// to exactly one so the result matches the canonical generate output
+		// (MarshalIndent + a single "\n") byte-for-byte.
+		formatted := append(bytes.TrimRight(buf.Bytes(), "\n"), '\n')
 
 		if err := os.WriteFile(file, formatted, filePermissions); err != nil {
 			return fmt.Errorf("failed to write %s: %w", file, err)

--- a/tools/schema-gen/main_test.go
+++ b/tools/schema-gen/main_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -121,6 +123,76 @@ func TestFormatExistingSchemas(t *testing.T) {
 	var result map[string]interface{}
 	if err := json.Unmarshal(formatted, &result); err != nil {
 		t.Errorf("Formatted data is not valid JSON: %v", err)
+	}
+}
+
+func TestFormatExistingSchemas_PreservesKeyOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "ordered.json")
+
+	// Canonical schema ordering is NOT alphabetical: $schema and $id come first,
+	// and property keys follow struct-declaration order (here "type" before
+	// "message"). Formatting must preserve this byte order — re-marshalling via a
+	// generic map sorts keys alphabetically, which silently rewrites every schema
+	// and breaks the `--check` CI guard.
+	original := []byte(`{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://example.com/ordered.json",
+  "type": "object",
+  "message": "x"
+}
+`)
+	if err := os.WriteFile(testFile, original, filePermissions); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := formatExistingSchemas(tmpDir); err != nil {
+		t.Fatalf("format: %v", err)
+	}
+
+	got, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(got)
+
+	if strings.Index(s, "$schema") > strings.Index(s, "$id") {
+		t.Errorf("key order not preserved: $schema must precede $id\n%s", s)
+	}
+	if strings.Index(s, `"type"`) > strings.Index(s, `"message"`) {
+		t.Errorf("key order not preserved: type must precede message\n%s", s)
+	}
+}
+
+func TestFormatExistingSchemas_IdempotentOnCanonicalOutput(t *testing.T) {
+	// Formatting must be byte-identical to the canonical generate output so the
+	// `--check` CI guard stays green. marshalSchema is exactly what the generate
+	// path writes; re-formatting it must not change a single byte (no key
+	// reordering, no extra trailing newline).
+	canonical, err := marshalSchema(map[string]interface{}{
+		"type":    "object",
+		"message": "x",
+	}, "test")
+	if err != nil {
+		t.Fatalf("marshalSchema: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "canonical.json")
+	if err := os.WriteFile(testFile, canonical, filePermissions); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := formatExistingSchemas(tmpDir); err != nil {
+		t.Fatalf("format: %v", err)
+	}
+
+	got, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, canonical) {
+		t.Errorf("format changed canonical output:\nwant: %q\ngot:  %q", canonical, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Investigated the schema-gen drift flagged during the #1311 work (every `schemas/v1alpha1/*.json` getting rewritten with reordered keys and `$schema`/`$id` moved far down).

**Root cause:** `schema-gen --format` (`formatExistingSchemas`) round-tripped each schema through a `map[string]interface{}` and re-marshalled with `json.MarshalIndent`. Go's `encoding/json` **sorts map keys alphabetically**, so `--format` produced output that diverges from the canonical generate path (invopop's `*jsonschema.Schema` marshaler, which preserves declaration order with `$schema`/`$id` first). Running `--format` silently rewrote all 9 schemas and would break the `--check` CI guard (`.github/workflows/schemas.yml`).

The canonical `make schemas` / `go run ./tools/schema-gen/...` path was always correct — only `--format` was broken. Nothing in the Makefile/CI invokes `--format`, but it's a live footgun for anyone who runs it.

## Fix

Re-indent in place with `json.Indent` (preserves byte/key order) instead of the map round-trip, and normalise the trailing newline to exactly one so the result is byte-identical to the generate output (`MarshalIndent` + `"\n"`).

## Tests (TDD)

- `TestFormatExistingSchemas_PreservesKeyOrder` — non-alphabetical key order (`$schema` before `$id`, `type` before `message`) survives formatting.
- `TestFormatExistingSchemas_IdempotentOnCanonicalOutput` — formatting `marshalSchema` output is byte-identical (caught the doubled trailing newline).

## Verification

`go run ./tools/schema-gen/... -format` followed by `-check` now produces **zero drift** on the committed schemas (previously `-format` rewrote all 9). Full schema-gen suite green; `golangci-lint` clean.

This unblocks #1314/#1315 (assertion schema work), which require regenerating schemas safely.
