### PR TITLE
fix(schema): make assertion params optional (#1314)

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -17,8 +17,11 @@ import (
 // This type is defined here (rather than in tools/arena/assertions) to avoid
 // an inverted dependency from the shared pkg/config package to the arena tool.
 type AssertionConfig struct {
-	Type    string                 `json:"type" yaml:"type"`
-	Params  map[string]interface{} `json:"params" yaml:"params"`
+	Type string `json:"type" yaml:"type"`
+	// Params is optional: many assertion types take no parameters, so an
+	// entry with only `type:` is valid and must not require an empty
+	// `params: {}` stub. omitempty also drops it from the schema's required set.
+	Params  map[string]interface{} `json:"params,omitempty" yaml:"params,omitempty"`
 	Message string                 `json:"message,omitempty" yaml:"message,omitempty"`
 	When    *AssertionWhen         `json:"when,omitempty" yaml:"when,omitempty"`
 	// PassThreshold is the minimum pass rate (0.0-1.0) required across trials.

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -213,8 +213,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "type",
-        "params"
+        "type"
       ]
     },
     "AssertionWhen": {

--- a/schemas/v1alpha1/eval.json
+++ b/schemas/v1alpha1/eval.json
@@ -23,8 +23,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "type",
-        "params"
+        "type"
       ]
     },
     "AssertionWhen": {

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -23,8 +23,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "type",
-        "params"
+        "type"
       ]
     },
     "AssertionWhen": {

--- a/tools/schema-gen/generators/generators_test.go
+++ b/tools/schema-gen/generators/generators_test.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/invopop/jsonschema"
@@ -65,6 +66,32 @@ func TestGenerateScenarioSchema(t *testing.T) {
 	expectedID := schemaBaseURL + "/scenario.json"
 	if string(jsonSchema.ID) != expectedID {
 		t.Errorf("Schema ID = %v, want %v", jsonSchema.ID, expectedID)
+	}
+}
+
+func TestGenerateScenarioSchema_AssertionParamsOptional(t *testing.T) {
+	schema, err := GenerateScenarioSchema()
+	if err != nil {
+		t.Fatalf("GenerateScenarioSchema() error = %v", err)
+	}
+	js, ok := schema.(*jsonschema.Schema)
+	if !ok {
+		t.Fatal("GenerateScenarioSchema() did not return *jsonschema.Schema")
+	}
+
+	def, ok := js.Definitions["AssertionConfig"]
+	if !ok {
+		t.Fatal("AssertionConfig definition not found in scenario schema")
+	}
+
+	// `type` is genuinely required — every assertion names a handler.
+	if !slices.Contains(def.Required, "type") {
+		t.Errorf("AssertionConfig should require 'type', got required=%v", def.Required)
+	}
+	// `params` must be OPTIONAL: param-less assertions are valid and must not
+	// need an explicit `params: {}` stub.
+	if slices.Contains(def.Required, "params") {
+		t.Errorf("AssertionConfig must not require 'params' (param-less assertions are valid), got required=%v", def.Required)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1314.

Param-less assertions (an entry with only `type:`) failed schema validation unless padded with an empty `params: {}`. `AssertionConfig.Params` lacked `omitempty`, so the reflector (`RequiredFromJSONSchemaTags: false`) marked `params` as required alongside `type`.

## Change

- Add `omitempty` to `Params` (json + yaml tags) in `pkg/config/types.go` so it drops out of the schema's `required` set. `type` stays required.
- Regenerate the three schemas that embed `AssertionConfig`: `arena.json`, `eval.json`, `scenario.json` (`required: ["type","params"]` → `["type"]`).

Consumers already handle nil params (`tools/arena/assertions/types.go`, `tools/arena/stages/assertions.go`).

## Tests

- `TestGenerateScenarioSchema_AssertionParamsOptional` — asserts the generated `AssertionConfig` keeps `type` required but **not** `params`.
- `make schemas` `--check` passes (schemas in sync); pkg/config + arena reader/assertions/stages/engine suites green.

## Note

This is the quick half of the assertion-schema work. #1315 (the schema's `params` is an untyped `object` stub — no per-assertion-type param keys) remains open and needs the generator to introspect the assertion registry. Unblocked now that #1322 fixed the `--format` drift, so schema regen is clean.
