### PR TITLE
fix(providers): allow keyless OpenAI embeddings for custom base URLs (#1316)

### DIFF
--- a/runtime/providers/openai/embedding.go
+++ b/runtime/providers/openai/embedding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -117,7 +118,11 @@ func NewEmbeddingProvider(opts ...EmbeddingOption) (*EmbeddingProvider, error) {
 			_, apiKey := providers.NewBaseProviderWithAPIKey("", false, "OPENAI_API_KEY", "OPENAI_TOKEN")
 			p.APIKey = apiKey
 		}
-		if p.APIKey == "" {
+		// Require a key only for the canonical OpenAI endpoint. A custom base
+		// URL (a local/self-hosted server or proxy) may be keyless;
+		// DoEmbeddingRequest omits the Authorization header when no key is set,
+		// so a dummy key is never needed for keyless local servers.
+		if p.APIKey == "" && strings.Contains(p.BaseURL, "api.openai.com") {
 			return nil, fmt.Errorf("OpenAI API key not found: set OPENAI_API_KEY environment variable")
 		}
 	}

--- a/runtime/providers/openai/embedding_test.go
+++ b/runtime/providers/openai/embedding_test.go
@@ -48,6 +48,18 @@ func TestNewEmbeddingProvider(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "API key not found")
 	})
+
+	t.Run("keyless allowed with custom base URL", func(t *testing.T) {
+		// A local / self-hosted OpenAI-compatible embedding server (custom base
+		// URL, no auth) must not require a dummy API key. The request layer omits
+		// the Authorization header when no key is set.
+		t.Setenv("OPENAI_API_KEY", "")
+		t.Setenv("OPENAI_TOKEN", "")
+
+		p, err := NewEmbeddingProvider(WithEmbeddingBaseURL("http://localhost:1234/v1"))
+		require.NoError(t, err, "keyless custom base URL must be allowed")
+		assert.Empty(t, p.APIKey)
+	})
 }
 
 func TestEmbeddingProvider_Embed(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1316.

A local / self-hosted OpenAI-compatible **embedding** server (custom `base_url`, no auth) still required an API key — `NewEmbeddingProvider` hard-errored `"OpenAI API key not found"` when no key was found, forcing a dummy `OPENAI_API_KEY`.

(The triage originally pointed at the chat provider, but tracing showed the chat path already tolerates an empty key — `applyAuth` omits the `Authorization` header when none is set. The embedding path was the one that actually demanded a key.)

## Change

Require a key only for the **canonical OpenAI endpoint** (`api.openai.com`) — preserving the friendly "set OPENAI_API_KEY" hint for the common forgot-the-key case. A **custom base URL** may now be keyless; the request layer already omits the `Authorization` header when no key is set (`base_embedding.go:148`), so a dummy key is never needed for local servers. This brings embeddings in line with chat.

Azure keyless (PR #1299) is unaffected — it uses `PlatformAuth`, which skips the guard entirely.

## Tests (TDD)

- `keyless allowed with custom base URL` — `NewEmbeddingProvider(WithEmbeddingBaseURL("http://localhost:1234/v1"))` with no key succeeds, `APIKey` empty.
- Existing `fails without API key` (default endpoint, no key) still errors — regression guard kept.

Full `runtime/providers/openai/...` suite green.
