### PR TITLE
feat(sdk): inference-provider registry on the pipeline + uniform WithXProvider family

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -50,6 +50,13 @@ type RuntimeConfigSpec struct {
 	//nolint:lll // jsonschema tags require single line
 	STTProviders []STTProviderConfig `yaml:"stt_providers,omitempty" json:"stt_providers,omitempty" jsonschema:"title=STT Providers,description=Speech-to-text provider configurations"`
 
+	// InferenceProviders configures inference (classify) providers
+	// (HuggingFace). Used by classify-backed eval handlers
+	// (audio_emotion, text_toxicity, …). First declared provider
+	// implementing a task becomes that task's default.
+	//nolint:lll // jsonschema tags require single line
+	InferenceProviders []InferenceProviderConfig `yaml:"inference_providers,omitempty" json:"inference_providers,omitempty" jsonschema:"title=Inference Providers,description=Inference (classify) provider configurations"`
+
 	// Tools binds pack tool names to implementations (HTTP, mock, or exec).
 	//nolint:lll // jsonschema tags require single line
 	Tools map[string]*ToolSpec `yaml:"tools,omitempty" json:"tools,omitempty" jsonschema:"title=Tools,description=Tool implementation bindings keyed by tool name"`
@@ -223,6 +230,29 @@ type STTProviderConfig struct {
 	AdditionalConfig map[string]any `yaml:"additional_config,omitempty" json:"additional_config,omitempty" jsonschema:"title=Additional Config,description=Provider-specific extras"`
 }
 
+// InferenceProviderConfig declares an inference (classify) provider —
+// the SDK twin of Arena's `providers:` entry with role: inference. Used
+// by classify-backed eval handlers (audio_emotion, text_toxicity, …).
+type InferenceProviderConfig struct {
+	// ID is a stable identifier; defaults to the type when empty.
+	ID string `yaml:"id,omitempty" json:"id,omitempty" jsonschema:"title=ID,description=Stable identifier"`
+	// Type selects the implementation. Today only "huggingface".
+	Type string `yaml:"type" json:"type" jsonschema:"enum=huggingface,title=Type,description=Inference provider type"`
+	// Model overrides the provider's default classification model.
+	//nolint:lll // jsonschema tags require single line
+	Model string `yaml:"model,omitempty" json:"model,omitempty" jsonschema:"title=Model,description=Classification model name"`
+	// BaseURL overrides the provider's default API endpoint.
+	//nolint:lll // jsonschema tags require single line
+	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty" jsonschema:"title=BaseURL,description=API endpoint override"`
+	// Credential names how to obtain the API key.
+	//nolint:lll // jsonschema tags require single line
+	Credential *CredentialConfig `yaml:"credential,omitempty" json:"credential,omitempty" jsonschema:"title=Credential,description=API key resolution"`
+	// AdditionalConfig carries provider-specific extras (e.g. dedicated
+	// endpoint flag for HuggingFace).
+	//nolint:lll // jsonschema tags require single line
+	AdditionalConfig map[string]any `yaml:"additional_config,omitempty" json:"additional_config,omitempty" jsonschema:"title=Additional Config,description=Provider-specific extras"`
+}
+
 // SandboxConfig declares a named sandbox backend. Mode selects a
 // factory registered via runtime/hooks/sandbox.RegisterFactory; every
 // other field is passed to the factory as its config map.
@@ -331,6 +361,9 @@ func (s *RuntimeConfigSpec) Validate() error {
 		return err
 	}
 	if err := s.validateSTTProviders(); err != nil {
+		return err
+	}
+	if err := s.validateInferenceProviders(); err != nil {
 		return err
 	}
 	if err := s.validateStateStore(); err != nil {
@@ -509,6 +542,43 @@ func (s *RuntimeConfigSpec) validateSTTProviders() error {
 			return &ValidationError{
 				Field:   fmt.Sprintf("stt_providers[%d].id", i),
 				Message: "duplicate STT provider id",
+				Value:   id,
+			}
+		}
+		seen[id] = true
+	}
+	return nil
+}
+
+var validInferenceTypes = map[string]bool{
+	"huggingface": true,
+}
+
+func (s *RuntimeConfigSpec) validateInferenceProviders() error {
+	seen := make(map[string]bool, len(s.InferenceProviders))
+	for i := range s.InferenceProviders {
+		ip := &s.InferenceProviders[i]
+		if ip.Type == "" {
+			return &ValidationError{
+				Field:   fmt.Sprintf("inference_providers[%d].type", i),
+				Message: "inference provider type is required",
+			}
+		}
+		if !validInferenceTypes[ip.Type] {
+			return &ValidationError{
+				Field:   fmt.Sprintf("inference_providers[%d].type", i),
+				Message: "must be one of: huggingface",
+				Value:   ip.Type,
+			}
+		}
+		id := ip.ID
+		if id == "" {
+			id = ip.Type
+		}
+		if seen[id] {
+			return &ValidationError{
+				Field:   fmt.Sprintf("inference_providers[%d].id", i),
+				Message: "duplicate inference provider id",
 				Value:   id,
 			}
 		}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -888,3 +888,36 @@ func TestRuntimeConfigSpec_Validate_StateStore_RejectsUnknownType(t *testing.T) 
 		t.Fatal("expected error for unknown store type")
 	}
 }
+
+func TestValidateInferenceProviders_TypeRequired(t *testing.T) {
+	s := &RuntimeConfigSpec{InferenceProviders: []InferenceProviderConfig{{Model: "x"}}}
+	if err := s.validateInferenceProviders(); err == nil {
+		t.Fatal("expected error when type is empty")
+	}
+}
+
+func TestValidateInferenceProviders_UnknownType(t *testing.T) {
+	s := &RuntimeConfigSpec{InferenceProviders: []InferenceProviderConfig{{Type: "bogus"}}}
+	if err := s.validateInferenceProviders(); err == nil {
+		t.Fatal("expected error for unknown inference provider type")
+	}
+}
+
+func TestValidateInferenceProviders_DuplicateID(t *testing.T) {
+	s := &RuntimeConfigSpec{InferenceProviders: []InferenceProviderConfig{
+		{ID: "hf", Type: "huggingface"},
+		{ID: "hf", Type: "huggingface"},
+	}}
+	if err := s.validateInferenceProviders(); err == nil {
+		t.Fatal("expected duplicate-id error")
+	}
+}
+
+func TestValidateInferenceProviders_Valid(t *testing.T) {
+	s := &RuntimeConfigSpec{InferenceProviders: []InferenceProviderConfig{
+		{ID: "hf", Type: "huggingface"},
+	}}
+	if err := s.validateInferenceProviders(); err != nil {
+		t.Fatalf("valid inference provider rejected: %v", err)
+	}
+}

--- a/runtime/classify/backends/all/all.go
+++ b/runtime/classify/backends/all/all.go
@@ -1,0 +1,8 @@
+// Package all blank-imports every classify backend so their factories
+// self-register. Import this (with _) from any consumer that builds a
+// classify.Registry from config (the SDK, Arena).
+package all
+
+import (
+	_ "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf" // register "huggingface" factory
+)

--- a/runtime/classify/backends/hf/register.go
+++ b/runtime/classify/backends/hf/register.go
@@ -1,0 +1,28 @@
+package hf
+
+import (
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// huggingFaceType is the provider `type` string for HF Inference API
+// classify backends. Matches Arena's existing `role: inference` entries.
+const huggingFaceType = "huggingface"
+
+//nolint:gochecknoinits // Factory registration requires init.
+func init() {
+	classify.RegisterFactory(huggingFaceType, func(spec classify.ProviderSpec) (classify.Backend, error) {
+		return NewClient(Config{
+			APIKey:    base.APIKeyFromCredential(spec.Credential),
+			BaseURL:   spec.BaseURL,
+			Dedicated: boolFromConfig(spec.AdditionalConfig, "dedicated"),
+		})
+	})
+}
+
+// boolFromConfig reads a boolean flag from a provider's additional_config.
+// Returns false when the key is absent or not a bool.
+func boolFromConfig(m map[string]any, key string) bool {
+	v, ok := m[key].(bool)
+	return ok && v
+}

--- a/runtime/classify/backends/hf/register_test.go
+++ b/runtime/classify/backends/hf/register_test.go
@@ -23,6 +23,9 @@ func TestHuggingFaceFactoryRegistered(t *testing.T) {
 	if _, ok := b.(classify.TextClassifier); !ok {
 		t.Fatal("HF backend should implement TextClassifier")
 	}
+	if _, ok := b.(classify.ImageClassifier); !ok {
+		t.Fatal("HF backend should implement ImageClassifier")
+	}
 	// HF deliberately does NOT implement VideoClassifier.
 	if _, ok := b.(classify.VideoClassifier); ok {
 		t.Fatal("HF backend should NOT implement VideoClassifier")

--- a/runtime/classify/backends/hf/register_test.go
+++ b/runtime/classify/backends/hf/register_test.go
@@ -1,0 +1,43 @@
+package hf_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	_ "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+)
+
+func TestHuggingFaceFactoryRegistered(t *testing.T) {
+	b, err := classify.CreateFromSpec(classify.ProviderSpec{
+		ID:         "hf",
+		Type:       "huggingface",
+		Credential: credentials.NewAPIKeyCredential("tok"),
+	})
+	if err != nil {
+		t.Fatalf("CreateFromSpec: %v", err)
+	}
+	if _, ok := b.(classify.AudioClassifier); !ok {
+		t.Fatal("HF backend should implement AudioClassifier")
+	}
+	if _, ok := b.(classify.TextClassifier); !ok {
+		t.Fatal("HF backend should implement TextClassifier")
+	}
+	// HF deliberately does NOT implement VideoClassifier.
+	if _, ok := b.(classify.VideoClassifier); ok {
+		t.Fatal("HF backend should NOT implement VideoClassifier")
+	}
+}
+
+func TestHuggingFaceFactory_DedicatedFlag(t *testing.T) {
+	_, err := classify.CreateFromSpec(classify.ProviderSpec{
+		ID:               "hf",
+		Type:             "huggingface",
+		BaseURL:          "https://x.endpoints.huggingface.cloud",
+		Credential:       credentials.NewAPIKeyCredential("tok"),
+		AdditionalConfig: map[string]any{"dedicated": true},
+	})
+	if err != nil {
+		t.Fatalf("CreateFromSpec with dedicated: %v", err)
+	}
+}

--- a/runtime/classify/factory.go
+++ b/runtime/classify/factory.go
@@ -1,0 +1,158 @@
+package classify
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// ProviderSpec is the runtime form of an inference-provider declaration.
+// Aliased to base.CapabilitySpec so the field shape is shared with the
+// TTS, STT, embedding, and image factories (id/type/model/base_url/
+// credential/additional_config).
+type ProviderSpec = base.CapabilitySpec
+
+// Backend is whatever a factory returns: a value that implements one or
+// more of the task interfaces (AudioClassifier, TextClassifier, …).
+// RegisterBackend type-asserts it against each. It is intentionally an
+// alias for any — there is no method common to all task interfaces.
+type Backend = any
+
+// Factory builds a Backend from a spec. Per-backend packages register
+// one via init() (see runtime/classify/backends/hf/register.go) so this
+// package never imports them.
+type Factory = base.Factory[Backend]
+
+var classifyRegistry = base.NewFactoryRegistry[Backend]()
+
+// RegisterFactory registers a factory for the given provider type.
+// Typically called from a per-backend package init().
+func RegisterFactory(providerType string, f Factory) {
+	classifyRegistry.Register(providerType, f)
+}
+
+// CreateFromSpec builds a Backend for the spec's Type.
+//
+//nolint:gocritic // spec is a value-semantics builder; callers assemble inline.
+func CreateFromSpec(spec ProviderSpec) (Backend, error) {
+	return classifyRegistry.Create(spec)
+}
+
+// ResolveCredential is a thin wrapper around base.ResolveCredential,
+// matching tts.ResolveCredential / stt.ResolveCredential.
+func ResolveCredential(
+	ctx context.Context,
+	providerType string,
+	cfgDir string,
+	cred *credentials.CredentialConfig,
+) (credentials.Credential, error) {
+	return base.ResolveCredential(ctx, providerType, cfgDir, cred)
+}
+
+// RegistryDefaults pins which provider id serves each task when a
+// handler doesn't name one. Mirrors config.InferenceDefaults but lives
+// in runtime so both Arena and the SDK map onto it.
+type RegistryDefaults struct {
+	AudioClassifier string
+	TextClassifier  string
+	ImageClassifier string
+	VideoClassifier string
+	Embedder        string
+}
+
+// RegisterBackend registers b under id against every task interface it
+// implements, returning the task labels registered (e.g. ["audio",
+// "text"]). A backend that satisfies no task interface registers nothing
+// and returns an empty slice. Shared by BuildRegistry and the SDK's
+// programmatic options so the type-assert logic lives in one place.
+func RegisterBackend(reg *Registry, id string, b Backend) []string {
+	var tasks []string
+	if c, ok := b.(AudioClassifier); ok {
+		reg.RegisterAudio(id, c)
+		tasks = append(tasks, "audio")
+	}
+	if c, ok := b.(TextClassifier); ok {
+		reg.RegisterText(id, c)
+		tasks = append(tasks, "text")
+	}
+	if c, ok := b.(ImageClassifier); ok {
+		reg.RegisterImage(id, c)
+		tasks = append(tasks, "image")
+	}
+	if c, ok := b.(VideoClassifier); ok {
+		reg.RegisterVideo(id, c)
+		tasks = append(tasks, "video")
+	}
+	if c, ok := b.(Embedder); ok {
+		reg.RegisterEmbedder(id, c)
+		tasks = append(tasks, "embedder")
+	}
+	return tasks
+}
+
+// BuildRegistry constructs a Registry from specs, registering each
+// backend against every task interface it implements, then applies
+// defaults. For any task with no explicit default, the first-declared
+// provider implementing it becomes the default (first-wins, matching
+// STT/TTS service defaults). Returns (nil, nil) when specs is empty —
+// classification is optional; callers that don't use it must not require
+// a token.
+//
+//nolint:gocritic // RegistryDefaults is a flat value type; pointer indirection adds no benefit here.
+func BuildRegistry(specs []ProviderSpec, defaults RegistryDefaults) (*Registry, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	reg := NewRegistry()
+	first := make(map[string]string)
+	for i := range specs {
+		spec := specs[i]
+		if spec.ID == "" {
+			return nil, fmt.Errorf("classify: inference provider at index %d has empty id", i)
+		}
+		b, err := CreateFromSpec(spec)
+		if err != nil {
+			return nil, fmt.Errorf("classify: inference provider %q: %w", spec.ID, err)
+		}
+		for _, task := range RegisterBackend(reg, spec.ID, b) {
+			if _, ok := first[task]; !ok {
+				first[task] = spec.ID
+			}
+		}
+	}
+	if err := applyDefaults(reg, defaults, first); err != nil {
+		return nil, err
+	}
+	return reg, nil
+}
+
+//nolint:gocritic // RegistryDefaults is a flat value type; pointer indirection adds no benefit here.
+func applyDefaults(reg *Registry, d RegistryDefaults, first map[string]string) error {
+	pick := func(explicit, task string) string {
+		if explicit != "" {
+			return explicit
+		}
+		return first[task]
+	}
+	type defPair struct {
+		id  string
+		set func(string) error
+	}
+	for _, p := range []defPair{
+		{pick(d.AudioClassifier, "audio"), reg.SetDefaultAudio},
+		{pick(d.TextClassifier, "text"), reg.SetDefaultText},
+		{pick(d.ImageClassifier, "image"), reg.SetDefaultImage},
+		{pick(d.VideoClassifier, "video"), reg.SetDefaultVideo},
+		{pick(d.Embedder, "embedder"), reg.SetDefaultEmbedder},
+	} {
+		if p.id == "" {
+			continue
+		}
+		if err := p.set(p.id); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/runtime/classify/factory_test.go
+++ b/runtime/classify/factory_test.go
@@ -1,0 +1,191 @@
+package classify_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+)
+
+// fakeText implements only TextClassifier, to prove partial-interface
+// backends register against just the interfaces they satisfy.
+type fakeText struct{}
+
+func (fakeText) ClassifyText(_ context.Context, _ string, _ classify.TextOptions) ([]classify.LabelScore, error) {
+	return []classify.LabelScore{{Label: "ok", Score: 1}}, nil
+}
+
+// fakeAll implements every task interface so RegisterBackend covers all paths.
+type fakeAll struct{}
+
+func (fakeAll) ClassifyText(_ context.Context, _ string, _ classify.TextOptions) ([]classify.LabelScore, error) {
+	return nil, nil
+}
+func (fakeAll) ClassifyAudio(_ context.Context, _ []byte, _ classify.AudioOptions) ([]classify.LabelScore, error) {
+	return nil, nil
+}
+func (fakeAll) ClassifyImage(_ context.Context, _ []byte, _ classify.ImageOptions) ([]classify.LabelScore, error) {
+	return nil, nil
+}
+func (fakeAll) ClassifyVideo(_ context.Context, _ []byte, _ classify.VideoOptions) ([]classify.LabelScore, error) {
+	return nil, nil
+}
+func (fakeAll) Embed(_ context.Context, _ []string, _ classify.EmbedOptions) ([][]float32, error) {
+	return nil, nil
+}
+
+func TestRegisterBackend_PartialInterface(t *testing.T) {
+	reg := classify.NewRegistry()
+	tasks := classify.RegisterBackend(reg, "fake", fakeText{})
+	if len(tasks) != 1 || tasks[0] != "text" {
+		t.Fatalf("expected [text], got %v", tasks)
+	}
+	if _, err := reg.TextClassifier("fake"); err != nil {
+		t.Fatalf("text classifier should resolve: %v", err)
+	}
+	if _, err := reg.AudioClassifier("fake"); err == nil {
+		t.Fatal("audio classifier should NOT be registered for a text-only backend")
+	}
+}
+
+func TestBuildRegistry_FirstWinsDefault(t *testing.T) {
+	classify.RegisterFactory("faketext", func(_ classify.ProviderSpec) (classify.Backend, error) {
+		return fakeText{}, nil
+	})
+	reg, err := classify.BuildRegistry(
+		[]classify.ProviderSpec{{ID: "a", Type: "faketext"}, {ID: "b", Type: "faketext"}},
+		classify.RegistryDefaults{},
+	)
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+	// Empty id resolves to the first-declared provider that implements the task.
+	c, err := reg.TextClassifier("")
+	if err != nil {
+		t.Fatalf("default text classifier: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil default text classifier")
+	}
+}
+
+func TestBuildRegistry_EmptyReturnsNil(t *testing.T) {
+	reg, err := classify.BuildRegistry(nil, classify.RegistryDefaults{})
+	if err != nil || reg != nil {
+		t.Fatalf("expected (nil, nil), got (%v, %v)", reg, err)
+	}
+}
+
+func TestBuildRegistry_ExplicitDefaultOverrides(t *testing.T) {
+	classify.RegisterFactory("faketext2", func(_ classify.ProviderSpec) (classify.Backend, error) {
+		return fakeText{}, nil
+	})
+	reg, err := classify.BuildRegistry(
+		[]classify.ProviderSpec{{ID: "a", Type: "faketext2"}, {ID: "b", Type: "faketext2"}},
+		classify.RegistryDefaults{TextClassifier: "b"},
+	)
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+	if _, err := reg.TextClassifier(""); err != nil {
+		t.Fatalf("explicit default should resolve: %v", err)
+	}
+}
+
+func TestBuildRegistry_UnknownType(t *testing.T) {
+	_, err := classify.BuildRegistry(
+		[]classify.ProviderSpec{{ID: "x", Type: "nope"}},
+		classify.RegistryDefaults{},
+	)
+	if err == nil {
+		t.Fatal("expected error for unknown provider type")
+	}
+}
+
+func TestBuildRegistry_EmptyIDError(t *testing.T) {
+	classify.RegisterFactory("fakeid", func(_ classify.ProviderSpec) (classify.Backend, error) {
+		return fakeText{}, nil
+	})
+	_, err := classify.BuildRegistry(
+		[]classify.ProviderSpec{{Type: "fakeid"}}, // no ID
+		classify.RegistryDefaults{},
+	)
+	if err == nil {
+		t.Fatal("expected error for empty provider id")
+	}
+}
+
+func TestRegisterBackend_AllInterfaces(t *testing.T) {
+	reg := classify.NewRegistry()
+	tasks := classify.RegisterBackend(reg, "all", fakeAll{})
+	// Should register all 5 task types.
+	if len(tasks) != 5 {
+		t.Fatalf("expected 5 tasks registered, got %d: %v", len(tasks), tasks)
+	}
+	if _, err := reg.AudioClassifier("all"); err != nil {
+		t.Fatalf("audio: %v", err)
+	}
+	if _, err := reg.TextClassifier("all"); err != nil {
+		t.Fatalf("text: %v", err)
+	}
+	if _, err := reg.ImageClassifier("all"); err != nil {
+		t.Fatalf("image: %v", err)
+	}
+	if _, err := reg.VideoClassifier("all"); err != nil {
+		t.Fatalf("video: %v", err)
+	}
+	if _, err := reg.Embedder("all"); err != nil {
+		t.Fatalf("embedder: %v", err)
+	}
+}
+
+func TestRegisterBackend_NoInterface(t *testing.T) {
+	reg := classify.NewRegistry()
+	tasks := classify.RegisterBackend(reg, "none", struct{}{})
+	if len(tasks) != 0 {
+		t.Fatalf("expected no tasks, got %v", tasks)
+	}
+}
+
+func TestBuildRegistry_AllTaskDefaults(t *testing.T) {
+	classify.RegisterFactory("fakeall", func(_ classify.ProviderSpec) (classify.Backend, error) {
+		return fakeAll{}, nil
+	})
+	reg, err := classify.BuildRegistry(
+		[]classify.ProviderSpec{{ID: "x", Type: "fakeall"}},
+		classify.RegistryDefaults{},
+	)
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+	// All task defaults should be set to "x" by first-wins.
+	if _, err := reg.AudioClassifier(""); err != nil {
+		t.Fatalf("default audio: %v", err)
+	}
+	if _, err := reg.TextClassifier(""); err != nil {
+		t.Fatalf("default text: %v", err)
+	}
+	if _, err := reg.ImageClassifier(""); err != nil {
+		t.Fatalf("default image: %v", err)
+	}
+	if _, err := reg.VideoClassifier(""); err != nil {
+		t.Fatalf("default video: %v", err)
+	}
+	if _, err := reg.Embedder(""); err != nil {
+		t.Fatalf("default embedder: %v", err)
+	}
+}
+
+func TestResolveCredential_APIKey(t *testing.T) {
+	cred, err := classify.ResolveCredential(
+		context.Background(), "huggingface", "",
+		&credentials.CredentialConfig{APIKey: "test-key"},
+	)
+	if err != nil {
+		t.Fatalf("ResolveCredential: %v", err)
+	}
+	if cred == nil {
+		t.Fatal("expected non-nil credential")
+	}
+}

--- a/runtime/pipeline/stage/config.go
+++ b/runtime/pipeline/stage/config.go
@@ -2,6 +2,8 @@ package stage
 
 import (
 	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
 )
 
 const (
@@ -51,6 +53,11 @@ type PipelineConfig struct {
 	// GracefulShutdownTimeout sets the maximum time to wait for in-flight executions during shutdown.
 	// Default: 10 seconds
 	GracefulShutdownTimeout time.Duration
+
+	// ClassifyRegistry, when non-nil, is attached to the execution
+	// context (via classify.WithRegistry) so stages and downstream
+	// consumers resolve inference backends with classify.FromContext.
+	ClassifyRegistry *classify.Registry
 }
 
 // DefaultPipelineConfig returns a PipelineConfig with sensible defaults.

--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -66,6 +67,12 @@ func (p *StreamPipeline) Execute(ctx context.Context, input <-chan StreamElement
 		logger.Debug("Pipeline IdleTimeout configured",
 			"timeout", p.config.IdleTimeout,
 			"stages", len(p.stages))
+	}
+
+	// Attach the classify registry so stages resolve inference backends
+	// via classify.FromContext, mirroring Arena's eval-orchestrator wiring.
+	if p.config.ClassifyRegistry != nil {
+		execCtx = classify.WithRegistry(execCtx, p.config.ClassifyRegistry)
 	}
 
 	// Track execution for graceful shutdown

--- a/runtime/pipeline/stage/pipeline_test.go
+++ b/runtime/pipeline/stage/pipeline_test.go
@@ -1,0 +1,42 @@
+package stage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+)
+
+func TestPipeline_AttachesClassifyRegistry(t *testing.T) {
+	reg := classify.NewRegistry()
+
+	var seen *classify.Registry
+	probe := NewStageFunc("probe", StageTypeTransform, func(ctx context.Context, in <-chan StreamElement, out chan<- StreamElement) error {
+		defer close(out)
+		seen = classify.FromContext(ctx)
+		for e := range in {
+			out <- e
+		}
+		return nil
+	})
+
+	cfg := DefaultPipelineConfig()
+	cfg.ClassifyRegistry = reg
+	p, err := NewPipelineBuilderWithConfig(cfg).Chain(probe).Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	in := make(chan StreamElement)
+	out, err := p.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	close(in)
+	for range out { //nolint:revive // drain
+	}
+
+	if seen != reg {
+		t.Fatalf("stage did not observe the configured classify registry (got %v)", seen)
+	}
+}

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -284,6 +284,48 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "InferenceProviderConfig": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "Stable identifier"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "huggingface"
+          ],
+          "title": "Type",
+          "description": "Inference provider type"
+        },
+        "model": {
+          "type": "string",
+          "title": "Model",
+          "description": "Classification model name"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "BaseURL",
+          "description": "API endpoint override"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig",
+          "title": "Credential",
+          "description": "API key resolution"
+        },
+        "additional_config": {
+          "type": "object",
+          "title": "Additional Config",
+          "description": "Provider-specific extras"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
     "LoggingConfigSpec": {
       "properties": {
         "defaultLevel": {
@@ -835,6 +877,14 @@
           "type": "array",
           "title": "STT Providers",
           "description": "Speech-to-text provider configurations"
+        },
+        "inference_providers": {
+          "items": {
+            "$ref": "#/$defs/InferenceProviderConfig"
+          },
+          "type": "array",
+          "title": "Inference Providers",
+          "description": "Inference (classify) provider configurations"
         },
         "tools": {
           "additionalProperties": {

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -483,6 +483,7 @@ func (c *Conversation) buildPipelineConfig(
 		CompactionStrategy:    c.config.compactionStrategy,
 		CompactionRules:       c.config.compactionRules,
 		ToolSelector:          c.config.selectors[c.config.toolSelectorName],
+		ClassifyRegistry:      c.config.classifyRegistry,
 	}
 
 	// Wire memory stages from MemoryCapability if present

--- a/sdk/inference_integration_test.go
+++ b/sdk/inference_integration_test.go
@@ -1,0 +1,133 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	mock "github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/sdk/internal/pack"
+	"github.com/AltairaLabs/PromptKit/sdk/session"
+	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
+	"github.com/stretchr/testify/require"
+)
+
+// probeToolCallRepo is a minimal ResponseRepository that:
+//   - turn 1: returns a tool_calls response invoking "probe"
+//   - turn 2+: returns a plain text response to terminate the loop
+type probeToolCallRepo struct{}
+
+func (probeToolCallRepo) GetResponse(_ context.Context, params mock.ResponseParams) (string, error) {
+	t, err := probeToolCallRepo{}.GetTurn(context.Background(), params)
+	if err != nil {
+		return "", err
+	}
+	return t.Content, nil
+}
+
+func (probeToolCallRepo) GetTurn(_ context.Context, params mock.ResponseParams) (*mock.Turn, error) {
+	if params.TurnNumber <= 1 {
+		return &mock.Turn{
+			Type:    "tool_calls",
+			Content: "",
+			ToolCalls: []mock.ToolCall{
+				{Name: "probe", Arguments: map[string]interface{}{}},
+			},
+		}, nil
+	}
+	return &mock.Turn{Type: "text", Content: "done"}, nil
+}
+
+// TestInferenceRegistry_VisibleDuringSend proves the full path:
+//
+//	WithClassifier("stub", stubText{})
+//	  → config.classifyRegistry
+//	  → intpipeline.Config.ClassifyRegistry
+//	  → PipelineConfig.ClassifyRegistry
+//	  → classify.WithRegistry(execCtx, registry) in StreamPipeline.Execute
+//	  → classify.FromContext(ctx) resolves inside OnToolCtx during Send.
+//
+// The probe tool is called by the mock provider on turn 1, and the OnToolCtx
+// handler captures the classify.Registry from context, asserting both that it
+// is non-nil and that the "stub" backend registered via WithClassifier resolves.
+func TestInferenceRegistry_VisibleDuringSend(t *testing.T) {
+	// ---- 1. Build a Conversation with a tool-call-capable mock provider ----
+	repo := probeToolCallRepo{}
+	mockProv := mock.NewToolProviderWithRepository("test-mock", "test-model", false, repo)
+	store := statestore.NewMemoryStore()
+
+	// The prompt's Tools list is what PromptAssemblyStage writes into
+	// TurnState.AllowedTools; the ProviderStage only sends tools in that
+	// list to the provider, so "probe" must appear here.
+	p := &pack.Pack{
+		ID: "test-pack",
+		Prompts: map[string]*pack.Prompt{
+			"chat": {
+				ID:             "chat",
+				SystemTemplate: "You are a helpful assistant.",
+				Tools:          []string{"probe"},
+			},
+		},
+	}
+
+	// Apply WithClassifier to wire the classify registry onto the config.
+	cfg := &config{}
+	require.NoError(t, WithClassifier("stub", stubText{})(cfg))
+	cfg.provider = mockProv
+
+	conv := &Conversation{
+		pack:           p,
+		prompt:         p.Prompts["chat"],
+		promptName:     "chat",
+		promptRegistry: p.ToPromptRegistry(),
+		toolRegistry:   tools.NewRegistry(),
+		config:         cfg,
+		mode:           UnaryMode,
+		handlers:       make(map[string]ToolHandler),
+		asyncHandlers:  make(map[string]sdktools.AsyncToolHandler),
+		pendingStore:   sdktools.NewPendingStore(),
+	}
+
+	// ---- 2. Register the "probe" tool descriptor (mode: local → localExecutor) ----
+	schema := json.RawMessage(`{"type":"object","properties":{}}`)
+	require.NoError(t, conv.toolRegistry.Register(&tools.ToolDescriptor{
+		Name:        "probe",
+		Description: "Registry probe",
+		InputSchema: schema,
+		Mode:        "local",
+	}))
+
+	// ---- 3. Register an OnToolCtx handler that captures classify.FromContext ----
+	var seen *classify.Registry
+	conv.OnToolCtx("probe", func(ctx context.Context, _ map[string]any) (any, error) {
+		seen = classify.FromContext(ctx)
+		return "ok", nil
+	})
+
+	// ---- 4. Build the pipeline and session ----
+	pipeline, err := conv.buildPipelineWithParams(store, "test-conv", nil, nil)
+	require.NoError(t, err)
+
+	unarySession, err := session.NewUnarySession(session.UnarySessionConfig{
+		ConversationID: "test-conv",
+		StateStore:     store,
+		Pipeline:       pipeline,
+	})
+	require.NoError(t, err)
+	conv.unarySession = unarySession
+
+	// ---- 5. Drive one turn; mock returns tool_call "probe" on turn 1 ----
+	_, err = conv.Send(context.Background(), "go")
+	require.NoError(t, err)
+
+	// ---- 6. Assert the registry was visible in the pipeline context ----
+	if seen == nil {
+		t.Fatal("classify registry not visible via classify.FromContext during Send")
+	}
+	if _, err := seen.TextClassifier("stub"); err != nil {
+		t.Fatalf("registered 'stub' classifier should resolve: %v", err)
+	}
+}

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
@@ -196,6 +197,11 @@ type Config struct {
 	// Required when RecordingConfig is set; without it, recording stages
 	// will not be added to the pipeline.
 	RecordingStore events.EventStore
+
+	// ClassifyRegistry is attached to the pipeline execution context.
+	// When non-nil, stages and downstream consumers can resolve inference
+	// backends via classify.FromContext.
+	ClassifyRegistry *classify.Registry
 }
 
 // Build creates a stage-based streaming pipeline.
@@ -255,19 +261,17 @@ func buildStreamPipelineInternal(cfg *Config) (*stage.StreamPipeline, error) {
 
 // newPipelineBuilder creates the appropriate pipeline builder for the config.
 func newPipelineBuilder(cfg *Config) *stage.PipelineBuilder {
-	if cfg.StreamInputProvider != nil {
+	pc := stage.DefaultPipelineConfig()
+	pc.ClassifyRegistry = cfg.ClassifyRegistry
+	switch {
+	case cfg.StreamInputProvider != nil:
 		// For duplex streaming (ASM mode), disable execution timeout
-		// since the session runs indefinitely until user ends it
-		pipelineConfig := stage.DefaultPipelineConfig()
-		pipelineConfig.ExecutionTimeout = 0 // Disable timeout for duplex
-		return stage.NewPipelineBuilderWithConfig(pipelineConfig)
+		// since the session runs indefinitely until user ends it.
+		pc.ExecutionTimeout = 0
+	case cfg.ExecutionTimeout != nil:
+		pc.ExecutionTimeout = *cfg.ExecutionTimeout
 	}
-	if cfg.ExecutionTimeout != nil {
-		pipelineConfig := stage.DefaultPipelineConfig()
-		pipelineConfig.ExecutionTimeout = *cfg.ExecutionTimeout
-		return stage.NewPipelineBuilderWithConfig(pipelineConfig)
-	}
-	return stage.NewPipelineBuilder()
+	return stage.NewPipelineBuilderWithConfig(pc)
 }
 
 // buildStateStoreConfig creates a state store config if a state store is configured.

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -1,12 +1,14 @@
 package sdk
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"go.opentelemetry.io/otel/trace"
 
+	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/a2a"
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
@@ -1911,6 +1913,78 @@ func WithTTS(service tts.Service) Option {
 func WithTurnDetector(detector audio.TurnDetector) Option {
 	return func(c *config) error {
 		c.turnDetector = detector
+		return nil
+	}
+}
+
+// ProviderSpec is the uniform, SDK-facing declaration for any capability
+// provider, used by WithInferenceProvider and the WithXProvider option family.
+// Fields mirror runtime base.CapabilitySpec; Credential is an unresolved
+// config that the option resolves before construction.
+type ProviderSpec struct {
+	ID               string
+	Type             string
+	Model            string
+	BaseURL          string
+	Credential       *pkgconfig.CredentialConfig
+	AdditionalConfig map[string]any
+}
+
+// idOrType returns the spec ID, falling back to Type.
+//
+//nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
+func (s ProviderSpec) idOrType() string {
+	if s.ID != "" {
+		return s.ID
+	}
+	return s.Type
+}
+
+// WithInferenceProvider registers an inference (classify) provider that the
+// SDK constructs and credential-resolves. The backend is registered against
+// every classify task interface it implements (AudioClassifier, TextClassifier,
+// etc.). The HuggingFace factory is available via the backends/all blank import
+// in runtime_config.go (same package).
+//
+//nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
+func WithInferenceProvider(spec ProviderSpec) Option {
+	return func(c *config) error {
+		id := spec.idOrType()
+		cred, err := classify.ResolveCredential(context.Background(), spec.Type, "", spec.Credential)
+		if err != nil {
+			return fmt.Errorf("WithInferenceProvider %q: resolving credential: %w", id, err)
+		}
+		backend, err := classify.CreateFromSpec(classify.ProviderSpec{
+			ID:               id,
+			Type:             spec.Type,
+			Model:            spec.Model,
+			BaseURL:          spec.BaseURL,
+			Credential:       cred,
+			AdditionalConfig: spec.AdditionalConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("WithInferenceProvider %q: %w", id, err)
+		}
+		c.ensureClassifyRegistry()
+		if len(classify.RegisterBackend(c.classifyRegistry, id, backend)) == 0 {
+			return fmt.Errorf("WithInferenceProvider %q: backend implements no classify task interface", id)
+		}
+		return nil
+	}
+}
+
+// WithClassifier registers an already-constructed classify backend (a value
+// implementing one or more of classify's task interfaces) under id. Escape
+// hatch for in-process classifiers and test doubles; no credential resolution.
+func WithClassifier(id string, backend classify.Backend) Option {
+	return func(c *config) error {
+		if id == "" {
+			return fmt.Errorf("WithClassifier: id is required")
+		}
+		c.ensureClassifyRegistry()
+		if len(classify.RegisterBackend(c.classifyRegistry, id, backend)) == 0 {
+			return fmt.Errorf("WithClassifier %q: backend implements no classify task interface", id)
+		}
 		return nil
 	}
 }

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/a2a"
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -117,6 +118,10 @@ type config struct {
 	ttsProviderIDs []string
 	sttProviders   map[string]stt.Service
 	sttProviderIDs []string
+
+	// Inference (classify) registry, built from declarative
+	// inference_providers and/or WithInferenceProvider / WithClassifier.
+	classifyRegistry *classify.Registry
 
 	// Auto-summarization for RAG context. The summarize provider is held
 	// in the providers pool; summarizeProviderID points at it.
@@ -397,6 +402,15 @@ func (c *config) getSummarizeProvider() providers.Provider {
 	}
 	p, _ := c.providers.Get(c.summarizeProviderID)
 	return p
+}
+
+// ensureClassifyRegistry lazy-initializes the classify registry.
+// Called by applyInferenceProviders and the WithInferenceProvider /
+// WithClassifier options before registering any backend.
+func (c *config) ensureClassifyRegistry() {
+	if c.classifyRegistry == nil {
+		c.classifyRegistry = classify.NewRegistry()
+	}
 }
 
 // CredentialOption configures credentials for a provider.

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -1989,6 +1989,142 @@ func WithClassifier(id string, backend classify.Backend) Option {
 	}
 }
 
+// toPkgProvider adapts a ProviderSpec to the pkgconfig.Provider shape
+// consumed by createProviderFromConfig (agent/LLM + image path).
+//
+//nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
+func (s ProviderSpec) toPkgProvider() *pkgconfig.Provider {
+	return &pkgconfig.Provider{
+		ID:               s.idOrType(),
+		Type:             s.Type,
+		Model:            s.Model,
+		BaseURL:          s.BaseURL,
+		Credential:       s.Credential,
+		AdditionalConfig: s.AdditionalConfig,
+	}
+}
+
+// WithLLMProvider sets the conversation's agent (completion) provider from a
+// spec. Sugar over WithProvider for the uniform spec-based option family.
+//
+//nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
+func WithLLMProvider(spec ProviderSpec) Option {
+	return func(c *config) error {
+		prov, err := createProviderFromConfig(spec.toPkgProvider())
+		if err != nil {
+			return fmt.Errorf("WithLLMProvider %q: %w", spec.idOrType(), err)
+		}
+		registerAgentProvider(c, prov)
+		return nil
+	}
+}
+
+// WithImageProvider sets an image-generation provider as the agent (completion)
+// provider. Image providers are Predict-compatible: the generated image is the
+// turn's response. Wired identically to WithLLMProvider; both target the single
+// agent slot (last writer wins).
+//
+//nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
+func WithImageProvider(spec ProviderSpec) Option {
+	return func(c *config) error {
+		prov, err := createProviderFromConfig(spec.toPkgProvider())
+		if err != nil {
+			return fmt.Errorf("WithImageProvider %q: %w", spec.idOrType(), err)
+		}
+		registerAgentProvider(c, prov)
+		return nil
+	}
+}
+
+// WithTTSProvider builds a TTS service from a spec and sets it as the default
+// ttsService (first-wins; does not overwrite one already set by WithTTS or a
+// prior WithTTSProvider call).
+//
+//nolint:gocritic,dupl // value-semantics builder; WithSTTProvider is structurally identical on a different type.
+func WithTTSProvider(spec ProviderSpec) Option {
+	return func(c *config) error {
+		cred, err := tts.ResolveCredential(context.Background(), spec.Type, "", spec.Credential)
+		if err != nil {
+			return fmt.Errorf("WithTTSProvider %q: resolving credential: %w", spec.idOrType(), err)
+		}
+		svc, err := tts.CreateFromSpec(tts.ProviderSpec{
+			ID: spec.idOrType(), Type: spec.Type, Model: spec.Model,
+			BaseURL: spec.BaseURL, Credential: cred, AdditionalConfig: spec.AdditionalConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("WithTTSProvider %q: %w", spec.idOrType(), err)
+		}
+		if c.ttsProviders == nil {
+			c.ttsProviders = make(map[string]tts.Service)
+		}
+		c.ttsProviders[spec.idOrType()] = svc
+		c.ttsProviderIDs = append(c.ttsProviderIDs, spec.idOrType())
+		if c.ttsService == nil {
+			c.ttsService = svc
+		}
+		return nil
+	}
+}
+
+// WithSTTProvider builds an STT service from a spec and sets it as the default
+// sttService (first-wins; does not overwrite one already set).
+//
+//nolint:gocritic,dupl // value-semantics builder; WithTTSProvider is structurally identical on a different type.
+func WithSTTProvider(spec ProviderSpec) Option {
+	return func(c *config) error {
+		cred, err := stt.ResolveCredential(context.Background(), spec.Type, "", spec.Credential)
+		if err != nil {
+			return fmt.Errorf("WithSTTProvider %q: resolving credential: %w", spec.idOrType(), err)
+		}
+		svc, err := stt.CreateFromSpec(stt.ProviderSpec{
+			ID: spec.idOrType(), Type: spec.Type, Model: spec.Model,
+			BaseURL: spec.BaseURL, Credential: cred, AdditionalConfig: spec.AdditionalConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("WithSTTProvider %q: %w", spec.idOrType(), err)
+		}
+		if c.sttProviders == nil {
+			c.sttProviders = make(map[string]stt.Service)
+		}
+		c.sttProviders[spec.idOrType()] = svc
+		c.sttProviderIDs = append(c.sttProviderIDs, spec.idOrType())
+		if c.sttService == nil {
+			c.sttService = svc
+		}
+		return nil
+	}
+}
+
+// WithEmbeddingProvider builds an embedding provider from a spec and sets it as
+// the default RAG retrievalProvider (first-wins; does not overwrite one already
+// set by WithContextRetrieval or a prior WithEmbeddingProvider call).
+//
+//nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
+func WithEmbeddingProvider(spec ProviderSpec) Option {
+	return func(c *config) error {
+		cred, err := providers.ResolveEmbeddingCredential(context.Background(), spec.Type, "", spec.Credential, nil)
+		if err != nil {
+			return fmt.Errorf("WithEmbeddingProvider %q: resolving credential: %w", spec.idOrType(), err)
+		}
+		ep, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+			ID: spec.idOrType(), Type: spec.Type, Model: spec.Model,
+			BaseURL: spec.BaseURL, Credential: cred, AdditionalConfig: spec.AdditionalConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("WithEmbeddingProvider %q: %w", spec.idOrType(), err)
+		}
+		if c.embeddingProviders == nil {
+			c.embeddingProviders = make(map[string]providers.EmbeddingProvider)
+		}
+		c.embeddingProviders[spec.idOrType()] = ep
+		c.embeddingProviderIDs = append(c.embeddingProviderIDs, spec.idOrType())
+		if c.retrievalProvider == nil {
+			c.retrievalProvider = ep
+		}
+		return nil
+	}
+}
+
 // WithStreamingConfig configures streaming for duplex mode.
 // When set, enables ASM (Audio Streaming Model) mode with continuous bidirectional streaming.
 // When nil (default), uses VAD (Voice Activity Detection) mode with turn-based streaming.

--- a/sdk/options_test.go
+++ b/sdk/options_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
@@ -1330,4 +1332,36 @@ func TestWithSelector(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already registered")
 	})
+}
+
+// stubText is a minimal TextClassifier for WithClassifier tests.
+type stubText struct{}
+
+func (stubText) ClassifyText(_ context.Context, _ string, _ classify.TextOptions) ([]classify.LabelScore, error) {
+	return nil, nil
+}
+
+func TestWithClassifier_RegistersBackend(t *testing.T) {
+	c := &config{}
+	require.NoError(t, WithClassifier("stub", stubText{})(c))
+	_, err := c.classifyRegistry.TextClassifier("stub")
+	require.NoError(t, err, "stub text classifier should resolve")
+}
+
+func TestWithClassifier_RejectsNonBackend(t *testing.T) {
+	c := &config{}
+	err := WithClassifier("nope", struct{}{})(c)
+	require.Error(t, err, "expected error: value implements no classify task interface")
+}
+
+func TestWithInferenceProvider_BuildsBackend(t *testing.T) {
+	c := &config{}
+	err := WithInferenceProvider(ProviderSpec{
+		ID:         "hf",
+		Type:       "huggingface",
+		Credential: &pkgconfig.CredentialConfig{APIKey: "tok"},
+	})(c)
+	require.NoError(t, err)
+	_, err = c.classifyRegistry.AudioClassifier("hf")
+	require.NoError(t, err, "hf audio classifier should resolve")
 }

--- a/sdk/options_test.go
+++ b/sdk/options_test.go
@@ -1365,3 +1365,56 @@ func TestWithInferenceProvider_BuildsBackend(t *testing.T) {
 	_, err = c.classifyRegistry.AudioClassifier("hf")
 	require.NoError(t, err, "hf audio classifier should resolve")
 }
+
+func TestWithLLMProvider_SetsAgentProvider(t *testing.T) {
+	c := &config{}
+	err := WithLLMProvider(ProviderSpec{
+		Type:       "openai",
+		Model:      "gpt-4o-mini",
+		Credential: &pkgconfig.CredentialConfig{APIKey: "tok"},
+	})(c)
+	require.NoError(t, err)
+	require.NotNil(t, c.getAgentProvider(), "expected agent provider to be set")
+}
+
+func TestWithEmbeddingProvider_SetsRetrievalProvider(t *testing.T) {
+	c := &config{}
+	err := WithEmbeddingProvider(ProviderSpec{
+		Type:       "openai",
+		Model:      "text-embedding-3-small",
+		Credential: &pkgconfig.CredentialConfig{APIKey: "tok"},
+	})(c)
+	require.NoError(t, err)
+	require.NotNil(t, c.retrievalProvider, "expected retrievalProvider to be set")
+}
+
+func TestWithTTSProvider_SetsService(t *testing.T) {
+	c := &config{}
+	err := WithTTSProvider(ProviderSpec{
+		Type:       "openai",
+		Credential: &pkgconfig.CredentialConfig{APIKey: "tok"},
+	})(c)
+	require.NoError(t, err)
+	require.NotNil(t, c.ttsService, "expected ttsService to be set")
+}
+
+func TestWithSTTProvider_SetsService(t *testing.T) {
+	c := &config{}
+	err := WithSTTProvider(ProviderSpec{
+		Type:       "openai",
+		Credential: &pkgconfig.CredentialConfig{APIKey: "tok"},
+	})(c)
+	require.NoError(t, err)
+	require.NotNil(t, c.sttService, "expected sttService to be set")
+}
+
+func TestWithImageProvider_SetsAgentProvider(t *testing.T) {
+	c := &config{}
+	err := WithImageProvider(ProviderSpec{
+		Type:       "imagen",
+		Model:      "imagen-4.0-generate-001",
+		Credential: &pkgconfig.CredentialConfig{APIKey: "tok"},
+	})(c)
+	require.NoError(t, err)
+	require.NotNil(t, c.getAgentProvider(), "expected image provider to be set as the agent provider")
+}

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -24,6 +24,7 @@ import (
 	// Chat-provider factories register through other SDK paths.
 	_ "github.com/AltairaLabs/PromptKit/runtime/classify/backends/all"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/imagen"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
@@ -18,9 +19,10 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 
-	// Side-effect imports register embedding-provider factories so
-	// CreateEmbeddingProviderFromSpec can resolve declarative entries.
+	// Side-effect imports register provider factories so CreateFromSpec
+	// can resolve declarative entries.
 	// Chat-provider factories register through other SDK paths.
+	_ "github.com/AltairaLabs/PromptKit/runtime/classify/backends/all"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
@@ -168,6 +170,9 @@ func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 	}
 	if err := applySTTProviders(c, spec.STTProviders); err != nil {
 		return fmt.Errorf("applying STT providers from runtime config: %w", err)
+	}
+	if err := applyInferenceProviders(c, spec.InferenceProviders); err != nil {
+		return fmt.Errorf("applying inference providers from runtime config: %w", err)
 	}
 
 	// Apply MCP servers
@@ -441,6 +446,80 @@ func applySTTProviders(c *config, specs []pkgconfig.STTProviderConfig) error {
 	}
 	if c.sttService == nil && len(c.sttProviderIDs) > 0 {
 		c.sttService = c.sttProviders[c.sttProviderIDs[0]]
+	}
+	return nil
+}
+
+// applyInferenceProviders builds classify backends from the declarative
+// inference_providers block and registers them on the SDK's classify
+// registry. The first declared provider implementing a task becomes that
+// task's default (first-wins, matching tts/stt service defaults). Merges
+// into any registry already created by WithInferenceProvider /
+// WithClassifier (programmatic registration runs first).
+func applyInferenceProviders(c *config, specs []pkgconfig.InferenceProviderConfig) error {
+	if len(specs) == 0 {
+		return nil
+	}
+	c.ensureClassifyRegistry()
+	seen := make(map[string]bool, len(specs))
+	first := make(map[string]string)
+	for i := range specs {
+		ip := &specs[i]
+		id := ip.ID
+		if id == "" {
+			id = ip.Type
+		}
+		if seen[id] {
+			return fmt.Errorf("inference provider %q: duplicate ID", id)
+		}
+		seen[id] = true
+		cred, err := classify.ResolveCredential(context.Background(), ip.Type, "", ip.Credential)
+		if err != nil {
+			return fmt.Errorf("inference provider %q: resolving credential: %w", id, err)
+		}
+		backend, err := classify.CreateFromSpec(classify.ProviderSpec{
+			ID:               id,
+			Type:             ip.Type,
+			Model:            ip.Model,
+			BaseURL:          ip.BaseURL,
+			Credential:       cred,
+			AdditionalConfig: ip.AdditionalConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("inference provider %q: %w", id, err)
+		}
+		for _, task := range classify.RegisterBackend(c.classifyRegistry, id, backend) {
+			if _, ok := first[task]; !ok {
+				first[task] = id
+			}
+		}
+	}
+	return applyInferenceFirstWins(c.classifyRegistry, first)
+}
+
+// applyInferenceFirstWins sets each task's default to the first declared
+// provider that implements it. Ignores SetDefault errors that can only
+// occur from an unregistered id (impossible here — ids come from the
+// registration loop).
+func applyInferenceFirstWins(reg *classify.Registry, first map[string]string) error {
+	type taskSetter struct {
+		task string
+		set  func(string) error
+	}
+	for _, ts := range []taskSetter{
+		{"audio", reg.SetDefaultAudio},
+		{contentTypeText, reg.SetDefaultText},
+		{"image", reg.SetDefaultImage},
+		{"video", reg.SetDefaultVideo},
+		{"embedder", reg.SetDefaultEmbedder},
+	} {
+		id, ok := first[ts.task]
+		if !ok {
+			continue
+		}
+		if err := ts.set(id); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -1031,3 +1031,40 @@ func (m *rtcMockProvider) Validate() error                     { return nil }
 func (m *rtcMockProvider) Init(_ context.Context) error        { return nil }
 func (m *rtcMockProvider) HealthCheck(_ context.Context) error { return nil }
 func (m *rtcMockProvider) Close() error                        { return nil }
+
+func TestApplyInferenceProviders_BuildsRegistry(t *testing.T) {
+	c := &config{}
+	err := applyInferenceProviders(c, []pkgconfig.InferenceProviderConfig{
+		{ID: "hf", Type: "huggingface", Credential: &pkgconfig.CredentialConfig{APIKey: "tok"}},
+	})
+	if err != nil {
+		t.Fatalf("applyInferenceProviders: %v", err)
+	}
+	if c.classifyRegistry == nil {
+		t.Fatal("expected classifyRegistry to be set")
+	}
+	if _, err := c.classifyRegistry.TextClassifier("hf"); err != nil {
+		t.Fatalf("hf text classifier should resolve: %v", err)
+	}
+}
+
+func TestApplyInferenceProviders_DuplicateID(t *testing.T) {
+	c := &config{}
+	err := applyInferenceProviders(c, []pkgconfig.InferenceProviderConfig{
+		{ID: "hf", Type: "huggingface", Credential: &pkgconfig.CredentialConfig{APIKey: "a"}},
+		{ID: "hf", Type: "huggingface", Credential: &pkgconfig.CredentialConfig{APIKey: "b"}},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate-id error")
+	}
+}
+
+func TestApplyInferenceProviders_Empty(t *testing.T) {
+	c := &config{}
+	if err := applyInferenceProviders(c, nil); err != nil {
+		t.Fatalf("empty should be a no-op: %v", err)
+	}
+	if c.classifyRegistry != nil {
+		t.Fatal("expected no registry for empty config")
+	}
+}

--- a/tools/arena/engine/classify_registry.go
+++ b/tools/arena/engine/classify_registry.go
@@ -6,139 +6,59 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
-	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+	_ "github.com/AltairaLabs/PromptKit/runtime/classify/backends/all" // registers classify backend factories via init()
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 )
 
-// inferenceTypeHuggingFace is the type string for HuggingFace Inference API
-// providers in arena's `providers:` list (role: inference). It's the only
-// backend kind that ships in this slice; ONNX and others are queued behind
-// separate issues.
-const inferenceTypeHuggingFace = "huggingface"
-
-// buildClassifyRegistry constructs a classify.Registry populated with the
-// task-interface implementations declared in cfg.LoadedInferenceProviders
-// (every `providers:` entry with `role: inference`). Each loaded provider
-// instantiates one backend Client and registers against every classify
-// task interface that backend implements (the HF backend covers four —
-// audio/text/image classifiers + embedder). cfg.Defaults.Inference is
-// then applied to pin which id wins when a handler doesn't specify one.
+// buildClassifyRegistry maps cfg.LoadedInferenceProviders (every
+// `providers:` entry with role: inference) into classify.ProviderSpecs
+// and delegates construction to the shared runtime factory. Returns
+// (nil, nil) when no inference providers are configured.
 //
-// Returns (nil, nil) when no inference providers are configured. Handlers
-// that need a classifier will surface "no classifier configured" via
-// classify.FromContext returning nil — arenas that don't use
-// classify-backed assertions shouldn't require an HF token.
-//
-// Returns a non-nil error only when a configured provider is malformed
-// (unsupported type, unresolvable credential, missing api key). The
-// caller logs and continues — one broken entry must not block a run
-// that doesn't reach a classify-dependent handler.
+// Arena keeps its own credential policy: an inference provider with no
+// resolvable API key is an error (the caller logs and continues with a
+// nil registry, so classify-backed handlers skip cleanly rather than
+// failing — this preserves demos that run without HF_TOKEN).
 func buildClassifyRegistry(cfg *config.Config) (*classify.Registry, error) {
 	if cfg == nil || len(cfg.LoadedInferenceProviders) == 0 {
 		return nil, nil
 	}
-	reg := classify.NewRegistry()
+	specs := make([]classify.ProviderSpec, 0, len(cfg.LoadedInferenceProviders))
 	for id, provider := range cfg.LoadedInferenceProviders {
-		if err := registerInferenceProvider(reg, id, provider, cfg.ConfigDir); err != nil {
-			return reg, err
-		}
-	}
-	if err := applyInferenceDefaults(reg, cfg.Defaults.Inference); err != nil {
-		return reg, err
-	}
-	return reg, nil
-}
-
-func registerInferenceProvider(reg *classify.Registry, id string, provider *config.Provider, configDir string) error {
-	switch provider.Type {
-	case inferenceTypeHuggingFace:
-		apiKey, err := resolveProviderAPIKey(provider, configDir)
-		if err != nil {
-			return fmt.Errorf("inference provider %s: %w", id, err)
-		}
-		client, err := classifyhf.NewClient(classifyhf.Config{
-			APIKey:    apiKey,
-			BaseURL:   provider.BaseURL,
-			Dedicated: providerBoolFromConfig(provider, "dedicated"),
+		cred, err := credentials.Resolve(context.Background(), credentials.ResolverConfig{
+			ProviderType:     provider.Type,
+			CredentialConfig: provider.Credential,
+			ConfigDir:        cfg.ConfigDir,
 		})
 		if err != nil {
-			return fmt.Errorf("inference provider %s: %w", id, err)
+			return nil, fmt.Errorf("inference provider %s: %w", id, err)
 		}
-		// HF Client implements every task interface (compile-time checked in
-		// runtime/classify/backends/hf/client.go). Register against each so
-		// handlers asking for any task get this backend by id.
-		reg.RegisterAudio(id, client)
-		reg.RegisterText(id, client)
-		reg.RegisterImage(id, client)
-		reg.RegisterEmbedder(id, client)
-		// VideoClassifier deliberately not registered: HF doesn't ship a
-		// general video classification endpoint and the decomposing default
-		// (audio + frame-sampled images) is queued in #1214 Phase 5.
-		return nil
-	default:
-		return fmt.Errorf("inference provider %s: unsupported type %q (supported: %s)",
-			id, provider.Type, inferenceTypeHuggingFace)
+		if base.APIKeyFromCredential(cred) == "" {
+			return nil, fmt.Errorf(
+				"inference provider %s: no api key configured (set credential.api_key, "+
+					"credential.credential_env, or export HF_TOKEN / HUGGING_FACE_HUB_TOKEN)", id)
+		}
+		specs = append(specs, classify.ProviderSpec{
+			ID:               id,
+			Type:             provider.Type,
+			BaseURL:          provider.BaseURL,
+			Credential:       cred,
+			AdditionalConfig: provider.AdditionalConfig,
+		})
 	}
+	return classify.BuildRegistry(specs, inferenceDefaults(cfg.Defaults.Inference))
 }
 
-// resolveProviderAPIKey runs the configured credential through the shared
-// resolver and extracts the raw API key. Non-APIKey credentials (NoOp,
-// cloud platform credentials) are rejected — the classify backends today
-// need a bearer token, not a signed request.
-func resolveProviderAPIKey(provider *config.Provider, configDir string) (string, error) {
-	cred, err := credentials.Resolve(context.Background(), credentials.ResolverConfig{
-		ProviderType:     provider.Type,
-		CredentialConfig: provider.Credential,
-		ConfigDir:        configDir,
-	})
-	if err != nil {
-		return "", err
+func inferenceDefaults(d *config.InferenceDefaults) classify.RegistryDefaults {
+	if d == nil {
+		return classify.RegistryDefaults{}
 	}
-	// Resolver returns NoOpCredential when no key is configured AND no
-	// default env var is set. For HF we always need a bearer token —
-	// surface a message that names every resolvable source.
-	apiKey, ok := cred.(*credentials.APIKeyCredential)
-	if !ok || apiKey.APIKey() == "" {
-		return "", fmt.Errorf(
-			"no api key configured (set credential.api_key, credential.credential_env, " +
-				"or export HF_TOKEN / HUGGING_FACE_HUB_TOKEN)")
+	return classify.RegistryDefaults{
+		AudioClassifier: d.AudioClassifier,
+		TextClassifier:  d.TextClassifier,
+		ImageClassifier: d.ImageClassifier,
+		VideoClassifier: d.VideoClassifier,
+		Embedder:        d.Embedder,
 	}
-	return apiKey.APIKey(), nil
-}
-
-// providerBoolFromConfig pulls a boolean flag out of Provider.AdditionalConfig.
-// Returns false when the key is absent or the value isn't a bool — the
-// backends already validate their own knobs at request time, so passing
-// through "false" for a misspelled flag won't cause a silent breakage in
-// practice (an unset Dedicated still hits the public HF endpoint).
-func providerBoolFromConfig(provider *config.Provider, key string) bool {
-	if provider == nil || provider.AdditionalConfig == nil {
-		return false
-	}
-	v, ok := provider.AdditionalConfig[key].(bool)
-	return ok && v
-}
-
-func applyInferenceDefaults(reg *classify.Registry, defaults *config.InferenceDefaults) error {
-	if defaults == nil {
-		return nil
-	}
-	for label, pair := range map[string]struct {
-		id  string
-		set func(string) error
-	}{
-		"audio_classifier": {defaults.AudioClassifier, reg.SetDefaultAudio},
-		"text_classifier":  {defaults.TextClassifier, reg.SetDefaultText},
-		"image_classifier": {defaults.ImageClassifier, reg.SetDefaultImage},
-		"video_classifier": {defaults.VideoClassifier, reg.SetDefaultVideo},
-		"embedder":         {defaults.Embedder, reg.SetDefaultEmbedder},
-	} {
-		if pair.id == "" {
-			continue
-		}
-		if err := pair.set(pair.id); err != nil {
-			return fmt.Errorf("defaults.inference.%s: %w", label, err)
-		}
-	}
-	return nil
 }

--- a/tools/arena/engine/classify_registry_test.go
+++ b/tools/arena/engine/classify_registry_test.go
@@ -109,9 +109,18 @@ func TestBuildClassifyRegistry_MissingAPIKeyErrors(t *testing.T) {
 }
 
 func TestBuildClassifyRegistry_UnsupportedTypeErrors(t *testing.T) {
+	// Provide a literal API key so the credential check passes and the
+	// unsupported-type error surfaces from classify.BuildRegistry.
 	cfg := &config.Config{
 		LoadedInferenceProviders: map[string]*config.Provider{
-			"x": {ID: "x", Type: "bogus", Role: config.RoleInference},
+			"x": {
+				ID:   "x",
+				Type: "bogus",
+				Role: config.RoleInference,
+				Credential: &config.CredentialConfig{
+					APIKey: "test-token",
+				},
+			},
 		},
 	}
 	_, err := buildClassifyRegistry(cfg)
@@ -165,8 +174,11 @@ func TestBuildClassifyRegistry_DefaultsReferencingUnregisteredID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when default references an unknown id")
 	}
-	if !strings.Contains(err.Error(), "audio_classifier") {
-		t.Errorf("error %q should identify which default failed", err.Error())
+	// The shared factory surfaces "audio classifier" (with space) in its
+	// error; the old bespoke code used "audio_classifier" (with underscore).
+	// Either form identifies the failing default — check for the id itself.
+	if !strings.Contains(err.Error(), "doesnotexist") {
+		t.Errorf("error %q should identify the unregistered default id", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes inference (classify) providers a first-class SDK capability and unifies the SDK provider surface so every capability looks the same.

- **Shared runtime factory** (`runtime/classify`): `ProviderSpec`/`CreateFromSpec`/`RegisterBackend`/`BuildRegistry` via `base.FactoryRegistry`; HF self-registers via `init()` with a `backends/all` blank-import aggregator. Hoisted out of Arena so SDK + Arena share one construction path (runtime invariant).
- **Arena refactor**: `tools/arena/engine/classify_registry.go` shrinks to a spec-mapping shim over `classify.BuildRegistry`; behavior preserved (missing-token still yields a nil registry → handlers skip).
- **SDK injection**: declarative `inference_providers` block in `RuntimeConfigSpec` + `applyInferenceProviders`; programmatic `WithInferenceProvider` / `WithClassifier`.
- **Uniform `WithXProvider` family**: `WithLLMProvider`, `WithImageProvider`, `WithTTSProvider`, `WithSTTProvider`, `WithEmbeddingProvider`, `WithInferenceProvider` — all take the shared `sdk.ProviderSpec`, each routing to its consumer. Additive sugar; existing instance-based options (`WithProvider`, `WithTTS`, `WithVADMode`, `WithContextRetrieval`) unchanged. Image generation rides the agent-provider path (it is a completion provider).
- **Context attach**: `classify.Registry` is attached once in the runtime runner (`StreamPipeline.Execute`), threaded from the SDK config, so any consumer resolves it via `classify.FromContext` — identical to Arena's eval-orchestrator wiring. No consumer wired here; the existing eval/assertion/guardrail structure picks it up.

Design + plan: `docs/local-backlog/SDK_INFERENCE_PROVIDER_REGISTRY_{DESIGN,PLAN}.md` (local-only).

## Notes

- **Arena first-wins defaults**: `BuildRegistry` now applies first-declared-wins defaults when no explicit default is set (new for Arena). Verified safe — the only shipped inference example (voice-refund-demo) names `classifier_id: hf` explicitly, and only the HF backend exists.
- **Schema**: `schemas/v1alpha1/runtime-config.json` regenerated for the new `inference_providers` field (`schema-gen --check` green).

## Test plan

- [x] `go build ./...` clean across runtime/pkg/sdk/tools/arena
- [x] Full suite green (`go test ./...`, incl. new runtime/classify, pkg/config, sdk, arena tests)
- [x] `golangci-lint run ./...` clean
- [x] `schema-gen --check` green
- [x] End-to-end SDK test: classify registry resolvable via `classify.FromContext` during `Send`

Closes #1326
