### PR TITLE
feat(sdk): declarative provider loading via WithProviderFile / WithProvidersDir

### DIFF
--- a/pkg/config/schema_validator.go
+++ b/pkg/config/schema_validator.go
@@ -121,6 +121,7 @@ func findLocalSchemaPath(configType string) string {
 	// This works when running tests or when the module is in the current directory
 	possiblePaths := []string{
 		filepath.Join(SchemaLocalPath, configType+".json"),
+		filepath.Join("..", SchemaLocalPath, configType+".json"),        // From a top-level module (sdk, runtime, server)
 		filepath.Join("../../", SchemaLocalPath, configType+".json"),    // From pkg/config
 		filepath.Join("../../../", SchemaLocalPath, configType+".json"), // From deeper nested packages
 	}

--- a/sdk/CLAUDE.md
+++ b/sdk/CLAUDE.md
@@ -68,6 +68,10 @@ Capabilities are auto-detected from pack structure. Explicit `WithCapability()` 
 
 `sdk/internal/pack/` defines its own `WorkflowSpec`, `WorkflowState`, etc. rather than importing `runtime/workflow`. This decouples the SDK's package graph from runtime evolution. Conversion happens via `packToRuntimePack()`.
 
+## Providers
+
+Providers can be supplied three ways: programmatic instances (`WithProvider`, `WithTTS`, …), the uniform spec-based family (`WithLLMProvider`/`WithImageProvider`/`WithTTSProvider`/`WithSTTProvider`/`WithEmbeddingProvider`/`WithInferenceProvider`), or **declarative files** (`WithProviderFile(path)` / `WithProvidersDir(dir)`). The file loaders parse Arena-format `*.provider.yaml` via `pkgconfig.LoadProvider` and route each by `role:` (`sdk/provider_file.go`): `llm`/`image` → agent pool (first declared becomes the agent; the rest stay pooled by ID), `tts`/`stt` → service slots, `embedding` → retrieval, `inference` → classify registry. Paths are CWD-relative; no auto-discovery. Platform-auth (Bedrock/Vertex/Azure) embedding via file isn't supported yet — use the programmatic options for those.
+
 ## Adding New Functionality
 
 - **New SDK option**: Add to `options.go` config struct + `With*` function. Wire through `conversation.go` → `internal/pipeline/builder.go`.

--- a/sdk/provider_file.go
+++ b/sdk/provider_file.go
@@ -61,6 +61,9 @@ func (c *config) applyProviderConfig(p *pkgconfig.Provider) error {
 	case pkgconfig.RoleInference:
 		return WithInferenceProvider(providerSpecFromConfig(p))(c)
 	default:
+		// Unreachable in practice: ValidateRole() above rejects any role not in
+		// the known set, and every known role is handled. Kept as a defensive
+		// guard against a future role being added to pkg/config without a route.
 		return fmt.Errorf("provider %q: unsupported role %q", id, p.GetRole())
 	}
 }

--- a/sdk/provider_file.go
+++ b/sdk/provider_file.go
@@ -1,0 +1,104 @@
+package sdk
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+// providerSpecFromConfig maps a loaded *pkgconfig.Provider onto the SDK's
+// uniform ProviderSpec. Platform is intentionally not carried — ProviderSpec
+// has no platform field; platform-auth providers are handled separately.
+func providerSpecFromConfig(p *pkgconfig.Provider) ProviderSpec {
+	return ProviderSpec{
+		ID:               p.ID,
+		Type:             p.Type,
+		Model:            p.Model,
+		BaseURL:          p.BaseURL,
+		Credential:       p.Credential,
+		AdditionalConfig: p.AdditionalConfig,
+	}
+}
+
+// applyProviderConfig routes a loaded provider to the SDK slot/pool matching
+// its role. Completion providers (llm/image) are pooled by ID; the first one
+// becomes the agent (first-wins). tts/stt/embedding/inference delegate to the
+// matching public option (each first-wins on its default slot).
+func (c *config) applyProviderConfig(p *pkgconfig.Provider) error {
+	if err := p.ValidateRole(); err != nil {
+		return err
+	}
+	id := p.ID
+	if id == "" {
+		id = p.Type
+	}
+	switch p.GetRole() {
+	case pkgconfig.RoleLLM, pkgconfig.RoleImage:
+		prov, err := createProviderFromConfig(p)
+		if err != nil {
+			return fmt.Errorf("provider %q: %w", id, err)
+		}
+		if c.agentSet {
+			ensureProviderPool(c)
+			c.providers.Register(prov) // keep in pool; first-declared stays the agent
+			return nil
+		}
+		registerAgentProvider(c, prov)
+		return nil
+	case pkgconfig.RoleTTS:
+		return WithTTSProvider(providerSpecFromConfig(p))(c)
+	case pkgconfig.RoleSTT:
+		return WithSTTProvider(providerSpecFromConfig(p))(c)
+	case pkgconfig.RoleEmbedding:
+		if p.Platform != nil {
+			return fmt.Errorf(
+				"provider %q: platform-auth embedding providers are not yet supported via "+
+					"file loading; use WithBedrock/WithVertex/WithAzure", id)
+		}
+		return WithEmbeddingProvider(providerSpecFromConfig(p))(c)
+	case pkgconfig.RoleInference:
+		return WithInferenceProvider(providerSpecFromConfig(p))(c)
+	default:
+		return fmt.Errorf("provider %q: unsupported role %q", id, p.GetRole())
+	}
+}
+
+// WithProviderFile loads a single Arena-format *.provider.yaml and routes it
+// into the SDK by its role. Path is resolved relative to the working directory.
+func WithProviderFile(path string) Option {
+	return func(c *config) error {
+		p, err := pkgconfig.LoadProvider(path)
+		if err != nil {
+			return fmt.Errorf("WithProviderFile %q: %w", path, err)
+		}
+		if err := c.applyProviderConfig(p); err != nil {
+			return fmt.Errorf("WithProviderFile %q: %w", path, err)
+		}
+		return nil
+	}
+}
+
+// WithProvidersDir loads every *.provider.yaml in dir (lexically sorted) and
+// routes each by role. Among multiple llm/image providers the first sorted
+// file becomes the agent; the rest stay in the pool.
+func WithProvidersDir(dir string) Option {
+	return func(c *config) error {
+		matches, err := filepath.Glob(filepath.Join(dir, "*.provider.yaml"))
+		if err != nil {
+			return fmt.Errorf("WithProvidersDir %q: %w", dir, err)
+		}
+		sort.Strings(matches)
+		for _, f := range matches {
+			p, err := pkgconfig.LoadProvider(f)
+			if err != nil {
+				return fmt.Errorf("WithProvidersDir %q: loading %s: %w", dir, f, err)
+			}
+			if err := c.applyProviderConfig(p); err != nil {
+				return fmt.Errorf("WithProvidersDir %q: %s: %w", dir, f, err)
+			}
+		}
+		return nil
+	}
+}

--- a/sdk/provider_file_test.go
+++ b/sdk/provider_file_test.go
@@ -124,6 +124,9 @@ spec:
 `
 
 func TestWithProviderFile_LoadsTTS(t *testing.T) {
+	// LoadProvider schema-validates; pin to the in-repo schema so the test is
+	// hermetic (no network fetch of the published schema).
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
 	dir := t.TempDir()
 	path := writeProviderYAML(t, dir, "tts.provider.yaml", ttsProviderYAML)
 
@@ -144,6 +147,7 @@ func TestWithProviderFile_MissingFile(t *testing.T) {
 }
 
 func TestWithProvidersDir_LoadsAllFirstWinsAgent(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
 	dir := t.TempDir()
 	// Two llm providers + one tts; glob is sorted, so "a-llm" sorts before "b-llm".
 	writeProviderYAML(t, dir, "a-llm.provider.yaml", `apiVersion: promptkit.altairalabs.ai/v1alpha1

--- a/sdk/provider_file_test.go
+++ b/sdk/provider_file_test.go
@@ -1,0 +1,166 @@
+package sdk
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+func cred(tok string) *pkgconfig.CredentialConfig {
+	return &pkgconfig.CredentialConfig{APIKey: tok}
+}
+
+func TestApplyProviderConfig_LLMBecomesAgent(t *testing.T) {
+	c := &config{}
+	if err := c.applyProviderConfig(&pkgconfig.Provider{ID: "m", Type: "mock", Role: pkgconfig.RoleLLM}); err != nil {
+		t.Fatalf("applyProviderConfig: %v", err)
+	}
+	if c.getAgentProvider() == nil {
+		t.Fatal("expected agent provider to be set")
+	}
+}
+
+func TestApplyProviderConfig_SecondLLMPooledNotAgent(t *testing.T) {
+	c := &config{}
+	if err := c.applyProviderConfig(&pkgconfig.Provider{ID: "first", Type: "mock", Role: pkgconfig.RoleLLM}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := c.applyProviderConfig(&pkgconfig.Provider{ID: "second", Type: "mock", Role: pkgconfig.RoleLLM}); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if got := c.agentProviderID; got != "first" {
+		t.Fatalf("agent should remain first-declared, got %q", got)
+	}
+	if _, ok := c.providers.Get("second"); !ok {
+		t.Fatal("second provider should still be registered in the pool")
+	}
+}
+
+func TestApplyProviderConfig_TTS(t *testing.T) {
+	c := &config{}
+	if err := c.applyProviderConfig(&pkgconfig.Provider{Type: "openai", Role: pkgconfig.RoleTTS, Credential: cred("tok")}); err != nil {
+		t.Fatalf("tts: %v", err)
+	}
+	if c.ttsService == nil {
+		t.Fatal("expected ttsService set")
+	}
+}
+
+func TestApplyProviderConfig_Inference(t *testing.T) {
+	c := &config{}
+	if err := c.applyProviderConfig(&pkgconfig.Provider{ID: "hf", Type: "huggingface", Role: pkgconfig.RoleInference, Credential: cred("tok")}); err != nil {
+		t.Fatalf("inference: %v", err)
+	}
+	if _, err := c.classifyRegistry.AudioClassifier("hf"); err != nil {
+		t.Fatalf("hf classifier should resolve: %v", err)
+	}
+}
+
+func TestApplyProviderConfig_EmbeddingPlatformRejected(t *testing.T) {
+	c := &config{}
+	err := c.applyProviderConfig(&pkgconfig.Provider{
+		Type:     "openai",
+		Role:     pkgconfig.RoleEmbedding,
+		Platform: &pkgconfig.PlatformConfig{Type: "azure"},
+	})
+	if err == nil {
+		t.Fatal("expected platform-auth embedding via file to be rejected")
+	}
+}
+
+func TestApplyProviderConfig_UnknownRoleRejected(t *testing.T) {
+	c := &config{}
+	if err := c.applyProviderConfig(&pkgconfig.Provider{Type: "x", Role: "bogus"}); err == nil {
+		t.Fatal("expected unknown-role error")
+	}
+}
+
+// --- Task 2: WithProviderFile + WithProvidersDir ---
+
+func writeProviderYAML(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+const ttsProviderYAML = `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openai-tts
+spec:
+  id: openai-tts
+  type: openai
+  role: tts
+  credential:
+    api_key: tok
+`
+
+func TestWithProviderFile_LoadsTTS(t *testing.T) {
+	dir := t.TempDir()
+	path := writeProviderYAML(t, dir, "tts.provider.yaml", ttsProviderYAML)
+
+	c := &config{}
+	if err := WithProviderFile(path)(c); err != nil {
+		t.Fatalf("WithProviderFile: %v", err)
+	}
+	if c.ttsService == nil {
+		t.Fatal("expected ttsService set from file")
+	}
+}
+
+func TestWithProviderFile_MissingFile(t *testing.T) {
+	c := &config{}
+	if err := WithProviderFile("/nonexistent/x.provider.yaml")(c); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestWithProvidersDir_LoadsAllFirstWinsAgent(t *testing.T) {
+	dir := t.TempDir()
+	// Two llm providers + one tts; glob is sorted, so "a-llm" sorts before "b-llm".
+	writeProviderYAML(t, dir, "a-llm.provider.yaml", `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: a
+spec:
+  id: a
+  type: mock
+  role: llm
+`)
+	writeProviderYAML(t, dir, "b-llm.provider.yaml", `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: b
+spec:
+  id: b
+  type: mock
+  role: llm
+`)
+	writeProviderYAML(t, dir, "tts.provider.yaml", ttsProviderYAML)
+
+	c := &config{}
+	if err := WithProvidersDir(dir)(c); err != nil {
+		t.Fatalf("WithProvidersDir: %v", err)
+	}
+	if c.agentProviderID != "a" {
+		t.Fatalf("first-declared (sorted) llm should be agent, got %q", c.agentProviderID)
+	}
+	if _, ok := c.providers.Get("b"); !ok {
+		t.Fatal("second llm should still be pooled")
+	}
+	if c.ttsService == nil {
+		t.Fatal("tts from dir should be set")
+	}
+}
+
+func TestWithProvidersDir_Empty(t *testing.T) {
+	c := &config{}
+	if err := WithProvidersDir(t.TempDir())(c); err != nil {
+		t.Fatalf("empty dir should be a no-op, got %v", err)
+	}
+}

--- a/sdk/provider_file_test.go
+++ b/sdk/provider_file_test.go
@@ -58,6 +58,29 @@ func TestApplyProviderConfig_Inference(t *testing.T) {
 	}
 }
 
+func TestApplyProviderConfig_STT(t *testing.T) {
+	c := &config{}
+	if err := c.applyProviderConfig(&pkgconfig.Provider{Type: "openai", Role: pkgconfig.RoleSTT, Credential: cred("tok")}); err != nil {
+		t.Fatalf("stt: %v", err)
+	}
+	if c.sttService == nil {
+		t.Fatal("expected sttService set")
+	}
+}
+
+func TestApplyProviderConfig_ImagePooledAsAgent(t *testing.T) {
+	c := &config{}
+	if err := c.applyProviderConfig(&pkgconfig.Provider{
+		ID: "img", Type: "imagen", Model: "imagen-4.0-generate-001",
+		Role: pkgconfig.RoleImage, Credential: cred("tok"),
+	}); err != nil {
+		t.Fatalf("image: %v", err)
+	}
+	if c.getAgentProvider() == nil {
+		t.Fatal("expected image provider to be set as the agent provider")
+	}
+}
+
 func TestApplyProviderConfig_EmbeddingPlatformRejected(t *testing.T) {
 	c := &config{}
 	err := c.applyProviderConfig(&pkgconfig.Provider{


### PR DESCRIPTION
## Summary

Adds declarative provider loading to the SDK — load Arena-format `*.provider.yaml` files and route each by its `role:` into the SDK's provider slots/pool. Pack portability between Arena tests and SDK production (the ask in #1213).

- `WithProviderFile(path)` — load one `*.provider.yaml`, route by role.
- `WithProvidersDir(dir)` — glob `*.provider.yaml` (lexically sorted), route each.
- Role routing (`sdk/provider_file.go`): `llm`/`image` → agent pool (first declared becomes the agent, the rest stay pooled by ID), `tts`/`stt` → service slots, `embedding` → retrieval, `inference` → classify registry.

Thin adapter over the #1327 routing targets — reuses `pkgconfig.LoadProvider`, the `WithXProvider` options, and `createProviderFromConfig`. No new construction logic, no module-boundary changes (SDK-only).

## Design decisions

- **First-wins everywhere** — first `llm`/`image` is the agent; all providers are still pooled (addressable by ID). Programmatic options set earlier aren't clobbered.
- **CWD-relative paths, no auto-discovery.**
- **Pool everything; consumers decide usage.** Multiple completion providers (e.g. several `role: image`) all land in the pool; invoking the non-agent ones is a future feature (an `image__generate`-style consumer), out of scope here.
- **Platform-auth embedding deferred** — a `role: embedding` file with a `platform:` block errors with a message pointing at the programmatic `WithBedrock`/`WithVertex`/`WithAzure` (the SDK `ProviderSpec` carries no platform field). `llm`/`image` platform auth works (flows through `createProviderFromConfig`).

## Test plan

- [x] `applyProviderConfig` routing: llm→agent, second-llm-pooled-not-agent, image→agent, tts, stt, inference, embedding+platform→error, unknown-role→error
- [x] `WithProviderFile` loads real YAML via `pkgconfig.LoadProvider`; missing-file → error
- [x] `WithProvidersDir`: sorted glob, first-wins agent across multiple files, empty dir = no-op
- [x] 4 modules build clean; full `sdk` suite green; `golangci-lint` exit 0 (no new findings)

Closes #1213
