### PR TITLE
feat(sdk): platform-auth for embedding + image/llm via ProviderSpec and file-loader

### DIFF
--- a/sdk/options.go
+++ b/sdk/options.go
@@ -1928,6 +1928,12 @@ type ProviderSpec struct {
 	BaseURL          string
 	Credential       *pkgconfig.CredentialConfig
 	AdditionalConfig map[string]any
+	// Platform carries hyperscaler platform configuration for keyless auth
+	// (azure/bedrock/vertex). When set, WithLLMProvider/WithImageProvider route
+	// through createProviderFromConfig's platform branch; WithEmbeddingProvider
+	// passes it to ResolveEmbeddingCredential and CreateEmbeddingProviderFromSpec.
+	// nil means direct API-key auth.
+	Platform *pkgconfig.PlatformConfig
 }
 
 // idOrType returns the spec ID, falling back to Type.
@@ -2001,6 +2007,7 @@ func (s ProviderSpec) toPkgProvider() *pkgconfig.Provider {
 		BaseURL:          s.BaseURL,
 		Credential:       s.Credential,
 		AdditionalConfig: s.AdditionalConfig,
+		Platform:         s.Platform,
 	}
 }
 
@@ -2102,13 +2109,18 @@ func WithSTTProvider(spec ProviderSpec) Option {
 //nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
 func WithEmbeddingProvider(spec ProviderSpec) Option {
 	return func(c *config) error {
-		cred, err := providers.ResolveEmbeddingCredential(context.Background(), spec.Type, "", spec.Credential, nil)
+		var platform string
+		if spec.Platform != nil {
+			platform = spec.Platform.Type
+		}
+		cred, err := providers.ResolveEmbeddingCredential(context.Background(), spec.Type, "", spec.Credential, spec.Platform)
 		if err != nil {
 			return fmt.Errorf("WithEmbeddingProvider %q: resolving credential: %w", spec.idOrType(), err)
 		}
 		ep, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
 			ID: spec.idOrType(), Type: spec.Type, Model: spec.Model,
 			BaseURL: spec.BaseURL, Credential: cred, AdditionalConfig: spec.AdditionalConfig,
+			Platform: platform, PlatformConfig: spec.Platform,
 		})
 		if err != nil {
 			return fmt.Errorf("WithEmbeddingProvider %q: %w", spec.idOrType(), err)

--- a/sdk/options_test.go
+++ b/sdk/options_test.go
@@ -1418,3 +1418,17 @@ func TestWithImageProvider_SetsAgentProvider(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, c.getAgentProvider(), "expected image provider to be set as the agent provider")
 }
+
+func TestProviderSpec_ToPkgProviderCarriesPlatform(t *testing.T) {
+	pc := &pkgconfig.PlatformConfig{Type: "bedrock", Region: "us-east-1"}
+	spec := ProviderSpec{
+		ID:       "llm-bedrock",
+		Type:     "anthropic",
+		Model:    "claude-3-5-sonnet-20241022",
+		Platform: pc,
+	}
+	p := spec.toPkgProvider()
+	require.NotNil(t, p.Platform, "expected Platform to be carried through toPkgProvider")
+	require.Equal(t, "bedrock", p.Platform.Type)
+	require.Equal(t, "us-east-1", p.Platform.Region)
+}

--- a/sdk/provider_file.go
+++ b/sdk/provider_file.go
@@ -9,8 +9,7 @@ import (
 )
 
 // providerSpecFromConfig maps a loaded *pkgconfig.Provider onto the SDK's
-// uniform ProviderSpec. Platform is intentionally not carried — ProviderSpec
-// has no platform field; platform-auth providers are handled separately.
+// uniform ProviderSpec, including any platform-auth configuration.
 func providerSpecFromConfig(p *pkgconfig.Provider) ProviderSpec {
 	return ProviderSpec{
 		ID:               p.ID,
@@ -19,6 +18,7 @@ func providerSpecFromConfig(p *pkgconfig.Provider) ProviderSpec {
 		BaseURL:          p.BaseURL,
 		Credential:       p.Credential,
 		AdditionalConfig: p.AdditionalConfig,
+		Platform:         p.Platform,
 	}
 }
 
@@ -52,11 +52,6 @@ func (c *config) applyProviderConfig(p *pkgconfig.Provider) error {
 	case pkgconfig.RoleSTT:
 		return WithSTTProvider(providerSpecFromConfig(p))(c)
 	case pkgconfig.RoleEmbedding:
-		if p.Platform != nil {
-			return fmt.Errorf(
-				"provider %q: platform-auth embedding providers are not yet supported via "+
-					"file loading; use WithBedrock/WithVertex/WithAzure", id)
-		}
 		return WithEmbeddingProvider(providerSpecFromConfig(p))(c)
 	case pkgconfig.RoleInference:
 		return WithInferenceProvider(providerSpecFromConfig(p))(c)

--- a/sdk/provider_file_test.go
+++ b/sdk/provider_file_test.go
@@ -81,15 +81,22 @@ func TestApplyProviderConfig_ImagePooledAsAgent(t *testing.T) {
 	}
 }
 
-func TestApplyProviderConfig_EmbeddingPlatformRejected(t *testing.T) {
-	c := &config{}
-	err := c.applyProviderConfig(&pkgconfig.Provider{
+func TestProviderSpecFromConfig_CarriesPlatform(t *testing.T) {
+	pc := &pkgconfig.PlatformConfig{Type: "azure", Endpoint: "https://my-resource.openai.azure.com"}
+	spec := providerSpecFromConfig(&pkgconfig.Provider{
+		ID:       "emb",
 		Type:     "openai",
 		Role:     pkgconfig.RoleEmbedding,
-		Platform: &pkgconfig.PlatformConfig{Type: "azure"},
+		Platform: pc,
 	})
-	if err == nil {
-		t.Fatal("expected platform-auth embedding via file to be rejected")
+	if spec.Platform == nil {
+		t.Fatal("expected Platform to be carried through providerSpecFromConfig, got nil")
+	}
+	if spec.Platform.Type != "azure" {
+		t.Fatalf("expected Platform.Type %q, got %q", "azure", spec.Platform.Type)
+	}
+	if spec.Platform.Endpoint != "https://my-resource.openai.azure.com" {
+		t.Fatalf("expected Platform.Endpoint carried through, got %q", spec.Platform.Endpoint)
 	}
 }
 


### PR DESCRIPTION
## Summary

Threads hyperscaler platform-auth (Azure/Bedrock/Vertex keyless credentials) through the SDK's uniform `ProviderSpec` and the `*.provider.yaml` file-loader, for the provider types that have a runtime substrate: **LLM/image** and **embedding**. No new platform logic — it carries one field through the existing reusable resolvers.

- Add `Platform *pkgconfig.PlatformConfig` to `sdk.ProviderSpec`.
- `toPkgProvider()` carries it → `WithLLMProvider`/`WithImageProvider` get platform via the existing `createProviderFromConfig` path.
- `WithEmbeddingProvider` passes `spec.Platform` to `ResolveEmbeddingCredential` + `EmbeddingProviderSpec` (mirrors the declarative `applyEmbeddingProviders` exactly).
- File-loader `providerSpecFromConfig` carries `p.Platform`; the `role: embedding` + `platform:` rejection added in #1328 is removed — it now just works.

Before this, platform-auth embedding worked in the runtime factory and the declarative `embedding_providers` block, but not via the new programmatic `WithEmbeddingProvider` or file loading. This closes that gap and brings Arena↔SDK pack portability to keyless-cloud embedding providers.

## Out of scope (tracked in #1330)

STT/TTS/inference are intentionally not touched — they have no platform substrate (`base.CapabilitySpec` has no `Platform` field, `base.ResolveCredential` no platform arg, and no platform-hosted backend exists). Adding SDK plumbing there would be dead code; #1330 captures the base-layer work for when a hosted backend lands.

## Caveat

This wires platform *through*; functional coverage is unchanged. Per the runtime today, only **Azure** embedding platform auth is functional end-to-end; Bedrock/Vertex embeddings still hit a "not yet supported" transport error (same as before — not a regression).

## Test plan

- [x] `ProviderSpec.Platform` mapping carried by `toPkgProvider` and `providerSpecFromConfig` (hermetic unit tests)
- [x] `WithEmbeddingProvider` ↔ `applyEmbeddingProviders` platform parity (reviewed)
- [x] embedding+platform file-loading no longer rejected
- [x] STT/TTS/inference untouched
- [x] `go build ./sdk/...` clean; sdk suite green under `PROMPTKIT_SCHEMA_SOURCE=local`

Related: #1327, #1328, #1330.
