### PR TITLE
feat(composition): Phase 1 — runtime/composition package (RFC 0010)

### DIFF
--- a/runtime/composition/parse.go
+++ b/runtime/composition/parse.go
@@ -1,0 +1,24 @@
+package composition
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ParseConfig parses an untyped compositions map (typically config.Compositions,
+// stored as interface{}) into typed Compositions keyed by name. Returns nil, nil
+// when raw is nil. Mirrors workflow.ParseConfig.
+func ParseConfig(raw interface{}) (map[string]*Composition, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling compositions config: %w", err)
+	}
+	var comps map[string]*Composition
+	if err := json.Unmarshal(data, &comps); err != nil {
+		return nil, fmt.Errorf("parsing compositions config: %w", err)
+	}
+	return comps, nil
+}

--- a/runtime/composition/parse_test.go
+++ b/runtime/composition/parse_test.go
@@ -1,0 +1,49 @@
+package composition
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseConfig_Nil(t *testing.T) {
+	got, err := ParseConfig(nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("want nil, got %v", got)
+	}
+}
+
+func TestParseConfig_Map(t *testing.T) {
+	raw := map[string]any{
+		"analyze": map[string]any{
+			"version": 1,
+			"steps": []any{
+				map[string]any{"id": "classify", "kind": "prompt", "prompt_task": "c"},
+			},
+		},
+	}
+	comps, err := ParseConfig(raw)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	c, ok := comps["analyze"]
+	if !ok {
+		t.Fatalf("missing composition; got keys %v", comps)
+	}
+	if c.Version != 1 || len(c.Steps) != 1 || c.Steps[0].ID != "classify" {
+		t.Fatalf("bad parse: %+v", c)
+	}
+}
+
+func TestParseConfig_InvalidStructure(t *testing.T) {
+	// Pass a non-object value so json.Unmarshal into map[string]*Composition fails.
+	_, err := ParseConfig("not a map")
+	if err == nil {
+		t.Fatal("want error for invalid structure, got nil")
+	}
+	if !strings.Contains(err.Error(), "parsing compositions config") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/runtime/composition/refs.go
+++ b/runtime/composition/refs.go
@@ -1,0 +1,40 @@
+package composition
+
+import "regexp"
+
+// refRe matches a ${root.path...} template reference and captures the leading
+// root token (the part before the first dot or the closing brace).
+var refRe = regexp.MustCompile(`\$\{\s*([a-zA-Z_][a-zA-Z0-9_]*)[^}]*\}`)
+
+// collectRefRoots walks an arbitrary JSON-ish value (string, map, slice) and
+// returns the deduplicated set of root tokens of every ${...} reference found.
+// Roots are "input" or a step id; resolution against those is done by Validate.
+func collectRefRoots(v any) []string {
+	seen := map[string]struct{}{}
+	var walk func(any)
+	walk = func(x any) {
+		switch t := x.(type) {
+		case string:
+			for _, m := range refRe.FindAllStringSubmatch(t, -1) {
+				seen[m[1]] = struct{}{}
+			}
+		case map[string]any:
+			for _, val := range t {
+				walk(val)
+			}
+		case []any:
+			for _, val := range t {
+				walk(val)
+			}
+		}
+	}
+	walk(v)
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	return out
+}

--- a/runtime/composition/refs_test.go
+++ b/runtime/composition/refs_test.go
@@ -1,0 +1,34 @@
+package composition
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCollectRefRoots(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want []string
+	}{
+		{"string ref", "${input.text}", []string{"input"}},
+		{"plain string", "no refs here", nil},
+		{"nested object", map[string]any{
+			"a": "${classify.output.type}",
+			"b": map[string]any{"c": "${input.x}"},
+		}, []string{"classify", "input"}},
+		{"slice", []any{"${a.output.y}", "literal"}, []string{"a"}},
+		{"multiple in one string", "${input.x} and ${meta.output.z}", []string{"input", "meta"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectRefRoots(tc.in)
+			sort.Strings(got)
+			sort.Strings(tc.want)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("collectRefRoots(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/runtime/composition/types.go
+++ b/runtime/composition/types.go
@@ -97,8 +97,8 @@ type Predicate struct {
 	Not    *Predicate   `json:"not,omitempty"`
 }
 
-// CompareOps is the set of valid comparison operators.
-var CompareOps = map[string]bool{
+// compareOps is the set of valid comparison operators.
+var compareOps = map[string]bool{
 	"equals": true, "not_equals": true,
 	"in": true, "not_in": true,
 	"less_than": true, "less_than_or_equals": true,

--- a/runtime/composition/types.go
+++ b/runtime/composition/types.go
@@ -1,0 +1,106 @@
+// Package composition defines RFC 0010 workflow-composition types and their
+// validation. It is a leaf package: it imports neither runtime/pipeline nor
+// runtime/workflow, so workflow.State can reference these types without a cycle.
+package composition
+
+// StepKind identifies a composition step's kind.
+type StepKind string
+
+// Step kinds (RFC 0010 v1).
+const (
+	KindPrompt   StepKind = "prompt"
+	KindAgent    StepKind = "agent"
+	KindTool     StepKind = "tool"
+	KindBranch   StepKind = "branch"
+	KindParallel StepKind = "parallel"
+)
+
+// Reduce strategies (RFC 0010 v1).
+const (
+	ReduceAppend  = "append"
+	ReduceReplace = "replace"
+	ReduceBarrier = "barrier"
+)
+
+// Composition is a named step graph over the pack's prompts, tools, and evals.
+type Composition struct {
+	Version      int            `json:"version"`
+	Description  string         `json:"description,omitempty"`
+	InputSchema  string         `json:"input_schema,omitempty"`
+	OutputSchema string         `json:"output_schema,omitempty"`
+	Output       string         `json:"output,omitempty"` // step id; default = last step
+	Steps        []*Step        `json:"steps"`
+	Engine       map[string]any `json:"engine,omitempty"` // opaque runtime-specific config
+}
+
+// Step is a single node in a composition graph. Only the fields legal for Kind
+// are set; per-kind legality is enforced by Validate.
+type Step struct {
+	ID        string         `json:"id"`
+	Kind      StepKind       `json:"kind"`
+	DependsOn []string       `json:"depends_on,omitempty"`
+	Modifiers *StepModifiers `json:"modifiers,omitempty"`
+
+	// prompt, agent
+	PromptTask   string       `json:"prompt_task,omitempty"`
+	Input        any          `json:"input,omitempty"` // StepInput: "${...}" string or object
+	OutputSchema string       `json:"output_schema,omitempty"`
+	Tools        []string     `json:"tools,omitempty"`       // agent only
+	Termination  *Termination `json:"termination,omitempty"` // agent only
+
+	// tool
+	Tool string         `json:"tool,omitempty"`
+	Args map[string]any `json:"args,omitempty"`
+
+	// branch
+	Predicate *Predicate `json:"predicate,omitempty"`
+	Then      string     `json:"then,omitempty"`
+	Else      string     `json:"else,omitempty"`
+
+	// parallel
+	Branches []*Step  `json:"branches,omitempty"`
+	Reduce   *Reducer `json:"reduce,omitempty"`
+}
+
+// Termination bounds an agent step's tool loop. anyOf max_steps | tool_called.
+type Termination struct {
+	MaxSteps   int    `json:"max_steps,omitempty"`
+	ToolCalled string `json:"tool_called,omitempty"`
+}
+
+// Reducer declares how parallel branch outputs merge. Both fields required.
+type Reducer struct {
+	Strategy string `json:"strategy"` // append | replace | barrier
+	Into     string `json:"into"`     // variable name the merged result is exposed under
+}
+
+// StepModifiers are optional per-step behaviors (RFC 0010 v1: retry, eval).
+type StepModifiers struct {
+	Retry *RetryModifier `json:"retry,omitempty"`
+	Eval  []string       `json:"eval,omitempty"` // references to pack eval keys (observability)
+}
+
+// RetryModifier re-runs a step on error up to MaxAttempts.
+type RetryModifier struct {
+	MaxAttempts int `json:"max_attempts,omitempty"`
+}
+
+// Predicate is the constrained predicate language. Exactly one variant is set:
+// compare (path+op+value), exists (path+exists), or a composite (all_of/any_of/not).
+type Predicate struct {
+	Path   string       `json:"path,omitempty"`
+	Op     string       `json:"op,omitempty"`
+	Value  any          `json:"value,omitempty"`
+	Exists *bool        `json:"exists,omitempty"`
+	AllOf  []*Predicate `json:"all_of,omitempty"`
+	AnyOf  []*Predicate `json:"any_of,omitempty"`
+	Not    *Predicate   `json:"not,omitempty"`
+}
+
+// CompareOps is the set of valid comparison operators.
+var CompareOps = map[string]bool{
+	"equals": true, "not_equals": true,
+	"in": true, "not_in": true,
+	"less_than": true, "less_than_or_equals": true,
+	"greater_than": true, "greater_than_or_equals": true,
+}

--- a/runtime/composition/types_test.go
+++ b/runtime/composition/types_test.go
@@ -1,0 +1,76 @@
+package composition
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestComposition_JSONRoundTrip(t *testing.T) {
+	raw := `{
+		"version": 1,
+		"description": "analyze",
+		"input_schema": "schemas/in.json",
+		"output_schema": "schemas/out.json",
+		"output": "synthesize",
+		"engine": {"vendor": "x"},
+		"steps": [
+			{"id": "classify", "kind": "prompt", "prompt_task": "doc_classifier",
+			 "input": "${input.text}", "output_schema": "schemas/doctype.json"},
+			{"id": "route", "kind": "branch",
+			 "predicate": {"path": "${classify.output.type}", "op": "equals", "value": "research_paper"},
+			 "then": "extract", "else": "general"},
+			{"id": "meta", "kind": "parallel",
+			 "branches": [
+				{"id": "structure", "kind": "tool", "tool": "doc.parse", "args": {"content": "${input.text}"}},
+				{"id": "citations", "kind": "tool", "tool": "doc.cite", "args": {"content": "${input.text}"}}
+			 ],
+			 "reduce": {"strategy": "barrier", "into": "metadata"}},
+			{"id": "synthesize", "kind": "agent", "prompt_task": "doc_analyzer",
+			 "input": "${meta.output.metadata}", "tools": ["ref.search"],
+			 "termination": {"max_steps": 10},
+			 "modifiers": {"retry": {"max_attempts": 3}, "eval": ["analysis_quality"]}}
+		]
+	}`
+
+	var c Composition
+	if err := json.Unmarshal([]byte(raw), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Version != 1 {
+		t.Errorf("version = %d, want 1", c.Version)
+	}
+	if c.Output != "synthesize" || len(c.Steps) != 4 {
+		t.Fatalf("output=%q steps=%d", c.Output, len(c.Steps))
+	}
+	if c.Engine["vendor"] != "x" {
+		t.Errorf("engine.vendor = %v, want x", c.Engine["vendor"])
+	}
+	if c.Steps[0].Kind != KindPrompt || c.Steps[0].PromptTask != "doc_classifier" {
+		t.Errorf("step0 = %+v", c.Steps[0])
+	}
+	if c.Steps[1].Predicate.Op != "equals" || c.Steps[1].Then != "extract" {
+		t.Errorf("branch = %+v", c.Steps[1])
+	}
+	if c.Steps[2].Reduce.Strategy != ReduceBarrier || c.Steps[2].Reduce.Into != "metadata" {
+		t.Errorf("reduce = %+v", c.Steps[2].Reduce)
+	}
+	if len(c.Steps[2].Branches) != 2 {
+		t.Errorf("branches = %d", len(c.Steps[2].Branches))
+	}
+	if c.Steps[3].Termination.MaxSteps != 10 || c.Steps[3].Modifiers.Retry.MaxAttempts != 3 {
+		t.Errorf("agent = %+v", c.Steps[3])
+	}
+	if len(c.Steps[3].Modifiers.Eval) != 1 || c.Steps[3].Modifiers.Eval[0] != "analysis_quality" {
+		t.Errorf("eval = %+v", c.Steps[3].Modifiers.Eval)
+	}
+}
+
+func TestPredicate_ExistsVariant(t *testing.T) {
+	var p Predicate
+	if err := json.Unmarshal([]byte(`{"path":"${a.output.x}","exists":true}`), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Exists == nil || !*p.Exists {
+		t.Fatalf("exists not parsed: %+v", p)
+	}
+}

--- a/runtime/composition/validate.go
+++ b/runtime/composition/validate.go
@@ -1,0 +1,189 @@
+package composition
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+var stepIDRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// reservedCompositionNames must not be used as composition keys.
+var reservedCompositionNames = map[string]bool{
+	"workflow__transition":   true,
+	"workflow__set_artifact": true,
+}
+
+// Available holds the pack key sets a composition's references resolve against.
+type Available struct {
+	Prompts []string
+	Tools   []string
+	Evals   []string
+}
+
+func (a Available) set(which []string) map[string]bool {
+	m := make(map[string]bool, len(which))
+	for _, k := range which {
+		m[k] = true
+	}
+	return m
+}
+
+// ValidationResult holds blocking errors and non-blocking warnings.
+type ValidationResult struct {
+	Errors   []string
+	Warnings []string
+}
+
+// HasErrors reports whether there are blocking validation errors.
+func (r *ValidationResult) HasErrors() bool { return len(r.Errors) > 0 }
+
+func (r *ValidationResult) merge(other *ValidationResult) {
+	r.Errors = append(r.Errors, other.Errors...)
+	r.Warnings = append(r.Warnings, other.Warnings...)
+}
+
+// ValidateAll validates every composition in a pack map and checks pack-wide
+// rules (rule 1: key uniqueness is inherent to the map; reserved-name collision).
+func ValidateAll(comps map[string]*Composition, avail Available) *ValidationResult {
+	r := &ValidationResult{}
+	names := make([]string, 0, len(comps))
+	for name := range comps {
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic error order
+	for _, name := range names {
+		if reservedCompositionNames[name] {
+			r.Errors = append(r.Errors,
+				fmt.Sprintf("compositions[%q]: name collides with a reserved runtime name", name))
+		}
+		r.merge(Validate(name, comps[name], avail))
+	}
+	return r
+}
+
+// Validate checks a single composition against the available pack key sets.
+// It implements composition-internal rules 2–11 from the design (rule 1 and the
+// workflow/pack-level rules live in ValidateAll and Plan 3 respectively).
+func Validate(name string, c *Composition, avail Available) *ValidationResult {
+	r := &ValidationResult{}
+	if c == nil {
+		return r
+	}
+	stepIDs := validateStepIDs(name, c, r)
+	prompts, tools, evals := avail.set(avail.Prompts), avail.set(avail.Tools), avail.set(avail.Evals)
+	forEachStep(c.Steps, func(s *Step) {
+		validateReferences(name, s, prompts, tools, evals, r)
+		validateRefRoots(name, s, stepIDs, r)
+	})
+	return r
+}
+
+// validateReferences checks rule 3.
+func validateReferences(name string, s *Step, prompts, tools, evals map[string]bool, r *ValidationResult) {
+	pfx := fmt.Sprintf("compositions[%q].steps[%q]", name, s.ID)
+	switch s.Kind {
+	case KindPrompt, KindAgent:
+		if s.PromptTask != "" && !prompts[s.PromptTask] {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: prompt_task %q does not reference a valid prompt", pfx, s.PromptTask))
+		}
+	case KindTool:
+		if s.Tool != "" && !tools[s.Tool] {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: tool %q does not reference a valid tool", pfx, s.Tool))
+		}
+	case KindBranch, KindParallel:
+		// no key-set references for branch/parallel — tools and prompts are on child steps
+	}
+	validateAgentTools(pfx, s, tools, r)
+	validateModifierEvals(pfx, s, evals, r)
+}
+
+// validateAgentTools checks agent-step tool references (rule 3 sub-check).
+func validateAgentTools(pfx string, s *Step, tools map[string]bool, r *ValidationResult) {
+	for _, tname := range s.Tools {
+		if !tools[tname] {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: tool %q does not reference a valid tool", pfx, tname))
+		}
+	}
+}
+
+// validateModifierEvals checks modifier eval references (rule 3 sub-check).
+func validateModifierEvals(pfx string, s *Step, evals map[string]bool, r *ValidationResult) {
+	if s.Modifiers == nil {
+		return
+	}
+	for _, ev := range s.Modifiers.Eval {
+		if !evals[ev] {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: eval %q does not reference a valid eval", pfx, ev))
+		}
+	}
+}
+
+// validateStepIDs checks rule 2 and returns the set of all step ids (including
+// nested parallel.branches) for downstream reference checks.
+func validateStepIDs(name string, c *Composition, r *ValidationResult) map[string]bool {
+	ids := map[string]bool{}
+	var walk func(steps []*Step)
+	walk = func(steps []*Step) {
+		for _, s := range steps {
+			if !stepIDRe.MatchString(s.ID) {
+				r.Errors = append(r.Errors, fmt.Sprintf(
+					"compositions[%q].steps: step id %q must match ^[a-zA-Z_][a-zA-Z0-9_]*$", name, s.ID))
+			}
+			if ids[s.ID] {
+				r.Errors = append(r.Errors, fmt.Sprintf(
+					"compositions[%q].steps: duplicate step id %q", name, s.ID))
+			}
+			ids[s.ID] = true
+			if s.Kind == KindParallel {
+				walk(s.Branches)
+			}
+		}
+	}
+	walk(c.Steps)
+	return ids
+}
+
+// forEachStep walks every step including nested parallel.branches.
+func forEachStep(steps []*Step, fn func(*Step)) {
+	for _, s := range steps {
+		fn(s)
+		if s.Kind == KindParallel {
+			forEachStep(s.Branches, fn)
+		}
+	}
+}
+
+// validateRefRoots checks rule 4: every ${...} root is "input" or a known step id.
+func validateRefRoots(name string, s *Step, stepIDs map[string]bool, r *ValidationResult) {
+	roots := collectRefRoots(s.Input)
+	roots = append(roots, collectRefRoots(s.Args)...)
+	roots = append(roots, collectRefRoots(predicatePaths(s.Predicate))...)
+	for _, root := range roots {
+		if root == "input" || stepIDs[root] {
+			continue
+		}
+		r.Errors = append(r.Errors, fmt.Sprintf(
+			"compositions[%q].steps[%q]: references unknown %q (not 'input' or a step id)", name, s.ID, root))
+	}
+}
+
+// predicatePaths flattens all path strings in a predicate tree into a slice so
+// collectRefRoots can extract their roots.
+func predicatePaths(p *Predicate) []any {
+	if p == nil {
+		return nil
+	}
+	var out []any
+	if p.Path != "" {
+		out = append(out, p.Path)
+	}
+	for _, c := range p.AllOf {
+		out = append(out, predicatePaths(c)...)
+	}
+	for _, c := range p.AnyOf {
+		out = append(out, predicatePaths(c)...)
+	}
+	out = append(out, predicatePaths(p.Not)...)
+	return out
+}

--- a/runtime/composition/validate.go
+++ b/runtime/composition/validate.go
@@ -8,6 +8,20 @@ import (
 
 var stepIDRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
+// fieldInput / fieldOutputSchema / fieldPromptTask are kind-field name constants
+// used in the allowed-fields map and presentKindFields to avoid goconst warnings.
+const (
+	fieldInput        = "input"
+	fieldOutputSchema = "output_schema"
+	fieldPromptTask   = "prompt_task"
+)
+
+// inputRefRoot is the special root token that refers to the composition's input.
+const inputRefRoot = "input"
+
+// minParallelBranches is the minimum number of branches a parallel step must have.
+const minParallelBranches = 2
+
 // reservedCompositionNames must not be used as composition keys.
 var reservedCompositionNames = map[string]bool{
 	"workflow__transition":   true,
@@ -75,6 +89,7 @@ func Validate(name string, c *Composition, avail Available) *ValidationResult {
 	forEachStep(c.Steps, func(s *Step) {
 		validateReferences(name, s, prompts, tools, evals, r)
 		validateRefRoots(name, s, stepIDs, r)
+		validateKind(name, s, r)
 	})
 	return r
 }
@@ -160,7 +175,7 @@ func validateRefRoots(name string, s *Step, stepIDs map[string]bool, r *Validati
 	roots = append(roots, collectRefRoots(s.Args)...)
 	roots = append(roots, collectRefRoots(predicatePaths(s.Predicate))...)
 	for _, root := range roots {
-		if root == "input" || stepIDs[root] {
+		if root == inputRefRoot || stepIDs[root] {
 			continue
 		}
 		r.Errors = append(r.Errors, fmt.Sprintf(
@@ -186,4 +201,150 @@ func predicatePaths(p *Predicate) []any {
 	}
 	out = append(out, predicatePaths(p.Not)...)
 	return out
+}
+
+// validateKind checks rules 5, 6, 7, 11 for a single step.
+func validateKind(name string, s *Step, r *ValidationResult) {
+	pfx := fmt.Sprintf("compositions[%q].steps[%q]", name, s.ID)
+	allowed := map[StepKind]map[string]bool{
+		KindPrompt:   {fieldPromptTask: true, fieldInput: true, fieldOutputSchema: true},
+		KindAgent:    {fieldPromptTask: true, fieldInput: true, fieldOutputSchema: true, "tools": true, "termination": true},
+		KindTool:     {"tool": true, "args": true},
+		KindBranch:   {"predicate": true, "then": true, "else": true},
+		KindParallel: {"branches": true, "reduce": true},
+	}
+	set, known := allowed[s.Kind]
+	if !known {
+		r.Errors = append(r.Errors, fmt.Sprintf("%s: unknown kind %q", pfx, s.Kind))
+		return
+	}
+	for _, f := range presentKindFields(s) {
+		if !set[f] {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: field %q not allowed for kind %q", pfx, f, s.Kind))
+		}
+	}
+	switch s.Kind {
+	case KindPrompt, KindTool:
+		// no additional structural checks beyond the allowed-field set
+	case KindAgent:
+		if s.Termination == nil || (s.Termination.MaxSteps == 0 && s.Termination.ToolCalled == "") {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: agent step must declare termination (max_steps or tool_called)", pfx))
+		}
+	case KindParallel:
+		if len(s.Branches) < minParallelBranches {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: parallel step must have at least two branches", pfx))
+		}
+		validateReducer(pfx, s.Reduce, r)
+	case KindBranch:
+		if s.Then == "" {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: branch step must declare then", pfx))
+		}
+		validatePredicate(pfx, s.Predicate, r)
+	}
+}
+
+// presentKindFields lists the kind-specific fields that are set on s.
+func presentKindFields(s *Step) []string {
+	var f []string
+	if s.PromptTask != "" {
+		f = append(f, fieldPromptTask)
+	}
+	if s.Input != nil {
+		f = append(f, fieldInput)
+	}
+	if s.OutputSchema != "" {
+		f = append(f, fieldOutputSchema)
+	}
+	if len(s.Tools) > 0 {
+		f = append(f, "tools")
+	}
+	if s.Termination != nil {
+		f = append(f, "termination")
+	}
+	if s.Tool != "" {
+		f = append(f, "tool")
+	}
+	if len(s.Args) > 0 {
+		f = append(f, "args")
+	}
+	if s.Predicate != nil {
+		f = append(f, "predicate")
+	}
+	if s.Then != "" {
+		f = append(f, "then")
+	}
+	if s.Else != "" {
+		f = append(f, "else")
+	}
+	if len(s.Branches) > 0 {
+		f = append(f, "branches")
+	}
+	if s.Reduce != nil {
+		f = append(f, "reduce")
+	}
+	return f
+}
+
+// validateReducer checks rule 6's reducer half.
+func validateReducer(pfx string, red *Reducer, r *ValidationResult) {
+	if red == nil {
+		r.Errors = append(r.Errors, fmt.Sprintf("%s: parallel step must declare reduce", pfx))
+		return
+	}
+	switch red.Strategy {
+	case ReduceAppend, ReduceReplace, ReduceBarrier:
+	default:
+		r.Errors = append(r.Errors, fmt.Sprintf(
+			"%s: reduce.strategy %q is not valid (append|replace|barrier)", pfx, red.Strategy))
+	}
+	if red.Into == "" {
+		r.Errors = append(r.Errors, fmt.Sprintf("%s: reduce.into is required", pfx))
+	}
+}
+
+// validatePredicate checks rule 7's predicate half: exactly one variant, valid op.
+func validatePredicate(pfx string, p *Predicate, r *ValidationResult) {
+	if p == nil {
+		r.Errors = append(r.Errors, fmt.Sprintf("%s: branch step must declare predicate", pfx))
+		return
+	}
+	isCompare, variants := countPredicateVariants(p)
+	if variants != 1 {
+		r.Errors = append(r.Errors, fmt.Sprintf(
+			"%s: predicate must set exactly one variant (compare|exists|all_of|any_of|not)", pfx))
+	}
+	if isCompare && !CompareOps[p.Op] {
+		r.Errors = append(r.Errors, fmt.Sprintf("%s: predicate op %q is not valid", pfx, p.Op))
+	}
+	for _, c := range p.AllOf {
+		validatePredicate(pfx, c, r)
+	}
+	for _, c := range p.AnyOf {
+		validatePredicate(pfx, c, r)
+	}
+	if p.Not != nil {
+		validatePredicate(pfx, p.Not, r)
+	}
+}
+
+// countPredicateVariants returns whether the predicate is a compare variant and
+// the total number of set variants (used by validatePredicate to enforce exactly-one).
+func countPredicateVariants(p *Predicate) (isCompare bool, variants int) {
+	isCompare = p.Op != "" || p.Value != nil
+	if isCompare {
+		variants++
+	}
+	if p.Exists != nil {
+		variants++
+	}
+	if len(p.AllOf) > 0 {
+		variants++
+	}
+	if len(p.AnyOf) > 0 {
+		variants++
+	}
+	if p.Not != nil {
+		variants++
+	}
+	return isCompare, variants
 }

--- a/runtime/composition/validate.go
+++ b/runtime/composition/validate.go
@@ -35,9 +35,10 @@ type Available struct {
 	Evals   []string
 }
 
-func (a Available) set(which []string) map[string]bool {
-	m := make(map[string]bool, len(which))
-	for _, k := range which {
+// stringSet converts a slice of strings to a presence map.
+func stringSet(keys []string) map[string]bool {
+	m := make(map[string]bool, len(keys))
+	for _, k := range keys {
 		m[k] = true
 	}
 	return m
@@ -84,8 +85,11 @@ func Validate(name string, c *Composition, avail Available) *ValidationResult {
 	if c == nil {
 		return r
 	}
+	if c.Version != 1 {
+		r.Errors = append(r.Errors, fmt.Sprintf("compositions[%q]: version must be 1, got %d", name, c.Version))
+	}
 	stepIDs := validateStepIDs(name, c, r)
-	prompts, tools, evals := avail.set(avail.Prompts), avail.set(avail.Tools), avail.set(avail.Evals)
+	prompts, tools, evals := stringSet(avail.Prompts), stringSet(avail.Tools), stringSet(avail.Evals)
 	forEachStep(c.Steps, func(s *Step) {
 		validateReferences(name, s, prompts, tools, evals, r)
 		validateRefRoots(name, s, stepIDs, r)
@@ -210,6 +214,8 @@ func predicatePaths(p *Predicate) []any {
 // validateKind checks rules 5, 6, 7, 11 for a single step.
 func validateKind(name string, s *Step, r *ValidationResult) {
 	pfx := fmt.Sprintf("compositions[%q].steps[%q]", name, s.ID)
+	// depends_on and modifiers are cross-kind fields; intentionally absent so they
+	// are never flagged as "field not allowed".
 	allowed := map[StepKind]map[string]bool{
 		KindPrompt:   {fieldPromptTask: true, fieldInput: true, fieldOutputSchema: true},
 		KindAgent:    {fieldPromptTask: true, fieldInput: true, fieldOutputSchema: true, "tools": true, "termination": true},
@@ -317,7 +323,10 @@ func validatePredicate(pfx string, p *Predicate, r *ValidationResult) {
 		r.Errors = append(r.Errors, fmt.Sprintf(
 			"%s: predicate must set exactly one variant (compare|exists|all_of|any_of|not)", pfx))
 	}
-	if isCompare && !CompareOps[p.Op] {
+	if isCompare && p.Path == "" {
+		r.Errors = append(r.Errors, fmt.Sprintf("%s: compare predicate must declare path", pfx))
+	}
+	if isCompare && !compareOps[p.Op] {
 		r.Errors = append(r.Errors, fmt.Sprintf("%s: predicate op %q is not valid", pfx, p.Op))
 	}
 	for _, c := range p.AllOf {
@@ -388,6 +397,8 @@ func validateAcyclic(name string, c *Composition, r *ValidationResult) {
 
 // buildStepEdges constructs the predecessor-edge map for the step graph.
 // Edges run from each step to its predecessors (depends_on or sequential).
+// Top-level steps without an explicit depends_on get an implicit sequential predecessor edge.
+// Nested branch steps inside a parallel only get depends_on edges (no implicit ordering).
 func buildStepEdges(c *Composition) map[string][]string {
 	edges := map[string][]string{}
 	var prev string
@@ -405,10 +416,22 @@ func buildStepEdges(c *Composition) map[string][]string {
 		}
 		prev = s.ID
 	}
+	// Add depends_on edges for nested branch steps inside parallel steps.
+	// Branches within a parallel have no implicit sequential ordering.
+	for _, s := range c.Steps {
+		if s.Kind == KindParallel {
+			forEachStep(s.Branches, func(b *Step) {
+				if len(b.DependsOn) > 0 {
+					edges[b.ID] = append(edges[b.ID], b.DependsOn...)
+				}
+			})
+		}
+	}
 	return edges
 }
 
 // hasCycle runs a DFS on the step edge map and returns true if a back-edge is found.
+// It seeds the DFS from all steps including nested parallel.branches.
 func hasCycle(c *Composition, edges map[string][]string) bool {
 	const (
 		white = iota
@@ -427,12 +450,13 @@ func hasCycle(c *Composition, edges map[string][]string) bool {
 		color[n] = black
 		return false
 	}
-	for _, s := range c.Steps {
-		if color[s.ID] == white && dfs(s.ID) {
-			return true
+	found := false
+	forEachStep(c.Steps, func(s *Step) {
+		if !found && color[s.ID] == white && dfs(s.ID) {
+			found = true
 		}
-	}
-	return false
+	})
+	return found
 }
 
 // validateJoinHints warns (rule 8 second half) when a top-level step textually

--- a/runtime/composition/validate.go
+++ b/runtime/composition/validate.go
@@ -91,6 +91,10 @@ func Validate(name string, c *Composition, avail Available) *ValidationResult {
 		validateRefRoots(name, s, stepIDs, r)
 		validateKind(name, s, r)
 	})
+	validateGraphTargets(name, c, stepIDs, r)
+	validateAcyclic(name, c, r)
+	validateOutput(name, c, stepIDs, r)
+	validateJoinHints(name, c, r)
 	return r
 }
 
@@ -347,4 +351,100 @@ func countPredicateVariants(p *Predicate) (isCompare bool, variants int) {
 		variants++
 	}
 	return isCompare, variants
+}
+
+// validateGraphTargets checks rule 8's resolution half.
+func validateGraphTargets(name string, c *Composition, stepIDs map[string]bool, r *ValidationResult) {
+	forEachStep(c.Steps, func(s *Step) {
+		pfx := fmt.Sprintf("compositions[%q].steps[%q]", name, s.ID)
+		if s.Then != "" && !stepIDs[s.Then] {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: then %q does not reference a step", pfx, s.Then))
+		}
+		if s.Else != "" && !stepIDs[s.Else] {
+			r.Errors = append(r.Errors, fmt.Sprintf("%s: else %q does not reference a step", pfx, s.Else))
+		}
+		for _, dep := range s.DependsOn {
+			if !stepIDs[dep] {
+				r.Errors = append(r.Errors, fmt.Sprintf("%s: depends_on %q does not reference a step", pfx, dep))
+			}
+		}
+	})
+}
+
+// validateOutput checks rule 10.
+func validateOutput(name string, c *Composition, stepIDs map[string]bool, r *ValidationResult) {
+	if c.Output != "" && !stepIDs[c.Output] {
+		r.Errors = append(r.Errors, fmt.Sprintf("compositions[%q]: output %q does not reference a step", name, c.Output))
+	}
+}
+
+// validateAcyclic checks rule 9 over the depends_on + branch (then/else) edges.
+func validateAcyclic(name string, c *Composition, r *ValidationResult) {
+	edges := buildStepEdges(c)
+	if hasCycle(c, edges) {
+		r.Errors = append(r.Errors, fmt.Sprintf("compositions[%q]: step graph contains a cycle", name))
+	}
+}
+
+// buildStepEdges constructs the predecessor-edge map for the step graph.
+// Edges run from each step to its predecessors (depends_on or sequential).
+func buildStepEdges(c *Composition) map[string][]string {
+	edges := map[string][]string{}
+	var prev string
+	for i, s := range c.Steps {
+		if len(s.DependsOn) > 0 {
+			edges[s.ID] = append(edges[s.ID], s.DependsOn...)
+		} else if i > 0 {
+			edges[s.ID] = append(edges[s.ID], prev) // sequential predecessor
+		}
+		if s.Then != "" {
+			edges[s.Then] = append(edges[s.Then], s.ID)
+		}
+		if s.Else != "" {
+			edges[s.Else] = append(edges[s.Else], s.ID)
+		}
+		prev = s.ID
+	}
+	return edges
+}
+
+// hasCycle runs a DFS on the step edge map and returns true if a back-edge is found.
+func hasCycle(c *Composition, edges map[string][]string) bool {
+	const (
+		white = iota
+		gray
+		black
+	)
+	color := map[string]int{}
+	var dfs func(string) bool
+	dfs = func(n string) bool {
+		color[n] = gray
+		for _, m := range edges[n] {
+			if color[m] == gray || (color[m] == white && dfs(m)) {
+				return true
+			}
+		}
+		color[n] = black
+		return false
+	}
+	for _, s := range c.Steps {
+		if color[s.ID] == white && dfs(s.ID) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateJoinHints warns (rule 8 second half) when a top-level step textually
+// follows a branch/parallel without declaring depends_on to mark the join point.
+func validateJoinHints(name string, c *Composition, r *ValidationResult) {
+	for i := 1; i < len(c.Steps); i++ {
+		prev := c.Steps[i-1]
+		cur := c.Steps[i]
+		if (prev.Kind == KindBranch || prev.Kind == KindParallel) && len(cur.DependsOn) == 0 {
+			r.Warnings = append(r.Warnings, fmt.Sprintf(
+				"compositions[%q].steps[%q]: step follows a %s; declare depends_on to mark the join point",
+				name, cur.ID, prev.Kind))
+		}
+	}
 }

--- a/runtime/composition/validate_test.go
+++ b/runtime/composition/validate_test.go
@@ -296,3 +296,33 @@ func TestValidate_JoinWarning(t *testing.T) {
 		t.Fatalf("want join-point warning, got warnings %v", r.Warnings)
 	}
 }
+
+func TestValidate_FullValidCompositionNoErrors(t *testing.T) {
+	c := &Composition{
+		Version: 1, Output: "synthesize",
+		Steps: []*Step{
+			{ID: "classify", Kind: KindPrompt, PromptTask: "doc_classifier", Input: "${input.text}"},
+			{ID: "route", Kind: KindBranch,
+				Predicate: &Predicate{Path: "${classify.output.type}", Op: "equals", Value: "paper"},
+				Then:      "paper", Else: "general"},
+			{ID: "paper", Kind: KindPrompt, PromptTask: "paper_extractor", Input: "${input.text}", DependsOn: []string{"route"}},
+			{ID: "general", Kind: KindPrompt, PromptTask: "general_extractor", Input: "${input.text}", DependsOn: []string{"route"}},
+			{ID: "meta", Kind: KindParallel, DependsOn: []string{"paper", "general"},
+				Branches: []*Step{
+					{ID: "structure", Kind: KindTool, Tool: "doc.parse", Args: map[string]any{"content": "${input.text}"}},
+					{ID: "citations", Kind: KindTool, Tool: "doc.cite", Args: map[string]any{"content": "${input.text}"}},
+				},
+				Reduce: &Reducer{Strategy: ReduceBarrier, Into: "metadata"}},
+			{ID: "synthesize", Kind: KindAgent, PromptTask: "doc_analyzer", Input: "${meta.output.metadata}",
+				Tools: []string{"ref.search"}, Termination: &Termination{MaxSteps: 10}, DependsOn: []string{"meta"},
+				Modifiers: &StepModifiers{Eval: []string{"analysis_quality"}}},
+		},
+	}
+	r := Validate("analyze", c,
+		av([]string{"doc_classifier", "paper_extractor", "general_extractor", "doc_analyzer"},
+			[]string{"doc.parse", "doc.cite", "ref.search"},
+			[]string{"analysis_quality"}))
+	if r.HasErrors() {
+		t.Fatalf("expected no errors, got %v (warnings %v)", r.Errors, r.Warnings)
+	}
+}

--- a/runtime/composition/validate_test.go
+++ b/runtime/composition/validate_test.go
@@ -297,6 +297,52 @@ func TestValidate_JoinWarning(t *testing.T) {
 	}
 }
 
+// --- TDD tests for fixes #1, #2, #3 ---
+
+// Fix #1: cycle detection must walk nested parallel.branches.
+func TestValidate_NestedBranchCycle(t *testing.T) {
+	// Two branches inside a parallel that depend on each other → cycle.
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "par", Kind: KindParallel,
+			Reduce: &Reducer{Strategy: ReduceAppend, Into: "x"},
+			Branches: []*Step{
+				{ID: "left", Kind: KindTool, Tool: "t", DependsOn: []string{"right"}},
+				{ID: "right", Kind: KindTool, Tool: "t", DependsOn: []string{"left"}},
+			},
+		},
+	}}
+	r := Validate("comp", c, av(nil, []string{"t"}, nil))
+	if !hasErr(r, "cycle") {
+		t.Fatalf("want cycle error for nested branch mutual dependency, got %v", r.Errors)
+	}
+}
+
+// Fix #2: compare predicate must declare path.
+func TestValidate_ComparePredicateMissingPath(t *testing.T) {
+	// Predicate with op+value but no path → error.
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "b", Kind: KindBranch,
+			Predicate: &Predicate{Op: "equals", Value: 1}, // no Path
+			Then:      "n"},
+		{ID: "n", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "must declare path") {
+		t.Fatalf("want 'must declare path' error for compare predicate with no path, got %v", r.Errors)
+	}
+}
+
+// Fix #3: Composition.Version must be 1.
+func TestValidate_VersionMustBeOne(t *testing.T) {
+	c := &Composition{Version: 2, Steps: []*Step{
+		{ID: "a", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "version must be 1") {
+		t.Fatalf("want version error, got %v", r.Errors)
+	}
+}
+
 func TestValidate_FullValidCompositionNoErrors(t *testing.T) {
 	c := &Composition{
 		Version: 1, Output: "synthesize",

--- a/runtime/composition/validate_test.go
+++ b/runtime/composition/validate_test.go
@@ -162,3 +162,77 @@ func TestValidate_PredicateAllOfAnyOfPaths(t *testing.T) {
 		t.Fatalf("unexpected errors: %v", r.Errors)
 	}
 }
+
+func TestValidate_AgentNeedsTermination(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindAgent, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "agent step") || !hasErr(r, "termination") {
+		t.Fatalf("want termination error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_ParallelNeedsTwoBranchesAndReduce(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "par", Kind: KindParallel, Branches: []*Step{{ID: "only", Kind: KindTool, Tool: "t"}}},
+	}}
+	r := Validate("comp", c, av(nil, []string{"t"}, nil))
+	if !hasErr(r, "at least two branches") {
+		t.Errorf("want >=2 branches error, got %v", r.Errors)
+	}
+	if !hasErr(r, "reduce") {
+		t.Errorf("want reduce error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_ReduceNeedsStrategyAndInto(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "par", Kind: KindParallel,
+			Branches: []*Step{{ID: "x", Kind: KindTool, Tool: "t"}, {ID: "y", Kind: KindTool, Tool: "t"}},
+			Reduce:   &Reducer{Strategy: "bogus"}},
+	}}
+	r := Validate("comp", c, av(nil, []string{"t"}, nil))
+	if !hasErr(r, "reduce.strategy") {
+		t.Errorf("want strategy error, got %v", r.Errors)
+	}
+	if !hasErr(r, "reduce.into") {
+		t.Errorf("want into error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_BranchNeedsThenAndPredicate(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "b", Kind: KindBranch, Predicate: &Predicate{Path: "${input.x}", Op: "bogus", Value: 1}},
+		{ID: "n", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "branch step") || !hasErr(r, "then") {
+		t.Errorf("want then error, got %v", r.Errors)
+	}
+	if !hasErr(r, "op") {
+		t.Errorf("want invalid op error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_KindLegalFields(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindPrompt, PromptTask: "p", Tool: "t"}, // tool field illegal on prompt
+	}}
+	r := Validate("comp", c, av([]string{"p"}, []string{"t"}, nil))
+	if !hasErr(r, "field \"tool\" not allowed") {
+		t.Fatalf("want kind-legal error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_PredicateExactlyOneVariant(t *testing.T) {
+	mixed := &Predicate{Path: "${input.x}", Op: "equals", Value: 1, AllOf: []*Predicate{{Path: "${input.y}", Op: "equals", Value: 2}}}
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "b", Kind: KindBranch, Predicate: mixed, Then: "n"},
+		{ID: "n", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "exactly one") {
+		t.Fatalf("want single-variant error, got %v", r.Errors)
+	}
+}

--- a/runtime/composition/validate_test.go
+++ b/runtime/composition/validate_test.go
@@ -1,0 +1,164 @@
+package composition
+
+import (
+	"strings"
+	"testing"
+)
+
+// av builds an Available with the given prompt/tool/eval keys.
+func av(prompts, tools, evals []string) Available {
+	return Available{Prompts: prompts, Tools: tools, Evals: evals}
+}
+
+func hasErr(r *ValidationResult, substr string) bool {
+	for _, e := range r.Errors {
+		if strings.Contains(e, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidate_DuplicateStepID(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindPrompt, PromptTask: "p"},
+		{ID: "a", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "duplicate step id") {
+		t.Fatalf("want duplicate step id error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_BadStepIDPattern(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "1bad", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "must match") {
+		t.Fatalf("want pattern error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_NestedParallelIDsCounted(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "dup", Kind: KindPrompt, PromptTask: "p"},
+		{ID: "par", Kind: KindParallel, Reduce: &Reducer{Strategy: ReduceAppend, Into: "x"}, Branches: []*Step{
+			{ID: "dup", Kind: KindTool, Tool: "t"},
+			{ID: "ok", Kind: KindTool, Tool: "t"},
+		}},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, []string{"t"}, nil))
+	if !hasErr(r, "duplicate step id") {
+		t.Fatalf("want duplicate across nested branches, got %v", r.Errors)
+	}
+}
+
+func TestValidateAll_ReservedNameCollision(t *testing.T) {
+	comps := map[string]*Composition{
+		"workflow__transition": {Version: 1, Steps: []*Step{{ID: "a", Kind: KindPrompt, PromptTask: "p"}}},
+	}
+	r := ValidateAll(comps, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "reserved") {
+		t.Fatalf("want reserved-name error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_UnknownPromptTask(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindPrompt, PromptTask: "missing"},
+	}}
+	r := Validate("comp", c, av([]string{"known"}, nil, nil))
+	if !hasErr(r, `prompt_task "missing"`) {
+		t.Fatalf("want unknown prompt error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_UnknownAgentToolAndEval(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindAgent, PromptTask: "p", Tools: []string{"nope"},
+			Termination: &Termination{MaxSteps: 1},
+			Modifiers:   &StepModifiers{Eval: []string{"noeval"}}},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, []string{"real"}, []string{"realeval"}))
+	if !hasErr(r, `tool "nope"`) {
+		t.Errorf("want unknown agent tool, got %v", r.Errors)
+	}
+	if !hasErr(r, `eval "noeval"`) {
+		t.Errorf("want unknown eval, got %v", r.Errors)
+	}
+}
+
+func TestValidate_UnknownRefRoot(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindPrompt, PromptTask: "p", Input: "${ghost.output.x}"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, `references unknown "ghost"`) {
+		t.Fatalf("want unknown ref root, got %v", r.Errors)
+	}
+}
+
+func TestValidate_InputAndPriorStepRefsOK(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "first", Kind: KindPrompt, PromptTask: "p", Input: "${input.text}"},
+		{ID: "second", Kind: KindPrompt, PromptTask: "p", Input: "${first.output.y}"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if r.HasErrors() {
+		t.Fatalf("unexpected errors: %v", r.Errors)
+	}
+}
+
+func TestValidate_NilComposition(t *testing.T) {
+	r := Validate("comp", nil, av(nil, nil, nil))
+	if r.HasErrors() {
+		t.Fatalf("nil composition should produce no errors, got %v", r.Errors)
+	}
+}
+
+func TestValidate_UnknownToolKindRef(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindTool, Tool: "missing"},
+	}}
+	r := Validate("comp", c, av(nil, []string{"real"}, nil))
+	if !hasErr(r, `tool "missing"`) {
+		t.Fatalf("want unknown tool error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_BranchPredicateRefRoot(t *testing.T) {
+	// Branch step with predicate path referencing unknown root.
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "b", Kind: KindBranch,
+			Predicate: &Predicate{Path: "${ghost.output.x}", Op: "equals", Value: 1},
+			Then:      "n"},
+		{ID: "n", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, `references unknown "ghost"`) {
+		t.Fatalf("want unknown predicate ref root, got %v", r.Errors)
+	}
+}
+
+func TestValidate_PredicateAllOfAnyOfPaths(t *testing.T) {
+	// Composite predicate — exercise all_of / any_of / not paths in predicatePaths.
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "b", Kind: KindBranch,
+			Predicate: &Predicate{
+				AllOf: []*Predicate{
+					{Path: "${input.x}", Op: "equals", Value: 1},
+					{AnyOf: []*Predicate{
+						{Path: "${input.y}", Op: "equals", Value: 2},
+					}},
+					{Not: &Predicate{Path: "${input.z}", Op: "equals", Value: 3}},
+				},
+			},
+			Then: "n"},
+		{ID: "n", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if r.HasErrors() {
+		t.Fatalf("unexpected errors: %v", r.Errors)
+	}
+}

--- a/runtime/composition/validate_test.go
+++ b/runtime/composition/validate_test.go
@@ -236,3 +236,63 @@ func TestValidate_PredicateExactlyOneVariant(t *testing.T) {
 		t.Fatalf("want single-variant error, got %v", r.Errors)
 	}
 }
+
+func TestValidate_BranchTargetResolves(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "b", Kind: KindBranch, Predicate: &Predicate{Path: "${input.x}", Op: "equals", Value: 1}, Then: "ghost"},
+		{ID: "n", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, `then "ghost"`) {
+		t.Fatalf("want unresolved then, got %v", r.Errors)
+	}
+}
+
+func TestValidate_DependsOnResolves(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindPrompt, PromptTask: "p"},
+		{ID: "b", Kind: KindPrompt, PromptTask: "p", DependsOn: []string{"ghost"}},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, `depends_on "ghost"`) {
+		t.Fatalf("want unresolved depends_on, got %v", r.Errors)
+	}
+}
+
+func TestValidate_Acyclic(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "a", Kind: KindPrompt, PromptTask: "p", DependsOn: []string{"b"}},
+		{ID: "b", Kind: KindPrompt, PromptTask: "p", DependsOn: []string{"a"}},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, "cycle") {
+		t.Fatalf("want cycle error, got %v", r.Errors)
+	}
+}
+
+func TestValidate_OutputResolves(t *testing.T) {
+	c := &Composition{Version: 1, Output: "ghost", Steps: []*Step{
+		{ID: "a", Kind: KindPrompt, PromptTask: "p"},
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	if !hasErr(r, `output "ghost"`) {
+		t.Fatalf("want unresolved output, got %v", r.Errors)
+	}
+}
+
+func TestValidate_JoinWarning(t *testing.T) {
+	c := &Composition{Version: 1, Steps: []*Step{
+		{ID: "b", Kind: KindBranch, Predicate: &Predicate{Path: "${input.x}", Op: "equals", Value: 1}, Then: "next"},
+		{ID: "next", Kind: KindPrompt, PromptTask: "p"}, // follows a branch without depends_on
+	}}
+	r := Validate("comp", c, av([]string{"p"}, nil, nil))
+	found := false
+	for _, w := range r.Warnings {
+		if strings.Contains(w, "depends_on") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("want join-point warning, got warnings %v", r.Warnings)
+	}
+}


### PR DESCRIPTION
Phase 1 of **RFC 0010 — Workflow Composition** (epic #1337). Lands the leaf `runtime/composition` package: types, `ParseConfig`, and composition-internal validation. No execution yet — that's Phase 2.

## Summary
- **Types** (`types.go`): `Composition`, `Step`, `Termination`, `Reducer`, `StepModifiers`, `RetryModifier`, `Predicate` (incl. the `exists` variant), `StepKind` + kind/strategy constants, `compareOps`. `Step.Input` is `any` (string|object); `Composition.Engine` opaque block; no `provider` field.
- **`ParseConfig`** (`parse.go`): untyped `compositions:` map → `map[string]*Composition`, mirroring `workflow.ParseConfig`.
- **`${...}` ref extraction** (`refs.go`): `collectRefRoots`.
- **Validation** (`validate.go`): `ValidationResult{Errors,Warnings}` + `Validate`/`ValidateAll`, implementing composition-internal rules 1–11 (ids/pattern incl. nested `parallel.branches`, reference resolution, `${...}` roots, agent termination, parallel branches+reduce, branch then+constrained predicate, kind-legal fields, then/else/depends_on resolution, acyclic — incl. nested-branch cycles, output, join-hint warning, `version == 1`, compare-predicate `path`).
- Leaf package: imports neither `runtime/pipeline` nor `runtime/workflow`, so `workflow.State` can reference these types in Phase 3 without a cycle. Style mirrors `runtime/workflow`.

Built test-first (TDD) and passed a two-stage review (spec compliance + code quality); review findings fixed (nested-branch cycle detection, compare-predicate path rule, version rule, `stringSet` cleanup, `compareOps` unexport).

Rules 12–14 (workflow `orchestration: composition`, reachability) are intentionally deferred to Phase 3, where `workflow.State` is amended.

## Test plan
- [x] `go test ./runtime/composition/... -race -count=1` — 38 pass, 96.7% coverage
- [x] `golangci-lint run ./composition/...` + `go vet` — clean
- [x] Leaf constraint verified (`go list -deps` shows no pipeline/workflow import)

Refs #1337
Closes #1332
