### PR TITLE
feat(composition): Plan 2a — orchestrator core engine (RFC 0010)

### DIFF
--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 )
@@ -205,7 +206,40 @@ func (e *Engine) runBranch(step *composition.Step, scope Scope, status map[strin
 	return nil
 }
 
-// runParallel is a stub completed in Task 7.
-func (e *Engine) runParallel(_ context.Context, _ *composition.Step, _ Scope) (any, error) {
-	return nil, fmt.Errorf("parallel not yet implemented")
+// runParallel runs each branch concurrently, collects outputs in branch order,
+// and reduces them. Branches must be leaf steps (prompt|agent|tool); nested
+// branch/parallel inside a parallel is out of scope for v1.
+func (e *Engine) runParallel(ctx context.Context, step *composition.Step, scope Scope) (any, error) {
+	outs := make([]NamedOutput, len(step.Branches))
+	errs := make([]error, len(step.Branches))
+
+	var wg sync.WaitGroup
+	for i, branch := range step.Branches {
+		wg.Add(1)
+		go func(i int, branch *composition.Step) {
+			defer wg.Done()
+			if branch.Kind == composition.KindBranch || branch.Kind == composition.KindParallel {
+				errs[i] = fmt.Errorf("branch %q: nested %s not supported in a parallel step", branch.ID, branch.Kind)
+				return
+			}
+			out, err := e.runLeaf(ctx, branch, scope)
+			if err != nil {
+				errs[i] = fmt.Errorf("branch %q: %w", branch.ID, err)
+				return
+			}
+			outs[i] = NamedOutput{ID: branch.ID, Output: out}
+		}(i, branch)
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+	if step.Reduce == nil {
+		return nil, fmt.Errorf("parallel step %q has no reducer", step.ID)
+	}
+	merged := reduce(step.Reduce, outs)
+	return map[string]any{step.Reduce.Into: merged}, nil
 }

--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -185,18 +185,20 @@ func bindOutput(comp *composition.Composition, scope Scope, lastOutputStep strin
 }
 
 // runBranch evaluates the branch predicate and marks the not-taken target
-// skipped. Predicate true -> the else target (if any) is skipped; predicate
-// false -> the then target is skipped (empty else just falls through).
+// skipped. Predicate true -> active target is Then, not-taken is Else; predicate
+// false -> active target is Else, not-taken is Then. The not-taken target is
+// skipped only when it differs from the taken target (Then == Else converges, so
+// the shared step must still run). The branch step itself produces no output.
 func (e *Engine) runBranch(step *composition.Step, scope Scope, status map[string]stepStatus) error {
 	taken, err := evalPredicate(step.Predicate, scope)
 	if err != nil {
 		return fmt.Errorf("step %q: %w", step.ID, err)
 	}
-	notTaken := step.Then
+	takenTarget, notTaken := step.Else, step.Then
 	if taken {
-		notTaken = step.Else
+		takenTarget, notTaken = step.Then, step.Else
 	}
-	if notTaken != "" {
+	if notTaken != "" && notTaken != takenTarget {
 		status[notTaken] = statusSkipped
 	}
 	status[step.ID] = statusCompleted

--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -168,6 +168,9 @@ func (e *Engine) execWithRetry(
 	}
 	var lastErr error
 	for i := 0; i < attempts; i++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		out, err := e.exec(ctx, step, input)
 		if err == nil {
 			return out, nil

--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -184,8 +184,22 @@ func bindOutput(comp *composition.Composition, scope Scope, lastOutputStep strin
 	return json.Marshal(entry[scopeOutputKey])
 }
 
-// runBranch is a stub completed in Task 6.
-func (e *Engine) runBranch(_ *composition.Step, _ Scope, _ map[string]stepStatus) error {
+// runBranch evaluates the branch predicate and marks the not-taken target
+// skipped. Predicate true -> the else target (if any) is skipped; predicate
+// false -> the then target is skipped (empty else just falls through).
+func (e *Engine) runBranch(step *composition.Step, scope Scope, status map[string]stepStatus) error {
+	taken, err := evalPredicate(step.Predicate, scope)
+	if err != nil {
+		return fmt.Errorf("step %q: %w", step.ID, err)
+	}
+	notTaken := step.Then
+	if taken {
+		notTaken = step.Else
+	}
+	if notTaken != "" {
+		status[notTaken] = statusSkipped
+	}
+	status[step.ID] = statusCompleted
 	return nil
 }
 

--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -11,7 +11,9 @@ import (
 // StepExecutor runs one leaf step (prompt|agent|tool) and returns its raw output.
 // input is the step's resolved Input (prompt/agent) or resolved Args (tool),
 // marshaled to JSON. Injected so the orchestrator core is testable without a
-// pipeline; the production implementation is supplied in a later phase.
+// pipeline; Plan 2b supplies the production implementation.
+// For an arg-less tool (nil Args) or nil Input, input is the JSON literal `null`;
+// production executors must treat `null` as "no input/args".
 type StepExecutor func(ctx context.Context, step *composition.Step, input json.RawMessage) (json.RawMessage, error)
 
 // Engine is the deterministic composition scheduler.
@@ -36,6 +38,8 @@ const scopeOutputKey = "output"
 
 // Execute walks the composition's step DAG to completion and returns the bound
 // output (comp.Output, or the last output-producing step).
+// The scope map is not safe for concurrent mutation; parallel branches (Task 7)
+// read it during fan-out and their merged result is written back only at the join.
 func (e *Engine) Execute(
 	ctx context.Context, comp *composition.Composition, input json.RawMessage,
 ) (json.RawMessage, error) {
@@ -105,8 +109,15 @@ func (e *Engine) runStep(
 	}
 }
 
-// shouldSkip reports whether a step is unreachable because every dependency was
-// skipped. A step with no depends_on is never skipped by this rule.
+// shouldSkip reports whether a step is unreachable: it has depends_on and every
+// dependency was skipped. A skipped dependency otherwise counts as satisfied.
+//
+// Soundness note: this reads status[dep] during an array-order walk and treats an
+// unset (pending) status as "not skipped". That is only correct because validation
+// guarantees every depends_on target precedes the step in array order (forward
+// deps are rejected by the validator's acyclic check over the sequential backbone).
+// If that invariant ever changes, a forward dep could read as pending and a skip
+// would fail to propagate.
 func shouldSkip(step *composition.Step, status map[string]stepStatus) bool {
 	if len(step.DependsOn) == 0 {
 		return false
@@ -142,8 +153,9 @@ func (e *Engine) runLeaf(ctx context.Context, step *composition.Step, scope Scop
 	return decodeOutput(out)
 }
 
-// decodeOutput turns a step's raw JSON output into a scope value.
-// Empty output decodes to nil.
+// decodeOutput turns a step's raw JSON output into a scope value. Empty output and
+// a literal JSON null both decode to nil; downstream ${step.output.x} resolution
+// against a nil value fails closed (resolves to not-found), which is intended.
 func decodeOutput(raw json.RawMessage) (any, error) {
 	if len(raw) == 0 {
 		return nil, nil
@@ -166,7 +178,8 @@ func bindOutput(comp *composition.Composition, scope Scope, lastOutputStep strin
 	}
 	entry, ok := scope[target].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("output step %q did not complete", target)
+		return nil, fmt.Errorf("output step %q produced no bindable output "+
+			"(it did not complete, or is a branch/control step)", target)
 	}
 	return json.Marshal(entry[scopeOutputKey])
 }

--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -1,0 +1,182 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+)
+
+// StepExecutor runs one leaf step (prompt|agent|tool) and returns its raw output.
+// input is the step's resolved Input (prompt/agent) or resolved Args (tool),
+// marshaled to JSON. Injected so the orchestrator core is testable without a
+// pipeline; the production implementation is supplied in a later phase.
+type StepExecutor func(ctx context.Context, step *composition.Step, input json.RawMessage) (json.RawMessage, error)
+
+// Engine is the deterministic composition scheduler.
+type Engine struct {
+	exec StepExecutor
+}
+
+// New builds an Engine around a StepExecutor.
+func New(exec StepExecutor) *Engine { return &Engine{exec: exec} }
+
+// stepStatus tracks scheduling state across the array walk.
+type stepStatus int
+
+const (
+	statusPending   stepStatus = iota // zero value; set on map miss
+	statusCompleted stepStatus = iota
+	statusSkipped   stepStatus = iota
+)
+
+// scopeOutputKey is the map key used to store a step's decoded output in scope.
+const scopeOutputKey = "output"
+
+// Execute walks the composition's step DAG to completion and returns the bound
+// output (comp.Output, or the last output-producing step).
+func (e *Engine) Execute(
+	ctx context.Context, comp *composition.Composition, input json.RawMessage,
+) (json.RawMessage, error) {
+	if comp == nil {
+		return nil, fmt.Errorf("nil composition")
+	}
+
+	var decodedInput any
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &decodedInput); err != nil {
+			return nil, fmt.Errorf("decoding composition input: %w", err)
+		}
+	}
+	scope := Scope{"input": decodedInput}
+	status := make(map[string]stepStatus, len(comp.Steps))
+	var lastOutputStep string
+
+	for _, step := range comp.Steps {
+		if status[step.ID] == statusSkipped {
+			continue
+		}
+		if shouldSkip(step, status) {
+			status[step.ID] = statusSkipped
+			continue
+		}
+		last, err := e.runStep(ctx, step, scope, status)
+		if err != nil {
+			return nil, err
+		}
+		if last != "" {
+			lastOutputStep = last
+		}
+	}
+
+	return bindOutput(comp, scope, lastOutputStep)
+}
+
+// runStep dispatches a single step to its handler, updates scope and status, and
+// returns the step ID if it produced an output (empty string if it did not).
+func (e *Engine) runStep(
+	ctx context.Context, step *composition.Step, scope Scope, status map[string]stepStatus,
+) (string, error) {
+	switch step.Kind {
+	case composition.KindBranch:
+		if err := e.runBranch(step, scope, status); err != nil {
+			return "", err
+		}
+		return "", nil
+	case composition.KindParallel:
+		out, err := e.runParallel(ctx, step, scope)
+		if err != nil {
+			return "", fmt.Errorf("step %q: %w", step.ID, err)
+		}
+		scope[step.ID] = map[string]any{scopeOutputKey: out}
+		status[step.ID] = statusCompleted
+		return step.ID, nil
+	case composition.KindPrompt, composition.KindAgent, composition.KindTool:
+		out, err := e.runLeaf(ctx, step, scope)
+		if err != nil {
+			return "", fmt.Errorf("step %q: %w", step.ID, err)
+		}
+		scope[step.ID] = map[string]any{scopeOutputKey: out}
+		status[step.ID] = statusCompleted
+		return step.ID, nil
+	default:
+		return "", fmt.Errorf("step %q: unknown kind %q", step.ID, step.Kind)
+	}
+}
+
+// shouldSkip reports whether a step is unreachable because every dependency was
+// skipped. A step with no depends_on is never skipped by this rule.
+func shouldSkip(step *composition.Step, status map[string]stepStatus) bool {
+	if len(step.DependsOn) == 0 {
+		return false
+	}
+	for _, dep := range step.DependsOn {
+		if status[dep] != statusSkipped {
+			return false
+		}
+	}
+	return true
+}
+
+// runLeaf resolves a leaf step's input/args, executes it, and decodes the output.
+func (e *Engine) runLeaf(ctx context.Context, step *composition.Step, scope Scope) (any, error) {
+	var raw any
+	if step.Kind == composition.KindTool {
+		raw = step.Args
+	} else {
+		raw = step.Input
+	}
+	resolved, err := resolveInput(raw, scope)
+	if err != nil {
+		return nil, err
+	}
+	resolvedJSON, err := json.Marshal(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling resolved input: %w", err)
+	}
+	out, err := e.exec(ctx, step, resolvedJSON)
+	if err != nil {
+		return nil, err
+	}
+	return decodeOutput(out)
+}
+
+// decodeOutput turns a step's raw JSON output into a scope value.
+// Empty output decodes to nil.
+func decodeOutput(raw json.RawMessage) (any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, fmt.Errorf("decoding step output: %w", err)
+	}
+	return v, nil
+}
+
+// bindOutput resolves the composition's output value to JSON.
+func bindOutput(comp *composition.Composition, scope Scope, lastOutputStep string) (json.RawMessage, error) {
+	target := comp.Output
+	if target == "" {
+		target = lastOutputStep
+	}
+	if target == "" {
+		return nil, fmt.Errorf("composition produced no output")
+	}
+	entry, ok := scope[target].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("output step %q did not complete", target)
+	}
+	return json.Marshal(entry[scopeOutputKey])
+}
+
+// runBranch is a stub completed in Task 6.
+func (e *Engine) runBranch(_ *composition.Step, _ Scope, _ map[string]stepStatus) error {
+	return nil
+}
+
+// runParallel is a stub completed in Task 7.
+func (e *Engine) runParallel(_ context.Context, _ *composition.Step, _ Scope) (any, error) {
+	return nil, fmt.Errorf("parallel not yet implemented")
+}

--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -148,11 +148,33 @@ func (e *Engine) runLeaf(ctx context.Context, step *composition.Step, scope Scop
 	if err != nil {
 		return nil, fmt.Errorf("marshaling resolved input: %w", err)
 	}
-	out, err := e.exec(ctx, step, resolvedJSON)
+	out, err := e.execWithRetry(ctx, step, resolvedJSON)
 	if err != nil {
 		return nil, err
 	}
 	return decodeOutput(out)
+}
+
+// execWithRetry invokes the executor, retrying per the step's retry modifier.
+// max_attempts is the total attempt count (a missing/zero/one modifier means a
+// single attempt). The last error propagates when the budget is exhausted. Used
+// by runLeaf, so parallel branches inherit retry too.
+func (e *Engine) execWithRetry(
+	ctx context.Context, step *composition.Step, input json.RawMessage,
+) (json.RawMessage, error) {
+	attempts := 1
+	if step.Modifiers != nil && step.Modifiers.Retry != nil && step.Modifiers.Retry.MaxAttempts > 1 {
+		attempts = step.Modifiers.Retry.MaxAttempts
+	}
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		out, err := e.exec(ctx, step, input)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
 }
 
 // decodeOutput turns a step's raw JSON output into a scope value. Empty output and

--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -208,8 +209,16 @@ func (e *Engine) runBranch(step *composition.Step, scope Scope, status map[strin
 
 // runParallel runs each branch concurrently, collects outputs in branch order,
 // and reduces them. Branches must be leaf steps (prompt|agent|tool); nested
-// branch/parallel inside a parallel is out of scope for v1.
+// branch/parallel inside a parallel is out of scope for v1 and is rejected.
+//
+// Semantics: a branch error does NOT cancel its siblings — all branches run to
+// completion and every error is surfaced together via errors.Join. The goroutine
+// count equals the (author-bounded) branch count; cancellation responsiveness
+// depends on the injected executor honoring ctx (the engine does not poll it).
 func (e *Engine) runParallel(ctx context.Context, step *composition.Step, scope Scope) (any, error) {
+	if step.Reduce == nil {
+		return nil, fmt.Errorf("parallel step %q: missing reducer", step.ID)
+	}
 	outs := make([]NamedOutput, len(step.Branches))
 	errs := make([]error, len(step.Branches))
 
@@ -232,13 +241,8 @@ func (e *Engine) runParallel(ctx context.Context, step *composition.Step, scope 
 	}
 	wg.Wait()
 
-	for _, err := range errs {
-		if err != nil {
-			return nil, err
-		}
-	}
-	if step.Reduce == nil {
-		return nil, fmt.Errorf("parallel step %q has no reducer", step.ID)
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
 	}
 	merged := reduce(step.Reduce, outs)
 	return map[string]any{step.Reduce.Into: merged}, nil

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -556,3 +556,60 @@ func TestExecute_ParallelBarrier(t *testing.T) {
 		t.Errorf("expected both branches to run, calls = %v", fe.calls)
 	}
 }
+
+func TestExecute_RetrySucceedsAfterFailures(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1, Output: "flaky",
+		Steps: []*composition.Step{
+			{ID: "flaky", Kind: composition.KindPrompt, PromptTask: "p", Input: "${input.x}",
+				Modifiers: &composition.StepModifiers{Retry: &composition.RetryModifier{MaxAttempts: 3}}},
+		},
+	}
+	fe := newFakeExec(map[string]any{"flaky": "ok"})
+	fe.errOn["flaky"] = 2 // first two attempts fail, third succeeds
+	out, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"x": 1}))
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if string(out) != `"ok"` {
+		t.Errorf("output = %s", out)
+	}
+	if fe.attempt["flaky"] != 3 {
+		t.Errorf("attempts = %d, want 3", fe.attempt["flaky"])
+	}
+}
+
+func TestExecute_RetryExhaustedPropagatesError(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1, Output: "flaky",
+		Steps: []*composition.Step{
+			{ID: "flaky", Kind: composition.KindPrompt, PromptTask: "p", Input: "${input.x}",
+				Modifiers: &composition.StepModifiers{Retry: &composition.RetryModifier{MaxAttempts: 2}}},
+		},
+	}
+	fe := newFakeExec(map[string]any{"flaky": "ok"})
+	fe.errOn["flaky"] = 5 // always fails within the 2-attempt budget
+	if _, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"x": 1})); err == nil {
+		t.Fatal("expected error after retries exhausted")
+	}
+	if fe.attempt["flaky"] != 2 {
+		t.Errorf("attempts = %d, want 2", fe.attempt["flaky"])
+	}
+}
+
+func TestExecute_NoRetryDefaultsToOneAttempt(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1, Output: "x",
+		Steps: []*composition.Step{
+			{ID: "x", Kind: composition.KindPrompt, PromptTask: "p", Input: "${input.v}"},
+		},
+	}
+	fe := newFakeExec(map[string]any{"x": "ok"})
+	fe.errOn["x"] = 1 // single failure, no retry modifier -> propagates
+	if _, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"v": 1})); err == nil {
+		t.Fatal("expected error with no retry")
+	}
+	if fe.attempt["x"] != 1 {
+		t.Errorf("attempts = %d, want 1", fe.attempt["x"])
+	}
+}

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -189,53 +189,6 @@ func TestExecute_UnknownKind(t *testing.T) {
 	}
 }
 
-func TestExecute_SkippedDeps(t *testing.T) {
-	// "b" depends on "a"; "a" is skipped (depends on a missing dep that is also
-	// skipped — simulated here by starting with an always-skipped step).
-	comp := &composition.Composition{
-		Version: 1,
-		Output:  "c",
-		Steps: []*composition.Step{
-			// "skip" has no deps so it runs; we skip it manually by making it
-			// produce a branch (which doesn't set status = completed, so we
-			// drive the skip via DependsOn chain instead).
-			// Simpler: use a direct dep chain where "a" dep on "skip",
-			// "b" dep on "a", and "skip" is KindBranch (no output, no completed).
-			{ID: "skip", Kind: composition.KindBranch},
-			{ID: "a", Kind: composition.KindPrompt, DependsOn: []string{"skip"}},
-			{ID: "c", Kind: composition.KindTool, Tool: "t"},
-		},
-	}
-	// "skip" is KindBranch stub — sets no status on itself, so status["skip"] == statusPending.
-	// "a" DependsOn "skip" but skip is pending (not skipped), so "a" runs.
-	// The interesting skip path: a step whose all deps are statusSkipped.
-	// Drive that by having "gone" never in the map (treated as pending), so "a" runs.
-	// Actually to test the shouldSkip path, we need all deps to be statusSkipped.
-	// Use a different approach: status for "gone" dep will be zero (pending), not skipped.
-	// To truly hit shouldSkip we need a step that was explicitly marked skipped.
-	// Restructure: chain skip→a→b where skip is itself skipped.
-	// The only way a step gets statusSkipped is if shouldSkip returns true for it.
-	// Bootstrap: step with DependsOn of a non-existent id won't be skipped because
-	// the zero value is statusPending, not statusSkipped.
-	// The real skip chain requires a prior step to have been skipped.
-	// Use: step "never" depends on step "gone" (unknown = pending → not skipped);
-	// so that won't work. We need an explicit skip.
-	//
-	// Conclusion: shouldSkip only fires when a dep was explicitly set to statusSkipped.
-	// That happens transitively. Build: root→mid→leaf where root is KindParallel
-	// (errors out) — but we need Execute to still run. Instead, let's test it via
-	// a KindBranch that has a dep on another KindBranch:
-	// Actually the simplest reliable path: manually confirm shouldSkip logic in a unit test.
-	fe := newFakeExec(map[string]any{"c": "cv"})
-	out, err := New(fe.exec).Execute(context.Background(), comp, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(out) != `"cv"` {
-		t.Errorf("skipped-deps output = %s", out)
-	}
-}
-
 func TestExecute_StepError(t *testing.T) {
 	comp := &composition.Composition{
 		Version: 1,

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 )
 
 // fakeExec returns canned output per step id and records the resolved input it saw.
+// mu guards calls, seen, and attempt so fakeExec is safe to use from concurrent goroutines
+// (e.g. parallel branch execution in TestExecute_ParallelBarrier).
 type fakeExec struct {
+	mu      sync.Mutex
 	outputs map[string]any
 	seen    map[string]json.RawMessage
 	calls   []string
@@ -28,13 +32,17 @@ func newFakeExec(outputs map[string]any) *fakeExec {
 }
 
 func (f *fakeExec) exec(_ context.Context, step *composition.Step, input json.RawMessage) (json.RawMessage, error) {
+	f.mu.Lock()
 	f.calls = append(f.calls, step.ID)
 	f.seen[step.ID] = input
 	f.attempt[step.ID]++
-	if fails := f.errOn[step.ID]; f.attempt[step.ID] <= fails {
+	fails := f.errOn[step.ID]
+	attempt := f.attempt[step.ID]
+	out := f.outputs[step.ID]
+	f.mu.Unlock()
+	if attempt <= fails {
 		return nil, context.DeadlineExceeded
 	}
-	out := f.outputs[step.ID]
 	raw, _ := json.Marshal(out)
 	return raw, nil
 }
@@ -419,5 +427,51 @@ func TestExecute_JoinSkippedWhenAllDepsSkipped(t *testing.T) {
 	}
 	if !reflectDeepEqual(fe.calls, []string{"tail"}) {
 		t.Errorf("calls = %v, want tail only (only+dependent skipped)", fe.calls)
+	}
+}
+
+func TestExecute_ParallelBarrier(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1, Output: "consume",
+		Steps: []*composition.Step{
+			{ID: "meta", Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "structure", Kind: composition.KindTool, Tool: "t.s", Args: map[string]any{"c": "${input.text}"}},
+					{ID: "citations", Kind: composition.KindTool, Tool: "t.c", Args: map[string]any{"c": "${input.text}"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "metadata"}},
+			{ID: "consume", Kind: composition.KindPrompt, PromptTask: "p",
+				Input: "${meta.output.metadata}"},
+		},
+	}
+	fe := newFakeExec(map[string]any{
+		"structure": map[string]any{"sections": float64(3)},
+		"citations": map[string]any{"count": float64(12)},
+		"consume":   "done",
+	})
+	out, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"text": "body"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `"done"` {
+		t.Errorf("output = %s", out)
+	}
+	var consumeInput map[string]any
+	if err := json.Unmarshal(fe.seen["consume"], &consumeInput); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"structure": map[string]any{"sections": float64(3)},
+		"citations": map[string]any{"count": float64(12)},
+	}
+	if !reflectDeepEqual(consumeInput, want) {
+		t.Errorf("consume input = %#v, want %#v", consumeInput, want)
+	}
+	ran := map[string]bool{}
+	for _, id := range fe.calls {
+		ran[id] = true
+	}
+	if !ran["structure"] || !ran["citations"] {
+		t.Errorf("expected both branches to run, calls = %v", fe.calls)
 	}
 }

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -644,3 +644,77 @@ func TestExecute_ParallelBranchRetry(t *testing.T) {
 		t.Errorf("branch a attempts = %d, want 2", fe.attempt["a"])
 	}
 }
+
+func TestExecute_Integration_BranchParallelRetryJoin(t *testing.T) {
+	// classify -> route(branch true) -> enrich(parallel, one branch retries) ; skip_path skipped
+	// -> synth(agent, depends_on [enrich, skip_path]) consumes ${enrich.output.meta}, with retry.
+	comp := &composition.Composition{
+		Version: 1,
+		Output:  "synth",
+		Steps: []*composition.Step{
+			{ID: "classify", Kind: composition.KindPrompt, PromptTask: "c", Input: "${input.text}"},
+			{ID: "route", Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${classify.output.type}", Op: "equals", Value: "paper"},
+				Then:      "enrich", Else: "skip_path"},
+			{ID: "enrich", Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "structure", Kind: composition.KindTool, Tool: "t.s", Args: map[string]any{"c": "${input.text}"},
+						Modifiers: &composition.StepModifiers{Retry: &composition.RetryModifier{MaxAttempts: 3}}},
+					{ID: "citations", Kind: composition.KindTool, Tool: "t.c", Args: map[string]any{"c": "${input.text}"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "meta"}},
+			{ID: "skip_path", Kind: composition.KindPrompt, PromptTask: "s", Input: "${input.text}"},
+			{ID: "synth", Kind: composition.KindAgent, PromptTask: "a",
+				DependsOn: []string{"enrich", "skip_path"},
+				Input:     "${enrich.output.meta}",
+				Modifiers: &composition.StepModifiers{Retry: &composition.RetryModifier{MaxAttempts: 2}}},
+		},
+	}
+	fe := newFakeExec(map[string]any{
+		"classify":  map[string]any{"type": "paper"},
+		"structure": map[string]any{"sections": float64(3)},
+		"citations": map[string]any{"count": float64(12)},
+		"synth":     map[string]any{"summary": "done"},
+	})
+	fe.errOn["structure"] = 1 // parallel branch retries once
+	fe.errOn["synth"] = 1     // agent step retries once
+
+	out, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"text": "body"}))
+	if err != nil {
+		t.Fatalf("integration execute failed: %v", err)
+	}
+
+	// skip_path was the not-taken branch target -> never executed.
+	for _, id := range fe.calls {
+		if id == "skip_path" {
+			t.Errorf("skip_path should have been skipped, calls = %v", fe.calls)
+		}
+	}
+	// the retrying parallel branch ran twice; the agent step ran twice.
+	if fe.attempt["structure"] != 2 {
+		t.Errorf("structure attempts = %d, want 2", fe.attempt["structure"])
+	}
+	if fe.attempt["synth"] != 2 {
+		t.Errorf("synth attempts = %d, want 2", fe.attempt["synth"])
+	}
+	// synth consumed the barrier-merged parallel output keyed by branch id.
+	var synthInput map[string]any
+	if err := json.Unmarshal(fe.seen["synth"], &synthInput); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"structure": map[string]any{"sections": float64(3)},
+		"citations": map[string]any{"count": float64(12)},
+	}
+	if !reflectDeepEqual(synthInput, want) {
+		t.Errorf("synth input = %#v, want %#v", synthInput, want)
+	}
+	// final output is the agent step's output.
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !reflectDeepEqual(got, map[string]any{"summary": "done"}) {
+		t.Errorf("output = %#v", got)
+	}
+}

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -3,12 +3,16 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 )
+
+// errInjected is the canned failure fakeExec returns for simulated step errors.
+var errInjected = errors.New("injected step failure")
 
 // fakeExec returns canned output per step id and records the resolved input it saw.
 // mu guards calls, seen, and attempt so fakeExec is safe to use from concurrent goroutines
@@ -41,7 +45,7 @@ func (f *fakeExec) exec(_ context.Context, step *composition.Step, input json.Ra
 	out := f.outputs[step.ID]
 	f.mu.Unlock()
 	if attempt <= fails {
-		return nil, context.DeadlineExceeded
+		return nil, errInjected
 	}
 	raw, _ := json.Marshal(out)
 	return raw, nil
@@ -611,5 +615,32 @@ func TestExecute_NoRetryDefaultsToOneAttempt(t *testing.T) {
 	}
 	if fe.attempt["x"] != 1 {
 		t.Errorf("attempts = %d, want 1", fe.attempt["x"])
+	}
+}
+
+func TestExecute_ParallelBranchRetry(t *testing.T) {
+	// A parallel branch with a retry modifier retries through runParallel -> runLeaf.
+	comp := &composition.Composition{
+		Version: 1, Output: "meta",
+		Steps: []*composition.Step{
+			{ID: "meta", Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "a", Kind: composition.KindTool, Tool: "t.a", Args: map[string]any{"c": "${input.x}"},
+						Modifiers: &composition.StepModifiers{Retry: &composition.RetryModifier{MaxAttempts: 2}}},
+					{ID: "b", Kind: composition.KindTool, Tool: "t.b", Args: map[string]any{"c": "${input.x}"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "m"}},
+		},
+	}
+	fe := newFakeExec(map[string]any{
+		"a": map[string]any{"ok": true},
+		"b": map[string]any{"ok": true},
+	})
+	fe.errOn["a"] = 1 // first attempt of branch a fails, retry succeeds
+	if _, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"x": 1})); err != nil {
+		t.Fatalf("expected parallel branch retry to succeed, got %v", err)
+	}
+	if fe.attempt["a"] != 2 {
+		t.Errorf("branch a attempts = %d, want 2", fe.attempt["a"])
 	}
 }

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
@@ -251,6 +252,76 @@ func TestShouldSkip_NoDeps(t *testing.T) {
 	step := &composition.Step{ID: "c"}
 	if shouldSkip(step, nil) {
 		t.Error("expected shouldSkip=false for step with no deps")
+	}
+}
+
+func TestExecute_BranchPredicateError(t *testing.T) {
+	// An ordered comparison against a non-numeric value errors; runBranch must
+	// wrap it with the branch step id and propagate it out of Execute.
+	comp := &composition.Composition{
+		Version: 1, Output: "after",
+		Steps: []*composition.Step{
+			{ID: "route", Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${input.name}", Op: "less_than", Value: float64(3)},
+				Then:      "after"},
+			{ID: "after", Kind: composition.KindPrompt, PromptTask: "a", Input: "${input.name}"},
+		},
+	}
+	fe := newFakeExec(map[string]any{"after": "A"})
+	_, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"name": "bob"}))
+	if err == nil {
+		t.Fatal("expected predicate error to propagate")
+	}
+	if !strings.Contains(err.Error(), "route") {
+		t.Errorf("error should name the branch step, got %v", err)
+	}
+}
+
+func TestExecute_BranchTakenOutputConsumedDownstream(t *testing.T) {
+	// Proves the taken branch's output is available in scope for a downstream step.
+	comp := &composition.Composition{
+		Version: 1, Output: "join",
+		Steps: []*composition.Step{
+			{ID: "route", Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${input.go}", Op: "equals", Value: true},
+				Then:      "paper", Else: "general"},
+			{ID: "paper", Kind: composition.KindPrompt, PromptTask: "pp", Input: "${input.x}"},
+			{ID: "general", Kind: composition.KindPrompt, PromptTask: "gg", Input: "${input.x}"},
+			{ID: "join", Kind: composition.KindPrompt, PromptTask: "j",
+				DependsOn: []string{"paper", "general"}, Input: "${paper.output.label}"},
+		},
+	}
+	fe := newFakeExec(map[string]any{
+		"paper":   map[string]any{"label": "PAPER"},
+		"general": map[string]any{"label": "GENERAL"},
+		"join":    "J",
+	})
+	if _, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"go": true, "x": 1})); err != nil {
+		t.Fatal(err)
+	}
+	if string(fe.seen["join"]) != `"PAPER"` {
+		t.Errorf("join should consume taken branch output, got %s", fe.seen["join"])
+	}
+}
+
+func TestExecute_BranchThenEqualsElse(t *testing.T) {
+	// Then and Else name the same step -> it must run regardless of predicate value.
+	comp := &composition.Composition{
+		Version: 1, Output: "merge",
+		Steps: []*composition.Step{
+			{ID: "route", Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${input.go}", Op: "equals", Value: true},
+				Then:      "merge", Else: "merge"},
+			{ID: "merge", Kind: composition.KindPrompt, PromptTask: "m", Input: "${input.x}"},
+		},
+	}
+	fe := newFakeExec(map[string]any{"merge": "M"})
+	out, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"go": false, "x": 1}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `"M"` {
+		t.Errorf("Then==Else target must run; calls=%v out=%s", fe.calls, out)
 	}
 }
 

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -174,15 +174,16 @@ func TestExecute_BranchKind_NoOutput(t *testing.T) {
 	}
 }
 
-func TestExecute_ParallelKind_ErrorStub(t *testing.T) {
+func TestExecute_ParallelMissingReducer(t *testing.T) {
+	// A parallel step with no reducer (Reduce: nil) must return an error immediately.
 	comp := &composition.Composition{
 		Version: 1,
-		Steps:   []*composition.Step{{ID: "p", Kind: composition.KindParallel}},
+		Steps:   []*composition.Step{{ID: "p", Kind: composition.KindParallel, Reduce: nil}},
 	}
 	fe := newFakeExec(nil)
 	_, err := New(fe.exec).Execute(context.Background(), comp, nil)
 	if err == nil {
-		t.Fatal("expected error from parallel stub")
+		t.Fatal("expected error from parallel step with missing reducer")
 	}
 }
 
@@ -427,6 +428,86 @@ func TestExecute_JoinSkippedWhenAllDepsSkipped(t *testing.T) {
 	}
 	if !reflectDeepEqual(fe.calls, []string{"tail"}) {
 		t.Errorf("calls = %v, want tail only (only+dependent skipped)", fe.calls)
+	}
+}
+
+func TestExecute_ParallelErrorPath(t *testing.T) {
+	// Both branches fail; errors.Join must surface BOTH branch names.
+	comp := &composition.Composition{
+		Version: 1, Output: "meta",
+		Steps: []*composition.Step{
+			{ID: "meta", Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "a", Kind: composition.KindTool, Tool: "t.a", Args: map[string]any{"c": "${input.x}"}},
+					{ID: "b", Kind: composition.KindTool, Tool: "t.b", Args: map[string]any{"c": "${input.x}"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "m"}},
+		},
+	}
+	fe := newFakeExec(map[string]any{"a": "A", "b": "B"})
+	fe.errOn["a"] = 1 // always fails (no retry)
+	fe.errOn["b"] = 1
+	_, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"x": 1}))
+	if err == nil {
+		t.Fatal("expected error when branches fail")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `branch "a"`) || !strings.Contains(msg, `branch "b"`) {
+		t.Errorf("joined error should name both failing branches, got %q", msg)
+	}
+}
+
+func TestExecute_ParallelAppend(t *testing.T) {
+	// append reducer must preserve branch order regardless of goroutine scheduling.
+	comp := &composition.Composition{
+		Version: 1, Output: "meta",
+		Steps: []*composition.Step{
+			{ID: "meta", Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "first", Kind: composition.KindTool, Tool: "t.1", Args: map[string]any{"c": "${input.x}"}},
+					{ID: "second", Kind: composition.KindTool, Tool: "t.2", Args: map[string]any{"c": "${input.x}"}},
+					{ID: "third", Kind: composition.KindTool, Tool: "t.3", Args: map[string]any{"c": "${input.x}"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceAppend, Into: "list"}},
+		},
+	}
+	fe := newFakeExec(map[string]any{"first": "F", "second": "S", "third": "T"})
+	out, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"x": 1}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{"list": []any{"F", "S", "T"}}
+	if !reflectDeepEqual(got, want) {
+		t.Errorf("append parallel = %#v, want %#v", got, want)
+	}
+}
+
+func TestExecute_ParallelNestedBranchRejected(t *testing.T) {
+	// A branch of kind=branch nested inside a parallel must be rejected at runtime.
+	comp := &composition.Composition{
+		Version: 1, Output: "meta",
+		Steps: []*composition.Step{
+			{ID: "meta", Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "leaf", Kind: composition.KindTool, Tool: "t.l", Args: map[string]any{"c": "${input.x}"}},
+					{ID: "nested", Kind: composition.KindBranch,
+						Predicate: &composition.Predicate{Path: "${input.x}", Op: "equals", Value: float64(1)},
+						Then:      "leaf"},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "m"}},
+		},
+	}
+	fe := newFakeExec(map[string]any{"leaf": "L"})
+	_, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"x": 1}))
+	if err == nil {
+		t.Fatal("expected error for nested branch inside parallel")
+	}
+	if !strings.Contains(err.Error(), "nested") {
+		t.Errorf("error should mention nested, got %v", err)
 	}
 }
 

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -1,0 +1,309 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+)
+
+// fakeExec returns canned output per step id and records the resolved input it saw.
+type fakeExec struct {
+	outputs map[string]any
+	seen    map[string]json.RawMessage
+	calls   []string
+	errOn   map[string]int
+	attempt map[string]int
+}
+
+func newFakeExec(outputs map[string]any) *fakeExec {
+	return &fakeExec{
+		outputs: outputs,
+		seen:    map[string]json.RawMessage{},
+		errOn:   map[string]int{},
+		attempt: map[string]int{},
+	}
+}
+
+func (f *fakeExec) exec(_ context.Context, step *composition.Step, input json.RawMessage) (json.RawMessage, error) {
+	f.calls = append(f.calls, step.ID)
+	f.seen[step.ID] = input
+	f.attempt[step.ID]++
+	if fails := f.errOn[step.ID]; f.attempt[step.ID] <= fails {
+		return nil, context.DeadlineExceeded
+	}
+	out := f.outputs[step.ID]
+	raw, _ := json.Marshal(out)
+	return raw, nil
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestExecute_Sequential(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1,
+		Output:  "second",
+		Steps: []*composition.Step{
+			{ID: "first", Kind: composition.KindPrompt, PromptTask: "p1", Input: "${input.text}"},
+			{ID: "second", Kind: composition.KindPrompt, PromptTask: "p2", Input: "${first.output.label}"},
+		},
+	}
+	fe := newFakeExec(map[string]any{
+		"first":  map[string]any{"label": "greeting"},
+		"second": map[string]any{"reply": "hi"},
+	})
+	eng := New(fe.exec)
+
+	out, err := eng.Execute(context.Background(), comp, mustJSON(t, map[string]any{"text": "hello"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflectDeepEqual(fe.calls, []string{"first", "second"}) {
+		t.Errorf("calls = %v", fe.calls)
+	}
+	if string(fe.seen["second"]) != `"greeting"` {
+		t.Errorf("second input = %s", fe.seen["second"])
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !reflectDeepEqual(got, map[string]any{"reply": "hi"}) {
+		t.Errorf("output = %#v", got)
+	}
+}
+
+func TestExecute_DefaultOutputIsLastStep(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1,
+		Steps: []*composition.Step{
+			{ID: "a", Kind: composition.KindTool, Tool: "t.a", Args: map[string]any{"x": "${input.v}"}},
+			{ID: "b", Kind: composition.KindTool, Tool: "t.b"},
+		},
+	}
+	fe := newFakeExec(map[string]any{"a": "ra", "b": "rb"})
+	out, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"v": 1}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `"rb"` {
+		t.Errorf("default output = %s, want \"rb\"", out)
+	}
+	if string(fe.seen["a"]) != `{"x":1}` {
+		t.Errorf("tool a args = %s", fe.seen["a"])
+	}
+}
+
+func TestExecute_NilComposition(t *testing.T) {
+	fe := newFakeExec(nil)
+	_, err := New(fe.exec).Execute(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil composition")
+	}
+}
+
+func TestExecute_NilInput(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1,
+		Steps:   []*composition.Step{{ID: "x", Kind: composition.KindTool, Tool: "t"}},
+	}
+	fe := newFakeExec(map[string]any{"x": "ok"})
+	out, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `"ok"` {
+		t.Errorf("nil-input output = %s", out)
+	}
+}
+
+func TestExecute_AgentKind(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1,
+		Steps:   []*composition.Step{{ID: "ag", Kind: composition.KindAgent, Input: "${input.q}"}},
+	}
+	fe := newFakeExec(map[string]any{"ag": "answer"})
+	out, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"q": "hi"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `"answer"` {
+		t.Errorf("agent output = %s", out)
+	}
+	if string(fe.seen["ag"]) != `"hi"` {
+		t.Errorf("agent resolved input = %s", fe.seen["ag"])
+	}
+}
+
+func TestExecute_BranchKind_Stub(t *testing.T) {
+	// runBranch is a stub that does nothing; the branch step produces no output.
+	// Output must be set explicitly — using a preceding leaf step here.
+	comp := &composition.Composition{
+		Version: 1,
+		Output:  "before",
+		Steps: []*composition.Step{
+			{ID: "before", Kind: composition.KindPrompt, Input: "x"},
+			{ID: "br", Kind: composition.KindBranch},
+		},
+	}
+	fe := newFakeExec(map[string]any{"before": "done"})
+	out, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `"done"` {
+		t.Errorf("branch stub output = %s", out)
+	}
+}
+
+func TestExecute_ParallelKind_ErrorStub(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1,
+		Steps:   []*composition.Step{{ID: "p", Kind: composition.KindParallel}},
+	}
+	fe := newFakeExec(nil)
+	_, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	if err == nil {
+		t.Fatal("expected error from parallel stub")
+	}
+}
+
+func TestExecute_UnknownKind(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1,
+		Steps:   []*composition.Step{{ID: "x", Kind: "unknown"}},
+	}
+	fe := newFakeExec(nil)
+	_, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown kind")
+	}
+}
+
+func TestExecute_SkippedDeps(t *testing.T) {
+	// "b" depends on "a"; "a" is skipped (depends on a missing dep that is also
+	// skipped — simulated here by starting with an always-skipped step).
+	comp := &composition.Composition{
+		Version: 1,
+		Output:  "c",
+		Steps: []*composition.Step{
+			// "skip" has no deps so it runs; we skip it manually by making it
+			// produce a branch (which doesn't set status = completed, so we
+			// drive the skip via DependsOn chain instead).
+			// Simpler: use a direct dep chain where "a" dep on "skip",
+			// "b" dep on "a", and "skip" is KindBranch (no output, no completed).
+			{ID: "skip", Kind: composition.KindBranch},
+			{ID: "a", Kind: composition.KindPrompt, DependsOn: []string{"skip"}},
+			{ID: "c", Kind: composition.KindTool, Tool: "t"},
+		},
+	}
+	// "skip" is KindBranch stub — sets no status on itself, so status["skip"] == statusPending.
+	// "a" DependsOn "skip" but skip is pending (not skipped), so "a" runs.
+	// The interesting skip path: a step whose all deps are statusSkipped.
+	// Drive that by having "gone" never in the map (treated as pending), so "a" runs.
+	// Actually to test the shouldSkip path, we need all deps to be statusSkipped.
+	// Use a different approach: status for "gone" dep will be zero (pending), not skipped.
+	// To truly hit shouldSkip we need a step that was explicitly marked skipped.
+	// Restructure: chain skip→a→b where skip is itself skipped.
+	// The only way a step gets statusSkipped is if shouldSkip returns true for it.
+	// Bootstrap: step with DependsOn of a non-existent id won't be skipped because
+	// the zero value is statusPending, not statusSkipped.
+	// The real skip chain requires a prior step to have been skipped.
+	// Use: step "never" depends on step "gone" (unknown = pending → not skipped);
+	// so that won't work. We need an explicit skip.
+	//
+	// Conclusion: shouldSkip only fires when a dep was explicitly set to statusSkipped.
+	// That happens transitively. Build: root→mid→leaf where root is KindParallel
+	// (errors out) — but we need Execute to still run. Instead, let's test it via
+	// a KindBranch that has a dep on another KindBranch:
+	// Actually the simplest reliable path: manually confirm shouldSkip logic in a unit test.
+	fe := newFakeExec(map[string]any{"c": "cv"})
+	out, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `"cv"` {
+		t.Errorf("skipped-deps output = %s", out)
+	}
+}
+
+func TestExecute_StepError(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1,
+		Steps:   []*composition.Step{{ID: "fail", Kind: composition.KindTool, Tool: "t"}},
+	}
+	fe := newFakeExec(nil)
+	fe.errOn["fail"] = 1 // fail on first attempt
+	_, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	if err == nil {
+		t.Fatal("expected error from failing step")
+	}
+}
+
+func TestExecute_OutputStepNotCompleted(t *testing.T) {
+	// Output points to a non-existent step id.
+	comp := &composition.Composition{
+		Version: 1,
+		Output:  "missing",
+		Steps:   []*composition.Step{{ID: "x", Kind: composition.KindTool, Tool: "t"}},
+	}
+	fe := newFakeExec(map[string]any{"x": "v"})
+	_, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	if err == nil {
+		t.Fatal("expected error when output step did not complete")
+	}
+}
+
+func TestExecute_EmptySteps(t *testing.T) {
+	comp := &composition.Composition{Version: 1}
+	fe := newFakeExec(nil)
+	_, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	if err == nil {
+		t.Fatal("expected error — no steps means no output")
+	}
+}
+
+func TestShouldSkip_AllDepsSkipped(t *testing.T) {
+	status := map[string]stepStatus{
+		"a": statusSkipped,
+		"b": statusSkipped,
+	}
+	step := &composition.Step{ID: "c", DependsOn: []string{"a", "b"}}
+	if !shouldSkip(step, status) {
+		t.Error("expected shouldSkip=true when all deps are skipped")
+	}
+}
+
+func TestShouldSkip_OneDep_Completed(t *testing.T) {
+	status := map[string]stepStatus{
+		"a": statusSkipped,
+		"b": statusCompleted,
+	}
+	step := &composition.Step{ID: "c", DependsOn: []string{"a", "b"}}
+	if shouldSkip(step, status) {
+		t.Error("expected shouldSkip=false when one dep completed")
+	}
+}
+
+func TestShouldSkip_NoDeps(t *testing.T) {
+	step := &composition.Step{ID: "c"}
+	if shouldSkip(step, nil) {
+		t.Error("expected shouldSkip=false for step with no deps")
+	}
+}
+
+func TestDecodeOutput_Empty(t *testing.T) {
+	v, err := decodeOutput(nil)
+	if err != nil || v != nil {
+		t.Errorf("empty decodeOutput = (%v, %v), want (nil, nil)", v, err)
+	}
+}

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -144,24 +144,24 @@ func TestExecute_AgentKind(t *testing.T) {
 	}
 }
 
-func TestExecute_BranchKind_Stub(t *testing.T) {
-	// runBranch is a stub that does nothing; the branch step produces no output.
-	// Output must be set explicitly — using a preceding leaf step here.
+func TestExecute_BranchKind_NoOutput(t *testing.T) {
+	// A branch step produces no scope output; Output must be set explicitly.
 	comp := &composition.Composition{
 		Version: 1,
 		Output:  "before",
 		Steps: []*composition.Step{
 			{ID: "before", Kind: composition.KindPrompt, Input: "x"},
-			{ID: "br", Kind: composition.KindBranch},
+			{ID: "br", Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${input.v}", Op: "equals", Value: true}},
 		},
 	}
 	fe := newFakeExec(map[string]any{"before": "done"})
-	out, err := New(fe.exec).Execute(context.Background(), comp, nil)
+	out, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"v": false}))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(out) != `"done"` {
-		t.Errorf("branch stub output = %s", out)
+		t.Errorf("branch no-output = %s", out)
 	}
 }
 
@@ -258,5 +258,95 @@ func TestDecodeOutput_Empty(t *testing.T) {
 	v, err := decodeOutput(nil)
 	if err != nil || v != nil {
 		t.Errorf("empty decodeOutput = (%v, %v), want (nil, nil)", v, err)
+	}
+}
+
+// branchComp builds: classify -> route(branch) -> paper|general -> join(depends_on both).
+func branchComp(predValue string) *composition.Composition {
+	return &composition.Composition{
+		Version: 1,
+		Output:  "join",
+		Steps: []*composition.Step{
+			{ID: "classify", Kind: composition.KindPrompt, PromptTask: "c", Input: "${input.text}"},
+			{ID: "route", Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${classify.output.type}", Op: "equals", Value: predValue},
+				Then:      "paper", Else: "general"},
+			{ID: "paper", Kind: composition.KindPrompt, PromptTask: "pp", Input: "${input.text}"},
+			{ID: "general", Kind: composition.KindPrompt, PromptTask: "gg", Input: "${input.text}"},
+			{ID: "join", Kind: composition.KindPrompt, PromptTask: "j",
+				DependsOn: []string{"paper", "general"}, Input: "${input.text}"},
+		},
+	}
+}
+
+func TestExecute_BranchThen(t *testing.T) {
+	comp := branchComp("paper") // predicate true -> take 'then' (paper), skip 'general'
+	fe := newFakeExec(map[string]any{
+		"classify": map[string]any{"type": "paper"},
+		"paper":    "P", "general": "G", "join": "J",
+	})
+	if _, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"text": "x"})); err != nil {
+		t.Fatal(err)
+	}
+	if !reflectDeepEqual(fe.calls, []string{"classify", "paper", "join"}) {
+		t.Errorf("calls = %v, want classify,paper,join", fe.calls)
+	}
+}
+
+func TestExecute_BranchElse(t *testing.T) {
+	comp := branchComp("memo") // predicate false -> take 'else' (general), skip 'paper'
+	fe := newFakeExec(map[string]any{
+		"classify": map[string]any{"type": "paper"},
+		"paper":    "P", "general": "G", "join": "J",
+	})
+	if _, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"text": "x"})); err != nil {
+		t.Fatal(err)
+	}
+	if !reflectDeepEqual(fe.calls, []string{"classify", "general", "join"}) {
+		t.Errorf("calls = %v, want classify,general,join", fe.calls)
+	}
+}
+
+func TestExecute_EmptyElseFallThrough(t *testing.T) {
+	// predicate false, empty else -> skip 'then' target, fall through to next step.
+	comp := &composition.Composition{
+		Version: 1, Output: "after",
+		Steps: []*composition.Step{
+			{ID: "route", Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${input.go}", Op: "equals", Value: true},
+				Then:      "optional"},
+			{ID: "optional", Kind: composition.KindPrompt, PromptTask: "o", Input: "${input.x}"},
+			{ID: "after", Kind: composition.KindPrompt, PromptTask: "a", Input: "${input.x}"},
+		},
+	}
+	fe := newFakeExec(map[string]any{"optional": "O", "after": "A"})
+	if _, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"go": false, "x": 1})); err != nil {
+		t.Fatal(err)
+	}
+	if !reflectDeepEqual(fe.calls, []string{"after"}) {
+		t.Errorf("calls = %v, want after only (optional skipped)", fe.calls)
+	}
+}
+
+func TestExecute_JoinSkippedWhenAllDepsSkipped(t *testing.T) {
+	// A step depending only on a skipped target is itself skipped.
+	comp := &composition.Composition{
+		Version: 1, Output: "tail",
+		Steps: []*composition.Step{
+			{ID: "route", Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${input.go}", Op: "equals", Value: true},
+				Then:      "only"},
+			{ID: "only", Kind: composition.KindPrompt, PromptTask: "o", Input: "${input.x}"},
+			{ID: "dependent", Kind: composition.KindPrompt, PromptTask: "d",
+				DependsOn: []string{"only"}, Input: "${input.x}"},
+			{ID: "tail", Kind: composition.KindPrompt, PromptTask: "t", Input: "${input.x}"},
+		},
+	}
+	fe := newFakeExec(map[string]any{"only": "O", "dependent": "D", "tail": "T"})
+	if _, err := New(fe.exec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"go": false, "x": 1})); err != nil {
+		t.Fatal(err)
+	}
+	if !reflectDeepEqual(fe.calls, []string{"tail"}) {
+		t.Errorf("calls = %v, want tail only (only+dependent skipped)", fe.calls)
 	}
 }

--- a/runtime/composition/engine/predicate.go
+++ b/runtime/composition/engine/predicate.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -89,7 +90,10 @@ func evalCompare(p *composition.Predicate, scope Scope) (bool, error) {
 		return inList(actual, p.Value)
 	case "not_in":
 		ok, err := inList(actual, p.Value)
-		return !ok, err
+		if err != nil {
+			return false, err
+		}
+		return !ok, nil
 	case opLessThan, opLessThanOrEquals, opGreaterThan, opGreaterThanOrEquals:
 		return compareOrdered(p.Op, actual, p.Value)
 	default:
@@ -157,6 +161,11 @@ func toFloat(v any) (float64, bool) {
 		return float64(n), true
 	case int64:
 		return float64(n), true
+	case json.Number:
+		if f, err := n.Float64(); err == nil {
+			return f, true
+		}
+		return 0, false
 	default:
 		return 0, false
 	}

--- a/runtime/composition/engine/predicate.go
+++ b/runtime/composition/engine/predicate.go
@@ -8,7 +8,6 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 )
 
-//nolint:unused // used by evalCompare and compareOrdered; wired to non-test callers in Task 5
 const (
 	opLessThan            = "less_than"
 	opLessThanOrEquals    = "less_than_or_equals"
@@ -19,8 +18,6 @@ const (
 // evalPredicate evaluates a constrained predicate against scope. Exactly one
 // variant is set on p (enforced by composition.Validate); precedence here favors
 // composites, then exists, then compare.
-//
-//nolint:unused // wired to non-test callers in Task 5
 func evalPredicate(p *composition.Predicate, scope Scope) (bool, error) {
 	if p == nil {
 		return false, fmt.Errorf("nil predicate")
@@ -45,7 +42,6 @@ func evalPredicate(p *composition.Predicate, scope Scope) (bool, error) {
 	return evalCompare(p, scope)
 }
 
-//nolint:unused // called by evalPredicate; wired to non-test callers in Task 5
 func evalAllOf(preds []*composition.Predicate, scope Scope) (bool, error) {
 	for _, sub := range preds {
 		ok, err := evalPredicate(sub, scope)
@@ -59,7 +55,6 @@ func evalAllOf(preds []*composition.Predicate, scope Scope) (bool, error) {
 	return true, nil
 }
 
-//nolint:unused // called by evalPredicate; wired to non-test callers in Task 5
 func evalAnyOf(preds []*composition.Predicate, scope Scope) (bool, error) {
 	for _, sub := range preds {
 		ok, err := evalPredicate(sub, scope)
@@ -73,7 +68,6 @@ func evalAnyOf(preds []*composition.Predicate, scope Scope) (bool, error) {
 	return false, nil
 }
 
-//nolint:unused // called by evalPredicate; wired to non-test callers in Task 5
 func evalCompare(p *composition.Predicate, scope Scope) (bool, error) {
 	actual, found := resolvePath(p.Path, scope)
 	if !found {
@@ -103,8 +97,6 @@ func evalCompare(p *composition.Predicate, scope Scope) (bool, error) {
 
 // jsonEqual compares two decoded-JSON values. Numbers compare numerically; other
 // values use reflect.DeepEqual.
-//
-//nolint:unused // called by evalCompare; wired to non-test callers in Task 5
 func jsonEqual(a, b any) bool {
 	af, aok := toFloat(a)
 	bf, bok := toFloat(b)
@@ -114,7 +106,6 @@ func jsonEqual(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-//nolint:unused // called by evalCompare; wired to non-test callers in Task 5
 func inList(actual, value any) (bool, error) {
 	list, ok := value.([]any)
 	if !ok {
@@ -128,7 +119,6 @@ func inList(actual, value any) (bool, error) {
 	return false, nil
 }
 
-//nolint:unused // called by evalCompare; wired to non-test callers in Task 5
 func compareOrdered(op string, actual, value any) (bool, error) {
 	af, aok := toFloat(actual)
 	bf, bok := toFloat(value)
@@ -149,8 +139,6 @@ func compareOrdered(op string, actual, value any) (bool, error) {
 }
 
 // toFloat coerces JSON-decoded numerics (float64, plus int kinds for safety) to float64.
-//
-//nolint:unused // called by jsonEqual and compareOrdered; wired to non-test callers in Task 5
 func toFloat(v any) (float64, bool) {
 	switch n := v.(type) {
 	case float64:

--- a/runtime/composition/engine/predicate.go
+++ b/runtime/composition/engine/predicate.go
@@ -1,0 +1,163 @@
+package engine
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+)
+
+//nolint:unused // used by evalCompare and compareOrdered; wired to non-test callers in Task 5
+const (
+	opLessThan            = "less_than"
+	opLessThanOrEquals    = "less_than_or_equals"
+	opGreaterThan         = "greater_than"
+	opGreaterThanOrEquals = "greater_than_or_equals"
+)
+
+// evalPredicate evaluates a constrained predicate against scope. Exactly one
+// variant is set on p (enforced by composition.Validate); precedence here favors
+// composites, then exists, then compare.
+//
+//nolint:unused // wired to non-test callers in Task 5
+func evalPredicate(p *composition.Predicate, scope Scope) (bool, error) {
+	if p == nil {
+		return false, fmt.Errorf("nil predicate")
+	}
+	if p.AllOf != nil {
+		return evalAllOf(p.AllOf, scope)
+	}
+	if p.AnyOf != nil {
+		return evalAnyOf(p.AnyOf, scope)
+	}
+	if p.Not != nil {
+		ok, err := evalPredicate(p.Not, scope)
+		if err != nil {
+			return false, err
+		}
+		return !ok, nil
+	}
+	if p.Exists != nil {
+		_, found := resolvePath(p.Path, scope)
+		return found == *p.Exists, nil
+	}
+	return evalCompare(p, scope)
+}
+
+//nolint:unused // called by evalPredicate; wired to non-test callers in Task 5
+func evalAllOf(preds []*composition.Predicate, scope Scope) (bool, error) {
+	for _, sub := range preds {
+		ok, err := evalPredicate(sub, scope)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+//nolint:unused // called by evalPredicate; wired to non-test callers in Task 5
+func evalAnyOf(preds []*composition.Predicate, scope Scope) (bool, error) {
+	for _, sub := range preds {
+		ok, err := evalPredicate(sub, scope)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+//nolint:unused // called by evalPredicate; wired to non-test callers in Task 5
+func evalCompare(p *composition.Predicate, scope Scope) (bool, error) {
+	actual, found := resolvePath(p.Path, scope)
+	if !found {
+		// A missing path is not an error for compare: equals/in are false,
+		// not_equals/not_in are true. Mirror that with nil actual.
+		actual = nil
+	}
+	switch p.Op {
+	case "equals":
+		return jsonEqual(actual, p.Value), nil
+	case "not_equals":
+		return !jsonEqual(actual, p.Value), nil
+	case "in":
+		return inList(actual, p.Value)
+	case "not_in":
+		ok, err := inList(actual, p.Value)
+		return !ok, err
+	case opLessThan, opLessThanOrEquals, opGreaterThan, opGreaterThanOrEquals:
+		return compareOrdered(p.Op, actual, p.Value)
+	default:
+		return false, fmt.Errorf("unknown predicate op %q", p.Op)
+	}
+}
+
+// jsonEqual compares two decoded-JSON values. Numbers compare numerically; other
+// values use reflect.DeepEqual.
+//
+//nolint:unused // called by evalCompare; wired to non-test callers in Task 5
+func jsonEqual(a, b any) bool {
+	af, aok := toFloat(a)
+	bf, bok := toFloat(b)
+	if aok && bok {
+		return af == bf
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+//nolint:unused // called by evalCompare; wired to non-test callers in Task 5
+func inList(actual, value any) (bool, error) {
+	list, ok := value.([]any)
+	if !ok {
+		return false, fmt.Errorf("in/not_in requires a list value, got %T", value)
+	}
+	for _, item := range list {
+		if jsonEqual(actual, item) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+//nolint:unused // called by evalCompare; wired to non-test callers in Task 5
+func compareOrdered(op string, actual, value any) (bool, error) {
+	af, aok := toFloat(actual)
+	bf, bok := toFloat(value)
+	if !aok || !bok {
+		return false, fmt.Errorf("ordered comparison %q requires numeric operands, got %T and %T", op, actual, value)
+	}
+	switch op {
+	case opLessThan:
+		return af < bf, nil
+	case opLessThanOrEquals:
+		return af <= bf, nil
+	case opGreaterThan:
+		return af > bf, nil
+	case opGreaterThanOrEquals:
+		return af >= bf, nil
+	}
+	return false, fmt.Errorf("unknown ordered op %q", op)
+}
+
+// toFloat coerces JSON-decoded numerics (float64, plus int kinds for safety) to float64.
+//
+//nolint:unused // called by jsonEqual and compareOrdered; wired to non-test callers in Task 5
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}

--- a/runtime/composition/engine/predicate_test.go
+++ b/runtime/composition/engine/predicate_test.go
@@ -213,3 +213,25 @@ func TestEvalPredicate_Float32Coercion(t *testing.T) {
 		t.Error("float32(0.5) < float64(1.0) should be true")
 	}
 }
+
+func TestEvalPredicate_EdgeCases(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper"}}
+
+	// not_in on a missing path: actual is nil, nil is not in the list → true.
+	got, err := evalPredicate(&composition.Predicate{Path: "${input.nope}", Op: "not_in", Value: []any{"memo"}}, scope)
+	if err != nil || !got {
+		t.Errorf("not_in missing path = (%v,%v), want (true,nil)", got, err)
+	}
+
+	// empty all_of is vacuously true.
+	got, err = evalPredicate(&composition.Predicate{AllOf: []*composition.Predicate{}}, scope)
+	if err != nil || !got {
+		t.Errorf("empty all_of = (%v,%v), want (true,nil)", got, err)
+	}
+
+	// empty any_of is false.
+	got, err = evalPredicate(&composition.Predicate{AnyOf: []*composition.Predicate{}}, scope)
+	if err != nil || got {
+		t.Errorf("empty any_of = (%v,%v), want (false,nil)", got, err)
+	}
+}

--- a/runtime/composition/engine/predicate_test.go
+++ b/runtime/composition/engine/predicate_test.go
@@ -1,0 +1,215 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestEvalPredicate_Compare(t *testing.T) {
+	scope := Scope{
+		"input": map[string]any{"type": "paper", "score": float64(8), "tags": []any{"a", "b"}},
+	}
+	cases := []struct {
+		name string
+		p    *composition.Predicate
+		want bool
+	}{
+		{"equals true", &composition.Predicate{Path: "${input.type}", Op: "equals", Value: "paper"}, true},
+		{"equals false", &composition.Predicate{Path: "${input.type}", Op: "equals", Value: "memo"}, false},
+		{"not_equals", &composition.Predicate{Path: "${input.type}", Op: "not_equals", Value: "memo"}, true},
+		{"less_than", &composition.Predicate{Path: "${input.score}", Op: "less_than", Value: float64(10)}, true},
+		{"greater_than_or_equals", &composition.Predicate{Path: "${input.score}", Op: "greater_than_or_equals", Value: float64(8)}, true},
+		{"in", &composition.Predicate{Path: "${input.type}", Op: "in", Value: []any{"paper", "memo"}}, true},
+		{"not_in", &composition.Predicate{Path: "${input.type}", Op: "not_in", Value: []any{"memo"}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := evalPredicate(c.p, scope)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != c.want {
+				t.Errorf("got %v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestEvalPredicate_Exists(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper"}}
+	got, _ := evalPredicate(&composition.Predicate{Path: "${input.type}", Exists: boolPtr(true)}, scope)
+	if !got {
+		t.Error("exists:true on present path should be true")
+	}
+	got, _ = evalPredicate(&composition.Predicate{Path: "${input.type}", Exists: boolPtr(false)}, scope)
+	if got {
+		t.Error("exists:false on present path should be false")
+	}
+	got, _ = evalPredicate(&composition.Predicate{Path: "${input.nope}", Exists: boolPtr(true)}, scope)
+	if got {
+		t.Error("exists:true on missing path should be false")
+	}
+}
+
+func TestEvalPredicate_Composites(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper", "score": float64(8)}}
+	allOf := &composition.Predicate{AllOf: []*composition.Predicate{
+		{Path: "${input.type}", Op: "equals", Value: "paper"},
+		{Path: "${input.score}", Op: "greater_than", Value: float64(5)},
+	}}
+	if got, _ := evalPredicate(allOf, scope); !got {
+		t.Error("all_of should be true")
+	}
+	anyOf := &composition.Predicate{AnyOf: []*composition.Predicate{
+		{Path: "${input.type}", Op: "equals", Value: "memo"},
+		{Path: "${input.score}", Op: "greater_than", Value: float64(5)},
+	}}
+	if got, _ := evalPredicate(anyOf, scope); !got {
+		t.Error("any_of should be true")
+	}
+	not := &composition.Predicate{Not: &composition.Predicate{Path: "${input.type}", Op: "equals", Value: "memo"}}
+	if got, _ := evalPredicate(not, scope); !got {
+		t.Error("not should be true")
+	}
+}
+
+func TestEvalPredicate_TypeMismatchErrors(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper"}}
+	if _, err := evalPredicate(&composition.Predicate{Path: "${input.type}", Op: "less_than", Value: float64(3)}, scope); err == nil {
+		t.Error("expected error comparing string < number")
+	}
+}
+
+func TestEvalPredicate_Nil(t *testing.T) {
+	_, err := evalPredicate(nil, Scope{})
+	if err == nil {
+		t.Error("expected error for nil predicate")
+	}
+}
+
+func TestEvalPredicate_AllOfShortCircuit(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper"}}
+	// First sub false → short-circuit, second sub never evaluated.
+	p := &composition.Predicate{AllOf: []*composition.Predicate{
+		{Path: "${input.type}", Op: "equals", Value: "memo"},
+		{Path: "${input.type}", Op: "equals", Value: "paper"},
+	}}
+	got, err := evalPredicate(p, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("all_of with first-sub false should be false")
+	}
+}
+
+func TestEvalPredicate_AnyOfAllFalse(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper"}}
+	p := &composition.Predicate{AnyOf: []*composition.Predicate{
+		{Path: "${input.type}", Op: "equals", Value: "memo"},
+		{Path: "${input.type}", Op: "equals", Value: "fax"},
+	}}
+	got, err := evalPredicate(p, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("any_of with all-false subs should be false")
+	}
+}
+
+func TestEvalPredicate_MissingPathCompare(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper"}}
+	// equals on a missing path should be false (not an error).
+	got, err := evalPredicate(&composition.Predicate{Path: "${input.nope}", Op: "equals", Value: "paper"}, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("equals on missing path should be false")
+	}
+	// not_equals on a missing path should be true.
+	got, err = evalPredicate(&composition.Predicate{Path: "${input.nope}", Op: "not_equals", Value: "paper"}, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("not_equals on missing path should be true")
+	}
+}
+
+func TestEvalPredicate_UnknownOp(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper"}}
+	if _, err := evalPredicate(&composition.Predicate{Path: "${input.type}", Op: "contains", Value: "paper"}, scope); err == nil {
+		t.Error("expected error for unknown op")
+	}
+}
+
+func TestEvalPredicate_InListError(t *testing.T) {
+	scope := Scope{"input": map[string]any{"type": "paper"}}
+	// Value must be []any for in/not_in; passing a string should error.
+	if _, err := evalPredicate(&composition.Predicate{Path: "${input.type}", Op: "in", Value: "paper"}, scope); err == nil {
+		t.Error("expected error when in-list value is not a slice")
+	}
+}
+
+func TestEvalPredicate_LessThanOrEquals(t *testing.T) {
+	scope := Scope{"input": map[string]any{"score": float64(8)}}
+	got, err := evalPredicate(&composition.Predicate{Path: "${input.score}", Op: "less_than_or_equals", Value: float64(8)}, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("less_than_or_equals with equal values should be true")
+	}
+}
+
+func TestEvalPredicate_NumericCoercion(t *testing.T) {
+	// Scope values of int kind (not float64) should compare numerically.
+	scope := Scope{"input": map[string]any{"count": int(5)}}
+	got, err := evalPredicate(&composition.Predicate{Path: "${input.count}", Op: "equals", Value: float64(5)}, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("int(5) should equal float64(5) via numeric coercion")
+	}
+}
+
+func TestEvalPredicate_NotError(t *testing.T) {
+	// not wrapping a predicate that itself errors should propagate the error.
+	p := &composition.Predicate{
+		Not: &composition.Predicate{Path: "${input.score}", Op: "less_than", Value: float64(3)},
+	}
+	scope := Scope{"input": map[string]any{"score": "notanumber"}}
+	if _, err := evalPredicate(p, scope); err == nil {
+		t.Error("expected error propagated through not")
+	}
+}
+
+func TestEvalPredicate_Int64Coercion(t *testing.T) {
+	// int64 scope values should compare numerically via toFloat.
+	scope := Scope{"input": map[string]any{"count": int64(42)}}
+	got, err := evalPredicate(&composition.Predicate{Path: "${input.count}", Op: "greater_than", Value: float64(10)}, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("int64(42) > float64(10) should be true")
+	}
+}
+
+func TestEvalPredicate_Float32Coercion(t *testing.T) {
+	// float32 scope values should compare numerically via toFloat.
+	scope := Scope{"input": map[string]any{"ratio": float32(0.5)}}
+	got, err := evalPredicate(&composition.Predicate{Path: "${input.ratio}", Op: "less_than", Value: float64(1.0)}, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("float32(0.5) < float64(1.0) should be true")
+	}
+}

--- a/runtime/composition/engine/reduce.go
+++ b/runtime/composition/engine/reduce.go
@@ -8,8 +8,9 @@ type NamedOutput struct {
 	Output any
 }
 
-// reduce merges parallel branch outputs per the reducer strategy. The result is
-// exposed downstream under the parallel step's output as reduce.Into.
+// reduce merges parallel branch outputs per the reducer strategy and returns the
+// merged value. Callers bind the result to the scope key named by r.Into (Task 7);
+// reduce itself does not touch scope. r must not be nil (guaranteed by Validate).
 //
 //nolint:unused // wired to non-test callers in Task 7
 func reduce(r *composition.Reducer, outs []NamedOutput) any {
@@ -25,11 +26,15 @@ func reduce(r *composition.Reducer, outs []NamedOutput) any {
 			m[o.ID] = o.Output
 		}
 		return m
-	default:
+	case composition.ReduceAppend:
 		list := make([]any, 0, len(outs))
 		for _, o := range outs {
 			list = append(list, o.Output)
 		}
 		return list
+	default:
+		// Validate enforces strategy ∈ {append,replace,barrier} upstream; an
+		// unrecognized strategy returns nil so it fails loudly downstream.
+		return nil
 	}
 }

--- a/runtime/composition/engine/reduce.go
+++ b/runtime/composition/engine/reduce.go
@@ -9,10 +9,8 @@ type NamedOutput struct {
 }
 
 // reduce merges parallel branch outputs per the reducer strategy and returns the
-// merged value. Callers bind the result to the scope key named by r.Into (Task 7);
+// merged value. Callers bind the result to the scope key named by r.Into;
 // reduce itself does not touch scope. r must not be nil (guaranteed by Validate).
-//
-//nolint:unused // wired to non-test callers in Task 7
 func reduce(r *composition.Reducer, outs []NamedOutput) any {
 	switch r.Strategy {
 	case composition.ReduceReplace:

--- a/runtime/composition/engine/reduce.go
+++ b/runtime/composition/engine/reduce.go
@@ -1,0 +1,35 @@
+package engine
+
+import "github.com/AltairaLabs/PromptKit/runtime/composition"
+
+// NamedOutput pairs a parallel branch id with its decoded output, in branch order.
+type NamedOutput struct {
+	ID     string
+	Output any
+}
+
+// reduce merges parallel branch outputs per the reducer strategy. The result is
+// exposed downstream under the parallel step's output as reduce.Into.
+//
+//nolint:unused // wired to non-test callers in Task 7
+func reduce(r *composition.Reducer, outs []NamedOutput) any {
+	switch r.Strategy {
+	case composition.ReduceReplace:
+		if len(outs) == 0 {
+			return nil
+		}
+		return outs[len(outs)-1].Output
+	case composition.ReduceBarrier:
+		m := make(map[string]any, len(outs))
+		for _, o := range outs {
+			m[o.ID] = o.Output
+		}
+		return m
+	default:
+		list := make([]any, 0, len(outs))
+		for _, o := range outs {
+			list = append(list, o.Output)
+		}
+		return list
+	}
+}

--- a/runtime/composition/engine/reduce_test.go
+++ b/runtime/composition/engine/reduce_test.go
@@ -46,4 +46,18 @@ func TestReduce(t *testing.T) {
 			t.Errorf("replace of empty = %#v, want nil", got)
 		}
 	})
+
+	t.Run("append empty", func(t *testing.T) {
+		got := reduce(&composition.Reducer{Strategy: composition.ReduceAppend}, nil)
+		if !reflectDeepEqual(got, []any{}) {
+			t.Errorf("append of empty = %#v, want empty slice", got)
+		}
+	})
+
+	t.Run("barrier empty", func(t *testing.T) {
+		got := reduce(&composition.Reducer{Strategy: composition.ReduceBarrier}, nil)
+		if !reflectDeepEqual(got, map[string]any{}) {
+			t.Errorf("barrier of empty = %#v, want empty map", got)
+		}
+	})
 }

--- a/runtime/composition/engine/reduce_test.go
+++ b/runtime/composition/engine/reduce_test.go
@@ -1,0 +1,49 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+)
+
+func TestReduce(t *testing.T) {
+	outs := []NamedOutput{
+		{ID: "structure", Output: map[string]any{"sections": float64(3)}},
+		{ID: "citations", Output: map[string]any{"count": float64(12)}},
+	}
+
+	t.Run("append", func(t *testing.T) {
+		got := reduce(&composition.Reducer{Strategy: composition.ReduceAppend, Into: "metadata"}, outs)
+		want := []any{
+			map[string]any{"sections": float64(3)},
+			map[string]any{"count": float64(12)},
+		}
+		if !reflectDeepEqual(got, want) {
+			t.Errorf("append = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("replace", func(t *testing.T) {
+		got := reduce(&composition.Reducer{Strategy: composition.ReduceReplace, Into: "metadata"}, outs)
+		if !reflectDeepEqual(got, map[string]any{"count": float64(12)}) {
+			t.Errorf("replace = %#v", got)
+		}
+	})
+
+	t.Run("barrier", func(t *testing.T) {
+		got := reduce(&composition.Reducer{Strategy: composition.ReduceBarrier, Into: "metadata"}, outs)
+		want := map[string]any{
+			"structure": map[string]any{"sections": float64(3)},
+			"citations": map[string]any{"count": float64(12)},
+		}
+		if !reflectDeepEqual(got, want) {
+			t.Errorf("barrier = %#v", got)
+		}
+	})
+
+	t.Run("replace empty", func(t *testing.T) {
+		if got := reduce(&composition.Reducer{Strategy: composition.ReduceReplace}, nil); got != nil {
+			t.Errorf("replace of empty = %#v, want nil", got)
+		}
+	})
+}

--- a/runtime/composition/engine/scope.go
+++ b/runtime/composition/engine/scope.go
@@ -1,0 +1,56 @@
+// Package engine is the deterministic orchestrator core for RFC 0010 workflow
+// compositions. It resolves ${...} references against a scope, evaluates the
+// constrained predicate language, merges parallel outputs, and walks the step
+// DAG. Step side-effects run through an injected StepExecutor, so this package
+// imports neither runtime/pipeline nor runtime/providers.
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Scope holds the composition input plus each completed step's output, shaped for
+// ${input.X} and ${stepID.output.X} resolution.
+type Scope map[string]any
+
+// refWholeRe matches a string that is exactly a single ${...} reference.
+//
+//nolint:unused // used by stripRef; later tasks in this package add callers
+var refWholeRe = regexp.MustCompile(`^\$\{\s*([a-zA-Z_][a-zA-Z0-9_.]*?)\s*\}$`)
+
+// stripRef returns the inner dotted path of a string that is exactly a ${...}
+// reference, and whether the input was such a reference.
+//
+//nolint:unused // used by resolvePath and the predicate evaluator added in later tasks
+func stripRef(s string) (string, bool) {
+	m := refWholeRe.FindStringSubmatch(s)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
+// resolvePath resolves a ${...} reference to its value in scope, walking dotted
+// segments through nested maps. Returns (nil, false) if the input is not a
+// whole-string reference or any segment is missing.
+//
+//nolint:unused // used by the predicate evaluator and step executor added in later tasks
+func resolvePath(ref string, scope Scope) (any, bool) {
+	inner, ok := stripRef(ref)
+	if !ok {
+		return nil, false
+	}
+	var cur any = map[string]any(scope)
+	for _, seg := range strings.Split(inner, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = m[seg]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}

--- a/runtime/composition/engine/scope.go
+++ b/runtime/composition/engine/scope.go
@@ -6,6 +6,7 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -67,24 +68,24 @@ var embeddedRefRe = regexp.MustCompile(`\$\{\s*[a-zA-Z_][a-zA-Z0-9_.]*?\s*\}`)
 //
 //nolint:unused // called only by resolveInput; wired to non-test callers in Task 5
 func resolveInputString(v string, scope Scope) (any, error) {
-	if inner, ok := stripRef(v); ok {
-		val, ok := resolvePath("${"+inner+"}", scope)
+	if _, ok := stripRef(v); ok {
+		val, ok := resolvePath(v, scope)
 		if !ok {
 			return nil, fmt.Errorf("unresolved reference %q", v)
 		}
 		return val, nil
 	}
-	var resolveErr error
+	var errs []error
 	out := embeddedRefRe.ReplaceAllStringFunc(v, func(ref string) string {
 		val, ok := resolvePath(ref, scope)
 		if !ok {
-			resolveErr = fmt.Errorf("unresolved reference %q", ref)
+			errs = append(errs, fmt.Errorf("unresolved reference %q", ref))
 			return ref
 		}
 		return fmt.Sprint(val)
 	})
-	if resolveErr != nil {
-		return nil, resolveErr
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
 	}
 	return out, nil
 }

--- a/runtime/composition/engine/scope.go
+++ b/runtime/composition/engine/scope.go
@@ -17,14 +17,10 @@ import (
 type Scope map[string]any
 
 // refWholeRe matches a string that is exactly a single ${...} reference.
-//
-//nolint:unused // transitively called by resolveInput; wired to non-test callers in Task 5
 var refWholeRe = regexp.MustCompile(`^\$\{\s*([a-zA-Z_][a-zA-Z0-9_.]*?)\s*\}$`)
 
 // stripRef returns the inner dotted path of a string that is exactly a ${...}
 // reference, and whether the input was such a reference.
-//
-//nolint:unused // transitively called by resolveInput; wired to non-test callers in Task 5
 func stripRef(s string) (string, bool) {
 	m := refWholeRe.FindStringSubmatch(s)
 	if m == nil {
@@ -36,8 +32,6 @@ func stripRef(s string) (string, bool) {
 // resolvePath resolves a ${...} reference to its value in scope, walking dotted
 // segments through nested maps. Returns (nil, false) if the input is not a
 // whole-string reference or any segment is missing.
-//
-//nolint:unused // transitively called by resolveInput; wired to non-test callers in Task 5
 func resolvePath(ref string, scope Scope) (any, bool) {
 	inner, ok := stripRef(ref)
 	if !ok {
@@ -58,15 +52,11 @@ func resolvePath(ref string, scope Scope) (any, bool) {
 }
 
 // embeddedRefRe finds ${...} references anywhere inside a string (for interpolation).
-//
-//nolint:unused // transitively called by resolveInput; wired to non-test callers in Task 5
 var embeddedRefRe = regexp.MustCompile(`\$\{\s*[a-zA-Z_][a-zA-Z0-9_.]*?\s*\}`)
 
 // resolveInputString handles the string branch of resolveInput: a pure whole-string
 // reference is returned as its typed value; otherwise embedded references are
 // interpolated as text.
-//
-//nolint:unused // called only by resolveInput; wired to non-test callers in Task 5
 func resolveInputString(v string, scope Scope) (any, error) {
 	if _, ok := stripRef(v); ok {
 		val, ok := resolvePath(v, scope)
@@ -97,8 +87,6 @@ func resolveInputString(v string, scope Scope) (any, error) {
 //   - any other value passes through unchanged
 //
 // An unresolvable reference returns an error.
-//
-//nolint:unused // wired in by the engine scheduler in Task 5
 func resolveInput(in any, scope Scope) (any, error) {
 	switch v := in.(type) {
 	case string:

--- a/runtime/composition/engine/scope.go
+++ b/runtime/composition/engine/scope.go
@@ -6,6 +6,7 @@
 package engine
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -16,13 +17,13 @@ type Scope map[string]any
 
 // refWholeRe matches a string that is exactly a single ${...} reference.
 //
-//nolint:unused // used by stripRef; later tasks in this package add callers
+//nolint:unused // transitively called by resolveInput; wired to non-test callers in Task 5
 var refWholeRe = regexp.MustCompile(`^\$\{\s*([a-zA-Z_][a-zA-Z0-9_.]*?)\s*\}$`)
 
 // stripRef returns the inner dotted path of a string that is exactly a ${...}
 // reference, and whether the input was such a reference.
 //
-//nolint:unused // used by resolvePath and the predicate evaluator added in later tasks
+//nolint:unused // transitively called by resolveInput; wired to non-test callers in Task 5
 func stripRef(s string) (string, bool) {
 	m := refWholeRe.FindStringSubmatch(s)
 	if m == nil {
@@ -35,7 +36,7 @@ func stripRef(s string) (string, bool) {
 // segments through nested maps. Returns (nil, false) if the input is not a
 // whole-string reference or any segment is missing.
 //
-//nolint:unused // used by the predicate evaluator and step executor added in later tasks
+//nolint:unused // transitively called by resolveInput; wired to non-test callers in Task 5
 func resolvePath(ref string, scope Scope) (any, bool) {
 	inner, ok := stripRef(ref)
 	if !ok {
@@ -53,4 +54,75 @@ func resolvePath(ref string, scope Scope) (any, bool) {
 		}
 	}
 	return cur, true
+}
+
+// embeddedRefRe finds ${...} references anywhere inside a string (for interpolation).
+//
+//nolint:unused // transitively called by resolveInput; wired to non-test callers in Task 5
+var embeddedRefRe = regexp.MustCompile(`\$\{\s*[a-zA-Z_][a-zA-Z0-9_.]*?\s*\}`)
+
+// resolveInputString handles the string branch of resolveInput: a pure whole-string
+// reference is returned as its typed value; otherwise embedded references are
+// interpolated as text.
+//
+//nolint:unused // called only by resolveInput; wired to non-test callers in Task 5
+func resolveInputString(v string, scope Scope) (any, error) {
+	if inner, ok := stripRef(v); ok {
+		val, ok := resolvePath("${"+inner+"}", scope)
+		if !ok {
+			return nil, fmt.Errorf("unresolved reference %q", v)
+		}
+		return val, nil
+	}
+	var resolveErr error
+	out := embeddedRefRe.ReplaceAllStringFunc(v, func(ref string) string {
+		val, ok := resolvePath(ref, scope)
+		if !ok {
+			resolveErr = fmt.Errorf("unresolved reference %q", ref)
+			return ref
+		}
+		return fmt.Sprint(val)
+	})
+	if resolveErr != nil {
+		return nil, resolveErr
+	}
+	return out, nil
+}
+
+// resolveInput resolves ${...} references inside a StepInput/Args value:
+//   - a whole-string reference returns the referenced value with its original type
+//   - a string containing embedded references interpolates them as text
+//   - maps and slices are resolved recursively
+//   - any other value passes through unchanged
+//
+// An unresolvable reference returns an error.
+//
+//nolint:unused // wired in by the engine scheduler in Task 5
+func resolveInput(in any, scope Scope) (any, error) {
+	switch v := in.(type) {
+	case string:
+		return resolveInputString(v, scope)
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, val := range v {
+			rv, err := resolveInput(val, scope)
+			if err != nil {
+				return nil, err
+			}
+			out[k] = rv
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(v))
+		for i, val := range v {
+			rv, err := resolveInput(val, scope)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = rv
+		}
+		return out, nil
+	default:
+		return in, nil
+	}
 }

--- a/runtime/composition/engine/scope_test.go
+++ b/runtime/composition/engine/scope_test.go
@@ -44,26 +44,22 @@ func TestResolvePath(t *testing.T) {
 		{"${nope.output.x}", nil, false},
 		{"${input}", map[string]any{"text": "hello", "n": float64(3)}, true},
 		{"bare.path", nil, false},
+		{"${input.text.extra}", nil, false}, // non-map value blocks mid-path descent
 	}
 	for _, c := range cases {
 		got, ok := resolvePath(c.ref, scope)
 		if ok != c.wantOK {
-			t.Fatalf("resolvePath(%q) ok = %v, want %v", c.ref, ok, c.wantOK)
+			t.Errorf("resolvePath(%q) ok = %v, want %v", c.ref, ok, c.wantOK)
+			continue
 		}
-		if ok && !deepEqualJSON(got, c.want) {
+		if ok && !reflectDeepEqual(got, c.want) {
 			t.Errorf("resolvePath(%q) = %#v, want %#v", c.ref, got, c.want)
 		}
 	}
 }
 
-// deepEqualJSON compares two decoded-JSON values structurally.
-func deepEqualJSON(a, b any) bool {
-	return reflectDeepEqual(a, b)
-}
-
-// reflectDeepEqual is a thin wrapper over reflect.DeepEqual.
-// NOTE: when Task 5 adds engine_test.go, this definition must move to exactly
-// one place to avoid a redeclaration compile error.
+// reflectDeepEqual is the shared structural-equality helper for this package's tests.
+// It wraps reflect.DeepEqual for use across all _test.go files in the engine package.
 func reflectDeepEqual(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }

--- a/runtime/composition/engine/scope_test.go
+++ b/runtime/composition/engine/scope_test.go
@@ -63,3 +63,58 @@ func TestResolvePath(t *testing.T) {
 func reflectDeepEqual(a, b any) bool {
 	return reflect.DeepEqual(a, b)
 }
+
+func TestResolveInput(t *testing.T) {
+	scope := Scope{
+		"input":    map[string]any{"text": "doc body", "id": float64(7)},
+		"classify": map[string]any{"output": map[string]any{"type": "paper"}},
+	}
+
+	// pure ref preserves the concrete value (here a map)
+	got, err := resolveInput("${input}", scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflectDeepEqual(got, map[string]any{"text": "doc body", "id": float64(7)}) {
+		t.Errorf("pure ref = %#v", got)
+	}
+
+	// pure ref to a scalar preserves type (number stays float64)
+	got, _ = resolveInput("${input.id}", scope)
+	if got != float64(7) {
+		t.Errorf("scalar ref = %#v, want 7", got)
+	}
+
+	// interpolated string substitutes stringified values
+	got, _ = resolveInput("type is ${classify.output.type}", scope)
+	if got != "type is paper" {
+		t.Errorf("interpolated = %#v", got)
+	}
+
+	// object combining literals + refs recurses
+	got, _ = resolveInput(map[string]any{
+		"content": "${input.text}",
+		"kind":    "${classify.output.type}",
+		"literal": "x",
+	}, scope)
+	want := map[string]any{"content": "doc body", "kind": "paper", "literal": "x"}
+	if !reflectDeepEqual(got, want) {
+		t.Errorf("object = %#v, want %#v", got, want)
+	}
+
+	// slice recurses
+	got, _ = resolveInput([]any{"${input.text}", "lit"}, scope)
+	if !reflectDeepEqual(got, []any{"doc body", "lit"}) {
+		t.Errorf("slice = %#v", got)
+	}
+
+	// unresolvable ref is an error
+	if _, err := resolveInput("${input.missing}", scope); err == nil {
+		t.Error("expected error for unresolvable ref")
+	}
+
+	// nil passes through
+	if got, err := resolveInput(nil, scope); err != nil || got != nil {
+		t.Errorf("nil = (%#v,%v)", got, err)
+	}
+}

--- a/runtime/composition/engine/scope_test.go
+++ b/runtime/composition/engine/scope_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -89,6 +90,22 @@ func TestResolveInput(t *testing.T) {
 	got, _ = resolveInput("type is ${classify.output.type}", scope)
 	if got != "type is paper" {
 		t.Errorf("interpolated = %#v", got)
+	}
+
+	// multiple embedded refs in one string, including a non-string value stringified
+	got, _ = resolveInput("${input.text} has id ${input.id}", scope)
+	if got != "doc body has id 7" {
+		t.Errorf("multi/typed interpolation = %#v, want %q", got, "doc body has id 7")
+	}
+
+	// multiple unresolvable embedded refs report all of them
+	if _, err := resolveInput("${input.nope} and ${input.also}", scope); err == nil {
+		t.Error("expected error for multiple unresolvable embedded refs")
+	} else {
+		msg := err.Error()
+		if !strings.Contains(msg, "input.nope") || !strings.Contains(msg, "input.also") {
+			t.Errorf("joined error should name both refs, got %q", msg)
+		}
 	}
 
 	// object combining literals + refs recurses

--- a/runtime/composition/engine/scope_test.go
+++ b/runtime/composition/engine/scope_test.go
@@ -1,0 +1,69 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripRef(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"${input.text}", "input.text", true},
+		{"${ classify.output.type }", "classify.output.type", true},
+		{"input.text", "", false}, // RFC Q4: ${...} wrapper required
+		{"prefix ${input.text}", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := stripRef(c.in)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("stripRef(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestResolvePath(t *testing.T) {
+	scope := Scope{
+		"input": map[string]any{"text": "hello", "n": float64(3)},
+		"classify": map[string]any{
+			"output": map[string]any{"type": "research_paper"},
+		},
+	}
+	cases := []struct {
+		ref    string
+		want   any
+		wantOK bool
+	}{
+		{"${input.text}", "hello", true},
+		{"${input.n}", float64(3), true},
+		{"${classify.output.type}", "research_paper", true},
+		{"${classify.output.missing}", nil, false},
+		{"${nope.output.x}", nil, false},
+		{"${input}", map[string]any{"text": "hello", "n": float64(3)}, true},
+		{"bare.path", nil, false},
+	}
+	for _, c := range cases {
+		got, ok := resolvePath(c.ref, scope)
+		if ok != c.wantOK {
+			t.Fatalf("resolvePath(%q) ok = %v, want %v", c.ref, ok, c.wantOK)
+		}
+		if ok && !deepEqualJSON(got, c.want) {
+			t.Errorf("resolvePath(%q) = %#v, want %#v", c.ref, got, c.want)
+		}
+	}
+}
+
+// deepEqualJSON compares two decoded-JSON values structurally.
+func deepEqualJSON(a, b any) bool {
+	return reflectDeepEqual(a, b)
+}
+
+// reflectDeepEqual is a thin wrapper over reflect.DeepEqual.
+// NOTE: when Task 5 adds engine_test.go, this definition must move to exactly
+// one place to avoid a redeclaration compile error.
+func reflectDeepEqual(a, b any) bool {
+	return reflect.DeepEqual(a, b)
+}


### PR DESCRIPTION
## Summary

Implements **Plan 2a** of RFC 0010 Workflow Composition: the pure, unit-testable orchestrator core in a new `runtime/composition/engine` package. Step side-effects (LLM/tool calls) sit behind an injected `StepExecutor`, so the package has **no dependency** on `runtime/pipeline` or `runtime/providers` — the production executor and `CompositionStage` wrapper land in Plan 2b.

Builds on Phase 1 (#1340), which shipped the leaf `runtime/composition` types + validation.

### What's here

| File | Responsibility |
|------|----------------|
| `scope.go` | `Scope`, `stripRef`, `resolvePath`, `resolveInput` — `${input.X}` / `${stepID.output.X}` reference resolution (RFC Q4: `${...}` wrapper required) |
| `predicate.go` | `evalPredicate` — constrained predicate language: 8 compare ops + `exists` + `all_of`/`any_of`/`not` |
| `reduce.go` | `NamedOutput`, `reduce` — `append` / `replace` / `barrier` reducers |
| `engine.go` | `Engine`, `New`, `Execute` — sequential array-order scheduler, branch routing + skip-propagation, `depends_on` joins, concurrent `parallel` (`errors.Join`), `retry` (honors `ctx` cancellation), output binding |

RFC fidelity spot-checked: Q1 (output defaults to last step), Q2 (sequential by array order, `depends_on` joins), Q4 (`${...}` required), Q8 (empty-`else` fall-through), and the step-scoped `${parallelId.output.into}` reducer exposure.

### Scope boundary

Deliberately **not** in this PR (Plan 2b): real LLM/tool execution, `CompositionStage`, `termination.tool_called` loop extension, eval-modifier wiring, hooks threading, SDK/Arena builder wiring. The `StepExecutor` func is the entire seam.

## Test Plan

- [x] `go test ./runtime/composition/engine/... -race -count=1` — green
- [x] `golangci-lint run ./runtime/composition/...` — 0 issues
- [x] 94% statement coverage, behavior-focused (fake-executor harness)
- [x] Cross-feature integration test: branch → parallel (per-branch retry) → `depends_on` join with skip-propagation → nested-scope ref → final output

Each task was reviewed for spec compliance and code quality before landing.

Part of #1333 (Phase 2 engine — CompositionStage + wiring follow in Plan 2b). Epic #1337.
