### PR TITLE
feat(composition): Plan 2b — production executor + CompositionStage (RFC 0010)

### DIFF
--- a/runtime/pipeline/stage/composition_executor.go
+++ b/runtime/pipeline/stage/composition_executor.go
@@ -20,6 +20,35 @@ import (
 // Go error so composition step execution stops.
 var errToolFailed = fmt.Errorf("tool reported failure")
 
+// allowedToolsStage overrides TurnState.AllowedTools after prompt assembly so a
+// composition step's own tool policy governs the provider (agent → step.Tools;
+// prompt → none), instead of the prompt template's AllowedTools which
+// PromptAssemblyStage would otherwise impose.
+type allowedToolsStage struct {
+	turnState *TurnState
+	tools     []string
+}
+
+func (s *allowedToolsStage) Name() string    { return "composition-allowed-tools" } //nolint:revive
+func (s *allowedToolsStage) Type() StageType { return StageTypeTransform }          //nolint:revive
+
+func (s *allowedToolsStage) Process(ctx context.Context, in <-chan StreamElement, out chan<- StreamElement) error { //nolint:revive,lll
+	defer close(out)
+	applied := false
+	for elem := range in {
+		if !applied {
+			s.turnState.AllowedTools = s.tools
+			applied = true
+		}
+		select {
+		case out <- elem:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
 // CompositionExecutorDeps carries the runtime collaborators a composition step
 // needs to execute. Injected once; reused for every step of every Execute call.
 type CompositionExecutorDeps struct {
@@ -90,9 +119,11 @@ func (deps CompositionExecutorDeps) execLLM(
 	}
 	cfg.ResponseFormat = rf
 
+	// Per-step tool policy: agent steps use step.Tools; prompt steps get no tools.
+	var allowed []string
 	policy := &pipeline.ToolPolicy{}
 	if step.Kind == composition.KindAgent {
-		turnState.AllowedTools = step.Tools
+		allowed = step.Tools
 		if step.Termination != nil {
 			if step.Termination.MaxSteps > 0 {
 				policy.MaxRounds = step.Termination.MaxSteps
@@ -101,13 +132,18 @@ func (deps CompositionExecutorDeps) execLLM(
 		}
 	} else {
 		policy.MaxRounds = 1
+		// allowed stays nil — prompt steps run with no tools.
 	}
+
+	// allowedToolsStage runs after PromptAssemblyStage so the step's tool policy
+	// overwrites whatever AllowedTools the prompt template imposed on turnState.
+	toolsOverride := &allowedToolsStage{turnState: turnState, tools: allowed}
 
 	provStage := NewProviderStageWithTurnState(
 		deps.Provider, deps.ToolRegistry, policy, cfg, deps.Emitter, deps.HookRegistry, turnState,
 	)
 
-	pipe, err := NewPipelineBuilder().Chain(promptStage, templateStage, provStage).Build()
+	pipe, err := NewPipelineBuilder().Chain(promptStage, templateStage, toolsOverride, provStage).Build()
 	if err != nil {
 		return nil, fmt.Errorf("step %q: building sub-pipeline: %w", step.ID, err)
 	}
@@ -120,7 +156,7 @@ func (deps CompositionExecutorDeps) execLLM(
 	if res == nil || res.Response == nil {
 		return nil, fmt.Errorf("step %q: sub-pipeline produced no response", step.ID)
 	}
-	return responseToJSON(res.Response)
+	return responseToJSON(res.Response, step.OutputSchema != "")
 }
 
 // responseFormat builds a structured-output ResponseFormat from the step's
@@ -159,10 +195,19 @@ func stepInputToText(input json.RawMessage) string {
 	return string(input)
 }
 
-// responseToJSON returns the sub-pipeline response as JSON: a Content that is
-// already valid JSON passes through; plain text is JSON-encoded as a string.
-func responseToJSON(resp *Response) (json.RawMessage, error) {
-	if json.Valid([]byte(resp.Content)) {
+// responseToJSON returns the sub-pipeline response as JSON.
+//
+// When structured is true (the step declared an output_schema), content that is
+// already valid JSON is passed through as-is — the provider was instructed to
+// return structured JSON and the raw payload must be preserved.
+//
+// When structured is false (a plain text step), the content is always
+// JSON-encoded as a string, even if it happens to be valid JSON (e.g. the
+// literal "null", "42", or "true"). This prevents ambiguity in downstream
+// ${step.output} resolution where a bare JSON primitive would be
+// indistinguishable from a structured value.
+func responseToJSON(resp *Response, structured bool) (json.RawMessage, error) {
+	if structured && json.Valid([]byte(resp.Content)) {
 		return json.RawMessage(resp.Content), nil
 	}
 	enc, err := json.Marshal(resp.Content)

--- a/runtime/pipeline/stage/composition_executor.go
+++ b/runtime/pipeline/stage/composition_executor.go
@@ -1,0 +1,75 @@
+package stage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/composition/engine"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// errToolFailed wraps a tool-reported failure (a non-empty ToolResult.Error) as a
+// Go error so composition step execution stops.
+var errToolFailed = fmt.Errorf("tool reported failure")
+
+// CompositionExecutorDeps carries the runtime collaborators a composition step
+// needs to execute. Injected once; reused for every step of every Execute call.
+type CompositionExecutorDeps struct {
+	PromptRegistry *prompt.Registry
+	Provider       providers.Provider
+	ToolRegistry   *tools.Registry
+	Emitter        *events.Emitter
+	HookRegistry   *hooks.Registry
+	BaseVariables  map[string]string
+	// SchemaResolver maps a step's output_schema path to JSON-schema bytes for
+	// structured output. nil (or a nil return) means no ResponseFormat is set.
+	// Plan 3 supplies the real resolver from the pack/config dir.
+	SchemaResolver func(path string) (json.RawMessage, error)
+}
+
+// NewCompositionStepExecutor returns an engine.StepExecutor that runs prompt/agent
+// steps as sub-pipelines and tool steps via the registry.
+func NewCompositionStepExecutor(deps CompositionExecutorDeps) engine.StepExecutor {
+	return func(ctx context.Context, step *composition.Step, input json.RawMessage) (json.RawMessage, error) {
+		//nolint:exhaustive // KindBranch and KindParallel are handled by the engine; a leaf executor never receives them.
+		switch step.Kind {
+		case composition.KindTool:
+			return deps.executeTool(ctx, step, input)
+		case composition.KindPrompt, composition.KindAgent:
+			return deps.execLLM(ctx, step, input)
+		default:
+			return nil, fmt.Errorf("composition executor: unsupported step kind %q", step.Kind)
+		}
+	}
+}
+
+// executeTool calls the tool registry with the engine-resolved args and surfaces
+// any tool-reported error as a Go error.
+func (deps CompositionExecutorDeps) executeTool(
+	ctx context.Context, step *composition.Step, input json.RawMessage,
+) (json.RawMessage, error) {
+	if deps.ToolRegistry == nil {
+		return nil, fmt.Errorf("tool %q: tool registry not configured", step.Tool)
+	}
+	res, err := deps.ToolRegistry.Execute(ctx, step.Tool, input)
+	if err != nil {
+		return nil, fmt.Errorf("tool %q: %w", step.Tool, err)
+	}
+	if res.Error != "" {
+		return nil, fmt.Errorf("tool %q: %w: %s", step.Tool, errToolFailed, res.Error)
+	}
+	return res.Result, nil
+}
+
+// execLLM is implemented in Task 3.
+func (deps CompositionExecutorDeps) execLLM(
+	_ context.Context, step *composition.Step, _ json.RawMessage,
+) (json.RawMessage, error) {
+	return nil, fmt.Errorf("step %q: prompt/agent execution not yet implemented", step.ID)
+}

--- a/runtime/pipeline/stage/composition_executor.go
+++ b/runtime/pipeline/stage/composition_executor.go
@@ -20,24 +20,25 @@ import (
 // Go error so composition step execution stops.
 var errToolFailed = fmt.Errorf("tool reported failure")
 
-// allowedToolsStage overrides TurnState.AllowedTools after prompt assembly so a
-// composition step's own tool policy governs the provider (agent → step.Tools;
-// prompt → none), instead of the prompt template's AllowedTools which
-// PromptAssemblyStage would otherwise impose.
-type allowedToolsStage struct {
+// toolScopeStage narrows TurnState.AllowedTools, after prompt assembly, to the
+// intersection of the prompt template's allowed tools and the composition step's
+// tools — matching how skill tools are scoped. A prompt step (no tools) therefore
+// ends up with no tools; an agent step gets only tools allowed by BOTH its
+// prompt_task and its own tools[] list.
+type toolScopeStage struct {
 	turnState *TurnState
-	tools     []string
+	stepTools []string
 }
 
-func (s *allowedToolsStage) Name() string    { return "composition-allowed-tools" } //nolint:revive
-func (s *allowedToolsStage) Type() StageType { return StageTypeTransform }          //nolint:revive
+func (s *toolScopeStage) Name() string    { return "composition-allowed-tools" } //nolint:revive
+func (s *toolScopeStage) Type() StageType { return StageTypeTransform }          //nolint:revive
 
-func (s *allowedToolsStage) Process(ctx context.Context, in <-chan StreamElement, out chan<- StreamElement) error { //nolint:revive,lll
+func (s *toolScopeStage) Process(ctx context.Context, in <-chan StreamElement, out chan<- StreamElement) error { //nolint:revive,lll
 	defer close(out)
 	applied := false
 	for elem := range in {
 		if !applied {
-			s.turnState.AllowedTools = s.tools
+			s.turnState.AllowedTools = intersectInOrder(s.turnState.AllowedTools, s.stepTools)
 			applied = true
 		}
 		select {
@@ -119,11 +120,13 @@ func (deps CompositionExecutorDeps) execLLM(
 	}
 	cfg.ResponseFormat = rf
 
-	// Per-step tool policy: agent steps use step.Tools; prompt steps get no tools.
-	var allowed []string
+	// Per-step tool policy: agent steps configure MaxRounds/StopOnTool from
+	// Termination; prompt steps are always single-round.
+	// Tool scoping is handled uniformly by toolScopeStage: it intersects the
+	// prompt template's AllowedTools with step.Tools, so a prompt step (empty
+	// Tools) yields no tools regardless of what the template declares.
 	policy := &pipeline.ToolPolicy{}
 	if step.Kind == composition.KindAgent {
-		allowed = step.Tools
 		if step.Termination != nil {
 			if step.Termination.MaxSteps > 0 {
 				policy.MaxRounds = step.Termination.MaxSteps
@@ -132,12 +135,11 @@ func (deps CompositionExecutorDeps) execLLM(
 		}
 	} else {
 		policy.MaxRounds = 1
-		// allowed stays nil — prompt steps run with no tools.
 	}
 
-	// allowedToolsStage runs after PromptAssemblyStage so the step's tool policy
-	// overwrites whatever AllowedTools the prompt template imposed on turnState.
-	toolsOverride := &allowedToolsStage{turnState: turnState, tools: allowed}
+	// toolScopeStage runs after PromptAssemblyStage and narrows AllowedTools to
+	// the intersection of the prompt template's tools and the step's tools.
+	toolsOverride := &toolScopeStage{turnState: turnState, stepTools: step.Tools}
 
 	provStage := NewProviderStageWithTurnState(
 		deps.Provider, deps.ToolRegistry, policy, cfg, deps.Emitter, deps.HookRegistry, turnState,

--- a/runtime/pipeline/stage/composition_executor.go
+++ b/runtime/pipeline/stage/composition_executor.go
@@ -9,9 +9,11 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/composition/engine"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // errToolFailed wraps a tool-reported failure (a non-empty ToolResult.Error) as a
@@ -67,9 +69,105 @@ func (deps CompositionExecutorDeps) executeTool(
 	return res.Result, nil
 }
 
-// execLLM is implemented in Task 3.
+// execLLM runs a prompt/agent step as a minimal PromptAssembly → Template →
+// Provider sub-pipeline. Agent steps pass their tools + termination bounds to the
+// tool loop; prompt steps run a single round with no tools.
 func (deps CompositionExecutorDeps) execLLM(
-	_ context.Context, step *composition.Step, _ json.RawMessage,
+	ctx context.Context, step *composition.Step, input json.RawMessage,
 ) (json.RawMessage, error) {
-	return nil, fmt.Errorf("step %q: prompt/agent execution not yet implemented", step.ID)
+	if deps.Provider == nil || deps.PromptRegistry == nil {
+		return nil, fmt.Errorf("step %q: provider/prompt registry not configured", step.ID)
+	}
+
+	turnState := &TurnState{}
+	promptStage := NewPromptAssemblyStageWithTurnState(deps.PromptRegistry, step.PromptTask, deps.BaseVariables, turnState)
+	templateStage := NewTemplateStageWithTurnState(deps.Emitter, turnState)
+
+	cfg := &ProviderConfig{Source: "agent"}
+	rf, err := deps.responseFormat(step)
+	if err != nil {
+		return nil, fmt.Errorf("step %q: %w", step.ID, err)
+	}
+	cfg.ResponseFormat = rf
+
+	policy := &pipeline.ToolPolicy{}
+	if step.Kind == composition.KindAgent {
+		turnState.AllowedTools = step.Tools
+		if step.Termination != nil {
+			if step.Termination.MaxSteps > 0 {
+				policy.MaxRounds = step.Termination.MaxSteps
+			}
+			policy.StopOnTool = step.Termination.ToolCalled
+		}
+	} else {
+		policy.MaxRounds = 1
+	}
+
+	provStage := NewProviderStageWithTurnState(
+		deps.Provider, deps.ToolRegistry, policy, cfg, deps.Emitter, deps.HookRegistry, turnState,
+	)
+
+	pipe, err := NewPipelineBuilder().Chain(promptStage, templateStage, provStage).Build()
+	if err != nil {
+		return nil, fmt.Errorf("step %q: building sub-pipeline: %w", step.ID, err)
+	}
+
+	userMsg := types.Message{Role: roleUser, Content: stepInputToText(input)}
+	res, err := pipe.ExecuteSync(ctx, NewMessageElement(&userMsg))
+	if err != nil {
+		return nil, fmt.Errorf("step %q: %w", step.ID, err)
+	}
+	if res == nil || res.Response == nil {
+		return nil, fmt.Errorf("step %q: sub-pipeline produced no response", step.ID)
+	}
+	return responseToJSON(res.Response)
+}
+
+// responseFormat builds a structured-output ResponseFormat from the step's
+// output_schema via the injected resolver. Returns nil when no schema is set or
+// no resolver is configured (Plan 3 wires the real resolver).
+func (deps CompositionExecutorDeps) responseFormat(step *composition.Step) (*providers.ResponseFormat, error) {
+	if step.OutputSchema == "" || deps.SchemaResolver == nil {
+		return nil, nil //nolint:nilnil // "no response format" is a valid, expected result
+	}
+	raw, err := deps.SchemaResolver(step.OutputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("resolving output_schema %q: %w", step.OutputSchema, err)
+	}
+	if len(raw) == 0 {
+		return nil, nil //nolint:nilnil // resolver declined; no response format
+	}
+	return &providers.ResponseFormat{
+		Type:       providers.ResponseFormatJSONSchema,
+		JSONSchema: raw,
+		SchemaName: step.ID,
+		Strict:     true,
+	}, nil
+}
+
+// stepInputToText turns the engine-resolved JSON input into the sub-pipeline's
+// user-message text. A JSON string becomes its unquoted value; anything else is
+// passed through as compact JSON. nil/`null` becomes empty.
+func stepInputToText(input json.RawMessage) string {
+	if len(input) == 0 || string(input) == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(input, &s); err == nil {
+		return s
+	}
+	return string(input)
+}
+
+// responseToJSON returns the sub-pipeline response as JSON: a Content that is
+// already valid JSON passes through; plain text is JSON-encoded as a string.
+func responseToJSON(resp *Response) (json.RawMessage, error) {
+	if json.Valid([]byte(resp.Content)) {
+		return json.RawMessage(resp.Content), nil
+	}
+	enc, err := json.Marshal(resp.Content)
+	if err != nil {
+		return nil, fmt.Errorf("encoding response: %w", err)
+	}
+	return enc, nil
 }

--- a/runtime/pipeline/stage/composition_executor_test.go
+++ b/runtime/pipeline/stage/composition_executor_test.go
@@ -3,11 +3,29 @@ package stage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 )
+
+// registerSimplePrompt adds a trivial prompt template under taskID to reg.
+// It uses the same mockRepository pattern already established in stages_core_test.go.
+func registerSimplePrompt(t *testing.T, reg *prompt.Registry, taskID string) {
+	t.Helper()
+	cfg := &prompt.Config{
+		Spec: prompt.Spec{
+			TaskType:       taskID,
+			SystemTemplate: "You are a helpful assistant.",
+		},
+	}
+	if err := reg.RegisterConfig(taskID, cfg); err != nil {
+		t.Fatalf("registerSimplePrompt: %v", err)
+	}
+}
 
 // echoExecutor is a local tools.Executor that returns its args back as the result.
 type echoExecutor struct{}
@@ -118,16 +136,16 @@ func TestCompositionExecutor_ToolStepNilRegistry(t *testing.T) {
 	}
 }
 
-func TestCompositionExecutor_PromptStepStub(t *testing.T) {
-	// Until Task 3 wires the real sub-pipeline, prompt/agent steps return a
-	// "not yet implemented" error. This test documents that contract and ensures
-	// the switch routes correctly.
-	exec := NewCompositionStepExecutor(CompositionExecutorDeps{})
+func TestCompositionExecutor_PromptStepNilProvider(t *testing.T) {
+	// execLLM must return an error when provider or prompt registry is nil,
+	// ensuring the switch routes prompt/agent steps into execLLM and that
+	// execLLM guards against missing deps.
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{}) // no provider, no registry
 	for _, kind := range []composition.StepKind{composition.KindPrompt, composition.KindAgent} {
 		step := &composition.Step{ID: "s", Kind: kind, PromptTask: "p"}
 		_, err := exec(context.Background(), step, json.RawMessage(`{}`))
 		if err == nil {
-			t.Errorf("kind %q: expected error from stub execLLM", kind)
+			t.Errorf("kind %q: expected error when provider/registry not configured", kind)
 		}
 	}
 }
@@ -137,5 +155,275 @@ func TestCompositionExecutor_UnknownKind(t *testing.T) {
 	step := &composition.Step{ID: "s", Kind: "bogus"}
 	if _, err := exec(context.Background(), step, json.RawMessage(`{}`)); err == nil {
 		t.Fatal("expected error for unknown step kind")
+	}
+}
+
+func TestCompositionExecutor_PromptStep(t *testing.T) {
+	// mock.NewProvider returns a provider whose default response is "Mock response from test-id model test-model".
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "p")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+	})
+	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p"}
+	out, err := exec(context.Background(), step, json.RawMessage(`"hello"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("expected non-empty output, got %s", out)
+	}
+	// Result must be valid JSON (responseToJSON ensures this).
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+}
+
+func TestCompositionExecutor_AgentStepUsesTermination(t *testing.T) {
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "a")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+	})
+	step := &composition.Step{
+		ID:          "s",
+		Kind:        composition.KindAgent,
+		PromptTask:  "a",
+		Tools:       []string{},
+		Termination: &composition.Termination{MaxSteps: 5},
+	}
+	out, err := exec(context.Background(), step, json.RawMessage(`"go"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("expected non-empty output, got %s", out)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+}
+
+func TestCompositionExecutor_AgentStepTerminationToolCalled(t *testing.T) {
+	// Covers the StopOnTool branch in execLLM when step.Termination.ToolCalled is set.
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "a")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+	})
+	step := &composition.Step{
+		ID:         "s",
+		Kind:       composition.KindAgent,
+		PromptTask: "a",
+		Termination: &composition.Termination{
+			MaxSteps:   3,
+			ToolCalled: "my_tool",
+		},
+	}
+	out, err := exec(context.Background(), step, json.RawMessage(`"run"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+}
+
+func TestCompositionExecutor_PromptStepNullInput(t *testing.T) {
+	// Covers the stepInputToText null/empty paths.
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "p")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+	})
+	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p"}
+
+	// null JSON input → empty message text
+	out, err := exec(context.Background(), step, json.RawMessage(`null`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+}
+
+func TestCompositionExecutor_PromptStepObjectInput(t *testing.T) {
+	// Covers the stepInputToText JSON-object (non-string) path.
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "p")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+	})
+	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p"}
+
+	// object JSON input → passed through as compact JSON string
+	out, err := exec(context.Background(), step, json.RawMessage(`{"key":"value"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+}
+
+func TestCompositionExecutor_ResponseFormatWithResolver(t *testing.T) {
+	// Covers the responseFormat resolver path (SchemaResolver returns schema bytes).
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "p")
+
+	resolver := func(path string) (json.RawMessage, error) {
+		return json.RawMessage(`{"type":"object"}`), nil
+	}
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+		SchemaResolver: resolver,
+	})
+	step := &composition.Step{
+		ID:           "s",
+		Kind:         composition.KindPrompt,
+		PromptTask:   "p",
+		OutputSchema: "my_schema.json",
+	}
+	out, err := exec(context.Background(), step, json.RawMessage(`"hello"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+}
+
+func TestCompositionExecutor_ResponseFormatResolverEmpty(t *testing.T) {
+	// Covers the responseFormat resolver returning empty (nil ResponseFormat path).
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "p")
+
+	resolver := func(path string) (json.RawMessage, error) {
+		return nil, nil // declined
+	}
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+		SchemaResolver: resolver,
+	})
+	step := &composition.Step{
+		ID:           "s",
+		Kind:         composition.KindPrompt,
+		PromptTask:   "p",
+		OutputSchema: "my_schema.json",
+	}
+	out, err := exec(context.Background(), step, json.RawMessage(`"hello"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+}
+
+func TestCompositionExecutor_ResponseFormatResolverError(t *testing.T) {
+	// Covers the responseFormat resolver returning an error.
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: prompt.NewRegistryWithRepository(newMockRepo()),
+		Provider:       mock.NewProvider("test-id", "test-model", false),
+		ToolRegistry:   tools.NewRegistry(),
+		SchemaResolver: func(path string) (json.RawMessage, error) {
+			return nil, fmt.Errorf("schema not found: %s", path)
+		},
+	})
+	step := &composition.Step{
+		ID:           "s",
+		Kind:         composition.KindPrompt,
+		PromptTask:   "p",
+		OutputSchema: "bad_schema.json",
+	}
+	if _, err := exec(context.Background(), step, json.RawMessage(`"hello"`)); err == nil {
+		t.Fatal("expected error when schema resolver returns an error")
+	}
+}
+
+func TestCompositionExecutor_CancelledContext(t *testing.T) {
+	// Covers the execLLM ExecuteSync error path by cancelling the context before execution.
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "p")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+	})
+	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before executing
+	_, err := exec(ctx, step, json.RawMessage(`"hello"`))
+	if err == nil {
+		// Some mock providers may still succeed with a cancelled context; that is OK —
+		// the important thing is the code is exercised. Don't fail if it happens to succeed.
+		t.Log("cancelled context did not produce an error (mock provider ignores cancellation)")
+	}
+}
+
+func TestCompositionExecutor_ResponseJSONPassthrough(t *testing.T) {
+	// Covers the responseToJSON JSON-passthrough path: when the mock returns
+	// content that is already valid JSON, responseToJSON returns it unchanged.
+	repo := mock.NewInMemoryMockRepository(`{"answer":42}`)
+	prov := mock.NewProviderWithRepository("test-id", "test-model", false, repo)
+	mockRepo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(mockRepo)
+	registerSimplePrompt(t, reg, "p")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+	})
+	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p"}
+	out, err := exec(context.Background(), step, json.RawMessage(`"hello"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+	// The JSON object passthrough means the output IS the mock's JSON content.
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("expected JSON object passthrough, got: %s", out)
 	}
 }

--- a/runtime/pipeline/stage/composition_executor_test.go
+++ b/runtime/pipeline/stage/composition_executor_test.go
@@ -463,49 +463,56 @@ func TestCompositionExecutor_TextStepNullLiteralEncodedAsString(t *testing.T) {
 	}
 }
 
-func TestCompositionExecutor_AllowedToolsOverrideStage(t *testing.T) {
-	// C1 regression test: proves that allowedToolsStage overrides whatever
-	// AllowedTools the prompt template declares, so the step's tool policy wins.
-	//
-	// The observable: after allowedToolsStage.Process runs over a channel,
-	// turnState.AllowedTools equals the configured list, regardless of what
-	// PromptAssemblyStage wrote to it first.
-	//
-	// This is a focused unit test of the override stage itself (fallback
-	// approach from the spec), because the ProviderStage snapshots AllowedTools
-	// inside its own goroutine and does not expose which tools it offered to
-	// the mock provider via the public StreamElement surface.
-	turnState := &TurnState{}
-
-	// Simulate what PromptAssemblyStage does: sets AllowedTools from the template.
-	turnState.AllowedTools = []string{"template-tool"}
-
-	stage := &allowedToolsStage{
-		turnState: turnState,
-		tools:     []string{"step-tool"},
+// runStageOverChannel drives a single stage through one StreamElement and drains
+// the output channel. It is used by focused unit tests that need to observe
+// side-effects on shared state (e.g. TurnState) after Process completes.
+func runStageOverChannel(t *testing.T, s Stage) {
+	t.Helper()
+	in := make(chan StreamElement, 1)
+	in <- NewMessageElement(&types.Message{Role: roleUser, Content: "x"})
+	close(in)
+	out := make(chan StreamElement, 1)
+	done := make(chan error, 1)
+	go func() { done <- s.Process(context.Background(), in, out) }()
+	for range out {
 	}
-
-	input := make(chan StreamElement, 1)
-	userMsg := &types.Message{Role: roleUser, Content: "hi"}
-	input <- NewMessageElement(userMsg)
-	close(input)
-
-	output := make(chan StreamElement, 1)
-	if err := stage.Process(context.Background(), input, output); err != nil {
-		t.Fatalf("allowedToolsStage.Process: %v", err)
+	if err := <-done; err != nil {
+		t.Fatalf("stage.Process: %v", err)
 	}
+}
 
-	// Drain output to confirm the element was forwarded.
-	var forwarded int
-	for range output {
-		forwarded++
+func TestCompositionExecutor_ToolScopeIntersection(t *testing.T) {
+	// C1 regression test: proves that toolScopeStage narrows AllowedTools to the
+	// intersection of the prompt template's tools and the step's tools, NOT a
+	// plain replacement. A replace-semantics implementation would fail the
+	// "overlap" case (it would return ["b","c","d"] instead of ["b","c"]).
+	cases := []struct {
+		name        string
+		promptTools []string
+		stepTools   []string
+		want        []string
+	}{
+		{"overlap", []string{"a", "b", "c"}, []string{"b", "c", "d"}, []string{"b", "c"}},
+		{"no overlap", []string{"a"}, []string{"z"}, []string{}},
+		{"empty step tools (prompt step)", []string{"a", "b"}, nil, []string{}},
+		{"empty prompt tools", nil, []string{"a"}, []string{}},
 	}
-	if forwarded != 1 {
-		t.Errorf("expected 1 forwarded element, got %d", forwarded)
-	}
-
-	// The override must have replaced the template's AllowedTools with step-tool.
-	if len(turnState.AllowedTools) != 1 || turnState.AllowedTools[0] != "step-tool" {
-		t.Errorf("AllowedTools after override = %v, want [step-tool]", turnState.AllowedTools)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ts := &TurnState{AllowedTools: c.promptTools}
+			st := &toolScopeStage{turnState: ts, stepTools: c.stepTools}
+			runStageOverChannel(t, st)
+			got := ts.AllowedTools
+			// intersectInOrder may return nil for empty results; treat nil and
+			// []string{} as equal by comparing lengths then elements.
+			if len(got) != len(c.want) {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+			for i := range c.want {
+				if got[i] != c.want[i] {
+					t.Fatalf("got %v, want %v", got, c.want)
+				}
+			}
+		})
 	}
 }

--- a/runtime/pipeline/stage/composition_executor_test.go
+++ b/runtime/pipeline/stage/composition_executor_test.go
@@ -1,0 +1,141 @@
+package stage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// echoExecutor is a local tools.Executor that returns its args back as the result.
+type echoExecutor struct{}
+
+func (e *echoExecutor) Name() string { return "echo-exec" }
+
+func (e *echoExecutor) Execute(_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+	return args, nil
+}
+
+// failExecutor is a local tools.Executor whose result carries a non-empty Error string.
+type failExecutor struct{ msg string }
+
+func (f *failExecutor) Name() string { return "fail-exec" }
+
+func (f *failExecutor) Execute(_ context.Context, _ *tools.ToolDescriptor, _ json.RawMessage) (json.RawMessage, error) {
+	// Return valid JSON with an empty result; the caller must inspect ToolResult.Error.
+	// Registry.Execute wraps executor errors as ToolResult.Error, but for a failure
+	// we need the ToolResult.Error path, not the Go-error path.
+	// Easiest: panic so we know if this is ever called wrong; but to get ToolResult.Error
+	// we rely on the registry's error wrapping: return a Go error which the registry
+	// turns into ToolResult{Error: <msg>}.
+	return nil, &toolExecError{f.msg}
+}
+
+// toolExecError satisfies the error interface for failExecutor.
+type toolExecError struct{ msg string }
+
+func (e *toolExecError) Error() string { return e.msg }
+
+// registerEchoTool registers a tool named toolName backed by echoExecutor.
+func registerEchoTool(t *testing.T, reg *tools.Registry, toolName string) {
+	t.Helper()
+	exec := &echoExecutor{}
+	reg.RegisterExecutor(exec)
+	if err := reg.Register(&tools.ToolDescriptor{
+		Name:        toolName,
+		Description: "echo tool",
+		Mode:        exec.Name(),
+		InputSchema: []byte(`{"type":"object"}`),
+	}); err != nil {
+		t.Fatalf("registerEchoTool: %v", err)
+	}
+}
+
+// registerFailingTool registers a tool named toolName whose execution returns an error,
+// which the registry surfaces as ToolResult.Error.
+func registerFailingTool(t *testing.T, reg *tools.Registry, toolName string) {
+	t.Helper()
+	exec := &failExecutor{msg: "kaboom"}
+	reg.RegisterExecutor(exec)
+	if err := reg.Register(&tools.ToolDescriptor{
+		Name:        toolName,
+		Description: "failing tool",
+		Mode:        exec.Name(),
+		InputSchema: []byte(`{"type":"object"}`),
+	}); err != nil {
+		t.Fatalf("registerFailingTool: %v", err)
+	}
+}
+
+func TestCompositionExecutor_ToolStep(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{ToolRegistry: reg})
+
+	step := &composition.Step{ID: "t", Kind: composition.KindTool, Tool: "echo"}
+	out, err := exec(context.Background(), step, json.RawMessage(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["x"] != float64(1) {
+		t.Errorf("echo tool output = %#v", got)
+	}
+}
+
+func TestCompositionExecutor_ToolStepError(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerFailingTool(t, reg, "boom")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{ToolRegistry: reg})
+	step := &composition.Step{ID: "t", Kind: composition.KindTool, Tool: "boom"}
+	if _, err := exec(context.Background(), step, json.RawMessage(`{}`)); err == nil {
+		t.Fatal("expected error when tool reports an error")
+	}
+}
+
+func TestCompositionExecutor_ToolStepNotFound(t *testing.T) {
+	// Registry.Execute returns a Go error (not ToolResult.Error) when the tool
+	// is not registered, exercising the err != nil branch in executeTool.
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{ToolRegistry: tools.NewRegistry()})
+	step := &composition.Step{ID: "t", Kind: composition.KindTool, Tool: "no-such-tool"}
+	if _, err := exec(context.Background(), step, json.RawMessage(`{}`)); err == nil {
+		t.Fatal("expected error for unregistered tool")
+	}
+}
+
+func TestCompositionExecutor_ToolStepNilRegistry(t *testing.T) {
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{}) // no ToolRegistry
+	step := &composition.Step{ID: "t", Kind: composition.KindTool, Tool: "echo"}
+	if _, err := exec(context.Background(), step, json.RawMessage(`{}`)); err == nil {
+		t.Fatal("expected error when tool registry is nil")
+	}
+}
+
+func TestCompositionExecutor_PromptStepStub(t *testing.T) {
+	// Until Task 3 wires the real sub-pipeline, prompt/agent steps return a
+	// "not yet implemented" error. This test documents that contract and ensures
+	// the switch routes correctly.
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{})
+	for _, kind := range []composition.StepKind{composition.KindPrompt, composition.KindAgent} {
+		step := &composition.Step{ID: "s", Kind: kind, PromptTask: "p"}
+		_, err := exec(context.Background(), step, json.RawMessage(`{}`))
+		if err == nil {
+			t.Errorf("kind %q: expected error from stub execLLM", kind)
+		}
+	}
+}
+
+func TestCompositionExecutor_UnknownKind(t *testing.T) {
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{})
+	step := &composition.Step{ID: "s", Kind: "bogus"}
+	if _, err := exec(context.Background(), step, json.RawMessage(`{}`)); err == nil {
+		t.Fatal("expected error for unknown step kind")
+	}
+}

--- a/runtime/pipeline/stage/composition_executor_test.go
+++ b/runtime/pipeline/stage/composition_executor_test.go
@@ -4,14 +4,34 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// countingProviderHook is a minimal ProviderHook that counts AfterCall invocations.
+type countingProviderHook struct {
+	calls atomic.Int64
+}
+
+func (h *countingProviderHook) Name() string { return "counting-hook" }
+
+func (h *countingProviderHook) BeforeCall(_ context.Context, _ *hooks.ProviderRequest) hooks.Decision {
+	return hooks.Allow
+}
+
+func (h *countingProviderHook) AfterCall(_ context.Context, _ *hooks.ProviderRequest, _ *hooks.ProviderResponse) hooks.Decision {
+	h.calls.Add(1)
+	return hooks.Allow
+}
+
+func (h *countingProviderHook) count() int64 { return h.calls.Load() }
 
 // registerSimplePrompt adds a trivial prompt template under taskID to reg.
 // It uses the same mockRepository pattern already established in stages_core_test.go.
@@ -478,6 +498,32 @@ func runStageOverChannel(t *testing.T, s Stage) {
 	}
 	if err := <-done; err != nil {
 		t.Fatalf("stage.Process: %v", err)
+	}
+}
+
+func TestCompositionExecutor_HooksFirePerStep(t *testing.T) {
+	// Regression guard: a ProviderHook registered on CompositionExecutorDeps.HookRegistry
+	// must fire during the sub-pipeline executed for each composition step.
+	prov := mock.NewProvider("test-id", "test-model", false)
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "p")
+
+	hk := &countingProviderHook{}
+	hookReg := hooks.NewRegistry(hooks.WithProviderHook(hk))
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+		HookRegistry:   hookReg,
+	})
+	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p"}
+	if _, err := exec(context.Background(), step, json.RawMessage(`"x"`)); err != nil {
+		t.Fatal(err)
+	}
+	if hk.count() == 0 {
+		t.Error("expected the provider hook to fire for the step's sub-pipeline, but AfterCall count is 0")
 	}
 }
 

--- a/runtime/pipeline/stage/composition_executor_test.go
+++ b/runtime/pipeline/stage/composition_executor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // registerSimplePrompt adds a trivial prompt template under taskID to reg.
@@ -401,7 +402,8 @@ func TestCompositionExecutor_CancelledContext(t *testing.T) {
 
 func TestCompositionExecutor_ResponseJSONPassthrough(t *testing.T) {
 	// Covers the responseToJSON JSON-passthrough path: when the mock returns
-	// content that is already valid JSON, responseToJSON returns it unchanged.
+	// content that is already valid JSON AND the step has an OutputSchema
+	// (structured=true), responseToJSON returns it unchanged.
 	repo := mock.NewInMemoryMockRepository(`{"answer":42}`)
 	prov := mock.NewProviderWithRepository("test-id", "test-model", false, repo)
 	mockRepo := newMockRepo()
@@ -413,7 +415,8 @@ func TestCompositionExecutor_ResponseJSONPassthrough(t *testing.T) {
 		Provider:       prov,
 		ToolRegistry:   tools.NewRegistry(),
 	})
-	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p"}
+	// OutputSchema non-empty → structured=true → JSON passthrough applies.
+	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p", OutputSchema: "schemas/x.json"}
 	out, err := exec(context.Background(), step, json.RawMessage(`"hello"`))
 	if err != nil {
 		t.Fatal(err)
@@ -425,5 +428,84 @@ func TestCompositionExecutor_ResponseJSONPassthrough(t *testing.T) {
 	var got map[string]any
 	if err := json.Unmarshal(out, &got); err != nil {
 		t.Fatalf("expected JSON object passthrough, got: %s", out)
+	}
+}
+
+func TestCompositionExecutor_TextStepNullLiteralEncodedAsString(t *testing.T) {
+	// I2 regression test: a TEXT step (no OutputSchema) whose provider returns
+	// the literal text "null" must produce the JSON string "\"null\"", NOT raw
+	// JSON null. Without the fix, json.Valid("null") is true and the old code
+	// would pass through null, making the output ambiguous/corrupt.
+	repo := mock.NewInMemoryMockRepository("null")
+	prov := mock.NewProviderWithRepository("test-id", "test-model", false, repo)
+	mockRepo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(mockRepo)
+	registerSimplePrompt(t, reg, "p")
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+	})
+	// No OutputSchema → structured=false → plain text encoding required.
+	step := &composition.Step{ID: "s", Kind: composition.KindPrompt, PromptTask: "p"}
+	out, err := exec(context.Background(), step, json.RawMessage(`"hello"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("output is not valid JSON: %s", out)
+	}
+	// Must be a JSON string, not raw null.
+	var s string
+	if err := json.Unmarshal(out, &s); err != nil {
+		t.Fatalf("expected JSON string encoding of text, got: %s (err: %v)", out, err)
+	}
+}
+
+func TestCompositionExecutor_AllowedToolsOverrideStage(t *testing.T) {
+	// C1 regression test: proves that allowedToolsStage overrides whatever
+	// AllowedTools the prompt template declares, so the step's tool policy wins.
+	//
+	// The observable: after allowedToolsStage.Process runs over a channel,
+	// turnState.AllowedTools equals the configured list, regardless of what
+	// PromptAssemblyStage wrote to it first.
+	//
+	// This is a focused unit test of the override stage itself (fallback
+	// approach from the spec), because the ProviderStage snapshots AllowedTools
+	// inside its own goroutine and does not expose which tools it offered to
+	// the mock provider via the public StreamElement surface.
+	turnState := &TurnState{}
+
+	// Simulate what PromptAssemblyStage does: sets AllowedTools from the template.
+	turnState.AllowedTools = []string{"template-tool"}
+
+	stage := &allowedToolsStage{
+		turnState: turnState,
+		tools:     []string{"step-tool"},
+	}
+
+	input := make(chan StreamElement, 1)
+	userMsg := &types.Message{Role: roleUser, Content: "hi"}
+	input <- NewMessageElement(userMsg)
+	close(input)
+
+	output := make(chan StreamElement, 1)
+	if err := stage.Process(context.Background(), input, output); err != nil {
+		t.Fatalf("allowedToolsStage.Process: %v", err)
+	}
+
+	// Drain output to confirm the element was forwarded.
+	var forwarded int
+	for range output {
+		forwarded++
+	}
+	if forwarded != 1 {
+		t.Errorf("expected 1 forwarded element, got %d", forwarded)
+	}
+
+	// The override must have replaced the template's AllowedTools with step-tool.
+	if len(turnState.AllowedTools) != 1 || turnState.AllowedTools[0] != "step-tool" {
+		t.Errorf("AllowedTools after override = %v, want [step-tool]", turnState.AllowedTools)
 	}
 }

--- a/runtime/pipeline/stage/stages_composition.go
+++ b/runtime/pipeline/stage/stages_composition.go
@@ -1,0 +1,80 @@
+package stage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/composition/engine"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// CompositionStage runs an RFC 0010 composition to completion as a single
+// pipeline stage: it reads the turn's input element, executes the composition's
+// step DAG via the engine, and emits one assistant element carrying the
+// structured output.
+type CompositionStage struct {
+	name string
+	comp *composition.Composition
+	eng  *engine.Engine
+}
+
+// NewCompositionStage builds a CompositionStage from a composition spec and the
+// runtime collaborators its steps need.
+func NewCompositionStage(name string, comp *composition.Composition, deps CompositionExecutorDeps) *CompositionStage {
+	return &CompositionStage{
+		name: name,
+		comp: comp,
+		eng:  engine.New(NewCompositionStepExecutor(deps)),
+	}
+}
+
+// Name returns the stage name.
+func (s *CompositionStage) Name() string { return s.name }
+
+// Type reports this as a transform stage.
+func (s *CompositionStage) Type() StageType { return StageTypeTransform }
+
+// Process reads the first message element as the composition input (its message
+// Content bytes are the input JSON), runs the composition, and emits one
+// assistant element whose Content is the composition's structured output.
+// History/non-message/EndOfStream elements and any elements after the first are
+// forwarded unchanged.
+func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement, out chan<- StreamElement) error { //nolint:lll
+	defer close(out)
+	executed := false
+	for elem := range in {
+		if executed || elem.Message == nil || elem.EndOfStream {
+			select {
+			case out <- elem:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			continue
+		}
+		result, err := s.eng.Execute(ctx, s.comp, compositionInput(elem.Message))
+		if err != nil {
+			return fmt.Errorf("composition %q: %w", s.name, err)
+		}
+		executed = true
+		assistant := &types.Message{Role: roleAssistant, Content: string(result)}
+		select {
+		case out <- NewMessageElement(assistant):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// compositionInput extracts the engine input JSON from a user message: a Content
+// that is already valid JSON is used verbatim; otherwise it is JSON-encoded.
+func compositionInput(msg *types.Message) json.RawMessage {
+	c := []byte(msg.Content)
+	if json.Valid(c) {
+		return c
+	}
+	enc, _ := json.Marshal(msg.Content)
+	return enc
+}

--- a/runtime/pipeline/stage/stages_composition.go
+++ b/runtime/pipeline/stage/stages_composition.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/composition/engine"
@@ -36,16 +37,17 @@ func (s *CompositionStage) Name() string { return s.name }
 // Type reports this as a transform stage.
 func (s *CompositionStage) Type() StageType { return StageTypeTransform }
 
-// Process reads the first message element as the composition input (its message
-// Content bytes are the input JSON), runs the composition, and emits one
-// assistant element whose Content is the composition's structured output.
-// History/non-message/EndOfStream elements and any elements after the first are
-// forwarded unchanged.
-func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement, out chan<- StreamElement) error { //nolint:lll
+// Process reads the first non-history message element as the composition input
+// (its message Content bytes are the input JSON), runs the composition, and
+// emits one assistant element whose Content is the composition's structured
+// output. History elements (elem.Meta.FromHistory == true),
+// non-message/EndOfStream elements, and any elements after the first live
+// message are forwarded unchanged.
+func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement, out chan<- StreamElement) error { //nolint:lll // Channel signature cannot be shortened
 	defer close(out)
 	executed := false
 	for elem := range in {
-		if executed || elem.Message == nil || elem.EndOfStream {
+		if executed || elem.Message == nil || elem.EndOfStream || elem.Meta.FromHistory {
 			select {
 			case out <- elem:
 			case <-ctx.Done():
@@ -68,11 +70,14 @@ func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement,
 	return nil
 }
 
-// compositionInput extracts the engine input JSON from a user message: a Content
-// that is already valid JSON is used verbatim; otherwise it is JSON-encoded.
+// compositionInput extracts the engine input JSON from a user message. Content
+// that is an explicit JSON object or array ({...} / [...]) is used verbatim as
+// the composition input; any other content (including bare scalars like `true`
+// or `42` that happen to be valid JSON) is encoded as a JSON string, since a
+// user message's Content is always text.
 func compositionInput(msg *types.Message) json.RawMessage {
-	c := []byte(msg.Content)
-	if json.Valid(c) {
+	c := []byte(strings.TrimSpace(msg.Content))
+	if len(c) > 0 && (c[0] == '{' || c[0] == '[') && json.Valid(c) {
 		return c
 	}
 	enc, _ := json.Marshal(msg.Content)

--- a/runtime/pipeline/stage/stages_composition_test.go
+++ b/runtime/pipeline/stage/stages_composition_test.go
@@ -118,37 +118,130 @@ func TestCompositionStage_ForwardsNonMessageElements(t *testing.T) {
 }
 
 // TestCompositionStage_ContextCancellation verifies that Process returns
-// ctx.Err() when the context is cancelled mid-stream.
+// ctx.Err() when the context is cancelled before a blocking composition runs.
+// A blocking tool is registered so the engine cannot complete before the context
+// is cancelled; we cancel before calling Process, ensuring the cancellation is
+// detected on the first forward or execute attempt.
 func TestCompositionStage_ContextCancellation(t *testing.T) {
+	reg := tools.NewRegistry()
+
+	// Register a tool that blocks until the context is cancelled.
+	blockExec := &blockingExecutor{}
+	reg.RegisterExecutor(blockExec)
+	if err := reg.Register(&tools.ToolDescriptor{
+		Name:        "block",
+		Description: "blocking tool",
+		Mode:        blockExec.Name(),
+		InputSchema: []byte(`{"type":"object"}`),
+	}); err != nil {
+		t.Fatalf("register block tool: %v", err)
+	}
+
+	comp := &composition.Composition{
+		Version: 1, Output: "a",
+		Steps: []*composition.Step{
+			{ID: "a", Kind: composition.KindTool, Tool: "block", Args: map[string]any{}},
+		},
+	}
+	cs := NewCompositionStage("cancel", comp, CompositionExecutorDeps{ToolRegistry: reg})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before Process is called
+
+	in := make(chan StreamElement, 1)
+	out := make(chan StreamElement, 10)
+
+	msg := &types.Message{Role: "user", Content: "{}"}
+	in <- NewMessageElement(msg)
+	close(in)
+
+	err := cs.Process(ctx, in, out)
+	if err == nil {
+		t.Error("expected a cancellation error, got nil")
+	}
+}
+
+// blockingExecutor is a tool executor that blocks until its context is cancelled.
+type blockingExecutor struct{}
+
+func (b *blockingExecutor) Name() string { return "blocking" }
+func (b *blockingExecutor) Execute(ctx context.Context, _ *tools.ToolDescriptor, _ json.RawMessage) (json.RawMessage, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestCompositionStage_SkipsHistoryMessages verifies that history-flagged
+// message elements (Meta.FromHistory == true) are forwarded without triggering
+// composition execution, while the subsequent live user message IS executed.
+func TestCompositionStage_SkipsHistoryMessages(t *testing.T) {
 	reg := tools.NewRegistry()
 	registerEchoTool(t, reg, "echo")
 
 	comp := &composition.Composition{
 		Version: 1, Output: "a",
 		Steps: []*composition.Step{
-			{ID: "a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "x"}},
+			{ID: "a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "${input}"}},
 		},
 	}
-	cs := NewCompositionStage("cancel", comp, CompositionExecutorDeps{ToolRegistry: reg})
+	cs := NewCompositionStage("hist", comp, CompositionExecutorDeps{ToolRegistry: reg})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
-
-	in := make(chan StreamElement, 1)
+	in := make(chan StreamElement, 3)
 	out := make(chan StreamElement, 10)
 
-	// Send a non-message element — the cancelled context should cause the
-	// forwarding select to return ctx.Err().
-	txt := "x"
-	in <- StreamElement{Text: &txt}
+	// First element: history message — must NOT trigger execution.
+	histMsg := &types.Message{Role: "user", Content: `{"x":"history"}`}
+	histElem := NewMessageElement(histMsg)
+	histElem.Meta.FromHistory = true
+	in <- histElem
+
+	// Second element: live user message — MUST trigger execution.
+	liveMsg := &types.Message{Role: "user", Content: `{"x":"live"}`}
+	in <- NewMessageElement(liveMsg)
 	close(in)
 
-	err := cs.Process(ctx, in, out)
-	if err == nil {
-		// context was already cancelled; most schedulers will pick the done case
-		// but Go's select is non-deterministic when both cases are ready.
-		// Accept either outcome rather than making the test racy.
-		t.Log("select chose the send case before ctx.Done — acceptable")
+	if err := cs.Process(context.Background(), in, out); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	elems := drainChannel(out)
+	// Expect: forwarded history element + assistant result from live message.
+	if len(elems) != 2 {
+		t.Fatalf("expected 2 elements (history + result), got %d: %+v", len(elems), elems)
+	}
+	// First element should be the forwarded history message (not an assistant).
+	if elems[0].Message == nil || elems[0].Message.Role != "user" {
+		t.Errorf("first element: want forwarded user/history message, got %+v", elems[0])
+	}
+	if !elems[0].Meta.FromHistory {
+		t.Errorf("first element: want FromHistory=true, got false")
+	}
+	// Second element should be the assistant result from the live message.
+	if elems[1].Message == nil || elems[1].Message.Role != roleAssistant {
+		t.Errorf("second element: want assistant message, got %+v", elems[1])
+	}
+}
+
+// TestCompositionInput_ObjectBiased verifies that compositionInput treats only
+// explicit JSON objects/arrays as verbatim composition input; bare scalars and
+// plain text are always encoded as JSON strings.
+func TestCompositionInput_ObjectBiased(t *testing.T) {
+	cases := []struct {
+		content string
+		want    string // expected JSON encoding of result
+	}{
+		{`{"x":1}`, `{"x":1}`},           // object → verbatim
+		{`[1,2,3]`, `[1,2,3]`},           // array → verbatim
+		{`true`, `"true"`},               // bare boolean → string
+		{`42`, `"42"`},                   // bare number → string
+		{`"hello"`, `"\"hello\""`},       // bare string literal → string
+		{`hello world`, `"hello world"`}, // plain text → string
+	}
+	for _, tc := range cases {
+		msg := &types.Message{Content: tc.content}
+		got := compositionInput(msg)
+		if string(got) != tc.want {
+			t.Errorf("compositionInput(%q) = %s, want %s", tc.content, got, tc.want)
+		}
 	}
 }
 

--- a/runtime/pipeline/stage/stages_composition_test.go
+++ b/runtime/pipeline/stage/stages_composition_test.go
@@ -1,0 +1,162 @@
+package stage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestCompositionStage_RunsToCompletion(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo") // reuse helper from composition_executor_test.go
+
+	comp := &composition.Composition{
+		Version: 1, Output: "b",
+		Steps: []*composition.Step{
+			{ID: "a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "${input.x}"}},
+			{ID: "b", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"prev": "${a.output.v}"}},
+		},
+	}
+	cs := NewCompositionStage("comp", comp, CompositionExecutorDeps{ToolRegistry: reg})
+
+	pipe, err := NewPipelineBuilder().Chain(cs).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := types.Message{Role: "user", Content: `{"x":"hi"}`}
+	res, err := pipe.ExecuteSync(context.Background(), NewMessageElement(&msg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || res.Response == nil {
+		t.Fatal("expected a response")
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(res.Response.Content), &got); err != nil {
+		t.Fatalf("response not JSON: %q (%v)", res.Response.Content, err)
+	}
+	if got["prev"] != "hi" {
+		t.Errorf("composition output = %#v, want prev=hi", got)
+	}
+}
+
+// TestCompositionStage_PlainTextInput verifies that a plain-text (non-JSON)
+// message content is JSON-encoded before being passed to the engine.
+func TestCompositionStage_PlainTextInput(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo")
+
+	// Single-step composition that echoes its input back directly.
+	comp := &composition.Composition{
+		Version: 1, Output: "a",
+		Steps: []*composition.Step{
+			{ID: "a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"msg": "${input}"}},
+		},
+	}
+	cs := NewCompositionStage("plain", comp, CompositionExecutorDeps{ToolRegistry: reg})
+
+	pipe, err := NewPipelineBuilder().Chain(cs).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "hello world" is not valid JSON — compositionInput must JSON-encode it.
+	msg := types.Message{Role: "user", Content: "hello world"}
+	res, err := pipe.ExecuteSync(context.Background(), NewMessageElement(&msg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || res.Response == nil {
+		t.Fatal("expected a response")
+	}
+}
+
+// TestCompositionStage_ForwardsNonMessageElements verifies that elements which
+// are not message elements (e.g. EndOfStream or elements without a Message) are
+// forwarded unchanged and do not trigger composition execution.
+func TestCompositionStage_ForwardsNonMessageElements(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo")
+
+	comp := &composition.Composition{
+		Version: 1, Output: "a",
+		Steps: []*composition.Step{
+			{ID: "a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "x"}},
+		},
+	}
+	cs := NewCompositionStage("fwd", comp, CompositionExecutorDeps{ToolRegistry: reg})
+
+	// Drive the stage directly: send a text element (no .Message) then a message element.
+	in := make(chan StreamElement, 2)
+	out := make(chan StreamElement, 10)
+
+	txt := "some text"
+	in <- StreamElement{Text: &txt} // non-message element — must be forwarded
+	msg := &types.Message{Role: "user", Content: `{}`}
+	in <- NewMessageElement(msg) // message element — triggers execution
+	close(in)
+
+	if err := cs.Process(context.Background(), in, out); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	elems := drainChannel(out)
+	if len(elems) < 2 {
+		t.Fatalf("expected at least 2 elements, got %d", len(elems))
+	}
+	// First element should be the forwarded text element.
+	if elems[0].Text == nil || *elems[0].Text != "some text" {
+		t.Errorf("first element: want text='some text', got %+v", elems[0])
+	}
+	// Second element should be the assistant result from the composition.
+	if elems[1].Message == nil || elems[1].Message.Role != roleAssistant {
+		t.Errorf("second element: want assistant message, got %+v", elems[1])
+	}
+}
+
+// TestCompositionStage_ContextCancellation verifies that Process returns
+// ctx.Err() when the context is cancelled mid-stream.
+func TestCompositionStage_ContextCancellation(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo")
+
+	comp := &composition.Composition{
+		Version: 1, Output: "a",
+		Steps: []*composition.Step{
+			{ID: "a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "x"}},
+		},
+	}
+	cs := NewCompositionStage("cancel", comp, CompositionExecutorDeps{ToolRegistry: reg})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	in := make(chan StreamElement, 1)
+	out := make(chan StreamElement, 10)
+
+	// Send a non-message element — the cancelled context should cause the
+	// forwarding select to return ctx.Err().
+	txt := "x"
+	in <- StreamElement{Text: &txt}
+	close(in)
+
+	err := cs.Process(ctx, in, out)
+	if err == nil {
+		// context was already cancelled; most schedulers will pick the done case
+		// but Go's select is non-deterministic when both cases are ready.
+		// Accept either outcome rather than making the test racy.
+		t.Log("select chose the send case before ctx.Done — acceptable")
+	}
+}
+
+// drainChannel collects all remaining elements from a closed channel.
+func drainChannel(ch <-chan StreamElement) []StreamElement {
+	var elems []StreamElement
+	for e := range ch {
+		elems = append(elems, e)
+	}
+	return elems
+}

--- a/runtime/pipeline/stage/stages_composition_test.go
+++ b/runtime/pipeline/stage/stages_composition_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -252,4 +254,88 @@ func drainChannel(ch <-chan StreamElement) []StreamElement {
 		elems = append(elems, e)
 	}
 	return elems
+}
+
+// TestCompositionStage_EndToEnd_MixedKinds proves that a multi-kind composition
+// runs through CompositionStage with a real mock-provider sub-pipeline:
+//
+//  1. classify (prompt step) — single LLM round
+//  2. meta (parallel step) — two echo-tool branches, barrier-merged into "m"
+//  3. synth (agent step) — depends on classify + meta, consumes ${meta.output.m},
+//     produces the final composition output
+func TestCompositionStage_EndToEnd_MixedKinds(t *testing.T) {
+	// Mock provider whose every LLM call returns "synthesized".
+	repo := mock.NewInMemoryMockRepository("synthesized")
+	prov := mock.NewProviderWithRepository("mock", "mock", false, repo)
+
+	// Prompt registry backed by the local in-package mock repository.
+	preg := prompt.NewRegistryWithRepository(newMockRepo())
+	registerSimplePrompt(t, preg, "classify")
+	registerSimplePrompt(t, preg, "analyze")
+
+	// Tool registry with a single echo tool used by the parallel branches.
+	treg := tools.NewRegistry()
+	registerEchoTool(t, treg, "echo")
+
+	comp := &composition.Composition{
+		Version: 1, Output: "synth",
+		Steps: []*composition.Step{
+			// Step 1: prompt step.
+			{
+				ID:         "classify",
+				Kind:       composition.KindPrompt,
+				PromptTask: "classify",
+				Input:      "${input.text}",
+			},
+			// Step 2: parallel step — two echo-tool branches, barrier-merged into "m".
+			{
+				ID:   "meta",
+				Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "s1", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"c": "${input.text}"}},
+					{ID: "s2", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"c": "${input.text}"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "m"},
+			},
+			// Step 3: agent step — depends on classify + meta, consumes barrier output.
+			{
+				ID:          "synth",
+				Kind:        composition.KindAgent,
+				PromptTask:  "analyze",
+				DependsOn:   []string{"classify", "meta"},
+				Input:       "${meta.output.m}",
+				Termination: &composition.Termination{MaxSteps: 3},
+			},
+		},
+	}
+
+	cs := NewCompositionStage("doc", comp, CompositionExecutorDeps{
+		PromptRegistry: preg,
+		Provider:       prov,
+		ToolRegistry:   treg,
+	})
+
+	pipe, err := NewPipelineBuilder().Chain(cs).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := types.Message{Role: "user", Content: `{"text":"a document"}`}
+	res, err := pipe.ExecuteSync(context.Background(), NewMessageElement(&msg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || res.Response == nil || res.Response.Content == "" {
+		t.Fatal("expected a non-empty composition output")
+	}
+	// The final agent step (analyze) drives the output; the mock provider returns
+	// "synthesized". responseToJSON encodes plain text as a JSON string, so
+	// Content should be the JSON-encoded form: `"synthesized"`.
+	var text string
+	if err := json.Unmarshal([]byte(res.Response.Content), &text); err != nil {
+		t.Fatalf("expected JSON-string output from agent step, got %q: %v", res.Response.Content, err)
+	}
+	if text != "synthesized" {
+		t.Errorf("expected final output = %q, got %q", "synthesized", text)
+	}
 }

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -518,6 +518,17 @@ func (tl *toolLoop) afterRound(
 
 	tl.toolChoice = toolChoiceAuto
 
+	// RFC 0010 termination.tool_called: stop cleanly after the round in which
+	// the named terminal tool fired. The tool has already executed and its result
+	// is recorded in tl.messages — now stop before the next provider round.
+	if policy != nil && policy.StopOnTool != "" {
+		for _, tc := range response.ToolCalls {
+			if tc.Name == policy.StopOnTool {
+				return true, tl.messages, nil
+			}
+		}
+	}
+
 	// Compact stale tool results before next round's provider call.
 	// Pass 0 for lastInputTokens: the provider's InputTokens reflects what it
 	// saw on the last call, but we've since appended the assistant response and

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -2914,3 +2914,104 @@ func TestAfterRound_CompactionEmitsEvent(t *testing.T) {
 	assert.Greater(t, data.OriginalTokens, data.CompactedTokens)
 	assert.Equal(t, 100, data.BudgetTokens)
 }
+
+// TestProviderStage_StopOnTool verifies that ToolPolicy.StopOnTool causes the
+// agent tool loop to stop cleanly at the end of any round in which the named
+// tool fires — no max-rounds error, no further provider call.
+func TestProviderStage_StopOnTool(t *testing.T) {
+	provider := mock.NewToolProvider("test", "model", false, nil)
+	registry := tools.NewRegistry()
+	err := registry.Register(&tools.ToolDescriptor{
+		Name:        "stop_tool",
+		Description: "terminal tool that ends the loop",
+		InputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:        "mock",
+	})
+	require.NoError(t, err)
+	err = registry.Register(&tools.ToolDescriptor{
+		Name:        "other_tool",
+		Description: "non-terminal tool",
+		InputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:        "mock",
+	})
+	require.NoError(t, err)
+
+	t.Run("named tool fires → clean stop (done=true, no error)", func(t *testing.T) {
+		stage := NewProviderStage(provider, registry,
+			&pipeline.ToolPolicy{StopOnTool: "stop_tool", MaxRounds: 10},
+			&ProviderConfig{},
+		)
+
+		acc := &providerInput{
+			allowedTools: []string{"stop_tool"},
+			messages:     []types.Message{{Role: "user", Content: "go"}},
+		}
+		loop, err := stage.newToolLoop(acc)
+		require.NoError(t, err)
+		// maxRounds is 10 — if StopOnTool is ignored we'd expect done=false here
+		// (round 1 < maxRounds). A clean done=true proves StopOnTool fired.
+
+		response := types.Message{
+			Role: "assistant",
+			ToolCalls: []types.MessageToolCall{
+				{ID: "c1", Name: "stop_tool", Args: json.RawMessage(`{}`)},
+			},
+		}
+		done, msgs, err := loop.afterRound(context.Background(), []string{"stop_tool"}, &response, true, 1)
+
+		assert.True(t, done, "StopOnTool should signal done when the named tool fires")
+		require.NoError(t, err, "StopOnTool stop should be clean — no error")
+		assert.NotEmpty(t, msgs, "messages should be returned on clean stop")
+	})
+
+	t.Run("different tool fires → loop continues (done=false)", func(t *testing.T) {
+		stage := NewProviderStage(provider, registry,
+			&pipeline.ToolPolicy{StopOnTool: "stop_tool", MaxRounds: 10},
+			&ProviderConfig{},
+		)
+
+		acc := &providerInput{
+			allowedTools: []string{"other_tool"},
+			messages:     []types.Message{{Role: "user", Content: "go"}},
+		}
+		loop, err := stage.newToolLoop(acc)
+		require.NoError(t, err)
+
+		response := types.Message{
+			Role: "assistant",
+			ToolCalls: []types.MessageToolCall{
+				{ID: "c2", Name: "other_tool", Args: json.RawMessage(`{}`)},
+			},
+		}
+		done, _, err := loop.afterRound(context.Background(), []string{"other_tool"}, &response, true, 1)
+
+		assert.False(t, done, "non-terminal tool should not stop the loop")
+		require.NoError(t, err)
+	})
+
+	t.Run("StopOnTool empty → normal MaxRounds behaviour", func(t *testing.T) {
+		stage := NewProviderStage(provider, registry,
+			&pipeline.ToolPolicy{MaxRounds: 1}, // no StopOnTool
+			&ProviderConfig{},
+		)
+
+		acc := &providerInput{
+			allowedTools: []string{"stop_tool"},
+			messages:     []types.Message{{Role: "user", Content: "go"}},
+		}
+		loop, err := stage.newToolLoop(acc)
+		require.NoError(t, err)
+
+		response := types.Message{
+			Role: "assistant",
+			ToolCalls: []types.MessageToolCall{
+				{ID: "c3", Name: "stop_tool", Args: json.RawMessage(`{}`)},
+			},
+		}
+		done, _, err := loop.afterRound(context.Background(), []string{"stop_tool"}, &response, true, 1)
+
+		assert.True(t, done, "max rounds should still stop the loop")
+		require.Error(t, err, "max rounds exceeded should be an error (not a clean stop)")
+		assert.Contains(t, err.Error(), "max rounds")
+	})
+}

--- a/runtime/pipeline/types.go
+++ b/runtime/pipeline/types.go
@@ -20,6 +20,9 @@ type ToolPolicy struct {
 	MaxCallsPerMinute    int      `json:"max_calls_per_minute,omitempty"`    // Per-tool calls/minute (0=unlimited)
 	MaxCostUSD           float64  `json:"max_cost_usd,omitempty"`            // Cost budget in USD (0=unlimited)
 	Blocklist            []string `json:"blocklist,omitempty"`
+	// StopOnTool, when non-empty, stops the agent tool loop at the end of any round
+	// in which a tool with this name was called (RFC 0010 termination.tool_called).
+	StopOnTool string `json:"stop_on_tool,omitempty"`
 }
 
 // PipelineConfig represents the complete pipeline configuration for pack format


### PR DESCRIPTION
## Summary

Implements **Plan 2b** of RFC 0010 Workflow Composition: makes the (merged) pure orchestrator core `runtime/composition/engine` actually run real work. Adds the production `StepExecutor` and `CompositionStage` in `runtime/pipeline/stage`, plus a `termination.tool_called` extension to the agent tool loop.

Builds on Plan 2a (#1341). The pure engine stays leaf — step side-effects go through the injected `engine.StepExecutor`, and `runtime/pipeline/stage` imports the engine (never the reverse), so there is no import cycle.

### What's here

| Area | Change |
|------|--------|
| `pipeline/types.go` + `stage/stages_provider.go` | `ToolPolicy.StopOnTool` + a terminal-tool stop in the agent loop's `afterRound` (the one `ProviderStage` extension); gated on `StopOnTool != ""` so existing callers are unaffected |
| `stage/composition_executor.go` | `NewCompositionStepExecutor`: `tool` steps → `tools.Registry.Execute`; `prompt`/`agent` steps → minimal `PromptAssembly → Template → Provider` sub-pipeline via `ExecuteSync`. `MaxRounds` from `termination.max_steps`, `StopOnTool` from `termination.tool_called`, `ResponseFormat` from `output_schema` (injected resolver). Tool access = **intersection of prompt-template tools ∩ step `tools:`** (same model as skill tools, via the existing `intersectInOrder`). |
| `stage/stages_composition.go` | `CompositionStage` (implements `stage.Stage`): runs `engine.Execute` once per turn on the live user message, emits the structured output as the assistant element; skips history elements |
| Hooks | the conversation's `hooks.Registry` threads into each step sub-pipeline, so `ProviderHook`/`ToolHook` fire per step (regression-tested) |

### Scope boundary (deferred to Plan 3, #1334)

No SDK/Arena builder wiring, no `workflow.State` fields, no real `output_schema` path→bytes resolution (resolver is injected, default nil), no eval-modifier observability. The executor + stage are proven via **direct construction** with a mock provider.

## Test Plan

- [x] `go test ./runtime/pipeline/... ./runtime/composition/... -race -count=1` — green
- [x] `golangci-lint run ./runtime/pipeline/... ./runtime/composition/...` — no new issues
- [x] Mock provider drives **real** sub-pipelines (nothing stubbed past the LLM); tool steps execute for real
- [x] End-to-end mixed-kind test: `prompt → parallel(barrier) → agent` through `CompositionStage`
- [x] Coverage: tool branches (success/registry-error/tool-error/not-found/nil-registry), both termination modes, all `responseFormat` resolver paths, structured-vs-text encoding (incl. `"null"` literal), tool-scope intersection, hook threading, history skip, context cancellation

Each task was spec- and quality-reviewed before landing; a final holistic review returned **Ship**.

**Known deferred coverage:** `StopOnTool` is tested thoroughly at the tool-loop (`afterRound`) level and agent steps run e2e, but the two aren't yet combined in one through-`execLLM` early-stop test (low risk; both halves independently proven).

Part of #1333 (Plan 2b completes the engine/stage; SDK/Arena wiring follows in Plan 3). Epic #1337.
