### PR TITLE
feat(composition): Plan 3a — execution wiring, run composition states via Send (RFC 0010)

### DIFF
--- a/runtime/pipeline/stage/stages_composition.go
+++ b/runtime/pipeline/stage/stages_composition.go
@@ -75,11 +75,16 @@ func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement,
 // the composition input; any other content (including bare scalars like `true`
 // or `42` that happen to be valid JSON) is encoded as a JSON string, since a
 // user message's Content is always text.
+//
+// GetContent() is used to unify the Content field with the Parts fallback so
+// that SDK messages built via AddTextPart (which set Parts instead of Content)
+// are handled correctly.
 func compositionInput(msg *types.Message) json.RawMessage {
-	c := []byte(strings.TrimSpace(msg.Content))
+	text := msg.GetContent()
+	c := []byte(strings.TrimSpace(text))
 	if len(c) > 0 && (c[0] == '{' || c[0] == '[') && json.Valid(c) {
 		return c
 	}
-	enc, _ := json.Marshal(msg.Content)
+	enc, _ := json.Marshal(text)
 	return enc
 }

--- a/runtime/workflow/types.go
+++ b/runtime/workflow/types.go
@@ -119,17 +119,20 @@ type Spec struct {
 
 // State defines a single state in the workflow state machine.
 type State struct {
-	PromptTask    string                  `json:"prompt_task"`
-	Description   string                  `json:"description,omitempty"`
-	OnEvent       map[string]string       `json:"on_event,omitempty"`
-	Persistence   Persistence             `json:"persistence,omitempty"`
-	Orchestration Orchestration           `json:"orchestration,omitempty"`
-	Control       ControlMode             `json:"control,omitempty"` // user (default) or agent
-	Skills        string                  `json:"skills,omitempty"`
-	Terminal      bool                    `json:"terminal,omitempty"`      // RFC 0009: explicit terminal marker
-	MaxVisits     int                     `json:"max_visits,omitempty"`    // RFC 0009: max times this state can be entered
-	OnMaxVisits   string                  `json:"on_max_visits,omitempty"` // RFC 0009: redirect on max_visits
-	Artifacts     map[string]*ArtifactDef `json:"artifacts,omitempty"`     // RFC 0009: artifact slot declarations
+	PromptTask    string            `json:"prompt_task"`
+	Description   string            `json:"description,omitempty"`
+	OnEvent       map[string]string `json:"on_event,omitempty"`
+	Persistence   Persistence       `json:"persistence,omitempty"`
+	Orchestration Orchestration     `json:"orchestration,omitempty"`
+	Control       ControlMode       `json:"control,omitempty"` // user (default) or agent
+	Skills        string            `json:"skills,omitempty"`
+	// Composition names the composition (in the pack's compositions map) that a
+	// composition-orchestrated state runs. Required when Orchestration == composition.
+	Composition string                  `json:"composition,omitempty"`
+	Terminal    bool                    `json:"terminal,omitempty"`      // RFC 0009: explicit terminal marker
+	MaxVisits   int                     `json:"max_visits,omitempty"`    // RFC 0009: max times this state can be entered
+	OnMaxVisits string                  `json:"on_max_visits,omitempty"` // RFC 0009: redirect on max_visits
+	Artifacts   map[string]*ArtifactDef `json:"artifacts,omitempty"`     // RFC 0009: artifact slot declarations
 }
 
 // ArtifactDef declares a named artifact slot on a workflow state.
@@ -171,6 +174,9 @@ const (
 	OrchestrationInternal Orchestration = "internal"
 	OrchestrationExternal Orchestration = "external"
 	OrchestrationHybrid   Orchestration = "hybrid"
+	// OrchestrationComposition runs a declarative composition step-graph for the
+	// state instead of an LLM-driven turn (RFC 0010).
+	OrchestrationComposition Orchestration = "composition"
 )
 
 // ControlMode describes who holds control after a transition into this state.

--- a/runtime/workflow/types_test.go
+++ b/runtime/workflow/types_test.go
@@ -359,3 +359,17 @@ func TestParseConfig_Invalid(t *testing.T) {
 		t.Error("expected error for invalid input")
 	}
 }
+
+func TestState_CompositionJSONRoundTrip(t *testing.T) {
+	raw := `{"orchestration":"composition","composition":"analyze_doc","terminal":true}`
+	var s State
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.Orchestration != OrchestrationComposition {
+		t.Errorf("orchestration = %q, want composition", s.Orchestration)
+	}
+	if s.Composition != "analyze_doc" {
+		t.Errorf("composition = %q, want analyze_doc", s.Composition)
+	}
+}

--- a/runtime/workflow/validate.go
+++ b/runtime/workflow/validate.go
@@ -53,17 +53,18 @@ func validateEntry(spec *Spec, promptSet map[string]bool, r *ValidationResult) {
 			"workflow.entry %q does not reference a key in states", spec.Entry))
 		return
 	}
-	if !promptSet[spec.States[spec.Entry].PromptTask] {
+	state := spec.States[spec.Entry]
+	if state.Orchestration != OrchestrationComposition && !promptSet[state.PromptTask] {
 		r.Errors = append(r.Errors, fmt.Sprintf(
 			"workflow.states[%q].prompt_task %q does not reference a valid prompt",
-			spec.Entry, spec.States[spec.Entry].PromptTask))
+			spec.Entry, state.PromptTask))
 	}
 }
 
 // validateStates checks rules 5-9 for each state.
 func validateStates(spec *Spec, promptSet map[string]bool, r *ValidationResult) {
 	for name, state := range spec.States {
-		if name != spec.Entry && !promptSet[state.PromptTask] {
+		if name != spec.Entry && state.Orchestration != OrchestrationComposition && !promptSet[state.PromptTask] {
 			r.Errors = append(r.Errors, fmt.Sprintf(
 				"workflow.states[%q].prompt_task %q does not reference a valid prompt",
 				name, state.PromptTask))
@@ -71,6 +72,7 @@ func validateStates(spec *Spec, promptSet map[string]bool, r *ValidationResult) 
 		validateEvents(spec, name, state, r)
 		validatePersistence(name, state, r)
 		validateOrchestration(name, state, r)
+		validateCompositionFields(name, state, r)
 		validateLoopGuards(spec, name, state, r)
 	}
 }
@@ -107,10 +109,31 @@ func validateOrchestration(name string, state *State, r *ValidationResult) {
 	if state.Orchestration != "" &&
 		state.Orchestration != OrchestrationInternal &&
 		state.Orchestration != OrchestrationExternal &&
-		state.Orchestration != OrchestrationHybrid {
+		state.Orchestration != OrchestrationHybrid &&
+		state.Orchestration != OrchestrationComposition {
 		r.Errors = append(r.Errors, fmt.Sprintf(
-			"workflow.states[%q].orchestration %q is not valid (must be \"internal\", \"external\", or \"hybrid\")",
+			"workflow.states[%q].orchestration %q is not valid"+
+				" (must be \"internal\", \"external\", \"hybrid\", or \"composition\")",
 			name, state.Orchestration))
+	}
+}
+
+// validateCompositionFields enforces RFC 0010 composition field rules:
+// - composition states must set Composition
+// - non-composition states must not set Composition
+func validateCompositionFields(name string, state *State, r *ValidationResult) {
+	if state.Orchestration == OrchestrationComposition {
+		if state.Composition == "" {
+			r.Errors = append(r.Errors, fmt.Sprintf(
+				"workflow.states[%q]: orchestration composition requires a composition",
+				name))
+		}
+	} else {
+		if state.Composition != "" {
+			r.Errors = append(r.Errors, fmt.Sprintf(
+				"workflow.states[%q]: composition is only valid with orchestration composition",
+				name))
+		}
 	}
 }
 

--- a/runtime/workflow/validate_test.go
+++ b/runtime/workflow/validate_test.go
@@ -287,6 +287,54 @@ func TestValidate_RedirectChainWarns(t *testing.T) {
 	assertContains(t, r.Warnings, "redirect chain")
 }
 
+func TestValidate_CompositionStateNoPromptTaskOK(t *testing.T) {
+	spec := &Spec{
+		Version: 1, Entry: "analyze",
+		States: map[string]*State{
+			"analyze": {Orchestration: OrchestrationComposition, Composition: "analyze_doc", Terminal: true},
+		},
+	}
+	res := Validate(spec, []string{})
+	if res.HasErrors() {
+		t.Errorf("composition state should validate without prompt_task: %v", res.Errors)
+	}
+}
+
+func TestValidate_CompositionStateMissingCompositionErrors(t *testing.T) {
+	spec := &Spec{
+		Version: 1, Entry: "analyze",
+		States: map[string]*State{"analyze": {Orchestration: OrchestrationComposition, Terminal: true}},
+	}
+	res := Validate(spec, []string{})
+	if !res.HasErrors() {
+		t.Error("composition state without composition must error")
+	}
+	assertContains(t, res.Errors, "composition")
+}
+
+func TestValidate_CompositionSetOnNonCompositionStateErrors(t *testing.T) {
+	spec := &Spec{
+		Version: 1, Entry: "chat",
+		States: map[string]*State{"chat": {PromptTask: "p", Composition: "x"}},
+	}
+	res := Validate(spec, []string{"p"})
+	if !res.HasErrors() {
+		t.Error("composition set on a non-composition state must error")
+	}
+	assertContains(t, res.Errors, "composition")
+}
+
+func TestValidate_NonCompositionStateStillRequiresPromptTask(t *testing.T) {
+	spec := &Spec{
+		Version: 1, Entry: "chat",
+		States: map[string]*State{"chat": {}},
+	}
+	res := Validate(spec, []string{})
+	if !res.HasErrors() {
+		t.Error("non-composition state without prompt_task must still error")
+	}
+}
+
 // --- helpers ---
 
 func assertContains(t *testing.T, strs []string, substr string) {

--- a/sdk/composition_exec_test.go
+++ b/sdk/composition_exec_test.go
@@ -1,0 +1,140 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// compositionExecPackJSON is a pack whose workflow entry state uses
+// orchestration: composition so the pipeline runs a CompositionStage instead
+// of the normal prompt-assembly → LLM path.
+//
+// The composition has a single tool step that calls "echo" with the user's
+// input text.  The echo tool is registered via OnTool so no LLM provider is
+// needed — the CompositionStage calls the tool directly through the registry.
+const compositionExecPackJSON = `{
+	"schema_version": "2025.1",
+	"id": "composition-exec-test",
+	"version": "1.0.0",
+	"template_engine": {"version": "v1", "syntax": "handlebars", "features": []},
+	"prompts": {
+		"_placeholder": {"id": "_placeholder", "name": "Placeholder", "version": "1.0.0", "system_template": "unused"}
+	},
+	"tools": {
+		"echo": {
+			"description": "Echoes its input back as output.",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"value": {"type": "string"}
+				},
+				"required": ["value"]
+			}
+		}
+	},
+	"workflow": {
+		"version": 1,
+		"entry": "compose",
+		"states": {
+			"compose": {
+				"orchestration": "composition",
+				"composition": "flow",
+				"terminal": true
+			}
+		}
+	},
+	"compositions": {
+		"flow": {
+			"version": 1,
+			"steps": [
+				{
+					"id": "a",
+					"kind": "tool",
+					"tool": "echo",
+					"args": {"value": "${input}"}
+				}
+			],
+			"output": "a"
+		}
+	}
+}`
+
+// TestComposition_EmbeddedState_RunsViaSend verifies the end-to-end composition
+// execution path:
+//
+//  1. A workflow entry state with orchestration: composition is opened — no
+//     prompt_task, no LLM provider required.
+//  2. Send forwards the user message to the CompositionStage.
+//  3. The stage executes the "flow" composition's single tool step ("echo")
+//     via the local tool registry.
+//  4. The echo tool returns the user's input, which becomes the response.
+//
+// The assertion checks that the echoed value appears in the response, proving
+// the CompositionStage ran (not just that Send didn't error).
+func TestComposition_EmbeddedState_RunsViaSend(t *testing.T) {
+	packPath := createTestPackFile(t, compositionExecPackJSON)
+
+	// A mock provider is wired so provider detection succeeds, but it is never
+	// called — the composition state's tool step runs entirely through the local
+	// tool registry without an LLM call.
+	mockProv := mock.NewProvider("mock", "mock-model", false)
+	wc, err := OpenWorkflow(packPath, WithSkipSchemaValidation(), WithProvider(mockProv))
+	require.NoError(t, err, "OpenWorkflow should succeed for a composition-entry workflow")
+	defer wc.Close()
+
+	assert.Equal(t, "compose", wc.CurrentState())
+
+	// Register the echo tool executor on the active conversation's tool registry.
+	// The pipeline is already built at Open time, so OnTool() alone (which snapshots
+	// handlers) is insufficient — we must register a live executor directly.
+	echoExec := &echoToolExecutor{}
+	wc.ActiveConversation().ToolRegistry().RegisterExecutor(echoExec)
+
+	ctx := context.Background()
+	resp, err := wc.Send(ctx, "hello from composition")
+	require.NoError(t, err, "Send should succeed — no LLM needed, only a tool step")
+
+	// The CompositionStage emits the composition output as the response.
+	// The echo tool returns {"echoed":"hello from composition"}, which the
+	// stage serialises as the assistant message Content.
+	raw := resp.Text()
+	require.NotEmpty(t, raw, "response must carry composition output")
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal([]byte(raw), &result),
+		"composition output should be valid JSON (the tool's return value)")
+	assert.Equal(t, "hello from composition", result["echoed"],
+		"composition must forward the user input through the echo tool")
+}
+
+// echoToolExecutor implements tools.Executor for the "echo" tool.
+// It is registered on the conversation's ToolRegistry after Open so the
+// CompositionStage can find it during tool-step execution. Executor registration
+// replaces the snapshot-based localExecutor built at pipeline-construction time,
+// which is the established pattern for integration tests (see tools_test.go).
+type echoToolExecutor struct{}
+
+func (e *echoToolExecutor) Name() string { return "local" }
+
+func (e *echoToolExecutor) Execute(
+	_ context.Context,
+	descriptor *tools.ToolDescriptor,
+	args json.RawMessage,
+) (json.RawMessage, error) {
+	if descriptor.Name != "echo" {
+		return nil, nil
+	}
+	var in map[string]any
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	v, _ := in["value"].(string)
+	out := map[string]string{"echoed": v}
+	return json.Marshal(out)
+}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -529,6 +530,18 @@ func (c *Conversation) buildPipelineConfig(
 		}
 		if c.prompt.Parameters.Temperature != nil {
 			pipelineCfg.Temperature = float32(*c.prompt.Parameters.Temperature)
+		}
+	}
+
+	// RFC 0010 — composition execution. When the active config carries a
+	// resolved composition (set by withResolvedComposition in workflow.go),
+	// thread it into the pipeline so CompositionStage runs instead of the
+	// normal prompt-assembly → LLM path.
+	if c.config.activeComposition != nil {
+		pipelineCfg.ActiveComposition = c.config.activeComposition
+		pipelineCfg.CompositionName = c.config.compositionName
+		if c.pack != nil && c.pack.FilePath != "" {
+			pipelineCfg.SchemaResolver = intpipeline.NewSchemaResolver(filepath.Dir(c.pack.FilePath))
 		}
 	}
 

--- a/sdk/internal/pack/load.go
+++ b/sdk/internal/pack/load.go
@@ -44,6 +44,10 @@ type Pack struct {
 	// Workflow - State-machine workflow config
 	Workflow *WorkflowSpec `json:"workflow,omitempty"`
 
+	// Compositions - Map of composition name -> raw JSON definition (RFC 0010).
+	// Stored as raw JSON to keep the SDK free of a runtime/composition import.
+	Compositions map[string]json.RawMessage `json:"compositions,omitempty"`
+
 	// Agents - Agent configuration mapping prompts to A2A-compatible agent definitions
 	Agents *AgentsConfig `json:"agents,omitempty"`
 

--- a/sdk/internal/pack/load_test.go
+++ b/sdk/internal/pack/load_test.go
@@ -628,3 +628,31 @@ func TestVariableBindingKindConstants(t *testing.T) {
 	assert.Equal(t, VariableBindingKind("secret"), BindingKindSecret)
 	assert.Equal(t, VariableBindingKind("configmap"), BindingKindConfigMap)
 }
+
+func TestLoad_PackWithCompositions(t *testing.T) {
+	raw := []byte(`{
+	  "id":"p","name":"p","version":"1","description":"",
+	  "prompts":{"analyze":{"id":"analyze","system_template":"Analyze this."}},
+	  "workflow":{"version":1,"entry":"analyze","states":{
+	     "analyze":{"orchestration":"composition","composition":"analyze_doc","terminal":true}}},
+	  "compositions":{"analyze_doc":{"version":1,"steps":[
+	     {"id":"s","kind":"tool","tool":"echo","args":{"x":"${input.t}"}}]}}
+	}`)
+
+	p, err := Parse(raw)
+	require.NoError(t, err)
+
+	if len(p.Compositions) != 1 {
+		t.Fatalf("expected 1 composition, got %d", len(p.Compositions))
+	}
+	if p.Workflow == nil {
+		t.Fatal("expected workflow to be set")
+	}
+	state, ok := p.Workflow.States["analyze"]
+	if !ok {
+		t.Fatal("expected state 'analyze' to exist")
+	}
+	if state.Composition != "analyze_doc" {
+		t.Errorf("state composition = %q, want analyze_doc", state.Composition)
+	}
+}

--- a/sdk/internal/pack/validate.go
+++ b/sdk/internal/pack/validate.go
@@ -104,7 +104,8 @@ func (p *Pack) validateWorkflowStateRefs() []string {
 
 	var errs []string
 	for name, state := range p.Workflow.States {
-		if !promptSet[state.PromptTask] {
+		// Composition-orchestrated states run a sub-pipeline; prompt_task is not required.
+		if state.Orchestration != "composition" && !promptSet[state.PromptTask] {
 			errs = append(errs, fmt.Sprintf(
 				"workflow.states[%q].prompt_task %q does not reference a valid prompt",
 				name, state.PromptTask))

--- a/sdk/internal/pack/workflow.go
+++ b/sdk/internal/pack/workflow.go
@@ -17,6 +17,7 @@ type WorkflowState struct {
 	OnEvent       map[string]string               `json:"on_event,omitempty"`
 	Persistence   string                          `json:"persistence,omitempty"`
 	Orchestration string                          `json:"orchestration,omitempty"`
+	Composition   string                          `json:"composition,omitempty"` // RFC 0010: names the composition to run
 	Skills        string                          `json:"skills,omitempty"`
 	Terminal      bool                            `json:"terminal,omitempty"`      // RFC 0009
 	MaxVisits     int                             `json:"max_visits,omitempty"`    // RFC 0009

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -318,11 +318,17 @@ func collectPipelineStages(
 	// 3. Prompt assembly stage - loads raw template (no rendering)
 	// 4. Template stage - single render point, emits events. With turnState,
 	// rendering happens once per Send rather than once per element.
-	stages = append(stages,
-		stage.NewVariableProviderStageWithVarsAndTurnState(cfg.Variables, cfg.VariableProviders, turnState),
-		stage.NewPromptAssemblyStageWithTurnState(cfg.PromptRegistry, cfg.TaskType, cfg.Variables, turnState),
-		stage.NewTemplateStageWithTurnState(cfg.EventEmitter, turnState),
-	)
+	//
+	// For composition states (RFC 0010), these three stages are skipped: the
+	// CompositionStage builds its own per-step sub-pipelines and there is no
+	// top-level prompt_task to assemble.
+	if cfg.ActiveComposition == nil {
+		stages = append(stages,
+			stage.NewVariableProviderStageWithVarsAndTurnState(cfg.Variables, cfg.VariableProviders, turnState),
+			stage.NewPromptAssemblyStageWithTurnState(cfg.PromptRegistry, cfg.TaskType, cfg.Variables, turnState),
+			stage.NewTemplateStageWithTurnState(cfg.EventEmitter, turnState),
+		)
+	}
 
 	// 4.1 Input recording stage - captures user input with full binary data
 	if cfg.RecordingConfig != nil && cfg.RecordingStore != nil {

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -322,13 +322,7 @@ func collectPipelineStages(
 	// For composition states (RFC 0010), these three stages are skipped: the
 	// CompositionStage builds its own per-step sub-pipelines and there is no
 	// top-level prompt_task to assemble.
-	if cfg.ActiveComposition == nil {
-		stages = append(stages,
-			stage.NewVariableProviderStageWithVarsAndTurnState(cfg.Variables, cfg.VariableProviders, turnState),
-			stage.NewPromptAssemblyStageWithTurnState(cfg.PromptRegistry, cfg.TaskType, cfg.Variables, turnState),
-			stage.NewTemplateStageWithTurnState(cfg.EventEmitter, turnState),
-		)
-	}
+	stages = appendPromptAssemblyStages(stages, cfg, turnState)
 
 	// 4.1 Input recording stage - captures user input with full binary data
 	if cfg.RecordingConfig != nil && cfg.RecordingStore != nil {
@@ -411,6 +405,21 @@ func appendStateStoreLoadStages(
 		}, turnState))
 	}
 	return append(stages, stage.NewStateStoreLoadStageWithTurnState(stateStoreConfig, turnState))
+}
+
+// appendPromptAssemblyStages adds VariableProviderStage, PromptAssemblyStage, and
+// TemplateStage when the pipeline is not running a composition (RFC 0010). Composition
+// states skip these three stages because the CompositionStage builds its own per-step
+// sub-pipelines and there is no top-level prompt_task to assemble.
+func appendPromptAssemblyStages(stages []stage.Stage, cfg *Config, turnState *stage.TurnState) []stage.Stage {
+	if cfg.ActiveComposition != nil {
+		return stages
+	}
+	return append(stages,
+		stage.NewVariableProviderStageWithVarsAndTurnState(cfg.Variables, cfg.VariableProviders, turnState),
+		stage.NewPromptAssemblyStageWithTurnState(cfg.PromptRegistry, cfg.TaskType, cfg.Variables, turnState),
+		stage.NewTemplateStageWithTurnState(cfg.EventEmitter, turnState),
+	)
 }
 
 // buildProviderStages returns the appropriate provider stage(s) based on config.

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -227,8 +227,6 @@ func BuildStreamPipeline(cfg *Config) (*stage.StreamPipeline, error) {
 
 // buildStreamPipelineInternal creates a stage pipeline directly without wrapping.
 // Used by DuplexSession which handles streaming at the session level.
-//
-//nolint:gocognit // Complex pipeline construction logic
 func buildStreamPipelineInternal(cfg *Config) (*stage.StreamPipeline, error) {
 	logger.Info("Building stage-based pipeline",
 		"task_type", cfg.TaskType,
@@ -304,14 +302,13 @@ func collectPipelineStages(
 
 	// 2. Variable provider stage - always present, handles static + dynamic vars
 	// 3. Prompt assembly stage - loads raw template (no rendering)
+	// 4. Template stage - single render point, emits events. With turnState,
+	// rendering happens once per Send rather than once per element.
 	stages = append(stages,
 		stage.NewVariableProviderStageWithVarsAndTurnState(cfg.Variables, cfg.VariableProviders, turnState),
 		stage.NewPromptAssemblyStageWithTurnState(cfg.PromptRegistry, cfg.TaskType, cfg.Variables, turnState),
+		stage.NewTemplateStageWithTurnState(cfg.EventEmitter, turnState),
 	)
-
-	// 4. Template stage - single render point, emits events. With turnState,
-	// rendering happens once per Send rather than once per element.
-	stages = append(stages, stage.NewTemplateStageWithTurnState(cfg.EventEmitter, turnState))
 
 	// 4.1 Input recording stage - captures user input with full binary data
 	if cfg.RecordingConfig != nil && cfg.RecordingStore != nil {

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -2,11 +2,13 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
@@ -202,6 +204,18 @@ type Config struct {
 	// When non-nil, stages and downstream consumers can resolve inference
 	// backends via classify.FromContext.
 	ClassifyRegistry *classify.Registry
+
+	// ActiveComposition, when non-nil, makes the work stage a CompositionStage
+	// that runs this composition instead of an LLM ProviderStage (RFC 0010).
+	ActiveComposition *composition.Composition
+
+	// CompositionName labels the CompositionStage (typically the state's composition name).
+	// Falls back to "composition" when empty.
+	CompositionName string
+
+	// SchemaResolver resolves a step's output_schema path to JSON-schema bytes.
+	// nil means no structured output is used.
+	SchemaResolver func(path string) (json.RawMessage, error)
 }
 
 // Build creates a stage-based streaming pipeline.
@@ -395,6 +409,24 @@ func appendStateStoreLoadStages(
 
 // buildProviderStages returns the appropriate provider stage(s) based on config.
 func buildProviderStages(cfg *Config, turnState *stage.TurnState) ([]stage.Stage, error) {
+	if cfg.ActiveComposition != nil {
+		// Composition mode (RFC 0010): replace the LLM ProviderStage with a
+		// CompositionStage that executes the composition graph.
+		deps := stage.CompositionExecutorDeps{
+			PromptRegistry: cfg.PromptRegistry,
+			Provider:       cfg.Provider,
+			ToolRegistry:   cfg.ToolRegistry,
+			Emitter:        cfg.EventEmitter,
+			HookRegistry:   cfg.HookRegistry,
+			BaseVariables:  cfg.Variables,
+			SchemaResolver: cfg.SchemaResolver,
+		}
+		name := cfg.CompositionName
+		if name == "" {
+			name = "composition"
+		}
+		return []stage.Stage{stage.NewCompositionStage(name, cfg.ActiveComposition, deps)}, nil
+	}
 	if cfg.StreamInputProvider != nil {
 		// ASM mode: Direct audio streaming to LLM
 		logger.Debug("Using DuplexProviderStage for ASM mode")

--- a/sdk/internal/pipeline/builder_test.go
+++ b/sdk/internal/pipeline/builder_test.go
@@ -2,9 +2,11 @@ package pipeline
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	memorystore "github.com/AltairaLabs/PromptKit/runtime/memory"
@@ -1197,6 +1199,116 @@ func TestBuildWithVideoStreamConfig(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, pipeline)
 	})
+}
+
+// TestBuildProviderStages_SelectsCompositionStage verifies that when
+// Config.ActiveComposition is non-nil, buildProviderStages returns a single
+// *stage.CompositionStage instead of a ProviderStage (RFC 0010).
+func TestBuildProviderStages_SelectsCompositionStage(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1, Output: "s",
+		Steps: []*composition.Step{{
+			ID:   "s",
+			Kind: composition.KindTool,
+			Tool: "echo",
+			Args: map[string]any{"v": "${input.x}"},
+		}},
+	}
+
+	// Build a tool registry with an echo tool (mirrors registerEchoTool from the
+	// stage package's own composition tests).
+	reg := tools.NewRegistry()
+	echoExec := &builderEchoExecutor{}
+	reg.RegisterExecutor(echoExec)
+	if err := reg.Register(&tools.ToolDescriptor{
+		Name:        "echo",
+		Description: "echo tool",
+		Mode:        echoExec.Name(),
+		InputSchema: []byte(`{"type":"object"}`),
+	}); err != nil {
+		t.Fatalf("register echo tool: %v", err)
+	}
+
+	promptReg := createTestRegistry("chat")
+
+	cfg := &Config{
+		Provider:          mock.NewProvider("test-mock", "test-model", false),
+		ToolRegistry:      reg,
+		PromptRegistry:    promptReg,
+		ActiveComposition: comp,
+		CompositionName:   "analyze_doc",
+	}
+
+	stages, err := buildProviderStages(cfg, stage.NewTurnState())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 1 {
+		t.Fatalf("want 1 stage, got %d", len(stages))
+	}
+	if _, ok := stages[0].(*stage.CompositionStage); !ok {
+		t.Fatalf("want *stage.CompositionStage, got %T", stages[0])
+	}
+}
+
+// TestBuildProviderStages_DefaultNameWhenCompositionNameEmpty verifies that an
+// empty CompositionName falls back to "composition".
+func TestBuildProviderStages_DefaultNameWhenCompositionNameEmpty(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1, Output: "s",
+		Steps: []*composition.Step{{
+			ID:   "s",
+			Kind: composition.KindTool,
+			Tool: "echo",
+			Args: map[string]any{"v": "x"},
+		}},
+	}
+
+	reg := tools.NewRegistry()
+	echoExec := &builderEchoExecutor{}
+	reg.RegisterExecutor(echoExec)
+	if err := reg.Register(&tools.ToolDescriptor{
+		Name:        "echo",
+		Description: "echo tool",
+		Mode:        echoExec.Name(),
+		InputSchema: []byte(`{"type":"object"}`),
+	}); err != nil {
+		t.Fatalf("register echo tool: %v", err)
+	}
+
+	cfg := &Config{
+		Provider:          mock.NewProvider("test-mock", "test-model", false),
+		ToolRegistry:      reg,
+		PromptRegistry:    createTestRegistry("chat"),
+		ActiveComposition: comp,
+		CompositionName:   "", // intentionally empty
+	}
+
+	stages, err := buildProviderStages(cfg, stage.NewTurnState())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 1 {
+		t.Fatalf("want 1 stage, got %d", len(stages))
+	}
+	cs, ok := stages[0].(*stage.CompositionStage)
+	if !ok {
+		t.Fatalf("want *stage.CompositionStage, got %T", stages[0])
+	}
+	if cs.Name() != "composition" {
+		t.Errorf("want name %q, got %q", "composition", cs.Name())
+	}
+}
+
+// builderEchoExecutor is a local tools.Executor that returns its args as the result.
+// Mirrors the echoExecutor in stage/composition_executor_test.go, but lives here
+// to avoid cross-package test helper imports.
+type builderEchoExecutor struct{}
+
+func (e *builderEchoExecutor) Name() string { return "builder-echo-exec" }
+
+func (e *builderEchoExecutor) Execute(_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+	return args, nil
 }
 
 // fakePipelineEventStore is a minimal events.EventStore for builder tests.

--- a/sdk/internal/pipeline/schema_resolver.go
+++ b/sdk/internal/pipeline/schema_resolver.go
@@ -1,0 +1,27 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// NewSchemaResolver returns a resolver that reads a schema file path relative to
+// configDir (absolute paths are used as-is). An empty path resolves to (nil, nil)
+// — "no schema" — matching CompositionExecutorDeps.SchemaResolver's contract.
+func NewSchemaResolver(configDir string) func(path string) (json.RawMessage, error) {
+	return func(path string) (json.RawMessage, error) {
+		if path == "" {
+			return nil, nil //nolint:nilnil // "no schema" is a valid, expected result
+		}
+		if !filepath.IsAbs(path) && configDir != "" {
+			path = filepath.Join(configDir, path)
+		}
+		b, err := os.ReadFile(path) //nolint:gosec // path is pack-author-controlled config
+		if err != nil {
+			return nil, fmt.Errorf("reading schema %q: %w", path, err)
+		}
+		return b, nil
+	}
+}

--- a/sdk/internal/pipeline/schema_resolver_test.go
+++ b/sdk/internal/pipeline/schema_resolver_test.go
@@ -1,0 +1,31 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewSchemaResolver(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "s.json"), []byte(`{"type":"object"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := NewSchemaResolver(dir)
+
+	got, err := r("s.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"type":"object"}` {
+		t.Errorf("got %s", got)
+	}
+
+	if b, err := r(""); err != nil || b != nil {
+		t.Errorf("empty path = (%s,%v), want (nil,nil)", b, err)
+	}
+
+	if _, err := r("missing.json"); err == nil {
+		t.Error("expected error for missing file")
+	}
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/a2a"
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -290,6 +291,24 @@ type config struct {
 	// stored only — wiring through to the SDK pipeline is a separate
 	// follow-up task.
 	audioMonitorOpts *AudioMonitorOptions
+
+	// RFC 0010 — composition execution. Set by withResolvedComposition when
+	// the workflow's current state has orchestration: composition. Non-nil
+	// causes the pipeline to run a CompositionStage instead of the normal
+	// prompt-assembly → LLM path.
+	activeComposition *composition.Composition
+	compositionName   string
+}
+
+// withResolvedComposition is an internal option that carries a pre-resolved
+// composition into the pipeline config. It is set by openConvForCurrentState
+// when the current workflow state has orchestration: composition.
+func withResolvedComposition(name string, comp *composition.Composition) Option {
+	return func(c *config) error {
+		c.compositionName = name
+		c.activeComposition = comp
+		return nil
+	}
 }
 
 // buildHookRegistry creates a hooks.Registry from the configured hooks.

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -321,6 +321,10 @@ var packCache sync.Map // map[string]*pack.Pack
 // loadAndValidatePack loads the pack and validates the prompt exists.
 // Packs are cached by absolute path so repeated Open() calls for the
 // same pack file skip disk I/O and schema validation.
+//
+// When cfg.activeComposition is non-nil the caller is opening a composition
+// state (RFC 0010) — prompt_task is intentionally empty for these states, so
+// the prompt-not-found check is skipped and a zero-value Prompt is returned.
 func loadAndValidatePack(packPath, promptName string, cfg *config) (*pack.Pack, *pack.Prompt, error) {
 	absPath, err := resolvePackPath(packPath)
 	if err != nil {
@@ -330,6 +334,10 @@ func loadAndValidatePack(packPath, promptName string, cfg *config) (*pack.Pack, 
 	// Check cache first.
 	if cached, ok := packCache.Load(absPath); ok {
 		p := cached.(*pack.Pack)
+		if cfg.activeComposition != nil {
+			// Composition state: no prompt_task required.
+			return p, &pack.Prompt{}, nil
+		}
 		prompt, ok := p.Prompts[promptName]
 		if !ok {
 			available := make([]string, 0, len(p.Prompts))
@@ -354,6 +362,11 @@ func loadAndValidatePack(packPath, promptName string, cfg *config) (*pack.Pack, 
 	// Store in cache. If another goroutine raced us, that's fine —
 	// both loaded the same file and the result is identical.
 	packCache.Store(absPath, p)
+
+	if cfg.activeComposition != nil {
+		// Composition state: no prompt_task required.
+		return p, &pack.Prompt{}, nil
+	}
 
 	prompt, ok := p.Prompts[promptName]
 	if !ok {

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -188,10 +188,11 @@ func openWorkflowAtState(packPath, startState string, opts ...Option) (*Workflow
 	return wc, nil
 }
 
-// resolveCompositionOptForState is the package-level variant of
-// WorkflowConversation.resolveCompositionOpt, used during initial workflow
-// construction before a WorkflowConversation exists.
-func resolveCompositionOptForState(p *pack.Pack, stateName string) (Option, error) {
+// resolveCompositionForState returns a withResolvedComposition Option when the
+// named state has orchestration: composition, or nil when it does not. Returns
+// an error when the state references a composition name that is absent from the
+// pack or that fails to parse.
+func resolveCompositionForState(p *pack.Pack, stateName string) (Option, error) {
 	if p == nil || p.Workflow == nil {
 		return nil, nil
 	}
@@ -209,6 +210,12 @@ func resolveCompositionOptForState(p *pack.Pack, stateName string) (Option, erro
 		return nil, fmt.Errorf("failed to parse composition %q: %w", compName, err)
 	}
 	return withResolvedComposition(compName, &comp), nil
+}
+
+// resolveCompositionOptForState delegates to resolveCompositionForState and is
+// kept for callers that use the older name (initial workflow construction path).
+func resolveCompositionOptForState(p *pack.Pack, stateName string) (Option, error) {
+	return resolveCompositionForState(p, stateName)
 }
 
 // ResumeWorkflow restores a WorkflowConversation from a previously persisted state.
@@ -509,23 +516,7 @@ func (wc *WorkflowConversation) openConvForCurrentState(contextSummary string) e
 // Returns an error when the state references a composition name that is absent
 // from the pack or that fails to parse.
 func (wc *WorkflowConversation) resolveCompositionOpt(stateName string) (Option, error) {
-	if wc.sdkPack == nil || wc.sdkPack.Workflow == nil {
-		return nil, nil
-	}
-	state, ok := wc.sdkPack.Workflow.States[stateName]
-	if !ok || state.Orchestration != orchestrationComposition {
-		return nil, nil
-	}
-	compName := state.Composition
-	raw, ok := wc.sdkPack.Compositions[compName]
-	if !ok {
-		return nil, fmt.Errorf("composition %q not found in pack", compName)
-	}
-	var comp composition.Composition
-	if err := json.Unmarshal(raw, &comp); err != nil {
-		return nil, fmt.Errorf("failed to parse composition %q: %w", compName, err)
-	}
-	return withResolvedComposition(compName, &comp), nil
+	return resolveCompositionForState(wc.sdkPack, stateName)
 }
 
 // Transition processes an event and moves to the next state.

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -825,6 +825,7 @@ func convertWorkflowSpec(sdkSpec *pack.WorkflowSpec) *workflow.Spec {
 			OnEvent:       s.OnEvent,
 			Persistence:   workflow.Persistence(s.Persistence),
 			Orchestration: workflow.Orchestration(s.Orchestration),
+			Composition:   s.Composition,
 		}
 	}
 	return &workflow.Spec{

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
@@ -31,6 +32,11 @@ const (
 	// workflowContextVar is the template variable name that carries the
 	// previous state's conversation summary into the new state's prompt.
 	workflowContextVar = "workflow_context"
+
+	// orchestrationComposition is the string value of orchestration: composition in pack
+	// workflow states. Kept as a local constant to avoid importing runtime/workflow into
+	// this package just for the constant (runtime → sdk import is forbidden).
+	orchestrationComposition = "composition"
 )
 
 // WorkflowConversation manages a stateful workflow that transitions between
@@ -54,12 +60,16 @@ const (
 //	newState, _ := wc.Transition("Escalate")
 //	fmt.Println("Moved to:", newState)
 type WorkflowConversation struct {
-	mu                  sync.RWMutex
-	machine             *workflow.StateMachine
-	workflowSpec        *workflow.Spec
-	packPath            string
-	sdkPack             *pack.Pack
-	activeConv          *Conversation
+	mu           sync.RWMutex
+	machine      *workflow.StateMachine
+	workflowSpec *workflow.Spec
+	packPath     string
+	sdkPack      *pack.Pack
+	activeConv   *Conversation
+	// activeStateName is the workflow state name for which activeConv was
+	// opened. It is set by openConvForCurrentState so reconcileActiveConv can
+	// detect drift on composition states whose prompt_task is "".
+	activeStateName     string
 	opts                []Option
 	emitter             *events.Emitter
 	stateStore          statestore.Store
@@ -133,9 +143,18 @@ func openWorkflowAtState(packPath, startState string, opts ...Option) (*Workflow
 		machine = workflow.NewStateMachineFromContext(spec, workflow.NewContext(startState, time.Now()))
 	}
 
-	// Open initial conversation for the current state's prompt_task
+	// Open initial conversation for the current state's prompt_task.
+	// For composition states (RFC 0010), promptName is empty and a composition
+	// option is prepended so the pipeline runs CompositionStage instead.
 	promptName := machine.CurrentPromptTask()
-	conv, err := Open(packPath, promptName, opts...)
+	initOpts := opts
+	if compOpt, compErr := resolveCompositionOptForState(p, machine.CurrentState()); compErr != nil {
+		return nil, fmt.Errorf("failed to resolve composition for initial state %q: %w",
+			machine.CurrentState(), compErr)
+	} else if compOpt != nil {
+		initOpts = append(append([]Option{}, opts...), compOpt)
+	}
+	conv, err := Open(packPath, promptName, initOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open initial conversation for state %q (prompt %q): %w",
 			machine.CurrentState(), promptName, err)
@@ -154,6 +173,7 @@ func openWorkflowAtState(packPath, startState string, opts ...Option) (*Workflow
 		packPath:            packPath,
 		sdkPack:             p,
 		activeConv:          conv,
+		activeStateName:     machine.CurrentState(),
 		opts:                opts,
 		emitter:             conv.newEmitter(cfg.eventBus),
 		stateStore:          cfg.stateStore,
@@ -166,6 +186,29 @@ func openWorkflowAtState(packPath, startState string, opts ...Option) (*Workflow
 	wc.registerWorkflowTools()
 
 	return wc, nil
+}
+
+// resolveCompositionOptForState is the package-level variant of
+// WorkflowConversation.resolveCompositionOpt, used during initial workflow
+// construction before a WorkflowConversation exists.
+func resolveCompositionOptForState(p *pack.Pack, stateName string) (Option, error) {
+	if p == nil || p.Workflow == nil {
+		return nil, nil
+	}
+	state, ok := p.Workflow.States[stateName]
+	if !ok || state.Orchestration != orchestrationComposition {
+		return nil, nil
+	}
+	compName := state.Composition
+	raw, ok := p.Compositions[compName]
+	if !ok {
+		return nil, fmt.Errorf("composition %q not found in pack", compName)
+	}
+	var comp composition.Composition
+	if err := json.Unmarshal(raw, &comp); err != nil {
+		return nil, fmt.Errorf("failed to parse composition %q: %w", compName, err)
+	}
+	return withResolvedComposition(compName, &comp), nil
 }
 
 // ResumeWorkflow restores a WorkflowConversation from a previously persisted state.
@@ -231,11 +274,19 @@ func ResumeWorkflow(workflowID, packPath string, opts ...Option) (*WorkflowConve
 	spec := convertWorkflowSpec(p.Workflow)
 	machine := workflow.NewStateMachineFromContext(spec, wfCtx)
 
-	// Open conversation for current state's prompt_task
+	// Open conversation for current state's prompt_task.
+	// For composition states (RFC 0010) promptName is empty; a composition
+	// option is appended so the pipeline runs CompositionStage instead.
 	promptName := machine.CurrentPromptTask()
-	optsWithID := make([]Option, len(opts), len(opts)+1)
+	optsWithID := make([]Option, len(opts))
 	copy(optsWithID, opts)
 	optsWithID = append(optsWithID, WithConversationID(workflowID))
+	if compOpt, compErr := resolveCompositionOptForState(p, machine.CurrentState()); compErr != nil {
+		return nil, fmt.Errorf("failed to resolve composition for state %q: %w",
+			machine.CurrentState(), compErr)
+	} else if compOpt != nil {
+		optsWithID = append(optsWithID, compOpt)
+	}
 	conv, err := Open(packPath, promptName, optsWithID...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open conversation for state %q (prompt %q): %w",
@@ -255,6 +306,7 @@ func ResumeWorkflow(workflowID, packPath string, opts ...Option) (*WorkflowConve
 		packPath:                packPath,
 		sdkPack:                 p,
 		activeConv:              conv,
+		activeStateName:         machine.CurrentState(),
 		opts:                    opts,
 		stateStore:              cfg.stateStore,
 		workflowID:              workflowID,
@@ -373,12 +425,27 @@ func (wc *WorkflowConversation) reconcileActiveConv(contextSummary string) error
 	if wc.activeConv.closed {
 		return nil
 	}
-	targetPrompt := wc.machine.CurrentPromptTask()
-	if targetPrompt == "" {
-		return nil
-	}
-	if wc.activeConv.promptName == targetPrompt {
-		return nil
+	// Primary comparison: by state name. This handles composition states whose
+	// prompt_task is "" — prompt-name comparison would return early on "" == ""
+	// even when the machine moved to a different composition state, or would
+	// skip reconciliation when transitioning between a normal state and a
+	// composition state.
+	//
+	// When activeStateName is not set (e.g. WorkflowConversation constructed
+	// directly in tests without going through openConvForCurrentState), fall
+	// back to prompt-name comparison so existing tests remain valid.
+	if wc.activeStateName != "" {
+		if wc.activeStateName == wc.machine.CurrentState() {
+			return nil
+		}
+	} else {
+		targetPrompt := wc.machine.CurrentPromptTask()
+		if targetPrompt == "" {
+			return nil
+		}
+		if wc.activeConv.promptName == targetPrompt {
+			return nil
+		}
 	}
 	return wc.openConvForCurrentState(contextSummary)
 }
@@ -416,14 +483,49 @@ func (wc *WorkflowConversation) openConvForCurrentState(contextSummary string) e
 		opts = append(append([]Option{}, opts...), WithVariables(artVars))
 	}
 
+	// RFC 0010: composition states have no prompt_task — resolve and thread the
+	// composition so the pipeline runs CompositionStage instead of the normal
+	// prompt-assembly → LLM path.
+	if compOpt, err := wc.resolveCompositionOpt(wc.machine.CurrentState()); err != nil {
+		return fmt.Errorf("failed to resolve composition for state %q: %w",
+			wc.machine.CurrentState(), err)
+	} else if compOpt != nil {
+		opts = append(append([]Option{}, opts...), compOpt)
+	}
+
 	conv, err := Open(wc.packPath, targetPrompt, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to open conversation for state %q (prompt %q): %w",
 			wc.machine.CurrentState(), targetPrompt, err)
 	}
 	wc.activeConv = conv
+	wc.activeStateName = wc.machine.CurrentState()
 	wc.registerWorkflowTools()
 	return nil
+}
+
+// resolveCompositionOpt returns a withResolvedComposition option when the named
+// workflow state has orchestration: composition, or nil when it does not.
+// Returns an error when the state references a composition name that is absent
+// from the pack or that fails to parse.
+func (wc *WorkflowConversation) resolveCompositionOpt(stateName string) (Option, error) {
+	if wc.sdkPack == nil || wc.sdkPack.Workflow == nil {
+		return nil, nil
+	}
+	state, ok := wc.sdkPack.Workflow.States[stateName]
+	if !ok || state.Orchestration != orchestrationComposition {
+		return nil, nil
+	}
+	compName := state.Composition
+	raw, ok := wc.sdkPack.Compositions[compName]
+	if !ok {
+		return nil, fmt.Errorf("composition %q not found in pack", compName)
+	}
+	var comp composition.Composition
+	if err := json.Unmarshal(raw, &comp); err != nil {
+		return nil, fmt.Errorf("failed to parse composition %q: %w", compName, err)
+	}
+	return withResolvedComposition(compName, &comp), nil
 }
 
 // Transition processes an event and moves to the next state.

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -170,6 +170,24 @@ func TestConvertWorkflowSpec(t *testing.T) {
 	assert.Equal(t, 300, spec.Engine["timeout"])
 }
 
+func TestConvertWorkflowSpec_CarriesComposition(t *testing.T) {
+	in := &pack.WorkflowSpec{
+		Version: 1,
+		Entry:   "analyze",
+		States: map[string]*pack.WorkflowState{
+			"analyze": {Orchestration: "composition", Composition: "analyze_doc", Terminal: true},
+		},
+	}
+	out := convertWorkflowSpec(in)
+	st := out.States["analyze"]
+	if st.Orchestration != workflow.OrchestrationComposition {
+		t.Errorf("orchestration = %q, want %q", st.Orchestration, workflow.OrchestrationComposition)
+	}
+	if st.Composition != "analyze_doc" {
+		t.Errorf("composition = %q, want analyze_doc", st.Composition)
+	}
+}
+
 func TestWorkflowConversation_ClosedErrors(t *testing.T) {
 	// Test that closed workflow returns errors
 	wc := &WorkflowConversation{closed: true}


### PR DESCRIPTION
## Summary

Implements **Plan 3a** of RFC 0010 Workflow Composition: makes a workflow **composition state reachable and runnable** through the normal SDK path. When `Send()` lands in a state with `orchestration: composition`, the pipeline runs the `CompositionStage` (Plan 2b) instead of an LLM `ProviderStage`, executes the named composition, and returns its structured output as the turn response.

Builds on Plan 2a (#1341) + Plan 2b (#1342). This is the **execution path only** — authoring (Arena/packc config parsing, `composition.ValidateAll` wiring, schema-gen) is **Plan 3b**.

### What's here

| Area | Change |
|------|--------|
| `runtime/workflow` | `State.Composition` field + `OrchestrationComposition` constant; `Validate` relaxes `prompt_task` for composition states, requires `composition` (and forbids it on non-composition states) |
| `sdk/internal/pack` | `Pack.Compositions map[string]json.RawMessage` (opaque — no `runtime/composition` import) + `WorkflowState.Composition`; pack validator exempts composition states from `prompt_task` |
| `sdk/internal/pipeline` | `Config.{ActiveComposition,CompositionName,SchemaResolver}`; `buildProviderStages` returns a `CompositionStage` when active; prompt-assembly/template/variable stages gated off for composition turns (they have no `prompt_task`); `NewSchemaResolver(configDir)` for `output_schema` |
| `sdk` | `convertWorkflowSpec` carries `Composition`; `WorkflowConversation` detects a composition state, resolves the named composition from the pack's raw JSON, and threads it (+ resolver) into the turn's pipeline config |

### Scope boundary (Plan 3b / Plan 4)

No Arena/packc/schema-gen changes; no `runtime/prompt.Pack.Compositions`; no `composition.ValidateAll` wiring; no `OpenComposition` function-mode / `LastCompositionOutput`. Those follow in Plan 3b (authoring) and Plan 4 (SDK ergonomics + Arena testability).

## Test Plan

- [x] `go test ./runtime/workflow/... ./runtime/composition/... ./runtime/pipeline/... -count=1` — green
- [x] `go test ./sdk/... -count=1` — green*
- [x] `golangci-lint run ./runtime/... ./sdk/...` — no new issues (verified `collectPipelineStages` gocognit + resolver dedup)
- [x] **End-to-end:** `TestComposition_EmbeddedState_RunsViaSend` writes a pack whose entry state is `orchestration: composition` (a one-tool composition), drives `Send`, and asserts the composition's echoed output is the turn response — genuinely routes through the composition path

\* `TestEvaluate_RuntimeConfigPath` is a pre-existing load-sensitive flake (a `custom_check` exec eval shell subprocess that times out under full-suite parallel contention; passes 5/5 in isolation). This branch touches **zero** eval files; unrelated to these changes.

Each task was implemented TDD-style; the integration crux (state resolution + prompt-assembly gating + e2e) got a dedicated principal-level review.

Part of #1334 (Plan 3a; authoring path follows in 3b). Epic #1337.
