### PR TITLE
feat(composition): Plan 3b — authoring / pack threading (RFC 0010)

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -106,17 +106,18 @@ type Config struct {
 	// every scenario in addition to its own definitions. Distinct from
 	// Defaults (which are "values when unspecified") — Globals is for
 	// "always-additive" entries.
-	Globals    *Globals          `yaml:"globals,omitempty" json:"globals,omitempty"`
-	Workflow   interface{}       `yaml:"workflow,omitempty" json:"workflow,omitempty"`
-	Memory     interface{}       `yaml:"memory,omitempty" json:"memory,omitempty"`
-	Agents     interface{}       `yaml:"agents,omitempty" json:"agents,omitempty"`
-	Deploy     *DeployConfig     `yaml:"deploy,omitempty" json:"deploy,omitempty"`
-	MCPServers []MCPServerConfig `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
-	A2AAgents  []A2AAgentConfig  `yaml:"a2a_agents,omitempty" json:"a2a_agents,omitempty"`
-	StateStore *StateStoreConfig `yaml:"state_store,omitempty" json:"state_store,omitempty"`
-	Defaults   Defaults          `yaml:"defaults" json:"defaults"`
-	SelfPlay   *SelfPlayConfig   `yaml:"self_play,omitempty" json:"self_play,omitempty"`
-	PackFile   string            `yaml:"pack_file,omitempty" json:"pack_file,omitempty"`
+	Globals      *Globals          `yaml:"globals,omitempty" json:"globals,omitempty"`
+	Workflow     interface{}       `yaml:"workflow,omitempty" json:"workflow,omitempty"`
+	Compositions interface{}       `yaml:"compositions,omitempty" json:"compositions,omitempty"`
+	Memory       interface{}       `yaml:"memory,omitempty" json:"memory,omitempty"`
+	Agents       interface{}       `yaml:"agents,omitempty" json:"agents,omitempty"`
+	Deploy       *DeployConfig     `yaml:"deploy,omitempty" json:"deploy,omitempty"`
+	MCPServers   []MCPServerConfig `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
+	A2AAgents    []A2AAgentConfig  `yaml:"a2a_agents,omitempty" json:"a2a_agents,omitempty"`
+	StateStore   *StateStoreConfig `yaml:"state_store,omitempty" json:"state_store,omitempty"`
+	Defaults     Defaults          `yaml:"defaults" json:"defaults"`
+	SelfPlay     *SelfPlayConfig   `yaml:"self_play,omitempty" json:"self_play,omitempty"`
+	PackFile     string            `yaml:"pack_file,omitempty" json:"pack_file,omitempty"`
 
 	// Inline resource specs (alternative to file refs, merged into LoadedX during load)
 	ProviderSpecs map[string]*Provider    `yaml:"provider_specs,omitempty" json:"provider_specs,omitempty"`

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -81,3 +81,24 @@ defaults:
 	assert.Equal(t, float32(0.7), cfg.Defaults.Temperature)
 	assert.Equal(t, 1024, cfg.Defaults.MaxTokens)
 }
+
+func TestConfig_ParsesCompositions(t *testing.T) {
+	yamlData := `
+workflow:
+  version: 1
+  entry: a
+  states:
+    a: { orchestration: composition, composition: flow, terminal: true }
+compositions:
+  flow:
+    version: 1
+    steps:
+      - { id: s, kind: tool, tool: echo, args: { x: "${input.t}" } }
+`
+	var cfg Config
+	err := yaml.Unmarshal([]byte(yamlData), &cfg)
+	require.NoError(t, err)
+	if cfg.Compositions == nil {
+		t.Fatal("Compositions not parsed")
+	}
+}

--- a/runtime/prompt/pack.go
+++ b/runtime/prompt/pack.go
@@ -738,6 +738,60 @@ func (p *Pack) ValidateWorkflow() *workflow.ValidationResult {
 	return workflow.Validate(p.Workflow, promptKeys)
 }
 
+// ValidateCompositions validates the pack's compositions (RFC 0010): each
+// composition's internal rules + reference resolution against the pack's
+// prompts/tools/evals, plus pack-level cross-checks against the workflow.
+func (p *Pack) ValidateCompositions() *composition.ValidationResult {
+	avail := composition.Available{
+		Prompts: p.ListPrompts(),
+		Tools:   p.toolKeys(),
+		Evals:   p.evalKeys(),
+	}
+	res := composition.ValidateAll(p.Compositions, avail)
+
+	referenced := map[string]bool{}
+	if p.Workflow != nil {
+		for name, st := range p.Workflow.States {
+			if st.Orchestration != workflow.OrchestrationComposition {
+				continue
+			}
+			referenced[st.Composition] = true
+			if _, ok := p.Compositions[st.Composition]; !ok {
+				res.Errors = append(res.Errors, fmt.Sprintf(
+					"workflow state %q references unknown composition %q", name, st.Composition))
+			}
+		}
+	}
+	if len(p.Compositions) > 0 && p.Workflow == nil {
+		res.Warnings = append(res.Warnings, "compositions defined but no workflow references them")
+	}
+	for name := range p.Compositions {
+		if !referenced[name] {
+			res.Warnings = append(res.Warnings,
+				fmt.Sprintf("composition %q is not referenced by any workflow state", name))
+		}
+	}
+	return res
+}
+
+// toolKeys returns the pack's tool names.
+func (p *Pack) toolKeys() []string {
+	keys := make([]string, 0, len(p.Tools))
+	for k := range p.Tools {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// evalKeys returns the pack's eval IDs.
+func (p *Pack) evalKeys() []string {
+	keys := make([]string, 0, len(p.Evals))
+	for i := range p.Evals {
+		keys = append(keys, p.Evals[i].ID)
+	}
+	return keys
+}
+
 // validatePackFields validates pack-level required fields
 func (p *Pack) validatePackFields() []string {
 	warnings := []string{}

--- a/runtime/prompt/pack.go
+++ b/runtime/prompt/pack.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 )
@@ -100,6 +101,9 @@ type Pack struct {
 
 	// Workflow - State-machine workflow over the pack's prompts
 	Workflow *workflow.Spec `json:"workflow,omitempty"`
+
+	// Compositions - Named composition step-graphs (RFC 0010)
+	Compositions map[string]*composition.Composition `json:"compositions,omitempty"`
 
 	// Agents - Agent configuration mapping prompts to A2A-compatible agent definitions
 	Agents *AgentsConfig `json:"agents,omitempty"`
@@ -203,9 +207,10 @@ type AgentDef struct {
 type CompileOption func(*compileOptions)
 
 type compileOptions struct {
-	workflow *workflow.Spec
-	agents   *AgentsConfig
-	skills   []SkillSourceConfig
+	workflow     *workflow.Spec
+	agents       *AgentsConfig
+	skills       []SkillSourceConfig
+	compositions map[string]*composition.Composition
 }
 
 // WithWorkflow sets the workflow config on the compiled pack.
@@ -221,6 +226,11 @@ func WithAgents(a *AgentsConfig) CompileOption {
 // WithSkills sets the skills config on the compiled pack.
 func WithSkills(s []SkillSourceConfig) CompileOption {
 	return func(o *compileOptions) { o.skills = s }
+}
+
+// WithCompositions sets the compositions map on the compiled pack.
+func WithCompositions(c map[string]*composition.Composition) CompileOption {
+	return func(o *compileOptions) { o.compositions = c }
 }
 
 // PackPrompt represents a single prompt configuration within a pack
@@ -507,6 +517,9 @@ func (pc *PackCompiler) CompileFromRegistryWithOptions(
 	}
 	if copts.skills != nil {
 		pack.Skills = copts.skills
+	}
+	if copts.compositions != nil {
+		pack.Compositions = copts.compositions
 	}
 
 	return pack, nil

--- a/runtime/prompt/pack.go
+++ b/runtime/prompt/pack.go
@@ -763,7 +763,10 @@ func (p *Pack) ValidateCompositions() *composition.ValidationResult {
 		}
 	}
 	if len(p.Compositions) > 0 && p.Workflow == nil {
+		// No workflow at all: one banner covers every composition; skip the
+		// redundant per-composition "unreferenced" warnings below.
 		res.Warnings = append(res.Warnings, "compositions defined but no workflow references them")
+		return res
 	}
 	for name := range p.Compositions {
 		if !referenced[name] {

--- a/runtime/prompt/pack_test.go
+++ b/runtime/prompt/pack_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -1533,5 +1534,44 @@ func TestWithCompositions_SetsPackField(t *testing.T) {
 	WithCompositions(comps)(&o)
 	if o.compositions == nil || o.compositions["flow"] == nil {
 		t.Fatal("WithCompositions did not set compileOptions.compositions")
+	}
+}
+
+func TestValidateCompositions_BadToolRefErrors(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*PackPrompt{}, Tools: map[string]*PackTool{},
+		Compositions: map[string]*composition.Composition{
+			"flow": {Version: 1, Steps: []*composition.Step{{ID: "s", Kind: composition.KindTool, Tool: "missing_tool"}}}},
+	}
+	if !p.ValidateCompositions().HasErrors() {
+		t.Error("composition referencing an unknown tool must error")
+	}
+}
+
+func TestValidateCompositions_UnresolvedStateRefErrors(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*PackPrompt{}, Tools: map[string]*PackTool{},
+		Compositions: map[string]*composition.Composition{},
+		Workflow: &workflow.Spec{Version: 1, Entry: "a", States: map[string]*workflow.State{
+			"a": {Orchestration: workflow.OrchestrationComposition, Composition: "nope", Terminal: true}}},
+	}
+	if !p.ValidateCompositions().HasErrors() {
+		t.Error("composition state referencing a missing composition must error")
+	}
+}
+
+func TestValidateCompositions_UnreachableWarns(t *testing.T) {
+	p := &Pack{
+		Prompts: map[string]*PackPrompt{},
+		Tools:   map[string]*PackTool{"echo": {}}, // tool exists so ValidateAll passes
+		Compositions: map[string]*composition.Composition{
+			"flow": {Version: 1, Steps: []*composition.Step{{ID: "s", Kind: composition.KindTool, Tool: "echo"}}}},
+	}
+	res := p.ValidateCompositions()
+	if res.HasErrors() {
+		t.Errorf("unreachable composition should warn, not error: %v", res.Errors)
+	}
+	if len(res.Warnings) == 0 {
+		t.Error("composition not referenced by any state should warn")
 	}
 }

--- a/runtime/prompt/pack_test.go
+++ b/runtime/prompt/pack_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1522,4 +1523,15 @@ func TestCompileFromRegistryWithOptions_Skills(t *testing.T) {
 	require.Len(t, pack.Skills, 2)
 	assert.Equal(t, "skills/billing", pack.Skills[0].Path)
 	assert.Equal(t, "inline", pack.Skills[1].Name)
+}
+
+func TestWithCompositions_SetsPackField(t *testing.T) {
+	comps := map[string]*composition.Composition{
+		"flow": {Version: 1, Steps: []*composition.Step{{ID: "s", Kind: composition.KindTool, Tool: "echo"}}},
+	}
+	var o compileOptions
+	WithCompositions(comps)(&o)
+	if o.compositions == nil || o.compositions["flow"] == nil {
+		t.Fatal("WithCompositions did not set compileOptions.compositions")
+	}
 }

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -499,6 +499,7 @@
           "$ref": "#/$defs/Globals"
         },
         "workflow": true,
+        "compositions": true,
         "memory": true,
         "agents": true,
         "deploy": {

--- a/tools/packc/compiler/compiler.go
+++ b/tools/packc/compiler/compiler.go
@@ -176,6 +176,14 @@ func buildCompileOptions(cfg *config.Config) ([]prompt.CompileOption, error) {
 		opts = append(opts, prompt.WithAgents(agentsConfig))
 	}
 
+	comps, err := parseCompositionsFromConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("parsing compositions config: %w", err)
+	}
+	if comps != nil {
+		opts = append(opts, prompt.WithCompositions(comps))
+	}
+
 	if skillsConfig := parseSkillsFromConfig(cfg); len(skillsConfig) > 0 {
 		opts = append(opts, prompt.WithSkills(skillsConfig))
 	}
@@ -199,6 +207,16 @@ func validatePack(pack *prompt.Pack, configDir string, warnings *[]string) error
 		}
 		for _, w := range wfResult.Warnings {
 			*warnings = append(*warnings, "workflow: "+w)
+		}
+	}
+
+	if len(pack.Compositions) > 0 {
+		cResult := pack.ValidateCompositions()
+		if cResult.HasErrors() {
+			return fmt.Errorf("composition validation errors: %v", cResult.Errors)
+		}
+		for _, w := range cResult.Warnings {
+			*warnings = append(*warnings, "composition: "+w)
 		}
 	}
 

--- a/tools/packc/compiler/compiler_test.go
+++ b/tools/packc/compiler/compiler_test.go
@@ -418,6 +418,126 @@ spec:
 	assert.Equal(t, "skills", result.Pack.Skills[0].EffectiveDir())
 }
 
+const echoToolYAML = `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Tool
+metadata:
+  name: echo
+spec:
+  name: echo
+  description: "Echo input back"
+  mode: client
+  input_schema:
+    type: object
+    properties:
+      x:
+        type: string
+        description: "Value to echo"
+  output_schema:
+    type: object
+    properties:
+      result:
+        type: string
+`
+
+func TestCompile_CarriesAndValidatesCompositions(t *testing.T) {
+	t.Setenv("PROMPTKIT_SCHEMA_SOURCE", "local")
+
+	// valid: workflow composition state referencing a real tool in the pack
+	dir := t.TempDir()
+	writeFixture(t, dir, "prompts/greeting.yaml", minimalPromptYAML)
+	writeFixture(t, dir, "tools/echo.yaml", echoToolYAML)
+
+	validArena := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: test
+spec:
+  prompt_configs:
+    - id: prompt0
+      file: prompts/greeting.yaml
+  tools:
+    - file: tools/echo.yaml
+  providers: []
+  workflow:
+    version: 1
+    entry: run
+    states:
+      run:
+        orchestration: composition
+        composition: flow
+        terminal: true
+  compositions:
+    flow:
+      version: 1
+      steps:
+        - id: s
+          kind: tool
+          tool: echo
+          args:
+            x: "${input.t}"
+  defaults:
+    temperature: 0.7
+    max_tokens: 100
+`
+	configFile := writeFixture(t, dir, "config.arena.yaml", validArena)
+
+	result, err := Compile(configFile,
+		WithPackID("comp-pack"),
+		WithCompilerVersion("test-v1"),
+		WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err, "valid composition pack should compile without error")
+	require.NotNil(t, result.Pack)
+	require.Len(t, result.Pack.Compositions, 1, "compiled pack should contain 1 composition")
+
+	// bad: composition step references a tool not in the pack
+	dir2 := t.TempDir()
+	writeFixture(t, dir2, "prompts/greeting.yaml", minimalPromptYAML)
+	writeFixture(t, dir2, "tools/echo.yaml", echoToolYAML)
+
+	badArena := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: test
+spec:
+  prompt_configs:
+    - id: prompt0
+      file: prompts/greeting.yaml
+  tools:
+    - file: tools/echo.yaml
+  providers: []
+  workflow:
+    version: 1
+    entry: run
+    states:
+      run:
+        orchestration: composition
+        composition: flow
+        terminal: true
+  compositions:
+    flow:
+      version: 1
+      steps:
+        - id: s
+          kind: tool
+          tool: missing_tool
+          args:
+            x: "${input.t}"
+  defaults:
+    temperature: 0.7
+    max_tokens: 100
+`
+	badConfigFile := writeFixture(t, dir2, "config.arena.yaml", badArena)
+
+	_, err = Compile(badConfigFile,
+		WithPackID("bad-comp-pack"),
+		WithCompilerVersion("test-v1"),
+		WithSkipSchemaValidation(),
+	)
+	require.Error(t, err, "composition with an unknown tool ref must fail compilation")
+	assert.Contains(t, err.Error(), "composition")
+}
+
 func TestCompileOptions(t *testing.T) {
 	t.Run("WithPackID sets pack ID", func(t *testing.T) {
 		var opts compileOptions

--- a/tools/packc/compiler/helpers_integration.go
+++ b/tools/packc/compiler/helpers_integration.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
@@ -16,6 +17,12 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 )
+
+// parseCompositionsFromConfig parses the compositions block from arena config.
+// Returns nil, nil when none are configured.
+func parseCompositionsFromConfig(cfg *config.Config) (map[string]*composition.Composition, error) {
+	return composition.ParseConfig(cfg.Compositions)
+}
 
 // buildMemoryRepo creates a memory-backed prompt repository from the loaded config.
 func buildMemoryRepo(cfg *config.Config) (*memory.PromptRepository, error) {


### PR DESCRIPTION
## Summary

Implements **Plan 3b** of RFC 0010 Workflow Composition: makes compositions authorable in Arena/packc configs. A `compositions:` block now parses from config, lands on the compiled `runtime/prompt.Pack`, and is validated at compile time. Together with **Plan 3a** (#1343, execution wiring), this completes the schema/pack-threading phase.

Builds on Plans 2a (#1341), 2b (#1342), 3a (#1343).

### What's here

| Area | Change |
|------|--------|
| `runtime/prompt` | `Pack.Compositions map[string]*composition.Composition` + `WithCompositions` compile option (mirrors `WithWorkflow`); `Pack.ValidateCompositions()` runs `composition.ValidateAll` against the pack's prompt/tool/eval keys **plus** cross-resolution: a `orchestration: composition` state whose `composition` doesn't resolve → **error**; unreachable / no-workflow compositions → **warning** |
| `pkg/config` | `Config.Compositions interface{}` (raw, mirrors `Workflow`) |
| `tools/packc` | `parseCompositionsFromConfig` (via `composition.ParseConfig`) wired into `buildCompileOptions`; `validatePack` calls `ValidateCompositions` (errors block, warnings surface) |
| `schemas/v1alpha1/arena.json` | regenerated — one line: `compositions` added to the config allowlist |

### Scope boundary (Plan 4 / 5)

No Arena *execution* of composition states (`TurnRequest.ActiveComposition` + Arena builder selection → **Plan 4, Arena testability**); no `OpenComposition`/`LastCompositionOutput`; no Arena assertion handlers / mock keying; no composition-using example (Plan 5, gated on a schema release).

## Test Plan

- [x] `go test ./runtime/prompt/... -count=1` — green
- [x] `go test ./pkg/config/... -count=1` — green (600 passed)
- [x] `go test ./tools/packc/... -count=1` — green
- [x] `golangci-lint run ./runtime/prompt/... ./pkg/config/... ./tools/packc/...` — no new issues
- [x] `packc` compile test: a valid composition pack compiles (pack carries it); a composition referencing an unknown tool **fails compilation**; `ValidateCompositions` error/warn cases covered

Implemented TDD-style; a final holistic review returned **Ship** (the only notes were minor warning-noise, addressed).

Closes #1334. Epic #1337.
