### PR TITLE
feat(composition): Plan 4c — Arena testability (RFC 0010)

### DIFF
--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -18,13 +18,29 @@ import (
 // production executors must treat `null` as "no input/args".
 type StepExecutor func(ctx context.Context, step *composition.Step, input json.RawMessage) (json.RawMessage, error)
 
+// Recorder observes step execution for observability (Arena testability). Methods
+// are called during Execute; a nil Recorder disables recording. RecordStep may be
+// called concurrently from parallel branches — implementations must be safe.
+type Recorder interface {
+	RecordStep(stepID string, output any)
+	RecordBranch(stepID string, takenTarget string)
+	RecordParallel(stepID string, branches []NamedOutput)
+}
+
 // Engine is the deterministic composition scheduler.
 type Engine struct {
-	exec StepExecutor
+	exec     StepExecutor
+	recorder Recorder
 }
 
 // New builds an Engine around a StepExecutor.
 func New(exec StepExecutor) *Engine { return &Engine{exec: exec} }
+
+// NewWithRecorder builds an Engine that records step observations via rec.
+// A nil rec is equivalent to calling New(exec).
+func NewWithRecorder(exec StepExecutor, rec Recorder) *Engine {
+	return &Engine{exec: exec, recorder: rec}
+}
 
 // stepStatus tracks scheduling state across the array walk.
 type stepStatus int
@@ -105,6 +121,9 @@ func (e *Engine) runStep(
 		}
 		scope[step.ID] = map[string]any{scopeOutputKey: out}
 		status[step.ID] = statusCompleted
+		if e.recorder != nil {
+			e.recorder.RecordStep(step.ID, out)
+		}
 		return step.ID, nil
 	default:
 		return "", fmt.Errorf("step %q: unknown kind %q", step.ID, step.Kind)
@@ -229,6 +248,9 @@ func (e *Engine) runBranch(step *composition.Step, scope Scope, status map[strin
 		status[notTaken] = statusSkipped
 	}
 	status[step.ID] = statusCompleted
+	if e.recorder != nil {
+		e.recorder.RecordBranch(step.ID, takenTarget)
+	}
 	return nil
 }
 
@@ -268,6 +290,9 @@ func (e *Engine) runParallel(ctx context.Context, step *composition.Step, scope 
 
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
+	}
+	if e.recorder != nil {
+		e.recorder.RecordParallel(step.ID, outs)
 	}
 	merged := reduce(step.Reduce, outs)
 	return map[string]any{step.Reduce.Into: merged}, nil

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -645,6 +645,96 @@ func TestExecute_ParallelBranchRetry(t *testing.T) {
 	}
 }
 
+// fakeRecorder is a test-only Recorder that captures what the engine observes.
+type fakeRecorder struct {
+	mu       sync.Mutex
+	steps    map[string]any
+	branches map[string]string
+	parallel map[string]bool
+}
+
+func newFakeRecorder() *fakeRecorder {
+	return &fakeRecorder{
+		steps:    map[string]any{},
+		branches: map[string]string{},
+		parallel: map[string]bool{},
+	}
+}
+
+func (r *fakeRecorder) RecordStep(id string, out any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.steps[id] = out
+}
+
+func (r *fakeRecorder) RecordBranch(id, taken string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.branches[id] = taken
+}
+
+func (r *fakeRecorder) RecordParallel(id string, _ []NamedOutput) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.parallel[id] = true
+}
+
+func TestEngine_RecorderBranch(t *testing.T) {
+	comp := branchComp("paper") // classify -> route(branch true->paper) -> paper|general -> join
+	fe := newFakeExec(map[string]any{
+		"classify": map[string]any{"type": "paper"},
+		"paper":    "P",
+		"general":  "G",
+		"join":     "J",
+	})
+	rec := newFakeRecorder()
+	if _, err := NewWithRecorder(fe.exec, rec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"text": "x"})); err != nil {
+		t.Fatal(err)
+	}
+	// branch step "route" should record that "paper" was taken
+	if rec.branches["route"] != "paper" {
+		t.Errorf("branch taken = %q, want paper", rec.branches["route"])
+	}
+	// taken step "paper" should be recorded
+	if _, ok := rec.steps["paper"]; !ok {
+		t.Error("paper step not recorded")
+	}
+	// skipped step "general" must NOT be recorded
+	if _, ok := rec.steps["general"]; ok {
+		t.Error("skipped general should not be recorded")
+	}
+	// "classify" and "join" also ran and should be recorded
+	if _, ok := rec.steps["classify"]; !ok {
+		t.Error("classify step not recorded")
+	}
+	if _, ok := rec.steps["join"]; !ok {
+		t.Error("join step not recorded")
+	}
+}
+
+func TestEngine_RecorderParallel(t *testing.T) {
+	// parallel step "meta" with two tool branches; assert rec.parallel["meta"]==true after Execute.
+	comp := &composition.Composition{
+		Version: 1, Output: "meta",
+		Steps: []*composition.Step{
+			{ID: "meta", Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "a", Kind: composition.KindTool, Tool: "t.a", Args: map[string]any{"c": "${input.x}"}},
+					{ID: "b", Kind: composition.KindTool, Tool: "t.b", Args: map[string]any{"c": "${input.x}"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "m"}},
+		},
+	}
+	fe := newFakeExec(map[string]any{"a": "A", "b": "B"})
+	rec := newFakeRecorder()
+	if _, err := NewWithRecorder(fe.exec, rec).Execute(context.Background(), comp, mustJSON(t, map[string]any{"x": 1})); err != nil {
+		t.Fatal(err)
+	}
+	if !rec.parallel["meta"] {
+		t.Error("parallel step meta not recorded")
+	}
+}
+
 func TestExecute_Integration_BranchParallelRetryJoin(t *testing.T) {
 	// classify -> route(branch true) -> enrich(parallel, one branch retries) ; skip_path skipped
 	// -> synth(agent, depends_on [enrich, skip_path]) consumes ${enrich.output.meta}, with retry.

--- a/runtime/evals/handlers/composition.go
+++ b/runtime/evals/handlers/composition.go
@@ -1,0 +1,215 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// Composition assertion handlers (RFC 0010 Arena testability). They read the
+// per-step observability injected into EvalContext.Metadata by the Arena
+// CompositionMetadataProvider:
+//   - composition_step_outputs   map of step id -> step output (raw JSON)
+//   - composition_branch_taken   map of branch step id -> taken target
+//   - composition_parallel_status map of parallel step id -> "complete"
+// and the composition's final output via EvalContext.CurrentOutput.
+//
+// Per the package convention these are pure primitives: they emit a raw Score
+// (and MetricValue) and put detail in Details; threshold judgment lives on the
+// `type: assertion` wrapper, so min_score/max_score are rejected here.
+
+const (
+	mdStepOutputs    = "composition_step_outputs"
+	mdBranchTaken    = "composition_branch_taken"
+	mdParallelStatus = "composition_parallel_status"
+	parallelComplete = "complete"
+
+	paramStep     = "step"
+	paramContains = "contains"
+	paramEquals   = "equals"
+	detailOutput  = "output"
+)
+
+// CompositionStepOutputHandler asserts a named step's output contains/equals a value.
+// Params: step (string, required); one of contains|equals (string).
+type CompositionStepOutputHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *CompositionStepOutputHandler) Type() string { return "composition_step_output" }
+
+// Eval matches the named step's recorded output against contains/equals.
+func (h *CompositionStepOutputHandler) Eval(
+	_ context.Context, evalCtx *evals.EvalContext, params map[string]any,
+) (*evals.EvalResult, error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(h.Type(), msg), nil
+	}
+	step, ok := params[paramStep].(string)
+	if !ok || step == "" {
+		return errorResult(h.Type(), "missing required param: step"), nil
+	}
+	outputs := compositionStepOutputs(evalCtx.Metadata)
+	got, found := outputs[step]
+	if !found {
+		return scored(h.Type(), false,
+			fmt.Sprintf("step %q produced no recorded output", step),
+			map[string]any{paramStep: step}), nil
+	}
+	matched, mode, want := matchStringParam(got, params)
+	return scored(h.Type(), matched,
+		fmt.Sprintf("step %q output %s %q", step, mode, want),
+		map[string]any{paramStep: step, detailOutput: got}), nil
+}
+
+// CompositionBranchTakenHandler asserts a branch step took the expected target.
+// Params: branch (string, required), expected (string, required).
+type CompositionBranchTakenHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *CompositionBranchTakenHandler) Type() string { return "composition_branch_taken" }
+
+// Eval checks the recorded branch target equals expected.
+func (h *CompositionBranchTakenHandler) Eval(
+	_ context.Context, evalCtx *evals.EvalContext, params map[string]any,
+) (*evals.EvalResult, error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(h.Type(), msg), nil
+	}
+	branch, ok := params["branch"].(string)
+	if !ok || branch == "" {
+		return errorResult(h.Type(), "missing required param: branch"), nil
+	}
+	expected, ok := params[keyExpected].(string)
+	if !ok || expected == "" {
+		return errorResult(h.Type(), "missing required param: expected"), nil
+	}
+	taken := compositionStringMap(evalCtx.Metadata, mdBranchTaken)
+	got := taken[branch]
+	return scored(h.Type(), got == expected,
+		fmt.Sprintf("branch %q took %q, expected %q", branch, got, expected),
+		map[string]any{"branch": branch, "taken": got, keyExpected: expected}), nil
+}
+
+// CompositionParallelCompleteHandler asserts a parallel step completed.
+// Params: parallel (string, required).
+type CompositionParallelCompleteHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *CompositionParallelCompleteHandler) Type() string { return "composition_parallel_complete" }
+
+// Eval checks the recorded parallel status is "complete".
+func (h *CompositionParallelCompleteHandler) Eval(
+	_ context.Context, evalCtx *evals.EvalContext, params map[string]any,
+) (*evals.EvalResult, error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(h.Type(), msg), nil
+	}
+	parallel, ok := params["parallel"].(string)
+	if !ok || parallel == "" {
+		return errorResult(h.Type(), "missing required param: parallel"), nil
+	}
+	status := compositionStringMap(evalCtx.Metadata, mdParallelStatus)
+	got := status[parallel]
+	return scored(h.Type(), got == parallelComplete,
+		fmt.Sprintf("parallel %q status %q", parallel, got),
+		map[string]any{"parallel": parallel, "status": got}), nil
+}
+
+// CompositionOutputHandler asserts the composition's final output contains/equals a value.
+// Params: one of contains|equals (string).
+type CompositionOutputHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *CompositionOutputHandler) Type() string { return "composition_output" }
+
+// Eval matches the composition's final output (CurrentOutput) against contains/equals.
+func (h *CompositionOutputHandler) Eval(
+	_ context.Context, evalCtx *evals.EvalContext, params map[string]any,
+) (*evals.EvalResult, error) {
+	if msg := rejectThresholdParams(params); msg != "" {
+		return errorResult(h.Type(), msg), nil
+	}
+	matched, mode, want := matchStringParam(evalCtx.CurrentOutput, params)
+	return scored(h.Type(), matched,
+		fmt.Sprintf("composition output %s %q", mode, want),
+		map[string]any{"output": evalCtx.CurrentOutput}), nil
+}
+
+// --- helpers ---
+
+// scored builds a pure-primitive EvalResult: raw Score + MetricValue + Details,
+// never Value (the assertion wrapper sets Value).
+func scored(handlerType string, pass bool, explanation string, details map[string]any) *evals.EvalResult {
+	s := boolScore(pass)
+	return &evals.EvalResult{
+		Type:        handlerType,
+		Score:       s,
+		MetricValue: s,
+		Explanation: explanation,
+		Details:     details,
+	}
+}
+
+// matchStringParam matches haystack against a contains or equals param.
+// Returns (matched, mode, wanted). With neither param, matches on non-empty output.
+func matchStringParam(haystack string, params map[string]any) (matched bool, mode, want string) {
+	if eq, ok := params[paramEquals].(string); ok {
+		return haystack == eq, paramEquals, eq
+	}
+	if c, ok := params[paramContains].(string); ok {
+		return strings.Contains(haystack, c), paramContains, c
+	}
+	return haystack != "", "is non-empty", ""
+}
+
+// compositionStepOutputs normalizes composition_step_outputs metadata (which may
+// be map[string]json.RawMessage, map[string]string, or map[string]any) to strings.
+func compositionStepOutputs(meta map[string]any) map[string]string {
+	out := map[string]string{}
+	v, ok := meta[mdStepOutputs]
+	if !ok {
+		return out
+	}
+	switch m := v.(type) {
+	case map[string]json.RawMessage:
+		for k, raw := range m {
+			out[k] = string(raw)
+		}
+	case map[string]string:
+		for k, s := range m {
+			out[k] = s
+		}
+	case map[string]any:
+		for k, val := range m {
+			if raw, ok := val.(json.RawMessage); ok {
+				out[k] = string(raw)
+			} else {
+				out[k] = fmt.Sprint(val)
+			}
+		}
+	}
+	return out
+}
+
+// compositionStringMap normalizes a string-valued composition metadata map.
+func compositionStringMap(meta map[string]any, key string) map[string]string {
+	out := map[string]string{}
+	v, ok := meta[key]
+	if !ok {
+		return out
+	}
+	switch m := v.(type) {
+	case map[string]string:
+		for k, s := range m {
+			out[k] = s
+		}
+	case map[string]any:
+		for k, val := range m {
+			out[k] = fmt.Sprint(val)
+		}
+	}
+	return out
+}

--- a/runtime/evals/handlers/composition_test.go
+++ b/runtime/evals/handlers/composition_test.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+func scoreVal(t *testing.T, r *evals.EvalResult) float64 {
+	t.Helper()
+	if r.Score == nil {
+		t.Fatalf("nil score (err=%q)", r.Error)
+	}
+	return *r.Score
+}
+
+func TestCompositionStepOutput(t *testing.T) {
+	ctx := &evals.EvalContext{Metadata: map[string]any{
+		mdStepOutputs: map[string]json.RawMessage{"classify": json.RawMessage(`{"type":"paper"}`)},
+	}}
+	h := &CompositionStepOutputHandler{}
+
+	got, err := h.Eval(context.Background(), ctx, map[string]any{"step": "classify", "contains": "paper"})
+	if err != nil || scoreVal(t, got) != 1.0 {
+		t.Fatalf("contains match: score=%v err=%v", got.Score, err)
+	}
+	got, _ = h.Eval(context.Background(), ctx, map[string]any{"step": "classify", "contains": "memo"})
+	if scoreVal(t, got) != 0.0 {
+		t.Errorf("non-match should score 0")
+	}
+	got, _ = h.Eval(context.Background(), ctx, map[string]any{"step": "missing", "contains": "x"})
+	if scoreVal(t, got) != 0.0 {
+		t.Errorf("missing step should score 0")
+	}
+	// missing required param + threshold rejection both error
+	if got, _ = h.Eval(context.Background(), ctx, map[string]any{"contains": "x"}); got.Error == "" {
+		t.Error("missing step param should error")
+	}
+	if got, _ = h.Eval(context.Background(), ctx, map[string]any{"step": "classify", "min_score": 0.5}); got.Error == "" {
+		t.Error("min_score must be rejected")
+	}
+}
+
+func TestCompositionBranchTaken(t *testing.T) {
+	ctx := &evals.EvalContext{Metadata: map[string]any{
+		mdBranchTaken: map[string]string{"route": "paper"},
+	}}
+	h := &CompositionBranchTakenHandler{}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"branch": "route", "expected": "paper"}); scoreVal(t, got) != 1.0 {
+		t.Error("matching branch should score 1")
+	}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"branch": "route", "expected": "general"}); scoreVal(t, got) != 0.0 {
+		t.Error("mismatched branch should score 0")
+	}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"branch": "route"}); got.Error == "" {
+		t.Error("missing expected param should error")
+	}
+}
+
+func TestCompositionParallelComplete(t *testing.T) {
+	ctx := &evals.EvalContext{Metadata: map[string]any{
+		mdParallelStatus: map[string]string{"meta": "complete"},
+	}}
+	h := &CompositionParallelCompleteHandler{}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"parallel": "meta"}); scoreVal(t, got) != 1.0 {
+		t.Error("complete parallel should score 1")
+	}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"parallel": "absent"}); scoreVal(t, got) != 0.0 {
+		t.Error("unknown parallel should score 0")
+	}
+}
+
+func TestCompositionOutput(t *testing.T) {
+	ctx := &evals.EvalContext{CurrentOutput: `{"summary":"done"}`}
+	h := &CompositionOutputHandler{}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"contains": "done"}); scoreVal(t, got) != 1.0 {
+		t.Error("contains match should score 1")
+	}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"equals": `{"summary":"done"}`}); scoreVal(t, got) != 1.0 {
+		t.Error("equals match should score 1")
+	}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"contains": "missing"}); scoreVal(t, got) != 0.0 {
+		t.Error("non-match should score 0")
+	}
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{"max_score": 0.9}); got.Error == "" {
+		t.Error("max_score must be rejected")
+	}
+	// no contains/equals → matches on non-empty output
+	if got, _ := h.Eval(context.Background(), ctx, map[string]any{}); scoreVal(t, got) != 1.0 {
+		t.Error("non-empty output with no matcher should score 1")
+	}
+	empty := &evals.EvalContext{CurrentOutput: ""}
+	if got, _ := h.Eval(context.Background(), empty, map[string]any{}); scoreVal(t, got) != 0.0 {
+		t.Error("empty output with no matcher should score 0")
+	}
+}
+
+// TestCompositionMetadata_AltTypes covers the tolerant accessors for
+// composition metadata supplied as map[string]string / map[string]any
+// (not just the concrete recorder types).
+func TestCompositionMetadata_AltTypes(t *testing.T) {
+	// step outputs as map[string]string
+	stepCtxStr := &evals.EvalContext{Metadata: map[string]any{
+		mdStepOutputs: map[string]string{"classify": "paper"},
+	}}
+	if got, _ := (&CompositionStepOutputHandler{}).Eval(context.Background(), stepCtxStr,
+		map[string]any{"step": "classify", "contains": "paper"}); scoreVal(t, got) != 1.0 {
+		t.Error("map[string]string step outputs should resolve")
+	}
+	// step outputs as map[string]any
+	stepCtxAny := &evals.EvalContext{Metadata: map[string]any{
+		mdStepOutputs: map[string]any{"classify": "paper"},
+	}}
+	if got, _ := (&CompositionStepOutputHandler{}).Eval(context.Background(), stepCtxAny,
+		map[string]any{"step": "classify", "equals": "paper"}); scoreVal(t, got) != 1.0 {
+		t.Error("map[string]any step outputs should resolve")
+	}
+	// branch-taken as map[string]any
+	brCtxAny := &evals.EvalContext{Metadata: map[string]any{
+		mdBranchTaken: map[string]any{"route": "paper"},
+	}}
+	if got, _ := (&CompositionBranchTakenHandler{}).Eval(context.Background(), brCtxAny,
+		map[string]any{"branch": "route", "expected": "paper"}); scoreVal(t, got) != 1.0 {
+		t.Error("map[string]any branch-taken should resolve")
+	}
+}

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -1668,6 +1668,12 @@ func TestRegisterInit(t *testing.T) {
 		"max_sentences",
 		"required_fields",
 
+		// Composition handlers (RFC 0010)
+		"composition_step_output",
+		"composition_branch_taken",
+		"composition_parallel_complete",
+		"composition_output",
+
 		// Wrapper handlers (resolve inner evals from registry)
 		"assertion",
 		"guardrail",

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -50,6 +50,12 @@ func init() {
 	// Property invariant validators (Phase 3)
 	evals.RegisterDefault(&InvariantFieldsPreservedHandler{})
 
+	// Composition handlers (RFC 0010 — Arena testability)
+	evals.RegisterDefault(&CompositionStepOutputHandler{})
+	evals.RegisterDefault(&CompositionBranchTakenHandler{})
+	evals.RegisterDefault(&CompositionParallelCompleteHandler{})
+	evals.RegisterDefault(&CompositionOutputHandler{})
+
 	// Workflow and skill handlers (Batch 3)
 	evals.RegisterDefault(&WorkflowCompleteHandler{})
 	evals.RegisterDefault(&WorkflowStateIsHandler{})

--- a/runtime/pipeline/stage/composition_executor.go
+++ b/runtime/pipeline/stage/composition_executor.go
@@ -20,6 +20,10 @@ import (
 // Go error so composition step execution stops.
 var errToolFailed = fmt.Errorf("tool reported failure")
 
+// compositionStepIDKey is the metadata key stamped into TurnState.ProviderRequestMetadata
+// so that the mock provider (and any metadata-aware provider) can key per-step responses.
+const compositionStepIDKey = "composition_step_id"
+
 // toolScopeStage narrows TurnState.AllowedTools, after prompt assembly, to the
 // intersection of the prompt template's allowed tools and the composition step's
 // tools — matching how skill tools are scoped. A prompt step (no tools) therefore
@@ -109,7 +113,11 @@ func (deps CompositionExecutorDeps) execLLM(
 		return nil, fmt.Errorf("step %q: provider/prompt registry not configured", step.ID)
 	}
 
-	turnState := &TurnState{}
+	turnState := &TurnState{
+		// Stamp the executing step id so the mock provider can key per-step
+		// responses (Arena testability); flows to PredictionRequest.Metadata.
+		ProviderRequestMetadata: map[string]interface{}{compositionStepIDKey: step.ID},
+	}
 	promptStage := NewPromptAssemblyStageWithTurnState(deps.PromptRegistry, step.PromptTask, deps.BaseVariables, turnState)
 	templateStage := NewTemplateStageWithTurnState(deps.Emitter, turnState)
 

--- a/runtime/pipeline/stage/composition_recorder.go
+++ b/runtime/pipeline/stage/composition_recorder.go
@@ -1,0 +1,89 @@
+package stage
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition/engine"
+)
+
+// CompositionRecorder captures per-step composition execution data for Arena
+// observability. Populated during a single engine.Execute (RecordStep may fire
+// from parallel-branch goroutines, hence the mutex) and read afterward via
+// CompositionMetadata. Reset() is called at the start of each turn.
+type CompositionRecorder struct {
+	mu       sync.Mutex
+	steps    map[string]json.RawMessage
+	branches map[string]string
+	parallel map[string]string
+}
+
+var _ engine.Recorder = (*CompositionRecorder)(nil)
+
+// parallelStatusComplete is the value written to the parallel-status map when a
+// parallel step finishes. Named to satisfy the goconst linter.
+const parallelStatusComplete = "complete"
+
+// NewCompositionRecorder returns an empty recorder.
+func NewCompositionRecorder() *CompositionRecorder {
+	return &CompositionRecorder{
+		steps:    map[string]json.RawMessage{},
+		branches: map[string]string{},
+		parallel: map[string]string{},
+	}
+}
+
+// Reset clears all recorded data (called per turn).
+func (r *CompositionRecorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.steps = map[string]json.RawMessage{}
+	r.branches = map[string]string{}
+	r.parallel = map[string]string{}
+}
+
+// RecordStep implements engine.Recorder.
+func (r *CompositionRecorder) RecordStep(id string, out any) {
+	raw, _ := json.Marshal(out)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.steps[id] = raw
+}
+
+// RecordBranch implements engine.Recorder.
+func (r *CompositionRecorder) RecordBranch(id, taken string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.branches[id] = taken
+}
+
+// RecordParallel implements engine.Recorder.
+func (r *CompositionRecorder) RecordParallel(id string, _ []engine.NamedOutput) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.parallel[id] = parallelStatusComplete
+}
+
+// CompositionMetadata returns a flat snapshot for the eval metadata bridge.
+// The returned maps are copies safe to read after the next Reset().
+func (r *CompositionRecorder) CompositionMetadata() map[string]any {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	steps := make(map[string]json.RawMessage, len(r.steps))
+	for k, v := range r.steps {
+		steps[k] = v
+	}
+	branches := make(map[string]string, len(r.branches))
+	for k, v := range r.branches {
+		branches[k] = v
+	}
+	parallel := make(map[string]string, len(r.parallel))
+	for k, v := range r.parallel {
+		parallel[k] = v
+	}
+	return map[string]any{
+		"composition_step_outputs":    steps,
+		"composition_branch_taken":    branches,
+		"composition_parallel_status": parallel,
+	}
+}

--- a/runtime/pipeline/stage/composition_recorder_test.go
+++ b/runtime/pipeline/stage/composition_recorder_test.go
@@ -1,0 +1,141 @@
+package stage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestCompositionRecorder exercises NewCompositionStageWithRecorder end-to-end:
+// branch selection, parallel execution, and leaf steps are all captured by
+// CompositionMetadata, and Reset() clears the state.
+func TestCompositionRecorder(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo") // defined in composition_executor_test.go
+
+	// Composition layout:
+	//   br      — if input.flag == "a" → take "leaf_a", else → take "leaf_b"
+	//   leaf_a  — echo tool (taken when flag=="a")
+	//   leaf_b  — echo tool (skipped when flag=="a", depends on leaf_a so it is
+	//             unreachable when leaf_a is skipped, not the case here)
+	//   par     — parallel of two echo branches, barrier-reduced into "m"
+	//   fin     — echo tool that consumes par output
+	comp := &composition.Composition{
+		Version: 1, Output: "fin",
+		Steps: []*composition.Step{
+			{
+				ID:   "br",
+				Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{
+					Path:  "${input.flag}",
+					Op:    "equals",
+					Value: "a",
+				},
+				Then: "leaf_a",
+				Else: "leaf_b",
+			},
+			{ID: "leaf_a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "A"}},
+			{ID: "leaf_b", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "B"}, DependsOn: []string{"leaf_a"}},
+			{
+				ID:   "par",
+				Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "p1", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"n": "1"}},
+					{ID: "p2", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"n": "2"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "m"},
+			},
+			{ID: "fin", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"out": "${par.output.m}"}},
+		},
+	}
+
+	rec := NewCompositionRecorder()
+	cs := NewCompositionStageWithRecorder("rec-comp", comp, CompositionExecutorDeps{ToolRegistry: reg}, rec)
+
+	pipe, err := NewPipelineBuilder().Chain(cs).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := types.Message{Role: "user", Content: `{"flag":"a"}`}
+	res, err := pipe.ExecuteSync(context.Background(), NewMessageElement(&msg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || res.Response == nil {
+		t.Fatal("expected a response")
+	}
+
+	meta := rec.CompositionMetadata()
+
+	// --- composition_step_outputs: must contain every completed leaf step ---
+	stepOutputsRaw, ok := meta["composition_step_outputs"]
+	if !ok {
+		t.Fatal("CompositionMetadata missing composition_step_outputs")
+	}
+	stepOutputs, ok := stepOutputsRaw.(map[string]json.RawMessage)
+	if !ok {
+		t.Fatalf("composition_step_outputs has unexpected type %T", stepOutputsRaw)
+	}
+	for _, wantID := range []string{"leaf_a", "fin"} {
+		if _, found := stepOutputs[wantID]; !found {
+			t.Errorf("composition_step_outputs missing step %q; got keys: %v", wantID, mapKeys(stepOutputs))
+		}
+	}
+
+	// --- composition_branch_taken: branch "br" must record the taken target ---
+	branchRaw, ok := meta["composition_branch_taken"]
+	if !ok {
+		t.Fatal("CompositionMetadata missing composition_branch_taken")
+	}
+	branches, ok := branchRaw.(map[string]string)
+	if !ok {
+		t.Fatalf("composition_branch_taken has unexpected type %T", branchRaw)
+	}
+	if taken, found := branches["br"]; !found {
+		t.Error("composition_branch_taken missing entry for step 'br'")
+	} else if taken != "leaf_a" {
+		t.Errorf("composition_branch_taken['br'] = %q, want 'leaf_a'", taken)
+	}
+
+	// --- composition_parallel_status: parallel step "par" must be "complete" ---
+	parallelRaw, ok := meta["composition_parallel_status"]
+	if !ok {
+		t.Fatal("CompositionMetadata missing composition_parallel_status")
+	}
+	parallel, ok := parallelRaw.(map[string]string)
+	if !ok {
+		t.Fatalf("composition_parallel_status has unexpected type %T", parallelRaw)
+	}
+	if status, found := parallel["par"]; !found {
+		t.Error("composition_parallel_status missing entry for step 'par'")
+	} else if status != "complete" {
+		t.Errorf("composition_parallel_status['par'] = %q, want 'complete'", status)
+	}
+
+	// --- Reset() clears all data ---
+	rec.Reset()
+	afterReset := rec.CompositionMetadata()
+	if steps, _ := afterReset["composition_step_outputs"].(map[string]json.RawMessage); len(steps) != 0 {
+		t.Errorf("after Reset, composition_step_outputs not empty: %v", steps)
+	}
+	if br, _ := afterReset["composition_branch_taken"].(map[string]string); len(br) != 0 {
+		t.Errorf("after Reset, composition_branch_taken not empty: %v", br)
+	}
+	if par, _ := afterReset["composition_parallel_status"].(map[string]string); len(par) != 0 {
+		t.Errorf("after Reset, composition_parallel_status not empty: %v", par)
+	}
+}
+
+// mapKeys returns the keys of a map[string]json.RawMessage for error messages.
+func mapKeys(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/runtime/pipeline/stage/stages_composition.go
+++ b/runtime/pipeline/stage/stages_composition.go
@@ -16,9 +16,10 @@ import (
 // step DAG via the engine, and emits one assistant element carrying the
 // structured output.
 type CompositionStage struct {
-	name string
-	comp *composition.Composition
-	eng  *engine.Engine
+	name     string
+	comp     *composition.Composition
+	eng      *engine.Engine
+	recorder *CompositionRecorder
 }
 
 // NewCompositionStage builds a CompositionStage from a composition spec and the
@@ -28,6 +29,22 @@ func NewCompositionStage(name string, comp *composition.Composition, deps Compos
 		name: name,
 		comp: comp,
 		eng:  engine.New(NewCompositionStepExecutor(deps)),
+	}
+}
+
+// NewCompositionStageWithRecorder builds a CompositionStage that records
+// step-level execution data via rec for Arena observability. rec.Reset() is
+// called before each composition execution so that each turn's metadata is
+// independent. A nil rec is equivalent to calling NewCompositionStage.
+func NewCompositionStageWithRecorder(
+	name string, comp *composition.Composition,
+	deps CompositionExecutorDeps, rec *CompositionRecorder,
+) *CompositionStage {
+	return &CompositionStage{
+		name:     name,
+		comp:     comp,
+		eng:      engine.NewWithRecorder(NewCompositionStepExecutor(deps), rec),
+		recorder: rec,
 	}
 }
 
@@ -54,6 +71,9 @@ func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement,
 				return ctx.Err()
 			}
 			continue
+		}
+		if s.recorder != nil {
+			s.recorder.Reset()
 		}
 		result, err := s.eng.Execute(ctx, s.comp, compositionInput(elem.Message))
 		if err != nil {

--- a/runtime/providers/mock/mock.go
+++ b/runtime/providers/mock/mock.go
@@ -223,6 +223,9 @@ func (m *Provider) buildResponseParams(req providers.PredictionRequest) Response
 		if arenaRole, ok := req.Metadata["arena_role"].(string); ok {
 			params.ArenaRole = arenaRole
 		}
+		if stepID, ok := req.Metadata["composition_step_id"].(string); ok {
+			params.StepID = stepID
+		}
 	}
 
 	return params

--- a/runtime/providers/mock/mock_repository.go
+++ b/runtime/providers/mock/mock_repository.go
@@ -40,6 +40,7 @@ type ResponseParams struct {
 	ModelName  string // Optional: Model name being mocked
 	PersonaID  string // Optional: ID of the persona for selfplay user responses
 	ArenaRole  string // Optional: Role in arena (e.g., "self_play_user")
+	StepID     string // Optional: Composition step ID for per-step mock responses
 }
 
 // Turn represents a structured mock response that may include tool calls and multimodal content.
@@ -124,6 +125,12 @@ type ScenarioConfig struct {
 	// Turn-specific responses keyed by turn number (1-indexed)
 	// Supports both simple string responses (backward compatibility) and structured Turn responses
 	Turns map[int]interface{} `yaml:"turns,omitempty"`
+
+	// Step-specific responses keyed by composition step ID.
+	// When ResponseParams.StepID is set and matches a key here, this entry is
+	// returned ahead of any turn-number lookup. Supports the same string or
+	// structured Turn formats as Turns entries.
+	Steps map[string]interface{} `yaml:"steps,omitempty"`
 }
 
 // FileMockRepository loads mock responses from a YAML configuration file.
@@ -214,6 +221,7 @@ func (r *FileMockRepository) logGetTurnDebug(params *ResponseParams) {
 	logger.Debug("FileMockRepository GetTurn",
 		"scenario_id", params.ScenarioID,
 		"turn_number", params.TurnNumber,
+		"step_id", params.StepID,
 		"provider_id", params.ProviderID,
 		"model", params.ModelName,
 		"persona_id", params.PersonaID,
@@ -237,6 +245,11 @@ func (r *FileMockRepository) getScenarioTurn(params *ResponseParams) *Turn {
 	}
 
 	logger.Debug("Found scenario in config", "scenario_id", params.ScenarioID)
+
+	// Try step-specific response (ahead of turn-number lookup)
+	if turn := r.getScenarioStepResponse(params, &scenario); turn != nil {
+		return turn
+	}
 
 	// Try turn-specific response
 	if turn := r.getScenarioTurnResponse(params, &scenario); turn != nil {
@@ -278,6 +291,33 @@ func (r *FileMockRepository) getScenarioTurnResponse(params *ResponseParams, sce
 	turn, err := r.parseTurnResponse(turnResponse)
 	if err != nil {
 		logger.Debug("Failed to parse turn response", "error", err)
+		return nil
+	}
+	return turn
+}
+
+// getScenarioStepResponse attempts to get a step-specific response from a scenario.
+// It is called when params.StepID is non-empty and the resolved scenario has a
+// Steps map. Uses the same parseTurnResponse path as turn-number entries.
+func (r *FileMockRepository) getScenarioStepResponse(params *ResponseParams, scenario *ScenarioConfig) *Turn {
+	if params.StepID == "" || len(scenario.Steps) == 0 {
+		return nil
+	}
+
+	stepResponse, ok := scenario.Steps[params.StepID]
+	if !ok {
+		logger.Debug("No step-specific response found", "step_id", params.StepID)
+		return nil
+	}
+
+	logger.Debug("Using scenario+step specific response",
+		"scenario_id", params.ScenarioID,
+		"step_id", params.StepID,
+		"response_type", fmt.Sprintf("%T", stepResponse))
+
+	turn, err := r.parseTurnResponse(stepResponse)
+	if err != nil {
+		logger.Debug("Failed to parse step response", "error", err)
 		return nil
 	}
 	return turn

--- a/runtime/providers/mock/mock_step_keying_test.go
+++ b/runtime/providers/mock/mock_step_keying_test.go
@@ -1,0 +1,129 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestFileMockRepository_StepIDKeying verifies the per-step response lookup in
+// FileMockRepository. The priority order is:
+//   - selfplay (unchanged — not tested here)
+//   - steps[stepID]  ← new, after selfplay, before turn-number lookup
+//   - turns[turnNumber]
+//   - scenario default
+//   - global default
+//   - fallback
+func TestFileMockRepository_StepIDKeying(t *testing.T) {
+	configData := `
+defaultResponse: "global default"
+scenarios:
+  my-scenario:
+    defaultResponse: "scenario default"
+    steps:
+      classify: "classify response"
+      synthesize:
+        type: text
+        content: "synthesize structured response"
+    turns:
+      1: "turn 1 response"
+`
+
+	tempFile := createTempYAMLFile(t, configData)
+	defer cleanupTempFile(t, tempFile)
+
+	repo, err := NewFileMockRepository(tempFile)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("step id classify returns step response", func(t *testing.T) {
+		turn, err := repo.GetTurn(ctx, ResponseParams{
+			ScenarioID: "my-scenario",
+			StepID:     "classify",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "classify response", turn.Content)
+		assert.Equal(t, turnTypeText, turn.Type)
+	})
+
+	t.Run("step id synthesize returns structured step response", func(t *testing.T) {
+		turn, err := repo.GetTurn(ctx, ResponseParams{
+			ScenarioID: "my-scenario",
+			StepID:     "synthesize",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "synthesize structured response", turn.Content)
+		assert.Equal(t, turnTypeText, turn.Type)
+	})
+
+	t.Run("unknown step id falls back to turn lookup", func(t *testing.T) {
+		turn, err := repo.GetTurn(ctx, ResponseParams{
+			ScenarioID: "my-scenario",
+			StepID:     "unknown-step",
+			TurnNumber: 1,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "turn 1 response", turn.Content)
+	})
+
+	t.Run("empty step id falls back to scenario default", func(t *testing.T) {
+		turn, err := repo.GetTurn(ctx, ResponseParams{
+			ScenarioID: "my-scenario",
+			StepID:     "",
+			TurnNumber: 99, // non-existent turn
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "scenario default", turn.Content)
+	})
+
+	t.Run("step id wins over turn number when both set", func(t *testing.T) {
+		turn, err := repo.GetTurn(ctx, ResponseParams{
+			ScenarioID: "my-scenario",
+			StepID:     "classify",
+			TurnNumber: 1, // turn 1 also exists but step should win
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "classify response", turn.Content)
+	})
+}
+
+// TestMockProvider_StepIDFromMetadata verifies that the Provider reads
+// "composition_step_id" from req.Metadata and populates ResponseParams.StepID.
+func TestMockProvider_StepIDFromMetadata(t *testing.T) {
+	configData := `
+defaultResponse: "global default"
+scenarios:
+  my-scenario:
+    steps:
+      classify: "classify mock response"
+`
+
+	tempFile := createTempYAMLFile(t, configData)
+	defer cleanupTempFile(t, tempFile)
+
+	repo, err := NewFileMockRepository(tempFile)
+	require.NoError(t, err)
+
+	provider := NewProviderWithRepository("test-provider", "test-model", false, repo)
+
+	ctx := context.Background()
+	req := providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "classify this"},
+		},
+		Metadata: map[string]interface{}{
+			"mock_scenario_id":    "my-scenario",
+			"composition_step_id": "classify",
+		},
+	}
+
+	resp, err := provider.Predict(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, "classify mock response", resp.Content)
+}

--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -331,32 +331,41 @@ func (ce *DefaultConversationExecutor) buildTurnRequest(req ConversationRequest,
 		activeComposition = req.ActiveCompositionResolver()
 	}
 
+	// RFC 0010 Task 5: reset the per-run composition recorder at the start of
+	// each turn so stale outputs from the previous turn do not bleed into the
+	// current turn's assertion context. Nil-safe: non-composition runs have no
+	// recorder set on the ConversationRequest.
+	if req.CompositionRecorder != nil {
+		req.CompositionRecorder.Reset()
+	}
+
 	return turnexecutors.TurnRequest{
-		Provider:          req.Provider,
-		Scenario:          req.Scenario,
-		PromptRegistry:    ce.promptRegistry,
-		TaskType:          req.Scenario.TaskType,
-		Region:            req.Region,
-		PromptVars:        promptVars,
-		BaseDir:           baseDir,
-		Temperature:       temperature,
-		MaxTokens:         maxTokens,
-		Seed:              &req.Config.Defaults.Seed,
-		StateStoreConfig:  convertStateStoreConfig(req.StateStoreConfig),
-		ConversationID:    req.ConversationID,
-		RunID:             req.RunID,
-		EventBus:          req.EventBus,
-		ScriptedContent:   scenarioTurn.Content, // Legacy text content (for backward compatibility)
-		ScriptedParts:     scenarioTurn.Parts,   // Multimodal content parts (takes precedence over ScriptedContent)
-		ConsentOverrides:  scenarioTurn.ConsentOverrides,
-		ChaosConfig:       scenarioTurn.Chaos,
-		Assertions:        scenarioTurn.Assertions,
-		TurnEvalRunner:    ce.resolveEvalOrchestrator(&req),
-		RecordingConfig:   req.RecordingConfig,
-		EventStore:        req.EventStore,
-		AudioRouter:       req.AudioRouter,
-		Metadata:          metadata,
-		ActiveComposition: activeComposition,
+		Provider:            req.Provider,
+		Scenario:            req.Scenario,
+		PromptRegistry:      ce.promptRegistry,
+		TaskType:            req.Scenario.TaskType,
+		Region:              req.Region,
+		PromptVars:          promptVars,
+		BaseDir:             baseDir,
+		Temperature:         temperature,
+		MaxTokens:           maxTokens,
+		Seed:                &req.Config.Defaults.Seed,
+		StateStoreConfig:    convertStateStoreConfig(req.StateStoreConfig),
+		ConversationID:      req.ConversationID,
+		RunID:               req.RunID,
+		EventBus:            req.EventBus,
+		ScriptedContent:     scenarioTurn.Content, // Legacy text content (for backward compatibility)
+		ScriptedParts:       scenarioTurn.Parts,   // Multimodal content parts (takes precedence over ScriptedContent)
+		ConsentOverrides:    scenarioTurn.ConsentOverrides,
+		ChaosConfig:         scenarioTurn.Chaos,
+		Assertions:          scenarioTurn.Assertions,
+		TurnEvalRunner:      ce.resolveEvalOrchestrator(&req),
+		RecordingConfig:     req.RecordingConfig,
+		EventStore:          req.EventStore,
+		AudioRouter:         req.AudioRouter,
+		Metadata:            metadata,
+		ActiveComposition:   activeComposition,
+		CompositionRecorder: req.CompositionRecorder,
 	}
 }
 

--- a/tools/arena/engine/eval_orchestrator.go
+++ b/tools/arena/engine/eval_orchestrator.go
@@ -16,6 +16,14 @@ type WorkflowMetadataProvider interface {
 	WorkflowMetadata() map[string]any
 }
 
+// CompositionMetadataProvider is implemented by types that provide per-turn
+// composition observability (step outputs, branch-taken, parallel status) for
+// injection into the eval context, so composition_* assertions can target
+// intermediate steps. Set per-run for composition scenarios (RFC 0010).
+type CompositionMetadataProvider interface {
+	CompositionMetadata() map[string]any
+}
+
 // EvalOrchestrator orchestrates eval and assertion execution during Arena runs.
 type EvalOrchestrator struct {
 	runner               *evals.EvalRunner
@@ -24,6 +32,9 @@ type EvalOrchestrator struct {
 	metadata             map[string]any           // injected into every EvalContext (e.g. judge_targets)
 	eventBus             events.Bus               // optional event bus for provider call telemetry in evals
 	workflowMetaProvider WorkflowMetadataProvider // optional workflow state provider
+	// compositionMetaProvider, when set (per-run), injects composition step
+	// observability into every EvalContext for composition_* assertions.
+	compositionMetaProvider CompositionMetadataProvider
 	// classifyRegistry, when non-nil, is attached to the context passed to
 	// every eval/assertion handler invocation via classify.WithRegistry.
 	// Handlers that need a classifier (audio_emotion, text_toxicity, ...)
@@ -68,6 +79,7 @@ func (h *EvalOrchestrator) Clone() *EvalOrchestrator {
 	}
 	clone := *h
 	clone.workflowMetaProvider = nil
+	clone.compositionMetaProvider = nil
 	// Clone the runner so the emitter is independent per run.
 	// The emitter is wired per-call in buildEvalContext with proper session IDs.
 	if h.runner != nil {
@@ -267,6 +279,16 @@ func (h *EvalOrchestrator) SetWorkflowMetadataProvider(provider WorkflowMetadata
 	h.workflowMetaProvider = provider
 }
 
+// SetCompositionMetadataProvider sets the composition observability provider for
+// eval context injection. Called per-run for composition scenarios so
+// composition_* assertions can access per-step outputs/branch/parallel status.
+func (h *EvalOrchestrator) SetCompositionMetadataProvider(provider CompositionMetadataProvider) {
+	if h == nil {
+		return
+	}
+	h.compositionMetaProvider = provider
+}
+
 // buildEvalContext constructs an EvalContext from Arena messages.
 // Delegates to the shared evals.BuildEvalContext helper.
 // If an event bus is configured, an emitter is injected into metadata
@@ -280,7 +302,7 @@ func (h *EvalOrchestrator) buildEvalContext(
 ) *evals.EvalContext {
 	latencyMs, haveLatency := latestAssistantLatencyMs(messages)
 	metadata := h.metadata
-	needsCopy := h.eventBus != nil || h.workflowMetaProvider != nil || haveLatency
+	needsCopy := h.eventBus != nil || h.workflowMetaProvider != nil || h.compositionMetaProvider != nil || haveLatency
 	if needsCopy {
 		merged := make(map[string]any, len(metadata)+4) //nolint:mnd // extra capacity for emitter + workflow + latency keys
 		for k, v := range metadata {
@@ -297,6 +319,11 @@ func (h *EvalOrchestrator) buildEvalContext(
 		}
 		if h.workflowMetaProvider != nil {
 			for k, v := range h.workflowMetaProvider.WorkflowMetadata() {
+				merged[k] = v
+			}
+		}
+		if h.compositionMetaProvider != nil {
+			for k, v := range h.compositionMetaProvider.CompositionMetadata() {
 				merged[k] = v
 			}
 		}

--- a/tools/arena/engine/eval_orchestrator_test.go
+++ b/tools/arena/engine/eval_orchestrator_test.go
@@ -145,6 +145,40 @@ func TestBuildEvalContext_BridgesLatencyMs(t *testing.T) {
 		"buildEvalContext should bridge latest assistant LatencyMs into metadata so latency_budget can read it")
 }
 
+type fakeCompositionMetaProvider struct{ md map[string]any }
+
+func (f *fakeCompositionMetaProvider) CompositionMetadata() map[string]any { return f.md }
+
+func TestBuildEvalContext_BridgesCompositionMetadata(t *testing.T) {
+	hook := NewEvalOrchestrator(newTestRegistry(), nil, false, nil, "chat")
+	hook.SetCompositionMetadataProvider(&fakeCompositionMetaProvider{md: map[string]any{
+		"composition_step_outputs":    map[string]any{"classify": "x"},
+		"composition_branch_taken":    map[string]any{"route": "paper"},
+		"composition_parallel_status": map[string]any{"meta": "complete"},
+	}})
+	messages := []types.Message{types.NewAssistantMessage("done")}
+
+	evalCtx := hook.buildEvalContext(messages, 1, "s")
+
+	require.NotNil(t, evalCtx.Metadata)
+	assert.NotNil(t, evalCtx.Metadata["composition_step_outputs"], "composition step outputs should be bridged")
+	assert.Equal(t, "paper", evalCtx.Metadata["composition_branch_taken"].(map[string]any)["route"])
+	assert.Equal(t, "complete", evalCtx.Metadata["composition_parallel_status"].(map[string]any)["meta"])
+}
+
+func TestEvalOrchestrator_CloneResetsCompositionProvider(t *testing.T) {
+	hook := NewEvalOrchestrator(newTestRegistry(), nil, false, nil, "chat")
+	hook.SetCompositionMetadataProvider(&fakeCompositionMetaProvider{md: map[string]any{
+		"composition_step_outputs": map[string]any{"a": "b"},
+	}})
+
+	clone := hook.Clone()
+	evalCtx := clone.buildEvalContext([]types.Message{types.NewAssistantMessage("x")}, 1, "s")
+
+	_, present := evalCtx.Metadata["composition_step_outputs"]
+	assert.False(t, present, "Clone must reset compositionMetaProvider for per-run isolation")
+}
+
 func TestBuildEvalContext_BridgesZeroLatency(t *testing.T) {
 	// Sub-millisecond mock provider calls produce LatencyMs == 0 but the
 	// metadata key should still be present — handlers may want to assert

--- a/tools/arena/engine/execution_composition_recorder_e2e_test.go
+++ b/tools/arena/engine/execution_composition_recorder_e2e_test.go
@@ -1,0 +1,277 @@
+package engine
+
+// TestExecuteRun_CompositionRecorder is an end-to-end Arena integration test
+// (RFC 0010 Task 7): verifies that per-run composition recorder is wired
+// through the full execution path so composition_* assertions can read
+// per-step observability data.
+//
+// The composition has:
+//   - a branch step ("route") that chooses "leaf_a" when the input flag == "a"
+//   - two leaf tool steps ("leaf_a", "leaf_b") with echo executors
+//   - a parallel step ("par") with two branches ("p1", "p2")
+//   - a final step ("fin") that echoes the parallel output
+//
+// The scenario declares ConversationAssertions using composition_step_output,
+// composition_branch_taken, composition_parallel_complete, and composition_output.
+// All four must pass, which proves:
+//  1. The recorder is reset per turn (no stale data from a hypothetical prior turn).
+//  2. The same recorder is both wired into the CompositionStage (recording)
+//     and set as the EvalOrchestrator's CompositionMetadataProvider (reading).
+//  3. The EvalOrchestrator clone used for this run has the recorder set (not nil).
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/workflow"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
+	"github.com/AltairaLabs/PromptKit/tools/arena/turnexecutors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers" // register composition_* and assertion handlers
+)
+
+// echoRecorderExecutor echoes its JSON args back unchanged (same as echoE2EExecutor
+// in the Task 4 test but with a distinct Name so both tests can coexist).
+type echoRecorderExecutor struct{ name string }
+
+func (e *echoRecorderExecutor) Name() string { return e.name }
+func (e *echoRecorderExecutor) Execute(
+	_ context.Context, _ *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
+	return args, nil
+}
+
+// TestExecuteRun_CompositionRecorder runs a full Arena executeRun with a
+// workflow entry state that has orchestration: composition. The composition
+// contains a branch, two parallel branches, and leaf tool steps. After the run,
+// the ConversationAssertionResults on the stored run metadata are inspected to
+// confirm all composition_* assertions passed.
+func TestExecuteRun_CompositionRecorder(t *testing.T) {
+	ctx := context.Background()
+
+	// --- 1. Build the composition:
+	//
+	//   route   — branch: if input.flag == "a" → "leaf_a", else → "leaf_b"
+	//   leaf_a  — echo tool (taken path)
+	//   leaf_b  — echo tool (depends on leaf_a, so only runs when leaf_a ran)
+	//   par     — parallel of two echo branches (p1, p2), reduced into "m"
+	//   fin     — echo tool consuming par.output.m (composition output)
+	comp := &composition.Composition{
+		Version: 1,
+		Output:  "fin",
+		Steps: []*composition.Step{
+			{
+				ID:   "route",
+				Kind: composition.KindBranch,
+				Predicate: &composition.Predicate{
+					Path:  "${input.flag}",
+					Op:    "equals",
+					Value: "a",
+				},
+				Then: "leaf_a",
+				Else: "leaf_b",
+			},
+			{
+				ID:   "leaf_a",
+				Kind: composition.KindTool,
+				Tool: "echo-rec",
+				Args: map[string]any{"step": "leaf_a", "value": "from-branch"},
+			},
+			{
+				// leaf_b depends on leaf_a so it only runs when leaf_a is skipped
+				// (i.e. when the branch takes "leaf_b"). For flag=="a" this is skipped.
+				ID:        "leaf_b",
+				Kind:      composition.KindTool,
+				Tool:      "echo-rec",
+				Args:      map[string]any{"step": "leaf_b", "value": "not-taken"},
+				DependsOn: []string{"leaf_a"},
+			},
+			{
+				ID:   "par",
+				Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{
+						ID:   "p1",
+						Kind: composition.KindTool,
+						Tool: "echo-rec",
+						Args: map[string]any{"branch": "p1"},
+					},
+					{
+						ID:   "p2",
+						Kind: composition.KindTool,
+						Tool: "echo-rec",
+						Args: map[string]any{"branch": "p2"},
+					},
+				},
+				Reduce: &composition.Reducer{
+					Strategy: composition.ReduceBarrier,
+					Into:     "m",
+				},
+			},
+			{
+				ID:   "fin",
+				Kind: composition.KindTool,
+				Tool: "echo-rec",
+				Args: map[string]any{"fin": "done", "parallel": "${par.output.m}"},
+			},
+		},
+	}
+
+	// --- 2. Build the workflow spec.
+	wfSpec := &workflow.Spec{
+		Version: 1,
+		Entry:   "compose",
+		States: map[string]*workflow.State{
+			"compose": {
+				PromptTask:    "compose-rec-task",
+				Orchestration: workflow.OrchestrationComposition,
+				Composition:   "rec-comp",
+			},
+		},
+	}
+
+	// --- 3. Tool registry with the echo executor.
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(&tools.ToolDescriptor{
+		Name:        "echo-rec",
+		Description: "echoes args",
+		Mode:        "echo-rec",
+	}))
+	reg.RegisterExecutor(&echoRecorderExecutor{name: "echo-rec"})
+
+	// --- 4. Pack carrying the composition.
+	pack := &prompt.Pack{
+		ID:       "recorder-test-pack",
+		Workflow: wfSpec,
+		Compositions: map[string]*composition.Composition{
+			"rec-comp": comp,
+		},
+	}
+
+	// --- 5. EvalOrchestrator with the full default registry (includes
+	//        composition_* handlers, assertion wrapper, etc.).
+	evalReg := evals.NewEvalTypeRegistry()
+	evalOrch := NewEvalOrchestrator(evalReg, nil, false, nil, "")
+
+	// --- 6. Scenario with ConversationAssertions that exercise all four
+	//        composition_* handlers. These run after the conversation completes
+	//        via evaluateConversationAssertions → resolveEvalOrchestrator.
+	scenario := &config.Scenario{
+		ID:       "recorder-scenario",
+		TaskType: "compose-rec-task",
+		Turns: []config.TurnDefinition{
+			{Role: "user", Content: `{"flag":"a"}`},
+		},
+		ConversationAssertions: []assertions.AssertionConfig{
+			// branch "route" must have taken "leaf_a" (flag == "a")
+			{
+				Type:    "composition_branch_taken",
+				Message: "branch route took leaf_a",
+				Params: map[string]any{
+					"branch":   "route",
+					"expected": "leaf_a",
+				},
+			},
+			// parallel "par" must be complete
+			{
+				Type:    "composition_parallel_complete",
+				Message: "parallel par is complete",
+				Params: map[string]any{
+					"parallel": "par",
+				},
+			},
+			// leaf_a step must have recorded output containing "leaf_a"
+			{
+				Type:    "composition_step_output",
+				Message: "leaf_a step output recorded",
+				Params: map[string]any{
+					"step":     "leaf_a",
+					"contains": "leaf_a",
+				},
+			},
+			// fin step (composition output) must contain "done"
+			{
+				Type:    "composition_output",
+				Message: "composition output contains done",
+				Params: map[string]any{
+					"contains": "done",
+				},
+			},
+		},
+	}
+
+	// --- 7. Wire the Arena engine.
+	mockProv := mock.NewProvider("mock-rec", "test-model", false)
+	provReg := providers.NewRegistry()
+	provReg.Register(mockProv)
+
+	arenaStore := statestore.NewArenaStateStore()
+
+	pipelineExec := turnexecutors.NewPipelineExecutor(reg, nil)
+	scriptedExec := turnexecutors.NewScriptedExecutor(pipelineExec)
+	convExec := NewDefaultConversationExecutor(scriptedExec, nil, nil, nil, evalOrch)
+
+	transExec := newWorkflowTransitionExecutor(wfSpec, reg)
+
+	e := &Engine{
+		config: &config.Config{
+			LoadedPack: pack,
+		},
+		scenarios: map[string]*config.Scenario{
+			"recorder-scenario": scenario,
+		},
+		evals:                make(map[string]*config.Eval),
+		providers:            make(map[string]*config.Provider),
+		providerRegistry:     provReg,
+		stateStore:           arenaStore,
+		conversationExecutor: convExec,
+		toolRegistry:         reg,
+		workflowSpec:         wfSpec,
+		workflowTransExec:    transExec,
+		evalOrchestrator:     evalOrch,
+	}
+
+	// --- 8. Execute.
+	combo := RunCombination{
+		ScenarioID: "recorder-scenario",
+		ProviderID: "mock-rec",
+		Region:     "default",
+	}
+	runID, err := e.executeRun(ctx, combo)
+	require.NoError(t, err)
+	require.NotEmpty(t, runID)
+
+	// --- 9. Load the stored run result.
+	result, err := arenaStore.GetResult(ctx, runID)
+	require.NoError(t, err)
+	require.NotNil(t, result, "run result must be stored")
+
+	// The run must not have failed.
+	assert.Empty(t, result.Error, "composition run must not error")
+
+	// --- 10. Assert all four composition_* conversation assertions passed.
+	//
+	//   ConversationAssertions.Results is populated by saveRunMetadata, which
+	//   reads from ConversationResult.ConversationAssertionResults.
+	summary := result.ConversationAssertions
+	require.NotEmpty(t, summary.Results,
+		"expected ConversationAssertions.Results to be populated (got %d total, %d failed)",
+		summary.Total, summary.Failed)
+
+	for _, res := range summary.Results {
+		assert.True(t, res.Passed,
+			"assertion %q must pass; message: %s; details: %v",
+			res.Type, res.Message, res.Details)
+	}
+}

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/skills"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
@@ -170,6 +171,17 @@ func (e *Engine) prepareWorkflowScenario(scenario *config.Scenario, runID string
 			orch = e.evalOrchestrator.Clone()
 			orch.SetWorkflowMetadataProvider(provider)
 		}
+
+		// RFC 0010 Task 5: create a per-run composition recorder and wire it
+		// so composition_* assertions can read step outputs, branch targets, and
+		// parallel statuses. The same recorder is stashed on the run state (for
+		// retrieval in buildTurnRequest) and set as the EvalOrchestrator's
+		// CompositionMetadataProvider (so assertions see it in buildEvalContext).
+		rec := stage.NewCompositionRecorder()
+		e.workflowTransExec.SetCompositionRecorder(runID, rec)
+		if orch != nil {
+			orch.SetCompositionMetadataProvider(rec)
+		}
 	}
 
 	return orch, nil
@@ -272,8 +284,9 @@ func (e *Engine) buildEntryStateMeta(stateName string) map[string]interface{} {
 // wireWorkflowHooks sets up per-turn hooks for workflow scenarios:
 // PostTurnHook commits deferred transitions, ContextEnricher injects
 // the per-run skill filter into context for the next turn's tool execution,
-// and ActiveCompositionResolver resolves the active composition for the
-// current workflow state (RFC 0010).
+// ActiveCompositionResolver resolves the active composition for the
+// current workflow state (RFC 0010), and CompositionRecorder threads the
+// per-run recorder so buildStagePipeline can wire it into CompositionStage.
 func (e *Engine) wireWorkflowHooks(req *ConversationRequest, runID string) {
 	req.PostTurnHook = func() error {
 		var emitter *events.Emitter
@@ -290,6 +303,10 @@ func (e *Engine) wireWorkflowHooks(req *ConversationRequest, runID string) {
 		return ctx
 	}
 	req.ActiveCompositionResolver = e.buildCompositionResolver(runID)
+	// RFC 0010 Task 5: thread the per-run composition recorder so that
+	// buildTurnRequest can stamp it onto every TurnRequest, enabling
+	// NewCompositionStageWithRecorder to record step outputs per turn.
+	req.CompositionRecorder = e.workflowTransExec.CompositionRecorder(runID)
 }
 
 // buildCompositionResolver returns a function that resolves the active

--- a/tools/arena/engine/interfaces.go
+++ b/tools/arena/engine/interfaces.go
@@ -99,6 +99,12 @@ type ConversationRequest struct {
 	// nil for states that are not composition-orchestrated.
 	ActiveCompositionResolver func() *composition.Composition
 
+	// CompositionRecorder is the per-run recorder for RFC 0010 testability. When
+	// non-nil it is stamped onto every TurnRequest so buildStagePipeline can pass
+	// it to NewCompositionStageWithRecorder. Reset() is called per turn so stale
+	// data from a prior turn does not leak into the next turn's assertions.
+	CompositionRecorder *stage.CompositionRecorder
+
 	// AudioRouter, when non-nil, is the per-run AudioRouter for audio
 	// monitoring. MonitorTap stages added to the pipeline publish to this
 	// router. Lifetime is the run; the engine owns Close().

--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 )
@@ -41,6 +42,8 @@ type workflowRunState struct {
 	transitions []map[string]any
 	skillFilter string // current skill glob filter for this run
 	emitter     *events.Emitter
+	// compositionRecorder captures per-step outputs for RFC 0010 testability; nil for non-composition runs.
+	compositionRecorder *stage.CompositionRecorder
 }
 
 // workflowTransitionExecutor routes workflow__transition tool calls to per-run
@@ -264,6 +267,26 @@ func (e *workflowTransitionExecutor) SkillFilter(runID string) string {
 		return run.skillFilter
 	}
 	return ""
+}
+
+// SetCompositionRecorder stores the per-run composition recorder on the run state.
+// Called from prepareWorkflowScenario after the run is registered.
+func (e *workflowTransitionExecutor) SetCompositionRecorder(runID string, rec *stage.CompositionRecorder) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if run := e.runs[runID]; run != nil {
+		run.compositionRecorder = rec
+	}
+}
+
+// CompositionRecorder returns the per-run composition recorder, or nil if not set.
+func (e *workflowTransitionExecutor) CompositionRecorder(runID string) *stage.CompositionRecorder {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if run := e.runs[runID]; run != nil {
+		return run.compositionRecorder
+	}
+	return nil
 }
 
 // UnregisterRun removes a completed run's state to prevent unbounded map growth.

--- a/tools/arena/turnexecutors/interfaces.go
+++ b/tools/arena/turnexecutors/interfaces.go
@@ -118,6 +118,12 @@ type TurnRequest struct {
 	// ActiveComposition, when non-nil, makes this turn run a CompositionStage that
 	// executes the composition instead of an LLM ProviderStage (RFC 0010).
 	ActiveComposition *composition.Composition
+
+	// CompositionRecorder, when non-nil, is the per-run recorder that captures
+	// step outputs, branch targets, and parallel statuses for composition_*
+	// assertion handlers. Reset() is called per turn before pipeline execution.
+	// Only set on workflow composition turns; nil on non-composition turns.
+	CompositionRecorder *stage.CompositionRecorder
 }
 
 // StateStoreConfig wraps the state store configuration for turn executors

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -365,7 +365,16 @@ func (e *PipelineExecutor) buildStagePipeline(
 			BaseVariables:  mergedVars,
 			SchemaResolver: stage.NewFileSchemaResolver(req.BaseDir),
 		}
-		stages = append(stages, stage.NewCompositionStage("composition", req.ActiveComposition, deps))
+		// RFC 0010 Task 5: when a per-run recorder is wired, build the
+		// CompositionStage with it so step outputs, branch targets, and
+		// parallel statuses are captured for composition_* assertions.
+		if req.CompositionRecorder != nil {
+			stages = append(stages, stage.NewCompositionStageWithRecorder(
+				"composition", req.ActiveComposition, deps, req.CompositionRecorder,
+			))
+		} else {
+			stages = append(stages, stage.NewCompositionStage("composition", req.ActiveComposition, deps))
+		}
 	} else {
 		providerConfig := buildProviderConfig(req)
 		guardrailHooks := loadGuardrailHooks(req, mergedVars)


### PR DESCRIPTION
## Summary

Implements **Plan 4c** of RFC 0010 Workflow Composition: Arena testability for composition states. Together with Plan 4a (#1345, Arena execution) and Plan 4b (#1346, SDK function-mode), this completes the SDK-surface + Arena-testability phase.

### What's here

| Area | Change |
|------|--------|
| `runtime/composition/engine` | optional `Recorder` (via `NewWithRecorder`; `New`/`Execute` unchanged) capturing per-step output / branch-taken / parallel-status |
| `runtime/pipeline/stage` | `CompositionRecorder` (mutex-guarded, implements `engine.Recorder` + `CompositionMetadata()` + `Reset()`); `NewCompositionStageWithRecorder` resets it per turn |
| `runtime/pipeline/stage` + `runtime/providers/mock` | **mock step-id keying** — `execLLM` stamps `step.ID` into `ProviderRequestMetadata`; mock `ResponseParams.StepID` + per-scenario `steps:` map → per-step mock responses |
| `tools/arena/engine` | `CompositionMetadataProvider` bridge in `EvalOrchestrator` (mirrors `WorkflowMetadataProvider`); per-run recorder shared between the orchestrator clone and each turn's `CompositionStage`, reset per turn |
| `runtime/evals/handlers` | four pure-primitive assertion handlers: `composition_step_output`, `composition_branch_taken`, `composition_parallel_complete`, `composition_output` |

### Design notes
- The engine recorder is **non-breaking** — `New`/`Execute` signatures are unchanged; recording is opt-in via `NewWithRecorder`.
- The metadata bridge uses the same **pull model** as `WorkflowMetadataProvider`; the per-run recorder is the single shared instance both written by the turn's stage and read by the orchestrator, with per-run isolation and reset-per-turn (no stale composition metadata leaks into non-composition turns).
- Handlers follow the package convention: emit raw `Score`/`MetricValue`/`Details`, never `Value`, and reject `min_score`/`max_score` (thresholds live on the `assertion` wrapper).

## Test Plan

- [x] `go test ./runtime/composition/... ./runtime/pipeline/stage/... ./runtime/providers/mock/... ./runtime/evals/... -race -count=1` — green
- [x] `go test ./tools/arena/... -count=1` — green
- [x] `golangci-lint run ./runtime/... ./tools/arena/...` — 0 new issues
- [x] **End-to-end:** `TestExecuteRun_CompositionRecorder` runs an Arena composition state (branch + parallel + steps) and asserts all four `composition_*` handlers pass on the real recorded data
- [x] Mock step-id keying tested; `engine.Recorder` records branch/parallel/step (skipped steps excluded)

Implemented TDD-style; a final principal-level review returned **Ship**.

Closes #1335. Epic #1337.
