### PR TITLE
fix(composition): load inline Arena compositions + propagate mock metadata into step sub-pipelines

### DIFF
--- a/runtime/pipeline/stage/composition_executor.go
+++ b/runtime/pipeline/stage/composition_executor.go
@@ -67,6 +67,10 @@ type CompositionExecutorDeps struct {
 	// structured output. nil (or a nil return) means no ResponseFormat is set.
 	// Plan 3 supplies the real resolver from the pack/config dir.
 	SchemaResolver func(path string) (json.RawMessage, error)
+	// BaseMetadata is merged into each sub-pipeline's ProviderRequestMetadata
+	// alongside composition_step_id. Arena uses this to propagate mock_scenario_id
+	// so per-step mock responses are keyed against the right scenario.
+	BaseMetadata map[string]interface{}
 }
 
 // NewCompositionStepExecutor returns an engine.StepExecutor that runs prompt/agent
@@ -113,10 +117,15 @@ func (deps CompositionExecutorDeps) execLLM(
 		return nil, fmt.Errorf("step %q: provider/prompt registry not configured", step.ID)
 	}
 
+	meta := map[string]interface{}{compositionStepIDKey: step.ID}
+	for k, v := range deps.BaseMetadata {
+		meta[k] = v
+	}
 	turnState := &TurnState{
 		// Stamp the executing step id so the mock provider can key per-step
 		// responses (Arena testability); flows to PredictionRequest.Metadata.
-		ProviderRequestMetadata: map[string]interface{}{compositionStepIDKey: step.ID},
+		// BaseMetadata (e.g. mock_scenario_id from Arena) is also merged here.
+		ProviderRequestMetadata: meta,
 	}
 	promptStage := NewPromptAssemblyStageWithTurnState(deps.PromptRegistry, step.PromptTask, deps.BaseVariables, turnState)
 	templateStage := NewTemplateStageWithTurnState(deps.Emitter, turnState)

--- a/runtime/pipeline/stage/composition_executor_test.go
+++ b/runtime/pipeline/stage/composition_executor_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -524,6 +526,87 @@ func TestCompositionExecutor_HooksFirePerStep(t *testing.T) {
 	}
 	if hk.count() == 0 {
 		t.Error("expected the provider hook to fire for the step's sub-pipeline, but AfterCall count is 0")
+	}
+}
+
+// recordingProvider is a minimal providers.Provider stub that records the
+// PredictionRequest.Metadata from the most recent Predict call. Used to verify
+// that BaseMetadata is threaded through to the provider request.
+type recordingProvider struct {
+	lastMetadata map[string]interface{}
+}
+
+func (r *recordingProvider) ID() string                               { return "recording" }
+func (r *recordingProvider) Name() string                             { return "recording" }
+func (r *recordingProvider) Type() base.ProviderType                  { return base.ProviderTypeInference }
+func (r *recordingProvider) Pricing() *base.PricingDescriptor         { return nil }
+func (r *recordingProvider) Validate() error                          { return nil }
+func (r *recordingProvider) Init(_ context.Context) error             { return nil }
+func (r *recordingProvider) HealthCheck(_ context.Context) error      { return nil }
+func (r *recordingProvider) Model() string                            { return "recording-model" }
+func (r *recordingProvider) SupportsStreaming() bool                  { return false }
+func (r *recordingProvider) ShouldIncludeRawOutput() bool             { return false }
+func (r *recordingProvider) CalculateCost(_, _, _ int) types.CostInfo { return types.CostInfo{} }
+func (r *recordingProvider) Close() error                             { return nil }
+
+func (r *recordingProvider) Predict(_ context.Context, req providers.PredictionRequest) (providers.PredictionResponse, error) {
+	r.lastMetadata = req.Metadata
+	return providers.PredictionResponse{Content: "ok"}, nil
+}
+
+func (r *recordingProvider) PredictStream(_ context.Context, req providers.PredictionRequest) (<-chan providers.StreamChunk, error) {
+	r.lastMetadata = req.Metadata
+	ch := make(chan providers.StreamChunk, 1)
+	ch <- providers.StreamChunk{Content: "ok", Delta: "ok", FinishReason: strPtr("stop"),
+		FinalResult: &providers.PredictionResponse{Content: "ok"}}
+	close(ch)
+	return ch, nil
+}
+
+func strPtr(s string) *string { return &s }
+
+// TestCompositionExecutor_BaseMetadataThreaded verifies that keys set in
+// CompositionExecutorDeps.BaseMetadata are forwarded to the provider's
+// PredictionRequest.Metadata alongside the composition_step_id.
+// This covers the BaseMetadata merge added in the inline-fixes PR.
+func TestCompositionExecutor_BaseMetadataThreaded(t *testing.T) {
+	repo := newMockRepo()
+	reg := prompt.NewRegistryWithRepository(repo)
+	registerSimplePrompt(t, reg, "p")
+
+	prov := &recordingProvider{}
+
+	exec := NewCompositionStepExecutor(CompositionExecutorDeps{
+		PromptRegistry: reg,
+		Provider:       prov,
+		ToolRegistry:   tools.NewRegistry(),
+		BaseMetadata: map[string]interface{}{
+			"mock_scenario_id": "sc1",
+			"extra_key":        "extra_val",
+		},
+	})
+
+	step := &composition.Step{ID: "my-step", Kind: composition.KindPrompt, PromptTask: "p"}
+	if _, err := exec(context.Background(), step, json.RawMessage(`"hello"`)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := prov.lastMetadata
+	if got == nil {
+		t.Fatal("provider received nil metadata — BaseMetadata was not threaded")
+	}
+
+	// composition_step_id must be stamped
+	if got["composition_step_id"] != "my-step" {
+		t.Errorf("composition_step_id = %v, want %q", got["composition_step_id"], "my-step")
+	}
+
+	// base metadata keys must be merged in
+	if got["mock_scenario_id"] != "sc1" {
+		t.Errorf("mock_scenario_id = %v, want %q", got["mock_scenario_id"], "sc1")
+	}
+	if got["extra_key"] != "extra_val" {
+		t.Errorf("extra_key = %v, want %q", got["extra_key"], "extra_val")
 	}
 }
 

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/skills"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
@@ -113,6 +114,28 @@ func (e *Engine) initWorkflow() error {
 	// Wire skill filtering so transitions update skill availability
 	if e.skillExecutor != nil {
 		transExec.skillFilterer = e.skillExecutor
+	}
+
+	// RFC 0010: parse inline compositions from the arena config and merge
+	// them into LoadedPack.Compositions so buildCompositionResolver can find
+	// them at turn time. This mirrors the packc compile-time path but avoids
+	// requiring a compiled pack for arena testing.
+	if e.config.Compositions != nil {
+		comps, compErr := composition.ParseConfig(e.config.Compositions)
+		if compErr != nil {
+			return fmt.Errorf("parsing compositions: %w", compErr)
+		}
+		if len(comps) > 0 {
+			if e.config.LoadedPack == nil {
+				e.config.LoadedPack = &prompt.Pack{}
+			}
+			if e.config.LoadedPack.Compositions == nil {
+				e.config.LoadedPack.Compositions = make(map[string]*composition.Composition)
+			}
+			for name, comp := range comps {
+				e.config.LoadedPack.Compositions[name] = comp
+			}
+		}
 	}
 
 	return nil
@@ -316,10 +339,12 @@ func (e *Engine) wireWorkflowHooks(req *ConversationRequest, runID string) {
 func (e *Engine) buildCompositionResolver(runID string) func() *composition.Composition {
 	return func() *composition.Composition {
 		if e.config.LoadedPack == nil || len(e.config.LoadedPack.Compositions) == 0 {
+			logger.Debug("buildCompositionResolver: no LoadedPack compositions")
 			return nil
 		}
 		sm := e.workflowTransExec.StateMachine(runID)
 		if sm == nil {
+			logger.Debug("buildCompositionResolver: no state machine")
 			return nil
 		}
 		stateName := sm.CurrentState()

--- a/tools/arena/engine/inline_composition_test.go
+++ b/tools/arena/engine/inline_composition_test.go
@@ -1,0 +1,160 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// minimalEngineForWorkflow builds an Engine directly (bypassing NewEngine's
+// side-effecting buildMediaStorage/buildStateStore) with just the fields that
+// initWorkflow reads. Used by inline-composition tests only.
+func minimalEngineForWorkflow(cfg *config.Config) *Engine {
+	return &Engine{
+		config:       cfg,
+		toolRegistry: tools.NewRegistry(),
+		// promptRegistry is not used by initWorkflow; nil is safe here.
+		promptRegistry: (*prompt.Registry)(nil),
+	}
+}
+
+// TestInitWorkflow_InlineCompositionsLoaded verifies that when config.Compositions
+// is set (the inline Arena path), initWorkflow parses them and populates
+// config.LoadedPack.Compositions so that buildCompositionResolver can find them
+// at turn time. This covers the fix in execution_workflow_integration.go.
+func TestInitWorkflow_InlineCompositionsLoaded(t *testing.T) {
+	// Minimal workflow spec — needed because initWorkflow returns early if
+	// config.Workflow is nil.
+	workflowRaw := map[string]interface{}{
+		"version": 1,
+		"entry":   "start",
+		"states": map[string]interface{}{
+			"start": map[string]interface{}{
+				"prompt_task":   "start-task",
+				"orchestration": "composition",
+				"composition":   "flow",
+			},
+		},
+	}
+
+	// Inline compositions: one named "flow" with a single tool step.
+	compositionsRaw := map[string]interface{}{
+		"flow": map[string]interface{}{
+			"version": 1,
+			"steps": []interface{}{
+				map[string]interface{}{
+					"id":   "step1",
+					"kind": "tool",
+					"tool": "echo",
+				},
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		Workflow:     workflowRaw,
+		Compositions: compositionsRaw,
+	}
+
+	eng := minimalEngineForWorkflow(cfg)
+
+	if err := eng.initWorkflow(); err != nil {
+		t.Fatalf("initWorkflow() returned unexpected error: %v", err)
+	}
+
+	// LoadedPack must have been created and populated.
+	if cfg.LoadedPack == nil {
+		t.Fatal("initWorkflow() did not create config.LoadedPack when Compositions was set")
+	}
+	if cfg.LoadedPack.Compositions == nil {
+		t.Fatal("initWorkflow() did not populate config.LoadedPack.Compositions")
+	}
+	comp, ok := cfg.LoadedPack.Compositions["flow"]
+	if !ok || comp == nil {
+		t.Fatalf("initWorkflow() did not add 'flow' to LoadedPack.Compositions; got: %v",
+			cfg.LoadedPack.Compositions)
+	}
+	if len(comp.Steps) != 1 || comp.Steps[0].ID != "step1" {
+		t.Errorf("composition 'flow' has unexpected steps: %+v", comp.Steps)
+	}
+}
+
+// TestInitWorkflow_NoCompositions verifies that when config.Compositions is nil,
+// initWorkflow does not create a LoadedPack (no-op path).
+func TestInitWorkflow_NoCompositions(t *testing.T) {
+	workflowRaw := map[string]interface{}{
+		"version": 1,
+		"entry":   "start",
+		"states": map[string]interface{}{
+			"start": map[string]interface{}{
+				"prompt_task": "start-task",
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		Workflow:     workflowRaw,
+		Compositions: nil,
+	}
+
+	eng := minimalEngineForWorkflow(cfg)
+
+	if err := eng.initWorkflow(); err != nil {
+		t.Fatalf("initWorkflow() returned unexpected error: %v", err)
+	}
+
+	// LoadedPack should not have been created when Compositions is nil.
+	if cfg.LoadedPack != nil {
+		t.Errorf("initWorkflow() unexpectedly created LoadedPack when Compositions was nil: %+v", cfg.LoadedPack)
+	}
+}
+
+// TestInitWorkflow_MergesIntoExistingLoadedPack verifies that when config.LoadedPack
+// is already populated (e.g. from a compiled pack file), initWorkflow merges inline
+// compositions into the existing map without replacing it.
+func TestInitWorkflow_MergesIntoExistingLoadedPack(t *testing.T) {
+	workflowRaw := map[string]interface{}{
+		"version": 1,
+		"entry":   "start",
+		"states": map[string]interface{}{
+			"start": map[string]interface{}{
+				"prompt_task": "start-task",
+			},
+		},
+	}
+
+	compositionsRaw := map[string]interface{}{
+		"inline-flow": map[string]interface{}{
+			"version": 1,
+			"steps": []interface{}{
+				map[string]interface{}{"id": "s1", "kind": "tool", "tool": "echo"},
+			},
+		},
+	}
+
+	existingPack := &prompt.Pack{
+		ID: "pre-existing",
+	}
+
+	cfg := &config.Config{
+		Workflow:     workflowRaw,
+		Compositions: compositionsRaw,
+		LoadedPack:   existingPack,
+	}
+
+	eng := minimalEngineForWorkflow(cfg)
+
+	if err := eng.initWorkflow(); err != nil {
+		t.Fatalf("initWorkflow() returned unexpected error: %v", err)
+	}
+
+	// The existing pack should still be the same pointer.
+	if cfg.LoadedPack != existingPack {
+		t.Error("initWorkflow() replaced config.LoadedPack instead of merging into it")
+	}
+	if cfg.LoadedPack.Compositions["inline-flow"] == nil {
+		t.Error("initWorkflow() did not merge 'inline-flow' into existing LoadedPack.Compositions")
+	}
+}

--- a/tools/arena/turnexecutors/composition_integration_test.go
+++ b/tools/arena/turnexecutors/composition_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/stretchr/testify/require"
@@ -78,5 +79,59 @@ func TestBuildStagePipeline_CompositionStageSelected(t *testing.T) {
 	// The echo tool returns the args JSON; composition output should reference "message".
 	if result.Response.Content == "" {
 		t.Fatal("expected non-empty response content from composition")
+	}
+}
+
+// TestBuildStagePipeline_CompositionStage_MockProviderBaseMetadata verifies that
+// when a mock provider is used for a composition turn AND the scenario has a non-empty
+// ID, buildStagePipeline sets mock_scenario_id in BaseMetadata so the mock provider
+// can key per-step responses against the right scenario. This covers the baseMetadata
+// lines added in the inline-fixes PR (pipeline_stages_integration.go).
+func TestBuildStagePipeline_CompositionStage_MockProviderBaseMetadata(t *testing.T) {
+	// One-step tool composition (echo), same as the sibling test.
+	comp := &composition.Composition{
+		Version: 1,
+		Steps: []*composition.Step{
+			{
+				ID:   "greet",
+				Kind: composition.KindTool,
+				Tool: "echo",
+				Args: map[string]any{"message": "hi"},
+			},
+		},
+	}
+
+	reg := tools.NewRegistry()
+	require.NoError(t, reg.Register(&tools.ToolDescriptor{
+		Name:        "echo",
+		Description: "echoes args",
+		Mode:        "echo",
+	}))
+	reg.RegisterExecutor(&echoExecutor{})
+
+	// Use a real mock.Provider so isMockProvider() returns true, exercising
+	// the baseMetadata["mock_scenario_id"] assignment.
+	mockProv := mock.NewProvider("mock-id", "mock-model", false)
+
+	executor := NewPipelineExecutor(reg, nil)
+
+	req := &TurnRequest{
+		Provider:          mockProv,
+		Scenario:          &config.Scenario{ID: "sc1", TaskType: "unused"},
+		ActiveComposition: comp,
+		BaseDir:           t.TempDir(),
+	}
+
+	baseVars := map[string]string{}
+	pipeline, err := executor.buildStagePipeline(req, baseVars)
+	require.NoError(t, err)
+	require.NotNil(t, pipeline)
+
+	userMsg := &types.Message{Role: "user", Content: `{"input":"hi"}`}
+	result, err := pipeline.ExecuteSync(context.Background(), stage.StreamElement{Message: userMsg})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	if result.Response == nil {
+		t.Fatal("expected a response from composition pipeline, got nil")
 	}
 }

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -356,6 +356,13 @@ func (e *PipelineExecutor) buildStagePipeline(
 		emitter := emitterFromRequest(req)
 		guardrailHooks := loadGuardrailHooks(req, mergedVars)
 		hookReg := buildHookRegistry(req, guardrailHooks)
+		// BaseMetadata propagates mock_scenario_id (and future per-turn metadata)
+		// into composition sub-pipelines so the mock provider can key per-step
+		// responses against the right scenario.
+		baseMetadata := map[string]interface{}{}
+		if req.Scenario != nil && req.Scenario.ID != "" && isMockProvider(req.Provider) {
+			baseMetadata["mock_scenario_id"] = req.Scenario.ID
+		}
 		deps := stage.CompositionExecutorDeps{
 			PromptRegistry: req.PromptRegistry,
 			Provider:       req.Provider,
@@ -364,6 +371,7 @@ func (e *PipelineExecutor) buildStagePipeline(
 			HookRegistry:   hookReg,
 			BaseVariables:  mergedVars,
 			SchemaResolver: stage.NewFileSchemaResolver(req.BaseDir),
+			BaseMetadata:   baseMetadata,
 		}
 		// RFC 0010 Task 5: when a per-run recorder is wired, build the
 		// CompositionStage with it so step outputs, branch targets, and


### PR DESCRIPTION
## Summary

Two real gaps surfaced while building the first end-to-end composition Arena example (RFC 0010), plus the supporting plumbing:

1. **Inline `compositions:` in an Arena config never loaded.** Only compiled `pack_file:` packs populated `LoadedPack.Compositions`; an Arena config with an inline `compositions:` block left it empty, so `buildCompositionResolver` never found the composition and the state ran as a normal (empty) turn. `initWorkflow` now parses `config.Compositions` into `LoadedPack.Compositions` (mirrors the packc compile path). The 4a/4c e2e tests had set that map directly in-test, which is why this path was missed.
2. **Mock metadata didn't reach composition sub-pipelines.** Each composition step builds its own sub-pipeline with a fresh `TurnState`, so `mock_scenario_id` from the outer turn was lost and the mock returned empty per-step responses. Added `CompositionExecutorDeps.BaseMetadata`, merged into each step's `ProviderRequestMetadata` alongside `composition_step_id`; Arena populates it with `mock_scenario_id` for mock providers.

## Test Plan
- [x] `TestCompositionExecutor_BaseMetadataThreaded` — a recording provider stub proves both `composition_step_id` and the base metadata reach the step's `PredictionRequest.Metadata`
- [x] `TestInitWorkflow_InlineCompositionsLoaded` (+ no-op + merge-into-existing) — inline `Compositions` populate `LoadedPack.Compositions`
- [x] Arena `buildStagePipeline` composition branch covered with a mock provider + scenario
- [x] `go test ./runtime/pipeline/stage/... -race`, `go test ./tools/arena/...` — green; coverage 88–95% on changed files; lint clean

Found while building the (schema-gated) `document-analysis` composition example; these fixes are independent of the schema-release gate and ship now. Part of #1336. Epic #1337.
