### PR TITLE
feat(examples): document-analysis composition example (RFC 0010) [gated on schema release]

### DIFF
--- a/examples/document-analysis/README.md
+++ b/examples/document-analysis/README.md
@@ -5,19 +5,6 @@ It shows how a multi-step document analysis pipeline — classify, branch, extra
 parallel metadata, synthesize — is authored as a `compositions:` block and tested
 with composition-specific assertions.
 
-> **IMPORTANT — requires `PROMPTKIT_SCHEMA_SOURCE=local`**
->
-> The `compositions:` and `orchestration: composition` schema fields have not yet
-> been published in a PromptKit release. Running this example against the remote
-> schemas (the default) will produce a schema validation error. Until the next
-> release ships, always set:
->
-> ```bash
-> export PROMPTKIT_SCHEMA_SOURCE=local
-> ```
->
-> or prefix the run command with `env PROMPTKIT_SCHEMA_SOURCE=local` as shown below.
-
 ## What it demonstrates
 
 - A single-state terminal workflow whose state uses `orchestration: composition`
@@ -61,14 +48,13 @@ make -C /path/to/promptkit build-arena
 Run the example:
 
 ```bash
-env PROMPTKIT_SCHEMA_SOURCE=local promptarena run --ci --formats json
+promptarena run --ci --formats json
 ```
 
 Or from the promptkit root:
 
 ```bash
-env -C examples/document-analysis PROMPTKIT_SCHEMA_SOURCE=local \
-  bin/promptarena run --ci --formats json
+env -C examples/document-analysis ../../bin/promptarena run --ci --formats json
 ```
 
 Successful output exits with code 0 and all four `composition_*` assertions pass.
@@ -99,8 +85,7 @@ input
 
 ## Schema status
 
-This example requires `PROMPTKIT_SCHEMA_SOURCE=local` because the `compositions`
-field and `orchestration: composition` state field have not yet been published to
-`https://promptkit.altairalabs.ai/schemas/v1alpha1/`. Once the next PromptKit
-release lands, this flag can be dropped and the example will validate against the
-remote schemas automatically.
+The `compositions` field, the `orchestration: composition` state mode, and the
+`composition_*` assertion types are published in the PromptPack spec **v1.5.0**
+(and PromptKit's bundled schemas), so this example validates against the remote
+schemas automatically — no `PROMPTKIT_SCHEMA_SOURCE=local` needed.

--- a/examples/document-analysis/README.md
+++ b/examples/document-analysis/README.md
@@ -1,246 +1,106 @@
-# Document Analysis Example
+# Document Analysis — Workflow Composition Example (RFC 0010)
 
-This example demonstrates document attachment support (PDFs, Word docs, etc.) using PromptArena configuration and testing framework.
+This example demonstrates **workflow composition** (RFC 0010) using PromptArena.
+It shows how a multi-step document analysis pipeline — classify, branch, extract,
+parallel metadata, synthesize — is authored as a `compositions:` block and tested
+with composition-specific assertions.
 
-## Overview
+> **IMPORTANT — requires `PROMPTKIT_SCHEMA_SOURCE=local`**
+>
+> The `compositions:` and `orchestration: composition` schema fields have not yet
+> been published in a PromptKit release. Running this example against the remote
+> schemas (the default) will produce a schema validation error. Until the next
+> release ships, always set:
+>
+> ```bash
+> export PROMPTKIT_SCHEMA_SOURCE=local
+> ```
+>
+> or prefix the run command with `env PROMPTKIT_SCHEMA_SOURCE=local` as shown below.
 
-PromptArena allows you to test document analysis workflows with multiple providers using declarative YAML configuration. This example shows how to:
+## What it demonstrates
 
-- Attach PDF documents to prompts using media configuration
-- Test document analysis across different LLM providers (Claude, Gemini)
-- Run deterministic tests with mock providers for CI/CD
-- Compare multiple documents or mix documents with images
+- A single-state terminal workflow whose state uses `orchestration: composition`
+- A `compositions:` block with all five RFC 0010 step kinds:
+  - `prompt` — classify document type
+  - `branch` — route to paper vs general extractor based on classify output
+  - `prompt` — extract_paper / extract_general (only one runs per document)
+  - `parallel` — generate summary and keywords concurrently, reduce with `barrier`
+  - `agent` — synthesize a final analysis (with `termination.max_steps`)
+- Mock provider with a `steps:` map keyed by composition step ID
+- All four composition assertion types: `composition_branch_taken`,
+  `composition_parallel_complete`, `composition_step_output`, `composition_output`
 
-## Quick Start
-
-Run all scenarios with the mock provider (no API calls):
-
-```bash
-promptarena run config.arena.yaml --provider mock-docs
-```
-
-Run with a real provider:
-
-```bash
-export ANTHROPIC_API_KEY=your-key
-promptarena run config.arena.yaml --provider claude-docs
-```
-
-## Configuration Structure
+## Directory structure
 
 ```
 document-analysis/
-├── config.arena.yaml           # Main Arena configuration
+├── config.arena.yaml               # Arena config with workflow + compositions blocks
+├── mock-responses.yaml             # Step-keyed mock responses
 ├── prompts/
-│   └── document-analyzer.yaml  # Prompt with document media support
+│   ├── classify_doc.yaml           # Classify: research_paper | general
+│   ├── extract_paper.yaml          # Extract paper title, authors, abstract
+│   ├── extract_general.yaml        # Extract summary and key points
+│   ├── meta_summary.yaml           # Generate concise summary
+│   ├── meta_keywords.yaml          # Extract keywords
+│   └── synthesize_doc.yaml         # Synthesize final analysis
 ├── providers/
-│   ├── claude-docs.provider.yaml   # Claude configuration
-│   ├── gemini-docs.provider.yaml   # Gemini configuration
-│   └── mock-docs.provider.yaml     # Mock provider for testing
-├── scenarios/
-│   ├── pdf-summary.scenario.yaml       # Single document analysis
-│   ├── multi-doc-compare.scenario.yaml # Multiple document comparison
-│   └── mixed-media.scenario.yaml       # Document + image analysis
-├── mock-responses.yaml         # Deterministic test responses
-└── test-docs/                  # Sample test documents
-    ├── sample.pdf
-    ├── version1.pdf
-    ├── version2.pdf
-    ├── specs.pdf
-    └── diagram.png
+│   └── mock-provider.yaml          # Mock provider pointing to mock-responses.yaml
+└── scenarios/
+    └── research-paper.scenario.yaml  # Single-turn scenario with composition assertions
 ```
 
-## Scenarios Explained
+## Run
 
-### 1. PDF Summary (`pdf-summary.scenario.yaml`)
-
-Analyzes a single PDF document:
-
-```yaml
-variables:
-  user_question: "Please provide a brief summary of this document"
-
-media:
-  - type: document
-    source: test-docs/sample.pdf
-```
-
-Run it:
-```bash
-promptarena run config.arena.yaml --scenario pdf-summary --provider claude-docs
-```
-
-### 2. Multi-Document Compare (`multi-doc-compare.scenario.yaml`)
-
-Compares multiple PDF documents:
-
-```yaml
-variables:
-  user_question: "Compare these documents and identify key differences"
-
-media:
-  - type: document
-    source: test-docs/version1.pdf
-  - type: document
-    source: test-docs/version2.pdf
-  - type: document
-    source: test-docs/specs.pdf
-```
-
-Run it:
-```bash
-promptarena run config.arena.yaml --scenario multi-doc-compare --provider claude-docs
-```
-
-### 3. Mixed Media (`mixed-media.scenario.yaml`)
-
-Analyzes documents together with images:
-
-```yaml
-variables:
-  user_question: "Analyze the technical specifications and compare with the diagram"
-
-media:
-  - type: image
-    source: test-docs/diagram.png
-  - type: document
-    source: test-docs/specs.pdf
-```
-
-Run it:
-```bash
-promptarena run config.arena.yaml --scenario mixed-media --provider gemini-docs
-```
-
-## Prompt Configuration
-
-The prompt template ([prompts/document-analyzer.yaml](prompts/document-analyzer.yaml)) defines how media attachments are handled:
-
-```yaml
-id: document-analyzer
-name: Document Analyzer
-system_template: |
-  You are a document analysis assistant. Analyze documents carefully and provide
-  clear, structured responses.
-
-media:
-  enabled: true
-  types:
-    - document
-    - image
-```
-
-This configuration:
-- Enables media attachments
-- Accepts both documents and images
-- Works with multiple attachments in a single message
-
-## Provider Configuration
-
-### Mock Provider (CI/CD Testing)
-
-The mock provider ([providers/mock-docs.provider.yaml](providers/mock-docs.provider.yaml)) returns predefined responses without API calls:
-
-```yaml
-id: mock-docs
-name: Mock Provider for Document Tests
-provider: mock
-
-mock_responses:
-  file: mock-responses.yaml
-```
-
-Perfect for:
-- Automated testing in CI/CD pipelines
-- Development without API costs
-- Deterministic test outcomes
-
-### Claude Provider
-
-Claude ([providers/claude-docs.provider.yaml](providers/claude-docs.provider.yaml)) supports PDFs up to 32MB:
-
-```yaml
-id: claude-docs
-name: Claude with Document Support
-provider: claude
-model: claude-3-5-sonnet-20241022
-api_key: ${ANTHROPIC_API_KEY}
-```
-
-Usage:
-```bash
-export ANTHROPIC_API_KEY=your-key-here
-promptarena run config.arena.yaml --provider claude-docs
-```
-
-### Gemini Provider
-
-Gemini ([providers/gemini-docs.provider.yaml](providers/gemini-docs.provider.yaml)) supports PDFs up to 20MB:
-
-```yaml
-id: gemini-docs
-name: Gemini with Document Support
-provider: gemini
-model: gemini-1.5-pro
-api_key: ${GOOGLE_API_KEY}
-```
-
-Usage:
-```bash
-export GOOGLE_API_KEY=your-key-here
-promptarena run config.arena.yaml --provider gemini-docs
-```
-
-## Provider Capabilities
-
-| Provider | Max Size | Formats | Notes |
-|----------|----------|---------|-------|
-| Claude   | 32 MB    | PDF     | Native document support |
-| Gemini   | 20 MB    | PDF     | Base64 inline data |
-| Mock     | N/A      | All     | Deterministic responses |
-
-## Using Documents in Go Code
-
-If you need to use document attachments programmatically (not via PromptArena):
-
-```go
-import "github.com/altairalabs/promptkit/sdk"
-
-// From file
-resp, err := conv.Send(ctx, "Analyze this document",
-    sdk.WithDocumentFile("path/to/document.pdf"))
-
-// From memory
-pdfData, _ := os.ReadFile("document.pdf")
-resp, err := conv.Send(ctx, "Review this contract",
-    sdk.WithDocumentData(pdfData, "application/pdf"))
-
-// Multiple documents
-resp, err := conv.Send(ctx, "Compare these documents",
-    sdk.WithDocumentFile("v1.pdf"),
-    sdk.WithDocumentFile("v2.pdf"))
-```
-
-## Testing in CI/CD
-
-Run with the mock provider for fast, deterministic tests:
+Build the binary (if not already built):
 
 ```bash
-promptarena run config.arena.yaml --provider mock-docs --ci
+make -C /path/to/promptkit build-arena
 ```
 
-The `--ci` flag:
-- Exits with non-zero status on failures
-- Provides structured output
-- Perfect for GitHub Actions, GitLab CI, etc.
-
-## Advanced: Custom Test Documents
-
-Replace files in `test-docs/` with your own documents:
+Run the example:
 
 ```bash
-cp my-contract.pdf test-docs/sample.pdf
-promptarena run config.arena.yaml --scenario pdf-summary --provider claude-docs
+env PROMPTKIT_SCHEMA_SOURCE=local promptarena run --ci --formats json
 ```
 
-Or create new scenarios in `scenarios/` directory following the existing patterns.
+Or from the promptkit root:
+
+```bash
+env -C examples/document-analysis PROMPTKIT_SCHEMA_SOURCE=local \
+  bin/promptarena run --ci --formats json
+```
+
+Successful output exits with code 0 and all four `composition_*` assertions pass.
+
+## Composition DAG
+
+```
+input
+  └─ classify (prompt)
+       └─ route (branch)
+            ├─ [type=research_paper] → extract_paper (prompt)
+            └─ [else]               → extract_general (prompt)
+  └─ meta (parallel)
+       ├─ meta_summary (prompt)
+       └─ meta_keywords (prompt)
+       reduce: barrier → metadata
+  └─ synthesize (agent, max_steps: 3)   ← composition output
+```
+
+## Assertions explained
+
+| Assertion type | What it checks |
+|---|---|
+| `composition_branch_taken` | The `route` branch picked `extract_paper` |
+| `composition_parallel_complete` | The `meta` parallel step completed |
+| `composition_step_output` | The `classify` step output contains `research_paper` |
+| `composition_output` | The final synthesis output contains `deep learning` |
+
+## Schema status
+
+This example requires `PROMPTKIT_SCHEMA_SOURCE=local` because the `compositions`
+field and `orchestration: composition` state field have not yet been published to
+`https://promptkit.altairalabs.ai/schemas/v1alpha1/`. Once the next PromptKit
+release lands, this flag can be dropped and the example will validate against the
+remote schemas automatically.

--- a/examples/document-analysis/config.arena.yaml
+++ b/examples/document-analysis/config.arena.yaml
@@ -4,26 +4,83 @@ metadata:
   name: document-analysis
 spec:
   prompt_configs:
-    - id: document-analyzer
-      file: prompts/document-analyzer.yaml
+    - id: classify_doc
+      file: prompts/classify_doc.yaml
+    - id: extract_paper
+      file: prompts/extract_paper.yaml
+    - id: extract_general
+      file: prompts/extract_general.yaml
+    - id: meta_summary
+      file: prompts/meta_summary.yaml
+    - id: meta_keywords
+      file: prompts/meta_keywords.yaml
+    - id: synthesize_doc
+      file: prompts/synthesize_doc.yaml
 
   providers:
-    - file: providers/claude-docs.provider.yaml
-    - file: providers/gemini-docs.provider.yaml
-    - file: providers/mock-docs.provider.yaml
+    - file: providers/mock-provider.yaml
 
   scenarios:
-    - file: scenarios/pdf-summary.scenario.yaml
-    - file: scenarios/multi-doc-compare.scenario.yaml
-    # Mixed-media scenario disabled - image loading issues
-    # - file: scenarios/mixed-media.scenario.yaml
+    - file: scenarios/research-paper.scenario.yaml
+
+  workflow:
+    version: 1
+    entry: analyzing
+    states:
+      analyzing:
+        orchestration: composition
+        composition: analyze_document
+        terminal: true
+
+  compositions:
+    analyze_document:
+      version: 1
+      output: synthesize
+      steps:
+        - id: classify
+          kind: prompt
+          prompt_task: classify_doc
+          input: "${input}"
+          output_schema: schemas/classify_output.json
+        - id: route
+          kind: branch
+          predicate:
+            path: "${classify.output.type}"
+            op: equals
+            value: "research_paper"
+          then: extract_paper
+          else: extract_general
+        - id: extract_paper
+          kind: prompt
+          prompt_task: extract_paper
+          input: "${input}"
+        - id: extract_general
+          kind: prompt
+          prompt_task: extract_general
+          input: "${input}"
+        - id: meta
+          kind: parallel
+          branches:
+            - id: meta_summary
+              kind: prompt
+              prompt_task: meta_summary
+              input: "${input}"
+            - id: meta_keywords
+              kind: prompt
+              prompt_task: meta_keywords
+              input: "${input}"
+          reduce:
+            strategy: barrier
+            into: metadata
+        - id: synthesize
+          kind: agent
+          prompt_task: synthesize_doc
+          termination:
+            max_steps: 3
 
   defaults:
-    temperature: 0.7
-    max_tokens: 2000
-    concurrency: 2
+    temperature: 0.1
+    max_tokens: 512
     output:
       dir: out
       formats: ["json", "html"]
-      html:
-        file: document-report.html

--- a/examples/document-analysis/config.arena.yaml
+++ b/examples/document-analysis/config.arena.yaml
@@ -75,6 +75,7 @@ spec:
         - id: synthesize
           kind: agent
           prompt_task: synthesize_doc
+          input: "${meta.output.metadata}"
           termination:
             max_steps: 3
 

--- a/examples/document-analysis/mock-responses.yaml
+++ b/examples/document-analysis/mock-responses.yaml
@@ -1,56 +1,16 @@
-# Mock responses for document analysis scenarios
-defaultResponse: "I can analyze the document you've provided."
+# Mock responses for the document-analysis composition example (RFC 0010).
+# Responses are keyed by composition step ID under each scenario's `steps:` map.
+# The mock provider looks up responses by the step ID stamped into request metadata
+# by CompositionStage, so each key here matches a step `id` in the composition.
+
+defaultResponse: "{}"
 
 scenarios:
-  pdf-summary:
-    turns:
-      1: |
-        This document appears to be a comprehensive overview covering several key topics:
-
-        1. **Main Subject**: The document discusses fundamental principles and best practices
-        2. **Key Points**:
-           - Implementation strategies for scalable systems
-           - Performance optimization techniques
-           - Security considerations and compliance requirements
-        3. **Important Dates**: Referenced timeline spans Q1-Q4 2024
-        4. **Target Audience**: Technical teams and stakeholders
-
-        The document is well-structured with clear sections and actionable recommendations. It emphasizes practical application over theoretical concepts.
-      2: |
-        The main topics covered in this document include infrastructure design, security compliance, performance optimization, and team resource allocation across the Q1-Q4 2024 timeline.
-
-  multi-doc-compare:
-    turns:
-      1: |
-        After comparing the two documents, here are the key difference and similarities:
-        
-        **Version 1 vs Version 2 Changes:**
-        
-        1. **Updated Timeline**: Version 2 extends the implementation deadline by 2 months
-        2. **Budget Adjustments**: Increased budget allocation by 15% in Section 3.2
-        3. **New Requirements**: Version 2 adds three additional security requirements
-        4. **Removed Sections**: Section 4.5 on legacy system migration was removed in Version 2
-        5. **Personnel Changes**: Version 2 lists updated team composition
-        
-        The core objectives remain the same, but Version 2 reflects more realistic timelines and resource allocation based on stakeholder feedback.
-
-  mixed-media:
-    turns:
-      1: |
-        Comparing the visual diagram with the written specification document:
-        
-        **Visual Diagram Analysis:**
-        - The diagram shows a three-tier architecture with clear separation of concerns
-        - Components are connected via well-defined interfaces
-        - Color coding indicates different service types (blue=data, green=business logic, orange=presentation)
-        
-        **Specification Document:**
-        - Describes the same three-tier architecture in detail
-        - Specifies communication protocols between tiers (REST, gRPC)
-        - Includes performance requirements (99.9% uptime, <100ms latency)
-        
-        **Alignment:**
-        The diagram accurately represents the architecture described in the specifications. All components mentioned in the text are present in the visual representation. The data flow matches the documented process flow.
-        
-        **Minor Discrepancy:**
-        The specifications mention a caching layer that doesn't appear in the diagram - this may need clarification.
+  research-paper:
+    steps:
+      classify: '{"type":"research_paper","confidence":0.95}'
+      extract_paper: '{"title":"Deep Learning Survey","authors":["Smith","Jones"],"abstract":"A comprehensive survey of deep learning techniques and architectures."}'
+      extract_general: '{"summary":"General document summary","key_points":["point1","point2"]}'
+      meta_summary: '{"summary":"This paper surveys deep learning techniques."}'
+      meta_keywords: '{"keywords":["deep learning","neural networks","survey"]}'
+      synthesize: '{"analysis":"The document is a research paper on deep learning. Key findings include comprehensive coverage of neural network architectures.","confidence":0.9}'

--- a/examples/document-analysis/prompts/classify_doc.yaml
+++ b/examples/document-analysis/prompts/classify_doc.yaml
@@ -1,0 +1,13 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: classify-doc
+spec:
+  task_type: "classify_doc"
+  version: "v1.0.0"
+  description: "Classify a document as research_paper or general"
+
+  system_template: |
+    You are a document classifier. Analyze the provided text and classify it.
+
+    Respond with JSON: {"type": "research_paper" | "general", "confidence": 0.0-1.0}

--- a/examples/document-analysis/prompts/extract_general.yaml
+++ b/examples/document-analysis/prompts/extract_general.yaml
@@ -1,0 +1,13 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: extract-general
+spec:
+  task_type: "extract_general"
+  version: "v1.0.0"
+  description: "Extract structured data from a general document"
+
+  system_template: |
+    You are a document extractor. Extract structured information from the provided text.
+
+    Respond with JSON: {"summary": string, "key_points": [string]}

--- a/examples/document-analysis/prompts/extract_paper.yaml
+++ b/examples/document-analysis/prompts/extract_paper.yaml
@@ -1,0 +1,13 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: extract-paper
+spec:
+  task_type: "extract_paper"
+  version: "v1.0.0"
+  description: "Extract structured data from a research paper"
+
+  system_template: |
+    You are a research paper extractor. Extract structured information from the provided text.
+
+    Respond with JSON: {"title": string, "authors": [string], "abstract": string}

--- a/examples/document-analysis/prompts/meta_keywords.yaml
+++ b/examples/document-analysis/prompts/meta_keywords.yaml
@@ -1,0 +1,13 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: meta-keywords
+spec:
+  task_type: "meta_keywords"
+  version: "v1.0.0"
+  description: "Extract keywords from the document"
+
+  system_template: |
+    You are a keyword extractor. Extract the most important keywords from the provided text.
+
+    Respond with JSON: {"keywords": [string]}

--- a/examples/document-analysis/prompts/meta_summary.yaml
+++ b/examples/document-analysis/prompts/meta_summary.yaml
@@ -1,0 +1,13 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: meta-summary
+spec:
+  task_type: "meta_summary"
+  version: "v1.0.0"
+  description: "Generate a concise summary of the document"
+
+  system_template: |
+    You are a summarizer. Produce a concise summary of the provided text.
+
+    Respond with JSON: {"summary": string}

--- a/examples/document-analysis/prompts/synthesize_doc.yaml
+++ b/examples/document-analysis/prompts/synthesize_doc.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: synthesize-doc
+spec:
+  task_type: "synthesize_doc"
+  version: "v1.0.0"
+  description: "Synthesize extraction results into a final analysis"
+
+  system_template: |
+    You are a document analysis synthesizer. Combine the extracted information
+    into a final structured analysis.
+
+    Respond with JSON: {"analysis": string, "confidence": 0.0-1.0}

--- a/examples/document-analysis/providers/mock-provider.yaml
+++ b/examples/document-analysis/providers/mock-provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: mock-doc-analysis
+spec:
+  id: mock-doc-analysis
+  type: mock
+  model: mock-model
+  additional_config:
+    mock_config: mock-responses.yaml
+  defaults:
+    temperature: 0.1
+    max_tokens: 512
+    top_p: 1.0

--- a/examples/document-analysis/scenarios/research-paper.scenario.yaml
+++ b/examples/document-analysis/scenarios/research-paper.scenario.yaml
@@ -1,0 +1,51 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: research-paper
+spec:
+  id: "research-paper"
+  task_type: ""
+  description: "Analyze a research paper through the full composition DAG: classify → branch → extract → parallel meta → synthesize."
+
+  turns:
+    - role: user
+      content: |
+        Deep Learning: A Comprehensive Survey
+
+        Authors: Smith, Jones
+
+        Abstract: This paper presents a comprehensive survey of deep learning
+        techniques and neural network architectures. We review convolutional
+        neural networks, recurrent neural networks, transformers, and recent
+        advances in self-supervised learning. The survey covers applications
+        in computer vision, natural language processing, and reinforcement
+        learning, with emphasis on practical implementation guidance.
+
+        1. Introduction
+        Deep learning has transformed artificial intelligence over the past
+        decade. Neural networks with many layers can learn hierarchical
+        representations from raw data, achieving superhuman performance on
+        tasks previously thought to require human expertise.
+
+      assertions:
+        - type: composition_branch_taken
+          params:
+            branch: route
+            expected: extract_paper
+          message: "route branch should take extract_paper path for a research paper"
+
+        - type: composition_parallel_complete
+          params:
+            parallel: meta
+          message: "meta parallel step should complete successfully"
+
+        - type: composition_step_output
+          params:
+            step: classify
+            contains: "research_paper"
+          message: "classify step output should contain research_paper type"
+
+        - type: composition_output
+          params:
+            contains: "deep learning"
+          message: "final composition output should mention deep learning"

--- a/examples/document-analysis/schemas/classify_output.json
+++ b/examples/document-analysis/schemas/classify_output.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "Document type: research_paper, general, report, etc."
+    },
+    "confidence": {
+      "type": "number",
+      "description": "Classification confidence score between 0 and 1"
+    }
+  },
+  "required": ["type"]
+}

--- a/examples/document-analysis/schemas/classify_output.json
+++ b/examples/document-analysis/schemas/classify_output.json
@@ -11,5 +11,6 @@
       "description": "Classification confidence score between 0 and 1"
     }
   },
-  "required": ["type"]
+  "required": ["type", "confidence"],
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

Plan 5a.2 of RFC 0010 — the shipped composition example. **Draft: blocked on a schema release** (see below).

`examples/document-analysis/` runs the `analyze_document` composition through the mock provider:
- `compositions:` block: `classify` (prompt) → `route` (branch) → `extract_paper`/`extract_general` (prompt) ; `meta` (parallel of two prompt steps, barrier reduce) ; `synthesize` (agent, `termination`)
- workflow entry state with `orchestration: composition`
- per-step mock responses via the `steps:` map (keyed by composition step id)
- scenario asserts via all four `composition_*` handlers

Verified green against the **local** schema:
```
env -C examples/document-analysis PROMPTKIT_SCHEMA_SOURCE=local ../../bin/promptarena run --ci --formats json
# composition_branch_taken=1  composition_parallel_complete=1  composition_step_output=1  composition_output=1
```

## ⚠️ Schema-release gate (why this is a draft)

Shipped examples must validate against the **published remote** schema (`promptarena validate --schema-only`, no `PROMPTKIT_SCHEMA_SOURCE=local`). The `compositions` schema field (added to `arena.json` in #1344) is not yet on the published remote, so this example only validates with the local flag.

**To unblock:** trigger a schema release — `gh workflow run release.yml -f version=vX.Y.Z -f phase=full`. Once the schema publishes:
1. re-run the example WITHOUT `PROMPTKIT_SCHEMA_SOURCE=local` and confirm it validates,
2. drop the local-flag note from the README,
3. mark this PR ready + merge → `Closes #1336` (completes epic #1337).

Part of #1336. Epic #1337.



---
Validated against the live v1.5.0 remote schemas (no local flag); 4/4 composition assertions pass.

Closes #1336
Closes #1337
