### PR TITLE
feat(composition): observability events + OTLP spans (RFC 0010, Plan A)

### DIFF
--- a/runtime/composition/engine/engine.go
+++ b/runtime/composition/engine/engine.go
@@ -19,10 +19,12 @@ import (
 type StepExecutor func(ctx context.Context, step *composition.Step, input json.RawMessage) (json.RawMessage, error)
 
 // Recorder observes step execution for observability (Arena testability). Methods
-// are called during Execute; a nil Recorder disables recording. RecordStep may be
-// called concurrently from parallel branches — implementations must be safe.
+// are called during Execute; a nil Recorder disables recording. RecordStepStarted
+// and RecordStepCompleted may be called concurrently from parallel branches —
+// implementations must be safe.
 type Recorder interface {
-	RecordStep(stepID string, output any)
+	RecordStepStarted(stepID, kind string, input json.RawMessage)
+	RecordStepCompleted(stepID, kind string, input, output json.RawMessage, attempt int, err error)
 	RecordBranch(stepID string, takenTarget string)
 	RecordParallel(stepID string, branches []NamedOutput)
 }
@@ -121,9 +123,6 @@ func (e *Engine) runStep(
 		}
 		scope[step.ID] = map[string]any{scopeOutputKey: out}
 		status[step.ID] = statusCompleted
-		if e.recorder != nil {
-			e.recorder.RecordStep(step.ID, out)
-		}
 		return step.ID, nil
 	default:
 		return "", fmt.Errorf("step %q: unknown kind %q", step.ID, step.Kind)
@@ -167,20 +166,28 @@ func (e *Engine) runLeaf(ctx context.Context, step *composition.Step, scope Scop
 	if err != nil {
 		return nil, fmt.Errorf("marshaling resolved input: %w", err)
 	}
-	out, err := e.execWithRetry(ctx, step, resolvedJSON)
-	if err != nil {
-		return nil, err
+	kind := string(step.Kind)
+	if e.recorder != nil {
+		e.recorder.RecordStepStarted(step.ID, kind, resolvedJSON)
+	}
+	out, attempt, execErr := e.execWithRetry(ctx, step, resolvedJSON)
+	if e.recorder != nil {
+		e.recorder.RecordStepCompleted(step.ID, kind, resolvedJSON, out, attempt, execErr)
+	}
+	if execErr != nil {
+		return nil, execErr
 	}
 	return decodeOutput(out)
 }
 
 // execWithRetry invokes the executor, retrying per the step's retry modifier.
 // max_attempts is the total attempt count (a missing/zero/one modifier means a
-// single attempt). The last error propagates when the budget is exhausted. Used
+// single attempt). Returns the raw output, the number of attempts actually made,
+// and any error. The last error propagates when the budget is exhausted. Used
 // by runLeaf, so parallel branches inherit retry too.
 func (e *Engine) execWithRetry(
 	ctx context.Context, step *composition.Step, input json.RawMessage,
-) (json.RawMessage, error) {
+) (json.RawMessage, int, error) {
 	attempts := 1
 	if step.Modifiers != nil && step.Modifiers.Retry != nil && step.Modifiers.Retry.MaxAttempts > 1 {
 		attempts = step.Modifiers.Retry.MaxAttempts
@@ -188,15 +195,15 @@ func (e *Engine) execWithRetry(
 	var lastErr error
 	for i := 0; i < attempts; i++ {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, i + 1, err
 		}
 		out, err := e.exec(ctx, step, input)
 		if err == nil {
-			return out, nil
+			return out, i + 1, nil
 		}
 		lastErr = err
 	}
-	return nil, lastErr
+	return nil, attempts, lastErr
 }
 
 // decodeOutput turns a step's raw JSON output into a scope value. Empty output and

--- a/runtime/composition/engine/engine_test.go
+++ b/runtime/composition/engine/engine_test.go
@@ -647,24 +647,32 @@ func TestExecute_ParallelBranchRetry(t *testing.T) {
 
 // fakeRecorder is a test-only Recorder that captures what the engine observes.
 type fakeRecorder struct {
-	mu       sync.Mutex
-	steps    map[string]any
-	branches map[string]string
-	parallel map[string]bool
+	mu        sync.Mutex
+	started   map[string]string // stepID -> kind
+	completed map[string]int    // stepID -> attempt
+	branches  map[string]string
+	parallel  map[string]bool
 }
 
 func newFakeRecorder() *fakeRecorder {
 	return &fakeRecorder{
-		steps:    map[string]any{},
-		branches: map[string]string{},
-		parallel: map[string]bool{},
+		started:   map[string]string{},
+		completed: map[string]int{},
+		branches:  map[string]string{},
+		parallel:  map[string]bool{},
 	}
 }
 
-func (r *fakeRecorder) RecordStep(id string, out any) {
+func (r *fakeRecorder) RecordStepStarted(id, kind string, _ json.RawMessage) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.steps[id] = out
+	r.started[id] = kind
+}
+
+func (r *fakeRecorder) RecordStepCompleted(id, kind string, _, _ json.RawMessage, attempt int, _ error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.completed[id] = attempt
 }
 
 func (r *fakeRecorder) RecordBranch(id, taken string) {
@@ -695,25 +703,38 @@ func TestEngine_RecorderBranch(t *testing.T) {
 	if rec.branches["route"] != "paper" {
 		t.Errorf("branch taken = %q, want paper", rec.branches["route"])
 	}
-	// taken step "paper" should be recorded
-	if _, ok := rec.steps["paper"]; !ok {
-		t.Error("paper step not recorded")
+	// taken step "paper": started with kind "prompt", completed with attempt 1
+	if kind, ok := rec.started["paper"]; !ok || kind != string(composition.KindPrompt) {
+		t.Errorf("paper started kind = %q (ok=%v), want %q", kind, ok, string(composition.KindPrompt))
+	}
+	if attempt, ok := rec.completed["paper"]; !ok || attempt != 1 {
+		t.Errorf("paper completed attempt = %d (ok=%v), want 1", attempt, ok)
 	}
 	// skipped step "general" must NOT be recorded
-	if _, ok := rec.steps["general"]; ok {
-		t.Error("skipped general should not be recorded")
+	if _, ok := rec.started["general"]; ok {
+		t.Error("skipped general should not be in started")
 	}
-	// "classify" and "join" also ran and should be recorded
-	if _, ok := rec.steps["classify"]; !ok {
-		t.Error("classify step not recorded")
+	if _, ok := rec.completed["general"]; ok {
+		t.Error("skipped general should not be in completed")
 	}
-	if _, ok := rec.steps["join"]; !ok {
-		t.Error("join step not recorded")
+	// "classify" and "join" also ran and should be started/completed
+	if _, ok := rec.started["classify"]; !ok {
+		t.Error("classify step not in started")
+	}
+	if _, ok := rec.completed["classify"]; !ok {
+		t.Error("classify step not in completed")
+	}
+	if _, ok := rec.started["join"]; !ok {
+		t.Error("join step not in started")
+	}
+	if _, ok := rec.completed["join"]; !ok {
+		t.Error("join step not in completed")
 	}
 }
 
 func TestEngine_RecorderParallel(t *testing.T) {
 	// parallel step "meta" with two tool branches; assert rec.parallel["meta"]==true after Execute.
+	// Branch steps "a" and "b" are leaf steps — they should appear in started/completed too.
 	comp := &composition.Composition{
 		Version: 1, Output: "meta",
 		Steps: []*composition.Step{
@@ -732,6 +753,19 @@ func TestEngine_RecorderParallel(t *testing.T) {
 	}
 	if !rec.parallel["meta"] {
 		t.Error("parallel step meta not recorded")
+	}
+	// branch leaf steps should also appear in started/completed
+	if _, ok := rec.started["a"]; !ok {
+		t.Error("branch a not in started")
+	}
+	if _, ok := rec.completed["a"]; !ok {
+		t.Error("branch a not in completed")
+	}
+	if _, ok := rec.started["b"]; !ok {
+		t.Error("branch b not in started")
+	}
+	if _, ok := rec.completed["b"]; !ok {
+		t.Error("branch b not in completed")
 	}
 }
 

--- a/runtime/events/composition_events.go
+++ b/runtime/events/composition_events.go
@@ -1,0 +1,96 @@
+package events
+
+import "encoding/json"
+
+// Composition events (RFC 0010 observability). Started/completed pairs allow the
+// OTel listener to open/close spans; branch and parallel are instantaneous.
+const (
+	// EventCompositionStarted marks the start of a composition flow execution.
+	EventCompositionStarted EventType = "composition.started"
+	// EventCompositionCompleted marks the successful or failed completion of a composition flow.
+	EventCompositionCompleted EventType = "composition.completed"
+	// EventCompositionStepStarted marks the start of an individual step within a composition.
+	EventCompositionStepStarted EventType = "composition.step.started"
+	// EventCompositionStepCompleted marks the completion (or failure) of an individual composition step.
+	EventCompositionStepCompleted EventType = "composition.step.completed"
+	// EventCompositionBranchEvaluated marks a branch decision within a composition flow.
+	EventCompositionBranchEvaluated EventType = "composition.branch.evaluated"
+	// EventCompositionParallelCompleted marks the completion of a parallel fan-out step.
+	EventCompositionParallelCompleted EventType = "composition.parallel.completed"
+)
+
+// CompositionStartedData is the payload for composition.started events.
+type CompositionStartedData struct {
+	baseEventData
+	// Composition is the name of the composition flow being executed.
+	Composition string `json:"composition"`
+	// Input is the JSON-encoded input passed to the composition.
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// CompositionCompletedData is the payload for composition.completed events.
+type CompositionCompletedData struct {
+	baseEventData
+	// Composition is the name of the composition flow that completed.
+	Composition string `json:"composition"`
+	// Output is the JSON-encoded final output of the composition.
+	Output json.RawMessage `json:"output,omitempty"`
+	// Error is the error message if the composition failed; empty on success.
+	Error string `json:"error,omitempty"`
+	// DurationMs is the wall-clock duration of the composition in milliseconds.
+	DurationMs int64 `json:"duration_ms"`
+}
+
+// CompositionStepStartedData is the payload for composition.step.started events.
+type CompositionStepStartedData struct {
+	baseEventData
+	// StepID is the identifier of the step within the composition.
+	StepID string `json:"step_id"`
+	// Kind is the step type (e.g. "prompt", "tool", "branch", "parallel").
+	Kind string `json:"kind"`
+	// Input is the JSON-encoded input passed to this step.
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// CompositionStepCompletedData is the payload for composition.step.completed events.
+type CompositionStepCompletedData struct {
+	baseEventData
+	// StepID is the identifier of the step within the composition.
+	StepID string `json:"step_id"`
+	// Kind is the step type (e.g. "prompt", "tool", "branch", "parallel").
+	Kind string `json:"kind"`
+	// Input is the JSON-encoded input passed to this step.
+	Input json.RawMessage `json:"input,omitempty"`
+	// Output is the JSON-encoded output produced by this step.
+	Output json.RawMessage `json:"output,omitempty"`
+	// Attempt is the 1-based attempt number (>1 indicates a retry).
+	Attempt int `json:"attempt"`
+	// Error is the error message if the step failed; empty on success.
+	Error string `json:"error,omitempty"`
+}
+
+// CompositionBranchEvaluatedData is the payload for composition.branch.evaluated events.
+type CompositionBranchEvaluatedData struct {
+	baseEventData
+	// StepID is the identifier of the branch step.
+	StepID string `json:"step_id"`
+	// Taken is the branch label or target step ID that was selected.
+	Taken string `json:"taken"`
+}
+
+// CompositionParallelBranch describes a single branch within a parallel fan-out step.
+type CompositionParallelBranch struct {
+	// ID is the branch identifier.
+	ID string `json:"id"`
+	// Status is the outcome of this branch (e.g. "complete", "failed", "skipped").
+	Status string `json:"status"`
+}
+
+// CompositionParallelCompletedData is the payload for composition.parallel.completed events.
+type CompositionParallelCompletedData struct {
+	baseEventData
+	// StepID is the identifier of the parallel fan-out step.
+	StepID string `json:"step_id"`
+	// Branches contains the per-branch outcomes for the parallel step.
+	Branches []CompositionParallelBranch `json:"branches"`
+}

--- a/runtime/events/composition_events_test.go
+++ b/runtime/events/composition_events_test.go
@@ -1,0 +1,215 @@
+package events
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestEmitter_CompositionEvents verifies that the Emitter publishes all six
+// composition.* events in order and that the payloads carry the expected values.
+func TestEmitter_CompositionEvents(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	em := NewEmitter(bus, "exec1", "sess1", "conv1")
+
+	var captured []*Event
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(6)
+
+	bus.SubscribeAll(func(e *Event) {
+		mu.Lock()
+		captured = append(captured, e)
+		mu.Unlock()
+		wg.Done()
+	})
+
+	em.CompositionStarted("flow", json.RawMessage(`{"x":1}`))
+	em.CompositionStepStarted("classify", "prompt", json.RawMessage(`"in"`))
+	em.CompositionStepCompleted("classify", "prompt", json.RawMessage(`"in"`), json.RawMessage(`{"type":"paper"}`), 1, nil)
+	em.CompositionBranchEvaluated("route", "extract_paper")
+	em.CompositionParallelCompleted("meta", []CompositionParallelBranch{{ID: "a", Status: "complete"}})
+	em.CompositionCompleted("flow", json.RawMessage(`{"ok":true}`), nil, 5)
+
+	if !waitForWG(&wg, 500*time.Millisecond) {
+		t.Fatalf("timed out: expected 6 composition events, got %d", len(captured))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(captured) != 6 {
+		t.Fatalf("expected 6 events, got %d", len(captured))
+	}
+
+	// Assert event types in order.
+	wantTypes := []EventType{
+		EventCompositionStarted,
+		EventCompositionStepStarted,
+		EventCompositionStepCompleted,
+		EventCompositionBranchEvaluated,
+		EventCompositionParallelCompleted,
+		EventCompositionCompleted,
+	}
+
+	// Sort by sequence to assert order.
+	// Events are appended under a mutex but goroutine scheduling may vary;
+	// sort by Sequence (stamped monotonically by the bus) for a stable check.
+	sortBySequence(captured)
+
+	for i, want := range wantTypes {
+		if captured[i].Type != want {
+			t.Errorf("event[%d]: got type %q, want %q", i, captured[i].Type, want)
+		}
+	}
+
+	// Spot-check CompositionStepCompleted payload (index 2).
+	stepCompleted, ok := captured[2].Data.(*CompositionStepCompletedData)
+	if !ok {
+		t.Fatalf("event[2] data: got %T, want *CompositionStepCompletedData", captured[2].Data)
+	}
+	if stepCompleted.StepID != "classify" {
+		t.Errorf("StepID = %q, want %q", stepCompleted.StepID, "classify")
+	}
+	if stepCompleted.Kind != "prompt" {
+		t.Errorf("Kind = %q, want %q", stepCompleted.Kind, "prompt")
+	}
+	if string(stepCompleted.Output) != `{"type":"paper"}` {
+		t.Errorf("Output = %q, want %q", string(stepCompleted.Output), `{"type":"paper"}`)
+	}
+	if stepCompleted.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", stepCompleted.Attempt)
+	}
+	if stepCompleted.Error != "" {
+		t.Errorf("Error = %q, want empty (no error)", stepCompleted.Error)
+	}
+
+	// Spot-check CompositionCompleted payload (index 5).
+	completed, ok := captured[5].Data.(*CompositionCompletedData)
+	if !ok {
+		t.Fatalf("event[5] data: got %T, want *CompositionCompletedData", captured[5].Data)
+	}
+	if completed.DurationMs != 5 {
+		t.Errorf("DurationMs = %d, want 5", completed.DurationMs)
+	}
+	if completed.Error != "" {
+		t.Errorf("Error = %q, want empty", completed.Error)
+	}
+}
+
+// TestEmitter_CompositionEvents_ErrorString verifies that CompositionCompleted
+// and CompositionStepCompleted carry error strings from non-nil errors.
+func TestEmitter_CompositionEvents_ErrorString(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	em := NewEmitter(bus, "exec-err", "sess-err", "conv-err")
+
+	var gotStep, gotComp *Event
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	bus.Subscribe(EventCompositionStepCompleted, func(e *Event) {
+		gotStep = e
+		wg.Done()
+	})
+	bus.Subscribe(EventCompositionCompleted, func(e *Event) {
+		gotComp = e
+		wg.Done()
+	})
+
+	em.CompositionStepCompleted("s1", "prompt", nil, nil, 2, errors.New("step failed"))
+	em.CompositionCompleted("flow", nil, errors.New("flow failed"), 10)
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for events")
+	}
+
+	stepData := gotStep.Data.(*CompositionStepCompletedData)
+	if stepData.Error != "step failed" {
+		t.Errorf("step Error = %q, want %q", stepData.Error, "step failed")
+	}
+
+	compData := gotComp.Data.(*CompositionCompletedData)
+	if compData.Error != "flow failed" {
+		t.Errorf("comp Error = %q, want %q", compData.Error, "flow failed")
+	}
+}
+
+// TestEmitter_CompositionStartedCtx verifies the Ctx variant stamps a SpanContext.
+func TestEmitter_CompositionStartedCtx(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	em := NewEmitter(bus, "exec-ctx", "sess-ctx", "conv-ctx")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventCompositionStarted, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	// nil ctx is safe.
+	em.CompositionStartedCtx(nil, "flow", json.RawMessage(`{}`))
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for composition.started event")
+	}
+
+	if got.Type != EventCompositionStarted {
+		t.Errorf("Type = %q, want %q", got.Type, EventCompositionStarted)
+	}
+	data, ok := got.Data.(*CompositionStartedData)
+	if !ok {
+		t.Fatalf("Data: got %T, want *CompositionStartedData", got.Data)
+	}
+	if data.Composition != "flow" {
+		t.Errorf("Composition = %q, want %q", data.Composition, "flow")
+	}
+}
+
+// TestEmitter_CompositionStepStartedCtx verifies the Ctx variant for step.started.
+func TestEmitter_CompositionStepStartedCtx(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	em := NewEmitter(bus, "exec-sctx", "sess-sctx", "conv-sctx")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventCompositionStepStarted, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	em.CompositionStepStartedCtx(nil, "classify", "prompt", json.RawMessage(`"input"`))
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for composition.step.started event")
+	}
+
+	data, ok := got.Data.(*CompositionStepStartedData)
+	if !ok {
+		t.Fatalf("Data: got %T, want *CompositionStepStartedData", got.Data)
+	}
+	if data.StepID != "classify" || data.Kind != "prompt" {
+		t.Errorf("StepID=%q Kind=%q, want classify/prompt", data.StepID, data.Kind)
+	}
+}
+
+// sortBySequence is a minimal sort used by tests (avoids importing sort for a small slice).
+func sortBySequence(events []*Event) {
+	n := len(events)
+	for i := 1; i < n; i++ {
+		for j := i; j > 0 && events[j].Sequence < events[j-1].Sequence; j-- {
+			events[j], events[j-1] = events[j-1], events[j]
+		}
+	}
+}

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"go.opentelemetry.io/otel/trace"
@@ -600,4 +601,66 @@ func (e *Emitter) STTCallFailedCtx(ctx context.Context, data *STTCallFailedData)
 		return
 	}
 	e.emitCtx(ctx, EventSTTCallFailed, data)
+}
+
+// errString converts err to its message string, returning "" for nil.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// CompositionStarted emits the composition.started event.
+func (e *Emitter) CompositionStarted(name string, input json.RawMessage) {
+	e.emit(EventCompositionStarted, &CompositionStartedData{Composition: name, Input: input})
+}
+
+// CompositionStartedCtx emits the composition.started event with trace context for exemplar correlation.
+func (e *Emitter) CompositionStartedCtx(ctx context.Context, name string, input json.RawMessage) {
+	e.emitCtx(ctx, EventCompositionStarted, &CompositionStartedData{Composition: name, Input: input})
+}
+
+// CompositionCompleted emits the composition.completed event.
+// err is converted to an error string; pass nil for successful completions.
+func (e *Emitter) CompositionCompleted(name string, output json.RawMessage, err error, durationMs int64) {
+	e.emit(EventCompositionCompleted, &CompositionCompletedData{
+		Composition: name,
+		Output:      output,
+		Error:       errString(err),
+		DurationMs:  durationMs,
+	})
+}
+
+// CompositionStepStarted emits the composition.step.started event.
+func (e *Emitter) CompositionStepStarted(stepID, kind string, input json.RawMessage) {
+	e.emit(EventCompositionStepStarted, &CompositionStepStartedData{StepID: stepID, Kind: kind, Input: input})
+}
+
+// CompositionStepStartedCtx emits the composition.step.started event with trace context for exemplar correlation.
+func (e *Emitter) CompositionStepStartedCtx(ctx context.Context, stepID, kind string, input json.RawMessage) {
+	e.emitCtx(ctx, EventCompositionStepStarted, &CompositionStepStartedData{StepID: stepID, Kind: kind, Input: input})
+}
+
+// CompositionStepCompleted emits the composition.step.completed event.
+// err is converted to an error string; pass nil for successful steps.
+func (e *Emitter) CompositionStepCompleted(stepID, kind string, input, output json.RawMessage, attempt int, err error) {
+	e.emit(EventCompositionStepCompleted, &CompositionStepCompletedData{
+		StepID:  stepID,
+		Kind:    kind,
+		Input:   input,
+		Output:  output,
+		Attempt: attempt,
+		Error:   errString(err),
+	})
+}
+
+// CompositionBranchEvaluated emits the composition.branch.evaluated event.
+func (e *Emitter) CompositionBranchEvaluated(stepID, taken string) {
+	e.emit(EventCompositionBranchEvaluated, &CompositionBranchEvaluatedData{StepID: stepID, Taken: taken})
+}
+
+// CompositionParallelCompleted emits the composition.parallel.completed event.
+func (e *Emitter) CompositionParallelCompleted(stepID string, branches []CompositionParallelBranch) {
+	e.emit(EventCompositionParallelCompleted, &CompositionParallelCompletedData{StepID: stepID, Branches: branches})
 }

--- a/runtime/pipeline/stage/composition_recorder.go
+++ b/runtime/pipeline/stage/composition_recorder.go
@@ -5,17 +5,22 @@ import (
 	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition/engine"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 )
 
 // CompositionRecorder captures per-step composition execution data for Arena
-// observability. Populated during a single engine.Execute (RecordStep may fire
-// from parallel-branch goroutines, hence the mutex) and read afterward via
-// CompositionMetadata. Reset() is called at the start of each turn.
+// observability. Populated during a single engine.Execute (RecordStepStarted and
+// RecordStepCompleted may fire from parallel-branch goroutines, hence the mutex)
+// and read afterward via CompositionMetadata. Reset() is called at the start of
+// each turn. An optional Emitter (set via SetEmitter) receives composition.*
+// events; all map mutations occur under the mutex but the emitter is called
+// outside the lock to avoid holding it across emit from concurrent branches.
 type CompositionRecorder struct {
 	mu       sync.Mutex
 	steps    map[string]json.RawMessage
 	branches map[string]string
 	parallel map[string]string
+	emitter  *events.Emitter
 }
 
 var _ engine.Recorder = (*CompositionRecorder)(nil)
@@ -33,7 +38,15 @@ func NewCompositionRecorder() *CompositionRecorder {
 	}
 }
 
-// Reset clears all recorded data (called per turn).
+// SetEmitter wires an Emitter so the recorder publishes composition.* events.
+// Safe to call concurrently; replaces any previously set emitter.
+func (r *CompositionRecorder) SetEmitter(em *events.Emitter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.emitter = em
+}
+
+// Reset clears all recorded data (called per turn). Does NOT clear the emitter.
 func (r *CompositionRecorder) Reset() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -42,26 +55,51 @@ func (r *CompositionRecorder) Reset() {
 	r.parallel = map[string]string{}
 }
 
-// RecordStep implements engine.Recorder.
-func (r *CompositionRecorder) RecordStep(id string, out any) {
-	raw, _ := json.Marshal(out)
+// RecordStepStarted implements engine.Recorder.
+func (r *CompositionRecorder) RecordStepStarted(id, kind string, input json.RawMessage) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.steps[id] = raw
+	em := r.emitter
+	r.mu.Unlock()
+	if em != nil {
+		em.CompositionStepStarted(id, kind, input)
+	}
+}
+
+// RecordStepCompleted implements engine.Recorder.
+func (r *CompositionRecorder) RecordStepCompleted(id, kind string, input, output json.RawMessage, attempt int, err error) { //nolint:lll
+	r.mu.Lock()
+	r.steps[id] = output
+	em := r.emitter
+	r.mu.Unlock()
+	if em != nil {
+		em.CompositionStepCompleted(id, kind, input, output, attempt, err)
+	}
 }
 
 // RecordBranch implements engine.Recorder.
 func (r *CompositionRecorder) RecordBranch(id, taken string) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.branches[id] = taken
+	em := r.emitter
+	r.mu.Unlock()
+	if em != nil {
+		em.CompositionBranchEvaluated(id, taken)
+	}
 }
 
 // RecordParallel implements engine.Recorder.
-func (r *CompositionRecorder) RecordParallel(id string, _ []engine.NamedOutput) {
+func (r *CompositionRecorder) RecordParallel(id string, branches []engine.NamedOutput) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.parallel[id] = parallelStatusComplete
+	em := r.emitter
+	r.mu.Unlock()
+	if em != nil {
+		evBranches := make([]events.CompositionParallelBranch, len(branches))
+		for i, o := range branches {
+			evBranches[i] = events.CompositionParallelBranch{ID: o.ID, Status: parallelStatusComplete}
+		}
+		em.CompositionParallelCompleted(id, evBranches)
+	}
 }
 
 // CompositionMetadata returns a flat snapshot for the eval metadata bridge.

--- a/runtime/pipeline/stage/composition_recorder_test.go
+++ b/runtime/pipeline/stage/composition_recorder_test.go
@@ -3,9 +3,12 @@ package stage
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -138,4 +141,125 @@ func mapKeys(m map[string]json.RawMessage) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// TestCompositionRecorderEmitter verifies that SetEmitter wires event emission:
+// (a) CompositionMetadata() still returns the expected bridge maps, and
+// (b) the bus receives matching composition.* events for each hook.
+func TestCompositionRecorderEmitter(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo")
+
+	// Same composition layout as TestCompositionRecorder.
+	comp := &composition.Composition{
+		Version: 1, Output: "fin",
+		Steps: []*composition.Step{
+			{
+				ID:        "br",
+				Kind:      composition.KindBranch,
+				Predicate: &composition.Predicate{Path: "${input.flag}", Op: "equals", Value: "a"},
+				Then:      "leaf_a",
+				Else:      "leaf_b",
+			},
+			{ID: "leaf_a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "A"}},
+			{ID: "leaf_b", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "B"}, DependsOn: []string{"leaf_a"}},
+			{
+				ID:   "par",
+				Kind: composition.KindParallel,
+				Branches: []*composition.Step{
+					{ID: "p1", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"n": "1"}},
+					{ID: "p2", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"n": "2"}},
+				},
+				Reduce: &composition.Reducer{Strategy: composition.ReduceBarrier, Into: "m"},
+			},
+			{ID: "fin", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"out": "${par.output.m}"}},
+		},
+	}
+
+	bus := events.NewEventBus()
+	defer bus.Close()
+	em := events.NewEmitter(bus, "test-exec", "test-sess", "test-conv")
+
+	var mu sync.Mutex
+	seen := map[events.EventType]int{}
+	bus.SubscribeAll(func(e *events.Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen[e.Type]++
+	})
+
+	rec := NewCompositionRecorder()
+	rec.SetEmitter(em)
+	cs := NewCompositionStageWithRecorder("emitter-comp", comp, CompositionExecutorDeps{ToolRegistry: reg}, rec)
+
+	pipe, err := NewPipelineBuilder().Chain(cs).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := types.Message{Role: "user", Content: `{"flag":"a"}`}
+	res, err := pipe.ExecuteSync(context.Background(), NewMessageElement(&msg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || res.Response == nil {
+		t.Fatal("expected a response")
+	}
+
+	// Give the async bus time to drain.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		done := seen[events.EventCompositionStepStarted] > 0 &&
+			seen[events.EventCompositionStepCompleted] > 0 &&
+			seen[events.EventCompositionBranchEvaluated] > 0 &&
+			seen[events.EventCompositionParallelCompleted] > 0
+		mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// (a) Bridge maps must still be populated correctly.
+	meta := rec.CompositionMetadata()
+	stepOutputs, _ := meta["composition_step_outputs"].(map[string]json.RawMessage)
+	if _, found := stepOutputs["leaf_a"]; !found {
+		t.Error("bridge: composition_step_outputs missing leaf_a")
+	}
+	if _, found := stepOutputs["fin"]; !found {
+		t.Error("bridge: composition_step_outputs missing fin")
+	}
+	branches, _ := meta["composition_branch_taken"].(map[string]string)
+	if branches["br"] != "leaf_a" {
+		t.Errorf("bridge: composition_branch_taken['br'] = %q, want 'leaf_a'", branches["br"])
+	}
+	parallel, _ := meta["composition_parallel_status"].(map[string]string)
+	if parallel["par"] != "complete" {
+		t.Errorf("bridge: composition_parallel_status['par'] = %q, want 'complete'", parallel["par"])
+	}
+
+	// (b) The bus received composition.* events.
+	if seen[events.EventCompositionStepStarted] == 0 {
+		t.Error("no composition.step.started events received")
+	}
+	if seen[events.EventCompositionStepCompleted] == 0 {
+		t.Error("no composition.step.completed events received")
+	}
+	if seen[events.EventCompositionBranchEvaluated] == 0 {
+		t.Error("no composition.branch.evaluated events received")
+	}
+	if seen[events.EventCompositionParallelCompleted] == 0 {
+		t.Error("no composition.parallel.completed events received")
+	}
+
+	// Reset must clear bridge maps but NOT the emitter.
+	rec.Reset()
+	afterReset := rec.CompositionMetadata()
+	if steps, _ := afterReset["composition_step_outputs"].(map[string]json.RawMessage); len(steps) != 0 {
+		t.Errorf("after Reset, composition_step_outputs not empty: %v", steps)
+	}
 }

--- a/runtime/pipeline/stage/stages_composition.go
+++ b/runtime/pipeline/stage/stages_composition.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/composition/engine"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -20,15 +22,17 @@ type CompositionStage struct {
 	comp     *composition.Composition
 	eng      *engine.Engine
 	recorder *CompositionRecorder
+	emitter  *events.Emitter
 }
 
 // NewCompositionStage builds a CompositionStage from a composition spec and the
 // runtime collaborators its steps need.
 func NewCompositionStage(name string, comp *composition.Composition, deps CompositionExecutorDeps) *CompositionStage {
 	return &CompositionStage{
-		name: name,
-		comp: comp,
-		eng:  engine.New(NewCompositionStepExecutor(deps)),
+		name:    name,
+		comp:    comp,
+		eng:     engine.New(NewCompositionStepExecutor(deps)),
+		emitter: deps.Emitter,
 	}
 }
 
@@ -45,6 +49,7 @@ func NewCompositionStageWithRecorder(
 		comp:     comp,
 		eng:      engine.NewWithRecorder(NewCompositionStepExecutor(deps), rec),
 		recorder: rec,
+		emitter:  deps.Emitter,
 	}
 }
 
@@ -72,12 +77,9 @@ func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement,
 			}
 			continue
 		}
-		if s.recorder != nil {
-			s.recorder.Reset()
-		}
-		result, err := s.eng.Execute(ctx, s.comp, compositionInput(elem.Message))
+		result, err := s.execute(ctx, elem.Message)
 		if err != nil {
-			return fmt.Errorf("composition %q: %w", s.name, err)
+			return err
 		}
 		executed = true
 		assistant := &types.Message{Role: roleAssistant, Content: string(result)}
@@ -88,6 +90,35 @@ func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement,
 		}
 	}
 	return nil
+}
+
+// execute runs a single composition turn: prepares the recorder and emitter,
+// brackets the engine call with composition.started / composition.completed
+// events, and returns the engine output.
+func (s *CompositionStage) execute(ctx context.Context, msg *types.Message) (json.RawMessage, error) {
+	inputBytes := compositionInput(msg)
+	if s.recorder != nil {
+		if s.emitter != nil {
+			s.recorder.SetEmitter(s.emitter)
+		}
+		s.recorder.Reset()
+	}
+	if s.emitter != nil {
+		s.emitter.CompositionStartedCtx(ctx, s.name, inputBytes)
+	}
+	start := time.Now()
+	result, execErr := s.eng.Execute(ctx, s.comp, inputBytes)
+	if s.emitter != nil {
+		var outputBytes json.RawMessage
+		if result != nil {
+			outputBytes = result
+		}
+		s.emitter.CompositionCompleted(s.name, outputBytes, execErr, time.Since(start).Milliseconds())
+	}
+	if execErr != nil {
+		return nil, fmt.Errorf("composition %q: %w", s.name, execErr)
+	}
+	return result, nil
 }
 
 // compositionInput extracts the engine input JSON from a user message. Content

--- a/runtime/pipeline/stage/stages_composition_test.go
+++ b/runtime/pipeline/stage/stages_composition_test.go
@@ -3,9 +3,12 @@ package stage
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
@@ -254,6 +257,120 @@ func drainChannel(ch <-chan StreamElement) []StreamElement {
 		elems = append(elems, e)
 	}
 	return elems
+}
+
+// TestCompositionStage_EmitsStartedAndCompleted verifies that CompositionStage
+// brackets a composition execution with composition.started (before engine.Execute)
+// and composition.completed (after), and that the two events appear in that order.
+// Per-step events (step.started, step.completed) must appear between them.
+func TestCompositionStage_EmitsStartedAndCompleted(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo") // defined in composition_executor_test.go
+
+	// Single-step composition: simplest possible case for bracketing verification.
+	comp := &composition.Composition{
+		Version: 1, Output: "a",
+		Steps: []*composition.Step{
+			{ID: "a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "${input}"}},
+		},
+	}
+
+	bus := events.NewEventBus()
+	defer bus.Close()
+	em := events.NewEmitter(bus, "test-exec", "test-sess", "test-conv")
+
+	var mu sync.Mutex
+	var received []events.EventType
+	bus.SubscribeAll(func(e *events.Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, e.Type)
+	})
+
+	rec := NewCompositionRecorder()
+	cs := NewCompositionStageWithRecorder("bracket-comp", comp,
+		CompositionExecutorDeps{ToolRegistry: reg, Emitter: em}, rec)
+
+	pipe, err := NewPipelineBuilder().Chain(cs).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := types.Message{Role: "user", Content: `{"v":"hello"}`}
+	res, err := pipe.ExecuteSync(context.Background(), NewMessageElement(&msg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || res.Response == nil {
+		t.Fatal("expected a response")
+	}
+
+	// Wait for async bus to drain.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		startSeen := false
+		completedSeen := false
+		for _, et := range received {
+			if et == events.EventCompositionStarted {
+				startSeen = true
+			}
+			if et == events.EventCompositionCompleted {
+				completedSeen = true
+			}
+		}
+		done := startSeen && completedSeen
+		mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Find the indices of composition.started and composition.completed.
+	startIdx := -1
+	completedIdx := -1
+	for i, et := range received {
+		switch et {
+		case events.EventCompositionStarted:
+			if startIdx == -1 {
+				startIdx = i
+			}
+		case events.EventCompositionCompleted:
+			if completedIdx == -1 {
+				completedIdx = i
+			}
+		}
+	}
+
+	if startIdx == -1 {
+		t.Fatal("composition.started event not received")
+	}
+	if completedIdx == -1 {
+		t.Fatal("composition.completed event not received")
+	}
+
+	// started must come before completed.
+	if startIdx >= completedIdx {
+		t.Errorf("composition.started (idx %d) must precede composition.completed (idx %d); got events: %v",
+			startIdx, completedIdx, received)
+	}
+
+	// At least one per-step event must appear between started and completed.
+	stepEventBetween := false
+	for i := startIdx + 1; i < completedIdx; i++ {
+		if received[i] == events.EventCompositionStepStarted ||
+			received[i] == events.EventCompositionStepCompleted {
+			stepEventBetween = true
+			break
+		}
+	}
+	if !stepEventBetween {
+		t.Errorf("expected at least one step event between composition.started and composition.completed; got: %v", received)
+	}
 }
 
 // TestCompositionStage_EndToEnd_MixedKinds proves that a multi-kind composition

--- a/runtime/telemetry/listener.go
+++ b/runtime/telemetry/listener.go
@@ -24,10 +24,12 @@ const cleanupInterval = 1 * time.Minute
 // Span-entry key prefixes: every in-flight span is keyed by "<prefix><id>" in
 // the inflight map. The prefix disambiguates sibling spans that share an ID.
 const (
-	spanKeyPipeline   = "pipeline:"
-	spanKeyProvider   = "provider:"
-	spanKeyMiddleware = "middleware:"
-	spanKeyValidation = "validation:"
+	spanKeyPipeline        = "pipeline:"
+	spanKeyProvider        = "provider:"
+	spanKeyMiddleware      = "middleware:"
+	spanKeyValidation      = "validation:"
+	spanKeyComposition     = "composition:"
+	spanKeyCompositionStep = "composition.step:"
 )
 
 // OpenTelemetry GenAI semantic-convention attribute keys.
@@ -232,6 +234,17 @@ func (l *OTelEventListener) OnEvent(evt *events.Event) {
 		l.handleEvalCompleted(evt)
 	case events.EventEvalFailed:
 		l.handleEvalFailed(evt)
+	case events.EventCompositionStarted:
+		l.startComposition(evt)
+	case events.EventCompositionCompleted:
+		l.completeComposition(evt)
+	case events.EventCompositionStepStarted:
+		l.startCompositionStep(evt)
+	case events.EventCompositionStepCompleted:
+		l.completeCompositionStep(evt)
+	case events.EventCompositionBranchEvaluated, events.EventCompositionParallelCompleted:
+		// v1: branch and parallel are instantaneous signals recorded in the
+		// event stream and report; they do not produce OTel spans.
 	}
 }
 
@@ -672,4 +685,77 @@ func labelsToAttributes(labels map[string]string) []attribute.KeyValue {
 		attrs = append(attrs, attribute.String("promptkit.label."+k, v))
 	}
 	return attrs
+}
+
+// --- Composition ---
+
+// parentCtxForComposition returns the context of the in-flight composition span
+// for the given executionID, falling back to the session root span context.
+// This mirrors parentCtxForRun, but resolves via spanKeyComposition instead of
+// spanKeyPipeline, allowing composition.step spans to be nested under their
+// parent composition span.
+func (l *OTelEventListener) parentCtxForComposition(sessionID, executionID string) context.Context {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if entry, ok := l.inflight[spanKeyComposition+executionID]; ok {
+		return entry.ctx
+	}
+	if ss, ok := l.sessions[sessionID]; ok {
+		return ss.ctx
+	}
+	return context.Background()
+}
+
+func (l *OTelEventListener) startComposition(evt *events.Event) {
+	data, ok := asPtr[events.CompositionStartedData](evt.Data)
+	if !ok {
+		return
+	}
+	l.startSpan(l.sessionCtx(evt.SessionID), spanKeyComposition+evt.ExecutionID,
+		"promptkit.composition",
+		trace.SpanKindInternal,
+		attribute.String("promptkit.composition.name", data.Composition),
+		attribute.String("promptkit.run.id", evt.ExecutionID),
+	)
+}
+
+func (l *OTelEventListener) completeComposition(evt *events.Event) {
+	data, ok := asPtr[events.CompositionCompletedData](evt.Data)
+	if !ok {
+		return
+	}
+	if data.Error != "" {
+		l.failSpan(spanKeyComposition+evt.ExecutionID, data.Error)
+		return
+	}
+	l.endSpan(spanKeyComposition+evt.ExecutionID,
+		attribute.Int64("promptkit.composition.duration_ms", data.DurationMs),
+	)
+}
+
+func (l *OTelEventListener) startCompositionStep(evt *events.Event) {
+	data, ok := asPtr[events.CompositionStepStartedData](evt.Data)
+	if !ok {
+		return
+	}
+	key := spanKeyCompositionStep + evt.ExecutionID + ":" + data.StepID
+	l.startSpan(l.parentCtxForComposition(evt.SessionID, evt.ExecutionID), key,
+		"promptkit.composition.step",
+		trace.SpanKindInternal,
+		attribute.String("promptkit.composition.step_id", data.StepID),
+		attribute.String("promptkit.composition.step_kind", data.Kind),
+	)
+}
+
+func (l *OTelEventListener) completeCompositionStep(evt *events.Event) {
+	data, ok := asPtr[events.CompositionStepCompletedData](evt.Data)
+	if !ok {
+		return
+	}
+	key := spanKeyCompositionStep + evt.ExecutionID + ":" + data.StepID
+	if data.Error != "" {
+		l.failSpan(key, data.Error)
+		return
+	}
+	l.endSpan(key, attribute.Int("promptkit.composition.step_attempt", data.Attempt))
 }

--- a/runtime/telemetry/listener_test.go
+++ b/runtime/telemetry/listener_test.go
@@ -1262,6 +1262,120 @@ func TestOTelEventListener_Close(t *testing.T) {
 	listener.Close()
 }
 
+func TestOTelEventListener_CompositionSpans(t *testing.T) {
+	listener, exp, tp := newTestListener(t)
+	now := time.Now()
+
+	listener.StartSession(context.Background(), "sess-1")
+
+	// 1. composition.started — opens the composition span.
+	listener.OnEvent(&events.Event{
+		Type: events.EventCompositionStarted, Timestamp: now,
+		SessionID: "sess-1", ExecutionID: "run-1",
+		Data: &events.CompositionStartedData{Composition: "flow"},
+	})
+
+	// 2. composition.step.started — opens a child step span.
+	listener.OnEvent(&events.Event{
+		Type: events.EventCompositionStepStarted, Timestamp: now.Add(10 * time.Millisecond),
+		SessionID: "sess-1", ExecutionID: "run-1",
+		Data: &events.CompositionStepStartedData{StepID: "classify", Kind: "prompt"},
+	})
+
+	// 3. composition.step.completed — closes the step span successfully.
+	listener.OnEvent(&events.Event{
+		Type: events.EventCompositionStepCompleted, Timestamp: now.Add(50 * time.Millisecond),
+		SessionID: "sess-1", ExecutionID: "run-1",
+		Data: &events.CompositionStepCompletedData{StepID: "classify", Kind: "prompt", Attempt: 1},
+	})
+
+	// 4. composition.completed — closes the composition span successfully.
+	listener.OnEvent(&events.Event{
+		Type: events.EventCompositionCompleted, Timestamp: now.Add(100 * time.Millisecond),
+		SessionID: "sess-1", ExecutionID: "run-1",
+		Data: &events.CompositionCompletedData{Composition: "flow", DurationMs: 100},
+	})
+
+	listener.EndSession("sess-1")
+	spans := flushAndGetSpans(t, tp, exp)
+
+	// Verify composition span exists with correct attributes and status.
+	compSpan := findSpan(t, spans, "promptkit.composition")
+	if compSpan.Status.Code != codes.Ok {
+		t.Errorf("composition span: expected Ok status, got %v", compSpan.Status.Code)
+	}
+	if !hasAttr(compSpan, "promptkit.composition.name", "flow") {
+		t.Error("composition span: expected promptkit.composition.name=flow")
+	}
+
+	// Verify step span exists with correct attributes and status.
+	stepSpan := findSpan(t, spans, "promptkit.composition.step")
+	if stepSpan.Status.Code != codes.Ok {
+		t.Errorf("step span: expected Ok status, got %v", stepSpan.Status.Code)
+	}
+	if !hasAttr(stepSpan, "promptkit.composition.step_id", "classify") {
+		t.Error("step span: expected promptkit.composition.step_id=classify")
+	}
+	if !hasAttr(stepSpan, "promptkit.composition.step_kind", "prompt") {
+		t.Error("step span: expected promptkit.composition.step_kind=prompt")
+	}
+
+	// Step span must be a child of the composition span (same trace, parent = composition span).
+	if stepSpan.SpanContext.TraceID() != compSpan.SpanContext.TraceID() {
+		t.Error("step span and composition span must share the same trace ID")
+	}
+	if stepSpan.Parent.SpanID() != compSpan.SpanContext.SpanID() {
+		t.Error("step span should be child of composition span")
+	}
+}
+
+func TestOTelEventListener_CompositionSpan_Failed(t *testing.T) {
+	listener, exp, tp := newTestListener(t)
+	now := time.Now()
+
+	listener.StartSession(context.Background(), "sess-1")
+
+	listener.OnEvent(&events.Event{
+		Type: events.EventCompositionStarted, Timestamp: now,
+		SessionID: "sess-1", ExecutionID: "run-1",
+		Data: &events.CompositionStartedData{Composition: "flow"},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventCompositionStepStarted, Timestamp: now.Add(10 * time.Millisecond),
+		SessionID: "sess-1", ExecutionID: "run-1",
+		Data: &events.CompositionStepStartedData{StepID: "call", Kind: "prompt"},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventCompositionStepCompleted, Timestamp: now.Add(20 * time.Millisecond),
+		SessionID: "sess-1", ExecutionID: "run-1",
+		Data: &events.CompositionStepCompletedData{StepID: "call", Kind: "prompt", Attempt: 1, Error: "provider timeout"},
+	})
+	listener.OnEvent(&events.Event{
+		Type: events.EventCompositionCompleted, Timestamp: now.Add(30 * time.Millisecond),
+		SessionID: "sess-1", ExecutionID: "run-1",
+		Data: &events.CompositionCompletedData{Composition: "flow", Error: "step failed: provider timeout"},
+	})
+
+	listener.EndSession("sess-1")
+	spans := flushAndGetSpans(t, tp, exp)
+
+	compSpan := findSpan(t, spans, "promptkit.composition")
+	if compSpan.Status.Code != codes.Error {
+		t.Errorf("composition span: expected Error status, got %v", compSpan.Status.Code)
+	}
+	if compSpan.Status.Description != "step failed: provider timeout" {
+		t.Errorf("composition span: expected error description, got %q", compSpan.Status.Description)
+	}
+
+	stepSpan := findSpan(t, spans, "promptkit.composition.step")
+	if stepSpan.Status.Code != codes.Error {
+		t.Errorf("step span: expected Error status, got %v", stepSpan.Status.Code)
+	}
+	if stepSpan.Status.Description != "provider timeout" {
+		t.Errorf("step span: expected error 'provider timeout', got %q", stepSpan.Status.Description)
+	}
+}
+
 func TestOTelEventListener_EvictStale(t *testing.T) {
 	listener, exp, tp := newTestListener(t)
 	defer listener.Close()

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -440,7 +440,8 @@ func buildProviderStages(cfg *Config, turnState *stage.TurnState) ([]stage.Stage
 		if name == "" {
 			name = "composition"
 		}
-		return []stage.Stage{stage.NewCompositionStage(name, cfg.ActiveComposition, deps)}, nil
+		cs := stage.NewCompositionStageWithRecorder(name, cfg.ActiveComposition, deps, stage.NewCompositionRecorder())
+		return []stage.Stage{cs}, nil
 	}
 	if cfg.StreamInputProvider != nil {
 		// ASM mode: Direct audio streaming to LLM

--- a/sdk/internal/pipeline/builder_test.go
+++ b/sdk/internal/pipeline/builder_test.go
@@ -1300,6 +1300,74 @@ func TestBuildProviderStages_DefaultNameWhenCompositionNameEmpty(t *testing.T) {
 	}
 }
 
+// TestBuildCompositionStage_EmitsEvents verifies that when ActiveComposition is set
+// and an EventEmitter is provided, executing the pipeline emits composition.*
+// events (composition.started, composition.step.started/completed,
+// composition.completed). Before the fix, NewCompositionStage was called without a
+// recorder so step-level events were never emitted; after the fix
+// NewCompositionStageWithRecorder wires a recorder that forwards to the emitter.
+func TestBuildCompositionStage_EmitsEvents(t *testing.T) {
+	comp := &composition.Composition{
+		Version: 1, Output: "s",
+		Steps: []*composition.Step{{
+			ID:   "s",
+			Kind: composition.KindTool,
+			Tool: "echo",
+			Args: map[string]any{"v": "${input.x}"},
+		}},
+	}
+
+	reg := tools.NewRegistry()
+	echoExec := &builderEchoExecutor{}
+	reg.RegisterExecutor(echoExec)
+	if err := reg.Register(&tools.ToolDescriptor{
+		Name:        "echo",
+		Description: "echo tool",
+		Mode:        echoExec.Name(),
+		InputSchema: []byte(`{"type":"object"}`),
+	}); err != nil {
+		t.Fatalf("register echo tool: %v", err)
+	}
+
+	bus := events.NewEventBus()
+	emitter := events.NewEmitter(bus, "", "session-1", "conv-1")
+
+	// Collect composition.step.completed events.
+	var stepEvents []*events.Event
+	done := make(chan struct{})
+	unsub := bus.Subscribe(events.EventCompositionStepCompleted, func(ev *events.Event) {
+		stepEvents = append(stepEvents, ev)
+		close(done)
+	})
+	defer unsub()
+
+	cfg := &Config{
+		Provider:          mock.NewProvider("test-mock", "test-model", false),
+		ToolRegistry:      reg,
+		PromptRegistry:    createTestRegistry("chat"),
+		ActiveComposition: comp,
+		CompositionName:   "test_comp",
+		EventEmitter:      emitter,
+	}
+
+	pipe, err := Build(cfg)
+	require.NoError(t, err)
+
+	userMsg := types.Message{Role: "user"}
+	userMsg.AddTextPart(`{"x":42}`)
+	elem := stage.StreamElement{Message: &userMsg}
+
+	_, err = pipe.ExecuteSync(context.Background(), elem)
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for composition.step.completed event — recorder not wired")
+	}
+	assert.Len(t, stepEvents, 1, "expected one composition.step.completed event")
+}
+
 // builderEchoExecutor is a local tools.Executor that returns its args as the result.
 // Mirrors the echoExecutor in stage/composition_executor_test.go, but lives here
 // to avoid cross-package test helper imports.


### PR DESCRIPTION
## Summary

Plan A of Composition Observability (RFC 0010 follow-up): emit composition step-graph execution as a new `composition.*` event category on the universal `events.Bus`, turn it into OTLP spans via the existing `OTelEventListener`, and wire both the Arena and SDK composition paths to emit — keeping the composition engine pure.

One producer (the `CompositionRecorder` + `CompositionStage`), one event category, multiple optional consumers (OTLP spans, EventStore, external/datagen subscribers). The bus emit is the only contract — no dependency on the optional recording middleware.

## What changed (6 commits)

1. **`feat(events)`** — new `composition.*` event category: 6 `EventType` consts (started/completed pairs for composition + step, plus branch-evaluated and parallel-completed) with typed payload structs and nil-safe `Emitter` methods (incl. `*Ctx` variants for trace correlation).
2. **`feat(composition)` engine hooks + recorder emits** — `engine.Recorder` gains started/completed step hooks (`RecordStepStarted`/`RecordStepCompleted` with kind/input/output/attempt/err); `execWithRetry` returns the attempt count; recording moves into `runLeaf`. The engine **stays pure** (imports only `runtime/composition` + stdlib — verified). `CompositionRecorder` keeps its assertion-bridge maps **and** emits the matching events via an injected emitter (emits outside the mutex; safe for concurrent parallel branches).
3. **`feat(composition)` stage brackets** — `CompositionStage` sets the recorder emitter per turn and brackets `composition.started`/`composition.completed` around `engine.Execute` (telemetry is side-effect-only; stage output/error/flow unchanged; completed emitted on error too).
4. **`feat(telemetry)`** — `OTelEventListener` gains `composition.*` cases: a composition span with per-step child spans parented under it (reuses the existing `parentCtxForRun` idiom; branch/parallel are lean no-op-as-spans in v1, still on the stream/report).
5. **`feat(sdk)`** — the SDK composition build site now constructs the stage with an emitting recorder, so SDK composition runs emit `composition.*` events (events only; the SDK has no report).

## Test plan

- [x] `runtime/events`, `runtime/composition/engine`, `runtime/pipeline/stage`, `runtime/telemetry` — green with `-race`
- [x] `sdk/internal/pipeline` — green
- [x] Engine purity invariant: `runtime/composition/engine` does not import `runtime/events`
- [x] 4c `composition_*` assertion-bridge tests still pass (recorder maps unchanged)
- [x] New tests: event ordering + payloads; recorder emits + bridge intact; stage brackets ordering; OTLP composition→step span nesting (+ failure path); SDK composition emits events

> Note: a combined 4-way `-race` sweep can surface a pre-existing `runtime/events` bus-delivery flake (`pipeline.started` / `timeout=50ms`), unrelated to this change — passes when `./events/` is run isolated and under normal CI scheduling.

Closes #1370

Plan B (Arena report rendering of the per-turn composition trace) follows separately.
