### PR TITLE
feat(arena): composition trace in HTML + JSON reports (RFC 0010, Plan B)

### DIFF
--- a/runtime/pipeline/stage/composition_recorder.go
+++ b/runtime/pipeline/stage/composition_recorder.go
@@ -8,6 +8,25 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 )
 
+// CompositionStepRecord is one entry in a CompositionSnapshot, capturing the
+// completion order, kind, retry attempt, and output of a single step.
+type CompositionStepRecord struct {
+	ID      string          `json:"id"`
+	Kind    string          `json:"kind"`
+	Attempt int             `json:"attempt"`
+	Output  json.RawMessage `json:"output,omitempty"`
+}
+
+// CompositionSnapshot is an ordered, richer per-turn view of composition
+// execution for report rendering. It is attached to the assistant message Meta
+// by CompositionStage so that JSON (and future HTML) reports can surface the
+// step-graph trace without touching the assertion-bridge maps.
+type CompositionSnapshot struct {
+	Steps    []CompositionStepRecord `json:"steps"`
+	Branches map[string]string       `json:"branches,omitempty"`
+	Parallel map[string]string       `json:"parallel,omitempty"`
+}
+
 // CompositionRecorder captures per-step composition execution data for Arena
 // observability. Populated during a single engine.Execute (RecordStepStarted and
 // RecordStepCompleted may fire from parallel-branch goroutines, hence the mutex)
@@ -16,11 +35,12 @@ import (
 // events; all map mutations occur under the mutex but the emitter is called
 // outside the lock to avoid holding it across emit from concurrent branches.
 type CompositionRecorder struct {
-	mu       sync.Mutex
-	steps    map[string]json.RawMessage
-	branches map[string]string
-	parallel map[string]string
-	emitter  *events.Emitter
+	mu          sync.Mutex
+	steps       map[string]json.RawMessage
+	branches    map[string]string
+	parallel    map[string]string
+	emitter     *events.Emitter
+	stepRecords []CompositionStepRecord
 }
 
 var _ engine.Recorder = (*CompositionRecorder)(nil)
@@ -53,6 +73,7 @@ func (r *CompositionRecorder) Reset() {
 	r.steps = map[string]json.RawMessage{}
 	r.branches = map[string]string{}
 	r.parallel = map[string]string{}
+	r.stepRecords = nil
 }
 
 // RecordStepStarted implements engine.Recorder.
@@ -69,11 +90,41 @@ func (r *CompositionRecorder) RecordStepStarted(id, kind string, input json.RawM
 func (r *CompositionRecorder) RecordStepCompleted(id, kind string, input, output json.RawMessage, attempt int, err error) { //nolint:lll
 	r.mu.Lock()
 	r.steps[id] = output
+	r.stepRecords = append(r.stepRecords, CompositionStepRecord{ID: id, Kind: kind, Attempt: attempt, Output: output})
 	em := r.emitter
 	r.mu.Unlock()
 	if em != nil {
 		em.CompositionStepCompleted(id, kind, input, output, attempt, err)
 	}
+}
+
+// Snapshot returns an ordered, richer per-turn view of the composition
+// execution for report rendering. The returned value is a deep copy safe to
+// read after the next Reset(). Returns nil when no steps, branches, or parallel
+// entries have been recorded (e.g. immediately after Reset).
+func (r *CompositionRecorder) Snapshot() *CompositionSnapshot {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.stepRecords) == 0 && len(r.branches) == 0 && len(r.parallel) == 0 {
+		return nil
+	}
+	steps := make([]CompositionStepRecord, len(r.stepRecords))
+	copy(steps, r.stepRecords)
+	var branches map[string]string
+	if len(r.branches) > 0 {
+		branches = make(map[string]string, len(r.branches))
+		for k, v := range r.branches {
+			branches[k] = v
+		}
+	}
+	var parallel map[string]string
+	if len(r.parallel) > 0 {
+		parallel = make(map[string]string, len(r.parallel))
+		for k, v := range r.parallel {
+			parallel[k] = v
+		}
+	}
+	return &CompositionSnapshot{Steps: steps, Branches: branches, Parallel: parallel}
 }
 
 // RecordBranch implements engine.Recorder.

--- a/runtime/pipeline/stage/composition_recorder_test.go
+++ b/runtime/pipeline/stage/composition_recorder_test.go
@@ -143,6 +143,36 @@ func mapKeys(m map[string]json.RawMessage) []string {
 	return keys
 }
 
+func TestCompositionRecorder_Snapshot(t *testing.T) {
+	r := NewCompositionRecorder()
+	r.RecordStepCompleted("a", "prompt", nil, json.RawMessage(`1`), 1, nil)
+	r.RecordStepCompleted("b", "tool", nil, json.RawMessage(`2`), 2, nil)
+	r.RecordBranch("route", "x")
+	snap := r.Snapshot()
+	if snap == nil || len(snap.Steps) != 2 {
+		t.Fatalf("snapshot = %#v", snap)
+	}
+	if snap.Steps[0].ID != "a" || snap.Steps[0].Kind != "prompt" || snap.Steps[0].Attempt != 1 || string(snap.Steps[0].Output) != "1" {
+		t.Errorf("step[0] = %#v", snap.Steps[0])
+	}
+	if snap.Steps[1].ID != "b" || snap.Steps[1].Attempt != 2 {
+		t.Errorf("step[1] = %#v", snap.Steps[1])
+	}
+	if snap.Branches["route"] != "x" {
+		t.Errorf("branches = %#v", snap.Branches)
+	}
+	// bridge maps unchanged
+	md := r.CompositionMetadata()
+	if _, ok := md["composition_step_outputs"]; !ok {
+		t.Error("bridge map composition_step_outputs missing")
+	}
+	// Snapshot is nil before any recording / after Reset
+	r.Reset()
+	if r.Snapshot() != nil {
+		t.Error("Snapshot should be nil after Reset")
+	}
+}
+
 // TestCompositionRecorderEmitter verifies that SetEmitter wires event emission:
 // (a) CompositionMetadata() still returns the expected bridge maps, and
 // (b) the bus receives matching composition.* events for each hook.

--- a/runtime/pipeline/stage/stages_composition.go
+++ b/runtime/pipeline/stage/stages_composition.go
@@ -13,6 +13,10 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// compositionSnapshotMetaKey is the key under which CompositionStage stores
+// the per-turn *CompositionSnapshot in the assistant message's Meta map.
+const compositionSnapshotMetaKey = "_composition_snapshot"
+
 // CompositionStage runs an RFC 0010 composition to completion as a single
 // pipeline stage: it reads the turn's input element, executes the composition's
 // step DAG via the engine, and emits one assistant element carrying the
@@ -83,6 +87,14 @@ func (s *CompositionStage) Process(ctx context.Context, in <-chan StreamElement,
 		}
 		executed = true
 		assistant := &types.Message{Role: roleAssistant, Content: string(result)}
+		if s.recorder != nil {
+			if snap := s.recorder.Snapshot(); snap != nil {
+				if assistant.Meta == nil {
+					assistant.Meta = map[string]interface{}{}
+				}
+				assistant.Meta[compositionSnapshotMetaKey] = snap
+			}
+		}
 		select {
 		case out <- NewMessageElement(assistant):
 		case <-ctx.Done():

--- a/runtime/pipeline/stage/stages_composition_test.go
+++ b/runtime/pipeline/stage/stages_composition_test.go
@@ -259,6 +259,66 @@ func drainChannel(ch <-chan StreamElement) []StreamElement {
 	return elems
 }
 
+// TestCompositionStage_AttachesSnapshotMeta verifies that when a
+// CompositionStage is constructed with a recorder, the assistant message emitted
+// after execution carries a non-nil *CompositionSnapshot under the
+// "_composition_snapshot" Meta key with at least one step recorded.
+func TestCompositionStage_AttachesSnapshotMeta(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerEchoTool(t, reg, "echo")
+
+	comp := &composition.Composition{
+		Version: 1, Output: "a",
+		Steps: []*composition.Step{
+			{ID: "a", Kind: composition.KindTool, Tool: "echo", Args: map[string]any{"v": "${input.x}"}},
+		},
+	}
+	rec := NewCompositionRecorder()
+	cs := NewCompositionStageWithRecorder("snap-comp", comp, CompositionExecutorDeps{ToolRegistry: reg}, rec)
+
+	in := make(chan StreamElement, 1)
+	out := make(chan StreamElement, 10)
+
+	msg := &types.Message{Role: "user", Content: `{"x":"hello"}`}
+	in <- NewMessageElement(msg)
+	close(in)
+
+	if err := cs.Process(context.Background(), in, out); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	elems := drainChannel(out)
+	if len(elems) == 0 {
+		t.Fatal("expected at least one output element")
+	}
+
+	// Find the assistant message element.
+	var assistantMsg *types.Message
+	for _, e := range elems {
+		if e.Message != nil && e.Message.Role == roleAssistant {
+			assistantMsg = e.Message
+			break
+		}
+	}
+	if assistantMsg == nil {
+		t.Fatal("no assistant message element emitted")
+	}
+	if assistantMsg.Meta == nil {
+		t.Fatal("assistant message Meta is nil; expected _composition_snapshot")
+	}
+	raw, ok := assistantMsg.Meta[compositionSnapshotMetaKey]
+	if !ok {
+		t.Fatalf("Meta missing key %q; got keys: %v", compositionSnapshotMetaKey, assistantMsg.Meta)
+	}
+	snap, ok := raw.(*CompositionSnapshot)
+	if !ok {
+		t.Fatalf("Meta[%q] has type %T, want *CompositionSnapshot", compositionSnapshotMetaKey, raw)
+	}
+	if len(snap.Steps) == 0 {
+		t.Errorf("snapshot has no steps; want at least 1")
+	}
+}
+
 // TestCompositionStage_EmitsStartedAndCompleted verifies that CompositionStage
 // brackets a composition execution with composition.started (before engine.Execute)
 // and composition.completed (after), and that the two events appear in that order.

--- a/runtime/pipeline/stage/stages_composition_test.go
+++ b/runtime/pipeline/stage/stages_composition_test.go
@@ -340,11 +340,11 @@ func TestCompositionStage_EmitsStartedAndCompleted(t *testing.T) {
 	em := events.NewEmitter(bus, "test-exec", "test-sess", "test-conv")
 
 	var mu sync.Mutex
-	var received []events.EventType
+	var received []*events.Event
 	bus.SubscribeAll(func(e *events.Event) {
 		mu.Lock()
 		defer mu.Unlock()
-		received = append(received, e.Type)
+		received = append(received, e)
 	})
 
 	rec := NewCompositionRecorder()
@@ -365,21 +365,24 @@ func TestCompositionStage_EmitsStartedAndCompleted(t *testing.T) {
 		t.Fatal("expected a response")
 	}
 
-	// Wait for async bus to drain.
+	// Wait for async bus to drain. Require started, completed, AND at least one
+	// step event, since async SubscribeAll delivery can deliver step events after
+	// composition.completed in arrival order.
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		mu.Lock()
-		startSeen := false
-		completedSeen := false
-		for _, et := range received {
-			if et == events.EventCompositionStarted {
+		startSeen, completedSeen, stepSeen := false, false, false
+		for _, e := range received {
+			switch e.Type {
+			case events.EventCompositionStarted:
 				startSeen = true
-			}
-			if et == events.EventCompositionCompleted {
+			case events.EventCompositionCompleted:
 				completedSeen = true
+			case events.EventCompositionStepStarted, events.EventCompositionStepCompleted:
+				stepSeen = true
 			}
 		}
-		done := startSeen && completedSeen
+		done := startSeen && completedSeen && stepSeen
 		mu.Unlock()
 		if done {
 			break
@@ -390,10 +393,20 @@ func TestCompositionStage_EmitsStartedAndCompleted(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
+	// Sort by the bus-stamped Sequence: SubscribeAll delivery is async, so arrival
+	// order is not emission order. Sequence (stamped at emit) reflects emission order.
+	ordered := make([]*events.Event, len(received))
+	copy(ordered, received)
+	sortEventsBySequence(ordered)
+	receivedTypes := make([]events.EventType, len(ordered))
+	for i, e := range ordered {
+		receivedTypes[i] = e.Type
+	}
+
 	// Find the indices of composition.started and composition.completed.
 	startIdx := -1
 	completedIdx := -1
-	for i, et := range received {
+	for i, et := range receivedTypes {
 		switch et {
 		case events.EventCompositionStarted:
 			if startIdx == -1 {
@@ -416,20 +429,30 @@ func TestCompositionStage_EmitsStartedAndCompleted(t *testing.T) {
 	// started must come before completed.
 	if startIdx >= completedIdx {
 		t.Errorf("composition.started (idx %d) must precede composition.completed (idx %d); got events: %v",
-			startIdx, completedIdx, received)
+			startIdx, completedIdx, receivedTypes)
 	}
 
 	// At least one per-step event must appear between started and completed.
 	stepEventBetween := false
 	for i := startIdx + 1; i < completedIdx; i++ {
-		if received[i] == events.EventCompositionStepStarted ||
-			received[i] == events.EventCompositionStepCompleted {
+		if receivedTypes[i] == events.EventCompositionStepStarted ||
+			receivedTypes[i] == events.EventCompositionStepCompleted {
 			stepEventBetween = true
 			break
 		}
 	}
 	if !stepEventBetween {
-		t.Errorf("expected at least one step event between composition.started and composition.completed; got: %v", received)
+		t.Errorf("expected at least one step event between composition.started and composition.completed; got: %v", receivedTypes)
+	}
+}
+
+// sortEventsBySequence orders events by their bus-stamped Sequence (emission
+// order), insulating assertions from async SubscribeAll delivery reordering.
+func sortEventsBySequence(evs []*events.Event) {
+	for i := 1; i < len(evs); i++ {
+		for j := i; j > 0 && evs[j].Sequence < evs[j-1].Sequence; j-- {
+			evs[j], evs[j-1] = evs[j-1], evs[j]
+		}
 	}
 }
 

--- a/tools/arena/render/html_test.go
+++ b/tools/arena/render/html_test.go
@@ -475,6 +475,49 @@ func TestGenerateHTMLReport_CreatesFiles(t *testing.T) {
 	}
 }
 
+func TestGenerateHTMLReport_CompositionTab(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "composition-report.html")
+
+	result := createTestResult(testRunID1, testProviderOpenAI, testRegionUSWest, testScenario1, 0.05, 100, 50, false, 500*time.Millisecond)
+	result.Messages = []types.Message{
+		{
+			Role:    "assistant",
+			Content: "Classified as paper.",
+			Meta: map[string]interface{}{
+				"_composition_snapshot": map[string]interface{}{
+					"steps": []map[string]interface{}{
+						{
+							"id":      "classify",
+							"kind":    "prompt",
+							"attempt": 1,
+						},
+					},
+					"branches": map[string]string{"route": "extract_paper"},
+				},
+			},
+		},
+	}
+
+	err := GenerateHTMLReport([]engine.RunResult{result}, outputPath)
+	if err != nil {
+		t.Fatalf("Failed to generate HTML report: %v", err)
+	}
+
+	htmlData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read HTML file: %v", err)
+	}
+	html := string(htmlData)
+
+	if !strings.Contains(html, `data-devtools="composition"`) {
+		t.Error("HTML does not contain composition data element (data-devtools=\"composition\")")
+	}
+	if !strings.Contains(html, "classify") {
+		t.Error("HTML does not contain composition step id 'classify'")
+	}
+}
+
 func TestGenerateHTMLReport_CreatesDirectory(t *testing.T) {
 	// Create temporary directory for test
 	tmpDir := t.TempDir()

--- a/tools/arena/render/templates/report.html.tmpl
+++ b/tools/arena/render/templates/report.html.tmpl
@@ -2172,6 +2172,7 @@
                                 {{$hasAvailableTools := false}}
                                 {{$hasToolDescriptors := false}}
                                 {{$hasWorkflowState := false}}
+                                {{$hasCompositionSnapshot := false}}
                                 {{$hasLLMTrace := false}}
                                 {{$hasFinishReason := false}}
                                 {{$hasPackEvals := false}}
@@ -2193,6 +2194,9 @@
                                         {{if index $metaMap "_workflow_state"}}
                                             {{$hasWorkflowState = true}}
                                         {{end}}
+                                        {{if index $metaMap "_composition_snapshot"}}
+                                            {{$hasCompositionSnapshot = true}}
+                                        {{end}}
                                         {{if index $metaMap "_llm_trace"}}
                                             {{$hasLLMTrace = true}}
                                         {{end}}
@@ -2209,7 +2213,7 @@
                                 {{$selfPlayPersonaID := selfPlayPersona $msg.Meta}}
                                 {{$selfPlayInfo := selfPlayDetails $msg.Meta}}
                                 {{$hasSelfPlayInfo := hasSelfPlayDetails $msg.Meta}}
-                                {{$hasDiagnostics := or $hasAssertions $hasValidators $hasAvailableTools $hasRawRequest $hasRawResponse $hasLLMTrace $hasPackEvals $hasWorkflowState $msg.CostInfo (not (not $msg.ToolCalls)) (eq $msg.Role "system") (eq $msg.Role "user")}}
+                                {{$hasDiagnostics := or $hasAssertions $hasValidators $hasAvailableTools $hasRawRequest $hasRawResponse $hasLLMTrace $hasPackEvals $hasWorkflowState $hasCompositionSnapshot $msg.CostInfo (not (not $msg.ToolCalls)) (eq $msg.Role "system") (eq $msg.Role "user")}}
                                 {{$assertionsFailed := not (assertionsPassed $assertions)}}
                                 {{$validatorsFailed := not (validatorsPassed $validators)}}
                                 {{$hasFailed := or $assertionsFailed $validatorsFailed}}
@@ -2313,6 +2317,9 @@
                                         {{end}}
                                         {{if $hasWorkflowState}}
                                         <div data-devtools="workflow">{{prettyJSON (index $msg.Meta "_workflow_state")}}</div>
+                                        {{end}}
+                                        {{if $hasCompositionSnapshot}}
+                                        <div data-devtools="composition">{{prettyJSON (index $msg.Meta "_composition_snapshot")}}</div>
                                         {{end}}
                                         {{if $msg.ToolCalls}}
                                         <div data-devtools="toolcalls">{{prettyJSON $msg.ToolCalls}}</div>
@@ -2546,6 +2553,7 @@
             var toolDescsEl = data.querySelector('[data-devtools="tooldescriptors"]');
             var toolcallsEl = data.querySelector('[data-devtools="toolcalls"]');
             var workflowEl = data.querySelector('[data-devtools="workflow"]');
+            var compositionEl = data.querySelector('[data-devtools="composition"]');
             var promptEl = data.querySelector('[data-devtools="systemprompt"]');
             var selfPlayEl = data.querySelector('[data-devtools="selfplay"]');
             var selfPlayInfoEl = data.querySelector('[data-devtools="selfplay-info"]');
@@ -2563,6 +2571,7 @@
             tabs.push({ id: 'info', label: 'Info', icon: 'ℹ️' });
 
             if (workflowEl) tabs.push({ id: 'workflow', label: 'Workflow', icon: '⚡' });
+            if (compositionEl) tabs.push({ id: 'composition', label: 'Composition', icon: '🔀' });
             if (metricsEl) tabs.push({ id: 'metrics', label: 'Metrics', icon: '📊' });
 
             if (toolsEl || toolcallsEl) {
@@ -2705,6 +2714,71 @@
                     }
                 } catch(e) {
                     html += '<div class="devtools-section"><div class="devtools-json">' + escapeHtml(workflowEl.textContent) + '</div></div>';
+                }
+                html += '</div>';
+            }
+
+            // --- Composition tab ---
+            if (compositionEl) {
+                html += '<div class="devtools-tab-content' + (firstTab === 'composition' ? ' active' : '') + '" data-tab-content="composition">';
+                try {
+                    var compData = JSON.parse(compositionEl.textContent);
+
+                    // Steps
+                    if (compData.steps && compData.steps.length > 0) {
+                        html += '<div class="devtools-section"><div class="devtools-section-title">Steps</div>';
+                        html += '<ol style="margin:0;padding-left:1.2rem;">';
+                        compData.steps.forEach(function(step, i) {
+                            var attempt = step.attempt > 1 ? ' <span style="color:#f38ba8;font-size:0.7rem;">attempt ' + step.attempt + '</span>' : '';
+                            html += '<li style="padding:0.4rem 0;border-bottom:1px solid #313244;">';
+                            html += '<div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.25rem;">';
+                            html += '<span style="background:#89b4fa;color:#1e1e2e;padding:0.15rem 0.4rem;border-radius:3px;font-family:monospace;font-size:0.78rem;font-weight:600;">' + escapeHtml(step.id || '') + '</span>';
+                            html += '<span style="color:#6c7086;font-size:0.75rem;">' + escapeHtml(step.kind || '') + attempt + '</span>';
+                            html += '</div>';
+                            if (step.output !== undefined) {
+                                html += '<details style="margin-left:0.25rem;"><summary style="color:#a6adc8;font-size:0.75rem;cursor:pointer;">output</summary>';
+                                html += '<div class="devtools-json" style="margin-top:0.2rem;">' + escapeHtml(JSON.stringify(step.output, null, 2)) + '</div>';
+                                html += '</details>';
+                            }
+                            html += '</li>';
+                        });
+                        html += '</ol></div>';
+                    }
+
+                    // Branches
+                    if (compData.branches && Object.keys(compData.branches).length > 0) {
+                        html += '<div class="devtools-section"><div class="devtools-section-title">Branches</div>';
+                        var branches = compData.branches;
+                        for (var bk in branches) {
+                            if (branches.hasOwnProperty(bk)) {
+                                html += '<div style="display:flex;align-items:center;gap:0.5rem;padding:0.3rem 0;">';
+                                html += '<span style="color:#a6adc8;font-size:0.8rem;font-family:monospace;">' + escapeHtml(bk) + '</span>';
+                                html += '<span style="color:#585b70;">→</span>';
+                                html += '<span style="color:#a6e3a1;font-family:monospace;font-size:0.8rem;">' + escapeHtml(String(branches[bk])) + '</span>';
+                                html += '</div>';
+                            }
+                        }
+                        html += '</div>';
+                    }
+
+                    // Parallel
+                    if (compData.parallel && Object.keys(compData.parallel).length > 0) {
+                        html += '<div class="devtools-section"><div class="devtools-section-title">Parallel</div>';
+                        var parallel = compData.parallel;
+                        for (var pk in parallel) {
+                            if (parallel.hasOwnProperty(pk)) {
+                                html += '<div style="display:flex;align-items:center;gap:0.5rem;padding:0.3rem 0;">';
+                                html += '<span style="color:#a6adc8;font-size:0.8rem;font-family:monospace;">' + escapeHtml(pk) + '</span>';
+                                html += '<span style="color:#585b70;">:</span>';
+                                html += '<span style="color:#cdd6f4;font-size:0.8rem;">' + escapeHtml(String(parallel[pk])) + '</span>';
+                                html += '</div>';
+                            }
+                        }
+                        html += '</div>';
+                    }
+
+                } catch(e) {
+                    html += '<div class="devtools-section"><div class="devtools-json">' + escapeHtml(compositionEl.textContent) + '</div></div>';
                 }
                 html += '</div>';
             }

--- a/tools/arena/results/json/json_repository_test.go
+++ b/tools/arena/results/json/json_repository_test.go
@@ -428,6 +428,45 @@ func TestJSONResultRepository_GetSummary_InvalidJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse summary")
 }
 
+func TestJSONResultRepository_CompositionSnapshot(t *testing.T) {
+	tmpDir := t.TempDir()
+	repo := jsonrepo.NewJSONResultRepository(tmpDir)
+
+	result := createTestResult("run-comp-001", "scenario-comp", "openai", false, 0.001)
+	result.Messages = []types.Message{
+		{
+			Role:    "assistant",
+			Content: "Classified as paper.",
+			Meta: map[string]interface{}{
+				"_composition_snapshot": map[string]interface{}{
+					"steps": []map[string]interface{}{
+						{
+							"id":      "classify",
+							"kind":    "prompt",
+							"attempt": 1,
+							"output":  json.RawMessage(`{"type":"paper"}`),
+						},
+					},
+					"branches": map[string]string{"route": "extract_paper"},
+				},
+			},
+		},
+	}
+
+	err := repo.SaveResults([]engine.RunResult{result})
+	require.NoError(t, err)
+
+	filename := filepath.Join(tmpDir, "run-comp-001.json")
+	assert.FileExists(t, filename)
+
+	data, err := os.ReadFile(filename)
+	require.NoError(t, err)
+
+	content := string(data)
+	assert.Contains(t, content, "_composition_snapshot")
+	assert.Contains(t, content, "classify")
+}
+
 func TestJSONResultRepository_IntegrationTest(t *testing.T) {
 	tmpDir := t.TempDir()
 	repo := jsonrepo.NewJSONResultRepository(tmpDir)


### PR DESCRIPTION
## Summary

Plan B of Composition Observability (RFC 0010 follow-up): surface the per-turn composition step-graph trace in the Arena HTML and JSON reports. Before this, a whole composition turn rendered as a single line — the internal DAG (which steps ran, branch taken, parallel status, per-step output/attempt) was invisible.

Builds on Plan A (#1371, `6c1605d7`). One producer, recording-independent: the snapshot rides on the composition turn's `types.Message.Meta`, which flows through `RunResult.Messages` into both reports — no dependency on the optional EventStore.

## What changed (2 commits)

1. **`feat(composition)` — per-turn snapshot on message Meta** — `CompositionRecorder` gains an ordered, richer snapshot (`CompositionSnapshot{Steps []{ID,Kind,Attempt,Output}, Branches, Parallel}`). It already received `kind`/`attempt` in `RecordStepCompleted` but discarded them; now it keeps an ordered `stepRecords` slice alongside the existing maps. `CompositionStage` attaches `Snapshot()` to the assistant message's `Meta` under `_composition_snapshot` after each composition turn. The assertion-bridge `CompositionMetadata()` maps are **byte-identical** (no eval regression).
2. **`feat(arena)` — render the trace** — the **JSON report is free** (`Message.Meta` marshals into `RunResult`). The **HTML report** gains a collapsible "Composition" devtools tab (🔀) mirroring the existing "Workflow" tab exactly — same `prettyJSON` template func, same `data-devtools` element + tab-registration + content pattern. The tab renders an ordered step list (id · kind · attempt → output), branches, and parallel status. It lives inside the on-demand devtools panel, so it's collapsed by default.

## Test plan

- [x] `runtime/pipeline/stage` — green with `-race` (snapshot ordering/kind/attempt; assistant Meta carries snapshot; Plan A + assertion-bridge tests unchanged)
- [x] `tools/arena/render` — HTML structural test: composition `data-devtools` element + tab render with step id
- [x] `tools/arena/results/json` — JSON test: `meta._composition_snapshot` present (passes with no production change — proves the free path)
- [x] `tools/arena/engine` — composition-metadata-provider / eval bridge tests still green
- [x] both modules build

> No engine or events change (Plan A shipped those). Recording-independent — the snapshot is on the message, not the EventStore.

Closes #1372

Note: a live HTML render of the tab needs a composition example that runs through Arena; that example (#1336, epic #1337) is gated on a user-triggered schema release.
