### PR TITLE
feat(arena): explicit current_workflow_state on turn results

### DIFF
--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -99,6 +99,17 @@ func (ce *DefaultConversationExecutor) executeWithoutStreaming(
 		ce.notifyTurnStarted(emitter, turnIdx, scenarioTurn.Role, req.Scenario.ID)
 		ce.debugOnUserTurnAssertions(scenarioTurn, turnIdx)
 
+		// Issue #1374: capture the live workflow state at TURN START (the state
+		// whose prompt drives this turn) and the current assistant-message count,
+		// so after the turn succeeds we can stamp current_workflow_state onto the
+		// new assistant message — and only when one was actually produced.
+		var turnStartState map[string]interface{}
+		var preAssistantCount int
+		if req.CurrentWorkflowState != nil && req.StampWorkflowState != nil {
+			turnStartState = req.CurrentWorkflowState()
+			preAssistantCount = ce.countAssistantMessages(ctx, req)
+		}
+
 		err := ce.executeNonStreamingTurn(turnCtx, req, scenarioTurn)
 
 		if err != nil {
@@ -122,6 +133,14 @@ func (ce *DefaultConversationExecutor) executeWithoutStreaming(
 			}
 		}
 
+		// Issue #1374: stamp the turn-start workflow state onto the assistant
+		// message this turn produced. Order vs PostTurnHook is irrelevant —
+		// turnStartState was captured before the turn ran. Skip plain user turns
+		// that produced no new assistant message. Side-effect-only.
+		if req.StampWorkflowState != nil && ce.countAssistantMessages(ctx, req) > preAssistantCount {
+			req.StampWorkflowState(turnStartState)
+		}
+
 		ce.notifyTurnCompleted(emitter, turnIdx, scenarioTurn.Role, req.Scenario.ID, nil)
 		logger.Debug("Turn completed",
 			"turn", turnIdx,
@@ -130,6 +149,24 @@ func (ce *DefaultConversationExecutor) executeWithoutStreaming(
 
 	// Load final conversation state from StateStore
 	return ce.buildResultFromStateStore(ctx, req)
+}
+
+// countAssistantMessages returns the number of assistant messages currently
+// persisted for the conversation. Used by the issue #1374 stamp guard to detect
+// whether a turn actually produced a new assistant message. Returns 0 on any
+// load error (the guard then simply skips stamping).
+func (ce *DefaultConversationExecutor) countAssistantMessages(ctx context.Context, req *ConversationRequest) int {
+	_, messages, err := ce.loadMessagesFromStateStore(ctx, req)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for i := range messages {
+		if messages[i].Role == roleAssistant {
+			count++
+		}
+	}
+	return count
 }
 
 // executeNonStreamingTurn executes a single turn without streaming

--- a/tools/arena/engine/current_workflow_state_test.go
+++ b/tools/arena/engine/current_workflow_state_test.go
@@ -1,0 +1,205 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	runtimestore "github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
+	"github.com/AltairaLabs/PromptKit/tools/arena/turnexecutors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStampCurrentWorkflowState_LastAssistant verifies the explicit per-turn
+// stamp lands current_workflow_state on the LAST assistant message and leaves
+// the legacy _workflow_state path untouched.
+func TestStampCurrentWorkflowState_LastAssistant(t *testing.T) {
+	ctx := context.Background()
+	store := statestore.NewArenaStateStore()
+	convID := "conv-stamp"
+
+	require.NoError(t, store.Save(ctx, &runtimestore.ConversationState{
+		ID: convID,
+		Messages: []types.Message{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "first"},
+			{Role: "user", Content: "again"},
+			{Role: "assistant", Content: "second"},
+		},
+	}))
+
+	e := &Engine{stateStore: store}
+	meta := map[string]interface{}{"current_state": "analyzing"}
+	e.stampCurrentWorkflowState(convID, meta)
+
+	got, err := store.Load(ctx, convID)
+	require.NoError(t, err)
+	require.Len(t, got.Messages, 4)
+
+	// Last assistant message is stamped.
+	last := got.Messages[3]
+	require.NotNil(t, last.Meta)
+	ws, ok := last.Meta["current_workflow_state"].(map[string]interface{})
+	require.True(t, ok, "current_workflow_state must be a map")
+	assert.Equal(t, "analyzing", ws["current_state"])
+
+	// Earlier assistant message is NOT stamped (only the last one).
+	assert.Nil(t, got.Messages[1].Meta["current_workflow_state"])
+
+	// Legacy key is never introduced by the explicit stamp.
+	assert.Nil(t, last.Meta["_workflow_state"])
+}
+
+// TestStampCurrentWorkflowState_NilSafe verifies nil meta is a no-op (no key
+// added) and that a conversation with no assistant message is left untouched.
+func TestStampCurrentWorkflowState_NilSafe(t *testing.T) {
+	ctx := context.Background()
+	store := statestore.NewArenaStateStore()
+	e := &Engine{stateStore: store}
+
+	t.Run("nil meta adds no key", func(t *testing.T) {
+		convID := "conv-nil-meta"
+		require.NoError(t, store.Save(ctx, &runtimestore.ConversationState{
+			ID:       convID,
+			Messages: []types.Message{{Role: "assistant", Content: "x"}},
+		}))
+		e.stampCurrentWorkflowState(convID, nil)
+		got, err := store.Load(ctx, convID)
+		require.NoError(t, err)
+		assert.Nil(t, got.Messages[0].Meta["current_workflow_state"])
+	})
+
+	t.Run("no assistant message is no-op", func(t *testing.T) {
+		convID := "conv-no-assistant"
+		require.NoError(t, store.Save(ctx, &runtimestore.ConversationState{
+			ID:       convID,
+			Messages: []types.Message{{Role: "user", Content: "x"}},
+		}))
+		e.stampCurrentWorkflowState(convID, map[string]interface{}{"current_state": "analyzing"})
+		got, err := store.Load(ctx, convID)
+		require.NoError(t, err)
+		assert.Nil(t, got.Messages[0].Meta["current_workflow_state"])
+	})
+}
+
+// stampingTurnExecutor appends one assistant message per assistant turn, mirroring
+// MockTurnExecutor's store-append behaviour, so the loop's stamp guard sees a new
+// assistant message.
+type stampingTurnExecutor struct{}
+
+func (s *stampingTurnExecutor) ExecuteTurn(ctx context.Context, req turnexecutors.TurnRequest) error {
+	if req.StateStoreConfig == nil || req.StateStoreConfig.Store == nil || req.ConversationID == "" {
+		return nil
+	}
+	store := req.StateStoreConfig.Store.(runtimestore.BulkWriter)
+	loader := req.StateStoreConfig.Store.(runtimestore.Store)
+	state, err := loader.Load(ctx, req.ConversationID)
+	if err != nil || state == nil {
+		state = &runtimestore.ConversationState{ID: req.ConversationID}
+	}
+	state.Messages = append(state.Messages,
+		types.Message{Role: "user", Content: req.ScriptedContent},
+		types.Message{Role: "assistant", Content: "response"},
+	)
+	return store.Save(ctx, state)
+}
+
+func (s *stampingTurnExecutor) ExecuteTurnStream(
+	ctx context.Context, req turnexecutors.TurnRequest,
+) (<-chan turnexecutors.MessageStreamChunk, error) {
+	ch := make(chan turnexecutors.MessageStreamChunk)
+	close(ch)
+	return ch, s.ExecuteTurn(ctx, req)
+}
+
+// TestExecuteConversation_StampsTurnStartState verifies the executor turn loop
+// stamps current_workflow_state captured at TURN START onto each turn's assistant
+// message, and that nil hooks (no workflow) add no key.
+func TestExecuteConversation_StampsTurnStartState(t *testing.T) {
+	ctx := context.Background()
+
+	newExecutor := func() *DefaultConversationExecutor {
+		return &DefaultConversationExecutor{
+			scriptedExecutor: &stampingTurnExecutor{},
+			promptRegistry:   nil,
+		}
+	}
+	newReq := func(store *statestore.ArenaStateStore, convID string) ConversationRequest {
+		return ConversationRequest{
+			Provider: &MockProvider{id: "mock"},
+			Scenario: &config.Scenario{
+				ID: "sc",
+				Turns: []config.TurnDefinition{
+					{Role: "user", Content: "turn one"},
+					{Role: "user", Content: "turn two"},
+				},
+			},
+			Config:           &config.Config{},
+			ConversationID:   convID,
+			RunID:            convID,
+			StateStoreConfig: &StateStoreConfig{Store: store},
+		}
+	}
+
+	t.Run("stamps each turn with the state observed at turn start", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		convID := "conv-loop"
+		require.NoError(t, store.Save(ctx, &runtimestore.ConversationState{ID: convID}))
+		e := &Engine{stateStore: store}
+		req := newReq(store, convID)
+
+		// Simulate a state machine that advances between turns: turn 1 sees
+		// "intake", turn 2 sees "analyzing". current_workflow_state is read at
+		// turn start so each assistant message records the driving state.
+		states := []string{"intake", "analyzing"}
+		idx := 0
+		req.CurrentWorkflowState = func() map[string]interface{} {
+			st := states[idx]
+			if idx < len(states)-1 {
+				idx++
+			}
+			return map[string]interface{}{"current_state": st}
+		}
+		req.StampWorkflowState = func(meta map[string]interface{}) {
+			e.stampCurrentWorkflowState(convID, meta)
+		}
+
+		res := newExecutor().ExecuteConversation(ctx, req)
+		require.False(t, res.Failed, res.Error)
+
+		got, err := store.Load(ctx, convID)
+		require.NoError(t, err)
+
+		var assistantStates []string
+		for i := range got.Messages {
+			if got.Messages[i].Role != "assistant" {
+				continue
+			}
+			ws, ok := got.Messages[i].Meta["current_workflow_state"].(map[string]interface{})
+			require.True(t, ok, "every assistant message must carry current_workflow_state")
+			assistantStates = append(assistantStates, ws["current_state"].(string))
+		}
+		assert.Equal(t, []string{"intake", "analyzing"}, assistantStates)
+	})
+
+	t.Run("no workflow hooks adds no key", func(t *testing.T) {
+		store := statestore.NewArenaStateStore()
+		convID := "conv-noworkflow"
+		require.NoError(t, store.Save(ctx, &runtimestore.ConversationState{ID: convID}))
+		req := newReq(store, convID)
+		// CurrentWorkflowState / StampWorkflowState left nil.
+
+		res := newExecutor().ExecuteConversation(ctx, req)
+		require.False(t, res.Failed, res.Error)
+
+		got, err := store.Load(ctx, convID)
+		require.NoError(t, err)
+		for i := range got.Messages {
+			assert.Nil(t, got.Messages[i].Meta["current_workflow_state"],
+				"non-workflow runs must not stamp the key")
+		}
+	})
+}

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -330,6 +330,63 @@ func (e *Engine) wireWorkflowHooks(req *ConversationRequest, runID string) {
 	// buildTurnRequest can stamp it onto every TurnRequest, enabling
 	// NewCompositionStageWithRecorder to record step outputs per turn.
 	req.CompositionRecorder = e.workflowTransExec.CompositionRecorder(runID)
+
+	// Issue #1374: capture the live workflow state at turn start (the state whose
+	// prompt drives the turn) and stamp it onto the turn's assistant result. This
+	// makes composition-orchestrated terminal states visible per turn — they
+	// transition no tool, so the legacy enrichMessagesWithWorkflowState replay
+	// can't see them. Reading at turn start (not end) is correct for both
+	// user-control (deferred CommitPending) and agent-control (eager mid-turn
+	// commit), since the prompt was built from the turn-start state.
+	// ConversationID is set to runID by executeRun (after this hook wiring), so
+	// use runID directly as the conversation key for the stamp.
+	conversationID := runID
+	req.CurrentWorkflowState = func() map[string]interface{} {
+		sm := e.workflowTransExec.StateMachine(runID)
+		if sm == nil {
+			return nil
+		}
+		return e.buildEntryStateMeta(sm.CurrentState())
+	}
+	req.StampWorkflowState = func(meta map[string]interface{}) {
+		e.stampCurrentWorkflowState(conversationID, meta)
+	}
+}
+
+// stampCurrentWorkflowState attaches current_workflow_state metadata to the last
+// assistant message of the conversation. It mirrors enrichMessagesWithWorkflowState's
+// load/mutate/save against the engine's ArenaStateStore but stamps a distinct,
+// explicit per-turn key (current_workflow_state) and leaves the legacy
+// _workflow_state path untouched. No-op when meta is nil or no assistant message
+// exists yet (e.g. plain user turns).
+func (e *Engine) stampCurrentWorkflowState(conversationID string, meta map[string]interface{}) {
+	if meta == nil {
+		return
+	}
+	store, ok := e.stateStore.(*arenastore.ArenaStateStore)
+	if !ok {
+		return
+	}
+	ctx := context.Background()
+	convState, err := store.Load(ctx, conversationID)
+	if err != nil {
+		logger.Warn("Failed to load conversation for current workflow state stamp",
+			"conversation_id", conversationID, "error", err)
+		return
+	}
+	if convState == nil || len(convState.Messages) == 0 {
+		return
+	}
+	for i := len(convState.Messages) - 1; i >= 0; i-- {
+		if convState.Messages[i].Role == roleAssistant {
+			setMeta(&convState.Messages[i], "current_workflow_state", meta)
+			if saveErr := store.Save(ctx, convState); saveErr != nil {
+				logger.Warn("Failed to save current workflow state metadata",
+					"conversation_id", convState.ID, "error", saveErr)
+			}
+			return
+		}
+	}
 }
 
 // buildCompositionResolver returns a function that resolves the active

--- a/tools/arena/engine/interfaces.go
+++ b/tools/arena/engine/interfaces.go
@@ -109,6 +109,18 @@ type ConversationRequest struct {
 	// monitoring. MonitorTap stages added to the pipeline publish to this
 	// router. Lifetime is the run; the engine owns Close().
 	AudioRouter *arenaaudio.AudioRouter
+
+	// CurrentWorkflowState returns the live workflow-state metadata for the turn
+	// about to run (captured at turn start, before the pipeline builds its
+	// prompt). Nil when there is no workflow. Used to stamp current_workflow_state
+	// onto each assistant result so composition-orchestrated terminal states —
+	// which leave no transition tool-result message — are still visible per turn.
+	CurrentWorkflowState func() map[string]interface{}
+
+	// StampWorkflowState attaches meta (captured at turn start) to the assistant
+	// message produced by the just-completed turn. No-op when meta is nil. This is
+	// side-effect-only and must never alter turn output, error, or flow.
+	StampWorkflowState func(meta map[string]interface{})
 }
 
 // StateStoreConfig wraps the pipeline StateStore configuration for Arena

--- a/tools/arena/render/html_test.go
+++ b/tools/arena/render/html_test.go
@@ -518,6 +518,46 @@ func TestGenerateHTMLReport_CompositionTab(t *testing.T) {
 	}
 }
 
+// TestGenerateHTMLReport_CurrentWorkflowStateTab verifies that an assistant
+// message carrying the explicit per-turn current_workflow_state (issue #1374)
+// renders the Workflow devtools tab with the state name, even without the legacy
+// _workflow_state key (the composition-orchestrated terminal-state case).
+func TestGenerateHTMLReport_CurrentWorkflowStateTab(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "current-workflow-state-report.html")
+
+	result := createTestResult(testRunID1, testProviderOpenAI, testRegionUSWest, testScenario1, 0.05, 100, 50, false, 500*time.Millisecond)
+	result.Messages = []types.Message{
+		{
+			Role:    "assistant",
+			Content: "Analyzing the document.",
+			Meta: map[string]interface{}{
+				"current_workflow_state": map[string]interface{}{
+					"current_state": "analyzing",
+					"description":   "Analyzing the uploaded document",
+				},
+			},
+		},
+	}
+
+	if err := GenerateHTMLReport([]engine.RunResult{result}, outputPath); err != nil {
+		t.Fatalf("Failed to generate HTML report: %v", err)
+	}
+
+	htmlData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read HTML file: %v", err)
+	}
+	html := string(htmlData)
+
+	if !strings.Contains(html, `data-devtools="workflow"`) {
+		t.Error("HTML does not contain workflow data element (data-devtools=\"workflow\")")
+	}
+	if !strings.Contains(html, "analyzing") {
+		t.Error("HTML does not contain workflow state name 'analyzing'")
+	}
+}
+
 func TestGenerateHTMLReport_CreatesDirectory(t *testing.T) {
 	// Create temporary directory for test
 	tmpDir := t.TempDir()

--- a/tools/arena/render/templates/report.html.tmpl
+++ b/tools/arena/render/templates/report.html.tmpl
@@ -2194,6 +2194,11 @@
                                         {{if index $metaMap "_workflow_state"}}
                                             {{$hasWorkflowState = true}}
                                         {{end}}
+                                        {{/* Issue #1374: explicit per-turn state surfaces the Workflow tab even
+                                             for composition-orchestrated states that left no transition message. */}}
+                                        {{if index $metaMap "current_workflow_state"}}
+                                            {{$hasWorkflowState = true}}
+                                        {{end}}
                                         {{if index $metaMap "_composition_snapshot"}}
                                             {{$hasCompositionSnapshot = true}}
                                         {{end}}
@@ -2316,7 +2321,15 @@
                                         <div data-devtools="tooldescriptors">{{prettyJSON (index $msg.Meta "_tool_descriptors")}}</div>
                                         {{end}}
                                         {{if $hasWorkflowState}}
+                                        {{/* Issue #1374: prefer the explicit per-turn current_workflow_state
+                                             (stamped from the turn-start state machine, visible even for
+                                             composition-orchestrated terminal states) and fall back to the
+                                             legacy replay-derived _workflow_state. */}}
+                                        {{if index $msg.Meta "current_workflow_state"}}
+                                        <div data-devtools="workflow">{{prettyJSON (index $msg.Meta "current_workflow_state")}}</div>
+                                        {{else}}
                                         <div data-devtools="workflow">{{prettyJSON (index $msg.Meta "_workflow_state")}}</div>
+                                        {{end}}
                                         {{end}}
                                         {{if $hasCompositionSnapshot}}
                                         <div data-devtools="composition">{{prettyJSON (index $msg.Meta "_composition_snapshot")}}</div>


### PR DESCRIPTION
## Summary

Arena reconstructed workflow state *after* a run by replaying the message log (`enrichMessagesWithWorkflowState`), tagging `_workflow_state` only on a transition tool-result or a leading system message. A **composition-orchestrated terminal state** has neither, so its turn showed **no workflow state** in the report — e.g. the `document-analysis` composition ran in state `analyzing`, but nothing said so.

This makes it **explicit**: the per-run state machine already knows the current state when a turn runs, so stamp it directly instead of inferring it later.

## What changed
- New per-message key **`current_workflow_state`** = `{current_state, description, available_events}` (reuses `buildEntryStateMeta`), stamped onto each assistant turn's result.
- **Captured at turn start** from the live `StateMachine` — the state whose prompt drives the turn. User-controlled transitions defer to `CommitPending` (PostTurnHook); agent-controlled commit eagerly mid-turn, so turn-*end* capture would record the wrong (chained) state. Turn-start is correct for both, and the prompt is always the turn-start state's (pipeline-per-turn).
- Uniform across provider / composition / agent orchestration; nil-safe when there's no workflow.
- Legacy `_workflow_state` / `_workflow_transitions` and the post-hoc enrichment are **untouched** (evals + assertions still consume them); the HTML Workflow devtools tab now renders `current_workflow_state` (falling back to `_workflow_state`).

## Test plan
- [x] Engine/executor unit tests: each assistant turn stamped with its turn-start state; nil-safe when no workflow; legacy key never introduced.
- [x] HTML render test: Workflow tab renders from `current_workflow_state` alone.
- [x] `tools/arena/engine` + `render` suites green; lint clean.
- [x] **Real reports:** `workflow-support` now shows per-turn state (`intake`→`specialist`→`closed`, not just entry); composition `document-analysis` shows `current_workflow_state.current_state = "analyzing"` in JSON + the Workflow tab in HTML.

Closes #1374

Note: scope is the non-streaming turn path (what workflow/composition scenarios use); the streaming path still relies on the legacy `_workflow_state`.
