### PR TITLE
feat(claude): native structured outputs (honor ResponseFormat via output_config)

### DIFF
--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -399,12 +399,36 @@ func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
 
 // Claude API request/response structures
 type claudeRequest struct {
-	Model       string               `json:"model"`
-	MaxTokens   int                  `json:"max_tokens"`
-	Messages    []claudeMessage      `json:"messages"`
-	System      []claudeContentBlock `json:"system,omitempty"`
-	Temperature float32              `json:"temperature,omitempty"`
-	TopP        float32              `json:"top_p,omitempty"`
+	Model        string               `json:"model"`
+	MaxTokens    int                  `json:"max_tokens"`
+	Messages     []claudeMessage      `json:"messages"`
+	System       []claudeContentBlock `json:"system,omitempty"`
+	Temperature  float32              `json:"temperature,omitempty"`
+	TopP         float32              `json:"top_p,omitempty"`
+	OutputConfig *claudeOutputConfig  `json:"output_config,omitempty"`
+}
+
+// claudeOutputConfig requests native structured outputs (GA, no beta header):
+// the response is guaranteed valid JSON conforming to the schema, returned in
+// content[0].text. https://platform.claude.com/docs/en/docs/build-with-claude/structured-outputs
+type claudeOutputConfig struct {
+	Format claudeOutputFormat `json:"format"`
+}
+
+type claudeOutputFormat struct {
+	Type   string          `json:"type"`   // "json_schema"
+	Schema json.RawMessage `json:"schema"` // the raw JSON schema
+}
+
+// outputConfigFor maps a provider ResponseFormat to Anthropic's output_config.
+// Returns nil unless a JSON-schema response format with a schema is set.
+func outputConfigFor(rf *providers.ResponseFormat) *claudeOutputConfig {
+	if rf == nil || rf.Type != providers.ResponseFormatJSONSchema || len(rf.JSONSchema) == 0 {
+		return nil
+	}
+	return &claudeOutputConfig{
+		Format: claudeOutputFormat{Type: "json_schema", Schema: rf.JSONSchema},
+	}
 }
 
 type claudeMessage struct {
@@ -755,6 +779,8 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 	if p.paramSupported("temperature") {
 		claudeReq.Temperature = temperature
 	}
+	// Native structured outputs: map a JSON-schema ResponseFormat to output_config.
+	claudeReq.OutputConfig = outputConfigFor(req.ResponseFormat)
 
 	// Prepare response with raw request if configured (set early to preserve on error)
 	predictResp := providers.PredictionResponse{

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -70,6 +70,12 @@ func (p *Provider) PredictStream(
 		}
 	}
 
+	// Native structured outputs (output_config). PredictStream is the no-tools
+	// path, so there's no tool-use conflict to guard against.
+	if oc := outputConfigFor(req.ResponseFormat); oc != nil {
+		claudeReq["output_config"] = oc
+	}
+
 	// Bedrock: use binary event-stream format, wired through the same
 	// RunStreamingRequest path as the direct API so Bedrock gets retry,
 	// budget, semaphore, and metrics for free.

--- a/runtime/providers/claude/structured_outputs_test.go
+++ b/runtime/providers/claude/structured_outputs_test.go
@@ -1,0 +1,65 @@
+package claude
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// TestOutputConfigFor verifies the ResponseFormat -> Anthropic output_config mapping.
+func TestOutputConfigFor(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"type":{"type":"string"}},"required":["type"],"additionalProperties":false}`)
+
+	if oc := outputConfigFor(nil); oc != nil {
+		t.Errorf("nil ResponseFormat: want nil, got %#v", oc)
+	}
+	if oc := outputConfigFor(&providers.ResponseFormat{Type: providers.ResponseFormatText}); oc != nil {
+		t.Errorf("text ResponseFormat: want nil, got %#v", oc)
+	}
+	if oc := outputConfigFor(&providers.ResponseFormat{Type: providers.ResponseFormatJSONSchema}); oc != nil {
+		t.Errorf("json_schema with empty schema: want nil, got %#v", oc)
+	}
+
+	oc := outputConfigFor(&providers.ResponseFormat{Type: providers.ResponseFormatJSONSchema, JSONSchema: schema})
+	if oc == nil {
+		t.Fatal("json_schema ResponseFormat with schema: want config, got nil")
+	}
+	if oc.Format.Type != "json_schema" {
+		t.Errorf("format type = %q, want json_schema", oc.Format.Type)
+	}
+	if string(oc.Format.Schema) != string(schema) {
+		t.Errorf("schema = %s, want %s", oc.Format.Schema, schema)
+	}
+}
+
+// TestClaudeRequest_OutputConfigSerialization verifies output_config serializes to
+// the Anthropic-expected shape and is omitted when unset.
+func TestClaudeRequest_OutputConfigSerialization(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"type":{"type":"string"}},"required":["type"],"additionalProperties":false}`)
+
+	withOC := claudeRequest{
+		Model:        "claude-haiku-4-5",
+		MaxTokens:    512,
+		OutputConfig: outputConfigFor(&providers.ResponseFormat{Type: providers.ResponseFormatJSONSchema, JSONSchema: schema}),
+	}
+	b, err := json.Marshal(withOC)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"output_config":{"format":{"type":"json_schema","schema":{`) {
+		t.Errorf("serialized request missing expected output_config shape: %s", got)
+	}
+
+	// Omitted when no ResponseFormat is set.
+	withoutOC := claudeRequest{Model: "claude-haiku-4-5", MaxTokens: 512}
+	b2, err := json.Marshal(withoutOC)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b2), "output_config") {
+		t.Errorf("output_config should be omitted when unset: %s", string(b2))
+	}
+}


### PR DESCRIPTION
## Summary

The claude provider **ignored `ResponseFormat` entirely** — OpenAI honors it (`response_format: json_schema`) but Claude dropped it and free-formed (markdown-fenced JSON + prose). This broke any structured-output use of Claude, including RFC 0010 composition `branch` predicates that parse a prior step's JSON output (`${classify.output.type}` couldn't resolve → branch misfired).

Fix: map a JSON-schema `ResponseFormat` to Anthropic's **native structured outputs** (`output_config.format = {type: "json_schema", schema}`) — GA, no beta header, supported on Haiku 4.5 / Sonnet 4.6 / Opus 4.x / Fable 5. Claude now returns guaranteed-valid JSON in `content[0].text`, achieving OpenAI parity.

## Found via a live test
Running the RFC 0010 `document-analysis` composition against **real Claude** (haiku-4-5) surfaced this — the mock provider always returns clean JSON, so it was invisible. Before: `classify` returned ` ```json {...} ``` ` + prose → branch took `else`. After: `classify` returns `{"type":"research_paper","confidence":0.95}` → branch routes correctly → **all 4 `composition_*` assertions pass** end-to-end on a live LLM.

## What changed
- `claude.go`: `claudeRequest.OutputConfig` field + `claudeOutputConfig`/`claudeOutputFormat` types + `outputConfigFor()` helper; set it in `Predict` (non-streaming, no-tools path).
- `claude_streaming.go`: set `output_config` in `PredictStream` (streaming, no-tools path — the one the pipeline uses).
- Not wired into the tools path (`buildToolRequest`): structured output and tool-use are mutually exclusive in the Anthropic API, and that path is only called with tools present.

## Test plan
- [x] `runtime/providers/claude` tests green; new `structured_outputs_test.go` covers the `ResponseFormat → output_config` mapping + serialization (present when set, omitted otherwise).
- [x] Live: `document-analysis` composition vs real Claude → clean JSON, correct branch, 4/4 assertions pass.

> Follow-up (filed separately): the claude provider has three+ parallel request builders (`Predict` struct, `PredictStream` map, `buildToolRequest` map) — this fix had to touch two of them. Consolidating to one request builder is tracked for later.
