### PR TITLE
fix(gemini): sanitize JSON schema for responseSchema

### DIFF
--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -359,11 +359,49 @@ func (p *Provider) applyResponseFormat(req *geminiRequest, rf *providers.Respons
 		if len(rf.JSONSchema) > 0 {
 			var schema interface{}
 			if err := json.Unmarshal(rf.JSONSchema, &schema); err == nil {
-				req.GenerationConfig.ResponseSchema = schema
+				// Gemini's responseSchema is an OpenAPI 3.0 subset and rejects
+				// standard JSON Schema keywords like $schema/additionalProperties.
+				req.GenerationConfig.ResponseSchema = sanitizeGeminiSchema(schema)
 			}
 		}
 	case providers.ResponseFormatText:
 		// Text is default, no changes needed
+	}
+}
+
+// geminiUnsupportedSchemaKeys are JSON Schema keywords that Gemini's
+// responseSchema (an OpenAPI 3.0 Schema subset) does not accept and that cause
+// a 400 INVALID_ARGUMENT if present.
+var geminiUnsupportedSchemaKeys = map[string]bool{
+	"$schema":              true,
+	"$id":                  true,
+	"$ref":                 true,
+	"$defs":                true,
+	"definitions":          true,
+	"$comment":             true,
+	"additionalProperties": true,
+}
+
+// sanitizeGeminiSchema recursively removes JSON Schema keywords Gemini rejects,
+// so a standard pack output_schema can be reused as a Gemini responseSchema.
+func sanitizeGeminiSchema(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, val := range t {
+			if geminiUnsupportedSchemaKeys[k] {
+				continue
+			}
+			out[k] = sanitizeGeminiSchema(val)
+		}
+		return out
+	case []interface{}:
+		for i, e := range t {
+			t[i] = sanitizeGeminiSchema(e)
+		}
+		return t
+	default:
+		return v
 	}
 }
 

--- a/runtime/providers/gemini/structured_outputs_test.go
+++ b/runtime/providers/gemini/structured_outputs_test.go
@@ -1,0 +1,56 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSanitizeGeminiSchema verifies that JSON Schema keywords Gemini's
+// responseSchema rejects ($schema, additionalProperties, $defs, …) are stripped
+// recursively while supported keywords are preserved.
+func TestSanitizeGeminiSchema(t *testing.T) {
+	in := []byte(`{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "x",
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"type": {"type": "string", "enum": ["a", "b"]},
+			"items": {
+				"type": "array",
+				"items": {"type": "object", "additionalProperties": false, "properties": {"k": {"type": "string"}}}
+			}
+		},
+		"required": ["type"],
+		"$defs": {"unused": {"type": "string"}}
+	}`)
+	var schema interface{}
+	if err := json.Unmarshal(in, &schema); err != nil {
+		t.Fatal(err)
+	}
+
+	got := sanitizeGeminiSchema(schema).(map[string]interface{})
+
+	for _, banned := range []string{"$schema", "$id", "additionalProperties", "$defs"} {
+		if _, present := got[banned]; present {
+			t.Errorf("top-level: %q should be stripped", banned)
+		}
+	}
+	// Supported keywords preserved.
+	if got["type"] != "object" {
+		t.Errorf("type should be preserved, got %v", got["type"])
+	}
+	if _, ok := got["required"]; !ok {
+		t.Error("required should be preserved")
+	}
+	// Nested object under properties.items.items must also be sanitized.
+	props := got["properties"].(map[string]interface{})
+	items := props["items"].(map[string]interface{})
+	nested := items["items"].(map[string]interface{})
+	if _, present := nested["additionalProperties"]; present {
+		t.Error("nested additionalProperties should be stripped")
+	}
+	if _, ok := nested["properties"]; !ok {
+		t.Error("nested properties should be preserved")
+	}
+}


### PR DESCRIPTION
## Summary

The gemini provider passed a pack's `output_schema` **raw** into Gemini's `responseSchema`, but that field is an OpenAPI-3.0 subset that rejects standard JSON Schema keywords. A composition step with `output_schema` against Gemini failed with:

```
400 INVALID_ARGUMENT: Unknown name "$schema" at 'generation_config.response_schema': Cannot find field.
Unknown name "additionalProperties" at 'generation_config.response_schema': Cannot find field.
```

Fix: `sanitizeGeminiSchema` recursively strips Gemini-unsupported keywords (`$schema`, `$id`, `$ref`, `$defs`, `definitions`, `$comment`, `additionalProperties`) before setting `responseSchema`, so a standard pack schema works as-is.

## Found via live cross-provider testing
Running the RFC 0010 `document-analysis` composition against **real Gemini** (`gemini-2.5-flash`) surfaced this. Note the cross-provider tension this resolves: Anthropic structured outputs *want* `additionalProperties:false`; Gemini *rejects* it — so the adaptation must live in each provider. After the fix, **all 4 `composition_*` assertions pass** on Gemini.

Cross-provider status for the composition (all 4/4 now):
- **Claude** (haiku-4-5) — needed `output_config` (#1378)
- **Gemini** (2.5-flash) — needed this schema sanitization
- **OpenAI** (gpt-4o-mini) — worked unchanged (already honored `ResponseFormat`)

## Test plan
- [x] `runtime/providers/gemini` tests green; new `structured_outputs_test.go` asserts unsupported keywords are stripped recursively and supported ones (type/properties/required/enum/items) preserved.
- [x] Live: `document-analysis` composition vs real Gemini → 4/4 assertions pass.
