### PR TITLE
feat(composition): surface silent composition-layer failures in logs

### DIFF
--- a/runtime/composition/engine/predicate.go
+++ b/runtime/composition/engine/predicate.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 )
 
 const (
@@ -72,7 +73,13 @@ func evalCompare(p *composition.Predicate, scope Scope) (bool, error) {
 	actual, found := resolvePath(p.Path, scope)
 	if !found {
 		// A missing path is not an error for compare: equals/in are false,
-		// not_equals/not_in are true. Mirror that with nil actual.
+		// not_equals/not_in are true. Mirror that with nil actual. Warn, because
+		// an unresolvable compare path usually means a misconfigured reference or
+		// an upstream step output that wasn't the expected shape (e.g. a provider
+		// returned non-JSON for a step with an output_schema), which silently
+		// sends a branch down its else path.
+		logger.Warn("composition branch predicate path did not resolve; treating value as null",
+			"path", p.Path, "op", p.Op)
 		actual = nil
 	}
 	switch p.Op {

--- a/runtime/pipeline/stage/composition_executor.go
+++ b/runtime/pipeline/stage/composition_executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/composition/engine"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -175,7 +176,7 @@ func (deps CompositionExecutorDeps) execLLM(
 	if res == nil || res.Response == nil {
 		return nil, fmt.Errorf("step %q: sub-pipeline produced no response", step.ID)
 	}
-	return responseToJSON(res.Response, step.OutputSchema != "")
+	return responseToJSON(res.Response, step.OutputSchema != "", step.ID)
 }
 
 // responseFormat builds a structured-output ResponseFormat from the step's
@@ -225,9 +226,19 @@ func stepInputToText(input json.RawMessage) string {
 // literal "null", "42", or "true"). This prevents ambiguity in downstream
 // ${step.output} resolution where a bare JSON primitive would be
 // indistinguishable from a structured value.
-func responseToJSON(resp *Response, structured bool) (json.RawMessage, error) {
-	if structured && json.Valid([]byte(resp.Content)) {
-		return json.RawMessage(resp.Content), nil
+func responseToJSON(resp *Response, structured bool, stepID string) (json.RawMessage, error) {
+	if structured {
+		if json.Valid([]byte(resp.Content)) {
+			return json.RawMessage(resp.Content), nil
+		}
+		// The step declared an output_schema but the provider returned content
+		// that is not valid JSON (e.g. a provider that doesn't enforce structured
+		// output, or wrapped the JSON in prose/markdown fences). It's encoded as a
+		// plain string below, so downstream ${stepID.output.field} references will
+		// not resolve — warn so this isn't silently invisible.
+		logger.Warn("composition step declared output_schema but provider returned non-JSON content; "+
+			"structured output may not have taken effect (downstream ${...output.field} refs will not resolve)",
+			"step", stepID)
 	}
 	enc, err := json.Marshal(resp.Content)
 	if err != nil {

--- a/runtime/prompt/registry.go
+++ b/runtime/prompt/registry.go
@@ -391,6 +391,18 @@ func (r *Registry) Load(activity string) *AssembledPrompt {
 	return r.LoadWithVars(activity, make(map[string]string), "")
 }
 
+// logPromptLoadFailure logs a prompt-config load failure. An empty activity is
+// expected for workflow states with no prompt_task (composition /
+// agent-orchestration states, RFC 0010) — benign, logged at Debug. ERROR is
+// reserved for genuinely-missing named prompts.
+func logPromptLoadFailure(activity string, err error) {
+	if activity == "" {
+		logger.Debug("No prompt config for empty activity (composition/orchestration state)", "error", err)
+		return
+	}
+	logger.Error("Failed to load prompt config", "activity", activity, "error", err)
+}
+
 // LoadTemplate loads a prompt without rendering, returning the raw template and
 // all metadata needed to render it later. This is the preferred path for pipeline
 // stages that separate assembly from rendering (e.g. PromptAssemblyStage +
@@ -398,7 +410,7 @@ func (r *Registry) Load(activity string) *AssembledPrompt {
 func (r *Registry) LoadTemplate(activity string, vars map[string]string, model string) (*Template, error) {
 	config, err := r.loadConfig(activity)
 	if err != nil {
-		logger.Error("Failed to load prompt config", "activity", activity, "error", err)
+		logPromptLoadFailure(activity, err)
 		return nil, fmt.Errorf("failed to load prompt config for %q: %w", activity, err)
 	}
 


### PR DESCRIPTION
## Summary

Closes the composition observability gaps from #1381 — composition-layer *semantic* failures were silent, forcing diagnosis via recorded JSON instead of logs (exactly what slowed down the live cross-provider bring-up).

Three fixes:
1. **Branch predicate resolution** (`composition/engine/predicate.go`): warn when a `branch` compare-predicate path (e.g. `${classify.output.type}`) doesn't resolve. Previously the branch silently fell to `else` with no signal — the hardest issue to diagnose this week. (Engine gains a `runtime/logger` import; the purity invariant that matters — no `runtime/events` coupling — is unchanged.)
2. **Structured-output fallback** (`pipeline/stage/composition_executor.go`): warn when a step declares `output_schema` but the provider returns non-JSON content (so it's string-encoded and downstream `${step.output.field}` refs won't resolve). Threads the step id for context.
3. **Benign ERROR noise** (`prompt/registry.go`): an empty `activity` (workflow states with no `prompt_task` — composition/agent-orchestration states) no longer logs at **ERROR**; it's now **Debug** via a small `logPromptLoadFailure` helper (keeps `LoadTemplate`'s complexity flat). ERROR is reserved for genuinely-missing named prompts.

## Test plan
- [x] `composition/engine`, `pipeline/stage`, `prompt` tests green; build clean.
- [x] Lint clean on changed lines (pre-commit passed).

Closes #1381
