### PR TITLE
ci: run document-analysis composition example in the mock-provider test list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,9 +537,16 @@ jobs:
           --ci \
           --formats json,junit,html,markdown
 
+    - name: Test document-analysis example (RFC 0010 composition)
+      run: |
+        cd examples/document-analysis
+        ../../bin/promptarena run --config config.arena.yaml \
+          --ci \
+          --formats json,junit,html,markdown
+
     - name: Verify outputs were generated
       run: |
-        EXAMPLES=("customer-support" "multimodal-basics" "variables-demo" "assertions-test" "llm-judge" "guardrails-test" "eval-test")
+        EXAMPLES=("customer-support" "multimodal-basics" "variables-demo" "assertions-test" "llm-judge" "guardrails-test" "eval-test" "document-analysis")
 
         for example in "${EXAMPLES[@]}"; do
           echo "=== Verifying $example ==="
@@ -573,8 +580,8 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         
         # Combine results from all examples
-        EXAMPLES=("customer-support" "multimodal-basics" "variables-demo" "assertions-test" "llm-judge" "guardrails-test" "eval-test")
-        EXAMPLE_NAMES=("Customer Support" "Multimodal Basics" "Variables Demo" "Assertions Test" "LLM Judge" "Guardrails Test" "Eval Test")
+        EXAMPLES=("customer-support" "multimodal-basics" "variables-demo" "assertions-test" "llm-judge" "guardrails-test" "eval-test" "document-analysis")
+        EXAMPLE_NAMES=("Customer Support" "Multimodal Basics" "Variables Demo" "Assertions Test" "LLM Judge" "Guardrails Test" "Eval Test" "Document Analysis (Composition)")
         
         for i in "${!EXAMPLES[@]}"; do
           example="${EXAMPLES[$i]}"


### PR DESCRIPTION
## Summary

Adds the RFC 0010 **`document-analysis`** composition example to the "Test Arena with Mock Provider" job in `ci.yml`, so the composition path is gated on every PR (against its pre-configured mock provider).

- New run step: `promptarena run --config config.arena.yaml --ci --formats json,junit,html,markdown` (no `--mock-provider` — the example ships a pre-configured `mock-provider.yaml`, matching the llm-judge/guardrails-test/eval-test style).
- Added `document-analysis` to both `EXAMPLES` arrays (the output-verification gate + the step-summary), with the display name "Document Analysis (Composition)".

## Verified locally
Ran the exact CI command from `examples/document-analysis`:
- 4/4 `composition_*` assertions pass
- `out/junit.xml` and `out/results.md` produced (what the verification step checks)
- validates against the live v1.5.0 remote schemas (no local flag)

Follow-up to #1350 (composition example, merged) — keeps the composition pipeline continuously exercised in CI.

> Note: this PR touches `.github/workflows/`, so it needs to be **merged via the GitHub UI** (the CLI token lacks `workflow` scope to merge workflow changes).
