### PR TITLE
feat(sdk,runtime): image__generate / video__generate tools (#1329)

### DIFF
--- a/examples/arena-media-test/config.arena.yaml
+++ b/examples/arena-media-test/config.arena.yaml
@@ -8,6 +8,8 @@ spec:
       file: prompts/media-assistant.yaml
     - id: audio-analyst
       file: prompts/audio-analyst.yaml
+    - id: image-generator
+      file: prompts/image-generator.yaml
 
   providers:
     - file: providers/mock-provider.provider.yaml
@@ -21,6 +23,7 @@ spec:
     - file: scenarios/multimodal-mixed.scenario.yaml
     - file: scenarios/audio-transcription.scenario.yaml
     - file: scenarios/imagen-generation.scenario.yaml
+    - file: scenarios/tool-image-generation.scenario.yaml
     - file: scenarios/openai-audio-output.scenario.yaml
 
   defaults:

--- a/examples/arena-media-test/prompts/image-generator.yaml
+++ b/examples/arena-media-test/prompts/image-generator.yaml
@@ -1,0 +1,19 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+metadata:
+  name: image-generator
+spec:
+  task_type: "image-generation"
+  version: "v1.0.0"
+  description: "Text agent that generates images mid-conversation via the image__generate tool"
+
+  # The agent here is a TEXT LLM (e.g. gemini). An image provider declared with
+  # role: image sits in the provider pool, which makes the built-in
+  # image__generate tool available. This is distinct from the imagen-generation
+  # scenario, where Imagen IS the agent and the image is its whole response.
+  system_template: |
+    You are a creative assistant that can generate images.
+    When the user asks you to create, generate, or draw an image, call the
+    image__generate tool with a clear, descriptive `prompt` argument describing
+    the desired image. After the image is generated, briefly confirm what you
+    produced.

--- a/examples/arena-media-test/scenarios/tool-image-generation.scenario.yaml
+++ b/examples/arena-media-test/scenarios/tool-image-generation.scenario.yaml
@@ -1,0 +1,39 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+metadata:
+  name: tool-image-generation
+  annotations:
+    description: |
+      Exercises the image__generate tool: a text agent (e.g. gemini) calls the
+      tool mid-conversation to generate an image, resolved from the pooled
+      role:image provider (imagen). Distinct from imagen-generation, where
+      Imagen is the agent. Run against a text provider with tool support and a
+      pooled image provider, e.g.:
+        promptarena run --provider gemini-provider
+      Requires GOOGLE_API_KEY (text agent + imagen). Not CI-gated.
+spec:
+  id: tool-image-generation
+  task_type: image-generation
+  description: |
+    Exercises the image__generate tool: the gemini text agent calls it
+    mid-conversation to generate an image, resolved from the pooled role:image
+    provider (imagen). Distinct from imagen-generation, where Imagen is the
+    agent. The agent is pinned to gemini-provider so it stays the text agent;
+    run WITHOUT --provider so imagen still loads into the pool and the tool
+    resolves. Requires GOOGLE_API_KEY. Not CI-gated:
+      promptarena run --scenario tool-image-generation
+  # Pin the agent-under-test to the text provider (id gemini-flash). imagen
+  # still loads into the pool (when the run is not provider-filtered), making
+  # image__generate available; only gemini runs this scenario as the agent.
+  providers:
+    - gemini-flash
+  turns:
+  - role: user
+    parts:
+    - type: text
+      text: Create an image of a red circle on a white background.
+    assertions:
+    - type: image_format
+      params:
+        formats:
+        - png

--- a/pkg/config/role.go
+++ b/pkg/config/role.go
@@ -16,6 +16,12 @@ const (
 	RoleSTT       = "stt"
 	RoleEmbedding = "embedding"
 	RoleImage     = "image"
+	// RoleVideo marks a video-generation provider. The abstraction
+	// (base.VideoProvider) exists so the video__generate tool can resolve a
+	// provider from the pool, but no concrete video provider ships yet — a
+	// role: video declaration only succeeds once a video provider type is
+	// registered in the provider factory.
+	RoleVideo = "video"
 	// RoleInference covers providers implementing the runtime/classify task
 	// interfaces (audio/text/image/video classifiers + embedders). A single
 	// inference provider can satisfy several of them — the HuggingFace
@@ -34,6 +40,7 @@ var knownRoles = map[string]struct{}{
 	RoleSTT:       {},
 	RoleEmbedding: {},
 	RoleImage:     {},
+	RoleVideo:     {},
 	RoleInference: {},
 }
 
@@ -52,8 +59,8 @@ func (p *Provider) ValidateRole() error {
 		return nil
 	}
 	if _, ok := knownRoles[p.Role]; !ok {
-		return fmt.Errorf("unknown provider role %q (valid: %s, %s, %s, %s, %s, %s)",
-			p.Role, RoleLLM, RoleTTS, RoleSTT, RoleEmbedding, RoleImage, RoleInference)
+		return fmt.Errorf("unknown provider role %q (valid: %s, %s, %s, %s, %s, %s, %s)",
+			p.Role, RoleLLM, RoleTTS, RoleSTT, RoleEmbedding, RoleImage, RoleVideo, RoleInference)
 	}
 	return nil
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1191,7 +1191,7 @@ type Provider struct {
 	// Renamed from "capability" 2026-05-18 to avoid singular/plural
 	// collision with Capabilities. The field is required for tts/stt
 	// providers; defaults to "llm" when empty.
-	Role    string `json:"role,omitempty" yaml:"role,omitempty" jsonschema:"enum=llm,enum=tts,enum=stt,enum=embedding,enum=image,enum=inference"` //nolint:lll // enum list can't be split inside a struct tag
+	Role    string `json:"role,omitempty" yaml:"role,omitempty" jsonschema:"enum=llm,enum=tts,enum=stt,enum=embedding,enum=image,enum=video,enum=inference"` //nolint:lll // enum list can't be split inside a struct tag
 	BaseURL string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	// Headers specifies custom HTTP headers to include in every request to
 	// this provider. Useful for OpenAI-compatible gateways (OpenRouter,

--- a/runtime/evals/handlers/helpers.go
+++ b/runtime/evals/handlers/helpers.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const roleAssistant = "assistant"
+const (
+	roleAssistant = "assistant"
+	roleTool      = "tool"
+)
 
 // extractStringSlice safely extracts a string slice from params.
 func extractStringSlice(params map[string]any, key string) []string {

--- a/runtime/evals/handlers/media_helpers.go
+++ b/runtime/evals/handlers/media_helpers.go
@@ -32,20 +32,37 @@ const (
 	msgHeightAboveMax = "height %d exceeds maximum %d"
 )
 
-// extractMediaParts finds media content parts of the given type from assistant messages.
+// extractMediaParts finds media content parts of the given type produced by the
+// agent's turn. This covers two sources: media the model emitted inline on an
+// assistant message, and media a tool produced (e.g. image__generate), which
+// lands in the tool-result parts of a tool-role message rather than on the
+// message's inline Parts.
 func extractMediaParts(messages []types.Message, contentType string) []types.ContentPart {
 	var parts []types.ContentPart
 	for i := range messages {
-		if messages[i].Role != roleAssistant {
-			continue
-		}
-		for _, part := range messages[i].Parts {
-			if part.Type == contentType && part.Media != nil {
-				parts = append(parts, part)
+		msg := &messages[i]
+		switch msg.Role {
+		case roleAssistant:
+			parts = appendMatchingMediaParts(parts, msg.Parts, contentType)
+		case roleTool:
+			if msg.ToolResult != nil {
+				parts = appendMatchingMediaParts(parts, msg.ToolResult.Parts, contentType)
 			}
 		}
 	}
 	return parts
+}
+
+// appendMatchingMediaParts appends parts of contentType that carry media.
+func appendMatchingMediaParts(
+	dst, src []types.ContentPart, contentType string,
+) []types.ContentPart {
+	for _, part := range src {
+		if part.Type == contentType && part.Media != nil {
+			dst = append(dst, part)
+		}
+	}
+	return dst
 }
 
 // mimeTypeParts is the expected number of parts when splitting a MIME type by "/".

--- a/runtime/evals/handlers/media_toolresult_test.go
+++ b/runtime/evals/handlers/media_toolresult_test.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestImageFormat_ToolResultPart guards that media produced by a tool (e.g.
+// image__generate), which lands in a tool-role message's ToolResult.Parts
+// rather than an assistant message's inline Parts, is visible to the media
+// format evals. Before the extractMediaParts fix these were silently ignored.
+func TestImageFormat_ToolResultPart(t *testing.T) {
+	msgs := []types.Message{
+		{Role: "user", Parts: []types.ContentPart{types.NewTextPart("make an image")}},
+		{Role: "assistant"},
+		{Role: "tool", ToolResult: &types.MessageToolResult{
+			Name:  "image__generate",
+			Parts: []types.ContentPart{types.NewImagePartFromData("iVBORw0KGgo=", "image/png", nil)},
+		}},
+	}
+
+	h := &ImageFormatHandler{}
+	res, err := h.Eval(context.Background(), &evals.EvalContext{Messages: msgs},
+		map[string]any{"formats": []any{"png"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Score == nil || *res.Score != 1 {
+		t.Fatalf("expected pass (score 1) for tool-result image, got %v: %s", res.Score, res.Explanation)
+	}
+}
+
+// TestImageFormat_NoImagesAnywhere keeps the negative path honest: no image in
+// assistant or tool messages still fails.
+func TestImageFormat_NoImagesAnywhere(t *testing.T) {
+	msgs := []types.Message{
+		{Role: "user", Parts: []types.ContentPart{types.NewTextPart("hi")}},
+		{Role: "assistant", Parts: []types.ContentPart{types.NewTextPart("hello")}},
+	}
+	h := &ImageFormatHandler{}
+	res, err := h.Eval(context.Background(), &evals.EvalContext{Messages: msgs},
+		map[string]any{"formats": []any{"png"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Score == nil || *res.Score != 0 {
+		t.Fatalf("expected fail (score 0) with no images, got %v", res.Score)
+	}
+}

--- a/runtime/mediagen/descriptors.go
+++ b/runtime/mediagen/descriptors.go
@@ -1,0 +1,89 @@
+// Package mediagen provides the built-in image__generate and video__generate
+// tools. They let a text agent generate media as one step of a conversation by
+// resolving an image/video provider from the shared provider pool
+// (base.Registry) and invoking its Generate method.
+//
+// The package lives in runtime so both the SDK and Arena can wire it without
+// duplicating provider-resolution logic. It depends only on runtime/providers/base,
+// runtime/tools, and runtime/types — never on sdk or tools/arena.
+package mediagen
+
+import (
+	"encoding/json"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+const (
+	// ImageGenerateToolName is the qualified name of the image generation tool.
+	ImageGenerateToolName = "image__generate"
+	// VideoGenerateToolName is the qualified name of the video generation tool.
+	VideoGenerateToolName = "video__generate"
+	// ExecutorMode is the tool Mode that routes to the mediagen Executor.
+	ExecutorMode = "mediagen"
+)
+
+const imageToolDescription = "Generate an image from a text prompt using the configured image " +
+	"provider. Returns the generated image inline in the conversation."
+
+const videoToolDescription = "Generate a video from a text prompt using the configured video " +
+	"provider. Returns the generated video inline in the conversation."
+
+// ImageGenerateDescriptor returns the descriptor for the image__generate tool.
+func ImageGenerateDescriptor() *tools.ToolDescriptor {
+	return &tools.ToolDescriptor{
+		Name:        ImageGenerateToolName,
+		Namespace:   "image",
+		Description: imageToolDescription,
+		InputSchema: imageInputSchema(),
+		Mode:        ExecutorMode,
+	}
+}
+
+// VideoGenerateDescriptor returns the descriptor for the video__generate tool.
+func VideoGenerateDescriptor() *tools.ToolDescriptor {
+	return &tools.ToolDescriptor{
+		Name:        VideoGenerateToolName,
+		Namespace:   "video",
+		Description: videoToolDescription,
+		InputSchema: videoInputSchema(),
+		Mode:        ExecutorMode,
+	}
+}
+
+func imageInputSchema() json.RawMessage {
+	return mediaInputSchema(
+		"The text description of the image to generate.",
+		"size", "Optional image size hint, e.g. \"1024x1024\".",
+	)
+}
+
+func videoInputSchema() json.RawMessage {
+	return mediaInputSchema(
+		"The text description of the video to generate.",
+		"aspect_ratio", "Optional aspect ratio hint, e.g. \"16:9\".",
+	)
+}
+
+const (
+	schemaTypeKey  = "type"
+	schemaPromptID = "prompt"
+)
+
+// mediaInputSchema builds the tool input schema shared by the image and video
+// tools: a required prompt plus one optional provider-specific string hint.
+func mediaInputSchema(promptDesc, optName, optDesc string) json.RawMessage {
+	strField := func(desc string) map[string]any {
+		return map[string]any{schemaTypeKey: "string", "description": desc}
+	}
+	schema := map[string]any{
+		schemaTypeKey: "object",
+		"properties": map[string]any{
+			schemaPromptID: strField(promptDesc),
+			optName:        strField(optDesc),
+		},
+		"required": []string{schemaPromptID},
+	}
+	out, _ := json.Marshal(schema)
+	return out
+}

--- a/runtime/mediagen/executor.go
+++ b/runtime/mediagen/executor.go
@@ -1,0 +1,190 @@
+package mediagen
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Executor resolves an image/video provider from the pool and invokes its
+// Generate method, returning the result as a media ContentPart that flows into
+// the conversation message log. It implements tools.MultimodalExecutor.
+type Executor struct {
+	pool *base.Registry
+}
+
+// NewExecutor returns an Executor backed by the given provider pool. The pool
+// may be nil; in that case every call resolves to a "no provider configured"
+// error returned to the calling agent.
+func NewExecutor(pool *base.Registry) *Executor {
+	return &Executor{pool: pool}
+}
+
+// Name returns the executor mode string. It must match ToolDescriptor.Mode.
+func (e *Executor) Name() string { return ExecutorMode }
+
+// Execute satisfies tools.Executor. mediagen always produces media parts, so
+// this returns the JSON summary and drops the parts; the registry prefers
+// ExecuteMultimodal where available.
+func (e *Executor) Execute(
+	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, error) {
+	result, _, err := e.ExecuteMultimodal(ctx, descriptor, args)
+	return result, err
+}
+
+// ExecuteMultimodal generates media and returns a JSON summary plus the media
+// ContentParts. An unresolved provider, a provider error, or empty output is
+// returned as an error so the agent sees a clear tool failure rather than a
+// silent no-op.
+func (e *Executor) ExecuteMultimodal(
+	ctx context.Context, descriptor *tools.ToolDescriptor, args json.RawMessage,
+) (json.RawMessage, []types.ContentPart, error) {
+	switch descriptor.Name {
+	case ImageGenerateToolName:
+		return e.generateImage(ctx, args)
+	case VideoGenerateToolName:
+		return e.generateVideo(ctx, args)
+	default:
+		return nil, nil, fmt.Errorf("mediagen: unsupported tool %q", descriptor.Name)
+	}
+}
+
+type imageArgs struct {
+	Prompt string `json:"prompt"`
+	Size   string `json:"size"`
+}
+
+type videoArgs struct {
+	Prompt      string `json:"prompt"`
+	AspectRatio string `json:"aspect_ratio"`
+}
+
+func (e *Executor) generateImage(
+	ctx context.Context, args json.RawMessage,
+) (json.RawMessage, []types.ContentPart, error) {
+	var a imageArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, nil, fmt.Errorf("mediagen: invalid image__generate args: %w", err)
+	}
+	if a.Prompt == "" {
+		return nil, nil, fmt.Errorf("mediagen: image__generate requires a non-empty prompt")
+	}
+
+	prov, err := resolveProvider[base.ImageProvider](e.pool, base.ProviderTypeImage, "image")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := prov.Generate(ctx, base.ImageRequest{Prompt: a.Prompt, Size: a.Size})
+	if err != nil {
+		return nil, nil, fmt.Errorf("mediagen: image generation failed: %w", err)
+	}
+
+	parts := mediaParts(resp.Images, resp.MIMEType, types.MIMETypeImagePNG, newImagePart)
+	if len(parts) == 0 {
+		return nil, nil, fmt.Errorf("mediagen: image provider %q returned no images", prov.Name())
+	}
+
+	summary := summaryJSON(prov.Name(), partsMIME(parts), len(parts))
+	return summary, parts, nil
+}
+
+func (e *Executor) generateVideo(
+	ctx context.Context, args json.RawMessage,
+) (json.RawMessage, []types.ContentPart, error) {
+	var a videoArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, nil, fmt.Errorf("mediagen: invalid video__generate args: %w", err)
+	}
+	if a.Prompt == "" {
+		return nil, nil, fmt.Errorf("mediagen: video__generate requires a non-empty prompt")
+	}
+
+	prov, err := resolveProvider[base.VideoProvider](e.pool, base.ProviderTypeVideo, "video")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := prov.Generate(ctx, base.VideoRequest{Prompt: a.Prompt, AspectRatio: a.AspectRatio})
+	if err != nil {
+		return nil, nil, fmt.Errorf("mediagen: video generation failed: %w", err)
+	}
+
+	parts := mediaParts(resp.Videos, resp.MIMEType, types.MIMETypeVideoMP4, types.NewVideoPartFromData)
+	if len(parts) == 0 {
+		return nil, nil, fmt.Errorf("mediagen: video provider %q returned no videos", prov.Name())
+	}
+
+	summary := summaryJSON(prov.Name(), partsMIME(parts), len(parts))
+	return summary, parts, nil
+}
+
+// resolveProvider returns the default provider of the given type, deterministically
+// chosen as the lexically-first provider by Name(). base.Registry.GetAll returns
+// map order, so it is sorted here. Multi-provider selection (an explicit
+// provider_id argument) is a planned follow-up; until then the first provider wins.
+func resolveProvider[T base.Provider](pool *base.Registry, typ base.ProviderType, kind string) (T, error) {
+	var zero T
+	if pool == nil {
+		return zero, fmt.Errorf("mediagen: no %s provider configured", kind)
+	}
+	provs := pool.GetAll(typ)
+	if len(provs) == 0 {
+		return zero, fmt.Errorf("mediagen: no %s provider configured", kind)
+	}
+	sort.Slice(provs, func(i, j int) bool { return provs[i].Name() < provs[j].Name() })
+	chosen := provs[0]
+	typed, ok := chosen.(T)
+	if !ok {
+		return zero, fmt.Errorf("mediagen: provider %q does not support %s generation", chosen.Name(), kind)
+	}
+	return typed, nil
+}
+
+// mediaParts builds media ContentParts from generated media bytes. Each entry is
+// treated as base64-encoded media data (the convention the imagen provider uses),
+// so it is passed through to the part factory as a base64 string. fallbackMIME is
+// used when the provider did not report a MIME type.
+func mediaParts(
+	media [][]byte, mimeType, fallbackMIME string, newPart func(base64Data, mimeType string) types.ContentPart,
+) []types.ContentPart {
+	if mimeType == "" {
+		mimeType = fallbackMIME
+	}
+	parts := make([]types.ContentPart, 0, len(media))
+	for _, m := range media {
+		if len(m) == 0 {
+			continue
+		}
+		parts = append(parts, newPart(string(m), mimeType))
+	}
+	return parts
+}
+
+// newImagePart adapts types.NewImagePartFromData (which takes a detail arg) to
+// the uniform (base64Data, mimeType) factory signature used by mediaParts.
+func newImagePart(base64Data, mimeType string) types.ContentPart {
+	return types.NewImagePartFromData(base64Data, mimeType, nil)
+}
+
+func partsMIME(parts []types.ContentPart) string {
+	if len(parts) == 0 || parts[0].Media == nil {
+		return ""
+	}
+	return parts[0].Media.MIMEType
+}
+
+func summaryJSON(provider, mimeType string, count int) json.RawMessage {
+	out, _ := json.Marshal(map[string]any{
+		"provider":  provider,
+		"mime_type": mimeType,
+		"count":     count,
+	})
+	return out
+}

--- a/runtime/mediagen/executor_test.go
+++ b/runtime/mediagen/executor_test.go
@@ -1,0 +1,214 @@
+package mediagen
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// fakeProvider is a configurable base.Provider used to back both image and
+// video provider fakes in these tests.
+type fakeProvider struct {
+	name string
+	typ  base.ProviderType
+}
+
+func (f *fakeProvider) Name() string                      { return f.name }
+func (f *fakeProvider) Type() base.ProviderType           { return f.typ }
+func (f *fakeProvider) Pricing() *base.PricingDescriptor  { return nil }
+func (f *fakeProvider) Validate() error                   { return nil }
+func (f *fakeProvider) Init(context.Context) error        { return nil }
+func (f *fakeProvider) HealthCheck(context.Context) error { return nil }
+func (f *fakeProvider) Close() error                      { return nil }
+
+// fakeImageProvider implements base.ImageProvider.
+type fakeImageProvider struct {
+	fakeProvider
+	resp base.ImageResponse
+	err  error
+}
+
+func newFakeImageProvider(name string, images [][]byte, mime string) *fakeImageProvider {
+	return &fakeImageProvider{
+		fakeProvider: fakeProvider{name: name, typ: base.ProviderTypeImage},
+		resp:         base.ImageResponse{Images: images, MIMEType: mime},
+	}
+}
+
+func (f *fakeImageProvider) Generate(context.Context, base.ImageRequest) (base.ImageResponse, error) {
+	if f.err != nil {
+		return base.ImageResponse{}, f.err
+	}
+	return f.resp, nil
+}
+
+// fakeVideoProvider implements base.VideoProvider.
+type fakeVideoProvider struct {
+	fakeProvider
+	resp base.VideoResponse
+}
+
+func newFakeVideoProvider(name string, videos [][]byte, mime string) *fakeVideoProvider {
+	return &fakeVideoProvider{
+		fakeProvider: fakeProvider{name: name, typ: base.ProviderTypeVideo},
+		resp:         base.VideoResponse{Videos: videos, MIMEType: mime},
+	}
+}
+
+func (f *fakeVideoProvider) Generate(context.Context, base.VideoRequest) (base.VideoResponse, error) {
+	return f.resp, nil
+}
+
+func mustRegister(t *testing.T, r *base.Registry, p base.Provider) {
+	t.Helper()
+	if err := r.Register(p); err != nil {
+		t.Fatalf("register %q: %v", p.Name(), err)
+	}
+}
+
+func imageCall(t *testing.T, e *Executor, prompt string) (json.RawMessage, []types.ContentPart, error) {
+	t.Helper()
+	args, _ := json.Marshal(imageArgs{Prompt: prompt})
+	return e.ExecuteMultimodal(context.Background(), ImageGenerateDescriptor(), args)
+}
+
+func TestExecutor_GenerateImage_HappyPath(t *testing.T) {
+	pool := base.NewRegistry()
+	mustRegister(t, pool, newFakeImageProvider("imagen", [][]byte{[]byte("YmFzZTY0aW1n")}, types.MIMETypeImagePNG))
+	e := NewExecutor(pool)
+
+	summary, parts, err := imageCall(t, e, "a fox in snow")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parts))
+	}
+	part := parts[0]
+	if part.Type != types.ContentTypeImage || part.Media == nil {
+		t.Fatalf("expected image media part, got %+v", part)
+	}
+	if part.Media.Data == nil || *part.Media.Data != "YmFzZTY0aW1n" {
+		t.Fatalf("expected base64 data passed through, got %v", part.Media.Data)
+	}
+	if part.Media.MIMEType != types.MIMETypeImagePNG {
+		t.Fatalf("unexpected mime %q", part.Media.MIMEType)
+	}
+
+	var sum map[string]any
+	if err := json.Unmarshal(summary, &sum); err != nil {
+		t.Fatalf("summary not valid json: %v", err)
+	}
+	if sum["provider"] != "imagen" {
+		t.Fatalf("unexpected summary provider: %v", sum["provider"])
+	}
+}
+
+func TestExecutor_GenerateImage_NoProvider(t *testing.T) {
+	e := NewExecutor(base.NewRegistry())
+	_, _, err := imageCall(t, e, "anything")
+	if err == nil || !strings.Contains(err.Error(), "no image provider configured") {
+		t.Fatalf("expected no-image-provider error, got %v", err)
+	}
+}
+
+func TestExecutor_GenerateImage_NilPool(t *testing.T) {
+	e := NewExecutor(nil)
+	_, _, err := imageCall(t, e, "anything")
+	if err == nil || !strings.Contains(err.Error(), "no image provider configured") {
+		t.Fatalf("expected no-image-provider error, got %v", err)
+	}
+}
+
+func TestExecutor_GenerateImage_EmptyPrompt(t *testing.T) {
+	pool := base.NewRegistry()
+	mustRegister(t, pool, newFakeImageProvider("imagen", [][]byte{[]byte("x")}, types.MIMETypeImagePNG))
+	e := NewExecutor(pool)
+	_, _, err := imageCall(t, e, "")
+	if err == nil || !strings.Contains(err.Error(), "non-empty prompt") {
+		t.Fatalf("expected empty-prompt error, got %v", err)
+	}
+}
+
+func TestExecutor_GenerateImage_ProviderReturnsNoImages(t *testing.T) {
+	pool := base.NewRegistry()
+	mustRegister(t, pool, newFakeImageProvider("imagen", nil, types.MIMETypeImagePNG))
+	e := NewExecutor(pool)
+	_, _, err := imageCall(t, e, "prompt")
+	if err == nil || !strings.Contains(err.Error(), "returned no images") {
+		t.Fatalf("expected no-images error, got %v", err)
+	}
+}
+
+// TestExecutor_GenerateImage_DeterministicDefault verifies the lexically-first
+// provider by Name() is chosen regardless of registration/map order.
+func TestExecutor_GenerateImage_DeterministicDefault(t *testing.T) {
+	pool := base.NewRegistry()
+	mustRegister(t, pool, newFakeImageProvider("zeta", [][]byte{[]byte("zzz")}, types.MIMETypeImagePNG))
+	mustRegister(t, pool, newFakeImageProvider("alpha", [][]byte{[]byte("aaa")}, types.MIMETypeImageJPEG))
+	e := NewExecutor(pool)
+
+	summary, _, err := imageCall(t, e, "prompt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var sum map[string]any
+	_ = json.Unmarshal(summary, &sum)
+	if sum["provider"] != "alpha" {
+		t.Fatalf("expected lexically-first provider 'alpha', got %v", sum["provider"])
+	}
+}
+
+func TestExecutor_GenerateVideo_NoProvider(t *testing.T) {
+	e := NewExecutor(base.NewRegistry())
+	args, _ := json.Marshal(videoArgs{Prompt: "a timelapse"})
+	_, _, err := e.ExecuteMultimodal(context.Background(), VideoGenerateDescriptor(), args)
+	if err == nil || !strings.Contains(err.Error(), "no video provider configured") {
+		t.Fatalf("expected no-video-provider error, got %v", err)
+	}
+}
+
+// TestExecutor_GenerateVideo_HappyPath exercises the video path with a fake
+// provider even though no concrete video provider ships yet.
+func TestExecutor_GenerateVideo_HappyPath(t *testing.T) {
+	pool := base.NewRegistry()
+	mustRegister(t, pool, newFakeVideoProvider("veo", [][]byte{[]byte("dmlkZW8=")}, types.MIMETypeVideoMP4))
+	e := NewExecutor(pool)
+
+	args, _ := json.Marshal(videoArgs{Prompt: "a timelapse", AspectRatio: "16:9"})
+	_, parts, err := e.ExecuteMultimodal(context.Background(), VideoGenerateDescriptor(), args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(parts) != 1 || parts[0].Type != types.ContentTypeVideo {
+		t.Fatalf("expected 1 video part, got %+v", parts)
+	}
+}
+
+func TestExecutor_UnsupportedTool(t *testing.T) {
+	e := NewExecutor(base.NewRegistry())
+	desc := ImageGenerateDescriptor()
+	desc.Name = "image__unknown"
+	_, _, err := e.ExecuteMultimodal(context.Background(), desc, json.RawMessage(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "unsupported tool") {
+		t.Fatalf("expected unsupported-tool error, got %v", err)
+	}
+}
+
+func TestExecutor_NameMatchesMode(t *testing.T) {
+	e := NewExecutor(nil)
+	if e.Name() != ExecutorMode {
+		t.Fatalf("Name() %q must equal ExecutorMode %q", e.Name(), ExecutorMode)
+	}
+	if ImageGenerateDescriptor().Mode != ExecutorMode || VideoGenerateDescriptor().Mode != ExecutorMode {
+		t.Fatalf("descriptors must use mode %q", ExecutorMode)
+	}
+}
+
+// compile-time guard: Executor satisfies tools.MultimodalExecutor.
+var _ tools.MultimodalExecutor = (*Executor)(nil)

--- a/runtime/providers/base/types.go
+++ b/runtime/providers/base/types.go
@@ -26,6 +26,7 @@ const (
 	ProviderTypeSTT       ProviderType = "stt"
 	ProviderTypeEmbedding ProviderType = "embedding"
 	ProviderTypeImage     ProviderType = "image"
+	ProviderTypeVideo     ProviderType = "video"
 )
 
 // AllProviderTypes returns every defined ProviderType. Used by the metric
@@ -37,6 +38,7 @@ func AllProviderTypes() []ProviderType {
 		ProviderTypeSTT,
 		ProviderTypeEmbedding,
 		ProviderTypeImage,
+		ProviderTypeVideo,
 	}
 }
 
@@ -124,6 +126,14 @@ type ImageProvider interface {
 	Generate(ctx context.Context, req ImageRequest) (ImageResponse, error)
 }
 
+// VideoProvider generates videos from prompts. No concrete provider implements
+// this interface yet; it defines the shape that the video__generate tool
+// resolves against once a provider (e.g. Veo) lands.
+type VideoProvider interface {
+	Provider
+	Generate(ctx context.Context, req VideoRequest) (VideoResponse, error)
+}
+
 // --- Request / response types for ancillary capabilities ---
 
 // TTSRequest carries parameters for a text-to-speech synthesis call.
@@ -191,6 +201,21 @@ type ImageRequest struct {
 type ImageResponse struct {
 	Images   [][]byte
 	MIMEType string
+	Cost     *types.CostInfo
+	Latency  time.Duration
+}
+
+// VideoRequest carries parameters for a video generation call.
+type VideoRequest struct {
+	Prompt      string
+	AspectRatio string            // e.g. "16:9"
+	Hints       map[string]string // additional dimension hints passed to pricing
+}
+
+// VideoResponse holds generated video bytes and metadata from a provider.
+type VideoResponse struct {
+	Videos   [][]byte
+	MIMEType string // e.g. "video/mp4"
 	Cost     *types.CostInfo
 	Latency  time.Duration
 }

--- a/runtime/tools/types.go
+++ b/runtime/tools/types.go
@@ -28,12 +28,16 @@ import (
 const NamespaceSep = "__"
 
 // knownNamespaces lists the namespaces recognized as system/infrastructure tools.
+// The image/video namespaces back the mediagen image__generate / video__generate
+// tools; their tokens match the corresponding ContentType values.
 var knownNamespaces = map[string]bool{
-	"a2a":      true,
-	"mcp":      true,
-	"workflow": true,
-	"memory":   true,
-	"skill":    true,
+	"a2a":                  true,
+	modeMCP:                true,
+	"workflow":             true,
+	"memory":               true,
+	"skill":                true,
+	types.ContentTypeImage: true,
+	types.ContentTypeVideo: true,
 }
 
 // ParseToolName splits a qualified tool name on the first NamespaceSep.

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2014,6 +2014,7 @@
             "stt",
             "embedding",
             "image",
+            "video",
             "inference"
           ]
         },

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -132,6 +132,7 @@
             "stt",
             "embedding",
             "image",
+            "video",
             "inference"
           ]
         },

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -663,6 +663,7 @@
             "stt",
             "embedding",
             "image",
+            "video",
             "inference"
           ]
         },

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -414,6 +414,7 @@ func (c *Conversation) buildPipelineConfig(
 
 	c.registerMCPExecutors()
 	c.registerExecExecutor()
+	c.registerMediaGenTools()
 	// Register capability tools (includes A2A) — only on first build
 	if !c.capabilitiesRegistered {
 		for _, cap := range c.capabilities {

--- a/sdk/mediagen_tools.go
+++ b/sdk/mediagen_tools.go
@@ -1,0 +1,40 @@
+package sdk
+
+import (
+	"github.com/AltairaLabs/PromptKit/runtime/mediagen"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// registerMediaGenTools wires the built-in image__generate and video__generate
+// tools during pipeline construction.
+//
+// Registration is capability-gated: a tool is registered only when a matching
+// provider is present in the pool (an image provider for image__generate, a
+// video provider for video__generate). Once registered, the tool is exposed to
+// every prompt in the conversation without a tools: entry, because image/video
+// are system namespaces (like workflow__/memory__). With no matching provider
+// the tool is absent entirely.
+//
+// The executor resolves the default provider of the relevant type from the pool
+// at call time. There is no concrete video provider yet, so GetAll(video) is
+// empty and video__generate stays unregistered until one lands.
+func (c *Conversation) registerMediaGenTools() {
+	// Ensure the pool exists so GetAll/Base are safe even before any provider
+	// option ran (the pointer is stable; entries are added during Open).
+	ensureProviderPool(c.config)
+	pool := c.config.providers.Base()
+
+	hasImage := len(pool.GetAll(base.ProviderTypeImage)) > 0
+	hasVideo := len(pool.GetAll(base.ProviderTypeVideo)) > 0
+	if !hasImage && !hasVideo {
+		return
+	}
+
+	c.toolRegistry.RegisterExecutor(mediagen.NewExecutor(pool))
+	if hasImage {
+		_ = c.toolRegistry.Register(mediagen.ImageGenerateDescriptor())
+	}
+	if hasVideo {
+		_ = c.toolRegistry.Register(mediagen.VideoGenerateDescriptor())
+	}
+}

--- a/sdk/mediagen_tools_test.go
+++ b/sdk/mediagen_tools_test.go
@@ -1,0 +1,69 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mediagen"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// mediagenFakeImageProvider is a minimal base.ImageProvider for wiring tests.
+type mediagenFakeImageProvider struct{ name string }
+
+func (f *mediagenFakeImageProvider) Name() string                      { return f.name }
+func (f *mediagenFakeImageProvider) Type() base.ProviderType           { return base.ProviderTypeImage }
+func (f *mediagenFakeImageProvider) Pricing() *base.PricingDescriptor  { return nil }
+func (f *mediagenFakeImageProvider) Validate() error                   { return nil }
+func (f *mediagenFakeImageProvider) Init(context.Context) error        { return nil }
+func (f *mediagenFakeImageProvider) HealthCheck(context.Context) error { return nil }
+func (f *mediagenFakeImageProvider) Close() error                      { return nil }
+func (f *mediagenFakeImageProvider) Generate(
+	context.Context, base.ImageRequest,
+) (base.ImageResponse, error) {
+	return base.ImageResponse{}, nil
+}
+
+func newMediagenTestConv() *Conversation {
+	return &Conversation{config: &config{}, toolRegistry: tools.NewRegistry()}
+}
+
+// TestRegisterMediaGenTools_ImageProviderPresent verifies the image tool is
+// registered (and is a system tool, so exposed without an allowlist entry) when
+// an image provider is in the pool, while video__generate stays absent because
+// no video provider exists.
+func TestRegisterMediaGenTools_ImageProviderPresent(t *testing.T) {
+	conv := newMediagenTestConv()
+	ensureProviderPool(conv.config)
+	if err := conv.config.providers.Base().Register(&mediagenFakeImageProvider{name: "imagen"}); err != nil {
+		t.Fatalf("register fake image provider: %v", err)
+	}
+
+	conv.registerMediaGenTools()
+
+	if conv.toolRegistry.Get(mediagen.ImageGenerateToolName) == nil {
+		t.Fatalf("expected %s to be registered when an image provider is pooled", mediagen.ImageGenerateToolName)
+	}
+	if conv.toolRegistry.Get(mediagen.VideoGenerateToolName) != nil {
+		t.Fatalf("did not expect %s registered (no video provider)", mediagen.VideoGenerateToolName)
+	}
+	if !tools.IsSystemTool(mediagen.ImageGenerateToolName) {
+		t.Fatalf("%s must be a system tool so it is exposed without a prompt tools entry",
+			mediagen.ImageGenerateToolName)
+	}
+}
+
+// TestRegisterMediaGenTools_NoProvider verifies neither tool is registered when
+// no matching provider is in the pool (capability-gated registration).
+func TestRegisterMediaGenTools_NoProvider(t *testing.T) {
+	conv := newMediagenTestConv()
+	conv.registerMediaGenTools()
+
+	if conv.toolRegistry.Get(mediagen.ImageGenerateToolName) != nil {
+		t.Fatalf("%s must be absent without an image provider", mediagen.ImageGenerateToolName)
+	}
+	if conv.toolRegistry.Get(mediagen.VideoGenerateToolName) != nil {
+		t.Fatalf("%s must be absent without a video provider", mediagen.VideoGenerateToolName)
+	}
+}

--- a/sdk/provider_file.go
+++ b/sdk/provider_file.go
@@ -35,7 +35,7 @@ func (c *config) applyProviderConfig(p *pkgconfig.Provider) error {
 		id = p.Type
 	}
 	switch p.GetRole() {
-	case pkgconfig.RoleLLM, pkgconfig.RoleImage:
+	case pkgconfig.RoleLLM, pkgconfig.RoleImage, pkgconfig.RoleVideo:
 		prov, err := createProviderFromConfig(p)
 		if err != nil {
 			return fmt.Errorf("provider %q: %w", id, err)

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -17,9 +17,11 @@ import (
 	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers" // register default eval handlers
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/runtime/mediagen"
 	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/skills"
 
 	// Import provider subpackages to register their factories
@@ -100,6 +102,10 @@ func BuildEngineComponents(cfg *config.Config, providerFilter []string) (
 
 	// Register HTTP executor for live HTTP tool calls (mode: "live")
 	toolRegistry.RegisterExecutor(tools.NewHTTPExecutor())
+
+	// Register mediagen image/video tools when matching providers are pooled.
+	// Arena's analog of the SDK's registerMediaGenTools.
+	registerMediaGenTools(toolRegistry, providerRegistry)
 
 	// Discover and register MCP tools (if any MCP servers configured)
 	if mcpErr := discoverAndRegisterMCPTools(mcpRegistry, toolRegistry); mcpErr != nil {
@@ -187,6 +193,32 @@ func BuildEngineComponents(cfg *config.Config, providerFilter []string) (
 
 	return providerRegistry, promptRegistry, mcpRegistry, conversationExecutor,
 		adapterRegistry, a2aCleanupFn, toolRegistry, skillExec, nil
+}
+
+// registerMediaGenTools wires the built-in image__generate / video__generate
+// tools when a matching provider is pooled, mirroring the SDK's
+// registerMediaGenTools. Registration is capability-gated: a tool is registered
+// only when a provider of its type is in the pool. image/video are system
+// namespaces, so a registered tool is exposed to the agent without a per-prompt
+// tools entry. No matching provider → tool absent.
+func registerMediaGenTools(toolRegistry *tools.Registry, providerRegistry *providers.Registry) {
+	if toolRegistry == nil || providerRegistry == nil {
+		return
+	}
+	pool := providerRegistry.Base()
+	hasImage := len(pool.GetAll(base.ProviderTypeImage)) > 0
+	hasVideo := len(pool.GetAll(base.ProviderTypeVideo)) > 0
+	if !hasImage && !hasVideo {
+		return
+	}
+	toolRegistry.RegisterExecutor(mediagen.NewExecutor(pool))
+	if hasImage {
+		_ = toolRegistry.Register(mediagen.ImageGenerateDescriptor())
+	}
+	if hasVideo {
+		_ = toolRegistry.Register(mediagen.VideoGenerateDescriptor())
+	}
+	logger.Info("registered mediagen tools", "image", hasImage, "video", hasVideo)
 }
 
 // createProviderImpl converts config.Provider to providers.Provider.

--- a/tools/arena/engine/duplex_executor_types.go
+++ b/tools/arena/engine/duplex_executor_types.go
@@ -19,6 +19,7 @@ const (
 
 	// Role constants
 	roleAssistant = "assistant"
+	roleTool      = "tool"
 )
 
 // errPartialSuccess is returned when a duplex conversation ends early but enough

--- a/tools/arena/engine/execution_workflow_integration.go
+++ b/tools/arena/engine/execution_workflow_integration.go
@@ -246,7 +246,7 @@ func (e *Engine) enrichWorkflowMessages(messages []types.Message) bool {
 	enriched := false
 	for i := range messages {
 		msg := &messages[i]
-		if msg.Role == "tool" && msg.ToolResult != nil && msg.ToolResult.Name == workflow.TransitionToolName {
+		if msg.Role == roleTool && msg.ToolResult != nil && msg.ToolResult.Name == workflow.TransitionToolName {
 			if newState, ws := e.buildTransitionMeta(msg, currentState); ws != nil {
 				currentState = newState
 				setMeta(msg, "_workflow_state", ws)

--- a/tools/arena/engine/media_collector.go
+++ b/tools/arena/engine/media_collector.go
@@ -12,23 +12,27 @@ func CollectMediaOutputs(messages []types.Message) []MediaOutput {
 	var outputs []MediaOutput
 
 	for msgIdx, msg := range messages {
-		// Only collect media from assistant messages (LLM-generated content)
-		if msg.Role != "assistant" {
-			continue
+		switch msg.Role {
+		case roleAssistant:
+			// Media the model emitted inline (e.g. Imagen-as-agent).
+			outputs = append(outputs, collectMediaFromParts(msg.Parts, msgIdx)...)
+		case roleTool:
+			// Media a tool produced (e.g. image__generate) lands in the
+			// tool-result parts, not the message's inline parts.
+			if msg.ToolResult != nil {
+				outputs = append(outputs, collectMediaFromParts(msg.ToolResult.Parts, msgIdx)...)
+			}
 		}
-
-		// Collect media from this message's parts
-		outputs = append(outputs, collectMediaFromMessage(msg, msgIdx)...)
 	}
 
 	return outputs
 }
 
-// collectMediaFromMessage extracts media outputs from a single message
-func collectMediaFromMessage(msg types.Message, msgIdx int) []MediaOutput {
+// collectMediaFromParts extracts media outputs from a slice of content parts.
+func collectMediaFromParts(parts []types.ContentPart, msgIdx int) []MediaOutput {
 	var outputs []MediaOutput
 
-	for partIdx, part := range msg.Parts {
+	for partIdx, part := range parts {
 		if part.Media == nil {
 			continue
 		}

--- a/tools/arena/engine/media_collector_test.go
+++ b/tools/arena/engine/media_collector_test.go
@@ -178,7 +178,7 @@ func TestCollectMediaFromMessage_NoMedia(t *testing.T) {
 		Role:    "assistant",
 		Content: "Text only",
 	}
-	outputs := collectMediaFromMessage(msg, 0)
+	outputs := collectMediaFromParts(msg.Parts, 0)
 
 	if len(outputs) != 0 {
 		t.Errorf("Expected 0 outputs for text-only message, got %d", len(outputs))
@@ -195,7 +195,7 @@ func TestCollectMediaFromMessage_NilMediaContent(t *testing.T) {
 			},
 		},
 	}
-	outputs := collectMediaFromMessage(msg, 0)
+	outputs := collectMediaFromParts(msg.Parts, 0)
 
 	// Should skip parts with nil media
 	if len(outputs) != 0 {

--- a/tools/arena/engine/mediagen_tools_test.go
+++ b/tools/arena/engine/mediagen_tools_test.go
@@ -1,0 +1,60 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mediagen"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// mediagenFakeImageProvider is a minimal base.ImageProvider for Arena wiring tests.
+type mediagenFakeImageProvider struct{ name string }
+
+func (f *mediagenFakeImageProvider) Name() string                      { return f.name }
+func (f *mediagenFakeImageProvider) Type() base.ProviderType           { return base.ProviderTypeImage }
+func (f *mediagenFakeImageProvider) Pricing() *base.PricingDescriptor  { return nil }
+func (f *mediagenFakeImageProvider) Validate() error                   { return nil }
+func (f *mediagenFakeImageProvider) Init(context.Context) error        { return nil }
+func (f *mediagenFakeImageProvider) HealthCheck(context.Context) error { return nil }
+func (f *mediagenFakeImageProvider) Close() error                      { return nil }
+func (f *mediagenFakeImageProvider) Generate(
+	context.Context, base.ImageRequest,
+) (base.ImageResponse, error) {
+	return base.ImageResponse{}, nil
+}
+
+// TestRegisterMediaGenTools_Arena_ImagePresent verifies Arena registers the image
+// tool when an image provider is pooled, and leaves video__generate absent.
+func TestRegisterMediaGenTools_Arena_ImagePresent(t *testing.T) {
+	pr := providers.NewRegistry()
+	if err := pr.Base().Register(&mediagenFakeImageProvider{name: "imagen"}); err != nil {
+		t.Fatalf("register fake image provider: %v", err)
+	}
+	reg := tools.NewRegistry()
+
+	registerMediaGenTools(reg, pr)
+
+	if reg.Get(mediagen.ImageGenerateToolName) == nil {
+		t.Fatalf("expected %s registered when an image provider is pooled", mediagen.ImageGenerateToolName)
+	}
+	if reg.Get(mediagen.VideoGenerateToolName) != nil {
+		t.Fatalf("did not expect %s registered (no video provider)", mediagen.VideoGenerateToolName)
+	}
+}
+
+// TestRegisterMediaGenTools_Arena_NoProvider verifies neither tool is registered
+// without a matching provider in the pool.
+func TestRegisterMediaGenTools_Arena_NoProvider(t *testing.T) {
+	reg := tools.NewRegistry()
+	registerMediaGenTools(reg, providers.NewRegistry())
+
+	if reg.Get(mediagen.ImageGenerateToolName) != nil {
+		t.Fatalf("%s must be absent without an image provider", mediagen.ImageGenerateToolName)
+	}
+	if reg.Get(mediagen.VideoGenerateToolName) != nil {
+		t.Fatalf("%s must be absent without a video provider", mediagen.VideoGenerateToolName)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1329. Adds the missing **consumer** for pooled image/video providers: built-in namespaced tools (`image__generate`, `video__generate`) an agent can call to generate media as one step of a text conversation. After #1327/#1328 the provider pool could *hold* multiple image providers; this adds the invocation path that resolves one and calls `Generate()`.

## What's included

- **`runtime/providers/base`** — `VideoProvider` interface + `ProviderTypeVideo` + `VideoRequest`/`VideoResponse`, mirroring the image stack. No concrete video provider ships yet; the abstraction is the stub boundary.
- **`runtime/mediagen`** (new package) — `image__generate` / `video__generate` descriptors + a shared `MultimodalExecutor`. It resolves the default provider of the relevant type from the `base.Registry` (deterministic: lexically-first by `Name()`), calls `Generate`, and returns the media as a `ContentPart` that lands in the message log via the existing `ToolResult.Parts` path (same shape Imagen-as-agent produces).
- **`pkg/config`** — `RoleVideo` ("video") added to the role enum + validation; JSON schemas regenerated.
- **`sdk`** — `registerMediaGenTools` wires the executor during pipeline construction. Registration is **capability-gated**: a tool is registered only when a matching provider is in the pool. `image`/`video` are system namespaces, so a registered tool is exposed to every prompt without a `tools:` allowlist entry. No matching provider → tool absent.

## Design decisions

- **Single default provider** in v1 — no `provider_id` argument yet. Multi-provider selection (a `provider_id` enum) is a clean follow-up.
- **Video stubbed** — full abstraction (interface + `ProviderTypeVideo` + `role: video`) so `video__generate` has a real shape to target, but with no concrete provider it stays unregistered until one (e.g. Veo) lands.

## Testing

- `runtime/mediagen` unit tests: happy path, no-provider error (image + video), deterministic default across multiple pooled providers, video path, bad args, unsupported tool.
- `sdk` wiring tests: gated registration (image present → image tool registered, video absent) and no-provider → both absent; asserts system-namespace exposure.
- Full pre-commit suite green (lint, build, tests, ≥80% coverage on all changed files).

## Known limitations (documented in code)

- Multi-provider `provider_id` selection deferred.
- Imagen-as-agent with no text LLM: `image__generate` would resolve the agent provider itself — harmless, documented.
- Large-media `ToolResult.Parts` aren't size-capped the way `Content` is — possible follow-up.
