### PR TITLE
feat(sdk): WithJSONInput — function-style structured input binding

### DIFF
--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -68,6 +68,38 @@ conv.SetVar("user_name", "Alice")
 name, ok := conv.GetVar("user_name")
 ```
 
+### WithJSONInput
+
+Bind a structured value to the prompt's template variables for a single `Send`
+or `Stream` — the input half of the "function-style" pattern (JSON in, one-shot,
+JSON out). Use it with `WithResponseFormat` for schema-enforced JSON output.
+
+```go
+func WithJSONInput(v any) SendOption
+```
+
+For a JSON **object** input, each top-level field is bound to `{{field}}`
+(strings verbatim; other types as compact JSON), and the whole object is bound
+to `{{input}}`. Bound values override open-time `WithVariables`. If you pass an
+empty message, the input JSON also becomes the user turn.
+
+**Example:**
+```go
+conv, _ := sdk.Open("./fn.pack.json", "plan",
+    sdk.WithResponseFormat(&providers.ResponseFormat{
+        Type: providers.ResponseFormatJSONSchema, JSONSchema: outSchema, Strict: true,
+    }),
+)
+resp, _ := conv.Send(ctx, "", sdk.WithJSONInput(map[string]any{
+    "topic": "battery storage", "audience": "executive",
+}))
+// {{topic}} and {{audience}} are now filled in the system prompt.
+```
+
+If a bound variable is declared `required` in the pack, `WithJSONInput`
+satisfies that requirement — the value is resolved before required-variable
+validation. See the [`json-function`](https://github.com/AltairaLabs/PromptKit/tree/main/sdk/examples/json-function) example.
+
 ### OnTool / OnToolCtx
 
 Register tool handlers.

--- a/runtime/pipeline/stage/stages_core.go
+++ b/runtime/pipeline/stage/stages_core.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/runtime/variables"
 )
 
 // PromptAssemblyStage loads and assembles prompts from the prompt registry.
@@ -64,7 +65,7 @@ func (s *PromptAssemblyStage) Process(ctx context.Context, input <-chan StreamEl
 	defer close(output)
 
 	// Load raw template (no rendering)
-	tmpl := s.loadTemplate()
+	tmpl := s.loadTemplate(ctx)
 
 	// Populate TurnState once, before forwarding the first element. Channel
 	// hand-off to downstream stages establishes happens-before so readers
@@ -89,7 +90,7 @@ func (s *PromptAssemblyStage) Process(ctx context.Context, input <-chan StreamEl
 	return nil
 }
 
-func (s *PromptAssemblyStage) loadTemplate() *prompt.Template {
+func (s *PromptAssemblyStage) loadTemplate(ctx context.Context) *prompt.Template {
 	defaultTemplate := &prompt.Template{
 		RawTemplate:  "You are a helpful AI assistant.",
 		AllowedTools: nil,
@@ -101,7 +102,22 @@ func (s *PromptAssemblyStage) loadTemplate() *prompt.Template {
 		return defaultTemplate
 	}
 
-	tmpl, err := s.promptRegistry.LoadTemplate(s.taskType, s.baseVariables, "")
+	// Merge per-request variables (carried on the context, e.g. from an SDK
+	// structured input) over the static base variables. Without this, a required
+	// variable supplied only per-request would fail LoadTemplate's required-var
+	// check and the pack prompt would be discarded for the default.
+	loadVars := s.baseVariables
+	if reqVars := variables.RequestVars(ctx); len(reqVars) > 0 {
+		loadVars = make(map[string]string, len(s.baseVariables)+len(reqVars))
+		for k, v := range s.baseVariables {
+			loadVars[k] = v
+		}
+		for k, v := range reqVars {
+			loadVars[k] = v
+		}
+	}
+
+	tmpl, err := s.promptRegistry.LoadTemplate(s.taskType, loadVars, "")
 	if err != nil {
 		logger.Warn("Using default system prompt, no prompt found for task type", "task_type", s.taskType)
 		return defaultTemplate

--- a/runtime/variables/request.go
+++ b/runtime/variables/request.go
@@ -1,0 +1,31 @@
+package variables
+
+import "context"
+
+// requestVarsKey is the context key under which per-request template variables
+// are carried. Using an unexported type avoids collisions with other packages.
+type requestVarsKey struct{}
+
+// WithRequestVars returns a context carrying per-request template variables.
+// These are resolved into the variable set for a single request — both when
+// validating required variables and when rendering — and take precedence over
+// static and provider-supplied variables. Returns ctx unchanged when vars is
+// empty.
+//
+// This is the vehicle for per-send variables (e.g. an SDK structured input):
+// because the values ride on the context, they are available at the very start
+// of request processing, before any pipeline stage runs.
+func WithRequestVars(ctx context.Context, vars map[string]string) context.Context {
+	if len(vars) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, requestVarsKey{}, vars)
+}
+
+// RequestVars returns the per-request variables carried on ctx, or nil if none.
+func RequestVars(ctx context.Context) map[string]string {
+	if vars, ok := ctx.Value(requestVarsKey{}).(map[string]string); ok {
+		return vars
+	}
+	return nil
+}

--- a/runtime/variables/request_test.go
+++ b/runtime/variables/request_test.go
@@ -1,0 +1,24 @@
+package variables
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestVars_RoundTrip(t *testing.T) {
+	ctx := WithRequestVars(context.Background(), map[string]string{"topic": "x"})
+	assert.Equal(t, map[string]string{"topic": "x"}, RequestVars(ctx))
+}
+
+func TestRequestVars_EmptyLeavesContextUnchanged(t *testing.T) {
+	base := context.Background()
+	ctx := WithRequestVars(base, nil)
+	assert.Equal(t, base, ctx)
+	assert.Nil(t, RequestVars(ctx))
+}
+
+func TestRequestVars_AbsentReturnsNil(t *testing.T) {
+	assert.Nil(t, RequestVars(context.Background()))
+}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -220,16 +220,26 @@ func (c *Conversation) Send(ctx context.Context, message any, opts ...SendOption
 
 	c.startOTelSession(ctx)
 
-	// Build user message from input
-	userMsg, err := c.buildUserMessage(message)
+	// Parse send options once: they carry content parts and any WithJSONInput
+	// binding (per-send variables + a fallback user turn).
+	sendCfg, err := parseSendOptions(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	// Apply send options and add content parts
-	if optErr := c.applyOptionsToMessage(userMsg, opts); optErr != nil {
+	// Build user message from input, falling back to the JSON input when the
+	// caller passes an empty message.
+	userMsg, err := c.buildUserMessageWithInput(message, sendCfg)
+	if err != nil {
+		return nil, err
+	}
+	if optErr := c.addContentParts(userMsg, sendCfg.parts); optErr != nil {
 		return nil, optErr
 	}
+
+	// Carry WithJSONInput-bound variables on the context so the send-scoped
+	// variable provider resolves them for this turn.
+	ctx = withSendVars(ctx, sendCfg.jsonInputVars)
 
 	// Refresh per-send skill index in case an external selector is
 	// configured. Runs after capability registration (which happens
@@ -355,16 +365,37 @@ func messageContentSize(msg *types.Message) int {
 	return total
 }
 
-// applyOptionsToMessage applies send options and adds content parts to the message.
-func (c *Conversation) applyOptionsToMessage(userMsg *types.Message, opts []SendOption) error {
+// parseSendOptions applies all send options to a fresh sendConfig.
+func parseSendOptions(opts []SendOption) (*sendConfig, error) {
 	sendCfg := &sendConfig{}
 	for _, opt := range opts {
 		if err := opt(sendCfg); err != nil {
-			return fmt.Errorf("failed to apply send option: %w", err)
+			return nil, fmt.Errorf("failed to apply send option: %w", err)
 		}
 	}
+	return sendCfg, nil
+}
 
-	return c.addContentParts(userMsg, sendCfg.parts)
+// buildUserMessageWithInput builds the user message, substituting the WithJSONInput
+// payload as the user turn when the caller passes an empty message.
+func (c *Conversation) buildUserMessageWithInput(message any, sendCfg *sendConfig) (*types.Message, error) {
+	if isEmptyMessage(message) && len(sendCfg.jsonInputRaw) > 0 {
+		return c.buildUserMessage(string(sendCfg.jsonInputRaw))
+	}
+	return c.buildUserMessage(message)
+}
+
+// isEmptyMessage reports whether the caller supplied no usable message text,
+// which triggers the WithJSONInput fallback turn.
+func isEmptyMessage(message any) bool {
+	switch m := message.(type) {
+	case nil:
+		return true
+	case string:
+		return m == ""
+	default:
+		return false
+	}
 }
 
 // buildPipelineConfig assembles the shared intpipeline.Config used by both unary
@@ -460,7 +491,7 @@ func (c *Conversation) buildPipelineConfig(
 		PromptRegistry:        c.promptRegistry,
 		TaskType:              c.promptName,
 		Variables:             vars,
-		VariableProviders:     c.config.variableProviders, // Pass to pipeline for dynamic resolution
+		VariableProviders:     appendSendScopedProvider(c.config.variableProviders), // dynamic + per-send resolution
 		MaxTokens:             defaultMaxTokens,
 		Temperature:           defaultTemperature,
 		StateStore:            store,

--- a/sdk/e2e_config_test.go
+++ b/sdk/e2e_config_test.go
@@ -28,17 +28,17 @@ import (
 // =============================================================================
 
 // Capability represents a provider capability for matrix testing.
-type Capability string
+type ProviderCapability string
 
 const (
-	CapText      Capability = "text"      // Basic text conversation
-	CapStreaming Capability = "streaming" // Streaming responses
-	CapVision    Capability = "vision"    // Image understanding
-	CapAudio     Capability = "audio"     // Audio input/output
-	CapVideo     Capability = "video"     // Video understanding
-	CapTools     Capability = "tools"     // Tool/function calling
-	CapJSON      Capability = "json"      // JSON mode output
-	CapRealtime  Capability = "realtime"  // Real-time streaming (WebSocket)
+	CapText      ProviderCapability = "text"      // Basic text conversation
+	CapStreaming ProviderCapability = "streaming" // Streaming responses
+	CapVision    ProviderCapability = "vision"    // Image understanding
+	CapAudio     ProviderCapability = "audio"     // Audio input/output
+	CapVideo     ProviderCapability = "video"     // Video understanding
+	CapTools     ProviderCapability = "tools"     // Tool/function calling
+	CapJSON      ProviderCapability = "json"      // JSON mode output
+	CapRealtime  ProviderCapability = "realtime"  // Real-time streaming (WebSocket)
 )
 
 // ProviderConfig defines a provider's capabilities and configuration.
@@ -56,7 +56,7 @@ type ProviderConfig struct {
 	DefaultModel string
 
 	// Capabilities lists what this provider supports
-	Capabilities []Capability
+	Capabilities []ProviderCapability
 
 	// VisionModel is the model to use for vision tests (if different)
 	VisionModel string
@@ -66,7 +66,7 @@ type ProviderConfig struct {
 }
 
 // HasCapability checks if the provider supports a capability.
-func (p *ProviderConfig) HasCapability(cap Capability) bool {
+func (p *ProviderConfig) HasCapability(cap ProviderCapability) bool {
 	for _, c := range p.Capabilities {
 		if c == cap {
 			return true
@@ -96,7 +96,7 @@ func DefaultProviders() []ProviderConfig {
 			EnvKey:       "OPENAI_API_KEY",
 			DefaultModel: "gpt-4o-mini",
 			VisionModel:  "gpt-4o",
-			Capabilities: []Capability{
+			Capabilities: []ProviderCapability{
 				CapText, CapStreaming, CapVision, CapTools, CapJSON,
 			},
 		},
@@ -105,7 +105,7 @@ func DefaultProviders() []ProviderConfig {
 			EnvKey:        "OPENAI_API_KEY",
 			DefaultModel:  "gpt-4o-mini",
 			RealtimeModel: "gpt-4o-realtime-preview",
-			Capabilities: []Capability{
+			Capabilities: []ProviderCapability{
 				CapRealtime, // Audio is only via realtime API, not predict
 			},
 		},
@@ -114,7 +114,7 @@ func DefaultProviders() []ProviderConfig {
 			EnvKey:       "ANTHROPIC_API_KEY",
 			DefaultModel: "claude-sonnet-4-20250514",
 			VisionModel:  "claude-sonnet-4-20250514",
-			Capabilities: []Capability{
+			Capabilities: []ProviderCapability{
 				CapText, CapStreaming, CapVision, CapTools, CapJSON,
 			},
 		},
@@ -124,7 +124,7 @@ func DefaultProviders() []ProviderConfig {
 			AltEnvKeys:   []string{"GOOGLE_API_KEY"},
 			DefaultModel: "gemini-2.0-flash",
 			VisionModel:  "gemini-2.0-flash",
-			Capabilities: []Capability{
+			Capabilities: []ProviderCapability{
 				CapText, CapStreaming, CapVision, CapAudio, CapVideo, CapTools, CapJSON,
 			},
 		},
@@ -134,7 +134,7 @@ func DefaultProviders() []ProviderConfig {
 			AltEnvKeys:    []string{"GOOGLE_API_KEY"},
 			DefaultModel:  "gemini-2.0-flash",
 			RealtimeModel: "gemini-2.0-flash-live-001",
-			Capabilities: []Capability{
+			Capabilities: []ProviderCapability{
 				CapRealtime, CapAudio, CapVideo,
 			},
 		},
@@ -143,7 +143,7 @@ func DefaultProviders() []ProviderConfig {
 			EnvKey:       "OLLAMA_HOST_URL", // Set to Ollama base URL (e.g., "http://localhost:11434")
 			DefaultModel: "llava:7b",        // Default to llava for vision tests
 			VisionModel:  "llava:7b",
-			Capabilities: []Capability{
+			Capabilities: []ProviderCapability{
 				CapText, CapStreaming, CapVision,
 				// Note: llava:7b does not support tools
 			},
@@ -152,7 +152,7 @@ func DefaultProviders() []ProviderConfig {
 			ID:           "ollama-tools",
 			EnvKey:       "OLLAMA_HOST_URL", // Set to Ollama base URL (e.g., "http://localhost:11434")
 			DefaultModel: "llama3.2:3b",     // llama3.2 supports function calling
-			Capabilities: []Capability{
+			Capabilities: []ProviderCapability{
 				CapText, CapStreaming, CapTools,
 			},
 		},
@@ -160,7 +160,7 @@ func DefaultProviders() []ProviderConfig {
 			ID:           "mock",
 			EnvKey:       "", // Always available
 			DefaultModel: "mock-model",
-			Capabilities: []Capability{
+			Capabilities: []ProviderCapability{
 				CapText, CapStreaming, CapTools,
 			},
 		},
@@ -222,7 +222,7 @@ func LoadE2EConfig() *E2EConfig {
 }
 
 // ProvidersWithCapability returns providers that support the given capability.
-func (c *E2EConfig) ProvidersWithCapability(cap Capability) []ProviderConfig {
+func (c *E2EConfig) ProvidersWithCapability(cap ProviderCapability) []ProviderConfig {
 	var result []ProviderConfig
 	for _, p := range c.Providers {
 		if p.HasCapability(cap) {
@@ -263,7 +263,7 @@ func contains(slice []string, item string) bool {
 
 // RunForProviders runs a test function for each provider with the required capability.
 // Skips providers that don't have the capability or aren't available.
-func RunForProviders(t *testing.T, cap Capability, testFn func(t *testing.T, provider ProviderConfig)) {
+func RunForProviders(t *testing.T, cap ProviderCapability, testFn func(t *testing.T, provider ProviderConfig)) {
 	t.Helper()
 
 	cfg := LoadE2EConfig()
@@ -283,7 +283,7 @@ func RunForProviders(t *testing.T, cap Capability, testFn func(t *testing.T, pro
 }
 
 // RunForProvidersSerial runs tests serially (for tests that can't be parallelized).
-func RunForProvidersSerial(t *testing.T, cap Capability, testFn func(t *testing.T, provider ProviderConfig)) {
+func RunForProvidersSerial(t *testing.T, cap ProviderCapability, testFn func(t *testing.T, provider ProviderConfig)) {
 	t.Helper()
 
 	cfg := LoadE2EConfig()
@@ -314,7 +314,7 @@ func SkipIfNoProvider(t *testing.T, providerID string) {
 }
 
 // RequireCapability skips if no providers have the capability.
-func RequireCapability(t *testing.T, cap Capability) []ProviderConfig {
+func RequireCapability(t *testing.T, cap ProviderCapability) []ProviderConfig {
 	t.Helper()
 
 	cfg := LoadE2EConfig()

--- a/sdk/e2e_config_test.go
+++ b/sdk/e2e_config_test.go
@@ -112,8 +112,8 @@ func DefaultProviders() []ProviderConfig {
 		{
 			ID:           "anthropic",
 			EnvKey:       "ANTHROPIC_API_KEY",
-			DefaultModel: "claude-sonnet-4-20250514",
-			VisionModel:  "claude-sonnet-4-20250514",
+			DefaultModel: "claude-haiku-4-5",
+			VisionModel:  "claude-haiku-4-5",
 			Capabilities: []ProviderCapability{
 				CapText, CapStreaming, CapVision, CapTools, CapJSON,
 			},
@@ -122,8 +122,8 @@ func DefaultProviders() []ProviderConfig {
 			ID:           "gemini",
 			EnvKey:       "GEMINI_API_KEY",
 			AltEnvKeys:   []string{"GOOGLE_API_KEY"},
-			DefaultModel: "gemini-2.0-flash",
-			VisionModel:  "gemini-2.0-flash",
+			DefaultModel: "gemini-2.5-flash",
+			VisionModel:  "gemini-2.5-flash",
 			Capabilities: []ProviderCapability{
 				CapText, CapStreaming, CapVision, CapAudio, CapVideo, CapTools, CapJSON,
 			},

--- a/sdk/e2e_json_input_test.go
+++ b/sdk/e2e_json_input_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+package sdk
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// WithJSONInput E2E Tests
+//
+// These verify that a structured JSON input bound via WithJSONInput reaches the
+// model's rendered prompt across all real providers — the input half of the
+// function-style pattern. Output-side structured JSON is covered by
+// e2e_json_mode_test.go.
+//
+// Run with: go test -tags=e2e ./sdk/... -run TestE2E_JSONInput
+// =============================================================================
+
+// echoPackJSON returns a pack whose system prompt is driven entirely by a bound
+// template variable, so the model's reply proves the binding took effect.
+const echoPackJSON = `{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "e2e-json-input",
+  "name": "E2E JSON Input Pack",
+  "version": "1.0.0",
+  "description": "Pack for WithJSONInput e2e tests",
+  "template_engine": {"version": "v1", "syntax": "{{variable}}"},
+  "prompts": {
+    "echo": {
+      "id": "echo",
+      "name": "Echo",
+      "version": "1.0.0",
+      "system_template": "You are an echo service. The secret code is {{secret_code}}. When the user asks for the code, reply with ONLY the secret code and nothing else.",
+      "variables": [
+        {"name": "secret_code", "type": "string", "required": true, "description": "The code to echo"}
+      ]
+    }
+  }
+}`
+
+// newEchoConversation opens the echo pack against a real provider.
+func newEchoConversation(t *testing.T, provider ProviderConfig) *Conversation {
+	t.Helper()
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "echo.pack.json")
+	require.NoError(t, os.WriteFile(packPath, []byte(echoPackJSON), 0o644))
+
+	conv, err := Open(packPath, "echo",
+		WithModel(provider.DefaultModel),
+		WithEventBus(CreateCostTrackingEventBus()),
+	)
+	require.NoError(t, err, "Failed to open echo conversation with provider %s", provider.ID)
+	return conv
+}
+
+// TestE2E_JSONInput_BoundVariableReachesModel verifies that a top-level field of
+// the JSON input is bound to the prompt's {{secret_code}} variable and reaches
+// the model, across every JSON-capable provider.
+func TestE2E_JSONInput_BoundVariableReachesModel(t *testing.T) {
+	const secret = "ZEBRA-4271"
+
+	RunForProviders(t, CapJSON, func(t *testing.T, provider ProviderConfig) {
+		if provider.ID == "mock" {
+			t.Skip("Skipping mock for JSON input binding test")
+		}
+
+		conv := newEchoConversation(t, provider)
+		defer conv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Non-empty message asks for the code; WithJSONInput binds it to {{secret_code}}.
+		resp, err := conv.Send(ctx, "What is the code?",
+			WithJSONInput(map[string]any{"secret_code": secret}))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Contains(t, resp.Text(), secret,
+			"provider %s should echo the bound secret_code", provider.ID)
+		t.Logf("Provider %s echoed: %s", provider.ID, strings.TrimSpace(resp.Text()))
+	})
+}
+
+// TestE2E_JSONInput_EmptyMessageFallbackReachesModel verifies the one-shot
+// function form: an empty message with WithJSONInput sends the JSON as the user
+// turn and binds {{secret_code}}, and the model still produces the value.
+func TestE2E_JSONInput_EmptyMessageFallbackReachesModel(t *testing.T) {
+	const secret = "MAGENTA-9930"
+
+	RunForProviders(t, CapJSON, func(t *testing.T, provider ProviderConfig) {
+		if provider.ID == "mock" {
+			t.Skip("Skipping mock for JSON input fallback test")
+		}
+
+		conv := newEchoConversation(t, provider)
+		defer conv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := conv.Send(ctx, "", WithJSONInput(map[string]any{"secret_code": secret}))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Contains(t, resp.Text(), secret,
+			"provider %s should echo the bound secret_code from the fallback turn", provider.ID)
+		t.Logf("Provider %s echoed: %s", provider.ID, strings.TrimSpace(resp.Text()))
+	})
+}

--- a/sdk/e2e_streaming_test.go
+++ b/sdk/e2e_streaming_test.go
@@ -198,6 +198,7 @@ func TestE2E_Streaming_Cancellation(t *testing.T) {
 		defer conv.Close()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
 		var chunksReceived int
 

--- a/sdk/e2e_transcription_pipeline_test.go
+++ b/sdk/e2e_transcription_pipeline_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/claude"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/openai"
@@ -250,10 +251,10 @@ func TestE2E_TranscriptionPipeline_WithStageEvents(t *testing.T) {
 	collectedEvents := collector.getEvents()
 	for _, e := range collectedEvents {
 		switch data := e.Data.(type) {
-		case events.StageStartedData:
-			t.Logf("Stage started: %s (type: %s)", data.Name, data.StageType)
-		case events.StageCompletedData:
-			t.Logf("Stage completed: %s (duration: %v)", data.Name, data.Duration)
+		case events.StageEventData:
+			// StageStartedData and StageCompletedData are both aliases of
+			// StageEventData; a single case covers stage start and completion.
+			t.Logf("Stage event: %s (type: %s, duration: %v)", data.Name, data.StageType, data.Duration)
 		case events.ProviderCallCompletedData:
 			t.Logf("Provider call completed: %s/%s (tokens: %d in, %d out, cost: $%.6f)",
 				data.Provider, data.Model, data.InputTokens, data.OutputTokens, data.Cost)
@@ -379,13 +380,13 @@ func TestE2E_TranscriptionPipeline_LongAudio(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	transcription, err := sttService.Transcribe(ctx, audioData, stt.TranscriptionConfig{
-		Format:     stt.FormatWAV,
-		SampleRate: 16000,
-		Channels:   1,
-		Language:   "en",
+	result, err := sttService.Transcribe(ctx, base.STTRequest{
+		Audio:    audioData,
+		MIMEType: "audio/wav",
+		Hints:    map[string]string{"sample_rate": "16000", "channels": "1", "language": "en"},
 	})
 	require.NoError(t, err)
+	transcription := result.Text
 
 	// Verify transcription
 	assert.NotEmpty(t, transcription)

--- a/sdk/examples/json-function/README.md
+++ b/sdk/examples/json-function/README.md
@@ -1,0 +1,61 @@
+# JSON Function Example
+
+Demonstrates the **function-style** PromptKit pattern: invoke a prompt like a
+serverless function — structured JSON in, one-shot, JSON out.
+
+## What it shows
+
+- **`WithJSONInput`** — bind a structured input to the prompt's template
+  variables for a single `Send`. Top-level fields become `{{topic}}` /
+  `{{audience}}`; the whole payload is available as `{{input}}`.
+- **`WithResponseFormat`** — request schema-enforced JSON output (works across
+  Claude, OpenAI, and Gemini).
+- **Empty-message one-shot** — passing `""` as the message makes the input JSON
+  also fill the user turn, so a single `Send` is a complete invocation.
+- **Typed round-trip** — unmarshal the JSON response into a Go struct.
+
+## The recipe
+
+```go
+conv, _ := sdk.Open("./research.pack.json", "plan",
+    sdk.WithResponseFormat(&providers.ResponseFormat{
+        Type:       providers.ResponseFormatJSONSchema,
+        JSONSchema: outputSchema,
+        SchemaName: "research_plan",
+        Strict:     true,
+    }),
+)
+defer conv.Close()
+
+resp, _ := conv.Send(ctx, "", sdk.WithJSONInput(PlanRequest{
+    Topic:    "utility-scale battery storage growth in 2023",
+    Audience: "executive",
+}))
+
+var plan PlanResponse
+json.Unmarshal([]byte(resp.Text()), &plan)
+```
+
+## Binding rules
+
+For a JSON object input:
+
+- `{{input}}` is bound to the whole object (compact JSON).
+- Each top-level field is bound to `{{field}}` — strings pass through verbatim;
+  numbers, booleans, objects, and arrays are bound as their compact JSON.
+- Bound variables override open-time `WithVariables` defaults.
+- A real top-level field named `input` shadows the synthetic whole-object var.
+
+## Run it
+
+```bash
+export OPENAI_API_KEY=your-key   # or ANTHROPIC_API_KEY / GEMINI_API_KEY
+go run .
+```
+
+The smoke test (`go test ./...`) exercises the same path with a mock provider —
+no API keys required.
+
+> Note: prefer `WithResponseFormat` with a schema over the schemaless
+> `WithJSONMode` for cross-provider output — `WithJSONMode` has no effect on
+> Anthropic, which only supports schema-backed structured output.

--- a/sdk/examples/json-function/main.go
+++ b/sdk/examples/json-function/main.go
@@ -1,0 +1,91 @@
+// Package main demonstrates the "function-style" PromptKit pattern: a prompt
+// invoked like a serverless function — structured JSON in, one-shot, JSON out.
+//
+// It shows:
+//   - WithJSONInput: binding a structured input to the prompt's {{variables}}
+//     (top-level fields become {{topic}}/{{audience}}; the whole payload is {{input}})
+//   - WithResponseFormat: requesting schema-enforced JSON output
+//   - A single Send with an empty message, so the input JSON also fills the user turn
+//   - Unmarshaling the JSON response into a Go struct
+//
+// Run with:
+//
+//	export OPENAI_API_KEY=your-key
+//	go run .
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// PlanRequest is the function input. Its top-level fields bind to the pack's
+// {{topic}} and {{audience}} template variables.
+type PlanRequest struct {
+	Topic    string `json:"topic"`
+	Audience string `json:"audience"`
+}
+
+// PlanResponse is the function output, matching outputSchema below.
+type PlanResponse struct {
+	Summary   string   `json:"summary"`
+	Questions []string `json:"questions"`
+}
+
+// outputSchema constrains the model to return a JSON object with exactly these
+// fields. additionalProperties:false + required are needed for strict
+// structured output (e.g. Anthropic / OpenAI strict mode).
+var outputSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"summary": {"type": "string"},
+		"questions": {"type": "array", "items": {"type": "string"}}
+	},
+	"required": ["summary", "questions"],
+	"additionalProperties": false
+}`)
+
+func main() {
+	// Open the prompt and request schema-enforced JSON output. WithResponseFormat
+	// is the proven cross-provider output mechanism (Claude output_config,
+	// OpenAI response_format, Gemini responseSchema).
+	conv, err := sdk.Open("./research.pack.json", "plan",
+		sdk.WithResponseFormat(&providers.ResponseFormat{
+			Type:       providers.ResponseFormatJSONSchema,
+			JSONSchema: outputSchema,
+			SchemaName: "research_plan",
+			Strict:     true,
+		}),
+	)
+	if err != nil {
+		log.Fatalf("Failed to open pack: %v", err)
+	}
+	defer conv.Close()
+
+	input := PlanRequest{
+		Topic:    "utility-scale battery storage growth in 2023",
+		Audience: "executive",
+	}
+
+	// One-shot invocation. The empty message means the input JSON also becomes
+	// the user turn; WithJSONInput binds its fields to {{topic}}/{{audience}}.
+	resp, err := conv.Send(context.Background(), "", sdk.WithJSONInput(input))
+	if err != nil {
+		log.Fatalf("Failed to invoke function: %v", err)
+	}
+
+	var plan PlanResponse
+	if err := json.Unmarshal([]byte(resp.Text()), &plan); err != nil {
+		log.Fatalf("Response was not valid JSON: %v\nraw: %s", err, resp.Text())
+	}
+
+	fmt.Printf("Summary: %s\n", plan.Summary)
+	for i, q := range plan.Questions {
+		fmt.Printf("  %d. %s\n", i+1, q)
+	}
+}

--- a/sdk/examples/json-function/research.pack.json
+++ b/sdk/examples/json-function/research.pack.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "json-function-example",
+  "name": "JSON Function Example",
+  "version": "1.0.0",
+  "description": "Function-style prompt: JSON input bound to template variables, JSON output",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "plan": {
+      "id": "plan",
+      "name": "Research Planner",
+      "version": "1.0.0",
+      "system_template": "You are a research planner. Produce a short research plan for the topic \"{{topic}}\" aimed at a {{audience}} audience. Respond ONLY with a JSON object matching the requested schema. The full request payload was: {{input}}.",
+      "variables": [
+        {
+          "name": "topic",
+          "type": "string",
+          "required": true,
+          "description": "The subject to research"
+        },
+        {
+          "name": "audience",
+          "type": "string",
+          "required": true,
+          "description": "The intended audience"
+        }
+      ]
+    }
+  }
+}

--- a/sdk/examples/json-function/smoke_test.go
+++ b/sdk/examples/json-function/smoke_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func TestSmoke(t *testing.T) {
+	// Mock provider returns a schema-shaped JSON payload so the example's
+	// unmarshal path is exercised without a live model.
+	repo := mock.NewInMemoryMockRepository(`{"summary":"ok","questions":["q1","q2"]}`)
+	provider := mock.NewProviderWithRepository("mock", "mock-model", false, repo)
+
+	conv, err := sdk.Open("research.pack.json", "plan",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+		sdk.WithResponseFormat(&providers.ResponseFormat{
+			Type:       providers.ResponseFormatJSONSchema,
+			JSONSchema: outputSchema,
+			SchemaName: "research_plan",
+			Strict:     true,
+		}),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	input := PlanRequest{Topic: "battery storage", Audience: "executive"}
+	resp, err := conv.Send(context.Background(), "", sdk.WithJSONInput(input))
+	require.NoError(t, err)
+
+	var plan PlanResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Text()), &plan))
+	assert.Equal(t, "ok", plan.Summary)
+	assert.Len(t, plan.Questions, 2)
+}

--- a/sdk/integration/json_input_test.go
+++ b/sdk/integration/json_input_test.go
@@ -1,0 +1,160 @@
+package integration
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// recordingProvider wraps a mock provider and records the last prediction
+// request so tests can assert on the rendered system prompt and user turn.
+type recordingProvider struct {
+	*mock.Provider
+	mu      sync.Mutex
+	lastReq providers.PredictionRequest
+}
+
+func newRecordingProvider() *recordingProvider {
+	return &recordingProvider{Provider: mock.NewProvider("rec", "rec-model", false)}
+}
+
+func (r *recordingProvider) Predict(
+	ctx context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	r.mu.Lock()
+	r.lastReq = req
+	r.mu.Unlock()
+	return r.Provider.Predict(ctx, req)
+}
+
+func (r *recordingProvider) PredictStream(
+	ctx context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	r.mu.Lock()
+	r.lastReq = req
+	r.mu.Unlock()
+	return r.Provider.PredictStream(ctx, req)
+}
+
+func (r *recordingProvider) system() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastReq.System
+}
+
+// userText returns the concatenated text of the last user-role message.
+func (r *recordingProvider) userText() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var sb strings.Builder
+	for i := range r.lastReq.Messages {
+		m := r.lastReq.Messages[i]
+		if m.Role != "user" {
+			continue
+		}
+		if m.Content != "" {
+			sb.WriteString(m.Content)
+		}
+		for _, p := range m.Parts {
+			if p.Type == "text" && p.Text != nil {
+				sb.WriteString(*p.Text)
+			}
+		}
+	}
+	return sb.String()
+}
+
+func jsonInputPack(systemTemplate string) string {
+	return `{
+		"id": "json-input-test",
+		"version": "1.0.0",
+		"description": "Pack for WithJSONInput integration tests",
+		"prompts": {
+			"fn": {
+				"id": "fn",
+				"name": "Function",
+				"system_template": ` + quote(systemTemplate) + `
+			}
+		}
+	}`
+}
+
+// quote returns a JSON-safe quoted string.
+func quote(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func openRecordingConv(t *testing.T, systemTemplate string, opts ...sdk.Option) (*sdk.Conversation, *recordingProvider) {
+	t.Helper()
+	rec := newRecordingProvider()
+	allOpts := append([]sdk.Option{sdk.WithProvider(rec), sdk.WithSkipSchemaValidation()}, opts...)
+	conv := openTestConvWithPack(t, jsonInputPack(systemTemplate), "fn", allOpts...)
+	return conv, rec
+}
+
+func TestJSONInput_BindsFieldToSystemPrompt(t *testing.T) {
+	conv, rec := openRecordingConv(t, "topic={{topic}}")
+	_, err := conv.Send(context.Background(), "", sdk.WithJSONInput(map[string]any{"topic": "batteries"}))
+	require.NoError(t, err)
+	assert.Contains(t, rec.system(), "topic=batteries")
+}
+
+func TestJSONInput_WholeObjectBoundToInputVar(t *testing.T) {
+	conv, rec := openRecordingConv(t, "payload={{input}}")
+	_, err := conv.Send(context.Background(), "", sdk.WithJSONInput(map[string]any{"a": 1}))
+	require.NoError(t, err)
+	assert.Contains(t, rec.system(), `payload={"a":1}`)
+}
+
+func TestJSONInput_OverridesWithVariablesDefault(t *testing.T) {
+	conv, rec := openRecordingConv(t, "topic={{topic}}",
+		sdk.WithVariables(map[string]string{"topic": "default"}))
+	_, err := conv.Send(context.Background(), "", sdk.WithJSONInput(map[string]any{"topic": "override"}))
+	require.NoError(t, err)
+	assert.Contains(t, rec.system(), "topic=override")
+	assert.NotContains(t, rec.system(), "topic=default")
+}
+
+func TestJSONInput_EmptyMessageFallsBackToJSONUserTurn(t *testing.T) {
+	conv, rec := openRecordingConv(t, "static prompt")
+	_, err := conv.Send(context.Background(), "", sdk.WithJSONInput(map[string]any{"topic": "x"}))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"topic":"x"}`, rec.userText())
+}
+
+func TestJSONInput_NonEmptyMessagePreservedWithBinding(t *testing.T) {
+	conv, rec := openRecordingConv(t, "topic={{topic}}")
+	_, err := conv.Send(context.Background(), "hello there", sdk.WithJSONInput(map[string]any{"topic": "x"}))
+	require.NoError(t, err)
+	assert.Equal(t, "hello there", rec.userText())
+	assert.Contains(t, rec.system(), "topic=x")
+}
+
+func TestJSONInput_StreamBindsField(t *testing.T) {
+	conv, rec := openRecordingConv(t, "topic={{topic}}")
+	for chunk := range conv.Stream(context.Background(), "", sdk.WithJSONInput(map[string]any{"topic": "wind"})) {
+		require.NoError(t, chunk.Error)
+	}
+	assert.Contains(t, rec.system(), "topic=wind")
+}

--- a/sdk/integration/json_input_test.go
+++ b/sdk/integration/json_input_test.go
@@ -151,6 +151,36 @@ func TestJSONInput_NonEmptyMessagePreservedWithBinding(t *testing.T) {
 	assert.Contains(t, rec.system(), "topic=x")
 }
 
+// jsonInputPackRequired returns a pack whose bound variable is declared
+// required — the realistic case (and what an inputSchema implies).
+func jsonInputPackRequired(systemTemplate string) string {
+	return `{
+		"id": "json-input-required-test",
+		"version": "1.0.0",
+		"description": "Pack with a required bound variable",
+		"prompts": {
+			"fn": {
+				"id": "fn",
+				"name": "Function",
+				"system_template": ` + quote(systemTemplate) + `,
+				"variables": [
+					{"name": "secret_code", "type": "string", "required": true, "description": "code"}
+				]
+			}
+		}
+	}`
+}
+
+func TestJSONInput_RequiredVariableBindsToSystemPrompt(t *testing.T) {
+	rec := newRecordingProvider()
+	conv := openTestConvWithPack(t, jsonInputPackRequired("code={{secret_code}}"), "fn",
+		sdk.WithProvider(rec), sdk.WithSkipSchemaValidation())
+	_, err := conv.Send(context.Background(), "", sdk.WithJSONInput(map[string]any{"secret_code": "ZEBRA-4271"}))
+	require.NoError(t, err)
+	assert.Contains(t, rec.system(), "code=ZEBRA-4271")
+	assert.NotContains(t, rec.system(), "{{secret_code}}")
+}
+
 func TestJSONInput_StreamBindsField(t *testing.T) {
 	conv, rec := openRecordingConv(t, "topic={{topic}}")
 	for chunk := range conv.Stream(context.Background(), "", sdk.WithJSONInput(map[string]any{"topic": "wind"})) {

--- a/sdk/json_input.go
+++ b/sdk/json_input.go
@@ -1,0 +1,116 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/variables"
+)
+
+// WithJSONInput binds a structured value to the prompt's template variables for
+// a single Send or Stream call. It is the input half of the "function-style"
+// pattern: pass a JSON object in, run one turn, and (paired with
+// WithResponseFormat) get JSON back.
+//
+// v may be any JSON-marshalable value — a map[string]any, a struct, or a
+// json.RawMessage. The marshaled value is bound to template variables as
+// follows:
+//
+//   - {{input}} is always bound to the whole value as compact JSON.
+//   - If the value is a JSON object, each top-level field is also bound to
+//     {{field}}: JSON strings pass through verbatim; numbers, booleans, objects
+//     and arrays are bound as their compact JSON encoding. A real top-level
+//     field named "input" shadows the synthetic whole-object variable.
+//
+// Bound variables override open-time WithVariables defaults (the live request
+// wins). If the caller passes an empty message, the input JSON is also used as
+// the user-turn message; a non-empty message is left untouched and only the
+// variables are added.
+//
+//	resp, _ := conv.Send(ctx, "", sdk.WithJSONInput(map[string]any{"topic": "x"}))
+func WithJSONInput(v any) SendOption {
+	return func(c *sendConfig) error {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("WithJSONInput: marshal input: %w", err)
+		}
+		c.jsonInputRaw = raw
+		c.jsonInputVars = bindJSONInputVars(raw)
+		return nil
+	}
+}
+
+// bindJSONInputVars maps a marshaled JSON value to flat string template
+// variables per the WithJSONInput contract.
+func bindJSONInputVars(raw json.RawMessage) map[string]string {
+	vars := make(map[string]string)
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		for k, v := range obj {
+			vars[k] = jsonValueToString(v)
+		}
+	}
+
+	// The whole object is exposed as {{input}} unless a real top-level field
+	// named "input" already claimed that name.
+	if _, exists := vars["input"]; !exists {
+		vars["input"] = string(raw)
+	}
+
+	return vars
+}
+
+// jsonValueToString renders a single JSON value as a template-variable string:
+// JSON strings are unquoted; everything else keeps its compact JSON encoding.
+func jsonValueToString(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
+}
+
+// sendVarsCtxKey is the context key under which per-send template variables are
+// carried from Send/Stream to the send-scoped variable provider.
+type sendVarsCtxKey struct{}
+
+// withSendVars returns a context carrying the given per-send variables. It
+// returns ctx unchanged when there are no variables to add.
+func withSendVars(ctx context.Context, vars map[string]string) context.Context {
+	if len(vars) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, sendVarsCtxKey{}, vars)
+}
+
+// sendScopedVarProvider resolves the per-send variables carried on the request
+// context (see WithJSONInput). It is registered once at pipeline-build time and
+// runs fresh on every turn, so each Send observes only its own variables. It is
+// ordered last among providers so request-scoped values win.
+type sendScopedVarProvider struct{}
+
+// Name identifies the provider in logs and merge ordering.
+func (sendScopedVarProvider) Name() string { return "send-scoped" }
+
+// Provide returns the per-send variables carried on ctx, or nil when none.
+func (sendScopedVarProvider) Provide(ctx context.Context) (map[string]string, error) {
+	if vars, ok := ctx.Value(sendVarsCtxKey{}).(map[string]string); ok {
+		return vars, nil
+	}
+	return nil, nil
+}
+
+// Compile-time assertion that sendScopedVarProvider implements variables.Provider.
+var _ variables.Provider = sendScopedVarProvider{}
+
+// appendSendScopedProvider returns a provider list with the send-scoped provider
+// appended last, so per-send variables win over user-configured providers and
+// open-time WithVariables. The input slice is not mutated.
+func appendSendScopedProvider(existing []variables.Provider) []variables.Provider {
+	out := make([]variables.Provider, 0, len(existing)+1)
+	out = append(out, existing...)
+	out = append(out, sendScopedVarProvider{})
+	return out
+}

--- a/sdk/json_input.go
+++ b/sdk/json_input.go
@@ -72,23 +72,19 @@ func jsonValueToString(raw json.RawMessage) string {
 	return string(raw)
 }
 
-// sendVarsCtxKey is the context key under which per-send template variables are
-// carried from Send/Stream to the send-scoped variable provider.
-type sendVarsCtxKey struct{}
-
-// withSendVars returns a context carrying the given per-send variables. It
-// returns ctx unchanged when there are no variables to add.
+// withSendVars returns a context carrying the given per-send variables, using
+// the runtime's request-variable vehicle so both the required-variable check
+// (PromptAssemblyStage) and rendering observe them. Returns ctx unchanged when
+// there are no variables to add.
 func withSendVars(ctx context.Context, vars map[string]string) context.Context {
-	if len(vars) == 0 {
-		return ctx
-	}
-	return context.WithValue(ctx, sendVarsCtxKey{}, vars)
+	return variables.WithRequestVars(ctx, vars)
 }
 
 // sendScopedVarProvider resolves the per-send variables carried on the request
-// context (see WithJSONInput). It is registered once at pipeline-build time and
-// runs fresh on every turn, so each Send observes only its own variables. It is
-// ordered last among providers so request-scoped values win.
+// context (see WithJSONInput) into the rendered variable set. It is registered
+// once at pipeline-build time and runs fresh on every turn, so each Send
+// observes only its own variables. It is ordered last among providers so
+// request-scoped values win.
 type sendScopedVarProvider struct{}
 
 // Name identifies the provider in logs and merge ordering.
@@ -96,10 +92,7 @@ func (sendScopedVarProvider) Name() string { return "send-scoped" }
 
 // Provide returns the per-send variables carried on ctx, or nil when none.
 func (sendScopedVarProvider) Provide(ctx context.Context) (map[string]string, error) {
-	if vars, ok := ctx.Value(sendVarsCtxKey{}).(map[string]string); ok {
-		return vars, nil
-	}
-	return nil, nil
+	return variables.RequestVars(ctx), nil
 }
 
 // Compile-time assertion that sendScopedVarProvider implements variables.Provider.

--- a/sdk/json_input_test.go
+++ b/sdk/json_input_test.go
@@ -1,0 +1,77 @@
+package sdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// applyJSONInput applies WithJSONInput(v) to a fresh sendConfig and returns it.
+func applyJSONInput(t *testing.T, v any) *sendConfig {
+	t.Helper()
+	cfg := &sendConfig{}
+	require.NoError(t, WithJSONInput(v)(cfg))
+	return cfg
+}
+
+func TestWithJSONInput_TopLevelStringPassesThrough(t *testing.T) {
+	cfg := applyJSONInput(t, map[string]any{"topic": "batteries"})
+	assert.Equal(t, "batteries", cfg.jsonInputVars["topic"])
+}
+
+func TestWithJSONInput_NonStringFieldsAreJSONEncoded(t *testing.T) {
+	cfg := applyJSONInput(t, map[string]any{
+		"count":   3,
+		"enabled": true,
+		"nested":  map[string]any{"a": 1},
+		"list":    []any{1, 2},
+	})
+	assert.Equal(t, "3", cfg.jsonInputVars["count"])
+	assert.Equal(t, "true", cfg.jsonInputVars["enabled"])
+	assert.JSONEq(t, `{"a":1}`, cfg.jsonInputVars["nested"])
+	assert.JSONEq(t, `[1,2]`, cfg.jsonInputVars["list"])
+}
+
+func TestWithJSONInput_WholeObjectBoundToInput(t *testing.T) {
+	cfg := applyJSONInput(t, map[string]any{"topic": "x", "n": 1})
+	assert.JSONEq(t, `{"topic":"x","n":1}`, cfg.jsonInputVars["input"])
+}
+
+func TestWithJSONInput_RealInputFieldShadowsWholeObject(t *testing.T) {
+	cfg := applyJSONInput(t, map[string]any{"input": "user-data", "topic": "x"})
+	assert.Equal(t, "user-data", cfg.jsonInputVars["input"])
+}
+
+func TestWithJSONInput_NonObjectBindsOnlyInput(t *testing.T) {
+	cfg := applyJSONInput(t, []any{"a", "b"})
+	assert.JSONEq(t, `["a","b"]`, cfg.jsonInputVars["input"])
+	assert.Len(t, cfg.jsonInputVars, 1)
+}
+
+func TestWithJSONInput_StructInput(t *testing.T) {
+	type req struct {
+		Topic string `json:"topic"`
+		Count int    `json:"count"`
+	}
+	cfg := applyJSONInput(t, req{Topic: "solar", Count: 5})
+	assert.Equal(t, "solar", cfg.jsonInputVars["topic"])
+	assert.Equal(t, "5", cfg.jsonInputVars["count"])
+}
+
+func TestWithJSONInput_RawMessageInput(t *testing.T) {
+	cfg := applyJSONInput(t, json.RawMessage(`{"topic":"wind"}`))
+	assert.Equal(t, "wind", cfg.jsonInputVars["topic"])
+}
+
+func TestWithJSONInput_RawIsSetForFallbackTurn(t *testing.T) {
+	cfg := applyJSONInput(t, map[string]any{"topic": "x"})
+	assert.JSONEq(t, `{"topic":"x"}`, string(cfg.jsonInputRaw))
+}
+
+func TestWithJSONInput_UnmarshalableReturnsError(t *testing.T) {
+	cfg := &sendConfig{}
+	err := WithJSONInput(make(chan int))(cfg)
+	assert.Error(t, err)
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -2490,6 +2491,14 @@ func WithStreamingVideo(cfg *VideoStreamConfig) Option {
 // sendConfig holds configuration for a single Send call.
 type sendConfig struct {
 	parts []any // Additional content parts (images, audio, etc.)
+
+	// jsonInputVars holds template variables bound from WithJSONInput for this
+	// send. They are injected into the request context and resolved per-turn by
+	// the send-scoped variable provider, overriding open-time WithVariables.
+	jsonInputVars map[string]string
+	// jsonInputRaw is the compact JSON encoding of the WithJSONInput value, used
+	// as the user-turn message when the caller supplies an empty message.
+	jsonInputRaw json.RawMessage
 }
 
 // SendOption configures a single Send call.

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -127,7 +127,7 @@ func (c *Conversation) Stream(ctx context.Context, message any, opts ...SendOpti
 		c.mu.RUnlock()
 
 		// Build user message with options
-		userMsg, err := c.buildStreamMessage(message, opts)
+		userMsg, sendCfg, err := c.buildStreamMessage(message, opts)
 		if err != nil {
 			select {
 			case ch <- StreamChunk{Error: err}:
@@ -135,6 +135,10 @@ func (c *Conversation) Stream(ctx context.Context, message any, opts ...SendOpti
 			}
 			return
 		}
+
+		// Carry WithJSONInput-bound variables on the context so the send-scoped
+		// variable provider resolves them for this turn.
+		ctx = withSendVars(ctx, sendCfg.jsonInputVars)
 
 		// Execute streaming pipeline
 		if err := c.executeStreamingPipeline(ctx, userMsg, ch, startTime); err != nil {
@@ -148,40 +152,45 @@ func (c *Conversation) Stream(ctx context.Context, message any, opts ...SendOpti
 	return ch
 }
 
-// buildStreamMessage constructs a user message from input and options.
-func (c *Conversation) buildStreamMessage(message any, opts []SendOption) (*types.Message, error) {
+// buildStreamMessage constructs a user message from input and options. It
+// returns the parsed sendConfig so the caller can carry any WithJSONInput-bound
+// variables on the context.
+func (c *Conversation) buildStreamMessage(message any, opts []SendOption) (*types.Message, *sendConfig, error) {
+	sendCfg, err := parseSendOptions(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Fall back to the JSON input as the user turn when the caller passes an
+	// empty message.
+	if isEmptyMessage(message) && len(sendCfg.jsonInputRaw) > 0 {
+		message = string(sendCfg.jsonInputRaw)
+	}
+
 	// Build user message from input
 	var userMsg *types.Message
 	switch m := message.(type) {
 	case string:
 		if err := c.validateMessageSize(len(m)); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		userMsg = &types.Message{Role: "user"}
 		userMsg.AddTextPart(m)
 	case *types.Message:
 		if err := c.validateMessageSize(messageContentSize(m)); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		userMsg = m
 	default:
-		return nil, fmt.Errorf("message must be string or *types.Message, got %T", message)
-	}
-
-	// Apply send options
-	sendCfg := &sendConfig{}
-	for _, opt := range opts {
-		if err := opt(sendCfg); err != nil {
-			return nil, fmt.Errorf("failed to apply send option: %w", err)
-		}
+		return nil, nil, fmt.Errorf("message must be string or *types.Message, got %T", message)
 	}
 
 	// Add content parts to message
 	if err := c.addContentParts(userMsg, sendCfg.parts); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return userMsg, nil
+	return userMsg, sendCfg, nil
 }
 
 // addContentParts adds content parts from options to the message.

--- a/sdk/streaming_test.go
+++ b/sdk/streaming_test.go
@@ -127,7 +127,7 @@ func TestBuildStreamMessage(t *testing.T) {
 	conv := newTestConversation()
 
 	t.Run("simple text message", func(t *testing.T) {
-		msg, err := conv.buildStreamMessage("hello", nil)
+		msg, _, err := conv.buildStreamMessage("hello", nil)
 		require.NoError(t, err)
 		assert.NotNil(t, msg)
 		assert.Equal(t, "user", msg.Role)
@@ -135,11 +135,32 @@ func TestBuildStreamMessage(t *testing.T) {
 	})
 
 	t.Run("message with parts", func(t *testing.T) {
-		msg, err := conv.buildStreamMessage("text", []SendOption{
+		msg, _, err := conv.buildStreamMessage("text", []SendOption{
 			WithImageURL("http://example.com/image.jpg"),
 		})
 		require.NoError(t, err)
 		assert.NotNil(t, msg)
+	})
+
+	t.Run("empty message falls back to JSON input as user turn", func(t *testing.T) {
+		msg, cfg, err := conv.buildStreamMessage("", []SendOption{
+			WithJSONInput(map[string]any{"topic": "x"}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		require.NotEmpty(t, msg.Parts)
+		assert.JSONEq(t, `{"topic":"x"}`, *msg.Parts[0].Text)
+		assert.Equal(t, "x", cfg.jsonInputVars["topic"])
+	})
+
+	t.Run("non-empty message keeps text and surfaces bound vars", func(t *testing.T) {
+		msg, cfg, err := conv.buildStreamMessage("hello", []SendOption{
+			WithJSONInput(map[string]any{"topic": "x"}),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, msg.Parts)
+		assert.Equal(t, "hello", *msg.Parts[0].Text)
+		assert.Equal(t, "x", cfg.jsonInputVars["topic"])
 	})
 }
 
@@ -332,7 +353,7 @@ func TestStreamRawClosedConversation(t *testing.T) {
 func TestBuildStreamMessageWithNil(t *testing.T) {
 	conv := newTestConversation()
 
-	_, err := conv.buildStreamMessage(nil, nil)
+	_, _, err := conv.buildStreamMessage(nil, nil)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
## Summary

Adds `WithJSONInput(v any) SendOption` — the **input half** of the function-style pattern: pass a JSON object in, run one turn, and (paired with `WithResponseFormat`) get JSON back. Closes #1386.

```go
conv, _ := sdk.Open(pack, "fn", sdk.WithResponseFormat(outSchema)) // JSON out (schema-enforced)
resp, _ := conv.Send(ctx, "", sdk.WithJSONInput(payload))          // JSON in (bound to {{vars}})
```

## Binding semantics

For a marshaled JSON **object**:
- `{{input}}` → the whole object as compact JSON.
- each top-level field → `{{field}}` (strings verbatim; numbers/bools/objects/arrays as compact JSON).
- bound vars override open-time `WithVariables` (live request wins); a real top-level field named `input` shadows the synthetic whole-object var.
- non-object input (array/scalar) binds only `{{input}}`.

Empty message → the input JSON also fills the user turn. A non-empty message is left as-is and only variables are added.

## Implementation

Per-send vars ride on the request `context` via a small **runtime** vehicle (`variables.WithRequestVars` / `RequestVars`), available before any pipeline stage runs. Two consumers read it:
- **rendering** — a send-scoped `variables.Provider` folds them into the rendered variable set;
- **required-var validation** — `PromptAssemblyStage.loadTemplate` merges them over the static base vars.

The second point was essential: without it, a pack that marks the bound field `required` (the natural case) fails `LoadTemplate`'s required check — which runs before per-send resolution — and the stage **discards the pack prompt for a generic default**, so the model never sees the bound values. Live testing across all three providers caught this; the fix makes required bound vars work.

## Out of scope (by design)

- No input schema validation, no PromptPack schema declaration (schemas stay external).
- No change to output-side options — `WithResponseFormat(schema)` already covers JSON output across all three providers.

## Tests & deliverables

- White-box unit tests for the binding contract; runtime unit tests for the request-var vehicle.
- Mock integration tests: `Send`/`Stream` parity, precedence over `WithVariables`, whole-object var, empty-message fallback, and the **required-variable** case (reproduces the bug a mock can catch).
- **Live cross-provider e2e tests — all green** on OpenAI, Anthropic, and Gemini (each echoes the bound `secret_code`).
- Runnable SDK example: `sdk/examples/json-function/` (+ README, mock smoke test).

### Incidental e2e suite repair (required for the live tests to compile/run)

The `e2e`-tagged suite did not compile on `main`. To land the cross-provider tests I:
- renamed the test-only `Capability` enum → `ProviderCapability` (collided with the SDK `Capability` interface),
- migrated `e2e_transcription_pipeline_test.go` to the current `base.STTRequest`/`STTResponse` API,
- fixed a `lostcancel` vet error in `e2e_streaming_test.go`,
- refreshed stale default model IDs (`claude-haiku-4-5`, `gemini-2.5-flash`).

## Verification

- `golangci-lint`: clean. Coverage ≥80% on all changed files. Full `sdk` + `runtime` + `integration` + example suites pass.
- Live e2e (`-tags=e2e`, real keys): `TestE2E_JSONInput_*` pass on all three providers.
