### PR TITLE
feat(arena): agentkb keystone + init agent brief (Phase A)

### DIFF
--- a/tools/arena/agentkb/catalog.go
+++ b/tools/arena/agentkb/catalog.go
@@ -1,0 +1,42 @@
+package agentkb
+
+import (
+	"embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed catalog.yaml
+var catalogFS embed.FS
+
+// CatalogEntry indexes one example/template the agent can discover.
+type CatalogEntry struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Source      string   `yaml:"source"` // "builtin:<name>" or "remote:<ref>"
+	Concepts    []string `yaml:"concepts"`
+	Tags        []string `yaml:"tags"`
+}
+
+// Catalog is the embedded example index.
+type Catalog struct {
+	Entries []CatalogEntry `yaml:"entries"`
+}
+
+// LoadCatalog parses the embedded catalog.yaml.
+func LoadCatalog() (Catalog, error) {
+	raw, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return Catalog{}, fmt.Errorf("read catalog: %w", err)
+	}
+	return parseCatalog(raw)
+}
+
+func parseCatalog(raw []byte) (Catalog, error) {
+	var cat Catalog
+	if err := yaml.Unmarshal(raw, &cat); err != nil {
+		return Catalog{}, fmt.Errorf("parse catalog: %w", err)
+	}
+	return cat, nil
+}

--- a/tools/arena/agentkb/catalog.yaml
+++ b/tools/arena/agentkb/catalog.yaml
@@ -1,0 +1,31 @@
+entries:
+  - name: quick-start
+    description: Minimal viable testing setup for rapid experimentation.
+    source: builtin:quick-start
+    concepts: [schema-validation, mock-providers]
+    tags: [beginner, minimal]
+  - name: customer-support
+    description: Customer-support assistant kit with scenarios and assertions.
+    source: builtin:customer-support
+    concepts: [assertions-vs-evals, mock-providers]
+    tags: [support, assertions]
+  - name: code-assistant
+    description: Code-assistant prompt kit.
+    source: builtin:code-assistant
+    concepts: [schema-validation]
+    tags: [code]
+  - name: content-generation
+    description: Content-generation prompt kit.
+    source: builtin:content-generation
+    concepts: [schema-validation]
+    tags: [content]
+  - name: mcp-integration
+    description: Kit wired to MCP tool servers.
+    source: builtin:mcp-integration
+    concepts: [schema-validation]
+    tags: [mcp, tools]
+  - name: multimodal
+    description: Multimodal (image/audio) testing kit.
+    source: builtin:multimodal
+    concepts: [schema-validation]
+    tags: [multimodal]

--- a/tools/arena/agentkb/catalog_test.go
+++ b/tools/arena/agentkb/catalog_test.go
@@ -1,0 +1,52 @@
+package agentkb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCatalog_NonEmpty(t *testing.T) {
+	cat, err := LoadCatalog()
+	require.NoError(t, err)
+	require.NotEmpty(t, cat.Entries)
+	for _, e := range cat.Entries {
+		assert.NotEmpty(t, e.Name)
+		assert.NotEmpty(t, e.Description)
+		assert.NotEmpty(t, e.Source)
+	}
+}
+
+func TestParseCatalog_ValidAndInvalid(t *testing.T) {
+	cat, err := parseCatalog([]byte("entries:\n  - name: x\n    source: builtin:x\n"))
+	require.NoError(t, err)
+	require.Len(t, cat.Entries, 1)
+	assert.Equal(t, "x", cat.Entries[0].Name)
+
+	_, err = parseCatalog([]byte("entries: [unterminated"))
+	require.Error(t, err)
+}
+
+// agentkb-lint: every catalog concept-ref resolves to a real concept, and every
+// source uses a known scheme.
+func TestCatalog_LintRefsAndSources(t *testing.T) {
+	cat, err := LoadCatalog()
+	require.NoError(t, err)
+	cs, err := Concepts()
+	require.NoError(t, err)
+
+	known := map[string]bool{}
+	for _, c := range cs {
+		known[c.ID] = true
+	}
+	for _, e := range cat.Entries {
+		for _, ref := range e.Concepts {
+			assert.True(t, known[ref], "catalog entry %q references unknown concept %q", e.Name, ref)
+		}
+		assert.True(t,
+			strings.HasPrefix(e.Source, "builtin:") || strings.HasPrefix(e.Source, "remote:"),
+			"catalog entry %q has invalid source %q", e.Name, e.Source)
+	}
+}

--- a/tools/arena/agentkb/concepts.go
+++ b/tools/arena/agentkb/concepts.go
@@ -1,0 +1,94 @@
+// Package agentkb is the embedded knowledge base that briefs AI coding agents
+// building PromptArena kits. Concepts are the single hand-authored source;
+// the skill, schema, and catalog accessors are layered on top.
+package agentkb
+
+import (
+	"embed"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed concepts/*.md
+var conceptsFS embed.FS
+
+// Concept is one authoring idiom parsed from concepts/<id>.md.
+type Concept struct {
+	ID      string
+	Title   string
+	Summary string
+	Tags    []string
+	Body    string
+}
+
+type conceptFrontmatter struct {
+	ID      string   `yaml:"id"`
+	Title   string   `yaml:"title"`
+	Summary string   `yaml:"summary"`
+	Tags    []string `yaml:"tags"`
+}
+
+const frontmatterFence = "---\n"
+
+func parseConcept(name string, raw []byte) (Concept, error) {
+	s := string(raw)
+	if !strings.HasPrefix(s, frontmatterFence) {
+		return Concept{}, fmt.Errorf("concept %s: missing frontmatter", name)
+	}
+	rest := s[len(frontmatterFence):]
+	fmText, rawBody, found := strings.Cut(rest, "\n"+frontmatterFence)
+	if !found {
+		return Concept{}, fmt.Errorf("concept %s: unterminated frontmatter", name)
+	}
+	var fm conceptFrontmatter
+	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
+		return Concept{}, fmt.Errorf("concept %s: parse frontmatter: %w", name, err)
+	}
+	if fm.ID == "" || fm.Title == "" || fm.Summary == "" {
+		return Concept{}, fmt.Errorf("concept %s: id, title and summary are required", name)
+	}
+	body := strings.TrimLeft(rawBody, "\n")
+	return Concept{ID: fm.ID, Title: fm.Title, Summary: fm.Summary, Tags: fm.Tags, Body: body}, nil
+}
+
+// Concepts returns every embedded concept, sorted by ID.
+func Concepts() ([]Concept, error) {
+	entries, err := conceptsFS.ReadDir("concepts")
+	if err != nil {
+		return nil, fmt.Errorf("read concepts dir: %w", err)
+	}
+	out := make([]Concept, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		raw, err := conceptsFS.ReadFile("concepts/" + e.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read concept %s: %w", e.Name(), err)
+		}
+		c, err := parseConcept(e.Name(), raw)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// ConceptByID returns a single concept by ID.
+func ConceptByID(id string) (Concept, error) {
+	cs, err := Concepts()
+	if err != nil {
+		return Concept{}, err
+	}
+	for _, c := range cs {
+		if c.ID == id {
+			return c, nil
+		}
+	}
+	return Concept{}, fmt.Errorf("unknown concept %q", id)
+}

--- a/tools/arena/agentkb/concepts/assertions-vs-evals.md
+++ b/tools/arena/agentkb/concepts/assertions-vs-evals.md
@@ -1,0 +1,21 @@
+---
+id: assertions-vs-evals
+title: Assertions judge; evals measure
+summary: Eval handlers emit a raw score; assertions apply a threshold. Never put the threshold on the eval.
+tags: [assertions, evals, scoring]
+---
+PromptArena is an **assertion** framework. Eval handlers are *inputs* to assertions:
+an eval handler emits `Score` as a raw signal (0..1) and nothing else. The pass/fail
+threshold lives on a `type: assertion` wrapper:
+
+```yaml
+assertions:
+  - type: assertion
+    eval:
+      type: toxicity        # eval handler — emits a raw score
+    max_score: 0.2          # threshold lives HERE, on the assertion
+```
+
+Putting `min_score`/`max_score` on the inner eval is a common trap — the eval must
+stay a pure primitive. Guardrails reuse the same eval primitives but enforce in
+production; assertions are test-only and may observe guardrail firings.

--- a/tools/arena/agentkb/concepts/mock-providers.md
+++ b/tools/arena/agentkb/concepts/mock-providers.md
@@ -1,0 +1,34 @@
+---
+id: mock-providers
+title: Mock providers simulate the LLM, not the tools
+summary: A mock provider replays canned model output; tools, workflow state, and memory still execute for real.
+tags: [providers, testing, mock]
+---
+A provider with `type: mock` simulates **only the LLM's decisions** — the text it
+returns and which tools it calls. The tools themselves run for real (InMemoryStore,
+workflow state machine, memory). Point the provider at a response file:
+
+```yaml
+spec:
+  type: mock
+  additional_config:
+    mock_config: mock-responses.yaml   # relative to the arena config directory
+```
+
+Response keys MUST match the scenario's `metadata.name`, NOT `spec.id`:
+
+```yaml
+scenarios:
+  my-scenario-name:
+    turns:
+      1:
+        response: "I'll look that up"
+        tool_calls:
+          - name: memory__recall
+            arguments: { query: "user preferences" }
+      2: "Based on what I found..."
+```
+
+The `--mock-provider` CLI flag is different: it replaces ALL providers with a generic
+mock that ignores `mock-responses.yaml`. If your example ships a `providers/mock-provider.yaml`,
+run it WITHOUT `--mock-provider`.

--- a/tools/arena/agentkb/concepts/schema-validation.md
+++ b/tools/arena/agentkb/concepts/schema-validation.md
@@ -1,0 +1,15 @@
+---
+id: schema-validation
+title: Validate against the binary's own schemas
+summary: Run `promptarena schema <type>` for authoritative structure and `promptarena validate` to check configs.
+tags: [schema, validation]
+---
+Every config type (scenario, provider, prompt, tool, arena) has a JSON schema. The
+schema embedded in your installed `promptarena` binary is the source of truth — it is
+the exact version `promptarena validate` enforces. Prefer it over the public web copy,
+which may be a different release.
+
+- `promptarena schema <type>` — print the authoritative schema for a type.
+- `promptarena validate` — check your configs before running.
+
+Author configs to the schema first; don't guess field names.

--- a/tools/arena/agentkb/concepts_test.go
+++ b/tools/arena/agentkb/concepts_test.go
@@ -1,0 +1,61 @@
+package agentkb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcepts_ParseAllWithFrontmatter(t *testing.T) {
+	cs, err := Concepts()
+	require.NoError(t, err)
+	require.NotEmpty(t, cs)
+
+	for _, c := range cs {
+		assert.NotEmpty(t, c.ID, "id required")
+		assert.NotEmpty(t, c.Title, "title required")
+		assert.NotEmpty(t, c.Summary, "summary required")
+		assert.NotEmpty(t, c.Body, "body required for %s", c.ID)
+	}
+
+	// Sorted by ID.
+	for i := 1; i < len(cs); i++ {
+		assert.Less(t, cs[i-1].ID, cs[i].ID)
+	}
+}
+
+func TestParseConcept_Errors(t *testing.T) {
+	cases := map[string]string{
+		"missing frontmatter":     "no fence here\nbody",
+		"unterminated":            "---\nid: x\ntitle: y\nsummary: z\nbody with no closing fence",
+		"invalid yaml":            "---\nid: [unclosed\n---\nbody",
+		"missing required fields": "---\nid: x\n---\nbody",
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseConcept(name+".md", []byte(raw))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseConcept_Valid(t *testing.T) {
+	raw := "---\nid: demo\ntitle: Demo\nsummary: A demo concept\ntags: [a, b]\n---\n\nThe body.\n"
+	c, err := parseConcept("demo.md", []byte(raw))
+	require.NoError(t, err)
+	assert.Equal(t, "demo", c.ID)
+	assert.Equal(t, "Demo", c.Title)
+	assert.Equal(t, []string{"a", "b"}, c.Tags)
+	assert.Equal(t, "The body.\n", c.Body)
+}
+
+func TestConcept_LookupAndUnknown(t *testing.T) {
+	c, err := ConceptByID("mock-providers")
+	require.NoError(t, err)
+	assert.Equal(t, "mock-providers", c.ID)
+	assert.Contains(t, c.Body, "type: mock")
+
+	_, err = ConceptByID("does-not-exist")
+	require.Error(t, err)
+}

--- a/tools/arena/agentkb/schema.go
+++ b/tools/arena/agentkb/schema.go
@@ -1,0 +1,38 @@
+package agentkb
+
+import (
+	"embed"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+//go:embed schemas/*.json schemas/common/*.json
+var schemasFS embed.FS
+
+// SchemaNames lists the top-level config schema type names (sorted), excluding the
+// common/ $ref directory.
+func SchemaNames() ([]string, error) {
+	entries, err := schemasFS.ReadDir("schemas")
+	if err != nil {
+		return nil, fmt.Errorf("read schemas dir: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Schema returns the raw JSON schema bytes for a config type (e.g. "scenario").
+func Schema(name string) ([]byte, error) {
+	b, err := schemasFS.ReadFile("schemas/" + name + ".json")
+	if err != nil {
+		return nil, fmt.Errorf("unknown schema %q: %w", name, err)
+	}
+	return b, nil
+}

--- a/tools/arena/agentkb/schema_test.go
+++ b/tools/arena/agentkb/schema_test.go
@@ -1,0 +1,43 @@
+package agentkb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaNames_IncludeCoreTypes(t *testing.T) {
+	names, err := SchemaNames()
+	require.NoError(t, err)
+	for _, want := range []string{"scenario", "provider", "promptconfig", "tool"} {
+		assert.Contains(t, names, want)
+	}
+	assert.NotContains(t, names, "common", "common is a $ref dir, not a type")
+}
+
+func TestSchema_ReturnsBytesAndRejectsUnknown(t *testing.T) {
+	b, err := Schema("scenario")
+	require.NoError(t, err)
+	assert.NotEmpty(t, b)
+	assert.Contains(t, string(b), "$schema")
+
+	_, err = Schema("nope")
+	require.Error(t, err)
+}
+
+// Parity: the embedded schemas must byte-match the generated source of truth, so
+// the binary can never ship a schema that disagrees with its own validate.
+func TestSchemas_ByteMatchGeneratedSource(t *testing.T) {
+	names, err := SchemaNames()
+	require.NoError(t, err)
+	for _, name := range names {
+		embedded, err := Schema(name)
+		require.NoError(t, err)
+		src, err := os.ReadFile(filepath.Join("..", "..", "..", "schemas", "v1alpha1", name+".json"))
+		require.NoError(t, err, "missing source schema for %s", name)
+		assert.Equal(t, string(src), string(embedded), "embedded %s drifted from schemas/v1alpha1", name)
+	}
+}

--- a/tools/arena/agentkb/schemas/arena.json
+++ b/tools/arena/agentkb/schemas/arena.json
@@ -1,0 +1,3219 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/arena.json",
+  "$defs": {
+    "A2AAgentConfig": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "card": {
+          "$ref": "#/$defs/A2ACardConfig"
+        },
+        "responses": {
+          "items": {
+            "$ref": "#/$defs/A2AResponseRule"
+          },
+          "type": "array"
+        },
+        "url": {
+          "type": "string"
+        },
+        "auth": {
+          "$ref": "#/$defs/A2AAuthConfig"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "headers_from_env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "skill_filter": {
+          "$ref": "#/$defs/A2ASkillFilter"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
+    "A2AAuthConfig": {
+      "properties": {
+        "scheme": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "token_env": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "scheme"
+      ]
+    },
+    "A2ACardConfig": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "skills": {
+          "items": {
+            "$ref": "#/$defs/A2ASkillConfig"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "skills"
+      ]
+    },
+    "A2AMatchConfig": {
+      "properties": {
+        "contains": {
+          "type": "string"
+        },
+        "regex": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "A2APartConfig": {
+      "properties": {
+        "text": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "text"
+      ]
+    },
+    "A2AResponseConfig": {
+      "properties": {
+        "parts": {
+          "items": {
+            "$ref": "#/$defs/A2APartConfig"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "parts"
+      ]
+    },
+    "A2AResponseRule": {
+      "properties": {
+        "skill": {
+          "type": "string"
+        },
+        "match": {
+          "$ref": "#/$defs/A2AMatchConfig"
+        },
+        "response": {
+          "$ref": "#/$defs/A2AResponseConfig"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "skill"
+      ]
+    },
+    "A2ASkillConfig": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "description"
+      ]
+    },
+    "A2ASkillFilter": {
+      "properties": {
+        "allowlist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "blocklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AssertionConfig": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "enum": [
+                "a2a_eval",
+                "a2a_eval_session",
+                "agent_invoked",
+                "agent_not_invoked",
+                "agent_response_contains",
+                "answer_relevancy",
+                "assertion",
+                "audio_duration",
+                "audio_emotion",
+                "audio_format",
+                "banned_words",
+                "bias",
+                "composition_branch_taken",
+                "composition_output",
+                "composition_parallel_complete",
+                "composition_step_output",
+                "contains",
+                "contains_any",
+                "content_excludes",
+                "content_includes",
+                "content_includes_any",
+                "content_matches",
+                "content_not_includes",
+                "contextual_precision",
+                "contextual_recall",
+                "contextual_relevancy",
+                "cosine_similarity",
+                "cost_budget",
+                "directional",
+                "faithfulness",
+                "field_presence",
+                "guardrail",
+                "guardrail_triggered",
+                "hallucination",
+                "image_dimensions",
+                "image_format",
+                "image_moderation",
+                "invariant_fields_preserved",
+                "is_valid_json",
+                "json_path",
+                "json_schema",
+                "json_valid",
+                "latency_budget",
+                "length",
+                "llm_judge",
+                "llm_judge_conversation",
+                "llm_judge_session",
+                "llm_judge_tool_calls",
+                "max_length",
+                "max_sentences",
+                "min_length",
+                "no_tool_errors",
+                "outcome_equivalent",
+                "pii_leakage",
+                "regex",
+                "required_fields",
+                "rest_eval",
+                "rest_eval_session",
+                "role_violation",
+                "sentence_count",
+                "skill_activated",
+                "skill_activation_order",
+                "skill_not_activated",
+                "state_is",
+                "text_sentiment",
+                "text_toxicity",
+                "tool_anti_pattern",
+                "tool_args",
+                "tool_args_excluded_session",
+                "tool_args_session",
+                "tool_call_chain",
+                "tool_call_count",
+                "tool_call_sequence",
+                "tool_called",
+                "tool_calls_with_args",
+                "tool_efficiency",
+                "tool_exec",
+                "tool_no_repeat",
+                "tool_result_has_media",
+                "tool_result_includes",
+                "tool_result_matches",
+                "tool_result_media_type",
+                "tools_called",
+                "tools_called_session",
+                "tools_not_called",
+                "tools_not_called_session",
+                "tools_not_called_with_args",
+                "toxicity",
+                "transitioned_to",
+                "valid_json",
+                "video_duration",
+                "video_resolution",
+                "workflow_complete",
+                "workflow_tool_access",
+                "workflow_transition_order"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Handler type. PromptKit-known types are suggested, but values are not restricted to this list — a different runtime may define additional types."
+        },
+        "params": {
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "when": {
+          "$ref": "#/$defs/AssertionWhen"
+        },
+        "pass_threshold": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "AssertionWhen": {
+      "properties": {
+        "tool_called": {
+          "type": "string"
+        },
+        "tool_called_pattern": {
+          "type": "string"
+        },
+        "any_tool_called": {
+          "type": "boolean"
+        },
+        "min_tool_calls": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AudioConfig": {
+      "properties": {
+        "max_size_mb": {
+          "type": "integer"
+        },
+        "allowed_formats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "max_duration_sec": {
+          "type": "integer"
+        },
+        "require_metadata": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AudioMonitorSection": {
+      "properties": {
+        "enabled": {
+          "type": "string"
+        },
+        "rate": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ChangelogEntry": {
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "date",
+        "description"
+      ]
+    },
+    "ChaosConfig": {
+      "properties": {
+        "tool_failures": {
+          "items": {
+            "$ref": "#/$defs/ChaosToolFailure"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ChaosToolFailure": {
+      "properties": {
+        "tool": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "probability": {
+          "type": "number"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool",
+        "mode"
+      ]
+    },
+    "CompilationInfo": {
+      "properties": {
+        "compiled_with": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "compiled_with",
+        "created_at"
+      ]
+    },
+    "Config": {
+      "properties": {
+        "prompt_configs": {
+          "items": {
+            "$ref": "#/$defs/PromptConfigRef"
+          },
+          "type": "array"
+        },
+        "providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
+        "judges": {
+          "items": {
+            "$ref": "#/$defs/JudgeRef"
+          },
+          "type": "array"
+        },
+        "judge_defaults": {
+          "$ref": "#/$defs/JudgeDefaults"
+        },
+        "scenarios": {
+          "items": {
+            "$ref": "#/$defs/ScenarioRef"
+          },
+          "type": "array"
+        },
+        "evals": {
+          "items": {
+            "$ref": "#/$defs/EvalRef"
+          },
+          "type": "array"
+        },
+        "tools": {
+          "items": {
+            "$ref": "#/$defs/ToolRef"
+          },
+          "type": "array"
+        },
+        "skills": {
+          "items": {
+            "$ref": "#/$defs/SkillSourceConfig"
+          },
+          "type": "array"
+        },
+        "pack_evals": {
+          "items": {
+            "$ref": "#/$defs/EvalDef"
+          },
+          "type": "array"
+        },
+        "globals": {
+          "$ref": "#/$defs/Globals"
+        },
+        "workflow": true,
+        "compositions": true,
+        "memory": true,
+        "agents": true,
+        "deploy": {
+          "$ref": "#/$defs/DeployConfig"
+        },
+        "mcp_servers": {
+          "items": {
+            "$ref": "#/$defs/MCPServerConfig"
+          },
+          "type": "array"
+        },
+        "a2a_agents": {
+          "items": {
+            "$ref": "#/$defs/A2AAgentConfig"
+          },
+          "type": "array"
+        },
+        "state_store": {
+          "$ref": "#/$defs/StateStoreConfig"
+        },
+        "defaults": {
+          "$ref": "#/$defs/Defaults"
+        },
+        "self_play": {
+          "$ref": "#/$defs/SelfPlayConfig"
+        },
+        "pack_file": {
+          "type": "string"
+        },
+        "provider_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Provider"
+          },
+          "type": "object"
+        },
+        "scenario_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Scenario"
+          },
+          "type": "object"
+        },
+        "eval_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Eval"
+          },
+          "type": "object"
+        },
+        "tool_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ToolSpec"
+          },
+          "type": "object"
+        },
+        "judge_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JudgeSpec"
+          },
+          "type": "object"
+        },
+        "prompt_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Spec"
+          },
+          "type": "object"
+        },
+        "tts_providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
+        "stt_providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
+        "embedding_providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
+        "image_providers": {
+          "items": {
+            "$ref": "#/$defs/ProviderRef"
+          },
+          "type": "array"
+        },
+        "voices": {
+          "items": {
+            "$ref": "#/$defs/VoiceBinding"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "providers",
+        "defaults"
+      ]
+    },
+    "ContextMetadata": {
+      "properties": {
+        "domain": {
+          "type": "string"
+        },
+        "user_role": {
+          "type": "string"
+        },
+        "project_stage": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ContextPolicy": {
+      "properties": {
+        "token_budget": {
+          "type": "integer"
+        },
+        "reserve_for_output": {
+          "type": "integer"
+        },
+        "strategy": {
+          "type": "string"
+        },
+        "cache_breakpoints": {
+          "type": "boolean"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CostEstimate": {
+      "properties": {
+        "min_cost_usd": {
+          "type": "number"
+        },
+        "max_cost_usd": {
+          "type": "number"
+        },
+        "avg_cost_usd": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "min_cost_usd",
+        "max_cost_usd",
+        "avg_cost_usd"
+      ]
+    },
+    "CredentialConfig": {
+      "properties": {
+        "api_key": {
+          "type": "string"
+        },
+        "credential_file": {
+          "type": "string"
+        },
+        "credential_env": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Defaults": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "max_tokens": {
+          "type": "integer"
+        },
+        "seed": {
+          "type": "integer"
+        },
+        "concurrency": {
+          "type": "integer"
+        },
+        "run_timeout": {
+          "type": "string"
+        },
+        "output": {
+          "$ref": "#/$defs/OutputConfig"
+        },
+        "config_dir": {
+          "type": "string"
+        },
+        "fail_on": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verbose": {
+          "type": "boolean"
+        },
+        "monitor": {
+          "$ref": "#/$defs/MonitorSection"
+        },
+        "inference": {
+          "$ref": "#/$defs/InferenceDefaults"
+        },
+        "html_report": {
+          "type": "string"
+        },
+        "out_dir": {
+          "type": "string"
+        },
+        "output_formats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "markdown_config": {
+          "$ref": "#/$defs/MarkdownConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DeployConfig": {
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "config": {
+          "type": "object"
+        },
+        "environments": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DeployEnvironment"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider"
+      ]
+    },
+    "DeployEnvironment": {
+      "properties": {
+        "config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DuplexConfig": {
+      "properties": {
+        "timeout": {
+          "type": "string"
+        },
+        "turn_detection": {
+          "$ref": "#/$defs/TurnDetectionConfig"
+        },
+        "resilience": {
+          "$ref": "#/$defs/DuplexResilienceConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DuplexResilienceConfig": {
+      "properties": {
+        "max_retries": {
+          "type": "integer"
+        },
+        "retry_delay_ms": {
+          "type": "integer"
+        },
+        "partial_success_min_turns": {
+          "type": "integer"
+        },
+        "ignore_last_turn_session_end": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Eval": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this evaluation"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "recording": {
+          "$ref": "#/$defs/RecordingSource",
+          "description": "Recording source"
+        },
+        "turns": {
+          "items": {
+            "$ref": "#/$defs/EvalTurnConfig"
+          },
+          "type": "array",
+          "description": "Turn-level assertions"
+        },
+        "conversation_assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array",
+          "description": "Conversation-level assertions"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Tags for categorization"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "instant",
+            "realtime",
+            "accelerated"
+          ],
+          "description": "Replay timing mode (instant"
+        },
+        "speed": {
+          "type": "number",
+          "description": "Playback speed (default 1.0)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description",
+        "recording"
+      ]
+    },
+    "EvalAllTurnsConfig": {
+      "properties": {
+        "assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array",
+          "description": "Assertions to apply to each assistant message"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EvalDef": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "enum": [
+                "a2a_eval",
+                "a2a_eval_session",
+                "agent_invoked",
+                "agent_not_invoked",
+                "agent_response_contains",
+                "answer_relevancy",
+                "assertion",
+                "audio_duration",
+                "audio_emotion",
+                "audio_format",
+                "banned_words",
+                "bias",
+                "composition_branch_taken",
+                "composition_output",
+                "composition_parallel_complete",
+                "composition_step_output",
+                "contains",
+                "contains_any",
+                "content_excludes",
+                "content_includes",
+                "content_includes_any",
+                "content_matches",
+                "content_not_includes",
+                "contextual_precision",
+                "contextual_recall",
+                "contextual_relevancy",
+                "cosine_similarity",
+                "cost_budget",
+                "directional",
+                "faithfulness",
+                "field_presence",
+                "guardrail",
+                "guardrail_triggered",
+                "hallucination",
+                "image_dimensions",
+                "image_format",
+                "image_moderation",
+                "invariant_fields_preserved",
+                "is_valid_json",
+                "json_path",
+                "json_schema",
+                "json_valid",
+                "latency_budget",
+                "length",
+                "llm_judge",
+                "llm_judge_conversation",
+                "llm_judge_session",
+                "llm_judge_tool_calls",
+                "max_length",
+                "max_sentences",
+                "min_length",
+                "no_tool_errors",
+                "outcome_equivalent",
+                "pii_leakage",
+                "regex",
+                "required_fields",
+                "rest_eval",
+                "rest_eval_session",
+                "role_violation",
+                "sentence_count",
+                "skill_activated",
+                "skill_activation_order",
+                "skill_not_activated",
+                "state_is",
+                "text_sentiment",
+                "text_toxicity",
+                "tool_anti_pattern",
+                "tool_args",
+                "tool_args_excluded_session",
+                "tool_args_session",
+                "tool_call_chain",
+                "tool_call_count",
+                "tool_call_sequence",
+                "tool_called",
+                "tool_calls_with_args",
+                "tool_efficiency",
+                "tool_exec",
+                "tool_no_repeat",
+                "tool_result_has_media",
+                "tool_result_includes",
+                "tool_result_matches",
+                "tool_result_media_type",
+                "tools_called",
+                "tools_called_session",
+                "tools_not_called",
+                "tools_not_called_session",
+                "tools_not_called_with_args",
+                "toxicity",
+                "transitioned_to",
+                "valid_json",
+                "video_duration",
+                "video_resolution",
+                "workflow_complete",
+                "workflow_tool_access",
+                "workflow_transition_order"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Handler type. PromptKit-known types are suggested, but values are not restricted to this list — a different runtime may define additional types."
+        },
+        "trigger": {
+          "type": "string"
+        },
+        "params": {
+          "type": "object"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "sample_percentage": {
+          "type": "number"
+        },
+        "metric": {
+          "$ref": "#/$defs/MetricDef"
+        },
+        "threshold": {
+          "$ref": "#/$defs/Threshold"
+        },
+        "message": {
+          "type": "string"
+        },
+        "when": {
+          "$ref": "#/$defs/EvalWhen"
+        },
+        "groups": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "trigger",
+        "params"
+      ]
+    },
+    "EvalRef": {
+      "properties": {
+        "file": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "file"
+      ]
+    },
+    "EvalTurnConfig": {
+      "properties": {
+        "all_turns": {
+          "$ref": "#/$defs/EvalAllTurnsConfig",
+          "description": "Assertions to apply to all assistant messages"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EvalWhen": {
+      "properties": {
+        "tool_called": {
+          "type": "string"
+        },
+        "tool_called_pattern": {
+          "type": "string"
+        },
+        "any_tool_called": {
+          "type": "boolean"
+        },
+        "min_tool_calls": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExampleContentPart": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/ExampleMedia"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ExampleMedia": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "ExecBinding": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "title": "Command",
+          "description": "Path to the executable"
+        },
+        "runtime": {
+          "type": "string",
+          "enum": [
+            "exec",
+            "server"
+          ],
+          "title": "Runtime",
+          "description": "Execution mode",
+          "default": "exec"
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Env",
+          "description": "Required environment variable names"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Args",
+          "description": "Additional command arguments"
+        },
+        "timeout_ms": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command"
+      ]
+    },
+    "FileStateStoreConfig": {
+      "properties": {
+        "root": {
+          "type": "string"
+        },
+        "fsync": {
+          "type": "string",
+          "enum": [
+            "",
+            "off",
+            "on-save",
+            "on-append"
+          ],
+          "title": "FSync Policy"
+        },
+        "ttl_days": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "root"
+      ]
+    },
+    "FragmentRef": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "required"
+      ]
+    },
+    "Globals": {
+      "properties": {
+        "conversation_assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HTMLOutputConfig": {
+      "properties": {
+        "file": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HTTPConfig": {
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "headers_from_env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "redact": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "request": {
+          "$ref": "#/$defs/RequestMapping"
+        },
+        "response": {
+          "$ref": "#/$defs/ResponseMapping"
+        },
+        "multimodal": {
+          "$ref": "#/$defs/MultimodalConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "url",
+        "method",
+        "timeout_ms"
+      ]
+    },
+    "HTTPTransportConfig": {
+      "properties": {
+        "max_conns_per_host": {
+          "type": "integer"
+        },
+        "max_idle_conns_per_host": {
+          "type": "integer"
+        },
+        "idle_conn_timeout": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ImageConfig": {
+      "properties": {
+        "max_size_mb": {
+          "type": "integer"
+        },
+        "allowed_formats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "default_detail": {
+          "type": "string"
+        },
+        "require_caption": {
+          "type": "boolean"
+        },
+        "max_images_per_msg": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "InferenceDefaults": {
+      "properties": {
+        "audio_classifier": {
+          "type": "string"
+        },
+        "text_classifier": {
+          "type": "string"
+        },
+        "image_classifier": {
+          "type": "string"
+        },
+        "video_classifier": {
+          "type": "string"
+        },
+        "embedder": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "JSONOutputConfig": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "JUnitOutputConfig": {
+      "properties": {
+        "file": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "JudgeDefaults": {
+      "properties": {
+        "prompt": {
+          "type": "string"
+        },
+        "prompt_registry": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "JudgeRef": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "provider"
+      ]
+    },
+    "JudgeSpec": {
+      "properties": {
+        "provider": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider"
+      ]
+    },
+    "MCPServerConfig": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "working_dir": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "transport": {
+          "type": "string",
+          "enum": [
+            "",
+            "stdio",
+            "sse",
+            "streamable_http"
+          ],
+          "title": "MCP Transport",
+          "description": "Explicit transport adapter. Defaults: url→sse for back-compat; command→stdio. Set to 'streamable_http' to opt into the MCP 2025-03-26 Streamable HTTP transport."
+        },
+        "source": {
+          "type": "string",
+          "title": "MCPSource Name",
+          "description": "Name of a host-registered MCPSource that provisions the endpoint per scope (e.g. 'docker'). Mutually exclusive with command and url."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "run",
+            "scenario",
+            "session"
+          ],
+          "title": "Source Scope",
+          "description": "Lifecycle boundary at which the source opens and closes. Required when source is set."
+        },
+        "source_args": {
+          "type": "object",
+          "title": "Source Args",
+          "description": "Opaque arguments passed to the named MCPSource. Schema is source-specific. See the source's reference for accepted fields."
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "tool_filter": {
+          "$ref": "#/$defs/MCPToolFilter"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
+    "MCPToolFilter": {
+      "properties": {
+        "allowlist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "blocklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MarkdownConfig": {
+      "properties": {
+        "include_details": {
+          "type": "boolean"
+        },
+        "show_overview": {
+          "type": "boolean"
+        },
+        "show_results_matrix": {
+          "type": "boolean"
+        },
+        "show_failed_tests": {
+          "type": "boolean"
+        },
+        "show_cost_summary": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "include_details",
+        "show_overview",
+        "show_results_matrix",
+        "show_failed_tests",
+        "show_cost_summary"
+      ]
+    },
+    "MarkdownOutputConfig": {
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "include_details": {
+          "type": "boolean"
+        },
+        "show_overview": {
+          "type": "boolean"
+        },
+        "show_results_matrix": {
+          "type": "boolean"
+        },
+        "show_failed_tests": {
+          "type": "boolean"
+        },
+        "show_cost_summary": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "include_details",
+        "show_overview",
+        "show_results_matrix",
+        "show_failed_tests",
+        "show_cost_summary"
+      ]
+    },
+    "MediaConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "supported_types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "image": {
+          "$ref": "#/$defs/ImageConfig"
+        },
+        "audio": {
+          "$ref": "#/$defs/AudioConfig"
+        },
+        "video": {
+          "$ref": "#/$defs/VideoConfig"
+        },
+        "examples": {
+          "items": {
+            "$ref": "#/$defs/MultimodalExample"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
+    },
+    "Metadata": {
+      "properties": {
+        "domain": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cost_estimate": {
+          "$ref": "#/$defs/CostEstimate"
+        },
+        "performance": {
+          "$ref": "#/$defs/PerformanceMetrics"
+        },
+        "changelog": {
+          "items": {
+            "$ref": "#/$defs/ChangelogEntry"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MetricDef": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "range": {
+          "$ref": "#/$defs/Range"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "MockMediaSpec": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "MockPartSpec": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/MockMediaSpec"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ModelOverride": {
+      "properties": {
+        "system_template": {
+          "type": "string"
+        },
+        "system_template_suffix": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ModelTestResultRef": {
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        },
+        "success_rate": {
+          "type": "number"
+        },
+        "avg_tokens": {
+          "type": "integer"
+        },
+        "avg_cost": {
+          "type": "number"
+        },
+        "avg_latency_ms": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider",
+        "model",
+        "date",
+        "success_rate"
+      ]
+    },
+    "MonitorSection": {
+      "properties": {
+        "audio": {
+          "$ref": "#/$defs/AudioMonitorSection"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MultimodalConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "accept_types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
+    },
+    "MultimodalExample": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "parts": {
+          "items": {
+            "$ref": "#/$defs/ExampleContentPart"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "role",
+        "parts"
+      ]
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "OutputConfig": {
+      "properties": {
+        "dir": {
+          "type": "string"
+        },
+        "formats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "json": {
+          "$ref": "#/$defs/JSONOutputConfig"
+        },
+        "html": {
+          "$ref": "#/$defs/HTMLOutputConfig"
+        },
+        "markdown": {
+          "$ref": "#/$defs/MarkdownOutputConfig"
+        },
+        "junit": {
+          "$ref": "#/$defs/JUnitOutputConfig"
+        },
+        "recording": {
+          "$ref": "#/$defs/RecordingConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "dir",
+        "formats"
+      ]
+    },
+    "ParametersPack": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "max_tokens": {
+          "type": "integer"
+        },
+        "top_p": {
+          "type": "number"
+        },
+        "top_k": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PerformanceMetrics": {
+      "properties": {
+        "avg_latency_ms": {
+          "type": "integer"
+        },
+        "p95_latency_ms": {
+          "type": "integer"
+        },
+        "avg_tokens": {
+          "type": "integer"
+        },
+        "success_rate": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "avg_latency_ms",
+        "p95_latency_ms",
+        "avg_tokens",
+        "success_rate"
+      ]
+    },
+    "PersonaDefaults": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "seed": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PersonaRef": {
+      "properties": {
+        "file": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "file"
+      ]
+    },
+    "PersonaStyle": {
+      "properties": {
+        "verbosity": {
+          "type": "string"
+        },
+        "challenge_level": {
+          "type": "string"
+        },
+        "friction_tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "expressive": {
+          "type": "boolean"
+        },
+        "characterization_rubric": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "verbosity",
+        "challenge_level",
+        "friction_tags"
+      ]
+    },
+    "PlatformConfig": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "additional_config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Pricing": {
+      "properties": {
+        "input_cost_per_1k": {
+          "type": "number"
+        },
+        "output_cost_per_1k": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "input_cost_per_1k",
+        "output_cost_per_1k"
+      ]
+    },
+    "PromptConfigRef": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "file": {
+          "type": "string"
+        },
+        "vars": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "file"
+      ]
+    },
+    "Provider": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "sample_rate": {
+          "type": "integer"
+        },
+        "audio_files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "llm",
+            "tts",
+            "stt",
+            "embedding",
+            "image",
+            "video",
+            "inference"
+          ]
+        },
+        "base_url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/RateLimit"
+        },
+        "defaults": {
+          "$ref": "#/$defs/ProviderDefaults"
+        },
+        "pricing": {
+          "$ref": "#/$defs/Pricing"
+        },
+        "pricing_correct_at": {
+          "type": "string"
+        },
+        "include_raw_output": {
+          "type": "boolean"
+        },
+        "additional_config": {
+          "type": "object"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig"
+        },
+        "platform": {
+          "$ref": "#/$defs/PlatformConfig"
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "unsupported_params": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "request_timeout": {
+          "type": "string"
+        },
+        "stream_idle_timeout": {
+          "type": "string"
+        },
+        "stream_retry": {
+          "$ref": "#/$defs/StreamRetryConfig"
+        },
+        "stream_max_concurrent": {
+          "type": "integer"
+        },
+        "http_transport": {
+          "$ref": "#/$defs/HTTPTransportConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ProviderDefaults": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "top_p": {
+          "type": "number"
+        },
+        "max_tokens": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "temperature",
+        "top_p",
+        "max_tokens"
+      ]
+    },
+    "ProviderRef": {
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "file"
+      ]
+    },
+    "Range": {
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RateLimit": {
+      "properties": {
+        "rps": {
+          "type": "integer"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "rps",
+        "burst"
+      ]
+    },
+    "RecordingConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "dir": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
+    },
+    "RecordingSource": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to recording file"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "session",
+            "arena_output",
+            "transcript",
+            "generic"
+          ],
+          "description": "Recording format type hint (auto-detected if omitted)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ]
+    },
+    "RedisConfig": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "database": {
+          "type": "integer"
+        },
+        "ttl": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "address"
+      ]
+    },
+    "RelevanceConfig": {
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "min_recent_messages": {
+          "type": "integer"
+        },
+        "always_keep_system_role": {
+          "type": "boolean"
+        },
+        "similarity_threshold": {
+          "type": "number"
+        },
+        "query_source": {
+          "type": "string"
+        },
+        "last_n_count": {
+          "type": "integer"
+        },
+        "custom_query": {
+          "type": "string"
+        },
+        "cache_embeddings": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider"
+      ]
+    },
+    "RequestMapping": {
+      "properties": {
+        "query_params": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "header_params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "body_mapping": {
+          "type": "string"
+        },
+        "exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "static_query": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "static_headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "static_body": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ResponseMapping": {
+      "properties": {
+        "body_mapping": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Scenario": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "task_type": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "context_metadata": {
+          "$ref": "#/$defs/ContextMetadata"
+        },
+        "turns": {
+          "items": {
+            "$ref": "#/$defs/TurnDefinition"
+          },
+          "type": "array"
+        },
+        "context": {
+          "type": "object"
+        },
+        "constraints": {
+          "type": "object"
+        },
+        "tool_policy": {
+          "$ref": "#/$defs/ToolPolicy"
+        },
+        "providers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "provider_group": {
+          "type": "string"
+        },
+        "required_capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "streaming": {
+          "type": "boolean"
+        },
+        "context_policy": {
+          "$ref": "#/$defs/ContextPolicy"
+        },
+        "conversation_assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array"
+        },
+        "duplex": {
+          "$ref": "#/$defs/DuplexConfig"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "variables": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Template variables to inject into the pack"
+        },
+        "trials": {
+          "type": "integer",
+          "description": "Number of times to run this scenario for statistical evaluation"
+        },
+        "seed_memories": {
+          "items": {
+            "$ref": "#/$defs/SeedMemoryEntry"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description"
+      ]
+    },
+    "ScenarioRef": {
+      "properties": {
+        "file": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "file"
+      ]
+    },
+    "SeedMemoryEntry": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "number"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "content"
+      ]
+    },
+    "SelfPlayConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "personas": {
+          "items": {
+            "$ref": "#/$defs/PersonaRef"
+          },
+          "type": "array"
+        },
+        "persona_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/UserPersonaPack"
+          },
+          "type": "object"
+        },
+        "roles": {
+          "items": {
+            "$ref": "#/$defs/SelfPlayRoleGroup"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "personas",
+        "roles"
+      ]
+    },
+    "SelfPlayRoleGroup": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "provider"
+      ]
+    },
+    "SkillSourceConfig": {
+      "properties": {
+        "dir": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "instructions": {
+          "type": "string"
+        },
+        "preload": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Spec": {
+      "properties": {
+        "task_type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "template_engine": {
+          "$ref": "#/$defs/TemplateEngineInfo"
+        },
+        "fragments": {
+          "items": {
+            "$ref": "#/$defs/FragmentRef"
+          },
+          "type": "array"
+        },
+        "system_template": {
+          "type": "string"
+        },
+        "variables": {
+          "items": {
+            "$ref": "#/$defs/VariableMetadata"
+          },
+          "type": "array"
+        },
+        "model_overrides": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ModelOverride"
+          },
+          "type": "object"
+        },
+        "allowed_tools": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "media": {
+          "$ref": "#/$defs/MediaConfig"
+        },
+        "validators": {
+          "items": {
+            "$ref": "#/$defs/ValidatorConfig"
+          },
+          "type": "array"
+        },
+        "tested_models": {
+          "items": {
+            "$ref": "#/$defs/ModelTestResultRef"
+          },
+          "type": "array"
+        },
+        "tool_policy": {
+          "$ref": "#/$defs/ToolPolicyPack"
+        },
+        "parameters": {
+          "$ref": "#/$defs/ParametersPack"
+        },
+        "evals": {
+          "items": {
+            "$ref": "#/$defs/EvalDef"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/Metadata"
+        },
+        "compilation": {
+          "$ref": "#/$defs/CompilationInfo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "task_type",
+        "version",
+        "description",
+        "system_template"
+      ]
+    },
+    "StateStoreConfig": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "redis": {
+          "$ref": "#/$defs/RedisConfig"
+        },
+        "file": {
+          "$ref": "#/$defs/FileStateStoreConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "StreamRetryBudgetConfig": {
+      "properties": {
+        "rate_per_sec": {
+          "type": "number"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StreamRetryConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "max_attempts": {
+          "type": "integer"
+        },
+        "initial_delay": {
+          "type": "string"
+        },
+        "max_delay": {
+          "type": "string"
+        },
+        "retry_window": {
+          "type": "string"
+        },
+        "budget": {
+          "$ref": "#/$defs/StreamRetryBudgetConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TemplateEngineInfo": {
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "syntax": {
+          "type": "string"
+        },
+        "features": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "syntax"
+      ]
+    },
+    "Threshold": {
+      "properties": {
+        "passed": {
+          "type": "boolean"
+        },
+        "min_score": {
+          "type": "number"
+        },
+        "max_score": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolClientConfig": {
+      "properties": {
+        "consent": {
+          "$ref": "#/$defs/ToolConsentConfig"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "categories": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "validate_output": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolConsentConfig": {
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "decline_strategy": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "required"
+      ]
+    },
+    "ToolPolicy": {
+      "properties": {
+        "tool_choice": {
+          "type": "string"
+        },
+        "max_tool_calls_per_turn": {
+          "type": "integer"
+        },
+        "max_total_tool_calls": {
+          "type": "integer"
+        },
+        "blocklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool_choice",
+        "max_tool_calls_per_turn",
+        "max_total_tool_calls"
+      ]
+    },
+    "ToolPolicyPack": {
+      "properties": {
+        "tool_choice": {
+          "type": "string"
+        },
+        "max_rounds": {
+          "type": "integer"
+        },
+        "max_tool_calls_per_turn": {
+          "type": "integer"
+        },
+        "blocklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolRef": {
+      "properties": {
+        "file": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "file"
+      ]
+    },
+    "ToolSpec": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "input_schema": true,
+        "output_schema": true,
+        "mode": {
+          "type": "string",
+          "description": "Execution mode. One of: 'mock' (use mock_result or mock_template) - 'live' (HTTP via 'http') - 'mcp' (MCP server) - 'exec' (subprocess) - 'client' (client-side handler)."
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "mock_result": {
+          "description": "Static mock response returned regardless of tool-call args. Use when the response does not depend on inputs. Mutually exclusive with mock_template."
+        },
+        "mock_template": {
+          "type": "string",
+          "description": "Go text/template rendered against tool-call args (parsed as a JSON map). Rendered output is parsed back as JSON. Use this instead of mock_result when the response should depend on inputs (e.g. branching on order_id with {{ if eq .order_id \"X\" }}...{{ end }}). Mutually exclusive with mock_result."
+        },
+        "mock_parts": {
+          "items": {
+            "$ref": "#/$defs/MockPartSpec"
+          },
+          "type": "array"
+        },
+        "http": {
+          "$ref": "#/$defs/HTTPConfig"
+        },
+        "exec": {
+          "$ref": "#/$defs/ExecBinding"
+        },
+        "client": {
+          "$ref": "#/$defs/ToolClientConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description",
+        "input_schema",
+        "output_schema",
+        "mode"
+      ]
+    },
+    "TurnContentPart": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/TurnMediaContent"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "TurnDefinition": {
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        },
+        "parts": {
+          "items": {
+            "$ref": "#/$defs/TurnContentPart"
+          },
+          "type": "array"
+        },
+        "persona": {
+          "type": "string"
+        },
+        "turns": {
+          "type": "integer"
+        },
+        "max_turns": {
+          "type": "integer"
+        },
+        "assistant_temp": {
+          "type": "number"
+        },
+        "user_temp": {
+          "type": "number"
+        },
+        "seed": {
+          "type": "integer"
+        },
+        "streaming": {
+          "type": "boolean"
+        },
+        "consent_overrides": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "perturbations": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "chaos": {
+          "$ref": "#/$defs/ChaosConfig"
+        },
+        "assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "role"
+      ]
+    },
+    "TurnDetectionConfig": {
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "vad": {
+          "$ref": "#/$defs/VADConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TurnMediaContent": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "data": {
+          "type": "string"
+        },
+        "storage_reference": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "UserPersonaPack": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "prompt_activity": {
+          "type": "string"
+        },
+        "fragments": {
+          "items": {
+            "$ref": "#/$defs/FragmentRef"
+          },
+          "type": "array"
+        },
+        "system_template": {
+          "type": "string"
+        },
+        "required_vars": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "optional_vars": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "system_prompt": {
+          "type": "string"
+        },
+        "goals": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "constraints": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "style": {
+          "$ref": "#/$defs/PersonaStyle"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "defaults": {
+          "$ref": "#/$defs/PersonaDefaults"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description",
+        "goals",
+        "constraints"
+      ]
+    },
+    "VADConfig": {
+      "properties": {
+        "silence_threshold_ms": {
+          "type": "integer"
+        },
+        "min_speech_ms": {
+          "type": "integer"
+        },
+        "max_turn_duration_s": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ValidatorConfig": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "params": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "fail_on_violation": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "params"
+      ]
+    },
+    "VariableBinding": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "autoPopulate": {
+          "type": "boolean"
+        },
+        "filter": {
+          "$ref": "#/$defs/VariableBindingFilter"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ]
+    },
+    "VariableBindingFilter": {
+      "properties": {
+        "capability": {
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "VariableMetadata": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "default": true,
+        "description": {
+          "type": "string"
+        },
+        "example": true,
+        "validation": {
+          "type": "object"
+        },
+        "binding": {
+          "$ref": "#/$defs/VariableBinding"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "required"
+      ]
+    },
+    "VideoConfig": {
+      "properties": {
+        "max_size_mb": {
+          "type": "integer"
+        },
+        "allowed_formats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "max_duration_sec": {
+          "type": "integer"
+        },
+        "require_metadata": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "VoiceBinding": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "provider"
+      ]
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/Config"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptArena Configuration",
+  "description": "Main configuration for PromptArena test suites",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "Arena",
+      "metadata": {
+        "name": "my-test-suite"
+      },
+      "spec": {
+        "defaults": {
+          "concurrency": 1,
+          "max_tokens": 1000,
+          "output": {
+            "dir": "out",
+            "formats": [
+              "json",
+              "html"
+            ]
+          },
+          "temperature": 0.7
+        },
+        "providers": [
+          {
+            "file": "providers/openai.yaml"
+          }
+        ],
+        "scenarios": [
+          {
+            "file": "scenarios/test-scenario.yaml"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/schemas/common/assertions.json
+++ b/tools/arena/agentkb/schemas/common/assertions.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/common/assertions.json",
+  "$defs": {
+    "AssertionWhen": {
+      "properties": {
+        "tool_called": {
+          "type": "string"
+        },
+        "tool_called_pattern": {
+          "type": "string"
+        },
+        "any_tool_called": {
+          "type": "boolean"
+        },
+        "min_tool_calls": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "properties": {
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "a2a_eval",
+            "a2a_eval_session",
+            "agent_invoked",
+            "agent_not_invoked",
+            "agent_response_contains",
+            "answer_relevancy",
+            "assertion",
+            "audio_duration",
+            "audio_emotion",
+            "audio_format",
+            "banned_words",
+            "bias",
+            "composition_branch_taken",
+            "composition_output",
+            "composition_parallel_complete",
+            "composition_step_output",
+            "contains",
+            "contains_any",
+            "content_excludes",
+            "content_includes",
+            "content_includes_any",
+            "content_matches",
+            "content_not_includes",
+            "contextual_precision",
+            "contextual_recall",
+            "contextual_relevancy",
+            "cosine_similarity",
+            "cost_budget",
+            "directional",
+            "faithfulness",
+            "field_presence",
+            "guardrail",
+            "guardrail_triggered",
+            "hallucination",
+            "image_dimensions",
+            "image_format",
+            "image_moderation",
+            "invariant_fields_preserved",
+            "is_valid_json",
+            "json_path",
+            "json_schema",
+            "json_valid",
+            "latency_budget",
+            "length",
+            "llm_judge",
+            "llm_judge_conversation",
+            "llm_judge_session",
+            "llm_judge_tool_calls",
+            "max_length",
+            "max_sentences",
+            "min_length",
+            "no_tool_errors",
+            "outcome_equivalent",
+            "pii_leakage",
+            "regex",
+            "required_fields",
+            "rest_eval",
+            "rest_eval_session",
+            "role_violation",
+            "sentence_count",
+            "skill_activated",
+            "skill_activation_order",
+            "skill_not_activated",
+            "state_is",
+            "text_sentiment",
+            "text_toxicity",
+            "tool_anti_pattern",
+            "tool_args",
+            "tool_args_excluded_session",
+            "tool_args_session",
+            "tool_call_chain",
+            "tool_call_count",
+            "tool_call_sequence",
+            "tool_called",
+            "tool_calls_with_args",
+            "tool_efficiency",
+            "tool_exec",
+            "tool_no_repeat",
+            "tool_result_has_media",
+            "tool_result_includes",
+            "tool_result_matches",
+            "tool_result_media_type",
+            "tools_called",
+            "tools_called_session",
+            "tools_not_called",
+            "tools_not_called_session",
+            "tools_not_called_with_args",
+            "toxicity",
+            "transitioned_to",
+            "valid_json",
+            "video_duration",
+            "video_resolution",
+            "workflow_complete",
+            "workflow_tool_access",
+            "workflow_transition_order"
+          ]
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "Handler type. PromptKit-known types are suggested, but values are not restricted to this list — a different runtime may define additional types."
+    },
+    "params": {
+      "type": "object"
+    },
+    "message": {
+      "type": "string"
+    },
+    "when": {
+      "$ref": "#/$defs/AssertionWhen"
+    },
+    "pass_threshold": {
+      "type": "number"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "title": "PromptArena Assertion",
+  "description": "A single assertion (type + optional params) for PromptArena scenarios"
+}

--- a/tools/arena/agentkb/schemas/common/media.json
+++ b/tools/arena/agentkb/schemas/common/media.json
@@ -1,0 +1,6 @@
+{
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/common/media.json",
+  "type": "object",
+  "title": "PromptKit Media Types",
+  "description": "Media content types for multimodal scenarios"
+}

--- a/tools/arena/agentkb/schemas/common/metadata.json
+++ b/tools/arena/agentkb/schemas/common/metadata.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/common/metadata.json",
+  "$defs": {
+    "FieldsV1": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ManagedFieldsEntry": {
+      "properties": {
+        "manager": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/$defs/Time"
+        },
+        "fieldsType": {
+          "type": "string"
+        },
+        "fieldsV1": {
+          "$ref": "#/$defs/FieldsV1"
+        },
+        "subresource": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "OwnerReference": {
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "controller": {
+          "type": "boolean"
+        },
+        "blockOwnerDeletion": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "apiVersion",
+        "kind",
+        "name",
+        "uid"
+      ]
+    },
+    "Time": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "generateName": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "selfLink": {
+      "type": "string"
+    },
+    "uid": {
+      "type": "string"
+    },
+    "resourceVersion": {
+      "type": "string"
+    },
+    "generation": {
+      "type": "integer"
+    },
+    "creationTimestamp": {
+      "$ref": "#/$defs/Time"
+    },
+    "deletionTimestamp": {
+      "$ref": "#/$defs/Time"
+    },
+    "deletionGracePeriodSeconds": {
+      "type": "integer"
+    },
+    "labels": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "ownerReferences": {
+      "items": {
+        "$ref": "#/$defs/OwnerReference"
+      },
+      "type": "array"
+    },
+    "finalizers": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "managedFields": {
+      "items": {
+        "$ref": "#/$defs/ManagedFieldsEntry"
+      },
+      "type": "array"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "title": "Kubernetes ObjectMeta",
+  "description": "Kubernetes-style metadata for PromptKit resources"
+}

--- a/tools/arena/agentkb/schemas/eval.json
+++ b/tools/arena/agentkb/schemas/eval.json
@@ -1,0 +1,353 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/eval.json",
+  "$defs": {
+    "AssertionConfig": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "enum": [
+                "a2a_eval",
+                "a2a_eval_session",
+                "agent_invoked",
+                "agent_not_invoked",
+                "agent_response_contains",
+                "answer_relevancy",
+                "assertion",
+                "audio_duration",
+                "audio_emotion",
+                "audio_format",
+                "banned_words",
+                "bias",
+                "composition_branch_taken",
+                "composition_output",
+                "composition_parallel_complete",
+                "composition_step_output",
+                "contains",
+                "contains_any",
+                "content_excludes",
+                "content_includes",
+                "content_includes_any",
+                "content_matches",
+                "content_not_includes",
+                "contextual_precision",
+                "contextual_recall",
+                "contextual_relevancy",
+                "cosine_similarity",
+                "cost_budget",
+                "directional",
+                "faithfulness",
+                "field_presence",
+                "guardrail",
+                "guardrail_triggered",
+                "hallucination",
+                "image_dimensions",
+                "image_format",
+                "image_moderation",
+                "invariant_fields_preserved",
+                "is_valid_json",
+                "json_path",
+                "json_schema",
+                "json_valid",
+                "latency_budget",
+                "length",
+                "llm_judge",
+                "llm_judge_conversation",
+                "llm_judge_session",
+                "llm_judge_tool_calls",
+                "max_length",
+                "max_sentences",
+                "min_length",
+                "no_tool_errors",
+                "outcome_equivalent",
+                "pii_leakage",
+                "regex",
+                "required_fields",
+                "rest_eval",
+                "rest_eval_session",
+                "role_violation",
+                "sentence_count",
+                "skill_activated",
+                "skill_activation_order",
+                "skill_not_activated",
+                "state_is",
+                "text_sentiment",
+                "text_toxicity",
+                "tool_anti_pattern",
+                "tool_args",
+                "tool_args_excluded_session",
+                "tool_args_session",
+                "tool_call_chain",
+                "tool_call_count",
+                "tool_call_sequence",
+                "tool_called",
+                "tool_calls_with_args",
+                "tool_efficiency",
+                "tool_exec",
+                "tool_no_repeat",
+                "tool_result_has_media",
+                "tool_result_includes",
+                "tool_result_matches",
+                "tool_result_media_type",
+                "tools_called",
+                "tools_called_session",
+                "tools_not_called",
+                "tools_not_called_session",
+                "tools_not_called_with_args",
+                "toxicity",
+                "transitioned_to",
+                "valid_json",
+                "video_duration",
+                "video_resolution",
+                "workflow_complete",
+                "workflow_tool_access",
+                "workflow_transition_order"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Handler type. PromptKit-known types are suggested, but values are not restricted to this list — a different runtime may define additional types."
+        },
+        "params": {
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "when": {
+          "$ref": "#/$defs/AssertionWhen"
+        },
+        "pass_threshold": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "AssertionWhen": {
+      "properties": {
+        "tool_called": {
+          "type": "string"
+        },
+        "tool_called_pattern": {
+          "type": "string"
+        },
+        "any_tool_called": {
+          "type": "boolean"
+        },
+        "min_tool_calls": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Eval": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this evaluation"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "recording": {
+          "$ref": "#/$defs/RecordingSource",
+          "description": "Recording source"
+        },
+        "turns": {
+          "items": {
+            "$ref": "#/$defs/EvalTurnConfig"
+          },
+          "type": "array",
+          "description": "Turn-level assertions"
+        },
+        "conversation_assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array",
+          "description": "Conversation-level assertions"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Tags for categorization"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "instant",
+            "realtime",
+            "accelerated"
+          ],
+          "description": "Replay timing mode (instant"
+        },
+        "speed": {
+          "type": "number",
+          "description": "Playback speed (default 1.0)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description",
+        "recording"
+      ]
+    },
+    "EvalAllTurnsConfig": {
+      "properties": {
+        "assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array",
+          "description": "Assertions to apply to each assistant message"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EvalTurnConfig": {
+      "properties": {
+        "all_turns": {
+          "$ref": "#/$defs/EvalAllTurnsConfig",
+          "description": "Assertions to apply to all assistant messages"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RecordingSource": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to recording file"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "session",
+            "arena_output",
+            "transcript",
+            "generic"
+          ],
+          "description": "Recording format type hint (auto-detected if omitted)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ]
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/Eval"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptArena Eval Configuration",
+  "description": "Eval configuration for replaying and validating saved conversations",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "Eval",
+      "metadata": {
+        "name": "my-eval"
+      },
+      "spec": {
+        "assertions": [
+          {
+            "config": {
+              "criteria": "Was the customer issue resolved satisfactorily?",
+              "expected": "pass",
+              "judge": "default"
+            },
+            "type": "llm_judge"
+          }
+        ],
+        "description": "Evaluate saved customer support conversation",
+        "id": "eval-saved-conversation",
+        "judge_targets": {
+          "default": {
+            "id": "gpt-4o-judge",
+            "model": "gpt-4o",
+            "type": "openai"
+          }
+        },
+        "mode": "instant",
+        "recording": {
+          "path": "recordings/session-2024-01-15.recording.json",
+          "type": "session"
+        },
+        "tags": [
+          "customer-support",
+          "evaluation"
+        ]
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/schemas/logging.json
+++ b/tools/arena/agentkb/schemas/logging.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/logging.json",
+  "$defs": {
+    "LoggingConfigSpec": {
+      "properties": {
+        "defaultLevel": {
+          "type": "string",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "title": "Default Level",
+          "description": "Default log level for all modules",
+          "default": "info"
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "json",
+            "text"
+          ],
+          "title": "Format",
+          "description": "Log output format",
+          "default": "text"
+        },
+        "commonFields": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Common Fields",
+          "description": "Key-value pairs added to every log entry"
+        },
+        "modules": {
+          "items": {
+            "$ref": "#/$defs/ModuleLoggingConfig"
+          },
+          "type": "array",
+          "title": "Modules",
+          "description": "Per-module logging configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ModuleLoggingConfig": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Module name pattern using dot notation (e.g. runtime.pipeline)"
+        },
+        "level": {
+          "type": "string",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "title": "Level",
+          "description": "Log level for this module"
+        },
+        "fields": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Fields",
+          "description": "Additional fields added to logs from this module"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "level"
+      ]
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "title": "API Version",
+      "description": "Schema version identifier"
+    },
+    "kind": {
+      "type": "string",
+      "title": "Kind",
+      "description": "Resource type identifier"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta",
+      "title": "Metadata",
+      "description": "Resource metadata"
+    },
+    "spec": {
+      "$ref": "#/$defs/LoggingConfigSpec",
+      "title": "Spec",
+      "description": "Logging configuration specification"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptKit Logging Configuration",
+  "description": "Configuration for structured logging with per-module log levels",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "LoggingConfig",
+      "metadata": {
+        "name": "development"
+      },
+      "spec": {
+        "commonFields": {
+          "environment": "development",
+          "service": "promptkit"
+        },
+        "defaultLevel": "info",
+        "format": "text",
+        "modules": [
+          {
+            "level": "debug",
+            "name": "runtime.pipeline"
+          },
+          {
+            "level": "debug",
+            "name": "providers.openai"
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "LoggingConfig",
+      "metadata": {
+        "name": "production"
+      },
+      "spec": {
+        "commonFields": {
+          "cluster": "us-east-1",
+          "environment": "production",
+          "service": "promptkit"
+        },
+        "defaultLevel": "warn",
+        "format": "json",
+        "modules": [
+          {
+            "level": "info",
+            "name": "runtime"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/schemas/persona.json
+++ b/tools/arena/agentkb/schemas/persona.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/persona.json",
+  "$defs": {
+    "FragmentRef": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "required"
+      ]
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PersonaDefaults": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "seed": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PersonaStyle": {
+      "properties": {
+        "verbosity": {
+          "type": "string"
+        },
+        "challenge_level": {
+          "type": "string"
+        },
+        "friction_tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "expressive": {
+          "type": "boolean"
+        },
+        "characterization_rubric": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "verbosity",
+        "challenge_level",
+        "friction_tags"
+      ]
+    },
+    "UserPersonaPack": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "prompt_activity": {
+          "type": "string"
+        },
+        "fragments": {
+          "items": {
+            "$ref": "#/$defs/FragmentRef"
+          },
+          "type": "array"
+        },
+        "system_template": {
+          "type": "string"
+        },
+        "required_vars": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "optional_vars": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "system_prompt": {
+          "type": "string"
+        },
+        "goals": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "constraints": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "style": {
+          "$ref": "#/$defs/PersonaStyle"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "defaults": {
+          "$ref": "#/$defs/PersonaDefaults"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description",
+        "goals",
+        "constraints"
+      ]
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/UserPersonaPack"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptKit Persona Configuration",
+  "description": "User persona configuration for self-play scenarios",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "Persona",
+      "metadata": {
+        "name": "customer-persona"
+      },
+      "spec": {
+        "id": "customer",
+        "provider": "gpt4"
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/schemas/promptconfig.json
+++ b/tools/arena/agentkb/schemas/promptconfig.json
@@ -1,0 +1,785 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/promptconfig.json",
+  "$defs": {
+    "AudioConfig": {
+      "properties": {
+        "max_size_mb": {
+          "type": "integer"
+        },
+        "allowed_formats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "max_duration_sec": {
+          "type": "integer"
+        },
+        "require_metadata": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ChangelogEntry": {
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "date",
+        "description"
+      ]
+    },
+    "CompilationInfo": {
+      "properties": {
+        "compiled_with": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "compiled_with",
+        "created_at"
+      ]
+    },
+    "CostEstimate": {
+      "properties": {
+        "min_cost_usd": {
+          "type": "number"
+        },
+        "max_cost_usd": {
+          "type": "number"
+        },
+        "avg_cost_usd": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "min_cost_usd",
+        "max_cost_usd",
+        "avg_cost_usd"
+      ]
+    },
+    "EvalDef": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "trigger": {
+          "type": "string"
+        },
+        "params": {
+          "type": "object"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "sample_percentage": {
+          "type": "number"
+        },
+        "metric": {
+          "$ref": "#/$defs/MetricDef"
+        },
+        "threshold": {
+          "$ref": "#/$defs/Threshold"
+        },
+        "message": {
+          "type": "string"
+        },
+        "when": {
+          "$ref": "#/$defs/EvalWhen"
+        },
+        "groups": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "trigger",
+        "params"
+      ]
+    },
+    "EvalWhen": {
+      "properties": {
+        "tool_called": {
+          "type": "string"
+        },
+        "tool_called_pattern": {
+          "type": "string"
+        },
+        "any_tool_called": {
+          "type": "boolean"
+        },
+        "min_tool_calls": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExampleContentPart": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/ExampleMedia"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ExampleMedia": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "FragmentRef": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "required"
+      ]
+    },
+    "ImageConfig": {
+      "properties": {
+        "max_size_mb": {
+          "type": "integer"
+        },
+        "allowed_formats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "default_detail": {
+          "type": "string"
+        },
+        "require_caption": {
+          "type": "boolean"
+        },
+        "max_images_per_msg": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MediaConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "supported_types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "image": {
+          "$ref": "#/$defs/ImageConfig"
+        },
+        "audio": {
+          "$ref": "#/$defs/AudioConfig"
+        },
+        "video": {
+          "$ref": "#/$defs/VideoConfig"
+        },
+        "examples": {
+          "items": {
+            "$ref": "#/$defs/MultimodalExample"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
+    },
+    "Metadata": {
+      "properties": {
+        "domain": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cost_estimate": {
+          "$ref": "#/$defs/CostEstimate"
+        },
+        "performance": {
+          "$ref": "#/$defs/PerformanceMetrics"
+        },
+        "changelog": {
+          "items": {
+            "$ref": "#/$defs/ChangelogEntry"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MetricDef": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "range": {
+          "$ref": "#/$defs/Range"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "ModelOverride": {
+      "properties": {
+        "system_template": {
+          "type": "string"
+        },
+        "system_template_suffix": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ModelTestResultRef": {
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string"
+        },
+        "success_rate": {
+          "type": "number"
+        },
+        "avg_tokens": {
+          "type": "integer"
+        },
+        "avg_cost": {
+          "type": "number"
+        },
+        "avg_latency_ms": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider",
+        "model",
+        "date",
+        "success_rate"
+      ]
+    },
+    "MultimodalExample": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "parts": {
+          "items": {
+            "$ref": "#/$defs/ExampleContentPart"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "role",
+        "parts"
+      ]
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ParametersPack": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "max_tokens": {
+          "type": "integer"
+        },
+        "top_p": {
+          "type": "number"
+        },
+        "top_k": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PerformanceMetrics": {
+      "properties": {
+        "avg_latency_ms": {
+          "type": "integer"
+        },
+        "p95_latency_ms": {
+          "type": "integer"
+        },
+        "avg_tokens": {
+          "type": "integer"
+        },
+        "success_rate": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "avg_latency_ms",
+        "p95_latency_ms",
+        "avg_tokens",
+        "success_rate"
+      ]
+    },
+    "Range": {
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Spec": {
+      "properties": {
+        "task_type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "template_engine": {
+          "$ref": "#/$defs/TemplateEngineInfo"
+        },
+        "fragments": {
+          "items": {
+            "$ref": "#/$defs/FragmentRef"
+          },
+          "type": "array"
+        },
+        "system_template": {
+          "type": "string"
+        },
+        "variables": {
+          "items": {
+            "$ref": "#/$defs/VariableMetadata"
+          },
+          "type": "array"
+        },
+        "model_overrides": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ModelOverride"
+          },
+          "type": "object"
+        },
+        "allowed_tools": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "media": {
+          "$ref": "#/$defs/MediaConfig"
+        },
+        "validators": {
+          "items": {
+            "$ref": "#/$defs/ValidatorConfig"
+          },
+          "type": "array"
+        },
+        "tested_models": {
+          "items": {
+            "$ref": "#/$defs/ModelTestResultRef"
+          },
+          "type": "array"
+        },
+        "tool_policy": {
+          "$ref": "#/$defs/ToolPolicyPack"
+        },
+        "parameters": {
+          "$ref": "#/$defs/ParametersPack"
+        },
+        "evals": {
+          "items": {
+            "$ref": "#/$defs/EvalDef"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/Metadata"
+        },
+        "compilation": {
+          "$ref": "#/$defs/CompilationInfo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "task_type",
+        "version",
+        "description",
+        "system_template"
+      ]
+    },
+    "TemplateEngineInfo": {
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "syntax": {
+          "type": "string"
+        },
+        "features": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "syntax"
+      ]
+    },
+    "Threshold": {
+      "properties": {
+        "passed": {
+          "type": "boolean"
+        },
+        "min_score": {
+          "type": "number"
+        },
+        "max_score": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolPolicyPack": {
+      "properties": {
+        "tool_choice": {
+          "type": "string"
+        },
+        "max_rounds": {
+          "type": "integer"
+        },
+        "max_tool_calls_per_turn": {
+          "type": "integer"
+        },
+        "blocklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ValidatorConfig": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "params": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "fail_on_violation": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "params"
+      ]
+    },
+    "VariableBinding": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "autoPopulate": {
+          "type": "boolean"
+        },
+        "filter": {
+          "$ref": "#/$defs/VariableBindingFilter"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ]
+    },
+    "VariableBindingFilter": {
+      "properties": {
+        "capability": {
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "VariableMetadata": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "default": true,
+        "description": {
+          "type": "string"
+        },
+        "example": true,
+        "validation": {
+          "type": "object"
+        },
+        "binding": {
+          "$ref": "#/$defs/VariableBinding"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "required"
+      ]
+    },
+    "VideoConfig": {
+      "properties": {
+        "max_size_mb": {
+          "type": "integer"
+        },
+        "allowed_formats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "max_duration_sec": {
+          "type": "integer"
+        },
+        "require_metadata": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/Spec"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptKit Prompt Configuration",
+  "description": "Prompt configuration for PromptKit",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "PromptConfig",
+      "metadata": {
+        "name": "customer-support"
+      },
+      "spec": {
+        "description": "Customer support assistant",
+        "system_template": "You are a helpful customer support assistant.",
+        "task_type": "support",
+        "version": "1.0.0"
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/schemas/provider.json
+++ b/tools/arena/agentkb/schemas/provider.json
@@ -1,0 +1,325 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/provider.json",
+  "$defs": {
+    "CredentialConfig": {
+      "properties": {
+        "api_key": {
+          "type": "string"
+        },
+        "credential_file": {
+          "type": "string"
+        },
+        "credential_env": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HTTPTransportConfig": {
+      "properties": {
+        "max_conns_per_host": {
+          "type": "integer"
+        },
+        "max_idle_conns_per_host": {
+          "type": "integer"
+        },
+        "idle_conn_timeout": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PlatformConfig": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "additional_config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Pricing": {
+      "properties": {
+        "input_cost_per_1k": {
+          "type": "number"
+        },
+        "output_cost_per_1k": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "input_cost_per_1k",
+        "output_cost_per_1k"
+      ]
+    },
+    "Provider": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "sample_rate": {
+          "type": "integer"
+        },
+        "audio_files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "llm",
+            "tts",
+            "stt",
+            "embedding",
+            "image",
+            "video",
+            "inference"
+          ]
+        },
+        "base_url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/RateLimit"
+        },
+        "defaults": {
+          "$ref": "#/$defs/ProviderDefaults"
+        },
+        "pricing": {
+          "$ref": "#/$defs/Pricing"
+        },
+        "pricing_correct_at": {
+          "type": "string"
+        },
+        "include_raw_output": {
+          "type": "boolean"
+        },
+        "additional_config": {
+          "type": "object"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig"
+        },
+        "platform": {
+          "$ref": "#/$defs/PlatformConfig"
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "unsupported_params": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "request_timeout": {
+          "type": "string"
+        },
+        "stream_idle_timeout": {
+          "type": "string"
+        },
+        "stream_retry": {
+          "$ref": "#/$defs/StreamRetryConfig"
+        },
+        "stream_max_concurrent": {
+          "type": "integer"
+        },
+        "http_transport": {
+          "$ref": "#/$defs/HTTPTransportConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ProviderDefaults": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "top_p": {
+          "type": "number"
+        },
+        "max_tokens": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "temperature",
+        "top_p",
+        "max_tokens"
+      ]
+    },
+    "RateLimit": {
+      "properties": {
+        "rps": {
+          "type": "integer"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "rps",
+        "burst"
+      ]
+    },
+    "StreamRetryBudgetConfig": {
+      "properties": {
+        "rate_per_sec": {
+          "type": "number"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StreamRetryConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "max_attempts": {
+          "type": "integer"
+        },
+        "initial_delay": {
+          "type": "string"
+        },
+        "max_delay": {
+          "type": "string"
+        },
+        "retry_window": {
+          "type": "string"
+        },
+        "budget": {
+          "$ref": "#/$defs/StreamRetryBudgetConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/Provider"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptArena Provider Configuration",
+  "description": "Provider configuration for PromptArena LLM connections",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "Provider",
+      "metadata": {
+        "name": "openai-gpt4"
+      },
+      "spec": {
+        "defaults": {
+          "max_tokens": 2000,
+          "temperature": 0.7
+        },
+        "id": "gpt4",
+        "model": "gpt-4",
+        "type": "openai"
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/schemas/runtime-config.json
+++ b/tools/arena/agentkb/schemas/runtime-config.json
@@ -1,0 +1,1333 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/runtime-config.json",
+  "$defs": {
+    "CredentialConfig": {
+      "properties": {
+        "api_key": {
+          "type": "string"
+        },
+        "credential_file": {
+          "type": "string"
+        },
+        "credential_env": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EmbeddingProviderConfig": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "Stable identifier"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "openai",
+            "gemini",
+            "voyageai",
+            "ollama"
+          ],
+          "title": "Type",
+          "description": "Embedding provider type"
+        },
+        "model": {
+          "type": "string",
+          "title": "Model",
+          "description": "Embedding model name"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "BaseURL",
+          "description": "API endpoint override"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig",
+          "title": "Credential",
+          "description": "API key resolution"
+        },
+        "platform": {
+          "$ref": "#/$defs/PlatformConfig",
+          "title": "Platform",
+          "description": "Hyperscaler platform hosting for keyless auth (azure/bedrock/vertex)"
+        },
+        "additional_config": {
+          "type": "object",
+          "title": "Additional Config",
+          "description": "Provider-specific extras"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ExecBinding": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "title": "Command",
+          "description": "Path to the executable"
+        },
+        "runtime": {
+          "type": "string",
+          "enum": [
+            "exec",
+            "server"
+          ],
+          "title": "Runtime",
+          "description": "Execution mode",
+          "default": "exec"
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Env",
+          "description": "Required environment variable names"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Args",
+          "description": "Additional command arguments"
+        },
+        "timeout_ms": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command"
+      ]
+    },
+    "ExecHook": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "title": "Command",
+          "description": "Path to the executable"
+        },
+        "runtime": {
+          "type": "string",
+          "enum": [
+            "exec",
+            "server"
+          ],
+          "title": "Runtime",
+          "description": "Execution mode",
+          "default": "exec"
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Env",
+          "description": "Required environment variable names"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Args",
+          "description": "Additional command arguments"
+        },
+        "timeout_ms": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
+        },
+        "hook": {
+          "type": "string",
+          "enum": [
+            "provider",
+            "tool",
+            "session",
+            "eval"
+          ],
+          "title": "Hook",
+          "description": "Hook interface type"
+        },
+        "phases": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Phases",
+          "description": "Hook phases to intercept"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "filter",
+            "observe"
+          ],
+          "title": "Mode",
+          "description": "Hook execution mode",
+          "default": "filter"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command",
+        "hook"
+      ]
+    },
+    "FileStateStoreConfig": {
+      "properties": {
+        "root": {
+          "type": "string"
+        },
+        "fsync": {
+          "type": "string",
+          "enum": [
+            "",
+            "off",
+            "on-save",
+            "on-append"
+          ],
+          "title": "FSync Policy"
+        },
+        "ttl_days": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "root"
+      ]
+    },
+    "HTTPConfig": {
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "headers_from_env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "redact": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "request": {
+          "$ref": "#/$defs/RequestMapping"
+        },
+        "response": {
+          "$ref": "#/$defs/ResponseMapping"
+        },
+        "multimodal": {
+          "$ref": "#/$defs/MultimodalConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "url",
+        "method",
+        "timeout_ms"
+      ]
+    },
+    "HTTPTransportConfig": {
+      "properties": {
+        "max_conns_per_host": {
+          "type": "integer"
+        },
+        "max_idle_conns_per_host": {
+          "type": "integer"
+        },
+        "idle_conn_timeout": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "InferenceProviderConfig": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "Stable identifier"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "huggingface"
+          ],
+          "title": "Type",
+          "description": "Inference provider type"
+        },
+        "model": {
+          "type": "string",
+          "title": "Model",
+          "description": "Classification model name"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "BaseURL",
+          "description": "API endpoint override"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig",
+          "title": "Credential",
+          "description": "API key resolution"
+        },
+        "additional_config": {
+          "type": "object",
+          "title": "Additional Config",
+          "description": "Provider-specific extras"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "LoggingConfigSpec": {
+      "properties": {
+        "defaultLevel": {
+          "type": "string",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "title": "Default Level",
+          "description": "Default log level for all modules",
+          "default": "info"
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "json",
+            "text"
+          ],
+          "title": "Format",
+          "description": "Log output format",
+          "default": "text"
+        },
+        "commonFields": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Common Fields",
+          "description": "Key-value pairs added to every log entry"
+        },
+        "modules": {
+          "items": {
+            "$ref": "#/$defs/ModuleLoggingConfig"
+          },
+          "type": "array",
+          "title": "Modules",
+          "description": "Per-module logging configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MCPServerConfig": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "working_dir": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "transport": {
+          "type": "string",
+          "enum": [
+            "",
+            "stdio",
+            "sse",
+            "streamable_http"
+          ],
+          "title": "MCP Transport",
+          "description": "Explicit transport adapter. Defaults: url→sse for back-compat; command→stdio. Set to 'streamable_http' to opt into the MCP 2025-03-26 Streamable HTTP transport."
+        },
+        "source": {
+          "type": "string",
+          "title": "MCPSource Name",
+          "description": "Name of a host-registered MCPSource that provisions the endpoint per scope (e.g. 'docker'). Mutually exclusive with command and url."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "run",
+            "scenario",
+            "session"
+          ],
+          "title": "Source Scope",
+          "description": "Lifecycle boundary at which the source opens and closes. Required when source is set."
+        },
+        "source_args": {
+          "type": "object",
+          "title": "Source Args",
+          "description": "Opaque arguments passed to the named MCPSource. Schema is source-specific. See the source's reference for accepted fields."
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "tool_filter": {
+          "$ref": "#/$defs/MCPToolFilter"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
+    "MCPToolFilter": {
+      "properties": {
+        "allowlist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "blocklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MockMediaSpec": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "MockPartSpec": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/MockMediaSpec"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ModuleLoggingConfig": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Module name pattern using dot notation (e.g. runtime.pipeline)"
+        },
+        "level": {
+          "type": "string",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "title": "Level",
+          "description": "Log level for this module"
+        },
+        "fields": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Fields",
+          "description": "Additional fields added to logs from this module"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "level"
+      ]
+    },
+    "MultimodalConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "accept_types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PlatformConfig": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "additional_config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Pricing": {
+      "properties": {
+        "input_cost_per_1k": {
+          "type": "number"
+        },
+        "output_cost_per_1k": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "input_cost_per_1k",
+        "output_cost_per_1k"
+      ]
+    },
+    "Provider": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "sample_rate": {
+          "type": "integer"
+        },
+        "audio_files": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "llm",
+            "tts",
+            "stt",
+            "embedding",
+            "image",
+            "video",
+            "inference"
+          ]
+        },
+        "base_url": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/RateLimit"
+        },
+        "defaults": {
+          "$ref": "#/$defs/ProviderDefaults"
+        },
+        "pricing": {
+          "$ref": "#/$defs/Pricing"
+        },
+        "pricing_correct_at": {
+          "type": "string"
+        },
+        "include_raw_output": {
+          "type": "boolean"
+        },
+        "additional_config": {
+          "type": "object"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig"
+        },
+        "platform": {
+          "$ref": "#/$defs/PlatformConfig"
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "unsupported_params": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "request_timeout": {
+          "type": "string"
+        },
+        "stream_idle_timeout": {
+          "type": "string"
+        },
+        "stream_retry": {
+          "$ref": "#/$defs/StreamRetryConfig"
+        },
+        "stream_max_concurrent": {
+          "type": "integer"
+        },
+        "http_transport": {
+          "$ref": "#/$defs/HTTPTransportConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ProviderDefaults": {
+      "properties": {
+        "temperature": {
+          "type": "number"
+        },
+        "top_p": {
+          "type": "number"
+        },
+        "max_tokens": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "temperature",
+        "top_p",
+        "max_tokens"
+      ]
+    },
+    "RateLimit": {
+      "properties": {
+        "rps": {
+          "type": "integer"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "rps",
+        "burst"
+      ]
+    },
+    "RedisConfig": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "database": {
+          "type": "integer"
+        },
+        "ttl": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "address"
+      ]
+    },
+    "RequestMapping": {
+      "properties": {
+        "query_params": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "header_params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "body_mapping": {
+          "type": "string"
+        },
+        "exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "static_query": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "static_headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "static_body": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ResponseMapping": {
+      "properties": {
+        "body_mapping": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RuntimeConfigSpec": {
+      "properties": {
+        "providers": {
+          "items": {
+            "$ref": "#/$defs/Provider"
+          },
+          "type": "array",
+          "title": "Providers",
+          "description": "LLM provider configurations"
+        },
+        "embedding_providers": {
+          "items": {
+            "$ref": "#/$defs/EmbeddingProviderConfig"
+          },
+          "type": "array",
+          "title": "Embedding Providers",
+          "description": "Embedding provider configurations"
+        },
+        "tts_providers": {
+          "items": {
+            "$ref": "#/$defs/TTSProviderConfig"
+          },
+          "type": "array",
+          "title": "TTS Providers",
+          "description": "Text-to-speech provider configurations"
+        },
+        "stt_providers": {
+          "items": {
+            "$ref": "#/$defs/STTProviderConfig"
+          },
+          "type": "array",
+          "title": "STT Providers",
+          "description": "Speech-to-text provider configurations"
+        },
+        "inference_providers": {
+          "items": {
+            "$ref": "#/$defs/InferenceProviderConfig"
+          },
+          "type": "array",
+          "title": "Inference Providers",
+          "description": "Inference (classify) provider configurations"
+        },
+        "tools": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ToolSpec"
+          },
+          "type": "object",
+          "title": "Tools",
+          "description": "Tool implementation bindings keyed by tool name"
+        },
+        "mcp_servers": {
+          "items": {
+            "$ref": "#/$defs/MCPServerConfig"
+          },
+          "type": "array",
+          "title": "MCP Servers",
+          "description": "MCP server configurations"
+        },
+        "state_store": {
+          "$ref": "#/$defs/StateStoreConfig",
+          "title": "State Store",
+          "description": "Conversation state persistence configuration"
+        },
+        "logging": {
+          "$ref": "#/$defs/LoggingConfigSpec",
+          "title": "Logging",
+          "description": "Logging configuration"
+        },
+        "evals": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ExecBinding"
+          },
+          "type": "object",
+          "title": "Evals",
+          "description": "External eval process bindings keyed by eval type name"
+        },
+        "hooks": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ExecHook"
+          },
+          "type": "object",
+          "title": "Hooks",
+          "description": "External hook process configurations"
+        },
+        "sandboxes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SandboxConfig"
+          },
+          "type": "object",
+          "title": "Sandboxes",
+          "description": "Named sandbox backends for exec-hook subprocess launch"
+        },
+        "selectors": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SelectorConfig"
+          },
+          "type": "object",
+          "title": "Selectors",
+          "description": "External selector processes narrowing skill and tool candidate sets"
+        },
+        "skills": {
+          "$ref": "#/$defs/SkillsConfig",
+          "title": "Skills",
+          "description": "Runtime skill configuration"
+        },
+        "tool_selector": {
+          "type": "string",
+          "title": "ToolSelector",
+          "description": "Name of a selector declared under spec.selectors used to narrow the LLM-visible tool set per turn"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "STTProviderConfig": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "Stable identifier"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "openai"
+          ],
+          "title": "Type",
+          "description": "STT provider type"
+        },
+        "model": {
+          "type": "string",
+          "title": "Model",
+          "description": "Transcription model name"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "BaseURL",
+          "description": "API endpoint override"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig",
+          "title": "Credential",
+          "description": "API key resolution"
+        },
+        "additional_config": {
+          "type": "object",
+          "title": "Additional Config",
+          "description": "Provider-specific extras"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "SandboxConfig": {
+      "properties": {
+        "mode": {
+          "type": "string",
+          "title": "Mode",
+          "description": "Registered sandbox factory name (direct ships in-tree; docker_run/docker_exec/kubectl_exec are examples)"
+        }
+      },
+      "additionalProperties": true,
+      "type": "object",
+      "required": [
+        "mode"
+      ]
+    },
+    "SelectorConfig": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "title": "Command",
+          "description": "Path to the selector executable"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Args",
+          "description": "Additional command arguments"
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Env",
+          "description": "Required environment variable names"
+        },
+        "timeout_ms": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command"
+      ]
+    },
+    "SkillsConfig": {
+      "properties": {
+        "selector": {
+          "type": "string",
+          "title": "Selector",
+          "description": "Name of a selector declared under spec.selectors"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StateStoreConfig": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "redis": {
+          "$ref": "#/$defs/RedisConfig"
+        },
+        "file": {
+          "$ref": "#/$defs/FileStateStoreConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "StreamRetryBudgetConfig": {
+      "properties": {
+        "rate_per_sec": {
+          "type": "number"
+        },
+        "burst": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StreamRetryConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "max_attempts": {
+          "type": "integer"
+        },
+        "initial_delay": {
+          "type": "string"
+        },
+        "max_delay": {
+          "type": "string"
+        },
+        "retry_window": {
+          "type": "string"
+        },
+        "budget": {
+          "$ref": "#/$defs/StreamRetryBudgetConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TTSProviderConfig": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "Stable identifier"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "openai",
+            "elevenlabs",
+            "cartesia"
+          ],
+          "title": "Type",
+          "description": "TTS provider type"
+        },
+        "model": {
+          "type": "string",
+          "title": "Model",
+          "description": "Voice or model name"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "BaseURL",
+          "description": "API endpoint override"
+        },
+        "credential": {
+          "$ref": "#/$defs/CredentialConfig",
+          "title": "Credential",
+          "description": "API key resolution"
+        },
+        "additional_config": {
+          "type": "object",
+          "title": "Additional Config",
+          "description": "Provider-specific extras"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "ToolClientConfig": {
+      "properties": {
+        "consent": {
+          "$ref": "#/$defs/ToolConsentConfig"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "categories": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "validate_output": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolConsentConfig": {
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "decline_strategy": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "required"
+      ]
+    },
+    "ToolSpec": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "input_schema": true,
+        "output_schema": true,
+        "mode": {
+          "type": "string",
+          "description": "Execution mode. One of: 'mock' (use mock_result or mock_template) - 'live' (HTTP via 'http') - 'mcp' (MCP server) - 'exec' (subprocess) - 'client' (client-side handler)."
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "mock_result": {
+          "description": "Static mock response returned regardless of tool-call args. Use when the response does not depend on inputs. Mutually exclusive with mock_template."
+        },
+        "mock_template": {
+          "type": "string",
+          "description": "Go text/template rendered against tool-call args (parsed as a JSON map). Rendered output is parsed back as JSON. Use this instead of mock_result when the response should depend on inputs (e.g. branching on order_id with {{ if eq .order_id \"X\" }}...{{ end }}). Mutually exclusive with mock_result."
+        },
+        "mock_parts": {
+          "items": {
+            "$ref": "#/$defs/MockPartSpec"
+          },
+          "type": "array"
+        },
+        "http": {
+          "$ref": "#/$defs/HTTPConfig"
+        },
+        "exec": {
+          "$ref": "#/$defs/ExecBinding"
+        },
+        "client": {
+          "$ref": "#/$defs/ToolClientConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description",
+        "input_schema",
+        "output_schema",
+        "mode"
+      ]
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "title": "API Version",
+      "description": "Schema version identifier"
+    },
+    "kind": {
+      "type": "string",
+      "title": "Kind",
+      "description": "Resource type"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta",
+      "title": "Metadata",
+      "description": "Resource metadata"
+    },
+    "spec": {
+      "$ref": "#/$defs/RuntimeConfigSpec",
+      "title": "Spec",
+      "description": "Runtime configuration specification"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptKit Runtime Configuration",
+  "description": "Environment-specific configuration for running a pack: providers, MCP servers, state store, logging, evals, and hooks",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "RuntimeConfig",
+      "metadata": {
+        "name": "production"
+      },
+      "spec": {
+        "logging": {
+          "defaultLevel": "info",
+          "format": "json"
+        },
+        "mcp_servers": [
+          {
+            "args": [
+              "-y",
+              "@anthropic/mcp-filesystem"
+            ],
+            "command": "npx",
+            "name": "filesystem"
+          }
+        ],
+        "providers": [
+          {
+            "credential": {
+              "credential_env": "OPENAI_API_KEY"
+            },
+            "id": "main",
+            "model": "gpt-4o",
+            "type": "openai"
+          }
+        ],
+        "state_store": {
+          "redis": {
+            "address": "localhost:6379"
+          },
+          "type": "redis"
+        }
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/schemas/scenario.json
+++ b/tools/arena/agentkb/schemas/scenario.json
@@ -1,0 +1,670 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/scenario.json",
+  "$defs": {
+    "AssertionConfig": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "enum": [
+                "a2a_eval",
+                "a2a_eval_session",
+                "agent_invoked",
+                "agent_not_invoked",
+                "agent_response_contains",
+                "answer_relevancy",
+                "assertion",
+                "audio_duration",
+                "audio_emotion",
+                "audio_format",
+                "banned_words",
+                "bias",
+                "composition_branch_taken",
+                "composition_output",
+                "composition_parallel_complete",
+                "composition_step_output",
+                "contains",
+                "contains_any",
+                "content_excludes",
+                "content_includes",
+                "content_includes_any",
+                "content_matches",
+                "content_not_includes",
+                "contextual_precision",
+                "contextual_recall",
+                "contextual_relevancy",
+                "cosine_similarity",
+                "cost_budget",
+                "directional",
+                "faithfulness",
+                "field_presence",
+                "guardrail",
+                "guardrail_triggered",
+                "hallucination",
+                "image_dimensions",
+                "image_format",
+                "image_moderation",
+                "invariant_fields_preserved",
+                "is_valid_json",
+                "json_path",
+                "json_schema",
+                "json_valid",
+                "latency_budget",
+                "length",
+                "llm_judge",
+                "llm_judge_conversation",
+                "llm_judge_session",
+                "llm_judge_tool_calls",
+                "max_length",
+                "max_sentences",
+                "min_length",
+                "no_tool_errors",
+                "outcome_equivalent",
+                "pii_leakage",
+                "regex",
+                "required_fields",
+                "rest_eval",
+                "rest_eval_session",
+                "role_violation",
+                "sentence_count",
+                "skill_activated",
+                "skill_activation_order",
+                "skill_not_activated",
+                "state_is",
+                "text_sentiment",
+                "text_toxicity",
+                "tool_anti_pattern",
+                "tool_args",
+                "tool_args_excluded_session",
+                "tool_args_session",
+                "tool_call_chain",
+                "tool_call_count",
+                "tool_call_sequence",
+                "tool_called",
+                "tool_calls_with_args",
+                "tool_efficiency",
+                "tool_exec",
+                "tool_no_repeat",
+                "tool_result_has_media",
+                "tool_result_includes",
+                "tool_result_matches",
+                "tool_result_media_type",
+                "tools_called",
+                "tools_called_session",
+                "tools_not_called",
+                "tools_not_called_session",
+                "tools_not_called_with_args",
+                "toxicity",
+                "transitioned_to",
+                "valid_json",
+                "video_duration",
+                "video_resolution",
+                "workflow_complete",
+                "workflow_tool_access",
+                "workflow_transition_order"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Handler type. PromptKit-known types are suggested, but values are not restricted to this list — a different runtime may define additional types."
+        },
+        "params": {
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "when": {
+          "$ref": "#/$defs/AssertionWhen"
+        },
+        "pass_threshold": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "AssertionWhen": {
+      "properties": {
+        "tool_called": {
+          "type": "string"
+        },
+        "tool_called_pattern": {
+          "type": "string"
+        },
+        "any_tool_called": {
+          "type": "boolean"
+        },
+        "min_tool_calls": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ChaosConfig": {
+      "properties": {
+        "tool_failures": {
+          "items": {
+            "$ref": "#/$defs/ChaosToolFailure"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ChaosToolFailure": {
+      "properties": {
+        "tool": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "probability": {
+          "type": "number"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool",
+        "mode"
+      ]
+    },
+    "ContextMetadata": {
+      "properties": {
+        "domain": {
+          "type": "string"
+        },
+        "user_role": {
+          "type": "string"
+        },
+        "project_stage": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ContextPolicy": {
+      "properties": {
+        "token_budget": {
+          "type": "integer"
+        },
+        "reserve_for_output": {
+          "type": "integer"
+        },
+        "strategy": {
+          "type": "string"
+        },
+        "cache_breakpoints": {
+          "type": "boolean"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DuplexConfig": {
+      "properties": {
+        "timeout": {
+          "type": "string"
+        },
+        "turn_detection": {
+          "$ref": "#/$defs/TurnDetectionConfig"
+        },
+        "resilience": {
+          "$ref": "#/$defs/DuplexResilienceConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DuplexResilienceConfig": {
+      "properties": {
+        "max_retries": {
+          "type": "integer"
+        },
+        "retry_delay_ms": {
+          "type": "integer"
+        },
+        "partial_success_min_turns": {
+          "type": "integer"
+        },
+        "ignore_last_turn_session_end": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RelevanceConfig": {
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "min_recent_messages": {
+          "type": "integer"
+        },
+        "always_keep_system_role": {
+          "type": "boolean"
+        },
+        "similarity_threshold": {
+          "type": "number"
+        },
+        "query_source": {
+          "type": "string"
+        },
+        "last_n_count": {
+          "type": "integer"
+        },
+        "custom_query": {
+          "type": "string"
+        },
+        "cache_embeddings": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider"
+      ]
+    },
+    "Scenario": {
+      "oneOf": [
+        {
+          "required": [
+            "task_type",
+            "turns"
+          ],
+          "description": "Regular conversation scenario"
+        },
+        {
+          "required": [
+            "pack",
+            "steps"
+          ],
+          "description": "Workflow scenario"
+        }
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "task_type": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "context_metadata": {
+          "$ref": "#/$defs/ContextMetadata"
+        },
+        "turns": {
+          "items": {
+            "$ref": "#/$defs/TurnDefinition"
+          },
+          "type": "array"
+        },
+        "context": {
+          "type": "object"
+        },
+        "constraints": {
+          "type": "object"
+        },
+        "tool_policy": {
+          "$ref": "#/$defs/ToolPolicy"
+        },
+        "providers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "provider_group": {
+          "type": "string"
+        },
+        "required_capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "streaming": {
+          "type": "boolean"
+        },
+        "context_policy": {
+          "$ref": "#/$defs/ContextPolicy"
+        },
+        "conversation_assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array"
+        },
+        "duplex": {
+          "$ref": "#/$defs/DuplexConfig"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "variables": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Template variables to inject into the pack"
+        },
+        "trials": {
+          "type": "integer",
+          "description": "Number of times to run this scenario for statistical evaluation"
+        },
+        "seed_memories": {
+          "items": {
+            "$ref": "#/$defs/SeedMemoryEntry"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description"
+      ]
+    },
+    "SeedMemoryEntry": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "number"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "content"
+      ]
+    },
+    "ToolPolicy": {
+      "properties": {
+        "tool_choice": {
+          "type": "string"
+        },
+        "max_tool_calls_per_turn": {
+          "type": "integer"
+        },
+        "max_total_tool_calls": {
+          "type": "integer"
+        },
+        "blocklist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool_choice",
+        "max_tool_calls_per_turn",
+        "max_total_tool_calls"
+      ]
+    },
+    "TurnContentPart": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/TurnMediaContent"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "TurnDefinition": {
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        },
+        "parts": {
+          "items": {
+            "$ref": "#/$defs/TurnContentPart"
+          },
+          "type": "array"
+        },
+        "persona": {
+          "type": "string"
+        },
+        "turns": {
+          "type": "integer"
+        },
+        "max_turns": {
+          "type": "integer"
+        },
+        "assistant_temp": {
+          "type": "number"
+        },
+        "user_temp": {
+          "type": "number"
+        },
+        "seed": {
+          "type": "integer"
+        },
+        "streaming": {
+          "type": "boolean"
+        },
+        "consent_overrides": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "perturbations": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "chaos": {
+          "$ref": "#/$defs/ChaosConfig"
+        },
+        "assertions": {
+          "items": {
+            "$ref": "#/$defs/AssertionConfig"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "role"
+      ]
+    },
+    "TurnDetectionConfig": {
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "vad": {
+          "$ref": "#/$defs/VADConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TurnMediaContent": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "data": {
+          "type": "string"
+        },
+        "storage_reference": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "VADConfig": {
+      "properties": {
+        "silence_threshold_ms": {
+          "type": "integer"
+        },
+        "min_speech_ms": {
+          "type": "integer"
+        },
+        "max_turn_duration_s": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/Scenario"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptArena Scenario Configuration",
+  "description": "Scenario configuration for PromptArena test cases",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "Scenario",
+      "metadata": {
+        "name": "test-scenario"
+      },
+      "spec": {
+        "description": "Test scenario",
+        "id": "test-1",
+        "task_type": "general",
+        "turns": [
+          {
+            "content": "Hello",
+            "role": "user"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/schemas/tool.json
+++ b/tools/arena/agentkb/schemas/tool.json
@@ -1,0 +1,379 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://promptkit.altairalabs.ai/schemas/v1alpha1/tool.json",
+  "$defs": {
+    "ExecBinding": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "title": "Command",
+          "description": "Path to the executable"
+        },
+        "runtime": {
+          "type": "string",
+          "enum": [
+            "exec",
+            "server"
+          ],
+          "title": "Runtime",
+          "description": "Execution mode",
+          "default": "exec"
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Env",
+          "description": "Required environment variable names"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Args",
+          "description": "Additional command arguments"
+        },
+        "timeout_ms": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "Per-invocation timeout in milliseconds"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox",
+          "description": "Name of a sandbox declared under spec.sandboxes"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command"
+      ]
+    },
+    "HTTPConfig": {
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "headers_from_env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "redact": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "request": {
+          "$ref": "#/$defs/RequestMapping"
+        },
+        "response": {
+          "$ref": "#/$defs/ResponseMapping"
+        },
+        "multimodal": {
+          "$ref": "#/$defs/MultimodalConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "url",
+        "method",
+        "timeout_ms"
+      ]
+    },
+    "MockMediaSpec": {
+      "properties": {
+        "file_path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "caption": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mime_type"
+      ]
+    },
+    "MockPartSpec": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "media": {
+          "$ref": "#/$defs/MockMediaSpec"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "MultimodalConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "accept_types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the resource"
+        },
+        "namespace": {
+          "type": "string",
+          "title": "Namespace",
+          "description": "Namespace for the resource"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Labels",
+          "description": "Key-value pairs for organizing resources"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional metadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RequestMapping": {
+      "properties": {
+        "query_params": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "header_params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "body_mapping": {
+          "type": "string"
+        },
+        "exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "static_query": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "static_headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "static_body": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ResponseMapping": {
+      "properties": {
+        "body_mapping": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolClientConfig": {
+      "properties": {
+        "consent": {
+          "$ref": "#/$defs/ToolConsentConfig"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "categories": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "validate_output": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolConsentConfig": {
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "decline_strategy": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "required"
+      ]
+    },
+    "ToolSpec": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "input_schema": true,
+        "output_schema": true,
+        "mode": {
+          "type": "string",
+          "description": "Execution mode. One of: 'mock' (use mock_result or mock_template) - 'live' (HTTP via 'http') - 'mcp' (MCP server) - 'exec' (subprocess) - 'client' (client-side handler)."
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "mock_result": {
+          "description": "Static mock response returned regardless of tool-call args. Use when the response does not depend on inputs. Mutually exclusive with mock_template."
+        },
+        "mock_template": {
+          "type": "string",
+          "description": "Go text/template rendered against tool-call args (parsed as a JSON map). Rendered output is parsed back as JSON. Use this instead of mock_result when the response should depend on inputs (e.g. branching on order_id with {{ if eq .order_id \"X\" }}...{{ end }}). Mutually exclusive with mock_result."
+        },
+        "mock_parts": {
+          "items": {
+            "$ref": "#/$defs/MockPartSpec"
+          },
+          "type": "array"
+        },
+        "http": {
+          "$ref": "#/$defs/HTTPConfig"
+        },
+        "exec": {
+          "$ref": "#/$defs/ExecBinding"
+        },
+        "client": {
+          "$ref": "#/$defs/ToolClientConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description",
+        "input_schema",
+        "output_schema",
+        "mode"
+      ]
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/ObjectMeta"
+    },
+    "spec": {
+      "$ref": "#/$defs/ToolSpec"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference URL"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "spec"
+  ],
+  "title": "PromptKit Tool Configuration",
+  "description": "Tool/function configuration for PromptKit",
+  "examples": [
+    {
+      "apiVersion": "promptkit.altairalabs.ai/v1alpha1",
+      "kind": "Tool",
+      "metadata": {
+        "name": "weather-tool"
+      },
+      "spec": {
+        "description": "Get current weather",
+        "mode": "mock",
+        "name": "get_weather"
+      }
+    }
+  ]
+}

--- a/tools/arena/agentkb/skill.go
+++ b/tools/arena/agentkb/skill.go
@@ -1,0 +1,63 @@
+package agentkb
+
+import (
+	"bytes"
+	"strings"
+)
+
+const skillFrontmatter = `---
+name: promptarena-authoring
+description: Author valid PromptArena kit configs; use when building or editing scenarios, providers, prompts, tools.
+---
+`
+
+const skillIntro = "Generated from the PromptArena agent knowledge base. " +
+	"Run `promptarena schema <type>` for authoritative config structure and " +
+	"`promptarena validate` to check your work.\n\n"
+
+// Skill assembles a SKILL.md from the embedded concepts. Concepts are the only
+// authored source, so the skill can never drift from them.
+func Skill() ([]byte, error) {
+	cs, err := Concepts()
+	if err != nil {
+		return nil, err
+	}
+	var b bytes.Buffer
+	b.WriteString(skillFrontmatter)
+	b.WriteString("\n# Authoring PromptArena Kits\n\n")
+	b.WriteString(skillIntro)
+	for _, c := range cs {
+		b.WriteString("## ")
+		b.WriteString(c.Title)
+		b.WriteString("\n\n")
+		b.WriteString(c.Body)
+		if !strings.HasSuffix(c.Body, "\n") {
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+	}
+	return b.Bytes(), nil
+}
+
+// AgentsBrief returns the cross-agent AGENTS.md shim written into a scaffolded
+// project. The marker comment lets init detect a prior brief and avoid duplicating.
+func AgentsBrief() []byte {
+	return []byte(agentsBrief)
+}
+
+const agentsBrief = `<!-- promptarena-authoring -->
+# PromptArena — notes for AI coding agents
+
+You are working in a PromptArena kit. Before authoring configs:
+
+- Read the authoring skill at ` + "`.claude/skills/promptarena-authoring/SKILL.md`" + `.
+- Run ` + "`promptarena schema <type>`" + ` for the authoritative structure of a
+  scenario, provider, prompt, tool, or arena config. The embedded schema is the
+  version this binary's ` + "`promptarena validate`" + ` enforces — prefer it over
+  any web copy.
+- Run ` + "`promptarena validate`" + ` to check your work before ` + "`promptarena run`" + `.
+- Mock providers simulate the LLM only; tools execute for real. Mock response keys
+  match the scenario's ` + "`metadata.name`" + `, not ` + "`spec.id`" + `.
+- Assertions apply thresholds; eval handlers emit raw scores. Keep thresholds on the
+  ` + "`type: assertion`" + ` wrapper, never on the eval.
+`

--- a/tools/arena/agentkb/skill_test.go
+++ b/tools/arena/agentkb/skill_test.go
@@ -1,0 +1,28 @@
+package agentkb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkill_AssembledFromConcepts(t *testing.T) {
+	b, err := Skill()
+	require.NoError(t, err)
+	s := string(b)
+
+	assert.True(t, strings.HasPrefix(s, "---\n"), "skill must start with frontmatter")
+	assert.Contains(t, s, "name: promptarena-authoring")
+	// Every concept title appears as a section heading.
+	cs, err := Concepts()
+	require.NoError(t, err)
+	for _, c := range cs {
+		assert.Contains(t, s, "## "+c.Title)
+	}
+}
+
+func TestAgentsBrief_HasMarker(t *testing.T) {
+	assert.Contains(t, string(AgentsBrief()), "<!-- promptarena-authoring -->")
+}

--- a/tools/arena/cmd/promptarena/agent_brief.go
+++ b/tools/arena/cmd/promptarena/agent_brief.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
+	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
+)
+
+const agentBriefMarker = "<!-- promptarena-authoring -->"
+
+const (
+	skillDirPerm  = 0o750
+	briefFilePerm = 0o600
+)
+
+var skillRelPath = filepath.Join(".claude", "skills", "promptarena-authoring", "SKILL.md")
+
+// writeAgentBrief drops the PromptArena authoring skill and an AGENTS.md shim into
+// a freshly scaffolded project so an AI coding agent starts briefed. Relative paths
+// of files actually written are appended to result.FilesCreated.
+func writeAgentBrief(result *templates.GenerationResult) error {
+	skill, err := agentkb.Skill()
+	if err != nil {
+		return fmt.Errorf("assemble skill: %w", err)
+	}
+	skillPath := filepath.Join(result.ProjectPath, skillRelPath)
+	if err = os.MkdirAll(filepath.Dir(skillPath), skillDirPerm); err != nil {
+		return fmt.Errorf("create skill dir: %w", err)
+	}
+	if err = os.WriteFile(skillPath, skill, briefFilePerm); err != nil {
+		return fmt.Errorf("write skill: %w", err)
+	}
+	result.FilesCreated = append(result.FilesCreated, skillRelPath)
+
+	rel, err := writeAgentsFile(result.ProjectPath)
+	if err != nil {
+		return err
+	}
+	if rel != "" {
+		result.FilesCreated = append(result.FilesCreated, rel)
+	}
+	return nil
+}
+
+// writeAgentsFile creates AGENTS.md, or appends the brief to an existing one. It
+// returns the relative path when it wrote, or "" when an existing file already
+// carried the brief. It never clobbers hand-written content.
+func writeAgentsFile(projectPath string) (string, error) {
+	const rel = "AGENTS.md"
+	path := filepath.Join(projectPath, rel)
+	brief := agentkb.AgentsBrief()
+
+	existing, err := os.ReadFile(path) //nolint:gosec // path is under the just-created project dir
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		if err = os.WriteFile(path, brief, briefFilePerm); err != nil {
+			return "", fmt.Errorf("write AGENTS.md: %w", err)
+		}
+		return rel, nil
+	case err != nil:
+		return "", fmt.Errorf("read AGENTS.md: %w", err)
+	default:
+		if bytes.Contains(existing, []byte(agentBriefMarker)) {
+			return "", nil
+		}
+		merged := append(append([]byte{}, existing...), '\n')
+		merged = append(merged, brief...)
+		//nolint:gosec // path is under the just-created project dir
+		if err = os.WriteFile(path, merged, briefFilePerm); err != nil {
+			return "", fmt.Errorf("append AGENTS.md: %w", err)
+		}
+		return rel, nil
+	}
+}

--- a/tools/arena/cmd/promptarena/agent_brief_test.go
+++ b/tools/arena/cmd/promptarena/agent_brief_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
+)
+
+func TestWriteAgentBrief_CreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	res := &templates.GenerationResult{ProjectPath: dir, Success: true}
+
+	require.NoError(t, writeAgentBrief(res))
+
+	skill := filepath.Join(dir, ".claude", "skills", "promptarena-authoring", "SKILL.md")
+	assert.FileExists(t, skill)
+	agents := filepath.Join(dir, "AGENTS.md")
+	assert.FileExists(t, agents)
+
+	assert.Contains(t, res.FilesCreated, filepath.Join(".claude", "skills", "promptarena-authoring", "SKILL.md"))
+	assert.Contains(t, res.FilesCreated, "AGENTS.md")
+}
+
+func TestWriteAgentBrief_AppendsWhenAgentsExists(t *testing.T) {
+	dir := t.TempDir()
+	existing := "# My project\n\nhand-written notes\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(existing), 0o644))
+
+	res := &templates.GenerationResult{ProjectPath: dir, Success: true}
+	require.NoError(t, writeAgentBrief(res))
+
+	got, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "hand-written notes", "must not clobber existing content")
+	assert.Contains(t, string(got), "<!-- promptarena-authoring -->", "must append the brief")
+}
+
+func TestWriteAgentBrief_ErrorsWhenAgentsUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	// A directory at the AGENTS.md path makes os.ReadFile fail with a non-NotExist
+	// error, exercising the read-error branch.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "AGENTS.md"), 0o755))
+
+	res := &templates.GenerationResult{ProjectPath: dir, Success: true}
+	require.Error(t, writeAgentBrief(res))
+}
+
+func TestWriteAgentBrief_IdempotentOnRerun(t *testing.T) {
+	dir := t.TempDir()
+	res := &templates.GenerationResult{ProjectPath: dir, Success: true}
+	require.NoError(t, writeAgentBrief(res))
+	first, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+
+	res2 := &templates.GenerationResult{ProjectPath: dir, Success: true}
+	require.NoError(t, writeAgentBrief(res2))
+	second, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second), "re-run must not duplicate the brief")
+	assert.NotContains(t, res2.FilesCreated, "AGENTS.md", "unchanged AGENTS.md not reported as created")
+}

--- a/tools/arena/cmd/promptarena/init.go
+++ b/tools/arena/cmd/promptarena/init.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -37,6 +36,8 @@ Examples:
 	RunE: runInit,
 }
 
+const projectNameVar = "project_name"
+
 var (
 	initTemplate      string
 	initQuick         bool
@@ -48,6 +49,7 @@ var (
 	initTemplateCache string
 	initRepoConfig    string
 	initVerbose       bool
+	initNoAgent       bool
 )
 
 func init() {
@@ -66,6 +68,8 @@ func init() {
 		"Template repo config file")
 	initCmd.Flags().StringVar(&initTemplateCache, "template-cache", templates.DefaultCacheDir(),
 		"Cache directory for remote templates")
+	initCmd.Flags().BoolVar(&initNoAgent, "no-agent", false,
+		"Skip writing the AI-agent brief (.claude skill + AGENTS.md)")
 
 	// Register dynamic completions (must be after flags are defined)
 	RegisterInitCompletions()
@@ -104,8 +108,18 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to generate project: %w", err)
 	}
 
+	// Brief any AI coding agent that opens this project (unless opted out).
+	agentBriefed := false
+	if !initNoAgent && result.Success {
+		if briefErr := writeAgentBrief(result); briefErr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("agent brief: %v", briefErr))
+		} else {
+			agentBriefed = true
+		}
+	}
+
 	// Display results
-	printSuccessMessage(projectName, result)
+	printSuccessMessage(projectName, result, agentBriefed)
 
 	return nil
 }
@@ -138,7 +152,7 @@ func collectConfiguration(cmd *cobra.Command, tmpl *templates.Template, projectN
 		Verbose:     initVerbose,
 	}
 
-	config.Variables["project_name"] = projectName
+	config.Variables[projectNameVar] = projectName
 
 	if initQuick {
 		return collectQuickModeVariables(config, tmpl)
@@ -149,7 +163,7 @@ func collectConfiguration(cmd *cobra.Command, tmpl *templates.Template, projectN
 
 func collectQuickModeVariables(config *templates.TemplateConfig, tmpl *templates.Template) (*templates.TemplateConfig, error) {
 	for _, v := range tmpl.Spec.Variables {
-		if v.Name == "project_name" {
+		if v.Name == projectNameVar {
 			continue
 		}
 		if v.Default != nil {
@@ -172,149 +186,7 @@ func applyCommandLineOverrides(config *templates.TemplateConfig) {
 	}
 }
 
-func collectInteractiveVariables(config *templates.TemplateConfig, tmpl *templates.Template) (*templates.TemplateConfig, error) {
-	fmt.Println("🏟️  Welcome to PromptArena!")
-	fmt.Println()
-	fmt.Println("Let's set up your testing project.")
-	fmt.Println()
-
-	for _, v := range tmpl.Spec.Variables {
-		if v.Name == "project_name" {
-			continue
-		}
-
-		value, err := promptForVariable(v)
-		if err != nil {
-			return nil, err
-		}
-		config.Variables[v.Name] = value
-	}
-
-	return config, nil
-}
-
-func promptForVariable(v templates.Variable) (interface{}, error) {
-	promptText := buildPromptText(v)
-
-	switch v.Type {
-	case "boolean":
-		return promptForBoolean(promptText)
-	case "select":
-		return promptForSelect(promptText, v)
-	case "array":
-		return promptForArray(promptText, v)
-	default:
-		return promptForString(promptText, v)
-	}
-}
-
-func buildPromptText(v templates.Variable) string {
-	promptText := v.Prompt
-	if promptText == "" {
-		promptText = v.Name
-	}
-	if v.Description != "" {
-		promptText = fmt.Sprintf("%s (%s)", promptText, v.Description)
-	}
-	return promptText
-}
-
-func promptForBoolean(promptText string) (interface{}, error) {
-	prompt := promptui.Prompt{
-		Label:     promptText,
-		IsConfirm: true,
-	}
-	_, err := prompt.Run()
-	if err != nil && err != promptui.ErrAbort {
-		return nil, err
-	}
-	return err != promptui.ErrAbort, nil
-}
-
-func promptForSelect(promptText string, v templates.Variable) (interface{}, error) {
-	prompt := promptui.Select{
-		Label: promptText,
-		Items: v.Options,
-	}
-	if v.Default != nil {
-		defaultStr := fmt.Sprintf("%v", v.Default)
-		for i, opt := range v.Options {
-			if opt == defaultStr {
-				prompt.CursorPos = i
-				break
-			}
-		}
-	}
-	_, result, err := prompt.Run()
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func promptForArray(promptText string, v templates.Variable) (interface{}, error) {
-	defaultStr := getArrayDefaultString(v)
-	prompt := promptui.Prompt{
-		Label:   promptText + " (comma-separated)",
-		Default: defaultStr,
-	}
-	result, err := prompt.Run()
-	if err != nil {
-		return nil, err
-	}
-
-	items := strings.Split(result, ",")
-	for i := range items {
-		items[i] = strings.TrimSpace(items[i])
-	}
-	return items, nil
-}
-
-func getArrayDefaultString(v templates.Variable) string {
-	if v.Default == nil {
-		return ""
-	}
-	if arr, ok := v.Default.([]interface{}); ok {
-		strs := make([]string, len(arr))
-		for i, item := range arr {
-			strs[i] = fmt.Sprintf("%v", item)
-		}
-		return strings.Join(strs, ",")
-	}
-	return ""
-}
-
-func promptForString(promptText string, v templates.Variable) (interface{}, error) {
-	defaultStr := ""
-	if v.Default != nil {
-		defaultStr = fmt.Sprintf("%v", v.Default)
-	}
-
-	prompt := promptui.Prompt{
-		Label:   promptText,
-		Default: defaultStr,
-	}
-	result, err := prompt.Run()
-	if err != nil {
-		return nil, err
-	}
-
-	if v.Type == "number" {
-		return parseNumber(result)
-	}
-
-	return result, nil
-}
-
-func parseNumber(result string) (interface{}, error) {
-	var num float64
-	if n, _ := fmt.Sscanf(result, "%f", &num); n == 1 {
-		return num, nil
-	}
-	return result, nil
-}
-
-func printSuccessMessage(projectName string, result *templates.GenerationResult) {
+func printSuccessMessage(projectName string, result *templates.GenerationResult, agentBriefed bool) {
 	fmt.Println()
 	fmt.Println("✨ Created", projectName+"/")
 	fmt.Println()
@@ -332,6 +204,12 @@ func printSuccessMessage(projectName string, result *templates.GenerationResult)
 		for _, warning := range result.Warnings {
 			fmt.Printf("   - %s\n", warning)
 		}
+		fmt.Println()
+	}
+
+	if agentBriefed {
+		fmt.Println("📎 AI-agent brief written (.claude/skills + AGENTS.md) —")
+		fmt.Println("   open this folder in Claude Code or Codex and it'll know PromptArena conventions.")
 		fmt.Println()
 	}
 

--- a/tools/arena/cmd/promptarena/init_interactive.go
+++ b/tools/arena/cmd/promptarena/init_interactive.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
+)
+
+func collectInteractiveVariables(
+	config *templates.TemplateConfig, tmpl *templates.Template,
+) (*templates.TemplateConfig, error) {
+	fmt.Println("🏟️  Welcome to PromptArena!")
+	fmt.Println()
+	fmt.Println("Let's set up your testing project.")
+	fmt.Println()
+
+	for i := range tmpl.Spec.Variables {
+		v := &tmpl.Spec.Variables[i]
+		if v.Name == projectNameVar {
+			continue
+		}
+
+		value, err := promptForVariable(v)
+		if err != nil {
+			return nil, err
+		}
+		config.Variables[v.Name] = value
+	}
+
+	return config, nil
+}
+
+func promptForVariable(v *templates.Variable) (interface{}, error) {
+	promptText := buildPromptText(v)
+
+	switch v.Type {
+	case "boolean":
+		return promptForBoolean(promptText)
+	case "select":
+		return promptForSelect(promptText, v)
+	case "array":
+		return promptForArray(promptText, v)
+	default:
+		return promptForString(promptText, v)
+	}
+}
+
+func buildPromptText(v *templates.Variable) string {
+	promptText := v.Prompt
+	if promptText == "" {
+		promptText = v.Name
+	}
+	if v.Description != "" {
+		promptText = fmt.Sprintf("%s (%s)", promptText, v.Description)
+	}
+	return promptText
+}
+
+func promptForBoolean(promptText string) (interface{}, error) {
+	prompt := promptui.Prompt{
+		Label:     promptText,
+		IsConfirm: true,
+	}
+	_, err := prompt.Run()
+	if err != nil && err != promptui.ErrAbort {
+		return nil, err
+	}
+	return err != promptui.ErrAbort, nil
+}
+
+func promptForSelect(promptText string, v *templates.Variable) (interface{}, error) {
+	prompt := promptui.Select{
+		Label: promptText,
+		Items: v.Options,
+	}
+	if v.Default != nil {
+		defaultStr := fmt.Sprintf("%v", v.Default)
+		for i, opt := range v.Options {
+			if opt == defaultStr {
+				prompt.CursorPos = i
+				break
+			}
+		}
+	}
+	_, result, err := prompt.Run()
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func promptForArray(promptText string, v *templates.Variable) (interface{}, error) {
+	defaultStr := getArrayDefaultString(v)
+	prompt := promptui.Prompt{
+		Label:   promptText + " (comma-separated)",
+		Default: defaultStr,
+	}
+	result, err := prompt.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	items := strings.Split(result, ",")
+	for i := range items {
+		items[i] = strings.TrimSpace(items[i])
+	}
+	return items, nil
+}
+
+func getArrayDefaultString(v *templates.Variable) string {
+	if v.Default == nil {
+		return ""
+	}
+	if arr, ok := v.Default.([]interface{}); ok {
+		strs := make([]string, len(arr))
+		for i, item := range arr {
+			strs[i] = fmt.Sprintf("%v", item)
+		}
+		return strings.Join(strs, ",")
+	}
+	return ""
+}
+
+func promptForString(promptText string, v *templates.Variable) (interface{}, error) {
+	defaultStr := ""
+	if v.Default != nil {
+		defaultStr = fmt.Sprintf("%v", v.Default)
+	}
+
+	prompt := promptui.Prompt{
+		Label:   promptText,
+		Default: defaultStr,
+	}
+	result, err := prompt.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	if v.Type == "number" {
+		return parseNumber(result)
+	}
+
+	return result, nil
+}
+
+func parseNumber(result string) (interface{}, error) {
+	var num float64
+	if n, _ := fmt.Sscanf(result, "%f", &num); n == 1 {
+		return num, nil
+	}
+	return result, nil
+}

--- a/tools/arena/cmd/promptarena/init_test.go
+++ b/tools/arena/cmd/promptarena/init_test.go
@@ -262,7 +262,7 @@ func TestBuildPromptText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildPromptText(tt.variable)
+			result := buildPromptText(&tt.variable)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -320,7 +320,7 @@ func TestGetArrayDefaultString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getArrayDefaultString(tt.variable)
+			result := getArrayDefaultString(&tt.variable)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -457,10 +457,12 @@ func TestPrintSuccessMessage(t *testing.T) {
 		name        string
 		projectName string
 		result      *templates.GenerationResult
+		briefed     bool
 	}{
 		{
 			name:        "basic success",
 			projectName: "test-project",
+			briefed:     true,
 			result: &templates.GenerationResult{
 				FilesCreated: []string{"arena.yaml", "prompts/test.yaml"},
 				Warnings:     []string{},
@@ -488,7 +490,7 @@ func TestPrintSuccessMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Should not panic
 			assert.NotPanics(t, func() {
-				printSuccessMessage(tt.projectName, tt.result)
+				printSuccessMessage(tt.projectName, tt.result, tt.briefed)
 			})
 		})
 	}


### PR DESCRIPTION
## Summary

First slice of the agent-driven kit authoring effort (epic #1393): the keystone embedded knowledge base plus Phase A, so an npm-installed `promptarena` can brief an AI coding agent that opens a freshly scaffolded kit.

The binding constraint: the CLI ships via npm, so the agent starts cold — none of this repo's examples/idioms/skills reach the user's project. The only reliable touchpoint is `promptarena init`. This PR makes the binary itself the delivery vehicle.

## What's in this PR

**Keystone — `tools/arena/agentkb/` (#1389)**
- `concepts/*.md` — the single hand-authored knowledge source (mock providers, assertions-vs-evals, schema validation), with `Concepts()` / `ConceptByID()` accessors.
- `Skill()` assembles a `SKILL.md` from the concepts (so it can never drift) + `AgentsBrief()` shim.
- Embedded **version-locked JSON schemas** with `Schema()` / `SchemaNames()` and a **parity test** asserting the embedded copies byte-match `schemas/v1alpha1/` — the binary can never ship a schema that disagrees with its own `validate`.
- `catalog.yaml` indexing the 6 embedded builtin templates + an agentkb-lint test (every concept-ref and source resolves).

**Phase A — `init` writes the brief (#1390)**
- After a successful scaffold, `promptarena init` writes `.claude/skills/promptarena-authoring/SKILL.md` and a cross-agent `AGENTS.md`.
- On by default; opt out with `--no-agent`. Appends (never clobbers) an existing `AGENTS.md`; idempotent on re-run via a marker comment.
- Untestable `promptui` helpers moved to `init_interactive.go` per repo convention.

## Verification

- Full `agentkb` + `cmd/promptarena` suites pass; all changed files clear the 80% coverage gate; lint clean.
- Live smoke test: `promptarena init --quick` writes both brief files; `SKILL.md` assembles cleanly from all three concepts.

## Not in this PR (follow-ups)

- Phase B — `explain` / `examples` / `schema` discovery commands + `--json` (#1391)
- Phase C — `promptarena mcp` stdio server (#1392)
- A make/CI target to auto-regenerate `agentkb/schemas/` from `schemas/v1alpha1/` (parity test is the safety net until then)

Closes #1389
Closes #1390
