### PR TITLE
feat(arena): agentkb discovery commands — explain/examples/schema + validate --json (Phase B)

### DIFF
--- a/tools/arena/agentkb/catalog.go
+++ b/tools/arena/agentkb/catalog.go
@@ -12,11 +12,11 @@ var catalogFS embed.FS
 
 // CatalogEntry indexes one example/template the agent can discover.
 type CatalogEntry struct {
-	Name        string   `yaml:"name"`
-	Description string   `yaml:"description"`
-	Source      string   `yaml:"source"` // "builtin:<name>" or "remote:<ref>"
-	Concepts    []string `yaml:"concepts"`
-	Tags        []string `yaml:"tags"`
+	Name        string   `yaml:"name" json:"name"`
+	Description string   `yaml:"description" json:"description"`
+	Source      string   `yaml:"source" json:"source"` // "builtin:<name>" or "remote:<ref>"
+	Concepts    []string `yaml:"concepts" json:"concepts"`
+	Tags        []string `yaml:"tags" json:"tags"`
 }
 
 // Catalog is the embedded example index.

--- a/tools/arena/agentkb/skill.go
+++ b/tools/arena/agentkb/skill.go
@@ -12,6 +12,7 @@ description: Author valid PromptArena kit configs; use when building or editing 
 `
 
 const skillIntro = "Generated from the PromptArena agent knowledge base. " +
+	"Discover more with `promptarena explain --list` and `promptarena examples list`. " +
 	"Run `promptarena schema <type>` for authoritative config structure and " +
 	"`promptarena validate` to check your work.\n\n"
 
@@ -51,6 +52,9 @@ const agentsBrief = `<!-- promptarena-authoring -->
 You are working in a PromptArena kit. Before authoring configs:
 
 - Read the authoring skill at ` + "`.claude/skills/promptarena-authoring/SKILL.md`" + `.
+- Discover idioms and examples on demand:
+  ` + "`promptarena explain --list`" + `, ` + "`promptarena explain <id>`" + `,
+  ` + "`promptarena examples list`" + `, ` + "`promptarena examples show <name>`" + `.
 - Run ` + "`promptarena schema <type>`" + ` for the authoritative structure of a
   scenario, provider, prompt, tool, or arena config. The embedded schema is the
   version this binary's ` + "`promptarena validate`" + ` enforces — prefer it over

--- a/tools/arena/cmd/promptarena/examples_cmd.go
+++ b/tools/arena/cmd/promptarena/examples_cmd.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
+	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
+)
+
+// exampleLoader is the subset of templates.Loader that examples show needs.
+type exampleLoader interface {
+	Load(name string) (*templates.Template, error)
+	ReadTemplateFile(templateName, filePath string) ([]byte, error)
+}
+
+const examplesListUse = "list"
+
+var (
+	examplesTagFlag  string
+	examplesJSONFlag bool
+)
+
+var examplesCmd = &cobra.Command{
+	Use:   "examples",
+	Short: "Discover example PromptArena kits",
+}
+
+var examplesListCmd = &cobra.Command{
+	Use:   examplesListUse,
+	Short: "List example kits from the embedded catalog",
+	Long: `List example kits the agent can copy from. Reads the embedded catalog,
+so it works offline.
+
+Examples:
+  promptarena examples list
+  promptarena examples list --tag mcp
+  promptarena examples list --json`,
+	RunE: runExamplesList,
+}
+
+var examplesShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Print an example kit's files",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runExamplesShow,
+}
+
+func init() {
+	rootCmd.AddCommand(examplesCmd)
+	examplesCmd.AddCommand(examplesListCmd, examplesShowCmd)
+	examplesListCmd.Flags().StringVar(&examplesTagFlag, "tag", "", "Filter by tag")
+	examplesListCmd.Flags().BoolVar(&examplesJSONFlag, "json", false, "Output JSON")
+}
+
+func runExamplesList(cmd *cobra.Command, _ []string) error {
+	return writeExamplesList(cmd.OutOrStdout(), examplesTagFlag, examplesJSONFlag)
+}
+
+func runExamplesShow(cmd *cobra.Command, args []string) error {
+	return writeExampleShow(cmd.OutOrStdout(), templates.NewLoader(""), args[0])
+}
+
+func writeExamplesList(w io.Writer, tag string, asJSON bool) error {
+	cat, err := agentkb.LoadCatalog()
+	if err != nil {
+		return err
+	}
+
+	entries := cat.Entries
+	if tag != "" {
+		filtered := entries[:0:0]
+		for _, e := range entries {
+			if containsString(e.Tags, tag) {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
+	}
+
+	tw := tabwriter.NewWriter(w, tabMinWidth, tabWidth, tabPadding, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NAME\tTAGS\tDESCRIPTION"); err != nil {
+		return err
+	}
+	for i := range entries {
+		e := &entries[i]
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", e.Name, strings.Join(e.Tags, ","), e.Description); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func writeExampleShow(w io.Writer, loader exampleLoader, name string) error {
+	cat, err := agentkb.LoadCatalog()
+	if err != nil {
+		return err
+	}
+
+	var entry *agentkb.CatalogEntry
+	for i := range cat.Entries {
+		if cat.Entries[i].Name == name {
+			entry = &cat.Entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		return fmt.Errorf("unknown example %q (try 'promptarena examples list')", name)
+	}
+
+	loadName := entry.Source
+	if idx := strings.IndexByte(loadName, ':'); idx >= 0 {
+		loadName = loadName[idx+1:]
+	}
+
+	tmpl, err := loader.Load(loadName)
+	if err != nil {
+		return fmt.Errorf("load example %q: %w", name, err)
+	}
+
+	if _, err := fmt.Fprintf(w, "# %s\n\n%s\n\nFiles:\n", entry.Name, entry.Description); err != nil {
+		return err
+	}
+	for i := range tmpl.Spec.Files {
+		f := &tmpl.Spec.Files[i]
+		if _, err := fmt.Fprintf(w, "\n--- %s ---\n", f.Path); err != nil {
+			return err
+		}
+		body := fileBody(loader, tmpl.Metadata.Name, f)
+		if _, err := fmt.Fprintln(w, body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// fileBody returns the displayable body for a template file: inline content, the
+// embedded template source, or a placeholder when the body lives elsewhere
+// (external/remote source).
+func fileBody(loader exampleLoader, templateName string, f *templates.FileSpec) string {
+	switch {
+	case f.Content != "":
+		return f.Content
+	case f.Template != "":
+		data, err := loader.ReadTemplateFile(templateName, f.Template)
+		if err != nil {
+			return fmt.Sprintf("(template body unavailable: %v)", err)
+		}
+		return string(data)
+	default:
+		return "(external source — fetch the example to see this file)"
+	}
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/arena/cmd/promptarena/examples_cmd_test.go
+++ b/tools/arena/cmd/promptarena/examples_cmd_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
+)
+
+func TestWriteExamplesList_Table(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeExamplesList(&buf, "", false))
+	out := buf.String()
+	assert.Contains(t, out, "quick-start")
+	assert.Contains(t, out, "customer-support")
+}
+
+func TestWriteExamplesList_TagFilter(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeExamplesList(&buf, "mcp", false))
+	out := buf.String()
+	assert.Contains(t, out, "mcp-integration")
+	assert.NotContains(t, out, "quick-start")
+}
+
+func TestWriteExamplesList_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeExamplesList(&buf, "", true))
+
+	var entries []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entries))
+	require.NotEmpty(t, entries)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e["name"].(string))
+	}
+	assert.Contains(t, names, "quick-start")
+}
+
+func TestWriteExampleShow_Builtin(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeExampleShow(&buf, templates.NewLoader(""), "quick-start"))
+	out := buf.String()
+	assert.Contains(t, out, "# quick-start")
+	assert.Contains(t, out, "config.arena.yaml") // a generated file path
+}
+
+func TestWriteExampleShow_Unknown(t *testing.T) {
+	var buf bytes.Buffer
+	require.Error(t, writeExampleShow(&buf, templates.NewLoader(""), "does-not-exist"))
+}

--- a/tools/arena/cmd/promptarena/explain_cmd.go
+++ b/tools/arena/cmd/promptarena/explain_cmd.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
+)
+
+var explainListFlag bool
+
+var explainCmd = &cobra.Command{
+	Use:   "explain [concept-id]",
+	Short: "Explain a PromptArena authoring concept",
+	Long: `Print an authoring idiom from the embedded knowledge base — mock providers,
+assertions-vs-evals, schema validation, and more.
+
+Examples:
+  promptarena explain --list
+  promptarena explain mock-providers`,
+	RunE: runExplain,
+}
+
+func init() {
+	rootCmd.AddCommand(explainCmd)
+	explainCmd.Flags().BoolVar(&explainListFlag, "list", false, "List available concepts")
+}
+
+func runExplain(cmd *cobra.Command, args []string) error {
+	return writeExplain(cmd.OutOrStdout(), explainListFlag, args)
+}
+
+func writeExplain(w io.Writer, list bool, args []string) error {
+	if list {
+		concepts, err := agentkb.Concepts()
+		if err != nil {
+			return err
+		}
+		for _, c := range concepts {
+			if _, err := fmt.Fprintf(w, "%-24s %s\n", c.ID, c.Summary); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("concept id required (try --list)")
+	}
+
+	c, err := agentkb.ConceptByID(args[0])
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "# %s\n\n%s\n", c.Title, c.Body)
+	return err
+}

--- a/tools/arena/cmd/promptarena/explain_cmd_test.go
+++ b/tools/arena/cmd/promptarena/explain_cmd_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteExplain_List(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeExplain(&buf, true, nil))
+	out := buf.String()
+	// Lists id + summary for each concept.
+	assert.Contains(t, out, "mock-providers")
+	assert.Contains(t, out, "assertions-vs-evals")
+}
+
+func TestWriteExplain_Concept(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeExplain(&buf, false, []string{"mock-providers"}))
+	out := buf.String()
+	assert.Contains(t, out, "Mock providers simulate the LLM")
+	assert.Contains(t, out, "type: mock")
+}
+
+func TestWriteExplain_UnknownAndMissing(t *testing.T) {
+	var buf bytes.Buffer
+	require.Error(t, writeExplain(&buf, false, []string{"nope"}), "unknown id errors")
+	require.Error(t, writeExplain(&buf, false, nil), "missing id errors")
+}

--- a/tools/arena/cmd/promptarena/schema_cmd.go
+++ b/tools/arena/cmd/promptarena/schema_cmd.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
+)
+
+var schemaListFlag bool
+
+var schemaCmd = &cobra.Command{
+	Use:   "schema [type]",
+	Short: "Print the embedded JSON schema for a config type",
+	Long: `Print the authoritative JSON schema for a PromptArena config type
+(scenario, provider, promptconfig, tool, arena, ...). The schema is embedded in
+this binary and is the exact version 'promptarena validate' enforces — prefer it
+over the public web copy, which may be a different release.
+
+Examples:
+  promptarena schema --list
+  promptarena schema scenario`,
+	RunE: runSchema,
+}
+
+func init() {
+	rootCmd.AddCommand(schemaCmd)
+	schemaCmd.Flags().BoolVar(&schemaListFlag, "list", false, "List available schema types")
+}
+
+func runSchema(cmd *cobra.Command, args []string) error {
+	return writeSchema(cmd.OutOrStdout(), schemaListFlag, args)
+}
+
+func writeSchema(w io.Writer, list bool, args []string) error {
+	if list {
+		names, err := agentkb.SchemaNames()
+		if err != nil {
+			return err
+		}
+		for _, n := range names {
+			if _, err := fmt.Fprintln(w, n); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("schema type required (try --list)")
+	}
+
+	b, err := agentkb.Schema(args[0])
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}

--- a/tools/arena/cmd/promptarena/schema_cmd_test.go
+++ b/tools/arena/cmd/promptarena/schema_cmd_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteSchema_List(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeSchema(&buf, true, nil))
+	out := buf.String()
+	assert.Contains(t, out, "scenario")
+	assert.Contains(t, out, "provider")
+}
+
+func TestWriteSchema_Type(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeSchema(&buf, false, []string{"scenario"}))
+	assert.Contains(t, buf.String(), "$schema")
+}
+
+func TestWriteSchema_UnknownAndMissing(t *testing.T) {
+	var buf bytes.Buffer
+	require.Error(t, writeSchema(&buf, false, []string{"nope"}), "unknown type errors")
+	require.Error(t, writeSchema(&buf, false, nil), "missing type errors")
+}

--- a/tools/arena/cmd/promptarena/validate.go
+++ b/tools/arena/cmd/promptarena/validate.go
@@ -34,6 +34,7 @@ var (
 	validateType       string
 	validateVerbose    bool
 	validateSchemaOnly bool
+	validateJSONFlag   bool
 )
 
 func init() {
@@ -41,6 +42,7 @@ func init() {
 	validateCmd.Flags().StringVar(&validateType, "type", "auto", "Config type: auto, arena, scenario, provider, promptconfig, tool, persona")
 	validateCmd.Flags().BoolVar(&validateVerbose, "verbose", false, "Show detailed validation errors")
 	validateCmd.Flags().BoolVar(&validateSchemaOnly, "schema-only", false, "Only validate schema, skip business logic checks")
+	validateCmd.Flags().BoolVar(&validateJSONFlag, "json", false, "Emit the validation result as JSON")
 }
 
 func runValidate(cmd *cobra.Command, args []string) error {
@@ -49,6 +51,10 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	}
 
 	filePath := args[0]
+	if validateJSONFlag {
+		return writeValidateJSON(cmd.OutOrStdout(), filePath, validateType)
+	}
+
 	if err := runValidationChecks(filePath, validateType, validateVerbose, validateSchemaOnly); err != nil {
 		return err
 	}

--- a/tools/arena/cmd/promptarena/validate_json.go
+++ b/tools/arena/cmd/promptarena/validate_json.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+// validateJSONError is the machine-readable form of one schema error.
+type validateJSONError struct {
+	Field       string   `json:"field"`
+	Description string   `json:"description"`
+	Keyword     string   `json:"keyword,omitempty"`
+	Suggestions []string `json:"suggestions,omitempty"`
+}
+
+// validateJSONReport is the structured result emitted by `validate --json`.
+type validateJSONReport struct {
+	File   string              `json:"file"`
+	Type   string              `json:"type"`
+	Valid  bool                `json:"valid"`
+	Errors []validateJSONError `json:"errors"`
+}
+
+func buildValidateReport(file, configType string, result *config.SchemaValidationResult) validateJSONReport {
+	report := validateJSONReport{
+		File:   file,
+		Type:   configType,
+		Valid:  result.Valid,
+		Errors: []validateJSONError{},
+	}
+	for _, e := range result.Errors {
+		report.Errors = append(report.Errors, validateJSONError{
+			Field:       e.Field,
+			Description: e.Description,
+			Keyword:     e.Keyword,
+			Suggestions: e.Suggestions,
+		})
+	}
+	return report
+}
+
+// writeValidateJSON runs schema validation and writes a JSON report. It returns a
+// non-nil error when validation fails so the process exits non-zero, while still
+// emitting the JSON report to w first.
+func writeValidateJSON(w io.Writer, filePath, typeOption string) error {
+	data, configType, err := prepareValidationWithType(filePath, typeOption)
+	if err != nil {
+		return err
+	}
+
+	result, err := validateWithSchema(data, config.ConfigType(configType))
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(buildValidateReport(filePath, configType, result)); err != nil {
+		return err
+	}
+
+	if !result.Valid {
+		return fmt.Errorf("schema validation failed with %d error(s)", len(result.Errors))
+	}
+	return nil
+}

--- a/tools/arena/cmd/promptarena/validate_json_test.go
+++ b/tools/arena/cmd/promptarena/validate_json_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+func TestBuildValidateReport_MapsErrors(t *testing.T) {
+	result := &config.SchemaValidationResult{
+		Valid: false,
+		Errors: []config.SchemaValidationError{
+			{Field: "spec.x", Description: "bad", Keyword: "enum", Suggestions: []string{"y"}},
+		},
+	}
+	report := buildValidateReport("f.yaml", "arena", result)
+	assert.Equal(t, "f.yaml", report.File)
+	assert.Equal(t, "arena", report.Type)
+	assert.False(t, report.Valid)
+	require.Len(t, report.Errors, 1)
+	assert.Equal(t, "spec.x", report.Errors[0].Field)
+	assert.Equal(t, "enum", report.Errors[0].Keyword)
+	assert.Equal(t, []string{"y"}, report.Errors[0].Suggestions)
+}
+
+func TestWriteValidateJSON_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "arena.yaml")
+	require.NoError(t, os.WriteFile(file, []byte(`apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: test
+spec:
+  scenarios:
+    - file: test.yaml
+`), 0o600))
+
+	var buf bytes.Buffer
+	require.NoError(t, writeValidateJSON(&buf, file, "auto"))
+
+	var report validateJSONReport
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &report))
+	assert.True(t, report.Valid)
+	assert.Equal(t, "arena", report.Type)
+}
+
+func TestWriteValidateJSON_FileNotFound(t *testing.T) {
+	var buf bytes.Buffer
+	require.Error(t, writeValidateJSON(&buf, "/no/such/file.yaml", "auto"))
+}


### PR DESCRIPTION
## Summary

Phase B of the agent-driven kit authoring effort (epic #1393): agent-facing **discovery commands** that turn the npm binary into a self-documenting knowledge base, all reading the embedded `agentkb` from Phase A.

> **Stacked on #1394** (keystone + Phase A). Based on `feat/agentkb-keystone-phase-a` so this PR's diff is just the Phase B changes; it auto-retargets to `main` once #1394 merges.

## What's in this PR

- **`promptarena schema [type] [--list]`** — print the embedded, version-locked JSON schema for a config type. The highest-value command for an agent: it's the exact schema `validate` enforces, available offline.
- **`promptarena explain [concept-id] [--list]`** — print authoring idioms (mock providers, assertions-vs-evals, schema validation) from the embedded knowledge base.
- **`promptarena examples list [--tag] [--json]`** — list example kits from the embedded catalog (offline). `--json` emits agent-friendly lowercase keys.
- **`promptarena examples show <name>`** — print a kit's files; resolves builtin sources offline via the templates loader (builtin-first, remote fallback handled by the loader).
- **`promptarena validate --json`** — structured `{file,type,valid,errors[]}` report with non-zero exit on failure, so an agent gets machine-readable results.
- Phase A agent brief updated to point at `explain` / `examples`; `CatalogEntry` gained json tags.

## Verification

- New unit tests for every command's pure logic (table/JSON/tag-filter/error paths); full `agentkb` + `cmd/promptarena` + whole-arena suites pass; all changed files clear the 80% coverage gate; lint clean.
- Live smoke test against the built binary: `explain --list`, `examples list --tag mcp`, `examples list --json`, `examples show quick-start`, `schema scenario`, and `validate --json` (real structured errors) all work.

## Not in this PR

- Phase C — `promptarena mcp` stdio server (#1392), which wraps these same handlers + `agentkb` as an MCP adapter.

Closes #1391
