### PR TITLE
feat(arena): promptarena mcp — stdio MCP server over agentkb (Phase C)

### DIFF
--- a/tools/arena/agentmcp/examples.go
+++ b/tools/arena/agentmcp/examples.go
@@ -1,0 +1,70 @@
+package agentmcp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
+	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
+)
+
+// exampleLoader is the subset of templates.Loader that renderExample needs.
+type exampleLoader interface {
+	Load(name string) (*templates.Template, error)
+	ReadTemplateFile(templateName, filePath string) ([]byte, error)
+}
+
+// renderExample resolves a catalog entry by name and renders its files as text.
+// Builtin sources resolve offline via the templates loader.
+func renderExample(loader exampleLoader, name string) (string, error) {
+	cat, err := agentkb.LoadCatalog()
+	if err != nil {
+		return "", err
+	}
+
+	var entry *agentkb.CatalogEntry
+	for i := range cat.Entries {
+		if cat.Entries[i].Name == name {
+			entry = &cat.Entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		return "", fmt.Errorf("unknown example %q (see list_examples)", name)
+	}
+
+	loadName := entry.Source
+	if idx := strings.IndexByte(loadName, ':'); idx >= 0 {
+		loadName = loadName[idx+1:]
+	}
+
+	tmpl, err := loader.Load(loadName)
+	if err != nil {
+		return "", fmt.Errorf("load example %q: %w", name, err)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n%s\n\nFiles:\n", entry.Name, entry.Description)
+	for i := range tmpl.Spec.Files {
+		f := &tmpl.Spec.Files[i]
+		fmt.Fprintf(&b, "\n--- %s ---\n", f.Path)
+		b.WriteString(exampleFileBody(loader, tmpl.Metadata.Name, f))
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
+func exampleFileBody(loader exampleLoader, templateName string, f *templates.FileSpec) string {
+	switch {
+	case f.Content != "":
+		return f.Content
+	case f.Template != "":
+		data, err := loader.ReadTemplateFile(templateName, f.Template)
+		if err != nil {
+			return fmt.Sprintf("(template body unavailable: %v)", err)
+		}
+		return string(data)
+	default:
+		return "(external source — fetch the example to see this file)"
+	}
+}

--- a/tools/arena/agentmcp/resources.go
+++ b/tools/arena/agentmcp/resources.go
@@ -1,0 +1,125 @@
+package agentmcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
+)
+
+const (
+	uriConceptPrefix = "promptarena://concepts/"
+	uriSchemaPrefix  = "promptarena://schemas/"
+	uriCatalog       = "promptarena://catalog"
+
+	mimeMarkdown = "text/markdown"
+	mimeJSON     = "application/json"
+)
+
+// resourceDef describes one MCP resource in resources/list.
+type resourceDef struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
+type resourcesListResult struct {
+	Resources []resourceDef `json:"resources"`
+}
+
+// resourceContents is one returned body in resources/read.
+type resourceContents struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text"`
+}
+
+type resourceReadResult struct {
+	Contents []resourceContents `json:"contents"`
+}
+
+func (s *Server) resourcesList() resourcesListResult {
+	var res []resourceDef
+
+	if concepts, err := agentkb.Concepts(); err == nil {
+		for _, c := range concepts {
+			res = append(res, resourceDef{
+				URI:         uriConceptPrefix + c.ID,
+				Name:        c.Title,
+				Description: c.Summary,
+				MimeType:    mimeMarkdown,
+			})
+		}
+	}
+
+	if names, err := agentkb.SchemaNames(); err == nil {
+		for _, n := range names {
+			res = append(res, resourceDef{
+				URI:      uriSchemaPrefix + n,
+				Name:     n + " schema",
+				MimeType: mimeJSON,
+			})
+		}
+	}
+
+	res = append(res, resourceDef{
+		URI:         uriCatalog,
+		Name:        "example catalog",
+		Description: "Index of example kits.",
+		MimeType:    mimeJSON,
+	})
+
+	return resourcesListResult{Resources: res}
+}
+
+func (s *Server) handleResourceRead(msg *mcp.JSONRPCMessage) *mcp.JSONRPCMessage {
+	var p struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(msg.Params, &p); err != nil {
+		return s.errorResp(msg.ID, invalidParams, "invalid params: "+err.Error())
+	}
+
+	text, mime, err := readResourceBody(p.URI)
+	if err != nil {
+		return s.errorResp(msg.ID, invalidParams, err.Error())
+	}
+	return s.result(msg.ID, resourceReadResult{
+		Contents: []resourceContents{{URI: p.URI, MimeType: mime, Text: text}},
+	})
+}
+
+func readResourceBody(uri string) (text, mime string, err error) {
+	switch {
+	case uri == uriCatalog:
+		cat, lErr := agentkb.LoadCatalog()
+		if lErr != nil {
+			return "", "", lErr
+		}
+		raw, mErr := json.MarshalIndent(cat, "", "  ")
+		if mErr != nil {
+			return "", "", mErr
+		}
+		return string(raw), mimeJSON, nil
+
+	case strings.HasPrefix(uri, uriConceptPrefix):
+		c, cErr := agentkb.ConceptByID(strings.TrimPrefix(uri, uriConceptPrefix))
+		if cErr != nil {
+			return "", "", cErr
+		}
+		return "# " + c.Title + "\n\n" + c.Body, mimeMarkdown, nil
+
+	case strings.HasPrefix(uri, uriSchemaPrefix):
+		b, sErr := agentkb.Schema(strings.TrimPrefix(uri, uriSchemaPrefix))
+		if sErr != nil {
+			return "", "", sErr
+		}
+		return string(b), mimeJSON, nil
+
+	default:
+		return "", "", fmt.Errorf("unknown resource uri: %s", uri)
+	}
+}

--- a/tools/arena/agentmcp/resources_test.go
+++ b/tools/arena/agentmcp/resources_test.go
@@ -1,0 +1,75 @@
+package agentmcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+)
+
+func TestResources_List(t *testing.T) {
+	s := NewServer("test")
+	resp := s.handleMessage(context.Background(), req(1, "resources/list", nil))
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Error)
+
+	var out resourcesListResult
+	require.NoError(t, json.Unmarshal(resp.Result, &out))
+	require.NotEmpty(t, out.Resources)
+
+	uris := map[string]bool{}
+	for _, r := range out.Resources {
+		uris[r.URI] = true
+		assert.NotEmpty(t, r.Name)
+	}
+	assert.True(t, uris["promptarena://concepts/mock-providers"], "concept resource listed")
+	assert.True(t, uris["promptarena://schemas/scenario"], "schema resource listed")
+	assert.True(t, uris["promptarena://catalog"], "catalog resource listed")
+}
+
+func readResource(t *testing.T, s *Server, uri string) *mcp.JSONRPCMessage {
+	t.Helper()
+	return s.handleMessage(context.Background(), req(2, "resources/read", map[string]string{"uri": uri}))
+}
+
+func TestResources_Read(t *testing.T) {
+	s := NewServer("test")
+
+	cases := map[string]string{
+		"promptarena://concepts/mock-providers": "type: mock",
+		"promptarena://schemas/scenario":        "$schema",
+		"promptarena://catalog":                 "quick-start",
+	}
+	for uri, want := range cases {
+		t.Run(uri, func(t *testing.T) {
+			resp := readResource(t, s, uri)
+			require.NotNil(t, resp)
+			require.Nil(t, resp.Error)
+			var out resourceReadResult
+			require.NoError(t, json.Unmarshal(resp.Result, &out))
+			require.NotEmpty(t, out.Contents)
+			assert.Equal(t, uri, out.Contents[0].URI)
+			assert.Contains(t, out.Contents[0].Text, want)
+		})
+	}
+}
+
+func TestResources_Read_UnknownURI(t *testing.T) {
+	s := NewServer("test")
+	resp := readResource(t, s, "promptarena://nope/x")
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+}
+
+func TestResources_Read_BadParams(t *testing.T) {
+	s := NewServer("test")
+	msg := &mcp.JSONRPCMessage{JSONRPC: "2.0", ID: 3, Method: "resources/read", Params: json.RawMessage(`"oops"`)}
+	resp := s.handleMessage(context.Background(), msg)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, invalidParams, resp.Error.Code)
+}

--- a/tools/arena/agentmcp/server.go
+++ b/tools/arena/agentmcp/server.go
@@ -1,0 +1,168 @@
+// Package agentmcp is a stdio MCP server that exposes the PromptArena agent
+// knowledge base (agentkb) — authoring concepts, example catalog, and JSON
+// schemas — as MCP tools and resources, so any MCP client can author kits.
+package agentmcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+)
+
+const (
+	serverName      = "promptarena-agentkb"
+	jsonRPCVersion  = "2.0"
+	contentTypeText = "text"
+)
+
+// JSON-RPC 2.0 error codes.
+const (
+	parseError     = -32700
+	invalidParams  = -32602
+	methodNotFound = -32601
+	internalError  = -32603
+)
+
+// scanBufferInitial / scanBufferMax bound a single JSON-RPC line
+// (schemas can be large).
+const (
+	scanBufferInitial = 64 * 1024
+	scanBufferMax     = 4 * 1024 * 1024
+)
+
+type toolHandler func(ctx context.Context, args json.RawMessage) (mcp.ToolCallResponse, error)
+
+type toolEntry struct {
+	def     mcp.Tool
+	handler toolHandler
+}
+
+// Server is a stdio MCP server over the PromptArena agent knowledge base.
+type Server struct {
+	version string
+	tools   map[string]toolEntry
+	order   []string // stable tool ordering for tools/list
+}
+
+// NewServer builds a server reporting the given version in its serverInfo.
+func NewServer(version string) *Server {
+	s := &Server{version: version, tools: map[string]toolEntry{}}
+	s.registerTools()
+	return s
+}
+
+// Serve runs the newline-delimited JSON-RPC stdio loop until in is exhausted.
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, scanBufferInitial), scanBufferMax)
+	enc := json.NewEncoder(out)
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var msg mcp.JSONRPCMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			if encErr := enc.Encode(s.errorResp(nil, parseError, "parse error")); encErr != nil {
+				return encErr
+			}
+			continue
+		}
+		if resp := s.handleMessage(ctx, &msg); resp != nil {
+			if err := enc.Encode(resp); err != nil {
+				return err
+			}
+		}
+	}
+	return scanner.Err()
+}
+
+func (s *Server) handleMessage(ctx context.Context, msg *mcp.JSONRPCMessage) *mcp.JSONRPCMessage {
+	switch msg.Method {
+	case "initialize":
+		return s.result(msg.ID, s.initializeResult())
+	case "notifications/initialized":
+		return nil
+	case "ping":
+		return s.result(msg.ID, struct{}{})
+	case "tools/list":
+		return s.result(msg.ID, mcp.ToolsListResponse{Tools: s.toolDefs()})
+	case "tools/call":
+		return s.handleToolCall(ctx, msg)
+	default:
+		if msg.ID == nil {
+			return nil // unknown notification — ignore
+		}
+		return s.errorResp(msg.ID, methodNotFound, "method not found: "+msg.Method)
+	}
+}
+
+func (s *Server) initializeResult() mcp.InitializeResponse {
+	return mcp.InitializeResponse{
+		ProtocolVersion: mcp.ProtocolVersion,
+		Capabilities: mcp.ServerCapabilities{
+			Tools:     &mcp.ToolsCapability{},
+			Resources: &mcp.ResourcesCapability{},
+		},
+		ServerInfo: mcp.Implementation{Name: serverName, Version: s.version},
+	}
+}
+
+func (s *Server) toolDefs() []mcp.Tool {
+	defs := make([]mcp.Tool, 0, len(s.order))
+	for _, name := range s.order {
+		defs = append(defs, s.tools[name].def)
+	}
+	return defs
+}
+
+func (s *Server) handleToolCall(ctx context.Context, msg *mcp.JSONRPCMessage) *mcp.JSONRPCMessage {
+	var req mcp.ToolCallRequest
+	if err := json.Unmarshal(msg.Params, &req); err != nil {
+		return s.errorResp(msg.ID, invalidParams, "invalid params: "+err.Error())
+	}
+	entry, ok := s.tools[req.Name]
+	if !ok {
+		return s.result(msg.ID, errorToolResult("unknown tool: "+req.Name))
+	}
+	resp, err := entry.handler(ctx, req.Arguments)
+	if err != nil {
+		return s.result(msg.ID, errorToolResult(err.Error()))
+	}
+	return s.result(msg.ID, resp)
+}
+
+func (s *Server) result(id, v any) *mcp.JSONRPCMessage {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return s.errorResp(id, internalError, err.Error())
+	}
+	return &mcp.JSONRPCMessage{JSONRPC: jsonRPCVersion, ID: id, Result: raw}
+}
+
+func (s *Server) errorResp(id any, code int, message string) *mcp.JSONRPCMessage {
+	return &mcp.JSONRPCMessage{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Error:   &mcp.JSONRPCError{Code: code, Message: message},
+	}
+}
+
+func textResult(text string) mcp.ToolCallResponse {
+	return mcp.ToolCallResponse{Content: []mcp.Content{{Type: contentTypeText, Text: text}}}
+}
+
+func errorToolResult(text string) mcp.ToolCallResponse {
+	return mcp.ToolCallResponse{IsError: true, Content: []mcp.Content{{Type: contentTypeText, Text: text}}}
+}
+
+// addTool registers a tool definition and handler, preserving call order.
+func (s *Server) addTool(def mcp.Tool, h toolHandler) {
+	s.tools[def.Name] = toolEntry{def: def, handler: h}
+	s.order = append(s.order, def.Name)
+}

--- a/tools/arena/agentmcp/server.go
+++ b/tools/arena/agentmcp/server.go
@@ -94,6 +94,10 @@ func (s *Server) handleMessage(ctx context.Context, msg *mcp.JSONRPCMessage) *mc
 		return s.result(msg.ID, mcp.ToolsListResponse{Tools: s.toolDefs()})
 	case "tools/call":
 		return s.handleToolCall(ctx, msg)
+	case "resources/list":
+		return s.result(msg.ID, s.resourcesList())
+	case "resources/read":
+		return s.handleResourceRead(msg)
 	default:
 		if msg.ID == nil {
 			return nil // unknown notification — ignore

--- a/tools/arena/agentmcp/server_test.go
+++ b/tools/arena/agentmcp/server_test.go
@@ -1,0 +1,175 @@
+package agentmcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+)
+
+func req(id int, method string, params any) *mcp.JSONRPCMessage {
+	var raw json.RawMessage
+	if params != nil {
+		raw, _ = json.Marshal(params)
+	}
+	return &mcp.JSONRPCMessage{JSONRPC: "2.0", ID: id, Method: method, Params: raw}
+}
+
+func TestServer_Initialize(t *testing.T) {
+	s := NewServer("test")
+	resp := s.handleMessage(context.Background(), req(1, "initialize", nil))
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Error)
+
+	var init mcp.InitializeResponse
+	require.NoError(t, json.Unmarshal(resp.Result, &init))
+	assert.Equal(t, mcp.ProtocolVersion, init.ProtocolVersion)
+	require.NotNil(t, init.Capabilities.Tools)
+	require.NotNil(t, init.Capabilities.Resources)
+	assert.NotEmpty(t, init.ServerInfo.Name)
+}
+
+func TestServer_ToolsList(t *testing.T) {
+	s := NewServer("test")
+	resp := s.handleMessage(context.Background(), req(2, "tools/list", nil))
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Error)
+
+	var out mcp.ToolsListResponse
+	require.NoError(t, json.Unmarshal(resp.Result, &out))
+	names := map[string]bool{}
+	for i := range out.Tools {
+		names[out.Tools[i].Name] = true
+		assert.NotEmpty(t, out.Tools[i].InputSchema, "tool %s needs an input schema", out.Tools[i].Name)
+	}
+	assert.True(t, names["explain"], "explain tool advertised")
+}
+
+func TestServer_ToolsCall_Explain(t *testing.T) {
+	s := NewServer("test")
+	call := mcp.ToolCallRequest{Name: "explain", Arguments: json.RawMessage(`{"id":"mock-providers"}`)}
+	resp := s.handleMessage(context.Background(), req(3, "tools/call", call))
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Error)
+
+	var out mcp.ToolCallResponse
+	require.NoError(t, json.Unmarshal(resp.Result, &out))
+	assert.False(t, out.IsError)
+	require.NotEmpty(t, out.Content)
+	assert.Contains(t, out.Content[0].Text, "type: mock")
+}
+
+func TestServer_ToolsCall_Explain_ListAll(t *testing.T) {
+	s := NewServer("test")
+	call := mcp.ToolCallRequest{Name: "explain"} // no id -> list
+	resp := s.handleMessage(context.Background(), req(10, "tools/call", call))
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Error)
+
+	var out mcp.ToolCallResponse
+	require.NoError(t, json.Unmarshal(resp.Result, &out))
+	require.NotEmpty(t, out.Content)
+	assert.Contains(t, out.Content[0].Text, "mock-providers")
+	assert.Contains(t, out.Content[0].Text, "assertions-vs-evals")
+}
+
+func TestServer_ToolsCall_UnknownTool(t *testing.T) {
+	s := NewServer("test")
+	call := mcp.ToolCallRequest{Name: "nope"}
+	resp := s.handleMessage(context.Background(), req(4, "tools/call", call))
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Error, "unknown tool is an isError result, not a protocol error")
+
+	var out mcp.ToolCallResponse
+	require.NoError(t, json.Unmarshal(resp.Result, &out))
+	assert.True(t, out.IsError)
+}
+
+func TestServer_NotificationGetsNoResponse(t *testing.T) {
+	s := NewServer("test")
+	resp := s.handleMessage(context.Background(), &mcp.JSONRPCMessage{JSONRPC: "2.0", Method: "notifications/initialized"})
+	assert.Nil(t, resp)
+}
+
+func TestServer_UnknownMethod(t *testing.T) {
+	s := NewServer("test")
+	resp := s.handleMessage(context.Background(), req(9, "bogus/method", nil))
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, methodNotFound, resp.Error.Code)
+}
+
+func TestServer_ToolsCall_InvalidParams(t *testing.T) {
+	s := NewServer("test")
+	// Params is a JSON string, not a ToolCallRequest object.
+	msg := &mcp.JSONRPCMessage{JSONRPC: "2.0", ID: 5, Method: "tools/call", Params: json.RawMessage(`"oops"`)}
+	resp := s.handleMessage(context.Background(), msg)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, invalidParams, resp.Error.Code)
+}
+
+func TestServer_ToolsCall_Explain_BadArgs(t *testing.T) {
+	s := NewServer("test")
+	call := mcp.ToolCallRequest{Name: "explain", Arguments: json.RawMessage(`"notanobject"`)}
+	resp := s.handleMessage(context.Background(), req(6, "tools/call", call))
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Error)
+
+	var out mcp.ToolCallResponse
+	require.NoError(t, json.Unmarshal(resp.Result, &out))
+	assert.True(t, out.IsError)
+}
+
+func TestServer_Ping(t *testing.T) {
+	s := NewServer("test")
+	resp := s.handleMessage(context.Background(), req(7, "ping", nil))
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+}
+
+func TestServer_UnknownNotificationIsSilent(t *testing.T) {
+	s := NewServer("test")
+	// No id + unknown method = notification we don't recognise -> no response.
+	resp := s.handleMessage(context.Background(), &mcp.JSONRPCMessage{JSONRPC: "2.0", Method: "notifications/cancelled"})
+	assert.Nil(t, resp)
+}
+
+func TestServer_Serve_ParseErrorThenRecovers(t *testing.T) {
+	in := "this is not json\n" + `{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n"
+	var out bytes.Buffer
+	require.NoError(t, NewServer("test").Serve(context.Background(), strings.NewReader(in), &out))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 2)
+	var parseErr mcp.JSONRPCMessage
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &parseErr))
+	require.NotNil(t, parseErr.Error)
+	assert.Equal(t, parseError, parseErr.Error.Code)
+}
+
+func TestServer_Serve_StdioRoundTrip(t *testing.T) {
+	// Two newline-delimited requests; expect two newline-delimited responses
+	// and no response for the interleaved notification.
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize"}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	}, "\n") + "\n"
+
+	var out bytes.Buffer
+	require.NoError(t, NewServer("test").Serve(context.Background(), strings.NewReader(in), &out))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 2, "two requests -> two responses, notification silent")
+
+	var first mcp.JSONRPCMessage
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+	assert.Equal(t, float64(1), first.ID)
+}

--- a/tools/arena/agentmcp/tools.go
+++ b/tools/arena/agentmcp/tools.go
@@ -1,0 +1,55 @@
+package agentmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
+)
+
+// registerTools wires the agentkb-backed MCP tools. Additional tools are added
+// in later tasks; explain is the proof-of-dispatch tool.
+func (s *Server) registerTools() {
+	s.addTool(mcp.Tool{
+		Name:        "explain",
+		Description: "Explain a PromptArena authoring concept. Omit id to list all concepts.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "id": { "type": "string", "description": "Concept id (e.g. mock-providers). Omit to list all." }
+  }
+}`),
+	}, s.toolExplain)
+}
+
+func (s *Server) toolExplain(_ context.Context, args json.RawMessage) (mcp.ToolCallResponse, error) {
+	var p struct {
+		ID string `json:"id"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &p); err != nil {
+			return mcp.ToolCallResponse{}, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+
+	if p.ID == "" {
+		concepts, err := agentkb.Concepts()
+		if err != nil {
+			return mcp.ToolCallResponse{}, err
+		}
+		var b strings.Builder
+		for _, c := range concepts {
+			fmt.Fprintf(&b, "%s — %s\n", c.ID, c.Summary)
+		}
+		return textResult(b.String()), nil
+	}
+
+	c, err := agentkb.ConceptByID(p.ID)
+	if err != nil {
+		return mcp.ToolCallResponse{}, err
+	}
+	return textResult("# " + c.Title + "\n\n" + c.Body), nil
+}

--- a/tools/arena/agentmcp/tools.go
+++ b/tools/arena/agentmcp/tools.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
+	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
 )
 
 // registerTools wires the agentkb-backed MCP tools. Additional tools are added
@@ -23,6 +25,118 @@ func (s *Server) registerTools() {
   }
 }`),
 	}, s.toolExplain)
+
+	s.addTool(mcp.Tool{
+		Name:        "get_schema",
+		Description: "Print the embedded JSON schema for a config type. Omit type to list types.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "type": { "type": "string", "description": "Config type (scenario, provider, ...). Omit to list." }
+  }
+}`),
+	}, s.toolGetSchema)
+
+	s.addTool(mcp.Tool{
+		Name:        "list_examples",
+		Description: "List example kits from the embedded catalog, as JSON. Optional tag filter.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "tag": { "type": "string", "description": "Filter examples by tag." }
+  }
+}`),
+	}, s.toolListExamples)
+
+	s.addTool(mcp.Tool{
+		Name:        "show_example",
+		Description: "Print an example kit's files by name (see list_examples).",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "description": "Catalog entry name (e.g. quick-start)." }
+  },
+  "required": ["name"]
+}`),
+	}, s.toolShowExample)
+}
+
+func (s *Server) toolGetSchema(_ context.Context, args json.RawMessage) (mcp.ToolCallResponse, error) {
+	var p struct {
+		Type string `json:"type"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &p); err != nil {
+			return mcp.ToolCallResponse{}, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+
+	if p.Type == "" {
+		names, err := agentkb.SchemaNames()
+		if err != nil {
+			return mcp.ToolCallResponse{}, err
+		}
+		return textResult(strings.Join(names, "\n")), nil
+	}
+
+	b, err := agentkb.Schema(p.Type)
+	if err != nil {
+		return mcp.ToolCallResponse{}, err
+	}
+	return textResult(string(b)), nil
+}
+
+func (s *Server) toolListExamples(_ context.Context, args json.RawMessage) (mcp.ToolCallResponse, error) {
+	var p struct {
+		Tag string `json:"tag"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &p); err != nil {
+			return mcp.ToolCallResponse{}, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+
+	cat, err := agentkb.LoadCatalog()
+	if err != nil {
+		return mcp.ToolCallResponse{}, err
+	}
+
+	entries := cat.Entries
+	if p.Tag != "" {
+		filtered := entries[:0:0]
+		for _, e := range entries {
+			if slices.Contains(e.Tags, p.Tag) {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	raw, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return mcp.ToolCallResponse{}, err
+	}
+	return textResult(string(raw)), nil
+}
+
+func (s *Server) toolShowExample(_ context.Context, args json.RawMessage) (mcp.ToolCallResponse, error) {
+	var p struct {
+		Name string `json:"name"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &p); err != nil {
+			return mcp.ToolCallResponse{}, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+	if p.Name == "" {
+		return mcp.ToolCallResponse{}, fmt.Errorf("name is required")
+	}
+
+	text, err := renderExample(templates.NewLoader(""), p.Name)
+	if err != nil {
+		return mcp.ToolCallResponse{}, err
+	}
+	return textResult(text), nil
 }
 
 func (s *Server) toolExplain(_ context.Context, args json.RawMessage) (mcp.ToolCallResponse, error) {

--- a/tools/arena/agentmcp/tools_test.go
+++ b/tools/arena/agentmcp/tools_test.go
@@ -1,0 +1,62 @@
+package agentmcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/mcp"
+)
+
+func callTool(t *testing.T, s *Server, name, argsJSON string) mcp.ToolCallResponse {
+	t.Helper()
+	call := mcp.ToolCallRequest{Name: name, Arguments: json.RawMessage(argsJSON)}
+	resp := s.handleMessage(context.Background(), req(99, "tools/call", call))
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Error)
+	var out mcp.ToolCallResponse
+	require.NoError(t, json.Unmarshal(resp.Result, &out))
+	return out
+}
+
+func TestTool_GetSchema(t *testing.T) {
+	s := NewServer("test")
+
+	list := callTool(t, s, "get_schema", `{}`)
+	require.NotEmpty(t, list.Content)
+	assert.Contains(t, list.Content[0].Text, "scenario")
+
+	one := callTool(t, s, "get_schema", `{"type":"scenario"}`)
+	assert.Contains(t, one.Content[0].Text, "$schema")
+
+	bad := callTool(t, s, "get_schema", `{"type":"nope"}`)
+	assert.True(t, bad.IsError)
+}
+
+func TestTool_ListExamples(t *testing.T) {
+	s := NewServer("test")
+
+	all := callTool(t, s, "list_examples", `{}`)
+	assert.Contains(t, all.Content[0].Text, "quick-start")
+
+	tagged := callTool(t, s, "list_examples", `{"tag":"mcp"}`)
+	assert.Contains(t, tagged.Content[0].Text, "mcp-integration")
+	assert.NotContains(t, tagged.Content[0].Text, "quick-start")
+}
+
+func TestTool_ShowExample(t *testing.T) {
+	s := NewServer("test")
+
+	ok := callTool(t, s, "show_example", `{"name":"quick-start"}`)
+	assert.False(t, ok.IsError)
+	assert.Contains(t, ok.Content[0].Text, "config.arena.yaml")
+
+	missing := callTool(t, s, "show_example", `{"name":"does-not-exist"}`)
+	assert.True(t, missing.IsError)
+
+	noName := callTool(t, s, "show_example", `{}`)
+	assert.True(t, noName.IsError)
+}

--- a/tools/arena/cmd/promptarena/mcp_cmd.go
+++ b/tools/arena/cmd/promptarena/mcp_cmd.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/agentmcp"
+)
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Run an MCP server exposing PromptArena authoring knowledge over stdio",
+	Long: `Start a stdio MCP server that exposes the PromptArena agent knowledge base —
+authoring concepts, the example catalog, and version-locked JSON schemas — as MCP
+tools and resources, so any MCP client can author kits.
+
+Tools: explain, get_schema, list_examples, show_example.
+Resources: promptarena://concepts/<id>, promptarena://schemas/<type>, promptarena://catalog.
+
+Add to an MCP client config (e.g. Claude Code .mcp.json):
+  { "mcpServers": { "promptarena": { "command": "promptarena", "args": ["mcp"] } } }`,
+	RunE: runMCP,
+}
+
+func init() {
+	rootCmd.AddCommand(mcpCmd)
+}
+
+func runMCP(cmd *cobra.Command, _ []string) error {
+	srv := agentmcp.NewServer(GetVersion())
+	return srv.Serve(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout())
+}

--- a/tools/arena/cmd/promptarena/mcp_cmd_test.go
+++ b/tools/arena/cmd/promptarena/mcp_cmd_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMCP_InitializeRoundTrip(t *testing.T) {
+	in := `{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"
+	var out bytes.Buffer
+
+	mcpCmd.SetContext(context.Background())
+	mcpCmd.SetIn(strings.NewReader(in))
+	mcpCmd.SetOut(&out)
+	t.Cleanup(func() { mcpCmd.SetIn(nil); mcpCmd.SetOut(nil) })
+
+	require.NoError(t, runMCP(mcpCmd, nil))
+
+	var resp struct {
+		Result struct {
+			ServerInfo struct {
+				Name string `json:"name"`
+			} `json:"serverInfo"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out.String())), &resp))
+	assert.NotEmpty(t, resp.Result.ServerInfo.Name)
+}


### PR DESCRIPTION
## Summary

Phase C of the agent-driven kit authoring effort (epic #1393): `promptarena mcp`, a stdio MCP server that exposes the embedded `agentkb` (concepts, example catalog, version-locked JSON schemas) as MCP tools and resources — so any MCP client (Claude Code, Cursor, …) gets the same authoring knowledge over a standard protocol.

Hand-rolled the small stdio JSON-RPC server reusing `runtime/mcp` protocol types (the repo builds its own MCP rather than adding a dependency).

## What's in this PR

New package `tools/arena/agentmcp`:
- **Server core** — newline-delimited JSON-RPC stdio loop; `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `ping`; notifications get no response; MCP-style tool errors (`isError`) vs JSON-RPC protocol errors.
- **Tools** — `explain`, `get_schema`, `list_examples`, `show_example` (all backed by `agentkb`; `show_example` resolves builtin sources offline via the templates loader).
- **Resources** — `promptarena://concepts/<id>`, `promptarena://schemas/<type>`, `promptarena://catalog`.

New command `promptarena mcp` wires the server over stdio, with a one-line client-config snippet in its `--help`.

## Verification

- Unit tests for the dispatch, every tool, every resource, the stdio round-trip, and protocol/param error paths; all changed files clear the 80% coverage gate; lint clean; full arena suite passes.
- **Live stdio smoke test** against the built binary:
  - `initialize` → `serverInfo=promptarena-agentkb`, proto `2025-06-18`, caps `tools`+`resources`
  - `tools/list` → `[explain, get_schema, list_examples, show_example]`
  - `resources/read promptarena://concepts/mock-providers` → returns the concept body

## Deferred (follow-up)

- An MCP `validate` tool — doing it offline/version-locked against the embedded schema dir (rather than a network fetch) is more than an adapter, so it deserves its own pass. Agents can still `get_schema` + shell `promptarena validate` today.
- The `show_example` renderer is duplicated between `cmd` and `agentmcp`; could be unified into a shared helper later.

Closes #1392
