### PR TITLE
refactor(arena): agentkb single source of truth — dedupe renderer + schema generate path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -698,6 +698,9 @@ install-tools-user: ## Install CLI tools to user PATH (~/.local/bin)
 schemas: build-schema-gen ## Generate JSON schemas (including latest refs)
 	@echo "Generating JSON schemas..."
 	@./bin/schema-gen
+	@echo "Syncing schemas into agentkb embed..."
+	@go generate ./tools/arena/agentkb/...
+	@echo "✓ agentkb schemas synced"
 
 schemas-check: build-schema-gen ## Check if schemas are up to date (for CI)
 	@echo "Checking if schemas are up to date..."

--- a/tools/arena/agentkb/examples.go
+++ b/tools/arena/agentkb/examples.go
@@ -1,28 +1,29 @@
-package agentmcp
+package agentkb
 
 import (
 	"fmt"
 	"strings"
 
-	"github.com/AltairaLabs/PromptKit/tools/arena/agentkb"
 	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
 )
 
-// exampleLoader is the subset of templates.Loader that renderExample needs.
-type exampleLoader interface {
+// ExampleLoader is the subset of templates.Loader that RenderExample needs.
+// templates.Loader satisfies it.
+type ExampleLoader interface {
 	Load(name string) (*templates.Template, error)
 	ReadTemplateFile(templateName, filePath string) ([]byte, error)
 }
 
-// renderExample resolves a catalog entry by name and renders its files as text.
-// Builtin sources resolve offline via the templates loader.
-func renderExample(loader exampleLoader, name string) (string, error) {
-	cat, err := agentkb.LoadCatalog()
+// RenderExample resolves a catalog entry by name and renders its files as text.
+// Builtin sources resolve offline via the loader. It is the single definition
+// shared by the `examples show` command and the MCP show_example tool.
+func RenderExample(loader ExampleLoader, name string) (string, error) {
+	cat, err := LoadCatalog()
 	if err != nil {
 		return "", err
 	}
 
-	var entry *agentkb.CatalogEntry
+	var entry *CatalogEntry
 	for i := range cat.Entries {
 		if cat.Entries[i].Name == name {
 			entry = &cat.Entries[i]
@@ -30,7 +31,7 @@ func renderExample(loader exampleLoader, name string) (string, error) {
 		}
 	}
 	if entry == nil {
-		return "", fmt.Errorf("unknown example %q (see list_examples)", name)
+		return "", fmt.Errorf("unknown example %q (see the example catalog)", name)
 	}
 
 	loadName := entry.Source
@@ -54,7 +55,10 @@ func renderExample(loader exampleLoader, name string) (string, error) {
 	return b.String(), nil
 }
 
-func exampleFileBody(loader exampleLoader, templateName string, f *templates.FileSpec) string {
+// exampleFileBody returns the displayable body for a template file: inline
+// content, the embedded template source, or a placeholder when the body lives
+// elsewhere (external/remote source).
+func exampleFileBody(loader ExampleLoader, templateName string, f *templates.FileSpec) string {
 	switch {
 	case f.Content != "":
 		return f.Content

--- a/tools/arena/agentkb/examples_test.go
+++ b/tools/arena/agentkb/examples_test.go
@@ -1,0 +1,22 @@
+package agentkb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
+)
+
+func TestRenderExample_Builtin(t *testing.T) {
+	out, err := RenderExample(templates.NewLoader(""), "quick-start")
+	require.NoError(t, err)
+	assert.Contains(t, out, "# quick-start")
+	assert.Contains(t, out, "config.arena.yaml")
+}
+
+func TestRenderExample_Unknown(t *testing.T) {
+	_, err := RenderExample(templates.NewLoader(""), "does-not-exist")
+	require.Error(t, err)
+}

--- a/tools/arena/agentkb/schema.go
+++ b/tools/arena/agentkb/schema.go
@@ -7,6 +7,12 @@ import (
 	"strings"
 )
 
+// The embedded schemas are a generated mirror of schemas/v1alpha1 (the source of
+// truth produced by schema-gen). Regenerate with `go generate ./tools/arena/agentkb/...`
+// or `make schemas`; TestSchemas_ByteMatchGeneratedSource guards against drift.
+//
+//go:generate sh -c "cp ../../../schemas/v1alpha1/*.json schemas/ && cp ../../../schemas/v1alpha1/common/*.json schemas/common/"
+
 //go:embed schemas/*.json schemas/common/*.json
 var schemasFS embed.FS
 

--- a/tools/arena/agentmcp/tools.go
+++ b/tools/arena/agentmcp/tools.go
@@ -132,7 +132,7 @@ func (s *Server) toolShowExample(_ context.Context, args json.RawMessage) (mcp.T
 		return mcp.ToolCallResponse{}, fmt.Errorf("name is required")
 	}
 
-	text, err := renderExample(templates.NewLoader(""), p.Name)
+	text, err := agentkb.RenderExample(templates.NewLoader(""), p.Name)
 	if err != nil {
 		return mcp.ToolCallResponse{}, err
 	}

--- a/tools/arena/cmd/promptarena/examples_cmd.go
+++ b/tools/arena/cmd/promptarena/examples_cmd.go
@@ -13,12 +13,6 @@ import (
 	"github.com/AltairaLabs/PromptKit/tools/arena/templates"
 )
 
-// exampleLoader is the subset of templates.Loader that examples show needs.
-type exampleLoader interface {
-	Load(name string) (*templates.Template, error)
-	ReadTemplateFile(templateName, filePath string) ([]byte, error)
-}
-
 const examplesListUse = "list"
 
 var (
@@ -102,65 +96,13 @@ func writeExamplesList(w io.Writer, tag string, asJSON bool) error {
 	return tw.Flush()
 }
 
-func writeExampleShow(w io.Writer, loader exampleLoader, name string) error {
-	cat, err := agentkb.LoadCatalog()
+func writeExampleShow(w io.Writer, loader agentkb.ExampleLoader, name string) error {
+	text, err := agentkb.RenderExample(loader, name)
 	if err != nil {
 		return err
 	}
-
-	var entry *agentkb.CatalogEntry
-	for i := range cat.Entries {
-		if cat.Entries[i].Name == name {
-			entry = &cat.Entries[i]
-			break
-		}
-	}
-	if entry == nil {
-		return fmt.Errorf("unknown example %q (try 'promptarena examples list')", name)
-	}
-
-	loadName := entry.Source
-	if idx := strings.IndexByte(loadName, ':'); idx >= 0 {
-		loadName = loadName[idx+1:]
-	}
-
-	tmpl, err := loader.Load(loadName)
-	if err != nil {
-		return fmt.Errorf("load example %q: %w", name, err)
-	}
-
-	if _, err := fmt.Fprintf(w, "# %s\n\n%s\n\nFiles:\n", entry.Name, entry.Description); err != nil {
-		return err
-	}
-	for i := range tmpl.Spec.Files {
-		f := &tmpl.Spec.Files[i]
-		if _, err := fmt.Fprintf(w, "\n--- %s ---\n", f.Path); err != nil {
-			return err
-		}
-		body := fileBody(loader, tmpl.Metadata.Name, f)
-		if _, err := fmt.Fprintln(w, body); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// fileBody returns the displayable body for a template file: inline content, the
-// embedded template source, or a placeholder when the body lives elsewhere
-// (external/remote source).
-func fileBody(loader exampleLoader, templateName string, f *templates.FileSpec) string {
-	switch {
-	case f.Content != "":
-		return f.Content
-	case f.Template != "":
-		data, err := loader.ReadTemplateFile(templateName, f.Template)
-		if err != nil {
-			return fmt.Sprintf("(template body unavailable: %v)", err)
-		}
-		return string(data)
-	default:
-		return "(external source — fetch the example to see this file)"
-	}
+	_, err = io.WriteString(w, text)
+	return err
 }
 
 func containsString(haystack []string, needle string) bool {


### PR DESCRIPTION
## Summary

Post-epic cleanup that collapses two hand-maintained duplicates onto `agentkb` as the single source of truth. Both were noted as deferred follow-ups on the agent-kit-authoring epic (#1393).

These are two faces of the same smell — `agentkb`/consumers holding a duplicate of something whose source lives elsewhere, with nothing forcing sync.

## Changes

**Example renderer — dedupe by ownership.**
The `examples show` command (`cmd/promptarena`) and the MCP `show_example` tool (`agentmcp`) each had their own copy of the catalog-lookup + file-render logic. Moved it into `agentkb` as `RenderExample` / `ExampleLoader`; both consumers now call the one definition. (Net −23 lines.)

**Schemas — generate + guard.**
`agentkb/schemas/` is an embedded mirror of `schemas/v1alpha1` (the schema-gen source of truth), but there was only a *parity test* to catch drift — no regeneration path. Added a `//go:generate` directive that mirrors the source, wired into `make schemas` (`go generate ./tools/arena/agentkb/...`). Now `make schemas` keeps the embed in lockstep; `TestSchemas_ByteMatchGeneratedSource` remains the CI guard.

The same `go generate` mechanism is what a future "generate the authoring skill from concepts" change would reuse.

## Verification

- `agentkb` + `agentmcp` + `cmd/promptarena` suites pass (incl. existing show-example tests on both consumers + a new direct `RenderExample` test); all changed files clear the 80% coverage gate; lint clean.
- `go generate ./tools/arena/agentkb/...` produces no diff (schemas already in sync); parity test passes.
