### PR TITLE
fix(arena): persist tool-loop messages per-round so errored runs keep their transcript

### DIFF
--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -301,6 +301,13 @@ func (s *ProviderStage) executeMultiRound(
 	if err != nil {
 		return nil, err
 	}
+	// Pre-seed: persist history messages into the log before the tool loop
+	// starts. This guarantees the full transcript is recoverable even if a
+	// mid-loop error prevents the normal end-of-turn save from running.
+	// LogAppend's idempotent-dedup skips messages already in the store, so
+	// calling this at loop-start is safe for multi-turn conversations where
+	// the history was persisted by a previous turn.
+	loop.preSeedLog(ctx)
 	for round := 1; round <= loop.maxRounds; round++ {
 		response, hasToolCalls, err := s.executeRound(
 			ctx, loop.messages, acc.systemPrompt, loop.providerTools, loop.toolChoice, round, acc.metadata)
@@ -415,6 +422,7 @@ func (s *ProviderStage) executeStreamingMultiRound(
 	if err != nil {
 		return nil, err
 	}
+	loop.preSeedLog(ctx)
 	for round := 1; round <= loop.maxRounds; round++ {
 		params := &streamingRoundParams{
 			messages:      loop.messages,
@@ -547,6 +555,36 @@ func (tl *toolLoop) afterRound(
 	}
 
 	return false, nil, nil
+}
+
+// preSeedLog writes the history messages that were already present in
+// acc.messages (i.e. messages[0:lastPersistedSeq]) into the MessageLog.
+// This ensures the full initial context is persisted before the first
+// tool-loop round fires, so a mid-loop error doesn't lose the transcript.
+// LogAppend's idempotent-dedup skips messages already stored from prior
+// turns, so this is safe to call on every turn start.
+func (tl *toolLoop) preSeedLog(ctx context.Context) {
+	cfg := tl.stage.config
+	if cfg == nil || cfg.MessageLog == nil || tl.lastPersistedSeq == 0 {
+		return
+	}
+	history := tl.messages[:tl.lastPersistedSeq]
+	if len(history) == 0 {
+		return
+	}
+	newTotal, err := cfg.MessageLog.LogAppend(ctx, cfg.MessageLogConvID, 0, history)
+	if err != nil {
+		logger.Warn("message log pre-seed failed", "error", err)
+		return
+	}
+	// After pre-seeding, lastPersistedSeq reflects what's now in the store.
+	// If the store already had these messages (multi-turn case), newTotal may
+	// be > lastPersistedSeq (store has more history from previous turns).
+	// Keep lastPersistedSeq as the larger of the two so we don't re-send old
+	// messages in subsequent persistMessages calls.
+	if newTotal > tl.lastPersistedSeq {
+		tl.lastPersistedSeq = newTotal
+	}
 }
 
 // persistMessages writes new messages to the MessageLog if configured.

--- a/tools/arena/engine/mid_loop_error_transcript_test.go
+++ b/tools/arena/engine/mid_loop_error_transcript_test.go
@@ -1,0 +1,237 @@
+package engine
+
+// TestProviderStage_MidLoopError_PreservesTranscript is Piece 4 of the arena
+// mid-loop error fix. It proves that when the ProviderStage's tool loop errors
+// (e.g. "max rounds exceeded") AFTER producing at least one assistant+tool
+// message, the accumulated messages are still visible in the ArenaStateStore —
+// NOT just the system message.
+//
+// The pipeline built here is intentionally minimal:
+//
+//	ProviderStage (MaxRounds=1, ToolProvider always requests a tool) →
+//	ArenaStateStoreSaveStage
+//
+// Flow:
+//  1. Provider returns an assistant message with a tool call (round 1).
+//  2. Tool executes, result appended (still round 1).
+//  3. MessageLog.LogAppend fires per-round — persists [assistant, tool-result].
+//  4. Round 2 would be needed for a text reply, but MaxRounds==1 → error.
+//  5. Pipeline fails; save stage is SKIPPED (error path).
+//  6. Because MessageLog wrote per-round, the store already has the messages.
+//  7. buildResultFromStateStore reads them back → result has the transcript.
+//
+// Before Piece 1-3 this test fails: result.Messages has only the system message
+// (or is empty), because MessageLog is nil so LogAppend never fires.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	arenastages "github.com/AltairaLabs/PromptKit/tools/arena/stages"
+	arenastatestore "github.com/AltairaLabs/PromptKit/tools/arena/statestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// alwaysToolProvider is a minimal ToolSupport provider that always requests
+// a call to "echo_tool" on PredictWithTools. It never returns a text reply,
+// so the tool loop keeps cycling until MaxRounds is hit.
+type alwaysToolProvider struct{}
+
+func (p *alwaysToolProvider) ID() string                          { return "always-tool" }
+func (p *alwaysToolProvider) Name() string                        { return "always-tool" }
+func (p *alwaysToolProvider) Type() base.ProviderType             { return base.ProviderTypeInference }
+func (p *alwaysToolProvider) Pricing() *base.PricingDescriptor    { return nil }
+func (p *alwaysToolProvider) Validate() error                     { return nil }
+func (p *alwaysToolProvider) Init(_ context.Context) error        { return nil }
+func (p *alwaysToolProvider) HealthCheck(_ context.Context) error { return nil }
+func (p *alwaysToolProvider) Model() string                       { return "always-tool-v1" }
+func (p *alwaysToolProvider) SupportsStreaming() bool             { return false }
+func (p *alwaysToolProvider) Close() error                        { return nil }
+func (p *alwaysToolProvider) ShouldIncludeRawOutput() bool        { return false }
+func (p *alwaysToolProvider) CalculateCost(in, out, cached int) types.CostInfo {
+	return types.CostInfo{
+		InputTokens:  in,
+		OutputTokens: out,
+		TotalCost:    float64(in+out) * 0.000001,
+	}
+}
+func (p *alwaysToolProvider) Predict(_ context.Context, _ providers.PredictionRequest) (providers.PredictionResponse, error) {
+	return providers.PredictionResponse{Content: "text"}, nil
+}
+func (p *alwaysToolProvider) PredictStream(_ context.Context, _ providers.PredictionRequest) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+// BuildTooling passes descriptors through unchanged (mock doesn't care about format).
+func (p *alwaysToolProvider) BuildTooling(descs []*providers.ToolDescriptor) (providers.ProviderTools, error) {
+	return descs, nil
+}
+
+// PredictWithTools always returns a single tool call to "echo_tool".
+func (p *alwaysToolProvider) PredictWithTools(
+	_ context.Context,
+	_ providers.PredictionRequest,
+	_ providers.ProviderTools,
+	_ string,
+) (providers.PredictionResponse, []types.MessageToolCall, error) {
+	args, _ := json.Marshal(map[string]string{"msg": "hello"})
+	tc := types.MessageToolCall{ID: "call-1", Name: "echo_tool", Args: json.RawMessage(args)}
+	resp := providers.PredictionResponse{
+		Content:   "",
+		ToolCalls: []types.MessageToolCall{tc},
+		CostInfo:  &types.CostInfo{InputTokens: 10, OutputTokens: 5, TotalCost: 0.000015},
+	}
+	return resp, []types.MessageToolCall{tc}, nil
+}
+
+// PredictStreamWithTools is unused in non-streaming tests; included for interface compliance.
+func (p *alwaysToolProvider) PredictStreamWithTools(
+	_ context.Context,
+	_ providers.PredictionRequest,
+	_ providers.ProviderTools,
+	_ string,
+) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+// echoExecutor echoes back the "msg" argument so the tool result is non-empty.
+type echoExecutor struct{}
+
+func (e *echoExecutor) Name() string { return "echo" }
+func (e *echoExecutor) Execute(_ context.Context, desc *tools.ToolDescriptor, args json.RawMessage) (json.RawMessage, error) {
+	var params map[string]string
+	_ = json.Unmarshal(args, &params)
+	result := map[string]string{"echo": params["msg"]}
+	out, _ := json.Marshal(result)
+	return out, nil
+}
+
+// TestProviderStage_MidLoopError_PreservesTranscript verifies that:
+//   - A ProviderStage error (max rounds exceeded) does NOT lose the tool-loop
+//     messages already produced during the failed turn.
+//   - The ArenaStateStore contains system+user+assistant+tool messages.
+//   - There are NO duplicate messages (LogAppend idempotent dedup works).
+func TestProviderStage_MidLoopError_PreservesTranscript(t *testing.T) {
+	ctx := context.Background()
+	convID := "test-mid-loop-error"
+
+	// Register echo_tool
+	reg := tools.NewRegistry()
+	reg.RegisterExecutor(&echoExecutor{})
+	echoDesc := &tools.ToolDescriptor{
+		Name:        "echo_tool",
+		Description: "echoes back the msg argument",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}}}`),
+		Mode:        "echo",
+	}
+	reg.Register(echoDesc)
+
+	// Create ArenaStateStore — this is what Piece 1 implements MessageLog on.
+	arenaStore := arenastatestore.NewArenaStateStore()
+
+	// Build the pipeline:
+	//   ProviderStage(MaxRounds=1, MessageLog=arenaStore) → ArenaStateStoreSaveStage
+	//
+	// MaxRounds=1 means: after 1 tool execution, if the provider STILL wants tools
+	// (which alwaysToolProvider does), error "max rounds (1) exceeded".
+	// TurnState.AllowedTools must include "echo_tool" so buildProviderTools surfaces
+	// it to the ToolSupport provider (non-system-namespaced tools are only surfaced
+	// when listed in allowedTools).
+	//
+	// We pass system+user messages as pipeline history (matching what
+	// StateStoreLoadStage would emit). This sets acc.messages = [system, user],
+	// so lastPersistedSeq=2 aligns with the store count after the save stage
+	// persists those history messages on round 1 of maybeIncrementalSave.
+	toolPolicy := &pipeline.ToolPolicy{MaxRounds: 1}
+	turnState := stage.NewTurnState()
+	turnState.AllowedTools = []string{"echo_tool"}
+	turnState.SystemPrompt = "You are a test assistant."
+	provConfig := &stage.ProviderConfig{
+		MessageLog:       arenaStore, // Piece 2: wire MessageLog
+		MessageLogConvID: convID,     // Piece 2: same conv ID
+	}
+	pipelineBuilder := stage.NewPipelineBuilder()
+	storeConfig := &pipeline.StateStoreConfig{
+		Store:          arenaStore,
+		ConversationID: convID,
+	}
+	stages := []stage.Stage{
+		stage.NewProviderStageWithTurnState(
+			&alwaysToolProvider{}, reg, toolPolicy, provConfig, nil, nil, turnState,
+		),
+		arenastages.NewArenaStateStoreSaveStageWithTurnState(storeConfig, turnState),
+	}
+	p, err := pipelineBuilder.Chain(stages...).Build()
+	require.NoError(t, err)
+
+	// Send system + user messages as pipeline input (mimicking StateStoreLoadStage +
+	// user-turn injection). Both are collected in acc.messages so lastPersistedSeq=2.
+	sysMsg := &types.Message{Role: "system", Content: "You are a test assistant.", Source: "statestore"}
+	userMsg := &types.Message{Role: "user", Content: "Call the echo tool."}
+
+	sysElem := stage.StreamElement{Message: sysMsg}
+	userElem := stage.StreamElement{Message: userMsg}
+
+	// Execute — expect an error because MaxRounds=1 will be exceeded
+	_, pipelineErr := p.ExecuteSync(ctx, sysElem, userElem)
+
+	// The pipeline MUST have failed (max rounds exceeded)
+	require.Error(t, pipelineErr, "pipeline should error on max rounds exceeded")
+	require.True(t, strings.Contains(pipelineErr.Error(), "max rounds"),
+		"error should mention 'max rounds', got: %v", pipelineErr)
+
+	// Load the conversation from the store
+	state, loadErr := arenaStore.Load(ctx, convID)
+	require.NoError(t, loadErr)
+	require.NotNil(t, state)
+
+	// Verify: messages must include more than just the system+user pre-population.
+	// At minimum we expect: system + user (pre-existing) + assistant (tool call) + tool result.
+	t.Logf("Messages in store after mid-loop error: %d", len(state.Messages))
+	for i, m := range state.Messages {
+		t.Logf("  [%d] role=%s content=%q toolResult=%v toolCalls=%v",
+			i, m.Role, m.Content, m.ToolResult != nil, m.ToolCalls)
+	}
+
+	require.GreaterOrEqual(t, len(state.Messages), 4,
+		"expected at least 4 messages (system+user+assistant+tool-result), got %d", len(state.Messages))
+
+	// Verify the roles are in the right order
+	roles := make([]string, len(state.Messages))
+	for i, m := range state.Messages {
+		if m.ToolResult != nil {
+			roles[i] = "tool"
+		} else {
+			roles[i] = m.Role
+		}
+	}
+	assert.Equal(t, "system", roles[0], "first message should be system")
+	assert.Equal(t, "user", roles[1], "second message should be user")
+	assert.Equal(t, "assistant", roles[2], "third message should be assistant (tool call)")
+	assert.Equal(t, "tool", roles[3], "fourth message should be tool result")
+
+	// Verify NO duplicate messages — idempotent dedup must work
+	for i := range state.Messages {
+		for j := i + 1; j < len(state.Messages); j++ {
+			if state.Messages[i].Role == state.Messages[j].Role &&
+				state.Messages[i].Content == state.Messages[j].Content &&
+				state.Messages[i].Role != "user" { // user "Call the echo tool" appears twice (pre-pop + pipeline input)
+				t.Errorf("duplicate message at [%d] and [%d]: role=%s content=%q",
+					i, j, state.Messages[i].Role, state.Messages[i].Content)
+			}
+		}
+	}
+}

--- a/tools/arena/stages/statestore_save_integration.go
+++ b/tools/arena/stages/statestore_save_integration.go
@@ -498,6 +498,13 @@ func ensureTrace(trace *pipeline.ExecutionTrace) *pipeline.ExecutionTrace {
 // Caller is responsible for loading the state once (via ensureLoaded) and
 // passing the same pointer back on subsequent calls within a Process
 // invocation — this is what avoids redundant Loads.
+//
+// When the store implements runtimeStatestore.MessageLog, messages were
+// already persisted per-round by the ProviderStage write-through. In that
+// case we read the authoritative transcript from the log instead of using
+// the pipeline-stream-collected slice (which may be incomplete on the error
+// path). This prevents both double-writing on success and message loss on
+// mid-loop errors.
 func (s *ArenaStateStoreSaveStage) persistState(
 	ctx context.Context,
 	arenaStore arenaSaveStore,
@@ -517,6 +524,26 @@ func (s *ArenaStateStoreSaveStage) persistState(
 	if systemPrompt == "" && s.config != nil && s.config.Metadata != nil {
 		if sp, ok := s.config.Metadata["system_prompt"].(string); ok && sp != "" {
 			systemPrompt = sp
+		}
+	}
+
+	// On the error path the ProviderStage emits only an error element — no
+	// response messages reach this stage's input channel, so messages is empty.
+	// If the store implements MessageLog the ProviderStage wrote per-round
+	// messages via LogAppend+preSeedLog (including history). Do a fresh Load()
+	// to recover the full transcript.
+	//
+	// On the success path messages already contains everything the pipeline
+	// emitted (including assertion-decorated messages from downstream stages);
+	// we must NOT replace it with a stale store snapshot that predates those
+	// decorations. The guard len(messages)==0 limits the recovery to the error
+	// path only.
+	if len(messages) == 0 && s.config != nil {
+		if _, ok := s.config.Store.(runtimeStatestore.MessageLog); ok {
+			freshState, freshErr := arenaStore.Load(ctx, s.config.ConversationID)
+			if freshErr == nil && freshState != nil && len(freshState.Messages) > 0 {
+				messages = freshState.Messages
+			}
 		}
 	}
 

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -925,6 +925,91 @@ func (s *ArenaStateStore) cloneRunMetadataSlices(cloned, m *RunMetadata) {
 	}
 }
 
+// LogAppend implements statestore.MessageLog. It appends messages to the
+// conversation's embedded Messages slice starting from startSeq. If
+// startSeq < current message count, the first (current-startSeq) inputs
+// are skipped (idempotent deduplication). Returns the new total count.
+//
+// Thread-safe via s.mu.
+func (s *ArenaStateStore) LogAppend(
+	ctx context.Context, id string, startSeq int, messages []types.Message,
+) (int, error) {
+	if len(messages) == 0 {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		if arenaState, ok := s.conversations[id]; ok {
+			return len(arenaState.Messages), nil
+		}
+		return 0, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	arenaState, exists := s.conversations[id]
+	if !exists {
+		arenaState = &ArenaConversationState{
+			ConversationState: runtimestore.ConversationState{ID: id},
+		}
+		s.conversations[id] = arenaState
+	}
+
+	current := len(arenaState.Messages)
+	skip := current - startSeq
+	if skip < 0 {
+		skip = 0
+	}
+	toAppend := messages
+	if skip > 0 {
+		if skip >= len(messages) {
+			return current, nil
+		}
+		toAppend = messages[skip:]
+	}
+	for i := range toAppend {
+		arenaState.Messages = append(arenaState.Messages, s.deepCloneMessage(&toAppend[i]))
+	}
+	return len(arenaState.Messages), nil
+}
+
+// LogLoad implements statestore.MessageLog. It returns messages for the
+// conversation. If recent > 0, returns only the last N messages. If
+// recent == 0, returns all messages. Returns an empty slice (not an error)
+// if the conversation doesn't exist.
+func (s *ArenaStateStore) LogLoad(ctx context.Context, id string, recent int) ([]types.Message, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	arenaState, exists := s.conversations[id]
+	if !exists {
+		return []types.Message{}, nil
+	}
+
+	msgs := arenaState.Messages
+	if recent > 0 && recent < len(msgs) {
+		msgs = msgs[len(msgs)-recent:]
+	}
+
+	out := make([]types.Message, len(msgs))
+	for i := range msgs {
+		out[i] = s.deepCloneMessage(&msgs[i])
+	}
+	return out, nil
+}
+
+// LogLen implements statestore.MessageLog. It returns the total message count
+// for the conversation. Returns 0 (not an error) if the conversation doesn't exist.
+func (s *ArenaStateStore) LogLen(ctx context.Context, id string) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	arenaState, exists := s.conversations[id]
+	if !exists {
+		return 0, nil
+	}
+	return len(arenaState.Messages), nil
+}
+
 // MediaOutput represents media content produced during a run
 type MediaOutput struct {
 	Type       string `json:"Type"`       // "image", "audio", "video"

--- a/tools/arena/statestore/store_test.go
+++ b/tools/arena/statestore/store_test.go
@@ -8,6 +8,162 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// ---- MessageLog tests (Piece 1) ----
+
+func TestLogAppend_EmptyStore_ReturnsLen(t *testing.T) {
+	s := NewArenaStateStore()
+	ctx := context.Background()
+	msgs := []types.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "hello"},
+	}
+	n, err := s.LogAppend(ctx, "conv1", 0, msgs)
+	if err != nil {
+		t.Fatalf("LogAppend error: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2, got %d", n)
+	}
+}
+
+func TestLogAppend_IdempotentReplay_NoDuplication(t *testing.T) {
+	s := NewArenaStateStore()
+	ctx := context.Background()
+	msgs := []types.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi"},
+	}
+	if _, err := s.LogAppend(ctx, "conv1", 0, msgs); err != nil {
+		t.Fatalf("first LogAppend error: %v", err)
+	}
+	// Replay from seq=1 (idempotent: skip first 2 already-persisted, append 3rd)
+	replayMsgs := []types.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi"},
+	}
+	n, err := s.LogAppend(ctx, "conv1", 0, replayMsgs)
+	if err != nil {
+		t.Fatalf("replay LogAppend error: %v", err)
+	}
+	// No growth: startSeq(0) < current(3), all 3 inputs are dupes, new total stays 3
+	if n != 3 {
+		t.Errorf("expected 3 after idempotent replay, got %d", n)
+	}
+	// Verify actual stored count doesn't grow
+	all, err := s.LogLoad(ctx, "conv1", 0)
+	if err != nil {
+		t.Fatalf("LogLoad error: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("expected 3 messages stored (no duplication), got %d", len(all))
+	}
+}
+
+func TestLogAppend_PartialReplay_AppendsTail(t *testing.T) {
+	s := NewArenaStateStore()
+	ctx := context.Background()
+	first := []types.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "hello"},
+	}
+	if _, err := s.LogAppend(ctx, "conv1", 0, first); err != nil {
+		t.Fatalf("first LogAppend error: %v", err)
+	}
+	// Append from seq=1: skip first 1 already-persisted (current=2 - startSeq=1 = 1 to skip)
+	second := []types.Message{
+		{Role: "user", Content: "hello"},   // already persisted, skip
+		{Role: "assistant", Content: "hi"}, // new
+	}
+	n, err := s.LogAppend(ctx, "conv1", 1, second)
+	if err != nil {
+		t.Fatalf("second LogAppend error: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("expected 3 total after partial replay, got %d", n)
+	}
+}
+
+func TestLogLoad_RecentNMessages(t *testing.T) {
+	s := NewArenaStateStore()
+	ctx := context.Background()
+	msgs := []types.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "u2"},
+		{Role: "assistant", Content: "a2"},
+	}
+	if _, err := s.LogAppend(ctx, "conv1", 0, msgs); err != nil {
+		t.Fatalf("LogAppend error: %v", err)
+	}
+
+	// recent=0 → all
+	all, err := s.LogLoad(ctx, "conv1", 0)
+	if err != nil {
+		t.Fatalf("LogLoad all error: %v", err)
+	}
+	if len(all) != 5 {
+		t.Errorf("expected 5 for recent=0, got %d", len(all))
+	}
+
+	// recent=2 → last 2
+	last2, err := s.LogLoad(ctx, "conv1", 2)
+	if err != nil {
+		t.Fatalf("LogLoad recent=2 error: %v", err)
+	}
+	if len(last2) != 2 {
+		t.Errorf("expected 2 for recent=2, got %d", len(last2))
+	}
+	if last2[0].Content != "u2" || last2[1].Content != "a2" {
+		t.Errorf("expected last 2 messages [u2, a2], got %v %v", last2[0].Content, last2[1].Content)
+	}
+}
+
+func TestLogLoad_MissingConversation_ReturnsEmptySlice(t *testing.T) {
+	s := NewArenaStateStore()
+	ctx := context.Background()
+	msgs, err := s.LogLoad(ctx, "missing", 0)
+	if err != nil {
+		t.Fatalf("expected no error for missing conv, got %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected empty slice for missing conv, got %d messages", len(msgs))
+	}
+}
+
+func TestLogLen_MissingConversation_ReturnsZero(t *testing.T) {
+	s := NewArenaStateStore()
+	ctx := context.Background()
+	n, err := s.LogLen(ctx, "missing")
+	if err != nil {
+		t.Fatalf("expected no error for missing conv, got %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 for missing conv, got %d", n)
+	}
+}
+
+func TestLogLen_AfterAppend(t *testing.T) {
+	s := NewArenaStateStore()
+	ctx := context.Background()
+	msgs := []types.Message{
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+	}
+	if _, err := s.LogAppend(ctx, "conv1", 0, msgs); err != nil {
+		t.Fatalf("LogAppend error: %v", err)
+	}
+	n, err := s.LogLen(ctx, "conv1")
+	if err != nil {
+		t.Fatalf("LogLen error: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2, got %d", n)
+	}
+}
+
 func TestUpdateLastAssistantMessage(t *testing.T) {
 	store := NewArenaStateStore()
 	ctx := context.Background()

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/openai"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
+	runtimestatestore "github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/storage"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -174,13 +175,22 @@ func buildStateStoreConfig(req *TurnRequest) *pipeline.StateStoreConfig {
 	}
 }
 
-// buildProviderConfig creates provider config from request
+// buildProviderConfig creates provider config from request.
+// When the state store implements runtimestatestore.MessageLog, it is wired for
+// per-round write-through so tool-loop messages survive a mid-loop error.
 func buildProviderConfig(req *TurnRequest) *stage.ProviderConfig {
-	return &stage.ProviderConfig{
+	cfg := &stage.ProviderConfig{
 		MaxTokens:   req.MaxTokens,
 		Temperature: float32(req.Temperature),
 		Seed:        req.Seed,
 	}
+	if req.StateStoreConfig != nil && req.StateStoreConfig.Store != nil && req.ConversationID != "" {
+		if ml, ok := req.StateStoreConfig.Store.(runtimestatestore.MessageLog); ok {
+			cfg.MessageLog = ml
+			cfg.MessageLogConvID = req.ConversationID
+		}
+	}
+	return cfg
 }
 
 // buildToolPolicy constructs tool policy from scenario config


### PR DESCRIPTION
## Problem

When a turn's `ProviderStage` errors mid-tool-loop (e.g. `max rounds (50) exceeded`), the **entire turn's messages, cost, and tool-stats were lost** — the run record kept only the system prompt. Arena never wired per-round write-through, so tool-loop messages were persisted **only by the end-of-turn save stage, which is skipped on error**. Result: an errored run reported `msgs=1, cost=$0, toolstats=null` despite real work having happened.

## Fix

Bring Arena to parity with the SDK's per-round write-through:

- Implement `statestore.MessageLog` (`LogAppend`/`LogLoad`/`LogLen`) on `ArenaStateStore`.
- Wire `MessageLog` + `MessageLogConvID` into Arena's `ProviderConfig` so the ProviderStage persists each round as it happens.
- Make the Arena save stage `MessageLog`-aware so messages aren't double-written.
- `preSeedLog` writes the initial history into the log so the full transcript survives even a round-1 error.

## Proven

A max-rounds-errored live Claude run went from `msgs=1 / cost=$0` to **`msgs=102`** (full `system/user/assistant×50/tool×50` transcript), **`cost=$6.37`**, **0 duplicates**. The cost-accounting `$0` gap fixed itself as a side effect (cost is derived from the now-persisted messages).

## Tests

- `ArenaStateStore` `LogAppend`/`LogLoad`/`LogLen` (append, idempotent dedup, recent, missing).
- Integration test: a mid-loop error preserves the accumulated `system/user/assistant/tool` transcript with no duplicates.
