### PR TITLE
feat(arena): bounded loop/cost caps (rounds + per-run $2 budget) + repeated-tool-call breaker

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -899,6 +899,16 @@ type ToolPolicy struct {
 	MaxToolCallsPerTurn int      `json:"max_tool_calls_per_turn" yaml:"max_tool_calls_per_turn"`
 	MaxTotalToolCalls   int      `json:"max_total_tool_calls" yaml:"max_total_tool_calls"`
 	Blocklist           []string `json:"blocklist,omitempty" yaml:"blocklist,omitempty"`
+	// MaxRounds is the maximum number of tool-call rounds per turn.
+	// 0/unset means use the Arena default (50). Never unlimited.
+	MaxRounds int `json:"max_rounds,omitempty" yaml:"max_rounds,omitempty"`
+	// MaxCostUSD is the maximum cost in USD allowed per turn.
+	// 0/unset means use the Arena default ($2.00). Never unlimited.
+	MaxCostUSD float64 `json:"max_cost_usd,omitempty" yaml:"max_cost_usd,omitempty"`
+	// MaxIdenticalToolCalls is the maximum number of times the same tool may be
+	// called with identical arguments before the loop is aborted.
+	// 0/unset means use the Arena default (3). Never unlimited.
+	MaxIdenticalToolCalls int `json:"max_identical_tool_calls,omitempty" yaml:"max_identical_tool_calls,omitempty"`
 }
 
 // Turn detection mode constants

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -25,6 +25,7 @@ import (
 const (
 	defaultMaxRounds            = 50
 	defaultMaxParallelToolCalls = 10
+	defaultMaxIdenticalCalls    = 3
 	toolChoiceAuto              = "auto"
 	toolChoiceNone              = "none"
 )
@@ -412,6 +413,50 @@ func (s *ProviderStage) getMaxRounds() int {
 	return defaultMaxRounds
 }
 
+// getMaxIdenticalToolCalls returns the threshold for aborting a loop where the
+// same tool is called repeatedly with identical arguments.
+func (s *ProviderStage) getMaxIdenticalToolCalls() int {
+	if s.toolPolicy != nil && s.toolPolicy.MaxIdenticalToolCalls > 0 {
+		return s.toolPolicy.MaxIdenticalToolCalls
+	}
+	return defaultMaxIdenticalCalls
+}
+
+// canonicalArgs returns a stable, order-insensitive string representation of
+// raw JSON arguments for use as an identical-call detection key. If the raw
+// bytes cannot be parsed as JSON, the raw bytes are used directly so the key
+// is still meaningful (just byte-order-sensitive).
+func canonicalArgs(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}
+
+// checkIdenticalToolCalls increments per-call counters and returns an error if
+// any single (tool, args) pair exceeds the configured threshold.
+func (tl *toolLoop) checkIdenticalToolCalls(toolCalls []types.MessageToolCall) error {
+	threshold := tl.stage.getMaxIdenticalToolCalls()
+	for _, tc := range toolCalls {
+		key := tc.Name + "\x00" + canonicalArgs(tc.Args)
+		tl.identicalCallCounts[key]++
+		if tl.identicalCallCounts[key] >= threshold {
+			return fmt.Errorf(
+				"provider stage: tool loop detected: %q called %d times with identical arguments",
+				tc.Name, tl.identicalCallCounts[key])
+		}
+	}
+	return nil
+}
+
 func (s *ProviderStage) executeStreamingMultiRound(
 	ctx context.Context,
 	acc *providerInput,
@@ -445,15 +490,16 @@ func (s *ProviderStage) executeStreamingMultiRound(
 
 // toolLoop holds shared state for multi-round tool execution.
 type toolLoop struct {
-	stage            *ProviderStage
-	messages         []types.Message
-	providerTools    interface{}
-	toolChoice       string
-	maxRounds        int
-	excluded         map[string]bool
-	rejectionCounts  map[string]int
-	lastPersistedSeq int     // messages persisted so far via MessageLog
-	cumulativeCost   float64 // accumulated cost across rounds
+	stage               *ProviderStage
+	messages            []types.Message
+	providerTools       interface{}
+	toolChoice          string
+	maxRounds           int
+	excluded            map[string]bool
+	rejectionCounts     map[string]int
+	identicalCallCounts map[string]int // keyed by "toolName\x00<canonical-args>"
+	lastPersistedSeq    int            // messages persisted so far via MessageLog
+	cumulativeCost      float64        // accumulated cost across rounds
 }
 
 func (s *ProviderStage) newToolLoop(acc *providerInput) (*toolLoop, error) {
@@ -463,14 +509,15 @@ func (s *ProviderStage) newToolLoop(acc *providerInput) (*toolLoop, error) {
 		return nil, fmt.Errorf("provider stage: %w", err)
 	}
 	return &toolLoop{
-		stage:            s,
-		messages:         acc.messages,
-		providerTools:    providerTools,
-		toolChoice:       toolChoice,
-		maxRounds:        s.getMaxRounds(),
-		excluded:         excluded,
-		rejectionCounts:  map[string]int{},
-		lastPersistedSeq: len(acc.messages), // history already in store
+		stage:               s,
+		messages:            acc.messages,
+		providerTools:       providerTools,
+		toolChoice:          toolChoice,
+		maxRounds:           s.getMaxRounds(),
+		excluded:            excluded,
+		rejectionCounts:     map[string]int{},
+		identicalCallCounts: map[string]int{},
+		lastPersistedSeq:    len(acc.messages), // history already in store
 	}, nil
 }
 
@@ -500,6 +547,13 @@ func (tl *toolLoop) afterRound(
 	if !hasToolCalls {
 		tl.persistMessages(ctx, round)
 		return true, tl.messages, nil
+	}
+
+	// Repeated-identical-call breaker: abort before executing tool calls if the
+	// same tool has been called with the same arguments too many times.
+	if err := tl.checkIdenticalToolCalls(response.ToolCalls); err != nil {
+		tl.persistMessages(ctx, round)
+		return true, tl.messages, err
 	}
 
 	toolResults, err := tl.stage.executeToolCalls(ctx, response.ToolCalls)

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -518,7 +518,26 @@ func (s *ProviderStage) newToolLoop(acc *providerInput) (*toolLoop, error) {
 		rejectionCounts:     map[string]int{},
 		identicalCallCounts: map[string]int{},
 		lastPersistedSeq:    len(acc.messages), // history already in store
+		// Seed with the cost already incurred in this conversation (prior
+		// turns), so MaxCostUSD bounds the whole RUN, not just this turn's
+		// loop. Arena builds a fresh pipeline (and toolLoop) per turn, so
+		// without this seed the cap would reset every turn and a multi-turn
+		// run could spend MaxCostUSD per turn. History cost is carried on the
+		// input messages' CostInfo.
+		cumulativeCost: sumHistoryCost(acc.messages),
 	}, nil
+}
+
+// sumHistoryCost totals the CostInfo across the conversation history fed into
+// this turn — i.e. the run's spend before this turn's loop begins.
+func sumHistoryCost(messages []types.Message) float64 {
+	var total float64
+	for i := range messages {
+		if messages[i].CostInfo != nil {
+			total += messages[i].CostInfo.TotalCost
+		}
+	}
+	return total
 }
 
 // afterRound handles tool execution, rejection tracking, and loop control after

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -3015,3 +3015,105 @@ func TestProviderStage_StopOnTool(t *testing.T) {
 		assert.Contains(t, err.Error(), "max rounds")
 	})
 }
+
+// TestAfterRound_IdenticalToolCallBreaker verifies that the repeated-identical-call
+// guard aborts the loop when the same tool is called with identical arguments
+// MaxIdenticalToolCalls times.
+func TestAfterRound_IdenticalToolCallBreaker(t *testing.T) {
+	provider := mock.NewToolProvider("test", "model", false, nil)
+	registry := tools.NewRegistry()
+	err := registry.Register(&tools.ToolDescriptor{
+		Name:        "loop_tool",
+		Description: "a tool that loops forever",
+		InputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:        "mock",
+	})
+	require.NoError(t, err)
+
+	t.Run("aborts at threshold with identical args", func(t *testing.T) {
+		stg := NewProviderStage(provider, registry,
+			&pipeline.ToolPolicy{MaxIdenticalToolCalls: 3},
+			&ProviderConfig{},
+		)
+
+		acc := &providerInput{
+			allowedTools: []string{"loop_tool"},
+			messages:     []types.Message{{Role: "user", Content: "go"}},
+		}
+		loop, err := stg.newToolLoop(acc)
+		require.NoError(t, err)
+		loop.maxRounds = 10 // high so rounds don't interfere
+
+		identicalArgs := json.RawMessage(`{"query":"same"}`)
+		// Round 1 and 2: below threshold — should continue
+		for round := 1; round <= 2; round++ {
+			response := types.Message{
+				Role: "assistant",
+				ToolCalls: []types.MessageToolCall{
+					{ID: fmt.Sprintf("c%d", round), Name: "loop_tool", Args: identicalArgs},
+				},
+			}
+			done, _, loopErr := loop.afterRound(context.Background(), []string{"loop_tool"}, &response, true, round)
+			assert.False(t, done, "round %d: should not stop before threshold", round)
+			require.NoError(t, loopErr, "round %d: should not error before threshold", round)
+		}
+
+		// Round 3: hits threshold — must abort
+		response3 := types.Message{
+			Role: "assistant",
+			ToolCalls: []types.MessageToolCall{
+				{ID: "c3", Name: "loop_tool", Args: identicalArgs},
+			},
+		}
+		done, _, loopErr := loop.afterRound(context.Background(), []string{"loop_tool"}, &response3, true, 3)
+		assert.True(t, done, "should stop at threshold")
+		require.Error(t, loopErr, "should return error at threshold")
+		assert.Contains(t, loopErr.Error(), "tool loop detected")
+		assert.Contains(t, loopErr.Error(), "loop_tool")
+	})
+
+	t.Run("does not abort when args differ each round", func(t *testing.T) {
+		stg := NewProviderStage(provider, registry,
+			&pipeline.ToolPolicy{MaxIdenticalToolCalls: 3},
+			&ProviderConfig{},
+		)
+
+		acc := &providerInput{
+			allowedTools: []string{"loop_tool"},
+			messages:     []types.Message{{Role: "user", Content: "go"}},
+		}
+		loop, err := stg.newToolLoop(acc)
+		require.NoError(t, err)
+		loop.maxRounds = 10
+
+		// Each round uses different args — should not trip the breaker
+		for round := 1; round <= 5; round++ {
+			response := types.Message{
+				Role: "assistant",
+				ToolCalls: []types.MessageToolCall{
+					{ID: fmt.Sprintf("c%d", round), Name: "loop_tool",
+						Args: json.RawMessage(fmt.Sprintf(`{"query":"step-%d"}`, round))},
+				},
+			}
+			done, _, loopErr := loop.afterRound(context.Background(), []string{"loop_tool"}, &response, true, round)
+			// round == loop.maxRounds would stop; otherwise should continue without error
+			if round < loop.maxRounds {
+				assert.False(t, done, "round %d: varying args should not trip breaker", round)
+				require.NoError(t, loopErr, "round %d: varying args should not error", round)
+			}
+		}
+	})
+
+	t.Run("default threshold is 3 when policy field is zero", func(t *testing.T) {
+		stg := NewProviderStage(provider, registry,
+			&pipeline.ToolPolicy{MaxIdenticalToolCalls: 0}, // 0 = use default
+			&ProviderConfig{},
+		)
+		assert.Equal(t, 3, stg.getMaxIdenticalToolCalls())
+	})
+
+	t.Run("nil policy uses default threshold", func(t *testing.T) {
+		stg := NewProviderStage(provider, registry, nil, &ProviderConfig{})
+		assert.Equal(t, 3, stg.getMaxIdenticalToolCalls())
+	})
+}

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -2847,6 +2847,55 @@ func TestAfterRound_CostBudgetZeroIsUnlimited(t *testing.T) {
 	require.NoError(t, err, "should not error — zero MaxCostUSD means unlimited")
 }
 
+// TestNewToolLoop_CostBudgetIsPerRun verifies MaxCostUSD bounds the whole run,
+// not just this turn's loop: newToolLoop seeds cumulativeCost from the cost
+// already carried on the input history, so a fresh-per-turn loop still trips
+// the budget on accumulated prior spend.
+func TestNewToolLoop_CostBudgetIsPerRun(t *testing.T) {
+	provider := mock.NewToolProvider("test", "model", false, nil)
+	registry := tools.NewRegistry()
+	require.NoError(t, registry.Register(&tools.ToolDescriptor{
+		Name:        "test_tool",
+		Description: "test",
+		InputSchema: json.RawMessage(`{"type": "object"}`),
+		Mode:        "mock",
+	}))
+
+	stage := NewProviderStage(provider, registry,
+		&pipeline.ToolPolicy{MaxCostUSD: 0.10},
+		&ProviderConfig{},
+	)
+
+	// Prior turns of this run already cost 0.08 (carried on message CostInfo).
+	acc := &providerInput{
+		allowedTools: []string{"test_tool"},
+		messages: []types.Message{
+			{Role: "user", Content: "hi"},
+			{Role: "assistant", Content: "prior turn", CostInfo: &types.CostInfo{TotalCost: 0.05}},
+			{Role: "tool", Content: "res", CostInfo: &types.CostInfo{TotalCost: 0.03}},
+		},
+	}
+	loop, err := stage.newToolLoop(acc)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.08, loop.cumulativeCost, 0.001,
+		"cumulativeCost should be seeded from prior-turn history cost")
+
+	// This turn's first round costs only 0.05 — under the cap on its own — but
+	// 0.08 (prior) + 0.05 = 0.13 > 0.10, so the RUN budget trips.
+	response := types.Message{
+		Role:     "assistant",
+		CostInfo: &types.CostInfo{TotalCost: 0.05},
+		ToolCalls: []types.MessageToolCall{
+			{ID: "c1", Name: "test_tool", Args: json.RawMessage(`{}`)},
+		},
+	}
+	done, msgs, err := loop.afterRound(context.Background(), []string{"test_tool"}, &response, true, 1)
+	assert.True(t, done, "run budget should trip from accumulated prior cost")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cost budget exceeded")
+	assert.NotEmpty(t, msgs, "should return messages even on budget exceeded")
+}
+
 func TestAfterRound_CompactionEmitsEvent(t *testing.T) {
 	provider := mock.NewToolProvider("test", "model", false, nil)
 	registry := tools.NewRegistry()

--- a/runtime/pipeline/types.go
+++ b/runtime/pipeline/types.go
@@ -20,6 +20,10 @@ type ToolPolicy struct {
 	MaxCallsPerMinute    int      `json:"max_calls_per_minute,omitempty"`    // Per-tool calls/minute (0=unlimited)
 	MaxCostUSD           float64  `json:"max_cost_usd,omitempty"`            // Cost budget in USD (0=unlimited)
 	Blocklist            []string `json:"blocklist,omitempty"`
+	// MaxIdenticalToolCalls is the maximum number of times the same tool may be called
+	// with identical arguments before the loop is aborted as an infinite-loop guard.
+	// 0/unset means use the default (3). Never set to unlimited — use a large number instead.
+	MaxIdenticalToolCalls int `json:"max_identical_tool_calls,omitempty"`
 	// StopOnTool, when non-empty, stops the agent tool loop at the end of any round
 	// in which a tool with this name was called (RFC 0010 termination.tool_called).
 	StopOnTool string `json:"stop_on_tool,omitempty"`

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2728,6 +2728,15 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "max_rounds": {
+          "type": "integer"
+        },
+        "max_cost_usd": {
+          "type": "number"
+        },
+        "max_identical_tool_calls": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -467,6 +467,15 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "max_rounds": {
+          "type": "integer"
+        },
+        "max_cost_usd": {
+          "type": "number"
+        },
+        "max_identical_tool_calls": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/agentkb/schemas/arena.json
+++ b/tools/arena/agentkb/schemas/arena.json
@@ -2728,6 +2728,15 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "max_rounds": {
+          "type": "integer"
+        },
+        "max_cost_usd": {
+          "type": "number"
+        },
+        "max_identical_tool_calls": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/agentkb/schemas/scenario.json
+++ b/tools/arena/agentkb/schemas/scenario.json
@@ -467,6 +467,15 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "max_rounds": {
+          "type": "integer"
+        },
+        "max_cost_usd": {
+          "type": "number"
+        },
+        "max_identical_tool_calls": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/turnexecutors/pipeline_executor_helpers_test.go
+++ b/tools/arena/turnexecutors/pipeline_executor_helpers_test.go
@@ -179,59 +179,90 @@ func TestBuildProviderConfig(t *testing.T) {
 }
 
 func TestBuildToolPolicy(t *testing.T) {
-	tests := []struct {
-		name     string
-		scenario *config.Scenario
-		want     *pipeline.ToolPolicy
-	}{
-		{
-			name:     "nil scenario returns nil",
-			scenario: nil,
-			want:     nil,
-		},
-		{
-			name: "scenario without tool policy returns nil",
-			scenario: &config.Scenario{
-				ID: "test",
-			},
-			want: nil,
-		},
-		{
-			name: "scenario with tool policy returns configured policy",
-			scenario: &config.Scenario{
-				ID: "test",
-				ToolPolicy: &config.ToolPolicy{
-					ToolChoice:          "auto",
-					MaxToolCallsPerTurn: 5,
-					Blocklist:           []string{"dangerous_tool"},
-				},
-			},
-			want: &pipeline.ToolPolicy{
-				ToolChoice:          "auto",
-				MaxRounds:           0,
-				MaxToolCallsPerTurn: 5,
-				Blocklist:           []string{"dangerous_tool"},
-			},
-		},
-	}
+	t.Run("nil scenario always returns non-nil policy with defaults", func(t *testing.T) {
+		got := buildToolPolicy(nil)
+		if got == nil {
+			t.Fatal("buildToolPolicy(nil) returned nil, want non-nil policy with defaults")
+		}
+		if got.MaxRounds != 50 {
+			t.Errorf("MaxRounds = %d, want 50 (default)", got.MaxRounds)
+		}
+		if got.MaxCostUSD != defaultArenaMaxCostUSD {
+			t.Errorf("MaxCostUSD = %f, want %f (default)", got.MaxCostUSD, defaultArenaMaxCostUSD)
+		}
+		if got.MaxIdenticalToolCalls != 3 {
+			t.Errorf("MaxIdenticalToolCalls = %d, want 3 (default)", got.MaxIdenticalToolCalls)
+		}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := buildToolPolicy(tt.scenario)
-			if (got == nil) != (tt.want == nil) {
-				t.Errorf("buildToolPolicy() = %v, want %v", got, tt.want)
-				return
-			}
-			if got != nil && tt.want != nil {
-				if got.ToolChoice != tt.want.ToolChoice {
-					t.Errorf("ToolChoice = %s, want %s", got.ToolChoice, tt.want.ToolChoice)
-				}
-				if got.MaxToolCallsPerTurn != tt.want.MaxToolCallsPerTurn {
-					t.Errorf("MaxToolCallsPerTurn = %d, want %d", got.MaxToolCallsPerTurn, tt.want.MaxToolCallsPerTurn)
-				}
-			}
+	t.Run("scenario without tool_policy returns non-nil policy with defaults", func(t *testing.T) {
+		got := buildToolPolicy(&config.Scenario{ID: "test"})
+		if got == nil {
+			t.Fatal("buildToolPolicy() returned nil, want non-nil policy with defaults")
+		}
+		if got.MaxRounds != 50 {
+			t.Errorf("MaxRounds = %d, want 50 (default)", got.MaxRounds)
+		}
+		if got.MaxCostUSD != defaultArenaMaxCostUSD {
+			t.Errorf("MaxCostUSD = %f, want %f (default)", got.MaxCostUSD, defaultArenaMaxCostUSD)
+		}
+		if got.MaxIdenticalToolCalls != 3 {
+			t.Errorf("MaxIdenticalToolCalls = %d, want 3 (default)", got.MaxIdenticalToolCalls)
+		}
+	})
+
+	t.Run("scenario with tool_policy honors explicit overrides", func(t *testing.T) {
+		got := buildToolPolicy(&config.Scenario{
+			ID: "test",
+			ToolPolicy: &config.ToolPolicy{
+				ToolChoice:            "auto",
+				MaxToolCallsPerTurn:   5,
+				Blocklist:             []string{"dangerous_tool"},
+				MaxRounds:             10,
+				MaxCostUSD:            5.00,
+				MaxIdenticalToolCalls: 7,
+			},
 		})
-	}
+		if got == nil {
+			t.Fatal("buildToolPolicy() returned nil")
+		}
+		if got.ToolChoice != "auto" {
+			t.Errorf("ToolChoice = %s, want auto", got.ToolChoice)
+		}
+		if got.MaxToolCallsPerTurn != 5 {
+			t.Errorf("MaxToolCallsPerTurn = %d, want 5", got.MaxToolCallsPerTurn)
+		}
+		if len(got.Blocklist) != 1 || got.Blocklist[0] != "dangerous_tool" {
+			t.Errorf("Blocklist = %v, want [dangerous_tool]", got.Blocklist)
+		}
+		if got.MaxRounds != 10 {
+			t.Errorf("MaxRounds = %d, want 10", got.MaxRounds)
+		}
+		if got.MaxCostUSD != 5.00 {
+			t.Errorf("MaxCostUSD = %f, want 5.00", got.MaxCostUSD)
+		}
+		if got.MaxIdenticalToolCalls != 7 {
+			t.Errorf("MaxIdenticalToolCalls = %d, want 7", got.MaxIdenticalToolCalls)
+		}
+	})
+
+	t.Run("MaxCostUSD is never zero even if scenario sets 0", func(t *testing.T) {
+		got := buildToolPolicy(&config.Scenario{
+			ID: "test",
+			ToolPolicy: &config.ToolPolicy{
+				MaxCostUSD: 0, // unset — must use default, not zero/unlimited
+			},
+		})
+		if got == nil {
+			t.Fatal("buildToolPolicy() returned nil")
+		}
+		if got.MaxCostUSD == 0 {
+			t.Errorf("MaxCostUSD = 0, want %f (default, never unlimited)", defaultArenaMaxCostUSD)
+		}
+		if got.MaxCostUSD != defaultArenaMaxCostUSD {
+			t.Errorf("MaxCostUSD = %f, want %f", got.MaxCostUSD, defaultArenaMaxCostUSD)
+		}
+	})
 }
 
 func TestBuildMediaConfig(t *testing.T) {

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -193,18 +193,46 @@ func buildProviderConfig(req *TurnRequest) *stage.ProviderConfig {
 	return cfg
 }
 
-// buildToolPolicy constructs tool policy from scenario config
+// defaultArenaMaxCostUSD is the cost cap applied to every Arena turn when no
+// explicit max_cost_usd is configured. 0/unset in the scenario always maps to
+// this value — Arena never allows unlimited cost runs.
+const defaultArenaMaxCostUSD = 2.00
+
+// buildToolPolicy constructs tool policy from scenario config.
+// It always returns a non-nil *pipeline.ToolPolicy with finite safety caps:
+//   - MaxRounds: scenario value if >0, else 50
+//   - MaxCostUSD: scenario value if >0, else defaultArenaMaxCostUSD ($2.00)
+//   - MaxIdenticalToolCalls: scenario value if >0, else 3
 func buildToolPolicy(scenario *config.Scenario) *pipeline.ToolPolicy {
-	if scenario == nil || scenario.ToolPolicy == nil {
-		return nil
+	const defaultRounds = 50
+	const defaultIdentical = 3
+
+	policy := &pipeline.ToolPolicy{
+		MaxRounds:             defaultRounds,
+		MaxCostUSD:            defaultArenaMaxCostUSD,
+		MaxIdenticalToolCalls: defaultIdentical,
 	}
 
-	return &pipeline.ToolPolicy{
-		ToolChoice:          scenario.ToolPolicy.ToolChoice,
-		MaxRounds:           0, // Not supported in config, using unlimited
-		MaxToolCallsPerTurn: scenario.ToolPolicy.MaxToolCallsPerTurn,
-		Blocklist:           scenario.ToolPolicy.Blocklist,
+	if scenario == nil || scenario.ToolPolicy == nil {
+		return policy
 	}
+
+	sp := scenario.ToolPolicy
+	policy.ToolChoice = sp.ToolChoice
+	policy.MaxToolCallsPerTurn = sp.MaxToolCallsPerTurn
+	policy.Blocklist = sp.Blocklist
+
+	if sp.MaxRounds > 0 {
+		policy.MaxRounds = sp.MaxRounds
+	}
+	if sp.MaxCostUSD > 0 {
+		policy.MaxCostUSD = sp.MaxCostUSD
+	}
+	if sp.MaxIdenticalToolCalls > 0 {
+		policy.MaxIdenticalToolCalls = sp.MaxIdenticalToolCalls
+	}
+
+	return policy
 }
 
 // buildMediaConfig creates media externalizer config


### PR DESCRIPTION
## Problem

Arena runs had **no cost cap and no configurable round cap**. `buildToolPolicy` returned `nil` when a scenario declared no `tool_policy`, and even otherwise left `MaxRounds: 0` (→ hardcoded 50) and never set `MaxCostUSD` (→ unlimited). A runaway agentic loop could burn unbounded spend — a single observed authoring run cost **~$6** before hitting the round wall.

## Fix

Three guards, all **finite, all overrideable, none ever unlimited** (`0`/unset always means "use default", never "disable"):

| Guard | Default | Override |
|---|---|---|
| Round cap | 50 | `tool_policy.max_rounds` |
| **Cost cap (whole run)** | **$2.00** | `tool_policy.max_cost_usd` |
| Repeated-identical-tool-call breaker | 3 | `tool_policy.max_identical_tool_calls` |

- `buildToolPolicy` now **always** returns a finite-capped policy, even when the scenario declares no `tool_policy`.
- The cost cap is a **per-run** budget: `newToolLoop` seeds `cumulativeCost` from the cost already on the conversation history, so `MaxCostUSD` bounds the whole run (not per-turn-loop) and is enforced every round.
- The repeated-call breaker lives in the runtime `ProviderStage` (keyed on tool name + canonical-JSON args), so it protects the SDK too. It allows one retry and trips on the 3rd identical call.
- New `tool_policy` config fields + regenerated schemas.

## Known limitation (deliberate)

The cost cap covers **agent inference + self-play + STT/TTS** (all folded into the run total). **Judge/eval LLM calls** run *after* the conversation loop; their cost is emitted as telemetry events but is **not** folded into the run total or the cap. Documented as a known limitation; closing it is a separate "complete run cost accounting" follow-up.

## Tests

- Repeated-call breaker: aborts at threshold with identical args; does not trip when args vary; default/zero/nil-policy thresholds.
- Per-run cost cap: a round under-budget on its own still trips once seeded prior-turn cost is added.
- `buildToolPolicy` defaults (nil scenario / no tool_policy) and explicit overrides; `MaxCostUSD` never 0.
