### PR TITLE
fix(providers): enable Claude prompt caching by default + provider-config opt-out

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1395,6 +1395,9 @@ type ProviderDefaults struct {
 	Temperature float32 `json:"temperature" yaml:"temperature"`
 	TopP        float32 `json:"top_p" yaml:"top_p"`
 	MaxTokens   int     `json:"max_tokens" yaml:"max_tokens"`
+	// PromptCaching controls Anthropic prompt caching. Omit or set true to enable
+	// (the default); set false to disable. Only affects Claude providers.
+	PromptCaching *bool `json:"prompt_caching,omitempty" yaml:"prompt_caching,omitempty"`
 }
 
 // PromptConfigSchema represents a PromptConfig in K8s-style manifest format for schema generation

--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -476,21 +476,11 @@ type claudeError struct {
 	Message string `json:"message"`
 }
 
-// supportsCaching returns true if the model supports prompt caching
+// supportsCaching returns true if prompt caching should be enabled.
+// All Anthropic models support caching by default; set DisablePromptCaching in
+// ProviderDefaults to opt out (e.g. when the provider config sets prompt_caching: false).
 func (p *Provider) supportsCaching() bool {
-	// Claude 3.5 Haiku does not support prompt caching as of October 2024
-	// Only Claude 3.5 Sonnet and Claude 3 Opus support it
-	switch p.model {
-	case "claude-3-5-haiku-20241022":
-		return false
-	case "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20240620":
-		return true
-	case "claude-3-opus-20240229":
-		return true
-	default:
-		// For unknown models, disable caching to be safe
-		return false
-	}
+	return !p.defaults.DisablePromptCaching
 }
 
 // convertMessagesToClaudeFormat converts provider messages to Claude format with cache control.

--- a/runtime/providers/claude/claude_cache_test.go
+++ b/runtime/providers/claude/claude_cache_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
-// TestClaudeProvider_CacheControlNotSentForHaiku tests that cache_control is not included
-// for models that don't support it (like Claude 3.5 Haiku)
-func TestClaudeProvider_CacheControlNotSentForHaiku(t *testing.T) {
+// TestClaudeProvider_CacheControlNotSentWhenDisabled tests that cache_control is not included
+// when DisablePromptCaching is set to true in ProviderDefaults.
+func TestClaudeProvider_CacheControlNotSentWhenDisabled(t *testing.T) {
 	// Create a test server that captures the request
 	var capturedRequest map[string]interface{}
 
@@ -32,7 +32,7 @@ func TestClaudeProvider_CacheControlNotSentForHaiku(t *testing.T) {
 			"type":    "message",
 			"role":    "assistant",
 			"content": []map[string]string{{"type": "text", "text": "Hello"}},
-			"model":   "claude-3-5-haiku-20241022",
+			"model":   "claude-haiku-4-5",
 			"usage": map[string]int{
 				"input_tokens":  10,
 				"output_tokens": 5,
@@ -45,15 +45,16 @@ func TestClaudeProvider_CacheControlNotSentForHaiku(t *testing.T) {
 	os.Setenv("ANTHROPIC_API_KEY", "test-key")
 	defer os.Unsetenv("ANTHROPIC_API_KEY")
 
-	// Create provider with Haiku model
+	// Create provider with caching explicitly disabled via DisablePromptCaching
 	provider := NewProvider(
 		"test-haiku",
-		"claude-3-5-haiku-20241022",
+		"claude-haiku-4-5",
 		server.URL,
 		providers.ProviderDefaults{
-			Temperature: 0.7,
-			MaxTokens:   100,
-			TopP:        1.0,
+			Temperature:          0.7,
+			MaxTokens:            100,
+			TopP:                 1.0,
+			DisablePromptCaching: true,
 		},
 		false,
 	)
@@ -99,15 +100,110 @@ func TestClaudeProvider_CacheControlNotSentForHaiku(t *testing.T) {
 		t.Fatal("First content is not a map")
 	}
 
-	// cache_control should NOT be present for Haiku (causes 400 error)
+	// cache_control should NOT be present when DisablePromptCaching is true
 	if cacheControl, exists := firstContent["cache_control"]; exists {
-		t.Errorf("cache_control should not be sent for Claude 3.5 Haiku, but found: %v", cacheControl)
-		t.Errorf("This causes a 400 error: 'messages.0.cache_control: Extra inputs are not permitted'")
+		t.Errorf("cache_control should not be sent when DisablePromptCaching=true, but found: %v", cacheControl)
 	}
 }
 
-// TestToolProvider_CacheControlNotSentForHaiku tests the same for tool provider
-func TestToolProvider_CacheControlNotSentForHaiku(t *testing.T) {
+// TestClaudeProvider_CacheControlSentForCurrentModels tests that cache_control IS included
+// for current models (haiku-4-5, sonnet-4-6, opus-4-8) when caching is enabled (default).
+func TestClaudeProvider_CacheControlSentForCurrentModels(t *testing.T) {
+	currentModels := []string{
+		"claude-haiku-4-5",
+		"claude-sonnet-4-6",
+		"claude-opus-4-8",
+	}
+
+	for _, model := range currentModels {
+		t.Run(model, func(t *testing.T) {
+			var capturedRequest map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&capturedRequest); err != nil {
+					t.Fatalf("Failed to decode request: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":      "msg_test",
+					"type":    "message",
+					"role":    "assistant",
+					"content": []map[string]string{{"type": "text", "text": "Hello"}},
+					"model":   model,
+					"usage": map[string]int{
+						"input_tokens":  10,
+						"output_tokens": 5,
+					},
+				})
+			}))
+			defer server.Close()
+
+			os.Setenv("ANTHROPIC_API_KEY", "test-key")
+			defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+			provider := NewProvider(
+				"test-provider",
+				model,
+				server.URL,
+				providers.ProviderDefaults{
+					Temperature: 0.7,
+					MaxTokens:   100,
+					TopP:        1.0,
+					// DisablePromptCaching defaults to false → caching enabled
+				},
+				false,
+			)
+
+			longContent := ""
+			for i := 0; i < 10000; i++ {
+				longContent += "This is a long message to test caching. "
+			}
+
+			req := providers.PredictionRequest{
+				Messages: []types.Message{
+					{Role: "user", Content: longContent},
+				},
+				Temperature: 0.7,
+				MaxTokens:   100,
+			}
+
+			_, err := provider.Predict(context.Background(), req)
+			if err != nil {
+				t.Fatalf("Predict failed: %v", err)
+			}
+
+			messages, ok := capturedRequest["messages"].([]interface{})
+			if !ok || len(messages) == 0 {
+				t.Fatal("No messages in captured request")
+			}
+
+			firstMessage, ok := messages[0].(map[string]interface{})
+			if !ok {
+				t.Fatal("First message is not a map")
+			}
+
+			content, ok := firstMessage["content"].([]interface{})
+			if !ok || len(content) == 0 {
+				t.Fatal("No content in first message")
+			}
+
+			firstContent, ok := content[0].(map[string]interface{})
+			if !ok {
+				t.Fatal("First content is not a map")
+			}
+
+			// cache_control SHOULD be present for current models with caching enabled
+			if _, exists := firstContent["cache_control"]; !exists {
+				t.Errorf("cache_control should be sent for %q with default caching settings, but was absent", model)
+			}
+		})
+	}
+}
+
+// TestToolProvider_CacheControlNotSentWhenDisabled tests that the tool provider does not
+// send cache_control when DisablePromptCaching is set to true in ProviderDefaults.
+func TestToolProvider_CacheControlNotSentWhenDisabled(t *testing.T) {
 	// Create a test server that captures the request
 	var capturedRequest map[string]interface{}
 
@@ -125,7 +221,7 @@ func TestToolProvider_CacheControlNotSentForHaiku(t *testing.T) {
 			"type":    "message",
 			"role":    "assistant",
 			"content": []map[string]string{{"type": "text", "text": "Hello"}},
-			"model":   "claude-3-5-haiku-20241022",
+			"model":   "claude-haiku-4-5",
 			"usage": map[string]int{
 				"input_tokens":  10,
 				"output_tokens": 5,
@@ -138,15 +234,16 @@ func TestToolProvider_CacheControlNotSentForHaiku(t *testing.T) {
 	os.Setenv("ANTHROPIC_API_KEY", "test-key")
 	defer os.Unsetenv("ANTHROPIC_API_KEY")
 
-	// Create tool provider with Haiku model
+	// Create tool provider with caching explicitly disabled
 	provider := NewToolProvider(
-		"test-haiku",
-		"claude-3-5-haiku-20241022",
+		"test-provider",
+		"claude-haiku-4-5",
 		server.URL,
 		providers.ProviderDefaults{
-			Temperature: 0.7,
-			MaxTokens:   100,
-			TopP:        1.0,
+			Temperature:          0.7,
+			MaxTokens:            100,
+			TopP:                 1.0,
+			DisablePromptCaching: true,
 		},
 		false,
 	)
@@ -180,13 +277,13 @@ func TestToolProvider_CacheControlNotSentForHaiku(t *testing.T) {
 		t.Fatalf("PredictWithTools failed: %v", err)
 	}
 
-	// Verify that cache_control was NOT sent in system blocks
+	// Verify that cache_control was NOT sent in system blocks when disabled
 	system, ok := capturedRequest["system"].([]interface{})
 	if ok && len(system) > 0 {
 		systemBlock, ok := system[0].(map[string]interface{})
 		if ok {
 			if cacheControl, exists := systemBlock["cache_control"]; exists {
-				t.Errorf("cache_control should not be sent for Claude 3.5 Haiku system prompt, but found: %v", cacheControl)
+				t.Errorf("cache_control should not be sent when DisablePromptCaching=true, but found: %v", cacheControl)
 			}
 		}
 	}
@@ -201,7 +298,7 @@ func TestToolProvider_CacheControlNotSentForHaiku(t *testing.T) {
 				lastContent, ok := content[0].(map[string]interface{})
 				if ok {
 					if cacheControl, exists := lastContent["cache_control"]; exists {
-						t.Errorf("cache_control should not be sent for Claude 3.5 Haiku message, but found: %v", cacheControl)
+						t.Errorf("cache_control should not be sent when DisablePromptCaching=true, but found: %v", cacheControl)
 					}
 				}
 			}

--- a/runtime/providers/claude/claude_integration_test.go
+++ b/runtime/providers/claude/claude_integration_test.go
@@ -311,11 +311,11 @@ func TestConvertMessagesToClaudeFormat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &Provider{
-				model: "claude-3-5-sonnet-20241022", // Supports caching
-			}
-
-			if !tt.supportsCaching {
-				provider.model = "claude-2" // Doesn't support caching
+				model: "claude-sonnet-4-6",
+				defaults: providers.ProviderDefaults{
+					// DisablePromptCaching controls caching; model name no longer matters
+					DisablePromptCaching: !tt.supportsCaching,
+				},
 			}
 
 			result := provider.convertMessagesToClaudeFormat(tt.messages)
@@ -368,11 +368,11 @@ func TestCreateSystemBlocks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &Provider{
-				model: "claude-3-5-sonnet-20241022",
-			}
-
-			if !tt.modelSupportsCache {
-				provider.model = "claude-2"
+				model: "claude-sonnet-4-6",
+				defaults: providers.ProviderDefaults{
+					// DisablePromptCaching controls caching; model name no longer matters
+					DisablePromptCaching: !tt.modelSupportsCache,
+				},
 			}
 
 			result := provider.createSystemBlocks(tt.systemPrompt)

--- a/runtime/providers/claude/supports_caching_test.go
+++ b/runtime/providers/claude/supports_caching_test.go
@@ -1,0 +1,56 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// TestSupportsCaching_DefaultOnForCurrentModels verifies that supportsCaching returns true
+// for all current Anthropic models when DisablePromptCaching is not set.
+func TestSupportsCaching_DefaultOnForCurrentModels(t *testing.T) {
+	currentModels := []string{
+		"claude-haiku-4-5",
+		"claude-opus-4-8",
+		"claude-sonnet-4-6",
+		"claude-future-model", // arbitrary unknown model — should default to on
+	}
+
+	for _, model := range currentModels {
+		t.Run(model, func(t *testing.T) {
+			p := &Provider{
+				model:    model,
+				defaults: providers.ProviderDefaults{},
+			}
+			if !p.supportsCaching() {
+				t.Errorf("supportsCaching() = false for model %q; want true (caching should be on by default)", model)
+			}
+		})
+	}
+}
+
+// TestSupportsCaching_DisabledWhenFlagSet verifies that setting DisablePromptCaching: true
+// disables caching regardless of the model.
+func TestSupportsCaching_DisabledWhenFlagSet(t *testing.T) {
+	models := []string{
+		"claude-haiku-4-5",
+		"claude-opus-4-8",
+		"claude-sonnet-4-6",
+		"claude-3-5-sonnet-20241022", // previously hard-coded to true
+		"claude-3-opus-20240229",     // previously hard-coded to true
+	}
+
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			p := &Provider{
+				model: model,
+				defaults: providers.ProviderDefaults{
+					DisablePromptCaching: true,
+				},
+			}
+			if p.supportsCaching() {
+				t.Errorf("supportsCaching() = true for model %q with DisablePromptCaching=true; want false", model)
+			}
+		})
+	}
+}

--- a/runtime/providers/provider.go
+++ b/runtime/providers/provider.go
@@ -130,6 +130,9 @@ type ProviderDefaults struct {
 	TopP        float32
 	MaxTokens   int
 	Pricing     Pricing
+	// DisablePromptCaching, when true, disables Anthropic prompt caching.
+	// Default (false) means caching is on for all models that support it.
+	DisablePromptCaching bool
 }
 
 // Provider interface defines the contract for predict providers.

--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -2097,6 +2097,9 @@
         },
         "max_tokens": {
           "type": "integer"
+        },
+        "prompt_caching": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/provider.json
+++ b/schemas/v1alpha1/provider.json
@@ -213,6 +213,9 @@
         },
         "max_tokens": {
           "type": "integer"
+        },
+        "prompt_caching": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/schemas/v1alpha1/runtime-config.json
+++ b/schemas/v1alpha1/runtime-config.json
@@ -744,6 +744,9 @@
         },
         "max_tokens": {
           "type": "integer"
+        },
+        "prompt_caching": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/sdk/internal/provider/detect.go
+++ b/sdk/internal/provider/detect.go
@@ -177,6 +177,10 @@ func createProvider(info *Info) (providers.Provider, error) {
 		Temperature: defaultTemperature,
 		TopP:        defaultTopP,
 		MaxTokens:   defaultMaxTokens,
+		// DisablePromptCaching is false (caching on by default).
+		// SDK callers that need to disable caching should use a provider file
+		// or WithLLMProvider option with prompt_caching: false in the config.
+		DisablePromptCaching: false,
 	}
 
 	switch strings.ToLower(info.Name) {

--- a/tools/arena/agentkb/schemas/arena.json
+++ b/tools/arena/agentkb/schemas/arena.json
@@ -2097,6 +2097,9 @@
         },
         "max_tokens": {
           "type": "integer"
+        },
+        "prompt_caching": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/agentkb/schemas/provider.json
+++ b/tools/arena/agentkb/schemas/provider.json
@@ -213,6 +213,9 @@
         },
         "max_tokens": {
           "type": "integer"
+        },
+        "prompt_caching": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/agentkb/schemas/runtime-config.json
+++ b/tools/arena/agentkb/schemas/runtime-config.json
@@ -744,6 +744,9 @@
         },
         "max_tokens": {
           "type": "integer"
+        },
+        "prompt_caching": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/tools/arena/engine/builder_integration.go
+++ b/tools/arena/engine/builder_integration.go
@@ -323,9 +323,10 @@ func createProviderImpl(configDir string, provider *config.Provider) (providers.
 		StreamMaxConcurrent: provider.StreamMaxConcurrent,
 		HTTPTransport:       httpTransport,
 		Defaults: providers.ProviderDefaults{
-			Temperature: provider.Defaults.Temperature,
-			TopP:        provider.Defaults.TopP,
-			MaxTokens:   provider.Defaults.MaxTokens,
+			Temperature:          provider.Defaults.Temperature,
+			TopP:                 provider.Defaults.TopP,
+			MaxTokens:            provider.Defaults.MaxTokens,
+			DisablePromptCaching: provider.Defaults.PromptCaching != nil && !*provider.Defaults.PromptCaching,
 			Pricing: providers.Pricing{
 				InputCostPer1K:  provider.Pricing.InputCostPer1K,
 				OutputCostPer1K: provider.Pricing.OutputCostPer1K,

--- a/tools/arena/engine/conversation_executor.go
+++ b/tools/arena/engine/conversation_executor.go
@@ -760,9 +760,10 @@ func providerSpecFromConfig(p *config.Provider) providers.ProviderSpec {
 		IncludeRawOutput: p.IncludeRawOutput,
 		AdditionalConfig: p.AdditionalConfig,
 		Defaults: providers.ProviderDefaults{
-			Temperature: p.Defaults.Temperature,
-			TopP:        p.Defaults.TopP,
-			MaxTokens:   p.Defaults.MaxTokens,
+			Temperature:          p.Defaults.Temperature,
+			TopP:                 p.Defaults.TopP,
+			MaxTokens:            p.Defaults.MaxTokens,
+			DisablePromptCaching: p.Defaults.PromptCaching != nil && !*p.Defaults.PromptCaching,
 			Pricing: providers.Pricing{
 				InputCostPer1K:  p.Pricing.InputCostPer1K,
 				OutputCostPer1K: p.Pricing.OutputCostPer1K,

--- a/tools/arena/engine/prompt_caching_config_test.go
+++ b/tools/arena/engine/prompt_caching_config_test.go
@@ -1,0 +1,90 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// boolPtr is a test helper that returns a pointer to the given bool value.
+func boolPtr(b bool) *bool { return &b }
+
+// TestProviderSpecFromConfig_PromptCaching verifies that the prompt_caching config field
+// maps correctly to DisablePromptCaching in the runtime ProviderDefaults.
+func TestProviderSpecFromConfig_PromptCaching(t *testing.T) {
+	tests := []struct {
+		name                     string
+		promptCaching            *bool // nil = omitted in config
+		wantDisablePromptCaching bool
+	}{
+		{
+			name:                     "prompt_caching omitted (nil) keeps caching on",
+			promptCaching:            nil,
+			wantDisablePromptCaching: false,
+		},
+		{
+			name:                     "prompt_caching: true keeps caching on",
+			promptCaching:            boolPtr(true),
+			wantDisablePromptCaching: false,
+		},
+		{
+			name:                     "prompt_caching: false disables caching",
+			promptCaching:            boolPtr(false),
+			wantDisablePromptCaching: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &config.Provider{
+				ID:    "test",
+				Type:  "anthropic",
+				Model: "claude-sonnet-4-6",
+				Defaults: config.ProviderDefaults{
+					Temperature:   0.7,
+					MaxTokens:     1024,
+					PromptCaching: tt.promptCaching,
+				},
+			}
+
+			spec := providerSpecFromConfig(p)
+
+			if spec.Defaults.DisablePromptCaching != tt.wantDisablePromptCaching {
+				t.Errorf("DisablePromptCaching = %v, want %v (prompt_caching input: %v)",
+					spec.Defaults.DisablePromptCaching, tt.wantDisablePromptCaching, tt.promptCaching)
+			}
+		})
+	}
+}
+
+// TestBuildArenaProvider_PromptCachingFalse verifies the builder_integration path also maps
+// prompt_caching: false → DisablePromptCaching: true.
+func TestBuildArenaProvider_PromptCachingFalse(t *testing.T) {
+	// We test the Defaults translation directly without constructing a full provider
+	// (which would require a live provider type). The logic is in the same literal
+	// that providerSpecFromConfig tests cover.
+	disableCaching := boolPtr(false)
+	pd := providers.ProviderDefaults{
+		DisablePromptCaching: disableCaching != nil && !*disableCaching,
+	}
+	if !pd.DisablePromptCaching {
+		t.Error("DisablePromptCaching should be true when PromptCaching pointer is false")
+	}
+
+	enableCaching := boolPtr(true)
+	pd2 := providers.ProviderDefaults{
+		DisablePromptCaching: enableCaching != nil && !*enableCaching,
+	}
+	if pd2.DisablePromptCaching {
+		t.Error("DisablePromptCaching should be false when PromptCaching pointer is true")
+	}
+
+	var nilCaching *bool
+	pd3 := providers.ProviderDefaults{
+		DisablePromptCaching: nilCaching != nil && !*nilCaching,
+	}
+	if pd3.DisablePromptCaching {
+		t.Error("DisablePromptCaching should be false when PromptCaching pointer is nil")
+	}
+}


### PR DESCRIPTION
## Problem

`runtime/providers/claude/claude.go` `supportsCaching()` gated prompt caching on a **stale October-2024 model allowlist** — only `claude-3-5-sonnet-*` and `claude-3-opus-20240229` returned `true`; everything current (`claude-haiku-4-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, Fable…) fell through to `default: return false`. So prompt caching was **silently OFF for every model PromptKit actually uses**, re-billing the large stable system prompt + tools at full input price on every call (and every tool-loop round).

## Fix

- `supportsCaching()` returns **`!p.defaults.DisablePromptCaching`** — caching **on by default for all models**, no hardcoded model names.
- Opt out per provider via config: `defaults.prompt_caching: false`.
- Plumbed through the runtime `ProviderDefaults` and the Arena build sites; SDK detect path defaults to on.
- Other providers need no change — OpenAI and Gemini cache automatically server-side (they only *report* cached tokens, no enable-gate).

Out of scope: the separate stale per-model **pricing** switch (already overridable via `defaults.pricing`).

## Tests

- `supportsCaching()` is `true` by default for `claude-haiku-4-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, and unknown models; `false` only when `DisablePromptCaching` is set.
- Config mapping: `prompt_caching: false` → `DisablePromptCaching: true`; omitted → on.
- Schemas regenerated (`prompt_caching` field on provider defaults).
