### PR TITLE
fix(ci): exclude testdata fixtures from example arena-config validation

### DIFF
--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -98,7 +98,9 @@ jobs:
         echo "Validating Arena configs with promptarena validate..."
         ERRORS=0
         
-        for file in $(find examples -name "config.arena.yaml" -o -name "*.arena.yaml" -o -name "arena.yaml"); do
+        # Exclude testdata/ fixtures: kits used as inputs to example gate scripts
+        # (e.g. trap-kit/empty-kit are intentionally invalid), not example configs.
+        for file in $(find examples -path "*/testdata/*" -prune -o \( -name "config.arena.yaml" -o -name "*.arena.yaml" -o -name "arena.yaml" \) -print); do
           echo "Validating $file..."
           if ./bin/promptarena validate "$file" --schema-only; then
             echo "✓ $file passed"


### PR DESCRIPTION
Follow-up to #1399. The `schemas.yml` "Validate example arena configs" step globs every `*.arena.yaml` under `examples/`, which now includes the `test-a-codegen-agent` gate-script fixtures (`tools/testdata/{good,trap,empty}-kit/config.arena.yaml`). `trap-kit`/`empty-kit` are **intentionally invalid** (the gate scripts must reject them), so the job goes red.

Prune `testdata/` from the `find`; real example configs are still validated (verified locally: testdata excluded, `test-a-codegen-agent/config.arena.yaml` still caught).

Touches `.github/workflows/` so it needs a UI merge (gh lacks workflow scope).