### PR TITLE
feat(deploy): stream apply/destroy progress + register omnia adapter

### DIFF
--- a/runtime/deploy/adaptersdk/serve.go
+++ b/runtime/deploy/adaptersdk/serve.go
@@ -64,7 +64,15 @@ type rpcError struct {
 
 // applyResult wraps the adapter state returned by Apply.
 type applyResult struct {
-	AdapterState string `json:"adapter_state"`
+	AdapterState string               `json:"adapter_state"`
+	Events       []*deploy.ApplyEvent `json:"events,omitempty"`
+}
+
+// destroyResult carries the destroy outcome plus the streamed events so the
+// client can replay them to its callback.
+type destroyResult struct {
+	Status string                 `json:"status"`
+	Events []*deploy.DestroyEvent `json:"events,omitempty"`
 }
 
 // Serve reads JSON-RPC requests from stdin, dispatches them to the
@@ -227,7 +235,7 @@ func handleApply(
 	if err != nil {
 		return errResponse(req.ID, CodeInternalError, err.Error())
 	}
-	return okResponse(req.ID, &applyResult{AdapterState: state})
+	return okResponse(req.ID, &applyResult{AdapterState: state, Events: events})
 }
 
 // handleDestroy handles the destroy method.
@@ -249,7 +257,7 @@ func handleDestroy(
 	if err != nil {
 		return errResponse(req.ID, CodeInternalError, err.Error())
 	}
-	return okResponse(req.ID, map[string]string{"status": "destroyed"})
+	return okResponse(req.ID, &destroyResult{Status: "destroyed", Events: events})
 }
 
 // handleStatus handles the status method.

--- a/runtime/deploy/adaptersdk/serve_test.go
+++ b/runtime/deploy/adaptersdk/serve_test.go
@@ -199,6 +199,10 @@ func TestServeIO_Apply(t *testing.T) {
 	if !strings.Contains(string(result), "state-123") {
 		t.Errorf("expected adapter_state in result, got %s", string(result))
 	}
+	// Apply must return the collected events so the client can replay them.
+	if !strings.Contains(string(result), "deploying") {
+		t.Errorf("expected streamed apply events in result, got %s", string(result))
+	}
 }
 
 func TestServeIO_ApplyError(t *testing.T) {
@@ -242,6 +246,11 @@ func TestServeIO_Destroy(t *testing.T) {
 	}
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	// Destroy must return the collected events so the client can replay them.
+	result, _ := json.Marshal(resp.Result)
+	if !strings.Contains(string(result), "destroying") {
+		t.Errorf("expected streamed destroy events in result, got %s", string(result))
 	}
 }
 

--- a/runtime/deploy/client.go
+++ b/runtime/deploy/client.go
@@ -258,23 +258,51 @@ func (c *AdapterClient) Plan(ctx context.Context, req *PlanRequest) (*PlanRespon
 
 // applyResult matches the adapter SDK's response shape for Apply.
 type applyResult struct {
-	AdapterState string `json:"adapter_state"`
+	AdapterState string        `json:"adapter_state"`
+	Events       []*ApplyEvent `json:"events,omitempty"`
 }
 
-// Apply executes the deployment. The callback is not invoked because the
-// current adapter protocol returns all events in the final response rather
-// than streaming them. The returned string is the opaque adapter state.
+type destroyResult struct {
+	Status string          `json:"status"`
+	Events []*DestroyEvent `json:"events,omitempty"`
+}
+
+// Apply executes the deployment. The adapter protocol returns all events in
+// the final response rather than streaming them; this method replays those
+// events to the callback (if non-nil) in order before returning. The returned
+// string is the opaque adapter state.
 func (c *AdapterClient) Apply(ctx context.Context, req *PlanRequest, callback ApplyCallback) (string, error) {
 	var result applyResult
 	if err := c.callCtx(ctx, methodApply, req, &result); err != nil {
 		return "", err
+	}
+	// The adapter collects streamed events and returns them in the response;
+	// replay them to the caller's callback in order.
+	if callback != nil {
+		for _, event := range result.Events {
+			if err := callback(event); err != nil {
+				return result.AdapterState, err
+			}
+		}
 	}
 	return result.AdapterState, nil
 }
 
 // Destroy tears down the deployment.
 func (c *AdapterClient) Destroy(ctx context.Context, req *DestroyRequest, callback DestroyCallback) error {
-	return c.callCtx(ctx, methodDestroy, req, nil)
+	var result destroyResult
+	if err := c.callCtx(ctx, methodDestroy, req, &result); err != nil {
+		return err
+	}
+	// Replay the adapter's collected events to the caller's callback in order.
+	if callback != nil {
+		for _, event := range result.Events {
+			if err := callback(event); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // Status returns the current deployment status.

--- a/tools/arena/cmd/promptarena/deploy_adapter_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_adapter_interactive.go
@@ -35,6 +35,12 @@ var defaultRegistryJSON = `{
       "description": "AWS Bedrock AgentCore",
       "latest": "0.2.0",
       "maintained_by": "AltairaLabs"
+    },
+    "omnia": {
+      "repo": "AltairaLabs/PromptArena-deploy-omnia",
+      "description": "Omnia Kubernetes platform",
+      "latest": "1.0.0",
+      "maintained_by": "AltairaLabs"
     }
   }
 }`

--- a/tools/arena/cmd/promptarena/deploy_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_interactive.go
@@ -216,6 +216,42 @@ func printPlan(plan *deploy.PlanResponse) {
 	fmt.Println()
 }
 
+// resultStatusSymbol maps a resource result status to a display symbol,
+// consistent with printPlan's action symbols.
+func resultStatusSymbol(status string) string {
+	switch status {
+	case "created":
+		return "+"
+	case "updated":
+		return "~"
+	case "deleted":
+		return "-"
+	case "failed":
+		return "!"
+	default:
+		return " "
+	}
+}
+
+// printDeployEvent renders a streaming apply/destroy event to stdout. Apply and
+// Destroy share the same event shape (type, message, resource), so both
+// callbacks delegate here to surface per-resource progress live.
+func printDeployEvent(eventType, message string, res *deploy.ResourceResult) {
+	switch eventType {
+	case "resource":
+		if res != nil {
+			line := fmt.Sprintf("  %s %s.%s (%s)",
+				resultStatusSymbol(res.Status), res.Type, res.Name, res.Status)
+			if res.Detail != "" {
+				line += ": " + res.Detail
+			}
+			fmt.Println(line)
+		}
+	case "error":
+		fmt.Printf("  ! %s\n", message)
+	}
+}
+
 // printStatus displays a deployment status to the user.
 func printStatus(status *deploy.StatusResponse) {
 	fmt.Printf("  Status: %s\n", status.Status)
@@ -347,7 +383,10 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	// Step 2: Apply.
 	fmt.Println("Step 2: Applying deployment...")
 
-	adapterState, err := client.Apply(ctx, planReq, nil)
+	adapterState, err := client.Apply(ctx, planReq, func(e *deploy.ApplyEvent) error {
+		printDeployEvent(e.Type, e.Message, e.Resource)
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("apply failed: %w", err)
 	}
@@ -534,7 +573,10 @@ func runDeployApply(cmd *cobra.Command, args []string) error {
 	}
 	defer client.Close()
 
-	adapterState, err := client.Apply(ctx, planReq, nil)
+	adapterState, err := client.Apply(ctx, planReq, func(e *deploy.ApplyEvent) error {
+		printDeployEvent(e.Type, e.Message, e.Resource)
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("apply failed: %w", err)
 	}
@@ -690,7 +732,10 @@ func runDeployDestroy(cmd *cobra.Command, args []string) error {
 		DeployConfig: configJSON,
 		Environment:  env,
 		PriorState:   priorState.State,
-	}, nil)
+	}, func(e *deploy.DestroyEvent) error {
+		printDeployEvent(e.Type, e.Message, e.Resource)
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("destroy failed: %w", err)
 	}


### PR DESCRIPTION
## What
Two related deploy-adapter improvements:

### 1. Stream apply/destroy progress to the CLI
The adapter collected per-resource events during Apply/Destroy, but the SDK serve handler **dropped** them (returned only `adapter_state`) and the client **ignored its callback** — so `promptarena deploy` showed nothing between "Applying deployment..." and "complete."
- `adaptersdk` serve: return collected events in the apply/destroy response (`applyResult.Events`; new `destroyResult{status,events}`)
- deploy client: replay returned events to the caller's callback in order (Apply + Destroy)
- promptarena CLI: render each event (`printDeployEvent`), wired into the combined deploy, the `apply` subcommand, and destroy
- Backward compatible (`events` is `omitempty`); tests added.

### 2. Register the `omnia` adapter
Add `omnia` to the embedded install registry so `promptarena deploy adapter install omnia` resolves to `AltairaLabs/PromptArena-deploy-omnia` and downloads its release binary.

## Verified
`golangci-lint run ./...` clean; full `runtime/` + `tools/arena/` suites pass with the per-file coverage gate (serve.go 88.8%, client.go 80.2%). Streaming validated end-to-end against a live deploy.
