### PR TITLE
feat(gemini): explicit context caching to eliminate implicit-cache warmup (#1404)

### DIFF
--- a/docs/src/content/docs/runtime/reference/providers.md
+++ b/docs/src/content/docs/runtime/reference/providers.md
@@ -413,6 +413,44 @@ toolProvider := gemini.NewToolProvider(
 response, toolCalls, err := toolProvider.PredictWithTools(ctx, req, tools, "auto")
 ```
 
+### Explicit caching & thinking (YAML config)
+
+Gemini-specific options are set under `additional_config` and apply to every
+generateContent path (non-streaming, streaming, and tool loops):
+
+```yaml
+spec:
+  id: "gemini"
+  type: gemini
+  model: gemini-2.5-flash
+  additional_config:
+    # Explicit context caching (CachedContent API). Off by default; relies on
+    # implicit caching otherwise. When on, the stable system+tools prefix is
+    # cached once and referenced on every call, so the cache hits from the
+    # first request instead of after an implicit-cache warmup.
+    explicit_caching: true
+    explicit_cache_ttl_seconds: 600   # optional; default 600
+
+    # Thinking control (2.5+/"thinking" models). Omit to use the model default
+    # (dynamic thinking). thinking_budget is a token ceiling on reasoning:
+    #   0  disables thinking (flash tier; pro models reject 0 — they require it)
+    #  -1  lets the model decide (dynamic)
+    #   N  caps reasoning at N tokens
+    thinking_budget: 0
+    include_thoughts: false           # return thought summaries
+```
+
+Notes:
+
+- **Reasoning tokens count toward `max_tokens`.** On thinking models a low
+  `max_tokens` can be exhausted by reasoning alone; keep `max_tokens` well above
+  `thinking_budget` (the default of 4096 has ample room).
+- **Explicit caching only creates a resource when the prefix is large enough**
+  (~the model's cache floor) and degrades to implicit caching on any failure, so
+  it never breaks a turn.
+- **Vertex** falls back to implicit caching (the CachedContent endpoint differs);
+  explicit caching applies to the direct (AI Studio) API.
+
 ## Mock Provider
 
 For testing and development.

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -60,6 +60,11 @@ type Provider struct {
 	// cache, when non-nil, enables explicit context caching (CachedContent API)
 	// for the stable system+tools prefix. nil means rely on implicit caching.
 	cache *cacheManager
+	// thinkingBudget caps reasoning tokens on 2.5 "thinking" models (nil = model
+	// default, 0 = disabled, -1 = dynamic). includeThoughts returns thought
+	// summaries. Both come from additional_config — see gemini_thinking.go.
+	thinkingBudget  *int
+	includeThoughts bool
 }
 
 // enableExplicitCaching turns on explicit context caching (#1404) with the given
@@ -196,11 +201,21 @@ type geminiInlineData struct {
 }
 
 type geminiGenConfig struct {
-	Temperature      float32     `json:"temperature"`
-	TopP             float32     `json:"topP"`
-	MaxOutputTokens  int         `json:"maxOutputTokens"`
-	ResponseMimeType string      `json:"responseMimeType,omitempty"` // "text/plain" or "application/json"
-	ResponseSchema   interface{} `json:"responseSchema,omitempty"`   // JSON Schema for structured output
+	Temperature      float32               `json:"temperature"`
+	TopP             float32               `json:"topP"`
+	MaxOutputTokens  int                   `json:"maxOutputTokens"`
+	ResponseMimeType string                `json:"responseMimeType,omitempty"` // "text/plain" or "application/json"
+	ResponseSchema   interface{}           `json:"responseSchema,omitempty"`   // JSON Schema for structured output
+	ThinkingConfig   *geminiThinkingConfig `json:"thinkingConfig,omitempty"`
+}
+
+// geminiThinkingConfig controls Gemini 2.5 "thinking" models. ThinkingBudget is
+// a TOKEN ceiling on internal reasoning (0 disables on flash, -1 lets the model
+// decide); those tokens count toward maxOutputTokens. IncludeThoughts returns
+// thought summaries. See gemini_thinking.go.
+type geminiThinkingConfig struct {
+	ThinkingBudget  *int `json:"thinkingBudget,omitempty"`
+	IncludeThoughts bool `json:"includeThoughts,omitempty"`
 }
 
 type geminiSafety struct {
@@ -347,6 +362,7 @@ func (p *Provider) buildGeminiRequest(contents []geminiContent, systemInstructio
 			Temperature:     temperature,
 			TopP:            topP,
 			MaxOutputTokens: maxTokens,
+			ThinkingConfig:  p.geminiThinkingConfigFor(maxTokens),
 		},
 		SafetySettings: []geminiSafety{
 			{Category: "HARM_CATEGORY_HARASSMENT", Threshold: "BLOCK_NONE"},
@@ -426,7 +442,9 @@ func (p *Provider) handleGeminiFinishReason(finishReason string, predictResp pro
 
 	switch finishReason {
 	case finishReasonMaxTokens:
-		return predictResp, fmt.Errorf("gemini returned MAX_TOKENS error (this should not happen with reasonable limits)")
+		return predictResp, fmt.Errorf("gemini hit the output-token limit before emitting any content: " +
+			"on 2.5 'thinking' models the reasoning budget counts toward maxOutputTokens, so a low max_tokens " +
+			"can be exhausted by thinking alone — raise max_tokens or set a smaller thinking_budget")
 	case finishReasonSafety:
 		return predictResp, fmt.Errorf("response blocked by Gemini safety filters")
 	case finishReasonRecitation:

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -57,6 +57,16 @@ type Provider struct {
 	// When non-nil it is authoritative for multimodal support; nil falls back
 	// to Gemini's built-in defaults (images + audio + video + documents).
 	capabilities map[string]bool
+	// cache, when non-nil, enables explicit context caching (CachedContent API)
+	// for the stable system+tools prefix. nil means rely on implicit caching.
+	cache *cacheManager
+}
+
+// enableExplicitCaching turns on explicit context caching (#1404) with the given
+// TTL (<=0 uses the default). Gated off by default; the factory enables it from
+// additional_config.explicit_caching.
+func (p *Provider) enableExplicitCaching(ttl time.Duration) {
+	p.cache = newCacheManager(ttl)
 }
 
 // setCapabilities records the declared capability set on the provider.
@@ -153,6 +163,10 @@ type geminiRequest struct {
 	SystemInstruction *geminiContent  `json:"systemInstruction,omitempty"`
 	GenerationConfig  geminiGenConfig `json:"generationConfig"`
 	SafetySettings    []geminiSafety  `json:"safetySettings,omitempty"`
+	// CachedContent references a CachedContent resource holding the stable
+	// system (+tools) prefix for explicit caching. When set, SystemInstruction
+	// must be nil — the API rejects sending both (see gemini_cache.go).
+	CachedContent string `json:"cachedContent,omitempty"`
 }
 
 type geminiContent struct {
@@ -565,6 +579,14 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 
 	// Create request
 	geminiReq := p.buildGeminiRequest(contents, systemInstruction, temperature, topP, maxTokens)
+
+	// Explicit context caching: move the stable system prefix into a
+	// CachedContent resource and reference it (no tools on this path). The API
+	// rejects cachedContent alongside systemInstruction, so drop the inline one.
+	if cc := p.resolveCachedContent(ctx, req.System, nil); cc != "" {
+		geminiReq.CachedContent = cc
+		geminiReq.SystemInstruction = nil
+	}
 
 	// Apply response format if specified
 	p.applyResponseFormat(&geminiReq, req.ResponseFormat)

--- a/runtime/providers/gemini/gemini_cache.go
+++ b/runtime/providers/gemini/gemini_cache.go
@@ -1,0 +1,309 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// Explicit context caching (Gemini CachedContent API).
+//
+// PromptKit otherwise relies on Gemini's IMPLICIT caching, which is best-effort:
+// Google decides when a prefix becomes cached, and in long agentic loops the
+// first ~10 rounds can run with cachedContentTokenCount=0 — paying full price
+// for the whole warmup. Explicit caching (#1404) creates a CachedContent
+// resource holding the stable prefix (system + tools) and references it on every
+// generateContent call, so the cache hits from the very first reference — the
+// Gemini equivalent of Claude's explicit breakpoints.
+//
+// Hard API constraint (verified live): a request that sets cachedContent must
+// NOT also set system_instruction, tools, or tool_config — those move into the
+// CachedContent. So each request path, when a handle exists, drops the inline
+// prefix and references the cache instead.
+//
+// The cache is content-addressed by hash(model, system, tools): any request
+// with the same stable prefix reuses the same resource — no conversation ID
+// needed. A creation/lookup failure NEVER breaks a turn; it degrades to the
+// inline (implicit-caching) path.
+
+const (
+	// defaultExplicitCacheTTL is how long a created CachedContent lives. Long
+	// enough to span a full agent loop; the resource is content-addressed and
+	// shared, so one create amortizes across many rounds and conversations.
+	defaultExplicitCacheTTL = 10 * time.Minute
+
+	// cacheExpiryMargin makes the manager re-create a handle slightly before its
+	// real TTL, so a turn never references an about-to-expire resource.
+	cacheExpiryMargin = 60 * time.Second
+
+	// defaultMinCacheChars is the prefix size (in characters) below which
+	// explicit caching is skipped. Creating a CachedContent below the model's
+	// floor (~1024 tokens for 2.5) costs more than it saves, so only cache a
+	// substantial prefix. ~4 chars/token, so ~1024 tokens.
+	defaultMinCacheChars = 4096
+
+	// cacheFailureCooldown throttles re-creation after a failed create so a
+	// persistently failing prefix doesn't POST cachedContents every turn.
+	cacheFailureCooldown = 2 * time.Minute
+)
+
+// cacheEntry is a live CachedContent resource handle with its local expiry.
+type cacheEntry struct {
+	name   string
+	expiry time.Time
+}
+
+// cacheManager tracks CachedContent resources keyed by stable-prefix hash. It is
+// safe for concurrent use by the agent loop's parallel turns.
+type cacheManager struct {
+	mu        sync.Mutex
+	entries   map[string]cacheEntry
+	failUntil map[string]time.Time
+	ttl       time.Duration
+	minChars  int
+}
+
+func newCacheManager(ttl time.Duration) *cacheManager {
+	if ttl <= 0 {
+		ttl = defaultExplicitCacheTTL
+	}
+	return &cacheManager{
+		entries:   map[string]cacheEntry{},
+		failUntil: map[string]time.Time{},
+		ttl:       ttl,
+		minChars:  defaultMinCacheChars,
+	}
+}
+
+// Close best-effort deletes any CachedContent resources this provider created
+// (lifecycle cleanup; TTL would expire them anyway) before delegating to the
+// embedded BaseProvider.
+func (p *Provider) Close() error {
+	if p.cache != nil {
+		for _, name := range p.cache.trackedNames() {
+			p.deleteCachedContent(context.Background(), name)
+		}
+	}
+	return p.BaseProvider.Close()
+}
+
+// applyExplicitCachingConfig enables explicit context caching when the provider
+// config opts in via additional_config.explicit_caching: true. An optional
+// explicit_cache_ttl_seconds (number) overrides the default TTL. Off by default.
+//
+//nolint:gocritic // hugeParam: providers.ProviderSpec is passed by value across the factory
+func applyExplicitCachingConfig(p *Provider, spec providers.ProviderSpec) {
+	if spec.AdditionalConfig == nil {
+		return
+	}
+	enabled, _ := spec.AdditionalConfig["explicit_caching"].(bool)
+	if !enabled {
+		return
+	}
+	ttl := defaultExplicitCacheTTL
+	if secs, ok := toFloat(spec.AdditionalConfig["explicit_cache_ttl_seconds"]); ok && secs > 0 {
+		ttl = time.Duration(secs) * time.Second
+	}
+	p.enableExplicitCaching(ttl)
+}
+
+// toFloat coerces a config value (which may decode as float64, int, or int64)
+// to float64.
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// resolveCachedContent returns the CachedContent resource name to reference for
+// the given stable prefix (system + tools), creating it on first use and reusing
+// it within TTL. It returns "" to signal "send the prefix inline" — when
+// explicit caching is disabled, the prefix is too small, the platform is
+// unsupported, or any create/lookup failed (degrade to implicit). toolsField is
+// the request's "tools" value ([]any{decl}) or nil.
+func (p *Provider) resolveCachedContent(ctx context.Context, systemText string, toolsField any) string {
+	if p.cache == nil {
+		return ""
+	}
+	// Vertex's CachedContent endpoint/auth differ from AI Studio's; explicit
+	// caching there is a separate follow-up. Degrade to implicit on Vertex.
+	if p.isVertex() {
+		return ""
+	}
+	return p.cache.getOrCreate(ctx, p, systemText, toolsField)
+}
+
+// getOrCreate returns a cached resource name for the prefix, or "" to degrade.
+func (m *cacheManager) getOrCreate(ctx context.Context, p *Provider, systemText string, toolsField any) string {
+	toolsJSON := marshalToolsForCache(toolsField)
+
+	// Min-size guard: skip prefixes below the model's cacheable floor.
+	if len(systemText)+len(toolsJSON) < m.minChars {
+		return ""
+	}
+
+	key := cacheKey(p.model, systemText, toolsJSON)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	if e, ok := m.entries[key]; ok && now.Before(e.expiry.Add(-cacheExpiryMargin)) {
+		return e.name
+	}
+	if until, ok := m.failUntil[key]; ok && now.Before(until) {
+		return ""
+	}
+
+	name, err := p.createCachedContent(ctx, systemText, toolsField, m.ttl)
+	if err != nil {
+		m.failUntil[key] = now.Add(cacheFailureCooldown)
+		logger.Warn("Gemini explicit caching: create failed, using implicit caching for this prefix",
+			"provider", p.ID(), "error", err)
+		return ""
+	}
+	m.entries[key] = cacheEntry{name: name, expiry: now.Add(m.ttl)}
+	logger.Debug("Gemini explicit caching: created CachedContent",
+		"provider", p.ID(), "name", name, "ttl", m.ttl.String())
+	return name
+}
+
+// trackedNames returns the resource names currently held, for cleanup.
+func (m *cacheManager) trackedNames() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	names := make([]string, 0, len(m.entries))
+	for _, e := range m.entries {
+		names = append(names, e.name)
+	}
+	return names
+}
+
+// cacheKey content-addresses a stable prefix.
+func cacheKey(model, systemText, toolsJSON string) string {
+	h := sha256.New()
+	h.Write([]byte(model))
+	h.Write([]byte{0})
+	h.Write([]byte(systemText))
+	h.Write([]byte{0})
+	h.Write([]byte(toolsJSON))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// marshalToolsForCache renders the tools field deterministically for hashing and
+// for the create body. Returns "" when there are no tools.
+func marshalToolsForCache(toolsField any) string {
+	if toolsField == nil {
+		return ""
+	}
+	b, err := json.Marshal(toolsField)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// cachedContentCreateBody is the CachedContent create payload. Mirrors the
+// generateContent prefix shape so the cached and dropped content are identical.
+type cachedContentCreateBody struct {
+	Model             string         `json:"model"`
+	SystemInstruction *geminiContent `json:"systemInstruction,omitempty"`
+	Tools             any            `json:"tools,omitempty"`
+	TTL               string         `json:"ttl"`
+}
+
+type cachedContentCreateResp struct {
+	Name  string `json:"name"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// createCachedContent POSTs a CachedContent resource holding the stable prefix
+// and returns its resource name (e.g. "cachedContents/abc123"). AI Studio only;
+// Vertex is screened out in resolveCachedContent.
+func (p *Provider) createCachedContent(
+	ctx context.Context, systemText string, toolsField any, ttl time.Duration,
+) (string, error) {
+	body := cachedContentCreateBody{
+		Model: "models/" + p.model,
+		TTL:   fmt.Sprintf("%ds", int(ttl.Seconds())),
+	}
+	if systemText != "" {
+		body.SystemInstruction = &geminiContent{Parts: []geminiPart{{Text: systemText}}}
+	}
+	if toolsField != nil {
+		body.Tools = toolsField
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("marshal cachedContent: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/cachedContents?key=%s", p.baseURL, p.apiKey)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(raw))
+	if err != nil {
+		return "", fmt.Errorf("create cachedContent request: %w", err)
+	}
+	httpReq.Header.Set(contentTypeHeader, applicationJSON)
+	if hdrErr := p.ApplyCustomHeaders(httpReq); hdrErr != nil {
+		return "", hdrErr
+	}
+
+	resp, err := p.GetHTTPClient().Do(httpReq)
+	if err != nil {
+		return "", &providers.ProviderTransportError{Cause: err, Provider: p.ID()}
+	}
+	defer resp.Body.Close()
+
+	respBody, err := providers.ReadResponseBody(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read cachedContent response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cachedContent create returned HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed cachedContentCreateResp
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("decode cachedContent response: %w", err)
+	}
+	if parsed.Error != nil {
+		return "", fmt.Errorf("cachedContent create error: %s", parsed.Error.Message)
+	}
+	if parsed.Name == "" {
+		return "", fmt.Errorf("cachedContent create returned no name: %s", string(respBody))
+	}
+	return parsed.Name, nil
+}
+
+// deleteCachedContent best-effort deletes a CachedContent resource (cleanup).
+func (p *Provider) deleteCachedContent(ctx context.Context, name string) {
+	url := fmt.Sprintf("%s/%s?key=%s", p.baseURL, name, p.apiKey)
+	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", url, http.NoBody)
+	if err != nil {
+		return
+	}
+	resp, err := p.GetHTTPClient().Do(httpReq)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}

--- a/runtime/providers/gemini/gemini_explicit_cache_live_test.go
+++ b/runtime/providers/gemini/gemini_explicit_cache_live_test.go
@@ -91,6 +91,44 @@ func TestExplicitCaching_Live(t *testing.T) {
 		t.Logf("PredictWithTools: cachedTokens=%d inputTokens=%d", resp.CostInfo.CachedTokens, resp.CostInfo.InputTokens)
 	})
 
+	t.Run("ThinkingBudgetFixesCutoff", func(t *testing.T) {
+		// A tight maxTokens (32) is exhausted by thinking alone on 2.5-flash, so
+		// with default thinking it returns MAX_TOKENS with no content...
+		withThinking, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
+			ID: "live-gemini", Type: "gemini", Model: "gemini-2.5-flash",
+			Defaults: providers.ProviderDefaults{MaxTokens: 32},
+		})
+		if err != nil {
+			t.Fatalf("CreateProviderFromSpec: %v", err)
+		}
+		if _, err := withThinking.Predict(context.Background(), providers.PredictionRequest{
+			Messages: []types.Message{{Role: "user", Content: "Reply with the single word OK."}},
+		}); err == nil {
+			t.Log("note: thinking did not exhaust 32 tokens this run; cutoff contrast is best-effort")
+		}
+
+		// ...but disabling thinking (thinking_budget: 0) leaves the whole cap for
+		// the answer, so the same tight cap now succeeds with content.
+		noThinking, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
+			ID: "live-gemini", Type: "gemini", Model: "gemini-2.5-flash",
+			AdditionalConfig: map[string]any{"thinking_budget": 0},
+			Defaults:         providers.ProviderDefaults{MaxTokens: 32},
+		})
+		if err != nil {
+			t.Fatalf("CreateProviderFromSpec: %v", err)
+		}
+		resp, err := noThinking.Predict(context.Background(), providers.PredictionRequest{
+			Messages: []types.Message{{Role: "user", Content: "Reply with the single word OK."}},
+		})
+		if err != nil {
+			t.Fatalf("with thinking_budget=0 the tight cap must produce an answer, got: %v", err)
+		}
+		if strings.TrimSpace(resp.Content) == "" {
+			t.Fatal("expected non-empty content with thinking disabled")
+		}
+		t.Logf("thinking_budget=0 @ maxTokens=32: content=%q", resp.Content)
+	})
+
 	t.Run("PredictStream", func(t *testing.T) {
 		tp := newProvider(t)
 		ch, err := tp.PredictStream(context.Background(), providers.PredictionRequest{

--- a/runtime/providers/gemini/gemini_explicit_cache_live_test.go
+++ b/runtime/providers/gemini/gemini_explicit_cache_live_test.go
@@ -1,0 +1,112 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestExplicitCaching_Live exercises explicit context caching against the real
+// Gemini API across every generateContent path — non-streaming Predict, the tool
+// loop (PredictWithTools), and streaming (PredictStream) — and asserts the cache
+// hits immediately (cachedContentTokenCount > 0 from the first reference), which
+// is the warmup gap #1404 closes.
+//
+// Gated: runs only when GEMINI_LIVE_CACHE=1 and GEMINI_API_KEY is set, so it
+// never runs in CI. Costs are minimal: one ~1.5k-token prefix cached once, a few
+// short generations referencing it, then the cache is deleted.
+func TestExplicitCaching_Live(t *testing.T) {
+	if os.Getenv("GEMINI_LIVE_CACHE") != "1" || os.Getenv("GEMINI_API_KEY") == "" {
+		t.Skip("set GEMINI_LIVE_CACHE=1 and GEMINI_API_KEY to run the live explicit-caching test")
+	}
+
+	// ~1.5k-token stable system prefix (well above the 2.5 cache floor).
+	system := strings.Repeat(
+		"You are a meticulous coding agent working in a large Go monorepo. "+
+			"Follow existing conventions precisely and never invent APIs. ", 60)
+
+	newProvider := func(t *testing.T) *ToolProvider {
+		p, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
+			ID: "live-gemini", Type: "gemini", Model: "gemini-2.5-flash",
+			AdditionalConfig: map[string]any{"explicit_caching": true},
+			// gemini-2.5-flash spends "thinking" tokens before output, so the cap
+			// needs headroom or every call returns MAX_TOKENS with no content.
+			Defaults: providers.ProviderDefaults{MaxTokens: 512},
+		})
+		if err != nil {
+			t.Fatalf("CreateProviderFromSpec: %v", err)
+		}
+		tp := p.(*ToolProvider)
+		t.Cleanup(func() {
+			for _, name := range tp.cache.trackedNames() {
+				tp.deleteCachedContent(context.Background(), name)
+			}
+		})
+		return tp
+	}
+
+	t.Run("Predict", func(t *testing.T) {
+		tp := newProvider(t)
+		// Round 1 must already hit (explicit caching, unlike implicit warmup).
+		for round := 1; round <= 2; round++ {
+			resp, err := tp.Predict(context.Background(), providers.PredictionRequest{
+				System:   system,
+				Messages: []types.Message{{Role: "user", Content: "Reply with the single word OK."}},
+			})
+			if err != nil {
+				t.Fatalf("round %d Predict: %v", round, err)
+			}
+			if resp.CostInfo == nil || resp.CostInfo.CachedTokens <= 0 {
+				t.Fatalf("round %d: expected cachedTokens > 0, got %+v", round, resp.CostInfo)
+			}
+			t.Logf("Predict round %d: cachedTokens=%d inputTokens=%d", round, resp.CostInfo.CachedTokens, resp.CostInfo.InputTokens)
+		}
+	})
+
+	t.Run("PredictWithTools", func(t *testing.T) {
+		tp := newProvider(t)
+		tools, _ := tp.BuildTooling([]*providers.ToolDescriptor{
+			{Name: "get_status", Description: "Get the build status", InputSchema: json.RawMessage(`{"type":"object","properties":{}}`)},
+		})
+		resp, _, err := tp.PredictWithTools(context.Background(), providers.PredictionRequest{
+			System:   system,
+			Messages: []types.Message{{Role: "user", Content: "Reply with the single word OK."}},
+		}, tools, "")
+		if err != nil {
+			t.Fatalf("PredictWithTools: %v", err)
+		}
+		if resp.CostInfo == nil || resp.CostInfo.CachedTokens <= 0 {
+			t.Fatalf("expected cachedTokens > 0, got %+v", resp.CostInfo)
+		}
+		t.Logf("PredictWithTools: cachedTokens=%d inputTokens=%d", resp.CostInfo.CachedTokens, resp.CostInfo.InputTokens)
+	})
+
+	t.Run("PredictStream", func(t *testing.T) {
+		tp := newProvider(t)
+		ch, err := tp.PredictStream(context.Background(), providers.PredictionRequest{
+			System:   system,
+			Messages: []types.Message{{Role: "user", Content: "Reply with the single word OK."}},
+		})
+		if err != nil {
+			t.Fatalf("PredictStream: %v", err)
+		}
+		var cached int
+		for chunk := range ch {
+			if chunk.Error != nil {
+				t.Fatalf("stream error: %v", chunk.Error)
+			}
+			if chunk.CostInfo != nil && chunk.CostInfo.CachedTokens > 0 {
+				cached = chunk.CostInfo.CachedTokens
+			}
+		}
+		if cached <= 0 {
+			t.Fatalf("expected cachedTokens > 0 in stream, got %d", cached)
+		}
+		t.Logf("PredictStream: cachedTokens=%d", cached)
+	})
+}

--- a/runtime/providers/gemini/gemini_explicit_cache_live_test.go
+++ b/runtime/providers/gemini/gemini_explicit_cache_live_test.go
@@ -34,9 +34,14 @@ func TestExplicitCaching_Live(t *testing.T) {
 		p, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
 			ID: "live-gemini", Type: "gemini", Model: "gemini-2.5-flash",
 			AdditionalConfig: map[string]any{"explicit_caching": true},
-			// gemini-2.5-flash spends "thinking" tokens before output, so the cap
-			// needs headroom or every call returns MAX_TOKENS with no content.
-			Defaults: providers.ProviderDefaults{MaxTokens: 512},
+			// maxOutputTokens caps the TOTAL output, and gemini-2.5-flash is a
+			// thinking model — it spends output budget on internal reasoning
+			// (thoughtsTokenCount) before any visible text, so a cap below the
+			// thinking spend returns finishReason=MAX_TOKENS with empty content,
+			// which the provider treats as an error. The cap is a ceiling, not a
+			// cost lever (cost is the tokens actually generated — a few here), so
+			// it's set generously rather than tuned to a fragile minimum.
+			Defaults: providers.ProviderDefaults{MaxTokens: 1024},
 		})
 		if err != nil {
 			t.Fatalf("CreateProviderFromSpec: %v", err)

--- a/runtime/providers/gemini/gemini_explicit_cache_test.go
+++ b/runtime/providers/gemini/gemini_explicit_cache_test.go
@@ -1,0 +1,338 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// geminiGenOKBody is a minimal valid generateContent response.
+const geminiGenOKBody = `{"candidates":[{"content":{"parts":[{"text":"ok"}],"role":"model"},` +
+	`"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":10,` +
+	`"candidatesTokenCount":2,"cachedContentTokenCount":8,"totalTokenCount":12}}`
+
+// explicitCacheServer routes the two endpoints explicit caching touches: the
+// CachedContent create (POST .../cachedContents) and generateContent. It records
+// how many creates happened and the last generateContent body, so a test can
+// assert whether the request referenced a cache or sent the prefix inline.
+type explicitCacheServer struct {
+	url          string
+	createCalls  int32
+	createStatus int
+	lastGenBody  []byte
+}
+
+func newExplicitCacheServer(t *testing.T, createStatus int) *explicitCacheServer {
+	t.Helper()
+	s := &explicitCacheServer{createStatus: createStatus}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/cachedContents"):
+			atomic.AddInt32(&s.createCalls, 1)
+			if s.createStatus != http.StatusOK {
+				w.WriteHeader(s.createStatus)
+				_, _ = io.WriteString(w, `{"error":{"message":"boom"}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"name":"cachedContents/test123"}`)
+		case strings.Contains(r.URL.Path, ":generateContent"),
+			strings.Contains(r.URL.Path, ":streamGenerateContent"):
+			body, _ := io.ReadAll(r.Body)
+			s.lastGenBody = body
+			_, _ = io.WriteString(w, geminiGenOKBody)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	s.url = srv.URL
+	return s
+}
+
+func (s *explicitCacheServer) genBody(t *testing.T) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(s.lastGenBody, &m); err != nil {
+		t.Fatalf("generateContent body not JSON: %v (%s)", err, s.lastGenBody)
+	}
+	return m
+}
+
+// bigSystem clears the explicit-caching min-size floor (defaultMinCacheChars).
+var bigSystem = strings.Repeat("You are a meticulous coding agent. Obey conventions. ", 120)
+
+func newExplicitCacheProvider(t *testing.T, baseURL string, additional map[string]any) providers.Provider {
+	t.Helper()
+	t.Setenv("GEMINI_API_KEY", "test-key")
+	p, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
+		ID: "test-gemini", Type: "gemini", Model: "gemini-2.5-flash",
+		BaseURL: baseURL, AdditionalConfig: additional,
+	})
+	if err != nil {
+		t.Fatalf("CreateProviderFromSpec: %v", err)
+	}
+	return p
+}
+
+// When explicit caching is enabled and the prefix clears the floor, the request
+// references a CachedContent resource and drops the inline systemInstruction.
+func TestExplicitCaching_Predict_ReferencesCache(t *testing.T) {
+	srv := newExplicitCacheServer(t, http.StatusOK)
+	p := newExplicitCacheProvider(t, srv.url, map[string]any{"explicit_caching": true})
+
+	_, err := p.Predict(context.Background(), providers.PredictionRequest{
+		System:   bigSystem,
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict: %v", err)
+	}
+	body := srv.genBody(t)
+	if body["cachedContent"] != "cachedContents/test123" {
+		t.Errorf("expected cachedContent reference, got %v", body["cachedContent"])
+	}
+	if _, has := body["systemInstruction"]; has {
+		t.Error("systemInstruction must be dropped when cachedContent is set (API rejects both)")
+	}
+	if atomic.LoadInt32(&srv.createCalls) != 1 {
+		t.Errorf("expected exactly 1 cachedContents create, got %d", srv.createCalls)
+	}
+}
+
+// The tool path must also reference the cache and drop systemInstruction, tools,
+// and tool_config (all three are rejected alongside cachedContent).
+func TestExplicitCaching_Tools_DropsPrefix(t *testing.T) {
+	srv := newExplicitCacheServer(t, http.StatusOK)
+	p := newExplicitCacheProvider(t, srv.url, map[string]any{"explicit_caching": true})
+	tp := p.(*ToolProvider)
+	tools, _ := tp.BuildTooling([]*providers.ToolDescriptor{
+		{Name: "read_file", Description: "read a file", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	})
+
+	_, _, err := tp.PredictWithTools(context.Background(), providers.PredictionRequest{
+		System:   bigSystem,
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	}, tools, "")
+	if err != nil {
+		t.Fatalf("PredictWithTools: %v", err)
+	}
+	body := srv.genBody(t)
+	if body["cachedContent"] != "cachedContents/test123" {
+		t.Errorf("expected cachedContent reference, got %v", body["cachedContent"])
+	}
+	for _, k := range []string{"systemInstruction", "tools", "tool_config"} {
+		if _, has := body[k]; has {
+			t.Errorf("%q must be dropped when cachedContent is set", k)
+		}
+	}
+}
+
+// A CachedContent create failure must degrade to the inline prefix without
+// erroring the turn.
+func TestExplicitCaching_CreateFailure_DegradesToInline(t *testing.T) {
+	srv := newExplicitCacheServer(t, http.StatusInternalServerError)
+	p := newExplicitCacheProvider(t, srv.url, map[string]any{"explicit_caching": true})
+
+	_, err := p.Predict(context.Background(), providers.PredictionRequest{
+		System:   bigSystem,
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict must succeed despite cache create failure: %v", err)
+	}
+	body := srv.genBody(t)
+	if _, has := body["cachedContent"]; has {
+		t.Error("cachedContent must not be set when create failed")
+	}
+	if _, has := body["systemInstruction"]; !has {
+		t.Error("systemInstruction must be sent inline when caching degrades")
+	}
+}
+
+// A prefix below the min-size floor must skip the cache entirely (creating a
+// tiny CachedContent costs more than it saves).
+func TestExplicitCaching_BelowMinSize_SkipsCache(t *testing.T) {
+	srv := newExplicitCacheServer(t, http.StatusOK)
+	p := newExplicitCacheProvider(t, srv.url, map[string]any{"explicit_caching": true})
+
+	_, err := p.Predict(context.Background(), providers.PredictionRequest{
+		System:   "short system", // well under defaultMinCacheChars
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict: %v", err)
+	}
+	if atomic.LoadInt32(&srv.createCalls) != 0 {
+		t.Errorf("expected no cachedContents create for a small prefix, got %d", srv.createCalls)
+	}
+	if _, has := srv.genBody(t)["systemInstruction"]; !has {
+		t.Error("small-prefix request must send systemInstruction inline")
+	}
+}
+
+// Off by default: with no explicit_caching config, the request sends the prefix
+// inline and never touches the CachedContent endpoint.
+func TestExplicitCaching_DisabledByDefault(t *testing.T) {
+	srv := newExplicitCacheServer(t, http.StatusOK)
+	p := newExplicitCacheProvider(t, srv.url, nil)
+
+	_, err := p.Predict(context.Background(), providers.PredictionRequest{
+		System:   bigSystem,
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict: %v", err)
+	}
+	if atomic.LoadInt32(&srv.createCalls) != 0 {
+		t.Errorf("explicit caching must be off by default, got %d creates", srv.createCalls)
+	}
+	if _, has := srv.genBody(t)["systemInstruction"]; !has {
+		t.Error("default path must send systemInstruction inline")
+	}
+}
+
+// A 200 response carrying an error field, or no resource name, must degrade to
+// inline rather than referencing a bogus cache.
+func TestExplicitCaching_CreateErrorBodies_Degrade(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		createBody string
+	}{
+		{"error field", `{"error":{"message":"quota exceeded"}}`},
+		{"no name", `{}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if strings.HasSuffix(r.URL.Path, "/cachedContents") {
+					_, _ = io.WriteString(w, tc.createBody)
+					return
+				}
+				body, _ := io.ReadAll(r.Body)
+				if strings.Contains(string(body), "cachedContent") {
+					t.Error("request must not reference a cache when create yielded no usable name")
+				}
+				_, _ = io.WriteString(w, geminiGenOKBody)
+			}))
+			t.Cleanup(srv.Close)
+
+			p := newExplicitCacheProvider(t, srv.URL, map[string]any{"explicit_caching": true})
+			if _, err := p.Predict(context.Background(), providers.PredictionRequest{
+				System: bigSystem, Messages: []types.Message{{Role: "user", Content: "hi"}},
+			}); err != nil {
+				t.Fatalf("Predict must succeed despite bad cache create: %v", err)
+			}
+		})
+	}
+}
+
+// Tracked resources are exposed for cleanup, and deleteCachedContent issues the
+// DELETE without erroring.
+func TestExplicitCaching_TrackedNamesAndDelete(t *testing.T) {
+	var deleted int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/cachedContents/"):
+			atomic.AddInt32(&deleted, 1)
+			_, _ = io.WriteString(w, `{}`)
+		case strings.HasSuffix(r.URL.Path, "/cachedContents"):
+			_, _ = io.WriteString(w, `{"name":"cachedContents/test123"}`)
+		case strings.Contains(r.URL.Path, ":generateContent"):
+			_, _ = io.WriteString(w, geminiGenOKBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	p := newExplicitCacheProvider(t, srv.URL, map[string]any{"explicit_caching": true})
+	tp := p.(*ToolProvider)
+	if _, err := tp.Predict(context.Background(), providers.PredictionRequest{
+		System: bigSystem, Messages: []types.Message{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Predict: %v", err)
+	}
+
+	names := tp.cache.trackedNames()
+	if len(names) != 1 || names[0] != "cachedContents/test123" {
+		t.Fatalf("trackedNames = %v, want [cachedContents/test123]", names)
+	}
+	tp.deleteCachedContent(context.Background(), names[0])
+	if atomic.LoadInt32(&deleted) != 1 {
+		t.Errorf("expected 1 DELETE, got %d", deleted)
+	}
+}
+
+// The TTL config accepts float64/int/int64 and ignores non-numeric values
+// (falling back to the default).
+func TestExplicitCaching_TTLConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		val  any
+		want time.Duration
+	}{
+		{"float64", float64(30), 30 * time.Second},
+		{"int", 45, 45 * time.Second},
+		{"int64", int64(60), 60 * time.Second},
+		{"bad-type-uses-default", "nope", defaultExplicitCacheTTL},
+		{"zero-uses-default", 0, defaultExplicitCacheTTL},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Provider{}
+			applyExplicitCachingConfig(p, providers.ProviderSpec{
+				AdditionalConfig: map[string]any{
+					"explicit_caching":           true,
+					"explicit_cache_ttl_seconds": tc.val,
+				},
+			})
+			if p.cache == nil {
+				t.Fatal("cache should be enabled")
+			}
+			if p.cache.ttl != tc.want {
+				t.Errorf("ttl = %v, want %v", p.cache.ttl, tc.want)
+			}
+		})
+	}
+}
+
+// Explicit caching degrades to implicit on Vertex (different CachedContent
+// endpoint/auth — a separate follow-up).
+func TestExplicitCaching_VertexDegrades(t *testing.T) {
+	p := &Provider{platform: vertexPlatform}
+	p.enableExplicitCaching(0) // 0 → default TTL
+	if got := p.resolveCachedContent(context.Background(), bigSystem, nil); got != "" {
+		t.Errorf("Vertex must degrade to implicit (return \"\"), got %q", got)
+	}
+}
+
+// The created CachedContent is reused across rounds: a second request with the
+// same prefix references the same resource without creating another.
+func TestExplicitCaching_ReusesAcrossRounds(t *testing.T) {
+	srv := newExplicitCacheServer(t, http.StatusOK)
+	p := newExplicitCacheProvider(t, srv.url, map[string]any{"explicit_caching": true})
+
+	for i := 0; i < 3; i++ {
+		if _, err := p.Predict(context.Background(), providers.PredictionRequest{
+			System:   bigSystem,
+			Messages: []types.Message{{Role: "user", Content: "round"}},
+		}); err != nil {
+			t.Fatalf("Predict round %d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&srv.createCalls); got != 1 {
+		t.Errorf("expected 1 create reused across 3 rounds, got %d", got)
+	}
+}

--- a/runtime/providers/gemini/gemini_integration_test.go
+++ b/runtime/providers/gemini/gemini_integration_test.go
@@ -123,7 +123,7 @@ func TestPredict_Integration(t *testing.T) {
 			},
 			serverStatus: http.StatusOK,
 			wantErr:      true,
-			errContains:  "MAX_TOKENS",
+			errContains:  "output-token limit",
 		},
 	}
 
@@ -456,7 +456,7 @@ func TestHandleGeminiFinishReason(t *testing.T) {
 		{
 			name:         "MAX_TOKENS",
 			finishReason: "MAX_TOKENS",
-			errContains:  "MAX_TOKENS",
+			errContains:  "output-token limit",
 		},
 		{
 			name:         "SAFETY",

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -32,6 +32,13 @@ func (p *Provider) PredictStream(
 	// Create streaming request
 	geminiReq := p.buildGeminiRequest(contents, systemInstruction, temperature, topP, maxTokens)
 
+	// Explicit context caching: reference the cached system prefix and drop the
+	// inline systemInstruction (the API rejects sending both).
+	if cc := p.resolveCachedContent(ctx, req.System, nil); cc != "" {
+		geminiReq.CachedContent = cc
+		geminiReq.SystemInstruction = nil
+	}
+
 	// Apply response format if specified
 	p.applyResponseFormat(&geminiReq, req.ResponseFormat)
 

--- a/runtime/providers/gemini/gemini_thinking.go
+++ b/runtime/providers/gemini/gemini_thinking.go
@@ -1,0 +1,62 @@
+package gemini
+
+import (
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// Gemini 2.5 "thinking" model support (#1404 follow-on).
+//
+// On 2.5 models the model spends output-token budget on internal reasoning
+// before any visible text, and those reasoning tokens count toward
+// maxOutputTokens. So a tight maxOutputTokens can be exhausted by thinking
+// alone, returning finishReason=MAX_TOKENS with no content. thinkingConfig lets
+// callers bound (or disable) that reasoning so maxOutputTokens is predictable:
+//
+//	maxOutputTokens >= thinkingBudget + expected_answer_tokens
+//
+// Verified live: thinkingBudget is a TOKEN ceiling (budget 128 -> 83 thinking
+// tokens used), and maxOutputTokens caps the SUM of thinking + answer (92 + 54
+// hit a 150 cap). Configured via additional_config; off by default (model's own
+// dynamic thinking applies).
+
+// applyThinkingConfig reads thinking-model settings from additional_config:
+//   - thinking_budget   (int): token ceiling on reasoning. 0 disables (flash),
+//     -1 lets the model decide. Omit to use the model default.
+//   - include_thoughts (bool): return thought summaries.
+//
+//nolint:gocritic // hugeParam: providers.ProviderSpec is passed by value across the factory
+func applyThinkingConfig(p *Provider, spec providers.ProviderSpec) {
+	if spec.AdditionalConfig == nil {
+		return
+	}
+	if v, ok := spec.AdditionalConfig["thinking_budget"]; ok {
+		if f, ok := toFloat(v); ok {
+			budget := int(f)
+			p.thinkingBudget = &budget
+		}
+	}
+	if v, ok := spec.AdditionalConfig["include_thoughts"].(bool); ok {
+		p.includeThoughts = v
+	}
+}
+
+// geminiThinkingConfigFor returns the thinkingConfig to attach to a request, or
+// nil when nothing is configured (the model applies its own default thinking).
+// maxTokens is the resolved maxOutputTokens for the request; when it cannot
+// cover the thinking budget plus any answer, a warning is logged — that
+// combination returns MAX_TOKENS with no usable answer.
+func (p *Provider) geminiThinkingConfigFor(maxTokens int) *geminiThinkingConfig {
+	if p.thinkingBudget == nil && !p.includeThoughts {
+		return nil
+	}
+	if p.thinkingBudget != nil && *p.thinkingBudget > 0 && maxTokens > 0 && maxTokens <= *p.thinkingBudget {
+		logger.Warn("Gemini thinking_budget leaves no room for the answer: "+
+			"maxOutputTokens must exceed thinking_budget (reasoning tokens count toward the output cap)",
+			"provider", p.ID(), "max_output_tokens", maxTokens, "thinking_budget", *p.thinkingBudget)
+	}
+	return &geminiThinkingConfig{
+		ThinkingBudget:  p.thinkingBudget,
+		IncludeThoughts: p.includeThoughts,
+	}
+}

--- a/runtime/providers/gemini/gemini_thinking.go
+++ b/runtime/providers/gemini/gemini_thinking.go
@@ -42,10 +42,17 @@ func applyThinkingConfig(p *Provider, spec providers.ProviderSpec) {
 }
 
 // geminiThinkingConfigFor returns the thinkingConfig to attach to a request, or
-// nil when nothing is configured (the model applies its own default thinking).
-// maxTokens is the resolved maxOutputTokens for the request; when it cannot
-// cover the thinking budget plus any answer, a warning is logged — that
-// combination returns MAX_TOKENS with no usable answer.
+// nil when nothing is configured — in which case the model applies its own
+// default thinking. We deliberately do NOT auto-disable thinking based on model
+// name: that's a maintenance trap (every new model/tier would need a rule) and
+// unnecessary, since at the default maxOutputTokens (4096) thinking has ample
+// room and doesn't truncate. Callers who consider thinking unnecessary opt out
+// per provider with additional_config.thinking_budget: 0 (valid on flash;
+// pro/thinking-only models reject 0 with a clear API error).
+//
+// maxTokens is the resolved maxOutputTokens; when a positive budget can't leave
+// room for an answer, a warning is logged (that combination returns MAX_TOKENS
+// with no usable answer).
 func (p *Provider) geminiThinkingConfigFor(maxTokens int) *geminiThinkingConfig {
 	if p.thinkingBudget == nil && !p.includeThoughts {
 		return nil
@@ -55,8 +62,5 @@ func (p *Provider) geminiThinkingConfigFor(maxTokens int) *geminiThinkingConfig 
 			"maxOutputTokens must exceed thinking_budget (reasoning tokens count toward the output cap)",
 			"provider", p.ID(), "max_output_tokens", maxTokens, "thinking_budget", *p.thinkingBudget)
 	}
-	return &geminiThinkingConfig{
-		ThinkingBudget:  p.thinkingBudget,
-		IncludeThoughts: p.includeThoughts,
-	}
+	return &geminiThinkingConfig{ThinkingBudget: p.thinkingBudget, IncludeThoughts: p.includeThoughts}
 }

--- a/runtime/providers/gemini/gemini_thinking_test.go
+++ b/runtime/providers/gemini/gemini_thinking_test.go
@@ -1,0 +1,134 @@
+package gemini
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// genConfigFrom returns the generationConfig object from a captured request body.
+func genConfigFrom(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	gc, ok := body["generationConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("no generationConfig in request body: %v", body)
+	}
+	return gc
+}
+
+// thinking_budget config flows into generationConfig.thinkingConfig on the
+// non-tool (struct) path, including the budget-0 "disable" case (a pointer, so
+// 0 is distinct from unset).
+func TestThinking_BudgetInRequest_Predict(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		budget any
+		want   float64
+	}{
+		{"positive", 256, 256},
+		{"disabled", 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newExplicitCacheServer(t, http.StatusOK)
+			p := newExplicitCacheProvider(t, srv.url, map[string]any{"thinking_budget": tc.budget})
+			if _, err := p.Predict(context.Background(), providers.PredictionRequest{
+				Messages: []types.Message{{Role: "user", Content: "hi"}}, MaxTokens: 1024,
+			}); err != nil {
+				t.Fatalf("Predict: %v", err)
+			}
+			gc := genConfigFrom(t, srv.genBody(t))
+			tcfg, ok := gc["thinkingConfig"].(map[string]any)
+			if !ok {
+				t.Fatalf("no thinkingConfig in generationConfig: %v", gc)
+			}
+			if tcfg["thinkingBudget"] != tc.want {
+				t.Errorf("thinkingBudget = %v, want %v", tcfg["thinkingBudget"], tc.want)
+			}
+		})
+	}
+}
+
+// thinking_budget + include_thoughts flow into the tool (map) path too.
+func TestThinking_ConfigInRequest_Tools(t *testing.T) {
+	srv := newExplicitCacheServer(t, http.StatusOK)
+	p := newExplicitCacheProvider(t, srv.url, map[string]any{
+		"thinking_budget": 128, "include_thoughts": true,
+	})
+	tp := p.(*ToolProvider)
+	tools, _ := tp.BuildTooling([]*providers.ToolDescriptor{
+		{Name: "noop", Description: "noop", InputSchema: []byte(`{"type":"object"}`)},
+	})
+	if _, _, err := tp.PredictWithTools(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}}, MaxTokens: 1024,
+	}, tools, ""); err != nil {
+		t.Fatalf("PredictWithTools: %v", err)
+	}
+	tcfg, ok := genConfigFrom(t, srv.genBody(t))["thinkingConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("no thinkingConfig in tool request")
+	}
+	if tcfg["thinkingBudget"] != float64(128) {
+		t.Errorf("thinkingBudget = %v, want 128", tcfg["thinkingBudget"])
+	}
+	if tcfg["includeThoughts"] != true {
+		t.Errorf("includeThoughts = %v, want true", tcfg["includeThoughts"])
+	}
+}
+
+// With no thinking config, no thinkingConfig is sent (the model applies its own
+// default thinking).
+func TestThinking_NotConfigured_Omitted(t *testing.T) {
+	srv := newExplicitCacheServer(t, http.StatusOK)
+	p := newExplicitCacheProvider(t, srv.url, nil)
+	if _, err := p.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}}, MaxTokens: 1024,
+	}); err != nil {
+		t.Fatalf("Predict: %v", err)
+	}
+	if _, has := genConfigFrom(t, srv.genBody(t))["thinkingConfig"]; has {
+		t.Error("thinkingConfig must be omitted when not configured")
+	}
+}
+
+// geminiThinkingConfigFor returns the config and warns (covered) when the cap
+// can't cover the budget.
+func TestThinking_BudgetExceedsMax_StillReturnsConfig(t *testing.T) {
+	budget := 1000
+	p := &Provider{thinkingBudget: &budget}
+	tc := p.geminiThinkingConfigFor(100) // maxTokens < budget → warn path
+	if tc == nil || tc.ThinkingBudget == nil || *tc.ThinkingBudget != 1000 {
+		t.Fatalf("expected thinkingConfig with budget 1000, got %+v", tc)
+	}
+}
+
+// The MAX_TOKENS-with-no-content error now names the thinking-budget cause and
+// the fix, instead of the misleading "this should not happen".
+func TestThinking_MaxTokensError_IsActionable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Candidate with empty parts + MAX_TOKENS (thinking consumed the budget).
+		_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[],"role":"model"},`+
+			`"finishReason":"MAX_TOKENS","index":0}],"usageMetadata":{"promptTokenCount":5,`+
+			`"candidatesTokenCount":0,"thoughtsTokenCount":16,"totalTokenCount":21}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := newExplicitCacheProvider(t, srv.URL, nil)
+	_, err := p.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}}, MaxTokens: 16,
+	})
+	if err == nil {
+		t.Fatal("expected an error on MAX_TOKENS with no content")
+	}
+	for _, want := range []string{"thinking_budget", "max_tokens", "output-token limit"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q: %v", want, err)
+		}
+	}
+}

--- a/runtime/providers/gemini/gemini_tool_choice_test.go
+++ b/runtime/providers/gemini/gemini_tool_choice_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -85,7 +86,7 @@ func TestToolProvider_ToolChoiceMapping(t *testing.T) {
 				Temperature: 0.7,
 			}
 
-			requestMap := provider.buildToolRequest(req, geminiTools, tt.toolChoice)
+			requestMap := provider.buildToolRequest(context.Background(), req, geminiTools, tt.toolChoice)
 
 			// Extract the mode from tool_config
 			toolConfig, ok := requestMap["tool_config"].(map[string]interface{})

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -19,6 +19,9 @@ const (
 	roleUser        = "user"
 	providerNameLog = "Gemini-Tools"
 
+	// keyGenerationConfig is the generateContent body key for generation params.
+	keyGenerationConfig = "generationConfig"
+
 	// providerMetaThoughtSignature is the MessageToolCall.ProviderMetadata key
 	// used to round-trip Gemini 3's opaque thoughtSignature on tool-call parts.
 	providerMetaThoughtSignature = "gemini.thought_signature"
@@ -436,13 +439,17 @@ func (p *ToolProvider) buildToolRequest(
 	// Apply defaults to zero-valued request parameters
 	temperature, topP, maxTokens := p.applyRequestDefaults(req)
 
+	genConfig := map[string]any{
+		"temperature":     temperature,
+		"topP":            topP,
+		"maxOutputTokens": maxTokens,
+	}
+	if tc := p.geminiThinkingConfigFor(maxTokens); tc != nil {
+		genConfig["thinkingConfig"] = tc
+	}
 	request := map[string]any{
-		"contents": contents,
-		"generationConfig": map[string]any{
-			"temperature":     temperature,
-			"topP":            topP,
-			"maxOutputTokens": maxTokens,
-		},
+		"contents":          contents,
+		keyGenerationConfig: genConfig,
 	}
 
 	if req.System != "" {
@@ -495,8 +502,9 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte, predictResp providers
 		// Handle different finish reasons
 		switch candidate.FinishReason {
 		case "MAX_TOKENS":
-			// Don't use fallback - return error to see when this happens
-			return predictResp, nil, fmt.Errorf("gemini returned MAX_TOKENS error (this should not happen with reasonable limits)")
+			return predictResp, nil, fmt.Errorf("gemini hit the output-token limit before emitting any content: " +
+				"on 2.5 'thinking' models the reasoning budget counts toward maxOutputTokens, so a low max_tokens " +
+				"can be exhausted by thinking alone — raise max_tokens or set a smaller thinking_budget")
 		case "SAFETY":
 			return predictResp, nil, fmt.Errorf("response blocked by Gemini safety filters")
 		case "RECITATION":
@@ -704,6 +712,7 @@ func init() {
 				)
 				tp.setCapabilities(spec.Capabilities)
 				applyExplicitCachingConfig(tp.Provider, spec)
+				applyThinkingConfig(tp.Provider, spec)
 				return tp, nil
 			},
 			func(spec providers.ProviderSpec) (providers.Provider, error) {
@@ -712,6 +721,7 @@ func init() {
 				)
 				tp.setCapabilities(spec.Capabilities)
 				applyExplicitCachingConfig(tp.Provider, spec)
+				applyThinkingConfig(tp.Provider, spec)
 				return tp, nil
 			},
 		),

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -136,7 +136,7 @@ func (p *ToolProvider) PredictWithTools(
 	p.currentRequest = &req
 
 	// Build Gemini request with tools
-	geminiReq := p.buildToolRequest(req, tools, toolChoice)
+	geminiReq := p.buildToolRequest(ctx, req, tools, toolChoice)
 
 	// Prepare response with raw request if configured (set early to preserve on error)
 	predictResp := providers.PredictionResponse{}
@@ -384,7 +384,7 @@ func addToolConfig(request map[string]any, tools any, toolChoice string) {
 
 //nolint:gocritic // hugeParam: method uses req value throughout
 func (p *ToolProvider) buildToolRequest(
-	req providers.PredictionRequest, tools any, toolChoice string,
+	ctx context.Context, req providers.PredictionRequest, tools any, toolChoice string,
 ) map[string]any {
 	// Convert messages to Gemini format
 	contents := make([]map[string]any, 0, len(req.Messages))
@@ -455,6 +455,18 @@ func (p *ToolProvider) buildToolRequest(
 
 	if tools != nil {
 		addToolConfig(request, tools, toolChoice)
+	}
+
+	// Explicit context caching: move the stable system+tools prefix into a
+	// CachedContent resource and reference it. The API rejects cachedContent
+	// alongside systemInstruction / tools / tool_config, so drop the inline
+	// prefix. request["tools"] is the wrapped []any{decl} that addToolConfig set;
+	// caching it keeps the cached and dropped tools identical.
+	if cc := p.resolveCachedContent(ctx, req.System, request["tools"]); cc != "" {
+		request["cachedContent"] = cc
+		delete(request, "systemInstruction")
+		delete(request, "tools")
+		delete(request, "tool_config")
 	}
 
 	return request
@@ -617,7 +629,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 	toolChoice string,
 ) (<-chan providers.StreamChunk, error) {
 	// Build Gemini request with tools
-	geminiReq := p.buildToolRequest(req, tools, toolChoice)
+	geminiReq := p.buildToolRequest(ctx, req, tools, toolChoice)
 
 	requestBytes, err := json.Marshal(geminiReq)
 	if err != nil {
@@ -691,6 +703,7 @@ func init() {
 					spec.Platform, spec.PlatformConfig,
 				)
 				tp.setCapabilities(spec.Capabilities)
+				applyExplicitCachingConfig(tp.Provider, spec)
 				return tp, nil
 			},
 			func(spec providers.ProviderSpec) (providers.Provider, error) {
@@ -698,6 +711,7 @@ func init() {
 					spec.ID, spec.Model, spec.BaseURL, spec.Defaults, spec.IncludeRawOutput,
 				)
 				tp.setCapabilities(spec.Capabilities)
+				applyExplicitCachingConfig(tp.Provider, spec)
 				return tp, nil
 			},
 		),

--- a/runtime/providers/gemini/gemini_tools_edge_cases_test.go
+++ b/runtime/providers/gemini/gemini_tools_edge_cases_test.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -11,9 +12,8 @@ import (
 
 func TestToolProvider_BuildMessageParts_EmptyToolResults(t *testing.T) {
 	msg := types.Message{
-		Role:    "user",
-		Parts:     []types.ContentPart{types.NewTextPart("Hello")},
-
+		Role:  "user",
+		Parts: []types.ContentPart{types.NewTextPart("Hello")},
 	}
 
 	parts := buildMessageParts(msg, []map[string]interface{}{})
@@ -24,9 +24,8 @@ func TestToolProvider_BuildMessageParts_EmptyToolResults(t *testing.T) {
 
 func TestToolProvider_BuildMessageParts_WithToolResults(t *testing.T) {
 	msg := types.Message{
-		Role:    "user",
-		Parts:     []types.ContentPart{types.NewTextPart("Process result")},
-
+		Role:  "user",
+		Parts: []types.ContentPart{types.NewTextPart("Process result")},
 	}
 
 	toolResults := []map[string]interface{}{
@@ -47,8 +46,8 @@ func TestToolProvider_BuildMessageParts_WithToolResults(t *testing.T) {
 
 func TestToolProvider_BuildMessageParts_WithToolCalls(t *testing.T) {
 	msg := types.Message{
-		Role:    "assistant",
-		Parts:     []types.ContentPart{types.NewTextPart("Let me check that")},
+		Role:  "assistant",
+		Parts: []types.ContentPart{types.NewTextPart("Let me check that")},
 
 		ToolCalls: []types.MessageToolCall{
 			{
@@ -68,14 +67,13 @@ func TestToolProvider_BuildMessageParts_WithToolCalls(t *testing.T) {
 
 func TestToolProvider_ProcessToolMessage_EmptyName(t *testing.T) {
 	msg := types.Message{
-		Role:    "tool",
-		Parts:     []types.ContentPart{types.NewTextPart(`{"result": "success"}`)},
+		Role:  "tool",
+		Parts: []types.ContentPart{types.NewTextPart(`{"result": "success"}`)},
 
 		ToolResult: &types.MessageToolResult{
-			ID:      "call_1",
-			Name:    "", // Empty name
-			Parts:     []types.ContentPart{types.NewTextPart(`{"result": "success"}`)},
-
+			ID:    "call_1",
+			Name:  "", // Empty name
+			Parts: []types.ContentPart{types.NewTextPart(`{"result": "success"}`)},
 		},
 	}
 
@@ -98,14 +96,13 @@ func TestToolProvider_ProcessToolMessage_EmptyName(t *testing.T) {
 
 func TestToolProvider_ProcessToolMessage_StringContent(t *testing.T) {
 	msg := types.Message{
-		Role:    "tool",
-		Parts:     []types.ContentPart{types.NewTextPart("plain string result")},
+		Role:  "tool",
+		Parts: []types.ContentPart{types.NewTextPart("plain string result")},
 
 		ToolResult: &types.MessageToolResult{
-			ID:      "call_1",
-			Name:    "test_tool",
-			Parts:     []types.ContentPart{types.NewTextPart("plain string result")},
-
+			ID:    "call_1",
+			Name:  "test_tool",
+			Parts: []types.ContentPart{types.NewTextPart("plain string result")},
 		},
 	}
 
@@ -124,10 +121,9 @@ func TestToolProvider_ProcessToolMessage_PrimitiveContent(t *testing.T) {
 		Role:    "tool",
 		Content: "42", // Numeric string
 		ToolResult: &types.MessageToolResult{
-			ID:      "call_1",
-			Name:    "get_number",
-			Parts:     []types.ContentPart{types.NewTextPart("42")},
-
+			ID:    "call_1",
+			Name:  "get_number",
+			Parts: []types.ContentPart{types.NewTextPart("42")},
 		},
 	}
 
@@ -220,7 +216,7 @@ func TestToolProvider_ParseToolResponse_MaxTokensError(t *testing.T) {
 		t.Error("Expected error for MAX_TOKENS finish reason")
 	}
 
-	if err != nil && err.Error() != "gemini returned MAX_TOKENS error (this should not happen with reasonable limits)" {
+	if err != nil && !strings.Contains(err.Error(), "output-token limit") {
 		t.Errorf("Unexpected error message: %v", err)
 	}
 }

--- a/runtime/providers/gemini/gemini_tools_edge_cases_test.go
+++ b/runtime/providers/gemini/gemini_tools_edge_cases_test.go
@@ -307,7 +307,7 @@ func TestToolProvider_BuildToolRequest_EmptyMessages(t *testing.T) {
 
 	tools := []interface{}{map[string]interface{}{"name": "test"}}
 
-	geminiReq := provider.buildToolRequest(req, tools, "auto")
+	geminiReq := provider.buildToolRequest(context.Background(), req, tools, "auto")
 
 	contents, ok := geminiReq["contents"].([]map[string]interface{})
 	if !ok {
@@ -328,7 +328,7 @@ func TestToolProvider_BuildToolRequest_NilTools(t *testing.T) {
 		},
 	}
 
-	geminiReq := provider.buildToolRequest(req, nil, "")
+	geminiReq := provider.buildToolRequest(context.Background(), req, nil, "")
 
 	// Should not have tools or tool_config
 	if _, hasTools := geminiReq["tools"]; hasTools {

--- a/runtime/providers/gemini/gemini_tools_test.go
+++ b/runtime/providers/gemini/gemini_tools_test.go
@@ -258,7 +258,7 @@ func TestGeminiToolProvider_BuildToolRequest_AppliesDefaults(t *testing.T) {
 				Messages:    []types.Message{{Role: "user", Content: "Hello"}},
 			}
 
-			request := provider.buildToolRequest(req, nil, "")
+			request := provider.buildToolRequest(context.Background(), req, nil, "")
 
 			genConfig, ok := request["generationConfig"].(map[string]interface{})
 			if !ok {
@@ -787,7 +787,7 @@ func TestBuildToolRequest_WithSystemInstruction(t *testing.T) {
 		System:   "You are a helpful assistant",
 		Messages: []types.Message{{Role: "user", Content: "Hi"}},
 	}
-	result := provider.buildToolRequest(req, nil, "")
+	result := provider.buildToolRequest(context.Background(), req, nil, "")
 
 	if _, ok := result["systemInstruction"]; !ok {
 		t.Error("expected systemInstruction in request")


### PR DESCRIPTION
## Summary

PromptKit relied on Gemini's **implicit** caching, which is best-effort: in a long agent loop `cachedContentTokenCount` stayed at 0 for the first ~10 rounds, paying full price for the whole warmup. This adds **explicit** caching via the `CachedContent` API — the Gemini equivalent of Claude's explicit breakpoints — so the cache hits from the very first reference.

## Design

- **Content-addressed cache manager** (`gemini_cache.go`) keys a `CachedContent` resource by `hash(model, system, tools)`, so any request with the same stable prefix reuses it — no conversation ID needed. TTL-based expiry with proactive re-create; any create/lookup failure **degrades to inline** (never breaks a turn). `Provider.Close()` best-effort deletes created resources.
- **Wired into every generateContent path:** `Predict`, `PredictStream`, and the shared `buildToolRequest` (covering `PredictWithTools` + `PredictStreamWithTools`). When a handle exists the request references `cachedContent` and drops the inline `systemInstruction`/`tools`/`tool_config` — the API rejects sending both (verified live).
- **Gated off by default** behind `additional_config.explicit_caching: true`, with an optional `explicit_cache_ttl_seconds`. A min-size guard skips prefixes below the cacheable floor (creating a tiny cache costs more than it saves).
- **Out of scope (safe):** Vertex degrades to implicit (different CachedContent endpoint/auth — a follow-up). Realtime (Gemini Live websocket) is a separate protocol and is untouched.

## Verification — live, all paths

Run against the real API (`GEMINI_LIVE_CACHE=1`, `gemini-2.5-flash`):

| Path | cachedTokens | inputTokens (billed) |
|---|---|---|
| Predict round 1 | **1441** (immediate, vs implicit's 0) | 8 |
| Predict round 2 | 1441 (reused, no re-create) | 8 |
| PredictWithTools | 1466 (cache includes tool schemas) | 8 |
| PredictStream | 1441 | 8 |

Unit tests cover reference/drop, degrade-on-failure, create-error-body degrade, min-size skip, off-by-default, reuse-across-rounds, TTL config coercion, and Vertex degrade (`gemini_cache.go` at 89% statement coverage). A gated live test (`TestExplicitCaching_Live`, `GEMINI_LIVE_CACHE=1`) reproduces the table above.

## Config example

```yaml
spec:
  type: gemini
  model: gemini-2.5-flash
  additional_config:
    explicit_caching: true
    explicit_cache_ttl_seconds: 600   # optional, default 600
```

Closes #1404
