### PR TITLE
feat(gemini): explicit context caching on Vertex AI (follow-up to #1404)

### DIFF
--- a/docs/src/content/docs/runtime/reference/providers.md
+++ b/docs/src/content/docs/runtime/reference/providers.md
@@ -448,8 +448,9 @@ Notes:
 - **Explicit caching only creates a resource when the prefix is large enough**
   (~the model's cache floor) and degrades to implicit caching on any failure, so
   it never breaks a turn.
-- **Vertex** falls back to implicit caching (the CachedContent endpoint differs);
-  explicit caching applies to the direct (AI Studio) API.
+- **Works on both AI Studio and Vertex.** On Vertex the CachedContent resource is
+  created on the regional `aiplatform` endpoint using the same credential as the
+  generateContent calls (no extra setup).
 
 ## Mock Provider
 

--- a/runtime/providers/gemini/gemini_cache.go
+++ b/runtime/providers/gemini/gemini_cache.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -134,16 +135,11 @@ func toFloat(v any) (float64, bool) {
 // resolveCachedContent returns the CachedContent resource name to reference for
 // the given stable prefix (system + tools), creating it on first use and reusing
 // it within TTL. It returns "" to signal "send the prefix inline" — when
-// explicit caching is disabled, the prefix is too small, the platform is
-// unsupported, or any create/lookup failed (degrade to implicit). toolsField is
+// explicit caching is disabled, the prefix is too small, or any create/lookup
+// failed (degrade to implicit). Works on both AI Studio and Vertex. toolsField is
 // the request's "tools" value ([]any{decl}) or nil.
 func (p *Provider) resolveCachedContent(ctx context.Context, systemText string, toolsField any) string {
 	if p.cache == nil {
-		return ""
-	}
-	// Vertex's CachedContent endpoint/auth differ from AI Studio's; explicit
-	// caching there is a separate follow-up. Degrade to implicit on Vertex.
-	if p.isVertex() {
 		return ""
 	}
 	return p.cache.getOrCreate(ctx, p, systemText, toolsField)
@@ -236,13 +232,14 @@ type cachedContentCreateResp struct {
 }
 
 // createCachedContent POSTs a CachedContent resource holding the stable prefix
-// and returns its resource name (e.g. "cachedContents/abc123"). AI Studio only;
-// Vertex is screened out in resolveCachedContent.
+// and returns its resource name. Works on both AI Studio (name like
+// "cachedContents/abc123") and Vertex (full "projects/.../cachedContents/123"
+// path) — the URL, model field, and auth vary by platform (see the helpers).
 func (p *Provider) createCachedContent(
 	ctx context.Context, systemText string, toolsField any, ttl time.Duration,
 ) (string, error) {
 	body := cachedContentCreateBody{
-		Model: "models/" + p.model,
+		Model: p.cachedContentModelField(),
 		TTL:   fmt.Sprintf("%ds", int(ttl.Seconds())),
 	}
 	if systemText != "" {
@@ -257,12 +254,14 @@ func (p *Provider) createCachedContent(
 		return "", fmt.Errorf("marshal cachedContent: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/cachedContents?key=%s", p.baseURL, p.apiKey)
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(raw))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.cachedContentsCreateURL(), bytes.NewReader(raw))
 	if err != nil {
 		return "", fmt.Errorf("create cachedContent request: %w", err)
 	}
 	httpReq.Header.Set(contentTypeHeader, applicationJSON)
+	if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
+		return "", fmt.Errorf("apply cachedContent auth: %w", authErr)
+	}
 	if hdrErr := p.ApplyCustomHeaders(httpReq); hdrErr != nil {
 		return "", hdrErr
 	}
@@ -296,9 +295,11 @@ func (p *Provider) createCachedContent(
 
 // deleteCachedContent best-effort deletes a CachedContent resource (cleanup).
 func (p *Provider) deleteCachedContent(ctx context.Context, name string) {
-	url := fmt.Sprintf("%s/%s?key=%s", p.baseURL, name, p.apiKey)
-	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", url, http.NoBody)
+	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", p.cachedContentDeleteURL(name), http.NoBody)
 	if err != nil {
+		return
+	}
+	if authErr := p.applyAuth(ctx, httpReq); authErr != nil {
 		return
 	}
 	resp, err := p.GetHTTPClient().Do(httpReq)
@@ -306,4 +307,41 @@ func (p *Provider) deleteCachedContent(ctx context.Context, name string) {
 		return
 	}
 	_ = resp.Body.Close()
+}
+
+// CachedContent endpoints differ by platform. AI Studio (direct) uses
+// generativelanguage.googleapis.com/v1beta/cachedContents with the API key in
+// the query string and a "models/<model>" model field. Vertex uses the regional
+// aiplatform host under the project/location, Bearer auth (applied separately),
+// and a full publishers/google/models path; created resources are referenced by
+// their full returned resource name.
+
+// cachedContentsCreateURL returns the POST URL for creating a CachedContent.
+func (p *Provider) cachedContentsCreateURL() string {
+	if p.isVertex() {
+		// baseURL: .../projects/{proj}/locations/{loc}/publishers/google/models
+		return strings.TrimSuffix(p.baseURL, "/publishers/google/models") + "/cachedContents"
+	}
+	return fmt.Sprintf("%s/cachedContents?key=%s", p.baseURL, p.apiKey)
+}
+
+// cachedContentModelField returns the create-body "model" value.
+func (p *Provider) cachedContentModelField() string {
+	if p.isVertex() {
+		if i := strings.Index(p.baseURL, "projects/"); i >= 0 {
+			return p.baseURL[i:] + "/" + p.model
+		}
+	}
+	return "models/" + p.model
+}
+
+// cachedContentDeleteURL returns the DELETE URL for a CachedContent resource
+// name. On Vertex the name is a full resource path appended to the API root.
+func (p *Provider) cachedContentDeleteURL(name string) string {
+	if p.isVertex() {
+		if i := strings.Index(p.baseURL, "/v1/"); i >= 0 {
+			return p.baseURL[:i+len("/v1/")] + name
+		}
+	}
+	return fmt.Sprintf("%s/%s?key=%s", p.baseURL, name, p.apiKey)
 }

--- a/runtime/providers/gemini/gemini_explicit_cache_test.go
+++ b/runtime/providers/gemini/gemini_explicit_cache_test.go
@@ -308,16 +308,6 @@ func TestExplicitCaching_TTLConfig(t *testing.T) {
 	}
 }
 
-// Explicit caching degrades to implicit on Vertex (different CachedContent
-// endpoint/auth — a separate follow-up).
-func TestExplicitCaching_VertexDegrades(t *testing.T) {
-	p := &Provider{platform: vertexPlatform}
-	p.enableExplicitCaching(0) // 0 → default TTL
-	if got := p.resolveCachedContent(context.Background(), bigSystem, nil); got != "" {
-		t.Errorf("Vertex must degrade to implicit (return \"\"), got %q", got)
-	}
-}
-
 // The created CachedContent is reused across rounds: a second request with the
 // same prefix references the same resource without creating another.
 func TestExplicitCaching_ReusesAcrossRounds(t *testing.T) {

--- a/runtime/providers/gemini/gemini_vertex_cache_live_test.go
+++ b/runtime/providers/gemini/gemini_vertex_cache_live_test.go
@@ -1,0 +1,67 @@
+package gemini
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestExplicitCaching_Vertex_Live exercises explicit context caching against a
+// real Vertex AI project, proving the CachedContent resource is created on the
+// regional aiplatform endpoint (Bearer auth) and hits immediately.
+//
+// Gated: set GEMINI_LIVE_VERTEX=1 and VERTEX_PROJECT=<project> (VERTEX_REGION
+// defaults to us-central1). Auth uses Application Default Credentials
+// (gcloud auth application-default login). Never runs in CI.
+func TestExplicitCaching_Vertex_Live(t *testing.T) {
+	if os.Getenv("GEMINI_LIVE_VERTEX") != "1" || os.Getenv("VERTEX_PROJECT") == "" {
+		t.Skip("set GEMINI_LIVE_VERTEX=1 and VERTEX_PROJECT to run the live Vertex caching test")
+	}
+	project := os.Getenv("VERTEX_PROJECT")
+	region := os.Getenv("VERTEX_REGION")
+	if region == "" {
+		region = "us-central1"
+	}
+
+	ctx := context.Background()
+	cred, err := credentials.NewGCPCredential(ctx, project, region)
+	if err != nil {
+		t.Fatalf("NewGCPCredential (is ADC set up?): %v", err)
+	}
+
+	provider, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
+		ID: "live-vertex-gemini", Type: "gemini", Model: "gemini-2.5-flash",
+		Platform:         "vertex",
+		PlatformConfig:   &providers.PlatformConfig{Type: "vertex", Region: region, Project: project},
+		Credential:       cred,
+		AdditionalConfig: map[string]any{"explicit_caching": true},
+		Defaults:         providers.ProviderDefaults{MaxTokens: 1024},
+	})
+	if err != nil {
+		t.Fatalf("CreateProviderFromSpec: %v", err)
+	}
+	tp := provider.(*ToolProvider)
+	t.Cleanup(func() {
+		for _, name := range tp.cache.trackedNames() {
+			tp.deleteCachedContent(context.Background(), name)
+		}
+	})
+
+	for round := 1; round <= 2; round++ {
+		resp, err := tp.Predict(ctx, providers.PredictionRequest{
+			System:   bigSystem,
+			Messages: []types.Message{{Role: "user", Content: "Reply with the single word OK."}},
+		})
+		if err != nil {
+			t.Fatalf("round %d Predict: %v", round, err)
+		}
+		if resp.CostInfo == nil || resp.CostInfo.CachedTokens <= 0 {
+			t.Fatalf("round %d: expected cachedTokens > 0 on Vertex, got %+v", round, resp.CostInfo)
+		}
+		t.Logf("Vertex Predict round %d: cachedTokens=%d inputTokens=%d", round, resp.CostInfo.CachedTokens, resp.CostInfo.InputTokens)
+	}
+}

--- a/runtime/providers/gemini/gemini_vertex_cache_test.go
+++ b/runtime/providers/gemini/gemini_vertex_cache_test.go
@@ -1,0 +1,100 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Explicit caching on Vertex uses the regional aiplatform endpoints, Bearer
+// auth, and full resource paths (verified live). This pins those differences:
+// the CachedContent create hits .../cachedContents under the project/location,
+// the create body's model is the full publishers/google/models path, the
+// returned full resource name is referenced as cachedContent, and the inline
+// systemInstruction is dropped — all with the credential's Bearer auth applied.
+func TestExplicitCaching_Vertex_UsesVertexEndpoints(t *testing.T) {
+	var createPath, createModel string
+	var genBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/cachedContents"):
+			createPath = r.URL.Path
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			createModel, _ = body["model"].(string)
+			_, _ = io.WriteString(w, `{"name":"projects/930678174047/locations/us-central1/cachedContents/abc123"}`)
+		case strings.Contains(r.URL.Path, ":generateContent"):
+			genBody, _ = io.ReadAll(r.Body)
+			_, _ = io.WriteString(w, geminiGenOKBody)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	cred := &mockBearerCredential{}
+	baseURL := srv.URL + "/v1/projects/test-proj/locations/us-central1/publishers/google/models"
+	provider, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
+		ID: "v-gemini", Type: "gemini", Model: "gemini-2.5-flash", BaseURL: baseURL,
+		Platform:         "vertex",
+		PlatformConfig:   &providers.PlatformConfig{Type: "vertex", Region: "us-central1", Project: "test-proj"},
+		Credential:       cred,
+		AdditionalConfig: map[string]any{"explicit_caching": true},
+	})
+	if err != nil {
+		t.Fatalf("CreateProviderFromSpec: %v", err)
+	}
+
+	if _, err := provider.Predict(context.Background(), providers.PredictionRequest{
+		System: bigSystem, Messages: []types.Message{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Predict: %v", err)
+	}
+
+	// Create hit the Vertex cachedContents endpoint under project/location.
+	if want := "/v1/projects/test-proj/locations/us-central1/cachedContents"; createPath != want {
+		t.Errorf("create path = %q, want %q", createPath, want)
+	}
+	// The create-body model is the full publisher path.
+	if want := "projects/test-proj/locations/us-central1/publishers/google/models/gemini-2.5-flash"; createModel != want {
+		t.Errorf("create model = %q, want %q", createModel, want)
+	}
+	// Bearer auth was applied (Vertex requires it).
+	if !cred.applied {
+		t.Error("expected the Vertex credential's Bearer auth to be applied to the cache create")
+	}
+	// generateContent references the full returned resource name and drops system.
+	var gen map[string]any
+	if err := json.Unmarshal(genBody, &gen); err != nil {
+		t.Fatalf("gen body not JSON: %v", err)
+	}
+	if gen["cachedContent"] != "projects/930678174047/locations/us-central1/cachedContents/abc123" {
+		t.Errorf("cachedContent = %v, want full resource name", gen["cachedContent"])
+	}
+	if _, has := gen["systemInstruction"]; has {
+		t.Error("systemInstruction must be dropped when cachedContent is set")
+	}
+}
+
+// cachedContentDeleteURL builds the Vertex delete URL from the full resource
+// name appended to the API root.
+func TestCachedContentDeleteURL_Vertex(t *testing.T) {
+	p := &Provider{
+		platform: vertexPlatform,
+		baseURL:  "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/publishers/google/models",
+	}
+	got := p.cachedContentDeleteURL("projects/123/locations/us-central1/cachedContents/abc")
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/123/locations/us-central1/cachedContents/abc"
+	if got != want {
+		t.Errorf("delete URL = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1404. Explicit Gemini context caching previously degraded to implicit on Vertex (the `CachedContent` endpoint and auth differ from AI Studio). This adds full Vertex support, so the cache hits immediately there too.

## What changed

The CachedContent create/delete calls are now platform-aware:

| | AI Studio (direct) | Vertex |
|---|---|---|
| Endpoint | `generativelanguage.googleapis.com/v1beta/cachedContents` | `{region}-aiplatform.googleapis.com/v1/projects/{p}/locations/{r}/cachedContents` |
| Auth | API key in `?key=` | **Bearer** (same credential as generateContent) |
| Model field | `models/<model>` | `projects/{p}/locations/{r}/publishers/google/models/<model>` |
| Reference | returned `cachedContents/<id>` | full returned resource name |

Implemented as `cachedContentsCreateURL` / `cachedContentModelField` / `cachedContentDeleteURL` helpers; `createCachedContent`/`deleteCachedContent` now apply auth (`applyAuth` is a no-op on AI Studio, Bearer on Vertex). The `isVertex` degrade in `resolveCachedContent` is removed.

## Verification

**Live against a real Vertex project** (`gemini-2.5-flash`, ADC auth): round 1 `cachedTokens=1322` (immediate hit), `inputTokens=6`, reused on round 2 with no re-create.

Unit tests pin the Vertex create path, full model path, Bearer-auth application, cache reference, system-instruction drop, and delete-URL construction (`gemini_cache.go` at 85% coverage). A gated live test (`TestExplicitCaching_Vertex_Live`, `GEMINI_LIVE_VERTEX=1 VERTEX_PROJECT=…`) reproduces the above via Application Default Credentials. The obsolete `TestExplicitCaching_VertexDegrades` is removed. Docs updated to note both platforms are supported.
