### PR TITLE
docs: document enforced DCO + CLA for contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -138,6 +138,7 @@ Please pay special attention to:
 
 **Before Submitting**
 - [ ] I have signed my commits with `git commit -s`
+- [ ] I have signed the CLA (the CLA Assistant bot will prompt on my first PR)
 - [ ] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
 - [ ] I have followed the [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [ ] My code follows the project's coding standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ This adds a "Signed-off-by" line to your commit message:
 Signed-off-by: Your Name <your.email@example.com>
 ```
 
+> **This is enforced.** A required `DCO` check verifies every commit in your pull request carries a matching `Signed-off-by` line. If you forget, fix it with `git commit --amend -s` (single commit) or `git rebase --signoff main` (multiple commits), then force-push.
+
+## Contributor License Agreement (CLA)
+
+Before your first contribution can be merged you must sign our Contributor License Agreement. When you open your first pull request, the **CLA Assistant** bot comments with a link to the CLA; you sign by replying on the PR with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+You sign **once** — the signature then applies to your future contributions across AltairaLabs repositories. The CLA is a **license grant**, not a copyright assignment: you keep ownership of your contribution and grant AltairaLabs a license to use and relicense it. You can read the full text [here](https://gist.github.com/chaholl/59e308a6c25cedeb6d1787aec2c70bcd).
+
 ## How to Contribute
 
 ### Reporting Bugs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Before your first contribution can be merged you must sign our Contributor Licen
 
 > I have read the CLA Document and I hereby sign the CLA
 
-You sign **once** — the signature then applies to your future contributions across AltairaLabs repositories. The CLA is a **license grant**, not a copyright assignment: you keep ownership of your contribution and grant AltairaLabs a license to use and relicense it. You can read the full text [here](https://gist.github.com/chaholl/59e308a6c25cedeb6d1787aec2c70bcd).
+You sign **once** — the signature then applies to your future contributions across AltairaLabs repositories. The CLA is a **license grant**, not a copyright assignment: you keep ownership of your contribution and grant AltairaLabs a license to use and relicense it. You can read the full text [here](https://gist.github.com/chaholl/acc8f1f6c38376d00a162351f566b93e).
 
 ## How to Contribute
 


### PR DESCRIPTION
Standardizes contributor docs to document the enforced DCO check and the Contributor License Agreement.

## Changes

- **CONTRIBUTING.md**
  - Added a "**This is enforced.**" note after the DCO sign-off example, explaining the required `DCO` check and how to fix missing sign-offs.
  - Added a new `## Contributor License Agreement (CLA)` section after the DCO section, describing the CLA Assistant bot flow, the one-time sign, and the license-grant (not assignment) nature, linking the full text.
- **.github/pull_request_template.md**
  - Added a CLA checklist item right after the existing DCO sign-off item.

Issue templates left unchanged.
