### PR TITLE
feat(providers): normalize finish/stop reasons across providers

### DIFF
--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -918,13 +918,14 @@ func (s *ProviderStage) executeRound(
 
 	// Build response message with latency and cost info
 	responseMsg := types.Message{
-		Role:      "assistant",
-		Content:   resp.Content,
-		Parts:     resp.Parts,
-		ToolCalls: toolCalls,
-		Timestamp: timeNow(),
-		LatencyMs: duration.Milliseconds(),
-		CostInfo:  resp.CostInfo,
+		Role:         roleAssistant,
+		Content:      resp.Content,
+		Parts:        resp.Parts,
+		ToolCalls:    toolCalls,
+		Timestamp:    timeNow(),
+		LatencyMs:    duration.Milliseconds(),
+		CostInfo:     resp.CostInfo,
+		FinishReason: resp.FinishReason,
 	}
 
 	// Run AfterCall hooks

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -2195,6 +2195,51 @@ func TestProviderStage_ResetsIdleOnNonStreamingRound(t *testing.T) {
 // Idle Timeout End-to-End Tests (slow provider)
 // =============================================================================
 
+// finishReasonProvider is a non-streaming fake that returns a fixed canonical
+// finish reason, used to verify the provider stage copies it onto the message.
+type finishReasonProvider struct {
+	delayedStreamProvider
+}
+
+func (p *finishReasonProvider) SupportsStreaming() bool { return false }
+
+func (p *finishReasonProvider) Predict(
+	_ context.Context, _ providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	return providers.PredictionResponse{
+		Content:      "done",
+		FinishReason: types.FinishReasonMaxOutputTokens,
+	}, nil
+}
+
+func TestProviderStage_CopiesFinishReasonToMessage(t *testing.T) {
+	provider := &finishReasonProvider{}
+
+	turnState := NewTurnState()
+	turnState.SystemPrompt = "helper"
+	providerStage := NewProviderStageWithTurnState(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, nil, turnState)
+
+	pl, err := NewPipelineBuilderWithConfig(DefaultPipelineConfig()).
+		Chain(providerStage).
+		Build()
+	require.NoError(t, err)
+
+	userMsg := types.Message{Role: "user", Content: "hi"}
+	result, err := pl.ExecuteSync(context.Background(), NewMessageElement(&userMsg))
+	require.NoError(t, err)
+
+	var assistant *types.Message
+	for i := range result.Messages {
+		if result.Messages[i].Role == "assistant" {
+			assistant = &result.Messages[i]
+		}
+	}
+	require.NotNil(t, assistant, "expected an assistant message")
+	assert.Equal(t, types.FinishReasonMaxOutputTokens, assistant.FinishReason)
+}
+
 // delayedStreamProvider simulates a provider that waits before producing its
 // first chunk — like Ollama queued behind other requests.
 type delayedStreamProvider struct {

--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -823,6 +823,7 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBody
+	predictResp.FinishReason = normalizeFinishReason(claudeResp.StopReason)
 
 	return predictResp, nil
 }

--- a/runtime/providers/claude/claude_bedrock_streaming_test.go
+++ b/runtime/providers/claude/claude_bedrock_streaming_test.go
@@ -105,8 +105,8 @@ func TestBedrockPredictStream(t *testing.T) {
 	if lastChunk.FinishReason == nil {
 		t.Fatal("expected finish reason on last chunk")
 	}
-	if *lastChunk.FinishReason != "end_turn" {
-		t.Errorf("expected finish reason 'end_turn', got %q", *lastChunk.FinishReason)
+	if *lastChunk.FinishReason != types.FinishReasonStop {
+		t.Errorf("expected finish reason %q, got %q", types.FinishReasonStop, *lastChunk.FinishReason)
 	}
 	if lastChunk.Content != "Hello from Bedrock" {
 		t.Errorf("expected accumulated content 'Hello from Bedrock', got %q", lastChunk.Content)

--- a/runtime/providers/claude/claude_integration_test.go
+++ b/runtime/providers/claude/claude_integration_test.go
@@ -724,6 +724,6 @@ func TestProcessClaudeMessageStop(t *testing.T) {
 	chunk := <-outChan
 	assert.Equal(t, "accumulated text", chunk.Content)
 	assert.NotNil(t, chunk.FinishReason)
-	assert.Equal(t, "end_turn", *chunk.FinishReason)
+	assert.Equal(t, types.FinishReasonStop, *chunk.FinishReason)
 	assert.NotNil(t, chunk.CostInfo)
 }

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -263,7 +263,7 @@ func (p *Provider) processClaudeMessageStop(
 
 	if event.Message != nil {
 		if event.Message.StopReason != "" {
-			finishReason = event.Message.StopReason
+			finishReason = normalizeFinishReason(event.Message.StopReason)
 			finalChunk.FinishReason = &finishReason
 		}
 
@@ -433,7 +433,7 @@ func (p *Provider) streamResponse(
 
 		case "message_stop":
 			// Send final chunk with accumulated usage
-			finishReason := stopReason
+			finishReason := normalizeFinishReason(stopReason)
 			if finishReason == "" {
 				finishReason = finishReasonStop
 			}

--- a/runtime/providers/claude/finish_reason.go
+++ b/runtime/providers/claude/finish_reason.go
@@ -1,0 +1,25 @@
+package claude
+
+import "github.com/AltairaLabs/PromptKit/runtime/types"
+
+// stopReasonToolUse is the Anthropic wire stop_reason indicating the model
+// stopped to call a tool. Declared here to keep the literal out of the switch
+// (the same string is used for the content-block type elsewhere in the package).
+const stopReasonToolUse = "tool_use"
+
+// normalizeFinishReason maps an Anthropic stop_reason onto the canonical
+// vocabulary in runtime/types. Unknown/empty values pass through verbatim.
+func normalizeFinishReason(raw string) string {
+	switch raw {
+	case "end_turn", "stop_sequence", "pause_turn":
+		return types.FinishReasonStop
+	case "max_tokens":
+		return types.FinishReasonMaxOutputTokens
+	case stopReasonToolUse:
+		return types.FinishReasonToolUse
+	case "refusal":
+		return types.FinishReasonRefusal
+	default:
+		return raw
+	}
+}

--- a/runtime/providers/claude/finish_reason_test.go
+++ b/runtime/providers/claude/finish_reason_test.go
@@ -1,0 +1,105 @@
+package claude
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func newFinishReasonTestProvider(baseURL string) *Provider {
+	return &Provider{
+		BaseProvider: providers.NewBaseProvider("test", false, &http.Client{}),
+		model:        "claude-3-opus",
+		baseURL:      baseURL,
+		apiKey:       "test-key",
+		defaults: providers.ProviderDefaults{
+			MaxTokens: 100,
+			Pricing:   providers.Pricing{InputCostPer1K: 0.003, OutputCostPer1K: 0.015},
+		},
+	}
+}
+
+func TestClaude_Predict_NormalizesFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"msg_1","type":"message","role":"assistant",
+			"content":[{"type":"text","text":"partial"}],
+			"model":"claude-3-opus","stop_reason":"max_tokens",
+			"usage":{"input_tokens":10,"output_tokens":5}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := newFinishReasonTestProvider(server.URL)
+	resp, err := provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.FinishReason != types.FinishReasonMaxOutputTokens {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, types.FinishReasonMaxOutputTokens)
+	}
+}
+
+func TestClaude_PredictStream_NormalizesFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		events := []string{
+			"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\"}}\n\n",
+			"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"partial\"}}\n\n",
+			"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"}}\n\n",
+			"event: message_stop\ndata: {\"type\":\"message_stop\",\"message\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n",
+		}
+		for _, e := range events {
+			_, _ = w.Write([]byte(e))
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	provider := newFinishReasonTestProvider(server.URL)
+	streamChan, err := provider.PredictStream(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream failed: %v", err)
+	}
+
+	var last providers.StreamChunk
+	for chunk := range streamChan {
+		if chunk.FinishReason != nil {
+			last = chunk
+		}
+	}
+	if last.FinishReason == nil {
+		t.Fatal("expected a final chunk carrying a finish reason")
+	}
+	if *last.FinishReason != types.FinishReasonMaxOutputTokens {
+		t.Errorf("FinishReason = %q, want %q", *last.FinishReason, types.FinishReasonMaxOutputTokens)
+	}
+}
+
+func TestNormalizeFinishReason(t *testing.T) {
+	cases := map[string]string{
+		"end_turn":      types.FinishReasonStop,
+		"stop_sequence": types.FinishReasonStop,
+		"pause_turn":    types.FinishReasonStop,
+		"max_tokens":    types.FinishReasonMaxOutputTokens,
+		"tool_use":      types.FinishReasonToolUse,
+		"refusal":       types.FinishReasonRefusal,
+		"":              "",
+		"future_reason": "future_reason",
+	}
+	for raw, want := range cases {
+		if got := normalizeFinishReason(raw); got != want {
+			t.Errorf("normalizeFinishReason(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}

--- a/runtime/providers/finish_reason.go
+++ b/runtime/providers/finish_reason.go
@@ -1,0 +1,22 @@
+package providers
+
+import "github.com/AltairaLabs/PromptKit/runtime/types"
+
+// NormalizeOpenAIFinishReason maps an OpenAI-wire finish_reason onto the
+// canonical vocabulary in runtime/types. Unknown (and empty) values pass
+// through verbatim so a new provider reason is never silently swallowed.
+// Shared by the OpenAI, vLLM, and Ollama providers, which speak this vocabulary.
+func NormalizeOpenAIFinishReason(raw string) string {
+	switch raw {
+	case "stop":
+		return types.FinishReasonStop
+	case "length":
+		return types.FinishReasonMaxOutputTokens
+	case "tool_calls", "function_call":
+		return types.FinishReasonToolUse
+	case "content_filter":
+		return types.FinishReasonSafety
+	default:
+		return raw
+	}
+}

--- a/runtime/providers/finish_reason_test.go
+++ b/runtime/providers/finish_reason_test.go
@@ -1,0 +1,24 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestNormalizeOpenAIFinishReason(t *testing.T) {
+	cases := map[string]string{
+		"stop":           types.FinishReasonStop,
+		"length":         types.FinishReasonMaxOutputTokens,
+		"tool_calls":     types.FinishReasonToolUse,
+		"function_call":  types.FinishReasonToolUse,
+		"content_filter": types.FinishReasonSafety,
+		"":               "",              // unreported passes through
+		"weird_new_one":  "weird_new_one", // unknown passes through verbatim
+	}
+	for raw, want := range cases {
+		if got := NormalizeOpenAIFinishReason(raw); got != want {
+			t.Errorf("NormalizeOpenAIFinishReason(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}

--- a/runtime/providers/gemini/finish_reason.go
+++ b/runtime/providers/gemini/finish_reason.go
@@ -1,0 +1,20 @@
+package gemini
+
+import "github.com/AltairaLabs/PromptKit/runtime/types"
+
+// normalizeFinishReason maps a Gemini finishReason onto the canonical
+// vocabulary in runtime/types. Unknown/empty values pass through verbatim.
+func normalizeFinishReason(raw string) string {
+	switch raw {
+	case "STOP":
+		return types.FinishReasonStop
+	case finishReasonMaxTokens:
+		return types.FinishReasonMaxOutputTokens
+	case finishReasonSafety, finishReasonRecitation, "PROHIBITED_CONTENT", "SPII", "BLOCKLIST":
+		return types.FinishReasonSafety
+	case "MALFORMED_FUNCTION_CALL":
+		return types.FinishReasonRefusal
+	default:
+		return raw
+	}
+}

--- a/runtime/providers/gemini/finish_reason_test.go
+++ b/runtime/providers/gemini/finish_reason_test.go
@@ -1,0 +1,89 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestNormalizeFinishReason(t *testing.T) {
+	cases := map[string]string{
+		"STOP":                    types.FinishReasonStop,
+		"MAX_TOKENS":              types.FinishReasonMaxOutputTokens,
+		"SAFETY":                  types.FinishReasonSafety,
+		"RECITATION":              types.FinishReasonSafety,
+		"PROHIBITED_CONTENT":      types.FinishReasonSafety,
+		"SPII":                    types.FinishReasonSafety,
+		"BLOCKLIST":               types.FinishReasonSafety,
+		"MALFORMED_FUNCTION_CALL": types.FinishReasonRefusal,
+		"":                        "",
+		"NEW_REASON":              "NEW_REASON",
+	}
+	for raw, want := range cases {
+		if got := normalizeFinishReason(raw); got != want {
+			t.Errorf("normalizeFinishReason(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+// MAX_TOKENS with content parts present must return the partial content plus the
+// canonical max_output_tokens reason (no error).
+func TestGemini_Predict_MaxTokensWithContent(t *testing.T) {
+	resp := geminiResponse{
+		Candidates: []geminiCandidate{{
+			Content:      geminiContent{Parts: []geminiPart{{Text: "partial answer"}}},
+			FinishReason: "MAX_TOKENS",
+		}},
+		UsageMetadata: &geminiUsage{PromptTokenCount: 10, CandidatesTokenCount: 5},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	provider := NewProvider("test", "gemini-2.0-flash", server.URL,
+		providers.ProviderDefaults{MaxTokens: 100}, false)
+	got, err := provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict returned error: %v", err)
+	}
+	if got.Content != "partial answer" {
+		t.Errorf("Content = %q, want %q", got.Content, "partial answer")
+	}
+	if got.FinishReason != types.FinishReasonMaxOutputTokens {
+		t.Errorf("FinishReason = %q, want %q", got.FinishReason, types.FinishReasonMaxOutputTokens)
+	}
+}
+
+// MAX_TOKENS with zero content parts must still error (unchanged behavior).
+func TestGemini_Predict_MaxTokensNoContent_StillErrors(t *testing.T) {
+	resp := geminiResponse{
+		Candidates: []geminiCandidate{{
+			Content:      geminiContent{Parts: []geminiPart{}},
+			FinishReason: "MAX_TOKENS",
+		}},
+		UsageMetadata: &geminiUsage{PromptTokenCount: 10},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	provider := NewProvider("test", "gemini-2.0-flash", server.URL,
+		providers.ProviderDefaults{MaxTokens: 100}, false)
+	_, err := provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected an error for MAX_TOKENS with no content, got nil")
+	}
+}

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -680,6 +680,7 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBody
+	predictResp.FinishReason = normalizeFinishReason(candidate.FinishReason)
 
 	// Debug log the extracted parts
 	logger.Debug("Extracted content parts from Gemini response",

--- a/runtime/providers/gemini/gemini_integration_test.go
+++ b/runtime/providers/gemini/gemini_integration_test.go
@@ -279,7 +279,7 @@ func TestPredictStream_Integration(t *testing.T) {
 			// Last chunk should have finish reason
 			lastChunk := chunks[len(chunks)-1]
 			assert.NotNil(t, lastChunk.FinishReason)
-			assert.Equal(t, "STOP", *lastChunk.FinishReason)
+			assert.Equal(t, types.FinishReasonStop, *lastChunk.FinishReason)
 			assert.NotNil(t, lastChunk.CostInfo)
 		})
 	}

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -146,10 +146,11 @@ func (p *Provider) processGeminiStreamChunk(
 			return totalTokens, toolCalls, true
 		}
 
+		normalized := normalizeFinishReason(candidate.FinishReason)
 		finalChunk := providers.StreamChunk{
 			Content:      sb.String(),
 			TokenCount:   totalTokens,
-			FinishReason: &candidate.FinishReason,
+			FinishReason: &normalized,
 			ToolCalls:    toolCalls,
 		}
 

--- a/runtime/providers/gemini/gemini_streaming_test.go
+++ b/runtime/providers/gemini/gemini_streaming_test.go
@@ -77,8 +77,8 @@ func TestStreamResponse_IncrementalParsing(t *testing.T) {
 		}
 
 		// Final chunk with finish reason
-		if chunks[3].FinishReason == nil || *chunks[3].FinishReason != "STOP" {
-			t.Errorf("expected finish reason 'STOP', got %v", chunks[3].FinishReason)
+		if chunks[3].FinishReason == nil || *chunks[3].FinishReason != types.FinishReasonStop {
+			t.Errorf("expected finish reason %q, got %v", types.FinishReasonStop, chunks[3].FinishReason)
 		}
 		if chunks[3].Content != "Hello world!" {
 			t.Errorf("expected final content 'Hello world!', got %q", chunks[3].Content)
@@ -116,8 +116,8 @@ func TestStreamResponse_IncrementalParsing(t *testing.T) {
 			t.Errorf("expected delta 'Done', got %q", chunks[0].Delta)
 		}
 
-		if chunks[1].FinishReason == nil || *chunks[1].FinishReason != "STOP" {
-			t.Errorf("expected finish reason 'STOP'")
+		if chunks[1].FinishReason == nil || *chunks[1].FinishReason != types.FinishReasonStop {
+			t.Errorf("expected finish reason %q", types.FinishReasonStop)
 		}
 	})
 

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -562,6 +562,7 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte, predictResp providers
 	predictResp.Latency = time.Since(start)
 	predictResp.Raw = respBytes
 	predictResp.ToolCalls = toolCalls
+	predictResp.FinishReason = normalizeFinishReason(candidate.FinishReason)
 
 	return predictResp, toolCalls, nil
 }

--- a/runtime/providers/ollama/finish_reason_test.go
+++ b/runtime/providers/ollama/finish_reason_test.go
@@ -1,0 +1,40 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestOllama_Predict_NormalizesFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := ollamaResponse{
+			Model: "llama2",
+			Choices: []ollamaChoice{{
+				Index:        0,
+				Message:      ollamaMessage{Role: "assistant", Content: "partial"},
+				FinishReason: "length",
+			}},
+			Usage: ollamaUsage{PromptTokens: 5, CompletionTokens: 3, TotalTokens: 8},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	provider := NewProvider("test", "llama2", server.URL, providers.ProviderDefaults{MaxTokens: 100}, false, nil)
+	resp, err := provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.FinishReason != types.FinishReasonMaxOutputTokens {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, types.FinishReasonMaxOutputTokens)
+	}
+}

--- a/runtime/providers/ollama/ollama.go
+++ b/runtime/providers/ollama/ollama.go
@@ -337,7 +337,8 @@ func (p *Provider) streamResponse(
 			&accumulatedToolCalls, outChan,
 		)
 		if choice.FinishReason != nil {
-			finishReason = choice.FinishReason
+			normalized := providers.NormalizeOpenAIFinishReason(*choice.FinishReason)
+			finishReason = &normalized
 		}
 	}
 
@@ -593,6 +594,7 @@ func (p *Provider) predictWithMessages(
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBody
+	predictResp.FinishReason = providers.NormalizeOpenAIFinishReason(ollamaResp.Choices[0].FinishReason)
 
 	return predictResp, nil
 }

--- a/runtime/providers/openai/bedrock_unit_test.go
+++ b/runtime/providers/openai/bedrock_unit_test.go
@@ -332,8 +332,8 @@ func TestToolProvider_PredictStreamWithTools_BedrockEmitsSingleChunk(t *testing.
 	if len(last.ToolCalls) != 1 || last.ToolCalls[0].Name != "get_weather" {
 		t.Errorf("expected get_weather tool call, got %+v", last.ToolCalls)
 	}
-	if last.FinishReason == nil || *last.FinishReason != "tool_calls" {
-		t.Errorf("expected finish=tool_calls, got %v", last.FinishReason)
+	if last.FinishReason == nil || *last.FinishReason != types.FinishReasonToolUse {
+		t.Errorf("expected finish=%q, got %v", types.FinishReasonToolUse, last.FinishReason)
 	}
 }
 

--- a/runtime/providers/openai/finish_reason_test.go
+++ b/runtime/providers/openai/finish_reason_test.go
@@ -1,0 +1,91 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func newFinishReasonTestProvider(baseURL string) *Provider {
+	return &Provider{
+		BaseProvider: providers.NewBaseProvider("test", false, &http.Client{Timeout: 30 * time.Second}),
+		model:        "gpt-4",
+		baseURL:      baseURL,
+		apiKey:       "test-key",
+		defaults: providers.ProviderDefaults{
+			Pricing: providers.Pricing{InputCostPer1K: 0.03, OutputCostPer1K: 0.06},
+		},
+	}
+}
+
+func TestOpenAI_Predict_NormalizesFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := openAIResponse{
+			Model: "gpt-4",
+			Choices: []openAIChoice{{
+				Index:        0,
+				Message:      openAIMessage{Role: "assistant", Content: "partial"},
+				FinishReason: "length",
+			}},
+			Usage: openAIUsage{PromptTokens: 5, CompletionTokens: 3, TotalTokens: 8},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	provider := newFinishReasonTestProvider(server.URL)
+	resp, err := provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict returned error: %v", err)
+	}
+	if resp.FinishReason != types.FinishReasonMaxOutputTokens {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, types.FinishReasonMaxOutputTokens)
+	}
+}
+
+func TestOpenAI_PredictStream_NormalizesFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		chunks := []string{
+			`data: {"choices":[{"delta":{"content":"partial"}}]}`,
+			`data: {"choices":[{"delta":{},"finish_reason":"length"}],"usage":{"prompt_tokens":5,"completion_tokens":3}}`,
+			`data: [DONE]`,
+		}
+		for _, chunk := range chunks {
+			_, _ = w.Write([]byte(chunk + "\n\n"))
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	provider := newFinishReasonTestProvider(server.URL)
+	streamChan, err := provider.PredictStream(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream returned error: %v", err)
+	}
+
+	var last providers.StreamChunk
+	for chunk := range streamChan {
+		if chunk.FinishReason != nil {
+			last = chunk
+		}
+	}
+	if last.FinishReason == nil {
+		t.Fatal("expected a final chunk carrying a finish reason")
+	}
+	if *last.FinishReason != types.FinishReasonMaxOutputTokens {
+		t.Errorf("FinishReason = %q, want %q", *last.FinishReason, types.FinishReasonMaxOutputTokens)
+	}
+}

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -938,8 +938,9 @@ func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outCh
 		if choice.FinishReason != nil {
 			// If usage is included in this chunk, send final chunk now
 			if chunk.Usage != nil {
+				normalized := providers.NormalizeOpenAIFinishReason(*choice.FinishReason)
 				finalChunk := p.createFinalStreamChunk(
-					sb.String(), accumulatedToolCalls, totalTokens, choice.FinishReason, chunk.Usage)
+					sb.String(), accumulatedToolCalls, totalTokens, &normalized, chunk.Usage)
 				outChan <- finalChunk
 				return
 			}
@@ -1157,6 +1158,7 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBody
+	predictResp.FinishReason = providers.NormalizeOpenAIFinishReason(openAIResp.Choices[0].FinishReason)
 
 	return predictResp, nil
 }

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -438,6 +438,7 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte) (providers.Prediction
 				Audio     *openAIAudioResponse `json:"audio,omitempty"`
 				ToolCalls []openAIToolCall     `json:"tool_calls,omitempty"`
 			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
 		} `json:"choices"`
 		Usage struct {
 			PromptTokens        int `json:"prompt_tokens"`
@@ -468,9 +469,10 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte) (providers.Prediction
 	costBreakdown := p.Provider.CalculateCost(openaiResp.Usage.PromptTokens, openaiResp.Usage.CompletionTokens, cachedTokens)
 
 	resp := providers.PredictionResponse{
-		Content:  choice.Message.Content,
-		CostInfo: &costBreakdown,
-		Raw:      respBytes,
+		Content:      choice.Message.Content,
+		CostInfo:     &costBreakdown,
+		Raw:          respBytes,
+		FinishReason: providers.NormalizeOpenAIFinishReason(choice.FinishReason),
 	}
 
 	if audio := choice.Message.Audio; audio != nil {
@@ -586,7 +588,7 @@ func (p *ToolProvider) predictStreamWithToolsBedrockFallback(
 	}
 	finish := finishStop
 	if len(toolCalls) > 0 {
-		finish = "tool_calls"
+		finish = types.FinishReasonToolUse
 	}
 	out <- providers.StreamChunk{
 		Content:      resp.Content,

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -951,8 +951,8 @@ data: [DONE]
 	}
 
 	final := chunks[len(chunks)-1]
-	if final.FinishReason == nil || *final.FinishReason != "tool_calls" {
-		t.Errorf("Expected finish_reason=tool_calls, got %v", final.FinishReason)
+	if final.FinishReason == nil || *final.FinishReason != types.FinishReasonToolUse {
+		t.Errorf("Expected finish_reason=%q, got %v", types.FinishReasonToolUse, final.FinishReason)
 	}
 
 	if len(final.ToolCalls) != 1 {

--- a/runtime/providers/provider.go
+++ b/runtime/providers/provider.go
@@ -116,6 +116,9 @@ type PredictionResponse struct {
 	Raw        []byte                  `json:"raw,omitempty"`
 	RawRequest any                     `json:"raw_request,omitempty"` // Raw API request (for debugging)
 	ToolCalls  []types.MessageToolCall `json:"tool_calls,omitempty"`  // Tools called in this response
+	// FinishReason is the canonical (normalized) reason the model stopped,
+	// or "" if the provider did not report one. See runtime/types FinishReason* constants.
+	FinishReason string `json:"finish_reason,omitempty"`
 }
 
 // Pricing defines cost per 1K tokens for input and output

--- a/runtime/providers/streaming_mock_test.go
+++ b/runtime/providers/streaming_mock_test.go
@@ -138,8 +138,8 @@ data: {"type":"message_stop"}
 		t.Errorf("Final content: got %q, want %q", final.Content, "Hello Claude")
 	}
 
-	if final.FinishReason == nil || *final.FinishReason != "end_turn" {
-		t.Errorf("Expected finish_reason=end_turn, got %v", final.FinishReason)
+	if final.FinishReason == nil || *final.FinishReason != types.FinishReasonStop {
+		t.Errorf("Expected finish_reason=%q, got %v", types.FinishReasonStop, final.FinishReason)
 	}
 }
 
@@ -193,8 +193,8 @@ func TestGeminiStreamResponse(t *testing.T) {
 		t.Errorf("Final content: got %q, want %q", final.Content, "Hello Gemini!")
 	}
 
-	if final.FinishReason == nil || *final.FinishReason != "STOP" {
-		t.Errorf("Expected finish_reason=STOP, got %v", final.FinishReason)
+	if final.FinishReason == nil || *final.FinishReason != types.FinishReasonStop {
+		t.Errorf("Expected finish_reason=%q, got %v", types.FinishReasonStop, final.FinishReason)
 	}
 }
 

--- a/runtime/providers/vllm/finish_reason_test.go
+++ b/runtime/providers/vllm/finish_reason_test.go
@@ -1,0 +1,40 @@
+package vllm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestVLLM_Predict_NormalizesFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := vllmChatResponse{
+			Model: "test-model",
+			Choices: []vllmChatChoice{{
+				Index:        0,
+				Message:      vllmMessage{Role: "assistant", Content: "partial"},
+				FinishReason: "length",
+			}},
+			Usage: vllmUsage{PromptTokens: 5, CompletionTokens: 3, TotalTokens: 8},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	provider := NewProvider("test", "model", server.URL, providers.ProviderDefaults{MaxTokens: 100}, false, nil)
+	resp, err := provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict failed: %v", err)
+	}
+	if resp.FinishReason != types.FinishReasonMaxOutputTokens {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, types.FinishReasonMaxOutputTokens)
+	}
+}

--- a/runtime/providers/vllm/vllm.go
+++ b/runtime/providers/vllm/vllm.go
@@ -412,6 +412,7 @@ func (p *Provider) predictWithMessages(
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBody
+	predictResp.FinishReason = providers.NormalizeOpenAIFinishReason(vllmResp.Choices[0].FinishReason)
 
 	return predictResp, nil
 }
@@ -540,9 +541,10 @@ func (p *Provider) streamResponse(
 		// Send final chunk with finish reason and usage
 		if choice.FinishReason != "" && chunk.Usage != nil {
 			costInfo := p.CalculateCost(chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens, 0)
+			normalized := providers.NormalizeOpenAIFinishReason(choice.FinishReason)
 			outChan <- providers.StreamChunk{
 				Content:      sb.String(),
-				FinishReason: &choice.FinishReason,
+				FinishReason: &normalized,
 				CostInfo:     &costInfo,
 			}
 		}

--- a/runtime/types/finish_reason_test.go
+++ b/runtime/types/finish_reason_test.go
@@ -1,0 +1,18 @@
+package types
+
+import "testing"
+
+func TestCanonicalFinishReasonValues(t *testing.T) {
+	cases := map[string]string{
+		FinishReasonStop:            "stop",
+		FinishReasonMaxOutputTokens: "max_output_tokens",
+		FinishReasonToolUse:         "tool_use",
+		FinishReasonSafety:          "safety",
+		FinishReasonRefusal:         "refusal",
+	}
+	for got, want := range cases {
+		if got != want {
+			t.Errorf("constant = %q, want %q", got, want)
+		}
+	}
+}

--- a/runtime/types/message.go
+++ b/runtime/types/message.go
@@ -33,13 +33,26 @@ type Message struct {
 	Timestamp time.Time `json:"timestamp,omitempty"`  // When the message was created
 	LatencyMs int64     `json:"latency_ms,omitempty"` // Time taken to generate (for assistant messages)
 	CostInfo  *CostInfo `json:"cost_info,omitempty"`  // Token usage and cost tracking
-	// Provider-reported reason the assistant stopped (e.g. "stop", "length", "tool_calls").
+	// Provider-reported reason the assistant stopped, normalized onto the
+	// canonical vocabulary (see FinishReason* constants). Empty if unreported.
 	FinishReason string                 `json:"finish_reason,omitempty"`
 	Meta         map[string]interface{} `json:"meta,omitempty"` // Custom metadata
 
 	// Validation results (for assistant messages)
 	Validations []ValidationResult `json:"validations,omitempty"`
 }
+
+// Canonical finish reasons. Each provider normalizes its raw wire value onto
+// one of these before populating Message.FinishReason, so consumers can
+// reliably detect e.g. an output-cap truncation regardless of provider. An
+// unknown provider value passes through verbatim rather than mapping here.
+const (
+	FinishReasonStop            = "stop"              // natural completion
+	FinishReasonMaxOutputTokens = "max_output_tokens" // output budget (incl. reasoning) exhausted
+	FinishReasonToolUse         = "tool_use"          // stopped to call tools
+	FinishReasonSafety          = "safety"            // blocked by safety / content filter
+	FinishReasonRefusal         = "refusal"           // model declined to answer
+)
 
 // MessageToolCall represents a request to call a tool within a Message.
 // The Args field contains the JSON-encoded arguments for the tool.


### PR DESCRIPTION
## Summary

Normalizes provider finish/stop reasons onto a single canonical vocabulary so consumers can reliably detect e.g. an output-cap truncation regardless of provider, and surfaces the reason on the non-streaming path (which previously dropped it entirely).

Closes #1413

## What changed

- **Canonical constants** in `runtime/types`: `stop`, `max_output_tokens`, `tool_use`, `safety`, `refusal`. These are the only values that land in `Message.FinishReason`; unknown wire values pass through verbatim so a new provider reason is never silently swallowed.
- **`PredictionResponse.FinishReason` field** + pipeline wiring (`stages_provider.go`): the non-streaming `Predict()`/`PredictWithTools()` path now surfaces the reason on the assistant `Message`, at parity with the streaming path (`PredictionResponse` had no such field before, so the non-streaming reason was dropped for every provider).
- **Per-provider mapping**, applied on both streaming and non-streaming paths:
  - Shared `providers.NormalizeOpenAIFinishReason` for **OpenAI / vLLM / Ollama** (`length`→`max_output_tokens`, `tool_calls`→`tool_use`, `content_filter`→`safety`). Also replaces the synthesized `"tool_calls"` literal with canonical `tool_use`.
  - `claude` package helper (`end_turn`/`stop_sequence`/`pause_turn`→`stop`, `max_tokens`→`max_output_tokens`, `tool_use`, `refusal`), incl. the Bedrock event-stream path.
  - `gemini` package helper (`STOP`→`stop`, `MAX_TOKENS`→`max_output_tokens`, `SAFETY`/`RECITATION`/`PROHIBITED_CONTENT`/`SPII`/`BLOCKLIST`→`safety`, `MALFORMED_FUNCTION_CALL`→`refusal`).

## Deliberate scope decisions

- **Raw wire value is dropped** after mapping (YAGNI — no consumer reads it today). Easy to add a `Meta` key later if needed.
- **Gemini error behavior unchanged**: it already returns partial content when content parts exist and only errors on the genuinely-empty (zero-parts) case. That error is preserved (covered by `TestGemini_Predict_MaxTokensNoContent_StillErrors`); only the success-path reason string is canonicalized.
- Pipeline/SDK-synthesized sentinels (`error`, `canceled`, `pending_tools`) are out of scope and unchanged.

## Tests

Per-provider table + httptest contract tests (no live calls): each wire value → canonical on stream and non-stream paths, unknown pass-through, Gemini partial-content-vs-empty-error split, and a pipeline-wiring test. Pre-existing tests that asserted raw wire values (`end_turn`, `STOP`, `tool_calls`) updated to the canonical contract.

- runtime: 8902 passed
- sdk, arena: green
