### PR TITLE
feat(arena): interactive agent console — Phase 2 (web chat in serve)

### DIFF
--- a/docs/src/content/docs/arena/reference/cli-commands.md
+++ b/docs/src/content/docs/arena/reference/cli-commands.md
@@ -951,6 +951,10 @@ Start a local web server with the Arena live UI. Streams run events to the brows
 
 The web UI loads any existing results from the output directory on startup, so previous runs are immediately visible. New runs can be started from the browser and their progress streams in real time.
 
+### Interactive chat
+
+The web UI also includes an **Interactive Chat** tab to talk live to an agent defined in the config. Pick an agent (prompt config) and provider, fill in any required prompt variables, optionally enable evals, then chat — your message drives a turn and the reply streams into the **same** conversation view a run uses (tool calls, guardrail firings, and cost included). Guardrails are enforced; assertions don't apply. Use `--mock-provider` to try it without API keys.
+
 ### Usage
 
 ```bash

--- a/tools/arena/engine/interactive.go
+++ b/tools/arena/engine/interactive.go
@@ -199,6 +199,7 @@ func (s *InteractiveSession) SendUserMessage(
 		PromptVars:     s.promptVars,
 		BaseDir:        s.engine.config.ConfigDir,
 		ConversationID: s.conversationID,
+		RunID:          s.conversationID,
 		StateStoreConfig: &turnexecutors.StateStoreConfig{
 			Store: s.engine.GetStateStore(),
 		},

--- a/tools/arena/engine/interactive_events_test.go
+++ b/tools/arena/engine/interactive_events_test.go
@@ -214,7 +214,16 @@ func TestInteractiveSession_EmittedEventsCarryExecutionID(t *testing.T) {
 	bus := events.NewEventBus()
 	eng.SetEventBus(bus, WithMessageEvents())
 
-	got := collectMessageEvents(bus)
+	// Collect ExecutionID from every message.created event on the primary bus.
+	var execIDCollector struct {
+		mu  sync.Mutex
+		ids []string
+	}
+	bus.Subscribe(events.EventMessageCreated, func(ev *events.Event) {
+		execIDCollector.mu.Lock()
+		defer execIDCollector.mu.Unlock()
+		execIDCollector.ids = append(execIDCollector.ids, ev.ExecutionID)
+	})
 
 	sess, err := eng.NewInteractiveSession(InteractiveSessionOptions{
 		ProviderID: "mock", TaskType: "basic", Variables: map[string]string{"company": "Acme"},
@@ -231,42 +240,8 @@ func TestInteractiveSession_EmittedEventsCarryExecutionID(t *testing.T) {
 	for range ch { //nolint:revive
 	}
 
-	got.waitFor(1, 2*time.Second)
-	evs := got.snapshot()
-	if len(evs) == 0 {
-		t.Fatal("no message.created events emitted")
-	}
-
+	// Give the bus time to deliver async events.
 	wantID := sess.ConversationID()
-	// Collect events via the raw bus to check ExecutionID (the emitter sets
-	// ExecutionID = RunID, ConversationID = ConversationID in every event).
-	var execIDCollector struct {
-		mu  sync.Mutex
-		ids []string
-	}
-	bus2 := events.NewEventBus()
-	eng2 := newFixtureEngine(t)
-	_ = eng2.EnableMockProviderMode("")
-	eng2.SetEventBus(bus2, WithMessageEvents())
-	bus2.Subscribe(events.EventMessageCreated, func(ev *events.Event) {
-		execIDCollector.mu.Lock()
-		defer execIDCollector.mu.Unlock()
-		execIDCollector.ids = append(execIDCollector.ids, ev.ExecutionID)
-	})
-	sess2, err := eng2.NewInteractiveSession(InteractiveSessionOptions{
-		ProviderID: "mock", TaskType: "basic", Variables: map[string]string{"company": "Acme"},
-	})
-	if err != nil {
-		t.Fatalf("session2: %v", err)
-	}
-	ch2, err := sess2.SendUserMessage(context.Background(), "world")
-	if err != nil {
-		t.Fatalf("send2: %v", err)
-	}
-	for range ch2 { //nolint:revive
-	}
-
-	// Give bus2 time to deliver async events.
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		execIDCollector.mu.Lock()
@@ -283,14 +258,11 @@ func TestInteractiveSession_EmittedEventsCarryExecutionID(t *testing.T) {
 	execIDCollector.mu.Unlock()
 
 	if len(ids) == 0 {
-		t.Fatal("bus2 received no message.created events")
+		t.Fatal("no message.created events emitted")
 	}
-	wantID2 := sess2.ConversationID()
 	for _, id := range ids {
-		if id != wantID2 {
-			t.Fatalf("event ExecutionID = %q, want conversationID %q", id, wantID2)
+		if id != wantID {
+			t.Fatalf("event ExecutionID = %q, want conversationID %q", id, wantID)
 		}
 	}
-	// wantID only used to show intent for sess (suppress unused warning).
-	_ = wantID
 }

--- a/tools/arena/engine/interactive_events_test.go
+++ b/tools/arena/engine/interactive_events_test.go
@@ -130,9 +130,12 @@ func TestInteractiveSession_EmitsLiveMessagesLikeARun(t *testing.T) {
 	got.waitFor(len(msgs), 2*time.Second)
 	events := got.snapshot()
 
-	// Every persisted non-system message must have been emitted exactly once,
-	// with an index matching its transcript position. No message emitted more
-	// than once (no re-fire of prior turns).
+	// EVERY persisted message — system included — must have been emitted exactly
+	// once at its store index. Asserting system explicitly guards the index
+	// derivation in the save stage (Finding 1): the system message lives at
+	// transcript index 0 and the live offset must keep every later message
+	// aligned with the persisted transcript. No message emitted more than once
+	// (no re-fire of prior turns).
 	type key struct {
 		role    string
 		content string
@@ -143,18 +146,33 @@ func TestInteractiveSession_EmitsLiveMessagesLikeARun(t *testing.T) {
 		seen[key{e.Role, e.Content, e.Index}]++
 	}
 	for i := range msgs {
-		if msgs[i].Role == "system" {
-			continue
-		}
 		k := key{msgs[i].Role, msgs[i].GetContent(), i}
 		if seen[k] != 1 {
 			t.Fatalf("message #%d (%s) emitted %d times, want exactly 1; events=%+v",
 				i, msgs[i].Role, seen[k], events)
 		}
 	}
+
+	// Exactly one system event, and it must sit at index 0. This is the direct
+	// regression guard for the index arithmetic: a stale prevLen-based offset
+	// would either drop the system event or fire it at the wrong index.
+	systemCount := 0
+	for _, e := range events {
+		if e.Role != "system" {
+			continue
+		}
+		systemCount++
+		if e.Index != 0 {
+			t.Fatalf("system event at index %d, want 0; events=%+v", e.Index, events)
+		}
+	}
+	if systemCount != 1 {
+		t.Fatalf("got %d system events, want exactly 1; events=%+v", systemCount, events)
+	}
+
 	// And no event carries an index outside the transcript (no stale/duplicate indices).
 	for _, e := range events {
-		if e.Role != "system" && (e.Index < 0 || e.Index >= len(msgs)) {
+		if e.Index < 0 || e.Index >= len(msgs) {
 			t.Fatalf("event index %d out of range [0,%d): %+v", e.Index, len(msgs), e)
 		}
 	}

--- a/tools/arena/engine/interactive_events_test.go
+++ b/tools/arena/engine/interactive_events_test.go
@@ -200,3 +200,97 @@ func TestInteractiveSession_NoBusNoEmission(t *testing.T) {
 		t.Fatal("expected persisted messages")
 	}
 }
+
+// TestInteractiveSession_EmittedEventsCarryExecutionID verifies that
+// message.created SSE events emitted during SendUserMessage have
+// ExecutionID == conversationID. Without RunID set on the TurnRequest
+// the emitter uses an empty executionId, so the web frontend can't key
+// messages to the right run entry via event.executionId.
+func TestInteractiveSession_EmittedEventsCarryExecutionID(t *testing.T) {
+	eng := newFixtureEngine(t)
+	if err := eng.EnableMockProviderMode(""); err != nil {
+		t.Fatalf("mock: %v", err)
+	}
+	bus := events.NewEventBus()
+	eng.SetEventBus(bus, WithMessageEvents())
+
+	got := collectMessageEvents(bus)
+
+	sess, err := eng.NewInteractiveSession(InteractiveSessionOptions{
+		ProviderID: "mock", TaskType: "basic", Variables: map[string]string{"company": "Acme"},
+	})
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+
+	// Drain one turn.
+	ch, err := sess.SendUserMessage(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	for range ch { //nolint:revive
+	}
+
+	got.waitFor(1, 2*time.Second)
+	evs := got.snapshot()
+	if len(evs) == 0 {
+		t.Fatal("no message.created events emitted")
+	}
+
+	wantID := sess.ConversationID()
+	// Collect events via the raw bus to check ExecutionID (the emitter sets
+	// ExecutionID = RunID, ConversationID = ConversationID in every event).
+	var execIDCollector struct {
+		mu  sync.Mutex
+		ids []string
+	}
+	bus2 := events.NewEventBus()
+	eng2 := newFixtureEngine(t)
+	_ = eng2.EnableMockProviderMode("")
+	eng2.SetEventBus(bus2, WithMessageEvents())
+	bus2.Subscribe(events.EventMessageCreated, func(ev *events.Event) {
+		execIDCollector.mu.Lock()
+		defer execIDCollector.mu.Unlock()
+		execIDCollector.ids = append(execIDCollector.ids, ev.ExecutionID)
+	})
+	sess2, err := eng2.NewInteractiveSession(InteractiveSessionOptions{
+		ProviderID: "mock", TaskType: "basic", Variables: map[string]string{"company": "Acme"},
+	})
+	if err != nil {
+		t.Fatalf("session2: %v", err)
+	}
+	ch2, err := sess2.SendUserMessage(context.Background(), "world")
+	if err != nil {
+		t.Fatalf("send2: %v", err)
+	}
+	for range ch2 { //nolint:revive
+	}
+
+	// Give bus2 time to deliver async events.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		execIDCollector.mu.Lock()
+		n := len(execIDCollector.ids)
+		execIDCollector.mu.Unlock()
+		if n > 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	execIDCollector.mu.Lock()
+	ids := execIDCollector.ids
+	execIDCollector.mu.Unlock()
+
+	if len(ids) == 0 {
+		t.Fatal("bus2 received no message.created events")
+	}
+	wantID2 := sess2.ConversationID()
+	for _, id := range ids {
+		if id != wantID2 {
+			t.Fatalf("event ExecutionID = %q, want conversationID %q", id, wantID2)
+		}
+	}
+	// wantID only used to show intent for sess (suppress unused warning).
+	_ = wantID
+}

--- a/tools/arena/engine/interactive_events_test.go
+++ b/tools/arena/engine/interactive_events_test.go
@@ -1,10 +1,14 @@
 package engine
 
 import (
+	"context"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/tools/arena/artifacts"
 	arenaaudio "github.com/AltairaLabs/PromptKit/tools/arena/audio"
 )
@@ -34,5 +38,147 @@ func TestEngine_SimpleAccessors(t *testing.T) {
 	opts := eng.AudioMonitorOptions()
 	if opts != (arenaaudio.Options{}) {
 		t.Errorf("AudioMonitorOptions should be zero before EnableAudioMonitor, got %v", opts)
+	}
+}
+
+// messageEventCollector subscribes to message.created events on the (async)
+// event bus and accumulates their payloads under a mutex. The bus delivers on
+// worker goroutines, so callers must waitFor the expected count before reading
+// snapshot — reading the slice directly would race delivery.
+type messageEventCollector struct {
+	mu  sync.Mutex
+	evs []events.MessageCreatedData
+}
+
+func collectMessageEvents(bus events.Bus) *messageEventCollector {
+	c := &messageEventCollector{}
+	bus.Subscribe(events.EventMessageCreated, func(ev *events.Event) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		switch d := ev.Data.(type) {
+		case *events.MessageCreatedData:
+			if d != nil {
+				c.evs = append(c.evs, *d)
+			}
+		case events.MessageCreatedData:
+			c.evs = append(c.evs, d)
+		}
+	})
+	return c
+}
+
+func (c *messageEventCollector) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.evs)
+}
+
+// snapshot returns a copy of the events collected so far, taken under lock.
+func (c *messageEventCollector) snapshot() []events.MessageCreatedData {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]events.MessageCreatedData, len(c.evs))
+	copy(out, c.evs)
+	return out
+}
+
+// waitFor blocks until at least n events have been delivered or the timeout
+// elapses, accommodating the bus's asynchronous worker delivery.
+func (c *messageEventCollector) waitFor(n int, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for c.len() < n && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestInteractiveSession_EmitsLiveMessagesLikeARun(t *testing.T) {
+	eng := newFixtureEngine(t)
+	if err := eng.EnableMockProviderMode(""); err != nil {
+		t.Fatalf("mock: %v", err)
+	}
+	bus := events.NewEventBus()
+	eng.SetEventBus(bus, WithMessageEvents())
+	got := collectMessageEvents(bus)
+
+	sess, err := eng.NewInteractiveSession(InteractiveSessionOptions{
+		ProviderID: "mock", TaskType: "basic", Variables: map[string]string{"company": "Acme"},
+	})
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	ctx := context.Background()
+
+	drain := func(text string) {
+		ch, err := sess.SendUserMessage(ctx, text)
+		if err != nil {
+			t.Fatalf("send %q: %v", text, err)
+		}
+		for range ch { //nolint:revive
+		}
+	}
+	drain("ONE")
+	drain("TWO")
+
+	// Authoritative transcript from the store.
+	msgs, err := sess.Messages(ctx)
+	if err != nil {
+		t.Fatalf("messages: %v", err)
+	}
+
+	// The bus delivers asynchronously on worker goroutines; wait until every
+	// persisted message has had its event delivered before asserting.
+	got.waitFor(len(msgs), 2*time.Second)
+	events := got.snapshot()
+
+	// Every persisted non-system message must have been emitted exactly once,
+	// with an index matching its transcript position. No message emitted more
+	// than once (no re-fire of prior turns).
+	type key struct {
+		role    string
+		content string
+		index   int
+	}
+	seen := map[key]int{}
+	for _, e := range events {
+		seen[key{e.Role, e.Content, e.Index}]++
+	}
+	for i := range msgs {
+		if msgs[i].Role == "system" {
+			continue
+		}
+		k := key{msgs[i].Role, msgs[i].GetContent(), i}
+		if seen[k] != 1 {
+			t.Fatalf("message #%d (%s) emitted %d times, want exactly 1; events=%+v",
+				i, msgs[i].Role, seen[k], events)
+		}
+	}
+	// And no event carries an index outside the transcript (no stale/duplicate indices).
+	for _, e := range events {
+		if e.Role != "system" && (e.Index < 0 || e.Index >= len(msgs)) {
+			t.Fatalf("event index %d out of range [0,%d): %+v", e.Index, len(msgs), e)
+		}
+	}
+}
+
+func TestInteractiveSession_NoBusNoEmission(t *testing.T) {
+	eng := newFixtureEngine(t)
+	_ = eng.EnableMockProviderMode("")
+	// No SetEventBus → engine.eventBus nil → no emitter → no panic, no events.
+	sess, err := eng.NewInteractiveSession(InteractiveSessionOptions{
+		ProviderID: "mock", TaskType: "basic", Variables: map[string]string{"company": "Acme"},
+	})
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	ch, err := sess.SendUserMessage(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	for range ch { //nolint:revive
+	}
+	// Reaching here without panic + a persisted transcript is the assertion.
+	msgs, _ := sess.Messages(context.Background())
+	if len(msgs) == 0 {
+		t.Fatal("expected persisted messages")
 	}
 }

--- a/tools/arena/stages/scenario_context_extraction.go
+++ b/tools/arena/stages/scenario_context_extraction.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	roleUser = "user"
+	roleUser   = "user"
+	roleSystem = "system"
 	// maxContextTruncationLength is the maximum length of context before truncation
 	maxContextTruncationLength = 150
 )

--- a/tools/arena/stages/stages_test.go
+++ b/tools/arena/stages/stages_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	runtimeStatestore "github.com/AltairaLabs/PromptKit/runtime/statestore"
@@ -687,6 +688,122 @@ func TestArenaStateStoreSaveStage_WithSystemPrompt(t *testing.T) {
 	assert.Len(t, state.Messages, 2) // system + user
 	assert.Equal(t, "system", state.Messages[0].Role)
 	assert.Equal(t, "You are a helpful assistant", state.Messages[0].Content)
+}
+
+// syncBus is a deterministic, synchronous events.Bus for stage tests: listeners
+// fire inside Publish on the caller's goroutine, so assertions need no waiting.
+type syncBus struct {
+	created []events.MessageCreatedData
+}
+
+func (b *syncBus) Publish(ev *events.Event) bool {
+	if ev.Type != events.EventMessageCreated {
+		return true
+	}
+	switch d := ev.Data.(type) {
+	case *events.MessageCreatedData:
+		if d != nil {
+			b.created = append(b.created, *d)
+		}
+	case events.MessageCreatedData:
+		b.created = append(b.created, d)
+	}
+	return true
+}
+
+func (b *syncBus) Subscribe(events.EventType, events.Listener) func() { return func() {} }
+func (b *syncBus) SubscribeAll(events.Listener) func()                { return func() {} }
+func (b *syncBus) Close()                                             {}
+
+// emittedSystemIndices returns the indices of every emitted system event.
+func emittedSystemIndices(evs []events.MessageCreatedData) []int {
+	var out []int
+	for _, e := range evs {
+		if e.Role == "system" {
+			out = append(out, e.Index)
+		}
+	}
+	return out
+}
+
+// assertLiveIndicesMatchTranscript checks that every emitted message.created
+// event lands at the index of an identical (role+content) message in the
+// persisted transcript — i.e. the live index equals the store index — and that
+// the system message is emitted exactly once, at index 0.
+func assertLiveIndicesMatchTranscript(t *testing.T, evs []events.MessageCreatedData, msgs []types.Message) {
+	t.Helper()
+	if sys := emittedSystemIndices(evs); len(sys) != 1 || sys[0] != 0 {
+		t.Fatalf("system events at indices %v, want exactly [0]; events=%+v", sys, evs)
+	}
+	for _, e := range evs {
+		if e.Index < 0 || e.Index >= len(msgs) {
+			t.Fatalf("event index %d out of range [0,%d): %+v", e.Index, len(msgs), e)
+		}
+		if msgs[e.Index].Role != e.Role || msgs[e.Index].Content != e.Content {
+			t.Fatalf("event %+v does not match transcript[%d]=%+v", e, e.Index, msgs[e.Index])
+		}
+	}
+}
+
+// TestArenaStateStoreSaveStage_LiveIndexSystemInTurn1Stream is the regression
+// guard for the index-derivation fix (Finding 1): a provider that forwards a
+// system-role element on turn 1 must still produce live indices that line up
+// with the persisted transcript. The old prevLen-inferred offset shifted the
+// user message to index 2 (colliding with the assistant); the stream-derived
+// offset keeps system@0, user@1, assistant@2.
+func TestArenaStateStoreSaveStage_LiveIndexSystemInTurn1Stream(t *testing.T) {
+	store := statestore.NewArenaStateStore()
+	cfg := &pipeline.StateStoreConfig{Store: store, ConversationID: "live-sys-in-stream"}
+
+	turnState := stage.NewTurnState()
+	turnState.SystemPrompt = "You are helpful"
+	s := NewArenaStateStoreSaveStageWithTurnState(cfg, turnState)
+
+	bus := &syncBus{}
+	s = s.WithEmitter(events.NewEmitter(bus, "exec", "sess", "live-sys-in-stream"))
+
+	// Provider forwards a system element first, then user + assistant.
+	inputs := []stage.StreamElement{
+		newTestMessageElement("system", "You are helpful"),
+		newTestMessageElement("user", "Hello"),
+		newTestMessageElement("assistant", "Hi there!"),
+	}
+	runStage(t, s, inputs)
+
+	state, err := store.Load(context.Background(), "live-sys-in-stream")
+	require.NoError(t, err)
+	require.Len(t, state.Messages, 3) // system + user + assistant (no double system)
+	assert.Equal(t, "system", state.Messages[0].Role)
+
+	assertLiveIndicesMatchTranscript(t, bus.created, state.Messages)
+}
+
+// TestArenaStateStoreSaveStage_LiveIndexSyntheticSystemTurn1 covers the common
+// path: no system element in the turn-1 stream, so persistState prepends a
+// synthetic system message and the live offset shifts new messages by one.
+func TestArenaStateStoreSaveStage_LiveIndexSyntheticSystemTurn1(t *testing.T) {
+	store := statestore.NewArenaStateStore()
+	cfg := &pipeline.StateStoreConfig{Store: store, ConversationID: "live-synthetic-sys"}
+
+	turnState := stage.NewTurnState()
+	turnState.SystemPrompt = "You are helpful"
+	s := NewArenaStateStoreSaveStageWithTurnState(cfg, turnState)
+
+	bus := &syncBus{}
+	s = s.WithEmitter(events.NewEmitter(bus, "exec", "sess", "live-synthetic-sys"))
+
+	inputs := []stage.StreamElement{
+		newTestMessageElement("user", "Hello"),
+		newTestMessageElement("assistant", "Hi there!"),
+	}
+	runStage(t, s, inputs)
+
+	state, err := store.Load(context.Background(), "live-synthetic-sys")
+	require.NoError(t, err)
+	require.Len(t, state.Messages, 3) // synthetic system + user + assistant
+	assert.Equal(t, "system", state.Messages[0].Role)
+
+	assertLiveIndicesMatchTranscript(t, bus.created, state.Messages)
 }
 
 func TestArenaStateStoreSaveStage_WithCostInfo(t *testing.T) {

--- a/tools/arena/stages/stages_test.go
+++ b/tools/arena/stages/stages_test.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -1368,4 +1369,49 @@ func TestArenaStateStoreSaveStage_TranscriptionByTurnID(t *testing.T) {
 		"User 2 should have transcript 2 (matched by turn_id)")
 	assert.Equal(t, user2Original, state.Messages[1].Meta["original_text"],
 		"User 2 should preserve original text")
+}
+
+// TestArenaStateStoreSaveStage_LiveIndexToolCallRound verifies that a turn
+// containing a tool-call round (user -> assistant+tool_calls -> tool-result ->
+// assistant-final) produces correct transcript-absolute live broadcast indices.
+// The persisted transcript is: system(0) user(1) assistant+tc(2) tool(3) final(4).
+func TestArenaStateStoreSaveStage_LiveIndexToolCallRound(t *testing.T) {
+	store := statestore.NewArenaStateStore()
+	cfg := &pipeline.StateStoreConfig{Store: store, ConversationID: "live-tool-round"}
+
+	turnState := stage.NewTurnState()
+	turnState.SystemPrompt = "You are helpful"
+	s := NewArenaStateStoreSaveStageWithTurnState(cfg, turnState)
+
+	bus := &syncBus{}
+	s = s.WithEmitter(events.NewEmitter(bus, "exec", "sess", "live-tool-round"))
+
+	// user turn
+	userElem := stage.NewMessageElement(&types.Message{Role: "user", Content: "run the tool"})
+
+	// assistant with tool call — Content intentionally empty (tool-call turn)
+	actWithTC := &types.Message{Role: "assistant", Content: ""}
+	actWithTC.ToolCalls = []types.MessageToolCall{
+		{ID: "call-1", Name: "my_tool", Args: json.RawMessage(`{"x":1}`)},
+	}
+	actWithTCElem := stage.NewMessageElement(actWithTC)
+
+	// tool result
+	toolRes := types.NewTextToolResult("call-1", "my_tool", "done")
+	toolResMsg := &types.Message{Role: "tool", Content: ""}
+	toolResMsg.ToolResult = &toolRes
+	toolResElem := stage.NewMessageElement(toolResMsg)
+
+	// assistant final
+	finalElem := stage.NewMessageElement(&types.Message{Role: "assistant", Content: "All done."})
+
+	runStage(t, s, []stage.StreamElement{userElem, actWithTCElem, toolResElem, finalElem})
+
+	ctx := context.Background()
+	state, err := store.Load(ctx, "live-tool-round")
+	require.NoError(t, err)
+	// system(synthetic) + user + assistant+tc + tool-result + assistant-final
+	require.Len(t, state.Messages, 5)
+
+	assertLiveIndicesMatchTranscript(t, bus.created, state.Messages)
 }

--- a/tools/arena/stages/statestore_save_integration.go
+++ b/tools/arena/stages/statestore_save_integration.go
@@ -27,6 +27,13 @@ type ArenaStateStoreSaveStage struct {
 	config    *pipeline.StateStoreConfig
 	turnState *stage.TurnState
 	emitter   *events.Emitter
+	// baseTranscriptLen is the persisted transcript length captured at build
+	// time (in WithEmitter, before the pipeline runs). Live broadcasts use it
+	// as the transcript-absolute base for this turn's new messages. Capturing
+	// at build time is race-free: the runtime ProviderStage write-through that
+	// appends this turn's messages only runs once the pipeline executes, so a
+	// read inside Process would race it and miscount.
+	baseTranscriptLen int
 }
 
 // NewArenaStateStoreSaveStage creates a new Arena state store save stage.
@@ -55,7 +62,29 @@ func NewArenaStateStoreSaveStageWithTurnState(
 // for replay and post-run results.
 func (s *ArenaStateStoreSaveStage) WithEmitter(emitter *events.Emitter) *ArenaStateStoreSaveStage {
 	s.emitter = emitter
+	s.baseTranscriptLen = s.captureBaseTranscriptLen()
 	return s
+}
+
+// captureBaseTranscriptLen reads the already-persisted transcript length for
+// this conversation. Called synchronously from WithEmitter at pipeline-build
+// time — before Execute — so it sees only prior turns, never this turn's own
+// write-through. Returns 0 when no store is wired or the load fails (a fresh
+// conversation reads as 0). Used as the transcript-absolute base for live
+// message broadcasts; the persisted state stays the source of truth.
+func (s *ArenaStateStoreSaveStage) captureBaseTranscriptLen() int {
+	if s.config == nil || s.config.Store == nil {
+		return 0
+	}
+	store, ok := s.config.Store.(arenaSaveStore)
+	if !ok {
+		return 0
+	}
+	state, err := store.Load(context.Background(), s.config.ConversationID)
+	if err != nil || state == nil {
+		return 0
+	}
+	return len(state.Messages)
 }
 
 // collectedData holds all data collected from stream elements.
@@ -248,15 +277,33 @@ func (s *ArenaStateStoreSaveStage) Process(
 	var cachedState *runtimeStatestore.ConversationState
 	ctxCanceled := false
 
-	// Broadcast the system prompt up-front so the live UI shows it as
-	// the first turn instead of waiting for the saved-result refresh.
-	// The persisted state already prepends a system message via
-	// persistState; this just mirrors that into the SSE stream.
-	cachedState = s.broadcastSystemPromptIfNeeded(ctx, arenaStore, cachedState)
+	// prevLen is the pre-turn transcript length captured at build time (see
+	// captureBaseTranscriptLen) — the count of messages the element stream
+	// replays before this turn's new ones. Elements at a stream position below
+	// it are history re-plays and must NOT be re-emitted (no re-fire of prior
+	// turns). Reading it here from the store would race the ProviderStage
+	// write-through that appends this turn's messages mid-stream.
+	prevLen := s.baseTranscriptLen
+
+	// The system prompt / offset are resolved lazily on the first element:
+	// the rendered system prompt is set by the upstream TemplateStage, which
+	// runs concurrently with this sink — at Process start it may not be ready.
+	// systemOffset accounts for a system message persistState will prepend
+	// that the element stream does not replay (first turn only).
+	var systemOffset int
+	broadcastReady := s.emitter == nil
 
 	for elem := range input {
+		if !broadcastReady {
+			s.broadcastSystemPromptIfNeeded(prevLen)
+			systemOffset = s.systemBroadcastOffset(prevLen)
+			broadcastReady = true
+		}
 		data.collectFromElement(&elem)
-		s.broadcastMessage(&elem, len(data.messages)-1)
+		pos := len(data.messages) - 1
+		if elem.Message != nil && pos >= prevLen {
+			s.broadcastMessage(&elem, pos+systemOffset)
+		}
 		cachedState = s.maybeIncrementalSave(ctx, arenaStore, &elem, data, cachedState, ctxCanceled)
 
 		// Try to forward element, but if context is canceled, just drain remaining input
@@ -290,21 +337,33 @@ func (s *ArenaStateStoreSaveStage) Process(
 	return nil
 }
 
-// broadcastSystemPromptIfNeeded emits a synthetic system MessageCreated
-// event when the conversation has no prior messages and the rendered
-// system prompt is available on TurnState (or fallback config metadata).
-// Without this the live UI never sees the system turn until the run
+// broadcastSystemPromptIfNeeded emits a synthetic system MessageCreated event
+// once, on the first turn of a conversation, when a rendered system prompt is
+// available. Without this the live UI never sees the system turn until the run
 // completes and the saved result is refetched — confusing during a demo.
 //
-// The conversation state is loaded eagerly here so we can detect "first
-// turn" by checking len(state.Messages) == 0. The cached state is
-// returned so subsequent maybeIncrementalSave calls can reuse it.
-func (s *ArenaStateStoreSaveStage) broadcastSystemPromptIfNeeded(
-	ctx context.Context, arenaStore arenaSaveStore, cached *runtimeStatestore.ConversationState,
-) *runtimeStatestore.ConversationState {
-	if s.emitter == nil {
-		return cached
+// "First turn" is detected from prevLen (the pre-turn transcript length
+// captured race-free at build time): prevLen == 0 means no prior messages,
+// hence no system message has been emitted yet. Re-loading the store here to
+// count messages would race the ProviderStage write-through and intermittently
+// suppress or double-fire the system turn. Called on the first element so the
+// rendered system prompt (set by the concurrent TemplateStage) is ready.
+func (s *ArenaStateStoreSaveStage) broadcastSystemPromptIfNeeded(prevLen int) {
+	if s.emitter == nil || prevLen > 0 {
+		return
 	}
+	sp := s.resolveSystemPrompt()
+	if sp == "" {
+		return
+	}
+	s.emitter.MessageCreated(roleSystem, sp, 0, nil, nil, nil)
+}
+
+// resolveSystemPrompt returns the rendered system prompt for this turn,
+// sourced from TurnState (set by TemplateStage) with a fallback to config
+// metadata for tests that wire the prompt through config. Mirrors the
+// resolution in persistState so broadcasts and persistence agree.
+func (s *ArenaStateStoreSaveStage) resolveSystemPrompt() string {
 	sp := ""
 	if s.turnState != nil {
 		sp = s.turnState.SystemPrompt
@@ -314,28 +373,33 @@ func (s *ArenaStateStoreSaveStage) broadcastSystemPromptIfNeeded(
 			sp = v
 		}
 	}
-	if sp == "" {
-		return cached
+	return sp
+}
+
+// systemBroadcastOffset returns 1 when a system message will be prepended on
+// persist but is absent from both the pre-turn transcript and the replayed
+// element stream (the first turn of a conversation); otherwise 0. Adding it
+// keeps live indices aligned with the persisted transcript where index 0 is
+// the system prompt. prevLen is the pre-turn transcript length: when it is 0
+// the conversation has no persisted (hence no system) messages yet.
+func (s *ArenaStateStoreSaveStage) systemBroadcastOffset(prevLen int) int {
+	if s.emitter == nil {
+		return 0
 	}
-	loaded, err := s.ensureLoaded(ctx, arenaStore, cached)
-	if err != nil {
-		return cached
+	if prevLen == 0 && s.resolveSystemPrompt() != "" {
+		return 1
 	}
-	// Already have messages on this conversation — system prompt was
-	// emitted on a prior turn, don't double-broadcast.
-	if len(loaded.Messages) > 0 {
-		return loaded
-	}
-	s.emitter.MessageCreated("system", sp, 0, nil, nil, nil)
-	return loaded
+	return 0
 }
 
 // broadcastMessage publishes the just-arrived message to the event bus when
-// an emitter is configured. Skipped when the element carries no Message or
-// when the index is out of range. Live UI consumers (TUI, web SSE) subscribe
-// to the bus and update their views in real time.
+// an emitter is configured. Skipped when the element carries no Message, when
+// the index is out of range, or when the message is the system prompt (system
+// is broadcast once by broadcastSystemPromptIfNeeded). idx is the message's
+// transcript-absolute position. Live UI consumers (TUI, web SSE) subscribe to
+// the bus and update their views in real time.
 func (s *ArenaStateStoreSaveStage) broadcastMessage(elem *stage.StreamElement, idx int) {
-	if s.emitter == nil || elem.Message == nil || idx < 0 {
+	if s.emitter == nil || elem.Message == nil || idx < 0 || elem.Message.Role == roleSystem {
 		return
 	}
 	s.emitter.MessageCreated(
@@ -596,7 +660,7 @@ func mergeMetadata(a, b map[string]interface{}) map[string]interface{} {
 func createSystemMessage(systemPrompt string, timestamp time.Time) types.Message {
 	textContent := systemPrompt
 	return types.Message{
-		Role:    "system",
+		Role:    roleSystem,
 		Content: systemPrompt,
 		Parts: []types.ContentPart{
 			{
@@ -611,7 +675,7 @@ func createSystemMessage(systemPrompt string, timestamp time.Time) types.Message
 // prependSystemMessage prepends a system message if not already present.
 func prependSystemMessage(messages []types.Message, systemPrompt string) []types.Message {
 	// Check if first message is already a system message
-	if len(messages) > 0 && messages[0].Role == "system" {
+	if len(messages) > 0 && messages[0].Role == roleSystem {
 		// Already has system message, return as-is
 		result := make([]types.Message, len(messages))
 		copy(result, messages)

--- a/tools/arena/stages/statestore_save_integration.go
+++ b/tools/arena/stages/statestore_save_integration.go
@@ -283,6 +283,11 @@ func (s *ArenaStateStoreSaveStage) Process(
 	// it are history re-plays and must NOT be re-emitted (no re-fire of prior
 	// turns). Reading it here from the store would race the ProviderStage
 	// write-through that appends this turn's messages mid-stream.
+	//
+	// COUPLING: prevLen is correct only because StateStoreLoadStage.emitHistoryMessages
+	// (runtime/pipeline/stage/stages_core.go) replays the full persisted transcript as
+	// stream elements before the new user message. If that replay is ever made lazy or
+	// optional, the live broadcast indices will silently miscount prior turns.
 	prevLen := s.baseTranscriptLen
 
 	// liveBroadcaster derives each message's transcript-absolute index from the

--- a/tools/arena/stages/statestore_save_integration.go
+++ b/tools/arena/stages/statestore_save_integration.go
@@ -285,24 +285,20 @@ func (s *ArenaStateStoreSaveStage) Process(
 	// write-through that appends this turn's messages mid-stream.
 	prevLen := s.baseTranscriptLen
 
-	// The system prompt / offset are resolved lazily on the first element:
-	// the rendered system prompt is set by the upstream TemplateStage, which
-	// runs concurrently with this sink — at Process start it may not be ready.
-	// systemOffset accounts for a system message persistState will prepend
-	// that the element stream does not replay (first turn only).
-	var systemOffset int
-	broadcastReady := s.emitter == nil
+	// liveBroadcaster derives each message's transcript-absolute index from the
+	// stream content itself (whether or not a system element appears), so the
+	// emitted index always matches the persisted transcript regardless of which
+	// provider supplies the elements. Created only when an emitter is wired.
+	var caster *liveBroadcaster
+	if s.emitter != nil {
+		caster = s.newLiveBroadcaster(prevLen)
+	}
 
 	for elem := range input {
-		if !broadcastReady {
-			s.broadcastSystemPromptIfNeeded(prevLen)
-			systemOffset = s.systemBroadcastOffset(prevLen)
-			broadcastReady = true
-		}
 		data.collectFromElement(&elem)
 		pos := len(data.messages) - 1
-		if elem.Message != nil && pos >= prevLen {
-			s.broadcastMessage(&elem, pos+systemOffset)
+		if caster != nil && elem.Message != nil {
+			caster.observe(&elem, pos)
 		}
 		cachedState = s.maybeIncrementalSave(ctx, arenaStore, &elem, data, cachedState, ctxCanceled)
 
@@ -337,26 +333,89 @@ func (s *ArenaStateStoreSaveStage) Process(
 	return nil
 }
 
-// broadcastSystemPromptIfNeeded emits a synthetic system MessageCreated event
-// once, on the first turn of a conversation, when a rendered system prompt is
-// available. Without this the live UI never sees the system turn until the run
-// completes and the saved result is refetched — confusing during a demo.
-//
-// "First turn" is detected from prevLen (the pre-turn transcript length
-// captured race-free at build time): prevLen == 0 means no prior messages,
-// hence no system message has been emitted yet. Re-loading the store here to
-// count messages would race the ProviderStage write-through and intermittently
-// suppress or double-fire the system turn. Called on the first element so the
-// rendered system prompt (set by the concurrent TemplateStage) is ready.
-func (s *ArenaStateStoreSaveStage) broadcastSystemPromptIfNeeded(prevLen int) {
-	if s.emitter == nil || prevLen > 0 {
+// liveBroadcaster derives the transcript-absolute index of each streamed
+// message from the stream's own content, then publishes it to the event bus.
+// It exists so the live index matches the persisted transcript (persistState
+// is the source of truth) for ANY provider — including one that forwards a
+// system-role element on turn 1 — rather than inferring the system position
+// from prevLen. Invariants it upholds:
+//   - the system message is emitted exactly once per conversation, at index 0;
+//   - messages from prior turns (stream position < prevLen) are never re-emitted;
+//   - a non-system message at collected position pos is emitted at pos+offset,
+//     where offset is 1 iff persistState will prepend a synthetic system message
+//     (a system prompt exists and no system element leads the stream), else 0 —
+//     identical to the offset persistState itself applies.
+type liveBroadcaster struct {
+	stage         *ArenaStateStoreSaveStage
+	prevLen       int    // history replayed before this turn's new messages
+	systemPrompt  string // rendered system prompt, "" when none
+	offset        int    // +1 when persistState prepends a synthetic system msg
+	resolved      bool   // offset/system decision made on first observed message
+	systemEmitted bool   // system broadcast guard (exactly once per conversation)
+}
+
+// newLiveBroadcaster builds a broadcaster for one Process invocation. prevLen is
+// the race-free pre-turn transcript length captured at build time. The offset is
+// resolved lazily on the first observed message because the rendered system
+// prompt (set by the concurrent TemplateStage) may not be ready at Process start.
+func (s *ArenaStateStoreSaveStage) newLiveBroadcaster(prevLen int) *liveBroadcaster {
+	return &liveBroadcaster{stage: s, prevLen: prevLen}
+}
+
+// observe handles one streamed message at collected position pos. It resolves
+// the system offset once (from whether the stream itself leads with a system
+// element), emits the system message exactly once at index 0, and emits each
+// new non-system message at its derived transcript-absolute index.
+func (b *liveBroadcaster) observe(elem *stage.StreamElement, pos int) {
+	if !b.resolved {
+		b.resolve(elem, pos)
+	}
+
+	isSystem := elem.Message.Role == roleSystem
+	isNew := pos >= b.prevLen
+
+	// The system message is broadcast once at index 0. A system element only
+	// appears in the stream as replayed history (it is persisted on turn 1 and
+	// replayed thereafter) or when a provider forwards it on turn 1; in the
+	// former case it predates this turn and must not re-fire. The synthetic
+	// branch (no system element in the stream) is handled in resolve().
+	if isSystem {
+		if isNew {
+			b.emitSystem(elem.Message.Content)
+		}
 		return
 	}
-	sp := s.resolveSystemPrompt()
-	if sp == "" {
+
+	if isNew {
+		b.stage.broadcastMessage(elem, pos+b.offset)
+	}
+}
+
+// resolve fixes the system offset and, when no system element leads the stream,
+// emits the synthetic system prompt at index 0. Called once, on the first
+// observed message, so persistState's prepend decision and the live offset agree:
+// persistState prepends a system message iff a system prompt exists and the
+// first message is not already a system message.
+func (b *liveBroadcaster) resolve(elem *stage.StreamElement, pos int) {
+	b.resolved = true
+	b.systemPrompt = b.stage.resolveSystemPrompt()
+
+	leadsWithSystem := pos == 0 && elem.Message.Role == roleSystem
+	if b.systemPrompt != "" && !leadsWithSystem {
+		// persistState will prepend a synthetic system message at index 0; the
+		// stream never carries it, so shift new messages by one and emit it now.
+		b.offset = 1
+		b.emitSystem(b.systemPrompt)
+	}
+}
+
+// emitSystem publishes the system message at index 0 exactly once.
+func (b *liveBroadcaster) emitSystem(content string) {
+	if b.systemEmitted || content == "" {
 		return
 	}
-	s.emitter.MessageCreated(roleSystem, sp, 0, nil, nil, nil)
+	b.systemEmitted = true
+	b.stage.emitter.MessageCreated(roleSystem, content, 0, nil, nil, nil)
 }
 
 // resolveSystemPrompt returns the rendered system prompt for this turn,
@@ -374,22 +433,6 @@ func (s *ArenaStateStoreSaveStage) resolveSystemPrompt() string {
 		}
 	}
 	return sp
-}
-
-// systemBroadcastOffset returns 1 when a system message will be prepended on
-// persist but is absent from both the pre-turn transcript and the replayed
-// element stream (the first turn of a conversation); otherwise 0. Adding it
-// keeps live indices aligned with the persisted transcript where index 0 is
-// the system prompt. prevLen is the pre-turn transcript length: when it is 0
-// the conversation has no persisted (hence no system) messages yet.
-func (s *ArenaStateStoreSaveStage) systemBroadcastOffset(prevLen int) int {
-	if s.emitter == nil {
-		return 0
-	}
-	if prevLen == 0 && s.resolveSystemPrompt() != "" {
-		return 1
-	}
-	return 0
 }
 
 // broadcastMessage publishes the just-arrived message to the event bus when

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -451,7 +451,11 @@ func (e *PipelineExecutor) buildStagePipeline(
 	// 10. Arena state store save - saves messages with assertion metadata
 	if req.StateStoreConfig != nil && req.ConversationID != "" {
 		storeConfig := buildStateStoreConfig(req)
-		stages = append(stages, arenastages.NewArenaStateStoreSaveStageWithTurnState(storeConfig, turnState))
+		saveStage := arenastages.NewArenaStateStoreSaveStageWithTurnState(storeConfig, turnState)
+		if emitter := emitterFromRequest(req); emitter != nil {
+			saveStage = saveStage.WithEmitter(emitter)
+		}
+		stages = append(stages, saveStage)
 	}
 
 	// Chain all stages together
@@ -736,7 +740,11 @@ func (e *PipelineExecutor) buildCommonStreamingStages(
 	if hasStateStore(req) {
 		storeConfig := buildStateStoreConfig(req)
 		if cfg.UseArenaStateStoreSave {
-			stages = append(stages, arenastages.NewArenaStateStoreSaveStageWithTurnState(storeConfig, turnState))
+			saveStage := arenastages.NewArenaStateStoreSaveStageWithTurnState(storeConfig, turnState)
+			if emitter := emitterFromRequest(req); emitter != nil {
+				saveStage = saveStage.WithEmitter(emitter)
+			}
+			stages = append(stages, saveStage)
 		} else {
 			stages = append(stages, stage.NewIncrementalSaveStageWithTurnState(
 				&stage.IncrementalSaveConfig{StateStoreConfig: storeConfig},

--- a/tools/arena/web/frontend/src/App.tsx
+++ b/tools/arena/web/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { DevToolsPanel } from "@/components/DevToolsPanel";
 import { RunControls } from "@/components/RunControls";
 import { EmptyStateLauncher } from "@/components/EmptyStateLauncher";
 import { HistoricalResults } from "@/components/HistoricalResults";
+import { InteractiveChat } from "@/components/InteractiveChat";
 import { useArenaEvents } from "@/hooks/useArenaEvents";
 import { useArenaAPI } from "@/hooks/useArenaAPI";
 import { AudioPlayer } from "@/audio/player";
@@ -42,7 +43,8 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
 }
 
 export default function App() {
-  const state = useArenaEvents();
+  const { registerInteractiveRun, ...state } = useArenaEvents();
+  const [activeTab, setActiveTab] = useState<"runs" | "chat">("runs");
   const { startRun, getResults, getResult, clearResults, loading } = useArenaAPI();
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [devToolsMessage, setDevToolsMessage] = useState<Message | undefined>();
@@ -150,75 +152,111 @@ export default function App() {
       <Layout
         connected={state.connected}
         headerActions={
-          <RunControls
-            connected={state.connected}
-            loading={loading}
-            startError={startError}
-            onStart={handleStartRun}
-          />
+          activeTab === "runs" ? (
+            <RunControls
+              connected={state.connected}
+              loading={loading}
+              startError={startError}
+              onStart={handleStartRun}
+            />
+          ) : null
         }
       >
-        <div className={devToolsOpen ? "lg:mr-[420px] transition-[margin] duration-200" : "transition-[margin] duration-200"}>
-          {selectedRunId ? (
-            <RunDetail
-              runId={selectedRunId}
-              liveRun={state.runs[selectedRunId]}
-              listeningRunId={listeningRunId}
-              onToggleListen={handleListen}
-              onBack={() => { setSelectedRunId(null); setDevToolsOpen(false); }}
-              onSelectMessage={handleSelectMessage}
-            />
-          ) : showEmptyHero ? (
-            <div className="max-w-2xl mx-auto">
-              <EmptyStateLauncher
-                connected={state.connected}
-                loading={loading}
-                startError={startError}
-                onStart={handleStartRun}
-              />
-            </div>
-          ) : (
-            <div className="space-y-8">
-              {startError && (
-                <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm text-[#EF4444]">{startError}</div>
-              )}
-              <SummaryCards
-                totalRuns={liveRuns.length + historicalResults.length}
-                activeRuns={liveRuns.filter((r) => r.status === "running").length}
-                completedRuns={liveRuns.filter((r) => r.status !== "running").length + historicalResults.length}
-                failedRuns={liveRuns.filter((r) => r.status === "failed").length + historicalResults.filter((r) => !!r.Error).length}
-                totalCost={state.totalCost + historicalResults.reduce((sum, r) => sum + (r.Cost?.total_cost_usd || 0), 0)}
-                totalTokens={state.totalTokens + historicalResults.reduce((sum, r) => sum + (r.Cost?.input_tokens || 0) + (r.Cost?.output_tokens || 0), 0)}
-              />
-              {liveRuns.length > 0 && (
-                <RunProgress
-                  runs={liveRuns}
-                  listeningRunId={listeningRunId}
-                  onSelectRun={setSelectedRunId}
-                  onToggleListen={handleListen}
-                />
-              )}
-              {historicalResults.length > 0 && (
-                <HistoricalResults
-                  results={historicalResults}
-                  onSelectRun={setSelectedRunId}
-                  onClear={async () => {
-                    await clearResults();
-                    setHistoricalResults([]);
-                  }}
-                />
-              )}
-            </div>
-          )}
+        {/* Tab bar */}
+        <div className="flex gap-1 mb-6 border-b border-mist pb-0">
+          <button
+            className={`px-4 py-2 text-sm font-medium rounded-t-lg border border-b-0 transition-colors ${
+              activeTab === "runs"
+                ? "bg-surface border-mist text-fg"
+                : "bg-canvas border-transparent text-fg-muted hover:text-fg hover:bg-surface"
+            }`}
+            onClick={() => setActiveTab("runs")}
+          >
+            Runs
+          </button>
+          <button
+            className={`px-4 py-2 text-sm font-medium rounded-t-lg border border-b-0 transition-colors ${
+              activeTab === "chat"
+                ? "bg-surface border-mist text-fg"
+                : "bg-canvas border-transparent text-fg-muted hover:text-fg hover:bg-surface"
+            }`}
+            onClick={() => setActiveTab("chat")}
+          >
+            Interactive Chat
+          </button>
         </div>
-        <DevToolsPanel
-          message={devToolsMessage}
-          messageIndex={devToolsIndex}
-          allMessages={devToolsAllMessages}
-          run={selectedRun}
-          open={devToolsOpen}
-          onClose={() => setDevToolsOpen(false)}
-        />
+
+        {activeTab === "chat" ? (
+          <InteractiveChat
+            state={state}
+            registerInteractiveRun={registerInteractiveRun}
+            onBack={() => setActiveTab("runs")}
+          />
+        ) : (
+          <>
+            <div className={devToolsOpen ? "lg:mr-[420px] transition-[margin] duration-200" : "transition-[margin] duration-200"}>
+              {selectedRunId ? (
+                <RunDetail
+                  runId={selectedRunId}
+                  liveRun={state.runs[selectedRunId]}
+                  listeningRunId={listeningRunId}
+                  onToggleListen={handleListen}
+                  onBack={() => { setSelectedRunId(null); setDevToolsOpen(false); }}
+                  onSelectMessage={handleSelectMessage}
+                />
+              ) : showEmptyHero ? (
+                <div className="max-w-2xl mx-auto">
+                  <EmptyStateLauncher
+                    connected={state.connected}
+                    loading={loading}
+                    startError={startError}
+                    onStart={handleStartRun}
+                  />
+                </div>
+              ) : (
+                <div className="space-y-8">
+                  {startError && (
+                    <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm text-[#EF4444]">{startError}</div>
+                  )}
+                  <SummaryCards
+                    totalRuns={liveRuns.length + historicalResults.length}
+                    activeRuns={liveRuns.filter((r) => r.status === "running").length}
+                    completedRuns={liveRuns.filter((r) => r.status !== "running").length + historicalResults.length}
+                    failedRuns={liveRuns.filter((r) => r.status === "failed").length + historicalResults.filter((r) => !!r.Error).length}
+                    totalCost={state.totalCost + historicalResults.reduce((sum, r) => sum + (r.Cost?.total_cost_usd || 0), 0)}
+                    totalTokens={state.totalTokens + historicalResults.reduce((sum, r) => sum + (r.Cost?.input_tokens || 0) + (r.Cost?.output_tokens || 0), 0)}
+                  />
+                  {liveRuns.length > 0 && (
+                    <RunProgress
+                      runs={liveRuns}
+                      listeningRunId={listeningRunId}
+                      onSelectRun={setSelectedRunId}
+                      onToggleListen={handleListen}
+                    />
+                  )}
+                  {historicalResults.length > 0 && (
+                    <HistoricalResults
+                      results={historicalResults}
+                      onSelectRun={setSelectedRunId}
+                      onClear={async () => {
+                        await clearResults();
+                        setHistoricalResults([]);
+                      }}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+            <DevToolsPanel
+              message={devToolsMessage}
+              messageIndex={devToolsIndex}
+              allMessages={devToolsAllMessages}
+              run={selectedRun}
+              open={devToolsOpen}
+              onClose={() => setDevToolsOpen(false)}
+            />
+          </>
+        )}
       </Layout>
     </ErrorBoundary>
   );

--- a/tools/arena/web/frontend/src/App.tsx
+++ b/tools/arena/web/frontend/src/App.tsx
@@ -101,6 +101,8 @@ export default function App() {
   // Exclude synthetic interactive-chat entries from the runs-tab aggregates.
   const liveRuns = Object.values(state.runs).filter((r) => r.scenario !== "interactive");
   const selectedRun = selectedRunId ? state.runs[selectedRunId] : undefined;
+  // The active interactive-chat session, surfaced as the DevTools "run" on the chat tab.
+  const interactiveRun = Object.values(state.runs).find((r) => r.scenario === "interactive");
 
   const handleSelectMessage = (index: number, message?: Message, allMsgs?: Message[]) => {
     setDevToolsIndex(index);
@@ -174,7 +176,7 @@ export default function App() {
                 ? "bg-surface border-mist text-fg"
                 : "bg-canvas border-transparent text-fg-muted hover:text-fg hover:bg-surface"
             }`}
-            onClick={() => setActiveTab("runs")}
+            onClick={() => { setActiveTab("runs"); setDevToolsOpen(false); }}
           >
             Runs
           </button>
@@ -184,18 +186,31 @@ export default function App() {
                 ? "bg-surface border-mist text-fg"
                 : "bg-canvas border-transparent text-fg-muted hover:text-fg hover:bg-surface"
             }`}
-            onClick={() => setActiveTab("chat")}
+            onClick={() => { setActiveTab("chat"); setDevToolsOpen(false); }}
           >
             Interactive Chat
           </button>
         </div>
 
         {activeTab === "chat" ? (
-          <InteractiveChat
-            state={state}
-            registerInteractiveRun={registerInteractiveRun}
-            onBack={() => setActiveTab("runs")}
-          />
+          <>
+            <div className={devToolsOpen ? "lg:mr-[420px] transition-[margin] duration-200" : "transition-[margin] duration-200"}>
+              <InteractiveChat
+                state={state}
+                registerInteractiveRun={registerInteractiveRun}
+                onSelectMessage={handleSelectMessage}
+                onBack={() => setActiveTab("runs")}
+              />
+            </div>
+            <DevToolsPanel
+              message={devToolsMessage}
+              messageIndex={devToolsIndex}
+              allMessages={devToolsAllMessages}
+              run={interactiveRun}
+              open={devToolsOpen}
+              onClose={() => setDevToolsOpen(false)}
+            />
+          </>
         ) : (
           <>
             <div className={devToolsOpen ? "lg:mr-[420px] transition-[margin] duration-200" : "transition-[margin] duration-200"}>

--- a/tools/arena/web/frontend/src/App.tsx
+++ b/tools/arena/web/frontend/src/App.tsx
@@ -79,7 +79,10 @@ export default function App() {
   useEffect(() => {
     const ids = Object.keys(state.runs);
     if (pendingAutoSelect) {
-      const newId = ids.find((id) => !knownRunIdsRef.current.has(id));
+      // Skip synthetic interactive-chat runs — they have no RunDetail to show.
+      const newId = ids.find(
+        (id) => !knownRunIdsRef.current.has(id) && state.runs[id]?.scenario !== "interactive"
+      );
       if (newId) {
         setSelectedRunId(newId);
         setPendingAutoSelect(false);
@@ -95,7 +98,8 @@ export default function App() {
     };
   }, []);
 
-  const liveRuns = Object.values(state.runs);
+  // Exclude synthetic interactive-chat entries from the runs-tab aggregates.
+  const liveRuns = Object.values(state.runs).filter((r) => r.scenario !== "interactive");
   const selectedRun = selectedRunId ? state.runs[selectedRunId] : undefined;
 
   const handleSelectMessage = (index: number, message?: Message, allMsgs?: Message[]) => {

--- a/tools/arena/web/frontend/src/components/InteractiveChat.tsx
+++ b/tools/arena/web/frontend/src/components/InteractiveChat.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft, Send } from "lucide-react";
+import { ConversationThread } from "@/components/ConversationThread";
+import { useInteractiveChat } from "@/hooks/useInteractiveChat";
+import type { ArenaState, MessageCreatedData } from "@/types";
+import type { Message } from "@/types";
+
+interface InteractiveChatProps {
+  state: ArenaState;
+  registerInteractiveRun: (sessionId: string) => void;
+  onBack: () => void;
+}
+
+// liveMessageToMessage maps in-flight SSE MessageCreatedData to the Message
+// shape ConversationThread renders. Mirrors the same helper in RunDetail.
+function liveMessageToMessage(m: MessageCreatedData): Message {
+  return {
+    role: m.role,
+    content: m.content,
+    tool_calls: m.toolCalls,
+    tool_result: m.toolResult ?? undefined,
+  };
+}
+
+type Phase = "setup" | "vars" | "chat";
+
+export function InteractiveChat({ state, registerInteractiveRun, onBack }: InteractiveChatProps) {
+  const { fetchOptions, createSession, sendMessage, busy, error } = useInteractiveChat();
+
+  // Setup phase state
+  const [loadingOptions, setLoadingOptions] = useState(true);
+  const [optionsError, setOptionsError] = useState<string | null>(null);
+  const [agents, setAgents] = useState<Array<{ taskType: string; description: string }>>([]);
+  const [providers, setProviders] = useState<string[]>([]);
+  const [hasEvals, setHasEvals] = useState(false);
+
+  const [selectedAgent, setSelectedAgent] = useState<string>("");
+  const [selectedProvider, setSelectedProvider] = useState<string>("");
+  const [enableEvals, setEnableEvals] = useState(false);
+  const [sessionCreating, setSessionCreating] = useState(false);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+
+  // Vars phase state
+  const [missingVars, setMissingVars] = useState<string[]>([]);
+  const [varValues, setVarValues] = useState<Record<string, string>>({});
+  const [pendingParams, setPendingParams] = useState<{
+    agent: string;
+    provider: string;
+    evals: boolean;
+  } | null>(null);
+
+  // Chat phase state
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [inputText, setInputText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const phase: Phase = sessionId ? "chat" : missingVars.length > 0 ? "vars" : "setup";
+
+  // Load options on mount
+  useEffect(() => {
+    setLoadingOptions(true);
+    fetchOptions()
+      .then((opts) => {
+        setAgents(opts.agents);
+        setProviders(opts.providers);
+        setHasEvals(opts.hasEvals);
+        if (opts.agents.length === 1) setSelectedAgent(opts.agents[0].taskType);
+        if (opts.providers.length === 1) setSelectedProvider(opts.providers[0]);
+      })
+      .catch((e: Error) => setOptionsError(e.message))
+      .finally(() => setLoadingOptions(false));
+  }, [fetchOptions]);
+
+  const doCreateSession = useCallback(
+    async (agent: string, provider: string, variables: Record<string, string>, evals: boolean) => {
+      setSessionCreating(true);
+      setSessionError(null);
+      try {
+        const result = await createSession({ agent, provider, variables, evals });
+        if (result.error) {
+          setSessionError(result.error);
+        } else if (result.missingVars && result.missingVars.length > 0) {
+          setMissingVars(result.missingVars);
+          setPendingParams({ agent, provider, evals });
+          const init: Record<string, string> = {};
+          for (const v of result.missingVars) init[v] = "";
+          setVarValues(init);
+        } else if (result.sessionId) {
+          registerInteractiveRun(result.sessionId);
+          setSessionId(result.sessionId);
+        }
+      } finally {
+        setSessionCreating(false);
+      }
+    },
+    [createSession, registerInteractiveRun],
+  );
+
+  const handleSetupSubmit = useCallback(async () => {
+    if (!selectedAgent || !selectedProvider) return;
+    await doCreateSession(selectedAgent, selectedProvider, {}, enableEvals);
+  }, [selectedAgent, selectedProvider, enableEvals, doCreateSession]);
+
+  const handleVarsSubmit = useCallback(async () => {
+    if (!pendingParams) return;
+    await doCreateSession(pendingParams.agent, pendingParams.provider, varValues, pendingParams.evals);
+  }, [pendingParams, varValues, doCreateSession]);
+
+  const handleSend = useCallback(async () => {
+    if (!sessionId || !inputText.trim() || busy) return;
+    const text = inputText.trim();
+    setInputText("");
+    await sendMessage(sessionId, text);
+    textareaRef.current?.focus();
+  }, [sessionId, inputText, busy, sendMessage]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        void handleSend();
+      }
+    },
+    [handleSend],
+  );
+
+  const handleReset = useCallback(() => {
+    setSessionId(null);
+    setMissingVars([]);
+    setPendingParams(null);
+    setVarValues({});
+    setSessionError(null);
+    setInputText("");
+  }, []);
+
+  // Messages for the active session, sorted by index (upsert already sorts,
+  // but defensive sort here handles any edge case).
+  const displayMessages: Message[] = useMemo(() => {
+    if (!sessionId) return [];
+    const run = state.runs[sessionId];
+    if (!run?.messages?.length) return [];
+    return [...run.messages]
+      .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+      .map(liveMessageToMessage);
+  }, [sessionId, state.runs]);
+
+  if (loadingOptions) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="text-sm text-fg-muted animate-pulse">Loading options…</div>
+      </div>
+    );
+  }
+
+  if (optionsError) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-6 max-w-lg mx-auto">
+        <p className="text-sm text-[#EF4444] mb-4">Failed to load interactive options: {optionsError}</p>
+        <button onClick={onBack} className="flex items-center gap-2 text-sm text-[#2563EB] hover:underline">
+          <ArrowLeft className="h-4 w-4" /> Back to Runs
+        </button>
+      </div>
+    );
+  }
+
+  // --- Setup phase ---
+  if (phase === "setup") {
+    return (
+      <div className="max-w-lg mx-auto">
+        <div className="rounded-xl border border-mist bg-surface p-8 shadow-sm">
+          <h2 className="text-lg font-semibold text-fg mb-1">Interactive Chat</h2>
+          <p className="text-sm text-fg-muted mb-6">Chat live with an agent from your Arena config.</p>
+
+          {sessionError && (
+            <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-[#EF4444]">
+              {sessionError}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            {agents.length > 1 && (
+              <div>
+                <label className="block text-sm font-medium text-fg mb-1">Agent</label>
+                <select
+                  className="w-full rounded-lg border border-mist bg-canvas px-3 py-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  value={selectedAgent}
+                  onChange={(e) => setSelectedAgent(e.target.value)}
+                >
+                  <option value="">Select agent…</option>
+                  {agents.map((a) => (
+                    <option key={a.taskType} value={a.taskType}>
+                      {a.taskType}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {providers.length > 1 && (
+              <div>
+                <label className="block text-sm font-medium text-fg mb-1">Provider</label>
+                <select
+                  className="w-full rounded-lg border border-mist bg-canvas px-3 py-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  value={selectedProvider}
+                  onChange={(e) => setSelectedProvider(e.target.value)}
+                >
+                  <option value="">Select provider…</option>
+                  {providers.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {hasEvals && (
+              <div className="flex items-center gap-2">
+                <input
+                  id="enable-evals"
+                  type="checkbox"
+                  checked={enableEvals}
+                  onChange={(e) => setEnableEvals(e.target.checked)}
+                  className="rounded border-mist"
+                />
+                <label htmlFor="enable-evals" className="text-sm text-fg">
+                  Run evals per turn
+                </label>
+              </div>
+            )}
+
+            <button
+              className="w-full rounded-lg bg-[#2563EB] px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={!selectedAgent || !selectedProvider || sessionCreating}
+              onClick={() => void handleSetupSubmit()}
+            >
+              {sessionCreating ? "Starting…" : "Start Chat"}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Vars phase ---
+  if (phase === "vars") {
+    return (
+      <div className="max-w-lg mx-auto">
+        <div className="rounded-xl border border-mist bg-surface p-8 shadow-sm">
+          <h2 className="text-lg font-semibold text-fg mb-1">Required Variables</h2>
+          <p className="text-sm text-fg-muted mb-6">
+            The selected agent requires values for the following template variables.
+          </p>
+
+          {sessionError && (
+            <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-[#EF4444]">
+              {sessionError}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            {missingVars.map((v) => (
+              <div key={v}>
+                <label className="block text-sm font-medium text-fg mb-1">{v}</label>
+                <input
+                  type="text"
+                  className="w-full rounded-lg border border-mist bg-canvas px-3 py-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  value={varValues[v] ?? ""}
+                  onChange={(e) => setVarValues((prev) => ({ ...prev, [v]: e.target.value }))}
+                  placeholder={`Enter ${v}…`}
+                />
+              </div>
+            ))}
+
+            <div className="flex gap-3">
+              <button
+                className="flex-1 rounded-lg border border-mist bg-canvas px-4 py-2.5 text-sm font-medium text-fg-muted hover:text-fg hover:bg-surface transition-colors"
+                onClick={handleReset}
+              >
+                Back
+              </button>
+              <button
+                className="flex-1 rounded-lg bg-[#2563EB] px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={missingVars.some((v) => !varValues[v]?.trim()) || sessionCreating}
+                onClick={() => void handleVarsSubmit()}
+              >
+                {sessionCreating ? "Starting…" : "Start Chat"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Chat phase ---
+  return (
+    <div className="flex flex-col h-[calc(100vh-220px)] min-h-[500px]">
+      {/* Sticky header */}
+      <div className="sticky top-0 z-10 flex items-center justify-between bg-canvas border-b border-mist px-4 py-3 mb-4">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleReset}
+            className="flex items-center gap-1.5 text-sm text-fg-muted hover:text-fg transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Reset
+          </button>
+          <div className="h-4 w-px bg-mist" />
+          <div className="flex items-center gap-3 text-xs text-fg-muted">
+            <span>
+              <span className="font-medium text-fg">{selectedAgent}</span>
+            </span>
+            <span>·</span>
+            <span>{selectedProvider}</span>
+            {enableEvals && (
+              <>
+                <span>·</span>
+                <span className="text-[#10B981]">evals on</span>
+              </>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={onBack}
+          className="text-xs text-fg-muted hover:text-fg transition-colors"
+        >
+          ← Runs
+        </button>
+      </div>
+
+      {/* Conversation thread */}
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {displayMessages.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-sm text-fg-muted">Send a message to start the conversation.</p>
+          </div>
+        ) : (
+          <ConversationThread messages={displayMessages} streaming={busy} />
+        )}
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="mx-4 mb-2 rounded-lg bg-red-50 border border-red-200 px-4 py-2 text-sm text-[#EF4444]">
+          {error}
+        </div>
+      )}
+
+      {/* Input area */}
+      <div className="border-t border-mist bg-surface p-4">
+        <div className="flex items-end gap-3">
+          <textarea
+            ref={textareaRef}
+            className="flex-1 resize-none rounded-lg border border-mist bg-canvas px-3 py-2 text-sm text-fg placeholder:text-fg-muted focus:outline-none focus:ring-2 focus:ring-blue-400 min-h-[44px] max-h-40"
+            placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
+            rows={1}
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={busy}
+          />
+          <button
+            className="flex-shrink-0 rounded-lg bg-[#2563EB] p-2.5 text-white hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={busy || !inputText.trim()}
+            onClick={() => void handleSend()}
+            aria-label="Send message"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/arena/web/frontend/src/components/InteractiveChat.tsx
+++ b/tools/arena/web/frontend/src/components/InteractiveChat.tsx
@@ -2,8 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, Send } from "lucide-react";
 import { ConversationThread } from "@/components/ConversationThread";
 import { useInteractiveChat } from "@/hooks/useInteractiveChat";
-import type { ArenaState, MessageCreatedData } from "@/types";
-import type { Message } from "@/types";
+import type { ArenaState, MessageCreatedData, Message } from "@/types";
 
 interface InteractiveChatProps {
   state: ArenaState;

--- a/tools/arena/web/frontend/src/components/InteractiveChat.tsx
+++ b/tools/arena/web/frontend/src/components/InteractiveChat.tsx
@@ -8,6 +8,8 @@ interface InteractiveChatProps {
   state: ArenaState;
   registerInteractiveRun: (sessionId: string) => void;
   onBack: () => void;
+  // Clicking a message opens the shared DevTools panel (same as the run view).
+  onSelectMessage?: (index: number, message: Message, allMessages: Message[]) => void;
 }
 
 // liveMessageToMessage maps in-flight SSE MessageCreatedData to the Message
@@ -23,7 +25,7 @@ function liveMessageToMessage(m: MessageCreatedData): Message {
 
 type Phase = "setup" | "vars" | "chat";
 
-export function InteractiveChat({ state, registerInteractiveRun, onBack }: InteractiveChatProps) {
+export function InteractiveChat({ state, registerInteractiveRun, onBack, onSelectMessage }: InteractiveChatProps) {
   const { fetchOptions, createSession, sendMessage, busy, error } = useInteractiveChat();
 
   // Setup phase state
@@ -52,6 +54,10 @@ export function InteractiveChat({ state, registerInteractiveRun, onBack }: Inter
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [inputText, setInputText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Auto-scroll: keep the conversation pinned to the bottom as messages arrive,
+  // unless the user has scrolled up to read history.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
 
   const phase: Phase = sessionId ? "chat" : missingVars.length > 0 ? "vars" : "setup";
 
@@ -142,6 +148,22 @@ export function InteractiveChat({ state, registerInteractiveRun, onBack }: Inter
       .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
       .map(liveMessageToMessage);
   }, [sessionId, state.runs]);
+
+  // Track whether the user is near the bottom so we only auto-stick when they
+  // haven't scrolled up to read history.
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
+
+  // Pin to the bottom as new messages stream in (when stuck to bottom).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && stickToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [displayMessages, busy]);
 
   if (loadingOptions) {
     return (
@@ -329,13 +351,19 @@ export function InteractiveChat({ state, registerInteractiveRun, onBack }: Inter
       </div>
 
       {/* Conversation thread */}
-      <div className="flex-1 overflow-y-auto min-h-0">
+      <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto min-h-0">
         {displayMessages.length === 0 ? (
           <div className="flex items-center justify-center h-full">
             <p className="text-sm text-fg-muted">Send a message to start the conversation.</p>
           </div>
         ) : (
-          <ConversationThread messages={displayMessages} streaming={busy} />
+          <ConversationThread
+            messages={displayMessages}
+            streaming={busy}
+            onSelectMessage={
+              onSelectMessage ? (i, m) => onSelectMessage(i, m, displayMessages) : undefined
+            }
+          />
         )}
       </div>
 

--- a/tools/arena/web/frontend/src/hooks/useArenaEvents.test.ts
+++ b/tools/arena/web/frontend/src/hooks/useArenaEvents.test.ts
@@ -151,4 +151,54 @@ describe("reducer", () => {
     expect(state.runs["run-1"].messages).toHaveLength(2);
     expect(state.runs["run-1"].messages.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
+
+  it("MESSAGE_CREATED upserts by index — duplicate index replaces, not appends", () => {
+    let state = __reducer(__initialState, {
+      type: "RUN_STARTED",
+      runId: "run-upsert",
+      data: { provider: "mock", region: "default", scenario: "test" },
+      timestamp: "t0",
+    });
+    // First message at index 0
+    state = __reducer(state, {
+      type: "MESSAGE_CREATED",
+      runId: "run-upsert",
+      data: { role: "user", content: "hello", index: 0 },
+      timestamp: "t1",
+    });
+    // Second message at same index 0 — should replace, not append
+    state = __reducer(state, {
+      type: "MESSAGE_CREATED",
+      runId: "run-upsert",
+      data: { role: "user", content: "hello updated", index: 0 },
+      timestamp: "t2",
+    });
+    expect(state.runs["run-upsert"].messages).toHaveLength(1);
+    expect(state.runs["run-upsert"].messages[0].content).toBe("hello updated");
+  });
+
+  it("MESSAGE_CREATED with different indices inserts in index order", () => {
+    let state = __reducer(__initialState, {
+      type: "RUN_STARTED",
+      runId: "run-order",
+      data: { provider: "mock", region: "default", scenario: "test" },
+      timestamp: "t0",
+    });
+    // Insert index 1 first, then index 0 (out of order arrival)
+    state = __reducer(state, {
+      type: "MESSAGE_CREATED",
+      runId: "run-order",
+      data: { role: "assistant", content: "reply", index: 1 },
+      timestamp: "t1",
+    });
+    state = __reducer(state, {
+      type: "MESSAGE_CREATED",
+      runId: "run-order",
+      data: { role: "user", content: "question", index: 0 },
+      timestamp: "t2",
+    });
+    expect(state.runs["run-order"].messages).toHaveLength(2);
+    expect(state.runs["run-order"].messages[0].index).toBe(0);
+    expect(state.runs["run-order"].messages[1].index).toBe(1);
+  });
 });

--- a/tools/arena/web/frontend/src/hooks/useArenaEvents.ts
+++ b/tools/arena/web/frontend/src/hooks/useArenaEvents.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 import type {
   ArenaState,
   SSEEvent,
@@ -111,13 +111,19 @@ function reducer(state: ArenaState, action: Action): ArenaState {
     case "MESSAGE_CREATED": {
       const existing = state.runs[action.runId];
       if (!existing) return state;
+      const msgs = existing.messages;
+      const idx = msgs.findIndex((m) => m.index === action.data.index);
+      const updatedMsgs =
+        idx >= 0
+          ? msgs.map((m, i) => (i === idx ? action.data : m))
+          : [...msgs, action.data].sort((a, b) => a.index - b.index);
       return {
         ...state,
         runs: {
           ...state.runs,
           [action.runId]: {
             ...existing,
-            messages: [...existing.messages, action.data],
+            messages: updatedMsgs,
           },
         },
       };
@@ -230,5 +236,17 @@ export function useArenaEvents() {
     return () => eventSource.close();
   }, []);
 
-  return state;
+  // registerInteractiveRun seeds a run entry for an interactive session so
+  // MESSAGE_CREATED events are not silently dropped. Interactive sessions
+  // never emit arena.run.started, so the run entry must be seeded manually.
+  const registerInteractiveRun = useCallback((sessionId: string) => {
+    dispatch({
+      type: "RUN_STARTED",
+      runId: sessionId,
+      data: { scenario: "interactive", provider: "", region: "" },
+      timestamp: new Date().toISOString(),
+    });
+  }, []);
+
+  return { ...state, registerInteractiveRun };
 }

--- a/tools/arena/web/frontend/src/hooks/useInteractiveChat.ts
+++ b/tools/arena/web/frontend/src/hooks/useInteractiveChat.ts
@@ -1,0 +1,65 @@
+import { useState, useCallback } from "react";
+
+export interface InteractiveOptions {
+  agents: Array<{ taskType: string; description: string }>;
+  providers: string[];
+  hasEvals: boolean;
+}
+
+export interface CreateSessionResult {
+  sessionId?: string;
+  missingVars?: string[];
+  error?: string;
+}
+
+export function useInteractiveChat() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOptions = useCallback(async (): Promise<InteractiveOptions> => {
+    const resp = await fetch("/api/interactive/options");
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({})) as { error?: string };
+      throw new Error(body.error ?? `Failed to load options: ${resp.status}`);
+    }
+    return resp.json() as Promise<InteractiveOptions>;
+  }, []);
+
+  const createSession = useCallback(async (params: {
+    agent: string;
+    provider: string;
+    variables: Record<string, string>;
+    evals: boolean;
+  }): Promise<CreateSessionResult> => {
+    const resp = await fetch("/api/interactive/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+    const body = await resp.json() as { sessionId?: string; missingVars?: string[]; error?: string };
+    if (!resp.ok) {
+      return { error: body.error ?? `Session creation failed: ${resp.status}` };
+    }
+    return body;
+  }, []);
+
+  const sendMessage = useCallback(async (sessionId: string, text: string): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const resp = await fetch("/api/interactive/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId, text }),
+      });
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({})) as { error?: string };
+        setError(body.error ?? `Send failed: ${resp.status}`);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  return { fetchOptions, createSession, sendMessage, busy, error };
+}

--- a/tools/arena/web/init_test.go
+++ b/tools/arena/web/init_test.go
@@ -1,0 +1,15 @@
+package web
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+// init disables schema validation for tests so fixture configs that predate
+// required schema fields (e.g. spec.description) still load cleanly.
+func init() {
+	if testing.Testing() {
+		config.SchemaValidationDisabled.Store(true)
+	}
+}

--- a/tools/arena/web/interactive.go
+++ b/tools/arena/web/interactive.go
@@ -1,0 +1,131 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
+)
+
+// jsonKeyError and jsonKeyTaskType are map keys used in JSON responses across
+// the interactive handlers. Defined as constants to satisfy goconst (these
+// strings also appear in event_adapter.go and server.go, pushing the
+// package-wide occurrence count above the linter threshold).
+const (
+	jsonKeyError    = "error"
+	jsonKeyTaskType = "taskType"
+)
+
+// interactiveSessions holds live chat sessions keyed by conversation ID.
+type interactiveSessions struct {
+	mu sync.Mutex
+	m  map[string]*engine.InteractiveSession
+}
+
+func newInteractiveSessions() *interactiveSessions {
+	return &interactiveSessions{m: map[string]*engine.InteractiveSession{}}
+}
+
+func (s *interactiveSessions) put(sess *engine.InteractiveSession) {
+	s.mu.Lock()
+	s.m[sess.ConversationID()] = sess
+	s.mu.Unlock()
+}
+
+func (s *interactiveSessions) get(id string) (*engine.InteractiveSession, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[id]
+	return v, ok
+}
+
+func (s *Server) handleInteractiveOptions(w http.ResponseWriter, _ *http.Request) {
+	if s.interactiveEngine == nil {
+		http.Error(w, "engine not configured", http.StatusServiceUnavailable)
+		return
+	}
+	agents := s.interactiveEngine.Agents()
+	out := struct {
+		Agents    []map[string]string `json:"agents"`
+		Providers []string            `json:"providers"`
+		HasEvals  bool                `json:"hasEvals"`
+	}{
+		Providers: s.interactiveEngine.ProviderIDs(),
+		HasEvals:  s.interactiveEngine.HasConfigEvals(),
+	}
+	for _, a := range agents {
+		out.Agents = append(out.Agents, map[string]string{jsonKeyTaskType: a.TaskType, "description": a.Description})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) handleInteractiveSession(w http.ResponseWriter, r *http.Request) {
+	if s.interactiveEngine == nil {
+		http.Error(w, "engine not configured", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Agent     string            `json:"agent"`
+		Provider  string            `json:"provider"`
+		Variables map[string]string `json:"variables"`
+		Evals     bool              `json:"evals"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	missing, err := s.interactiveEngine.MissingRequiredVars(body.Agent, body.Variables)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{jsonKeyError: err.Error()})
+		return
+	}
+	if len(missing) > 0 {
+		writeJSON(w, http.StatusOK, map[string]any{"missingVars": missing})
+		return
+	}
+	sess, err := s.interactiveEngine.NewInteractiveSession(engine.InteractiveSessionOptions{
+		ProviderID: body.Provider,
+		TaskType:   body.Agent,
+		Variables:  body.Variables,
+		RunEvals:   body.Evals,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{jsonKeyError: err.Error()})
+		return
+	}
+	s.interactive.put(sess)
+	writeJSON(w, http.StatusOK, map[string]any{"sessionId": sess.ConversationID()})
+}
+
+func (s *Server) handleInteractiveMessage(w http.ResponseWriter, r *http.Request) {
+	if s.interactiveEngine == nil {
+		http.Error(w, "engine not configured", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		SessionID string `json:"sessionId"`
+		Text      string `json:"text"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	sess, ok := s.interactive.get(body.SessionID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]any{jsonKeyError: "unknown session"})
+		return
+	}
+	ch, err := sess.SendUserMessage(r.Context(), body.Text)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]any{jsonKeyError: err.Error()})
+		return
+	}
+	for chunk := range ch { // messages render live via SSE; drain + surface first error
+		if chunk.Error != nil {
+			writeJSON(w, http.StatusBadGateway, map[string]any{jsonKeyError: chunk.Error.Error()})
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}

--- a/tools/arena/web/interactive.go
+++ b/tools/arena/web/interactive.go
@@ -15,6 +15,7 @@ import (
 const (
 	jsonKeyError    = "error"
 	jsonKeyTaskType = "taskType"
+	msgBadRequest   = "bad request"
 )
 
 // interactiveSessions holds live chat sessions keyed by conversation ID.
@@ -72,7 +73,7 @@ func (s *Server) handleInteractiveSession(w http.ResponseWriter, r *http.Request
 		Evals     bool              `json:"evals"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+		writeJSON(w, http.StatusBadRequest, map[string]any{jsonKeyError: msgBadRequest})
 		return
 	}
 	missing, err := s.interactiveEngine.MissingRequiredVars(body.Agent, body.Variables)
@@ -108,7 +109,7 @@ func (s *Server) handleInteractiveMessage(w http.ResponseWriter, r *http.Request
 		Text      string `json:"text"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+		writeJSON(w, http.StatusBadRequest, map[string]any{jsonKeyError: msgBadRequest})
 		return
 	}
 	sess, ok := s.interactive.get(body.SessionID)

--- a/tools/arena/web/interactive_test.go
+++ b/tools/arena/web/interactive_test.go
@@ -1,0 +1,231 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
+)
+
+const interactiveFixtureConfig = "../engine/testdata/interactive/config.arena.yaml"
+
+// newTestServer builds a Server backed by the interactive fixture engine with
+// mock provider mode enabled. Mirrors the pattern in engine/interactive_test.go.
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	eng, err := engine.NewEngineFromConfigFile(filepath.Clean(interactiveFixtureConfig))
+	if err != nil {
+		t.Fatalf("NewEngineFromConfigFile: %v", err)
+	}
+	if err := eng.EnableMockProviderMode(""); err != nil {
+		t.Fatalf("EnableMockProviderMode: %v", err)
+	}
+	t.Cleanup(func() { _ = eng.Close() })
+	adapter := NewEventAdapter()
+	return NewServer(adapter, eng, nil, "")
+}
+
+func TestInteractiveOptions(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/interactive/options", nil)
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Agents []struct {
+			TaskType string `json:"taskType"`
+		} `json:"agents"`
+		Providers []string `json:"providers"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Agents) == 0 || got.Agents[0].TaskType != "basic" {
+		t.Fatalf("want agent basic, got %+v", got.Agents)
+	}
+	if len(got.Providers) == 0 {
+		t.Fatalf("want providers, got %+v", got.Providers)
+	}
+}
+
+func TestInteractiveSession_MissingVars(t *testing.T) {
+	srv := newTestServer(t)
+	body := `{"agent":"basic","provider":"mock","variables":{}}`
+	req := httptest.NewRequest("POST", "/api/interactive/session", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	var got struct {
+		SessionID   string   `json:"sessionId"`
+		MissingVars []string `json:"missingVars"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if len(got.MissingVars) != 1 || got.MissingVars[0] != "company" {
+		t.Fatalf("want missing [company], got %+v (status %d)", got.MissingVars, rec.Code)
+	}
+	if got.SessionID != "" {
+		t.Fatal("session must not be created when vars are missing")
+	}
+}
+
+func TestInteractiveSession_CreateSuccess(t *testing.T) {
+	srv := newTestServer(t)
+	body := `{"agent":"basic","provider":"mock","variables":{"company":"Acme"}}`
+	req := httptest.NewRequest("POST", "/api/interactive/session", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.SessionID == "" {
+		t.Fatal("want a sessionId, got empty")
+	}
+}
+
+func TestInteractiveMessage_Roundtrip(t *testing.T) {
+	srv := newTestServer(t)
+
+	// Step 1: create session.
+	sessBody := `{"agent":"basic","provider":"mock","variables":{"company":"Acme"}}`
+	sessReq := httptest.NewRequest("POST", "/api/interactive/session", strings.NewReader(sessBody))
+	sessRec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(sessRec, sessReq)
+	if sessRec.Code != 200 {
+		t.Fatalf("create session status %d: %s", sessRec.Code, sessRec.Body.String())
+	}
+	var sessGot struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(sessRec.Body.Bytes(), &sessGot); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2: send a message.
+	msgBodyStr := `{"sessionId":"` + sessGot.SessionID + `","text":"Hello there"}`
+	msgReq := httptest.NewRequest("POST", "/api/interactive/message", strings.NewReader(msgBodyStr))
+	msgRec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(msgRec, msgReq)
+	if msgRec.Code != 200 {
+		t.Fatalf("message status %d: %s", msgRec.Code, msgRec.Body.String())
+	}
+	var msgGot struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal(msgRec.Body.Bytes(), &msgGot); err != nil {
+		t.Fatal(err)
+	}
+	if !msgGot.OK {
+		t.Fatal("want ok:true, got false")
+	}
+
+	// Step 3: verify the transcript grew (at least user + assistant).
+	sess, ok := srv.interactive.get(sessGot.SessionID)
+	if !ok {
+		t.Fatal("session not in registry after message")
+	}
+	msgs, err := sess.Messages(context.Background())
+	if err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if len(msgs) < 2 {
+		t.Fatalf("want at least 2 messages in transcript, got %d", len(msgs))
+	}
+}
+
+func TestInteractiveMessage_UnknownSession(t *testing.T) {
+	srv := newTestServer(t)
+	body := `{"sessionId":"no-such-session","text":"hi"}`
+	req := httptest.NewRequest("POST", "/api/interactive/message", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 404 {
+		t.Fatalf("want 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInteractiveOptions_NoEngine(t *testing.T) {
+	// NewServer with nil engine — interactive endpoints should return 503.
+	adapter := NewEventAdapter()
+	srv := NewServer(adapter, nil, nil, "")
+	req := httptest.NewRequest("GET", "/api/interactive/options", nil)
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Fatalf("want 503 when no engine, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInteractiveSession_NoEngine(t *testing.T) {
+	adapter := NewEventAdapter()
+	srv := NewServer(adapter, nil, nil, "")
+	req := httptest.NewRequest("POST", "/api/interactive/session", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Fatalf("want 503 when no engine, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInteractiveMessage_NoEngine(t *testing.T) {
+	adapter := NewEventAdapter()
+	srv := NewServer(adapter, nil, nil, "")
+	req := httptest.NewRequest("POST", "/api/interactive/message", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Fatalf("want 503 when no engine, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInteractiveSession_BadJSON(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/interactive/session", strings.NewReader("not-json"))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("want 400 for bad JSON, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInteractiveMessage_BadJSON(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequest("POST", "/api/interactive/message", strings.NewReader("not-json"))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("want 400 for bad JSON, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInteractiveSession_UnknownTaskType(t *testing.T) {
+	srv := newTestServer(t)
+	body := `{"agent":"no-such-agent","provider":"mock","variables":{}}`
+	req := httptest.NewRequest("POST", "/api/interactive/session", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("want 400 for unknown task type, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInteractiveSession_UnknownProvider(t *testing.T) {
+	srv := newTestServer(t)
+	body := `{"agent":"basic","provider":"no-such-provider","variables":{"company":"Acme"}}`
+	req := httptest.NewRequest("POST", "/api/interactive/session", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("want 400 for unknown provider, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/tools/arena/web/interactive_test.go
+++ b/tools/arena/web/interactive_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
@@ -112,7 +113,7 @@ func TestInteractiveMessage_Roundtrip(t *testing.T) {
 	}
 
 	// Step 2: send a message.
-	msgBodyStr := `{"sessionId":"` + sessGot.SessionID + `","text":"Hello there"}`
+	msgBodyStr := fmt.Sprintf(`{"sessionId":%q,"text":"Hello there"}`, sessGot.SessionID)
 	msgReq := httptest.NewRequest("POST", "/api/interactive/message", strings.NewReader(msgBodyStr))
 	msgRec := httptest.NewRecorder()
 	srv.mux.ServeHTTP(msgRec, msgReq)
@@ -196,6 +197,13 @@ func TestInteractiveSession_BadJSON(t *testing.T) {
 	if rec.Code != 400 {
 		t.Fatalf("want 400 for bad JSON, got %d: %s", rec.Code, rec.Body.String())
 	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not JSON: %v — body: %s", err, rec.Body.String())
+	}
+	if got["error"] != "bad request" {
+		t.Fatalf("want error=bad request in JSON body, got %v", got)
+	}
 }
 
 func TestInteractiveMessage_BadJSON(t *testing.T) {
@@ -205,6 +213,13 @@ func TestInteractiveMessage_BadJSON(t *testing.T) {
 	srv.mux.ServeHTTP(rec, req)
 	if rec.Code != 400 {
 		t.Fatalf("want 400 for bad JSON, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not JSON: %v — body: %s", err, rec.Body.String())
+	}
+	if got["error"] != "bad request" {
+		t.Fatalf("want error=bad request in JSON body, got %v", got)
 	}
 }
 

--- a/tools/arena/web/server.go
+++ b/tools/arena/web/server.go
@@ -49,11 +49,13 @@ type engineRunner interface {
 
 // Server is the Arena web UI HTTP server.
 type Server struct {
-	adapter    *EventAdapter
-	engine     engineRunner
-	stateStore *statestore.ArenaStateStore
-	outputDir  string
-	mux        *http.ServeMux
+	adapter           *EventAdapter
+	engine            engineRunner
+	interactiveEngine *engine.Engine
+	interactive       *interactiveSessions
+	stateStore        *statestore.ArenaStateStore
+	outputDir         string
+	mux               *http.ServeMux
 
 	// pending tracks background goroutines spawned by handleStartRun so
 	// tests can wait for outputDir writes to drain before TempDir
@@ -80,7 +82,9 @@ func NewServer(adapter *EventAdapter, eng *engine.Engine, store *statestore.Aren
 			})
 		}
 	}
-	return newServerWithRunner(adapter, runner, store, outputDir)
+	s := newServerWithRunner(adapter, runner, store, outputDir)
+	s.interactiveEngine = eng
+	return s
 }
 
 // newServerWithRunner creates a Server using the engineRunner interface (used for testing).
@@ -88,11 +92,12 @@ func newServerWithRunner(
 	adapter *EventAdapter, runner engineRunner, store *statestore.ArenaStateStore, outputDir string,
 ) *Server {
 	s := &Server{
-		adapter:    adapter,
-		engine:     runner,
-		stateStore: store,
-		outputDir:  outputDir,
-		mux:        http.NewServeMux(),
+		adapter:     adapter,
+		engine:      runner,
+		interactive: newInteractiveSessions(),
+		stateStore:  store,
+		outputDir:   outputDir,
+		mux:         http.NewServeMux(),
 	}
 	if runner != nil && store != nil && outputDir != "" {
 		runner.RegisterRunCompletedHook(func(runID string, _ error) {
@@ -107,6 +112,9 @@ func newServerWithRunner(
 	s.mux.HandleFunc("GET /api/media/{path...}", s.handleMedia)
 	s.mux.HandleFunc("DELETE /api/results", s.handleClearResults)
 	s.mux.HandleFunc("POST /api/run", s.handleStartRun)
+	s.mux.HandleFunc("GET /api/interactive/options", s.handleInteractiveOptions)
+	s.mux.HandleFunc("POST /api/interactive/session", s.handleInteractiveSession)
+	s.mux.HandleFunc("POST /api/interactive/message", s.handleInteractiveMessage)
 
 	// SPA fallback: serve embedded frontend
 	sub, subErr := fs.Sub(frontendFS, "frontend/dist")


### PR DESCRIPTION
## Interactive agent console — Phase 2: web chat in `serve`

Adds an **Interactive Chat** tab to `promptarena serve` so you can talk live to an agent in a config — rendered with the **same** conversation UI a run uses, differing only in the input (a chat box) and that turns are user-driven.

Part of #1407. Closes #1410.

### The key idea: a chat turn is a run turn

Rather than a separate render path or a frontend dedup hack, this makes a chat turn emit on the engine event bus exactly like a run, so the existing event → SSE → React pipeline renders it:

```
interactive turn ──emits message.created/updated──▶ event bus
                                                       ├─▶ TUI EventAdapter
                                                       └─▶ web EventAdapter ─▶ SSE ─▶ React (ConversationThread)
```

The earlier "duplication" was root-caused to a since-reverted bridge hack, not the real emitter. The fix is correct emission, at the source.

### What's included

1. **Shared live message emission** (`stages/statestore_save_integration.go`, `turnexecutors/pipeline_stages_integration.go`): scripted/interactive turns now emit `message.created` via `ArenaStateStoreSaveStage.WithEmitter` — only the turn's new messages, transcript-absolute index derived from stream content, system once at index 0, no re-fire. **This also gives normal scripted runs live rendering they didn't have before.**
2. **Web endpoints** (`web/interactive.go`): `GET /api/interactive/options`, `POST /api/interactive/session` (missing-vars gate), `POST /api/interactive/message`; mutex-guarded session registry; JSON error bodies.
3. **Frontend chat view** (`web/frontend/src/components/InteractiveChat.tsx` + hook): setup (agent/provider/vars/eval) then a chat box, rendering the same `ConversationThread` a run uses, populated live via SSE. `SendUserMessage` sets `RunID=conversationID` so events key by `sessionId`; a synthetic run entry is isolated from the runs tab.
4. **Docs**: `serve` Interactive chat section.

### Behavior

Guardrails enforced; assertions skipped; evals optional. Same conversation rendering as a run (tool calls, guardrail firings, cost). Try without API keys: `promptarena serve <config> --mock-provider` → Interactive Chat tab.

### Verification

- Full Arena suite passes; `go build ./...` ok; vitest 37 pass (incl. reducer upsert tests).
- HTTP smoke: `serve` returns `/api/interactive/options` (3 providers) and serves the embedded UI.
- Built subagent-driven with per-task review + an opus whole-branch review (verdict: merge). The high-risk shared-emission change was traced across turns, **tool-call rounds**, system replay, and both scripted + duplex paths — no double-emit, correct session isolation; locked down by stage-level index tests (incl. a tool-round test) and a cross-module coupling comment.

### Follow-ups (out of scope)

- Unify the TUI chat to event-driven rendering (drop its Phase-1 state-store workaround now that scripted turns emit live).
- Optional: make the run-TUI message handler upsert-by-index for symmetry with the web reducer.
- `testdata/interactive` fixture is test-only (no `description`; real `serve` schema-validates) — any schema-valid config drives the chat tab.
