### PR TITLE
feat(arena): deploy config import — merge + validate a deploy profile (#1429)

### DIFF
--- a/tools/arena/agentkb/reference/cli.md
+++ b/tools/arena/agentkb/reference/cli.md
@@ -30,6 +30,7 @@ Deploy the arena pack to a target environment
 
 - `promptarena deploy adapter` — Manage deploy adapter binaries
 - `promptarena deploy apply` — Apply the deployment
+- `promptarena deploy config` — Manage the deploy configuration
 - `promptarena deploy destroy` — Tear down a deployment
 - `promptarena deploy import` — Import a pre-existing resource into deployment state
 - `promptarena deploy plan` — Preview the deployment plan

--- a/tools/arena/cmd/promptarena/deploy_config_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_config_interactive.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+)
+
+// deployConfigCmd groups commands that operate on the deploy configuration
+// itself (as opposed to a live deployment).
+var deployConfigCmd = &cobra.Command{
+	Use:   deployConfigCmdName,
+	Short: "Manage the deploy configuration",
+	Long: `Manage the deploy section of your arena config.
+
+Subcommands:
+  import   Merge an exported deploy profile into the config and validate it`,
+}
+
+var (
+	deployConfigImportProvider     string
+	deployConfigImportSkipValidate bool
+)
+
+var deployConfigImportCmd = &cobra.Command{
+	Use:   "import <profile-file|->",
+	Short: "Import a deploy profile into the deploy config and validate it",
+	Long: `Merge an exported deploy profile fragment into the deploy config
+(under the provider's config: block), then validate the result against the
+adapter's validate_config RPC.
+
+The profile is a JSON or YAML mapping — typically exported by your deploy
+provider (e.g. Omnia) — containing connection details, a scoped token, and
+discovered providers/skills. Pass "-" to read the profile from stdin.
+
+The merge is surgical: only deploy.config is touched, and the rest of your
+config file (comments, key order, other sections) is preserved. Existing keys
+are overridden by the profile; nested mappings are deep-merged. If the deploy
+section or its config block is absent it is created, with the provider set from
+--provider.
+
+Examples:
+  promptarena deploy config import omnia-profile.json
+  promptarena deploy config import - < omnia-profile.yaml
+  promptarena deploy config import profile.json --provider omnia
+  promptarena deploy config import profile.json --skip-validate`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDeployConfigImport,
+}
+
+func init() {
+	deployCmd.AddCommand(deployConfigCmd)
+	deployConfigCmd.AddCommand(deployConfigImportCmd)
+
+	deployConfigImportCmd.Flags().StringVar(
+		&deployConfigImportProvider, "provider", "omnia",
+		"Provider to set when the deploy section is created",
+	)
+	deployConfigImportCmd.Flags().BoolVar(
+		&deployConfigImportSkipValidate, "skip-validate", false,
+		"Skip validating the merged config against the adapter",
+	)
+}
+
+const (
+	// configFilePerms is the fallback permission used when writing a config
+	// file that does not yet exist. The profile may carry a scoped token, so
+	// default to owner-only.
+	configFilePerms = 0o600
+	// yamlIndentSpaces matches the repo's 2-space YAML convention.
+	yamlIndentSpaces = 2
+
+	yamlTagMap = "!!map"
+	yamlTagStr = "!!str"
+
+	// deployConfigCmdName is the "config" subcommand name (shared with the
+	// --config flag string elsewhere in the package).
+	deployConfigCmdName = "config"
+)
+
+// readProfile reads a deploy profile fragment from path (or stdin when path is
+// "-") and parses it as YAML, which is a superset of JSON. The profile must be
+// a mapping.
+func readProfile(path string, stdin io.Reader) (map[string]interface{}, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if path == "-" {
+		if stdin == nil {
+			stdin = os.Stdin
+		}
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read profile from stdin: %w", err)
+		}
+	} else {
+		data, err = os.ReadFile(path) //nolint:gosec // path is a user-supplied flag
+		if err != nil {
+			return nil, fmt.Errorf("failed to read profile file %s: %w", path, err)
+		}
+	}
+
+	var profile map[string]interface{}
+	if err := yaml.Unmarshal(data, &profile); err != nil {
+		return nil, fmt.Errorf("failed to parse profile (expects a JSON or YAML mapping): %w", err)
+	}
+	if profile == nil {
+		return nil, fmt.Errorf("profile is empty or not a mapping")
+	}
+	return profile, nil
+}
+
+// mergeProfileIntoConfigDoc deep-merges the profile fragment into the
+// spec.deploy.config mapping of the arena config YAML document, preserving the
+// rest of the document (comments, key order, unrelated sections). The arena
+// config is a Kubernetes-style manifest, so the deploy section lives under
+// spec. If the deploy section or its config mapping is absent it is created,
+// and provider sets spec.deploy.provider when it is otherwise empty.
+func mergeProfileIntoConfigDoc(doc []byte, profile map[string]interface{}, provider string) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(doc, &root); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	rootMap := documentMapping(&root)
+
+	specNode := mappingGet(rootMap, "spec")
+	if specNode == nil || specNode.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf(
+			"config is not a valid arena manifest: missing or malformed spec: section",
+		)
+	}
+
+	deployNode := mappingGet(specNode, "deploy")
+	if deployNode == nil {
+		deployNode = &yaml.Node{Kind: yaml.MappingNode, Tag: yamlTagMap}
+		mappingSet(specNode, "deploy", deployNode)
+	}
+	if deployNode.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("deploy section is not a mapping")
+	}
+
+	if provider != "" {
+		provNode := mappingGet(deployNode, "provider")
+		switch {
+		case provNode == nil:
+			mappingSet(deployNode, "provider", scalarNode(provider))
+		case strings.TrimSpace(provNode.Value) == "":
+			provNode.Kind = yaml.ScalarNode
+			provNode.Tag = yamlTagStr
+			provNode.Value = provider
+		}
+	}
+
+	cfgNode := mappingGet(deployNode, "config")
+	if cfgNode == nil {
+		cfgNode = &yaml.Node{Kind: yaml.MappingNode, Tag: yamlTagMap}
+		mappingSet(deployNode, "config", cfgNode)
+	}
+	if cfgNode.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("deploy.config is not a mapping")
+	}
+
+	if err := mergeMapIntoNode(cfgNode, profile); err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	// Match the repo's 2-space YAML convention; yaml.Marshal would otherwise
+	// reindent the entire document to 4 spaces.
+	enc.SetIndent(yamlIndentSpaces)
+	if err := enc.Encode(&root); err != nil {
+		return nil, fmt.Errorf("failed to marshal merged config: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("failed to flush merged config: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// documentMapping returns the root mapping node of a YAML document, creating an
+// empty mapping when the document is empty or not a mapping.
+func documentMapping(root *yaml.Node) *yaml.Node {
+	if root.Kind != yaml.DocumentNode {
+		m := &yaml.Node{Kind: yaml.MappingNode, Tag: yamlTagMap}
+		root.Kind = yaml.DocumentNode
+		root.Content = []*yaml.Node{m}
+		return m
+	}
+	if len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		m := &yaml.Node{Kind: yaml.MappingNode, Tag: yamlTagMap}
+		root.Content = []*yaml.Node{m}
+		return m
+	}
+	return root.Content[0]
+}
+
+// mappingGet returns the value node for key in a mapping node, or nil.
+func mappingGet(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// mappingSet replaces the value for key in a mapping node, appending a new
+// key/value pair when the key is absent.
+func mappingSet(m *yaml.Node, key string, val *yaml.Node) {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			m.Content[i+1] = val
+			return
+		}
+	}
+	m.Content = append(m.Content, scalarNode(key), val)
+}
+
+// scalarNode builds a string scalar node.
+func scalarNode(s string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s}
+}
+
+// mergeMapIntoNode deep-merges src into the target mapping node. Keys are
+// applied in sorted order for deterministic output. Nested mappings recurse;
+// every other value type replaces the existing node.
+func mergeMapIntoNode(target *yaml.Node, src map[string]interface{}) error {
+	keys := make([]string, 0, len(src))
+	for k := range src {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := src[k]
+		existing := mappingGet(target, k)
+		if sub, ok := v.(map[string]interface{}); ok && existing != nil && existing.Kind == yaml.MappingNode {
+			if err := mergeMapIntoNode(existing, sub); err != nil {
+				return err
+			}
+			continue
+		}
+		node := &yaml.Node{}
+		if err := node.Encode(v); err != nil {
+			return fmt.Errorf("failed to encode profile value for key %q: %w", k, err)
+		}
+		mappingSet(target, k, node)
+	}
+	return nil
+}
+
+func runDeployConfigImport(cmd *cobra.Command, args []string) error {
+	profilePath := args[0]
+
+	profile, err := readProfile(profilePath, cmd.InOrStdin())
+	if err != nil {
+		return err
+	}
+
+	if _, statErr := os.Stat(deployConfig); os.IsNotExist(statErr) {
+		return fmt.Errorf(
+			"config file not found: %s\nCreate one first (e.g. 'promptarena init')",
+			deployConfig,
+		)
+	}
+
+	doc, err := os.ReadFile(deployConfig)
+	if err != nil {
+		return fmt.Errorf("failed to read config %s: %w", deployConfig, err)
+	}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, deployConfigImportProvider)
+	if err != nil {
+		return err
+	}
+
+	mode := os.FileMode(configFilePerms)
+	if fi, statErr := os.Stat(deployConfig); statErr == nil {
+		mode = fi.Mode().Perm()
+	}
+	if err := os.WriteFile(deployConfig, merged, mode); err != nil {
+		return fmt.Errorf("failed to write config %s: %w", deployConfig, err)
+	}
+	fmt.Printf("Imported profile into %s (merged under deploy.config)\n", deployConfig)
+
+	if deployConfigImportSkipValidate {
+		fmt.Println("Skipping validation (--skip-validate).")
+		return nil
+	}
+
+	return validateDeployConfig()
+}
+
+// validateDeployConfig loads the (just-merged) deploy config and validates it
+// against the adapter's validate_config RPC.
+func validateDeployConfig() error {
+	deployCfg, err := loadDeployConfig()
+	if err != nil {
+		return err
+	}
+
+	env := resolveEnvironment()
+	projectDir, _ := os.Getwd()
+	ctx := context.Background()
+
+	configJSON, err := mergedDeployConfigJSON(deployCfg, env)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Validating config against %q adapter...\n", deployCfg.Provider)
+	client, err := connectAdapter(deployCfg.Provider, projectDir)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	resp, err := client.ValidateConfig(ctx, &deploy.ValidateRequest{Config: configJSON})
+	if err != nil {
+		return fmt.Errorf("validate_config failed: %w", err)
+	}
+	if !resp.Valid {
+		fmt.Println()
+		fmt.Println("Config is INVALID:")
+		for _, e := range resp.Errors {
+			fmt.Printf("  - %s\n", e)
+		}
+		return fmt.Errorf("deploy config validation failed (%d error(s))", len(resp.Errors))
+	}
+
+	fmt.Println("Config is valid.")
+	return nil
+}

--- a/tools/arena/cmd/promptarena/deploy_config_test.go
+++ b/tools/arena/cmd/promptarena/deploy_config_test.go
@@ -1,0 +1,431 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// withImportGlobals saves and restores the package-level flags that
+// runDeployConfigImport reads, so tests can set them in isolation.
+func withImportGlobals(t *testing.T, cfgPath, provider string, skipValidate bool) {
+	t.Helper()
+	oldCfg, oldSkip, oldProv := deployConfig, deployConfigImportSkipValidate, deployConfigImportProvider
+	t.Cleanup(func() {
+		deployConfig = oldCfg
+		deployConfigImportSkipValidate = oldSkip
+		deployConfigImportProvider = oldProv
+	})
+	deployConfig = cfgPath
+	deployConfigImportSkipValidate = skipValidate
+	deployConfigImportProvider = provider
+}
+
+func TestReadProfileFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	content := "endpoint: https://omnia.example.com\ntoken: secret-123\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp profile: %v", err)
+	}
+
+	profile, err := readProfile(path, nil)
+	if err != nil {
+		t.Fatalf("readProfile() error: %v", err)
+	}
+	if profile["endpoint"] != "https://omnia.example.com" {
+		t.Errorf("endpoint = %v, want https://omnia.example.com", profile["endpoint"])
+	}
+	if profile["token"] != "secret-123" {
+		t.Errorf("token = %v, want secret-123", profile["token"])
+	}
+}
+
+func TestReadProfileFromJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	content := `{"endpoint": "https://omnia.example.com", "providers": ["openai"]}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp profile: %v", err)
+	}
+
+	profile, err := readProfile(path, nil)
+	if err != nil {
+		t.Fatalf("readProfile() error: %v", err)
+	}
+	if profile["endpoint"] != "https://omnia.example.com" {
+		t.Errorf("endpoint = %v, want https://omnia.example.com", profile["endpoint"])
+	}
+	providers, ok := profile["providers"].([]interface{})
+	if !ok || len(providers) != 1 || providers[0] != "openai" {
+		t.Errorf("providers = %v, want [openai]", profile["providers"])
+	}
+}
+
+func TestReadProfileFromStdin(t *testing.T) {
+	stdin := strings.NewReader("endpoint: https://stdin.example.com\n")
+	profile, err := readProfile("-", stdin)
+	if err != nil {
+		t.Fatalf("readProfile() error: %v", err)
+	}
+	if profile["endpoint"] != "https://stdin.example.com" {
+		t.Errorf("endpoint = %v, want https://stdin.example.com", profile["endpoint"])
+	}
+}
+
+func TestReadProfileMissingFile(t *testing.T) {
+	_, err := readProfile("/nonexistent/profile.yaml", nil)
+	if err == nil {
+		t.Fatal("expected error for missing profile file")
+	}
+}
+
+func TestReadProfileNotAMapping(t *testing.T) {
+	stdin := strings.NewReader("- just\n- a\n- list\n")
+	_, err := readProfile("-", stdin)
+	if err == nil {
+		t.Fatal("expected error when profile is not a mapping")
+	}
+}
+
+// arenaManifest wraps a spec body in the k8s-style arena manifest envelope that
+// LoadConfig expects (apiVersion/kind/metadata/spec).
+func arenaManifest(specBody string) []byte {
+	var b strings.Builder
+	b.WriteString("apiVersion: promptkit.altairalabs.ai/v1alpha1\n")
+	b.WriteString("kind: Arena\n")
+	b.WriteString("metadata:\n  name: test\n")
+	b.WriteString("spec:\n")
+	b.WriteString(specBody)
+	return []byte(b.String())
+}
+
+// parseDeployConfig is a test helper that extracts spec.deploy.config from a
+// merged arena manifest.
+func parseDeployConfig(t *testing.T, doc []byte) map[string]interface{} {
+	t.Helper()
+	var parsed struct {
+		Spec struct {
+			Deploy struct {
+				Provider string                 `yaml:"provider"`
+				Config   map[string]interface{} `yaml:"config"`
+			} `yaml:"deploy"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(doc, &parsed); err != nil {
+		t.Fatalf("re-parse merged doc: %v\n%s", err, doc)
+	}
+	return parsed.Spec.Deploy.Config
+}
+
+func TestMergeProfileIntoExistingConfig(t *testing.T) {
+	doc := arenaManifest(`  deploy:
+    provider: omnia
+    config:
+      region: us-east-1
+`)
+	profile := map[string]interface{}{
+		"endpoint": "https://omnia.example.com",
+		"token":    "secret-123",
+	}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err != nil {
+		t.Fatalf("mergeProfileIntoConfigDoc() error: %v", err)
+	}
+
+	cfg := parseDeployConfig(t, merged)
+	if cfg["region"] != "us-east-1" {
+		t.Errorf("existing region lost: got %v", cfg["region"])
+	}
+	if cfg["endpoint"] != "https://omnia.example.com" {
+		t.Errorf("endpoint = %v, want merged in", cfg["endpoint"])
+	}
+	if cfg["token"] != "secret-123" {
+		t.Errorf("token = %v, want merged in", cfg["token"])
+	}
+}
+
+func TestMergeProfileOverridesExistingKey(t *testing.T) {
+	doc := arenaManifest(`  deploy:
+    provider: omnia
+    config:
+      token: old-token
+`)
+	profile := map[string]interface{}{"token": "new-token"}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err != nil {
+		t.Fatalf("mergeProfileIntoConfigDoc() error: %v", err)
+	}
+
+	cfg := parseDeployConfig(t, merged)
+	if cfg["token"] != "new-token" {
+		t.Errorf("token = %v, want new-token (override)", cfg["token"])
+	}
+}
+
+func TestMergeProfileDeepMergesNestedMaps(t *testing.T) {
+	doc := arenaManifest(`  deploy:
+    provider: omnia
+    config:
+      auth:
+        mode: token
+        scope: read
+`)
+	profile := map[string]interface{}{
+		"auth": map[string]interface{}{
+			"scope": "write",
+			"realm": "prod",
+		},
+	}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err != nil {
+		t.Fatalf("mergeProfileIntoConfigDoc() error: %v", err)
+	}
+
+	cfg := parseDeployConfig(t, merged)
+	auth, ok := cfg["auth"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("auth not a map: %v", cfg["auth"])
+	}
+	if auth["mode"] != "token" {
+		t.Errorf("auth.mode = %v, want token (preserved)", auth["mode"])
+	}
+	if auth["scope"] != "write" {
+		t.Errorf("auth.scope = %v, want write (overridden)", auth["scope"])
+	}
+	if auth["realm"] != "prod" {
+		t.Errorf("auth.realm = %v, want prod (added)", auth["realm"])
+	}
+}
+
+func TestMergeProfileCreatesDeploySection(t *testing.T) {
+	doc := arenaManifest(`  providers:
+    - file: providers/openai.yaml
+`)
+	profile := map[string]interface{}{"endpoint": "https://omnia.example.com"}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err != nil {
+		t.Fatalf("mergeProfileIntoConfigDoc() error: %v", err)
+	}
+
+	var parsed struct {
+		Spec struct {
+			Deploy struct {
+				Provider string                 `yaml:"provider"`
+				Config   map[string]interface{} `yaml:"config"`
+			} `yaml:"deploy"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(merged, &parsed); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if parsed.Spec.Deploy.Provider != "omnia" {
+		t.Errorf("deploy.provider = %q, want omnia", parsed.Spec.Deploy.Provider)
+	}
+	if parsed.Spec.Deploy.Config["endpoint"] != "https://omnia.example.com" {
+		t.Errorf("deploy.config.endpoint = %v, want merged in", parsed.Spec.Deploy.Config["endpoint"])
+	}
+	// The existing spec content must survive.
+	if !strings.Contains(string(merged), "providers/openai.yaml") {
+		t.Errorf("existing spec content lost:\n%s", merged)
+	}
+}
+
+func TestMergeProfileCreatesConfigUnderExistingDeploy(t *testing.T) {
+	doc := arenaManifest(`  deploy:
+    provider: omnia
+`)
+	profile := map[string]interface{}{"endpoint": "https://omnia.example.com"}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err != nil {
+		t.Fatalf("mergeProfileIntoConfigDoc() error: %v", err)
+	}
+
+	cfg := parseDeployConfig(t, merged)
+	if cfg["endpoint"] != "https://omnia.example.com" {
+		t.Errorf("deploy.config.endpoint = %v, want merged in", cfg["endpoint"])
+	}
+}
+
+func TestMergeProfileDoesNotOverrideExistingProvider(t *testing.T) {
+	doc := arenaManifest(`  deploy:
+    provider: agentcore
+    config:
+      region: us-east-1
+`)
+	profile := map[string]interface{}{"endpoint": "https://omnia.example.com"}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err != nil {
+		t.Fatalf("mergeProfileIntoConfigDoc() error: %v", err)
+	}
+
+	var parsed struct {
+		Spec struct {
+			Deploy struct {
+				Provider string `yaml:"provider"`
+			} `yaml:"deploy"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(merged, &parsed); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if parsed.Spec.Deploy.Provider != "agentcore" {
+		t.Errorf("deploy.provider = %q, want agentcore (preserved)", parsed.Spec.Deploy.Provider)
+	}
+}
+
+func TestMergeProfilePreservesComments(t *testing.T) {
+	doc := []byte(`# Arena config for my project
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+metadata:
+  name: test
+spec:
+  deploy:
+    provider: omnia
+    config:
+      # region is required
+      region: us-east-1
+`)
+	profile := map[string]interface{}{"token": "secret-123"}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err != nil {
+		t.Fatalf("mergeProfileIntoConfigDoc() error: %v", err)
+	}
+
+	out := string(merged)
+	if !strings.Contains(out, "# Arena config for my project") {
+		t.Errorf("top-level comment lost:\n%s", out)
+	}
+	if !strings.Contains(out, "# region is required") {
+		t.Errorf("inline comment lost:\n%s", out)
+	}
+}
+
+func TestMergeProfilePreservesTwoSpaceIndent(t *testing.T) {
+	doc := arenaManifest(`  deploy:
+    provider: omnia
+    config:
+      workspace: existing-ws
+`)
+	profile := map[string]interface{}{"token": "abc"}
+
+	merged, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err != nil {
+		t.Fatalf("mergeProfileIntoConfigDoc() error: %v", err)
+	}
+
+	out := string(merged)
+	// The whole document must keep the repo's 2-space indentation; a 4-space
+	// reindent (yaml.Marshal's default) would rewrite every line.
+	if !strings.Contains(out, "\n  name: test\n") {
+		t.Errorf("metadata.name should stay at 2-space indent:\n%s", out)
+	}
+	if strings.Contains(out, "\n    name: test\n") {
+		t.Errorf("document was reindented to 4 spaces:\n%s", out)
+	}
+}
+
+func TestMergeProfileMissingSpecErrors(t *testing.T) {
+	doc := []byte("apiVersion: promptkit.altairalabs.ai/v1alpha1\nkind: Arena\n")
+	profile := map[string]interface{}{"endpoint": "https://omnia.example.com"}
+
+	_, err := mergeProfileIntoConfigDoc(doc, profile, "omnia")
+	if err == nil {
+		t.Fatal("expected error when manifest has no spec: section")
+	}
+}
+
+func TestRunDeployConfigImportWritesAndSkipsValidate(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.arena.yaml")
+	manifest := arenaManifest(`  deploy:
+    provider: omnia
+    config:
+      region: us-east-1
+`)
+	if err := os.WriteFile(cfgPath, manifest, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	profPath := filepath.Join(dir, "profile.json")
+	profile := `{"token": "abc", "endpoint": "https://omnia.example.com"}`
+	if err := os.WriteFile(profPath, []byte(profile), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	withImportGlobals(t, cfgPath, "omnia", true)
+
+	if err := runDeployConfigImport(&cobra.Command{}, []string{profPath}); err != nil {
+		t.Fatalf("runDeployConfigImport() error: %v", err)
+	}
+
+	out, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read merged config: %v", err)
+	}
+	cfg := parseDeployConfig(t, out)
+	if cfg["token"] != "abc" {
+		t.Errorf("token = %v, want abc (merged from profile)", cfg["token"])
+	}
+	if cfg["endpoint"] != "https://omnia.example.com" {
+		t.Errorf("endpoint = %v, want merged from profile", cfg["endpoint"])
+	}
+	if cfg["region"] != "us-east-1" {
+		t.Errorf("region = %v, want us-east-1 (preserved)", cfg["region"])
+	}
+}
+
+func TestRunDeployConfigImportFromStdin(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.arena.yaml")
+	manifest := arenaManifest(`  deploy:
+    provider: omnia
+    config: {}
+`)
+	if err := os.WriteFile(cfgPath, manifest, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	withImportGlobals(t, cfgPath, "omnia", true)
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("workspace: my-ws\n"))
+	if err := runDeployConfigImport(cmd, []string{"-"}); err != nil {
+		t.Fatalf("runDeployConfigImport() error: %v", err)
+	}
+
+	out, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read merged config: %v", err)
+	}
+	cfg := parseDeployConfig(t, out)
+	if cfg["workspace"] != "my-ws" {
+		t.Errorf("workspace = %v, want my-ws (merged from stdin)", cfg["workspace"])
+	}
+}
+
+func TestRunDeployConfigImportMissingConfigErrors(t *testing.T) {
+	dir := t.TempDir()
+	profPath := filepath.Join(dir, "profile.json")
+	if err := os.WriteFile(profPath, []byte(`{"token": "abc"}`), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	withImportGlobals(t, filepath.Join(dir, "does-not-exist.yaml"), "omnia", true)
+
+	err := runDeployConfigImport(&cobra.Command{}, []string{profPath})
+	if err == nil {
+		t.Fatal("expected error when config file is missing")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `promptarena deploy config import <profile-file|->` — a first-class command to bootstrap the deploy-adapter config from an exported profile fragment instead of hand-editing YAML. Onboarding becomes **export → import → tweak intent → deploy**.

- Reads a JSON or YAML profile **mapping** from a file or stdin (`-`).
- **Surgically deep-merges** it into `spec.deploy.config` via a `yaml.Node` walk — preserves comments, key order, unrelated sections, and the repo's 2-space indentation. Existing keys are overridden; nested mappings deep-merge.
- **Creates** the deploy section when absent (provider from `--provider`, default `omnia`); never clobbers an existing provider.
- **Validates** the merged config against the adapter's `validate_config` RPC (`--skip-validate` to skip when the adapter isn't installed).

## Design notes

- The merge/validate path is **provider-agnostic** — the CLI assumes nothing about the profile's internal shape; it merges whatever mapping it's handed under `deploy.config` and defers correctness to the adapter's `validate_config` RPC. Only the profile *source* is omnia-specific (AltairaLabs/Omnia#1519).
- Real arena configs are k8s-style manifests, so the merge targets `spec.deploy.config` (not top-level `deploy:`), verified against `examples/customer-support/config.arena.yaml`.
- No adapter changes needed — `get_provider_info` (`ConfigSchema`) and `validate_config` already exist in the contract.

## Scope

- Interactive `deploy init --provider omnia` is **deferred** (needs the Omnia profile source from #1519 plus a JSON-Schema → prompt driver).

## Tests

18 tests (TDD): profile read (file/stdin/JSON/YAML/error cases), surgical merge (override, deep-merge, create-section, preserve-provider, comment + 2-space-indent preservation, missing-`spec` error), and command wiring (write-back + `--skip-validate`, stdin, missing-config error). Regenerated the agentkb CLI reference catalog (drift-gate).

Refs #1429
