### PR TITLE
feat(sdk): decouple memory RAG from tool registration (#1427)

### DIFF
--- a/sdk/capability_memory.go
+++ b/sdk/capability_memory.go
@@ -13,6 +13,10 @@ type MemoryCapability struct {
 	extractor memory.Extractor
 	retriever memory.Retriever
 	formatter memory.ContextFormatter
+	// toolsDisabled suppresses registration of the memory tools
+	// (memory__remember / memory__recall, etc.) and their executor,
+	// leaving only the retriever wired for ambient RAG injection.
+	toolsDisabled bool
 }
 
 // NewMemoryCapability creates a MemoryCapability with the given store and scope.
@@ -45,7 +49,16 @@ func (c *MemoryCapability) Init(_ CapabilityContext) error { return nil }
 // registered — the LLM simply doesn't see memory as an option. This
 // prevents confusing backend errors when the memory store rejects
 // operations without a user_id. See AltairaLabs/PromptKit#852.
+//
+// When tools are disabled via [WithMemoryToolsDisabled], no executor or
+// tool descriptors are registered at all — the LLM never sees memory as an
+// option, but ambient RAG injection still works because the retriever is
+// wired separately from this method (see AltairaLabs/PromptKit#1427).
 func (c *MemoryCapability) RegisterTools(registry *tools.Registry) {
+	if c.toolsDisabled {
+		logger.Debug("memory tools skipped: tools disabled (retriever-only mode)")
+		return
+	}
 	if c.scope["user_id"] == "" {
 		logger.Debug("memory tools skipped: scope has no user_id (anonymous user)")
 		return

--- a/sdk/capability_memory_test.go
+++ b/sdk/capability_memory_test.go
@@ -40,6 +40,51 @@ func TestMemoryCapability_RegisterTools(t *testing.T) {
 	}
 }
 
+func TestMemoryCapability_ToolsDisabled_SkipsRegistration(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	scope := map[string]string{"user_id": "test"}
+	cap := NewMemoryCapability(store, scope)
+	cap.toolsDisabled = true
+
+	registry := tools.NewRegistry()
+	cap.RegisterTools(registry)
+
+	// No memory tools should be registered when tools are disabled,
+	// even though the user_id scope is present.
+	for _, name := range []string{
+		memory.RecallToolName,
+		memory.RememberToolName,
+		memory.ListToolName,
+		memory.ForgetToolName,
+	} {
+		if registry.Get(name) != nil {
+			t.Errorf("tool %q registered, want skipped when tools disabled", name)
+		}
+	}
+}
+
+func TestWithMemoryToolsDisabled_StoredOnCapability(t *testing.T) {
+	store := memory.NewInMemoryStore()
+	scope := map[string]string{"user_id": "test"}
+
+	retriever := memory.Retriever(nil)
+	cfg := &config{}
+	opt := WithMemory(store, scope,
+		WithMemoryRetriever(retriever),
+		WithMemoryToolsDisabled(),
+	)
+	if err := opt(cfg); err != nil {
+		t.Fatalf("WithMemory: %v", err)
+	}
+	cap, ok := cfg.capabilities[0].(*MemoryCapability)
+	if !ok {
+		t.Fatalf("expected *MemoryCapability, got %T", cfg.capabilities[0])
+	}
+	if !cap.toolsDisabled {
+		t.Error("expected toolsDisabled to be true")
+	}
+}
+
 func TestMemoryCapability_WithExtractorRetriever(t *testing.T) {
 	store := memory.NewInMemoryStore()
 	cap := NewMemoryCapability(store, nil)

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -1114,6 +1114,27 @@ func WithMemoryRetriever(r memory.Retriever) MemoryOption {
 	return func(c *MemoryCapability) { c.retriever = r }
 }
 
+// WithMemoryToolsDisabled wires the memory retriever (and store/scope) for
+// ambient RAG injection without exposing the memory tools
+// (memory__remember / memory__recall, etc.) to the LLM.
+//
+// Use this when a host wants relevant memories injected into the system
+// prompt but does not want the model to be able to read or write memory
+// directly. Combine with [WithMemoryRetriever]:
+//
+//	conv, _ := sdk.Open(packPath, "chat",
+//	    sdk.WithMemory(store, scope,
+//	        sdk.WithMemoryRetriever(myRetriever),
+//	        sdk.WithMemoryToolsDisabled(),
+//	    ),
+//	)
+//
+// Without a retriever this option simply disables memory entirely (no tools,
+// no injection). See AltairaLabs/PromptKit#1427.
+func WithMemoryToolsDisabled() MemoryOption {
+	return func(c *MemoryCapability) { c.toolsDisabled = true }
+}
+
 // WithMemoryContextFormatter overrides how retrieved memories are rendered
 // into the "memory_context" template variable that the system prompt sees.
 // Composes with [WithMemory] / [WithMemoryRetriever]; ignored when no


### PR DESCRIPTION
## Summary

`WithMemory` bundled the memory **tools** (`memory__remember` / `memory__recall`) with the **retriever** (RAG injection), so a host could not enable ambient retrieval *without* also exposing the tools to the LLM — the "RAG on / tools off" corner of the matrix was unreachable.

## Change

- New `WithMemoryToolsDisabled()` `MemoryOption`. When set, `MemoryCapability.RegisterTools` registers no executor and no tool descriptors, while the retriever stays wired (it is set on the pipeline config independently in `conversation.go`).
- Composes with the existing option family:
  ```go
  sdk.WithMemory(store, scope,
      sdk.WithMemoryRetriever(r),
      sdk.WithMemoryToolsDisabled(),
  )
  ```

## Test plan
- TDD: tests written first (skip-registration behaviour + option-sets-flag). Changed-file coverage 84.2% / 83.7% (≥80% gate).
- `go test ./sdk/...` — memory tests green (two unrelated `provider_file` tests fail only in a worktree path containing `+`; pre-existing, environmental, pass in CI).

Closes #1427
