### PR TITLE
feat(arena): link configure docs when deploy config is missing

### DIFF
--- a/tools/arena/cmd/promptarena/deploy_config_test.go
+++ b/tools/arena/cmd/promptarena/deploy_config_test.go
@@ -415,6 +415,50 @@ func TestRunDeployConfigImportFromStdin(t *testing.T) {
 	}
 }
 
+// withDeployConfigGlobal saves and restores the package-level deployConfig flag
+// that loadFullConfig reads, so tests can set it in isolation.
+func withDeployConfigGlobal(t *testing.T, cfgPath string) {
+	t.Helper()
+	old := deployConfig
+	t.Cleanup(func() { deployConfig = old })
+	deployConfig = cfgPath
+}
+
+func TestLoadFullConfigMissingFileLinksDocs(t *testing.T) {
+	withDeployConfigGlobal(t, filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+
+	_, _, err := loadFullConfig()
+	if err == nil {
+		t.Fatal("expected error when config file is missing")
+	}
+	if !strings.Contains(err.Error(), deployConfigureDocsURL) {
+		t.Errorf("error should link configure docs %q, got: %v", deployConfigureDocsURL, err)
+	}
+}
+
+func TestLoadFullConfigNoDeploySectionLinksDocs(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.arena.yaml")
+	// A valid arena manifest with no deploy: section.
+	manifest := arenaManifest("  providers: []\n")
+	if err := os.WriteFile(cfgPath, manifest, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	withDeployConfigGlobal(t, cfgPath)
+
+	_, _, err := loadFullConfig()
+	if err == nil {
+		t.Fatal("expected error when config has no deploy section")
+	}
+	if !strings.Contains(err.Error(), "no deploy configuration found") {
+		t.Errorf("error should mention missing deploy configuration, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), deployConfigureDocsURL) {
+		t.Errorf("error should link configure docs %q, got: %v", deployConfigureDocsURL, err)
+	}
+}
+
 func TestRunDeployConfigImportMissingConfigErrors(t *testing.T) {
 	dir := t.TempDir()
 	profPath := filepath.Join(dir, "profile.json")

--- a/tools/arena/cmd/promptarena/deploy_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_interactive.go
@@ -63,6 +63,10 @@ func init() {
 	deployCmd.AddCommand(deployImportCmd)
 }
 
+// deployConfigureDocsURL points users at the how-to for setting up a deploy
+// configuration when one is missing or incomplete.
+const deployConfigureDocsURL = "https://promptkit.altairalabs.ai/arena/how-to/deploy/configure/"
+
 // loadDeployConfig loads the arena config and returns the deploy section.
 func loadDeployConfig() (*config.DeployConfig, error) {
 	_, deployCfg, err := loadFullConfig()
@@ -72,7 +76,10 @@ func loadDeployConfig() (*config.DeployConfig, error) {
 // loadFullConfig loads the arena config and returns both the full config and deploy section.
 func loadFullConfig() (*config.Config, *config.DeployConfig, error) {
 	if _, err := os.Stat(deployConfig); os.IsNotExist(err) {
-		return nil, nil, fmt.Errorf("config file not found: %s", deployConfig)
+		return nil, nil, fmt.Errorf(
+			"config file not found: %s\nSet up a deploy config — see %s",
+			deployConfig, deployConfigureDocsURL,
+		)
 	}
 
 	cfg, err := config.LoadConfig(deployConfig)
@@ -82,8 +89,8 @@ func loadFullConfig() (*config.Config, *config.DeployConfig, error) {
 
 	if cfg.Deploy == nil {
 		return nil, nil, fmt.Errorf(
-			"no deploy configuration found in %s\nAdd a 'deploy' section to your arena config",
-			deployConfig,
+			"no deploy configuration found in %s\nAdd a 'deploy' section to your arena config — see %s",
+			deployConfig, deployConfigureDocsURL,
 		)
 	}
 


### PR DESCRIPTION
## What

When `promptarena deploy` runs without a usable deploy config, the error
messages now point the user to the configure how-to:
https://promptkit.altairalabs.ai/arena/how-to/deploy/configure/

`loadFullConfig()` produces two such errors, both now linked:

- **Config file missing**: `config file not found: <file>\nSet up a deploy config — see <docs-url>`
- **No `deploy:` section**: `no deploy configuration found in <file>\nAdd a 'deploy' section to your arena config — see <docs-url>`

The URL is held in a single shared `const deployConfigureDocsURL`. No
behavior changes beyond the message text.

## Tests

Added to `deploy_config_test.go`:
- `TestLoadFullConfigMissingFileLinksDocs` — missing config path returns an error containing the docs URL.
- `TestLoadFullConfigNoDeploySectionLinksDocs` — a valid arena manifest with no `deploy:` section returns an error containing both "no deploy configuration found" and the docs URL.

`go test ./tools/arena/cmd/promptarena/... -count=1` and `golangci-lint run ./tools/arena/...` both pass; pre-commit hook green.

Closes #1467
