### PR TITLE
feat(arena): accept -? as an alias for -h/--help

### DIFF
--- a/tools/arena/cmd/promptarena/main_integration.go
+++ b/tools/arena/cmd/promptarena/main_integration.go
@@ -75,8 +75,26 @@ func setupVersion() {
 	rootCmd.SetVersionTemplate(GetVersionInfo() + "\n")
 }
 
+// normalizeHelpArgs returns a copy of args with every standalone "-?" token
+// replaced by "--help". Cobra reserves -h/--help internally and does not allow
+// registering "?" as a shorthand on the help flag, so we translate the alias
+// before cobra parses the arguments. Only the exact token "-?" is rewritten;
+// "--help", "-h", and unrelated arguments pass through unchanged.
+func normalizeHelpArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		if a == "-?" {
+			out[i] = "--help"
+			continue
+		}
+		out[i] = a
+	}
+	return out
+}
+
 func Execute() {
 	setupVersion()
+	rootCmd.SetArgs(normalizeHelpArgs(os.Args[1:]))
 	err := rootCmd.Execute()
 	if err != nil {
 		// Error already printed by cobra

--- a/tools/arena/cmd/promptarena/main_integration_test.go
+++ b/tools/arena/cmd/promptarena/main_integration_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeHelpArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "nil args",
+			args: nil,
+			want: []string{},
+		},
+		{
+			name: "empty args",
+			args: []string{},
+			want: []string{},
+		},
+		{
+			name: "single -? becomes --help",
+			args: []string{"-?"},
+			want: []string{"--help"},
+		},
+		{
+			name: "-? after subcommand",
+			args: []string{"run", "-?"},
+			want: []string{"run", "--help"},
+		},
+		{
+			name: "-? mixed with other flags",
+			args: []string{"run", "--config", "foo.yaml", "-?"},
+			want: []string{"run", "--config", "foo.yaml", "--help"},
+		},
+		{
+			name: "multiple -? all rewritten",
+			args: []string{"-?", "run", "-?"},
+			want: []string{"--help", "run", "--help"},
+		},
+		{
+			name: "--help passes through unchanged",
+			args: []string{"--help"},
+			want: []string{"--help"},
+		},
+		{
+			name: "-h passes through unchanged",
+			args: []string{"run", "-h"},
+			want: []string{"run", "-h"},
+		},
+		{
+			name: "no question mark passes through unchanged",
+			args: []string{"run", "--config", "foo.yaml"},
+			want: []string{"run", "--config", "foo.yaml"},
+		},
+		{
+			name: "embedded ? not rewritten",
+			args: []string{"--filter=a?b", "-?x"},
+			want: []string{"--filter=a?b", "-?x"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeHelpArgs(tt.args)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("normalizeHelpArgs(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeHelpArgsDoesNotMutateInput(t *testing.T) {
+	in := []string{"run", "-?"}
+	_ = normalizeHelpArgs(in)
+	if in[1] != "-?" {
+		t.Errorf("normalizeHelpArgs mutated its input: got %v", in)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `-?` as an alias for `-h`/`--help` on the `promptarena` CLI — for the root command **and all subcommands**.

Cobra reserves `-h`/`--help` internally and does not allow registering `?` as a shorthand on the help flag. The robust approach is to normalize args **before** cobra parses them: a small pure helper `normalizeHelpArgs` translates each standalone `-?` token to `--help`, applied via `rootCmd.SetArgs(...)` immediately before `Execute()`. `-h`/`--help` behavior is unchanged; only the exact token `-?` is rewritten (embedded `?` like `--filter=a?b` is left alone).

## Tests

Table-driven unit tests in `tools/arena/cmd/promptarena/main_integration_test.go`:
- `TestNormalizeHelpArgs` — `-?` → `--help`, `-?` after subcommand, `-?` mixed with other flags, multiple `-?`, `--help`/`-h`/no-`?` pass through, nil/empty args, embedded `?` untouched
- `TestNormalizeHelpArgsDoesNotMutateInput`

## Manual verification

- `promptarena -?` → prints root help (exit 0)
- `promptarena run -?` → prints `run` subcommand help (exit 0)
- `promptarena -h` → unchanged, prints root help (exit 0)

`-?` no longer errors as an unknown flag.

Closes #1463
