### PR TITLE
feat(arena): compile pack on the fly for deploy (drop packc compile prerequisite)

### DIFF
--- a/tools/arena/cmd/promptarena/deploy_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_interactive.go
@@ -6,14 +6,13 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+	"github.com/AltairaLabs/PromptKit/tools/packc/compiler"
 )
 
 var deployCmd = &cobra.Command{
@@ -53,7 +52,8 @@ func init() {
 
 	deployCmd.PersistentFlags().StringVarP(&deployEnv, "env", "e", "", "Target environment")
 	deployCmd.PersistentFlags().StringVar(&deployConfig, "config", "arena.yaml", "Config file path")
-	deployCmd.PersistentFlags().StringVar(&deployPackFile, "pack", "", "Pack file path (default: auto-detect *.pack.json)")
+	deployCmd.PersistentFlags().StringVar(&deployPackFile, "pack", "",
+		"Optional pre-compiled *.pack.json to deploy (default: compile from --config)")
 
 	deployCmd.AddCommand(deployPlanCmd)
 	deployCmd.AddCommand(deployApplyCmd)
@@ -113,37 +113,29 @@ func resolveEnvironment() string {
 	return defaultEnvironment
 }
 
-// resolvePackFile finds and reads the .pack.json file. If --pack is set, use
-// that; otherwise look for a single *.pack.json in the current directory.
+// resolvePackFile resolves the pack JSON to deploy. If --pack is set, it reads
+// that pre-compiled *.pack.json file (explicit override). Otherwise it compiles
+// the arena config (--config) on the fly and returns the freshly compiled JSON,
+// so users do not need to run a separate compile step before deploying.
 func resolvePackFile() ([]byte, error) {
-	path := deployPackFile
-	if path == "" {
-		matches, err := filepath.Glob("*.pack.json")
+	if deployPackFile != "" {
+		data, err := os.ReadFile(deployPackFile) //nolint:gosec // path is from user flag
 		if err != nil {
-			return nil, fmt.Errorf("failed to search for pack files: %w", err)
+			return nil, fmt.Errorf("failed to read pack file %s: %w", deployPackFile, err)
 		}
-		switch len(matches) {
-		case 0:
-			return nil, fmt.Errorf(
-				"no .pack.json file found in the current directory\n" +
-					"Run 'packc compile' first or specify --pack <file>",
-			)
-		case 1:
-			path = matches[0]
-		default:
-			return nil, fmt.Errorf(
-				"multiple .pack.json files found: %s\nSpecify one with --pack <file>",
-				strings.Join(matches, ", "),
-			)
-		}
+		fmt.Printf("  Pack file:   %s\n", deployPackFile)
+		return data, nil
 	}
 
-	data, err := os.ReadFile(path) //nolint:gosec // path is from user flag or glob
+	result, err := compiler.Compile(deployConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read pack file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to compile pack from %s: %w", deployConfig, err)
 	}
-	fmt.Printf("  Pack file:   %s\n", path)
-	return data, nil
+	for _, w := range result.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
+	fmt.Printf("  Pack:        compiled from %s\n", deployConfig)
+	return result.JSON, nil
 }
 
 // mergedDeployConfigJSON merges the base deploy config with environment-specific

--- a/tools/arena/cmd/promptarena/deploy_resolve_pack_test.go
+++ b/tools/arena/cmd/promptarena/deploy_resolve_pack_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withDeployPackGlobals saves and restores the package-level flags that
+// resolvePackFile reads, so tests can set them in isolation.
+func withDeployPackGlobals(t *testing.T, cfgPath, packFile string) {
+	t.Helper()
+	oldCfg, oldPack := deployConfig, deployPackFile
+	t.Cleanup(func() {
+		deployConfig = oldCfg
+		deployPackFile = oldPack
+	})
+	deployConfig = cfgPath
+	deployPackFile = packFile
+}
+
+func TestResolvePackFile_ExplicitPackOverride(t *testing.T) {
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "my.pack.json")
+	want := []byte(`{"id":"override-pack"}`)
+	require.NoError(t, os.WriteFile(packPath, want, 0o600))
+
+	// Point --config at a nonexistent file to prove the override path does not
+	// touch the compiler when --pack is provided.
+	withDeployPackGlobals(t, filepath.Join(dir, "does-not-exist.yaml"), packPath)
+
+	got, err := resolvePackFile()
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestResolvePackFile_CompilesFromConfig(t *testing.T) {
+	// Place the config in a directory whose name yields a schema-valid pack ID
+	// (the compiler derives the pack ID from the parent dir name).
+	dir := filepath.Join(t.TempDir(), "deploy-pack")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "prompts"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "prompts", "greeting.yaml"), []byte(exportPromptYAML), 0o644))
+	configFile := filepath.Join(dir, "config.arena.yaml")
+	require.NoError(t, os.WriteFile(
+		configFile, []byte(exportArenaConfig("prompts/greeting.yaml")), 0o644))
+
+	withDeployPackGlobals(t, configFile, "")
+
+	got, err := resolvePackFile()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+	assert.True(t, json.Valid(got), "compiled pack should be valid JSON")
+
+	var pack map[string]interface{}
+	require.NoError(t, json.Unmarshal(got, &pack))
+	assert.Contains(t, pack, "id", "compiled output should be a pack with an id")
+}
+
+func TestResolvePackFile_MissingPackFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	withDeployPackGlobals(t, "arena.yaml", filepath.Join(dir, "missing.pack.json"))
+
+	_, err := resolvePackFile()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read pack file")
+}
+
+func TestResolvePackFile_CompileFailureIsClear(t *testing.T) {
+	withDeployPackGlobals(t, "/nonexistent/path/config.arena.yaml", "")
+
+	_, err := resolvePackFile()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to compile pack")
+	assert.NotContains(t, err.Error(), "packc compile",
+		"error should not reference the removed packc compile prerequisite")
+}


### PR DESCRIPTION
## Summary

`promptarena deploy` now compiles the pack **in-memory from the arena config** (`--config`, default `arena.yaml`) by default, so users no longer need to run `packc compile` (or keep a `*.pack.json` on disk) before deploying. This removes a manual step and a tool dependency from the deploy UX.

- `--pack <file>` remains as an explicit override for a pre-compiled `*.pack.json` (unchanged behavior on that path).
- The implicit cwd `*.pack.json` auto-discovery is **removed** (explicit `--pack` only) — this is intended.
- Checksum/drift behavior is unchanged: `ComputePackChecksum` hashes whatever bytes it is given, now the freshly compiled JSON.
- All three pack-consuming paths (`deploy`, `deploy plan`, `deploy apply`) go through the single `resolvePackFile()` resolver, so all benefit. `status`/`destroy`/`refresh`/`import` never used the pack.

## Code changes

- `tools/arena/cmd/promptarena/deploy_interactive.go`
  - Rewrote `resolvePackFile()`: `--pack` → read that file; otherwise `compiler.Compile(deployConfig)` and return `result.JSON`. Surfaces compiler warnings to stderr and a clear compile error (no more "Run 'packc compile' first").
  - Updated `--pack` flag help text.
  - Dropped now-unused `path/filepath` and `strings` imports; added `tools/packc/compiler`.
- `tools/arena/cmd/promptarena/deploy_resolve_pack_test.go` (new): tests for the resolver.

## New `--pack` help text

```
      --pack string     Optional pre-compiled *.pack.json to deploy (default: compile from --config)
```

## Tests added

- `TestResolvePackFile_ExplicitPackOverride` — `--pack` returns the file contents (and does not touch the compiler).
- `TestResolvePackFile_CompilesFromConfig` — no `--pack`, valid arena config → non-empty valid pack JSON.
- `TestResolvePackFile_MissingPackFileErrors` — `--pack` at a missing path → clear read error.
- `TestResolvePackFile_CompileFailureIsClear` — bad `--config` → clear compile error, asserts the message does **not** mention `packc compile`.

## Docs follow-up (NOT touched here — see open docs PR #1475)

Per scope guard, no `docs/` files were modified. Deploy-specific docs still telling users to run `packc compile` as a deploy prerequisite, for a separate cleanup:

- `docs/src/content/docs/arena/how-to/deploy/ci-cd.md:48,89,127`
- `docs/src/content/docs/arena/how-to/deploy/plan-and-apply.md:153`
- `docs/src/content/docs/arena/tutorials/deploy/first-deployment.md:218`
- `docs/src/content/docs/arena/tutorials/deploy/multi-environment.md:155`
- `docs/src/content/docs/arena/reference/cli-commands.md:549` (mentions deploy uses the same pipeline as `packc compile`)

(The many `docs/src/content/docs/packc/**` references are about the `packc` tool itself and are out of scope.)

Closes #1464
