### PR TITLE
docs(arena): drop packc compile prerequisite from deploy docs

### DIFF
--- a/docs/src/content/docs/arena/how-to/deploy/ci-cd.md
+++ b/docs/src/content/docs/arena/how-to/deploy/ci-cd.md
@@ -9,8 +9,9 @@ Automate deployments with GitHub Actions.
 ## Prerequisites
 
 - Deploy configuration in arena.yaml
-- A compiled `.pack.json` committed to your repository (or compiled in CI)
 - Cloud provider credentials configured as GitHub secrets
+
+`promptarena deploy` compiles the pack from `arena.yaml` automatically, so no separate compile step is required. Pre-compiling with `packc` is optional — see the [Multi-Environment Pipeline](#multi-environment-pipeline) below for when it helps.
 
 ## GitHub Actions Workflow
 
@@ -37,15 +38,10 @@ jobs:
           go-version: '1.22'
 
       - name: Install PromptKit
-        run: |
-          go install github.com/AltairaLabs/PromptKit/tools/arena/cmd/promptarena@latest
-          go install github.com/AltairaLabs/PromptKit/tools/packc@latest
+        run: go install github.com/AltairaLabs/PromptKit/tools/arena/cmd/promptarena@latest
 
       - name: Install adapter
         run: promptarena deploy adapter install omnia
-
-      - name: Compile pack
-        run: packc compile --config arena.yaml --output app.pack.json --id my-app
 
       - name: Deploy
         env:
@@ -91,15 +87,10 @@ jobs:
           go-version: '1.22'
 
       - name: Install PromptKit
-        run: |
-          go install github.com/AltairaLabs/PromptKit/tools/arena/cmd/promptarena@latest
-          go install github.com/AltairaLabs/PromptKit/tools/packc@latest
+        run: go install github.com/AltairaLabs/PromptKit/tools/arena/cmd/promptarena@latest
 
       - name: Install adapter
         run: promptarena deploy adapter install agentcore
-
-      - name: Compile pack
-        run: packc compile --config arena.yaml --output app.pack.json --id my-app
 
       - name: Plan deployment
         env:
@@ -111,7 +102,7 @@ jobs:
 
 ### Multi-Environment Pipeline
 
-Deploy to staging first, then production after approval:
+Deploy to staging first, then production after approval. This pipeline pre-compiles the pack once with `packc` and deploys the **same** `app.pack.json` artifact to every environment (via `--pack`), guaranteeing byte-identical deploys across stages. For single-environment deploys you can skip the compile step — `promptarena deploy` compiles from `arena.yaml` automatically.
 
 ```yaml
 # .github/workflows/deploy-pipeline.yml

--- a/docs/src/content/docs/arena/how-to/deploy/plan-and-apply.md
+++ b/docs/src/content/docs/arena/how-to/deploy/plan-and-apply.md
@@ -151,10 +151,7 @@ When you update a pack and redeploy, the adapter receives the prior state and ca
 # Update your prompt
 vim prompts/greeting.yaml
 
-# Recompile
-packc compile --config arena.yaml --output app.pack.json --id my-app
-
-# Plan shows updates
+# Plan shows updates (deploy recompiles from arena.yaml automatically)
 promptarena deploy plan --env production
 
 # Apply updates

--- a/docs/src/content/docs/arena/tutorials/deploy/first-deployment.md
+++ b/docs/src/content/docs/arena/tutorials/deploy/first-deployment.md
@@ -210,17 +210,17 @@ The deploy workflow follows a plan-apply pattern:
 promptarena deploy adapter install agentcore
 ```
 
-### Issue: no pack file found
+### Issue: pack file not found
 
-**Solution:** Compile your pack before deploying:
+`promptarena deploy` compiles the pack from `arena.yaml` automatically, so this usually only appears when you pass `--pack` pointing at a file that does not exist.
 
-```bash
-packc compile --config arena.yaml --output app.pack.json --id my-app
-```
-
-Or specify the pack file explicitly:
+**Solution:** Drop `--pack` to compile from `arena.yaml`, or point it at an existing pre-compiled pack:
 
 ```bash
+# Compile from arena.yaml (default)
+promptarena deploy --env production
+
+# Or deploy a pre-compiled pack
 promptarena deploy --pack app.pack.json
 ```
 

--- a/docs/src/content/docs/arena/tutorials/deploy/multi-environment.md
+++ b/docs/src/content/docs/arena/tutorials/deploy/multi-environment.md
@@ -151,10 +151,7 @@ Production uses different instance types and enables autoscaling as configured i
 When you update your pack, you can redeploy to a single environment:
 
 ```bash
-# Recompile after prompt changes
-packc compile --config arena.yaml --output app.pack.json --id my-app
-
-# Deploy updated pack to dev first
+# Deploy updated pack to dev first (recompiles from arena.yaml automatically)
 promptarena deploy --env dev
 
 # Plan will show updates instead of creates


### PR DESCRIPTION
## What

Follow-up to #1476 / #1464. Now that `promptarena deploy` compiles the pack from `arena.yaml` on the fly, the manual `packc compile` step is no longer a prerequisite. This removes the stale instructions.

## Changes

- **`how-to/deploy/ci-cd.md`** — removed the `packc` install + "Compile pack" steps from the basic Deploy-on-Push and Plan-on-PR workflows; updated Prerequisites. **Kept** the Multi-Environment Pipeline's `packc compile` on purpose (it deploys the same `app.pack.json` artifact to every env via `--pack` for byte-identical deploys) and added a note that it's optional for single-environment deploys.
- **`how-to/deploy/plan-and-apply.md`** — dropped the "Recompile" step from the redeployment workflow.
- **`tutorials/deploy/first-deployment.md`** — reworked the "no pack file found" troubleshooting to reflect on-the-fly compile (`--pack` is an optional override).
- **`tutorials/deploy/multi-environment.md`** — dropped the recompile step from the single-environment update.

Left untouched: `reference/cli-commands.md:549` (accurate description of `promptarena export` sharing the compile pipeline) and all `docs/packc/**` pages (about the `packc` tool itself).

Refs #1464
