### PR TITLE
feat(sdk): add ResumeDuplex to resume a persisted voice conversation

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -907,6 +907,72 @@ func Resume(conversationID, packPath, promptName string, opts ...Option) (*Conve
 	return conv, nil
 }
 
+// ResumeDuplex loads an existing conversation from state storage and opens it as
+// a duplex (audio/realtime) conversation seeded with the persisted history.
+//
+// It is the duplex counterpart to [Resume]: where Resume restores a unary
+// conversation, ResumeDuplex restores a streaming voice conversation so a new
+// process (e.g. a fresh Kubernetes pod after disruption) can open a new provider
+// session that continues "with memory." The live provider socket cannot migrate,
+// so recovery means reconstructing context from durable state, not the socket.
+//
+//	store := statestore.NewRedisStore("redis://localhost:6379")
+//	conv, err := sdk.ResumeDuplex("session-123", "./chat.pack.json", "assistant",
+//	    sdk.WithStateStore(store),
+//	    sdk.WithProvider(realtimeProvider),
+//	)
+//	if errors.Is(err, sdk.ErrConversationNotFound) {
+//	    // No persisted state for this ID → start fresh
+//	    conv, _ = sdk.OpenDuplex("./chat.pack.json", "assistant",
+//	        sdk.WithStateStore(store),
+//	        sdk.WithProvider(realtimeProvider),
+//	        sdk.WithConversationID("session-123"),
+//	    )
+//	}
+//
+// ResumeDuplex requires a state store to be configured. If no state store is
+// provided, it returns [ErrNoStateStore]. If no persisted state exists for the
+// given conversationID, it returns [ErrConversationNotFound].
+//
+// The persisted message history is seeded into the duplex pipeline by the same
+// StateStore load stage that the unary path uses; no separate replay is needed.
+func ResumeDuplex(conversationID, packPath, promptName string, opts ...Option) (*Conversation, error) {
+	// Options are applied twice intentionally: first here to extract the state
+	// store for loading, then again inside OpenDuplex() for full initialization.
+	// This is safe because options are idempotent config setters.
+	cfg := &config{}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return nil, fmt.Errorf("failed to apply option: %w", err)
+		}
+	}
+
+	if cfg.stateStore == nil {
+		return nil, ErrNoStateStore
+	}
+
+	// Try to load existing state
+	ctx := context.Background()
+	state, err := cfg.stateStore.Load(ctx, conversationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load conversation state: %w", err)
+	}
+	if state == nil {
+		return nil, ErrConversationNotFound
+	}
+
+	// Open the duplex conversation with the loaded state.
+	// Add WithConversationID to preserve the original ID so the duplex pipeline's
+	// StateStore load stage seeds the persisted history.
+	opts = append(opts, WithConversationID(conversationID))
+	conv, err := OpenDuplex(packPath, promptName, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return conv, nil
+}
+
 // OpenComposition loads a pack and creates a Conversation that runs the named
 // composition directly (RFC 0010 function-mode surface).
 //

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -870,9 +870,24 @@ func applyDefaultVariables(conv *Conversation, prompt *pack.Prompt) {
 // Resume requires a state store to be configured. If no state store is provided,
 // it returns [ErrNoStateStore].
 func Resume(conversationID, packPath, promptName string, opts ...Option) (*Conversation, error) {
-	// Options are applied twice intentionally: first here to extract the state
-	// store for loading, then again inside Open() for full initialization.
-	// This is safe because options are idempotent config setters.
+	return resumeWith(Open, conversationID, packPath, promptName, opts...)
+}
+
+// resumeWith is the shared implementation behind [Resume] and [ResumeDuplex].
+//
+// It applies the options once to extract the configured state store, verifies a
+// persisted conversation exists, then delegates to opener (Open or OpenDuplex)
+// with WithConversationID appended so the pipeline's StateStore load stage seeds
+// the prior history into the new session.
+//
+// Options are applied twice intentionally: first here to read the state store,
+// then again inside opener for full initialization. This is safe because options
+// are idempotent config setters.
+func resumeWith(
+	opener func(packPath, promptName string, opts ...Option) (*Conversation, error),
+	conversationID, packPath, promptName string,
+	opts ...Option,
+) (*Conversation, error) {
 	cfg := &config{}
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {
@@ -894,17 +909,10 @@ func Resume(conversationID, packPath, promptName string, opts ...Option) (*Conve
 		return nil, ErrConversationNotFound
 	}
 
-	// Open conversation with the loaded state
-	// Add WithConversationID to preserve the original ID
+	// Open conversation with the loaded state. WithConversationID preserves the
+	// original ID so the StateStore load stage seeds the persisted history.
 	opts = append(opts, WithConversationID(conversationID))
-	conv, err := Open(packPath, promptName, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	// The session now has the correct conversation ID from WithConversationID option
-
-	return conv, nil
+	return opener(packPath, promptName, opts...)
 }
 
 // ResumeDuplex loads an existing conversation from state storage and opens it as
@@ -937,40 +945,7 @@ func Resume(conversationID, packPath, promptName string, opts ...Option) (*Conve
 // The persisted message history is seeded into the duplex pipeline by the same
 // StateStore load stage that the unary path uses; no separate replay is needed.
 func ResumeDuplex(conversationID, packPath, promptName string, opts ...Option) (*Conversation, error) {
-	// Options are applied twice intentionally: first here to extract the state
-	// store for loading, then again inside OpenDuplex() for full initialization.
-	// This is safe because options are idempotent config setters.
-	cfg := &config{}
-	for _, opt := range opts {
-		if err := opt(cfg); err != nil {
-			return nil, fmt.Errorf("failed to apply option: %w", err)
-		}
-	}
-
-	if cfg.stateStore == nil {
-		return nil, ErrNoStateStore
-	}
-
-	// Try to load existing state
-	ctx := context.Background()
-	state, err := cfg.stateStore.Load(ctx, conversationID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load conversation state: %w", err)
-	}
-	if state == nil {
-		return nil, ErrConversationNotFound
-	}
-
-	// Open the duplex conversation with the loaded state.
-	// Add WithConversationID to preserve the original ID so the duplex pipeline's
-	// StateStore load stage seeds the persisted history.
-	opts = append(opts, WithConversationID(conversationID))
-	conv, err := OpenDuplex(packPath, promptName, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return conv, nil
+	return resumeWith(OpenDuplex, conversationID, packPath, promptName, opts...)
 }
 
 // OpenComposition loads a pack and creates a Conversation that runs the named

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -405,6 +405,107 @@ func TestResumeWithMockStateStore(t *testing.T) {
 	})
 }
 
+func TestResumeDuplexWithMockStateStore(t *testing.T) {
+	// Create a valid pack file
+	dir := t.TempDir()
+	packFile := filepath.Join(dir, "test.pack.json")
+	packContent := `{
+		"name": "test-pack",
+		"version": "v1",
+		"prompts": {
+			"main": {
+				"system_template": "You are a helpful assistant."
+			}
+		}
+	}`
+	err := os.WriteFile(packFile, []byte(packContent), 0644)
+	require.NoError(t, err)
+
+	t.Run("no state store returns error", func(t *testing.T) {
+		mockProv := &mockStreamingProvider{}
+		_, err := ResumeDuplex("conv-123", packFile, "main",
+			WithProvider(mockProv),
+			WithSkipSchemaValidation(),
+		)
+		assert.ErrorIs(t, err, ErrNoStateStore)
+	})
+
+	t.Run("conversation not found", func(t *testing.T) {
+		mockProv := &mockStreamingProvider{}
+		store := newMockStore()
+		_, err := ResumeDuplex("nonexistent", packFile, "main",
+			WithProvider(mockProv),
+			WithSkipSchemaValidation(),
+			WithStateStore(store),
+		)
+		assert.ErrorIs(t, err, ErrConversationNotFound)
+	})
+
+	t.Run("state load error", func(t *testing.T) {
+		mockProv := &mockStreamingProvider{}
+		store := newMockStore()
+		store.loadErr = errors.New("storage failure")
+		_, err := ResumeDuplex("conv-123", packFile, "main",
+			WithProvider(mockProv),
+			WithSkipSchemaValidation(),
+			WithStateStore(store),
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "storage failure")
+	})
+
+	t.Run("successful resume seeds duplex session", func(t *testing.T) {
+		mockProv := &mockStreamingProvider{}
+		store := newMockStore()
+		store.conversations["conv-123"] = &statestore.ConversationState{
+			ID: "conv-123",
+			Messages: []types.Message{
+				{Role: "user", Content: "earlier turn"},
+			},
+		}
+
+		conv, err := ResumeDuplex("conv-123", packFile, "main",
+			WithProvider(mockProv),
+			WithSkipSchemaValidation(),
+			WithStateStore(store),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, conv)
+		defer conv.Close()
+		assert.Equal(t, "conv-123", conv.ID())
+		assert.Equal(t, DuplexMode, conv.mode)
+		assert.NotNil(t, conv.duplexSession)
+		assert.Nil(t, conv.unarySession)
+	})
+
+	t.Run("fails with non-streaming provider", func(t *testing.T) {
+		store := newMockStore()
+		store.conversations["conv-123"] = &statestore.ConversationState{
+			ID: "conv-123",
+		}
+		_, err := ResumeDuplex("conv-123", packFile, "main",
+			WithProvider(&mockProvider{}),
+			WithSkipSchemaValidation(),
+			WithStateStore(store),
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not support duplex streaming")
+	})
+
+	t.Run("resume with option error", func(t *testing.T) {
+		store := newMockStore()
+		store.conversations["conv-123"] = &statestore.ConversationState{
+			ID: "conv-123",
+		}
+		_, err := ResumeDuplex("conv-123", packFile, "main",
+			WithSkipSchemaValidation(),
+			WithStateStore(store),
+			func(c *config) error { return errors.New("option error") },
+		)
+		assert.Error(t, err)
+	})
+}
+
 func TestApplyOptions(t *testing.T) {
 	t.Run("empty options", func(t *testing.T) {
 		cfg, err := applyOptions("test-prompt", nil)


### PR DESCRIPTION
## Summary

Adds `sdk.ResumeDuplex` — a duplex (audio/realtime) counterpart to the existing unary `sdk.Resume`. It opens a duplex conversation seeded with previously persisted state from the configured `statestore.Store`, so a realtime voice session can be reconstructed "with memory" after the original provider socket is gone.

## Motivation

Realtime voice agents (OpenAI Realtime / Gemini Live) running on Kubernetes need a conversation to survive pod disruption (rollouts, node drain, crash). The live provider socket cannot migrate between pods, so recovery means a *new* pod opens a *new* provider session **seeded with the prior conversation history**. Previously `OpenDuplex` always started fresh, losing all in-call context. `Resume` solved this for unary conversations but had no duplex equivalent.

Closes #1459.

## Implementation

The duplex pipeline already wires the same `StateStore` + `ConversationID` that the unary path uses (`initDuplexSession` → `buildStreamPipelineWithParams` → `StateStoreLoadStage`), so persisted history is seeded automatically. `ResumeDuplex` therefore mirrors `Resume` exactly:

- Applies options to extract the state store → returns `ErrNoStateStore` if none configured.
- Loads `ConversationState` for the ID → wraps load errors, returns `ErrConversationNotFound` on missing state.
- Appends `WithConversationID` and delegates to `OpenDuplex`; the load stage seeds prior turns into the new provider session.

No new persistence or replay logic — fully additive and backward compatible.

## Tests

`TestResumeDuplexWithMockStateStore` (TDD, written failing-first) covers:
- no state store → `ErrNoStateStore`
- missing conversation → `ErrConversationNotFound`
- state load error propagation
- successful resume → `DuplexMode` with seeded duplex session, preserved ID
- non-streaming provider rejection
- option-error propagation

`golangci-lint` clean; full `./sdk/` suite passes.
