### PR TITLE
feat(pipeline): EndOfTurn + Interrupt control signals on StreamElement

### DIFF
--- a/runtime/pipeline/stage/element.go
+++ b/runtime/pipeline/stage/element.go
@@ -90,7 +90,9 @@ type StreamElement struct {
 	Meta ElementMetadata
 
 	// Control signals
-	EndOfStream bool  // No more elements after this
+	EndOfStream bool  // No more elements after this (session over)
+	EndOfTurn   bool  // End of one conversational turn's input; stream stays open
+	Interrupt   bool  // Barge-in: cancel in-flight generation/playback
 	Error       error // Error propagation
 }
 
@@ -379,6 +381,28 @@ func NewEndOfStreamElement() StreamElement {
 	}
 }
 
+// NewEndOfTurnElement marks the end of one conversational turn's input within a
+// still-open stream. Distinct from NewEndOfStreamElement (session over): the
+// streaming provider stage fires its tool loop on EndOfTurn and stays open for
+// the next turn.
+func NewEndOfTurnElement() StreamElement {
+	return StreamElement{
+		EndOfTurn: true,
+		Timestamp: time.Now(),
+		Priority:  PriorityCritical,
+	}
+}
+
+// NewInterruptElement signals barge-in: downstream stages cancel in-flight
+// generation/playback and drop queued audio. Travels at PriorityCritical.
+func NewInterruptElement() StreamElement {
+	return StreamElement{
+		Interrupt: true,
+		Timestamp: time.Now(),
+		Priority:  PriorityCritical,
+	}
+}
+
 // IsEmpty returns true if the element contains no content.
 func (e *StreamElement) IsEmpty() bool {
 	return e.Text == nil &&
@@ -390,6 +414,8 @@ func (e *StreamElement) IsEmpty() bool {
 		e.Part == nil &&
 		e.MediaData == nil &&
 		!e.EndOfStream &&
+		!e.EndOfTurn &&
+		!e.Interrupt &&
 		e.Error == nil
 }
 
@@ -405,9 +431,10 @@ func (e *StreamElement) HasContent() bool {
 		e.MediaData != nil
 }
 
-// IsControl returns true if the element is a control signal (error or end-of-stream).
+// IsControl returns true if the element is a control signal (error, end-of-stream,
+// end-of-turn, or interrupt) rather than content.
 func (e *StreamElement) IsControl() bool {
-	return e.Error != nil || e.EndOfStream
+	return e.Error != nil || e.EndOfStream || e.EndOfTurn || e.Interrupt
 }
 
 // WithSource sets the source stage name for this element.

--- a/runtime/pipeline/stage/element_test.go
+++ b/runtime/pipeline/stage/element_test.go
@@ -422,6 +422,48 @@ func TestVideoData_EnsureLoaded_Error(t *testing.T) {
 	}
 }
 
+func TestNewEndOfTurnElement(t *testing.T) {
+	e := NewEndOfTurnElement()
+	if !e.EndOfTurn {
+		t.Fatal("expected EndOfTurn true")
+	}
+	if e.EndOfStream {
+		t.Fatal("EndOfTurn element must not set EndOfStream")
+	}
+	if e.Priority != PriorityCritical {
+		t.Fatalf("expected PriorityCritical, got %v", e.Priority)
+	}
+	if !e.IsControl() {
+		t.Fatal("EndOfTurn element must be a control signal")
+	}
+	if e.IsEmpty() {
+		t.Fatal("EndOfTurn element must not be empty")
+	}
+}
+
+func TestNewInterruptElement(t *testing.T) {
+	e := NewInterruptElement()
+	if !e.Interrupt {
+		t.Fatal("expected Interrupt true")
+	}
+	if e.Priority != PriorityCritical {
+		t.Fatalf("expected PriorityCritical, got %v", e.Priority)
+	}
+	if !e.IsControl() {
+		t.Fatal("Interrupt element must be a control signal")
+	}
+	if e.IsEmpty() {
+		t.Fatal("Interrupt element must not be empty")
+	}
+}
+
+func TestControlSignals_DefaultFalse(t *testing.T) {
+	e := NewTextElement("hi")
+	if e.EndOfTurn || e.Interrupt {
+		t.Fatal("new content element must default EndOfTurn/Interrupt to false")
+	}
+}
+
 func TestImageData_EnsureLoaded_Error(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockMediaStorageService{

--- a/runtime/pipeline/stage/stages_recording.go
+++ b/runtime/pipeline/stage/stages_recording.go
@@ -135,7 +135,8 @@ func (rs *RecordingStage) recordElement(ctx context.Context, elem *StreamElement
 		return
 	}
 
-	// Skip control signals (errors, end-of-stream)
+	// Skip control signals (end-of-stream, end-of-turn, interrupt) — they carry
+	// no content to record. Errors fall through to be recorded below.
 	if elem.IsControl() && elem.Error == nil {
 		return
 	}


### PR DESCRIPTION
## What

Adds two additive control-signal fields to `StreamElement`, alongside the existing `EndOfStream`/`Error` in the `// Control signals` block:

- **`EndOfTurn bool`** — marks the end of one conversational turn's input within a **still-open** stream (distinct from `EndOfStream` = session over).
- **`Interrupt bool`** — barge-in signal, travels at `PriorityCritical`; downstream stages will cancel in-flight generation/playback.

Plus constructor helpers `NewEndOfTurnElement()` / `NewInterruptElement()` (mirroring `NewEndOfStreamElement`), and `IsControl()` / `IsEmpty()` updates so the new signals are recognised as control (not content).

## Why

First PR of **epic #1469** (composed-VAD voice — turn-by-turn conversation + barge-in). The composed VAD path currently uses the unary `ProviderStage`, which drains its input until close and fires the LLM once — so a continuous mic session gets no reply mid-conversation. The follow-ups build on these signals:

- #1471 — streaming provider stage fires the tool loop on `EndOfTurn` and stays open
- #1472 — barge-in: VAD speech-start emits `Interrupt`, cancelling in-flight generation/TTS
- #1473 — rebuild the composed pipeline as a continuous conversation + integration test

## Blast radius

Both fields default to `false` = today's behaviour, so every existing SDK and Arena pipeline is unchanged. The only `IsControl()` consumer outside tests is the recording stage, which already skips control signals (no content to record) — comment updated to note the new signals are intentionally skipped.

## Tests

- `TestNewEndOfTurnElement`, `TestNewInterruptElement`, `TestControlSignals_DefaultFalse` (new)
- Full `runtime/pipeline/stage` suite passes; changed files at 96.6% / 95.9% coverage.

Closes #1470
