### PR TITLE
feat(pipeline): streaming multi-turn mode for ProviderStage

### DIFF
--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -75,6 +75,15 @@ type ProviderConfig struct {
 	// exceeds the configured threshold. Nil = disabled.
 	Compactor CompactionStrategy
 
+	// Streaming enables continuous multi-turn mode: instead of draining the
+	// input channel and firing the provider once at close (the unary default,
+	// correct for Arena's "pipeline per turn"), the stage fires the tool loop
+	// on each EndOfTurn control element, emits that turn's reply, stays open,
+	// and threads conversation history across turns within the session. Used by
+	// the composed-VAD voice path (one continuous mic session). Default false
+	// preserves today's fire-once-at-close behavior for every existing pipeline.
+	Streaming bool
+
 	// ToolSelector, when set, narrows the pack-declared allowedTools
 	// each turn before tools are sent to the provider. The selector
 	// receives the latest user message as its query and the current
@@ -195,6 +204,10 @@ func (s *ProviderStage) Process(
 		return errors.New("provider stage: no provider configured")
 	}
 
+	if s.config != nil && s.config.Streaming {
+		return s.processStreaming(ctx, input, output)
+	}
+
 	accumulated := s.accumulateInput(input)
 
 	logger.Debug("ProviderStage accumulated input",
@@ -232,6 +245,160 @@ func (s *ProviderStage) accumulateInput(input <-chan StreamElement) *providerInp
 	}
 
 	return acc
+}
+
+// streamingConfig holds the per-session invariants for continuous multi-turn
+// mode, read once from TurnState. The metadata map is copied so per-turn
+// mutation does not leak back onto TurnState.
+type streamingConfig struct {
+	systemPrompt string
+	allowedTools []string
+	baseMeta     map[string]interface{}
+}
+
+// streamingTurnState snapshots the per-session invariants for a streaming run.
+func (s *ProviderStage) streamingTurnState() streamingConfig {
+	cfg := streamingConfig{baseMeta: map[string]interface{}{}}
+	if s.turnState == nil {
+		return cfg
+	}
+	cfg.systemPrompt = s.turnState.SystemPrompt
+	cfg.allowedTools = s.turnState.AllowedTools
+	cfg.baseMeta = make(map[string]interface{}, len(s.turnState.ProviderRequestMetadata))
+	for k, v := range s.turnState.ProviderRequestMetadata {
+		cfg.baseMeta[k] = v
+	}
+	return cfg
+}
+
+// processStreaming runs the continuous multi-turn mode. It accumulates Message
+// elements until an EndOfTurn control element arrives, fires the existing tool
+// loop on the accumulated history, emits that turn's new messages, re-emits an
+// EndOfTurn boundary, and stays open for the next turn. History threads across
+// turns within the session. Non-Message, non-control elements (e.g. an Interrupt
+// arriving between turns) are forwarded downstream unchanged so later stages and
+// follow-up work (the barge-in path) can act on them.
+func (s *ProviderStage) processStreaming(
+	ctx context.Context,
+	input <-chan StreamElement,
+	output chan<- StreamElement,
+) error {
+	cfg := s.streamingTurnState()
+	var history []types.Message
+	var pending []types.Message
+
+	for elem := range input {
+		switch {
+		case elem.EndOfTurn:
+			next, err := s.fireIfPending(ctx, &history, pending, cfg, output)
+			if err != nil {
+				return err
+			}
+			pending = next
+		case elem.EndOfStream:
+			// Session over: fire any partial turn, then stop. Closing output
+			// downstream signals end-of-conversation to the next stages.
+			_, err := s.fireIfPending(ctx, &history, pending, cfg, output)
+			return err
+		case elem.Message != nil:
+			pending = append(pending, *elem.Message)
+		default:
+			// Control signals (Interrupt) and any stray content pass through.
+			if err := sendStreamElement(ctx, elem, output); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Input closed without an explicit EndOfStream: fire any trailing turn.
+	_, err := s.fireIfPending(ctx, &history, pending, cfg, output)
+	return err
+}
+
+// fireIfPending fires a streaming turn when there is buffered input, returning
+// the reset pending slice. A no-op (returning pending unchanged) when empty.
+func (s *ProviderStage) fireIfPending(
+	ctx context.Context,
+	history *[]types.Message,
+	pending []types.Message,
+	cfg streamingConfig,
+	output chan<- StreamElement,
+) ([]types.Message, error) {
+	if len(pending) == 0 {
+		return pending, nil
+	}
+	if err := s.fireStreamingTurn(ctx, history, pending, cfg, output); err != nil {
+		return pending, err
+	}
+	return nil, nil
+}
+
+// fireStreamingTurn runs the tool loop for one turn against (history + pending),
+// emits only this turn's new messages (the turn's user transcript plus the
+// assistant reply and any tool messages — the provider drains its input, so it
+// must re-emit the user messages itself for the save stage), advances history to
+// the full conversation, and emits an EndOfTurn boundary. A turn-level error is
+// surfaced as an error element but does not tear down the session — a live
+// conversation survives one failed turn.
+func (s *ProviderStage) fireStreamingTurn(
+	ctx context.Context,
+	history *[]types.Message,
+	pending []types.Message,
+	cfg streamingConfig,
+	output chan<- StreamElement,
+) error {
+	priorLen := len(*history)
+	messages := make([]types.Message, 0, priorLen+len(pending))
+	messages = append(messages, *history...)
+	messages = append(messages, pending...)
+
+	metadata := make(map[string]interface{}, len(cfg.baseMeta))
+	for k, v := range cfg.baseMeta {
+		metadata[k] = v
+	}
+	acc := &providerInput{
+		messages:     messages,
+		systemPrompt: cfg.systemPrompt,
+		allowedTools: cfg.allowedTools,
+		metadata:     metadata,
+	}
+
+	var full []types.Message
+	var err error
+	if s.provider.SupportsStreaming() {
+		full, err = s.executeStreamingMultiRound(ctx, acc, output)
+	} else {
+		full, err = s.executeMultiRound(ctx, acc)
+	}
+	if err != nil {
+		// Surface the failure but keep the session alive (return nil on a
+		// successful send; ctx cancellation still propagates).
+		logger.Error("ProviderStage streaming turn failed", "error", err)
+		return sendStreamElement(ctx, NewErrorElement(err), output)
+	}
+
+	// full = (history + pending) + new assistant/tool messages. Emit everything
+	// after the prior history: this turn's user messages and the new reply.
+	if priorLen <= len(full) {
+		if emitErr := s.emitResponseMessages(ctx, full[priorLen:], output); emitErr != nil {
+			return emitErr
+		}
+	}
+	*history = full
+
+	return sendStreamElement(ctx, NewEndOfTurnElement(), output)
+}
+
+// sendStreamElement forwards one element downstream, honoring cancellation.
+//
+//nolint:gocritic // hugeParam: StreamElement is the channel element type, passed by value throughout the pipeline
+func sendStreamElement(ctx context.Context, elem StreamElement, output chan<- StreamElement) error {
+	select {
+	case output <- elem:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // executeAndEmit runs provider execution and emits results.

--- a/runtime/pipeline/stage/stages_provider_streaming_test.go
+++ b/runtime/pipeline/stage/stages_provider_streaming_test.go
@@ -1,0 +1,146 @@
+package stage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// multiTurnRecordingProvider records the messages of every Predict call and
+// returns a numbered reply, so tests can assert one provider call per turn and
+// that later turns see earlier turns as history.
+type multiTurnRecordingProvider struct {
+	requests [][]types.Message
+}
+
+func (p *multiTurnRecordingProvider) ID() string                          { return "rec" }
+func (p *multiTurnRecordingProvider) Name() string                        { return "rec" }
+func (p *multiTurnRecordingProvider) Type() base.ProviderType             { return base.ProviderTypeInference }
+func (p *multiTurnRecordingProvider) Pricing() *base.PricingDescriptor    { return nil }
+func (p *multiTurnRecordingProvider) Validate() error                     { return nil }
+func (p *multiTurnRecordingProvider) Init(_ context.Context) error        { return nil }
+func (p *multiTurnRecordingProvider) HealthCheck(_ context.Context) error { return nil }
+func (p *multiTurnRecordingProvider) Model() string                       { return "rec-model" }
+func (p *multiTurnRecordingProvider) SupportsStreaming() bool             { return false }
+func (p *multiTurnRecordingProvider) ShouldIncludeRawOutput() bool        { return false }
+func (p *multiTurnRecordingProvider) CalculateCost(_, _, _ int) types.CostInfo {
+	return types.CostInfo{}
+}
+func (p *multiTurnRecordingProvider) Close() error { return nil }
+
+func (p *multiTurnRecordingProvider) Predict(
+	_ context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	msgs := make([]types.Message, len(req.Messages))
+	copy(msgs, req.Messages)
+	p.requests = append(p.requests, msgs)
+	return providers.PredictionResponse{Content: fmt.Sprintf("reply-%d", len(p.requests))}, nil
+}
+
+func (p *multiTurnRecordingProvider) PredictStream(
+	_ context.Context, _ providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+// TestProviderStage_Streaming_OneReplyPerTurn verifies that with Streaming
+// enabled, the provider fires once per EndOfTurn (not once at channel close),
+// emits an assistant reply per turn, and re-emits an EndOfTurn boundary after
+// each reply.
+func TestProviderStage_Streaming_OneReplyPerTurn(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	ts := NewTurnState()
+	ts.SystemPrompt = "sys"
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, ts)
+
+	input := make(chan StreamElement, 8)
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "hello one"})
+	input <- NewEndOfTurnElement()
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "hello two"})
+	input <- NewEndOfTurnElement()
+	close(input)
+
+	output := make(chan StreamElement, 64)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	var assistant []*types.Message
+	endOfTurns := 0
+	for e := range output {
+		switch {
+		case e.EndOfTurn:
+			endOfTurns++
+		case e.Message != nil && e.Message.Role == roleAssistant:
+			m := e.Message
+			assistant = append(assistant, m)
+		}
+	}
+
+	require.Len(t, prov.requests, 2, "provider should fire once per EndOfTurn, not once at close")
+	require.Len(t, assistant, 2, "one assistant reply per turn")
+	assert.Equal(t, "reply-1", assistant[0].Content)
+	assert.Equal(t, "reply-2", assistant[1].Content)
+	assert.Equal(t, 2, endOfTurns, "an EndOfTurn boundary is re-emitted after each reply")
+}
+
+// TestProviderStage_Streaming_ThreadsHistory verifies turn 2's provider request
+// carries turn 1 (user message + assistant reply) as history.
+func TestProviderStage_Streaming_ThreadsHistory(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	ts := NewTurnState()
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, ts)
+
+	input := make(chan StreamElement, 8)
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "first question"})
+	input <- NewEndOfTurnElement()
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "second question"})
+	input <- NewEndOfTurnElement()
+	close(input)
+
+	output := make(chan StreamElement, 64)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	require.Len(t, prov.requests, 2)
+	require.Len(t, prov.requests[0], 1, "turn 1 sees only its own user message")
+	assert.Equal(t, "first question", prov.requests[0][0].Content)
+
+	// Turn 2 sees: turn-1 user, turn-1 assistant reply, turn-2 user.
+	require.Len(t, prov.requests[1], 3, "turn 2 sees turn 1 as history plus its own user message")
+	assert.Equal(t, "first question", prov.requests[1][0].Content)
+	assert.Equal(t, roleAssistant, prov.requests[1][1].Role)
+	assert.Equal(t, "reply-1", prov.requests[1][1].Content)
+	assert.Equal(t, "second question", prov.requests[1][2].Content)
+}
+
+// TestProviderStage_Streaming_EmitsUserMessages verifies the user transcript for
+// each turn is forwarded downstream (so the save stage persists it), not just
+// the assistant reply. The provider drains its input, so it must re-emit the
+// turn's user messages itself.
+func TestProviderStage_Streaming_EmitsUserMessages(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	input := make(chan StreamElement, 4)
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "persist me"})
+	input <- NewEndOfTurnElement()
+	close(input)
+
+	output := make(chan StreamElement, 16)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	var roles []string
+	for e := range output {
+		if e.Message != nil {
+			roles = append(roles, e.Message.Role)
+		}
+	}
+	assert.Contains(t, roles, "user", "the turn's user message must be emitted downstream")
+	assert.Contains(t, roles, roleAssistant, "the assistant reply must be emitted downstream")
+}

--- a/runtime/pipeline/stage/stages_provider_streaming_test.go
+++ b/runtime/pipeline/stage/stages_provider_streaming_test.go
@@ -51,6 +51,185 @@ func (p *multiTurnRecordingProvider) PredictStream(
 	return ch, nil
 }
 
+// streamingRecordingProvider is the streaming counterpart of
+// multiTurnRecordingProvider: SupportsStreaming reports true so the stage takes
+// the executeStreamingMultiRound sub-path.
+type streamingRecordingProvider struct {
+	multiTurnRecordingProvider
+}
+
+func (p *streamingRecordingProvider) SupportsStreaming() bool { return true }
+
+func (p *streamingRecordingProvider) PredictStream(
+	_ context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	msgs := make([]types.Message, len(req.Messages))
+	copy(msgs, req.Messages)
+	p.requests = append(p.requests, msgs)
+	reply := fmt.Sprintf("reply-%d", len(p.requests))
+	ch := make(chan providers.StreamChunk, 1)
+	stop := "stop"
+	ch <- providers.StreamChunk{
+		Content:      reply,
+		Delta:        reply,
+		FinishReason: &stop,
+		FinalResult:  &providers.PredictionResponse{Content: reply},
+	}
+	close(ch)
+	return ch, nil
+}
+
+// erroringProvider always fails its Predict call, to exercise the turn-level
+// error path (the session must survive).
+type erroringProvider struct {
+	multiTurnRecordingProvider
+}
+
+func (p *erroringProvider) Predict(
+	_ context.Context, _ providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	return providers.PredictionResponse{}, fmt.Errorf("boom")
+}
+
+// TestProviderStage_Streaming_NilTurnState verifies streaming mode works when no
+// TurnState is wired (the ad-hoc construction path).
+func TestProviderStage_Streaming_NilTurnState(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	stage := NewProviderStage(prov, nil, nil, &ProviderConfig{Streaming: true})
+
+	input := make(chan StreamElement, 4)
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "hi"})
+	input <- NewEndOfTurnElement()
+	close(input)
+
+	output := make(chan StreamElement, 16)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	require.Len(t, prov.requests, 1)
+}
+
+// TestProviderStage_Streaming_EndOfStreamFires verifies an EndOfStream fires the
+// trailing turn (no explicit EndOfTurn needed) and then stops.
+func TestProviderStage_Streaming_EndOfStreamFires(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	input := make(chan StreamElement, 4)
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "last words"})
+	input <- NewEndOfStreamElement()
+	close(input)
+
+	output := make(chan StreamElement, 16)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	require.Len(t, prov.requests, 1, "EndOfStream fires the buffered turn")
+}
+
+// TestProviderStage_Streaming_ForwardsInterrupt verifies an Interrupt element is
+// passed through downstream (for the barge-in path), not swallowed.
+func TestProviderStage_Streaming_ForwardsInterrupt(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	input := make(chan StreamElement, 2)
+	input <- NewInterruptElement()
+	close(input)
+
+	output := make(chan StreamElement, 8)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	sawInterrupt := false
+	for e := range output {
+		if e.Interrupt {
+			sawInterrupt = true
+		}
+	}
+	assert.True(t, sawInterrupt, "Interrupt must be forwarded downstream")
+}
+
+// TestProviderStage_Streaming_EndOfTurnNoPending verifies an EndOfTurn with no
+// buffered messages is a no-op (no provider call, no panic).
+func TestProviderStage_Streaming_EndOfTurnNoPending(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	input := make(chan StreamElement, 2)
+	input <- NewEndOfTurnElement()
+	close(input)
+
+	output := make(chan StreamElement, 4)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	assert.Empty(t, prov.requests, "EndOfTurn with no pending input must not call the provider")
+}
+
+// TestProviderStage_Streaming_StreamingProvider verifies the streaming-provider
+// sub-path (executeStreamingMultiRound) produces a reply per turn.
+func TestProviderStage_Streaming_StreamingProvider(t *testing.T) {
+	prov := &streamingRecordingProvider{}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	input := make(chan StreamElement, 4)
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "stream turn"})
+	input <- NewEndOfTurnElement()
+	close(input)
+
+	output := make(chan StreamElement, 32)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	require.Len(t, prov.requests, 1)
+	var assistant []*types.Message
+	for e := range output {
+		if e.Message != nil && e.Message.Role == roleAssistant {
+			m := e.Message
+			assistant = append(assistant, m)
+		}
+	}
+	require.Len(t, assistant, 1, "streaming provider yields one assistant reply for the turn")
+	assert.Equal(t, "reply-1", assistant[0].Content)
+}
+
+// TestProviderStage_Streaming_TurnErrorSurvives verifies a failed turn emits an
+// error element but keeps the session alive for the next turn.
+func TestProviderStage_Streaming_TurnErrorSurvives(t *testing.T) {
+	prov := &erroringProvider{}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	input := make(chan StreamElement, 4)
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "will fail"})
+	input <- NewEndOfTurnElement()
+	close(input)
+
+	output := make(chan StreamElement, 8)
+	require.NoError(t, stage.Process(context.Background(), input, output), "a turn error must not tear down the session")
+
+	sawError := false
+	for e := range output {
+		if e.Error != nil {
+			sawError = true
+		}
+	}
+	assert.True(t, sawError, "a failed turn surfaces an error element")
+}
+
+// TestProviderStage_Streaming_ContextCancelled verifies sending honors context
+// cancellation while forwarding an element.
+func TestProviderStage_Streaming_ContextCancelled(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before processing
+
+	input := make(chan StreamElement, 1)
+	input <- NewInterruptElement() // routed to the forwarding (default) path
+	close(input)
+
+	output := make(chan StreamElement) // unbuffered: send blocks, ctx.Done wins
+	err := stage.Process(ctx, input, output)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 // TestProviderStage_Streaming_OneReplyPerTurn verifies that with Streaming
 // enabled, the provider fires once per EndOfTurn (not once at channel close),
 // emits an assistant reply per turn, and re-emits an EndOfTurn boundary after


### PR DESCRIPTION
## What

Adds `ProviderConfig.Streaming`. When enabled, `ProviderStage` runs a **continuous multi-turn loop** instead of the unary "drain the input channel, fire the LLM once at close" behaviour:

- Accumulate `Message` elements until an **`EndOfTurn`** control element arrives (the signal added in #1470).
- Fire the **existing** tool loop (`executeMultiRound` / `executeStreamingMultiRound`) on `history + this turn's messages`.
- Emit only this turn's **new** messages — the turn's user transcript (so the save stage persists it; the provider drains its input, so it must re-emit the user message itself) plus the assistant reply and any tool messages.
- Re-emit an **`EndOfTurn`** boundary downstream so TTS knows the turn ended.
- Thread conversation history across turns; stay open until the channel closes or an `EndOfStream` arrives.

A turn-level provider error is surfaced as an error element but **does not tear down the session** — a live conversation survives one failed turn. `Interrupt` and stray elements pass through, for the barge-in path (#1472).

## Why

Second PR of **epic #1469**. The composed-VAD voice path currently uses the unary provider stage, which batches every VAD turn and only replies at mic-close (finding from PR #1457). This adds the *when/how often the loop fires* without re-implementing the LLM call — single responsibility, no wrapping of STT/TTS.

## Blast radius

`Streaming` defaults to `false`, so every existing SDK and Arena pipeline keeps the fire-once-at-close behaviour byte-for-byte. The new code path is only taken when a caller opts in (the composed-VAD pipeline does so in #1473).

## Tests

New `stages_provider_streaming_test.go` with a recording provider:
- `TestProviderStage_Streaming_OneReplyPerTurn` — one provider call + one assistant reply + one `EndOfTurn` boundary per turn (not batched at close).
- `TestProviderStage_Streaming_ThreadsHistory` — turn 2's request carries turn 1 (user + assistant reply) as history.
- `TestProviderStage_Streaming_EmitsUserMessages` — the turn's user transcript is forwarded downstream for persistence.

Full `runtime/pipeline/stage` suite passes; changed file at 88.0% coverage.

Closes #1471
