### PR TITLE
feat(pipeline): barge-in / interrupt propagation path

### DIFF
--- a/runtime/pipeline/stage/audio_turn_stage_test.go
+++ b/runtime/pipeline/stage/audio_turn_stage_test.go
@@ -359,6 +359,14 @@ func TestAudioTurnStage_Interruption_ResetsState(t *testing.T) {
 	// Reset the handler to clear the interruption
 	handler.Reset()
 
+	// Barge-in emits an Interrupt element first.
+	select {
+	case elem := <-output:
+		assert.True(t, elem.Interrupt, "barge-in should emit an Interrupt element first")
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for Interrupt element")
+	}
+
 	// Send another chunk and close
 	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
 	close(input)
@@ -372,6 +380,37 @@ func TestAudioTurnStage_Interruption_ResetsState(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Timeout waiting for post-interruption audio")
 	}
+}
+
+func TestAudioTurnStage_EmitsInterruptOnBargeIn(t *testing.T) {
+	config := stage.DefaultAudioTurnConfig()
+	config.SilenceDuration = 10 * time.Second // Won't trigger via silence
+
+	// A single Speaking chunk while the bot is speaking is a barge-in.
+	mockVAD := &mockVADAnalyzer{
+		states: []audio.VADState{audio.VADStateSpeaking},
+	}
+	config.VAD = mockVAD
+
+	handler := audio.NewInterruptionHandler(audio.InterruptionImmediate, nil)
+	handler.SetBotSpeaking(true)
+	config.InterruptionHandler = handler
+
+	s, err := stage.NewAudioTurnStage(config)
+	require.NoError(t, err)
+
+	inputs := []stage.StreamElement{
+		makeAudioElement(generateTestPCMAudio(160), 16000),
+	}
+	results := runStage(t, s, inputs, 2*time.Second)
+
+	sawInterrupt := false
+	for _, r := range results {
+		if r.Interrupt {
+			sawInterrupt = true
+		}
+	}
+	assert.True(t, sawInterrupt, "barge-in (user speech while bot speaking) must emit an Interrupt element")
 }
 
 func TestAudioTurnStage_MultipleTurns(t *testing.T) {

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -284,13 +284,30 @@ func (s *ProviderStage) processStreaming(
 	output chan<- StreamElement,
 ) error {
 	cfg := s.streamingTurnState()
+
+	// A concurrent reader cancels in-flight generation the instant a barge-in
+	// Interrupt arrives, so a blocking provider call cannot swallow it.
+	canceller := newTurnCanceller(ctx)
+	defer canceller.stop()
+	work := make(chan StreamElement, interruptWorkBuffer)
+	go drainCancelingOnInterrupt(input, work, canceller)
+
 	var history []types.Message
 	var pending []types.Message
 
-	for elem := range input {
+	for elem := range work {
 		switch {
+		case elem.Interrupt:
+			// Barge-in: in-flight generation was already canceled out of band by
+			// the reader. Drop the partial turn's input, roll a fresh context,
+			// and forward the Interrupt downstream.
+			pending = nil
+			canceller.refresh()
+			if err := sendStreamElement(ctx, elem, output); err != nil {
+				return err
+			}
 		case elem.EndOfTurn:
-			next, err := s.fireIfPending(ctx, &history, pending, cfg, output)
+			next, err := s.fireIfPending(ctx, canceller.context(), &history, pending, cfg, output)
 			if err != nil {
 				return err
 			}
@@ -298,12 +315,12 @@ func (s *ProviderStage) processStreaming(
 		case elem.EndOfStream:
 			// Session over: fire any partial turn, then stop. Closing output
 			// downstream signals end-of-conversation to the next stages.
-			_, err := s.fireIfPending(ctx, &history, pending, cfg, output)
+			_, err := s.fireIfPending(ctx, canceller.context(), &history, pending, cfg, output)
 			return err
 		case elem.Message != nil:
 			pending = append(pending, *elem.Message)
 		default:
-			// Control signals (Interrupt) and any stray content pass through.
+			// Stray content passes through unchanged.
 			if err := sendStreamElement(ctx, elem, output); err != nil {
 				return err
 			}
@@ -311,14 +328,16 @@ func (s *ProviderStage) processStreaming(
 	}
 
 	// Input closed without an explicit EndOfStream: fire any trailing turn.
-	_, err := s.fireIfPending(ctx, &history, pending, cfg, output)
+	_, err := s.fireIfPending(ctx, canceller.context(), &history, pending, cfg, output)
 	return err
 }
 
 // fireIfPending fires a streaming turn when there is buffered input, returning
 // the reset pending slice. A no-op (returning pending unchanged) when empty.
+// forwardCtx carries the downstream emits; genCtx (cancelable per turn) governs
+// the provider call so a barge-in can abort it.
 func (s *ProviderStage) fireIfPending(
-	ctx context.Context,
+	forwardCtx, genCtx context.Context,
 	history *[]types.Message,
 	pending []types.Message,
 	cfg streamingConfig,
@@ -327,7 +346,7 @@ func (s *ProviderStage) fireIfPending(
 	if len(pending) == 0 {
 		return pending, nil
 	}
-	if err := s.fireStreamingTurn(ctx, history, pending, cfg, output); err != nil {
+	if err := s.fireStreamingTurn(forwardCtx, genCtx, history, pending, cfg, output); err != nil {
 		return pending, err
 	}
 	return nil, nil
@@ -337,11 +356,16 @@ func (s *ProviderStage) fireIfPending(
 // emits only this turn's new messages (the turn's user transcript plus the
 // assistant reply and any tool messages — the provider drains its input, so it
 // must re-emit the user messages itself for the save stage), advances history to
-// the full conversation, and emits an EndOfTurn boundary. A turn-level error is
-// surfaced as an error element but does not tear down the session — a live
-// conversation survives one failed turn.
+// the full conversation, and emits an EndOfTurn boundary.
+//
+// genCtx governs the provider call: a barge-in cancels it, which drops the turn
+// (no reply) without tearing down the session. A non-cancellation error is
+// surfaced as an error element but likewise keeps the session alive — a live
+// conversation survives one failed turn. forwardCtx carries the downstream emits
+// so a late interrupt that cancels genCtx after a successful generation does not
+// abort the emit.
 func (s *ProviderStage) fireStreamingTurn(
-	ctx context.Context,
+	forwardCtx, genCtx context.Context,
 	history *[]types.Message,
 	pending []types.Message,
 	cfg streamingConfig,
@@ -366,27 +390,31 @@ func (s *ProviderStage) fireStreamingTurn(
 	var full []types.Message
 	var err error
 	if s.provider.SupportsStreaming() {
-		full, err = s.executeStreamingMultiRound(ctx, acc, output)
+		full, err = s.executeStreamingMultiRound(genCtx, acc, output)
 	} else {
-		full, err = s.executeMultiRound(ctx, acc)
+		full, err = s.executeMultiRound(genCtx, acc)
 	}
 	if err != nil {
-		// Surface the failure but keep the session alive (return nil on a
-		// successful send; ctx cancellation still propagates).
+		if errors.Is(err, context.Canceled) {
+			// Barge-in (or shutdown) canceled this turn's generation; drop it.
+			// The session continues with a fresh context.
+			logger.Debug("ProviderStage streaming turn canceled (barge-in/shutdown), dropping")
+			return nil
+		}
 		logger.Error("ProviderStage streaming turn failed", "error", err)
-		return sendStreamElement(ctx, NewErrorElement(err), output)
+		return sendStreamElement(forwardCtx, NewErrorElement(err), output)
 	}
 
 	// full = (history + pending) + new assistant/tool messages. Emit everything
 	// after the prior history: this turn's user messages and the new reply.
 	if priorLen <= len(full) {
-		if emitErr := s.emitResponseMessages(ctx, full[priorLen:], output); emitErr != nil {
+		if emitErr := s.emitResponseMessages(forwardCtx, full[priorLen:], output); emitErr != nil {
 			return emitErr
 		}
 	}
 	*history = full
 
-	return sendStreamElement(ctx, NewEndOfTurnElement(), output)
+	return sendStreamElement(forwardCtx, NewEndOfTurnElement(), output)
 }
 
 // sendStreamElement forwards one element downstream, honoring cancellation.

--- a/runtime/pipeline/stage/stages_provider_streaming_test.go
+++ b/runtime/pipeline/stage/stages_provider_streaming_test.go
@@ -3,6 +3,7 @@ package stage
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -89,6 +90,55 @@ func (p *erroringProvider) Predict(
 	_ context.Context, _ providers.PredictionRequest,
 ) (providers.PredictionResponse, error) {
 	return providers.PredictionResponse{}, fmt.Errorf("boom")
+}
+
+// blockingProvider blocks in Predict until its context is cancelled, signaling
+// when generation is in-flight so a test can drive a barge-in mid-generation.
+type blockingProvider struct {
+	multiTurnRecordingProvider
+	started chan struct{}
+	once    sync.Once
+}
+
+func (p *blockingProvider) Predict(
+	ctx context.Context, _ providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.once.Do(func() { close(p.started) })
+	<-ctx.Done()
+	return providers.PredictionResponse{}, ctx.Err()
+}
+
+// TestProviderStage_Streaming_InterruptCancelsGeneration verifies a barge-in
+// Interrupt cancels in-flight provider generation: the turn is dropped (no
+// assistant reply), the Interrupt is forwarded, and the session survives.
+func TestProviderStage_Streaming_InterruptCancelsGeneration(t *testing.T) {
+	prov := &blockingProvider{started: make(chan struct{})}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	input := make(chan StreamElement)
+	output := make(chan StreamElement, 16)
+	done := make(chan error, 1)
+	go func() { done <- stage.Process(context.Background(), input, output) }()
+
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "hello"})
+	input <- NewEndOfTurnElement()
+	<-prov.started // generation is in-flight
+	input <- NewInterruptElement()
+	close(input)
+
+	require.NoError(t, <-done)
+
+	var assistant, interrupts int
+	for e := range output {
+		if e.Message != nil && e.Message.Role == roleAssistant {
+			assistant++
+		}
+		if e.Interrupt {
+			interrupts++
+		}
+	}
+	assert.Equal(t, 0, assistant, "interrupted generation must yield no assistant reply")
+	assert.Equal(t, 1, interrupts, "the Interrupt must be forwarded downstream")
 }
 
 // TestProviderStage_Streaming_NilTurnState verifies streaming mode works when no

--- a/runtime/pipeline/stage/stages_speech_integration.go
+++ b/runtime/pipeline/stage/stages_speech_integration.go
@@ -205,9 +205,11 @@ func (s *AudioTurnStage) processAudioElement(
 		return err
 	}
 
-	// Check for interruption
+	// Check for interruption (barge-in): user spoke while the bot was talking.
+	// Emit an Interrupt control element so the provider and TTS stages cancel
+	// in-flight generation/playback, then drop the partial turn.
 	if s.checkInterruption(ctx, state) {
-		return nil
+		return s.emitInterrupt(ctx, output)
 	}
 
 	// Check if turn is complete
@@ -218,6 +220,18 @@ func (s *AudioTurnStage) processAudioElement(
 		s.resetState(state)
 	}
 	return nil
+}
+
+// emitInterrupt sends an Interrupt control element downstream so the provider
+// and TTS stages can cancel in-flight generation and playback on barge-in.
+func (s *AudioTurnStage) emitInterrupt(ctx context.Context, output chan<- StreamElement) error {
+	logger.Debug("AudioTurnStage: barge-in detected, emitting Interrupt")
+	select {
+	case output <- NewInterruptElement():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // checkInterruption checks for user interruption and resets state if detected.

--- a/runtime/pipeline/stage/stages_speech_integration.go
+++ b/runtime/pipeline/stage/stages_speech_integration.go
@@ -2,9 +2,11 @@ package stage
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
@@ -602,8 +604,70 @@ func NewTTSStageWithInterruption(
 	}
 }
 
+// ttsWorkBuffer bounds the in-flight element queue between the input reader and
+// the synthesis loop. A barge-in Interrupt cancels in-flight synthesis out of
+// band (see readTTSInput), so this buffer only needs to absorb a single
+// assistant turn's worth of elements — far below this bound in practice.
+const ttsWorkBuffer = 64
+
+// synthCanceller hands the synthesis loop a cancelable child of the pipeline
+// context and lets a barge-in cancel the in-flight synthesis from another
+// goroutine. refresh() rolls a fresh context for the next turn after an
+// interrupt; the canceled context drops both the in-flight call and any text
+// already queued behind it (their context is already done).
+type synthCanceller struct {
+	parent context.Context
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newSynthCanceller(parent context.Context) *synthCanceller {
+	c := &synthCanceller{parent: parent}
+	c.refresh()
+	return c
+}
+
+// refresh cancels the current synthesis context (if any) and starts a new one.
+func (c *synthCanceller) refresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.ctx, c.cancel = context.WithCancel(c.parent)
+}
+
+// interrupt cancels the in-flight synthesis context without rolling a new one.
+func (c *synthCanceller) interrupt() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+// context returns the current synthesis context.
+func (c *synthCanceller) context() context.Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ctx
+}
+
+// stop releases the final context on shutdown.
+func (c *synthCanceller) stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
 // Process implements the Stage interface.
-// Synthesizes audio for text elements with interruption support.
+// Synthesizes audio for text elements with interruption support. A concurrent
+// reader cancels in-flight synthesis the instant a barge-in Interrupt arrives,
+// so a long synthesis call cannot swallow the interrupt; queued text behind the
+// interrupt is dropped too, and synthesis resumes on the next turn.
 func (s *TTSStageWithInterruption) Process(
 	ctx context.Context,
 	input <-chan StreamElement,
@@ -611,8 +675,24 @@ func (s *TTSStageWithInterruption) Process(
 ) error {
 	defer close(output)
 
-	for elem := range input {
-		if err := s.processElement(ctx, &elem, output); err != nil {
+	canceller := newSynthCanceller(ctx)
+	defer canceller.stop()
+
+	work := make(chan StreamElement, ttsWorkBuffer)
+	go readTTSInput(input, work, canceller)
+
+	for elem := range work {
+		if elem.Interrupt {
+			// In-flight synthesis was already canceled out of band by the
+			// reader. Roll a fresh context for the next turn and forward the
+			// Interrupt downstream so playback can flush too.
+			canceller.refresh()
+			if err := s.forwardElement(ctx, elem, output); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := s.processElement(ctx, canceller.context(), &elem, output); err != nil {
 			return err
 		}
 	}
@@ -620,22 +700,41 @@ func (s *TTSStageWithInterruption) Process(
 	return nil
 }
 
-// processElement handles a single element in the TTS pipeline.
+// readTTSInput drains input into work, canceling any in-flight synthesis the
+// instant an Interrupt arrives (out of band) so a barge-in preempts a synthesis
+// call that would otherwise block the loop. Order is preserved: the Interrupt is
+// still forwarded through work so the synthesis loop refreshes the context and
+// emits it downstream.
+func readTTSInput(input <-chan StreamElement, work chan<- StreamElement, c *synthCanceller) {
+	defer close(work)
+	for elem := range input {
+		if elem.Interrupt {
+			c.interrupt()
+		}
+		work <- elem
+	}
+}
+
+// processElement handles a single element in the TTS pipeline. forwardCtx (the
+// pipeline context) carries pass-through of non-synthesizable elements; synthCtx
+// (cancelable per turn) governs synthesis so a barge-in can abort it. They
+// differ only in the window after an interrupt cancels synthCtx but before the
+// loop refreshes it — forwarding a queued control element must not fail then.
 func (s *TTSStageWithInterruption) processElement(
-	ctx context.Context,
+	forwardCtx, synthCtx context.Context,
 	elem *StreamElement,
 	output chan<- StreamElement,
 ) error {
 	text := s.extractText(elem)
 	if text == "" {
-		return s.forwardElement(ctx, *elem, output)
+		return s.forwardElement(forwardCtx, *elem, output)
 	}
 
 	if s.shouldSkipText(text) {
 		return nil
 	}
 
-	return s.synthesizeAndEmit(ctx, text, elem, output)
+	return s.synthesizeAndEmit(synthCtx, text, elem, output)
 }
 
 // shouldSkipText checks if text should be skipped based on config.
@@ -733,14 +832,21 @@ func (s *TTSStageWithInterruption) performSynthesis(
 }
 
 // handleSynthesisError handles synthesis errors and emits error element.
+// A context cancellation means a barge-in interrupt (or pipeline shutdown)
+// aborted the synthesis — that audio is intentionally dropped, not an error to
+// surface downstream.
 func (s *TTSStageWithInterruption) handleSynthesisError(
 	ctx context.Context,
 	err error,
 	elem *StreamElement,
 	output chan<- StreamElement,
 ) error {
-	logger.Error("TTSStageWithInterruption: synthesis failed", "error", err)
 	s.setBotSpeaking(false)
+	if errors.Is(err, context.Canceled) {
+		logger.Debug("TTSStageWithInterruption: synthesis canceled (barge-in/shutdown), dropping output")
+		return nil
+	}
+	logger.Error("TTSStageWithInterruption: synthesis failed", "error", err)
 	elem.Error = err
 	return s.forwardElement(ctx, *elem, output)
 }

--- a/runtime/pipeline/stage/stages_speech_integration.go
+++ b/runtime/pipeline/stage/stages_speech_integration.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
@@ -604,65 +603,6 @@ func NewTTSStageWithInterruption(
 	}
 }
 
-// ttsWorkBuffer bounds the in-flight element queue between the input reader and
-// the synthesis loop. A barge-in Interrupt cancels in-flight synthesis out of
-// band (see readTTSInput), so this buffer only needs to absorb a single
-// assistant turn's worth of elements — far below this bound in practice.
-const ttsWorkBuffer = 64
-
-// synthCanceller hands the synthesis loop a cancelable child of the pipeline
-// context and lets a barge-in cancel the in-flight synthesis from another
-// goroutine. refresh() rolls a fresh context for the next turn after an
-// interrupt; the canceled context drops both the in-flight call and any text
-// already queued behind it (their context is already done).
-type synthCanceller struct {
-	parent context.Context
-	mu     sync.Mutex
-	ctx    context.Context
-	cancel context.CancelFunc
-}
-
-func newSynthCanceller(parent context.Context) *synthCanceller {
-	c := &synthCanceller{parent: parent}
-	c.refresh()
-	return c
-}
-
-// refresh cancels the current synthesis context (if any) and starts a new one.
-func (c *synthCanceller) refresh() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.cancel != nil {
-		c.cancel()
-	}
-	c.ctx, c.cancel = context.WithCancel(c.parent)
-}
-
-// interrupt cancels the in-flight synthesis context without rolling a new one.
-func (c *synthCanceller) interrupt() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.cancel != nil {
-		c.cancel()
-	}
-}
-
-// context returns the current synthesis context.
-func (c *synthCanceller) context() context.Context {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.ctx
-}
-
-// stop releases the final context on shutdown.
-func (c *synthCanceller) stop() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.cancel != nil {
-		c.cancel()
-	}
-}
-
 // Process implements the Stage interface.
 // Synthesizes audio for text elements with interruption support. A concurrent
 // reader cancels in-flight synthesis the instant a barge-in Interrupt arrives,
@@ -675,11 +615,11 @@ func (s *TTSStageWithInterruption) Process(
 ) error {
 	defer close(output)
 
-	canceller := newSynthCanceller(ctx)
+	canceller := newTurnCanceller(ctx)
 	defer canceller.stop()
 
-	work := make(chan StreamElement, ttsWorkBuffer)
-	go readTTSInput(input, work, canceller)
+	work := make(chan StreamElement, interruptWorkBuffer)
+	go drainCancelingOnInterrupt(input, work, canceller)
 
 	for elem := range work {
 		if elem.Interrupt {
@@ -698,21 +638,6 @@ func (s *TTSStageWithInterruption) Process(
 	}
 
 	return nil
-}
-
-// readTTSInput drains input into work, canceling any in-flight synthesis the
-// instant an Interrupt arrives (out of band) so a barge-in preempts a synthesis
-// call that would otherwise block the loop. Order is preserved: the Interrupt is
-// still forwarded through work so the synthesis loop refreshes the context and
-// emits it downstream.
-func readTTSInput(input <-chan StreamElement, work chan<- StreamElement, c *synthCanceller) {
-	defer close(work)
-	for elem := range input {
-		if elem.Interrupt {
-			c.interrupt()
-		}
-		work <- elem
-	}
 }
 
 // processElement handles a single element in the TTS pipeline. forwardCtx (the

--- a/runtime/pipeline/stage/tts_interruption_stage_test.go
+++ b/runtime/pipeline/stage/tts_interruption_stage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -89,6 +90,83 @@ func TestTTSStageWithInterruption_MultipleTexts(t *testing.T) {
 	}
 	assert.Equal(t, 3, audioCount, "Expected 3 audio outputs")
 	assert.Equal(t, 3, synthesizeCount, "Expected 3 synthesize calls")
+}
+
+func TestTTSStageWithInterruption_DropsInFlightOnInterrupt(t *testing.T) {
+	started := make(chan struct{})
+	mock := &mockTTSService{
+		synthesizeFunc: func(ctx context.Context, _ string, _ tts.SynthesisConfig) (io.ReadCloser, error) {
+			close(started)
+			<-ctx.Done() // block until barge-in cancels the synthesis context
+			return nil, ctx.Err()
+		},
+	}
+	s := stage.NewTTSStageWithInterruption(mock, stage.DefaultTTSStageWithInterruptionConfig())
+
+	input := make(chan stage.StreamElement)
+	output := make(chan stage.StreamElement, 16)
+	done := make(chan error, 1)
+	go func() { done <- s.Process(context.Background(), input, output) }()
+
+	input <- makeTextElement("hello, this is the bot speaking at length")
+	<-started // synthesis is in-flight
+	input <- stage.NewInterruptElement()
+	close(input)
+
+	require.NoError(t, <-done)
+
+	var audioCount, interruptCount int
+	for e := range output {
+		if e.Audio != nil {
+			audioCount++
+		}
+		if e.Interrupt {
+			interruptCount++
+		}
+	}
+	assert.Equal(t, 0, audioCount, "in-flight audio must be dropped on barge-in")
+	assert.Equal(t, 1, interruptCount, "the Interrupt must be forwarded downstream")
+}
+
+func TestTTSStageWithInterruption_SynthesizesAfterInterrupt(t *testing.T) {
+	var calls int32
+	firstStarted := make(chan struct{})
+	mock := &mockTTSService{
+		synthesizeFunc: func(ctx context.Context, _ string, _ tts.SynthesisConfig) (io.ReadCloser, error) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				close(firstStarted)
+				<-ctx.Done() // first turn: interrupted
+				return nil, ctx.Err()
+			}
+			return io.NopCloser(strings.NewReader("second-turn-audio")), nil
+		},
+	}
+	s := stage.NewTTSStageWithInterruption(mock, stage.DefaultTTSStageWithInterruptionConfig())
+
+	input := make(chan stage.StreamElement)
+	output := make(chan stage.StreamElement, 16)
+	done := make(chan error, 1)
+	go func() { done <- s.Process(context.Background(), input, output) }()
+
+	input <- makeTextElement("first reply, interrupted")
+	<-firstStarted
+	input <- stage.NewInterruptElement()
+	input <- makeTextElement("second reply, after barge-in")
+	close(input)
+
+	require.NoError(t, <-done)
+
+	var audioCount, interruptCount int
+	for e := range output {
+		if e.Audio != nil {
+			audioCount++
+		}
+		if e.Interrupt {
+			interruptCount++
+		}
+	}
+	assert.Equal(t, 1, interruptCount, "the Interrupt is forwarded")
+	assert.Equal(t, 1, audioCount, "synthesis resumes with a fresh context after the interrupt")
 }
 
 func TestTTSStageWithInterruption_ExtractText_FromMessage(t *testing.T) {

--- a/runtime/pipeline/stage/turn_canceller.go
+++ b/runtime/pipeline/stage/turn_canceller.go
@@ -1,0 +1,84 @@
+package stage
+
+import (
+	"context"
+	"sync"
+)
+
+// interruptWorkBuffer bounds the in-flight element queue between an input reader
+// goroutine and a stage's processing loop in the barge-in pattern. An Interrupt
+// cancels the in-flight turn out of band (see drainCancelingOnInterrupt), so this
+// buffer only needs to absorb a single turn's worth of elements — far below this
+// bound in practice.
+const interruptWorkBuffer = 64
+
+// turnCanceller hands a stage's processing loop a cancelable child of the
+// pipeline context and lets a barge-in cancel the in-flight turn from a separate
+// reader goroutine. It is shared by the stages that must preempt a blocking call
+// (provider generation, TTS synthesis) when an Interrupt arrives.
+//
+// refresh() rolls a fresh context for the next turn after an interrupt; the
+// canceled context drops both the in-flight call and any work already queued
+// behind it (their context is already done).
+type turnCanceller struct {
+	parent context.Context
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newTurnCanceller(parent context.Context) *turnCanceller {
+	c := &turnCanceller{parent: parent}
+	c.refresh()
+	return c
+}
+
+// refresh cancels the current turn context (if any) and starts a new one.
+func (c *turnCanceller) refresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.ctx, c.cancel = context.WithCancel(c.parent)
+}
+
+// interrupt cancels the in-flight turn context without rolling a new one.
+func (c *turnCanceller) interrupt() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+// context returns the current turn context.
+func (c *turnCanceller) context() context.Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ctx
+}
+
+// stop releases the final context on shutdown.
+func (c *turnCanceller) stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+// drainCancelingOnInterrupt drains input into work, canceling the in-flight turn
+// the instant an Interrupt arrives (out of band) so a barge-in preempts a
+// blocking call (generation/synthesis) that would otherwise hold the loop. Order
+// is preserved: the Interrupt is still forwarded through work so the loop can
+// refresh the context and emit it downstream.
+func drainCancelingOnInterrupt(input <-chan StreamElement, work chan<- StreamElement, c *turnCanceller) {
+	defer close(work)
+	for elem := range input {
+		if elem.Interrupt {
+			c.interrupt()
+		}
+		work <- elem
+	}
+}


### PR DESCRIPTION
## What

Implements barge-in (interruption) for the composed-VAD voice path — the third PR of **epic #1469**. Builds on the `Interrupt` control signal (#1470) and the streaming provider stage (#1471). Three parts:

1. **AudioTurnStage emits `Interrupt` on barge-in** — when the user speaks while the bot is still talking (VAD speech-start + bot speaking, per the shared `InterruptionHandler` policy), the stage emits an `Interrupt` control element downstream instead of only silently resetting.

2. **TTS drops in-flight + queued audio on `Interrupt`** — `TTSStageWithInterruption` runs a concurrent reader that cancels the in-flight synthesis context the instant an `Interrupt` arrives, so a long `Synthesize` call can no longer swallow the barge-in. Text queued behind the interrupt is dropped too; synthesis resumes with a fresh context on the next turn. A context cancellation is treated as an intentional drop, not an error.

3. **Streaming provider cancels in-flight generation on `Interrupt`** — same concurrent-reader pattern: a barge-in cancels the generation context, the turn is dropped (no reply), the `Interrupt` is forwarded, and the session continues.

The cancellation machinery is extracted into a shared **`turnCanceller`** (+ `drainCancelingOnInterrupt`) reused by both stages.

## Why this design

An in-channel `Interrupt` element alone can't preempt a stage blocked in `Synthesize`/`Predict` — it queues behind the in-flight work. So each stage spawns a concurrent reader that cancels a per-turn `context.WithCancel` out of band (the proven `DuplexProviderStage` pattern). Generation/synthesis use the cancelable context; downstream emits use the pipeline context, so a late interrupt after a successful call doesn't abort the emit.

## Echo caveat

Barge-in needs the mic open during agent output → works on headphones / with AEC. Under `--echo-guard` (laptop speakers) the mic is gated during output, so the `InterruptionHandler` policy is effectively `Ignore` until real acoustic echo cancellation (e.g. Krisp) is wired at the `VADAnalyzer` seam. This PR adds the mechanism; #1473 wires the shared handler into the composed pipeline.

## Tests

- `TestAudioTurnStage_EmitsInterruptOnBargeIn` + updated `..._Interruption_ResetsState`.
- `TestTTSStageWithInterruption_DropsInFlightOnInterrupt`, `..._SynthesizesAfterInterrupt`.
- `TestProviderStage_Streaming_InterruptCancelsGeneration`.
- All run under `-race`; `turnCanceller` at 100%, changed files ≥89% coverage; full `runtime/pipeline/stage` suite green.

Closes #1472
