### PR TITLE
feat(arena): composed-VAD pipeline as continuous conversation + integration test

### DIFF
--- a/runtime/pipeline/stage/audio_turn_stage_test.go
+++ b/runtime/pipeline/stage/audio_turn_stage_test.go
@@ -413,6 +413,108 @@ func TestAudioTurnStage_EmitsInterruptOnBargeIn(t *testing.T) {
 	assert.True(t, sawInterrupt, "barge-in (user speech while bot speaking) must emit an Interrupt element")
 }
 
+func TestAudioTurnStage_EmitsEndOfTurnAfterTurn(t *testing.T) {
+	config := stage.DefaultAudioTurnConfig()
+	config.EmitEndOfTurn = true
+	config.SilenceDuration = 30 * time.Millisecond
+	config.MinSpeechDuration = 10 * time.Millisecond
+
+	mockVAD := &mockVADAnalyzer{
+		states: []audio.VADState{
+			audio.VADStateSpeaking, // chunk1
+			audio.VADStateStopping, // chunk2 — silenceStart set
+			audio.VADStateQuiet,    // chunk3 — turn completes
+		},
+	}
+	config.VAD = mockVAD
+
+	s, err := stage.NewAudioTurnStage(config)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	input := make(chan stage.StreamElement, 10)
+	output := make(chan stage.StreamElement, 10)
+	go func() { _ = s.Process(ctx, input, output) }()
+
+	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
+	time.Sleep(20 * time.Millisecond)
+	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
+	time.Sleep(35 * time.Millisecond) // let SilenceDuration elapse
+	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
+	close(input)
+
+	var sawAudio, sawEndOfTurn, audioBeforeEOT bool
+	timeout := time.After(time.Second)
+loop:
+	for {
+		select {
+		case elem, ok := <-output:
+			if !ok {
+				break loop
+			}
+			if elem.Audio != nil {
+				sawAudio = true
+			}
+			if elem.EndOfTurn {
+				sawEndOfTurn = true
+				if sawAudio {
+					audioBeforeEOT = true
+				}
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+
+	assert.True(t, sawAudio, "turn audio should be emitted")
+	assert.True(t, sawEndOfTurn, "EndOfTurn should be emitted after a completed turn")
+	assert.True(t, audioBeforeEOT, "EndOfTurn should follow the turn audio")
+}
+
+func TestAudioTurnStage_NoEndOfTurnByDefault(t *testing.T) {
+	config := stage.DefaultAudioTurnConfig() // EmitEndOfTurn defaults false
+	config.SilenceDuration = 30 * time.Millisecond
+	config.MinSpeechDuration = 10 * time.Millisecond
+
+	mockVAD := &mockVADAnalyzer{
+		states: []audio.VADState{
+			audio.VADStateSpeaking, audio.VADStateStopping, audio.VADStateQuiet,
+		},
+	}
+	config.VAD = mockVAD
+
+	s, err := stage.NewAudioTurnStage(config)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	input := make(chan stage.StreamElement, 10)
+	output := make(chan stage.StreamElement, 10)
+	go func() { _ = s.Process(ctx, input, output) }()
+
+	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
+	time.Sleep(20 * time.Millisecond)
+	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
+	time.Sleep(35 * time.Millisecond)
+	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
+	close(input)
+
+	timeout := time.After(time.Second)
+loop:
+	for {
+		select {
+		case elem, ok := <-output:
+			if !ok {
+				break loop
+			}
+			assert.False(t, elem.EndOfTurn, "no EndOfTurn should be emitted when EmitEndOfTurn is false")
+		case <-timeout:
+			break loop
+		}
+	}
+}
+
 func TestAudioTurnStage_MultipleTurns(t *testing.T) {
 	config := stage.DefaultAudioTurnConfig()
 	// SilenceDuration=30ms. Turn completion fires when a new chunk arrives after

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -283,8 +283,6 @@ func (s *ProviderStage) processStreaming(
 	input <-chan StreamElement,
 	output chan<- StreamElement,
 ) error {
-	cfg := s.streamingTurnState()
-
 	// A concurrent reader cancels in-flight generation the instant a barge-in
 	// Interrupt arrives, so a blocking provider call cannot swallow it.
 	canceller := newTurnCanceller(ctx)
@@ -307,7 +305,7 @@ func (s *ProviderStage) processStreaming(
 				return err
 			}
 		case elem.EndOfTurn:
-			next, err := s.fireIfPending(ctx, canceller.context(), &history, pending, cfg, output)
+			next, err := s.fireIfPending(ctx, canceller.context(), &history, pending, output)
 			if err != nil {
 				return err
 			}
@@ -315,7 +313,7 @@ func (s *ProviderStage) processStreaming(
 		case elem.EndOfStream:
 			// Session over: fire any partial turn, then stop. Closing output
 			// downstream signals end-of-conversation to the next stages.
-			_, err := s.fireIfPending(ctx, canceller.context(), &history, pending, cfg, output)
+			_, err := s.fireIfPending(ctx, canceller.context(), &history, pending, output)
 			return err
 		case elem.Message != nil:
 			pending = append(pending, *elem.Message)
@@ -328,7 +326,7 @@ func (s *ProviderStage) processStreaming(
 	}
 
 	// Input closed without an explicit EndOfStream: fire any trailing turn.
-	_, err := s.fireIfPending(ctx, canceller.context(), &history, pending, cfg, output)
+	_, err := s.fireIfPending(ctx, canceller.context(), &history, pending, output)
 	return err
 }
 
@@ -340,13 +338,12 @@ func (s *ProviderStage) fireIfPending(
 	forwardCtx, genCtx context.Context,
 	history *[]types.Message,
 	pending []types.Message,
-	cfg streamingConfig,
 	output chan<- StreamElement,
 ) ([]types.Message, error) {
 	if len(pending) == 0 {
 		return pending, nil
 	}
-	if err := s.fireStreamingTurn(forwardCtx, genCtx, history, pending, cfg, output); err != nil {
+	if err := s.fireStreamingTurn(forwardCtx, genCtx, history, pending, output); err != nil {
 		return pending, err
 	}
 	return nil, nil
@@ -368,9 +365,14 @@ func (s *ProviderStage) fireStreamingTurn(
 	forwardCtx, genCtx context.Context,
 	history *[]types.Message,
 	pending []types.Message,
-	cfg streamingConfig,
 	output chan<- StreamElement,
 ) error {
+	// Read the per-session invariants here, not before the loop: upstream
+	// prompt/template stages write TurnState lazily as elements flow, and this
+	// turn's messages have already passed through them by fire time, so the read
+	// is safely ordered after those writes (channel happens-before).
+	cfg := s.streamingTurnState()
+
 	priorLen := len(*history)
 	messages := make([]types.Message, 0, priorLen+len(pending))
 	messages = append(messages, *history...)

--- a/runtime/pipeline/stage/stages_speech_integration.go
+++ b/runtime/pipeline/stage/stages_speech_integration.go
@@ -45,6 +45,12 @@ type AudioTurnConfig struct {
 	// SampleRate is the audio sample rate for output AudioData.
 	// Default: 16000
 	SampleRate int
+
+	// EmitEndOfTurn, when true, emits an EndOfTurn control element after each
+	// completed turn's audio. The streaming (continuous multi-turn) composed-VAD
+	// pipeline sets this so the streaming provider stage fires once per turn.
+	// Default false preserves single-shot behavior for every other consumer.
+	EmitEndOfTurn bool
 }
 
 const (
@@ -219,8 +225,27 @@ func (s *AudioTurnStage) processAudioElement(
 			return err
 		}
 		s.resetState(state)
+		// Mark the conversational turn boundary so the streaming provider stage
+		// fires this turn. The trailing turn at stream close is fired by the
+		// EndOfStream that follows, so it is not marked here.
+		if s.config.EmitEndOfTurn {
+			if err := s.emitEndOfTurn(ctx, output); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
+}
+
+// emitEndOfTurn sends an EndOfTurn control element downstream, marking the end
+// of one conversational turn's input within the still-open session.
+func (s *AudioTurnStage) emitEndOfTurn(ctx context.Context, output chan<- StreamElement) error {
+	select {
+	case output <- NewEndOfTurnElement():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // emitInterrupt sends an Interrupt control element downstream so the provider

--- a/tools/arena/engine/duplex_interactive.go
+++ b/tools/arena/engine/duplex_interactive.go
@@ -368,7 +368,11 @@ func (de *DuplexConversationExecutor) buildVADComposedPipeline(
 // "quiet mic" environments where SimpleVAD's fixed threshold would miss speech.
 func (de *DuplexConversationExecutor) buildInteractiveVADConfig(req *ConversationRequest) stage.AudioTurnConfig {
 	if req.Scenario != nil && req.Scenario.Duplex != nil {
-		return de.buildVADConfig(req)
+		cfg := de.buildVADConfig(req)
+		if req.vadOverride != nil {
+			cfg.VAD = req.vadOverride
+		}
+		return cfg
 	}
 
 	cfg := stage.DefaultAudioTurnConfig()

--- a/tools/arena/engine/duplex_interactive.go
+++ b/tools/arena/engine/duplex_interactive.go
@@ -282,8 +282,21 @@ func (de *DuplexConversationExecutor) buildVADComposedPipeline(
 	builder := stage.NewPipelineBuilderWithConfig(
 		stage.DefaultPipelineConfig().WithExecutionTimeout(0),
 	)
-	// 1. VAD turn segmentation: N audio chunks → 1 audio utterance.
-	vadStage, err := stage.NewAudioTurnStage(de.buildInteractiveVADConfig(req))
+
+	// Shared interruption handler coordinates barge-in across the AudioTurn and
+	// TTS stages: TTS marks when the bot is speaking, AudioTurn fires an Interrupt
+	// when the user speaks over it. Immediate strategy — under --echo-guard the
+	// driver gates the mic during output, so no speech reaches AudioTurn and
+	// barge-in is naturally suppressed without changing the strategy here.
+	interruptionHandler := audio.NewInterruptionHandler(audio.InterruptionImmediate, nil)
+
+	// 1. VAD turn segmentation: N audio chunks → 1 audio utterance, emitting an
+	// EndOfTurn boundary per turn (so the streaming provider fires per turn) and
+	// an Interrupt on barge-in.
+	vadCfg := de.buildInteractiveVADConfig(req)
+	vadCfg.EmitEndOfTurn = true
+	vadCfg.InterruptionHandler = interruptionHandler
+	vadStage, err := stage.NewAudioTurnStage(vadCfg)
 	if err != nil {
 		return nil, fmt.Errorf("audio turn stage: %w", err)
 	}
@@ -308,7 +321,7 @@ func (de *DuplexConversationExecutor) buildVADComposedPipeline(
 		stage.NewPromptAssemblyStageWithTurnState(de.promptRegistry, taskType, mergedVars, turnState),
 		stage.NewTemplateStageWithTurnState(nil, turnState),
 		stage.NewProviderStageWithTurnState(
-			req.Provider, de.toolRegistry, nil, &stage.ProviderConfig{}, emitter, nil, turnState,
+			req.Provider, de.toolRegistry, nil, &stage.ProviderConfig{Streaming: true}, emitter, nil, turnState,
 		),
 	}
 
@@ -332,10 +345,14 @@ func (de *DuplexConversationExecutor) buildVADComposedPipeline(
 	// assistant Messages carry text the TTS stage should synthesize; forwarding
 	// user/system/tool Messages would cause the pipeline to speak the user's own
 	// words back at them.
-	// 7. TTS: assistant text → audio for playback.
+	// 7. TTS: assistant text → audio for playback. Shares the interruption
+	// handler with the AudioTurn stage so it knows when the bot is speaking and
+	// drops in-flight audio on barge-in.
+	ttsCfg := de.buildInteractiveTTSConfig(req)
+	ttsCfg.InterruptionHandler = interruptionHandler
 	stages = append(stages,
 		arenastages.NewAssistantTTSFilterStage(),
-		stage.NewTTSStageWithInterruption(ttsSvc, de.buildInteractiveTTSConfig(req)),
+		stage.NewTTSStageWithInterruption(ttsSvc, ttsCfg),
 	)
 
 	return builder.Chain(stages...).Build()

--- a/tools/arena/engine/duplex_interactive_multiturn_test.go
+++ b/tools/arena/engine/duplex_interactive_multiturn_test.go
@@ -1,0 +1,197 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/selfplay"
+	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
+)
+
+// scriptedVAD is a deterministic audio.VADAnalyzer for the continuous
+// multi-turn integration test. It plays back a fixed state sequence (one state
+// per Analyze call) so turn boundaries are exact rather than dependent on the
+// real VAD's threshold behavior over synthetic audio. Reset clears only the
+// current state — the index advances linearly across turns, so the script
+// describes the whole session.
+type scriptedVAD struct {
+	mu     sync.Mutex
+	states []audio.VADState
+	idx    int
+	cur    audio.VADState
+}
+
+func (v *scriptedVAD) Name() string { return "scripted-vad" }
+
+func (v *scriptedVAD) Analyze(_ context.Context, _ []byte) (float64, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.idx < len(v.states) {
+		v.cur = v.states[v.idx]
+		v.idx++
+	} else {
+		v.cur = audio.VADStateQuiet
+	}
+	return 0, nil
+}
+
+func (v *scriptedVAD) State() audio.VADState {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.cur
+}
+
+func (v *scriptedVAD) OnStateChange() <-chan audio.VADEvent { return nil }
+
+func (v *scriptedVAD) Reset() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.cur = audio.VADStateQuiet
+}
+
+// countRoles returns how many messages carry each of the user / assistant roles.
+func countRoles(msgs []types.Message) (users, assistants int) {
+	for i := range msgs {
+		switch string(msgs[i].Role) {
+		case "user":
+			users++
+		case "assistant":
+			assistants++
+		}
+	}
+	return users, assistants
+}
+
+// newDuplexTestExecutorMultiTurn builds the composed-VAD executor with a
+// scripted VAD injected (req.vadOverride) and a short silence threshold, so the
+// AudioTurn stage produces exact turn boundaries. The text mock provider returns
+// a reply on every Predict call, so each fired turn yields an assistant message.
+func newDuplexTestExecutorMultiTurn(
+	t *testing.T, vad *scriptedVAD,
+) (*DuplexConversationExecutor, *ConversationRequest, *statestore.ArenaStateStore) {
+	t.Helper()
+
+	textProvider := mock.NewProvider("test-mock-multiturn", "mock-model", false)
+
+	reg := selfplay.NewRegistry(nil, nil, nil, nil)
+	reg.GetTTSRegistry().Register(selfplay.TTSProviderMock, selfplay.NewMockTTS())
+	reg.GetSTTRegistry().Register("fake-stt-mt", &fakeSTTService{transcript: "hello there"})
+
+	executor := NewDuplexConversationExecutor(reg, nil, nil, nil, nil)
+	store := statestore.NewArenaStateStore()
+
+	sttProvider := &config.Provider{ID: "fake-stt-mt", Type: "fake-stt-mt", Role: config.RoleSTT}
+	ttsProvider := &config.Provider{ID: "mock-tts-mt", Type: selfplay.TTSProviderMock, Role: config.RoleTTS}
+
+	scenario := &config.Scenario{
+		ID: "interactive-voice-multiturn-test",
+		Duplex: &config.DuplexConfig{
+			Timeout: "10s",
+			TurnDetection: &config.TurnDetectionConfig{
+				Mode: config.TurnDetectionModeVAD,
+				VAD: &config.VADConfig{
+					SilenceThresholdMs: 20, // short so turns complete quickly + deterministically
+					MinSpeechMs:        5,
+				},
+			},
+		},
+		Turns: []config.TurnDefinition{},
+	}
+
+	cfg := &config.Config{
+		LoadedProviders:    map[string]*config.Provider{},
+		LoadedTTSProviders: map[string]*config.Provider{"mock-tts-mt": ttsProvider},
+		Voices:             []config.VoiceBinding{{ID: "mock-tts-mt", Provider: "mock-tts-mt"}},
+	}
+
+	req := &ConversationRequest{
+		Provider:         textProvider,
+		Scenario:         scenario,
+		Config:           cfg,
+		RunID:            "test-run-multiturn",
+		ConversationID:   "test-conv-multiturn",
+		VoiceSTT:         sttProvider,
+		VoiceOutputVoice: "mock-tts-mt",
+		StateStoreConfig: &StateStoreConfig{Store: store},
+		vadOverride:      vad,
+	}
+
+	return executor, req, store
+}
+
+// TestRunInteractiveVoice_VAD_ContinuousMultiTurn drives speech → silence →
+// speech → silence through the REAL composed-VAD pipeline (scripted VAD, mock
+// STT/LLM/TTS, no live keys) and asserts a reply PER turn: two user transcripts
+// and two assistant messages materialize via the save stage. This exercises the
+// continuous multi-turn behavior delivered by epic #1469 — the streaming
+// provider firing once per EndOfTurn rather than batching every turn until the
+// mic closes (the bug from PR #1457).
+func TestRunInteractiveVoice_VAD_ContinuousMultiTurn(t *testing.T) {
+	// Two turns, each: 2 speech frames then 2 silence frames. The first silence
+	// frame sets the silence timer; after the silence threshold elapses the
+	// second silence frame completes the turn. Reset() clears only the current
+	// state, so the index runs linearly across both turns.
+	vad := &scriptedVAD{states: []audio.VADState{
+		audio.VADStateSpeaking, audio.VADStateSpeaking, audio.VADStateQuiet, audio.VADStateQuiet, // turn 1
+		audio.VADStateSpeaking, audio.VADStateSpeaking, audio.VADStateQuiet, audio.VADStateQuiet, // turn 2
+	}}
+
+	exec, req, store := newDuplexTestExecutorMultiTurn(t, vad)
+
+	mic := make(chan []byte)
+	var played [][]byte
+	var playMu sync.Mutex
+	play := func(b []byte) {
+		playMu.Lock()
+		played = append(played, b)
+		playMu.Unlock()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- exec.RunInteractiveVoice(ctx, req, mic, play) }()
+
+	feedTurn := func() {
+		mic <- speechFrame()
+		mic <- speechFrame()
+		mic <- make([]byte, 320) // silence 1 — silence timer starts
+		time.Sleep(40 * time.Millisecond)
+		mic <- make([]byte, 320) // silence 2 — turn completes (silence ≥ 20ms)
+		time.Sleep(40 * time.Millisecond)
+	}
+
+	feedTurn() // turn 1
+	feedTurn() // turn 2
+	close(mic)
+
+	if err := <-runErr; err != nil {
+		t.Fatalf("RunInteractiveVoice: %v", err)
+	}
+
+	state, err := store.Load(ctx, req.ConversationID)
+	if err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	users, assistants := countRoles(state.Messages)
+	if users != 2 {
+		t.Errorf("expected 2 user transcripts (one per turn), got %d (messages: %+v)", users, state.Messages)
+	}
+	if assistants != 2 {
+		t.Errorf("expected 2 assistant replies (one per turn), got %d (messages: %+v)", assistants, state.Messages)
+	}
+
+	playMu.Lock()
+	playCount := len(played)
+	playMu.Unlock()
+	if playCount == 0 {
+		t.Error("expected playback audio from the TTS stage across the conversation, got none")
+	}
+}

--- a/tools/arena/engine/interfaces.go
+++ b/tools/arena/engine/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	audioseam "github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/composition"
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -129,6 +130,13 @@ type ConversationRequest struct {
 	// message produced by the just-completed turn. No-op when meta is nil. This is
 	// side-effect-only and must never alter turn output, error, or flow.
 	StampWorkflowState func(meta map[string]interface{})
+
+	// vadOverride, when non-nil, replaces the VAD analyzer the composed-VAD
+	// pipeline would otherwise construct. Test-only seam: the real VAD's
+	// speech/silence detection on synthetic audio is non-deterministic, so the
+	// continuous-conversation integration test injects a scripted VAD here to
+	// drive exact turn boundaries. Unexported — never set on a production path.
+	vadOverride audioseam.VADAnalyzer
 }
 
 // StateStoreConfig wraps the pipeline StateStore configuration for Arena


### PR DESCRIPTION
## What

The capstone of **epic #1469** — turns the composed-VAD voice path into a real turn-by-turn conversation and proves it end-to-end. Builds on #1470 (control signals), #1471 (streaming provider), #1472 (barge-in).

1. **AudioTurnStage emits `EndOfTurn`** (config-gated `EmitEndOfTurn`, default false) after each completed turn's audio, so the streaming provider fires once per turn.

2. **`buildVADComposedPipeline` rewired**: sets `ProviderConfig.Streaming`, enables `EmitEndOfTurn`, and wires a shared `InterruptionHandler` (Immediate) across the AudioTurn and TTS stages for barge-in. The unary "fire-once-at-mic-close" provider is gone — a continuous mic session now gets a reply per turn, interruptible, instead of one batched reply at quit (the bug from PR #1457).

3. **Deterministic end-to-end integration test**: a scripted VAD (injected via a test-only `vadOverride` seam) drives `speech → silence → speech → silence` through the **real** pipeline (mock STT/LLM/TTS, no live keys), asserting a reply **per turn** — two user transcripts and two assistant messages materialize via the save stage. Closes the composed-path integration-test gap noted on PR #1457. Verified under `-race` across repeated runs.

## Race fix included

The full pipeline exposed a `TurnState` data race that the #1471 unit tests couldn't: the streaming provider read `TurnState` once before its loop, but the upstream prompt/template stages write it lazily as elements flow (the unary path was safe because it drained all input first). Moved the read into `fireStreamingTurn`, where this turn's messages have already passed through those stages — so the read is ordered after their writes (channel happens-before).

## Scope notes

- All four intermediate pipeline stages (STTUserMessage, variable/prompt/template, save, AssistantTTSFilter) already forward control elements unchanged — verified, no pass-through fixes needed.
- The barge-in propagation mechanism itself is unit-tested across the AudioTurn, TTS, and provider stages in #1472; this PR adds the multi-turn conversation integration coverage.
- `vadOverride` is an unexported, test-only seam (the real VAD's speech/silence detection on synthetic audio is non-deterministic) — never set on a production path.

Closes #1473
Closes #1469
