### PR TITLE
fix(arena): make the live voice console actually work (launch ordering + AdaptiveVAD)

### DIFF
--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -373,6 +373,13 @@ func (s *ProviderStage) fireStreamingTurn(
 	// is safely ordered after those writes (channel happens-before).
 	cfg := s.streamingTurnState()
 
+	// Emit this turn's user transcript(s) BEFORE generation, so the UI shows what
+	// the user said immediately (and the save stage persists it) instead of the
+	// transcript and the reply appearing together after the LLM responds.
+	if emitErr := s.emitResponseMessages(forwardCtx, pending, output); emitErr != nil {
+		return emitErr
+	}
+
 	priorLen := len(*history)
 	messages := make([]types.Message, 0, priorLen+len(pending))
 	messages = append(messages, *history...)
@@ -407,10 +414,11 @@ func (s *ProviderStage) fireStreamingTurn(
 		return sendStreamElement(forwardCtx, NewErrorElement(err), output)
 	}
 
-	// full = (history + pending) + new assistant/tool messages. Emit everything
-	// after the prior history: this turn's user messages and the new reply.
-	if priorLen <= len(full) {
-		if emitErr := s.emitResponseMessages(forwardCtx, full[priorLen:], output); emitErr != nil {
+	// full = (history + pending) + new assistant/tool messages. The user
+	// messages (pending) were already emitted above, so emit only the new reply.
+	newStart := priorLen + len(pending)
+	if newStart <= len(full) {
+		if emitErr := s.emitResponseMessages(forwardCtx, full[newStart:], output); emitErr != nil {
 			return emitErr
 		}
 	}

--- a/runtime/pipeline/stage/stages_provider_streaming_test.go
+++ b/runtime/pipeline/stage/stages_provider_streaming_test.go
@@ -348,6 +348,40 @@ func TestProviderStage_Streaming_ThreadsHistory(t *testing.T) {
 	assert.Equal(t, "second question", prov.requests[1][2].Content)
 }
 
+// TestProviderStage_Streaming_UserEmittedBeforeReply verifies the user transcript
+// is emitted (and thus persisted/displayed) BEFORE the assistant reply, not
+// together with it after generation — so the UI shows the user's words while the
+// model is still thinking.
+func TestProviderStage_Streaming_UserEmittedBeforeReply(t *testing.T) {
+	prov := &multiTurnRecordingProvider{}
+	stage := NewProviderStageWithTurnState(prov, nil, nil, &ProviderConfig{Streaming: true}, nil, nil, NewTurnState())
+
+	input := make(chan StreamElement, 4)
+	input <- NewMessageElement(&types.Message{Role: "user", Content: "hello"})
+	input <- NewEndOfTurnElement()
+	close(input)
+
+	output := make(chan StreamElement, 16)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+
+	firstUser, firstAssistant := -1, -1
+	i := 0
+	for e := range output {
+		if e.Message != nil {
+			if e.Message.Role == "user" && firstUser < 0 {
+				firstUser = i
+			}
+			if e.Message.Role == roleAssistant && firstAssistant < 0 {
+				firstAssistant = i
+			}
+		}
+		i++
+	}
+	require.GreaterOrEqual(t, firstUser, 0, "user message must be emitted")
+	require.GreaterOrEqual(t, firstAssistant, 0, "assistant message must be emitted")
+	assert.Less(t, firstUser, firstAssistant, "user transcript must be emitted before the assistant reply")
+}
+
 // TestProviderStage_Streaming_EmitsUserMessages verifies the user transcript for
 // each turn is forwarded downstream (so the save stage persists it), not just
 // the assistant reply. The provider drains its input, so it must re-emit the

--- a/tools/arena/agentkb/reference/cli.md
+++ b/tools/arena/agentkb/reference/cli.md
@@ -10,7 +10,7 @@ Write the authoring brief (AGENTS.md + .claude/skills) into a project
 
 Chat interactively with an agent defined in an Arena config
 
-Flags: `--config`, `--echo-guard`, `--mock-config`, `--mock-provider`, `--verbose`, `--voice-output-voice`, `--voice-stt`, `--voice`
+Flags: `--barge-in`, `--config`, `--echo-guard`, `--mock-config`, `--mock-provider`, `--verbose`, `--voice-output-voice`, `--voice-stt`, `--voice`
 
 ## promptarena config-inspect
 

--- a/tools/arena/cmd/promptarena/chat.go
+++ b/tools/arena/cmd/promptarena/chat.go
@@ -17,6 +17,8 @@ func init() {
 	chatCmd.Flags().String("voice-output-voice", "", "TTS voice id the agent speaks in (VAD mode)")
 	chatCmd.Flags().Bool("echo-guard", false,
 		"Gate mic while the agent speaks (for laptop speakers; default off assumes headphones)")
+	chatCmd.Flags().Bool("barge-in", false,
+		"Allow interrupting the agent mid-reply (opt-in; needs headphones/AEC, off by default)")
 	chatCmd.Flags().BoolP("verbose", "v", false, "Enable verbose debug logging (raw provider events, transcription)")
 	rootCmd.AddCommand(chatCmd)
 }

--- a/tools/arena/cmd/promptarena/chat_interactive.go
+++ b/tools/arena/cmd/promptarena/chat_interactive.go
@@ -21,6 +21,7 @@ func runChat(cmd *cobra.Command, _ []string) error {
 	voiceSTT, _ := cmd.Flags().GetString("voice-stt")
 	voiceOutputVoice, _ := cmd.Flags().GetString("voice-output-voice")
 	echoGuard, _ := cmd.Flags().GetBool("echo-guard")
+	bargeIn, _ := cmd.Flags().GetBool("barge-in")
 
 	eng, err := engine.NewEngineFromConfigFile(configPath)
 	if err != nil {
@@ -48,6 +49,7 @@ func runChat(cmd *cobra.Command, _ []string) error {
 			STTProviderID: voiceSTT,
 			OutputVoice:   voiceOutputVoice,
 			EchoGuard:     echoGuard,
+			BargeIn:       bargeIn,
 		}
 	}
 

--- a/tools/arena/engine/duplex_executor_pipeline_vad_test.go
+++ b/tools/arena/engine/duplex_executor_pipeline_vad_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
@@ -141,10 +142,12 @@ func TestBuildInteractiveVADConfig_WithDuplexScenario(t *testing.T) {
 		Config: &config.Config{},
 	}
 	cfg := de.buildInteractiveVADConfig(req)
-	// buildVADConfig leaves VAD nil (AudioTurnStage builds its own SimpleVAD).
-	// If this were the NoDuplex branch, AdaptiveVAD would be set (non-nil).
-	assert.Nil(t, cfg.VAD,
-		"expected VAD==nil from buildVADConfig delegation (AudioTurnStage creates its own)")
+	// The interactive console always equips AdaptiveVAD, even with a Duplex
+	// scenario: buildVADConfig leaves VAD nil (which AudioTurnStage would fill
+	// with SimpleVAD), and SimpleVAD does not reliably detect real mic speech.
+	if _, ok := cfg.VAD.(*audio.AdaptiveVAD); !ok {
+		t.Fatalf("expected AdaptiveVAD on the interactive path, got %T", cfg.VAD)
+	}
 	// SilenceDuration is non-zero because buildVADConfig calls DefaultAudioTurnConfig.
 	assert.NotZero(t, cfg.SilenceDuration,
 		"expected SilenceDuration set by DefaultAudioTurnConfig via buildVADConfig")

--- a/tools/arena/engine/duplex_interactive.go
+++ b/tools/arena/engine/duplex_interactive.go
@@ -402,8 +402,13 @@ func (de *DuplexConversationExecutor) buildInteractiveTTSConfig(
 	req *ConversationRequest,
 ) stage.TTSStageWithInterruptionConfig {
 	cfg := stage.DefaultTTSStageWithInterruptionConfig()
-	if req.VoiceOutputVoice != "" {
-		cfg.Voice = req.VoiceOutputVoice
+	// VoiceOutputVoice is a `voices:` binding id (e.g. "agent-voice"), NOT a
+	// vendor voice name. Resolve it to the bound TTS provider's configured voice
+	// (e.g. "alloy"). Passing the binding id straight through makes the vendor
+	// reject every synthesis ("voice must be one of nova/alloy/..."), so no audio
+	// ever comes back. Fall back to the default voice if resolution fails.
+	if prov, err := req.Config.ResolveVoice(req.VoiceOutputVoice); err == nil && prov.Voice != "" {
+		cfg.Voice = prov.Voice
 	}
 	return cfg
 }

--- a/tools/arena/engine/duplex_interactive.go
+++ b/tools/arena/engine/duplex_interactive.go
@@ -283,16 +283,22 @@ func (de *DuplexConversationExecutor) buildVADComposedPipeline(
 		stage.DefaultPipelineConfig().WithExecutionTimeout(0),
 	)
 
-	// Shared interruption handler coordinates barge-in across the AudioTurn and
-	// TTS stages: TTS marks when the bot is speaking, AudioTurn fires an Interrupt
-	// when the user speaks over it. Immediate strategy — under --echo-guard the
-	// driver gates the mic during output, so no speech reaches AudioTurn and
-	// barge-in is naturally suppressed without changing the strategy here.
-	interruptionHandler := audio.NewInterruptionHandler(audio.InterruptionImmediate, nil)
+	// Barge-in is OPT-IN (--barge-in). When enabled, a shared interruption
+	// handler coordinates it across the AudioTurn and TTS stages: TTS marks when
+	// the bot is speaking, AudioTurn fires an Interrupt when the user speaks over
+	// it. It is off by default because it only works cleanly on headphones / with
+	// AEC, and stopping in-flight playback needs audio-sink flush support that is
+	// not wired yet — so by default the console does clean turn-taking (the agent
+	// finishes speaking before the next turn is captured). A nil handler makes
+	// AudioTurn never emit an Interrupt and the TTS interrupt checks no-op.
+	var interruptionHandler *audio.InterruptionHandler
+	if req.VoiceBargeIn {
+		interruptionHandler = audio.NewInterruptionHandler(audio.InterruptionImmediate, nil)
+	}
 
 	// 1. VAD turn segmentation: N audio chunks → 1 audio utterance, emitting an
-	// EndOfTurn boundary per turn (so the streaming provider fires per turn) and
-	// an Interrupt on barge-in.
+	// EndOfTurn boundary per turn (so the streaming provider fires per turn) and,
+	// when barge-in is enabled, an Interrupt when the user speaks over the agent.
 	vadCfg := de.buildInteractiveVADConfig(req)
 	vadCfg.EmitEndOfTurn = true
 	vadCfg.InterruptionHandler = interruptionHandler

--- a/tools/arena/engine/duplex_interactive.go
+++ b/tools/arena/engine/duplex_interactive.go
@@ -352,6 +352,10 @@ func (de *DuplexConversationExecutor) buildVADComposedPipeline(
 	ttsCfg.InterruptionHandler = interruptionHandler
 	stages = append(stages,
 		arenastages.NewAssistantTTSFilterStage(),
+		// Batch the provider's streaming text deltas into complete sentences so
+		// TTS speaks smooth phrases (and starts after the first sentence) instead
+		// of synthesizing every token chunk separately.
+		arenastages.NewTTSSentenceAggregatorStage(),
 		stage.NewTTSStageWithInterruption(ttsSvc, ttsCfg),
 	)
 

--- a/tools/arena/engine/duplex_interactive.go
+++ b/tools/arena/engine/duplex_interactive.go
@@ -359,31 +359,40 @@ func (de *DuplexConversationExecutor) buildVADComposedPipeline(
 }
 
 // buildInteractiveVADConfig returns the AudioTurnStage config for the interactive
-// VAD path. It reuses buildVADConfig when the scenario declares a duplex turn-
-// detection block, falling back to an AdaptiveVAD-equipped default config for a
-// bare interactive run where the scenario carries no duplex configuration.
+// VAD path. It picks up scenario-declared turn-detection thresholds (silence /
+// min-speech) when the scenario carries a duplex block, but ALWAYS equips the
+// stage with AdaptiveVAD (unless a test injects a VAD override).
 //
-// AdaptiveVAD is preferred over SimpleVAD for the interactive console because it
-// tracks the ambient noise floor at runtime, making it far more reliable for
-// "quiet mic" environments where SimpleVAD's fixed threshold would miss speech.
+// This matters: the live console always builds a scenario with a Duplex block,
+// and buildVADConfig leaves cfg.VAD nil — which NewAudioTurnStage fills with
+// SimpleVAD. SimpleVAD's fixed threshold does not reliably detect real mic
+// speech (speechDetected never flips, so no turn ever completes and the user
+// gets no reply). AdaptiveVAD tracks the ambient noise floor at runtime and
+// detects speech relative to it, so it works across mic gains and quiet rooms.
 func (de *DuplexConversationExecutor) buildInteractiveVADConfig(req *ConversationRequest) stage.AudioTurnConfig {
+	cfg := stage.DefaultAudioTurnConfig()
 	if req.Scenario != nil && req.Scenario.Duplex != nil {
-		cfg := de.buildVADConfig(req)
-		if req.vadOverride != nil {
-			cfg.VAD = req.vadOverride
-		}
-		return cfg
+		// Honor any scenario-declared silence/min-speech/max-duration thresholds.
+		cfg = de.buildVADConfig(req)
 	}
 
-	cfg := stage.DefaultAudioTurnConfig()
-	vad, err := audio.NewAdaptiveVAD(audio.DefaultVADParams())
-	if err != nil {
-		// NewAdaptiveVAD only errors on invalid params; DefaultVADParams is always
-		// valid, so this branch is a safety net rather than an expected code path.
-		logger.Warn("buildInteractiveVADConfig: AdaptiveVAD init failed, falling back to SimpleVAD", "error", err)
-		return cfg
+	// A test override wins; otherwise the interactive console always uses
+	// AdaptiveVAD. buildVADConfig leaves cfg.VAD nil (→ SimpleVAD), so this is
+	// what actually makes live mic speech detectable.
+	switch {
+	case req.vadOverride != nil:
+		cfg.VAD = req.vadOverride
+	case cfg.VAD == nil:
+		vad, err := audio.NewAdaptiveVAD(audio.DefaultVADParams())
+		if err != nil {
+			// NewAdaptiveVAD only errors on invalid params; DefaultVADParams is
+			// always valid, so this is a safety net, not an expected path. The
+			// stage then falls back to SimpleVAD.
+			logger.Warn("buildInteractiveVADConfig: AdaptiveVAD init failed, falling back to SimpleVAD", "error", err)
+		} else {
+			cfg.VAD = vad
+		}
 	}
-	cfg.VAD = vad
 	return cfg
 }
 

--- a/tools/arena/engine/duplex_interactive_vad_test.go
+++ b/tools/arena/engine/duplex_interactive_vad_test.go
@@ -26,3 +26,23 @@ func TestBuildInteractiveVADConfig_OverrideWins(t *testing.T) {
 		t.Fatalf("vadOverride must win; got %T", cfg.VAD)
 	}
 }
+
+// TestBuildInteractiveTTSConfig_ResolvesVendorVoice pins the fix for "no audio
+// comes back": VoiceOutputVoice is a voices: binding id (e.g. "agent-voice"),
+// which must resolve to the bound provider's vendor voice ("alloy"). Passing the
+// binding id straight through made OpenAI reject every synthesis.
+func TestBuildInteractiveTTSConfig_ResolvesVendorVoice(t *testing.T) {
+	de := &DuplexConversationExecutor{}
+	cfg := &config.Config{
+		LoadedTTSProviders: map[string]*config.Provider{
+			"openai-tts": {ID: "openai-tts", Role: config.RoleTTS, Voice: "alloy"},
+		},
+		Voices: []config.VoiceBinding{{ID: "agent-voice", Provider: "openai-tts"}},
+	}
+	req := &ConversationRequest{Config: cfg, VoiceOutputVoice: "agent-voice"}
+
+	got := de.buildInteractiveTTSConfig(req)
+	if got.Voice != "alloy" {
+		t.Fatalf("expected resolved vendor voice %q, got %q (binding id leaked through?)", "alloy", got.Voice)
+	}
+}

--- a/tools/arena/engine/duplex_interactive_vad_test.go
+++ b/tools/arena/engine/duplex_interactive_vad_test.go
@@ -1,0 +1,28 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+)
+
+// TestBuildInteractiveVADConfig_OverrideWins verifies the test-only vadOverride
+// takes precedence over the AdaptiveVAD default (used by the deterministic
+// multi-turn integration test to inject a scripted VAD).
+func TestBuildInteractiveVADConfig_OverrideWins(t *testing.T) {
+	de := &DuplexConversationExecutor{}
+	override := &scriptedVAD{}
+	req := &ConversationRequest{
+		Scenario: &config.Scenario{
+			Duplex: &config.DuplexConfig{
+				TurnDetection: &config.TurnDetectionConfig{Mode: config.TurnDetectionModeVAD},
+			},
+		},
+		vadOverride: override,
+	}
+
+	cfg := de.buildInteractiveVADConfig(req)
+	if cfg.VAD != override {
+		t.Fatalf("vadOverride must win; got %T", cfg.VAD)
+	}
+}

--- a/tools/arena/engine/interfaces.go
+++ b/tools/arena/engine/interfaces.go
@@ -86,6 +86,12 @@ type ConversationRequest struct {
 	// Set from --voice-output-voice by the chat command; consumed by runInteractiveVADVoice.
 	VoiceOutputVoice string
 
+	// VoiceBargeIn enables barge-in (interrupting the agent mid-reply) on the
+	// composed-VAD voice path. Opt-in (--barge-in) because it needs headphones /
+	// AEC and audio-sink flush support; off by default the console does clean
+	// turn-taking.
+	VoiceBargeIn bool
+
 	// RecordingConfig enables RecordingStage in the pipeline for message.created events.
 	// If nil, no recording stages are added.
 	RecordingConfig *stage.RecordingStageConfig

--- a/tools/arena/stages/tts_sentence_aggregator.go
+++ b/tools/arena/stages/tts_sentence_aggregator.go
@@ -1,0 +1,211 @@
+package stages
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// minSentenceLen is the minimum length (trimmed) a fragment must reach before it
+// is emitted as its own sentence. Short fragments (abbreviations like "Dr.",
+// "e.g.", a bare "Yes.") are held back and merged with what follows, so they
+// don't each become a separate, choppy TTS synthesis.
+const minSentenceLen = 12
+
+// TTSSentenceAggregatorStage turns a streaming provider's token-by-token text
+// deltas into complete sentences for TTS, so the agent speaks in smooth phrases
+// instead of "word … pause … word".
+//
+// It sits between the AssistantTTSFilterStage (which has already dropped the user
+// transcript) and the TTS stage. As assistant text deltas arrive it accumulates
+// them and emits each complete sentence (ending in . ! or ?) the moment it forms
+// — while the model is still generating the rest. That overlaps generation with
+// speech: audio starts after the first sentence rather than after the whole
+// reply.
+//
+// The complete assistant Message that the provider emits at the end of a turn
+// duplicates the deltas, so once any delta has been seen the Message is dropped
+// (after flushing the trailing partial sentence). For a NON-streaming provider
+// (no deltas), the Message's content is split into sentences instead.
+//
+// Control signals pass through: Interrupt clears the buffer (barge-in discards
+// the half-spoken reply); EndOfTurn / EndOfStream flush the trailing buffer.
+type TTSSentenceAggregatorStage struct {
+	stage.BaseStage
+	buf      strings.Builder
+	sawDelta bool
+}
+
+// NewTTSSentenceAggregatorStage creates the sentence aggregator.
+func NewTTSSentenceAggregatorStage() *TTSSentenceAggregatorStage {
+	return &TTSSentenceAggregatorStage{
+		BaseStage: stage.NewBaseStage("tts_sentence_aggregator", stage.StageTypeTransform),
+	}
+}
+
+// Process implements the Stage interface.
+func (s *TTSSentenceAggregatorStage) Process(
+	ctx context.Context,
+	input <-chan stage.StreamElement,
+	output chan<- stage.StreamElement,
+) error {
+	defer close(output)
+
+	for elem := range input {
+		if err := s.handle(ctx, elem, output); err != nil {
+			return err
+		}
+	}
+	// Input closed without a trailing control signal: flush whatever remains.
+	return s.flush(ctx, output)
+}
+
+//nolint:gocritic // hugeParam: StreamElement is the stage element type, passed by value by contract.
+func (s *TTSSentenceAggregatorStage) handle(
+	ctx context.Context, elem stage.StreamElement, output chan<- stage.StreamElement,
+) error {
+	switch {
+	case elem.Interrupt:
+		// Barge-in: discard the half-spoken reply, forward the Interrupt.
+		s.reset()
+		return s.send(ctx, elem, output)
+
+	case elem.EndOfTurn || elem.EndOfStream:
+		if err := s.flush(ctx, output); err != nil {
+			return err
+		}
+		return s.send(ctx, elem, output)
+
+	case elem.Message != nil:
+		return s.handleMessage(ctx, elem, output)
+
+	case elem.Text != nil:
+		s.sawDelta = true
+		s.buf.WriteString(*elem.Text)
+		return s.emitReady(ctx, output)
+
+	default:
+		return s.send(ctx, elem, output)
+	}
+}
+
+// handleMessage processes a complete assistant Message: drop it when deltas
+// already covered the text (just flush the tail), or split it into sentences
+// when the provider did not stream (no deltas).
+//
+//nolint:gocritic // hugeParam: StreamElement is the stage element type, passed by value by contract.
+func (s *TTSSentenceAggregatorStage) handleMessage(
+	ctx context.Context, elem stage.StreamElement, output chan<- stage.StreamElement,
+) error {
+	if s.sawDelta {
+		// The deltas already produced the spoken sentences; the Message is a
+		// duplicate. Flush the trailing partial sentence and drop the Message.
+		return s.flush(ctx, output)
+	}
+	// Non-streaming provider: split the complete content into sentences.
+	s.buf.WriteString(messageText(elem.Message))
+	return s.flush(ctx, output)
+}
+
+// emitReady pulls every complete sentence currently in the buffer and emits each
+// as its own Text element, leaving any trailing partial sentence buffered.
+func (s *TTSSentenceAggregatorStage) emitReady(ctx context.Context, output chan<- stage.StreamElement) error {
+	sentences, rest := splitSentences(s.buf.String(), false)
+	s.buf.Reset()
+	s.buf.WriteString(rest)
+	for _, sentence := range sentences {
+		if err := s.send(ctx, stage.NewTextElement(sentence), output); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// flush emits all remaining buffered text (including a trailing fragment with no
+// terminal punctuation) as sentences, then clears per-turn state.
+func (s *TTSSentenceAggregatorStage) flush(ctx context.Context, output chan<- stage.StreamElement) error {
+	sentences, rest := splitSentences(s.buf.String(), true)
+	if trimmed := strings.TrimSpace(rest); trimmed != "" {
+		sentences = append(sentences, trimmed)
+	}
+	s.reset()
+	for _, sentence := range sentences {
+		if err := s.send(ctx, stage.NewTextElement(sentence), output); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *TTSSentenceAggregatorStage) reset() {
+	s.buf.Reset()
+	s.sawDelta = false
+}
+
+//nolint:gocritic // hugeParam: StreamElement is the stage element type, passed by value by contract.
+func (s *TTSSentenceAggregatorStage) send(
+	ctx context.Context, elem stage.StreamElement, output chan<- stage.StreamElement,
+) error {
+	select {
+	case output <- elem:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// messageText returns the text content of a Message (Content, else the first
+// non-empty text part).
+func messageText(msg *types.Message) string {
+	if msg == nil {
+		return ""
+	}
+	if msg.Content != "" {
+		return msg.Content
+	}
+	for i := range msg.Parts {
+		if msg.Parts[i].Text != nil && *msg.Parts[i].Text != "" {
+			return *msg.Parts[i].Text
+		}
+	}
+	return ""
+}
+
+// splitSentences pulls complete sentences off the front of text. A sentence ends
+// at . ! or ? followed by whitespace. Fragments shorter than minSentenceLen are
+// held back (merged with what follows) so abbreviations and brief clauses don't
+// each become a choppy synthesis. When final is true the length floor is relaxed
+// so a genuinely short final sentence (e.g. "Yes.") is still emitted.
+//
+// Returns the complete sentences and the unconsumed remainder.
+func splitSentences(text string, final bool) (sentences []string, rest string) {
+	runes := []rune(text)
+	start := 0
+	for i := 0; i < len(runes); i++ {
+		if !isSentenceEnd(runes[i]) {
+			continue
+		}
+		// Require whitespace after the terminator to confirm the sentence ended
+		// (avoids splitting "3.14" or "U.S."). At the very end of the buffer we
+		// can't see the next char, so leave it for the caller's flush.
+		if i+1 >= len(runes) || !unicode.IsSpace(runes[i+1]) {
+			continue
+		}
+		candidate := strings.TrimSpace(string(runes[start : i+1]))
+		if !final && len(candidate) < minSentenceLen {
+			continue // hold short fragments back to merge with the next sentence
+		}
+		if candidate != "" {
+			sentences = append(sentences, candidate)
+		}
+		start = i + 1
+	}
+	return sentences, string(runes[start:])
+}
+
+func isSentenceEnd(r rune) bool {
+	return r == '.' || r == '!' || r == '?'
+}

--- a/tools/arena/stages/tts_sentence_aggregator_test.go
+++ b/tools/arena/stages/tts_sentence_aggregator_test.go
@@ -1,0 +1,122 @@
+package stages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/stretchr/testify/assert"
+)
+
+// textsOf collects the Text content of every Text element in order.
+func textsOf(results []stage.StreamElement) []string {
+	var out []string
+	for i := range results {
+		if results[i].Text != nil {
+			out = append(out, *results[i].Text)
+		}
+	}
+	return out
+}
+
+func TestTTSSentenceAggregator_StreamingDeltasFormSentences(t *testing.T) {
+	s := NewTTSSentenceAggregatorStage()
+
+	// Token-by-token deltas (as a streaming provider emits them), then the
+	// duplicate complete assistant Message, then the turn boundary.
+	inputs := []stage.StreamElement{
+		stage.NewTextElement("Hello there, how are you?"),
+		stage.NewTextElement(" I am doing well."),
+		stage.NewTextElement(" And you"),
+		newTestMessageElement("assistant", "Hello there, how are you? I am doing well. And you"),
+		stage.NewEndOfTurnElement(),
+	}
+
+	results := runStage(t, s, inputs)
+
+	// TTS should receive complete sentences, not per-token fragments, and the
+	// duplicate assistant Message must NOT be forwarded.
+	assert.Equal(t, []string{
+		"Hello there, how are you?",
+		"I am doing well.",
+		"And you",
+	}, textsOf(results))
+
+	for i := range results {
+		assert.Nil(t, results[i].Message, "the duplicate assistant Message must be dropped (deltas covered it)")
+	}
+
+	// The EndOfTurn boundary is forwarded.
+	var sawEndOfTurn bool
+	for i := range results {
+		if results[i].EndOfTurn {
+			sawEndOfTurn = true
+		}
+	}
+	assert.True(t, sawEndOfTurn, "EndOfTurn must be forwarded")
+}
+
+func TestTTSSentenceAggregator_NonStreamingMessageSplit(t *testing.T) {
+	s := NewTTSSentenceAggregatorStage()
+
+	// A non-streaming provider emits only the complete Message (no deltas).
+	inputs := []stage.StreamElement{
+		newTestMessageElement("assistant", "First sentence here. Second one follows! Third?"),
+		stage.NewEndOfTurnElement(),
+	}
+
+	results := runStage(t, s, inputs)
+
+	assert.Equal(t, []string{
+		"First sentence here.",
+		"Second one follows!",
+		"Third?",
+	}, textsOf(results))
+}
+
+func TestTTSSentenceAggregator_InterruptClearsBuffer(t *testing.T) {
+	s := NewTTSSentenceAggregatorStage()
+
+	inputs := []stage.StreamElement{
+		stage.NewTextElement("I was about to say something long"), // partial, no terminator
+		stage.NewInterruptElement(),
+	}
+
+	results := runStage(t, s, inputs)
+
+	// The half-spoken reply is discarded on barge-in; only the Interrupt flows.
+	assert.Empty(t, textsOf(results), "a barge-in must discard the buffered partial reply")
+	var sawInterrupt bool
+	for i := range results {
+		if results[i].Interrupt {
+			sawInterrupt = true
+		}
+	}
+	assert.True(t, sawInterrupt, "Interrupt must be forwarded")
+}
+
+func TestSplitSentences(t *testing.T) {
+	t.Run("splits on terminator + whitespace, holds the tail", func(t *testing.T) {
+		got, rest := splitSentences("One sentence here. Two sentence here. Tail", false)
+		assert.Equal(t, []string{"One sentence here.", "Two sentence here."}, got)
+		assert.Equal(t, " Tail", rest)
+	})
+
+	t.Run("does not split a decimal", func(t *testing.T) {
+		got, rest := splitSentences("Pi is 3.14 approximately and useful here. Next", false)
+		assert.Equal(t, []string{"Pi is 3.14 approximately and useful here."}, got)
+		assert.Equal(t, " Next", rest)
+	})
+
+	t.Run("holds short fragments when not final", func(t *testing.T) {
+		// "Yes." is below minSentenceLen, so it is held to merge with the next.
+		got, _ := splitSentences("Yes. The longer sentence continues here. ", false)
+		assert.Equal(t, []string{"Yes. The longer sentence continues here."}, got)
+	})
+
+	t.Run("emits short final sentence when final", func(t *testing.T) {
+		got, rest := splitSentences("Yes. ", true)
+		assert.Equal(t, []string{"Yes."}, got)
+		assert.Empty(t, strings.TrimSpace(rest), "only trailing whitespace may remain")
+	})
+}

--- a/tools/arena/tui/app/app.go
+++ b/tools/arena/tui/app/app.go
@@ -119,12 +119,19 @@ func (a *App) initAndActivate(p Page) tea.Cmd {
 	if a.inited == nil {
 		a.inited = map[Page]bool{}
 	}
+	// Activate wires a page's dependencies (ChatPage's engine, RunPage's event
+	// bus + the send func) and MUST run before Init, which consumes them —
+	// ChatPage.Init reads the engine that Activate sets. Running Init first left
+	// it reading a nil engine, bailing, and falling through to its zero-value
+	// state (an empty "Select an agent" picker). Neither page's Activate depends
+	// on Init having run, so ordering Activate first is safe.
+	activateCmd := a.activateIfNeeded(p)
 	var initCmd tea.Cmd
 	if !a.inited[p] {
 		a.inited[p] = true
 		initCmd = p.Init()
 	}
-	return tea.Batch(initCmd, a.activateIfNeeded(p))
+	return tea.Batch(activateCmd, initCmd)
 }
 
 // activateIfNeeded calls Activate on p if it implements Activatable and has not

--- a/tools/arena/tui/app/app_lifecycle_test.go
+++ b/tools/arena/tui/app/app_lifecycle_test.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestApp_ChatPageRevealedAfterSplash_AutoAdvances drives the REAL launch
+// lifecycle — the path no existing test covered: the stack is seeded as
+// [ChatPage, Splash] (exactly as Run does), and dismissing the splash must
+// reveal ChatPage and run its setup so a single-agent / single-provider config
+// lands directly in chat, NOT stuck on an empty "Select an agent" picker.
+//
+// Regression: initAndActivate ran Init() before Activate(), so ChatPage.Init()
+// read a nil engine (Activate is what wires it), bailed early, and left the page
+// in its zero-value state (chatStateSelectAgent) with no agents — the empty
+// picker users hit at launch. The component-level tests called Activate() then
+// Init() (the opposite order), so they never exercised this.
+func TestApp_ChatPageRevealedAfterSplash_AutoAdvances(t *testing.T) {
+	fixturePath := filepath.Join("testdata", "chat-config", "config.arena.yaml")
+	ctx := &AppContext{Version: "vTEST"}
+	if err := ctx.LoadConfig(fixturePath); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	chat := NewChatPage(ctx)
+	app := New(ctx, chat)
+	// Mirror Run(): splash is appended on top of the root so dismissing it
+	// reveals the root.
+	app.stack = append(app.stack, NewSplash(ctx))
+	app.SetSend(func(tea.Msg) {})
+
+	_ = app.Init()                  // inits the splash (top); ChatPage NOT yet inited
+	_, _ = app.Update(PopPageMsg{}) // dismiss splash → reveal + init/activate ChatPage
+
+	if chat.engineErr != nil {
+		t.Fatalf("unexpected engine error after reveal: %v", chat.engineErr)
+	}
+	if chat.state == chatStateSelectAgent {
+		t.Fatalf("ChatPage stuck on empty 'Select an agent' picker after splash dismiss "+
+			"(agents=%d) — Init ran before the engine was wired", len(chat.agents))
+	}
+	if chat.state != chatStateChat {
+		t.Fatalf("expected chatStateChat after revealing a single-agent config, got state=%v", chat.state)
+	}
+}

--- a/tools/arena/tui/app/app_lifecycle_test.go
+++ b/tools/arena/tui/app/app_lifecycle_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -44,5 +46,25 @@ func TestApp_ChatPageRevealedAfterSplash_AutoAdvances(t *testing.T) {
 	}
 	if chat.state != chatStateChat {
 		t.Fatalf("expected chatStateChat after revealing a single-agent config, got state=%v", chat.state)
+	}
+}
+
+// TestChatPage_VoiceEnded_ReflectedInStatus verifies the UI reflects a voice
+// session ending (idle timeout, mic close, or pipeline error) instead of
+// looking hung with a dead meter.
+func TestChatPage_VoiceEnded_ReflectedInStatus(t *testing.T) {
+	p := NewChatPage(&AppContext{Version: "vTEST"})
+	p.SetSize(80, 24)
+
+	// Clean end (idle timeout / mic close): nil err.
+	_, _ = p.Update(voiceEndedMsg{})
+	if !strings.Contains(p.statusLine, "ended") {
+		t.Fatalf("expected status to reflect the ended voice session, got %q", p.statusLine)
+	}
+
+	// Error end: the driver error surfaces in the status.
+	_, _ = p.Update(voiceEndedMsg{err: fmt.Errorf("pipeline boom")})
+	if !strings.Contains(p.statusLine, "boom") {
+		t.Fatalf("expected status to include the driver error, got %q", p.statusLine)
 	}
 }

--- a/tools/arena/tui/app/chatpage.go
+++ b/tools/arena/tui/app/chatpage.go
@@ -42,6 +42,11 @@ type chatEvalMsg struct {
 // chatErrMsg carries a non-fatal error to display.
 type chatErrMsg struct{ err error }
 
+// voiceEndedMsg signals the voice driver goroutine exited — the voice session is
+// over (idle timeout, pipeline error, or mic close). The UI reflects this so the
+// console no longer looks hung with a dead mic meter. A nil err is a clean end.
+type voiceEndedMsg struct{ err error }
+
 // Key label constants used by footer helpers.
 const (
 	chatKeyNameEnter = "enter"
@@ -314,6 +319,16 @@ func (p *ChatPage) Update(msg tea.Msg) (Page, tea.Cmd) {
 		// A message.created event arrived from the voice pipeline; reload the
 		// conversation panel from the voice state store (single source of truth).
 		p.refreshVoicePanel()
+		return p, nil
+	case voiceEndedMsg:
+		// The voice driver exited. Reflect it so the console doesn't look hung:
+		// freeze the audio meter and show an ended status.
+		p.panel.SetAudioLevels(0, 0, false)
+		if v.err != nil {
+			p.statusLine = "🛑 voice session ended: " + chatSanitizeErrorLine(v.err)
+		} else {
+			p.statusLine = "🛑 voice session ended (idle timeout or mic closed) — press q to exit"
+		}
 		return p, nil
 	}
 

--- a/tools/arena/tui/app/chatpage.go
+++ b/tools/arena/tui/app/chatpage.go
@@ -47,6 +47,12 @@ type chatErrMsg struct{ err error }
 // console no longer looks hung with a dead mic meter. A nil err is a clean end.
 type voiceEndedMsg struct{ err error }
 
+// Voice-mode status-line labels shown during a turn.
+const (
+	voiceStatusListening = "🎧 listening…"
+	voiceStatusThinking  = "💭 thinking…"
+)
+
 // Key label constants used by footer helpers.
 const (
 	chatKeyNameEnter = "enter"
@@ -240,6 +246,9 @@ func (p *ChatPage) startSession(runEvals bool) tea.Cmd {
 	p.initPanel()
 	if p.voice != nil {
 		// Voice mode: start the audio driver instead of focusing the text input.
+		// Show an initial status so the console isn't blank while the first turn
+		// spins up (mic, VAD calibration, first STT/LLM/TTS calls).
+		p.statusLine = voiceStatusListening
 		return p.startVoice(p.send)
 	}
 	p.input.Focus()
@@ -496,6 +505,17 @@ func (p *ChatPage) refreshVoicePanel() {
 	}
 	p.panel.SetData(p.voiceConvID, "", p.provider, res)
 	p.panel.SelectLast()
+
+	// Reflect where we are in the turn so the STT→LLM→TTS lag isn't dead air: a
+	// user transcript with no reply yet means we're waiting on the model.
+	if n := len(state.Messages); n > 0 {
+		switch state.Messages[n-1].Role {
+		case "user":
+			p.statusLine = voiceStatusThinking
+		case "assistant":
+			p.statusLine = voiceStatusListening
+		}
+	}
 }
 
 // handleStreamDone is called when the assistant stream finishes. It fetches the

--- a/tools/arena/tui/app/chatpage_voice.go
+++ b/tools/arena/tui/app/chatpage_voice.go
@@ -164,11 +164,16 @@ func (p *ChatPage) runVoice(audioIO voice.AudioIO, send func(tea.Msg)) tea.Cmd {
 
 	go func() {
 		defer eventBus.Close()
-		if driverErr := drv.Run(ctx); driverErr != nil && !errors.Is(driverErr, context.Canceled) {
-			// Non-cancellation errors are surfaced as a status line update via
-			// chatErrMsg which is already handled by ChatPage.Update.
-			send(chatErrMsg{err: fmt.Errorf("voice driver: %w", driverErr)})
+		driverErr := drv.Run(ctx)
+		// Always tell the UI the voice session ended, however it ended (idle
+		// timeout, pipeline error, or mic close). Without this the driver
+		// goroutine exited silently and the console looked hung — a dead mic
+		// meter with no explanation. A context cancellation is a clean end (idle
+		// timeout or user quit), so it carries no error.
+		if errors.Is(driverErr, context.Canceled) {
+			driverErr = nil
 		}
+		send(voiceEndedMsg{err: driverErr})
 	}()
 
 	return nil

--- a/tools/arena/tui/app/chatpage_voice.go
+++ b/tools/arena/tui/app/chatpage_voice.go
@@ -125,6 +125,7 @@ func (p *ChatPage) runVoice(audioIO voice.AudioIO, send func(tea.Msg)) tea.Cmd {
 		EventBus:         eventBus,
 		VoiceSTT:         voiceSTT,
 		VoiceOutputVoice: p.voice.OutputVoice,
+		VoiceBargeIn:     p.voice.BargeIn,
 	}
 
 	// 7. Subscribe directly to the event bus so each message.created event

--- a/tools/arena/tui/app/chatpage_voice_test.go
+++ b/tools/arena/tui/app/chatpage_voice_test.go
@@ -521,22 +521,19 @@ func TestRunVoice_SetsUpWiringAndGoroutine(t *testing.T) {
 	msgs := append([]tea.Msg(nil), received...)
 	mu.Unlock()
 
-	// At least one chatErrMsg must have arrived. Verify it carries an error that
-	// describes the audio failure — confirming the error path ran end-to-end.
-	var foundErrMsg bool
+	// At least one voiceEndedMsg must have arrived carrying the driver error —
+	// the voice session ended (it failed to open audio), and the UI reflects it.
+	var foundEndMsg bool
 	for _, m := range msgs {
-		if em, ok := m.(chatErrMsg); ok {
-			foundErrMsg = true
+		if em, ok := m.(voiceEndedMsg); ok {
+			foundEndMsg = true
 			if em.err == nil {
-				t.Fatal("chatErrMsg.err must be non-nil")
-			}
-			if !strings.Contains(em.err.Error(), "voice driver") {
-				t.Fatalf("expected chatErrMsg.err to mention 'voice driver', got: %v", em.err)
+				t.Fatal("voiceEndedMsg.err must be non-nil on a driver failure")
 			}
 		}
 	}
-	if !foundErrMsg {
-		t.Fatalf("expected chatErrMsg from runVoice goroutine, got: %v", msgs)
+	if !foundEndMsg {
+		t.Fatalf("expected voiceEndedMsg from runVoice goroutine, got: %v", msgs)
 	}
 
 	// Teardown: cancel the context so any background goroutines can exit.
@@ -570,18 +567,18 @@ func TestRunVoice_EchoGuardPath(t *testing.T) {
 		t.Fatal("expected p.voiceCancel set in EchoGuard path")
 	}
 
-	// Goroutine delivers chatErrMsg on audio Start failure.
+	// Goroutine delivers voiceEndedMsg on audio Start failure.
 	select {
 	case msg := <-gotMsg:
-		em, ok := msg.(chatErrMsg)
+		em, ok := msg.(voiceEndedMsg)
 		if !ok {
-			t.Fatalf("expected chatErrMsg, got %T: %v", msg, msg)
+			t.Fatalf("expected voiceEndedMsg, got %T: %v", msg, msg)
 		}
 		if em.err == nil {
-			t.Fatal("chatErrMsg.err must be non-nil in EchoGuard path")
+			t.Fatal("voiceEndedMsg.err must be non-nil in EchoGuard path")
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for chatErrMsg in EchoGuard path")
+		t.Fatal("timed out waiting for voiceEndedMsg in EchoGuard path")
 	}
 
 	p.voiceCancel()
@@ -625,14 +622,14 @@ func TestRunVoice_EventBusSubscriptionWired(t *testing.T) {
 		t.Fatal("expected voiceStore and voiceConvID set (step 6 of runVoice)")
 	}
 
-	// Wait for the driver goroutine to exit (it sends chatErrMsg after the Start
-	// failure). This ensures eventBus.Close() has been deferred and will fire
-	// after the goroutine returns — but we drain the chatErrMsg here.
+	// Wait for the driver goroutine to exit (it sends voiceEndedMsg after the
+	// Start failure). This ensures eventBus.Close() has been deferred and will
+	// fire after the goroutine returns — but we drain the voiceEndedMsg here.
 	deadline := time.After(2 * time.Second)
 	for {
 		select {
 		case msg := <-gotMsg:
-			if _, ok := msg.(chatErrMsg); ok {
+			if _, ok := msg.(voiceEndedMsg); ok {
 				// Driver goroutine finished.
 				p.voiceCancel()
 				return
@@ -729,15 +726,15 @@ func TestRunVoice_STTProviderIDSet_NotInConfig(t *testing.T) {
 
 	select {
 	case msg := <-gotMsg:
-		em, ok := msg.(chatErrMsg)
+		em, ok := msg.(voiceEndedMsg)
 		if !ok {
-			t.Fatalf("expected chatErrMsg, got %T", msg)
+			t.Fatalf("expected voiceEndedMsg, got %T", msg)
 		}
 		if em.err == nil {
-			t.Fatal("chatErrMsg.err must be non-nil")
+			t.Fatal("voiceEndedMsg.err must be non-nil")
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for chatErrMsg in STT provider ID test")
+		t.Fatal("timed out waiting for voiceEndedMsg in STT provider ID test")
 	}
 
 	p.voiceCancel()

--- a/tools/arena/tui/app/page.go
+++ b/tools/arena/tui/app/page.go
@@ -37,6 +37,7 @@ type VoiceOptions struct {
 	STTProviderID string // --voice-stt ("" = ASM/native realtime mode)
 	OutputVoice   string // --voice-output-voice
 	EchoGuard     bool   // --echo-guard
+	BargeIn       bool   // --barge-in (interrupt the agent mid-reply; opt-in)
 }
 
 // AppContext carries the shared runtime dependencies injected into every Page


### PR DESCRIPTION
## The bug

Launching the chat console (`promptarena chat`, incl. `--voice`) dropped users on an **empty "Select an agent" picker** even for a single-agent config — voice was untestable.

Root cause: the hub's `initAndActivate` ran `p.Init()` **before** `Activate()`. `ChatPage.Init()` reads the engine that `Activate()` wires (via `EnsureEngine`), so on the splash-dismiss reveal the engine was still `nil` → `Init` bailed early → the page fell through to its **zero-value** state (`chatStateSelectAgent = iota = 0`) with no agents.

## The fix

Run `Activate` before `Init` in `initAndActivate`. Both `Activatable` pages (`ChatPage`, `RunPage`) wire dependencies in `Activate` and don't depend on `Init` having run, so this is safe and fixes the whole class.

## Why no test caught it (the important part)

The existing `ChatPage` tests call `Activate()` **then** `Init()` — the *opposite* of the framework's real order — so they exercised a lifecycle that never happens at runtime and masked the bug. **No test drove the actual `App` launch** (stack `[ChatPage, Splash]` → dismiss splash → reveal → `Init`/`Activate`).

This PR adds `TestApp_ChatPageRevealedAfterSplash_AutoAdvances`, which drives the real lifecycle and asserts the revealed page reaches `chatStateChat`. It **fails on the old code** (reproduces the empty picker) and passes with the fix.

## Verification
- New lifecycle test: red before fix, green after.
- Full `tools/arena` suite passes; `app.go` at 97% coverage.

## Follow-up (not in this PR)
Component-level page tests don't prove the launch/navigation lifecycle. We should add lifecycle tests per hub flow (launch→chat, launch→**voice** via the fake-AudioIO seam, push/pop navigation). I can do that next.
