### PR TITLE
feat(deploy): resolve adapter latest version from GitHub, not a baked-in constant

### DIFF
--- a/tools/arena/cmd/promptarena/deploy_adapter_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_adapter_interactive.go
@@ -207,6 +207,72 @@ func httpDownload(url string) ([]byte, error) {
 	return data, nil
 }
 
+// latestVersionFunc resolves the most recent published version for an adapter
+// repo. It is a package var so tests can stub network access.
+var latestVersionFunc = githubLatestVersion
+
+// githubLatestRelease is the subset of the GitHub releases/latest response read
+// to discover the newest adapter version.
+type githubLatestRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// githubLatestVersion queries the GitHub Releases API for the newest published
+// release of repo and returns its version with any leading "v" stripped
+// (e.g. "v1.2.0" -> "1.2.0"). Resolving the version live means a newly
+// published adapter release is installable WITHOUT rebuilding the CLI: the
+// embedded registry only supplies the repo, never a frozen version.
+func githubLatestVersion(repo string) (string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("resolve latest version: %w", err)
+	}
+	// api.github.com rejects requests with no User-Agent.
+	req.Header.Set("User-Agent", "promptarena")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("resolve latest version: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("resolve latest version: HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	var rel githubLatestRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", fmt.Errorf("parse latest release for %s: %w", repo, err)
+	}
+	tag := strings.TrimPrefix(rel.TagName, "v")
+	if tag == "" {
+		return "", fmt.Errorf("no published release found for %s", repo)
+	}
+	return tag, nil
+}
+
+// resolveInstallVersion picks the version to install when the user did not pin
+// one. It prefers the live latest release from GitHub; if that lookup fails
+// (offline, rate-limited), it falls back to the registry's embedded default so
+// installs still work without network access to the API. Returns "" only when
+// neither source yields a version.
+func resolveInstallVersion(provider string, entry adapterRegistryEntry) string {
+	resolved, err := latestVersionFunc(entry.Repo)
+	if err == nil && resolved != "" {
+		return resolved
+	}
+	if entry.Latest != "" {
+		fmt.Fprintf(os.Stderr,
+			"warning: could not resolve latest %s from GitHub (%v); "+
+				"falling back to registry default v%s\n",
+			provider, err, entry.Latest,
+		)
+		return entry.Latest
+	}
+	return ""
+}
+
 func runAdapterInstall(_ *cobra.Command, args []string) error {
 	provider, version := parseProviderVersion(args[0])
 
@@ -224,7 +290,13 @@ func runAdapterInstall(_ *cobra.Command, args []string) error {
 	}
 
 	if version == "" {
-		version = entry.Latest
+		version = resolveInstallVersion(provider, entry)
+		if version == "" {
+			return fmt.Errorf(
+				"could not resolve a version for adapter %q; specify one explicitly (e.g. %s@<version>)",
+				provider, provider,
+			)
+		}
 	}
 
 	goos := runtime.GOOS

--- a/tools/arena/cmd/promptarena/deploy_adapter_test.go
+++ b/tools/arena/cmd/promptarena/deploy_adapter_test.go
@@ -203,4 +203,58 @@ func TestDeployAdapterLoadDefaultRegistry(t *testing.T) {
 	if _, ok := reg.Adapters["agentcore"]; !ok {
 		t.Error("expected agentcore in default registry")
 	}
+	if _, ok := reg.Adapters["omnia"]; !ok {
+		t.Error("expected omnia in default registry")
+	}
 }
+
+func TestResolveInstallVersion(t *testing.T) {
+	t.Run("prefers live latest over embedded default", func(t *testing.T) {
+		orig := latestVersionFunc
+		t.Cleanup(func() { latestVersionFunc = orig })
+		latestVersionFunc = func(_ string) (string, error) { return "1.1.0", nil }
+
+		got := resolveInstallVersion("omnia", adapterRegistryEntry{
+			Repo: "AltairaLabs/PromptArena-deploy-omnia", Latest: "1.0.0",
+		})
+		if got != "1.1.0" {
+			t.Errorf("got %q, want live latest 1.1.0", got)
+		}
+	})
+
+	t.Run("falls back to embedded default when lookup fails", func(t *testing.T) {
+		orig := latestVersionFunc
+		t.Cleanup(func() { latestVersionFunc = orig })
+		latestVersionFunc = func(_ string) (string, error) {
+			return "", errTestNoNetwork
+		}
+
+		got := resolveInstallVersion("omnia", adapterRegistryEntry{
+			Repo: "AltairaLabs/PromptArena-deploy-omnia", Latest: "1.0.0",
+		})
+		if got != "1.0.0" {
+			t.Errorf("got %q, want embedded fallback 1.0.0", got)
+		}
+	})
+
+	t.Run("returns empty when neither source yields a version", func(t *testing.T) {
+		orig := latestVersionFunc
+		t.Cleanup(func() { latestVersionFunc = orig })
+		latestVersionFunc = func(_ string) (string, error) {
+			return "", errTestNoNetwork
+		}
+
+		got := resolveInstallVersion("omnia", adapterRegistryEntry{
+			Repo: "AltairaLabs/PromptArena-deploy-omnia", Latest: "",
+		})
+		if got != "" {
+			t.Errorf("got %q, want empty string", got)
+		}
+	})
+}
+
+var errTestNoNetwork = errTestErr("network unavailable")
+
+type errTestErr string
+
+func (e errTestErr) Error() string { return string(e) }


### PR DESCRIPTION
## Why

The adapter install flow pinned each provider's `latest` version inside the
CLI's embedded registry. Publishing a new adapter release therefore required
rebuilding and re-releasing `promptarena` before `deploy adapter install <p>`
would pick it up — which defeats the purpose of independently released,
out-of-band deploy adapters.

## What

- `githubLatestVersion(repo)` resolves the newest published version live from
  the GitHub Releases API at install time (with the required `User-Agent`).
- `resolveInstallVersion` prefers the live latest and falls back to the embedded
  registry value only when the lookup fails (offline / rate-limited).
- The embedded registry now supplies the **repo**; the pinned `latest` is just
  an offline fallback. Explicit pins (`install omnia@1.2.0`) are unchanged.

## Verification

- Unit tests: live-latest preference, offline fallback to embedded default,
  empty-on-both. Pre-commit lint/build/coverage green.
- Live: `deploy adapter install omnia` queried GitHub, resolved `v1.0.0`, and
  downloaded it — no embedded version consulted.

## Follow-up (not this PR)

A fully out-of-band model could also fetch the provider→repo registry from a
hosted URL (mirroring the remote JSON-schema source), so **new providers** —
not just new versions — need no CLI release. Filed as a follow-up idea.
