### PR TITLE
feat(deploy): add a Warnings channel to the deploy protocol

### DIFF
--- a/runtime/deploy/adaptersdk/serve_test.go
+++ b/runtime/deploy/adaptersdk/serve_test.go
@@ -177,6 +177,33 @@ func TestServeIO_Plan(t *testing.T) {
 	}
 }
 
+func TestServeIO_Plan_Warnings(t *testing.T) {
+	provider := newFakeProvider()
+	provider.planResp.Warnings = []string{"no binding named default"}
+	params := deploy.PlanRequest{PackJSON: "{}", DeployConfig: "{}"}
+	input := makeRequest("plan", params, 7) + "\n"
+	var out bytes.Buffer
+
+	if err := ServeIO(provider, strings.NewReader(input), &out); err != nil {
+		t.Fatalf("ServeIO error: %v", err)
+	}
+
+	var resp response
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	// Round-trip the result back into a typed PlanResponse — the same path the
+	// AdapterClient takes — and confirm the warning survived the protocol.
+	raw, _ := json.Marshal(resp.Result)
+	var plan deploy.PlanResponse
+	if err := json.Unmarshal(raw, &plan); err != nil {
+		t.Fatalf("unmarshal plan: %v", err)
+	}
+	if len(plan.Warnings) != 1 || plan.Warnings[0] != "no binding named default" {
+		t.Errorf("warnings did not pass through: %+v", plan.Warnings)
+	}
+}
+
 func TestServeIO_Apply(t *testing.T) {
 	provider := newFakeProvider()
 	params := deploy.PlanRequest{PackJSON: "{}", DeployConfig: "{}"}

--- a/runtime/deploy/provider.go
+++ b/runtime/deploy/provider.go
@@ -31,6 +31,9 @@ type ValidateRequest struct {
 type ValidateResponse struct {
 	Valid  bool     `json:"valid"`
 	Errors []string `json:"errors,omitempty"`
+	// Warnings are non-blocking advisories surfaced to the user. Unlike
+	// Errors, they do not make Valid false; the deployment proceeds.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // PlanRequest is the input to Plan.
@@ -46,6 +49,9 @@ type PlanRequest struct {
 type PlanResponse struct {
 	Changes []ResourceChange `json:"changes"`
 	Summary string           `json:"summary"`
+	// Warnings are non-blocking advisories surfaced to the user before the
+	// plan changes (e.g. a config that deploys but behaves surprisingly).
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // ResourceChange describes a single resource modification.

--- a/tools/arena/cmd/promptarena/deploy_config_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_config_interactive.go
@@ -340,6 +340,7 @@ func validateDeployConfig() error {
 		return fmt.Errorf("deploy config validation failed (%d error(s))", len(resp.Errors))
 	}
 
+	printDeployWarnings(resp.Warnings)
 	fmt.Println("Config is valid.")
 	return nil
 }

--- a/tools/arena/cmd/promptarena/deploy_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_interactive.go
@@ -183,9 +183,18 @@ func connectAdapter(provider, projectDir string) (*deploy.AdapterClient, error) 
 	return client, nil
 }
 
+// printDeployWarnings renders non-blocking adapter warnings to stderr with a
+// "⚠" prefix. It is a no-op when there are none.
+func printDeployWarnings(warnings []string) {
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "⚠ %s\n", w)
+	}
+}
+
 // printPlan displays a deployment plan to the user.
 func printPlan(plan *deploy.PlanResponse) {
 	fmt.Println()
+	printDeployWarnings(plan.Warnings)
 	fmt.Printf("Plan: %s\n", plan.Summary)
 	fmt.Println()
 	if len(plan.Changes) == 0 {


### PR DESCRIPTION
## Why

Deploy adapters had no way to surface a **non-blocking** advisory — `validate_config`
returns blocking errors, and `Plan` returns only `{Changes, Summary}`. The first
need: the omnia adapter wants to warn when a config deploys fine but behaves
surprisingly (no `default` provider binding → the runtime silently picks the
lexicographically-first one as primary).

## What

- `Warnings []string` on `PlanResponse` and `ValidateResponse`.
- No serve/client changes needed: the adaptersdk marshals the provider's response
  wholesale and `AdapterClient` deserializes the same structs, so warnings flow
  end-to-end. Added a round-trip passthrough test.
- The CLI prints warnings to stderr with a `⚠` prefix — before the plan changes,
  and after `Config is valid`.

## Next

A follow-up PR in `promptarena-deploy-omnia` populates `Warnings` (the no-`default`
check). It depends on this field, so this ships and releases first.

Spec: `docs/local-backlog/DEPLOY_DEFAULT_PROVIDER_WARNING.md` (local).
