### PR TITLE
feat(deploy): surface plan warnings on apply

### DIFF
--- a/tools/arena/cmd/promptarena/deploy_apply_interactive.go
+++ b/tools/arena/cmd/promptarena/deploy_apply_interactive.go
@@ -56,9 +56,11 @@ func runDeployApply(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load saved plan: %w", err)
 	}
+	usedSavedPlan := false
 	if savedPlan != nil && savedPlan.PackChecksum == packChecksum && savedPlan.Environment == env {
 		fmt.Println("  Using saved plan.")
 		planReq = savedPlan.Request
+		usedSavedPlan = true
 	} else {
 		if savedPlan != nil {
 			fmt.Println("  Saved plan is stale (pack or environment changed), re-planning...")
@@ -92,6 +94,11 @@ func runDeployApply(cmd *cobra.Command, args []string) error {
 	}
 	defer client.Close()
 
+	// Surface the plan's non-blocking advisories before applying — the same
+	// warnings the plan command shows — from the saved plan, or a fresh plan when
+	// re-planning. Apply streams resource events but has no Warnings channel.
+	printDeployWarnings(applyWarnings(ctx, client, usedSavedPlan, savedPlan, planReq))
+
 	adapterState, err := client.Apply(ctx, planReq, func(e *deploy.ApplyEvent) error {
 		printDeployEvent(e.Type, e.Message, e.Resource)
 		return nil
@@ -117,5 +124,27 @@ func runDeployApply(cmd *cobra.Command, args []string) error {
 
 	fmt.Println()
 	fmt.Println("Apply complete.")
+	return nil
+}
+
+// planWarner fetches a plan for its non-blocking warnings. It's satisfied by
+// *deploy.AdapterClient; an interface so applyWarnings is unit-testable.
+type planWarner interface {
+	Plan(context.Context, *deploy.PlanRequest) (*deploy.PlanResponse, error)
+}
+
+// applyWarnings returns the plan-time advisories to surface before an apply: the
+// reused saved plan's warnings, otherwise a fresh plan's. A plan error is
+// non-fatal here — apply proceeds and runs its own validation.
+func applyWarnings(
+	ctx context.Context, client planWarner,
+	usedSavedPlan bool, savedPlan *deploy.SavedPlan, planReq *deploy.PlanRequest,
+) []string {
+	if usedSavedPlan && savedPlan != nil && savedPlan.Plan != nil {
+		return savedPlan.Plan.Warnings
+	}
+	if plan, err := client.Plan(ctx, planReq); err == nil {
+		return plan.Warnings
+	}
 	return nil
 }

--- a/tools/arena/cmd/promptarena/deploy_apply_interactive_test.go
+++ b/tools/arena/cmd/promptarena/deploy_apply_interactive_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+)
+
+type fakePlanner struct {
+	resp   *deploy.PlanResponse
+	err    error
+	called bool
+}
+
+func (f *fakePlanner) Plan(_ context.Context, _ *deploy.PlanRequest) (*deploy.PlanResponse, error) {
+	f.called = true
+	return f.resp, f.err
+}
+
+func TestApplyWarnings_SavedPlan_UsesSavedWarningsWithoutReplanning(t *testing.T) {
+	saved := &deploy.SavedPlan{Plan: &deploy.PlanResponse{Warnings: []string{"a", "b"}}}
+	fp := &fakePlanner{}
+	got := applyWarnings(context.Background(), fp, true, saved, &deploy.PlanRequest{})
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("want [a b], got %v", got)
+	}
+	if fp.called {
+		t.Error("must not re-plan when a saved plan is reused")
+	}
+}
+
+func TestApplyWarnings_Replan_FetchesFreshWarnings(t *testing.T) {
+	fp := &fakePlanner{resp: &deploy.PlanResponse{Warnings: []string{"fresh"}}}
+	got := applyWarnings(context.Background(), fp, false, nil, &deploy.PlanRequest{})
+	if !fp.called {
+		t.Error("expected a fresh plan call when not using a saved plan")
+	}
+	if len(got) != 1 || got[0] != "fresh" {
+		t.Fatalf("want [fresh], got %v", got)
+	}
+}
+
+func TestApplyWarnings_PlanError_NoWarnings(t *testing.T) {
+	fp := &fakePlanner{err: errors.New("boom")}
+	got := applyWarnings(context.Background(), fp, false, nil, &deploy.PlanRequest{})
+	if got != nil {
+		t.Fatalf("want nil on plan error, got %v", got)
+	}
+}


### PR DESCRIPTION
`deploy apply` streamed resource events but never surfaced the plan's non-blocking warnings, so adapter advisories (e.g. "wired N handlers from the arena source", "M placeholders need real URLs", provider-not-ready, no-`default`-prompt) were invisible at apply time — only `plan` showed them.

`Apply` has no Warnings channel (only `Plan`/`Validate` do). But the warnings are already available: `SavedPlan` carries the full `*PlanResponse` (`Plan.Warnings`). So this renders them with the **existing** `printDeployWarnings`:
- **saved plan reused** → `savedPlan.Plan.Warnings`
- **re-planning** (stale/no saved plan) → a fresh `client.Plan(...)` for its `Warnings`

A plan error here is non-fatal — apply proceeds and runs its own validation. No new event type or prefix contract; reuses the warnings mechanism already in the CLI.

Unit-tested via a small `planWarner` interface (saved-plan path doesn't re-plan; re-plan path fetches fresh; plan error → no warnings).
