### PR TITLE
docs(deploy): publish the omnia deploy-login how-to

### DIFF
--- a/docs/scripts/fetch-adapter-docs.mjs
+++ b/docs/scripts/fetch-adapter-docs.mjs
@@ -183,6 +183,10 @@ const ADAPTERS = [
     "AltairaLabs/PromptArena-deploy-omnia",
     {
       // Extra files specific to omnia.
+      "how-to/login.md": {
+        target: "how-to/deploy/omnia/login.md",
+        order: 40,
+      },
       "how-to/labels.md": {
         target: "how-to/deploy/omnia/labels.md",
         order: 41,


### PR DESCRIPTION
Maps the omnia adapter's new `how-to/login.md` into the docs fetch (`fetch-adapter-docs.mjs`) so it's published — a new adapter page is silently skipped until it has a fileMap entry. Targets `how-to/deploy/omnia/login.md`, ordered with the other primary how-tos.

Pairs with deploy-omnia#49 (the new login how-to). Needs to land on main **before** the next PromptKit release so the docs build picks it up.