### PR TITLE
fix(arena): keep workflow transition tool registered across runs (#1480)

### DIFF
--- a/tools/arena/engine/workflow_tool_executor.go
+++ b/tools/arena/engine/workflow_tool_executor.go
@@ -231,7 +231,13 @@ func (e *workflowTransitionExecutor) applyPostCommit(
 		if run.scenario != nil {
 			run.scenario.TaskType = newState.PromptTask
 		}
-		run.transExec.RegisterForState(e.registry, newState)
+		// Re-register the transition tool for the new state's events, but never
+		// unregister it: e.registry is shared across every scenario run, so the
+		// unregister that runtime's RegisterForState performs on terminal-state
+		// entry would strip workflow__transition from sibling runs that still
+		// need it (issue #1480). registerTransitionTool no-ops on terminal
+		// states, leaving the tool registered for other runs.
+		registerTransitionTool(e.registry, newState)
 		run.skillFilter = newState.Skills
 	}
 }

--- a/tools/arena/engine/workflow_tool_executor_test.go
+++ b/tools/arena/engine/workflow_tool_executor_test.go
@@ -123,6 +123,38 @@ func TestWorkflowTransitionExecutor_TerminalState(t *testing.T) {
 	assert.Equal(t, true, meta["workflow_complete"])
 }
 
+// TestWorkflowTransitionExecutor_TerminalKeepsToolForSiblingRuns guards against
+// regression of issue #1480: the transition tool descriptor lives in a registry
+// that Arena shares across every scenario run, but per-run state machines are
+// isolated. When one run reaches a terminal state, committing that transition
+// must NOT unregister workflow__transition from the shared registry — doing so
+// strips the tool from sibling runs that still need it, so their pipelines take
+// the no-tools provider path and silently drop transition tool calls.
+func TestWorkflowTransitionExecutor_TerminalKeepsToolForSiblingRuns(t *testing.T) {
+	spec := testWorkflowSpec()
+	registry := tools.NewRegistry()
+	exec := newWorkflowTransitionExecutor(spec, registry)
+
+	// Register the transition tool for the entry state, mirroring initWorkflow.
+	registerTransitionTool(registry, spec.States[spec.Entry])
+	require.NotNil(t, registry.Get(workflow.TransitionToolName),
+		"transition tool should be registered after init")
+
+	// Run a scenario all the way to the terminal "closed" state.
+	scenario := &config.Scenario{ID: "s1", TaskType: "intake"}
+	exec.RegisterRun("s1", scenario)
+	args, _ := json.Marshal(map[string]string{"event": "Resolve"})
+	_, err := exec.Execute(withWorkflowScenarioID(context.Background(), "s1"), nil, args)
+	require.NoError(t, err)
+	require.NoError(t, exec.CommitPendingTransition("s1", nil))
+	require.Equal(t, true, exec.RunMetadata("s1")["workflow_complete"])
+
+	// The shared registry must still expose the transition tool so a sibling
+	// run can drive its own transitions.
+	assert.NotNil(t, registry.Get(workflow.TransitionToolName),
+		"reaching a terminal state must not unregister the shared transition tool")
+}
+
 func TestWorkflowTransitionExecutor_ConcurrentRuns(t *testing.T) {
 	spec := testWorkflowSpec()
 	registry := tools.NewRegistry()


### PR DESCRIPTION
## Summary

Fixes #1480 — `examples/workflow-support` second scenario (`state-assertions`) failed its `transitioned_to: closed` assertion: deterministically when run serially, flakily under concurrency.

## Root cause

Arena shares a single `tools.Registry` across every scenario run, while each run gets its own state machine. `applyPostCommit` refreshed the `workflow__transition` descriptor through the runtime `TransitionExecutor.RegisterForState`, which **unregisters** the tool on terminal-state entry (correct for a single SDK conversation, harmful for Arena's shared registry).

So the first run to reach a terminal state (`basic-flow` → `closed`) stripped `workflow__transition` from the shared registry. Sibling runs then saw **no tools**, took the no-tools provider path (`PredictStream` instead of `PredictWithTools`), and silently dropped their turn's transition tool call — so no transition was recorded and the assertion failed.

- Serial (`-j 1`): `basic-flow` always finishes first → **10/10 failed**
- Concurrent (default `-j 6`): depends on which run captured the tool first → ~**17/20 failed**

## Fix

Use Arena's existing register-only `registerTransitionTool` helper in `applyPostCommit`. It refreshes the descriptor for non-terminal states but **no-ops on terminal states** instead of unregistering, leaving the shared tool available to other runs. Per-run correctness is still enforced by the per-run state machine inside the executor.

## Verification

- New unit test `TestWorkflowTransitionExecutor_TerminalKeepsToolForSiblingRuns` asserts the shared registry keeps `workflow__transition` after a run reaches terminal (fails before the fix, passes after).
- `examples/workflow-support`: **0/10** serial and **0/20** concurrent failures after the fix (was 10/10 and 17/20).
- Full arena suite: 3919 tests pass. `runtime/workflow` passes. Lint clean.
