### PR TITLE
ci(release): build windows voice binary with MSYS2 MinGW PortAudio (#1497)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -785,11 +785,14 @@ jobs:
             goos: linux
             goarch: arm64
             portaudio_install: sudo apt-get update && sudo apt-get install -y portaudio19-dev
-          # windows/amd64 (windows/arm64 excluded — no GitHub-hosted runner exists)
+          # windows/amd64 (windows/arm64 excluded — no GitHub-hosted runner exists).
+          # PortAudio is installed via MSYS2/MinGW below (not the shared run step),
+          # so CGO's gcc, pkg-config, and libportaudio are all MinGW-consistent.
+          # vcpkg's x64-windows PortAudio is MSVC-built and its .pc file is not on
+          # the runner's pkg-config path, which broke the v1.5.3 build (#1497).
           - os: windows-latest
             goos: windows
             goarch: amd64
-            portaudio_install: vcpkg install portaudio:x64-windows
 
     steps:
     - name: Checkout code
@@ -802,8 +805,34 @@ jobs:
       # to GoReleaser's git state inspection on this runner.
       run: git fetch --tags --force origin
 
-    - name: Install PortAudio
+    - name: Install PortAudio (macOS/Linux)
+      if: matrix.goos != 'windows'
       run: ${{ matrix.portaudio_install }}
+
+    # Windows: install PortAudio + a matching MinGW toolchain via MSYS2. The
+    # gordonklaus/portaudio binding uses `#cgo pkg-config: portaudio-2.0`, so
+    # CGO must find portaudio-2.0.pc and link libportaudio with the SAME
+    # toolchain it compiles with. MSYS2's MinGW64 provides gcc, pkgconf, and
+    # libportaudio together; putting mingw64/bin first on PATH makes CGO use
+    # them instead of the runner's Strawberry Perl gcc/pkg-config (#1497).
+    - name: Install PortAudio + MinGW (Windows)
+      if: matrix.goos == 'windows'
+      id: msys2
+      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-portaudio
+          mingw-w64-x86_64-pkgconf
+
+    - name: Put MinGW64 on PATH (Windows)
+      if: matrix.goos == 'windows'
+      shell: pwsh
+      run: |
+        "${{ steps.msys2.outputs.msys2-location }}/mingw64/bin" `
+          | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
## Summary

Fixes #1497 — the v1.5.3 release's `Build Voice Binary (windows/amd64)` job failed, so no Windows `promptarena-voice` asset shipped (macOS/Linux were fine).

## Root cause (from the failed job log)

The build died at the **pkg-config** stage, before any compile:

```
# github.com/gordonklaus/portaudio
# [pkg-config --cflags  -- portaudio-2.0]
Can't find portaudio-2.0.pc in any of C:/Strawberry/c/lib/pkgconfig
use the PKG_CONFIG_PATH environment variable, or ...
```

The binding hardcodes `#cgo pkg-config: portaudio-2.0`, so CGO locates PortAudio via **pkg-config** — the issue's `CGO_CFLAGS/LDFLAGS` guess wouldn't take effect. The runner's pkg-config (Strawberry Perl) only searches `C:/Strawberry/c/lib/pkgconfig`; vcpkg put `portaudio-2.0.pc` in its own tree and nothing set `PKG_CONFIG_PATH`. vcpkg's `x64-windows` PortAudio is also **MSVC-built**, which wouldn't link cleanly against the MinGW gcc that CGO uses on the runner — so just adding `PKG_CONFIG_PATH` would likely fail at the link step next.

## Fix

Replace vcpkg on Windows with **MSYS2 MinGW64**, which ships gcc + pkgconf + libportaudio from one consistent toolchain:

- `msys2/setup-msys2` installs `mingw-w64-x86_64-toolchain`, `-portaudio`, `-pkgconf`.
- Prepend `mingw64/bin` to `PATH` so CGO's `gcc`/`pkg-config` resolve to the MinGW ones; pkgconf finds `portaudio-2.0.pc` from its default prefix.
- The shared `Install PortAudio` run step is now guarded to non-Windows; macOS/Linux are unchanged.

Action pinned to a commit SHA (`66cd2cce…` = v2.32.0) per the repo's supply-chain convention.

## Validation

This job runs **only during a release** (`release.yml`, `phase: full`), so it can't be exercised on this PR's CI. Changes are isolated to the Windows matrix entry; macOS/Linux paths are untouched. Recommend confirming on the next full release.

## Follow-up (not in this PR)

The MinGW PortAudio is a DLL — the produced `.exe` dynamically links `libportaudio.dll`, which isn't bundled in the voice archive (currently README + LICENSE only). To make the Windows asset runnable on a clean machine we should bundle `libportaudio.dll` (or statically link). Worth a separate issue.

Separately, actionlint flags the pre-existing `ubuntu-24.04-arm64` label in the linux/arm64 matrix entry as unknown (valid label is `ubuntu-24.04-arm`) — out of scope here, but may be worth checking whether that voice target actually runs.
