### PR TITLE
fix(voice): flush in-flight playback on barge-in + clean interrupt state (#1485)

### DIFF
--- a/examples/voice-console-asm/README.md
+++ b/examples/voice-console-asm/README.md
@@ -32,6 +32,19 @@ Speak naturally; the agent replies in voice. Press `q` or `Ctrl-C` to exit.
   back into the mic without them. For laptop speakers add `--echo-guard`
   (best-effort).
 
+## Barge-in
+
+`--barge-in` now stops in-flight speaker playback the moment you interrupt: the
+audio sink is flushed so the agent goes quiet immediately instead of finishing
+its buffered sentence ([#1485](https://github.com/AltairaLabs/PromptKit/issues/1485)).
+
+Genuine open-speaker barge-in (talking over the agent without headphones) still
+needs acoustic echo cancellation so the open mic doesn't hear the agent and
+interrupt it. AEC is in progress — Speex
+([#1506](https://github.com/AltairaLabs/PromptKit/issues/1506)) and WebRTC AEC3
+([#1507](https://github.com/AltairaLabs/PromptKit/issues/1507)) — so until it
+lands, **use headphones for reliable barge-in**.
+
 ## How it works
 
 `openai-realtime` is the only LLM provider, so the console selects it and

--- a/runtime/pipeline/stage/stages_speech_integration.go
+++ b/runtime/pipeline/stage/stages_speech_integration.go
@@ -649,9 +649,14 @@ func (s *TTSStageWithInterruption) Process(
 	for elem := range work {
 		if elem.Interrupt {
 			// In-flight synthesis was already canceled out of band by the
-			// reader. Roll a fresh context for the next turn and forward the
-			// Interrupt downstream so playback can flush too.
+			// reader. Roll a fresh context for the next turn, reset the shared
+			// handler so its interrupted flag does not carry over and block the
+			// next turn's synthesis, then forward the Interrupt downstream so
+			// playback can flush too.
 			canceller.refresh()
+			if s.interruption != nil {
+				s.interruption.Reset()
+			}
 			if err := s.forwardElement(ctx, elem, output); err != nil {
 				return err
 			}
@@ -709,23 +714,18 @@ func (s *TTSStageWithInterruption) forwardElement(
 }
 
 // setBotSpeaking safely sets bot speaking state if handler exists.
+// The bot-speaking flag is still needed: AudioTurnStage's ProcessVADState only
+// fires a barge-in while the bot is speaking, so this gate must stay in sync.
 func (s *TTSStageWithInterruption) setBotSpeaking(speaking bool) {
 	if s.interruption != nil {
 		s.interruption.SetBotSpeaking(speaking)
 	}
 }
 
-// checkAndResetInterruption checks if interrupted and resets if so.
-func (s *TTSStageWithInterruption) checkAndResetInterruption() bool {
-	if s.interruption != nil && s.interruption.WasInterrupted() {
-		s.interruption.Reset()
-		s.setBotSpeaking(false)
-		return true
-	}
-	return false
-}
-
 // synthesizeAndEmit performs TTS synthesis and emits the audio element.
+// Interruption is handled exclusively by the in-channel Interrupt element and
+// the per-turn synthCtx (canceled by turnCanceller on barge-in), so there is
+// no need to poll the shared handler here.
 func (s *TTSStageWithInterruption) synthesizeAndEmit(
 	ctx context.Context,
 	text string,
@@ -734,19 +734,9 @@ func (s *TTSStageWithInterruption) synthesizeAndEmit(
 ) error {
 	s.setBotSpeaking(true)
 
-	if s.checkAndResetInterruption() {
-		logger.Debug("TTSStageWithInterruption: interrupted before synthesis")
-		return nil
-	}
-
 	audioData, err := s.performSynthesis(ctx, text, elem, output)
 	if err != nil || audioData == nil {
 		return err
-	}
-
-	if s.checkAndResetInterruption() {
-		logger.Debug("TTSStageWithInterruption: interrupted after synthesis, discarding")
-		return nil
 	}
 
 	return s.emitAudioElement(ctx, text, audioData, &elem.Meta, output)

--- a/runtime/pipeline/stage/tts_interruption_stage_test.go
+++ b/runtime/pipeline/stage/tts_interruption_stage_test.go
@@ -421,27 +421,37 @@ func TestTTSStageWithInterruption_WithInterruption(t *testing.T) {
 
 	s := stage.NewTTSStageWithInterruption(mock, config)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	// Simulate interruption by processing a Speaking VAD state
-	_, _ = handler.ProcessVADState(ctx, audio.VADStateSpeaking)
+	// Simulate a prior turn's barge-in leaving the handler's interrupted flag set.
+	_, _ = handler.ProcessVADState(context.Background(), audio.VADStateSpeaking)
+	require.True(t, handler.WasInterrupted(), "precondition: handler must be interrupted")
 
 	input := make(chan stage.StreamElement, 1)
 	output := make(chan stage.StreamElement, 10)
+	done := make(chan error, 1)
+	go func() { done <- s.Process(context.Background(), input, output) }()
 
-	go func() {
-		_ = s.Process(ctx, input, output)
-	}()
-
-	input <- makeTextElement("This should be interrupted")
+	input <- makeTextElement("This proceeds despite the stale interrupted flag")
 	close(input)
 
-	// Wait for processing — audio should be skipped
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, <-done)
+
+	// With no Interrupt element in the channel, synthesis proceeds even if the
+	// handler's interrupted flag was set before this turn — only an in-channel
+	// Interrupt element (plus synthCtx cancellation) drops audio.
+	var audioCount int
+	for e := range output {
+		if e.Audio != nil {
+			audioCount++
+		}
+	}
+	assert.Equal(t, 1, audioCount, "synthesis proceeds when no Interrupt element cancels the turn")
 }
 
 func TestTTSStageWithInterruption_PostSynthesisInterruption(t *testing.T) {
+	// If the synthesis context was NOT cancelled (no Interrupt in the channel),
+	// synthesis that completed is emitted even when the shared handler's interrupted
+	// flag is set.  Discarding completed audio is no longer done by polling — only
+	// an in-channel Interrupt + synthCtx cancellation drops in-flight audio.
 	config := stage.DefaultTTSStageWithInterruptionConfig()
 	handler := audio.NewInterruptionHandler(audio.InterruptionImmediate, nil)
 	handler.SetBotSpeaking(true)
@@ -449,7 +459,8 @@ func TestTTSStageWithInterruption_PostSynthesisInterruption(t *testing.T) {
 
 	mock := &mockTTSService{
 		synthesizeFunc: func(ctx context.Context, _ string, _ tts.SynthesisConfig) (io.ReadCloser, error) {
-			// Trigger interruption INSIDE synthesizeFunc
+			// Trigger interruption INSIDE synthesizeFunc — but synthesis still
+			// completes because no Interrupt element cancels synthCtx.
 			_, _ = handler.ProcessVADState(ctx, audio.VADStateSpeaking)
 			return io.NopCloser(strings.NewReader("audio data")), nil
 		},
@@ -457,28 +468,100 @@ func TestTTSStageWithInterruption_PostSynthesisInterruption(t *testing.T) {
 
 	s := stage.NewTTSStageWithInterruption(mock, config)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
 	input := make(chan stage.StreamElement, 1)
 	output := make(chan stage.StreamElement, 10)
-
-	go func() {
-		_ = s.Process(ctx, input, output)
-	}()
+	done := make(chan error, 1)
+	go func() { done <- s.Process(context.Background(), input, output) }()
 
 	input <- makeTextElement("Test post-synthesis interruption")
 	close(input)
 
-	time.Sleep(200 * time.Millisecond)
+	require.NoError(t, <-done)
 
-	// Audio should be discarded; no audio elements expected
-	select {
-	case elem := <-output:
-		if elem.Audio != nil {
-			t.Errorf("Expected audio to be discarded after interruption, got audio element")
+	var audioCount int
+	for e := range output {
+		if e.Audio != nil {
+			audioCount++
 		}
-	default:
-		// Nothing in output is expected
 	}
+	assert.Equal(t, 1, audioCount, "audio must be emitted when synthesis completes without synthCtx cancellation")
+}
+
+// TestTTSStageWithInterruption_StaleFlagNoLongerDropsNextSynthesis covers
+// #1485 item 2: after a barge-in sets interrupted=true on the shared handler,
+// the NEXT turn's synthesis must not be silently dropped.
+func TestTTSStageWithInterruption_StaleFlagNoLongerDropsNextSynthesis(t *testing.T) {
+	// Pre-condition: simulate a prior turn's barge-in leaving interrupted=true.
+	handler := audio.NewInterruptionHandler(audio.InterruptionImmediate, nil)
+	handler.SetBotSpeaking(true)
+	interrupted, err := handler.ProcessVADState(context.Background(), audio.VADStateSpeaking)
+	require.NoError(t, err)
+	require.True(t, interrupted, "precondition: handler must be interrupted")
+	require.True(t, handler.WasInterrupted(), "precondition: flag must be set")
+
+	mock := &mockTTSService{
+		synthesizeFunc: func(_ context.Context, _ string, _ tts.SynthesisConfig) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader("turn-2-audio")), nil
+		},
+	}
+	config := stage.DefaultTTSStageWithInterruptionConfig()
+	config.InterruptionHandler = handler
+
+	s := stage.NewTTSStageWithInterruption(mock, config)
+
+	input := make(chan stage.StreamElement)
+	output := make(chan stage.StreamElement, 16)
+	done := make(chan error, 1)
+	go func() { done <- s.Process(context.Background(), input, output) }()
+
+	// An Interrupt element arrives (as AudioTurnStage emits on barge-in), then turn-2 text.
+	input <- stage.NewInterruptElement()
+	input <- makeTextElement("second-turn reply")
+	close(input)
+
+	require.NoError(t, <-done)
+
+	var audioCount, interruptCount int
+	for e := range output {
+		if e.Audio != nil {
+			audioCount++
+		}
+		if e.Interrupt {
+			interruptCount++
+		}
+	}
+	assert.Equal(t, 1, interruptCount, "Interrupt must be forwarded downstream")
+	assert.Equal(t, 1, audioCount, "turn-2 synthesis must not be dropped by a stale interrupted flag")
+}
+
+// TestTTSStageWithInterruption_InterruptElementClearsHandler covers #1485 item 2
+// (second half): processing an Interrupt element must reset the shared handler so
+// AudioTurnStage can fire a second barge-in in the next turn.
+func TestTTSStageWithInterruption_InterruptElementClearsHandler(t *testing.T) {
+	// Pre-set the handler into the "interrupted" state as a prior barge-in would.
+	handler := audio.NewInterruptionHandler(audio.InterruptionImmediate, nil)
+	handler.SetBotSpeaking(true)
+	_, err := handler.ProcessVADState(context.Background(), audio.VADStateSpeaking)
+	require.NoError(t, err)
+	require.True(t, handler.WasInterrupted(), "precondition: handler must be interrupted")
+
+	config := stage.DefaultTTSStageWithInterruptionConfig()
+	config.InterruptionHandler = handler
+
+	s := stage.NewTTSStageWithInterruption(&mockTTSService{}, config)
+
+	input := make(chan stage.StreamElement, 1)
+	output := make(chan stage.StreamElement, 4)
+	done := make(chan error, 1)
+	go func() { done <- s.Process(context.Background(), input, output) }()
+
+	input <- stage.NewInterruptElement()
+	close(input)
+
+	require.NoError(t, <-done)
+	for range output {
+	} // drain
+
+	assert.False(t, handler.WasInterrupted(),
+		"Interrupt element must call handler.Reset() to clear the interrupted flag for the next turn")
 }

--- a/runtime/pipeline/stage/tts_interruption_stage_test.go
+++ b/runtime/pipeline/stage/tts_interruption_stage_test.go
@@ -406,7 +406,7 @@ func TestTTSStageWithInterruption_ContextCancellation(t *testing.T) {
 	}
 }
 
-func TestTTSStageWithInterruption_WithInterruption(t *testing.T) {
+func TestTTSStageWithInterruption_StaleFlagWithoutInterruptElementStillSynthesizes(t *testing.T) {
 	mock := &mockTTSService{
 		synthesizeFunc: func(_ context.Context, _ string, _ tts.SynthesisConfig) (io.ReadCloser, error) {
 			return io.NopCloser(strings.NewReader("audio")), nil
@@ -447,7 +447,7 @@ func TestTTSStageWithInterruption_WithInterruption(t *testing.T) {
 	assert.Equal(t, 1, audioCount, "synthesis proceeds when no Interrupt element cancels the turn")
 }
 
-func TestTTSStageWithInterruption_PostSynthesisInterruption(t *testing.T) {
+func TestTTSStageWithInterruption_CompletedSynthesisEmittedWhenSynthCtxNotCancelled(t *testing.T) {
 	// If the synthesis context was NOT cancelled (no Interrupt in the channel),
 	// synthesis that completed is emitted even when the shared handler's interrupted
 	// flag is set.  Discarding completed audio is no longer done by polling — only

--- a/tools/arena/engine/duplex_interactive.go
+++ b/tools/arena/engine/duplex_interactive.go
@@ -50,6 +50,7 @@ func (de *DuplexConversationExecutor) RunInteractiveVoice(
 	req *ConversationRequest,
 	mic <-chan []byte,
 	play func([]byte),
+	flush func(),
 ) error {
 	// VoiceSTT is an unambiguous "use the composed STT→LLM→TTS path" signal from
 	// the caller (--voice-stt flag). Check it before the StreamInputSupport
@@ -57,14 +58,14 @@ func (de *DuplexConversationExecutor) RunInteractiveVoice(
 	// model — realtime and plain-text alike — so the type assertion alone cannot
 	// distinguish a gpt-4o-realtime session from a plain gpt-4o text agent.
 	if req.VoiceSTT != nil {
-		return de.runInteractiveVADVoice(ctx, req, mic, play)
+		return de.runInteractiveVADVoice(ctx, req, mic, play, flush)
 	}
 
 	streamProvider, ok := req.Provider.(providers.StreamInputSupport)
 	if !ok {
 		// Provider is text-only; runInteractiveVADVoice will return an error
 		// explaining that --voice-stt is required.
-		return de.runInteractiveVADVoice(ctx, req, mic, play)
+		return de.runInteractiveVADVoice(ctx, req, mic, play, flush)
 	}
 
 	pipeline, err := de.buildDuplexPipeline(req, streamProvider)
@@ -85,7 +86,7 @@ func (de *DuplexConversationExecutor) RunInteractiveVoice(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		drainAudioOutput(outputChan, play)
+		drainAudioOutput(outputChan, play, flush)
 	}()
 
 	// Feed mic frames into the pipeline until mic closes or ctx ends, then
@@ -106,9 +107,15 @@ func (de *DuplexConversationExecutor) RunInteractiveVoice(
 }
 
 // drainAudioOutput ranges over outputChan and delivers every audio frame to play.
-// It exits when outputChan is closed (by the pipeline on completion or ctx cancel).
-func drainAudioOutput(outputChan <-chan stage.StreamElement, play func([]byte)) {
+// When an Interrupt element arrives, onInterrupt is called (if non-nil) to flush
+// in-flight speaker playback, then the element is skipped. It exits when
+// outputChan is closed (by the pipeline on completion or ctx cancel).
+func drainAudioOutput(outputChan <-chan stage.StreamElement, play func([]byte), onInterrupt func()) {
 	for elem := range outputChan {
+		if elem.Interrupt && onInterrupt != nil {
+			onInterrupt()
+			continue
+		}
 		if elem.Audio != nil && len(elem.Audio.Samples) > 0 {
 			play(elem.Audio.Samples)
 		}
@@ -169,6 +176,7 @@ func (de *DuplexConversationExecutor) runInteractiveVADVoice(
 	req *ConversationRequest,
 	mic <-chan []byte,
 	play func([]byte),
+	flush func(),
 ) error {
 	if req.VoiceSTT == nil {
 		return fmt.Errorf("voice over a text agent requires an STT provider (--voice-stt)")
@@ -201,7 +209,7 @@ func (de *DuplexConversationExecutor) runInteractiveVADVoice(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		drainAudioOutput(outputChan, play)
+		drainAudioOutput(outputChan, play, flush)
 	}()
 
 	defer func() {

--- a/tools/arena/engine/duplex_interactive_multiturn_test.go
+++ b/tools/arena/engine/duplex_interactive_multiturn_test.go
@@ -157,7 +157,7 @@ func TestRunInteractiveVoice_VAD_ContinuousMultiTurn(t *testing.T) {
 	defer cancel()
 
 	runErr := make(chan error, 1)
-	go func() { runErr <- exec.RunInteractiveVoice(ctx, req, mic, play) }()
+	go func() { runErr <- exec.RunInteractiveVoice(ctx, req, mic, play, func() {}) }()
 
 	feedTurn := func() {
 		mic <- speechFrame()

--- a/tools/arena/engine/duplex_interactive_test.go
+++ b/tools/arena/engine/duplex_interactive_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
@@ -18,6 +19,23 @@ import (
 	"github.com/AltairaLabs/PromptKit/tools/arena/selfplay"
 	"github.com/AltairaLabs/PromptKit/tools/arena/statestore"
 )
+
+// TestDrainAudioOutput_InterruptFlushes verifies that drainAudioOutput delivers
+// audio frames to play and calls onInterrupt when an Interrupt element arrives.
+func TestDrainAudioOutput_InterruptFlushes(t *testing.T) {
+	out := make(chan stage.StreamElement, 2)
+	out <- stage.StreamElement{Audio: &stage.AudioData{Samples: []byte{1, 2}}}
+	out <- stage.StreamElement{Interrupt: true}
+	close(out)
+
+	var played [][]byte
+	var flushes int
+	drainAudioOutput(out, func(b []byte) { played = append(played, b) }, func() { flushes++ })
+
+	if len(played) != 1 || flushes != 1 {
+		t.Fatalf("played=%d flushes=%d, want 1/1", len(played), flushes)
+	}
+}
 
 // interactiveVoiceTestRepo is a minimal ResponseRepository for TestRunInteractiveVoice_ASM
 // that returns an audio fixture on every GetTurn call. It implements just enough of the
@@ -148,7 +166,7 @@ func TestRunInteractiveVoice_ASM_EchoesAudioToPlayback(t *testing.T) {
 	mic <- make([]byte, 320) // one 10ms-ish PCM16 frame @16kHz
 	close(mic)
 
-	if err := exec.RunInteractiveVoice(ctx, req, mic, play); err != nil {
+	if err := exec.RunInteractiveVoice(ctx, req, mic, play, func() {}); err != nil {
 		t.Fatalf("RunInteractiveVoice: %v", err)
 	}
 	if len(played) == 0 {
@@ -179,7 +197,7 @@ func TestRunInteractiveVoice_VAD_RequiresSTTProvider(t *testing.T) {
 	close(mic)
 
 	ctx := context.Background()
-	err := exec.RunInteractiveVoice(ctx, req, mic, func(_ []byte) {})
+	err := exec.RunInteractiveVoice(ctx, req, mic, func(_ []byte) {}, func() {})
 	if err == nil {
 		t.Fatal("expected error for non-streaming provider, got nil")
 	}
@@ -337,7 +355,7 @@ func TestRunInteractiveVoice_VAD_MaterializesTurn(t *testing.T) {
 	}
 	close(mic)
 
-	if err := exec.RunInteractiveVoice(ctx, req, mic, play); err != nil {
+	if err := exec.RunInteractiveVoice(ctx, req, mic, play, func() {}); err != nil {
 		t.Fatalf("RunInteractiveVoice: %v", err)
 	}
 
@@ -474,7 +492,7 @@ func TestRunInteractiveVoice_VAD_AssistantOnlySynthesized(t *testing.T) {
 	}
 	close(mic)
 
-	if err := exec.RunInteractiveVoice(ctx, req, mic, play); err != nil {
+	if err := exec.RunInteractiveVoice(ctx, req, mic, play, func() {}); err != nil {
 		t.Fatalf("RunInteractiveVoice: %v", err)
 	}
 
@@ -608,7 +626,7 @@ func TestRunInteractiveVoice_ASM_MaterializesUserTranscript(t *testing.T) {
 	mic <- make([]byte, 320) // one mic frame
 	close(mic)
 
-	if err := exec.RunInteractiveVoice(ctx, req, mic, play); err != nil {
+	if err := exec.RunInteractiveVoice(ctx, req, mic, play, func() {}); err != nil {
 		t.Fatalf("RunInteractiveVoice: %v", err)
 	}
 
@@ -761,7 +779,7 @@ func TestRunInteractiveVoice_RoutesToVADWhenVoiceSTTSet(t *testing.T) {
 	}
 	close(mic)
 
-	if err := exec.RunInteractiveVoice(ctx, req, mic, play); err != nil {
+	if err := exec.RunInteractiveVoice(ctx, req, mic, play, func() {}); err != nil {
 		t.Fatalf("RunInteractiveVoice: %v", err)
 	}
 

--- a/tools/arena/tui/app/chatpage_voice.go
+++ b/tools/arena/tui/app/chatpage_voice.go
@@ -152,8 +152,8 @@ func (p *ChatPage) runVoice(audioIO voice.AudioIO, send func(tea.Msg)) tea.Cmd {
 		send(voiceLevelMsg{user: userLevel, agent: agentLevel})
 	}
 
-	runner := voice.LiveRunner(func(runCtx context.Context, mic <-chan []byte, play func([]byte)) error {
-		return duplexExec.RunInteractiveVoice(runCtx, req, mic, play)
+	runner := voice.LiveRunner(func(runCtx context.Context, mic <-chan []byte, play func([]byte), flush func()) error {
+		return duplexExec.RunInteractiveVoice(runCtx, req, mic, play, flush)
 	})
 
 	var drv *voice.Driver

--- a/tools/arena/tui/app/chatpage_voice_test.go
+++ b/tools/arena/tui/app/chatpage_voice_test.go
@@ -50,6 +50,8 @@ func (f *fakeAudioIO) Play(frame []byte) {
 	f.playBuf = append(f.playBuf, frame)
 }
 
+func (f *fakeAudioIO) Flush() {}
+
 func (f *fakeAudioIO) Close() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/tools/arena/voice/audioio_interactive.go
+++ b/tools/arena/voice/audioio_interactive.go
@@ -3,6 +3,7 @@ package voice
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -141,6 +142,9 @@ func NewAudioIO() (AudioIO, error) {
 func (p *portaudioIO) Start(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.closed {
+		return errors.New("audio io closed")
+	}
 	if p.started {
 		return nil
 	}
@@ -217,13 +221,18 @@ func (p *portaudioIO) playLoop(ctx context.Context) {
 		case <-p.flushCh:
 			// Flush: discard the accumulation buffer so no stale audio plays, then
 			// stop+start the output stream to abort PortAudio's internal device buffer.
+			// Snapshot the stream handle + lib under a brief lock and release it BEFORE
+			// the blocking stop/start FFI calls — holding p.mu across them would stall a
+			// concurrent Close() (same pattern Close() uses).
 			buffer = buffer[:0]
 			p.mu.Lock()
-			if p.outStream != 0 {
-				_ = p.lib.stopStream(p.outStream)
-				_ = p.lib.startStream(p.outStream)
-			}
+			outStream := p.outStream
+			lib := p.lib
 			p.mu.Unlock()
+			if outStream != 0 {
+				_ = lib.stopStream(outStream)
+				_ = lib.startStream(outStream)
+			}
 		case frame, ok := <-p.playCh:
 			if !ok {
 				return

--- a/tools/arena/voice/audioio_interactive.go
+++ b/tools/arena/voice/audioio_interactive.go
@@ -239,6 +239,17 @@ func (p *portaudioIO) Play(frame []byte) {
 	}
 }
 
+// Flush is completed in #1485 follow-up (stream restart); this minimal drain keeps the interface satisfied.
+func (p *portaudioIO) Flush() {
+	for {
+		select {
+		case <-p.playCh:
+		default:
+			return
+		}
+	}
+}
+
 func (p *portaudioIO) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/tools/arena/voice/audioio_interactive.go
+++ b/tools/arena/voice/audioio_interactive.go
@@ -109,6 +109,7 @@ type portaudioIO struct {
 	outBuf    []int16
 	captureCh chan []byte
 	playCh    chan []byte
+	flushCh   chan struct{}
 	started   bool
 	closed    bool
 	done      chan struct{}
@@ -132,6 +133,7 @@ func NewAudioIO() (AudioIO, error) {
 		outBuf:    make([]int16, playbackFramesPerBuffer),
 		captureCh: make(chan []byte, captureChanBuffer),
 		playCh:    make(chan []byte, captureChanBuffer),
+		flushCh:   make(chan struct{}, 1),
 		done:      make(chan struct{}),
 	}, nil
 }
@@ -212,6 +214,16 @@ func (p *portaudioIO) playLoop(ctx context.Context) {
 			return
 		case <-p.done:
 			return
+		case <-p.flushCh:
+			// Flush: discard the accumulation buffer so no stale audio plays, then
+			// stop+start the output stream to abort PortAudio's internal device buffer.
+			buffer = buffer[:0]
+			p.mu.Lock()
+			if p.outStream != 0 {
+				_ = p.lib.stopStream(p.outStream)
+				_ = p.lib.startStream(p.outStream)
+			}
+			p.mu.Unlock()
 		case frame, ok := <-p.playCh:
 			if !ok {
 				return
@@ -239,33 +251,54 @@ func (p *portaudioIO) Play(frame []byte) {
 	}
 }
 
-// Flush is completed in #1485 follow-up (stream restart); this minimal drain keeps the interface satisfied.
-func (p *portaudioIO) Flush() {
+// requestFlush drains queued play frames and signals playLoop to abort its
+// in-flight accumulation and restart the output stream. Non-blocking.
+func (p *portaudioIO) requestFlush() {
 	for {
 		select {
 		case <-p.playCh:
 		default:
-			return
+			goto signal
 		}
+	}
+signal:
+	select {
+	case p.flushCh <- struct{}{}:
+	default:
 	}
 }
 
+// Flush implements AudioIO. It cuts playback immediately.
+func (p *portaudioIO) Flush() { p.requestFlush() }
+
 func (p *portaudioIO) Close() error {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if p.closed {
+		p.mu.Unlock()
 		return nil
 	}
 	p.closed = true
+	// Snapshot stream handles before releasing the lock. inStream/outStream are
+	// written only during Start() (which also holds mu), so the snapshots are
+	// stable for the lifetime of this call.
+	inStream := p.inStream
+	outStream := p.outStream
+	p.mu.Unlock()
+
+	// Signal goroutines to exit, then wait. mu must NOT be held across wg.Wait():
+	// playLoop's flush case acquires mu (to guard stopStream/startStream), so
+	// holding mu here while waiting for playLoop to exit is a deadlock.
 	close(p.done)
 	p.wg.Wait()
-	if p.inStream != 0 {
-		_ = p.lib.stopStream(p.inStream)
-		_ = p.lib.closeStream(p.inStream)
+
+	// Goroutines have exited; streams are no longer in use.
+	if inStream != 0 {
+		_ = p.lib.stopStream(inStream)
+		_ = p.lib.closeStream(inStream)
 	}
-	if p.outStream != 0 {
-		_ = p.lib.stopStream(p.outStream)
-		_ = p.lib.closeStream(p.outStream)
+	if outStream != 0 {
+		_ = p.lib.stopStream(outStream)
+		_ = p.lib.closeStream(outStream)
 	}
 	return p.lib.paError("terminate", p.lib.terminate())
 }

--- a/tools/arena/voice/audioio_test.go
+++ b/tools/arena/voice/audioio_test.go
@@ -95,6 +95,9 @@ func TestPortaudioIO_FlushClearsAccumulator(t *testing.T) {
 	if got := len(p.playCh); got != 0 {
 		t.Fatalf("expected playCh drained, got %d queued", got)
 	}
+	if got := len(p.flushCh); got != 1 {
+		t.Fatalf("expected flush signal queued, got %d", got)
+	}
 }
 
 // TestNewAudioIO_LoadsOrReportsMissing exercises the real purego binding. On a

--- a/tools/arena/voice/audioio_test.go
+++ b/tools/arena/voice/audioio_test.go
@@ -82,6 +82,21 @@ func TestFakeAudioIO_FlushDropsQueuedPlayback(t *testing.T) {
 	}
 }
 
+func TestPortaudioIO_FlushClearsAccumulator(t *testing.T) {
+	p := &portaudioIO{
+		outBuf:  make([]int16, playbackFramesPerBuffer),
+		playCh:  make(chan []byte, captureChanBuffer),
+		flushCh: make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	p.playCh <- make([]byte, 64)
+	p.playCh <- make([]byte, 64)
+	p.requestFlush()
+	if got := len(p.playCh); got != 0 {
+		t.Fatalf("expected playCh drained, got %d queued", got)
+	}
+}
+
 // TestNewAudioIO_LoadsOrReportsMissing exercises the real purego binding. On a
 // machine with PortAudio installed it must load + initialize successfully
 // (proving the CGO-free FFI works); otherwise it must return errPortAudioMissing

--- a/tools/arena/voice/audioio_test.go
+++ b/tools/arena/voice/audioio_test.go
@@ -1,10 +1,43 @@
 package voice
 
 import (
+	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 )
+
+// fakeAudioIO is a test double for AudioIO that records Play calls and supports
+// Flush tracking.
+type fakeAudioIO struct {
+	mu         sync.Mutex
+	queued     []byte
+	flushCount int
+	captureCh  chan []byte
+}
+
+func newFakeAudioIO() *fakeAudioIO {
+	return &fakeAudioIO{captureCh: make(chan []byte)}
+}
+
+func (f *fakeAudioIO) Start(_ context.Context) error { return nil }
+func (f *fakeAudioIO) CaptureChunks() <-chan []byte  { return f.captureCh }
+func (f *fakeAudioIO) Play(frame []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queued = append(f.queued, frame...)
+}
+func (f *fakeAudioIO) Flush() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queued = nil
+	f.flushCount++
+}
+func (f *fakeAudioIO) Close() error { return nil }
+
+func (f *fakeAudioIO) PlayedAfterFlush() []byte { f.mu.Lock(); defer f.mu.Unlock(); return f.queued }
+func (f *fakeAudioIO) FlushCount() int          { f.mu.Lock(); defer f.mu.Unlock(); return f.flushCount }
 
 // TestPortAudioCandidatesFor verifies each OS gets sensible, ordered library
 // names (the discovery list dlopen walks).
@@ -33,6 +66,19 @@ func TestPortAudioCandidatesFor(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFakeAudioIO_FlushDropsQueuedPlayback(t *testing.T) {
+	io := newFakeAudioIO()
+	io.Play([]byte{1, 2, 3, 4})
+	io.Play([]byte{5, 6, 7, 8})
+	io.Flush()
+	if got := io.PlayedAfterFlush(); len(got) != 0 {
+		t.Fatalf("expected no queued playback after flush, got %d bytes", len(got))
+	}
+	if io.FlushCount() != 1 {
+		t.Fatalf("expected 1 flush, got %d", io.FlushCount())
 	}
 }
 

--- a/tools/arena/voice/driver.go
+++ b/tools/arena/voice/driver.go
@@ -4,8 +4,10 @@ import "context"
 
 // LiveRunner consumes mic frames and emits playback frames, returning when mic
 // closes or ctx ends. engine.(*DuplexConversationExecutor).RunInteractiveVoice
-// is adapted to this signature by the chat command.
-type LiveRunner func(ctx context.Context, mic <-chan []byte, play func([]byte)) error
+// is adapted to this signature by the chat command. flush is called to drop
+// in-flight speaker audio on barge-in (Interrupt element); the driver passes
+// AudioIO.Flush so the hardware buffer is cleared immediately.
+type LiveRunner func(ctx context.Context, mic <-chan []byte, play func([]byte), flush func()) error
 
 // Driver wires hardware AudioIO to a LiveRunner and (optionally) reports RMS
 // levels for the TUI meter. It owns no LLM or pipeline knowledge.
@@ -63,7 +65,7 @@ func (d *Driver) Run(ctx context.Context) error {
 	if d.onLevel != nil || d.guard != nil {
 		mic = d.tapLevels(ctx, mic)
 	}
-	return d.run(ctx, mic, play)
+	return d.run(ctx, mic, play, d.io.Flush)
 }
 
 // tapLevels forwards mic frames while reporting their RMS as the user level.

--- a/tools/arena/voice/driver_test.go
+++ b/tools/arena/voice/driver_test.go
@@ -21,7 +21,7 @@ func (f *fakeIO) Close() error                 { return nil }
 func TestDriver_PipesMicToRunnerAndPlaysOutput(t *testing.T) {
 	io := &fakeIO{capture: make(chan []byte, 2)}
 	// runner echoes each mic frame to play, then returns when mic closes.
-	runner := func(ctx context.Context, mic <-chan []byte, play func([]byte)) error {
+	runner := func(ctx context.Context, mic <-chan []byte, play func([]byte), _ func()) error {
 		for f := range mic {
 			play(f)
 		}
@@ -52,7 +52,7 @@ func TestDriver_ReportsLevelsViaTapAndPlay(t *testing.T) {
 		userLevels = append(userLevels, user)
 		agentLevels = append(agentLevels, agent)
 	}
-	runner := func(ctx context.Context, mic <-chan []byte, play func([]byte)) error {
+	runner := func(ctx context.Context, mic <-chan []byte, play func([]byte), _ func()) error {
 		for f := range mic {
 			play(f)
 		}
@@ -101,7 +101,7 @@ func TestRMS_NonSilenceIsPositive(t *testing.T) {
 func TestDriverWithGuard_DropsQuietMicWhileAgentSpeaks(t *testing.T) {
 	io := &fakeIO{capture: make(chan []byte, 2)}
 	var received [][]byte
-	runner := func(ctx context.Context, mic <-chan []byte, play func([]byte)) error {
+	runner := func(ctx context.Context, mic <-chan []byte, play func([]byte), _ func()) error {
 		for f := range mic {
 			received = append(received, f)
 		}

--- a/tools/arena/voice/driver_test.go
+++ b/tools/arena/voice/driver_test.go
@@ -15,6 +15,7 @@ type fakeIO struct {
 func (f *fakeIO) Start(context.Context) error  { f.started = true; return nil }
 func (f *fakeIO) CaptureChunks() <-chan []byte { return f.capture }
 func (f *fakeIO) Play(b []byte)                { f.played = append(f.played, b) }
+func (f *fakeIO) Flush()                       {}
 func (f *fakeIO) Close() error                 { return nil }
 
 func TestDriver_PipesMicToRunnerAndPlaysOutput(t *testing.T) {

--- a/tools/arena/voice/types.go
+++ b/tools/arena/voice/types.go
@@ -26,6 +26,9 @@ type AudioIO interface {
 	CaptureChunks() <-chan []byte
 	// Play enqueues a PCM16 frame (PlaybackSampleRate, mono) for the speaker.
 	Play(frame []byte)
+	// Flush drops all queued and buffered playback immediately. After Flush
+	// the speaker is silent until the next Play. Safe to call concurrently.
+	Flush()
 	// Close stops devices and releases resources.
 	Close() error
 }


### PR DESCRIPTION
## What

P0 of the voice barge-in epic (#1502): make a barge-in **Interrupt actually stop in-flight speaker playback**, and clean up stale interrupt state so it doesn't leak across turns.

Until now, an interrupt cancelled *generation* but the already-buffered speaker audio kept playing (`AudioIO` had no flush), so the agent talked over you after you interrupted it.

## Changes

- **`AudioIO.Flush()`** added to the interface + the real `portaudioIO` impl: drains the play queue, resets the accumulation buffer, and stop/starts the PortAudio output stream to abort the device buffer.
- **Interrupt → Flush wired end-to-end:** `drainAudioOutput` gains an `onInterrupt` hook; `LiveRunner` carries a `flush func()`; `Driver.Run` threads `io.Flush` through `RunInteractiveVoice`/`runInteractiveVADVoice` so an in-channel `Interrupt` element flushes playback. Both the ASM and composed-VAD paths.
- **Stale interrupt-state fix:** removed the legacy `checkAndResetInterruption()` polling from the TTS stage (cancellation is now done by the in-channel `Interrupt` + per-turn `turnCanceller`), and reset the shared `InterruptionHandler` when an Interrupt element is processed. The stale `interrupted` flag previously (a) dropped the *next* turn's synthesis with "interrupted before synthesis" and (b) blocked any *second* barge-in (`handleInterruption` early-returns while the flag is set).
- **Concurrency hardening:** `Close()` now releases `p.mu` before `wg.Wait()` (removes a deadlock vs. the flush path); the flush case snapshots the stream handle so `p.mu` is never held across the blocking PortAudio FFI; `Start()` guards on `p.closed`.
- **Docs:** `voice-console-asm` README notes that `--barge-in` now flushes playback, and that open-speaker barge-in still needs AEC (#1506/#1507) so headphones remain recommended.

## Plan deviation (intentional)

The Task 1.2 plan sketch held `p.mu` across `stopStream`/`startStream` inside the `playLoop` flush case. That would deadlock against `Close()` (which waited on the play goroutine while holding `p.mu`). The implementation deliberately snapshots the handle and releases the lock before the blocking FFI instead — please don't "correct" it back toward the plan text.

## Testing

- New/updated unit tests: fake-IO flush, `portaudioIO` queue drain + flush signal, `drainAudioOutput` interrupt→flush, and TTS stale-flag/Interrupt-clears-handler behavior (with the two repurposed tests renamed to match their new invariants).
- `runtime/pipeline/stage`, `runtime/audio`, `tools/arena/voice`, `tools/arena/engine` all pass with `-race`. All four modules build clean.
- The device-buffer-abort (`stopStream`/`startStream`) path is only reachable with real audio hardware, so it's exercised manually, not in CI.

Part of epic AltairaLabs/promptarena#52. Foundation/duplex/AEC phases follow in AltairaLabs/PromptKit#1503–#1508.

Closes AltairaLabs/PromptKit#1485
