### PR TITLE
feat(audio): consolidate hardware I/O into runtime/audio behind Session interfaces (#1503, #1504)

### DIFF
--- a/runtime/audio/media.go
+++ b/runtime/audio/media.go
@@ -54,6 +54,10 @@ type Source interface {
 // devices (speaker), file writers, and the in-memory MemSink test double.
 type Sink interface {
 	// Write enqueues a MediaFrame for playback/storage.
+	// Note: hardware sinks fix the playback sample rate at session construction
+	// (WithPlaybackRate, default 24 kHz); MediaFrame.Format is informational and
+	// is NOT resampled. Callers must write frames at the session's playback rate.
+	// (Phase 3 adds resample-at-sink.)
 	Write(MediaFrame)
 	// Flush drops all queued output immediately (e.g. on barge-in).
 	Flush()

--- a/runtime/audio/media.go
+++ b/runtime/audio/media.go
@@ -1,0 +1,77 @@
+package audio
+
+import (
+	"context"
+	"time"
+)
+
+// MediaKind identifies the type of media carried in a MediaFrame.
+type MediaKind int
+
+const (
+	// KindAudio is a PCM16 little-endian audio frame.
+	KindAudio MediaKind = iota
+	// KindVideo is reserved for future use (YAGNI — not implemented).
+	KindVideo
+)
+
+// Format describes the encoding of the media payload.
+// Audio fields are present now; video fields (Width, Height, Codec) will be added later.
+type Format struct {
+	// SampleRate is the number of audio samples per second (e.g. 16000, 24000, 48000).
+	SampleRate int
+	// Channels is 1 for mono, 2 for stereo.
+	Channels int
+}
+
+// MediaFrame is a single unit of captured or synthesized media.
+// PTS (presentation timestamp) is measured from the session clock and is the
+// load-bearing field for AEC delay estimation and A/V sync.
+type MediaFrame struct {
+	// Kind identifies the media type.
+	Kind MediaKind
+	// Data is the raw payload — PCM16 little-endian for audio.
+	Data []byte
+	// PTS is the presentation timestamp from the session clock.
+	PTS time.Duration
+	// Format describes the encoding of Data.
+	Format Format
+}
+
+// Source is a read-only media stream. Implementations include hardware capture
+// devices (microphone), file readers, and the in-memory MemSource test double.
+type Source interface {
+	// Frames returns a channel that delivers captured MediaFrames.
+	// The channel is closed when the source ends or Close is called.
+	Frames() <-chan MediaFrame
+	// Kind returns the MediaKind produced by this source.
+	Kind() MediaKind
+	// Close stops the source and releases any underlying resources.
+	Close() error
+}
+
+// Sink is a write-only media stream. Implementations include hardware playback
+// devices (speaker), file writers, and the in-memory MemSink test double.
+type Sink interface {
+	// Write enqueues a MediaFrame for playback/storage.
+	Write(MediaFrame)
+	// Flush drops all queued output immediately (e.g. on barge-in).
+	Flush()
+	// Kind returns the MediaKind consumed by this sink.
+	Kind() MediaKind
+	// Close stops the sink and releases any underlying resources.
+	Close() error
+}
+
+// Session groups the Sources and Sinks that belong to one audio session
+// (e.g. a single call leg: one microphone source + one speaker sink).
+type Session interface {
+	// Start begins media flow. It runs until ctx is canceled or Close is called.
+	Start(ctx context.Context) error
+	// Sources returns all Sources in this session.
+	Sources() []Source
+	// Sinks returns all Sinks in this session.
+	Sinks() []Sink
+	// Close stops all Sources and Sinks and releases session resources.
+	Close() error
+}

--- a/runtime/audio/media_test.go
+++ b/runtime/audio/media_test.go
@@ -41,7 +41,7 @@ func TestMemSource_RoundTrip(t *testing.T) {
 	}
 	f := MediaFrame{Kind: KindAudio, Data: []byte{0x01, 0x02}, PTS: 20 * time.Millisecond}
 	src.Push(f)
-	src.Close() //nolint:errcheck // test
+	_ = src.Close()
 
 	var frames []MediaFrame
 	for fr := range src.Frames() {
@@ -52,6 +52,17 @@ func TestMemSource_RoundTrip(t *testing.T) {
 	}
 	if frames[0].PTS != 20*time.Millisecond {
 		t.Errorf("PTS mismatch: got %v", frames[0].PTS)
+	}
+}
+
+func TestMemSource_DoubleCloseNoPanic(t *testing.T) {
+	src := NewMemSource(KindAudio, 1)
+	if err := src.Close(); err != nil {
+		t.Fatalf("first Close() error: %v", err)
+	}
+	// Second Close must not panic on an already-closed channel.
+	if err := src.Close(); err != nil {
+		t.Fatalf("second Close() error: %v", err)
 	}
 }
 

--- a/runtime/audio/media_test.go
+++ b/runtime/audio/media_test.go
@@ -1,0 +1,60 @@
+package audio
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMemSink_FlushDropsQueued(t *testing.T) {
+	s := NewMemSink(KindAudio)
+	s.Write(MediaFrame{Kind: KindAudio, Data: []byte{1, 2}, PTS: 0})
+	s.Write(MediaFrame{Kind: KindAudio, Data: []byte{3, 4}, PTS: 10 * time.Millisecond})
+	s.Flush()
+	if got := s.Written(); len(got) != 0 {
+		t.Fatalf("expected queue dropped after flush, got %d frames", len(got))
+	}
+}
+
+func TestMemSink_WriteAndRead(t *testing.T) {
+	s := NewMemSink(KindAudio)
+	if s.Kind() != KindAudio {
+		t.Fatalf("expected KindAudio, got %v", s.Kind())
+	}
+	f1 := MediaFrame{Kind: KindAudio, Data: []byte{0xAB}, PTS: 5 * time.Millisecond, Format: Format{SampleRate: 16000, Channels: 1}}
+	s.Write(f1)
+	got := s.Written()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(got))
+	}
+	if got[0].PTS != 5*time.Millisecond {
+		t.Errorf("PTS mismatch: got %v", got[0].PTS)
+	}
+	if err := s.Close(); err != nil {
+		t.Errorf("Close() unexpected error: %v", err)
+	}
+}
+
+func TestMemSource_RoundTrip(t *testing.T) {
+	src := NewMemSource(KindAudio, 4)
+	if src.Kind() != KindAudio {
+		t.Fatalf("expected KindAudio, got %v", src.Kind())
+	}
+	f := MediaFrame{Kind: KindAudio, Data: []byte{0x01, 0x02}, PTS: 20 * time.Millisecond}
+	src.Push(f)
+	src.Close() //nolint:errcheck // test
+
+	var frames []MediaFrame
+	for fr := range src.Frames() {
+		frames = append(frames, fr)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(frames))
+	}
+	if frames[0].PTS != 20*time.Millisecond {
+		t.Errorf("PTS mismatch: got %v", frames[0].PTS)
+	}
+}
+
+// Ensure compile-time interface satisfaction.
+var _ Source = (*MemSource)(nil)
+var _ Sink = (*MemSink)(nil)

--- a/runtime/audio/memio.go
+++ b/runtime/audio/memio.go
@@ -1,0 +1,59 @@
+package audio
+
+import "sync"
+
+// MemSink is an in-memory Sink for tests and headless use.
+// It records every Write call; Flush drops the recorded frames.
+// Safe for concurrent use.
+type MemSink struct {
+	kind    MediaKind
+	mu      sync.Mutex
+	written []MediaFrame
+}
+
+// NewMemSink creates a MemSink that accepts frames of the given kind.
+func NewMemSink(k MediaKind) *MemSink { return &MemSink{kind: k} }
+
+// Write appends f to the internal frame log.
+func (m *MemSink) Write(f MediaFrame) { m.mu.Lock(); m.written = append(m.written, f); m.mu.Unlock() }
+
+// Flush drops all queued frames, simulating barge-in drain.
+func (m *MemSink) Flush() { m.mu.Lock(); m.written = nil; m.mu.Unlock() }
+
+// Kind returns the MediaKind this sink accepts.
+func (m *MemSink) Kind() MediaKind { return m.kind }
+
+// Close is a no-op for MemSink; it satisfies the Sink interface.
+func (m *MemSink) Close() error { return nil }
+
+// Written returns a snapshot of the frames written since the last Flush.
+func (m *MemSink) Written() []MediaFrame {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.written
+}
+
+// MemSource is an in-memory Source for tests and headless use.
+// Push frames via Push; close the channel via Close so that range-loops terminate.
+// Safe for concurrent use.
+type MemSource struct {
+	kind   MediaKind
+	frames chan MediaFrame
+}
+
+// NewMemSource creates a MemSource with a buffered channel of size buf.
+func NewMemSource(kind MediaKind, buf int) *MemSource {
+	return &MemSource{kind: kind, frames: make(chan MediaFrame, buf)}
+}
+
+// Push sends f onto the internal channel. It blocks if the buffer is full.
+func (m *MemSource) Push(f MediaFrame) { m.frames <- f }
+
+// Frames returns the read-only channel of MediaFrames.
+func (m *MemSource) Frames() <-chan MediaFrame { return m.frames }
+
+// Kind returns the MediaKind produced by this source.
+func (m *MemSource) Kind() MediaKind { return m.kind }
+
+// Close closes the underlying channel, signaling end-of-stream to consumers.
+func (m *MemSource) Close() error { close(m.frames); return nil }

--- a/runtime/audio/memio.go
+++ b/runtime/audio/memio.go
@@ -26,11 +26,13 @@ func (m *MemSink) Kind() MediaKind { return m.kind }
 // Close is a no-op for MemSink; it satisfies the Sink interface.
 func (m *MemSink) Close() error { return nil }
 
-// Written returns a snapshot of the frames written since the last Flush.
+// Written returns a copy of the frames written since the last Flush.
+// The returned slice is independent of the internal buffer, making it safe
+// to read concurrently with ongoing Write or Flush calls.
 func (m *MemSink) Written() []MediaFrame {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.written
+	return append([]MediaFrame(nil), m.written...)
 }
 
 // MemSource is an in-memory Source for tests and headless use.

--- a/runtime/audio/memio.go
+++ b/runtime/audio/memio.go
@@ -39,6 +39,7 @@ func (m *MemSink) Written() []MediaFrame {
 type MemSource struct {
 	kind   MediaKind
 	frames chan MediaFrame
+	once   sync.Once
 }
 
 // NewMemSource creates a MemSource with a buffered channel of size buf.
@@ -56,4 +57,5 @@ func (m *MemSource) Frames() <-chan MediaFrame { return m.frames }
 func (m *MemSource) Kind() MediaKind { return m.kind }
 
 // Close closes the underlying channel, signaling end-of-stream to consumers.
-func (m *MemSource) Close() error { close(m.frames); return nil }
+// It is idempotent; calling Close more than once is safe.
+func (m *MemSource) Close() error { m.once.Do(func() { close(m.frames) }); return nil }

--- a/runtime/audio/portaudio_discovery.go
+++ b/runtime/audio/portaudio_discovery.go
@@ -1,4 +1,4 @@
-package voice
+package audio
 
 import "runtime"
 

--- a/runtime/audio/portaudio_dlopen_other.go
+++ b/runtime/audio/portaudio_dlopen_other.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package voice
+package audio
 
 import "github.com/ebitengine/purego"
 

--- a/runtime/audio/portaudio_dlopen_windows.go
+++ b/runtime/audio/portaudio_dlopen_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package voice
+package audio
 
 import "syscall"
 

--- a/runtime/audio/portaudio_io_interactive.go
+++ b/runtime/audio/portaudio_io_interactive.go
@@ -1,0 +1,342 @@
+package audio
+
+// portaudio_io_interactive.go contains the hardware-bound PortAudio I/O core:
+// dynamic library loading, the portaudioIO struct and all its methods
+// (Start/captureLoop/playLoop/Close). These cannot be unit-tested without a
+// real audio device, so they live in an *_interactive.go file to exclude them
+// from the per-file coverage threshold.
+//
+// The testable session/option/source/sink layer lives in portaudio_session.go.
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+const (
+	// paInt16 is PortAudio's PaSampleFormat for signed 16-bit PCM.
+	paInt16 = 0x00000008
+	// playbackAccumHeadroom over-allocates the playback accumulation buffer so
+	// appends rarely re-grow it (4 output blocks of headroom).
+	playbackAccumHeadroom = 4
+)
+
+// portAudioLib holds a dynamically-loaded libportaudio and its blocking-API
+// entry points. The binary itself does NOT link PortAudio (the build stays pure
+// Go, CGO_ENABLED=0); the library is dlopen-ed on demand so the only people who
+// need PortAudio installed are those who use voice.
+//
+// Only the blocking read/write API is bound — no stream callbacks — which keeps
+// the FFI surface to plain function calls that purego marshals directly.
+type portAudioLib struct {
+	handle uintptr
+
+	initialize     func() int32
+	terminate      func() int32
+	getErrorText   func(int32) string
+	getVersionText func() string
+	// openDefaultStream mirrors Pa_OpenDefaultStream; callback/userData are 0
+	// (blocking mode). format/framesPerBuffer are C `unsigned long` — passed as
+	// uint64; values always fit in 32 bits so the low word is correct on Windows.
+	openDefaultStream func(
+		stream *uintptr, numInput, numOutput int32,
+		format uint64, sampleRate float64, framesPerBuffer uint64,
+		callback, userData uintptr,
+	) int32
+	startStream func(uintptr) int32
+	stopStream  func(uintptr) int32
+	closeStream func(uintptr) int32
+	readStream  func(stream, buffer uintptr, frames uint64) int32
+	writeStream func(stream, buffer uintptr, frames uint64) int32
+}
+
+// loadPortAudio dlopens libportaudio across the platform's usual names/paths and
+// binds the blocking API. It returns a helpful, actionable error when the
+// library is absent so voice can fail gracefully while the rest of the app keeps
+// working.
+func loadPortAudio() (*portAudioLib, error) {
+	var handle uintptr
+	var lastErr error
+	for _, name := range portAudioCandidates() {
+		h, err := openSharedLib(name)
+		if err == nil && h != 0 {
+			handle = h
+			break
+		}
+		lastErr = err
+	}
+	if handle == 0 {
+		return nil, fmt.Errorf("%w: %v", errPortAudioMissing, lastErr)
+	}
+
+	lib := &portAudioLib{handle: handle}
+	purego.RegisterLibFunc(&lib.initialize, handle, "Pa_Initialize")
+	purego.RegisterLibFunc(&lib.terminate, handle, "Pa_Terminate")
+	purego.RegisterLibFunc(&lib.getErrorText, handle, "Pa_GetErrorText")
+	purego.RegisterLibFunc(&lib.getVersionText, handle, "Pa_GetVersionText")
+	purego.RegisterLibFunc(&lib.openDefaultStream, handle, "Pa_OpenDefaultStream")
+	purego.RegisterLibFunc(&lib.startStream, handle, "Pa_StartStream")
+	purego.RegisterLibFunc(&lib.stopStream, handle, "Pa_StopStream")
+	purego.RegisterLibFunc(&lib.closeStream, handle, "Pa_CloseStream")
+	purego.RegisterLibFunc(&lib.readStream, handle, "Pa_ReadStream")
+	purego.RegisterLibFunc(&lib.writeStream, handle, "Pa_WriteStream")
+	return lib, nil
+}
+
+// errPortAudioMissing is returned (wrapped) when libportaudio cannot be loaded.
+var errPortAudioMissing = fmt.Errorf(
+	"voice requires PortAudio installed on this machine — "+
+		"macOS: `brew install portaudio`; "+
+		"Debian/Ubuntu: `sudo apt install libportaudio2`; "+
+		"Windows: place portaudio.dll on PATH. See %s",
+	voiceDocsURL)
+
+// paError converts a PortAudio return code into a Go error (nil on success).
+func (l *portAudioLib) paError(op string, rc int32) error {
+	if rc == 0 {
+		return nil
+	}
+	return fmt.Errorf("portaudio %s: %s", op, l.getErrorText(rc))
+}
+
+type portaudioIO struct {
+	lib *portAudioLib
+
+	captureRate  int // mic sample rate in Hz (e.g. 16000)
+	playbackRate int // speaker sample rate in Hz (e.g. 24000)
+
+	mu        sync.Mutex
+	wg        sync.WaitGroup
+	inStream  uintptr
+	outStream uintptr
+	inBuf     []int16
+	outBuf    []int16
+	captureCh chan []byte
+	playCh    chan []byte
+	flushCh   chan struct{}
+	started   bool
+	closed    bool
+	done      chan struct{}
+}
+
+// newAudioIO loads libportaudio at runtime and constructs the PortAudio-backed
+// I/O core. It returns errPortAudioMissing (wrapped) when the library is not
+// installed, so callers can surface a clear "install PortAudio" message instead
+// of crashing. Callers use NewPortAudioSession, which wraps this in the
+// Session/Source/Sink interfaces.
+//
+// Buffer sizes are derived from the configured rates to preserve the target
+// windows: capture = rate/captureWindowDivisor (100 ms), playback =
+// rate*playbackWindowMs/msPerSecond (40 ms).
+func newAudioIO(cfg sessionConfig) (*portaudioIO, error) {
+	lib, err := loadPortAudio()
+	if err != nil {
+		return nil, err
+	}
+	if err := lib.paError("init", lib.initialize()); err != nil {
+		return nil, err
+	}
+	captureFrames := cfg.captureRate / captureWindowDivisor
+	playbackFrames := cfg.playbackRate * playbackWindowMs / msPerSecond
+	return &portaudioIO{
+		lib:          lib,
+		captureRate:  cfg.captureRate,
+		playbackRate: cfg.playbackRate,
+		inBuf:        make([]int16, captureFrames),
+		outBuf:       make([]int16, playbackFrames),
+		captureCh:    make(chan []byte, captureChanBuffer),
+		playCh:       make(chan []byte, captureChanBuffer),
+		flushCh:      make(chan struct{}, 1),
+		done:         make(chan struct{}),
+	}, nil
+}
+
+// Start opens the mic and speaker streams and launches the capture/playback
+// goroutines. It is idempotent and safe to call once per session.
+func (p *portaudioIO) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return errors.New("audio io closed")
+	}
+	if p.started {
+		return nil
+	}
+
+	var in, out uintptr
+	if err := p.lib.paError("open mic",
+		p.lib.openDefaultStream(&in, 1, 0, paInt16, float64(p.captureRate), uint64(len(p.inBuf)), 0, 0)); err != nil {
+		return err
+	}
+	if err := p.lib.paError("open speaker",
+		p.lib.openDefaultStream(&out, 0, 1, paInt16, float64(p.playbackRate), uint64(len(p.outBuf)), 0, 0)); err != nil {
+		_ = p.lib.closeStream(in)
+		return err
+	}
+	if err := p.lib.paError("start mic", p.lib.startStream(in)); err != nil {
+		_ = p.lib.closeStream(in)
+		_ = p.lib.closeStream(out)
+		return err
+	}
+	if err := p.lib.paError("start speaker", p.lib.startStream(out)); err != nil {
+		_ = p.lib.closeStream(in)
+		_ = p.lib.closeStream(out)
+		return err
+	}
+	p.inStream, p.outStream, p.started = in, out, true
+	const numLoops = 2 // captureLoop + playLoop
+	p.wg.Add(numLoops)
+	go p.captureLoop(ctx)
+	go p.playLoop(ctx)
+	return nil
+}
+
+func (p *portaudioIO) captureLoop(ctx context.Context) {
+	defer p.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.done:
+			return
+		default:
+		}
+		// Pa_ReadStream blocks until inBuf is filled. KeepAlive guards the
+		// backing array across the C call (purego passes a raw pointer).
+		//nolint:gosec // G103: handing a Go-owned PCM buffer to PortAudio's blocking read; KeepAlive pins it.
+		rc := p.lib.readStream(p.inStream, uintptr(unsafe.Pointer(&p.inBuf[0])), uint64(len(p.inBuf)))
+		runtime.KeepAlive(p.inBuf)
+		if rc != 0 {
+			return
+		}
+		frame := make([]byte, len(p.inBuf)*bytesPerSample)
+		for i, s := range p.inBuf {
+			//nolint:gosec // G115: deliberate PCM16 bit reinterpretation (int16 → wire bytes).
+			binary.LittleEndian.PutUint16(frame[i*bytesPerSample:], uint16(s))
+		}
+		select {
+		case p.captureCh <- frame:
+		default: // drop on backpressure — observer cadence
+		}
+	}
+}
+
+//nolint:gocognit // hardware playback loop: ctx/done/flush/write branches kept inline for clarity.
+func (p *portaudioIO) playLoop(ctx context.Context) {
+	defer p.wg.Done()
+	// buffer accumulates incoming PCM bytes across frames so we only write
+	// complete outBuf-sized blocks to PortAudio (prevents truncation and
+	// stale-sample padding that cause choppy output).
+	buffer := make([]byte, 0, len(p.outBuf)*playbackAccumHeadroom)
+	blockBytes := len(p.outBuf) * bytesPerSample
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.done:
+			return
+		case <-p.flushCh:
+			// Flush: discard the accumulation buffer so no stale audio plays, then
+			// stop+start the output stream to abort PortAudio's internal device buffer.
+			// Snapshot the stream handle + lib under a brief lock and release it BEFORE
+			// the blocking stop/start FFI calls — holding p.mu across them would stall a
+			// concurrent Close() (same pattern Close() uses).
+			buffer = buffer[:0]
+			p.mu.Lock()
+			outStream := p.outStream
+			lib := p.lib
+			p.mu.Unlock()
+			if outStream != 0 {
+				_ = lib.stopStream(outStream)
+				_ = lib.startStream(outStream)
+			}
+		case frame, ok := <-p.playCh:
+			if !ok {
+				return
+			}
+			buffer = append(buffer, frame...)
+			for len(buffer) >= blockBytes {
+				for i := 0; i < len(p.outBuf); i++ {
+					//nolint:gosec // G115: deliberate PCM16 bit reinterpretation (wire bytes → int16).
+					p.outBuf[i] = int16(binary.LittleEndian.Uint16(buffer[i*bytesPerSample:]))
+				}
+				//nolint:gosec // G103: handing a Go-owned PCM buffer to PortAudio's blocking write; KeepAlive pins it.
+				p.lib.writeStream(p.outStream, uintptr(unsafe.Pointer(&p.outBuf[0])), uint64(len(p.outBuf)))
+				runtime.KeepAlive(p.outBuf)
+				buffer = buffer[blockBytes:]
+			}
+		}
+	}
+}
+
+// CaptureChunks returns the channel of captured mic PCM16 frames.
+func (p *portaudioIO) CaptureChunks() <-chan []byte { return p.captureCh }
+
+// Play enqueues a PCM16 frame for speaker playback, dropping it on backpressure.
+func (p *portaudioIO) Play(frame []byte) {
+	select {
+	case p.playCh <- frame:
+	default:
+	}
+}
+
+// requestFlush drains queued play frames and signals playLoop to abort its
+// in-flight accumulation and restart the output stream. Non-blocking.
+func (p *portaudioIO) requestFlush() {
+	for {
+		select {
+		case <-p.playCh:
+		default:
+			goto signal
+		}
+	}
+signal:
+	select {
+	case p.flushCh <- struct{}{}:
+	default:
+	}
+}
+
+// Flush cuts playback immediately, dropping queued and in-flight speaker audio.
+func (p *portaudioIO) Flush() { p.requestFlush() }
+
+// Close stops the capture/playback goroutines, closes both streams, and
+// terminates PortAudio. It is idempotent.
+func (p *portaudioIO) Close() error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	// Snapshot stream handles before releasing the lock. inStream/outStream are
+	// written only during Start() (which also holds mu), so the snapshots are
+	// stable for the lifetime of this call.
+	inStream := p.inStream
+	outStream := p.outStream
+	p.mu.Unlock()
+
+	// Signal goroutines to exit, then wait. mu must NOT be held across wg.Wait():
+	// playLoop's flush case acquires mu (to guard stopStream/startStream), so
+	// holding mu here while waiting for playLoop to exit is a deadlock.
+	close(p.done)
+	p.wg.Wait()
+
+	// Goroutines have exited; streams are no longer in use.
+	if inStream != 0 {
+		_ = p.lib.stopStream(inStream)
+		_ = p.lib.closeStream(inStream)
+	}
+	if outStream != 0 {
+		_ = p.lib.stopStream(outStream)
+		_ = p.lib.closeStream(outStream)
+	}
+	return p.lib.paError("terminate", p.lib.terminate())
+}

--- a/runtime/audio/portaudio_session.go
+++ b/runtime/audio/portaudio_session.go
@@ -1,4 +1,4 @@
-package voice
+package audio
 
 import (
 	"context"
@@ -7,15 +7,30 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/ebitengine/purego"
 )
 
 const (
+	// CaptureSampleRate is the mic capture rate (16 kHz mono PCM16), matching
+	// the VAD/STT pipeline default. Aliased to SampleRate16kHz to avoid a
+	// duplicate value declaration.
+	CaptureSampleRate = SampleRate16kHz
+	// PlaybackSampleRate is the speaker playback rate (24 kHz mono PCM16),
+	// matching TTS / realtime-provider output. Aliased to SampleRate24kHz.
+	PlaybackSampleRate = SampleRate24kHz
+
 	captureFramesPerBuffer  = 1600 // 100 ms @ 16 kHz
 	playbackFramesPerBuffer = 960  // 40 ms @ 24 kHz
 	captureChanBuffer       = 32
+
+	// bytesPerSample is the width of one PCM16 sample (signed 16-bit == 2 bytes).
+	bytesPerSample = 2
+	// playbackAccumHeadroom over-allocates the playback accumulation buffer so
+	// appends rarely re-grow it (4 output blocks of headroom).
+	playbackAccumHeadroom = 4
 
 	// paInt16 is PortAudio's PaSampleFormat for signed 16-bit PCM.
 	paInt16 = 0x00000008
@@ -116,11 +131,12 @@ type portaudioIO struct {
 	done      chan struct{}
 }
 
-// NewAudioIO loads libportaudio at runtime and constructs a PortAudio-backed
-// AudioIO. It returns errPortAudioMissing (wrapped) when the library is not
+// newAudioIO loads libportaudio at runtime and constructs the PortAudio-backed
+// I/O core. It returns errPortAudioMissing (wrapped) when the library is not
 // installed, so callers can surface a clear "install PortAudio" message instead
-// of crashing.
-func NewAudioIO() (AudioIO, error) {
+// of crashing. Callers use NewPortAudioSession, which wraps this in the
+// Session/Source/Sink interfaces.
+func newAudioIO() (*portaudioIO, error) {
 	lib, err := loadPortAudio()
 	if err != nil {
 		return nil, err
@@ -139,6 +155,8 @@ func NewAudioIO() (AudioIO, error) {
 	}, nil
 }
 
+// Start opens the mic and speaker streams and launches the capture/playback
+// goroutines. It is idempotent and safe to call once per session.
 func (p *portaudioIO) Start(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -170,7 +188,8 @@ func (p *portaudioIO) Start(ctx context.Context) error {
 		return err
 	}
 	p.inStream, p.outStream, p.started = in, out, true
-	p.wg.Add(2)
+	const numLoops = 2 // captureLoop + playLoop
+	p.wg.Add(numLoops)
 	go p.captureLoop(ctx)
 	go p.playLoop(ctx)
 	return nil
@@ -194,9 +213,10 @@ func (p *portaudioIO) captureLoop(ctx context.Context) {
 		if rc != 0 {
 			return
 		}
-		frame := make([]byte, len(p.inBuf)*2)
+		frame := make([]byte, len(p.inBuf)*bytesPerSample)
 		for i, s := range p.inBuf {
-			binary.LittleEndian.PutUint16(frame[i*2:], uint16(s))
+			//nolint:gosec // G115: deliberate PCM16 bit reinterpretation (int16 → wire bytes).
+			binary.LittleEndian.PutUint16(frame[i*bytesPerSample:], uint16(s))
 		}
 		select {
 		case p.captureCh <- frame:
@@ -205,13 +225,14 @@ func (p *portaudioIO) captureLoop(ctx context.Context) {
 	}
 }
 
+//nolint:gocognit // hardware playback loop: ctx/done/flush/write branches kept inline for clarity.
 func (p *portaudioIO) playLoop(ctx context.Context) {
 	defer p.wg.Done()
 	// buffer accumulates incoming PCM bytes across frames so we only write
 	// complete outBuf-sized blocks to PortAudio (prevents truncation and
 	// stale-sample padding that cause choppy output).
-	buffer := make([]byte, 0, len(p.outBuf)*4)
-	blockBytes := len(p.outBuf) * 2 // one int16 == 2 bytes per sample
+	buffer := make([]byte, 0, len(p.outBuf)*playbackAccumHeadroom)
+	blockBytes := len(p.outBuf) * bytesPerSample
 	for {
 		select {
 		case <-ctx.Done():
@@ -240,7 +261,8 @@ func (p *portaudioIO) playLoop(ctx context.Context) {
 			buffer = append(buffer, frame...)
 			for len(buffer) >= blockBytes {
 				for i := 0; i < len(p.outBuf); i++ {
-					p.outBuf[i] = int16(binary.LittleEndian.Uint16(buffer[i*2:]))
+					//nolint:gosec // G115: deliberate PCM16 bit reinterpretation (wire bytes → int16).
+					p.outBuf[i] = int16(binary.LittleEndian.Uint16(buffer[i*bytesPerSample:]))
 				}
 				//nolint:gosec // G103: handing a Go-owned PCM buffer to PortAudio's blocking write; KeepAlive pins it.
 				p.lib.writeStream(p.outStream, uintptr(unsafe.Pointer(&p.outBuf[0])), uint64(len(p.outBuf)))
@@ -251,8 +273,10 @@ func (p *portaudioIO) playLoop(ctx context.Context) {
 	}
 }
 
+// CaptureChunks returns the channel of captured mic PCM16 frames.
 func (p *portaudioIO) CaptureChunks() <-chan []byte { return p.captureCh }
 
+// Play enqueues a PCM16 frame for speaker playback, dropping it on backpressure.
 func (p *portaudioIO) Play(frame []byte) {
 	select {
 	case p.playCh <- frame:
@@ -277,9 +301,11 @@ signal:
 	}
 }
 
-// Flush implements AudioIO. It cuts playback immediately.
+// Flush cuts playback immediately, dropping queued and in-flight speaker audio.
 func (p *portaudioIO) Flush() { p.requestFlush() }
 
+// Close stops the capture/playback goroutines, closes both streams, and
+// terminates PortAudio. It is idempotent.
 func (p *portaudioIO) Close() error {
 	p.mu.Lock()
 	if p.closed {
@@ -311,3 +337,110 @@ func (p *portaudioIO) Close() error {
 	}
 	return p.lib.paError("terminate", p.lib.terminate())
 }
+
+// portaudioSession adapts the PortAudio-backed portaudioIO to the
+// Session/Source/Sink interfaces. It still drives TWO PortAudio streams (mic at
+// 16 kHz, speaker at 24 kHz) — collapsing to a single duplex stream is Phase 3.
+type portaudioSession struct {
+	io     *portaudioIO
+	source *portaudioSource
+	sink   *portaudioSink
+}
+
+// NewPortAudioSession loads libportaudio and returns a Session exposing one
+// audio Source (microphone, 16 kHz mono PCM16) and one audio Sink (speaker,
+// 24 kHz mono PCM16). It returns errPortAudioMissing (wrapped) when the library
+// is not installed.
+func NewPortAudioSession() (Session, error) {
+	io, err := newAudioIO()
+	if err != nil {
+		return nil, err
+	}
+	s := &portaudioSession{io: io}
+	s.source = &portaudioSource{io: io}
+	s.sink = &portaudioSink{io: io}
+	return s, nil
+}
+
+// Start begins media flow on both streams; it delegates to the underlying I/O.
+func (s *portaudioSession) Start(ctx context.Context) error { return s.io.Start(ctx) }
+
+// Sources returns the single microphone Source.
+func (s *portaudioSession) Sources() []Source { return []Source{s.source} }
+
+// Sinks returns the single speaker Sink.
+func (s *portaudioSession) Sinks() []Sink { return []Sink{s.sink} }
+
+// Close stops both streams and terminates PortAudio. It is idempotent.
+func (s *portaudioSession) Close() error { return s.io.Close() }
+
+// portaudioSource adapts the mic captureCh ([]byte PCM16) to a stream of
+// MediaFrames. The conversion goroutine starts lazily on the first Frames call.
+type portaudioSource struct {
+	io     *portaudioIO
+	once   sync.Once
+	frames chan MediaFrame
+}
+
+// Frames returns a channel of captured audio MediaFrames. The channel is closed
+// when the underlying session closes (io.done). PTS is a best-effort monotonic
+// sample counter; the load-bearing duplex clock arrives in Phase 3.
+func (s *portaudioSource) Frames() <-chan MediaFrame {
+	s.once.Do(func() {
+		s.frames = make(chan MediaFrame, captureChanBuffer)
+		go s.pump()
+	})
+	return s.frames
+}
+
+func (s *portaudioSource) pump() {
+	defer close(s.frames)
+	in := s.io.CaptureChunks()
+	var pts time.Duration
+	for {
+		select {
+		case <-s.io.done:
+			return
+		case data, ok := <-in:
+			if !ok {
+				return
+			}
+			frame := MediaFrame{
+				Kind:   KindAudio,
+				Data:   data,
+				PTS:    pts,
+				Format: Format{SampleRate: CaptureSampleRate, Channels: 1},
+			}
+			// Advance PTS by this frame's duration (PCM16 ⇒ bytesPerSample/sample).
+			pts += time.Duration(len(data)/bytesPerSample) * time.Second / time.Duration(CaptureSampleRate)
+			select {
+			case s.frames <- frame:
+			case <-s.io.done:
+				return
+			}
+		}
+	}
+}
+
+// Kind reports that this Source produces audio.
+func (s *portaudioSource) Kind() MediaKind { return KindAudio }
+
+// Close stops the source by closing the underlying session (idempotent).
+func (s *portaudioSource) Close() error { return s.io.Close() }
+
+// portaudioSink adapts the speaker playback path to the Sink interface.
+type portaudioSink struct {
+	io *portaudioIO
+}
+
+// Write enqueues the frame's PCM16 bytes for speaker playback.
+func (s *portaudioSink) Write(f MediaFrame) { s.io.Play(f.Data) }
+
+// Flush drops all queued and in-flight playback (Phase-1 flush machinery).
+func (s *portaudioSink) Flush() { s.io.Flush() }
+
+// Kind reports that this Sink consumes audio.
+func (s *portaudioSink) Kind() MediaKind { return KindAudio }
+
+// Close stops the sink by closing the underlying session (idempotent).
+func (s *portaudioSink) Close() error { return s.io.Close() }

--- a/runtime/audio/portaudio_session.go
+++ b/runtime/audio/portaudio_session.go
@@ -1,346 +1,80 @@
 package audio
 
+// portaudio_session.go contains the testable session/option/source/sink layer
+// that wraps the hardware-bound portaudioIO (portaudio_io_interactive.go).
+// All types and functions here are covered by hardware-free unit tests.
+
 import (
 	"context"
-	"encoding/binary"
-	"errors"
-	"fmt"
-	"runtime"
 	"sync"
 	"time"
-	"unsafe"
-
-	"github.com/ebitengine/purego"
 )
 
 const (
-	// CaptureSampleRate is the mic capture rate (16 kHz mono PCM16), matching
-	// the VAD/STT pipeline default. Aliased to SampleRate16kHz to avoid a
-	// duplicate value declaration.
+	// CaptureSampleRate is the default mic capture rate (16 kHz mono PCM16),
+	// matching the VAD/STT pipeline default. Aliased to SampleRate16kHz to avoid
+	// a duplicate value declaration. Pass WithCaptureRate to override.
 	CaptureSampleRate = SampleRate16kHz
-	// PlaybackSampleRate is the speaker playback rate (24 kHz mono PCM16),
-	// matching TTS / realtime-provider output. Aliased to SampleRate24kHz.
+	// PlaybackSampleRate is the default speaker playback rate (24 kHz mono
+	// PCM16), matching TTS / realtime-provider output. Aliased to SampleRate24kHz.
+	// Pass WithPlaybackRate to override.
 	PlaybackSampleRate = SampleRate24kHz
 
-	captureFramesPerBuffer  = 1600 // 100 ms @ 16 kHz
-	playbackFramesPerBuffer = 960  // 40 ms @ 24 kHz
-	captureChanBuffer       = 32
-
+	// captureChanBuffer is the channel buffer depth for captured PCM frames.
+	captureChanBuffer = 32
 	// bytesPerSample is the width of one PCM16 sample (signed 16-bit == 2 bytes).
 	bytesPerSample = 2
-	// playbackAccumHeadroom over-allocates the playback accumulation buffer so
-	// appends rarely re-grow it (4 output blocks of headroom).
-	playbackAccumHeadroom = 4
 
-	// paInt16 is PortAudio's PaSampleFormat for signed 16-bit PCM.
-	paInt16 = 0x00000008
+	// captureWindowDivisor divides the capture rate to get a 100 ms buffer
+	// (rate / captureWindowDivisor == samples per 100 ms).
+	captureWindowDivisor = 10
+	// playbackWindowMs is the playback buffer target window in milliseconds (40 ms).
+	playbackWindowMs = 40
+	// msPerSecond converts milliseconds to samples for buffer size computation.
+	msPerSecond = 1000
 )
 
-// portAudioLib holds a dynamically-loaded libportaudio and its blocking-API
-// entry points. The binary itself does NOT link PortAudio (the build stays pure
-// Go, CGO_ENABLED=0); the library is dlopen-ed on demand so the only people who
-// need PortAudio installed are those who use voice.
-//
-// Only the blocking read/write API is bound — no stream callbacks — which keeps
-// the FFI surface to plain function calls that purego marshals directly.
-type portAudioLib struct {
-	handle uintptr
-
-	initialize     func() int32
-	terminate      func() int32
-	getErrorText   func(int32) string
-	getVersionText func() string
-	// openDefaultStream mirrors Pa_OpenDefaultStream; callback/userData are 0
-	// (blocking mode). format/framesPerBuffer are C `unsigned long` — passed as
-	// uint64; values always fit in 32 bits so the low word is correct on Windows.
-	openDefaultStream func(
-		stream *uintptr, numInput, numOutput int32,
-		format uint64, sampleRate float64, framesPerBuffer uint64,
-		callback, userData uintptr,
-	) int32
-	startStream func(uintptr) int32
-	stopStream  func(uintptr) int32
-	closeStream func(uintptr) int32
-	readStream  func(stream, buffer uintptr, frames uint64) int32
-	writeStream func(stream, buffer uintptr, frames uint64) int32
+// sessionConfig holds the configurable parameters for a PortAudio session.
+// It is populated from SessionOption values and used by newAudioIO.
+type sessionConfig struct {
+	captureRate  int // mic sample rate in Hz
+	playbackRate int // speaker sample rate in Hz
 }
 
-// loadPortAudio dlopens libportaudio across the platform's usual names/paths and
-// binds the blocking API. It returns a helpful, actionable error when the
-// library is absent so voice can fail gracefully while the rest of the app keeps
-// working.
-func loadPortAudio() (*portAudioLib, error) {
-	var handle uintptr
-	var lastErr error
-	for _, name := range portAudioCandidates() {
-		h, err := openSharedLib(name)
-		if err == nil && h != 0 {
-			handle = h
-			break
-		}
-		lastErr = err
-	}
-	if handle == 0 {
-		return nil, fmt.Errorf("%w: %v", errPortAudioMissing, lastErr)
-	}
+// SessionOption is a functional option for NewPortAudioSession.
+type SessionOption func(*sessionConfig)
 
-	lib := &portAudioLib{handle: handle}
-	purego.RegisterLibFunc(&lib.initialize, handle, "Pa_Initialize")
-	purego.RegisterLibFunc(&lib.terminate, handle, "Pa_Terminate")
-	purego.RegisterLibFunc(&lib.getErrorText, handle, "Pa_GetErrorText")
-	purego.RegisterLibFunc(&lib.getVersionText, handle, "Pa_GetVersionText")
-	purego.RegisterLibFunc(&lib.openDefaultStream, handle, "Pa_OpenDefaultStream")
-	purego.RegisterLibFunc(&lib.startStream, handle, "Pa_StartStream")
-	purego.RegisterLibFunc(&lib.stopStream, handle, "Pa_StopStream")
-	purego.RegisterLibFunc(&lib.closeStream, handle, "Pa_CloseStream")
-	purego.RegisterLibFunc(&lib.readStream, handle, "Pa_ReadStream")
-	purego.RegisterLibFunc(&lib.writeStream, handle, "Pa_WriteStream")
-	return lib, nil
+// WithCaptureRate sets the microphone capture sample rate (default 16000 Hz).
+// The capture frames-per-buffer is derived as rate/captureWindowDivisor,
+// giving a 100 ms window (e.g. 24000/10 = 2400 frames at 24 kHz).
+func WithCaptureRate(hz int) SessionOption {
+	return func(c *sessionConfig) { c.captureRate = hz }
 }
 
-// errPortAudioMissing is returned (wrapped) when libportaudio cannot be loaded.
-var errPortAudioMissing = fmt.Errorf(
-	"voice requires PortAudio installed on this machine — "+
-		"macOS: `brew install portaudio`; "+
-		"Debian/Ubuntu: `sudo apt install libportaudio2`; "+
-		"Windows: place portaudio.dll on PATH. See %s",
-	voiceDocsURL)
-
-// paError converts a PortAudio return code into a Go error (nil on success).
-func (l *portAudioLib) paError(op string, rc int32) error {
-	if rc == 0 {
-		return nil
-	}
-	return fmt.Errorf("portaudio %s: %s", op, l.getErrorText(rc))
+// WithPlaybackRate sets the speaker playback sample rate (default 24000 Hz).
+// The playback frames-per-buffer is derived as rate*playbackWindowMs/msPerSecond,
+// giving a 40 ms window (e.g. 48000*40/1000 = 1920 frames at 48 kHz).
+func WithPlaybackRate(hz int) SessionOption {
+	return func(c *sessionConfig) { c.playbackRate = hz }
 }
 
-type portaudioIO struct {
-	lib *portAudioLib
-
-	mu        sync.Mutex
-	wg        sync.WaitGroup
-	inStream  uintptr
-	outStream uintptr
-	inBuf     []int16
-	outBuf    []int16
-	captureCh chan []byte
-	playCh    chan []byte
-	flushCh   chan struct{}
-	started   bool
-	closed    bool
-	done      chan struct{}
-}
-
-// newAudioIO loads libportaudio at runtime and constructs the PortAudio-backed
-// I/O core. It returns errPortAudioMissing (wrapped) when the library is not
-// installed, so callers can surface a clear "install PortAudio" message instead
-// of crashing. Callers use NewPortAudioSession, which wraps this in the
-// Session/Source/Sink interfaces.
-func newAudioIO() (*portaudioIO, error) {
-	lib, err := loadPortAudio()
-	if err != nil {
-		return nil, err
+// buildSessionConfig applies opts over the default 16 kHz capture / 24 kHz
+// playback configuration and returns the resulting sessionConfig.
+func buildSessionConfig(opts []SessionOption) sessionConfig {
+	cfg := sessionConfig{
+		captureRate:  CaptureSampleRate,
+		playbackRate: PlaybackSampleRate,
 	}
-	if err := lib.paError("init", lib.initialize()); err != nil {
-		return nil, err
+	for _, o := range opts {
+		o(&cfg)
 	}
-	return &portaudioIO{
-		lib:       lib,
-		inBuf:     make([]int16, captureFramesPerBuffer),
-		outBuf:    make([]int16, playbackFramesPerBuffer),
-		captureCh: make(chan []byte, captureChanBuffer),
-		playCh:    make(chan []byte, captureChanBuffer),
-		flushCh:   make(chan struct{}, 1),
-		done:      make(chan struct{}),
-	}, nil
-}
-
-// Start opens the mic and speaker streams and launches the capture/playback
-// goroutines. It is idempotent and safe to call once per session.
-func (p *portaudioIO) Start(ctx context.Context) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.closed {
-		return errors.New("audio io closed")
-	}
-	if p.started {
-		return nil
-	}
-
-	var in, out uintptr
-	if err := p.lib.paError("open mic",
-		p.lib.openDefaultStream(&in, 1, 0, paInt16, float64(CaptureSampleRate), uint64(len(p.inBuf)), 0, 0)); err != nil {
-		return err
-	}
-	if err := p.lib.paError("open speaker",
-		p.lib.openDefaultStream(&out, 0, 1, paInt16, float64(PlaybackSampleRate), uint64(len(p.outBuf)), 0, 0)); err != nil {
-		_ = p.lib.closeStream(in)
-		return err
-	}
-	if err := p.lib.paError("start mic", p.lib.startStream(in)); err != nil {
-		_ = p.lib.closeStream(in)
-		_ = p.lib.closeStream(out)
-		return err
-	}
-	if err := p.lib.paError("start speaker", p.lib.startStream(out)); err != nil {
-		_ = p.lib.closeStream(in)
-		_ = p.lib.closeStream(out)
-		return err
-	}
-	p.inStream, p.outStream, p.started = in, out, true
-	const numLoops = 2 // captureLoop + playLoop
-	p.wg.Add(numLoops)
-	go p.captureLoop(ctx)
-	go p.playLoop(ctx)
-	return nil
-}
-
-func (p *portaudioIO) captureLoop(ctx context.Context) {
-	defer p.wg.Done()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-p.done:
-			return
-		default:
-		}
-		// Pa_ReadStream blocks until inBuf is filled. KeepAlive guards the
-		// backing array across the C call (purego passes a raw pointer).
-		//nolint:gosec // G103: handing a Go-owned PCM buffer to PortAudio's blocking read; KeepAlive pins it.
-		rc := p.lib.readStream(p.inStream, uintptr(unsafe.Pointer(&p.inBuf[0])), uint64(len(p.inBuf)))
-		runtime.KeepAlive(p.inBuf)
-		if rc != 0 {
-			return
-		}
-		frame := make([]byte, len(p.inBuf)*bytesPerSample)
-		for i, s := range p.inBuf {
-			//nolint:gosec // G115: deliberate PCM16 bit reinterpretation (int16 → wire bytes).
-			binary.LittleEndian.PutUint16(frame[i*bytesPerSample:], uint16(s))
-		}
-		select {
-		case p.captureCh <- frame:
-		default: // drop on backpressure — observer cadence
-		}
-	}
-}
-
-//nolint:gocognit // hardware playback loop: ctx/done/flush/write branches kept inline for clarity.
-func (p *portaudioIO) playLoop(ctx context.Context) {
-	defer p.wg.Done()
-	// buffer accumulates incoming PCM bytes across frames so we only write
-	// complete outBuf-sized blocks to PortAudio (prevents truncation and
-	// stale-sample padding that cause choppy output).
-	buffer := make([]byte, 0, len(p.outBuf)*playbackAccumHeadroom)
-	blockBytes := len(p.outBuf) * bytesPerSample
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-p.done:
-			return
-		case <-p.flushCh:
-			// Flush: discard the accumulation buffer so no stale audio plays, then
-			// stop+start the output stream to abort PortAudio's internal device buffer.
-			// Snapshot the stream handle + lib under a brief lock and release it BEFORE
-			// the blocking stop/start FFI calls — holding p.mu across them would stall a
-			// concurrent Close() (same pattern Close() uses).
-			buffer = buffer[:0]
-			p.mu.Lock()
-			outStream := p.outStream
-			lib := p.lib
-			p.mu.Unlock()
-			if outStream != 0 {
-				_ = lib.stopStream(outStream)
-				_ = lib.startStream(outStream)
-			}
-		case frame, ok := <-p.playCh:
-			if !ok {
-				return
-			}
-			buffer = append(buffer, frame...)
-			for len(buffer) >= blockBytes {
-				for i := 0; i < len(p.outBuf); i++ {
-					//nolint:gosec // G115: deliberate PCM16 bit reinterpretation (wire bytes → int16).
-					p.outBuf[i] = int16(binary.LittleEndian.Uint16(buffer[i*bytesPerSample:]))
-				}
-				//nolint:gosec // G103: handing a Go-owned PCM buffer to PortAudio's blocking write; KeepAlive pins it.
-				p.lib.writeStream(p.outStream, uintptr(unsafe.Pointer(&p.outBuf[0])), uint64(len(p.outBuf)))
-				runtime.KeepAlive(p.outBuf)
-				buffer = buffer[blockBytes:]
-			}
-		}
-	}
-}
-
-// CaptureChunks returns the channel of captured mic PCM16 frames.
-func (p *portaudioIO) CaptureChunks() <-chan []byte { return p.captureCh }
-
-// Play enqueues a PCM16 frame for speaker playback, dropping it on backpressure.
-func (p *portaudioIO) Play(frame []byte) {
-	select {
-	case p.playCh <- frame:
-	default:
-	}
-}
-
-// requestFlush drains queued play frames and signals playLoop to abort its
-// in-flight accumulation and restart the output stream. Non-blocking.
-func (p *portaudioIO) requestFlush() {
-	for {
-		select {
-		case <-p.playCh:
-		default:
-			goto signal
-		}
-	}
-signal:
-	select {
-	case p.flushCh <- struct{}{}:
-	default:
-	}
-}
-
-// Flush cuts playback immediately, dropping queued and in-flight speaker audio.
-func (p *portaudioIO) Flush() { p.requestFlush() }
-
-// Close stops the capture/playback goroutines, closes both streams, and
-// terminates PortAudio. It is idempotent.
-func (p *portaudioIO) Close() error {
-	p.mu.Lock()
-	if p.closed {
-		p.mu.Unlock()
-		return nil
-	}
-	p.closed = true
-	// Snapshot stream handles before releasing the lock. inStream/outStream are
-	// written only during Start() (which also holds mu), so the snapshots are
-	// stable for the lifetime of this call.
-	inStream := p.inStream
-	outStream := p.outStream
-	p.mu.Unlock()
-
-	// Signal goroutines to exit, then wait. mu must NOT be held across wg.Wait():
-	// playLoop's flush case acquires mu (to guard stopStream/startStream), so
-	// holding mu here while waiting for playLoop to exit is a deadlock.
-	close(p.done)
-	p.wg.Wait()
-
-	// Goroutines have exited; streams are no longer in use.
-	if inStream != 0 {
-		_ = p.lib.stopStream(inStream)
-		_ = p.lib.closeStream(inStream)
-	}
-	if outStream != 0 {
-		_ = p.lib.stopStream(outStream)
-		_ = p.lib.closeStream(outStream)
-	}
-	return p.lib.paError("terminate", p.lib.terminate())
+	return cfg
 }
 
 // portaudioSession adapts the PortAudio-backed portaudioIO to the
 // Session/Source/Sink interfaces. It still drives TWO PortAudio streams (mic at
-// 16 kHz, speaker at 24 kHz) — collapsing to a single duplex stream is Phase 3.
+// capture rate, speaker at playback rate) — collapsing to a single duplex stream
+// is Phase 3.
 type portaudioSession struct {
 	io     *portaudioIO
 	source *portaudioSource
@@ -348,11 +82,13 @@ type portaudioSession struct {
 }
 
 // NewPortAudioSession loads libportaudio and returns a Session exposing one
-// audio Source (microphone, 16 kHz mono PCM16) and one audio Sink (speaker,
-// 24 kHz mono PCM16). It returns errPortAudioMissing (wrapped) when the library
-// is not installed.
-func NewPortAudioSession() (Session, error) {
-	io, err := newAudioIO()
+// audio Source (microphone) and one audio Sink (speaker). The default rates
+// are 16 kHz capture / 24 kHz playback; pass WithCaptureRate or
+// WithPlaybackRate to override. It returns errPortAudioMissing (wrapped) when
+// the library is not installed.
+func NewPortAudioSession(opts ...SessionOption) (Session, error) {
+	cfg := buildSessionConfig(opts)
+	io, err := newAudioIO(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -409,10 +145,10 @@ func (s *portaudioSource) pump() {
 				Kind:   KindAudio,
 				Data:   data,
 				PTS:    pts,
-				Format: Format{SampleRate: CaptureSampleRate, Channels: 1},
+				Format: Format{SampleRate: s.io.captureRate, Channels: 1},
 			}
 			// Advance PTS by this frame's duration (PCM16 ⇒ bytesPerSample/sample).
-			pts += time.Duration(len(data)/bytesPerSample) * time.Second / time.Duration(CaptureSampleRate)
+			pts += time.Duration(len(data)/bytesPerSample) * time.Second / time.Duration(s.io.captureRate)
 			select {
 			case s.frames <- frame:
 			case <-s.io.done:

--- a/runtime/audio/portaudio_session.go
+++ b/runtime/audio/portaudio_session.go
@@ -170,6 +170,10 @@ type portaudioSink struct {
 }
 
 // Write enqueues the frame's PCM16 bytes for speaker playback.
+// The playback sample rate is fixed at session construction (WithPlaybackRate,
+// default 24 kHz); f.Format.SampleRate is informational and is NOT resampled.
+// Callers must write frames at the session's configured playback rate.
+// (Phase 3 adds resample-at-sink.)
 func (s *portaudioSink) Write(f MediaFrame) { s.io.Play(f.Data) }
 
 // Flush drops all queued and in-flight playback (Phase-1 flush machinery).

--- a/runtime/audio/portaudio_session_test.go
+++ b/runtime/audio/portaudio_session_test.go
@@ -41,7 +41,7 @@ func TestPortaudioIO_FlushClearsAccumulator(t *testing.T) {
 	// Use the default playback rate to derive the expected buffer size (40 ms @ 24 kHz = 960 samples).
 	p := &portaudioIO{
 		playbackRate: PlaybackSampleRate,
-		outBuf:       make([]int16, PlaybackSampleRate*40/1000),
+		outBuf:       make([]int16, PlaybackSampleRate*playbackWindowMs/msPerSecond),
 		playCh:       make(chan []byte, captureChanBuffer),
 		flushCh:      make(chan struct{}, 1),
 		done:         make(chan struct{}),
@@ -127,9 +127,12 @@ func TestSessionConfig_Defaults(t *testing.T) {
 		t.Errorf("playbackRate = %d, want %d (PlaybackSampleRate)", cfg.playbackRate, PlaybackSampleRate)
 	}
 
-	// Validate buffer-size formula reproduces the original constants.
-	captureFrames := cfg.captureRate / 10          // 100 ms window
-	playbackFrames := cfg.playbackRate * 40 / 1000 // 40 ms window
+	// Validate the production buffer-size formula (named constants, not raw
+	// literals) reproduces the original 1600/960 frame counts. The 1600/960
+	// literals are intentionally hard-coded here as the regression guard against
+	// any behavior change at the defaults.
+	captureFrames := cfg.captureRate / captureWindowDivisor             // 100 ms window
+	playbackFrames := cfg.playbackRate * playbackWindowMs / msPerSecond // 40 ms window
 	if captureFrames != 1600 {
 		t.Errorf("captureFrames = %d, want 1600 (100 ms @ 16 kHz)", captureFrames)
 	}
@@ -146,7 +149,7 @@ func TestSessionConfig_WithCaptureRate(t *testing.T) {
 	if cfg.captureRate != 24000 {
 		t.Errorf("captureRate = %d, want 24000", cfg.captureRate)
 	}
-	captureFrames := cfg.captureRate / 10 // 100 ms window
+	captureFrames := cfg.captureRate / captureWindowDivisor // 100 ms window
 	if captureFrames != 2400 {
 		t.Errorf("captureFrames = %d, want 2400 (100 ms @ 24 kHz)", captureFrames)
 	}
@@ -164,7 +167,7 @@ func TestSessionConfig_WithPlaybackRate(t *testing.T) {
 	if cfg.playbackRate != 48000 {
 		t.Errorf("playbackRate = %d, want 48000", cfg.playbackRate)
 	}
-	playbackFrames := cfg.playbackRate * 40 / 1000 // 40 ms window
+	playbackFrames := cfg.playbackRate * playbackWindowMs / msPerSecond // 40 ms window
 	if playbackFrames != 1920 {
 		t.Errorf("playbackFrames = %d, want 1920 (40 ms @ 48 kHz)", playbackFrames)
 	}
@@ -177,6 +180,12 @@ func TestSessionConfig_WithPlaybackRate(t *testing.T) {
 // TestPortaudioSource_FrameFormatReflectsConfiguredRate verifies that the
 // portaudioSource emits MediaFrames whose Format.SampleRate matches the
 // configured capture rate, not the package default. No PortAudio device needed.
+//
+// Delivery is made deterministic: the pump is started first, then the frame is
+// enqueued and RECEIVED (with the assertion running every time) BEFORE io.done
+// is closed. Closing done before receiving would race the pump's select (both
+// done and captureCh ready ⇒ Go picks randomly), so the assertion could be
+// skipped on ~50% of runs.
 func TestPortaudioSource_FrameFormatReflectsConfiguredRate(t *testing.T) {
 	const wantRate = 24000
 
@@ -188,21 +197,19 @@ func TestPortaudioSource_FrameFormatReflectsConfiguredRate(t *testing.T) {
 	}
 	src := &portaudioSource{io: io}
 
-	// Enqueue a fake PCM frame (32 bytes = 16 samples of PCM16) and close done
-	// so pump exits after draining it.
-	fakeFrame := make([]byte, 32)
-	io.captureCh <- fakeFrame
-	close(io.done)
-
+	// Start the pump first; io.done is still open so the only ready case is the
+	// frame we enqueue, making delivery deterministic.
 	frames := src.Frames()
 
-	// Drain up to the one frame we queued (pump may not deliver it if done fires
-	// first — accept either outcome, but if a frame arrives it must have the right rate).
+	// Enqueue a fake PCM frame (32 bytes = 16 samples of PCM16).
+	fakeFrame := make([]byte, 32)
+	io.captureCh <- fakeFrame
+
+	// Receive and assert — this MUST run every time.
 	select {
 	case f, ok := <-frames:
 		if !ok {
-			// pump exited before delivering the frame — done raced; still valid.
-			return
+			t.Fatal("frames channel closed before delivering the enqueued frame")
 		}
 		if f.Format.SampleRate != wantRate {
 			t.Errorf("frame SampleRate = %d, want %d", f.Format.SampleRate, wantRate)
@@ -210,9 +217,12 @@ func TestPortaudioSource_FrameFormatReflectsConfiguredRate(t *testing.T) {
 		if f.Kind != KindAudio {
 			t.Errorf("frame Kind = %v, want KindAudio", f.Kind)
 		}
-	case <-time.After(500 * time.Millisecond):
-		// pump exited before delivering — acceptable, done was already closed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the enqueued frame")
 	}
+
+	// Only now signal the pump to exit.
+	close(io.done)
 }
 
 // TestPortaudioSource_Kind verifies the Source kind accessor.

--- a/runtime/audio/portaudio_session_test.go
+++ b/runtime/audio/portaudio_session_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestPortAudioCandidatesFor verifies each OS gets sensible, ordered library
@@ -37,11 +38,13 @@ func TestPortAudioCandidatesFor(t *testing.T) {
 }
 
 func TestPortaudioIO_FlushClearsAccumulator(t *testing.T) {
+	// Use the default playback rate to derive the expected buffer size (40 ms @ 24 kHz = 960 samples).
 	p := &portaudioIO{
-		outBuf:  make([]int16, playbackFramesPerBuffer),
-		playCh:  make(chan []byte, captureChanBuffer),
-		flushCh: make(chan struct{}, 1),
-		done:    make(chan struct{}),
+		playbackRate: PlaybackSampleRate,
+		outBuf:       make([]int16, PlaybackSampleRate*40/1000),
+		playCh:       make(chan []byte, captureChanBuffer),
+		flushCh:      make(chan struct{}, 1),
+		done:         make(chan struct{}),
 	}
 	p.playCh <- make([]byte, 64)
 	p.playCh <- make([]byte, 64)
@@ -59,7 +62,7 @@ func TestPortaudioIO_FlushClearsAccumulator(t *testing.T) {
 // (proving the CGO-free FFI works); otherwise it must return errPortAudioMissing
 // with actionable guidance — never crash.
 func TestNewAudioIO_LoadsOrReportsMissing(t *testing.T) {
-	io, err := newAudioIO()
+	io, err := newAudioIO(buildSessionConfig(nil))
 	if err != nil {
 		if !errors.Is(err, errPortAudioMissing) {
 			t.Fatalf("expected errPortAudioMissing when load fails, got: %v", err)
@@ -107,5 +110,194 @@ func TestNewPortAudioSession_MissingLibIsActionable(t *testing.T) {
 	}
 	if k := sess.Sinks()[0].Kind(); k != KindAudio {
 		t.Fatalf("sink kind = %v, want KindAudio", k)
+	}
+}
+
+// TestSessionConfig_Defaults verifies that buildSessionConfig with no options
+// produces the documented defaults (16 kHz capture / 24 kHz playback) and that
+// the derived buffer sizes exactly match the pre-refactor package constants
+// (1600 capture frames, 960 playback frames), locking in zero behavior change.
+func TestSessionConfig_Defaults(t *testing.T) {
+	cfg := buildSessionConfig(nil)
+
+	if cfg.captureRate != CaptureSampleRate {
+		t.Errorf("captureRate = %d, want %d (CaptureSampleRate)", cfg.captureRate, CaptureSampleRate)
+	}
+	if cfg.playbackRate != PlaybackSampleRate {
+		t.Errorf("playbackRate = %d, want %d (PlaybackSampleRate)", cfg.playbackRate, PlaybackSampleRate)
+	}
+
+	// Validate buffer-size formula reproduces the original constants.
+	captureFrames := cfg.captureRate / 10          // 100 ms window
+	playbackFrames := cfg.playbackRate * 40 / 1000 // 40 ms window
+	if captureFrames != 1600 {
+		t.Errorf("captureFrames = %d, want 1600 (100 ms @ 16 kHz)", captureFrames)
+	}
+	if playbackFrames != 960 {
+		t.Errorf("playbackFrames = %d, want 960 (40 ms @ 24 kHz)", playbackFrames)
+	}
+}
+
+// TestSessionConfig_WithCaptureRate verifies that WithCaptureRate(24000) sets
+// the capture rate to 24 kHz and derives the correct 100 ms buffer (2400 frames).
+func TestSessionConfig_WithCaptureRate(t *testing.T) {
+	cfg := buildSessionConfig([]SessionOption{WithCaptureRate(24000)})
+
+	if cfg.captureRate != 24000 {
+		t.Errorf("captureRate = %d, want 24000", cfg.captureRate)
+	}
+	captureFrames := cfg.captureRate / 10 // 100 ms window
+	if captureFrames != 2400 {
+		t.Errorf("captureFrames = %d, want 2400 (100 ms @ 24 kHz)", captureFrames)
+	}
+	// playbackRate must remain at the default.
+	if cfg.playbackRate != PlaybackSampleRate {
+		t.Errorf("playbackRate = %d, want %d (unchanged default)", cfg.playbackRate, PlaybackSampleRate)
+	}
+}
+
+// TestSessionConfig_WithPlaybackRate verifies that WithPlaybackRate(48000) sets
+// the playback rate to 48 kHz and derives the correct 40 ms buffer (1920 frames).
+func TestSessionConfig_WithPlaybackRate(t *testing.T) {
+	cfg := buildSessionConfig([]SessionOption{WithPlaybackRate(48000)})
+
+	if cfg.playbackRate != 48000 {
+		t.Errorf("playbackRate = %d, want 48000", cfg.playbackRate)
+	}
+	playbackFrames := cfg.playbackRate * 40 / 1000 // 40 ms window
+	if playbackFrames != 1920 {
+		t.Errorf("playbackFrames = %d, want 1920 (40 ms @ 48 kHz)", playbackFrames)
+	}
+	// captureRate must remain at the default.
+	if cfg.captureRate != CaptureSampleRate {
+		t.Errorf("captureRate = %d, want %d (unchanged default)", cfg.captureRate, CaptureSampleRate)
+	}
+}
+
+// TestPortaudioSource_FrameFormatReflectsConfiguredRate verifies that the
+// portaudioSource emits MediaFrames whose Format.SampleRate matches the
+// configured capture rate, not the package default. No PortAudio device needed.
+func TestPortaudioSource_FrameFormatReflectsConfiguredRate(t *testing.T) {
+	const wantRate = 24000
+
+	// Construct a minimal portaudioIO with captureRate set but no real device.
+	io := &portaudioIO{
+		captureRate: wantRate,
+		captureCh:   make(chan []byte, 1),
+		done:        make(chan struct{}),
+	}
+	src := &portaudioSource{io: io}
+
+	// Enqueue a fake PCM frame (32 bytes = 16 samples of PCM16) and close done
+	// so pump exits after draining it.
+	fakeFrame := make([]byte, 32)
+	io.captureCh <- fakeFrame
+	close(io.done)
+
+	frames := src.Frames()
+
+	// Drain up to the one frame we queued (pump may not deliver it if done fires
+	// first — accept either outcome, but if a frame arrives it must have the right rate).
+	select {
+	case f, ok := <-frames:
+		if !ok {
+			// pump exited before delivering the frame — done raced; still valid.
+			return
+		}
+		if f.Format.SampleRate != wantRate {
+			t.Errorf("frame SampleRate = %d, want %d", f.Format.SampleRate, wantRate)
+		}
+		if f.Kind != KindAudio {
+			t.Errorf("frame Kind = %v, want KindAudio", f.Kind)
+		}
+	case <-time.After(500 * time.Millisecond):
+		// pump exited before delivering — acceptable, done was already closed.
+	}
+}
+
+// TestPortaudioSource_Kind verifies the Source kind accessor.
+func TestPortaudioSource_Kind(t *testing.T) {
+	src := &portaudioSource{io: &portaudioIO{done: make(chan struct{})}}
+	if k := src.Kind(); k != KindAudio {
+		t.Errorf("Kind = %v, want KindAudio", k)
+	}
+}
+
+// TestPortaudioSource_CloseIsIdempotent verifies that portaudioSource.Close
+// delegates to portaudioIO.Close and is idempotent when the IO is already closed.
+func TestPortaudioSource_CloseIsIdempotent(t *testing.T) {
+	io := &portaudioIO{
+		closed: true,
+		done:   make(chan struct{}),
+	}
+	src := &portaudioSource{io: io}
+	// Close on an already-closed IO must return nil without panicking.
+	if err := src.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+// TestPortaudioSink_WriteEnqueuesFrame verifies that Write enqueues the frame
+// data onto the play channel.
+func TestPortaudioSink_WriteEnqueuesFrame(t *testing.T) {
+	io := &portaudioIO{
+		playCh:  make(chan []byte, 4),
+		flushCh: make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	sink := &portaudioSink{io: io}
+
+	data := []byte{0x01, 0x02, 0x03, 0x04}
+	sink.Write(MediaFrame{Data: data})
+
+	select {
+	case got := <-io.playCh:
+		if len(got) != len(data) {
+			t.Errorf("playCh got %d bytes, want %d", len(got), len(data))
+		}
+	default:
+		t.Fatal("expected frame in playCh after Write")
+	}
+}
+
+// TestPortaudioSink_FlushSignalsPlayLoop verifies that Flush drains queued
+// frames and sends a signal on the flush channel.
+func TestPortaudioSink_FlushSignalsPlayLoop(t *testing.T) {
+	io := &portaudioIO{
+		playCh:  make(chan []byte, 4),
+		flushCh: make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	sink := &portaudioSink{io: io}
+
+	io.playCh <- make([]byte, 16)
+	sink.Flush()
+
+	if got := len(io.playCh); got != 0 {
+		t.Errorf("playCh should be drained after Flush, got %d item(s)", got)
+	}
+	if got := len(io.flushCh); got != 1 {
+		t.Errorf("flushCh should have 1 signal after Flush, got %d", got)
+	}
+}
+
+// TestPortaudioSink_Kind verifies the Sink kind accessor.
+func TestPortaudioSink_Kind(t *testing.T) {
+	sink := &portaudioSink{io: &portaudioIO{done: make(chan struct{})}}
+	if k := sink.Kind(); k != KindAudio {
+		t.Errorf("Kind = %v, want KindAudio", k)
+	}
+}
+
+// TestPortaudioSink_CloseIsIdempotent verifies that portaudioSink.Close
+// delegates to portaudioIO.Close and is idempotent when the IO is already closed.
+func TestPortaudioSink_CloseIsIdempotent(t *testing.T) {
+	io := &portaudioIO{
+		closed: true,
+		done:   make(chan struct{}),
+	}
+	sink := &portaudioSink{io: io}
+	if err := sink.Close(); err != nil {
+		t.Errorf("Close: %v", err)
 	}
 }

--- a/runtime/audio/portaudio_session_test.go
+++ b/runtime/audio/portaudio_session_test.go
@@ -1,0 +1,111 @@
+package audio
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestPortAudioCandidatesFor verifies each OS gets sensible, ordered library
+// names (the discovery list dlopen walks).
+func TestPortAudioCandidatesFor(t *testing.T) {
+	cases := map[string]struct {
+		first    string
+		contains string
+	}{
+		"darwin":  {first: "libportaudio.2.dylib", contains: ".dylib"},
+		"linux":   {first: "libportaudio.so.2", contains: ".so"},
+		"windows": {first: "portaudio.dll", contains: ".dll"},
+		"freebsd": {first: "libportaudio.so.2", contains: ".so"}, // default branch
+	}
+	for goos, want := range cases {
+		t.Run(goos, func(t *testing.T) {
+			got := portAudioCandidatesFor(goos)
+			if len(got) == 0 {
+				t.Fatalf("no candidates for %s", goos)
+			}
+			if got[0] != want.first {
+				t.Fatalf("%s: first candidate = %q, want %q", goos, got[0], want.first)
+			}
+			for _, c := range got {
+				if !strings.Contains(c, want.contains) {
+					t.Fatalf("%s: candidate %q missing %q", goos, c, want.contains)
+				}
+			}
+		})
+	}
+}
+
+func TestPortaudioIO_FlushClearsAccumulator(t *testing.T) {
+	p := &portaudioIO{
+		outBuf:  make([]int16, playbackFramesPerBuffer),
+		playCh:  make(chan []byte, captureChanBuffer),
+		flushCh: make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	p.playCh <- make([]byte, 64)
+	p.playCh <- make([]byte, 64)
+	p.requestFlush()
+	if got := len(p.playCh); got != 0 {
+		t.Fatalf("expected playCh drained, got %d queued", got)
+	}
+	if got := len(p.flushCh); got != 1 {
+		t.Fatalf("expected flush signal queued, got %d", got)
+	}
+}
+
+// TestNewAudioIO_LoadsOrReportsMissing exercises the real purego binding. On a
+// machine with PortAudio installed it must load + initialize successfully
+// (proving the CGO-free FFI works); otherwise it must return errPortAudioMissing
+// with actionable guidance — never crash.
+func TestNewAudioIO_LoadsOrReportsMissing(t *testing.T) {
+	io, err := newAudioIO()
+	if err != nil {
+		if !errors.Is(err, errPortAudioMissing) {
+			t.Fatalf("expected errPortAudioMissing when load fails, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), voiceDocsURL) {
+			t.Fatalf("missing-PortAudio error should link the docs (%s), got: %v", voiceDocsURL, err)
+		}
+		t.Skipf("PortAudio not installed on this host: %v", err)
+	}
+	// Loaded + Pa_Initialize succeeded — the runtime-load binding works. Close
+	// terminates PortAudio; no audio device was opened (Start was never called).
+	if cerr := io.Close(); cerr != nil {
+		t.Fatalf("Close: %v", cerr)
+	}
+}
+
+// TestNewPortAudioSession_MissingLibIsActionable asserts the Session constructor
+// surfaces the actionable errPortAudioMissing when PortAudio is absent (as in
+// CI), and otherwise exposes exactly one audio Source and one audio Sink without
+// opening a device.
+func TestNewPortAudioSession_MissingLibIsActionable(t *testing.T) {
+	sess, err := NewPortAudioSession()
+	if err != nil {
+		if !errors.Is(err, errPortAudioMissing) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(err.Error(), voiceDocsURL) {
+			t.Fatalf("missing-PortAudio error should link the docs (%s), got: %v", voiceDocsURL, err)
+		}
+		t.Skipf("PortAudio not installed on this host: %v", err)
+	}
+	defer func() {
+		if cerr := sess.Close(); cerr != nil {
+			t.Fatalf("Close: %v", cerr)
+		}
+	}()
+	if got := len(sess.Sources()); got != 1 {
+		t.Fatalf("expected exactly 1 source, got %d", got)
+	}
+	if got := len(sess.Sinks()); got != 1 {
+		t.Fatalf("expected exactly 1 sink, got %d", got)
+	}
+	if k := sess.Sources()[0].Kind(); k != KindAudio {
+		t.Fatalf("source kind = %v, want KindAudio", k)
+	}
+	if k := sess.Sinks()[0].Kind(); k != KindAudio {
+		t.Fatalf("sink kind = %v, want KindAudio", k)
+	}
+}

--- a/sdk/examples/duplex-streaming/main.go
+++ b/sdk/examples/duplex-streaming/main.go
@@ -1,0 +1,63 @@
+//go:build !portaudio
+
+// Package main demonstrates bidirectional streaming with OpenDuplex.
+//
+// This is the text-mode fallback that builds without the portaudio tag (no
+// microphone/speaker access). For full interactive voice streaming with a
+// microphone, build the interactive variant in main_interactive.go:
+//
+//	export GEMINI_API_KEY=your-key
+//	go run -tags portaudio . interactive
+//
+// Run the text demo with:
+//
+//	export GEMINI_API_KEY=your-key
+//	go run .
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func main() {
+	fmt.Println("🎙️  Duplex Streaming with OpenDuplex (text mode)")
+	fmt.Println("================================================")
+	fmt.Println()
+	fmt.Println("Note: For interactive voice streaming, build with: go run -tags portaudio . interactive")
+	fmt.Println()
+
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		log.Fatal("GEMINI_API_KEY environment variable is required")
+	}
+
+	ctx := context.Background()
+
+	conv, err := sdk.Open(
+		"./duplex.pack.json",
+		"assistant",
+		sdk.WithModel("gemini-2.5-flash"),
+		sdk.WithAPIKey(apiKey),
+	)
+	if err != nil {
+		log.Fatalf("Failed to open conversation: %v", err)
+	}
+	defer conv.Close()
+
+	fmt.Println("✅ Conversation created (unary mode)")
+	fmt.Println()
+	fmt.Println("Sending: 'Hello, tell me a short joke'")
+	fmt.Println()
+
+	resp, err := conv.Send(ctx, "Hello, tell me a short joke")
+	if err != nil {
+		log.Fatalf("Failed to send: %v", err)
+	}
+
+	fmt.Printf("Response: %s\n", resp.Text())
+}

--- a/sdk/examples/duplex-streaming/main_interactive.go
+++ b/sdk/examples/duplex-streaming/main_interactive.go
@@ -388,6 +388,9 @@ func (ah *AudioHandler) setSpeaking(speaking bool) {
 
 // hasAudioEnergy checks if audio frame has significant energy
 func hasAudioEnergy(samples []int16) bool {
+	if len(samples) == 0 {
+		return false
+	}
 	const threshold = 500
 	var sum int64
 	for _, s := range samples {

--- a/sdk/examples/duplex-streaming/main_interactive.go
+++ b/sdk/examples/duplex-streaming/main_interactive.go
@@ -41,8 +41,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gordonklaus/portaudio"
-
+	rtaudio "github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/sdk"
@@ -52,8 +51,6 @@ const (
 	sampleRate       = 16000 // 16kHz for speech input
 	outputSampleRate = 24000 // 24kHz for audio output
 	channels         = 1     // Mono
-	framesPerBuf     = 1600  // 100ms at 16kHz for input
-	outputFramesBuf  = 960   // 40ms at 24kHz for output
 )
 
 func main() {
@@ -162,18 +159,26 @@ func interactiveAudioExample(ctx context.Context, conv *sdk.Conversation) error 
 	fmt.Println("🎤 Interactive Voice Mode")
 	fmt.Println("=========================")
 
-	// Initialize PortAudio
-	if err := portaudio.Initialize(); err != nil {
-		return fmt.Errorf("failed to initialize PortAudio: %w", err)
-	}
-	defer portaudio.Terminate()
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	// Open the shared pure-Go audio session (16 kHz mic + 24 kHz speaker defaults).
+	session, err := rtaudio.NewPortAudioSession(
+		rtaudio.WithCaptureRate(sampleRate),
+		rtaudio.WithPlaybackRate(outputSampleRate),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to open audio session: %w", err)
+	}
+	defer session.Close()
+	if err := session.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start audio session: %w", err)
+	}
 
 	// Create audio handler
 	audioHandler := &AudioHandler{
 		conv:        conv,
+		session:     session,
 		audioBuffer: make([]byte, 0),
 		audioQueue:  make(chan []byte, 100),
 	}
@@ -230,6 +235,7 @@ func interactiveAudioExample(ctx context.Context, conv *sdk.Conversation) error 
 // AudioHandler manages audio capture and streaming
 type AudioHandler struct {
 	conv        *sdk.Conversation
+	session     rtaudio.Session
 	mu          sync.Mutex
 	audioQueue  chan []byte // Queue for audio playback
 	audioBuffer []byte
@@ -238,42 +244,25 @@ type AudioHandler struct {
 
 // captureAndStreamAudio captures microphone input and streams it to the conversation
 func (ah *AudioHandler) captureAndStreamAudio(ctx context.Context) error {
-	// Open input stream
-	in := make([]int16, framesPerBuf)
-	stream, err := portaudio.OpenDefaultStream(channels, 0, sampleRate, framesPerBuf, in)
-	if err != nil {
-		return fmt.Errorf("failed to open input stream: %w", err)
-	}
-	defer stream.Close()
-
-	if err := stream.Start(); err != nil {
-		return fmt.Errorf("failed to start input stream: %w", err)
-	}
-	defer stream.Stop()
-
 	fmt.Println("Starting continuous audio streaming...")
 
 	// Stream audio continuously in chunks
+	frames := ah.session.Sources()[0].Frames()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		default:
-			// Read audio frame
-			if err := stream.Read(); err != nil {
-				log.Printf("Audio read error: %v", err)
-				continue
+		case frame, ok := <-frames:
+			if !ok {
+				return nil
 			}
 
-			// Convert int16 to bytes (PCM16)
-			audioBytes := int16ToBytes(in)
-
-			// Stream audio continuously to the model
-			// Gemini ASM can handle continuous bidirectional audio
+			// frame.Data is already PCM16 little-endian bytes.
+			// Gemini ASM can handle continuous bidirectional audio.
 			chunk := &providers.StreamChunk{
 				MediaData: &providers.StreamMediaData{
 					MIMEType: "audio/pcm",
-					Data:     audioBytes,
+					Data:     frame.Data,
 				},
 			}
 
@@ -283,7 +272,7 @@ func (ah *AudioHandler) captureAndStreamAudio(ctx context.Context) error {
 			}
 
 			// Visual feedback
-			if hasAudioEnergy(in) {
+			if hasAudioEnergy(bytesToInt16(frame.Data)) {
 				fmt.Print("█")
 			} else {
 				fmt.Print("░")
@@ -371,21 +360,7 @@ func (ah *AudioHandler) processResponses(ctx context.Context) {
 
 // playAudioOutput plays audio responses through speakers
 func (ah *AudioHandler) playAudioOutput(ctx context.Context) error {
-	// Open output stream
-	out := make([]int16, outputFramesBuf)
-	stream, err := portaudio.OpenDefaultStream(0, channels, float64(outputSampleRate), outputFramesBuf, out)
-	if err != nil {
-		return fmt.Errorf("failed to open output stream: %w", err)
-	}
-	defer stream.Close()
-
-	if err := stream.Start(); err != nil {
-		return fmt.Errorf("failed to start output stream: %w", err)
-	}
-	defer stream.Stop()
-
-	buffer := []byte{}
-
+	sink := ah.session.Sinks()[0]
 	for {
 		select {
 		case <-ctx.Done():
@@ -395,25 +370,11 @@ func (ah *AudioHandler) playAudioOutput(ctx context.Context) error {
 				return nil
 			}
 
-			buffer = append(buffer, audioData...)
-
-			// Play when we have enough samples
-			for len(buffer) >= len(out)*2 {
-				// Convert bytes to int16
-				for i := 0; i < len(out); i++ {
-					if i*2+1 < len(buffer) {
-						out[i] = int16(buffer[i*2]) | int16(buffer[i*2+1])<<8
-					}
-				}
-
-				// Write to output
-				if err := stream.Write(); err != nil {
-					log.Printf("Audio write error: %v", err)
-				}
-
-				// Remove played samples
-				buffer = buffer[len(out)*2:]
-			}
+			sink.Write(rtaudio.MediaFrame{
+				Kind:   rtaudio.KindAudio,
+				Data:   audioData,
+				Format: rtaudio.Format{SampleRate: outputSampleRate, Channels: channels},
+			})
 		}
 	}
 }
@@ -440,14 +401,13 @@ func hasAudioEnergy(samples []int16) bool {
 	return avg > threshold
 }
 
-// int16ToBytes converts int16 audio samples to bytes (little-endian PCM16)
-func int16ToBytes(samples []int16) []byte {
-	bytes := make([]byte, len(samples)*2)
-	for i, s := range samples {
-		bytes[i*2] = byte(s & 0xFF)
-		bytes[i*2+1] = byte((s >> 8) & 0xFF)
+// bytesToInt16 converts little-endian PCM16 bytes to int16 audio samples.
+func bytesToInt16(data []byte) []int16 {
+	samples := make([]int16, len(data)/2)
+	for i := range samples {
+		samples[i] = int16(data[i*2]) | int16(data[i*2+1])<<8
 	}
-	return bytes
+	return samples
 }
 
 // textStreamingExample demonstrates basic text streaming

--- a/sdk/examples/openai-realtime/main_interactive.go
+++ b/sdk/examples/openai-realtime/main_interactive.go
@@ -663,6 +663,9 @@ func (ah *AudioHandler) playAudioOutput(ctx context.Context) error {
 
 // hasAudioEnergy checks if audio frame has significant energy
 func hasAudioEnergy(samples []int16) bool {
+	if len(samples) == 0 {
+		return false
+	}
 	const threshold = 500
 	var sum int64
 	for _, s := range samples {

--- a/sdk/examples/openai-realtime/main_interactive.go
+++ b/sdk/examples/openai-realtime/main_interactive.go
@@ -37,8 +37,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gordonklaus/portaudio"
-
+	rtaudio "github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/sdk"
@@ -46,9 +45,8 @@ import (
 
 const (
 	// OpenAI Realtime uses 24kHz for both input and output
-	sampleRate   = 24000
-	channels     = 1
-	framesPerBuf = 2400 // 100ms at 24kHz
+	sampleRate = 24000
+	channels   = 1
 )
 
 func main() {
@@ -95,12 +93,6 @@ func main() {
 
 // runInteractiveMode runs the main voice chat mode
 func runInteractiveMode(ctx context.Context, apiKey string) error {
-	// Initialize PortAudio
-	if err := portaudio.Initialize(); err != nil {
-		return fmt.Errorf("failed to initialize PortAudio: %w", err)
-	}
-	defer portaudio.Terminate()
-
 	// Open duplex conversation with OpenAI Realtime
 	conv, err := sdk.OpenDuplex(
 		"./openai-realtime.pack.json",
@@ -134,9 +126,23 @@ func runInteractiveMode(ctx context.Context, apiKey string) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// Open the shared pure-Go audio session (24 kHz mic + 24 kHz speaker).
+	session, err := rtaudio.NewPortAudioSession(
+		rtaudio.WithCaptureRate(sampleRate),
+		rtaudio.WithPlaybackRate(sampleRate),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to open audio session: %w", err)
+	}
+	defer session.Close()
+	if err := session.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start audio session: %w", err)
+	}
+
 	// Create audio handler
 	handler := &AudioHandler{
 		conv:       conv,
+		session:    session,
 		audioQueue: make(chan []byte, 100),
 	}
 
@@ -186,11 +192,6 @@ func runInteractiveMode(ctx context.Context, apiKey string) error {
 
 // runToolsDemo demonstrates function calling during realtime streaming
 func runToolsDemo(ctx context.Context, apiKey string) error {
-	if err := portaudio.Initialize(); err != nil {
-		return fmt.Errorf("failed to initialize PortAudio: %w", err)
-	}
-	defer portaudio.Terminate()
-
 	// Open with tools configuration
 	conv, err := sdk.OpenDuplex(
 		"./openai-realtime.pack.json",
@@ -246,8 +247,21 @@ func runToolsDemo(ctx context.Context, apiKey string) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	session, err := rtaudio.NewPortAudioSession(
+		rtaudio.WithCaptureRate(sampleRate),
+		rtaudio.WithPlaybackRate(sampleRate),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to open audio session: %w", err)
+	}
+	defer session.Close()
+	if err := session.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start audio session: %w", err)
+	}
+
 	handler := &AudioHandler{
 		conv:       conv,
+		session:    session,
 		audioQueue: make(chan []byte, 100),
 	}
 
@@ -293,11 +307,6 @@ func runToolsDemo(ctx context.Context, apiKey string) error {
 
 // runTranslatorMode demonstrates real-time translation
 func runTranslatorMode(ctx context.Context, apiKey string) error {
-	if err := portaudio.Initialize(); err != nil {
-		return fmt.Errorf("failed to initialize PortAudio: %w", err)
-	}
-	defer portaudio.Terminate()
-
 	conv, err := sdk.OpenDuplex(
 		"./openai-realtime.pack.json",
 		"translator",
@@ -334,8 +343,21 @@ func runTranslatorMode(ctx context.Context, apiKey string) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	session, err := rtaudio.NewPortAudioSession(
+		rtaudio.WithCaptureRate(sampleRate),
+		rtaudio.WithPlaybackRate(sampleRate),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to open audio session: %w", err)
+	}
+	defer session.Close()
+	if err := session.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start audio session: %w", err)
+	}
+
 	handler := &AudioHandler{
 		conv:       conv,
+		session:    session,
 		audioQueue: make(chan []byte, 100),
 	}
 
@@ -382,6 +404,7 @@ func runTranslatorMode(ctx context.Context, apiKey string) error {
 // AudioHandler manages audio capture, streaming, and playback
 type AudioHandler struct {
 	conv       *sdk.Conversation
+	session    rtaudio.Session
 	audioQueue chan []byte
 	mu         sync.Mutex
 	speaking   bool
@@ -389,38 +412,23 @@ type AudioHandler struct {
 
 // captureAndStreamAudio captures microphone input and streams to OpenAI
 func (ah *AudioHandler) captureAndStreamAudio(ctx context.Context) error {
-	in := make([]int16, framesPerBuf)
-	stream, err := portaudio.OpenDefaultStream(channels, 0, sampleRate, framesPerBuf, in)
-	if err != nil {
-		return fmt.Errorf("failed to open input stream: %w", err)
-	}
-	defer stream.Close()
-
-	if err := stream.Start(); err != nil {
-		return fmt.Errorf("failed to start input stream: %w", err)
-	}
-	defer stream.Stop()
-
 	fmt.Println("Audio capture started...")
 
+	frames := ah.session.Sources()[0].Frames()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		default:
-			if err := stream.Read(); err != nil {
-				log.Printf("Audio read error: %v", err)
-				continue
+		case frame, ok := <-frames:
+			if !ok {
+				return nil
 			}
 
-			// Convert int16 to bytes (PCM16 little-endian)
-			audioBytes := int16ToBytes(in)
-
-			// Create audio chunk
+			// frame.Data is already PCM16 little-endian bytes.
 			chunk := &providers.StreamChunk{
 				MediaData: &providers.StreamMediaData{
 					MIMEType: "audio/pcm",
-					Data:     audioBytes,
+					Data:     frame.Data,
 				},
 			}
 
@@ -431,7 +439,7 @@ func (ah *AudioHandler) captureAndStreamAudio(ctx context.Context) error {
 			}
 
 			// Visual feedback for audio level
-			if hasAudioEnergy(in) {
+			if hasAudioEnergy(bytesToInt16(frame.Data)) {
 				fmt.Print("\033[32m|\033[0m") // Green bar for speech
 			}
 		}
@@ -634,20 +642,7 @@ func (ah *AudioHandler) executeToolCall(name, arguments string) string {
 
 // playAudioOutput plays audio responses through speakers
 func (ah *AudioHandler) playAudioOutput(ctx context.Context) error {
-	out := make([]int16, framesPerBuf)
-	stream, err := portaudio.OpenDefaultStream(0, channels, float64(sampleRate), framesPerBuf, out)
-	if err != nil {
-		return fmt.Errorf("failed to open output stream: %w", err)
-	}
-	defer stream.Close()
-
-	if err := stream.Start(); err != nil {
-		return fmt.Errorf("failed to start output stream: %w", err)
-	}
-	defer stream.Stop()
-
-	buffer := []byte{}
-
+	sink := ah.session.Sinks()[0]
 	for {
 		select {
 		case <-ctx.Done():
@@ -657,22 +652,11 @@ func (ah *AudioHandler) playAudioOutput(ctx context.Context) error {
 				return nil
 			}
 
-			buffer = append(buffer, audioData...)
-
-			// Play when we have enough samples
-			for len(buffer) >= len(out)*2 {
-				for i := 0; i < len(out); i++ {
-					if i*2+1 < len(buffer) {
-						out[i] = int16(buffer[i*2]) | int16(buffer[i*2+1])<<8
-					}
-				}
-
-				if err := stream.Write(); err != nil {
-					log.Printf("Audio write error: %v", err)
-				}
-
-				buffer = buffer[len(out)*2:]
-			}
+			sink.Write(rtaudio.MediaFrame{
+				Kind:   rtaudio.KindAudio,
+				Data:   audioData,
+				Format: rtaudio.Format{SampleRate: sampleRate, Channels: channels},
+			})
 		}
 	}
 }
@@ -692,12 +676,11 @@ func hasAudioEnergy(samples []int16) bool {
 	return avg > threshold
 }
 
-// int16ToBytes converts int16 audio samples to bytes (little-endian PCM16)
-func int16ToBytes(samples []int16) []byte {
-	bytes := make([]byte, len(samples)*2)
-	for i, s := range samples {
-		bytes[i*2] = byte(s & 0xFF)
-		bytes[i*2+1] = byte((s >> 8) & 0xFF)
+// bytesToInt16 converts little-endian PCM16 bytes to int16 audio samples.
+func bytesToInt16(data []byte) []int16 {
+	samples := make([]int16, len(data)/2)
+	for i := range samples {
+		samples[i] = int16(data[i*2]) | int16(data[i*2+1])<<8
 	}
-	return bytes
+	return samples
 }

--- a/sdk/examples/voice-interview/audio/portaudio.go
+++ b/sdk/examples/voice-interview/audio/portaudio.go
@@ -1,6 +1,7 @@
-//go:build portaudio
-
-// Package audio provides audio capture and playback using PortAudio.
+// Package audio provides microphone capture and speaker playback for the
+// voice-interview example. It is a thin adapter over the shared pure-Go
+// runtime/audio Session (purego/dlopen PortAudio — no CGO), preserving the
+// capture/playback API the interview controller depends on.
 package audio
 
 import (
@@ -10,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gordonklaus/portaudio"
+	rtaudio "github.com/AltairaLabs/PromptKit/runtime/audio"
 )
 
 const (
@@ -30,12 +31,11 @@ const (
 
 // AudioCapture handles microphone input
 type AudioCapture struct {
-	mu          sync.Mutex
-	stream      *portaudio.Stream
-	audioOut    chan []byte
-	energyOut   chan float64
-	running     bool
-	initialized bool
+	sys       *AudioSystem
+	mu        sync.Mutex
+	audioOut  chan []byte
+	energyOut chan float64
+	running   bool
 
 	// Drop detection metrics
 	chunksSent    uint64
@@ -45,36 +45,53 @@ type AudioCapture struct {
 
 // AudioPlayback handles speaker output
 type AudioPlayback struct {
-	mu          sync.Mutex
-	stream      *portaudio.Stream
-	audioIn     chan []byte
-	running     bool
-	initialized bool
+	sys     *AudioSystem
+	mu      sync.Mutex
+	audioIn chan []byte
+	running bool
 }
 
-// AudioSystem manages both capture and playback
+// AudioSystem manages both capture and playback over one shared audio session.
 type AudioSystem struct {
+	session  rtaudio.Session
 	capture  *AudioCapture
 	playback *AudioPlayback
-	paInit   bool
+
+	startOnce sync.Once
+	startErr  error
 }
 
-// NewAudioSystem creates a new audio system
+// NewAudioSystem creates a new audio system backed by the shared runtime/audio
+// Session (16kHz capture, 24kHz playback).
 func NewAudioSystem() (*AudioSystem, error) {
-	if err := portaudio.Initialize(); err != nil {
-		return nil, fmt.Errorf("failed to initialize PortAudio: %w", err)
+	session, err := rtaudio.NewPortAudioSession(
+		rtaudio.WithCaptureRate(InputSampleRate),
+		rtaudio.WithPlaybackRate(OutputSampleRate),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize audio session: %w", err)
 	}
 
-	return &AudioSystem{
-		capture: &AudioCapture{
-			audioOut:  make(chan []byte, 100),
-			energyOut: make(chan float64, 100),
-		},
-		playback: &AudioPlayback{
-			audioIn: make(chan []byte, 500),
-		},
-		paInit: true,
-	}, nil
+	as := &AudioSystem{session: session}
+	as.capture = &AudioCapture{
+		sys:       as,
+		audioOut:  make(chan []byte, 100),
+		energyOut: make(chan float64, 100),
+	}
+	as.playback = &AudioPlayback{
+		sys:     as,
+		audioIn: make(chan []byte, 500),
+	}
+	return as, nil
+}
+
+// startSession starts the underlying session exactly once. Both Capture.Start
+// and Playback.Start call it; the shared session drives both streams.
+func (as *AudioSystem) startSession(ctx context.Context) error {
+	as.startOnce.Do(func() {
+		as.startErr = as.session.Start(ctx)
+	})
+	return as.startErr
 }
 
 // Close shuts down the audio system
@@ -85,8 +102,8 @@ func (as *AudioSystem) Close() error {
 	if as.playback != nil {
 		as.playback.Stop()
 	}
-	if as.paInit {
-		portaudio.Terminate()
+	if as.session != nil {
+		return as.session.Close()
 	}
 	return nil
 }
@@ -109,35 +126,23 @@ func (ac *AudioCapture) Start(ctx context.Context) error {
 		fmt.Println("[AUDIO] Capture already running")
 		return nil
 	}
+	ac.running = true
 	ac.mu.Unlock()
 
 	fmt.Printf("[AUDIO] Starting capture: %dHz, %d channels, %d frames/buffer\n",
 		InputSampleRate, Channels, InputFramesPerBuffer)
 
-	// Open input stream
-	in := make([]int16, InputFramesPerBuffer)
-	stream, err := portaudio.OpenDefaultStream(Channels, 0, InputSampleRate, InputFramesPerBuffer, in)
-	if err != nil {
-		fmt.Printf("[AUDIO ERROR] Failed to open input stream: %v\n", err)
-		return fmt.Errorf("failed to open input stream: %w", err)
+	if err := ac.sys.startSession(ctx); err != nil {
+		ac.mu.Lock()
+		ac.running = false
+		ac.mu.Unlock()
+		fmt.Printf("[AUDIO ERROR] Failed to start audio session: %v\n", err)
+		return fmt.Errorf("failed to start audio session: %w", err)
 	}
-
-	if err := stream.Start(); err != nil {
-		stream.Close()
-		fmt.Printf("[AUDIO ERROR] Failed to start input stream: %v\n", err)
-		return fmt.Errorf("failed to start input stream: %w", err)
-	}
-
-	ac.mu.Lock()
-	ac.stream = stream
-	ac.running = true
-	ac.initialized = true
-	ac.mu.Unlock()
 
 	fmt.Println("[AUDIO] Microphone stream opened successfully")
 
-	// Start capture goroutine
-	go ac.captureLoop(ctx, in)
+	go ac.captureLoop(ctx)
 
 	return nil
 }
@@ -146,12 +151,6 @@ func (ac *AudioCapture) Start(ctx context.Context) error {
 func (ac *AudioCapture) Stop() {
 	ac.mu.Lock()
 	defer ac.mu.Unlock()
-
-	if ac.stream != nil {
-		ac.stream.Stop()
-		ac.stream.Close()
-		ac.stream = nil
-	}
 	ac.running = false
 }
 
@@ -165,66 +164,55 @@ func (ac *AudioCapture) EnergyLevels() <-chan float64 {
 	return ac.energyOut
 }
 
-func (ac *AudioCapture) captureLoop(ctx context.Context, in []int16) {
+func (ac *AudioCapture) captureLoop(ctx context.Context) {
 	fmt.Println("[AUDIO] Capture loop started - listening for microphone input")
 
+	frames := ac.sys.session.Sources()[0].Frames()
 	for {
 		select {
 		case <-ctx.Done():
 			ac.logFinalStats()
 			ac.Stop()
 			return
-		default:
-		}
-
-		ac.mu.Lock()
-		if !ac.running || ac.stream == nil {
-			ac.mu.Unlock()
-			ac.logFinalStats()
-			return
-		}
-		stream := ac.stream
-		ac.mu.Unlock()
-
-		// Read audio frame
-		if err := stream.Read(); err != nil {
-			time.Sleep(10 * time.Millisecond)
-			continue
-		}
-
-		// Convert int16 to bytes (PCM16 little-endian)
-		audioBytes := int16ToBytes(in)
-
-		// Calculate energy level (0.0 - 1.0)
-		energy := calculateEnergy(in)
-
-		// Send audio data with drop detection
-		select {
-		case ac.audioOut <- audioBytes:
-			ac.chunksSent++
-			// Log first chunk and periodic progress
-			if ac.chunksSent == 1 {
-				fmt.Printf("[AUDIO] First audio chunk captured: %d bytes, energy=%.3f\n", len(audioBytes), energy)
-			} else if ac.chunksSent%500 == 0 {
-				fmt.Printf("[AUDIO] Captured %d chunks (dropped %d, %.1f%% loss)\n",
-					ac.chunksSent, ac.chunksDropped,
-					float64(ac.chunksDropped)/float64(ac.chunksSent+ac.chunksDropped)*100)
+		case frame, ok := <-frames:
+			if !ok {
+				ac.logFinalStats()
+				ac.Stop()
+				return
 			}
-		default:
-			ac.chunksDropped++
-			// Log drops (throttled to avoid spam)
-			if time.Since(ac.lastDropLog) > time.Second {
-				fmt.Printf("[AUDIO WARNING] Dropping audio chunks! Sent=%d, Dropped=%d (channel full)\n",
-					ac.chunksSent, ac.chunksDropped)
-				ac.lastDropLog = time.Now()
-			}
-		}
 
-		// Send energy level
-		select {
-		case ac.energyOut <- energy:
-		default:
-			// Energy drops are less critical, don't log
+			// frame.Data is already PCM16 little-endian bytes.
+			audioBytes := frame.Data
+
+			// Calculate energy level (0.0 - 1.0)
+			energy := calculateEnergy(BytesToInt16(audioBytes))
+
+			// Send audio data with drop detection
+			select {
+			case ac.audioOut <- audioBytes:
+				ac.chunksSent++
+				if ac.chunksSent == 1 {
+					fmt.Printf("[AUDIO] First audio chunk captured: %d bytes, energy=%.3f\n", len(audioBytes), energy)
+				} else if ac.chunksSent%500 == 0 {
+					fmt.Printf("[AUDIO] Captured %d chunks (dropped %d, %.1f%% loss)\n",
+						ac.chunksSent, ac.chunksDropped,
+						float64(ac.chunksDropped)/float64(ac.chunksSent+ac.chunksDropped)*100)
+				}
+			default:
+				ac.chunksDropped++
+				if time.Since(ac.lastDropLog) > time.Second {
+					fmt.Printf("[AUDIO WARNING] Dropping audio chunks! Sent=%d, Dropped=%d (channel full)\n",
+						ac.chunksSent, ac.chunksDropped)
+					ac.lastDropLog = time.Now()
+				}
+			}
+
+			// Send energy level
+			select {
+			case ac.energyOut <- energy:
+			default:
+				// Energy drops are less critical, don't log
+			}
 		}
 	}
 }
@@ -246,28 +234,17 @@ func (ap *AudioPlayback) Start(ctx context.Context) error {
 		ap.mu.Unlock()
 		return nil
 	}
-	ap.mu.Unlock()
-
-	// Open output stream
-	out := make([]int16, OutputFramesPerBuffer)
-	stream, err := portaudio.OpenDefaultStream(0, Channels, float64(OutputSampleRate), OutputFramesPerBuffer, out)
-	if err != nil {
-		return fmt.Errorf("failed to open output stream: %w", err)
-	}
-
-	if err := stream.Start(); err != nil {
-		stream.Close()
-		return fmt.Errorf("failed to start output stream: %w", err)
-	}
-
-	ap.mu.Lock()
-	ap.stream = stream
 	ap.running = true
-	ap.initialized = true
 	ap.mu.Unlock()
 
-	// Start playback goroutine
-	go ap.playbackLoop(ctx, out)
+	if err := ap.sys.startSession(ctx); err != nil {
+		ap.mu.Lock()
+		ap.running = false
+		ap.mu.Unlock()
+		return fmt.Errorf("failed to start audio session: %w", err)
+	}
+
+	go ap.playbackLoop(ctx)
 
 	return nil
 }
@@ -276,12 +253,6 @@ func (ap *AudioPlayback) Start(ctx context.Context) error {
 func (ap *AudioPlayback) Stop() {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
-
-	if ap.stream != nil {
-		ap.stream.Stop()
-		ap.stream.Close()
-		ap.stream = nil
-	}
 	ap.running = false
 }
 
@@ -300,9 +271,8 @@ func (ap *AudioPlayback) AudioInput() chan<- []byte {
 	return ap.audioIn
 }
 
-func (ap *AudioPlayback) playbackLoop(ctx context.Context, out []int16) {
-	buffer := make([]byte, 0, OutputFramesPerBuffer*4)
-
+func (ap *AudioPlayback) playbackLoop(ctx context.Context) {
+	sink := ap.sys.session.Sinks()[0]
 	for {
 		select {
 		case <-ctx.Done():
@@ -313,26 +283,13 @@ func (ap *AudioPlayback) playbackLoop(ctx context.Context, out []int16) {
 				return
 			}
 
-			buffer = append(buffer, audioData...)
-
-			// Play when we have enough samples
-			for len(buffer) >= len(out)*2 {
-				// Convert bytes to int16
-				for i := 0; i < len(out); i++ {
-					if i*2+1 < len(buffer) {
-						out[i] = int16(binary.LittleEndian.Uint16(buffer[i*2:]))
-					}
-				}
-
-				ap.mu.Lock()
-				if ap.stream != nil {
-					ap.stream.Write()
-				}
-				ap.mu.Unlock()
-
-				// Remove played samples
-				buffer = buffer[len(out)*2:]
-			}
+			// The sink buffers and paces playback internally; hand it the raw
+			// PCM16 little-endian bytes.
+			sink.Write(rtaudio.MediaFrame{
+				Kind:   rtaudio.KindAudio,
+				Data:   audioData,
+				Format: rtaudio.Format{SampleRate: OutputSampleRate, Channels: Channels},
+			})
 		}
 	}
 }
@@ -344,6 +301,9 @@ func HasVoiceActivity(samples []int16) bool {
 
 // calculateEnergy returns normalized energy level (0.0 - 1.0)
 func calculateEnergy(samples []int16) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
 	var sum int64
 	for _, s := range samples {
 		if s < 0 {
@@ -359,15 +319,6 @@ func calculateEnergy(samples []int16) float64 {
 		normalized = 1.0
 	}
 	return normalized
-}
-
-// int16ToBytes converts int16 audio samples to bytes (little-endian PCM16)
-func int16ToBytes(samples []int16) []byte {
-	bytes := make([]byte, len(samples)*2)
-	for i, s := range samples {
-		binary.LittleEndian.PutUint16(bytes[i*2:], uint16(s))
-	}
-	return bytes
 }
 
 // BytesToInt16 converts bytes to int16 audio samples (little-endian PCM16)

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/google/uuid v1.6.0
-	github.com/gordonklaus/portaudio v0.0.0-20250206071425-98a94950218b
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
@@ -59,6 +58,7 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -86,6 +86,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
+github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -106,8 +108,6 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gordonklaus/portaudio v0.0.0-20250206071425-98a94950218b h1:WEuQWBxelOGHA6z9lABqaMLMrfwVyMdN3UgRLT+YUPo=
-github.com/gordonklaus/portaudio v0.0.0-20250206071425-98a94950218b/go.mod h1:esZFQEUwqC+l76f2R8bIWSwXMaPbp79PppwZ1eJhFco=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/tools/arena/voice/audioio_test.go
+++ b/tools/arena/voice/audioio_test.go
@@ -2,8 +2,6 @@ package voice
 
 import (
 	"context"
-	"errors"
-	"strings"
 	"sync"
 	"testing"
 )
@@ -39,36 +37,6 @@ func (f *fakeAudioIO) Close() error { return nil }
 func (f *fakeAudioIO) PlayedAfterFlush() []byte { f.mu.Lock(); defer f.mu.Unlock(); return f.queued }
 func (f *fakeAudioIO) FlushCount() int          { f.mu.Lock(); defer f.mu.Unlock(); return f.flushCount }
 
-// TestPortAudioCandidatesFor verifies each OS gets sensible, ordered library
-// names (the discovery list dlopen walks).
-func TestPortAudioCandidatesFor(t *testing.T) {
-	cases := map[string]struct {
-		first    string
-		contains string
-	}{
-		"darwin":  {first: "libportaudio.2.dylib", contains: ".dylib"},
-		"linux":   {first: "libportaudio.so.2", contains: ".so"},
-		"windows": {first: "portaudio.dll", contains: ".dll"},
-		"freebsd": {first: "libportaudio.so.2", contains: ".so"}, // default branch
-	}
-	for goos, want := range cases {
-		t.Run(goos, func(t *testing.T) {
-			got := portAudioCandidatesFor(goos)
-			if len(got) == 0 {
-				t.Fatalf("no candidates for %s", goos)
-			}
-			if got[0] != want.first {
-				t.Fatalf("%s: first candidate = %q, want %q", goos, got[0], want.first)
-			}
-			for _, c := range got {
-				if !strings.Contains(c, want.contains) {
-					t.Fatalf("%s: candidate %q missing %q", goos, c, want.contains)
-				}
-			}
-		})
-	}
-}
-
 func TestFakeAudioIO_FlushDropsQueuedPlayback(t *testing.T) {
 	io := newFakeAudioIO()
 	io.Play([]byte{1, 2, 3, 4})
@@ -79,45 +47,5 @@ func TestFakeAudioIO_FlushDropsQueuedPlayback(t *testing.T) {
 	}
 	if io.FlushCount() != 1 {
 		t.Fatalf("expected 1 flush, got %d", io.FlushCount())
-	}
-}
-
-func TestPortaudioIO_FlushClearsAccumulator(t *testing.T) {
-	p := &portaudioIO{
-		outBuf:  make([]int16, playbackFramesPerBuffer),
-		playCh:  make(chan []byte, captureChanBuffer),
-		flushCh: make(chan struct{}, 1),
-		done:    make(chan struct{}),
-	}
-	p.playCh <- make([]byte, 64)
-	p.playCh <- make([]byte, 64)
-	p.requestFlush()
-	if got := len(p.playCh); got != 0 {
-		t.Fatalf("expected playCh drained, got %d queued", got)
-	}
-	if got := len(p.flushCh); got != 1 {
-		t.Fatalf("expected flush signal queued, got %d", got)
-	}
-}
-
-// TestNewAudioIO_LoadsOrReportsMissing exercises the real purego binding. On a
-// machine with PortAudio installed it must load + initialize successfully
-// (proving the CGO-free FFI works); otherwise it must return errPortAudioMissing
-// with actionable guidance — never crash.
-func TestNewAudioIO_LoadsOrReportsMissing(t *testing.T) {
-	io, err := NewAudioIO()
-	if err != nil {
-		if !errors.Is(err, errPortAudioMissing) {
-			t.Fatalf("expected errPortAudioMissing when load fails, got: %v", err)
-		}
-		if !strings.Contains(err.Error(), voiceDocsURL) {
-			t.Fatalf("missing-PortAudio error should link the docs (%s), got: %v", voiceDocsURL, err)
-		}
-		t.Skipf("PortAudio not installed on this host: %v", err)
-	}
-	// Loaded + Pa_Initialize succeeded — the runtime-load binding works. Close
-	// terminates PortAudio; no audio device was opened (Start was never called).
-	if cerr := io.Close(); cerr != nil {
-		t.Fatalf("Close: %v", cerr)
 	}
 }

--- a/tools/arena/voice/session_audioio.go
+++ b/tools/arena/voice/session_audioio.go
@@ -1,0 +1,73 @@
+package voice
+
+import (
+	"context"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// captureChanBuffer bounds the mic forwarding channel. It matches the buffer the
+// runtime/audio capture path uses so backpressure behaves identically.
+const captureChanBuffer = 32
+
+// sessionAudioIO adapts a runtime/audio Session to the voice.AudioIO interface.
+// It bridges the MediaFrame Source/Sink to the []byte capture channel plus the
+// Play/Flush/Close shape Arena's Driver and pipeline seam expect.
+type sessionAudioIO struct {
+	sess   audio.Session
+	source audio.Source
+	sink   audio.Sink
+
+	mu        sync.Mutex
+	captureCh chan []byte
+}
+
+func newSessionAudioIO(sess audio.Session) *sessionAudioIO {
+	return &sessionAudioIO{
+		sess:   sess,
+		source: sess.Sources()[0],
+		sink:   sess.Sinks()[0],
+	}
+}
+
+// Start opens the underlying session's devices.
+func (s *sessionAudioIO) Start(ctx context.Context) error { return s.sess.Start(ctx) }
+
+// CaptureChunks lazily starts a forwarding goroutine that reads the Source's
+// MediaFrames and emits their raw PCM16 bytes. Frames are dropped on backpressure
+// (preserving the hardware observer cadence); the channel closes when Frames does.
+func (s *sessionAudioIO) CaptureChunks() <-chan []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.captureCh == nil {
+		s.captureCh = make(chan []byte, captureChanBuffer)
+		go s.pump(s.captureCh)
+	}
+	return s.captureCh
+}
+
+func (s *sessionAudioIO) pump(out chan<- []byte) {
+	defer close(out)
+	for frame := range s.source.Frames() {
+		select {
+		case out <- frame.Data:
+		default: // drop on backpressure — preserve observer cadence
+		}
+	}
+}
+
+// Play enqueues a PCM16 frame for speaker playback at the playback sample rate.
+func (s *sessionAudioIO) Play(frame []byte) {
+	s.sink.Write(audio.MediaFrame{
+		Kind:   audio.KindAudio,
+		Data:   frame,
+		Format: audio.Format{SampleRate: PlaybackSampleRate, Channels: 1},
+	})
+}
+
+// Flush drops all queued and in-flight speaker audio (barge-in).
+func (s *sessionAudioIO) Flush() { s.sink.Flush() }
+
+// Close stops the underlying session and releases its resources.
+func (s *sessionAudioIO) Close() error { return s.sess.Close() }

--- a/tools/arena/voice/session_audioio_interactive.go
+++ b/tools/arena/voice/session_audioio_interactive.go
@@ -1,0 +1,20 @@
+package voice
+
+import "github.com/AltairaLabs/PromptKit/runtime/audio"
+
+// NewAudioIO constructs an AudioIO backed by the shared runtime/audio PortAudio
+// Session. The hardware core now lives in runtime/audio; this thin adapter keeps
+// the Driver and pipeline seam consuming the unchanged voice.AudioIO interface.
+// It returns the actionable missing-PortAudio error unchanged so the console can
+// surface install steps instead of crashing.
+//
+// This file is named *_interactive.go because it opens real audio hardware and
+// cannot be unit-tested without PortAudio; the testable adapter logic lives in
+// session_audioio.go.
+func NewAudioIO() (AudioIO, error) {
+	sess, err := audio.NewPortAudioSession()
+	if err != nil {
+		return nil, err
+	}
+	return newSessionAudioIO(sess), nil
+}

--- a/tools/arena/voice/session_audioio_test.go
+++ b/tools/arena/voice/session_audioio_test.go
@@ -1,0 +1,106 @@
+package voice
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// fakeSession is an audio.Session backed by MemSource/MemSink so the adapter can
+// be exercised without PortAudio or hardware.
+type fakeSession struct {
+	src  *audio.MemSource
+	sink *audio.MemSink
+}
+
+func newFakeSession() *fakeSession {
+	return &fakeSession{
+		src:  audio.NewMemSource(audio.KindAudio, 4),
+		sink: audio.NewMemSink(audio.KindAudio),
+	}
+}
+
+func (f *fakeSession) Start(context.Context) error { return nil }
+func (f *fakeSession) Sources() []audio.Source     { return []audio.Source{f.src} }
+func (f *fakeSession) Sinks() []audio.Sink         { return []audio.Sink{f.sink} }
+func (f *fakeSession) Close() error                { _ = f.src.Close(); return nil }
+
+// TestSessionAudioIO_CaptureForwardsFrameData proves CaptureChunks forwards the
+// raw PCM16 bytes of each MediaFrame and closes when the source's Frames close.
+func TestSessionAudioIO_CaptureForwardsFrameData(t *testing.T) {
+	fs := newFakeSession()
+	io := newSessionAudioIO(fs)
+
+	fs.src.Push(audio.MediaFrame{Kind: audio.KindAudio, Data: []byte{1, 2, 3, 4}})
+	fs.src.Push(audio.MediaFrame{Kind: audio.KindAudio, Data: []byte{5, 6}})
+
+	ch := io.CaptureChunks()
+	select {
+	case got := <-ch:
+		if string(got) != string([]byte{1, 2, 3, 4}) {
+			t.Fatalf("first chunk = %v, want [1 2 3 4]", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first chunk")
+	}
+	select {
+	case got := <-ch:
+		if string(got) != string([]byte{5, 6}) {
+			t.Fatalf("second chunk = %v, want [5 6]", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for second chunk")
+	}
+
+	// Closing the source closes the forwarded channel.
+	_ = fs.src.Close()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected capture channel to be closed after source close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for capture channel close")
+	}
+}
+
+// TestSessionAudioIO_PlayAndFlushReachSink proves Play writes a 24 kHz audio
+// MediaFrame to the sink and Flush drops queued frames.
+func TestSessionAudioIO_PlayAndFlushReachSink(t *testing.T) {
+	fs := newFakeSession()
+	io := newSessionAudioIO(fs)
+
+	io.Play([]byte{9, 8, 7, 6})
+	written := fs.sink.Written()
+	if len(written) != 1 {
+		t.Fatalf("expected 1 written frame, got %d", len(written))
+	}
+	if string(written[0].Data) != string([]byte{9, 8, 7, 6}) {
+		t.Fatalf("written data = %v, want [9 8 7 6]", written[0].Data)
+	}
+	if written[0].Kind != audio.KindAudio {
+		t.Fatalf("written kind = %v, want KindAudio", written[0].Kind)
+	}
+	if written[0].Format.SampleRate != PlaybackSampleRate {
+		t.Fatalf("written sample rate = %d, want %d", written[0].Format.SampleRate, PlaybackSampleRate)
+	}
+
+	io.Flush()
+	if got := fs.sink.Written(); len(got) != 0 {
+		t.Fatalf("expected sink drained after flush, got %d frames", len(got))
+	}
+}
+
+// TestSessionAudioIO_StartAndClose proves Start and Close delegate to the session.
+func TestSessionAudioIO_StartAndClose(t *testing.T) {
+	fs := newFakeSession()
+	io := newSessionAudioIO(fs)
+	if err := io.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := io.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Phase 2 (Foundation) of the voice barge-in epic (#1502): consolidate the hardware-audio layer into `runtime/audio` behind a timestamped media-frame / session-track shape, and retire the SDK's CGO audio duplication onto that one shared core.

> ⚠️ **Stacked on AltairaLabs/PromptKit#1509** (Phase 1 / AltairaLabs/PromptKit#1485). Review/merge AltairaLabs/PromptKit#1509 first — the base of this PR is `feat/1485-audio-sink-flush`, so this diff shows only the Phase 2 commits.

Closes AltairaLabs/PromptKit#1503
Closes AltairaLabs/PromptKit#1504

## Changes

**#1503 — media interfaces (`runtime/audio`)**
- New `media.go`: `MediaKind`, `MediaFrame{Kind, Data, PTS, Format}`, `Format{SampleRate, Channels}`, and the `Source` / `Sink` / `Session` interfaces. Audio-only implementation, **video-ready shape** — the `PTS` timestamp is the load-bearing decision for AEC delay-estimation and future A/V sync. No video code (YAGNI).
- New `memio.go`: exported in-memory `MemSource` / `MemSink` test doubles (importable cross-package; idempotent `Close` via `sync.Once`).

**#1504 — move hardware I/O + retire SDK CGO duplication**
- PortAudio hardware I/O **moved** from `tools/arena/voice` into `runtime/audio/portaudio_session.go` (+ dlopen/discovery; build tags preserved; git-mv history). It implements `Session`/`Source`/`Sink`. The Phase-1 (#1485) flush and `Close()`-deadlock fix are preserved byte-for-byte.
- `NewPortAudioSession(opts…)` gains `WithCaptureRate` / `WithPlaybackRate` (defaults 16 kHz / 24 kHz; frame windows reproduce the prior 1600 / 960 exactly — proven by a regression test).
- **Arena is behaviorally unchanged**: it keeps the `AudioIO` interface via a thin `sessionAudioIO` adapter over the shared `Session`. The pipeline seam is deliberately NOT rewired to `MediaFrame` yet — that lands in Phase 3 (P1 duplex), where `PTS`/duplex make it necessary.
- **SDK examples migrated off CGO `gordonklaus/portaudio`** onto the shared pure-Go session: `openai-realtime` (24 kHz), `duplex-streaming` (16/24 kHz), `voice-interview` (16/24 kHz). `gordonklaus/portaudio` is **dropped from `sdk/go.mod`** (now pure-Go via `purego`). `voice-chat` (separate module) is tracked in AltairaLabs/PromptKit#1510.

## Intentional deviations from the plan sketch (all reviewed)

1. **Arena kept on an `AudioIO`→`Session` adapter** instead of rewiring the pipeline seam to `MediaFrame` now — lowest-risk; Driver/`feedMicToPipeline`/`drainAudioOutput` untouched, so Arena behavior is provably unchanged. The seam rewire is Phase 3.
2. **Migrated all three sdk-module examples + dropped the dep** (scope expanded from "one example") — leaving any on CGO `gordonklaus` would have kept it in `go.sum` and defeated the dedup.
3. **Added a minimal `!portaudio` text-fallback `main.go` to duplex-streaming** so the otherwise tag-only package typechecks in the default build for the lint hook (mirrors openai-realtime).

## Testing

- `runtime/audio` (moved PortAudio tests + media/memio + rate-option tests), `tools/arena/voice`, `tools/arena/engine` all pass with `-race`.
- All four modules (`runtime`, `tools/arena`, `sdk`, `pkg`) build; `sdk` builds both default and `-tags portaudio`; `gordonklaus` gone from go.mod/go.sum.
- Device-level capture/playback (real PortAudio) is exercised manually, not in CI.

## Follow-ups
- AltairaLabs/PromptKit#1510 — migrate `voice-chat` (own module) off `gordonklaus`.
- Phase 3 (P1, AltairaLabs/PromptKit#1505) collapses the two streams into a single 48 kHz duplex stream, adds the real PTS clock + resample-at-sink, and rewires the pipeline seam to `MediaFrame`.
