### PR TITLE
feat(reasoning): unified reasoning/thinking across providers — backend (Plans 1+2) (#1527)

### DIFF
--- a/runtime/pipeline/stage/element.go
+++ b/runtime/pipeline/stage/element.go
@@ -63,6 +63,14 @@ func externalizeData(
 	return ref, nil
 }
 
+// ReasoningDelta is a non-content stream element payload carrying incremental
+// model reasoning for live display. It is never persisted as content and never
+// sent to the model on future turns.
+type ReasoningDelta struct {
+	Text   string
+	Opaque []types.OpaqueReasoning
+}
+
 // StreamElement is the unit of data flowing through the pipeline.
 // It can carry different types of content and supports backpressure.
 // Each element should contain at most one content type.
@@ -82,6 +90,11 @@ type StreamElement struct {
 	Timestamp time.Time // When element was created
 	Source    string    // Stage that produced this element
 	Priority  Priority  // Scheduling priority (for QoS)
+
+	// Reasoning is non-content: incremental model reasoning for live display.
+	// It is never persisted as content and never sent to the model on future
+	// turns. Distinct from the content fields above so consumers exclude it.
+	Reasoning *ReasoningDelta
 
 	// Meta is the typed schema for per-element coordination data
 	// (e.g. FromHistory, TurnID, MediaExtract). Per-Turn invariants

--- a/runtime/pipeline/stage/element_test.go
+++ b/runtime/pipeline/stage/element_test.go
@@ -483,3 +483,14 @@ func TestImageData_EnsureLoaded_Error(t *testing.T) {
 // NewImageElement, NewErrorElement, NewEndOfStreamElement, StreamElement.IsEmpty,
 // StreamElement.HasContent, StreamElement.IsControl, and AudioFormat.String
 // are defined in stages_utilities_test.go
+
+func TestStreamElement_ReasoningIsNonContent(t *testing.T) {
+	d := "thinking..."
+	e := StreamElement{Reasoning: &ReasoningDelta{Text: d}}
+	if e.Message != nil || e.Text != nil || e.Part != nil || e.Audio != nil {
+		t.Fatal("a reasoning element must carry no content fields")
+	}
+	if e.Reasoning == nil || e.Reasoning.Text != "thinking..." {
+		t.Fatal("reasoning delta not set")
+	}
+}

--- a/runtime/pipeline/stage/stages_duplex_provider_integration.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_integration.go
@@ -78,9 +78,11 @@ type DuplexProviderStage struct {
 
 	// Response accumulation for the current turn
 	// Reset when turn completes (FinishReason received)
-	accumulatedText      strings.Builder
-	accumulatedMedia     []byte
-	accumulatedToolCalls []types.MessageToolCall
+	accumulatedText            strings.Builder
+	accumulatedReasoning       strings.Builder         // reasoning/thinking text (kept off spoken content)
+	accumulatedOpaqueReasoning []types.OpaqueReasoning // provider round-trip reasoning tokens
+	accumulatedMedia           []byte
+	accumulatedToolCalls       []types.MessageToolCall
 
 	// Input transcription for the current turn (what user said)
 	// Captured from provider's inputTranscription events (if supported)
@@ -744,23 +746,8 @@ func (s *DuplexProviderStage) forwardResponseElements(
 					},
 				}
 
-				if accumulatedText != "" {
-					msg.Parts = append(msg.Parts, types.ContentPart{
-						Type: types.ContentTypeText,
-						Text: &accumulatedText,
-					})
-				}
-
-				if len(s.accumulatedMedia) > 0 {
-					mediaData := base64.StdEncoding.EncodeToString(s.accumulatedMedia)
-					msg.Parts = append(msg.Parts, types.ContentPart{
-						Type: types.ContentTypeAudio,
-						Media: &types.MediaContent{
-							Data:     &mediaData,
-							MIMEType: mimeTypeAudioPCM,
-						},
-					})
-				}
+				msg.Parts = s.buildAssistantParts(accumulatedText)
+				msg.Reasoning = s.takeReasoning()
 
 				elem := StreamElement{
 					Message:     msg,
@@ -785,6 +772,8 @@ func (s *DuplexProviderStage) forwardResponseElements(
 
 				// Clear accumulators
 				s.accumulatedText.Reset()
+				s.accumulatedReasoning.Reset()
+				s.accumulatedOpaqueReasoning = nil
 				s.accumulatedMedia = nil
 			}
 			return ctx.Err()
@@ -849,23 +838,8 @@ func (s *DuplexProviderStage) forwardResponseElements(
 						},
 					}
 
-					if accumulatedText != "" {
-						msg.Parts = append(msg.Parts, types.ContentPart{
-							Type: types.ContentTypeText,
-							Text: &accumulatedText,
-						})
-					}
-
-					if len(s.accumulatedMedia) > 0 {
-						mediaData := base64.StdEncoding.EncodeToString(s.accumulatedMedia)
-						msg.Parts = append(msg.Parts, types.ContentPart{
-							Type: types.ContentTypeAudio,
-							Media: &types.MediaContent{
-								Data:     &mediaData,
-								MIMEType: mimeTypeAudioPCM,
-							},
-						})
-					}
+					msg.Parts = s.buildAssistantParts(accumulatedText)
+					msg.Reasoning = s.takeReasoning()
 
 					elem := StreamElement{
 						Message:     msg,
@@ -884,6 +858,8 @@ func (s *DuplexProviderStage) forwardResponseElements(
 
 					// Clear accumulators
 					s.accumulatedText.Reset()
+					s.accumulatedReasoning.Reset()
+					s.accumulatedOpaqueReasoning = nil
 					s.accumulatedMedia = nil
 				}
 
@@ -1066,6 +1042,19 @@ func (s *DuplexProviderStage) handleResponseChunk(
 		s.accumulatedText.WriteString(chunk.Content)
 	}
 
+	// Accumulate reasoning/thinking separately from spoken text (it lands on
+	// Message.Reasoning at turn complete, never as content), and emit a live
+	// non-content ReasoningDelta so the UI can stream thinking as it arrives.
+	if chunk.Reasoning != "" || len(chunk.OpaqueReasoning) > 0 {
+		s.accumulatedReasoning.WriteString(chunk.Reasoning)
+		s.accumulatedOpaqueReasoning = append(s.accumulatedOpaqueReasoning, chunk.OpaqueReasoning...)
+		select {
+		case output <- StreamElement{Reasoning: &ReasoningDelta{Text: chunk.Reasoning, Opaque: chunk.OpaqueReasoning}}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	// Accumulate media content for this turn
 	// MediaData.Data is already raw bytes — providers decode base64 at source
 	if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
@@ -1089,6 +1078,8 @@ func (s *DuplexProviderStage) handleResponseChunk(
 	// we need to accumulate the real response content that comes next
 	if chunk.FinishReason != nil && *chunk.FinishReason != "" && elem.EndOfStream {
 		s.accumulatedText.Reset()
+		s.accumulatedReasoning.Reset()
+		s.accumulatedOpaqueReasoning = nil
 		s.accumulatedMedia = nil
 		s.accumulatedToolCalls = nil
 		// Mark transcription as captured - don't reset yet!
@@ -1162,6 +1153,36 @@ func (s *DuplexProviderStage) handleResponseChunk(
 // - Interruptions: Captured as partial responses with finish_reason="interrupted"
 // - Turn completion: Creates Message with accumulated content
 // - Streaming content: Passes through text/audio for real-time display/playback
+// buildAssistantParts assembles the assistant message content parts for the
+// current turn: spoken text, then accumulated audio. Reasoning is NOT a content
+// part — it lives on Message.Reasoning (see takeReasoning), off Parts, so it's
+// excluded from content/exports/future context by construction.
+func (s *DuplexProviderStage) buildAssistantParts(accumulatedText string) []types.ContentPart {
+	parts := []types.ContentPart{}
+	if accumulatedText != "" {
+		text := accumulatedText
+		parts = append(parts, types.ContentPart{Type: types.ContentTypeText, Text: &text})
+	}
+	if len(s.accumulatedMedia) > 0 {
+		mediaData := base64.StdEncoding.EncodeToString(s.accumulatedMedia)
+		parts = append(parts, types.ContentPart{
+			Type:  types.ContentTypeAudio,
+			Media: &types.MediaContent{Data: &mediaData, MIMEType: mimeTypeAudioPCM},
+		})
+	}
+	return parts
+}
+
+// takeReasoning returns the accumulated reasoning trace for the turn, or nil if
+// none. Attached to the assistant Message.Reasoning at each build site.
+func (s *DuplexProviderStage) takeReasoning() *types.ReasoningTrace {
+	text := s.accumulatedReasoning.String()
+	if text == "" && len(s.accumulatedOpaqueReasoning) == 0 {
+		return nil
+	}
+	return &types.ReasoningTrace{Text: text, Opaque: s.accumulatedOpaqueReasoning}
+}
+
 func (s *DuplexProviderStage) chunkToElement(chunk *providers.StreamChunk) StreamElement {
 	elem := StreamElement{}
 
@@ -1193,29 +1214,16 @@ func (s *DuplexProviderStage) chunkToElement(chunk *providers.StreamChunk) Strea
 				msg.LatencyMs = time.Since(s.turnStartTime).Milliseconds()
 			}
 
-			if accumulatedText != "" {
-				msg.Parts = append(msg.Parts, types.ContentPart{
-					Type: types.ContentTypeText,
-					Text: &accumulatedText,
-				})
-			}
-
-			if len(s.accumulatedMedia) > 0 {
-				mediaData := base64.StdEncoding.EncodeToString(s.accumulatedMedia)
-				msg.Parts = append(msg.Parts, types.ContentPart{
-					Type: types.ContentTypeAudio,
-					Media: &types.MediaContent{
-						Data:     &mediaData,
-						MIMEType: mimeTypeAudioPCM,
-					},
-				})
-			}
+			msg.Parts = s.buildAssistantParts(accumulatedText)
+			msg.Reasoning = s.takeReasoning()
 
 			elem.Message = msg
 		}
 
 		// Clear accumulated content - provider will start new response
 		s.accumulatedText.Reset()
+		s.accumulatedReasoning.Reset()
+		s.accumulatedOpaqueReasoning = nil
 		s.accumulatedMedia = nil
 
 		// Mark that we saw an interruption - the next turnComplete without content should be skipped
@@ -1322,23 +1330,8 @@ func (s *DuplexProviderStage) chunkToElement(chunk *providers.StreamChunk) Strea
 					"count", len(chunk.ToolCalls))
 			}
 
-			if accumulatedText != "" {
-				msg.Parts = append(msg.Parts, types.ContentPart{
-					Type: types.ContentTypeText,
-					Text: &accumulatedText,
-				})
-			}
-
-			if len(s.accumulatedMedia) > 0 {
-				mediaData := base64.StdEncoding.EncodeToString(s.accumulatedMedia)
-				msg.Parts = append(msg.Parts, types.ContentPart{
-					Type: types.ContentTypeAudio,
-					Media: &types.MediaContent{
-						Data:     &mediaData,
-						MIMEType: mimeTypeAudioPCM,
-					},
-				})
-			}
+			msg.Parts = s.buildAssistantParts(accumulatedText)
+			msg.Reasoning = s.takeReasoning()
 
 			elem.Message = msg
 			logger.Debug("DuplexProviderStage: created message for turn",

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1271,7 +1271,7 @@ func (s *ProviderStage) executeStreamingRound(
 	}
 
 	// Process all chunks and collect response
-	content, toolCalls, costInfo, chunkValidations, err := s.processStreamChunks(ctx, streamChan, output)
+	content, toolCalls, costInfo, reasoning, chunkValidations, err := s.processStreamChunks(ctx, streamChan, output)
 	duration := time.Since(startTime)
 
 	if err != nil {
@@ -1333,6 +1333,7 @@ func (s *ProviderStage) executeStreamingRound(
 		Role:        "assistant",
 		Content:     content,
 		ToolCalls:   toolCalls,
+		Reasoning:   reasoning,
 		Timestamp:   timeNow(),
 		LatencyMs:   duration.Milliseconds(),
 		CostInfo:    costInfo,
@@ -1429,10 +1430,12 @@ func (s *ProviderStage) processStreamChunks(
 	ctx context.Context,
 	streamChan <-chan providers.StreamChunk,
 	output chan<- StreamElement,
-) (string, []types.MessageToolCall, *types.CostInfo, []types.ValidationResult, error) {
+) (string, []types.MessageToolCall, *types.CostInfo, *types.ReasoningTrace, []types.ValidationResult, error) {
 	var content string
 	var toolCalls []types.MessageToolCall
 	var costInfo *types.CostInfo
+	var reasoning strings.Builder
+	var opaqueReasoning []types.OpaqueReasoning
 	var pendingValidations []types.ValidationResult
 
 	for chunk := range streamChan {
@@ -1446,12 +1449,14 @@ func (s *ProviderStage) processStreamChunks(
 			content = ""
 			toolCalls = nil
 			costInfo = nil
+			reasoning.Reset()
+			opaqueReasoning = nil
 			continue
 		}
 
 		if chunk.Error != nil {
 			logger.Error("Stream chunk error", "error", chunk.Error)
-			return "", nil, nil, nil, fmt.Errorf("stream chunk error: %w", chunk.Error)
+			return "", nil, nil, nil, nil, fmt.Errorf("stream chunk error: %w", chunk.Error)
 		}
 
 		content = chunk.Content
@@ -1462,9 +1467,13 @@ func (s *ProviderStage) processStreamChunks(
 		if chunk.CostInfo != nil {
 			costInfo = chunk.CostInfo
 		}
+		// Accumulate reasoning (deltas) separately from content; it surfaces on
+		// Message.Reasoning, never as content or future context.
+		reasoning.WriteString(chunk.Reasoning)
+		opaqueReasoning = append(opaqueReasoning, chunk.OpaqueReasoning...)
 
 		if err := s.emitChunkElement(ctx, &chunk, output); err != nil {
-			return "", nil, nil, nil, err
+			return "", nil, nil, nil, nil, err
 		}
 
 		// Run chunk interceptor hooks
@@ -1489,7 +1498,7 @@ func (s *ProviderStage) processStreamChunks(
 					content = chunk.Content
 					break
 				}
-				return "", nil, nil, nil, &providers.ValidationAbortError{
+				return "", nil, nil, nil, nil, &providers.ValidationAbortError{
 					Reason: d.Reason,
 					Chunk:  chunk,
 				}
@@ -1497,7 +1506,11 @@ func (s *ProviderStage) processStreamChunks(
 		}
 	}
 
-	return content, toolCalls, costInfo, pendingValidations, nil
+	var trace *types.ReasoningTrace
+	if reasoning.Len() > 0 || len(opaqueReasoning) > 0 {
+		trace = &types.ReasoningTrace{Text: reasoning.String(), Opaque: opaqueReasoning}
+	}
+	return content, toolCalls, costInfo, trace, pendingValidations, nil
 }
 
 // emitChunkElement creates and emits streaming element(s) for a chunk.
@@ -1507,6 +1520,16 @@ func (s *ProviderStage) emitChunkElement(
 	chunk *providers.StreamChunk,
 	output chan<- StreamElement,
 ) error {
+	// Emit a live, non-content reasoning element if present, so the UI can stream
+	// thinking as it arrives (it also accumulates onto Message.Reasoning).
+	if chunk.Reasoning != "" || len(chunk.OpaqueReasoning) > 0 {
+		select {
+		case output <- StreamElement{Reasoning: &ReasoningDelta{Text: chunk.Reasoning, Opaque: chunk.OpaqueReasoning}}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	// Emit text element if present
 	if chunk.Delta != "" {
 		elem := NewTextElement(chunk.Delta)

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1126,6 +1126,7 @@ func (s *ProviderStage) executeRound(
 		Role:         roleAssistant,
 		Content:      resp.Content,
 		Parts:        resp.Parts,
+		Reasoning:    resp.Reasoning,
 		ToolCalls:    toolCalls,
 		Timestamp:    timeNow(),
 		LatencyMs:    duration.Milliseconds(),

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -3247,3 +3247,60 @@ func TestProcessStreamChunks_AccumulatesReasoning(t *testing.T) {
 	}
 	assert.True(t, sawReasoning, "expected a live ReasoningDelta element")
 }
+
+// reasoningEndToEndProvider returns a response carrying reasoning, and records the
+// messages it was asked to predict on (to verify reasoning never re-enters context).
+type reasoningEndToEndProvider struct {
+	delayedStreamProvider
+	gotMessages []types.Message
+}
+
+func (p *reasoningEndToEndProvider) SupportsStreaming() bool { return false }
+
+func (p *reasoningEndToEndProvider) Predict(
+	_ context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.gotMessages = req.Messages
+	return providers.PredictionResponse{
+		Content: "the answer",
+		Reasoning: &types.ReasoningTrace{
+			Text:   "internal reasoning",
+			Opaque: []types.OpaqueReasoning{{Provider: "test", Kind: "thinking_signature", Data: "sig"}},
+		},
+	}, nil
+}
+
+// TestProviderStage_ReasoningEndToEnd proves the wired seam: a provider's reasoning
+// flows through the real pipeline onto Message.Reasoning, is excluded from the
+// message's content projection, and is NOT echoed back into the provider request.
+func TestProviderStage_ReasoningEndToEnd(t *testing.T) {
+	provider := &reasoningEndToEndProvider{}
+	turnState := NewTurnState()
+	turnState.SystemPrompt = "helper"
+	providerStage := NewProviderStageWithTurnState(provider, nil, nil, &ProviderConfig{MaxTokens: 100}, nil, nil, turnState)
+
+	pl, err := NewPipelineBuilderWithConfig(DefaultPipelineConfig()).Chain(providerStage).Build()
+	require.NoError(t, err)
+
+	userMsg := types.Message{Role: "user", Content: "hi"}
+	result, err := pl.ExecuteSync(context.Background(), NewMessageElement(&userMsg))
+	require.NoError(t, err)
+
+	var assistant *types.Message
+	for i := range result.Messages {
+		if result.Messages[i].Role == "assistant" {
+			assistant = &result.Messages[i]
+		}
+	}
+	require.NotNil(t, assistant, "expected an assistant message")
+	require.NotNil(t, assistant.Reasoning, "reasoning must flow end-to-end onto Message.Reasoning")
+	assert.Equal(t, "internal reasoning", assistant.Reasoning.Text)
+	require.Len(t, assistant.Reasoning.Opaque, 1)
+	assert.Equal(t, "the answer", assistant.GetContent(), "reasoning must be excluded from content")
+
+	// The provider's request must not contain the reasoning text in any message.
+	for _, m := range provider.gotMessages {
+		assert.NotContains(t, m.GetContent(), "internal reasoning", "reasoning must not re-enter context")
+		assert.Nil(t, m.Reasoning, "history messages into the provider carry no reasoning")
+	}
+}

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -3218,3 +3218,32 @@ func TestAfterRound_IdenticalToolCallBreaker(t *testing.T) {
 		assert.Equal(t, 3, stg.getMaxIdenticalToolCalls())
 	})
 }
+
+// TestProcessStreamChunks_AccumulatesReasoning verifies the regular streaming
+// provider stage accumulates StreamChunk.Reasoning deltas into a ReasoningTrace
+// (returned, not in content) and emits a live non-content ReasoningDelta element.
+func TestProcessStreamChunks_AccumulatesReasoning(t *testing.T) {
+	s := &ProviderStage{}
+	in := make(chan providers.StreamChunk, 4)
+	out := make(chan StreamElement, 16)
+	fr := "stop"
+	in <- providers.StreamChunk{Reasoning: "think "}
+	in <- providers.StreamChunk{Reasoning: "more"}
+	in <- providers.StreamChunk{Content: "answer", Delta: "answer", FinishReason: &fr}
+	close(in)
+
+	content, _, _, trace, _, err := s.processStreamChunks(context.Background(), in, out)
+	require.NoError(t, err)
+	assert.Equal(t, "answer", content, "content must exclude reasoning")
+	require.NotNil(t, trace, "expected a reasoning trace")
+	assert.Equal(t, "think more", trace.Text)
+
+	close(out)
+	var sawReasoning bool
+	for e := range out {
+		if e.Reasoning != nil {
+			sawReasoning = true
+		}
+	}
+	assert.True(t, sawReasoning, "expected a live ReasoningDelta element")
+}

--- a/runtime/pipeline/stage/stages_save.go
+++ b/runtime/pipeline/stage/stages_save.go
@@ -39,6 +39,11 @@ type IncrementalSaveConfig struct {
 	// by the provider stage's write-through. The save stage skips message append
 	// but still handles indexing and summarization.
 	MessageLog statestore.MessageLog
+
+	// PersistReasoning, when false (the default), strips Message.Reasoning before
+	// persisting so model reasoning never lands in the conversation store. Set true
+	// to retain reasoning in the persisted record.
+	PersistReasoning bool
 }
 
 // IncrementalSaveStage saves only new messages from the current turn using
@@ -99,11 +104,18 @@ func (s *IncrementalSaveStage) Process(
 
 	convID := s.config.StateStoreConfig.ConversationID
 
+	// Strip model reasoning before persistence unless explicitly retained, so it
+	// never lands in the conversation store (default off).
+	toPersist := collected.messages
+	if !s.config.PersistReasoning {
+		toPersist = types.StripReasoning(toPersist)
+	}
+
 	// When MessageLog is NOT active, persist messages via the store.
 	// When MessageLog IS active, messages are already persisted per-round
 	// by the provider stage write-through — skip message append.
 	if s.config.MessageLog == nil {
-		if err := s.persistMessages(ctx, convID, collected.messages); err != nil {
+		if err := s.persistMessages(ctx, convID, toPersist); err != nil {
 			return err
 		}
 	}

--- a/runtime/pipeline/stage/stages_save_test.go
+++ b/runtime/pipeline/stage/stages_save_test.go
@@ -1114,3 +1114,58 @@ func TestIncrementalSaveStage_FullSavePreservesSummariesViaSummaryAccessor(t *te
 	require.Len(t, store.state.Summaries, 1)
 	assert.Equal(t, "summary written between Load and Save", store.state.Summaries[0].Content)
 }
+
+// TestIncrementalSaveStage_StripsReasoningByDefault proves the persistence seam:
+// model reasoning is removed before it reaches the conversation store unless
+// PersistReasoning is set.
+func TestIncrementalSaveStage_StripsReasoningByDefault(t *testing.T) {
+	store := statestore.NewMemoryStore()
+	ctx := context.Background()
+	config := &IncrementalSaveConfig{
+		StateStoreConfig: &pipeline.StateStoreConfig{Store: store, ConversationID: "conv-r"},
+	}
+	s := NewIncrementalSaveStage(config)
+
+	user := types.Message{Role: "user", Content: "q"}
+	asst := types.Message{Role: "assistant", Content: "answer", Reasoning: &types.ReasoningTrace{Text: "secret reasoning"}}
+	runTestStage(t, s, []StreamElement{NewMessageElement(&user), NewMessageElement(&asst)})
+
+	state, err := store.Load(ctx, "conv-r")
+	require.NoError(t, err)
+	var got *types.Message
+	for i := range state.Messages {
+		if state.Messages[i].Role == "assistant" {
+			got = &state.Messages[i]
+		}
+	}
+	require.NotNil(t, got, "expected the assistant message persisted")
+	assert.Nil(t, got.Reasoning, "reasoning must be stripped from the store by default")
+	assert.Equal(t, "answer", got.Content)
+}
+
+// TestIncrementalSaveStage_KeepsReasoningWhenEnabled proves the opt-in retains it.
+func TestIncrementalSaveStage_KeepsReasoningWhenEnabled(t *testing.T) {
+	store := statestore.NewMemoryStore()
+	ctx := context.Background()
+	config := &IncrementalSaveConfig{
+		StateStoreConfig: &pipeline.StateStoreConfig{Store: store, ConversationID: "conv-rk"},
+		PersistReasoning: true,
+	}
+	s := NewIncrementalSaveStage(config)
+
+	user := types.Message{Role: "user", Content: "q"}
+	asst := types.Message{Role: "assistant", Content: "answer", Reasoning: &types.ReasoningTrace{Text: "kept reasoning"}}
+	runTestStage(t, s, []StreamElement{NewMessageElement(&user), NewMessageElement(&asst)})
+
+	state, err := store.Load(ctx, "conv-rk")
+	require.NoError(t, err)
+	var got *types.Message
+	for i := range state.Messages {
+		if state.Messages[i].Role == "assistant" {
+			got = &state.Messages[i]
+		}
+	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.Reasoning, "reasoning must be retained when PersistReasoning is true")
+	assert.Equal(t, "kept reasoning", got.Reasoning.Text)
+}

--- a/runtime/pipeline/stage/stages_streaming_test.go
+++ b/runtime/pipeline/stage/stages_streaming_test.go
@@ -241,6 +241,79 @@ func TestDuplexProviderStage_ResponseForwarding(t *testing.T) {
 	})
 }
 
+// TestDuplexProviderStage_ReasoningOnMessageAndStreamedLive verifies reasoning
+// (StreamChunk.Reasoning) is streamed live as a non-content ReasoningDelta and
+// attached to the assistant message on Message.Reasoning (off Parts), excluded
+// from spoken content — not leaked into the transcript and not a content part.
+func TestDuplexProviderStage_ReasoningOnMessageAndStreamedLive(t *testing.T) {
+	s := NewDuplexProviderStage(providersmock.NewStreamingProvider("t", "m", false), baseConfig())
+	output := make(chan StreamElement, 8)
+	ctx := context.Background()
+
+	require.NoError(t, s.handleResponseChunk(ctx, &providers.StreamChunk{Reasoning: "Let me think about Dylan."}, output))
+	// A live, non-content reasoning element is emitted immediately.
+	live := <-output
+	require.NotNil(t, live.Reasoning, "expected a live ReasoningDelta element")
+	require.Nil(t, live.Message, "reasoning element must not be a message")
+	assert.Equal(t, "Let me think about Dylan.", live.Reasoning.Text)
+
+	require.NoError(t, s.handleResponseChunk(ctx, &providers.StreamChunk{
+		Delta:    "Bob Dylan is a legend.",
+		Metadata: map[string]interface{}{"type": "output_transcription"},
+	}, output))
+	fr := "complete"
+	require.NoError(t, s.handleResponseChunk(ctx, &providers.StreamChunk{FinishReason: &fr}, output))
+
+	msg := drainAssistantMessage(output)
+	require.NotNil(t, msg, "expected an assistant message at turn complete")
+	assert.Equal(t, "Bob Dylan is a legend.", msg.GetContent(), "spoken content must exclude reasoning")
+	require.NotNil(t, msg.Reasoning, "reasoning should be on Message.Reasoning")
+	assert.Equal(t, "Let me think about Dylan.", msg.Reasoning.Text)
+	for _, p := range msg.Parts {
+		assert.NotEqual(t, types.ContentTypeThinking, p.Type, "reasoning must not be a content part")
+	}
+}
+
+// TestDuplexProviderStage_ReasoningDoesNotBleedAcrossTurns verifies the reasoning
+// accumulator resets per turn, so turn 2 carries no reasoning from turn 1.
+func TestDuplexProviderStage_ReasoningDoesNotBleedAcrossTurns(t *testing.T) {
+	s := NewDuplexProviderStage(providersmock.NewStreamingProvider("t", "m", false), baseConfig())
+	output := make(chan StreamElement, 16)
+	ctx := context.Background()
+	fr := "complete"
+
+	// Turn 1: reasoning + spoken + complete.
+	require.NoError(t, s.handleResponseChunk(ctx, &providers.StreamChunk{Reasoning: "turn one thoughts"}, output))
+	require.NoError(t, s.handleResponseChunk(ctx, &providers.StreamChunk{Delta: "One.", Metadata: map[string]interface{}{"type": "output_transcription"}}, output))
+	require.NoError(t, s.handleResponseChunk(ctx, &providers.StreamChunk{FinishReason: &fr}, output))
+	_ = drainAssistantMessage(output)
+
+	// Turn 2: spoken only, no reasoning.
+	require.NoError(t, s.handleResponseChunk(ctx, &providers.StreamChunk{Delta: "Two.", Metadata: map[string]interface{}{"type": "output_transcription"}}, output))
+	require.NoError(t, s.handleResponseChunk(ctx, &providers.StreamChunk{FinishReason: &fr}, output))
+	msg2 := drainAssistantMessage(output)
+
+	require.NotNil(t, msg2, "expected turn-2 assistant message")
+	assert.Nil(t, msg2.Reasoning, "turn 2 must not carry turn 1's reasoning")
+}
+
+// drainAssistantMessage returns the last assistant Message drained from output.
+func drainAssistantMessage(output chan StreamElement) *types.Message {
+	var msg *types.Message
+	for {
+		select {
+		case e := <-output:
+			if e.Message != nil && e.Message.Role == "assistant" {
+				msg = e.Message
+			}
+			continue
+		default:
+		}
+		break
+	}
+	return msg
+}
+
 // TestDuplexProviderStage_MaterializesUserTurnAtAssistantResponse verifies the
 // provider-agnostic fix: a buffered user transcript becomes a user Message when
 // the assistant starts responding, even without a transcription_final marker

--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -495,6 +495,11 @@ type claudeResponse struct {
 type claudeContent struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
+	// Signature accompanies a thinking block; Data carries a redacted_thinking
+	// payload. Both are opaque reasoning tokens captured for round-trip, never
+	// displayed. See extractReasoning.
+	Signature string `json:"signature,omitempty"`
+	Data      string `json:"data,omitempty"`
 }
 
 type claudeUsage struct {
@@ -753,21 +758,19 @@ func (p *Provider) parseAndValidateClaudeResponse(respBody []byte, predictResp p
 		return claudeResp, "", predictResp, fmt.Errorf("no content in response")
 	}
 
-	// Extract text and thinking content from response blocks
+	// Extract text content from response blocks; reasoning goes on Reasoning.
 	var responseText string
 	var parts []types.ContentPart
 	for _, content := range claudeResp.Content {
-		switch content.Type {
-		case "text":
+		if content.Type == "text" {
 			responseText = content.Text
 			parts = append(parts, types.NewTextPart(content.Text))
-		case types.ContentTypeThinking:
-			parts = append(parts, types.NewThinkingPart(content.Text))
 		}
 	}
 	if len(parts) > 0 {
 		predictResp.Parts = parts
 	}
+	predictResp.Reasoning = extractReasoning(claudeResp.Content)
 
 	if responseText == "" {
 		predictResp.Latency = time.Since(start)

--- a/runtime/providers/claude/claude_reasoning_test.go
+++ b/runtime/providers/claude/claude_reasoning_test.go
@@ -1,0 +1,44 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractReasoning_TextAndSignature(t *testing.T) {
+	content := []claudeContent{
+		{Type: types.ContentTypeThinking, Text: "let me reason", Signature: "sig"},
+		{Type: "text", Text: "the answer"},
+	}
+
+	rt := extractReasoning(content)
+	require.NotNil(t, rt, "expected a reasoning trace")
+	assert.Equal(t, "let me reason", rt.Text)
+	require.Len(t, rt.Opaque, 1)
+	assert.Equal(t, "claude", rt.Opaque[0].Provider)
+	assert.Equal(t, "thinking_signature", rt.Opaque[0].Kind)
+	assert.Equal(t, "sig", rt.Opaque[0].Data)
+
+	// Reasoning must NOT appear as a content part.
+	parts := extractContentParts(content)
+	require.Len(t, parts, 1, "only the text part should remain")
+	assert.Equal(t, types.ContentTypeText, parts[0].Type)
+}
+
+func TestExtractReasoning_RedactedThinking(t *testing.T) {
+	rt := extractReasoning([]claudeContent{{Type: "redacted_thinking", Data: "enc"}})
+	require.NotNil(t, rt)
+	assert.True(t, rt.Redacted)
+	require.Len(t, rt.Opaque, 1)
+	assert.Equal(t, "redacted_thinking", rt.Opaque[0].Kind)
+	assert.Equal(t, "enc", rt.Opaque[0].Data)
+}
+
+func TestExtractReasoning_None(t *testing.T) {
+	if extractReasoning([]claudeContent{{Type: "text", Text: "hi"}}) != nil {
+		t.Fatal("expected nil reasoning when none present")
+	}
+}

--- a/runtime/providers/claude/claude_test.go
+++ b/runtime/providers/claude/claude_test.go
@@ -720,23 +720,20 @@ func TestParseAndValidateClaudeResponse_ThinkingAndText(t *testing.T) {
 		t.Errorf("expected responseText %q, got %q", "Here is my answer.", responseText)
 	}
 
-	// Parts should contain both thinking and text
-	if len(result.Parts) != 2 {
-		t.Fatalf("expected 2 parts, got %d", len(result.Parts))
+	// Parts should contain only the text block; reasoning lives on Reasoning.
+	if len(result.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(result.Parts))
+	}
+	if result.Parts[0].Type != "text" {
+		t.Errorf("expected part type 'text', got %q", result.Parts[0].Type)
+	}
+	if result.Parts[0].Text == nil || *result.Parts[0].Text != "Here is my answer." {
+		t.Errorf("expected part text 'Here is my answer.', got %v", result.Parts[0].Text)
 	}
 
-	if result.Parts[0].Type != "thinking" {
-		t.Errorf("expected first part type 'thinking', got %q", result.Parts[0].Type)
-	}
-	if result.Parts[0].Text == nil || *result.Parts[0].Text != "Let me think about this..." {
-		t.Errorf("expected first part text 'Let me think about this...', got %v", result.Parts[0].Text)
-	}
-
-	if result.Parts[1].Type != "text" {
-		t.Errorf("expected second part type 'text', got %q", result.Parts[1].Type)
-	}
-	if result.Parts[1].Text == nil || *result.Parts[1].Text != "Here is my answer." {
-		t.Errorf("expected second part text 'Here is my answer.', got %v", result.Parts[1].Text)
+	// Thinking is captured on Message.Reasoning, not as a content part.
+	if result.Reasoning == nil || result.Reasoning.Text != "Let me think about this..." {
+		t.Errorf("expected reasoning text 'Let me think about this...', got %v", result.Reasoning)
 	}
 }
 

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -447,18 +447,47 @@ func extractTextContentFromResponse(content []claudeContent) string {
 }
 
 // extractContentParts converts Claude content blocks to typed ContentParts.
-// Returns text and thinking parts; tool_use blocks are handled separately.
+// Returns text parts only; reasoning is extracted separately via extractReasoning
+// (onto Message.Reasoning, off Parts), and tool_use blocks are handled separately.
 func extractContentParts(content []claudeContent) []types.ContentPart {
 	var parts []types.ContentPart
 	for _, c := range content {
-		switch c.Type {
-		case "text":
+		if c.Type == "text" {
 			parts = append(parts, types.NewTextPart(c.Text))
-		case types.ContentTypeThinking:
-			parts = append(parts, types.NewThinkingPart(c.Text))
 		}
 	}
 	return parts
+}
+
+// extractReasoning gathers Claude reasoning blocks into a ReasoningTrace: thinking
+// text (with its signature as an opaque round-trip token) and redacted_thinking
+// (opaque, marked Redacted). Returns nil when the response carries no reasoning.
+func extractReasoning(content []claudeContent) *types.ReasoningTrace {
+	const (
+		providerClaude   = "claude"
+		redactedThinking = "redacted_thinking"
+	)
+	var rt types.ReasoningTrace
+	for _, c := range content {
+		switch c.Type {
+		case types.ContentTypeThinking:
+			rt.Text += c.Text
+			if c.Signature != "" {
+				rt.Opaque = append(rt.Opaque, types.OpaqueReasoning{
+					Provider: providerClaude, Kind: "thinking_signature", Data: c.Signature,
+				})
+			}
+		case redactedThinking:
+			rt.Redacted = true
+			rt.Opaque = append(rt.Opaque, types.OpaqueReasoning{
+				Provider: providerClaude, Kind: redactedThinking, Data: c.Data,
+			})
+		}
+	}
+	if rt.Text == "" && len(rt.Opaque) == 0 {
+		return nil
+	}
+	return &rt
 }
 
 // parseToolCallsFromRawResponse extracts tool calls from raw JSON response
@@ -532,6 +561,7 @@ func (p *ToolProvider) parseToolResponse(
 
 	predictResp.Content = textContent
 	predictResp.Parts = extractContentParts(resp.Content)
+	predictResp.Reasoning = extractReasoning(resp.Content)
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBytes

--- a/runtime/providers/claude/claude_tools_test.go
+++ b/runtime/providers/claude/claude_tools_test.go
@@ -1009,21 +1009,18 @@ func TestExtractContentParts(t *testing.T) {
 			{Type: "thinking", Text: "reasoning here"},
 			{Type: "text", Text: "final answer"},
 		}
+		// Reasoning is no longer a content part — only the text part remains.
 		parts := extractContentParts(content)
-		if len(parts) != 2 {
-			t.Fatalf("expected 2 parts, got %d", len(parts))
+		if len(parts) != 1 {
+			t.Fatalf("expected 1 part, got %d", len(parts))
 		}
-		if parts[0].Type != "thinking" {
-			t.Errorf("expected first part type 'thinking', got %q", parts[0].Type)
+		if parts[0].Type != "text" || parts[0].Text == nil || *parts[0].Text != "final answer" {
+			t.Errorf("expected text part 'final answer', got %+v", parts[0])
 		}
-		if parts[0].Text == nil || *parts[0].Text != "reasoning here" {
-			t.Errorf("expected first part text 'reasoning here', got %v", parts[0].Text)
-		}
-		if parts[1].Type != "text" {
-			t.Errorf("expected second part type 'text', got %q", parts[1].Type)
-		}
-		if parts[1].Text == nil || *parts[1].Text != "final answer" {
-			t.Errorf("expected second part text 'final answer', got %v", parts[1].Text)
+		// Thinking is captured on the reasoning trace instead.
+		rt := extractReasoning(content)
+		if rt == nil || rt.Text != "reasoning here" {
+			t.Errorf("expected reasoning 'reasoning here', got %v", rt)
 		}
 	})
 
@@ -1070,12 +1067,14 @@ func TestExtractContentParts(t *testing.T) {
 		content := []claudeContent{
 			{Type: "thinking", Text: "deep thoughts"},
 		}
+		// Thinking is no longer a content part; it surfaces on the reasoning trace.
 		parts := extractContentParts(content)
-		if len(parts) != 1 {
-			t.Fatalf("expected 1 part, got %d", len(parts))
+		if len(parts) != 0 {
+			t.Fatalf("expected 0 content parts (reasoning is not content), got %d", len(parts))
 		}
-		if parts[0].Type != "thinking" || parts[0].Text == nil || *parts[0].Text != "deep thoughts" {
-			t.Errorf("unexpected part: %+v", parts[0])
+		rt := extractReasoning(content)
+		if rt == nil || rt.Text != "deep thoughts" {
+			t.Errorf("expected reasoning 'deep thoughts', got %v", rt)
 		}
 	})
 }

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -183,10 +183,42 @@ type geminiPart struct {
 	Text         string              `json:"text,omitempty"`
 	InlineData   *geminiInlineData   `json:"inlineData,omitempty"`
 	FunctionCall *geminiPartFuncCall `json:"functionCall,omitempty"`
+	// Thought marks this text part as the model's reasoning (thinking models).
+	// Such text is routed to Message.Reasoning, never spoken/visible content.
+	Thought bool `json:"thought,omitempty"`
 	// ThoughtSignature is Gemini 3's opaque signature that accompanies a
 	// functionCall part. It must be replayed verbatim on subsequent turns
 	// or Gemini 3 rejects the request. See gemini_tools.go for round-trip.
 	ThoughtSignature string `json:"thoughtSignature,omitempty"`
+}
+
+// Reasoning normalization constants (shared by the generate + streaming paths).
+const (
+	providerNameGemini   = "gemini"
+	kindThoughtSignature = "thought_signature"
+)
+
+// reasoningFromParts builds a ReasoningTrace from a candidate's thought parts:
+// thought text plus any signature as an opaque round-trip token. Returns nil
+// when there is no reasoning. Non-thought parts (incl. signed functionCall
+// parts) are ignored here — their signatures round-trip via gemini_tools.go.
+func reasoningFromParts(parts []geminiPart) *types.ReasoningTrace {
+	var rt types.ReasoningTrace
+	for _, p := range parts {
+		if !p.Thought {
+			continue
+		}
+		rt.Text += p.Text
+		if p.ThoughtSignature != "" {
+			rt.Opaque = append(rt.Opaque, types.OpaqueReasoning{
+				Provider: providerNameGemini, Kind: kindThoughtSignature, Data: p.ThoughtSignature,
+			})
+		}
+	}
+	if rt.Text == "" && len(rt.Opaque) == 0 {
+		return nil
+	}
+	return &rt
 }
 
 // geminiPartFuncCall represents a function call in a streaming response part
@@ -647,6 +679,10 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 	var textContent strings.Builder
 
 	for _, part := range candidate.Content.Parts {
+		// Reasoning ("thought") parts go to Message.Reasoning, not content.
+		if part.Thought {
+			continue
+		}
 		if part.Text != "" {
 			// Check if text contains markdown images and split accordingly
 			textParts := processTextPartForImages(part.Text)
@@ -677,6 +713,7 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 
 	predictResp.Content = textContent.String()
 	predictResp.Parts = contentParts
+	predictResp.Reasoning = reasoningFromParts(candidate.Content.Parts)
 	predictResp.CostInfo = &costBreakdown
 	predictResp.Latency = latency
 	predictResp.Raw = respBody

--- a/runtime/providers/gemini/gemini_reasoning_test.go
+++ b/runtime/providers/gemini/gemini_reasoning_test.go
@@ -1,0 +1,33 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReasoningFromParts_ThoughtAndSignature(t *testing.T) {
+	parts := []geminiPart{
+		{Text: "let me think", Thought: true, ThoughtSignature: "sig"},
+		{Text: "the answer"},
+	}
+	rt := reasoningFromParts(parts)
+	require.NotNil(t, rt)
+	assert.Equal(t, "let me think", rt.Text)
+	require.Len(t, rt.Opaque, 1)
+	assert.Equal(t, "gemini", rt.Opaque[0].Provider)
+	assert.Equal(t, "thought_signature", rt.Opaque[0].Kind)
+	assert.Equal(t, "sig", rt.Opaque[0].Data)
+}
+
+func TestReasoningFromParts_None(t *testing.T) {
+	// Plain text and a signed functionCall part carry no *thought* text → nil.
+	parts := []geminiPart{
+		{Text: "hello"},
+		{FunctionCall: &geminiPartFuncCall{Name: "f"}, ThoughtSignature: "sig"},
+	}
+	if reasoningFromParts(parts) != nil {
+		t.Fatal("expected nil reasoning when no thought parts")
+	}
+}

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -95,6 +95,20 @@ func (p *Provider) processGeminiStreamChunk(
 	// Process all parts in the candidate (a no-op when Parts is empty — an
 	// empty-parts chunk may still carry a terminal finishReason, handled below).
 	for i, part := range candidate.Content.Parts {
+		// Reasoning ("thought") parts stream on Reasoning, not content.
+		if part.Thought {
+			if part.Text != "" || part.ThoughtSignature != "" {
+				rc := providers.StreamChunk{Reasoning: part.Text}
+				if part.ThoughtSignature != "" {
+					rc.OpaqueReasoning = []types.OpaqueReasoning{{
+						Provider: providerNameGemini, Kind: kindThoughtSignature, Data: part.ThoughtSignature,
+					}}
+				}
+				outChan <- rc
+			}
+			continue
+		}
+
 		// Handle text content
 		if part.Text != "" {
 			sb.WriteString(part.Text)

--- a/runtime/providers/gemini/stream_session_protocol_integration.go
+++ b/runtime/providers/gemini/stream_session_protocol_integration.go
@@ -339,8 +339,15 @@ func (s *StreamSession) processModelTurn(turn *ModelTurn, turnComplete bool, cos
 	// Extract text and audio from parts
 	for _, part := range turn.Parts {
 		if part.Text != "" {
-			response.Content += part.Text
-			response.Delta = part.Text
+			if part.Thought {
+				// Reasoning, not spoken output — surface separately so it doesn't
+				// leak into the transcript (the spoken text arrives via
+				// outputTranscription).
+				response.Reasoning += part.Text
+			} else {
+				response.Content += part.Text
+				response.Delta = part.Text
+			}
 		}
 
 		// Handle audio/media data. While the pump is dropping (post-barge-in,

--- a/runtime/providers/gemini/stream_session_test.go
+++ b/runtime/providers/gemini/stream_session_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/gorilla/websocket"
 )
@@ -970,6 +971,27 @@ func TestTruncateInlineData(t *testing.T) {
 		if !strings.Contains(elemData, "bytes") {
 			t.Error("Expected array element data to be truncated")
 		}
+	}
+}
+
+// TestProcessModelTurn_ThoughtRoutedToReasoning verifies a thought:true text part
+// is surfaced as StreamChunk.Reasoning (not spoken Content), while a normal text
+// part stays in Content — so reasoning doesn't leak into the transcript.
+func TestProcessModelTurn_ThoughtRoutedToReasoning(t *testing.T) {
+	s := &StreamSession{ctx: context.Background(), emitCh: make(chan providers.StreamChunk, 4)}
+	turn := &ModelTurn{Parts: []Part{
+		{Text: "Let me reason about this.", Thought: true},
+		{Text: "Spoken answer.", Thought: false},
+	}}
+	if err := s.processModelTurn(turn, false, nil); err != nil {
+		t.Fatalf("processModelTurn: %v", err)
+	}
+	chunk := <-s.emitCh
+	if chunk.Reasoning != "Let me reason about this." {
+		t.Errorf("Reasoning = %q, want the thought text", chunk.Reasoning)
+	}
+	if chunk.Content != "Spoken answer." {
+		t.Errorf("Content = %q, want spoken text only (no thought)", chunk.Content)
 	}
 }
 

--- a/runtime/providers/gemini/stream_session_types_integration.go
+++ b/runtime/providers/gemini/stream_session_types_integration.go
@@ -56,6 +56,9 @@ type ModelTurn struct {
 type Part struct {
 	Text       string      `json:"text,omitempty"`
 	InlineData *InlineData `json:"inlineData,omitempty"` // camelCase!
+	// Thought marks this text part as the model's reasoning (Gemini native-audio
+	// thinking models). Reasoning is surfaced separately, not as spoken text.
+	Thought bool `json:"thought,omitempty"`
 }
 
 // InlineData represents inline media data

--- a/runtime/providers/provider.go
+++ b/runtime/providers/provider.go
@@ -116,6 +116,10 @@ type PredictionResponse struct {
 	Raw        []byte                  `json:"raw,omitempty"`
 	RawRequest any                     `json:"raw_request,omitempty"` // Raw API request (for debugging)
 	ToolCalls  []types.MessageToolCall `json:"tool_calls,omitempty"`  // Tools called in this response
+	// Reasoning holds the model's reasoning/"thinking" for this response, carried
+	// onto Message.Reasoning (off Parts) so it is excluded from content/exports/
+	// future context by construction. Nil when the model reported none.
+	Reasoning *types.ReasoningTrace `json:"reasoning,omitempty"`
 	// FinishReason is the canonical (normalized) reason the model stopped,
 	// or "" if the provider did not report one. See runtime/types FinishReason* constants.
 	FinishReason string `json:"finish_reason,omitempty"`

--- a/runtime/providers/streaming.go
+++ b/runtime/providers/streaming.go
@@ -60,6 +60,11 @@ type StreamChunk struct {
 	// must not be appended to the content stream.
 	Reasoning string `json:"reasoning,omitempty"`
 
+	// OpaqueReasoning carries provider round-trip reasoning tokens (signatures /
+	// encrypted blocks) for this chunk. Never displayed, never content; preserved
+	// so a provider can feed it back where required (intra-turn).
+	OpaqueReasoning []types.OpaqueReasoning `json:"opaque_reasoning,omitempty"`
+
 	// MediaData contains raw streaming media bytes (audio, video, images).
 	// Data is always raw bytes, never base64. Providers decode at source.
 	MediaData *StreamMediaData `json:"-"`

--- a/runtime/statestore/memory.go
+++ b/runtime/statestore/memory.go
@@ -1175,6 +1175,14 @@ func cloneMessage(msg *types.Message) types.Message {
 			cp.Validations[i] = cloneValidationResult(&msg.Validations[i])
 		}
 	}
+	if msg.Reasoning != nil {
+		r := *msg.Reasoning
+		if len(msg.Reasoning.Opaque) > 0 {
+			r.Opaque = make([]types.OpaqueReasoning, len(msg.Reasoning.Opaque))
+			copy(r.Opaque, msg.Reasoning.Opaque)
+		}
+		cp.Reasoning = &r
+	}
 	return cp
 }
 

--- a/runtime/types/content.go
+++ b/runtime/types/content.go
@@ -93,11 +93,37 @@ func NewTextPart(text string) ContentPart {
 
 // NewThinkingPart creates a ContentPart with thinking/reasoning content.
 // Thinking parts are stored alongside text parts but excluded from GetContent().
+//
+// Deprecated: reasoning now lives on Message.Reasoning (a ReasoningTrace), off
+// Parts, so it is structurally excluded from content/exports/future context.
+// New code should populate Message.Reasoning, not a thinking ContentPart.
 func NewThinkingPart(text string) ContentPart {
 	return ContentPart{
 		Type: ContentTypeThinking,
 		Text: &text,
 	}
+}
+
+// ReasoningTrace holds a model's reasoning/"thinking" for one assistant turn.
+// It is a sibling of content (NOT a ContentPart), so GetContent()/Parts-based
+// consumers — external conversation stores, exports, the events bus — exclude it
+// by default. Text is human-readable (display/record only); Opaque holds provider
+// round-trip tokens that may be fed back where a provider requires, never shown.
+type ReasoningTrace struct {
+	Text     string            `json:"text,omitempty"`
+	Opaque   []OpaqueReasoning `json:"opaque,omitempty"`
+	Redacted bool              `json:"redacted,omitempty"`
+}
+
+// OpaqueReasoning is a provider-native reasoning token (signature / encrypted
+// block) preserved for intra-turn round-trip. Never displayed, never content.
+// Kind values: thinking_signature, redacted_thinking, thought_signature,
+// encrypted_reasoning (provider-specific).
+type OpaqueReasoning struct {
+	Provider string `json:"provider"`      // claude | openai | gemini
+	Kind     string `json:"kind"`          // see Kind values above
+	Data     string `json:"data"`          // opaque payload
+	Ref      string `json:"ref,omitempty"` // optional association (e.g. tool-call id)
 }
 
 // NewImagePart creates a ContentPart with image content from a file path

--- a/runtime/types/message.go
+++ b/runtime/types/message.go
@@ -38,6 +38,10 @@ type Message struct {
 	FinishReason string                 `json:"finish_reason,omitempty"`
 	Meta         map[string]interface{} `json:"meta,omitempty"` // Custom metadata
 
+	// Reasoning holds the turn's model reasoning, off Parts so it is not content
+	// and is excluded from future-turn context by default. See ReasoningTrace.
+	Reasoning *ReasoningTrace `json:"reasoning,omitempty"`
+
 	// Validation results (for assistant messages)
 	Validations []ValidationResult `json:"validations,omitempty"`
 }
@@ -249,6 +253,18 @@ func (m *Message) GetContent() string {
 	}
 
 	return m.Content
+}
+
+// StripReasoning returns copies of msgs with Reasoning cleared, for persistence
+// or export paths that must not retain model reasoning (the default behavior;
+// see Message.Reasoning). The input slice and its messages are not mutated.
+func StripReasoning(msgs []Message) []Message {
+	out := make([]Message, len(msgs))
+	copy(out, msgs)
+	for i := range out {
+		out[i].Reasoning = nil
+	}
+	return out
 }
 
 // IsMultimodal returns true if the message contains multimodal content (Parts)

--- a/runtime/types/reasoning_test.go
+++ b/runtime/types/reasoning_test.go
@@ -1,0 +1,49 @@
+package types
+
+import "testing"
+
+func TestMessageReasoning_ExcludedFromContent(t *testing.T) {
+	txt := "the spoken answer"
+	m := Message{
+		Role:  "assistant",
+		Parts: []ContentPart{{Type: ContentTypeText, Text: &txt}},
+		Reasoning: &ReasoningTrace{
+			Text:   "internal chain of thought",
+			Opaque: []OpaqueReasoning{{Provider: "claude", Kind: "thinking_signature", Data: "abc"}},
+		},
+	}
+	if got := m.GetContent(); got != "the spoken answer" {
+		t.Fatalf("GetContent() = %q, reasoning must not appear in content", got)
+	}
+}
+
+func TestReasoningTrace_ZeroValueIsEmpty(t *testing.T) {
+	var rt ReasoningTrace
+	if rt.Text != "" || len(rt.Opaque) != 0 || rt.Redacted {
+		t.Fatal("zero ReasoningTrace should be empty")
+	}
+}
+
+// TestReasoning_NotInContentProjection pins the structural guarantee: a
+// reasoning-only message projects no content and is not multimodal, so any
+// content/Parts-based consumer (stores, exports, request builders) excludes it.
+func TestReasoning_NotInContentProjection(t *testing.T) {
+	m := Message{Role: "assistant", Reasoning: &ReasoningTrace{Text: "secret reasoning"}}
+	if m.GetContent() != "" {
+		t.Fatal("a reasoning-only message must project empty content")
+	}
+	if m.IsMultimodal() {
+		t.Fatal("reasoning must not make a message multimodal (it is not a Part)")
+	}
+}
+
+func TestStripReasoning(t *testing.T) {
+	in := []Message{{Role: "assistant", Content: "hi", Reasoning: &ReasoningTrace{Text: "thoughts"}}}
+	out := StripReasoning(in)
+	if out[0].Reasoning != nil {
+		t.Fatal("StripReasoning must clear Reasoning")
+	}
+	if in[0].Reasoning == nil {
+		t.Fatal("StripReasoning must not mutate the input")
+	}
+}


### PR DESCRIPTION
## What

The backend of the unified reasoning architecture (#1527, Plans 1 + 2 of 3). Reasoning/"thinking" is now captured into one canonical place across every provider and modality — display (Plan 3) is a separate follow-up.

Closes #1525

## Architecture

Reasoning is a typed **sibling of content** (`types.ReasoningTrace` on `Message.Reasoning`, off `Parts`), so it's excluded from content/exports/future context **by construction**. Streaming carries it on `StreamChunk.Reasoning`/`OpaqueReasoning` and a non-content `StreamElement.Reasoning`; both pipeline paths accumulate it and stream it live. Persistence is gated by `PersistReasoning` (default off).

## Coverage

- **Foundation:** `ReasoningTrace`/`OpaqueReasoning`, `Message.Reasoning`, `StripReasoning`, transport fields, shared duplex accumulator, regular streaming-stage accumulator, persistence flag.
- **Providers:** Claude (non-streaming + tools), OpenAI (streaming `reasoning_content`), Gemini (realtime + generate, streaming + non-streaming). Thought text → `Reasoning.Text`; signatures/encrypted/redacted → opaque round-trip tokens (never displayed).

## Testing

Unit tests per layer/provider, **plus end-to-end integration tests through the real pipeline + store** — which caught a real bug: the memory store's `cloneMessage` silently dropped `Message.Reasoning` (fixed here). Tests cover: provider→`Message.Reasoning` mapping + content exclusion + non-re-entry into context; persistence strip-by-default / keep-when-enabled. All `-race`; pre-commit gates passed on every commit.

## Known gaps (follow-ups)

- **Plan 3 (display):** TUI live+collapse rendering + HTML/JSON report reasoning sections — not started.
- A duplex `Process`-loop reasoning test needs mock stream-chunk injection (the duplex accumulator is unit-tested via `handleResponseChunk`).
- `stages_duplex_provider_integration.go` is coverage-gate-exempt by its `_integration` suffix; the structural fix is splitting its pure logic into a gated file (follow-up).
