### PR TITLE
feat(reasoning): display reasoning in turn history + reports (Plan 3, partial) (#1527)

### DIFF
--- a/tools/arena/render/html.go
+++ b/tools/arena/render/html.go
@@ -1083,10 +1083,22 @@ func getMessageFromStruct(result interface{}) string {
 	return ""
 }
 
-// renderMessageContent renders a message with multimodal media support.
+// renderMessageContent renders a message with multimodal media support, plus a
+// collapsible reasoning section when the message carries model reasoning.
 // This is a bridge function for template use.
 func renderMessageContent(msg types.Message) template.HTML {
-	return template.HTML(renderMessageWithMedia(msg))
+	out := renderMessageWithMedia(msg)
+	if msg.Reasoning != nil && msg.Reasoning.Text != "" {
+		out += renderReasoningHTML(msg.Reasoning.Text)
+	}
+	return template.HTML(out) //nolint:gosec // reasoning text is HTML-escaped below
+}
+
+// renderReasoningHTML renders model reasoning as a collapsed <details> section.
+// The text is HTML-escaped; opaque round-trip tokens are never rendered.
+func renderReasoningHTML(text string) string {
+	return `<details class="reasoning"><summary>💭 Reasoning</summary><pre>` +
+		template.HTMLEscapeString(text) + `</pre></details>`
 }
 
 // formatBytesHTML formats a byte count as a human-readable string.

--- a/tools/arena/render/html_reasoning_test.go
+++ b/tools/arena/render/html_reasoning_test.go
@@ -1,0 +1,36 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderMessageContent_IncludesReasoning(t *testing.T) {
+	msg := types.Message{
+		Role:      "assistant",
+		Content:   "the answer",
+		Reasoning: &types.ReasoningTrace{Text: "the chain of thought"},
+	}
+	out := string(renderMessageContent(msg))
+	assert.Contains(t, out, "the answer", "spoken content present")
+	assert.Contains(t, out, "Reasoning", "reasoning section present")
+	assert.Contains(t, out, "the chain of thought")
+	assert.Contains(t, out, "<details", "reasoning rendered as a collapsible section")
+}
+
+func TestRenderMessageContent_EscapesReasoning(t *testing.T) {
+	msg := types.Message{
+		Role:      "assistant",
+		Reasoning: &types.ReasoningTrace{Text: "<script>alert(1)</script>"},
+	}
+	out := string(renderMessageContent(msg))
+	assert.NotContains(t, out, "<script>", "reasoning text must be HTML-escaped")
+}
+
+func TestRenderMessageContent_NoReasoning(t *testing.T) {
+	out := string(renderMessageContent(types.Message{Role: "assistant", Content: "x"}))
+	assert.False(t, strings.Contains(out, "💭 Reasoning"), "no reasoning section when absent")
+}

--- a/tools/arena/results/json/json_repository_test.go
+++ b/tools/arena/results/json/json_repository_test.go
@@ -505,3 +505,36 @@ func TestJSONResultRepository_IntegrationTest(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, resultFiles, len(originalResults))
 }
+
+// TestJSONResultRepository_SerializesReasoning locks the JSON report including
+// Message.Reasoning so reasoning is reviewable in the durable artifact.
+func TestJSONResultRepository_SerializesReasoning(t *testing.T) {
+	tmpDir := t.TempDir()
+	repo := jsonrepo.NewJSONResultRepository(tmpDir)
+
+	result := &engine.RunResult{
+		RunID:      "run-reason",
+		ScenarioID: "scenario-r",
+		ProviderID: "test",
+		Messages: []types.Message{
+			{Role: "user", Content: "q"},
+			{Role: "assistant", Content: "answer", Reasoning: &types.ReasoningTrace{Text: "chain of thought"}},
+		},
+	}
+	require.NoError(t, repo.SaveResult(result))
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "run-reason.json"))
+	require.NoError(t, err)
+
+	var saved engine.RunResult
+	require.NoError(t, json.Unmarshal(data, &saved))
+	var asst *types.Message
+	for i := range saved.Messages {
+		if saved.Messages[i].Role == "assistant" {
+			asst = &saved.Messages[i]
+		}
+	}
+	require.NotNil(t, asst)
+	require.NotNil(t, asst.Reasoning, "JSON report must serialize Message.Reasoning")
+	assert.Equal(t, "chain of thought", asst.Reasoning.Text)
+}

--- a/tools/arena/tui/panels/conversation.go
+++ b/tools/arena/tui/panels/conversation.go
@@ -460,6 +460,7 @@ func (c *ConversationPanel) buildDetailLines(res *statestore.RunResult, msg *typ
 	c.appendToolCallsMarkdown(&md, msg)
 	c.appendToolResultMarkdown(&md, msg)
 	c.appendContentMarkdown(&md, msg)
+	c.appendReasoningMarkdown(&md, msg)
 	c.appendValidationsMarkdown(&md, msg)
 
 	// Render the markdown content

--- a/tools/arena/tui/panels/conversation_render.go
+++ b/tools/arena/tui/panels/conversation_render.go
@@ -343,6 +343,18 @@ func (c *ConversationPanel) appendContentMarkdown(md *strings.Builder, msg *type
 	md.WriteString("\n\n")
 }
 
+// appendReasoningMarkdown renders the message's model reasoning ("thinking") in
+// its own section, distinct from the spoken/visible content. Opaque round-trip
+// tokens are never shown. No-op when the message carries no reasoning text.
+func (c *ConversationPanel) appendReasoningMarkdown(md *strings.Builder, msg *types.Message) {
+	if msg.Reasoning == nil || msg.Reasoning.Text == "" {
+		return
+	}
+	md.WriteString("## 💭 Reasoning\n\n")
+	md.WriteString(msg.Reasoning.Text)
+	md.WriteString("\n\n")
+}
+
 func (c *ConversationPanel) appendValidationsMarkdown(md *strings.Builder, msg *types.Message) {
 	if len(msg.Validations) == 0 {
 		return

--- a/tools/arena/tui/panels/conversation_test.go
+++ b/tools/arena/tui/panels/conversation_test.go
@@ -572,6 +572,32 @@ func TestConversationPanel_AppendContentMarkdown_Empty(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+func TestConversationPanel_AppendReasoningMarkdown(t *testing.T) {
+	panel := NewConversationPanel()
+	var md strings.Builder
+
+	msg := &types.Message{
+		Role:      "assistant",
+		Content:   "the answer",
+		Reasoning: &types.ReasoningTrace{Text: "the model's chain of thought"},
+	}
+
+	panel.appendReasoningMarkdown(&md, msg)
+
+	result := md.String()
+	assert.Contains(t, result, "Reasoning")
+	assert.Contains(t, result, "the model's chain of thought")
+}
+
+func TestConversationPanel_AppendReasoningMarkdown_None(t *testing.T) {
+	panel := NewConversationPanel()
+	var md strings.Builder
+
+	panel.appendReasoningMarkdown(&md, &types.Message{Role: "assistant", Content: "x"})
+
+	assert.Empty(t, md.String())
+}
+
 func TestConversationPanel_AppendValidationsMarkdown(t *testing.T) {
 	panel := NewConversationPanel()
 	var md strings.Builder


### PR DESCRIPTION
## What

Plan 3 (display) of the unified reasoning epic (#1527) — surfaces `Message.Reasoning` in turn history and reports. Backend (Plans 1+2) shipped in #1528.

Refs #1527

## Surfaces (all tested)

- **TUI turn history** — `Message.Reasoning` renders as a `💭 Reasoning` section in the conversation detail view (`appendReasoningMarkdown`), distinct from spoken content; opaque round-trip tokens never shown.
- **HTML report** — collapsible `<details>` reasoning section per assistant turn, HTML-escaped.
- **JSON report** — reasoning serialized in the durable artifact (the full `RunResult.Messages` marshal already carries it via the `reasoning` json tag; locked by test).

Report `RunResult.Messages` is the live in-memory conversation (not store-reloaded), so reasoning is present at render time independent of the `PersistReasoning` persistence flag.

## Remaining (separate follow-up under #1527)

- **TUI live streaming** ("watch it think, then collapse"): a multi-layer events-bus effort — a non-content reasoning event type + emitter + `event_adapter` handling + live-panel render (where the design's "emit reasoning on a distinct non-content signal" lives). Only affects interactive sessions; batch runs use the reports above.
- Plus the carried-over backend follow-ups: duplex `Process`-loop reasoning test (needs mock stream-chunk injection); split `stages_duplex_provider_integration.go` so its logic is coverage-gated.
