### PR TITLE
feat(reasoning): live-stream reasoning into the TUI (Plan 3 complete) (#1527)

### DIFF
--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -399,6 +399,12 @@ func (e *Emitter) StreamInterrupted(reason string) {
 	})
 }
 
+// ReasoningDelta emits the reasoning.delta event — an incremental chunk of model
+// reasoning ("thinking") for live display. Not conversational content.
+func (e *Emitter) ReasoningDelta(text string) {
+	e.emit(EventReasoningDelta, &ReasoningDeltaData{Text: text})
+}
+
 // EmitCustom allows middleware to emit arbitrary event types with structured payloads.
 func (e *Emitter) EmitCustom(
 	eventType EventType,

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -1477,3 +1477,31 @@ func TestEmitter_TemplateMethods(t *testing.T) {
 		t.Fatal("timed out waiting for prompt.template.failed")
 	}
 }
+
+func TestEmitter_ReasoningDelta(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	emitter := NewEmitter(bus, "run-r", "session-r", "conv-r")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+	bus.Subscribe(EventReasoningDelta, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	emitter.ReasoningDelta("thinking...")
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for reasoning.delta event")
+	}
+	data, ok := got.Data.(*ReasoningDeltaData)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", got.Data)
+	}
+	if data.Text != "thinking..." {
+		t.Fatalf("Text = %q, want %q", data.Text, "thinking...")
+	}
+}

--- a/runtime/events/store.go
+++ b/runtime/events/store.go
@@ -200,6 +200,7 @@ var eventDataRegistry = map[string]eventDataFactory{
 	"*events.StateLoadedData":         func() EventData { return &StateEventData{} },
 	"*events.StateSavedData":          func() EventData { return &StateEventData{} },
 	"*events.StreamInterruptedData":   func() EventData { return &StreamInterruptedData{} },
+	"*events.ReasoningDeltaData":      func() EventData { return &ReasoningDeltaData{} },
 
 	// Workflow events
 	"*events.WorkflowTransitionedData":      func() EventData { return &WorkflowTransitionedData{} },

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -67,6 +67,12 @@ const (
 	// EventStreamInterrupted marks a stream interruption.
 	EventStreamInterrupted EventType = "stream.interrupted"
 
+	// EventReasoningDelta carries an incremental chunk of model reasoning
+	// ("thinking") for live display. It is explicitly NOT conversational content
+	// — subscribers (incl. external conversation stores) must not treat it as a
+	// user/assistant message.
+	EventReasoningDelta EventType = "reasoning.delta"
+
 	// EventMessageCreated marks message creation.
 	EventMessageCreated EventType = "message.created"
 	// EventMessageUpdated marks message update (e.g., cost/latency after completion).
@@ -370,6 +376,13 @@ type (
 type StreamInterruptedData struct {
 	baseEventData
 	Reason string
+}
+
+// ReasoningDeltaData carries an incremental chunk of model reasoning for live
+// display. Not conversational content — never persisted as a message.
+type ReasoningDeltaData struct {
+	baseEventData
+	Text string
 }
 
 // CustomEventData allows middleware to emit arbitrary structured events.

--- a/runtime/pipeline/stage/stages_duplex_provider_integration.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_integration.go
@@ -1048,6 +1048,9 @@ func (s *DuplexProviderStage) handleResponseChunk(
 	if chunk.Reasoning != "" || len(chunk.OpaqueReasoning) > 0 {
 		s.accumulatedReasoning.WriteString(chunk.Reasoning)
 		s.accumulatedOpaqueReasoning = append(s.accumulatedOpaqueReasoning, chunk.OpaqueReasoning...)
+		if s.emitter != nil && chunk.Reasoning != "" {
+			s.emitter.ReasoningDelta(chunk.Reasoning)
+		}
 		select {
 		case output <- StreamElement{Reasoning: &ReasoningDelta{Text: chunk.Reasoning, Opaque: chunk.OpaqueReasoning}}:
 		case <-ctx.Done():

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1521,8 +1521,12 @@ func (s *ProviderStage) emitChunkElement(
 	output chan<- StreamElement,
 ) error {
 	// Emit a live, non-content reasoning element if present, so the UI can stream
-	// thinking as it arrives (it also accumulates onto Message.Reasoning).
+	// thinking as it arrives (it also accumulates onto Message.Reasoning). Mirror
+	// onto the events bus as a distinct non-content signal for live consumers.
 	if chunk.Reasoning != "" || len(chunk.OpaqueReasoning) > 0 {
+		if s.emitter != nil && chunk.Reasoning != "" {
+			s.emitter.ReasoningDelta(chunk.Reasoning)
+		}
 		select {
 		case output <- StreamElement{Reasoning: &ReasoningDelta{Text: chunk.Reasoning, Opaque: chunk.OpaqueReasoning}}:
 		case <-ctx.Done():

--- a/tools/arena/tui/app/livefeed.go
+++ b/tools/arena/tui/app/livefeed.go
@@ -50,10 +50,16 @@ func (f *liveFeed) Apply(panel *panels.ConversationPanel, msg tea.Msg) bool {
 			})
 		}
 		return true
+	case tui.ReasoningDeltaMsg:
+		// Non-content live thinking — accumulate transiently for this turn.
+		panel.AppendLiveReasoning(m.Text)
+		return true
 	case tui.MessageCreatedMsg:
 		if m.ConversationID != f.convID {
 			return false
 		}
+		// The turn's message arrived — clear the transient thinking display.
+		panel.ClearLiveReasoning()
 		f.appendCreated(panel, &m)
 		return true
 	case tui.MessageUpdatedMsg:

--- a/tools/arena/tui/app/livefeed_test.go
+++ b/tools/arena/tui/app/livefeed_test.go
@@ -80,3 +80,20 @@ func TestLiveFeed_AudioSystemPromptAndMetadata(t *testing.T) {
 	// Unknown message types are not consumed.
 	require.False(t, f.Apply(panel, struct{}{}))
 }
+
+// TestLiveFeed_ReasoningStreamsThenClears covers the live reasoning path:
+// ReasoningDeltaMsg accumulates transient thinking; the turn's message clears it.
+func TestLiveFeed_ReasoningStreamsThenClears(t *testing.T) {
+	panel := seededPanel(t, "conv-1", 1)
+	f := newLiveFeed("conv-1", 1)
+
+	require.True(t, f.Apply(panel, tui.ReasoningDeltaMsg{Text: "thinking "}))
+	require.True(t, f.Apply(panel, tui.ReasoningDeltaMsg{Text: "hard"}))
+	require.Equal(t, "thinking hard", panel.LiveReasoning())
+
+	// The turn's message arriving clears the transient reasoning.
+	require.True(t, f.Apply(panel, tui.MessageCreatedMsg{
+		ConversationID: "conv-1", Index: 1, Role: "assistant", Content: "answer",
+	}))
+	require.Empty(t, panel.LiveReasoning(), "reasoning cleared when the turn message arrives")
+}

--- a/tools/arena/tui/event_adapter.go
+++ b/tools/arena/tui/event_adapter.go
@@ -106,6 +106,11 @@ func (a *EventAdapter) mapEvent(event *events.Event) tea.Msg { //nolint:gocyclo 
 		return a.handleStateSaved(event)
 	case events.EventStreamInterrupted:
 		return a.logf("ERROR", event, "Stream interrupted: %s", readString(event.Data, "reason"))
+	case events.EventReasoningDelta:
+		if d, ok := event.Data.(*events.ReasoningDeltaData); ok && d != nil {
+			return ReasoningDeltaMsg{Text: d.Text}
+		}
+		return nil
 	case events.EventMessageCreated:
 		return a.handleMessageCreated(event)
 	case events.EventMessageUpdated:

--- a/tools/arena/tui/event_adapter_test.go
+++ b/tools/arena/tui/event_adapter_test.go
@@ -910,3 +910,22 @@ func TestEventAdapter_HandleEvent_NewEventTypes(t *testing.T) {
 		adapter.HandleEvent(evt)
 	})
 }
+
+// TestEventAdapter_ReasoningDelta verifies the events-bus reasoning signal maps
+// to a non-content ReasoningDeltaMsg for live display.
+func TestEventAdapter_ReasoningDelta(t *testing.T) {
+	t.Parallel()
+	adapter := NewEventAdapter(nil)
+	msg := adapter.mapEvent(&events.Event{
+		Type:      events.EventReasoningDelta,
+		Timestamp: time.Now(),
+		Data:      &events.ReasoningDeltaData{Text: "thinking out loud"},
+	})
+	rd, ok := msg.(ReasoningDeltaMsg)
+	if !ok {
+		t.Fatalf("expected ReasoningDeltaMsg, got %T", msg)
+	}
+	if rd.Text != "thinking out loud" {
+		t.Fatalf("Text = %q, want %q", rd.Text, "thinking out loud")
+	}
+}

--- a/tools/arena/tui/messages.go
+++ b/tools/arena/tui/messages.go
@@ -77,6 +77,12 @@ type MessageUpdatedMsg struct {
 	Time           time.Time
 }
 
+// ReasoningDeltaMsg is sent when the model emits an incremental chunk of
+// reasoning ("thinking") for live display. It is NOT conversational content.
+type ReasoningDeltaMsg struct {
+	Text string
+}
+
 // ConversationStartedMsg is sent when a new conversation starts with its system prompt.
 type ConversationStartedMsg struct {
 	ConversationID string

--- a/tools/arena/tui/panels/conversation.go
+++ b/tools/arena/tui/panels/conversation.go
@@ -92,6 +92,28 @@ type ConversationPanel struct {
 	audioUserLevel  float32
 	audioAgentLevel float32
 	audioActive     bool
+
+	// liveReasoning accumulates streamed model reasoning ("thinking") for the
+	// in-progress turn, shown transiently and cleared when the turn's message
+	// arrives. Not conversational content.
+	liveReasoning string
+}
+
+// AppendLiveReasoning adds a streamed reasoning chunk to the in-progress turn's
+// transient thinking display.
+func (c *ConversationPanel) AppendLiveReasoning(text string) {
+	c.liveReasoning += text
+}
+
+// ClearLiveReasoning clears the transient thinking display (e.g. when the turn's
+// message arrives).
+func (c *ConversationPanel) ClearLiveReasoning() {
+	c.liveReasoning = ""
+}
+
+// LiveReasoning returns the current transient reasoning text (for rendering/tests).
+func (c *ConversationPanel) LiveReasoning() string {
+	return c.liveReasoning
 }
 
 // NewConversationPanel creates an empty conversation panel with defaults.

--- a/tools/arena/tui/panels/conversation_render.go
+++ b/tools/arena/tui/panels/conversation_render.go
@@ -50,15 +50,21 @@ func (c *ConversationPanel) View() string {
 // drops out cleanly when there is no active audio (no manual append/join math).
 func (c *ConversationPanel) composeView(title, content string) string {
 	meter := renderAudioMeters(c.audioUserLevel, c.audioAgentLevel, c.audioActive)
+	reasoning := ""
+	if c.liveReasoning != "" {
+		reasoning = "💭 " + c.liveReasoning
+	}
 	tree := layout.VSplit(
 		layout.Pane("title"),
 		layout.Optional(meter != "", layout.Pane("audio")),
+		layout.Optional(reasoning != "", layout.Pane("reasoning")),
 		layout.Pane("content"),
 	)
 	body := layout.RenderTree(tree, map[string]string{
-		"title":   title,
-		"audio":   meter,
-		"content": content,
+		"title":     title,
+		"audio":     meter,
+		"reasoning": reasoning,
+		"content":   content,
 	})
 	return lipgloss.NewStyle().
 		Padding(conversationPanelPadding, conversationPanelHorizontal).

--- a/tools/arena/tui/panels/conversation_test.go
+++ b/tools/arena/tui/panels/conversation_test.go
@@ -1162,3 +1162,22 @@ func TestConversationPanel_SetActive(t *testing.T) {
 	tb, _ = c.getBorderColors()
 	assert.Equal(t, theme.BorderColorFocused(), tb)
 }
+
+func TestConversationPanel_LiveReasoning(t *testing.T) {
+	panel := NewConversationPanel()
+	panel.SetDimensions(120, 40)
+	// A live run has the turn's user message in res, so the populated view (which
+	// carries the transient reasoning pane) renders.
+	panel.SetData("run", "scenario", "provider", &statestore.RunResult{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+
+	panel.AppendLiveReasoning("thinking ")
+	panel.AppendLiveReasoning("hard")
+	assert.Equal(t, "thinking hard", panel.LiveReasoning())
+	assert.Contains(t, panel.View(), "thinking hard", "live reasoning shown in the view")
+
+	panel.ClearLiveReasoning()
+	assert.Empty(t, panel.LiveReasoning())
+	assert.NotContains(t, panel.View(), "thinking hard", "cleared reasoning no longer shown")
+}


### PR DESCRIPTION
## What

The final Plan 3 (display) piece for the unified reasoning epic (#1527): live "watch it think" streaming in the TUI. With this, all four display surfaces are done (TUI history + HTML + JSON reports landed in #1529).

Refs #1527

## Changes

- **Events bus:** new non-content `reasoning.delta` event (`EventReasoningDelta` + `ReasoningDeltaData` + `Emitter.ReasoningDelta`, registered for the event store) — explicitly NOT conversational content, so subscribers/external stores never treat it as a message.
- **Pipeline:** both stages (regular streaming + duplex) emit `reasoning.delta` when reasoning flows, alongside the in-band `StreamElement.Reasoning`.
- **TUI:** `event_adapter` maps it to a non-content `ReasoningDeltaMsg`; `liveFeed.Apply` accumulates it via the panel's `AppendLiveReasoning` and clears it when the turn's message arrives; the conversation panel shows a transient `💭 <thinking>` pane (optional layout pane, drops out when empty) — "stream live, then collapse".

## Testing

Emitter test; adapter mapping; panel accumulate/render/clear; livefeed routing+clear. All `-race`; pre-commit green on every commit (events 98–100%, livefeed 84.8%).

## Epic status

With this merged, #1527 is fully delivered: reasoning unified across all providers/modalities (backend #1528), shown in turn history + reports (#1529), and streamed live (this PR). Remaining carried-over follow-ups (not blockers): duplex `Process`-loop reasoning test (needs mock stream-chunk injection); split `stages_duplex_provider_integration.go` so its logic is coverage-gated.
