### PR TITLE
docs(examples): reasoning-test — see model thinking in reports + TUI (#1527)

### DIFF
--- a/examples/reasoning-test/README.md
+++ b/examples/reasoning-test/README.md
@@ -1,0 +1,42 @@
+# reasoning-test
+
+Demonstrates unified model **reasoning ("thinking")** capture and display
+(epic #1527). A Gemini 2.5 thinking model solves a multi-step word problem; its
+reasoning is surfaced separately from the spoken answer.
+
+## Run it
+
+Requires a `GEMINI_API_KEY` (or `GOOGLE_API_KEY`). From this directory:
+
+```bash
+../../bin/promptarena run --ci --formats html,json
+open out/report.html
+```
+
+(Build the CLI first with `make build-arena` from the repo root.)
+
+## What to look for
+
+Reasoning is captured as a **sibling of content** (`Message.Reasoning`), so it is
+never mixed into the assistant's answer, exports, or future-turn context.
+
+- **HTML report** (`out/report.html`): each assistant turn has a collapsible
+  `💭 Reasoning` section, separate from the answer.
+- **JSON report** (`out/*.json`): the assistant message carries a `reasoning`
+  field alongside `content`.
+- **TUI** (`../../bin/promptarena run` without `--ci`): the conversation detail
+  view shows a `💭 Reasoning` section; interactive/voice sessions stream it live.
+
+## How reasoning is enabled
+
+Gemini 2.5 thinking models return thought summaries only when asked. See
+`providers/gemini-25-flash.provider.yaml`:
+
+```yaml
+additional_config:
+  include_thoughts: true   # return thought summaries
+  thinking_budget: 1024    # cap on reasoning tokens (count toward max_tokens)
+```
+
+Reasoning is **not persisted** to the conversation store by default; the reports
+above are built from the live run, so they show it regardless.

--- a/examples/reasoning-test/README.md
+++ b/examples/reasoning-test/README.md
@@ -17,15 +17,30 @@ open out/report.html
 
 ## What to look for
 
-Reasoning is captured as a **sibling of content** (`Message.Reasoning`), so it is
-never mixed into the assistant's answer, exports, or future-turn context.
+The prompt asks for a **terse** answer on purpose, so the distinction is obvious:
 
-- **HTML report** (`out/report.html`): each assistant turn has a collapsible
-  `💭 Reasoning` section, separate from the answer.
-- **JSON report** (`out/*.json`): the assistant message carries a `reasoning`
-  field alongside `content`.
-- **TUI** (`../../bin/promptarena run` without `--ci`): the conversation detail
-  view shows a `💭 Reasoning` section; interactive/voice sessions stream it live.
+- `content` is a single line, e.g. `ANSWER: 16`.
+- `reasoning` holds the model's multi-step thinking — captured **separately**.
+
+Reasoning is a **sibling of content** (`Message.Reasoning`), never mixed into the
+answer, exports, or future-turn context.
+
+**The definitive check** — see the two side by side (a populated `reasoning`
+proves capture; a short `content` proves it didn't leak into the answer):
+
+```bash
+jq '.Messages[] | select(.role=="assistant") | {content, reasoning}' out/*.json
+```
+
+Also visible in:
+- **HTML report** (`out/report.html`): a collapsible `💭 Reasoning` section,
+  rendered *only* when reasoning is present — so its appearance is the proof.
+- **TUI** (`../../bin/promptarena run` without `--ci`): a `💭 Reasoning` section
+  in the turn detail; interactive/voice sessions stream it live.
+
+If you instead see the step-by-step working *inside* `content`, the model ignored
+the terse instruction — that's the answer text, not the captured reasoning. The
+`reasoning` field is the ground truth.
 
 ## How reasoning is enabled
 

--- a/examples/reasoning-test/config.arena.yaml
+++ b/examples/reasoning-test/config.arena.yaml
@@ -1,0 +1,28 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Arena
+
+metadata:
+  name: reasoning-test
+
+spec:
+  prompt_configs:
+    - id: reasoning
+      file: prompts/reasoning.yaml
+
+  providers:
+    - file: providers/gemini-25-flash.provider.yaml
+
+  scenarios:
+    - file: scenarios/reasoning.scenario.yaml
+
+  defaults:
+    temperature: 0.0
+    max_tokens: 2048   # generous: reasoning tokens count toward the output cap
+    concurrency: 1
+    output:
+      dir: out
+      formats: ["json", "html"]
+      html:
+        file: report.html
+    fail_on:
+      - provider_error

--- a/examples/reasoning-test/prompts/reasoning.yaml
+++ b/examples/reasoning-test/prompts/reasoning.yaml
@@ -1,0 +1,14 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: PromptConfig
+
+metadata:
+  name: reasoning
+
+spec:
+  version: "1.0.0"
+  description: "Prompt for a multi-step reasoning task that exercises model thinking"
+  task_type: "reasoning"
+
+  system_template: |
+    You are a careful problem solver. Work through the problem step by step,
+    then state the final answer clearly on its own line as: ANSWER: <value>

--- a/examples/reasoning-test/prompts/reasoning.yaml
+++ b/examples/reasoning-test/prompts/reasoning.yaml
@@ -10,5 +10,9 @@ spec:
   task_type: "reasoning"
 
   system_template: |
-    You are a careful problem solver. Work through the problem step by step,
-    then state the final answer clearly on its own line as: ANSWER: <value>
+    You are a careful problem solver. Reply with ONLY the final answer in the
+    form "ANSWER: <value>" — a single line, nothing else. Do NOT show any working
+    or explanation in your reply.
+
+    (Thinking models still reason internally; that reasoning is captured separately
+    as the message's reasoning, distinct from this terse answer.)

--- a/examples/reasoning-test/providers/gemini-25-flash.provider.yaml
+++ b/examples/reasoning-test/providers/gemini-25-flash.provider.yaml
@@ -1,0 +1,23 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+
+metadata:
+  name: gemini-25-flash
+
+spec:
+  id: gemini-25-flash
+  type: gemini
+  model: gemini-2.5-flash
+  capabilities:
+    - text
+    - streaming
+  defaults:
+    temperature: 0.0
+    max_tokens: 2048
+    top_p: 1.0
+  # Gemini 2.5 "thinking" models: return thought summaries so PromptKit can
+  # surface them as Message.Reasoning (shown in the report + TUI). thinking_budget
+  # caps reasoning tokens (they count toward max_tokens); omit for the model default.
+  additional_config:
+    include_thoughts: true
+    thinking_budget: 1024

--- a/examples/reasoning-test/scenarios/reasoning.scenario.yaml
+++ b/examples/reasoning-test/scenarios/reasoning.scenario.yaml
@@ -1,0 +1,28 @@
+apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Scenario
+
+metadata:
+  name: reasoning
+
+spec:
+  id: reasoning
+  task_type: reasoning
+  description: "A multi-step word problem that makes the model reason before answering"
+  required_capabilities:
+    - text
+  tool_policy:
+    tool_choice: none
+    max_tool_calls_per_turn: 0
+    max_total_tool_calls: 0
+
+  turns:
+    - role: user
+      content: |
+        Alice, Bob, and Carol have ages in a strict descending order: Alice is
+        the oldest, then Bob, then Carol. Each person is exactly 3 years older
+        than the next-youngest. Carol is 10 years old. How old is Alice?
+      assertions:
+        - type: content_includes
+          message: "Alice should be 16 (Carol 10, Bob 13, Alice 16)"
+          params:
+            patterns: ["16"]

--- a/tools/arena/statestore/store.go
+++ b/tools/arena/statestore/store.go
@@ -428,6 +428,17 @@ func (s *ArenaStateStore) deepCloneMessage(msg *types.Message) types.Message {
 	s.cloneMessageMeta(&cloned, msg)
 	s.cloneMessageValidations(&cloned, msg)
 
+	// Reasoning is a sibling of content; clone it (with a deep copy of Opaque) so
+	// it survives save/load and reaches reports. Mirrors the runtime store fix.
+	if msg.Reasoning != nil {
+		r := *msg.Reasoning
+		if len(msg.Reasoning.Opaque) > 0 {
+			r.Opaque = make([]types.OpaqueReasoning, len(msg.Reasoning.Opaque))
+			copy(r.Opaque, msg.Reasoning.Opaque)
+		}
+		cloned.Reasoning = &r
+	}
+
 	return cloned
 }
 

--- a/tools/arena/statestore/store_test.go
+++ b/tools/arena/statestore/store_test.go
@@ -419,3 +419,33 @@ func TestUpdateLastAssistantMessageFallbackWithEmptyID(t *testing.T) {
 		t.Error("Expected fallback scan to update the message")
 	}
 }
+
+// TestDeepCloneMessage_PreservesReasoning guards the bug where the arena store's
+// field-by-field clone dropped Message.Reasoning, so reasoning never reached
+// reports (RunResult.Messages is loaded back from the store).
+func TestDeepCloneMessage_PreservesReasoning(t *testing.T) {
+	s := NewArenaStateStore()
+	msg := &types.Message{
+		Role:    "assistant",
+		Content: "ANSWER: 16",
+		Reasoning: &types.ReasoningTrace{
+			Text:   "step-by-step thinking",
+			Opaque: []types.OpaqueReasoning{{Provider: "gemini", Kind: "thought_signature", Data: "sig"}},
+		},
+	}
+	cloned := s.deepCloneMessage(msg)
+	if cloned.Reasoning == nil {
+		t.Fatal("clone dropped Message.Reasoning")
+	}
+	if cloned.Reasoning.Text != "step-by-step thinking" {
+		t.Fatalf("reasoning text = %q", cloned.Reasoning.Text)
+	}
+	if len(cloned.Reasoning.Opaque) != 1 || cloned.Reasoning.Opaque[0].Data != "sig" {
+		t.Fatalf("opaque reasoning not deep-copied: %+v", cloned.Reasoning.Opaque)
+	}
+	// Mutating the clone's Opaque must not touch the original (deep copy).
+	cloned.Reasoning.Opaque[0].Data = "changed"
+	if msg.Reasoning.Opaque[0].Data != "sig" {
+		t.Fatal("clone shares Opaque backing array with the original")
+	}
+}

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -747,7 +747,10 @@ func (e *PipelineExecutor) buildCommonStreamingStages(
 			stages = append(stages, saveStage)
 		} else {
 			stages = append(stages, stage.NewIncrementalSaveStageWithTurnState(
-				&stage.IncrementalSaveConfig{StateStoreConfig: storeConfig},
+				// Arena reports surface model reasoning, so persist it (the runtime
+				// default strips reasoning before the store). RunResult.Messages is
+				// loaded back from the store, so without this the report shows none.
+				&stage.IncrementalSaveConfig{StateStoreConfig: storeConfig, PersistReasoning: true},
 				turnState,
 			))
 		}


### PR DESCRIPTION
## What

A runnable example for the unified reasoning epic (#1527). A Gemini 2.5 thinking
model solves a multi-step word problem with `include_thoughts: true`, so its
reasoning is captured as `Message.Reasoning` and surfaced separately from the answer.

Refs #1527

## See it

```bash
make build-arena
cd examples/reasoning-test
GEMINI_API_KEY=... ../../bin/promptarena run --ci --formats html,json
open out/report.html
```

- **HTML report**: collapsible `💭 Reasoning` per assistant turn
- **JSON report**: `reasoning` field on the assistant message
- **TUI** (no `--ci`): `💭 Reasoning` section; live streaming in interactive mode

## Verified

Validates against the **published** schemas (no `PROMPTKIT_SCHEMA_SOURCE=local`) and
runs end-to-end to the Gemini API (only blocked here by the absence of an API key).
Files: `config.arena.yaml`, `prompts/reasoning.yaml`, `providers/gemini-25-flash.provider.yaml`, `scenarios/reasoning.scenario.yaml`, `README.md`.
