### PR TITLE
feat(claude): enable extended thinking + capture reasoning in streaming (#1527)

### DIFF
--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -528,6 +528,9 @@ type claudeResponse struct {
 type claudeContent struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
+	// Thinking carries the reasoning text of a "thinking" block — Claude puts it in
+	// a "thinking" field, NOT "text". Captured onto Message.Reasoning.
+	Thinking string `json:"thinking,omitempty"`
 	// Signature accompanies a thinking block; Data carries a redacted_thinking
 	// payload. Both are opaque reasoning tokens captured for round-trip, never
 	// displayed. See extractReasoning.

--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -123,6 +123,9 @@ type Provider struct {
 	// When non-nil it is authoritative for multimodal support; nil falls back
 	// to Claude's built-in defaults (images + documents, no audio/video).
 	capabilities map[string]bool
+	// thinkingBudget, when non-nil, enables Claude extended thinking with this
+	// token budget. Set from additional_config.thinking_budget. nil = off.
+	thinkingBudget *int
 }
 
 // setCapabilities records the declared capability set on the provider.
@@ -401,9 +404,31 @@ type claudeRequest struct {
 	Temperature  float32              `json:"temperature,omitempty"`
 	TopP         float32              `json:"top_p,omitempty"`
 	OutputConfig *claudeOutputConfig  `json:"output_config,omitempty"`
+	Thinking     *claudeThinking      `json:"thinking,omitempty"`
 	Stream       bool                 `json:"stream,omitempty"`
 	Tools        any                  `json:"tools,omitempty"`
 	ToolChoice   any                  `json:"tool_choice,omitempty"`
+}
+
+// claudeThinking enables Claude extended thinking. BudgetTokens caps reasoning
+// tokens (>= 1024) and must be below max_tokens (the answer needs headroom). With
+// thinking enabled the API rejects a custom temperature, so callers omit it.
+type claudeThinking struct {
+	Type         string `json:"type"` // "enabled"
+	BudgetTokens int    `json:"budget_tokens"`
+}
+
+// thinkingAnswerHeadroom is added above budget_tokens when the configured
+// max_tokens leaves no room for an answer after reasoning.
+const thinkingAnswerHeadroom = 1024
+
+// claudeThinkingFor returns the thinking block to attach, or nil when extended
+// thinking is not configured for this provider.
+func (p *Provider) claudeThinkingFor() *claudeThinking {
+	if p.thinkingBudget == nil {
+		return nil
+	}
+	return &claudeThinking{Type: "enabled", BudgetTokens: *p.thinkingBudget}
 }
 
 // buildBaseRequest assembles the fields every Claude request shares: model,
@@ -431,8 +456,16 @@ func (p *Provider) buildBaseRequest(req providers.PredictionRequest, messages an
 		Messages:  messages,
 		System:    p.createSystemBlocks(req.System),
 	}
-	// Claude 4.7+ models reject temperature; only send it when supported.
-	if p.paramSupported("temperature") {
+	if thinking := p.claudeThinkingFor(); thinking != nil {
+		// Extended thinking: reasoning tokens count toward max_tokens, so ensure
+		// headroom for an answer; and the API rejects a custom temperature, so we
+		// leave it omitted (omitempty).
+		cr.Thinking = thinking
+		if cr.MaxTokens <= thinking.BudgetTokens {
+			cr.MaxTokens = thinking.BudgetTokens + thinkingAnswerHeadroom
+		}
+	} else if p.paramSupported("temperature") {
+		// Claude 4.7+ models reject temperature; only send it when supported.
 		cr.Temperature = temperature
 	}
 	return cr

--- a/runtime/providers/claude/claude_reasoning_streaming_test.go
+++ b/runtime/providers/claude/claude_reasoning_streaming_test.go
@@ -1,0 +1,115 @@
+package claude
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestProvider_PredictStream_CapturesThinking verifies the streaming SSE parser
+// routes thinking_delta to StreamChunk.Reasoning and signature_delta to
+// OpaqueReasoning, keeping reasoning out of spoken content. Hermetic (httptest).
+func TestProvider_PredictStream_CapturesThinking(t *testing.T) {
+	const sse = "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5}}}\n\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"weigh the options\"}}\n\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"sig-abc\"}}\n\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"the answer\"}}\n\n" +
+		"data: {\"type\":\"message_stop\"}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sse))
+	}))
+	t.Cleanup(server.Close)
+
+	p := &Provider{
+		BaseProvider: providers.NewBaseProvider("test", false, server.Client()),
+		model:        "claude-sonnet-4-5",
+		baseURL:      server.URL,
+		apiKey:       "test-key",
+		defaults:     providers.ProviderDefaults{MaxTokens: 256},
+	}
+
+	ch, err := p.PredictStream(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "decide"}},
+	})
+	if err != nil {
+		t.Fatalf("PredictStream: %v", err)
+	}
+
+	var reasoning, content string
+	var signature string
+	for chunk := range ch {
+		reasoning += chunk.Reasoning
+		if chunk.Content != "" {
+			content = chunk.Content // accumulated spoken text
+		}
+		for _, o := range chunk.OpaqueReasoning {
+			if o.Kind == thinkingSignatureKind {
+				signature = o.Data
+			}
+		}
+	}
+
+	if reasoning != "weigh the options" {
+		t.Fatalf("reasoning = %q, want %q", reasoning, "weigh the options")
+	}
+	if signature != "sig-abc" {
+		t.Fatalf("signature opaque token = %q, want %q", signature, "sig-abc")
+	}
+	if !strings.Contains(content, "the answer") {
+		t.Fatalf("content = %q, want it to contain the spoken answer", content)
+	}
+	if strings.Contains(content, "weigh the options") {
+		t.Fatalf("reasoning leaked into content: %q", content)
+	}
+}
+
+// TestBuildBaseRequest_ExtendedThinking verifies the request-enable wiring: a
+// configured thinking budget attaches the thinking block, omits temperature
+// (Claude rejects a custom one with thinking), and guarantees answer headroom.
+func TestBuildBaseRequest_ExtendedThinking(t *testing.T) {
+	budget := 2048
+	p := &Provider{
+		model:          "claude-sonnet-4-5",
+		defaults:       providers.ProviderDefaults{MaxTokens: 1024, Temperature: 0.7},
+		thinkingBudget: &budget,
+	}
+	cr := p.buildBaseRequest(providers.PredictionRequest{Temperature: 0.7, MaxTokens: 1024}, nil)
+
+	if cr.Thinking == nil {
+		t.Fatal("thinking block must be set when a budget is configured")
+	}
+	if cr.Thinking.Type != "enabled" || cr.Thinking.BudgetTokens != 2048 {
+		t.Fatalf("thinking = %+v, want {enabled 2048}", cr.Thinking)
+	}
+	if cr.MaxTokens <= cr.Thinking.BudgetTokens {
+		t.Fatalf("max_tokens (%d) must exceed budget (%d) for answer headroom", cr.MaxTokens, cr.Thinking.BudgetTokens)
+	}
+	if cr.Temperature != 0 {
+		t.Fatalf("temperature must be omitted with thinking, got %v", cr.Temperature)
+	}
+}
+
+// TestApplyThinkingConfig reads the budget from additional_config.
+func TestApplyThinkingConfig(t *testing.T) {
+	p := &Provider{}
+	applyThinkingConfig(p, providers.ProviderSpec{
+		AdditionalConfig: map[string]any{"thinking_budget": 1024},
+	})
+	if p.thinkingBudget == nil || *p.thinkingBudget != 1024 {
+		t.Fatalf("thinkingBudget = %v, want 1024", p.thinkingBudget)
+	}
+
+	none := &Provider{}
+	applyThinkingConfig(none, providers.ProviderSpec{})
+	if none.thinkingBudget != nil {
+		t.Fatal("thinkingBudget must stay nil without config")
+	}
+}

--- a/runtime/providers/claude/claude_reasoning_test.go
+++ b/runtime/providers/claude/claude_reasoning_test.go
@@ -10,7 +10,8 @@ import (
 
 func TestExtractReasoning_TextAndSignature(t *testing.T) {
 	content := []claudeContent{
-		{Type: types.ContentTypeThinking, Text: "let me reason", Signature: "sig"},
+		// Claude carries thinking text in the "thinking" field, not "text".
+		{Type: types.ContentTypeThinking, Thinking: "let me reason", Signature: "sig"},
 		{Type: "text", Text: "the answer"},
 	}
 

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -377,11 +377,25 @@ func (p *Provider) streamResponse(
 					Type        string `json:"type"`
 					Text        string `json:"text"`
 					PartialJSON string `json:"partial_json"`
+					Thinking    string `json:"thinking"`
+					Signature   string `json:"signature"`
 				} `json:"delta,omitempty"`
 			}
 			if err := json.Unmarshal([]byte(data), &deltaEvent); err == nil {
 				if deltaEvent.Delta != nil {
 					switch deltaEvent.Delta.Type {
+					case "thinking_delta":
+						// Extended-thinking text streams on Reasoning, never content.
+						if deltaEvent.Delta.Thinking != "" {
+							outChan <- providers.StreamChunk{Reasoning: deltaEvent.Delta.Thinking}
+						}
+					case "signature_delta":
+						// Opaque round-trip token for the thinking block; never displayed.
+						if deltaEvent.Delta.Signature != "" {
+							outChan <- providers.StreamChunk{OpaqueReasoning: []types.OpaqueReasoning{{
+								Provider: providerClaude, Kind: thinkingSignatureKind, Data: deltaEvent.Delta.Signature,
+							}}}
+						}
 					case textDeltaType:
 						// Handle text delta - create a compatible struct for processClaudeContentDeltaInternal
 						textDelta := &struct {

--- a/runtime/providers/claude/claude_test.go
+++ b/runtime/providers/claude/claude_test.go
@@ -701,7 +701,7 @@ func TestParseAndValidateClaudeResponse_ThinkingAndText(t *testing.T) {
 		"type": "message",
 		"role": "assistant",
 		"content": [
-			{"type": "thinking", "text": "Let me think about this..."},
+			{"type": "thinking", "thinking": "Let me think about this..."},
 			{"type": "text", "text": "Here is my answer."}
 		],
 		"model": "claude-3-5-sonnet-20241022",

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -459,14 +459,18 @@ func extractContentParts(content []claudeContent) []types.ContentPart {
 	return parts
 }
 
+// Reasoning-block constants shared by the non-streaming (extractReasoning) and
+// streaming (signature_delta) capture paths.
+const (
+	providerClaude        = "claude"
+	thinkingSignatureKind = "thinking_signature"
+	redactedThinking      = "redacted_thinking"
+)
+
 // extractReasoning gathers Claude reasoning blocks into a ReasoningTrace: thinking
 // text (with its signature as an opaque round-trip token) and redacted_thinking
 // (opaque, marked Redacted). Returns nil when the response carries no reasoning.
 func extractReasoning(content []claudeContent) *types.ReasoningTrace {
-	const (
-		providerClaude   = "claude"
-		redactedThinking = "redacted_thinking"
-	)
 	var rt types.ReasoningTrace
 	for _, c := range content {
 		switch c.Type {
@@ -474,7 +478,7 @@ func extractReasoning(content []claudeContent) *types.ReasoningTrace {
 			rt.Text += c.Text
 			if c.Signature != "" {
 				rt.Opaque = append(rt.Opaque, types.OpaqueReasoning{
-					Provider: providerClaude, Kind: "thinking_signature", Data: c.Signature,
+					Provider: providerClaude, Kind: thinkingSignatureKind, Data: c.Signature,
 				})
 			}
 		case redactedThinking:
@@ -800,6 +804,33 @@ func (p *ToolProvider) buildDirectStreamingRequestFn(
 	}
 }
 
+// applyThinkingConfig enables Claude extended thinking from additional_config:
+//   - thinking_budget (int): reasoning-token budget (>= 1024). Sets the request's
+//     thinking block; omit to leave thinking off.
+//
+//nolint:gocritic // hugeParam: providers.ProviderSpec is passed by value across the factory
+func applyThinkingConfig(p *Provider, spec providers.ProviderSpec) {
+	if spec.AdditionalConfig == nil {
+		return
+	}
+	v, ok := spec.AdditionalConfig["thinking_budget"]
+	if !ok {
+		return
+	}
+	var budget int
+	switch n := v.(type) {
+	case int:
+		budget = n
+	case int64:
+		budget = int(n)
+	case float64:
+		budget = int(n)
+	default:
+		return
+	}
+	p.thinkingBudget = &budget
+}
+
 //nolint:gochecknoinits // Factory registration requires init
 func init() {
 	providers.RegisterProviderFactory("claude", providers.CredentialFactory(
@@ -811,6 +842,7 @@ func init() {
 			)
 			tp.setUnsupportedParams(spec.UnsupportedParams)
 			tp.setCapabilities(spec.Capabilities)
+			applyThinkingConfig(tp.Provider, spec)
 			return tp, nil
 		},
 		func(spec providers.ProviderSpec) (providers.Provider, error) {
@@ -819,6 +851,7 @@ func init() {
 			)
 			tp.setUnsupportedParams(spec.UnsupportedParams)
 			tp.setCapabilities(spec.Capabilities)
+			applyThinkingConfig(tp.Provider, spec)
 			return tp, nil
 		},
 	))

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -475,7 +475,7 @@ func extractReasoning(content []claudeContent) *types.ReasoningTrace {
 	for _, c := range content {
 		switch c.Type {
 		case types.ContentTypeThinking:
-			rt.Text += c.Text
+			rt.Text += c.Thinking
 			if c.Signature != "" {
 				rt.Opaque = append(rt.Opaque, types.OpaqueReasoning{
 					Provider: providerClaude, Kind: thinkingSignatureKind, Data: c.Signature,

--- a/runtime/providers/claude/claude_tools_test.go
+++ b/runtime/providers/claude/claude_tools_test.go
@@ -1006,7 +1006,7 @@ func TestToolProvider_MakeRequest_BedrockBodyMutation(t *testing.T) {
 func TestExtractContentParts(t *testing.T) {
 	t.Run("text and thinking blocks", func(t *testing.T) {
 		content := []claudeContent{
-			{Type: "thinking", Text: "reasoning here"},
+			{Type: "thinking", Thinking: "reasoning here"},
 			{Type: "text", Text: "final answer"},
 		}
 		// Reasoning is no longer a content part — only the text part remains.
@@ -1065,7 +1065,7 @@ func TestExtractContentParts(t *testing.T) {
 
 	t.Run("thinking only", func(t *testing.T) {
 		content := []claudeContent{
-			{Type: "thinking", Text: "deep thoughts"},
+			{Type: "thinking", Thinking: "deep thoughts"},
 		}
 		// Thinking is no longer a content part; it surfaces on the reasoning trace.
 		parts := extractContentParts(content)

--- a/runtime/providers/claude/reasoning_integration_test.go
+++ b/runtime/providers/claude/reasoning_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package claude
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestClaude_Reasoning_Live verifies the live seam: a real Claude call with
+// extended thinking enabled (additional_config.thinking_budget) streams
+// thinking_delta text on StreamChunk.Reasoning, separate from spoken content.
+//
+// Run: ANTHROPIC_API_KEY=... go test -tags integration ./runtime/providers/claude/ -run TestClaude_Reasoning_Live -v
+// Override the model with CLAUDE_THINKING_MODEL if the default is unavailable.
+func TestClaude_Reasoning_Live(t *testing.T) {
+	if os.Getenv("ANTHROPIC_API_KEY") == "" && os.Getenv("CLAUDE_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+
+	model := os.Getenv("CLAUDE_THINKING_MODEL")
+	if model == "" {
+		model = "claude-sonnet-4-5"
+	}
+
+	tp := NewToolProvider("claude-reasoning", model, "https://api.anthropic.com/v1",
+		providers.ProviderDefaults{MaxTokens: 3072}, false)
+	defer tp.Close()
+
+	applyThinkingConfig(tp.Provider, providers.ProviderSpec{
+		AdditionalConfig: map[string]any{"thinking_budget": 2048},
+	})
+
+	req := providers.PredictionRequest{
+		System: "Reply with ONLY the final answer, nothing else.",
+		Messages: []types.Message{{
+			Role: "user",
+			Content: "A bat and a ball cost $1.10 in total. The bat costs $1.00 more " +
+				"than the ball. How much does the ball cost?",
+		}},
+	}
+
+	ch, err := tp.PredictStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("PredictStream: %v", err)
+	}
+
+	var reasoning, content strings.Builder
+	for chunk := range ch {
+		reasoning.WriteString(chunk.Reasoning)
+		if chunk.Content != "" {
+			content.Reset()
+			content.WriteString(chunk.Content) // accumulated spoken text
+		}
+	}
+
+	if reasoning.Len() == 0 {
+		t.Fatalf("expected non-empty reasoning from extended thinking; got none (content=%q) — "+
+			"the thinking block is not reaching the wire or the model is not returning thinking deltas",
+			content.String())
+	}
+	if r := reasoning.String(); strings.Contains(content.String(), r) {
+		t.Fatalf("reasoning leaked into spoken content: %q", content.String())
+	}
+	t.Logf("captured reasoning (%d chars); spoken content=%q", reasoning.Len(), content.String())
+}

--- a/runtime/providers/claude/reasoning_integration_test.go
+++ b/runtime/providers/claude/reasoning_integration_test.go
@@ -69,3 +69,97 @@ func TestClaude_Reasoning_Live(t *testing.T) {
 	}
 	t.Logf("captured reasoning (%d chars); spoken content=%q", reasoning.Len(), content.String())
 }
+
+// newClaudeThinkingProvider builds an extended-thinking-enabled Claude tool provider.
+func newClaudeThinkingProvider(t *testing.T) *ToolProvider {
+	t.Helper()
+	if os.Getenv("ANTHROPIC_API_KEY") == "" && os.Getenv("CLAUDE_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+	model := os.Getenv("CLAUDE_THINKING_MODEL")
+	if model == "" {
+		model = "claude-sonnet-4-5"
+	}
+	tp := NewToolProvider("claude-reasoning", model, "https://api.anthropic.com/v1",
+		providers.ProviderDefaults{MaxTokens: 4096}, false)
+	applyThinkingConfig(tp.Provider, providers.ProviderSpec{
+		AdditionalConfig: map[string]any{"thinking_budget": 2048},
+	})
+	return tp
+}
+
+const claudeReasoningPrompt = "A bat and a ball cost $1.10 in total. The bat costs $1.00 more " +
+	"than the ball. How much does the ball cost?"
+
+// TestClaude_Reasoning_Live_NonStreaming covers the non-streaming Predict path.
+func TestClaude_Reasoning_Live_NonStreaming(t *testing.T) {
+	tp := newClaudeThinkingProvider(t)
+	defer tp.Close()
+
+	resp, err := tp.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: claudeReasoningPrompt}},
+	})
+	if err != nil {
+		t.Fatalf("Predict: %v", err)
+	}
+	if resp.Reasoning == nil || resp.Reasoning.Text == "" {
+		t.Fatalf("expected reasoning on the non-streaming response; got none (content=%q)", resp.Content)
+	}
+	if strings.Contains(resp.Content, resp.Reasoning.Text) {
+		t.Fatalf("reasoning leaked into content: %q", resp.Content)
+	}
+	t.Logf("non-streaming reasoning %d chars", len(resp.Reasoning.Text))
+}
+
+func claudeWeatherTool(t *testing.T, tp *ToolProvider) providers.ProviderTools {
+	t.Helper()
+	tools, err := tp.BuildTooling([]*providers.ToolDescriptor{{
+		Name:        "get_weather",
+		Description: "Get the current weather for a city",
+		InputSchema: []byte(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+	}})
+	if err != nil {
+		t.Fatalf("BuildTooling: %v", err)
+	}
+	return tools
+}
+
+const claudeToolPrompt = "Work out the capital of France, then call get_weather for that city."
+
+// TestClaude_Reasoning_Live_Tools covers the non-streaming tools path.
+func TestClaude_Reasoning_Live_Tools(t *testing.T) {
+	tp := newClaudeThinkingProvider(t)
+	defer tp.Close()
+
+	resp, _, err := tp.PredictWithTools(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: claudeToolPrompt}},
+	}, claudeWeatherTool(t, tp), "auto")
+	if err != nil {
+		t.Fatalf("PredictWithTools: %v", err)
+	}
+	if resp.Reasoning == nil || resp.Reasoning.Text == "" {
+		t.Fatalf("expected reasoning on the tools response; got none (content=%q)", resp.Content)
+	}
+	t.Logf("tools reasoning %d chars", len(resp.Reasoning.Text))
+}
+
+// TestClaude_Reasoning_Live_StreamingTools covers the streaming tools path.
+func TestClaude_Reasoning_Live_StreamingTools(t *testing.T) {
+	tp := newClaudeThinkingProvider(t)
+	defer tp.Close()
+
+	ch, err := tp.PredictStreamWithTools(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: claudeToolPrompt}},
+	}, claudeWeatherTool(t, tp), "auto")
+	if err != nil {
+		t.Fatalf("PredictStreamWithTools: %v", err)
+	}
+	var reasoning strings.Builder
+	for chunk := range ch {
+		reasoning.WriteString(chunk.Reasoning)
+	}
+	if reasoning.Len() == 0 {
+		t.Fatal("expected reasoning on the streaming-tools path; got none")
+	}
+	t.Logf("streaming-tools reasoning %d chars", reasoning.Len())
+}


### PR DESCRIPTION
## What

Makes Claude actually emit reasoning. It could *display* reasoning but never produce it: there was no request-side enable knob, and the streaming SSE parser ignored thinking entirely (only non-streaming `Predict` captured it).

Refs #1527

## Changes

- **Enable** — `additional_config.thinking_budget` attaches a `thinking` block on every request (via the shared `buildBaseRequest`), omitting temperature (Claude rejects a custom one with thinking) and guaranteeing answer headroom above the budget.
- **Capture (streaming)** — parse `thinking_delta` → `StreamChunk.Reasoning` and `signature_delta` → `OpaqueReasoning` (opaque round-trip token), keeping reasoning out of spoken content.

## Testing

- Hermetic (no key): `httptest` SSE parse asserting thinking/signature routing + content exclusion; `buildBaseRequest` enable wiring; `applyThinkingConfig`.
- Gated live test (`//go:build integration` + `ANTHROPIC_API_KEY`, `CLAUDE_THINKING_MODEL` override).

Coverage on changed files: claude.go 85%, claude_streaming.go 88.5%, claude_tools.go 83.7%.

## Config

```yaml
spec:
  type: claude
  model: claude-sonnet-4-5
  additional_config:
    thinking_budget: 2048   # reasoning-token budget; max_tokens auto-bumped for headroom
```
