### PR TITLE
feat(tui): show reasoning on completed turns in the live interactive console (#1527)

### DIFF
--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -430,6 +430,7 @@ func (e *Emitter) MessageCreated(
 	parts []types.ContentPart,
 	toolCalls []MessageToolCall,
 	toolResult *MessageToolResult,
+	reasoning *types.ReasoningTrace,
 ) {
 	e.emit(EventMessageCreated, &MessageCreatedData{
 		Role:       role,
@@ -438,6 +439,7 @@ func (e *Emitter) MessageCreated(
 		Parts:      types.MetadataOnlyParts(parts),
 		ToolCalls:  toolCalls,
 		ToolResult: toolResult,
+		Reasoning:  reasoning,
 	})
 }
 

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -160,7 +160,7 @@ func TestEmitterHandlesNilEmitter(t *testing.T) {
 	var emitter *Emitter
 	// Should not panic when emitter is nil
 	emitter.PipelineStarted(1)
-	emitter.MessageCreated("user", "hello", 0, nil, nil, nil)
+	emitter.MessageCreated("user", "hello", 0, nil, nil, nil, nil)
 	emitter.MessageUpdated(0, 100, 10, 20, 0.001)
 	emitter.ConversationStarted("system prompt")
 }
@@ -183,7 +183,7 @@ func TestEmitter_MessageCreated(t *testing.T) {
 	toolCalls := []MessageToolCall{
 		{Name: "test_tool", Args: `{"key":"value"}`},
 	}
-	emitter.MessageCreated("assistant", "Hello!", 1, nil, toolCalls, nil)
+	emitter.MessageCreated("assistant", "Hello!", 1, nil, toolCalls, nil, nil)
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for message.created event")
@@ -225,7 +225,7 @@ func TestEmitter_MessageCreated_WithToolResult(t *testing.T) {
 		Name:  "weather_tool",
 		Parts: []types.ContentPart{types.NewTextPart(`{"temp": 72}`)},
 	}
-	emitter.MessageCreated("tool", "", 2, nil, nil, toolResult)
+	emitter.MessageCreated("tool", "", 2, nil, nil, toolResult, nil)
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for message.created event with tool result")
@@ -265,7 +265,7 @@ func TestEmitter_MessageCreated_WithParts(t *testing.T) {
 		{Type: "text", Text: &textVal},
 		{Type: "image", Media: &types.MediaContent{MIMEType: "image/png", URL: &imgURL}},
 	}
-	emitter.MessageCreated("user", "Hello with image", 0, parts, nil, nil)
+	emitter.MessageCreated("user", "Hello with image", 0, parts, nil, nil, nil)
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for message.created event with parts")
@@ -321,7 +321,7 @@ func TestEmitter_MessageCreated_StripsBinaryData(t *testing.T) {
 			},
 		},
 	}
-	emitter.MessageCreated("user", "Check this out", 0, parts, nil, nil)
+	emitter.MessageCreated("user", "Check this out", 0, parts, nil, nil, nil)
 
 	if !waitForWG(&wg, 200*time.Millisecond) {
 		t.Fatal("timed out waiting for message.created event")

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -2,8 +2,10 @@ package events
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +14,29 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// TestMessageCreatedData_ReasoningNotSerialized guards the invariant that the
+// MessageCreated event carries reasoning in-memory for live consumers but never
+// serializes it — recordings, session exports, and SSE all marshal event data to
+// JSON, and reasoning persistence must stay opt-in (save stage PersistReasoning,
+// default off). If `json:"-"` is dropped, reasoning would leak into every sink.
+func TestMessageCreatedData_ReasoningNotSerialized(t *testing.T) {
+	data := &MessageCreatedData{
+		Role:      "assistant",
+		Content:   "ANSWER: 16",
+		Reasoning: &types.ReasoningTrace{Text: "SECRET_CHAIN_OF_THOUGHT"},
+	}
+	out, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "SECRET_CHAIN_OF_THOUGHT") {
+		t.Fatalf("reasoning leaked into serialized event: %s", out)
+	}
+	if strings.Contains(strings.ToLower(string(out)), "reasoning") {
+		t.Fatalf("reasoning field leaked into serialized event: %s", out)
+	}
+}
 
 func TestEmitterPublishesSharedContext(t *testing.T) {
 	t.Parallel()

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -442,6 +442,9 @@ type MessageCreatedData struct {
 	Parts      []types.ContentPart // Multimodal content parts (text, images, audio, video)
 	ToolCalls  []MessageToolCall   // Tool calls requested by assistant (if any)
 	ToolResult *MessageToolResult  // Tool result for tool messages (if any)
+	// Reasoning is the model's reasoning ("thinking") for this message, so live
+	// consumers (TUI, web) can show it in turn history. Not conversational content.
+	Reasoning *types.ReasoningTrace
 }
 
 // MessageUpdatedData contains data for message update events.

--- a/runtime/events/types.go
+++ b/runtime/events/types.go
@@ -442,9 +442,13 @@ type MessageCreatedData struct {
 	Parts      []types.ContentPart // Multimodal content parts (text, images, audio, video)
 	ToolCalls  []MessageToolCall   // Tool calls requested by assistant (if any)
 	ToolResult *MessageToolResult  // Tool result for tool messages (if any)
-	// Reasoning is the model's reasoning ("thinking") for this message, so live
-	// consumers (TUI, web) can show it in turn history. Not conversational content.
-	Reasoning *types.ReasoningTrace
+	// Reasoning is the model's reasoning ("thinking") for this message, carried
+	// in-memory so live consumers (the in-process TUI) can show it in turn
+	// history. It is NOT conversational content, and `json:"-"` keeps it out of
+	// every serialized sink (session recordings, exports, SSE) — reasoning
+	// persistence stays opt-in via the save stage's PersistReasoning, default
+	// off. Live consumers read the Go struct directly, so they still receive it.
+	Reasoning *types.ReasoningTrace `json:"-"`
 }
 
 // MessageUpdatedData contains data for message update events.

--- a/tools/arena/stages/statestore_save_integration.go
+++ b/tools/arena/stages/statestore_save_integration.go
@@ -420,7 +420,7 @@ func (b *liveBroadcaster) emitSystem(content string) {
 		return
 	}
 	b.systemEmitted = true
-	b.stage.emitter.MessageCreated(roleSystem, content, 0, nil, nil, nil)
+	b.stage.emitter.MessageCreated(roleSystem, content, 0, nil, nil, nil, nil)
 }
 
 // resolveSystemPrompt returns the rendered system prompt for this turn,
@@ -457,6 +457,7 @@ func (s *ArenaStateStoreSaveStage) broadcastMessage(elem *stage.StreamElement, i
 		elem.Message.Parts,
 		convertToolCalls(elem.Message.ToolCalls),
 		convertToolResult(elem.Message.ToolResult),
+		elem.Message.Reasoning,
 	)
 }
 

--- a/tools/arena/tui/app/livefeed.go
+++ b/tools/arena/tui/app/livefeed.go
@@ -111,6 +111,7 @@ func (f *liveFeed) appendCreated(panel *panels.ConversationPanel, m *tui.Message
 		Timestamp:  m.Time,
 		ToolCalls:  toolCalls,
 		ToolResult: toolResult,
+		Reasoning:  m.Reasoning,
 	})
 	f.appended = m.Index - f.seeded + 1
 }

--- a/tools/arena/tui/app/livefeed_test.go
+++ b/tools/arena/tui/app/livefeed_test.go
@@ -47,6 +47,28 @@ func TestLiveFeed_AppendsNewDedupsOld(t *testing.T) {
 	require.Equal(t, 3, panel.MessageCount())
 }
 
+// TestLiveFeed_CompletedTurnShowsReasoning proves the live interactive path:
+// a MessageCreatedMsg carrying Reasoning is appended to the panel and the
+// completed turn's detail view renders the reasoning (not just the transient
+// streaming pane). Guards the event->tui-message->panel reasoning seam.
+func TestLiveFeed_CompletedTurnShowsReasoning(t *testing.T) {
+	panel := seededPanel(t, "conv-1", 1)
+	f := newLiveFeed("conv-1", 1)
+
+	// Single non-wrapping token: the detail pane line-wraps and ANSI-styles
+	// prose, so a multi-word phrase won't survive as a contiguous substring.
+	require.True(t, f.Apply(panel, tui.MessageCreatedMsg{
+		ConversationID: "conv-1", Index: 1, Role: "assistant", Content: "ANSWER: 16",
+		Reasoning: &types.ReasoningTrace{Text: "THOUGHTMARKER"},
+	}))
+	require.Equal(t, 2, panel.MessageCount())
+
+	panel.SelectLast()
+	view := panel.View()
+	require.Contains(t, view, "Reasoning", "detail view shows the reasoning section")
+	require.Contains(t, view, "THOUGHTMARKER", "reasoning text rendered in the completed turn")
+}
+
 // TestLiveFeed_AudioSystemPromptAndMetadata covers the audio, conversation
 // started (system prompt), and message updated paths.
 func TestLiveFeed_AudioSystemPromptAndMetadata(t *testing.T) {

--- a/tools/arena/tui/event_adapter.go
+++ b/tools/arena/tui/event_adapter.go
@@ -197,6 +197,7 @@ func (a *EventAdapter) handleMessageCreated(event *events.Event) tea.Msg {
 		Index:          data.Index,
 		ToolCalls:      data.ToolCalls,
 		ToolResult:     data.ToolResult,
+		Reasoning:      data.Reasoning,
 		Time:           event.Timestamp,
 	}
 }

--- a/tools/arena/tui/event_adapter_test.go
+++ b/tools/arena/tui/event_adapter_test.go
@@ -616,6 +616,27 @@ func TestEventAdapter_HandleMessageCreated(t *testing.T) {
 		assert.Equal(t, 0, createdMsg.Index)
 	})
 
+	t.Run("with reasoning", func(t *testing.T) {
+		evt := &events.Event{
+			Type:           events.EventMessageCreated,
+			ConversationID: "conv-1",
+			Timestamp:      time.Now(),
+			Data: events.MessageCreatedData{
+				Role:      "assistant",
+				Content:   "ANSWER: 16",
+				Index:     0,
+				Reasoning: &types.ReasoningTrace{Text: "chain of thought"},
+			},
+		}
+
+		msg := adapter.handleMessageCreated(evt)
+		require.NotNil(t, msg)
+		createdMsg, ok := msg.(MessageCreatedMsg)
+		require.True(t, ok)
+		require.NotNil(t, createdMsg.Reasoning, "reasoning must survive the event->msg seam")
+		assert.Equal(t, "chain of thought", createdMsg.Reasoning.Text)
+	})
+
 	t.Run("with tool calls", func(t *testing.T) {
 		evt := &events.Event{
 			Type:           events.EventMessageCreated,

--- a/tools/arena/tui/messages.go
+++ b/tools/arena/tui/messages.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // RunStartedMsg is sent when a run begins execution.
@@ -61,8 +62,9 @@ type MessageCreatedMsg struct {
 	Role           string
 	Content        string
 	Index          int
-	ToolCalls      []MessageToolCall  // Tool calls requested by assistant
-	ToolResult     *MessageToolResult // Tool result for tool messages
+	ToolCalls      []MessageToolCall     // Tool calls requested by assistant
+	ToolResult     *MessageToolResult    // Tool result for tool messages
+	Reasoning      *types.ReasoningTrace // Model reasoning ("thinking") for this turn
 	Time           time.Time
 }
 

--- a/tools/arena/web/event_adapter_test.go
+++ b/tools/arena/web/event_adapter_test.go
@@ -265,7 +265,7 @@ func TestAdapter_EmitterContract(t *testing.T) {
 	emitter := events.NewEmitter(bus, "exec-1", "sess-1", "conv-1")
 
 	// MessageCreated mirrors what the duplex executor calls during a real run.
-	emitter.MessageCreated("user", "round-trip test", 0, nil, nil, nil)
+	emitter.MessageCreated("user", "round-trip test", 0, nil, nil, nil, nil)
 
 	select {
 	case msg := <-ch:


### PR DESCRIPTION
## Problem

The live interactive chat/voice TUI builds its transcript from the **events bus**, not from a stored `RunResult`. While a turn streams, the transient `💭` pane works (separate `reasoning.delta` path). But once the turn completed, the message rebuilt from `MessageCreatedMsg` had **no reasoning** — `events.MessageCreatedData` and `tui.MessageCreatedMsg` never carried it — so the completed-turn detail view showed nothing.

This is the gap surfaced while verifying reasoning across surfaces: reports and the run-results viewer were fine (they load from the store), but the live console's scrollback was not.

## Fix

Thread `Reasoning` through the event → TUI-message → panel seam:

- `events.MessageCreatedData` gains `Reasoning`; `Emitter.MessageCreated(...)` takes it and the arena save stage's `broadcastMessage` passes `elem.Message.Reasoning`.
- `tui.MessageCreatedMsg` gains `Reasoning`; the event adapter copies it; `liveFeed.appendCreated` sets it on the appended `types.Message`, so `buildDetailView` renders the `💭 Reasoning` section.

## Tests

- **event → msg seam** (`event_adapter`): a `MessageCreatedData{Reasoning}` survives into `MessageCreatedMsg`.
- **end-to-end render** (`livefeed`): a `MessageCreatedMsg{Reasoning}` is appended and the completed turn's detail `View()` shows the reasoning.

Part of the unified reasoning epic #1527. Complements the store-clone fix (#1532) that covered the report/run-viewer path.
