### PR TITLE
fix(tui): show streaming reasoning before the first RunResult (#1527)

### DIFF
--- a/tools/arena/tui/panels/conversation_render.go
+++ b/tools/arena/tui/panels/conversation_render.go
@@ -20,6 +20,12 @@ import (
 // View renders the conversation panel.
 func (c *ConversationPanel) View() string {
 	if c.res == nil {
+		// A ReasoningDelta can arrive before the first RunResult is set; still
+		// surface the streaming 💭 rather than swallowing it behind the
+		// placeholder. composeView doesn't depend on c.res.
+		if c.liveReasoning != "" {
+			return c.composeView(c.buildTitle(), "No conversation available.")
+		}
 		return "No conversation available."
 	}
 

--- a/tools/arena/tui/panels/conversation_test.go
+++ b/tools/arena/tui/panels/conversation_test.go
@@ -1181,3 +1181,20 @@ func TestConversationPanel_LiveReasoning(t *testing.T) {
 	assert.Empty(t, panel.LiveReasoning())
 	assert.NotContains(t, panel.View(), "thinking hard", "cleared reasoning no longer shown")
 }
+
+// TestConversationPanel_LiveReasoning_NilRes covers the edge where a
+// ReasoningDelta arrives before any RunResult is set: the streaming 💭 must
+// still render rather than being swallowed by the "no conversation" placeholder.
+func TestConversationPanel_LiveReasoning_NilRes(t *testing.T) {
+	panel := NewConversationPanel()
+	panel.SetDimensions(120, 40)
+
+	// No SetData call — c.res is nil.
+	assert.Equal(t, "No conversation available.", panel.View())
+
+	panel.AppendLiveReasoning("thinking early")
+	assert.Contains(t, panel.View(), "thinking early", "streaming reasoning shown before any RunResult")
+
+	panel.ClearLiveReasoning()
+	assert.Equal(t, "No conversation available.", panel.View(), "falls back to placeholder once cleared")
+}


### PR DESCRIPTION
Closes the last minor tail of the unified reasoning epic (#1527).

The conversation panel's `nil`-`res` early return dropped straight to the "No conversation available." placeholder, swallowing any live `💭` reasoning that arrived before the first `RunResult` was set. Now routes through `composeView` when `liveReasoning` is present (`composeView` doesn't depend on `c.res`), and falls back to the placeholder once cleared.

Test covers the nil-res streaming edge + placeholder fallback.
