### PR TITLE
fix(arena): don't warn about guardrails for composition/workflow states

### DIFF
--- a/tools/arena/turnexecutors/pipeline_executor_test.go
+++ b/tools/arena/turnexecutors/pipeline_executor_test.go
@@ -4,7 +4,30 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 )
+
+// TestLoadGuardrailHooks_EmptyTaskType covers composition/workflow entry states,
+// which have no prompt_task: guardrail loading must return no hooks quietly,
+// without reaching LoadTemplate (which would fail "prompt not found" on the empty
+// task and log a misleading warning). A nil-repository registry is safe here
+// precisely because the early return means the repository is never touched.
+func TestLoadGuardrailHooks_EmptyTaskType(t *testing.T) {
+	req := &TurnRequest{
+		PromptRegistry: prompt.NewRegistryWithRepository(nil),
+		TaskType:       "",
+	}
+	if got := loadGuardrailHooks(req, nil); got != nil {
+		t.Fatalf("expected no guardrail hooks for empty task type, got %d", len(got))
+	}
+}
+
+// TestLoadGuardrailHooks_NoRegistry covers the other quiet no-op path.
+func TestLoadGuardrailHooks_NoRegistry(t *testing.T) {
+	if got := loadGuardrailHooks(&TurnRequest{TaskType: "chat"}, nil); got != nil {
+		t.Fatalf("expected no guardrail hooks without a registry, got %d", len(got))
+	}
+}
 
 // Note: mock provider detection covered in existing helpers test file
 

--- a/tools/arena/turnexecutors/pipeline_stages_integration.go
+++ b/tools/arena/turnexecutors/pipeline_stages_integration.go
@@ -565,6 +565,12 @@ func loadGuardrailHooks(req *TurnRequest, vars map[string]string) []hooks.Provid
 	if req.PromptRegistry == nil {
 		return nil
 	}
+	// A composition/workflow entry state has no prompt_task, so there is no pack
+	// prompt to source guardrails from. Skip quietly — loading a template for an
+	// empty task would fail with "prompt not found" and log a misleading warning.
+	if req.TaskType == "" {
+		return nil
+	}
 	tmpl, err := req.PromptRegistry.LoadTemplate(req.TaskType, vars, "")
 	if err != nil {
 		logger.Warn("Skipping pack guardrails: template load failed",


### PR DESCRIPTION
Small cleanup surfaced while verifying the RFC 0010 composition example (`examples/document-analysis/`).

A composition/workflow **entry** state has no `prompt_task`, so `loadGuardrailHooks` called `LoadTemplate("")`, which fails with "prompt not found" and logged a misleading `Skipping pack guardrails: template load failed` warning on every run of a composition example.

There's simply no pack prompt to source guardrails from in that case, so return no hooks quietly when `TaskType` is empty.

Verified: the document-analysis example now runs with **0** such warnings and all **4** composition assertions still pass. Unit tests cover the empty-task and no-registry quiet no-op paths.
