### PR TITLE
docs(readme): refocus on the runtime/SDK and performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,170 +4,163 @@
 [![Docs](https://github.com/AltairaLabs/PromptKit/actions/workflows/docs.yml/badge.svg)](https://github.com/AltairaLabs/PromptKit/actions/workflows/docs.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AltairaLabs_PromptKit&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AltairaLabs_PromptKit)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=AltairaLabs_PromptKit&metric=coverage)](https://sonarcloud.io/summary/new_code?id=AltairaLabs_PromptKit)
-[![Go Report Card](https://goreportcard.com/badge/github.com/AltairaLabs/PromptKit)](https://goreportcard.com/report/github.com/AltairaLabs/PromptKit)
 [![Go Reference](https://pkg.go.dev/badge/github.com/AltairaLabs/PromptKit.svg)](https://pkg.go.dev/github.com/AltairaLabs/PromptKit)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-> **Multi-provider prompt testing and deployment. Test prompts before they fail in production.**
+> **The high-performance Go runtime and SDK for production LLM applications.**
 
-PromptKit is the open-source toolkit for [**PromptPack**](https://github.com/AltairaLabs/promptpack-spec) — test prompts across Claude, OpenAI, Gemini, Azure, and local models, run red-team scenarios in CI, and compile portable packs for runtime. The spec lives upstream so your config isn't locked to a vendor.
+PromptKit is a Go library for building LLM apps that hold up under real load:
+multi-provider streaming with a bounded back-pressure stack, native tool calling
+(MCP), agent-to-agent orchestration, workflow state machines, voice, and
+multimodal — all behind one pipeline with first-class metrics. It stays flat on
+memory and CPU where other frameworks balloon or fall over (see
+[Performance](#performance)).
+
+Config is portable via the [**PromptPack**](https://github.com/AltairaLabs/promptpack-spec)
+spec, so your prompts, providers, and tools aren't locked to a vendor.
 
 ## How it fits together
 
 ```
 PromptPack  ── open spec for portable prompts (JSON, vendor-neutral)
     │
-    ├── PromptKit  ── this repo: Go SDK + runtime libraries + hosted schemas
+    ├── PromptKit  ── this repo: Go runtime + SDK (embed in your application)
     │
     └── PromptArena  ── github.com/AltairaLabs/promptarena
          ├── promptarena  ── test, red-team, evaluate (CLI)
          └── packc        ── compile config → portable pack
 ```
 
-The **PromptArena** and **PackC** command-line tools now live in their own
-repository, [github.com/AltairaLabs/promptarena](https://github.com/AltairaLabs/promptarena),
-and are documented at [promptarena.altairalabs.ai](https://promptarena.altairalabs.ai).
-This repository is the Go SDK and runtime that they (and your own applications)
-build on.
+PromptKit is the runtime your application links against. The
+[**PromptArena**](https://github.com/AltairaLabs/promptarena) CLI (testing,
+red-team, evaluation) and the **PackC** compiler build on it and live in their
+own repo.
 
-## Why PromptKit
+## Performance
 
-| | PromptKit | Promptfoo | LangSmith | Helicone |
+The [efficiency benchmark](./benchmarks) ([#919](https://github.com/AltairaLabs/PromptKit/pull/919))
+runs a realistic tool-calling profile — the framework receives tool calls,
+executes them against a mock tool endpoint, feeds results back, and streams the
+final response — against a shared mock upstream. Resident memory and CPU are
+sampled at 100 / 500 / 1000 / 2000 concurrent streams; cost is computed against
+a `c6g.xlarge` reference ($0.136/hr). The load-test harness lives in
+[`benchmarks/`](./benchmarks); reproduce the numbers below with
+`make -C benchmarks round1-tools` (Docker spins up the mock upstream plus each
+framework). Full write-up:
+[*Bulletproofing Streaming LLM Calls*](https://altairalabs.ai/blog/streaming-llm-back-pressure).
+
+**Resident memory** (MB, lower is better)
+
+| Concurrent | PromptKit | LangChain | Vercel AI | Strands |
 |---|---|---|---|---|
-| Multi-provider testing | ✅ | ✅ | LangChain-only | Observability-only |
-| Built-in workflow orchestration | ✅ | ❌ | Partial | ❌ |
-| Red-team / security scenarios | ✅ | Partial | ❌ | ❌ |
-| Voice self-play (persona callers → realtime agent) | ✅ | ❌¹ | ❌ | ❌ |
-| Speech-emotion / paralinguistic checks | ✅ | ❌ | ❌ | ❌ |
-| Multimodal scenarios (audio + vision + video) | ✅ | Partial | ❌ | ❌ |
-| MCP integration | ✅ | ❌ | ❌ | ❌ |
-| Spec-driven (portable packs) | ✅ ([PromptPack](https://github.com/AltairaLabs/promptpack-spec)) | ❌ | ❌ | ❌ |
-| License | Apache 2.0 | MIT | Closed | Closed |
+| 100  | **74**  | 220   | 370   | 458   |
+| 500  | **210** | 688   | 903   | 1,229 |
+| 1000 | **348** | 1,331 | 1,024 | 2,355 |
+| 2000 | **607** | OOM   | 1,024 | 4,608 |
 
-<sub>¹ Promptfoo has a text-only [simulated user](https://www.promptfoo.dev/docs/providers/simulated-user/) and separate audio testing, but doesn't combine them — it can't drive a persona-driven caller through a realtime voice agent.</sub>
+**CPU utilization** (%, lower is better)
+
+| Concurrent | PromptKit | LangChain | Vercel AI | Strands |
+|---|---|---|---|---|
+| 100  | **29** | 67 | 54  | 54 |
+| 500  | **29** | 98 | 140 | 96 |
+| 1000 | **29** | 99 | 131 | 99 |
+| 2000 | **29** | —  | 115 | 99 |
+
+**Cost per million requests** (USD, lower is better)
+
+| Concurrent | PromptKit | LangChain | Vercel AI | Strands |
+|---|---|---|---|---|
+| 100  | **$0.03** | $0.14 | $0.06 | $0.09 |
+| 500  | **$0.03** | $0.11 | $0.05 | $0.08 |
+| 1000 | **$0.03** | $0.12 | $0.03 | $0.10 |
+| 2000 | **$0.03** | —     | $0.04 | $0.33 |
+
+PromptKit holds **~29% CPU and $0.03 per million requests from 100 concurrent
+all the way to 2000**, with memory growing linearly instead of exploding.
+LangChain OOMs at 2000; Strands uses **6.6× more memory** at 1000 concurrent.
+That flatness comes from bounded concurrency, a cross-call retry budget, and
+acquire-before-work back-pressure — not from cutting corners. The benchmark
+harness is in-tree and CI runs a perf-regression gate on every PR, so a
+throughput or memory regression fails the build.
+
+## Capabilities
+
+| | |
+|---|---|
+| **Providers** | One interface across capability types — **inference**, **speech-to-text**, **text-to-speech**, **embeddings**, and **image** — for OpenAI (Chat + Responses), Anthropic Claude, Google Gemini, Ollama, vLLM, Imagen, and VoyageAI, with structured error types |
+| **Platforms** | Run any provider on its direct vendor API or a hyperscaler **platform** with keyless auth — Azure, AWS Bedrock, or Google Vertex |
+| **Resilient streaming** | Three-layer back-pressure: bounded pre-first-chunk retry, per-provider retry budget (thundering-herd control), and a total in-flight semaphore |
+| **Tools & MCP** | Native tool calling with a real [Model Context Protocol](https://modelcontextprotocol.io) client for live tool execution |
+| **Agent-to-Agent (A2A)** | Multi-agent orchestration, discovery, and an A2A protocol server (`server/a2a`) |
+| **Workflow composition** | Event-driven state machines with orchestration modes and context carry-forward |
+| **Evals & guardrails** | Pluggable eval primitives (RAG, safety, quality) and inline guardrails that enforce in production |
+| **Voice / duplex** | Streaming STT + TTS stages and full-duplex realtime sessions (Gemini Live, OpenAI Realtime) with the same retry semantics as text |
+| **Multimodal** | Audio + vision + video inputs, plus image/media generation |
+| **Skills** | Native [AgentSkills.io](https://agentskills.io) support with progressive, demand-driven knowledge loading |
+| **Memory & state** | Conversation memory, a pluggable state store, and session recording / replay |
+| **Observability** | Direct-update Prometheus metrics (in-flight gauges, retry budgets, first-chunk latency) that don't drop under load |
 
 ## Install
 
 ```bash
-npm install -g @altairalabs/promptarena @altairalabs/packc
+go get github.com/AltairaLabs/PromptKit/sdk
 ```
 
-Building from source: see [CONTRIBUTING.md](./CONTRIBUTING.md).
+Requires Go 1.26+.
 
 ## Quick Start
 
-### 1. Create a project
+Embed a conversation in your Go application. Prompts, providers, and tools are
+loaded from a portable [PromptPack](https://github.com/AltairaLabs/promptpack-spec)
+(hand-written, or compiled from YAML with [`packc`](https://github.com/AltairaLabs/promptarena)):
 
-```bash
-promptarena init my-project --template iot-maintenance-demo
-cd my-project
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func main() {
+	conv, err := sdk.Open("./app.pack.json", "chat", sdk.WithModel("gpt-4o"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conv.Close()
+
+	resp, err := conv.Send(context.Background(), "Summarize the Q3 report.")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(resp.Text())
+}
 ```
 
-![init project](recordings/gifs/02-init-project.gif)
-
-### 2. Inspect configuration
-
-```bash
-promptarena config-inspect
-```
-
-![config overview](recordings/gifs/03-config-overview.gif)
-
-### 3. Run a test scenario
-
-```bash
-promptarena run --scenario scenarios/hardware-faults.scenario.yaml
-```
-
-![run scenario](recordings/gifs/05-run-scenario.gif)
-
-### 4. Red-team security testing
-
-```bash
-promptarena run --scenario scenarios/redteam-selfplay.scenario.yaml
-```
-
-![redteam test](recordings/gifs/06-redteam-test.gif)
-
-### 5. Review results
-
-```bash
-promptarena view
-```
-
-![view conversation](recordings/gifs/07-view-conversation.gif)
-
-### 6. Deploy with the SDK
-
-Compile prompts and run in your Go application:
-
-```bash
-packc compile -c config.arena.yaml -o app.pack.json
-```
-
-![sdk demo](recordings/gifs/08-sdk-demo.gif)
-
-## Voice-agent self-play
-
-You can't unit-test a voice agent — so PromptKit has AI personas *call it*. Synthetic, personality-driven callers (hostile, evasive, anxious) are driven through TTS into your realtime agent (Gemini Live, OpenAI Realtime), and structured assertions score whether it holds policy under pressure — never issuing an unauthorized refund, escalating when it should. It even checks the caller *sounds* angry (speech-emotion recognition), not just says angry words.
-
-Try it in one command — keyless, runs green out of the box:
-
-```bash
-promptarena init my-refund-demo --template voice-refund-demo
-cd my-refund-demo
-promptarena run --provider mock-duplex --ci   # no API keys needed
-```
-
-Swap in `--provider gemini-2-flash` or `openai-gpt4o-realtime` (plus TTS keys) to run it against a live voice agent — pass rates vary, and that variation is the test. Full breakdown: [voice-refund walkthrough](https://promptarena.altairalabs.ai/arena/examples/voice-refund-demo/).
-
-## Features
-
-| Feature | Description |
-|---------|-------------|
-| **Multi-Provider** | OpenAI, Anthropic, Google Gemini, Azure OpenAI, Ollama, vLLM |
-| **Skills** | Native [AgentSkills.io](https://agentskills.io) support — demand-driven knowledge loading with progressive disclosure |
-| **A2A Protocol** | Agent-to-Agent communication with multi-agent orchestration and discovery |
-| **Workflows** | Event-driven state machines with orchestration modes and context carry-forward |
-| **MCP Integration** | Native Model Context Protocol for real tool execution |
-| **Deploy Adapters** | Plan, apply, and manage deployments via pluggable adapter SDK |
-| **Self-Play Testing** | AI personas for adversarial and user simulation |
-| **Voice Self-Play** | Adversarial TTS personas stress-test realtime voice agents (Gemini Live, OpenAI Realtime), scored on behavior + speech-emotion |
-| **Red-Team** | Security testing with prompt injection detection |
-| **Tool Validation** | Mock or live tool call verification with three-level scoping |
-| **SDK Deployment** | Compile prompts to portable packs for production |
-
-## GitHub Actions
-
-The **PromptArena** and **PackC** CI/CD actions live in the
-[promptarena repo](https://github.com/AltairaLabs/promptarena):
-
-```yaml
-- uses: AltairaLabs/promptarena/.github/actions/promptarena-action@v1
-  with:
-    config-file: config.arena.yaml
-  env:
-    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-
-- uses: AltairaLabs/promptarena/.github/actions/packc-action@v1
-  with:
-    config-file: config.arena.yaml
-```
-
-See the [PromptArena docs](https://promptarena.altairalabs.ai) for full usage details.
+For streaming, tools, workflows, A2A, and duplex voice, see the
+[SDK documentation](https://promptkit.altairalabs.ai/sdk/).
 
 ## Repository Structure
 
 ```
 promptkit/
-├── sdk/               # Production SDK (conversations, workflows, A2A, skills)
-├── runtime/           # Shared runtime (providers, pipeline, tools, skills, a2a, deploy)
+├── sdk/               # Production SDK (Open/OpenDuplex/OpenWorkflow, capabilities, options)
+├── runtime/           # Core runtime (providers, pipeline, streaming, tools, mcp, a2a, voice, deploy)
 ├── pkg/               # Shared config and schema-validation packages
 ├── server/a2a/        # A2A protocol server module
 ├── tools/schema-gen/  # JSON Schema generator for config types
-├── examples/          # Example projects
+├── benchmarks/        # Efficiency/throughput harness vs LangChain, Vercel AI, Strands
+├── examples/          # SDK examples (A2A, logging config)
 └── docs/              # Documentation
 ```
+
+## Documentation
+
+Full docs at [promptkit.altairalabs.ai](https://promptkit.altairalabs.ai).
 
 ## Contributing
 


### PR DESCRIPTION
## Refocus the README on the runtime/SDK + performance

The README still read as a PromptArena landing page (CLI quick-start, red-team,
voice self-play, a prompt-testing comparison). This rewrites it around what the
repo actually is — the **Go runtime and SDK**.

- **Performance up top**: the in-tree efficiency benchmark (`make -C benchmarks round1-tools`) vs LangChain / Vercel AI / Strands — memory, CPU, and cost-per-million tables. PromptKit stays flat (~29% CPU, $0.03/M from 100→2000 concurrent); LangChain OOMs at 2000; Strands uses 6.6× more memory at 1000. Numbers from PR #919 / the *Bulletproofing Streaming LLM Calls* write-up.
- **Capabilities** table for the runtime: providers (inference/STT/TTS/embeddings/image) × platforms (Azure/Bedrock/Vertex), resilient streaming back-pressure, tools/MCP, A2A, workflow composition, evals/guardrails, voice/duplex, multimodal, skills, memory/state, observability, deploy adapters.
- Go install + a real `sdk.Open`/`conv.Send` (`resp.Text()`) quick start.
- Dropped the arena CLI content (lives in the promptarena repo, still linked).

> ⚠️ One thing to confirm: the blog link uses `https://altairalabs.ai/blog/streaming-llm-back-pressure` (inferred from the content slug) — check it resolves.
