### PR TITLE
test(gemini): un-hide stream-session pure logic from the coverage gate

### DIFF
--- a/runtime/providers/gemini/protocol.go
+++ b/runtime/providers/gemini/protocol.go
@@ -1,0 +1,62 @@
+package gemini
+
+import (
+	"encoding/json"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// handleToolCalls processes tool calls from the server.
+func (s *StreamSession) handleToolCalls(toolCall *ToolCallMsg) error {
+	toolCalls := make([]types.MessageToolCall, len(toolCall.FunctionCalls))
+	for i, fc := range toolCall.FunctionCalls {
+		argsJSON, err := json.Marshal(fc.Args)
+		if err != nil {
+			argsJSON = []byte("{}")
+		}
+		toolCalls[i] = types.MessageToolCall{
+			ID:   fc.ID,
+			Name: fc.Name,
+			Args: argsJSON,
+		}
+	}
+
+	finishReason := "tool_calls"
+	response := providers.StreamChunk{
+		ToolCalls:    toolCalls,
+		FinishReason: &finishReason,
+	}
+
+	if err := s.sendChunk(&response); err != nil {
+		return err
+	}
+	logger.Debug("Gemini tool calls emitted", "count", len(toolCalls))
+	return nil
+}
+
+// buildCostInfo creates cost information from usage metadata.
+func (s *StreamSession) buildCostInfo(usage *UsageMetadata) *types.CostInfo {
+	if usage == nil {
+		return nil
+	}
+
+	inputTokens := usage.PromptTokenCount
+	outputTokens := usage.ResponseTokenCount
+
+	var inputCostUSD, outputCostUSD, totalCost float64
+	if s.inputCostPer1K > 0 && s.outputCostPer1K > 0 {
+		inputCostUSD = float64(inputTokens) / tokensPerThousand * s.inputCostPer1K
+		outputCostUSD = float64(outputTokens) / tokensPerThousand * s.outputCostPer1K
+		totalCost = inputCostUSD + outputCostUSD
+	}
+
+	return &types.CostInfo{
+		InputTokens:   inputTokens,
+		OutputTokens:  outputTokens,
+		InputCostUSD:  inputCostUSD,
+		OutputCostUSD: outputCostUSD,
+		TotalCost:     totalCost,
+	}
+}

--- a/runtime/providers/gemini/protocol_test.go
+++ b/runtime/providers/gemini/protocol_test.go
@@ -1,0 +1,106 @@
+package gemini
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+func TestBuildCostInfo(t *testing.T) {
+	t.Run("nil usage returns nil", func(t *testing.T) {
+		s := &StreamSession{inputCostPer1K: 1, outputCostPer1K: 2}
+		if got := s.buildCostInfo(nil); got != nil {
+			t.Errorf("expected nil CostInfo for nil usage, got %+v", got)
+		}
+	})
+
+	t.Run("tokens populated but zero cost when rates unset", func(t *testing.T) {
+		s := &StreamSession{} // both rates zero
+		usage := &UsageMetadata{PromptTokenCount: 1000, ResponseTokenCount: 500}
+		got := s.buildCostInfo(usage)
+		if got == nil {
+			t.Fatal("expected non-nil CostInfo")
+		}
+		if got.InputTokens != 1000 || got.OutputTokens != 500 {
+			t.Errorf("tokens = %d/%d, want 1000/500", got.InputTokens, got.OutputTokens)
+		}
+		if got.InputCostUSD != 0 || got.OutputCostUSD != 0 || got.TotalCost != 0 {
+			t.Errorf("expected zero cost when rates unset, got %+v", got)
+		}
+	})
+
+	t.Run("cost skipped when only one rate is set", func(t *testing.T) {
+		s := &StreamSession{inputCostPer1K: 3.0} // outputCostPer1K == 0
+		got := s.buildCostInfo(&UsageMetadata{PromptTokenCount: 1000, ResponseTokenCount: 1000})
+		if got.TotalCost != 0 {
+			t.Errorf("expected zero cost when only input rate set, got %f", got.TotalCost)
+		}
+	})
+
+	t.Run("full billing math", func(t *testing.T) {
+		// 2000 input tokens @ $3/1K = $6.00; 1000 output @ $10/1K = $10.00
+		s := &StreamSession{inputCostPer1K: 3.0, outputCostPer1K: 10.0}
+		got := s.buildCostInfo(&UsageMetadata{PromptTokenCount: 2000, ResponseTokenCount: 1000})
+		if got.InputCostUSD != 6.0 {
+			t.Errorf("InputCostUSD = %f, want 6.0", got.InputCostUSD)
+		}
+		if got.OutputCostUSD != 10.0 {
+			t.Errorf("OutputCostUSD = %f, want 10.0", got.OutputCostUSD)
+		}
+		if got.TotalCost != 16.0 {
+			t.Errorf("TotalCost = %f, want 16.0", got.TotalCost)
+		}
+	})
+}
+
+func TestHandleToolCalls(t *testing.T) {
+	t.Run("FunctionCall maps to MessageToolCall with marshaled args", func(t *testing.T) {
+		s := &StreamSession{
+			ctx:    context.Background(),
+			emitCh: make(chan providers.StreamChunk, 4),
+		}
+		msg := &ToolCallMsg{FunctionCalls: []FunctionCall{
+			{ID: "call_1", Name: "lookup", Args: map[string]interface{}{"q": "hi"}},
+			{ID: "call_2", Name: "noargs"}, // nil Args -> "null"? see below
+		}}
+		if err := s.handleToolCalls(msg); err != nil {
+			t.Fatalf("handleToolCalls: %v", err)
+		}
+
+		chunk := <-s.emitCh
+		if chunk.FinishReason == nil || *chunk.FinishReason != "tool_calls" {
+			t.Errorf("FinishReason = %v, want tool_calls", chunk.FinishReason)
+		}
+		if len(chunk.ToolCalls) != 2 {
+			t.Fatalf("expected 2 tool calls, got %d", len(chunk.ToolCalls))
+		}
+		if chunk.ToolCalls[0].ID != "call_1" || chunk.ToolCalls[0].Name != "lookup" {
+			t.Errorf("call[0] = %+v", chunk.ToolCalls[0])
+		}
+		if string(chunk.ToolCalls[0].Args) != `{"q":"hi"}` {
+			t.Errorf("call[0].Args = %s, want {\"q\":\"hi\"}", chunk.ToolCalls[0].Args)
+		}
+		// nil map marshals to "null" (json.Marshal(nil map) == "null").
+		if string(chunk.ToolCalls[1].Args) != "null" {
+			t.Errorf("call[1].Args = %s, want null", chunk.ToolCalls[1].Args)
+		}
+	})
+
+	t.Run("empty args map marshals to {}", func(t *testing.T) {
+		s := &StreamSession{
+			ctx:    context.Background(),
+			emitCh: make(chan providers.StreamChunk, 1),
+		}
+		msg := &ToolCallMsg{FunctionCalls: []FunctionCall{
+			{ID: "c", Name: "n", Args: map[string]interface{}{}},
+		}}
+		if err := s.handleToolCalls(msg); err != nil {
+			t.Fatalf("handleToolCalls: %v", err)
+		}
+		chunk := <-s.emitCh
+		if string(chunk.ToolCalls[0].Args) != "{}" {
+			t.Errorf("Args = %s, want {}", chunk.ToolCalls[0].Args)
+		}
+	})
+}

--- a/runtime/providers/gemini/setup.go
+++ b/runtime/providers/gemini/setup.go
@@ -1,0 +1,179 @@
+package gemini
+
+import (
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+)
+
+// Wire-protocol field keys and modality values for the Gemini Live setup message.
+const (
+	modalityText = "TEXT"
+	wireKeyParts = "parts"
+	wireKeyText  = "text"
+	wireKeyName  = "name"
+	wireKeyModel = "model"
+)
+
+// getResponseModalities returns modalities with TEXT as default
+func getResponseModalities(modalities []string) []string {
+	if len(modalities) == 0 {
+		return []string{modalityText}
+	}
+	return modalities
+}
+
+// validateModalities checks for invalid modality combinations
+func validateModalities(modalities []string) error {
+	if len(modalities) > 1 && sliceContains(modalities, modalityText) && sliceContains(modalities, "AUDIO") {
+		return fmt.Errorf(
+			"invalid response modalities: Gemini Live API does not support TEXT and AUDIO " +
+				"simultaneously. Use either [\"TEXT\"] or [\"AUDIO\"], not both")
+	}
+	return nil
+}
+
+// buildSetupMessage constructs the initial setup message for Gemini Live API
+func buildSetupMessage(config *StreamSessionConfig, modalities []string) map[string]interface{} {
+	modelPath := getModelPath(config.Model)
+	generationConfig := buildGenerationConfig(modalities)
+
+	setupContent := map[string]interface{}{
+		wireKeyModel:       modelPath,
+		"generationConfig": generationConfig,
+	}
+
+	addTranscriptionConfig(setupContent, modalities)
+	addVADConfig(setupContent, config.VAD)
+	addSystemInstruction(setupContent, config.SystemInstruction)
+	addToolsConfig(setupContent, config.Tools)
+
+	return map[string]interface{}{
+		"setup": setupContent,
+	}
+}
+
+// getModelPath ensures model is in correct format: models/{model}
+func getModelPath(model string) string {
+	if model == "" {
+		return "models/gemini-2.0-flash-exp"
+	}
+	if len(model) < 7 || model[:7] != "models/" {
+		return "models/" + model
+	}
+	return model
+}
+
+// buildGenerationConfig creates the generation configuration
+func buildGenerationConfig(modalities []string) map[string]interface{} {
+	config := map[string]interface{}{
+		"responseModalities": modalities,
+	}
+
+	if sliceContains(modalities, "AUDIO") {
+		config["speechConfig"] = map[string]interface{}{
+			"voiceConfig": map[string]interface{}{
+				"prebuiltVoiceConfig": map[string]interface{}{
+					"voiceName": "Puck",
+				},
+			},
+		}
+	}
+
+	return config
+}
+
+// addTranscriptionConfig adds transcription settings for AUDIO mode
+func addTranscriptionConfig(setupContent map[string]interface{}, modalities []string) {
+	if sliceContains(modalities, "AUDIO") {
+		setupContent["outputAudioTranscription"] = map[string]interface{}{}
+		setupContent["inputAudioTranscription"] = map[string]interface{}{}
+	}
+}
+
+// addVADConfig adds VAD configuration if provided
+func addVADConfig(setupContent map[string]interface{}, vad *VADConfig) {
+	if vad == nil {
+		return
+	}
+
+	vadConfig := buildVADConfigMap(vad)
+	if len(vadConfig) > 0 {
+		setupContent["realtimeInputConfig"] = map[string]interface{}{
+			"automaticActivityDetection": vadConfig,
+		}
+		logger.Debug("Gemini VAD config added to setup", "vadConfig", vadConfig)
+	}
+}
+
+// buildVADConfigMap converts VADConfig to a map for the API
+func buildVADConfigMap(vad *VADConfig) map[string]interface{} {
+	vadConfig := map[string]interface{}{}
+
+	if vad.Disabled {
+		vadConfig["disabled"] = true
+		return vadConfig
+	}
+
+	if vad.StartOfSpeechSensitivity != "" {
+		vadConfig["startOfSpeechSensitivity"] = vad.StartOfSpeechSensitivity
+	}
+	if vad.EndOfSpeechSensitivity != "" {
+		vadConfig["endOfSpeechSensitivity"] = vad.EndOfSpeechSensitivity
+	}
+	if vad.PrefixPaddingMs > 0 {
+		vadConfig["prefixPaddingMs"] = vad.PrefixPaddingMs
+	}
+	if vad.SilenceThresholdMs > 0 {
+		vadConfig["silenceDurationMs"] = vad.SilenceThresholdMs
+	}
+
+	return vadConfig
+}
+
+// addSystemInstruction adds system instruction if provided
+func addSystemInstruction(setupContent map[string]interface{}, instruction string) {
+	if instruction != "" {
+		setupContent["systemInstruction"] = map[string]interface{}{
+			wireKeyParts: []map[string]interface{}{
+				{wireKeyText: instruction},
+			},
+		}
+	}
+}
+
+// addToolsConfig adds tools configuration if provided
+func addToolsConfig(setupContent map[string]interface{}, tools []ToolDefinition) {
+	if len(tools) == 0 {
+		return
+	}
+
+	functionDeclarations := make([]map[string]interface{}, len(tools))
+	for i, tool := range tools {
+		functionDeclarations[i] = buildFunctionDeclaration(tool)
+	}
+
+	setupContent["tools"] = []map[string]interface{}{
+		{"functionDeclarations": functionDeclarations},
+	}
+	logger.Debug("Gemini tools added to setup", "tool_count", len(tools))
+}
+
+// buildFunctionDeclaration converts a ToolDefinition to API format
+func buildFunctionDeclaration(tool ToolDefinition) map[string]interface{} {
+	funcDecl := map[string]interface{}{
+		wireKeyName: tool.Name,
+	}
+	if tool.Description != "" {
+		funcDecl["description"] = tool.Description
+	}
+	if len(tool.Parameters) > 0 {
+		funcDecl["parameters"] = tool.Parameters
+	}
+	return funcDecl
+}
+
+// isVADDisabled returns true if automatic VAD is disabled for this session.
+func (s *StreamSession) isVADDisabled() bool {
+	return s.config.VAD != nil && s.config.VAD.Disabled
+}

--- a/runtime/providers/gemini/setup_test.go
+++ b/runtime/providers/gemini/setup_test.go
@@ -1,0 +1,338 @@
+package gemini
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetResponseModalities(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty defaults to TEXT", nil, []string{"TEXT"}},
+		{"empty slice defaults to TEXT", []string{}, []string{"TEXT"}},
+		{"explicit AUDIO preserved", []string{"AUDIO"}, []string{"AUDIO"}},
+		{"explicit TEXT preserved", []string{"TEXT"}, []string{"TEXT"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getResponseModalities(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getResponseModalities(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateModalities(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		wantErr bool
+	}{
+		{"TEXT only ok", []string{"TEXT"}, false},
+		{"AUDIO only ok", []string{"AUDIO"}, false},
+		{"empty ok", nil, false},
+		{"TEXT+AUDIO rejected", []string{"TEXT", "AUDIO"}, true},
+		{"AUDIO+TEXT rejected", []string{"AUDIO", "TEXT"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateModalities(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateModalities(%v) err=%v, wantErr=%v", tt.in, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetModelPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty -> default", "", "models/gemini-2.0-flash-exp"},
+		{"bare name gets prefixed", "gemini-2.0-flash", "models/gemini-2.0-flash"},
+		{"already prefixed unchanged", "models/gemini-2.0-flash", "models/gemini-2.0-flash"},
+		{"short name gets prefixed", "abc", "models/abc"},
+		{"exactly models/ prefix preserved", "models/x", "models/x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getModelPath(tt.in); got != tt.want {
+				t.Errorf("getModelPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildGenerationConfig(t *testing.T) {
+	t.Run("TEXT has no speechConfig", func(t *testing.T) {
+		cfg := buildGenerationConfig([]string{"TEXT"})
+		if !reflect.DeepEqual(cfg["responseModalities"], []string{"TEXT"}) {
+			t.Errorf("responseModalities = %v", cfg["responseModalities"])
+		}
+		if _, ok := cfg["speechConfig"]; ok {
+			t.Error("expected no speechConfig for TEXT")
+		}
+	})
+
+	t.Run("AUDIO adds Puck speechConfig", func(t *testing.T) {
+		cfg := buildGenerationConfig([]string{"AUDIO"})
+		speech, ok := cfg["speechConfig"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected speechConfig for AUDIO")
+		}
+		voiceCfg, ok := speech["voiceConfig"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected voiceConfig")
+		}
+		prebuilt, ok := voiceCfg["prebuiltVoiceConfig"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected prebuiltVoiceConfig")
+		}
+		if prebuilt["voiceName"] != "Puck" {
+			t.Errorf("voiceName = %v, want Puck", prebuilt["voiceName"])
+		}
+	})
+}
+
+func TestAddTranscriptionConfig(t *testing.T) {
+	t.Run("TEXT adds nothing", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addTranscriptionConfig(content, []string{"TEXT"})
+		if len(content) != 0 {
+			t.Errorf("expected no transcription keys for TEXT, got %v", content)
+		}
+	})
+
+	t.Run("AUDIO adds input+output transcription", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addTranscriptionConfig(content, []string{"AUDIO"})
+		if _, ok := content["outputAudioTranscription"]; !ok {
+			t.Error("expected outputAudioTranscription key")
+		}
+		if _, ok := content["inputAudioTranscription"]; !ok {
+			t.Error("expected inputAudioTranscription key")
+		}
+	})
+}
+
+func TestAddVADConfig(t *testing.T) {
+	t.Run("nil VAD adds nothing", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addVADConfig(content, nil)
+		if len(content) != 0 {
+			t.Errorf("expected no keys for nil VAD, got %v", content)
+		}
+	})
+
+	t.Run("empty VAD (no fields) adds nothing", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addVADConfig(content, &VADConfig{})
+		if len(content) != 0 {
+			t.Errorf("expected no realtimeInputConfig when VAD map is empty, got %v", content)
+		}
+	})
+
+	t.Run("populated VAD nests under automaticActivityDetection", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addVADConfig(content, &VADConfig{StartOfSpeechSensitivity: "HIGH"})
+		ric, ok := content["realtimeInputConfig"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected realtimeInputConfig")
+		}
+		aad, ok := ric["automaticActivityDetection"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected automaticActivityDetection")
+		}
+		if aad["startOfSpeechSensitivity"] != "HIGH" {
+			t.Errorf("startOfSpeechSensitivity = %v", aad["startOfSpeechSensitivity"])
+		}
+	})
+}
+
+func TestBuildVADConfigMap(t *testing.T) {
+	t.Run("disabled short-circuits with only disabled flag", func(t *testing.T) {
+		got := buildVADConfigMap(&VADConfig{
+			Disabled:                 true,
+			StartOfSpeechSensitivity: "HIGH", // must be ignored
+			PrefixPaddingMs:          100,    // must be ignored
+		})
+		want := map[string]interface{}{"disabled": true}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("buildVADConfigMap disabled = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("all optional numeric/string fields mapped with exact keys", func(t *testing.T) {
+		got := buildVADConfigMap(&VADConfig{
+			StartOfSpeechSensitivity: "LOW",
+			EndOfSpeechSensitivity:   "MEDIUM",
+			PrefixPaddingMs:          200,
+			SilenceThresholdMs:       500,
+		})
+		want := map[string]interface{}{
+			"startOfSpeechSensitivity": "LOW",
+			"endOfSpeechSensitivity":   "MEDIUM",
+			"prefixPaddingMs":          200,
+			// SilenceThresholdMs maps to Gemini's silenceDurationMs
+			"silenceDurationMs": 500,
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("buildVADConfigMap = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("zero-value optionals omitted", func(t *testing.T) {
+		got := buildVADConfigMap(&VADConfig{})
+		if len(got) != 0 {
+			t.Errorf("expected empty map for zero-value VAD, got %v", got)
+		}
+	})
+
+	t.Run("only non-empty fields included", func(t *testing.T) {
+		got := buildVADConfigMap(&VADConfig{EndOfSpeechSensitivity: "HIGH"})
+		want := map[string]interface{}{"endOfSpeechSensitivity": "HIGH"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
+func TestAddSystemInstruction(t *testing.T) {
+	t.Run("empty adds nothing", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addSystemInstruction(content, "")
+		if len(content) != 0 {
+			t.Errorf("expected no key for empty instruction, got %v", content)
+		}
+	})
+
+	t.Run("non-empty nests parts[].text", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addSystemInstruction(content, "be helpful")
+		si, ok := content["systemInstruction"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected systemInstruction")
+		}
+		parts, ok := si["parts"].([]map[string]interface{})
+		if !ok || len(parts) != 1 {
+			t.Fatalf("expected 1 part, got %v", si["parts"])
+		}
+		if parts[0]["text"] != "be helpful" {
+			t.Errorf("text = %v", parts[0]["text"])
+		}
+	})
+}
+
+func TestAddToolsConfig(t *testing.T) {
+	t.Run("no tools adds nothing", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addToolsConfig(content, nil)
+		if len(content) != 0 {
+			t.Errorf("expected no key for empty tools, got %v", content)
+		}
+	})
+
+	t.Run("tools nest under functionDeclarations", func(t *testing.T) {
+		content := map[string]interface{}{}
+		addToolsConfig(content, []ToolDefinition{
+			{Name: "a"},
+			{Name: "b", Description: "does b"},
+		})
+		tools, ok := content["tools"].([]map[string]interface{})
+		if !ok || len(tools) != 1 {
+			t.Fatalf("expected 1 tools entry, got %v", content["tools"])
+		}
+		decls, ok := tools[0]["functionDeclarations"].([]map[string]interface{})
+		if !ok || len(decls) != 2 {
+			t.Fatalf("expected 2 function declarations, got %v", tools[0]["functionDeclarations"])
+		}
+		if decls[0]["name"] != "a" || decls[1]["name"] != "b" {
+			t.Errorf("declaration names = %v, %v", decls[0]["name"], decls[1]["name"])
+		}
+	})
+}
+
+func TestBuildFunctionDeclaration(t *testing.T) {
+	t.Run("name only", func(t *testing.T) {
+		got := buildFunctionDeclaration(ToolDefinition{Name: "search"})
+		if got["name"] != "search" {
+			t.Errorf("name = %v", got["name"])
+		}
+		if _, ok := got["description"]; ok {
+			t.Error("expected no description key")
+		}
+		if _, ok := got["parameters"]; ok {
+			t.Error("expected no parameters key")
+		}
+	})
+
+	t.Run("with description and parameters", func(t *testing.T) {
+		params := map[string]interface{}{"type": "object"}
+		got := buildFunctionDeclaration(ToolDefinition{
+			Name:        "search",
+			Description: "search the web",
+			Parameters:  params,
+		})
+		if got["description"] != "search the web" {
+			t.Errorf("description = %v", got["description"])
+		}
+		if !reflect.DeepEqual(got["parameters"], params) {
+			t.Errorf("parameters = %v", got["parameters"])
+		}
+	})
+
+	t.Run("empty parameters map omitted", func(t *testing.T) {
+		got := buildFunctionDeclaration(ToolDefinition{
+			Name:       "n",
+			Parameters: map[string]interface{}{},
+		})
+		if _, ok := got["parameters"]; ok {
+			t.Error("expected empty parameters map to be omitted")
+		}
+	})
+}
+
+func TestBuildSetupMessage(t *testing.T) {
+	t.Run("minimal TEXT config", func(t *testing.T) {
+		msg := buildSetupMessage(&StreamSessionConfig{Model: "gemini-2.0-flash"}, []string{"TEXT"})
+		setup, ok := msg["setup"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected setup key")
+		}
+		if setup["model"] != "models/gemini-2.0-flash" {
+			t.Errorf("model = %v", setup["model"])
+		}
+		if _, ok := setup["generationConfig"]; !ok {
+			t.Error("expected generationConfig")
+		}
+		// TEXT should not add transcription/tools/system instruction
+		for _, k := range []string{"outputAudioTranscription", "tools", "systemInstruction", "realtimeInputConfig"} {
+			if _, ok := setup[k]; ok {
+				t.Errorf("did not expect key %q for minimal TEXT config", k)
+			}
+		}
+	})
+
+	t.Run("full AUDIO config wires every section", func(t *testing.T) {
+		msg := buildSetupMessage(&StreamSessionConfig{
+			Model:             "gemini-live",
+			SystemInstruction: "be nice",
+			VAD:               &VADConfig{SilenceThresholdMs: 700},
+			Tools:             []ToolDefinition{{Name: "t"}},
+		}, []string{"AUDIO"})
+		setup := msg["setup"].(map[string]interface{})
+		for _, k := range []string{
+			"model", "generationConfig", "outputAudioTranscription",
+			"inputAudioTranscription", "systemInstruction", "tools", "realtimeInputConfig",
+		} {
+			if _, ok := setup[k]; !ok {
+				t.Errorf("expected key %q in full AUDIO setup", k)
+			}
+		}
+	})
+}

--- a/runtime/providers/gemini/stream_session_integration.go
+++ b/runtime/providers/gemini/stream_session_integration.go
@@ -168,24 +168,6 @@ func NewStreamSession(ctx context.Context, wsURL, apiKey string, config *StreamS
 	return session, nil
 }
 
-// getResponseModalities returns modalities with TEXT as default
-func getResponseModalities(modalities []string) []string {
-	if len(modalities) == 0 {
-		return []string{"TEXT"}
-	}
-	return modalities
-}
-
-// validateModalities checks for invalid modality combinations
-func validateModalities(modalities []string) error {
-	if len(modalities) > 1 && sliceContains(modalities, "TEXT") && sliceContains(modalities, "AUDIO") {
-		return fmt.Errorf(
-			"invalid response modalities: Gemini Live API does not support TEXT and AUDIO " +
-				"simultaneously. Use either [\"TEXT\"] or [\"AUDIO\"], not both")
-	}
-	return nil
-}
-
 // createSession creates a new StreamSession with the given configuration
 func createSession(
 	ctx context.Context,
@@ -217,146 +199,6 @@ func createSession(
 		autoReconnect:     config.AutoReconnect,
 		maxReconnectTries: maxReconnectTries,
 	}
-}
-
-// buildSetupMessage constructs the initial setup message for Gemini Live API
-func buildSetupMessage(config *StreamSessionConfig, modalities []string) map[string]interface{} {
-	modelPath := getModelPath(config.Model)
-	generationConfig := buildGenerationConfig(modalities)
-
-	setupContent := map[string]interface{}{
-		"model":            modelPath,
-		"generationConfig": generationConfig,
-	}
-
-	addTranscriptionConfig(setupContent, modalities)
-	addVADConfig(setupContent, config.VAD)
-	addSystemInstruction(setupContent, config.SystemInstruction)
-	addToolsConfig(setupContent, config.Tools)
-
-	return map[string]interface{}{
-		"setup": setupContent,
-	}
-}
-
-// getModelPath ensures model is in correct format: models/{model}
-func getModelPath(model string) string {
-	if model == "" {
-		return "models/gemini-2.0-flash-exp"
-	}
-	if len(model) < 7 || model[:7] != "models/" {
-		return "models/" + model
-	}
-	return model
-}
-
-// buildGenerationConfig creates the generation configuration
-func buildGenerationConfig(modalities []string) map[string]interface{} {
-	config := map[string]interface{}{
-		"responseModalities": modalities,
-	}
-
-	if sliceContains(modalities, "AUDIO") {
-		config["speechConfig"] = map[string]interface{}{
-			"voiceConfig": map[string]interface{}{
-				"prebuiltVoiceConfig": map[string]interface{}{
-					"voiceName": "Puck",
-				},
-			},
-		}
-	}
-
-	return config
-}
-
-// addTranscriptionConfig adds transcription settings for AUDIO mode
-func addTranscriptionConfig(setupContent map[string]interface{}, modalities []string) {
-	if sliceContains(modalities, "AUDIO") {
-		setupContent["outputAudioTranscription"] = map[string]interface{}{}
-		setupContent["inputAudioTranscription"] = map[string]interface{}{}
-	}
-}
-
-// addVADConfig adds VAD configuration if provided
-func addVADConfig(setupContent map[string]interface{}, vad *VADConfig) {
-	if vad == nil {
-		return
-	}
-
-	vadConfig := buildVADConfigMap(vad)
-	if len(vadConfig) > 0 {
-		setupContent["realtimeInputConfig"] = map[string]interface{}{
-			"automaticActivityDetection": vadConfig,
-		}
-		logger.Debug("Gemini VAD config added to setup", "vadConfig", vadConfig)
-	}
-}
-
-// buildVADConfigMap converts VADConfig to a map for the API
-func buildVADConfigMap(vad *VADConfig) map[string]interface{} {
-	vadConfig := map[string]interface{}{}
-
-	if vad.Disabled {
-		vadConfig["disabled"] = true
-		return vadConfig
-	}
-
-	if vad.StartOfSpeechSensitivity != "" {
-		vadConfig["startOfSpeechSensitivity"] = vad.StartOfSpeechSensitivity
-	}
-	if vad.EndOfSpeechSensitivity != "" {
-		vadConfig["endOfSpeechSensitivity"] = vad.EndOfSpeechSensitivity
-	}
-	if vad.PrefixPaddingMs > 0 {
-		vadConfig["prefixPaddingMs"] = vad.PrefixPaddingMs
-	}
-	if vad.SilenceThresholdMs > 0 {
-		vadConfig["silenceDurationMs"] = vad.SilenceThresholdMs
-	}
-
-	return vadConfig
-}
-
-// addSystemInstruction adds system instruction if provided
-func addSystemInstruction(setupContent map[string]interface{}, instruction string) {
-	if instruction != "" {
-		setupContent["systemInstruction"] = map[string]interface{}{
-			"parts": []map[string]interface{}{
-				{"text": instruction},
-			},
-		}
-	}
-}
-
-// addToolsConfig adds tools configuration if provided
-func addToolsConfig(setupContent map[string]interface{}, tools []ToolDefinition) {
-	if len(tools) == 0 {
-		return
-	}
-
-	functionDeclarations := make([]map[string]interface{}, len(tools))
-	for i, tool := range tools {
-		functionDeclarations[i] = buildFunctionDeclaration(tool)
-	}
-
-	setupContent["tools"] = []map[string]interface{}{
-		{"functionDeclarations": functionDeclarations},
-	}
-	logger.Debug("Gemini tools added to setup", "tool_count", len(tools))
-}
-
-// buildFunctionDeclaration converts a ToolDefinition to API format
-func buildFunctionDeclaration(tool ToolDefinition) map[string]interface{} {
-	funcDecl := map[string]interface{}{
-		"name": tool.Name,
-	}
-	if tool.Description != "" {
-		funcDecl["description"] = tool.Description
-	}
-	if len(tool.Parameters) > 0 {
-		funcDecl["parameters"] = tool.Parameters
-	}
-	return funcDecl
 }
 
 // logSetupMessage logs the setup message at debug level
@@ -558,11 +400,6 @@ func (s *StreamSession) sendActivityEnd() error {
 
 	logger.Debug("Gemini StreamSession: sending activityEnd")
 	return ws.Send(msg)
-}
-
-// isVADDisabled returns true if automatic VAD is disabled for this session.
-func (s *StreamSession) isVADDisabled() bool {
-	return s.config.VAD != nil && s.config.VAD.Disabled
 }
 
 // EndInput implements the EndInputter interface expected by DuplexProviderStage.

--- a/runtime/providers/gemini/stream_session_protocol_integration.go
+++ b/runtime/providers/gemini/stream_session_protocol_integration.go
@@ -189,59 +189,6 @@ func (s *StreamSession) processServerMessage(msg *ServerMessage) error {
 	return s.processServerContent(msg.ServerContent, costInfo)
 }
 
-// handleToolCalls processes tool calls from the server.
-func (s *StreamSession) handleToolCalls(toolCall *ToolCallMsg) error {
-	toolCalls := make([]types.MessageToolCall, len(toolCall.FunctionCalls))
-	for i, fc := range toolCall.FunctionCalls {
-		argsJSON, err := json.Marshal(fc.Args)
-		if err != nil {
-			argsJSON = []byte("{}")
-		}
-		toolCalls[i] = types.MessageToolCall{
-			ID:   fc.ID,
-			Name: fc.Name,
-			Args: argsJSON,
-		}
-	}
-
-	finishReason := "tool_calls"
-	response := providers.StreamChunk{
-		ToolCalls:    toolCalls,
-		FinishReason: &finishReason,
-	}
-
-	if err := s.sendChunk(&response); err != nil {
-		return err
-	}
-	logger.Debug("Gemini tool calls emitted", "count", len(toolCalls))
-	return nil
-}
-
-// buildCostInfo creates cost information from usage metadata.
-func (s *StreamSession) buildCostInfo(usage *UsageMetadata) *types.CostInfo {
-	if usage == nil {
-		return nil
-	}
-
-	inputTokens := usage.PromptTokenCount
-	outputTokens := usage.ResponseTokenCount
-
-	var inputCostUSD, outputCostUSD, totalCost float64
-	if s.inputCostPer1K > 0 && s.outputCostPer1K > 0 {
-		inputCostUSD = float64(inputTokens) / tokensPerThousand * s.inputCostPer1K
-		outputCostUSD = float64(outputTokens) / tokensPerThousand * s.outputCostPer1K
-		totalCost = inputCostUSD + outputCostUSD
-	}
-
-	return &types.CostInfo{
-		InputTokens:   inputTokens,
-		OutputTokens:  outputTokens,
-		InputCostUSD:  inputCostUSD,
-		OutputCostUSD: outputCostUSD,
-		TotalCost:     totalCost,
-	}
-}
-
 // sendCostInfoIfPresent sends a chunk with cost info if present.
 func (s *StreamSession) sendCostInfoIfPresent(costInfo *types.CostInfo) error {
 	if costInfo == nil {

--- a/runtime/providers/gemini/stream_session_test.go
+++ b/runtime/providers/gemini/stream_session_test.go
@@ -1235,8 +1235,30 @@ func TestProcessServerMessage_ToolCall(t *testing.T) {
 	}
 	defer session.Close()
 
-	// Tool calls are currently no-op, just verify no error
-	time.Sleep(200 * time.Millisecond)
+	// The tool call must surface as a StreamChunk with a populated ToolCalls
+	// slice and finish_reason=tool_calls, with the FunctionCall args marshaled
+	// back to JSON.
+	select {
+	case chunk := <-session.Response():
+		if chunk.FinishReason == nil || *chunk.FinishReason != "tool_calls" {
+			t.Errorf("Expected finish_reason=tool_calls, got %v", chunk.FinishReason)
+		}
+		if len(chunk.ToolCalls) != 1 {
+			t.Fatalf("Expected 1 tool call, got %d", len(chunk.ToolCalls))
+		}
+		tc := chunk.ToolCalls[0]
+		if tc.ID != "call_1" {
+			t.Errorf("Expected tool call ID call_1, got %q", tc.ID)
+		}
+		if tc.Name != "test_function" {
+			t.Errorf("Expected tool call name test_function, got %q", tc.Name)
+		}
+		if string(tc.Args) != `{"arg":"value"}` {
+			t.Errorf("Expected args {\"arg\":\"value\"}, got %s", tc.Args)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for tool call chunk")
+	}
 }
 
 func TestStreamSessionConstants(t *testing.T) {

--- a/runtime/providers/gemini/stream_session_tools_integration.go
+++ b/runtime/providers/gemini/stream_session_tools_integration.go
@@ -47,35 +47,7 @@ func (s *StreamSession) SendToolResponses(ctx context.Context, responses []provi
 	}
 	s.mu.Unlock()
 
-	// Build Gemini's BidiGenerateContentToolResponse format
-	// Per docs: toolResponse.functionResponses[].{id, name, response}
-	functionResponses := make([]map[string]interface{}, len(responses))
-	for i, resp := range responses {
-		// Parse result as JSON if possible, otherwise wrap as string
-		var resultObj interface{}
-		if err := json.Unmarshal([]byte(resp.Result), &resultObj); err != nil {
-			// Result is not valid JSON, wrap it
-			resultObj = map[string]interface{}{"result": resp.Result}
-		}
-
-		funcResp := map[string]interface{}{
-			"id":       resp.ToolCallID,
-			"response": resultObj,
-		}
-
-		// Add error flag if the tool execution failed
-		if resp.IsError {
-			funcResp["error"] = true
-		}
-
-		functionResponses[i] = funcResp
-	}
-
-	msg := map[string]interface{}{
-		"toolResponse": map[string]interface{}{
-			"functionResponses": functionResponses,
-		},
-	}
+	msg := buildToolResponseMessage(responses)
 
 	// Log tool response for debugging
 	if logger.DefaultLogger != nil {

--- a/runtime/providers/gemini/stream_session_types.go
+++ b/runtime/providers/gemini/stream_session_types.go
@@ -1,7 +1,5 @@
 package gemini
 
-import "encoding/json"
-
 // ServerMessage represents a message from the Gemini server (BidiGenerateContentServerMessage)
 type ServerMessage struct {
 	SetupComplete *SetupComplete `json:"setupComplete,omitempty"`
@@ -65,15 +63,4 @@ type Part struct {
 type InlineData struct {
 	MimeType string `json:"mimeType,omitempty"` // camelCase!
 	Data     string `json:"data,omitempty"`     // Base64 encoded
-}
-
-// UnmarshalJSON unmarshals ServerMessage from JSON with custom handling.
-func (s *ServerMessage) UnmarshalJSON(data []byte) error {
-	type Alias ServerMessage
-	aux := &struct {
-		*Alias
-	}{
-		Alias: (*Alias)(s),
-	}
-	return json.Unmarshal(data, aux)
 }

--- a/runtime/providers/gemini/tools.go
+++ b/runtime/providers/gemini/tools.go
@@ -1,0 +1,53 @@
+package gemini
+
+import (
+	"encoding/json"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// Wire-protocol field keys for the Gemini Live tool-response message.
+const (
+	wireKeyResult   = "result"
+	wireKeyResponse = "response"
+)
+
+// buildToolResponseMessage constructs Gemini's BidiGenerateContentToolResponse
+// wire message from a set of tool execution results.
+//
+// Per the Gemini docs the shape is:
+//
+//	{ "toolResponse": { "functionResponses": [ { id, response, [error] }, ... ] } }
+//
+// Each result string is parsed as JSON when possible so the model receives a
+// structured object; a non-JSON string is wrapped as {"result": "<string>"}.
+// A failed tool execution (IsError) sets "error": true on its entry.
+func buildToolResponseMessage(responses []providers.ToolResponse) map[string]interface{} {
+	functionResponses := make([]map[string]interface{}, len(responses))
+	for i, resp := range responses {
+		// Parse result as JSON if possible, otherwise wrap as string
+		var resultObj interface{}
+		if err := json.Unmarshal([]byte(resp.Result), &resultObj); err != nil {
+			// Result is not valid JSON, wrap it
+			resultObj = map[string]interface{}{wireKeyResult: resp.Result}
+		}
+
+		funcResp := map[string]interface{}{
+			"id":            resp.ToolCallID,
+			wireKeyResponse: resultObj,
+		}
+
+		// Add error flag if the tool execution failed
+		if resp.IsError {
+			funcResp["error"] = true
+		}
+
+		functionResponses[i] = funcResp
+	}
+
+	return map[string]interface{}{
+		"toolResponse": map[string]interface{}{
+			"functionResponses": functionResponses,
+		},
+	}
+}

--- a/runtime/providers/gemini/tools_test.go
+++ b/runtime/providers/gemini/tools_test.go
@@ -1,0 +1,88 @@
+package gemini
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+func TestBuildToolResponseMessage(t *testing.T) {
+	// unwrap navigates toolResponse.functionResponses[i].
+	unwrap := func(t *testing.T, msg map[string]interface{}) []map[string]interface{} {
+		t.Helper()
+		tr, ok := msg["toolResponse"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected toolResponse key, got %v", msg)
+		}
+		frs, ok := tr["functionResponses"].([]map[string]interface{})
+		if !ok {
+			t.Fatalf("expected functionResponses slice, got %v", tr["functionResponses"])
+		}
+		return frs
+	}
+
+	t.Run("JSON result is parsed into a structured object", func(t *testing.T) {
+		msg := buildToolResponseMessage([]providers.ToolResponse{
+			{ToolCallID: "id1", Result: `{"temp":72,"unit":"F"}`},
+		})
+		frs := unwrap(t, msg)
+		if len(frs) != 1 {
+			t.Fatalf("expected 1 response, got %d", len(frs))
+		}
+		if frs[0]["id"] != "id1" {
+			t.Errorf("id = %v", frs[0]["id"])
+		}
+		resp, ok := frs[0]["response"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected parsed object response, got %T", frs[0]["response"])
+		}
+		// JSON numbers decode to float64
+		if resp["temp"].(float64) != 72 || resp["unit"] != "F" {
+			t.Errorf("parsed response = %v", resp)
+		}
+		if _, ok := frs[0]["error"]; ok {
+			t.Error("expected no error key for successful result")
+		}
+	})
+
+	t.Run("non-JSON string is wrapped as {result: ...}", func(t *testing.T) {
+		msg := buildToolResponseMessage([]providers.ToolResponse{
+			{ToolCallID: "id2", Result: "plain text"},
+		})
+		frs := unwrap(t, msg)
+		want := map[string]interface{}{"result": "plain text"}
+		if !reflect.DeepEqual(frs[0]["response"], want) {
+			t.Errorf("response = %v, want %v", frs[0]["response"], want)
+		}
+	})
+
+	t.Run("IsError sets error:true", func(t *testing.T) {
+		msg := buildToolResponseMessage([]providers.ToolResponse{
+			{ToolCallID: "id3", Result: "boom", IsError: true},
+		})
+		frs := unwrap(t, msg)
+		if frs[0]["error"] != true {
+			t.Errorf("expected error:true, got %v", frs[0]["error"])
+		}
+	})
+
+	t.Run("multiple parallel responses preserve order", func(t *testing.T) {
+		msg := buildToolResponseMessage([]providers.ToolResponse{
+			{ToolCallID: "a", Result: "1"},
+			{ToolCallID: "b", Result: "2"},
+		})
+		frs := unwrap(t, msg)
+		if len(frs) != 2 || frs[0]["id"] != "a" || frs[1]["id"] != "b" {
+			t.Errorf("responses = %v", frs)
+		}
+	})
+
+	t.Run("empty input yields empty slice", func(t *testing.T) {
+		msg := buildToolResponseMessage(nil)
+		frs := unwrap(t, msg)
+		if len(frs) != 0 {
+			t.Errorf("expected empty functionResponses, got %v", frs)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Files named `*_integration.go` are **exempted from the 80% coverage gate**
(SonarCloud + pre-commit hook, by filename only — no build tags, they compile
normally). In `runtime/providers/gemini/` several of these files carried
substantial **pure, testable logic** that was riding along untested behind the
suffix. This PR extracts that logic into gated `.go` siblings with unit tests,
so it actually counts toward coverage, and keeps only the thin live-socket glue
in the `_integration.go` files.

## Changes

**`setup.go` (new, gated)** — extracted the pure Gemini Live setup-message
builders out of `stream_session_integration.go`:
`buildSetupMessage`, `getModelPath`, `buildGenerationConfig`,
`addTranscriptionConfig`, `addVADConfig`, `buildVADConfigMap`,
`addSystemInstruction`, `addToolsConfig`, `buildFunctionDeclaration`,
`getResponseModalities`, `validateModalities`, `isVADDisabled`.
`setup_test.go` table-tests each, asserting **exact wire keys and casing**:
- `SilenceThresholdMs` maps to Gemini's `silenceDurationMs` (not a 1:1 name)
- VAD `disabled: true` short-circuits and drops all other fields
- AUDIO modality adds the `Puck` `prebuiltVoiceConfig` + `inputAudioTranscription`/`outputAudioTranscription`
- `getModelPath` empty→`models/gemini-2.0-flash-exp`, bare name→`models/`-prefixed, already-prefixed unchanged
- `TEXT`+`AUDIO` together is rejected

**`protocol.go` (new, gated)** — extracted `buildCostInfo` and
`handleToolCalls` out of `stream_session_protocol_integration.go`.
`protocol_test.go` covers, via the buffered-`emitCh` pattern:
- `buildCostInfo` token→USD **billing math** (previously **zero tests**): nil-usage→nil, cost stays 0 when either rate is unset, full math (2000 in @ $3/1K + 1000 out @ $10/1K = $16.00)
- `handleToolCalls` `FunctionCall`→`types.MessageToolCall` with args marshaled (`{"q":"hi"}`, empty map→`{}`, nil map→`null`) and `finish_reason=tool_calls`

**`tools.go` (new, gated)** — extracted the pure
`buildToolResponseMessage([]providers.ToolResponse) map[...]` out of
`stream_session_tools_integration.go` (the thin `s.ws.Send(msg)` wrapper +
logging stay behind). `tools_test.go` covers JSON-result-parsed-to-object
vs non-JSON-string-wrapped-as-`{"result": ...}`, and `IsError`→`error:true`.

**`stream_session_types_integration.go` → `stream_session_types.go`** — pure
type declarations that never needed the suffix. Also **deleted the redundant
no-op `ServerMessage.UnmarshalJSON`** (an `Alias` round-trip that added no
fields — default unmarshaling is byte-identical; all mock-server marshal/unmarshal
tests still pass).

Also **strengthened `TestProcessServerMessage_ToolCall`** to assert the emitted
`ToolCalls` (id/name/args) instead of just "no error", and named the moved wire
keys as constants to satisfy `goconst` on the new files.

## Verified behaviors
- Wire keys/casing exactly as the Gemini Live API expects (see `setup_test.go`).
- Billing: cost only computed when **both** rates are set; otherwise tokens are
  reported with zero cost. No bugs found — the extracted logic is faithful.

## Coverage (new gated files)
- `setup.go`: **100.0%**
- `protocol.go`: **90.9%** (`buildCostInfo` 100%, `handleToolCalls` ~83%)
- `tools.go`: **100.0%**

## Tests
`go -C runtime test -race -count=1 ./providers/gemini/...` — green.
