### PR TITLE
test(openai): extract pure logic from *_integration.go into gated, tested siblings

### DIFF
--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -54,58 +54,6 @@ const (
 // APIMode represents the OpenAI API mode to use
 type APIMode string
 
-// requiresResponsesAPI returns true if the model is only served by the Responses
-// API. OpenAI's "pro" reasoning models (o1-pro, gpt-5-pro, gpt-5.2-pro, ...) all
-// 404 on v1/chat/completions and must use v1/responses. This is a genuine,
-// OpenAI-defined model property (not a behavior we can default), so it's keyed
-// off the "-pro" suffix that those models share rather than enumerated one by one.
-func requiresResponsesAPI(model string) bool {
-	return strings.HasSuffix(model, "-pro")
-}
-
-// transformToResponsesCallID converts a call ID to Responses API format.
-// The Responses API requires function call IDs to start with 'fc_'.
-// Chat Completions API uses 'call_' prefix which must be transformed.
-func transformToResponsesCallID(callID string) string {
-	// If already in Responses format, return as-is
-	if strings.HasPrefix(callID, "fc_") {
-		return callID
-	}
-	// Transform call_ prefix to fc_ prefix
-	if strings.HasPrefix(callID, "call_") {
-		return "fc_" + strings.TrimPrefix(callID, "call_")
-	}
-	// For any other format, add fc_ prefix
-	return "fc_" + callID
-}
-
-// getAPIMode determines which OpenAI API to use. Priority:
-//  1. Explicit config (additional_config.api_mode) — data-driven, always wins.
-//  2. requiresResponsesAPI fallback — for Responses-only models when the
-//     config doesn't declare a mode.
-//  3. Default to the legacy Chat Completions API.
-//
-// Config-first ordering means a provider config is the source of truth; the
-// model-name heuristic is only a best-effort default for undeclared configs.
-func getAPIMode(model string, additionalConfig map[string]any) APIMode {
-	if additionalConfig != nil {
-		if mode, ok := additionalConfig["api_mode"].(string); ok {
-			switch strings.ToLower(mode) {
-			case "completions", "chat_completions", "legacy":
-				return APIModeCompletions
-			case "responses":
-				return APIModeResponses
-			}
-		}
-	}
-
-	if requiresResponsesAPI(model) {
-		return APIModeResponses
-	}
-
-	return APIModeCompletions
-}
-
 // Responses API response structures
 
 // responsesResponse represents the response from the Responses API
@@ -237,189 +185,6 @@ func (p *Provider) buildResponsesRequest(req providers.PredictionRequest, tools 
 	}
 
 	return responsesReq
-}
-
-// convertMessagesToResponsesInput converts messages to Responses API input format
-// The Responses API expects a flat list where tool calls are separate function_call items
-func (p *Provider) convertMessagesToResponsesInput(messages []types.Message) []any {
-	// Allocate extra capacity for tool calls which become separate items
-	const toolCallCapacityMultiplier = 2
-	input := make([]any, 0, len(messages)*toolCallCapacityMultiplier)
-	for i := range messages {
-		items := p.convertSingleMessageToResponsesInput(&messages[i])
-		for _, item := range items {
-			input = append(input, item)
-		}
-	}
-	return input
-}
-
-// convertSingleMessageToResponsesInput converts a single message to Responses API format
-// Returns a slice because assistant messages with tool calls become multiple items
-func (p *Provider) convertSingleMessageToResponsesInput(msg *types.Message) []map[string]any {
-	// Handle tool results - these are function_call_output items
-	// NOTE: The Responses API only supports text output for function_call_output.
-	// Multimodal tool results (images, audio) are reduced to text here.
-	// Use the Chat Completions API for full multimodal tool result support.
-	if msg.Role == roleToolResult && msg.ToolResult != nil {
-		// call_id must match the call_id on the corresponding function_call input
-		return []map[string]any{{
-			"type":    "function_call_output",
-			"call_id": msg.ToolResult.ID,
-			"output":  msg.ToolResult.GetTextContent(),
-		}}
-	}
-
-	// Handle assistant messages with tool calls
-	// In Responses API, tool calls become separate function_call items
-	if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
-		items := make([]map[string]any, 0, len(msg.ToolCalls)+1)
-
-		// Add text content as a message if present
-		content := msg.GetContent()
-		if content != "" {
-			items = append(items, map[string]any{
-				"type": "message",
-				"role": "assistant",
-				"content": []map[string]any{{
-					"type": "output_text",
-					"text": content,
-				}},
-			})
-		}
-
-		// Add each tool call as a separate function_call item
-		for _, tc := range msg.ToolCalls {
-			// Responses API expects arguments as a JSON string, not object
-			fcID := transformToResponsesCallID(tc.ID)
-			items = append(items, map[string]any{
-				"type":      typeFunctionCall,
-				"id":        fcID,
-				"call_id":   tc.ID,
-				"name":      tc.Name,
-				"arguments": string(tc.Args),
-			})
-		}
-		return items
-	}
-
-	// Regular message (user or assistant without tool calls)
-	inputMsg := map[string]any{
-		"role": msg.Role,
-	}
-
-	// Handle content (multimodal or simple text)
-	inputMsg["content"] = p.getMessageContent(msg)
-
-	return []map[string]any{inputMsg}
-}
-
-// getMessageContent extracts content from a message in Responses API format
-func (p *Provider) getMessageContent(msg *types.Message) any {
-	if len(msg.Parts) == 0 {
-		return msg.GetContent()
-	}
-
-	parts := make([]map[string]any, 0, len(msg.Parts))
-	for i := range msg.Parts {
-		if part := p.convertPartToResponsesFormat(&msg.Parts[i]); part != nil {
-			parts = append(parts, part)
-		}
-	}
-	return parts
-}
-
-// convertPartToResponsesFormat converts a single message part to Responses API format
-func (p *Provider) convertPartToResponsesFormat(part *types.ContentPart) map[string]any {
-	switch part.Type {
-	case partTypeText:
-		return map[string]any{
-			"type": "input_text",
-			"text": part.Text,
-		}
-	case "image":
-		if part.Media != nil {
-			var imageURL string
-
-			// Check for URL first
-			if part.Media.URL != nil && *part.Media.URL != "" {
-				imageURL = *part.Media.URL
-			} else if part.Media.Data != nil && *part.Media.Data != "" {
-				// Handle base64 data - construct data URL
-				mimeType := part.Media.MIMEType
-				if mimeType == "" {
-					mimeType = "image/png" // Default mime type
-				}
-				imageURL = "data:" + mimeType + ";base64," + *part.Media.Data
-			}
-
-			if imageURL != "" {
-				// Responses API expects image_url as a string (the URL directly)
-				return map[string]any{
-					"type":      "input_image",
-					"image_url": imageURL,
-				}
-			}
-		}
-	}
-	return nil
-}
-
-// convertToolsToResponsesFormat converts tools to Responses API format
-func (p *Provider) convertToolsToResponsesFormat(tools any) []any {
-	// Tools format is similar but uses "function" type with slightly different structure
-	openAITools, ok := tools.([]openAITool)
-	if !ok {
-		return nil
-	}
-
-	result := make([]any, len(openAITools))
-	for i, tool := range openAITools {
-		entry := map[string]any{
-			"type":        "function",
-			"name":        tool.Function.Name,
-			"description": tool.Function.Description,
-			"parameters":  tool.Function.Parameters,
-		}
-		if tool.Function.Strict {
-			entry["strict"] = true
-		}
-		result[i] = entry
-	}
-	return result
-}
-
-// convertResponseFormatToResponses converts response format to Responses API format
-func (p *Provider) convertResponseFormatToResponses(rf *providers.ResponseFormat) map[string]any {
-	if rf == nil {
-		return nil
-	}
-
-	result := map[string]any{
-		"format": map[string]any{
-			"type": string(rf.Type),
-		},
-	}
-
-	if rf.Type == providers.ResponseFormatJSONSchema && len(rf.JSONSchema) > 0 {
-		var schema any
-		if err := json.Unmarshal(rf.JSONSchema, &schema); err == nil {
-			schemaName := rf.SchemaName
-			if schemaName == "" {
-				schemaName = defaultResponseSchema
-			}
-			result["format"] = map[string]any{
-				"type": "json_schema",
-				"json_schema": map[string]any{
-					"name":   schemaName,
-					"schema": schema,
-					"strict": rf.Strict,
-				},
-			}
-		}
-	}
-
-	return result
 }
 
 // predictWithResponses performs a prediction using the Responses API
@@ -646,11 +411,11 @@ func (p *Provider) sendFinalChunk(
 	outChan <- finalChunk
 }
 
-// handleStreamEvent processes a single streaming event and returns updated state
-//
-//nolint:gocritic // hugeParam: event passed by value for simplicity in switch dispatch
+// handleStreamEvent processes a single streaming event and returns updated state.
+// event is taken by pointer to avoid copying the (~120-byte) struct on every SSE
+// event in the hot streaming loop.
 func (p *Provider) handleStreamEvent(
-	event responsesStreamEvent,
+	event *responsesStreamEvent,
 	data string,
 	sb *strings.Builder,
 	totalTokens int,
@@ -992,7 +757,7 @@ func (p *Provider) streamResponsesResponse(
 
 		// Handle different event types
 		totalTokens, accumulatedToolCalls, usage = p.handleStreamEvent(
-			event, data, &sb, totalTokens, accumulatedToolCalls, usage, outChan, idMap,
+			&event, data, &sb, totalTokens, accumulatedToolCalls, usage, outChan, idMap,
 		)
 
 		// Check if we should return (completed or error events signal this via usage being set and returned)

--- a/runtime/providers/openai/openai_responses_integration_test.go
+++ b/runtime/providers/openai/openai_responses_integration_test.go
@@ -190,7 +190,7 @@ func TestHandleStreamEvent_AudioDelta(t *testing.T) {
 	data := fmt.Sprintf(`{"type":"response.audio.delta","delta":"%s"}`, audioB64)
 
 	tokens, tc, usage := provider.handleStreamEvent(
-		responsesStreamEvent{Type: "response.audio.delta"},
+		&responsesStreamEvent{Type: "response.audio.delta"},
 		data, &sb, 0, nil, nil, outChan, idMap,
 	)
 
@@ -234,7 +234,7 @@ func TestHandleStreamEvent_AudioTranscriptDelta(t *testing.T) {
 	data := `{"type":"response.audio_transcript.delta","delta":"Hello "}`
 
 	tokens, _, _ := provider.handleStreamEvent(
-		responsesStreamEvent{Type: "response.audio_transcript.delta"},
+		&responsesStreamEvent{Type: "response.audio_transcript.delta"},
 		data, &sb, 0, nil, nil, outChan, idMap,
 	)
 
@@ -269,7 +269,7 @@ func TestHandleStreamEvent_AudioDone(t *testing.T) {
 	data := `{"type":"response.audio.done"}`
 
 	tokens, tc, usage := provider.handleStreamEvent(
-		responsesStreamEvent{Type: "response.audio.done"},
+		&responsesStreamEvent{Type: "response.audio.done"},
 		data, &sb, 5, nil, nil, outChan, idMap,
 	)
 

--- a/runtime/providers/openai/realtime_config.go
+++ b/runtime/providers/openai/realtime_config.go
@@ -1,0 +1,132 @@
+// Package openai provides OpenAI Realtime API streaming support.
+package openai
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// GA Realtime session literal values, named to avoid repeated string literals.
+const (
+	sessionTypeRealtime = "realtime"
+	mimeAudioPCM        = "audio/pcm"
+)
+
+// buildRealtimeSessionConfig converts our internal RealtimeSessionConfig into
+// the GA Realtime session.update payload. Output modalities flatten (audio
+// implies text-too); codec, voice, VAD, and transcription nest under
+// audio.{input,output}; voice moved into audio.output.voice.
+//
+// When TurnDetection is nil we leave audio.input.turn_detection nil; the
+// pointer-without-omitempty tag marshals it as `"turn_detection":null` — the GA
+// signal for "manual turn control".
+func buildRealtimeSessionConfig(config RealtimeSessionConfig) SessionConfig {
+	cfg := SessionConfig{
+		Type:             sessionTypeRealtime,
+		Instructions:     config.Instructions,
+		OutputModalities: outputModalities(config.Modalities),
+		Audio: &RealtimeAudioConfig{
+			Input: &RealtimeAudioInput{
+				Format: pcmFormat(config.InputAudioFormat, DefaultRealtimeSampleRate),
+			},
+			Output: &RealtimeAudioOutput{
+				Format: pcmFormat(config.OutputAudioFormat, DefaultRealtimeSampleRate),
+				Voice:  config.Voice,
+			},
+		},
+	}
+
+	if config.InputAudioTranscription != nil {
+		cfg.Audio.Input.Transcription = &TranscriptionConfig{
+			Model: config.InputAudioTranscription.Model,
+		}
+	}
+
+	if config.TurnDetection != nil {
+		cfg.Audio.Input.TurnDetection = &TurnDetectionConfig{
+			Type:              config.TurnDetection.Type,
+			Threshold:         config.TurnDetection.Threshold,
+			PrefixPaddingMs:   config.TurnDetection.PrefixPaddingMs,
+			SilenceDurationMs: config.TurnDetection.SilenceDurationMs,
+			CreateResponse:    config.TurnDetection.CreateResponse,
+		}
+	}
+
+	if len(config.Tools) > 0 {
+		cfg.Tools = make([]RealtimeToolDef, len(config.Tools))
+		for i, tool := range config.Tools {
+			cfg.Tools[i] = RealtimeToolDef{
+				Type:        typeFunction,
+				Name:        tool.Name,
+				Description: tool.Description,
+				Parameters:  tool.Parameters,
+			}
+		}
+	}
+
+	if config.MaxResponseOutputTokens != nil {
+		cfg.MaxOutputTokens = config.MaxResponseOutputTokens
+	}
+
+	return cfg
+}
+
+// Realtime modality names shared with the GA output_modalities field.
+const (
+	modalityAudio = "audio"
+	modalityText  = "text"
+)
+
+// outputModalities maps our internal modality list onto the GA
+// output_modalities field. The GA API accepts ["audio"] (which implies
+// text-too) or ["text"] for text-only.
+func outputModalities(in []string) []string {
+	for _, m := range in {
+		if m == modalityAudio {
+			return []string{modalityAudio}
+		}
+	}
+	if len(in) == 0 {
+		return []string{modalityAudio} // safe default for a Realtime session
+	}
+	return []string{modalityText}
+}
+
+// pcmFormat returns the GA-shape audio format descriptor for a legacy
+// "pcm16"-style codec name. Empty / unknown formats fall through as nil
+// so the server uses its default.
+func pcmFormat(legacy string, rate int) *RealtimeAudioFormat {
+	if legacy != "" && legacy != audioPCM16Format {
+		return nil
+	}
+	return &RealtimeAudioFormat{Type: mimeAudioPCM, Rate: rate}
+}
+
+// markToolCallEmitted records that a tool call for the given item ID was already
+// emitted to responseCh; returns true if the caller should skip its emission.
+// Items with empty IDs are never deduped (best-effort emit).
+func (s *RealtimeSession) markToolCallEmitted(itemID string) bool {
+	if itemID == "" {
+		return false
+	}
+	_, alreadyEmitted := s.emittedToolCalls.LoadOrStore(itemID, struct{}{})
+	return alreadyEmitted
+}
+
+// realtimeWSURL builds the Realtime WebSocket URL, carrying the model as a query
+// parameter (the GA API selects the model via ?model=).
+func realtimeWSURL(endpoint, model string) string {
+	return fmt.Sprintf("%s?model=%s", endpoint, model)
+}
+
+// realtimeWSHeaders builds the HTTP headers for the Realtime WebSocket
+// handshake. It sets Authorization but deliberately does NOT set the
+// OpenAI-Beta header: per OpenAI's GA migration guide the legacy beta header is
+// rejected by gpt-realtime and friends (the server treats it as a legacy
+// connection and serves pre-GA defaults that conflict with the current event
+// schema).
+func realtimeWSHeaders(apiKey string) http.Header {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+apiKey)
+	return headers
+}

--- a/runtime/providers/openai/realtime_config_test.go
+++ b/runtime/providers/openai/realtime_config_test.go
@@ -1,0 +1,211 @@
+package openai
+
+import (
+	"testing"
+)
+
+func TestOutputModalities(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty defaults to audio", nil, []string{"audio"}},
+		{"empty slice defaults to audio", []string{}, []string{"audio"}},
+		{"audio present flattens to audio", []string{"text", "audio"}, []string{"audio"}},
+		{"audio only", []string{"audio"}, []string{"audio"}},
+		{"text only", []string{"text"}, []string{"text"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := outputModalities(tt.in)
+			if len(got) != len(tt.want) || (len(got) > 0 && got[0] != tt.want[0]) {
+				t.Errorf("outputModalities(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPcmFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		legacy  string
+		rate    int
+		wantNil bool
+	}{
+		{"empty codec defaults to pcm", "", 24000, false},
+		{"pcm16 maps to audio/pcm", "pcm16", 24000, false},
+		{"unknown codec yields nil", "g711_ulaw", 8000, true},
+		{"another unknown codec yields nil", "opus", 48000, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pcmFormat(tt.legacy, tt.rate)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("pcmFormat(%q) = %+v, want nil", tt.legacy, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("pcmFormat(%q) = nil, want non-nil", tt.legacy)
+			}
+			if got.Type != "audio/pcm" {
+				t.Errorf("Type = %q, want audio/pcm", got.Type)
+			}
+			if got.Rate != tt.rate {
+				t.Errorf("Rate = %d, want %d", got.Rate, tt.rate)
+			}
+		})
+	}
+}
+
+func TestBuildRealtimeSessionConfig_TurnDetectionNilMeansManual(t *testing.T) {
+	cfg := RealtimeSessionConfig{
+		Modalities:        []string{"audio"},
+		Instructions:      "be helpful",
+		Voice:             "alloy",
+		InputAudioFormat:  "pcm16",
+		OutputAudioFormat: "pcm16",
+		TurnDetection:     nil, // manual turn control
+	}
+
+	got := buildRealtimeSessionConfig(cfg)
+
+	if got.Type != "realtime" {
+		t.Errorf("Type = %q, want realtime", got.Type)
+	}
+	if got.Instructions != "be helpful" {
+		t.Errorf("Instructions = %q", got.Instructions)
+	}
+	if got.Audio == nil || got.Audio.Input == nil {
+		t.Fatal("expected audio.input to be set")
+	}
+	// Nil TurnDetection ⇒ the field stays nil so it marshals as "turn_detection":null
+	// (the GA "manual turn control" signal).
+	if got.Audio.Input.TurnDetection != nil {
+		t.Errorf("TurnDetection = %+v, want nil for manual-turn semantics", got.Audio.Input.TurnDetection)
+	}
+	if got.Audio.Output == nil || got.Audio.Output.Voice != "alloy" {
+		t.Errorf("expected audio.output.voice=alloy")
+	}
+	if got.Audio.Input.Format == nil || got.Audio.Input.Format.Type != "audio/pcm" {
+		t.Errorf("expected pcm input format")
+	}
+}
+
+func TestBuildRealtimeSessionConfig_VADSetNestsUnderInput(t *testing.T) {
+	cfg := RealtimeSessionConfig{
+		Modalities: []string{"audio"},
+		TurnDetection: &TurnDetectionConfig{
+			Type:              "server_vad",
+			Threshold:         0.5,
+			PrefixPaddingMs:   300,
+			SilenceDurationMs: 500,
+			CreateResponse:    true,
+		},
+		InputAudioTranscription: &TranscriptionConfig{Model: "whisper-1"},
+	}
+
+	got := buildRealtimeSessionConfig(cfg)
+
+	td := got.Audio.Input.TurnDetection
+	if td == nil {
+		t.Fatal("expected turn_detection to be nested under audio.input")
+	}
+	if td.Type != "server_vad" || td.Threshold != 0.5 || td.SilenceDurationMs != 500 {
+		t.Errorf("turn_detection not copied faithfully: %+v", td)
+	}
+	if got.Audio.Input.Transcription == nil || got.Audio.Input.Transcription.Model != "whisper-1" {
+		t.Errorf("expected transcription model whisper-1, got %+v", got.Audio.Input.Transcription)
+	}
+}
+
+func TestBuildRealtimeSessionConfig_ToolsAndMaxTokens(t *testing.T) {
+	cfg := RealtimeSessionConfig{
+		Modalities: []string{"text"},
+		Tools: []RealtimeToolDefinition{
+			{
+				Type:        "function",
+				Name:        "get_weather",
+				Description: "Get weather",
+				Parameters:  map[string]any{"type": "object"},
+			},
+		},
+		MaxResponseOutputTokens: 4096,
+	}
+
+	got := buildRealtimeSessionConfig(cfg)
+
+	if len(got.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(got.Tools))
+	}
+	if got.Tools[0].Name != "get_weather" || got.Tools[0].Type != "function" {
+		t.Errorf("tool mapping wrong: %+v", got.Tools[0])
+	}
+	if got.MaxOutputTokens != 4096 {
+		t.Errorf("MaxOutputTokens = %v, want 4096", got.MaxOutputTokens)
+	}
+	if len(got.OutputModalities) != 1 || got.OutputModalities[0] != "text" {
+		t.Errorf("OutputModalities = %v, want [text]", got.OutputModalities)
+	}
+}
+
+func TestBuildRealtimeSessionConfig_NoToolsNoMaxTokens(t *testing.T) {
+	got := buildRealtimeSessionConfig(RealtimeSessionConfig{Modalities: []string{"audio"}})
+	if got.Tools != nil {
+		t.Errorf("expected no tools, got %+v", got.Tools)
+	}
+	if got.MaxOutputTokens != nil {
+		t.Errorf("expected no max tokens, got %v", got.MaxOutputTokens)
+	}
+}
+
+func TestMarkToolCallEmitted_Dedup(t *testing.T) {
+	s := &RealtimeSession{}
+
+	// Empty item IDs are never deduped (best-effort emit ⇒ always false).
+	if s.markToolCallEmitted("") {
+		t.Error("empty item id should never be marked emitted")
+	}
+	if s.markToolCallEmitted("") {
+		t.Error("empty item id should still not dedupe on repeat")
+	}
+
+	// First sighting of a real ID returns false (emit); second returns true (skip).
+	if s.markToolCallEmitted("item_1") {
+		t.Error("first emit of item_1 should return false")
+	}
+	if !s.markToolCallEmitted("item_1") {
+		t.Error("second emit of item_1 should return true (deduped)")
+	}
+	// Distinct IDs are tracked independently.
+	if s.markToolCallEmitted("item_2") {
+		t.Error("first emit of item_2 should return false")
+	}
+}
+
+func TestRealtimeWSURL(t *testing.T) {
+	got := realtimeWSURL("wss://api.openai.com/v1/realtime", "gpt-realtime")
+	want := "wss://api.openai.com/v1/realtime?model=gpt-realtime"
+	if got != want {
+		t.Errorf("realtimeWSURL = %q, want %q", got, want)
+	}
+}
+
+// TestRealtimeWSHeaders_NoBetaHeader is the GA regression guard: the Realtime
+// handshake must carry Authorization but must NOT send the legacy OpenAI-Beta
+// header (the GA server rejects it and serves pre-GA defaults).
+func TestRealtimeWSHeaders_NoBetaHeader(t *testing.T) {
+	headers := realtimeWSHeaders("sk-test-123")
+
+	if got := headers.Get("Authorization"); got != "Bearer sk-test-123" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer sk-test-123")
+	}
+	if v := headers.Get("OpenAI-Beta"); v != "" {
+		t.Errorf("OpenAI-Beta must be absent for the GA Realtime API, got %q", v)
+	}
+	if _, ok := headers["Openai-Beta"]; ok {
+		t.Error("OpenAI-Beta header key present, must be absent for GA")
+	}
+}

--- a/runtime/providers/openai/realtime_cost.go
+++ b/runtime/providers/openai/realtime_cost.go
@@ -1,0 +1,73 @@
+// Package openai provides OpenAI Realtime API streaming support.
+package openai
+
+import "github.com/AltairaLabs/PromptKit/runtime/types"
+
+// gpt-realtime GA pricing per 1K tokens (USD). Audio costs an order of
+// magnitude more than text — pricing one against the other vastly mis-
+// estimates the bill. The wire `usage` payload includes a per-type
+// breakdown (input_token_details / output_token_details), and we use it.
+//
+// Cached input is billed at the same per-1K rate as fresh input on the
+// gpt-realtime GA model (10% discount for prompt-cached audio is folded
+// in by the server already; we don't double-count).
+//
+// Source: https://platform.openai.com/docs/pricing (gpt-realtime row).
+const (
+	defaultAudioInputCostPer1K  = 0.032 // $32 / 1M
+	defaultAudioOutputCostPer1K = 0.064 // $64 / 1M
+	defaultTextInputCostPer1K   = 0.004 // $4  / 1M
+	defaultTextOutputCostPer1K  = 0.016 // $16 / 1M
+)
+
+// calculateRealtimeCost computes the USD cost of a single realtime turn from its
+// token usage. audioInRateOverride / audioOutRateOverride, when non-zero,
+// replace the default GA audio per-1K rates (applied to AUDIO tokens only —
+// text tokens always bill at the default text rates, since audio dominates a
+// realtime bill).
+//
+// When the per-type token breakdown is missing (input_token_details /
+// output_token_details all zero — older API responses, mock providers) it falls
+// back to treating ALL tokens as audio. Over-reporting text at audio rates
+// (~8x) is preferable to silently reporting $0 or under-reporting audio at text
+// rates for a realtime session. Returns nil for nil usage.
+func calculateRealtimeCost(usage *UsageInfo, audioInRateOverride, audioOutRateOverride float64) *types.CostInfo {
+	if usage == nil {
+		return nil
+	}
+
+	audioInRate := audioInRateOverride
+	if audioInRate == 0 {
+		audioInRate = defaultAudioInputCostPer1K
+	}
+	audioOutRate := audioOutRateOverride
+	if audioOutRate == 0 {
+		audioOutRate = defaultAudioOutputCostPer1K
+	}
+
+	inAudio := usage.InputTokenDetails.AudioTokens
+	inText := usage.InputTokenDetails.TextTokens
+	outAudio := usage.OutputTokenDetails.AudioTokens
+	outText := usage.OutputTokenDetails.TextTokens
+
+	// Fall back to "all tokens are audio" if the breakdown is missing.
+	if inAudio == 0 && inText == 0 {
+		inAudio = usage.InputTokens
+	}
+	if outAudio == 0 && outText == 0 {
+		outAudio = usage.OutputTokens
+	}
+
+	inputCost := float64(inAudio)/tokensPerThousand*audioInRate +
+		float64(inText)/tokensPerThousand*defaultTextInputCostPer1K
+	outputCost := float64(outAudio)/tokensPerThousand*audioOutRate +
+		float64(outText)/tokensPerThousand*defaultTextOutputCostPer1K
+
+	return &types.CostInfo{
+		InputTokens:   usage.InputTokens,
+		OutputTokens:  usage.OutputTokens,
+		InputCostUSD:  inputCost,
+		OutputCostUSD: outputCost,
+		TotalCost:     inputCost + outputCost,
+	}
+}

--- a/runtime/providers/openai/realtime_cost_test.go
+++ b/runtime/providers/openai/realtime_cost_test.go
@@ -1,0 +1,161 @@
+package openai
+
+import (
+	"math"
+	"testing"
+)
+
+// usageWith builds a UsageInfo with the given totals and per-type breakdown.
+func usageWith(inTok, outTok, inAudio, inText, outAudio, outText int) *UsageInfo {
+	u := &UsageInfo{
+		TotalTokens:  inTok + outTok,
+		InputTokens:  inTok,
+		OutputTokens: outTok,
+	}
+	u.InputTokenDetails.AudioTokens = inAudio
+	u.InputTokenDetails.TextTokens = inText
+	u.OutputTokenDetails.AudioTokens = outAudio
+	u.OutputTokenDetails.TextTokens = outText
+	return u
+}
+
+const costEpsilon = 1e-9
+
+func approxEqual(a, b float64) bool { return math.Abs(a-b) < costEpsilon }
+
+func TestCalculateRealtimeCost(t *testing.T) {
+	tests := []struct {
+		name        string
+		usage       *UsageInfo
+		inOverride  float64
+		outOverride float64
+		wantNil     bool
+		wantIn      float64
+		wantOut     float64
+	}{
+		{
+			name:    "nil usage returns nil",
+			usage:   nil,
+			wantNil: true,
+		},
+		{
+			name:  "with breakdown uses per-type default rates",
+			usage: usageWith(1000, 500, 800, 200, 400, 100),
+			// in:  800/1000*0.032 + 200/1000*0.004 = 0.0256 + 0.0008
+			// out: 400/1000*0.064 + 100/1000*0.016 = 0.0256 + 0.0016
+			wantIn:  0.0264,
+			wantOut: 0.0272,
+		},
+		{
+			name:        "audio rate overrides apply to audio tokens only",
+			usage:       usageWith(1000, 500, 800, 200, 400, 100),
+			inOverride:  0.1,
+			outOverride: 0.2,
+			// in:  800/1000*0.1 + 200/1000*0.004 = 0.08 + 0.0008
+			// out: 400/1000*0.2 + 100/1000*0.016 = 0.08 + 0.0016
+			wantIn:  0.0808,
+			wantOut: 0.0816,
+		},
+		{
+			name: "missing breakdown treats all tokens as audio (no-undercount fallback)",
+			// Neither audio nor text token details set — the ~8x mis-bill guard
+			// bills the full token count at AUDIO rates, not $0 or text rates.
+			usage: usageWith(1000, 500, 0, 0, 0, 0),
+			// in:  1000/1000*0.032 = 0.032
+			// out: 500/1000*0.064  = 0.032
+			wantIn:  0.032,
+			wantOut: 0.032,
+		},
+		{
+			name:  "zero tokens is zero cost",
+			usage: usageWith(0, 0, 0, 0, 0, 0),
+			// fallback sets inAudio=0, outAudio=0 → all terms zero.
+			wantIn:  0,
+			wantOut: 0,
+		},
+		{
+			name:  "text-only breakdown does not trigger the audio fallback",
+			usage: usageWith(1000, 500, 0, 1000, 0, 500),
+			// inText present ⇒ fallback skipped; billed entirely at text rates.
+			// in:  1000/1000*0.004 = 0.004
+			// out: 500/1000*0.016  = 0.008
+			wantIn:  0.004,
+			wantOut: 0.008,
+		},
+		{
+			name:  "override of zero falls back to default audio rate",
+			usage: usageWith(1000, 0, 1000, 0, 0, 0),
+			// inOverride 0 ⇒ default 0.032 audio-in rate.
+			wantIn:  0.032,
+			wantOut: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateRealtimeCost(tt.usage, tt.inOverride, tt.outOverride)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil cost, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil cost")
+			}
+			if !approxEqual(got.InputCostUSD, tt.wantIn) {
+				t.Errorf("InputCostUSD = %v, want %v", got.InputCostUSD, tt.wantIn)
+			}
+			if !approxEqual(got.OutputCostUSD, tt.wantOut) {
+				t.Errorf("OutputCostUSD = %v, want %v", got.OutputCostUSD, tt.wantOut)
+			}
+			if !approxEqual(got.TotalCost, tt.wantIn+tt.wantOut) {
+				t.Errorf("TotalCost = %v, want %v", got.TotalCost, tt.wantIn+tt.wantOut)
+			}
+			if got.InputTokens != tt.usage.InputTokens {
+				t.Errorf("InputTokens = %d, want %d", got.InputTokens, tt.usage.InputTokens)
+			}
+			if got.OutputTokens != tt.usage.OutputTokens {
+				t.Errorf("OutputTokens = %d, want %d", got.OutputTokens, tt.usage.OutputTokens)
+			}
+		})
+	}
+}
+
+// TestCalculateRealtimeCost_AudioVsTextMisbill documents the core money risk:
+// the same token count costs ~8x more billed as audio than as text. The
+// missing-breakdown fallback deliberately errs toward the audio (higher) side.
+func TestCalculateRealtimeCost_AudioVsTextMisbill(t *testing.T) {
+	asAudio := calculateRealtimeCost(usageWith(1000, 0, 1000, 0, 0, 0), 0, 0)
+	asText := calculateRealtimeCost(usageWith(1000, 0, 0, 1000, 0, 0), 0, 0)
+
+	if asAudio.InputCostUSD <= asText.InputCostUSD {
+		t.Fatalf("audio billing (%v) should exceed text billing (%v)",
+			asAudio.InputCostUSD, asText.InputCostUSD)
+	}
+	ratio := asAudio.InputCostUSD / asText.InputCostUSD
+	if !approxEqual(ratio, defaultAudioInputCostPer1K/defaultTextInputCostPer1K) {
+		t.Errorf("audio/text ratio = %v, want %v", ratio,
+			defaultAudioInputCostPer1K/defaultTextInputCostPer1K)
+	}
+}
+
+// TestRealtimeSession_calculateCost_DelegatesOverrides verifies the thin method
+// forwards the session's per-1K overrides to the pure function.
+func TestRealtimeSession_calculateCost_DelegatesOverrides(t *testing.T) {
+	s := &RealtimeSession{inputCostPer1K: 0.1, outputCostPer1K: 0.2}
+	got := s.calculateCost(usageWith(1000, 500, 800, 200, 400, 100))
+	if got == nil {
+		t.Fatal("expected non-nil cost")
+	}
+	if !approxEqual(got.InputCostUSD, 0.0808) {
+		t.Errorf("InputCostUSD = %v, want 0.0808 (overrides applied)", got.InputCostUSD)
+	}
+	if !approxEqual(got.OutputCostUSD, 0.0816) {
+		t.Errorf("OutputCostUSD = %v, want 0.0816 (overrides applied)", got.OutputCostUSD)
+	}
+
+	if s.calculateCost(nil) != nil {
+		t.Error("calculateCost(nil) should return nil")
+	}
+}

--- a/runtime/providers/openai/realtime_session_integration.go
+++ b/runtime/providers/openai/realtime_session_integration.go
@@ -230,88 +230,11 @@ func (s *RealtimeSession) sendSessionUpdate() error {
 	return s.ws.Send(event)
 }
 
-// buildSessionConfig converts our internal RealtimeSessionConfig into
-// the GA Realtime session.update payload. Output modalities flatten
-// (audio implies text-too); codec, voice, VAD, and transcription nest
-// under audio.{input,output}; temperature dropped (GA moved it to
-// per-response.create); voice moved into audio.output.voice.
+// buildSessionConfig delegates to the pure buildRealtimeSessionConfig; the GA
+// config-translation logic lives in realtime_config.go so it can be unit-tested
+// without a live session.
 func (s *RealtimeSession) buildSessionConfig() SessionConfig {
-	cfg := SessionConfig{
-		Type:             "realtime",
-		Instructions:     s.config.Instructions,
-		OutputModalities: outputModalities(s.config.Modalities),
-		Audio: &RealtimeAudioConfig{
-			Input: &RealtimeAudioInput{
-				Format: pcmFormat(s.config.InputAudioFormat, DefaultRealtimeSampleRate),
-			},
-			Output: &RealtimeAudioOutput{
-				Format: pcmFormat(s.config.OutputAudioFormat, DefaultRealtimeSampleRate),
-				Voice:  s.config.Voice,
-			},
-		},
-	}
-
-	if s.config.InputAudioTranscription != nil {
-		cfg.Audio.Input.Transcription = &TranscriptionConfig{
-			Model: s.config.InputAudioTranscription.Model,
-		}
-	}
-
-	if s.config.TurnDetection != nil {
-		cfg.Audio.Input.TurnDetection = &TurnDetectionConfig{
-			Type:              s.config.TurnDetection.Type,
-			Threshold:         s.config.TurnDetection.Threshold,
-			PrefixPaddingMs:   s.config.TurnDetection.PrefixPaddingMs,
-			SilenceDurationMs: s.config.TurnDetection.SilenceDurationMs,
-			CreateResponse:    s.config.TurnDetection.CreateResponse,
-		}
-	}
-	// When TurnDetection is nil we leave audio.input.turn_detection nil;
-	// the pointer-without-omitempty tag marshals it as
-	// `"turn_detection":null` — the GA signal for "manual turn control".
-
-	if len(s.config.Tools) > 0 {
-		cfg.Tools = make([]RealtimeToolDef, len(s.config.Tools))
-		for i, tool := range s.config.Tools {
-			cfg.Tools[i] = RealtimeToolDef{
-				Type:        "function",
-				Name:        tool.Name,
-				Description: tool.Description,
-				Parameters:  tool.Parameters,
-			}
-		}
-	}
-
-	if s.config.MaxResponseOutputTokens != nil {
-		cfg.MaxOutputTokens = s.config.MaxResponseOutputTokens
-	}
-
-	return cfg
-}
-
-// outputModalities maps our internal modality list onto the GA
-// output_modalities field. The GA API accepts ["audio"] (which implies
-// text-too) or ["text"] for text-only.
-func outputModalities(in []string) []string {
-	for _, m := range in {
-		if m == "audio" {
-			return []string{"audio"}
-		}
-	}
-	if len(in) == 0 {
-		return []string{"audio"} // safe default for a Realtime session
-	}
-	return []string{"text"}
-}
-
-// pcmFormat returns the GA-shape audio format descriptor for a legacy
-// "pcm16"-style codec name. Empty / unknown formats fall through as nil
-// so the server uses its default.
-func pcmFormat(legacy string, rate int) *RealtimeAudioFormat {
-	if legacy != "" && legacy != "pcm16" {
-		return nil
-	}
-	return &RealtimeAudioFormat{Type: "audio/pcm", Rate: rate}
+	return buildRealtimeSessionConfig(s.config)
 }
 
 // nextEventID generates a unique event ID.
@@ -408,7 +331,7 @@ func (s *RealtimeSession) SendSystemContext(ctx context.Context, text string) er
 			Type:    "session.update",
 		},
 		Session: SessionConfig{
-			Type:         "realtime",
+			Type:         sessionTypeRealtime,
 			Instructions: text,
 		},
 	}
@@ -783,7 +706,7 @@ func (s *RealtimeSession) handleAudioDelta(e *ResponseAudioDeltaEvent) {
 	s.emitCh <- providers.StreamChunk{
 		MediaData: &providers.StreamMediaData{
 			Data:       rawBytes,
-			MIMEType:   "audio/pcm",
+			MIMEType:   mimeAudioPCM,
 			SampleRate: s.outputSampleRate(),
 			Channels:   1,
 		},
@@ -883,17 +806,6 @@ func (s *RealtimeSession) handleOutputItemDone(e *ResponseOutputItemDoneEvent) {
 	}
 }
 
-// markToolCallEmitted records that a tool call for the given item ID was already
-// emitted to responseCh; returns true if the caller should skip its emission.
-// Items with empty IDs are never deduped (best-effort emit).
-func (s *RealtimeSession) markToolCallEmitted(itemID string) bool {
-	if itemID == "" {
-		return false
-	}
-	_, alreadyEmitted := s.emittedToolCalls.LoadOrStore(itemID, struct{}{})
-	return alreadyEmitted
-}
-
 func (s *RealtimeSession) handleResponseDone(e *ResponseDoneEvent) {
 	// The response is over (completed or canceled by barge-in); stop treating
 	// further speech_started as barge-in and stop dropping audio.
@@ -942,67 +854,9 @@ func (s *RealtimeSession) handleRateLimits(e *RateLimitsUpdatedEvent) {
 	}
 }
 
-// gpt-realtime GA pricing per 1K tokens (USD). Audio costs an order of
-// magnitude more than text — pricing one against the other vastly mis-
-// estimates the bill. The wire `usage` payload includes a per-type
-// breakdown (input_token_details / output_token_details), and we use it.
-//
-// Cached input is billed at the same per-1K rate as fresh input on the
-// gpt-realtime GA model (10% discount for prompt-cached audio is folded
-// in by the server already; we don't double-count).
-//
-// Source: https://platform.openai.com/docs/pricing (gpt-realtime row).
-const (
-	defaultAudioInputCostPer1K  = 0.032 // $32 / 1M
-	defaultAudioOutputCostPer1K = 0.064 // $64 / 1M
-	defaultTextInputCostPer1K   = 0.004 // $4  / 1M
-	defaultTextOutputCostPer1K  = 0.016 // $16 / 1M
-)
-
+// calculateCost delegates to the pure calculateRealtimeCost, passing the
+// session's per-1K audio-rate overrides (0 ⇒ use the GA defaults). The money
+// math lives in realtime_cost.go so it can be unit-tested in isolation.
 func (s *RealtimeSession) calculateCost(usage *UsageInfo) *types.CostInfo {
-	if usage == nil {
-		return nil
-	}
-
-	// Default to GA gpt-realtime rates. The provider config can override
-	// the audio rates via inputCostPer1K / outputCostPer1K — those are
-	// applied to AUDIO tokens, since that's where the bulk of the bill
-	// lives in a realtime session.
-	audioInRate := s.inputCostPer1K
-	if audioInRate == 0 {
-		audioInRate = defaultAudioInputCostPer1K
-	}
-	audioOutRate := s.outputCostPer1K
-	if audioOutRate == 0 {
-		audioOutRate = defaultAudioOutputCostPer1K
-	}
-
-	inAudio := usage.InputTokenDetails.AudioTokens
-	inText := usage.InputTokenDetails.TextTokens
-	outAudio := usage.OutputTokenDetails.AudioTokens
-	outText := usage.OutputTokenDetails.TextTokens
-
-	// Fall back to "all tokens are audio" if the breakdown is missing
-	// (older API responses, mock providers, etc.) so we don't silently
-	// report $0 — overcounting text at audio rates is preferable to
-	// undercounting audio at text rates for a Realtime session.
-	if inAudio == 0 && inText == 0 {
-		inAudio = usage.InputTokens
-	}
-	if outAudio == 0 && outText == 0 {
-		outAudio = usage.OutputTokens
-	}
-
-	inputCost := float64(inAudio)/tokensPerThousand*audioInRate +
-		float64(inText)/tokensPerThousand*defaultTextInputCostPer1K
-	outputCost := float64(outAudio)/tokensPerThousand*audioOutRate +
-		float64(outText)/tokensPerThousand*defaultTextOutputCostPer1K
-
-	return &types.CostInfo{
-		InputTokens:   usage.InputTokens,
-		OutputTokens:  usage.OutputTokens,
-		InputCostUSD:  inputCost,
-		OutputCostUSD: outputCost,
-		TotalCost:     inputCost + outputCost,
-	}
+	return calculateRealtimeCost(usage, s.inputCostPer1K, s.outputCostPer1K)
 }

--- a/runtime/providers/openai/realtime_tools_test.go
+++ b/runtime/providers/openai/realtime_tools_test.go
@@ -1,0 +1,165 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// newToolCaptureServer returns a fake Realtime WebSocket server that completes
+// the handshake, drains the client's session.update, then forwards every
+// subsequent client event (decoded JSON) to received in order.
+func newToolCaptureServer(t *testing.T, received chan<- map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := bargeInUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		if err := conn.WriteJSON(map[string]any{
+			"type":    "session.created",
+			"session": map[string]any{"id": "sess_test", "model": "gpt-realtime"},
+		}); err != nil {
+			return
+		}
+		if _, _, err := conn.ReadMessage(); err != nil { // drain session.update
+			return
+		}
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var m map[string]any
+			if err := json.Unmarshal(data, &m); err != nil {
+				continue
+			}
+			received <- m
+		}
+	}))
+}
+
+func recvEvent(t *testing.T, received <-chan map[string]any) map[string]any {
+	t.Helper()
+	select {
+	case m := <-received:
+		return m
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for a client event")
+		return nil
+	}
+}
+
+func openToolSession(t *testing.T, srv *httptest.Server) *RealtimeSession {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	config := DefaultRealtimeSessionConfig()
+	session, err := newRealtimeSession(ctx, "test-key", &config, realtimeSessionOpts{
+		endpoint: bargeInWSURL(srv),
+	})
+	if err != nil {
+		t.Fatalf("newRealtimeSession: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func TestSendToolResponse_EmitsFunctionOutputThenResponseCreate(t *testing.T) {
+	received := make(chan map[string]any, 16)
+	srv := newToolCaptureServer(t, received)
+	defer srv.Close()
+
+	session := openToolSession(t, srv)
+
+	if err := session.SendToolResponse(context.Background(), "call_123", "the result"); err != nil {
+		t.Fatalf("SendToolResponse: %v", err)
+	}
+
+	// 1. conversation.item.create carrying a function_call_output item.
+	create := recvEvent(t, received)
+	if create["type"] != "conversation.item.create" {
+		t.Fatalf("first event type = %v, want conversation.item.create", create["type"])
+	}
+	item, ok := create["item"].(map[string]any)
+	if !ok {
+		t.Fatalf("event missing item object: %+v", create)
+	}
+	if item["type"] != "function_call_output" {
+		t.Errorf("item.type = %v, want function_call_output", item["type"])
+	}
+	if item["call_id"] != "call_123" {
+		t.Errorf("item.call_id = %v, want call_123", item["call_id"])
+	}
+	if item["output"] != "the result" {
+		t.Errorf("item.output = %v, want 'the result'", item["output"])
+	}
+
+	// 2. response.create to continue the turn.
+	resp := recvEvent(t, received)
+	if resp["type"] != "response.create" {
+		t.Errorf("second event type = %v, want response.create", resp["type"])
+	}
+}
+
+func TestSendToolResponses_MultipleOutputsThenOneResponseCreate(t *testing.T) {
+	received := make(chan map[string]any, 16)
+	srv := newToolCaptureServer(t, received)
+	defer srv.Close()
+
+	session := openToolSession(t, srv)
+
+	responses := []providers.ToolResponse{
+		{ToolCallID: "call_a", Result: "res a"},
+		{ToolCallID: "call_b", Result: "res b"},
+	}
+	if err := session.SendToolResponses(context.Background(), responses); err != nil {
+		t.Fatalf("SendToolResponses: %v", err)
+	}
+
+	// Two function_call_output items, in order, then a single response.create.
+	for _, want := range responses {
+		ev := recvEvent(t, received)
+		if ev["type"] != "conversation.item.create" {
+			t.Fatalf("event type = %v, want conversation.item.create", ev["type"])
+		}
+		item := ev["item"].(map[string]any)
+		if item["call_id"] != want.ToolCallID {
+			t.Errorf("item.call_id = %v, want %v", item["call_id"], want.ToolCallID)
+		}
+		if item["output"] != want.Result {
+			t.Errorf("item.output = %v, want %v", item["output"], want.Result)
+		}
+	}
+	final := recvEvent(t, received)
+	if final["type"] != "response.create" {
+		t.Errorf("final event type = %v, want response.create", final["type"])
+	}
+}
+
+func TestSendToolResponse_ClosedSessionErrors(t *testing.T) {
+	received := make(chan map[string]any, 16)
+	srv := newToolCaptureServer(t, received)
+	defer srv.Close()
+
+	session := openToolSession(t, srv)
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := session.SendToolResponse(context.Background(), "call_1", "x"); err == nil {
+		t.Error("SendToolResponse on closed session should error")
+	}
+	err := session.SendToolResponses(context.Background(), []providers.ToolResponse{{ToolCallID: "call_1", Result: "x"}})
+	if err == nil {
+		t.Error("SendToolResponses on closed session should error")
+	}
+}

--- a/runtime/providers/openai/realtime_websocket_integration.go
+++ b/runtime/providers/openai/realtime_websocket_integration.go
@@ -3,8 +3,6 @@ package openai
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
@@ -35,15 +33,11 @@ func NewRealtimeWebSocket(model, apiKey string) *RealtimeWebSocket {
 // tests point it at a local fake WebSocket server to exercise the session's
 // receive/back-pressure behavior without the real API.
 func newRealtimeWebSocketAt(model, apiKey, endpoint string) *RealtimeWebSocket {
-	wsURL := fmt.Sprintf("%s?model=%s", endpoint, model)
-
-	headers := http.Header{}
-	headers.Set("Authorization", "Bearer "+apiKey)
-	// Per OpenAI's GA migration guide: do NOT send the OpenAI-Beta header
-	// against the GA Realtime API (gpt-realtime and friends). The legacy
-	// beta header was required for the original 2024 preview but is now
-	// rejected — the server treats it as a legacy connection and serves
-	// pre-GA defaults that conflict with the current event schema.
+	// URL + header construction is extracted into realtime_config.go
+	// (realtimeWSURL / realtimeWSHeaders) so the GA requirement — Authorization
+	// present, OpenAI-Beta absent — can be unit-tested without a live socket.
+	wsURL := realtimeWSURL(endpoint, model)
+	headers := realtimeWSHeaders(apiKey)
 
 	return &RealtimeWebSocket{
 		conn: streaming.NewConn(&streaming.ConnConfig{

--- a/runtime/providers/openai/responses_convert.go
+++ b/runtime/providers/openai/responses_convert.go
@@ -1,0 +1,288 @@
+// Package openai provides OpenAI LLM provider integration.
+package openai
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Responses API JSON keys and literal values, named to keep the map-literal
+// converters below free of repeated string literals (goconst).
+const (
+	keyType      = "type"
+	keyName      = "name"
+	keyRole      = "role"
+	keyContent   = "content"
+	keyFormat    = "format"
+	keyCallID    = "call_id"
+	keyStrict    = "strict"
+	keyImageURL  = "image_url"
+	keyArguments = "arguments"
+
+	typeJSONSchema         = "json_schema"
+	typeFunction           = "function"
+	typeFunctionCallOutput = "function_call_output"
+	typeMessage            = "message"
+	typeOutputText         = "output_text"
+	typeInputText          = "input_text"
+	roleAssistant          = "assistant"
+
+	fcCallIDPrefix          = "fc_"
+	chatCallIDPrefix        = "call_"
+	responsesProModelSuffix = "-pro"
+)
+
+// requiresResponsesAPI returns true if the model is only served by the Responses
+// API. OpenAI's "pro" reasoning models (o1-pro, gpt-5-pro, gpt-5.2-pro, ...) all
+// 404 on v1/chat/completions and must use v1/responses. This is a genuine,
+// OpenAI-defined model property (not a behavior we can default), so it's keyed
+// off the "-pro" suffix that those models share rather than enumerated one by one.
+func requiresResponsesAPI(model string) bool {
+	return strings.HasSuffix(model, responsesProModelSuffix)
+}
+
+// transformToResponsesCallID converts a call ID to Responses API format.
+// The Responses API requires function call IDs to start with 'fc_'.
+// Chat Completions API uses 'call_' prefix which must be transformed.
+func transformToResponsesCallID(callID string) string {
+	// If already in Responses format, return as-is
+	if strings.HasPrefix(callID, fcCallIDPrefix) {
+		return callID
+	}
+	// Transform call_ prefix to fc_ prefix
+	if strings.HasPrefix(callID, chatCallIDPrefix) {
+		return fcCallIDPrefix + strings.TrimPrefix(callID, chatCallIDPrefix)
+	}
+	// For any other format, add fc_ prefix
+	return fcCallIDPrefix + callID
+}
+
+// getAPIMode determines which OpenAI API to use. Priority:
+//  1. Explicit config (additional_config.api_mode) — data-driven, always wins.
+//  2. requiresResponsesAPI fallback — for Responses-only models when the
+//     config doesn't declare a mode.
+//  3. Default to the legacy Chat Completions API.
+//
+// Config-first ordering means a provider config is the source of truth; the
+// model-name heuristic is only a best-effort default for undeclared configs.
+func getAPIMode(model string, additionalConfig map[string]any) APIMode {
+	if additionalConfig != nil {
+		if mode, ok := additionalConfig["api_mode"].(string); ok {
+			switch strings.ToLower(mode) {
+			case "completions", "chat_completions", "legacy":
+				return APIModeCompletions
+			case "responses":
+				return APIModeResponses
+			}
+		}
+	}
+
+	if requiresResponsesAPI(model) {
+		return APIModeResponses
+	}
+
+	return APIModeCompletions
+}
+
+// convertMessagesToResponsesInput converts messages to Responses API input format
+// The Responses API expects a flat list where tool calls are separate function_call items
+func (p *Provider) convertMessagesToResponsesInput(messages []types.Message) []any {
+	// Allocate extra capacity for tool calls which become separate items
+	const toolCallCapacityMultiplier = 2
+	input := make([]any, 0, len(messages)*toolCallCapacityMultiplier)
+	for i := range messages {
+		items := p.convertSingleMessageToResponsesInput(&messages[i])
+		for _, item := range items {
+			input = append(input, item)
+		}
+	}
+	return input
+}
+
+// convertSingleMessageToResponsesInput converts a single message to Responses API format
+// Returns a slice because assistant messages with tool calls become multiple items
+func (p *Provider) convertSingleMessageToResponsesInput(msg *types.Message) []map[string]any {
+	// Handle tool results - these are function_call_output items
+	// NOTE: The Responses API only supports text output for function_call_output.
+	// Multimodal tool results (images, audio) are reduced to text here.
+	// Use the Chat Completions API for full multimodal tool result support.
+	if msg.Role == roleToolResult && msg.ToolResult != nil {
+		// call_id must match the call_id on the corresponding function_call input
+		return []map[string]any{{
+			keyType:   typeFunctionCallOutput,
+			keyCallID: msg.ToolResult.ID,
+			"output":  msg.ToolResult.GetTextContent(),
+		}}
+	}
+
+	// Handle assistant messages with tool calls
+	// In Responses API, tool calls become separate function_call items
+	if msg.Role == roleAssistant && len(msg.ToolCalls) > 0 {
+		return p.assistantToolCallItems(msg)
+	}
+
+	// Regular message (user or assistant without tool calls)
+	inputMsg := map[string]any{
+		keyRole: msg.Role,
+	}
+
+	// Handle content (multimodal or simple text)
+	inputMsg[keyContent] = p.getMessageContent(msg)
+
+	return []map[string]any{inputMsg}
+}
+
+// assistantToolCallItems splits an assistant message that carries tool calls
+// into its Responses API items: an optional leading text message followed by
+// one function_call item per tool call.
+func (p *Provider) assistantToolCallItems(msg *types.Message) []map[string]any {
+	items := make([]map[string]any, 0, len(msg.ToolCalls)+1)
+
+	// Add text content as a message if present
+	content := msg.GetContent()
+	if content != "" {
+		items = append(items, map[string]any{
+			keyType: typeMessage,
+			keyRole: roleAssistant,
+			keyContent: []map[string]any{{
+				keyType:      typeOutputText,
+				partTypeText: content,
+			}},
+		})
+	}
+
+	// Add each tool call as a separate function_call item
+	for _, tc := range msg.ToolCalls {
+		// Responses API expects arguments as a JSON string, not object
+		items = append(items, map[string]any{
+			keyType:      typeFunctionCall,
+			"id":         transformToResponsesCallID(tc.ID),
+			keyCallID:    tc.ID,
+			keyName:      tc.Name,
+			keyArguments: string(tc.Args),
+		})
+	}
+	return items
+}
+
+// getMessageContent extracts content from a message in Responses API format
+func (p *Provider) getMessageContent(msg *types.Message) any {
+	if len(msg.Parts) == 0 {
+		return msg.GetContent()
+	}
+
+	parts := make([]map[string]any, 0, len(msg.Parts))
+	for i := range msg.Parts {
+		if part := p.convertPartToResponsesFormat(&msg.Parts[i]); part != nil {
+			parts = append(parts, part)
+		}
+	}
+	return parts
+}
+
+// convertPartToResponsesFormat converts a single message part to Responses API format
+func (p *Provider) convertPartToResponsesFormat(part *types.ContentPart) map[string]any {
+	switch part.Type {
+	case partTypeText:
+		return map[string]any{
+			keyType:      typeInputText,
+			partTypeText: part.Text,
+		}
+	case "image":
+		return imageResponsesPart(part.Media)
+	}
+	return nil
+}
+
+// imageResponsesPart renders an image part as a Responses API input_image, or
+// nil when there is no usable image source.
+func imageResponsesPart(media *types.MediaContent) map[string]any {
+	if media == nil {
+		return nil
+	}
+	imageURL := imageURLFromMedia(media)
+	if imageURL == "" {
+		return nil
+	}
+	// Responses API expects image_url as a string (the URL directly).
+	return map[string]any{
+		keyType:     "input_image",
+		keyImageURL: imageURL,
+	}
+}
+
+// imageURLFromMedia resolves an image URL from media, preferring an explicit URL
+// and falling back to a base64 data URL. Returns "" when neither is present.
+func imageURLFromMedia(media *types.MediaContent) string {
+	if media.URL != nil && *media.URL != "" {
+		return *media.URL
+	}
+	if media.Data != nil && *media.Data != "" {
+		mimeType := media.MIMEType
+		if mimeType == "" {
+			mimeType = "image/png" // Default mime type
+		}
+		return "data:" + mimeType + ";base64," + *media.Data
+	}
+	return ""
+}
+
+// convertToolsToResponsesFormat converts tools to Responses API format
+func (p *Provider) convertToolsToResponsesFormat(tools any) []any {
+	// Tools format is similar but uses "function" type with slightly different structure
+	openAITools, ok := tools.([]openAITool)
+	if !ok {
+		return nil
+	}
+
+	result := make([]any, len(openAITools))
+	for i, tool := range openAITools {
+		entry := map[string]any{
+			keyType:       typeFunction,
+			keyName:       tool.Function.Name,
+			"description": tool.Function.Description,
+			"parameters":  tool.Function.Parameters,
+		}
+		if tool.Function.Strict {
+			entry[keyStrict] = true
+		}
+		result[i] = entry
+	}
+	return result
+}
+
+// convertResponseFormatToResponses converts response format to Responses API format
+func (p *Provider) convertResponseFormatToResponses(rf *providers.ResponseFormat) map[string]any {
+	if rf == nil {
+		return nil
+	}
+
+	result := map[string]any{
+		keyFormat: map[string]any{
+			keyType: string(rf.Type),
+		},
+	}
+
+	if rf.Type == providers.ResponseFormatJSONSchema && len(rf.JSONSchema) > 0 {
+		var schema any
+		if err := json.Unmarshal(rf.JSONSchema, &schema); err == nil {
+			schemaName := rf.SchemaName
+			if schemaName == "" {
+				schemaName = defaultResponseSchema
+			}
+			result[keyFormat] = map[string]any{
+				keyType: typeJSONSchema,
+				typeJSONSchema: map[string]any{
+					keyName:   schemaName,
+					"schema":  schema,
+					keyStrict: rf.Strict,
+				},
+			}
+		}
+	}
+
+	return result
+}

--- a/runtime/providers/openai/responses_convert_test.go
+++ b/runtime/providers/openai/responses_convert_test.go
@@ -1,0 +1,373 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestRequiresResponsesAPI(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-5-pro", true},
+		{"o1-pro", true},
+		{"gpt-5.2-pro", true},
+		{"gpt-4o", false},
+		{"gpt-4o-realtime-preview", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := requiresResponsesAPI(tt.model); got != tt.want {
+			t.Errorf("requiresResponsesAPI(%q) = %v, want %v", tt.model, got, tt.want)
+		}
+	}
+}
+
+func TestTransformToResponsesCallID(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"fc_already", "fc_already"},
+		{"call_abc123", "fc_abc123"},
+		{"weirdformat", "fc_weirdformat"},
+		{"", "fc_"},
+	}
+	for _, tt := range tests {
+		if got := transformToResponsesCallID(tt.in); got != tt.want {
+			t.Errorf("transformToResponsesCallID(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestGetAPIMode_ConfigVsHeuristic(t *testing.T) {
+	tests := []struct {
+		name   string
+		model  string
+		config map[string]any
+		want   APIMode
+	}{
+		{"nil config, non-pro model defaults to completions", "gpt-4o", nil, APIModeCompletions},
+		{"nil config, pro model heuristic → responses", "gpt-5-pro", nil, APIModeResponses},
+		{"explicit responses wins", "gpt-4o", map[string]any{"api_mode": "responses"}, APIModeResponses},
+		{"explicit completions overrides pro heuristic", "gpt-5-pro", map[string]any{"api_mode": "completions"}, APIModeCompletions},
+		{"chat_completions alias", "gpt-4o", map[string]any{"api_mode": "chat_completions"}, APIModeCompletions},
+		{"legacy alias", "gpt-4o", map[string]any{"api_mode": "legacy"}, APIModeCompletions},
+		{"case-insensitive", "gpt-4o", map[string]any{"api_mode": "RESPONSES"}, APIModeResponses},
+		{"unknown api_mode falls through to heuristic (pro)", "gpt-5-pro", map[string]any{"api_mode": "banana"}, APIModeResponses},
+		{"unknown api_mode falls through to heuristic (default)", "gpt-4o", map[string]any{"api_mode": "banana"}, APIModeCompletions},
+		{"non-string api_mode ignored", "gpt-4o", map[string]any{"api_mode": 42}, APIModeCompletions},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAPIMode(tt.model, tt.config); got != tt.want {
+				t.Errorf("getAPIMode(%q, %v) = %q, want %q", tt.model, tt.config, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertSingleMessageToResponsesInput_ToolResult(t *testing.T) {
+	p := &Provider{}
+	tr := types.NewTextToolResult("call_abc", "lookup", "result text")
+	msg := &types.Message{Role: roleToolResult, ToolResult: &tr}
+
+	items := p.convertSingleMessageToResponsesInput(msg)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0]["type"] != "function_call_output" {
+		t.Errorf("type = %v, want function_call_output", items[0]["type"])
+	}
+	if items[0]["call_id"] != "call_abc" {
+		t.Errorf("call_id = %v, want call_abc", items[0]["call_id"])
+	}
+	if items[0]["output"] != "result text" {
+		t.Errorf("output = %v, want result text", items[0]["output"])
+	}
+}
+
+func TestConvertSingleMessageToResponsesInput_AssistantToolCallsSplit(t *testing.T) {
+	p := &Provider{}
+	msg := &types.Message{
+		Role:    "assistant",
+		Content: "let me check",
+		ToolCalls: []types.MessageToolCall{
+			{ID: "call_1", Name: "get_weather", Args: json.RawMessage(`{"city":"London"}`)},
+			{ID: "fc_2", Name: "get_time", Args: json.RawMessage(`{}`)},
+		},
+	}
+
+	items := p.convertSingleMessageToResponsesInput(msg)
+	// 1 message item (text) + 2 function_call items.
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d: %+v", len(items), items)
+	}
+	if items[0]["type"] != "message" {
+		t.Errorf("item[0].type = %v, want message", items[0]["type"])
+	}
+	if items[1]["type"] != typeFunctionCall {
+		t.Errorf("item[1].type = %v, want function_call", items[1]["type"])
+	}
+	// call_ prefix transformed to fc_ on the id field, call_id preserved.
+	if items[1]["id"] != "fc_1" {
+		t.Errorf("item[1].id = %v, want fc_1", items[1]["id"])
+	}
+	if items[1]["call_id"] != "call_1" {
+		t.Errorf("item[1].call_id = %v, want call_1", items[1]["call_id"])
+	}
+	if items[1]["arguments"] != `{"city":"London"}` {
+		t.Errorf("item[1].arguments = %v", items[1]["arguments"])
+	}
+	// Already-fc id preserved.
+	if items[2]["id"] != "fc_2" {
+		t.Errorf("item[2].id = %v, want fc_2", items[2]["id"])
+	}
+}
+
+func TestConvertSingleMessageToResponsesInput_AssistantToolCallsNoText(t *testing.T) {
+	p := &Provider{}
+	msg := &types.Message{
+		Role:      "assistant",
+		ToolCalls: []types.MessageToolCall{{ID: "call_1", Name: "x", Args: json.RawMessage(`{}`)}},
+	}
+	items := p.convertSingleMessageToResponsesInput(msg)
+	// No text ⇒ no leading message item, just the function_call.
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (no text message), got %d", len(items))
+	}
+	if items[0]["type"] != typeFunctionCall {
+		t.Errorf("type = %v, want function_call", items[0]["type"])
+	}
+}
+
+func TestConvertSingleMessageToResponsesInput_PlainUserMessage(t *testing.T) {
+	p := &Provider{}
+	msg := &types.Message{Role: "user", Content: "hello"}
+	items := p.convertSingleMessageToResponsesInput(msg)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0]["role"] != "user" {
+		t.Errorf("role = %v, want user", items[0]["role"])
+	}
+	if items[0]["content"] != "hello" {
+		t.Errorf("content = %v, want hello", items[0]["content"])
+	}
+}
+
+func TestConvertMessagesToResponsesInput_FlattensAll(t *testing.T) {
+	p := &Provider{}
+	msgs := []types.Message{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "sure", ToolCalls: []types.MessageToolCall{
+			{ID: "call_1", Name: "t", Args: json.RawMessage(`{}`)},
+		}},
+	}
+	input := p.convertMessagesToResponsesInput(msgs)
+	// user(1) + assistant-text(1) + function_call(1) = 3
+	if len(input) != 3 {
+		t.Fatalf("expected 3 flattened items, got %d", len(input))
+	}
+}
+
+func TestGetMessageContent_MultimodalImage(t *testing.T) {
+	p := &Provider{}
+	text := "look at this"
+	data := "aGVsbG8=" // base64 "hello"
+	msg := &types.Message{
+		Role: "user",
+		Parts: []types.ContentPart{
+			{Type: partTypeText, Text: &text},
+			{Type: "image", Media: &types.MediaContent{Data: &data, MIMEType: "image/jpeg"}},
+		},
+	}
+
+	content := p.getMessageContent(msg)
+	parts, ok := content.([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", content)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	if parts[0]["type"] != "input_text" {
+		t.Errorf("part[0].type = %v, want input_text", parts[0]["type"])
+	}
+	if parts[1]["type"] != "input_image" {
+		t.Errorf("part[1].type = %v, want input_image", parts[1]["type"])
+	}
+	if parts[1]["image_url"] != "data:image/jpeg;base64,aGVsbG8=" {
+		t.Errorf("image_url = %v, want data URL", parts[1]["image_url"])
+	}
+}
+
+func TestGetMessageContent_NoPartsReturnsText(t *testing.T) {
+	p := &Provider{}
+	msg := &types.Message{Role: "user", Content: "plain"}
+	if got := p.getMessageContent(msg); got != "plain" {
+		t.Errorf("getMessageContent = %v, want plain", got)
+	}
+}
+
+func TestConvertPartToResponsesFormat(t *testing.T) {
+	p := &Provider{}
+	url := "https://example.com/cat.png"
+
+	tests := []struct {
+		name      string
+		part      types.ContentPart
+		wantNil   bool
+		wantType  string
+		wantImage string
+	}{
+		{
+			name:     "text part",
+			part:     types.ContentPart{Type: partTypeText, Text: strPtr("hi")},
+			wantType: "input_text",
+		},
+		{
+			name:      "image with URL",
+			part:      types.ContentPart{Type: "image", Media: &types.MediaContent{URL: &url}},
+			wantType:  "input_image",
+			wantImage: url,
+		},
+		{
+			name:      "image base64 default mime",
+			part:      types.ContentPart{Type: "image", Media: &types.MediaContent{Data: strPtr("Zm9v")}},
+			wantType:  "input_image",
+			wantImage: "data:image/png;base64,Zm9v",
+		},
+		{
+			name:    "image with nil media yields nil",
+			part:    types.ContentPart{Type: "image"},
+			wantNil: true,
+		},
+		{
+			name:    "image with empty media yields nil",
+			part:    types.ContentPart{Type: "image", Media: &types.MediaContent{}},
+			wantNil: true,
+		},
+		{
+			name:    "unknown part type yields nil",
+			part:    types.ContentPart{Type: "audio"},
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.convertPartToResponsesFormat(&tt.part)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got["type"] != tt.wantType {
+				t.Errorf("type = %v, want %v", got["type"], tt.wantType)
+			}
+			if tt.wantImage != "" && got["image_url"] != tt.wantImage {
+				t.Errorf("image_url = %v, want %v", got["image_url"], tt.wantImage)
+			}
+		})
+	}
+}
+
+func TestConvertToolsToResponsesFormat(t *testing.T) {
+	p := &Provider{}
+
+	// Wrong type ⇒ nil.
+	if got := p.convertToolsToResponsesFormat("not tools"); got != nil {
+		t.Errorf("expected nil for wrong type, got %v", got)
+	}
+
+	tools := []openAITool{
+		{Type: "function", Function: openAIToolFunction{
+			Name: "a", Description: "desc a", Parameters: json.RawMessage(`{"type":"object"}`), Strict: true,
+		}},
+		{Type: "function", Function: openAIToolFunction{
+			Name: "b", Description: "desc b", Parameters: json.RawMessage(`{}`), Strict: false,
+		}},
+	}
+	got := p.convertToolsToResponsesFormat(tools)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(got))
+	}
+	first := got[0].(map[string]any)
+	if first["type"] != "function" || first["name"] != "a" {
+		t.Errorf("first tool wrong: %+v", first)
+	}
+	if first["strict"] != true {
+		t.Errorf("expected strict=true on first tool")
+	}
+	second := got[1].(map[string]any)
+	if _, hasStrict := second["strict"]; hasStrict {
+		t.Errorf("non-strict tool should omit strict key, got %+v", second)
+	}
+}
+
+func TestConvertResponseFormatToResponses(t *testing.T) {
+	p := &Provider{}
+
+	// nil ⇒ nil.
+	if got := p.convertResponseFormatToResponses(nil); got != nil {
+		t.Errorf("expected nil for nil format, got %v", got)
+	}
+
+	// Plain text format.
+	textRF := &providers.ResponseFormat{Type: providers.ResponseFormatText}
+	got := p.convertResponseFormatToResponses(textRF)
+	format := got["format"].(map[string]any)
+	if format["type"] != "text" {
+		t.Errorf("text format type = %v, want text", format["type"])
+	}
+
+	// JSON schema strict mode with explicit name.
+	schemaRF := &providers.ResponseFormat{
+		Type:       providers.ResponseFormatJSONSchema,
+		JSONSchema: json.RawMessage(`{"type":"object","properties":{"x":{"type":"string"}}}`),
+		SchemaName: "my_schema",
+		Strict:     true,
+	}
+	got = p.convertResponseFormatToResponses(schemaRF)
+	format = got["format"].(map[string]any)
+	if format["type"] != "json_schema" {
+		t.Fatalf("type = %v, want json_schema", format["type"])
+	}
+	js := format["json_schema"].(map[string]any)
+	if js["name"] != "my_schema" {
+		t.Errorf("name = %v, want my_schema", js["name"])
+	}
+	if js["strict"] != true {
+		t.Errorf("strict = %v, want true", js["strict"])
+	}
+	if js["schema"] == nil {
+		t.Errorf("schema should be populated")
+	}
+
+	// JSON schema with no name ⇒ default name.
+	defRF := &providers.ResponseFormat{
+		Type:       providers.ResponseFormatJSONSchema,
+		JSONSchema: json.RawMessage(`{"type":"object"}`),
+	}
+	got = p.convertResponseFormatToResponses(defRF)
+	js = got["format"].(map[string]any)["json_schema"].(map[string]any)
+	if js["name"] != defaultResponseSchema {
+		t.Errorf("default name = %v, want %v", js["name"], defaultResponseSchema)
+	}
+
+	// JSON schema type but empty schema ⇒ falls back to the bare {type:json_schema} format.
+	emptyRF := &providers.ResponseFormat{Type: providers.ResponseFormatJSONSchema}
+	got = p.convertResponseFormatToResponses(emptyRF)
+	format = got["format"].(map[string]any)
+	if format["type"] != string(providers.ResponseFormatJSONSchema) {
+		t.Errorf("empty-schema format type = %v", format["type"])
+	}
+	if _, hasJS := format["json_schema"]; hasJS {
+		t.Errorf("empty schema should not populate json_schema block")
+	}
+}


### PR DESCRIPTION
## What was hiding

The `*_integration.go` suffix exempts a file from the 80% coverage gate purely by **filename** (no build tags — these files compile normally). Real, pure logic was hiding behind the suffix in `runtime/providers/openai/`:

- **Money math** (`calculateCost`) — audio-vs-text per-1K rate math with a "token breakdown missing ⇒ treat all tokens as audio" fallback (~8x mis-bill risk) and config rate overrides.
- **GA session config translation** (`buildSessionConfig`) — `turn_detection:nil` ⇒ manual-turn semantics, VAD/transcription nesting, tools mapping.
- **Responses-API converters** (`getAPIMode`, message/tool/response-format converters, image data-URL handling) — none of which had unit tests.

## What this PR does

Extracts the pure functions into **normal (gated) sibling files** with table tests; the thin socket/HTTP glue stays in the suffixed files and now delegates. **No behavior change** — functions moved within the same package.

### New gated files (100% statement coverage on every function)

| File | Extracted |
|------|-----------|
| `realtime_cost.go` | `calculateRealtimeCost` (rate math, overrides, missing-breakdown fallback) |
| `realtime_config.go` | `buildRealtimeSessionConfig`, `outputModalities`, `pcmFormat`, `markToolCallEmitted`, `realtimeWSURL`, `realtimeWSHeaders` |
| `responses_convert.go` | `getAPIMode`, `requiresResponsesAPI`, `transformToResponsesCallID`, `convertMessages/SingleMessageToResponsesInput`, `convertToolsToResponsesFormat`, `convertResponseFormatToResponses`, `getMessageContent`, `convertPartToResponsesFormat` (+`imageResponsesPart`/`imageURLFromMedia`) |

### Tests added

- `realtime_cost_test.go` — with/without breakdown, rate overrides, zero tokens, the audio-vs-text ~8x mis-bill guard, and the delegating method.
- `realtime_config_test.go` — VAD nil vs set, tools present/absent, modalities, pcm codec, dedup guard, and a **GA regression guard** asserting the WS handshake sets `Authorization` and does **not** set `OpenAI-Beta`, with `?model=` in the URL.
- `responses_convert_test.go` — config-vs-heuristic API-mode precedence, `call_`→`fc_` transform, tool-call splitting into `function_call`/`function_call_output` items, json_schema strict mode, image data-URL.
- `realtime_tools_test.go` — drives `SendToolResponse`/`SendToolResponses` against the fake-WS harness, asserting the emitted `function_call_output` items + single `response.create`, and closed-session errors.

### calculateCost verification

Behavior verified correct — **no bug found**. With a token breakdown it bills audio and text tokens separately at their rates; config overrides apply to audio rates only; a **missing** breakdown bills the full token count at audio rates (never $0 or text rates); zero tokens ⇒ zero cost.

### Minor
- `handleStreamEvent` now takes `*responsesStreamEvent` (was a ~120-byte value copy per SSE event), removing a now-dead `//nolint:gocritic` directive.
- Repeated JSON keys/values in the moved converters are named as package constants to keep `goconst` clean.

## Verification

- `go test -race -count=1 ./providers/openai/...` — green
- Coverage on each new gated file: **100%**
- New-code lint: clean
