### PR TITLE
chore(ci): replace *_integration.go coverage escape-hatch with an explicit allowlist

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -156,8 +156,16 @@ else
             print_info "Linting $module..."
 
             # --new-from-rev=HEAD reports issues only in new/changed code.
+            # `env -u GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE`: when this hook runs
+            # from a linked git worktree, `git commit` exports GIT_DIR (an
+            # absolute path under .git/worktrees/<name>) into the hook env.
+            # golangci-lint's go-git-based revgrep then cannot resolve the work
+            # tree, fails open, and floods the whole module's pre-existing debt
+            # instead of just the diff. Unsetting those vars restores correct
+            # new-from-rev scoping (main repo and worktree behave identically).
             set +e
-            lint_out=$(run_in_module "$module" golangci-lint run --new-from-rev=HEAD --timeout=3m ./... 2>&1)
+            lint_out=$(run_in_module "$module" env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE \
+                golangci-lint run --new-from-rev=HEAD --timeout=3m ./... 2>&1)
             lint_rc=$?
             set -e
             [ -n "$lint_out" ] && echo "$lint_out"
@@ -272,14 +280,44 @@ else
         COVERAGE_FAILED=0
         COVERAGE_RESULTS=()
         
+        # Files exempt from the coverage gate — MUST stay in sync with
+        # sonar.coverage.exclusions. Each is thin live-I/O glue that cannot run
+        # in CI (real network/websocket to a provider, ffmpeg subprocess,
+        # cloud-SDK credential fetch) or a cross-package test harness. The
+        # *_integration.go / *_interactive.go suffix ALONE no longer grants an
+        # exemption — only membership in this list does — so new code cannot
+        # dodge the gate by adopting the suffix. Extract pure logic into a gated
+        # sibling and test it instead of adding entries here.
+        COVERAGE_EXEMPT_FILES="runtime/credentials/aws_integration.go
+runtime/credentials/azure_integration.go
+runtime/credentials/gcp_integration.go
+runtime/media/audio_converter_integration.go
+runtime/pipeline/stage/stages_video_frames_integration.go
+runtime/providers/gemini/stream_session_integration.go
+runtime/providers/gemini/stream_session_protocol_integration.go
+runtime/providers/gemini/stream_session_tools_integration.go
+runtime/providers/openai/openai_responses_integration.go
+runtime/providers/openai/realtime_session_integration.go
+runtime/providers/openai/realtime_tools_integration.go
+runtime/providers/openai/realtime_websocket_integration.go
+runtime/providers/openai/streaming_support_integration.go
+runtime/providers/provider_contract_integration.go
+runtime/skills/installer_integration.go
+runtime/tts/cartesia_interactive.go"
+
         if [ -f "$MERGED_COVERAGE" ]; then
-            # Check each staged Go file (excluding test, interactive, and integration files)
+            # Check each staged Go file (test files and the explicit exempt
+            # allowlist are skipped; the suffix alone is not an exemption).
             for file in $STAGED_GO_FILES; do
-                # Skip test files, interactive files, and integration files
-                if [[ "$file" == *_test.go ]] || [[ "$file" == *_interactive.go ]] || [[ "$file" == *_integration.go ]]; then
+                # Always skip test files.
+                if [[ "$file" == *_test.go ]]; then
                     continue
                 fi
-                
+                # Skip only files on the explicit coverage-exemption allowlist.
+                if printf '%s\n' "$COVERAGE_EXEMPT_FILES" | grep -qxF "$file"; then
+                    continue
+                fi
+
                 # Skip example files (examples directory) and integration tests (tests directory)
                 if [[ "$file" == examples/* ]] || [[ "$file" == */examples/* ]] || [[ "$file" == tests/* ]]; then
                     continue
@@ -345,7 +383,7 @@ else
                 echo ""
                 if [ $COVERAGE_FAILED -eq 1 ]; then
                     print_error "Some files have insufficient test coverage (threshold: ${COVERAGE_THRESHOLD}%)"
-                    print_info "Add tests or move untestable code to *_interactive.go or *_integration.go files"
+                    print_info "Add tests. If the code is genuinely un-runnable in CI (live network/device/subprocess), extract the pure logic into a gated sibling and test THAT — renaming to *_integration.go no longer exempts a file; only the COVERAGE_EXEMPT_FILES allowlist (mirrored in sonar.coverage.exclusions) does."
                     CHECKS_FAILED=1
                 else
                     print_success "All changed files meet coverage threshold (≥${COVERAGE_THRESHOLD}%)"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,15 @@ sonar.projectVersion=1.0
 # Source configuration - Include Go, TypeScript, and JavaScript production source files
 sonar.sources=sdk,runtime,pkg
 sonar.inclusions=**/*.go,**/*.ts,**/*.js
-sonar.exclusions=**/*_test.go,**/test_*.go,**/*.test.ts,**/*.test.js,**/tests/**,**/testdata/**,**/vendor/**,**/bin/**,**/docs/**,**/*.md,**/.git/**,**/node_modules/**,**/examples/**,**/*example*/**,**/.vscode/**,**/.scannerwork/**,**/*_interactive.go,**/*_integration.go,**/__mocks__/**,**/dist/**,**/coverage/**,**/jest.config.js,**/jest.config.ts
+# NOTE: the *_interactive.go / *_integration.go suffix is NO LONGER an exclusion
+# pattern. The handful of files legitimately kept out of analysis (thin live-I/O
+# glue / test harnesses) are listed explicitly below, mirroring the
+# sonar.coverage.exclusions allowlist. This stops new code from escaping analysis
+# and the coverage gate simply by adopting the suffix — a new *_integration.go is
+# now analyzed and coverage-gated unless it is deliberately added to both lists.
+# (Follow-up worth considering: drop these from sonar.exclusions so the live glue
+# is bug/security-analyzed while staying coverage-exempt via the list below.)
+sonar.exclusions=**/*_test.go,**/test_*.go,**/*.test.ts,**/*.test.js,**/tests/**,**/testdata/**,**/vendor/**,**/bin/**,**/docs/**,**/*.md,**/.git/**,**/node_modules/**,**/examples/**,**/*example*/**,**/.vscode/**,**/.scannerwork/**,**/__mocks__/**,**/dist/**,**/coverage/**,**/jest.config.js,**/jest.config.ts,runtime/credentials/aws_integration.go,runtime/credentials/azure_integration.go,runtime/credentials/gcp_integration.go,runtime/media/audio_converter_integration.go,runtime/pipeline/stage/stages_video_frames_integration.go,runtime/providers/gemini/stream_session_integration.go,runtime/providers/gemini/stream_session_protocol_integration.go,runtime/providers/gemini/stream_session_tools_integration.go,runtime/providers/openai/openai_responses_integration.go,runtime/providers/openai/realtime_session_integration.go,runtime/providers/openai/realtime_tools_integration.go,runtime/providers/openai/realtime_websocket_integration.go,runtime/providers/openai/streaming_support_integration.go,runtime/providers/provider_contract_integration.go,runtime/skills/installer_integration.go,runtime/tts/cartesia_interactive.go
 
 # Test files completely excluded from analysis
 # sonar.tests=.
@@ -21,8 +29,14 @@ sonar.go.coverage.reportPaths=coverage.out
 sonar.go.golangci-lint.reportPaths=golangci-lint-report.json
 
 
-# Coverage exclusions - exclude example code, untestable interactive I/O code, integration test code, platform-specific code (CI runs on Linux), and test helpers (narrow list — remove entries as tests land)
-sonar.coverage.exclusions=**/examples/**,**/*example*/**,**/*_interactive.go,**/*_integration.go,**/*_windows.go,**/*_darwin.go,**/__mocks__/**,**/dist/**,**/providers/provider_contract.go
+# Coverage exclusions — EXPLICIT allowlist, not a suffix glob. Each entry is
+# either thin live-I/O glue that cannot run in CI (real network/websocket to a
+# provider, ffmpeg subprocess, cloud-SDK credential fetch) or a cross-package
+# test harness. Pure/testable logic must be extracted into a gated sibling and
+# covered — the *_interactive.go / *_integration.go suffix does NOT grant a
+# coverage exemption by itself. Adding a file here should be a reviewed decision.
+# Keeps: example code, platform-specific files (CI runs on Linux), TS mocks/dist.
+sonar.coverage.exclusions=**/examples/**,**/*example*/**,**/*_windows.go,**/*_darwin.go,**/__mocks__/**,**/dist/**,runtime/credentials/aws_integration.go,runtime/credentials/azure_integration.go,runtime/credentials/gcp_integration.go,runtime/media/audio_converter_integration.go,runtime/pipeline/stage/stages_video_frames_integration.go,runtime/providers/gemini/stream_session_integration.go,runtime/providers/gemini/stream_session_protocol_integration.go,runtime/providers/gemini/stream_session_tools_integration.go,runtime/providers/openai/openai_responses_integration.go,runtime/providers/openai/realtime_session_integration.go,runtime/providers/openai/realtime_tools_integration.go,runtime/providers/openai/realtime_websocket_integration.go,runtime/providers/openai/streaming_support_integration.go,runtime/providers/provider_contract_integration.go,runtime/skills/installer_integration.go,runtime/tts/cartesia_interactive.go
 
 # Duplication exclusions - fan-in accumulator stages share intentional design pattern code
 # GitHub Actions runner files have similar patterns across actions


### PR DESCRIPTION
## Why

The `*_interactive.go` / `*_integration.go` suffix exempted a file from the **80% coverage gate** in both SonarCloud and the pre-commit hook — purely by filename, with no build tag. That let testable logic dodge coverage. The audit + PRs #1559, #1562–#1568 already moved the real logic back onto the gate (extracting pure funcs into gated siblings, renaming fully-testable files, deleting one dead stage). **This PR closes the hatch structurally so it can't recur.**

## Changes

**`sonar-project.properties`**
- Drop the blanket `**/*_interactive.go` / `**/*_integration.go` globs from `sonar.exclusions` and `sonar.coverage.exclusions`.
- Replace with an **explicit 16-file allowlist** — the files that genuinely can't be covered in CI: thin live-I/O glue (real provider network/websocket, ffmpeg subprocess, cloud-SDK credential fetch) and the cross-package `provider_contract` test harness.
- Remove the dead `**/providers/provider_contract.go` entry (that file is now `provider_contract_integration.go`, on the list).
- A new `*_integration.go` is now analyzed + coverage-gated **unless deliberately added to the list** (a reviewed decision).

**`scripts/pre-commit.sh`**
- Replace the suffix-based coverage skip with the same explicit `COVERAGE_EXEMPT_FILES` allowlist (kept in sync with sonar), and fix the failure hint that literally told devs to rename code to `*_integration.go` to dodge the gate.
- **Fix a worktree bug:** committing from a linked git worktree exports `GIT_DIR` into the hook, which breaks golangci-lint's `--new-from-rev` scoping (it floods the whole module's pre-existing debt instead of the diff). Wrap the lint call in `env -u GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE`. Five subagents hit this during the audit; one resorted to `--no-verify` because of it.

## Verified
- `bash -n scripts/pre-commit.sh` passes; allowlist membership logic tested: exempt files skip, a new non-listed `*_integration.go` is gated, gated files are checked.
- No blanket suffix globs remain in either exclusion list.

## Follow-ups (noted inline, out of scope here)
1. Consider dropping the 16 files from `sonar.exclusions` so live glue is bug/security-analyzed while staying coverage-exempt via the list.
2. The `e12`–`e23` suffix-based issue-ignore rules (complexity/hotspots) are now partly redundant and could be tightened.
3. `sonar.sources` still omits `server/` (a shipped module outside the quality gate) — pre-existing, separate from this hatch.
