### PR TITLE
chore(ci): analyze server/a2a in Sonar + tidy the suffix-based issue ignores

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,17 +7,18 @@ sonar.projectName=PromptKit
 sonar.projectVersion=1.0
 
 # Source configuration - Include Go, TypeScript, and JavaScript production source files
-sonar.sources=sdk,runtime,pkg
+# `server` covers the shipped server/a2a module (previously analysed by nothing —
+# its coverage was uploaded but never mapped because the tree wasn't a source).
+sonar.sources=sdk,runtime,pkg,server
 sonar.inclusions=**/*.go,**/*.ts,**/*.js
-# NOTE: the *_interactive.go / *_integration.go suffix is NO LONGER an exclusion
-# pattern. The handful of files legitimately kept out of analysis (thin live-I/O
-# glue / test harnesses) are listed explicitly below, mirroring the
-# sonar.coverage.exclusions allowlist. This stops new code from escaping analysis
-# and the coverage gate simply by adopting the suffix — a new *_integration.go is
-# now analyzed and coverage-gated unless it is deliberately added to both lists.
-# (Follow-up worth considering: drop these from sonar.exclusions so the live glue
-# is bug/security-analyzed while staying coverage-exempt via the list below.)
-sonar.exclusions=**/*_test.go,**/test_*.go,**/*.test.ts,**/*.test.js,**/tests/**,**/testdata/**,**/vendor/**,**/bin/**,**/docs/**,**/*.md,**/.git/**,**/node_modules/**,**/examples/**,**/*example*/**,**/.vscode/**,**/.scannerwork/**,**/__mocks__/**,**/dist/**,**/coverage/**,**/jest.config.js,**/jest.config.ts,runtime/credentials/aws_integration.go,runtime/credentials/azure_integration.go,runtime/credentials/gcp_integration.go,runtime/media/audio_converter_integration.go,runtime/pipeline/stage/stages_video_frames_integration.go,runtime/providers/gemini/stream_session_integration.go,runtime/providers/gemini/stream_session_protocol_integration.go,runtime/providers/gemini/stream_session_tools_integration.go,runtime/providers/openai/openai_responses_integration.go,runtime/providers/openai/realtime_session_integration.go,runtime/providers/openai/realtime_tools_integration.go,runtime/providers/openai/realtime_websocket_integration.go,runtime/providers/openai/streaming_support_integration.go,runtime/providers/provider_contract_integration.go,runtime/skills/installer_integration.go,runtime/tts/cartesia_interactive.go
+# The *_interactive.go / *_integration.go suffix is NOT an exclusion pattern.
+# Files that legitimately can't be covered in CI (thin live-I/O glue, test
+# harnesses) are NOT excluded from analysis — they are production code that
+# ships and must be bug/security-analysed. They are only exempt from the
+# COVERAGE requirement, via the explicit sonar.coverage.exclusions allowlist
+# below. A new *_integration.go is analysed and coverage-gated unless it is
+# deliberately added to that list.
+sonar.exclusions=**/*_test.go,**/test_*.go,**/*.test.ts,**/*.test.js,**/tests/**,**/testdata/**,**/vendor/**,**/bin/**,**/docs/**,**/*.md,**/.git/**,**/node_modules/**,**/examples/**,**/*example*/**,**/.vscode/**,**/.scannerwork/**,**/__mocks__/**,**/dist/**,**/coverage/**,**/jest.config.js,**/jest.config.ts
 
 # Test files completely excluded from analysis
 # sonar.tests=.
@@ -50,17 +51,15 @@ sonar.cpd.exclusions=**/runtime/pipeline/stage/stages_video_frames.go,**/runtime
 # e9: Disable godre:S8177 rule globally
 # e10: Disable godre:S8179 rule globally
 # e11: Disable godre:S1172 (unused parameters) - rely on golangci-lint/unparam instead
-sonar.issue.ignore.multicriteria=e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23
-sonar.issue.ignore.multicriteria.e12.ruleKey=common-go:InsufficientLineCoverage
-sonar.issue.ignore.multicriteria.e12.resourceKey=**/*_interactive.go
-sonar.issue.ignore.multicriteria.e13.ruleKey=common-go:InsufficientBranchCoverage
-sonar.issue.ignore.multicriteria.e13.resourceKey=**/*_interactive.go
+sonar.issue.ignore.multicriteria=e7,e8,e9,e10,e11,e14,e17,e18,e19,e20,e21,e22,e23
+# e14/e17: suppress cognitive-complexity (S3776) on live-I/O glue (interactive/
+# integration files) — provider session loops and protocol handlers are
+# irreducibly branchy. The InsufficientLineCoverage/BranchCoverage ignores that
+# used to sit here for these suffixes were removed: they are redundant now that
+# the coverage gate is driven by the sonar.coverage.exclusions allowlist, and a
+# non-exempt *_integration.go MUST be coverage-gated, not waved through.
 sonar.issue.ignore.multicriteria.e14.ruleKey=go:S3776
 sonar.issue.ignore.multicriteria.e14.resourceKey=**/*_interactive.go
-sonar.issue.ignore.multicriteria.e15.ruleKey=common-go:InsufficientLineCoverage
-sonar.issue.ignore.multicriteria.e15.resourceKey=**/*_integration.go
-sonar.issue.ignore.multicriteria.e16.ruleKey=common-go:InsufficientBranchCoverage
-sonar.issue.ignore.multicriteria.e16.resourceKey=**/*_integration.go
 sonar.issue.ignore.multicriteria.e17.ruleKey=go:S3776
 sonar.issue.ignore.multicriteria.e17.resourceKey=**/*_integration.go
 sonar.issue.ignore.multicriteria.e7.ruleKey=go:S1135


### PR DESCRIPTION
Follow-ups from #1569. Confirmed via the SonarCloud API that the quality gate is **100% new-code-only** (every condition is `new_*`; no overall/absolute rating thresholds), so none of these can fail the gate on existing lines.

## 1. Fix the `server/a2a` analysis gap
`server/a2a` is a shipped module — CI lints/tests it and uploads its coverage — but it was **outside `sonar.sources`** (`sdk,runtime,pkg`), so SonarCloud analyzed none of it and silently dropped that coverage. Added `server` to `sonar.sources`; `server/` contains only `a2a/`.

## 2. Analyze the live-glue files (stop hiding them from Sonar)
The 16 live-I/O / test-harness files were excluded from **analysis** entirely. They're production code that makes network/websocket/credential calls — exactly the code that benefits from bug/security analysis. Dropped them from `sonar.exclusions`; they remain in `sonar.coverage.exclusions` (coverage-exempt only).

## 3. Drop the now-redundant suffix-keyed coverage-issue ignores
Removed `e12/e13/e15/e16` (`common-go:InsufficientLineCoverage`/`BranchCoverage` on `*_interactive.go`/`*_integration.go`) — redundant now that the coverage gate is driven by the `sonar.coverage.exclusions` allowlist, and a non-exempt `*_integration.go` must be gated. Kept `e14/e17` (S3776 cognitive complexity — provider session loops are irreducibly branchy) and `e18–e23` (security hotspots on interactive dev-tool files).

## Verified
Multicriteria list and rule definitions are consistent (13 rules, no orphans); no leftover `e12/e13/e15/e16`. The SonarCloud job on this PR is the live validation of the parse + gate.
