### PR TITLE
test(sdk): assert shipped example packs are PromptPack-schema compliant

### DIFF
--- a/examples/a2a-demo/assistant.pack.json
+++ b/examples/a2a-demo/assistant.pack.json
@@ -1,16 +1,22 @@
 {
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "a2a-demo-assistant",
   "name": "a2a-demo-assistant",
   "version": "1.0.0",
   "description": "Demo assistant for A2A examples",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
   "prompts": {
     "chat": {
-      "provider": {
-        "type": "openai"
-      },
-      "model": "gpt-4o-mini",
-      "task_type": "chat",
-      "system": "You are a helpful assistant. Answer questions clearly and concisely. When tools are available, use them to provide accurate information.",
-      "max_tokens": 1024
+      "id": "chat",
+      "name": "Chat Assistant",
+      "version": "1.0.0",
+      "system_template": "You are a helpful assistant. Answer questions clearly and concisely. When tools are available, use them to provide accurate information.",
+      "parameters": {
+        "max_tokens": 1024
+      }
     }
   }
 }

--- a/sdk/examples/client-tools/client-tools.pack.json
+++ b/sdk/examples/client-tools/client-tools.pack.json
@@ -21,7 +21,6 @@
     "get_location": {
       "name": "get_location",
       "description": "Get the user's current GPS location",
-      "mode": "client",
       "parameters": {
         "type": "object",
         "properties": {
@@ -30,13 +29,6 @@
             "enum": ["high", "low"],
             "description": "GPS accuracy level"
           }
-        }
-      },
-      "client": {
-        "consent": {
-          "required": true,
-          "message": "This app wants to access your location",
-          "decline_strategy": "graceful"
         }
       }
     }

--- a/sdk/examples/client-tools/main_interactive.go
+++ b/sdk/examples/client-tools/main_interactive.go
@@ -70,9 +70,8 @@ func deferredExample() {
 	if resp.HasPendingClientTools() {
 		for _, tool := range resp.ClientTools() {
 			fmt.Printf("  [Client] Tool requested: %s\n", tool.ToolName)
-			fmt.Printf("  [Client] Consent message: %s\n", tool.ConsentMsg)
 
-			// Simulate user granting consent and providing data.
+			// Simulate the caller fulfilling the client tool on-device.
 			err := conv.SendToolResult(ctx, tool.CallID, map[string]any{
 				"lat": 37.7749, "lon": -122.4194, "city": "San Francisco",
 			})

--- a/sdk/examples/openai-realtime/openai-realtime.pack.json
+++ b/sdk/examples/openai-realtime/openai-realtime.pack.json
@@ -24,14 +24,15 @@
       "name": "Real-time Translator",
       "version": "1.0.0",
       "system_template": "You are a real-time translator. When you hear speech, translate it to {{target_language}}. Respond only with the translation, speaking naturally in the target language.",
-      "variables": {
-        "target_language": {
+      "variables": [
+        {
+          "name": "target_language",
           "type": "string",
           "required": true,
           "default": "Spanish",
           "description": "The target language for translation"
         }
-      },
+      ],
       "parameters": {
         "temperature": 0.6,
         "max_tokens": 500

--- a/sdk/examples/sdk-http-auth/assistant.pack.json
+++ b/sdk/examples/sdk-http-auth/assistant.pack.json
@@ -1,7 +1,13 @@
 {
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "http-auth-demo",
   "name": "http-auth-demo",
   "version": "1.0.0",
   "description": "Demonstrates HTTP tool authentication patterns",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
   "tools": {
     "get_customer": {
       "name": "get_customer",
@@ -48,7 +54,10 @@
   },
   "prompts": {
     "assistant": {
-      "system": "You are a helpful assistant with access to customer, product, and analytics tools.",
+      "id": "assistant",
+      "name": "HTTP Auth Assistant",
+      "version": "1.0.0",
+      "system_template": "You are a helpful assistant with access to customer, product, and analytics tools.",
       "tools": ["get_customer", "search_products", "get_analytics"]
     }
   }

--- a/sdk/internal/pack/examples_schema_compliance_test.go
+++ b/sdk/internal/pack/examples_schema_compliance_test.go
@@ -8,23 +8,17 @@ import (
 )
 
 // packSchemaExceptions lists example packs that intentionally do NOT validate
-// against the embedded PromptPack schema, with the reason. Anything not listed
-// here MUST validate cleanly — that is the whole point of this test: the packs
-// we ship are the spec's reference material, so they have to be spec-compliant.
+// against the embedded PromptPack schema, keyed by a path substring with the
+// reason. It is currently empty: every shipped pack is spec-compliant, which is
+// the whole point of this test — the packs we ship are the spec's reference
+// material.
 //
-// The key is a path substring (matched against the discovered file path).
-var packSchemaExceptions = map[string]string{
-	// client-tools declares tool-level `mode: "client"` and a `client: {consent}`
-	// block. These are real runtime concepts (runtime/tools.ToolDescriptor.Mode +
-	// ClientConfig, documented as a built-in mode in runtime/CLAUDE.md), but they
-	// are ahead of the published spec on two fronts: (1) the upstream
-	// promptpack.org schema's Tool definition is additionalProperties:false and
-	// does not yet model them, and (2) the SDK loader (pack.ToToolRepository)
-	// currently drops them and hardcodes Mode:"local". Until the schema models
-	// client tools and the loader reads them, this example is knowingly ahead of
-	// spec. See https://github.com/AltairaLabs/promptpack-spec.
-	"client-tools": "declares tool mode/client (client-side execution) not yet in the published schema",
-}
+// If you must add an entry, prefer fixing the pack. A legitimate exception is
+// one where the pack is deliberately ahead of the published schema; note that a
+// tool's execution mode (client/live/mcp/...) is a HOSTING concern bound by the
+// host (e.g. conv.OnClientTool), not a pack field — do not reintroduce it here.
+// The test below asserts excepted packs still FAIL, so the list can't rot.
+var packSchemaExceptions = map[string]string{}
 
 // TestExamplePacksAreSchemaCompliant validates every *.pack.json we ship (SDK
 // examples + testdata) against the embedded PromptPack schema. New or edited

--- a/sdk/internal/pack/examples_schema_compliance_test.go
+++ b/sdk/internal/pack/examples_schema_compliance_test.go
@@ -26,9 +26,14 @@ var packSchemaExceptions = map[string]string{}
 // example smoke test passes WithSkipSchemaValidation() and nothing checks that
 // the shipped packs actually conform to the schema they advertise.
 func TestExamplePacksAreSchemaCompliant(t *testing.T) {
+	// Cover every *.pack.json we ship, across modules. These are file reads +
+	// schema validation only (no cross-module compilation), so walking sibling
+	// module trees from here is safe. Paths are relative to this package dir.
 	roots := []string{
-		filepath.Join("..", "..", "examples"),
-		filepath.Join("..", "..", "testdata", "packs"),
+		filepath.Join("..", "..", "examples"),          // sdk/examples
+		filepath.Join("..", "..", "testdata", "packs"), // sdk/testdata/packs
+		filepath.Join("..", "..", "..", "examples"),    // repo-root examples/
+		filepath.Join("..", "..", "..", "benchmarks"),  // benchmarks/
 	}
 
 	var files []string

--- a/sdk/internal/pack/examples_schema_compliance_test.go
+++ b/sdk/internal/pack/examples_schema_compliance_test.go
@@ -1,0 +1,95 @@
+package pack
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// packSchemaExceptions lists example packs that intentionally do NOT validate
+// against the embedded PromptPack schema, with the reason. Anything not listed
+// here MUST validate cleanly — that is the whole point of this test: the packs
+// we ship are the spec's reference material, so they have to be spec-compliant.
+//
+// The key is a path substring (matched against the discovered file path).
+var packSchemaExceptions = map[string]string{
+	// client-tools declares tool-level `mode: "client"` and a `client: {consent}`
+	// block. These are real runtime concepts (runtime/tools.ToolDescriptor.Mode +
+	// ClientConfig, documented as a built-in mode in runtime/CLAUDE.md), but they
+	// are ahead of the published spec on two fronts: (1) the upstream
+	// promptpack.org schema's Tool definition is additionalProperties:false and
+	// does not yet model them, and (2) the SDK loader (pack.ToToolRepository)
+	// currently drops them and hardcodes Mode:"local". Until the schema models
+	// client tools and the loader reads them, this example is knowingly ahead of
+	// spec. See https://github.com/AltairaLabs/promptpack-spec.
+	"client-tools": "declares tool mode/client (client-side execution) not yet in the published schema",
+}
+
+// TestExamplePacksAreSchemaCompliant validates every *.pack.json we ship (SDK
+// examples + testdata) against the embedded PromptPack schema. New or edited
+// example packs that drift from the spec fail here, closing the gap where every
+// example smoke test passes WithSkipSchemaValidation() and nothing checks that
+// the shipped packs actually conform to the schema they advertise.
+func TestExamplePacksAreSchemaCompliant(t *testing.T) {
+	roots := []string{
+		filepath.Join("..", "..", "examples"),
+		filepath.Join("..", "..", "testdata", "packs"),
+	}
+
+	var files []string
+	for _, root := range roots {
+		err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() && strings.HasSuffix(p, ".pack.json") {
+				files = append(files, p)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	if len(files) == 0 {
+		t.Fatal("no *.pack.json files discovered — check the example/testdata roots")
+	}
+
+	for _, f := range files {
+		f := f
+		t.Run(f, func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+
+			err = ValidateAgainstSchema(data)
+
+			if reason, excepted := exceptionFor(f); excepted {
+				// Excepted packs must still fail. If one starts passing, the
+				// schema/loader has caught up — remove it from the allowlist.
+				if err == nil {
+					t.Fatalf("%s is on the schema-exception allowlist (%q) but now "+
+						"validates cleanly — remove it from packSchemaExceptions", f, reason)
+				}
+				t.Logf("known exception (%s): %v", reason, err)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("%s does not conform to the PromptPack schema:\n%v", f, err)
+			}
+		})
+	}
+}
+
+func exceptionFor(path string) (string, bool) {
+	for substr, reason := range packSchemaExceptions {
+		if strings.Contains(path, substr) {
+			return reason, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
## Problem

SDK example smoke tests open their packs with `WithSkipSchemaValidation()`, and `sdk.Open` validates by default (skip is opt-in) — so **no test verified that the packs we ship actually conform to the PromptPack schema they advertise**. Running the real validator over every `*.pack.json` in the repo surfaced **4 non-compliant packs across 3 example areas**, two of which were also latent runtime bugs (empty system prompts) and one that couldn't load at all.

## Fixed packs

- **openai-realtime** — `translator.variables` was a JSON object; the schema and the SDK's `[]Variable` both require an **array** (as an object it never unmarshalled). Unnoticed because the example opens `assistant`, never `translator`.
- **sdk-http-auth** — missing top-level `id` / `template_engine`; prompt used `system` instead of `system_template` (silently dropped → **empty system prompt**), plus missing `id`/`name`/`version`. Verified fixed (0 → 82 chars).
- **a2a-demo** (repo-root `examples/`) — stale pre-1.0 format: missing `id`/`template_engine`, prompt used `system` with no `id`/`name`/`version`, `max_tokens` at prompt level, and carried `provider`/`model`/`task_type`. Because `sdk.Open` validates by default, **the demo could not load at all** (both `tools/main.go` and `server/main.go`). Rewritten to spec; verified it loads (system prompt 0 → 136 chars, `max_tokens` parsed). `provider`/`model`/`task_type` dropped — see below.
- **client-tools** — declared tool-level `mode: "client"` + `client: { consent }`. A tool's **execution mode and consent policy are hosting concerns** bound by the host (`conv.OnClientTool(name, …)`), not properties of a portable pack. The SDK already works this way: `pack.Tool` has no such fields (so `encoding/json` discarded them on every load) and `ToToolRepository` defaults `Mode` to `"local"` for the host to override — the declared consent never reached the runtime. Removed the fields (no-op for the loader; now schema-compliant) and dropped the dead consent print from the interactive example.

## Guard

`TestExamplePacksAreSchemaCompliant` walks **every** shipped pack tree — `sdk/examples`, `sdk/testdata/packs`, repo-root `examples/`, and `benchmarks/` — and validates each `*.pack.json` against the embedded schema. **All 32 packs pass, no exceptions.** A `packSchemaExceptions` mechanism remains (currently empty, with an anti-rot assertion that excepted packs must still fail) for any future pack genuinely ahead of the published schema — with a note that execution mode must not be reintroduced as a pack field.

## Notes

- Embedded schema was **not** modified — the upstream freshness gate is unaffected, and no hosting concept was leaked into the spec.
- Smoke tests still skip schema validation; this central test is the dedicated guard and also covers packs (openai-realtime, sdk-http-auth, a2a-demo) that have no smoke test.

## Test

```
go test ./sdk/internal/pack/ -run TestExamplePacksAreSchemaCompliant -count=1   # PASS (32/32)
```
