### PR TITLE
fix(pipeline): populate real message/token/cost on pipeline.completed (fix messageCount:0)

### DIFF
--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -110,16 +110,19 @@ func (p *StreamPipeline) executeBackground(ctx context.Context, input <-chan Str
 	// Create channels between stages
 	channels := p.createChannels()
 
-	// Start stages and collect output
+	// Start stages and collect output. totals accumulates the message/token/cost
+	// counts as output elements flow through, so the completion event reports
+	// real numbers instead of zeros.
+	totals := &completionTotals{}
 	stageErrors := p.startStages(ctx, input, channels)
-	outputDone := p.startOutputCollection(channels, output)
+	outputDone := p.startOutputCollection(channels, output, totals)
 
 	// Wait for errors and output collection
 	firstError := p.waitForStageErrors(stageErrors)
 	<-outputDone
 
-	// Emit completion event
-	p.emitCompletionEvent(firstError, time.Since(start))
+	// Emit completion event with the real totals observed during collection.
+	p.emitCompletionEvent(firstError, time.Since(start), totals)
 }
 
 // monitorExecutionTimeout logs when execution timeout triggers.
@@ -169,10 +172,11 @@ func (p *StreamPipeline) startStages(ctx context.Context, input <-chan StreamEle
 func (p *StreamPipeline) startOutputCollection(
 	channels map[string]chan StreamElement,
 	output chan<- StreamElement,
+	totals *completionTotals,
 ) <-chan struct{} {
 	outputDone := make(chan struct{})
 	go func() {
-		p.collectOutput(channels, output)
+		p.collectOutput(channels, output, totals)
 		close(output)
 		close(outputDone)
 	}()
@@ -190,8 +194,48 @@ func (p *StreamPipeline) waitForStageErrors(stageErrors <-chan error) error {
 	return firstError
 }
 
+// completionTotals accumulates the message/token/cost counts observed as output
+// elements flow through collectOutput, so the pipeline.completed event carries
+// real numbers instead of placeholder zeros. It is written from the (possibly
+// concurrent) leaf fan-in goroutines, so access is mutex-guarded; the lock is
+// only taken for elements that carry a Message, which are rare relative to
+// audio/text stream elements.
+type completionTotals struct {
+	mu           sync.Mutex
+	messageCount int
+	inputTokens  int
+	outputTokens int
+	totalCost    float64
+}
+
+// observe records a single output element's contribution to the totals. Nil-safe
+// on the receiver so callers (and tests) can pass a nil accumulator to opt out.
+func (t *completionTotals) observe(elem *StreamElement) {
+	if t == nil || elem.Message == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.messageCount++
+	if elem.Message.Role == roleAssistant && elem.Message.CostInfo != nil {
+		t.inputTokens += elem.Message.CostInfo.InputTokens
+		t.outputTokens += elem.Message.CostInfo.OutputTokens
+		t.totalCost += elem.Message.CostInfo.TotalCost
+	}
+}
+
+// snapshot returns the accumulated totals. Nil-safe (returns zeros).
+func (t *completionTotals) snapshot() (messages, inputTokens, outputTokens int, cost float64) {
+	if t == nil {
+		return 0, 0, 0, 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.messageCount, t.inputTokens, t.outputTokens, t.totalCost
+}
+
 // emitCompletionEvent emits the appropriate pipeline completion event.
-func (p *StreamPipeline) emitCompletionEvent(err error, duration time.Duration) {
+func (p *StreamPipeline) emitCompletionEvent(err error, duration time.Duration, totals *completionTotals) {
 	if p.eventEmitter == nil {
 		return
 	}
@@ -199,7 +243,8 @@ func (p *StreamPipeline) emitCompletionEvent(err error, duration time.Duration) 
 	if err != nil {
 		p.eventEmitter.PipelineFailed(err, duration)
 	} else {
-		p.eventEmitter.PipelineCompleted(duration, 0, 0, 0, 0)
+		messages, inputTokens, outputTokens, cost := totals.snapshot()
+		p.eventEmitter.PipelineCompleted(duration, cost, inputTokens, outputTokens, messages)
 	}
 }
 
@@ -339,7 +384,11 @@ func instrumentStageInput(stageName string, input <-chan StreamElement) <-chan S
 // collectOutput collects output from all leaf stages into the pipeline output
 // channel. Leaf stages are read concurrently so that a slow leaf does not
 // block faster ones.
-func (p *StreamPipeline) collectOutput(channels map[string]chan StreamElement, output chan<- StreamElement) {
+func (p *StreamPipeline) collectOutput(
+	channels map[string]chan StreamElement,
+	output chan<- StreamElement,
+	totals *completionTotals,
+) {
 	// Identify leaf stages (stages with no outgoing edges).
 	var leafChans []<-chan StreamElement
 	for _, stage := range p.stages {
@@ -352,6 +401,7 @@ func (p *StreamPipeline) collectOutput(channels map[string]chan StreamElement, o
 		// Fast path: single leaf — no extra goroutines needed.
 		for _, ch := range leafChans {
 			for elem := range ch {
+				totals.observe(&elem)
 				output <- elem
 			}
 		}
@@ -365,6 +415,7 @@ func (p *StreamPipeline) collectOutput(channels map[string]chan StreamElement, o
 		go func(src <-chan StreamElement) {
 			defer wg.Done()
 			for elem := range src {
+				totals.observe(&elem)
 				output <- elem
 			}
 		}(ch)

--- a/runtime/pipeline/stage/pipeline_completion_test.go
+++ b/runtime/pipeline/stage/pipeline_completion_test.go
@@ -1,0 +1,65 @@
+package stage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestPipelineCompleted_ReportsMessageCount verifies that the pipeline.completed
+// event carries the real message/token/cost totals observed during the run,
+// instead of the placeholder zeros that made "messageCount:0" show up in logs
+// even for pipelines that produced messages.
+func TestPipelineCompleted_ReportsMessageCount(t *testing.T) {
+	bus := events.NewEventBus()
+	t.Cleanup(bus.Close)
+
+	got := make(chan *events.PipelineCompletedData, 1)
+	bus.Subscribe(events.EventPipelineCompleted, func(e *events.Event) {
+		if d, ok := e.Data.(*events.PipelineCompletedData); ok {
+			select {
+			case got <- d:
+			default:
+			}
+		}
+	})
+	emitter := events.NewEmitter(bus, "run", "sess", "conv")
+
+	pipeline, err := NewPipelineBuilder().
+		AddStage(&testPassthroughStage{name: "s"}).
+		Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	pipeline.eventEmitter = emitter
+
+	msg := types.Message{
+		Role:     roleAssistant,
+		Content:  "hello",
+		CostInfo: &types.CostInfo{InputTokens: 5, OutputTokens: 7, TotalCost: 0.01},
+	}
+	if _, err := pipeline.ExecuteSync(context.Background(), StreamElement{Message: &msg}); err != nil {
+		t.Fatalf("ExecuteSync: %v", err)
+	}
+
+	select {
+	case d := <-got:
+		if d.MessageCount != 1 {
+			t.Errorf("MessageCount = %d, want 1", d.MessageCount)
+		}
+		if d.InputTokens != 5 {
+			t.Errorf("InputTokens = %d, want 5", d.InputTokens)
+		}
+		if d.OutputTokens != 7 {
+			t.Errorf("OutputTokens = %d, want 7", d.OutputTokens)
+		}
+		if d.TotalCost != 0.01 {
+			t.Errorf("TotalCost = %v, want 0.01", d.TotalCost)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for pipeline.completed event")
+	}
+}

--- a/runtime/pipeline/stage/pipeline_internal_test.go
+++ b/runtime/pipeline/stage/pipeline_internal_test.go
@@ -258,7 +258,7 @@ func TestCollectOutput_ConcurrentLeafStages(t *testing.T) {
 
 	output := make(chan StreamElement, 10)
 	go func() {
-		pipeline.collectOutput(channels, output)
+		pipeline.collectOutput(channels, output, &completionTotals{})
 		close(output)
 	}()
 
@@ -282,8 +282,8 @@ func TestEmitCompletionEvent(t *testing.T) {
 		}
 
 		// Should not panic
-		pipeline.emitCompletionEvent(nil, time.Second)
-		pipeline.emitCompletionEvent(errors.New("error"), time.Second)
+		pipeline.emitCompletionEvent(nil, time.Second, nil)
+		pipeline.emitCompletionEvent(errors.New("error"), time.Second, nil)
 	})
 
 	t.Run("success event with emitter", func(t *testing.T) {
@@ -294,7 +294,7 @@ func TestEmitCompletionEvent(t *testing.T) {
 		}
 
 		// Should not panic - emitter handles nil bus gracefully
-		pipeline.emitCompletionEvent(nil, time.Second)
+		pipeline.emitCompletionEvent(nil, time.Second, &completionTotals{})
 	})
 
 	t.Run("failure event with emitter", func(t *testing.T) {
@@ -306,7 +306,7 @@ func TestEmitCompletionEvent(t *testing.T) {
 
 		testErr := errors.New("test error")
 		// Should not panic - emitter handles nil bus gracefully
-		pipeline.emitCompletionEvent(testErr, time.Second)
+		pipeline.emitCompletionEvent(testErr, time.Second, &completionTotals{})
 	})
 }
 


### PR DESCRIPTION
## Summary

`pipeline.completed` events were emitted with **hardcoded zeros** for message count, tokens, and cost:

```go
p.eventEmitter.PipelineCompleted(duration, 0, 0, 0, 0)
```

So every completed pipeline logged `messageCount:0` (and zero tokens/cost) even when it produced messages — a persistent, confusing signal in logs. The fields were also the only place a `0` looked like real data.

## Fix

Accumulate the real totals as output elements flow through `collectOutput` (the single choke point every emitted element passes before completion fires), then emit them:

- `completionTotals` — mutex-guarded accumulator; the lock is only taken for `Message`-bearing elements (rare vs audio/text stream elements), so no hot-path cost.
- Counts every emitted message; sums input/output tokens + cost from assistant messages (mirrors `accumulateResult`).
- Threaded through `collectOutput` → `emitCompletionEvent`; covers both the streaming (`Execute`) and sync (`ExecuteSync`) paths, since both emit via `executeBackground` after output collection completes.

## Tests

- New `TestPipelineCompleted_ReportsMessageCount`: runs a pipeline that emits an assistant message with cost info, subscribes to `pipeline.completed`, asserts `MessageCount=1` + real tokens/cost (was failing with all zeros before the fix).
- Full `runtime/pipeline/stage` suite passes under `-race`.
