### PR TITLE
fix: eliminate silent field-drop phantoms (Tier 1 from phantom-data review)

### DIFF
--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1091,6 +1091,7 @@ func (s *ProviderStage) executeRound(
 			Model:         s.provider.Model(),
 			Duration:      duration,
 			ToolCallCount: len(toolCalls),
+			FinishReason:  resp.FinishReason,
 			Source:        s.config.Source,
 			Labels:        s.config.Labels,
 		}
@@ -1271,7 +1272,8 @@ func (s *ProviderStage) executeStreamingRound(
 	}
 
 	// Process all chunks and collect response
-	content, toolCalls, costInfo, reasoning, chunkValidations, err := s.processStreamChunks(ctx, streamChan, output)
+	content, toolCalls, costInfo, reasoning, chunkValidations, finishReason, err :=
+		s.processStreamChunks(ctx, streamChan, output)
 	duration := time.Since(startTime)
 
 	if err != nil {
@@ -1296,6 +1298,7 @@ func (s *ProviderStage) executeStreamingRound(
 			Model:         s.provider.Model(),
 			Duration:      duration,
 			ToolCallCount: len(toolCalls),
+			FinishReason:  finishReason,
 			Source:        s.config.Source,
 			Labels:        s.config.Labels,
 		}
@@ -1430,13 +1433,14 @@ func (s *ProviderStage) processStreamChunks(
 	ctx context.Context,
 	streamChan <-chan providers.StreamChunk,
 	output chan<- StreamElement,
-) (string, []types.MessageToolCall, *types.CostInfo, *types.ReasoningTrace, []types.ValidationResult, error) {
+) (string, []types.MessageToolCall, *types.CostInfo, *types.ReasoningTrace, []types.ValidationResult, string, error) {
 	var content string
 	var toolCalls []types.MessageToolCall
 	var costInfo *types.CostInfo
 	var reasoning strings.Builder
 	var opaqueReasoning []types.OpaqueReasoning
 	var pendingValidations []types.ValidationResult
+	var finishReason string
 
 	for chunk := range streamChan {
 		ResetIdleFromContext(ctx)
@@ -1456,7 +1460,7 @@ func (s *ProviderStage) processStreamChunks(
 
 		if chunk.Error != nil {
 			logger.Error("Stream chunk error", "error", chunk.Error)
-			return "", nil, nil, nil, nil, fmt.Errorf("stream chunk error: %w", chunk.Error)
+			return "", nil, nil, nil, nil, "", fmt.Errorf("stream chunk error: %w", chunk.Error)
 		}
 
 		content = chunk.Content
@@ -1467,13 +1471,18 @@ func (s *ProviderStage) processStreamChunks(
 		if chunk.CostInfo != nil {
 			costInfo = chunk.CostInfo
 		}
+		// Capture the finish reason (last non-nil wins) so the completion event
+		// carries it instead of an empty string.
+		if chunk.FinishReason != nil {
+			finishReason = *chunk.FinishReason
+		}
 		// Accumulate reasoning (deltas) separately from content; it surfaces on
 		// Message.Reasoning, never as content or future context.
 		reasoning.WriteString(chunk.Reasoning)
 		opaqueReasoning = append(opaqueReasoning, chunk.OpaqueReasoning...)
 
 		if err := s.emitChunkElement(ctx, &chunk, output); err != nil {
-			return "", nil, nil, nil, nil, err
+			return "", nil, nil, nil, nil, "", err
 		}
 
 		// Run chunk interceptor hooks
@@ -1498,7 +1507,7 @@ func (s *ProviderStage) processStreamChunks(
 					content = chunk.Content
 					break
 				}
-				return "", nil, nil, nil, nil, &providers.ValidationAbortError{
+				return "", nil, nil, nil, nil, "", &providers.ValidationAbortError{
 					Reason: d.Reason,
 					Chunk:  chunk,
 				}
@@ -1510,7 +1519,7 @@ func (s *ProviderStage) processStreamChunks(
 	if reasoning.Len() > 0 || len(opaqueReasoning) > 0 {
 		trace = &types.ReasoningTrace{Text: reasoning.String(), Opaque: opaqueReasoning}
 	}
-	return content, toolCalls, costInfo, trace, pendingValidations, nil
+	return content, toolCalls, costInfo, trace, pendingValidations, finishReason, nil
 }
 
 // emitChunkElement creates and emits streaming element(s) for a chunk.

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -867,6 +867,7 @@ func TestProviderStage_EmitsProviderCallCompletedEvent(t *testing.T) {
 	require.True(t, ok, "event data should be *ProviderCallCompletedData")
 	assert.Equal(t, "test-provider", data.Provider)
 	assert.Greater(t, data.Duration, time.Duration(0), "duration should be positive")
+	assert.NotEmpty(t, data.FinishReason, "FinishReason must be populated, not the placeholder empty string")
 }
 
 func TestProviderStage_EmitsProviderCallCompletedEvent_NonStreaming(t *testing.T) {
@@ -3232,11 +3233,12 @@ func TestProcessStreamChunks_AccumulatesReasoning(t *testing.T) {
 	in <- providers.StreamChunk{Content: "answer", Delta: "answer", FinishReason: &fr}
 	close(in)
 
-	content, _, _, trace, _, err := s.processStreamChunks(context.Background(), in, out)
+	content, _, _, trace, _, finishReason, err := s.processStreamChunks(context.Background(), in, out)
 	require.NoError(t, err)
 	assert.Equal(t, "answer", content, "content must exclude reasoning")
 	require.NotNil(t, trace, "expected a reasoning trace")
 	assert.Equal(t, "think more", trace.Text)
+	assert.Equal(t, "stop", finishReason, "finish reason must be threaded out for the completion event")
 
 	close(out)
 	var sawReasoning bool

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -570,6 +570,10 @@ func (p *ToolProvider) parseToolResponse(
 	predictResp.Latency = latency
 	predictResp.Raw = respBytes
 	predictResp.ToolCalls = toolCalls
+	// Normalize + surface the stop reason (tool_use / end_turn / max_tokens /
+	// refusal); the non-streaming and streaming paths already do this — the tool
+	// path was the only one dropping it, emitting an empty FinishReason.
+	predictResp.FinishReason = normalizeFinishReason(resp.StopReason)
 
 	return *predictResp, toolCalls, nil
 }

--- a/runtime/providers/claude/claude_tools_test.go
+++ b/runtime/providers/claude/claude_tools_test.go
@@ -325,6 +325,11 @@ func TestClaudeParseToolResponse_WithToolCall(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
+	// The tool path must surface the normalized finish reason, not an empty string.
+	if predictResp.FinishReason != types.FinishReasonToolUse {
+		t.Errorf("Expected FinishReason %q, got %q", types.FinishReasonToolUse, predictResp.FinishReason)
+	}
+
 	if len(toolCalls) != 1 {
 		t.Fatalf("Expected 1 tool call, got %d", len(toolCalls))
 	}

--- a/runtime/statestore/memory.go
+++ b/runtime/statestore/memory.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"context"
 	"encoding/json"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -1117,11 +1118,18 @@ func cloneContentPart(cp *types.ContentPart) types.ContentPart {
 
 // cloneToolCall returns a deep copy of a types.MessageToolCall.
 func cloneToolCall(tc *types.MessageToolCall) types.MessageToolCall {
-	return types.MessageToolCall{
+	clone := types.MessageToolCall{
 		ID:   tc.ID,
 		Name: tc.Name,
 		Args: cloneRawMessage(tc.Args),
 	}
+	// ProviderMetadata carries opaque provider round-trip data (e.g. Gemini 3's
+	// thought_signature) that must survive a statestore round-trip to be replayed.
+	if len(tc.ProviderMetadata) > 0 {
+		clone.ProviderMetadata = make(map[string]string, len(tc.ProviderMetadata))
+		maps.Copy(clone.ProviderMetadata, tc.ProviderMetadata)
+	}
+	return clone
 }
 
 // cloneValidationResult returns a deep copy of a types.ValidationResult.
@@ -1139,11 +1147,12 @@ func cloneValidationResult(vr *types.ValidationResult) types.ValidationResult {
 // Only reference types (slices, maps, pointers) need deep copying for isolation.
 func cloneMessage(msg *types.Message) types.Message {
 	cp := types.Message{
-		Role:      msg.Role,
-		Content:   msg.Content,
-		Source:    msg.Source,
-		Timestamp: msg.Timestamp,
-		LatencyMs: msg.LatencyMs,
+		Role:         msg.Role,
+		Content:      msg.Content,
+		Source:       msg.Source,
+		Timestamp:    msg.Timestamp,
+		LatencyMs:    msg.LatencyMs,
+		FinishReason: msg.FinishReason,
 	}
 
 	// Only clone reference-type fields when non-nil to avoid unnecessary allocations

--- a/runtime/statestore/memory_test.go
+++ b/runtime/statestore/memory_test.go
@@ -1414,6 +1414,44 @@ func TestMemoryStore_LoadSummaries_ReadOnly(t *testing.T) {
 	wg.Wait()
 }
 
+// TestCloneMessage_PreservesFinishReasonAndProviderMetadata guards against the
+// silent field-drop class: cloneMessage rebuilds types.Message field-by-field,
+// so a forgotten field silently becomes zero-value after any statestore
+// round-trip. FinishReason (used to detect max_output_tokens/safety/refusal)
+// and MessageToolCall.ProviderMetadata (carries Gemini 3 thought_signature that
+// must be replayed) must survive the clone.
+func TestCloneMessage_PreservesFinishReasonAndProviderMetadata(t *testing.T) {
+	orig := &types.Message{
+		Role:         "assistant",
+		Content:      "capped",
+		FinishReason: types.FinishReasonMaxOutputTokens,
+		ToolCalls: []types.MessageToolCall{{
+			ID:               "call-1",
+			Name:             "search",
+			Args:             json.RawMessage(`{"q":"x"}`),
+			ProviderMetadata: map[string]string{"gemini.thought_signature": "sig-abc"},
+		}},
+	}
+
+	cloned := cloneMessage(orig)
+
+	if cloned.FinishReason != types.FinishReasonMaxOutputTokens {
+		t.Errorf("FinishReason dropped: got %q, want %q", cloned.FinishReason, types.FinishReasonMaxOutputTokens)
+	}
+	if len(cloned.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls not cloned: got %d", len(cloned.ToolCalls))
+	}
+	if got := cloned.ToolCalls[0].ProviderMetadata["gemini.thought_signature"]; got != "sig-abc" {
+		t.Errorf("ProviderMetadata dropped: got %q, want %q", got, "sig-abc")
+	}
+
+	// Deep-copy isolation: mutating the clone's ProviderMetadata must not touch the original.
+	cloned.ToolCalls[0].ProviderMetadata["gemini.thought_signature"] = "mutated"
+	if orig.ToolCalls[0].ProviderMetadata["gemini.thought_signature"] != "sig-abc" {
+		t.Errorf("ProviderMetadata not deep-copied: mutation leaked to original")
+	}
+}
+
 func TestDeepCopyState_Nil(t *testing.T) {
 	result := deepCopyState(nil)
 	assert.Nil(t, result)

--- a/sdk/session/unary_session.go
+++ b/sdk/session/unary_session.go
@@ -366,6 +366,14 @@ func (p *streamProcessor) processElement(elem *stage.StreamElement) bool {
 		})
 	}
 
+	// Fold emitted messages into finalResult so the terminal chunk carries real
+	// cost/token/validation data. Without this the streaming Response reports
+	// zero cost/tokens even though tokens were spent (the non-streaming Send()
+	// path is unaffected). Mirrors stage.accumulateResult.
+	if elem.Message != nil {
+		p.accumulateMessage(elem.Message)
+	}
+
 	if elem.Text != nil && *elem.Text != "" {
 		p.sb.WriteString(*elem.Text)
 		if !p.sendChunk(&providers.StreamChunk{Delta: *elem.Text}) {
@@ -377,6 +385,40 @@ func (p *streamProcessor) processElement(elem *stage.StreamElement) bool {
 		p.emitPendingTools(elem.Meta.PendingTools)
 	}
 	return true
+}
+
+// streamRoleAssistant is the role of assistant messages whose cost/token usage
+// is accumulated into the streaming final result.
+const streamRoleAssistant = "assistant"
+
+// accumulateMessage folds an emitted message into finalResult, summing cost/token
+// usage from assistant messages and recording the response so the terminal
+// stream chunk (and thus the streaming Response) reports real values instead of
+// zeros. Mirrors stage.accumulateResult for the streaming path.
+func (p *streamProcessor) accumulateMessage(msg *types.Message) {
+	if p.finalResult == nil {
+		p.finalResult = &pipeline.ExecutionResult{}
+	}
+	p.finalResult.Messages = append(p.finalResult.Messages, *msg)
+	if msg.Role != streamRoleAssistant {
+		return
+	}
+	p.finalResult.Response = &pipeline.Response{
+		Role:      msg.Role,
+		Content:   msg.Content,
+		Parts:     msg.Parts,
+		ToolCalls: msg.ToolCalls,
+	}
+	if msg.CostInfo != nil {
+		ci := &p.finalResult.CostInfo
+		ci.InputTokens += msg.CostInfo.InputTokens
+		ci.OutputTokens += msg.CostInfo.OutputTokens
+		ci.CachedTokens += msg.CostInfo.CachedTokens
+		ci.InputCostUSD += msg.CostInfo.InputCostUSD
+		ci.OutputCostUSD += msg.CostInfo.OutputCostUSD
+		ci.CachedCostUSD += msg.CostInfo.CachedCostUSD
+		ci.TotalCost += msg.CostInfo.TotalCost
+	}
 }
 
 // emitPendingTools surfaces pending tool calls as a final stream chunk.

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
+	rtpipeline "github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -18,6 +19,38 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/AltairaLabs/PromptKit/sdk/internal/pipeline"
 )
+
+// TestProcessStreamElements_PopulatesFinalResultCost guards the streaming-cost
+// phantom: the streaming path must fold assistant-message CostInfo into the
+// terminal chunk's FinalResult, so the streaming Response reports real cost/
+// tokens instead of zero (the non-streaming Send() path was always correct).
+func TestProcessStreamElements_PopulatesFinalResultCost(t *testing.T) {
+	stageChan := make(chan stage.StreamElement, 2)
+	chunkChan := make(chan providers.StreamChunk, 8)
+
+	msg := types.Message{
+		Role:     "assistant",
+		Content:  "hi",
+		CostInfo: &types.CostInfo{InputTokens: 11, OutputTokens: 7, TotalCost: 0.02},
+	}
+	stageChan <- stage.StreamElement{Message: &msg}
+	close(stageChan)
+
+	processStreamElements(context.Background(), stageChan, chunkChan)
+	close(chunkChan)
+
+	var final *rtpipeline.ExecutionResult
+	for chunk := range chunkChan {
+		if r, ok := chunk.FinalResult.(*rtpipeline.ExecutionResult); ok {
+			final = r
+		}
+	}
+
+	require.NotNil(t, final, "terminal chunk must carry a FinalResult with cost data")
+	assert.Equal(t, 11, final.CostInfo.InputTokens, "input tokens must survive to the streaming Response")
+	assert.Equal(t, 7, final.CostInfo.OutputTokens)
+	assert.InEpsilon(t, 0.02, final.CostInfo.TotalCost, 1e-9)
+}
 
 func TestNewUnarySession(t *testing.T) {
 	t.Run("creates session successfully", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes 5 **silent field-drop phantoms** — the same class as the `pipeline.completed` `messageCount:0` bug: values that read as real in logs/APIs/dashboards but are actually hardcoded or dropped placeholders. Found via a codebase-wide phantom-data review.

Each has a regression test.

## Fixes

| Fix | File | Impact |
|-----|------|--------|
| `cloneMessage` preserves `FinishReason` | `runtime/statestore/memory.go` | Every state round-trip turned `max_output_tokens`/`safety`/`refusal` into a phantom "natural stop" (`FinishReason:""`) |
| `cloneToolCall` deep-copies `ProviderMetadata` | `runtime/statestore/memory.go` | Was losing Gemini 3's `thought_signature` → tool-call replay failed after a round-trip |
| `ProviderCallCompletedData.FinishReason` populated | `runtime/pipeline/stage/stages_provider.go` | Was always `""` on both non-streaming and streaming paths, feeding an empty `gen_ai.response.finish_reason` OTel dimension. Threaded the finish reason out of `processStreamChunks` |
| Claude tool-path `FinishReason` | `runtime/providers/claude/claude_tools.go` | The non-stream/stream paths normalized `StopReason`; only the tool path dropped it |
| Streaming `Response` cost/tokens | `sdk/session/unary_session.go` | `resp.Cost()`/`TokensUsed()` returned `0` after `conv.Stream()` even though tokens were spent — `finalResult` was never populated. Non-streaming `Send()` was always correct; no test covered streaming |

## Context

These came out of a review prompted by the `messageCount:0` confusion. Remaining findings (Tier 2 — billing understatement: Gemini thinking tokens, Claude cache-creation tokens, OpenAI Realtime cached tokens, etc.; and Tier 3 low-severity/cleanup) are tracked separately and intentionally out of scope here.

## Tests / verification

- New regression test per fix (clone preservation; provider-completed `FinishReason` non-stream + stream; Claude tool `FinishReason`; streaming `FinalResult` cost).
- `go build ./...` clean; touched runtime packages pass under `-race`; pre-commit coverage gate passes on all changed files (≥80%).
