### PR TITLE
fix(cost): adopt unit-keyed token groups on the LLM path (Tier 2 billing)

### DIFF
--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
@@ -496,15 +497,10 @@ func (p *StreamPipeline) accumulateResult(output <-chan StreamElement) (*Executi
 					Parts:     elem.Message.Parts,
 					ToolCalls: elem.Message.ToolCalls,
 				}
-				// Propagate cost info from provider response to result
+				// Propagate cost info from provider response to result via the
+				// single shared aggregator so Breakdown/Quantities are never dropped.
 				if elem.Message.CostInfo != nil {
-					result.CostInfo.InputTokens += elem.Message.CostInfo.InputTokens
-					result.CostInfo.OutputTokens += elem.Message.CostInfo.OutputTokens
-					result.CostInfo.CachedTokens += elem.Message.CostInfo.CachedTokens
-					result.CostInfo.InputCostUSD += elem.Message.CostInfo.InputCostUSD
-					result.CostInfo.OutputCostUSD += elem.Message.CostInfo.OutputCostUSD
-					result.CostInfo.CachedCostUSD += elem.Message.CostInfo.CachedCostUSD
-					result.CostInfo.TotalCost += elem.Message.CostInfo.TotalCost
+					result.CostInfo = base.AggregateCost(&result.CostInfo, elem.Message.CostInfo)
 				}
 			}
 		}

--- a/runtime/pipeline/stage/pipeline_test.go
+++ b/runtime/pipeline/stage/pipeline_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 func TestPipeline_AttachesClassifyRegistry(t *testing.T) {
@@ -38,5 +40,44 @@ func TestPipeline_AttachesClassifyRegistry(t *testing.T) {
 
 	if seen != reg {
 		t.Fatalf("stage did not observe the configured classify registry (got %v)", seen)
+	}
+}
+
+// TestPipelineRollup_DoesNotDropBreakdown is a drop-guard: accumulateResult's
+// per-message cost roll-up must preserve Quantities/Breakdown carried on each
+// assistant message's CostInfo, not just sum the flat headline fields.
+func TestPipelineRollup_DoesNotDropBreakdown(t *testing.T) {
+	m1 := &types.CostInfo{
+		Quantities: map[string]float64{base.UnitInputToken: 100},
+		Breakdown: []types.CostLineItem{
+			{Provider: "x", Capability: "inference", Unit: base.UnitInputToken, Quantity: 100, USD: 0.1},
+		},
+		InputCostUSD: 0.1,
+		TotalCost:    0.1,
+		InputTokens:  100,
+	}
+	m2 := &types.CostInfo{
+		Quantities: map[string]float64{base.UnitCacheWriteToken: 40},
+		Breakdown: []types.CostLineItem{
+			{Provider: "x", Capability: "inference", Unit: base.UnitCacheWriteToken, Quantity: 40, USD: 0.05},
+		},
+	}
+
+	out := make(chan StreamElement, 2)
+	out <- StreamElement{Message: &types.Message{Role: roleAssistant, CostInfo: m1}}
+	out <- StreamElement{Message: &types.Message{Role: roleAssistant, CostInfo: m2}}
+	close(out)
+
+	p := &StreamPipeline{}
+	result, err := p.accumulateResult(out)
+	if err != nil {
+		t.Fatalf("accumulateResult: %v", err)
+	}
+
+	if got := result.CostInfo.Quantities[base.UnitCacheWriteToken]; got != 40 {
+		t.Fatalf("cache-write must survive roll-up, got %v", got)
+	}
+	if diff := result.CostInfo.TotalCost - 0.15; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("expected TotalCost ~0.15, got %v", result.CostInfo.TotalCost)
 	}
 }

--- a/runtime/providers/base/aggregate.go
+++ b/runtime/providers/base/aggregate.go
@@ -1,0 +1,64 @@
+package base
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// AggregateCost merges per-message CostInfo into one roll-up: it sums
+// Quantities, merges Breakdown line items by (provider, capability, unit,
+// dimensions), and re-derives the flat directional headlines so the
+// TotalCost == Input+Output+Cached invariant holds on the aggregate. This is
+// the single source of truth for cost roll-up — no caller sums CostInfo by hand.
+func AggregateCost(parts ...*types.CostInfo) types.CostInfo {
+	out := types.CostInfo{Quantities: map[string]float64{}}
+	lines := map[string]*types.CostLineItem{}
+	var order []string
+
+	for _, p := range parts {
+		if p == nil {
+			continue
+		}
+		if out.ProviderName == "" {
+			out.ProviderName = p.ProviderName
+			out.Capability = p.Capability
+		}
+		for unit, qty := range p.Quantities {
+			out.Quantities[unit] += qty
+		}
+		for i := range p.Breakdown {
+			li := p.Breakdown[i]
+			key := lineKey(li)
+			if agg, ok := lines[key]; ok {
+				agg.Quantity += li.Quantity
+				agg.USD += li.USD
+			} else {
+				cp := li
+				lines[key] = &cp
+				order = append(order, key)
+			}
+		}
+	}
+
+	for _, k := range order {
+		li := *lines[k]
+		out.Breakdown = append(out.Breakdown, li)
+		out.TotalCost += li.USD
+	}
+	deriveHeadlines(&out)
+	if len(out.Quantities) == 0 {
+		out.Quantities = nil
+	}
+	return out
+}
+
+func lineKey(li types.CostLineItem) string {
+	dims := make([]string, 0, len(li.Dimensions))
+	for k, v := range li.Dimensions {
+		dims = append(dims, k+"="+v)
+	}
+	sort.Strings(dims)
+	return li.Provider + "|" + li.Capability + "|" + li.Unit + "|" + strings.Join(dims, ",")
+}

--- a/runtime/providers/base/aggregate.go
+++ b/runtime/providers/base/aggregate.go
@@ -12,6 +12,13 @@ import (
 // dimensions), and re-derives the flat directional headlines so the
 // TotalCost == Input+Output+Cached invariant holds on the aggregate. This is
 // the single source of truth for cost roll-up — no caller sums CostInfo by hand.
+//
+// A part with an empty Breakdown (headline-only: pre-migration provider
+// results, or older/serialized CostInfo values that never populated
+// Breakdown/Quantities) is never dropped — its flat fields are synthesized
+// into breakdown lines so the cost flows through the same merge path. A part
+// with a non-empty Breakdown uses only that Breakdown (its flat fields are
+// re-derived output, not re-read) to avoid double-counting.
 func AggregateCost(parts ...*types.CostInfo) types.CostInfo {
 	out := types.CostInfo{Quantities: map[string]float64{}}
 	lines := map[string]*types.CostLineItem{}
@@ -25,20 +32,18 @@ func AggregateCost(parts ...*types.CostInfo) types.CostInfo {
 			out.ProviderName = p.ProviderName
 			out.Capability = p.Capability
 		}
-		for unit, qty := range p.Quantities {
-			out.Quantities[unit] += qty
-		}
-		for i := range p.Breakdown {
-			li := p.Breakdown[i]
-			key := lineKey(li)
-			if agg, ok := lines[key]; ok {
-				agg.Quantity += li.Quantity
-				agg.USD += li.USD
-			} else {
-				cp := li
-				lines[key] = &cp
-				order = append(order, key)
+		if len(p.Breakdown) > 0 {
+			for unit, qty := range p.Quantities {
+				out.Quantities[unit] += qty
 			}
+			for i := range p.Breakdown {
+				mergeLine(lines, &order, p.Breakdown[i])
+			}
+			continue
+		}
+		for _, li := range synthesizeLines(p) {
+			out.Quantities[li.Unit] += li.Quantity
+			mergeLine(lines, &order, li)
 		}
 	}
 
@@ -51,6 +56,46 @@ func AggregateCost(parts ...*types.CostInfo) types.CostInfo {
 	if len(out.Quantities) == 0 {
 		out.Quantities = nil
 	}
+	return out
+}
+
+// mergeLine folds li into the accumulating breakdown, keyed by (provider,
+// capability, unit, dimensions): repeated keys sum Quantity and USD, new
+// keys are recorded in first-seen order so output is deterministic.
+func mergeLine(lines map[string]*types.CostLineItem, order *[]string, li types.CostLineItem) {
+	key := lineKey(li)
+	if agg, ok := lines[key]; ok {
+		agg.Quantity += li.Quantity
+		agg.USD += li.USD
+		return
+	}
+	cp := li
+	lines[key] = &cp
+	*order = append(*order, key)
+}
+
+// synthesizeLines builds Breakdown-shaped lines from a headline-only
+// CostInfo's flat fields (Input/Cached/OutputTokens and their *CostUSD
+// siblings), tagged with the part's own ProviderName/Capability. This lets
+// values that never populated Breakdown/Quantities flow through the same
+// merge + deriveHeadlines path as unified-path values, so AggregateCost
+// never silently drops cost.
+func synthesizeLines(p *types.CostInfo) []types.CostLineItem {
+	var out []types.CostLineItem
+	add := func(unit string, qty float64, usd float64) {
+		if qty != 0 || usd != 0 {
+			out = append(out, types.CostLineItem{
+				Provider:   p.ProviderName,
+				Capability: p.Capability,
+				Unit:       unit,
+				Quantity:   qty,
+				USD:        usd,
+			})
+		}
+	}
+	add(UnitInputToken, float64(p.InputTokens), p.InputCostUSD)
+	add(UnitCacheReadToken, float64(p.CachedTokens), p.CachedCostUSD)
+	add(UnitOutputToken, float64(p.OutputTokens), p.OutputCostUSD)
 	return out
 }
 

--- a/runtime/providers/base/aggregate.go
+++ b/runtime/providers/base/aggregate.go
@@ -32,18 +32,38 @@ func AggregateCost(parts ...*types.CostInfo) types.CostInfo {
 			out.ProviderName = p.ProviderName
 			out.Capability = p.Capability
 		}
+		for unit, qty := range p.Quantities {
+			out.Quantities[unit] += qty
+		}
 		if len(p.Breakdown) > 0 {
-			for unit, qty := range p.Quantities {
-				out.Quantities[unit] += qty
-			}
 			for i := range p.Breakdown {
 				mergeLine(lines, &order, p.Breakdown[i])
 			}
 			continue
 		}
+		var synthUSD float64
 		for _, li := range synthesizeLines(p) {
-			out.Quantities[li.Unit] += li.Quantity
+			if _, ok := p.Quantities[li.Unit]; !ok {
+				out.Quantities[li.Unit] += li.Quantity
+			}
+			synthUSD += li.USD
 			mergeLine(lines, &order, li)
+		}
+		// Preserve any cost the flat TotalCost carries that the synthesized
+		// lines didn't account for (e.g. imagen's per-image TotalCost with no
+		// token buckets, or replay's token counts priced at $0 with the real
+		// cost only in TotalCost). Without this, a headline-only part whose
+		// TotalCost isn't fully explained by Input/Output/CachedCostUSD would
+		// silently lose the difference.
+		residual := p.TotalCost - synthUSD
+		if residual > 1e-12 || residual < -1e-12 {
+			mergeLine(lines, &order, types.CostLineItem{
+				Provider:   p.ProviderName,
+				Capability: p.Capability,
+				Unit:       UnitOutputToken,
+				Quantity:   0,
+				USD:        residual,
+			})
 		}
 	}
 

--- a/runtime/providers/base/aggregate_test.go
+++ b/runtime/providers/base/aggregate_test.go
@@ -3,32 +3,32 @@ package base_test
 import (
 	"testing"
 
-	. "github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAggregateCost_MergesBreakdownAndReDerivesHeadlines(t *testing.T) {
 	a := &types.CostInfo{
-		Quantities: map[string]float64{UnitInputToken: 100, UnitOutputToken: 50},
+		Quantities: map[string]float64{base.UnitInputToken: 100, base.UnitOutputToken: 50},
 		Breakdown: []types.CostLineItem{
-			{Provider: "claude", Capability: "inference", Unit: UnitInputToken, Quantity: 100, USD: 0.1},
-			{Provider: "claude", Capability: "inference", Unit: UnitOutputToken, Quantity: 50, USD: 0.1},
+			{Provider: "claude", Capability: "inference", Unit: base.UnitInputToken, Quantity: 100, USD: 0.1},
+			{Provider: "claude", Capability: "inference", Unit: base.UnitOutputToken, Quantity: 50, USD: 0.1},
 		},
 		InputCostUSD: 0.1, OutputCostUSD: 0.1, TotalCost: 0.2,
 		InputTokens: 100, OutputTokens: 50,
 	}
 	b := &types.CostInfo{
-		Quantities: map[string]float64{UnitInputToken: 10, UnitReasoningToken: 5},
+		Quantities: map[string]float64{base.UnitInputToken: 10, base.UnitReasoningToken: 5},
 		Breakdown: []types.CostLineItem{
-			{Provider: "claude", Capability: "inference", Unit: UnitInputToken, Quantity: 10, USD: 0.01},
-			{Provider: "claude", Capability: "inference", Unit: UnitReasoningToken, Quantity: 5, USD: 0.01},
+			{Provider: "claude", Capability: "inference", Unit: base.UnitInputToken, Quantity: 10, USD: 0.01},
+			{Provider: "claude", Capability: "inference", Unit: base.UnitReasoningToken, Quantity: 5, USD: 0.01},
 		},
 	}
-	got := AggregateCost(a, b)
+	got := base.AggregateCost(a, b)
 	// input line merged: 110 tokens, 0.11 USD
-	assert.Equal(t, 110.0, got.Quantities[UnitInputToken])
-	assert.Equal(t, 5.0, got.Quantities[UnitReasoningToken])
+	assert.Equal(t, 110.0, got.Quantities[base.UnitInputToken])
+	assert.Equal(t, 5.0, got.Quantities[base.UnitReasoningToken])
 	assert.InDelta(t, 0.11, got.InputCostUSD, 1e-9)  // input line
 	assert.InDelta(t, 0.11, got.OutputCostUSD, 1e-9) // output 0.1 + reasoning 0.01
 	assert.InDelta(t, 0.22, got.TotalCost, 1e-9)
@@ -39,13 +39,65 @@ func TestAggregateCost_MergesBreakdownAndReDerivesHeadlines(t *testing.T) {
 func TestAggregateCost_SkipsNilAndDoesNotDropGranularData(t *testing.T) {
 	// Regression guard: a message carrying Breakdown must not vanish from the roll-up.
 	msg := &types.CostInfo{
-		Quantities: map[string]float64{UnitCacheWriteToken: 40},
+		Quantities: map[string]float64{base.UnitCacheWriteToken: 40},
 		Breakdown: []types.CostLineItem{
-			{Provider: "claude", Capability: "inference", Unit: UnitCacheWriteToken, Quantity: 40, USD: 0.05},
+			{Provider: "claude", Capability: "inference", Unit: base.UnitCacheWriteToken, Quantity: 40, USD: 0.05},
 		},
 	}
-	got := AggregateCost(nil, msg, nil)
-	assert.Equal(t, 40.0, got.Quantities[UnitCacheWriteToken])
+	got := base.AggregateCost(nil, msg, nil)
+	assert.Equal(t, 40.0, got.Quantities[base.UnitCacheWriteToken])
 	assert.InDelta(t, 0.05, got.InputCostUSD, 1e-9) // cache_write folds into input side
 	assert.InDelta(t, 0.05, got.TotalCost, 1e-9)
+}
+
+func TestAggregateCost_HeadlineOnlyPartNotDropped(t *testing.T) {
+	// Regression guard: a headline-only CostInfo (no Breakdown/Quantities,
+	// e.g. a pre-migration provider result or an older/serialized message)
+	// must not silently aggregate to $0.
+	legacy := &types.CostInfo{
+		InputTokens:   1000,
+		OutputTokens:  500,
+		CachedTokens:  100,
+		InputCostUSD:  0.1,
+		OutputCostUSD: 0.2,
+		CachedCostUSD: 0.01,
+		TotalCost:     0.31,
+		ProviderName:  "legacy",
+		Capability:    "inference",
+	}
+	got := base.AggregateCost(legacy)
+	assert.InDelta(t, 0.31, got.TotalCost, 1e-9)
+	assert.InDelta(t, 0.1, got.InputCostUSD, 1e-9)
+	assert.InDelta(t, 0.2, got.OutputCostUSD, 1e-9)
+	assert.InDelta(t, 0.01, got.CachedCostUSD, 1e-9)
+	assert.InDelta(t, got.TotalCost, got.InputCostUSD+got.OutputCostUSD+got.CachedCostUSD, 1e-9)
+	assert.Equal(t, 1000.0, got.Quantities[base.UnitInputToken])
+}
+
+func TestAggregateCost_MixedBreakdownAndHeadlineOnly(t *testing.T) {
+	// One part carries a real Breakdown, the other is headline-only. Both
+	// must contribute, with no double-counting.
+	withBreakdown := &types.CostInfo{
+		Quantities: map[string]float64{base.UnitInputToken: 100, base.UnitOutputToken: 50},
+		Breakdown: []types.CostLineItem{
+			{Provider: "claude", Capability: "inference", Unit: base.UnitInputToken, Quantity: 100, USD: 0.1},
+			{Provider: "claude", Capability: "inference", Unit: base.UnitOutputToken, Quantity: 50, USD: 0.1},
+		},
+		InputCostUSD: 0.1, OutputCostUSD: 0.1, TotalCost: 0.2,
+		InputTokens: 100, OutputTokens: 50,
+	}
+	headlineOnly := &types.CostInfo{
+		InputTokens:   200,
+		OutputTokens:  100,
+		InputCostUSD:  0.05,
+		OutputCostUSD: 0.03,
+		TotalCost:     0.08,
+		ProviderName:  "legacy",
+		Capability:    "inference",
+	}
+	got := base.AggregateCost(withBreakdown, headlineOnly)
+	assert.InDelta(t, withBreakdown.TotalCost+headlineOnly.TotalCost, got.TotalCost, 1e-9)
+	assert.Equal(t, 300.0, got.Quantities[base.UnitInputToken])
+	assert.Equal(t, 150.0, got.Quantities[base.UnitOutputToken])
+	assert.InDelta(t, got.TotalCost, got.InputCostUSD+got.OutputCostUSD+got.CachedCostUSD, 1e-9)
 }

--- a/runtime/providers/base/aggregate_test.go
+++ b/runtime/providers/base/aggregate_test.go
@@ -1,0 +1,51 @@
+package base_test
+
+import (
+	"testing"
+
+	. "github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAggregateCost_MergesBreakdownAndReDerivesHeadlines(t *testing.T) {
+	a := &types.CostInfo{
+		Quantities: map[string]float64{UnitInputToken: 100, UnitOutputToken: 50},
+		Breakdown: []types.CostLineItem{
+			{Provider: "claude", Capability: "inference", Unit: UnitInputToken, Quantity: 100, USD: 0.1},
+			{Provider: "claude", Capability: "inference", Unit: UnitOutputToken, Quantity: 50, USD: 0.1},
+		},
+		InputCostUSD: 0.1, OutputCostUSD: 0.1, TotalCost: 0.2,
+		InputTokens: 100, OutputTokens: 50,
+	}
+	b := &types.CostInfo{
+		Quantities: map[string]float64{UnitInputToken: 10, UnitReasoningToken: 5},
+		Breakdown: []types.CostLineItem{
+			{Provider: "claude", Capability: "inference", Unit: UnitInputToken, Quantity: 10, USD: 0.01},
+			{Provider: "claude", Capability: "inference", Unit: UnitReasoningToken, Quantity: 5, USD: 0.01},
+		},
+	}
+	got := AggregateCost(a, b)
+	// input line merged: 110 tokens, 0.11 USD
+	assert.Equal(t, 110.0, got.Quantities[UnitInputToken])
+	assert.Equal(t, 5.0, got.Quantities[UnitReasoningToken])
+	assert.InDelta(t, 0.11, got.InputCostUSD, 1e-9)  // input line
+	assert.InDelta(t, 0.11, got.OutputCostUSD, 1e-9) // output 0.1 + reasoning 0.01
+	assert.InDelta(t, 0.22, got.TotalCost, 1e-9)
+	assert.InDelta(t, got.TotalCost, got.InputCostUSD+got.OutputCostUSD+got.CachedCostUSD, 1e-9)
+	assert.Equal(t, 110, got.InputTokens)
+}
+
+func TestAggregateCost_SkipsNilAndDoesNotDropGranularData(t *testing.T) {
+	// Regression guard: a message carrying Breakdown must not vanish from the roll-up.
+	msg := &types.CostInfo{
+		Quantities: map[string]float64{UnitCacheWriteToken: 40},
+		Breakdown: []types.CostLineItem{
+			{Provider: "claude", Capability: "inference", Unit: UnitCacheWriteToken, Quantity: 40, USD: 0.05},
+		},
+	}
+	got := AggregateCost(nil, msg, nil)
+	assert.Equal(t, 40.0, got.Quantities[UnitCacheWriteToken])
+	assert.InDelta(t, 0.05, got.InputCostUSD, 1e-9) // cache_write folds into input side
+	assert.InDelta(t, 0.05, got.TotalCost, 1e-9)
+}

--- a/runtime/providers/base/aggregate_test.go
+++ b/runtime/providers/base/aggregate_test.go
@@ -74,6 +74,55 @@ func TestAggregateCost_HeadlineOnlyPartNotDropped(t *testing.T) {
 	assert.Equal(t, 1000.0, got.Quantities[base.UnitInputToken])
 }
 
+func TestAggregateCost_TotalCostOnlyPartNotDropped(t *testing.T) {
+	// Regression guard (imagen shape): a part carries only a non-canonical
+	// Quantities unit (image count) and a flat TotalCost, no token buckets,
+	// no Breakdown. The $ amount and the quantity must both survive.
+	imagen := &types.CostInfo{
+		Quantities:   map[string]float64{"image": 1},
+		TotalCost:    0.04,
+		ProviderName: "imagen",
+		Capability:   "image",
+	}
+	got := base.AggregateCost(imagen)
+	assert.InDelta(t, 0.04, got.TotalCost, 1e-9)
+	assert.InDelta(t, 0.04, got.OutputCostUSD, 1e-9)
+	assert.InDelta(t, got.TotalCost, got.InputCostUSD+got.OutputCostUSD+got.CachedCostUSD, 1e-9)
+	assert.Equal(t, 1.0, got.Quantities["image"])
+}
+
+func TestAggregateCost_TokensAndTotalCostNoBuckets(t *testing.T) {
+	// Regression guard (replay shape): token counts + TotalCost are present
+	// but no bucket-USD and no Breakdown. Cost must not be zeroed out, and
+	// the token headline counts must still survive the roll-up.
+	replay := &types.CostInfo{
+		InputTokens:  100,
+		OutputTokens: 50,
+		CachedTokens: 10,
+		TotalCost:    0.02,
+	}
+	got := base.AggregateCost(replay)
+	assert.InDelta(t, 0.02, got.TotalCost, 1e-9)
+	assert.InDelta(t, got.TotalCost, got.InputCostUSD+got.OutputCostUSD+got.CachedCostUSD, 1e-9)
+	assert.Equal(t, 100, got.InputTokens)
+	assert.Equal(t, 50, got.OutputTokens)
+	assert.Equal(t, 10, got.CachedTokens)
+}
+
+func TestAggregateCost_FreeProviderQuantitiesPreserved(t *testing.T) {
+	// Regression guard: a free/local provider carries real Quantities (e.g.
+	// reasoning_token) at $0 with no Breakdown. The quantities must survive
+	// even though there is no cost to preserve.
+	free := &types.CostInfo{
+		Quantities:  map[string]float64{base.UnitInputToken: 100, base.UnitReasoningToken: 20},
+		InputTokens: 100,
+		TotalCost:   0,
+	}
+	got := base.AggregateCost(free)
+	assert.Equal(t, 20.0, got.Quantities[base.UnitReasoningToken])
+	assert.InDelta(t, 0, got.TotalCost, 1e-9)
+}
+
 func TestAggregateCost_MixedBreakdownAndHeadlineOnly(t *testing.T) {
 	// One part carries a real Breakdown, the other is headline-only. Both
 	// must contribute, with no double-counting.

--- a/runtime/providers/base/cost.go
+++ b/runtime/providers/base/cost.go
@@ -142,11 +142,14 @@ func PricingFromAdditionalConfig(additional map[string]any) *PricingDescriptor {
 	return &desc
 }
 
-// MakeCostInfo builds a *types.CostInfo from raw quantities and runs
-// ComputeCost against the supplied descriptor to fill TotalCost. Returns
-// the CostInfo with quantities and identity tags populated even if pricing
-// is nil or doesn't match — callers can decide whether to drop a nil-cost
-// entry. This is the shared cost-construction path for ancillary providers
+// MakeCostInfo builds a *types.CostInfo from raw quantities and prices every
+// unit it can match against the supplied descriptor. Returns the CostInfo
+// with quantities and identity tags populated even if pricing is nil —
+// callers can decide whether to drop a nil-cost entry. Any nonzero quantity
+// unit that has no matching price item is NOT silently swallowed to $0: the
+// priced-partial total is kept and the gap is surfaced via a deduped warning
+// (see warnUnpriced), so operators see undercounted cost instead of a false
+// zero. This is the shared cost-construction path for ancillary providers
 // (TTS, STT, image gen) that report a single-quantity unit at call time.
 func MakeCostInfo(
 	desc *PricingDescriptor,
@@ -164,8 +167,11 @@ func MakeCostInfo(
 	if desc == nil {
 		return info
 	}
-	if usd, _, err := ComputeCost(desc, info); err == nil {
-		info.TotalCost = usd
+	total, breakdown, unpriced := computeCostPartial(desc, info)
+	info.TotalCost = total
+	info.Breakdown = toCostLineItems(providerName, capability, breakdown)
+	if len(unpriced) > 0 {
+		warnUnpriced(providerName, capability, unpriced)
 	}
 	return info
 }

--- a/runtime/providers/base/cost.go
+++ b/runtime/providers/base/cost.go
@@ -17,19 +17,25 @@ type LineItem struct {
 	Dimensions map[string]string `json:"dimensions,omitempty"`
 }
 
-// ComputeCost multiplies raw quantities by matching rates from the pricing descriptor.
-// Returns total USD, the breakdown for reports, and an error if any unit lacks a match.
+// unpricedUnit is a nonzero quantity with no matching price item.
+type unpricedUnit struct {
+	Unit     string
+	Quantity float64
+}
+
+// computeCostPartial prices every unit it can match against desc and returns
+// the nonzero units it could not price rather than failing outright. A nil
+// descriptor (free/local provider) returns zero cost and no unpriced units.
 //
 // Matching rule: a PriceItem matches a quantity unit if PriceItem.Unit == unit AND
 // every key in PriceItem.Dimensions has a matching value in info.DimensionMatch.
 // When multiple items match, the one with the most dimension keys wins (most specific).
-//
-// nil pricing returns zero cost without error (free / local provider).
-func ComputeCost(desc *PricingDescriptor, info *types.CostInfo) (totalUSD float64, breakdown []LineItem, err error) {
+func computeCostPartial(
+	desc *PricingDescriptor, info *types.CostInfo,
+) (totalUSD float64, breakdown []LineItem, unpriced []unpricedUnit) {
 	if desc == nil || info == nil || len(info.Quantities) == 0 {
 		return 0, nil, nil
 	}
-
 	breakdown = make([]LineItem, 0, len(info.Quantities))
 	for unit, qty := range info.Quantities {
 		if qty == 0 {
@@ -37,7 +43,8 @@ func ComputeCost(desc *PricingDescriptor, info *types.CostInfo) (totalUSD float6
 		}
 		item, ok := matchPriceItem(desc.Items, unit, info.DimensionMatch)
 		if !ok {
-			return 0, nil, fmt.Errorf("no pricing match for unit=%q dimensions=%v", unit, info.DimensionMatch)
+			unpriced = append(unpriced, unpricedUnit{Unit: unit, Quantity: qty})
+			continue
 		}
 		usd := qty * item.Rate
 		totalUSD += usd
@@ -49,7 +56,21 @@ func ComputeCost(desc *PricingDescriptor, info *types.CostInfo) (totalUSD float6
 			Dimensions: copyMap(item.Dimensions),
 		})
 	}
-	return totalUSD, breakdown, nil
+	return totalUSD, breakdown, unpriced
+}
+
+// ComputeCost multiplies raw quantities by matching rates from the pricing
+// descriptor. Returns total USD, the breakdown, and an error if ANY nonzero
+// unit lacks a match (back-compat: callers relying on the strict error).
+//
+// nil pricing returns zero cost without error (free / local provider).
+func ComputeCost(desc *PricingDescriptor, info *types.CostInfo) (totalUSD float64, breakdown []LineItem, err error) {
+	total, bd, unpriced := computeCostPartial(desc, info)
+	if len(unpriced) > 0 {
+		return 0, nil, fmt.Errorf("no pricing match for unit=%q dimensions=%v",
+			unpriced[0].Unit, info.DimensionMatch)
+	}
+	return total, bd, nil
 }
 
 // matchPriceItem returns the most-specific matching PriceItem for the given unit and dimensions.

--- a/runtime/providers/base/cost_internal_test.go
+++ b/runtime/providers/base/cost_internal_test.go
@@ -1,0 +1,28 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeCostPartial_PricesMatchedCollectsUnmatched(t *testing.T) {
+	desc := &PricingDescriptor{Items: []PriceItem{{Unit: UnitInputToken, Rate: 0.001}}}
+	info := &types.CostInfo{Quantities: map[string]float64{
+		UnitInputToken:     100, // priced
+		UnitReasoningToken: 20,  // no matching item
+	}}
+	total, breakdown, unpriced := computeCostPartial(desc, info)
+	assert.InDelta(t, 0.1, total, 1e-9) // only the matched 100*0.001
+	assert.Len(t, breakdown, 1)
+	assert.Equal(t, []unpricedUnit{{Unit: UnitReasoningToken, Quantity: 20}}, unpriced)
+}
+
+func TestComputeCostPartial_NilDescriptorSilent(t *testing.T) {
+	info := &types.CostInfo{Quantities: map[string]float64{UnitInputToken: 100}}
+	total, breakdown, unpriced := computeCostPartial(nil, info)
+	assert.Zero(t, total)
+	assert.Nil(t, breakdown)
+	assert.Nil(t, unpriced)
+}

--- a/runtime/providers/base/cost_test.go
+++ b/runtime/providers/base/cost_test.go
@@ -69,6 +69,13 @@ func TestComputeCost_NoMatchingDimensions_ReturnsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestComputeCost_WrapperErrorsWhenUnpriced(t *testing.T) {
+	desc := &base.PricingDescriptor{Items: []base.PriceItem{{Unit: base.UnitInputToken, Rate: 0.001}}}
+	info := &types.CostInfo{Quantities: map[string]float64{base.UnitReasoningToken: 20}}
+	_, _, err := base.ComputeCost(desc, info)
+	assert.Error(t, err)
+}
+
 func TestComputeCost_NilPricing_ReturnsZero(t *testing.T) {
 	info := &types.CostInfo{Quantities: map[string]float64{"image": 1}}
 	total, breakdown, err := base.ComputeCost(nil, info)

--- a/runtime/providers/base/cost_test.go
+++ b/runtime/providers/base/cost_test.go
@@ -114,6 +114,16 @@ func TestMakeCostInfo_NilPricing_ReturnsQuantitiesWithZeroCost(t *testing.T) {
 	assert.Equal(t, float64(100), info.Quantities["character"])
 }
 
+func TestMakeCostInfo_UnpricedNonzeroNotSwallowedToZero(t *testing.T) {
+	desc := &base.PricingDescriptor{Items: []base.PriceItem{{Unit: "character", Rate: 0.00001}}}
+	// quantity present, but unit "second" has no price item
+	ci := base.MakeCostInfo(desc, "tts", base.ProviderTypeTTS,
+		map[string]float64{"character": 1000, "second": 5}, 0)
+	// priced-partial: only the 1000 characters, NOT a swallowed $0
+	assert.InDelta(t, 1000*0.00001, ci.TotalCost, 1e-9)
+	assert.NotEmpty(t, ci.Breakdown)
+}
+
 func TestCostInfoToMetaMap_NilReturnsNil(t *testing.T) {
 	assert.Nil(t, base.CostInfoToMetaMap(nil))
 }

--- a/runtime/providers/base/implementation.go
+++ b/runtime/providers/base/implementation.go
@@ -23,8 +23,16 @@ func (i *Implementation) Name() string { return i.name }
 // Type returns the capability type.
 func (i *Implementation) Type() ProviderType { return i.typ }
 
-// Pricing returns the configured pricing descriptor (may be nil).
-func (i *Implementation) Pricing() *PricingDescriptor { return i.pricing }
+// Pricing returns the configured pricing descriptor (may be nil). Safe to
+// call on a nil receiver — a provider struct built via a raw literal (common
+// in tests) that skips NewImplementation has a nil *Implementation, and this
+// must degrade to "no pricing configured" rather than panic.
+func (i *Implementation) Pricing() *PricingDescriptor {
+	if i == nil {
+		return nil
+	}
+	return i.pricing
+}
 
 // Validate performs synchronous config validation. Default no-op.
 func (i *Implementation) Validate() error { return nil }

--- a/runtime/providers/base/llmpricing.go
+++ b/runtime/providers/base/llmpricing.go
@@ -26,9 +26,16 @@ func ResolveLLMPricing(
 		return configDesc
 	}
 	if flat.Input > 0 && flat.Output > 0 {
+		// Reasoning tokens bill at the output rate for every provider that
+		// splits them out (OpenAI o-series, Gemini thinking), so a flat config
+		// — which does carry a known output rate — must price reasoning too, or
+		// a thinking model under flat config understates cost by the reasoning
+		// amount. (Cache tokens are deliberately NOT priced here: a flat config
+		// carries no provider-specific cache multiplier, so they go loud-unpriced.)
 		return &PricingDescriptor{Source: PricingSourceInline, Items: []PriceItem{
 			{Unit: UnitInputToken, Rate: flat.Input / per1KScale},
 			{Unit: UnitOutputToken, Rate: flat.Output / per1KScale},
+			{Unit: UnitReasoningToken, Rate: flat.Output / per1KScale},
 		}}
 	}
 	if d, ok := table[normalizeModel(model)]; ok {

--- a/runtime/providers/base/llmpricing.go
+++ b/runtime/providers/base/llmpricing.go
@@ -1,0 +1,49 @@
+package base
+
+import "strings"
+
+// FlatPricing is the legacy per-1K input/output rate a config may carry. It is
+// mapped to canonical input_token/output_token price items when no richer
+// descriptor is supplied. base defines its own type (rather than reusing a
+// providers-package type) to avoid importing the providers package, which
+// would create an import cycle.
+type FlatPricing struct {
+	Input  float64 // per 1K input tokens
+	Output float64 // per 1K output tokens
+}
+
+// per1KScale converts a per-1K rate to a per-unit rate.
+const per1KScale = 1000.0
+
+// ResolveLLMPricing selects the pricing descriptor for a model, in order:
+// explicit config descriptor > flat config pricing > embedded default table >
+// nil (paid provider; PriceUsage will warn on nonzero unpriced units).
+func ResolveLLMPricing(
+	configDesc *PricingDescriptor, flat FlatPricing,
+	table map[string]*PricingDescriptor, model string,
+) *PricingDescriptor {
+	if configDesc != nil && len(configDesc.Items) > 0 {
+		return configDesc
+	}
+	if flat.Input > 0 && flat.Output > 0 {
+		return &PricingDescriptor{Source: PricingSourceInline, Items: []PriceItem{
+			{Unit: UnitInputToken, Rate: flat.Input / per1KScale},
+			{Unit: UnitOutputToken, Rate: flat.Output / per1KScale},
+		}}
+	}
+	if d, ok := table[normalizeModel(model)]; ok {
+		return d
+	}
+	return nil
+}
+
+// normalizeModel strips a leading vendor prefix (everything up to and
+// including the last "/") so vendor-qualified model ids (e.g.
+// "anthropic/claude-sonnet-4-5") match bare table keys. Providers whose wire
+// model ids differ in other ways should pass an already-normalized model.
+func normalizeModel(model string) string {
+	if i := strings.LastIndex(model, "/"); i >= 0 {
+		model = model[i+1:]
+	}
+	return model
+}

--- a/runtime/providers/base/llmpricing_test.go
+++ b/runtime/providers/base/llmpricing_test.go
@@ -1,0 +1,48 @@
+package base_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func rateOf(d *base.PricingDescriptor, unit string) float64 {
+	for _, it := range d.Items {
+		if it.Unit == unit {
+			return it.Rate
+		}
+	}
+	return -1
+}
+
+func TestResolveLLMPricing_Order(t *testing.T) {
+	cfg := &base.PricingDescriptor{Items: []base.PriceItem{{Unit: base.UnitInputToken, Rate: 0.009}}}
+	flat := base.FlatPricing{Input: 0.001, Output: 0.002} // per-1K
+	table := map[string]*base.PricingDescriptor{
+		"claude-sonnet-4-5": {Items: []base.PriceItem{{Unit: base.UnitInputToken, Rate: 0.003}}},
+	}
+
+	// explicit config wins
+	assert.Equal(t, 0.009, base.ResolveLLMPricing(cfg, flat, table, "claude-sonnet-4-5").Items[0].Rate)
+
+	// flat config maps to per-unit (0.002/1000 output) when no descriptor
+	got := base.ResolveLLMPricing(nil, flat, table, "claude-sonnet-4-5")
+	assert.InDelta(t, 0.001/1000, rateOf(got, base.UnitInputToken), 1e-12)
+	assert.InDelta(t, 0.002/1000, rateOf(got, base.UnitOutputToken), 1e-12)
+
+	// no config: table by model
+	got2 := base.ResolveLLMPricing(nil, base.FlatPricing{}, table, "claude-sonnet-4-5")
+	assert.Equal(t, 0.003, rateOf(got2, base.UnitInputToken))
+
+	// unknown model, no config, no flat: nil
+	assert.Nil(t, base.ResolveLLMPricing(nil, base.FlatPricing{}, table, "made-up-model"))
+}
+
+func TestResolveLLMPricing_NormalizeModelStripsVendorPrefix(t *testing.T) {
+	table := map[string]*base.PricingDescriptor{
+		"claude-sonnet-4-5": {Items: []base.PriceItem{{Unit: base.UnitInputToken, Rate: 0.003}}},
+	}
+	got := base.ResolveLLMPricing(nil, base.FlatPricing{}, table, "anthropic/claude-sonnet-4-5")
+	assert.Equal(t, 0.003, rateOf(got, base.UnitInputToken))
+}

--- a/runtime/providers/base/llmpricing_test.go
+++ b/runtime/providers/base/llmpricing_test.go
@@ -30,6 +30,9 @@ func TestResolveLLMPricing_Order(t *testing.T) {
 	got := base.ResolveLLMPricing(nil, flat, table, "claude-sonnet-4-5")
 	assert.InDelta(t, 0.001/1000, rateOf(got, base.UnitInputToken), 1e-12)
 	assert.InDelta(t, 0.002/1000, rateOf(got, base.UnitOutputToken), 1e-12)
+	// flat config also prices reasoning at the output rate, so a thinking model
+	// under flat config does not silently understate cost by the reasoning amount.
+	assert.InDelta(t, 0.002/1000, rateOf(got, base.UnitReasoningToken), 1e-12)
 
 	// no config: table by model
 	got2 := base.ResolveLLMPricing(nil, base.FlatPricing{}, table, "claude-sonnet-4-5")

--- a/runtime/providers/base/priceusage.go
+++ b/runtime/providers/base/priceusage.go
@@ -1,0 +1,103 @@
+package base
+
+import (
+	"sync"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// unpricedWarnOnce dedupes the loud "nonzero unpriced unit" warning so a
+// missing rate cannot flood one line per request. Keyed by provider|capability|unit.
+var unpricedWarnOnce sync.Map
+
+// PriceUsage prices a normalized TokenUsage against desc, populating the
+// authoritative Quantities+Breakdown and deriving the flat headline view. A
+// nonzero unit with no price (and a non-nil descriptor) is surfaced loudly
+// (deduped) and contributes to no cost — the total is the priced-partial sum,
+// never a fabricated constant and never a swallowed $0. A nil descriptor is a
+// free/local provider: zero cost, no warning.
+func PriceUsage(
+	desc *PricingDescriptor,
+	providerName string,
+	capability ProviderType,
+	usage TokenUsage,
+	dims map[string]string,
+	latency time.Duration,
+) types.CostInfo {
+	ci := types.CostInfo{
+		Quantities:     usage.Quantities(),
+		DimensionMatch: dims,
+		ProviderName:   providerName,
+		Capability:     string(capability),
+		Latency:        latency,
+	}
+	total, breakdown, unpriced := computeCostPartial(desc, &ci)
+	ci.TotalCost = total
+	ci.Breakdown = toCostLineItems(providerName, capability, breakdown)
+	if len(unpriced) > 0 && desc != nil {
+		warnUnpriced(providerName, capability, unpriced)
+	}
+	deriveHeadlines(&ci)
+	return ci
+}
+
+// deriveHeadlines fills the flat directional headline fields from the priced
+// Breakdown, preserving TotalCost == InputCostUSD + OutputCostUSD + CachedCostUSD.
+//
+//	InputCostUSD  <- input + cache_write + audio_input
+//	CachedCostUSD <- cache_read
+//	OutputCostUSD <- output + reasoning + audio_output
+//
+// Token headlines: InputTokens<-input, CachedTokens<-cache_read,
+// OutputTokens<-output (visible-only). Other token counts live in Quantities.
+func deriveHeadlines(ci *types.CostInfo) {
+	for _, li := range ci.Breakdown {
+		switch li.Unit {
+		case UnitInputToken, UnitCacheWriteToken, UnitAudioInputToken:
+			ci.InputCostUSD += li.USD
+		case UnitCacheReadToken:
+			ci.CachedCostUSD += li.USD
+		case UnitOutputToken, UnitReasoningToken, UnitAudioOutputToken:
+			ci.OutputCostUSD += li.USD
+		}
+	}
+	ci.InputTokens = int(ci.Quantities[UnitInputToken])
+	ci.CachedTokens = int(ci.Quantities[UnitCacheReadToken])
+	ci.OutputTokens = int(ci.Quantities[UnitOutputToken])
+}
+
+// warnUnpriced surfaces nonzero units that had no matching price item. Each
+// (provider, capability, unit) triple is warned at most once per process.
+func warnUnpriced(providerName string, capability ProviderType, unpriced []unpricedUnit) {
+	for _, u := range unpriced {
+		key := providerName + "|" + string(capability) + "|" + u.Unit
+		if _, loaded := unpricedWarnOnce.LoadOrStore(key, struct{}{}); loaded {
+			continue
+		}
+		logger.Warn("cost: nonzero token unit has no pricing; cost understated",
+			"provider", providerName, "capability", string(capability),
+			"unit", u.Unit, "quantity", u.Quantity)
+	}
+}
+
+// toCostLineItems converts the internal LineItem breakdown into the exported
+// types.CostLineItem shape, tagging each row with provider + capability.
+func toCostLineItems(provider string, capability ProviderType, in []LineItem) []types.CostLineItem {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]types.CostLineItem, len(in))
+	for i, li := range in {
+		out[i] = types.CostLineItem{
+			Provider:   provider,
+			Capability: string(capability),
+			Unit:       li.Unit,
+			Quantity:   li.Quantity,
+			USD:        li.USD,
+			Dimensions: li.Dimensions,
+		}
+	}
+	return out
+}

--- a/runtime/providers/base/priceusage.go
+++ b/runtime/providers/base/priceusage.go
@@ -28,7 +28,7 @@ func PriceUsage(
 ) types.CostInfo {
 	ci := types.CostInfo{
 		Quantities:     usage.Quantities(),
-		DimensionMatch: dims,
+		DimensionMatch: copyMap(dims),
 		ProviderName:   providerName,
 		Capability:     string(capability),
 		Latency:        latency,
@@ -50,6 +50,10 @@ func PriceUsage(
 //	CachedCostUSD <- cache_read
 //	OutputCostUSD <- output + reasoning + audio_output
 //
+// Any other unit (e.g. a custom unit priced via TokenUsage.Extra) falls into
+// the default arm below and is folded into OutputCostUSD, so the invariant
+// holds for every priced unit, canonical or not.
+//
 // Token headlines: InputTokens<-input, CachedTokens<-cache_read,
 // OutputTokens<-output (visible-only). Other token counts live in Quantities.
 func deriveHeadlines(ci *types.CostInfo) {
@@ -60,6 +64,10 @@ func deriveHeadlines(ci *types.CostInfo) {
 		case UnitCacheReadToken:
 			ci.CachedCostUSD += li.USD
 		case UnitOutputToken, UnitReasoningToken, UnitAudioOutputToken:
+			ci.OutputCostUSD += li.USD
+		default:
+			// Unknown/custom priced units (e.g. TokenUsage.Extra) default to
+			// the output-side bucket so TotalCost == In+Out+Cached always holds.
 			ci.OutputCostUSD += li.USD
 		}
 	}

--- a/runtime/providers/base/priceusage_test.go
+++ b/runtime/providers/base/priceusage_test.go
@@ -1,10 +1,13 @@
 package base_test
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPriceUsage_ReasoningAdditivePricedAtOwnRate(t *testing.T) {
@@ -54,4 +57,53 @@ func TestPriceUsage_UnpricedNonzeroIsLoudButPartial(t *testing.T) {
 	ci := base.PriceUsage(desc, "gemini", base.ProviderTypeInference,
 		base.TokenUsage{Input: 100, Reasoning: 30}, nil, 0) // reasoning unpriced
 	assert.InDelta(t, 0.1, ci.TotalCost, 1e-9) // priced-partial, not $0, not fabricated
+}
+
+// TestPriceUsage_ExtraPricedUnitPreservesInvariant asserts that a priced unit
+// arriving via TokenUsage.Extra (not one of the 7 canonical units) still
+// folds into a headline bucket, so TotalCost == In+Out+Cached always holds
+// even for custom/future units.
+func TestPriceUsage_ExtraPricedUnitPreservesInvariant(t *testing.T) {
+	desc := &base.PricingDescriptor{Items: []base.PriceItem{
+		{Unit: base.UnitInputToken, Rate: 0.001},
+		{Unit: "custom_token", Rate: 0.001},
+	}}
+	ci := base.PriceUsage(desc, "acme", base.ProviderTypeInference,
+		base.TokenUsage{Input: 100, Extra: map[string]float64{"custom_token": 50}}, nil, 0)
+	// TotalCost = 100*.001 + 50*.001 = 0.1 + 0.05 = 0.15
+	assert.InDelta(t, 0.15, ci.TotalCost, 1e-9)
+	// The custom unit's USD must be included somewhere in the headline split.
+	assert.InDelta(t, ci.TotalCost, ci.InputCostUSD+ci.OutputCostUSD+ci.CachedCostUSD, 1e-9)
+	assert.InDelta(t, 0.05, ci.OutputCostUSD, 1e-9) // custom unit folds into OutputCostUSD
+	assert.InDelta(t, 0.1, ci.InputCostUSD, 1e-9)
+}
+
+// TestPriceUsage_LoudUnpricedWarns asserts the unpriced-unit warning actually
+// reaches the logger for a non-nil descriptor, and stays silent for a nil
+// descriptor. Uses a provider/unit combination unique to this test since
+// unpricedWarnOnce dedupes per-process by provider|capability|unit.
+func TestPriceUsage_LoudUnpricedWarns(t *testing.T) {
+	t.Run("nonzero unpriced unit with non-nil descriptor warns", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger.SetOutput(&buf)
+		defer logger.SetOutput(nil)
+
+		desc := &base.PricingDescriptor{Items: []base.PriceItem{{Unit: base.UnitInputToken, Rate: 0.001}}}
+		_ = base.PriceUsage(desc, "loud-warn-test-provider", base.ProviderTypeInference,
+			base.TokenUsage{Input: 100, Extra: map[string]float64{"loud_warn_test_unit": 7}}, nil, 0)
+
+		require.Contains(t, buf.String(), "loud_warn_test_unit")
+		assert.Contains(t, buf.String(), "nonzero token unit has no pricing")
+	})
+
+	t.Run("nil descriptor stays silent", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger.SetOutput(&buf)
+		defer logger.SetOutput(nil)
+
+		_ = base.PriceUsage(nil, "loud-warn-test-provider-nil", base.ProviderTypeInference,
+			base.TokenUsage{Input: 100, Extra: map[string]float64{"loud_warn_test_unit_nil": 7}}, nil, 0)
+
+		assert.Empty(t, buf.String())
+	})
 }

--- a/runtime/providers/base/priceusage_test.go
+++ b/runtime/providers/base/priceusage_test.go
@@ -1,0 +1,57 @@
+package base_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPriceUsage_ReasoningAdditivePricedAtOwnRate(t *testing.T) {
+	desc := &base.PricingDescriptor{Items: []base.PriceItem{
+		{Unit: base.UnitInputToken, Rate: 0.001},
+		{Unit: base.UnitOutputToken, Rate: 0.002},
+		{Unit: base.UnitReasoningToken, Rate: 0.002},
+	}}
+	ci := base.PriceUsage(desc, "gemini", base.ProviderTypeInference,
+		base.TokenUsage{Input: 100, Output: 50, Reasoning: 30}, nil, 0)
+	// TotalCost = 100*.001 + 50*.002 + 30*.002 = 0.1 + 0.1 + 0.06 = 0.26
+	assert.InDelta(t, 0.26, ci.TotalCost, 1e-9)
+	// Directional fold: reasoning USD lands in OutputCostUSD.
+	assert.InDelta(t, 0.16, ci.OutputCostUSD, 1e-9)
+	assert.InDelta(t, 0.10, ci.InputCostUSD, 1e-9)
+	// Invariant.
+	assert.InDelta(t, ci.TotalCost, ci.InputCostUSD+ci.OutputCostUSD+ci.CachedCostUSD, 1e-9)
+	// Reasoning token count NOT in OutputTokens headline; only in Quantities.
+	assert.Equal(t, 50, ci.OutputTokens)
+	assert.Equal(t, 30.0, ci.Quantities[base.UnitReasoningToken])
+}
+
+func TestPriceUsage_CacheWriteFoldsIntoInputCost(t *testing.T) {
+	desc := &base.PricingDescriptor{Items: []base.PriceItem{
+		{Unit: base.UnitInputToken, Rate: 0.001},
+		{Unit: base.UnitCacheWriteToken, Rate: 0.00125},
+		{Unit: base.UnitCacheReadToken, Rate: 0.0001},
+	}}
+	ci := base.PriceUsage(desc, "claude", base.ProviderTypeInference,
+		base.TokenUsage{Input: 100, CacheWrite: 200, CacheRead: 300}, nil, 0)
+	assert.InDelta(t, 100*0.001+200*0.00125, ci.InputCostUSD, 1e-9)
+	assert.InDelta(t, 300*0.0001, ci.CachedCostUSD, 1e-9)
+	assert.InDelta(t, ci.TotalCost, ci.InputCostUSD+ci.OutputCostUSD+ci.CachedCostUSD, 1e-9)
+	assert.Equal(t, 300, ci.CachedTokens)
+}
+
+func TestPriceUsage_NilDescriptorSilentZero(t *testing.T) {
+	ci := base.PriceUsage(nil, "ollama", base.ProviderTypeInference,
+		base.TokenUsage{Input: 100, Output: 50}, nil, 0)
+	assert.Zero(t, ci.TotalCost)
+	assert.Equal(t, 100, ci.InputTokens) // headline counts still populated
+	assert.Equal(t, 50, ci.OutputTokens)
+}
+
+func TestPriceUsage_UnpricedNonzeroIsLoudButPartial(t *testing.T) {
+	desc := &base.PricingDescriptor{Items: []base.PriceItem{{Unit: base.UnitInputToken, Rate: 0.001}}}
+	ci := base.PriceUsage(desc, "gemini", base.ProviderTypeInference,
+		base.TokenUsage{Input: 100, Reasoning: 30}, nil, 0) // reasoning unpriced
+	assert.InDelta(t, 0.1, ci.TotalCost, 1e-9) // priced-partial, not $0, not fabricated
+}

--- a/runtime/providers/base/units.go
+++ b/runtime/providers/base/units.go
@@ -1,0 +1,60 @@
+// Package base — canonical token-unit vocabulary shared by all inference
+// providers and their pricing tables. The pricing engine still accepts any
+// unit string; these constants exist so providers and price items never drift.
+package base
+
+// Canonical token units. Providers MUST emit these names; pricing tables MUST
+// price them by the same names.
+const (
+	UnitInputToken       = "input_token"        // full-price, uncached input
+	UnitCacheReadToken   = "cache_read_token"   // prompt-cache read (discounted input)
+	UnitCacheWriteToken  = "cache_write_token"  //nolint:gosec // prompt-cache creation (premium input), not a credential
+	UnitOutputToken      = "output_token"       // visible output only, EXCLUDES reasoning
+	UnitReasoningToken   = "reasoning_token"    // thinking tokens, priced additively
+	UnitAudioInputToken  = "audio_input_token"  //nolint:gosec // realtime audio in, not a credential
+	UnitAudioOutputToken = "audio_output_token" // realtime audio out
+)
+
+// TokenUsage is the normalized, provider-agnostic usage a provider hands to
+// PriceUsage. Each provider maps its wire usage into these canonical meanings,
+// absorbing its own quirks (cache-inclusive vs -exclusive input, reasoning
+// bundled into output vs separate) so every field means the same thing here.
+type TokenUsage struct {
+	Input       int // full-price uncached input
+	CacheRead   int
+	CacheWrite  int
+	Output      int // visible output only
+	Reasoning   int
+	AudioInput  int
+	AudioOutput int
+	// Extra carries future/uncommon units keyed by canonical unit name.
+	Extra map[string]float64
+}
+
+// tokenUsageUnitCount is the number of canonical unit fields on TokenUsage,
+// used to pre-size the Quantities map.
+const tokenUsageUnitCount = 7
+
+// Quantities converts the usage into the unit-keyed map the pricing engine
+// consumes, omitting zero-valued units.
+func (u TokenUsage) Quantities() map[string]float64 {
+	q := make(map[string]float64, tokenUsageUnitCount)
+	set := func(unit string, v int) {
+		if v != 0 {
+			q[unit] = float64(v)
+		}
+	}
+	set(UnitInputToken, u.Input)
+	set(UnitCacheReadToken, u.CacheRead)
+	set(UnitCacheWriteToken, u.CacheWrite)
+	set(UnitOutputToken, u.Output)
+	set(UnitReasoningToken, u.Reasoning)
+	set(UnitAudioInputToken, u.AudioInput)
+	set(UnitAudioOutputToken, u.AudioOutput)
+	for k, v := range u.Extra {
+		if v != 0 {
+			q[k] = v
+		}
+	}
+	return q
+}

--- a/runtime/providers/base/units_test.go
+++ b/runtime/providers/base/units_test.go
@@ -1,0 +1,35 @@
+package base_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenUsage_Quantities_OnlyNonzero(t *testing.T) {
+	u := base.TokenUsage{Input: 100, Output: 50, Reasoning: 20}
+	q := u.Quantities()
+	assert.Equal(t, map[string]float64{
+		base.UnitInputToken:     100,
+		base.UnitOutputToken:    50,
+		base.UnitReasoningToken: 20,
+	}, q)
+}
+
+func TestTokenUsage_Quantities_IncludesAllUnitsAndExtra(t *testing.T) {
+	u := base.TokenUsage{
+		Input: 1, CacheRead: 2, CacheWrite: 3, Output: 4, Reasoning: 5,
+		AudioInput: 6, AudioOutput: 7,
+		Extra: map[string]float64{"custom_token": 8},
+	}
+	q := u.Quantities()
+	assert.Equal(t, 1.0, q[base.UnitInputToken])
+	assert.Equal(t, 2.0, q[base.UnitCacheReadToken])
+	assert.Equal(t, 3.0, q[base.UnitCacheWriteToken])
+	assert.Equal(t, 4.0, q[base.UnitOutputToken])
+	assert.Equal(t, 5.0, q[base.UnitReasoningToken])
+	assert.Equal(t, 6.0, q[base.UnitAudioInputToken])
+	assert.Equal(t, 7.0, q[base.UnitAudioOutputToken])
+	assert.Equal(t, 8.0, q["custom_token"])
+}

--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -855,8 +856,11 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 
 	latency := time.Since(start)
 
-	// Calculate cost breakdown
-	costBreakdown := p.CalculateCost(claudeResp.Usage.InputTokens, claudeResp.Usage.OutputTokens, claudeResp.Usage.CacheReadInputTokens)
+	// Calculate cost breakdown. claudeResp.Usage already carries
+	// CacheCreationInputTokens (cache WRITE) alongside the read/input/output
+	// counts, so route the full wire usage straight through costFromUsage
+	// rather than the CalculateCost wrapper (which only accepts cache reads).
+	costBreakdown := p.costFromUsage(claudeResp.Usage)
 
 	predictResp.Content = responseText
 	predictResp.CostInfo = &costBreakdown
@@ -892,21 +896,21 @@ func claudePricing(model string) (inputPrice, outputPrice, cachedPrice float64) 
 	)
 
 	switch model {
-	case "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20240620", "claude-3-sonnet-20240229":
+	case idClaude35Sonnet20241022, idClaude35Sonnet20240620, idClaude3Sonnet20240229:
 		return sonnetInput, sonnetOutput, sonnetCached
-	case "claude-sonnet-4-6", "claude-sonnet-4-5":
+	case "claude-sonnet-4-6", idClaudeSonnet45:
 		return sonnetInput, sonnetOutput, sonnetCached
-	case "claude-haiku-4-5":
+	case idClaudeHaiku45:
 		return haikuInput, haikuOutput, haikuCached
-	case "claude-3-5-haiku-20241022":
+	case idClaude35Haiku20241022:
 		return haikuInput, haikuOutput, haikuCached
 	case "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6":
 		return opus4Input, opus4Output, opus4Cached
 	case "claude-fable-5", "claude-mythos-5", "claude-mythos-preview":
 		return fableInput, fableOutput, fableCached
-	case "claude-3-opus-20240229":
+	case idClaude3Opus20240229:
 		return opus3Input, opus3Output, opus3Cached
-	case "claude-3-haiku-20240307":
+	case idClaude3Haiku20240307:
 		return haiku3Input, haiku3Output, haiku3Cached
 	default:
 		// Heuristic fallback for unlisted IDs (e.g. a future dated snapshot) so a
@@ -925,40 +929,42 @@ func claudePricing(model string) (inputPrice, outputPrice, cachedPrice float64) 
 	}
 }
 
-// CalculateCost calculates detailed cost breakdown including optional cached tokens
+// claudeUsageToTokens maps Anthropic's cache-EXCLUSIVE input accounting into
+// canonical units: input_tokens is already full-price, uncached input (do NOT
+// subtract cache reads/writes from it — cache_read_input_tokens and
+// cache_creation_input_tokens are separate wire fields, not a subset of
+// input_tokens).
+func claudeUsageToTokens(u claudeUsage) base.TokenUsage {
+	return base.TokenUsage{
+		Input:      u.InputTokens,
+		CacheRead:  u.CacheReadInputTokens,
+		CacheWrite: u.CacheCreationInputTokens,
+		Output:     u.OutputTokens,
+	}
+}
+
+// costFromUsage prices a claudeUsage through the unit-keyed pricing engine:
+// an explicit config descriptor wins, then legacy flat per-1K config, then
+// the built-in per-model table (claudePricingTable), else nil (priced units
+// are surfaced loudly by PriceUsage rather than silently reported as $0
+// without warning — see ResolveLLMPricing/PriceUsage doc comments).
+func (p *Provider) costFromUsage(u claudeUsage) types.CostInfo {
+	desc := base.ResolveLLMPricing(
+		p.Pricing(),
+		base.FlatPricing{Input: p.defaults.Pricing.InputCostPer1K, Output: p.defaults.Pricing.OutputCostPer1K},
+		claudePricingTable, p.model)
+	return base.PriceUsage(desc, p.ID(), base.ProviderTypeInference, claudeUsageToTokens(u), nil, 0)
+}
+
+// CalculateCost calculates detailed cost breakdown including optional cached
+// tokens. Thin wrapper over costFromUsage, kept for the Provider interface's
+// legacy signature (cachedTokens here means cache READS only — callers that
+// also have cache-write counts, e.g. wire claudeUsage, should call
+// costFromUsage directly instead so cache writes aren't dropped).
 func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.CostInfo {
-	var inputCostPer1K, outputCostPer1K, cachedCostPer1K float64
-
-	// Use configured pricing if available
-	if p.defaults.Pricing.InputCostPer1K > 0 && p.defaults.Pricing.OutputCostPer1K > 0 {
-		inputCostPer1K = p.defaults.Pricing.InputCostPer1K
-		outputCostPer1K = p.defaults.Pricing.OutputCostPer1K
-		// Cached tokens cost 10% of input tokens according to Anthropic pricing
-		cachedCostPer1K = inputCostPer1K * 0.1
-	} else {
-		// Fallback to hardcoded pricing with warning
-		logger.Warn("No pricing configured, using fallback pricing", "provider", p.ID(), "model", p.model)
-		inputCostPer1K, outputCostPer1K, cachedCostPer1K = claudePricing(p.model)
-	}
-
-	// Calculate costs. Anthropic reports input_tokens EXCLUSIVE of cache reads
-	// (cache_read_input_tokens is a separate field), so tokensIn is already the
-	// uncached, full-price input — do NOT subtract cachedTokens (that double-counts
-	// and goes negative once a cache read exceeds the fresh input).
-	const per1K = 1000.0
-	inputCost := float64(tokensIn) / per1K * inputCostPer1K
-	cachedCost := float64(cachedTokens) / per1K * cachedCostPer1K
-	outputCost := float64(tokensOut) / per1K * outputCostPer1K
-
-	return types.CostInfo{
-		InputTokens:   tokensIn,
-		OutputTokens:  tokensOut,
-		CachedTokens:  cachedTokens,
-		InputCostUSD:  inputCost,
-		OutputCostUSD: outputCost,
-		CachedCostUSD: cachedCost,
-		TotalCost:     inputCost + cachedCost + outputCost,
-	}
+	return p.costFromUsage(claudeUsage{
+		InputTokens: tokensIn, OutputTokens: tokensOut, CacheReadInputTokens: cachedTokens,
+	})
 }
 
 // SupportsStreaming is provided by BaseProvider (returns true)

--- a/runtime/providers/claude/claude_cost_test.go
+++ b/runtime/providers/claude/claude_cost_test.go
@@ -1,0 +1,104 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// newTestClaudeProvider builds a bare Provider with only the model set, so
+// costFromUsage resolves pricing purely from claudePricingTable (no config
+// descriptor, no legacy flat Pricing).
+func newTestClaudeProvider(t *testing.T, model string) *Provider {
+	t.Helper()
+	return NewProvider("test-claude", model, "https://api.anthropic.com", providers.ProviderDefaults{}, false)
+}
+
+// TestClaudeCost_PricesCacheWrite is the regression test for finding G: Claude
+// reports cache_creation_input_tokens (cache WRITE, ~1.25x input) on the wire,
+// but the old CalculateCost path only ever accepted a single "cachedTokens"
+// (cache READ) argument, so every cache-write token was silently dropped and
+// cost was understated. costFromUsage must price it.
+func TestClaudeCost_PricesCacheWrite(t *testing.T) {
+	p := newTestClaudeProvider(t, "claude-sonnet-4-5")
+	u := claudeUsage{
+		InputTokens: 1000, OutputTokens: 500,
+		CacheCreationInputTokens: 200, CacheReadInputTokens: 300,
+	}
+	ci := p.costFromUsage(u)
+	assert.Greater(t, ci.Quantities[base.UnitCacheWriteToken], 0.0)
+	assert.Greater(t, ci.InputCostUSD, 0.0)
+
+	// Cache-write must contribute cost (previously dropped -> understated).
+	uNoWrite := claudeUsage{InputTokens: 1000, OutputTokens: 500, CacheReadInputTokens: 300}
+	assert.Greater(t, ci.TotalCost, p.costFromUsage(uNoWrite).TotalCost)
+
+	// TotalCost stays the sum of the flat headline buckets.
+	assert.InDelta(t, ci.TotalCost, ci.InputCostUSD+ci.OutputCostUSD+ci.CachedCostUSD, 1e-9)
+}
+
+// TestClaudeUsageToTokens_MapsAllFields verifies the field-by-field mapping
+// from the wire claudeUsage shape into canonical base.TokenUsage units,
+// including that InputTokens is used as-is (Anthropic's input_tokens is
+// already cache-EXCLUSIVE — never subtract cache reads/writes from it).
+func TestClaudeUsageToTokens_MapsAllFields(t *testing.T) {
+	u := claudeUsage{
+		InputTokens: 1000, OutputTokens: 500,
+		CacheCreationInputTokens: 200, CacheReadInputTokens: 300,
+	}
+	got := claudeUsageToTokens(u)
+	assert.Equal(t, base.TokenUsage{Input: 1000, CacheRead: 300, CacheWrite: 200, Output: 500}, got)
+}
+
+// TestClaudeCost_KnownModelPricesCacheReadAndWrite pins the actual USD amounts
+// for a known table entry so a future edit to the multipliers or table values
+// is caught, not just "greater than zero".
+func TestClaudeCost_KnownModelPricesCacheReadAndWrite(t *testing.T) {
+	p := newTestClaudeProvider(t, "claude-sonnet-4-5")
+	ci := p.costFromUsage(claudeUsage{
+		InputTokens: 1_000_000, OutputTokens: 1_000_000,
+		CacheReadInputTokens: 1_000_000, CacheCreationInputTokens: 1_000_000,
+	})
+
+	// claude-sonnet-4-5: $3/$15 per 1M; cache_read = 0.1x input ($0.3/M),
+	// cache_write = 1.25x input ($3.75/M). InputCostUSD folds in input + cache_write.
+	assert.InDelta(t, 1_000_000.0, ci.Quantities[base.UnitInputToken], 1e-9)
+	assert.InDelta(t, 3.0+3.75, ci.InputCostUSD, 1e-9)
+	assert.InDelta(t, 0.3, ci.CachedCostUSD, 1e-9)
+	assert.InDelta(t, 15.0, ci.OutputCostUSD, 1e-9)
+}
+
+// TestClaudeCost_UnknownModelNoWrongConstant matches the sibling providers'
+// (e.g. Gemini) fix for the same class of bug: an unmatched model must price
+// as $0 (surfaced via the loud-unpriced-unit warning path), never silently
+// fall back to a guessed constant like "assume Sonnet pricing".
+func TestClaudeCost_UnknownModelNoWrongConstant(t *testing.T) {
+	p := newTestClaudeProvider(t, "claude-9-9-imaginary")
+	ci := p.costFromUsage(claudeUsage{InputTokens: 1000, OutputTokens: 500})
+	assert.Zero(t, ci.TotalCost)
+}
+
+// TestClaudeCost_CalculateCostWrapperMatchesCostFromUsage verifies the public
+// CalculateCost(tokensIn, tokensOut, cachedTokens) signature (kept for the
+// Provider interface contract) is a pure wrapper over costFromUsage, treating
+// cachedTokens as cache READS only (it has no cache-write parameter).
+func TestClaudeCost_CalculateCostWrapperMatchesCostFromUsage(t *testing.T) {
+	p := newTestClaudeProvider(t, "claude-sonnet-4-5")
+	want := p.costFromUsage(claudeUsage{InputTokens: 1000, OutputTokens: 500, CacheReadInputTokens: 200})
+	got := p.CalculateCost(1000, 500, 200)
+
+	// Compare the priced fields directly rather than the whole struct: Breakdown
+	// row order comes from a map iteration (computeCostPartial ranges over
+	// Quantities) and is not guaranteed stable across two independent calls.
+	assert.Equal(t, want.TotalCost, got.TotalCost)
+	assert.Equal(t, want.InputCostUSD, got.InputCostUSD)
+	assert.Equal(t, want.OutputCostUSD, got.OutputCostUSD)
+	assert.Equal(t, want.CachedCostUSD, got.CachedCostUSD)
+	assert.Equal(t, want.InputTokens, got.InputTokens)
+	assert.Equal(t, want.OutputTokens, got.OutputTokens)
+	assert.Equal(t, want.CachedTokens, got.CachedTokens)
+	assert.Equal(t, want.Quantities, got.Quantities)
+}

--- a/runtime/providers/claude/claude_integration_test.go
+++ b/runtime/providers/claude/claude_integration_test.go
@@ -492,12 +492,19 @@ func TestCalculateCost(t *testing.T) {
 			expectCost:   true,
 		},
 		{
-			name:         "Unknown model falls back to Sonnet pricing",
+			// Routed through the unit-keyed pricing engine (base.ResolveLLMPricing),
+			// an unmatched model has no exact-match table entry and no substring
+			// heuristic fallback, so it prices as $0 (surfaced via a loud warning,
+			// not a silently guessed constant) — the same fix applied to Gemini's
+			// unknown-model handling. Guessing "assume Sonnet" for a genuinely
+			// unknown model is the class of bug this effort is removing, not
+			// preserving.
+			name:         "Unknown model prices as zero, not a guessed constant",
 			model:        "claude-unknown",
 			tokensIn:     1000,
 			tokensOut:    500,
 			cachedTokens: 0,
-			expectCost:   true,
+			expectCost:   false,
 		},
 	}
 
@@ -516,6 +523,12 @@ func TestCalculateCost(t *testing.T) {
 			assert.Equal(t, tt.tokensIn, costInfo.InputTokens)
 			assert.Equal(t, tt.tokensOut, costInfo.OutputTokens)
 			assert.Equal(t, tt.cachedTokens, costInfo.CachedTokens)
+
+			if !tt.expectCost {
+				assert.Zero(t, costInfo.TotalCost)
+				return
+			}
+
 			assert.Greater(t, costInfo.TotalCost, 0.0)
 			assert.Greater(t, costInfo.InputCostUSD, 0.0)
 			assert.Greater(t, costInfo.OutputCostUSD, 0.0)

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -267,13 +267,12 @@ func (p *Provider) processClaudeMessageStop(
 			finalChunk.FinishReason = &finishReason
 		}
 
-		// Extract cost from usage if available
+		// Extract cost from usage if available. event.Message.Usage already
+		// carries CacheCreationInputTokens (cache WRITE), so route it through
+		// costFromUsage directly rather than the CalculateCost wrapper (which
+		// only accepts cache reads).
 		if event.Message.Usage != nil {
-			tokensIn := event.Message.Usage.InputTokens
-			tokensOut := event.Message.Usage.OutputTokens
-			cachedTokens := event.Message.Usage.CacheReadInputTokens
-
-			costBreakdown := p.CalculateCost(tokensIn, tokensOut, cachedTokens)
+			costBreakdown := p.costFromUsage(*event.Message.Usage)
 			finalChunk.CostInfo = &costBreakdown
 		}
 	}
@@ -301,7 +300,7 @@ func (p *Provider) streamResponse(
 	totalTokens := 0
 
 	// Track usage from message_start and message_delta events
-	var inputTokens, outputTokens, cachedTokens int
+	var inputTokens, outputTokens, cachedTokens, cacheWriteTokens int
 	var stopReason string
 
 	// Track tool calls from content_block_start and content_block_delta events
@@ -344,6 +343,7 @@ func (p *Provider) streamResponse(
 				if startEvent.Message != nil && startEvent.Message.Usage != nil {
 					inputTokens = startEvent.Message.Usage.InputTokens
 					cachedTokens = startEvent.Message.Usage.CacheReadInputTokens
+					cacheWriteTokens = startEvent.Message.Usage.CacheCreationInputTokens
 				}
 			}
 
@@ -458,9 +458,14 @@ func (p *Provider) streamResponse(
 				FinishReason: &finishReason,
 			}
 
-			// Calculate cost from accumulated usage
+			// Calculate cost from accumulated usage, including cache writes
+			// (cache_creation_input_tokens from message_start) alongside the
+			// cache-read/input/output counts tracked across the stream.
 			if inputTokens > 0 || outputTokens > 0 {
-				costBreakdown := p.CalculateCost(inputTokens, outputTokens, cachedTokens)
+				costBreakdown := p.costFromUsage(claudeUsage{
+					InputTokens: inputTokens, OutputTokens: outputTokens,
+					CacheReadInputTokens: cachedTokens, CacheCreationInputTokens: cacheWriteTokens,
+				})
 				finalChunk.CostInfo = &costBreakdown
 			}
 

--- a/runtime/providers/claude/claude_test.go
+++ b/runtime/providers/claude/claude_test.go
@@ -179,16 +179,22 @@ func TestClaudeProvider_CostBreakdown(t *testing.T) {
 	expectedInputCost := 0.003   // 1000 tokens = 1 * $0.003
 	expectedOutputCost := 0.0075 // 500 tokens = 0.5 * $0.015
 
-	if breakdown.InputCostUSD != expectedInputCost {
+	// Tolerance-based comparison: the priced-partial engine sums per-unit costs
+	// via a map iteration (computeCostPartial ranges over Quantities), whose
+	// order is randomized per call. Summation order can flip the last bit or
+	// two of a float64 total even though the two orderings are mathematically
+	// equal, so exact equality against a hand-computed literal is flaky here.
+	tolerance := 0.0000001
+	if breakdown.InputCostUSD < expectedInputCost-tolerance || breakdown.InputCostUSD > expectedInputCost+tolerance {
 		t.Errorf("Expected input cost %.4f, got %.4f", expectedInputCost, breakdown.InputCostUSD)
 	}
 
-	if breakdown.OutputCostUSD != expectedOutputCost {
+	if breakdown.OutputCostUSD < expectedOutputCost-tolerance || breakdown.OutputCostUSD > expectedOutputCost+tolerance {
 		t.Errorf("Expected output cost %.4f, got %.4f", expectedOutputCost, breakdown.OutputCostUSD)
 	}
 
 	expectedTotal := expectedInputCost + expectedOutputCost
-	if breakdown.TotalCost != expectedTotal {
+	if breakdown.TotalCost < expectedTotal-tolerance || breakdown.TotalCost > expectedTotal+tolerance {
 		t.Errorf("Expected total cost %.4f, got %.4f", expectedTotal, breakdown.TotalCost)
 	}
 }
@@ -206,8 +212,7 @@ func TestClaudeProvider_CostBreakdownWithCachedTokens(t *testing.T) {
 	provider := NewProvider("test", "claude-3-5-sonnet-20241022", "url", defaults, false)
 
 	// Anthropic's input_tokens EXCLUDES cache reads (cache_read_input_tokens is a
-	// separate field), so the 1000 here is already the non-cached input; 200 cached
-	// is billed on top at 10%. (Verified live in caching_integration_test.go.)
+	// separate field), so the 1000 here is already the non-cached input.
 	breakdown := provider.CalculateCost(1000, 500, 200)
 
 	// InputTokens is the non-cached input as reported by the API — not reduced again.
@@ -223,10 +228,19 @@ func TestClaudeProvider_CostBreakdownWithCachedTokens(t *testing.T) {
 		t.Error("CachedTokens mismatch")
 	}
 
-	// Cached tokens cost 10% of regular input tokens (Claude pricing)
-	expectedCachedCost := 0.00006 // 200 * 0.003 / 1000 * 0.1 = 0.00006
-	expectedInputCost := 0.003    // 1000 * 0.003 / 1000 = 0.003
-	expectedOutputCost := 0.0075  // 500 * 0.015 / 1000 = 0.0075
+	// The legacy flat providers.Pricing{InputCostPer1K,OutputCostPer1K} config
+	// carries only input_token/output_token rates (base.ResolveLLMPricing's
+	// FlatPricing branch, by design — it can't know a provider-specific cache
+	// multiplier). So with flat config set, cache reads have no matching price
+	// item: the quantity is still tracked (CachedTokens above) but the dollar
+	// amount is $0, surfaced via a loud "unpriced unit" warning rather than a
+	// silently assumed 10% discount. Cache-aware pricing requires either the
+	// built-in per-model table (claudePricingTable, used when flat pricing is
+	// NOT configured) or an explicit PricingDescriptor with cache_read_token/
+	// cache_write_token items.
+	expectedCachedCost := 0.0
+	expectedInputCost := 0.003   // 1000 * 0.003 / 1000 = 0.003
+	expectedOutputCost := 0.0075 // 500 * 0.015 / 1000 = 0.0075
 
 	// Use tolerance for floating point comparison
 	tolerance := 0.0000001

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -560,8 +560,11 @@ func (p *ToolProvider) parseToolResponse(
 	// Parse tool calls from raw response
 	toolCalls := parseToolCallsFromRawResponse(respBytes)
 
-	// Calculate cost breakdown
-	costBreakdown := p.Provider.CalculateCost(resp.Usage.InputTokens, resp.Usage.OutputTokens, resp.Usage.CacheReadInputTokens)
+	// Calculate cost breakdown. resp.Usage already carries
+	// CacheCreationInputTokens (cache WRITE) alongside read/input/output, so
+	// route the full wire usage through costFromUsage directly rather than
+	// the CalculateCost wrapper (which only accepts cache reads).
+	costBreakdown := p.costFromUsage(resp.Usage)
 
 	predictResp.Content = textContent
 	predictResp.Parts = extractContentParts(resp.Content)

--- a/runtime/providers/claude/pricing_table.go
+++ b/runtime/providers/claude/pricing_table.go
@@ -1,0 +1,153 @@
+package claude
+
+import (
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// claudePricingCorrectAtYear/Month/Day pin the capture date stamped onto
+// every table entry below. Named instead of inlined into time.Date so the
+// magic-number linter doesn't fire on the call site.
+const (
+	claudePricingCorrectAtYear  = 2026
+	claudePricingCorrectAtMonth = time.July
+	claudePricingCorrectAtDay   = 7
+)
+
+// claudePricingCorrectAt is the date these per-model rates were captured.
+// RATES NEED HUMAN VERIFICATION against https://www.anthropic.com/pricing —
+// they were filled in from best-available knowledge, not fetched live. See
+// the task-9 report for the full per-model list and verification note.
+var claudePricingCorrectAt = time.Date(
+	claudePricingCorrectAtYear, claudePricingCorrectAtMonth, claudePricingCorrectAtDay,
+	0, 0, 0, 0, time.UTC,
+)
+
+// perMillionScale converts a published per-1M-token USD rate into a per-unit rate.
+const perMillionScale = 1_000_000.0
+
+// Anthropic prompt-cache economics are stable multipliers of the input rate,
+// independent of model tier: a cache READ (hit) is discounted, a cache WRITE
+// (miss; creates the 5-minute ephemeral cache entry) carries a premium. See
+// https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching.
+const (
+	cacheReadDiscount = 0.1  // cache_read_token = 10% of input rate
+	cacheWritePremium = 1.25 // cache_write_token = 125% of input rate
+)
+
+// perM builds a per-model pricing descriptor from published per-1M-token USD
+// input/output rates, deriving the cache_read and cache_write items from the
+// standard Anthropic multipliers above.
+func perM(input, output float64) *base.PricingDescriptor {
+	return &base.PricingDescriptor{
+		Source:           base.PricingSourceInline,
+		PricingCorrectAt: claudePricingCorrectAt,
+		Items: []base.PriceItem{
+			{Unit: base.UnitInputToken, Rate: input / perMillionScale},
+			{Unit: base.UnitOutputToken, Rate: output / perMillionScale},
+			{Unit: base.UnitCacheReadToken, Rate: input * cacheReadDiscount / perMillionScale},
+			{Unit: base.UnitCacheWriteToken, Rate: input * cacheWritePremium / perMillionScale},
+		},
+	}
+}
+
+// Per-1M-token USD rates (input, output) for every current Claude model
+// family. RATES NEED HUMAN VERIFICATION against https://www.anthropic.com/pricing
+// before being relied on for real billing — see the task-9 report.
+const (
+	claude3HaikuIn, claude3HaikuOut   = 0.25, 1.25 // Claude 3 Haiku
+	claude3SonnetIn, claude3SonnetOut = 3.0, 15.0  // Claude 3 Sonnet
+	claude3OpusIn, claude3OpusOut     = 15.0, 75.0 // Claude 3 Opus
+
+	claude35SonnetIn, claude35SonnetOut = 3.0, 15.0 // Claude 3.5 Sonnet
+	claude35HaikuIn, claude35HaikuOut   = 1.0, 5.0  // Claude 3.5 Haiku
+
+	claude37SonnetIn, claude37SonnetOut = 3.0, 15.0 // Claude 3.7 Sonnet
+
+	claudeSonnet4In, claudeSonnet4Out = 3.0, 15.0  // Claude Sonnet 4
+	claudeOpus4In, claudeOpus4Out     = 15.0, 75.0 // Claude Opus 4
+	claudeOpus41In, claudeOpus41Out   = 15.0, 75.0 // Claude Opus 4.1
+
+	claudeSonnet45In, claudeSonnet45Out = 3.0, 15.0 // Claude Sonnet 4.5
+	claudeHaiku45In, claudeHaiku45Out   = 1.0, 5.0  // Claude Haiku 4.5
+	// Claude Opus 4.5 reportedly launched at a lower price than prior Opus
+	// releases; the exact figure below is a low-confidence guess pending
+	// verification (flagged in the task-9 report).
+	claudeOpus45In, claudeOpus45Out = 5.0, 25.0 // Claude Opus 4.5
+)
+
+// Shared descriptors, one per rate tier, reused across dated snapshot IDs and
+// bare family aliases in claudePricingTable so every alias of a model prices
+// identically.
+var (
+	claude3Haiku   = perM(claude3HaikuIn, claude3HaikuOut)
+	claude3Sonnet  = perM(claude3SonnetIn, claude3SonnetOut)
+	claude3Opus    = perM(claude3OpusIn, claude3OpusOut)
+	claude35Sonnet = perM(claude35SonnetIn, claude35SonnetOut)
+	claude35Haiku  = perM(claude35HaikuIn, claude35HaikuOut)
+	claude37Sonnet = perM(claude37SonnetIn, claude37SonnetOut)
+	claudeSonnet4  = perM(claudeSonnet4In, claudeSonnet4Out)
+	claudeOpus4    = perM(claudeOpus4In, claudeOpus4Out)
+	claudeOpus41   = perM(claudeOpus41In, claudeOpus41Out)
+	claudeSonnet45 = perM(claudeSonnet45In, claudeSonnet45Out)
+	claudeHaiku45  = perM(claudeHaiku45In, claudeHaiku45Out)
+	claudeOpus45   = perM(claudeOpus45In, claudeOpus45Out)
+)
+
+// Model IDs shared with the legacy claudePricing() heuristic fallback in
+// claude.go (still exercised directly by claude_pricing_test.go), named here
+// so the id string is spelled once instead of duplicated across the two
+// tables (goconst).
+const (
+	idClaude3Haiku20240307   = "claude-3-haiku-20240307"
+	idClaude3Sonnet20240229  = "claude-3-sonnet-20240229"
+	idClaude3Opus20240229    = "claude-3-opus-20240229"
+	idClaude35Sonnet20240620 = "claude-3-5-sonnet-20240620"
+	idClaude35Sonnet20241022 = "claude-3-5-sonnet-20241022"
+	idClaude35Haiku20241022  = "claude-3-5-haiku-20241022"
+	idClaudeSonnet45         = "claude-sonnet-4-5"
+	idClaudeHaiku45          = "claude-haiku-4-5"
+)
+
+// claudePricingTable maps both dated snapshot IDs and bare family aliases to
+// their pricing descriptor. Looked up via base.ResolveLLMPricing, which
+// normalizes a vendor-qualified model id (e.g. "anthropic/claude-sonnet-4-5")
+// down to the bare id before matching — there is no substring/heuristic
+// fallback, so a model absent here prices as $0 with a loud warning rather
+// than silently guessing a wrong constant.
+var claudePricingTable = map[string]*base.PricingDescriptor{
+	// Claude 3
+	idClaude3Haiku20240307:  claude3Haiku,
+	idClaude3Sonnet20240229: claude3Sonnet,
+	idClaude3Opus20240229:   claude3Opus,
+	"claude-3-haiku":        claude3Haiku,
+	"claude-3-sonnet":       claude3Sonnet,
+	"claude-3-opus":         claude3Opus,
+
+	// Claude 3.5
+	idClaude35Sonnet20240620: claude35Sonnet,
+	idClaude35Sonnet20241022: claude35Sonnet,
+	idClaude35Haiku20241022:  claude35Haiku,
+	"claude-3-5-sonnet":      claude35Sonnet,
+	"claude-3-5-haiku":       claude35Haiku,
+
+	// Claude 3.7
+	"claude-3-7-sonnet-20250219": claude37Sonnet,
+	"claude-3-7-sonnet":          claude37Sonnet,
+
+	// Claude 4
+	"claude-sonnet-4-20250514": claudeSonnet4,
+	"claude-opus-4-20250514":   claudeOpus4,
+	"claude-opus-4-1-20250805": claudeOpus41,
+	"claude-sonnet-4":          claudeSonnet4,
+	"claude-opus-4":            claudeOpus4,
+	"claude-opus-4-1":          claudeOpus41,
+
+	// Claude 4.5
+	"claude-sonnet-4-5-20250929": claudeSonnet45,
+	"claude-haiku-4-5-20251001":  claudeHaiku45,
+	idClaudeSonnet45:             claudeSonnet45,
+	idClaudeHaiku45:              claudeHaiku45,
+	"claude-opus-4-5":            claudeOpus45,
+}

--- a/runtime/providers/finish_reason.go
+++ b/runtime/providers/finish_reason.go
@@ -8,7 +8,9 @@ import "github.com/AltairaLabs/PromptKit/runtime/types"
 // Shared by the OpenAI, vLLM, and Ollama providers, which speak this vocabulary.
 func NormalizeOpenAIFinishReason(raw string) string {
 	switch raw {
-	case "stop":
+	case "stop", "eos_token":
+		// "eos_token" is vLLM's native (non-OpenAI-compat) stop reason,
+		// surfaced verbatim by some vLLM deployments/engines instead of "stop".
 		return types.FinishReasonStop
 	case "length":
 		return types.FinishReasonMaxOutputTokens

--- a/runtime/providers/finish_reason_test.go
+++ b/runtime/providers/finish_reason_test.go
@@ -9,6 +9,7 @@ import (
 func TestNormalizeOpenAIFinishReason(t *testing.T) {
 	cases := map[string]string{
 		"stop":           types.FinishReasonStop,
+		"eos_token":      types.FinishReasonStop, // vLLM native stop-token reason
 		"length":         types.FinishReasonMaxOutputTokens,
 		"tool_calls":     types.FinishReasonToolUse,
 		"function_call":  types.FinishReasonToolUse,

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -273,6 +274,34 @@ type geminiUsage struct {
 	CandidatesTokenCount    int `json:"candidatesTokenCount"`
 	TotalTokenCount         int `json:"totalTokenCount"`
 	CachedContentTokenCount int `json:"cachedContentTokenCount,omitempty"`
+	// ThoughtsTokenCount is Gemini 2.5+ "thinking" token usage. It is billed
+	// on top of CandidatesTokenCount (at the output rate), not a subset of it.
+	ThoughtsTokenCount int `json:"thoughtsTokenCount,omitempty"`
+}
+
+// geminiUsageToTokens maps Gemini's cache-INCLUSIVE prompt accounting into
+// canonical units: uncached input = prompt - cached; thoughts are billed on
+// top of candidates, so they become the reasoning unit.
+func geminiUsageToTokens(u geminiUsage) base.TokenUsage {
+	return base.TokenUsage{
+		Input:     u.PromptTokenCount - u.CachedContentTokenCount,
+		CacheRead: u.CachedContentTokenCount,
+		Output:    u.CandidatesTokenCount,
+		Reasoning: u.ThoughtsTokenCount,
+	}
+}
+
+// costFromUsage prices a geminiUsage through the unit-keyed pricing engine: an
+// explicit config descriptor wins, then legacy flat per-1K config, then the
+// built-in per-model table (geminiPricingTable), else nil (priced units are
+// surfaced loudly by PriceUsage rather than silently reported as $0 without
+// warning — see ResolveLLMPricing/PriceUsage doc comments).
+func (p *Provider) costFromUsage(u geminiUsage) types.CostInfo {
+	desc := base.ResolveLLMPricing(
+		p.Pricing(),
+		base.FlatPricing{Input: p.defaults.Pricing.InputCostPer1K, Output: p.defaults.Pricing.OutputCostPer1K},
+		geminiPricingTable, p.model)
+	return base.PriceUsage(desc, p.ID(), base.ProviderTypeInference, geminiUsageToTokens(u), nil, 0)
 }
 
 type geminiPromptFeedback struct {
@@ -661,18 +690,16 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 		return predictResp, err
 	}
 
-	// Extract token counts
-	var tokensIn, tokensOut, cachedTokens int
+	// costFromUsage (not the CalculateCost wrapper) so thinking tokens
+	// (ThoughtsTokenCount) are priced; the wrapper's narrower signature drops them.
+	var usage geminiUsage
 	if geminiResp.UsageMetadata != nil {
-		tokensIn = geminiResp.UsageMetadata.PromptTokenCount
-		tokensOut = geminiResp.UsageMetadata.CandidatesTokenCount
-		cachedTokens = geminiResp.UsageMetadata.CachedContentTokenCount
+		usage = *geminiResp.UsageMetadata
 	}
 
 	latency := time.Since(start)
 
-	// promptTokenCount includes cached tokens; CalculateCost subtracts them.
-	costBreakdown := p.CalculateCost(tokensIn, tokensOut, cachedTokens)
+	costBreakdown := p.costFromUsage(usage)
 
 	// Extract all content parts (text + inline media + markdown images)
 	var contentParts []types.ContentPart
@@ -757,9 +784,9 @@ func geminiPricing(model string) (inputPrice, outputPrice, cachedPrice float64) 
 	)
 
 	switch model {
-	case "gemini-1.5-pro", "gemini-2.5-pro":
+	case idGemini15Pro, idGemini25Pro:
 		return proInput, proOutput, proCached
-	case "gemini-1.5-flash", "gemini-2.5-flash":
+	case idGemini15Flash, idGemini25Flash:
 		return flashInput, flashOutput, flashCached
 	case "gemini-pro":
 		return geminiInput, geminiOutput, geminiCached
@@ -775,36 +802,16 @@ func geminiPricing(model string) (inputPrice, outputPrice, cachedPrice float64) 
 // deterministic tool-order fix).
 func (p *Provider) SupportsPromptCaching() bool { return true }
 
-// CalculateCost calculates detailed cost breakdown including optional cached tokens
+// CalculateCost calculates detailed cost breakdown including optional cached
+// tokens. Thin wrapper over costFromUsage, kept for the Provider interface's
+// legacy signature. Note Gemini's promptTokenCount is cache-INCLUSIVE on the
+// wire, but this legacy signature's tokensIn parameter is documented (at call
+// sites) as already including cached tokens, so it is passed straight through
+// as PromptTokenCount and geminiUsageToTokens subtracts cachedTokens from it.
 func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.CostInfo {
-	var inputCostPer1K, outputCostPer1K, cachedCostPer1K float64
-
-	// Use configured pricing if available
-	if p.defaults.Pricing.InputCostPer1K > 0 && p.defaults.Pricing.OutputCostPer1K > 0 {
-		inputCostPer1K = p.defaults.Pricing.InputCostPer1K
-		outputCostPer1K = p.defaults.Pricing.OutputCostPer1K
-		// Cached tokens cost 50% of input tokens for Gemini
-		cachedCostPer1K = inputCostPer1K * 0.5
-	} else {
-		// Fallback to hardcoded pricing with warning
-		logger.Warn("No pricing configured, using fallback pricing", "provider", p.ID(), "model", p.model)
-		inputCostPer1K, outputCostPer1K, cachedCostPer1K = geminiPricing(p.model)
-	}
-
-	// Calculate costs
-	inputCost := float64(tokensIn-cachedTokens) / 1000.0 * inputCostPer1K
-	cachedCost := float64(cachedTokens) / 1000.0 * cachedCostPer1K
-	outputCost := float64(tokensOut) / 1000.0 * outputCostPer1K
-
-	return types.CostInfo{
-		InputTokens:   tokensIn - cachedTokens,
-		OutputTokens:  tokensOut,
-		CachedTokens:  cachedTokens,
-		InputCostUSD:  inputCost,
-		OutputCostUSD: outputCost,
-		CachedCostUSD: cachedCost,
-		TotalCost:     inputCost + cachedCost + outputCost,
-	}
+	return p.costFromUsage(geminiUsage{
+		PromptTokenCount: tokensIn, CandidatesTokenCount: tokensOut, CachedContentTokenCount: cachedTokens,
+	})
 }
 
 // inferMediaTypeFromMIME infers the content type (image/audio/video) from a MIME type

--- a/runtime/providers/gemini/gemini_cost_test.go
+++ b/runtime/providers/gemini/gemini_cost_test.go
@@ -1,0 +1,101 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// newTestGeminiProvider builds a bare Provider with only the model set, so
+// costFromUsage resolves pricing purely from geminiPricingTable (no config
+// descriptor, no legacy flat Pricing).
+func newTestGeminiProvider(t *testing.T, model string) *Provider {
+	t.Helper()
+	return NewProvider("test-gemini", model, "https://generativelanguage.googleapis.com/v1beta", providers.ProviderDefaults{}, false)
+}
+
+// TestGeminiCost_AddsThinkingTokens is the regression test for finding F:
+// Gemini's usageMetadata reports thoughtsTokenCount (Gemini 2.5+ "thinking"
+// models) separately from candidatesTokenCount, billed ON TOP of it at the
+// output rate. The old CalculateCost path never read thoughtsTokenCount at
+// all, so every thinking token was silently free. costFromUsage must price it.
+func TestGeminiCost_AddsThinkingTokens(t *testing.T) {
+	p := newTestGeminiProvider(t, "gemini-2.5-pro")
+	base_ := geminiUsage{PromptTokenCount: 1000, CandidatesTokenCount: 500, CachedContentTokenCount: 200}
+	withThinking := base_
+	withThinking.ThoughtsTokenCount = 300
+
+	ci := p.costFromUsage(withThinking)
+	assert.Equal(t, 300.0, ci.Quantities[base.UnitReasoningToken])
+	assert.Greater(t, ci.TotalCost, p.costFromUsage(base_).TotalCost) // thinking billed on top
+
+	// input is cache-exclusive: prompt - cached
+	assert.Equal(t, 800, ci.InputTokens)
+}
+
+// TestGeminiCost_UnknownModelNoWrongConstant is the regression test for
+// finding K: an unmatched model must price as $0 (surfaced via the loud
+// unpriced-unit warning path), never silently fall back to a guessed constant
+// like "assume Gemini 1.5 Pro pricing" (the old geminiPricing() default arm).
+func TestGeminiCost_UnknownModelNoWrongConstant(t *testing.T) {
+	p := newTestGeminiProvider(t, "gemini-9.9-imaginary")
+	ci := p.costFromUsage(geminiUsage{PromptTokenCount: 1000, CandidatesTokenCount: 500})
+	assert.Zero(t, ci.TotalCost) // loud warn + $0, NOT gemini-1.5-pro constants
+}
+
+// TestGeminiUsageToTokens_MapsAllFields verifies the field-by-field mapping
+// from the wire geminiUsage shape into canonical base.TokenUsage units,
+// including that PromptTokenCount is cache-INCLUSIVE (must subtract
+// CachedContentTokenCount to get the canonical, full-price Input unit).
+func TestGeminiUsageToTokens_MapsAllFields(t *testing.T) {
+	u := geminiUsage{
+		PromptTokenCount: 1000, CandidatesTokenCount: 500,
+		CachedContentTokenCount: 200, ThoughtsTokenCount: 300,
+	}
+	got := geminiUsageToTokens(u)
+	assert.Equal(t, base.TokenUsage{Input: 800, CacheRead: 200, Output: 500, Reasoning: 300}, got)
+}
+
+// TestGeminiCost_KnownModelPricesThinking pins the actual USD amounts for a
+// known table entry so a future edit to the thinking-rate/table values is
+// caught, not just "greater than zero".
+func TestGeminiCost_KnownModelPricesThinking(t *testing.T) {
+	p := newTestGeminiProvider(t, "gemini-2.5-pro")
+	ci := p.costFromUsage(geminiUsage{
+		PromptTokenCount: 1_000_000, CandidatesTokenCount: 1_000_000, ThoughtsTokenCount: 1_000_000,
+	})
+
+	// gemini-2.5-pro: $1.25/$10.00 per 1M; thinking priced at the output rate
+	// ($10/M). OutputCostUSD folds in output + reasoning.
+	assert.InDelta(t, 1_000_000.0, ci.Quantities[base.UnitInputToken], 1e-9)
+	assert.InDelta(t, 1.25, ci.InputCostUSD, 1e-9)
+	assert.InDelta(t, 10.0+10.0, ci.OutputCostUSD, 1e-9)
+}
+
+// TestGeminiCost_CalculateCostWrapperMatchesCostFromUsage verifies the public
+// CalculateCost(tokensIn, tokensOut, cachedTokens) signature (kept for the
+// Provider interface contract) is a pure wrapper over costFromUsage. Gemini's
+// legacy signature treats tokensIn as cache-INCLUSIVE (matching promptTokenCount
+// on the wire), so it maps straight through to geminiUsage.PromptTokenCount.
+func TestGeminiCost_CalculateCostWrapperMatchesCostFromUsage(t *testing.T) {
+	p := newTestGeminiProvider(t, "gemini-2.5-flash")
+	want := p.costFromUsage(geminiUsage{
+		PromptTokenCount: 1000, CandidatesTokenCount: 500, CachedContentTokenCount: 200,
+	})
+	got := p.CalculateCost(1000, 500, 200)
+
+	// Compare the priced fields directly rather than the whole struct: Breakdown
+	// row order comes from a map iteration and is not guaranteed stable across
+	// two independent calls.
+	assert.Equal(t, want.TotalCost, got.TotalCost)
+	assert.Equal(t, want.InputCostUSD, got.InputCostUSD)
+	assert.Equal(t, want.OutputCostUSD, got.OutputCostUSD)
+	assert.Equal(t, want.CachedCostUSD, got.CachedCostUSD)
+	assert.Equal(t, want.InputTokens, got.InputTokens)
+	assert.Equal(t, want.OutputTokens, got.OutputTokens)
+	assert.Equal(t, want.CachedTokens, got.CachedTokens)
+	assert.Equal(t, want.Quantities, got.Quantities)
+}

--- a/runtime/providers/gemini/gemini_integration_test.go
+++ b/runtime/providers/gemini/gemini_integration_test.go
@@ -488,18 +488,22 @@ func TestHandleGeminiFinishReason(t *testing.T) {
 	}
 }
 
-// TestProcessGeminiStreamChunk tests stream chunk processing
+// TestProcessGeminiStreamChunk tests stream chunk processing. Regression
+// coverage for finding I: TokenCount on the emitted StreamChunk must come
+// only from real usageMetadata (the finish-chunk case), never from a
+// per-part-incremented approximation (the old totalTokens fabrication) —
+// interim chunks emit TokenCount 0.
 func TestProcessGeminiStreamChunk(t *testing.T) {
 	provider := NewProvider("test", "gemini-2.0-flash", "https://api.test", providers.ProviderDefaults{}, false)
 
 	tests := []struct {
-		name         string
-		chunk        geminiResponse
-		accumulated  string
-		totalTokens  int
-		wantFinished bool
-		wantContent  string
-		wantTokens   int
+		name           string
+		chunk          geminiResponse
+		accumulated    string
+		wantFinished   bool
+		wantContent    string
+		wantEmit       bool
+		wantTokenCount int
 	}{
 		{
 			name: "Regular chunk with text",
@@ -512,11 +516,11 @@ func TestProcessGeminiStreamChunk(t *testing.T) {
 					},
 				},
 			},
-			accumulated:  "Previous ",
-			totalTokens:  1,
-			wantFinished: false,
-			wantContent:  "Previous Hello",
-			wantTokens:   2,
+			accumulated:    "Previous ",
+			wantFinished:   false,
+			wantContent:    "Previous Hello",
+			wantEmit:       true,
+			wantTokenCount: 0,
 		},
 		{
 			name: "Finish chunk with usage",
@@ -534,11 +538,11 @@ func TestProcessGeminiStreamChunk(t *testing.T) {
 					CandidatesTokenCount: 5,
 				},
 			},
-			accumulated:  "Hello",
-			totalTokens:  5,
-			wantFinished: true,
-			wantContent:  "Hello!",
-			wantTokens:   6,
+			accumulated:    "Hello",
+			wantFinished:   true,
+			wantContent:    "Hello!",
+			wantEmit:       true,
+			wantTokenCount: 5, // real usageMetadata.CandidatesTokenCount
 		},
 		{
 			name: "Empty chunk",
@@ -546,10 +550,9 @@ func TestProcessGeminiStreamChunk(t *testing.T) {
 				Candidates: []geminiCandidate{},
 			},
 			accumulated:  "Hello",
-			totalTokens:  5,
 			wantFinished: false,
 			wantContent:  "Hello",
-			wantTokens:   5,
+			wantEmit:     false,
 		},
 	}
 
@@ -560,11 +563,36 @@ func TestProcessGeminiStreamChunk(t *testing.T) {
 
 			var sb strings.Builder
 			sb.WriteString(tt.accumulated)
-			tokens, _, finished := provider.processGeminiStreamChunk(tt.chunk, &sb, tt.totalTokens, nil, outChan)
+			_, finished := provider.processGeminiStreamChunk(tt.chunk, &sb, nil, outChan)
 
 			assert.Equal(t, tt.wantContent, sb.String())
-			assert.Equal(t, tt.wantTokens, tokens)
 			assert.Equal(t, tt.wantFinished, finished)
+
+			// A finish-chunk that also carries a text part emits two
+			// StreamChunks: the interim text delta first, then the terminal
+			// chunk with the real TokenCount. Drain all of them and check the
+			// last (the terminal one when finished, the only one otherwise).
+			var emitted []providers.StreamChunk
+		drain:
+			for {
+				select {
+				case sc := <-outChan:
+					emitted = append(emitted, sc)
+				default:
+					break drain
+				}
+			}
+
+			if !tt.wantEmit {
+				if len(emitted) != 0 {
+					t.Fatalf("did not expect a chunk to be emitted, got %+v", emitted)
+				}
+				return
+			}
+			if len(emitted) == 0 {
+				t.Fatal("expected a chunk to be emitted")
+			}
+			assert.Equal(t, tt.wantTokenCount, emitted[len(emitted)-1].TokenCount)
 		})
 	}
 }

--- a/runtime/providers/gemini/gemini_multimodal.go
+++ b/runtime/providers/gemini/gemini_multimodal.go
@@ -260,18 +260,16 @@ func (p *Provider) predictWithContents(ctx context.Context, contents []geminiCon
 		return predictResp, err
 	}
 
-	// Extract token counts
-	var tokensIn, tokensOut, cachedTokens int
+	// costFromUsage (not the CalculateCost wrapper) so thinking tokens
+	// (ThoughtsTokenCount) are priced; the wrapper's narrower signature drops them.
+	var usage geminiUsage
 	if geminiResp.UsageMetadata != nil {
-		tokensIn = geminiResp.UsageMetadata.PromptTokenCount
-		tokensOut = geminiResp.UsageMetadata.CandidatesTokenCount
-		cachedTokens = geminiResp.UsageMetadata.CachedContentTokenCount
+		usage = *geminiResp.UsageMetadata
 	}
 
 	latency := time.Since(start)
 
-	// Calculate cost breakdown
-	costBreakdown := p.CalculateCost(tokensIn, tokensOut, cachedTokens)
+	costBreakdown := p.costFromUsage(usage)
 
 	// Guard against an empty/odd API response (no candidates, no parts) rather
 	// than panicking with an index-out-of-range.

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -78,16 +78,22 @@ func (p *Provider) PredictStream(
 	}, p.streamResponse)
 }
 
-// processGeminiStreamChunk processes a single chunk from the Gemini stream
+// processGeminiStreamChunk processes a single chunk from the Gemini stream.
+//
+// TokenCount/DeltaTokens are populated ONLY from real usageMetadata (present
+// on the terminal chunk), never from a per-part-incremented approximation —
+// Gemini's "tokens" are not 1:1 with text parts (a part can be a whole
+// sentence or a single character), so counting parts fabricated a number that
+// looked precise but was not calibrated to anything real. Interim chunks
+// leave TokenCount/DeltaTokens at their zero value.
 func (p *Provider) processGeminiStreamChunk(
 	chunk geminiResponse,
 	sb *strings.Builder,
-	totalTokens int,
 	toolCalls []types.MessageToolCall,
 	outChan chan<- providers.StreamChunk,
-) (newTotalTokens int, newToolCalls []types.MessageToolCall, finished bool) {
+) (newToolCalls []types.MessageToolCall, finished bool) {
 	if len(chunk.Candidates) == 0 {
-		return totalTokens, toolCalls, false
+		return toolCalls, false
 	}
 
 	candidate := chunk.Candidates[0]
@@ -112,13 +118,10 @@ func (p *Provider) processGeminiStreamChunk(
 		// Handle text content
 		if part.Text != "" {
 			sb.WriteString(part.Text)
-			totalTokens++ // Approximate
 
 			outChan <- providers.StreamChunk{
-				Content:     sb.String(),
-				Delta:       part.Text,
-				TokenCount:  totalTokens,
-				DeltaTokens: 1,
+				Content: sb.String(),
+				Delta:   part.Text,
 			}
 		}
 
@@ -157,32 +160,30 @@ func (p *Provider) processGeminiStreamChunk(
 				),
 				FinishReason: &candidate.FinishReason,
 			}
-			return totalTokens, toolCalls, true
+			return toolCalls, true
 		}
 
 		normalized := normalizeFinishReason(candidate.FinishReason)
 		finalChunk := providers.StreamChunk{
 			Content:      sb.String(),
-			TokenCount:   totalTokens,
 			FinishReason: &normalized,
 			ToolCalls:    toolCalls,
 		}
 
-		// Extract cost from usage metadata if available
+		// TokenCount and CostInfo come from real usageMetadata only — routed
+		// through costFromUsage (not the CalculateCost wrapper) so thinking
+		// tokens are priced too (see Task 10).
 		if chunk.UsageMetadata != nil {
-			costBreakdown := p.CalculateCost(
-				chunk.UsageMetadata.PromptTokenCount,
-				chunk.UsageMetadata.CandidatesTokenCount,
-				chunk.UsageMetadata.CachedContentTokenCount,
-			)
+			finalChunk.TokenCount = chunk.UsageMetadata.CandidatesTokenCount
+			costBreakdown := p.costFromUsage(*chunk.UsageMetadata)
 			finalChunk.CostInfo = &costBreakdown
 		}
 
 		outChan <- finalChunk
-		return totalTokens, toolCalls, true // Signal finish
+		return toolCalls, true // Signal finish
 	}
 
-	return totalTokens, toolCalls, false
+	return toolCalls, false
 }
 
 // streamResponse reads a JSON array stream from Gemini and sends chunks incrementally.
@@ -225,7 +226,6 @@ func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outCh
 	}
 
 	var sb strings.Builder
-	totalTokens := 0
 	var toolCalls []types.MessageToolCall
 
 	// Decode each element incrementally as it arrives
@@ -252,8 +252,7 @@ func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outCh
 		}
 
 		var finished bool
-		totalTokens, toolCalls, finished = p.processGeminiStreamChunk(
-			chunk, &sb, totalTokens, toolCalls, outChan)
+		toolCalls, finished = p.processGeminiStreamChunk(chunk, &sb, toolCalls, outChan)
 		if finished {
 			return
 		}
@@ -269,10 +268,11 @@ func (p *Provider) streamResponse(ctx context.Context, body io.ReadCloser, outCh
 		return
 	}
 
-	// No finish reason received, send final chunk
+	// No finish reason received, send final chunk. No usageMetadata was seen
+	// on this path, so TokenCount stays at its zero value rather than a
+	// fabricated approximation.
 	outChan <- providers.StreamChunk{
 		Content:      sb.String(),
-		TokenCount:   totalTokens,
 		ToolCalls:    toolCalls,
 		FinishReason: providers.StringPtr("stop"),
 	}

--- a/runtime/providers/gemini/gemini_streaming_test.go
+++ b/runtime/providers/gemini/gemini_streaming_test.go
@@ -388,11 +388,10 @@ func TestProcessGeminiStreamChunk_Incremental(t *testing.T) {
 		var sb strings.Builder
 		sb.WriteString("prev")
 
-		tokens, toolCalls, finished := provider.processGeminiStreamChunk(
-			chunk, &sb, 5, nil, outChan)
+		toolCalls, finished := provider.processGeminiStreamChunk(chunk, &sb, nil, outChan)
 
-		if sb.String() != "prev" || tokens != 5 || finished {
-			t.Errorf("expected unchanged state, got acc=%q tokens=%d finished=%v", sb.String(), tokens, finished)
+		if sb.String() != "prev" || finished {
+			t.Errorf("expected unchanged state, got acc=%q finished=%v", sb.String(), finished)
 		}
 		if len(toolCalls) != 0 {
 			t.Errorf("expected no tool calls, got %d", len(toolCalls))
@@ -409,15 +408,17 @@ func TestProcessGeminiStreamChunk_Incremental(t *testing.T) {
 		var sb strings.Builder
 		sb.WriteString("prev")
 
-		tokens, _, finished := provider.processGeminiStreamChunk(
-			chunk, &sb, 5, nil, outChan)
+		_, finished := provider.processGeminiStreamChunk(chunk, &sb, nil, outChan)
 
-		if sb.String() != "prev" || tokens != 5 || finished {
-			t.Errorf("expected unchanged state, got acc=%q tokens=%d finished=%v", sb.String(), tokens, finished)
+		if sb.String() != "prev" || finished {
+			t.Errorf("expected unchanged state, got acc=%q finished=%v", sb.String(), finished)
 		}
 	})
 
-	t.Run("text part emits chunk and accumulates", func(t *testing.T) {
+	// Regression for finding I: interim text chunks must not fabricate a
+	// TokenCount by incrementing a per-part counter. TokenCount/DeltaTokens
+	// only ever reflect real usageMetadata, reported on the terminal chunk.
+	t.Run("text part emits chunk and accumulates without fabricating token count", func(t *testing.T) {
 		chunk := geminiResponse{
 			Candidates: []geminiCandidate{
 				{Content: geminiContent{Parts: []geminiPart{{Text: "delta"}}}},
@@ -427,14 +428,10 @@ func TestProcessGeminiStreamChunk_Incremental(t *testing.T) {
 		var sb strings.Builder
 		sb.WriteString("prev")
 
-		tokens, _, finished := provider.processGeminiStreamChunk(
-			chunk, &sb, 5, nil, outChan)
+		_, finished := provider.processGeminiStreamChunk(chunk, &sb, nil, outChan)
 
 		if sb.String() != "prevdelta" {
 			t.Errorf("expected accumulated 'prevdelta', got %q", sb.String())
-		}
-		if tokens != 6 {
-			t.Errorf("expected 6 tokens, got %d", tokens)
 		}
 		if finished {
 			t.Error("expected not finished")
@@ -444,6 +441,10 @@ func TestProcessGeminiStreamChunk_Incremental(t *testing.T) {
 		case sc := <-outChan:
 			if sc.Delta != "delta" {
 				t.Errorf("expected delta 'delta', got %q", sc.Delta)
+			}
+			if sc.TokenCount != 0 || sc.DeltaTokens != 0 {
+				t.Errorf("interim chunk must not fabricate a token count, got TokenCount=%d DeltaTokens=%d",
+					sc.TokenCount, sc.DeltaTokens)
 			}
 		default:
 			t.Fatal("expected chunk on channel")
@@ -471,8 +472,7 @@ func TestProcessGeminiStreamChunk_Incremental(t *testing.T) {
 		outChan := make(chan providers.StreamChunk, 10)
 		var sb strings.Builder
 
-		_, toolCalls, finished := provider.processGeminiStreamChunk(
-			chunk, &sb, 0, nil, outChan)
+		toolCalls, finished := provider.processGeminiStreamChunk(chunk, &sb, nil, outChan)
 
 		if !finished {
 			t.Error("expected finished")
@@ -484,6 +484,42 @@ func TestProcessGeminiStreamChunk_Incremental(t *testing.T) {
 			t.Errorf("expected tool name 'myTool', got %q", toolCalls[0].Name)
 		}
 	})
+}
+
+// TestGeminiStreaming_NoFabricatedTokenCount is the regression test for
+// finding I: a stream whose chunks carry no usageMetadata until the final
+// chunk must not report a per-part-incremented TokenCount on intermediate
+// chunks; the final chunk must reflect the real usageMetadata.
+func TestGeminiStreaming_NoFabricatedTokenCount(t *testing.T) {
+	provider := &Provider{}
+	responses := []geminiResponse{
+		{Candidates: []geminiCandidate{{Content: geminiContent{Parts: []geminiPart{{Text: "Hello"}}}}}},
+		{Candidates: []geminiCandidate{{Content: geminiContent{Parts: []geminiPart{{Text: " world"}}}}}},
+		{
+			Candidates: []geminiCandidate{
+				{Content: geminiContent{Parts: []geminiPart{{Text: "!"}}}, FinishReason: "STOP"},
+			},
+			UsageMetadata: &geminiUsage{PromptTokenCount: 10, CandidatesTokenCount: 3},
+		},
+	}
+
+	body := marshalJSONArray(t, responses)
+	outChan := make(chan providers.StreamChunk, 10)
+	provider.streamResponse(context.Background(), io.NopCloser(body), outChan)
+	chunks := collectChunks(t, outChan)
+
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	for _, c := range chunks[:len(chunks)-1] {
+		if c.TokenCount != 0 {
+			t.Errorf("interim chunk must not fabricate a token count, got %d", c.TokenCount)
+		}
+	}
+	last := chunks[len(chunks)-1]
+	if last.TokenCount <= 0 {
+		t.Errorf("expected final chunk to report a positive real token count, got %d", last.TokenCount)
+	}
 }
 
 // --- Helpers ---

--- a/runtime/providers/gemini/gemini_test.go
+++ b/runtime/providers/gemini/gemini_test.go
@@ -205,16 +205,22 @@ func TestGeminiProvider_CostBreakdown(t *testing.T) {
 	expectedInputCost := 0.00125 // 1000 tokens = 1 * $0.00125
 	expectedOutputCost := 0.0025 // 500 tokens = 0.5 * $0.005
 
-	if breakdown.InputCostUSD != expectedInputCost {
+	// Tolerance-based comparison: the priced-partial engine sums per-unit costs
+	// via a map iteration (computeCostPartial ranges over Quantities), whose
+	// order is randomized per call. Summation order can flip the last bit or
+	// two of a float64 total even though the two orderings are mathematically
+	// equal, so exact equality against a hand-computed literal is flaky here.
+	tolerance := 0.0000001
+	if breakdown.InputCostUSD < expectedInputCost-tolerance || breakdown.InputCostUSD > expectedInputCost+tolerance {
 		t.Errorf("Expected input cost %.5f, got %.5f", expectedInputCost, breakdown.InputCostUSD)
 	}
 
-	if breakdown.OutputCostUSD != expectedOutputCost {
+	if breakdown.OutputCostUSD < expectedOutputCost-tolerance || breakdown.OutputCostUSD > expectedOutputCost+tolerance {
 		t.Errorf("Expected output cost %.4f, got %.4f", expectedOutputCost, breakdown.OutputCostUSD)
 	}
 
 	expectedTotal := expectedInputCost + expectedOutputCost
-	if breakdown.TotalCost != expectedTotal {
+	if breakdown.TotalCost < expectedTotal-tolerance || breakdown.TotalCost > expectedTotal+tolerance {
 		t.Errorf("Expected total cost %.5f, got %.5f", expectedTotal, breakdown.TotalCost)
 	}
 }
@@ -232,7 +238,6 @@ func TestGeminiProvider_CostBreakdownWithCachedTokens(t *testing.T) {
 	provider := NewProvider("test", "gemini-1.5-pro", "url", defaults, false)
 
 	// 1000 input (total), 500 output, 200 cached
-	// Gemini cached tokens cost 50% of input tokens
 	breakdown := provider.CalculateCost(1000, 500, 200)
 
 	// InputTokens field contains only non-cached input tokens
@@ -248,8 +253,17 @@ func TestGeminiProvider_CostBreakdownWithCachedTokens(t *testing.T) {
 		t.Error("CachedTokens mismatch")
 	}
 
-	// Cached tokens cost 50% of regular input tokens (Gemini pricing)
-	expectedCachedCost := 0.000125 // 200 * 0.00125 / 1000 * 0.5 = 0.000125
+	// The legacy flat providers.Pricing{InputCostPer1K,OutputCostPer1K} config
+	// carries only input_token/output_token rates (base.ResolveLLMPricing's
+	// FlatPricing branch, by design — it can't know a provider-specific cache
+	// multiplier). So with flat config set, cache reads have no matching price
+	// item: the quantity is still tracked (CachedTokens above) but the dollar
+	// amount is $0, surfaced via a loud "unpriced unit" warning rather than a
+	// silently assumed 50% discount. Cache-aware pricing requires either the
+	// built-in per-model table (geminiPricingTable, used when flat pricing is
+	// NOT configured) or an explicit PricingDescriptor with a cache_read_token
+	// item.
+	expectedCachedCost := 0.0
 	// Input cost is for 800 tokens only
 	expectedInputCost := 0.001   // 800 * 0.00125 / 1000 = 0.001
 	expectedOutputCost := 0.0025 // 500 * 0.005 / 1000 = 0.0025

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -551,15 +551,13 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte, predictResp providers
 		}
 	}
 
-	var tokensIn, tokensOut, cachedTokens int
+	// costFromUsage (not the CalculateCost wrapper) so thinking tokens
+	// (ThoughtsTokenCount) are priced; the wrapper's narrower signature drops them.
+	var usage geminiUsage
 	if resp.UsageMetadata != nil {
-		tokensIn = resp.UsageMetadata.PromptTokenCount
-		tokensOut = resp.UsageMetadata.CandidatesTokenCount
-		cachedTokens = resp.UsageMetadata.CachedContentTokenCount
+		usage = *resp.UsageMetadata
 	}
-
-	// promptTokenCount includes cached tokens; CalculateCost subtracts them.
-	costBreakdown := p.CalculateCost(tokensIn, tokensOut, cachedTokens)
+	costBreakdown := p.costFromUsage(usage)
 
 	predictResp.Content = textBuilder.String()
 	predictResp.Reasoning = reasoningFromToolParts(candidate.Content.Parts)

--- a/runtime/providers/gemini/pricing_table.go
+++ b/runtime/providers/gemini/pricing_table.go
@@ -1,0 +1,142 @@
+package gemini
+
+import (
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// geminiPricingCorrectAtYear/Month/Day pin the capture date stamped onto
+// every table entry below. Named instead of inlined into time.Date so the
+// magic-number linter doesn't fire on the call site.
+const (
+	geminiPricingCorrectAtYear  = 2026
+	geminiPricingCorrectAtMonth = time.July
+	geminiPricingCorrectAtDay   = 7
+)
+
+// geminiPricingCorrectAt is the date these per-model rates were captured.
+// RATES NEED HUMAN VERIFICATION against https://ai.google.dev/pricing — they
+// were filled in from best-available knowledge, not fetched live. See the
+// task-10 report for the full per-model list and verification note. Notably,
+// Google publishes tiered input/output rates for some models (a higher rate
+// above a context-length threshold, e.g. 128K/200K tokens); this table prices
+// only the lower (short-context) tier — long-context requests will be
+// understated until a dimensioned price item is added.
+var geminiPricingCorrectAt = time.Date(
+	geminiPricingCorrectAtYear, geminiPricingCorrectAtMonth, geminiPricingCorrectAtDay,
+	0, 0, 0, 0, time.UTC,
+)
+
+// perMillionScale converts a published per-1M-token USD rate into a per-unit rate.
+const perMillionScale = 1_000_000.0
+
+// geminiCacheReadDiscount: Gemini prices an (implicit or explicit) cache hit
+// at 50% of the input rate. See https://ai.google.dev/gemini-api/docs/caching.
+const geminiCacheReadDiscount = 0.5
+
+// geminiPerM builds a per-model pricing descriptor from published
+// per-1M-token USD input/output rates. thinking gates whether the model bills
+// "thinking"/reasoning tokens separately (at the output rate) — Gemini 2.5+
+// "thinking" models do; earlier non-thinking models never emit
+// ThoughtsTokenCount, so the item is simply never priced for them, but adding
+// it unconditionally on non-thinking models would mean a future thinking
+// backport prices silently at $0 until this table is updated, so it stays
+// explicit.
+func geminiPerM(input, output float64, thinking bool) *base.PricingDescriptor {
+	items := []base.PriceItem{
+		{Unit: base.UnitInputToken, Rate: input / perMillionScale},
+		{Unit: base.UnitOutputToken, Rate: output / perMillionScale},
+		{Unit: base.UnitCacheReadToken, Rate: input * geminiCacheReadDiscount / perMillionScale},
+	}
+	if thinking {
+		items = append(items, base.PriceItem{Unit: base.UnitReasoningToken, Rate: output / perMillionScale})
+	}
+	return &base.PricingDescriptor{
+		Source:           base.PricingSourceInline,
+		PricingCorrectAt: geminiPricingCorrectAt,
+		Items:            items,
+	}
+}
+
+// Per-1M-token USD rates (input, output) for every current Gemini model
+// family. RATES NEED HUMAN VERIFICATION against https://ai.google.dev/pricing
+// before being relied on for real billing — see the task-10 report. The 3.x
+// rates in particular are low-confidence estimates (no verified public
+// pricing available at capture time) and are flagged individually below.
+const (
+	gemini15ProIn, gemini15ProOut     = 1.25, 5.00  // Gemini 1.5 Pro (short-context tier)
+	gemini15FlashIn, gemini15FlashOut = 0.075, 0.30 // Gemini 1.5 Flash (short-context tier)
+
+	gemini20FlashIn, gemini20FlashOut         = 0.10, 0.40  // Gemini 2.0 Flash
+	gemini20FlashLiteIn, gemini20FlashLiteOut = 0.075, 0.30 // Gemini 2.0 Flash-Lite
+
+	gemini25ProIn, gemini25ProOut             = 1.25, 10.0 // Gemini 2.5 Pro (short-context tier; thinking)
+	gemini25FlashIn, gemini25FlashOut         = 0.30, 2.50 // Gemini 2.5 Flash (thinking)
+	gemini25FlashLiteIn, gemini25FlashLiteOut = 0.10, 0.40 // Gemini 2.5 Flash-Lite (thinking)
+
+	// Gemini 3.x: LOW-CONFIDENCE ESTIMATE. No verified public pricing was
+	// available at capture time; these are extrapolated from the 2.5 tier
+	// pricing trend and MUST be verified before being relied on for billing.
+	gemini3ProIn, gemini3ProOut             = 2.00, 12.00 // Gemini 3 Pro (thinking) — UNVERIFIED
+	gemini3FlashIn, gemini3FlashOut         = 0.40, 3.00  // Gemini 3 Flash (thinking) — UNVERIFIED
+	gemini3FlashLiteIn, gemini3FlashLiteOut = 0.15, 0.60  // Gemini 3 Flash-Lite (thinking) — UNVERIFIED
+)
+
+// Shared descriptors, one per rate tier, reused across dated snapshot IDs and
+// bare family aliases in geminiPricingTable so every alias of a model prices
+// identically.
+var (
+	gemini15Pro       = geminiPerM(gemini15ProIn, gemini15ProOut, false)
+	gemini15Flash     = geminiPerM(gemini15FlashIn, gemini15FlashOut, false)
+	gemini20Flash     = geminiPerM(gemini20FlashIn, gemini20FlashOut, false)
+	gemini20FlashLite = geminiPerM(gemini20FlashLiteIn, gemini20FlashLiteOut, false)
+	gemini25Pro       = geminiPerM(gemini25ProIn, gemini25ProOut, true)
+	gemini25Flash     = geminiPerM(gemini25FlashIn, gemini25FlashOut, true)
+	gemini25FlashLite = geminiPerM(gemini25FlashLiteIn, gemini25FlashLiteOut, true)
+	gemini3Pro        = geminiPerM(gemini3ProIn, gemini3ProOut, true)
+	gemini3Flash      = geminiPerM(gemini3FlashIn, gemini3FlashOut, true)
+	gemini3FlashLite  = geminiPerM(gemini3FlashLiteIn, gemini3FlashLiteOut, true)
+)
+
+// Model IDs shared with the legacy geminiPricing() heuristic fallback in
+// gemini.go (still used directly by streaming_support.go's
+// applyPricingConfig for the Live/duplex session, a separate cost path from
+// costFromUsage), named here so the id string is spelled once instead of
+// duplicated across the two tables (goconst).
+const (
+	idGemini15Pro   = "gemini-1.5-pro"
+	idGemini15Flash = "gemini-1.5-flash"
+	idGemini25Pro   = "gemini-2.5-pro"
+	idGemini25Flash = "gemini-2.5-flash"
+)
+
+// geminiPricingTable maps both dated/versioned model IDs and bare family
+// aliases to their pricing descriptor. Looked up via base.ResolveLLMPricing,
+// which normalizes a vendor-qualified model id down to the bare id before
+// matching — there is no substring/heuristic fallback, so a model absent here
+// prices as $0 with a loud warning rather than silently guessing a wrong
+// constant (see PriceUsage).
+var geminiPricingTable = map[string]*base.PricingDescriptor{
+	// Gemini 1.5
+	idGemini15Pro:          gemini15Pro,
+	"gemini-1.5-pro-002":   gemini15Pro,
+	idGemini15Flash:        gemini15Flash,
+	"gemini-1.5-flash-002": gemini15Flash,
+
+	// Gemini 2.0
+	"gemini-2.0-flash":      gemini20Flash,
+	"gemini-2.0-flash-001":  gemini20Flash,
+	"gemini-2.0-flash-exp":  gemini20Flash,
+	"gemini-2.0-flash-lite": gemini20FlashLite,
+
+	// Gemini 2.5
+	idGemini25Pro:           gemini25Pro,
+	idGemini25Flash:         gemini25Flash,
+	"gemini-2.5-flash-lite": gemini25FlashLite,
+
+	// Gemini 3.x — UNVERIFIED, see const block comment above.
+	"gemini-3-pro":        gemini3Pro,
+	"gemini-3-flash":      gemini3Flash,
+	"gemini-3-flash-lite": gemini3FlashLite,
+}

--- a/runtime/providers/mock/mock.go
+++ b/runtime/providers/mock/mock.go
@@ -309,26 +309,32 @@ func (m *Provider) ShouldIncludeRawOutput() bool {
 	return m.includeRawOutput
 }
 
-// CalculateCost calculates cost breakdown for given token counts.
+// Mock provider's simple fixed test pricing, mirrored into mockPricing below.
+const (
+	mockTokensPer1K     = 1000.0
+	mockInputCostPer1K  = 0.01
+	mockOutputCostPer1K = 0.01
+	mockCachedCostPer1K = 0.005 // 50% discount for cached tokens
+)
+
+// mockPricing preserves the mock provider's intentionally nonzero, fixed
+// pricing so mock-based cost tests keep their historical expected values
+// after routing through the shared base.PriceUsage engine.
+var mockPricing = &base.PricingDescriptor{
+	Items: []base.PriceItem{
+		{Unit: base.UnitInputToken, Rate: mockInputCostPer1K / mockTokensPer1K},
+		{Unit: base.UnitCacheReadToken, Rate: mockCachedCostPer1K / mockTokensPer1K},
+		{Unit: base.UnitOutputToken, Rate: mockOutputCostPer1K / mockTokensPer1K},
+	},
+}
+
+// CalculateCost calculates cost breakdown for given token counts. inputTokens
+// is the total prompt token count including any cached tokens, so it is
+// reduced by cachedTokens before being reported as the canonical (uncached)
+// input unit — matching the historical formula's InputTokens semantics.
 func (m *Provider) CalculateCost(inputTokens, outputTokens, cachedTokens int) types.CostInfo {
-	// Mock provider uses simple fixed pricing
-	inputCostPer1K := 0.01
-	outputCostPer1K := 0.01
-	cachedCostPer1K := 0.005 // 50% discount for cached tokens
-
-	inputCost := float64(inputTokens-cachedTokens) / 1000.0 * inputCostPer1K
-	cachedCost := float64(cachedTokens) / 1000.0 * cachedCostPer1K
-	outputCost := float64(outputTokens) / 1000.0 * outputCostPer1K
-
-	return types.CostInfo{
-		InputTokens:   inputTokens - cachedTokens,
-		OutputTokens:  outputTokens,
-		CachedTokens:  cachedTokens,
-		InputCostUSD:  inputCost,
-		OutputCostUSD: outputCost,
-		CachedCostUSD: cachedCost,
-		TotalCost:     inputCost + cachedCost + outputCost,
-	}
+	return base.PriceUsage(mockPricing, m.ID(), base.ProviderTypeInference,
+		base.TokenUsage{Input: inputTokens - cachedTokens, CacheRead: cachedTokens, Output: outputTokens}, nil, 0)
 }
 
 // generateContentSummary creates a human-readable summary from content parts

--- a/runtime/providers/ollama/ollama.go
+++ b/runtime/providers/ollama/ollama.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -175,18 +176,14 @@ func (p *Provider) Predict(
 	return p.predictWithMessages(ctx, req, messages)
 }
 
-// CalculateCost calculates cost breakdown - Ollama is free (local inference)
+// CalculateCost calculates cost breakdown - Ollama is free (local inference).
+// A nil pricing descriptor routes through the shared engine as $0 while still
+// populating the headline token counts (see base.PriceUsage). tokensIn is the
+// total prompt token count including any cached tokens, so it is reduced by
+// cachedTokens before being reported as the canonical (uncached) input unit.
 func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.CostInfo {
-	// Ollama is free local inference - no cost
-	return types.CostInfo{
-		InputTokens:   tokensIn - cachedTokens,
-		OutputTokens:  tokensOut,
-		CachedTokens:  cachedTokens,
-		InputCostUSD:  0,
-		OutputCostUSD: 0,
-		CachedCostUSD: 0,
-		TotalCost:     0,
-	}
+	return base.PriceUsage(nil, p.ID(), base.ProviderTypeInference,
+		base.TokenUsage{Input: tokensIn - cachedTokens, CacheRead: cachedTokens, Output: tokensOut}, nil, 0)
 }
 
 // PredictStream streams a predict response from Ollama

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -15,6 +15,7 @@ import (
 	credentials "github.com/AltairaLabs/PromptKit/runtime/credentials"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -30,13 +31,6 @@ const (
 	authorizationHeader          = "Authorization"
 	bearerPrefix                 = "Bearer "
 	httpClientTimeout            = 60 * time.Second
-)
-
-// Default pricing constants (GPT-4o pricing used as fallback for unknown models)
-const (
-	defaultInputCostPer1K  = 0.0025
-	defaultOutputCostPer1K = 0.01
-	defaultCachedCostPer1K = 0.00125
 )
 
 // oSeriesMinLen is the minimum length of an o-series model name (e.g. "o1").
@@ -534,14 +528,24 @@ type openAIChoice struct {
 }
 
 type openAIUsage struct {
-	PromptTokens        int                  `json:"prompt_tokens"`
-	CompletionTokens    int                  `json:"completion_tokens"`
-	TotalTokens         int                  `json:"total_tokens"`
-	PromptTokensDetails *openAIPromptDetails `json:"prompt_tokens_details,omitempty"`
+	PromptTokens            int                      `json:"prompt_tokens"`
+	CompletionTokens        int                      `json:"completion_tokens"`
+	TotalTokens             int                      `json:"total_tokens"`
+	PromptTokensDetails     *openAIPromptDetails     `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *openAICompletionDetails `json:"completion_tokens_details,omitempty"`
 }
 
 type openAIPromptDetails struct {
 	CachedTokens int `json:"cached_tokens"`
+}
+
+// openAICompletionDetails carries the reasoning-token sub-count OpenAI
+// reports on completion_tokens_details. completion_tokens on the wire
+// INCLUDES reasoning tokens (they share the same output budget), so this
+// value must be subtracted back out to get the visible-only output count —
+// see openAIUsageToTokens.
+type openAICompletionDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens"`
 }
 
 type openAIError struct {
@@ -652,61 +656,52 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 // prefix is stable across rounds (see the deterministic tool-order fix).
 func (p *Provider) SupportsPromptCaching() bool { return true }
 
-// CalculateCost calculates detailed cost breakdown including optional cached tokens
+// openAIUsageToTokens maps OpenAI's cache-INCLUSIVE prompt accounting and
+// reasoning-INCLUSIVE completion accounting into canonical units.
+// prompt_tokens on the wire INCLUDES any cached_tokens sub-count, so cached
+// must be subtracted back out to get full-price input. completion_tokens
+// likewise INCLUDES reasoning_tokens, so output is the visible-only
+// remainder and reasoning is priced as its own additive unit.
+func openAIUsageToTokens(u openAIUsage) base.TokenUsage {
+	reasoning, cached := 0, 0
+	if u.CompletionTokensDetails != nil {
+		reasoning = u.CompletionTokensDetails.ReasoningTokens
+	}
+	if u.PromptTokensDetails != nil {
+		cached = u.PromptTokensDetails.CachedTokens
+	}
+	return base.TokenUsage{
+		Input:     u.PromptTokens - cached,
+		CacheRead: cached,
+		Output:    u.CompletionTokens - reasoning,
+		Reasoning: reasoning,
+	}
+}
+
+// costFromUsage prices an openAIUsage through the unit-keyed pricing engine:
+// an explicit config descriptor wins, then legacy flat per-1K config, then
+// the built-in per-model table (openaiPricingTable), else nil (priced units
+// are surfaced loudly by PriceUsage rather than silently reported as $0
+// without warning — see ResolveLLMPricing/PriceUsage doc comments).
+func (p *Provider) costFromUsage(u openAIUsage) types.CostInfo {
+	desc := base.ResolveLLMPricing(
+		p.Pricing(),
+		base.FlatPricing{Input: p.defaults.Pricing.InputCostPer1K, Output: p.defaults.Pricing.OutputCostPer1K},
+		openaiPricingTable, p.model)
+	return base.PriceUsage(desc, p.ID(), base.ProviderTypeInference, openAIUsageToTokens(u), nil, 0)
+}
+
+// CalculateCost calculates detailed cost breakdown including optional cached
+// tokens. Thin wrapper over costFromUsage, kept for the Provider interface's
+// legacy signature (cachedTokens here means cache reads only — callers that
+// also have a reasoning-token count, e.g. wire openAIUsage, should call
+// costFromUsage directly instead so reasoning tokens aren't dropped).
 func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.CostInfo {
-	var inputCostPer1K, outputCostPer1K, cachedCostPer1K float64
-
-	// Use configured pricing if available
-	if p.defaults.Pricing.InputCostPer1K > 0 && p.defaults.Pricing.OutputCostPer1K > 0 {
-		inputCostPer1K = p.defaults.Pricing.InputCostPer1K
-		outputCostPer1K = p.defaults.Pricing.OutputCostPer1K
-		// Assume cached tokens cost 50% of input tokens
-		cachedCostPer1K = inputCostPer1K * 0.5
-	} else {
-		switch p.model {
-		case "gpt-4":
-			inputCostPer1K = 0.03   // $0.03 per 1K input tokens
-			outputCostPer1K = 0.06  // $0.06 per 1K output tokens
-			cachedCostPer1K = 0.015 // $0.015 per 1K cached tokens (50% discount)
-		case "gpt-4o-mini":
-			inputCostPer1K = 0.00015   // $0.00015 per 1K input tokens
-			outputCostPer1K = 0.0006   // $0.0006 per 1K output tokens
-			cachedCostPer1K = 0.000075 // $0.000075 per 1K cached tokens (50% discount)
-		case "gpt-3.5-turbo":
-			inputCostPer1K = 0.0015   // $0.0015 per 1K input tokens
-			outputCostPer1K = 0.002   // $0.002 per 1K output tokens
-			cachedCostPer1K = 0.00075 // $0.00075 per 1K cached tokens (50% discount)
-		case "gpt-4o":
-			inputCostPer1K = defaultInputCostPer1K
-			outputCostPer1K = defaultOutputCostPer1K
-			cachedCostPer1K = defaultCachedCostPer1K
-		default:
-			// Unknown model (e.g. a local/self-hosted server behind a custom
-			// base_url): there is no reliable price. Report zero rather than
-			// fabricate a cost from GPT-4o rates. Configure `pricing` on the
-			// provider to get real cost numbers for unrecognized models.
-			logger.Warn("No pricing configured for unknown model; reporting zero cost",
-				"provider", p.ID(), "model", p.model)
-			inputCostPer1K = 0
-			outputCostPer1K = 0
-			cachedCostPer1K = 0
-		}
-	}
-
-	// Calculate costs
-	inputCost := float64(tokensIn-cachedTokens) / 1000.0 * inputCostPer1K
-	cachedCost := float64(cachedTokens) / 1000.0 * cachedCostPer1K
-	outputCost := float64(tokensOut) / 1000.0 * outputCostPer1K
-
-	return types.CostInfo{
-		InputTokens:   tokensIn - cachedTokens,
-		OutputTokens:  tokensOut,
-		CachedTokens:  cachedTokens,
-		InputCostUSD:  inputCost,
-		OutputCostUSD: outputCost,
-		CachedCostUSD: cachedCost,
-		TotalCost:     inputCost + cachedCost + outputCost,
-	}
+	return p.costFromUsage(openAIUsage{
+		PromptTokens:        tokensIn,
+		CompletionTokens:    tokensOut,
+		PromptTokensDetails: &openAIPromptDetails{CachedTokens: cachedTokens},
+	})
 }
 
 // PredictStream streams a predict response from OpenAI.
@@ -834,14 +829,10 @@ func (p *Provider) createFinalStreamChunk(accumulated string, accumulatedToolCal
 	}
 
 	if usage != nil {
-		tokensIn := usage.PromptTokens
-		tokensOut := usage.CompletionTokens
-		cachedTokens := 0
-		if usage.PromptTokensDetails != nil {
-			cachedTokens = usage.PromptTokensDetails.CachedTokens
-		}
-
-		costBreakdown := p.CalculateCost(tokensIn, tokensOut, cachedTokens)
+		// Route the full wire usage through costFromUsage (not the CalculateCost
+		// wrapper) so reasoning tokens reported in the final streamed usage chunk
+		// are priced rather than silently dropped.
+		costBreakdown := p.costFromUsage(*usage)
 		finalChunk.CostInfo = &costBreakdown
 	}
 
@@ -1160,13 +1151,10 @@ func (p *Provider) predictWithMessages(ctx context.Context, req providers.Predic
 
 	latency := time.Since(start)
 
-	cachedTokens := 0
-	if openAIResp.Usage.PromptTokensDetails != nil {
-		cachedTokens = openAIResp.Usage.PromptTokensDetails.CachedTokens
-	}
-
-	// Calculate cost breakdown
-	costBreakdown := p.CalculateCost(openAIResp.Usage.PromptTokens, openAIResp.Usage.CompletionTokens, cachedTokens)
+	// Calculate cost breakdown. Route the full wire usage through costFromUsage
+	// (not the CalculateCost wrapper) so reasoning tokens are priced rather
+	// than silently dropped.
+	costBreakdown := p.costFromUsage(openAIResp.Usage)
 
 	// Extract content - can be string or array of content parts
 	content := extractContentString(openAIResp.Choices[0].Message.Content)

--- a/runtime/providers/openai/openai_cost_test.go
+++ b/runtime/providers/openai/openai_cost_test.go
@@ -1,0 +1,140 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// newTestOpenAIProvider builds a bare Provider with only the model set, so
+// costFromUsage resolves pricing purely from openaiPricingTable (no config
+// descriptor, no legacy flat Pricing).
+func newTestOpenAIProvider(t *testing.T, model string) *Provider {
+	t.Helper()
+	return NewProvider("test-openai", model, "https://api.openai.com/v1", providers.ProviderDefaults{}, false)
+}
+
+// TestOpenAICost_ReasoningSplitOutOfOutput is the regression test for the
+// reasoning-token normalization: OpenAI reports completion_tokens INCLUSIVE
+// of reasoning_tokens, so the old bespoke CalculateCost (which only ever
+// took a flat tokensOut count) billed reasoning tokens as ordinary visible
+// output and never surfaced them as their own quantity. costFromUsage must
+// split reasoning out of the output headline while still pricing it (at the
+// output rate) so the total cost is unchanged but the breakdown is honest.
+func TestOpenAICost_ReasoningSplitOutOfOutput(t *testing.T) {
+	p := newTestOpenAIProvider(t, "o4-mini")
+	u := openAIUsage{PromptTokens: 1000, CompletionTokens: 800} // completion INCLUDES reasoning
+	u.CompletionTokensDetails = &openAICompletionDetails{ReasoningTokens: 300}
+	ci := p.costFromUsage(u)
+
+	// Output headline is visible-only: 800 - 300 = 500.
+	assert.Equal(t, 500, ci.OutputTokens)
+	assert.Equal(t, 300.0, ci.Quantities[base.UnitReasoningToken])
+
+	// Cost invariant holds; total equals output+reasoning at output rate + input.
+	assert.InDelta(t, ci.TotalCost, ci.InputCostUSD+ci.OutputCostUSD+ci.CachedCostUSD, 1e-9)
+}
+
+// TestOpenAIUsageToTokens_MapsAllFields verifies the field-by-field mapping
+// from the wire openAIUsage shape into canonical base.TokenUsage units,
+// including that prompt_tokens is cache-INCLUSIVE (cached must be
+// subtracted out) and completion_tokens is reasoning-INCLUSIVE (reasoning
+// must be subtracted out of the visible output count).
+func TestOpenAIUsageToTokens_MapsAllFields(t *testing.T) {
+	u := openAIUsage{
+		PromptTokens:            1000,
+		CompletionTokens:        800,
+		PromptTokensDetails:     &openAIPromptDetails{CachedTokens: 300},
+		CompletionTokensDetails: &openAICompletionDetails{ReasoningTokens: 200},
+	}
+	got := openAIUsageToTokens(u)
+	assert.Equal(t, base.TokenUsage{Input: 700, CacheRead: 300, Output: 600, Reasoning: 200}, got)
+}
+
+// TestOpenAIUsageToTokens_NilDetailsDefaultToZero verifies that a response
+// without prompt_tokens_details/completion_tokens_details (older models,
+// mock providers) treats prompt_tokens/completion_tokens as already
+// cache-exclusive/reasoning-exclusive rather than panicking on the nil
+// pointers.
+func TestOpenAIUsageToTokens_NilDetailsDefaultToZero(t *testing.T) {
+	got := openAIUsageToTokens(openAIUsage{PromptTokens: 1000, CompletionTokens: 500})
+	assert.Equal(t, base.TokenUsage{Input: 1000, Output: 500}, got)
+}
+
+// TestOpenAICost_KnownModelPricesCacheAndReasoning pins the actual USD
+// amounts for a known table entry so a future edit to the table is caught,
+// not just "greater than zero".
+func TestOpenAICost_KnownModelPricesCacheAndReasoning(t *testing.T) {
+	p := newTestOpenAIProvider(t, "gpt-4o")
+	ci := p.costFromUsage(openAIUsage{
+		PromptTokens:            2_000_000,
+		CompletionTokens:        1_000_000,
+		PromptTokensDetails:     &openAIPromptDetails{CachedTokens: 1_000_000},
+		CompletionTokensDetails: &openAICompletionDetails{ReasoningTokens: 500_000},
+	})
+
+	// gpt-4o: $2.50/$10.00 per 1M; cache_read = 50% of input ($1.25/M).
+	// InputCostUSD folds in input only (no cache_write unit for OpenAI).
+	assert.InDelta(t, 1_000_000.0, ci.Quantities[base.UnitInputToken], 1e-9)
+	assert.InDelta(t, 2.50, ci.InputCostUSD, 1e-9)
+	assert.InDelta(t, 1.25, ci.CachedCostUSD, 1e-9)
+	// Output cost folds in visible output (500K @ $10/M = $5) + reasoning
+	// (500K @ $10/M, same rate = $5) = $10.
+	assert.InDelta(t, 10.0, ci.OutputCostUSD, 1e-9)
+}
+
+// TestOpenAICost_UnknownModelNoWrongConstant matches the sibling providers'
+// (e.g. Claude, Gemini) fix for the same class of bug: an unmatched model
+// must price as $0 (surfaced via the loud-unpriced-unit warning path),
+// never silently fall back to a guessed constant like "assume GPT-4o pricing".
+func TestOpenAICost_UnknownModelNoWrongConstant(t *testing.T) {
+	p := newTestOpenAIProvider(t, "llama-3.1-70b-instruct")
+	ci := p.costFromUsage(openAIUsage{PromptTokens: 1000, CompletionTokens: 500})
+	assert.Zero(t, ci.TotalCost)
+}
+
+// TestOpenAICost_CalculateCostWrapperMatchesCostFromUsage verifies the
+// public CalculateCost(tokensIn, tokensOut, cachedTokens) signature (kept
+// for the Provider interface contract) is a pure wrapper over costFromUsage,
+// treating cachedTokens as cache reads only (it has no reasoning parameter).
+func TestOpenAICost_CalculateCostWrapperMatchesCostFromUsage(t *testing.T) {
+	p := newTestOpenAIProvider(t, "gpt-4o")
+	want := p.costFromUsage(openAIUsage{
+		PromptTokens: 1000, CompletionTokens: 500,
+		PromptTokensDetails: &openAIPromptDetails{CachedTokens: 200},
+	})
+	got := p.CalculateCost(1000, 500, 200)
+
+	// Compare the priced fields directly rather than the whole struct:
+	// Breakdown row order comes from a map iteration (computeCostPartial
+	// ranges over Quantities) and is not guaranteed stable across two
+	// independent calls.
+	assert.Equal(t, want.TotalCost, got.TotalCost)
+	assert.Equal(t, want.InputCostUSD, got.InputCostUSD)
+	assert.Equal(t, want.OutputCostUSD, got.OutputCostUSD)
+	assert.Equal(t, want.CachedCostUSD, got.CachedCostUSD)
+	assert.Equal(t, want.InputTokens, got.InputTokens)
+	assert.Equal(t, want.OutputTokens, got.OutputTokens)
+	assert.Equal(t, want.CachedTokens, got.CachedTokens)
+	assert.Equal(t, want.Quantities, got.Quantities)
+}
+
+// TestOpenAICost_ResponsesUsageMapsCachedTokens verifies
+// responsesUsageToOpenAIUsage carries InputTokensCached through to the
+// cache_read unit for the Responses API cost path, and that a nil usage
+// prices as zero rather than panicking.
+func TestOpenAICost_ResponsesUsageMapsCachedTokens(t *testing.T) {
+	p := newTestOpenAIProvider(t, "gpt-4o")
+	u := &responsesUsage{InputTokens: 1000, OutputTokens: 500, InputTokensCached: 200}
+	ci := p.costFromUsage(responsesUsageToOpenAIUsage(u))
+
+	assert.Equal(t, 800, ci.InputTokens)
+	assert.Equal(t, 200, ci.CachedTokens)
+	assert.Equal(t, 500, ci.OutputTokens)
+
+	zero := p.costFromUsage(responsesUsageToOpenAIUsage(nil))
+	assert.Zero(t, zero.TotalCost)
+}

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -101,6 +101,22 @@ type responsesUsage struct {
 	OutputTokensCached int `json:"output_tokens_cached,omitempty"`
 }
 
+// responsesUsageToOpenAIUsage builds the equivalent chat-shape openAIUsage
+// from a Responses API usage payload so both API surfaces share a single
+// costFromUsage pricing path. InputTokensCached maps to the chat
+// prompt_tokens_details.cached_tokens sub-count; a nil usage returns a
+// zero-value openAIUsage (zero cost).
+func responsesUsageToOpenAIUsage(u *responsesUsage) openAIUsage {
+	if u == nil {
+		return openAIUsage{}
+	}
+	return openAIUsage{
+		PromptTokens:        u.InputTokens,
+		CompletionTokens:    u.OutputTokens,
+		PromptTokensDetails: &openAIPromptDetails{CachedTokens: u.InputTokensCached},
+	}
+}
+
 // responsesError represents an error in the Responses API
 type responsesError struct {
 	Code    string `json:"code"`
@@ -283,11 +299,7 @@ func (p *Provider) predictWithResponses(
 	// Calculate cost
 	var costInfo *types.CostInfo
 	if responsesResp.Usage != nil {
-		cost := p.CalculateCost(
-			responsesResp.Usage.InputTokens,
-			responsesResp.Usage.OutputTokens,
-			responsesResp.Usage.InputTokensCached,
-		)
+		cost := p.costFromUsage(responsesUsageToOpenAIUsage(responsesResp.Usage))
 		costInfo = &cost
 	}
 
@@ -405,7 +417,7 @@ func (p *Provider) sendFinalChunk(
 		FinishReason: &reason,
 	}
 	if usage != nil {
-		cost := p.CalculateCost(usage.InputTokens, usage.OutputTokens, usage.InputTokensCached)
+		cost := p.costFromUsage(responsesUsageToOpenAIUsage(usage))
 		finalChunk.CostInfo = &cost
 	}
 	outChan <- finalChunk

--- a/runtime/providers/openai/openai_test.go
+++ b/runtime/providers/openai/openai_test.go
@@ -240,8 +240,13 @@ func TestOpenAIProvider_CostBreakdown(t *testing.T) {
 		t.Errorf("Expected output cost %.4f, got %.4f", expectedOutputCost, breakdown.OutputCostUSD)
 	}
 
+	// TotalCost is summed independently by the shared pricing engine (over an
+	// unordered Quantities map) rather than as InputCostUSD+OutputCostUSD, so
+	// use a tolerance rather than exact float equality — see
+	// base.PriceUsage/deriveHeadlines.
 	expectedTotal := expectedInputCost + expectedOutputCost
-	if breakdown.TotalCost != expectedTotal {
+	const costTolerance = 1e-9
+	if diff := breakdown.TotalCost - expectedTotal; diff < -costTolerance || diff > costTolerance {
 		t.Errorf("Expected total cost %.4f, got %.4f", expectedTotal, breakdown.TotalCost)
 	}
 }
@@ -275,8 +280,18 @@ func TestOpenAIProvider_CostBreakdownWithCachedTokens(t *testing.T) {
 		t.Error("CachedTokens mismatch")
 	}
 
-	// Cached tokens cost 50% of regular input tokens
-	expectedCachedCost := 0.001 // 200 * 0.01 / 1000 * 0.5 = 0.001
+	// The legacy flat providers.Pricing{InputCostPer1K,OutputCostPer1K} config
+	// carries only input_token/output_token rates (base.ResolveLLMPricing's
+	// FlatPricing branch, by design — it can't know a provider-specific cache
+	// discount). So with flat config set, cache reads have no matching price
+	// item: the quantity is still tracked (CachedTokens above) but the dollar
+	// amount is $0, surfaced via a loud "unpriced unit" warning rather than a
+	// silently assumed 50% discount. Cache-aware pricing requires either the
+	// built-in per-model table (openaiPricingTable, used when flat pricing is
+	// NOT configured) or an explicit PricingDescriptor with a cache_read_token
+	// item. See TestCalculateCost_FallbackPricing/gpt-4_with_cached_tokens for
+	// the table-driven cache-aware path.
+	expectedCachedCost := 0.0
 	// Input cost is for 800 tokens only
 	expectedInputCost := 0.008  // 800 * 0.01 / 1000 = 0.008
 	expectedOutputCost := 0.015 // 500 * 0.03 / 1000 = 0.015
@@ -289,9 +304,12 @@ func TestOpenAIProvider_CostBreakdownWithCachedTokens(t *testing.T) {
 		t.Errorf("Expected input cost %.4f, got %.4f", expectedInputCost, breakdown.InputCostUSD)
 	}
 
-	// Total should include all costs
+	// Total should include all costs. TotalCost is summed independently by the
+	// shared pricing engine, so use a tolerance rather than exact float
+	// equality — see base.PriceUsage/deriveHeadlines.
 	expectedTotal := expectedInputCost + expectedCachedCost + expectedOutputCost
-	if breakdown.TotalCost != expectedTotal {
+	const costTolerance = 1e-9
+	if diff := breakdown.TotalCost - expectedTotal; diff < -costTolerance || diff > costTolerance {
 		t.Errorf("Expected total cost %.4f, got %.4f", expectedTotal, breakdown.TotalCost)
 	}
 }

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -440,13 +440,7 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte) (providers.Prediction
 			} `json:"message"`
 			FinishReason string `json:"finish_reason"`
 		} `json:"choices"`
-		Usage struct {
-			PromptTokens        int `json:"prompt_tokens"`
-			CompletionTokens    int `json:"completion_tokens"`
-			PromptTokensDetails *struct {
-				CachedTokens int `json:"cached_tokens"`
-			} `json:"prompt_tokens_details,omitempty"`
-		} `json:"usage"`
+		Usage openAIUsage `json:"usage"`
 	}
 
 	if err := json.Unmarshal(respBytes, &openaiResp); err != nil {
@@ -459,14 +453,10 @@ func (p *ToolProvider) parseToolResponse(respBytes []byte) (providers.Prediction
 
 	choice := openaiResp.Choices[0]
 
-	// Get cached tokens if available
-	cachedTokens := 0
-	if openaiResp.Usage.PromptTokensDetails != nil {
-		cachedTokens = openaiResp.Usage.PromptTokensDetails.CachedTokens
-	}
-
-	// Calculate cost breakdown
-	costBreakdown := p.Provider.CalculateCost(openaiResp.Usage.PromptTokens, openaiResp.Usage.CompletionTokens, cachedTokens)
+	// Calculate cost breakdown. Route the full wire usage through
+	// costFromUsage (not the CalculateCost wrapper) so reasoning tokens are
+	// priced rather than silently dropped.
+	costBreakdown := p.costFromUsage(openaiResp.Usage)
 
 	resp := providers.PredictionResponse{
 		Content:      choice.Message.Content,

--- a/runtime/providers/openai/pricing_table.go
+++ b/runtime/providers/openai/pricing_table.go
@@ -1,0 +1,141 @@
+// Package openai provides OpenAI LLM provider integration.
+package openai
+
+import (
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// openaiPricingCorrectAtYear/Month/Day pin the capture date stamped onto
+// every table entry below. Named instead of inlined into time.Date so the
+// magic-number linter doesn't fire on the call site.
+const (
+	openaiPricingCorrectAtYear  = 2026
+	openaiPricingCorrectAtMonth = time.July
+	openaiPricingCorrectAtDay   = 8
+)
+
+// openaiPricingCorrectAt is the date these per-model rates were captured.
+// RATES NEED HUMAN VERIFICATION against https://openai.com/api/pricing —
+// they were filled in from best-available knowledge, not fetched live. See
+// the task-12 report for the full per-model list and verification note.
+var openaiPricingCorrectAt = time.Date(
+	openaiPricingCorrectAtYear, openaiPricingCorrectAtMonth, openaiPricingCorrectAtDay,
+	0, 0, 0, 0, time.UTC,
+)
+
+// perMillionScale converts a published per-1M-token USD rate into a per-unit rate.
+const perMillionScale = 1_000_000.0
+
+// perM builds a per-model pricing descriptor from published per-1M-token USD
+// input/cachedInput/output rates. Reasoning tokens are billed by OpenAI at
+// the same per-token rate as visible output tokens — completion_tokens
+// (which reasoning_tokens is a sub-count of) is one undifferentiated output
+// budget on the wire — so reasoning_token prices at the output rate rather
+// than a separate published constant.
+func perM(input, cachedInput, output float64) *base.PricingDescriptor {
+	return &base.PricingDescriptor{
+		Source:           base.PricingSourceInline,
+		PricingCorrectAt: openaiPricingCorrectAt,
+		Items: []base.PriceItem{
+			{Unit: base.UnitInputToken, Rate: input / perMillionScale},
+			{Unit: base.UnitCacheReadToken, Rate: cachedInput / perMillionScale},
+			{Unit: base.UnitOutputToken, Rate: output / perMillionScale},
+			{Unit: base.UnitReasoningToken, Rate: output / perMillionScale},
+		},
+	}
+}
+
+// Per-1M-token USD rates (input, cached input, output) for every current
+// OpenAI model family. RATES NEED HUMAN VERIFICATION against
+// https://openai.com/api/pricing before being relied on for real billing —
+// see the task-12 report.
+const (
+	// Legacy chat models. Cached-prompt discount is the original 50% OpenAI
+	// launched prompt caching with in 2024.
+	gpt4In, gpt4Cached, gpt4Out                   = 30.0, 15.0, 60.0 // GPT-4 (8K, legacy)
+	gpt4TurboIn, gpt4TurboCached, gpt4TurboOut    = 10.0, 5.0, 30.0  // GPT-4 Turbo
+	gpt35TurboIn, gpt35TurboCached, gpt35TurboOut = 1.50, 0.75, 2.00 // GPT-3.5 Turbo
+
+	// GPT-4o family (50% cached-input discount).
+	gpt4oIn, gpt4oCached, gpt4oOut             = 2.50, 1.25, 10.0  // GPT-4o
+	gpt4oMiniIn, gpt4oMiniCached, gpt4oMiniOut = 0.15, 0.075, 0.60 // GPT-4o mini
+
+	// GPT-4.1 family (75% cached-input discount).
+	gpt41In, gpt41Cached, gpt41Out             = 2.00, 0.50, 8.00  // GPT-4.1
+	gpt41MiniIn, gpt41MiniCached, gpt41MiniOut = 0.40, 0.10, 1.60  // GPT-4.1 mini
+	gpt41NanoIn, gpt41NanoCached, gpt41NanoOut = 0.10, 0.025, 0.40 // GPT-4.1 nano
+
+	// o-series reasoning models. o3 pricing reflects OpenAI's June 2025 price
+	// cut (from an initial $10/$40 launch price down to $2/$8 per 1M).
+	o1In, o1Cached, o1Out             = 15.0, 7.50, 60.0  // o1
+	o1MiniIn, o1MiniCached, o1MiniOut = 1.10, 0.55, 4.40  // o1-mini
+	o3In, o3Cached, o3Out             = 2.00, 0.50, 8.00  // o3 (post price-cut)
+	o3MiniIn, o3MiniCached, o3MiniOut = 1.10, 0.55, 4.40  // o3-mini
+	o4MiniIn, o4MiniCached, o4MiniOut = 1.10, 0.275, 4.40 // o4-mini
+
+	// GPT-5 family (90% cached-input discount).
+	gpt5In, gpt5Cached, gpt5Out             = 1.25, 0.125, 10.0 // GPT-5
+	gpt5MiniIn, gpt5MiniCached, gpt5MiniOut = 0.25, 0.025, 2.00 // GPT-5 mini
+	gpt5NanoIn, gpt5NanoCached, gpt5NanoOut = 0.05, 0.005, 0.40 // GPT-5 nano
+)
+
+// Shared descriptors, one per rate tier, reused across bare family aliases
+// in openaiPricingTable so every alias of a model prices identically.
+var (
+	gpt4       = perM(gpt4In, gpt4Cached, gpt4Out)
+	gpt4Turbo  = perM(gpt4TurboIn, gpt4TurboCached, gpt4TurboOut)
+	gpt35Turbo = perM(gpt35TurboIn, gpt35TurboCached, gpt35TurboOut)
+
+	gpt4o     = perM(gpt4oIn, gpt4oCached, gpt4oOut)
+	gpt4oMini = perM(gpt4oMiniIn, gpt4oMiniCached, gpt4oMiniOut)
+
+	gpt41     = perM(gpt41In, gpt41Cached, gpt41Out)
+	gpt41Mini = perM(gpt41MiniIn, gpt41MiniCached, gpt41MiniOut)
+	gpt41Nano = perM(gpt41NanoIn, gpt41NanoCached, gpt41NanoOut)
+
+	o1     = perM(o1In, o1Cached, o1Out)
+	o1Mini = perM(o1MiniIn, o1MiniCached, o1MiniOut)
+	o3     = perM(o3In, o3Cached, o3Out)
+	o3Mini = perM(o3MiniIn, o3MiniCached, o3MiniOut)
+	o4Mini = perM(o4MiniIn, o4MiniCached, o4MiniOut)
+
+	gpt5     = perM(gpt5In, gpt5Cached, gpt5Out)
+	gpt5Mini = perM(gpt5MiniIn, gpt5MiniCached, gpt5MiniOut)
+	gpt5Nano = perM(gpt5NanoIn, gpt5NanoCached, gpt5NanoOut)
+)
+
+// openaiPricingTable maps bare model-family names to their pricing
+// descriptor. Looked up via base.ResolveLLMPricing, which normalizes a
+// vendor-qualified model id (e.g. "azure/gpt-4o") down to the bare id
+// before matching — there is no substring/heuristic fallback, so a model
+// absent here prices as $0 with a loud warning rather than silently
+// guessing a wrong constant.
+var openaiPricingTable = map[string]*base.PricingDescriptor{
+	// Legacy
+	"gpt-4":         gpt4,
+	"gpt-4-turbo":   gpt4Turbo,
+	"gpt-3.5-turbo": gpt35Turbo,
+
+	// GPT-4o
+	"gpt-4o":      gpt4o,
+	"gpt-4o-mini": gpt4oMini,
+
+	// GPT-4.1
+	"gpt-4.1":      gpt41,
+	"gpt-4.1-mini": gpt41Mini,
+	"gpt-4.1-nano": gpt41Nano,
+
+	// o-series
+	"o1":      o1,
+	"o1-mini": o1Mini,
+	"o3":      o3,
+	"o3-mini": o3Mini,
+	"o4-mini": o4Mini,
+
+	// GPT-5
+	"gpt-5":      gpt5,
+	"gpt-5-mini": gpt5Mini,
+	"gpt-5-nano": gpt5Nano,
+}

--- a/runtime/providers/openai/realtime_cost.go
+++ b/runtime/providers/openai/realtime_cost.go
@@ -1,16 +1,15 @@
 // Package openai provides OpenAI Realtime API streaming support.
 package openai
 
-import "github.com/AltairaLabs/PromptKit/runtime/types"
+import (
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
 
 // gpt-realtime GA pricing per 1K tokens (USD). Audio costs an order of
 // magnitude more than text — pricing one against the other vastly mis-
 // estimates the bill. The wire `usage` payload includes a per-type
 // breakdown (input_token_details / output_token_details), and we use it.
-//
-// Cached input is billed at the same per-1K rate as fresh input on the
-// gpt-realtime GA model (10% discount for prompt-cached audio is folded
-// in by the server already; we don't double-count).
 //
 // Source: https://platform.openai.com/docs/pricing (gpt-realtime row).
 const (
@@ -20,54 +19,83 @@ const (
 	defaultTextOutputCostPer1K  = 0.016 // $16 / 1M
 )
 
-// calculateRealtimeCost computes the USD cost of a single realtime turn from its
-// token usage. audioInRateOverride / audioOutRateOverride, when non-zero,
-// replace the default GA audio per-1K rates (applied to AUDIO tokens only —
-// text tokens always bill at the default text rates, since audio dominates a
-// realtime bill).
-//
-// When the per-type token breakdown is missing (input_token_details /
-// output_token_details all zero — older API responses, mock providers) it falls
-// back to treating ALL tokens as audio. Over-reporting text at audio rates
-// (~8x) is preferable to silently reporting $0 or under-reporting audio at text
-// rates for a realtime session. Returns nil for nil usage.
-func calculateRealtimeCost(usage *UsageInfo, audioInRateOverride, audioOutRateOverride float64) *types.CostInfo {
-	if usage == nil {
-		return nil
-	}
+// realtimeK converts a per-1K rate to a per-unit rate for the pricing engine.
+const realtimeK = 1000.0
 
-	audioInRate := audioInRateOverride
+// realtimeDescriptor prices gpt-realtime GA text + audio units. audioInRate /
+// audioOutRate, when non-zero, replace the default GA per-1K audio rates
+// (applied to AUDIO tokens only — text tokens always bill at the default
+// text rates, since audio dominates a realtime bill). Cached input is billed
+// at the same per-1K rate as fresh text input on the gpt-realtime GA model
+// (a discount for prompt-cached audio is folded in by the server already;
+// we don't double-count) — seeded at parity via cache_read_token, refine if
+// OpenAI ever publishes a distinct cached-audio rate.
+func realtimeDescriptor(audioInRate, audioOutRate float64) *base.PricingDescriptor {
 	if audioInRate == 0 {
 		audioInRate = defaultAudioInputCostPer1K
 	}
-	audioOutRate := audioOutRateOverride
 	if audioOutRate == 0 {
 		audioOutRate = defaultAudioOutputCostPer1K
 	}
+	return &base.PricingDescriptor{
+		Source: base.PricingSourceInline,
+		Items: []base.PriceItem{
+			{Unit: base.UnitInputToken, Rate: defaultTextInputCostPer1K / realtimeK},
+			{Unit: base.UnitOutputToken, Rate: defaultTextOutputCostPer1K / realtimeK},
+			{Unit: base.UnitAudioInputToken, Rate: audioInRate / realtimeK},
+			{Unit: base.UnitAudioOutputToken, Rate: audioOutRate / realtimeK},
+			{Unit: base.UnitCacheReadToken, Rate: defaultTextInputCostPer1K / realtimeK},
+		},
+	}
+}
 
-	inAudio := usage.InputTokenDetails.AudioTokens
-	inText := usage.InputTokenDetails.TextTokens
-	outAudio := usage.OutputTokenDetails.AudioTokens
-	outText := usage.OutputTokenDetails.TextTokens
+// realtimeUsageToTokens maps the per-modality breakdown on a realtime
+// UsageInfo into canonical base.TokenUsage units, falling back to "all
+// input/output tokens are audio" when the breakdown is missing (older API
+// responses, mock providers) — over-reporting text at audio rates (~8x) is
+// preferable to silently reporting $0 or under-reporting audio at text
+// rates for a realtime session.
+//
+// CachedTokens is a subset of InputTokenDetails.TextTokens on the wire (a
+// cache hit still counts toward the text-token total); it is priced as its
+// own cache_read_token line and removed from full-price text input so it is
+// not double-counted (finding H: cached tokens were previously dropped
+// entirely by the old calculateRealtimeCost, which had no cache handling).
+func realtimeUsageToTokens(u *UsageInfo) base.TokenUsage {
+	inAudio, inText := u.InputTokenDetails.AudioTokens, u.InputTokenDetails.TextTokens
+	outAudio, outText := u.OutputTokenDetails.AudioTokens, u.OutputTokenDetails.TextTokens
 
 	// Fall back to "all tokens are audio" if the breakdown is missing.
 	if inAudio == 0 && inText == 0 {
-		inAudio = usage.InputTokens
+		inAudio = u.InputTokens
 	}
 	if outAudio == 0 && outText == 0 {
-		outAudio = usage.OutputTokens
+		outAudio = u.OutputTokens
 	}
 
-	inputCost := float64(inAudio)/tokensPerThousand*audioInRate +
-		float64(inText)/tokensPerThousand*defaultTextInputCostPer1K
-	outputCost := float64(outAudio)/tokensPerThousand*audioOutRate +
-		float64(outText)/tokensPerThousand*defaultTextOutputCostPer1K
-
-	return &types.CostInfo{
-		InputTokens:   usage.InputTokens,
-		OutputTokens:  usage.OutputTokens,
-		InputCostUSD:  inputCost,
-		OutputCostUSD: outputCost,
-		TotalCost:     inputCost + outputCost,
+	cached := u.InputTokenDetails.CachedTokens
+	if cached > inText {
+		cached = inText
 	}
+
+	return base.TokenUsage{
+		Input:       inText - cached,
+		CacheRead:   cached,
+		AudioInput:  inAudio,
+		Output:      outText,
+		AudioOutput: outAudio,
+	}
+}
+
+// realtimeCostInfo computes the USD cost of a single realtime turn from its
+// token usage via the shared unit-keyed pricing engine. audioInRate /
+// audioOutRate, when non-zero, override the default GA audio per-1K rates.
+// Returns nil for nil usage.
+func realtimeCostInfo(u *UsageInfo, audioInRate, audioOutRate float64) *types.CostInfo {
+	if u == nil {
+		return nil
+	}
+	ci := base.PriceUsage(realtimeDescriptor(audioInRate, audioOutRate),
+		"openai-realtime", base.ProviderTypeInference, realtimeUsageToTokens(u), nil, 0)
+	return &ci
 }

--- a/runtime/providers/openai/realtime_cost_test.go
+++ b/runtime/providers/openai/realtime_cost_test.go
@@ -3,6 +3,10 @@ package openai
 import (
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 )
 
 // usageWith builds a UsageInfo with the given totals and per-type breakdown.
@@ -23,21 +27,104 @@ const costEpsilon = 1e-9
 
 func approxEqual(a, b float64) bool { return math.Abs(a-b) < costEpsilon }
 
-func TestCalculateRealtimeCost(t *testing.T) {
+// TestRealtimeCost_PricesCachedTokens is the regression test for finding H:
+// the old bespoke calculateRealtimeCost had no cache handling at all, so
+// InputTokenDetails.CachedTokens was silently dropped — a cache hit was
+// billed as if it were full-price fresh text input. realtimeCostInfo must
+// surface it as its own priced cache_read_token quantity.
+func TestRealtimeCost_PricesCachedTokens(t *testing.T) {
+	u := &UsageInfo{
+		InputTokens: 1000, OutputTokens: 500,
+	}
+	u.InputTokenDetails.AudioTokens = 700
+	u.InputTokenDetails.TextTokens = 300
+	u.InputTokenDetails.CachedTokens = 200 // previously dropped (H)
+	u.OutputTokenDetails.AudioTokens = 400
+	u.OutputTokenDetails.TextTokens = 100
+
+	ci := realtimeCostInfo(u, 0, 0)
+
+	assert.Equal(t, 200.0, ci.Quantities[base.UnitCacheReadToken])
+	assert.Equal(t, 700.0, ci.Quantities[base.UnitAudioInputToken])
+	assert.Equal(t, 400.0, ci.Quantities[base.UnitAudioOutputToken])
+	assert.InDelta(t, ci.TotalCost, ci.InputCostUSD+ci.OutputCostUSD+ci.CachedCostUSD, 1e-9)
+}
+
+// TestRealtimeCost_NilUsageReturnsNil verifies the nil-usage short-circuit.
+func TestRealtimeCost_NilUsageReturnsNil(t *testing.T) {
+	if realtimeCostInfo(nil, 0, 0) != nil {
+		t.Fatal("expected nil cost for nil usage")
+	}
+}
+
+// TestRealtimeUsageToTokens_MapsBreakdown verifies the per-modality mapping,
+// the cache-is-a-subset-of-text clamp, and the "breakdown missing ⇒ treat
+// all tokens as audio" fallback (over-reporting text at audio rates is
+// preferable to silently under-billing a realtime session).
+func TestRealtimeUsageToTokens_MapsBreakdown(t *testing.T) {
+	tests := []struct {
+		name   string
+		usage  *UsageInfo
+		want   base.TokenUsage
+		cached int
+	}{
+		{
+			name:  "full breakdown, no cache",
+			usage: usageWith(1000, 500, 800, 200, 400, 100),
+			want:  base.TokenUsage{Input: 200, AudioInput: 800, Output: 100, AudioOutput: 400},
+		},
+		{
+			name:   "cache is a subset of text input",
+			usage:  usageWith(1000, 500, 700, 300, 400, 100),
+			cached: 200,
+			want:   base.TokenUsage{Input: 100, CacheRead: 200, AudioInput: 700, Output: 100, AudioOutput: 400},
+		},
+		{
+			name:   "cache clamped to text tokens if wire ever over-reports",
+			usage:  usageWith(1000, 500, 700, 300, 400, 100),
+			cached: 999,
+			want:   base.TokenUsage{Input: 0, CacheRead: 300, AudioInput: 700, Output: 100, AudioOutput: 400},
+		},
+		{
+			name:  "missing breakdown treats all tokens as audio",
+			usage: usageWith(1000, 500, 0, 0, 0, 0),
+			want:  base.TokenUsage{AudioInput: 1000, AudioOutput: 500},
+		},
+		{
+			name:  "zero tokens is zero usage",
+			usage: usageWith(0, 0, 0, 0, 0, 0),
+			want:  base.TokenUsage{},
+		},
+		{
+			name:  "text-only breakdown does not trigger the audio fallback",
+			usage: usageWith(1000, 500, 0, 1000, 0, 500),
+			want:  base.TokenUsage{Input: 1000, Output: 500},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.usage.InputTokenDetails.CachedTokens = tt.cached
+			got := realtimeUsageToTokens(tt.usage)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestRealtimeCost_DollarAmounts pins USD amounts across the audio/text/
+// override/fallback matrix — the same scenarios the pre-unit-engine
+// calculateRealtimeCost covered — so the migration to base.PriceUsage is
+// verified to preserve them exactly (no cache tokens in play here; that is
+// covered separately by TestRealtimeCost_PricesCachedTokens).
+func TestRealtimeCost_DollarAmounts(t *testing.T) {
 	tests := []struct {
 		name        string
 		usage       *UsageInfo
 		inOverride  float64
 		outOverride float64
-		wantNil     bool
 		wantIn      float64
 		wantOut     float64
 	}{
-		{
-			name:    "nil usage returns nil",
-			usage:   nil,
-			wantNil: true,
-		},
 		{
 			name:  "with breakdown uses per-type default rates",
 			usage: usageWith(1000, 500, 800, 200, 400, 100),
@@ -93,13 +180,7 @@ func TestCalculateRealtimeCost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := calculateRealtimeCost(tt.usage, tt.inOverride, tt.outOverride)
-			if tt.wantNil {
-				if got != nil {
-					t.Fatalf("expected nil cost, got %+v", got)
-				}
-				return
-			}
+			got := realtimeCostInfo(tt.usage, tt.inOverride, tt.outOverride)
 			if got == nil {
 				t.Fatal("expected non-nil cost")
 			}
@@ -112,22 +193,16 @@ func TestCalculateRealtimeCost(t *testing.T) {
 			if !approxEqual(got.TotalCost, tt.wantIn+tt.wantOut) {
 				t.Errorf("TotalCost = %v, want %v", got.TotalCost, tt.wantIn+tt.wantOut)
 			}
-			if got.InputTokens != tt.usage.InputTokens {
-				t.Errorf("InputTokens = %d, want %d", got.InputTokens, tt.usage.InputTokens)
-			}
-			if got.OutputTokens != tt.usage.OutputTokens {
-				t.Errorf("OutputTokens = %d, want %d", got.OutputTokens, tt.usage.OutputTokens)
-			}
 		})
 	}
 }
 
-// TestCalculateRealtimeCost_AudioVsTextMisbill documents the core money risk:
-// the same token count costs ~8x more billed as audio than as text. The
+// TestRealtimeCost_AudioVsTextMisbill documents the core money risk: the
+// same token count costs ~8x more billed as audio than as text. The
 // missing-breakdown fallback deliberately errs toward the audio (higher) side.
-func TestCalculateRealtimeCost_AudioVsTextMisbill(t *testing.T) {
-	asAudio := calculateRealtimeCost(usageWith(1000, 0, 1000, 0, 0, 0), 0, 0)
-	asText := calculateRealtimeCost(usageWith(1000, 0, 0, 1000, 0, 0), 0, 0)
+func TestRealtimeCost_AudioVsTextMisbill(t *testing.T) {
+	asAudio := realtimeCostInfo(usageWith(1000, 0, 1000, 0, 0, 0), 0, 0)
+	asText := realtimeCostInfo(usageWith(1000, 0, 0, 1000, 0, 0), 0, 0)
 
 	if asAudio.InputCostUSD <= asText.InputCostUSD {
 		t.Fatalf("audio billing (%v) should exceed text billing (%v)",
@@ -141,7 +216,7 @@ func TestCalculateRealtimeCost_AudioVsTextMisbill(t *testing.T) {
 }
 
 // TestRealtimeSession_calculateCost_DelegatesOverrides verifies the thin method
-// forwards the session's per-1K overrides to the pure function.
+// forwards the session's per-1K overrides to realtimeCostInfo.
 func TestRealtimeSession_calculateCost_DelegatesOverrides(t *testing.T) {
 	s := &RealtimeSession{inputCostPer1K: 0.1, outputCostPer1K: 0.2}
 	got := s.calculateCost(usageWith(1000, 500, 800, 200, 400, 100))

--- a/runtime/providers/openai/realtime_session_integration.go
+++ b/runtime/providers/openai/realtime_session_integration.go
@@ -33,7 +33,6 @@ const (
 	responseChannelSize = 10
 	heartbeatInterval   = 30 * time.Second
 	setupTimeout        = 10 * time.Second
-	tokensPerThousand   = 1000.0
 
 	// receiveLoopBlockWarn is the threshold above which receiveLoop logs that an
 	// inbound event blocked while being forwarded to responseCh. receiveLoop is
@@ -854,9 +853,9 @@ func (s *RealtimeSession) handleRateLimits(e *RateLimitsUpdatedEvent) {
 	}
 }
 
-// calculateCost delegates to the pure calculateRealtimeCost, passing the
+// calculateCost delegates to the pure realtimeCostInfo, passing the
 // session's per-1K audio-rate overrides (0 ⇒ use the GA defaults). The money
 // math lives in realtime_cost.go so it can be unit-tested in isolation.
 func (s *RealtimeSession) calculateCost(usage *UsageInfo) *types.CostInfo {
-	return calculateRealtimeCost(usage, s.inputCostPer1K, s.outputCostPer1K)
+	return realtimeCostInfo(usage, s.inputCostPer1K, s.outputCostPer1K)
 }

--- a/runtime/providers/replay/provider.go
+++ b/runtime/providers/replay/provider.go
@@ -448,14 +448,14 @@ func (p *Provider) Close() error {
 	return nil
 }
 
-// CalculateCost returns zero cost as replays don't incur real costs.
+// CalculateCost returns zero cost as replays don't incur real costs. A nil
+// pricing descriptor routes through the shared engine as $0 while still
+// populating the headline token counts (see base.PriceUsage). Unlike
+// ollama/mock, inputTokens here is already the exclusive (non-cached) count,
+// so it is passed through unmodified.
 func (p *Provider) CalculateCost(inputTokens, outputTokens, cachedTokens int) types.CostInfo {
-	return types.CostInfo{
-		InputTokens:  inputTokens,
-		OutputTokens: outputTokens,
-		CachedTokens: cachedTokens,
-		TotalCost:    0, // No real cost for replays
-	}
+	return base.PriceUsage(nil, p.ID(), base.ProviderTypeInference,
+		base.TokenUsage{Input: inputTokens, CacheRead: cachedTokens, Output: outputTokens}, nil, 0)
 }
 
 // Reset resets the provider to replay from the beginning.

--- a/runtime/providers/vllm/vllm.go
+++ b/runtime/providers/vllm/vllm.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
@@ -21,7 +22,6 @@ const (
 	vllmChatCompletionsPath = "/v1/chat/completions"
 	contentTypeHeader       = "Content-Type"
 	applicationJSON         = "application/json"
-	tokensPerThousand       = 1000.0 // divisor for per-1K pricing
 )
 
 // Provider implements the Provider interface for vLLM
@@ -83,6 +83,9 @@ type vllmRequest struct {
 	MaxTokens   int           `json:"max_tokens"`
 	Seed        *int          `json:"seed,omitempty"`
 	Stream      bool          `json:"stream"`
+	// StreamOptions carries streaming-only parameters. Set only when Stream is
+	// true, so vLLM knows to emit a terminal usage-bearing chunk before [DONE].
+	StreamOptions *vllmStreamOptions `json:"stream_options,omitempty"`
 
 	// vLLM-specific parameters
 	UseBeamSearch     bool                   `json:"use_beam_search,omitempty"`
@@ -93,6 +96,14 @@ type vllmRequest struct {
 	GuidedRegex       string                 `json:"guided_regex,omitempty"`
 	GuidedGrammar     string                 `json:"guided_grammar,omitempty"`
 	GuidedChoice      []string               `json:"guided_choice,omitempty"`
+}
+
+// vllmStreamOptions requests that the OpenAI-compatible streaming endpoint
+// include a final usage-bearing chunk before [DONE], mirroring OpenAI's
+// stream_options.include_usage. Without it vLLM's streaming responses never
+// carry token counts, so cost is silently unavailable.
+type vllmStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
 }
 
 type vllmMessage struct {
@@ -219,6 +230,10 @@ func (p *Provider) buildRequest( // NOSONAR
 		Seed:        req.Seed,
 		Stream:      stream,
 	}
+	if stream {
+		// Request the terminal usage chunk so streamed responses carry cost.
+		vllmReq.StreamOptions = &vllmStreamOptions{IncludeUsage: true}
+	}
 
 	// Apply vLLM-specific configuration from additional_config
 	if p.additionalConfig != nil {
@@ -268,28 +283,34 @@ func (p *Provider) Predict(
 	return p.predictWithMessages(ctx, req, messages)
 }
 
-// CalculateCost calculates cost breakdown
-// vLLM is typically self-hosted, so default is $0 unless custom pricing is configured
+// vllmUsageToTokens maps vLLM's OpenAI-compatible usage into canonical units.
+// vLLM's wire usage carries no cache breakdown, so PromptTokens maps straight
+// to full-price input; a nonzero cachedTokens on the legacy CalculateCost
+// wrapper is subtracted before this mapping runs (see CalculateCost below).
+func vllmUsageToTokens(u vllmUsage) base.TokenUsage {
+	return base.TokenUsage{Input: u.PromptTokens, Output: u.CompletionTokens}
+}
+
+// costFromUsage prices a vllmUsage through the unit-keyed pricing engine: an
+// explicit config descriptor wins, then legacy flat per-1K config, else nil.
+// vLLM is typically self-hosted with no embedded pricing table, so an
+// unconfigured provider prices as $0 while still reporting token counts
+// (PriceUsage handles a nil descriptor silently, no warning).
+func (p *Provider) costFromUsage(u vllmUsage) types.CostInfo {
+	desc := base.ResolveLLMPricing(
+		p.Pricing(),
+		base.FlatPricing{Input: p.defaults.Pricing.InputCostPer1K, Output: p.defaults.Pricing.OutputCostPer1K},
+		nil, p.model)
+	return base.PriceUsage(desc, p.ID(), base.ProviderTypeInference, vllmUsageToTokens(u), nil, 0)
+}
+
+// CalculateCost calculates cost breakdown. Thin wrapper over costFromUsage,
+// kept for the Provider interface's legacy signature. vLLM's wire usage has
+// no separate cache-read count, so cachedTokens is folded out of the billed
+// input before pricing (matching the prior behavior of excluding it from
+// InputCostUSD); it is not reported back as a cache unit.
 func (p *Provider) CalculateCost(tokensIn, tokensOut, cachedTokens int) types.CostInfo {
-	// Default: free for self-hosted
-	inputCost := 0.0
-	outputCost := 0.0
-
-	// Use configured pricing if available
-	if p.defaults.Pricing.InputCostPer1K > 0 || p.defaults.Pricing.OutputCostPer1K > 0 {
-		inputCost = float64(tokensIn-cachedTokens) * p.defaults.Pricing.InputCostPer1K / tokensPerThousand
-		outputCost = float64(tokensOut) * p.defaults.Pricing.OutputCostPer1K / tokensPerThousand
-	}
-
-	return types.CostInfo{
-		InputTokens:   tokensIn - cachedTokens,
-		OutputTokens:  tokensOut,
-		CachedTokens:  cachedTokens,
-		InputCostUSD:  inputCost,
-		OutputCostUSD: outputCost,
-		CachedCostUSD: 0,
-		TotalCost:     inputCost + outputCost,
-	}
+	return p.costFromUsage(vllmUsage{PromptTokens: tokensIn - cachedTokens, CompletionTokens: tokensOut})
 }
 
 // PredictStream streams a prediction response from vLLM
@@ -400,10 +421,8 @@ func (p *Provider) predictWithMessages(
 
 	latency := time.Since(start)
 
-	// Calculate cost breakdown
-	costBreakdown := p.CalculateCost(
-		vllmResp.Usage.PromptTokens, vllmResp.Usage.CompletionTokens, 0,
-	)
+	// Calculate cost breakdown from the full wire usage.
+	costBreakdown := p.costFromUsage(vllmResp.Usage)
 
 	// Extract content
 	content := extractContentString(vllmResp.Choices[0].Message.Content)
@@ -540,7 +559,7 @@ func (p *Provider) streamResponse(
 
 		// Send final chunk with finish reason and usage
 		if choice.FinishReason != "" && chunk.Usage != nil {
-			costInfo := p.CalculateCost(chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens, 0)
+			costInfo := p.costFromUsage(*chunk.Usage)
 			normalized := providers.NormalizeOpenAIFinishReason(choice.FinishReason)
 			outChan <- providers.StreamChunk{
 				Content:      sb.String(),

--- a/runtime/providers/vllm/vllm_cost_test.go
+++ b/runtime/providers/vllm/vllm_cost_test.go
@@ -1,0 +1,161 @@
+package vllm
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// newTestVLLMProvider builds a bare Provider for cost/streaming unit tests.
+func newTestVLLMProvider(t *testing.T) *Provider {
+	t.Helper()
+	return NewProvider("test-vllm", "test-model", "http://localhost:8000", providers.ProviderDefaults{}, false, nil)
+}
+
+// TestVLLMUsageToTokens_MapsFields verifies the wire-to-canonical mapping:
+// vLLM's usage carries no cache breakdown, so PromptTokens/CompletionTokens
+// map straight to full-price Input/Output.
+func TestVLLMUsageToTokens_MapsFields(t *testing.T) {
+	got := vllmUsageToTokens(vllmUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150})
+	assert.Equal(t, base.TokenUsage{Input: 100, Output: 50}, got)
+}
+
+// TestVLLMCost_CalculateCostWrapperMatchesCostFromUsage verifies the public
+// CalculateCost(tokensIn, tokensOut, cachedTokens) signature (kept for the
+// Provider interface contract) is a thin wrapper over costFromUsage.
+func TestVLLMCost_CalculateCostWrapperMatchesCostFromUsage(t *testing.T) {
+	p := newTestVLLMProvider(t)
+	want := p.costFromUsage(vllmUsage{PromptTokens: 800, CompletionTokens: 500})
+	got := p.CalculateCost(1000, 500, 200)
+
+	assert.Equal(t, want.TotalCost, got.TotalCost)
+	assert.Equal(t, want.InputCostUSD, got.InputCostUSD)
+	assert.Equal(t, want.OutputCostUSD, got.OutputCostUSD)
+	assert.Equal(t, want.InputTokens, got.InputTokens)
+	assert.Equal(t, want.OutputTokens, got.OutputTokens)
+}
+
+// TestVLLMCost_UnconfiguredIsZeroWithTokenCounts pins finding J's stated
+// contract: an unconfigured (self-hosted, no pricing table) vLLM provider
+// prices as $0 but still reports token counts, silently (PriceUsage's nil
+// descriptor path), matching the pre-existing "free for self-hosted" default.
+func TestVLLMCost_UnconfiguredIsZeroWithTokenCounts(t *testing.T) {
+	p := newTestVLLMProvider(t)
+	ci := p.costFromUsage(vllmUsage{PromptTokens: 1000, CompletionTokens: 500})
+	assert.Zero(t, ci.TotalCost)
+	assert.Equal(t, 1000, ci.InputTokens)
+	assert.Equal(t, 500, ci.OutputTokens)
+}
+
+// TestVLLMStreaming_RequestsUsage is the regression test for finding J: a
+// streaming request must set stream_options.include_usage so vLLM's terminal
+// SSE chunk carries usage (without it, streamed responses never report cost).
+func TestVLLMStreaming_RequestsUsage(t *testing.T) {
+	p := newTestVLLMProvider(t)
+	req := &providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}}
+	messages, err := p.prepareMessages(req)
+	require.NoError(t, err)
+
+	vllmReq := p.buildRequest(req, messages, 0.7, 0.9, 100, true)
+
+	require.NotNil(t, vllmReq.StreamOptions)
+	assert.True(t, vllmReq.StreamOptions.IncludeUsage)
+}
+
+// TestVLLMStreaming_NonStreamingRequestOmitsStreamOptions guards against
+// stream_options leaking onto non-streaming requests (vLLM only expects it
+// alongside stream: true).
+func TestVLLMStreaming_NonStreamingRequestOmitsStreamOptions(t *testing.T) {
+	p := newTestVLLMProvider(t)
+	req := &providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}}
+	messages, err := p.prepareMessages(req)
+	require.NoError(t, err)
+
+	vllmReq := p.buildRequest(req, messages, 0.7, 0.9, 100, false)
+
+	assert.Nil(t, vllmReq.StreamOptions)
+}
+
+// TestVLLMToolStreamRequest_IncludesStreamOptions verifies the map-based
+// tool-streaming request builder (buildToolRequest) also carries
+// stream_options through, so PredictStreamWithTools' terminal chunk can
+// receive usage the same way the non-tool streaming path does.
+func TestVLLMToolStreamRequest_IncludesStreamOptions(t *testing.T) {
+	p := newTestVLLMProvider(t)
+	req := &providers.PredictionRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}}
+	messages, err := p.prepareMessages(req)
+	require.NoError(t, err)
+
+	reqMap := p.buildToolRequest(req, messages, toolRequestParams{
+		temperature: 0.7, topP: 0.9, maxTokens: 100, stream: true,
+	})
+
+	streamOpts, ok := reqMap["stream_options"].(*vllmStreamOptions)
+	require.True(t, ok, "expected stream_options to be present and typed *vllmStreamOptions")
+	assert.True(t, streamOpts.IncludeUsage)
+}
+
+// streamWithUsageAndStop returns a fake vLLM tool-streaming SSE body whose
+// terminal chunk carries usage and vLLM's native "eos_token" finish reason
+// (rather than the OpenAI-compat "stop"), exercising both normalization and
+// cost propagation on the terminal chunk.
+func streamWithUsageAndStop() io.ReadCloser {
+	sse := "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"eos_token\"}]," +
+		"\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n" +
+		"data: [DONE]\n\n"
+	return io.NopCloser(strings.NewReader(sse))
+}
+
+// collectVLLMToolStreamChunks drains streamToolResponse (the SSE consumer
+// behind PredictStreamWithTools) into a slice for assertion.
+func collectVLLMToolStreamChunks(t *testing.T, body io.ReadCloser) []providers.StreamChunk {
+	t.Helper()
+	p := newTestVLLMProvider(t)
+	chunks := make(chan providers.StreamChunk, 10)
+	go p.streamToolResponse(context.Background(), body, chunks)
+
+	var out []providers.StreamChunk
+	for c := range chunks {
+		out = append(out, c)
+	}
+	return out
+}
+
+// TestVLLMToolStreaming_TerminalChunkCarriesCostAndNormalizedFinish is the
+// regression test for finding J: the tool-streaming terminal chunk must
+// carry a priced CostInfo (when usage is present) and a normalized finish
+// reason ("stop", not vLLM's raw "eos_token").
+func TestVLLMToolStreaming_TerminalChunkCarriesCostAndNormalizedFinish(t *testing.T) {
+	chunks := collectVLLMToolStreamChunks(t, streamWithUsageAndStop())
+	require.NotEmpty(t, chunks)
+
+	last := chunks[len(chunks)-1]
+	require.NotNil(t, last.FinishReason)
+	assert.Equal(t, types.FinishReasonStop, *last.FinishReason)
+	require.NotNil(t, last.CostInfo)
+	assert.Equal(t, 10, last.CostInfo.InputTokens)
+	assert.Equal(t, 5, last.CostInfo.OutputTokens)
+}
+
+// TestVLLMToolStreaming_NoUsageOmitsCostInfo guards the converse: without a
+// usage-bearing terminal chunk (e.g. stream_options wasn't honored by the
+// server), CostInfo must stay nil rather than fabricate a $0/0-token result.
+func TestVLLMToolStreaming_NoUsageOmitsCostInfo(t *testing.T) {
+	sse := "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+	chunks := collectVLLMToolStreamChunks(t, io.NopCloser(strings.NewReader(sse)))
+	require.NotEmpty(t, chunks)
+
+	last := chunks[len(chunks)-1]
+	require.NotNil(t, last.FinishReason)
+	assert.Equal(t, types.FinishReasonStop, *last.FinishReason)
+	assert.Nil(t, last.CostInfo)
+}

--- a/runtime/providers/vllm/vllm_tools.go
+++ b/runtime/providers/vllm/vllm_tools.go
@@ -175,8 +175,8 @@ func (p *Provider) PredictWithTools( // NOSONAR
 	choice := vllmResp.Choices[0]
 	predictResp.Content = choice.Message.Content.(string)
 
-	// Calculate cost
-	costInfo := p.CalculateCost(vllmResp.Usage.PromptTokens, vllmResp.Usage.CompletionTokens, 0)
+	// Calculate cost from the full wire usage.
+	costInfo := p.costFromUsage(vllmResp.Usage)
 	predictResp.CostInfo = &costInfo
 
 	// Set latency
@@ -302,6 +302,9 @@ func (p *Provider) buildToolRequest(
 	reqMap["top_p"] = vllmReq.TopP
 	reqMap["max_tokens"] = vllmReq.MaxTokens
 	reqMap["stream"] = vllmReq.Stream
+	if vllmReq.StreamOptions != nil {
+		reqMap["stream_options"] = vllmReq.StreamOptions
+	}
 
 	if vllmReq.Seed != nil {
 		reqMap["seed"] = vllmReq.Seed
@@ -446,13 +449,21 @@ func (p *Provider) streamToolResponse(ctx context.Context, body io.ReadCloser, c
 			}
 		}
 
-		// Check for finish reason
+		// Check for finish reason. Normalize to the canonical vocabulary (matching
+		// the non-tool streaming and non-streaming paths) and, when the terminal
+		// chunk carries usage (requires stream_options.include_usage on the
+		// request, see buildRequest), attach the priced cost breakdown.
 		if choice.FinishReason != "" {
-			finishReason := choice.FinishReason
-			chunks <- providers.StreamChunk{
+			finishReason := providers.NormalizeOpenAIFinishReason(choice.FinishReason)
+			terminal := providers.StreamChunk{
 				FinishReason: &finishReason,
 				ToolCalls:    toolCalls,
 			}
+			if chunk.Usage != nil {
+				costInfo := p.costFromUsage(*chunk.Usage)
+				terminal.CostInfo = &costInfo
+			}
+			chunks <- terminal
 		}
 	}
 

--- a/runtime/providers/vllm/vllm_tools_test.go
+++ b/runtime/providers/vllm/vllm_tools_test.go
@@ -337,8 +337,12 @@ data: [DONE]
 		t.Fatal("Expected final chunk with finish reason")
 	}
 
-	if *finalChunk.FinishReason != "tool_calls" {
-		t.Errorf("Expected finish reason 'tool_calls', got %s", *finalChunk.FinishReason)
+	// Terminal tool-streaming finish reasons are now normalized to the
+	// canonical vocabulary (task 14, finding J), matching the non-tool
+	// streaming and non-streaming PredictWithTools paths: raw "tool_calls"
+	// becomes types.FinishReasonToolUse ("tool_use"), not the raw wire value.
+	if *finalChunk.FinishReason != types.FinishReasonToolUse {
+		t.Errorf("Expected finish reason %q, got %s", types.FinishReasonToolUse, *finalChunk.FinishReason)
 	}
 
 	if len(finalChunk.ToolCalls) != 1 {

--- a/sdk/session/unary_session.go
+++ b/sdk/session/unary_session.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -410,14 +411,7 @@ func (p *streamProcessor) accumulateMessage(msg *types.Message) {
 		ToolCalls: msg.ToolCalls,
 	}
 	if msg.CostInfo != nil {
-		ci := &p.finalResult.CostInfo
-		ci.InputTokens += msg.CostInfo.InputTokens
-		ci.OutputTokens += msg.CostInfo.OutputTokens
-		ci.CachedTokens += msg.CostInfo.CachedTokens
-		ci.InputCostUSD += msg.CostInfo.InputCostUSD
-		ci.OutputCostUSD += msg.CostInfo.OutputCostUSD
-		ci.CachedCostUSD += msg.CostInfo.CachedCostUSD
-		ci.TotalCost += msg.CostInfo.TotalCost
+		p.finalResult.CostInfo = base.AggregateCost(&p.finalResult.CostInfo, msg.CostInfo)
 	}
 }
 

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
@@ -29,9 +30,12 @@ func TestProcessStreamElements_PopulatesFinalResultCost(t *testing.T) {
 	chunkChan := make(chan providers.StreamChunk, 8)
 
 	msg := types.Message{
-		Role:     "assistant",
-		Content:  "hi",
-		CostInfo: &types.CostInfo{InputTokens: 11, OutputTokens: 7, TotalCost: 0.02},
+		Role:    "assistant",
+		Content: "hi",
+		CostInfo: &types.CostInfo{
+			InputTokens: 11, OutputTokens: 7,
+			InputCostUSD: 0.015, OutputCostUSD: 0.005, TotalCost: 0.02,
+		},
 	}
 	stageChan <- stage.StreamElement{Message: &msg}
 	close(stageChan)
@@ -50,6 +54,44 @@ func TestProcessStreamElements_PopulatesFinalResultCost(t *testing.T) {
 	assert.Equal(t, 11, final.CostInfo.InputTokens, "input tokens must survive to the streaming Response")
 	assert.Equal(t, 7, final.CostInfo.OutputTokens)
 	assert.InEpsilon(t, 0.02, final.CostInfo.TotalCost, 1e-9)
+}
+
+// TestStreamProcessor_AccumulateMessage_PreservesBreakdown guards the
+// session roll-up against the lossy hand-rolled-field-sum pattern: it must
+// route through base.AggregateCost so Quantities/Breakdown survive (and sum
+// correctly across messages), not just the flat headline fields.
+func TestStreamProcessor_AccumulateMessage_PreservesBreakdown(t *testing.T) {
+	p := &streamProcessor{}
+
+	msg1 := &types.Message{
+		Role: streamRoleAssistant,
+		CostInfo: &types.CostInfo{
+			Quantities: map[string]float64{base.UnitReasoningToken: 25},
+			Breakdown: []types.CostLineItem{
+				{Provider: "g", Capability: "inference", Unit: base.UnitReasoningToken, Quantity: 25, USD: 0.02},
+			},
+		},
+	}
+	msg2 := &types.Message{
+		Role: streamRoleAssistant,
+		CostInfo: &types.CostInfo{
+			Quantities: map[string]float64{base.UnitReasoningToken: 10},
+			Breakdown: []types.CostLineItem{
+				{Provider: "g", Capability: "inference", Unit: base.UnitReasoningToken, Quantity: 10, USD: 0.01},
+			},
+		},
+	}
+
+	p.accumulateMessage(msg1)
+	p.accumulateMessage(msg2)
+
+	require.NotNil(t, p.finalResult)
+	assert.Equal(t, 35.0, p.finalResult.CostInfo.Quantities[base.UnitReasoningToken],
+		"quantities must sum across accumulated messages")
+	require.Len(t, p.finalResult.CostInfo.Breakdown, 1, "matching lines must merge into a single breakdown row")
+	assert.InEpsilon(t, 35.0, p.finalResult.CostInfo.Breakdown[0].Quantity, 1e-9)
+	assert.InEpsilon(t, 0.03, p.finalResult.CostInfo.Breakdown[0].USD, 1e-9)
+	assert.InEpsilon(t, 0.03, p.finalResult.CostInfo.TotalCost, 1e-9)
 }
 
 func TestNewUnarySession(t *testing.T) {

--- a/sdk/session/unary_session_test.go
+++ b/sdk/session/unary_session_test.go
@@ -30,12 +30,9 @@ func TestProcessStreamElements_PopulatesFinalResultCost(t *testing.T) {
 	chunkChan := make(chan providers.StreamChunk, 8)
 
 	msg := types.Message{
-		Role:    "assistant",
-		Content: "hi",
-		CostInfo: &types.CostInfo{
-			InputTokens: 11, OutputTokens: 7,
-			InputCostUSD: 0.015, OutputCostUSD: 0.005, TotalCost: 0.02,
-		},
+		Role:     "assistant",
+		Content:  "hi",
+		CostInfo: &types.CostInfo{InputTokens: 11, OutputTokens: 7, TotalCost: 0.02},
 	}
 	stageChan <- stage.StreamElement{Message: &msg}
 	close(stageChan)
@@ -92,6 +89,31 @@ func TestStreamProcessor_AccumulateMessage_PreservesBreakdown(t *testing.T) {
 	assert.InEpsilon(t, 35.0, p.finalResult.CostInfo.Breakdown[0].Quantity, 1e-9)
 	assert.InEpsilon(t, 0.03, p.finalResult.CostInfo.Breakdown[0].USD, 1e-9)
 	assert.InEpsilon(t, 0.03, p.finalResult.CostInfo.TotalCost, 1e-9)
+}
+
+// TestStreamProcessor_AccumulateMessage_TotalCostOnlyNotDropped guards the
+// same phantom as TestProcessStreamElements_PopulatesFinalResultCost but for
+// a headline that carries no token buckets at all (the imagen/replay shape:
+// a non-canonical Quantities unit plus a flat TotalCost, no Breakdown, no
+// Input/Output/CachedCostUSD). accumulateMessage routes through
+// base.AggregateCost, so this must survive the roll-up instead of silently
+// zeroing out.
+func TestStreamProcessor_AccumulateMessage_TotalCostOnlyNotDropped(t *testing.T) {
+	p := &streamProcessor{}
+
+	msg := &types.Message{
+		Role: streamRoleAssistant,
+		CostInfo: &types.CostInfo{
+			Quantities: map[string]float64{"image": 1},
+			TotalCost:  0.04,
+		},
+	}
+
+	p.accumulateMessage(msg)
+
+	require.NotNil(t, p.finalResult)
+	assert.InEpsilon(t, 0.04, p.finalResult.CostInfo.TotalCost, 1e-9,
+		"a TotalCost-only message with no buckets/Breakdown must not aggregate to $0")
 }
 
 func TestNewUnarySession(t *testing.T) {


### PR DESCRIPTION
Closes #1589.

Routes every LLM provider's cost through the existing unit-keyed pricing engine, makes `Breakdown` the authoritative cost record with a single `AggregateCost` roll-up, and fixes the Tier-2 billing-understatement bugs. `types.CostInfo` is unchanged — flat headline fields are derived from the canonical units (Level 2 scope; flat-field deprecation is a Level-3 follow-up).

## What changed

**Engine + roll-up**
- Canonical token-unit vocabulary (`base` constants) + `TokenUsage` carrier.
- `PriceUsage`: prices `TokenUsage` against a `PricingDescriptor`, fills `Quantities`/`Breakdown`, derives flat headlines via a directional-fold rule that preserves `TotalCost == InputCostUSD + OutputCostUSD + CachedCostUSD`, and surfaces nonzero unpriced units loudly (deduped) instead of a silent `$0`.
- Partial-tolerant `computeCostPartial`; `MakeCostInfo` no longer swallows a no-pricing-match to `$0` (**#7**).
- `AggregateCost`: single shared roll-up merging `Breakdown` by `(provider, capability, unit, dims)`; never drops cost for any `CostInfo` shape (headline-only, `TotalCost`-only like imagen/replay, or `Breakdown`-bearing). Replaces the two hand-rolled, lossy sum sites in `pipeline.go` and `sdk/session/unary_session.go`.
- `ResolveLLMPricing`: per-`(impl, model)` resolution — config descriptor → flat config → embedded table → nil (loud on unknown paid model, no wrong-constant guess).

**Provider migrations**
- **Claude** — cache-write tokens priced (~1.25×) via `cache_write_token` (**G**).
- **Gemini** — `thoughtsTokenCount` priced as reasoning, billed on top (**F**); unknown model → loud `$0`, no Gemini-1.5-Pro fallback (**K**); removed the fabricated streaming token counter (**I**).
- **OpenAI** — reasoning split out of `completion_tokens` into its own priced unit (output headline is now visible-only); Realtime cached + audio tokens priced (**H**).
- **vLLM** — streaming `stream_options.include_usage`, terminal tool-chunk `CostInfo` + normalized finish reason (**J**).
- **ollama/mock/replay** — routed through `PriceUsage` (preserving each package's cache-inclusive/exclusive convention).

## Verification
- All three modules build (runtime, sdk, server/a2a); full runtime provider/base/pipeline suites + SDK roll-up suite + the `TotalCost == In+Out+Cached` contract-invariant all pass. 88.3% coverage.
- Final whole-branch review: **READY TO MERGE**, no Critical/Important defects.

## Reviewer note — deliberate behavior changes (not regressions)
- OpenAI o-series `OutputTokens` headline is now visible-only (reasoning moved to `Quantities[reasoning_token]`); `TotalCost` unchanged.
- Flat-config (`Pricing{InputCostPer1K, OutputCostPer1K}`) providers price cache tokens as loud-unpriced `$0` (a flat config carries no cache multiplier) rather than a hardcoded discount. Reasoning IS priced at the output rate under flat config.

## Follow-ups (not blockers)
- [ ] **Human-verify all pricing rate values** against vendor pricing pages — rates were authored without web access (Gemini 3.x low-confidence; long-context Gemini tier not modeled). Add dollar-exact golden cost-locks once verified.
- [ ] Migrate the Gemini **Live/duplex** cost path (finding F's second location).
- [ ] Split reasoning into its own unit on the OpenAI **Responses API** path (dollar total already correct).
- [ ] Confirm voice dashboards tolerate text-only Realtime `InputTokens`/`OutputTokens` headlines (audio now in `Quantities`).
