### PR TITLE
chore: pin gomarkdoc + document state_store file backend

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,7 +63,7 @@ jobs:
           cache: true
 
       - name: Install gomarkdoc
-        run: go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
+        run: go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0
 
       - name: Install D2
         run: curl -fsSL https://d2lang.com/install.sh | sh -s --

--- a/.github/workflows/reference-drift.yml
+++ b/.github/workflows/reference-drift.yml
@@ -41,7 +41,7 @@ jobs:
         go-version: '1.26.0'
 
     - name: Install gomarkdoc
-      run: go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
+      run: go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0
 
     - name: Check runtime reference is up to date
       run: make docs-reference-check

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ docs-install: ## Install documentation dependencies
 	@echo "📦 Installing documentation dependencies..."
 	@command -v gomarkdoc >/dev/null 2>&1 || { \
 		echo "Installing gomarkdoc..."; \
-		go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest; \
+		go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0; \
 	}
 	@echo "Installing Astro dependencies..."
 	@cd docs && npm install

--- a/docs/scripts/gen-reference.sh
+++ b/docs/scripts/gen-reference.sh
@@ -8,7 +8,7 @@ ROOT="$(git rev-parse --show-toplevel)"
 OUT="${1:-$ROOT/docs/src/content/docs/runtime/reference}"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
-GOMARKDOC="github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest"
+GOMARKDOC="github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0"
 
 # pkg | filename | title | sidebar-order
 MAP=(

--- a/docs/src/content/docs/sdk/reference/runtime-config.md
+++ b/docs/src/content/docs/sdk/reference/runtime-config.md
@@ -266,8 +266,9 @@ Configures conversation state persistence. Defaults to in-memory storage when om
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | string | no | Store implementation: `memory` (default) or `redis`. |
+| `type` | string | no | Store implementation: `memory` (default), `redis`, or `file`. |
 | `redis` | object | conditional | Redis configuration. Required when `type` is `redis`. See [redis](#redis). |
+| `file` | object | conditional | Filesystem store configuration. Required when `type` is `file`. See [file](#file). |
 
 #### redis
 
@@ -278,6 +279,16 @@ Configures conversation state persistence. Defaults to in-memory storage when om
 | `database` | int | no | Redis database number (0-15, default: 0). |
 | `ttl` | string | no | Key TTL as a Go duration string (e.g., `24h`, `168h`). Default: `24h`. |
 | `prefix` | string | no | Key prefix for all state keys. Default: `promptkit`. |
+
+#### file
+
+Single-machine, filesystem-backed persistence (survives process restarts; no cross-process locking).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `root` | string | yes | Directory under which per-conversation state is stored. Created if absent. |
+| `fsync` | string | no | Durability policy: `off`, `on-save` (default), `on-append`. |
+| `ttl_days` | int | no | At startup, remove conversation state older than this many days. Default: `0` (disabled). |
 
 ---
 


### PR DESCRIPTION
Two follow-ups from the runtime-reference generation work (#1591):

1. **Pin gomarkdoc to v1.1.0** — the generator (`gen-reference.sh`) and every install step (`reference-drift.yml`, `docs.yml`, `Makefile`) used `@latest`; a gomarkdoc release landing mid-CI-run could produce a flaky false drift failure. v1.1.0 is the version that produced the committed pages, so no regeneration is needed and the drift gate stays green.
2. **Document `state_store: {type: file}`** — the SDK `runtime-config` reference listed only `memory`/`redis` for `state_store.type`, but `StateStoreConfig` (`pkg/config/types.go`) also supports `file`. Added `file` to the type list + a `file` sub-section (root/fsync/ttl_days), verified against source.

Touches `.github/workflows/**`, so **merging may need the GitHub UI**.
