### PR TITLE
feat: resolve media StorageReference through the provider path (#1595, #1596, #1597)

### DIFF
--- a/docs/src/content/docs/runtime/reference/providers.md
+++ b/docs/src/content/docs/runtime/reference/providers.md
@@ -109,6 +109,7 @@ This file contains exported test helpers that can be used by provider implementa
   - [func \(b \*BaseProvider\) MakeJSONRequest\(ctx context.Context, url string, request any, headers RequestHeaders, providerName string\) \(\[\]byte, error\)](<#BaseProvider.MakeJSONRequest>)
   - [func \(b \*BaseProvider\) MakeRawRequest\(ctx context.Context, url string, body \[\]byte, headers RequestHeaders, providerName string\) \(\[\]byte, error\)](<#BaseProvider.MakeRawRequest>)
   - [func \(b \*BaseProvider\) MaxPayloadSize\(\) int64](<#BaseProvider.MaxPayloadSize>)
+  - [func \(b \*BaseProvider\) MediaLoader\(\) \*MediaLoader](<#BaseProvider.MediaLoader>)
   - [func \(b \*BaseProvider\) RateLimiter\(\) \*rate.Limiter](<#BaseProvider.RateLimiter>)
   - [func \(b \*BaseProvider\) ReleaseStreamSlot\(\)](<#BaseProvider.ReleaseStreamSlot>)
   - [func \(b \*BaseProvider\) RunStreamingRequest\(ctx context.Context, req \*StreamRetryRequest, consumer StreamConsumer\) \(\<\-chan StreamChunk, error\)](<#BaseProvider.RunStreamingRequest>)
@@ -116,6 +117,7 @@ This file contains exported test helpers that can be used by provider implementa
   - [func \(b \*BaseProvider\) SetHTTPTimeout\(timeout time.Duration\)](<#BaseProvider.SetHTTPTimeout>)
   - [func \(b \*BaseProvider\) SetHTTPTransport\(rt http.RoundTripper\)](<#BaseProvider.SetHTTPTransport>)
   - [func \(b \*BaseProvider\) SetMaxPayloadSize\(size int64\)](<#BaseProvider.SetMaxPayloadSize>)
+  - [func \(b \*BaseProvider\) SetMediaStorageService\(store storage.MediaStorageService\)](<#BaseProvider.SetMediaStorageService>)
   - [func \(b \*BaseProvider\) SetRateLimit\(requestsPerSecond float64, burst int\)](<#BaseProvider.SetRateLimit>)
   - [func \(b \*BaseProvider\) SetRetryPolicy\(policy pipeline.RetryPolicy\)](<#BaseProvider.SetRetryPolicy>)
   - [func \(b \*BaseProvider\) SetStreamIdleTimeout\(d time.Duration\)](<#BaseProvider.SetStreamIdleTimeout>)
@@ -169,7 +171,9 @@ This file contains exported test helpers that can be used by provider implementa
 - [type MediaLoader](<#MediaLoader>)
   - [func NewMediaLoader\(config MediaLoaderConfig\) \*MediaLoader](<#NewMediaLoader>)
   - [func \(ml \*MediaLoader\) GetBase64Data\(ctx context.Context, media \*types.MediaContent\) \(string, error\)](<#MediaLoader.GetBase64Data>)
+  - [func \(ml \*MediaLoader\) ResolveURL\(ctx context.Context, media \*types.MediaContent\) \(string, bool, error\)](<#MediaLoader.ResolveURL>)
 - [type MediaLoaderConfig](<#MediaLoaderConfig>)
+- [type MediaStorageConfigurable](<#MediaStorageConfigurable>)
 - [type MultimodalCapabilities](<#MultimodalCapabilities>)
 - [type MultimodalCapabilityProvider](<#MultimodalCapabilityProvider>)
   - [func GetMultimodalProvider\(p Provider\) MultimodalCapabilityProvider](<#GetMultimodalProvider>)
@@ -1184,6 +1188,15 @@ func (b *BaseProvider) MaxPayloadSize() int64
 
 MaxPayloadSize returns the current maximum request payload size in bytes.
 
+<a name="BaseProvider.MediaLoader"></a>
+### func \(\*BaseProvider\) MediaLoader
+
+```go
+func (b *BaseProvider) MediaLoader() *MediaLoader
+```
+
+MediaLoader returns a per\-call MediaLoader configured with this provider's injected storage service \(if any\). Providers use it to resolve media parts \(ResolveURL for URL\-first providers, GetBase64Data for byte\-based ones\).
+
 <a name="BaseProvider.RateLimiter"></a>
 ### func \(\*BaseProvider\) RateLimiter
 
@@ -1261,6 +1274,15 @@ func (b *BaseProvider) SetMaxPayloadSize(size int64)
 ```
 
 SetMaxPayloadSize configures the maximum allowed request payload size in bytes. A zero or negative value disables payload size checking.
+
+<a name="BaseProvider.SetMediaStorageService"></a>
+### func \(\*BaseProvider\) SetMediaStorageService
+
+```go
+func (b *BaseProvider) SetMediaStorageService(store storage.MediaStorageService)
+```
+
+SetMediaStorageService injects the media storage service used to resolve MediaContent.StorageReference values at request\-build time. Nil \(the default\) preserves prior behavior. See MediaStorageConfigurable in registry.go.
 
 <a name="BaseProvider.SetRateLimit"></a>
 ### func \(\*BaseProvider\) SetRateLimit
@@ -1952,6 +1974,15 @@ aGVsbG8=
 </p>
 </details>
 
+<a name="MediaLoader.ResolveURL"></a>
+### func \(\*MediaLoader\) ResolveURL
+
+```go
+func (ml *MediaLoader) ResolveURL(ctx context.Context, media *types.MediaContent) (string, bool, error)
+```
+
+ResolveURL returns a URL a provider can hand to the model when the media can be represented as one. ok is false when the source cannot be a fetchable URL \(inline data, local file path, a non\-remote storage URL such as file://, or a storage reference with no store configured\); callers then fall back to GetBase64Data. URL expiry/caching is entirely the store's concern — we pass 0 so the store chooses its own policy.
+
 <a name="MediaLoaderConfig"></a>
 ## type MediaLoaderConfig
 
@@ -1967,6 +1998,19 @@ type MediaLoaderConfig struct {
 
     // MaxURLSizeBytes is the maximum size for URL-based media (default: 50MB)
     MaxURLSizeBytes int64
+}
+```
+
+<a name="MediaStorageConfigurable"></a>
+## type MediaStorageConfigurable
+
+MediaStorageConfigurable is implemented by any provider embedding \*BaseProvider. CreateProviderFromSpec uses it to inject the media storage service so providers can resolve MediaContent.StorageReference values at request\-build time.
+
+NOSONAR: name intentionally matches the existing \*Configurable pattern for post\-construction wiring interfaces \(timeoutConfigurable etc.\)
+
+```go
+type MediaStorageConfigurable interface {
+    SetMediaStorageService(storage.MediaStorageService)
 }
 ```
 
@@ -2367,6 +2411,12 @@ type ProviderSpec struct {
     // via SetStreamSemaphore on providers that implement the
     // streamConcurrencyConfigurable interface.
     StreamMaxConcurrent int
+
+    // StorageService resolves MediaContent.StorageReference values at
+    // request-build time (to a model-fetchable URL via GetURL, or bytes via
+    // RetrieveMedia). Applied via SetMediaStorageService on providers
+    // implementing MediaStorageConfigurable. Nil = disabled.
+    StorageService storage.MediaStorageService
 
     // HTTPTransport configures the per-provider HTTP connection pool.
     // Zero-valued fields fall back to package-level defaults

--- a/docs/src/content/docs/runtime/reference/storage.md
+++ b/docs/src/content/docs/runtime/reference/storage.md
@@ -228,7 +228,8 @@ type MediaStorageService interface {
     // Parameters:
     //   - ctx: Context for cancellation and timeouts
     //   - reference: The storage reference
-    //   - expiry: How long the URL should be valid (ignored for local storage)
+    //   - expiry: How long the URL should be valid (ignored for local storage).
+    //     An expiry <= 0 means the store chooses its own expiry/caching policy.
     //
     // Returns:
     //   - URL string that can be used to access the media

--- a/docs/src/content/docs/runtime/reference/types.md
+++ b/docs/src/content/docs/runtime/reference/types.md
@@ -34,15 +34,19 @@ import "github.com/AltairaLabs/PromptKit/runtime/types"
   - [func MetadataOnlyParts\(parts \[\]ContentPart\) \[\]ContentPart](<#MetadataOnlyParts>)
   - [func NewAudioPart\(filePath string\) \(ContentPart, error\)](<#NewAudioPart>)
   - [func NewAudioPartFromData\(base64Data, mimeType string\) ContentPart](<#NewAudioPartFromData>)
+  - [func NewAudioPartFromStorageRef\(ref, mimeType string\) ContentPart](<#NewAudioPartFromStorageRef>)
   - [func NewDocumentPart\(filePath string\) \(ContentPart, error\)](<#NewDocumentPart>)
   - [func NewDocumentPartFromData\(base64Data, mimeType string\) ContentPart](<#NewDocumentPartFromData>)
+  - [func NewDocumentPartFromStorageRef\(ref, mimeType string\) ContentPart](<#NewDocumentPartFromStorageRef>)
   - [func NewImagePart\(filePath string, detail \*string\) \(ContentPart, error\)](<#NewImagePart>)
   - [func NewImagePartFromData\(base64Data, mimeType string, detail \*string\) ContentPart](<#NewImagePartFromData>)
+  - [func NewImagePartFromStorageRef\(ref, mimeType string, detail \*string\) ContentPart](<#NewImagePartFromStorageRef>)
   - [func NewImagePartFromURL\(url string, detail \*string\) ContentPart](<#NewImagePartFromURL>)
   - [func NewTextPart\(text string\) ContentPart](<#NewTextPart>)
   - [func NewThinkingPart\(text string\) ContentPart](<#NewThinkingPart>)
   - [func NewVideoPart\(filePath string\) \(ContentPart, error\)](<#NewVideoPart>)
   - [func NewVideoPartFromData\(base64Data, mimeType string\) ContentPart](<#NewVideoPartFromData>)
+  - [func NewVideoPartFromStorageRef\(ref, mimeType string\) ContentPart](<#NewVideoPartFromStorageRef>)
   - [func SplitMultimodalMessage\(msg Message\) \(text string, mediaParts \[\]ContentPart\)](<#SplitMultimodalMessage>)
   - [func \(cp \*ContentPart\) Validate\(\) error](<#ContentPart.Validate>)
 - [type CostInfo](<#CostInfo>)
@@ -376,6 +380,15 @@ func NewAudioPartFromData(base64Data, mimeType string) ContentPart
 
 NewAudioPartFromData creates a ContentPart with base64\-encoded audio data
 
+<a name="NewAudioPartFromStorageRef"></a>
+### func NewAudioPartFromStorageRef
+
+```go
+func NewAudioPartFromStorageRef(ref, mimeType string) ContentPart
+```
+
+NewAudioPartFromStorageRef creates an audio ContentPart backed by a storage reference.
+
 <a name="NewDocumentPart"></a>
 ### func NewDocumentPart
 
@@ -394,6 +407,15 @@ func NewDocumentPartFromData(base64Data, mimeType string) ContentPart
 
 NewDocumentPartFromData creates a ContentPart with base64\-encoded document data
 
+<a name="NewDocumentPartFromStorageRef"></a>
+### func NewDocumentPartFromStorageRef
+
+```go
+func NewDocumentPartFromStorageRef(ref, mimeType string) ContentPart
+```
+
+NewDocumentPartFromStorageRef creates a document ContentPart backed by a storage reference.
+
 <a name="NewImagePart"></a>
 ### func NewImagePart
 
@@ -411,6 +433,15 @@ func NewImagePartFromData(base64Data, mimeType string, detail *string) ContentPa
 ```
 
 NewImagePartFromData creates a ContentPart with base64\-encoded image data
+
+<a name="NewImagePartFromStorageRef"></a>
+### func NewImagePartFromStorageRef
+
+```go
+func NewImagePartFromStorageRef(ref, mimeType string, detail *string) ContentPart
+```
+
+NewImagePartFromStorageRef creates an image ContentPart backed by a durable storage reference. The reference is resolved to a URL or bytes at provider\-call time \(see providers.MediaLoader\).
 
 <a name="NewImagePartFromURL"></a>
 ### func NewImagePartFromURL
@@ -487,6 +518,15 @@ func NewVideoPartFromData(base64Data, mimeType string) ContentPart
 ```
 
 NewVideoPartFromData creates a ContentPart with base64\-encoded video data
+
+<a name="NewVideoPartFromStorageRef"></a>
+### func NewVideoPartFromStorageRef
+
+```go
+func NewVideoPartFromStorageRef(ref, mimeType string) ContentPart
+```
+
+NewVideoPartFromStorageRef creates a video ContentPart backed by a storage reference.
 
 <a name="SplitMultimodalMessage"></a>
 ### func SplitMultimodalMessage

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -307,6 +307,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func WithMaxActiveSkillsOption\(n int\) Option](<#WithMaxActiveSkillsOption>)
   - [func WithMaxConcurrentEvals\(n int\) Option](<#WithMaxConcurrentEvals>)
   - [func WithMaxMessageSize\(bytes int\) Option](<#WithMaxMessageSize>)
+  - [func WithMediaStorage\(store storage.MediaStorageService\) Option](<#WithMediaStorage>)
   - [func WithMemory\(store memory.Store, scope map\[string\]string, opts ...MemoryOption\) Option](<#WithMemory>)
   - [func WithMessageLog\(log statestore.MessageLog\) Option](<#WithMessageLog>)
   - [func WithMetricRecorder\(r evals.MetricRecorder\) Option](<#WithMetricRecorder>)
@@ -399,15 +400,19 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
 - [type SendOption](<#SendOption>)
   - [func WithAudioData\(data \[\]byte, mimeType string\) SendOption](<#WithAudioData>)
   - [func WithAudioFile\(path string\) SendOption](<#WithAudioFile>)
+  - [func WithAudioStorageRef\(ref, mimeType string\) SendOption](<#WithAudioStorageRef>)
   - [func WithDocumentData\(data \[\]byte, mimeType string\) SendOption](<#WithDocumentData>)
   - [func WithDocumentFile\(path string\) SendOption](<#WithDocumentFile>)
   - [func WithFile\(name string, data \[\]byte\) SendOption](<#WithFile>)
+  - [func WithFileStorageRef\(name, ref, mimeType string\) SendOption](<#WithFileStorageRef>)
   - [func WithImageData\(data \[\]byte, mimeType string, detail ...\*string\) SendOption](<#WithImageData>)
   - [func WithImageFile\(path string, detail ...\*string\) SendOption](<#WithImageFile>)
+  - [func WithImageStorageRef\(ref, mimeType string, detail ...\*string\) SendOption](<#WithImageStorageRef>)
   - [func WithImageURL\(url string, detail ...\*string\) SendOption](<#WithImageURL>)
   - [func WithJSONInput\(v any\) SendOption](<#WithJSONInput>)
   - [func WithVideoData\(data \[\]byte, mimeType string\) SendOption](<#WithVideoData>)
   - [func WithVideoFile\(path string\) SendOption](<#WithVideoFile>)
+  - [func WithVideoStorageRef\(ref, mimeType string\) SendOption](<#WithVideoStorageRef>)
 - [type SessionMode](<#SessionMode>)
 - [type ShutdownManager](<#ShutdownManager>)
   - [func NewShutdownManager\(\) \*ShutdownManager](<#NewShutdownManager>)
@@ -3380,6 +3385,15 @@ conv, _ := sdk.Open("./chat.pack.json", "assistant",
 )
 ```
 
+<a name="WithMediaStorage"></a>
+### func WithMediaStorage
+
+```go
+func WithMediaStorage(store storage.MediaStorageService) Option
+```
+
+WithMediaStorage injects a MediaStorageService so MediaContent.StorageReference values \(e.g. from WithImageStorageRef\) resolve to a model\-fetchable URL or bytes at provider\-call time. Applied to every provider in the pool.
+
 <a name="WithMemory"></a>
 ### func WithMemory
 
@@ -4923,6 +4937,15 @@ resp, _ := conv.Send(ctx, "Transcribe this audio",
 )
 ```
 
+<a name="WithAudioStorageRef"></a>
+### func WithAudioStorageRef
+
+```go
+func WithAudioStorageRef(ref, mimeType string) SendOption
+```
+
+WithAudioStorageRef attaches audio by durable storage reference.
+
 <a name="WithDocumentData"></a>
 ### func WithDocumentData
 
@@ -4970,6 +4993,15 @@ resp, _ := conv.Send(ctx, "Analyze this data",
 )
 ```
 
+<a name="WithFileStorageRef"></a>
+### func WithFileStorageRef
+
+```go
+func WithFileStorageRef(name, ref, mimeType string) SendOption
+```
+
+WithFileStorageRef attaches a document by durable storage reference. The name is preserved as the media caption for downstream display.
+
 <a name="WithImageData"></a>
 ### func WithImageData
 
@@ -4997,6 +5029,21 @@ WithImageFile attaches an image from a file path.
 ```
 resp, _ := conv.Send(ctx, "What's in this image?",
     sdk.WithImageFile("/path/to/image.jpg"),
+)
+```
+
+<a name="WithImageStorageRef"></a>
+### func WithImageStorageRef
+
+```go
+func WithImageStorageRef(ref, mimeType string, detail ...*string) SendOption
+```
+
+WithImageStorageRef attaches an image by durable storage reference. The reference is resolved to a model\-fetchable URL or bytes at provider\-call time by the MediaStorageService configured via WithMediaStorage.
+
+```
+resp, _ := conv.Send(ctx, "What's in this image?",
+    sdk.WithImageStorageRef("s3://bucket/key", "image/png"),
 )
 ```
 
@@ -5064,6 +5111,15 @@ resp, _ := conv.Send(ctx, "Describe this video",
     sdk.WithVideoFile("/path/to/video.mp4"),
 )
 ```
+
+<a name="WithVideoStorageRef"></a>
+### func WithVideoStorageRef
+
+```go
+func WithVideoStorageRef(ref, mimeType string) SendOption
+```
+
+WithVideoStorageRef attaches a video by durable storage reference.
 
 <a name="SessionMode"></a>
 ## type SessionMode

--- a/runtime/providers/base_provider.go
+++ b/runtime/providers/base_provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/safe"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
 )
 
 // Connection pooling defaults for HTTP transports shared across providers.
@@ -162,6 +163,7 @@ type BaseProvider struct {
 	retryPolicy           pipeline.RetryPolicy
 	maxRequestPayloadSize int64
 	customHeaders         map[string]string
+	mediaStorage          storage.MediaStorageService
 }
 
 // NewBaseProvider creates a new BaseProvider with common fields. A companion
@@ -350,6 +352,20 @@ func (b *BaseProvider) SetHTTPTransport(rt http.RoundTripper) {
 // X-Title). Called by CreateProviderFromSpec after factory construction.
 func (b *BaseProvider) SetCustomHeaders(headers map[string]string) {
 	b.customHeaders = headers
+}
+
+// SetMediaStorageService injects the media storage service used to resolve
+// MediaContent.StorageReference values at request-build time. Nil (the default)
+// preserves prior behavior. See MediaStorageConfigurable in registry.go.
+func (b *BaseProvider) SetMediaStorageService(store storage.MediaStorageService) {
+	b.mediaStorage = store
+}
+
+// MediaLoader returns a per-call MediaLoader configured with this provider's
+// injected storage service (if any). Providers use it to resolve media parts
+// (ResolveURL for URL-first providers, GetBase64Data for byte-based ones).
+func (b *BaseProvider) MediaLoader() *MediaLoader {
+	return NewMediaLoader(MediaLoaderConfig{StorageService: b.mediaStorage})
 }
 
 // ApplyCustomHeaders applies stored custom headers to the HTTP request.

--- a/runtime/providers/base_provider_mediastore_test.go
+++ b/runtime/providers/base_provider_mediastore_test.go
@@ -1,0 +1,25 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func TestBaseProvider_MediaLoaderUsesInjectedStore(t *testing.T) {
+	b := NewBaseProvider("t", false, nil)
+	ref := "s3://bucket/key"
+	media := &types.MediaContent{StorageReference: &ref, MIMEType: "image/png"}
+
+	// Without a store: ResolveURL cannot make a URL.
+	if _, ok, _ := b.MediaLoader().ResolveURL(context.Background(), media); ok {
+		t.Fatal("expected ok=false with no store")
+	}
+
+	b.SetMediaStorageService(resolveURLFakeStore{url: "https://s3/x?sig=1"})
+	url, ok, err := b.MediaLoader().ResolveURL(context.Background(), media)
+	if err != nil || !ok || url != "https://s3/x?sig=1" {
+		t.Fatalf("got (%q,%v,%v) after injecting store", url, ok, err)
+	}
+}

--- a/runtime/providers/claude/claude.go
+++ b/runtime/providers/claude/claude.go
@@ -568,7 +568,7 @@ func (p *Provider) SupportsPromptCaching() bool {
 
 // convertMessagesToClaudeFormat converts provider messages to Claude format with cache control.
 // Handles both text-only and multimodal (image) messages inline.
-func (p *Provider) convertMessagesToClaudeFormat(messages []types.Message) []claudeMessage {
+func (p *Provider) convertMessagesToClaudeFormat(ctx context.Context, messages []types.Message) []claudeMessage {
 	claudeMessages := make([]claudeMessage, 0, len(messages))
 	minCharsForCaching := 2048 * 4 // ~8192 characters (Claude requires 2048 tokens minimum)
 
@@ -578,7 +578,7 @@ func (p *Provider) convertMessagesToClaudeFormat(messages []types.Message) []cla
 		// Check if message has media content (images, audio, video)
 		if msg.HasMediaContent() {
 			// Use multimodal conversion path
-			claudeMsg, err := p.convertMessageToClaudeMultimodal(*msg)
+			claudeMsg, err := p.convertMessageToClaudeMultimodal(ctx, *msg)
 			if err != nil {
 				// Fall back to text-only on conversion error
 				logger.Warn("Failed to convert multimodal message, falling back to text", "error", err)
@@ -830,7 +830,7 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 
 	// Build the canonical request via the shared base builder, then layer on
 	// structured outputs (the no-tools paths honor output_config).
-	messages := p.convertMessagesToClaudeFormat(req.Messages)
+	messages := p.convertMessagesToClaudeFormat(ctx, req.Messages)
 	claudeReq := p.buildBaseRequest(req, messages)
 	claudeReq.OutputConfig = outputConfigFor(req.ResponseFormat)
 

--- a/runtime/providers/claude/claude_caching_request_test.go
+++ b/runtime/providers/claude/claude_caching_request_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -40,7 +41,9 @@ func TestToolRequest_CachingBreakpointsAndDeterminism(t *testing.T) {
 	}
 
 	build := func() []byte {
-		req := tp.buildToolRequest(providers.PredictionRequest{System: system, Messages: msgs, MaxTokens: 100}, tools, "")
+		req := tp.buildToolRequest(
+			context.Background(),
+			providers.PredictionRequest{System: system, Messages: msgs, MaxTokens: 100}, tools, "")
 		b, mErr := json.Marshal(req)
 		if mErr != nil {
 			t.Fatalf("marshal request: %v", mErr)
@@ -75,7 +78,9 @@ func TestToolRequest_RollingBreakpointOnLastMessage(t *testing.T) {
 		{Role: "assistant", ToolCalls: []types.MessageToolCall{{ID: "1", Name: "Bash", Args: json.RawMessage(`{"command":"ls"}`)}}},
 		{Role: "tool", ToolResult: &types.MessageToolResult{ID: "1", Name: "Bash", Parts: []types.ContentPart{types.NewTextPart("big output")}}},
 	}
-	req := tp.buildToolRequest(providers.PredictionRequest{System: "sys", Messages: msgs, MaxTokens: 100}, tools, "")
+	req := tp.buildToolRequest(
+		context.Background(),
+		providers.PredictionRequest{System: "sys", Messages: msgs, MaxTokens: 100}, tools, "")
 	cms, ok := req.Messages.([]claudeToolMessage)
 	if !ok || len(cms) == 0 {
 		t.Fatalf("expected claude messages, got %T", req.Messages)

--- a/runtime/providers/claude/claude_integration_test.go
+++ b/runtime/providers/claude/claude_integration_test.go
@@ -318,7 +318,7 @@ func TestConvertMessagesToClaudeFormat(t *testing.T) {
 				},
 			}
 
-			result := provider.convertMessagesToClaudeFormat(tt.messages)
+			result := provider.convertMessagesToClaudeFormat(context.Background(), tt.messages)
 			require.NotEmpty(t, result)
 
 			lastMsg := result[len(result)-1]

--- a/runtime/providers/claude/claude_multimodal.go
+++ b/runtime/providers/claude/claude_multimodal.go
@@ -76,8 +76,9 @@ func (p *Provider) convertMessagesToClaudeMultimodal(messages []types.Message) (
 			continue
 		}
 
-		// Convert multimodal message
-		claudeMsg, err := p.convertMessageToClaudeMultimodal(*msg)
+		// Convert multimodal message. This helper has no production caller (the
+		// live path is convertMessagesToClaudeFormat); background context suffices.
+		claudeMsg, err := p.convertMessageToClaudeMultimodal(context.Background(), *msg)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -89,7 +90,7 @@ func (p *Provider) convertMessagesToClaudeMultimodal(messages []types.Message) (
 }
 
 // convertMessageToClaudeMultimodal converts a single PromptKit message to Claude format
-func (p *Provider) convertMessageToClaudeMultimodal(msg types.Message) (claudeMessage, error) {
+func (p *Provider) convertMessageToClaudeMultimodal(ctx context.Context, msg types.Message) (claudeMessage, error) {
 	var contentBlocks []interface{}
 
 	// Handle legacy string content
@@ -100,7 +101,7 @@ func (p *Provider) convertMessageToClaudeMultimodal(msg types.Message) (claudeMe
 		})
 	} else {
 		// Handle multimodal parts
-		blocks, err := p.convertPartsToClaudeBlocks(msg.Parts)
+		blocks, err := p.convertPartsToClaudeBlocks(ctx, msg.Parts)
 		if err != nil {
 			return claudeMessage{}, err
 		}
@@ -112,7 +113,7 @@ func (p *Provider) convertMessageToClaudeMultimodal(msg types.Message) (claudeMe
 }
 
 // convertPartsToClaudeBlocks converts content parts to Claude content blocks
-func (p *Provider) convertPartsToClaudeBlocks(parts []types.ContentPart) ([]interface{}, error) {
+func (p *Provider) convertPartsToClaudeBlocks(ctx context.Context, parts []types.ContentPart) ([]interface{}, error) {
 	var contentBlocks []interface{}
 
 	for _, part := range parts {
@@ -126,14 +127,14 @@ func (p *Provider) convertPartsToClaudeBlocks(parts []types.ContentPart) ([]inte
 			}
 
 		case types.ContentTypeImage:
-			block, err := p.convertImagePartToClaude(part)
+			block, err := p.convertImagePartToClaude(ctx, part)
 			if err != nil {
 				return nil, err
 			}
 			contentBlocks = append(contentBlocks, block)
 
 		case types.ContentTypeDocument:
-			block, err := p.convertDocumentPartToClaude(part)
+			block, err := p.convertDocumentPartToClaude(ctx, part)
 			if err != nil {
 				return nil, err
 			}
@@ -175,7 +176,9 @@ func (p *Provider) buildClaudeMessage(role string, contentBlocks []interface{}) 
 }
 
 // convertImagePartToClaude converts an image part to Claude's format
-func (p *Provider) convertImagePartToClaude(part types.ContentPart) (claudeContentBlockMultimodal, error) {
+func (p *Provider) convertImagePartToClaude(
+	ctx context.Context, part types.ContentPart,
+) (claudeContentBlockMultimodal, error) {
 	if part.Media == nil {
 		return claudeContentBlockMultimodal{}, fmt.Errorf("image part missing media data")
 	}
@@ -187,15 +190,16 @@ func (p *Provider) convertImagePartToClaude(part types.ContentPart) (claudeConte
 		},
 	}
 
-	// Determine which data source is set
-	if part.Media.URL != nil && *part.Media.URL != "" {
-		// External URL - use directly
+	// Prefer a model-fetchable URL (explicit URL or presigned StorageReference);
+	// fall back to inlined base64 bytes when no URL is available.
+	loader := p.MediaLoader()
+	if url, ok, err := loader.ResolveURL(ctx, part.Media); err != nil {
+		return claudeContentBlockMultimodal{}, fmt.Errorf("failed to resolve image: %w", err)
+	} else if ok {
 		block.Source.Type = "url"
-		block.Source.URL = *part.Media.URL
+		block.Source.URL = url
 	} else {
-		// Use MediaLoader for all other sources (Data, FilePath, StorageReference)
-		loader := providers.NewMediaLoader(providers.MediaLoaderConfig{})
-		data, err := loader.GetBase64Data(context.Background(), part.Media)
+		data, err := loader.GetBase64Data(ctx, part.Media)
 		if err != nil {
 			return claudeContentBlockMultimodal{}, fmt.Errorf("failed to load image data: %w", err)
 		}
@@ -207,7 +211,9 @@ func (p *Provider) convertImagePartToClaude(part types.ContentPart) (claudeConte
 }
 
 // convertDocumentPartToClaude converts a document part to Claude's format
-func (p *Provider) convertDocumentPartToClaude(part types.ContentPart) (claudeContentBlockMultimodal, error) {
+func (p *Provider) convertDocumentPartToClaude(
+	ctx context.Context, part types.ContentPart,
+) (claudeContentBlockMultimodal, error) {
 	if part.Media == nil {
 		return claudeContentBlockMultimodal{}, fmt.Errorf("document part missing media data")
 	}
@@ -224,10 +230,9 @@ func (p *Provider) convertDocumentPartToClaude(part types.ContentPart) (claudeCo
 		},
 	}
 
-	// Claude documents only support base64 encoding (no URL support)
-	// Use MediaLoader for all sources (Data, FilePath, StorageReference)
-	loader := providers.NewMediaLoader(providers.MediaLoaderConfig{})
-	data, err := loader.GetBase64Data(context.Background(), part.Media)
+	// Claude documents only support base64 encoding (no URL support).
+	// The store-aware loader resolves Data, FilePath, and StorageReference.
+	data, err := p.MediaLoader().GetBase64Data(ctx, part.Media)
 	if err != nil {
 		return claudeContentBlockMultimodal{}, fmt.Errorf("failed to load document data: %w", err)
 	}

--- a/runtime/providers/claude/claude_multimodal_test.go
+++ b/runtime/providers/claude/claude_multimodal_test.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestClaudeProvider_ConvertLegacyMessage(t *testing.T) {
 		Content: "Hello, world!",
 	}
 
-	claudeMsg, err := provider.convertMessageToClaudeMultimodal(msg)
+	claudeMsg, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -99,7 +100,7 @@ func TestClaudeProvider_ConvertTextOnlyMultimodalMessage(t *testing.T) {
 		},
 	}
 
-	claudeMsg, err := provider.convertMessageToClaudeMultimodal(msg)
+	claudeMsg, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -131,7 +132,7 @@ func TestClaudeProvider_ConvertImageBase64Message(t *testing.T) {
 		},
 	}
 
-	claudeMsg, err := provider.convertMessageToClaudeMultimodal(msg)
+	claudeMsg, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -163,7 +164,7 @@ func TestClaudeProvider_ConvertImageURLMessage(t *testing.T) {
 		},
 	}
 
-	claudeMsg, err := provider.convertMessageToClaudeMultimodal(msg)
+	claudeMsg, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestClaudeProvider_ConvertMultipleImages(t *testing.T) {
 		},
 	}
 
-	claudeMsg, err := provider.convertMessageToClaudeMultimodal(msg)
+	claudeMsg, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -221,7 +222,7 @@ func TestClaudeProvider_ConvertAudioReturnsError(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToClaudeMultimodal(msg)
+	_, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for audio content, got nil")
 	}
@@ -247,7 +248,7 @@ func TestClaudeProvider_ConvertVideoReturnsError(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToClaudeMultimodal(msg)
+	_, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for video content, got nil")
 	}
@@ -275,7 +276,7 @@ func TestClaudeProvider_ConvertEmptyTextPart(t *testing.T) {
 		},
 	}
 
-	claudeMsg, err := provider.convertMessageToClaudeMultimodal(msg)
+	claudeMsg, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -302,7 +303,7 @@ func TestClaudeProvider_ConvertImageMissingMedia(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToClaudeMultimodal(msg)
+	_, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for image without media, got nil")
 	}
@@ -330,7 +331,7 @@ func TestClaudeProvider_ConvertImageMissingDataSource(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToClaudeMultimodal(msg)
+	_, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for image without data source, got nil")
 	}
@@ -517,7 +518,7 @@ func TestClaudeProvider_MixedMultimodal(t *testing.T) {
 		},
 	}
 
-	claudeMsg, err := provider.convertMessageToClaudeMultimodal(msg)
+	claudeMsg, err := provider.convertMessageToClaudeMultimodal(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert mixed multimodal message: %v", err)
 	}
@@ -591,7 +592,7 @@ func TestClaudeProvider_ConvertPartsToClaudeBlocks(t *testing.T) {
 		types.NewTextPart("Valid text"),
 	}
 
-	blocks, err := provider.convertPartsToClaudeBlocks(parts)
+	blocks, err := provider.convertPartsToClaudeBlocks(context.Background(), parts)
 	if err != nil {
 		t.Fatalf("Failed to convert parts: %v", err)
 	}
@@ -606,7 +607,7 @@ func TestClaudeProvider_ConvertPartsToClaudeBlocks(t *testing.T) {
 		{Type: "unsupported-type"},
 	}
 
-	_, err = provider.convertPartsToClaudeBlocks(unsupportedParts)
+	_, err = provider.convertPartsToClaudeBlocks(context.Background(), unsupportedParts)
 	if err == nil {
 		t.Error("Expected error for unsupported content type")
 	}
@@ -631,7 +632,7 @@ func TestClaudeProvider_ConvertImagePartToClaude_FilePath(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertImagePartToClaude(part)
+	_, err := provider.convertImagePartToClaude(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for nonexistent file path")
 	}
@@ -735,7 +736,7 @@ func testClaudeProvider() *Provider {
 func TestConvertDocumentPartToClaude_NilMedia(t *testing.T) {
 	provider := testClaudeProvider()
 	part := types.ContentPart{Type: types.ContentTypeDocument}
-	_, err := provider.convertDocumentPartToClaude(part)
+	_, err := provider.convertDocumentPartToClaude(context.Background(), part)
 	if err == nil {
 		t.Error("expected error for nil media")
 	}
@@ -749,7 +750,7 @@ func TestConvertDocumentPartToClaude_UnsupportedType(t *testing.T) {
 			MIMEType: "application/msword",
 		},
 	}
-	_, err := provider.convertDocumentPartToClaude(part)
+	_, err := provider.convertDocumentPartToClaude(context.Background(), part)
 	if err == nil {
 		t.Error("expected error for non-PDF document")
 	}
@@ -768,7 +769,7 @@ func TestConvertDocumentPartToClaude_PDF(t *testing.T) {
 			Data:     &data,
 		},
 	}
-	block, err := provider.convertDocumentPartToClaude(part)
+	block, err := provider.convertDocumentPartToClaude(context.Background(), part)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/runtime/providers/claude/claude_storageref_test.go
+++ b/runtime/providers/claude/claude_storageref_test.go
@@ -1,0 +1,70 @@
+package claude
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// refStore is a fake MediaStorageService that returns a canned URL and/or bytes
+// so the Claude conversion path can be exercised without a real backend.
+type refStore struct{ url, bytes string }
+
+func (s refStore) StoreMedia(context.Context, *types.MediaContent, *storage.MediaMetadata) (storage.Reference, error) {
+	return "", nil
+}
+
+func (s refStore) RetrieveMedia(context.Context, storage.Reference) (*types.MediaContent, error) {
+	d := s.bytes
+	return &types.MediaContent{Data: &d, MIMEType: "image/png"}, nil
+}
+
+func (s refStore) DeleteMedia(context.Context, storage.Reference) error { return nil }
+
+func (s refStore) GetURL(context.Context, storage.Reference, time.Duration) (string, error) {
+	return s.url, nil
+}
+
+// TestClaude_ImageStorageRef_UsesURL asserts a StorageReference image resolves to
+// a model-fetchable URL (URL-first) rather than inlined bytes.
+func TestClaude_ImageStorageRef_UsesURL(t *testing.T) {
+	p := testClaudeProvider()
+	p.SetMediaStorageService(refStore{url: "https://s3/img?sig=1"})
+
+	part := types.NewImagePartFromStorageRef("s3://b/k", types.MIMETypeImagePNG, nil)
+	block, err := p.convertImagePartToClaude(context.Background(), part)
+	if err != nil {
+		t.Fatalf("convertImagePartToClaude returned error: %v", err)
+	}
+	if block.Source.Type != "url" {
+		t.Fatalf("expected source type url, got %q", block.Source.Type)
+	}
+	if block.Source.URL != "https://s3/img?sig=1" {
+		t.Errorf("expected presigned URL, got %q", block.Source.URL)
+	}
+}
+
+// TestClaude_DocumentStorageRef_UsesBytes asserts a StorageReference document
+// falls back to base64 bytes, since Claude documents do not support URL sources.
+func TestClaude_DocumentStorageRef_UsesBytes(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("PDFBYTES"))
+	p := testClaudeProvider()
+	p.SetMediaStorageService(refStore{bytes: encoded})
+
+	part := types.NewDocumentPartFromStorageRef("s3://b/doc", types.MIMETypePDF)
+	block, err := p.convertDocumentPartToClaude(context.Background(), part)
+	if err != nil {
+		t.Fatalf("convertDocumentPartToClaude returned error: %v", err)
+	}
+	if block.Source.Type != "base64" {
+		t.Fatalf("expected source type base64, got %q", block.Source.Type)
+	}
+	if !strings.Contains(block.Source.Data, encoded) {
+		t.Errorf("expected data to contain %q, got %q", encoded, block.Source.Data)
+	}
+}

--- a/runtime/providers/claude/claude_streaming.go
+++ b/runtime/providers/claude/claude_streaming.go
@@ -36,7 +36,7 @@ func (p *Provider) PredictStream(
 	// Build the canonical request via the shared base builder, then layer on the
 	// streaming deltas. PredictStream is the no-tools path, so it honors
 	// output_config with no tool-use conflict to guard against.
-	messages := p.convertMessagesToClaudeFormat(req.Messages)
+	messages := p.convertMessagesToClaudeFormat(ctx, req.Messages)
 	claudeReq := p.buildBaseRequest(req, messages)
 	claudeReq.OutputConfig = outputConfigFor(req.ResponseFormat)
 	claudeReq.Stream = true

--- a/runtime/providers/claude/claude_tool_results_test.go
+++ b/runtime/providers/claude/claude_tool_results_test.go
@@ -290,7 +290,7 @@ func TestProcessClaudeToolResult_UsesToolResultContent(t *testing.T) {
 	}
 
 	// Process the tool result
-	result := processClaudeToolResult(toolResultMsg)
+	result := testClaudeProvider().processClaudeToolResult(context.Background(), toolResultMsg)
 
 	// Verify the result uses ToolResult text content as a plain string
 	contentStr, ok := result.Content.(string)
@@ -325,7 +325,7 @@ func TestProcessClaudeToolResult_MultimodalImageResult(t *testing.T) {
 		},
 	}
 
-	result := processClaudeToolResult(msg)
+	result := testClaudeProvider().processClaudeToolResult(context.Background(), msg)
 
 	if result.ToolUseID != "toolu_img_123" {
 		t.Errorf("Expected ToolUseID 'toolu_img_123', got '%s'", result.ToolUseID)
@@ -398,7 +398,7 @@ func TestProcessClaudeToolResult_DocumentResult(t *testing.T) {
 		},
 	}
 
-	result := processClaudeToolResult(msg)
+	result := testClaudeProvider().processClaudeToolResult(context.Background(), msg)
 
 	blocks, ok := result.Content.([]interface{})
 	if !ok {
@@ -447,7 +447,7 @@ func TestProcessClaudeToolResult_TextOnlyRegression(t *testing.T) {
 		}(),
 	}
 
-	result := processClaudeToolResult(msg)
+	result := testClaudeProvider().processClaudeToolResult(context.Background(), msg)
 
 	// Should be a plain string, not an array
 	contentStr, ok := result.Content.(string)
@@ -489,7 +489,7 @@ func TestProcessClaudeToolResult_ImageWithURL(t *testing.T) {
 		},
 	}
 
-	result := processClaudeToolResult(msg)
+	result := testClaudeProvider().processClaudeToolResult(context.Background(), msg)
 
 	blocks, ok := result.Content.([]interface{})
 	if !ok {

--- a/runtime/providers/claude/claude_tools.go
+++ b/runtime/providers/claude/claude_tools.go
@@ -122,7 +122,7 @@ func (p *ToolProvider) PredictWithTools(
 	start := time.Now()
 
 	// Build Claude request with tools
-	claudeReq := p.buildToolRequest(req, tools, toolChoice)
+	claudeReq := p.buildToolRequest(ctx, req, tools, toolChoice)
 
 	// Prepare response with raw request if configured (set early to preserve on error)
 	predictResp := providers.PredictionResponse{}
@@ -149,7 +149,7 @@ func (p *ToolProvider) PredictWithTools(
 // For multimodal results (containing images, documents, etc.), content is an array of content blocks.
 //
 //nolint:gocritic // hugeParam: types.Message is part of established API
-func processClaudeToolResult(msg types.Message) claudeToolResult {
+func (p *Provider) processClaudeToolResult(ctx context.Context, msg types.Message) claudeToolResult {
 	result := claudeToolResult{
 		Type:      "tool_result",
 		ToolUseID: msg.ToolResult.ID,
@@ -157,7 +157,7 @@ func processClaudeToolResult(msg types.Message) claudeToolResult {
 
 	// If the tool result has media parts, serialize as an array of content blocks
 	if msg.ToolResult.HasMedia() {
-		result.Content = buildToolResultContentBlocks(msg.ToolResult.Parts)
+		result.Content = p.buildToolResultContentBlocks(ctx, msg.ToolResult.Parts)
 		return result
 	}
 
@@ -168,10 +168,10 @@ func processClaudeToolResult(msg types.Message) claudeToolResult {
 
 // buildToolResultContentBlocks converts tool result parts to Claude content block array.
 // Each part is converted independently via convertToolResultPart.
-func buildToolResultContentBlocks(parts []types.ContentPart) []interface{} {
+func (p *Provider) buildToolResultContentBlocks(ctx context.Context, parts []types.ContentPart) []interface{} {
 	blocks := make([]interface{}, 0, len(parts))
 	for _, part := range parts {
-		if block := convertToolResultPart(part); block != nil {
+		if block := p.convertToolResultPart(ctx, part); block != nil {
 			blocks = append(blocks, block)
 		}
 	}
@@ -180,7 +180,7 @@ func buildToolResultContentBlocks(parts []types.ContentPart) []interface{} {
 
 // convertToolResultPart converts a single content part to a Claude content block.
 // Returns nil if the part cannot be converted.
-func convertToolResultPart(part types.ContentPart) interface{} {
+func (p *Provider) convertToolResultPart(ctx context.Context, part types.ContentPart) interface{} {
 	switch part.Type {
 	case types.ContentTypeText:
 		if part.Text != nil && *part.Text != "" {
@@ -188,18 +188,20 @@ func convertToolResultPart(part types.ContentPart) interface{} {
 		}
 	case types.ContentTypeImage:
 		if part.Media != nil {
-			return buildToolResultMediaBlock("image", part)
+			return p.buildToolResultMediaBlock(ctx, "image", part)
 		}
 	case types.ContentTypeDocument:
 		if part.Media != nil {
-			return buildToolResultMediaBlock("document", part)
+			return p.buildToolResultMediaBlock(ctx, "document", part)
 		}
 	}
 	return nil
 }
 
 // buildToolResultMediaBlock creates a Claude media content block (image or document).
-func buildToolResultMediaBlock(blockType string, part types.ContentPart) interface{} {
+func (p *Provider) buildToolResultMediaBlock(
+	ctx context.Context, blockType string, part types.ContentPart,
+) interface{} {
 	block := claudeContentBlockMultimodal{
 		Type: blockType,
 		Source: &claudeImageSource{
@@ -214,9 +216,8 @@ func buildToolResultMediaBlock(blockType string, part types.ContentPart) interfa
 		return block
 	}
 
-	// Use MediaLoader for base64 data (supports Data, FilePath, StorageReference)
-	loader := providers.NewMediaLoader(providers.MediaLoaderConfig{})
-	data, err := loader.GetBase64Data(context.Background(), part.Media)
+	// Use the store-aware MediaLoader for base64 data (Data, FilePath, StorageReference)
+	data, err := p.MediaLoader().GetBase64Data(ctx, part.Media)
 	if err != nil {
 		return nil
 	}
@@ -229,6 +230,7 @@ func buildToolResultMediaBlock(blockType string, part types.ContentPart) interfa
 //
 //nolint:gocritic // hugeParam: types.Message is part of established API
 func (p *ToolProvider) buildClaudeMessageContent(
+	ctx context.Context,
 	msg types.Message,
 	pendingToolResults []claudeToolResult,
 ) []interface{} {
@@ -242,7 +244,7 @@ func (p *ToolProvider) buildClaudeMessageContent(
 	}
 
 	// Add message content (text and/or media)
-	content = append(content, p.buildMessageContentBlocks(msg)...)
+	content = append(content, p.buildMessageContentBlocks(ctx, msg)...)
 
 	// Add tool calls if this is an assistant message
 	if msg.Role == roleAssistant && len(msg.ToolCalls) > 0 {
@@ -266,11 +268,11 @@ func (p *ToolProvider) buildClaudeMessageContent(
 // This is extracted to reduce cognitive complexity of buildClaudeMessageContent.
 //
 //nolint:gocritic // hugeParam: types.Message is part of established API
-func (p *ToolProvider) buildMessageContentBlocks(msg types.Message) []interface{} {
+func (p *ToolProvider) buildMessageContentBlocks(ctx context.Context, msg types.Message) []interface{} {
 	// Check if message has multimodal content (images, etc.)
 	if msg.HasMediaContent() {
 		// Use multimodal conversion path
-		blocks, err := p.convertPartsToClaudeBlocks(msg.Parts)
+		blocks, err := p.convertPartsToClaudeBlocks(ctx, msg.Parts)
 		if err == nil {
 			return blocks
 		}
@@ -326,6 +328,7 @@ func flushPendingToolResults(pendingToolResults []claudeToolResult) claudeToolMe
 
 // processMessageForTools processes a single message and manages tool results
 func (p *ToolProvider) processMessageForTools(
+	ctx context.Context,
 	msg types.Message,
 	pendingToolResults []claudeToolResult,
 	messages []claudeToolMessage,
@@ -337,7 +340,7 @@ func (p *ToolProvider) processMessageForTools(
 		pendingToolResults = nil
 	}
 
-	content := p.buildClaudeMessageContent(msg, pendingToolResults)
+	content := p.buildClaudeMessageContent(ctx, msg, pendingToolResults)
 	if msg.Role == roleUser {
 		pendingToolResults = nil
 	}
@@ -396,18 +399,20 @@ func markLastBlockCacheable(messages []claudeToolMessage) {
 }
 
 //nolint:gocritic // hugeParam: providers.PredictionRequest is passed by value across the provider interface
-func (p *ToolProvider) buildToolRequest(req providers.PredictionRequest, tools any, toolChoice string) claudeRequest {
+func (p *ToolProvider) buildToolRequest(
+	ctx context.Context, req providers.PredictionRequest, tools any, toolChoice string,
+) claudeRequest {
 	messages := make([]claudeToolMessage, 0, len(req.Messages))
 	var pendingToolResults []claudeToolResult
 
 	for i := range req.Messages {
 		msg := &req.Messages[i]
 		if msg.Role == roleTool {
-			pendingToolResults = append(pendingToolResults, processClaudeToolResult(*msg))
+			pendingToolResults = append(pendingToolResults, p.processClaudeToolResult(ctx, *msg))
 			continue
 		}
 
-		messages, pendingToolResults = p.processMessageForTools(*msg, pendingToolResults, messages, tools)
+		messages, pendingToolResults = p.processMessageForTools(ctx, *msg, pendingToolResults, messages, tools)
 	}
 
 	// If there are still pending tool results at the end, add them as a final user message
@@ -670,7 +675,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 	toolChoice string,
 ) (<-chan providers.StreamChunk, error) {
 	// Build Claude request with tools
-	claudeReq := p.buildToolRequest(req, tools, toolChoice)
+	claudeReq := p.buildToolRequest(ctx, req, tools, toolChoice)
 
 	// Add streaming flag
 	claudeReq.Stream = true

--- a/runtime/providers/claude/claude_tools_test.go
+++ b/runtime/providers/claude/claude_tools_test.go
@@ -732,7 +732,7 @@ func TestClaudeToolProvider_BuildToolRequest_AppliesDefaults(t *testing.T) {
 				Messages:    []types.Message{{Role: "user", Content: "Hello"}},
 			}
 
-			request := provider.buildToolRequest(req, nil, "")
+			request := provider.buildToolRequest(context.Background(), req, nil, "")
 
 			if request.Temperature != tt.expectedTemp {
 				t.Errorf("Expected temperature %.2f, got %v", tt.expectedTemp, request.Temperature)

--- a/runtime/providers/claude/request_golden_test.go
+++ b/runtime/providers/claude/request_golden_test.go
@@ -149,7 +149,7 @@ func TestUnifiedBuilder_OmitsZeroTemperature(t *testing.T) {
 	tools, _ := tp.BuildTooling([]*providers.ToolDescriptor{
 		{Name: "Bash", Description: "run", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	})
-	body, err := json.Marshal(tp.buildToolRequest(req, tools, ""))
+	body, err := json.Marshal(tp.buildToolRequest(context.Background(), req, tools, ""))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}

--- a/runtime/providers/claude/unsupported_params_test.go
+++ b/runtime/providers/claude/unsupported_params_test.go
@@ -124,7 +124,7 @@ func TestUnsupportedParams_TemperatureOmitted(t *testing.T) {
 			t.Fatalf("expected *ToolProvider, got %T", provider)
 		}
 
-		request := tp.buildToolRequest(providers.PredictionRequest{
+		request := tp.buildToolRequest(context.Background(), providers.PredictionRequest{
 			Messages:    []types.Message{{Role: "user", Content: "hi"}},
 			Temperature: 0.1,
 			MaxTokens:   100,

--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -323,52 +323,40 @@ type geminiSafetyRating struct {
 //
 // For messages with actual media content (images, audio, video), each part is
 // converted separately using the multimodal conversion functions.
-func convertMessagesToGeminiContents(messages []types.Message) []geminiContent {
+func (p *Provider) convertMessagesToGeminiContents(ctx context.Context, messages []types.Message) []geminiContent {
 	contents := make([]geminiContent, 0, len(messages))
 	for i := range messages {
-		role := messages[i].Role
-		// Gemini uses "user" and "model" roles
-		if role == roleAssistant {
-			role = roleModel
-		}
-
-		// Check if this message has actual media content (images, audio, video).
-		// We use HasMediaContent() rather than IsMultimodal() because IsMultimodal()
-		// returns true even for text-only messages that use Parts (SDK-style).
-		// For text-only messages, we want to combine all text into a single part.
-		if messages[i].HasMediaContent() {
-			// Convert multimodal parts using the shared conversion functions
-			var parts []geminiPart
-			conversionFailed := false
-			for _, part := range messages[i].Parts {
-				gPart, err := convertPartToGemini(part)
-				if err != nil {
-					// Fall back to text-only on conversion error
-					conversionFailed = true
-					break
-				}
-				parts = append(parts, gPart)
-			}
-			if conversionFailed {
-				contents = append(contents, geminiContent{
-					Role:  role,
-					Parts: []geminiPart{{Text: messages[i].GetContent()}},
-				})
-			} else {
-				contents = append(contents, geminiContent{
-					Role:  role,
-					Parts: parts,
-				})
-			}
-		} else {
-			// Text-only message (legacy or SDK-style with only text parts)
-			contents = append(contents, geminiContent{
-				Role:  role,
-				Parts: []geminiPart{{Text: messages[i].GetContent()}},
-			})
-		}
+		contents = append(contents, p.geminiContentForMessage(ctx, &messages[i]))
 	}
 	return contents
+}
+
+// geminiContentForMessage converts a single provider message to Gemini content.
+// Messages with actual media (images, audio, video) convert each part; text-only
+// messages combine all text via GetContent(). We use HasMediaContent() rather
+// than IsMultimodal() because IsMultimodal() is true even for text-only Parts
+// (SDK-style). On any per-part conversion error we fall back to text-only.
+func (p *Provider) geminiContentForMessage(ctx context.Context, msg *types.Message) geminiContent {
+	role := msg.Role
+	// Gemini uses "user" and "model" roles
+	if role == roleAssistant {
+		role = roleModel
+	}
+
+	if !msg.HasMediaContent() {
+		return geminiContent{Role: role, Parts: []geminiPart{{Text: msg.GetContent()}}}
+	}
+
+	parts := make([]geminiPart, 0, len(msg.Parts))
+	for _, part := range msg.Parts {
+		gPart, err := p.convertPartToGemini(ctx, part)
+		if err != nil {
+			// Fall back to text-only on conversion error
+			return geminiContent{Role: role, Parts: []geminiPart{{Text: msg.GetContent()}}}
+		}
+		parts = append(parts, gPart)
+	}
+	return geminiContent{Role: role, Parts: parts}
 }
 
 // applyRequestDefaults applies provider defaults to zero-valued request parameters
@@ -392,7 +380,7 @@ func (p *Provider) applyRequestDefaults(req providers.PredictionRequest) (temper
 }
 
 // prepareGeminiRequest converts a predict request to Gemini format with defaults applied
-func (p *Provider) prepareGeminiRequest(req providers.PredictionRequest) (
+func (p *Provider) prepareGeminiRequest(ctx context.Context, req providers.PredictionRequest) (
 	contents []geminiContent,
 	systemInstruction *geminiContent,
 	temperature, topP float32,
@@ -406,7 +394,7 @@ func (p *Provider) prepareGeminiRequest(req providers.PredictionRequest) (
 	}
 
 	// Convert conversation messages
-	contents = convertMessagesToGeminiContents(req.Messages)
+	contents = p.convertMessagesToGeminiContents(ctx, req.Messages)
 
 	// Apply defaults using the shared method
 	temperature, topP, maxTokens = p.applyRequestDefaults(req)
@@ -654,7 +642,7 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 	start := time.Now()
 
 	// Convert messages to Gemini format and apply defaults
-	contents, systemInstruction, temperature, topP, maxTokens := p.prepareGeminiRequest(req)
+	contents, systemInstruction, temperature, topP, maxTokens := p.prepareGeminiRequest(ctx, req)
 
 	// Create request
 	geminiReq := p.buildGeminiRequest(contents, systemInstruction, temperature, topP, maxTokens)

--- a/runtime/providers/gemini/gemini_helpers_test.go
+++ b/runtime/providers/gemini/gemini_helpers_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"context"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -55,7 +56,7 @@ func TestConvertMessagesToGeminiContents(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			contents := convertMessagesToGeminiContents(tt.messages)
+			contents := convProvider().convertMessagesToGeminiContents(context.Background(), tt.messages)
 
 			if len(contents) != tt.expected {
 				t.Errorf("Expected %d contents, got %d", tt.expected, len(contents))
@@ -171,7 +172,7 @@ func TestPrepareGeminiRequest(t *testing.T) {
 				defaults: tt.defaults,
 			}
 
-			contents, systemInstruction, temp, topP, maxTokens := provider.prepareGeminiRequest(tt.req)
+			contents, systemInstruction, temp, topP, maxTokens := provider.prepareGeminiRequest(context.Background(), tt.req)
 
 			// Check contents
 			if len(contents) != len(tt.req.Messages) {
@@ -321,7 +322,7 @@ func TestGeminiHelpers_Integration(t *testing.T) {
 		}
 
 		// Step 1: Prepare request
-		contents, systemInstruction, temp, topP, maxTokens := provider.prepareGeminiRequest(req)
+		contents, systemInstruction, temp, topP, maxTokens := provider.prepareGeminiRequest(context.Background(), req)
 
 		if len(contents) != 3 {
 			t.Errorf("Expected 3 contents, got %d", len(contents))

--- a/runtime/providers/gemini/gemini_multimodal.go
+++ b/runtime/providers/gemini/gemini_multimodal.go
@@ -76,8 +76,15 @@ func (p *Provider) GetMultimodalCapabilities() providers.MultimodalCapabilities 
 }
 
 // convertMessagesToGemini converts PromptKit messages to Gemini format
-// Handles both legacy text-only and new multimodal messages
-func convertMessagesToGemini(messages []types.Message, systemPrompt string) (contents []geminiContent, systemInstruction *geminiContent, err error) {
+// Handles both legacy text-only and new multimodal messages.
+//
+// Exercised only by tests (the live path uses convertMessagesToGeminiContents);
+// the unused linter runs with tests:false so it cannot see those callers.
+//
+//nolint:unused // covered by unit tests; linter is configured with tests:false
+func (p *Provider) convertMessagesToGemini(
+	ctx context.Context, messages []types.Message, systemPrompt string,
+) (contents []geminiContent, systemInstruction *geminiContent, err error) {
 	// Handle system message
 	if systemPrompt != "" {
 		systemInstruction = &geminiContent{
@@ -86,7 +93,7 @@ func convertMessagesToGemini(messages []types.Message, systemPrompt string) (con
 	}
 
 	for i := range messages {
-		content, err := convertMessageToGemini(messages[i])
+		content, err := p.convertMessageToGemini(ctx, messages[i])
 		if err != nil {
 			return nil, nil, err
 		}
@@ -96,8 +103,10 @@ func convertMessagesToGemini(messages []types.Message, systemPrompt string) (con
 	return contents, systemInstruction, nil
 }
 
-// convertMessageToGemini converts a single PromptKit message to Gemini format
-func convertMessageToGemini(msg types.Message) (geminiContent, error) {
+// convertMessageToGemini converts a single PromptKit message to Gemini format.
+//
+//nolint:unused // covered by unit tests; linter is configured with tests:false
+func (p *Provider) convertMessageToGemini(ctx context.Context, msg types.Message) (geminiContent, error) {
 	// Handle legacy text-only messages
 	if !msg.IsMultimodal() {
 		role := msg.Role
@@ -119,7 +128,7 @@ func convertMessageToGemini(msg types.Message) (geminiContent, error) {
 
 	var parts []geminiPart
 	for _, part := range msg.Parts {
-		gPart, err := convertPartToGemini(part)
+		gPart, err := p.convertPartToGemini(ctx, part)
 		if err != nil {
 			return geminiContent{}, err
 		}
@@ -133,7 +142,7 @@ func convertMessageToGemini(msg types.Message) (geminiContent, error) {
 }
 
 // convertPartToGemini converts a ContentPart to Gemini's format
-func convertPartToGemini(part types.ContentPart) (geminiPart, error) {
+func (p *Provider) convertPartToGemini(ctx context.Context, part types.ContentPart) (geminiPart, error) {
 	switch part.Type {
 	case types.ContentTypeText:
 		if part.Text == nil || *part.Text == "" {
@@ -142,7 +151,7 @@ func convertPartToGemini(part types.ContentPart) (geminiPart, error) {
 		return geminiPart{Text: *part.Text}, nil
 
 	case types.ContentTypeImage, types.ContentTypeAudio, types.ContentTypeVideo, types.ContentTypeDocument:
-		return convertMediaPartToGemini(part)
+		return p.convertMediaPartToGemini(ctx, part)
 
 	default:
 		return geminiPart{}, fmt.Errorf("unsupported part type: %s", part.Type)
@@ -150,7 +159,7 @@ func convertPartToGemini(part types.ContentPart) (geminiPart, error) {
 }
 
 // convertMediaPartToGemini converts image/audio/video/document parts to Gemini format
-func convertMediaPartToGemini(part types.ContentPart) (geminiPart, error) {
+func (p *Provider) convertMediaPartToGemini(ctx context.Context, part types.ContentPart) (geminiPart, error) {
 	if part.Media == nil {
 		return geminiPart{}, fmt.Errorf("%s part missing media field", part.Type)
 	}
@@ -161,9 +170,9 @@ func convertMediaPartToGemini(part types.ContentPart) (geminiPart, error) {
 		return geminiPart{}, fmt.Errorf("%s part missing mime_type", part.Type)
 	}
 
-	// Use MediaLoader to get base64 data from any source (Data, FilePath, URL, StorageReference)
-	loader := providers.NewMediaLoader(providers.MediaLoaderConfig{})
-	base64Data, err := loader.GetBase64Data(context.Background(), part.Media)
+	// Use the provider's store-aware MediaLoader to get base64 data from any
+	// source (Data, FilePath, URL, StorageReference).
+	base64Data, err := p.MediaLoader().GetBase64Data(ctx, part.Media)
 	if err != nil {
 		return geminiPart{}, fmt.Errorf("failed to load %s data: %w", part.Type, err)
 	}

--- a/runtime/providers/gemini/gemini_multimodal_edge_cases_test.go
+++ b/runtime/providers/gemini/gemini_multimodal_edge_cases_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -132,7 +133,7 @@ func TestGeminiProvider_ConvertMediaPartToGemini_URLError(t *testing.T) {
 		},
 	}
 
-	_, err := convertMediaPartToGemini(part)
+	_, err := convProvider().convertMediaPartToGemini(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for unreachable URL")
 	}
@@ -153,7 +154,7 @@ func TestGeminiProvider_ConvertMediaPartToGemini_MissingMIMEType(t *testing.T) {
 		},
 	}
 
-	_, err := convertMediaPartToGemini(part)
+	_, err := convProvider().convertMediaPartToGemini(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for missing MIME type")
 	}
@@ -168,7 +169,7 @@ func TestGeminiProvider_ConvertMediaPartToGemini_MissingDataSource(t *testing.T)
 		},
 	}
 
-	_, err := convertMediaPartToGemini(part)
+	_, err := convProvider().convertMediaPartToGemini(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for missing data source")
 	}
@@ -181,7 +182,7 @@ func TestGeminiProvider_ConvertPartToGemini_EmptyText(t *testing.T) {
 		Text: &emptyText,
 	}
 
-	_, err := convertPartToGemini(part)
+	_, err := convProvider().convertPartToGemini(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for empty text")
 	}
@@ -193,7 +194,7 @@ func TestGeminiProvider_ConvertPartToGemini_NilText(t *testing.T) {
 		Text: nil,
 	}
 
-	_, err := convertPartToGemini(part)
+	_, err := convProvider().convertPartToGemini(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for nil text")
 	}
@@ -204,7 +205,7 @@ func TestGeminiProvider_ConvertPartToGemini_UnsupportedType(t *testing.T) {
 		Type: "unsupported-type",
 	}
 
-	_, err := convertPartToGemini(part)
+	_, err := convProvider().convertPartToGemini(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for unsupported part type")
 	}
@@ -216,7 +217,7 @@ func TestGeminiProvider_ConvertMediaPartToGemini_MissingMedia(t *testing.T) {
 		Media: nil,
 	}
 
-	_, err := convertMediaPartToGemini(part)
+	_, err := convProvider().convertMediaPartToGemini(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for missing media")
 	}
@@ -232,7 +233,7 @@ func TestGeminiProvider_ConvertMediaPartToGemini_FilePathError(t *testing.T) {
 		},
 	}
 
-	_, err := convertMediaPartToGemini(part)
+	_, err := convProvider().convertMediaPartToGemini(context.Background(), part)
 	if err == nil {
 		t.Error("Expected error for nonexistent file path")
 	}
@@ -288,7 +289,7 @@ func TestGeminiProvider_ConvertMessagesToGemini_EmptySystem(t *testing.T) {
 		},
 	}
 
-	contents, sysInst, err := convertMessagesToGemini(messages, "")
+	contents, sysInst, err := convProvider().convertMessagesToGemini(context.Background(), messages, "")
 	if err != nil {
 		t.Fatalf("Failed to convert messages: %v", err)
 	}
@@ -309,7 +310,7 @@ func TestGeminiProvider_ConvertMessageToGemini_RoleConversion(t *testing.T) {
 		Content: "I can help",
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert: %v", err)
 	}

--- a/runtime/providers/gemini/gemini_multimodal_test.go
+++ b/runtime/providers/gemini/gemini_multimodal_test.go
@@ -57,7 +57,7 @@ func TestGeminiProvider_ConvertLegacyMessage(t *testing.T) {
 		Content: "Hello, world!",
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert legacy message: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestGeminiProvider_ConvertAssistantRole(t *testing.T) {
 		Content: "I can help!",
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestGeminiProvider_ConvertTextOnlyMultimodalMessage(t *testing.T) {
 		},
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestGeminiProvider_ConvertImageBase64Message(t *testing.T) {
 		},
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestGeminiProvider_ConvertMultipleImages(t *testing.T) {
 		},
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert message: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestGeminiProvider_ConvertImageURLReturnsError(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for URL-based images (Gemini doesn't support URLs)")
 	}
@@ -244,7 +244,7 @@ func TestGeminiProvider_ConvertEmptyTextPart(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for empty text part")
 	}
@@ -258,7 +258,7 @@ func TestGeminiProvider_ConvertImageMissingMedia(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for image without media")
 	}
@@ -278,7 +278,7 @@ func TestGeminiProvider_ConvertImageMissingDataSource(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for image without data source")
 	}
@@ -411,7 +411,7 @@ func TestGeminiProvider_ConvertMessagesToGemini(t *testing.T) {
 		},
 	}
 
-	contents, sysInst, err := convertMessagesToGemini(messages, "You are helpful")
+	contents, sysInst, err := convProvider().convertMessagesToGemini(context.Background(), messages, "You are helpful")
 	if err != nil {
 		t.Fatalf("Failed to convert messages: %v", err)
 	}
@@ -459,7 +459,7 @@ func TestGeminiProvider_AudioSupport(t *testing.T) {
 		},
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert audio message: %v", err)
 	}
@@ -492,7 +492,7 @@ func TestGeminiProvider_VideoSupport(t *testing.T) {
 		},
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert video message: %v", err)
 	}
@@ -536,7 +536,7 @@ func TestGeminiProvider_MixedMultimodal(t *testing.T) {
 		},
 	}
 
-	converted, err := convertMessageToGemini(msg)
+	converted, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert mixed multimodal message: %v", err)
 	}
@@ -698,7 +698,7 @@ func TestConvertImageMissingMIMEType(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing mime_type")
 }
@@ -714,7 +714,7 @@ func TestConvertUnsupportedPartType(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported part type")
 }
@@ -731,7 +731,7 @@ func TestConvertNilTextPart(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty text")
 }
@@ -753,7 +753,7 @@ func TestConvertMediaURLNotSupported(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	// MediaLoader now fetches URLs, so we expect connection error
 	assert.Contains(t, err.Error(), "failed to load image data")
@@ -774,7 +774,7 @@ func TestConvertMediaMissingDataSource(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no media source available")
 }
@@ -791,7 +791,7 @@ func TestConvertMediaMissingMediaField(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing media field")
 }
@@ -1006,7 +1006,7 @@ func TestConvertMessagesToGemini_WithSystemPrompt(t *testing.T) {
 		{Role: "user", Content: "Hello"},
 	}
 
-	contents, systemInstruction, err := convertMessagesToGemini(messages, "You are helpful")
+	contents, systemInstruction, err := convProvider().convertMessagesToGemini(context.Background(), messages, "You are helpful")
 	require.NoError(t, err)
 	require.NotNil(t, systemInstruction)
 	assert.Equal(t, "You are helpful", systemInstruction.Parts[0].Text)
@@ -1024,7 +1024,7 @@ func TestConvertMessagesToGemini_ConversionError(t *testing.T) {
 		},
 	}
 
-	_, _, err := convertMessagesToGemini(messages, "")
+	_, _, err := convProvider().convertMessagesToGemini(context.Background(), messages, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported part type")
 }
@@ -1063,7 +1063,7 @@ func TestConvertEmptyTextString(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty text")
 }
@@ -1084,7 +1084,7 @@ func TestConvertAudioPartWithFilePath(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read file")
 }
@@ -1105,7 +1105,7 @@ func TestConvertVideoPartWithFilePath(t *testing.T) {
 		},
 	}
 
-	_, err := convertMessageToGemini(msg)
+	_, err := convProvider().convertMessageToGemini(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read file")
 }

--- a/runtime/providers/gemini/gemini_storageref_test.go
+++ b/runtime/providers/gemini/gemini_storageref_test.go
@@ -1,0 +1,101 @@
+package gemini
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// refStore is a minimal MediaStorageService that resolves any storage reference
+// to a fixed base64 payload, letting tests assert that Gemini's conversion path
+// routes StorageReference media through the injected store.
+type refStore struct{ bytes string }
+
+func (s refStore) StoreMedia(
+	context.Context, *types.MediaContent, *storage.MediaMetadata,
+) (storage.Reference, error) {
+	return "", nil
+}
+
+func (s refStore) RetrieveMedia(context.Context, storage.Reference) (*types.MediaContent, error) {
+	d := s.bytes
+	return &types.MediaContent{Data: &d, MIMEType: "image/png"}, nil
+}
+
+func (s refStore) DeleteMedia(context.Context, storage.Reference) error { return nil }
+
+func (s refStore) GetURL(context.Context, storage.Reference, time.Duration) (string, error) {
+	return "", nil
+}
+
+// convProvider returns a bare Gemini provider for exercising the (now-method)
+// conversion helpers in tests.
+func convProvider() *Provider {
+	return NewProvider("test", "gemini-1.5-flash", "https://test.com", providers.ProviderDefaults{}, false)
+}
+
+func TestGeminiConvertMediaPart_ResolvesStorageReference(t *testing.T) {
+	want := base64.StdEncoding.EncodeToString([]byte("IMGBYTES"))
+
+	p := convProvider()
+	p.SetMediaStorageService(refStore{bytes: want})
+
+	ref := "s3://b/k"
+	part := types.ContentPart{
+		Type: types.ContentTypeImage,
+		Media: &types.MediaContent{
+			StorageReference: &ref,
+			MIMEType:         "image/png",
+		},
+	}
+
+	got, err := p.convertMediaPartToGemini(context.Background(), part)
+	if err != nil {
+		t.Fatalf("convertMediaPartToGemini returned error: %v", err)
+	}
+	if got.InlineData == nil {
+		t.Fatalf("expected inline data on converted part, got nil")
+	}
+	if got.InlineData.Data != want {
+		t.Errorf("inline data mismatch: got %q, want %q", got.InlineData.Data, want)
+	}
+	if got.InlineData.MimeType != "image/png" {
+		t.Errorf("mime type mismatch: got %q, want image/png", got.InlineData.MimeType)
+	}
+}
+
+// TestGeminiToolPath_ResolvesStorageReference verifies the tool-request media
+// builder (convertMediaPartToMap) also routes StorageReference through the store,
+// fixing the prior bug where only Data/URL were handled.
+func TestGeminiToolPath_ResolvesStorageReference(t *testing.T) {
+	want := base64.StdEncoding.EncodeToString([]byte("IMGBYTES"))
+
+	p := convProvider()
+	p.SetMediaStorageService(refStore{bytes: want})
+
+	ref := "s3://b/k"
+	part := types.ContentPart{
+		Type: types.ContentTypeImage,
+		Media: &types.MediaContent{
+			StorageReference: &ref,
+			MIMEType:         "image/png",
+		},
+	}
+
+	got := p.convertMediaPartToMap(context.Background(), part)
+	if got == nil {
+		t.Fatalf("convertMediaPartToMap returned nil for storage-reference media")
+	}
+	inline, ok := got["inlineData"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inlineData map, got %#v", got)
+	}
+	if inline["data"] != want {
+		t.Errorf("inline data mismatch: got %v, want %q", inline["data"], want)
+	}
+}

--- a/runtime/providers/gemini/gemini_streaming.go
+++ b/runtime/providers/gemini/gemini_streaming.go
@@ -27,7 +27,7 @@ func (p *Provider) PredictStream(
 	})
 
 	// Convert messages to Gemini format and apply defaults
-	contents, systemInstruction, temperature, topP, maxTokens := p.prepareGeminiRequest(req)
+	contents, systemInstruction, temperature, topP, maxTokens := p.prepareGeminiRequest(ctx, req)
 
 	// Create streaming request
 	geminiReq := p.buildGeminiRequest(contents, systemInstruction, temperature, topP, maxTokens)

--- a/runtime/providers/gemini/gemini_test.go
+++ b/runtime/providers/gemini/gemini_test.go
@@ -564,7 +564,7 @@ func TestConvertMessagesToGeminiContents_WithParts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			msg := tt.setup()
-			contents := convertMessagesToGeminiContents([]types.Message{msg})
+			contents := convProvider().convertMessagesToGeminiContents(context.Background(), []types.Message{msg})
 
 			if len(contents) != 1 {
 				t.Fatalf("Expected 1 content, got %d", len(contents))

--- a/runtime/providers/gemini/gemini_tool_helpers_test.go
+++ b/runtime/providers/gemini/gemini_tool_helpers_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -74,7 +75,7 @@ func TestProcessToolMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := processToolMessage(tt.msg)
+			result := convProvider().processToolMessage(context.Background(), tt.msg)
 
 			// Check structure
 			if result == nil {
@@ -215,7 +216,7 @@ func TestBuildMessageParts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parts := buildMessageParts(tt.msg, tt.pendingToolResults)
+			parts := convProvider().buildMessageParts(context.Background(), tt.msg, tt.pendingToolResults)
 
 			if len(parts) < tt.expectedMinParts {
 				t.Errorf("Expected at least %d parts, got %d", tt.expectedMinParts, len(parts))
@@ -361,7 +362,7 @@ func TestGeminiToolHelpers_Integration(t *testing.T) {
 			Role:    "user",
 			Content: "What's the weather?",
 		}
-		userParts := buildMessageParts(userMsg, nil)
+		userParts := convProvider().buildMessageParts(context.Background(), userMsg, nil)
 		if len(userParts) != 1 {
 			t.Errorf("Expected 1 part for user message, got %d", len(userParts))
 		}
@@ -378,7 +379,7 @@ func TestGeminiToolHelpers_Integration(t *testing.T) {
 				},
 			},
 		}
-		assistantParts := buildMessageParts(assistantMsg, nil)
+		assistantParts := convProvider().buildMessageParts(context.Background(), assistantMsg, nil)
 		if len(assistantParts) != 2 {
 			t.Errorf("Expected 2 parts (text + tool call), got %d", len(assistantParts))
 		}
@@ -392,7 +393,7 @@ func TestGeminiToolHelpers_Integration(t *testing.T) {
 				ID:   "call_123",
 			},
 		}
-		toolResponse := processToolMessage(toolMsg)
+		toolResponse := convProvider().processToolMessage(context.Background(), toolMsg)
 		if toolResponse == nil {
 			t.Fatal("Expected non-nil tool response")
 		}
@@ -403,7 +404,7 @@ func TestGeminiToolHelpers_Integration(t *testing.T) {
 			Content: "Thanks!",
 		}
 		pendingResults := []map[string]interface{}{toolResponse}
-		followUpParts := buildMessageParts(followUpMsg, pendingResults)
+		followUpParts := convProvider().buildMessageParts(context.Background(), followUpMsg, pendingResults)
 		if len(followUpParts) != 2 {
 			t.Errorf("Expected 2 parts (tool result + text), got %d", len(followUpParts))
 		}
@@ -441,7 +442,7 @@ func TestBuildMessageParts_ThoughtSignatureRoundTrip(t *testing.T) {
 		},
 	}
 
-	parts := buildMessageParts(msg, nil)
+	parts := convProvider().buildMessageParts(context.Background(), msg, nil)
 	if len(parts) == 0 {
 		t.Fatal("expected at least one part")
 	}
@@ -490,7 +491,7 @@ func TestBuildMessageParts_NoThoughtSignature(t *testing.T) {
 		},
 	}
 
-	parts := buildMessageParts(msg, nil)
+	parts := convProvider().buildMessageParts(context.Background(), msg, nil)
 	for _, p := range parts {
 		if pm, ok := p.(map[string]any); ok {
 			if _, hasFC := pm["functionCall"]; hasFC {

--- a/runtime/providers/gemini/gemini_tool_results_test.go
+++ b/runtime/providers/gemini/gemini_tool_results_test.go
@@ -311,7 +311,7 @@ func TestProcessToolMessage_TextOnly(t *testing.T) {
 		},
 	}
 
-	result := processToolMessage(msg)
+	result := convProvider().processToolMessage(context.Background(), msg)
 	funcResp, ok := result["functionResponse"].(map[string]any)
 	if !ok {
 		t.Fatalf("Expected functionResponse map, got %T", result["functionResponse"])
@@ -362,7 +362,7 @@ func TestProcessToolMessage_ImagePart(t *testing.T) {
 		},
 	}
 
-	result := processToolMessage(msg)
+	result := convProvider().processToolMessage(context.Background(), msg)
 	funcResp := result["functionResponse"].(map[string]any)
 
 	if funcResp["name"] != "generate_chart" {
@@ -415,7 +415,7 @@ func TestProcessToolMessage_MixedContent(t *testing.T) {
 		},
 	}
 
-	result := processToolMessage(msg)
+	result := convProvider().processToolMessage(context.Background(), msg)
 	funcResp := result["functionResponse"].(map[string]any)
 	response := funcResp["response"].(map[string]any)
 
@@ -450,7 +450,7 @@ func TestProcessToolMessage_ImageOnlyNoText(t *testing.T) {
 		},
 	}
 
-	result := processToolMessage(msg)
+	result := convProvider().processToolMessage(context.Background(), msg)
 	funcResp := result["functionResponse"].(map[string]any)
 	response := funcResp["response"].(map[string]any)
 
@@ -523,7 +523,7 @@ func TestBuildMultimodalToolResponse(t *testing.T) {
 		},
 	}
 
-	response := buildMultimodalToolResponse(result)
+	response := convProvider().buildMultimodalToolResponse(context.Background(), result)
 
 	if response["text"] != "Image ready" {
 		t.Errorf("Expected text 'Image ready', got '%v'", response["text"])
@@ -561,7 +561,7 @@ func TestProcessToolMessage_UsesToolResultContent(t *testing.T) {
 	}
 
 	// Process the tool message
-	result := processToolMessage(toolResultMsg)
+	result := convProvider().processToolMessage(context.Background(), toolResultMsg)
 
 	// Verify the result has functionResponse
 	funcResponse, ok := result["functionResponse"].(map[string]interface{})

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -165,7 +165,7 @@ func (p *ToolProvider) PredictWithTools(
 // with text and inlineData entries per Gemini's multimodal function response format.
 //
 //nolint:gocritic // hugeParam: types.Message is part of established API
-func processToolMessage(msg types.Message) map[string]any {
+func (p *Provider) processToolMessage(ctx context.Context, msg types.Message) map[string]any {
 	// Debug: log tool message details
 	logger.Debug("Processing tool message",
 		"name", msg.ToolResult.Name,
@@ -179,7 +179,7 @@ func processToolMessage(msg types.Message) map[string]any {
 	var response any
 
 	if msg.ToolResult.HasMedia() {
-		response = buildMultimodalToolResponse(msg.ToolResult)
+		response = p.buildMultimodalToolResponse(ctx, msg.ToolResult)
 	} else {
 		response = buildTextToolResponse(msg.ToolResult.GetTextContent())
 	}
@@ -218,13 +218,15 @@ func buildTextToolResponse(content string) any {
 //	  "text": "Chart generated successfully",
 //	  "inlineData": { "mimeType": "image/png", "data": "..." }
 //	}
-func buildMultimodalToolResponse(result *types.MessageToolResult) map[string]any {
+func (p *Provider) buildMultimodalToolResponse(
+	ctx context.Context, result *types.MessageToolResult,
+) map[string]any {
 	response := make(map[string]any)
 
 	// Collect text content from all text parts
 	textContent := result.GetTextContent()
 	if textContent != "" {
-		response["text"] = textContent
+		response[wireKeyText] = textContent
 	}
 
 	// Find the first media part and add it as inlineData.
@@ -233,7 +235,7 @@ func buildMultimodalToolResponse(result *types.MessageToolResult) map[string]any
 		if part.Type == types.ContentTypeText || part.Media == nil {
 			continue
 		}
-		mediaMap := convertMediaPartToMap(part)
+		mediaMap := p.convertMediaPartToMap(ctx, part)
 		if mediaMap != nil {
 			// mediaMap is {"inlineData": {"mimeType": ..., "data": ...}}
 			if inlineData, ok := mediaMap["inlineData"]; ok {
@@ -249,7 +251,9 @@ func buildMultimodalToolResponse(result *types.MessageToolResult) map[string]any
 // buildMessageParts creates parts array for a message including text, images, and tool calls
 //
 //nolint:gocritic // hugeParam: types.Message is part of established API
-func buildMessageParts(msg types.Message, pendingToolResults []map[string]any) []any {
+func (p *Provider) buildMessageParts(
+	ctx context.Context, msg types.Message, pendingToolResults []map[string]any,
+) []any {
 	parts := make([]any, 0)
 
 	// Add pending tool results first if this is a user message
@@ -261,61 +265,70 @@ func buildMessageParts(msg types.Message, pendingToolResults []map[string]any) [
 
 	// Check if message has multimodal content (images, etc.)
 	if msg.HasMediaContent() {
-		// Process each part including images
-		for _, part := range msg.Parts {
-			switch part.Type {
-			case types.ContentTypeText:
-				if part.Text != nil && *part.Text != "" {
-					parts = append(parts, map[string]any{
-						"text": *part.Text,
-					})
-				}
-			case types.ContentTypeImage, types.ContentTypeAudio, types.ContentTypeVideo, types.ContentTypeDocument:
-				if part.Media != nil {
-					mediaMap := convertMediaPartToMap(part)
-					if mediaMap != nil {
-						parts = append(parts, mediaMap)
-					}
-				}
-			}
-		}
-	} else {
-		// Add text content - use GetContent() to properly handle both Content field and Parts
-		textContent := msg.GetContent()
-		if textContent != "" {
-			parts = append(parts, map[string]any{
-				"text": textContent,
-			})
-		}
+		parts = append(parts, p.mediaContentParts(ctx, msg.Parts)...)
+	} else if textContent := msg.GetContent(); textContent != "" {
+		// Text content - use GetContent() to handle both Content field and Parts
+		parts = append(parts, map[string]any{wireKeyText: textContent})
 	}
 
 	// Add tool calls if this is a model message
-	if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
-		for _, toolCall := range msg.ToolCalls {
-			var args any
-			if err := json.Unmarshal(toolCall.Args, &args); err != nil {
-				args = string(toolCall.Args)
-			}
-			partMap := map[string]any{
-				"functionCall": map[string]any{
-					"name": toolCall.Name,
-					"args": args,
-				},
-			}
-			// Replay Gemini 3's thoughtSignature verbatim. Gemini 2.x ignores
-			// unknown part fields, so emitting it unconditionally is safe.
-			if sig := toolCall.ProviderMetadata[providerMetaThoughtSignature]; sig != "" {
-				partMap["thoughtSignature"] = sig
-			}
-			parts = append(parts, partMap)
-		}
+	if msg.Role == roleAssistant && len(msg.ToolCalls) > 0 {
+		parts = append(parts, toolCallParts(msg.ToolCalls)...)
 	}
 
 	return parts
 }
 
-// convertMediaPartToMap converts a media ContentPart to Gemini's inline_data format
-func convertMediaPartToMap(part types.ContentPart) map[string]any {
+// mediaContentParts converts a multimodal message's parts into Gemini part maps,
+// emitting text entries for text parts and inlineData for resolved media parts.
+func (p *Provider) mediaContentParts(ctx context.Context, msgParts []types.ContentPart) []any {
+	parts := make([]any, 0, len(msgParts))
+	for _, part := range msgParts {
+		switch part.Type {
+		case types.ContentTypeText:
+			if part.Text != nil && *part.Text != "" {
+				parts = append(parts, map[string]any{wireKeyText: *part.Text})
+			}
+		case types.ContentTypeImage, types.ContentTypeAudio, types.ContentTypeVideo, types.ContentTypeDocument:
+			if part.Media != nil {
+				if mediaMap := p.convertMediaPartToMap(ctx, part); mediaMap != nil {
+					parts = append(parts, mediaMap)
+				}
+			}
+		}
+	}
+	return parts
+}
+
+// toolCallParts converts an assistant message's tool calls into Gemini
+// functionCall part maps, replaying any Gemini 3 thoughtSignature verbatim.
+func toolCallParts(toolCalls []types.MessageToolCall) []any {
+	parts := make([]any, 0, len(toolCalls))
+	for _, toolCall := range toolCalls {
+		var args any
+		if err := json.Unmarshal(toolCall.Args, &args); err != nil {
+			args = string(toolCall.Args)
+		}
+		partMap := map[string]any{
+			"functionCall": map[string]any{
+				"name": toolCall.Name,
+				"args": args,
+			},
+		}
+		// Gemini 2.x ignores unknown part fields, so emitting it unconditionally is safe.
+		if sig := toolCall.ProviderMetadata[providerMetaThoughtSignature]; sig != "" {
+			partMap["thoughtSignature"] = sig
+		}
+		parts = append(parts, partMap)
+	}
+	return parts
+}
+
+// convertMediaPartToMap converts a media ContentPart to Gemini's inline_data format.
+// All media sources (Data, StorageReference, FilePath, URL) are resolved through
+// the provider's store-aware MediaLoader so externalized media (e.g. an S3
+// StorageReference) is fetched and inlined as base64 like any other source.
+func (p *Provider) convertMediaPartToMap(ctx context.Context, part types.ContentPart) map[string]any {
 	if part.Media == nil {
 		return nil
 	}
@@ -338,20 +351,10 @@ func convertMediaPartToMap(part types.ContentPart) map[string]any {
 		}
 	}
 
-	// Get base64 data - try Data field first, then URL
-	var base64Data string
-	if part.Media.Data != nil && *part.Media.Data != "" {
-		base64Data = *part.Media.Data
-	} else if part.Media.URL != nil && *part.Media.URL != "" {
-		// For URL-based media, use the MediaLoader
-		loader := providers.NewMediaLoader(providers.MediaLoaderConfig{})
-		data, err := loader.GetBase64Data(context.Background(), part.Media)
-		if err != nil {
-			logger.Warn("Failed to load media from URL", "url", *part.Media.URL, "error", err)
-			return nil
-		}
-		base64Data = data
-	} else {
+	// Resolve base64 data from any source via the store-aware MediaLoader.
+	base64Data, err := p.MediaLoader().GetBase64Data(ctx, part.Media)
+	if err != nil {
+		logger.Warn("Failed to load media for Gemini tool request", "mime_type", mimeType, "error", err)
 		return nil
 	}
 
@@ -398,7 +401,7 @@ func (p *ToolProvider) buildToolRequest(
 
 	for i := range req.Messages {
 		if req.Messages[i].Role == "tool" {
-			pendingToolResults = append(pendingToolResults, processToolMessage(req.Messages[i]))
+			pendingToolResults = append(pendingToolResults, p.processToolMessage(ctx, req.Messages[i]))
 			continue
 		}
 
@@ -411,7 +414,7 @@ func (p *ToolProvider) buildToolRequest(
 			pendingToolResults = nil
 		}
 
-		parts := buildMessageParts(req.Messages[i], pendingToolResults)
+		parts := p.buildMessageParts(ctx, req.Messages[i], pendingToolResults)
 		if req.Messages[i].Role == roleUser {
 			pendingToolResults = nil
 		}
@@ -458,7 +461,7 @@ func (p *ToolProvider) buildToolRequest(
 	if req.System != "" {
 		request["systemInstruction"] = map[string]any{
 			"parts": []any{
-				map[string]any{"text": req.System},
+				map[string]any{wireKeyText: req.System},
 			},
 		}
 	}

--- a/runtime/providers/gemini/gemini_tools_edge_cases_test.go
+++ b/runtime/providers/gemini/gemini_tools_edge_cases_test.go
@@ -16,7 +16,7 @@ func TestToolProvider_BuildMessageParts_EmptyToolResults(t *testing.T) {
 		Parts: []types.ContentPart{types.NewTextPart("Hello")},
 	}
 
-	parts := buildMessageParts(msg, []map[string]interface{}{})
+	parts := convProvider().buildMessageParts(context.Background(), msg, []map[string]interface{}{})
 	if len(parts) != 1 {
 		t.Errorf("Expected 1 part, got %d", len(parts))
 	}
@@ -37,7 +37,7 @@ func TestToolProvider_BuildMessageParts_WithToolResults(t *testing.T) {
 		},
 	}
 
-	parts := buildMessageParts(msg, toolResults)
+	parts := convProvider().buildMessageParts(context.Background(), msg, toolResults)
 	// Should have tool result + text
 	if len(parts) != 2 {
 		t.Errorf("Expected 2 parts (tool result + text), got %d", len(parts))
@@ -58,7 +58,7 @@ func TestToolProvider_BuildMessageParts_WithToolCalls(t *testing.T) {
 		},
 	}
 
-	parts := buildMessageParts(msg, []map[string]interface{}{})
+	parts := convProvider().buildMessageParts(context.Background(), msg, []map[string]interface{}{})
 	// Should have text + function call
 	if len(parts) < 2 {
 		t.Errorf("Expected at least 2 parts (text + function call), got %d", len(parts))
@@ -77,7 +77,7 @@ func TestToolProvider_ProcessToolMessage_EmptyName(t *testing.T) {
 		},
 	}
 
-	result := processToolMessage(msg)
+	result := convProvider().processToolMessage(context.Background(), msg)
 
 	// Should still return a valid structure even with empty name
 	if result == nil {
@@ -106,7 +106,7 @@ func TestToolProvider_ProcessToolMessage_StringContent(t *testing.T) {
 		},
 	}
 
-	result := processToolMessage(msg)
+	result := convProvider().processToolMessage(context.Background(), msg)
 	funcResp := result["functionResponse"].(map[string]interface{})
 	response := funcResp["response"].(map[string]interface{})
 
@@ -127,7 +127,7 @@ func TestToolProvider_ProcessToolMessage_PrimitiveContent(t *testing.T) {
 		},
 	}
 
-	result := processToolMessage(msg)
+	result := convProvider().processToolMessage(context.Background(), msg)
 	funcResp := result["functionResponse"].(map[string]interface{})
 	response := funcResp["response"].(map[string]interface{})
 

--- a/runtime/providers/gemini/gemini_tools_test.go
+++ b/runtime/providers/gemini/gemini_tools_test.go
@@ -624,7 +624,7 @@ func TestGeminiToolProvider_ParseToolResponse_NoCandidates(t *testing.T) {
 func TestConvertMediaPartToMap(t *testing.T) {
 	t.Run("nil media", func(t *testing.T) {
 		part := types.ContentPart{Type: types.ContentTypeImage}
-		result := convertMediaPartToMap(part)
+		result := convProvider().convertMediaPartToMap(context.Background(), part)
 		if result != nil {
 			t.Errorf("expected nil for nil media, got %v", result)
 		}
@@ -639,7 +639,7 @@ func TestConvertMediaPartToMap(t *testing.T) {
 				Data:     &data,
 			},
 		}
-		result := convertMediaPartToMap(part)
+		result := convProvider().convertMediaPartToMap(context.Background(), part)
 		if result == nil {
 			t.Fatal("expected non-nil result")
 		}
@@ -658,7 +658,7 @@ func TestConvertMediaPartToMap(t *testing.T) {
 			Type:  types.ContentTypeImage,
 			Media: &types.MediaContent{Data: &data},
 		}
-		result := convertMediaPartToMap(part)
+		result := convProvider().convertMediaPartToMap(context.Background(), part)
 		if result == nil {
 			t.Fatal("expected non-nil result")
 		}
@@ -674,7 +674,7 @@ func TestConvertMediaPartToMap(t *testing.T) {
 			Type:  types.ContentTypeAudio,
 			Media: &types.MediaContent{Data: &data},
 		}
-		result := convertMediaPartToMap(part)
+		result := convProvider().convertMediaPartToMap(context.Background(), part)
 		if result == nil {
 			t.Fatal("expected non-nil result")
 		}
@@ -690,7 +690,7 @@ func TestConvertMediaPartToMap(t *testing.T) {
 			Type:  types.ContentTypeVideo,
 			Media: &types.MediaContent{Data: &data},
 		}
-		result := convertMediaPartToMap(part)
+		result := convProvider().convertMediaPartToMap(context.Background(), part)
 		if result == nil {
 			t.Fatal("expected non-nil result")
 		}
@@ -706,7 +706,7 @@ func TestConvertMediaPartToMap(t *testing.T) {
 			Type:  types.ContentTypeDocument,
 			Media: &types.MediaContent{Data: &data},
 		}
-		result := convertMediaPartToMap(part)
+		result := convProvider().convertMediaPartToMap(context.Background(), part)
 		if result == nil {
 			t.Fatal("expected non-nil result")
 		}
@@ -721,7 +721,7 @@ func TestConvertMediaPartToMap(t *testing.T) {
 			Type:  "unknown",
 			Media: &types.MediaContent{},
 		}
-		result := convertMediaPartToMap(part)
+		result := convProvider().convertMediaPartToMap(context.Background(), part)
 		if result != nil {
 			t.Errorf("expected nil for unknown type, got %v", result)
 		}
@@ -732,7 +732,7 @@ func TestConvertMediaPartToMap(t *testing.T) {
 			Type:  types.ContentTypeImage,
 			Media: &types.MediaContent{MIMEType: "image/png"},
 		}
-		result := convertMediaPartToMap(part)
+		result := convProvider().convertMediaPartToMap(context.Background(), part)
 		if result != nil {
 			t.Errorf("expected nil for no data, got %v", result)
 		}
@@ -755,7 +755,7 @@ func TestBuildMessageParts_MultimodalContent(t *testing.T) {
 			},
 		},
 	}
-	parts := buildMessageParts(msg, nil)
+	parts := convProvider().buildMessageParts(context.Background(), msg, nil)
 	if len(parts) != 2 {
 		t.Fatalf("expected 2 parts, got %d", len(parts))
 	}

--- a/runtime/providers/media_loader.go
+++ b/runtime/providers/media_loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -123,6 +124,44 @@ func (ml *MediaLoader) GetBase64Data(ctx context.Context, media *types.MediaCont
 	}
 
 	return "", fmt.Errorf("no media source available (data, storage_reference, file_path, or url)")
+}
+
+// ResolveURL returns a URL a provider can hand to the model when the media can
+// be represented as one. ok is false when the source cannot be a fetchable URL
+// (inline data, local file path, a non-remote storage URL such as file://, or a
+// storage reference with no store configured); callers then fall back to
+// GetBase64Data. URL expiry/caching is entirely the store's concern — we pass 0
+// so the store chooses its own policy.
+func (ml *MediaLoader) ResolveURL(ctx context.Context, media *types.MediaContent) (string, bool, error) {
+	if media == nil {
+		return "", false, nil
+	}
+	if media.URL != nil && *media.URL != "" {
+		return *media.URL, true, nil
+	}
+	if media.StorageReference != nil && *media.StorageReference != "" {
+		if ml.storageService == nil {
+			return "", false, nil
+		}
+		u, err := ml.storageService.GetURL(ctx, storage.Reference(*media.StorageReference), 0)
+		if err != nil {
+			return "", false, fmt.Errorf("failed to resolve storage reference %s to URL: %w", *media.StorageReference, err)
+		}
+		if isRemoteURL(u) {
+			return u, true, nil
+		}
+		return "", false, nil
+	}
+	return "", false, nil
+}
+
+// isRemoteURL reports whether raw is an http(s) URL the provider's model can fetch.
+func isRemoteURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "http" || u.Scheme == "https"
 }
 
 // trackSize adds rawSize to the aggregate tracker and returns an error if the

--- a/runtime/providers/media_loader_resolveurl_test.go
+++ b/runtime/providers/media_loader_resolveurl_test.go
@@ -1,0 +1,67 @@
+package providers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// resolveURLFakeStore is a minimal MediaStorageService for tests in this package.
+// GetURL returns url/err; RetrieveMedia returns bytes as inline Data when set.
+type resolveURLFakeStore struct {
+	url   string
+	err   error
+	bytes string // base64; returned by RetrieveMedia when non-empty
+}
+
+func (f resolveURLFakeStore) StoreMedia(context.Context, *types.MediaContent, *storage.MediaMetadata) (storage.Reference, error) {
+	return "", nil
+}
+
+func (f resolveURLFakeStore) RetrieveMedia(context.Context, storage.Reference) (*types.MediaContent, error) {
+	d := f.bytes
+	return &types.MediaContent{Data: &d, MIMEType: "image/png"}, nil
+}
+
+func (f resolveURLFakeStore) DeleteMedia(context.Context, storage.Reference) error { return nil }
+
+func (f resolveURLFakeStore) GetURL(context.Context, storage.Reference, time.Duration) (string, error) {
+	return f.url, f.err
+}
+
+func TestResolveURL(t *testing.T) {
+	ref := "s3://bucket/key"
+	explicit := "https://cdn.example.com/a.png"
+	cases := []struct {
+		name    string
+		loader  *MediaLoader
+		media   *types.MediaContent
+		wantURL string
+		wantOK  bool
+	}{
+		{"explicit url passthrough", NewMediaLoader(MediaLoaderConfig{}),
+			&types.MediaContent{URL: &explicit, MIMEType: "image/png"}, explicit, true},
+		{"remote storage ref", NewMediaLoader(MediaLoaderConfig{StorageService: resolveURLFakeStore{url: "https://s3/x?sig=1"}}),
+			&types.MediaContent{StorageReference: &ref, MIMEType: "image/png"}, "https://s3/x?sig=1", true},
+		{"local file:// ref falls back", NewMediaLoader(MediaLoaderConfig{StorageService: resolveURLFakeStore{url: "file:///tmp/x.png"}}),
+			&types.MediaContent{StorageReference: &ref, MIMEType: "image/png"}, "", false},
+		{"storage ref without store", NewMediaLoader(MediaLoaderConfig{}),
+			&types.MediaContent{StorageReference: &ref, MIMEType: "image/png"}, "", false},
+		{"inline data not url-able", NewMediaLoader(MediaLoaderConfig{}),
+			&types.MediaContent{Data: stringPtr("abc"), MIMEType: "image/png"}, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			url, ok, err := tc.loader.ResolveURL(context.Background(), tc.media)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if ok != tc.wantOK || url != tc.wantURL {
+				t.Fatalf("got (%q,%v), want (%q,%v)", url, ok, tc.wantURL, tc.wantOK)
+			}
+		})
+	}
+}

--- a/runtime/providers/ollama/ollama.go
+++ b/runtime/providers/ollama/ollama.go
@@ -118,7 +118,9 @@ type ollamaError struct {
 }
 
 // prepareMessages converts predict request messages to Ollama format with system message
-func (p *Provider) prepareMessages(req providers.PredictionRequest) ([]ollamaMessage, error) {
+func (p *Provider) prepareMessages(
+	ctx context.Context, req providers.PredictionRequest,
+) ([]ollamaMessage, error) {
 	messages := make([]ollamaMessage, 0, len(req.Messages)+1)
 	if req.System != "" {
 		messages = append(messages, ollamaMessage{
@@ -129,7 +131,7 @@ func (p *Provider) prepareMessages(req providers.PredictionRequest) ([]ollamaMes
 
 	// Convert each message, handling both legacy text and multimodal Parts
 	for i := range req.Messages {
-		converted, err := p.convertMessageToOllama(&req.Messages[i])
+		converted, err := p.convertMessageToOllama(ctx, &req.Messages[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert message: %w", err)
 		}
@@ -167,7 +169,7 @@ func (p *Provider) Predict(
 	req providers.PredictionRequest,
 ) (providers.PredictionResponse, error) {
 	// Convert messages to Ollama format
-	messages, err := p.prepareMessages(req)
+	messages, err := p.prepareMessages(ctx, req)
 	if err != nil {
 		return providers.PredictionResponse{}, fmt.Errorf("failed to prepare messages: %w", err)
 	}
@@ -192,7 +194,7 @@ func (p *Provider) PredictStream(
 	req providers.PredictionRequest,
 ) (<-chan providers.StreamChunk, error) {
 	// Convert messages to Ollama format
-	messages, err := p.prepareMessages(req)
+	messages, err := p.prepareMessages(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare messages: %w", err)
 	}

--- a/runtime/providers/ollama/ollama_multimodal.go
+++ b/runtime/providers/ollama/ollama_multimodal.go
@@ -30,33 +30,10 @@ func (p *Provider) GetMultimodalCapabilities() providers.MultimodalCapabilities 
 	}
 }
 
-// convertMessagesToOllama converts PromptKit messages to Ollama format
-// Handles both legacy text-only and new multimodal messages
-func (p *Provider) convertMessagesToOllama(req providers.PredictionRequest) ([]ollamaMessage, error) {
-	messages := make([]ollamaMessage, 0, len(req.Messages)+1)
-
-	// Add system message if present
-	if req.System != "" {
-		messages = append(messages, ollamaMessage{
-			Role:    "system",
-			Content: req.System,
-		})
-	}
-
-	// Convert each message
-	for i := range req.Messages {
-		converted, err := p.convertMessageToOllama(&req.Messages[i])
-		if err != nil {
-			return nil, err
-		}
-		messages = append(messages, converted)
-	}
-
-	return messages, nil
-}
-
 // convertMessageToOllama converts a single PromptKit message to Ollama format
-func (p *Provider) convertMessageToOllama(msg *types.Message) (ollamaMessage, error) {
+func (p *Provider) convertMessageToOllama(
+	ctx context.Context, msg *types.Message,
+) (ollamaMessage, error) {
 	// Handle legacy text-only messages
 	if !msg.IsMultimodal() {
 		return ollamaMessage{
@@ -84,7 +61,7 @@ func (p *Provider) convertMessageToOllama(msg *types.Message) (ollamaMessage, er
 				return ollamaMessage{}, fmt.Errorf("image part missing media content")
 			}
 
-			imagePart, err := p.convertImagePartToOllama(part)
+			imagePart, err := p.convertImagePartToOllama(ctx, part)
 			if err != nil {
 				return ollamaMessage{}, err
 			}
@@ -105,7 +82,9 @@ func (p *Provider) convertMessageToOllama(msg *types.Message) (ollamaMessage, er
 }
 
 // convertImagePartToOllama converts an image ContentPart to Ollama's format
-func (p *Provider) convertImagePartToOllama(part types.ContentPart) (map[string]any, error) {
+func (p *Provider) convertImagePartToOllama(
+	ctx context.Context, part types.ContentPart,
+) (map[string]any, error) {
 	if part.Media == nil {
 		return nil, fmt.Errorf("image part missing media content")
 	}
@@ -116,19 +95,20 @@ func (p *Provider) convertImagePartToOllama(part types.ContentPart) (map[string]
 
 	imageURL := make(map[string]any)
 
-	// Handle different data sources
-	if part.Media.URL != nil && *part.Media.URL != "" {
-		// External URL - use directly
-		imageURL["url"] = *part.Media.URL
+	// Resolve to a URL when possible (external URL or storage reference), else
+	// fall back to inline base64 data. The MediaLoader is store-aware via the
+	// injected MediaStorageService.
+	loader := p.MediaLoader()
+	if url, ok, err := loader.ResolveURL(ctx, part.Media); err != nil {
+		return nil, fmt.Errorf("failed to resolve image: %w", err)
+	} else if ok {
+		imageURL["url"] = url
 	} else {
-		// Use MediaLoader for all other sources (Data, FilePath, StorageReference)
-		loader := providers.NewMediaLoader(providers.MediaLoaderConfig{})
-		data, err := loader.GetBase64Data(context.Background(), part.Media)
+		data, err := loader.GetBase64Data(ctx, part.Media)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load image data: %w", err)
 		}
-		dataURL := fmt.Sprintf("data:%s;base64,%s", part.Media.MIMEType, data)
-		imageURL["url"] = dataURL
+		imageURL["url"] = fmt.Sprintf("data:%s;base64,%s", part.Media.MIMEType, data)
 	}
 
 	// Add detail level if specified

--- a/runtime/providers/ollama/ollama_multimodal_test.go
+++ b/runtime/providers/ollama/ollama_multimodal_test.go
@@ -1,6 +1,7 @@
 package ollama
 
 import (
+	"context"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
@@ -52,7 +53,7 @@ func TestProvider_ConvertMessageToOllama_TextOnly(t *testing.T) {
 		Content: "Hello, world!",
 	}
 
-	result, err := provider.convertMessageToOllama(msg)
+	result, err := provider.convertMessageToOllama(context.Background(), msg)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -93,7 +94,7 @@ func TestProvider_ConvertMessageToOllama_Multimodal(t *testing.T) {
 		},
 	}
 
-	result, err := provider.convertMessageToOllama(msg)
+	result, err := provider.convertMessageToOllama(context.Background(), msg)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -127,7 +128,7 @@ func TestProvider_ConvertMessageToOllama_UnsupportedMedia(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToOllama(msg)
+	_, err := provider.convertMessageToOllama(context.Background(), msg)
 
 	if err == nil {
 		t.Error("Expected error for unsupported audio content")
@@ -148,7 +149,7 @@ func TestProvider_ConvertMessageToOllama_MissingMediaContent(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToOllama(msg)
+	_, err := provider.convertMessageToOllama(context.Background(), msg)
 
 	if err == nil {
 		t.Error("Expected error for missing media content")
@@ -171,7 +172,7 @@ func TestProvider_ConvertImagePartToOllama_URL(t *testing.T) {
 		},
 	}
 
-	result, err := provider.convertImagePartToOllama(part)
+	result, err := provider.convertImagePartToOllama(context.Background(), part)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -204,7 +205,7 @@ func TestProvider_ConvertImagePartToOllama_MissingMedia(t *testing.T) {
 		Media: nil,
 	}
 
-	_, err := provider.convertImagePartToOllama(part)
+	_, err := provider.convertImagePartToOllama(context.Background(), part)
 
 	if err == nil {
 		t.Error("Expected error for missing media")
@@ -224,7 +225,7 @@ func TestProvider_ConvertMessagesToOllama(t *testing.T) {
 		},
 	}
 
-	messages, err := provider.convertMessagesToOllama(req)
+	messages, err := provider.prepareMessages(context.Background(), req)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -258,7 +259,7 @@ func TestProvider_ConvertMessageToOllama_UnknownContentType(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToOllama(msg)
+	_, err := provider.convertMessageToOllama(context.Background(), msg)
 
 	if err == nil {
 		t.Error("Expected error for unknown content type")
@@ -279,7 +280,7 @@ func TestProvider_ConvertMessageToOllama_VideoUnsupported(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToOllama(msg)
+	_, err := provider.convertMessageToOllama(context.Background(), msg)
 
 	if err == nil {
 		t.Error("Expected error for unsupported video content")
@@ -304,7 +305,7 @@ func TestProvider_ConvertMessageToOllama_EmptyTextPart(t *testing.T) {
 		},
 	}
 
-	result, err := provider.convertMessageToOllama(msg)
+	result, err := provider.convertMessageToOllama(context.Background(), msg)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -335,7 +336,7 @@ func TestProvider_ConvertImagePartToOllama_Base64(t *testing.T) {
 		},
 	}
 
-	result, err := provider.convertImagePartToOllama(part)
+	result, err := provider.convertImagePartToOllama(context.Background(), part)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -367,7 +368,7 @@ func TestProvider_ConvertImagePartToOllama_MissingURLAndData(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertImagePartToOllama(part)
+	_, err := provider.convertImagePartToOllama(context.Background(), part)
 
 	if err == nil {
 		t.Error("Expected error for missing URL and data")

--- a/runtime/providers/ollama/ollama_storageref_test.go
+++ b/runtime/providers/ollama/ollama_storageref_test.go
@@ -1,0 +1,62 @@
+package ollama
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// refStore is a fake MediaStorageService that resolves any reference to a fixed
+// remote URL (and to fixed bytes on retrieval).
+type refStore struct{ url, bytes string }
+
+func (s refStore) StoreMedia(
+	context.Context, *types.MediaContent, *storage.MediaMetadata,
+) (storage.Reference, error) {
+	return "", nil
+}
+
+func (s refStore) RetrieveMedia(context.Context, storage.Reference) (*types.MediaContent, error) {
+	d := s.bytes
+	return &types.MediaContent{Data: &d, MIMEType: "image/png"}, nil
+}
+
+func (s refStore) DeleteMedia(context.Context, storage.Reference) error { return nil }
+
+func (s refStore) GetURL(context.Context, storage.Reference, time.Duration) (string, error) {
+	return s.url, nil
+}
+
+// TestOllama_ImageStorageRef_UsesURL asserts a StorageReference image is resolved
+// to a URL via the injected MediaStorageService (URL-first, no base64 fallback).
+func TestOllama_ImageStorageRef_UsesURL(t *testing.T) {
+	p := NewProvider("test", "llava", "http://localhost:11434",
+		providers.ProviderDefaults{}, false, nil)
+	p.SetMediaStorageService(refStore{url: "https://s3/img?sig=1"})
+
+	ref := "s3://b/k"
+	part := types.ContentPart{
+		Type: types.ContentTypeImage,
+		Media: &types.MediaContent{
+			StorageReference: &ref,
+			MIMEType:         "image/png",
+		},
+	}
+
+	result, err := p.convertImagePartToOllama(context.Background(), part)
+	if err != nil {
+		t.Fatalf("convertImagePartToOllama returned error: %v", err)
+	}
+
+	imageURL, ok := result["image_url"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected image_url to be map[string]any, got %T", result["image_url"])
+	}
+	if got := imageURL["url"]; got != "https://s3/img?sig=1" {
+		t.Errorf("expected resolved storage URL, got %v", got)
+	}
+}

--- a/runtime/providers/ollama/ollama_tools.go
+++ b/runtime/providers/ollama/ollama_tools.go
@@ -92,7 +92,7 @@ func (p *ToolProvider) PredictWithTools(
 	start := time.Now()
 
 	// Build Ollama request with tools
-	ollamaReq := p.buildToolRequest(req, tools, toolChoice)
+	ollamaReq := p.buildToolRequest(ctx, req, tools, toolChoice)
 
 	// Prepare response with raw request if configured (set early to preserve on error)
 	predictResp := providers.PredictionResponse{}
@@ -127,11 +127,12 @@ func (p *ToolProvider) PredictWithTools(
 
 // buildToolRequest constructs the Ollama API request with tools
 func (p *ToolProvider) buildToolRequest(
+	ctx context.Context,
 	req providers.PredictionRequest,
 	tools any,
 	toolChoice string,
 ) map[string]any {
-	messages := p.convertRequestMessagesToOllama(req)
+	messages := p.convertRequestMessagesToOllama(ctx, req)
 
 	// Apply defaults to zero-valued request parameters
 	temperature, topP, maxTokens := p.applyRequestDefaults(req)
@@ -164,7 +165,7 @@ func (p *ToolProvider) buildToolRequest(
 
 // convertRequestMessagesToOllama converts all messages in a request to Ollama format
 func (p *ToolProvider) convertRequestMessagesToOllama(
-	req providers.PredictionRequest,
+	ctx context.Context, req providers.PredictionRequest,
 ) []map[string]any {
 	messages := make([]map[string]any, 0, len(req.Messages)+1)
 
@@ -178,7 +179,7 @@ func (p *ToolProvider) convertRequestMessagesToOllama(
 
 	// Add conversation messages
 	for i := range req.Messages {
-		ollamaMsg := p.convertSingleMessageForTools(&req.Messages[i])
+		ollamaMsg := p.convertSingleMessageForTools(ctx, &req.Messages[i])
 		messages = append(messages, ollamaMsg)
 	}
 
@@ -186,9 +187,11 @@ func (p *ToolProvider) convertRequestMessagesToOllama(
 }
 
 // convertSingleMessageForTools converts a single message to Ollama format including tool metadata
-func (p *ToolProvider) convertSingleMessageForTools(msg *types.Message) map[string]any {
+func (p *ToolProvider) convertSingleMessageForTools(
+	ctx context.Context, msg *types.Message,
+) map[string]any {
 	// Convert message to Ollama format (handles both legacy and multimodal)
-	convertedMsg, err := p.convertMessageToOllama(msg)
+	convertedMsg, err := p.convertMessageToOllama(ctx, msg)
 	if err != nil {
 		// Log error but continue with best effort (use Content as fallback)
 		convertedMsg = ollamaMessage{
@@ -333,7 +336,7 @@ func (p *ToolProvider) PredictStreamWithTools(
 	})
 
 	// Build Ollama request with tools (same as non-streaming)
-	ollamaReq := p.buildToolRequest(req, tools, toolChoice)
+	ollamaReq := p.buildToolRequest(ctx, req, tools, toolChoice)
 
 	// Add streaming options
 	ollamaReq["stream"] = true

--- a/runtime/providers/ollama/ollama_tools_test.go
+++ b/runtime/providers/ollama/ollama_tools_test.go
@@ -315,7 +315,7 @@ func TestToolProvider_ConvertSingleMessageForTools(t *testing.T) {
 			Content: "Hello",
 		}
 
-		result := provider.convertSingleMessageForTools(msg)
+		result := provider.convertSingleMessageForTools(context.Background(), msg)
 
 		if result["role"] != "user" {
 			t.Error("Role mismatch")
@@ -333,7 +333,7 @@ func TestToolProvider_ConvertSingleMessageForTools(t *testing.T) {
 			},
 		}
 
-		result := provider.convertSingleMessageForTools(msg)
+		result := provider.convertSingleMessageForTools(context.Background(), msg)
 
 		if result["tool_calls"] == nil {
 			t.Error("Expected tool_calls in result")
@@ -348,7 +348,7 @@ func TestToolProvider_ConvertSingleMessageForTools(t *testing.T) {
 			ToolResult: &toolResult,
 		}
 
-		result := provider.convertSingleMessageForTools(msg)
+		result := provider.convertSingleMessageForTools(context.Background(), msg)
 
 		if result["tool_call_id"] != "call_1" {
 			t.Error("Expected tool_call_id")

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -555,7 +555,9 @@ type openAIError struct {
 }
 
 // prepareOpenAIMessages converts predict request messages to OpenAI format with system message
-func (p *Provider) prepareOpenAIMessages(req providers.PredictionRequest) ([]openAIMessage, error) {
+func (p *Provider) prepareOpenAIMessages(
+	ctx context.Context, req providers.PredictionRequest,
+) ([]openAIMessage, error) {
 	messages := make([]openAIMessage, 0, len(req.Messages)+1)
 	if req.System != "" {
 		messages = append(messages, openAIMessage{
@@ -566,7 +568,7 @@ func (p *Provider) prepareOpenAIMessages(req providers.PredictionRequest) ([]ope
 
 	// Convert each message, handling both legacy text and multimodal Parts
 	for i := range req.Messages {
-		converted, err := p.convertMessageToOpenAI(req.Messages[i])
+		converted, err := p.convertMessageToOpenAI(ctx, req.Messages[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert message: %w", err)
 		}
@@ -641,7 +643,7 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 	}
 
 	// Convert messages to OpenAI format
-	messages, err := p.prepareOpenAIMessages(req)
+	messages, err := p.prepareOpenAIMessages(ctx, req)
 	if err != nil {
 		return providers.PredictionResponse{}, fmt.Errorf("failed to prepare messages: %w", err)
 	}
@@ -726,7 +728,7 @@ func (p *Provider) PredictStream(ctx context.Context, req providers.PredictionRe
 	}
 
 	// Convert messages to OpenAI format
-	messages, err := p.prepareOpenAIMessages(req)
+	messages, err := p.prepareOpenAIMessages(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare messages: %w", err)
 	}

--- a/runtime/providers/openai/openai_helpers_test.go
+++ b/runtime/providers/openai/openai_helpers_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestPrepareOpenAIMessages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			messages, err := provider.prepareOpenAIMessages(tt.req)
+			messages, err := provider.prepareOpenAIMessages(context.Background(), tt.req)
 			if err != nil {
 				t.Fatalf("Failed to prepare messages: %v", err)
 			}
@@ -562,7 +563,7 @@ func TestOpenAIHelpers_Integration(t *testing.T) {
 		}
 
 		// Step 1: Prepare messages
-		messages, err := provider.prepareOpenAIMessages(req)
+		messages, err := provider.prepareOpenAIMessages(context.Background(), req)
 		if err != nil {
 			t.Fatalf("Failed to prepare messages: %v", err)
 		}

--- a/runtime/providers/openai/openai_multimodal.go
+++ b/runtime/providers/openai/openai_multimodal.go
@@ -62,33 +62,8 @@ func isAudioModel(model string) bool {
 	}
 }
 
-// convertMessagesToOpenAI converts PromptKit messages to OpenAI format
-// Handles both legacy text-only and new multimodal messages
-func (p *Provider) convertMessagesToOpenAI(req providers.PredictionRequest) ([]openAIMessage, error) {
-	messages := make([]openAIMessage, 0, len(req.Messages)+1)
-
-	// Add system message if present
-	if req.System != "" {
-		messages = append(messages, openAIMessage{
-			Role:    "system",
-			Content: req.System,
-		})
-	}
-
-	// Convert each message
-	for i := range req.Messages {
-		converted, err := p.convertMessageToOpenAI(req.Messages[i])
-		if err != nil {
-			return nil, err
-		}
-		messages = append(messages, converted)
-	}
-
-	return messages, nil
-}
-
 // convertMessageToOpenAI converts a single PromptKit message to OpenAI format
-func (p *Provider) convertMessageToOpenAI(msg types.Message) (openAIMessage, error) {
+func (p *Provider) convertMessageToOpenAI(ctx context.Context, msg types.Message) (openAIMessage, error) {
 	// Handle legacy text-only messages
 	if !msg.IsMultimodal() {
 		return openAIMessage{
@@ -100,47 +75,13 @@ func (p *Provider) convertMessageToOpenAI(msg types.Message) (openAIMessage, err
 	// Handle multimodal messages - OpenAI uses a different structure
 	// Content becomes an array of content parts
 	var contentParts []interface{}
-
 	for _, part := range msg.Parts {
-		switch part.Type {
-		case types.ContentTypeText:
-			if part.Text != nil && *part.Text != "" {
-				contentParts = append(contentParts, map[string]interface{}{
-					"type": "text",
-					"text": *part.Text,
-				})
-			}
-
-		case types.ContentTypeImage:
-			if part.Media == nil {
-				return openAIMessage{}, fmt.Errorf("image part missing media content")
-			}
-
-			imagePart, err := p.convertImagePartToOpenAI(part)
-			if err != nil {
-				return openAIMessage{}, err
-			}
-			contentParts = append(contentParts, imagePart)
-
-		case types.ContentTypeAudio:
-			// Audio is only supported for audio models using Chat Completions API
-			if p.apiMode != APIModeCompletions || !p.supportsAudioInput() {
-				return openAIMessage{}, fmt.Errorf("audio content requires audio model with Chat Completions API")
-			}
-			if part.Media == nil {
-				return openAIMessage{}, fmt.Errorf("audio part missing media content")
-			}
-			audioPart, err := p.convertAudioPartToOpenAI(part)
-			if err != nil {
-				return openAIMessage{}, err
-			}
-			contentParts = append(contentParts, audioPart)
-
-		case types.ContentTypeVideo:
-			return openAIMessage{}, fmt.Errorf("video content not supported by OpenAI API")
-
-		default:
-			return openAIMessage{}, fmt.Errorf("unknown content type: %s", part.Type)
+		element, err := p.convertContentPartToOpenAI(ctx, part)
+		if err != nil {
+			return openAIMessage{}, err
+		}
+		if element != nil {
+			contentParts = append(contentParts, element)
 		}
 	}
 
@@ -150,8 +91,47 @@ func (p *Provider) convertMessageToOpenAI(msg types.Message) (openAIMessage, err
 	}, nil
 }
 
+// convertContentPartToOpenAI converts a single multimodal content part to its
+// OpenAI representation. It returns (nil, nil) for parts that produce no output
+// (e.g. empty text) so callers skip them.
+func (p *Provider) convertContentPartToOpenAI(
+	ctx context.Context, part types.ContentPart,
+) (interface{}, error) {
+	switch part.Type {
+	case types.ContentTypeText:
+		if part.Text == nil || *part.Text == "" {
+			return nil, nil
+		}
+		return map[string]interface{}{keyType: partTypeText, partTypeText: *part.Text}, nil
+
+	case types.ContentTypeImage:
+		if part.Media == nil {
+			return nil, fmt.Errorf("image part missing media content")
+		}
+		return p.convertImagePartToOpenAI(ctx, part)
+
+	case types.ContentTypeAudio:
+		// Audio is only supported for audio models using Chat Completions API
+		if p.apiMode != APIModeCompletions || !p.supportsAudioInput() {
+			return nil, fmt.Errorf("audio content requires audio model with Chat Completions API")
+		}
+		if part.Media == nil {
+			return nil, fmt.Errorf("audio part missing media content")
+		}
+		return p.convertAudioPartToOpenAI(ctx, part)
+
+	case types.ContentTypeVideo:
+		return nil, fmt.Errorf("video content not supported by OpenAI API")
+
+	default:
+		return nil, fmt.Errorf("unknown content type: %s", part.Type)
+	}
+}
+
 // convertImagePartToOpenAI converts an image ContentPart to OpenAI's format
-func (p *Provider) convertImagePartToOpenAI(part types.ContentPart) (map[string]interface{}, error) {
+func (p *Provider) convertImagePartToOpenAI(
+	ctx context.Context, part types.ContentPart,
+) (map[string]interface{}, error) {
 	if part.Media == nil {
 		return nil, fmt.Errorf("image part missing media content")
 	}
@@ -162,19 +142,19 @@ func (p *Provider) convertImagePartToOpenAI(part types.ContentPart) (map[string]
 
 	imageURL := make(map[string]interface{})
 
-	// Handle different data sources
-	if part.Media.URL != nil && *part.Media.URL != "" {
-		// External URL - use directly
-		imageURL["url"] = *part.Media.URL
+	// Prefer a model-fetchable URL (external URL or storage reference resolved via
+	// the injected store); otherwise fall back to inline base64 bytes.
+	loader := p.MediaLoader()
+	if url, ok, err := loader.ResolveURL(ctx, part.Media); err != nil {
+		return nil, fmt.Errorf("failed to resolve image: %w", err)
+	} else if ok {
+		imageURL["url"] = url
 	} else {
-		// Use MediaLoader for all other sources (Data, FilePath, StorageReference)
-		loader := providers.NewMediaLoader(providers.MediaLoaderConfig{})
-		data, err := loader.GetBase64Data(context.Background(), part.Media)
+		data, err := loader.GetBase64Data(ctx, part.Media)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load image data: %w", err)
 		}
-		dataURL := fmt.Sprintf("data:%s;base64,%s", part.Media.MIMEType, data)
-		imageURL["url"] = dataURL
+		imageURL["url"] = fmt.Sprintf("data:%s;base64,%s", part.Media.MIMEType, data)
 	}
 
 	// Add detail level if specified
@@ -189,23 +169,18 @@ func (p *Provider) convertImagePartToOpenAI(part types.ContentPart) (map[string]
 
 // convertAudioPartToOpenAI converts an audio ContentPart to OpenAI's input_audio format
 // OpenAI audio input format: { "type": "input_audio", "input_audio": { "data": base64, "format": "wav"|"mp3" } }
-func (p *Provider) convertAudioPartToOpenAI(part types.ContentPart) (map[string]interface{}, error) {
+func (p *Provider) convertAudioPartToOpenAI(
+	ctx context.Context, part types.ContentPart,
+) (map[string]interface{}, error) {
 	if part.Media == nil {
 		return nil, fmt.Errorf("audio part missing media content")
 	}
 
-	// Get base64-encoded audio data
-	var audioData string
-	if part.Media.Data != nil && *part.Media.Data != "" {
-		audioData = *part.Media.Data
-	} else {
-		// Use MediaLoader for URL, FilePath, or StorageReference
-		loader := providers.NewMediaLoader(providers.MediaLoaderConfig{})
-		data, err := loader.GetBase64Data(context.Background(), part.Media)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load audio data: %w", err)
-		}
-		audioData = data
+	// Get base64-encoded audio data. The store-aware loader already returns inline
+	// Data first, then resolves a StorageReference via the injected store.
+	audioData, err := p.MediaLoader().GetBase64Data(ctx, part.Media)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load audio data: %w", err)
 	}
 
 	// Determine audio format from MIME type

--- a/runtime/providers/openai/openai_multimodal_test.go
+++ b/runtime/providers/openai/openai_multimodal_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -138,7 +139,7 @@ func TestOpenAIProvider_ConvertLegacyMessage(t *testing.T) {
 		Content: "Hello, world!",
 	}
 
-	converted, err := provider.convertMessageToOpenAI(legacyMsg)
+	converted, err := provider.convertMessageToOpenAI(context.Background(), legacyMsg)
 	if err != nil {
 		t.Fatalf("Failed to convert legacy message: %v", err)
 	}
@@ -165,7 +166,7 @@ func TestOpenAIProvider_ConvertTextOnlyMultimodalMessage(t *testing.T) {
 		Parts: []types.ContentPart{types.NewTextPart("Hello from multimodal!")},
 	}
 
-	converted, err := provider.convertMessageToOpenAI(msg)
+	converted, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert text-only multimodal message: %v", err)
 	}
@@ -215,7 +216,7 @@ func TestOpenAIProvider_ConvertImageURLMessage(t *testing.T) {
 		},
 	}
 
-	converted, err := provider.convertMessageToOpenAI(msg)
+	converted, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert image URL message: %v", err)
 	}
@@ -274,7 +275,7 @@ func TestOpenAIProvider_ConvertImageBase64Message(t *testing.T) {
 		},
 	}
 
-	converted, err := provider.convertMessageToOpenAI(msg)
+	converted, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert base64 image message: %v", err)
 	}
@@ -319,7 +320,7 @@ func TestOpenAIProvider_ConvertImageWithDetail(t *testing.T) {
 		},
 	}
 
-	converted, err := provider.convertMessageToOpenAI(msg)
+	converted, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert image with detail: %v", err)
 	}
@@ -370,7 +371,7 @@ func TestOpenAIProvider_ConvertMultipleImages(t *testing.T) {
 		},
 	}
 
-	converted, err := provider.convertMessageToOpenAI(msg)
+	converted, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert multiple images: %v", err)
 	}
@@ -418,7 +419,7 @@ func TestOpenAIProvider_ConvertAudioReturnsError(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToOpenAI(msg)
+	_, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err == nil {
 		t.Fatal("Expected error when converting audio content, got nil")
 	}
@@ -446,7 +447,7 @@ func TestOpenAIProvider_ConvertVideoReturnsError(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToOpenAI(msg)
+	_, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err == nil {
 		t.Fatal("Expected error when converting video content, got nil")
 	}
@@ -466,7 +467,7 @@ func TestOpenAIProvider_ConvertEmptyTextPart(t *testing.T) {
 		},
 	}
 
-	converted, err := provider.convertMessageToOpenAI(msg)
+	converted, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("Failed to convert empty text part: %v", err)
 	}
@@ -495,7 +496,7 @@ func TestOpenAIProvider_ConvertImageMissingMedia(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToOpenAI(msg)
+	_, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	if err == nil {
 		t.Fatal("Expected error when image part is missing media content, got nil")
 	}
@@ -517,7 +518,7 @@ func TestOpenAIProvider_ConvertImageMissingDataSource(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertImagePartToOpenAI(msg.Parts[0])
+	_, err := provider.convertImagePartToOpenAI(context.Background(), msg.Parts[0])
 	if err == nil {
 		t.Fatal("Expected error when image has no data source, got nil")
 	}
@@ -735,7 +736,7 @@ func TestOpenAIProvider_ConvertMessagesToOpenAI(t *testing.T) {
 		},
 	}
 
-	messages, err := provider.convertMessagesToOpenAI(req)
+	messages, err := provider.prepareOpenAIMessages(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Failed to convert messages: %v", err)
 	}
@@ -1075,7 +1076,7 @@ func TestOpenAIProvider_ConvertAudioPartToOpenAI(t *testing.T) {
 			},
 		}
 
-		result, err := provider.convertAudioPartToOpenAI(part)
+		result, err := provider.convertAudioPartToOpenAI(context.Background(), part)
 		require.NoError(t, err)
 
 		assert.Equal(t, "input_audio", result["type"])
@@ -1095,7 +1096,7 @@ func TestOpenAIProvider_ConvertAudioPartToOpenAI(t *testing.T) {
 			},
 		}
 
-		result, err := provider.convertAudioPartToOpenAI(part)
+		result, err := provider.convertAudioPartToOpenAI(context.Background(), part)
 		require.NoError(t, err)
 
 		inputAudio := result["input_audio"].(map[string]interface{})
@@ -1112,7 +1113,7 @@ func TestOpenAIProvider_ConvertAudioPartToOpenAI(t *testing.T) {
 			},
 		}
 
-		_, err := provider.convertAudioPartToOpenAI(part)
+		_, err := provider.convertAudioPartToOpenAI(context.Background(), part)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported audio format")
 	})
@@ -1123,7 +1124,7 @@ func TestOpenAIProvider_ConvertAudioPartToOpenAI(t *testing.T) {
 			Media: nil,
 		}
 
-		_, err := provider.convertAudioPartToOpenAI(part)
+		_, err := provider.convertAudioPartToOpenAI(context.Background(), part)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing media content")
 	})
@@ -1152,7 +1153,7 @@ func TestOpenAIProvider_AudioModelConvertMessage(t *testing.T) {
 			},
 		}
 
-		converted, err := provider.convertMessageToOpenAI(msg)
+		converted, err := provider.convertMessageToOpenAI(context.Background(), msg)
 		require.NoError(t, err)
 
 		parts, ok := converted.Content.([]interface{})
@@ -1226,7 +1227,7 @@ func TestOpenAIProvider_AudioNotSupportedOnNonAudioModel(t *testing.T) {
 		},
 	}
 
-	_, err := provider.convertMessageToOpenAI(msg)
+	_, err := provider.convertMessageToOpenAI(context.Background(), msg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "audio content requires audio model")
 }

--- a/runtime/providers/openai/openai_multimodal_tools_test.go
+++ b/runtime/providers/openai/openai_multimodal_tools_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -249,7 +250,7 @@ func TestConvertSingleMessageForTools_MultimodalToolResult(t *testing.T) {
 		},
 	}
 
-	openaiMsg := provider.convertSingleMessageForTools(msg)
+	openaiMsg := provider.convertSingleMessageForTools(context.Background(), msg)
 
 	if openaiMsg["tool_call_id"] != "call_100" {
 		t.Errorf("Expected tool_call_id 'call_100', got %v", openaiMsg["tool_call_id"])
@@ -343,7 +344,7 @@ func TestToolProvider_WithMultimodalMessages(t *testing.T) {
 
 	// The current buildToolRequest uses msg.Content directly
 	// This will NOT work correctly with multimodal messages
-	toolReq := toolProvider.buildToolRequest(req, nil, "")
+	toolReq := toolProvider.buildToolRequest(context.Background(), req, nil, "")
 
 	// Extract the message that was built
 	messages, ok := toolReq["messages"].([]map[string]interface{})
@@ -408,7 +409,7 @@ func TestToolProvider_BuildToolRequestWithLegacyMessage(t *testing.T) {
 		Messages: []types.Message{msg},
 	}
 
-	toolReq := toolProvider.buildToolRequest(req, nil, "")
+	toolReq := toolProvider.buildToolRequest(context.Background(), req, nil, "")
 	messages := toolReq["messages"].([]map[string]interface{})
 
 	if len(messages) != 1 {
@@ -460,7 +461,7 @@ func TestToolProvider_BuildToolRequestWithTools(t *testing.T) {
 		},
 	}
 
-	toolReq := toolProvider.buildToolRequest(req, tools, "auto")
+	toolReq := toolProvider.buildToolRequest(context.Background(), req, tools, "auto")
 
 	// Verify tools are present
 	if toolReq["tools"] == nil {
@@ -512,7 +513,7 @@ func TestToolProvider_BuildToolRequestWithToolCalls(t *testing.T) {
 		Messages: []types.Message{assistantMsg, toolResultMsg},
 	}
 
-	toolReq := toolProvider.buildToolRequest(req, nil, "")
+	toolReq := toolProvider.buildToolRequest(context.Background(), req, nil, "")
 	messages := toolReq["messages"].([]map[string]interface{})
 
 	if len(messages) != 2 {
@@ -588,7 +589,7 @@ func TestToolProvider_BuildToolRequestWithMultimodalAndToolResult(t *testing.T) 
 		Messages: []types.Message{userMsg, assistantMsg, toolMsg, finalMsg},
 	}
 
-	toolReq := toolProvider.buildToolRequest(req, nil, "")
+	toolReq := toolProvider.buildToolRequest(context.Background(), req, nil, "")
 	messages := toolReq["messages"].([]map[string]interface{})
 
 	if len(messages) != 4 {
@@ -643,7 +644,7 @@ func TestToolProvider_MultimodalValidation(t *testing.T) {
 	}
 
 	// This should fail validation since OpenAI doesn't support audio in predict
-	_, err := toolProvider.convertMessageToOpenAI(msg)
+	_, err := toolProvider.convertMessageToOpenAI(context.Background(), msg)
 	if err == nil {
 		t.Error("Expected error for unsupported audio content")
 	} else {

--- a/runtime/providers/openai/openai_storageref_test.go
+++ b/runtime/providers/openai/openai_storageref_test.go
@@ -1,0 +1,95 @@
+package openai
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// refStore is a minimal MediaStorageService for storage-reference tests.
+// GetURL returns a fixed URL; RetrieveMedia returns bytes as inline Data.
+type refStore struct {
+	url   string
+	bytes string
+}
+
+func (s refStore) StoreMedia(
+	context.Context, *types.MediaContent, *storage.MediaMetadata,
+) (storage.Reference, error) {
+	return "", nil
+}
+
+func (s refStore) RetrieveMedia(context.Context, storage.Reference) (*types.MediaContent, error) {
+	d := s.bytes
+	return &types.MediaContent{Data: &d, MIMEType: "audio/mpeg"}, nil
+}
+
+func (s refStore) DeleteMedia(context.Context, storage.Reference) error { return nil }
+
+func (s refStore) GetURL(context.Context, storage.Reference, time.Duration) (string, error) {
+	return s.url, nil
+}
+
+// TestOpenAI_ImageStorageRef_UsesURL verifies an image carried by a storage
+// reference is resolved to a model-fetchable URL (not inlined as a data: URL).
+func TestOpenAI_ImageStorageRef_UsesURL(t *testing.T) {
+	p := NewProvider("test", "gpt-4o", "https://api.openai.com/v1", providers.ProviderDefaults{}, false)
+	p.SetMediaStorageService(refStore{url: "https://s3/img?sig=1"})
+
+	ref := "s3://b/k"
+	part := types.ContentPart{
+		Type: types.ContentTypeImage,
+		Media: &types.MediaContent{
+			StorageReference: &ref,
+			MIMEType:         types.MIMETypeImagePNG,
+		},
+	}
+
+	out, err := p.convertImagePartToOpenAI(context.Background(), part)
+	if err != nil {
+		t.Fatalf("convertImagePartToOpenAI returned error: %v", err)
+	}
+
+	imageURL, ok := out["image_url"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected image_url map, got %T", out["image_url"])
+	}
+	if got := imageURL["url"]; got != "https://s3/img?sig=1" {
+		t.Fatalf("expected resolved URL, got %v", got)
+	}
+}
+
+// TestOpenAI_AudioStorageRef_UsesBytes verifies audio carried by a storage
+// reference is loaded as base64 bytes via the store (OpenAI has no audio URL path).
+func TestOpenAI_AudioStorageRef_UsesBytes(t *testing.T) {
+	p := NewProvider("test", "gpt-4o", "https://api.openai.com/v1", providers.ProviderDefaults{}, false)
+	want := base64.StdEncoding.EncodeToString([]byte("AUDIO"))
+	p.SetMediaStorageService(refStore{bytes: want})
+
+	ref := "s3://b/audio"
+	part := types.ContentPart{
+		Type: types.ContentTypeAudio,
+		Media: &types.MediaContent{
+			StorageReference: &ref,
+			MIMEType:         types.MIMETypeAudioMP3,
+		},
+	}
+
+	out, err := p.convertAudioPartToOpenAI(context.Background(), part)
+	if err != nil {
+		t.Fatalf("convertAudioPartToOpenAI returned error: %v", err)
+	}
+
+	inputAudio, ok := out["input_audio"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected input_audio map, got %T", out["input_audio"])
+	}
+	if got := inputAudio["data"]; got != want {
+		t.Fatalf("expected base64 %q, got %v", want, got)
+	}
+}

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -202,7 +202,7 @@ func (p *ToolProvider) predictWithCompletions(
 	start := time.Now()
 
 	// Build OpenAI request with tools
-	openaiReq := p.buildToolRequest(req, tools, toolChoice)
+	openaiReq := p.buildToolRequest(ctx, req, tools, toolChoice)
 
 	// Prepare response with raw request if configured (set early to preserve on error)
 	predictResp := providers.PredictionResponse{}
@@ -236,8 +236,10 @@ func (p *ToolProvider) predictWithCompletions(
 }
 
 // buildToolRequest constructs the OpenAI API request with tools
-func (p *ToolProvider) buildToolRequest(req providers.PredictionRequest, tools interface{}, toolChoice string) map[string]interface{} {
-	messages := p.convertRequestMessagesToOpenAI(req)
+func (p *ToolProvider) buildToolRequest(
+	ctx context.Context, req providers.PredictionRequest, tools interface{}, toolChoice string,
+) map[string]interface{} {
+	messages := p.convertRequestMessagesToOpenAI(ctx, req)
 
 	// Apply defaults to zero-valued request parameters
 	temperature, topP, maxTokens := p.applyRequestDefaults(req)
@@ -276,7 +278,9 @@ func (p *ToolProvider) buildToolRequest(req providers.PredictionRequest, tools i
 }
 
 // convertRequestMessagesToOpenAI converts all messages in a request to OpenAI format
-func (p *ToolProvider) convertRequestMessagesToOpenAI(req providers.PredictionRequest) []map[string]interface{} {
+func (p *ToolProvider) convertRequestMessagesToOpenAI(
+	ctx context.Context, req providers.PredictionRequest,
+) []map[string]interface{} {
 	messages := make([]map[string]interface{}, 0, len(req.Messages)+1)
 
 	// Add system message if present
@@ -289,7 +293,7 @@ func (p *ToolProvider) convertRequestMessagesToOpenAI(req providers.PredictionRe
 
 	// Add conversation messages
 	for i := range req.Messages {
-		openaiMsg := p.convertSingleMessageForTools(req.Messages[i])
+		openaiMsg := p.convertSingleMessageForTools(ctx, req.Messages[i])
 		messages = append(messages, openaiMsg)
 	}
 
@@ -297,9 +301,9 @@ func (p *ToolProvider) convertRequestMessagesToOpenAI(req providers.PredictionRe
 }
 
 // convertSingleMessageForTools converts a single message to OpenAI format including tool metadata
-func (p *ToolProvider) convertSingleMessageForTools(msg types.Message) map[string]interface{} {
+func (p *ToolProvider) convertSingleMessageForTools(ctx context.Context, msg types.Message) map[string]interface{} {
 	// Convert message to OpenAI format (handles both legacy and multimodal)
-	convertedMsg, err := p.convertMessageToOpenAI(msg)
+	convertedMsg, err := p.convertMessageToOpenAI(ctx, msg)
 	if err != nil {
 		// Log error but continue with best effort (use Content as fallback)
 		// This allows tool calls to work even if multimodal conversion fails
@@ -601,7 +605,7 @@ func (p *ToolProvider) predictStreamWithCompletions(
 	toolChoice string,
 ) (<-chan providers.StreamChunk, error) {
 	// Build OpenAI request with tools (same as non-streaming)
-	openaiReq := p.buildToolRequest(req, tools, toolChoice)
+	openaiReq := p.buildToolRequest(ctx, req, tools, toolChoice)
 
 	// Add streaming options
 	openaiReq["stream"] = true

--- a/runtime/providers/openai/openai_tools_test.go
+++ b/runtime/providers/openai/openai_tools_test.go
@@ -757,7 +757,7 @@ func TestOpenAIToolProvider_BuildToolRequest_AppliesDefaults(t *testing.T) {
 				Messages:    []types.Message{{Role: "user", Content: "Hello"}},
 			}
 
-			request := provider.buildToolRequest(req, nil, "")
+			request := provider.buildToolRequest(context.Background(), req, nil, "")
 
 			if temp, ok := request["temperature"].(float32); !ok || temp != tt.expectedTemp {
 				t.Errorf("Expected temperature %.2f, got %v", tt.expectedTemp, request["temperature"])
@@ -1011,7 +1011,7 @@ func TestToolProvider_ConvertToolResultMessage_ContentIsSet(t *testing.T) {
 	}
 
 	// Convert to OpenAI format
-	openaiMsg := provider.convertSingleMessageForTools(toolResultMsg)
+	openaiMsg := provider.convertSingleMessageForTools(context.Background(), toolResultMsg)
 
 	// Verify tool_call_id and name are set
 	if openaiMsg["tool_call_id"] != "call_123" {
@@ -1060,7 +1060,7 @@ func TestToolProvider_ConvertRequestMessages_ToolResultHasContent(t *testing.T) 
 		},
 	}
 
-	messages := provider.convertRequestMessagesToOpenAI(req)
+	messages := provider.convertRequestMessagesToOpenAI(context.Background(), req)
 
 	// Find the tool result message
 	var toolMsg map[string]interface{}
@@ -1119,7 +1119,7 @@ func TestBuildToolRequest_AudioModalities(t *testing.T) {
 		},
 	}
 
-	result := provider.buildToolRequest(req, nil, "")
+	result := provider.buildToolRequest(context.Background(), req, nil, "")
 
 	// Must have modalities set
 	modalities, ok := result["modalities"]
@@ -1173,7 +1173,7 @@ func TestBuildToolRequest_AudioModalities_TextInput(t *testing.T) {
 		}},
 	}
 
-	result := provider.buildToolRequest(req, nil, "")
+	result := provider.buildToolRequest(context.Background(), req, nil, "")
 
 	mods, ok := result["modalities"].([]string)
 	if !ok {

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
 )
 
 const (
@@ -177,6 +178,12 @@ type ProviderSpec struct {
 	// streamConcurrencyConfigurable interface.
 	StreamMaxConcurrent int
 
+	// StorageService resolves MediaContent.StorageReference values at
+	// request-build time (to a model-fetchable URL via GetURL, or bytes via
+	// RetrieveMedia). Applied via SetMediaStorageService on providers
+	// implementing MediaStorageConfigurable. Nil = disabled.
+	StorageService storage.MediaStorageService
+
 	// HTTPTransport configures the per-provider HTTP connection pool.
 	// Zero-valued fields fall back to package-level defaults
 	// (DefaultMaxConnsPerHost, etc.). Applied via SetHTTPTransport on
@@ -252,6 +259,17 @@ type httpTransportConfigurable interface {
 // for post-construction wiring interfaces (timeoutConfigurable etc.)
 type headersConfigurable interface {
 	SetCustomHeaders(map[string]string)
+}
+
+// MediaStorageConfigurable is implemented by any provider embedding
+// *BaseProvider. CreateProviderFromSpec uses it to inject the media storage
+// service so providers can resolve MediaContent.StorageReference values at
+// request-build time.
+//
+// NOSONAR: name intentionally matches the existing *Configurable pattern for
+// post-construction wiring interfaces (timeoutConfigurable etc.)
+type MediaStorageConfigurable interface {
+	SetMediaStorageService(storage.MediaStorageService)
 }
 
 // CreateProviderFromSpec creates a provider implementation from a spec.
@@ -366,6 +384,12 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 	// empty map is a no-op at request time.
 	if hc, ok := provider.(headersConfigurable); ok && len(spec.Headers) > 0 {
 		hc.SetCustomHeaders(spec.Headers)
+	}
+
+	// Inject the media storage service so the provider can resolve
+	// MediaContent.StorageReference values at request-build time.
+	if mc, ok := provider.(MediaStorageConfigurable); ok && spec.StorageService != nil {
+		mc.SetMediaStorageService(spec.StorageService)
 	}
 
 	return provider, nil

--- a/runtime/providers/registry_mediastore_test.go
+++ b/runtime/providers/registry_mediastore_test.go
@@ -1,0 +1,56 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/httputil"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestCreateProviderFromSpec_AppliesStorageService verifies the registry entry
+// point injects spec.StorageService into any provider embedding BaseProvider
+// (via MediaStorageConfigurable), so StorageReference resolution works uniformly.
+func TestCreateProviderFromSpec_AppliesStorageService(t *testing.T) {
+	const typeName = "test-mediastore-provider"
+
+	originalFactory := providerFactories[typeName]
+	t.Cleanup(func() {
+		if originalFactory != nil {
+			providerFactories[typeName] = originalFactory
+		} else {
+			delete(providerFactories, typeName)
+		}
+	})
+
+	RegisterProviderFactory(typeName, func(spec ProviderSpec) (Provider, error) {
+		base := NewBaseProvider(spec.ID, false, &http.Client{
+			Timeout:   httputil.DefaultProviderTimeout,
+			Transport: NewInstrumentedTransport(NewPooledTransport()),
+		})
+		return &timeoutAwareProvider{BaseProvider: &base}, nil
+	})
+
+	store := resolveURLFakeStore{url: "https://s3/x?sig=1"}
+	p, err := CreateProviderFromSpec(ProviderSpec{ID: "m", Type: typeName, StorageService: store})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	ref := "s3://b/k"
+	url, ok, err := p.(*timeoutAwareProvider).MediaLoader().ResolveURL(context.Background(),
+		&types.MediaContent{StorageReference: &ref, MIMEType: "image/png"})
+	if err != nil || !ok || url != "https://s3/x?sig=1" {
+		t.Fatalf("store not applied to provider: (%q,%v,%v)", url, ok, err)
+	}
+
+	// Nil store must be a no-op (no panic, ResolveURL falls back).
+	p2, err := CreateProviderFromSpec(ProviderSpec{ID: "m2", Type: typeName})
+	if err != nil {
+		t.Fatalf("create nil-store: %v", err)
+	}
+	if _, ok, _ := p2.(*timeoutAwareProvider).MediaLoader().ResolveURL(context.Background(),
+		&types.MediaContent{StorageReference: &ref, MIMEType: "image/png"}); ok {
+		t.Fatal("expected ok=false with no store")
+	}
+}

--- a/runtime/storage/interfaces.go
+++ b/runtime/storage/interfaces.go
@@ -80,7 +80,8 @@ type MediaStorageService interface {
 	// Parameters:
 	//   - ctx: Context for cancellation and timeouts
 	//   - reference: The storage reference
-	//   - expiry: How long the URL should be valid (ignored for local storage)
+	//   - expiry: How long the URL should be valid (ignored for local storage).
+	//     An expiry <= 0 means the store chooses its own expiry/caching policy.
 	//
 	// Returns:
 	//   - URL string that can be used to access the media

--- a/runtime/types/content.go
+++ b/runtime/types/content.go
@@ -168,6 +168,20 @@ func NewImagePartFromData(base64Data, mimeType string, detail *string) ContentPa
 	}
 }
 
+// NewImagePartFromStorageRef creates an image ContentPart backed by a durable
+// storage reference. The reference is resolved to a URL or bytes at
+// provider-call time (see providers.MediaLoader).
+func NewImagePartFromStorageRef(ref, mimeType string, detail *string) ContentPart {
+	return ContentPart{
+		Type: ContentTypeImage,
+		Media: &MediaContent{
+			StorageReference: &ref,
+			MIMEType:         mimeType,
+			Detail:           detail,
+		},
+	}
+}
+
 // NewAudioPart creates a ContentPart with audio content from a file path
 func NewAudioPart(filePath string) (ContentPart, error) {
 	mimeType, err := inferMIMEType(filePath)
@@ -192,6 +206,14 @@ func NewAudioPartFromData(base64Data, mimeType string) ContentPart {
 			Data:     &base64Data,
 			MIMEType: mimeType,
 		},
+	}
+}
+
+// NewAudioPartFromStorageRef creates an audio ContentPart backed by a storage reference.
+func NewAudioPartFromStorageRef(ref, mimeType string) ContentPart {
+	return ContentPart{
+		Type:  ContentTypeAudio,
+		Media: &MediaContent{StorageReference: &ref, MIMEType: mimeType},
 	}
 }
 
@@ -222,6 +244,14 @@ func NewVideoPartFromData(base64Data, mimeType string) ContentPart {
 	}
 }
 
+// NewVideoPartFromStorageRef creates a video ContentPart backed by a storage reference.
+func NewVideoPartFromStorageRef(ref, mimeType string) ContentPart {
+	return ContentPart{
+		Type:  ContentTypeVideo,
+		Media: &MediaContent{StorageReference: &ref, MIMEType: mimeType},
+	}
+}
+
 // NewDocumentPart creates a ContentPart with document content from a file path
 func NewDocumentPart(filePath string) (ContentPart, error) {
 	mimeType, err := inferMIMEType(filePath)
@@ -246,6 +276,14 @@ func NewDocumentPartFromData(base64Data, mimeType string) ContentPart {
 			Data:     &base64Data,
 			MIMEType: mimeType,
 		},
+	}
+}
+
+// NewDocumentPartFromStorageRef creates a document ContentPart backed by a storage reference.
+func NewDocumentPartFromStorageRef(ref, mimeType string) ContentPart {
+	return ContentPart{
+		Type:  ContentTypeDocument,
+		Media: &MediaContent{StorageReference: &ref, MIMEType: mimeType},
 	}
 }
 
@@ -278,9 +316,10 @@ func (mc *MediaContent) Validate() error {
 	hasData := mc.Data != nil && *mc.Data != ""
 	hasFilePath := mc.FilePath != nil && *mc.FilePath != ""
 	hasURL := mc.URL != nil && *mc.URL != ""
+	hasStorageRef := mc.StorageReference != nil && *mc.StorageReference != ""
 
-	if !hasData && !hasFilePath && !hasURL {
-		return fmt.Errorf("media content must have a data source (data, file_path, or url)")
+	if !hasData && !hasFilePath && !hasURL && !hasStorageRef {
+		return fmt.Errorf("media content must have a data source (data, file_path, url, or storage_reference)")
 	}
 	if hasURL && hasData {
 		return fmt.Errorf("media content cannot have both url and inline data")

--- a/runtime/types/content_storageref_test.go
+++ b/runtime/types/content_storageref_test.go
@@ -1,0 +1,57 @@
+package types
+
+import "testing"
+
+func TestMediaContent_Validate_AcceptsStorageReference(t *testing.T) {
+	ref := "s3://bucket/key"
+	mc := &MediaContent{StorageReference: &ref, MIMEType: "image/png"}
+	if err := mc.Validate(); err != nil {
+		t.Fatalf("storage reference should be a valid source, got: %v", err)
+	}
+}
+
+func TestMediaContent_Validate_StillRejectsNoSource(t *testing.T) {
+	mc := &MediaContent{MIMEType: "image/png"}
+	if err := mc.Validate(); err == nil {
+		t.Fatal("expected error when no data source is present")
+	}
+}
+
+func TestNewImagePartFromStorageRef(t *testing.T) {
+	detail := "high"
+	cp := NewImagePartFromStorageRef("s3://b/k", "image/png", &detail)
+	if cp.Type != ContentTypeImage {
+		t.Fatalf("type = %s, want image", cp.Type)
+	}
+	if cp.Media == nil || cp.Media.StorageReference == nil || *cp.Media.StorageReference != "s3://b/k" {
+		t.Fatal("storage reference not set")
+	}
+	if cp.Media.MIMEType != "image/png" {
+		t.Fatalf("mime = %q", cp.Media.MIMEType)
+	}
+	if cp.Media.Detail == nil || *cp.Media.Detail != "high" {
+		t.Fatal("detail not set")
+	}
+	if err := cp.Media.Validate(); err != nil {
+		t.Fatalf("constructed part must validate: %v", err)
+	}
+}
+
+func TestNewAudioVideoDocumentPartFromStorageRef(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cp   ContentPart
+		want string
+	}{
+		{"audio", NewAudioPartFromStorageRef("s3://a", "audio/mp3"), ContentTypeAudio},
+		{"video", NewVideoPartFromStorageRef("s3://v", "video/mp4"), ContentTypeVideo},
+		{"document", NewDocumentPartFromStorageRef("s3://d", MIMETypePDF), ContentTypeDocument},
+	} {
+		if tc.cp.Type != tc.want {
+			t.Errorf("%s: type = %s, want %s", tc.name, tc.cp.Type, tc.want)
+		}
+		if err := tc.cp.Media.Validate(); err != nil {
+			t.Errorf("%s: must validate: %v", tc.name, err)
+		}
+	}
+}

--- a/sdk/e2e_storage_ref_test.go
+++ b/sdk/e2e_storage_ref_test.go
@@ -1,0 +1,134 @@
+//go:build e2e
+
+package sdk
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/storage/local"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Storage-Reference Resolution E2E Tests
+//
+// These tests prove that media sent by durable StorageReference resolves
+// end-to-end against real vision providers, exercising both resolution paths:
+//
+//   - URL path:   ref -> store.GetURL -> remote URL -> model fetches the URL
+//   - Bytes path: ref -> file:// URL (non-remote) -> provider falls back to
+//                 downloading bytes -> model receives inline image data
+//
+// They are opt-in and require a live provider API key:
+//
+//	go test -tags=e2e ./sdk/... -run TestE2E_StorageRef
+//
+// A live-S3 presigned-URL test is intentionally out of scope here: the
+// URL-path test uses a fake store returning a stable PUBLIC image URL, which
+// exercises exactly the same GetURL -> remote-URL -> model code path a real
+// S3/GCS presigned URL would, without the credential and network coupling.
+// =============================================================================
+
+// publicStorageRefImageURL is the same stable public test image the vision
+// URL test (e2e_vision_test.go) uses; reused so both cover an identical
+// remote-URL model path.
+const publicStorageRefImageURL = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/" +
+	"PNG_transparency_demonstration_1.png/300px-PNG_transparency_demonstration_1.png"
+
+// urlFakeStore is a minimal MediaStorageService whose GetURL always returns a
+// stable, public, remote image URL. It lets the URL-resolution path be tested
+// without any cloud credentials.
+type urlFakeStore struct{ url string }
+
+func (s *urlFakeStore) StoreMedia(
+	_ context.Context, _ *types.MediaContent, _ *storage.MediaMetadata,
+) (storage.Reference, error) {
+	return storage.Reference("ref-1"), nil
+}
+
+func (s *urlFakeStore) RetrieveMedia(
+	_ context.Context, _ storage.Reference,
+) (*types.MediaContent, error) {
+	return nil, nil
+}
+
+func (s *urlFakeStore) DeleteMedia(_ context.Context, _ storage.Reference) error {
+	return nil
+}
+
+func (s *urlFakeStore) GetURL(
+	_ context.Context, _ storage.Reference, _ time.Duration,
+) (string, error) {
+	return s.url, nil
+}
+
+// TestE2E_StorageRef_URLPath proves ref -> GetURL -> remote URL -> real model.
+func TestE2E_StorageRef_URLPath(t *testing.T) {
+	EnsureTestPacks(t)
+
+	RunForProviders(t, CapVision, func(t *testing.T, provider ProviderConfig) {
+		if provider.ID == "mock" {
+			t.Skip("Mock provider doesn't support real vision")
+		}
+
+		store := &urlFakeStore{url: publicStorageRefImageURL}
+
+		conv := NewVisionConversation(t, provider, WithMediaStorage(store))
+		defer conv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+
+		resp, err := conv.Send(ctx,
+			"What do you see in this image? Answer in one sentence.",
+			WithImageStorageRef("ref-1", "image/png"))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.NotEmpty(t, resp.Text(), "Should return a description via URL path")
+
+		t.Logf("Provider %s storage-ref URL path: %s", provider.ID, truncate(resp.Text(), 150))
+	})
+}
+
+// TestE2E_StorageRef_BytesPath proves ref -> file:// -> bytes fallback -> real
+// model. The local file store's GetURL returns a non-remote file:// URL, so
+// providers fetch the stored bytes instead of handing the model a URL.
+func TestE2E_StorageRef_BytesPath(t *testing.T) {
+	EnsureTestPacks(t)
+
+	RunForProviders(t, CapVision, func(t *testing.T, provider ProviderConfig) {
+		if provider.ID == "mock" {
+			t.Skip("Mock provider doesn't support real vision")
+		}
+
+		store, err := local.NewFileStore(local.FileStoreConfig{BaseDir: t.TempDir()})
+		require.NoError(t, err)
+
+		data := base64.StdEncoding.EncodeToString(getTestImage(t))
+		ref, err := store.StoreMedia(context.Background(),
+			&types.MediaContent{Data: &data, MIMEType: "image/png"},
+			&storage.MediaMetadata{SessionID: "storage-ref-e2e", MIMEType: "image/png"})
+		require.NoError(t, err)
+
+		conv := NewVisionConversation(t, provider, WithMediaStorage(store))
+		defer conv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+
+		resp, err := conv.Send(ctx,
+			"What do you see in this image? Answer in one sentence.",
+			WithImageStorageRef(string(ref), "image/png"))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.NotEmpty(t, resp.Text(), "Should return a description via bytes path")
+
+		t.Logf("Provider %s storage-ref bytes path: %s", provider.ID, truncate(resp.Text(), 150))
+	})
+}

--- a/sdk/examples/media-storage-ref/README.md
+++ b/sdk/examples/media-storage-ref/README.md
@@ -1,0 +1,37 @@
+# Media Storage Reference Example
+
+Send media to a vision model by a **durable storage reference** instead of
+inlining bytes on every request.
+
+The caller stores an image once in a `MediaStorageService`, then passes a
+durable reference on each request. At model-call time the provider resolves
+that reference through the store — to a model-fetchable URL (via the store's
+`GetURL`) or to bytes. With a cloud-backed store the model fetches the
+presigned URL directly, so **no image bytes transit the app** on each turn.
+
+## What it shows
+
+- Creating a local disk-backed store with `local.NewFileStore`
+- Storing an image once with `StoreMedia` and getting back a `Reference`
+- Wiring the store into a conversation with `sdk.WithMediaStorage`
+- Sending the image by reference with `sdk.WithImageStorageRef`
+
+## Run it
+
+```bash
+export OPENAI_API_KEY=your-key   # or GEMINI_API_KEY / ANTHROPIC_API_KEY
+go run .
+```
+
+The example writes the stored image under `./data`. It generates a tiny PNG
+in code so it is fully self-contained — the point is the reference wiring, not
+the image content.
+
+## Test it (no keys needed)
+
+```bash
+go test ./ -count=1
+```
+
+The smoke test uses the mock provider and a real local store, asserting that
+`Open` + `Send` succeed with an image sent by reference.

--- a/sdk/examples/media-storage-ref/main_interactive.go
+++ b/sdk/examples/media-storage-ref/main_interactive.go
@@ -1,0 +1,114 @@
+// Package main demonstrates sending media to a vision model by durable
+// storage reference with the PromptKit SDK.
+//
+// Instead of inlining image bytes on every request, the caller stores the
+// image once in a MediaStorageService and passes a durable reference. At
+// model-call time the provider resolves that reference to a model-fetchable
+// URL (or bytes) via the store. With a cloud store the model fetches the
+// presigned URL directly, so no image bytes need to transit the app.
+//
+// This example shows:
+//   - Creating a local disk-backed MediaStorageService
+//   - Storing an image once and getting back a durable reference
+//   - Wiring the store into the conversation with WithMediaStorage
+//   - Sending the image by reference with WithImageStorageRef
+//
+// Run with:
+//
+//	export OPENAI_API_KEY=your-key
+//	go run .
+//
+// Alternatively set GEMINI_API_KEY or ANTHROPIC_API_KEY and the SDK will
+// select the matching vision-capable provider from the environment.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/storage/local"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// 1. Create a local disk-backed media store under ./data. In production
+	//    this would be an S3/GCS-backed store whose GetURL returns a presigned
+	//    URL the model can fetch directly.
+	dir := filepath.Join(".", "data")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.Fatalf("Failed to create data dir: %v", err)
+	}
+	store, err := local.NewFileStore(local.FileStoreConfig{BaseDir: dir})
+	if err != nil {
+		log.Fatalf("Failed to create file store: %v", err)
+	}
+
+	// 2. Store an image once. Here we generate a tiny PNG in code; a real app
+	//    would store an uploaded or generated image. StoreMedia returns a
+	//    durable reference we can re-send cheaply on any later request.
+	ref, err := store.StoreMedia(ctx,
+		&types.MediaContent{Data: pngDataURLPayload(), MIMEType: "image/png"},
+		&storage.MediaMetadata{SessionID: "example", MIMEType: "image/png"},
+	)
+	if err != nil {
+		log.Fatalf("Failed to store image: %v", err)
+	}
+	fmt.Printf("Stored image as durable reference: %s\n\n", ref)
+
+	// 3. Open a conversation, wiring the store in so providers can resolve
+	//    references at model-call time.
+	conv, err := sdk.Open("./media-storage-ref.pack.json", "vision-analyst",
+		sdk.WithMediaStorage(store),
+	)
+	if err != nil {
+		log.Fatalf("Failed to open pack: %v", err)
+	}
+	defer conv.Close()
+
+	// 4. Send the image BY REFERENCE — no bytes are attached to the request.
+	fmt.Println("=== Vision Analysis (image sent by reference) ===")
+	fmt.Println()
+
+	for chunk := range conv.Stream(ctx, "Describe this image.",
+		sdk.WithImageStorageRef(string(ref), "image/png"),
+	) {
+		if chunk.Error != nil {
+			log.Printf("Error: %v", chunk.Error)
+			break
+		}
+		if chunk.Type == sdk.ChunkDone {
+			fmt.Println("\n\n[Analysis Complete]")
+			break
+		}
+		fmt.Print(chunk.Text)
+	}
+}
+
+// pngDataURLPayload builds a minimal 2x2 PNG and returns its base64 payload.
+// MediaContent.Data holds base64-encoded bytes.
+func pngDataURLPayload() *string {
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 0xFF, A: 0xFF})
+	img.Set(1, 0, color.RGBA{G: 0xFF, A: 0xFF})
+	img.Set(0, 1, color.RGBA{B: 0xFF, A: 0xFF})
+	img.Set(1, 1, color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF})
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		log.Fatalf("Failed to encode PNG: %v", err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return &encoded
+}

--- a/sdk/examples/media-storage-ref/media-storage-ref.pack.json
+++ b/sdk/examples/media-storage-ref/media-storage-ref.pack.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "media-storage-ref-example",
+  "name": "Media Storage Reference Example",
+  "version": "1.0.0",
+  "description": "Example demonstrating sending media to a vision model by durable storage reference",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "vision-analyst": {
+      "id": "vision-analyst",
+      "name": "Vision Analyst",
+      "version": "1.0.0",
+      "system_template": "You are an expert visual analyst. When shown images, provide detailed, accurate descriptions and analysis. Be thorough but concise. If you cannot see an image or it fails to load, let the user know.",
+      "parameters": {
+        "temperature": 0.7,
+        "max_tokens": 1024
+      }
+    }
+  }
+}

--- a/sdk/examples/media-storage-ref/smoke_test.go
+++ b/sdk/examples/media-storage-ref/smoke_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/storage/local"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// TestSmoke proves the media-by-reference wiring compiles and validates using
+// the mock provider — no API keys and no network access. The mock ignores the
+// media itself, so the assertion is simply that Open + Send succeed with a
+// stored image sent by durable reference.
+func TestSmoke(t *testing.T) {
+	ctx := context.Background()
+
+	store, err := local.NewFileStore(local.FileStoreConfig{BaseDir: t.TempDir()})
+	require.NoError(t, err)
+
+	ref, err := store.StoreMedia(ctx,
+		&types.MediaContent{Data: pngDataURLPayload(), MIMEType: "image/png"},
+		&storage.MediaMetadata{SessionID: "example", MIMEType: "image/png"},
+	)
+	require.NoError(t, err)
+
+	provider := mock.NewProvider("mock", "mock-model", false)
+	conv, err := sdk.Open("media-storage-ref.pack.json", "vision-analyst",
+		sdk.WithProvider(provider),
+		sdk.WithMediaStorage(store),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp, err := conv.Send(ctx, "hi", sdk.WithImageStorageRef(string(ref), "image/png"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Text())
+}

--- a/sdk/media_storage_test.go
+++ b/sdk/media_storage_test.go
@@ -1,0 +1,93 @@
+package sdk
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// fakeMediaStore is a no-op MediaStorageService used to verify injection.
+type fakeMediaStore struct{}
+
+func (fakeMediaStore) StoreMedia(
+	context.Context, *types.MediaContent, *storage.MediaMetadata,
+) (storage.Reference, error) {
+	return "", nil
+}
+
+func (fakeMediaStore) RetrieveMedia(context.Context, storage.Reference) (*types.MediaContent, error) {
+	return nil, nil
+}
+
+func (fakeMediaStore) DeleteMedia(context.Context, storage.Reference) error { return nil }
+
+func (fakeMediaStore) GetURL(context.Context, storage.Reference, time.Duration) (string, error) {
+	return "", nil
+}
+
+// storageSpyProvider embeds a mock provider (a full providers.Provider) and
+// records SetMediaStorageService calls, so it satisfies
+// providers.MediaStorageConfigurable. The runtime mock provider embeds
+// base.Implementation, not BaseProvider, so it does not implement the
+// interface on its own — this spy adds the seam.
+type storageSpyProvider struct {
+	*mock.Provider
+	mu    sync.Mutex
+	store storage.MediaStorageService
+}
+
+func (s *storageSpyProvider) SetMediaStorageService(st storage.MediaStorageService) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.store = st
+}
+
+func (s *storageSpyProvider) injectedStore() storage.MediaStorageService {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.store
+}
+
+func TestWithMediaStorage_InjectsIntoPooledProvider(t *testing.T) {
+	spy := &storageSpyProvider{Provider: mock.NewProvider("spy", "mock-model", false)}
+	// Compile-time proof the spy implements the configurable interface.
+	var _ providers.MediaStorageConfigurable = spy
+
+	fake := fakeMediaStore{}
+	conv, err := Open("./testdata/packs/eval-test.pack.json", "assistant",
+		WithProvider(spy),
+		WithMediaStorage(fake),
+		WithSkipSchemaValidation(),
+	)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = conv.Close() }()
+
+	if spy.injectedStore() == nil {
+		t.Fatal("expected WithMediaStorage to inject the store into the pooled provider")
+	}
+}
+
+func TestWithMediaStorage_NoStoreIsNoOp(t *testing.T) {
+	spy := &storageSpyProvider{Provider: mock.NewProvider("spy", "mock-model", false)}
+
+	conv, err := Open("./testdata/packs/eval-test.pack.json", "assistant",
+		WithProvider(spy),
+		WithSkipSchemaValidation(),
+	)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = conv.Close() }()
+
+	if spy.injectedStore() != nil {
+		t.Fatal("expected no store injection when WithMediaStorage is not set")
+	}
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -27,6 +27,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/selection"
 	"github.com/AltairaLabs/PromptKit/runtime/skills"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
 	"github.com/AltairaLabs/PromptKit/runtime/stt"
 	"github.com/AltairaLabs/PromptKit/runtime/telemetry"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
@@ -77,6 +78,11 @@ type config struct {
 	apiKey     string
 	model      string
 	credential *credentialConfig
+
+	// mediaStorage resolves MediaContent.StorageReference values (e.g. from
+	// WithImageStorageRef) to a model-fetchable URL or bytes at provider-call
+	// time. Injected into every provider in the pool via WithMediaStorage.
+	mediaStorage storage.MediaStorageService
 
 	// State management
 	stateStore     statestore.Store
@@ -378,6 +384,16 @@ func WithProvider(p providers.Provider) Option {
 			return nil
 		}
 		registerAgentProvider(c, p)
+		return nil
+	}
+}
+
+// WithMediaStorage injects a MediaStorageService so MediaContent.StorageReference
+// values (e.g. from WithImageStorageRef) resolve to a model-fetchable URL or bytes
+// at provider-call time. Applied to every provider in the pool.
+func WithMediaStorage(store storage.MediaStorageService) Option {
+	return func(c *config) error {
+		c.mediaStorage = store
 		return nil
 	}
 }
@@ -2058,7 +2074,7 @@ func (s ProviderSpec) toPkgProvider() *pkgconfig.Provider {
 //nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
 func WithLLMProvider(spec ProviderSpec) Option {
 	return func(c *config) error {
-		prov, err := createProviderFromConfig(spec.toPkgProvider())
+		prov, err := createProviderFromConfig(spec.toPkgProvider(), c.mediaStorage)
 		if err != nil {
 			return fmt.Errorf("WithLLMProvider %q: %w", spec.idOrType(), err)
 		}
@@ -2075,7 +2091,7 @@ func WithLLMProvider(spec ProviderSpec) Option {
 //nolint:gocritic // ProviderSpec is a value-semantics builder; callers assemble inline.
 func WithImageProvider(spec ProviderSpec) Option {
 	return func(c *config) error {
-		prov, err := createProviderFromConfig(spec.toPkgProvider())
+		prov, err := createProviderFromConfig(spec.toPkgProvider(), c.mediaStorage)
 		if err != nil {
 			return fmt.Errorf("WithImageProvider %q: %w", spec.idOrType(), err)
 		}
@@ -2661,10 +2677,75 @@ func WithDocumentData(data []byte, mimeType string) SendOption {
 	}
 }
 
+// WithImageStorageRef attaches an image by durable storage reference. The
+// reference is resolved to a model-fetchable URL or bytes at provider-call
+// time by the MediaStorageService configured via WithMediaStorage.
+//
+//	resp, _ := conv.Send(ctx, "What's in this image?",
+//	    sdk.WithImageStorageRef("s3://bucket/key", "image/png"),
+//	)
+func WithImageStorageRef(ref, mimeType string, detail ...*string) SendOption {
+	return func(c *sendConfig) error {
+		var d *string
+		if len(detail) > 0 {
+			d = detail[0]
+		}
+		c.parts = append(c.parts, imageStorageRefPart{ref: ref, mimeType: mimeType, detail: d})
+		return nil
+	}
+}
+
+// WithAudioStorageRef attaches audio by durable storage reference.
+func WithAudioStorageRef(ref, mimeType string) SendOption {
+	return func(c *sendConfig) error {
+		c.parts = append(c.parts, audioStorageRefPart{ref: ref, mimeType: mimeType})
+		return nil
+	}
+}
+
+// WithVideoStorageRef attaches a video by durable storage reference.
+func WithVideoStorageRef(ref, mimeType string) SendOption {
+	return func(c *sendConfig) error {
+		c.parts = append(c.parts, videoStorageRefPart{ref: ref, mimeType: mimeType})
+		return nil
+	}
+}
+
+// WithFileStorageRef attaches a document by durable storage reference. The
+// name is preserved as the media caption for downstream display.
+func WithFileStorageRef(name, ref, mimeType string) SendOption {
+	return func(c *sendConfig) error {
+		c.parts = append(c.parts, documentStorageRefPart{name: name, ref: ref, mimeType: mimeType})
+		return nil
+	}
+}
+
 // Internal types for content parts
 type imageFilePart struct {
 	path   string
 	detail *string
+}
+
+type imageStorageRefPart struct {
+	ref      string
+	mimeType string
+	detail   *string
+}
+
+type audioStorageRefPart struct {
+	ref      string
+	mimeType string
+}
+
+type videoStorageRefPart struct {
+	ref      string
+	mimeType string
+}
+
+type documentStorageRefPart struct {
+	name     string
+	ref      string
+	mimeType string
 }
 
 type imageURLPart struct {

--- a/sdk/options_storageref_test.go
+++ b/sdk/options_storageref_test.go
@@ -1,0 +1,89 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// applyStorageRefParts runs the given send-options through a sendConfig and
+// materializes their parts onto a fresh user message via addContentParts.
+func applyStorageRefParts(t *testing.T, opts ...SendOption) *types.Message {
+	t.Helper()
+	cfg := &sendConfig{}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			t.Fatalf("apply option: %v", err)
+		}
+	}
+	msg := &types.Message{Role: "user"}
+	if err := (&Conversation{}).addContentParts(msg, cfg.parts); err != nil {
+		t.Fatalf("addContentParts: %v", err)
+	}
+	return msg
+}
+
+func firstMedia(t *testing.T, msg *types.Message, wantType string) *types.MediaContent {
+	t.Helper()
+	if len(msg.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(msg.Parts))
+	}
+	p := msg.Parts[0]
+	if p.Type != wantType {
+		t.Fatalf("part type = %q, want %q", p.Type, wantType)
+	}
+	if p.Media == nil {
+		t.Fatal("part has nil Media")
+	}
+	return p.Media
+}
+
+func assertStorageRef(t *testing.T, m *types.MediaContent, wantRef, wantMIME string) {
+	t.Helper()
+	if m.StorageReference == nil || *m.StorageReference != wantRef {
+		t.Fatalf("StorageReference = %v, want %q", m.StorageReference, wantRef)
+	}
+	if m.MIMEType != wantMIME {
+		t.Fatalf("MIMEType = %q, want %q", m.MIMEType, wantMIME)
+	}
+}
+
+func TestWithImageStorageRef(t *testing.T) {
+	detail := "high"
+	msg := applyStorageRefParts(t, WithImageStorageRef("s3://bucket/img", "image/png", &detail))
+	m := firstMedia(t, msg, types.ContentTypeImage)
+	assertStorageRef(t, m, "s3://bucket/img", "image/png")
+	if m.Detail == nil || *m.Detail != "high" {
+		t.Fatalf("Detail = %v, want %q", m.Detail, "high")
+	}
+}
+
+func TestWithImageStorageRef_NoDetail(t *testing.T) {
+	msg := applyStorageRefParts(t, WithImageStorageRef("s3://bucket/img", "image/jpeg"))
+	m := firstMedia(t, msg, types.ContentTypeImage)
+	assertStorageRef(t, m, "s3://bucket/img", "image/jpeg")
+	if m.Detail != nil {
+		t.Fatalf("Detail = %v, want nil", m.Detail)
+	}
+}
+
+func TestWithAudioStorageRef(t *testing.T) {
+	msg := applyStorageRefParts(t, WithAudioStorageRef("s3://bucket/aud", "audio/mp3"))
+	m := firstMedia(t, msg, types.ContentTypeAudio)
+	assertStorageRef(t, m, "s3://bucket/aud", "audio/mp3")
+}
+
+func TestWithVideoStorageRef(t *testing.T) {
+	msg := applyStorageRefParts(t, WithVideoStorageRef("s3://bucket/vid", "video/mp4"))
+	m := firstMedia(t, msg, types.ContentTypeVideo)
+	assertStorageRef(t, m, "s3://bucket/vid", "video/mp4")
+}
+
+func TestWithFileStorageRef(t *testing.T) {
+	msg := applyStorageRefParts(t, WithFileStorageRef("contract.pdf", "s3://bucket/doc", types.MIMETypePDF))
+	m := firstMedia(t, msg, types.ContentTypeDocument)
+	assertStorageRef(t, m, "s3://bucket/doc", types.MIMETypePDF)
+	if m.Caption == nil || *m.Caption != "contract.pdf" {
+		t.Fatalf("Caption = %v, want %q", m.Caption, "contract.pdf")
+	}
+}

--- a/sdk/provider_file.go
+++ b/sdk/provider_file.go
@@ -36,7 +36,7 @@ func (c *config) applyProviderConfig(p *pkgconfig.Provider) error {
 	}
 	switch p.GetRole() {
 	case pkgconfig.RoleLLM, pkgconfig.RoleImage, pkgconfig.RoleVideo:
-		prov, err := createProviderFromConfig(p)
+		prov, err := createProviderFromConfig(p, c.mediaStorage)
 		if err != nil {
 			return fmt.Errorf("provider %q: %w", id, err)
 		}

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
 	"github.com/AltairaLabs/PromptKit/runtime/mcp"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
 
 	// Side-effect imports register provider factories so CreateFromSpec
 	// can resolve declarative entries.
@@ -112,7 +113,7 @@ func WithRuntimeConfig(path string) Option {
 func applyRuntimeConfig(c *config, spec *pkgconfig.RuntimeConfigSpec) error {
 	// Apply provider (use first provider if configured and no provider already set)
 	if len(spec.Providers) > 0 && c.getAgentProvider() == nil {
-		prov, err := createProviderFromConfig(&spec.Providers[0])
+		prov, err := createProviderFromConfig(&spec.Providers[0], c.mediaStorage)
 		if err != nil {
 			return fmt.Errorf("creating provider from runtime config: %w", err)
 		}
@@ -576,7 +577,12 @@ func slogLevel(level string) slog.Level {
 }
 
 // createProviderFromConfig converts a config.Provider to a providers.Provider.
-func createProviderFromConfig(p *pkgconfig.Provider) (providers.Provider, error) {
+// store, when non-nil, is threaded onto the spec so StorageReference media
+// resolves at model-call time (best-effort; the pool-injection loop in
+// initConversation is the order-independent guarantee).
+func createProviderFromConfig(
+	p *pkgconfig.Provider, store storage.MediaStorageService,
+) (providers.Provider, error) {
 	ctx := context.Background()
 
 	// Resolve credential
@@ -626,6 +632,7 @@ func createProviderFromConfig(p *pkgconfig.Provider) (providers.Provider, error)
 				OutputCostPer1K: p.Pricing.OutputCostPer1K,
 			},
 		},
+		StorageService: store,
 	}
 	return providers.CreateProviderFromSpec(spec)
 }

--- a/sdk/runtime_config_test.go
+++ b/sdk/runtime_config_test.go
@@ -291,7 +291,7 @@ func TestCreateProviderFromConfig_WithPlatform(t *testing.T) {
 		Type:  "mock",
 		Model: "mock-model",
 	}
-	prov, err := createProviderFromConfig(p)
+	prov, err := createProviderFromConfig(p, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, prov)
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -217,6 +217,13 @@ func initConversation(
 		return nil, nil, err
 	}
 
+	// Inject the media storage service into every pooled provider. This runs
+	// after all options are applied and the pool is fully populated
+	// (resolveProvider registers the agent/summarizer), and well before the
+	// first provider call (the pipeline is built per-Send). Providers that
+	// don't implement MediaStorageConfigurable are skipped.
+	applyMediaStorageToPool(cfg)
+
 	// Use caller-provided tool registry or create a new one from the pack.
 	toolReg := cfg.toolRegistry
 	if toolReg == nil {
@@ -418,6 +425,22 @@ func resolveProvider(cfg *config) (providers.Provider, error) {
 	return detected, nil
 }
 
+// applyMediaStorageToPool injects the configured MediaStorageService into every
+// provider in the pool that implements providers.MediaStorageConfigurable.
+// No-op when no store is configured or the pool is empty.
+func applyMediaStorageToPool(c *config) {
+	if c.mediaStorage == nil || c.providers == nil {
+		return
+	}
+	for _, id := range c.providers.List() {
+		if p, ok := c.providers.Get(id); ok {
+			if mc, ok := p.(providers.MediaStorageConfigurable); ok {
+				mc.SetMediaStorageService(c.mediaStorage)
+			}
+		}
+	}
+}
+
 // registerAgentProvider installs p as the agent provider in the pool.
 func registerAgentProvider(cfg *config, p providers.Provider) {
 	ensureProviderPool(cfg)
@@ -505,6 +528,7 @@ func resolvePlatformProvider(cfg *config) (providers.Provider, error) {
 			TopP:        1.0,
 			MaxTokens:   defaultMaxTokens,
 		},
+		StorageService: cfg.mediaStorage,
 	}
 
 	return providers.CreateProviderFromSpec(spec)

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -231,6 +231,19 @@ func (c *Conversation) addContentParts(msg *types.Message, parts []any) error {
 			base64Data := base64.StdEncoding.EncodeToString(p.data)
 			contentPart := types.NewDocumentPartFromData(base64Data, p.mimeType)
 			msg.AddPart(contentPart)
+		case imageStorageRefPart:
+			msg.AddPart(types.NewImagePartFromStorageRef(p.ref, p.mimeType, p.detail))
+		case audioStorageRefPart:
+			msg.AddPart(types.NewAudioPartFromStorageRef(p.ref, p.mimeType))
+		case videoStorageRefPart:
+			msg.AddPart(types.NewVideoPartFromStorageRef(p.ref, p.mimeType))
+		case documentStorageRefPart:
+			docPart := types.NewDocumentPartFromStorageRef(p.ref, p.mimeType)
+			if p.name != "" && docPart.Media != nil {
+				name := p.name
+				docPart.Media.Caption = &name
+			}
+			msg.AddPart(docPart)
 		case filePart:
 			// Legacy file part - kept for backward compatibility
 			// Try to detect if it's a document by checking the name extension


### PR DESCRIPTION
## What & why

Lets an SDK consumer send media by a **durable `StorageReference`** (e.g. an image uploaded to an S3 bucket) and have each provider resolve it at model-call time. This keeps large binaries **out of conversation history** — the persisted message carries only the lightweight ref.

Closes #1595
Closes #1596
Closes #1597

## Design (note: intentionally *not* the "resolve to bytes" approach the tickets sketched)

The point of media externalization is to avoid shuttling big blobs. So resolution is **URL-first**:

- At provider-call time, the store's `GetURL(ref)` mints a fresh, model-fetchable (presigned) URL; the model fetches the bytes directly. Nothing large transits PromptKit; history stays tiny. Fresh URL every turn from the durable ref, so presigned expiry is a non-issue.
- **Bytes are a fallback** (`RetrieveMedia`) for base64-only media types (Gemini `inlineData`, Claude PDF, OpenAI audio, Ollama) or non-remote `file://` refs.
- **The provider decides** URL vs bytes — only it knows what its model accepts.
- **URL expiry/caching is the store's concern** — PromptKit passes `0` to `GetURL` and exposes no knob.

## Changes

**Runtime foundation**
- `types.MediaContent.Validate()` accepts a `StorageReference`; new `types.New<Kind>PartFromStorageRef` constructors.
- `MediaLoader.ResolveURL(ctx, media)` — returns a remote URL or `ok=false` (→ caller falls back to `GetBase64Data`).
- `BaseProvider.SetMediaStorageService(store)` + `MediaLoader()` helper; `providers.MediaStorageConfigurable` optional interface applied in `CreateProviderFromSpec` (via new `ProviderSpec.StorageService`).

**Providers (uniform resolution + real request `ctx` threaded — was `context.Background()`)**
- Claude / OpenAI / Ollama: image URL-first, base64 fallback; Claude PDF + OpenAI audio stay base64.
- Gemini: conversion chain converted from free functions to `*Provider` methods so it can reach the injected store; **fixes** the tool path that previously ignored `StorageReference`/`FilePath`.

**SDK**
- `WithMediaStorage(store)` — injected into every provider in the pool (order-independent).
- `WithImageStorageRef` / `WithAudioStorageRef` / `WithVideoStorageRef` / `WithFileStorageRef` send-options.

**Tests & example**
- Cross-provider unit contract tests per provider (URL path vs bytes path) + `ResolveURL` + registry/pool wiring + send-option tests.
- `sdk/e2e_storage_ref_test.go` (`//go:build e2e`, opt-in): URL path via a public-URL fake store, bytes path via a local `FileStore`. Run with `go test -tags=e2e ./sdk/... -run TestE2E_StorageRef` (needs a provider key). A live-S3 presigned test is intentionally out of scope — the public-URL fake exercises the same `GetURL`→remote-URL path.
- `sdk/examples/media-storage-ref/` — runnable example (stores an image to a local `FileStore`, sends by reference) + mock-provider smoke test.

## Verification

- `go build ./...` and `go test ./...` pass across `runtime` and `sdk`.
- `golangci-lint` — 0 new issues (runtime + sdk).
- `server/a2a` compile sweep clean (no shared-interface breakage).
- `go vet -tags=e2e ./sdk/` compiles the opt-in live tests.

## Backward compatibility

Fully additive. `nil` store = today's behavior; a `StorageReference` without `WithMediaStorage` errors clearly.
