### PR TITLE
fix(providers): guard nil storage media + omit media_type on Claude URL sources

### DIFF
--- a/runtime/providers/claude/claude_multimodal.go
+++ b/runtime/providers/claude/claude_multimodal.go
@@ -46,8 +46,11 @@ func (p *Provider) GetMultimodalCapabilities() providers.MultimodalCapabilities 
 
 // claudeImageSource represents an image or document source in Claude's format
 type claudeImageSource struct {
-	Type      string `json:"type"`       // "base64" or "url"
-	MediaType string `json:"media_type"` // MIME type
+	Type string `json:"type"` // "base64" or "url"
+	// MediaType is required for base64 sources but MUST be omitted for url
+	// sources — Anthropic rejects "media_type" on a url source with 400
+	// "Extra inputs are not permitted".
+	MediaType string `json:"media_type,omitempty"`
 	Data      string `json:"data,omitempty"`
 	URL       string `json:"url,omitempty"`
 }
@@ -175,6 +178,9 @@ func (p *Provider) buildClaudeMessage(role string, contentBlocks []interface{}) 
 	return claudeMsg, nil
 }
 
+// claudeBlockTypeImage is the Claude content-block type for image sources.
+const claudeBlockTypeImage = "image"
+
 // convertImagePartToClaude converts an image part to Claude's format
 func (p *Provider) convertImagePartToClaude(
 	ctx context.Context, part types.ContentPart,
@@ -184,14 +190,13 @@ func (p *Provider) convertImagePartToClaude(
 	}
 
 	block := claudeContentBlockMultimodal{
-		Type: "image",
-		Source: &claudeImageSource{
-			MediaType: part.Media.MIMEType,
-		},
+		Type:   claudeBlockTypeImage,
+		Source: &claudeImageSource{},
 	}
 
 	// Prefer a model-fetchable URL (explicit URL or presigned StorageReference);
-	// fall back to inlined base64 bytes when no URL is available.
+	// fall back to inlined base64 bytes when no URL is available. MediaType is
+	// set only on the base64 branch — Anthropic rejects it on a url source.
 	loader := p.MediaLoader()
 	if url, ok, err := loader.ResolveURL(ctx, part.Media); err != nil {
 		return claudeContentBlockMultimodal{}, fmt.Errorf("failed to resolve image: %w", err)
@@ -204,6 +209,7 @@ func (p *Provider) convertImagePartToClaude(
 			return claudeContentBlockMultimodal{}, fmt.Errorf("failed to load image data: %w", err)
 		}
 		block.Source.Type = "base64"
+		block.Source.MediaType = part.Media.MIMEType
 		block.Source.Data = data
 	}
 

--- a/runtime/providers/media_loader.go
+++ b/runtime/providers/media_loader.go
@@ -204,6 +204,9 @@ func (ml *MediaLoader) loadFromStorage(ctx context.Context, ref string) (string,
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve media from storage %s: %w", ref, err)
 	}
+	if media == nil {
+		return "", fmt.Errorf("storage returned nil media for reference: %s", ref)
+	}
 
 	// Storage can return media with either Data or FilePath
 	if media.Data != nil && *media.Data != "" {

--- a/runtime/providers/media_loader_storage_test.go
+++ b/runtime/providers/media_loader_storage_test.go
@@ -1,0 +1,37 @@
+package providers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/storage"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// nilMediaStore is a misbehaving store whose RetrieveMedia returns (nil, nil).
+type nilMediaStore struct{}
+
+func (nilMediaStore) StoreMedia(context.Context, *types.MediaContent, *storage.MediaMetadata) (storage.Reference, error) {
+	return "", nil
+}
+func (nilMediaStore) RetrieveMedia(context.Context, storage.Reference) (*types.MediaContent, error) {
+	return nil, nil //nolint:nilnil // deliberately misbehaving store for the guard test
+}
+func (nilMediaStore) DeleteMedia(context.Context, storage.Reference) error { return nil }
+func (nilMediaStore) GetURL(context.Context, storage.Reference, time.Duration) (string, error) {
+	return "", nil
+}
+
+// TestGetBase64Data_NilMediaFromStore guards against a segfault when a storage
+// backend returns a nil *MediaContent with no error: it must surface an error,
+// not panic. Regression for the nil-deref found by the live e2e suite.
+func TestGetBase64Data_NilMediaFromStore(t *testing.T) {
+	loader := NewMediaLoader(MediaLoaderConfig{StorageService: nilMediaStore{}})
+	ref := "s3://bucket/key"
+	_, err := loader.GetBase64Data(context.Background(),
+		&types.MediaContent{StorageReference: &ref, MIMEType: "image/png"})
+	if err == nil {
+		t.Fatal("expected an error when the store returns nil media, got nil")
+	}
+}

--- a/sdk/e2e_storage_ref_test.go
+++ b/sdk/e2e_storage_ref_test.go
@@ -35,16 +35,21 @@ import (
 // S3/GCS presigned URL would, without the credential and network coupling.
 // =============================================================================
 
-// publicStorageRefImageURL is the same stable public test image the vision
-// URL test (e2e_vision_test.go) uses; reused so both cover an identical
-// remote-URL model path.
-const publicStorageRefImageURL = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/" +
-	"PNG_transparency_demonstration_1.png/300px-PNG_transparency_demonstration_1.png"
+// publicStorageRefImageURL is a stable, provider-fetchable public PNG. It stands
+// in for a presigned S3/GCS URL: the point is that the model fetches a remote URL
+// our code produced from a StorageReference. GitHub raw is used (not Wikipedia,
+// which bot-blocks provider fetchers with a 400 "unable to download").
+const publicStorageRefImageURL = "https://raw.githubusercontent.com/opencv/opencv/master/samples/data/opencv-logo.png"
 
 // urlFakeStore is a minimal MediaStorageService whose GetURL always returns a
 // stable, public, remote image URL. It lets the URL-resolution path be tested
-// without any cloud credentials.
-type urlFakeStore struct{ url string }
+// without any cloud credentials. URL-capable providers (Claude, OpenAI) hand
+// the model that URL; base64-only providers (Gemini) instead call RetrieveMedia,
+// so it also serves real image bytes.
+type urlFakeStore struct {
+	url      string
+	bytesB64 string // base64 image bytes, served by RetrieveMedia for base64-only providers
+}
 
 func (s *urlFakeStore) StoreMedia(
 	_ context.Context, _ *types.MediaContent, _ *storage.MediaMetadata,
@@ -55,7 +60,8 @@ func (s *urlFakeStore) StoreMedia(
 func (s *urlFakeStore) RetrieveMedia(
 	_ context.Context, _ storage.Reference,
 ) (*types.MediaContent, error) {
-	return nil, nil
+	data := s.bytesB64
+	return &types.MediaContent{Data: &data, MIMEType: "image/png"}, nil
 }
 
 func (s *urlFakeStore) DeleteMedia(_ context.Context, _ storage.Reference) error {
@@ -77,7 +83,10 @@ func TestE2E_StorageRef_URLPath(t *testing.T) {
 			t.Skip("Mock provider doesn't support real vision")
 		}
 
-		store := &urlFakeStore{url: publicStorageRefImageURL}
+		store := &urlFakeStore{
+			url:      publicStorageRefImageURL,
+			bytesB64: base64.StdEncoding.EncodeToString(getTestImage(t)),
+		}
 
 		conv := NewVisionConversation(t, provider, WithMediaStorage(store))
 		defer conv.Close()


### PR DESCRIPTION
## What & why

Follow-up to #1598. Running the new storage-reference e2e suite (`-tags=e2e`) against **real** OpenAI, Anthropic, and Gemini surfaced two bugs the mock-based unit tests missed. Both are fixed here; both resolution paths now pass live on all three providers.

## Fixes

1. **Runtime never-crash — nil media from a storage backend.** `MediaLoader.loadFromStorage` dereferenced the `*MediaContent` returned by `RetrieveMedia` without a nil check, so a store returning `(nil, nil)` **segfaulted the whole pipeline**. Now it returns a clear error. Regression test added (`TestGetBase64Data_NilMediaFromStore`).

2. **Claude 400 on URL image sources.** The Claude image source struct always emitted `media_type`; Anthropic rejects it on a `type:"url"` source with `400 "Extra inputs are not permitted"`. Added `omitempty` and set `MediaType` only on the base64 branch. This also fixes any plain `WithImageURL` send to Claude (latent before this feature).

3. **E2E fixture reliability.** The URL-path fake store now serves real bytes from `RetrieveMedia` (so base64-only Gemini resolves), and the test uses a provider-fetchable GitHub-raw PNG instead of the Wikipedia thumbnail URL that OpenAI/Anthropic bot-block (`400 unable to download`).

## Live verification

`go test -tags=e2e ./sdk/... -run TestE2E_StorageRef` (keys from `.env`):

```
--- PASS: TestE2E_StorageRef_URLPath/openai      (model described the fetched OpenCV logo)
--- PASS: TestE2E_StorageRef_URLPath/anthropic   (model described the fetched OpenCV logo)
--- PASS: TestE2E_StorageRef_URLPath/gemini       (bytes fallback; base64-only)
--- PASS: TestE2E_StorageRef_BytesPath/openai
--- PASS: TestE2E_StorageRef_BytesPath/anthropic
--- PASS: TestE2E_StorageRef_BytesPath/gemini
```

Unit suites (`runtime/providers/...`, `sdk/`) green; golangci-lint 0 new issues.
