### PR TITLE
fix(release): allow tools-only re-runs past the version ordering check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,18 @@ jobs:
             exit 1
           fi
         fi
-        
+
+        # tools-only re-runs finish tagging the SDK/server modules for a version
+        # whose libraries (runtime/pkg/root) are already tagged. The
+        # newer-than-latest ordering check below would always fail for that case
+        # (LATEST == the version being completed), so skip it for tools-only.
+        if [ "${{ inputs.phase }}" = "tools-only" ]; then
+          echo "✓ tools-only phase: skipping newer-than-latest ordering check"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "✓ Version $VERSION is valid for a tools-only release"
+          exit 0
+        fi
+
         # Get latest version and compare
         echo "Checking if $VERSION is newer than existing versions..."
         LATEST_TAG=$(git tag -l "runtime/v*" | sort -V | tail -n1)


### PR DESCRIPTION
## Problem

The `Release` workflow's `Validate Release` step has **two** guards against re-releasing a version:

1. **"Version already exists"** (release.yml:64-72) — exempts the `tools-only` phase, so the SDK/server modules can be tagged after a `libs-only` release.
2. **"Newer than latest" ordering check** (release.yml:78+) — had **no** such exemption.

Because a `tools-only` run by definition targets a version whose libraries are already tagged, `LATEST_TAG` equals the version being completed, so guard #2 always resolves to:

```
##[error]New version vX.Y.Z is not newer than latest vX.Y.Z (patch version is not higher)
```

This makes the documented `tools-only` recovery path (re-tag `sdk/`, `server/a2a/` after libs) **impossible**. Observed on a `tools-only` dispatch for `v1.5.4` (libs tagged 2026-07-02, SDK never tagged).

## Fix

Skip the ordering check for the `tools-only` phase, mirroring guard #1. `full` and `libs-only` are unaffected.

## Notes

- This PR touches `.github/workflows/**`, so it needs to be **merged in the UI** (the `gh` CLI token lacks `workflow` scope).
- Discovered while completing a release; the actual v1.5.4 SDK tag was intentionally **not** force-completed because `main` had moved 44 commits ahead — a fresh `v1.5.5 full` release was cut instead. This fix is for future legitimate same-day `tools-only` recovery.
