### PR TITLE
fix(tools): require explicit allowed_tools for MCP tools + wildcards (#1578)

### DIFF
--- a/docs/src/content/docs/runtime/reference/mcp.md
+++ b/docs/src/content/docs/runtime/reference/mcp.md
@@ -873,7 +873,7 @@ type ToolFilter struct {
 func (f ToolFilter) Includes(name string) bool
 ```
 
-Includes returns true if the given tool name passes the filter.
+Includes returns true if the given tool name passes the filter. Allowlist and blocklist entries may use a trailing\-"\*" prefix wildcard.
 
 <a name="ToolsCapability"></a>
 ## type ToolsCapability

--- a/docs/src/content/docs/runtime/reference/tools.md
+++ b/docs/src/content/docs/runtime/reference/tools.md
@@ -31,7 +31,9 @@ Tools can be loaded from YAML/JSON files and executed with argument validation, 
 - [func ContentTypeToMediaType\(contentType string\) string](<#ContentTypeToMediaType>)
 - [func DecodeArgsExtras\(args json.RawMessage, typed any, knownKeys ...string\) \(map\[string\]any, error\)](<#DecodeArgsExtras>)
 - [func IsBinaryContentType\(contentType string, acceptTypes \[\]string\) bool](<#IsBinaryContentType>)
+- [func IsImplicitTool\(name string\) bool](<#IsImplicitTool>)
 - [func IsSystemTool\(name string\) bool](<#IsSystemTool>)
+- [func MatchToolPattern\(pattern, name string\) bool](<#MatchToolPattern>)
 - [func MergeExtrasIntoMetadata\(target, extras map\[string\]any\) map\[string\]any](<#MergeExtrasIntoMetadata>)
 - [func ParseToolName\(name string\) \(namespace, localName string\)](<#ParseToolName>)
 - [func QualifyToolName\(namespace, localName string\) string](<#QualifyToolName>)
@@ -300,6 +302,15 @@ func IsBinaryContentType(contentType string, acceptTypes []string) bool
 
 IsBinaryContentType returns true if the Content\-Type indicates a binary response that should be handled as multimodal content rather than JSON. If acceptTypes is non\-empty, only those specific types match. Otherwise, common image/audio/video prefixes are checked.
 
+<a name="IsImplicitTool"></a>
+## func IsImplicitTool
+
+```go
+func IsImplicitTool(name string) bool
+```
+
+IsImplicitTool reports whether a system tool is auto\-surfaced to every prompt without an allowed\_tools entry. Capability tools \(a2a, workflow, memory, skill, image/video mediagen\) are implicitly available. MCP tools are system\-namespaced but must be listed explicitly in allowed\_tools \(or matched by an mcp\_\_\<server\>\_\_\* wildcard\), so they are excluded here.
+
 <a name="IsSystemTool"></a>
 ## func IsSystemTool
 
@@ -308,6 +319,15 @@ func IsSystemTool(name string) bool
 ```
 
 IsSystemTool returns true if name belongs to a known system namespace.
+
+<a name="MatchToolPattern"></a>
+## func MatchToolPattern
+
+```go
+func MatchToolPattern(pattern, name string) bool
+```
+
+MatchToolPattern reports whether a tool name matches an allowed\_tools entry. An entry ending in "\*" is a prefix match \(the text before "\*" is treated as a literal prefix\), so "mcp\_\_memory\_\_\*" matches every tool from the "memory" MCP server and "mcp\_\_\*" matches every MCP tool. Any other entry is an exact match.
 
 <a name="MergeExtrasIntoMetadata"></a>
 ## func MergeExtrasIntoMetadata

--- a/runtime/mcp/tool_filter_test.go
+++ b/runtime/mcp/tool_filter_test.go
@@ -43,4 +43,19 @@ func TestToolFilter_Includes(t *testing.T) {
 		// not in either list — excluded by allowlist logic
 		assert.False(t, f.Includes("other"))
 	})
+
+	t.Run("allowlist supports trailing-* prefix wildcards", func(t *testing.T) {
+		f := ToolFilter{Allowlist: []string{"read_*"}}
+		assert.True(t, f.Includes("read_file"))
+		assert.True(t, f.Includes("read_dir"))
+		assert.False(t, f.Includes("write_file"))
+		assert.False(t, f.Includes("read")) // no trailing text, not the "read_" prefix
+	})
+
+	t.Run("blocklist supports trailing-* prefix wildcards", func(t *testing.T) {
+		f := ToolFilter{Blocklist: []string{"admin_*"}}
+		assert.True(t, f.Includes("read"))
+		assert.False(t, f.Includes("admin_delete"))
+		assert.False(t, f.Includes("admin_reset"))
+	})
 }

--- a/runtime/mcp/types.go
+++ b/runtime/mcp/types.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 )
 
 // ProtocolVersion defines the MCP protocol version (as of 2025-06-18).
@@ -148,18 +149,29 @@ type ToolFilter struct {
 	Blocklist []string `json:"blocklist,omitempty" yaml:"blocklist,omitempty"`
 }
 
-// Includes returns true if the given tool name passes the filter.
+// matchToolPattern reports whether a tool name matches a filter entry. An entry
+// ending in "*" is a prefix match (e.g. "read_*" matches "read_file"); any other
+// entry is an exact match.
+func matchToolPattern(pattern, name string) bool {
+	if prefix, ok := strings.CutSuffix(pattern, "*"); ok {
+		return strings.HasPrefix(name, prefix)
+	}
+	return pattern == name
+}
+
+// Includes returns true if the given tool name passes the filter. Allowlist and
+// blocklist entries may use a trailing-"*" prefix wildcard.
 func (f ToolFilter) Includes(name string) bool {
 	if len(f.Allowlist) > 0 {
 		for _, a := range f.Allowlist {
-			if a == name {
+			if matchToolPattern(a, name) {
 				return true
 			}
 		}
 		return false
 	}
 	for _, b := range f.Blocklist {
-		if b == name {
+		if matchToolPattern(b, name) {
 			return false
 		}
 	}

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -2059,17 +2059,7 @@ func (s *ProviderStage) collectProviderDescriptors(
 ) []*providers.ToolDescriptor {
 	seen := make(map[string]bool)
 	var descriptors []*providers.ToolDescriptor
-
-	// 1. Pack-declared tools from the prompt's allowed list (slice order).
-	for _, toolName := range allowedTools {
-		if excluded[toolName] {
-			continue
-		}
-		tool, err := s.toolRegistry.GetTool(toolName)
-		if err != nil {
-			logger.Warn("Tool not found in registry", "tool", toolName, "error", err)
-			continue
-		}
+	add := func(tool *tools.ToolDescriptor) {
 		seen[tool.Name] = true
 		descriptors = append(descriptors, &providers.ToolDescriptor{
 			Name:        tool.Name,
@@ -2078,17 +2068,40 @@ func (s *ProviderStage) collectProviderDescriptors(
 		})
 	}
 
-	// 2. Capability tools (skill__, a2a__, workflow__, mcp__, memory__), gathered
-	//    in randomized map order — sorted below to make the whole set stable.
+	// 1. Pack-declared tools from the prompt's allowed list (slice order). An
+	//    entry ending in "*" (e.g. mcp__server__*) is a wildcard expanded against
+	//    the registry: MCP servers reveal their tool sets only at connection time,
+	//    so authors can't enumerate exact names (issue #1578).
+	for _, entry := range allowedTools {
+		if strings.HasSuffix(entry, "*") {
+			s.toolRegistry.IterateTools(func(name string, tool *tools.ToolDescriptor) {
+				if seen[name] || excluded[name] || !tools.MatchToolPattern(entry, name) {
+					return
+				}
+				add(tool)
+			})
+			continue
+		}
+		if excluded[entry] {
+			continue
+		}
+		tool, err := s.toolRegistry.GetTool(entry)
+		if err != nil {
+			logger.Warn("Tool not found in registry", "tool", entry, "error", err)
+			continue
+		}
+		add(tool)
+	}
+
+	// 2. Implicit capability tools (skill__, a2a__, workflow__, memory__, media),
+	//    gathered in randomized map order — sorted below to make the whole set
+	//    stable. MCP tools are NOT implicit: they surface only via an explicit
+	//    allowed_tools entry in loop 1 above (issue #1578).
 	s.toolRegistry.IterateTools(func(name string, tool *tools.ToolDescriptor) {
-		if seen[name] || excluded[name] || !tools.IsSystemTool(name) {
+		if seen[name] || excluded[name] || !tools.IsImplicitTool(name) {
 			return
 		}
-		descriptors = append(descriptors, &providers.ToolDescriptor{
-			Name:        tool.Name,
-			Description: tool.Description,
-			InputSchema: tool.InputSchema,
-		})
+		add(tool)
 	})
 
 	sort.Slice(descriptors, func(i, j int) bool {

--- a/runtime/pipeline/stage/stages_provider_allowed_tools_test.go
+++ b/runtime/pipeline/stage/stages_provider_allowed_tools_test.go
@@ -1,0 +1,129 @@
+package stage
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+)
+
+// buildToolRegistry registers the given tool names with a trivial object schema.
+func buildToolRegistry(t *testing.T, names ...string) *tools.Registry {
+	t.Helper()
+	reg := tools.NewRegistry()
+	for _, n := range names {
+		if err := reg.Register(&tools.ToolDescriptor{
+			Name: n, Description: "d", InputSchema: json.RawMessage(`{"type":"object"}`),
+		}); err != nil {
+			t.Fatalf("register %s: %v", n, err)
+		}
+	}
+	return reg
+}
+
+// sortedDescriptorNames returns the descriptor names, sorted, for set comparison.
+func sortedDescriptorNames(s *ProviderStage, allowed []string, excluded map[string]bool) []string {
+	names := descriptorNames(s.collectProviderDescriptors(allowed, excluded))
+	sort.Strings(names)
+	return names
+}
+
+// MCP tools are system-namespaced but must be surfaced only when named in
+// allowed_tools (issue #1578). Capability tools (a2a/workflow/memory/skill/media)
+// stay auto-surfaced. Wildcard allowed_tools entries expand against the registry.
+func TestCollectProviderDescriptors_AllowedTools(t *testing.T) {
+	// Registry: two MCP servers (kb, fs), one capability tool, one user tool.
+	const (
+		kbCreate = "mcp__kb__create"
+		kbRecall = "mcp__kb__recall"
+		fsRead   = "mcp__fs__read"
+		a2aTool  = "a2a__agent__forecast" // implicit capability
+		userTool = "get_weather"          // plain user tool
+	)
+	newStage := func() *ProviderStage {
+		return &ProviderStage{
+			toolRegistry: buildToolRegistry(t, kbCreate, kbRecall, fsRead, a2aTool, userTool),
+		}
+	}
+
+	tests := []struct {
+		name     string
+		allowed  []string
+		excluded map[string]bool
+		want     []string
+	}{
+		{
+			name:    "no allowed_tools surfaces only implicit capability tools",
+			allowed: nil,
+			want:    []string{a2aTool},
+		},
+		{
+			name:    "exact MCP name surfaces just that tool plus implicit",
+			allowed: []string{kbCreate},
+			want:    []string{a2aTool, kbCreate},
+		},
+		{
+			name:    "server wildcard surfaces that server only",
+			allowed: []string{"mcp__kb__*"},
+			want:    []string{a2aTool, kbCreate, kbRecall},
+		},
+		{
+			name:    "namespace wildcard surfaces all MCP tools",
+			allowed: []string{"mcp__*"},
+			want:    []string{a2aTool, fsRead, kbCreate, kbRecall},
+		},
+		{
+			name:     "excluded tool is dropped from wildcard expansion",
+			allowed:  []string{"mcp__kb__*"},
+			excluded: map[string]bool{kbRecall: true},
+			want:     []string{a2aTool, kbCreate},
+		},
+		{
+			name:    "user tool surfaces only when explicitly allowed",
+			allowed: []string{userTool},
+			want:    []string{a2aTool, userTool},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortedDescriptorNames(newStage(), tt.allowed, tt.excluded)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// Wildcard expansion walks the registry via IterateTools (randomized map order),
+// so it carries the same cache-stability risk as the auto-surface loop: the tools
+// array is part of the provider's cached prefix, and a varying order busts prompt
+// caching (see reference: tool order breaks prompt caching). The shared sort keeps
+// it stable; this guards against a future change to the wildcard path losing it.
+func TestCollectProviderDescriptors_WildcardDeterministic(t *testing.T) {
+	reg := buildToolRegistry(t,
+		"mcp__kb__zebra", "mcp__kb__alpha", "mcp__kb__mike", "mcp__kb__bravo",
+		"mcp__kb__yankee", "mcp__kb__delta", "mcp__kb__oscar", "mcp__kb__charlie",
+	)
+	s := &ProviderStage{toolRegistry: reg}
+
+	first := descriptorNames(s.collectProviderDescriptors([]string{"mcp__kb__*"}, nil))
+	if len(first) != 8 {
+		t.Fatalf("expected 8 descriptors, got %d: %v", len(first), first)
+	}
+	if !sort.StringsAreSorted(first) {
+		t.Fatalf("wildcard-expanded descriptors must be sorted (cache stability), got %v", first)
+	}
+	for i := range 100 {
+		got := descriptorNames(s.collectProviderDescriptors([]string{"mcp__kb__*"}, nil))
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("non-deterministic wildcard order on call %d:\n got %v\nwant %v", i, got, first)
+		}
+	}
+}

--- a/runtime/pipeline/stage/tool_order_determinism_test.go
+++ b/runtime/pipeline/stage/tool_order_determinism_test.go
@@ -27,9 +27,13 @@ func descriptorNames(ds []*providers.ToolDescriptor) []string {
 // sort.
 func TestCollectProviderDescriptors_DeterministicSortedOrder(t *testing.T) {
 	reg := tools.NewRegistry()
+	// a2a__ tools are implicitly surfaced (no allowed_tools entry needed), so this
+	// exercises the auto-surface loop's map-iteration order. MCP tools are no
+	// longer implicit (issue #1578) — see the wildcard determinism test for that
+	// path.
 	for _, n := range []string{
-		"mcp__zebra", "mcp__alpha", "mcp__mike", "mcp__bravo",
-		"mcp__yankee", "mcp__delta", "mcp__oscar", "mcp__charlie",
+		"a2a__zebra", "a2a__alpha", "a2a__mike", "a2a__bravo",
+		"a2a__yankee", "a2a__delta", "a2a__oscar", "a2a__charlie",
 	} {
 		if err := reg.Register(&tools.ToolDescriptor{
 			Name: n, Description: "d", InputSchema: json.RawMessage(`{"type":"object"}`),

--- a/runtime/tools/types.go
+++ b/runtime/tools/types.go
@@ -68,6 +68,27 @@ func IsSystemTool(name string) bool {
 	return knownNamespaces[ns]
 }
 
+// MatchToolPattern reports whether a tool name matches an allowed_tools entry.
+// An entry ending in "*" is a prefix match (the text before "*" is treated as a
+// literal prefix), so "mcp__memory__*" matches every tool from the "memory" MCP
+// server and "mcp__*" matches every MCP tool. Any other entry is an exact match.
+func MatchToolPattern(pattern, name string) bool {
+	if prefix, ok := strings.CutSuffix(pattern, "*"); ok {
+		return strings.HasPrefix(name, prefix)
+	}
+	return pattern == name
+}
+
+// IsImplicitTool reports whether a system tool is auto-surfaced to every prompt
+// without an allowed_tools entry. Capability tools (a2a, workflow, memory,
+// skill, image/video mediagen) are implicitly available. MCP tools are
+// system-namespaced but must be listed explicitly in allowed_tools (or matched
+// by an mcp__<server>__* wildcard), so they are excluded here.
+func IsImplicitTool(name string) bool {
+	ns, _ := ParseToolName(name)
+	return knownNamespaces[ns] && ns != modeMCP
+}
+
 // ToolConfig represents a K8s-style tool configuration manifest
 type ToolConfig struct {
 	APIVersion string            `json:"apiVersion" yaml:"apiVersion"`

--- a/runtime/tools/types_test.go
+++ b/runtime/tools/types_test.go
@@ -207,6 +207,54 @@ func TestIsSystemTool(t *testing.T) {
 	}
 }
 
+func TestIsImplicitTool(t *testing.T) {
+	tests := []struct {
+		name string
+		tool string
+		want bool
+	}{
+		{"a2a auto-surfaced", "a2a__weather__forecast", true},
+		{"workflow auto-surfaced", "workflow__transition", true},
+		{"memory auto-surfaced", "memory__recall", true},
+		{"skill auto-surfaced", "skill__do_thing", true},
+		{"image auto-surfaced", "image__generate", true},
+		{"video auto-surfaced", "video__generate", true},
+		{"mcp NOT auto-surfaced", "mcp__fs__read_file", false},
+		{"user tool", "get_weather", false},
+		{"empty string", "", false},
+		{"unknown namespace", "custom__tool", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsImplicitTool(tt.tool))
+		})
+	}
+}
+
+func TestMatchToolPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		tool    string
+		want    bool
+	}{
+		{"exact match", "get_weather", "get_weather", true},
+		{"exact mismatch", "get_weather", "get_forecast", false},
+		{"server wildcard matches", "mcp__memory__*", "mcp__memory__create_entities", true},
+		{"server wildcard other server", "mcp__memory__*", "mcp__fs__read_file", false},
+		{"namespace wildcard matches", "mcp__*", "mcp__memory__create_entities", true},
+		{"namespace wildcard other namespace", "mcp__*", "a2a__agent__do", false},
+		{"bare star matches anything", "*", "literally__anything", true},
+		{"server prefix does not match a different server", "mcp__memory__*", "mcp__memory_other__x", false},
+		{"exact name is not a prefix of longer", "mcp__memory__create", "mcp__memory__create_entities", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, MatchToolPattern(tt.pattern, tt.tool))
+		})
+	}
+}
+
 func TestParseToolName_RoundTrip(t *testing.T) {
 	// Verify that QualifyToolName(ParseToolName(name)) == name for namespaced names
 	names := []string{


### PR DESCRIPTION
## Summary

MCP tools were auto-surfaced to the provider **regardless of `allowed_tools`**, because `mcp` is a system namespace and the auto-surface loop in `collectProviderDescriptors` keyed off `tools.IsSystemTool`. A pack that used MCP tools but declared them incorrectly (or not at all) in `allowed_tools` **passed in Arena but broke on deploy** (which honors only `allowed_tools`) — the test run was not representative of production.

Closes #1578 (runtime side).

## Changes

- **`IsImplicitTool`** — new predicate: system-namespaced *and* implicitly available to every prompt. The auto-surface loop now uses it, which **excludes MCP**. Capability tools (a2a / workflow / memory / skill / image·video mediagen) stay auto-surfaced. `IsSystemTool` semantics are unchanged (MCP is still a system namespace for every other purpose).
- **Wildcard `allowed_tools`** — trailing-`*` prefix wildcards (`mcp__<server>__*`, `mcp__*`) are expanded against the tool registry in the allowlist loop. An MCP server's tool set is discovered at connection time, so authors can't enumerate exact names when authoring the pack — the wildcard is needed alongside the fix, not optional.
- **`mcp.ToolFilter.Includes`** — mirror the same trailing-`*` wildcard on allowlist + blocklist (server-local names, e.g. `read_*`).
- **Tests** — re-point the tool-order determinism test to `a2a__` (still-implicit) names so it keeps guarding the auto-surface loop's sort; add a wildcard-expansion determinism guard (same cache-stability invariant); full `IsImplicitTool` / `MatchToolPattern` / `collectProviderDescriptors` / `ToolFilter` coverage.

## Behavior

| `allowed_tools` | Before | After |
|---|---|---|
| (empty) + MCP registered | all MCP tools surface | no MCP tools surface; capability tools still do |
| `mcp__kb__create` | that tool + all other MCP | just that tool (+ implicit) |
| `mcp__kb__*` | none (exact lookup fails) | all `kb` server tools |
| `mcp__*` | — | all MCP tools |

Arena and deployed packs now behave identically.

## Downstream (separate promptarena PR)

- Example packs (`mcp-chatbot`, `mcp-memory-test`, `mcp-filesystem-test`, `mcp-everything-test`) use bare MCP tool names (e.g. `create_entities`) — they need qualifying to `mcp__<server>__create_entities` or `mcp__<server>__*`, else they get no tools after this fix.
- A `packc` compile-time warning when an `allowed_tools` entry resolves to no registered tool (and no wildcard).

## Test plan

- `go test ./runtime/... -count=1` — full runtime suite passes.
- `go test ./sdk/... -count=1` — SDK suite passes (shared pipeline path).
- `-race` on `tools`, `mcp`, `pipeline/stage`.
- Coverage on changed files ≥ 80% (mcp/types.go 100%, tools/types.go 100%, stages_provider.go 88.9%).
