### PR TITLE
feat: composable streaming pipeline with WithIngestion duplex-agent path

### DIFF
--- a/runtime/audio/doc.go
+++ b/runtime/audio/doc.go
@@ -5,6 +5,7 @@
 //   - VAD (Voice Activity Detection): Detects when someone is speaking vs. silent
 //   - Turn Detection: Determines when a speaker has finished their turn
 //   - Interruption Handling: Manages user interrupting bot output
+//   - G.711 Codec: mu-law/a-law companding <-> PCM16 (telephony/SIP/PSTN)
 //
 // # Architecture
 //

--- a/runtime/audio/g711.go
+++ b/runtime/audio/g711.go
@@ -1,0 +1,147 @@
+package audio
+
+import "encoding/binary"
+
+// G.711 telephony codec (mu-law / a-law) <-> little-endian PCM16. Pure
+// computation; the standard companding used by SIP/PSTN/Twilio/Talkdesk.
+
+const (
+	bytesPerSample = 2 // little-endian PCM16 = 2 bytes per sample
+
+	muLawBias = 0x84  // 132, per ITU-T G.711
+	muLawClip = 32635 // largest magnitude before mu-law clipping
+	aLawClip  = 32635 // largest magnitude before a-law clipping
+
+	signBit      = 0x80 // sign bit in the wire byte (mu-law and a-law)
+	segmentMask  = 0x07 // 3-bit segment/exponent value once shifted into place
+	mantissaMask = 0x0F // 4-bit mantissa mask (low nibble)
+	nibbleShift  = 4    // bit width of the segment/mantissa nibbles
+
+	maxSegmentExponent = 7      // largest 3-bit segment exponent
+	topSegmentBit      = 0x4000 // starting probe bit when searching for the segment exponent
+	mantissaBitShift   = 3      // bits below the mantissa field in the raw sample magnitude
+
+	aLawToggleMask      = 0x55  // alternating-bit mask XORed into every a-law wire byte
+	aLawExpMask         = 0x70  // 3-bit exponent field, still in bits 4-6
+	aLawSegmentBias     = 8     // a-law: linear bias for the lowest (exponent-0) segment
+	aLawSegmentBase     = 0x100 // a-law: base added once above the lowest segment
+	aLawLinearThreshold = 256   // below this magnitude, a-law encodes the linear segment directly
+)
+
+// DecodeMuLaw converts G.711 mu-law bytes to little-endian PCM16 (2 bytes/sample).
+func DecodeMuLaw(mulaw []byte) []byte {
+	out := make([]byte, len(mulaw)*bytesPerSample)
+	for i, u := range mulaw {
+		//nolint:gosec // decodeMuLawSample is bounded to +-32124, fits uint16 bit pattern
+		binary.LittleEndian.PutUint16(out[i*bytesPerSample:], uint16(decodeMuLawSample(u)))
+	}
+	return out
+}
+
+// EncodeMuLaw converts little-endian PCM16 to G.711 mu-law bytes (1 byte/sample).
+func EncodeMuLaw(pcm16le []byte) []byte {
+	n := len(pcm16le) / bytesPerSample
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		//nolint:gosec // reinterpreting PCM16 wire bytes as a signed sample; same bit pattern
+		out[i] = encodeMuLawSample(int16(binary.LittleEndian.Uint16(pcm16le[i*bytesPerSample:])))
+	}
+	return out
+}
+
+func decodeMuLawSample(u byte) int16 {
+	u = ^u // stored inverted
+	sign := u & signBit
+	exponent := (u >> nibbleShift) & segmentMask
+	mantissa := u & mantissaMask
+	sample := (int(mantissa) << mantissaBitShift) + muLawBias
+	sample <<= exponent
+	sample -= muLawBias
+	if sign != 0 {
+		sample = -sample
+	}
+	return int16(sample) //nolint:gosec // G.711 companding bounds the magnitude to +-32124, fits int16
+}
+
+func encodeMuLawSample(sample int16) byte {
+	sign := 0
+	s := int(sample)
+	if s < 0 {
+		sign = signBit
+		s = -s
+	}
+	if s > muLawClip {
+		s = muLawClip
+	}
+	s += muLawBias
+	exponent := maxSegmentExponent
+	for mask := topSegmentBit; s&mask == 0 && exponent > 0; mask >>= 1 {
+		exponent--
+	}
+	mantissa := (s >> (exponent + mantissaBitShift)) & mantissaMask
+	return byte(^(sign | (exponent << nibbleShift) | mantissa)) //nolint:gosec // result is masked to one byte
+}
+
+// DecodeALaw converts G.711 a-law bytes to little-endian PCM16 (2 bytes/sample).
+func DecodeALaw(alaw []byte) []byte {
+	out := make([]byte, len(alaw)*bytesPerSample)
+	for i, a := range alaw {
+		//nolint:gosec // decodeALawSample is bounded to +-32124, fits uint16 bit pattern
+		binary.LittleEndian.PutUint16(out[i*bytesPerSample:], uint16(decodeALawSample(a)))
+	}
+	return out
+}
+
+// EncodeALaw converts little-endian PCM16 to G.711 a-law bytes (1 byte/sample).
+func EncodeALaw(pcm16le []byte) []byte {
+	n := len(pcm16le) / bytesPerSample
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		//nolint:gosec // reinterpreting PCM16 wire bytes as a signed sample; same bit pattern
+		out[i] = encodeALawSample(int16(binary.LittleEndian.Uint16(pcm16le[i*bytesPerSample:])))
+	}
+	return out
+}
+
+func decodeALawSample(a byte) int16 {
+	a ^= aLawToggleMask
+	sign := a & signBit
+	exponent := (a & aLawExpMask) >> nibbleShift
+	mantissa := int(a & mantissaMask)
+	sample := (mantissa << nibbleShift) + aLawSegmentBias
+	if exponent != 0 {
+		sample += aLawSegmentBase
+		sample <<= exponent - 1
+	}
+	if sign == 0 {
+		return int16(-sample)
+	}
+	return int16(sample)
+}
+
+func encodeALawSample(sample int16) byte {
+	s := int(sample)
+	sign := signBit
+	if s < 0 {
+		sign = 0
+		s = -s - 1
+		if s < 0 {
+			s = 0
+		}
+	}
+	if s > aLawClip {
+		s = aLawClip
+	}
+	var enc byte
+	if s >= aLawLinearThreshold {
+		exponent := maxSegmentExponent
+		for mask := topSegmentBit; s&mask == 0 && exponent > 0; mask >>= 1 {
+			exponent--
+		}
+		mantissa := (s >> (exponent + mantissaBitShift)) & mantissaMask
+		enc = byte((exponent << nibbleShift) | mantissa) //nolint:gosec // result is masked to one byte
+	} else {
+		enc = byte(s >> nibbleShift)
+	}
+	return (byte(sign) | enc) ^ aLawToggleMask
+}

--- a/runtime/audio/g711_test.go
+++ b/runtime/audio/g711_test.go
@@ -1,0 +1,84 @@
+package audio
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// Known G.711 μ-law anchor values (ITU-T G.711, canonical Sun/ITU reference
+// bit layout: sign bit is the MSB of the *wire* byte, mirrored across 0x00
+// and 0x80 since 0xFF and 0x7F are the two "zero" codes, positive and
+// negative zero respectively):
+//
+//	0xFF decodes to 0 (positive-zero / silence midpoint);
+//	0x00 decodes to the largest-magnitude negative sample (-32124);
+//	0x80 decodes to the largest-magnitude positive sample (+32124).
+func TestDecodeMuLaw_AnchorValues(t *testing.T) {
+	out := DecodeMuLaw([]byte{0xFF, 0x00, 0x80})
+	if len(out) != 6 {
+		t.Fatalf("expected 6 bytes (3 samples), got %d", len(out))
+	}
+	s0 := int16(binary.LittleEndian.Uint16(out[0:2]))
+	s1 := int16(binary.LittleEndian.Uint16(out[2:4]))
+	s2 := int16(binary.LittleEndian.Uint16(out[4:6]))
+	if s0 != 0 {
+		t.Errorf("0xFF should decode to 0, got %d", s0)
+	}
+	if s1 != -32124 {
+		t.Errorf("0x00 should decode to -32124, got %d", s1)
+	}
+	if s2 != 32124 {
+		t.Errorf("0x80 should decode to 32124, got %d", s2)
+	}
+}
+
+// Known G.711 a-law anchor values (ITU-T G.711, canonical reference bit
+// layout: the wire byte is XORed with the alternating-bit mask 0x55, and
+// zero encodes to the positive-zero code 0xD5, whose reconstruction is the
+// small linear-segment bias +8, not exactly 0).
+func TestALaw_AnchorValues(t *testing.T) {
+	zero := pcmBytes(0)
+	enc := EncodeALaw(zero)
+	if len(enc) != 1 || enc[0] != 0xD5 {
+		t.Fatalf("EncodeALaw(0) should yield 0xD5, got %#x", enc)
+	}
+
+	out := DecodeALaw([]byte{0xD5})
+	if len(out) != 2 {
+		t.Fatalf("expected 2 bytes (1 sample), got %d", len(out))
+	}
+	s0 := int16(binary.LittleEndian.Uint16(out[0:2]))
+	if s0 != 8 {
+		t.Errorf("0xD5 should decode to +8, got %d", s0)
+	}
+}
+
+func pcmBytes(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+func TestMuLaw_RoundTrip(t *testing.T) {
+	samples := []int16{0, 1000, -1000, 30000, -30000, 12345}
+	back := DecodeMuLaw(EncodeMuLaw(pcmBytes(samples...)))
+	for i, want := range samples {
+		got := int16(binary.LittleEndian.Uint16(back[i*2:]))
+		if d := int(got) - int(want); d > 400 || d < -400 {
+			t.Errorf("mu-law sample %d: got %d want ~%d", i, got, want)
+		}
+	}
+}
+
+func TestALaw_RoundTrip(t *testing.T) {
+	samples := []int16{0, 1000, -1000, 30000, -30000, 12345}
+	back := DecodeALaw(EncodeALaw(pcmBytes(samples...)))
+	for i, want := range samples {
+		got := int16(binary.LittleEndian.Uint16(back[i*2:]))
+		if d := int(got) - int(want); d > 400 || d < -400 {
+			t.Errorf("a-law sample %d: got %d want ~%d", i, got, want)
+		}
+	}
+}

--- a/runtime/pipeline/stage/builder.go
+++ b/runtime/pipeline/stage/builder.go
@@ -110,6 +110,15 @@ func (b *PipelineBuilder) Branch(fromStage string, toStages ...string) *Pipeline
 	return b
 }
 
+// Merge wires multiple upstream stages into a single downstream fan-in node.
+// The target stage must implement MultiInputStage (e.g. MergeStage).
+func (b *PipelineBuilder) Merge(into string, from ...string) *PipelineBuilder {
+	for _, f := range from {
+		b.Connect(f, into)
+	}
+	return b
+}
+
 // Build constructs the pipeline from the builder's configuration.
 // It validates the pipeline structure and returns an error if invalid.
 func (b *PipelineBuilder) Build() (*StreamPipeline, error) {
@@ -119,13 +128,14 @@ func (b *PipelineBuilder) Build() (*StreamPipeline, error) {
 	}
 
 	// Precompute root stages (stages with no incoming edges) and
-	// reverse-edge adjacency map for O(1) upstream lookup.
-	reverseEdges := make(map[string]string)
+	// reverse-edge adjacency map for O(1) upstream lookup. Fan-in aware:
+	// a stage may have multiple upstreams (see MultiInputStage).
+	reverseEdges := make(map[string][]string)
 	hasIncoming := make(map[string]struct{})
 	for fromStage, toStages := range b.edges {
 		for _, toStage := range toStages {
 			hasIncoming[toStage] = struct{}{}
-			reverseEdges[toStage] = fromStage
+			reverseEdges[toStage] = append(reverseEdges[toStage], fromStage)
 		}
 	}
 	rootStages := make(map[string]struct{})
@@ -135,15 +145,30 @@ func (b *PipelineBuilder) Build() (*StreamPipeline, error) {
 		}
 	}
 
+	// Precompute the set of stages implementing MultiOutputStage (selective
+	// fan-out / 1:N routing, e.g. RouterStage), keyed by name and holding the
+	// asserted MultiOutputStage reference, so getStageInputs can decide, per
+	// upstream, whether a downstream reads a dedicated per-edge channel or the
+	// upstream's shared output channel (linear / competitive Branch fan-out).
+	// This is the single source of truth for "which stages are multi-output" —
+	// registerMultiOutputEdges reuses it instead of re-asserting per Execute().
+	multiOutputStages := make(map[string]MultiOutputStage)
+	for _, s := range b.stages {
+		if mo, ok := s.(MultiOutputStage); ok {
+			multiOutputStages[s.Name()] = mo
+		}
+	}
+
 	// Build the pipeline
 	return &StreamPipeline{
-		stages:       b.stages,
-		edges:        b.edges,
-		reverseEdges: reverseEdges,
-		rootStages:   rootStages,
-		config:       b.config,
-		eventEmitter: b.eventEmitter,
-		shutdown:     make(chan struct{}),
+		stages:            b.stages,
+		edges:             b.edges,
+		reverseEdges:      reverseEdges,
+		rootStages:        rootStages,
+		multiOutputStages: multiOutputStages,
+		config:            b.config,
+		eventEmitter:      b.eventEmitter,
+		shutdown:          make(chan struct{}),
 	}, nil
 }
 
@@ -185,9 +210,77 @@ func (b *PipelineBuilder) validate() error {
 		return err
 	}
 
+	// Reject fan-in into a stage that cannot handle multiple upstreams.
+	if err := b.validateFanIn(stageNames); err != nil {
+		return err
+	}
+
 	// Validate format capabilities between connected stages (logs warnings)
 	ValidateCapabilities(b.stages, b.edges)
 
+	return nil
+}
+
+// validateFanIn rejects a stage with more than one upstream edge unless it
+// implements MultiInputStage (e.g. MergeStage). stageNames is passed in from
+// validate() since it has already confirmed all stage names are unique.
+// It also detects and rejects duplicate upstream edges into any stage.
+func (b *PipelineBuilder) validateFanIn(stageNames map[string]bool) error {
+	upstreamCount, upstreamPairs := b.buildUpstreamMaps()
+	if err := checkDuplicateFanInEdges(upstreamPairs); err != nil {
+		return err
+	}
+	return b.checkFanInSupport(upstreamCount, stageNames)
+}
+
+// buildUpstreamMaps tallies, per destination stage, the number of incoming
+// edges (upstreamCount) and the count of edges from each source
+// (upstreamPairs), the latter used to detect duplicate edges.
+func (b *PipelineBuilder) buildUpstreamMaps() (upstreamCount map[string]int, upstreamPairs map[string]map[string]int) {
+	upstreamCount = make(map[string]int)
+	upstreamPairs = make(map[string]map[string]int)
+	for fromStage, toStages := range b.edges {
+		for _, toStage := range toStages {
+			upstreamCount[toStage]++
+			if upstreamPairs[toStage] == nil {
+				upstreamPairs[toStage] = make(map[string]int)
+			}
+			upstreamPairs[toStage][fromStage]++
+		}
+	}
+	return upstreamCount, upstreamPairs
+}
+
+// checkDuplicateFanInEdges rejects more than one edge between the same
+// (source, destination) stage pair.
+func checkDuplicateFanInEdges(upstreamPairs map[string]map[string]int) error {
+	for toStage, upstreams := range upstreamPairs {
+		for fromStage, count := range upstreams {
+			if count > 1 {
+				return fmt.Errorf("%w: stage %s has %d edges from %s",
+					ErrDuplicateFanInEdge, toStage, count, fromStage)
+			}
+		}
+	}
+	return nil
+}
+
+// checkFanInSupport rejects a stage that receives multiple inputs unless it
+// implements MultiInputStage. Unknown stage names are ignored here — the
+// edge-reference check reports them.
+func (b *PipelineBuilder) checkFanInSupport(upstreamCount map[string]int, stageNames map[string]bool) error {
+	stageByName := make(map[string]Stage, len(b.stages))
+	for _, s := range b.stages {
+		stageByName[s.Name()] = s
+	}
+	for name, n := range upstreamCount {
+		if !stageNames[name] || n <= 1 {
+			continue
+		}
+		if _, ok := stageByName[name].(MultiInputStage); !ok {
+			return fmt.Errorf("%w: %s", ErrFanInNotSupported, name)
+		}
+	}
 	return nil
 }
 

--- a/runtime/pipeline/stage/builder_test.go
+++ b/runtime/pipeline/stage/builder_test.go
@@ -1,0 +1,41 @@
+package stage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeBuilderConnectsAllUpstreams(t *testing.T) {
+	a := NewPassthroughStage("a")
+	b := NewPassthroughStage("b")
+	merge := NewMergeStage("merge", 2)
+	p, err := NewPipelineBuilder().
+		AddStage(a).AddStage(b).AddStage(merge).
+		Merge("merge", "a", "b").
+		Build()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"a", "b"}, p.findUpstreamStages("merge"))
+}
+
+func TestBuildRejectsFanInIntoNonMultiInputStage(t *testing.T) {
+	a := NewPassthroughStage("a")
+	b := NewPassthroughStage("b")
+	sink := NewPassthroughStage("sink") // NOT a MultiInputStage
+	_, err := NewPipelineBuilder().
+		AddStage(a).AddStage(b).AddStage(sink).
+		Merge("sink", "a", "b").
+		Build()
+	require.ErrorIs(t, err, ErrFanInNotSupported)
+}
+
+func TestBuildRejectsDuplicateFanInEdge(t *testing.T) {
+	a := NewPassthroughStage("a")
+	merge := NewMergeStage("merge", 2)
+	_, err := NewPipelineBuilder().
+		AddStage(a).AddStage(merge).
+		Merge("merge", "a", "a").
+		Build()
+	require.ErrorIs(t, err, ErrDuplicateFanInEdge)
+}

--- a/runtime/pipeline/stage/errors.go
+++ b/runtime/pipeline/stage/errors.go
@@ -60,6 +60,14 @@ var (
 
 	// ErrVideoDataRequired is returned when video data is required but missing.
 	ErrVideoDataRequired = errors.New("video data required but not available")
+
+	// ErrFanInNotSupported is returned when a stage has multiple upstream edges but
+	// does not implement MultiInputStage.
+	ErrFanInNotSupported = errors.New("stage has multiple upstreams but does not implement MultiInputStage")
+
+	// ErrDuplicateFanInEdge is returned when a stage receives multiple edges from
+	// the same upstream stage, creating a duplicate input source.
+	ErrDuplicateFanInEdge = errors.New("duplicate upstream edge detected")
 )
 
 // StageError wraps an error with stage information.

--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -21,8 +21,22 @@ import (
 type StreamPipeline struct {
 	stages       []Stage
 	edges        map[string][]string // stage name -> downstream stage names
-	reverseEdges map[string]string   // stage name -> upstream stage name (O(1) lookup)
+	reverseEdges map[string][]string // stage name -> upstream stage names (fan-in aware)
 	rootStages   map[string]struct{} // precomputed set of stages with no incoming edges
+
+	// multiOutputStages is the precomputed set of stages implementing
+	// MultiOutputStage (selective fan-out / 1:N routing, e.g. RouterStage),
+	// keyed by name. Computed once at Build() time and read-only thereafter —
+	// safe to share across concurrent Execute() calls. The per-Execute edge
+	// channels themselves (edgeChannels[upstreamName][downstreamName]) are
+	// NOT stored on the pipeline; they are built fresh per Execute() in
+	// createChannels and threaded as a local through startStages /
+	// getStageInputs / upstreamChannel. Storing them on *StreamPipeline would
+	// make them a shared field mutated on every Execute(), racing across
+	// concurrent Execute() calls on the same pipeline (see the doc comment on
+	// MultiOutputStage in stage.go for the resulting single-Execute caveat).
+	multiOutputStages map[string]MultiOutputStage
+
 	config       *PipelineConfig
 	eventEmitter *events.Emitter
 
@@ -108,14 +122,16 @@ func (p *StreamPipeline) executeBackground(ctx context.Context, input <-chan Str
 
 	p.monitorExecutionTimeout(ctx, start)
 
-	// Create channels between stages
-	channels := p.createChannels()
+	// Create channels between stages. Both channels and edgeChannels are local
+	// to this Execute() call — see the doc comment on the multiOutputStages
+	// field for why edgeChannels must not be stored on *StreamPipeline.
+	channels, edgeChannels := p.createChannels()
 
 	// Start stages and collect output. totals accumulates the message/token/cost
 	// counts as output elements flow through, so the completion event reports
 	// real numbers instead of zeros.
 	totals := &completionTotals{}
-	stageErrors := p.startStages(ctx, input, channels)
+	stageErrors := p.startStages(ctx, input, channels, edgeChannels)
 	outputDone := p.startOutputCollection(channels, output, totals)
 
 	// Wait for errors and output collection
@@ -146,18 +162,26 @@ func (p *StreamPipeline) monitorExecutionTimeout(ctx context.Context, start time
 }
 
 // startStages starts all pipeline stages as goroutines and returns the error channel.
+// edgeChannels is the per-Execute() map of dedicated MultiOutputStage edge
+// channels built by createChannels; it is threaded through as a local
+// parameter (like channels) rather than stored on the pipeline.
 //
 //nolint:lll // Channel signature cannot be shortened
-func (p *StreamPipeline) startStages(ctx context.Context, input <-chan StreamElement, channels map[string]chan StreamElement) <-chan error {
+func (p *StreamPipeline) startStages(
+	ctx context.Context,
+	input <-chan StreamElement,
+	channels map[string]chan StreamElement,
+	edgeChannels map[string]map[string]chan StreamElement,
+) <-chan error {
 	stageWg := sync.WaitGroup{}
 	stageErrors := make(chan error, len(p.stages))
 
 	for _, stage := range p.stages {
-		stageInput := p.getStageInput(stage, input, channels)
+		stageInputs := p.getStageInputs(stage, input, channels, edgeChannels)
 		stageOutput := p.getStageOutput(stage, channels)
 
 		stageWg.Add(1)
-		go p.runStage(ctx, stage, stageInput, stageOutput, &stageWg, stageErrors)
+		go p.runStage(ctx, stage, stageInputs, stageOutput, &stageWg, stageErrors)
 	}
 
 	// Close error channel when all stages complete
@@ -250,7 +274,14 @@ func (p *StreamPipeline) emitCompletionEvent(err error, duration time.Duration, 
 }
 
 // createChannels creates all inter-stage channels based on the DAG topology.
-func (p *StreamPipeline) createChannels() map[string]chan StreamElement {
+// It also builds and registers per-edge channels for any MultiOutputStage
+// (selective fan-out) BEFORE stages start, since RegisterOutput must be
+// called before Process runs. Both returned maps are local to this Execute()
+// call — see the doc comment on the multiOutputStages field.
+func (p *StreamPipeline) createChannels() (
+	map[string]chan StreamElement,
+	map[string]map[string]chan StreamElement,
+) {
 	channels := make(map[string]chan StreamElement)
 
 	// Create a channel for each stage's output
@@ -258,25 +289,86 @@ func (p *StreamPipeline) createChannels() map[string]chan StreamElement {
 		channels[stage.Name()] = make(chan StreamElement, p.config.ChannelBufferSize)
 	}
 
-	return channels
+	edgeChannels := p.registerMultiOutputEdges()
+
+	return channels, edgeChannels
 }
 
-// getStageInput returns the input channel for a stage.
-// For root stages, it's the pipeline input. For others, it's determined by the DAG.
+// registerMultiOutputEdges creates one dedicated channel per downstream edge
+// for each stage implementing MultiOutputStage (selective fan-out / 1:N
+// routing) and registers it with the stage via RegisterOutput. It iterates
+// p.multiOutputStages — the single source of truth for "which stages are
+// multi-output", computed once at Build() — rather than re-type-asserting
+// p.stages on every Execute(). Downstream stages read these dedicated
+// channels instead of the upstream's shared channels[upstream] entry (see
+// getStageInputs / upstreamChannel) — that shared entry becomes an orphan the
+// stage still closes via Process's `defer close(output)`, but nothing reads
+// it (the stage is not a leaf, so collectOutput does not collect it either).
+//
+// RegisterOutput call-site caveat: this registers fresh channels onto the
+// MultiOutputStage instance itself (e.g. RouterStage.outputs) on every
+// Execute(), not onto anything owned by this per-Execute call. A pipeline
+// containing a MultiOutputStage is therefore only safe for a single (or
+// strictly sequential, non-concurrent) Execute() — concurrent Execute() calls
+// on the same pipeline would race on the stage's own output registry. This
+// matches the only real usage today: the long-running duplex streaming
+// session, Execute'd once. See the MultiOutputStage doc comment in stage.go.
+func (p *StreamPipeline) registerMultiOutputEdges() map[string]map[string]chan StreamElement {
+	edgeChannels := make(map[string]map[string]chan StreamElement, len(p.multiOutputStages))
+	for name, mo := range p.multiOutputStages {
+		downstreams := p.edges[name]
+		perEdge := make(map[string]chan StreamElement, len(downstreams))
+		for _, d := range downstreams {
+			ch := make(chan StreamElement, p.config.ChannelBufferSize)
+			perEdge[d] = ch
+			mo.RegisterOutput(d, ch)
+		}
+		edgeChannels[name] = perEdge
+	}
+	return edgeChannels
+}
+
+// getStageInputs returns the input channel(s) for a stage.
+// For root stages, it's the pipeline input (single channel). For others, it's
+// determined by the DAG — one channel per upstream stage, in reverseEdges order.
 //
 //nolint:lll // Channel signature cannot be shortened
-func (p *StreamPipeline) getStageInput(stage Stage, pipelineInput <-chan StreamElement, channels map[string]chan StreamElement) <-chan StreamElement {
+func (p *StreamPipeline) getStageInputs(
+	stage Stage,
+	pipelineInput <-chan StreamElement,
+	channels map[string]chan StreamElement,
+	edgeChannels map[string]map[string]chan StreamElement,
+) []<-chan StreamElement {
 	if p.isRootStage(stage.Name()) {
-		return pipelineInput
+		return []<-chan StreamElement{pipelineInput}
 	}
 
-	// For non-root stages, find the upstream stage
-	if upstream := p.findUpstreamStage(stage.Name()); upstream != "" {
-		return channels[upstream]
+	ups := p.findUpstreamStages(stage.Name())
+	inputs := make([]<-chan StreamElement, 0, len(ups))
+	for _, u := range ups {
+		inputs = append(inputs, p.upstreamChannel(u, stage.Name(), channels, edgeChannels))
 	}
+	return inputs
+}
 
-	// Should never reach here if validation worked
-	return nil
+// upstreamChannel resolves the channel a downstream stage should read from for
+// a given upstream. If the upstream implements MultiOutputStage (selective
+// fan-out), the downstream reads its dedicated per-edge channel from
+// edgeChannels (built fresh per Execute() by createChannels and threaded in
+// as a local parameter); otherwise it reads the upstream's shared output
+// channel, preserving existing linear and competitive-Branch fan-out
+// behavior unchanged for every stage that is not a MultiOutputStage.
+func (p *StreamPipeline) upstreamChannel(
+	upstream, downstream string,
+	channels map[string]chan StreamElement,
+	edgeChannels map[string]map[string]chan StreamElement,
+) <-chan StreamElement {
+	if _, ok := p.multiOutputStages[upstream]; ok {
+		if ch, ok := edgeChannels[upstream][downstream]; ok {
+			return ch
+		}
+	}
+	return channels[upstream]
 }
 
 // isRootStage checks if a stage has no incoming edges (O(1) lookup).
@@ -285,24 +377,24 @@ func (p *StreamPipeline) isRootStage(stageName string) bool {
 	return ok
 }
 
-// findUpstreamStage finds the stage that feeds into the given stage using a
-// precomputed reverse-edge map for O(1) lookup.
-// Note: Fan-in (multiple stages feeding into one) is a Phase 5 enhancement.
-// Current implementation supports single upstream stage per stage (sufficient for linear chains and fan-out).
-// For fan-in/merge patterns, a dedicated MergeStage will be implemented in Phase 5.
-func (p *StreamPipeline) findUpstreamStage(stageName string) string {
+// findUpstreamStages returns all stages that feed into the given stage, using a
+// precomputed reverse-edge map for O(1) lookup. A stage with more than one
+// upstream is a fan-in node (see MultiInputStage); single-upstream is the
+// common linear/fan-out case.
+func (p *StreamPipeline) findUpstreamStages(stageName string) []string {
 	if p.reverseEdges != nil {
 		return p.reverseEdges[stageName]
 	}
 	// Fallback to linear scan (should not happen with properly built pipelines).
+	var ups []string
 	for fromStage, toStages := range p.edges {
 		for _, toStage := range toStages {
 			if toStage == stageName {
-				return fromStage
+				ups = append(ups, fromStage)
 			}
 		}
 	}
-	return ""
+	return ups
 }
 
 // getStageOutput returns the output channel for a stage.
@@ -311,10 +403,13 @@ func (p *StreamPipeline) getStageOutput(stage Stage, channels map[string]chan St
 }
 
 // runStage executes a single stage, wrapping it with events and error handling.
+// It dispatches to Stage.Process for the common single-upstream case, and to
+// MultiInputStage.ProcessMultiple when the stage has more than one upstream
+// channel and implements that interface (fan-in).
 func (p *StreamPipeline) runStage(
 	ctx context.Context,
 	stage Stage,
-	input <-chan StreamElement,
+	inputs []<-chan StreamElement,
 	output chan<- StreamElement,
 	wg *sync.WaitGroup,
 	errors chan<- error,
@@ -323,19 +418,29 @@ func (p *StreamPipeline) runStage(
 	// Note: We don't close output here because the stage's Process() method
 	// is responsible for closing it according to the Stage interface contract.
 
-	// Wrap input with Prometheus metrics so operators can see element and
-	// audio-byte flow per stage. The wrapper is a zero-overhead passthrough
-	// when DefaultStreamMetrics() returns nil (no host has registered).
-	instrumentedInput := instrumentStageInput(stage.Name(), input)
-
 	// Emit stage started event
 	start := time.Now()
 	if p.eventEmitter != nil {
 		p.eventEmitter.StageStarted(stage.Name(), 0, stage.Type())
 	}
 
-	// Run the stage
-	err := stage.Process(ctx, instrumentedInput, output)
+	// Run the stage. Wrap input(s) with Prometheus metrics so operators can see
+	// element and audio-byte flow per stage. The wrapper is a zero-overhead
+	// passthrough when DefaultStreamMetrics() returns nil (no host has registered).
+	var err error
+	if mi, ok := stage.(MultiInputStage); ok && len(inputs) > 1 {
+		instrumented := make([]<-chan StreamElement, len(inputs))
+		for i, in := range inputs {
+			instrumented[i] = instrumentStageInput(stage.Name(), in)
+		}
+		err = mi.ProcessMultiple(ctx, instrumented, output)
+	} else {
+		var in <-chan StreamElement
+		if len(inputs) > 0 {
+			in = inputs[0]
+		}
+		err = stage.Process(ctx, instrumentStageInput(stage.Name(), in), output)
+	}
 	duration := time.Since(start)
 
 	// Emit stage completed/failed event

--- a/runtime/pipeline/stage/pipeline_fanin_test.go
+++ b/runtime/pipeline/stage/pipeline_fanin_test.go
@@ -1,0 +1,57 @@
+package stage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emitN is a root stage that emits n text elements tagged with a label, then closes.
+func emitN(name, label string, n int) *StageFunc {
+	return NewStageFunc(name, StageTypeGenerate,
+		func(ctx context.Context, _ <-chan StreamElement, out chan<- StreamElement) error {
+			defer close(out)
+			for i := 0; i < n; i++ {
+				e := StreamElement{Text: &label}
+				select {
+				case out <- e:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return nil
+		})
+}
+
+func TestPipelineFanInMergesTwoSources(t *testing.T) {
+	a := emitN("a", "from-a", 3)
+	b := emitN("b", "from-b", 2)
+	merge := NewMergeStage("merge", 2)
+
+	p, err := NewPipelineBuilder().
+		AddStage(a).AddStage(b).AddStage(merge).
+		Merge("merge", "a", "b").
+		Build()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	in := make(chan StreamElement)
+	close(in) // roots ignore pipeline input; they generate
+	out, err := p.Execute(ctx, in)
+	require.NoError(t, err)
+
+	var count, tagged int
+	for e := range out {
+		count++
+		if e.Meta.MergeInputIndex != nil {
+			tagged++
+		}
+	}
+	assert.Equal(t, 5, count, "all elements from both sources arrive")
+	assert.Equal(t, 5, tagged, "merge stamps MergeInputIndex on every element")
+}

--- a/runtime/pipeline/stage/pipeline_fanout_test.go
+++ b/runtime/pipeline/stage/pipeline_fanout_test.go
@@ -1,0 +1,230 @@
+package stage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emitSourced is a root stage that emits n text elements tagged with the given
+// Source, then closes. Used to feed a RouterStage with a deterministic mix.
+func emitSourced(name, source string, n int) *StageFunc {
+	return NewStageFunc(name, StageTypeGenerate,
+		func(ctx context.Context, _ <-chan StreamElement, out chan<- StreamElement) error {
+			defer close(out)
+			for i := 0; i < n; i++ {
+				e := StreamElement{Source: source}
+				select {
+				case out <- e:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return nil
+		})
+}
+
+// collectStage is a sink stage that records every element it receives, guarded
+// by a mutex since it may be read from the test goroutine after execution.
+type collectStage struct {
+	BaseStage
+	mu  sync.Mutex
+	got []StreamElement
+}
+
+func newCollectStage(name string) *collectStage {
+	return &collectStage{BaseStage: NewBaseStage(name, StageTypeSink)}
+}
+
+func (c *collectStage) Process(ctx context.Context, input <-chan StreamElement, output chan<- StreamElement) error {
+	defer close(output)
+	for elem := range input {
+		c.mu.Lock()
+		c.got = append(c.got, elem)
+		c.mu.Unlock()
+	}
+	return ctx.Err()
+}
+
+func (c *collectStage) elements() []StreamElement {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]StreamElement, len(c.got))
+	copy(out, c.got)
+	return out
+}
+
+// routeToDest returns a RouterFunc that sends Source == "a" elements to destA
+// and Source == "b" elements to destB, dropping anything else.
+func routeToDest(destA, destB string) RouterFunc {
+	return func(elem *StreamElement) []string {
+		switch elem.Source {
+		case "a":
+			return []string{destA}
+		case "b":
+			return []string{destB}
+		default:
+			return nil
+		}
+	}
+}
+
+// TestRouterDeterministicSplit proves selective fan-out: every "a"-sourced
+// element lands in sinkA and every "b"-sourced element lands in sinkB. A
+// competitive Branch (shared channel, first-reader-wins) cannot guarantee this
+// — both sinks would race for every element regardless of Source.
+func TestRouterDeterministicSplit(t *testing.T) {
+	router := NewRouterStage("router", routeToDest("sinkA", "sinkB"))
+	sinkA := newCollectStage("sinkA")
+	sinkB := newCollectStage("sinkB")
+
+	p, err := NewPipelineBuilder().
+		AddStage(router).AddStage(sinkA).AddStage(sinkB).
+		Connect("router", "sinkA").
+		Connect("router", "sinkB").
+		Build()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const perSource = 25
+	in := make(chan StreamElement, perSource*2)
+	for i := 0; i < perSource; i++ {
+		in <- StreamElement{Source: "a"}
+		in <- StreamElement{Source: "b"}
+	}
+	close(in)
+
+	out, err := p.Execute(ctx, in)
+	require.NoError(t, err)
+
+	// Router is not a leaf (has downstream edges), so nothing should reach the
+	// pipeline output channel — it drains and closes once the sinks finish.
+	var strayCount int
+	for range out {
+		strayCount++
+	}
+	assert.Equal(t, 0, strayCount, "router output must not leak into pipeline output")
+
+	gotA := sinkA.elements()
+	gotB := sinkB.elements()
+	require.Len(t, gotA, perSource, "sinkA receives exactly the 'a' elements")
+	require.Len(t, gotB, perSource, "sinkB receives exactly the 'b' elements")
+	for _, e := range gotA {
+		assert.Equal(t, "a", e.Source, "sinkA must never see a 'b' element")
+	}
+	for _, e := range gotB {
+		assert.Equal(t, "b", e.Source, "sinkB must never see an 'a' element")
+	}
+}
+
+// TestRouterFanOutThenFanIn composes selective fan-out with the existing
+// fan-in (MergeStage): router splits by Source into two tracks, each track
+// passes through a passthrough stage, and both tracks merge back into one
+// collector. Asserts per-source counts and that MergeInputIndex is stamped,
+// proving fan-out and fan-in compose.
+func TestRouterFanOutThenFanIn(t *testing.T) {
+	router := NewRouterStage("router", routeToDest("trackA", "trackB"))
+	trackA := NewPassthroughStage("trackA")
+	trackB := NewPassthroughStage("trackB")
+	merge := NewMergeStage("merge", 2)
+	sink := newCollectStage("sink")
+
+	p, err := NewPipelineBuilder().
+		AddStage(router).AddStage(trackA).AddStage(trackB).AddStage(merge).AddStage(sink).
+		Connect("router", "trackA").
+		Connect("router", "trackB").
+		Merge("merge", "trackA", "trackB").
+		Connect("merge", "sink").
+		Build()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const perSource = 10
+	in := make(chan StreamElement, perSource*2)
+	for i := 0; i < perSource; i++ {
+		in <- StreamElement{Source: "a"}
+		in <- StreamElement{Source: "b"}
+	}
+	close(in)
+
+	out, err := p.Execute(ctx, in)
+	require.NoError(t, err)
+	for range out {
+		// sink is the only leaf; nothing should reach the pipeline output.
+		t.Fatal("unexpected element on pipeline output; sink should have consumed it")
+	}
+
+	got := sink.elements()
+	require.Len(t, got, perSource*2)
+
+	var countA, countB, tagged int
+	for _, e := range got {
+		switch e.Source {
+		case "a":
+			countA++
+		case "b":
+			countB++
+		}
+		if e.Meta.MergeInputIndex != nil {
+			tagged++
+		}
+	}
+	assert.Equal(t, perSource, countA)
+	assert.Equal(t, perSource, countB)
+	assert.Equal(t, perSource*2, tagged, "merge stamps MergeInputIndex on every element")
+}
+
+// TestPipelineConcurrentExecute proves that a single built *StreamPipeline
+// (router-less, so it exercises the general Execute() path used by the SDK's
+// unary Send()) can be Execute()'d from multiple goroutines concurrently
+// without racing. It regression-tests the fix that made the per-Execute
+// MultiOutputStage edge-channel map (edgeChannels) a local threaded through
+// createChannels/startStages/getStageInputs/upstreamChannel instead of a
+// shared field written on every Execute() — the shared-field version raced
+// under `go test -race` when two Execute() calls ran concurrently on the same
+// pipeline (the SDK's Conversation.Send() reuses one built pipeline across
+// concurrent calls, guarded only by an RLock).
+func TestPipelineConcurrentExecute(t *testing.T) {
+	p, err := NewPipelineBuilder().
+		Chain(NewPassthroughStage("stageA"), NewPassthroughStage("stageB")).
+		Build()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const goroutines = 8
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+
+			in := make(chan StreamElement, perGoroutine)
+			for i := 0; i < perGoroutine; i++ {
+				in <- StreamElement{Source: "concurrent"}
+			}
+			close(in)
+
+			out, execErr := p.Execute(ctx, in)
+			assert.NoError(t, execErr)
+
+			var got int
+			for range out {
+				got++
+			}
+			assert.Equal(t, perGoroutine, got, "each concurrent Execute() must see exactly its own elements")
+		}()
+	}
+	wg.Wait()
+}

--- a/runtime/pipeline/stage/pipeline_internal_test.go
+++ b/runtime/pipeline/stage/pipeline_internal_test.go
@@ -168,8 +168,8 @@ func TestWaitForStageErrors(t *testing.T) {
 	})
 }
 
-// TestFindUpstreamStage_ReverseEdges verifies O(1) lookup via precomputed reverseEdges.
-func TestFindUpstreamStage_ReverseEdges(t *testing.T) {
+// TestFindUpstreamStages_ReverseEdges verifies O(1) lookup via precomputed reverseEdges.
+func TestFindUpstreamStages_ReverseEdges(t *testing.T) {
 	stageA := &testPassthroughStage{name: "stageA"}
 	stageB := &testPassthroughStage{name: "stageB"}
 	stageC := &testPassthroughStage{name: "stageC"}
@@ -186,23 +186,23 @@ func TestFindUpstreamStage_ReverseEdges(t *testing.T) {
 		t.Fatal("reverseEdges should not be nil")
 	}
 
-	if upstream := pipeline.findUpstreamStage("stageB"); upstream != "stageA" {
-		t.Errorf("expected stageA upstream of stageB, got %q", upstream)
+	if upstream := pipeline.findUpstreamStages("stageB"); len(upstream) != 1 || upstream[0] != "stageA" {
+		t.Errorf("expected [stageA] upstream of stageB, got %v", upstream)
 	}
-	if upstream := pipeline.findUpstreamStage("stageC"); upstream != "stageB" {
-		t.Errorf("expected stageB upstream of stageC, got %q", upstream)
+	if upstream := pipeline.findUpstreamStages("stageC"); len(upstream) != 1 || upstream[0] != "stageB" {
+		t.Errorf("expected [stageB] upstream of stageC, got %v", upstream)
 	}
-	if upstream := pipeline.findUpstreamStage("stageA"); upstream != "" {
-		t.Errorf("expected empty upstream for root stageA, got %q", upstream)
+	if upstream := pipeline.findUpstreamStages("stageA"); len(upstream) != 0 {
+		t.Errorf("expected empty upstream for root stageA, got %v", upstream)
 	}
-	if upstream := pipeline.findUpstreamStage("nonexistent"); upstream != "" {
-		t.Errorf("expected empty upstream for nonexistent, got %q", upstream)
+	if upstream := pipeline.findUpstreamStages("nonexistent"); len(upstream) != 0 {
+		t.Errorf("expected empty upstream for nonexistent, got %v", upstream)
 	}
 }
 
-// TestFindUpstreamStage_FallbackNilReverseEdges tests the fallback linear scan
+// TestFindUpstreamStages_FallbackNilReverseEdges tests the fallback linear scan
 // when reverseEdges is nil (should not happen in practice).
-func TestFindUpstreamStage_FallbackNilReverseEdges(t *testing.T) {
+func TestFindUpstreamStages_FallbackNilReverseEdges(t *testing.T) {
 	pipeline := &StreamPipeline{
 		edges: map[string][]string{
 			"A": {"B"},
@@ -211,11 +211,11 @@ func TestFindUpstreamStage_FallbackNilReverseEdges(t *testing.T) {
 		reverseEdges: nil, // force fallback
 	}
 
-	if upstream := pipeline.findUpstreamStage("B"); upstream != "A" {
-		t.Errorf("fallback: expected A upstream of B, got %q", upstream)
+	if upstream := pipeline.findUpstreamStages("B"); len(upstream) != 1 || upstream[0] != "A" {
+		t.Errorf("fallback: expected [A] upstream of B, got %v", upstream)
 	}
-	if upstream := pipeline.findUpstreamStage("X"); upstream != "" {
-		t.Errorf("fallback: expected empty for X, got %q", upstream)
+	if upstream := pipeline.findUpstreamStages("X"); len(upstream) != 0 {
+		t.Errorf("fallback: expected empty for X, got %v", upstream)
 	}
 }
 

--- a/runtime/pipeline/stage/stage.go
+++ b/runtime/pipeline/stage/stage.go
@@ -62,6 +62,35 @@ type Stage interface {
 	Process(ctx context.Context, input <-chan StreamElement, output chan<- StreamElement) error
 }
 
+// MultiInputStage is a Stage that consumes multiple upstream input channels
+// (fan-in / N:1 merge). The pipeline calls ProcessMultiple instead of Process
+// when the stage has more than one upstream edge. Like Process, the stage MUST
+// close output when all inputs are drained.
+type MultiInputStage interface {
+	Stage
+	ProcessMultiple(ctx context.Context, inputs []<-chan StreamElement, output chan<- StreamElement) error
+}
+
+// MultiOutputStage is a Stage that routes elements to named downstream outputs
+// (selective fan-out / 1:N routing). The pipeline registers one channel per
+// downstream edge via RegisterOutput before Process runs; the stage routes each
+// element to the appropriate registered output(s) and MUST close them when done.
+//
+// Single-Execute caveat: RegisterOutput is called on the stage INSTANCE (e.g.
+// RouterStage.outputs) fresh on every StreamPipeline.Execute() call, since the
+// per-Execute edge channels live for the duration of that Execute() only. A
+// pipeline containing a MultiOutputStage is therefore only safe for a single
+// (or strictly sequential, non-concurrent) Execute() call — concurrent
+// Execute() calls on the same pipeline would race registering/routing through
+// the stage's shared output registry. This matches the only real usage today:
+// the long-running duplex streaming session, Execute'd once. Callers that
+// reuse one *StreamPipeline across concurrent Execute() calls (e.g. the
+// unary Send() path) must not include a MultiOutputStage in that pipeline.
+type MultiOutputStage interface {
+	Stage
+	RegisterOutput(name string, output chan<- StreamElement)
+}
+
 // StageType defines the processing model of a stage.
 //
 //nolint:revive // Intentionally named StageType for clarity; stage.Type would be too generic

--- a/runtime/pipeline/stage/stages_advanced_test.go
+++ b/runtime/pipeline/stage/stages_advanced_test.go
@@ -280,3 +280,11 @@ func TestPriorityChannel_Len(t *testing.T) {
 
 	assert.Equal(t, 2, pc.Len())
 }
+
+func TestMergeStageSatisfiesMultiInputStage(t *testing.T) {
+	var _ MultiInputStage = NewMergeStage("merge", 2)
+}
+
+func TestRouterStageSatisfiesMultiOutputStage(t *testing.T) {
+	var _ MultiOutputStage = NewRouterStage("router", nil)
+}

--- a/runtime/providers/streaming.go
+++ b/runtime/providers/streaming.go
@@ -110,6 +110,10 @@ type StreamChunk struct {
 	// PendingTools contains client-mode tools awaiting caller fulfillment.
 	// Only set when FinishReason is "pending_tools".
 	PendingTools []tools.PendingToolExecution `json:"pending_tools,omitempty"`
+
+	// Source labels the input track/speaker for fan-out routing (e.g. "caller",
+	// "agent"). Copied onto StreamElement.Source at the session boundary.
+	Source string `json:"source,omitempty"`
 }
 
 // StreamEvent is sent to observers for monitoring

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -630,6 +630,18 @@ func (c *Conversation) buildStreamPipelineWithParams(
 		pipelineCfg.InterruptionHandler = interruptionHandler
 	}
 
+	// Custom ingestion sub-graph configuration (duplex-only), mutually
+	// exclusive with VAD mode: both author the input side of the pipeline.
+	if c.config.ingestion != nil {
+		if c.config.vadModeConfig != nil {
+			return nil, fmt.Errorf("WithIngestion and WithVADMode are mutually exclusive")
+		}
+		pipelineCfg.Ingestion = c.config.ingestion
+		if c.config.sttService != nil {
+			pipelineCfg.STTService = c.config.sttService
+		}
+	}
+
 	return intpipeline.Build(pipelineCfg)
 }
 

--- a/sdk/ingestion_perturn_test.go
+++ b/sdk/ingestion_perturn_test.go
@@ -1,0 +1,171 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTurnProvider records the messages of every Predict call and returns
+// a numbered reply, so a test can assert one provider call per turn and that
+// later turns carry earlier turns as history. It does NOT implement
+// providers.StreamInputSupport — so it also exercises the WithIngestion gate
+// relaxation, and proves the standard (streaming) text ProviderStage drives the
+// agent regardless of provider streaming support.
+type recordingTurnProvider struct {
+	mu       sync.Mutex
+	requests [][]types.Message
+}
+
+func (p *recordingTurnProvider) ID() string                        { return "rec" }
+func (p *recordingTurnProvider) Name() string                      { return "rec" }
+func (p *recordingTurnProvider) Type() base.ProviderType           { return base.ProviderTypeInference }
+func (p *recordingTurnProvider) Pricing() *base.PricingDescriptor  { return nil }
+func (p *recordingTurnProvider) Validate() error                   { return nil }
+func (p *recordingTurnProvider) Init(context.Context) error        { return nil }
+func (p *recordingTurnProvider) HealthCheck(context.Context) error { return nil }
+func (p *recordingTurnProvider) Model() string                     { return "rec-model" }
+func (p *recordingTurnProvider) SupportsStreaming() bool           { return false }
+func (p *recordingTurnProvider) ShouldIncludeRawOutput() bool      { return false }
+func (p *recordingTurnProvider) Close() error                      { return nil }
+func (p *recordingTurnProvider) CalculateCost(_, _, _ int) types.CostInfo {
+	return types.CostInfo{}
+}
+
+func (p *recordingTurnProvider) Predict(
+	_ context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	msgs := make([]types.Message, len(req.Messages))
+	copy(msgs, req.Messages)
+	p.requests = append(p.requests, msgs)
+	return providers.PredictionResponse{Content: fmt.Sprintf("reply-%d", len(p.requests))}, nil
+}
+
+func (p *recordingTurnProvider) PredictStream(
+	_ context.Context, _ providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (p *recordingTurnProvider) turnCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.requests)
+}
+
+// messagesInTurn returns how many messages the provider saw on the i-th turn.
+func (p *recordingTurnProvider) messagesInTurn(i int) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.requests[i])
+}
+
+// turnEmitterStage is a minimal ingestion sub-graph: for each text-bearing
+// input element it emits a user Message followed by an EndOfTurn control
+// element, so the downstream ProviderStage sees one complete turn per input.
+// It stands in for the example's per-track resample/VAD/STT sub-chain without
+// any audio. Control signals (EndOfStream etc.) pass through so Drain completes.
+type turnEmitterStage struct {
+	stage.BaseStage
+}
+
+func newTurnEmitterStage(name string) *turnEmitterStage {
+	return &turnEmitterStage{BaseStage: stage.NewBaseStage(name, stage.StageTypeTransform)}
+}
+
+func (s *turnEmitterStage) Process(
+	ctx context.Context, in <-chan stage.StreamElement, out chan<- stage.StreamElement,
+) error {
+	defer close(out)
+	for elem := range in {
+		if elem.EndOfStream || elem.EndOfTurn || elem.Interrupt {
+			if err := sendPerTurnElem(ctx, out, elem); err != nil {
+				return err
+			}
+			continue
+		}
+		if elem.Text == nil || *elem.Text == "" {
+			continue
+		}
+		msg := &types.Message{Role: "user"}
+		msg.AddTextPart(*elem.Text)
+		if err := sendPerTurnElem(ctx, out, stage.StreamElement{Message: msg}); err != nil {
+			return err
+		}
+		if err := sendPerTurnElem(ctx, out, stage.NewEndOfTurnElement()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sendPerTurnElem(ctx context.Context, out chan<- stage.StreamElement, e stage.StreamElement) error {
+	select {
+	case out <- e:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TestOpenDuplexWithIngestion_FiresAgentPerTurn is the SDK-level proof that a
+// WithIngestion duplex is a real duplex-AGENT path: the path builds a streaming
+// ProviderStage, so each EndOfTurn from the ingestion sub-graph fires the agent
+// once, while the session is still open, and history threads across turns.
+//
+// This is the SDK-wiring counterpart to the runtime's own per-turn coverage
+// (runtime/pipeline/stage: TestProviderStage_Streaming_OneReplyPerTurn /
+// _ThreadsHistory). Before the streaming wiring, the standard ProviderStage
+// drained the whole session and fired ONCE at close — this test would then see
+// 0 provider calls until Close, and fail.
+func TestOpenDuplexWithIngestion_FiresAgentPerTurn(t *testing.T) {
+	packFile := writeIngestionTestPack(t)
+	prov := &recordingTurnProvider{}
+
+	ingest := IngestionFunc(func(b *stage.PipelineBuilder) (string, error) {
+		b.AddStage(newTurnEmitterStage("turn_emitter"))
+		return "turn_emitter", nil
+	})
+
+	conv, err := OpenDuplex(packFile, "main",
+		WithProvider(prov),
+		WithSkipSchemaValidation(),
+		WithIngestion(ingest),
+	)
+	require.NoError(t, err)
+	defer func() { _ = conv.Close() }()
+
+	responseCh, err := conv.Response()
+	require.NoError(t, err)
+	go func() {
+		for range responseCh { //nolint:revive // drain so the pipeline output never blocks
+		}
+	}()
+
+	ctx := context.Background()
+	require.NoError(t, conv.SendChunk(ctx, &providers.StreamChunk{Content: "first turn", Source: "caller"}))
+	require.NoError(t, conv.SendChunk(ctx, &providers.StreamChunk{Content: "second turn", Source: "caller"}))
+
+	// Decisive assertion: both turns fire while the session is still OPEN — no
+	// Close() flush. The non-streaming (fire-once-at-close) path shows 0 here.
+	require.Eventually(t, func() bool { return prov.turnCount() >= 2 }, 5*time.Second, 10*time.Millisecond,
+		"streaming ProviderStage must fire the agent once per EndOfTurn while the session is open")
+	require.Equal(t, 2, prov.turnCount(), "exactly one agent turn per EndOfTurn")
+
+	// History threads across turns: turn 2 sees turn 1 (user + assistant reply)
+	// plus its own user message, so it carries strictly more messages than turn 1.
+	require.Greater(t, prov.messagesInTurn(1), prov.messagesInTurn(0),
+		"later turns must carry earlier turns as history")
+}

--- a/sdk/ingestion_test.go
+++ b/sdk/ingestion_test.go
@@ -1,0 +1,210 @@
+package sdk
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeIngestionTestPack writes a minimal valid pack file and returns its path.
+func writeIngestionTestPack(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	packFile := filepath.Join(dir, "test.pack.json")
+	packContent := `{
+		"name": "test-pack",
+		"version": "v1",
+		"prompts": {
+			"main": {
+				"system_template": "You are a helpful assistant."
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(packFile, []byte(packContent), 0o600))
+	return packFile
+}
+
+// sourceRecorder is a passthrough IngestionFunc callback that records the
+// Source of every element flowing through it, proving both that the
+// sub-graph is actually wired ahead of the agent chain (elements reach it at
+// all) and that StreamChunk.Source survives the SendChunk boundary copy into
+// StreamElement.Source.
+type sourceRecorder struct {
+	mu      sync.Mutex
+	sources []string
+}
+
+func (r *sourceRecorder) record(elem stage.StreamElement) (stage.StreamElement, error) {
+	r.mu.Lock()
+	r.sources = append(r.sources, elem.Source)
+	r.mu.Unlock()
+	return elem, nil
+}
+
+func (r *sourceRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.sources))
+	copy(out, r.sources)
+	return out
+}
+
+// waitForCount polls until snapshot() has at least n entries or the timeout
+// elapses, returning the final snapshot either way.
+func (r *sourceRecorder) waitForCount(n int, timeout time.Duration) []string {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if got := r.snapshot(); len(got) >= n {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return r.snapshot()
+}
+
+// TestOpenDuplexWithIngestion verifies that WithIngestion installs a custom
+// upstream sub-graph ahead of the agent chain in a duplex session, and that
+// StreamChunk.Source is copied onto StreamElement.Source at the SendChunk
+// boundary (sdk/session/duplex_session.go) so a custom ingestion stage can
+// see which track/speaker produced each element. It also verifies the
+// session builds and streams a real response without any VAD/TTS wiring.
+func TestOpenDuplexWithIngestion(t *testing.T) {
+	packFile := writeIngestionTestPack(t)
+	provider := mock.NewStreamingProvider("mock", "mock-model", false).
+		WithAutoRespond("Hello from ingestion test")
+
+	recorder := &sourceRecorder{}
+	ingest := IngestionFunc(func(b *stage.PipelineBuilder) (string, error) {
+		b.AddStage(stage.NewMapStage("ingest", recorder.record))
+		return "ingest", nil
+	})
+
+	conv, err := OpenDuplex(packFile, "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithIngestion(ingest),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, conv)
+	assert.Equal(t, DuplexMode, conv.mode)
+	assert.NotNil(t, conv.duplexSession)
+	defer func() { _ = conv.Close() }()
+
+	responseCh, err := conv.Response()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, conv.SendChunk(ctx, &providers.StreamChunk{
+		Content: "hello from caller",
+		Source:  "caller",
+	}))
+	require.NoError(t, conv.SendChunk(ctx, &providers.StreamChunk{
+		Content: "hello from agent",
+		Source:  "agent",
+	}))
+
+	// The ingest MapStage runs sequentially on a single linear chain fed by
+	// one root channel, so element order is preserved end to end; poll
+	// (rather than sleep a fixed duration) since SendChunk only enqueues.
+	got := recorder.waitForCount(2, 2*time.Second)
+	require.Len(t, got, 2, "ingest stage must observe both elements")
+	assert.Equal(t, []string{"caller", "agent"}, got,
+		"StreamChunk.Source must survive the SendChunk boundary copy onto StreamElement.Source")
+
+	// Drain the response channel briefly to confirm the wired pipeline
+	// actually produces output through the ingestion → agent-chain path,
+	// without requiring WithVADMode (no TTS service configured at all).
+	select {
+	case chunk, ok := <-responseCh:
+		if ok {
+			t.Logf("received response chunk: content=%q", chunk.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Log("no response chunk observed within timeout (non-fatal: ingestion wiring already proven above)")
+	}
+}
+
+// TestOpenDuplexWithIngestionAcceptsNonStreamingProvider proves that
+// WithIngestion drives the standard agent chain (a streaming text
+// ProviderStage), not the ASM DuplexProviderStage, so OpenDuplex must NOT
+// require the provider to implement providers.StreamInputSupport. mock.Provider
+// (unlike mock.StreamingProvider) does not implement it — without the ingestion
+// relaxation this fails fast with "does not support duplex streaming", which is
+// what blocks real Claude from driving a WithIngestion duplex.
+func TestOpenDuplexWithIngestionAcceptsNonStreamingProvider(t *testing.T) {
+	packFile := writeIngestionTestPack(t)
+
+	// mock.NewProvider returns *mock.Provider, which — unlike the streaming
+	// mocks used elsewhere in this file — does NOT implement StreamInputSupport.
+	provider := mock.NewProvider("mock", "mock-model", false)
+	if _, ok := providers.Provider(provider).(providers.StreamInputSupport); ok {
+		t.Fatal("test premise broken: mock.NewProvider must NOT implement StreamInputSupport")
+	}
+
+	ingest := IngestionFunc(func(b *stage.PipelineBuilder) (string, error) {
+		b.AddStage(stage.NewMapStage("ingest", func(elem stage.StreamElement) (stage.StreamElement, error) {
+			return elem, nil
+		}))
+		return "ingest", nil
+	})
+
+	conv, err := OpenDuplex(packFile, "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithIngestion(ingest),
+	)
+	require.NoError(t, err, "OpenDuplex must accept a non-StreamInputSupport provider when WithIngestion is set")
+	require.NotNil(t, conv)
+	assert.Equal(t, DuplexMode, conv.mode)
+	assert.NotNil(t, conv.duplexSession, "duplex session must build on the ingestion path without a stream provider")
+
+	responseCh, err := conv.Response()
+	require.NoError(t, err)
+	go func() {
+		for range responseCh {
+		}
+	}()
+
+	// Push one element through the streaming path so the ProviderStage's
+	// continuous loop is active before Drain sends EndOfStream — a session that
+	// receives no input at all has nothing to flush and falls back to the drain
+	// timeout on Close, which is orthogonal to the gate under test here.
+	require.NoError(t, conv.SendChunk(context.Background(), &providers.StreamChunk{
+		Content: "hello",
+		Source:  "caller",
+	}))
+	_ = conv.Close()
+}
+
+// TestWithIngestionAndVADModeMutuallyExclusive verifies that combining
+// WithIngestion and WithVADMode on the same duplex conversation is rejected:
+// both options author the input side of the pipeline and cannot coexist.
+func TestWithIngestionAndVADModeMutuallyExclusive(t *testing.T) {
+	packFile := writeIngestionTestPack(t)
+	provider := mock.NewStreamingProvider("mock", "mock-model", false)
+
+	ingest := IngestionFunc(func(b *stage.PipelineBuilder) (string, error) {
+		b.AddStage(stage.NewMapStage("ingest", func(elem stage.StreamElement) (stage.StreamElement, error) {
+			return elem, nil
+		}))
+		return "ingest", nil
+	})
+
+	_, err := OpenDuplex(packFile, "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithVADMode(nil, nil, nil),
+		WithIngestion(ingest),
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "mutually exclusive")
+}

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -135,6 +135,12 @@ type Config struct {
 	// VADConfig configures the AudioTurnStage for VAD mode
 	VADConfig *stage.AudioTurnConfig
 
+	// Ingestion, when non-nil, authors a custom upstream stage sub-graph whose
+	// output node feeds the standard agent chain. Mutually exclusive with the
+	// VAD/ASM front. The callback adds stages/edges to the shared builder and
+	// returns the name of the node whose output feeds the agent chain.
+	Ingestion func(b *stage.PipelineBuilder) (outputNode string, err error)
+
 	// STTService for speech-to-text in VAD mode
 	STTService base.STTProvider
 
@@ -260,6 +266,25 @@ func buildStreamPipelineInternal(cfg *Config) (*stage.StreamPipeline, error) {
 	// Wire event emitter so the pipeline emits PipelineStarted/Completed events.
 	if cfg.EventEmitter != nil {
 		builder.WithEventEmitter(cfg.EventEmitter)
+	}
+
+	// Custom ingestion sub-graph: author it onto the same builder, then feed the
+	// agent chain's head from its output node instead of chaining from the root.
+	if cfg.Ingestion != nil {
+		if len(stages) == 0 {
+			return nil, fmt.Errorf("ingestion sub-graph: %w", stage.ErrNoStages)
+		}
+		outputNode, ierr := cfg.Ingestion(builder)
+		if ierr != nil {
+			return nil, fmt.Errorf("ingestion sub-graph: %w", ierr)
+		}
+		builder.Chain(stages...)
+		builder.Connect(outputNode, stages[0].Name())
+		streamPipeline, buildErr := builder.Build()
+		if buildErr != nil {
+			return nil, fmt.Errorf("failed to build ingestion pipeline: %w", buildErr)
+		}
+		return streamPipeline, nil
 	}
 
 	// Build and return the StreamPipeline directly
@@ -455,7 +480,15 @@ func buildProviderStages(cfg *Config, turnState *stage.TurnState) ([]stage.Stage
 		return buildVADPipelineStages(cfg)
 	}
 	if cfg.Provider != nil {
-		// Text mode: standard LLM call
+		// Text mode: standard LLM call.
+		//
+		// A custom ingestion sub-graph (WithIngestion) turns this into a
+		// continuous multi-turn duplex session: the ingestion side emits an
+		// EndOfTurn control element per completed turn, so the ProviderStage
+		// must run in streaming mode (fire the tool loop per EndOfTurn, thread
+		// history across turns, stay open) rather than the unary default that
+		// drains the whole input channel and fires once at close. Without this,
+		// the agent would only run when the session ends.
 		providerConfig := &stage.ProviderConfig{
 			MaxTokens:        cfg.MaxTokens,
 			Temperature:      cfg.Temperature,
@@ -463,6 +496,7 @@ func buildProviderStages(cfg *Config, turnState *stage.TurnState) ([]stage.Stage
 			MessageLog:       cfg.MessageLog,
 			MessageLogConvID: cfg.ConversationID,
 			ToolSelector:     cfg.ToolSelector,
+			Streaming:        cfg.Ingestion != nil,
 		}
 		// Configure compaction strategy
 		if cfg.CompactionEnabled == nil || *cfg.CompactionEnabled {

--- a/sdk/internal/pipeline/builder_vad.go
+++ b/sdk/internal/pipeline/builder_vad.go
@@ -5,7 +5,75 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 )
+
+// prefixedStage wraps a Stage to override its Name(), so the same constructor
+// (audio-resample/audio_turn/stt) can be instantiated more than once in a single
+// pipeline graph — e.g. one call to BuildAudioTrackStages per audio track — without
+// colliding on stage name. An empty prefix is a no-op passthrough wrapper so the
+// single-track VAD front keeps its original, unprefixed stage names.
+type prefixedStage struct {
+	stage.Stage
+	name string
+}
+
+// Name reports the prefixed stage name, overriding the embedded stage's Name.
+func (p *prefixedStage) Name() string { return p.name }
+
+// withNamePrefix returns s unchanged when prefix is empty, otherwise wraps it so
+// Name() reports "<prefix>_<original name>".
+func withNamePrefix(prefix string, s stage.Stage) stage.Stage {
+	if prefix == "" {
+		return s
+	}
+	return &prefixedStage{Stage: s, name: prefix + "_" + s.Name()}
+}
+
+// BuildAudioTrackStages returns the ordered stages for one named audio track:
+// [Resample→]AudioTurn(VAD)→STT. namePrefix uniquifies stage names (e.g. "caller")
+// so multiple tracks can be wired into the same pipeline graph without name
+// collisions; pass "" to keep the constructors' natural names (single-track case).
+// Reused by both the VAD front (buildVADPipelineStages, includeResample=false to
+// keep that topology byte-for-byte unchanged) and custom ingestion sub-graphs that
+// need to feed one or more raw audio tracks — possibly at an arbitrary sample
+// rate — into the standard agent chain (includeResample=true).
+//
+// When includeResample is true, the AudioResampleStage normalizes the track to
+// vad.SampleRate (falling back to the package default when unset) before
+// VAD/turn-detection runs, and is a no-op passthrough when the source is already
+// at that rate — see runtime/pipeline/stage/stages_resample.go.
+func BuildAudioTrackStages(
+	namePrefix string,
+	includeResample bool,
+	vad stage.AudioTurnConfig,
+	stt stage.STTStageConfig,
+	sttSvc base.STTProvider,
+) ([]stage.Stage, error) {
+	audioTurnStage, err := stage.NewAudioTurnStage(vad)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AudioTurnStage: %w", err)
+	}
+
+	sttStage := stage.NewSTTStage(sttSvc, stt)
+
+	// Resample + AudioTurn + STT is the maximum size (Resample is opt-in).
+	const maxAudioTrackStages = 3
+	stages := make([]stage.Stage, 0, maxAudioTrackStages)
+	if includeResample {
+		resampleConfig := stage.DefaultAudioResampleConfig()
+		if vad.SampleRate > 0 {
+			resampleConfig.TargetSampleRate = vad.SampleRate
+		}
+		stages = append(stages, withNamePrefix(namePrefix, stage.NewAudioResampleStage(resampleConfig)))
+	}
+	stages = append(stages,
+		withNamePrefix(namePrefix, audioTurnStage),
+		withNamePrefix(namePrefix, sttStage),
+	)
+
+	return stages, nil
+}
 
 // buildVADPipelineStages creates the VAD mode pipeline stages.
 // VAD mode: Audio → VAD → STT → LLM → TTS
@@ -15,21 +83,19 @@ func buildVADPipelineStages(cfg *Config) ([]stage.Stage, error) {
 
 	logger.Debug("Using VAD pipeline stages")
 
-	// 5a. AudioTurnStage - VAD + turn detection + audio accumulation
-	audioTurnStage, err := stage.NewAudioTurnStage(*cfg.VADConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create AudioTurnStage: %w", err)
-	}
-	stages = append(stages, audioTurnStage)
-
-	// 5b. STTStage - transcribe audio to text
+	// 5a-b. AudioTurnStage → STTStage - the single-track audio front. No resample:
+	// this preserves the pre-existing VAD topology exactly (see BuildAudioTrackStages).
 	sttConfig := stage.DefaultSTTStageConfig()
 	if cfg.STTConfig != nil {
 		sttConfig = *cfg.STTConfig
 	}
-	stages = append(stages, stage.NewSTTStage(cfg.STTService, sttConfig))
+	trackStages, err := BuildAudioTrackStages("", false, *cfg.VADConfig, sttConfig, cfg.STTService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AudioTurnStage: %w", err)
+	}
+	stages = append(stages, trackStages...)
 
-	// 5c. ProviderStage - LLM call
+	// 5d. ProviderStage - LLM call
 	if cfg.Provider != nil {
 		providerConfig := &stage.ProviderConfig{
 			MaxTokens:   cfg.MaxTokens,
@@ -44,7 +110,7 @@ func buildVADPipelineStages(cfg *Config) ([]stage.Stage, error) {
 		))
 	}
 
-	// 5d. TTSStage - synthesize text to audio
+	// 5e. TTSStage - synthesize text to audio
 	ttsConfig := stage.DefaultTTSStageWithInterruptionConfig()
 	if cfg.TTSConfig != nil {
 		ttsConfig = *cfg.TTSConfig

--- a/sdk/internal/pipeline/builder_vad_test.go
+++ b/sdk/internal/pipeline/builder_vad_test.go
@@ -176,3 +176,49 @@ func TestBuildVADPipelineStages(t *testing.T) {
 		})
 	})
 }
+
+// TestBuildAudioTrackStages exercises the non-empty-prefix path directly — the
+// actual new capability added for ingestion sub-graphs — including the
+// prefixedStage.Name() override and its Type() delegation to the wrapped stage.
+func TestBuildAudioTrackStages(t *testing.T) {
+	sttService := &mockSTTService{}
+	vadAnalyzer := &mockVADAnalyzer{}
+	turnDetector := &mockTurnDetector{}
+	vadConfig := stage.AudioTurnConfig{
+		VAD:          vadAnalyzer,
+		TurnDetector: turnDetector,
+	}
+	sttConfig := stage.DefaultSTTStageConfig()
+
+	t.Run("includeResample=true returns 3 prefixed stages", func(t *testing.T) {
+		unprefixed, err := BuildAudioTrackStages("", true, vadConfig, sttConfig, sttService)
+		require.NoError(t, err)
+		require.Len(t, unprefixed, 3) // Resample, AudioTurn, STT
+
+		prefixed, err := BuildAudioTrackStages("caller", true, vadConfig, sttConfig, sttService)
+		require.NoError(t, err)
+		require.Len(t, prefixed, 3)
+
+		for i, s := range prefixed {
+			assert.Equal(t, "caller_"+unprefixed[i].Name(), s.Name())
+			// Type() must still delegate to the wrapped stage's Type() even
+			// though Name() is overridden by prefixedStage.
+			assert.Equal(t, unprefixed[i].Type(), s.Type())
+		}
+	})
+
+	t.Run("includeResample=false returns 2 prefixed stages", func(t *testing.T) {
+		unprefixed, err := BuildAudioTrackStages("", false, vadConfig, sttConfig, sttService)
+		require.NoError(t, err)
+		require.Len(t, unprefixed, 2) // AudioTurn, STT
+
+		prefixed, err := BuildAudioTrackStages("caller", false, vadConfig, sttConfig, sttService)
+		require.NoError(t, err)
+		require.Len(t, prefixed, 2)
+
+		for i, s := range prefixed {
+			assert.Equal(t, "caller_"+unprefixed[i].Name(), s.Name())
+			assert.Equal(t, unprefixed[i].Type(), s.Type())
+		}
+	})
+}

--- a/sdk/internal/pipeline/ingestion_test.go
+++ b/sdk/internal/pipeline/ingestion_test.go
@@ -1,0 +1,124 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildWithIngestionConnectsToAgentChain verifies that a custom
+// Config.Ingestion callback can author an upstream sub-graph whose output
+// feeds the head of the standard agent chain.
+//
+// *stage.StreamPipeline has no exported root-stage accessor (only Execute,
+// ExecuteSync, and Shutdown are exported — see runtime/pipeline/stage/pipeline.go),
+// and the mock provider ignores request content (it always returns a fixed
+// response), so a marker stamped on the message can't be observed by asserting
+// on result.Response.Content. Instead, the "ingest" stage is a stage.MapStage
+// that flips an atomic flag as a side effect of its Process() actually running.
+//
+// This is deterministic, unlike asserting only on result.Response != nil: if
+// Ingestion's output were NOT wired ahead of the agent chain (e.g. the
+// builder.Connect(outputNode, ...) call were dropped), both "ingest" and the
+// agent head become independent root stages sharing one pipelineInput channel,
+// and the single fed element is delivered to whichever root reads it first:
+//   - if "ingest" wins the race, ingestInvoked flips true, but the raw
+//     (role=user) element becomes the terminal output with no assistant
+//     message, so result.Response stays nil — assertion fails.
+//   - if the agent head wins the race, it bypasses "ingest" entirely and
+//     still produces a normal assistant Response — the old assertion would
+//     pass here roughly half the time despite the broken wiring, but
+//     ingestInvoked stays false, so the strengthened assertion fails.
+//
+// Only correct wiring (ingest is the sole root, feeding the agent head)
+// guarantees both ingestInvoked == true and result.Response != nil every time.
+func TestBuildWithIngestionConnectsToAgentChain(t *testing.T) {
+	registry := createTestRegistry("chat")
+	mockProvider := mock.NewProvider("test-mock", "test-model", false)
+
+	cfg := &Config{
+		PromptRegistry: registry,
+		TaskType:       "chat",
+		Provider:       mockProvider,
+		MaxTokens:      100,
+		Temperature:    0.5,
+	}
+	var ingestInvoked atomic.Bool
+	cfg.Ingestion = func(b *stage.PipelineBuilder) (string, error) {
+		b.AddStage(stage.NewMapStage("ingest", func(elem stage.StreamElement) (stage.StreamElement, error) {
+			ingestInvoked.Store(true)
+			return elem, nil
+		}))
+		return "ingest", nil
+	}
+
+	p, err := Build(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	userMsg := types.Message{Role: "user"}
+	userMsg.AddTextPart("Hello!")
+	elem := stage.StreamElement{Message: &userMsg}
+
+	result, err := p.ExecuteSync(context.Background(), elem)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotNil(t, result.Response)
+	assert.True(t, ingestInvoked.Load(), "ingest stage's Process must run before the agent head does")
+}
+
+// TestBuildWithIngestionPropagatesCallbackError verifies that an error returned
+// by the Ingestion callback aborts the build and is wrapped, not swallowed.
+func TestBuildWithIngestionPropagatesCallbackError(t *testing.T) {
+	registry := createTestRegistry("chat")
+	mockProvider := mock.NewProvider("test-mock", "test-model", false)
+
+	cfg := &Config{
+		PromptRegistry: registry,
+		TaskType:       "chat",
+		Provider:       mockProvider,
+	}
+	wantErr := errors.New("boom")
+	cfg.Ingestion = func(_ *stage.PipelineBuilder) (string, error) {
+		return "", wantErr
+	}
+
+	p, err := Build(cfg)
+	require.Error(t, err)
+	assert.Nil(t, p)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// TestBuildWithoutIngestionUnaffected pins the non-ingestion path: when
+// Config.Ingestion is nil, the agent chain is still rooted at its own head
+// (existing behavior, unchanged).
+func TestBuildWithoutIngestionUnaffected(t *testing.T) {
+	registry := createTestRegistry("chat")
+	mockProvider := mock.NewProvider("test-mock", "test-model", false)
+
+	cfg := &Config{
+		PromptRegistry: registry,
+		TaskType:       "chat",
+		Provider:       mockProvider,
+	}
+
+	p, err := Build(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	userMsg := types.Message{Role: "user"}
+	userMsg.AddTextPart("Hello!")
+	elem := stage.StreamElement{Message: &userMsg}
+
+	result, err := p.ExecuteSync(context.Background(), elem)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotNil(t, result.Response)
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -188,6 +188,10 @@ type config struct {
 	// STT service for VAD mode
 	sttService stt.Service
 
+	// Custom ingestion sub-graph (duplex-only). Mutually exclusive with
+	// vadModeConfig. See IngestionFunc / WithIngestion.
+	ingestion IngestionFunc
+
 	// Image preprocessing configuration
 	// When set, images are preprocessed (resized, optimized) before sending to provider
 	imagePreprocessConfig *stage.ImagePreprocessConfig
@@ -2298,6 +2302,21 @@ func WithVADMode(sttService stt.Service, ttsService tts.Service, cfg *VADModeCon
 		c.vadModeConfig = cfg
 		c.sttService = sttService
 		c.ttsService = ttsService
+		return nil
+	}
+}
+
+// IngestionFunc authors a custom upstream stage sub-graph. It adds stages and edges
+// to the shared builder and returns the name of the node whose output feeds the agent
+// chain. Mutually exclusive with WithVADMode.
+type IngestionFunc func(b *stage.PipelineBuilder) (outputNode string, err error)
+
+// WithIngestion installs a custom ingestion sub-graph in front of the agent chain
+// (fan-out/fan-in supported). Use with OpenDuplex for streaming harnesses that map
+// multiple input sources onto one agent without a TTS return path.
+func WithIngestion(fn IngestionFunc) Option {
+	return func(c *config) error {
+		c.ingestion = fn
 		return nil
 	}
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -158,9 +158,14 @@ func OpenDuplex(packPath, promptName string, opts ...Option) (*Conversation, err
 		return nil, err
 	}
 
-	// Verify provider supports streaming input
-	streamProvider, ok := prov.(providers.StreamInputSupport)
-	if !ok {
+	// Verify provider supports streaming input. A custom ingestion sub-graph
+	// (WithIngestion) drives the standard agent chain — the streaming text
+	// ProviderStage, not the ASM DuplexProviderStage — and never calls
+	// CreateStreamSession, so it does not need StreamInputSupport. When it is
+	// absent, only ASM mode requires the interface. NewDuplexSession re-derives
+	// the streaming provider from the base provider itself for ASM mode, so the
+	// gate here is purely a fail-fast check.
+	if _, ok := prov.(providers.StreamInputSupport); !ok && conv.config.ingestion == nil {
 		return nil, fmt.Errorf(
 			"provider %T does not support duplex streaming (must implement providers.StreamInputSupport)",
 			prov,
@@ -168,7 +173,7 @@ func OpenDuplex(packPath, promptName string, opts ...Option) (*Conversation, err
 	}
 
 	// Initialize duplex session
-	if err := initDuplexSession(conv, conv.config, streamProvider); err != nil {
+	if err := initDuplexSession(conv, conv.config); err != nil {
 		return nil, err
 	}
 
@@ -668,7 +673,7 @@ func initInternalStateStore(conv *Conversation, cfg *config) error {
 // and DuplexProviderStage reads it from TurnState when creating the session.
 
 // initDuplexSession initializes a duplex streaming session.
-func initDuplexSession(conv *Conversation, cfg *config, streamProvider providers.StreamInputSupport) error {
+func initDuplexSession(conv *Conversation, cfg *config) error {
 	var store statestore.Store
 	if cfg.stateStore != nil {
 		store = cfg.stateStore
@@ -711,9 +716,33 @@ func initDuplexSession(conv *Conversation, cfg *config, streamProvider providers
 	// publishes it to TurnState and DuplexProviderStage reads from there.
 	streamConfig := cfg.streamingConfig
 
-	// Build HITL checker closure — reads asyncHandlers dynamically under lock
-	// so handlers registered after OpenDuplex() are still consulted.
-	asyncChecker := session.AsyncToolChecker(func(callID, name string, args map[string]any) *session.AsyncToolCheckResult {
+	// Create duplex session with builder
+	duplexSession, err := session.NewDuplexSession(context.Background(), &session.DuplexSessionConfig{
+		ConversationID:   conversationID,
+		UserID:           cfg.userID,
+		StateStore:       store,
+		PipelineBuilder:  pipelineBuilder,
+		Provider:         cfg.getAgentProvider(),
+		Config:           streamConfig, // nil for VAD mode, set for ASM mode
+		ToolRegistry:     conv.toolRegistry,
+		AsyncToolChecker: conv.newAsyncToolChecker(),
+		Metadata:         cfg.sessionMetadata,
+		Variables:        initialVars,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create duplex session: %w", err)
+	}
+
+	conv.mode = DuplexMode
+	conv.duplexSession = duplexSession
+	return nil
+}
+
+// newAsyncToolChecker builds the HITL checker for a duplex session. It reads
+// asyncHandlers dynamically under lock so handlers registered after
+// OpenDuplex() (via OnToolAsync) are still consulted.
+func (conv *Conversation) newAsyncToolChecker() session.AsyncToolChecker {
+	return session.AsyncToolChecker(func(callID, name string, args map[string]any) *session.AsyncToolCheckResult {
 		conv.asyncHandlersMu.RLock()
 		checkFunc, isAsync := conv.asyncHandlers[name]
 		conv.asyncHandlersMu.RUnlock()
@@ -724,23 +753,7 @@ func initDuplexSession(conv *Conversation, cfg *config, streamProvider providers
 
 		checkResult := checkFunc(args)
 		if !checkResult.IsPending() {
-			// Check passed — execute the handler directly (it may not be in the registry
-			// since OnToolAsync is often called after OpenDuplex builds the pipeline).
-			conv.handlersMu.RLock()
-			handler := conv.handlers[name]
-			conv.handlersMu.RUnlock()
-			if handler == nil {
-				return nil // No handler — fall through to registry
-			}
-			result, execErr := handler(args)
-			if execErr != nil {
-				return &session.AsyncToolCheckResult{Handled: true, HandlerError: execErr}
-			}
-			resultJSON, marshalErr := json.Marshal(result)
-			if marshalErr != nil {
-				return &session.AsyncToolCheckResult{Handled: true, HandlerError: marshalErr}
-			}
-			return &session.AsyncToolCheckResult{Handled: true, HandlerResult: resultJSON}
+			return conv.executeAsyncToolNow(name, args)
 		}
 
 		// Tool requires human approval — create pending call using the provider's
@@ -753,7 +766,6 @@ func initDuplexSession(conv *Conversation, cfg *config, streamProvider providers
 			Message:   checkResult.Message,
 		}
 
-		// Set the handler for execution on resolve
 		conv.handlersMu.RLock()
 		handler := conv.handlers[name]
 		conv.handlersMu.RUnlock()
@@ -774,27 +786,29 @@ func initDuplexSession(conv *Conversation, cfg *config, streamProvider providers
 			},
 		}
 	})
+}
 
-	// Create duplex session with builder
-	duplexSession, err := session.NewDuplexSession(context.Background(), &session.DuplexSessionConfig{
-		ConversationID:   conversationID,
-		UserID:           cfg.userID,
-		StateStore:       store,
-		PipelineBuilder:  pipelineBuilder,
-		Provider:         streamProvider,
-		Config:           streamConfig, // nil for VAD mode, set for ASM mode
-		ToolRegistry:     conv.toolRegistry,
-		AsyncToolChecker: asyncChecker,
-		Metadata:         cfg.sessionMetadata,
-		Variables:        initialVars,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create duplex session: %w", err)
+// executeAsyncToolNow runs an async tool's handler inline when its HITL check
+// passed without needing approval. The handler may not be in the registry
+// (OnToolAsync is often called after OpenDuplex builds the pipeline), so it is
+// looked up and invoked directly. Returns nil to fall through to the registry
+// when there is no handler.
+func (conv *Conversation) executeAsyncToolNow(name string, args map[string]any) *session.AsyncToolCheckResult {
+	conv.handlersMu.RLock()
+	handler := conv.handlers[name]
+	conv.handlersMu.RUnlock()
+	if handler == nil {
+		return nil
 	}
-
-	conv.mode = DuplexMode
-	conv.duplexSession = duplexSession
-	return nil
+	result, execErr := handler(args)
+	if execErr != nil {
+		return &session.AsyncToolCheckResult{Handled: true, HandlerError: execErr}
+	}
+	resultJSON, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return &session.AsyncToolCheckResult{Handled: true, HandlerError: marshalErr}
+	}
+	return &session.AsyncToolCheckResult{Handled: true, HandlerResult: resultJSON}
 }
 
 // initMCPRegistry initializes the MCP registry if servers are configured.

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -209,6 +209,9 @@ func (s *duplexSession) SendChunk(ctx context.Context, chunk *providers.StreamCh
 
 	// Convert StreamChunk to StreamElement at the boundary
 	elem := streamChunkToStreamElement(chunk)
+	if chunk.Source != "" {
+		elem.WithSource(chunk.Source)
+	}
 
 	// Send converted element to Pipeline
 	select {

--- a/sdk/template.go
+++ b/sdk/template.go
@@ -230,14 +230,16 @@ func (t *PackTemplate) initSession(
 	duplex bool,
 ) error {
 	if duplex {
-		streamProvider, ok := prov.(providers.StreamInputSupport)
-		if !ok {
+		// A custom ingestion sub-graph drives the standard agent chain rather
+		// than the ASM DuplexProviderStage, so it does not require the provider
+		// to implement StreamInputSupport (see OpenDuplex for the full rationale).
+		if _, ok := prov.(providers.StreamInputSupport); !ok && cfg.ingestion == nil {
 			return fmt.Errorf(
 				"provider %T does not support duplex streaming (must implement providers.StreamInputSupport)",
 				prov,
 			)
 		}
-		return initDuplexSession(conv, cfg, streamProvider)
+		return initDuplexSession(conv, cfg)
 	}
 	return initInternalStateStore(conv, cfg)
 }


### PR DESCRIPTION
## What

Adds a **composable multi-output streaming pipeline** to the runtime and exposes it through the SDK as a **duplex-agent path** driven by a custom ingestion sub-graph.

### Runtime (`runtime/pipeline/stage`, `runtime/providers`, `runtime/audio`)
- Selective multi-output routing (router / branch / merge, fan-out / fan-in) with **execution-local edge channels**, so a stage can split a stream into parallel sub-chains and merge them back.
- `StreamChunk.Source` track tagging, so a multi-track input (e.g. two-party audio) can be routed per track.
- G.711 (µ-law / A-law) PCM codec helpers.

### SDK (`sdk`, `sdk/internal/pipeline`)
- **`WithIngestion`** option: inject a custom upstream sub-graph ahead of the standard agent chain in a duplex session (mutually exclusive with VAD mode).
- **`OpenDuplex` / `PackTemplate` no longer require `providers.StreamInputSupport`** when an ingestion sub-graph is present — the ingestion path drives the standard agent chain (a streaming text `ProviderStage`), not the ASM `DuplexProviderStage`, so **any LLM provider (e.g. Claude) can open the session**.
- The ingestion path builds a **streaming `ProviderStage`**: the agent fires the tool loop **per `EndOfTurn`** and threads history across turns, instead of the unary default that drains the whole input channel and fires once at close.

## Why

Before this, a `WithIngestion` duplex was duplex *transcription* only — it built a non-streaming `ProviderStage` that fired the LLM once at session close, and `OpenDuplex` rejected any provider without `StreamInputSupport`. Together these three changes make it a real duplex-**agent** path: custom per-track ingestion (VAD/STT/routing of your choosing) feeding an agent that responds per turn, with any provider.

## Testing

- Runtime already covers the streaming `ProviderStage` internals (`TestProviderStage_Streaming_OneReplyPerTurn` / `_ThreadsHistory`) and `AudioTurnStage` `EmitEndOfTurn`.
- New SDK-level tests prove the wiring end-to-end with mocks, independent of any example:
  - `TestOpenDuplexWithIngestionAcceptsNonStreamingProvider` — the gate relaxation.
  - `TestOpenDuplexWithIngestion_FiresAgentPerTurn` — the agent fires once per `EndOfTurn` **while the session is open**, threading history across turns.
- Full `runtime/...` and `sdk/...` suites pass; coverage 85.8% overall, all changed files ≥ 80%.

## Notes

- Library-only: this PR intentionally contains **no example project** — the runtime/SDK changes stand on their own with SDK-level tests. A demo consuming this path is maintained separately.
