### PR TITLE
docs(reference): regenerate runtime reference for composable pipeline APIs

### DIFF
--- a/docs/src/content/docs/runtime/reference/audio.md
+++ b/docs/src/content/docs/runtime/reference/audio.md
@@ -18,6 +18,7 @@ The package follows industry\-standard patterns for voice AI:
 - VAD \(Voice Activity Detection\): Detects when someone is speaking vs. silent
 - Turn Detection: Determines when a speaker has finished their turn
 - Interruption Handling: Manages user interrupting bot output
+- G.711 Codec: mu\-law/a\-law companding \<\-\> PCM16 \(telephony/SIP/PSTN\)
 
 ### Architecture
 
@@ -45,6 +46,10 @@ Package audio provides audio processing utilities.
 ## Index
 
 - [Constants](<#constants>)
+- [func DecodeALaw\(alaw \[\]byte\) \[\]byte](<#DecodeALaw>)
+- [func DecodeMuLaw\(mulaw \[\]byte\) \[\]byte](<#DecodeMuLaw>)
+- [func EncodeALaw\(pcm16le \[\]byte\) \[\]byte](<#EncodeALaw>)
+- [func EncodeMuLaw\(pcm16le \[\]byte\) \[\]byte](<#EncodeMuLaw>)
 - [func Resample24kTo16k\(input \[\]byte\) \(\[\]byte, error\)](<#Resample24kTo16k>)
 - [func ResamplePCM16\(input \[\]byte, fromRate, toRate int\) \(\[\]byte, error\)](<#ResamplePCM16>)
 - [type AccumulatingTurnDetector](<#AccumulatingTurnDetector>)
@@ -159,6 +164,42 @@ const (
 ```go
 const DefaultMaxAudioBufferSize = 10 * 1024 * 1024
 ```
+
+<a name="DecodeALaw"></a>
+## func DecodeALaw
+
+```go
+func DecodeALaw(alaw []byte) []byte
+```
+
+DecodeALaw converts G.711 a\-law bytes to little\-endian PCM16 \(2 bytes/sample\).
+
+<a name="DecodeMuLaw"></a>
+## func DecodeMuLaw
+
+```go
+func DecodeMuLaw(mulaw []byte) []byte
+```
+
+DecodeMuLaw converts G.711 mu\-law bytes to little\-endian PCM16 \(2 bytes/sample\).
+
+<a name="EncodeALaw"></a>
+## func EncodeALaw
+
+```go
+func EncodeALaw(pcm16le []byte) []byte
+```
+
+EncodeALaw converts little\-endian PCM16 to G.711 a\-law bytes \(1 byte/sample\).
+
+<a name="EncodeMuLaw"></a>
+## func EncodeMuLaw
+
+```go
+func EncodeMuLaw(pcm16le []byte) []byte
+```
+
+EncodeMuLaw converts little\-endian PCM16 to G.711 mu\-law bytes \(1 byte/sample\).
 
 <a name="Resample24kTo16k"></a>
 ## func Resample24kTo16k

--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -251,6 +251,8 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func NewMetricsStage\(wrappedStage Stage\) \*MetricsStage](<#NewMetricsStage>)
   - [func \(s \*MetricsStage\) GetMetrics\(\) StageMetrics](<#MetricsStage.GetMetrics>)
   - [func \(s \*MetricsStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#MetricsStage.Process>)
+- [type MultiInputStage](<#MultiInputStage>)
+- [type MultiOutputStage](<#MultiOutputStage>)
 - [type PassthroughStage](<#PassthroughStage>)
   - [func NewPassthroughStage\(name string\) \*PassthroughStage](<#NewPassthroughStage>)
   - [func \(ps \*PassthroughStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#PassthroughStage.Process>)
@@ -263,6 +265,7 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func \(b \*PipelineBuilder\) Chain\(stages ...Stage\) \*PipelineBuilder](<#PipelineBuilder.Chain>)
   - [func \(b \*PipelineBuilder\) Clone\(\) \*PipelineBuilder](<#PipelineBuilder.Clone>)
   - [func \(b \*PipelineBuilder\) Connect\(fromStage, toStage string\) \*PipelineBuilder](<#PipelineBuilder.Connect>)
+  - [func \(b \*PipelineBuilder\) Merge\(into string, from ...string\) \*PipelineBuilder](<#PipelineBuilder.Merge>)
   - [func \(b \*PipelineBuilder\) WithConfig\(config \*PipelineConfig\) \*PipelineBuilder](<#PipelineBuilder.WithConfig>)
   - [func \(b \*PipelineBuilder\) WithEventEmitter\(emitter \*events.Emitter\) \*PipelineBuilder](<#PipelineBuilder.WithEventEmitter>)
 - [type PipelineConfig](<#PipelineConfig>)
@@ -598,6 +601,14 @@ var (
 
     // ErrVideoDataRequired is returned when video data is required but missing.
     ErrVideoDataRequired = errors.New("video data required but not available")
+
+    // ErrFanInNotSupported is returned when a stage has multiple upstream edges but
+    // does not implement MultiInputStage.
+    ErrFanInNotSupported = errors.New("stage has multiple upstreams but does not implement MultiInputStage")
+
+    // ErrDuplicateFanInEdge is returned when a stage receives multiple edges from
+    // the same upstream stage, creating a duplicate input source.
+    ErrDuplicateFanInEdge = errors.New("duplicate upstream edge detected")
 )
 ```
 
@@ -3189,6 +3200,32 @@ func (s *MetricsStage) Process(ctx context.Context, input <-chan StreamElement, 
 
 Process implements the Stage interface with metrics collection.
 
+<a name="MultiInputStage"></a>
+## type MultiInputStage
+
+MultiInputStage is a Stage that consumes multiple upstream input channels \(fan\-in / N:1 merge\). The pipeline calls ProcessMultiple instead of Process when the stage has more than one upstream edge. Like Process, the stage MUST close output when all inputs are drained.
+
+```go
+type MultiInputStage interface {
+    Stage
+    ProcessMultiple(ctx context.Context, inputs []<-chan StreamElement, output chan<- StreamElement) error
+}
+```
+
+<a name="MultiOutputStage"></a>
+## type MultiOutputStage
+
+MultiOutputStage is a Stage that routes elements to named downstream outputs \(selective fan\-out / 1:N routing\). The pipeline registers one channel per downstream edge via RegisterOutput before Process runs; the stage routes each element to the appropriate registered output\(s\) and MUST close them when done.
+
+Single\-Execute caveat: RegisterOutput is called on the stage INSTANCE \(e.g. RouterStage.outputs\) fresh on every StreamPipeline.Execute\(\) call, since the per\-Execute edge channels live for the duration of that Execute\(\) only. A pipeline containing a MultiOutputStage is therefore only safe for a single \(or strictly sequential, non\-concurrent\) Execute\(\) call — concurrent Execute\(\) calls on the same pipeline would race registering/routing through the stage's shared output registry. This matches the only real usage today: the long\-running duplex streaming session, Execute'd once. Callers that reuse one \*StreamPipeline across concurrent Execute\(\) calls \(e.g. the unary Send\(\) path\) must not include a MultiOutputStage in that pipeline.
+
+```go
+type MultiOutputStage interface {
+    Stage
+    RegisterOutput(name string, output chan<- StreamElement)
+}
+```
+
 <a name="PassthroughStage"></a>
 ## type PassthroughStage
 
@@ -3433,6 +3470,15 @@ func (b *PipelineBuilder) Connect(fromStage, toStage string) *PipelineBuilder
 ```
 
 Connect creates a directed edge from one stage to another. The output of fromStage will be connected to the input of toStage.
+
+<a name="PipelineBuilder.Merge"></a>
+### func \(\*PipelineBuilder\) Merge
+
+```go
+func (b *PipelineBuilder) Merge(into string, from ...string) *PipelineBuilder
+```
+
+Merge wires multiple upstream stages into a single downstream fan\-in node. The target stage must implement MultiInputStage \(e.g. MergeStage\).
 
 <a name="PipelineBuilder.WithConfig"></a>
 ### func \(\*PipelineBuilder\) WithConfig

--- a/docs/src/content/docs/runtime/reference/providers.md
+++ b/docs/src/content/docs/runtime/reference/providers.md
@@ -2898,6 +2898,10 @@ type StreamChunk struct {
     // PendingTools contains client-mode tools awaiting caller fulfillment.
     // Only set when FinishReason is "pending_tools".
     PendingTools []tools.PendingToolExecution `json:"pending_tools,omitempty"`
+
+    // Source labels the input track/speaker for fan-out routing (e.g. "caller",
+    // "agent"). Copied onto StreamElement.Source at the session boundary.
+    Source string `json:"source,omitempty"`
 }
 ```
 

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -227,6 +227,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
 - [type EndpointResolver](<#EndpointResolver>)
 - [type EvaluateOpts](<#EvaluateOpts>)
 - [type InMemoryA2ATaskStore](<#InMemoryA2ATaskStore>)
+- [type IngestionFunc](<#IngestionFunc>)
 - [type LocalAgentExecutor](<#LocalAgentExecutor>)
   - [func NewLocalAgentExecutor\(members map\[string\]Agent\) \*LocalAgentExecutor](<#NewLocalAgentExecutor>)
   - [func \(e \*LocalAgentExecutor\) Execute\(ctx context.Context, descriptor \*tools.ToolDescriptor, args json.RawMessage\) \(json.RawMessage, error\)](<#LocalAgentExecutor.Execute>)
@@ -297,6 +298,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func WithImagePreprocessing\(cfg \*stage.ImagePreprocessConfig\) Option](<#WithImagePreprocessing>)
   - [func WithImageProvider\(spec ProviderSpec\) Option](<#WithImageProvider>)
   - [func WithInferenceProvider\(spec ProviderSpec\) Option](<#WithInferenceProvider>)
+  - [func WithIngestion\(fn IngestionFunc\) Option](<#WithIngestion>)
   - [func WithJSONMode\(\) Option](<#WithJSONMode>)
   - [func WithJudgeProvider\(jp handlers.JudgeProvider\) Option](<#WithJudgeProvider>)
   - [func WithLLMProvider\(spec ProviderSpec\) Option](<#WithLLMProvider>)
@@ -2216,6 +2218,15 @@ InMemoryA2ATaskStore is a concurrency\-safe in\-memory TaskStore.
 type InMemoryA2ATaskStore = a2aserver.InMemoryTaskStore
 ```
 
+<a name="IngestionFunc"></a>
+## type IngestionFunc
+
+IngestionFunc authors a custom upstream stage sub\-graph. It adds stages and edges to the shared builder and returns the name of the node whose output feeds the agent chain. Mutually exclusive with WithVADMode.
+
+```go
+type IngestionFunc func(b *stage.PipelineBuilder) (outputNode string, err error)
+```
+
 <a name="LocalAgentExecutor"></a>
 ## type LocalAgentExecutor
 
@@ -3184,6 +3195,15 @@ func WithInferenceProvider(spec ProviderSpec) Option
 ```
 
 WithInferenceProvider registers an inference \(classify\) provider that the SDK constructs and credential\-resolves. The backend is registered against every classify task interface it implements \(AudioClassifier, TextClassifier, etc.\). The HuggingFace factory is available via the backends/all blank import in runtime\_config.go \(same package\).
+
+<a name="WithIngestion"></a>
+### func WithIngestion
+
+```go
+func WithIngestion(fn IngestionFunc) Option
+```
+
+WithIngestion installs a custom ingestion sub\-graph in front of the agent chain \(fan\-out/fan\-in supported\). Use with OpenDuplex for streaming harnesses that map multiple input sources onto one agent without a TTS return path.
 
 <a name="WithJSONMode"></a>
 ### func WithJSONMode


### PR DESCRIPTION
Regenerates the committed runtime reference pages from source after #1612, fixing the Reference Drift Check. Adds `StreamChunk.Source` (providers.md), the multi-output/router/merge stage APIs (pipeline.md), and the G.711 codec helpers (audio.md). Generated by `make docs-reference` — no hand edits.