### PR TITLE
fix(sdk): execute local tool handlers registered after OpenDuplex

### DIFF
--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -434,7 +434,11 @@ func (c *Conversation) buildPipelineConfig(
 		ctxHandlersCopy[k] = v
 	}
 
-	localExec := &localExecutor{handlers: handlersCopy, ctxHandlers: ctxHandlersCopy}
+	localExec := &localExecutor{
+		handlers:    handlersCopy,
+		ctxHandlers: ctxHandlersCopy,
+		live:        &localHandlersAccessor{conv: c},
+	}
 	c.toolRegistry.RegisterExecutor(localExec)
 
 	clientExec := &clientExecutor{

--- a/sdk/tool_executors.go
+++ b/sdk/tool_executors.go
@@ -16,6 +16,31 @@ import (
 type localExecutor struct {
 	handlers    map[string]ToolHandler
 	ctxHandlers map[string]ToolHandlerCtx
+	live        *localHandlersAccessor
+}
+
+// localHandlersAccessor provides live read access to the conversation's local
+// tool handlers under its mutex. It lets the executor dispatch handlers
+// registered AFTER the pipeline was built — e.g. OnTool/OnToolCtx called after
+// OpenDuplex, whose duplex pipeline is built once (mirrors the client-tool
+// accessor). Without it, a duplex session's local tools use only the empty
+// build-time snapshot and fail with "no handler registered".
+type localHandlersAccessor struct {
+	conv *Conversation
+}
+
+func (a *localHandlersAccessor) getCtxHandler(name string) (ToolHandlerCtx, bool) {
+	a.conv.handlersMu.RLock()
+	defer a.conv.handlersMu.RUnlock()
+	h, ok := a.conv.ctxHandlers[name]
+	return h, ok
+}
+
+func (a *localHandlersAccessor) getHandler(name string) (ToolHandler, bool) {
+	a.conv.handlersMu.RLock()
+	defer a.conv.handlersMu.RUnlock()
+	h, ok := a.conv.handlers[name]
+	return h, ok
 }
 
 // Name returns "local" to match the Mode on tools in the pack.
@@ -34,15 +59,28 @@ func (e *localExecutor) Execute(
 		return nil, fmt.Errorf("failed to parse tool arguments: %w", err)
 	}
 
-	// Prefer context-aware handler
+	// Prefer context-aware handler; for each kind look at the build-time
+	// snapshot first, then live handlers via the accessor (handlers registered
+	// after the pipeline was built, e.g. after OpenDuplex).
+	ctxHandler, ok := e.ctxHandlers[descriptor.Name]
+	if !ok && e.live != nil {
+		ctxHandler, ok = e.live.getCtxHandler(descriptor.Name)
+	}
+
 	var result any
 	var err error
-	if ctxHandler, ok := e.ctxHandlers[descriptor.Name]; ok {
+	switch {
+	case ok:
 		result, err = ctxHandler(ctx, argsMap)
-	} else if handler, ok := e.handlers[descriptor.Name]; ok {
+	default:
+		handler, hok := e.handlers[descriptor.Name]
+		if !hok && e.live != nil {
+			handler, hok = e.live.getHandler(descriptor.Name)
+		}
+		if !hok {
+			return nil, fmt.Errorf("no handler registered for tool: %s", descriptor.Name)
+		}
 		result, err = handler(argsMap)
-	} else {
-		return nil, fmt.Errorf("no handler registered for tool: %s", descriptor.Name)
 	}
 	if err != nil {
 		return nil, err

--- a/sdk/tool_executors_test.go
+++ b/sdk/tool_executors_test.go
@@ -1,0 +1,83 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLocalExecutor_ResolvesHandlersRegisteredAfterBuild covers the duplex gap:
+// a duplex pipeline builds its localExecutor ONCE at OpenDuplex, before the app
+// registers tool handlers (OnTool/OnToolCtx). With only the build-time snapshot
+// the executor cannot see those handlers and fails with "no handler registered";
+// the live accessor lets it read the conversation's handlers at call time.
+func TestLocalExecutor_ResolvesHandlersRegisteredAfterBuild(t *testing.T) {
+	conv := &Conversation{
+		handlers:    map[string]ToolHandler{},
+		ctxHandlers: map[string]ToolHandlerCtx{},
+	}
+
+	// Executor built with an EMPTY snapshot (as in a duplex pipeline built before
+	// any handler is registered) but wired to the live accessor.
+	exec := &localExecutor{
+		handlers:    map[string]ToolHandler{},
+		ctxHandlers: map[string]ToolHandlerCtx{},
+		live:        &localHandlersAccessor{conv: conv},
+	}
+
+	// Register a ctx handler AFTER the executor was built (post-OpenDuplex).
+	var called bool
+	conv.handlersMu.Lock()
+	conv.ctxHandlers["echo"] = func(_ context.Context, args map[string]any) (any, error) {
+		called = true
+		return map[string]any{"echoed": args["msg"]}, nil
+	}
+	conv.handlersMu.Unlock()
+
+	out, err := exec.Execute(context.Background(),
+		&tools.ToolDescriptor{Name: "echo"}, json.RawMessage(`{"msg":"hi"}`))
+	require.NoError(t, err)
+	require.True(t, called, "a handler registered after build must dispatch via the live accessor")
+	require.JSONEq(t, `{"echoed":"hi"}`, string(out))
+}
+
+// TestLocalExecutor_PrefersPlainHandlerViaLiveAccessor confirms the plain
+// (non-ctx) handler path is also resolved live.
+func TestLocalExecutor_PrefersPlainHandlerViaLiveAccessor(t *testing.T) {
+	conv := &Conversation{
+		handlers:    map[string]ToolHandler{},
+		ctxHandlers: map[string]ToolHandlerCtx{},
+	}
+	exec := &localExecutor{
+		handlers:    map[string]ToolHandler{},
+		ctxHandlers: map[string]ToolHandlerCtx{},
+		live:        &localHandlersAccessor{conv: conv},
+	}
+
+	conv.handlersMu.Lock()
+	conv.handlers["ping"] = func(map[string]any) (any, error) { return "pong", nil }
+	conv.handlersMu.Unlock()
+
+	out, err := exec.Execute(context.Background(),
+		&tools.ToolDescriptor{Name: "ping"}, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	require.JSONEq(t, `"pong"`, string(out))
+}
+
+// TestLocalExecutor_NoAccessorMissesLateHandlers pins the pre-fix behavior: with
+// only a build-time snapshot and no live accessor, a handler registered later is
+// invisible — this is exactly what broke duplex + local tools.
+func TestLocalExecutor_NoAccessorMissesLateHandlers(t *testing.T) {
+	exec := &localExecutor{
+		handlers:    map[string]ToolHandler{},
+		ctxHandlers: map[string]ToolHandlerCtx{},
+		// no live accessor
+	}
+	_, err := exec.Execute(context.Background(),
+		&tools.ToolDescriptor{Name: "echo"}, json.RawMessage(`{}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no handler registered")
+}


### PR DESCRIPTION
## What

`localExecutor` captured tool handlers in a **build-time snapshot**. A duplex pipeline builds **once** at `OpenDuplex`, before the app registers handlers (`OnTool`/`OnToolCtx`), so the snapshot was empty and local (server-side) tools failed with `no handler registered`. Client tools worked only because `clientExecutor` already reads handlers **live** via an accessor.

This gives `localExecutor` the same live accessor (`localHandlersAccessor`): look up the build-time snapshot first, then the conversation's current handlers under its mutex.

## Why

Without it, **duplex + server-side tools is broken**: the model calls the tool, the handler never runs, and it gets `no handler registered` back. Unary sends are unaffected (they rebuild the snapshot per `Send`).

## How it surfaced

A duplex voice example wired data tools via `OnToolCtx` after `OpenDuplex`. Against a real provider, the model made native tool calls but the handlers never executed. (Mock providers only *script* tool calls, so mock tests never exercised real handler dispatch — this was invisible in tests.)

## Testing

`sdk/tool_executors_test.go`:
- a handler registered **after** the executor was built dispatches via the live accessor (ctx and plain handler paths);
- without the accessor, the late handler is invisible — pinning the pre-fix behavior.

Full `sdk/...` suite passes; changed-file coverage ≥ 80%.