### PR TITLE
fix(pipeline): time audio turns by sample count, not wall-clock

### DIFF
--- a/runtime/pipeline/stage/audio_turn_stage_test.go
+++ b/runtime/pipeline/stage/audio_turn_stage_test.go
@@ -419,11 +419,15 @@ func TestAudioTurnStage_EmitsEndOfTurnAfterTurn(t *testing.T) {
 	config.SilenceDuration = 30 * time.Millisecond
 	config.MinSpeechDuration = 10 * time.Millisecond
 
+	// 160 samples/chunk = 10 ms @ 16 kHz. Turn completion is timed in AUDIO time,
+	// so the turn closes after 30 ms (3 chunks) of silence audio — no wall-clock
+	// sleeps required.
 	mockVAD := &mockVADAnalyzer{
 		states: []audio.VADState{
-			audio.VADStateSpeaking, // chunk1
-			audio.VADStateStopping, // chunk2 — silenceStart set
-			audio.VADStateQuiet,    // chunk3 — turn completes
+			audio.VADStateSpeaking, // chunk1: speech (>= MinSpeechDuration)
+			audio.VADStateQuiet,    // chunk2: 10 ms silence
+			audio.VADStateQuiet,    // chunk3: 20 ms silence
+			audio.VADStateQuiet,    // chunk4: 30 ms silence -> turn completes
 		},
 	}
 	config.VAD = mockVAD
@@ -437,11 +441,9 @@ func TestAudioTurnStage_EmitsEndOfTurnAfterTurn(t *testing.T) {
 	output := make(chan stage.StreamElement, 10)
 	go func() { _ = s.Process(ctx, input, output) }()
 
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
-	time.Sleep(20 * time.Millisecond)
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
-	time.Sleep(35 * time.Millisecond) // let SilenceDuration elapse
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000)
+	for range 4 {
+		input <- makeAudioElement(generateTestPCMAudio(320), 16000) // 320 B = 160 samples = 10 ms
+	}
 	close(input)
 
 	var sawAudio, sawEndOfTurn, audioBeforeEOT bool
@@ -517,23 +519,19 @@ loop:
 
 func TestAudioTurnStage_MultipleTurns(t *testing.T) {
 	config := stage.DefaultAudioTurnConfig()
-	// SilenceDuration=30ms. Turn completion fires when a new chunk arrives after
-	// the silence timer has run for ≥30ms. We send the Stopping chunk then wait
-	// 35ms before sending the next chunk so shouldCompleteTurn fires on that chunk.
+	// 160 samples/chunk = 10 ms @ 16 kHz. Each turn closes on 30 ms (3 chunks) of
+	// silence AUDIO — no wall-clock sleeps. resetState calls vad.Reset(), which
+	// rewinds the mock's state index, so both turns replay this same 4-state
+	// pattern.
 	config.SilenceDuration = 30 * time.Millisecond
 	config.MinSpeechDuration = 10 * time.Millisecond
 
-	// VAD sequence: turn1 = [Speaking, Stopping, Quiet], turn2 = [Speaking, Stopping, Quiet]
-	// State reset between turns does not reset the mock VAD index.
-	// Turn 1 consumes indices 0-2; turn 2 consumes indices 3-5.
 	mockVAD := &mockVADAnalyzer{
 		states: []audio.VADState{
-			audio.VADStateSpeaking, // T1 chunk1
-			audio.VADStateStopping, // T1 chunk2 — silenceStart set here
-			audio.VADStateQuiet,    // T1 chunk3 — shouldCompleteTurn fires (silence ≥ 30ms after wait)
-			audio.VADStateSpeaking, // T2 chunk4 — speechDetected=true for turn 2
-			audio.VADStateStopping, // T2 chunk5 — silenceStart set for turn 2
-			audio.VADStateQuiet,    // T2 chunk6 — shouldCompleteTurn fires for turn 2
+			audio.VADStateSpeaking, // speech (>= MinSpeechDuration)
+			audio.VADStateQuiet,    // 10 ms silence
+			audio.VADStateQuiet,    // 20 ms silence
+			audio.VADStateQuiet,    // 30 ms silence -> turn completes
 		},
 	}
 	config.VAD = mockVAD
@@ -551,12 +549,10 @@ func TestAudioTurnStage_MultipleTurns(t *testing.T) {
 		_ = s.Process(ctx, input, output)
 	}()
 
-	// Turn 1:
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000) // chunk1: Speaking
-	time.Sleep(20 * time.Millisecond)
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000) // chunk2: Stopping, silenceStart set
-	time.Sleep(35 * time.Millisecond)                           // wait for SilenceDuration to expire
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000) // chunk3: Quiet, shouldCompleteTurn=true
+	// Turn 1: speech + 30 ms silence audio.
+	for range 4 {
+		input <- makeAudioElement(generateTestPCMAudio(320), 16000) // 320 B = 160 samples = 10 ms
+	}
 
 	// Wait for first turn output
 	var turn1 *stage.StreamElement
@@ -568,12 +564,10 @@ func TestAudioTurnStage_MultipleTurns(t *testing.T) {
 	}
 	require.NotNil(t, turn1.Audio, "Turn 1 should produce audio")
 
-	// Turn 2 (same timing pattern):
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000) // chunk4: Speaking
-	time.Sleep(20 * time.Millisecond)
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000) // chunk5: Stopping, silenceStart set
-	time.Sleep(35 * time.Millisecond)                           // wait for SilenceDuration to expire
-	input <- makeAudioElement(generateTestPCMAudio(160), 16000) // chunk6: Quiet, shouldCompleteTurn=true
+	// Turn 2 (same pattern):
+	for range 4 {
+		input <- makeAudioElement(generateTestPCMAudio(320), 16000) // 320 B = 160 samples = 10 ms
+	}
 	close(input)
 
 	// Wait for second turn output

--- a/runtime/pipeline/stage/audioturn_audiotime_test.go
+++ b/runtime/pipeline/stage/audioturn_audiotime_test.go
@@ -1,0 +1,119 @@
+package stage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// collectTurns drains output and returns one []byte per emitted audio turn.
+func collectTurns(output <-chan stage.StreamElement) [][]byte {
+	var turns [][]byte
+	for e := range output {
+		if e.Audio != nil && len(e.Audio.Samples) > 0 {
+			turns = append(turns, e.Audio.Samples)
+		}
+	}
+	return turns
+}
+
+// TestAudioTurnStage_SegmentsByAudioTimeNotWallClock feeds
+// speech|silence|speech|silence INSTANTLY (no real-time pacing) and requires the
+// stage to still segment into two turns.
+//
+// Turn boundaries must be decided from the AUDIO's own duration (sample count),
+// not wall-clock elapsed time. In a live pipeline, a blocking STT call or GC
+// pause drives wall-clock ahead of audio-time and mis-cuts turns — the defect
+// that split a caller utterance and dropped its trailing word ("...Springfield")
+// from a real call. With wall-clock timing an instant feed accumulates ~0s of
+// silence and emits a single turn only at EndOfStream; audio-time timing yields
+// two turns regardless of how fast the audio arrives.
+func TestAudioTurnStage_SegmentsByAudioTimeNotWallClock(t *testing.T) {
+	s, err := stage.NewAudioTurnStage(stage.DefaultAudioTurnConfig())
+	if err != nil {
+		t.Fatalf("NewAudioTurnStage: %v", err)
+	}
+
+	const chunkSamples = 1600 // 100 ms @ 16 kHz
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	input := make(chan stage.StreamElement)
+	output := make(chan stage.StreamElement, 64)
+	go func() { _ = s.Process(ctx, input, output) }()
+
+	go func() {
+		feed := func(gen func(int) []byte, chunks int) {
+			for range chunks {
+				input <- makeAudioElement(gen(chunkSamples), 16000)
+			}
+		}
+		feed(vadSpeechPCM, 10)  // 1.0 s speech
+		feed(vadSilencePCM, 12) // 1.2 s silence  (> 0.8 s SilenceDuration in AUDIO time)
+		feed(vadSpeechPCM, 10)  // 1.0 s speech
+		feed(vadSilencePCM, 12) // 1.2 s silence
+		input <- stage.StreamElement{EndOfStream: true}
+		close(input)
+	}()
+
+	turns := collectTurns(output)
+	if len(turns) < 2 {
+		t.Fatalf("expected >=2 audio-time-segmented turns from an instant feed, got %d; "+
+			"turn segmentation depends on wall-clock, not audio duration", len(turns))
+	}
+}
+
+// TestAudioTurnStage_ZeroSampleRateFallsBackToDefault guards the audio-time
+// timebase. Callers may build an AudioTurnConfig by hand instead of via
+// DefaultAudioTurnConfig, leaving SampleRate unset. Because turn boundaries are
+// now measured in samples, a zero rate would collapse every duration to 0 —
+// MinSpeechDuration would never be satisfied and the stage would accumulate
+// forever, emitting only at EndOfStream. NewAudioTurnStage must substitute the
+// default rate so segmentation still works.
+func TestAudioTurnStage_ZeroSampleRateFallsBackToDefault(t *testing.T) {
+	cfg := audioTurnConfigNoRate()
+	s, err := stage.NewAudioTurnStage(cfg)
+	if err != nil {
+		t.Fatalf("NewAudioTurnStage: %v", err)
+	}
+
+	const chunkSamples = 1600 // 100 ms @ 16 kHz
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	input := make(chan stage.StreamElement)
+	output := make(chan stage.StreamElement, 64)
+	go func() { _ = s.Process(ctx, input, output) }()
+
+	go func() {
+		feed := func(gen func(int) []byte, chunks int) {
+			for range chunks {
+				input <- makeAudioElement(gen(chunkSamples), 16000)
+			}
+		}
+		feed(vadSpeechPCM, 10)  // 1.0 s speech
+		feed(vadSilencePCM, 12) // 1.2 s silence
+		feed(vadSpeechPCM, 10)  // 1.0 s speech
+		feed(vadSilencePCM, 12) // 1.2 s silence
+		input <- stage.StreamElement{EndOfStream: true}
+		close(input)
+	}()
+
+	turns := collectTurns(output)
+	if len(turns) < 2 {
+		t.Fatalf("expected >=2 turns with SampleRate unset (default should apply), got %d; "+
+			"a zero sample rate collapses audio-time durations to 0 and stalls segmentation", len(turns))
+	}
+}
+
+// audioTurnConfigNoRate builds a config the way a caller would when they
+// only care about the turn thresholds and never set SampleRate.
+func audioTurnConfigNoRate() stage.AudioTurnConfig {
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.SampleRate = 0
+	return cfg
+}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -100,6 +100,13 @@ type AudioTurnStage struct {
 
 // NewAudioTurnStage creates a new audio turn stage.
 func NewAudioTurnStage(config AudioTurnConfig) (*AudioTurnStage, error) {
+	// Turn boundaries are measured in audio time (sample counts), so a zero
+	// sample rate would collapse every duration to 0 and no turn would ever
+	// complete. Fall back to the default rather than stalling silently.
+	if config.SampleRate <= 0 {
+		config.SampleRate = defaultAudioTurnSampleRate
+	}
+
 	// Create default VAD if not provided
 	vad := config.VAD
 	if vad == nil {
@@ -120,12 +127,28 @@ func NewAudioTurnStage(config AudioTurnConfig) (*AudioTurnStage, error) {
 }
 
 // audioTurnState holds the state for turn processing.
+//
+// Turn boundaries are timed in AUDIO time (accumulated PCM sample counts), not
+// wall-clock: a live pipeline stalls (a blocking STT call on the previous turn,
+// a GC pause) or delivers a burst after a stall, so wall-clock diverges from the
+// audio's own duration. Timing silence by wall-clock mis-cut turns and dropped
+// the tail of an utterance. Sample counts make segmentation independent of how
+// fast audio arrives.
 type audioTurnState struct {
 	audioBuffer    []byte
 	speechDetected bool
-	speechStart    time.Time
-	silenceStart   time.Time
-	turnStart      time.Time
+	speechSamples  int // samples since speech first detected (~ time since speech start)
+	silenceSamples int // consecutive silence samples since the last speech (0 while speaking)
+	turnSamples    int // total samples accumulated this turn
+}
+
+// samplesToDuration converts a PCM16-mono sample count to a wall-clock-equivalent
+// duration at the given sample rate. Returns 0 for a non-positive rate.
+func samplesToDuration(samples, sampleRate int) time.Duration {
+	if sampleRate <= 0 {
+		return 0
+	}
+	return time.Duration(samples) * time.Second / time.Duration(sampleRate)
 }
 
 // Process implements the Stage interface.
@@ -137,9 +160,7 @@ func (s *AudioTurnStage) Process(
 ) error {
 	defer close(output)
 
-	state := &audioTurnState{
-		turnStart: time.Now(),
-	}
+	state := &audioTurnState{}
 
 	for elem := range input {
 		// Handle EndOfStream specially - emit any accumulated audio first
@@ -311,6 +332,10 @@ func (s *AudioTurnStage) processAudio(
 	// This is important for pre-recorded audio files where VAD may not detect speech
 	state.audioBuffer = append(state.audioBuffer, elem.Audio.Samples...)
 
+	// Account for this chunk in AUDIO time (sample count), never wall-clock.
+	n := len(elem.Audio.Samples) / bytesPerSample16Bit
+	state.turnSamples += n
+
 	// Run VAD analysis for turn detection
 	_, err := s.vad.Analyze(ctx, elem.Audio.Samples)
 	if err != nil {
@@ -319,21 +344,27 @@ func (s *AudioTurnStage) processAudio(
 
 	vadState := s.vad.State()
 
-	// Update speech detection state based on VAD
+	// Update speech/silence sample tallies based on VAD.
 	switch vadState {
 	case audio.VADStateSpeaking, audio.VADStateStarting:
 		if !state.speechDetected {
 			state.speechDetected = true
-			state.speechStart = time.Now()
 			logger.Debug("AudioTurnStage: speech started")
 		}
-		state.silenceStart = time.Time{} // Reset silence timer
+		state.silenceSamples = 0 // speech resumed; reset the silence run
 
 	case audio.VADStateStopping, audio.VADStateQuiet:
-		if state.speechDetected && state.silenceStart.IsZero() {
-			state.silenceStart = time.Now()
-			logger.Debug("AudioTurnStage: silence started")
+		if state.speechDetected {
+			if state.silenceSamples == 0 {
+				logger.Debug("AudioTurnStage: silence started")
+			}
+			state.silenceSamples += n
 		}
+	}
+
+	// Time-since-speech-start (incl. intra-utterance pauses), for MinSpeechDuration.
+	if state.speechDetected {
+		state.speechSamples += n
 	}
 
 	// Also use TurnDetector if available
@@ -353,19 +384,21 @@ func (s *AudioTurnStage) shouldCompleteTurn(state *audioTurnState) bool {
 		return false
 	}
 
+	sr := s.config.SampleRate
+
 	// Check minimum speech duration
-	if time.Since(state.speechStart) < s.config.MinSpeechDuration {
+	if samplesToDuration(state.speechSamples, sr) < s.config.MinSpeechDuration {
 		return false
 	}
 
-	// Check silence duration
-	if !state.silenceStart.IsZero() && time.Since(state.silenceStart) >= s.config.SilenceDuration {
+	// Check silence duration (audio time, not wall-clock)
+	if state.silenceSamples > 0 && samplesToDuration(state.silenceSamples, sr) >= s.config.SilenceDuration {
 		logger.Debug("AudioTurnStage: turn complete - silence duration exceeded")
 		return true
 	}
 
 	// Check max turn duration
-	if time.Since(state.turnStart) >= s.config.MaxTurnDuration {
+	if samplesToDuration(state.turnSamples, sr) >= s.config.MaxTurnDuration {
 		logger.Debug("AudioTurnStage: turn complete - max duration exceeded")
 		return true
 	}
@@ -415,9 +448,9 @@ func (s *AudioTurnStage) emitTurnAudio(
 func (s *AudioTurnStage) resetState(state *audioTurnState) {
 	state.audioBuffer = nil
 	state.speechDetected = false
-	state.speechStart = time.Time{}
-	state.silenceStart = time.Time{}
-	state.turnStart = time.Now()
+	state.speechSamples = 0
+	state.silenceSamples = 0
+	state.turnSamples = 0
 	s.vad.Reset()
 	if s.turnDetector != nil {
 		s.turnDetector.Reset()


### PR DESCRIPTION
## Problem

`AudioTurnStage` decided turn boundaries with `time.Since()` — segmentation depended on how fast audio *arrived* rather than on the audio's own duration.

In a live pipeline those diverge. A blocking STT call on the previous turn, or a GC pause, advances wall-clock while no audio flows, so the silence and max-turn thresholds trip early and cut an utterance mid-sentence. A non-real-time feed (tests, file replay, batch ingestion) has the opposite failure: everything accumulates into one turn.

This was found while debugging a real two-party call where a caller's address lost its trailing word. (The proximate cause there was `SimpleVAD` misclassifying speech as silence — a separate issue, fixed example-side. This is the underlying correctness bug found en route, and it stands on its own.)

## Change

Track speech, silence, and turn extent as PCM16 sample counts; convert to durations via the configured sample rate. Segmentation is now independent of delivery rate.

Because durations now derive from `SampleRate`, a config built by hand instead of via `DefaultAudioTurnConfig` left it zero — which collapsed every duration to 0 and **panicked** on the debug-log divide. `NewAudioTurnStage` now substitutes the default rate.

## Tests

- `TestAudioTurnStage_SegmentsByAudioTimeNotWallClock` — feeds `speech|silence|speech|silence` instantly, expects 2 turns. Verified RED (1 turn) before the fix, GREEN after.
- `TestAudioTurnStage_ZeroSampleRateFallsBackToDefault` — verified RED (panic) with the guard disabled, GREEN with it.
- Two existing tests reached `SilenceDuration` via `time.Sleep`; they now feed silence chunks. This corrects the contract they were asserting rather than relaxing it — under the fixed stage, sleeping no longer advances turn state, which is the point.

Full `runtime` suite passes with `-race`; `golangci-lint --new-from-rev=origin/main` reports 0 issues; changed-file coverage 84.6%.

## Note for review

No public API change — `samplesToDuration` is unexported and the config surface is unchanged. Behavior does change for any caller relying on wall-clock segmentation with a non-real-time feed; that path was producing incorrect turns.
