### PR TITLE
fix(pipeline): trim leading silence before sending a turn to STT

### DIFF
--- a/runtime/pipeline/stage/audioturn_trim_test.go
+++ b/runtime/pipeline/stage/audioturn_trim_test.go
@@ -1,0 +1,152 @@
+package stage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+const trimTestSampleRate = 16000
+
+// turnDuration reports the wall-clock-equivalent duration of a PCM16-mono turn.
+func turnDuration(samples []byte) time.Duration {
+	return time.Duration(len(samples)/2) * time.Second / time.Duration(trimTestSampleRate)
+}
+
+// runTurnStage feeds the supplied chunks through an AudioTurnStage and returns
+// the emitted turns.
+func runTurnStage(t *testing.T, cfg stage.AudioTurnConfig, feed func(in chan<- stage.StreamElement)) [][]byte {
+	t.Helper()
+
+	s, err := stage.NewAudioTurnStage(cfg)
+	if err != nil {
+		t.Fatalf("NewAudioTurnStage: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	input := make(chan stage.StreamElement)
+	output := make(chan stage.StreamElement, 64)
+	go func() { _ = s.Process(ctx, input, output) }()
+
+	go func() {
+		feed(input)
+		input <- stage.StreamElement{EndOfStream: true}
+		close(input)
+	}()
+
+	return collectTurns(output)
+}
+
+// TestAudioTurnStage_TrimsLeadingSilenceBeforeSpeech covers the STT cost and
+// accuracy problem: between turns the stage buffers every silent chunk, so a
+// caller who is quiet for several seconds prepends all of that silence to the
+// next turn. That silence is billed per-second by STT providers and, with
+// Whisper in particular, invites hallucinated text on near-silent input.
+//
+// The emitted turn must start shortly before speech onset, not at the start of
+// the preceding silence.
+func TestAudioTurnStage_TrimsLeadingSilenceBeforeSpeech(t *testing.T) {
+	const chunkSamples = 1600 // 100 ms @ 16 kHz
+
+	turns := runTurnStage(t, stage.DefaultAudioTurnConfig(), func(in chan<- stage.StreamElement) {
+		feed := func(gen func(int) []byte, chunks int) {
+			for range chunks {
+				in <- makeAudioElement(gen(chunkSamples), trimTestSampleRate)
+			}
+		}
+		feed(vadSilencePCM, 30) // 3.0 s of dead air before the caller speaks
+		feed(vadSpeechPCM, 10)  // 1.0 s speech
+		feed(vadSilencePCM, 12) // 1.2 s trailing silence completes the turn
+	})
+
+	if len(turns) == 0 {
+		t.Fatalf("expected at least one turn, got none")
+	}
+
+	got := turnDuration(turns[0])
+
+	// Untrimmed this is ~5.2 s. Trimmed it should be the 1.0 s of speech plus
+	// trailing silence and a small pre-roll — comfortably under 3 s.
+	if got >= 3*time.Second {
+		t.Errorf("leading silence not trimmed: turn is %v, expected well under 3s "+
+			"(3.0s of dead air is still being sent to STT)", got)
+	}
+
+	// The speech itself must survive. Anything under 1 s means the onset was clipped.
+	if got < time.Second {
+		t.Errorf("turn is %v, shorter than the 1.0s of speech — onset was clipped", got)
+	}
+}
+
+// TestAudioTurnStage_PreservesPreRollBeforeSpeechOnset guards against trimming
+// exactly at the VAD's speech-start marker. VAD triggers a beat late, so cutting
+// precisely at onset clips the leading consonant. A short pre-roll must be kept.
+func TestAudioTurnStage_PreservesPreRollBeforeSpeechOnset(t *testing.T) {
+	const chunkSamples = 1600 // 100 ms @ 16 kHz
+
+	turns := runTurnStage(t, stage.DefaultAudioTurnConfig(), func(in chan<- stage.StreamElement) {
+		feed := func(gen func(int) []byte, chunks int) {
+			for range chunks {
+				in <- makeAudioElement(gen(chunkSamples), trimTestSampleRate)
+			}
+		}
+		feed(vadSilencePCM, 20) // 2.0 s dead air
+		feed(vadSpeechPCM, 10)  // 1.0 s speech
+		feed(vadSilencePCM, 12) // 1.2 s trailing silence
+	})
+
+	if len(turns) == 0 {
+		t.Fatalf("expected at least one turn, got none")
+	}
+
+	got := turnDuration(turns[0])
+
+	// speech (1.0s) + trailing silence (1.2s) = 2.2s of content the turn must keep.
+	// A pre-roll adds a little more, but only a little: the bounds must exclude
+	// BOTH trimming flush at onset (<=2.2s, clips the leading consonant) and not
+	// trimming at all (the untrimmed 4.2s would otherwise satisfy a lower bound).
+	const content = 2200 * time.Millisecond
+	const maxPreRoll = 3 * time.Second
+	if got <= content {
+		t.Errorf("turn is %v with no pre-roll before speech onset; expected >%v "+
+			"so a late VAD trigger cannot clip the leading consonant", got, content)
+	}
+	if got >= maxPreRoll {
+		t.Errorf("turn is %v, beyond %v: pre-roll should be a short margin, "+
+			"not the whole preceding silence", got, maxPreRoll)
+	}
+}
+
+// TestAudioTurnStage_ForwardsUntrimmedWhenNoSpeechDetected pins the safety
+// property that makes this stage recoverable when VAD is wrong.
+//
+// The stage buffers unconditionally so that a VAD misread mis-cuts a turn rather
+// than deleting audio — that is why a SimpleVAD misclassification was a
+// segmentation bug and not silent data loss. Trimming must not weaken it: when
+// VAD never reports speech at all, the buffer has to be forwarded whole, because
+// the audio may well contain speech the VAD failed to see.
+func TestAudioTurnStage_ForwardsUntrimmedWhenNoSpeechDetected(t *testing.T) {
+	const chunkSamples = 1600 // 100 ms @ 16 kHz
+	const chunks = 20         // 2.0 s
+
+	turns := runTurnStage(t, stage.DefaultAudioTurnConfig(), func(in chan<- stage.StreamElement) {
+		for range chunks {
+			in <- makeAudioElement(vadSilencePCM(chunkSamples), trimTestSampleRate)
+		}
+	})
+
+	if len(turns) == 0 {
+		t.Fatalf("expected the buffered audio to be forwarded at EndOfStream, got no turns")
+	}
+
+	got := turnDuration(turns[0])
+	want := 2 * time.Second
+	if got != want {
+		t.Errorf("VAD never detected speech: expected the full %v forwarded untrimmed, got %v "+
+			"— trimming must not discard audio the VAD may have misread", want, got)
+	}
+}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -58,10 +58,20 @@ const (
 	defaultAudioTurnMinSpeech   = 200 * time.Millisecond
 	defaultAudioTurnMaxDuration = 30 * time.Second
 	defaultAudioTurnSampleRate  = 16000
-	bytesPerSample16Bit         = 2     // 16-bit audio = 2 bytes per sample
-	defaultMinAudioBytes        = 1600  // 50ms at 16kHz 16-bit mono
-	defaultTTSOutputSampleRate  = 24000 // OpenAI TTS output sample rate
-	msPerSecond                 = 1000
+	// defaultAudioTurnPreRoll is the audio kept ahead of VAD's speech-onset marker.
+	// VAD reports speech only once it has accumulated enough confident frames
+	// (DefaultVADStartSecs is 0.2s, and chunk granularity pushes the marker later
+	// still), so trimming flush at the marker cuts into the utterance.
+	//
+	// Deliberately generous. The costs are asymmetric: an extra second of retained
+	// silence is a rounding error against the many seconds of dead air removed,
+	// whereas too small a pre-roll corrupts the transcript by clipping the
+	// caller's first word. Bias toward keeping audio.
+	defaultAudioTurnPreRoll    = time.Second
+	bytesPerSample16Bit        = 2     // 16-bit audio = 2 bytes per sample
+	defaultMinAudioBytes       = 1600  // 50ms at 16kHz 16-bit mono
+	defaultTTSOutputSampleRate = 24000 // OpenAI TTS output sample rate
+	msPerSecond                = 1000
 
 	// ResponseVAD default params - tuned for TTS audio detection
 	defaultResponseVADConfidence = 0.3   // Lower threshold for TTS audio
@@ -140,6 +150,15 @@ type audioTurnState struct {
 	speechSamples  int // samples since speech first detected (~ time since speech start)
 	silenceSamples int // consecutive silence samples since the last speech (0 while speaking)
 	turnSamples    int // total samples accumulated this turn
+	// speechStartOffset is the byte offset in audioBuffer of the chunk where VAD
+	// first reported speech, or -1 while no speech has been detected. Leading
+	// silence before this point (less a pre-roll) is trimmed at emit time.
+	speechStartOffset int
+}
+
+// newAudioTurnState returns turn state with no speech onset recorded yet.
+func newAudioTurnState() *audioTurnState {
+	return &audioTurnState{speechStartOffset: -1}
 }
 
 // samplesToDuration converts a PCM16-mono sample count to a wall-clock-equivalent
@@ -160,7 +179,7 @@ func (s *AudioTurnStage) Process(
 ) error {
 	defer close(output)
 
-	state := &audioTurnState{}
+	state := newAudioTurnState()
 
 	for elem := range input {
 		// Handle EndOfStream specially - emit any accumulated audio first
@@ -349,6 +368,8 @@ func (s *AudioTurnStage) processAudio(
 	case audio.VADStateSpeaking, audio.VADStateStarting:
 		if !state.speechDetected {
 			state.speechDetected = true
+			// Record where this chunk starts so the dead air before it can be trimmed.
+			state.speechStartOffset = len(state.audioBuffer) - len(elem.Audio.Samples)
 			logger.Debug("AudioTurnStage: speech started")
 		}
 		state.silenceSamples = 0 // speech resumed; reset the silence run
@@ -422,13 +443,16 @@ func (s *AudioTurnStage) emitTurnAudio(
 		return nil
 	}
 
+	samples := s.trimLeadingSilence(state)
+
 	logger.Debug("AudioTurnStage: emitting turn audio",
-		"bytes", len(state.audioBuffer),
-		"duration_ms", len(state.audioBuffer)*msPerSecond/(s.config.SampleRate*bytesPerSample16Bit))
+		"bytes", len(samples),
+		"trimmed_bytes", len(state.audioBuffer)-len(samples),
+		"duration_ms", len(samples)*msPerSecond/(s.config.SampleRate*bytesPerSample16Bit))
 
 	elem := StreamElement{
 		Audio: &AudioData{
-			Samples:    state.audioBuffer,
+			Samples:    samples,
 			SampleRate: s.config.SampleRate,
 			Channels:   1,
 			Format:     AudioFormatPCM16,
@@ -444,6 +468,29 @@ func (s *AudioTurnStage) emitTurnAudio(
 	}
 }
 
+// trimLeadingSilence drops the dead air preceding speech onset, keeping a
+// pre-roll margin. STT is billed per second and Whisper is prone to emitting
+// hallucinated text over long near-silent input, so shipping a caller's several
+// seconds of pause with their utterance costs money and invites phantom
+// transcripts.
+//
+// When VAD never reported speech the buffer is returned whole. That is
+// deliberate: the stage buffers unconditionally so a VAD misread mis-cuts a turn
+// instead of deleting audio, and trimming must not turn a misread into silent
+// data loss.
+func (s *AudioTurnStage) trimLeadingSilence(state *audioTurnState) []byte {
+	if !state.speechDetected || state.speechStartOffset <= 0 {
+		return state.audioBuffer
+	}
+
+	preRoll := int(defaultAudioTurnPreRoll.Seconds() * float64(s.config.SampleRate) * bytesPerSample16Bit)
+	start := state.speechStartOffset - preRoll
+	if start <= 0 {
+		return state.audioBuffer
+	}
+	return state.audioBuffer[start:]
+}
+
 // resetState resets the turn state for a new turn.
 func (s *AudioTurnStage) resetState(state *audioTurnState) {
 	state.audioBuffer = nil
@@ -451,6 +498,7 @@ func (s *AudioTurnStage) resetState(state *audioTurnState) {
 	state.speechSamples = 0
 	state.silenceSamples = 0
 	state.turnSamples = 0
+	state.speechStartOffset = -1
 	s.vad.Reset()
 	if s.turnDetector != nil {
 		s.turnDetector.Reset()


### PR DESCRIPTION
Stacked on #1616 — review/merge that one first.

## Problem

`AudioTurnStage` buffers every chunk unconditionally. Between turns, all the dead air before the caller speaks accumulates in the buffer and ships to STT prepended to the utterance. A caller quiet for 30s sends 30s of silence along with their sentence.

Three costs:

- **Billing** — STT is priced per second of audio.
- **Latency** — larger payload, slower turnaround on a live call.
- **Whisper hallucination** — Whisper is prone to emitting phantom text over long near-silent input. Those hallucinated transcripts then flow downstream as if the caller had actually said them, which is the failure mode that worries me most here.

## Change

Record the buffer offset where VAD first reports speech; drop everything before it, less a pre-roll, at emit time.

**Pre-roll is a deliberate full second.** VAD only reports speech once it has accumulated confident frames (`DefaultVADStartSecs` is 0.2s, chunk granularity pushes the marker later still), so the onset marker lands inside the utterance. Trimming flush at it clipped 200ms of real speech — caught by the pre-roll test, not by inspection. The costs are asymmetric: a retained second of silence is nothing against the dead air removed, while too small a margin corrupts the transcript.

**The degrade-open property is preserved.** When VAD never reports speech, the buffer is forwarded whole. This stage buffers unconditionally so that a VAD misread mis-cuts a turn rather than deleting audio — that is precisely why a `SimpleVAD` misclassification was a recoverable segmentation bug and not silent data loss. Trimming must not convert a misread into deleted speech.

## Tests (TDD)

- `TestAudioTurnStage_TrimsLeadingSilenceBeforeSpeech` — RED at 4.9s, GREEN after.
- `TestAudioTurnStage_PreservesPreRollBeforeSpeechOnset` — bounded on both sides so it cannot pass either by trimming flush at onset or by not trimming at all. Verified RED, then caught the 200ms clip at a 300ms pre-roll before going GREEN at 1s.
- `TestAudioTurnStage_ForwardsUntrimmedWhenNoSpeechDetected` — **this one passed from the start.** It is a regression guard pinning existing degrade-open behavior, not a test that drove new code. Flagging that explicitly rather than presenting it as red-green.

`runtime/pipeline/...` passes with `-race`; `golangci-lint --new-from-rev=origin/main` reports 0 issues; changed-file coverage 85.5%.

## Known limitation, not addressed here

Trimming happens at **emit** time, so it does not bound memory during the silence itself. A caller idle for several minutes still accumulates the whole buffer (~32 KB/s at 16 kHz mono PCM16) before any of it is discarded. Capping in-flight buffered silence is a separate change; say the word if you want it.

The pre-roll is a package constant rather than a config field — happy to promote it to `AudioTurnConfig` if you would rather it be tunable.
