### PR TITLE
perf(audio): benchmark memory retention and per-chunk churn on the audio path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help build test test-race lint clean coverage install test-e2e test-e2e-mock test-e2e-coverage test-e2e-ci schemas schemas-check schemas-copy
+.PHONY: help build test test-race lint clean coverage install test-e2e test-e2e-mock test-e2e-coverage test-e2e-ci schemas schemas-check schemas-copy bench-audio-memory
 
 # Route unknown targets to help
 .DEFAULT:
@@ -38,6 +38,15 @@ test: ## Run all tests
 	@cd sdk && go test -v ./...
 	@echo "Testing pkg..."
 	@cd pkg && go test -v ./... || echo "No pkg tests yet"
+
+bench-audio-memory: ## Report audio-path memory: retention per session + allocation churn per chunk
+	@echo "Audio path memory benchmarks (no -race: it perturbs allocation)"
+	@echo ""
+	@echo "== Retention: heap held per session length =="
+	@cd runtime && go test ./pipeline/stage/ -run '^$$' -bench BenchmarkAudioTurnStageRetention -benchtime 1x
+	@echo ""
+	@echo "== Churn: cost per audio chunk =="
+	@cd runtime && go test ./audio/ -run '^$$' -bench 'BenchmarkSilenceDetectorProcessAudio|BenchmarkResamplePCM16' -benchtime 2000x
 
 # =============================================================================
 # SDK E2E Tests

--- a/runtime/audio/resample_memory_bench_test.go
+++ b/runtime/audio/resample_memory_bench_test.go
@@ -1,0 +1,52 @@
+package audio_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// BenchmarkResamplePCM16 measures per-chunk allocation on the resample path.
+//
+// ResamplePCM16 pools its []int16 scratch (resamplePool) but not the []byte it
+// returns, so every chunk allocates an output slice. The same-rate case also
+// allocates: it takes a full copy rather than returning the input untouched.
+//
+// AudioResampleStage avoids that same-rate copy via PassthroughIfSameRate
+// (default true), so the SameRate figure here is the cost paid by callers using
+// ResamplePCM16 directly or disabling passthrough — not by the default pipeline.
+func BenchmarkResamplePCM16(b *testing.B) {
+	cases := []struct {
+		name       string
+		from, to   int
+		chunkBytes int
+	}{
+		// Telephony 8 kHz into the 16 kHz the STT path expects — the upsample a
+		// real call performs on every chunk.
+		{name: "8kTo16k", from: 8000, to: 16000, chunkBytes: benchChunkBytes / 2},
+		// TTS output rate down to 16 kHz.
+		{name: "24kTo16k", from: 24000, to: 16000, chunkBytes: benchChunkBytes * 3 / 2},
+		// No conversion needed: measures the copy taken anyway.
+		{name: "SameRate16k", from: 16000, to: 16000, chunkBytes: benchChunkBytes},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			input := make([]byte, tc.chunkBytes)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(tc.chunkBytes))
+			b.ResetTimer()
+
+			for range b.N {
+				out, err := audio.ResamplePCM16(input, tc.from, tc.to)
+				if err != nil {
+					b.Fatalf("ResamplePCM16: %v", err)
+				}
+				if len(out) == 0 {
+					b.Fatal("empty output")
+				}
+			}
+		})
+	}
+}

--- a/runtime/audio/silence_memory_bench_test.go
+++ b/runtime/audio/silence_memory_bench_test.go
@@ -1,0 +1,100 @@
+package audio_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// Audio geometry used by these benchmarks: 16 kHz mono PCM16, 100 ms chunks.
+const (
+	benchSampleRate   = 16000
+	benchChunkSamples = benchSampleRate / 10 // 100 ms
+	benchChunkBytes   = benchChunkSamples * 2
+)
+
+// quietLogger redirects slog away from stderr for the duration of a benchmark.
+//
+// SilenceDetector emits a slog.Warn on every chunk once its buffer is at the
+// cap. Left on stderr that would both flood the output and make the measurement
+// mostly a test of the logging backend. Discarding it isolates the memmove —
+// note that production cost is therefore HIGHER than these numbers, not lower.
+func quietLogger(b *testing.B) {
+	b.Helper()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	b.Cleanup(func() { slog.SetDefault(prev) })
+}
+
+// newSpeakingDetector returns a detector already in a speaking turn, which is
+// the state in which ProcessAudio accumulates (it buffers only while
+// userSpeaking || hadSpeech).
+func newSpeakingDetector(b *testing.B, maxBuffer int) *audio.SilenceDetector {
+	b.Helper()
+	d := audio.NewSilenceDetector(time.Second, audio.WithMaxAudioBufferSize(maxBuffer))
+	if _, err := d.ProcessVADState(context.Background(), audio.VADStateSpeaking); err != nil {
+		b.Fatalf("ProcessVADState: %v", err)
+	}
+	return d
+}
+
+// BenchmarkSilenceDetectorProcessAudio measures the per-chunk cost of feeding a
+// speaking turn, below and at the buffer cap.
+//
+// SilenceDetector bounds its buffer by shifting the entire buffer down by one
+// chunk on every call once full:
+//
+//	copy(d.audioBuffer, d.audioBuffer[excess:])
+//
+// Below the cap that branch never runs and the cost is a plain append. At the
+// cap every chunk memmoves the whole buffer — at 100 chunks/sec/track that is
+// the difference the AtCap/BelowCap ratio makes visible.
+//
+// This is churn, not retention: the buffer IS bounded at 10 MB, so a
+// retention-only measurement would report this code as healthy.
+func BenchmarkSilenceDetectorProcessAudio(b *testing.B) {
+	cases := []struct {
+		name string
+		// maxBuffer sized so the benchmark either never reaches the cap or is
+		// already sitting on it before the timer starts.
+		maxBuffer int
+		prefill   bool
+	}{
+		{name: "BelowCap", maxBuffer: audio.DefaultMaxAudioBufferSize, prefill: false},
+		{name: "AtCap_10MB", maxBuffer: audio.DefaultMaxAudioBufferSize, prefill: true},
+		{name: "AtCap_1MB", maxBuffer: 1024 * 1024, prefill: true},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			quietLogger(b)
+			ctx := context.Background()
+			chunk := make([]byte, benchChunkBytes)
+			d := newSpeakingDetector(b, tc.maxBuffer)
+
+			if tc.prefill {
+				// Fill past the cap so the trim branch is active from the first
+				// timed iteration rather than partway through.
+				for filled := 0; filled <= tc.maxBuffer; filled += benchChunkBytes {
+					if _, err := d.ProcessAudio(ctx, chunk); err != nil {
+						b.Fatalf("prefill ProcessAudio: %v", err)
+					}
+				}
+			}
+
+			b.ReportAllocs()
+			b.SetBytes(benchChunkBytes)
+			b.ResetTimer()
+
+			for range b.N {
+				if _, err := d.ProcessAudio(ctx, chunk); err != nil {
+					b.Fatalf("ProcessAudio: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/runtime/pipeline/stage/audioturn_memory_bench_test.go
+++ b/runtime/pipeline/stage/audioturn_memory_bench_test.go
@@ -1,0 +1,125 @@
+package stage_test
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// Audio geometry: 16 kHz mono PCM16 in 100 ms chunks, so one chunk is 3200 bytes
+// and a minute of audio is 600 chunks (~1.9 MB).
+const (
+	memBenchSampleRate   = 16000
+	memBenchChunkSamples = memBenchSampleRate / 10
+	memBenchChunkBytes   = memBenchChunkSamples * 2
+	memBenchChunksPerMin = 600
+)
+
+// heapInUse returns current heap bytes after forcing collection twice.
+//
+// A single GC can leave the previous cycle's garbage uncollected, which on a
+// benchmark feeding hundreds of MB is enough to swamp the signal.
+func heapInUse() uint64 {
+	runtime.GC()
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapInuse
+}
+
+// feedSilenceRetained feeds minutes of pure silence into an AudioTurnStage and
+// reports the heap still held afterwards, with the stage alive and mid-turn.
+//
+// Feeding is instant. Turn boundaries are timed by accumulated sample count
+// rather than wall-clock, so an hour of audio costs milliseconds to push through
+// and retention is a deterministic function of the code — no soak test needed.
+//
+// The same chunk slice is reused for every element. The stage copies bytes into
+// its own buffer (append(state.audioBuffer, elem.Audio.Samples...)), so what the
+// measurement attributes to the heap is the stage's retention, not the feed's.
+func feedSilenceRetained(b *testing.B, minutes int) uint64 {
+	b.Helper()
+
+	s, err := stage.NewAudioTurnStage(stage.DefaultAudioTurnConfig())
+	if err != nil {
+		b.Fatalf("NewAudioTurnStage: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	input := make(chan stage.StreamElement)
+	output := make(chan stage.StreamElement, 1024)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = s.Process(ctx, input, output)
+	}()
+
+	// Drain output so a full channel can never stall the feed. Pure silence
+	// should emit nothing, but the drain keeps the benchmark honest if it does.
+	go func() {
+		for range output { //nolint:revive // draining
+		}
+	}()
+
+	chunk := make([]byte, memBenchChunkBytes)
+	before := heapInUse()
+
+	for range minutes * memBenchChunksPerMin {
+		input <- makeAudioElement(chunk, memBenchSampleRate)
+	}
+
+	// Measure while the stage is still holding the turn. Closing input first
+	// would flush the buffer and hide exactly what we came to measure.
+	after := heapInUse()
+
+	close(input)
+	<-done
+
+	if after < before {
+		return 0
+	}
+	return after - before
+}
+
+// BenchmarkAudioTurnStageRetention reports heap retained by a stage fed nothing
+// but silence, across increasing session lengths.
+//
+// AudioTurnStage buffers every chunk unconditionally, and shouldCompleteTurn
+// returns early while speechDetected is false — so the MaxTurnDuration bound
+// never applies on this path. If retention is bounded, the reported figure stays
+// flat as the minutes increase. If it scales with session length, the buffer is
+// unbounded and a quiet caller grows the heap for as long as they stay quiet.
+//
+// Reports, does not assert. The point is to produce numbers that decide which
+// sites are worth fixing, not to encode either the current behavior or a target
+// as a contract.
+func BenchmarkAudioTurnStageRetention(b *testing.B) {
+	for _, minutes := range []int{1, 5, 30, 60} {
+		b.Run(durationLabel(minutes), func(b *testing.B) {
+			var retained uint64
+			for range b.N {
+				retained = feedSilenceRetained(b, minutes)
+			}
+			b.ReportMetric(float64(retained), "retained_B")
+			b.ReportMetric(float64(retained)/float64(minutes), "retained_B/min")
+		})
+	}
+}
+
+func durationLabel(minutes int) string {
+	switch minutes {
+	case 1:
+		return "1min"
+	case 5:
+		return "5min"
+	case 30:
+		return "30min"
+	default:
+		return "60min"
+	}
+}

--- a/runtime/pipeline/stage/audioturn_trim_test.go
+++ b/runtime/pipeline/stage/audioturn_trim_test.go
@@ -127,8 +127,9 @@ func TestAudioTurnStage_PreservesPreRollBeforeSpeechOnset(t *testing.T) {
 // The stage buffers unconditionally so that a VAD misread mis-cuts a turn rather
 // than deleting audio — that is why a SimpleVAD misclassification was a
 // segmentation bug and not silent data loss. Trimming must not weaken it: when
-// VAD never reports speech at all, the buffer has to be forwarded whole, because
-// the audio may well contain speech the VAD failed to see.
+// VAD never reports speech at all, the buffer is forwarded whole, up to the
+// retention cap in TestAudioTurnStage_CapsBufferedSilenceWhenNoSpeechDetected,
+// because the audio may well contain speech the VAD failed to see.
 func TestAudioTurnStage_ForwardsUntrimmedWhenNoSpeechDetected(t *testing.T) {
 	const chunkSamples = 1600 // 100 ms @ 16 kHz
 	const chunks = 20         // 2.0 s


### PR DESCRIPTION
Stacked on #1617 (which is stacked on #1616). Measurement only — no behavior change.

## Why

Go's efficiency against Python and Node is a stated selling point, but nothing measured the audio path.

**The existing voice benchmark only appears to cover it.** `frameworks/promptkit/round2`'s `go.mod` requires just `gorilla/websocket`; the server is hand-rolled, frames are zero-filled `make([]byte, 640)`, and it runs no VAD, no resampler, no turn stage. It is also not on the `perf-regression` CI gate, which runs round1 only. The voice path is currently unmeasured.

## What this adds

In-process benchmarks over the **real** stages, measuring two properties that fail differently and hide each other:

**Retention** — heap held per session length. Cheap and deterministic because #1616 made turn segmentation sample-count based rather than wall-clock: an hour of audio feeds through in **108 ms**, so retention is a function of the code, not of elapsed time. No soak harness required.

**Churn** — allocations and time per chunk. Invisible to retention measurement: `SilenceDetector` *is* bounded at 10 MB, yet enforces that bound by memmoving the whole buffer once per chunk. Retention looks healthy while throughput burns.

## Measured (Apple M4 Pro)

### `AudioTurnStage` retention, fed pure silence

| Session | Retained | Per minute |
|---|---|---|
| 1 min | 2.35 MB | 2.35 MB/min |
| 5 min | 11.3 MB | 2.27 MB/min |
| 30 min | 67.8 MB | 2.26 MB/min |
| 60 min | 132.5 MB | 2.21 MB/min |

Flat per-minute across a 60× range — linear growth, no ceiling. One quiet participant costs ~2.2 MB/min indefinitely.

### `SilenceDetector.ProcessAudio`, per 100 ms chunk

| Case | ns/op | Throughput | vs baseline |
|---|---|---|---|
| BelowCap | 1,249 | 2,561 MB/s | — |
| AtCap, 1 MB | 14,586 | 219 MB/s | 11.7× slower |
| AtCap, 10 MB (default) | 151,027 | 21 MB/s | **121× slower** |

The most severe finding. Throughput collapses two orders of magnitude once the buffer fills, scaling linearly with `MaxBufferSize` — the O(buffer) per-chunk signature of `copy(d.audioBuffer, d.audioBuffer[excess:])`. At 100 chunks/sec/track that is ~1.5% of a core per track spent purely on memmove. Measured with logging discarded, so production is worse — there is also a `slog.Warn` per chunk in that branch.

### `ResamplePCM16`, per chunk

1 alloc/chunk at ~3,200 B — roughly 320 KB/s of garbage per track. Real GC pressure at scale, no cliff.

## Design decisions worth reviewing

**These report, they do not assert.** Five sites are known-unbounded; asserting correct bounds would block the branch, while asserting current behavior would enshrine a bug as the contract. Gates come later against targets chosen deliberately.

**They cannot flake the PR gate** — `testing.B` only runs under `-bench`. Never run with `-race`, which perturbs allocation.

**Generators stay in `_test.go`** rather than `runtime/testutil`, since new exported API there trips the Reference Drift gate.

## Honest gaps

- **`DuplexProviderStage.accumulatedMedia` was in scope and is NOT covered.** It needs a live duplex session to exercise. Its unboundedness remains a static reading of the reset condition at `stages_duplex_provider_session.go:1084` — treat as unverified.
- The recommended fix order **inverts the original assumption**: this investigation started from `AudioTurnStage`, which measurement ranks second behind the memmove.

Full write-up and baselines in `docs/local-backlog/AUDIO_MEMORY_MEASUREMENT.md` (gitignored, local only). Reproduce with `make bench-audio-memory`.
