### PR TITLE
perf(audio): amortize SilenceDetector buffer trim instead of memmoving per chunk

### DIFF
--- a/runtime/audio/silence.go
+++ b/runtime/audio/silence.go
@@ -27,10 +27,60 @@ type SilenceDetector struct {
 	inSilence    bool
 	userSpeaking bool
 	audioBuffer  []byte
+	// bufStart is the offset in audioBuffer at which live audio begins.
+	// Trimming advances this instead of moving bytes; the dead prefix is
+	// reclaimed by an occasional compaction. See trimToCapLocked.
+	bufStart     int
 	transcript   string
 	turnCallback TurnCallback
 	lastVADState VADState
 	hadSpeech    bool // Track if we've had any speech this turn
+}
+
+// liveAudioLocked returns the audio currently retained, excluding any dead
+// prefix left behind by trimming. Must be called with mu held.
+func (d *SilenceDetector) liveAudioLocked() []byte {
+	return d.audioBuffer[d.bufStart:]
+}
+
+// trimToCapLocked enforces MaxBufferSize, keeping the most recent audio.
+// Must be called with mu held.
+//
+// Trimming advances bufStart rather than shifting the buffer down. Shifting per
+// chunk costs a full memmove of the retained audio on every call once the cap is
+// reached — with the 10MB default at ~100 chunks/sec that measured 121x slower
+// than the uncapped path (2561 MB/s down to 21 MB/s), scaling linearly with
+// MaxBufferSize.
+//
+// The dead prefix is reclaimed only once it grows past the cap, so a compaction
+// copies at most MaxBufferSize bytes per MaxBufferSize bytes appended: O(1)
+// amortized per byte instead of O(buffer) per chunk. The cost is up to 2x
+// MaxBufferSize of allocated slice while a dead prefix is outstanding.
+func (d *SilenceDetector) trimToCapLocked() {
+	if d.MaxBufferSize <= 0 {
+		return
+	}
+
+	live := len(d.audioBuffer) - d.bufStart
+	if live <= d.MaxBufferSize {
+		return
+	}
+
+	// Drop the oldest audio by advancing the window, not by moving bytes.
+	d.bufStart += live - d.MaxBufferSize
+
+	// Reclaim once the dead prefix is worth a copy. Logging here rather than on
+	// every trim keeps this off the per-chunk path: at 100 chunks/sec a
+	// per-chunk warning is a sustained 100 lines/sec of log spam.
+	if d.bufStart >= d.MaxBufferSize {
+		copy(d.audioBuffer, d.liveAudioLocked())
+		d.audioBuffer = d.audioBuffer[:d.MaxBufferSize]
+		d.bufStart = 0
+		slog.Warn("audio buffer at max size, dropped oldest data",
+			"max_buffer_size", d.MaxBufferSize,
+			"dropped_bytes", d.MaxBufferSize,
+		)
+	}
 }
 
 // SilenceDetectorOption configures a SilenceDetector.
@@ -73,17 +123,7 @@ func (d *SilenceDetector) ProcessAudio(ctx context.Context, audio []byte) (bool,
 	// Accumulate audio if we're tracking a turn
 	if d.userSpeaking || d.hadSpeech {
 		d.audioBuffer = append(d.audioBuffer, audio...)
-
-		// Cap the buffer to MaxBufferSize, keeping the most recent data
-		if d.MaxBufferSize > 0 && len(d.audioBuffer) > d.MaxBufferSize {
-			excess := len(d.audioBuffer) - d.MaxBufferSize
-			copy(d.audioBuffer, d.audioBuffer[excess:])
-			d.audioBuffer = d.audioBuffer[:d.MaxBufferSize]
-			slog.Warn("audio buffer exceeded max size, trimmed oldest data",
-				"excess_bytes", excess,
-				"max_buffer_size", d.MaxBufferSize,
-			)
-		}
+		d.trimToCapLocked()
 	}
 	d.mu.Unlock()
 
@@ -140,10 +180,10 @@ func (d *SilenceDetector) ProcessVADState(ctx context.Context, state VADState) (
 // triggerTurnComplete fires the callback and resets state.
 // Must be called with mu held.
 func (d *SilenceDetector) triggerTurnComplete() {
-	if d.turnCallback != nil && len(d.audioBuffer) > 0 {
+	if live := d.liveAudioLocked(); d.turnCallback != nil && len(live) > 0 {
 		// Copy buffer before callback
-		audio := make([]byte, len(d.audioBuffer))
-		copy(audio, d.audioBuffer)
+		audio := make([]byte, len(live))
+		copy(audio, live)
 		transcript := d.transcript
 
 		// Fire callback (without lock to prevent deadlock)
@@ -152,6 +192,7 @@ func (d *SilenceDetector) triggerTurnComplete() {
 
 	// Reset for next turn
 	d.audioBuffer = nil
+	d.bufStart = 0
 	d.transcript = ""
 	d.hadSpeech = false
 	d.userSpeaking = false
@@ -173,6 +214,7 @@ func (d *SilenceDetector) Reset() {
 	d.inSilence = true
 	d.userSpeaking = false
 	d.audioBuffer = nil
+	d.bufStart = 0
 	d.transcript = ""
 	d.lastVADState = VADStateQuiet
 	d.hadSpeech = false
@@ -190,11 +232,12 @@ func (d *SilenceDetector) GetAccumulatedAudio() []byte {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	if len(d.audioBuffer) == 0 {
+	live := d.liveAudioLocked()
+	if len(live) == 0 {
 		return nil
 	}
-	result := make([]byte, len(d.audioBuffer))
-	copy(result, d.audioBuffer)
+	result := make([]byte, len(live))
+	copy(result, live)
 	return result
 }
 

--- a/runtime/audio/silence_trim_test.go
+++ b/runtime/audio/silence_trim_test.go
@@ -1,0 +1,163 @@
+package audio_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// countingHandler counts emitted records at or above warn level.
+type countingHandler struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level >= slog.LevelWarn {
+		h.mu.Lock()
+		h.n++
+		h.mu.Unlock()
+	}
+	return nil
+}
+
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *countingHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.n
+}
+
+// captureWarnings installs a counting logger for the duration of the test.
+func captureWarnings(t *testing.T) *countingHandler {
+	t.Helper()
+	h := &countingHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return h
+}
+
+// speakingDetector returns a detector already inside a speaking turn, which is
+// the only state in which ProcessAudio accumulates.
+func speakingDetector(t *testing.T, maxBuffer int) *audio.SilenceDetector {
+	t.Helper()
+	d := audio.NewSilenceDetector(time.Second, audio.WithMaxAudioBufferSize(maxBuffer))
+	if _, err := d.ProcessVADState(context.Background(), audio.VADStateSpeaking); err != nil {
+		t.Fatalf("ProcessVADState: %v", err)
+	}
+	return d
+}
+
+const trimChunkBytes = 3200 // 100 ms @ 16 kHz mono PCM16
+
+// TestSilenceDetectorDoesNotWarnOncePerChunkAtCap covers log spam on the hot path.
+//
+// The buffer cap is enforced inside ProcessAudio, which runs once per audio
+// chunk — roughly 100 times a second per track. Emitting a warning from that
+// branch means a caller who simply keeps talking past the cap produces a
+// sustained 100 warnings/sec, drowning the log and costing formatting work on
+// the audio path.
+//
+// Trimming is routine backpressure, not an anomaly worth a per-chunk warning.
+// It should be reported at most once per compaction.
+func TestSilenceDetectorDoesNotWarnOncePerChunkAtCap(t *testing.T) {
+	warnings := captureWarnings(t)
+	ctx := context.Background()
+
+	maxBuffer := 10 * trimChunkBytes
+	d := speakingDetector(t, maxBuffer)
+	chunk := make([]byte, trimChunkBytes)
+
+	// Fill to the cap, then push 100 more chunks while sitting on it.
+	const overflowChunks = 100
+	for range (maxBuffer / trimChunkBytes) + overflowChunks {
+		if _, err := d.ProcessAudio(ctx, chunk); err != nil {
+			t.Fatalf("ProcessAudio: %v", err)
+		}
+	}
+
+	// One warning per compaction is fine; one per chunk is not. Compaction can
+	// only happen a handful of times across this many chunks.
+	const tolerated = overflowChunks / 10
+	if got := warnings.count(); got > tolerated {
+		t.Errorf("emitted %d warnings across %d chunks past the cap, want <=%d; "+
+			"the trim branch is warning per chunk on the audio hot path",
+			got, overflowChunks, tolerated)
+	}
+}
+
+// TestSilenceDetectorCapBoundsAccumulatedAudio pins the size contract that the
+// trim exists to enforce. A change to how trimming is scheduled must not let the
+// exposed buffer exceed the cap.
+func TestSilenceDetectorCapBoundsAccumulatedAudio(t *testing.T) {
+	captureWarnings(t)
+	ctx := context.Background()
+
+	maxBuffer := 10 * trimChunkBytes
+	d := speakingDetector(t, maxBuffer)
+	chunk := make([]byte, trimChunkBytes)
+
+	for range 50 {
+		if _, err := d.ProcessAudio(ctx, chunk); err != nil {
+			t.Fatalf("ProcessAudio: %v", err)
+		}
+		if got := len(d.GetAccumulatedAudio()); got > maxBuffer {
+			t.Fatalf("accumulated audio is %d bytes, exceeds cap %d", got, maxBuffer)
+		}
+	}
+}
+
+// TestSilenceDetectorRetainsMostRecentAudio pins WHICH audio survives trimming.
+//
+// The cap keeps the newest audio and drops the oldest — a caller who overruns
+// the buffer must still get the end of what they said, not the beginning. Any
+// change to the trim mechanism has to preserve both the contents and their
+// order, which a size-only assertion would not catch.
+func TestSilenceDetectorRetainsMostRecentAudio(t *testing.T) {
+	captureWarnings(t)
+	ctx := context.Background()
+
+	const chunkSize = 100
+	const capChunks = 8
+	maxBuffer := capChunks * chunkSize
+	d := speakingDetector(t, maxBuffer)
+
+	// Feed chunks whose every byte is the chunk's own index, so the retained
+	// window is self-identifying.
+	const totalChunks = 40
+	for i := range totalChunks {
+		chunk := make([]byte, chunkSize)
+		for j := range chunk {
+			chunk[j] = byte(i)
+		}
+		if _, err := d.ProcessAudio(ctx, chunk); err != nil {
+			t.Fatalf("ProcessAudio: %v", err)
+		}
+	}
+
+	got := d.GetAccumulatedAudio()
+	if len(got) != maxBuffer {
+		t.Fatalf("retained %d bytes, want exactly the cap %d", len(got), maxBuffer)
+	}
+
+	// The final capChunks chunks are indices totalChunks-capChunks .. totalChunks-1.
+	for i := range capChunks {
+		wantByte := byte(totalChunks - capChunks + i)
+		for j := range chunkSize {
+			if got[i*chunkSize+j] != wantByte {
+				t.Fatalf("byte %d of retained buffer is %d, want %d; "+
+					"trimming lost or reordered the most recent audio",
+					i*chunkSize+j, got[i*chunkSize+j], wantByte)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #1618. First of the runtime memory fixes, in the order the benchmarks ranked them.

## Problem

`SilenceDetector` capped its audio buffer by shifting the whole buffer down by one chunk on every `ProcessAudio` call once full:

```go
copy(d.audioBuffer, d.audioBuffer[excess:])
```

`ProcessAudio` runs per audio chunk — ~100×/sec/track — so a caller who keeps talking past the cap pays a full memmove of the retained audio on every chunk. The cost scales linearly with `MaxBufferSize`, so the 10 MB default is the worst case.

Measured in #1618: **121× slower** than the uncapped path, 2,561 MB/s down to 21 MB/s. That is ~1.5% of a core per track spent purely on memmove, ~1.5 cores at 100 concurrent tracks.

## Change

Track the live window with a `bufStart` offset. Trimming advances the offset rather than moving bytes; the dead prefix is reclaimed only once it exceeds the cap, so a compaction copies at most `MaxBufferSize` bytes per `MaxBufferSize` appended — **O(1) amortized per byte** instead of O(buffer) per chunk.

## Measured after (M4 Pro, 100 ms chunks)

| Case | Before | After | Change |
|---|---|---|---|
| At cap, 10 MB | 151,027 ns/op (21 MB/s) | 1,093 ns/op (2,928 MB/s) | **138× faster** |
| At cap, 1 MB | 14,586 ns/op (219 MB/s) | 296 ns/op (10,802 MB/s) | **49× faster** |
| Below cap | 1,249 ns/op | ~1,300 ns/op | unchanged |

The cliff is gone — at-cap is now *faster* than below-cap, since the buffer stops reallocating once it stabilizes.

On "below cap": a single run showed 2,779 ns/op, which looked like a regression. Repeated runs gave 1,130–1,817 ns/op, spanning the original 1,249. That path is dominated by spiky `append` reallocation; the apparent regression was noise, not a real change.

## Trade-off

Peak allocation. The backing array settles at ~2.25× `MaxBufferSize` while a dead prefix is outstanding, rather than 1×. At the 10 MB default that is ~22 MB per detector in steady state. Deliberate: trading bounded extra memory for removing a two-order-of-magnitude throughput cliff.

## Tests

- `TestSilenceDetectorDoesNotWarnOncePerChunkAtCap` — **RED at 100 warnings/100 chunks**, green after. The old code logged from the per-chunk trim branch, a sustained ~100 lines/sec while a caller overran the buffer.
- `TestSilenceDetectorCapBoundsAccumulatedAudio` and `TestSilenceDetectorRetainsMostRecentAudio` — contract guards. Both passed before and after **by design**: this is a perf refactor and the observable contract must not change. The second pins *which* bytes survive (newest, in order), which a size-only assertion would miss.

Logging severity stays at `Warn`, only its frequency changes (now per compaction, ~once per 5 min of speech at the default cap). I had initially dropped it to `Debug`; review correctly flagged that this would hide buffer overrun at default log levels — the problem was frequency, not severity.

## Review

Adversarially reviewed for correctness, with an empirical simulation of 200,000 compaction cycles confirming the backing array stabilizes at ~2.25× rather than growing. Also verified: both escape points (`triggerTurnComplete`'s goroutine, `GetAccumulatedAudio`) deep-copy under the lock; boundary cases at `live == MaxBufferSize` and single-chunk-larger-than-cap; all three `audioBuffer` reset sites also reset `bufStart`; all `bufStart` access under the mutex. `-race` clean.

One low-severity residual, noted not fixed: a single chunk far larger than `MaxBufferSize` pins the array capacity at that chunk's size until the next turn boundary nils the slice. Bounded by the largest chunk ever seen, and arguably pre-existing.

`runtime/audio` coverage 95.3% on the changed file; `pipeline/...` and `stt/...` also pass.
