### PR TITLE
fix(pipeline): bound AudioTurnStage retention on the no-speech path

### DIFF
--- a/runtime/pipeline/stage/audioturn_retention_test.go
+++ b/runtime/pipeline/stage/audioturn_retention_test.go
@@ -1,0 +1,202 @@
+package stage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// TestAudioTurnStage_BoundsRetainedSilenceWhenNoSpeechDetected covers unbounded
+// memory growth on the no-speech path.
+//
+// The stage buffers every chunk, and shouldCompleteTurn returns early while
+// speechDetected is false, so the MaxTurnDuration bound never applies. A
+// participant who stays quiet — listening while the other party talks, a hot mic
+// below the VAD threshold, a VAD misconfigured for the sample rate — grows the
+// buffer for as long as they stay quiet. Benchmarked at ~2.2 MB/min with a flat
+// per-minute rate across a 60x range: linear, no ceiling.
+//
+// Retention must be bounded by MaxTurnDuration, which is already the stage's
+// declared maximum extent for any turn.
+func TestAudioTurnStage_BoundsRetainedSilenceWhenNoSpeechDetected(t *testing.T) {
+	cfg := stage.DefaultAudioTurnConfig() // MaxTurnDuration 30s, 16 kHz
+	const chunkSamples = 1600             // 100 ms
+	const minutes = 5
+
+	turns := runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		for range minutes * 600 {
+			in <- makeAudioElement(vadSilencePCM(chunkSamples), 16000)
+		}
+	})
+
+	if len(turns) == 0 {
+		t.Fatalf("expected buffered audio to be forwarded at EndOfStream, got no turns")
+	}
+
+	// Every emitted turn must respect the bound, not just the first.
+	for i, turn := range turns {
+		got := turnDuration(turn)
+		if got > cfg.MaxTurnDuration {
+			t.Errorf("turn %d retained %v of silence, exceeds MaxTurnDuration %v; "+
+				"buffering on the no-speech path is unbounded (fed %d minutes)",
+				i, got, cfg.MaxTurnDuration, minutes)
+		}
+	}
+}
+
+// TestAudioTurnStage_BoundsRetentionForSubSecondMaxTurnDuration covers the
+// retention bound silently not applying at all.
+//
+// Computing the window from MaxTurnDuration.Seconds() as an int truncates: any
+// duration below one second yields zero bytes, which reads as "no bound
+// configured" and disables the cap entirely. Sub-second values are reachable —
+// existing tests use 100ms and the SDK exposes the field — so the leak would
+// still be present wherever it is set that low.
+func TestAudioTurnStage_BoundsRetentionForSubSecondMaxTurnDuration(t *testing.T) {
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.MaxTurnDuration = 500 * time.Millisecond
+
+	const chunkSamples = 1600 // 100 ms
+	const fedSeconds = 60
+
+	turns := runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		for range fedSeconds * 10 {
+			in <- makeAudioElement(vadSilencePCM(chunkSamples), 16000)
+		}
+	})
+
+	if len(turns) == 0 {
+		t.Fatalf("expected a turn at EndOfStream, got none")
+	}
+
+	for i, turn := range turns {
+		if got := turnDuration(turn); got > cfg.MaxTurnDuration {
+			t.Errorf("turn %d retained %v against a %v bound (fed %ds); "+
+				"sub-second MaxTurnDuration truncates to zero and disables the bound",
+				i, got, cfg.MaxTurnDuration, fedSeconds)
+		}
+	}
+}
+
+// TestAudioTurnStage_RetentionBoundKeepsFractionalSeconds guards the window
+// against losing the fractional part of MaxTurnDuration.
+//
+// Truncating 1.5s to 1.0s bounds tighter than configured, discarding a third
+// more audio than the contract promises. Feeding well past the bound and
+// measuring what survives detects the narrower window.
+func TestAudioTurnStage_RetentionBoundKeepsFractionalSeconds(t *testing.T) {
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.MaxTurnDuration = 1500 * time.Millisecond
+
+	const chunkSamples = 1600 // 100 ms
+
+	turns := runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		for range 300 { // 30s, far past the bound
+			in <- makeAudioElement(vadSilencePCM(chunkSamples), 16000)
+		}
+	})
+
+	if len(turns) == 0 {
+		t.Fatalf("expected a turn at EndOfStream, got none")
+	}
+
+	got := turnDuration(turns[len(turns)-1])
+	// Allow a chunk of slack: the window is enforced per chunk, so the retained
+	// span lands within one chunk of the bound rather than exactly on it.
+	const slack = 100 * time.Millisecond
+	if got < cfg.MaxTurnDuration-slack {
+		t.Errorf("retained %v against a %v bound; the fractional second was "+
+			"truncated away, bounding tighter than configured", got, cfg.MaxTurnDuration)
+	}
+	if got > cfg.MaxTurnDuration+slack {
+		t.Errorf("retained %v, exceeds the %v bound", got, cfg.MaxTurnDuration)
+	}
+}
+
+// TestAudioTurnStage_DoesNotSplitUtteranceAfterLongSilence covers an utterance
+// being cut in two when it follows a long pause.
+//
+// turnSamples accumulates during silence, but shouldCompleteTurn measures it
+// against MaxTurnDuration. After a quiet stretch longer than MaxTurnDuration the
+// budget is already spent before anyone speaks, so the turn force-completes the
+// moment MinSpeechDuration is satisfied — chopping the utterance into a ~1s
+// fragment plus the remainder. That is two STT calls and a transcript broken
+// mid-word.
+//
+// Silence that the retention bound has already discarded must not count against
+// the turn's duration budget.
+func TestAudioTurnStage_DoesNotSplitUtteranceAfterLongSilence(t *testing.T) {
+	cfg := stage.DefaultAudioTurnConfig() // MaxTurnDuration 30s
+	const chunkSamples = 1600             // 100 ms
+
+	turns := runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		// A long pause, well past MaxTurnDuration.
+		for range 400 { // 40s
+			in <- makeAudioElement(vadSilencePCM(chunkSamples), 16000)
+		}
+		// Then one continuous utterance, with no internal pause to split on.
+		for range 50 { // 5s
+			in <- makeAudioElement(vadSpeechPCM(chunkSamples), 16000)
+		}
+	})
+
+	if len(turns) == 0 {
+		t.Fatalf("expected a turn, got none")
+	}
+	if len(turns) > 1 {
+		durations := make([]time.Duration, len(turns))
+		for i, turn := range turns {
+			durations[i] = turnDuration(turn)
+		}
+		t.Fatalf("continuous 5s utterance after a 40s pause split into %d turns (%v); "+
+			"silence consumed the turn's duration budget before speech began",
+			len(turns), durations)
+	}
+}
+
+// TestAudioTurnStage_RetainsNewestSilenceWithinBound pins WHICH audio survives
+// the retention bound.
+//
+// Dropping the bound's worth from the wrong end would keep the oldest audio and
+// discard whatever the participant said just before the stream ended — the exact
+// audio most likely to matter. A duration-only assertion cannot tell the two
+// apart.
+func TestAudioTurnStage_RetainsNewestSilenceWithinBound(t *testing.T) {
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.MaxTurnDuration = time.Second // keep the test small and the window obvious
+
+	const chunkSamples = 1600 // 100 ms, so the bound holds 10 chunks
+	const totalChunks = 100
+
+	turns := runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		for i := range totalChunks {
+			// Silence, but tagged: every sample carries the chunk index, so the
+			// retained window identifies itself. Values stay small enough to
+			// remain below the VAD threshold.
+			chunk := make([]byte, chunkSamples*2)
+			for j := range chunk {
+				chunk[j] = byte(i % 8)
+			}
+			in <- makeAudioElement(chunk, 16000)
+		}
+	})
+
+	if len(turns) == 0 {
+		t.Fatalf("expected a turn at EndOfStream, got none")
+	}
+
+	last := turns[len(turns)-1]
+	if len(last) == 0 {
+		t.Fatalf("emitted turn is empty")
+	}
+
+	// The final byte must come from the last chunk fed. If the bound dropped
+	// from the wrong end, the tail would carry an older index.
+	wantTail := byte((totalChunks - 1) % 8)
+	if got := last[len(last)-1]; got != wantTail {
+		t.Errorf("retained window ends with chunk tag %d, want %d; "+
+			"the retention bound is discarding the newest audio instead of the oldest",
+			got, wantTail)
+	}
+}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -154,6 +154,15 @@ type audioTurnState struct {
 	// first reported speech, or -1 while no speech has been detected. Leading
 	// silence before this point (less a pre-roll) is trimmed at emit time.
 	speechStartOffset int
+	// bufStart is the offset at which live audio begins. Bounding retention
+	// advances this rather than moving bytes; see capSilenceRetention.
+	bufStart int
+}
+
+// liveAudio returns the audio currently retained, excluding any dead prefix
+// dropped by the retention bound.
+func (s *audioTurnState) liveAudio() []byte {
+	return s.audioBuffer[s.bufStart:]
 }
 
 // newAudioTurnState returns turn state with no speech onset recorded yet.
@@ -322,15 +331,16 @@ func (s *AudioTurnStage) emitRemainingAudio(
 	state *audioTurnState,
 	output chan<- StreamElement,
 ) error {
-	if len(state.audioBuffer) == 0 {
+	live := state.liveAudio()
+	if len(live) == 0 {
 		return nil
 	}
 	// Emit buffered audio if speech was detected OR if we have significant audio data
 	// For pre-recorded files, VAD may not detect speech, but we still want to forward the audio
-	if state.speechDetected || len(state.audioBuffer) > defaultMinAudioBytes {
+	if state.speechDetected || len(live) > defaultMinAudioBytes {
 		logger.Debug("AudioTurnStage: emitting remaining audio",
 			"speechDetected", state.speechDetected,
-			"bufferSize", len(state.audioBuffer))
+			"bufferSize", len(live))
 		return s.emitTurnAudio(ctx, state, output)
 	}
 	return nil
@@ -354,6 +364,8 @@ func (s *AudioTurnStage) processAudio(
 	// Account for this chunk in AUDIO time (sample count), never wall-clock.
 	n := len(elem.Audio.Samples) / bytesPerSample16Bit
 	state.turnSamples += n
+
+	s.capSilenceRetention(state)
 
 	// Run VAD analysis for turn detection
 	_, err := s.vad.Analyze(ctx, elem.Audio.Samples)
@@ -439,7 +451,7 @@ func (s *AudioTurnStage) emitTurnAudio(
 	state *audioTurnState,
 	output chan<- StreamElement,
 ) error {
-	if len(state.audioBuffer) == 0 {
+	if len(state.liveAudio()) == 0 {
 		return nil
 	}
 
@@ -447,7 +459,7 @@ func (s *AudioTurnStage) emitTurnAudio(
 
 	logger.Debug("AudioTurnStage: emitting turn audio",
 		"bytes", len(samples),
-		"trimmed_bytes", len(state.audioBuffer)-len(samples),
+		"trimmed_bytes", len(state.liveAudio())-len(samples),
 		"duration_ms", len(samples)*msPerSecond/(s.config.SampleRate*bytesPerSample16Bit))
 
 	elem := StreamElement{
@@ -468,6 +480,75 @@ func (s *AudioTurnStage) emitTurnAudio(
 	}
 }
 
+// capSilenceRetention bounds audio retained before any speech is detected.
+//
+// shouldCompleteTurn returns early while speechDetected is false, so the
+// MaxTurnDuration bound never applies on that path and the buffer grows for as
+// long as a participant stays quiet — measured at ~2.2 MB/min with a flat
+// per-minute rate across a 60x range, i.e. linear with no ceiling. A listener on
+// a long call, a hot mic below the VAD threshold, or a VAD misconfigured for the
+// sample rate all hit this.
+//
+// The bound is MaxTurnDuration because that is already the stage's declared
+// maximum extent for any turn: retaining more than one turn's worth of audio
+// that no turn will ever contain cannot help. Once speech is detected this stops
+// applying and the normal turn machinery takes over.
+//
+// Like SilenceDetector, this advances an offset rather than moving bytes, so
+// bounding costs O(1) amortized per byte instead of a memmove per chunk.
+//
+// Ordering matters: this must run BEFORE the VAD analysis that sets
+// speechStartOffset. That offset is an absolute index into audioBuffer, and a
+// compaction here rewrites those indices. Running before means the offset is
+// always computed against the post-compaction buffer, and this function returns
+// early once speech is detected, so it can never invalidate one already set.
+//
+// This narrows the degrade-open guarantee: when VAD never fires, the stage
+// forwards the most recent MaxTurnDuration rather than everything. It keeps the
+// newest audio, which is the audio a late-firing or broken VAD is most likely to
+// have been wrong about.
+func (s *AudioTurnStage) capSilenceRetention(state *audioTurnState) {
+	if state.speechDetected {
+		return
+	}
+
+	// Compute in nanosecond space, not float seconds. int(Duration.Seconds())
+	// truncates: any MaxTurnDuration below 1s would yield zero and read as "no
+	// bound", silently disabling the cap, and 1.5s would bound at 1s.
+	maxSamples := int(s.config.MaxTurnDuration * time.Duration(s.config.SampleRate) / time.Second)
+	maxBytes := maxSamples * bytesPerSample16Bit
+	if maxBytes <= 0 {
+		return
+	}
+
+	live := len(state.audioBuffer) - state.bufStart
+	if live <= maxBytes {
+		return
+	}
+
+	state.bufStart += live - maxBytes
+
+	// Silence before anyone speaks must not consume the turn's duration budget.
+	// shouldCompleteTurn measures turnSamples against MaxTurnDuration, so a pause
+	// longer than the bound would spend the entire budget before the utterance
+	// began and force-complete the turn the moment MinSpeechDuration was met,
+	// splitting it into a short fragment plus the remainder.
+	//
+	// Zero, not maxSamples: the retained window is exactly the bound, so carrying
+	// it forward would still read as "budget exhausted". While no speech has been
+	// detected the turn has not started, so it has spent nothing. Once speech is
+	// detected this function returns early and the budget accrues normally from
+	// there.
+	state.turnSamples = 0
+
+	// Reclaim the dead prefix only once it is worth a copy.
+	if state.bufStart >= maxBytes {
+		copy(state.audioBuffer, state.liveAudio())
+		state.audioBuffer = state.audioBuffer[:maxBytes]
+		state.bufStart = 0
+	}
+}
+
 // trimLeadingSilence drops the dead air preceding speech onset, keeping a
 // pre-roll margin. STT is billed per second and Whisper is prone to emitting
 // hallucinated text over long near-silent input, so shipping a caller's several
@@ -479,21 +560,26 @@ func (s *AudioTurnStage) emitTurnAudio(
 // instead of deleting audio, and trimming must not turn a misread into silent
 // data loss.
 func (s *AudioTurnStage) trimLeadingSilence(state *audioTurnState) []byte {
+	live := state.liveAudio()
 	if !state.speechDetected || state.speechStartOffset <= 0 {
-		return state.audioBuffer
+		return live
 	}
 
 	preRoll := int(defaultAudioTurnPreRoll.Seconds() * float64(s.config.SampleRate) * bytesPerSample16Bit)
 	start := state.speechStartOffset - preRoll
+	// speechStartOffset indexes audioBuffer, so rebase it onto the live window.
+	// The retention bound may already have dropped audio ahead of the onset.
+	start -= state.bufStart
 	if start <= 0 {
-		return state.audioBuffer
+		return live
 	}
-	return state.audioBuffer[start:]
+	return live[start:]
 }
 
 // resetState resets the turn state for a new turn.
 func (s *AudioTurnStage) resetState(state *audioTurnState) {
 	state.audioBuffer = nil
+	state.bufStart = 0
 	state.speechDetected = false
 	state.speechSamples = 0
 	state.silenceSamples = 0


### PR DESCRIPTION
Stacked on #1619. Second of the runtime memory fixes.

## Problem

`AudioTurnStage` buffers every chunk, and `shouldCompleteTurn` returns early while `speechDetected` is false, so the `MaxTurnDuration` bound never applies on that path. A participant who stays quiet — listening while the other party talks, a hot mic below the VAD threshold, a VAD misconfigured for the sample rate — grows the buffer for as long as they stay quiet.

Benchmarked in #1618 at ~2.2 MB/min with a **flat per-minute rate from 1 to 60 minutes**: linear, no ceiling, 132 MB at an hour. Per track, per concurrent call.

## Change

Bound retention at `MaxTurnDuration` — already the stage's declared maximum extent for any turn, so retaining more audio than any turn could contain cannot help. As in #1619, trimming advances an offset rather than moving bytes, so this is O(1) amortized per byte and does not reintroduce the per-chunk memmove that PR removed.

## Measured after

| Session | Before | After |
|---|---|---|
| 1 min | 2.35 MB | 2.35 MB |
| 5 min | 11.3 MB | 2.35 MB |
| 30 min | 67.8 MB | 2.35 MB |
| 60 min | **132.5 MB** | **2.35 MB** |

Flat across every session length. 56× reduction at an hour, constant thereafter.

## Two further defects found in review, both red first

**The bound silently didn't apply below one second.** The window was `int(MaxTurnDuration.Seconds())`, which truncates — any value under 1s gave zero bytes, read as "no bound configured", and disabled the cap entirely. Measured: **60 s retained against a 500 ms bound**. This is reachable, not theoretical: `audio_turn_stage_test.go:161` already uses 100 ms and `sdk/options.go:2333` exposes the field. `1.5s` also bounded at `1s`. Now computed in nanosecond space.

**Silence consumed the turn's duration budget.** `turnSamples` accumulated during silence while `shouldCompleteTurn` measured it against `MaxTurnDuration`, so after a pause longer than the bound the budget was already spent before anyone spoke, and the turn force-completed the moment `MinSpeechDuration` was met. A continuous 5 s utterance after a 40 s pause split into **1.2 s + 4.6 s** — two STT calls and a transcript broken mid-word.

This one is pre-existing, not introduced here, but it directly contradicted the doc comment this PR adds ("once speech is detected the normal turn machinery takes over"), so shipping the cap without it would have left a false claim in the code.

My first attempt at that fix was wrong and the test caught it: setting `turnSamples = maxSamples` still reads as budget-exhausted, since the retained window *is* exactly the bound. It has to be zero — while no speech has been detected, the turn hasn't started and has spent nothing.

## Behavior change worth flagging

This **narrows the degrade-open guarantee**. When VAD never fires, the stage now forwards the most recent `MaxTurnDuration` rather than everything. It keeps the *newest* audio, which is what a late-firing or broken VAD is most likely to have been wrong about, and `TestAudioTurnStage_RetainsNewestSilenceWithinBound` pins that direction — a duration-only assertion couldn't tell the two ends apart.

No caller depends on longer: the sole non-test caller is `sdk/internal/pipeline/builder_vad.go:53`, and no example feeds pre-recorded files through this stage.

## Review

Adversarially reviewed. The primary suspect — `speechStartOffset` being an absolute index that compaction rewrites — was empirically probed across forced compactions at 2s/3s/30s bounds with 0–30 s of leading silence: the first speech byte landed at an identical offset in every case. Correctness rests on `capSilenceRetention` running *before* the VAD analysis; that invariant is now documented, since moving the call would reintroduce the bug silently.

`-race` clean, 0 new lint findings, 85.8% coverage on the changed file.
