### PR TITLE
fix(audio): make TurnDetector integration work end to end

### DIFF
--- a/runtime/audio/adaptive_vad.go
+++ b/runtime/audio/adaptive_vad.go
@@ -122,8 +122,9 @@ func (v *AdaptiveVAD) Analyze(_ context.Context, audioData []byte) (float64, err
 	// Map smoothed RMS to probability.
 	probability := adaptiveProbability(smoothed, floor, speechThreshold)
 
-	// Advance the shared state machine.
-	v.update(probability)
+	// Advance the shared state machine by this chunk's AUDIO duration, so
+	// transitions do not depend on how fast audio is delivered.
+	v.update(probability, pcm16Duration(len(audioData), v.params.SampleRate))
 
 	return probability, nil
 }

--- a/runtime/audio/silence.go
+++ b/runtime/audio/silence.go
@@ -142,7 +142,14 @@ func (d *SilenceDetector) ProcessVADState(ctx context.Context, state VADState) (
 	d.lastVADState = state
 
 	switch state {
-	case VADStateSpeaking:
+	// Starting counts as speaking. It means voice has been detected but the VAD
+	// has not yet held it long enough to promote to Speaking, and reaching
+	// Speaking takes several chunks (smoothing to cross the threshold, then
+	// StartSecs in Starting). Treating that window as silence disagrees with
+	// every consumer — AudioTurnStage groups the two states as speech — so a
+	// turn detector would report not-speaking over audio the pipeline has
+	// already accepted as speech, and end the turn part way through a word.
+	case VADStateSpeaking, VADStateStarting:
 		d.userSpeaking = true
 		d.hadSpeech = true
 		d.inSilence = false
@@ -168,10 +175,6 @@ func (d *SilenceDetector) ProcessVADState(ctx context.Context, state VADState) (
 			d.inSilence = true
 		}
 		d.userSpeaking = false
-
-	case VADStateStarting:
-		// User might be starting to speak again
-		d.inSilence = false
 	}
 
 	return false, nil

--- a/runtime/audio/silence.go
+++ b/runtime/audio/silence.go
@@ -142,16 +142,26 @@ func (d *SilenceDetector) ProcessVADState(ctx context.Context, state VADState) (
 	d.lastVADState = state
 
 	switch state {
-	// Starting counts as speaking. It means voice has been detected but the VAD
-	// has not yet held it long enough to promote to Speaking, and reaching
-	// Speaking takes several chunks (smoothing to cross the threshold, then
-	// StartSecs in Starting). Treating that window as silence disagrees with
-	// every consumer — AudioTurnStage groups the two states as speech — so a
-	// turn detector would report not-speaking over audio the pipeline has
-	// already accepted as speech, and end the turn part way through a word.
-	case VADStateSpeaking, VADStateStarting:
+	case VADStateSpeaking:
 		d.userSpeaking = true
 		d.hadSpeech = true
+		d.inSilence = false
+
+	// Starting counts as speaking, but does NOT arm turn completion.
+	//
+	// It means voice has been detected without yet being held long enough to
+	// promote to Speaking, and reaching Speaking takes several chunks (smoothing
+	// to cross the threshold, then StartSecs in Starting). Reporting silence
+	// through that window disagrees with AudioTurnStage, which groups the two
+	// states as speech, so a turn detector would vote to end the turn over audio
+	// the pipeline had already accepted — cutting utterances mid-word.
+	//
+	// hadSpeech is deliberately left alone: it gates triggerTurnComplete, and
+	// Starting needs only a single above-threshold chunk. Arming completion here
+	// would let a cough or a door slam fire a turn and ship noise-only audio to
+	// STT as an utterance. Only confirmed speech arms it.
+	case VADStateStarting:
+		d.userSpeaking = true
 		d.inSilence = false
 
 	case VADStateStopping:

--- a/runtime/audio/silence_noise_test.go
+++ b/runtime/audio/silence_noise_test.go
@@ -1,0 +1,90 @@
+package audio_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// TestSilenceDetectorDoesNotCompleteTurnOnUnconfirmedSpeech covers a single
+// noise chunk being enough to fire a turn.
+//
+// Reaching VADStateStarting takes only one chunk above the threshold — a cough,
+// a door slam, a knock on the desk. Turn completion is gated on hadSpeech, so if
+// Starting arms that flag then a blip followed by silence fires turnCallback and
+// ships noise-only audio to STT as if it were an utterance.
+//
+// Starting must count as speaking for IsUserSpeaking (a turn detector that
+// reports not-speaking during the Starting window ends turns mid-word), but it
+// must not by itself arm turn completion. Only confirmed speech should do that.
+func TestSilenceDetectorDoesNotCompleteTurnOnUnconfirmedSpeech(t *testing.T) {
+	ctx := context.Background()
+	d := audio.NewSilenceDetector(10 * time.Millisecond)
+
+	// A blip: one chunk crosses the threshold, never confirmed as speech.
+	if _, err := d.ProcessVADState(ctx, audio.VADStateStarting); err != nil {
+		t.Fatalf("ProcessVADState(Starting): %v", err)
+	}
+	// It falls away again.
+	if _, err := d.ProcessVADState(ctx, audio.VADStateQuiet); err != nil {
+		t.Fatalf("ProcessVADState(Quiet): %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond) // let the silence threshold elapse
+
+	done, err := d.ProcessVADState(ctx, audio.VADStateQuiet)
+	if err != nil {
+		t.Fatalf("ProcessVADState(Quiet): %v", err)
+	}
+	if done {
+		t.Error("a single unconfirmed noise chunk completed a turn; " +
+			"Starting must not arm turn completion on its own")
+	}
+}
+
+// TestSilenceDetectorStillCompletesTurnAfterConfirmedSpeech is the counterpart:
+// narrowing what arms turn completion must not stop real speech from ending a
+// turn.
+func TestSilenceDetectorStillCompletesTurnAfterConfirmedSpeech(t *testing.T) {
+	ctx := context.Background()
+	d := audio.NewSilenceDetector(10 * time.Millisecond)
+
+	for _, st := range []audio.VADState{audio.VADStateStarting, audio.VADStateSpeaking} {
+		if _, err := d.ProcessVADState(ctx, st); err != nil {
+			t.Fatalf("ProcessVADState(%v): %v", st, err)
+		}
+	}
+	if _, err := d.ProcessVADState(ctx, audio.VADStateStopping); err != nil {
+		t.Fatalf("ProcessVADState(Stopping): %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	done, err := d.ProcessVADState(ctx, audio.VADStateQuiet)
+	if err != nil {
+		t.Fatalf("ProcessVADState(Quiet): %v", err)
+	}
+	if !done {
+		t.Error("confirmed speech followed by silence did not complete the turn")
+	}
+}
+
+// TestSilenceDetectorReportsSpeakingDuringStarting pins the half of the Starting
+// change that must be kept: IsUserSpeaking has to be true during the Starting
+// window, or a turn detector reports not-speaking over audio the pipeline has
+// already accepted as speech and cuts the turn mid-word.
+func TestSilenceDetectorReportsSpeakingDuringStarting(t *testing.T) {
+	ctx := context.Background()
+	d := audio.NewSilenceDetector(800 * time.Millisecond)
+
+	if _, err := d.ProcessVADState(ctx, audio.VADStateStarting); err != nil {
+		t.Fatalf("ProcessVADState(Starting): %v", err)
+	}
+
+	if !d.IsUserSpeaking() {
+		t.Error("detector reports not-speaking during the VAD Starting window; " +
+			"the turn detector's vote would end the turn mid-utterance")
+	}
+}

--- a/runtime/audio/simple_vad.go
+++ b/runtime/audio/simple_vad.go
@@ -74,8 +74,9 @@ func (v *SimpleVAD) Analyze(_ context.Context, audioData []byte) (float64, error
 	// Convert RMS to probability (0.0-1.0).
 	probability := v.rmsToProbability(smoothed)
 
-	// Advance the shared state machine.
-	v.update(probability)
+	// Advance the shared state machine by this chunk's AUDIO duration, so
+	// transitions do not depend on how fast audio is delivered.
+	v.update(probability, pcm16Duration(len(audioData), v.params.SampleRate))
 
 	return probability, nil
 }

--- a/runtime/audio/vad_audiotime_test.go
+++ b/runtime/audio/vad_audiotime_test.go
@@ -1,0 +1,108 @@
+package audio_test
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// speechPCM returns 16-bit PCM sine at ~0.106 RMS, matching measured real speech
+// levels, which the energy VADs treat as speech.
+func speechPCM(samples int) []byte {
+	b := make([]byte, samples*2)
+	for i := range samples {
+		v := int16(0.15 * 32767 * math.Sin(float64(i)*0.2))
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(v))
+	}
+	return b
+}
+
+// TestVADReachesSpeakingByAudioTimeNotWallClock covers VAD state transitions
+// being timed by wall-clock.
+//
+// The state machine advances Starting -> Speaking once StartSecs has elapsed,
+// but measures that against time.Now(). Delivery rate and audio duration are not
+// the same thing: a file replayed faster than real time, a batch ingestion, or a
+// test feeding buffered audio all elapse far less wall-clock than the audio they
+// carry, so the VAD stalls in Starting and never reports Speaking.
+//
+// Consumers that key off VADStateSpeaking specifically — SilenceDetector sets
+// userSpeaking only there, InterruptionHandler gates barge-in on it — then never
+// fire. Transitions must be driven by the duration of audio analyzed.
+func TestVADReachesSpeakingByAudioTimeNotWallClock(t *testing.T) {
+	const sampleRate = 16000
+	const chunkSamples = sampleRate / 10 // 100 ms
+
+	cases := []struct {
+		name string
+		make func() (audio.VADAnalyzer, error)
+	}{
+		{name: "SimpleVAD", make: func() (audio.VADAnalyzer, error) {
+			return audio.NewSimpleVAD(audio.DefaultVADParams())
+		}},
+		{name: "AdaptiveVAD", make: func() (audio.VADAnalyzer, error) {
+			return audio.NewAdaptiveVAD(audio.DefaultVADParams())
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := tc.make()
+			if err != nil {
+				t.Fatalf("construct: %v", err)
+			}
+
+			ctx := context.Background()
+			chunk := speechPCM(chunkSamples)
+
+			// 2s of continuous speech, fed instantly. DefaultVADStartSecs is
+			// 0.2s, so Speaking is due after ~2 chunks of audio time.
+			for range 20 {
+				if _, err := v.Analyze(ctx, chunk); err != nil {
+					t.Fatalf("Analyze: %v", err)
+				}
+			}
+
+			if got := v.State(); got != audio.VADStateSpeaking {
+				t.Errorf("after 2s of continuous speech the VAD reports %v, want %v; "+
+					"state transitions are timed by wall-clock, so an instant feed never advances them",
+					got, audio.VADStateSpeaking)
+			}
+		})
+	}
+}
+
+// TestVADReturnsToQuietByAudioTime is the mirror: the Speaking -> Stopping ->
+// Quiet path must also advance on audio duration, or a VAD driven faster than
+// real time latches in Speaking and never reports the end of a turn.
+func TestVADReturnsToQuietByAudioTime(t *testing.T) {
+	const sampleRate = 16000
+	const chunkSamples = sampleRate / 10
+
+	v, err := audio.NewSimpleVAD(audio.DefaultVADParams())
+	if err != nil {
+		t.Fatalf("NewSimpleVAD: %v", err)
+	}
+
+	ctx := context.Background()
+
+	for range 20 { // 2s speech
+		if _, err := v.Analyze(ctx, speechPCM(chunkSamples)); err != nil {
+			t.Fatalf("Analyze speech: %v", err)
+		}
+	}
+	// DefaultVADStopSecs is 0.8s; feed 2s of silence.
+	for range 20 {
+		if _, err := v.Analyze(ctx, make([]byte, chunkSamples*2)); err != nil {
+			t.Fatalf("Analyze silence: %v", err)
+		}
+	}
+
+	if got := v.State(); got != audio.VADStateQuiet {
+		t.Errorf("after 2s of silence following speech the VAD reports %v, want %v; "+
+			"the stop transition is timed by wall-clock", got, audio.VADStateQuiet)
+	}
+}

--- a/runtime/audio/vad_state_machine.go
+++ b/runtime/audio/vad_state_machine.go
@@ -16,7 +16,12 @@ type vadStateMachine struct {
 	state       VADState
 	prevState   VADState
 	stateChange chan VADEvent
-	stateStart  time.Time
+	// stateDuration is how much AUDIO has been analyzed in the current state,
+	// not how much wall-clock has passed. Delivery rate and audio duration are
+	// different things: a file replayed faster than real time, a batch
+	// ingestion, or a stalled pipeline all diverge, and timing transitions by
+	// the clock then either stalls them or fires them early.
+	stateDuration time.Duration
 }
 
 // newVADStateMachine creates a vadStateMachine with the given params.
@@ -25,19 +30,21 @@ func newVADStateMachine(params VADParams) *vadStateMachine {
 		params:      params,
 		state:       VADStateQuiet,
 		stateChange: make(chan VADEvent, stateChangeBufferSize),
-		stateStart:  time.Now(),
 	}
 }
 
 // update advances the state machine with the given voice probability and emits
 // a VADEvent on state change. The send is non-blocking; events are dropped when
 // the channel is full.
-func (m *vadStateMachine) update(probability float64) {
+// audioDuration is the duration of the audio this probability was derived from,
+// which is what advances the state machine's sense of time.
+func (m *vadStateMachine) update(probability float64, audioDuration time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	now := time.Now()
-	stateDuration := now.Sub(m.stateStart)
+	m.stateDuration += audioDuration
+	stateDuration := m.stateDuration
 
 	newState := m.computeNextState(m.state, probability, stateDuration.Seconds())
 
@@ -52,7 +59,7 @@ func (m *vadStateMachine) update(probability float64) {
 
 		m.prevState = m.state
 		m.state = newState
-		m.stateStart = now
+		m.stateDuration = 0
 
 		// Non-blocking send — drop the event if the channel is full.
 		select {
@@ -60,6 +67,17 @@ func (m *vadStateMachine) update(probability float64) {
 		default:
 		}
 	}
+}
+
+// pcm16Duration returns the duration represented by a PCM16-mono byte count at
+// the given sample rate. Returns 0 for a non-positive rate.
+func pcm16Duration(byteLen, sampleRate int) time.Duration {
+	if sampleRate <= 0 {
+		return 0
+	}
+	const bytesPerSample16Bit = 2
+	samples := byteLen / bytesPerSample16Bit
+	return time.Duration(samples) * time.Second / time.Duration(sampleRate)
 }
 
 // computeNextState is a pure function that determines the next VAD state given
@@ -117,7 +135,7 @@ func (m *vadStateMachine) Reset() {
 
 	m.state = VADStateQuiet
 	m.prevState = VADStateQuiet
-	m.stateStart = time.Now()
+	m.stateDuration = 0
 
 	for len(m.stateChange) > 0 {
 		<-m.stateChange

--- a/runtime/audio/vad_state_machine.go
+++ b/runtime/audio/vad_state_machine.go
@@ -21,6 +21,13 @@ type vadStateMachine struct {
 	// different things: a file replayed faster than real time, a batch
 	// ingestion, or a stalled pipeline all diverge, and timing transitions by
 	// the clock then either stalls them or fires them early.
+	//
+	// The contract this places on callers: transitions only advance when audio
+	// is analyzed, so a discontinuous transport must inject silence for any
+	// interval it suppresses. On a line using silence suppression — where the
+	// far end sends no packets at all while quiet — the machine holds its state
+	// across the gap rather than aging out of it. Feed comfort noise or
+	// explicit silence for suppressed intervals.
 	stateDuration time.Duration
 }
 
@@ -71,6 +78,11 @@ func (m *vadStateMachine) update(probability float64, audioDuration time.Duratio
 
 // pcm16Duration returns the duration represented by a PCM16-mono byte count at
 // the given sample rate. Returns 0 for a non-positive rate.
+//
+// Assumes single-channel PCM16. Interleaved stereo reports twice its true
+// duration, and non-PCM16 payloads (G.711, for instance) are meaningless when
+// reinterpreted as int16 — VADParams carries no channel count, and no stage on
+// the VAD path normalizes one. Callers must feed mono PCM16 at params.SampleRate.
 func pcm16Duration(byteLen, sampleRate int) time.Duration {
 	if sampleRate <= 0 {
 		return 0

--- a/runtime/pipeline/stage/audioturn_samplerate_test.go
+++ b/runtime/pipeline/stage/audioturn_samplerate_test.go
@@ -1,0 +1,88 @@
+package stage_test
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// ratePCM returns `samples` of speech-level sine, independent of sample rate.
+func ratePCM(samples int) []byte {
+	b := make([]byte, samples*2)
+	for i := range samples {
+		v := int16(0.15 * 32767 * math.Sin(float64(i)*0.2))
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(v))
+	}
+	return b
+}
+
+// chunksToSpeaking feeds 100ms chunks at the configured rate and returns how
+// many were needed before the turn detector saw a Speaking state, or -1.
+func chunksToSpeaking(t *testing.T, sampleRate int) int {
+	t.Helper()
+
+	spy := &spyTurnDetector{}
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.SampleRate = sampleRate
+	cfg.TurnDetector = spy
+
+	chunkSamples := sampleRate / 10 // 100 ms at this rate
+
+	runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		for range 30 {
+			in <- makeAudioElement(ratePCM(chunkSamples), sampleRate)
+		}
+	})
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	for i, s := range spy.states {
+		if s == audio.VADStateSpeaking {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// TestAudioTurnStage_VADHonorsConfiguredSampleRate covers the stage building its
+// VAD at a hardcoded rate while timing its own turn math at the configured one.
+//
+// NewAudioTurnStage resolves config.SampleRate for its turn math, then creates
+// the default VAD with DefaultVADParams() — always 16 kHz. That was harmless
+// while the VAD state machine ignored SampleRate, but transitions are now scaled
+// by it, so the VAD and the stage disagree about how long a chunk lasts whenever
+// the configured rate is not 16 kHz.
+//
+// At 8 kHz telephony the VAD sees every duration as half its true length, so
+// StartSecs 0.2 behaves as 0.4 and StopSecs 0.8 as 1.6 — the VAD lags turn-end
+// by an extra ~800ms while the stage's own silence math is on schedule. At
+// 48 kHz it fires three times early.
+//
+// Measured in chunks-to-Speaking, which should be the same count at any rate
+// because each chunk is 100ms of audio regardless.
+func TestAudioTurnStage_VADHonorsConfiguredSampleRate(t *testing.T) {
+	base := chunksToSpeaking(t, 16000)
+	if base < 0 {
+		t.Fatal("VAD never reached Speaking at 16kHz; the baseline is broken")
+	}
+
+	for _, rate := range []int{8000, 48000} {
+		got := chunksToSpeaking(t, rate)
+		if got < 0 {
+			t.Errorf("at %dHz the VAD never reached Speaking within 30 chunks (3s of audio); "+
+				"the stage builds its VAD at a hardcoded 16kHz, so durations are scaled wrong", rate)
+			continue
+		}
+		// Each chunk is 100ms of audio at every rate, so the count must match.
+		// One chunk of slack absorbs rounding.
+		if got < base-1 || got > base+1 {
+			t.Errorf("at %dHz the VAD reached Speaking after %d chunks, but after %d at 16kHz; "+
+				"each chunk is 100ms at both rates, so the stage is building its VAD with "+
+				"DefaultVADParams (hardcoded 16kHz) instead of the configured rate",
+				rate, got, base)
+		}
+	}
+}

--- a/runtime/pipeline/stage/audioturn_turndetector_test.go
+++ b/runtime/pipeline/stage/audioturn_turndetector_test.go
@@ -1,0 +1,160 @@
+package stage_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// TestAudioTurnStage_TurnDetectorDoesNotShatterContinuousSpeech covers a
+// TurnDetector being fed audio but never the VAD states it needs.
+//
+// AudioTurnStage calls turnDetector.ProcessAudio and IsUserSpeaking, but never
+// ProcessVADState — the only caller of that is the interruption handler. A
+// SilenceDetector decides speaking/silence entirely inside ProcessVADState, so
+// left undriven its IsUserSpeaking is permanently false, and shouldCompleteTurn's
+// detector vote ("not speaking, so the turn is over") fires on every evaluation.
+//
+// A continuous utterance is then cut at MinSpeechDuration over and over: one
+// sentence becomes many fragments, each its own STT call and transcript.
+//
+// This is the configuration the WithTurnDetector doc comment recommends.
+func TestAudioTurnStage_TurnDetectorDoesNotShatterContinuousSpeech(t *testing.T) {
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.TurnDetector = audio.NewSilenceDetector(800 * time.Millisecond)
+
+	const chunkSamples = 1600 // 100 ms
+
+	turns := runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		// 5s of continuous speech with no pause to segment on.
+		for range 50 {
+			in <- makeAudioElement(vadSpeechPCM(chunkSamples), 16000)
+		}
+	})
+
+	if len(turns) > 1 {
+		durations := make([]time.Duration, len(turns))
+		for i, turn := range turns {
+			durations[i] = turnDuration(turn)
+		}
+		t.Fatalf("continuous 5s utterance split into %d turns (%v) with a TurnDetector configured; "+
+			"the detector never receives VAD states, so it always reports not-speaking",
+			len(turns), durations)
+	}
+}
+
+// TestAudioTurnStage_TurnDetectorMatchesNoDetectorOnContinuousSpeech pins that
+// adding a detector does not change segmentation of audio that has no turn
+// boundary in it.
+//
+// A detector is meant to refine when a turn ends, not to invent boundaries in
+// unbroken speech. Comparing against the no-detector baseline catches a detector
+// that is being driven incorrectly rather than merely producing a different
+// answer.
+func TestAudioTurnStage_TurnDetectorMatchesNoDetectorOnContinuousSpeech(t *testing.T) {
+	const chunkSamples = 1600
+
+	feed := func(in chan<- stage.StreamElement) {
+		for range 50 {
+			in <- makeAudioElement(vadSpeechPCM(chunkSamples), 16000)
+		}
+	}
+
+	withDetector := stage.DefaultAudioTurnConfig()
+	withDetector.TurnDetector = audio.NewSilenceDetector(800 * time.Millisecond)
+
+	got := len(runTurnStage(t, withDetector, feed))
+	want := len(runTurnStage(t, stage.DefaultAudioTurnConfig(), feed))
+
+	if got != want {
+		t.Errorf("continuous speech produced %d turns with a TurnDetector but %d without; "+
+			"a detector should not invent boundaries in unbroken speech", got, want)
+	}
+}
+
+// spyTurnDetector records the VAD states delivered to it.
+//
+// Asserting on a real detector's IsUserSpeaking after a run cannot prove the
+// wiring: EndOfStream resets the stage, which resets the detector, so the flag
+// is legitimately false by the time the test reads it. Recording the delivered
+// states observes the wiring itself rather than a state that is correctly
+// cleared afterwards.
+type spyTurnDetector struct {
+	mu     sync.Mutex
+	states []audio.VADState
+	audioN int
+}
+
+func (d *spyTurnDetector) Name() string { return "spy" }
+
+func (d *spyTurnDetector) ProcessAudio(_ context.Context, _ []byte) (bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.audioN++
+	return false, nil
+}
+
+func (d *spyTurnDetector) ProcessVADState(_ context.Context, state audio.VADState) (bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.states = append(d.states, state)
+	return false, nil
+}
+
+func (d *spyTurnDetector) IsUserSpeaking() bool { return true }
+
+func (d *spyTurnDetector) Reset() {}
+
+func (d *spyTurnDetector) sawSpeech() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, s := range d.states {
+		if s == audio.VADStateSpeaking || s == audio.VADStateStarting {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *spyTurnDetector) counts() (states, audioChunks int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.states), d.audioN
+}
+
+// TestAudioTurnStage_TurnDetectorReceivesVADState pins the wiring itself.
+//
+// A detector splits its work: ProcessAudio carries the samples, ProcessVADState
+// carries the speaking/silence signal that IsUserSpeaking — and therefore
+// shouldCompleteTurn's vote — depends on. Delivering only the audio leaves the
+// detector unable to answer the question the stage asks it.
+func TestAudioTurnStage_TurnDetectorReceivesVADState(t *testing.T) {
+	spy := &spyTurnDetector{}
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.TurnDetector = spy
+
+	const chunkSamples = 1600
+
+	runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		for range 20 { // 2s of speech
+			in <- makeAudioElement(vadSpeechPCM(chunkSamples), 16000)
+		}
+	})
+
+	states, audioChunks := spy.counts()
+	if states == 0 {
+		t.Fatalf("TurnDetector received %d audio chunks but 0 VAD states; "+
+			"the stage is not driving ProcessVADState", audioChunks)
+	}
+	if states != audioChunks {
+		t.Errorf("TurnDetector received %d VAD states for %d audio chunks; "+
+			"both must be delivered per chunk to stay in step", states, audioChunks)
+	}
+	if !spy.sawSpeech() {
+		t.Error("TurnDetector never received a speaking state across 2s of continuous speech")
+	}
+}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -400,9 +400,19 @@ func (s *AudioTurnStage) processAudio(
 		state.speechSamples += n
 	}
 
-	// Also use TurnDetector if available
+	// Also use TurnDetector if available.
+	//
+	// Both calls are required. Detectors split the work: ProcessAudio accumulates
+	// the turn's audio, while speaking/silence tracking — and therefore
+	// IsUserSpeaking, which shouldCompleteTurn votes on — is driven entirely by
+	// ProcessVADState. Feeding only the audio leaves a detector permanently
+	// reporting not-speaking, so its vote ends the turn on every evaluation and
+	// continuous speech is shattered into MinSpeechDuration fragments.
 	if s.turnDetector != nil {
 		if _, err := s.turnDetector.ProcessAudio(ctx, elem.Audio.Samples); err != nil {
+			return err
+		}
+		if _, err := s.turnDetector.ProcessVADState(ctx, vadState); err != nil {
 			return err
 		}
 	}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -117,11 +117,19 @@ func NewAudioTurnStage(config AudioTurnConfig) (*AudioTurnStage, error) {
 		config.SampleRate = defaultAudioTurnSampleRate
 	}
 
-	// Create default VAD if not provided
+	// Create default VAD if not provided.
+	//
+	// The VAD's params must carry the configured sample rate, not the default.
+	// VAD state transitions are scaled by it — it is how a chunk's byte count
+	// becomes a duration — so leaving it at 16kHz makes the VAD and this stage
+	// disagree about how long a chunk lasts at any other rate: 8kHz telephony
+	// would see every threshold at twice its intended length, 48kHz at a third.
 	vad := config.VAD
 	if vad == nil {
+		params := audio.DefaultVADParams()
+		params.SampleRate = config.SampleRate
 		var err error
-		vad, err = audio.NewSimpleVAD(audio.DefaultVADParams())
+		vad, err = audio.NewSimpleVAD(params)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Stacked on #1620.

## Problem

Configuring a `TurnDetector` shattered continuous speech: a **5 s utterance became 13 turns of ~400 ms**, each its own STT call and transcript fragment. This is the configuration the `WithTurnDetector` doc comment recommends (`options.go:1972`).

It is opt-in and **nothing in `examples/` or the SDK defaults uses it**, so no shipped path is affected today — the first person to follow the documentation hits it.

## Three coupled defects

Any one alone leaves it broken; I found them in sequence, each only visible after the previous was fixed.

**1. The stage never delivered VAD states.** `AudioTurnStage` called `turnDetector.ProcessAudio` and `IsUserSpeaking`, but never `ProcessVADState` — its only caller was the interruption handler. Detectors split the work: `ProcessAudio` carries samples, `ProcessVADState` carries the speaking/silence signal `IsUserSpeaking` depends on. Undriven, a detector reports not-speaking forever, so `shouldCompleteTurn`'s vote ended the turn on every evaluation.

**2. VAD state transitions were timed by wall-clock.** `vadStateMachine` measured `StartSecs`/`StopSecs` against `time.Now()` — the same defect fixed in `AudioTurnStage` in #1616. Delivery rate and audio duration are different things: a file replayed faster than real time, a batch ingestion, or a test feeding buffered audio elapses far less wall-clock than the audio carries, so the VAD stalls in `Starting` and never reports `Speaking`. Consumers keyed on `VADStateSpeaking` — `SilenceDetector` sets `userSpeaking` only there, `InterruptionHandler` gates barge-in on it — then never fire. Affects both `SimpleVAD` and `AdaptiveVAD`.

**3. `SilenceDetector` disagreed with the pipeline about what counts as speech.** `ProcessVADState` treated `VADStateStarting` as not-speaking, while `AudioTurnStage` groups `Starting` with `Speaking`. Reaching `Speaking` takes ~500 ms (smoothing to cross the threshold, then `StartSecs` in `Starting`), but `MinSpeechDuration` is satisfied at ~300 ms — so the turn completed at 400 ms while the detector still reported silence over audio the pipeline had already accepted as speech.

Defect 2 is the one with reach beyond this feature: it means VAD misbehaves for **any** non-real-time input, independent of whether a `TurnDetector` is configured. Fixing it also made the behavior deterministic at any feed rate, which is what allowed these to be pinned by tests instead of real-time sleeps.

## Tests

- `TestAudioTurnStage_TurnDetectorDoesNotShatterContinuousSpeech` — RED at 13 turns, green at 1.
- `TestAudioTurnStage_TurnDetectorMatchesNoDetectorOnContinuousSpeech` — compares against the no-detector baseline, so a detector that is merely *differently* wrong still fails.
- `TestVADReachesSpeakingByAudioTimeNotWallClock` — RED for both `SimpleVAD` and `AdaptiveVAD`.
- `TestVADReturnsToQuietByAudioTime` — mirror guard on the stop path.
- `TestAudioTurnStage_TurnDetectorReceivesVADState` — spy detector asserting states and audio chunks arrive in step.

That last one I had to rewrite: it originally asserted `IsUserSpeaking()` after the run, which fails for a legitimate reason — `EndOfStream` resets the stage, which resets the detector. The test was wrong, not the code. A spy observes the wiring directly instead of a state that is correctly cleared afterwards.

## Review note

I have **not** run a separate adversarial review pass on this one, unlike #1619 and #1620. Defect 2 changes VAD timing semantics for every consumer, which is the broadest blast radius of anything in this series, so it deserves careful review. Full runtime suite passes with `-race`; coverage on all five changed files is 85–96%; 0 new lint findings.

Happy to split defect 2 (VAD audio-time) into its own PR if you'd rather review it in isolation — it is independently valuable and the other two depend on it only for testability.
