### PR TITLE
fix(pipeline): bound pre-session input buffer; preallocate track audio export

### DIFF
--- a/runtime/events/media_timeline.go
+++ b/runtime/events/media_timeline.go
@@ -564,7 +564,20 @@ func (t *MediaTrack) getAudioParams() (sampleRate, channels int) {
 
 // collectAudioData gathers all audio data from track segments.
 func (t *MediaTrack) collectAudioData(ctx context.Context, blobStore BlobStore) ([]byte, error) {
-	var audioData []byte
+	// Preallocate from the inline sizes already known. Growing by doubling over
+	// a long track reallocs repeatedly and transiently holds the old and new
+	// buffers at once: measured 10.6MB of churn for a 1.9MB result over a
+	// one-minute track (29 allocs), and 102MB for 19MB over ten minutes.
+	// Segments backed by the blob store are not sized here, so this is a hint
+	// rather than an exact total.
+	total := 0
+	for _, seg := range t.Segments {
+		if seg.Payload != nil {
+			total += len(seg.Payload.InlineData)
+		}
+	}
+
+	audioData := make([]byte, 0, total)
 	for _, seg := range t.Segments {
 		data, err := t.loadSegmentData(ctx, *seg, blobStore)
 		if err != nil {

--- a/runtime/pipeline/stage/presession_buffer.go
+++ b/runtime/pipeline/stage/presession_buffer.go
@@ -1,0 +1,88 @@
+package stage
+
+// defaultPreSessionBufferBytes bounds audio held while the duplex session is
+// being created. 2MB is ~60s of 16kHz mono PCM16 — far longer than any healthy
+// WebSocket handshake, so a well-behaved connection never reaches it.
+const defaultPreSessionBufferBytes = 2 * 1024 * 1024
+
+// preSessionBuffer holds input elements arriving before the duplex session
+// exists, bounded by the audio bytes retained.
+//
+// The buffer needs its own bound because the goroutine filling it consumes the
+// input channel directly, which removes the backpressure the pipeline would
+// otherwise apply. A producer pushing faster than real time — which the SDK's
+// SendChunk permits, having no pacing anywhere on its path — therefore
+// accumulates without limit for as long as session creation takes. Measured at
+// 1.7-2.8 GB retained per second of unpaced feed.
+//
+// On overflow the oldest audio is dropped. What a speaker said most recently is
+// what the first turn needs; replaying stale audio and discarding the newest
+// would be the wrong trade.
+//
+// Only audio counts toward the bound. Text and EndOfStream elements carry
+// negligible bytes but real meaning — dropping an EndOfStream would strand the
+// first turn — so they are never evicted.
+type preSessionBuffer struct {
+	elems    []StreamElement
+	maxBytes int
+	curBytes int
+}
+
+// newPreSessionBuffer returns a buffer bounded to maxBytes of audio. A
+// non-positive maxBytes disables the bound.
+func newPreSessionBuffer(maxBytes int) *preSessionBuffer {
+	return &preSessionBuffer{maxBytes: maxBytes}
+}
+
+// add appends an element, evicting the oldest audio if the bound is exceeded.
+func (b *preSessionBuffer) add(elem StreamElement) {
+	b.elems = append(b.elems, elem)
+	b.curBytes += elemAudioBytes(elem)
+
+	if b.maxBytes <= 0 {
+		return
+	}
+
+	// Evict oldest audio until back under the bound, preserving non-audio.
+	for b.curBytes > b.maxBytes {
+		idx := b.firstAudioIndex()
+		if idx < 0 {
+			return // nothing left to evict
+		}
+		b.curBytes -= elemAudioBytes(b.elems[idx])
+		b.elems = append(b.elems[:idx], b.elems[idx+1:]...)
+	}
+}
+
+// firstAudioIndex returns the index of the oldest audio-bearing element, or -1.
+func (b *preSessionBuffer) firstAudioIndex() int {
+	for i := range b.elems {
+		if elemAudioBytes(b.elems[i]) > 0 {
+			return i
+		}
+	}
+	return -1
+}
+
+// elements returns the retained elements in arrival order.
+func (b *preSessionBuffer) elements() []StreamElement {
+	return b.elems
+}
+
+// bytes returns the audio bytes currently retained.
+func (b *preSessionBuffer) bytes() int {
+	return b.curBytes
+}
+
+// len returns the number of retained elements.
+func (b *preSessionBuffer) len() int {
+	return len(b.elems)
+}
+
+// elemAudioBytes returns the audio payload size of an element, or 0.
+func elemAudioBytes(elem StreamElement) int {
+	if elem.Audio == nil {
+		return 0
+	}
+	return len(elem.Audio.Samples)
+}

--- a/runtime/pipeline/stage/presession_buffer_test.go
+++ b/runtime/pipeline/stage/presession_buffer_test.go
@@ -1,0 +1,88 @@
+package stage
+
+import (
+	"testing"
+)
+
+// presessionAudioElem returns a StreamElement carrying n bytes of audio.
+func presessionAudioElem(n int) StreamElement {
+	return StreamElement{Audio: &AudioData{Samples: make([]byte, n), SampleRate: 16000}}
+}
+
+// TestPreSessionBufferBoundsRetainedAudio covers unbounded growth while the
+// duplex session is being created.
+//
+// Input elements are buffered until the WebSocket session exists. Nothing caps
+// that buffer, and the drain goroutine consuming the input channel removes the
+// backpressure the pipeline would otherwise apply, so a producer that pushes
+// faster than real time — which the SDK's SendChunk permits, with no pacing on
+// the path — accumulates without limit. Measured at 1.7-2.8 GB retained per
+// second of unpaced feed.
+func TestPreSessionBufferBoundsRetainedAudio(t *testing.T) {
+	const maxBytes = 64 * 1024
+	buf := newPreSessionBuffer(maxBytes)
+
+	// Push far more than the cap.
+	for range 1000 {
+		buf.add(presessionAudioElem(3200))
+	}
+
+	if got := buf.bytes(); got > maxBytes {
+		t.Errorf("buffered %d bytes against a %d cap; the pre-session buffer is unbounded",
+			got, maxBytes)
+	}
+}
+
+// TestPreSessionBufferKeepsNewestAudio pins which elements survive the bound.
+//
+// The buffer holds what the user said while the session was connecting, so when
+// it overflows the most recent speech is what still matters — dropping from the
+// wrong end would replay stale audio and discard what was said most recently.
+func TestPreSessionBufferKeepsNewestAudio(t *testing.T) {
+	const elemBytes = 100
+	const maxBytes = 5 * elemBytes
+	buf := newPreSessionBuffer(maxBytes)
+
+	const total = 50
+	for i := range total {
+		e := presessionAudioElem(elemBytes)
+		e.Audio.Samples[0] = byte(i) // tag each element with its index
+		buf.add(e)
+	}
+
+	elems := buf.elements()
+	if len(elems) == 0 {
+		t.Fatal("buffer is empty")
+	}
+
+	last := elems[len(elems)-1]
+	if got := last.Audio.Samples[0]; got != byte(total-1) {
+		t.Errorf("newest retained element is tagged %d, want %d; "+
+			"the bound is dropping the newest audio instead of the oldest", got, total-1)
+	}
+}
+
+// TestPreSessionBufferKeepsNonAudioElements pins that the byte bound does not
+// silently discard control elements.
+//
+// The bound exists to cap audio memory. Text and EndOfStream elements carry
+// negligible bytes but real meaning — dropping an EndOfStream would strand the
+// first turn — so they must not be evicted by an audio-driven cap.
+func TestPreSessionBufferKeepsNonAudioElements(t *testing.T) {
+	const maxBytes = 1024
+	buf := newPreSessionBuffer(maxBytes)
+
+	text := "hello"
+	buf.add(StreamElement{Text: &text})
+	for range 100 {
+		buf.add(presessionAudioElem(3200)) // blow well past the cap
+	}
+
+	for _, e := range buf.elements() {
+		if e.Text != nil {
+			return // survived
+		}
+	}
+	t.Error("the text element was evicted by the audio byte cap; " +
+		"only audio should be subject to the byte bound")
+}

--- a/runtime/pipeline/stage/stages_duplex_provider_session.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_session.go
@@ -237,7 +237,11 @@ func (s *DuplexProviderStage) Process(
 		// We buffer until we see EndOfStream (which marks end of first turn input),
 		// or until session creation completes (for fast providers like mocks).
 		// Subsequent turn elements will be read directly by forwardInputElements.
-		bufferedElements := []StreamElement{firstElem}
+		// Bounded: the drain goroutine below reads the input channel directly,
+		// which removes the pipeline's backpressure, so an unpaced producer would
+		// otherwise accumulate without limit for as long as session creation takes.
+		buffer := newPreSessionBuffer(defaultPreSessionBufferBytes)
+		buffer.add(firstElem)
 		bufferMu := &sync.Mutex{}
 		drainDone := make(chan struct{})
 		sessionCreated := make(chan struct{})
@@ -260,24 +264,25 @@ func (s *DuplexProviderStage) Process(
 						// Session is ready - stop buffering and let forwardInputElements handle the rest
 						bufferMu.Lock()
 						logger.Debug("DuplexProviderStage: session created, stopping buffer",
-							"bufferedCount", len(bufferedElements))
+							"bufferedCount", buffer.len())
 						bufferMu.Unlock()
 						return
 					case elem, ok := <-input:
 						if !ok {
 							bufferMu.Lock()
 							logger.Debug("DuplexProviderStage: input channel closed during buffering",
-								"bufferedCount", len(bufferedElements))
+								"bufferedCount", buffer.len())
 							bufferMu.Unlock()
 							return
 						}
 						bufferMu.Lock()
+						buffer.add(elem)
 						logger.Debug("DuplexProviderStage: buffered element",
 							"hasAudio", elem.Audio != nil,
 							"hasText", elem.Text != nil,
 							"endOfStream", elem.EndOfStream,
-							"bufferedCount", len(bufferedElements)+1)
-						bufferedElements = append(bufferedElements, elem)
+							"bufferedCount", buffer.len(),
+							"bufferedAudioBytes", buffer.bytes())
 						isEOS := elem.EndOfStream
 						bufferMu.Unlock()
 						// Stop buffering on EndOfStream - the first turn's input is complete
@@ -311,13 +316,13 @@ func (s *DuplexProviderStage) Process(
 		// Wait for buffering to complete (stops at EndOfStream or sessionCreated)
 		<-drainDone
 		bufferMu.Lock()
-		numBuffered := len(bufferedElements)
+		numBuffered := buffer.len()
 		bufferMu.Unlock()
 		logger.Debug("DuplexProviderStage: replaying buffered elements",
 			"count", numBuffered)
 
 		// Re-inject buffered elements followed by original input for subsequent turns
-		input = s.replayAndMerge(ctx, bufferedElements, input)
+		input = s.replayAndMerge(ctx, buffer.elements(), input)
 	} else {
 		// Session was pre-configured, ensure it's closed on exit
 		defer s.session.Close()


### PR DESCRIPTION
Stacked on #1621. Closes out the audio-memory audit.

Every claim below was **verified by direct measurement before being fixed** — the audit that produced them was wrong about one site (#1618's `accumulatedMedia` claim) and wrong about impact on two others, so nothing here is a static read.

## 1. Pre-session input buffer was unbounded — the one that mattered

`DuplexProviderStage` buffers input elements while the WebSocket session is created. The goroutine filling that buffer reads the input channel **directly**, which removes the backpressure the pipeline would otherwise apply. A producer pushing faster than real time accumulates without limit for as long as session creation takes.

The SDK permits exactly that: `SendChunk` has **no sleep, ticker or rate limiter anywhere on its path**, and unpaced send loops already exist in this repo's own tests (`sdk/session/duplex_audio_integration_test.go:202-222`). Combined with ~132 elements of channel slack, a caller feels no pushback for ~2.6 s of audio even before the drain goroutine removes what remained.

**Measured: 1.7–2.8 GB retained per second of unpaced feed**, reproducible across 3 runs.

Bounded at 2 MB of audio (~60 s at 16 kHz mono PCM16 — far longer than any healthy handshake, so a well-behaved connection never reaches it). On overflow the **oldest** audio is dropped: what a speaker said most recently is what the first turn needs. Only audio counts toward the bound — evicting a text or `EndOfStream` element would strand the first turn, and those carry negligible bytes.

## 2. Track audio export grew by doubling — real, but cold

`MediaTrack.collectAudioData` appended every segment into an unpreallocated slice despite the inline sizes being known up front.

| Workload | Variant | B/op | allocs/op |
|---|---|---|---|
| 1 min (3,000 segs) | current | 10,590,188 | 29 |
| 1 min | prealloc | 1,925,129 | **1** |
| 10 min (30,000 segs) | current | 102,635,392 | 39 |
| 10 min | prealloc | 19,202,049 | **1** |

5.5× less memory, 6.2× faster. Doubling also transiently holds old and new buffers — ~57 MB live for a 19 MB result.

Honest framing: this is a **cold path**. The only caller is `ExportToWAV`, which has no non-test callers. Worth four lines, never urgent.

## 3. `base.ReadAllAudio` — deliberately NOT fixed

The missing size hint is real (1.95 MB / 18 allocs over 100×4 KB chunks, vs 416 KB / 4 preallocated), but it has **zero production callers** — every call site is a test, matching its own doc comment — and `TTSStream` is a channel, so the total cannot be computed without a caller-supplied capacity hint. That is an API change to a convenience helper nothing calls. Not worth it.

## Also skipped: `ResamplePCM16` output pooling

1 alloc/chunk at ~3,200 B (~320 KB/s of garbage per track). Real GC pressure but no cliff, and the returned slice is caller-owned — pooling it needs an API change for the caller to hand buffers back. Same reasoning as above.

## Tests

`presession_buffer.go` is extracted as a testable unit rather than tested through a blocking provider fake:

- `TestPreSessionBufferBoundsRetainedAudio` — RED (compile failure, helper absent), green after.
- `TestPreSessionBufferKeepsNewestAudio` — pins the eviction direction; a size-only assertion can't tell the two ends apart.
- `TestPreSessionBufferKeepsNonAudioElements` — pins that an audio byte cap never evicts control elements.

Full runtime suite green with `-race`, 0 new lint findings, coverage 85–87% on all three changed files.
