### PR TITLE
fix(pipeline): don't emit a speechless remainder once a turn has been emitted

### DIFF
--- a/runtime/pipeline/stage/audioturn_remainder_test.go
+++ b/runtime/pipeline/stage/audioturn_remainder_test.go
@@ -1,0 +1,73 @@
+package stage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// TestAudioTurnStage_DoesNotEmitSpeechlessRemainderAfterATurn covers trailing
+// silence being emitted as a turn of its own.
+//
+// When a turn completes mid-stream the buffer resets, and whatever silence
+// arrives afterwards accumulates until EndOfStream. emitRemainingAudio then
+// forwards it on size alone, so a stream that ends with more silence than the
+// turn threshold produces a second, speechless "turn".
+//
+// Downstream that is an STT call on pure silence: billed, slow, and a standing
+// invitation for Whisper to hallucinate text that then flows on as if the
+// speaker had said it. Observed as a phantom duplicate transcript in the
+// voice-sales-assist example, where one utterance produced two.
+func TestAudioTurnStage_DoesNotEmitSpeechlessRemainderAfterATurn(t *testing.T) {
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.SilenceDuration = 500 * time.Millisecond
+
+	const chunkSamples = 1600 // 100 ms
+
+	turns := runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		feed := func(gen func(int) []byte, chunks int) {
+			for range chunks {
+				in <- makeAudioElement(gen(chunkSamples), 16000)
+			}
+		}
+		feed(vadSpeechPCM, 10)  // 1.0s speech
+		feed(vadSilencePCM, 20) // 2.0s silence: completes the turn, leaves a tail
+	})
+
+	if len(turns) == 0 {
+		t.Fatal("expected the spoken turn to be emitted, got none")
+	}
+	if len(turns) > 1 {
+		durations := make([]string, len(turns))
+		for i, turn := range turns {
+			durations[i] = turnDuration(turn).String()
+		}
+		t.Errorf("one utterance produced %d turns (%v); the trailing silence after the "+
+			"turn completed was emitted as a speechless turn of its own and would be "+
+			"sent to STT", len(turns), durations)
+	}
+}
+
+// TestAudioTurnStage_StillForwardsAudioWhenVADNeverFires guards the degrade-open
+// property that the fix must not break.
+//
+// The stage forwards a buffer at EndOfStream even without detected speech, so a
+// pre-recorded file whose VAD never triggers is not silently dropped. Suppressing
+// speechless remainders must remain conditional on having already emitted a turn
+// — if nothing has been emitted, the audio still has to come out.
+func TestAudioTurnStage_StillForwardsAudioWhenVADNeverFires(t *testing.T) {
+	const chunkSamples = 1600
+	const chunks = 20 // 2.0s, comfortably over defaultMinAudioBytes
+
+	turns := runTurnStage(t, stage.DefaultAudioTurnConfig(), func(in chan<- stage.StreamElement) {
+		for range chunks {
+			in <- makeAudioElement(vadSilencePCM(chunkSamples), 16000)
+		}
+	})
+
+	if len(turns) == 0 {
+		t.Error("no turn emitted when VAD never detected speech; audio the VAD may have " +
+			"misread must still be forwarded")
+	}
+}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -165,6 +165,12 @@ type audioTurnState struct {
 	// bufStart is the offset at which live audio begins. Bounding retention
 	// advances this rather than moving bytes; see capSilenceRetention.
 	bufStart int
+	// emittedTurn records whether any turn has been emitted for this stream.
+	// Deliberately NOT cleared by resetState: it is a property of the stream,
+	// not of the current turn, and it is what distinguishes "the VAD has never
+	// fired, so forward everything" from "the VAD is working and this is just
+	// trailing silence".
+	emittedTurn bool
 }
 
 // liveAudio returns the audio currently retained, excluding any dead prefix
@@ -343,14 +349,28 @@ func (s *AudioTurnStage) emitRemainingAudio(
 	if len(live) == 0 {
 		return nil
 	}
-	// Emit buffered audio if speech was detected OR if we have significant audio data
-	// For pre-recorded files, VAD may not detect speech, but we still want to forward the audio
-	if state.speechDetected || len(live) > defaultMinAudioBytes {
+	// Emit if this turn contains speech.
+	//
+	// Failing that, emit on size alone only when no turn has been emitted for
+	// this stream at all. That is the degrade-open case: a pre-recorded file
+	// whose VAD never fires must still be forwarded rather than silently
+	// dropped, since the audio may well contain speech the VAD misread.
+	//
+	// Once a turn HAS been emitted, the VAD has demonstrably been working, so a
+	// speechless remainder is just the tail of silence that completed the last
+	// turn. Forwarding it costs an STT call on pure silence — billed, slow, and
+	// a standing invitation for Whisper to hallucinate text that then flows
+	// downstream as if it had been spoken. It produced a phantom duplicate
+	// transcript in the voice-sales-assist example.
+	if state.speechDetected || (!state.emittedTurn && len(live) > defaultMinAudioBytes) {
 		logger.Debug("AudioTurnStage: emitting remaining audio",
 			"speechDetected", state.speechDetected,
 			"bufferSize", len(live))
 		return s.emitTurnAudio(ctx, state, output)
 	}
+
+	logger.Debug("AudioTurnStage: dropping speechless remainder",
+		"bufferSize", len(live))
 	return nil
 }
 
@@ -492,6 +512,10 @@ func (s *AudioTurnStage) emitTurnAudio(
 
 	select {
 	case output <- elem:
+		// Records that the VAD has demonstrably produced a turn on this stream,
+		// which is what lets emitRemainingAudio drop a speechless tail without
+		// weakening the degrade-open path.
+		state.emittedTurn = true
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
Found by the voice-sales-assist example, which produced a phantom duplicate transcript once it was rebuilt against the merged audio fixes.

## Problem

When a turn completes mid-stream the buffer resets, and whatever silence arrives afterwards accumulates until EndOfStream. `emitRemainingAudio` then forwarded it **on size alone**, so any stream ending with more silence than the turn threshold produced a second, speechless "turn".

Measured in the example — one spoken utterance, one track:

| Turn | Size | Content |
|---|---|---|
| 1 | 62,080 B (~1.94 s) | 0.3 s speech + trailing silence — correct |
| 2 | 11,520 B (~0.36 s) | **pure silence, no speech** |

That second turn went to STT and came back as a duplicate transcript line. Downstream it is an STT call on pure silence: billed, slow, and a standing invitation for Whisper to hallucinate text that then flows on as if it had been spoken.

## Change

Emit the remainder when the turn contains speech, or — failing that — only when **no turn has been emitted for this stream at all**.

That second clause is what preserves the degrade-open path: a pre-recorded file whose VAD never fires is still forwarded whole rather than silently dropped, because the audio may contain speech the VAD misread. Once a turn *has* been emitted, the VAD is demonstrably working, so a speechless tail is just the silence that ended the previous turn.

`emittedTurn` is a property of the stream, not the turn, so `resetState` deliberately leaves it alone.

## Why the existing trim didn't catch it

`trimLeadingSilence` (#1617) returns the buffer untouched when no speech was detected — precisely to protect the same degrade-open case. So the two mechanisms are complementary rather than overlapping: the trim bounds what a *speech-bearing* turn sends, this bounds whether a *speechless* buffer is sent at all.

## Tests

- `TestAudioTurnStage_DoesNotEmitSpeechlessRemainderAfterATurn` — RED at 2 turns (`[1.6s 1.4s]`), green at 1.
- `TestAudioTurnStage_StillForwardsAudioWhenVADNeverFires` — degrade-open guard; passed before and after by design, since the fix must not touch that path.

Full runtime suite green with `-race`, 0 new lint findings, 86.0% coverage on the changed file.

Verified end-to-end: the voice-sales-assist suite, which was failing with 4 transcripts for 2 utterances, now passes in full.
