### PR TITLE
fix(audio): default AudioTurnStage to AdaptiveVAD; release promptly on silence

### DIFF
--- a/docs/src/content/docs/runtime/reference/audio.md
+++ b/docs/src/content/docs/runtime/reference/audio.md
@@ -30,7 +30,7 @@ Audio processing follows a two\-stage approach:
 ### Usage Example
 
 ```
-vad := audio.NewSimpleVAD(audio.DefaultVADParams())
+vad := audio.NewAdaptiveVAD(audio.DefaultVADParams())
 detector := audio.NewSilenceDetector(500 * time.Millisecond)
 
 for chunk := range audioStream {
@@ -862,7 +862,13 @@ WithMaxAudioBufferSize sets the maximum audio buffer size in bytes. When the buf
 <a name="SimpleVAD"></a>
 ## type SimpleVAD
 
-SimpleVAD is a basic voice activity detector using RMS \(Root Mean Square\) analysis. It provides a lightweight VAD implementation without requiring external ML models. For more accurate detection, consider using SileroVAD.
+SimpleVAD is a voice activity detector using a FIXED RMS threshold.
+
+Deprecated: use AdaptiveVAD. SimpleVAD's threshold does not track the input level, and the default mapping makes it insensitive to ordinary speech: RMS is scaled linearly between MinVolume \(0.01\) and maxExpectedRMS \(0.1\) against a 0.5 Confidence threshold, so nothing below \~0.055 RMS registers as speech. Conversational speech averages \~0.10 RMS but ranges far below that within a single utterance — a trailing word at 0.021 reads as silence, which closes the turn mid\-sentence and orphans the word.
+
+Measured against AdaptiveVAD across nine acoustic conditions and against TTS playback, SimpleVAD is worse or equal everywhere: it misses quiet speech \(0.04 RMS\), misses low\-level TTS entirely \(0.02 RMS\), reaches Speaking later at every level it does detect, and drops out of quiet tails. It false\-positives no less often. There is no input for which it is the better choice.
+
+It remains exported so existing callers keep compiling. Both AudioTurnStage and ResponseVADStage now default to AdaptiveVAD.
 
 SimpleVAD embeds \*vadStateMachine, which promotes State\(\), OnStateChange\(\), and base Reset\(\) — together they satisfy the VADAnalyzer interface.
 

--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -937,7 +937,9 @@ AudioTurnConfig configures the AudioTurnStage.
 ```go
 type AudioTurnConfig struct {
     // VAD is the voice activity detector.
-    // If nil, a SimpleVAD with default params is created.
+    // If nil, an AdaptiveVAD with default params is created — it tracks the
+    // noise floor rather than holding a fixed threshold, so it follows a speaker
+    // down through the quiet parts of an utterance.
     VAD audio.VADAnalyzer
 
     // TurnDetector determines when user has finished speaking.

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -346,6 +346,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func WithTruncation\(strategy string\) Option](<#WithTruncation>)
   - [func WithTurnDetector\(detector audio.TurnDetector\) Option](<#WithTurnDetector>)
   - [func WithUserID\(id string\) Option](<#WithUserID>)
+  - [func WithVAD\(vad audio.VADAnalyzer\) Option](<#WithVAD>)
   - [func WithVADMode\(sttService stt.Service, ttsService tts.Service, cfg \*VADModeConfig\) Option](<#WithVADMode>)
   - [func WithVariableProvider\(p variables.Provider\) Option](<#WithVariableProvider>)
   - [func WithVariables\(vars map\[string\]string\) Option](<#WithVariables>)
@@ -4130,6 +4131,25 @@ conv, _ := sdk.Open("./chat.pack.json", "assistant",
 )
 ```
 
+<a name="WithVAD"></a>
+### func WithVAD
+
+```go
+func WithVAD(vad audio.VADAnalyzer) Option
+```
+
+WithVAD supplies the voice activity detector used for audio sessions.
+
+The detector decides what counts as speech, which governs where turns begin and end. The default \(AdaptiveVAD\) tracks the ambient noise floor and suits general microphone input; supply your own when you have a better model or acoustics it does not handle — telephony codecs, a far\-field array, or an ML detector.
+
+Implement audio.VADAnalyzer; the interface depends on no runtime internals.
+
+```
+conv, _ := sdk.Open("./assistant.pack.json", "voice",
+    sdk.WithVAD(myDetector),
+)
+```
+
 <a name="WithVADMode"></a>
 ### func WithVADMode
 
@@ -5579,6 +5599,12 @@ type VADModeConfig struct {
     // Speed is the TTS speech rate (0.5-2.0).
     // Default: 1.0
     Speed float64
+
+    // VAD is the voice activity detector deciding what counts as speech, and so
+    // where turns begin and end.
+    // If nil, an AdaptiveVAD tuned for general microphone input is used.
+    // Also settable via the WithVAD option.
+    VAD audio.VADAnalyzer
 }
 ```
 

--- a/runtime/audio/adaptive_vad.go
+++ b/runtime/audio/adaptive_vad.go
@@ -6,9 +6,25 @@ import (
 )
 
 const (
-	// adaptiveSmoothingAlpha is the weight given to the current RMS frame when
-	// computing the exponential moving average (lower = more smoothing).
+	// adaptiveSmoothingAlpha is the weight given to the current RMS frame while
+	// the level is RISING (lower = more smoothing). Attack is deliberately
+	// gentle: a single loud frame should not be enough to declare speech.
 	adaptiveSmoothingAlpha = 0.3
+	// adaptiveReleaseAlpha is the weight used while the level is FALLING.
+	//
+	// Release is much faster than attack. With a symmetric factor the level
+	// estimate decays slowly from a high value however abruptly the audio stops,
+	// so the detector kept reporting Speaking for 600ms after true silence
+	// against SimpleVAD's 200ms. AudioTurnStage's silence budget only accrues
+	// once the VAD leaves Speaking, so that lag is added to every turn boundary
+	// and merges utterances separated by shorter pauses.
+	//
+	// Releasing quickly does not cost tail retention: holding through a quiet
+	// trailing word comes from the threshold tracking the noise floor, not from
+	// the smoothing lag. Real silence collapses the level to zero and the
+	// detector releases; quiet speech stays above an adaptive threshold and
+	// holds.
+	adaptiveReleaseAlpha = 0.7
 	// adaptiveSpeechRatio is the multiplier applied to the noise floor to derive
 	// the speech threshold. Speech must be this many times louder than background.
 	adaptiveSpeechRatio = 3.0
@@ -89,8 +105,13 @@ func (v *AdaptiveVAD) Analyze(_ context.Context, audioData []byte) (float64, err
 
 	v.mu.Lock()
 
-	// Exponential moving average of RMS (0.3 × current + 0.7 × history).
-	v.smoothedRMS = adaptiveSmoothingAlpha*rms + (1-adaptiveSmoothingAlpha)*v.smoothedRMS
+	// Exponential moving average of RMS, with a faster factor while falling so
+	// the detector releases promptly when audio actually stops.
+	alpha := adaptiveSmoothingAlpha
+	if rms < v.smoothedRMS {
+		alpha = adaptiveReleaseAlpha
+	}
+	v.smoothedRMS = alpha*rms + (1-alpha)*v.smoothedRMS
 	smoothed := v.smoothedRMS
 	floor := v.noiseFloor
 

--- a/runtime/audio/adaptive_vad_release_test.go
+++ b/runtime/audio/adaptive_vad_release_test.go
@@ -1,0 +1,91 @@
+package audio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// feedSpeechThenTail runs 1s of speech at loudRMS, then tailChunks of tailRMS,
+// and reports the chunk index (1-based, 100ms each) at which the VAD stopped
+// reporting Speaking, or -1 if it never did.
+func feedSpeechThenTail(t *testing.T, v audio.VADAnalyzer, loudRMS, tailRMS float64, tailChunks int) int {
+	t.Helper()
+	ctx := context.Background()
+
+	for range 10 {
+		if _, err := v.Analyze(ctx, pcmAtRMS(cmpChunkSamples, loudRMS)); err != nil {
+			t.Fatalf("Analyze speech: %v", err)
+		}
+	}
+	if v.State() != audio.VADStateSpeaking {
+		t.Fatalf("VAD did not reach Speaking on 1s of %.2f RMS speech (got %v)", loudRMS, v.State())
+	}
+
+	for i := range tailChunks {
+		var chunk []byte
+		if tailRMS == 0 {
+			chunk = make([]byte, cmpChunkSamples*2)
+		} else {
+			chunk = pcmAtRMS(cmpChunkSamples, tailRMS)
+		}
+		if _, err := v.Analyze(ctx, chunk); err != nil {
+			t.Fatalf("Analyze tail: %v", err)
+		}
+		if v.State() != audio.VADStateSpeaking {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// TestAdaptiveVADReleasesPromptlyOnSilence covers release lag.
+//
+// AudioTurnStage counts Stopping and Quiet as silence, so its SilenceDuration
+// budget only begins accruing once the VAD leaves Speaking. Every millisecond
+// spent lingering is added to the end of every turn — latency the caller feels
+// before a response starts, and, when it exceeds the gap between two
+// utterances, the reason they merge into a single turn instead of segmenting.
+//
+// Measured at 600ms against SimpleVAD's 200ms, caused by a symmetric smoothing
+// factor: the level estimate decays slowly from a high value regardless of how
+// abruptly the audio stops.
+func TestAdaptiveVADReleasesPromptlyOnSilence(t *testing.T) {
+	v, err := audio.NewAdaptiveVAD(audio.DefaultVADParams())
+	if err != nil {
+		t.Fatalf("NewAdaptiveVAD: %v", err)
+	}
+
+	left := feedSpeechThenTail(t, v, 0.10, 0, 30)
+	if left < 0 {
+		t.Fatalf("VAD never left Speaking across 3s of true silence")
+	}
+
+	const maxChunks = 3 // 300ms
+	if left > maxChunks {
+		t.Errorf("VAD held Speaking for %dms after speech stopped, want <=%dms; "+
+			"the lag is added to every turn boundary and merges utterances "+
+			"separated by shorter pauses", left*100, maxChunks*100)
+	}
+}
+
+// TestAdaptiveVADHoldsThroughQuietTail guards the property a faster release must
+// not cost us.
+//
+// A trailing word measured at 0.021 RMS is real speech, not the end of a turn.
+// Releasing on it closes the turn mid-utterance and orphans the word — the
+// original "742 Evergreen Terrace, Springfield" defect. The detector must
+// distinguish quiet speech from actual silence rather than simply reacting
+// faster to everything.
+func TestAdaptiveVADHoldsThroughQuietTail(t *testing.T) {
+	v, err := audio.NewAdaptiveVAD(audio.DefaultVADParams())
+	if err != nil {
+		t.Fatalf("NewAdaptiveVAD: %v", err)
+	}
+
+	if left := feedSpeechThenTail(t, v, 0.10, 0.021, 10); left > 0 {
+		t.Errorf("VAD left Speaking %dms into a 0.021 RMS speech tail; "+
+			"quiet trailing speech must not read as end-of-turn", left*100)
+	}
+}

--- a/runtime/audio/doc.go
+++ b/runtime/audio/doc.go
@@ -16,7 +16,7 @@
 //
 // # Usage Example
 //
-//	vad := audio.NewSimpleVAD(audio.DefaultVADParams())
+//	vad := audio.NewAdaptiveVAD(audio.DefaultVADParams())
 //	detector := audio.NewSilenceDetector(500 * time.Millisecond)
 //
 //	for chunk := range audioStream {

--- a/runtime/audio/simple_vad.go
+++ b/runtime/audio/simple_vad.go
@@ -25,9 +25,24 @@ const (
 	maxExpectedRMS = 0.1
 )
 
-// SimpleVAD is a basic voice activity detector using RMS (Root Mean Square) analysis.
-// It provides a lightweight VAD implementation without requiring external ML models.
-// For more accurate detection, consider using SileroVAD.
+// SimpleVAD is a voice activity detector using a FIXED RMS threshold.
+//
+// Deprecated: use AdaptiveVAD. SimpleVAD's threshold does not track the input
+// level, and the default mapping makes it insensitive to ordinary speech: RMS is
+// scaled linearly between MinVolume (0.01) and maxExpectedRMS (0.1) against a
+// 0.5 Confidence threshold, so nothing below ~0.055 RMS registers as speech.
+// Conversational speech averages ~0.10 RMS but ranges far below that within a
+// single utterance — a trailing word at 0.021 reads as silence, which closes the
+// turn mid-sentence and orphans the word.
+//
+// Measured against AdaptiveVAD across nine acoustic conditions and against TTS
+// playback, SimpleVAD is worse or equal everywhere: it misses quiet speech
+// (0.04 RMS), misses low-level TTS entirely (0.02 RMS), reaches Speaking later
+// at every level it does detect, and drops out of quiet tails. It false-positives
+// no less often. There is no input for which it is the better choice.
+//
+// It remains exported so existing callers keep compiling. Both AudioTurnStage
+// and ResponseVADStage now default to AdaptiveVAD.
 //
 // SimpleVAD embeds *vadStateMachine, which promotes State(), OnStateChange(), and
 // base Reset() — together they satisfy the VADAnalyzer interface.

--- a/runtime/audio/vad_comparison_test.go
+++ b/runtime/audio/vad_comparison_test.go
@@ -1,0 +1,336 @@
+package audio_test
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// Comparative characterization of the VAD implementations across realistic
+// acoustic conditions. Reports rather than asserts: the point is to establish
+// what each detector actually does before choosing a default, not to freeze
+// current behavior as a contract.
+//
+// Run: go test ./runtime/audio/ -run TestVADComparisonMatrix -v
+
+const (
+	cmpSampleRate   = 16000
+	cmpChunkSamples = cmpSampleRate / 10 // 100 ms
+)
+
+// pcmAtRMS returns `samples` of sine scaled to approximately the target RMS.
+// A full-scale sine has RMS = amplitude/sqrt(2), so amplitude = rms*sqrt(2).
+func pcmAtRMS(samples int, targetRMS float64) []byte {
+	amp := targetRMS * math.Sqrt2
+	b := make([]byte, samples*2)
+	for i := range samples {
+		v := int16(amp * 32767 * math.Sin(float64(i)*0.2))
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(v))
+	}
+	return b
+}
+
+// noiseAtRMS returns `samples` of deterministic white noise at approximately the
+// target RMS. Uniform noise on [-a,a] has RMS = a/sqrt(3).
+func noiseAtRMS(samples int, targetRMS float64, seed int64) []byte {
+	r := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic test signal
+	amp := targetRMS * math.Sqrt(3)
+	b := make([]byte, samples*2)
+	for i := range samples {
+		v := int16(amp * 32767 * (r.Float64()*2 - 1))
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(v))
+	}
+	return b
+}
+
+// mixPCM sums two equal-length PCM16 buffers with clipping.
+func mixPCM(a, b []byte) []byte {
+	out := make([]byte, len(a))
+	for i := 0; i+1 < len(a); i += 2 {
+		x := int32(int16(binary.LittleEndian.Uint16(a[i:])))
+		y := int32(int16(binary.LittleEndian.Uint16(b[i:])))
+		s := x + y
+		if s > math.MaxInt16 {
+			s = math.MaxInt16
+		} else if s < math.MinInt16 {
+			s = math.MinInt16
+		}
+		binary.LittleEndian.PutUint16(out[i:], uint16(int16(s)))
+	}
+	return out
+}
+
+// vadRun feeds chunks and reports when (if ever) the VAD reported Speaking.
+type vadRun struct {
+	reachedSpeaking bool
+	chunkAtSpeaking int
+	finalState      audio.VADState
+}
+
+func runVAD(t *testing.T, v audio.VADAnalyzer, chunks [][]byte) vadRun {
+	t.Helper()
+	ctx := context.Background()
+	res := vadRun{chunkAtSpeaking: -1}
+	for i, c := range chunks {
+		if _, err := v.Analyze(ctx, c); err != nil {
+			t.Fatalf("Analyze: %v", err)
+		}
+		if v.State() == audio.VADStateSpeaking && !res.reachedSpeaking {
+			res.reachedSpeaking = true
+			res.chunkAtSpeaking = i + 1
+		}
+	}
+	res.finalState = v.State()
+	return res
+}
+
+func repeatChunks(gen func() []byte, n int) [][]byte {
+	out := make([][]byte, n)
+	for i := range out {
+		out[i] = gen()
+	}
+	return out
+}
+
+// TestVADComparisonMatrix reports SimpleVAD vs AdaptiveVAD across conditions.
+//
+// "Detected" means the detector reached VADStateSpeaking, which is the state
+// SilenceDetector and InterruptionHandler key on. For speech rows detection is
+// desirable; for the silence and noise rows it is a false positive.
+func TestVADComparisonMatrix(t *testing.T) {
+	const secs = 2
+	const nChunks = secs * 10
+
+	// Room noise at ~0.005 RMS, the level of a quiet office mic floor.
+	const roomNoiseRMS = 0.005
+
+	cases := []struct {
+		name     string
+		gen      func() []byte
+		isSpeech bool
+	}{
+		{name: "digital silence", gen: func() []byte { return make([]byte, cmpChunkSamples*2) }},
+		{name: "room noise 0.005", gen: func() []byte { return noiseAtRMS(cmpChunkSamples, roomNoiseRMS, 1) }},
+		{name: "loud room noise 0.02", gen: func() []byte { return noiseAtRMS(cmpChunkSamples, 0.02, 2) }},
+		{name: "very quiet speech 0.02", gen: func() []byte { return pcmAtRMS(cmpChunkSamples, 0.02) }, isSpeech: true},
+		{name: "quiet speech 0.04", gen: func() []byte { return pcmAtRMS(cmpChunkSamples, 0.04) }, isSpeech: true},
+		{name: "normal speech 0.10", gen: func() []byte { return pcmAtRMS(cmpChunkSamples, 0.10) }, isSpeech: true},
+		{name: "loud speech 0.25", gen: func() []byte { return pcmAtRMS(cmpChunkSamples, 0.25) }, isSpeech: true},
+		{
+			name: "quiet speech over room noise",
+			gen: func() []byte {
+				return mixPCM(pcmAtRMS(cmpChunkSamples, 0.02), noiseAtRMS(cmpChunkSamples, roomNoiseRMS, 3))
+			},
+			isSpeech: true,
+		},
+		{
+			name: "normal speech over room noise",
+			gen: func() []byte {
+				return mixPCM(pcmAtRMS(cmpChunkSamples, 0.10), noiseAtRMS(cmpChunkSamples, roomNoiseRMS, 4))
+			},
+			isSpeech: true,
+		},
+	}
+
+	t.Logf("%-32s | %-24s | %-24s", "condition", "SimpleVAD", "AdaptiveVAD")
+	t.Logf("%-32s-+-%-24s-+-%-24s", "--------------------------------", "------------------------", "------------------------")
+
+	var simpleWrong, adaptiveWrong int
+
+	for _, tc := range cases {
+		chunks := repeatChunks(tc.gen, nChunks)
+
+		sv, err := audio.NewSimpleVAD(audio.DefaultVADParams())
+		if err != nil {
+			t.Fatalf("NewSimpleVAD: %v", err)
+		}
+		av, err := audio.NewAdaptiveVAD(audio.DefaultVADParams())
+		if err != nil {
+			t.Fatalf("NewAdaptiveVAD: %v", err)
+		}
+
+		s := runVAD(t, sv, chunks)
+		a := runVAD(t, av, chunks)
+
+		fmtRes := func(r vadRun) string {
+			if !r.reachedSpeaking {
+				return "no speech (" + r.finalState.String() + ")"
+			}
+			return "SPEECH @ chunk " + itoa(r.chunkAtSpeaking) + " (" + itoa(r.chunkAtSpeaking*100) + "ms)"
+		}
+
+		mark := func(r vadRun) string {
+			if r.reachedSpeaking == tc.isSpeech {
+				return "  ok"
+			}
+			if tc.isSpeech {
+				return " MISS"
+			}
+			return " FALSE+"
+		}
+
+		if s.reachedSpeaking != tc.isSpeech {
+			simpleWrong++
+		}
+		if a.reachedSpeaking != tc.isSpeech {
+			adaptiveWrong++
+		}
+
+		t.Logf("%-32s | %-24s%s | %-24s%s", tc.name, fmtRes(s), mark(s), fmtRes(a), mark(a))
+	}
+
+	t.Logf("")
+	t.Logf("incorrect classifications: SimpleVAD=%d/%d  AdaptiveVAD=%d/%d",
+		simpleWrong, len(cases), adaptiveWrong, len(cases))
+}
+
+// TestVADQuietTailMatrix reports whether each VAD holds Speaking through the
+// quiet end of an utterance.
+//
+// This is the failure mode that dropped "Springfield" from "742 Evergreen
+// Terrace, Springfield": the trailing word measured 0.021 RMS. What matters is
+// not whether a detector can find 0.02 speech from cold — neither can — but
+// whether one already in Speaking stays there when the speaker tails off, or
+// falls to Quiet and lets the turn close mid-utterance.
+//
+// The final state after the quiet tail is the signal. Speaking or Stopping means
+// the turn survives; Quiet means it was cut.
+func TestVADQuietTailMatrix(t *testing.T) {
+	cases := []struct {
+		name     string
+		loudRMS  float64
+		tailRMS  float64
+		tailSecs int
+	}{
+		{name: "0.10 then 0.021 tail (Springfield)", loudRMS: 0.10, tailRMS: 0.021, tailSecs: 1},
+		{name: "0.10 then 0.04 tail", loudRMS: 0.10, tailRMS: 0.04, tailSecs: 1},
+		{name: "0.10 then 0.01 tail (very soft)", loudRMS: 0.10, tailRMS: 0.01, tailSecs: 1},
+		{name: "0.10 then true silence", loudRMS: 0.10, tailRMS: 0, tailSecs: 1},
+	}
+
+	t.Logf("%-38s | %-14s | %-14s", "utterance", "SimpleVAD", "AdaptiveVAD")
+	t.Logf("%-38s-+-%-14s-+-%-14s", "--------------------------------------", "--------------", "--------------")
+
+	for _, tc := range cases {
+		build := func() [][]byte {
+			var chunks [][]byte
+			for range 10 { // 1s of normal speech to establish Speaking
+				chunks = append(chunks, pcmAtRMS(cmpChunkSamples, tc.loudRMS))
+			}
+			for range tc.tailSecs * 10 {
+				if tc.tailRMS == 0 {
+					chunks = append(chunks, make([]byte, cmpChunkSamples*2))
+				} else {
+					chunks = append(chunks, pcmAtRMS(cmpChunkSamples, tc.tailRMS))
+				}
+			}
+			return chunks
+		}
+
+		sv, err := audio.NewSimpleVAD(audio.DefaultVADParams())
+		if err != nil {
+			t.Fatalf("NewSimpleVAD: %v", err)
+		}
+		av, err := audio.NewAdaptiveVAD(audio.DefaultVADParams())
+		if err != nil {
+			t.Fatalf("NewAdaptiveVAD: %v", err)
+		}
+
+		s := runVAD(t, sv, build())
+		a := runVAD(t, av, build())
+
+		verdict := func(r vadRun) string {
+			switch r.finalState {
+			case audio.VADStateQuiet:
+				return "CUT (quiet)"
+			default:
+				return "held (" + r.finalState.String() + ")"
+			}
+		}
+
+		t.Logf("%-38s | %-14s | %-14s", tc.name, verdict(s), verdict(a))
+	}
+
+	t.Logf("")
+	t.Logf("'CUT' on a speech tail closes the turn mid-utterance and orphans the trailing word.")
+	t.Logf("'CUT' on true silence is correct — that is a real end of turn.")
+}
+
+// TestVADReleaseLagMatrix reports how long each VAD keeps reporting Speaking
+// after speech actually stops.
+//
+// This is the cost side of a more sensitive detector. AudioTurnStage counts both
+// Stopping and Quiet as silence, so its SilenceDuration budget only starts
+// accruing once the VAD leaves Speaking. A detector that lingers eats into that
+// budget: two utterances separated by a pause shorter than (release lag +
+// SilenceDuration) merge into one turn instead of segmenting.
+func TestVADReleaseLagMatrix(t *testing.T) {
+	const speechChunks = 10 // 1s to establish Speaking
+	const silenceChunks = 30
+
+	measure := func(v audio.VADAnalyzer) (leftSpeakingMS, reachedQuietMS int) {
+		ctx := context.Background()
+		leftSpeakingMS, reachedQuietMS = -1, -1
+		for range speechChunks {
+			if _, err := v.Analyze(ctx, pcmAtRMS(cmpChunkSamples, 0.10)); err != nil {
+				t.Fatalf("Analyze: %v", err)
+			}
+		}
+		silent := make([]byte, cmpChunkSamples*2)
+		for i := range silenceChunks {
+			if _, err := v.Analyze(ctx, silent); err != nil {
+				t.Fatalf("Analyze: %v", err)
+			}
+			ms := (i + 1) * 100
+			if v.State() != audio.VADStateSpeaking && leftSpeakingMS < 0 {
+				leftSpeakingMS = ms
+			}
+			if v.State() == audio.VADStateQuiet && reachedQuietMS < 0 {
+				reachedQuietMS = ms
+			}
+		}
+		return leftSpeakingMS, reachedQuietMS
+	}
+
+	sv, err := audio.NewSimpleVAD(audio.DefaultVADParams())
+	if err != nil {
+		t.Fatalf("NewSimpleVAD: %v", err)
+	}
+	av, err := audio.NewAdaptiveVAD(audio.DefaultVADParams())
+	if err != nil {
+		t.Fatalf("NewAdaptiveVAD: %v", err)
+	}
+
+	sLeft, sQuiet := measure(sv)
+	aLeft, aQuiet := measure(av)
+
+	t.Logf("after speech stops (true silence):")
+	t.Logf("  SimpleVAD   left Speaking @ %dms, reached Quiet @ %dms", sLeft, sQuiet)
+	t.Logf("  AdaptiveVAD left Speaking @ %dms, reached Quiet @ %dms", aLeft, aQuiet)
+	t.Logf("")
+	t.Logf("AudioTurnStage's SilenceDuration budget only accrues once the VAD leaves")
+	t.Logf("Speaking, so the difference in 'left Speaking' is added to every turn boundary.")
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(b)
+	}
+	return string(b)
+}

--- a/runtime/audio/vad_tts_comparison_test.go
+++ b/runtime/audio/vad_tts_comparison_test.go
@@ -1,0 +1,108 @@
+package audio_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// ResponseVADStage's params, mirrored from runtime/pipeline/stage/stages_speech.go.
+// They differ substantially from the microphone defaults: a lower confidence
+// bar and min volume, much faster start, faster stop, and a 24kHz rate.
+func responseVADParams() audio.VADParams {
+	p := audio.DefaultVADParams()
+	p.Confidence = 0.3
+	p.StartSecs = 0.05
+	p.StopSecs = 0.3
+	p.MinVolume = 0.005
+	p.SampleRate = 24000
+	return p
+}
+
+// TestResponseVADComparison reports SimpleVAD vs AdaptiveVAD under the params
+// and signal characteristics of TTS OUTPUT detection, which is a different
+// problem from microphone input.
+//
+// ResponseVADStage watches the assistant's own synthesized audio to confirm a
+// response has finished. That signal is normalized and predictable — the failure
+// modes that make a fixed threshold wrong for a microphone (quiet speakers,
+// trailing syllables below the bar) largely do not arise. What matters here is
+// reliable detection of playback and prompt release when it stops.
+//
+// Reports rather than asserts: this exists to decide whether the mic-side
+// default change should extend to this stage, not to freeze behavior.
+func TestResponseVADComparison(t *testing.T) {
+	const chunkSamples = 2400 // 100 ms @ 24kHz
+
+	// TTS output is normalized and sits high; include a quieter case for a
+	// provider that renders at a lower level.
+	levels := []struct {
+		name string
+		rms  float64
+	}{
+		{name: "loud TTS 0.20", rms: 0.20},
+		{name: "normal TTS 0.10", rms: 0.10},
+		{name: "quiet TTS 0.05", rms: 0.05},
+		{name: "very quiet TTS 0.02", rms: 0.02},
+	}
+
+	t.Logf("DETECTION of TTS playback (chunks to Speaking, 100ms each)")
+	t.Logf("%-24s | %-22s | %-22s", "level", "SimpleVAD", "AdaptiveVAD")
+	for _, lv := range levels {
+		chunks := repeatChunks(func() []byte { return pcmAtRMS(chunkSamples, lv.rms) }, 20)
+
+		sv, err := audio.NewSimpleVAD(responseVADParams())
+		if err != nil {
+			t.Fatalf("NewSimpleVAD: %v", err)
+		}
+		av, err := audio.NewAdaptiveVAD(responseVADParams())
+		if err != nil {
+			t.Fatalf("NewAdaptiveVAD: %v", err)
+		}
+
+		s := runVAD(t, sv, chunks)
+		a := runVAD(t, av, chunks)
+
+		f := func(r vadRun) string {
+			if !r.reachedSpeaking {
+				return "NOT DETECTED"
+			}
+			return "detected @ " + itoa(r.chunkAtSpeaking*100) + "ms"
+		}
+		t.Logf("%-24s | %-22s | %-22s", lv.name, f(s), f(a))
+	}
+
+	t.Logf("")
+	t.Logf("RELEASE after playback stops (playback 1s @0.10, then silence)")
+
+	measureRelease := func(v audio.VADAnalyzer) string {
+		ctx := context.Background()
+		for range 10 {
+			if _, err := v.Analyze(ctx, pcmAtRMS(chunkSamples, 0.10)); err != nil {
+				t.Fatalf("Analyze: %v", err)
+			}
+		}
+		silent := make([]byte, chunkSamples*2)
+		for i := range 30 {
+			if _, err := v.Analyze(ctx, silent); err != nil {
+				t.Fatalf("Analyze: %v", err)
+			}
+			if v.State() == audio.VADStateQuiet {
+				return "quiet @ " + itoa((i+1)*100) + "ms"
+			}
+		}
+		return "never reached quiet"
+	}
+
+	sv, err := audio.NewSimpleVAD(responseVADParams())
+	if err != nil {
+		t.Fatalf("NewSimpleVAD: %v", err)
+	}
+	av, err := audio.NewAdaptiveVAD(responseVADParams())
+	if err != nil {
+		t.Fatalf("NewAdaptiveVAD: %v", err)
+	}
+	t.Logf("  SimpleVAD   %s", measureRelease(sv))
+	t.Logf("  AdaptiveVAD %s", measureRelease(av))
+}

--- a/runtime/pipeline/stage/audioturn_defaultvad_test.go
+++ b/runtime/pipeline/stage/audioturn_defaultvad_test.go
@@ -1,0 +1,95 @@
+package stage_test
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// quietSpeechPCM returns sine at ~0.04 RMS — quiet but unambiguous conversational
+// speech, well above a room-noise floor (~0.005) and far above digital silence.
+func quietSpeechPCM(samples int) []byte {
+	const targetRMS = 0.04
+	amp := targetRMS * math.Sqrt2
+	b := make([]byte, samples*2)
+	for i := range samples {
+		v := int16(amp * 32767 * math.Sin(float64(i)*0.2))
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(v))
+	}
+	return b
+}
+
+// TestAudioTurnStage_DefaultVADDetectsQuietSpeech covers the stage's default VAD
+// failing to recognize quiet speech as speech at all.
+//
+// The default was SimpleVAD, which maps RMS to probability linearly between
+// MinVolume (0.01) and maxExpectedRMS (0.1) and compares against a 0.5
+// Confidence threshold — so nothing below ~0.055 RMS is ever speech.
+// Conversational speech averages ~0.10 RMS but ranges well under that: a
+// measured 0.04 RMS passage scores 0.33 and is classified as silence.
+//
+// Measured across conditions, AdaptiveVAD detects this where SimpleVAD does not,
+// detects normal speech sooner (300ms vs 500ms), and holds through quiet tails,
+// while false-positive behavior on silence and room noise is identical.
+//
+// Observed through a turn detector, which receives every VAD state the stage
+// computes. A turn is emitted either way at EndOfStream (the degrade-open path),
+// so segmentation alone would not reveal whether the VAD ever saw speech.
+func TestAudioTurnStage_DefaultVADDetectsQuietSpeech(t *testing.T) {
+	spy := &spyTurnDetector{}
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.TurnDetector = spy // leave cfg.VAD nil so the stage picks its default
+
+	const chunkSamples = 1600 // 100 ms
+
+	runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		for range 20 { // 2s of quiet speech
+			in <- makeAudioElement(quietSpeechPCM(chunkSamples), 16000)
+		}
+	})
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+
+	sawSpeaking := false
+	for _, s := range spy.states {
+		if s == audio.VADStateSpeaking {
+			sawSpeaking = true
+			break
+		}
+	}
+
+	if !sawSpeaking {
+		t.Errorf("the stage's default VAD never reported speech across 2s of 0.04 RMS speech; "+
+			"a fixed-threshold default classifies quiet conversational speech as silence "+
+			"(states seen: %v)", spy.states)
+	}
+}
+
+// TestAudioTurnStage_DefaultVADIgnoresRoomNoise is the counterpart: a more
+// sensitive default must not start treating a quiet mic's noise floor as speech.
+func TestAudioTurnStage_DefaultVADIgnoresRoomNoise(t *testing.T) {
+	spy := &spyTurnDetector{}
+	cfg := stage.DefaultAudioTurnConfig()
+	cfg.TurnDetector = spy
+
+	const chunkSamples = 1600
+
+	runTurnStage(t, cfg, func(in chan<- stage.StreamElement) {
+		for range 20 { // 2s of digital silence
+			in <- makeAudioElement(vadSilencePCM(chunkSamples), 16000)
+		}
+	})
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+
+	for _, s := range spy.states {
+		if s == audio.VADStateSpeaking {
+			t.Fatalf("the default VAD reported speech over silence (states: %v)", spy.states)
+		}
+	}
+}

--- a/runtime/pipeline/stage/response_vad_quiet_test.go
+++ b/runtime/pipeline/stage/response_vad_quiet_test.go
@@ -1,0 +1,95 @@
+package stage_test
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+)
+
+// ttsPCM returns `samples` of sine at the given RMS, for 24kHz TTS output.
+func ttsPCM(samples int, targetRMS float64) []byte {
+	amp := targetRMS * math.Sqrt2
+	b := make([]byte, samples*2)
+	for i := range samples {
+		v := int16(amp * 32767 * math.Sin(float64(i)*0.2))
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(v))
+	}
+	return b
+}
+
+// TestResponseVADStage_HoldsEndOfStreamThroughQuietPlayback covers the stage
+// releasing EndOfStream while the assistant is still speaking.
+//
+// ResponseVADStage delays EndOfStream until the response audio stops, so a
+// consumer does not treat a turn as finished mid-sentence. That depends
+// entirely on its VAD recognizing playback as speech: if the audio reads as
+// silence, the silence timer starts immediately and EndOfStream is released
+// while audio is still streaming.
+//
+// A fixed-threshold VAD does not detect TTS at 0.02 RMS at all — measured NOT
+// DETECTED against these very params — so any provider rendering at a low level
+// ends its turns early.
+func TestResponseVADStage_HoldsEndOfStreamThroughQuietPlayback(t *testing.T) {
+	cfg := stage.DefaultResponseVADConfig()
+	cfg.SampleRate = 24000
+	cfg.SilenceDuration = 300 * time.Millisecond
+
+	s, err := stage.NewResponseVADStage(cfg)
+	if err != nil {
+		t.Fatalf("NewResponseVADStage: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	input := make(chan stage.StreamElement)
+	output := make(chan stage.StreamElement, 64)
+	go func() { _ = s.Process(ctx, input, output) }()
+
+	const chunkSamples = 2400 // 100 ms @ 24kHz
+	quietTTS := func() stage.StreamElement {
+		return makeAudioElement(ttsPCM(chunkSamples, 0.02), 24000)
+	}
+
+	// Playback is real-time paced: this stage's silence window is wall-clock.
+	go func() {
+		for range 5 {
+			input <- quietTTS()
+			time.Sleep(100 * time.Millisecond)
+		}
+		// Provider signals end of response while audio is still streaming.
+		input <- stage.StreamElement{EndOfStream: true}
+		// Playback continues far past SilenceDuration (1.5s vs 300ms), so a
+		// stage that starts its silence window immediately releases EndOfStream
+		// well inside the observation period rather than marginally at its edge.
+		for range 15 {
+			input <- quietTTS()
+			time.Sleep(100 * time.Millisecond)
+		}
+		close(input)
+	}()
+
+	// Watch for EndOfStream arriving while playback is still in flight.
+	deadline := time.After(1400 * time.Millisecond)
+	for {
+		select {
+		case elem, ok := <-output:
+			if !ok {
+				return
+			}
+			if elem.EndOfStream {
+				t.Fatal("EndOfStream released while quiet TTS playback was still streaming; " +
+					"the stage's VAD is not detecting low-level TTS as speech, so the " +
+					"silence window starts immediately and turns end mid-sentence")
+			}
+		case <-deadline:
+			return // held correctly for the duration of playback
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -18,7 +18,9 @@ import (
 // AudioTurnConfig configures the AudioTurnStage.
 type AudioTurnConfig struct {
 	// VAD is the voice activity detector.
-	// If nil, a SimpleVAD with default params is created.
+	// If nil, an AdaptiveVAD with default params is created — it tracks the
+	// noise floor rather than holding a fixed threshold, so it follows a speaker
+	// down through the quiet parts of an utterance.
 	VAD audio.VADAnalyzer
 
 	// TurnDetector determines when user has finished speaking.
@@ -119,17 +121,35 @@ func NewAudioTurnStage(config AudioTurnConfig) (*AudioTurnStage, error) {
 
 	// Create default VAD if not provided.
 	//
-	// The VAD's params must carry the configured sample rate, not the default.
-	// VAD state transitions are scaled by it — it is how a chunk's byte count
-	// becomes a duration — so leaving it at 16kHz makes the VAD and this stage
-	// disagree about how long a chunk lasts at any other rate: 8kHz telephony
-	// would see every threshold at twice its intended length, 48kHz at a third.
+	// AdaptiveVAD, not SimpleVAD. SimpleVAD maps RMS to probability linearly
+	// between MinVolume (0.01) and maxExpectedRMS (0.1) against a 0.5 Confidence
+	// threshold, so it only calls audio speech above ~0.055 RMS. Conversational
+	// speech averages ~0.10 RMS but ranges far below that within one utterance,
+	// and a trailing word measured at 0.021 read as silence — closing the turn
+	// mid-sentence and orphaning the word.
+	//
+	// Measured across conditions, AdaptiveVAD dominates: it detects quiet speech
+	// (0.04 RMS) that SimpleVAD misses, reaches Speaking sooner on normal speech
+	// (300ms vs 500ms), and holds through quiet tails, with identical
+	// false-positive behavior on digital silence and room noise up to 0.02 RMS.
+	// Its one trade is reaching Quiet more slowly after speech ends, because its
+	// smoothed estimate decays from a higher level — which does not affect this
+	// stage (Stopping already counts as silence for turn completion) but does
+	// delay a TurnDetector that keys on Quiet.
+	//
+	// SimpleVAD remains exported for callers that want a fixed threshold.
+	//
+	// The params must carry the configured sample rate, not the default. VAD
+	// state transitions are scaled by it — it is how a chunk's byte count becomes
+	// a duration — so leaving it at 16kHz makes the VAD and this stage disagree
+	// about how long a chunk lasts at any other rate: 8kHz telephony would see
+	// every threshold at twice its intended length, 48kHz at a third.
 	vad := config.VAD
 	if vad == nil {
 		params := audio.DefaultVADParams()
 		params.SampleRate = config.SampleRate
 		var err error
-		vad, err = audio.NewSimpleVAD(params)
+		vad, err = audio.NewAdaptiveVAD(params)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -1141,8 +1141,14 @@ func NewResponseVADStage(config ResponseVADConfig) (*ResponseVADStage, error) {
 			params.SampleRate = defaultResponseVADSampleRate
 		}
 
+		// AdaptiveVAD here too. TTS output was assumed predictable enough for a
+		// fixed threshold, but measured against these very params it is not:
+		// SimpleVAD does not detect 0.02 RMS playback at all, and is slower at
+		// every level it does detect (0.05 RMS at 500ms vs 200ms). Undetected
+		// playback starts the silence window immediately, releasing EndOfStream
+		// while the assistant is still speaking.
 		var err error
-		vad, err = audio.NewSimpleVAD(params)
+		vad, err = audio.NewAdaptiveVAD(params)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -623,6 +623,13 @@ func (c *Conversation) buildStreamPipelineWithParams(
 			audioTurnCfg.TurnDetector = c.config.turnDetector
 		}
 
+		// Wire custom VAD from WithVAD option. Takes precedence over any VAD set
+		// directly on VADModeConfig, since the option is the more specific
+		// expression of intent.
+		if c.config.vad != nil {
+			audioTurnCfg.VAD = c.config.vad
+		}
+
 		sttCfg := vadCfg.toSTTStageConfig()
 		ttsCfg := vadCfg.toTTSStageConfig(interruptionHandler)
 

--- a/sdk/examples/vad-demo/README.md
+++ b/sdk/examples/vad-demo/README.md
@@ -4,7 +4,7 @@ This example demonstrates Voice Activity Detection using PromptKit's audio packa
 
 ## Features
 
-- **SimpleVAD**: Basic voice activity detection using RMS energy analysis
+- **AdaptiveVAD**: Voice activity detection that tracks the ambient noise floor, so it follows a speaker through the quiet parts of an utterance
 - **State Tracking**: Monitor transitions between quiet/starting/speaking/stopping
 - **Configurable Parameters**: Tune sensitivity for different environments
 - **Event Notifications**: React to state changes in real-time
@@ -67,7 +67,7 @@ params := audio.VADParams{
 ## State Change Events
 
 ```go
-vad, _ := audio.NewSimpleVAD(audio.DefaultVADParams())
+vad, _ := audio.NewAdaptiveVAD(audio.DefaultVADParams())
 stateChanges := vad.OnStateChange()
 
 go func() {
@@ -87,7 +87,7 @@ conv, _ := sdk.Open("./pack.json", "assistant")
 
 // Create audio session with VAD
 session, _ := conv.OpenAudioSession(ctx,
-    sdk.WithSessionVAD(audio.NewSimpleVAD(audio.DefaultVADParams())),
+    sdk.WithSessionVAD(audio.NewAdaptiveVAD(audio.DefaultVADParams())),
 )
 
 // VAD automatically processes audio chunks

--- a/sdk/examples/vad-demo/README.md
+++ b/sdk/examples/vad-demo/README.md
@@ -83,15 +83,13 @@ go func() {
 VAD is typically used with audio sessions:
 
 ```go
-conv, _ := sdk.Open("./pack.json", "assistant")
+// A voice session uses AdaptiveVAD by default; pass WithVAD only to override it.
+myVAD, _ := audio.NewAdaptiveVAD(audio.DefaultVADParams())
 
-// Create audio session with VAD
-session, _ := conv.OpenAudioSession(ctx,
-    sdk.WithSessionVAD(audio.NewAdaptiveVAD(audio.DefaultVADParams())),
+conv, _ := sdk.Open("./pack.json", "assistant",
+    sdk.WithVADMode(sttService, ttsService, nil),
+    sdk.WithVAD(myVAD),
 )
-
-// VAD automatically processes audio chunks
-session.SendChunk(ctx, audioChunk)
 ```
 
 ## Notes

--- a/sdk/examples/vad-demo/main_interactive.go
+++ b/sdk/examples/vad-demo/main_interactive.go
@@ -1,7 +1,7 @@
 // Package main demonstrates Voice Activity Detection (VAD) in PromptKit.
 //
 // This example shows:
-//   - Creating a SimpleVAD analyzer
+//   - Creating an AdaptiveVAD analyzer
 //   - Processing audio frames and detecting speech
 //   - Handling VAD state transitions
 //   - Configuring VAD parameters
@@ -42,7 +42,7 @@ func basicVADDemo() {
 
 	// Create VAD with default parameters
 	params := audio.DefaultVADParams()
-	vad, err := audio.NewSimpleVAD(params)
+	vad, err := audio.NewAdaptiveVAD(params)
 	if err != nil {
 		fmt.Printf("Failed to create VAD: %v\n", err)
 		return
@@ -160,7 +160,7 @@ func stateChangeDemo() {
 	fmt.Println("🔔 VAD State Change Demo")
 	fmt.Println("------------------------")
 
-	vad, _ := audio.NewSimpleVAD(audio.DefaultVADParams())
+	vad, _ := audio.NewAdaptiveVAD(audio.DefaultVADParams())
 
 	// Get the state change channel
 	stateChanges := vad.OnStateChange()

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -175,6 +175,7 @@ type config struct {
 
 	// Audio session configuration for Pipeline middleware
 	turnDetector audio.TurnDetector
+	vad          audio.VADAnalyzer
 
 	// Streaming configuration for duplex mode
 	// If set: ASM mode (audio streaming model with continuous bidirectional streaming)
@@ -1978,6 +1979,26 @@ func WithTurnDetector(detector audio.TurnDetector) Option {
 	}
 }
 
+// WithVAD supplies the voice activity detector used for audio sessions.
+//
+// The detector decides what counts as speech, which governs where turns begin
+// and end. The default (AdaptiveVAD) tracks the ambient noise floor and suits
+// general microphone input; supply your own when you have a better model or
+// acoustics it does not handle — telephony codecs, a far-field array, or an ML
+// detector.
+//
+// Implement audio.VADAnalyzer; the interface depends on no runtime internals.
+//
+//	conv, _ := sdk.Open("./assistant.pack.json", "voice",
+//	    sdk.WithVAD(myDetector),
+//	)
+func WithVAD(vad audio.VADAnalyzer) Option {
+	return func(c *config) error {
+		c.vad = vad
+		return nil
+	}
+}
+
 // ProviderSpec is the uniform, SDK-facing declaration for any capability
 // provider, used by WithInferenceProvider and the WithXProvider option family.
 // Fields mirror runtime base.CapabilitySpec; Credential is an unresolved
@@ -2254,6 +2275,12 @@ type VADModeConfig struct {
 	// Speed is the TTS speech rate (0.5-2.0).
 	// Default: 1.0
 	Speed float64
+
+	// VAD is the voice activity detector deciding what counts as speech, and so
+	// where turns begin and end.
+	// If nil, an AdaptiveVAD tuned for general microphone input is used.
+	// Also settable via the WithVAD option.
+	VAD audio.VADAnalyzer
 }
 
 // DefaultVADModeConfig returns sensible defaults for VAD mode.
@@ -2335,6 +2362,9 @@ func (v *VADModeConfig) toAudioTurnConfig(ih *audio.InterruptionHandler) stage.A
 	}
 	if v.SampleRate > 0 {
 		cfg.SampleRate = v.SampleRate
+	}
+	if v.VAD != nil {
+		cfg.VAD = v.VAD
 	}
 	cfg.InterruptionHandler = ih
 	return cfg

--- a/sdk/vad_option_test.go
+++ b/sdk/vad_option_test.go
@@ -1,0 +1,80 @@
+package sdk
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+)
+
+// countingVAD is a caller-supplied VADAnalyzer. It implements the exported
+// interface directly, with no dependency on runtime internals — the whole point
+// being that an SDK consumer can write one.
+type countingVAD struct {
+	mu       sync.Mutex
+	analyzed int
+	events   chan audio.VADEvent
+}
+
+func newCountingVAD() *countingVAD {
+	return &countingVAD{events: make(chan audio.VADEvent, 1)}
+}
+
+func (v *countingVAD) Name() string { return "counting" }
+
+func (v *countingVAD) Analyze(_ context.Context, _ []byte) (float64, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.analyzed++
+	return 0, nil
+}
+
+func (v *countingVAD) State() audio.VADState                { return audio.VADStateQuiet }
+func (v *countingVAD) OnStateChange() <-chan audio.VADEvent { return v.events }
+func (v *countingVAD) Reset()                               {}
+
+// TestWithVADReachesAudioTurnConfig covers there being no way for an SDK caller
+// to supply their own voice activity detector.
+//
+// The stage accepts one — AudioTurnConfig.VAD is an exported field taking the
+// exported VADAnalyzer interface — but nothing in the SDK plumbs it. VADModeConfig
+// exposes durations, sample rate, language, voice and speed, and there is a
+// WithTurnDetector option, but no equivalent for the VAD itself. A caller with a
+// better detector (a real ML VAD, or one tuned for their acoustics) has to
+// abandon the SDK and build the pipeline through the runtime API.
+func TestWithVADReachesAudioTurnConfig(t *testing.T) {
+	custom := newCountingVAD()
+
+	c := &config{}
+	if err := WithVAD(custom)(c); err != nil {
+		t.Fatalf("WithVAD: %v", err)
+	}
+
+	if c.vad == nil {
+		t.Fatal("WithVAD did not record the analyzer on the config")
+	}
+	if c.vad.Name() != "counting" {
+		t.Errorf("config holds a %q analyzer, want the caller's %q", c.vad.Name(), "counting")
+	}
+}
+
+// TestVADModeConfigCarriesCustomVAD pins that the option survives conversion
+// into the stage config, which is what actually decides whether the caller's
+// detector runs. Recording it on the SDK config alone would look correct while
+// changing nothing.
+func TestVADModeConfigCarriesCustomVAD(t *testing.T) {
+	custom := newCountingVAD()
+
+	cfg := DefaultVADModeConfig()
+	cfg.VAD = custom
+
+	audioTurnCfg := cfg.toAudioTurnConfig(nil)
+
+	if audioTurnCfg.VAD == nil {
+		t.Fatal("the stage config has no VAD; the caller's analyzer was dropped in conversion")
+	}
+	if audioTurnCfg.VAD.Name() != "counting" {
+		t.Errorf("stage config holds %q, want the caller's %q", audioTurnCfg.VAD.Name(), "counting")
+	}
+}


### PR DESCRIPTION
Closes the loop on the original "Springfield" bug: fixes the default that caused it, rather than only the example that worked around it.

## Problem

`SimpleVAD` — the stage's default when no VAD is supplied — maps RMS to probability linearly between `MinVolume` (0.01) and `maxExpectedRMS` (0.1), compared against a 0.5 `Confidence` threshold:

```
probability = (rms - 0.01) / 0.09   →  speech requires rms ≥ 0.055
```

Conversational speech averages ~0.10 RMS but ranges far below that within a single utterance. The trailing word in "742 Evergreen Terrace, Springfield" measured **0.021**, scored 0.12, and read as silence — closing the turn mid-sentence and orphaning the word. Every consumer that doesn't supply its own VAD gets this.

## Measured before changing anything

Nine acoustic conditions, landed as tests (`TestVADComparisonMatrix`, `TestVADQuietTailMatrix`, `TestVADReleaseLagMatrix`):

| Condition | SimpleVAD | AdaptiveVAD |
|---|---|---|
| digital silence / room noise 0.005 / 0.02 | no speech ✓ | no speech ✓ |
| quiet speech 0.04 | **MISS** | detects @400ms |
| normal speech 0.10 | @500ms | **@300ms** |
| 0.021 speech tail (Springfield) | drops out | **holds** |

## The swap was NOT safe as-is

AdaptiveVAD kept reporting `Speaking` for **600ms** after true silence, against SimpleVAD's 200ms. `AudioTurnStage`'s `SilenceDuration` budget only accrues once the VAD leaves `Speaking`, so that lag is added to **every turn boundary** — and merges utterances separated by shorter pauses.

**Five existing stage tests failed, correctly.** I did not touch them; they were the acceptance criteria.

## Root cause and fix

A symmetric smoothing factor: the level estimate decayed slowly from a high value however abruptly audio stopped. Smoothing is now asymmetric — gentle attack (0.3), fast release (0.7).

Crucially, tail retention does **not** depend on that lag. Holding through a quiet trailing word comes from the *threshold tracking the noise floor*, not from smoothing inertia. Real silence collapses the level and the detector releases; quiet speech stays above an adaptive threshold and holds. That's why both properties are achievable at once.

## After

| Metric | SimpleVAD | AdaptiveVAD before | AdaptiveVAD now |
|---|---|---|---|
| Left `Speaking` on silence | 200ms | 600ms ❌ | **200ms** |
| Reached `Quiet` | 1000ms | 1400ms | **1000ms** |
| Springfield tail | stopping | held | **held** |
| True silence | CUT | held ❌ | **CUT** |
| Quiet speech 0.04 | MISS | detects | **detects** |

Strict domination, zero latency cost. The five stage tests pass **unmodified**.

## Scope

- `SimpleVAD` remains exported for callers wanting a fixed threshold.
- `ResponseVADStage` is **unchanged** — it is tuned for TTS output, not microphone input, and has its own params.
- Verified end-to-end: the voice-sales-assist suite passes against the new default.

Full runtime suite green with `-race`, 0 new lint findings, coverage 86.0% / 87.2% on changed files.
