### PR TITLE
fix(pipeline): STTStage emits a Message so transcripts reach the model

### DIFF
--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/stt"
 	"github.com/AltairaLabs/PromptKit/runtime/tts"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 // AudioTurnConfig configures the AudioTurnStage.
@@ -759,9 +760,26 @@ func (s *STTStage) Process(
 
 		logger.Debug("STTStage: transcribed", "textLength", len(text))
 
-		// Create text element, preserving metadata
+		// Create text element, preserving metadata.
+		//
+		// Message is populated as well as Text. ProviderStage's accumulateInput
+		// collects only elem.Message, so a Text-only element reaches the model as
+		// nothing at all — and the shipped VAD topology wires this stage straight
+		// into it (sdk/internal/pipeline/builder_vad.go: Audio -> VAD -> STT ->
+		// LLM -> TTS, no stage between). A transcribed turn was therefore asking
+		// the model to answer an empty conversation, silently.
+		//
+		// Text is kept alongside it: consumers that read the raw transcript
+		// (UI mirrors, logging) continue to work unchanged.
+		//
+		// The role is "user" because this stage transcribes inbound speech. A
+		// pipeline transcribing something else should map the role downstream.
+		msg := types.Message{Role: roleUser}
+		msg.AddTextPart(text)
+
 		outElem := StreamElement{
 			Text:      &text,
+			Message:   &msg,
 			Timestamp: time.Now(),
 			Meta:      elem.Meta,
 		}

--- a/runtime/pipeline/stage/stt_to_provider_test.go
+++ b/runtime/pipeline/stage/stt_to_provider_test.go
@@ -1,0 +1,159 @@
+package stage
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturingProvider records the messages the model is actually asked to answer.
+//
+// The stock mock provider answers regardless of its input, so asserting that a
+// turn was produced proves only that the stage ran — not that the transcript
+// reached the model. Capturing the request is what distinguishes the two.
+type capturingProvider struct {
+	*mock.Provider
+
+	mu   sync.Mutex
+	seen [][]types.Message
+}
+
+func newCapturingProvider() *capturingProvider {
+	return &capturingProvider{Provider: mock.NewProvider("capturing", "test-model", false)}
+}
+
+func (p *capturingProvider) Predict(
+	ctx context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.record(req.Messages)
+	return p.Provider.Predict(ctx, req)
+}
+
+func (p *capturingProvider) PredictStream(
+	ctx context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	p.record(req.Messages)
+	return p.Provider.PredictStream(ctx, req)
+}
+
+func (p *capturingProvider) record(msgs []types.Message) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cp := make([]types.Message, len(msgs))
+	copy(cp, msgs)
+	p.seen = append(p.seen, cp)
+}
+
+// sawText reports whether any captured request carried the given text.
+func (p *capturingProvider) sawText(want string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, req := range p.seen {
+		for _, m := range req {
+			if m.GetContent() == want {
+				return true
+			}
+			for _, part := range m.Parts {
+				if part.Text != nil && *part.Text == want {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// TestProviderStage_ReceivesTranscriptText covers a transcript being silently
+// dropped between STT and the model.
+//
+// STTStage's entire output for a completed turn is StreamElement{Text: &text}.
+// The shipped VAD topology wires it straight into ProviderStage — see
+// sdk/internal/pipeline/builder_vad.go, "Audio -> VAD -> STT -> LLM -> TTS",
+// with no stage in between. But accumulateInput collects only elem.Message and
+// discards everything else, so the model is asked to answer an empty
+// conversation. Nothing errors; the turn is simply empty.
+func TestProviderStage_ReceivesTranscriptText(t *testing.T) {
+	const transcript = "I'd like a home insurance quote"
+
+	// Chain the two stages exactly as the shipped VAD pipeline does, rather than
+	// feeding ProviderStage by hand: the contract under test is that a
+	// transcribed turn reaches the model, and either stage may be the one to
+	// close the gap.
+	sttStage := NewSTTStage(&transcriptSTT{text: transcript}, DefaultSTTStageConfig())
+
+	provider := newCapturingProvider()
+	turnState := NewTurnState()
+	turnState.SystemPrompt = "You are a helpful assistant"
+	providerStage := NewProviderStageWithTurnState(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, nil, turnState)
+
+	ctx := context.Background()
+
+	sttIn := make(chan StreamElement, 1)
+	sttIn <- StreamElement{Audio: &AudioData{
+		Samples:    make([]byte, 32000), // 1s @ 16kHz PCM16, over MinAudioBytes
+		SampleRate: 16000,
+		Channels:   1,
+		Format:     AudioFormatPCM16,
+	}}
+	close(sttIn)
+
+	sttOut := make(chan StreamElement, 8)
+	require.NoError(t, sttStage.Process(ctx, sttIn, sttOut))
+
+	provOut := make(chan StreamElement, 32)
+	require.NoError(t, providerStage.Process(ctx, sttOut, provOut))
+	for range provOut { //nolint:revive // drain
+	}
+
+	assert.True(t, provider.sawText(transcript),
+		"the model never received the transcript. STTStage emits it on elem.Text, "+
+			"and accumulateInput collects only elem.Message, so a VAD-mode turn asks "+
+			"the model to answer an empty conversation")
+}
+
+// transcriptSTT is a base.STTProvider returning a fixed transcript.
+type transcriptSTT struct{ text string }
+
+func (s *transcriptSTT) Name() string                      { return "transcript" }
+func (s *transcriptSTT) Type() base.ProviderType           { return base.ProviderTypeSTT }
+func (s *transcriptSTT) Pricing() *base.PricingDescriptor  { return nil }
+func (s *transcriptSTT) Validate() error                   { return nil }
+func (s *transcriptSTT) Init(context.Context) error        { return nil }
+func (s *transcriptSTT) HealthCheck(context.Context) error { return nil }
+func (s *transcriptSTT) Close() error                      { return nil }
+func (s *transcriptSTT) Transcribe(context.Context, base.STTRequest) (base.STTResponse, error) {
+	return base.STTResponse{Text: s.text}, nil
+}
+
+// TestProviderStage_StillReceivesMessageElements guards the existing path: the
+// fix must add Text handling without disturbing how Message elements arrive.
+func TestProviderStage_StillReceivesMessageElements(t *testing.T) {
+	provider := newCapturingProvider()
+
+	turnState := NewTurnState()
+	s := NewProviderStageWithTurnState(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, nil, turnState)
+
+	const content = "an ordinary message element"
+	msg := types.Message{Role: "user", Content: content}
+	input := make(chan StreamElement, 1)
+	input <- NewMessageElement(&msg)
+	close(input)
+
+	output := make(chan StreamElement, 32)
+	require.NoError(t, s.Process(context.Background(), input, output))
+	for range output { //nolint:revive // drain
+	}
+
+	assert.True(t, provider.sawText(content), "a Message element must still reach the model")
+}


### PR DESCRIPTION
Closes #1633.

## Problem

`STTStage`'s entire output for a completed turn is `StreamElement{Text: &text}`. `ProviderStage.accumulateInput` collects **only** `elem.Message` and discards everything else:

```go
for elem := range input {
    if elem.Message != nil {
        acc.messages = append(acc.messages, *elem.Message)
    }
}
```

So a transcribed turn reaches the model as **nothing at all** — no error, just an empty conversation. Transcription itself keeps working, which is what makes it hard to spot: the transcript appears everywhere it's displayed while the model is deaf.

## Evidence

Demonstrated on the voice-sales-assist example with real Whisper and real Claude. That example hand-rolls a `MapStage` bridging `Text` → `Message`. Removing **one line** from it (`elem.Message = msg`), changing nothing else:

```
[transcript] CUSTOMER: Hi, I'm calling to get a home insurance quote.
[transcript] AGENT:    I'd be happy to help. What's the property address?
[transcript] CUSTOMER: It's 742 Evergreen Terrace, Springfield.
[transcript] AGENT:    Perfect. Let me pull that up right now.
[transcript] CUSTOMER: Thanks. It's a single-family home we've owned for six years.
```

**Zero agent output** across five turns — no reasoning, no tool calls, no surface updates. Restore the line and the agent reasons on every turn and fires `lookup_property`, `hazard_report`, `prefill_quote`. The example works *because* it carries this fix privately.

## Change

`STTStage` now populates `Message` alongside `Text`. `Text` is kept, so consumers reading the raw transcript (UI mirrors, logging) are unaffected.

**Fixed at the source rather than in `accumulateInput`, deliberately.** `ProviderStage` also *emits* `Text` elements as streaming deltas, so teaching the accumulator to treat any `Text` as user input would misread a chained provider's own output as user speech.

## Two things worth reviewing

**The stage already contained dead code implying this was intended.** `stages_speech.go` had cost-stamping guarded on `if outElem.Message != nil`, which could never run because `Message` was never set.

**My first version of this test passed against the broken code.** The stock mock provider answers regardless of its input, so asserting "a turn was produced" proves the stage *ran*, not that the transcript *arrived*. The test now uses a `capturingProvider` recording the actual `PredictionRequest`. Worth remembering for any similar provider-path test.

## Scope — what is and isn't established

Established: the mechanism above, and that the example depends on its bridge.

**Not established: how many users this affects.** The obvious candidate is `WithVADMode` (the mode built for text-only providers, where the pipeline supplies STT/TTS), since that topology is `AudioTurn → STT → Provider` with nothing between. But I could not verify it end-to-end — `OpenDuplex` rejects non-`StreamInputSupport` providers even in VAD mode (see the follow-up issue), and a Gemini-based attempt timed out inconclusively. I've deliberately not claimed a blast radius I haven't measured.

This fix stands on its own regardless: it corrects a real defect and cannot make any current path worse.

## Tests

- `TestProviderStage_ReceivesTranscriptText` — chains `STTStage → ProviderStage` as the VAD builder does, feeds audio, asserts the model received the transcript. RED before, green after.
- `TestProviderStage_StillReceivesMessageElements` — guard that ordinary `Message` elements are unaffected.

Full runtime suite green with `-race`, 0 new lint findings, 87.3% coverage on the changed file.
