### PR TITLE
fix(events): emit EventAudioTranscription from STTStage

### DIFF
--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -330,6 +330,7 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func RouteWhen\(output string, predicate func\(StreamElement\) bool\) RoutingRule](<#RouteWhen>)
 - [type STTStage](<#STTStage>)
   - [func NewSTTStage\(service base.STTProvider, config STTStageConfig\) \*STTStage](<#NewSTTStage>)
+  - [func NewSTTStageWithEmitter\(service base.STTProvider, config STTStageConfig, emitter \*events.Emitter\) \*STTStage](<#NewSTTStageWithEmitter>)
   - [func \(s \*STTStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#STTStage.Process>)
 - [type STTStageConfig](<#STTStageConfig>)
   - [func DefaultSTTStageConfig\(\) STTStageConfig](<#DefaultSTTStageConfig>)
@@ -4292,6 +4293,19 @@ func NewSTTStage(service base.STTProvider, config STTStageConfig) *STTStage
 ```
 
 NewSTTStage creates a new STT stage. The service parameter accepts any base.STTProvider implementation. The legacy stt.Service interface embeds base.STTProvider, so existing callers that pass an stt.Service remain compatible without changes.
+
+<a name="NewSTTStageWithEmitter"></a>
+### func NewSTTStageWithEmitter
+
+```go
+func NewSTTStageWithEmitter(service base.STTProvider, config STTStageConfig, emitter *events.Emitter) *STTStage
+```
+
+NewSTTStageWithEmitter creates an STT stage that publishes an EventAudioTranscription for each completed transcription.
+
+The event type and its payload \(events.AudioTranscriptionData\) were declared and already consumed — session export writes transcriptions out as subtitles, and annotated sessions query them by type — but nothing produced them, so subscribers waited forever and both consumers saw an empty set. Applications wanting a live transcript had to thread their own callback through the stage graph instead.
+
+The emitter is optional; NewSTTStage remains the no\-events constructor.
 
 <a name="STTStage.Process"></a>
 ### func \(\*STTStage\) Process

--- a/runtime/events/emitter.go
+++ b/runtime/events/emitter.go
@@ -88,6 +88,21 @@ func (e *Emitter) PipelineStarted(middlewareCount int) {
 	})
 }
 
+// AudioTranscription emits the audio.transcription event for a completed
+// speech-to-text result.
+//
+// isFinal distinguishes a settled transcription from an interim one; a
+// completed STT turn is final. provider names the STT service, language the
+// hint or detected code, both optional.
+func (e *Emitter) AudioTranscription(text, language, provider string, isFinal bool) {
+	e.emit(EventAudioTranscription, &AudioTranscriptionData{
+		Text:     text,
+		Language: language,
+		Provider: provider,
+		IsFinal:  isFinal,
+	})
+}
+
 // PipelineCompleted emits the pipeline.completed event.
 func (e *Emitter) PipelineCompleted(
 	duration time.Duration,

--- a/runtime/events/emitter_test.go
+++ b/runtime/events/emitter_test.go
@@ -1530,3 +1530,47 @@ func TestEmitter_ReasoningDelta(t *testing.T) {
 		t.Fatalf("Text = %q, want %q", data.Text, "thinking...")
 	}
 }
+
+// TestEmitterAudioTranscription pins the transcription event's payload.
+//
+// The event type and AudioTranscriptionData were declared and consumed (session
+// export renders them as subtitles, annotated sessions query them by type)
+// without any producer, so nothing verified the shape a consumer would receive.
+func TestEmitterAudioTranscription(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	emitter := NewEmitter(bus, "run-1", "session-1", "conv-1")
+
+	var got *Event
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	bus.Subscribe(EventAudioTranscription, func(e *Event) {
+		got = e
+		wg.Done()
+	})
+
+	emitter.AudioTranscription("the transcribed text", "en", "whisper", true)
+
+	if !waitForWG(&wg, 200*time.Millisecond) {
+		t.Fatal("timed out waiting for audio transcription event")
+	}
+
+	data, ok := got.Data.(*AudioTranscriptionData)
+	if !ok {
+		t.Fatalf("unexpected payload type %T; consumers type-assert *AudioTranscriptionData", got.Data)
+	}
+	if data.Text != "the transcribed text" {
+		t.Errorf("Text = %q, want the transcribed text", data.Text)
+	}
+	if data.Language != "en" {
+		t.Errorf("Language = %q, want en", data.Language)
+	}
+	if data.Provider != "whisper" {
+		t.Errorf("Provider = %q, want whisper", data.Provider)
+	}
+	if !data.IsFinal {
+		t.Error("IsFinal = false; a completed STT turn is a final transcription")
+	}
+}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/stt"
@@ -687,6 +688,9 @@ type STTStage struct {
 	BaseStage
 	service base.STTProvider
 	config  STTStageConfig
+	// emitter is optional. When set, each completed transcription publishes an
+	// EventAudioTranscription so subscribers and session export can see it.
+	emitter *events.Emitter
 }
 
 // NewSTTStage creates a new STT stage.
@@ -699,6 +703,27 @@ func NewSTTStage(service base.STTProvider, config STTStageConfig) *STTStage {
 		service:   service,
 		config:    config,
 	}
+}
+
+// NewSTTStageWithEmitter creates an STT stage that publishes an
+// EventAudioTranscription for each completed transcription.
+//
+// The event type and its payload (events.AudioTranscriptionData) were declared
+// and already consumed — session export writes transcriptions out as subtitles,
+// and annotated sessions query them by type — but nothing produced them, so
+// subscribers waited forever and both consumers saw an empty set. Applications
+// wanting a live transcript had to thread their own callback through the stage
+// graph instead.
+//
+// The emitter is optional; NewSTTStage remains the no-events constructor.
+func NewSTTStageWithEmitter(
+	service base.STTProvider,
+	config STTStageConfig,
+	emitter *events.Emitter,
+) *STTStage {
+	s := NewSTTStage(service, config)
+	s.emitter = emitter
+	return s
 }
 
 // Process implements the Stage interface.
@@ -759,6 +784,12 @@ func (s *STTStage) Process(
 		}
 
 		logger.Debug("STTStage: transcribed", "textLength", len(text))
+
+		// Publish the transcription so subscribers and session export can see it.
+		// Optional: a stage built without an emitter behaves exactly as before.
+		if s.emitter != nil {
+			s.emitter.AudioTranscription(text, s.config.Language, s.service.Name(), true)
+		}
 
 		// Create text element, preserving metadata.
 		//

--- a/runtime/pipeline/stage/stt_events_test.go
+++ b/runtime/pipeline/stage/stt_events_test.go
@@ -1,0 +1,113 @@
+package stage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedTranscriptSTT returns a set transcript for any audio.
+type fixedTranscriptSTT struct{ text string }
+
+func (s *fixedTranscriptSTT) Name() string                      { return "fixed-transcript" }
+func (s *fixedTranscriptSTT) Type() base.ProviderType           { return base.ProviderTypeSTT }
+func (s *fixedTranscriptSTT) Pricing() *base.PricingDescriptor  { return nil }
+func (s *fixedTranscriptSTT) Validate() error                   { return nil }
+func (s *fixedTranscriptSTT) Init(context.Context) error        { return nil }
+func (s *fixedTranscriptSTT) HealthCheck(context.Context) error { return nil }
+func (s *fixedTranscriptSTT) Close() error                      { return nil }
+func (s *fixedTranscriptSTT) Transcribe(
+	context.Context, base.STTRequest,
+) (base.STTResponse, error) {
+	return base.STTResponse{Text: s.text}, nil
+}
+
+// TestSTTStage_EmitsTranscriptionEvent covers EventAudioTranscription having no
+// producer.
+//
+// The event type is declared (events/types.go), its payload is fully specified
+// (AudioTranscriptionData), and two consumers already read it: session export
+// writes it out as subtitles, and annotated_session queries it by type. Nothing
+// emits it, so both consumers see nothing and any subscriber waits forever
+// without error.
+//
+// The voice-sales-assist example threads a manual callback through its stage
+// graph for exactly this reason, noting that subscribing "would silently never
+// fire".
+func TestSTTStage_EmitsTranscriptionEvent(t *testing.T) {
+	const transcript = "I'd like a home insurance quote"
+
+	bus := events.NewEventBus()
+	defer bus.Close()
+
+	received := make(chan *events.AudioTranscriptionData, 4)
+	bus.Subscribe(events.EventAudioTranscription, func(e *events.Event) {
+		if data, ok := e.Data.(*events.AudioTranscriptionData); ok {
+			received <- data
+		}
+	})
+
+	emitter := events.NewEmitter(bus, "exec-1", "session-1", "conv-1")
+	s := NewSTTStageWithEmitter(
+		&fixedTranscriptSTT{text: transcript},
+		DefaultSTTStageConfig(),
+		emitter,
+	)
+
+	input := make(chan StreamElement, 1)
+	input <- StreamElement{Audio: &AudioData{
+		Samples:    make([]byte, 32000), // 1s @ 16kHz PCM16
+		SampleRate: 16000,
+		Channels:   1,
+		Format:     AudioFormatPCM16,
+	}}
+	close(input)
+
+	output := make(chan StreamElement, 8)
+	require.NoError(t, s.Process(context.Background(), input, output))
+	for range output { //nolint:revive // drain
+	}
+
+	select {
+	case data := <-received:
+		assert.Equal(t, transcript, data.Text, "the event should carry the transcribed text")
+		assert.True(t, data.IsFinal, "a completed STT turn is a final transcription")
+	case <-time.After(2 * time.Second):
+		t.Error("no EventAudioTranscription was emitted for a completed transcription; " +
+			"the event type is declared and consumed but has no producer, so subscribers " +
+			"and session export silently see nothing")
+	}
+}
+
+// TestSTTStage_WithoutEmitterStillTranscribes guards that the emitter stays
+// optional: an STTStage built without one must behave exactly as before.
+func TestSTTStage_WithoutEmitterStillTranscribes(t *testing.T) {
+	const transcript = "no emitter configured"
+
+	s := NewSTTStage(&fixedTranscriptSTT{text: transcript}, DefaultSTTStageConfig())
+
+	input := make(chan StreamElement, 1)
+	input <- StreamElement{Audio: &AudioData{
+		Samples:    make([]byte, 32000),
+		SampleRate: 16000,
+		Channels:   1,
+		Format:     AudioFormatPCM16,
+	}}
+	close(input)
+
+	output := make(chan StreamElement, 8)
+	require.NoError(t, s.Process(context.Background(), input, output))
+
+	var sawText bool
+	for elem := range output {
+		if elem.Text != nil && *elem.Text == transcript {
+			sawText = true
+		}
+	}
+	assert.True(t, sawText, "transcription must still work with no emitter wired")
+}


### PR DESCRIPTION
Closes #1634.

## Problem

`EventAudioTranscription` was declared, its payload fully specified (`AudioTranscriptionData`: text, language, confidence, turn ID, provider, is-final), and **two consumers already read it**:

- `events/session_export.go:546` — writes transcriptions out as SRT subtitles
- `events/annotated_session.go:261` — `GetEventsByType(EventAudioTranscription)`

**Nothing emitted it.** Grepping the constant and the literal `"audio.transcription"` across `runtime/` and `sdk/` found only the declaration, those two consumers, and one test assertion.

So both consumers always saw an empty set, and any subscriber waited forever with no error. Same failure shape as the phantom `WithSessionVAD` fixed in #1632: the symptom is silence, not a diagnostic.

Applications wanting a live transcript had to thread their own callback through the stage graph. `examples/voice-sales-assist` does exactly that, and documents why:

> nothing in `runtime/pipeline/stage` publishes that event today (confirmed by inspection: STTStage never calls an emitter), so subscribing to it would silently never fire

## Change

- `Emitter.AudioTranscription(text, language, provider, isFinal)`
- `NewSTTStageWithEmitter(service, config, emitter)`
- `STTStage` publishes one event per completed transcription, carrying the text, the configured language hint, the STT provider's name, and `IsFinal: true`.

**The emitter is optional.** `NewSTTStage` remains the no-events constructor, and a stage built without one behaves exactly as before — pinned by `TestSTTStage_WithoutEmitterStillTranscribes`.

## Tests

- `TestSTTStage_EmitsTranscriptionEvent` — subscribes to the bus, runs a transcription, asserts an event arrives carrying the right text and `IsFinal`. RED before (constructor absent), green after.
- `TestSTTStage_WithoutEmitterStillTranscribes` — guard on the optional path.

Full runtime suite green, 0 new lint findings, coverage 97.3% (`emitter.go`) and 86.8% (`stages_speech.go`). Runtime reference docs regenerated for the new exported API.

## Follow-up

`examples/voice-sales-assist` can now drop its manual `onTranscript` plumbing and subscribe to the event instead. Not done here — the example is mid-change in the working tree.

Independent of #1636, though both touch `stages_speech.go` and will need one of them rebasing.
