### PR TITLE
feat(pipeline): export WithNamePrefix for multi-branch stage graphs

### DIFF
--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -339,6 +339,7 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func \(s ScoredMessages\) Less\(i, j int\) bool](<#ScoredMessages.Less>)
   - [func \(s ScoredMessages\) Swap\(i, j int\)](<#ScoredMessages.Swap>)
 - [type Stage](<#Stage>)
+  - [func WithNamePrefix\(prefix string, s Stage\) Stage](<#WithNamePrefix>)
 - [type StageError](<#StageError>)
   - [func NewStageError\(stageName string, stageType StageType, err error\) \*StageError](<#NewStageError>)
   - [func \(e \*StageError\) Error\(\) string](<#StageError.Error>)
@@ -4451,6 +4452,21 @@ type Stage interface {
     Process(ctx context.Context, input <-chan StreamElement, output chan<- StreamElement) error
 }
 ```
+
+<a name="WithNamePrefix"></a>
+### func WithNamePrefix
+
+```go
+func WithNamePrefix(prefix string, s Stage) Stage
+```
+
+WithNamePrefix returns s renamed to "\<prefix\>\_\<name\>", so the same stage constructors can be instantiated once per branch in a single pipeline.
+
+PipelineBuilder.Build rejects duplicate stage names, so a fan\-out that runs identical sub\-chains — one audio track per speaker on a two\-party call, one per camera, one per tenant — must give each branch's stages distinct names. Without a shared helper, every consumer re\-derives the same wrapper by embedding Stage and overriding Name\(\).
+
+An empty prefix returns s unchanged, which is the single\-branch case: the constructors' natural names are already unique and no wrapper is warranted.
+
+The original stage is not mutated, so the same instance can be wrapped more than once — though note that wrapping shares the underlying stage, including any state it holds. Branches needing independent state must construct separate stages.
 
 <a name="StageError"></a>
 ## type StageError

--- a/runtime/pipeline/stage/rename.go
+++ b/runtime/pipeline/stage/rename.go
@@ -1,0 +1,34 @@
+package stage
+
+// prefixedStage wraps a Stage to override its Name(), leaving all other
+// behavior to the embedded stage.
+type prefixedStage struct {
+	Stage
+	name string
+}
+
+// Name returns the prefixed stage name.
+func (p *prefixedStage) Name() string { return p.name }
+
+// WithNamePrefix returns s renamed to "<prefix>_<name>", so the same stage
+// constructors can be instantiated once per branch in a single pipeline.
+//
+// PipelineBuilder.Build rejects duplicate stage names, so a fan-out that runs
+// identical sub-chains — one audio track per speaker on a two-party call, one
+// per camera, one per tenant — must give each branch's stages distinct names.
+// Without a shared helper, every consumer re-derives the same wrapper by
+// embedding Stage and overriding Name().
+//
+// An empty prefix returns s unchanged, which is the single-branch case: the
+// constructors' natural names are already unique and no wrapper is warranted.
+//
+// The original stage is not mutated, so the same instance can be wrapped more
+// than once — though note that wrapping shares the underlying stage, including
+// any state it holds. Branches needing independent state must construct
+// separate stages.
+func WithNamePrefix(prefix string, s Stage) Stage {
+	if prefix == "" {
+		return s
+	}
+	return &prefixedStage{Stage: s, name: prefix + "_" + s.Name()}
+}

--- a/runtime/pipeline/stage/rename_test.go
+++ b/runtime/pipeline/stage/rename_test.go
@@ -1,0 +1,67 @@
+package stage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithNamePrefix covers building the same stage more than once in one graph.
+//
+// PipelineBuilder.Build rejects duplicate stage names, so a fan-out that runs
+// the same constructors per branch — one audio track per speaker on a two-party
+// call, one per camera, one per tenant — needs each branch's stages renamed.
+// The SDK has a helper for this in sdk/internal/pipeline, which Go's internal
+// rule makes unreachable from anywhere outside sdk/: examples and downstream
+// consumers re-derive it, embedding Stage and overriding Name() by hand.
+func TestWithNamePrefix(t *testing.T) {
+	inner := NewMapStage("audio_turn", func(e StreamElement) (StreamElement, error) {
+		return e, nil
+	})
+
+	renamed := WithNamePrefix("caller", inner)
+
+	assert.Equal(t, "caller_audio_turn", renamed.Name(),
+		"the prefixed stage should carry a unique name")
+	assert.Equal(t, "audio_turn", inner.Name(),
+		"the original stage must not be mutated — the same instance may be wrapped twice")
+}
+
+// TestWithNamePrefixEmptyPrefixIsIdentity pins the single-track case: no prefix
+// means the constructors' natural names, and no wrapper.
+func TestWithNamePrefixEmptyPrefixIsIdentity(t *testing.T) {
+	inner := NewMapStage("stt", func(e StreamElement) (StreamElement, error) { return e, nil })
+
+	assert.Same(t, inner, WithNamePrefix("", inner),
+		"an empty prefix should return the stage unchanged, not an extra wrapper")
+}
+
+// TestWithNamePrefixDelegatesProcessing pins that renaming is only a rename: the
+// wrapped stage must still do its work, or a fan-out would silently drop data.
+func TestWithNamePrefixDelegatesProcessing(t *testing.T) {
+	const marker = "processed"
+	inner := NewMapStage("mapper", func(e StreamElement) (StreamElement, error) {
+		text := marker
+		e.Text = &text
+		return e, nil
+	})
+
+	renamed := WithNamePrefix("agent", inner)
+
+	in := make(chan StreamElement, 1)
+	in <- StreamElement{}
+	close(in)
+	out := make(chan StreamElement, 4)
+
+	require.NoError(t, renamed.Process(context.Background(), in, out))
+
+	var got string
+	for e := range out {
+		if e.Text != nil {
+			got = *e.Text
+		}
+	}
+	assert.Equal(t, marker, got, "the renamed stage must delegate to the wrapped stage")
+}

--- a/sdk/internal/pipeline/builder_vad.go
+++ b/sdk/internal/pipeline/builder_vad.go
@@ -8,26 +8,14 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 )
 
-// prefixedStage wraps a Stage to override its Name(), so the same constructor
-// (audio-resample/audio_turn/stt) can be instantiated more than once in a single
-// pipeline graph — e.g. one call to BuildAudioTrackStages per audio track — without
-// colliding on stage name. An empty prefix is a no-op passthrough wrapper so the
-// single-track VAD front keeps its original, unprefixed stage names.
-type prefixedStage struct {
-	stage.Stage
-	name string
-}
-
-// Name reports the prefixed stage name, overriding the embedded stage's Name.
-func (p *prefixedStage) Name() string { return p.name }
-
-// withNamePrefix returns s unchanged when prefix is empty, otherwise wraps it so
-// Name() reports "<prefix>_<original name>".
+// withNamePrefix delegates to stage.WithNamePrefix.
+//
+// The wrapper used to be defined here, which put it behind Go's internal-package
+// rule: examples and downstream consumers building multi-track graphs could not
+// import it and re-derived the same ~15 lines. It now lives in
+// runtime/pipeline/stage alongside the Stage interface it wraps.
 func withNamePrefix(prefix string, s stage.Stage) stage.Stage {
-	if prefix == "" {
-		return s
-	}
-	return &prefixedStage{Stage: s, name: prefix + "_" + s.Name()}
+	return stage.WithNamePrefix(prefix, s)
 }
 
 // BuildAudioTrackStages returns the ordered stages for one named audio track:


### PR DESCRIPTION
Closes #1635.

`PipelineBuilder.Build` rejects duplicate stage names, so a fan-out running the same constructors per branch — one audio track per speaker on a two-party call, one per camera, one per tenant — must rename each branch's stages.

The helper for this lived in `sdk/internal/pipeline`, which Go's internal-package rule puts out of reach of `examples/` and every downstream consumer. They re-derive the same wrapper by embedding `Stage` and overriding `Name()` — `examples/voice-sales-assist` does exactly that, with a comment explaining why it has to.

Moved to `runtime/pipeline/stage`, next to the `Stage` interface it wraps, with the SDK's internal helper delegating to it so there is one implementation rather than two.

An empty prefix returns the stage unchanged — the single-branch case, where the constructors' natural names are already unique.

Tests cover the rename, the empty-prefix identity, non-mutation of the original, and that the wrapper still delegates processing (a rename that dropped data would be worse than the duplication). `rename.go` at 100% coverage; full runtime and SDK suites green; 0 new lint findings; runtime reference regenerated.