### PR TITLE
fix(sdk): admit text-only providers to OpenDuplex in VAD mode

### DIFF
--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -1279,7 +1279,10 @@ for chunk := range respCh {
 }
 ```
 
-The provider must support streaming input \(implement providers.StreamInputSupport\). Currently supported providers: Gemini with certain models.
+Provider requirements depend on how the input side is driven:
+
+- ASM mode \(default\): audio is sent to the model itself, so the provider must implement providers.StreamInputSupport. Currently that means Gemini with certain models.
+- WithVADMode / WithIngestion: the pipeline owns the input side and the model only ever sees text, so any text provider works — including Claude and OpenAI Chat Completions.
 
 <a name="Resume"></a>
 ### func Resume

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -142,8 +142,14 @@ func Open(packPath, promptName string, opts ...Option) (*Conversation, error) {
 //	    fmt.Print(chunk.Content)
 //	}
 //
-// The provider must support streaming input (implement providers.StreamInputSupport).
-// Currently supported providers: Gemini with certain models.
+// Provider requirements depend on how the input side is driven:
+//
+//   - ASM mode (default): audio is sent to the model itself, so the provider
+//     must implement providers.StreamInputSupport. Currently that means Gemini
+//     with certain models.
+//   - WithVADMode / WithIngestion: the pipeline owns the input side and the
+//     model only ever sees text, so any text provider works — including Claude
+//     and OpenAI Chat Completions.
 func OpenDuplex(packPath, promptName string, opts ...Option) (*Conversation, error) {
 	conv, prov, err := initConversation(packPath, promptName, opts)
 	if err != nil {
@@ -158,14 +164,21 @@ func OpenDuplex(packPath, promptName string, opts ...Option) (*Conversation, err
 		return nil, err
 	}
 
-	// Verify provider supports streaming input. A custom ingestion sub-graph
-	// (WithIngestion) drives the standard agent chain — the streaming text
-	// ProviderStage, not the ASM DuplexProviderStage — and never calls
-	// CreateStreamSession, so it does not need StreamInputSupport. When it is
-	// absent, only ASM mode requires the interface. NewDuplexSession re-derives
-	// the streaming provider from the base provider itself for ASM mode, so the
-	// gate here is purely a fail-fast check.
-	if _, ok := prov.(providers.StreamInputSupport); !ok && conv.config.ingestion == nil {
+	// Verify provider supports streaming input. Only ASM mode — where audio
+	// goes to the model itself — needs StreamInputSupport. Two duplex modes
+	// author the input side themselves and drive the standard agent chain (the
+	// streaming text ProviderStage, not the ASM DuplexProviderStage), never
+	// calling CreateStreamSession, so neither needs the interface:
+	//
+	//   - WithIngestion: a custom upstream sub-graph.
+	//   - WithVADMode:   AudioTurn → STT → LLM → TTS, where the model only ever
+	//     sees text. Requiring the ASM interface here would exclude exactly the
+	//     text-only providers VAD mode exists to serve (#1637).
+	//
+	// NewDuplexSession re-derives the streaming provider from the base provider
+	// itself for ASM mode, so the gate here is purely a fail-fast check.
+	if _, ok := prov.(providers.StreamInputSupport); !ok &&
+		conv.config.ingestion == nil && conv.config.vadModeConfig == nil {
 		return nil, fmt.Errorf(
 			"provider %T does not support duplex streaming (must implement providers.StreamInputSupport)",
 			prov,

--- a/sdk/vad_duplex_gate_test.go
+++ b/sdk/vad_duplex_gate_test.go
@@ -1,0 +1,227 @@
+package sdk
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTextProvider implements providers.Provider but deliberately NOT
+// providers.StreamInputSupport — it is the shape of every text-only LLM
+// (Claude, GPT via Chat Completions) that VAD mode exists to serve. It records
+// the user text of every PredictStream request so a test can prove the model
+// actually received the STT transcript, not merely that construction succeeded.
+type recordingTextProvider struct {
+	base.Implementation
+
+	mu       sync.Mutex
+	received []string
+}
+
+func (p *recordingTextProvider) ID() string    { return "recording-text" }
+func (p *recordingTextProvider) Model() string { return "recording-text-model" }
+
+func (p *recordingTextProvider) Predict(
+	_ context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.record(req)
+	return providers.PredictionResponse{Content: "ack"}, nil
+}
+
+func (p *recordingTextProvider) PredictStream(
+	_ context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	p.record(req)
+	stop := "stop"
+	ch := make(chan providers.StreamChunk, 1)
+	ch <- providers.StreamChunk{Content: "ack", Delta: "ack", FinishReason: &stop}
+	close(ch)
+	return ch, nil
+}
+
+func (p *recordingTextProvider) record(req providers.PredictionRequest) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, msg := range req.Messages {
+		if msg.Role != "user" {
+			continue
+		}
+		// STTStage populates the transcript via AddTextPart (Parts), not the
+		// legacy Content field — read both.
+		if msg.Content != "" {
+			p.received = append(p.received, msg.Content)
+		}
+		for _, part := range msg.Parts {
+			if part.Text != nil && *part.Text != "" {
+				p.received = append(p.received, *part.Text)
+			}
+		}
+	}
+}
+
+func (p *recordingTextProvider) userTexts() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.received))
+	copy(out, p.received)
+	return out
+}
+
+// waitForUserText polls until the provider has seen a user message containing
+// want, returning whether it arrived within the timeout.
+func (p *recordingTextProvider) waitForUserText(want string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, got := range p.userTexts() {
+			if got == want {
+				return true
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+func (p *recordingTextProvider) SupportsStreaming() bool      { return true }
+func (p *recordingTextProvider) ShouldIncludeRawOutput() bool { return false }
+func (p *recordingTextProvider) Close() error                 { return nil }
+func (p *recordingTextProvider) CalculateCost(_, _, _ int) types.CostInfo {
+	return types.CostInfo{}
+}
+
+// TestOpenDuplexVADModeAcceptsNonStreamInputProvider proves the duplex
+// construction gate admits a text-only provider when WithVADMode is set. In VAD
+// mode the pipeline (AudioTurn → STT → LLM → TTS) handles speech and the model
+// only ever sees text, so providers.StreamInputSupport — the ASM interface for
+// sending audio to the model — is not required. Requiring it excludes exactly
+// the providers VAD mode was built for. See #1637.
+func TestOpenDuplexVADModeAcceptsNonStreamInputProvider(t *testing.T) {
+	packFile := writeIngestionTestPack(t)
+
+	provider := &recordingTextProvider{}
+	if _, ok := providers.Provider(provider).(providers.StreamInputSupport); ok {
+		t.Fatal("test premise broken: recordingTextProvider must NOT implement StreamInputSupport")
+	}
+
+	conv, err := OpenDuplex(packFile, "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithVADMode(&convMockSTTService{}, newConvMockTTSService(), nil),
+	)
+	require.NoError(t, err,
+		"OpenDuplex must accept a non-StreamInputSupport provider when WithVADMode is set")
+	require.NotNil(t, conv)
+	assert.Equal(t, DuplexMode, conv.mode)
+	assert.NotNil(t, conv.duplexSession,
+		"duplex session must build on the VAD path without a stream provider")
+
+	// Close is slow here (~30s) regardless of whether the response channel is
+	// drained: an idle VAD duplex session always waits out the full drain
+	// timeout. That is #1638, not this gate.
+	_ = conv.Close()
+}
+
+// pcmSpeech returns d worth of 16-bit mono PCM at sampleRate carrying a
+// full-scale tone — loud enough for an energy-based VAD to call it speech.
+func pcmSpeech(d time.Duration, sampleRate int) []byte {
+	n := int(float64(sampleRate) * d.Seconds())
+	buf := make([]byte, n*2)
+	for i := 0; i < n; i++ {
+		v := int16(12000)
+		if i%8 < 4 {
+			v = -12000
+		}
+		buf[i*2] = byte(v)
+		buf[i*2+1] = byte(v >> 8)
+	}
+	return buf
+}
+
+// pcmSilence returns d worth of zeroed 16-bit mono PCM at sampleRate.
+func pcmSilence(d time.Duration, sampleRate int) []byte {
+	return make([]byte, int(float64(sampleRate)*d.Seconds())*2)
+}
+
+// TestOpenDuplexVADModeDeliversTranscriptToTextProvider is the behavioral half
+// of #1637: admitting a text-only provider through the construction gate is
+// only useful if the VAD pipeline then actually drives it. This feeds PCM
+// through the real AudioTurn → STT → LLM path and asserts the model received
+// the STT transcript as a user message.
+//
+// The assertion is made after Close because VAD mode currently builds a
+// non-streaming ProviderStage (sdk/internal/pipeline/builder.go sets
+// Streaming only for the ingestion path) and never sets
+// AudioTurnConfig.EmitEndOfTurn, so the model fires once when the input
+// channel closes rather than per turn. That per-turn gap is a separate,
+// pre-existing VAD-mode defect — it affects Gemini callers too — and is
+// deliberately not fixed here; this test asserts only what the gate change
+// itself makes possible, so it does not encode the gap as intended behavior.
+func TestOpenDuplexVADModeDeliversTranscriptToTextProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip("drives a real VAD turn in wall-clock time and closes a duplex session")
+	}
+	const sampleRate = 16000
+	packFile := writeIngestionTestPack(t)
+	provider := &recordingTextProvider{}
+
+	conv, err := OpenDuplex(packFile, "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithVADMode(&convMockSTTService{}, newConvMockTTSService(), &VADModeConfig{
+			SilenceDuration:   300 * time.Millisecond,
+			MinSpeechDuration: 100 * time.Millisecond,
+			MaxTurnDuration:   5 * time.Second,
+			SampleRate:        sampleRate,
+			Language:          "en",
+			Voice:             "alloy",
+			Speed:             1.0,
+		}),
+	)
+	require.NoError(t, err)
+
+	responseCh, err := conv.Response()
+	require.NoError(t, err)
+	go func() {
+		for range responseCh {
+		}
+	}()
+
+	ctx := context.Background()
+	send := func(pcm []byte) {
+		require.NoError(t, conv.SendChunk(ctx, &providers.StreamChunk{
+			MediaData: &providers.StreamMediaData{MIMEType: "audio/pcm", Data: pcm},
+		}))
+	}
+
+	// One utterance: speech long enough to open a turn, then silence long
+	// enough to close it. convMockSTTService transcribes anything as "hello".
+	// Frames are streamed at their real duration because AudioTurnStage
+	// measures speech and silence with time.Since and only re-evaluates the
+	// turn on element arrival — bulk-sending the same bytes never closes a turn.
+	const frame = 20 * time.Millisecond
+	for i := 0; i < 30; i++ {
+		send(pcmSpeech(frame, sampleRate))
+		time.Sleep(frame)
+	}
+	for i := 0; i < 30; i++ {
+		send(pcmSilence(frame, sampleRate))
+		time.Sleep(frame)
+	}
+
+	// Close both flushes the turn and, today, reports a drain timeout on this
+	// path (tracked separately as #1638). The drain outcome is logged rather
+	// than asserted: what this test is about is whether the transcript reached
+	// the model, which it does regardless.
+	if err := conv.Close(); err != nil {
+		t.Logf("Close reported: %v (see #1638)", err)
+	}
+	assert.True(t, provider.waitForUserText("hello", 5*time.Second),
+		"model must receive the STT transcript as a user message; got %v", provider.userTexts())
+}


### PR DESCRIPTION
## What

Exempts VAD mode from the `providers.StreamInputSupport` requirement in `OpenDuplex`, mirroring the existing `WithIngestion` exemption.

The two duplex modes have opposite provider requirements:

| Mode | Speech handled by | Needs `StreamInputSupport`? |
|---|---|---|
| ASM | the provider (Gemini Live, OpenAI Realtime) | yes — audio goes to the model |
| VAD | the pipeline (`AudioTurn → STT → LLM → TTS`) | no — the model only ever sees text |

VAD mode exists *for* providers without built-in speech, so requiring the ASM interface excluded exactly the providers it was built to serve. The gate's own comment already reasoned this way; the condition didn't implement it. The `OpenDuplex` doc comment (which still claimed Gemini-only) is updated too.

## Verification

Two tests, both written before the fix and watched to fail:

- `TestOpenDuplexVADModeAcceptsNonStreamInputProvider` — the construction gate. Failed with the exact reported error before the change.
- `TestOpenDuplexVADModeDeliversTranscriptToTextProvider` — end-to-end: streams real PCM through `AudioTurn → STT` and asserts the transcript reaches the model as a user message.

Full SDK suite green (`sdk`, `sdk/session`, `sdk/internal/...`), plus `runtime/pipeline/...`.

## A finding this surfaced, deliberately NOT fixed here

The issue asked whether VAD mode works once admitted. It does — but the model fires **once at session close, not per turn**:

- `sdk/internal/pipeline/builder.go:499` sets `Streaming: cfg.Ingestion != nil`, so VAD mode gets the non-streaming `ProviderStage`.
- `AudioTurnConfig.EmitEndOfTurn` is never set anywhere in the SDK, so no turn boundaries are emitted regardless.

This is **pre-existing and not caused by this change** — `builder.go:478` picks the VAD path whenever `VADConfig != nil` regardless of provider, so Gemini callers of `WithVADMode` hit it too. It's the same three-coupled-pieces shape as the `WithIngestion` path in #1612 (relaxed gate + streaming ProviderStage + `EmitEndOfTurn`); this PR is piece one.

The behavioral test therefore asserts after `Close()`, and says so in a comment, so it doesn't encode the gap as intended behavior.

Note that `sdk/examples/voice-interview` is the only `WithVADMode` caller in the repo — `voice-sales-assist` is on the `WithIngestion` path, which already has all three pieces, which is why it works.

## Incidental: #1638 reproduces

`conv.Close()` on a VAD duplex session returns `drain timed out: context deadline exceeded` and blocks the full 30s — even on an idle session that received no input, and whether or not the response channel is drained. Not diagnosed, not addressed here; both new tests pay the 30s.

Closes #1637
