### PR TITLE
fix(sdk,pipeline): duplex Close drains promptly instead of timing out

### DIFF
--- a/runtime/pipeline/stage/provider_endofstream_test.go
+++ b/runtime/pipeline/stage/provider_endofstream_test.go
@@ -1,0 +1,46 @@
+package stage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProviderStageCompletesOnEndOfStreamWithoutChannelClose proves the
+// non-streaming ProviderStage treats an EndOfStream control element as
+// end-of-input, rather than waiting for the input channel to close.
+//
+// This is what makes graceful duplex shutdown possible. duplexSession.Drain
+// signals end-of-input by sending EndOfStream and then waits for the pipeline
+// to finish before closing the channel — so a stage that only reacts to channel
+// close can never complete during a drain, and every duplex Close burns the
+// full 30s DefaultDrainTimeout before hard-closing. EndOfStream is already the
+// established session-over signal honored by AudioTurnStage, ResponseVAD and
+// the streaming ProviderStage; this stage was the sole holdout. See #1638.
+func TestProviderStageCompletesOnEndOfStreamWithoutChannelClose(t *testing.T) {
+	provider := mock.NewProvider("mock", "mock-model", false)
+	st := NewProviderStage(provider, nil, nil, &ProviderConfig{})
+
+	// Deliberately left open for the lifetime of the test, exactly as Drain
+	// leaves it: the stage must finish on the control element alone.
+	input := make(chan StreamElement, 4)
+	output := make(chan StreamElement, 16)
+
+	msg := types.Message{Role: "user", Content: "hello"}
+	input <- StreamElement{Message: &msg}
+	input <- StreamElement{EndOfStream: true}
+
+	done := make(chan error, 1)
+	go func() { done <- st.Process(context.Background(), input, output) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ProviderStage did not complete on EndOfStream while the input channel stayed open")
+	}
+}

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -221,6 +221,14 @@ func (s *ProviderStage) Process(
 
 // accumulateInput collects messages from the input channel and seeds
 // per-Turn provider request metadata from TurnState.
+//
+// Input ends on either a closed channel (the unary "pipeline per turn" shape)
+// or an EndOfStream control element. Honoring EndOfStream is what lets a duplex
+// session shut down gracefully: duplexSession.Drain signals end-of-input with
+// that element and then waits for the pipeline to finish *before* closing the
+// channel, so waiting on channel close alone deadlocks the drain until its
+// timeout expires. EndOfStream is the same session-over signal AudioTurnStage,
+// ResponseVAD and processStreaming already honor. See #1638.
 func (s *ProviderStage) accumulateInput(input <-chan StreamElement) *providerInput {
 	acc := &providerInput{
 		metadata: make(map[string]interface{}),
@@ -229,6 +237,9 @@ func (s *ProviderStage) accumulateInput(input <-chan StreamElement) *providerInp
 	for elem := range input {
 		if elem.Message != nil {
 			acc.messages = append(acc.messages, *elem.Message)
+		}
+		if elem.EndOfStream {
+			break
 		}
 	}
 

--- a/sdk/duplex_drain_test.go
+++ b/sdk/duplex_drain_test.go
@@ -1,0 +1,98 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// closeDuration reports how long Close took and what it returned.
+func closeDuration(t *testing.T, conv *Conversation) (time.Duration, error) {
+	t.Helper()
+	start := time.Now()
+	err := conv.Close()
+	return time.Since(start), err
+}
+
+// drainBudget is well under session.DefaultDrainTimeout (30s): a graceful drain
+// completes in milliseconds, so anything near the timeout means it deadlocked.
+const drainBudget = 5 * time.Second
+
+// TestDuplexCloseDrainsPromptly covers #1638: closing a duplex conversation
+// used to block for the full 30s drain timeout and return
+// "drain timed out: context deadline exceeded", regardless of whether the
+// caller drained Response().
+//
+// Drain sends an EndOfStream element and waits for the pipeline before closing
+// the input channel, but the non-streaming ProviderStage only ended on channel
+// close — so the wait could never succeed. The session did shut down correctly
+// afterwards via the hard-close fallback, which is why the failure showed up as
+// a 30s pause rather than broken behavior.
+//
+// The subtests cover the shapes that all previously timed out, including the
+// undrained case the issue originally blamed. Draining was never the variable.
+func TestDuplexCloseDrainsPromptly(t *testing.T) {
+	newConv := func(t *testing.T) *Conversation {
+		t.Helper()
+		conv, err := OpenDuplex(writeIngestionTestPack(t), "main",
+			WithProvider(mock.NewStreamingProvider("mock", "mock-model", false).
+				WithAutoRespond("hi")),
+			WithSkipSchemaValidation(),
+		)
+		require.NoError(t, err)
+		return conv
+	}
+
+	sendOne := func(t *testing.T, conv *Conversation) {
+		t.Helper()
+		require.NoError(t, conv.SendChunk(context.Background(),
+			&providers.StreamChunk{Content: "hello"}))
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Run("idle session that never received input", func(t *testing.T) {
+		d, err := closeDuration(t, newConv(t))
+		assert.NoError(t, err)
+		assert.Less(t, d, drainBudget, "Close blocked on the drain timeout")
+	})
+
+	t.Run("response channel drained", func(t *testing.T) {
+		conv := newConv(t)
+		ch, err := conv.Response()
+		require.NoError(t, err)
+		go func() {
+			for range ch {
+			}
+		}()
+		sendOne(t, conv)
+
+		d, cerr := closeDuration(t, conv)
+		assert.NoError(t, cerr)
+		assert.Less(t, d, drainBudget, "Close blocked on the drain timeout")
+	})
+
+	t.Run("response channel taken but never read", func(t *testing.T) {
+		conv := newConv(t)
+		_, err := conv.Response()
+		require.NoError(t, err)
+		sendOne(t, conv)
+
+		d, cerr := closeDuration(t, conv)
+		assert.NoError(t, cerr)
+		assert.Less(t, d, drainBudget, "Close blocked on the drain timeout")
+	})
+
+	t.Run("response never requested", func(t *testing.T) {
+		conv := newConv(t)
+		sendOne(t, conv)
+
+		d, cerr := closeDuration(t, conv)
+		assert.NoError(t, cerr)
+		assert.Less(t, d, drainBudget, "Close blocked on the drain timeout")
+	})
+}

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -432,6 +432,16 @@ func (s *duplexSession) Drain(ctx context.Context) error {
 	}
 	s.closeMu.Unlock()
 
+	// A session that never received a chunk never started executePipeline, so
+	// pipelineDone will never be closed and there is nothing to drain. Waiting
+	// would block for the full timeout and then report a spurious failure.
+	s.executionMu.Lock()
+	started := s.executionStarted
+	s.executionMu.Unlock()
+	if !started {
+		return s.Close()
+	}
+
 	// Send EndOfStream signal so the pipeline knows input is done.
 	select {
 	case s.stageInput <- stage.StreamElement{EndOfStream: true}:


### PR DESCRIPTION
## What

Closing a duplex conversation blocked for the full 30s `DefaultDrainTimeout` and returned `drain timed out: context deadline exceeded`. Now it completes in milliseconds and returns `nil`.

The session always *did* shut down correctly afterwards, via the hard-close fallback — so the symptom was a 30s pause and a spurious error, not broken behavior. That's why it went unnoticed.

## Root causes (two, independent)

**1. `Drain` deadlocked against its own shutdown order.** It signals end-of-input by sending an `EndOfStream` element, then waits for the pipeline to finish *before* closing the input channel. But the non-streaming `ProviderStage`'s `accumulateInput` ended only on channel close, so the wait could never succeed.

`EndOfStream` is already the session-over signal honored by `AudioTurnStage`, `ResponseVAD` and `processStreaming` — `accumulateInput` was the sole holdout. It now breaks on it too.

**2. Idle sessions waited on a channel nothing would ever close.** `executePipeline` (whose `defer` closes `pipelineDone`) only starts on the first `SendChunk`, so a session that never received input had no pipeline to drain. `Drain` now short-circuits to `Close` when execution never started.

## Measurements

`Close()` duration, before → after:

| Scenario | Before | After |
|---|---|---|
| Idle, no input | 30.0s + error | ~0s, nil |
| Active, `Response()` drained | 30.0s + error | 0.2s, nil |
| Active, `Response()` taken but never read | 30.0s + error | 0.2s, nil |
| Active, `Response()` never called | 30.0s + error | 0.2s, nil |
| `WithIngestion` (already worked) | 0s, nil | 0s, nil |

## Note: this is not the mechanism #1638 describes

The issue attributes the stall to an undrained `Response()` channel. Measurement contradicts that — the drained and undrained cases were identical at 30s, and a session that never called `Response()` at all behaved the same. Draining was never the variable.

The one path that already closed promptly was `WithIngestion`, because it sets `Streaming: true` and therefore used the `EndOfStream`-honoring provider loop. That asymmetry is what isolated cause 1.

Marked `Refs #1638` rather than `Closes`, because the issue's actual ask — documenting the `Response()` draining requirement on `Conversation.Response()` — is untouched here, and whether that documented requirement is real has not been tested.

## Tests

- `TestProviderStageCompletesOnEndOfStreamWithoutChannelClose` (runtime) — the stage-level defect, written first and watched to fail.
- `TestDuplexCloseDrainsPromptly` (sdk) — all four session shapes, asserting Close returns `nil` well under the drain timeout.

Full `runtime/...` and `sdk/...` suites pass.

One unrelated failure appeared under concurrent sweeps, `TestExecEvalHook_PassesArgsAndEnv`. It reproduces identically on unmodified `main` under the same load, so it is pre-existing, not caused by this change. Its exec hook gives a spawned subprocess a fixed 5s, and under CPU contention the process is killed and the test then asserts on a file that was never written — worth fixing separately.

Refs #1638
