### PR TITLE
feat(sdk): multi-track audio ingestion helper for duplex voice apps

### DIFF
--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -228,6 +228,8 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
 - [type EvaluateOpts](<#EvaluateOpts>)
 - [type InMemoryA2ATaskStore](<#InMemoryA2ATaskStore>)
 - [type IngestionFunc](<#IngestionFunc>)
+  - [func MultiTrackIngestion\(cfg MultiTrackIngestionConfig\) IngestionFunc](<#MultiTrackIngestion>)
+- [type IngestionTrack](<#IngestionTrack>)
 - [type LocalAgentExecutor](<#LocalAgentExecutor>)
   - [func NewLocalAgentExecutor\(members map\[string\]Agent\) \*LocalAgentExecutor](<#NewLocalAgentExecutor>)
   - [func \(e \*LocalAgentExecutor\) Execute\(ctx context.Context, descriptor \*tools.ToolDescriptor, args json.RawMessage\) \(json.RawMessage, error\)](<#LocalAgentExecutor.Execute>)
@@ -266,6 +268,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func \(s \*MultiAgentSession\) Entry\(\) Agent](<#MultiAgentSession.Entry>)
   - [func \(s \*MultiAgentSession\) Members\(\) map\[string\]Agent](<#MultiAgentSession.Members>)
   - [func \(s \*MultiAgentSession\) Send\(ctx context.Context, message any, opts ...SendOption\) \(\*Response, error\)](<#MultiAgentSession.Send>)
+- [type MultiTrackIngestionConfig](<#MultiTrackIngestionConfig>)
 - [type Option](<#Option>)
   - [func WithA2AAgent\(builder \*A2AAgentBuilder\) Option](<#WithA2AAgent>)
   - [func WithA2ATools\(bridge \*a2a.ToolBridge\) Option](<#WithA2ATools>)
@@ -2228,6 +2231,49 @@ IngestionFunc authors a custom upstream stage sub\-graph. It adds stages and edg
 type IngestionFunc func(b *stage.PipelineBuilder) (outputNode string, err error)
 ```
 
+<a name="MultiTrackIngestion"></a>
+### func MultiTrackIngestion
+
+```go
+func MultiTrackIngestion(cfg MultiTrackIngestionConfig) IngestionFunc
+```
+
+MultiTrackIngestion returns an IngestionFunc \(for WithIngestion\) that fans inbound audio out to one independent per\-track pipeline each — resample → VAD turn detection → STT → speaker\-labeled Message — keyed on StreamChunk.Source, then merges the labeled transcripts back into the single stream the standard agent chain consumes.
+
+It exists so a two\-party / multi\-party voice application does not have to re\-derive the routing topology by hand, which hides two footguns:
+
+- Control signals \(EndOfStream/EndOfTurn/Interrupt\) carry no Source, so the router broadcasts them to every track. Routing only on Source would drop them, the merge would never complete, and a duplex session's Drain/Close would deadlock waiting on it.
+- PipelineBuilder.Chain already registers the stages it wires, so each track's stages are added exactly once \(via Chain\), never AddStage'd first, which would trip Build's duplicate\-name check.
+
+The returned function forces EmitEndOfTurn on every track so the streaming ProviderStage installed by the WithIngestion duplex path fires the agent once per turn \(per track\) rather than only at session close.
+
+<a name="IngestionTrack"></a>
+## type IngestionTrack
+
+IngestionTrack describes one named audio track fed into the multi\-track ingestion graph built by MultiTrackIngestion. Each track gets its own independent resample→VAD\-turn→STT→label pipeline, keyed on the audio's StreamChunk.Source.
+
+```go
+type IngestionTrack struct {
+    // Source matches StreamChunk.Source on inbound audio destined for this
+    // track — the value passed to Conversation.SendChunk. It also uniquifies
+    // this track's stage names, so it must be distinct across tracks.
+    Source string
+
+    // Speaker prefixes each transcribed Message from this track, e.g.
+    // "CUSTOMER" yields "CUSTOMER: <transcript>", so a multi-party agent chain
+    // can attribute turns to a speaker. Empty means no prefix.
+    Speaker string
+
+    // STT transcribes this track's audio. Required.
+    STT base.STTProvider
+
+    // TurnConfig optionally overrides turn-detection/VAD config for this track.
+    // Nil uses stage.DefaultAudioTurnConfig(). MultiTrackIngestion always forces
+    // EmitEndOfTurn on the effective config so the agent fires once per turn.
+    TurnConfig *stage.AudioTurnConfig
+}
+```
+
 <a name="LocalAgentExecutor"></a>
 ## type LocalAgentExecutor
 
@@ -2638,6 +2684,24 @@ func (s *MultiAgentSession) Send(ctx context.Context, message any, opts ...SendO
 ```
 
 Send sends a message through the entry agent.
+
+<a name="MultiTrackIngestionConfig"></a>
+## type MultiTrackIngestionConfig
+
+MultiTrackIngestionConfig configures MultiTrackIngestion.
+
+```go
+type MultiTrackIngestionConfig struct {
+    // Tracks are the audio tracks to ingest. At least one is required.
+    Tracks []IngestionTrack
+
+    // OnTranscript, if set, is called with the speaker label and raw
+    // transcribed text for every completed turn on any track — a convenient
+    // hook for mirroring the live transcript to a UI without subscribing to
+    // EventAudioTranscription.
+    OnTranscript func(speaker, text string)
+}
+```
 
 <a name="Option"></a>
 ## type Option

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -2268,8 +2268,14 @@ type IngestionTrack struct {
     STT base.STTProvider
 
     // TurnConfig optionally overrides turn-detection/VAD config for this track.
-    // Nil uses stage.DefaultAudioTurnConfig(). MultiTrackIngestion always forces
+    // Nil uses stage.DefaultAudioTurnConfig(), which lets each track's
+    // AudioTurnStage construct its own VAD. MultiTrackIngestion always forces
     // EmitEndOfTurn on the effective config so the agent fires once per turn.
+    //
+    // If you set an explicit VAD (TurnConfig.VAD), give each track its own
+    // instance — the detector is stateful, so sharing one across tracks
+    // interleaves their audio into a single VAD state and corrupts turn
+    // detection on both.
     TurnConfig *stage.AudioTurnConfig
 }
 ```

--- a/sdk/ingestion_multitrack.go
+++ b/sdk/ingestion_multitrack.go
@@ -1,0 +1,205 @@
+package sdk
+
+import (
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	intpipeline "github.com/AltairaLabs/PromptKit/sdk/internal/pipeline"
+)
+
+// roleUser is the message role for a transcribed turn handed to the agent chain.
+const roleUser = "user"
+
+// IngestionTrack describes one named audio track fed into the multi-track
+// ingestion graph built by MultiTrackIngestion. Each track gets its own
+// independent resample→VAD-turn→STT→label pipeline, keyed on the audio's
+// StreamChunk.Source.
+type IngestionTrack struct {
+	// Source matches StreamChunk.Source on inbound audio destined for this
+	// track — the value passed to Conversation.SendChunk. It also uniquifies
+	// this track's stage names, so it must be distinct across tracks.
+	Source string
+
+	// Speaker prefixes each transcribed Message from this track, e.g.
+	// "CUSTOMER" yields "CUSTOMER: <transcript>", so a multi-party agent chain
+	// can attribute turns to a speaker. Empty means no prefix.
+	Speaker string
+
+	// STT transcribes this track's audio. Required.
+	STT base.STTProvider
+
+	// TurnConfig optionally overrides turn-detection/VAD config for this track.
+	// Nil uses stage.DefaultAudioTurnConfig(). MultiTrackIngestion always forces
+	// EmitEndOfTurn on the effective config so the agent fires once per turn.
+	TurnConfig *stage.AudioTurnConfig
+}
+
+// MultiTrackIngestionConfig configures MultiTrackIngestion.
+type MultiTrackIngestionConfig struct {
+	// Tracks are the audio tracks to ingest. At least one is required.
+	Tracks []IngestionTrack
+
+	// OnTranscript, if set, is called with the speaker label and raw
+	// transcribed text for every completed turn on any track — a convenient
+	// hook for mirroring the live transcript to a UI without subscribing to
+	// EventAudioTranscription.
+	OnTranscript func(speaker, text string)
+}
+
+// MultiTrackIngestion returns an IngestionFunc (for WithIngestion) that fans
+// inbound audio out to one independent per-track pipeline each — resample → VAD
+// turn detection → STT → speaker-labeled Message — keyed on StreamChunk.Source,
+// then merges the labeled transcripts back into the single stream the standard
+// agent chain consumes.
+//
+// It exists so a two-party / multi-party voice application does not have to
+// re-derive the routing topology by hand, which hides two footguns:
+//
+//   - Control signals (EndOfStream/EndOfTurn/Interrupt) carry no Source, so the
+//     router broadcasts them to every track. Routing only on Source would drop
+//     them, the merge would never complete, and a duplex session's Drain/Close
+//     would deadlock waiting on it.
+//   - PipelineBuilder.Chain already registers the stages it wires, so each
+//     track's stages are added exactly once (via Chain), never AddStage'd
+//     first, which would trip Build's duplicate-name check.
+//
+// The returned function forces EmitEndOfTurn on every track so the streaming
+// ProviderStage installed by the WithIngestion duplex path fires the agent once
+// per turn (per track) rather than only at session close.
+func MultiTrackIngestion(cfg MultiTrackIngestionConfig) IngestionFunc {
+	return func(b *stage.PipelineBuilder) (string, error) {
+		if len(cfg.Tracks) == 0 {
+			return "", fmt.Errorf("MultiTrackIngestion: at least one track is required")
+		}
+
+		trackStages, err := buildAllTrackStages(cfg)
+		if err != nil {
+			return "", err
+		}
+		heads, tails, headBySource := trackEndpoints(cfg.Tracks, trackStages)
+
+		router := stage.NewRouterStage("router", routeBySource(heads, headBySource))
+		merge := stage.NewMergeStage("merge", len(cfg.Tracks))
+
+		// Chain registers each track's stages exactly once (it appends to the
+		// builder's stage list as well as wiring sequential edges), so no
+		// AddStage precedes it — that would double-register and fail Build's
+		// duplicate stage-name check.
+		b.AddStage(router)
+		b.AddStage(merge)
+		b.Branch("router", heads...)
+		for _, stages := range trackStages {
+			b.Chain(stages...)
+		}
+		b.Merge("merge", tails...)
+
+		return "merge", nil
+	}
+}
+
+// buildAllTrackStages builds the per-track stage slices, rejecting a missing
+// STT provider or a duplicate track source.
+func buildAllTrackStages(cfg MultiTrackIngestionConfig) ([][]stage.Stage, error) {
+	trackStages := make([][]stage.Stage, len(cfg.Tracks))
+	seen := make(map[string]bool, len(cfg.Tracks))
+	for i, track := range cfg.Tracks {
+		if track.STT == nil {
+			return nil, fmt.Errorf("MultiTrackIngestion: track %q has no STT provider", track.Source)
+		}
+		if seen[track.Source] {
+			return nil, fmt.Errorf("MultiTrackIngestion: duplicate track source %q", track.Source)
+		}
+		seen[track.Source] = true
+
+		stages, err := buildTrackStages(track, cfg.OnTranscript)
+		if err != nil {
+			return nil, err
+		}
+		trackStages[i] = stages
+	}
+	return trackStages, nil
+}
+
+// trackEndpoints returns each track's head and tail stage name, plus a map from
+// track source to head stage name for the router.
+func trackEndpoints(
+	tracks []IngestionTrack, trackStages [][]stage.Stage,
+) (heads, tails []string, headBySource map[string]string) {
+	heads = make([]string, len(trackStages))
+	tails = make([]string, len(trackStages))
+	headBySource = make(map[string]string, len(trackStages))
+	for i, stages := range trackStages {
+		heads[i] = stages[0].Name()
+		tails[i] = stages[len(stages)-1].Name()
+		headBySource[tracks[i].Source] = stages[0].Name()
+	}
+	return heads, tails, headBySource
+}
+
+// routeBySource routes an element to its track by Source, broadcasting Source-less
+// control signals (EndOfStream/EndOfTurn/Interrupt) to every track so they
+// cascade through each per-track sub-chain and let the merge's ProcessMultiple
+// complete. Routing only on Source would silently drop them (no source matches)
+// and deadlock a duplex session's Drain/Close.
+func routeBySource(heads []string, headBySource map[string]string) stage.RouterFunc {
+	return func(e *stage.StreamElement) []string {
+		if e.EndOfStream || e.EndOfTurn || e.Interrupt {
+			return heads
+		}
+		if head, ok := headBySource[e.Source]; ok {
+			return []string{head}
+		}
+		return nil
+	}
+}
+
+// buildTrackStages returns the ordered stages for one track:
+// resample → AudioTurn(VAD, EmitEndOfTurn) → STT → labeled ToMessage.
+//
+// The first three come from the shared internal BuildAudioTrackStages so the
+// resample/turn/STT segment stays identical to the single-track VAD front. The
+// trailing ToMessage stage is specific to ingestion sub-graphs: STTStage emits
+// StreamElement{Text}, but the agent chain (ProviderStage) only ever acts on
+// StreamElement.Message, so a bare transcript would silently vanish without
+// this conversion. IngestionFunc callbacks own their whole sub-graph up to the
+// node they hand back, so adding it here is squarely within the API surface.
+func buildTrackStages(track IngestionTrack, onTranscript func(speaker, text string)) ([]stage.Stage, error) {
+	turnCfg := stage.DefaultAudioTurnConfig()
+	if track.TurnConfig != nil {
+		turnCfg = *track.TurnConfig
+	}
+	// Fire the agent per turn: the streaming ProviderStage the WithIngestion
+	// duplex path installs keys off EndOfTurn.
+	turnCfg.EmitEndOfTurn = true
+
+	stages, err := intpipeline.BuildAudioTrackStages(
+		track.Source, true, turnCfg, stage.DefaultSTTStageConfig(), track.STT,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("MultiTrackIngestion: track %q: %w", track.Source, err)
+	}
+
+	speaker := track.Speaker
+	label := func(elem stage.StreamElement) (stage.StreamElement, error) {
+		if elem.Text == nil {
+			return elem, nil
+		}
+		text := *elem.Text
+		if onTranscript != nil {
+			onTranscript(speaker, text)
+		}
+		labeled := text
+		if speaker != "" {
+			labeled = speaker + ": " + text
+		}
+		msg := types.NewTextMessage(roleUser, labeled)
+		elem.Message = &msg
+		elem.Text = nil
+		return elem, nil
+	}
+	toMessage := stage.NewMapStage(track.Source+"_to_message", label)
+
+	return append(stages, toMessage), nil
+}

--- a/sdk/ingestion_multitrack.go
+++ b/sdk/ingestion_multitrack.go
@@ -31,8 +31,14 @@ type IngestionTrack struct {
 	STT base.STTProvider
 
 	// TurnConfig optionally overrides turn-detection/VAD config for this track.
-	// Nil uses stage.DefaultAudioTurnConfig(). MultiTrackIngestion always forces
+	// Nil uses stage.DefaultAudioTurnConfig(), which lets each track's
+	// AudioTurnStage construct its own VAD. MultiTrackIngestion always forces
 	// EmitEndOfTurn on the effective config so the agent fires once per turn.
+	//
+	// If you set an explicit VAD (TurnConfig.VAD), give each track its own
+	// instance — the detector is stateful, so sharing one across tracks
+	// interleaves their audio into a single VAD state and corrupts turn
+	// detection on both.
 	TurnConfig *stage.AudioTurnConfig
 }
 

--- a/sdk/ingestion_multitrack_test.go
+++ b/sdk/ingestion_multitrack_test.go
@@ -1,0 +1,195 @@
+package sdk
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bytesPerTestFrame is 20ms of 8kHz 16-bit mono PCM (8000 * 0.02 * 2).
+const bytesPerTestFrame = 320
+
+// fixedSTT is a base.STTProvider that answers every transcription with the same
+// line. Each track gets its own instance so the test can prove the two tracks
+// transcribe independently and are labeled with the right speaker.
+type fixedSTT struct{ line string }
+
+func (f *fixedSTT) Name() string                      { return "fixed" }
+func (f *fixedSTT) Type() base.ProviderType           { return base.ProviderTypeSTT }
+func (f *fixedSTT) Pricing() *base.PricingDescriptor  { return nil }
+func (f *fixedSTT) Validate() error                   { return nil }
+func (f *fixedSTT) Init(context.Context) error        { return nil }
+func (f *fixedSTT) HealthCheck(context.Context) error { return nil }
+func (f *fixedSTT) Close() error                      { return nil }
+func (f *fixedSTT) Transcribe(context.Context, base.STTRequest) (base.STTResponse, error) {
+	return base.STTResponse{Text: f.line}, nil
+}
+
+// feedTrackTurn pushes one loud-then-silent "turn" of 8kHz PCM16 on the given
+// Source track: > MinSpeechDuration of non-silent samples, then enough silence
+// (> the default turn SilenceDuration) that AudioTurnStage detects a complete
+// turn and emits it to STT. Amplitude pattern (~0x20 every other byte) matches
+// what drives the real audio VAD.
+func feedTrackTurn(in chan<- stage.StreamElement, source string) {
+	loud := make([]byte, 4800) // 300ms
+	for i := 0; i+1 < len(loud); i += 2 {
+		loud[i+1] = 0x20
+	}
+	silence := make([]byte, 48000) // 3s, comfortably over any default SilenceDuration
+	pcm := append(loud, silence...)
+
+	for off := 0; off < len(pcm); off += bytesPerTestFrame {
+		end := min(off+bytesPerTestFrame, len(pcm))
+		elem := stage.NewAudioElement(&stage.AudioData{
+			Samples:    pcm[off:end],
+			SampleRate: 8000,
+			Channels:   1,
+			Format:     stage.AudioFormatPCM16,
+		})
+		elem.Source = source
+		in <- elem
+	}
+}
+
+// TestMultiTrackIngestion_RoutesTranscribesLabelsAndBroadcasts drives the
+// IngestionFunc built by MultiTrackIngestion directly through a PipelineBuilder
+// (bypassing OpenDuplex) to deterministically prove its whole contract:
+//
+//  1. Elements route to their own per-track resample→VAD→STT pipeline by
+//     StreamElement.Source.
+//  2. Each track transcribes independently (distinct STT per track).
+//  3. Each transcript becomes a role="user" Message prefixed with the track's
+//     speaker label, and OnTranscript fires per completed turn.
+//  4. Control signals (EndOfStream) with no Source are broadcast to every track
+//     rather than dropped — so they reach the merge output and Drain/Close of a
+//     real duplex session can't deadlock waiting on a merge that never sees
+//     end-of-stream (the #1638 failure class).
+//  5. The whole graph passes PipelineBuilder.Build validation — i.e. no
+//     duplicate stage registration (the AddStage+Chain double-register footgun).
+func TestMultiTrackIngestion_RoutesTranscribesLabelsAndBroadcasts(t *testing.T) {
+	var mu sync.Mutex
+	var transcripts []string
+	onTranscript := func(speaker, text string) {
+		mu.Lock()
+		transcripts = append(transcripts, speaker+": "+text)
+		mu.Unlock()
+	}
+
+	ingest := MultiTrackIngestion(MultiTrackIngestionConfig{
+		Tracks: []IngestionTrack{
+			{Source: "caller", Speaker: "CUSTOMER", STT: &fixedSTT{line: "hello from caller"}},
+			{Source: "agent", Speaker: "AGENT", STT: &fixedSTT{line: "hi from agent"}},
+		},
+		OnTranscript: onTranscript,
+	})
+
+	b := stage.NewPipelineBuilder()
+	outputNode, err := ingest(b)
+	require.NoError(t, err)
+
+	var sinkMu sync.Mutex
+	var messages []string
+	var sawEndOfStream bool
+	sink := stage.NewMapStage("sink", func(elem stage.StreamElement) (stage.StreamElement, error) {
+		sinkMu.Lock()
+		if elem.Message != nil {
+			messages = append(messages, elem.Message.GetContent())
+		}
+		if elem.EndOfStream {
+			sawEndOfStream = true
+		}
+		sinkMu.Unlock()
+		return elem, nil
+	})
+	b.AddStage(sink)
+	b.Connect(outputNode, sink.Name())
+
+	pipe, err := b.Build()
+	require.NoError(t, err, "the ingestion sub-graph must pass build validation (no duplicate registration)")
+
+	in := make(chan stage.StreamElement, 512)
+	out, err := pipe.Execute(context.Background(), in)
+	require.NoError(t, err)
+
+	feedTrackTurn(in, "caller")
+	feedTrackTurn(in, "agent")
+	// A control signal with no Source must be broadcast to every track, not
+	// dropped for lack of a matching route.
+	in <- stage.StreamElement{EndOfStream: true}
+	close(in)
+
+	for range out { // drain to completion; if merge deadlocked this would hang
+	}
+
+	mu.Lock()
+	assert.ElementsMatch(t,
+		[]string{"CUSTOMER: hello from caller", "AGENT: hi from agent"},
+		transcripts,
+		"each track must transcribe independently and fire OnTranscript with its speaker label")
+	mu.Unlock()
+
+	sinkMu.Lock()
+	assert.ElementsMatch(t,
+		[]string{"CUSTOMER: hello from caller", "AGENT: hi from agent"},
+		messages,
+		"each transcript must reach the merge output as a speaker-labeled Message")
+	assert.True(t, sawEndOfStream,
+		"EndOfStream must be broadcast through the tracks to the merge output, not dropped")
+	sinkMu.Unlock()
+}
+
+// TestMultiTrackIngestion_SingleTrack proves the helper is not two-party-only:
+// one track builds and routes correctly through the same router/merge topology.
+func TestMultiTrackIngestion_SingleTrack(t *testing.T) {
+	ingest := MultiTrackIngestion(MultiTrackIngestionConfig{
+		Tracks: []IngestionTrack{
+			{Source: "caller", Speaker: "CUSTOMER", STT: &fixedSTT{line: "solo"}},
+		},
+	})
+
+	b := stage.NewPipelineBuilder()
+	outputNode, err := ingest(b)
+	require.NoError(t, err)
+
+	var sinkMu sync.Mutex
+	var messages []string
+	sink := stage.NewMapStage("sink", func(elem stage.StreamElement) (stage.StreamElement, error) {
+		if elem.Message != nil {
+			sinkMu.Lock()
+			messages = append(messages, elem.Message.GetContent())
+			sinkMu.Unlock()
+		}
+		return elem, nil
+	})
+	b.AddStage(sink)
+	b.Connect(outputNode, sink.Name())
+
+	pipe, err := b.Build()
+	require.NoError(t, err)
+
+	in := make(chan stage.StreamElement, 512)
+	out, err := pipe.Execute(context.Background(), in)
+	require.NoError(t, err)
+
+	feedTrackTurn(in, "caller")
+	close(in)
+	for range out {
+	}
+
+	sinkMu.Lock()
+	assert.Equal(t, []string{"CUSTOMER: solo"}, messages)
+	sinkMu.Unlock()
+}
+
+// TestMultiTrackIngestion_RejectsEmptyTracks guards the obvious misuse.
+func TestMultiTrackIngestion_RejectsEmptyTracks(t *testing.T) {
+	ingest := MultiTrackIngestion(MultiTrackIngestionConfig{})
+	_, err := ingest(stage.NewPipelineBuilder())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "at least one track")
+}


### PR DESCRIPTION
## What

Adds `sdk.MultiTrackIngestion` — an `IngestionFunc` (for `WithIngestion`) that fans inbound audio out to one independent per-track pipeline each (`resample → VAD turn → STT → speaker-labeled Message`), keyed on `StreamChunk.Source`, then merges the labeled transcripts back into the single stream the agent chain consumes.

## Why

The `voice-sales-assist` example hand-rolled this exact router→per-track→merge topology. The value of promoting it isn't code reuse — it's that the topology hides two footguns a consumer would otherwise re-derive and debug from scratch:

1. **Control signals carry no `Source`.** `EndOfStream`/`EndOfTurn`/`Interrupt` must be **broadcast to every track**. Route only on `Source` and they're dropped, the merge never completes, and a duplex session's `Drain`/`Close` deadlocks — the same failure class as #1638.
2. **`Chain` already registers stages.** `AddStage` + `Chain` double-registers and fails `Build`'s duplicate-name check.

Same rationale that already justified promoting `WithNamePrefix` and the G.711 codec out of this example.

## Design

- Public `sdk` API (`IngestionTrack`, `MultiTrackIngestionConfig`, `MultiTrackIngestion`) — consumers need it, so it can't live in `sdk/internal`.
- Reuses the existing internal `pipeline.BuildAudioTrackStages` for the `resample→turn→STT` segment, so it stays byte-identical to the single-track VAD front; the helper adds the speaker-labeling `ToMessage` stage and the router/merge topology.
- Forces `EmitEndOfTurn` so the streaming ProviderStage fires the agent once per turn.

## Tests

`TestMultiTrackIngestion_*` drive the built sub-graph directly with real loud-then-silent PCM turns:
- routing by `Source`, independent per-track transcription, speaker labeling, `OnTranscript` callback
- **control-signal broadcast**: an `EndOfStream` with no `Source` reaches the merge output rather than being dropped (guards the deadlock footgun)
- single-track case + empty-tracks rejection

New file coverage 89.4%; full `sdk` suite (1870 tests) green.

## Follow-up (separate)

The `voice-sales-assist` example's `twoPartyIngestion` will be reduced to a thin call into this helper (and a stale comment about `EventAudioTranscription` never being emitted — false since `NewSTTStageWithEmitter` landed — fixed) on the example's own branch, so this library PR stays example-independent.

Closes #1646
