### PR TITLE
fix(statestore): make the Redis TTL a sliding window, matching MemoryStore

### DIFF
--- a/runtime/statestore/memory.go
+++ b/runtime/statestore/memory.go
@@ -69,8 +69,18 @@ const (
 // MemoryStoreOption configures optional behavior for MemoryStore.
 type MemoryStoreOption func(*MemoryStore)
 
-// WithMemoryTTL sets the time-to-live for conversation states. Entries that have not
-// been accessed within the TTL are considered expired and eligible for eviction.
+// WithMemoryTTL sets the time-to-live for conversation states.
+//
+// The TTL is a sliding window measured from last use: a conversation expires
+// once it has gone this long without being read or written. Reading a
+// conversation (Load, LoadRecentMessages, LoadMetadata) extends it, so a
+// conversation in active use is never collected underneath its owner. Bulk or
+// diagnostic reads — MessageCount, LoadSummaries, LoadList, LogLoad, List —
+// deliberately do not extend it, so inspecting a store cannot keep it alive.
+//
+// RedisStore applies the same rule to the same set of operations, so a given
+// TTL means the same thing whichever backend is configured.
+//
 // A zero or negative TTL disables expiration. By default, DefaultTTL is applied.
 // Use WithNoTTL() as an explicit, self-documenting way to disable TTL expiration.
 func WithMemoryTTL(ttl time.Duration) MemoryStoreOption {

--- a/runtime/statestore/redis.go
+++ b/runtime/statestore/redis.go
@@ -39,7 +39,17 @@ type RedisStore struct {
 type RedisOption func(*RedisStore)
 
 // WithTTL sets the time-to-live for conversation states.
-// After this duration, conversations will be automatically deleted.
+//
+// The TTL is a sliding window measured from last use: a conversation expires
+// once it has gone this long without being read or written. Reading a
+// conversation (Load, LoadRecentMessages, LoadMetadata) extends it, so a
+// conversation in active use is never collected underneath its owner. Bulk or
+// diagnostic reads — MessageCount, LoadSummaries, LoadList, LogLoad, List —
+// deliberately do not extend it, so inspecting a store cannot keep it alive.
+//
+// MemoryStore applies the same rule to the same set of operations, so a given
+// TTL means the same thing whichever backend is configured.
+//
 // Default is 24 hours. Set to 0 for no expiration.
 func WithTTL(ttl time.Duration) RedisOption {
 	return func(s *RedisStore) {
@@ -102,6 +112,7 @@ func (s *RedisStore) Load(ctx context.Context, id string) (*ConversationState, e
 	// Try decomposed format first
 	state, err := s.loadDecomposed(ctx, id)
 	if err == nil {
+		s.slideTTLOnRead(ctx, id)
 		return state, nil
 	}
 	if !errors.Is(err, ErrNotFound) {
@@ -109,7 +120,60 @@ func (s *RedisStore) Load(ctx context.Context, id string) (*ConversationState, e
 	}
 
 	// Fall back to legacy monolithic format
-	return s.loadMonolithic(ctx, id)
+	state, err = s.loadMonolithic(ctx, id)
+	if err == nil {
+		s.slideTTLOnRead(ctx, id)
+	}
+	return state, err
+}
+
+// slideTTLOnRead pushes a conversation's expiry window forward after a
+// successful read, so a conversation in active use does not expire underneath
+// its owner.
+//
+// The TTL is a sliding window measured from last use, where use means a read or
+// a write. The memory store has always behaved this way; this makes the Redis
+// store agree, so the same configured TTL means the same thing on both.
+//
+// Best-effort: a conversation that was successfully read is returned to the
+// caller whether or not the expiry window could be extended. Failing the read
+// because a follow-up EXPIRE failed would turn a cosmetic problem into a
+// user-visible one.
+//
+// Every key for the conversation is refreshed together, including append-only
+// lists enumerated via the per-conversation index, so no part of a live
+// conversation expires ahead of the rest.
+func (s *RedisStore) slideTTLOnRead(ctx context.Context, id string) {
+	if s.ttl <= 0 {
+		return
+	}
+
+	keys := []string{
+		s.conversationKey(id), // legacy monolithic key
+		s.metaKey(id),         // decomposed meta
+		s.messagesKey(id),     // decomposed messages list
+		s.summariesKey(id),    // decomposed summaries list
+		s.metadataKey(id),     // decomposed user metadata hash
+		s.listsIndexKey(id),   // per-conversation list-name index set
+	}
+
+	// EXPIRE on a missing key is a no-op, so the keys a given conversation does
+	// not use cost nothing beyond pipeline space.
+	if listNames, err := s.client.SMembers(ctx, s.listsIndexKey(id)).Result(); err == nil {
+		for _, name := range listNames {
+			keys = append(keys, s.listKey(id, name))
+		}
+	}
+
+	// PExpire, not Expire: EXPIRE has one-second granularity and silently
+	// rounds, which would quietly lengthen any TTL that is not a whole number
+	// of seconds. The write path avoids this by setting the TTL through SET,
+	// which takes milliseconds.
+	pipe := s.client.Pipeline()
+	for _, key := range keys {
+		pipe.PExpire(ctx, key, s.ttl)
+	}
+	_, _ = pipe.Exec(ctx)
 }
 
 // loadDecomposed loads a conversation state from decomposed keys
@@ -698,9 +762,15 @@ func (s *RedisStore) LoadMetadata(ctx context.Context, id string) (map[string]in
 		if existsCmd.Val() == 0 {
 			return nil, ErrNotFound
 		}
+		s.slideTTLOnRead(ctx, id)
 		return nil, nil
 	}
-	return decodeMetadataHash(fields)
+	decoded, err := decodeMetadataHash(fields)
+	if err != nil {
+		return nil, err
+	}
+	s.slideTTLOnRead(ctx, id)
+	return decoded, nil
 }
 
 // loadMetadataHash reads the metadata hash and JSON-decodes each value.
@@ -907,7 +977,12 @@ func (s *RedisStore) LoadRecentMessages(ctx context.Context, id string, n int) (
 		return nil, fmt.Errorf("redis lrange failed: %w", err)
 	}
 
-	return unmarshalMessages(vals)
+	msgs, err := unmarshalMessages(vals)
+	if err != nil {
+		return nil, err
+	}
+	s.slideTTLOnRead(ctx, id)
+	return msgs, nil
 }
 
 // MessageCount returns the total number of messages.

--- a/runtime/statestore/redis_test.go
+++ b/runtime/statestore/redis_test.go
@@ -2479,3 +2479,89 @@ func TestRedisStore_MessageLog_AppendThenSaveNoDup(t *testing.T) {
 	// Save also fills in the user-id; the LogAppend meta stub had none.
 	assert.Equal(t, "user-1", loaded.UserID)
 }
+
+// A conversation's TTL is a sliding window measured from last use, where use
+// means a read as well as a write. The memory store has always behaved this
+// way; before this the Redis store ran a fixed window from the last write, so
+// the same configured TTL meant two different things depending on the backend
+// and a conversation being actively read could expire underneath its owner.
+func TestRedisStore_TTLSlidesOnRead(t *testing.T) {
+	store, mr := setupRedisStore(t, WithTTL(time.Hour))
+	ctx := context.Background()
+
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-slide", UserID: "user-alice"}))
+
+	// Read repeatedly, each time advancing most of the way to expiry. Under a
+	// write-based window this conversation is gone after the first jump.
+	for i := range 3 {
+		mr.FastForward(50 * time.Minute)
+		_, err := store.Load(ctx, "conv-slide")
+		require.NoErrorf(t, err, "conversation expired while being read (iteration %d)", i)
+	}
+
+	// Left alone for longer than the TTL, it still expires.
+	mr.FastForward(2 * time.Hour)
+	_, err := store.Load(ctx, "conv-slide")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// The other two reads that refresh in the memory store must refresh here too,
+// so the backends agree on exactly which operations count as use.
+func TestRedisStore_TTLSlidesOnMessageAndMetadataReads(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		read func(*RedisStore, context.Context, string) error
+	}{
+		{
+			name: "LoadRecentMessages",
+			read: func(s *RedisStore, ctx context.Context, id string) error {
+				_, err := s.LoadRecentMessages(ctx, id, 10)
+				return err
+			},
+		},
+		{
+			name: "LoadMetadata",
+			read: func(s *RedisStore, ctx context.Context, id string) error {
+				_, err := s.LoadMetadata(ctx, id)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, mr := setupRedisStore(t, WithTTL(time.Hour))
+			ctx := context.Background()
+
+			require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-x", UserID: "u"}))
+			require.NoError(t, store.AppendMessages(ctx, "conv-x",
+				[]types.Message{{Role: "user", Content: "hello"}}))
+			require.NoError(t, store.MergeMetadata(ctx, "conv-x",
+				map[string]interface{}{"k": "v"}))
+
+			mr.FastForward(50 * time.Minute)
+			require.NoError(t, tc.read(store, ctx, "conv-x"))
+
+			// The read slid the window, so the conversation survives a second
+			// jump that would otherwise have taken it past the TTL.
+			mr.FastForward(50 * time.Minute)
+			_, err := store.Load(ctx, "conv-x")
+			require.NoError(t, err, "read did not slide the expiry window")
+		})
+	}
+}
+
+// A sub-second TTL must not be silently rounded up: EXPIRE has one-second
+// granularity, so the refresh has to use PEXPIRE.
+func TestRedisStore_TTLSlideKeepsSubSecondPrecision(t *testing.T) {
+	store, mr := setupRedisStore(t, WithTTL(100*time.Millisecond))
+	ctx := context.Background()
+
+	require.NoError(t, store.Save(ctx, &ConversationState{ID: "conv-ms", UserID: "u"}))
+	_, err := store.Load(ctx, "conv-ms")
+	require.NoError(t, err)
+
+	// Well past 100ms but well under the 1s that EXPIRE would have rounded to.
+	mr.FastForward(300 * time.Millisecond)
+
+	_, err = store.Load(ctx, "conv-ms")
+	assert.ErrorIs(t, err, ErrNotFound, "sub-second TTL was rounded up by the refresh")
+}


### PR DESCRIPTION
Closes #1649.

## The problem

`MemoryStore` and `RedisStore` accept the same-shaped TTL option but measure two different things.

- **MemoryStore** treats it as idle time and refreshes on read — `isExpired` compares against `LastAccessedAt`, which `Load` advances.
- **RedisStore** ran a fixed window from the last write — the TTL is applied by `Save` and refreshed by `AppendMessages`; `Load` issued no `EXPIRE` at all.

So the same configured value produced a different lifetime depending on which backend was deployed, and a conversation being actively read could expire underneath its owner on Redis while surviving indefinitely in memory. Neither doc comment said which it was.

## The fix

`RedisStore` now slides on read too, so both backends agree.

- `Load`, `LoadRecentMessages` and `LoadMetadata` refresh the window — **exactly** the reads `MemoryStore` refreshes on.
- `MessageCount`, `LoadSummaries`, `LoadList`, `LogLoad` and `List` deliberately do **not**, also matching `MemoryStore`, so inspecting or polling a store cannot keep a conversation alive.
- Every key for the conversation is refreshed together, including append-only lists enumerated via the per-conversation index, so no part of a live conversation expires ahead of the rest.
- Best-effort: a conversation read successfully is returned whether or not the `EXPIRE` landed. Failing a read because a follow-up refresh failed would turn a cosmetic problem into a user-visible one.

### PEXPIRE, not EXPIRE

The refresh uses `PEXPIRE`. `EXPIRE` has one-second granularity and silently rounds, so a 100ms TTL becomes 1s — go-redis even logs `minimal supported value is 1s - truncating`. I hit this directly: the first version used `EXPIRE` and quietly broke `TestRedisStore_TTL`, because the refreshed key outlived a 200ms fast-forward. The write path already avoids this by setting the TTL through `SET`, which takes milliseconds.

## Why this direction

The alternative was to make expiry write-based everywhere (drop the memory store's sliding behaviour), which would have been cheaper — no refresh cost on reads at all. I went the other way because `TestMemoryStore_TTLAccessRefreshes` shows the sliding behaviour is deliberate and tested, not accidental; Redis was the one that never matched the intent.

The cost is one extra round-trip per refreshing read: an `SMEMBERS` for the list index plus a pipelined batch of `PEXPIRE`s. If you'd rather not pay that on the hot path, the write-based variant is a small change in the other direction — say the word and I'll swap it.

## Documentation

Both `WithTTL` and `WithMemoryTTL` now state what the clock measures and list which operations count as use. The previous wording ("sets the time-to-live for conversation states") didn't say.

## Tests

Three new tests, each verified to fail without the change:

| Test | Covers |
|---|---|
| `TestRedisStore_TTLSlidesOnRead` | repeated reads keep a conversation alive; left alone it still expires |
| `TestRedisStore_TTLSlidesOnMessageAndMetadataReads` | `LoadRecentMessages` and `LoadMetadata` slide too |
| `TestRedisStore_TTLSlideKeepsSubSecondPrecision` | a sub-second TTL isn't rounded up by the refresh |

`slideTTLOnRead` and `Load` are at 100% statement coverage; changed-file coverage is `redis.go` 85.3%, `memory.go` 96.1%.

## Not addressed here

The defaults still differ — `MemoryStore.DefaultTTL` is **1 hour**, `RedisStore` defaults to **24 hours**. That's a behaviour change for anyone relying on either default, so it felt wrong to fold into this PR. Worth deciding separately; happy to follow up.

## Context

Found from the consumer side in AltairaLabs/Omnia#1876, where a resume probe read through `Load` and so extended the lifetime of the very thing it was checking on one backend but not the other. Omnia worked around it by probing through `MessageCount` — which, usefully, remains correct under this change, since `MessageCount` is in the deliberately-non-refreshing set on both backends.
