### PR TITLE
feat(sdk): approve-with-edits for HITL pending tool calls

### DIFF
--- a/docs/src/content/docs/runtime/reference/statestore.md
+++ b/docs/src/content/docs/runtime/reference/statestore.md
@@ -625,7 +625,13 @@ WithMemoryMaxEntries sets the maximum number of entries the store will hold. Whe
 func WithMemoryTTL(ttl time.Duration) MemoryStoreOption
 ```
 
-WithMemoryTTL sets the time\-to\-live for conversation states. Entries that have not been accessed within the TTL are considered expired and eligible for eviction. A zero or negative TTL disables expiration. By default, DefaultTTL is applied. Use WithNoTTL\(\) as an explicit, self\-documenting way to disable TTL expiration.
+WithMemoryTTL sets the time\-to\-live for conversation states.
+
+The TTL is a sliding window measured from last use: a conversation expires once it has gone this long without being read or written. Reading a conversation \(Load, LoadRecentMessages, LoadMetadata\) extends it, so a conversation in active use is never collected underneath its owner. Bulk or diagnostic reads — MessageCount, LoadSummaries, LoadList, LogLoad, List — deliberately do not extend it, so inspecting a store cannot keep it alive.
+
+RedisStore applies the same rule to the same set of operations, so a given TTL means the same thing whichever backend is configured.
+
+A zero or negative TTL disables expiration. By default, DefaultTTL is applied. Use WithNoTTL\(\) as an explicit, self\-documenting way to disable TTL expiration.
 
 <a name="WithNoMaxEntries"></a>
 ### func WithNoMaxEntries
@@ -768,7 +774,13 @@ WithPrefix sets the key prefix for Redis keys. Default is "promptkit".
 func WithTTL(ttl time.Duration) RedisOption
 ```
 
-WithTTL sets the time\-to\-live for conversation states. After this duration, conversations will be automatically deleted. Default is 24 hours. Set to 0 for no expiration.
+WithTTL sets the time\-to\-live for conversation states.
+
+The TTL is a sliding window measured from last use: a conversation expires once it has gone this long without being read or written. Reading a conversation \(Load, LoadRecentMessages, LoadMetadata\) extends it, so a conversation in active use is never collected underneath its owner. Bulk or diagnostic reads — MessageCount, LoadSummaries, LoadList, LogLoad, List — deliberately do not extend it, so inspecting a store cannot keep it alive.
+
+MemoryStore applies the same rule to the same set of operations, so a given TTL means the same thing whichever backend is configured.
+
+Default is 24 hours. Set to 0 for no expiration.
 
 <a name="RedisStore"></a>
 ## type RedisStore

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -201,6 +201,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func \(c \*Conversation\) RejectClientTool\(\_ context.Context, callID, reason string\)](<#Conversation.RejectClientTool>)
   - [func \(c \*Conversation\) RejectTool\(id, reason string\) \(\*sdktools.ToolResolution, error\)](<#Conversation.RejectTool>)
   - [func \(c \*Conversation\) ResolveTool\(id string\) \(\*sdktools.ToolResolution, error\)](<#Conversation.ResolveTool>)
+  - [func \(c \*Conversation\) ResolveToolWithArgs\(id string, overrides map\[string\]any\) \(\*sdktools.ToolResolution, error\)](<#Conversation.ResolveToolWithArgs>)
   - [func \(c \*Conversation\) Response\(\) \(\<\-chan providers.StreamChunk, error\)](<#Conversation.Response>)
   - [func \(c \*Conversation\) Resume\(ctx context.Context\) \(\*Response, error\)](<#Conversation.Resume>)
   - [func \(c \*Conversation\) ResumeStream\(ctx context.Context\) \<\-chan StreamChunk](<#Conversation.ResumeStream>)
@@ -1750,6 +1751,26 @@ if len(resp.PendingTools()) > 0 {
     // Continue the conversation with the result
     resp, _ = conv.Continue(ctx)
 }
+```
+
+<a name="Conversation.ResolveToolWithArgs"></a>
+### func \(\*Conversation\) ResolveToolWithArgs
+
+```go
+func (c *Conversation) ResolveToolWithArgs(id string, overrides map[string]any) (*sdktools.ToolResolution, error)
+```
+
+ResolveToolWithArgs approves a pending tool call with reviewer\-supplied argument overrides \(approve\-with\-edits\), then executes it.
+
+Overrides are shallow\-merged over the arguments the model proposed: keys in overrides replace the originals, absent keys are preserved. A nil or empty map is identical to ResolveTool \(approve as\-proposed\). The resulting ToolResolution reports Edited=true and carries the effective Arguments.
+
+Works on both paths: after Send\(\) follow with Continue\(\), and after a duplex pending surfaces follow with ContinueDuplex\(\) — both consume the resolution this produces.
+
+```
+pending := resp.PendingTools()[0]
+// reviewer tweaks the draft before it sends:
+conv.ResolveToolWithArgs(pending.ID, map[string]any{"body": editedText})
+resp, _ = conv.Continue(ctx)
 ```
 
 <a name="Conversation.Response"></a>

--- a/sdk/conversation_tools.go
+++ b/sdk/conversation_tools.go
@@ -207,14 +207,34 @@ func (c *Conversation) OnToolAsync(
 //	    resp, _ = conv.Continue(ctx)
 //	}
 func (c *Conversation) ResolveTool(id string) (*sdktools.ToolResolution, error) {
+	return c.ResolveToolWithArgs(id, nil)
+}
+
+// ResolveToolWithArgs approves a pending tool call with reviewer-supplied
+// argument overrides (approve-with-edits), then executes it.
+//
+// Overrides are shallow-merged over the arguments the model proposed: keys in
+// overrides replace the originals, absent keys are preserved. A nil or empty
+// map is identical to ResolveTool (approve as-proposed). The resulting
+// ToolResolution reports Edited=true and carries the effective Arguments.
+//
+// Works on both paths: after Send() follow with Continue(), and after a duplex
+// pending surfaces follow with ContinueDuplex() — both consume the resolution
+// this produces.
+//
+//	pending := resp.PendingTools()[0]
+//	// reviewer tweaks the draft before it sends:
+//	conv.ResolveToolWithArgs(pending.ID, map[string]any{"body": editedText})
+//	resp, _ = conv.Continue(ctx)
+func (c *Conversation) ResolveToolWithArgs(id string, overrides map[string]any) (*sdktools.ToolResolution, error) {
 	if c.pendingStore == nil {
 		return nil, fmt.Errorf("no pending tools")
 	}
-	resolution, err := c.pendingStore.Resolve(id)
+	resolution, err := c.pendingStore.ResolveWithArgs(id, overrides)
 	if err != nil {
 		return nil, err
 	}
-	// Store for Continue() to use
+	// Store for Continue()/ContinueDuplex() to use
 	if c.resolvedStore != nil {
 		c.resolvedStore.Add(resolution)
 	}

--- a/sdk/examples/hitl/main_interactive.go
+++ b/sdk/examples/hitl/main_interactive.go
@@ -84,20 +84,37 @@ func main() {
 			fmt.Printf("Reason: %s\n", p.Reason)
 			fmt.Printf("Message: %s\n", p.Message)
 			fmt.Printf("Arguments: %v\n", p.Arguments)
-			fmt.Print("\nApprove this action? (yes/no): ")
+			fmt.Print("\nApprove (yes), edit the amount then approve (edit), or reject (no)? ")
 
 			input, _ := reader.ReadString('\n')
 			input = strings.TrimSpace(strings.ToLower(input))
 
-			if input == "yes" || input == "y" {
-				// Approve and execute the tool
+			switch input {
+			case "yes", "y":
+				// Approve and execute the tool as proposed.
 				result, err := conv.ResolveTool(p.ID)
 				if err != nil {
 					log.Printf("Failed to resolve tool: %v", err)
 					continue
 				}
 				fmt.Printf("\nTool executed successfully:\n%v\n", result.Result)
-			} else {
+			case "edit":
+				// Approve WITH edits: the reviewer corrects an argument before it
+				// executes. Overrides shallow-merge over the proposed args.
+				fmt.Print("New amount to approve: ")
+				amtStr, _ := reader.ReadString('\n')
+				var amount float64
+				if _, err := fmt.Sscanf(strings.TrimSpace(amtStr), "%f", &amount); err != nil {
+					log.Printf("Invalid amount: %v", err)
+					continue
+				}
+				result, err := conv.ResolveToolWithArgs(p.ID, map[string]any{"amount": amount})
+				if err != nil {
+					log.Printf("Failed to resolve tool: %v", err)
+					continue
+				}
+				fmt.Printf("\nTool executed with edited amount (edited=%v):\n%v\n", result.Edited, result.Result)
+			default:
 				// Reject the tool
 				result, err := conv.RejectTool(p.ID, "Not authorized by supervisor")
 				if err != nil {

--- a/sdk/hitl_test.go
+++ b/sdk/hitl_test.go
@@ -136,6 +136,58 @@ func TestResolveTool(t *testing.T) {
 	})
 }
 
+func TestResolveToolWithArgs(t *testing.T) {
+	t.Run("returns error when no pending store", func(t *testing.T) {
+		conv := newTestConversation()
+		conv.pendingStore = nil
+
+		_, err := conv.ResolveToolWithArgs("some-id", map[string]any{"x": 1})
+		assert.Error(t, err)
+	})
+
+	t.Run("approves with edited args and records resolution", func(t *testing.T) {
+		conv := newTestConversation()
+		conv.pendingStore = sdktools.NewPendingStore()
+		defer conv.pendingStore.Close()
+		conv.resolvedStore = sdktools.NewResolvedStore()
+
+		var gotArgs map[string]any
+		call := &sdktools.PendingToolCall{
+			ID:        "test-id",
+			Name:      "send_message",
+			Arguments: map[string]any{"to": "Dana", "body": "original"},
+		}
+		call.SetHandler(func(args map[string]any) (any, error) {
+			gotArgs = args
+			return map[string]any{"sent": args["body"]}, nil
+		})
+		require.NoError(t, conv.pendingStore.Add(call))
+
+		resolution, err := conv.ResolveToolWithArgs("test-id", map[string]any{"body": "edited"})
+		require.NoError(t, err)
+		assert.Equal(t, "edited", gotArgs["body"])
+		assert.Equal(t, "Dana", gotArgs["to"]) // untouched original preserved
+		assert.True(t, resolution.Edited)
+		// The resolution is recorded for Continue()/ContinueDuplex() to consume.
+		assert.Equal(t, 1, conv.resolvedStore.Len())
+	})
+
+	t.Run("ResolveTool delegates with no edits", func(t *testing.T) {
+		conv := newTestConversation()
+		conv.pendingStore = sdktools.NewPendingStore()
+		defer conv.pendingStore.Close()
+		conv.resolvedStore = sdktools.NewResolvedStore()
+
+		call := &sdktools.PendingToolCall{ID: "test-id", Name: "t", Arguments: map[string]any{"body": "original"}}
+		call.SetHandler(func(args map[string]any) (any, error) { return args["body"], nil })
+		require.NoError(t, conv.pendingStore.Add(call))
+
+		resolution, err := conv.ResolveTool("test-id")
+		require.NoError(t, err)
+		assert.False(t, resolution.Edited)
+	})
+}
+
 func TestRejectTool(t *testing.T) {
 	t.Run("returns error when no pending store", func(t *testing.T) {
 		conv := newTestConversation()

--- a/sdk/tools/pending.go
+++ b/sdk/tools/pending.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -260,10 +261,34 @@ type ToolResolution struct {
 
 	// RejectionReason explains why the tool was rejected
 	RejectionReason string
+
+	// Arguments are the effective arguments the handler executed with. When the
+	// call was approved with edits, this is the original arguments with the
+	// reviewer's overrides merged in.
+	Arguments map[string]any
+
+	// Edited is true when the call was approved with reviewer-supplied argument
+	// overrides (see ResolveWithArgs). Provides an audit trail distinguishing an
+	// as-proposed approval from an edited one.
+	Edited bool
 }
 
-// Resolve executes an approved pending tool call.
+// Resolve executes an approved pending tool call with its original arguments.
+// It is equivalent to ResolveWithArgs(id, nil).
 func (s *PendingStore) Resolve(id string) (*ToolResolution, error) {
+	return s.ResolveWithArgs(id, nil)
+}
+
+// ResolveWithArgs executes an approved pending tool call, applying the given
+// argument overrides (approve-with-edits). Overrides are shallow-merged over
+// the original arguments: keys present in overrides replace the originals, keys
+// absent are preserved. A nil or empty overrides map executes the call exactly
+// as proposed (equivalent to Resolve).
+//
+// The original PendingToolCall.Arguments are not mutated; the merged arguments
+// are recorded on the returned ToolResolution (with Edited set when overrides
+// were applied).
+func (s *PendingStore) ResolveWithArgs(id string, overrides map[string]any) (*ToolResolution, error) {
 	s.mu.Lock()
 	call, ok := s.pending[id]
 	if !ok {
@@ -273,12 +298,21 @@ func (s *PendingStore) Resolve(id string) (*ToolResolution, error) {
 	delete(s.pending, id)
 	s.mu.Unlock()
 
-	// Execute the handler
-	result, err := call.handler(call.Arguments)
+	// Shallow-merge overrides over a copy of the original args so the pending
+	// call is never mutated.
+	args := make(map[string]any, len(call.Arguments)+len(overrides))
+	maps.Copy(args, call.Arguments)
+	maps.Copy(args, overrides)
+	edited := len(overrides) > 0
+
+	// Execute the handler with the (possibly edited) arguments.
+	result, err := call.handler(args)
 	if err != nil {
 		return &ToolResolution{
-			ID:    id,
-			Error: err,
+			ID:        id,
+			Arguments: args,
+			Edited:    edited,
+			Error:     err,
 		}, nil
 	}
 
@@ -286,8 +320,10 @@ func (s *PendingStore) Resolve(id string) (*ToolResolution, error) {
 	resultJSON, err := json.Marshal(result)
 	if err != nil {
 		return &ToolResolution{
-			ID:    id,
-			Error: fmt.Errorf("failed to serialize result: %w", err),
+			ID:        id,
+			Arguments: args,
+			Edited:    edited,
+			Error:     fmt.Errorf("failed to serialize result: %w", err),
 		}, nil
 	}
 
@@ -295,6 +331,8 @@ func (s *PendingStore) Resolve(id string) (*ToolResolution, error) {
 		ID:         id,
 		Result:     result,
 		ResultJSON: resultJSON,
+		Arguments:  args,
+		Edited:     edited,
 	}, nil
 }
 

--- a/sdk/tools/pending_test.go
+++ b/sdk/tools/pending_test.go
@@ -131,6 +131,68 @@ func TestPendingStoreResolve(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("resolve with edited args merges overrides and flags edited", func(t *testing.T) {
+		store := NewPendingStore()
+		defer store.Close()
+		var gotArgs map[string]any
+		call := &PendingToolCall{
+			ID:        "call-1",
+			Name:      "send_message",
+			Arguments: map[string]any{"to": "Dana", "body": "original", "channel": "SMS"},
+			handler: func(args map[string]any) (any, error) {
+				gotArgs = args
+				return map[string]any{"sent": args["body"]}, nil
+			},
+		}
+		require.NoError(t, store.Add(call))
+
+		resolution, err := store.ResolveWithArgs("call-1", map[string]any{"body": "edited"})
+		require.NoError(t, err)
+		// Handler ran with the override applied over the original args.
+		assert.Equal(t, "edited", gotArgs["body"])
+		assert.Equal(t, "Dana", gotArgs["to"])     // untouched original preserved
+		assert.Equal(t, "SMS", gotArgs["channel"]) // untouched original preserved
+		assert.Equal(t, "edited", resolution.Result.(map[string]any)["sent"])
+		// Audit: the resolution records that it was edited and the effective args.
+		assert.True(t, resolution.Edited)
+		assert.Equal(t, "edited", resolution.Arguments["body"])
+		// The original pending call's Arguments must NOT be mutated.
+		assert.Equal(t, "original", call.Arguments["body"])
+	})
+
+	t.Run("resolve with nil overrides is not flagged edited", func(t *testing.T) {
+		store := NewPendingStore()
+		defer store.Close()
+		call := &PendingToolCall{
+			ID:        "call-1",
+			Name:      "send_message",
+			Arguments: map[string]any{"body": "original"},
+			handler:   func(args map[string]any) (any, error) { return args["body"], nil },
+		}
+		require.NoError(t, store.Add(call))
+
+		resolution, err := store.ResolveWithArgs("call-1", nil)
+		require.NoError(t, err)
+		assert.False(t, resolution.Edited)
+		assert.Equal(t, "original", resolution.Result)
+	})
+
+	t.Run("Resolve is ResolveWithArgs with no overrides", func(t *testing.T) {
+		store := NewPendingStore()
+		defer store.Close()
+		call := &PendingToolCall{
+			ID:        "call-1",
+			Name:      "send_message",
+			Arguments: map[string]any{"body": "original"},
+			handler:   func(args map[string]any) (any, error) { return args["body"], nil },
+		}
+		require.NoError(t, store.Add(call))
+
+		resolution, err := store.Resolve("call-1")
+		require.NoError(t, err)
+		assert.False(t, resolution.Edited)
+	})
+
 	t.Run("resolve handler error", func(t *testing.T) {
 		store := NewPendingStore()
 		defer store.Close()


### PR DESCRIPTION
## What

Adds **approve-with-edits** to the HITL pending-tool flow: a reviewer can approve a pending tool call with argument overrides, not only accept it as-proposed or reject it.

- `PendingStore.ResolveWithArgs(id, overrides)` — shallow-merges overrides over the model's proposed args and executes the handler. The original `PendingToolCall` is never mutated.
- `Conversation.ResolveToolWithArgs(id, overrides)` — conversation-level wrapper; records the resolution for `Continue()`/`ContinueDuplex()`.
- `ToolResolution` gains `Arguments` (the effective args the handler ran with) and `Edited` (audit flag).

`ResolveTool` and `PendingStore.Resolve` now delegate to the `*WithArgs` variants with `nil` overrides, so **existing behavior is unchanged**.

## Why

Today `ResolveTool(id)` runs the pending call with the *original* args — a reviewer can accept or reject wholesale, but not correct what the agent proposed (the only workaround was reaching into `PendingToolCall.SetHandler`). Editing-before-commit is a common HITL need.

## Both paths, no extra wiring

The edit is applied at resolve time (where `execFunc` runs), and both the unary (`Continue`) and duplex (`ContinueDuplex`) paths consume the resolution produced there — so approve-with-edits works on both without touching `SubmitToolResults`.

## Tests / docs

- Store-level: merge semantics, original-args-not-mutated, `Edited` flag, `Resolve` == no-edit. (`sdk/tools/pending.go` 97.8%)
- Conversation-level: `ResolveToolWithArgs` executes with overrides + records the resolution; `ResolveTool` delegates. (`sdk/conversation_tools.go` 92.7%)
- `sdk/examples/hitl` gains an "edit" branch demonstrating the flow.
- SDK reference regenerated (new exported API).

Full `sdk` + `sdk/tools` suites pass under `-race` (1224 tests).

Closes #1651
