### PR TITLE
feat: HITL approval gate on the standard ProviderStage (unary + WithIngestion)

### DIFF
--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -3771,6 +3771,14 @@ type ProviderConfig struct {
     // set is used (the provider stage never crashes a turn because
     // selection broke).
     ToolSelector selection.Selector
+
+    // ApprovalChecker, when set, is consulted before each tool executes. If it
+    // returns a non-nil PendingToolInfo the call is HELD pending (surfaced via
+    // ErrToolsPending / PendingTools metadata) instead of executing — the
+    // human-in-the-loop approval gate. Nil (default) executes every tool
+    // normally. This is what makes HITL approval work on the standard
+    // ProviderStage, not only the ASM duplex session.
+    ApprovalChecker tools.ApprovalChecker
 }
 ```
 

--- a/docs/src/content/docs/runtime/reference/tools.md
+++ b/docs/src/content/docs/runtime/reference/tools.md
@@ -47,6 +47,7 @@ Tools can be loaded from YAML/JSON files and executed with argument validation, 
 - [type A2ARetryConfig](<#A2ARetryConfig>)
 - [type A2ASkillFilter](<#A2ASkillFilter>)
   - [func \(f \*A2ASkillFilter\) IncludesSkill\(skillID string\) bool](<#A2ASkillFilter.IncludesSkill>)
+- [type ApprovalChecker](<#ApprovalChecker>)
 - [type AsyncToolExecutor](<#AsyncToolExecutor>)
 - [type ClientConfig](<#ClientConfig>)
 - [type Coercion](<#Coercion>)
@@ -470,6 +471,15 @@ func (f *A2ASkillFilter) IncludesSkill(skillID string) bool
 ```
 
 IncludesSkill returns true if the given skill ID passes the filter.
+
+<a name="ApprovalChecker"></a>
+## type ApprovalChecker
+
+ApprovalChecker decides whether a tool call must be held for external approval \(human\-in\-the\-loop\) before execution. It returns a non\-nil PendingToolInfo to hold the call pending, or nil to let it execute normally. It is consulted per tool call before execution; a nil checker is a no\-op.
+
+```go
+type ApprovalChecker func(callID, name string, args map[string]any) *PendingToolInfo
+```
 
 <a name="AsyncToolExecutor"></a>
 ## type AsyncToolExecutor
@@ -1083,7 +1093,7 @@ type PendingToolExecution struct {
 <a name="PendingToolInfo"></a>
 ## type PendingToolInfo
 
-PendingToolInfo provides context for middleware \(email templates, notifications\)
+PendingToolInfo describes a tool call awaiting external input or approval.
 
 ```go
 type PendingToolInfo struct {

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -34,8 +34,9 @@ const (
 // ProviderStage implementation notes:
 // - ✅ Multi-round tool execution with automatic tool result handling
 // - ✅ Synchronous tool execution via toolRegistry.ExecuteAsync()
-// - ⚠️ Limited async/pending tool support (no ExecutionContext for tracking)
-// - TODO: Implement full async tool support with approval workflows
+// - ✅ Human-in-the-loop approval gate via ProviderConfig.ApprovalChecker: a
+//      held call is surfaced pending (ErrToolsPending / PendingTools metadata)
+//      and the pipeline suspends until the caller resolves it
 
 // ProviderStage executes LLM calls and handles tool execution.
 // This is the request/response mode implementation.
@@ -1934,18 +1935,15 @@ func (s *ProviderStage) handleToolResult(
 ) types.MessageToolResult {
 	switch asyncResult.Status {
 	case tools.ToolStatusPending:
-		// Tool requires approval - for stages we don't have ExecutionContext for tracking pending tools
-		// Return a message indicating approval is needed
+		// Tool is held pending external resolution (HITL approval or a client-mode
+		// tool awaiting fulfillment). The call is surfaced via ErrToolsPending /
+		// PendingTools metadata and the pipeline suspends; this placeholder result
+		// is only used if the pending execution is inspected before it resolves.
 		pendingMsg := asyncResult.PendingInfo.Message
 		if pendingMsg == "" {
-			pendingMsg = fmt.Sprintf("Tool %s requires approval", call.Name)
+			pendingMsg = fmt.Sprintf("Tool %s is awaiting approval", call.Name)
 		}
-		logger.Warn("Tool requires approval in ProviderStage - pending tool support not yet implemented",
-			"tool", call.Name, "call_id", call.ID)
-		return types.NewTextToolResult(
-			call.ID, call.Name,
-			pendingMsg+" (Note: Async tool approval workflows not yet implemented in stages)",
-		)
+		return types.NewTextToolResult(call.ID, call.Name, pendingMsg)
 
 	case tools.ToolStatusFailed:
 		failResult := types.NewTextToolResult(

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -95,6 +95,14 @@ type ProviderConfig struct {
 	// set is used (the provider stage never crashes a turn because
 	// selection broke).
 	ToolSelector selection.Selector
+
+	// ApprovalChecker, when set, is consulted before each tool executes. If it
+	// returns a non-nil PendingToolInfo the call is HELD pending (surfaced via
+	// ErrToolsPending / PendingTools metadata) instead of executing — the
+	// human-in-the-loop approval gate. Nil (default) executes every tool
+	// normally. This is what makes HITL approval work on the standard
+	// ProviderStage, not only the ASM duplex session.
+	ApprovalChecker tools.ApprovalChecker
 }
 
 // streamingRoundParams holds parameters for a streaming round execution.
@@ -1754,6 +1762,26 @@ func (s *ProviderStage) executeSingleToolCall(
 	hookDecision, blocked, skip := s.preExecCheck(ctx, toolCall)
 	if skip {
 		return blocked
+	}
+
+	// Human-in-the-loop approval gate: if a checker holds this call, surface it
+	// as pending (via ErrToolsPending / PendingTools metadata) instead of
+	// executing. The caller resolves it (approve / approve-with-edits / reject)
+	// and resumes.
+	if s.config != nil && s.config.ApprovalChecker != nil {
+		var argsMap map[string]any
+		if len(toolCall.Args) > 0 {
+			_ = json.Unmarshal(toolCall.Args, &argsMap)
+		}
+		if info := s.config.ApprovalChecker(toolCall.ID, toolCall.Name, argsMap); info != nil {
+			if info.ToolName == "" {
+				info.ToolName = toolCall.Name
+			}
+			return s.buildPendingResult(ctx, toolCall, &tools.ToolExecutionResult{
+				Status:      tools.ToolStatusPending,
+				PendingInfo: info,
+			})
+		}
 	}
 
 	labels := s.toolLabels(toolCall.Name)

--- a/runtime/pipeline/stage/stages_provider_approval_test.go
+++ b/runtime/pipeline/stage/stages_provider_approval_test.go
@@ -1,0 +1,86 @@
+package stage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupApprovalStage builds a ProviderStage with one tool and an ApprovalChecker.
+func setupApprovalStage(t *testing.T, exec *delayedExecutor, checker tools.ApprovalChecker) *ProviderStage {
+	t.Helper()
+	registry := tools.NewRegistry()
+	registry.RegisterExecutor(exec)
+	require.NoError(t, registry.Register(&tools.ToolDescriptor{
+		Name:        "risky",
+		Description: "needs approval",
+		Mode:        exec.Name(),
+		InputSchema: []byte(`{"type":"object"}`),
+	}))
+	return NewProviderStage(mock.NewProvider("t", "m", false), registry, nil,
+		&ProviderConfig{ApprovalChecker: checker})
+}
+
+func TestProviderStage_ApprovalCheckerHoldsToolPending(t *testing.T) {
+	exec := &delayedExecutor{name: "local-exec", status: tools.ToolStatusComplete, content: []byte(`{"ok":true}`)}
+
+	var checkedName string
+	var checkedArgs map[string]any
+	stage := setupApprovalStage(t, exec, func(callID, name string, args map[string]any) *tools.PendingToolInfo {
+		checkedName, checkedArgs = name, args
+		return &tools.PendingToolInfo{Reason: "requires_approval", Message: "Approve?", ToolName: name}
+	})
+
+	_, err := stage.executeToolCalls(context.Background(),
+		[]types.MessageToolCall{{ID: "c1", Name: "risky", Args: json.RawMessage(`{"amount":150}`)}})
+
+	// The tool is HELD pending, not executed.
+	var pendErr *tools.ErrToolsPending
+	require.ErrorAs(t, err, &pendErr)
+	require.Len(t, pendErr.Pending, 1)
+	assert.Equal(t, "risky", pendErr.Pending[0].ToolName)
+	assert.Equal(t, "c1", pendErr.Pending[0].CallID)
+	require.NotNil(t, pendErr.Pending[0].PendingInfo)
+	assert.Equal(t, "requires_approval", pendErr.Pending[0].PendingInfo.Reason)
+
+	// The checker saw the call, and the executor never ran.
+	assert.Equal(t, "risky", checkedName)
+	assert.EqualValues(t, 150, checkedArgs["amount"])
+	assert.EqualValues(t, 0, exec.callCount.Load(), "held tool must not execute")
+}
+
+func TestProviderStage_ApprovalCheckerNilExecutesNormally(t *testing.T) {
+	exec := &delayedExecutor{name: "local-exec", status: tools.ToolStatusComplete, content: []byte(`{"ok":true}`)}
+
+	// Checker returns nil → no approval needed → executes.
+	stage := setupApprovalStage(t, exec, func(_, _ string, _ map[string]any) *tools.PendingToolInfo {
+		return nil
+	})
+
+	results, err := stage.executeToolCalls(context.Background(),
+		[]types.MessageToolCall{{ID: "c1", Name: "risky", Args: json.RawMessage(`{}`)}})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.EqualValues(t, 1, exec.callCount.Load(), "tool with no approval gate should execute")
+}
+
+func TestProviderStage_NoApprovalCheckerExecutesNormally(t *testing.T) {
+	exec := &delayedExecutor{name: "local-exec", status: tools.ToolStatusComplete, content: []byte(`{"ok":true}`)}
+	registry := tools.NewRegistry()
+	registry.RegisterExecutor(exec)
+	require.NoError(t, registry.Register(&tools.ToolDescriptor{
+		Name: "risky", Mode: exec.Name(), InputSchema: []byte(`{"type":"object"}`),
+	}))
+	stage := NewProviderStage(mock.NewProvider("t", "m", false), registry, nil, nil) // nil config
+
+	_, err := stage.executeToolCalls(context.Background(),
+		[]types.MessageToolCall{{ID: "c1", Name: "risky", Args: json.RawMessage(`{}`)}})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, exec.callCount.Load())
+}

--- a/runtime/pipeline/stage/stages_provider_test.go
+++ b/runtime/pipeline/stage/stages_provider_test.go
@@ -1488,7 +1488,7 @@ func TestProviderStage_HandleToolResult_AllStatuses(t *testing.T) {
 			name:           "pending status without message",
 			status:         tools.ToolStatusPending,
 			pendingMsg:     "",
-			contentContain: "requires approval",
+			contentContain: "awaiting approval",
 		},
 		{
 			name:           "unknown status",

--- a/runtime/tools/types.go
+++ b/runtime/tools/types.go
@@ -322,7 +322,6 @@ type ToolExecutionResult struct {
 	PendingInfo *PendingToolInfo `json:"pending_info,omitempty"`
 }
 
-// PendingToolInfo provides context for middleware (email templates, notifications)
 // ApprovalChecker decides whether a tool call must be held for external
 // approval (human-in-the-loop) before execution. It returns a non-nil
 // PendingToolInfo to hold the call pending, or nil to let it execute normally.

--- a/runtime/tools/types.go
+++ b/runtime/tools/types.go
@@ -323,6 +323,13 @@ type ToolExecutionResult struct {
 }
 
 // PendingToolInfo provides context for middleware (email templates, notifications)
+// ApprovalChecker decides whether a tool call must be held for external
+// approval (human-in-the-loop) before execution. It returns a non-nil
+// PendingToolInfo to hold the call pending, or nil to let it execute normally.
+// It is consulted per tool call before execution; a nil checker is a no-op.
+type ApprovalChecker func(callID, name string, args map[string]any) *PendingToolInfo
+
+// PendingToolInfo describes a tool call awaiting external input or approval.
 type PendingToolInfo struct {
 	// Reason for pending (e.g., "requires_approval", "waiting_external_api")
 	Reason string `json:"reason"`

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -520,6 +520,7 @@ func (c *Conversation) buildPipelineConfig(
 		CompactionStrategy:    c.config.compactionStrategy,
 		CompactionRules:       c.config.compactionRules,
 		ToolSelector:          c.config.selectors[c.config.toolSelectorName],
+		ApprovalChecker:       c.newApprovalChecker(),
 		ClassifyRegistry:      c.config.classifyRegistry,
 	}
 
@@ -703,9 +704,25 @@ func (c *Conversation) buildResponse(result *rtpipeline.ExecutionResult, startTi
 		}
 	}
 
-	// Populate pending client tools from pipeline result
+	// Split suspended tool calls. A call the OnToolAsync approval gate registered
+	// in the pending store is a HITL approval hold — surface it via PendingTools()
+	// for ResolveTool/RejectTool. Everything else is a client-mode tool awaiting
+	// external fulfillment — surface it via ClientTools() for SendToolResult.
 	for i := range result.PendingTools {
-		resp.clientTools = append(resp.clientTools, buildPendingClientToolFromExecution(&result.PendingTools[i]))
+		pt := &result.PendingTools[i]
+		if c.pendingStore != nil {
+			if held, ok := c.pendingStore.Get(pt.CallID); ok {
+				resp.pendingTools = append(resp.pendingTools, PendingTool{
+					ID:        held.ID,
+					Name:      held.Name,
+					Arguments: held.Arguments,
+					Reason:    held.Reason,
+					Message:   held.Message,
+				})
+				continue
+			}
+		}
+		resp.clientTools = append(resp.clientTools, buildPendingClientToolFromExecution(pt))
 	}
 
 	return resp

--- a/sdk/hitl_gate_integration_test.go
+++ b/sdk/hitl_gate_integration_test.go
@@ -1,0 +1,229 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gateTurnRepo scripts mock LLM turns for the gate integration test.
+type gateTurnRepo struct {
+	mu    sync.RWMutex
+	turns map[string]*mock.Turn
+}
+
+func newGateTurnRepo() *gateTurnRepo { return &gateTurnRepo{turns: map[string]*mock.Turn{}} }
+
+func (r *gateTurnRepo) add(n int, turn mock.Turn) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.turns[fmt.Sprintf("default:%d", n)] = &turn
+}
+
+func (r *gateTurnRepo) GetResponse(ctx context.Context, p mock.ResponseParams) (string, error) {
+	t, err := r.GetTurn(ctx, p)
+	if err != nil {
+		return "", err
+	}
+	return t.Content, nil
+}
+
+func (r *gateTurnRepo) GetTurn(_ context.Context, p mock.ResponseParams) (*mock.Turn, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if t, ok := r.turns[fmt.Sprintf("default:%d", p.TurnNumber)]; ok {
+		return t, nil
+	}
+	return &mock.Turn{Type: "text", Content: ""}, nil
+}
+
+// A pack with a single tool the model can call.
+func writeGatePack(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "gate.pack.json")
+	body := `{
+      "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+      "id": "gate", "name": "gate", "version": "1.0.0",
+      "template_engine": {"version": "v1", "syntax": "{{variable}}"},
+      "prompts": {"assist": {"id": "assist", "name": "a", "version": "1.0.0",
+        "system_template": "You help.",
+        "tools": ["send_message"]}},
+      "tools": {"send_message": {"name": "send_message", "description": "send",
+        "parameters": {"type": "object", "properties": {"body": {"type": "string"}}}}}
+    }`
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+	return p
+}
+
+// The standard (unary) pipeline must now enforce the OnToolAsync approval gate:
+// a held tool is surfaced pending and NOT executed until ResolveTool. This is
+// the path that previously bypassed HITL entirely (CheckPending was dead code).
+func TestOnToolAsync_GatesOnStandardPipeline(t *testing.T) {
+	repo := newGateTurnRepo()
+	repo.add(1, mock.Turn{
+		Type:      "tool_calls",
+		Content:   "Sending.",
+		ToolCalls: []mock.ToolCall{{Name: "send_message", Arguments: map[string]any{"body": "hi"}}},
+	})
+	repo.add(2, mock.Turn{Type: "text", Content: "Done."})
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+
+	conv, err := Open(writeGatePack(t), "assist", WithProvider(provider), WithSkipSchemaValidation())
+	require.NoError(t, err)
+	defer func() { _ = conv.Close() }()
+
+	var executedWith string
+	conv.OnToolAsync(
+		"send_message",
+		func(args map[string]any) sdktools.PendingResult {
+			return sdktools.PendingResult{Reason: "requires_approval", Message: "Approve send?"}
+		},
+		func(args map[string]any) (any, error) {
+			executedWith, _ = args["body"].(string)
+			return map[string]any{"sent": args["body"]}, nil
+		},
+	)
+
+	resp, err := conv.Send(context.Background(), "please send a message")
+	require.NoError(t, err)
+
+	// HELD: surfaced pending, and the handler did NOT run.
+	pending := resp.PendingTools()
+	require.Len(t, pending, 1, "tool must be held pending on the standard pipeline")
+	assert.Equal(t, "send_message", pending[0].Name)
+	assert.Equal(t, "requires_approval", pending[0].Reason)
+	assert.Empty(t, executedWith, "held tool must not execute before approval")
+
+	// Also resolvable via the conversation store.
+	require.Len(t, conv.PendingTools(), 1)
+
+	// APPROVE → the handler runs.
+	_, err = conv.ResolveTool(pending[0].ID)
+	require.NoError(t, err)
+	assert.Equal(t, "hi", executedWith, "approval must execute the held tool")
+}
+
+// Approve-with-edits (#1651) now works on the standard pipeline too, because
+// the gate surfaces the call and ResolveToolWithArgs re-runs the handler with
+// the reviewer's overrides.
+func TestOnToolAsync_ApproveWithEditsOnStandardPipeline(t *testing.T) {
+	repo := newGateTurnRepo()
+	repo.add(1, mock.Turn{
+		Type:      "tool_calls",
+		Content:   "Sending.",
+		ToolCalls: []mock.ToolCall{{Name: "send_message", Arguments: map[string]any{"body": "original"}}},
+	})
+	repo.add(2, mock.Turn{Type: "text", Content: "Done."})
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+
+	conv, err := Open(writeGatePack(t), "assist", WithProvider(provider), WithSkipSchemaValidation())
+	require.NoError(t, err)
+	defer func() { _ = conv.Close() }()
+
+	var executedWith string
+	conv.OnToolAsync(
+		"send_message",
+		func(map[string]any) sdktools.PendingResult { return sdktools.PendingResult{Reason: "approval"} },
+		func(args map[string]any) (any, error) {
+			executedWith, _ = args["body"].(string)
+			return "ok", nil
+		},
+	)
+
+	resp, err := conv.Send(context.Background(), "send it")
+	require.NoError(t, err)
+	pending := resp.PendingTools()
+	require.Len(t, pending, 1)
+
+	// Reviewer edits the body before approving.
+	res, err := conv.ResolveToolWithArgs(pending[0].ID, map[string]any{"body": "edited"})
+	require.NoError(t, err)
+	assert.True(t, res.Edited)
+	assert.Equal(t, "edited", executedWith, "approve-with-edits must run the handler with the override")
+}
+
+// The WithIngestion streaming-duplex path (the Guardian per-turn shape) must
+// enforce the same gate: the streaming ProviderStage built for a duplex agent
+// consults the approval checker, holds the tool pending, and does not execute it
+// until ResolveTool. This is the second of the two paths #1653 wires (the first
+// being the unary Send path above); the ASM DuplexProviderStage already gated.
+func TestOnToolAsync_GatesOnWithIngestionDuplexPipeline(t *testing.T) {
+	repo := newGateTurnRepo()
+	repo.add(1, mock.Turn{
+		Type:      "tool_calls",
+		Content:   "Sending.",
+		ToolCalls: []mock.ToolCall{{Name: "send_message", Arguments: map[string]any{"body": "hi"}}},
+	})
+	provider := mock.NewToolProviderWithRepository("mock", "mock-model", false, repo)
+
+	ingest := IngestionFunc(func(b *stage.PipelineBuilder) (string, error) {
+		b.AddStage(newTurnEmitterStage("turn_emitter"))
+		return "turn_emitter", nil
+	})
+
+	conv, err := OpenDuplex(writeGatePack(t), "assist",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithIngestion(ingest),
+	)
+	require.NoError(t, err)
+	defer func() { _ = conv.Close() }()
+
+	var mu sync.Mutex
+	var executedWith string
+	conv.OnToolAsync(
+		"send_message",
+		func(map[string]any) sdktools.PendingResult {
+			return sdktools.PendingResult{Reason: "requires_approval", Message: "Approve send?"}
+		},
+		func(args map[string]any) (any, error) {
+			mu.Lock()
+			executedWith, _ = args["body"].(string)
+			mu.Unlock()
+			return map[string]any{"sent": args["body"]}, nil
+		},
+	)
+
+	responseCh, err := conv.Response()
+	require.NoError(t, err)
+	go func() {
+		for range responseCh { //nolint:revive // drain so the pipeline output never blocks
+		}
+	}()
+
+	ctx := context.Background()
+	require.NoError(t, conv.SendChunk(ctx, &providers.StreamChunk{Content: "please send", Source: "caller"}))
+
+	// HELD: the streaming ProviderStage surfaces the call in the pending store and
+	// the handler does not run while the session stays open.
+	require.Eventually(t, func() bool { return len(conv.PendingTools()) == 1 },
+		5*time.Second, 10*time.Millisecond,
+		"WithIngestion streaming ProviderStage must hold the tool pending")
+	mu.Lock()
+	assert.Empty(t, executedWith, "held tool must not execute before approval")
+	mu.Unlock()
+
+	pending := conv.PendingTools()
+	require.Len(t, pending, 1)
+	assert.Equal(t, "send_message", pending[0].Name)
+	assert.Equal(t, "requires_approval", pending[0].Reason)
+
+	// APPROVE → the handler runs with the model's proposed args.
+	_, err = conv.ResolveTool(pending[0].ID)
+	require.NoError(t, err)
+	mu.Lock()
+	assert.Equal(t, "hi", executedWith, "approval must execute the held tool")
+	mu.Unlock()
+}

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -87,6 +87,11 @@ type Config struct {
 	// provider sees the full allowedTools list (existing behavior).
 	ToolSelector selection.Selector
 
+	// ApprovalChecker, when set, gates tool execution for human-in-the-loop
+	// approval on the standard ProviderStage: a tool the checker holds is
+	// surfaced as pending instead of executing. Optional; nil executes normally.
+	ApprovalChecker tools.ApprovalChecker
+
 	// CompactionStrategy replaces the default compactor entirely.
 	// Mutually exclusive with CompactionRules.
 	CompactionStrategy stage.CompactionStrategy
@@ -496,6 +501,7 @@ func buildProviderStages(cfg *Config, turnState *stage.TurnState) ([]stage.Stage
 			MessageLog:       cfg.MessageLog,
 			MessageLogConvID: cfg.ConversationID,
 			ToolSelector:     cfg.ToolSelector,
+			ApprovalChecker:  cfg.ApprovalChecker,
 			Streaming:        cfg.Ingestion != nil,
 		}
 		// Configure compaction strategy

--- a/sdk/internal/pipeline/builder_vad.go
+++ b/sdk/internal/pipeline/builder_vad.go
@@ -86,8 +86,9 @@ func buildVADPipelineStages(cfg *Config) ([]stage.Stage, error) {
 	// 5d. ProviderStage - LLM call
 	if cfg.Provider != nil {
 		providerConfig := &stage.ProviderConfig{
-			MaxTokens:   cfg.MaxTokens,
-			Temperature: cfg.Temperature,
+			MaxTokens:       cfg.MaxTokens,
+			Temperature:     cfg.Temperature,
+			ApprovalChecker: cfg.ApprovalChecker,
 		}
 		stages = append(stages, stage.NewProviderStageWithEmitter(
 			cfg.Provider,

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -824,6 +824,59 @@ func (conv *Conversation) executeAsyncToolNow(name string, args map[string]any) 
 	return &session.AsyncToolCheckResult{Handled: true, HandlerResult: resultJSON}
 }
 
+// newApprovalChecker builds the HITL approval gate consulted by the standard
+// ProviderStage before each tool executes. Like newAsyncToolChecker (the ASM
+// duplex equivalent), it reads asyncHandlers dynamically so handlers registered
+// after the pipeline is built (e.g. OnToolAsync called after Open) are honored.
+//
+// When a tool's check returns pending, it records a PendingToolCall in the
+// pendingStore — keyed by the provider call ID, with the execution handler set
+// — so ResolveTool / ResolveToolWithArgs / RejectTool can resolve it, and
+// returns the PendingToolInfo that holds the call. Otherwise it returns nil and
+// the tool executes normally.
+func (conv *Conversation) newApprovalChecker() tools.ApprovalChecker {
+	return func(callID, name string, args map[string]any) *tools.PendingToolInfo {
+		conv.asyncHandlersMu.RLock()
+		checkFunc, isAsync := conv.asyncHandlers[name]
+		conv.asyncHandlersMu.RUnlock()
+		if !isAsync {
+			return nil // not an async tool — execute normally
+		}
+
+		result := checkFunc(args)
+		if !result.IsPending() {
+			return nil // approval not required — execute normally
+		}
+
+		if conv.pendingStore == nil {
+			return nil // no store to resolve against; don't strand the call
+		}
+
+		pending := &sdktools.PendingToolCall{
+			ID:        callID,
+			Name:      name,
+			Arguments: args,
+			Reason:    result.Reason,
+			Message:   result.Message,
+		}
+		conv.handlersMu.RLock()
+		handler := conv.handlers[name]
+		conv.handlersMu.RUnlock()
+		if handler != nil {
+			pending.SetHandler(handler)
+		}
+		if err := conv.pendingStore.Add(pending); err != nil {
+			return nil
+		}
+
+		return &tools.PendingToolInfo{
+			Reason:   result.Reason,
+			Message:  result.Message,
+			ToolName: name,
+		}
+	}
+}
+
 // initMCPRegistry initializes the MCP registry if servers are configured.
 //
 // Each server configured by name only (no URL, no Command) gets its


### PR DESCRIPTION
Closes #1653.

## Problem

`OnToolAsync` (human-in-the-loop tool approval) only gated on the ASM
`DuplexProviderStage`. On the two other execution paths the approval check
was never consulted, so a held tool executed immediately:

- **unary `Send`** — `CheckPending` existed but was dead code (never called
  by the pipeline), and `Response.PendingTools()` was never populated.
- **`WithIngestion` streaming-duplex** — the standard streaming ProviderStage
  had an explicit "not yet implemented" TODO for approval.

## Change

The runtime `ProviderStage` now carries an `ApprovalChecker` hook consulted
before each tool executes (61591ff4). This PR wires it through the SDK on both
remaining paths and makes the held call surface correctly.

- `newApprovalChecker()` reads `asyncHandlers` dynamically (handlers registered
  after `Open` are honored), records the held call in `pendingStore` keyed by
  the provider call ID with its execution handler attached, and returns a
  `PendingToolInfo` to hold the call.
- Pipeline builders set `ProviderConfig.ApprovalChecker` on the standard text
  stage (unary + ingestion) and the VAD stage.
- `buildResponse` splits suspended calls: a call registered in the pending
  store surfaces via `Response.PendingTools()` (HITL — resolve with
  `ResolveTool` / `ResolveToolWithArgs` / `RejectTool` then `Continue` /
  `ContinueDuplex`); everything else stays `Response.ClientTools()`
  (client-mode fulfillment). This fixes `PendingTools()`, which nothing
  populated before.
- Runtime cleanup: dropped the stale "not yet implemented" WARN + placeholder
  note in `handleToolResult`, the resolved TODO, and a stray orphan doc comment
  on the `ApprovalChecker` type.

## Tests

- `TestOnToolAsync_GatesOnStandardPipeline` — unary hold + resolve.
- `TestOnToolAsync_ApproveWithEditsOnStandardPipeline` — unary approve-with-edits.
- `TestOnToolAsync_GatesOnWithIngestionDuplexPipeline` — streaming-duplex hold + resolve.
- Existing runtime `stages_provider_approval_test.go` covers the stage-level gate.

Reference docs regenerated (`pipeline.md`, `tools.md`).

## Note

`Conversation.CheckPending` is now redundant with the wired gate but is left in
place — it is exported public API and used by existing tests. Removing it would
be a breaking change, out of scope here.
