### PR TITLE
fix(sdk): VAD mode fires the LLM per turn and speaks the reply once

### DIFF
--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -1974,6 +1974,14 @@ type ElementMetadata struct {
     // must be surfaced to the caller for out-of-band completion.
     PendingTools []tools.PendingToolExecution
 
+    // SynthesizedSpeech marks an element produced by a TTS stage: it carries the
+    // spoken audio plus, for reference, the text that was submitted for synthesis.
+    // That text is the same reply already delivered as streaming Text deltas, so a
+    // consumer converting elements to output chunks must NOT re-present it as new
+    // model output (Delta) — the audio is the payload. It is also not necessarily
+    // the true spoken text, since providers strip or rewrite markup at synthesis.
+    SynthesizedSpeech bool
+
     // StreamingDelta marks an incremental content Text element emitted by a
     // streaming provider mid-generation (see ProviderStage.emitChunkElement).
     // These are the live-text feed for UI consumers; the same reply also arrives

--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -1974,6 +1974,14 @@ type ElementMetadata struct {
     // must be surfaced to the caller for out-of-band completion.
     PendingTools []tools.PendingToolExecution
 
+    // StreamingDelta marks an incremental content Text element emitted by a
+    // streaming provider mid-generation (see ProviderStage.emitChunkElement).
+    // These are the live-text feed for UI consumers; the same reply also arrives
+    // as a complete assistant Message. A speech-out stage must skip the deltas —
+    // the TTS provider takes a complete string, so synthesizing per-fragment
+    // would be one request per token and choppy audio — and speak the Message.
+    StreamingDelta bool
+
     // TokenCount is the per-chunk token count emitted by streaming providers.
     // Zero when the chunk did not include a token count.
     TokenCount int

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -4259,6 +4259,8 @@ WithVADMode configures VAD mode for voice conversations with standard text\-base
 
 This is an alternative to ASM mode \(WithStreamingConfig\) for providers without native audio streaming support.
 
+The model runs once per detected turn — when the speaker falls silent for SilenceDuration — and conversation history threads across turns for the life of the session, so a caller hears a reply without the session having to end.
+
 Example:
 
 ```

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1569,6 +1569,10 @@ func (s *ProviderStage) emitChunkElement(
 		elem.Timestamp = timeNow()
 		elem.Priority = PriorityNormal
 
+		// Mark as an incremental delta so a downstream speech-out stage speaks
+		// the complete assistant Message instead of each fragment (see
+		// ElementMetadata.StreamingDelta).
+		elem.Meta.StreamingDelta = true
 		elem.Meta.TokenCount = chunk.TokenCount
 		if chunk.FinishReason != nil {
 			fr := *chunk.FinishReason

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -1100,11 +1100,25 @@ func (s *TTSStageWithInterruption) emitAudioElement(
 
 // extractText extracts text content from an element.
 func (s *TTSStageWithInterruption) extractText(elem *StreamElement) string {
+	// Skip incremental streaming deltas: the same reply arrives as a complete
+	// assistant Message below, and the TTS provider needs the whole utterance in
+	// one call (see ElementMetadata.StreamingDelta).
+	if elem.Meta.StreamingDelta {
+		return ""
+	}
+
 	if elem.Text != nil && *elem.Text != "" {
 		return *elem.Text
 	}
 
-	if elem.Message != nil {
+	// Only the assistant is spoken. The continuous multi-turn ProviderStage
+	// re-emits each turn's user transcript downstream before generating (so the
+	// UI and save stages see it immediately), and in the VAD voice topology this
+	// stage sits directly downstream of it — without the role check the caller
+	// hears their own question read back before it is answered. Tool results are
+	// likewise data for later stages, not lines to read aloud. A bare Text
+	// element carries no role and stays an explicit "speak this" instruction.
+	if elem.Message != nil && elem.Message.Role == roleAssistant {
 		if elem.Message.Content != "" {
 			return elem.Message.Content
 		}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -1093,6 +1093,12 @@ func (s *TTSStageWithInterruption) emitAudioElement(
 	if meta != nil {
 		outElem.Meta = *meta
 	}
+	// The reply text already streamed as deltas; this element's Text is a
+	// reference copy of what was submitted for synthesis. Mark it so a consumer
+	// does not re-present that text as new model output (see
+	// ElementMetadata.SynthesizedSpeech). Set after the meta copy so it wins.
+	outElem.Meta.SynthesizedSpeech = true
+	outElem.Meta.StreamingDelta = false
 
 	s.setBotSpeaking(false)
 	return s.forwardElement(ctx, outElem, output)

--- a/runtime/pipeline/stage/stages_tts.go
+++ b/runtime/pipeline/stage/stages_tts.go
@@ -133,11 +133,19 @@ const ttsCostMetaKey = "tts_cost"
 
 // extractText extracts text content from an element.
 func (s *TTSStage) extractText(elem *StreamElement) string {
+	// Skip incremental streaming deltas — see TTSStageWithInterruption.extractText.
+	if elem.Meta.StreamingDelta {
+		return ""
+	}
+
 	if elem.Text != nil && *elem.Text != "" {
 		return *elem.Text
 	}
 
-	if elem.Message != nil {
+	// Only the assistant is spoken — a user transcript or tool result reaching a
+	// speech-out stage is data for later stages, not a line to read aloud. See
+	// TTSStageWithInterruption.extractText for the topology that proved this.
+	if elem.Message != nil && elem.Message.Role == roleAssistant {
 		// Extract text from message content
 		if elem.Message.Content != "" {
 			return elem.Message.Content

--- a/runtime/pipeline/stage/stages_tts_role_test.go
+++ b/runtime/pipeline/stage/stages_tts_role_test.go
@@ -1,0 +1,162 @@
+package stage_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTTS captures every text handed to synthesis, so a test can assert on
+// what the stage chose to speak rather than merely that it spoke.
+type recordingTTS struct {
+	mockTTSService
+
+	mu     sync.Mutex
+	spoken []string
+}
+
+func newRecordingTTS() *recordingTTS {
+	r := &recordingTTS{}
+	r.synthesizeFunc = func(_ context.Context, text string, _ tts.SynthesisConfig) (io.ReadCloser, error) {
+		r.mu.Lock()
+		r.spoken = append(r.spoken, text)
+		r.mu.Unlock()
+		return io.NopCloser(strings.NewReader(generateTestPCM(100))), nil
+	}
+	return r
+}
+
+func (r *recordingTTS) texts() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.spoken))
+	copy(out, r.spoken)
+	return out
+}
+
+// messageElement builds a StreamElement carrying a role-tagged text message.
+func messageElement(role, text string) stage.StreamElement {
+	msg := types.Message{Role: role, Content: text}
+	return stage.NewMessageElement(&msg)
+}
+
+// TestTTSStageSpeaksOnlyTheAssistant guards the speech-out contract: a stage
+// that turns text into the voice the caller hears must speak the assistant's
+// words and nothing else.
+//
+// The continuous multi-turn ProviderStage re-emits each turn's user transcript
+// downstream before generating, so the UI and save stages see what was said
+// right away. In the VAD voice topology TTS sits directly downstream of it, so
+// an unfiltered stage synthesizes the caller's own question back at them before
+// answering it. Roles other than assistant — user transcripts, tool results —
+// are data for later stages, not lines to be read aloud.
+func TestTTSStageSpeaksOnlyTheAssistant(t *testing.T) {
+	svc := newRecordingTTS()
+	ttsStage := stage.NewTTSStageWithInterruption(svc, stage.DefaultTTSStageWithInterruptionConfig())
+
+	inputs := []stage.StreamElement{
+		messageElement("user", "what is the capital of france"),
+		messageElement("assistant", "The capital of France is Paris."),
+	}
+	runStage(t, ttsStage, inputs, 5*time.Second)
+
+	assert.Equal(t, []string{"The capital of France is Paris."}, svc.texts(),
+		"only the assistant's reply may be spoken; the caller's own transcript must not be read back")
+}
+
+// recordingPlainTTS implements the narrower stage.TTSService used by the plain
+// TTSStage, recording what it was asked to say.
+type recordingPlainTTS struct {
+	mu     sync.Mutex
+	spoken []string
+}
+
+func (r *recordingPlainTTS) MIMEType() string { return "audio/pcm" }
+
+func (r *recordingPlainTTS) Synthesize(_ context.Context, text string) ([]byte, error) {
+	r.mu.Lock()
+	r.spoken = append(r.spoken, text)
+	r.mu.Unlock()
+	return generateTestPCMAudio(100), nil
+}
+
+func (r *recordingPlainTTS) texts() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.spoken))
+	copy(out, r.spoken)
+	return out
+}
+
+// TestPlainTTSStageSpeaksOnlyTheAssistant holds the plain stage to the same
+// contract as the interruption-aware one. It is not on the VAD voice path
+// today, but it carries the identical text extraction, so any topology that
+// puts it downstream of a provider inherits the same read-the-caller-back bug.
+func TestPlainTTSStageSpeaksOnlyTheAssistant(t *testing.T) {
+	svc := &recordingPlainTTS{}
+	ttsStage := stage.NewTTSStage(svc, stage.DefaultTTSConfig())
+
+	runStage(t, ttsStage, []stage.StreamElement{
+		messageElement("user", "what is the capital of france"),
+		messageElement("assistant", "The capital of France is Paris."),
+	}, 5*time.Second)
+
+	assert.Equal(t, []string{"The capital of France is Paris."}, svc.texts(),
+		"only the assistant's reply may be spoken")
+}
+
+// TestTTSStageDoesNotSpeakStreamingDeltas is the second half of why the VAD
+// path double-spoke: the streaming ProviderStage emits each reply as both a run
+// of incremental Text deltas (for live-text consumers) and a final assistant
+// Message (the canonical record). The TTS provider takes a complete string and
+// streams only audio out — synthesizing per-fragment deltas would be one HTTP
+// request per token and choppy audio — so the deltas must not be spoken; the
+// Message is. A complete Text element (no delta marker) is still spoken, which
+// is the contract the rest of the TTS tests rely on.
+func TestTTSStageDoesNotSpeakStreamingDeltas(t *testing.T) {
+	svc := newRecordingTTS()
+	ttsStage := stage.NewTTSStageWithInterruption(svc, stage.DefaultTTSStageWithInterruptionConfig())
+
+	delta := "Paris."
+	deltaElem := stage.StreamElement{Text: &delta}
+	deltaElem.Meta.StreamingDelta = true
+
+	inputs := []stage.StreamElement{
+		deltaElem,
+		messageElement("assistant", "The capital of France is Paris."),
+	}
+	runStage(t, ttsStage, inputs, 5*time.Second)
+
+	assert.Equal(t, []string{"The capital of France is Paris."}, svc.texts(),
+		"streaming deltas must not be synthesized; only the complete assistant reply is spoken")
+}
+
+// TestTTSStageForwardsUnspokenMessages is the other half of the contract:
+// declining to speak a message must not drop it. Downstream save and UI stages
+// still need the user transcript, so it passes through untouched.
+func TestTTSStageForwardsUnspokenMessages(t *testing.T) {
+	svc := newRecordingTTS()
+	ttsStage := stage.NewTTSStageWithInterruption(svc, stage.DefaultTTSStageWithInterruptionConfig())
+
+	results := runStage(t, ttsStage, []stage.StreamElement{
+		messageElement("user", "what is the capital of france"),
+	}, 5*time.Second)
+
+	var forwarded []string
+	for _, elem := range results {
+		if elem.Message != nil {
+			forwarded = append(forwarded, elem.Message.Content)
+		}
+	}
+	require.Contains(t, forwarded, "what is the capital of france",
+		"a message the stage declines to speak must still reach downstream stages")
+}

--- a/runtime/pipeline/stage/turn_state.go
+++ b/runtime/pipeline/stage/turn_state.go
@@ -153,6 +153,14 @@ type ElementMetadata struct {
 	// must be surfaced to the caller for out-of-band completion.
 	PendingTools []tools.PendingToolExecution
 
+	// StreamingDelta marks an incremental content Text element emitted by a
+	// streaming provider mid-generation (see ProviderStage.emitChunkElement).
+	// These are the live-text feed for UI consumers; the same reply also arrives
+	// as a complete assistant Message. A speech-out stage must skip the deltas —
+	// the TTS provider takes a complete string, so synthesizing per-fragment
+	// would be one request per token and choppy audio — and speak the Message.
+	StreamingDelta bool
+
 	// TokenCount is the per-chunk token count emitted by streaming providers.
 	// Zero when the chunk did not include a token count.
 	TokenCount int

--- a/runtime/pipeline/stage/turn_state.go
+++ b/runtime/pipeline/stage/turn_state.go
@@ -153,6 +153,14 @@ type ElementMetadata struct {
 	// must be surfaced to the caller for out-of-band completion.
 	PendingTools []tools.PendingToolExecution
 
+	// SynthesizedSpeech marks an element produced by a TTS stage: it carries the
+	// spoken audio plus, for reference, the text that was submitted for synthesis.
+	// That text is the same reply already delivered as streaming Text deltas, so a
+	// consumer converting elements to output chunks must NOT re-present it as new
+	// model output (Delta) — the audio is the payload. It is also not necessarily
+	// the true spoken text, since providers strip or rewrite markup at synthesis.
+	SynthesizedSpeech bool
+
 	// StreamingDelta marks an incremental content Text element emitted by a
 	// streaming provider mid-generation (see ProviderStage.emitChunkElement).
 	// These are the live-text feed for UI consumers; the same reply also arrives

--- a/sdk/internal/pipeline/builder_vad.go
+++ b/sdk/internal/pipeline/builder_vad.go
@@ -77,7 +77,17 @@ func buildVADPipelineStages(cfg *Config) ([]stage.Stage, error) {
 	if cfg.STTConfig != nil {
 		sttConfig = *cfg.STTConfig
 	}
-	trackStages, err := BuildAudioTrackStages("", false, *cfg.VADConfig, sttConfig, cfg.STTService)
+
+	// VAD mode is turn-based by construction — the AudioTurnStage closes a turn
+	// on silence — so it must emit that boundary for the ProviderStage's
+	// continuous multi-turn loop to fire on (see the Streaming flag below). The
+	// two are a pair: with neither, the model runs only when the input channel
+	// closes, so a caller hears nothing until they hang up (#1644). This is the
+	// same coupling the WithIngestion path got in #1612.
+	vadConfig := *cfg.VADConfig
+	vadConfig.EmitEndOfTurn = true
+
+	trackStages, err := BuildAudioTrackStages("", false, vadConfig, sttConfig, cfg.STTService)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AudioTurnStage: %w", err)
 	}
@@ -89,6 +99,11 @@ func buildVADPipelineStages(cfg *Config) ([]stage.Stage, error) {
 			MaxTokens:       cfg.MaxTokens,
 			Temperature:     cfg.Temperature,
 			ApprovalChecker: cfg.ApprovalChecker,
+			// Run the continuous multi-turn loop: fire the tool loop per
+			// EndOfTurn, thread history across turns, and stay open for the next
+			// utterance — rather than the unary default that drains the whole
+			// input channel and fires once at session close (#1644).
+			Streaming: true,
 		}
 		stages = append(stages, stage.NewProviderStageWithEmitter(
 			cfg.Provider,

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -2329,6 +2329,10 @@ func DefaultVADModeConfig() *VADModeConfig {
 // This is an alternative to ASM mode (WithStreamingConfig) for providers without
 // native audio streaming support.
 //
+// The model runs once per detected turn — when the speaker falls silent for
+// SilenceDuration — and conversation history threads across turns for the life
+// of the session, so a caller hears a reply without the session having to end.
+//
 // Example:
 //
 //	sttService := stt.NewOpenAI(os.Getenv("OPENAI_API_KEY"))

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -729,8 +729,12 @@ func streamElementToStreamChunk(elem *stage.StreamElement) providers.StreamChunk
 		}
 	}
 
-	// Convert text content
-	if elem.Text != nil && *elem.Text != "" {
+	// Convert text content. A synthesized-speech element carries a reference copy
+	// of the text it spoke, but that text already reached the caller as streaming
+	// deltas — presenting it again as Delta/Content would deliver the reply twice
+	// (and the submitted text is not the true spoken text once a provider strips
+	// markup). Its audio is delivered via MediaData above; the text is dropped.
+	if elem.Text != nil && *elem.Text != "" && !elem.Meta.SynthesizedSpeech {
 		chunk.Delta = *elem.Text
 		chunk.Content = *elem.Text
 	}

--- a/sdk/session/tts_chunk_conversion_test.go
+++ b/sdk/session/tts_chunk_conversion_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStreamElementToStreamChunk_SynthesizedSpeechCarriesAudioNotDelta guards
+// the fix for the voice-path double-count: the TTS output element carries the
+// spoken audio plus, for reference, the text it was asked to speak. That text is
+// the same reply already delivered as streaming Text deltas, so mapping it onto
+// Delta (which means "new LLM output") delivers the reply text twice — and the
+// submitted text is not even the true spoken text, since providers strip/rewrite
+// markup at synthesis. A synthesized-speech element must therefore surface its
+// audio and leave Delta empty.
+func TestStreamElementToStreamChunk_SynthesizedSpeechCarriesAudioNotDelta(t *testing.T) {
+	spoken := "The capital of France is Paris."
+	elem := stage.StreamElement{
+		Text: &spoken,
+		Audio: &stage.AudioData{
+			Samples:    []byte{0x01, 0x02, 0x03, 0x04},
+			SampleRate: 24000,
+			Channels:   1,
+			Format:     stage.AudioFormatPCM16,
+		},
+	}
+	elem.Meta.SynthesizedSpeech = true
+
+	chunk := streamElementToStreamChunk(&elem)
+
+	assert.Empty(t, chunk.Delta, "synthesized speech must not present its text as a new LLM delta")
+	assert.Empty(t, chunk.Content, "synthesized speech must not present its text as content")
+	if assert.NotNil(t, chunk.MediaData, "the audio payload must be delivered") {
+		assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, chunk.MediaData.Data)
+	}
+}
+
+// TestStreamElementToStreamChunk_PlainTextStillDeltas is the regression guard:
+// an ordinary streamed Text element (an LLM delta, no synthesized-speech marker)
+// must still map to Delta and Content.
+func TestStreamElementToStreamChunk_PlainTextStillDeltas(t *testing.T) {
+	delta := "Paris"
+	elem := stage.StreamElement{Text: &delta}
+
+	chunk := streamElementToStreamChunk(&elem)
+
+	assert.Equal(t, "Paris", chunk.Delta, "an ordinary text element is an LLM delta and must map to Delta")
+	assert.Equal(t, "Paris", chunk.Content)
+}

--- a/sdk/vad_duplex_gate_test.go
+++ b/sdk/vad_duplex_gate_test.go
@@ -155,14 +155,10 @@ func pcmSilence(d time.Duration, sampleRate int) []byte {
 // through the real AudioTurn → STT → LLM path and asserts the model received
 // the STT transcript as a user message.
 //
-// The assertion is made after Close because VAD mode currently builds a
-// non-streaming ProviderStage (sdk/internal/pipeline/builder.go sets
-// Streaming only for the ingestion path) and never sets
-// AudioTurnConfig.EmitEndOfTurn, so the model fires once when the input
-// channel closes rather than per turn. That per-turn gap is a separate,
-// pre-existing VAD-mode defect — it affects Gemini callers too — and is
-// deliberately not fixed here; this test asserts only what the gate change
-// itself makes possible, so it does not encode the gap as intended behavior.
+// The assertion is made after Close only because that is the weakest claim
+// that proves the gate: the transcript reached the model at all. Whether it
+// arrives per turn *during* the session — it does, since #1644 — is covered by
+// TestVADModeFiresLLMDuringSessionNotAtClose in vad_mode_per_turn_test.go.
 func TestOpenDuplexVADModeDeliversTranscriptToTextProvider(t *testing.T) {
 	if testing.Short() {
 		t.Skip("drives a real VAD turn in wall-clock time and closes a duplex session")

--- a/sdk/vad_mode_per_turn_e2e_test.go
+++ b/sdk/vad_mode_per_turn_e2e_test.go
@@ -279,6 +279,8 @@ func TestVADModeLiveRepliesMidSessionEndToEnd(t *testing.T) {
 	assert.Contains(t, firstSpoken, "paris", "the mid-session reply must answer the question asked")
 	assert.Equal(t, 1, countTTS.count(),
 		"the reply must be synthesized once, not once per streamed representation")
+	assert.LessOrEqual(t, strings.Count(strings.ToLower(firstText), "paris"), 1,
+		"the reply text must reach the caller once — the audio chunk must not re-deliver it on Delta")
 
 	// Turn two, on the same open session.
 	replies.reset()

--- a/sdk/vad_mode_per_turn_e2e_test.go
+++ b/sdk/vad_mode_per_turn_e2e_test.go
@@ -86,6 +86,32 @@ func synthesizeSpeech(t *testing.T, svc tts.Service, text string) []byte {
 	return pcm
 }
 
+// countingTTS wraps a real TTS service and counts synthesis calls, so the live
+// test can prove the reply is spoken exactly once per turn rather than once per
+// streamed representation (the double-speak fixed alongside #1644).
+type countingTTS struct {
+	inner tts.Service
+	mu    sync.Mutex
+	calls int
+}
+
+func (c *countingTTS) Name() string                        { return c.inner.Name() }
+func (c *countingTTS) SupportedVoices() []tts.Voice        { return c.inner.SupportedVoices() }
+func (c *countingTTS) SupportedFormats() []tts.AudioFormat { return c.inner.SupportedFormats() }
+func (c *countingTTS) Synthesize(
+	ctx context.Context, text string, cfg tts.SynthesisConfig,
+) (io.ReadCloser, error) {
+	c.mu.Lock()
+	c.calls++
+	c.mu.Unlock()
+	return c.inner.Synthesize(ctx, text, cfg)
+}
+func (c *countingTTS) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
 // replyCollector accumulates the audio the pipeline speaks back, so a test can
 // tell whether a reply arrived *while the session was still open*.
 type replyCollector struct {
@@ -212,10 +238,14 @@ func TestVADModeLiveRepliesMidSessionEndToEnd(t *testing.T) {
 	francePCM := synthesizeSpeech(t, ttsSvc, "What is the capital of France?")
 	germanyPCM := synthesizeSpeech(t, ttsSvc, "And what is the capital of Germany?")
 
+	// Count synthesis calls through the live pipeline (pre-rendering above uses
+	// the raw service, so it is not counted).
+	countTTS := &countingTTS{inner: ttsSvc}
+
 	conv, err := OpenDuplex(writeVADLivePack(t), "main",
 		WithProvider(llm),
 		WithSkipSchemaValidation(),
-		WithVADMode(sttSvc, ttsSvc, &VADModeConfig{
+		WithVADMode(sttSvc, countTTS, &VADModeConfig{
 			SilenceDuration:   500 * time.Millisecond,
 			MinSpeechDuration: 200 * time.Millisecond,
 			MaxTurnDuration:   15 * time.Second,
@@ -247,6 +277,8 @@ func TestVADModeLiveRepliesMidSessionEndToEnd(t *testing.T) {
 	t.Logf("turn 1 reply: transcript=%q streamed_text=%q audio_bytes=%d",
 		firstSpoken, firstText, len(firstAudio))
 	assert.Contains(t, firstSpoken, "paris", "the mid-session reply must answer the question asked")
+	assert.Equal(t, 1, countTTS.count(),
+		"the reply must be synthesized once, not once per streamed representation")
 
 	// Turn two, on the same open session.
 	replies.reset()
@@ -259,4 +291,6 @@ func TestVADModeLiveRepliesMidSessionEndToEnd(t *testing.T) {
 	t.Logf("turn 2 reply: transcript=%q streamed_text=%q audio_bytes=%d",
 		secondSpoken, secondText, len(secondAudio))
 	assert.Contains(t, secondSpoken, "berlin", "the second turn must be answered on its own merits")
+	assert.Equal(t, 2, countTTS.count(),
+		"two turns must produce two syntheses total, one per reply")
 }

--- a/sdk/vad_mode_per_turn_e2e_test.go
+++ b/sdk/vad_mode_per_turn_e2e_test.go
@@ -1,0 +1,262 @@
+//go:build e2e
+
+package sdk
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/claude"
+	"github.com/AltairaLabs/PromptKit/runtime/stt"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// OpenAI TTS emits headerless PCM16 mono at 24 kHz. Running the whole pipeline
+// at that rate keeps the audio byte-exact end to end: AudioTurnStage stamps
+// SampleRate onto the audio element and STTStage forwards it as the
+// "sample_rate" hint, so no resampling step can misdescribe the samples.
+const liveSampleRate = 24000
+
+// liveFrame is the wall-clock chunk size speech is fed at. AudioTurnStage
+// measures silence in audio-sample time but only re-evaluates on element
+// arrival, so audio must arrive paced roughly like a live microphone.
+const liveFrame = 20 * time.Millisecond
+
+// requireLiveKeys skips unless both real providers are configured. e2e_init_test.go
+// loads .env before this runs.
+func requireLiveKeys(t *testing.T) string {
+	t.Helper()
+	openAIKey := os.Getenv("OPENAI_API_KEY")
+	if openAIKey == "" {
+		t.Skip("OPENAI_API_KEY not set; skipping live VAD-mode test")
+	}
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY not set; skipping live VAD-mode test")
+	}
+	return openAIKey
+}
+
+// writeVADLivePack writes a pack whose system prompt keeps replies short, so a
+// turn's audio is a second or two rather than a paragraph.
+func writeVADLivePack(t *testing.T) string {
+	t.Helper()
+	packFile := filepath.Join(t.TempDir(), "voice.pack.json")
+	content := `{
+		"name": "vad-live-pack",
+		"version": "v1",
+		"prompts": {
+			"main": {
+				"system_template": "You are a voice assistant. Answer in one short sentence, naming the place directly."
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(packFile, []byte(content), 0o600))
+	return packFile
+}
+
+// synthesizeSpeech renders text to headerless PCM16 at liveSampleRate using the
+// real OpenAI TTS service — genuine speech, not a synthetic tone, so the VAD and
+// Whisper both see what a caller would actually produce.
+func synthesizeSpeech(t *testing.T, svc tts.Service, text string) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	rc, err := svc.Synthesize(ctx, text, tts.SynthesisConfig{
+		Voice:  tts.VoiceAlloy,
+		Format: tts.FormatPCM16,
+		Speed:  1.0,
+		Model:  tts.ModelTTS1,
+	})
+	require.NoError(t, err, "TTS synthesis of %q", text)
+	defer func() { _ = rc.Close() }()
+
+	pcm, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NotEmpty(t, pcm, "TTS returned no audio for %q", text)
+	return pcm
+}
+
+// replyCollector accumulates the audio the pipeline speaks back, so a test can
+// tell whether a reply arrived *while the session was still open*.
+type replyCollector struct {
+	mu    sync.Mutex
+	audio []byte
+	text  strings.Builder
+}
+
+func (c *replyCollector) consume(ch <-chan providers.StreamChunk) {
+	for chunk := range ch {
+		c.mu.Lock()
+		if chunk.MediaData != nil && len(chunk.MediaData.Data) > 0 {
+			c.audio = append(c.audio, chunk.MediaData.Data...)
+		}
+		if chunk.Delta != "" {
+			c.text.WriteString(chunk.Delta)
+		}
+		c.mu.Unlock()
+	}
+}
+
+func (c *replyCollector) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.audio = nil
+	c.text.Reset()
+}
+
+func (c *replyCollector) snapshot() ([]byte, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]byte, len(c.audio))
+	copy(out, c.audio)
+	return out, c.text.String()
+}
+
+// waitForReply polls until at least minBytes of spoken reply have arrived.
+// A quarter second of speech is far more than any stray artifact.
+func (c *replyCollector) waitForReply(minBytes int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		audio, _ := c.snapshot()
+		if len(audio) >= minBytes {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// speak streams pre-rendered speech at real time, then trailing silence long
+// enough to close the VAD turn.
+func speak(t *testing.T, conv *Conversation, pcm []byte, trailingSilence time.Duration) {
+	t.Helper()
+	ctx := context.Background()
+	bytesPerFrame := int(float64(liveSampleRate)*liveFrame.Seconds()) * 2
+
+	send := func(chunk []byte) {
+		require.NoError(t, conv.SendChunk(ctx, &providers.StreamChunk{
+			MediaData: &providers.StreamMediaData{MIMEType: "audio/pcm", Data: chunk},
+		}))
+		time.Sleep(liveFrame)
+	}
+
+	for off := 0; off < len(pcm); off += bytesPerFrame {
+		end := off + bytesPerFrame
+		if end > len(pcm) {
+			end = len(pcm)
+		}
+		send(pcm[off:end])
+	}
+	silence := make([]byte, bytesPerFrame)
+	for elapsed := time.Duration(0); elapsed < trailingSilence; elapsed += liveFrame {
+		send(silence)
+	}
+}
+
+// transcribe runs the spoken reply back through real Whisper so the test can
+// assert on what the assistant actually said, not merely that it said something.
+func transcribe(t *testing.T, svc *stt.OpenAIService, pcm []byte) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	text, err := svc.TranscribeBytes(ctx, pcm, stt.TranscriptionConfig{
+		Format:     stt.FormatPCM,
+		SampleRate: liveSampleRate,
+		Channels:   1,
+		BitDepth:   16,
+		Language:   "en",
+	})
+	require.NoError(t, err)
+	return strings.ToLower(text)
+}
+
+// TestVADModeLiveRepliesMidSessionEndToEnd is #1644 proven against real
+// providers: synthesized speech in through OpenAI TTS, real Whisper STT, a real
+// Claude turn, real TTS back — and the reply must be spoken while the caller is
+// still on the line. Before the fix this produced silence until Close, which no
+// mock can demonstrate is a *product* failure rather than a wiring detail.
+//
+// Two utterances run back to back, because one early reply could in principle
+// come from a single flush; a second reply to a second question can only come
+// from a pipeline that stayed open and kept listening.
+func TestVADModeLiveRepliesMidSessionEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("live voice round trip against real providers")
+	}
+	openAIKey := requireLiveKeys(t)
+
+	ttsSvc := tts.NewOpenAI(openAIKey)
+	sttSvc := stt.NewOpenAI(openAIKey)
+	llm := claude.NewProvider(
+		"claude-vad-live",
+		"claude-haiku-4-5-20251001",
+		"https://api.anthropic.com/v1",
+		providers.ProviderDefaults{Temperature: 0.2, MaxTokens: 100},
+		false,
+	)
+	t.Cleanup(func() { _ = llm.Close() })
+
+	// Render both questions up front: synthesis latency must not eat into the
+	// paced streaming that the VAD turn boundaries depend on.
+	francePCM := synthesizeSpeech(t, ttsSvc, "What is the capital of France?")
+	germanyPCM := synthesizeSpeech(t, ttsSvc, "And what is the capital of Germany?")
+
+	conv, err := OpenDuplex(writeVADLivePack(t), "main",
+		WithProvider(llm),
+		WithSkipSchemaValidation(),
+		WithVADMode(sttSvc, ttsSvc, &VADModeConfig{
+			SilenceDuration:   500 * time.Millisecond,
+			MinSpeechDuration: 200 * time.Millisecond,
+			MaxTurnDuration:   15 * time.Second,
+			SampleRate:        liveSampleRate,
+			Language:          "en",
+			Voice:             "alloy",
+			Speed:             1.0,
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	responseCh, err := conv.Response()
+	require.NoError(t, err)
+	replies := &replyCollector{}
+	go replies.consume(responseCh)
+
+	// A quarter second of 16-bit mono speech.
+	const minReplyBytes = liveSampleRate / 4 * 2
+	const replyTimeout = 45 * time.Second
+
+	// Turn one.
+	speak(t, conv, francePCM, time.Second)
+	require.True(t, replies.waitForReply(minReplyBytes, replyTimeout),
+		"assistant must speak a reply during the session, before Close")
+
+	firstAudio, firstText := replies.snapshot()
+	firstSpoken := transcribe(t, sttSvc, firstAudio)
+	t.Logf("turn 1 reply: transcript=%q streamed_text=%q audio_bytes=%d",
+		firstSpoken, firstText, len(firstAudio))
+	assert.Contains(t, firstSpoken, "paris", "the mid-session reply must answer the question asked")
+
+	// Turn two, on the same open session.
+	replies.reset()
+	speak(t, conv, germanyPCM, time.Second)
+	require.True(t, replies.waitForReply(minReplyBytes, replyTimeout),
+		"a second utterance must be answered too — the session must stay open and keep listening")
+
+	secondAudio, secondText := replies.snapshot()
+	secondSpoken := transcribe(t, sttSvc, secondAudio)
+	t.Logf("turn 2 reply: transcript=%q streamed_text=%q audio_bytes=%d",
+		secondSpoken, secondText, len(secondAudio))
+	assert.Contains(t, secondSpoken, "berlin", "the second turn must be answered on its own merits")
+}

--- a/sdk/vad_mode_per_turn_test.go
+++ b/sdk/vad_mode_per_turn_test.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/stt"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -162,6 +164,48 @@ func userTextsIn(msgs []types.Message) []string {
 	return out
 }
 
+// recordingConvTTS records every text the pipeline chose to speak, so a test can
+// assert on the words the caller would hear. convMockTTSService discards them.
+type recordingConvTTS struct {
+	convMockTTSService
+
+	mu     sync.Mutex
+	spoken []string
+}
+
+func newRecordingConvTTS() *recordingConvTTS {
+	return &recordingConvTTS{convMockTTSService: *newConvMockTTSService()}
+}
+
+func (r *recordingConvTTS) Synthesize(
+	ctx context.Context, text string, cfg tts.SynthesisConfig,
+) (io.ReadCloser, error) {
+	r.mu.Lock()
+	r.spoken = append(r.spoken, text)
+	r.mu.Unlock()
+	return r.convMockTTSService.Synthesize(ctx, text, cfg)
+}
+
+func (r *recordingConvTTS) texts() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.spoken))
+	copy(out, r.spoken)
+	return out
+}
+
+// waitForSpoken polls until the pipeline has spoken at least n texts.
+func (r *recordingConvTTS) waitForSpoken(n int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(r.texts()) >= n {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
 const perTurnTestSampleRate = 16000
 
 // openVADModeConv opens a duplex VAD-mode conversation wired to the given STT
@@ -170,10 +214,19 @@ func openVADModeConv(
 	t *testing.T, sttSvc *scriptedSTTService, provider *turnRecordingProvider,
 ) *Conversation {
 	t.Helper()
+	return openVADModeConvWithTTS(t, sttSvc, provider, newConvMockTTSService())
+}
+
+// openVADModeConvWithTTS is openVADModeConv with the TTS service under the
+// caller's control, for tests that assert on what the pipeline speaks.
+func openVADModeConvWithTTS(
+	t *testing.T, sttSvc *scriptedSTTService, provider *turnRecordingProvider, ttsSvc tts.Service,
+) *Conversation {
+	t.Helper()
 	conv, err := OpenDuplex(writeIngestionTestPack(t), "main",
 		WithProvider(provider),
 		WithSkipSchemaValidation(),
-		WithVADMode(sttSvc, newConvMockTTSService(), &VADModeConfig{
+		WithVADMode(sttSvc, ttsSvc, &VADModeConfig{
 			SilenceDuration:   300 * time.Millisecond,
 			MinSpeechDuration: 100 * time.Millisecond,
 			MaxTurnDuration:   5 * time.Second,
@@ -236,6 +289,34 @@ func TestVADModeFiresLLMDuringSessionNotAtClose(t *testing.T) {
 		"model must fire during the session, before Close; fired %d times", provider.turnCount())
 	assert.Contains(t, userTextsIn(provider.turnAt(0)), "what is the capital of france",
 		"the turn the model fired on must carry that turn's transcript")
+}
+
+// TestVADModeSpeaksTheReplyNotTheCallersOwnWords guards the composition that
+// the per-turn fix created. The continuous multi-turn ProviderStage re-emits
+// each turn's user transcript downstream before generating, and in VAD mode TTS
+// is what sits downstream — so an unfiltered speech stage reads the caller's
+// own question back to them before answering it. Caught against real providers,
+// pinned here because CI has no API keys.
+func TestVADModeSpeaksTheReplyNotTheCallersOwnWords(t *testing.T) {
+	if testing.Short() {
+		t.Skip("drives a real VAD turn in wall-clock time")
+	}
+	const transcript = "what is the capital of france"
+	sttSvc := newScriptedSTT(transcript)
+	provider := &turnRecordingProvider{}
+	ttsSvc := newRecordingConvTTS()
+	conv := openVADModeConvWithTTS(t, sttSvc, provider, ttsSvc)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	speakOneUtterance(t, conv)
+	require.True(t, ttsSvc.waitForSpoken(1, 8*time.Second),
+		"the assistant must speak something during the session")
+
+	spoken := ttsSvc.texts()
+	assert.NotContains(t, spoken, transcript,
+		"the caller's own transcript must never be spoken back at them")
+	assert.Equal(t, []string{"ack"}, spoken,
+		"exactly the assistant's reply is spoken, once — not the streamed deltas as well")
 }
 
 // TestVADModeThreadsHistoryAcrossTurns proves the fix is the continuous

--- a/sdk/vad_mode_per_turn_test.go
+++ b/sdk/vad_mode_per_turn_test.go
@@ -1,0 +1,265 @@
+package sdk
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+	"github.com/AltairaLabs/PromptKit/runtime/stt"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedSTTService returns a different transcript per call so a test can tell
+// one VAD turn from the next. convMockSTTService transcribes everything as
+// "hello", which cannot distinguish "fired twice" from "fired once, twice read".
+type scriptedSTTService struct {
+	mu          sync.Mutex
+	transcripts []string
+	calls       int
+}
+
+func newScriptedSTT(transcripts ...string) *scriptedSTTService {
+	return &scriptedSTTService{transcripts: transcripts}
+}
+
+func (m *scriptedSTTService) next() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.calls >= len(m.transcripts) {
+		m.calls++
+		return "overrun"
+	}
+	out := m.transcripts[m.calls]
+	m.calls++
+	return out
+}
+
+func (m *scriptedSTTService) Name() string                        { return "scripted-stt" }
+func (m *scriptedSTTService) Type() base.ProviderType             { return base.ProviderTypeSTT }
+func (m *scriptedSTTService) Pricing() *base.PricingDescriptor    { return nil }
+func (m *scriptedSTTService) Validate() error                     { return nil }
+func (m *scriptedSTTService) Init(_ context.Context) error        { return nil }
+func (m *scriptedSTTService) HealthCheck(_ context.Context) error { return nil }
+func (m *scriptedSTTService) Close() error                        { return nil }
+func (m *scriptedSTTService) SupportedFormats() []string          { return []string{"pcm"} }
+
+func (m *scriptedSTTService) Transcribe(_ context.Context, _ base.STTRequest) (base.STTResponse, error) {
+	return base.STTResponse{Text: m.next()}, nil
+}
+
+func (m *scriptedSTTService) TranscribeBytes(
+	_ context.Context, _ []byte, _ stt.TranscriptionConfig,
+) (string, error) {
+	return m.next(), nil
+}
+
+// turnRecordingProvider records the full message list of every request, so a
+// test can assert both how many times the model fired and what history each
+// call carried. recordingTextProvider flattens user text across calls and so
+// cannot express either.
+type turnRecordingProvider struct {
+	base.Implementation
+
+	mu    sync.Mutex
+	turns [][]types.Message
+}
+
+func (p *turnRecordingProvider) ID() string    { return "turn-recording" }
+func (p *turnRecordingProvider) Model() string { return "turn-recording-model" }
+
+func (p *turnRecordingProvider) Predict(
+	_ context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.record(req)
+	return providers.PredictionResponse{Content: "ack"}, nil
+}
+
+func (p *turnRecordingProvider) PredictStream(
+	_ context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	p.record(req)
+	stop := "stop"
+	ch := make(chan providers.StreamChunk, 1)
+	ch <- providers.StreamChunk{Content: "ack", Delta: "ack", FinishReason: &stop}
+	close(ch)
+	return ch, nil
+}
+
+func (p *turnRecordingProvider) record(req providers.PredictionRequest) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	msgs := make([]types.Message, len(req.Messages))
+	copy(msgs, req.Messages)
+	p.turns = append(p.turns, msgs)
+}
+
+func (p *turnRecordingProvider) turnCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.turns)
+}
+
+// turnAt returns a copy of the messages the nth (0-based) call carried.
+func (p *turnRecordingProvider) turnAt(n int) []types.Message {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if n >= len(p.turns) {
+		return nil
+	}
+	out := make([]types.Message, len(p.turns[n]))
+	copy(out, p.turns[n])
+	return out
+}
+
+// waitForTurns polls until the model has fired at least n times.
+func (p *turnRecordingProvider) waitForTurns(n int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if p.turnCount() >= n {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+func (p *turnRecordingProvider) SupportsStreaming() bool      { return true }
+func (p *turnRecordingProvider) ShouldIncludeRawOutput() bool { return false }
+func (p *turnRecordingProvider) Close() error                 { return nil }
+func (p *turnRecordingProvider) CalculateCost(_, _, _ int) types.CostInfo {
+	return types.CostInfo{}
+}
+
+// messageText flattens a Message's text across the legacy Content field and Parts.
+func messageText(msg types.Message) string {
+	if msg.Content != "" {
+		return msg.Content
+	}
+	for _, part := range msg.Parts {
+		if part.Text != nil && *part.Text != "" {
+			return *part.Text
+		}
+	}
+	return ""
+}
+
+// userTextsIn returns the text of every user message in msgs.
+func userTextsIn(msgs []types.Message) []string {
+	var out []string
+	for _, msg := range msgs {
+		if msg.Role != "user" {
+			continue
+		}
+		if text := messageText(msg); text != "" {
+			out = append(out, text)
+		}
+	}
+	return out
+}
+
+const perTurnTestSampleRate = 16000
+
+// openVADModeConv opens a duplex VAD-mode conversation wired to the given STT
+// and provider, with turn timings tightened so a test utterance closes quickly.
+func openVADModeConv(
+	t *testing.T, sttSvc *scriptedSTTService, provider *turnRecordingProvider,
+) *Conversation {
+	t.Helper()
+	conv, err := OpenDuplex(writeIngestionTestPack(t), "main",
+		WithProvider(provider),
+		WithSkipSchemaValidation(),
+		WithVADMode(sttSvc, newConvMockTTSService(), &VADModeConfig{
+			SilenceDuration:   300 * time.Millisecond,
+			MinSpeechDuration: 100 * time.Millisecond,
+			MaxTurnDuration:   5 * time.Second,
+			SampleRate:        perTurnTestSampleRate,
+			Language:          "en",
+			Voice:             "alloy",
+			Speed:             1.0,
+		}),
+	)
+	require.NoError(t, err)
+
+	responseCh, err := conv.Response()
+	require.NoError(t, err)
+	go func() {
+		for range responseCh { //nolint:revive // drained so the output stage never blocks
+		}
+	}()
+	return conv
+}
+
+// speakOneUtterance feeds speech then silence at real time, which is what makes
+// AudioTurnStage open and then close exactly one turn. Bulk-sending the same
+// bytes never closes a turn — the stage re-evaluates only on element arrival.
+func speakOneUtterance(t *testing.T, conv *Conversation) {
+	t.Helper()
+	ctx := context.Background()
+	send := func(pcm []byte) {
+		require.NoError(t, conv.SendChunk(ctx, &providers.StreamChunk{
+			MediaData: &providers.StreamMediaData{MIMEType: "audio/pcm", Data: pcm},
+		}))
+	}
+	const frame = 20 * time.Millisecond
+	for i := 0; i < 30; i++ {
+		send(pcmSpeech(frame, perTurnTestSampleRate))
+		time.Sleep(frame)
+	}
+	for i := 0; i < 30; i++ {
+		send(pcmSilence(frame, perTurnTestSampleRate))
+		time.Sleep(frame)
+	}
+}
+
+// TestVADModeFiresLLMDuringSessionNotAtClose is the core of #1644: a live voice
+// conversation must get a reply while the caller is still on the line. VAD mode
+// built a non-streaming ProviderStage and never emitted turn boundaries, so the
+// model fired once when the input channel closed — a caller heard nothing until
+// they hung up.
+func TestVADModeFiresLLMDuringSessionNotAtClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("drives a real VAD turn in wall-clock time")
+	}
+	sttSvc := newScriptedSTT("what is the capital of france")
+	provider := &turnRecordingProvider{}
+	conv := openVADModeConv(t, sttSvc, provider)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	speakOneUtterance(t, conv)
+
+	require.True(t, provider.waitForTurns(1, 8*time.Second),
+		"model must fire during the session, before Close; fired %d times", provider.turnCount())
+	assert.Contains(t, userTextsIn(provider.turnAt(0)), "what is the capital of france",
+		"the turn the model fired on must carry that turn's transcript")
+}
+
+// TestVADModeThreadsHistoryAcrossTurns proves the fix is the continuous
+// multi-turn loop and not merely an earlier single firing: a second utterance
+// fires the model again, and that call still carries the first exchange.
+func TestVADModeThreadsHistoryAcrossTurns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("drives two real VAD turns in wall-clock time")
+	}
+	sttSvc := newScriptedSTT("first question", "second question")
+	provider := &turnRecordingProvider{}
+	conv := openVADModeConv(t, sttSvc, provider)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	speakOneUtterance(t, conv)
+	require.True(t, provider.waitForTurns(1, 8*time.Second), "first utterance must fire the model")
+
+	speakOneUtterance(t, conv)
+	require.True(t, provider.waitForTurns(2, 8*time.Second),
+		"second utterance must fire the model again; fired %d times", provider.turnCount())
+
+	second := provider.turnAt(1)
+	assert.Contains(t, userTextsIn(second), "second question",
+		"the second call must carry the second transcript")
+	assert.Contains(t, userTextsIn(second), "first question",
+		"the second call must still carry the first turn's history")
+}


### PR DESCRIPTION
## Summary

`WithVADMode` built a pipeline whose LLM fired **once, at session close** — a live
voice caller heard nothing until they hung up (#1644). Fixing that put a TTS stage
downstream of a streaming `ProviderStage` for the first time, which surfaced two
further speech-out bugs. A live round trip against real providers (OpenAI TTS →
Whisper → Claude → TTS) caught both; no mock could.

## The three bugs

1. **Fired once at close, not per turn** (#1644). Same coupling the `WithIngestion`
   path got in #1612, which VAD never received because the two are mutually
   exclusive. Fix: `ProviderConfig.Streaming = true` (else the unary
   accumulate-until-close path runs) **and** `AudioTurnConfig.EmitEndOfTurn = true`
   (the streaming loop fires on turn boundaries). Either alone is insufficient.

2. **Spoke the caller's own question back.** The streaming stage re-emits each
   turn's user transcript downstream before generating (for the UI/save stages,
   #1612); TTS sat on the same channel and synthesized it. Fix: a speech-out stage
   speaks only the assistant.

3. **Synthesized every reply twice.** One reply reaches TTS as both a run of
   incremental `Text` deltas (the live-text feed) and the final assistant
   `Message` (the canonical record). The TTS provider takes a complete string and
   streams only audio out — per-fragment synthesis would be one HTTP request per
   token and choppy audio. Fix: streaming deltas are marked
   (`ElementMetadata.StreamingDelta`) and skipped by the speech-out stages; the
   complete `Message` is spoken. Applied to the interruption-aware stage and its
   plain sibling.

## Verification

- TDD throughout — every test written first and shown failing for the right reason.
- Mock-level (CI, no keys): fires per turn during the session (1.3s, was ~9s at
  close); threads history across turns; speaks exactly the reply, once, never the
  caller's words.
- Live e2e (`//go:build e2e`, skips without `OPENAI_API_KEY`+`ANTHROPIC_API_KEY`):
  real speech in, real speech out, two turns on one session, transcribes the spoken
  reply back (`paris`, `berlin`), and counts synthesis calls (1 per turn).
- Full `runtime/` and `sdk/` suites green.

Closes #1644
