### PR TITLE
fix(sdk): don't let an unread duplex Response() silently stall the pipeline

### DIFF
--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -1766,6 +1766,10 @@ func (c *Conversation) Response() (<-chan providers.StreamChunk, error)
 
 Response returns the response channel for duplex streaming. Only available when the conversation was opened with OpenDuplex\(\).
 
+The caller MUST drain the returned channel for the lifetime of the session, even when it consumes results by other means \(e.g. OnClientTool handlers\) and discards the streamed content — run a goroutine that ranges over it. The pipeline's output stage sends here; an unread channel fills and back\-pressures the whole pipeline to a halt.
+
+A session whose Response\(\) is never called does not stall — the SDK drops output once the buffer fills, logging a one\-time warning — so call Response\(\) before the session produces output, or early chunks may be dropped.
+
 <a name="Conversation.Resume"></a>
 ### func \(\*Conversation\) Resume
 

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -873,6 +873,16 @@ func (c *Conversation) TriggerStart(ctx context.Context, message string) error {
 
 // Response returns the response channel for duplex streaming.
 // Only available when the conversation was opened with OpenDuplex().
+//
+// The caller MUST drain the returned channel for the lifetime of the session,
+// even when it consumes results by other means (e.g. OnClientTool handlers) and
+// discards the streamed content — run a goroutine that ranges over it. The
+// pipeline's output stage sends here; an unread channel fills and back-pressures
+// the whole pipeline to a halt.
+//
+// A session whose Response() is never called does not stall — the SDK drops
+// output once the buffer fills, logging a one-time warning — so call Response()
+// before the session produces output, or early chunks may be dropped.
 func (c *Conversation) Response() (<-chan providers.StreamChunk, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/sdk/session/duplex_forward_chunk_test.go
+++ b/sdk/session/duplex_forward_chunk_test.go
@@ -1,0 +1,142 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newForwardTestSession builds a bare duplexSession with a small output buffer,
+// enough to exercise forwardChunk in isolation.
+func newForwardTestSession(bufferSize int) *duplexSession {
+	return &duplexSession{
+		streamOutput: make(chan providers.StreamChunk, bufferSize),
+	}
+}
+
+// TestForwardChunk_UnreadNeverBlocks is #1638: a caller that never takes
+// Response() must not stall the pipeline. When nobody is reading, forwardChunk
+// buffers while there is room and then drops — it never blocks — so the
+// forwarding loop keeps running and the session stays alive.
+func TestForwardChunk_UnreadNeverBlocks(t *testing.T) {
+	s := newForwardTestSession(2)
+	// responseTaken defaults to false — Response() was never called.
+
+	ctx := context.Background()
+	for i := range 5 {
+		keepGoing := s.forwardChunk(ctx, providers.StreamChunk{Delta: "x"})
+		assert.True(t, keepGoing, "unread forwarding must keep the loop running, never block (chunk %d)", i)
+	}
+
+	assert.Equal(t, int64(3), s.droppedChunks.Load(),
+		"with buffer 2 and 5 sends and no reader, the 3 overflow chunks must be dropped, not blocked on")
+}
+
+// TestForwardChunk_TakenDeliversToReader is the regression guard: once Response()
+// is taken, chunks are delivered to the consumer rather than dropped.
+func TestForwardChunk_TakenDeliversToReader(t *testing.T) {
+	s := newForwardTestSession(4)
+	s.responseTaken.Store(true)
+
+	ctx := context.Background()
+	for range 3 {
+		assert.True(t, s.forwardChunk(ctx, providers.StreamChunk{Delta: "y"}))
+	}
+	close(s.streamOutput)
+
+	var got int
+	for range s.streamOutput {
+		got++
+	}
+	assert.Equal(t, 3, got, "a taken consumer must receive every chunk")
+	assert.Equal(t, int64(0), s.droppedChunks.Load(), "nothing is dropped when Response() is taken")
+}
+
+// TestForwardChunk_TakenHonorsContextCancel proves a taken-but-stalled consumer
+// does not wedge the loop forever: a full buffer plus a cancelled context makes
+// forwardChunk return false so the forwarding loop can unwind.
+func TestForwardChunk_TakenHonorsContextCancel(t *testing.T) {
+	s := newForwardTestSession(1)
+	s.responseTaken.Store(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	assert.True(t, s.forwardChunk(ctx, providers.StreamChunk{Delta: "fills-buffer"}))
+
+	cancel() // consumer never reads; buffer stays full
+	keepGoing := s.forwardChunk(ctx, providers.StreamChunk{Delta: "would-block"})
+	assert.False(t, keepGoing, "a cancelled context must release a blocked send so the loop can stop")
+}
+
+// TestForwardChunk_TakenSlowConsumerWarnsThenDelivers covers the taken-but-behind
+// path: with the buffer full and the context alive, forwardChunk waits, warns
+// once past the (test-lowered) threshold, and then delivers the moment the
+// consumer drains — never losing the chunk.
+func TestForwardChunk_TakenSlowConsumerWarnsThenDelivers(t *testing.T) {
+	prev := outputBlockWarnThreshold
+	outputBlockWarnThreshold = 10 * time.Millisecond
+	defer func() { outputBlockWarnThreshold = prev }()
+
+	s := newForwardTestSession(1)
+	s.responseTaken.Store(true)
+	s.streamOutput <- providers.StreamChunk{Delta: "fills-buffer"} // buffer now full
+
+	ctx := context.Background()
+	done := make(chan bool, 1)
+	go func() { done <- s.forwardChunk(ctx, providers.StreamChunk{Delta: "waits-then-delivers"}) }()
+
+	// Let it pass the warn threshold while blocked, then drain so the send lands.
+	time.Sleep(40 * time.Millisecond)
+	<-s.streamOutput // free a slot
+
+	select {
+	case keepGoing := <-done:
+		assert.True(t, keepGoing, "a slow consumer that eventually drains must still receive the chunk")
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwardChunk did not deliver after the buffer drained")
+	}
+	assert.True(t, s.warnedSlowConsumer.Load(), "a consumer stalled past the threshold must be warned")
+	assert.Equal(t, int64(0), s.droppedChunks.Load(), "a taken consumer never drops")
+
+	got := <-s.streamOutput
+	assert.Equal(t, "waits-then-delivers", got.Delta)
+}
+
+// TestHandleToolCalls_UnreadFullBufferDoesNotBlock guards the wiring: the
+// forwarding path in handleToolCalls must go through forwardChunk, so a session
+// whose Response() is never read and whose output buffer is already full drops
+// the chunk and returns rather than blocking the pipeline. Without the fix this
+// call blocks forever (test would hang).
+func TestHandleToolCalls_UnreadFullBufferDoesNotBlock(t *testing.T) {
+	s := &duplexSession{
+		id:           "test",
+		toolRegistry: nil, // no registry → forwards the element via forwardChunk
+		stageInput:   make(chan stage.StreamElement, 1),
+		streamOutput: make(chan providers.StreamChunk, 1),
+	}
+	// Response() was never taken, and the buffer is already full.
+	s.streamOutput <- providers.StreamChunk{Delta: "already-buffered"}
+
+	elem := &stage.StreamElement{
+		Message: &types.Message{
+			ToolCalls: []types.MessageToolCall{{ID: "c1", Name: "t", Args: json.RawMessage(`{}`)}},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.handleToolCalls(context.Background(), elem) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleToolCalls blocked on a full, unread output channel — the stall is not fixed")
+	}
+	assert.Equal(t, int64(1), s.droppedChunks.Load(), "the un-deliverable chunk must be dropped, not blocked on")
+}

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -47,6 +48,19 @@ type duplexSession struct {
 
 	// External API channel (providers.StreamChunk)
 	streamOutput chan providers.StreamChunk // Consumer receives chunks here
+
+	// responseTaken records whether Response() has been called. Until it is, no
+	// one can read streamOutput, so the forwarding loop must not block on it —
+	// otherwise a caller that reacts only through OnClientTool handlers (and never
+	// reads Response()) silently stalls the whole pipeline once the buffer fills.
+	// See forwardChunk and issue #1638.
+	responseTaken atomic.Bool
+	// droppedChunks counts output chunks discarded because Response() was never
+	// taken. Its first increment emits a one-time warning.
+	droppedChunks atomic.Int64
+	// warnedSlowConsumer guards the one-time "consumer is not draining" warning
+	// for a taken-but-stalled Response().
+	warnedSlowConsumer atomic.Bool
 
 	// Pipeline execution control
 	executionStarted bool
@@ -359,9 +373,7 @@ func (s *duplexSession) executePipeline(ctx context.Context) {
 
 			case streaming.ResponseActionContinue, streaming.ResponseActionComplete:
 				chunk := streamElementToStreamChunk(&elem)
-				select {
-				case s.streamOutput <- chunk:
-				case <-ctx.Done():
+				if !s.forwardChunk(ctx, chunk) {
 					return
 				}
 			}
@@ -378,9 +390,7 @@ func (s *duplexSession) handleToolCalls(ctx context.Context, elem *stage.StreamE
 	// No registry — forward the element as-is (caller must handle tool calls)
 	if s.toolRegistry == nil {
 		chunk := streamElementToStreamChunk(elem)
-		select {
-		case s.streamOutput <- chunk:
-		case <-ctx.Done():
+		if !s.forwardChunk(ctx, chunk) {
 			return ctx.Err()
 		}
 		return nil
@@ -403,9 +413,7 @@ func (s *duplexSession) handleToolCalls(ctx context.Context, elem *stage.StreamE
 	if len(duplexResult.Pending) > 0 {
 		elem.Meta.PendingTools = duplexResult.Pending
 		chunk := streamElementToStreamChunk(elem)
-		select {
-		case s.streamOutput <- chunk:
-		case <-ctx.Done():
+		if !s.forwardChunk(ctx, chunk) {
 			return ctx.Err()
 		}
 	}
@@ -413,9 +421,78 @@ func (s *duplexSession) handleToolCalls(ctx context.Context, elem *stage.StreamE
 	return nil
 }
 
-// Response returns the response channel from the Pipeline.
+// Response returns the channel of streamed output chunks.
+//
+// The caller MUST drain this channel for the lifetime of the session, even if it
+// consumes results by other means (e.g. OnClientTool handlers) and discards the
+// streamed content — spin up a goroutine that ranges over it. The pipeline's
+// output stage sends here; if the channel is never read it fills and back-pressures
+// the whole pipeline to a silent halt.
+//
+// As a safety net, a session whose Response() is never called does NOT stall: the
+// forwarding loop drops output chunks once the buffer fills (logging a one-time
+// warning) rather than blocking. Because of that, call Response() before the
+// session produces output — chunks emitted before the first call may be dropped.
 func (s *duplexSession) Response() <-chan providers.StreamChunk {
+	s.responseTaken.Store(true)
 	return s.streamOutput
+}
+
+// outputBlockWarnThreshold is how long a taken Response() consumer may stall the
+// output send before forwardChunk warns that it is not draining fast enough. A
+// var (not const) so tests can lower it; not meant to change at runtime.
+var outputBlockWarnThreshold = 3 * time.Second
+
+// forwardChunk delivers one chunk to the response channel and reports whether the
+// forwarding loop should keep running (false means the session context is done).
+//
+// If Response() has been taken, the send blocks (bounded by ctx) so no output is
+// lost, but a consumer that stalls past outputBlockWarnThreshold is warned once.
+// If Response() has NOT been taken, nothing will ever read the channel, so the
+// send must never block: it buffers while there is room and then drops, keeping
+// the pipeline alive instead of deadlocking it (issue #1638). Dropping warns once.
+func (s *duplexSession) forwardChunk(ctx context.Context, chunk providers.StreamChunk) bool {
+	if !s.responseTaken.Load() {
+		select {
+		case <-ctx.Done():
+			return false
+		case s.streamOutput <- chunk:
+			return true
+		default:
+			if s.droppedChunks.Add(1) == 1 {
+				logger.Warn("duplexSession: Response() was never read; dropping streamed output. " +
+					"Call Response() and drain the channel (even a discard goroutine) to receive output.")
+			}
+			return true
+		}
+	}
+
+	// Fast path: room in the buffer, or the session is already done.
+	select {
+	case <-ctx.Done():
+		return false
+	case s.streamOutput <- chunk:
+		return true
+	default:
+	}
+
+	// The consumer is behind. Wait for room, but warn once past the threshold so a
+	// stalled reader is a diagnostic rather than a silent hang.
+	timer := time.NewTimer(outputBlockWarnThreshold)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case s.streamOutput <- chunk:
+			return true
+		case <-timer.C:
+			if !s.warnedSlowConsumer.Swap(true) {
+				logger.Warn("duplexSession: Response() consumer is not draining fast enough; " +
+					"the output stage is blocked. Read Response() promptly to avoid stalling the pipeline.")
+			}
+		}
+	}
 }
 
 // DefaultDrainTimeout is the maximum time to wait for pipeline completion during Drain.


### PR DESCRIPTION
## Summary

A duplex `Response()` that is never read silently stalls the whole pipeline. Root-caused, then fixed so non-consumption is safe **and** observable.

## Root cause

The output stage sends every chunk into a buffered channel (`streamBufferSize = 100`) via `select { case streamOutput <- chunk: case <-ctx.Done(): }`. If the caller never reads `Response()` — e.g. a tool-only app reacting entirely through `OnClientTool` handlers — the buffer fills after 100 chunks, the send blocks, the forwarding loop stops draining the stage output, and back-pressure halts the entire pipeline until the session context is cancelled. No error, no log. It needs ~100 chunks to manifest, which is why short sessions never hit it and it went unnoticed.

## Fix

`forwardChunk` centralizes every output send:

- **`Response()` taken** — block (bounded by ctx) so no output is lost, and warn **once** if the consumer stalls past `outputBlockWarnThreshold` (3s). A slow-but-eventually-draining consumer is still delivered every chunk.
- **`Response()` never taken** — nothing can ever read the channel, so never block: buffer while there's room, then **drop** (warn once), keeping the pipeline alive.
- `Response()` records that it was taken; both it and the SDK-facing `Conversation.Response()` now document the drain requirement and the drop-when-unread safety net (so call `Response()` before output, or early chunks may be dropped).

## Verification

- Root cause confirmed by code + the `streamBufferSize` constant before any fix.
- TDD, 5 tests, `-race` clean: unread never blocks (buffers→drops); a taken consumer receives every chunk; a cancelled context releases a blocked send; a slow consumer is warned once then delivered; and the wired `handleToolCalls` path does **not** block on a full unread channel (guards against regressing to the old send — would hang under the old code).
- Coverage 88.3% on the changed file. Full `sdk/` suite green.

Closes #1638
