### PR TITLE
test(evals): give subprocess side-effect tests a generous budget

### DIFF
--- a/runtime/evals/exec_hook_test.go
+++ b/runtime/evals/exec_hook_test.go
@@ -10,6 +10,15 @@ import (
 	"time"
 )
 
+// testExecHookTimeoutMs is a deliberately generous per-invocation budget for
+// tests that assert on a subprocess side effect (a file the script writes). The
+// scripts do microseconds of work, but the 5s default (DefaultExecEvalHookTimeout)
+// starves to death under a busy runner — e.g. `runtime/...` and `sdk/...` sweeps
+// running concurrently — killing the process before it writes and surfacing as a
+// confusing missing-file read error rather than a timeout (#1645). This margin
+// absorbs scheduling contention; it is not exercising a real timeout.
+const testExecHookTimeoutMs = 60_000
+
 func writeTempScript(t *testing.T, body string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -29,8 +38,9 @@ func TestExecEvalHook_PipesResultJSONOnStdin(t *testing.T) {
 	script := writeTempScript(t, `cat > "`+out+`"`)
 
 	hook := NewExecEvalHook(&ExecEvalHookConfig{
-		Name:    "capture",
-		Command: script,
+		Name:      "capture",
+		Command:   script,
+		TimeoutMs: testExecHookTimeoutMs,
 	})
 
 	score := 0.75
@@ -39,7 +49,7 @@ func TestExecEvalHook_PipesResultJSONOnStdin(t *testing.T) {
 
 	payload, err := os.ReadFile(out)
 	if err != nil {
-		t.Fatalf("read captured stdin: %v", err)
+		t.Fatalf("read captured stdin (subprocess may have failed — see WARN log above): %v", err)
 	}
 
 	var got EvalResult
@@ -115,10 +125,11 @@ func TestExecEvalHook_PassesArgsAndEnv(t *testing.T) {
 	t.Cleanup(func() { _ = os.Unsetenv("EVAL_HOOK_TEST_VAR") })
 
 	hook := NewExecEvalHook(&ExecEvalHookConfig{
-		Name:    "with-args-env",
-		Command: script,
-		Args:    []string{"hello-arg"},
-		Env:     []string{"EVAL_HOOK_TEST_VAR"},
+		Name:      "with-args-env",
+		Command:   script,
+		Args:      []string{"hello-arg"},
+		Env:       []string{"EVAL_HOOK_TEST_VAR"},
+		TimeoutMs: testExecHookTimeoutMs,
 	})
 
 	score := 1.0
@@ -126,7 +137,7 @@ func TestExecEvalHook_PassesArgsAndEnv(t *testing.T) {
 
 	got, err := os.ReadFile(out)
 	if err != nil {
-		t.Fatalf("read captured output: %v", err)
+		t.Fatalf("read captured output (subprocess may have failed — see WARN log above): %v", err)
 	}
 	want := "arg=hello-arg env=from-env\n"
 	if string(got) != want {


### PR DESCRIPTION
## Summary

`TestExecEvalHook_PassesArgsAndEnv` fails intermittently under CPU contention with a confusing missing-file error (#1645). Root-caused and fixed.

## Root cause

The test — and its sibling `TestExecEvalHook_PipesResultJSONOnStdin` — assert on a file their spawned script writes, but leave `TimeoutMs` at the 5s default (`DefaultExecEvalHookTimeout`). The scripts do microseconds of work, but under a busy runner (`runtime/...` and `sdk/...` sweeps running concurrently) the process is starved past 5s and killed before it writes. `OnEvalResult` is fire-and-forget — it logs the timeout (`signal: killed`) and drops it — so the test then fails on the missing-file read, pointing at file I/O rather than the timeout that actually happened.

## Fix

- Set a deliberately generous 60s budget on both side-effect tests via a shared, documented constant — enough margin to absorb scheduling contention without exercising a real timeout.
- Make the read-failure message point at the subprocess / WARN log so the next person doesn't debug the wrong layer.

The 5s default is unchanged for real eval hooks; this is purely test robustness (the issue explicitly endorses raising the budget for the test hook).

## Verification

- Root cause confirmed in code: `OnEvalResult` (`exec_hook.go`) is synchronous, defaults to 5s when `TimeoutMs<=0`; both file-asserting tests omitted it.
- `go test ./evals -run TestExecEvalHook -race -count=5` — all pass; lint clean.
- The flake is load-dependent (starving a `printf` for 5s needs real contention), so a deterministic repro isn't practical; the fix removes the fixed-budget starvation window rather than papering the assertion.

Closes #1645
