### PR TITLE
fix(evals): judge the full session transcript, not assistant text only

### DIFF
--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -582,7 +582,10 @@ Turn-level LLM evaluation. The judge sees the current assistant response and eva
 
 ### `llm_judge_session`
 
-Session-level LLM evaluation. The judge sees the full conversation. Alias: `llm_judge_conversation`.
+Session-level LLM evaluation. The judge sees a full role-labeled transcript of the
+conversation — every turn (user, assistant, and any other role), plus every tool
+call with its arguments and result — so tool-using and observer agents are judged
+on what they actually did, not only on their prose. Alias: `llm_judge_conversation`.
 
 Same params as `llm_judge`. **Surfaces:** A E
 

--- a/runtime/evals/handlers/llm_judge_session.go
+++ b/runtime/evals/handlers/llm_judge_session.go
@@ -2,14 +2,19 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
 // LLMJudgeSessionHandler is the session-level counterpart of
-// LLMJudgeHandler — concatenates all assistant messages and runs the
-// judge once over the lot. Same params, same conventions.
+// LLMJudgeHandler. It runs the judge once over a full, role-labeled
+// transcript of the conversation — user (and other) turns, assistant
+// text, and every tool call with its arguments and result — so the
+// judge sees what the agent actually did, not only its prose. Same
+// params, same conventions. Registered under `llm_judge_conversation`
+// too (see register.go).
 type LLMJudgeSessionHandler struct{}
 
 // Type returns the eval type identifier.
@@ -17,13 +22,65 @@ func (h *LLMJudgeSessionHandler) Type() string {
 	return "llm_judge_session"
 }
 
-// Eval runs the LLM judge on all assistant messages in the session.
+// Eval runs the LLM judge over the full session transcript.
 func (h *LLMJudgeSessionHandler) Eval(
 	ctx context.Context,
 	evalCtx *evals.EvalContext,
 	params map[string]any,
 ) (result *evals.EvalResult, err error) {
-	return runJudgeEval(ctx, evalCtx, h.Type(), params, collectAssistantContent(evalCtx)), nil
+	return runJudgeEval(ctx, evalCtx, h.Type(), params, renderSessionTranscript(evalCtx)), nil
+}
+
+// renderSessionTranscript builds the content the session/conversation judge
+// sees: a role-labeled transcript of the interaction followed by the tool
+// calls with their arguments and results.
+//
+// The previous view (collectAssistantContent) was assistant text only — it
+// dropped user turns, every tool call, and every tool result, so a tool-using
+// or observer agent (whose real output *is* its tool calls) was judged blind
+// and scored meaninglessly (#1615). The data was always present on the eval
+// context; it was simply discarded.
+//
+// System messages (setup, not interaction) and tool-result rows are omitted
+// from the turn list — tool results are rendered with their calls below.
+func renderSessionTranscript(evalCtx *evals.EvalContext) string {
+	var b strings.Builder
+
+	for i := range evalCtx.Messages {
+		msg := &evalCtx.Messages[i]
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		if role == "system" || role == roleTool {
+			continue
+		}
+		content := strings.TrimSpace(msg.GetContent())
+		if content == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "%s: %s", titleRole(msg.Role), content)
+	}
+
+	if len(evalCtx.ToolCalls) > 0 {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString("Tool calls (name, arguments, result):\n")
+		b.WriteString(formatToolCallViews(viewsFromRecords(evalCtx.ToolCalls)))
+	}
+
+	return b.String()
+}
+
+// titleRole renders a message role for the transcript with an upper-case first
+// letter, preserving non-standard roles (e.g. "customer", "agent") verbatim.
+func titleRole(role string) string {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return "Unknown"
+	}
+	return strings.ToUpper(role[:1]) + role[1:]
 }
 
 // collectAssistantContent concatenates all assistant message

--- a/runtime/evals/handlers/llm_judge_session_test.go
+++ b/runtime/evals/handlers/llm_judge_session_test.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// capturingJudgeProvider records the content it was asked to judge, so a test
+// can assert on what actually reached the judge through the handler path.
+type capturingJudgeProvider struct {
+	content string
+}
+
+func (c *capturingJudgeProvider) Judge(_ context.Context, opts JudgeOpts) (*JudgeResult, error) {
+	c.content = opts.Content
+	return &JudgeResult{Passed: true, Score: 1.0, Reasoning: "ok"}, nil
+}
+
+// TestRenderSessionTranscript_IncludesUserTurnsToolCallsAndResults is the core of
+// #1615: the session/conversation judge must see the whole interaction, not just
+// assistant prose. A silent tool-using turn (no assistant text, one tool call)
+// used to render an empty string and score near zero; the transcript must now
+// carry the user's turn, the tool name, its arguments, and its result.
+func TestRenderSessionTranscript_IncludesUserTurnsToolCallsAndResults(t *testing.T) {
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "My address is 742 Evergreen Terrace, Springfield, IL"},
+			{Role: "assistant", Content: ""}, // silent tool-only turn
+		},
+		ToolCalls: []evals.ToolCallRecord{
+			{
+				TurnIndex: 0,
+				ToolName:  "lookup_property",
+				Arguments: map[string]any{"address": "742 Evergreen Terrace, Springfield, IL"},
+				Result:    map[string]any{"parcel_id": "SPR-742-ET"},
+			},
+		},
+	}
+
+	got := renderSessionTranscript(evalCtx)
+
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("transcript must not be empty for a silent tool-only turn")
+	}
+	for _, want := range []string{
+		"742 Evergreen Terrace", // the user's turn
+		"lookup_property",       // the tool that was called
+		"parcel_id",             // the tool's result
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("transcript missing %q\n---\n%s", want, got)
+		}
+	}
+	if !strings.Contains(strings.ToLower(got), "user") {
+		t.Errorf("transcript must label the user turn\n---\n%s", got)
+	}
+}
+
+// TestRenderSessionTranscript_LabelsRolesAndSkipsSystem checks the transcript
+// labels each speaking turn by its role (including non-standard roles like a
+// customer/observer setup) and omits the system prompt, which is setup, not
+// interaction.
+func TestRenderSessionTranscript_LabelsRolesAndSkipsSystem(t *testing.T) {
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "system", Content: "SECRET-SYSTEM-PROMPT"},
+			{Role: "customer", Content: "hello there"},
+			{Role: "assistant", Content: "hi, how can I help?"},
+		},
+	}
+
+	got := renderSessionTranscript(evalCtx)
+
+	if strings.Contains(got, "SECRET-SYSTEM-PROMPT") {
+		t.Errorf("system prompt must be excluded from the judge transcript\n---\n%s", got)
+	}
+	if !strings.Contains(got, "hello there") || !strings.Contains(got, "hi, how can I help?") {
+		t.Errorf("transcript must include the customer and assistant turns\n---\n%s", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "customer") {
+		t.Errorf("transcript must preserve the customer role label\n---\n%s", got)
+	}
+}
+
+// TestRenderSessionTranscript_EmptyContextIsSafe guards against a panic and
+// returns an empty transcript when there is nothing to render.
+func TestRenderSessionTranscript_EmptyContextIsSafe(t *testing.T) {
+	if got := renderSessionTranscript(&evals.EvalContext{}); got != "" {
+		t.Errorf("empty context should render an empty transcript, got %q", got)
+	}
+}
+
+// TestLLMJudgeSessionHandler_FeedsFullTranscriptToJudge is the end-to-end guard:
+// the wired handler must hand the judge the full transcript (tool calls
+// included), not the old assistant-text-only view. Injects a capturing judge and
+// asserts on what it received.
+func TestLLMJudgeSessionHandler_FeedsFullTranscriptToJudge(t *testing.T) {
+	judge := &capturingJudgeProvider{}
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "look up 742 Evergreen Terrace"},
+			{Role: "assistant", Content: ""}, // tool-only turn
+		},
+		ToolCalls: []evals.ToolCallRecord{
+			{TurnIndex: 0, ToolName: "lookup_property", Arguments: map[string]any{"address": "742 Evergreen Terrace"}},
+		},
+		Metadata: map[string]any{"judge_provider": JudgeProvider(judge)},
+	}
+
+	h := &LLMJudgeSessionHandler{}
+	if _, err := h.Eval(context.Background(), evalCtx, map[string]any{"criteria": "did it look up the address?"}); err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+
+	if !strings.Contains(judge.content, "lookup_property") {
+		t.Errorf("judge never saw the tool call; content=\n%s", judge.content)
+	}
+	if !strings.Contains(judge.content, "look up 742 Evergreen Terrace") {
+		t.Errorf("judge never saw the user turn; content=\n%s", judge.content)
+	}
+}

--- a/runtime/evals/handlers/llm_judge_test.go
+++ b/runtime/evals/handlers/llm_judge_test.go
@@ -251,7 +251,7 @@ func TestLLMJudgeSessionHandler_Type(t *testing.T) {
 	}
 }
 
-func TestLLMJudgeSessionHandler_ConcatenatesAssistant(t *testing.T) {
+func TestLLMJudgeSessionHandler_RendersFullTranscript(t *testing.T) {
 	t.Parallel()
 	mock := &llmJudgeMock{
 		result: &JudgeResult{
@@ -293,8 +293,14 @@ func TestLLMJudgeSessionHandler_ConcatenatesAssistant(t *testing.T) {
 		t.Errorf("unexpected type: %s", result.Type)
 	}
 
-	// Verify content is concatenated assistant messages
-	want := "Hi there!\nI'm doing great.\nGoodbye!"
+	// The judge sees a full role-labeled transcript — both sides of the
+	// conversation — not just the assistant's lines (#1615).
+	want := "User: Hello\n" +
+		"Assistant: Hi there!\n" +
+		"User: How are you?\n" +
+		"Assistant: I'm doing great.\n" +
+		"User: Bye\n" +
+		"Assistant: Goodbye!"
 	if mock.opts.Content != want {
 		t.Errorf(
 			"content mismatch:\ngot:  %q\nwant: %q",
@@ -402,7 +408,7 @@ func TestLLMJudgeSessionHandler_RejectsThresholdParams(t *testing.T) {
 		map[string]any{"criteria": "test"})
 }
 
-func TestLLMJudgeSessionHandler_NoAssistantMessages(t *testing.T) {
+func TestLLMJudgeSessionHandler_UserOnlyStillRendersTranscript(t *testing.T) {
 	t.Parallel()
 	mock := &llmJudgeMock{
 		result: &JudgeResult{
@@ -428,12 +434,12 @@ func TestLLMJudgeSessionHandler_NoAssistantMessages(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Empty content is sent to the judge
-	if mock.opts.Content != "" {
-		t.Errorf(
-			"expected empty content, got: %q",
-			mock.opts.Content,
-		)
+	// A user turn with no assistant reply is still content the judge must see —
+	// e.g. to decide whether the agent's silence was appropriate. The old
+	// assistant-text-only view sent an empty string here, the exact blind spot
+	// #1615 fixes.
+	if mock.opts.Content != "User: Hello" {
+		t.Errorf("expected the user turn in the transcript, got: %q", mock.opts.Content)
 	}
 	if result.Score != nil && *result.Score >= 1.0 {
 		t.Error("expected passed=false")


### PR DESCRIPTION
## Summary

`llm_judge_session` (and its alias `llm_judge_conversation`) judged **assistant text only**, dropping every user turn, tool call, and tool result. For a tool-using or observer agent — whose real output *is* its tool calls — the judge was structurally blind: a correct silent tool-only turn rendered an empty string and scored near zero, with a confident rationale describing tool calls that "never happened."

## Fix

Render a **full role-labeled transcript** instead of assistant-text-only:

- every conversational turn (user, assistant, and any other role such as a customer/observer), then
- every tool call with its arguments and result.

The data was always on the eval context (`evalCtx.Messages` + `evalCtx.ToolCalls` — the same source `tool_args_session` reads); it was simply discarded. System messages (setup, not interaction) and tool-result rows are omitted from the turn list — results are shown with their calls. Reuses the existing tool-call renderer (`formatToolCallViews`).

This is the **new default** — the old view was a bug, not a mode. `collectAssistantContent` is unchanged and still used by `rest_eval` / `a2a_eval`.

## Verification (TDD)

- `renderSessionTranscript`: a silent tool-only turn now carries the user turn + tool name + args + result (was empty); roles labeled incl. non-standard ones; system prompt excluded; empty context safe.
- End-to-end: a capturing judge injected via `judge_provider` proves the full transcript actually reaches the judge through the handler.
- Updated the two tests that pinned the old behavior — one asserted a user-only session sends the judge an **empty string**, the exact blind spot.
- Full `evals` suite passes; lint + `-race` clean; checks.md updated.

Closes #1615
