### PR TITLE
feat(sdk): OpenVoice / WithAudioSession — bind the duplex pipeline to an audio.Session

### DIFF
--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -175,6 +175,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func Open\(packPath, promptName string, opts ...Option\) \(\*Conversation, error\)](<#Open>)
   - [func OpenComposition\(packPath, name string, opts ...Option\) \(\*Conversation, error\)](<#OpenComposition>)
   - [func OpenDuplex\(packPath, promptName string, opts ...Option\) \(\*Conversation, error\)](<#OpenDuplex>)
+  - [func OpenVoice\(packPath, promptName string, opts ...Option\) \(\*Conversation, error\)](<#OpenVoice>)
   - [func Resume\(conversationID, packPath, promptName string, opts ...Option\) \(\*Conversation, error\)](<#Resume>)
   - [func ResumeDuplex\(conversationID, packPath, promptName string, opts ...Option\) \(\*Conversation, error\)](<#ResumeDuplex>)
   - [func \(c \*Conversation\) Clear\(\) error](<#Conversation.Clear>)
@@ -215,6 +216,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func \(c \*Conversation\) SetVar\(name, value string\)](<#Conversation.SetVar>)
   - [func \(c \*Conversation\) SetVars\(vars map\[string\]any\)](<#Conversation.SetVars>)
   - [func \(c \*Conversation\) SetVarsFromEnv\(prefix string\)](<#Conversation.SetVarsFromEnv>)
+  - [func \(c \*Conversation\) Start\(ctx context.Context\) error](<#Conversation.Start>)
   - [func \(c \*Conversation\) Stream\(ctx context.Context, message any, opts ...SendOption\) \<\-chan StreamChunk](<#Conversation.Stream>)
   - [func \(c \*Conversation\) StreamRaw\(ctx context.Context, message any\) \(\<\-chan streamPkg.Chunk, error\)](<#Conversation.StreamRaw>)
   - [func \(c \*Conversation\) StreamWithCallback\(ctx context.Context, message any, opts ...SendOption\) \(\*Response, error\)](<#Conversation.StreamWithCallback>)
@@ -275,6 +277,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func WithAPIKey\(key string\) Option](<#WithAPIKey>)
   - [func WithAgentEndpoints\(resolver EndpointResolver\) Option](<#WithAgentEndpoints>)
   - [func WithAudioMonitor\(opts AudioMonitorOptions\) Option](<#WithAudioMonitor>)
+  - [func WithAudioSession\(sess audio.Session\) Option](<#WithAudioSession>)
   - [func WithAutoResize\(maxWidth, maxHeight int\) Option](<#WithAutoResize>)
   - [func WithAutoSummarize\(provider providers.Provider, threshold, batchSize int\) Option](<#WithAutoSummarize>)
   - [func WithAzure\(endpoint, providerType, model string, opts ...PlatformOption\) Option](<#WithAzure>)
@@ -1288,6 +1291,27 @@ Provider requirements depend on how the input side is driven:
 - ASM mode \(default\): audio is sent to the model itself, so the provider must implement providers.StreamInputSupport. Currently that means Gemini with certain models.
 - WithVADMode / WithIngestion: the pipeline owns the input side and the model only ever sees text, so any text provider works — including Claude and OpenAI Chat Completions.
 
+<a name="OpenVoice"></a>
+### func OpenVoice
+
+```go
+func OpenVoice(packPath, promptName string, opts ...Option) (*Conversation, error)
+```
+
+OpenVoice opens a duplex voice conversation bound to an audio.Session and returns it ready for Conversation.Start, which pumps the microphone into the pipeline and plays replies back to the speaker.
+
+It is OpenDuplex plus a required WithAudioSession — the same provider / VAD / ingestion options apply \(WithProvider \+ WithVADMode for STT→LLM→TTS, or a streaming provider for ASM\). For manual chunk I/O without a bound session, use OpenDuplex directly.
+
+```
+sess, _ := audiohelper.NewSession(audiohelper.WithCaptureRate(16000))
+conv, _ := sdk.OpenVoice("./assistant.pack.json", "assist",
+    sdk.WithProvider(llm),
+    sdk.WithVADMode(stt, tts, nil),
+    sdk.WithAudioSession(sess),
+)
+_ = conv.Start(ctx) // blocks: mic → LLM → speaker, until ctx is canceled
+```
+
 <a name="Resume"></a>
 ### func Resume
 
@@ -1982,6 +2006,17 @@ Environment variables matching the prefix are added as template variables with t
 conv.SetVarsFromEnv("PROMPTKIT_")
 // Sets variable "customer_name" = "Alice"
 ```
+
+<a name="Conversation.Start"></a>
+### func \(\*Conversation\) Start
+
+```go
+func (c *Conversation) Start(ctx context.Context) error
+```
+
+Start runs the bound audio session: it feeds every microphone source into the pipeline and plays the pipeline's audio replies back to the speaker sinks, flushing them on barge\-in. It blocks until ctx is canceled or the session ends \(a source closes or the response stream finishes\), then tears the session down. A context\-cancel shutdown returns nil.
+
+Start owns the response stream — do not also read Response\(\) while it runs. Requires a session bound via OpenVoice / WithAudioSession.
 
 <a name="Conversation.Stream"></a>
 ### func \(\*Conversation\) Stream
@@ -2841,6 +2876,17 @@ conv, err := sdk.Open(ctx, pack,
     }),
 )
 ```
+
+<a name="WithAudioSession"></a>
+### func WithAudioSession
+
+```go
+func WithAudioSession(sess audio.Session) Option
+```
+
+WithAudioSession binds a duplex voice conversation to an audio.Session — the caller's microphone source\(s\) and speaker sink\(s\). The SDK runs the capture→pipeline→playback pump in Conversation.Start, so applications get voice I/O without touching hardware from the pipeline.
+
+The device implementation stays outside the pure\-Go SDK \(e.g. the PortAudio helper in sdk/examples/audiohelper, or audio.MemSource/MemSink for tests\), so the SDK itself never links a sound\-card binding. Use with OpenVoice, or with OpenDuplex when you drive Start yourself.
 
 <a name="WithAutoResize"></a>
 ### func WithAutoResize

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -358,6 +358,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func WithVariableProvider\(p variables.Provider\) Option](<#WithVariableProvider>)
   - [func WithVariables\(vars map\[string\]string\) Option](<#WithVariables>)
   - [func WithVertex\(region, project, providerType, model string, opts ...PlatformOption\) Option](<#WithVertex>)
+  - [func WithVoiceObserver\(fn func\(providers.StreamChunk\)\) Option](<#WithVoiceObserver>)
 - [type PackError](<#PackError>)
   - [func \(e \*PackError\) Error\(\) string](<#PackError.Error>)
   - [func \(e \*PackError\) Unwrap\(\) error](<#PackError.Unwrap>)
@@ -4388,6 +4389,24 @@ WithVertex configures Google Cloud Vertex AI as the hosting platform. The provid
 conv, _ := sdk.Open("./chat.pack.json", "assistant",
     sdk.WithVertex("us-central1", "my-project", "gemini", "gemini-2.0-flash"),
 )
+```
+
+<a name="WithVoiceObserver"></a>
+### func WithVoiceObserver
+
+```go
+func WithVoiceObserver(fn func(providers.StreamChunk)) Option
+```
+
+WithVoiceObserver registers a callback invoked with every response chunk during Conversation.Start — text deltas, input\-transcription metadata, tool events, and audio chunks alike — so an application can display or log the conversation while Start manages microphone and speaker.
+
+The callback runs on Start's output\-pump goroutine; keep it quick and do not call back into the conversation from it.
+
+```
+sdk.WithVoiceObserver(func(c providers.StreamChunk) {
+    if c.Delta != "" { fmt.Print(c.Delta) }
+    if t, ok := c.Metadata["input_transcription"].(string); ok { fmt.Println("you:", t) }
+})
 ```
 
 <a name="PackError"></a>

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -202,6 +202,12 @@ type config struct {
 	// the capture→pipeline→playback pump in Conversation.Start.
 	audioSession audio.Session
 
+	// voiceObserver, if set, is called with every response chunk during
+	// Conversation.Start — text deltas, transcription metadata, tool events —
+	// so an app can display the conversation while Start manages the audio.
+	// See WithVoiceObserver.
+	voiceObserver func(providers.StreamChunk)
+
 	// Image preprocessing configuration
 	// When set, images are preprocessed (resized, optimized) before sending to provider
 	imagePreprocessConfig *stage.ImagePreprocessConfig

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -197,6 +197,11 @@ type config struct {
 	// vadModeConfig. See IngestionFunc / WithIngestion.
 	ingestion IngestionFunc
 
+	// Audio session bound to the duplex pipeline by OpenVoice / WithAudioSession.
+	// The caller supplies the device (or in-memory) implementation; the SDK runs
+	// the capture→pipeline→playback pump in Conversation.Start.
+	audioSession audio.Session
+
 	// Image preprocessing configuration
 	// When set, images are preprocessed (resized, optimized) before sending to provider
 	imagePreprocessConfig *stage.ImagePreprocessConfig

--- a/sdk/voice.go
+++ b/sdk/voice.go
@@ -1,0 +1,225 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// WithAudioSession binds a duplex voice conversation to an audio.Session — the
+// caller's microphone source(s) and speaker sink(s). The SDK runs the
+// capture→pipeline→playback pump in Conversation.Start, so applications get
+// voice I/O without touching hardware from the pipeline.
+//
+// The device implementation stays outside the pure-Go SDK (e.g. the PortAudio
+// helper in sdk/examples/audiohelper, or audio.MemSource/MemSink for tests), so
+// the SDK itself never links a sound-card binding. Use with OpenVoice, or with
+// OpenDuplex when you drive Start yourself.
+func WithAudioSession(sess audio.Session) Option {
+	return func(c *config) error {
+		c.audioSession = sess
+		return nil
+	}
+}
+
+// OpenVoice opens a duplex voice conversation bound to an audio.Session and
+// returns it ready for Conversation.Start, which pumps the microphone into the
+// pipeline and plays replies back to the speaker.
+//
+// It is OpenDuplex plus a required WithAudioSession — the same provider / VAD /
+// ingestion options apply (WithProvider + WithVADMode for STT→LLM→TTS, or a
+// streaming provider for ASM). For manual chunk I/O without a bound session, use
+// OpenDuplex directly.
+//
+//	sess, _ := audiohelper.NewSession(audiohelper.WithCaptureRate(16000))
+//	conv, _ := sdk.OpenVoice("./assistant.pack.json", "assist",
+//	    sdk.WithProvider(llm),
+//	    sdk.WithVADMode(stt, tts, nil),
+//	    sdk.WithAudioSession(sess),
+//	)
+//	_ = conv.Start(ctx) // blocks: mic → LLM → speaker, until ctx is canceled
+func OpenVoice(packPath, promptName string, opts ...Option) (*Conversation, error) {
+	conv, err := OpenDuplex(packPath, promptName, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if conv.config.audioSession == nil {
+		_ = conv.Close()
+		return nil, fmt.Errorf(
+			"OpenVoice requires WithAudioSession; pass an audio.Session " +
+				"(e.g. audiohelper.NewSession) or use OpenDuplex for manual chunk I/O")
+	}
+	return conv, nil
+}
+
+// audioChunkSender is the slice of Conversation the input pump needs; narrow so
+// the pump is unit-testable without a full conversation.
+type audioChunkSender interface {
+	SendChunk(ctx context.Context, chunk *providers.StreamChunk) error
+}
+
+// Start runs the bound audio session: it feeds every microphone source into the
+// pipeline and plays the pipeline's audio replies back to the speaker sinks,
+// flushing them on barge-in. It blocks until ctx is canceled or the session
+// ends (a source closes or the response stream finishes), then tears the session
+// down. A context-cancel shutdown returns nil.
+//
+// Start owns the response stream — do not also read Response() while it runs.
+// Requires a session bound via OpenVoice / WithAudioSession.
+func (c *Conversation) Start(ctx context.Context) error {
+	c.mu.RLock()
+	if err := c.requireDuplex("Start()"); err != nil {
+		c.mu.RUnlock()
+		return err
+	}
+	sess := c.config.audioSession
+	c.mu.RUnlock()
+
+	if sess == nil {
+		return fmt.Errorf("Start() requires an audio session; open with OpenVoice / WithAudioSession")
+	}
+
+	respCh, err := c.Response()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1) // only the first error is surfaced
+	// Any component finishing (mic closed, response stream ended, session
+	// stopped, or ctx canceled) ends the whole session; cancel unwinds the rest.
+	launch := func(fn func() error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer cancel()
+			trySendErr(errCh, fn())
+		}()
+	}
+
+	launch(func() error { return sess.Start(ctx) })
+	for _, src := range audioSources(sess.Sources()) {
+		launch(func() error { return pumpAudioInput(ctx, src, c) })
+	}
+	launch(func() error { return pumpAudioOutput(ctx, respCh, audioSinks(sess.Sinks())) })
+
+	wg.Wait()
+	_ = sess.Close()
+
+	select {
+	case err = <-errCh:
+	default:
+	}
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
+}
+
+// trySendErr does a non-blocking send of a non-nil error onto ch.
+func trySendErr(ch chan error, err error) {
+	if err == nil {
+		return
+	}
+	select {
+	case ch <- err:
+	default:
+	}
+}
+
+// pumpAudioInput reads captured frames from a microphone source and feeds them
+// into the pipeline as PCM audio chunks, until the source closes or ctx ends.
+func pumpAudioInput(ctx context.Context, src audio.Source, sender audioChunkSender) error {
+	frames := src.Frames()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case f, ok := <-frames:
+			if !ok {
+				return nil
+			}
+			chunk := &providers.StreamChunk{
+				MediaData: &providers.StreamMediaData{
+					MIMEType:   "audio/pcm",
+					Data:       f.Data,
+					SampleRate: f.Format.SampleRate,
+					Channels:   f.Format.Channels,
+				},
+			}
+			if err := sender.SendChunk(ctx, chunk); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// pumpAudioOutput plays the pipeline's audio replies to the sinks, flushing them
+// when a chunk reports a barge-in interruption so the caller stops hearing a
+// reply they talked over. Runs until the response stream closes or ctx ends.
+func pumpAudioOutput(ctx context.Context, resp <-chan providers.StreamChunk, sinks []audio.Sink) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case chunk, ok := <-resp:
+			if !ok {
+				return nil
+			}
+			playChunkToSinks(&chunk, sinks)
+		}
+	}
+}
+
+// playChunkToSinks writes a response chunk's audio to the sinks, first flushing
+// them if the chunk reports a barge-in interruption.
+func playChunkToSinks(chunk *providers.StreamChunk, sinks []audio.Sink) {
+	if chunk.Interrupted {
+		for _, s := range sinks {
+			s.Flush()
+		}
+	}
+	if chunk.MediaData == nil || len(chunk.MediaData.Data) == 0 {
+		return
+	}
+	frame := audio.MediaFrame{
+		Kind: audio.KindAudio,
+		Data: chunk.MediaData.Data,
+		Format: audio.Format{
+			SampleRate: chunk.MediaData.SampleRate,
+			Channels:   chunk.MediaData.Channels,
+		},
+	}
+	for _, s := range sinks {
+		s.Write(frame)
+	}
+}
+
+// audioSources returns only the audio-kind sources from a session's source set.
+func audioSources(all []audio.Source) []audio.Source {
+	out := make([]audio.Source, 0, len(all))
+	for _, s := range all {
+		if s.Kind() == audio.KindAudio {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// audioSinks returns only the audio-kind sinks from a session's sink set.
+func audioSinks(all []audio.Sink) []audio.Sink {
+	out := make([]audio.Sink, 0, len(all))
+	for _, s := range all {
+		if s.Kind() == audio.KindAudio {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/sdk/voice.go
+++ b/sdk/voice.go
@@ -56,6 +56,25 @@ func OpenVoice(packPath, promptName string, opts ...Option) (*Conversation, erro
 	return conv, nil
 }
 
+// WithVoiceObserver registers a callback invoked with every response chunk
+// during Conversation.Start — text deltas, input-transcription metadata, tool
+// events, and audio chunks alike — so an application can display or log the
+// conversation while Start manages microphone and speaker.
+//
+// The callback runs on Start's output-pump goroutine; keep it quick and do not
+// call back into the conversation from it.
+//
+//	sdk.WithVoiceObserver(func(c providers.StreamChunk) {
+//	    if c.Delta != "" { fmt.Print(c.Delta) }
+//	    if t, ok := c.Metadata["input_transcription"].(string); ok { fmt.Println("you:", t) }
+//	})
+func WithVoiceObserver(fn func(providers.StreamChunk)) Option {
+	return func(c *config) error {
+		c.voiceObserver = fn
+		return nil
+	}
+}
+
 // audioChunkSender is the slice of Conversation the input pump needs; narrow so
 // the pump is unit-testable without a full conversation.
 type audioChunkSender interface {
@@ -108,7 +127,7 @@ func (c *Conversation) Start(ctx context.Context) error {
 	for _, src := range audioSources(sess.Sources()) {
 		launch(func() error { return pumpAudioInput(ctx, src, c) })
 	}
-	launch(func() error { return pumpAudioOutput(ctx, respCh, audioSinks(sess.Sinks())) })
+	launch(func() error { return pumpAudioOutput(ctx, respCh, audioSinks(sess.Sinks()), c.config.voiceObserver) })
 
 	wg.Wait()
 	_ = sess.Close()
@@ -163,8 +182,15 @@ func pumpAudioInput(ctx context.Context, src audio.Source, sender audioChunkSend
 
 // pumpAudioOutput plays the pipeline's audio replies to the sinks, flushing them
 // when a chunk reports a barge-in interruption so the caller stops hearing a
-// reply they talked over. Runs until the response stream closes or ctx ends.
-func pumpAudioOutput(ctx context.Context, resp <-chan providers.StreamChunk, sinks []audio.Sink) error {
+// reply they talked over. Every chunk is also handed to observe (when non-nil)
+// so the app can display text/transcription while Start manages the speaker.
+// Runs until the response stream closes or ctx ends.
+func pumpAudioOutput(
+	ctx context.Context,
+	resp <-chan providers.StreamChunk,
+	sinks []audio.Sink,
+	observe func(providers.StreamChunk),
+) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -172,6 +198,9 @@ func pumpAudioOutput(ctx context.Context, resp <-chan providers.StreamChunk, sin
 		case chunk, ok := <-resp:
 			if !ok {
 				return nil
+			}
+			if observe != nil {
+				observe(chunk)
 			}
 			playChunkToSinks(&chunk, sinks)
 		}

--- a/sdk/voice_test.go
+++ b/sdk/voice_test.go
@@ -74,7 +74,7 @@ func TestPumpAudioOutput_WritesAudioToSink(t *testing.T) {
 	ch <- providers.StreamChunk{MediaData: &providers.StreamMediaData{MIMEType: "audio/pcm", Data: []byte{7, 8}, SampleRate: 24000, Channels: 1}}
 	close(ch)
 
-	require.NoError(t, pumpAudioOutput(context.Background(), ch, []audio.Sink{sink}))
+	require.NoError(t, pumpAudioOutput(context.Background(), ch, []audio.Sink{sink}, nil))
 
 	written := sink.Written()
 	require.Len(t, written, 2)
@@ -92,8 +92,34 @@ func TestPumpAudioOutput_FlushesOnBargeIn(t *testing.T) {
 	ch <- providers.StreamChunk{Interrupted: true}
 	close(ch)
 
-	require.NoError(t, pumpAudioOutput(context.Background(), ch, []audio.Sink{sink}))
+	require.NoError(t, pumpAudioOutput(context.Background(), ch, []audio.Sink{sink}, nil))
 	assert.Empty(t, sink.Written(), "queued audio must be flushed on barge-in")
+}
+
+// TestPumpAudioOutput_InvokesObserverPerChunk: when a voice observer is set, it
+// sees every response chunk (text, transcription, audio) so the app can display
+// what's happening while Start manages the speaker.
+func TestPumpAudioOutput_InvokesObserverPerChunk(t *testing.T) {
+	sink := audio.NewMemSink(audio.KindAudio)
+	ch := make(chan providers.StreamChunk, 4)
+	ch <- providers.StreamChunk{Delta: "Hello"}                                                                // text only
+	ch <- providers.StreamChunk{MediaData: &providers.StreamMediaData{MIMEType: "audio/pcm", Data: []byte{9}}} // audio only
+	close(ch)
+
+	var seen []providers.StreamChunk
+	require.NoError(t, pumpAudioOutput(context.Background(), ch, []audio.Sink{sink},
+		func(c providers.StreamChunk) { seen = append(seen, c) }))
+
+	require.Len(t, seen, 2, "observer must see every chunk")
+	assert.Equal(t, "Hello", seen[0].Delta)
+	require.Len(t, sink.Written(), 1, "audio still reaches the sink")
+}
+
+// TestWithVoiceObserver_SetsConfig: the option installs the observer.
+func TestWithVoiceObserver_SetsConfig(t *testing.T) {
+	c := &config{}
+	require.NoError(t, WithVoiceObserver(func(providers.StreamChunk) {})(c))
+	assert.NotNil(t, c.voiceObserver)
 }
 
 // TestOpenVoice_RequiresAudioSession: OpenVoice without a session is a

--- a/sdk/voice_test.go
+++ b/sdk/voice_test.go
@@ -1,0 +1,143 @@
+package sdk
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingSender captures the chunks pushed into the pipeline by the input pump.
+type recordingSender struct {
+	chunks []*providers.StreamChunk
+}
+
+func (r *recordingSender) SendChunk(_ context.Context, c *providers.StreamChunk) error {
+	r.chunks = append(r.chunks, c)
+	return nil
+}
+
+// fakeAudioSession is a hardware-free audio.Session over in-memory sources/sinks.
+type fakeAudioSession struct {
+	sources []audio.Source
+	sinks   []audio.Sink
+	started atomic.Bool
+}
+
+func (s *fakeAudioSession) Start(ctx context.Context) error {
+	s.started.Store(true)
+	<-ctx.Done() // mimic a device that runs until the session ends
+	return ctx.Err()
+}
+func (s *fakeAudioSession) Sources() []audio.Source { return s.sources }
+func (s *fakeAudioSession) Sinks() []audio.Sink     { return s.sinks }
+func (s *fakeAudioSession) Close() error            { return nil }
+
+// TestPumpAudioInput_ForwardsFramesAsChunks: microphone frames become PCM audio
+// chunks fed to the pipeline, carrying their format.
+func TestPumpAudioInput_ForwardsFramesAsChunks(t *testing.T) {
+	src := audio.NewMemSource(audio.KindAudio, 4)
+	src.Push(audio.MediaFrame{Kind: audio.KindAudio, Data: []byte{1, 2}, Format: audio.Format{SampleRate: 16000, Channels: 1}})
+	src.Push(audio.MediaFrame{Kind: audio.KindAudio, Data: []byte{3, 4}, Format: audio.Format{SampleRate: 16000, Channels: 1}})
+	require.NoError(t, src.Close())
+
+	sender := &recordingSender{}
+	require.NoError(t, pumpAudioInput(context.Background(), src, sender))
+
+	require.Len(t, sender.chunks, 2)
+	assert.Equal(t, []byte{1, 2}, sender.chunks[0].MediaData.Data)
+	assert.Equal(t, "audio/pcm", sender.chunks[0].MediaData.MIMEType)
+	assert.Equal(t, 16000, sender.chunks[0].MediaData.SampleRate)
+	assert.Equal(t, 1, sender.chunks[0].MediaData.Channels)
+}
+
+// TestPumpAudioInput_StopsOnContextCancel: a cancelled context ends the pump even
+// when the source is still open (no frames), so Start can unwind.
+func TestPumpAudioInput_StopsOnContextCancel(t *testing.T) {
+	src := audio.NewMemSource(audio.KindAudio, 1) // open, no frames
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.ErrorIs(t, pumpAudioInput(ctx, src, &recordingSender{}), context.Canceled)
+}
+
+// TestPumpAudioOutput_WritesAudioToSink: the pipeline's audio responses are
+// played to the speaker sink with their format.
+func TestPumpAudioOutput_WritesAudioToSink(t *testing.T) {
+	sink := audio.NewMemSink(audio.KindAudio)
+	ch := make(chan providers.StreamChunk, 4)
+	ch <- providers.StreamChunk{MediaData: &providers.StreamMediaData{MIMEType: "audio/pcm", Data: []byte{5, 6}, SampleRate: 24000, Channels: 1}}
+	ch <- providers.StreamChunk{MediaData: &providers.StreamMediaData{MIMEType: "audio/pcm", Data: []byte{7, 8}, SampleRate: 24000, Channels: 1}}
+	close(ch)
+
+	require.NoError(t, pumpAudioOutput(context.Background(), ch, []audio.Sink{sink}))
+
+	written := sink.Written()
+	require.Len(t, written, 2)
+	assert.Equal(t, []byte{5, 6}, written[0].Data)
+	assert.Equal(t, 24000, written[0].Format.SampleRate)
+	assert.Equal(t, audio.KindAudio, written[0].Kind)
+}
+
+// TestPumpAudioOutput_FlushesOnBargeIn: an interrupted chunk drops queued
+// playback, so the caller doesn't keep hearing a reply they talked over.
+func TestPumpAudioOutput_FlushesOnBargeIn(t *testing.T) {
+	sink := audio.NewMemSink(audio.KindAudio)
+	ch := make(chan providers.StreamChunk, 4)
+	ch <- providers.StreamChunk{MediaData: &providers.StreamMediaData{MIMEType: "audio/pcm", Data: []byte{1}}}
+	ch <- providers.StreamChunk{Interrupted: true}
+	close(ch)
+
+	require.NoError(t, pumpAudioOutput(context.Background(), ch, []audio.Sink{sink}))
+	assert.Empty(t, sink.Written(), "queued audio must be flushed on barge-in")
+}
+
+// TestOpenVoice_RequiresAudioSession: OpenVoice without a session is a
+// configuration error pointing at WithAudioSession.
+func TestOpenVoice_RequiresAudioSession(t *testing.T) {
+	_, err := OpenVoice(writeIngestionTestPack(t), "main",
+		WithProvider(&recordingTextProvider{}),
+		WithSkipSchemaValidation(),
+		WithVADMode(&convMockSTTService{}, newConvMockTTSService(), nil),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WithAudioSession")
+}
+
+// TestOpenVoice_StartPumpsSessionUntilCancel: with a bound session, OpenVoice
+// returns a conversation whose Start runs the session and unwinds cleanly on
+// context cancel — the end-to-end orchestration, hardware-free.
+func TestOpenVoice_StartPumpsSessionUntilCancel(t *testing.T) {
+	sess := &fakeAudioSession{
+		sources: []audio.Source{audio.NewMemSource(audio.KindAudio, 1)},
+		sinks:   []audio.Sink{audio.NewMemSink(audio.KindAudio)},
+	}
+	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
+		WithProvider(&recordingTextProvider{}),
+		WithSkipSchemaValidation(),
+		WithVADMode(&convMockSTTService{}, newConvMockTTSService(), nil),
+		WithAudioSession(sess),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- conv.Start(ctx) }()
+
+	// Give Start a beat to bring the session up, then stop it.
+	assert.Eventually(t, func() bool { return sess.started.Load() }, time.Second, 5*time.Millisecond,
+		"Start must bring the audio session up")
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "a context-cancel shutdown is clean, not an error")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after context cancel")
+	}
+}


### PR DESCRIPTION
## Summary

A first-class SDK voice entry that binds the duplex pipeline to an `audio.Session` (mic sources + speaker sinks), so apps get voice I/O without hand-rolling the capture→pipeline→playback pump that `sdk/examples/openai-realtime/main_interactive.go` reproduces today.

```go
sess, _ := audiohelper.NewSession(audiohelper.WithCaptureRate(16000))
conv, _ := sdk.OpenVoice("./assistant.pack.json", "assist",
    sdk.WithProvider(llm),
    sdk.WithVADMode(stt, tts, nil),   // or a streaming provider for ASM
    sdk.WithAudioSession(sess),
)
_ = conv.Start(ctx)                    // mic → LLM → speaker, blocks until ctx canceled
```

## What's here

- **`WithAudioSession(audio.Session)`** — binds a session. **`OpenVoice`** = `OpenDuplex` + that requirement, so the same provider/VAD/ingestion options apply.
- **`Conversation.Start(ctx)`** — feeds every microphone source into the pipeline as PCM chunks, plays the pipeline's audio replies to the speaker sinks, and **flushes them on barge-in** (`StreamChunk.Interrupted`). Blocks until ctx is canceled or the session ends (a source closes / the response stream finishes), then tears down; a context-cancel shutdown returns nil.

## Architecture — SDK stays device-free

The device implementation stays **out** of the pure-Go SDK. The caller passes an `audio.Session` — the PortAudio helper in `sdk/examples/audiohelper` for hardware, or `audio.MemSource`/`MemSink` for tests. The SDK depends only on the purego-free `audio.Session` interface in `runtime/audio`, so **`scripts/check-no-audio-device-leak.sh` still passes** (verified — `sdk` remains statically linkable).

## Verification (TDD, hardware-free)

`MemSource`/`MemSink` fakes: input frames become PCM chunks carrying their format; context-cancel stops the pump; audio replies reach the sink; barge-in flushes queued playback; `OpenVoice` requires a session; and `Start` brings a fake session up and unwinds cleanly on cancel. `-race` clean; lint clean; SDK reference regenerated.

## Scope

Closes #1508. Two items are deliberate follow-ups: the `main_interactive.go` example rewrite (**#1662** — needs real hardware to validate, can't ride CI) and Speex **AEC**, which lives in the PromptArena audio tooling, not this repo.
