### PR TITLE
fix(sdk): OpenVoice Start must not tear down when the device Start returns

### DIFF
--- a/sdk/voice.go
+++ b/sdk/voice.go
@@ -112,8 +112,9 @@ func (c *Conversation) Start(ctx context.Context) error {
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 1) // only the first error is surfaced
-	// Any component finishing (mic closed, response stream ended, session
-	// stopped, or ctx canceled) ends the whole session; cancel unwinds the rest.
+
+	// A pump finishing (mic source closed, response stream ended) ends the whole
+	// session; cancel unwinds the rest.
 	launch := func(fn func() error) {
 		wg.Add(1)
 		go func() {
@@ -123,7 +124,19 @@ func (c *Conversation) Start(ctx context.Context) error {
 		}()
 	}
 
-	launch(func() error { return sess.Start(ctx) })
+	// Starting the device is NOT a pump: many sessions (e.g. the PortAudio
+	// helper) launch capture/playback in the background and return from Start
+	// immediately. A nil return means "running", not "session over", so it must
+	// not cancel the pumps — only a real start error tears the session down.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if e := sess.Start(ctx); e != nil && !errors.Is(e, context.Canceled) {
+			trySendErr(errCh, e)
+			cancel()
+		}
+	}()
+
 	for _, src := range audioSources(sess.Sources()) {
 		launch(func() error { return pumpAudioInput(ctx, src, c) })
 	}

--- a/sdk/voice_test.go
+++ b/sdk/voice_test.go
@@ -23,16 +23,20 @@ func (r *recordingSender) SendChunk(_ context.Context, c *providers.StreamChunk)
 }
 
 // fakeAudioSession is a hardware-free audio.Session over in-memory sources/sinks.
+// Its Start RETURNS IMMEDIATELY after "starting", exactly as a real device
+// session does (the PortAudio helper opens its streams, launches capture and
+// playback goroutines, and returns) — rather than blocking until ctx. Modeling
+// that is what catches a Start that mistakes the device-start returning for the
+// session ending.
 type fakeAudioSession struct {
 	sources []audio.Source
 	sinks   []audio.Sink
 	started atomic.Bool
 }
 
-func (s *fakeAudioSession) Start(ctx context.Context) error {
+func (s *fakeAudioSession) Start(_ context.Context) error {
 	s.started.Store(true)
-	<-ctx.Done() // mimic a device that runs until the session ends
-	return ctx.Err()
+	return nil // device now running in the background; Start does not block
 }
 func (s *fakeAudioSession) Sources() []audio.Source { return s.sources }
 func (s *fakeAudioSession) Sinks() []audio.Sink     { return s.sinks }
@@ -134,12 +138,15 @@ func TestOpenVoice_RequiresAudioSession(t *testing.T) {
 	assert.Contains(t, err.Error(), "WithAudioSession")
 }
 
-// TestOpenVoice_StartPumpsSessionUntilCancel: with a bound session, OpenVoice
-// returns a conversation whose Start runs the session and unwinds cleanly on
-// context cancel — the end-to-end orchestration, hardware-free.
-func TestOpenVoice_StartPumpsSessionUntilCancel(t *testing.T) {
+// TestOpenVoice_StartStaysAliveUntilCancel is the regression test for the
+// device-start lifecycle bug: a real session's Start returns as soon as the
+// device is running, and Start must keep pumping until ctx is canceled — not
+// tear the session down the instant Start returns. Against the old code (which
+// treated the device-start returning as the session ending) Start returned
+// almost immediately; here it must stay alive until we cancel.
+func TestOpenVoice_StartStaysAliveUntilCancel(t *testing.T) {
 	sess := &fakeAudioSession{
-		sources: []audio.Source{audio.NewMemSource(audio.KindAudio, 1)},
+		sources: []audio.Source{audio.NewMemSource(audio.KindAudio, 1)}, // open, no frames
 		sinks:   []audio.Sink{audio.NewMemSink(audio.KindAudio)},
 	}
 	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
@@ -155,15 +162,64 @@ func TestOpenVoice_StartPumpsSessionUntilCancel(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- conv.Start(ctx) }()
 
-	// Give Start a beat to bring the session up, then stop it.
-	assert.Eventually(t, func() bool { return sess.started.Load() }, time.Second, 5*time.Millisecond,
+	require.Eventually(t, func() bool { return sess.started.Load() }, time.Second, 5*time.Millisecond,
 		"Start must bring the audio session up")
-	cancel()
 
+	// The device has started (started==true) and Start returned nil from the
+	// session — Start must NOT have torn down. Prove it is still running.
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned before cancel (%v) — device-start return was mistaken for session end", err)
+	case <-time.After(300 * time.Millisecond):
+		// still running, as required
+	}
+
+	cancel()
 	select {
 	case err := <-done:
 		assert.NoError(t, err, "a context-cancel shutdown is clean, not an error")
 	case <-time.After(3 * time.Second):
 		t.Fatal("Start did not return after context cancel")
 	}
+}
+
+// TestOpenVoice_StartPumpsMicFramesWhileAlive proves the input pump actually runs
+// while the session is alive: with a size-1 source buffer, a first frame is
+// consumed by the pump (emptying the buffer) so a second Push does not block.
+// If Start had torn down, nothing would drain the buffer and the second Push
+// would time out.
+func TestOpenVoice_StartPumpsMicFramesWhileAlive(t *testing.T) {
+	src := audio.NewMemSource(audio.KindAudio, 1)
+	sess := &fakeAudioSession{
+		sources: []audio.Source{src},
+		sinks:   []audio.Sink{audio.NewMemSink(audio.KindAudio)},
+	}
+	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
+		WithProvider(&recordingTextProvider{}),
+		WithSkipSchemaValidation(),
+		WithVADMode(&convMockSTTService{}, newConvMockTTSService(), nil),
+		WithAudioSession(sess),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conv.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- conv.Start(ctx) }()
+
+	frame := audio.MediaFrame{Kind: audio.KindAudio, Data: []byte{1, 2}, Format: audio.Format{SampleRate: 16000, Channels: 1}}
+	src.Push(frame) // fills the size-1 buffer
+
+	pushed := make(chan struct{})
+	go func() { src.Push(frame); close(pushed) }() // blocks until the pump drains the first
+	select {
+	case <-pushed:
+		// pump consumed the first frame — the input pump is running
+	case <-time.After(2 * time.Second):
+		t.Fatal("input pump did not drain the source — Start is not pumping while alive")
+	}
+
+	cancel()
+	<-done
 }


### PR DESCRIPTION
## Summary

`Conversation.Start` (OpenVoice, #1508) tore the voice session down within ~half a second against a **real** audio session, before any audio could flow. Found by running the `openai-realtime` example: it reached "Listening…" and closed instantly.

## Root cause

`Start` launched the `audio.Session`'s `Start` alongside the input/output pumps and treated **any** of them returning as "session over" (`defer cancel()`). But a real device session — the PortAudio helper — opens its streams, launches capture/playback goroutines, and **returns immediately** (`audiohelper` `portaudioIO.Start` returns nil after starting). `Conversation.Start` read that nil return as end-of-session and cancelled everything.

The test fake hid it: its `Start` **blocked** until ctx (faithful to the `audio.Session` contract, "runs until ctx is canceled"), so the teardown path never triggered under test while it fired immediately against real hardware.

## Fix

Run the device start separately from the pumps: a start **error** is fatal, but a **nil** return means "running", not "session over", so it no longer cancels. The session's lifetime is governed by the input/output pumps and ctx, as intended.

With the fix, the example holds in Listening, the OpenAI Realtime WebSocket connects, the session is created (`model=gpt-realtime`), and it stays live until Ctrl+C.

## Tests

- The fake session's `Start` now **returns immediately**, like real hardware.
- `TestOpenVoice_StartStaysAliveUntilCancel` asserts `Start` keeps running after the device-start returns, until ctx is canceled — **fails against the old code** (verified by reverting the fix).
- `TestOpenVoice_StartPumpsMicFramesWhileAlive` proves the input pump actually drains the mic source while the session is alive.
- `-race` clean; full `sdk` suite green.

Follows up #1508 / #1663. The mock-vs-hardware gap here is why the example (#1662) can't be fully CI-validated — this closes the biggest part of that gap with a realistic fake.
