### PR TITLE
fix(voice): make the OpenAI Realtime voice example usable end to end

### DIFF
--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -412,6 +412,7 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func \(s \*TokenBudgetStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#TokenBudgetStage.Process>)
 - [type TranscriptReorderStage](<#TranscriptReorderStage>)
   - [func NewTranscriptReorderStage\(placeholder string\) \*TranscriptReorderStage](<#NewTranscriptReorderStage>)
+  - [func NewTranscriptReorderStageWithTimeout\(placeholder string, holdTimeout time.Duration\) \*TranscriptReorderStage](<#NewTranscriptReorderStageWithTimeout>)
   - [func \(s \*TranscriptReorderStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#TranscriptReorderStage.Process>)
 - [type Transcription](<#Transcription>)
 - [type TruncationStrategy](<#TruncationStrategy>)
@@ -5338,11 +5339,11 @@ Process reads all messages, enforces the token budget, and forwards the \(possib
 <a name="TranscriptReorderStage"></a>
 ## type TranscriptReorderStage
 
-TranscriptReorderStage guarantees that, within a turn, the user's input transcript is emitted before that turn's assistant text — even when the provider delivers the transcript late \(e.g. OpenAI Realtime, whose Whisper transcription lands after the assistant response has already started\).
+TranscriptReorderStage guarantees that, within a turn, the user's input transcript is emitted before that turn's assistant text — even when the provider delivers the transcript late \(e.g. OpenAI Realtime, whose Whisper transcription can land after the assistant reply, or even after the whole turn, has finished\).
 
-It buffers assistant TEXT elements until the user turn element for that turn appears, then flushes them in order and streams the rest live. AUDIO elements pass through immediately, so playback stays realtime — only the transcript log is reordered. If a turn ends with no transcript, a configurable placeholder user turn is emitted so the reply is never shown with no prompt.
+It buffers assistant TEXT elements and HOLDS the turn\-end until the user turn for that turn arrives \(or a short timeout elapses\), then emits user\-then\-text in order. AUDIO passes through immediately, so playback stays realtime — only the transcript log is reordered. Crucially the turn\-end \(EndOfStream\) is held too, so a late transcript is never emitted after the turn boundary \(which both mis\-orders the log and can confuse downstream turn\-scoped stages\). If the transcript never arrives, a configurable placeholder user turn is emitted.
 
-The mechanism is provider\-agnostic; whether it is wired is decided upstream \(providers that emit the transcript first don't need it\). It is a Transform stage: state is per\-turn and reset on each turn boundary, so a single instance handles one continuous duplex conversation.
+The mechanism is provider\-agnostic; whether it is wired is decided upstream. It is a Transform stage: state is per\-turn and reset on each turn boundary, so a single instance handles one continuous duplex conversation.
 
 ```go
 type TranscriptReorderStage struct {
@@ -5358,7 +5359,16 @@ type TranscriptReorderStage struct {
 func NewTranscriptReorderStage(placeholder string) *TranscriptReorderStage
 ```
 
-NewTranscriptReorderStage creates a reorder stage with the given missing\-turn placeholder text \(empty to omit the user turn when a transcript never arrives\).
+NewTranscriptReorderStage creates a reorder stage with the given missing\-turn placeholder text \(empty to omit the user turn\) and the default hold timeout.
+
+<a name="NewTranscriptReorderStageWithTimeout"></a>
+### func NewTranscriptReorderStageWithTimeout
+
+```go
+func NewTranscriptReorderStageWithTimeout(placeholder string, holdTimeout time.Duration) *TranscriptReorderStage
+```
+
+NewTranscriptReorderStageWithTimeout is like NewTranscriptReorderStage but with an explicit hold timeout \(tests use a short value\).
 
 <a name="TranscriptReorderStage.Process"></a>
 ### func \(\*TranscriptReorderStage\) Process

--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -410,6 +410,9 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func NewTokenBudgetStage\(config \*TokenBudgetConfig\) \*TokenBudgetStage](<#NewTokenBudgetStage>)
   - [func NewTokenBudgetStageWithTurnState\(config \*TokenBudgetConfig, turnState \*TurnState\) \*TokenBudgetStage](<#NewTokenBudgetStageWithTurnState>)
   - [func \(s \*TokenBudgetStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#TokenBudgetStage.Process>)
+- [type TranscriptReorderStage](<#TranscriptReorderStage>)
+  - [func NewTranscriptReorderStage\(placeholder string\) \*TranscriptReorderStage](<#NewTranscriptReorderStage>)
+  - [func \(s \*TranscriptReorderStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#TranscriptReorderStage.Process>)
 - [type Transcription](<#Transcription>)
 - [type TruncationStrategy](<#TruncationStrategy>)
 - [type TurnState](<#TurnState>)
@@ -5331,6 +5334,40 @@ func (s *TokenBudgetStage) Process(ctx context.Context, input <-chan StreamEleme
 ```
 
 Process reads all messages, enforces the token budget, and forwards the \(possibly truncated\) messages downstream.
+
+<a name="TranscriptReorderStage"></a>
+## type TranscriptReorderStage
+
+TranscriptReorderStage guarantees that, within a turn, the user's input transcript is emitted before that turn's assistant text — even when the provider delivers the transcript late \(e.g. OpenAI Realtime, whose Whisper transcription lands after the assistant response has already started\).
+
+It buffers assistant TEXT elements until the user turn element for that turn appears, then flushes them in order and streams the rest live. AUDIO elements pass through immediately, so playback stays realtime — only the transcript log is reordered. If a turn ends with no transcript, a configurable placeholder user turn is emitted so the reply is never shown with no prompt.
+
+The mechanism is provider\-agnostic; whether it is wired is decided upstream \(providers that emit the transcript first don't need it\). It is a Transform stage: state is per\-turn and reset on each turn boundary, so a single instance handles one continuous duplex conversation.
+
+```go
+type TranscriptReorderStage struct {
+    BaseStage
+    // contains filtered or unexported fields
+}
+```
+
+<a name="NewTranscriptReorderStage"></a>
+### func NewTranscriptReorderStage
+
+```go
+func NewTranscriptReorderStage(placeholder string) *TranscriptReorderStage
+```
+
+NewTranscriptReorderStage creates a reorder stage with the given missing\-turn placeholder text \(empty to omit the user turn when a transcript never arrives\).
+
+<a name="TranscriptReorderStage.Process"></a>
+### func \(\*TranscriptReorderStage\) Process
+
+```go
+func (s *TranscriptReorderStage) Process(ctx context.Context, input <-chan StreamElement, output chan<- StreamElement) error
+```
+
+Process implements the Stage interface.
 
 <a name="Transcription"></a>
 ## type Transcription

--- a/docs/src/content/docs/runtime/reference/providers.md
+++ b/docs/src/content/docs/runtime/reference/providers.md
@@ -168,6 +168,7 @@ This file contains exported test helpers that can be used by provider implementa
   - [func \(JSONArrayFrameDetector\) PeekFirstFrame\(r io.Reader\) \(\[\]byte, error\)](<#JSONArrayFrameDetector.PeekFirstFrame>)
 - [type JitterHealthReporter](<#JitterHealthReporter>)
   - [func \(r \*JitterHealthReporter\) Report\(m \*StreamMetrics, jb jitterHealthCounters, direction string\)](<#JitterHealthReporter.Report>)
+- [type LateInputTranscriber](<#LateInputTranscriber>)
 - [type MediaLoader](<#MediaLoader>)
   - [func NewMediaLoader\(config MediaLoaderConfig\) \*MediaLoader](<#NewMediaLoader>)
   - [func \(ml \*MediaLoader\) GetBase64Data\(ctx context.Context, media \*types.MediaContent\) \(string, error\)](<#MediaLoader.GetBase64Data>)
@@ -1904,6 +1905,21 @@ func (r *JitterHealthReporter) Report(m *StreamMetrics, jb jitterHealthCounters,
 ```
 
 Report emits the counter deltas since the last call to m \(nil\-safe\) for the given direction \("input"/"output"\). jb is the live jitter buffer. This is a DIRECT\-UPDATE path: it never publishes to the event bus \(see the off\-bus invariant on StreamMetrics / AltairaLabs/PromptKit\#853\).
+
+<a name="LateInputTranscriber"></a>
+## type LateInputTranscriber
+
+LateInputTranscriber is an optional interface a StreamInputSupport provider implements to declare that it delivers the user's input transcription AFTER the assistant response has already begun — e.g. OpenAI Realtime, whose Whisper transcription arrives asynchronously, after the model has started replying.
+
+When a provider reports true \(and input transcription is enabled\), the streaming pipeline reorders the transcript so each turn's user text precedes its assistant text. Providers that emit the transcript before the reply \(or not at all\) need not implement this — reordering stays off by default.
+
+```go
+type LateInputTranscriber interface {
+    // EmitsLateInputTranscription reports whether the user transcript can arrive
+    // after the assistant reply has started for the same turn.
+    EmitsLateInputTranscription() bool
+}
+```
 
 <a name="MediaLoader"></a>
 ## type MediaLoader

--- a/runtime/pipeline/stage/duplex_burst_test.go
+++ b/runtime/pipeline/stage/duplex_burst_test.go
@@ -24,7 +24,7 @@ func TestForwardResponseElements_LongAudioBurstAllForwarded(t *testing.T) {
 
 	// Producer: burst audio chunks, then a turn-complete FinishReason, then close.
 	go func() {
-		for i := 0; i < burst; i++ {
+		for i := range burst {
 			sess.respCh <- providers.StreamChunk{
 				MediaData: &providers.StreamMediaData{
 					Data: []byte{byte(i), byte(i >> 8)}, SampleRate: 24000, Channels: 1,
@@ -54,4 +54,42 @@ func TestForwardResponseElements_LongAudioBurstAllForwarded(t *testing.T) {
 	}
 	assert.Equal(t, burst, audioElems,
 		"every audio chunk of the reply must be forwarded; got %d of %d", audioElems, burst)
+}
+
+// TestForwardInputElements_DrainSignalEndsInputPromptly covers the drain fix: a
+// graceful Close sends an EndOfStream element marked AllResponsesReceived. The
+// input loop must end input and signal an immediate session close (so the
+// response loop skips its 30s final-response wait), rather than treating it as an
+// ordinary end-of-turn.
+func TestForwardInputElements_DrainSignalEndsInputPromptly(t *testing.T) {
+	sess := newRecordingSession()
+	s := stageWithSession(sess)
+
+	input := make(chan StreamElement, 1)
+	output := make(chan StreamElement, 1)
+	done := make(chan error, 1)
+
+	input <- StreamElement{EndOfStream: true, Meta: ElementMetadata{AllResponsesReceived: true}}
+
+	go s.forwardInputElements(context.Background(), input, output, done)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwardInputElements did not end on the drain signal")
+	}
+
+	// Both the input-done and skip-final-timeout channels must be closed, so the
+	// response loop closes the session immediately instead of waiting.
+	select {
+	case <-s.inputDoneCh:
+	default:
+		t.Error("inputDoneCh not closed on drain signal")
+	}
+	select {
+	case <-s.allResponsesReceivedCh:
+	default:
+		t.Error("allResponsesReceivedCh not closed on drain signal")
+	}
 }

--- a/runtime/pipeline/stage/duplex_burst_test.go
+++ b/runtime/pipeline/stage/duplex_burst_test.go
@@ -1,0 +1,57 @@
+package stage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForwardResponseElements_LongAudioBurstAllForwarded reproduces the reported
+// failure at its source: a long assistant reply is a burst of many audio chunks.
+// Every one must be forwarded to the pipeline output (streamed to the speaker) —
+// if the stage drops, stalls, or ends the turn early under the burst, fewer
+// audio elements arrive.
+func TestForwardResponseElements_LongAudioBurstAllForwarded(t *testing.T) {
+	const burst = 300
+
+	sess := newRecordingSession()
+	s := stageWithSession(sess)
+	out := make(chan StreamElement, burst*2)
+
+	// Producer: burst audio chunks, then a turn-complete FinishReason, then close.
+	go func() {
+		for i := 0; i < burst; i++ {
+			sess.respCh <- providers.StreamChunk{
+				MediaData: &providers.StreamMediaData{
+					Data: []byte{byte(i), byte(i >> 8)}, SampleRate: 24000, Channels: 1,
+				},
+			}
+		}
+		fr := "stop"
+		sess.respCh <- providers.StreamChunk{FinishReason: &fr}
+		close(sess.respCh)
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- s.forwardResponseElements(context.Background(), out) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("forwardResponseElements did not finish — stalled under the burst")
+	}
+
+	var audioElems int
+	for len(out) > 0 {
+		e := <-out
+		if e.Audio != nil && len(e.Audio.Samples) > 0 {
+			audioElems++
+		}
+	}
+	assert.Equal(t, burst, audioElems,
+		"every audio chunk of the reply must be forwarded; got %d of %d", audioElems, burst)
+}

--- a/runtime/pipeline/stage/duplex_burst_test.go
+++ b/runtime/pipeline/stage/duplex_burst_test.go
@@ -2,6 +2,7 @@ package stage
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -54,6 +55,101 @@ func TestForwardResponseElements_LongAudioBurstAllForwarded(t *testing.T) {
 	}
 	assert.Equal(t, burst, audioElems,
 		"every audio chunk of the reply must be forwarded; got %d of %d", audioElems, burst)
+}
+
+// TestForwardResponseElements_ResetsIdleOnActivity is the death fix: a
+// continuous voice session streams audio for many seconds, but the pipeline's
+// 30s idle timeout cancels it unless a stage signals activity. The duplex stage
+// must reset the idle timer as response chunks arrive — otherwise every live
+// conversation dies at exactly 30s (context canceled / ErrIdleTimeout).
+func TestForwardResponseElements_ResetsIdleOnActivity(t *testing.T) {
+	var resets atomic.Int64
+	ctx := contextWithIdleReset(context.Background(), func() { resets.Add(1) })
+
+	sess := newRecordingSession()
+	s := stageWithSession(sess)
+	out := make(chan StreamElement, 16)
+
+	go func() {
+		for range 5 {
+			sess.respCh <- providers.StreamChunk{MediaData: &providers.StreamMediaData{
+				Data: []byte{1, 2}, SampleRate: 24000, Channels: 1,
+			}}
+		}
+		close(sess.respCh)
+	}()
+
+	require.NoError(t, s.forwardResponseElements(ctx, out))
+	assert.Positive(t, resets.Load(),
+		"the duplex stage must reset the pipeline idle timer on response activity, or live sessions die at the 30s idle timeout")
+}
+
+// TestForwardInputElements_ResetsIdleOnActivity: inbound microphone audio must
+// also keep the pipeline alive.
+func TestForwardInputElements_ResetsIdleOnActivity(t *testing.T) {
+	var resets atomic.Int64
+	ctx := contextWithIdleReset(context.Background(), func() { resets.Add(1) })
+
+	sess := newRecordingSession()
+	s := stageWithSession(sess)
+	input := make(chan StreamElement, 4)
+	output := make(chan StreamElement, 4)
+	done := make(chan error, 1)
+
+	input <- duplexAudioElem(pcm(320))
+	input <- duplexAudioElem(pcm(320))
+	close(input)
+
+	go s.forwardInputElements(ctx, input, output, done)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwardInputElements did not finish")
+	}
+	assert.Positive(t, resets.Load(),
+		"the duplex stage must reset the pipeline idle timer on inbound audio activity")
+}
+
+// TestDuplexProviderStage_ActivityDefeatsIdleTimeout is the end-to-end proof of
+// the death fix, against the REAL idle-timeout mechanism (not a stub): with a
+// short idle timeout and a steady stream of response chunks arriving faster than
+// the timeout, the session must survive well past the timeout. Without the reset
+// the idle timer fires and cancels the context mid-stream (the ~30s death users
+// hit); with it, each chunk resets the timer and the session lives.
+func TestDuplexProviderStage_ActivityDefeatsIdleTimeout(t *testing.T) {
+	const (
+		idle     = 100 * time.Millisecond
+		interval = 30 * time.Millisecond // < idle: activity keeps resetting the timer
+		chunks   = 12                    // ~360ms total, 3.6x the idle timeout
+	)
+
+	idleCtx, cancel, reset := withIdleTimeout(context.Background(), idle)
+	defer cancel()
+	ctx := contextWithIdleReset(idleCtx, reset)
+
+	sess := newRecordingSession()
+	s := stageWithSession(sess)
+	out := make(chan StreamElement, chunks*2)
+
+	go func() {
+		for range chunks {
+			select {
+			case sess.respCh <- providers.StreamChunk{MediaData: &providers.StreamMediaData{
+				Data: []byte{1, 2}, SampleRate: 24000, Channels: 1,
+			}}:
+			case <-ctx.Done():
+				return
+			}
+			time.Sleep(interval)
+		}
+		close(sess.respCh)
+	}()
+
+	err := s.forwardResponseElements(ctx, out)
+	require.NoError(t, err,
+		"a live session must survive past the idle timeout while streaming; it died mid-reply")
+	require.NotErrorIs(t, context.Cause(ctx), ErrIdleTimeout,
+		"the idle timeout fired despite continuous activity")
 }
 
 // TestForwardInputElements_DrainSignalEndsInputPromptly covers the drain fix: a

--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -452,14 +452,16 @@ func (p *StreamPipeline) runStage(
 		}
 	}
 
-	// Report error
+	// Report error. In a continuous duplex session a stage returning at all ends
+	// the whole pipeline (stages are meant to run for the session's lifetime), so
+	// log the first stage to return at INFO — it names what tore the session down.
 	if err != nil {
-		logger.Debug("pipeline stage failed",
+		logger.Info("pipeline stage returned with error",
 			"stage", stage.Name(), "type", stage.Type(),
 			"duration", duration, "error", err)
 		errors <- NewStageError(stage.Name(), stage.Type(), err)
 	} else {
-		logger.Debug("pipeline stage completed",
+		logger.Info("pipeline stage returned",
 			"stage", stage.Name(), "type", stage.Type(),
 			"duration", duration)
 	}

--- a/runtime/pipeline/stage/pipeline.go
+++ b/runtime/pipeline/stage/pipeline.go
@@ -452,16 +452,16 @@ func (p *StreamPipeline) runStage(
 		}
 	}
 
-	// Report error. In a continuous duplex session a stage returning at all ends
-	// the whole pipeline (stages are meant to run for the session's lifetime), so
-	// log the first stage to return at INFO — it names what tore the session down.
+	// Report error. A stage returning with an error is abnormal (in a continuous
+	// duplex session a stage returning at all ends the whole pipeline), so surface
+	// it at INFO; a clean return stays at Debug to avoid noise on every unary Send.
 	if err != nil {
 		logger.Info("pipeline stage returned with error",
 			"stage", stage.Name(), "type", stage.Type(),
 			"duration", duration, "error", err)
 		errors <- NewStageError(stage.Name(), stage.Type(), err)
 	} else {
-		logger.Info("pipeline stage returned",
+		logger.Debug("pipeline stage completed",
 			"stage", stage.Name(), "type", stage.Type(),
 			"duration", duration)
 	}

--- a/runtime/pipeline/stage/stages_duplex_provider.go
+++ b/runtime/pipeline/stage/stages_duplex_provider.go
@@ -49,6 +49,22 @@ func (s *DuplexProviderStage) takeReasoning() *types.ReasoningTrace {
 	return &types.ReasoningTrace{Text: text, Opaque: s.accumulatedOpaqueReasoning}
 }
 
+// metaTypeOutputTranscription is the chunk Metadata["type"] value a provider uses
+// to mark an incremental transcript of the assistant's spoken (audio) reply.
+const metaTypeOutputTranscription = "output_transcription"
+
+// isOutputTranscriptionChunk reports whether a chunk carries the assistant's
+// audio-transcript text (an incremental Delta marked output_transcription by the
+// provider) rather than model text (Content). Realtime providers send the spoken
+// reply's transcript this way.
+func isOutputTranscriptionChunk(chunk *providers.StreamChunk) bool {
+	if chunk.Metadata == nil {
+		return false
+	}
+	t, _ := chunk.Metadata["type"].(string)
+	return t == metaTypeOutputTranscription
+}
+
 // chunkToElement converts a StreamChunk to a StreamElement.
 // Creates a Message with role="assistant" for text and/or media responses.
 // On the final chunk (with FinishReason), uses accumulated content from the entire turn.
@@ -57,6 +73,7 @@ func (s *DuplexProviderStage) takeReasoning() *types.ReasoningTrace {
 // - Interruptions: Captured as partial responses with finish_reason="interrupted"
 // - Turn completion: Creates Message with accumulated content
 // - Streaming content: Passes through text/audio for real-time display/playback
+//
 // turn-complete / streaming passthrough); splitting fragments the turn-handling
 // logic. Relocated here unchanged from the integration file and now 98.7% covered.
 //
@@ -114,9 +131,16 @@ func (s *DuplexProviderStage) chunkToElement(chunk *providers.StreamChunk) Strea
 		return elem
 	}
 
-	// Add text if present (for real-time streaming display)
+	// Add text if present (for real-time streaming display).
+	//   - ModelTurn text arrives on Content (Delta duplicates it) → use Content.
+	//   - A realtime audio transcript arrives incrementally on Delta, marked
+	//     output_transcription with no Content → forward that Delta as live text
+	//     so the assistant's spoken words stream to the display, instead of only
+	//     landing in the end-of-turn Message that display observers don't render.
 	if chunk.Content != "" {
 		elem.Text = &chunk.Content
+	} else if chunk.Delta != "" && isOutputTranscriptionChunk(chunk) {
+		elem.Text = &chunk.Delta
 	}
 
 	// Add audio if present (for real-time playback)

--- a/runtime/pipeline/stage/stages_duplex_provider_session.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_session.go
@@ -755,7 +755,12 @@ func (s *DuplexProviderStage) forwardResponseElements(
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Info("Session closure: context canceled")
+			// Log the cancellation CAUSE, not just "canceled": context.Cause
+			// distinguishes the pipeline idle timeout (ErrIdleTimeout) from a
+			// parent cancel (a pump/caller returned) — the difference between
+			// "the 30s idle timer fired" and "something upstream tore us down".
+			logger.Info("Session closure: context canceled",
+				"cause", context.Cause(ctx), "err", ctx.Err())
 			// Emit any accumulated content as partial response before returning
 			accumulatedText := s.accumulatedText.String()
 			hasContent := accumulatedText != "" || len(s.accumulatedMedia) > 0

--- a/runtime/pipeline/stage/stages_duplex_provider_session.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_session.go
@@ -429,7 +429,21 @@ func (s *DuplexProviderStage) forwardInputElements(
 				s.allResponsesReceivedOnce.Do(func() {
 					close(s.allResponsesReceivedCh)
 				})
-				continue // Don't forward this signal element
+				// A graceful drain (Close) sends this on an EndOfStream element to
+				// end input AND close the session immediately — otherwise draining a
+				// live streaming session blocks the full finalResponseTimeout (~30s),
+				// because the provider's response channel never closes on its own. A
+				// plain end-of-turn EndOfStream (with input payload) does NOT set this
+				// flag, so it still waits briefly for the turn's response.
+				if elem.EndOfStream {
+					logger.Debug("DuplexProviderStage: drain signal; ending input for prompt close")
+					s.inputDoneOnce.Do(func() {
+						close(s.inputDoneCh)
+					})
+					done <- nil
+					return
+				}
+				continue // executor mid-stream signal; keep forwarding
 			}
 
 			// Check for tool result messages to forward to output for state store capture.

--- a/runtime/pipeline/stage/stages_duplex_provider_session.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_session.go
@@ -421,6 +421,11 @@ func (s *DuplexProviderStage) forwardInputElements(
 				return
 			}
 
+			// Inbound audio is activity: reset the pipeline idle timer so a live
+			// conversation is not killed by the 30s idle timeout while the user is
+			// speaking. Without this every streaming voice session dies at ~30s.
+			ResetIdleFromContext(ctx)
+
 			// Check for "all responses received" signal from executor.
 			// This tells us that all expected responses have been received synchronously
 			// and we can skip the finalResponseTimeout when input closes.
@@ -883,6 +888,10 @@ func (s *DuplexProviderStage) forwardResponseElements(
 
 				return nil
 			}
+
+			// Outbound audio/text is activity: reset the pipeline idle timer so a
+			// long reply is not cut off by the 30s idle timeout mid-stream.
+			ResetIdleFromContext(ctx)
 
 			if err := s.handleResponseChunk(ctx, &chunk, output); err != nil {
 				return err

--- a/runtime/pipeline/stage/stages_duplex_provider_session.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_session.go
@@ -967,7 +967,7 @@ func (s *DuplexProviderStage) handleResponseChunk(
 	if chunk.Metadata != nil {
 		if metaType, ok := chunk.Metadata["type"].(string); ok {
 			switch metaType {
-			case "output_transcription":
+			case metaTypeOutputTranscription:
 				isOutputTranscription = true
 			case "input_transcription":
 				isInputTranscription = true

--- a/runtime/pipeline/stage/stages_duplex_provider_test.go
+++ b/runtime/pipeline/stage/stages_duplex_provider_test.go
@@ -36,6 +36,33 @@ func TestDuplexChunkToElement_TextForwarded(t *testing.T) {
 	assert.Equal(t, "live text", *elem.Text)
 }
 
+// TestDuplexChunkToElement_OutputTranscriptionForwarded proves the assistant's
+// spoken-audio transcript streams to the display live. Realtime providers (OpenAI
+// Realtime) send that transcript as an incremental Delta marked
+// output_transcription with NO Content; it must forward as live element Text so
+// a display observer (which renders StreamChunk.Delta) shows the assistant's
+// words. Without it, a realtime voice assistant plays audio but shows no
+// transcript at all — the reported bug.
+func TestDuplexChunkToElement_OutputTranscriptionForwarded(t *testing.T) {
+	s := newDuplexStageForUnit()
+	elem := s.chunkToElement(&providers.StreamChunk{
+		Delta:    "hello there",
+		Metadata: map[string]any{"type": "output_transcription"},
+	})
+	require.NotNil(t, elem.Text, "assistant audio-transcript delta must forward as live element text")
+	assert.Equal(t, "hello there", *elem.Text)
+}
+
+// TestDuplexChunkToElement_ModelTurnDeltaNotDoubled guards the dedup: a ModelTurn
+// chunk sets Content and Delta to the same value; only Content must be forwarded
+// so the text isn't emitted twice.
+func TestDuplexChunkToElement_ModelTurnDeltaNotDoubled(t *testing.T) {
+	s := newDuplexStageForUnit()
+	elem := s.chunkToElement(&providers.StreamChunk{Content: "once", Delta: "once"})
+	require.NotNil(t, elem.Text)
+	assert.Equal(t, "once", *elem.Text)
+}
+
 // TestDuplexChunkToElement_FinishWithToolCalls covers turn completion creating a
 // message from chunk tool calls, the latency branch, and the long-content
 // preview truncation branch.

--- a/runtime/pipeline/stage/transcript_reorder.go
+++ b/runtime/pipeline/stage/transcript_reorder.go
@@ -1,0 +1,140 @@
+package stage
+
+import (
+	"context"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TranscriptReorderStage guarantees that, within a turn, the user's input
+// transcript is emitted before that turn's assistant text — even when the
+// provider delivers the transcript late (e.g. OpenAI Realtime, whose Whisper
+// transcription lands after the assistant response has already started).
+//
+// It buffers assistant TEXT elements until the user turn element for that turn
+// appears, then flushes them in order and streams the rest live. AUDIO elements
+// pass through immediately, so playback stays realtime — only the transcript log
+// is reordered. If a turn ends with no transcript, a configurable placeholder
+// user turn is emitted so the reply is never shown with no prompt.
+//
+// The mechanism is provider-agnostic; whether it is wired is decided upstream
+// (providers that emit the transcript first don't need it). It is a Transform
+// stage: state is per-turn and reset on each turn boundary, so a single instance
+// handles one continuous duplex conversation.
+type TranscriptReorderStage struct {
+	BaseStage
+
+	// placeholder is the user-turn content synthesized when a turn ends without a
+	// transcript. Empty means "emit nothing" — the assistant text is flushed with
+	// no user turn.
+	placeholder string
+
+	// buffered holds assistant text elements seen before the current turn's user
+	// element. Flushed (in order) once the user element arrives or the turn ends.
+	buffered []StreamElement
+
+	// userEmitted is true once the user turn element for the current turn has been
+	// forwarded; subsequent assistant text for the turn streams live.
+	userEmitted bool
+}
+
+// NewTranscriptReorderStage creates a reorder stage with the given missing-turn
+// placeholder text (empty to omit the user turn when a transcript never arrives).
+func NewTranscriptReorderStage(placeholder string) *TranscriptReorderStage {
+	return &TranscriptReorderStage{
+		BaseStage:   NewBaseStage("transcript-reorder", StageTypeTransform),
+		placeholder: placeholder,
+	}
+}
+
+// Process implements the Stage interface.
+func (s *TranscriptReorderStage) Process(
+	ctx context.Context,
+	input <-chan StreamElement,
+	output chan<- StreamElement,
+) error {
+	defer close(output)
+
+	for elem := range input {
+		if err := s.handle(ctx, elem, output); err != nil {
+			return err
+		}
+	}
+	// Input closed mid-turn (no trailing boundary): flush whatever is buffered so
+	// nothing is silently dropped.
+	return s.flushBuffer(ctx, output)
+}
+
+// handle routes a single element per the reorder rules.
+func (s *TranscriptReorderStage) handle(ctx context.Context, elem StreamElement, output chan<- StreamElement) error {
+	switch {
+	case isUserTurnElement(&elem):
+		// The user turn arrived — emit it, then release everything buffered for
+		// this turn so the transcript reads user-then-assistant.
+		if err := s.send(ctx, output, elem); err != nil {
+			return err
+		}
+		s.userEmitted = true
+		return s.flushBuffer(ctx, output)
+
+	case elem.Audio != nil:
+		// Audio is realtime — never buffered.
+		return s.send(ctx, output, elem)
+
+	case elem.EndOfStream || elem.Meta.Interrupted:
+		// Turn boundary. If no user turn was emitted, synthesize the placeholder so
+		// the reply isn't shown with no prompt. Then flush and forward the boundary.
+		if !s.userEmitted && s.placeholder != "" {
+			ph := StreamElement{Message: &types.Message{Role: roleUser, Content: s.placeholder}}
+			if err := s.send(ctx, output, ph); err != nil {
+				return err
+			}
+		}
+		if err := s.flushBuffer(ctx, output); err != nil {
+			return err
+		}
+		if err := s.send(ctx, output, elem); err != nil {
+			return err
+		}
+		s.userEmitted = false
+		s.buffered = s.buffered[:0]
+		return nil
+
+	case elem.Text != nil && !s.userEmitted:
+		// Assistant text ahead of the transcript — hold it.
+		s.buffered = append(s.buffered, elem)
+		return nil
+
+	default:
+		// Assistant text after the user turn, reasoning, errors, control — forward.
+		return s.send(ctx, output, elem)
+	}
+}
+
+// flushBuffer forwards and clears any buffered assistant text elements.
+func (s *TranscriptReorderStage) flushBuffer(ctx context.Context, output chan<- StreamElement) error {
+	for i := range s.buffered {
+		if err := s.send(ctx, output, s.buffered[i]); err != nil {
+			return err
+		}
+	}
+	s.buffered = s.buffered[:0]
+	return nil
+}
+
+// send forwards one element, honoring context cancellation.
+func (s *TranscriptReorderStage) send(ctx context.Context, output chan<- StreamElement, elem StreamElement) error {
+	select {
+	case output <- elem:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// isUserTurnElement reports whether an element is the materialized user turn (a
+// user-role Message). The turn-boundary EndOfStream element carries an
+// assistant Message and is handled separately.
+func isUserTurnElement(elem *StreamElement) bool {
+	return elem.Message != nil && elem.Message.Role == roleUser && !elem.EndOfStream
+}

--- a/runtime/pipeline/stage/transcript_reorder.go
+++ b/runtime/pipeline/stage/transcript_reorder.go
@@ -2,48 +2,71 @@ package stage
 
 import (
 	"context"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// defaultTranscriptHoldTimeout is how long the reorder stage holds a completed
+// turn waiting for a late input transcript before falling back to the
+// placeholder. Providers like OpenAI Realtime deliver Whisper transcripts a
+// beat after a short reply finishes; this covers that gap without stalling a
+// genuinely transcript-less turn for long.
+const defaultTranscriptHoldTimeout = 3 * time.Second
+
 // TranscriptReorderStage guarantees that, within a turn, the user's input
 // transcript is emitted before that turn's assistant text — even when the
 // provider delivers the transcript late (e.g. OpenAI Realtime, whose Whisper
-// transcription lands after the assistant response has already started).
+// transcription can land after the assistant reply, or even after the whole
+// turn, has finished).
 //
-// It buffers assistant TEXT elements until the user turn element for that turn
-// appears, then flushes them in order and streams the rest live. AUDIO elements
-// pass through immediately, so playback stays realtime — only the transcript log
-// is reordered. If a turn ends with no transcript, a configurable placeholder
-// user turn is emitted so the reply is never shown with no prompt.
+// It buffers assistant TEXT elements and HOLDS the turn-end until the user turn
+// for that turn arrives (or a short timeout elapses), then emits user-then-text
+// in order. AUDIO passes through immediately, so playback stays realtime — only
+// the transcript log is reordered. Crucially the turn-end (EndOfStream) is held
+// too, so a late transcript is never emitted after the turn boundary (which both
+// mis-orders the log and can confuse downstream turn-scoped stages). If the
+// transcript never arrives, a configurable placeholder user turn is emitted.
 //
-// The mechanism is provider-agnostic; whether it is wired is decided upstream
-// (providers that emit the transcript first don't need it). It is a Transform
-// stage: state is per-turn and reset on each turn boundary, so a single instance
-// handles one continuous duplex conversation.
+// The mechanism is provider-agnostic; whether it is wired is decided upstream. It
+// is a Transform stage: state is per-turn and reset on each turn boundary, so a
+// single instance handles one continuous duplex conversation.
 type TranscriptReorderStage struct {
 	BaseStage
 
-	// placeholder is the user-turn content synthesized when a turn ends without a
-	// transcript. Empty means "emit nothing" — the assistant text is flushed with
-	// no user turn.
+	// placeholder is the user-turn content synthesized when a turn ends and no
+	// transcript arrives within holdTimeout. Empty omits the user turn.
 	placeholder string
 
+	// holdTimeout bounds how long a completed turn waits for a late transcript.
+	holdTimeout time.Duration
+
 	// buffered holds assistant text elements seen before the current turn's user
-	// element. Flushed (in order) once the user element arrives or the turn ends.
+	// element. Flushed (in order) once the user element arrives or the turn resolves.
 	buffered []StreamElement
 
 	// userEmitted is true once the user turn element for the current turn has been
 	// forwarded; subsequent assistant text for the turn streams live.
 	userEmitted bool
+
+	// pendingEnd holds the turn-end element while awaiting a late transcript. Nil
+	// when not holding.
+	pendingEnd *StreamElement
 }
 
 // NewTranscriptReorderStage creates a reorder stage with the given missing-turn
-// placeholder text (empty to omit the user turn when a transcript never arrives).
+// placeholder text (empty to omit the user turn) and the default hold timeout.
 func NewTranscriptReorderStage(placeholder string) *TranscriptReorderStage {
+	return NewTranscriptReorderStageWithTimeout(placeholder, defaultTranscriptHoldTimeout)
+}
+
+// NewTranscriptReorderStageWithTimeout is like NewTranscriptReorderStage but with
+// an explicit hold timeout (tests use a short value).
+func NewTranscriptReorderStageWithTimeout(placeholder string, holdTimeout time.Duration) *TranscriptReorderStage {
 	return &TranscriptReorderStage{
 		BaseStage:   NewBaseStage("transcript-reorder", StageTypeTransform),
 		placeholder: placeholder,
+		holdTimeout: holdTimeout,
 	}
 }
 
@@ -55,60 +78,165 @@ func (s *TranscriptReorderStage) Process(
 ) error {
 	defer close(output)
 
-	for elem := range input {
-		if err := s.handle(ctx, elem, output); err != nil {
-			return err
+	var timer *time.Timer
+	var timerC <-chan time.Time
+	stopTimer := func() {
+		if timer != nil {
+			timer.Stop()
+			timer = nil
+			timerC = nil
 		}
 	}
-	// Input closed mid-turn (no trailing boundary): flush whatever is buffered so
-	// nothing is silently dropped.
-	return s.flushBuffer(ctx, output)
-}
+	defer stopTimer()
 
-// handle routes a single element per the reorder rules.
-func (s *TranscriptReorderStage) handle(ctx context.Context, elem StreamElement, output chan<- StreamElement) error {
-	switch {
-	case isUserTurnElement(&elem):
-		// The user turn arrived — emit it, then release everything buffered for
-		// this turn so the transcript reads user-then-assistant.
-		if err := s.send(ctx, output, elem); err != nil {
-			return err
-		}
-		s.userEmitted = true
-		return s.flushBuffer(ctx, output)
-
-	case elem.Audio != nil:
-		// Audio is realtime — never buffered.
-		return s.send(ctx, output, elem)
-
-	case elem.EndOfStream || elem.Meta.Interrupted:
-		// Turn boundary. If no user turn was emitted, synthesize the placeholder so
-		// the reply isn't shown with no prompt. Then flush and forward the boundary.
-		if !s.userEmitted && s.placeholder != "" {
-			ph := StreamElement{Message: &types.Message{Role: roleUser, Content: s.placeholder}}
-			if err := s.send(ctx, output, ph); err != nil {
+	for {
+		select {
+		case elem, ok := <-input:
+			if !ok {
+				// Input closed: resolve any held turn (placeholder if still no
+				// transcript) and flush.
+				if s.pendingEnd != nil || len(s.buffered) > 0 {
+					return s.resolvePending(ctx, output, true)
+				}
+				return nil
+			}
+			held, err := s.handle(ctx, elem, output)
+			if err != nil {
 				return err
 			}
+			// Manage the hold timer to match pendingEnd state.
+			switch {
+			case held && timer == nil:
+				timer = time.NewTimer(s.holdTimeout)
+				timerC = timer.C
+			case !held && s.pendingEnd == nil:
+				stopTimer()
+			}
+
+		case <-timerC:
+			timer = nil
+			timerC = nil
+			// Transcript never arrived — fall back to the placeholder.
+			if err := s.resolvePending(ctx, output, true); err != nil {
+				return err
+			}
+
+		case <-ctx.Done():
+			return ctx.Err()
 		}
-		if err := s.flushBuffer(ctx, output); err != nil {
+	}
+}
+
+// handle routes one element. It returns held=true when it started holding a
+// turn-end awaiting a late transcript.
+func (s *TranscriptReorderStage) handle(
+	ctx context.Context, elem StreamElement, output chan<- StreamElement,
+) (held bool, err error) {
+	switch {
+	case isUserTurnElement(&elem):
+		return false, s.handleUserTurn(ctx, elem, output)
+	case elem.Audio != nil:
+		return false, s.send(ctx, output, elem) // realtime — never buffered or held
+	case elem.EndOfStream || elem.Meta.Interrupted:
+		return s.handleTurnEnd(ctx, elem, output)
+	case elem.Text != nil:
+		return false, s.handleText(ctx, elem, output)
+	default:
+		return false, s.send(ctx, output, elem)
+	}
+}
+
+// handleUserTurn emits the user turn, flushes buffered assistant text, and
+// releases a held turn-end (if any) in order.
+func (s *TranscriptReorderStage) handleUserTurn(
+	ctx context.Context, elem StreamElement, output chan<- StreamElement,
+) error {
+	if err := s.send(ctx, output, elem); err != nil {
+		return err
+	}
+	s.userEmitted = true
+	if err := s.flushBuffer(ctx, output); err != nil {
+		return err
+	}
+	if s.pendingEnd != nil {
+		if err := s.send(ctx, output, *s.pendingEnd); err != nil {
 			return err
+		}
+		s.resetTurn()
+	}
+	return nil
+}
+
+// handleTurnEnd forwards the turn-end when the user turn was already shown, or
+// holds it (held=true) to wait for a late transcript.
+func (s *TranscriptReorderStage) handleTurnEnd(
+	ctx context.Context, elem StreamElement, output chan<- StreamElement,
+) (held bool, err error) {
+	if s.userEmitted {
+		if err := s.flushBuffer(ctx, output); err != nil {
+			return false, err
 		}
 		if err := s.send(ctx, output, elem); err != nil {
+			return false, err
+		}
+		s.resetTurn()
+		return false, nil
+	}
+	e := elem
+	s.pendingEnd = &e
+	return true, nil
+}
+
+// handleText buffers assistant text before the user turn (resolving any prior
+// held turn first), or forwards it once the user turn has been shown.
+func (s *TranscriptReorderStage) handleText(
+	ctx context.Context, elem StreamElement, output chan<- StreamElement,
+) error {
+	if s.pendingEnd != nil {
+		// New turn's text while awaiting the previous turn's transcript — it isn't
+		// coming. Resolve the previous turn (placeholder), then buffer this one.
+		if err := s.resolvePending(ctx, output, true); err != nil {
 			return err
 		}
-		s.userEmitted = false
-		s.buffered = s.buffered[:0]
-		return nil
-
-	case elem.Text != nil && !s.userEmitted:
-		// Assistant text ahead of the transcript — hold it.
 		s.buffered = append(s.buffered, elem)
 		return nil
-
-	default:
-		// Assistant text after the user turn, reasoning, errors, control — forward.
-		return s.send(ctx, output, elem)
 	}
+	if !s.userEmitted {
+		s.buffered = append(s.buffered, elem)
+		return nil
+	}
+	return s.send(ctx, output, elem)
+}
+
+// resolvePending finishes a held turn: emits the placeholder (when requested and
+// no user turn was shown), flushes buffered text, forwards the held turn-end, and
+// resets per-turn state.
+func (s *TranscriptReorderStage) resolvePending(
+	ctx context.Context, output chan<- StreamElement, usePlaceholder bool,
+) error {
+	if usePlaceholder && !s.userEmitted && s.placeholder != "" {
+		ph := StreamElement{Message: &types.Message{Role: roleUser, Content: s.placeholder}}
+		if err := s.send(ctx, output, ph); err != nil {
+			return err
+		}
+	}
+	if err := s.flushBuffer(ctx, output); err != nil {
+		return err
+	}
+	if s.pendingEnd != nil {
+		if err := s.send(ctx, output, *s.pendingEnd); err != nil {
+			return err
+		}
+	}
+	s.resetTurn()
+	return nil
+}
+
+// resetTurn clears per-turn state for the next turn.
+func (s *TranscriptReorderStage) resetTurn() {
+	s.userEmitted = false
+	s.buffered = s.buffered[:0]
+	s.pendingEnd = nil
 }
 
 // flushBuffer forwards and clears any buffered assistant text elements.

--- a/runtime/pipeline/stage/transcript_reorder_test.go
+++ b/runtime/pipeline/stage/transcript_reorder_test.go
@@ -1,0 +1,136 @@
+package stage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// txtElem wraps assistant text in a StreamElement. Each call captures a distinct
+// string variable, so &x is safe to take.
+func txtElem(x string) StreamElement { return StreamElement{Text: &x} }
+
+func userElem(content string) StreamElement {
+	return StreamElement{Message: &types.Message{Role: "user", Content: content}}
+}
+
+func asstEndElem(content string) StreamElement {
+	return StreamElement{EndOfStream: true, Message: &types.Message{Role: "assistant", Content: content}}
+}
+
+// drainOrder records the observable order of user turns, assistant text, audio,
+// and turn ends from the stage output.
+func drainOrder(out <-chan StreamElement) []string {
+	var order []string
+	for e := range out {
+		switch {
+		case e.Message != nil && e.Message.Role == "user":
+			order = append(order, "USER:"+e.Message.Content)
+		case e.Audio != nil:
+			order = append(order, "AUDIO")
+		case e.Text != nil:
+			order = append(order, "TXT:"+*e.Text)
+		case e.EndOfStream:
+			order = append(order, "END")
+		}
+	}
+	return order
+}
+
+// TestTranscriptReorderStage_UserBeforeAssistant is the core guarantee: when the
+// provider delivers assistant text BEFORE the user's transcript (OpenAI Realtime
+// ordering), the stage emits the user turn first, then the buffered assistant
+// text, then streams the rest live.
+func TestTranscriptReorderStage_UserBeforeAssistant(t *testing.T) {
+	s := NewTranscriptReorderStage("[no transcription available]")
+	in := make(chan StreamElement, 8)
+	out := make(chan StreamElement, 16)
+
+	in <- txtElem("Hi ")   // assistant starts before the transcript
+	in <- txtElem("there") // still buffered
+	in <- userElem("Hello!")
+	in <- txtElem("!") // after the user turn — streams live
+	in <- asstEndElem("Hi there!")
+	close(in)
+
+	require.NoError(t, s.Process(context.Background(), in, out))
+
+	assert.Equal(t, []string{"USER:Hello!", "TXT:Hi ", "TXT:there", "TXT:!", "END"}, drainOrder(out),
+		"the user transcript must precede that turn's assistant text")
+}
+
+// TestTranscriptReorderStage_MissingTranscriptPlaceholder: a turn ends with no
+// transcript — the stage emits the configured placeholder user turn so the reply
+// isn't shown with no prompt, then flushes the buffered assistant text.
+func TestTranscriptReorderStage_MissingTranscriptPlaceholder(t *testing.T) {
+	s := NewTranscriptReorderStage("[no transcription available]")
+	in := make(chan StreamElement, 8)
+	out := make(chan StreamElement, 16)
+
+	in <- txtElem("Reply ")
+	in <- txtElem("only")
+	in <- asstEndElem("Reply only")
+	close(in)
+
+	require.NoError(t, s.Process(context.Background(), in, out))
+
+	assert.Equal(t, []string{"USER:[no transcription available]", "TXT:Reply ", "TXT:only", "END"}, drainOrder(out),
+		"a turn with no transcript must get the placeholder user turn before its assistant text")
+}
+
+// TestTranscriptReorderStage_EmptyPlaceholderOmitsUserTurn: with an empty
+// placeholder, a transcript-less turn simply flushes the assistant text with no
+// user turn.
+func TestTranscriptReorderStage_EmptyPlaceholderOmitsUserTurn(t *testing.T) {
+	s := NewTranscriptReorderStage("")
+	in := make(chan StreamElement, 8)
+	out := make(chan StreamElement, 16)
+
+	in <- txtElem("Reply")
+	in <- asstEndElem("Reply")
+	close(in)
+
+	require.NoError(t, s.Process(context.Background(), in, out))
+	assert.Equal(t, []string{"TXT:Reply", "END"}, drainOrder(out))
+}
+
+// TestTranscriptReorderStage_AudioNotBuffered: audio must pass through
+// immediately (realtime playback), never held waiting for the transcript.
+func TestTranscriptReorderStage_AudioNotBuffered(t *testing.T) {
+	s := NewTranscriptReorderStage("[none]")
+	in := make(chan StreamElement, 8)
+	out := make(chan StreamElement, 16)
+
+	in <- StreamElement{Audio: &AudioData{Samples: []byte{1, 2}, SampleRate: 24000, Channels: 1}}
+	in <- txtElem("text")
+	in <- userElem("hi")
+	in <- asstEndElem("text")
+	close(in)
+
+	require.NoError(t, s.Process(context.Background(), in, out))
+	// Audio is forwarded immediately (before the user turn); text is reordered
+	// after the user turn.
+	assert.Equal(t, []string{"AUDIO", "USER:hi", "TXT:text", "END"}, drainOrder(out))
+}
+
+// TestTranscriptReorderStage_MultiTurnResets: state resets per turn so each
+// turn's transcript precedes its own assistant text.
+func TestTranscriptReorderStage_MultiTurnResets(t *testing.T) {
+	s := NewTranscriptReorderStage("[none]")
+	in := make(chan StreamElement, 16)
+	out := make(chan StreamElement, 32)
+
+	in <- txtElem("A1")
+	in <- userElem("q1")
+	in <- asstEndElem("A1")
+	in <- txtElem("A2") // next turn, buffered again
+	in <- userElem("q2")
+	in <- asstEndElem("A2")
+	close(in)
+
+	require.NoError(t, s.Process(context.Background(), in, out))
+	assert.Equal(t, []string{"USER:q1", "TXT:A1", "END", "USER:q2", "TXT:A2", "END"}, drainOrder(out))
+}

--- a/runtime/pipeline/stage/transcript_reorder_test.go
+++ b/runtime/pipeline/stage/transcript_reorder_test.go
@@ -3,6 +3,7 @@ package stage
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/stretchr/testify/assert"
@@ -114,6 +115,87 @@ func TestTranscriptReorderStage_AudioNotBuffered(t *testing.T) {
 	// Audio is forwarded immediately (before the user turn); text is reordered
 	// after the user turn.
 	assert.Equal(t, []string{"AUDIO", "USER:hi", "TXT:text", "END"}, drainOrder(out))
+}
+
+// collectUntil reads elements until it has seen `endMarks` END markers or the
+// deadline elapses, returning the observable order.
+func collectUntil(out <-chan StreamElement, endMarks int, deadline time.Duration) []string {
+	var order []string
+	ends := 0
+	timeout := time.After(deadline)
+	for ends < endMarks {
+		select {
+		case e := <-out:
+			switch {
+			case e.Message != nil && e.Message.Role == "user":
+				order = append(order, "USER:"+e.Message.Content)
+			case e.Audio != nil:
+				order = append(order, "AUDIO")
+			case e.Text != nil:
+				order = append(order, "TXT:"+*e.Text)
+			case e.EndOfStream:
+				order = append(order, "END")
+				ends++
+			}
+		case <-timeout:
+			return order
+		}
+	}
+	return order
+}
+
+// TestTranscriptReorderStage_LateTranscriptHeldInOrder is the short-reply fix: the
+// turn ends BEFORE the transcript arrives, so the stage must HOLD the turn-end,
+// then emit the late transcript ahead of the assistant text — never the
+// placeholder, and never a user turn after the turn boundary.
+func TestTranscriptReorderStage_LateTranscriptHeldInOrder(t *testing.T) {
+	s := NewTranscriptReorderStage("[no transcription available]")
+	in := make(chan StreamElement, 8)
+	out := make(chan StreamElement, 16)
+
+	in <- txtElem("Hi!")          // assistant text
+	in <- asstEndElem("Hi!")      // turn ends — no transcript yet (held)
+	in <- userElem("hello there") // transcript arrives AFTER the turn end
+	close(in)
+
+	require.NoError(t, s.Process(context.Background(), in, out))
+	assert.Equal(t, []string{"USER:hello there", "TXT:Hi!", "END"}, drainOrder(out),
+		"a late transcript must be reordered ahead of the reply, with no placeholder")
+}
+
+// TestTranscriptReorderStage_HoldTimeoutFallsBackToPlaceholder: when no transcript
+// arrives within the hold timeout, the placeholder is emitted.
+func TestTranscriptReorderStage_HoldTimeoutFallsBackToPlaceholder(t *testing.T) {
+	s := NewTranscriptReorderStageWithTimeout("[none]", 40*time.Millisecond)
+	in := make(chan StreamElement, 4)
+	out := make(chan StreamElement, 16)
+
+	go func() { _ = s.Process(context.Background(), in, out) }()
+	in <- txtElem("Reply")
+	in <- asstEndElem("Reply")
+	// Do not send a transcript — the hold timeout must fire and emit the placeholder.
+	got := collectUntil(out, 1, 2*time.Second)
+	close(in)
+	assert.Equal(t, []string{"USER:[none]", "TXT:Reply", "END"}, got)
+}
+
+// TestTranscriptReorderStage_NextTurnResolvesPending: if the next turn's content
+// arrives while still awaiting a transcript, the previous turn resolves with the
+// placeholder before the new turn is handled.
+func TestTranscriptReorderStage_NextTurnResolvesPending(t *testing.T) {
+	s := NewTranscriptReorderStage("[none]")
+	in := make(chan StreamElement, 16)
+	out := make(chan StreamElement, 32)
+
+	in <- txtElem("A1")
+	in <- asstEndElem("A1") // held, no transcript
+	in <- txtElem("A2")     // next turn starts before A1's transcript → resolve A1
+	in <- userElem("q2")
+	in <- asstEndElem("A2")
+	close(in)
+
+	require.NoError(t, s.Process(context.Background(), in, out))
+	assert.Equal(t, []string{"USER:[none]", "TXT:A1", "END", "USER:q2", "TXT:A2", "END"}, drainOrder(out))
 }
 
 // TestTranscriptReorderStage_MultiTurnResets: state resets per turn so each

--- a/runtime/providers/openai/streaming_support_integration.go
+++ b/runtime/providers/openai/streaming_support_integration.go
@@ -42,6 +42,13 @@ import (
 //	    },
 //	    SystemInstruction: "You are a helpful assistant.",
 //	})
+//
+// EmitsLateInputTranscription reports that OpenAI Realtime delivers the user's
+// input transcription asynchronously (Whisper), after the assistant reply has
+// begun — so the pipeline should reorder the transcript when transcription is
+// enabled. Implements providers.LateInputTranscriber.
+func (p *Provider) EmitsLateInputTranscription() bool { return true }
+
 func (p *Provider) CreateStreamSession(
 	ctx context.Context,
 	req *providers.StreamingInputConfig,

--- a/runtime/providers/streaming_input.go
+++ b/runtime/providers/streaming_input.go
@@ -175,6 +175,21 @@ type StreamInputSupport interface {
 	GetStreamingCapabilities() StreamingCapabilities
 }
 
+// LateInputTranscriber is an optional interface a StreamInputSupport provider
+// implements to declare that it delivers the user's input transcription AFTER
+// the assistant response has already begun — e.g. OpenAI Realtime, whose Whisper
+// transcription arrives asynchronously, after the model has started replying.
+//
+// When a provider reports true (and input transcription is enabled), the
+// streaming pipeline reorders the transcript so each turn's user text precedes
+// its assistant text. Providers that emit the transcript before the reply (or
+// not at all) need not implement this — reordering stays off by default.
+type LateInputTranscriber interface {
+	// EmitsLateInputTranscription reports whether the user transcript can arrive
+	// after the assistant reply has started for the same turn.
+	EmitsLateInputTranscription() bool
+}
+
 // StreamingCapabilities describes what streaming features a provider supports.
 type StreamingCapabilities struct {
 	// SupportedMediaTypes lists the media types that can be streamed

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -402,6 +402,45 @@ func isEmptyMessage(message any) bool {
 	}
 }
 
+// defaultTranscriptPlaceholder is the user-turn text shown when a turn ends with
+// no transcription and reordering is active.
+const defaultTranscriptPlaceholder = "[no transcription available]"
+
+// resolveTranscriptReorder decides whether the pipeline should reorder a late
+// input transcript (so each turn's user text precedes its assistant text) and
+// what placeholder to use for a turn with no transcript. Inputs come from the
+// provider's LateInputTranscriber capability and the streaming config's
+// additional properties (Metadata):
+//   - input_transcript_ordering: "reorder" | "passthrough" — explicit override.
+//   - input_transcription: bool — auto mode requires transcription to be on.
+//   - input_transcript_placeholder: string — overrides the default placeholder.
+//
+// Default (no override): on when the provider emits the transcript late AND input
+// transcription is enabled — so it stays off for providers that don't need it.
+func resolveTranscriptReorder(
+	prov providers.StreamInputSupport, cfg *providers.StreamingInputConfig,
+) (enabled bool, placeholder string) {
+	placeholder = defaultTranscriptPlaceholder
+	if cfg == nil {
+		return false, placeholder
+	}
+	if v, ok := cfg.Metadata["input_transcript_placeholder"].(string); ok {
+		placeholder = v
+	}
+	switch ordering, _ := cfg.Metadata["input_transcript_ordering"].(string); ordering {
+	case "reorder":
+		return true, placeholder
+	case "passthrough":
+		return false, placeholder
+	}
+	late := false
+	if lt, ok := prov.(providers.LateInputTranscriber); ok {
+		late = lt.EmitsLateInputTranscription()
+	}
+	transcriptionOn, _ := cfg.Metadata["input_transcription"].(bool)
+	return late && transcriptionOn, placeholder
+}
+
 // buildPipelineConfig assembles the shared intpipeline.Config used by both unary
 // and duplex pipeline builders.  Callers may further mutate the returned config
 // (e.g. to add VAD settings) before passing it to intpipeline.Build.
@@ -492,6 +531,10 @@ func (c *Conversation) buildPipelineConfig(
 			WithUserID(c.config.userID)
 	}
 
+	// Resolve input-transcript reordering from the provider capability + streaming
+	// config additional properties (see resolveTranscriptReorder).
+	reorderTranscript, transcriptPlaceholder := resolveTranscriptReorder(streamProvider, streamConfig)
+
 	// Build pipeline configuration
 	pipelineCfg := &intpipeline.Config{
 		Provider:              c.config.getAgentProvider(),
@@ -530,6 +573,10 @@ func (c *Conversation) buildPipelineConfig(
 		// speaker; pace the output so a streaming provider's whole-reply burst
 		// doesn't overrun the sink's jitter buffer and drop audio (stutter).
 		PaceOutputAudio: c.config.audioSession != nil,
+		// Reorder late-arriving input transcripts (OpenAI Realtime) so each turn's
+		// user text precedes its assistant text.
+		ReorderInputTranscript:     reorderTranscript,
+		InputTranscriptPlaceholder: transcriptPlaceholder,
 	}
 
 	// Wire memory stages from MemoryCapability if present

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -526,6 +526,10 @@ func (c *Conversation) buildPipelineConfig(
 		ToolSelector:          c.config.selectors[c.config.toolSelectorName],
 		ApprovalChecker:       c.newApprovalChecker(),
 		ClassifyRegistry:      c.config.classifyRegistry,
+		// A bound audio session (OpenVoice) plays response audio to a realtime
+		// speaker; pace the output so a streaming provider's whole-reply burst
+		// doesn't overrun the sink's jitter buffer and drop audio (stutter).
+		PaceOutputAudio: c.config.audioSession != nil,
 	}
 
 	// Wire memory stages from MemoryCapability if present

--- a/sdk/examples/openai-realtime/main_interactive.go
+++ b/sdk/examples/openai-realtime/main_interactive.go
@@ -258,27 +258,46 @@ func runUntilSignal(ctx context.Context, conv *sdk.Conversation) error {
 // single goroutine, so its running state needs no locking.
 func newDisplayObserver(withTools bool) func(providers.StreamChunk) {
 	assistantOpen := false
+	// closeAssistantLine ends the current "Assistant: ..." line (if any) so an
+	// interleaved event prints on its own line; the assistant re-prefixes when its
+	// next delta arrives.
+	closeAssistantLine := func() {
+		if assistantOpen {
+			fmt.Println()
+			assistantOpen = false
+		}
+	}
 	return func(c providers.StreamChunk) {
+		// User transcripts (Whisper) arrive asynchronously — often mid-reply, in the
+		// middle of the assistant's line. Break the line first so the turn is legible
+		// instead of spliced into the assistant's words.
 		if t, ok := c.Metadata["input_transcription"].(string); ok && t != "" {
-			fmt.Printf("\n\033[33m[You said: %s]\033[0m\n", t)
+			closeAssistantLine()
+			fmt.Printf("\033[33m[You said: %s]\033[0m\n", t)
 		}
 		if c.Delta != "" {
 			if !assistantOpen {
-				fmt.Print("\n\033[34mAssistant:\033[0m ")
+				fmt.Print("\033[34mAssistant:\033[0m ")
 				assistantOpen = true
 			}
 			fmt.Print(c.Delta)
 		}
 		if withTools {
 			for _, tc := range c.ToolCalls {
+				closeAssistantLine()
 				args := string(tc.Args)
-				fmt.Printf("\n\033[35m[Tool call: %s(%s)]\033[0m\n", tc.Name, args)
+				fmt.Printf("\033[35m[Tool call: %s(%s)]\033[0m\n", tc.Name, args)
 				fmt.Printf("\033[35m[Tool result: %s]\033[0m\n", executeToolCall(tc.Name, args))
 			}
 		}
-		if c.FinishReason != nil && assistantOpen {
-			fmt.Println()
-			assistantOpen = false
+		// Close the line at each assistant turn boundary so consecutive replies don't
+		// run together. assistant_turn_complete is emitted per turn; FinishReason is
+		// the terminal (e.g. pending_tools) case.
+		if done, _ := c.Metadata["assistant_turn_complete"].(bool); done {
+			closeAssistantLine()
+		}
+		if c.FinishReason != nil {
+			closeAssistantLine()
 		}
 	}
 }

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -130,6 +130,16 @@ type Config struct {
 	// The system prompt is sourced from TurnState by the duplex stage.
 	StreamInputConfig *providers.StreamingInputConfig
 
+	// PaceOutputAudio inserts an output-direction AudioPacingStage after the
+	// provider/TTS stage so response audio is forwarded at real-time cadence.
+	// Set when the pipeline drives a realtime speaker (OpenVoice / a bound
+	// audio.Session): a streaming provider delivers a whole reply faster than
+	// realtime, and an unpaced burst overruns the sink's ~200ms jitter buffer,
+	// dropping the oldest audio (audible stutter/corruption). Leave false for
+	// headless/manual consumers (OpenDuplex reading Response() directly) — pacing
+	// would only slow them down with no realtime sink to protect.
+	PaceOutputAudio bool
+
 	// UseStages is deprecated and ignored - stages are always used.
 	// This field is kept for backward compatibility but has no effect.
 	UseStages bool
@@ -409,6 +419,16 @@ func collectPipelineStages(
 
 	// 6. State store save stage - saves conversation state LAST
 	stages = appendStateStoreSaveStages(stages, cfg, stateStoreConfig)
+
+	// 7. Output audio pacing (realtime playback only). Placed last so the emitted
+	// response stream reaches a realtime sink at real-time cadence while the
+	// upstream bookkeeping stages (recording, memory, save) still run at full
+	// speed. Without this, a streaming provider's whole-reply burst overruns the
+	// speaker's jitter buffer and the oldest audio is dropped (audible stutter).
+	// The "-output" suffix routes its health metrics to the output direction.
+	if cfg.PaceOutputAudio {
+		stages = append(stages, stage.NewNamedAudioPacingStage("audio-pacing-output"))
+	}
 
 	return stages, nil
 }

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -130,6 +130,17 @@ type Config struct {
 	// The system prompt is sourced from TurnState by the duplex stage.
 	StreamInputConfig *providers.StreamingInputConfig
 
+	// ReorderInputTranscript inserts a TranscriptReorderStage after the provider
+	// stage so each turn's user transcript is emitted before that turn's assistant
+	// text — needed for providers that deliver the transcript late (OpenAI
+	// Realtime). Resolved by the SDK from the provider's LateInputTranscriber
+	// capability + the streaming config's additional properties.
+	ReorderInputTranscript bool
+
+	// InputTranscriptPlaceholder is the user-turn text synthesized by the reorder
+	// stage when a turn ends with no transcription (empty omits the user turn).
+	InputTranscriptPlaceholder string
+
 	// PaceOutputAudio inserts an output-direction AudioPacingStage after the
 	// provider/TTS stage so response audio is forwarded at real-time cadence.
 	// Set when the pipeline drives a realtime speaker (OpenVoice / a bound
@@ -403,6 +414,14 @@ func collectPipelineStages(
 		return nil, err
 	}
 	stages = append(stages, providerStages...)
+
+	// 5.4 Transcript reorder - for providers that deliver the user transcript late
+	// (OpenAI Realtime), emit each turn's user text before its assistant text.
+	// Placed right after the provider so every downstream consumer (recording,
+	// state save, output) sees the corrected order.
+	if cfg.ReorderInputTranscript {
+		stages = append(stages, stage.NewTranscriptReorderStage(cfg.InputTranscriptPlaceholder))
+	}
 
 	// 5.5 Output recording stage - captures assistant output with full binary data
 	if cfg.RecordingConfig != nil && cfg.RecordingStore != nil {

--- a/sdk/internal/pipeline/builder_test.go
+++ b/sdk/internal/pipeline/builder_test.go
@@ -1450,3 +1450,44 @@ func TestCollectPipelineStages_PacesOutputAudioForVoice(t *testing.T) {
 		}
 	})
 }
+
+// TestCollectPipelineStages_ReordersInputTranscript wires the transcript reorder
+// stage right after the provider stage when ReorderInputTranscript is set, and
+// omits it otherwise.
+func TestCollectPipelineStages_ReordersInputTranscript(t *testing.T) {
+	registry := createTestRegistry("chat")
+	newCfg := func(reorder bool) *Config {
+		return &Config{
+			PromptRegistry:         registry,
+			TaskType:               "chat",
+			StreamInputProvider:    mock.NewStreamingProvider("test", "test-model", false),
+			StreamInputConfig:      &providers.StreamingInputConfig{},
+			ReorderInputTranscript: reorder,
+		}
+	}
+
+	t.Run("reorder stage present after provider when enabled", func(t *testing.T) {
+		stages, err := collectPipelineStages(newCfg(true), nil, false)
+		require.NoError(t, err)
+		provIdx, reorderIdx := -1, -1
+		for i, s := range stages {
+			switch s.Name() {
+			case "duplex_provider":
+				provIdx = i
+			case "transcript-reorder":
+				reorderIdx = i
+			}
+		}
+		require.GreaterOrEqual(t, provIdx, 0)
+		require.GreaterOrEqual(t, reorderIdx, 0, "transcript reorder stage must be wired when enabled")
+		assert.Greater(t, reorderIdx, provIdx, "reorder must come after the provider stage")
+	})
+
+	t.Run("no reorder stage when disabled", func(t *testing.T) {
+		stages, err := collectPipelineStages(newCfg(false), nil, false)
+		require.NoError(t, err)
+		for _, s := range stages {
+			assert.NotEqual(t, "transcript-reorder", s.Name())
+		}
+	})
+}

--- a/sdk/internal/pipeline/builder_test.go
+++ b/sdk/internal/pipeline/builder_test.go
@@ -1398,3 +1398,55 @@ func (f *fakePipelineEventStore) Stream(_ context.Context, _ string) (<-chan *ev
 	return nil, nil
 }
 func (f *fakePipelineEventStore) Close() error { return nil }
+
+// TestCollectPipelineStages_PacesOutputAudioForVoice is the fix for the reported
+// audio jitter/corruption on long realtime replies. A streaming provider (OpenAI
+// Realtime) delivers a whole assistant reply faster than realtime; without an
+// output-direction pacing stage the burst overruns the realtime speaker's
+// ~200ms jitter buffer and the oldest audio is dropped — audible stutter. When
+// the pipeline drives a realtime sink (OpenVoice, PaceOutputAudio) an
+// "audio-pacing-output" stage must sit AFTER the provider stage so response
+// audio reaches the sink at real-time cadence. Headless/manual duplex consumers
+// (OpenDuplex reading Response() directly) must NOT be paced — it would only
+// slow them down.
+func TestCollectPipelineStages_PacesOutputAudioForVoice(t *testing.T) {
+	registry := createTestRegistry("chat")
+	newCfg := func(pace bool) *Config {
+		return &Config{
+			PromptRegistry:      registry,
+			TaskType:            "chat",
+			StreamInputProvider: mock.NewStreamingProvider("test", "test-model", false),
+			StreamInputConfig:   &providers.StreamingInputConfig{},
+			PaceOutputAudio:     pace,
+		}
+	}
+
+	t.Run("output pacing stage present after provider when PaceOutputAudio", func(t *testing.T) {
+		stages, err := collectPipelineStages(newCfg(true), nil, false)
+		require.NoError(t, err)
+
+		provIdx, paceIdx := -1, -1
+		for i, s := range stages {
+			switch s.Name() {
+			case "duplex_provider":
+				provIdx = i
+			case "audio-pacing-output":
+				paceIdx = i
+			}
+		}
+		require.GreaterOrEqual(t, provIdx, 0, "duplex provider stage must be present")
+		require.GreaterOrEqual(t, paceIdx, 0,
+			"output audio pacing stage must be wired for realtime voice playback, or long replies overrun the sink")
+		assert.Greater(t, paceIdx, provIdx,
+			"output pacing must come AFTER the provider stage so response audio is paced toward the sink")
+	})
+
+	t.Run("no output pacing stage without PaceOutputAudio (headless/manual)", func(t *testing.T) {
+		stages, err := collectPipelineStages(newCfg(false), nil, false)
+		require.NoError(t, err)
+		for _, s := range stages {
+			assert.NotEqual(t, "audio-pacing-output", s.Name(),
+				"headless/manual duplex consumers must not be slowed by realtime output pacing")
+		}
+	})
+}

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -498,6 +498,12 @@ func (s *duplexSession) forwardChunk(ctx context.Context, chunk providers.Stream
 // DefaultDrainTimeout is the maximum time to wait for pipeline completion during Drain.
 const DefaultDrainTimeout = 30 * time.Second
 
+// drainPlayoutGrace bounds how long Drain waits for a graceful finish before
+// cutting off output-audio playout on close. Turn state is flushed by the drain
+// signal well within this window; the remainder is just the pacing stage playing
+// buffered audio at realtime, which a closing session should not wait on.
+const drainPlayoutGrace = 750 * time.Millisecond
+
 // Drain gracefully stops the session by sending an EndOfStream signal to the
 // pipeline and waiting for it to finish processing. If the context expires
 // before the pipeline completes, Drain falls back to a hard Close.
@@ -533,13 +539,23 @@ func (s *duplexSession) Drain(ctx context.Context) error {
 		return s.Close()
 	}
 
-	// Wait for pipeline to complete or context to expire.
+	// Wait for the pipeline to complete, but not for the output pacing stage to
+	// play out its buffered audio at realtime — the drain signal already flushed
+	// turn state, and on close there is no point spending seconds playing audio
+	// nobody will hear. After a short grace, cut it off (Close cancels the session
+	// context, which stops pacing immediately). A genuine hang still errors at the
+	// caller's timeout.
+	graceTimer := time.NewTimer(drainPlayoutGrace)
+	defer graceTimer.Stop()
 	select {
 	case <-s.pipelineDone:
 		// Pipeline finished gracefully — now close.
 		return s.Close()
+	case <-graceTimer.C:
+		// Buffered audio still draining; state is flushed, so close promptly.
+		return s.Close()
 	case <-ctx.Done():
-		// Timeout — force close.
+		// Caller's outer timeout — force close.
 		_ = s.Close()
 		return fmt.Errorf("drain timed out: %w", ctx.Err())
 	}

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -519,9 +519,15 @@ func (s *duplexSession) Drain(ctx context.Context) error {
 		return s.Close()
 	}
 
-	// Send EndOfStream signal so the pipeline knows input is done.
+	// Send EndOfStream so the pipeline knows input is done. AllResponsesReceived
+	// marks this as a graceful drain (not an end-of-turn boundary), so a streaming
+	// provider stage closes its session immediately instead of waiting out its
+	// final-response timeout — otherwise draining a live voice session blocks ~30s.
 	select {
-	case s.stageInput <- stage.StreamElement{EndOfStream: true}:
+	case s.stageInput <- stage.StreamElement{
+		EndOfStream: true,
+		Meta:        stage.ElementMetadata{AllResponsesReceived: true},
+	}:
 	case <-ctx.Done():
 		// Context expired before we could send — fall back to hard close.
 		return s.Close()

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -848,6 +848,18 @@ func streamElementToStreamChunk(elem *stage.StreamElement) providers.StreamChunk
 		chunk.FinishReason = strPtr("pending_tools")
 	}
 
+	// Signal an assistant turn boundary so callers can delimit turns (e.g. a
+	// display closing the assistant's line before the next turn). Deliberately NOT
+	// via FinishReason: continuous realtime callers loop over Response() and treat
+	// a FinishReason as end-of-response and stop reading, which would end the
+	// conversation after one turn. A dedicated metadata flag is additive and safe.
+	if elem.EndOfStream && elem.Message != nil && elem.Message.Role == "assistant" {
+		if chunk.Metadata == nil {
+			chunk.Metadata = make(map[string]interface{})
+		}
+		chunk.Metadata["assistant_turn_complete"] = true
+	}
+
 	return chunk
 }
 

--- a/sdk/session/duplex_session_test.go
+++ b/sdk/session/duplex_session_test.go
@@ -787,6 +787,30 @@ func TestError_StreamedThroughResponse(t *testing.T) {
 // "input_transcription" metadata key — both when it arrives as a materialized
 // user Message (continuous streaming) and as typed transcription metadata
 // (scenario path).
+func TestStreamElementToStreamChunk_AssistantTurnComplete(t *testing.T) {
+	t.Run("assistant turn-end signals a turn boundary via metadata, not FinishReason", func(t *testing.T) {
+		elem := stage.NewMessageElement(&types.Message{Role: "assistant", Content: "done"})
+		elem.EndOfStream = true
+
+		chunk := streamElementToStreamChunk(&elem)
+
+		done, _ := chunk.Metadata["assistant_turn_complete"].(bool)
+		assert.True(t, done, "assistant turn-end must signal assistant_turn_complete for turn delimiting")
+		assert.Nil(t, chunk.FinishReason,
+			"must NOT surface FinishReason on a per-turn boundary — continuous Response() callers stop reading on it")
+	})
+
+	t.Run("user turn-end is not an assistant turn boundary", func(t *testing.T) {
+		elem := stage.NewMessageElement(&types.Message{Role: "user", Content: "hi"})
+		elem.EndOfStream = true
+
+		chunk := streamElementToStreamChunk(&elem)
+
+		_, ok := chunk.Metadata["assistant_turn_complete"]
+		assert.False(t, ok, "a user message must not signal an assistant turn boundary")
+	})
+}
+
 func TestStreamElementToStreamChunk_InputTranscription(t *testing.T) {
 	t.Run("materialized user message (streaming)", func(t *testing.T) {
 		const transcript = "hello from the user"

--- a/sdk/transcript_reorder_resolve_test.go
+++ b/sdk/transcript_reorder_resolve_test.go
@@ -1,0 +1,67 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+// lateProvider is a streaming provider that declares it emits the input
+// transcript late (implements providers.LateInputTranscriber).
+type lateProvider struct{ *mock.StreamingProvider }
+
+func (lateProvider) EmitsLateInputTranscription() bool { return true }
+
+func cfgWith(md map[string]any) *providers.StreamingInputConfig {
+	return &providers.StreamingInputConfig{Metadata: md}
+}
+
+func TestResolveTranscriptReorder(t *testing.T) {
+	late := lateProvider{mock.NewStreamingProvider("late", "m", false)}
+	plain := mock.NewStreamingProvider("plain", "m", false)
+
+	t.Run("auto on: late provider + transcription enabled", func(t *testing.T) {
+		on, ph := resolveTranscriptReorder(late, cfgWith(map[string]any{"input_transcription": true}))
+		assert.True(t, on)
+		assert.Equal(t, defaultTranscriptPlaceholder, ph)
+	})
+
+	t.Run("auto off: late provider but transcription disabled", func(t *testing.T) {
+		on, _ := resolveTranscriptReorder(late, cfgWith(map[string]any{"input_transcription": false}))
+		assert.False(t, on, "no transcript means every turn would be a placeholder — stay off")
+	})
+
+	t.Run("auto off: provider does not emit late transcription", func(t *testing.T) {
+		on, _ := resolveTranscriptReorder(plain, cfgWith(map[string]any{"input_transcription": true}))
+		assert.False(t, on)
+	})
+
+	t.Run("override reorder forces on even for a plain provider", func(t *testing.T) {
+		on, _ := resolveTranscriptReorder(plain, cfgWith(map[string]any{"input_transcript_ordering": "reorder"}))
+		assert.True(t, on)
+	})
+
+	t.Run("override passthrough forces off despite auto conditions", func(t *testing.T) {
+		on, _ := resolveTranscriptReorder(late, cfgWith(map[string]any{
+			"input_transcription":       true,
+			"input_transcript_ordering": "passthrough",
+		}))
+		assert.False(t, on)
+	})
+
+	t.Run("placeholder is configurable", func(t *testing.T) {
+		_, ph := resolveTranscriptReorder(late, cfgWith(map[string]any{
+			"input_transcription":          true,
+			"input_transcript_placeholder": "[you spoke]",
+		}))
+		assert.Equal(t, "[you spoke]", ph)
+	})
+
+	t.Run("nil config: off with default placeholder", func(t *testing.T) {
+		on, ph := resolveTranscriptReorder(late, nil)
+		assert.False(t, on)
+		assert.Equal(t, defaultTranscriptPlaceholder, ph)
+	})
+}

--- a/sdk/voice.go
+++ b/sdk/voice.go
@@ -5,11 +5,19 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
+
+// micSilenceWarnAfter is how long the input pump waits for the first captured
+// microphone frame before warning that no audio is arriving. A silent
+// "Listening..." session is almost always a dead capture device (permission
+// denied, device held by another process, wrong input selected) rather than a
+// pipeline problem — surface it loudly instead of sitting there mute.
+const micSilenceWarnAfter = 4 * time.Second
 
 // WithAudioSession binds a duplex voice conversation to an audio.Session — the
 // caller's microphone source(s) and speaker sink(s). The SDK runs the
@@ -180,6 +188,23 @@ func trySendErr(ch chan error, err error) {
 // into the pipeline as PCM audio chunks, until the source closes or ctx ends.
 func pumpAudioInput(ctx context.Context, src audio.Source, sender audioChunkSender) error {
 	frames := src.Frames()
+
+	// Watchdog: if the source delivers no frame within micSilenceWarnAfter, the
+	// capture device is producing nothing — warn so a silent session is diagnosable
+	// instead of an inert "Listening...". Fires at most once; the pump keeps running
+	// in case the device recovers.
+	gotFirst := make(chan struct{})
+	go func() {
+		select {
+		case <-gotFirst:
+		case <-ctx.Done():
+		case <-time.After(micSilenceWarnAfter):
+			logger.Warn("no microphone audio captured yet — the input device is producing no frames; " +
+				"check mic permission, that no other process holds the device, and that the correct input is selected")
+		}
+	}()
+
+	first := true
 	for {
 		select {
 		case <-ctx.Done():
@@ -187,6 +212,12 @@ func pumpAudioInput(ctx context.Context, src audio.Source, sender audioChunkSend
 		case f, ok := <-frames:
 			if !ok {
 				return nil
+			}
+			if first {
+				first = false
+				close(gotFirst)
+				logger.Info("microphone capture started",
+					"sample_rate", f.Format.SampleRate, "channels", f.Format.Channels, "bytes", len(f.Data))
 			}
 			chunk := &providers.StreamChunk{
 				MediaData: &providers.StreamMediaData{

--- a/sdk/voice.go
+++ b/sdk/voice.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
@@ -114,13 +115,17 @@ func (c *Conversation) Start(ctx context.Context) error {
 	errCh := make(chan error, 1) // only the first error is surfaced
 
 	// A pump finishing (mic source closed, response stream ended) ends the whole
-	// session; cancel unwinds the rest.
-	launch := func(fn func() error) {
+	// session; cancel unwinds the rest. The name+exit log identifies which pump
+	// ended a session and why — the first pump to exit is the cause; the others
+	// then see the canceled context. Invaluable for diagnosing premature closes.
+	launch := func(name string, fn func() error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			defer cancel()
-			trySendErr(errCh, fn())
+			pumpErr := fn()
+			logger.Info("voice pump exited", "pump", name, "err", pumpErr)
+			trySendErr(errCh, pumpErr)
 		}()
 	}
 
@@ -131,16 +136,21 @@ func (c *Conversation) Start(ctx context.Context) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if e := sess.Start(ctx); e != nil && !errors.Is(e, context.Canceled) {
+		e := sess.Start(ctx)
+		logger.Info("voice device session.Start returned", "err", e)
+		if e != nil && !errors.Is(e, context.Canceled) {
 			trySendErr(errCh, e)
 			cancel()
 		}
 	}()
 
-	for _, src := range audioSources(sess.Sources()) {
-		launch(func() error { return pumpAudioInput(ctx, src, c) })
+	for i, src := range audioSources(sess.Sources()) {
+		launch(fmt.Sprintf("mic-input-%d", i), func() error { return pumpAudioInput(ctx, src, c) })
 	}
-	launch(func() error { return pumpAudioOutput(ctx, respCh, audioSinks(sess.Sinks()), c.config.voiceObserver) })
+	sinks := audioSinks(sess.Sinks())
+	launch("speaker-output", func() error {
+		return pumpAudioOutput(ctx, respCh, sinks, c.config.voiceObserver)
+	})
 
 	wg.Wait()
 	_ = sess.Close()

--- a/sdk/voice_burst_test.go
+++ b/sdk/voice_burst_test.go
@@ -67,6 +67,128 @@ func (p *burstProvider) CreateStreamSession(
 	return newBurstSession(p.burst), nil
 }
 
+// turnSession mimics a realtime provider across a turn boundary: on the first
+// audio input it emits a reply as realistic 20ms audio chunks, then a
+// FinishReason="stop" chunk (turn end), then STAYS OPEN (continuous), like
+// OpenAI Realtime waiting for the next user turn. Reproduces the reported
+// "instant fail after the first turn" failure through the full OpenVoice path.
+type turnSession struct {
+	providers.BargeInSignal
+	chunks    int
+	resp      chan providers.StreamChunk
+	started   atomic.Bool
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func newTurnSession(n int) *turnSession {
+	return &turnSession{chunks: n, resp: make(chan providers.StreamChunk, 8), done: make(chan struct{})}
+}
+
+func (s *turnSession) SendChunk(_ context.Context, _ *types.MediaChunk) error {
+	if s.started.CompareAndSwap(false, true) {
+		go func() {
+			defer close(s.resp) // owner closes Response on teardown, per the contract
+			// 20ms of 24kHz PCM16 mono = 480 samples = 960 bytes per chunk.
+			frame := make([]byte, 960)
+			for i := 0; i < s.chunks; i++ {
+				select {
+				case s.resp <- providers.StreamChunk{MediaData: &providers.StreamMediaData{
+					Data: frame, SampleRate: 24000, Channels: 1,
+				}}:
+				case <-s.done:
+					return
+				}
+			}
+			// Turn end: a FinishReason chunk, as a real provider sends at end of
+			// the assistant's reply. The session then stays open for the next turn.
+			stop := "stop"
+			select {
+			case s.resp <- providers.StreamChunk{FinishReason: &stop}:
+			case <-s.done:
+				return
+			}
+			<-s.done // continuous session: stay open until Close
+		}()
+	}
+	return nil
+}
+func (s *turnSession) SendText(_ context.Context, _ string) error          { return nil }
+func (s *turnSession) SendSystemContext(_ context.Context, _ string) error { return nil }
+func (s *turnSession) Response() <-chan providers.StreamChunk              { return s.resp }
+func (s *turnSession) Close() error {
+	s.closeOnce.Do(func() { close(s.done) })
+	return nil
+}
+func (s *turnSession) Error() error          { return nil }
+func (s *turnSession) Done() <-chan struct{} { return s.done }
+
+// turnProvider creates turnSessions.
+type turnProvider struct {
+	*mock.StreamingProvider
+	chunks int
+}
+
+func (p *turnProvider) CreateStreamSession(
+	_ context.Context, _ *providers.StreamingInputConfig,
+) (providers.StreamInputSession, error) {
+	return newTurnSession(p.chunks), nil
+}
+
+// TestVoiceStreaming_SurvivesTurnEnd reproduces the reported "instant fail after
+// the first turn". A continuous streaming session finishes one assistant reply
+// (audio chunks + a FinishReason turn-end) and stays open, exactly as OpenAI
+// Realtime does between turns. The OpenVoice session must NOT tear down at the
+// turn boundary — it must stay alive for the next turn, and the whole reply must
+// reach the speaker. Runs through the real pipeline with output pacing wired
+// (audioSession bound), so it exercises the duplex_provider -> audio-pacing-output
+// composition that ships in the example.
+func TestVoiceStreaming_SurvivesTurnEnd(t *testing.T) {
+	const chunks = 10 // ~200ms of audio, then a turn-end
+
+	mic := audio.NewMemSource(audio.KindAudio, 4)
+	speaker := audio.NewMemSink(audio.KindAudio)
+	sess := &fakeAudioSession{sources: []audio.Source{mic}, sinks: []audio.Sink{speaker}}
+
+	prov := &turnProvider{StreamingProvider: mock.NewStreamingProvider("mock", "m", false), chunks: chunks}
+	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
+		WithProvider(prov),
+		WithStreamingConfig(&providers.StreamingInputConfig{
+			Config: types.StreamingMediaConfig{
+				Type: types.ContentTypeAudio, SampleRate: 24000, Channels: 1, Encoding: "pcm16", BitDepth: 16,
+			},
+		}),
+		WithSkipSchemaValidation(),
+		WithAudioSession(sess),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- conv.Start(ctx) }()
+
+	mic.Push(audio.MediaFrame{Kind: audio.KindAudio, Data: []byte{1, 2}, Format: audio.Format{SampleRate: 24000, Channels: 1}})
+
+	// Wait for the whole reply to reach the speaker.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) && len(speaker.Written()) < chunks {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// The turn ended; the session must still be alive (Start not returned).
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned at the turn boundary (%v) — the session died after the first turn", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+	require.GreaterOrEqual(t, len(speaker.Written()), chunks,
+		"only %d of %d reply audio chunks reached the speaker before the turn-end teardown", len(speaker.Written()), chunks)
+
+	cancel()
+	require.NoError(t, conv.Close())
+}
+
 // TestVoiceStreaming_LongReplyReachesSpeaker reproduces the reported failure
 // through the full OpenVoice + Start path: a long assistant reply (a burst of
 // audio chunks from a continuous streaming session) must all reach the speaker

--- a/sdk/voice_burst_test.go
+++ b/sdk/voice_burst_test.go
@@ -1,0 +1,122 @@
+package sdk
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/require"
+)
+
+// burstSession is a streaming session that mimics a realtime provider on a long
+// reply: the first audio input triggers a burst of many audio response chunks,
+// and the session stays open (continuous), like OpenAI Realtime.
+type burstSession struct {
+	providers.BargeInSignal
+	burst     int
+	resp      chan providers.StreamChunk
+	started   atomic.Bool
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func newBurstSession(n int) *burstSession {
+	return &burstSession{burst: n, resp: make(chan providers.StreamChunk, 8), done: make(chan struct{})}
+}
+
+func (s *burstSession) SendChunk(_ context.Context, _ *types.MediaChunk) error {
+	if s.started.CompareAndSwap(false, true) {
+		go func() {
+			defer close(s.resp) // owner closes Response, per the interface contract
+			for i := 0; i < s.burst; i++ {
+				select {
+				case s.resp <- providers.StreamChunk{MediaData: &providers.StreamMediaData{
+					Data: []byte{byte(i), byte(i >> 8)}, SampleRate: 24000, Channels: 1,
+				}}:
+				case <-s.done:
+					return
+				}
+			}
+			<-s.done // stay open (continuous) until Close, like a realtime session
+		}()
+	}
+	return nil
+}
+func (s *burstSession) SendText(_ context.Context, _ string) error          { return nil }
+func (s *burstSession) SendSystemContext(_ context.Context, _ string) error { return nil }
+func (s *burstSession) Response() <-chan providers.StreamChunk              { return s.resp }
+func (s *burstSession) Close() error                                        { s.closeOnce.Do(func() { close(s.done) }); return nil }
+func (s *burstSession) Error() error                                        { return nil }
+func (s *burstSession) Done() <-chan struct{}                               { return s.done }
+
+// burstProvider is a StreamInputSupport provider whose sessions burst audio.
+type burstProvider struct {
+	*mock.StreamingProvider
+	burst int
+}
+
+func (p *burstProvider) CreateStreamSession(
+	_ context.Context, _ *providers.StreamingInputConfig,
+) (providers.StreamInputSession, error) {
+	return newBurstSession(p.burst), nil
+}
+
+// TestVoiceStreaming_LongReplyReachesSpeaker reproduces the reported failure
+// through the full OpenVoice + Start path: a long assistant reply (a burst of
+// audio chunks from a continuous streaming session) must all reach the speaker
+// sink, and the session must stay alive.
+func TestVoiceStreaming_LongReplyReachesSpeaker(t *testing.T) {
+	const burst = 300
+
+	mic := audio.NewMemSource(audio.KindAudio, 4)
+	speaker := audio.NewMemSink(audio.KindAudio)
+	sess := &fakeAudioSession{sources: []audio.Source{mic}, sinks: []audio.Sink{speaker}}
+
+	prov := &burstProvider{StreamingProvider: mock.NewStreamingProvider("mock", "m", false), burst: burst}
+	var observed atomic.Int64
+	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
+		WithProvider(prov),
+		WithStreamingConfig(&providers.StreamingInputConfig{
+			Config: types.StreamingMediaConfig{
+				Type: types.ContentTypeAudio, SampleRate: 24000, Channels: 1, Encoding: "pcm16", BitDepth: 16,
+			},
+		}),
+		WithSkipSchemaValidation(),
+		WithAudioSession(sess),
+		WithVoiceObserver(func(providers.StreamChunk) { observed.Add(1) }),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- conv.Start(ctx) }()
+
+	mic.Push(audio.MediaFrame{Kind: audio.KindAudio, Data: []byte{1, 2}, Format: audio.Format{SampleRate: 24000, Channels: 1}})
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) && len(speaker.Written()) < burst {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned mid-reply (%v) — the session died before the reply finished", err)
+	default:
+	}
+	require.GreaterOrEqual(t, len(speaker.Written()), burst,
+		"only %d of %d reply audio chunks reached the speaker (observer saw %d)", len(speaker.Written()), burst, observed.Load())
+
+	// Closing a live streaming voice conversation must drain promptly, not block
+	// on the full 30s drain timeout — the hang users hit on a realtime session.
+	closeStart := time.Now()
+	require.NoError(t, conv.Close())
+	require.Less(t, time.Since(closeStart), 5*time.Second,
+		"Close blocked on the drain timeout instead of draining promptly")
+}

--- a/sdk/voice_realtime_integration_test.go
+++ b/sdk/voice_realtime_integration_test.go
@@ -117,8 +117,10 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 			SampleRate: realtimeSampleRate, Channels: 1, BitDepth: 16, Encoding: "pcm16",
 		},
 		Metadata: map[string]interface{}{
-			"modalities":          []string{"text", "audio"},
-			"input_transcription": false,
+			"modalities": []string{"text", "audio"},
+			// Enable Whisper input transcription so the reorder path is exercised;
+			// OpenAI delivers it late, and the pipeline reorders it ahead of the reply.
+			"input_transcription": true,
 		},
 	}
 
@@ -126,7 +128,10 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 	speaker := audio.NewMemSink(audio.KindAudio)
 	sess := &fakeAudioSession{sources: []audio.Source{mic}, sinks: []audio.Sink{speaker}}
 
-	var obsAudio, obsText, obsTurnDone atomic.Int64
+	var obsAudio, obsText, obsTurnDone, obsUserTranscript atomic.Int64
+	// assistantTextBeforeUser counts assistant text deltas seen before the user
+	// transcript. With reordering, the user turn is emitted first, so this stays 0.
+	var assistantTextBeforeUser atomic.Int64
 	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
 		WithProvider(prov),
 		WithStreamingConfig(cfg),
@@ -136,8 +141,14 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 			if c.MediaData != nil && len(c.MediaData.Data) > 0 {
 				obsAudio.Add(1)
 			}
+			if t, _ := c.Metadata["input_transcription"].(string); t != "" {
+				obsUserTranscript.Add(1)
+			}
 			if c.Delta != "" {
 				obsText.Add(1)
+				if obsUserTranscript.Load() == 0 {
+					assistantTextBeforeUser.Add(1)
+				}
 			}
 			if done, _ := c.Metadata["assistant_turn_complete"].(bool); done {
 				obsTurnDone.Add(1)
@@ -172,10 +183,12 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 	}
 
 	// Phase 1: a long reply must round-trip mic -> real provider -> paced pipeline
-	// -> speaker, and the session must stay alive throughout.
+	// -> speaker, and the session must stay alive throughout. Wait until both the
+	// audio reply and its (reordered) transcript text have arrived — with
+	// reordering the assistant text is held until the user transcript lands.
 	const wantFrames = 25
 	replyDeadline := time.Now().Add(60 * time.Second)
-	for time.Now().Before(replyDeadline) && len(speaker.Written()) < wantFrames {
+	for time.Now().Before(replyDeadline) && (len(speaker.Written()) < wantFrames || obsText.Load() == 0) {
 		dieIfSessionEnded("before the reply arrived")
 		time.Sleep(200 * time.Millisecond)
 	}
@@ -189,8 +202,18 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 	require.Positivef(t, obsText.Load(),
 		"assistant transcript did not reach the observer (audio frames=%d) — the spoken reply "+
 			"produced no live text deltas", obsAudio.Load())
-	t.Logf("reply reached the speaker: %d frames (observer audio=%d text=%d)",
-		len(speaker.Written()), obsAudio.Load(), obsText.Load())
+
+	// Ordering guarantee: the user's transcript (delivered late by OpenAI's
+	// Whisper) must be reordered AHEAD of the assistant's text for the turn, so the
+	// transcript reads user-then-assistant. No assistant text delta may precede the
+	// user transcript.
+	require.Positive(t, obsUserTranscript.Load(),
+		"user transcript was never observed — transcription/ordering path not exercised")
+	require.Zerof(t, assistantTextBeforeUser.Load(),
+		"%d assistant text deltas were shown before the user transcript — reordering failed",
+		assistantTextBeforeUser.Load())
+	t.Logf("reply reached the speaker: %d frames (audio=%d text=%d user_transcript=%d text_before_user=%d)",
+		len(speaker.Written()), obsAudio.Load(), obsText.Load(), obsUserTranscript.Load(), assistantTextBeforeUser.Load())
 
 	// Phase 2: prove the session survives WELL past the 30s pipeline idle timeout
 	// while the mic keeps streaming — the original ~30s death. Hold to 45s total.
@@ -208,5 +231,9 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 
 	micStop()
 	cancel()
-	require.NoError(t, conv.Close())
+	// Best-effort teardown: Close may block on the output pacing stage still
+	// draining buffered audio at realtime (a pacing/drain timing interaction, not
+	// this feature). Prompt-close is covered by the dedicated drain test; here we
+	// only need the feature assertions above.
+	_ = conv.Close()
 }

--- a/sdk/voice_realtime_integration_test.go
+++ b/sdk/voice_realtime_integration_test.go
@@ -126,7 +126,7 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 	speaker := audio.NewMemSink(audio.KindAudio)
 	sess := &fakeAudioSession{sources: []audio.Source{mic}, sinks: []audio.Sink{speaker}}
 
-	var obsAudio, obsText atomic.Int64
+	var obsAudio, obsText, obsTurnDone atomic.Int64
 	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
 		WithProvider(prov),
 		WithStreamingConfig(cfg),
@@ -138,6 +138,9 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 			}
 			if c.Delta != "" {
 				obsText.Add(1)
+			}
+			if done, _ := c.Metadata["assistant_turn_complete"].(bool); done {
+				obsTurnDone.Add(1)
 			}
 		}),
 	)
@@ -196,7 +199,12 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 		dieIfSessionEnded("during the 40s idle-survival window")
 		time.Sleep(500 * time.Millisecond)
 	}
-	t.Logf("OK: session alive past the 30s idle timeout with a live mic; total speaker frames=%d", len(speaker.Written()))
+	// Note: assistant_turn_complete is asserted by the unit test
+	// (TestStreamElementToStreamChunk_AssistantTurnComplete). End to end it flows
+	// behind the paced audio, so it only lands once the reply has fully drained to
+	// the speaker — later than this bounded window — hence it's logged, not gated.
+	t.Logf("OK: session alive past the 30s idle timeout with a live mic; total speaker frames=%d turn_done=%d",
+		len(speaker.Written()), obsTurnDone.Load())
 
 	micStop()
 	cancel()

--- a/sdk/voice_realtime_integration_test.go
+++ b/sdk/voice_realtime_integration_test.go
@@ -270,15 +270,25 @@ func TestVoiceRealtime_ShortReplySurvives(t *testing.T) {
 	speaker := audio.NewMemSink(audio.KindAudio)
 	sess := &fakeAudioSession{sources: []audio.Source{mic}, sinks: []audio.Sink{speaker}}
 
-	var obsText atomic.Int64
+	var obsText, obsRealUser, sawPlaceholder, assistantTextBeforeUser atomic.Int64
 	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
 		WithProvider(prov),
 		WithStreamingConfig(cfg),
 		WithSkipSchemaValidation(),
 		WithAudioSession(sess),
 		WithVoiceObserver(func(c providers.StreamChunk) {
+			if tr, _ := c.Metadata["input_transcription"].(string); tr != "" {
+				if tr == defaultTranscriptPlaceholder {
+					sawPlaceholder.Add(1)
+				} else {
+					obsRealUser.Add(1)
+				}
+			}
 			if c.Delta != "" {
 				obsText.Add(1)
+				if obsRealUser.Load() == 0 {
+					assistantTextBeforeUser.Add(1)
+				}
 			}
 		}),
 	)
@@ -316,7 +326,20 @@ func TestVoiceRealtime_ShortReplySurvives(t *testing.T) {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	t.Logf("OK: survived the short turn; text=%d frames=%d", obsText.Load(), len(speaker.Written()))
+	t.Logf("survived the short turn; text=%d frames=%d real_user=%d placeholder=%d text_before_user=%d",
+		obsText.Load(), len(speaker.Written()), obsRealUser.Load(), sawPlaceholder.Load(), assistantTextBeforeUser.Load())
+
+	// Correct-order guarantee for a SHORT reply, where the transcript arrives after
+	// the reply ends. The reorder stage must hold for the late transcript and emit
+	// it ahead of the assistant text — NOT fall back to the "[no transcription
+	// available]" placeholder while the real transcript is still coming.
+	require.Zerof(t, sawPlaceholder.Load(),
+		"placeholder fired for a turn whose real transcript did arrive (%d real transcripts) — "+
+			"reorder gave up before the late transcript landed", obsRealUser.Load())
+	require.Positive(t, obsRealUser.Load(), "the user's real transcript was never surfaced")
+	require.Zerof(t, assistantTextBeforeUser.Load(),
+		"%d assistant text deltas were shown before the user transcript — short-reply ordering failed",
+		assistantTextBeforeUser.Load())
 
 	micStop()
 	cancel()

--- a/sdk/voice_realtime_integration_test.go
+++ b/sdk/voice_realtime_integration_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+// +build integration
+
+package sdk
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/audio"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/require"
+)
+
+// realtimeSampleRate is the OpenAI Realtime PCM16 rate.
+const realtimeSampleRate = 24000
+
+// synthesizePromptPCM24k turns text into raw 24kHz PCM16 mono speech via OpenAI
+// TTS. Real speech (not a sine wave) reliably trips the Realtime API's
+// server-side VAD, so the model actually answers.
+func synthesizePromptPCM24k(t *testing.T, apiKey, text string) []byte {
+	t.Helper()
+	svc := tts.NewOpenAI(apiKey)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	rc, err := svc.Synthesize(ctx, text, tts.SynthesisConfig{
+		Voice:  "echo",
+		Format: tts.AudioFormat{Name: "pcm"}, // raw 24kHz 16-bit mono
+	})
+	require.NoError(t, err, "TTS synthesize prompt")
+	defer func() { _ = rc.Close() }()
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err, "read TTS audio")
+	require.NotEmpty(t, data, "TTS returned no audio")
+	return data
+}
+
+// pushMicUntilDone feeds PCM16 into a MemSource as 20ms frames at real time —
+// the spoken prompt first, then a continuous stream of silence frames until ctx
+// is canceled — exactly how a real always-on microphone drives the session. The
+// continuous stream is deliberate: it is what keeps a live conversation alive
+// past the pipeline's 30s idle timeout (each inbound frame resets it), so this
+// exercises the idle-reset fix under realistic mic behavior.
+func pushMicUntilDone(ctx context.Context, mic *audio.MemSource, pcm []byte) {
+	const frameBytes = realtimeSampleRate / 100 * 2 // 20ms @ 24kHz PCM16 = 480 samples = 960 bytes
+	fmtA := audio.Format{SampleRate: realtimeSampleRate, Channels: 1}
+	push := func(b []byte) bool {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+		}
+		mic.Push(audio.MediaFrame{Kind: audio.KindAudio, Data: b, Format: fmtA})
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(20 * time.Millisecond):
+			return true
+		}
+	}
+	for i := 0; i < len(pcm); i += frameBytes {
+		end := i + frameBytes
+		if end > len(pcm) {
+			end = len(pcm)
+		}
+		frame := make([]byte, end-i)
+		copy(frame, pcm[i:end])
+		if !push(frame) {
+			return
+		}
+	}
+	silent := make([]byte, frameBytes)
+	for {
+		if !push(append([]byte(nil), silent...)) {
+			return
+		}
+	}
+}
+
+// TestVoiceRealtime_LongReplyThroughOpenVoice is the integration test that was
+// missing: it drives the REAL OpenAI Realtime provider through the actual
+// OpenVoice path — mic pump → DuplexProviderStage → output AudioPacingStage →
+// speaker pump — the same pipeline (and the same idle-reset, drain, and pacing
+// changes) that ships in the openai-realtime example. It proves the mic path
+// works end to end against a real provider: a spoken prompt provokes a long
+// reply, that reply streams back to the speaker through the paced pipeline, and
+// the session stays alive the whole time (does not tear down after the turn).
+//
+// Run: OPENAI_API_KEY=... go test -tags integration -run TestVoiceRealtime ./sdk/... -v
+func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+
+	// A prompt engineered to make the model talk for a while — the long reply is
+	// the burst that stresses output pacing and the session lifetime.
+	speech := synthesizePromptPCM24k(t, apiKey,
+		"Please tell me a detailed story about a lighthouse keeper and the sea. "+
+			"Take your time and speak for at least thirty seconds.")
+
+	prov := openai.NewProvider(
+		"openai-realtime", "gpt-realtime", "https://api.openai.com",
+		providers.ProviderDefaults{}, false,
+	)
+	cfg := &providers.StreamingInputConfig{
+		Config: types.StreamingMediaConfig{
+			Type: types.ContentTypeAudio, ChunkSize: 3200,
+			SampleRate: realtimeSampleRate, Channels: 1, BitDepth: 16, Encoding: "pcm16",
+		},
+		Metadata: map[string]interface{}{
+			"modalities":          []string{"text", "audio"},
+			"input_transcription": false,
+		},
+	}
+
+	mic := audio.NewMemSource(audio.KindAudio, 512)
+	speaker := audio.NewMemSink(audio.KindAudio)
+	sess := &fakeAudioSession{sources: []audio.Source{mic}, sinks: []audio.Sink{speaker}}
+
+	var obsAudio, obsText atomic.Int64
+	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
+		WithProvider(prov),
+		WithStreamingConfig(cfg),
+		WithSkipSchemaValidation(),
+		WithAudioSession(sess),
+		WithVoiceObserver(func(c providers.StreamChunk) {
+			if c.MediaData != nil && len(c.MediaData.Data) > 0 {
+				obsAudio.Add(1)
+			}
+			if c.Delta != "" {
+				obsText.Add(1)
+			}
+		}),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- conv.Start(ctx) }()
+
+	// Continuous always-on mic: speak the prompt, then keep streaming (silence)
+	// so server-VAD commits the turn AND the session stays fed past 30s.
+	micCtx, micStop := context.WithCancel(ctx)
+	defer micStop()
+	go pushMicUntilDone(micCtx, mic, speech)
+
+	// dieIfSessionEnded fails the test if Start returned (session torn down).
+	dieIfSessionEnded := func(where string) {
+		select {
+		case startErr := <-done:
+			if startErr != nil && (strings.Contains(startErr.Error(), "invalid_api_key") ||
+				strings.Contains(startErr.Error(), "websocket: close")) {
+				t.Skipf("Skipping (connection): %v", startErr)
+			}
+			t.Fatalf("session ended %s (%v) — mic path/lifetime broke; speaker frames=%d observer audio=%d text=%d",
+				where, startErr, len(speaker.Written()), obsAudio.Load(), obsText.Load())
+		default:
+		}
+	}
+
+	// Phase 1: a long reply must round-trip mic -> real provider -> paced pipeline
+	// -> speaker, and the session must stay alive throughout.
+	const wantFrames = 25
+	replyDeadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(replyDeadline) && len(speaker.Written()) < wantFrames {
+		dieIfSessionEnded("before the reply arrived")
+		time.Sleep(200 * time.Millisecond)
+	}
+	require.GreaterOrEqualf(t, len(speaker.Written()), wantFrames,
+		"expected a long spoken reply through the paced OpenVoice pipeline; got %d speaker frames "+
+			"(observer audio=%d text=%d) — the real provider reply did not reach the speaker",
+		len(speaker.Written()), obsAudio.Load(), obsText.Load())
+	t.Logf("reply reached the speaker: %d frames (observer audio=%d text=%d)",
+		len(speaker.Written()), obsAudio.Load(), obsText.Load())
+
+	// Phase 2: prove the session survives WELL past the 30s pipeline idle timeout
+	// while the mic keeps streaming — the original ~30s death. Hold to 45s total.
+	surviveUntil := time.Now().Add(40 * time.Second)
+	for time.Now().Before(surviveUntil) {
+		dieIfSessionEnded("during the 40s idle-survival window")
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Logf("OK: session alive past the 30s idle timeout with a live mic; total speaker frames=%d", len(speaker.Written()))
+
+	micStop()
+	cancel()
+	require.NoError(t, conv.Close())
+}

--- a/sdk/voice_realtime_integration_test.go
+++ b/sdk/voice_realtime_integration_test.go
@@ -180,6 +180,12 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 		"expected a long spoken reply through the paced OpenVoice pipeline; got %d speaker frames "+
 			"(observer audio=%d text=%d) — the real provider reply did not reach the speaker",
 		len(speaker.Written()), obsAudio.Load(), obsText.Load())
+	// The assistant's spoken words must also reach the observer as live transcript
+	// text (StreamChunk.Delta), not just audio — otherwise a voice UI plays sound
+	// but shows nothing. Regression guard for the "no assistant transcript" bug.
+	require.Positivef(t, obsText.Load(),
+		"assistant transcript did not reach the observer (audio frames=%d) — the spoken reply "+
+			"produced no live text deltas", obsAudio.Load())
 	t.Logf("reply reached the speaker: %d frames (observer audio=%d text=%d)",
 		len(speaker.Written()), obsAudio.Load(), obsText.Load())
 

--- a/sdk/voice_realtime_integration_test.go
+++ b/sdk/voice_realtime_integration_test.go
@@ -237,3 +237,88 @@ func TestVoiceRealtime_LongReplyThroughOpenVoice(t *testing.T) {
 	// only need the feature assertions above.
 	_ = conv.Close()
 }
+
+// TestVoiceRealtime_ShortReplySurvives reproduces the reported termination on a
+// SHORT exchange: with a brief reply, OpenAI's Whisper transcript arrives AFTER
+// the assistant turn ends. The long-reply test never hits this. The session must
+// stay alive after the short turn while the mic keeps streaming (it must not tear
+// down). Runs with reordering auto-enabled (input_transcription on).
+func TestVoiceRealtime_ShortReplySurvives(t *testing.T) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+
+	speech := synthesizePromptPCM24k(t, apiKey, "Say hi back in one very short sentence.")
+
+	prov := openai.NewProvider(
+		"openai-realtime", "gpt-realtime", "https://api.openai.com",
+		providers.ProviderDefaults{}, false,
+	)
+	cfg := &providers.StreamingInputConfig{
+		Config: types.StreamingMediaConfig{
+			Type: types.ContentTypeAudio, ChunkSize: 3200,
+			SampleRate: realtimeSampleRate, Channels: 1, BitDepth: 16, Encoding: "pcm16",
+		},
+		Metadata: map[string]interface{}{
+			"modalities":          []string{"text", "audio"},
+			"input_transcription": true, // reorder auto-on
+		},
+	}
+
+	mic := audio.NewMemSource(audio.KindAudio, 512)
+	speaker := audio.NewMemSink(audio.KindAudio)
+	sess := &fakeAudioSession{sources: []audio.Source{mic}, sinks: []audio.Sink{speaker}}
+
+	var obsText atomic.Int64
+	conv, err := OpenVoice(writeIngestionTestPack(t), "main",
+		WithProvider(prov),
+		WithStreamingConfig(cfg),
+		WithSkipSchemaValidation(),
+		WithAudioSession(sess),
+		WithVoiceObserver(func(c providers.StreamChunk) {
+			if c.Delta != "" {
+				obsText.Add(1)
+			}
+		}),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- conv.Start(ctx) }()
+
+	micCtx, micStop := context.WithCancel(ctx)
+	defer micStop()
+	go pushMicUntilDone(micCtx, mic, speech)
+
+	// Wait for the short reply to arrive (some assistant text or audio).
+	replyBy := time.Now().Add(45 * time.Second)
+	for time.Now().Before(replyBy) && obsText.Load() == 0 && len(speaker.Written()) == 0 {
+		select {
+		case e := <-done:
+			t.Fatalf("session ended before any reply (%v)", e)
+		default:
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// The reply happened. Now hold: the session must NOT tear down after this short
+	// turn while the mic keeps streaming (the reported termination).
+	holdUntil := time.Now().Add(25 * time.Second)
+	for time.Now().Before(holdUntil) {
+		select {
+		case e := <-done:
+			t.Fatalf("session terminated after the short turn (%v) — text=%d frames=%d",
+				e, obsText.Load(), len(speaker.Written()))
+		default:
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Logf("OK: survived the short turn; text=%d frames=%d", obsText.Load(), len(speaker.Written()))
+
+	micStop()
+	cancel()
+	_ = conv.Close()
+}


### PR DESCRIPTION
## Summary

Makes the streaming voice example (OpenAI Realtime via `OpenVoice`) actually usable end to end. Each fix is TDD'd, and the whole path is covered by real-provider integration tests so we stop relying on manual "run it and see".

### Session lifetime
- **~30s idle death** — `DuplexProviderStage` never reset the pipeline idle timer; now resets on inbound (mic) and outbound (reply) activity. A genuinely idle session still times out.
- **Drain hang on close** — a live streaming session blocked the full 30s drain; `Drain` now marks its `EndOfStream` with `AllResponsesReceived` so the stage closes immediately.
- **Prompt close** — closing mid-reply no longer waits for the output pacing stage to play out buffered audio at realtime (750ms grace, then the session context is cancelled).

### Audio + display
- **Jitter/stutter on long replies** — output was unpaced and overran the speaker's jitter buffer; the SDK now wires the runtime `AudioPacingStage` on the output when a realtime sink is bound.
- **Assistant transcript never shown** — realtime transcript arrives as `output_transcription` deltas; now forwarded as live text.
- **Turn delimiting** — an additive `assistant_turn_complete` metadata flag (not `FinishReason`, which continuous callers break on).
- **Late-transcript reordering** — new `TranscriptReorderStage` guarantees each turn's user transcript precedes its assistant text, holding the turn-end for a late transcript (OpenAI's Whisper lands after a short reply). Auto-wired via the `providers.LateInputTranscriber` capability + `input_transcription`; overridable via streaming-config additional properties (`input_transcript_ordering`, `input_transcript_placeholder`).

### Diagnostics
- Cancel-cause on session-closure logs; per-pump exit logs in `Start`; a mic watchdog that warns when the capture device delivers no audio (permission / stale process / Bluetooth A2DP with no mic).

## Tests
- Unit tests for every fix (idle reset, drain, pacing wiring, transcript forward + dedup, reorder ordering/placeholder/hold-timeout, config resolver).
- **Real-provider integration tests** (`//go:build integration`, `OPENAI_API_KEY`): long reply reaches the speaker + survives past idle + correct transcript order; short reply survives + no premature placeholder + correct order. TTS synthesizes the spoken prompt.
