### PR TITLE
fix(gemini): send realtime audio via current realtimeInput.audio field

### DIFF
--- a/runtime/providers/gemini/stream_session_helpers_test.go
+++ b/runtime/providers/gemini/stream_session_helpers_test.go
@@ -84,24 +84,29 @@ func TestBuildClientMessage_AudioPCM(t *testing.T) {
 		t.Fatal("Expected non-nil message")
 	}
 
-	realtimeInput, ok := msg["realtime_input"].(map[string]interface{})
+	// Audio must use the CURRENT realtimeInput.audio wire format. The legacy
+	// realtime_input.media_chunks form is deprecated and closes current Gemini
+	// Live models (e.g. gemini-*-live) with websocket close 1007. (#1666)
+	if _, legacy := msg["realtime_input"]; legacy {
+		t.Fatal("audio must not use the deprecated realtime_input.media_chunks form")
+	}
+
+	realtimeInput, ok := msg["realtimeInput"].(map[string]interface{})
 	if !ok {
-		t.Fatal("Expected realtime_input in message")
+		t.Fatal("Expected realtimeInput in message")
 	}
 
-	mediaChunks, ok := realtimeInput["media_chunks"].([]map[string]interface{})
-	if !ok || len(mediaChunks) == 0 {
-		t.Fatal("Expected media_chunks array")
+	audio, ok := realtimeInput["audio"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected realtimeInput.audio object")
 	}
 
-	firstChunk := mediaChunks[0]
-	mimeType, ok := firstChunk["mime_type"].(string)
-	if !ok || mimeType != "audio/pcm" {
-		t.Errorf("Expected mime_type 'audio/pcm', got %v", mimeType)
+	// Gemini Live requires the sample rate in the audio mimeType.
+	if mimeType, _ := audio["mimeType"].(string); mimeType != "audio/pcm;rate=16000" {
+		t.Errorf("Expected mimeType 'audio/pcm;rate=16000', got %v", mimeType)
 	}
 
-	data, ok := firstChunk["data"].(string)
-	if !ok || data == "" {
+	if data, _ := audio["data"].(string); data == "" {
 		t.Error("Expected base64 encoded data")
 	}
 }

--- a/runtime/providers/gemini/stream_session_protocol_integration.go
+++ b/runtime/providers/gemini/stream_session_protocol_integration.go
@@ -17,6 +17,10 @@ const finishReasonComplete = "complete"
 // audioPCMMime is the MIME type for PCM audio used by Gemini Live API.
 const audioPCMMime = "audio/pcm"
 
+// audioPCMMimeRate is the audio input MIME type for the current Gemini Live wire
+// format, which requires the sample rate. Gemini Live input is 16 kHz mono PCM16.
+const audioPCMMimeRate = "audio/pcm;rate=16000"
+
 // defaultOutputSampleRate is the default output sample rate for Gemini native audio models (24kHz).
 const defaultOutputSampleRate = 24000
 
@@ -345,7 +349,9 @@ func (s *StreamSession) processModelTurn(turn *ModelTurn, turnComplete bool, cos
 //	session.sendRealtimeInput({ media: { data: base64Data, mimeType: 'image/jpeg' } })
 //
 // Which translates to wire format: { "realtimeInput": { "media": { "data": "...", "mimeType": "..." } } }
-// For audio, uses the legacy format with media_chunks array.
+// For audio, uses the current realtimeInput.audio field. The legacy
+// realtime_input.media_chunks form is deprecated and closes current Gemini Live
+// models (e.g. gemini-*-live) with websocket close 1007 (#1666).
 func buildClientMessage(chunk types.MediaChunk, _ bool) map[string]interface{} {
 	// Determine MIME type from metadata or default to audio/pcm
 	mimeType := audioPCMMime
@@ -374,7 +380,9 @@ func buildClientMessage(chunk types.MediaChunk, _ bool) map[string]interface{} {
 		}
 	}
 
-	// For audio, use PCM encoder with legacy format
+	// For audio, use the current realtimeInput.audio field (camelCase, matching
+	// the image/video branch and the protobuf JSON encoding). Gemini Live requires
+	// the sample rate in the mimeType.
 	encoder := NewAudioEncoder()
 	var err error
 	base64Data, err = encoder.EncodePCM(chunk.Data)
@@ -384,12 +392,10 @@ func buildClientMessage(chunk types.MediaChunk, _ bool) map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"realtime_input": map[string]interface{}{
-			"media_chunks": []map[string]interface{}{
-				{
-					"mime_type": audioPCMMime,
-					"data":      base64Data,
-				},
+		"realtimeInput": map[string]interface{}{
+			"audio": map[string]interface{}{
+				"data":     base64Data,
+				"mimeType": audioPCMMimeRate,
 			},
 		},
 	}

--- a/runtime/providers/gemini/stream_session_test.go
+++ b/runtime/providers/gemini/stream_session_test.go
@@ -76,8 +76,8 @@ func TestGeminiStreamSession_SendChunk(t *testing.T) {
 			return
 		}
 
-		// Check for realtime_input format (new format for audio chunks)
-		if msg["realtime_input"] != nil {
+		// Audio chunks use the current realtimeInput.audio wire format (#1666).
+		if msg["realtimeInput"] != nil {
 			receivedMsg.Store(true)
 		}
 
@@ -777,22 +777,23 @@ func TestBuildClientMessage(t *testing.T) {
 		t.Fatal("Expected message to be built")
 	}
 
-	// New format uses realtime_input instead of client_content
-	realtimeInput, ok := msg["realtime_input"].(map[string]interface{})
+	// Audio uses the current realtimeInput.audio format (not the deprecated
+	// realtime_input.media_chunks, which closes current Gemini Live models 1007).
+	realtimeInput, ok := msg["realtimeInput"].(map[string]interface{})
 	if !ok {
-		t.Fatal("Expected realtime_input field")
+		t.Fatal("Expected realtimeInput field")
 	}
 
-	mediaChunks, ok := realtimeInput["media_chunks"].([]map[string]interface{})
-	if !ok || len(mediaChunks) == 0 {
-		t.Fatal("Expected media_chunks array")
+	audio, ok := realtimeInput["audio"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected realtimeInput.audio object")
 	}
 
-	if mimeType, ok := mediaChunks[0]["mime_type"].(string); !ok || mimeType != "audio/pcm" {
-		t.Error("Expected mime_type to be 'audio/pcm'")
+	if mimeType, ok := audio["mimeType"].(string); !ok || mimeType != "audio/pcm;rate=16000" {
+		t.Error("Expected mimeType to be 'audio/pcm;rate=16000'")
 	}
 
-	if data, ok := mediaChunks[0]["data"].(string); !ok || data == "" {
+	if data, ok := audio["data"].(string); !ok || data == "" {
 		t.Error("Expected base64 encoded data")
 	}
 }


### PR DESCRIPTION
Fixes the Gemini Live realtime audio breakage: audio was sent via the deprecated `realtime_input.media_chunks` field, which current Gemini Live models reject with `close 1007 (…media_chunks is deprecated…)`. `buildClientMessage` now emits audio via the current `realtimeInput.audio` field with the rate in the mimeType (`audio/pcm;rate=16000`), mirroring the image/video branch. Unit tests updated (TDD: red→green) to assert the new format and reject the legacy `media_chunks` form. Closes #1666.