### PR TITLE
feat(gemini): response modality settable via provider additional_config

### DIFF
--- a/runtime/providers/gemini/gemini.go
+++ b/runtime/providers/gemini/gemini.go
@@ -66,6 +66,12 @@ type Provider struct {
 	// summaries. Both come from additional_config — see gemini_thinking.go.
 	thinkingBudget  *int
 	includeThoughts bool
+	// responseModalities is the Live-API response modality declared once at the
+	// provider level via additional_config.response_modalities (e.g. ["AUDIO"]).
+	// Empty means "not set"; a per-request Metadata["response_modalities"] still
+	// overrides it, and the session falls back to ["TEXT"] when neither is set.
+	// See gemini_streaming.go / streaming_support.go (#1667).
+	responseModalities []string
 }
 
 // enableExplicitCaching turns on explicit context caching (#1404) with the given

--- a/runtime/providers/gemini/gemini_tools.go
+++ b/runtime/providers/gemini/gemini_tools.go
@@ -742,6 +742,7 @@ func init() {
 				tp.setCapabilities(spec.Capabilities)
 				applyExplicitCachingConfig(tp.Provider, spec)
 				applyThinkingConfig(tp.Provider, spec)
+				applyStreamingModalitiesConfig(tp.Provider, spec)
 				return tp, nil
 			},
 			func(spec providers.ProviderSpec) (providers.Provider, error) {
@@ -751,6 +752,7 @@ func init() {
 				tp.setCapabilities(spec.Capabilities)
 				applyExplicitCachingConfig(tp.Provider, spec)
 				applyThinkingConfig(tp.Provider, spec)
+				applyStreamingModalitiesConfig(tp.Provider, spec)
 				return tp, nil
 			},
 		),

--- a/runtime/providers/gemini/streaming_support.go
+++ b/runtime/providers/gemini/streaming_support.go
@@ -106,6 +106,13 @@ func (p *Provider) buildStreamSessionConfig(req *providers.StreamingInputConfig)
 		MaxReconnectTries: defaultMaxReconnectTries,
 	}
 
+	// Seed the provider-level default modality (from additional_config); per-request
+	// metadata overrides it in applyMetadataConfig, and it falls back to TEXT when
+	// neither is set (#1667).
+	if len(p.responseModalities) > 0 {
+		config.ResponseModalities = append([]string(nil), p.responseModalities...)
+	}
+
 	p.applyPricingConfig(&config)
 	return config
 }
@@ -130,18 +137,46 @@ func (p *Provider) applyMetadataConfig(metadata map[string]interface{}, config *
 	p.applyVADDisabled(metadata, config)
 }
 
-// applyResponseModalities extracts response modalities from metadata
+// applyResponseModalities extracts response modalities from metadata, overriding
+// any provider-level default seeded in buildStreamSessionConfig.
 func (p *Provider) applyResponseModalities(metadata map[string]interface{}, config *StreamSessionConfig) {
-	switch modalities := metadata["response_modalities"].(type) {
+	if mods := parseModalities(metadata["response_modalities"]); mods != nil {
+		config.ResponseModalities = mods
+	}
+}
+
+// parseModalities normalizes a response_modalities value (from request metadata or
+// provider additional_config) into a []string. It accepts a []string or a
+// []interface{} of strings (the shape YAML/JSON config decodes to). Returns nil
+// when the value is absent or the wrong type, so callers can tell "not set" from
+// "set to empty".
+func parseModalities(v interface{}) []string {
+	switch mods := v.(type) {
 	case []string:
-		config.ResponseModalities = modalities
+		return mods
 	case []interface{}:
-		config.ResponseModalities = make([]string, 0, len(modalities))
-		for _, m := range modalities {
+		out := make([]string, 0, len(mods))
+		for _, m := range mods {
 			if s, ok := m.(string); ok {
-				config.ResponseModalities = append(config.ResponseModalities, s)
+				out = append(out, s)
 			}
 		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// applyStreamingModalitiesConfig seeds the provider's default Live-API response
+// modality from additional_config.response_modalities, so a voice provider can be
+// declared once (e.g. additional_config: {response_modalities: ["AUDIO"]}) rather
+// than configured per request. Per-request metadata still overrides it. (#1667)
+func applyStreamingModalitiesConfig(p *Provider, spec providers.ProviderSpec) {
+	if spec.AdditionalConfig == nil {
+		return
+	}
+	if mods := parseModalities(spec.AdditionalConfig["response_modalities"]); len(mods) > 0 {
+		p.responseModalities = mods
 	}
 }
 

--- a/runtime/providers/gemini/streaming_support_test.go
+++ b/runtime/providers/gemini/streaming_support_test.go
@@ -324,6 +324,63 @@ func TestGeminiProvider_CreateStreamSession_ResponseModalities(t *testing.T) {
 	}
 }
 
+// TestGeminiProvider_CreateStreamSession_ProviderConfigModalities: a provider can
+// declare its response modality once via additional_config (response_modalities),
+// and per-request metadata still overrides it. Native-audio Live models require
+// AUDIO, so provider-level config is the declarative home for it. (#1667)
+func TestGeminiProvider_CreateStreamSession_ProviderConfigModalities(t *testing.T) {
+	baseConfig := types.StreamingMediaConfig{
+		Type:       types.ContentTypeAudio,
+		ChunkSize:  3200,
+		SampleRate: 16000,
+		Channels:   1,
+		BitDepth:   16,
+		Encoding:   "pcm_linear16",
+	}
+
+	// run builds a provider (optionally seeded from additional_config), captures the
+	// StreamSessionConfig the factory receives, and returns its ResponseModalities.
+	run := func(t *testing.T, providerMod interface{}, reqMeta map[string]interface{}) []string {
+		t.Helper()
+		p := NewProvider("test", "gemini-3.1-flash-live-preview", "https://api.test.com", providers.ProviderDefaults{}, false)
+		if providerMod != nil {
+			applyStreamingModalitiesConfig(p, providers.ProviderSpec{
+				AdditionalConfig: map[string]interface{}{"response_modalities": providerMod},
+			})
+		}
+		var got []string
+		p.newStreamSessionFn = func(ctx context.Context, _, _ string, cfg *StreamSessionConfig) (*StreamSession, error) {
+			got = cfg.ResponseModalities
+			sctx, cancel := context.WithCancel(ctx)
+			return &StreamSession{ctx: sctx, cancel: cancel, errCh: make(chan error, 1)}, nil
+		}
+		if _, err := p.CreateStreamSession(context.Background(), &providers.StreamingInputConfig{Config: baseConfig, Metadata: reqMeta}); err != nil {
+			t.Fatalf("CreateStreamSession: %v", err)
+		}
+		return got
+	}
+
+	cases := []struct {
+		name        string
+		providerMod interface{}
+		reqMeta     map[string]interface{}
+		want        string
+	}{
+		{"provider config sets AUDIO (no metadata)", []interface{}{"AUDIO"}, nil, "AUDIO"},
+		{"provider config accepts []string", []string{"AUDIO"}, nil, "AUDIO"},
+		{"per-request metadata overrides provider config", []interface{}{"AUDIO"},
+			map[string]interface{}{"response_modalities": []string{"TEXT"}}, "TEXT"},
+		{"defaults to TEXT when neither is set", nil, nil, "TEXT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := strings.Join(run(t, tc.providerMod, tc.reqMeta), ","); got != tc.want {
+				t.Errorf("ResponseModalities = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestGeminiProvider_CreateStreamSession_EmptyConfig(t *testing.T) {
 	provider := NewProvider("test", "gemini-2.0-flash-exp", "https://api.test.com", providers.ProviderDefaults{}, false)
 	ctx := context.Background()


### PR DESCRIPTION
Lets a Gemini voice provider be declared once via `additional_config: {response_modalities: ["AUDIO"]}` instead of imperatively per-request — unblocking declarative voice providers (PromptArena / Omnia Provider CRD). The provider reads `additional_config.response_modalities` at construction (mirroring thinking/explicit-caching) and seeds the stream session from it; per-request metadata still overrides, TEXT is the fallback. Unit tests capture the resolved config across all cases. Closes #1667.