### PR TITLE
feat(tts): surface the real spoken text from synthesis (post markup-lowering)

### DIFF
--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -1986,6 +1986,13 @@ type ElementMetadata struct {
     // the true spoken text, since providers strip or rewrite markup at synthesis.
     SynthesizedSpeech bool
 
+    // SpokenText is the text the TTS provider actually spoke, after markup
+    // lowering — the faithful, provider- and model-specific value the reference
+    // Text (above) only approximates. Populated on SynthesizedSpeech elements when
+    // the provider implements tts.SpokenTextReporter; empty otherwise (consumers
+    // then fall back to the reference/LLM text). See #1657.
+    SpokenText string
+
     // StreamingDelta marks an incremental content Text element emitted by a
     // streaming provider mid-generation (see ProviderStage.emitChunkElement).
     // These are the live-text feed for UI consumers; the same reply also arrives

--- a/docs/src/content/docs/runtime/reference/tts.md
+++ b/docs/src/content/docs/runtime/reference/tts.md
@@ -90,6 +90,7 @@ The package includes implementations for:
   - [func \(s \*CartesiaService\) Init\(\_ context.Context\) error](<#CartesiaService.Init>)
   - [func \(s \*CartesiaService\) ModelName\(\) string](<#CartesiaService.ModelName>)
   - [func \(s \*CartesiaService\) PersonaRubric\(\) string](<#CartesiaService.PersonaRubric>)
+  - [func \(s \*CartesiaService\) SpokenText\(text string, \_ SynthesisConfig\) string](<#CartesiaService.SpokenText>)
   - [func \(s \*CartesiaService\) SupportedFormats\(\) \[\]AudioFormat](<#CartesiaService.SupportedFormats>)
   - [func \(s \*CartesiaService\) SupportedVoices\(\) \[\]Voice](<#CartesiaService.SupportedVoices>)
   - [func \(s \*CartesiaService\) Synthesize\(ctx context.Context, text string, config SynthesisConfig\) \(io.ReadCloser, error\)](<#CartesiaService.Synthesize>)
@@ -106,6 +107,7 @@ The package includes implementations for:
   - [func \(s \*ElevenLabsService\) Init\(\_ context.Context\) error](<#ElevenLabsService.Init>)
   - [func \(s \*ElevenLabsService\) ModelName\(\) string](<#ElevenLabsService.ModelName>)
   - [func \(s \*ElevenLabsService\) PersonaRubric\(\) string](<#ElevenLabsService.PersonaRubric>)
+  - [func \(s \*ElevenLabsService\) SpokenText\(text string, config SynthesisConfig\) string](<#ElevenLabsService.SpokenText>)
   - [func \(s \*ElevenLabsService\) SupportedFormats\(\) \[\]AudioFormat](<#ElevenLabsService.SupportedFormats>)
   - [func \(s \*ElevenLabsService\) SupportedVoices\(\) \[\]Voice](<#ElevenLabsService.SupportedVoices>)
   - [func \(s \*ElevenLabsService\) Synthesize\(ctx context.Context, text string, config SynthesisConfig\) \(io.ReadCloser, error\)](<#ElevenLabsService.Synthesize>)
@@ -122,6 +124,7 @@ The package includes implementations for:
   - [func \(s \*OpenAIService\) Init\(\_ context.Context\) error](<#OpenAIService.Init>)
   - [func \(s \*OpenAIService\) ModelName\(\) string](<#OpenAIService.ModelName>)
   - [func \(s \*OpenAIService\) PersonaRubric\(\) string](<#OpenAIService.PersonaRubric>)
+  - [func \(s \*OpenAIService\) SpokenText\(text string, config SynthesisConfig\) string](<#OpenAIService.SpokenText>)
   - [func \(s \*OpenAIService\) SupportedFormats\(\) \[\]AudioFormat](<#OpenAIService.SupportedFormats>)
   - [func \(s \*OpenAIService\) SupportedVoices\(\) \[\]Voice](<#OpenAIService.SupportedVoices>)
   - [func \(s \*OpenAIService\) Synthesize\(ctx context.Context, text string, config SynthesisConfig\) \(io.ReadCloser, error\)](<#OpenAIService.Synthesize>)
@@ -134,6 +137,7 @@ The package includes implementations for:
   - [func DefaultRetryConfig\(\) RetryConfig](<#DefaultRetryConfig>)
 - [type Service](<#Service>)
   - [func CreateFromSpec\(spec ProviderSpec\) \(Service, error\)](<#CreateFromSpec>)
+- [type SpokenTextReporter](<#SpokenTextReporter>)
 - [type StreamingService](<#StreamingService>)
 - [type SynthesisConfig](<#SynthesisConfig>)
   - [func DefaultSynthesisConfig\(\) SynthesisConfig](<#DefaultSynthesisConfig>)
@@ -503,6 +507,15 @@ func (s *CartesiaService) PersonaRubric() string
 
 PersonaRubric implements [PersonaRubricProvider](<#PersonaRubricProvider>). Returns the emotion\-only rubric: Cartesia's experimental controls accept a narrow vocabulary \(positivity / sadness / anger\), so we advertise only the tags the adapter actually maps. Other tags \(e.g. whispers, pause\) would be dropped by lowerCartesiaMarkup, so we omit them from the rubric to keep persona tokens focused on directives that move audio.
 
+<a name="CartesiaService.SpokenText"></a>
+### func \(\*CartesiaService\) SpokenText
+
+```go
+func (s *CartesiaService) SpokenText(text string, _ SynthesisConfig) string
+```
+
+SpokenText reports the text Cartesia will actually speak for the given input: emotion tags become generation config, so the spoken transcript is the text with tags removed. Implements tts.SpokenTextReporter \(\#1657\).
+
 <a name="CartesiaService.SupportedFormats"></a>
 ### func \(\*CartesiaService\) SupportedFormats
 
@@ -649,6 +662,15 @@ func (s *ElevenLabsService) PersonaRubric() string
 ```
 
 PersonaRubric implements [PersonaRubricProvider](<#PersonaRubricProvider>). Returns the full markup rubric on v3\-class models \(they consume bracket tags natively\); older models \(v1, v2, turbo\) speak the brackets literally, so we return the empty string and the persona prompt is left untouched.
+
+<a name="ElevenLabsService.SpokenText"></a>
+### func \(\*ElevenLabsService\) SpokenText
+
+```go
+func (s *ElevenLabsService) SpokenText(text string, config SynthesisConfig) string
+```
+
+SpokenText reports the text ElevenLabs will actually speak for the given input, after markup lowering: eleven\_v3 keeps inline tags \(the model interprets them\), other models strip tags. Implements tts.SpokenTextReporter \(\#1657\).
 
 <a name="ElevenLabsService.SupportedFormats"></a>
 ### func \(\*ElevenLabsService\) SupportedFormats
@@ -797,6 +819,15 @@ func (s *OpenAIService) PersonaRubric() string
 
 PersonaRubric implements [PersonaRubricProvider](<#PersonaRubricProvider>). Returns the full markup rubric on gpt\-4o\-mini\-tts \(the model honors arbitrary instructions via the request's instructions field\). Older models \(tts\-1, tts\-1\-hd\) do not understand the markup, so we return the empty string — emitting tags would just waste persona tokens.
 
+<a name="OpenAIService.SpokenText"></a>
+### func \(\*OpenAIService\) SpokenText
+
+```go
+func (s *OpenAIService) SpokenText(text string, config SynthesisConfig) string
+```
+
+SpokenText reports the text OpenAI will actually speak for the given input, after markup lowering: on gpt\-4o\-mini\-tts the bracket tags become the \`instructions\` field so the spoken text is the stripped remainder; other models strip tags entirely. Implements tts.SpokenTextReporter \(\#1657\).
+
 <a name="OpenAIService.SupportedFormats"></a>
 ### func \(\*OpenAIService\) SupportedFormats
 
@@ -931,6 +962,19 @@ func CreateFromSpec(spec ProviderSpec) (Service, error)
 ```
 
 CreateFromSpec returns a Service implementation for the given spec.
+
+<a name="SpokenTextReporter"></a>
+## type SpokenTextReporter
+
+SpokenTextReporter is an optional Service extension: given the input text and config, it returns the exact text that will be submitted to the synthesis engine after PromptKit's bracket\-tag markup is lowered — provider\- and model\-specific \(e.g. OpenAI gpt\-4o\-mini\-tts moves tags to \`instructions\`, so the spoken text is the stripped remainder; ElevenLabs v3 keeps inline tags\). The lowering is pure, so this reports the value without synthesizing. Returns "" when unknown, letting consumers fall back to the LLM text. \(\#1657\)
+
+```go
+type SpokenTextReporter interface {
+    // SpokenText returns the text that would actually be spoken for the given
+    // input and config, after markup lowering.
+    SpokenText(text string, config SynthesisConfig) string
+}
+```
 
 <a name="StreamingService"></a>
 ## type StreamingService

--- a/runtime/pipeline/stage/spoken_text_stage_test.go
+++ b/runtime/pipeline/stage/spoken_text_stage_test.go
@@ -1,0 +1,65 @@
+package stage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reportingTTS is a TTS service that also implements tts.SpokenTextReporter,
+// returning a canned spoken-text value so a test can assert the stage stamped it.
+type reportingTTS struct {
+	mockTTSService
+	spokenText string
+}
+
+func (r *reportingTTS) SpokenText(_ string, _ tts.SynthesisConfig) string { return r.spokenText }
+
+// synthesizedSpeech returns the first element the stage marked as synthesized
+// speech, or nil if none was emitted.
+func synthesizedSpeech(out []stage.StreamElement) *stage.StreamElement {
+	for i := range out {
+		if out[i].Meta.SynthesizedSpeech {
+			return &out[i]
+		}
+	}
+	return nil
+}
+
+// TestTTSStage_StampsSpokenTextFromReporter verifies that when the TTS provider
+// implements tts.SpokenTextReporter, the stage stamps the real spoken text (post
+// markup-lowering) onto the synthesized-speech element. See #1657.
+func TestTTSStage_StampsSpokenTextFromReporter(t *testing.T) {
+	svc := &reportingTTS{spokenText: "the real spoken words"}
+	ttsStage := stage.NewTTSStageWithInterruption(svc, stage.DefaultTTSStageWithInterruptionConfig())
+
+	out := runStage(t, ttsStage, []stage.StreamElement{
+		messageElement("assistant", "[whispers]the real spoken words"),
+	}, 5*time.Second)
+
+	speech := synthesizedSpeech(out)
+	require.NotNil(t, speech, "expected a synthesized-speech element")
+	assert.Equal(t, "the real spoken words", speech.Meta.SpokenText,
+		"the stage must stamp the reporter's spoken text onto the element")
+}
+
+// TestTTSStage_NoReporterLeavesSpokenTextEmpty guards the degrade path: a
+// provider that does not implement tts.SpokenTextReporter leaves SpokenText
+// empty so consumers fall back to the reference text. See #1657.
+func TestTTSStage_NoReporterLeavesSpokenTextEmpty(t *testing.T) {
+	svc := &mockTTSService{} // no SpokenText method
+	ttsStage := stage.NewTTSStageWithInterruption(svc, stage.DefaultTTSStageWithInterruptionConfig())
+
+	out := runStage(t, ttsStage, []stage.StreamElement{
+		messageElement("assistant", "The capital of France is Paris."),
+	}, 5*time.Second)
+
+	speech := synthesizedSpeech(out)
+	require.NotNil(t, speech, "expected a synthesized-speech element")
+	assert.Empty(t, speech.Meta.SpokenText,
+		"a provider without SpokenTextReporter must leave SpokenText empty")
+}

--- a/runtime/pipeline/stage/stages_speech.go
+++ b/runtime/pipeline/stage/stages_speech.go
@@ -1099,6 +1099,16 @@ func (s *TTSStageWithInterruption) emitAudioElement(
 	// ElementMetadata.SynthesizedSpeech). Set after the meta copy so it wins.
 	outElem.Meta.SynthesizedSpeech = true
 	outElem.Meta.StreamingDelta = false
+	// Attach the faithful spoken text (post markup-lowering) when the provider can
+	// report it, so a consumer can caption exactly what was said (#1657). Uses the
+	// same config as synthesis; empty when the provider doesn't implement it.
+	if reporter, ok := s.service.(tts.SpokenTextReporter); ok {
+		outElem.Meta.SpokenText = reporter.SpokenText(text, tts.SynthesisConfig{
+			Voice:  s.config.Voice,
+			Speed:  s.config.Speed,
+			Format: tts.FormatPCM16,
+		})
+	}
 
 	s.setBotSpeaking(false)
 	return s.forwardElement(ctx, outElem, output)

--- a/runtime/pipeline/stage/turn_state.go
+++ b/runtime/pipeline/stage/turn_state.go
@@ -161,6 +161,13 @@ type ElementMetadata struct {
 	// the true spoken text, since providers strip or rewrite markup at synthesis.
 	SynthesizedSpeech bool
 
+	// SpokenText is the text the TTS provider actually spoke, after markup
+	// lowering — the faithful, provider- and model-specific value the reference
+	// Text (above) only approximates. Populated on SynthesizedSpeech elements when
+	// the provider implements tts.SpokenTextReporter; empty otherwise (consumers
+	// then fall back to the reference/LLM text). See #1657.
+	SpokenText string
+
 	// StreamingDelta marks an incremental content Text element emitted by a
 	// streaming provider mid-generation (see ProviderStage.emitChunkElement).
 	// These are the live-text feed for UI consumers; the same reply also arrives

--- a/runtime/tts/cartesia.go
+++ b/runtime/tts/cartesia.go
@@ -220,6 +220,14 @@ func (s *CartesiaService) Synthesize(
 	)
 }
 
+// SpokenText reports the text Cartesia will actually speak for the given input:
+// emotion tags become generation config, so the spoken transcript is the text
+// with tags removed. Implements tts.SpokenTextReporter (#1657).
+func (s *CartesiaService) SpokenText(text string, _ SynthesisConfig) string {
+	transcript, _ := lowerCartesiaMarkup(text)
+	return transcript
+}
+
 // lowerCartesiaMarkup translates characterization tags in text into the
 // Cartesia request shape: a stripped transcript and an optional
 // *cartesiaGenerationConfig carrying the chosen emotion (single string)

--- a/runtime/tts/elevenlabs.go
+++ b/runtime/tts/elevenlabs.go
@@ -184,6 +184,17 @@ func (s *ElevenLabsService) Synthesize(
 	return postJSONForAudio(ctx, s.Client, "elevenlabs", endpoint, reqBody, headers, s.handleError)
 }
 
+// SpokenText reports the text ElevenLabs will actually speak for the given input,
+// after markup lowering: eleven_v3 keeps inline tags (the model interprets them),
+// other models strip tags. Implements tts.SpokenTextReporter (#1657).
+func (s *ElevenLabsService) SpokenText(text string, config SynthesisConfig) string {
+	model := config.Model
+	if model == "" {
+		model = s.Model
+	}
+	return lowerElevenLabsMarkup(text, model)
+}
+
 // lowerElevenLabsMarkup returns the spoken-text body to send to ElevenLabs:
 // pass-through verbatim for v3-class models (they consume inline tags
 // natively), strip tags for older models so they don't literally speak

--- a/runtime/tts/openai.go
+++ b/runtime/tts/openai.go
@@ -217,6 +217,19 @@ func (s *OpenAIService) Synthesize(
 	return resp.Body, nil
 }
 
+// SpokenText reports the text OpenAI will actually speak for the given input,
+// after markup lowering: on gpt-4o-mini-tts the bracket tags become the
+// `instructions` field so the spoken text is the stripped remainder; other
+// models strip tags entirely. Implements tts.SpokenTextReporter (#1657).
+func (s *OpenAIService) SpokenText(text string, config SynthesisConfig) string {
+	model := config.Model
+	if model == "" {
+		model = s.Model
+	}
+	input, _ := lowerOpenAIMarkup(text, model)
+	return input
+}
+
 // lowerOpenAIMarkup translates characterization tags in the input text into
 // the OpenAI request shape. For gpt-4o-mini-tts (expressive), tags become
 // the `instructions` field and the spoken text is stripped. For tts-1 and

--- a/runtime/tts/service.go
+++ b/runtime/tts/service.go
@@ -35,6 +35,19 @@ type Service interface {
 	SupportedFormats() []AudioFormat
 }
 
+// SpokenTextReporter is an optional Service extension: given the input text and
+// config, it returns the exact text that will be submitted to the synthesis
+// engine after PromptKit's bracket-tag markup is lowered — provider- and
+// model-specific (e.g. OpenAI gpt-4o-mini-tts moves tags to `instructions`, so
+// the spoken text is the stripped remainder; ElevenLabs v3 keeps inline tags).
+// The lowering is pure, so this reports the value without synthesizing. Returns
+// "" when unknown, letting consumers fall back to the LLM text. (#1657)
+type SpokenTextReporter interface {
+	// SpokenText returns the text that would actually be spoken for the given
+	// input and config, after markup lowering.
+	SpokenText(text string, config SynthesisConfig) string
+}
+
 // StreamingService extends Service with streaming synthesis capabilities.
 // Streaming TTS provides lower latency by returning audio chunks as they're generated.
 type StreamingService interface {

--- a/runtime/tts/spoken_text_test.go
+++ b/runtime/tts/spoken_text_test.go
@@ -1,0 +1,96 @@
+package tts
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
+)
+
+// These tests cover SpokenTextReporter: the text each provider actually speaks
+// after markup lowering. See #1657. Every provider degrades identically on
+// plain text (no tags ⇒ input returned verbatim) and each honors config.Model,
+// falling back to the service's configured model when config.Model is empty.
+
+func TestOpenAIService_SpokenText(t *testing.T) {
+	t.Run("tts-1 strips tags", func(t *testing.T) {
+		s := NewOpenAI("test-key")
+		got := s.SpokenText("[whispers]Come here[/]Did you hear that?", SynthesisConfig{Model: ModelTTS1})
+		if want := "Come hereDid you hear that?"; got != want {
+			t.Errorf("SpokenText = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("gpt-4o-mini-tts moves tags to instructions, speaks the remainder", func(t *testing.T) {
+		s := NewOpenAI("test-key")
+		got := s.SpokenText("[whispers]Come here", SynthesisConfig{Model: ModelGPT4oMiniTTS})
+		if want := "Come here"; got != want {
+			t.Errorf("SpokenText = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("plain text unchanged", func(t *testing.T) {
+		s := NewOpenAI("test-key")
+		if got := s.SpokenText("plain text", SynthesisConfig{}); got != "plain text" {
+			t.Errorf("SpokenText = %q, want %q", got, "plain text")
+		}
+	})
+
+	t.Run("empty config.Model falls back to service model", func(t *testing.T) {
+		s := NewOpenAI("test-key", base.WithModel(ModelGPT4oMiniTTS))
+		// config.Model empty ⇒ uses the expressive service model ⇒ tags become
+		// instructions and the spoken remainder is "Come here".
+		if got := s.SpokenText("[whispers]Come here", SynthesisConfig{}); got != "Come here" {
+			t.Errorf("SpokenText = %q, want %q", got, "Come here")
+		}
+	})
+}
+
+func TestCartesiaService_SpokenText(t *testing.T) {
+	s := NewCartesia("test-key")
+
+	t.Run("strips emotion markup from the transcript", func(t *testing.T) {
+		if got := s.SpokenText("[excited]a[sad]b[/]c", SynthesisConfig{}); got != "abc" {
+			t.Errorf("SpokenText = %q, want %q", got, "abc")
+		}
+	})
+
+	t.Run("plain text unchanged", func(t *testing.T) {
+		if got := s.SpokenText("plain text", SynthesisConfig{}); got != "plain text" {
+			t.Errorf("SpokenText = %q, want %q", got, "plain text")
+		}
+	})
+}
+
+func TestElevenLabsService_SpokenText(t *testing.T) {
+	t.Run("v3 keeps inline tags verbatim", func(t *testing.T) {
+		s := NewElevenLabs("test-key")
+		in := "[whispers]Come here[/]Did you hear that?"
+		if got := s.SpokenText(in, SynthesisConfig{Model: ElevenLabsModelV3}); got != in {
+			t.Errorf("SpokenText = %q, want %q (verbatim)", got, in)
+		}
+	})
+
+	t.Run("non-v3 strips tags", func(t *testing.T) {
+		s := NewElevenLabs("test-key")
+		got := s.SpokenText("[whispers]Come here[/]Did you hear that?", SynthesisConfig{Model: ElevenLabsModelMultilingual})
+		if want := "Come hereDid you hear that?"; got != want {
+			t.Errorf("SpokenText = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty config.Model falls back to service model", func(t *testing.T) {
+		// Service defaults to a non-v3 model, so tags are stripped.
+		s := NewElevenLabs("test-key")
+		got := s.SpokenText("[whispers]Come here", SynthesisConfig{})
+		if want := "Come here"; got != want {
+			t.Errorf("SpokenText = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("plain text unchanged", func(t *testing.T) {
+		s := NewElevenLabs("test-key")
+		if got := s.SpokenText("plain text", SynthesisConfig{}); got != "plain text" {
+			t.Errorf("SpokenText = %q, want %q", got, "plain text")
+		}
+	})
+}

--- a/sdk/session/duplex_session.go
+++ b/sdk/session/duplex_session.go
@@ -838,6 +838,17 @@ func streamElementToStreamChunk(elem *stage.StreamElement) providers.StreamChunk
 		chunk.Content = *elem.Text
 	}
 
+	// Surface the faithful spoken text of a synthesized-speech element (post
+	// markup-lowering) under a stable key, so a voice UI can caption exactly what
+	// was said. Kept OFF Delta/Content (which mean new model output) — mirrors the
+	// input_transcription key. Empty when the provider can't report it. (#1657)
+	if elem.Meta.SpokenText != "" {
+		if chunk.Metadata == nil {
+			chunk.Metadata = make(map[string]interface{})
+		}
+		chunk.Metadata["spoken_text"] = elem.Meta.SpokenText
+	}
+
 	// Handle errors
 	if elem.Error != nil {
 		chunk.Error = elem.Error

--- a/sdk/session/tts_chunk_conversion_test.go
+++ b/sdk/session/tts_chunk_conversion_test.go
@@ -37,6 +37,54 @@ func TestStreamElementToStreamChunk_SynthesizedSpeechCarriesAudioNotDelta(t *tes
 	}
 }
 
+// TestStreamElementToStreamChunk_SpokenTextSurfacedInMetadata verifies that when
+// the TTS provider reported the real spoken text (post markup-lowering) on the
+// element, the converter surfaces it on the chunk under a stable "spoken_text"
+// metadata key so a voice UI can caption exactly what was said. See #1657.
+func TestStreamElementToStreamChunk_SpokenTextSurfacedInMetadata(t *testing.T) {
+	reference := "[whispers]The capital of France is Paris."
+	spoken := "The capital of France is Paris."
+	elem := stage.StreamElement{
+		Text: &reference,
+		Audio: &stage.AudioData{
+			Samples:    []byte{0x01, 0x02},
+			SampleRate: 24000,
+			Channels:   1,
+			Format:     stage.AudioFormatPCM16,
+		},
+	}
+	elem.Meta.SynthesizedSpeech = true
+	elem.Meta.SpokenText = spoken
+
+	chunk := streamElementToStreamChunk(&elem)
+
+	assert.Equal(t, spoken, chunk.Metadata["spoken_text"],
+		"the real spoken text must be surfaced under the spoken_text metadata key")
+}
+
+// TestStreamElementToStreamChunk_NoSpokenTextNoKey guards the degrade path: a
+// provider that cannot report spoken text leaves SpokenText empty, and the
+// converter must not emit an empty spoken_text key (consumers fall back to the
+// reference/LLM text). See #1657.
+func TestStreamElementToStreamChunk_NoSpokenTextNoKey(t *testing.T) {
+	reference := "The capital of France is Paris."
+	elem := stage.StreamElement{
+		Text: &reference,
+		Audio: &stage.AudioData{
+			Samples:    []byte{0x01, 0x02},
+			SampleRate: 24000,
+			Channels:   1,
+			Format:     stage.AudioFormatPCM16,
+		},
+	}
+	elem.Meta.SynthesizedSpeech = true
+
+	chunk := streamElementToStreamChunk(&elem)
+
+	_, ok := chunk.Metadata["spoken_text"]
+	assert.False(t, ok, "no spoken_text key when the provider did not report spoken text")
+}
+
 // TestStreamElementToStreamChunk_PlainTextStillDeltas is the regression guard:
 // an ordinary streamed Text element (an LLM delta, no synthesized-speech marker)
 // must still map to Delta and Content.


### PR DESCRIPTION
## What

TTS providers lower PromptKit's bracket-tag markup differently per model, so the text submitted for synthesis (carried on the `SynthesizedSpeech` element for reference) only *approximates* what was actually spoken. A voice UI can't caption faithfully from it.

This adds an optional **`tts.SpokenTextReporter`** interface — a pure `SpokenText(text, config) string` — so a provider can report exactly what it will say after markup-lowering. That value flows onto the element and out to the duplex `Response()` chunk under a stable metadata key.

## How

- **`runtime/tts/service.go`** — new optional `SpokenTextReporter` interface.
- **Providers** implement it by delegating to their existing pure lowering functions:
  - **OpenAI** — `gpt-4o-mini-tts` moves tags to `instructions` (speaks the remainder); `tts-1`/`tts-1-hd` strip tags.
  - **Cartesia** — emotion tags become generation config; the transcript has tags removed.
  - **ElevenLabs** — `eleven_v3` keeps inline tags verbatim; older models strip them.
- **`ElementMetadata.SpokenText`** — new field; the TTS stage (`emitAudioElement`) stamps the reported value when the provider implements the interface.
- **Duplex converter** — surfaces it on the `Response()` chunk under `chunk.Metadata["spoken_text"]`.

## Degrade path

Providers that can't report return `""`; the converter omits the key entirely; consumers fall back to the reference/LLM text. No behavior change on that path — the interface is optional, so nothing existing breaks.

## Tests

- Per-provider `SpokenText`: OpenAI (tts-1 + gpt-4o-mini-tts), Cartesia, ElevenLabs (v3 + non-v3), plus plain-text and empty-`config.Model` fallback.
- Stage stamps `SpokenText` from a reporter; leaves it empty for a provider without the interface.
- Converter surfaces `spoken_text`; omits the key when empty.
- Reference docs regenerated (`tts.md`, `pipeline.md`).

Closes #1657.
