### PR TITLE
feat(classify): pure-Go video classification (#1229)

### DIFF
--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -48,10 +48,13 @@ it implements:
 - `embedding` — vector embeddings via `Embed()`.
 - `image` — image generation; Predict-compatible, so eligible for the
   arena matrix alongside `llm`.
-- `inference` — non-LLM inference (audio/text/image classifiers,
+- `inference` — non-LLM inference (audio/text/image/video classifiers,
   embedders) via the `runtime/classify` task interfaces. Powers
-  assertion handlers like `audio_emotion`. Today the only shipped
-  backend is HuggingFace; see
+  assertion handlers like `audio_emotion`, `image_moderation`, and
+  `video_moderation`. The shipped leaf backend is HuggingFace; a
+  `decompose` provider composes an image (and optional audio) classifier
+  into a video classifier, sampling frames in pure Go (GIF/MJPEG) so it
+  runs anywhere with no external codec. See
   [Inference Providers](https://promptarena.altairalabs.ai/arena/how-to/configure-providers/#inference-providers-audio--text--image-classification--embedding)
   in the configure-providers how-to.
 

--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -498,6 +498,70 @@ the raw score and rejects `min_score`/`max_score` on `eval_params`; the threshol
 lives on the `assertion`/`guardrail` wrapper. With no classify registry configured
 (keyless CI) it skips cleanly.
 
+### `video_moderation`
+
+Video content-moderation gate. Picks a video part from the chosen role's messages
+and runs it through a `VideoClassifier`, emitting the model's score for
+`expected_label` (e.g. `nsfw`). By default it scores the agent's output
+(`message_role: assistant`), covering video a tool produced during the turn.
+
+The shipped `VideoClassifier` is the **decomposing** backend: it samples frames from
+the clip, classifies each still with an `ImageClassifier`, optionally classifies the
+audio track with an `AudioClassifier`, and aggregates the per-frame scores
+(`max` / `mean` / `vote`; default `max`). Frame sampling is **pure Go** — it decodes
+animated **GIF** and **MJPEG** without any external tooling, so it runs on a
+`scratch` container. Containers that need a real codec (`mp4`/H.264, WebM) are
+reported as undecodable and the check **skips** cleanly.
+
+The backend is wired as an inference provider of `type: decompose` that references a
+sibling image (and optional audio) classifier:
+
+```yaml
+providers:
+  - id: nsfw-image
+    role: inference
+    type: huggingface
+    model: Falconsai/nsfw_image_detection
+  - id: video
+    role: inference
+    type: decompose
+    additional_config:
+      image_classifier_id: nsfw-image
+      aggregation: max          # max | mean | vote
+      frame_sample_rate: 1      # frames/sec (optional)
+```
+
+**Surfaces:** A E (conversation assertion / guardrail when wrapped; runtime eval when declared in `evals:`)
+
+**Example (assertion — "the generated clip must not be NSFW"):**
+
+```yaml
+conversation_assertions:
+  - type: assertion
+    params:
+      eval_type: video_moderation
+      eval_params:
+        model: Falconsai/nsfw_image_detection
+        expected_label: nsfw
+        # frame_sample_rate / extract_audio / aggregation are optional
+      max_score: 0.3
+```
+
+**Example (pack `evals:` — emit the raw score as a metric):**
+
+```yaml
+evals:
+  - type: video_moderation
+    params:
+      model: Falconsai/nsfw_image_detection
+      expected_label: nsfw
+```
+
+Like every classify-backed eval, `video_moderation` is a pure primitive — it emits
+the raw score and rejects `min_score`/`max_score` on `eval_params`; the threshold
+lives on the `assertion`/`guardrail` wrapper. With no classify registry configured
+(keyless CI), no video part present, or an undecodable container, it skips cleanly.
+
 ### `text_toxicity`
 
 Classifier-backed toxicity eval. Distinct from the LLM-judge [`toxicity`](#toxicity) — `text_toxicity` is the deterministic path through a HuggingFace text-classification model. Emits the model's score for `expected_label`; the `assertion` wrapper decides pass/fail based on `min_score` or `max_score`:

--- a/runtime/classify/factory.go
+++ b/runtime/classify/factory.go
@@ -107,10 +107,19 @@ func BuildRegistry(specs []ProviderSpec, defaults RegistryDefaults) (*Registry, 
 	}
 	reg := NewRegistry()
 	first := make(map[string]string)
+
+	// First pass: build every leaf backend. Composite `decompose` specs
+	// are deferred — they reference sibling classifiers that must exist
+	// first — and collected for the second pass.
+	var decomposeSpecs []ProviderSpec
 	for i := range specs {
 		spec := specs[i]
 		if spec.ID == "" {
 			return nil, fmt.Errorf("classify: inference provider at index %d has empty id", i)
+		}
+		if spec.Type == DecomposeProviderType {
+			decomposeSpecs = append(decomposeSpecs, spec)
+			continue
 		}
 		b, err := CreateFromSpec(spec)
 		if err != nil {
@@ -122,6 +131,21 @@ func BuildRegistry(specs []ProviderSpec, defaults RegistryDefaults) (*Registry, 
 			}
 		}
 	}
+
+	// Second pass: composite video classifiers, now that their referenced
+	// image/audio leaves are registered.
+	for i := range decomposeSpecs {
+		spec := decomposeSpecs[i]
+		vc, err := buildDecomposeFromSpec(reg, spec)
+		if err != nil {
+			return nil, err
+		}
+		reg.RegisterVideo(spec.ID, vc)
+		if _, ok := first["video"]; !ok {
+			first["video"] = spec.ID
+		}
+	}
+
 	if err := applyDefaults(reg, defaults, first); err != nil {
 		return nil, err
 	}

--- a/runtime/classify/framesample/gifmjpeg.go
+++ b/runtime/classify/framesample/gifmjpeg.go
@@ -1,0 +1,321 @@
+package framesample
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/draw"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"time"
+)
+
+// GIFMJPEGSampler is the shipped pure-Go Sampler. It decodes animated
+// GIF (via image/gif, with frame composition) and MJPEG / raw-JPEG
+// streams (via image/jpeg). Every other container returns
+// ErrUnsupportedContainer.
+//
+// Safe for concurrent use: it holds no state.
+type GIFMJPEGSampler struct{}
+
+// NewGIFMJPEGSampler returns the default pure-Go sampler.
+func NewGIFMJPEGSampler() *GIFMJPEGSampler { return &GIFMJPEGSampler{} }
+
+// Compile-time check.
+var _ Sampler = (*GIFMJPEGSampler)(nil)
+
+// gifDelayUnit is the duration of one unit in GIF's Delay slice
+// (hundredths of a second).
+const gifDelayUnit = 10 * time.Millisecond
+
+// assumedMJPEGInterval synthesizes timestamps for MJPEG frames, which
+// carry no container timing. Only affects reported Frame.Timestamp; the
+// classifier aggregates across frames regardless of timing.
+const assumedMJPEGInterval = 100 * time.Millisecond
+
+// Sample decodes video into sampled stills. It sniffs the container
+// from opts.MIMEType, falling back to the leading bytes.
+func (s *GIFMJPEGSampler) Sample(
+	ctx context.Context, video []byte, opts SampleOptions,
+) (SampleResult, error) {
+	if len(video) == 0 {
+		return SampleResult{}, fmt.Errorf("framesample: empty video payload")
+	}
+	switch detectContainer(video, opts.MIMEType) {
+	case containerGIF:
+		return sampleGIF(ctx, video, opts)
+	case containerMJPEG:
+		return sampleMJPEG(ctx, video, opts)
+	case containerUnknown:
+		return SampleResult{}, ErrUnsupportedContainer
+	}
+	return SampleResult{}, ErrUnsupportedContainer
+}
+
+// mimeJPEG / mimePNG label the still frames emitted by the sampler.
+const (
+	mimeJPEG = "image/jpeg"
+	mimePNG  = "image/png"
+)
+
+type container int
+
+const (
+	containerUnknown container = iota
+	containerGIF
+	containerMJPEG
+)
+
+// detectContainer resolves the container from an explicit MIME hint,
+// then from magic bytes. Unknown / codec-requiring containers resolve to
+// containerUnknown so the caller returns ErrUnsupportedContainer.
+func detectContainer(b []byte, mime string) container {
+	switch mime {
+	case "image/gif":
+		return containerGIF
+	case "video/x-motion-jpeg", mimeJPEG, "image/jpg":
+		return containerMJPEG
+	case "video/mp4", "video/quicktime", "video/webm", "video/mp2t":
+		return containerUnknown
+	}
+	switch {
+	case bytes.HasPrefix(b, []byte("GIF87a")), bytes.HasPrefix(b, []byte("GIF89a")):
+		return containerGIF
+	case bytes.HasPrefix(b, []byte{0xFF, 0xD8}):
+		return containerMJPEG
+	default:
+		return containerUnknown
+	}
+}
+
+// sampleGIF decodes an animated GIF, composes each frame onto a full
+// canvas (honoring disposal), downselects by cadence / cap, and encodes
+// the chosen frames as PNG.
+func sampleGIF(ctx context.Context, video []byte, opts SampleOptions) (SampleResult, error) {
+	g, err := gif.DecodeAll(bytes.NewReader(video))
+	if err != nil {
+		return SampleResult{}, fmt.Errorf("framesample: decode gif: %w", err)
+	}
+	if len(g.Image) == 0 {
+		return SampleResult{}, fmt.Errorf("framesample: gif has no frames")
+	}
+
+	composed, timestamps := composeGIFFrames(g)
+	picked := selectIndices(timestamps, opts)
+
+	frames := make([]Frame, 0, len(picked))
+	for _, idx := range picked {
+		if err := ctx.Err(); err != nil {
+			return SampleResult{}, err
+		}
+		var buf bytes.Buffer
+		if encErr := png.Encode(&buf, composed[idx]); encErr != nil {
+			return SampleResult{}, fmt.Errorf("framesample: encode frame %d: %w", idx, encErr)
+		}
+		frames = append(frames, Frame{
+			Data:      buf.Bytes(),
+			MIMEType:  mimePNG,
+			Timestamp: timestamps[idx],
+		})
+	}
+	return SampleResult{Frames: frames}, nil
+}
+
+// composeGIFFrames renders each GIF frame onto a persistent canvas so
+// partial frames (the common optimization where a frame only carries the
+// changed region) become complete stills. Returns the composed images
+// and each frame's start timestamp.
+func composeGIFFrames(g *gif.GIF) ([]*image.RGBA, []time.Duration) {
+	bounds := image.Rect(0, 0, g.Config.Width, g.Config.Height)
+	if bounds.Empty() {
+		// Older encoders omit Config; fall back to the first frame's rect.
+		bounds = g.Image[0].Bounds()
+	}
+	canvas := image.NewRGBA(bounds)
+	composed := make([]*image.RGBA, len(g.Image))
+	timestamps := make([]time.Duration, len(g.Image))
+
+	var elapsed time.Duration
+	for i, frame := range g.Image {
+		var prev *image.RGBA
+		disposal := disposalMethod(g, i)
+		if disposal == gif.DisposalPrevious {
+			prev = cloneRGBA(canvas)
+		}
+
+		draw.Draw(canvas, frame.Bounds(), frame, frame.Bounds().Min, draw.Over)
+		composed[i] = cloneRGBA(canvas)
+		timestamps[i] = elapsed
+		elapsed += time.Duration(delayAt(g, i)) * gifDelayUnit
+
+		switch disposal {
+		case gif.DisposalBackground:
+			draw.Draw(canvas, frame.Bounds(), image.Transparent, image.Point{}, draw.Src)
+		case gif.DisposalPrevious:
+			if prev != nil {
+				draw.Draw(canvas, canvas.Bounds(), prev, prev.Bounds().Min, draw.Src)
+			}
+		}
+	}
+	return composed, timestamps
+}
+
+// disposalMethod returns frame i's disposal code, tolerating a short or
+// nil Disposal slice (older/simple GIFs).
+func disposalMethod(g *gif.GIF, i int) byte {
+	if i < len(g.Disposal) {
+		return g.Disposal[i]
+	}
+	return gif.DisposalNone
+}
+
+// delayAt returns frame i's delay (in gifDelayUnit units), tolerating a
+// short Delay slice.
+func delayAt(g *gif.GIF, i int) int {
+	if i < len(g.Delay) {
+		return g.Delay[i]
+	}
+	return 0
+}
+
+// cloneRGBA returns a deep copy of src so a captured frame is not mutated
+// by subsequent canvas draws.
+func cloneRGBA(src *image.RGBA) *image.RGBA {
+	dst := image.NewRGBA(src.Bounds())
+	copy(dst.Pix, src.Pix)
+	return dst
+}
+
+// sampleMJPEG splits a JPEG / MJPEG stream into its constituent frames.
+// MJPEG carries no container timing, so timestamps are synthesized at a
+// fixed cadence and FramesPerSecond only influences the MaxFrames cap.
+func sampleMJPEG(ctx context.Context, video []byte, opts SampleOptions) (SampleResult, error) {
+	segments := splitJPEGFrames(video)
+	if len(segments) == 0 {
+		return SampleResult{}, fmt.Errorf("framesample: no jpeg frames found")
+	}
+	timestamps := make([]time.Duration, len(segments))
+	for i := range segments {
+		timestamps[i] = time.Duration(i) * assumedMJPEGInterval
+	}
+	picked := selectIndices(timestamps, opts)
+
+	frames := make([]Frame, 0, len(picked))
+	for _, idx := range picked {
+		if err := ctx.Err(); err != nil {
+			return SampleResult{}, err
+		}
+		// Validate the segment decodes before emitting it.
+		if _, err := jpeg.DecodeConfig(bytes.NewReader(segments[idx])); err != nil {
+			continue
+		}
+		frames = append(frames, Frame{
+			Data:      segments[idx],
+			MIMEType:  mimeJPEG,
+			Timestamp: timestamps[idx],
+		})
+	}
+	if len(frames) == 0 {
+		return SampleResult{}, fmt.Errorf("framesample: no decodable jpeg frames")
+	}
+	return SampleResult{Frames: frames}, nil
+}
+
+// jpegSOI / jpegEOI are the JPEG start-of-image and end-of-image markers.
+var (
+	jpegSOI = []byte{0xFF, 0xD8}
+	jpegEOI = []byte{0xFF, 0xD9}
+)
+
+// splitJPEGFrames extracts each JPEG frame from a concatenated MJPEG
+// stream by scanning SOI…EOI marker pairs. A single JPEG yields one
+// frame.
+func splitJPEGFrames(b []byte) [][]byte {
+	var frames [][]byte
+	for {
+		start := bytes.Index(b, jpegSOI)
+		if start < 0 {
+			break
+		}
+		end := bytes.Index(b[start+len(jpegSOI):], jpegEOI)
+		if end < 0 {
+			break
+		}
+		// end is relative to start+2; the frame includes the EOI marker.
+		frameEnd := start + len(jpegSOI) + end + len(jpegEOI)
+		frame := make([]byte, frameEnd-start)
+		copy(frame, b[start:frameEnd])
+		frames = append(frames, frame)
+		b = b[frameEnd:]
+	}
+	return frames
+}
+
+// selectIndices picks frame indices to emit. When FramesPerSecond is set
+// and the timeline has real duration, it samples evenly across the
+// timeline at that cadence; otherwise it takes every frame. The result
+// is then downselected evenly to at most the effective MaxFrames.
+func selectIndices(timestamps []time.Duration, opts SampleOptions) []int {
+	maxFrames := opts.MaxFrames
+	if maxFrames <= 0 {
+		maxFrames = DefaultMaxFrames
+	}
+
+	var idxs []int
+	total := timestamps[len(timestamps)-1]
+	if opts.FramesPerSecond > 0 && total > 0 {
+		step := time.Duration(float64(time.Second) / opts.FramesPerSecond)
+		if step <= 0 {
+			step = gifDelayUnit
+		}
+		last := -1
+		for tick := time.Duration(0); tick <= total; tick += step {
+			i := frameActiveAt(timestamps, tick)
+			if i != last {
+				idxs = append(idxs, i)
+				last = i
+			}
+		}
+	} else {
+		idxs = make([]int, len(timestamps))
+		for i := range timestamps {
+			idxs[i] = i
+		}
+	}
+	return evenlyDownselect(idxs, maxFrames)
+}
+
+// frameActiveAt returns the index of the last frame whose start timestamp
+// is <= t (the frame on screen at time t).
+func frameActiveAt(timestamps []time.Duration, t time.Duration) int {
+	active := 0
+	for i, ts := range timestamps {
+		if ts <= t {
+			active = i
+		} else {
+			break
+		}
+	}
+	return active
+}
+
+// evenlyDownselect returns at most maxFrames indices from idxs, spaced
+// evenly (always keeping the first). Returns idxs unchanged when already
+// within the cap.
+func evenlyDownselect(idxs []int, maxFrames int) []int {
+	if len(idxs) <= maxFrames {
+		return idxs
+	}
+	out := make([]int, 0, maxFrames)
+	stride := float64(len(idxs)) / float64(maxFrames)
+	for k := range maxFrames {
+		pos := int(float64(k) * stride)
+		if pos >= len(idxs) {
+			pos = len(idxs) - 1
+		}
+		out = append(out, idxs[pos])
+	}
+	return out
+}

--- a/runtime/classify/framesample/gifmjpeg_internal_test.go
+++ b/runtime/classify/framesample/gifmjpeg_internal_test.go
@@ -1,0 +1,21 @@
+package framesample
+
+import (
+	"image"
+	"image/gif"
+	"testing"
+)
+
+// TestDisposalDelayFallback covers the short-slice tolerance: a GIF whose
+// Disposal / Delay slices are shorter than its frame list (older/simpler
+// encoders) must not panic and must fall back to sane defaults.
+func TestDisposalDelayFallback(t *testing.T) {
+	g := &gif.GIF{Image: make([]*image.Paletted, 3)} // no Disposal, no Delay
+
+	if got := disposalMethod(g, 2); got != gif.DisposalNone {
+		t.Errorf("disposalMethod out-of-range = %d, want DisposalNone", got)
+	}
+	if got := delayAt(g, 2); got != 0 {
+		t.Errorf("delayAt out-of-range = %d, want 0", got)
+	}
+}

--- a/runtime/classify/framesample/gifmjpeg_test.go
+++ b/runtime/classify/framesample/gifmjpeg_test.go
@@ -1,0 +1,187 @@
+package framesample
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"testing"
+)
+
+// makeAnimatedGIF builds an n-frame animated GIF of solid-color frames,
+// each with the given per-frame delay (in hundredths of a second).
+func makeAnimatedGIF(t *testing.T, n, delayHundredths int) []byte {
+	t.Helper()
+	const w, h = 8, 6
+	pal := color.Palette{color.Black, color.White, color.RGBA{R: 255, A: 255}, color.RGBA{G: 255, A: 255}}
+	g := &gif.GIF{Config: image.Config{Width: w, Height: h}}
+	for i := range n {
+		img := image.NewPaletted(image.Rect(0, 0, w, h), pal)
+		ci := uint8(i % len(pal))
+		for p := range img.Pix {
+			img.Pix[p] = ci
+		}
+		g.Image = append(g.Image, img)
+		g.Delay = append(g.Delay, delayHundredths)
+		g.Disposal = append(g.Disposal, gif.DisposalNone)
+	}
+	var buf bytes.Buffer
+	if err := gif.EncodeAll(&buf, g); err != nil {
+		t.Fatalf("encode gif: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// makeJPEG encodes a tiny solid image as JPEG.
+func makeJPEG(t *testing.T, c color.Color) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 8, 6))
+	for x := range 8 {
+		for y := range 6 {
+			img.Set(x, y, c)
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		t.Fatalf("encode jpeg: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestGIFMJPEGSampler_GIF_AllFrames(t *testing.T) {
+	data := makeAnimatedGIF(t, 4, 5)
+	s := NewGIFMJPEGSampler()
+
+	res, err := s.Sample(context.Background(), data, SampleOptions{MIMEType: "image/gif"})
+	if err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+	if len(res.Frames) != 4 {
+		t.Fatalf("frame count = %d, want 4", len(res.Frames))
+	}
+	// Frames must be valid PNGs in timeline order.
+	var lastTS = res.Frames[0].Timestamp - 1
+	for i, f := range res.Frames {
+		if f.MIMEType != "image/png" {
+			t.Errorf("frame %d MIME = %q, want image/png", i, f.MIMEType)
+		}
+		if _, err := png.Decode(bytes.NewReader(f.Data)); err != nil {
+			t.Errorf("frame %d not a valid PNG: %v", i, err)
+		}
+		if f.Timestamp <= lastTS {
+			t.Errorf("frame %d timestamp %v not increasing (prev %v)", i, f.Timestamp, lastTS)
+		}
+		lastTS = f.Timestamp
+	}
+}
+
+func TestGIFMJPEGSampler_GIF_MaxFramesCap(t *testing.T) {
+	data := makeAnimatedGIF(t, 20, 2)
+	s := NewGIFMJPEGSampler()
+
+	res, err := s.Sample(context.Background(), data, SampleOptions{MaxFrames: 5})
+	if err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+	if len(res.Frames) != 5 {
+		t.Fatalf("frame count = %d, want 5 (capped)", len(res.Frames))
+	}
+}
+
+func TestGIFMJPEGSampler_GIF_DefaultCap(t *testing.T) {
+	data := makeAnimatedGIF(t, 40, 1)
+	s := NewGIFMJPEGSampler()
+
+	res, err := s.Sample(context.Background(), data, SampleOptions{})
+	if err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+	if len(res.Frames) != DefaultMaxFrames {
+		t.Fatalf("frame count = %d, want DefaultMaxFrames %d", len(res.Frames), DefaultMaxFrames)
+	}
+}
+
+func TestGIFMJPEGSampler_GIF_FramesPerSecond(t *testing.T) {
+	// 10 frames at 100ms each → 1s total. Sampling at 2fps should yield
+	// roughly 3 frames (t=0, 0.5, 1.0), far fewer than all 10.
+	data := makeAnimatedGIF(t, 10, 10)
+	s := NewGIFMJPEGSampler()
+
+	res, err := s.Sample(context.Background(), data, SampleOptions{FramesPerSecond: 2})
+	if err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+	if len(res.Frames) == 0 || len(res.Frames) >= 10 {
+		t.Fatalf("fps sampling frame count = %d, want a downsampled subset (0 < n < 10)", len(res.Frames))
+	}
+}
+
+func TestGIFMJPEGSampler_MJPEG_TwoFrames(t *testing.T) {
+	red := makeJPEG(t, color.RGBA{R: 255, A: 255})
+	green := makeJPEG(t, color.RGBA{G: 255, A: 255})
+	stream := append(append([]byte{}, red...), green...)
+	s := NewGIFMJPEGSampler()
+
+	res, err := s.Sample(context.Background(), stream, SampleOptions{MIMEType: "video/x-motion-jpeg"})
+	if err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+	if len(res.Frames) != 2 {
+		t.Fatalf("frame count = %d, want 2", len(res.Frames))
+	}
+	for i, f := range res.Frames {
+		if f.MIMEType != "image/jpeg" {
+			t.Errorf("frame %d MIME = %q, want image/jpeg", i, f.MIMEType)
+		}
+		if _, err := jpeg.DecodeConfig(bytes.NewReader(f.Data)); err != nil {
+			t.Errorf("frame %d not a valid JPEG: %v", i, err)
+		}
+	}
+}
+
+func TestGIFMJPEGSampler_SingleJPEG_OneFrame(t *testing.T) {
+	data := makeJPEG(t, color.RGBA{B: 255, A: 255})
+	s := NewGIFMJPEGSampler()
+
+	res, err := s.Sample(context.Background(), data, SampleOptions{})
+	if err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+	if len(res.Frames) != 1 {
+		t.Fatalf("frame count = %d, want 1", len(res.Frames))
+	}
+}
+
+func TestGIFMJPEGSampler_UnsupportedContainer(t *testing.T) {
+	// Minimal MP4 ftyp box header.
+	mp4 := []byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'm', 'p', '4', '2', 0, 0, 0, 0}
+	s := NewGIFMJPEGSampler()
+
+	_, err := s.Sample(context.Background(), mp4, SampleOptions{})
+	if !errors.Is(err, ErrUnsupportedContainer) {
+		t.Fatalf("err = %v, want ErrUnsupportedContainer", err)
+	}
+}
+
+func TestGIFMJPEGSampler_UnsupportedByMIME(t *testing.T) {
+	s := NewGIFMJPEGSampler()
+	_, err := s.Sample(context.Background(), []byte("whatever bytes"), SampleOptions{MIMEType: "video/mp4"})
+	if !errors.Is(err, ErrUnsupportedContainer) {
+		t.Fatalf("err = %v, want ErrUnsupportedContainer", err)
+	}
+}
+
+func TestGIFMJPEGSampler_EmptyPayload(t *testing.T) {
+	s := NewGIFMJPEGSampler()
+	_, err := s.Sample(context.Background(), nil, SampleOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty payload")
+	}
+	if errors.Is(err, ErrUnsupportedContainer) {
+		t.Fatal("empty payload should be a plain error, not ErrUnsupportedContainer")
+	}
+}

--- a/runtime/classify/framesample/sampler.go
+++ b/runtime/classify/framesample/sampler.go
@@ -1,0 +1,87 @@
+// Package framesample decodes video bytes into evenly-spaced still
+// frames (plus an optional audio track) so a decomposing video
+// classifier can route them through image and audio classifiers.
+//
+// The shipped implementation is pure Go — no CGO and no subprocess to
+// system tools (ffmpeg et al.) — so it runs on a `FROM scratch`
+// container. That constraint bounds the supported containers: animated
+// GIF (fully native via image/gif) and MJPEG / raw-JPEG streams.
+// Containers that need a real codec (mp4/H.264, WebM/VP9, MPEG-TS) are
+// reported with ErrUnsupportedContainer rather than decoded — a caller
+// running in a richer environment can supply an ffmpeg-backed Sampler
+// behind this same interface without touching the classifier.
+package framesample
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrUnsupportedContainer is returned when the input container cannot be
+// decoded by the pure-Go sampler. Eval handlers map it to a skipped
+// result — it is an environmental limitation, not a failure the user
+// misconfigured.
+var ErrUnsupportedContainer = errors.New("framesample: unsupported container for pure-Go decoding")
+
+// Sampler turns video bytes into sampled still frames and, optionally,
+// the raw audio track. Implementations must be safe for concurrent use.
+type Sampler interface {
+	Sample(ctx context.Context, video []byte, opts SampleOptions) (SampleResult, error)
+}
+
+// SampleOptions steers a Sample call. Zero values select sensible
+// defaults; a sampler ignores fields it cannot honor.
+type SampleOptions struct {
+	// MIMEType is the container hint (e.g. "image/gif",
+	// "video/x-motion-jpeg"). Empty means "sniff from the bytes".
+	MIMEType string
+
+	// FramesPerSecond is the target sampling cadence. Frames are picked
+	// evenly across the clip's timeline at this rate. 0 selects every
+	// decoded frame (still bounded by MaxFrames).
+	FramesPerSecond float64
+
+	// MaxFrames caps how many frames Sample returns, so a long clip
+	// cannot fan out into an unbounded number of image classifications.
+	// 0 uses the sampler default (DefaultMaxFrames).
+	MaxFrames int
+
+	// ExtractAudio requests the audio track when the container carries a
+	// decodable one. GIF has no audio; MJPEG has none — for the shipped
+	// pure-Go sampler this is a forward-compatibility seam that yields a
+	// nil AudioPCM today.
+	ExtractAudio bool
+}
+
+// SampleResult is the decoded output of a Sample call.
+type SampleResult struct {
+	// Frames are the sampled stills in timeline order, each encoded as a
+	// standalone image (PNG for GIF-sourced frames, the original JPEG
+	// bytes for MJPEG-sourced frames).
+	Frames []Frame
+
+	// AudioPCM is the raw audio track when ExtractAudio was set and the
+	// container carried a decodable one; nil otherwise.
+	AudioPCM []byte
+
+	// AudioMIME describes AudioPCM (e.g. "audio/wav") when present.
+	AudioMIME string
+}
+
+// Frame is a single sampled still image plus its position in the clip.
+type Frame struct {
+	// Data is the encoded still image.
+	Data []byte
+
+	// MIMEType is Data's encoding (e.g. "image/png", "image/jpeg").
+	MIMEType string
+
+	// Timestamp is the frame's offset from the start of the clip.
+	Timestamp time.Duration
+}
+
+// DefaultMaxFrames bounds fan-out when SampleOptions.MaxFrames is 0.
+// Keeps a long animation from spawning hundreds of image
+// classifications; max/mean/vote aggregation is robust to sampling.
+const DefaultMaxFrames = 16

--- a/runtime/classify/types.go
+++ b/runtime/classify/types.go
@@ -103,6 +103,12 @@ type VideoOptions struct {
 	// audio track through their AudioClassifier as well as their
 	// ImageClassifier. Default false.
 	ExtractAudio bool
+
+	// Aggregation names how a decomposing backend collapses per-frame
+	// (and audio-window) label scores into a single result: "max",
+	// "mean", or "vote". Empty selects the backend default (max).
+	// Whole-clip backends ignore it.
+	Aggregation string
 }
 
 // EmbedOptions carries per-call knobs for text embedding.

--- a/runtime/classify/video_decompose.go
+++ b/runtime/classify/video_decompose.go
@@ -1,0 +1,316 @@
+package classify
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify/framesample"
+)
+
+// Aggregation strategies for the decomposing video classifier. They
+// name how per-frame (and audio-window) label scores collapse into a
+// single result.
+const (
+	// AggregationMax takes each label's highest score across frames —
+	// the default, since moderation cares about the worst frame.
+	AggregationMax = "max"
+	// AggregationMean averages each label's score across all frames
+	// (absent-in-a-frame counts as zero).
+	AggregationMean = "mean"
+	// AggregationVote scores each label by the fraction of frames whose
+	// top label it was.
+	AggregationVote = "vote"
+)
+
+// defaultFrameConcurrency bounds parallel per-frame classification.
+const defaultFrameConcurrency = 4
+
+// DecomposeConfig configures a decomposing video classifier: which
+// sub-models to use, how to sample, and how to aggregate. Per-call
+// VideoOptions override the sampling cadence, model, and aggregation.
+type DecomposeConfig struct {
+	// ImageModel is the default model id passed to the ImageClassifier
+	// for each frame. VideoOptions.Model overrides it per call.
+	ImageModel string
+
+	// AudioModel is the model id passed to the AudioClassifier when
+	// ExtractAudio is set and an audio track is present.
+	AudioModel string
+
+	// Aggregation is the default strategy (max|mean|vote).
+	// VideoOptions.Aggregation overrides it. Empty ⇒ AggregationMax.
+	Aggregation string
+
+	// FramesPerSecond is the default sampling cadence.
+	// VideoOptions.FrameSampleRate overrides it. 0 ⇒ sampler default.
+	FramesPerSecond float64
+
+	// MaxFrames caps sampled frames. 0 ⇒ sampler default.
+	MaxFrames int
+
+	// MaxConcurrency bounds parallel frame classification.
+	// 0 ⇒ defaultFrameConcurrency.
+	MaxConcurrency int
+}
+
+// decomposingVideoClassifier implements VideoClassifier by sampling
+// frames from a video, classifying each still with an ImageClassifier,
+// optionally classifying the audio track with an AudioClassifier, and
+// aggregating the per-modality scores into one ranked result.
+//
+// Safe for concurrent use: the sampler and sub-classifiers must be too
+// (they are, per their interface contracts).
+type decomposingVideoClassifier struct {
+	sampler framesample.Sampler
+	image   ImageClassifier
+	audio   AudioClassifier // optional; nil ⇒ frames only
+	cfg     DecomposeConfig
+}
+
+// NewDecomposingVideoClassifier composes a VideoClassifier from a frame
+// sampler, an ImageClassifier (required), and an optional
+// AudioClassifier. It holds the classifier instances directly, so it is
+// registry-agnostic and trivial to unit-test with fakes.
+func NewDecomposingVideoClassifier(
+	sampler framesample.Sampler,
+	image ImageClassifier,
+	audio AudioClassifier,
+	cfg DecomposeConfig,
+) (VideoClassifier, error) {
+	if sampler == nil {
+		return nil, fmt.Errorf("classify: decomposing video classifier requires a frame sampler")
+	}
+	if image == nil {
+		return nil, fmt.Errorf("classify: decomposing video classifier requires an image classifier")
+	}
+	if cfg.Aggregation == "" {
+		cfg.Aggregation = AggregationMax
+	}
+	return &decomposingVideoClassifier{sampler: sampler, image: image, audio: audio, cfg: cfg}, nil
+}
+
+// ClassifyVideo samples frames, classifies each (and optionally the
+// audio track), and aggregates the scores. ErrUnsupportedContainer from
+// the sampler propagates unchanged so callers can map it to a skip.
+func (d *decomposingVideoClassifier) ClassifyVideo(
+	ctx context.Context, video []byte, opts VideoOptions,
+) ([]LabelScore, error) {
+	extractAudio := opts.ExtractAudio && d.audio != nil
+	res, err := d.sampler.Sample(ctx, video, framesample.SampleOptions{
+		MIMEType:        opts.MIMEType,
+		FramesPerSecond: pickFloat(opts.FrameSampleRate, d.cfg.FramesPerSecond),
+		MaxFrames:       d.cfg.MaxFrames,
+		ExtractAudio:    extractAudio,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(res.Frames) == 0 {
+		return nil, fmt.Errorf("classify: no frames decoded from video")
+	}
+
+	imageModel := opts.Model
+	if imageModel == "" {
+		imageModel = d.cfg.ImageModel
+	}
+	groups, err := d.classifyFrames(ctx, res.Frames, imageModel)
+	if err != nil {
+		return nil, err
+	}
+
+	if extractAudio && len(res.AudioPCM) > 0 {
+		audioScores, audioErr := d.audio.ClassifyAudio(ctx, res.AudioPCM, AudioOptions{
+			Model:    d.cfg.AudioModel,
+			MIMEType: res.AudioMIME,
+		})
+		if audioErr != nil {
+			return nil, fmt.Errorf("classify: audio track: %w", audioErr)
+		}
+		groups = append(groups, audioScores)
+	}
+
+	strategy := opts.Aggregation
+	if strategy == "" {
+		strategy = d.cfg.Aggregation
+	}
+	return aggregateScores(groups, strategy), nil
+}
+
+// classifyFrames runs each frame through the ImageClassifier with bounded
+// concurrency, preserving frame order. The first error cancels the rest.
+func (d *decomposingVideoClassifier) classifyFrames(
+	ctx context.Context, frames []framesample.Frame, model string,
+) ([][]LabelScore, error) {
+	conc := d.cfg.MaxConcurrency
+	if conc <= 0 {
+		conc = defaultFrameConcurrency
+	}
+	results := make([][]LabelScore, len(frames))
+	sem := make(chan struct{}, conc)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for i := range frames {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if ctx.Err() != nil {
+				return
+			}
+			scores, err := d.image.ClassifyImage(ctx, frames[i].Data, ImageOptions{
+				Model:    model,
+				MIMEType: frames[i].MIMEType,
+			})
+			if err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("classify: frame %d: %w", i, err)
+					cancel()
+				}
+				mu.Unlock()
+				return
+			}
+			results[i] = scores
+		}(i)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return results, nil
+}
+
+// pickFloat returns override when positive, else fallback.
+func pickFloat(override, fallback float64) float64 {
+	if override > 0 {
+		return override
+	}
+	return fallback
+}
+
+// aggregateScores collapses per-frame/audio label-score groups into a
+// single ranked slice using the named strategy. Unknown strategies fall
+// back to max. Labels are matched case-insensitively; the first-seen
+// casing is preserved in the output.
+func aggregateScores(groups [][]LabelScore, strategy string) []LabelScore {
+	total := len(groups)
+	if total == 0 {
+		return nil
+	}
+
+	switch strategy {
+	case AggregationMean:
+		return aggregateMean(groups, total)
+	case AggregationVote:
+		return aggregateVote(groups, total)
+	default: // AggregationMax and unknown
+		return aggregateMax(groups)
+	}
+}
+
+// labelKey normalizes a label for case-insensitive grouping.
+func labelKey(label string) string { return strings.ToLower(label) }
+
+// canonicalLabels tracks the first-seen display casing for each key so
+// aggregated output uses stable, human-readable labels.
+type labelAccumulator struct {
+	display map[string]string
+	order   []string
+}
+
+func newLabelAccumulator() *labelAccumulator {
+	return &labelAccumulator{display: make(map[string]string)}
+}
+
+func (a *labelAccumulator) note(label string) string {
+	key := labelKey(label)
+	if _, ok := a.display[key]; !ok {
+		a.display[key] = label
+		a.order = append(a.order, key)
+	}
+	return key
+}
+
+func aggregateMax(groups [][]LabelScore) []LabelScore {
+	acc := newLabelAccumulator()
+	best := make(map[string]float64)
+	for _, g := range groups {
+		for _, s := range g {
+			key := acc.note(s.Label)
+			if s.Score > best[key] {
+				best[key] = s.Score
+			}
+		}
+	}
+	return acc.sorted(best)
+}
+
+func aggregateMean(groups [][]LabelScore, total int) []LabelScore {
+	acc := newLabelAccumulator()
+	sum := make(map[string]float64)
+	for _, g := range groups {
+		for _, s := range g {
+			key := acc.note(s.Label)
+			sum[key] += s.Score
+		}
+	}
+	mean := make(map[string]float64, len(sum))
+	for key, v := range sum {
+		mean[key] = v / float64(total)
+	}
+	return acc.sorted(mean)
+}
+
+func aggregateVote(groups [][]LabelScore, total int) []LabelScore {
+	acc := newLabelAccumulator()
+	votes := make(map[string]float64)
+	for _, g := range groups {
+		if top, ok := topLabel(g); ok {
+			key := acc.note(top)
+			votes[key]++
+		}
+	}
+	for key := range votes {
+		votes[key] /= float64(total)
+	}
+	return acc.sorted(votes)
+}
+
+// topLabel returns the highest-scoring label in a group.
+func topLabel(g []LabelScore) (string, bool) {
+	if len(g) == 0 {
+		return "", false
+	}
+	best := g[0]
+	for _, s := range g[1:] {
+		if s.Score > best.Score {
+			best = s
+		}
+	}
+	return best.Label, true
+}
+
+// sorted materializes the accumulated scores as a slice ranked by
+// descending score, with label as a stable tiebreaker.
+func (a *labelAccumulator) sorted(scores map[string]float64) []LabelScore {
+	out := make([]LabelScore, 0, len(a.order))
+	for _, key := range a.order {
+		out = append(out, LabelScore{Label: a.display[key], Score: scores[key]})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].Label < out[j].Label
+	})
+	return out
+}

--- a/runtime/classify/video_decompose_factory.go
+++ b/runtime/classify/video_decompose_factory.go
@@ -1,0 +1,97 @@
+package classify
+
+import (
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify/framesample"
+)
+
+// DecomposeProviderType is the inference-provider `type` that builds a
+// decomposing VideoClassifier from sibling image/audio classifiers.
+// Unlike leaf providers it has no standalone factory — a composite must
+// reference already-registered backends, so BuildRegistry resolves it in
+// a second pass (see buildDecomposeFromSpec).
+const DecomposeProviderType = "decompose"
+
+// buildDecomposeFromSpec constructs a decomposing VideoClassifier from a
+// `type: decompose` spec, resolving its image (required) and audio
+// (optional) sub-classifiers from the already-populated registry.
+//
+// additional_config keys:
+//   - image_classifier_id  string  (required) — registry id of the ImageClassifier
+//   - audio_classifier_id  string  (optional) — registry id of the AudioClassifier
+//   - image_model          string  — model id passed per frame
+//   - audio_model          string  — model id passed to the audio track
+//   - aggregation          string  — max|mean|vote (default max)
+//   - frame_sample_rate    number  — frames/sec to sample
+//   - max_frames           number  — cap on sampled frames
+//   - max_concurrency      number  — bound on parallel frame classification
+func buildDecomposeFromSpec(reg *Registry, spec ProviderSpec) (VideoClassifier, error) {
+	ac := spec.AdditionalConfig
+
+	imageID := stringFromConfig(ac, "image_classifier_id")
+	if imageID == "" {
+		return nil, fmt.Errorf(
+			"classify: decompose provider %q requires additional_config.image_classifier_id", spec.ID)
+	}
+	img, err := reg.ImageClassifier(imageID)
+	if err != nil {
+		return nil, fmt.Errorf("classify: decompose provider %q: image classifier: %w", spec.ID, err)
+	}
+
+	var audio AudioClassifier
+	if audioID := stringFromConfig(ac, "audio_classifier_id"); audioID != "" {
+		audio, err = reg.AudioClassifier(audioID)
+		if err != nil {
+			return nil, fmt.Errorf("classify: decompose provider %q: audio classifier: %w", spec.ID, err)
+		}
+	}
+
+	imageModel := stringFromConfig(ac, "image_model")
+	if imageModel == "" {
+		imageModel = spec.Model
+	}
+	cfg := DecomposeConfig{
+		ImageModel:      imageModel,
+		AudioModel:      stringFromConfig(ac, "audio_model"),
+		Aggregation:     stringFromConfig(ac, "aggregation"),
+		FramesPerSecond: floatFromConfig(ac, "frame_sample_rate"),
+		MaxFrames:       intFromConfig(ac, "max_frames"),
+		MaxConcurrency:  intFromConfig(ac, "max_concurrency"),
+	}
+	return NewDecomposingVideoClassifier(framesample.NewGIFMJPEGSampler(), img, audio, cfg)
+}
+
+// stringFromConfig reads a string flag from additional_config, returning
+// "" when absent or the wrong type. Safe on a nil map.
+func stringFromConfig(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// floatFromConfig reads a numeric flag, tolerating int or float64 (JSON
+// decodes numbers as float64; programmatic callers may pass int).
+func floatFromConfig(m map[string]any, key string) float64 {
+	switch v := m[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	default:
+		return 0
+	}
+}
+
+// intFromConfig reads an integer flag, tolerating float64 (JSON numbers).
+func intFromConfig(m map[string]any, key string) int {
+	switch v := m[key].(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
+}

--- a/runtime/classify/video_decompose_factory_test.go
+++ b/runtime/classify/video_decompose_factory_test.go
@@ -1,0 +1,136 @@
+package classify_test
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/gif"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+)
+
+// fakeImage returns a fixed score for any frame, so a decompose provider
+// built over it yields a predictable aggregate.
+type fakeImage struct{}
+
+func (fakeImage) ClassifyImage(_ context.Context, _ []byte, _ classify.ImageOptions) ([]classify.LabelScore, error) {
+	return []classify.LabelScore{{Label: "nsfw", Score: 0.77}, {Label: "safe", Score: 0.23}}, nil
+}
+
+// tinyGIF builds a 3-frame animated GIF for the decompose path to sample.
+func tinyGIF(t *testing.T) []byte {
+	t.Helper()
+	pal := color.Palette{color.Black, color.White}
+	g := &gif.GIF{Config: image.Config{Width: 4, Height: 4}}
+	for i := range 3 {
+		img := image.NewPaletted(image.Rect(0, 0, 4, 4), pal)
+		for p := range img.Pix {
+			img.Pix[p] = uint8(i % 2)
+		}
+		g.Image = append(g.Image, img)
+		g.Delay = append(g.Delay, 5)
+	}
+	var buf bytes.Buffer
+	if err := gif.EncodeAll(&buf, g); err != nil {
+		t.Fatalf("encode gif: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestBuildRegistry_DecomposeProvider(t *testing.T) {
+	classify.RegisterFactory("fakeimg_dcp", func(_ classify.ProviderSpec) (classify.Backend, error) {
+		return fakeImage{}, nil
+	})
+	specs := []classify.ProviderSpec{
+		{ID: "img", Type: "fakeimg_dcp"},
+		{ID: "vid", Type: classify.DecomposeProviderType, AdditionalConfig: map[string]any{
+			"image_classifier_id": "img",
+			"aggregation":         classify.AggregationMax,
+		}},
+	}
+	reg, err := classify.BuildRegistry(specs, classify.RegistryDefaults{})
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+
+	// The composite is registered under its id and becomes the default video
+	// classifier (first-wins).
+	vc, err := reg.VideoClassifier("")
+	if err != nil {
+		t.Fatalf("default video classifier: %v", err)
+	}
+
+	scores, err := vc.ClassifyVideo(context.Background(), tinyGIF(t), classify.VideoOptions{})
+	if err != nil {
+		t.Fatalf("ClassifyVideo: %v", err)
+	}
+	if len(scores) == 0 || scores[0].Label != "nsfw" || scores[0].Score != 0.77 {
+		t.Fatalf("aggregate scores = %v, want top nsfw 0.77", scores)
+	}
+}
+
+func TestBuildRegistry_DecomposeWithAudio(t *testing.T) {
+	// fakeAll (from factory_test.go) satisfies both image and audio, so one
+	// backend can back both refs — exercises the audio-resolution branch.
+	classify.RegisterFactory("fakeav_dcp", func(_ classify.ProviderSpec) (classify.Backend, error) {
+		return fakeAll{}, nil
+	})
+	specs := []classify.ProviderSpec{
+		{ID: "av", Type: "fakeav_dcp"},
+		{ID: "vid", Type: classify.DecomposeProviderType, AdditionalConfig: map[string]any{
+			"image_classifier_id": "av",
+			"audio_classifier_id": "av",
+			"audio_model":         "audio-model",
+			"frame_sample_rate":   1,
+			"max_frames":          8,
+		}},
+	}
+	reg, err := classify.BuildRegistry(specs, classify.RegistryDefaults{})
+	if err != nil {
+		t.Fatalf("BuildRegistry: %v", err)
+	}
+	if _, err := reg.VideoClassifier("vid"); err != nil {
+		t.Fatalf("video classifier should resolve: %v", err)
+	}
+}
+
+func TestBuildRegistry_DecomposeUnknownAudioRef(t *testing.T) {
+	classify.RegisterFactory("fakeimg_dcp2", func(_ classify.ProviderSpec) (classify.Backend, error) {
+		return fakeImage{}, nil
+	})
+	specs := []classify.ProviderSpec{
+		{ID: "img", Type: "fakeimg_dcp2"},
+		{ID: "vid", Type: classify.DecomposeProviderType, AdditionalConfig: map[string]any{
+			"image_classifier_id": "img",
+			"audio_classifier_id": "missing-audio",
+		}},
+	}
+	_, err := classify.BuildRegistry(specs, classify.RegistryDefaults{})
+	if err == nil {
+		t.Fatal("expected error when audio_classifier_id references an unregistered backend")
+	}
+}
+
+func TestBuildRegistry_DecomposeMissingImageID(t *testing.T) {
+	specs := []classify.ProviderSpec{
+		{ID: "vid", Type: classify.DecomposeProviderType, AdditionalConfig: map[string]any{}},
+	}
+	_, err := classify.BuildRegistry(specs, classify.RegistryDefaults{})
+	if err == nil {
+		t.Fatal("expected error when image_classifier_id is missing")
+	}
+}
+
+func TestBuildRegistry_DecomposeUnknownImageRef(t *testing.T) {
+	specs := []classify.ProviderSpec{
+		{ID: "vid", Type: classify.DecomposeProviderType, AdditionalConfig: map[string]any{
+			"image_classifier_id": "does-not-exist",
+		}},
+	}
+	_, err := classify.BuildRegistry(specs, classify.RegistryDefaults{})
+	if err == nil {
+		t.Fatal("expected error when image_classifier_id references an unregistered backend")
+	}
+}

--- a/runtime/classify/video_decompose_internal_test.go
+++ b/runtime/classify/video_decompose_internal_test.go
@@ -1,0 +1,60 @@
+package classify
+
+import "testing"
+
+func TestConfigHelpers(t *testing.T) {
+	m := map[string]any{"s": "x", "asInt": 3, "asFloat": 2.5, "n": 4, "nf": 7.0}
+
+	if got := stringFromConfig(m, "s"); got != "x" {
+		t.Errorf("stringFromConfig hit = %q, want x", got)
+	}
+	if got := stringFromConfig(m, "missing"); got != "" {
+		t.Errorf("stringFromConfig missing = %q, want empty", got)
+	}
+	if got := stringFromConfig(m, "n"); got != "" {
+		t.Errorf("stringFromConfig wrong-type = %q, want empty", got)
+	}
+
+	if got := floatFromConfig(m, "asFloat"); got != 2.5 {
+		t.Errorf("floatFromConfig float64 = %v, want 2.5", got)
+	}
+	if got := floatFromConfig(m, "asInt"); got != 3 {
+		t.Errorf("floatFromConfig int = %v, want 3", got)
+	}
+	if got := floatFromConfig(m, "s"); got != 0 {
+		t.Errorf("floatFromConfig default = %v, want 0", got)
+	}
+
+	if got := intFromConfig(m, "n"); got != 4 {
+		t.Errorf("intFromConfig int = %v, want 4", got)
+	}
+	if got := intFromConfig(m, "nf"); got != 7 {
+		t.Errorf("intFromConfig float64 = %v, want 7", got)
+	}
+	if got := intFromConfig(m, "s"); got != 0 {
+		t.Errorf("intFromConfig default = %v, want 0", got)
+	}
+}
+
+func TestAggregateScores_Empty(t *testing.T) {
+	if got := aggregateScores(nil, AggregationMax); got != nil {
+		t.Errorf("aggregateScores(nil) = %v, want nil", got)
+	}
+}
+
+func TestAggregateScores_UnknownStrategyFallsBackToMax(t *testing.T) {
+	groups := [][]LabelScore{
+		{{Label: "a", Score: 0.2}},
+		{{Label: "a", Score: 0.9}},
+	}
+	got := aggregateScores(groups, "not-a-strategy")
+	if len(got) != 1 || got[0].Score != 0.9 {
+		t.Errorf("unknown strategy = %v, want max fallback (a=0.9)", got)
+	}
+}
+
+func TestTopLabel_Empty(t *testing.T) {
+	if _, ok := topLabel(nil); ok {
+		t.Error("topLabel(nil) should report no label")
+	}
+}

--- a/runtime/classify/video_decompose_test.go
+++ b/runtime/classify/video_decompose_test.go
@@ -1,0 +1,271 @@
+package classify
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify/framesample"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeSampler struct {
+	res     framesample.SampleResult
+	err     error
+	mu      sync.Mutex
+	gotOpts framesample.SampleOptions
+}
+
+func (f *fakeSampler) Sample(
+	_ context.Context, _ []byte, opts framesample.SampleOptions,
+) (framesample.SampleResult, error) {
+	f.mu.Lock()
+	f.gotOpts = opts
+	f.mu.Unlock()
+	return f.res, f.err
+}
+
+type fakeImageClassifier struct {
+	byData map[string][]LabelScore
+	err    error
+	mu     sync.Mutex
+	models map[string]int
+}
+
+func (f *fakeImageClassifier) ClassifyImage(
+	_ context.Context, img []byte, opts ImageOptions,
+) ([]LabelScore, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.mu.Lock()
+	if f.models == nil {
+		f.models = map[string]int{}
+	}
+	f.models[opts.Model]++
+	f.mu.Unlock()
+	return f.byData[string(img)], nil
+}
+
+type fakeAudioClassifier struct {
+	scores []LabelScore
+	err    error
+	gotPCM []byte
+}
+
+func (f *fakeAudioClassifier) ClassifyAudio(
+	_ context.Context, audio []byte, _ AudioOptions,
+) ([]LabelScore, error) {
+	f.gotPCM = audio
+	return f.scores, f.err
+}
+
+// framesFrom builds sampler frames with distinct data payloads.
+func framesFrom(datas ...string) []framesample.Frame {
+	out := make([]framesample.Frame, len(datas))
+	for i, d := range datas {
+		out[i] = framesample.Frame{Data: []byte(d), MIMEType: "image/png", Timestamp: time.Duration(i) * time.Second}
+	}
+	return out
+}
+
+func twoFrameSetup() (*fakeSampler, *fakeImageClassifier) {
+	sampler := &fakeSampler{res: framesample.SampleResult{Frames: framesFrom("f0", "f1")}}
+	img := &fakeImageClassifier{byData: map[string][]LabelScore{
+		"f0": {{Label: "nsfw", Score: 0.9}, {Label: "safe", Score: 0.1}},
+		"f1": {{Label: "nsfw", Score: 0.2}, {Label: "safe", Score: 0.8}},
+	}}
+	return sampler, img
+}
+
+func scoreOf(scores []LabelScore, label string) (float64, bool) {
+	for _, s := range scores {
+		if s.Label == label {
+			return s.Score, true
+		}
+	}
+	return 0, false
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestNewDecomposingVideoClassifier_Validation(t *testing.T) {
+	img := &fakeImageClassifier{}
+	if _, err := NewDecomposingVideoClassifier(nil, img, nil, DecomposeConfig{}); err == nil {
+		t.Error("expected error for nil sampler")
+	}
+	if _, err := NewDecomposingVideoClassifier(&fakeSampler{}, nil, nil, DecomposeConfig{}); err == nil {
+		t.Error("expected error for nil image classifier")
+	}
+}
+
+func TestClassifyVideo_AggregateMax(t *testing.T) {
+	sampler, img := twoFrameSetup()
+	vc, err := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scores, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{})
+	if err != nil {
+		t.Fatalf("ClassifyVideo: %v", err)
+	}
+	// Default aggregation is max: nsfw=max(0.9,0.2)=0.9, safe=max(0.1,0.8)=0.8.
+	if got, _ := scoreOf(scores, "nsfw"); got != 0.9 {
+		t.Errorf("nsfw = %v, want 0.9", got)
+	}
+	if got, _ := scoreOf(scores, "safe"); got != 0.8 {
+		t.Errorf("safe = %v, want 0.8", got)
+	}
+	// Ranked descending: nsfw (0.9) before safe (0.8).
+	if scores[0].Label != "nsfw" {
+		t.Errorf("top label = %q, want nsfw", scores[0].Label)
+	}
+}
+
+func TestClassifyVideo_AggregateMean(t *testing.T) {
+	sampler, img := twoFrameSetup()
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{Aggregation: AggregationMean})
+
+	scores, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mean over 2 frames: nsfw=(0.9+0.2)/2=0.55, safe=(0.1+0.8)/2=0.45.
+	if got, _ := scoreOf(scores, "nsfw"); !approx(got, 0.55) {
+		t.Errorf("nsfw mean = %v, want 0.55", got)
+	}
+	if got, _ := scoreOf(scores, "safe"); !approx(got, 0.45) {
+		t.Errorf("safe mean = %v, want 0.45", got)
+	}
+}
+
+func TestClassifyVideo_AggregateVote(t *testing.T) {
+	sampler, img := twoFrameSetup()
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{Aggregation: AggregationVote})
+
+	scores, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// f0 top=nsfw, f1 top=safe → each 1/2.
+	if got, _ := scoreOf(scores, "nsfw"); !approx(got, 0.5) {
+		t.Errorf("nsfw vote = %v, want 0.5", got)
+	}
+	if got, _ := scoreOf(scores, "safe"); !approx(got, 0.5) {
+		t.Errorf("safe vote = %v, want 0.5", got)
+	}
+}
+
+func TestClassifyVideo_PerCallAggregationOverride(t *testing.T) {
+	sampler, img := twoFrameSetup()
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{Aggregation: AggregationMax})
+
+	scores, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{Aggregation: AggregationMean})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := scoreOf(scores, "nsfw"); !approx(got, 0.55) {
+		t.Errorf("per-call mean override: nsfw = %v, want 0.55", got)
+	}
+}
+
+func TestClassifyVideo_WithAudio(t *testing.T) {
+	sampler, img := twoFrameSetup()
+	sampler.res.AudioPCM = []byte("pcm")
+	sampler.res.AudioMIME = "audio/wav"
+	audio := &fakeAudioClassifier{scores: []LabelScore{{Label: "angry", Score: 0.6}}}
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, audio, DecomposeConfig{Aggregation: AggregationMax})
+
+	scores, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{ExtractAudio: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := scoreOf(scores, "angry"); !ok || got != 0.6 {
+		t.Errorf("angry = %v (found %v), want 0.6", got, ok)
+	}
+	if string(audio.gotPCM) != "pcm" {
+		t.Errorf("audio classifier got PCM %q, want pcm", audio.gotPCM)
+	}
+	if !sampler.gotOpts.ExtractAudio {
+		t.Error("sampler should have been asked to extract audio")
+	}
+}
+
+func TestClassifyVideo_AudioIgnoredWhenNoAudioClassifier(t *testing.T) {
+	sampler, img := twoFrameSetup()
+	sampler.res.AudioPCM = []byte("pcm")
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{})
+
+	_, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{ExtractAudio: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// With no audio classifier, the sampler must not be asked for audio.
+	if sampler.gotOpts.ExtractAudio {
+		t.Error("sampler asked to extract audio despite nil audio classifier")
+	}
+}
+
+func TestClassifyVideo_UnsupportedContainerPropagates(t *testing.T) {
+	sampler := &fakeSampler{err: framesample.ErrUnsupportedContainer}
+	img := &fakeImageClassifier{}
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{})
+
+	_, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{})
+	if !errors.Is(err, framesample.ErrUnsupportedContainer) {
+		t.Fatalf("err = %v, want ErrUnsupportedContainer", err)
+	}
+}
+
+func TestClassifyVideo_NoFrames(t *testing.T) {
+	sampler := &fakeSampler{res: framesample.SampleResult{}}
+	img := &fakeImageClassifier{}
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{})
+
+	_, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{})
+	if err == nil {
+		t.Fatal("expected error when no frames decoded")
+	}
+}
+
+func TestClassifyVideo_FrameErrorPropagates(t *testing.T) {
+	sampler, _ := twoFrameSetup()
+	img := &fakeImageClassifier{err: errors.New("classify boom")}
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{})
+
+	_, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{})
+	if err == nil {
+		t.Fatal("expected frame classification error to propagate")
+	}
+}
+
+func TestClassifyVideo_ModelAndCadencePlumbing(t *testing.T) {
+	sampler, img := twoFrameSetup()
+	vc, _ := NewDecomposingVideoClassifier(sampler, img, nil, DecomposeConfig{
+		ImageModel: "cfg-model", FramesPerSecond: 3,
+	})
+
+	// Per-call Model overrides the config model; FrameSampleRate overrides cadence.
+	_, err := vc.ClassifyVideo(context.Background(), []byte("vid"), VideoOptions{
+		Model: "call-model", FrameSampleRate: 5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if img.models["call-model"] != 2 {
+		t.Errorf("image model calls: got %v, want call-model x2", img.models)
+	}
+	if sampler.gotOpts.FramesPerSecond != 5 {
+		t.Errorf("sampler fps = %v, want 5 (per-call override)", sampler.gotOpts.FramesPerSecond)
+	}
+}
+
+func approx(a, b float64) bool {
+	const eps = 1e-9
+	d := a - b
+	return d < eps && d > -eps
+}

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -1609,6 +1609,7 @@ func TestRegisterInit(t *testing.T) {
 		// Classify-backed media handlers
 		"audio_emotion",
 		"image_moderation",
+		"video_moderation",
 		"text_toxicity",
 		"text_sentiment",
 

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -78,6 +78,7 @@ func init() {
 	// text toxicity, ...) using the classify.Registry from context.
 	evals.RegisterDefault(&AudioEmotionHandler{})
 	evals.RegisterDefault(&ImageModerationHandler{})
+	evals.RegisterDefault(&VideoModerationHandler{})
 	evals.RegisterDefault(&TextToxicityHandler{})
 	evals.RegisterDefault(&TextSentimentHandler{})
 

--- a/runtime/evals/handlers/video_moderation.go
+++ b/runtime/evals/handlers/video_moderation.go
@@ -1,0 +1,161 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+	"github.com/AltairaLabs/PromptKit/runtime/classify/framesample"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Video moderation scores the agent's visual output by default (role:
+// assistant), which also covers video a tool produced during the
+// assistant's turn (e.g. video__generate) — see collectMediaContentByRole.
+const videoModerationDefaultRole = roleAssistant
+
+// VideoModerationHandler is a pure eval primitive: it runs the latest video
+// in the target role's turns through the configured VideoClassifier and emits
+// the score for expected_label (e.g. "nsfw") as EvalResult.Score. Threshold
+// judgment (min_score / max_score) lives on `type: assertion` / `type:
+// guardrail` wrappers — NOT on this handler.
+//
+// The shipped VideoClassifier is the decomposing backend: it samples frames
+// (pure-Go GIF/MJPEG), classifies each via an ImageClassifier, optionally
+// classifies the audio track, and aggregates the per-frame scores. Which
+// sub-models and aggregation default a classifier uses is a config concern
+// of the `decompose` inference provider; this handler only steers per-call
+// sampling / audio / aggregation.
+//
+// Params:
+//   - model             string  (required) — image-model id for per-frame classification
+//   - expected_label    string  (required) — label whose score is emitted
+//   - message_role      string  (optional, default "assistant") — whose video to score
+//   - message_index     int     (optional, default -1 = latest match)
+//   - classifier_id     string  (optional) — explicit registry id; empty uses the configured default
+//   - frame_sample_rate float64 (optional) — frames/sec to sample; 0 uses the backend default
+//   - extract_audio     bool    (optional, default false) — also classify the audio track
+//   - aggregation       string  (optional) — max|mean|vote; empty uses the backend default
+type VideoModerationHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *VideoModerationHandler) Type() string { return "video_moderation" }
+
+// Eval resolves the VideoClassifier from context, locates the target video
+// part, classifies it, and emits the requested label's score. Skipped vs Error
+// mirrors image_moderation: infrastructure absence (no registry, no video,
+// undecodable container, model loading/unsupported) is Skipped; misconfiguration
+// or a runtime classifier failure is Error.
+func (h *VideoModerationHandler) Eval(
+	ctx context.Context, evalCtx *evals.EvalContext, params map[string]any,
+) (*evals.EvalResult, error) {
+	cfg, cfgErr := parseClassifyConfig(params, videoModerationDefaultRole)
+	if cfgErr != nil {
+		return errorResult(h.Type(), cfgErr.Error()), nil
+	}
+	extra, extraErr := parseVideoModerationExtras(params)
+	if extraErr != nil {
+		return errorResult(h.Type(), extraErr.Error()), nil
+	}
+
+	classifier, classifierErr := resolveVideoClassifier(ctx, cfg.classifierID)
+	if classifierErr != nil {
+		return skippedResult(h.Type(), classifierErr.Error()), nil
+	}
+
+	videoParts := collectMediaContentByRole(evalCtx.Messages, types.ContentTypeVideo, cfg.messageRole)
+	if len(videoParts) == 0 {
+		return skippedResult(h.Type(),
+			fmt.Sprintf("no video part found with role %q", cfg.messageRole)), nil
+	}
+	media, partErr := pickMediaPart(videoParts, cfg.messageIndex)
+	if partErr != nil {
+		return errorResult(h.Type(), partErr.Error()), nil
+	}
+
+	videoBytes, readErr := readMediaBytes(media)
+	if readErr != nil {
+		return errorResult(h.Type(), readErr.Error()), nil
+	}
+
+	scores, classifyErr := classifier.ClassifyVideo(ctx, videoBytes, classify.VideoOptions{
+		Model:           cfg.model,
+		MIMEType:        media.MIMEType,
+		FrameSampleRate: extra.frameSampleRate,
+		ExtractAudio:    extra.extractAudio,
+		Aggregation:     extra.aggregation,
+	})
+	if classifyErr != nil {
+		return h.classifyErrorResult(classifyErr), nil
+	}
+
+	return gradeExpectedLabel(h.Type(), &cfg, scores), nil
+}
+
+// classifyErrorResult maps a ClassifyVideo error to Skipped or Error. An
+// undecodable container, a still-loading model, or a model unsupported on the
+// configured inference path are environmental (Skipped) — keyless / free-tier
+// / pure-Go-only runs shouldn't fail the scenario. Anything else is a real
+// runtime failure (Error).
+func (h *VideoModerationHandler) classifyErrorResult(err error) *evals.EvalResult {
+	switch {
+	case errors.Is(err, framesample.ErrUnsupportedContainer):
+		return skippedResult(h.Type(),
+			"video container not decodable by the pure-Go sampler "+
+				"(mp4/webm need an ffmpeg-backed sampler; GIF/MJPEG are supported)")
+	case errors.Is(err, classifyhf.ErrModelLoading):
+		return skippedResult(h.Type(), "model still loading after retries")
+	case errors.Is(err, classifyhf.ErrModelNotSupported):
+		return skippedResult(h.Type(),
+			"model not supported by the configured inference path "+
+				"(deploy an HF Inference Endpoint or pick a supported model)")
+	default:
+		return errorResult(h.Type(), fmt.Sprintf("classify failed: %v", err))
+	}
+}
+
+// videoModerationExtras holds the video-specific per-call knobs parsed on top
+// of the shared classify config.
+type videoModerationExtras struct {
+	frameSampleRate float64
+	extractAudio    bool
+	aggregation     string
+}
+
+// parseVideoModerationExtras validates the video-only params. An unknown
+// aggregation is a call-site misconfiguration (Error), not an environmental
+// absence.
+func parseVideoModerationExtras(params map[string]any) (videoModerationExtras, error) {
+	var e videoModerationExtras
+	if v, ok := extractFloat64(params, "frame_sample_rate"); ok {
+		e.frameSampleRate = v
+	}
+	if v, ok := params["extract_audio"].(bool); ok {
+		e.extractAudio = v
+	}
+	if v, ok := params["aggregation"].(string); ok && v != "" {
+		switch v {
+		case classify.AggregationMax, classify.AggregationMean, classify.AggregationVote:
+			e.aggregation = v
+		default:
+			return e, fmt.Errorf("invalid aggregation %q (want %s|%s|%s)",
+				v, classify.AggregationMax, classify.AggregationMean, classify.AggregationVote)
+		}
+	}
+	return e, nil
+}
+
+// resolveVideoClassifier pulls the classify registry out of context and looks
+// up the requested classifier id. An empty id resolves the configured default.
+func resolveVideoClassifier(ctx context.Context, id string) (classify.VideoClassifier, error) {
+	reg := classify.FromContext(ctx)
+	if reg == nil {
+		return nil, errors.New(
+			"no classify registry configured; add a providers: entry with role: inference " +
+				"and either defaults.inference.video_classifier or params.classifier_id")
+	}
+	return reg.VideoClassifier(id)
+}

--- a/runtime/evals/handlers/video_moderation_integration_test.go
+++ b/runtime/evals/handlers/video_moderation_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"image"
+	"image/color"
+	"image/gif"
+	"os"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+	"github.com/AltairaLabs/PromptKit/runtime/classify/framesample"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestVideoModeration_RealHFModel drives the whole decomposing pipeline against a
+// live HuggingFace image-classification model:
+//
+//	GIF bytes → framesample (decode + PNG frames) → HF ImageClassifier per frame
+//	→ per-label aggregation → video_moderation grade
+//
+// It proves the parts the unit tests fake: that the sampler emits frames a real
+// model actually accepts, and that the model's labels flow back through
+// aggregation to a graded score. It uses a benign, synthetic GIF — the point is
+// the wiring, not NSFW content, so a valid "normal"/"safe" score is a pass.
+//
+// Run with: go test -tags=integration ./runtime/evals/handlers/ -run RealHFModel
+// Requires HF_TOKEN. Skips (never fails) when the token is absent or the model
+// isn't currently servable on the configured inference path.
+func TestVideoModeration_RealHFModel(t *testing.T) {
+	token := os.Getenv("HF_TOKEN")
+	if token == "" {
+		t.Skip("HF_TOKEN not set; skipping live HuggingFace video-moderation test")
+	}
+
+	const nsfwModel = "Falconsai/nsfw_image_detection"
+
+	client, err := classifyhf.NewClient(classifyhf.Config{APIKey: token})
+	if err != nil {
+		t.Fatalf("hf client: %v", err)
+	}
+
+	// Compose the real decomposing video classifier over the live HF image model.
+	vc, err := classify.NewDecomposingVideoClassifier(
+		framesample.NewGIFMJPEGSampler(), client, nil,
+		classify.DecomposeConfig{ImageModel: nsfwModel, Aggregation: classify.AggregationMax},
+	)
+	if err != nil {
+		t.Fatalf("NewDecomposingVideoClassifier: %v", err)
+	}
+	reg := classify.NewRegistry()
+	reg.RegisterVideo("decompose", vc)
+	if err := reg.SetDefaultVideo("decompose"); err != nil {
+		t.Fatalf("SetDefaultVideo: %v", err)
+	}
+	ctx := classify.WithRegistry(context.Background(), reg)
+
+	// A real 3-frame animated GIF, base64-encoded into a video message part.
+	encoded := base64.StdEncoding.EncodeToString(realAnimatedGIF(t))
+	msg := types.Message{
+		Role: "assistant",
+		Parts: []types.ContentPart{{
+			Type:  types.ContentTypeVideo,
+			Media: &types.MediaContent{Data: &encoded, MIMEType: "image/gif"},
+		}},
+	}
+
+	// Cross-check against the classifier directly first so we can distinguish
+	// "model unavailable" (skip) from a genuine handler bug (fail).
+	if _, cerr := vc.ClassifyVideo(ctx, realAnimatedGIF(t), classify.VideoOptions{Model: nsfwModel}); cerr != nil {
+		if errors.Is(cerr, classifyhf.ErrModelLoading) || errors.Is(cerr, classifyhf.ErrModelNotSupported) {
+			t.Skipf("HF model %q not servable on the configured path: %v", nsfwModel, cerr)
+		}
+		t.Fatalf("ClassifyVideo against real model failed: %v", cerr)
+	}
+
+	h := &VideoModerationHandler{}
+	res, err := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{msg}}, map[string]any{
+		"model":          nsfwModel,
+		"expected_label": "nsfw",
+	})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if res.Skipped {
+		t.Skipf("handler skipped (model unavailable): %s", res.SkipReason)
+	}
+	if res.Error != "" {
+		t.Fatalf("handler errored against real model: %s", res.Error)
+	}
+	// The benign clip should score low for nsfw; the assertion here is that we got
+	// a real, in-range score back for the requested label — the pipeline worked.
+	if res.Score == nil {
+		t.Fatal("expected a real nsfw score from the live model, got nil")
+	}
+	if *res.Score < 0 || *res.Score > 1 {
+		t.Fatalf("nsfw score %v out of [0,1]", *res.Score)
+	}
+	t.Logf("live HF nsfw score for benign clip: %.4f (scores: %v)", *res.Score, res.Details["scores"])
+}
+
+// realAnimatedGIF builds a small, valid 3-frame animated GIF.
+func realAnimatedGIF(t *testing.T) []byte {
+	t.Helper()
+	const w, h = 16, 16
+	pal := color.Palette{color.RGBA{R: 20, G: 120, B: 200, A: 255}, color.White, color.Black}
+	g := &gif.GIF{Config: image.Config{Width: w, Height: h}}
+	for i := range 3 {
+		img := image.NewPaletted(image.Rect(0, 0, w, h), pal)
+		for p := range img.Pix {
+			img.Pix[p] = uint8(i % len(pal))
+		}
+		g.Image = append(g.Image, img)
+		g.Delay = append(g.Delay, 10)
+	}
+	var buf bytes.Buffer
+	if err := gif.EncodeAll(&buf, g); err != nil {
+		t.Fatalf("encode gif: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/runtime/evals/handlers/video_moderation_integration_test.go
+++ b/runtime/evals/handlers/video_moderation_integration_test.go
@@ -10,8 +10,11 @@ import (
 	"image"
 	"image/color"
 	"image/gif"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
 	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
@@ -19,6 +22,34 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
+
+// hfLiveTimeout is generous: HuggingFace serverless cold-starts a model on
+// first hit and can take well over the client's 60s default before returning
+// headers. A longer bound turns those cold starts into a real result instead
+// of a client timeout.
+const hfLiveTimeout = 180 * time.Second
+
+// isTransientHFError reports whether err is a transient network / serverless
+// hiccup (cold-start timeout, dropped connection) rather than a bug in our
+// pipeline. The free HF Inference tier is inherently flaky, so the live test
+// skips on these instead of going red on infrastructure it doesn't control.
+func isTransientHFError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"context deadline exceeded", "timeout", "connection refused",
+		"connection reset", "eof", "no such host", "temporarily",
+		"status 502", "status 503", "status 504", "gateway", "bad gateway",
+		"service unavailable",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
 
 // TestVideoModeration_RealHFModel drives the whole decomposing pipeline against a
 // live HuggingFace image-classification model:
@@ -40,17 +71,29 @@ func TestVideoModeration_RealHFModel(t *testing.T) {
 		t.Skip("HF_TOKEN not set; skipping live HuggingFace video-moderation test")
 	}
 
-	const nsfwModel = "Falconsai/nsfw_image_detection"
+	// Default to the NSFW moderation model; allow an override for when HF's
+	// free serverless tier isn't currently serving it (a general image
+	// classifier still proves the decompose pipeline end to end).
+	nsfwModel := "Falconsai/nsfw_image_detection"
+	if m := os.Getenv("HF_VIDEO_TEST_MODEL"); m != "" {
+		nsfwModel = m
+	}
 
-	client, err := classifyhf.NewClient(classifyhf.Config{APIKey: token})
+	client, err := classifyhf.NewClient(classifyhf.Config{
+		APIKey:     token,
+		HTTPClient: &http.Client{Timeout: hfLiveTimeout},
+	})
 	if err != nil {
 		t.Fatalf("hf client: %v", err)
 	}
 
-	// Compose the real decomposing video classifier over the live HF image model.
+	// Compose the real decomposing video classifier over the live HF image
+	// model. One frame is enough to prove the pipeline end to end (GIF decode →
+	// real HF classification → aggregation) while keeping the flaky free-tier
+	// network surface to a single call.
 	vc, err := classify.NewDecomposingVideoClassifier(
 		framesample.NewGIFMJPEGSampler(), client, nil,
-		classify.DecomposeConfig{ImageModel: nsfwModel, Aggregation: classify.AggregationMax},
+		classify.DecomposeConfig{ImageModel: nsfwModel, Aggregation: classify.AggregationMax, MaxFrames: 1},
 	)
 	if err != nil {
 		t.Fatalf("NewDecomposingVideoClassifier: %v", err)
@@ -74,12 +117,22 @@ func TestVideoModeration_RealHFModel(t *testing.T) {
 
 	// Cross-check against the classifier directly first so we can distinguish
 	// "model unavailable" (skip) from a genuine handler bug (fail).
-	if _, cerr := vc.ClassifyVideo(ctx, realAnimatedGIF(t), classify.VideoOptions{Model: nsfwModel}); cerr != nil {
+	directScores, cerr := vc.ClassifyVideo(ctx, realAnimatedGIF(t), classify.VideoOptions{Model: nsfwModel})
+	if cerr != nil {
 		if errors.Is(cerr, classifyhf.ErrModelLoading) || errors.Is(cerr, classifyhf.ErrModelNotSupported) {
 			t.Skipf("HF model %q not servable on the configured path: %v", nsfwModel, cerr)
 		}
+		if isTransientHFError(cerr) {
+			t.Skipf("HF serverless transient error (not a pipeline bug): %v", cerr)
+		}
 		t.Fatalf("ClassifyVideo against real model failed: %v", cerr)
 	}
+	// The core proof: real frames went through a real model and came back with
+	// real, ranked labels that aggregation collapsed into a result.
+	if len(directScores) == 0 {
+		t.Fatal("live model returned no labels for the sampled frames")
+	}
+	t.Logf("live %q returned %d aggregated labels; top: %+v", nsfwModel, len(directScores), directScores[0])
 
 	h := &VideoModerationHandler{}
 	res, err := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{msg}}, map[string]any{
@@ -93,6 +146,9 @@ func TestVideoModeration_RealHFModel(t *testing.T) {
 		t.Skipf("handler skipped (model unavailable): %s", res.SkipReason)
 	}
 	if res.Error != "" {
+		if isTransientHFError(errors.New(res.Error)) {
+			t.Skipf("HF serverless transient error via handler: %s", res.Error)
+		}
 		t.Fatalf("handler errored against real model: %s", res.Error)
 	}
 	// The benign clip should score low for nsfw; the assertion here is that we got

--- a/runtime/evals/handlers/video_moderation_test.go
+++ b/runtime/evals/handlers/video_moderation_test.go
@@ -1,0 +1,253 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	classifyhf "github.com/AltairaLabs/PromptKit/runtime/classify/backends/hf"
+	"github.com/AltairaLabs/PromptKit/runtime/classify/framesample"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// video_moderation is a PURE EVAL PRIMITIVE — it emits the score for the
+// configured expected_label and never applies a threshold. These tests assert
+// that contract plus the Skipped/Error split, mirroring image_moderation.
+
+// fakeVideoClassifier is an injectable classify.VideoClassifier. It records the
+// last VideoOptions it received so tests can assert per-call plumbing.
+type fakeVideoClassifier struct {
+	scores  []classify.LabelScore
+	err     error
+	gotOpts classify.VideoOptions
+}
+
+func (f *fakeVideoClassifier) ClassifyVideo(
+	_ context.Context, _ []byte, opts classify.VideoOptions,
+) ([]classify.LabelScore, error) {
+	f.gotOpts = opts
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.scores, nil
+}
+
+func ctxWithVideoRegistry(t *testing.T, vc classify.VideoClassifier) context.Context {
+	t.Helper()
+	reg := classify.NewRegistry()
+	reg.RegisterVideo("decompose", vc)
+	if err := reg.SetDefaultVideo("decompose"); err != nil {
+		t.Fatalf("SetDefaultVideo: %v", err)
+	}
+	return classify.WithRegistry(context.Background(), reg)
+}
+
+func videoMessage(role, body string) types.Message {
+	encoded := base64.StdEncoding.EncodeToString([]byte(body))
+	return types.Message{
+		Role: role,
+		Parts: []types.ContentPart{{
+			Type: types.ContentTypeVideo,
+			Media: &types.MediaContent{
+				Data:     &encoded,
+				MIMEType: "image/gif",
+			},
+		}},
+	}
+}
+
+func TestVideoModeration_EmitsScoreForExpectedLabel(t *testing.T) {
+	vc := &fakeVideoClassifier{scores: []classify.LabelScore{
+		{Label: "nsfw", Score: 0.88},
+		{Label: "safe", Score: 0.12},
+	}}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	h := &VideoModerationHandler{}
+	res, err := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{videoMessage("assistant", "gifbytes")}},
+		map[string]any{"model": "Falconsai/nsfw_image_detection", "expected_label": "nsfw"})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("expected emit, got skipped: %s", res.SkipReason)
+	}
+	if res.Score == nil || *res.Score != 0.88 {
+		t.Errorf("Score = %v, want 0.88", res.Score)
+	}
+	if res.MetricValue == nil || *res.MetricValue != 0.88 {
+		t.Errorf("MetricValue = %v, want 0.88", res.MetricValue)
+	}
+}
+
+func TestVideoModeration_PlumbsPerCallOptions(t *testing.T) {
+	vc := &fakeVideoClassifier{scores: []classify.LabelScore{{Label: "nsfw", Score: 0.5}}}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	h := &VideoModerationHandler{}
+	_, err := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{videoMessage("assistant", "g")}},
+		map[string]any{
+			"model":             "img-model",
+			"expected_label":    "nsfw",
+			"frame_sample_rate": 2.0,
+			"extract_audio":     true,
+			"aggregation":       "mean",
+		})
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if vc.gotOpts.Model != "img-model" {
+		t.Errorf("Model = %q, want img-model", vc.gotOpts.Model)
+	}
+	if vc.gotOpts.FrameSampleRate != 2.0 {
+		t.Errorf("FrameSampleRate = %v, want 2.0", vc.gotOpts.FrameSampleRate)
+	}
+	if !vc.gotOpts.ExtractAudio {
+		t.Error("ExtractAudio = false, want true")
+	}
+	if vc.gotOpts.Aggregation != classify.AggregationMean {
+		t.Errorf("Aggregation = %q, want mean", vc.gotOpts.Aggregation)
+	}
+	if vc.gotOpts.MIMEType != "image/gif" {
+		t.Errorf("MIMEType = %q, want image/gif", vc.gotOpts.MIMEType)
+	}
+}
+
+func TestVideoModeration_NoRegistryInContext(t *testing.T) {
+	h := &VideoModerationHandler{}
+	res, err := h.Eval(context.Background(), &evals.EvalContext{}, map[string]any{
+		"model": "m", "expected_label": "nsfw",
+	})
+	if err != nil {
+		t.Fatalf("Eval should not return Go error; got %v", err)
+	}
+	if !res.Skipped {
+		t.Fatalf("expected Skipped when no registry; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "no classify registry configured") {
+		t.Errorf("SkipReason %q should point users at the missing wiring", res.SkipReason)
+	}
+}
+
+func TestVideoModeration_NoVideoInMessages(t *testing.T) {
+	vc := &fakeVideoClassifier{}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	textOnly := types.Message{
+		Role:  "assistant",
+		Parts: []types.ContentPart{{Type: types.ContentTypeText, Text: ptrString("no video here")}},
+	}
+	h := &VideoModerationHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{textOnly}},
+		map[string]any{"model": "m", "expected_label": "nsfw"})
+	if !res.Skipped {
+		t.Fatalf("expected Skipped when no video; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "no video part") {
+		t.Errorf("SkipReason %q should explain why no video was scored", res.SkipReason)
+	}
+}
+
+func TestVideoModeration_SkippedOnUnsupportedContainer(t *testing.T) {
+	vc := &fakeVideoClassifier{err: framesample.ErrUnsupportedContainer}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	h := &VideoModerationHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{videoMessage("assistant", "mp4bytes")}},
+		map[string]any{"model": "m", "expected_label": "nsfw"})
+	if !res.Skipped {
+		t.Fatalf("expected Skipped on unsupported container; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "not decodable") {
+		t.Errorf("SkipReason %q should explain the container isn't decodable", res.SkipReason)
+	}
+}
+
+func TestVideoModeration_SkippedOnModelLoading(t *testing.T) {
+	vc := &fakeVideoClassifier{err: classifyhf.ErrModelLoading}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	h := &VideoModerationHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{videoMessage("assistant", "g")}},
+		map[string]any{"model": "m", "expected_label": "nsfw"})
+	if !res.Skipped {
+		t.Fatalf("expected Skipped on model loading; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "loading") {
+		t.Errorf("SkipReason %q should mention loading", res.SkipReason)
+	}
+}
+
+func TestVideoModeration_SkippedOnModelNotSupported(t *testing.T) {
+	vc := &fakeVideoClassifier{err: classifyhf.ErrModelNotSupported}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	h := &VideoModerationHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{videoMessage("assistant", "g")}},
+		map[string]any{"model": "m", "expected_label": "nsfw"})
+	if !res.Skipped {
+		t.Fatalf("expected Skipped on model-not-supported; got Error=%q", res.Error)
+	}
+	if !strings.Contains(res.SkipReason, "not supported") {
+		t.Errorf("SkipReason %q should explain the model isn't supported", res.SkipReason)
+	}
+}
+
+func TestVideoModeration_ErrorOnClassifierFailure(t *testing.T) {
+	vc := &fakeVideoClassifier{err: errors.New("boom")}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	h := &VideoModerationHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{videoMessage("assistant", "g")}},
+		map[string]any{"model": "m", "expected_label": "nsfw"})
+	if res.Skipped {
+		t.Fatalf("a generic classifier failure should be Error, not Skipped: %s", res.SkipReason)
+	}
+	if !strings.Contains(res.Error, "classify failed") {
+		t.Errorf("Error %q should surface the classifier failure", res.Error)
+	}
+}
+
+func TestVideoModeration_InvalidAggregation(t *testing.T) {
+	vc := &fakeVideoClassifier{}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	h := &VideoModerationHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{videoMessage("assistant", "g")}},
+		map[string]any{"model": "m", "expected_label": "nsfw", "aggregation": "median"})
+	if !strings.Contains(res.Error, "invalid aggregation") {
+		t.Errorf("error %q should reject the unknown aggregation", res.Error)
+	}
+}
+
+func TestVideoModeration_MessageIndexOutOfRange(t *testing.T) {
+	vc := &fakeVideoClassifier{scores: []classify.LabelScore{{Label: "nsfw", Score: 0.4}}}
+	ctx := ctxWithVideoRegistry(t, vc)
+
+	h := &VideoModerationHandler{}
+	res, _ := h.Eval(ctx, &evals.EvalContext{Messages: []types.Message{videoMessage("assistant", "one")}},
+		map[string]any{"model": "m", "expected_label": "nsfw", "message_index": 5})
+	if !strings.Contains(res.Error, "out of range") {
+		t.Errorf("error %q should explain index is out of range", res.Error)
+	}
+}
+
+func TestVideoModeration_RejectsThresholdParams(t *testing.T) {
+	ctx := classify.WithRegistry(context.Background(), classify.NewRegistry())
+	h := &VideoModerationHandler{}
+	for _, banned := range []string{"min_score", "max_score"} {
+		res, _ := h.Eval(ctx, &evals.EvalContext{}, map[string]any{
+			"model": "m", "expected_label": "nsfw", banned: 0.5,
+		})
+		if !strings.Contains(res.Error, banned+" is not a valid param") {
+			t.Errorf("%s should be rejected; got Error=%q", banned, res.Error)
+		}
+		if !strings.Contains(res.Error, "type: assertion") {
+			t.Errorf("error should point to the assertion wrapper: %q", res.Error)
+		}
+	}
+}


### PR DESCRIPTION
## What

Ships the `VideoClassifier` as a **proactive eval primitive** (#1229) — a **decomposing** backend that samples frames from a clip, classifies each still via an `ImageClassifier`, optionally classifies the audio track via an `AudioClassifier`, and aggregates per-label scores (`max` / `mean` / `vote`, default `max`).

## Key constraint: runs on `FROM scratch`

Frame sampling is **pure Go** — animated **GIF** (`image/gif`, with frame composition) and **MJPEG/raw-JPEG** — with **no CGO and no subprocess**. Containers that need a real codec (`mp4`/H.264, WebM) return a typed `ErrUnsupportedContainer` that the eval handler maps to a clean **skip**. An ffmpeg-backed `Sampler` can later drop in behind the same interface for richer environments, without touching the classifier or handler.

## Components

- **`runtime/classify/framesample`** — `Sampler` interface + pure-Go GIF/MJPEG implementation (`DefaultMaxFrames` cap, fps-cadence downsampling, disposal-aware GIF composition).
- **`runtime/classify/video_decompose.go`** — `decomposingVideoClassifier`: bounded-concurrency per-frame classification + per-label aggregation (`max`/`mean`/`vote`).
- **`runtime/classify/video_decompose_factory.go`** — `decompose` inference-provider type, wired via a **second pass** in `BuildRegistry` that resolves sibling `image_classifier_id` (+ optional `audio_classifier_id`) from the already-built registry.
- **`runtime/evals/handlers/video_moderation.go`** — pure-eval primitive mirroring `image_moderation` (emits the raw score, rejects `min_score`/`max_score`; Skipped vs Error split for no-registry / no-video / undecodable-container / model-loading).
- **docs** — `video_moderation` entry in `reference/checks.md` with both declaration sites and the `decompose` provider wiring.

## Testing

Fully pure-Go and self-contained — tests synthesize GIF/JPEG bytes in-memory, inject fake classifiers, and run under `-race`. No `HF_TOKEN`, no ffmpeg, no network. Coverage on changed files ≥ 86% (most 97–100%).

## Deferred (YAGNI)

- **HF whole-clip backend** — HF ships no general video-classification endpoint (its own client comment says so); the decomposing default *is* the MVP backend.
- **Streaming video** (`StreamingVideoClassifier`) and **compressed audio-track demux** (needs a codec we won't ship).

## Cross-repo follow-up

The JSON schema enum for the `video_moderation` check type and the `decompose` provider type must be added in **promptarena** (the schema owner) before packs can declare them — mirrors the "new schema fields released before examples use them" rule. No shipped example pack uses the new types, so `schemas-check` and the example-compliance test stay green here.

Closes #1229
