### PR TITLE
test(events): wait on asserted events, not just pipeline.completed

### DIFF
--- a/sdk/integration/events_test.go
+++ b/sdk/integration/events_test.go
@@ -144,9 +144,17 @@ func TestEvents_ProviderCallCompletedHasDetails(t *testing.T) {
 	_, err := conv.Send(context.Background(), "Check provider details")
 	require.NoError(t, err)
 
-	// Wait for PipelineCompleted (the last event emitted) to avoid a race
-	// between bus.Close() in cleanup and the pipeline goroutine still publishing.
-	ec.waitForEvent(events.EventPipelineCompleted, 2*time.Second)
+	// Wait for the ProviderCallCompleted event specifically — NOT just
+	// PipelineCompleted. The event bus dispatches to listeners via a worker
+	// pool (DefaultWorkerPoolSize=10), so delivery order to the collector is
+	// not publish order: PipelineCompleted can be delivered before
+	// ProviderCallCompleted even though it is published later. Waiting on the
+	// event we actually assert on is what the sibling tests
+	// (TestEvents_SequenceOrder, TestEvents_DataPointerTypes) already do.
+	require.True(t, ec.waitForEvents([]events.EventType{
+		events.EventProviderCallCompleted,
+		events.EventPipelineCompleted,
+	}, 2*time.Second), "not all expected events arrived")
 
 	provCompleted := ec.ofType(events.EventProviderCallCompleted)
 	require.NotEmpty(t, provCompleted)

--- a/sdk/integration/tools_test.go
+++ b/sdk/integration/tools_test.go
@@ -445,9 +445,16 @@ func TestTools_EventsEmitted(t *testing.T) {
 	_, err := conv.Send(ctx, "Weather in Tokyo?")
 	require.NoError(t, err)
 
-	// Wait for PipelineCompleted to avoid race with bus.Close()
-	require.True(t, ec.waitForEvent(events.EventPipelineCompleted, 5*time.Second),
-		"should receive pipeline.completed event")
+	// Wait for the tool-call events we assert on specifically — NOT just
+	// PipelineCompleted. The event bus dispatches to listeners via a worker
+	// pool (DefaultWorkerPoolSize=10), so delivery order to the collector is
+	// not publish order: PipelineCompleted can be delivered before the
+	// tool-call events even though they are published earlier.
+	require.True(t, ec.waitForEvents([]events.EventType{
+		events.EventToolCallStarted,
+		events.EventToolCallCompleted,
+		events.EventPipelineCompleted,
+	}, 5*time.Second), "should receive tool-call and pipeline.completed events")
 
 	// Verify tool call events
 	assert.True(t, ec.hasType(events.EventToolCallStarted),


### PR DESCRIPTION
## Problem

The `v1.5.6` release was blocked by a Validate-stage test failure:

```
sdk/integration/events_test.go:152
    Error: Should NOT be empty, but was []
    Test:  TestEvents_ProviderCallCompletedHasDetails
```

This is **not a product regression** and **not a flake to shrug off** — it's a real test synchronization bug.

## Root cause

The event bus (`runtime/events/bus.go`) dispatches events to subscribers through a **worker-goroutine pool** (`DefaultWorkerPoolSize = 10`), pulling from a buffered channel. Delivery order to a subscriber is therefore **not** the publish order.

Two tests waited only for `EventPipelineCompleted` and then asserted that events published *earlier* (`ProviderCallCompleted`, `ToolCall{Started,Completed}`) had already been collected. With 10 workers, `pipeline.completed` can be delivered to the collector before those earlier events, so the collector snapshot is missing them and `require.NotEmpty` / `hasType` fails. The failing test's own comment ("PipelineCompleted (the last event emitted)") was wrong about *delivery* ordering.

The sibling tests `TestEvents_SequenceOrder` and `TestEvents_DataPointerTypes` already handle this correctly by waiting for the specific events via `waitForEvents`.

## Fix

Wait for the exact events each test asserts on, matching the sibling pattern:

- `TestEvents_ProviderCallCompletedHasDetails`
- `TestTools_EventsEmitted`

## Verification

Reproduced deterministically by amplifying delivery reorder with `PROMPTKIT_EVENT_BUS_WORKER_POOL_SIZE=64`:

- **Before:** both tests fail within a few hundred iterations.
- **After:** 500 iterations each, plus full `sdk/integration` suite under `-race`, all green.

Closes the release blocker for v1.5.6.
