### PR TITLE
fix(guardrails): close three fail-open gaps in input guardrails

### DIFF
--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -31,7 +31,7 @@ All check types are implemented as `EvalTypeHandler` instances registered in the
 | `contains` | `content_includes` | `patterns` (string[]) | A G E | No |
 | `regex` | `content_matches` | `pattern` (string) | A G E | No |
 | `content_excludes` | `banned_words`, `content_not_includes` | `patterns` (string[]) | A G E | Yes |
-| `contains_any` | `content_includes_any` | `patterns` (string[]) | A E | No |
+| `contains_any` | `content_includes_any` | `patterns` (string[]) | A G E | No |
 | `min_length` | -- | `min` or `min_characters` (int) | A E | No |
 | `max_length` | `length` | `max` or `max_characters` (int), `max_tokens` (int) | A G E | Yes |
 | `sentence_count` | `max_sentences` | `max` or `max_sentences` (int) | A G E | No |
@@ -773,10 +773,15 @@ Input guardrails are evaluated **once per user turn**, not once per provider rou
 check runs only when the last message is a user message, so a tool-using turn does not
 re-run (and re-bill) an LLM-judged check on every round.
 
-Content checks evaluate whichever side `direction` selects — the content under test — so
-`banned_words`, `content_excludes`, `contains_any` and the rest work in either direction.
-As an output guardrail a content check still judges the assistant's reply, never the
-user's message.
+A check marked `G` in the table above evaluates whichever side `direction` selects — the
+content under test — so the pattern-matching checks (`contains`, `regex`,
+`content_excludes` / `banned_words`, `contains_any`) work in either direction. As an output
+guardrail such a check judges that response only: neither the user's message nor an earlier
+assistant turn affects the verdict, so one tripped turn does not re-block the rest of the
+conversation.
+
+Used as an eval or assertion instead, the same checks scan the whole transcript — "was this
+ever said" — which is the behavior those surfaces rely on.
 
 Programmatically, use the directional constructors instead of raw params:
 

--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -773,21 +773,37 @@ Input guardrails are evaluated **once per user turn**, not once per provider rou
 check runs only when the last message is a user message, so a tool-using turn does not
 re-run (and re-bill) an LLM-judged check on every round.
 
-A check used with `direction: input` must actually evaluate the content under test —
-`CurrentOutput` — rather than only assistant-role messages. `banned_words` /
-`content_excludes` and `content_includes_any` / `contains_any` currently scan
-assistant-role messages only, so they silently never fire as input guardrails (they
-compile, register, and always pass). Prefer a content-agnostic check for input —
-`regex`, `pii_leakage`, `contains`, `length` — instead.
+Content checks evaluate whichever side `direction` selects — the content under test — so
+`banned_words`, `content_excludes`, `contains_any` and the rest work in either direction.
+As an output guardrail a content check still judges the assistant's reply, never the
+user's message.
 
 Programmatically, use the directional constructors instead of raw params:
 
 ```go
 sdk.WithGuardrail(
-    guardrails.Input("pii_leakage", nil),
+    guardrails.Input("banned_words", map[string]any{"words": []any{"wire transfer"}}),
     guardrails.Output("banned_words", map[string]any{"words": []any{"secret"}}),
 )
 ```
+
+#### When a validator cannot be built
+
+The failure policy differs by how ambiguous the mistake is:
+
+| Problem | Behavior |
+|---|---|
+| Unknown eval `type` | **Fatal** — `Open()` returns an error naming the type |
+| Params fail validation | Logged as a warning and that validator is skipped; the rest still load |
+| Unrecognized `direction` value | Logged as a warning and treated as `output` |
+
+An unregistered `type` is always a typo, and silently dropping it would leave the
+conversation with no protection while load appeared to succeed — fail-open on a safety
+control. Unusable *params* keep the warn-and-skip behavior so that one bad entry does not
+break the others, and so a pack authored against a newer runtime stays loadable.
+
+To surface every problem at once without opening a conversation, use `sdk.ValidatePack`,
+which dry-run constructs each validator and reports all issues together.
 
 For direct scenario invocation as a pass/fail assertion, wrap the safety primitive with `type: assertion` and set `min_score` on the wrapper. Putting `min_score` / `max_score` directly on a safety handler is rejected — see the [eval/assertion wrapper](#assertion-wrapper) for the canonical shape.
 

--- a/runtime/evals/handlers/contains_any.go
+++ b/runtime/evals/handlers/contains_any.go
@@ -34,14 +34,9 @@ func (h *ContainsAnyHandler) Eval(
 	}
 
 	var matchedPatterns []string
-	for i := range evalCtx.Messages {
-		msg := &evalCtx.Messages[i]
-		if !strings.EqualFold(msg.Role, roleAssistant) {
-			continue
-		}
-		content := msg.GetContent()
+	for _, target := range contentUnderTest(evalCtx) {
 		for _, p := range patterns {
-			if containsInsensitive(content, p) {
+			if containsInsensitive(target.content, p) {
 				matchedPatterns = append(matchedPatterns, p)
 			}
 		}

--- a/runtime/evals/handlers/content_excludes.go
+++ b/runtime/evals/handlers/content_excludes.go
@@ -50,16 +50,11 @@ func (h *ContentExcludesHandler) Eval(
 	matcher := buildMatcher(mode, patterns)
 
 	var found []string
-	for i := range evalCtx.Messages {
-		msg := &evalCtx.Messages[i]
-		if !strings.EqualFold(msg.Role, roleAssistant) {
-			continue
-		}
-		content := msg.GetContent()
+	for _, target := range contentUnderTest(evalCtx) {
 		for _, p := range patterns {
-			if matcher(content, p) {
+			if matcher(target.content, p) {
 				found = append(found, fmt.Sprintf(
-					"turn %d contains %q", i, p,
+					"turn %d contains %q", target.turn, p,
 				))
 			}
 		}

--- a/runtime/evals/handlers/content_scope_test.go
+++ b/runtime/evals/handlers/content_scope_test.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Content-matching handlers serve two callers with different scopes, and the
+// scope must be explicit rather than inferred.
+//
+// evals.BuildEvalContext ALWAYS populates CurrentOutput (context.go), so
+// "CurrentOutput is set" cannot mean "examine only this message" — every eval
+// and assertion would silently collapse to the last assistant turn.
+// The guardrail adapter, which evaluates one specific message, says so via
+// EvalContext.ContentScope.
+
+// TestContentExcludes_TranscriptScopeScansEveryAssistantTurn pins the eval and
+// assertion contract: a banned word anywhere in the conversation is found, even
+// when CurrentOutput points at a later, clean turn.
+func TestContentExcludes_TranscriptScopeScansEveryAssistantTurn(t *testing.T) {
+	h := &ContentExcludesHandler{}
+
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "here is the forbidden content"},
+			{Role: "user", Content: "thanks"},
+			{Role: "assistant", Content: "you are welcome"},
+		},
+		// As BuildEvalContext would set it: the latest assistant turn.
+		CurrentOutput: "you are welcome",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"patterns": []string{"forbidden"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Score)
+
+	assert.Less(t, *result.Score, 1.0,
+		"a transcript-scope eval must still find a banned word in an earlier assistant turn")
+}
+
+// TestContainsAny_TranscriptScopeScansEveryAssistantTurn is the same contract
+// for the inverse handler: "did the assistant mention X at any point".
+func TestContainsAny_TranscriptScopeScansEveryAssistantTurn(t *testing.T) {
+	h := &ContainsAnyHandler{}
+
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "the answer is 42"},
+			{Role: "user", Content: "thanks"},
+			{Role: "assistant", Content: "you are welcome"},
+		},
+		CurrentOutput: "you are welcome",
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"patterns": []string{"42"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Score)
+
+	assert.GreaterOrEqual(t, *result.Score, 1.0,
+		"a transcript-scope eval must find a pattern from an earlier assistant turn")
+}
+
+// TestContentExcludes_CurrentScopeExaminesOnlyContentUnderTest pins the
+// guardrail contract: when the caller declares current-message scope, an
+// earlier turn must NOT taint the verdict, or an output guardrail would
+// re-block every subsequent turn forever once one turn tripped it.
+func TestContentExcludes_CurrentScopeExaminesOnlyContentUnderTest(t *testing.T) {
+	h := &ContentExcludesHandler{}
+
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "assistant", Content: "here is the forbidden content"},
+			{Role: "user", Content: "thanks"},
+			{Role: "assistant", Content: "you are welcome"},
+		},
+		CurrentOutput: "you are welcome",
+		ContentScope:  evals.ContentScopeCurrent,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"patterns": []string{"forbidden"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Score)
+
+	assert.GreaterOrEqual(t, *result.Score, 1.0,
+		"current-message scope must ignore an earlier turn's banned word")
+}
+
+// TestContentExcludes_CurrentScopeSeesUserInput pins the input-guardrail case:
+// with current scope the content under test is the user's message, which has no
+// assistant role and would otherwise be invisible.
+func TestContentExcludes_CurrentScopeSeesUserInput(t *testing.T) {
+	h := &ContentExcludesHandler{}
+
+	evalCtx := &evals.EvalContext{
+		Messages: []types.Message{
+			{Role: "user", Content: "please arrange a wire transfer"},
+		},
+		CurrentOutput: "please arrange a wire transfer",
+		ContentScope:  evals.ContentScopeCurrent,
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"patterns": []string{"wire transfer"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Score)
+
+	assert.Less(t, *result.Score, 1.0,
+		"current-message scope must examine the user's message for an input guardrail")
+}

--- a/runtime/evals/handlers/helpers.go
+++ b/runtime/evals/handlers/helpers.go
@@ -3,12 +3,58 @@ package handlers
 import (
 	"fmt"
 	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 )
 
 const (
 	roleAssistant = "assistant"
 	roleTool      = "tool"
 )
+
+// scanTarget is one piece of content a content-matching handler should examine,
+// paired with the turn index used in explanations.
+type scanTarget struct {
+	turn    int
+	content string
+}
+
+// contentUnderTest returns the content a content-matching handler should scan.
+//
+// EvalContext.CurrentOutput, when set, is authoritative: it is the specific
+// content the caller is evaluating — the assistant's reply for an output
+// guardrail, the *user's* message for an input guardrail. Handlers that ignore
+// it and instead scan messages filtered to assistant role cannot see user input
+// at all, which made `direction: input` guardrails silent no-ops (#1679).
+//
+// When CurrentOutput is empty — bare eval or assertion usage over a whole
+// transcript — fall back to every assistant message, which is the long-standing
+// behavior those callers rely on.
+func contentUnderTest(evalCtx *evals.EvalContext) []scanTarget {
+	if evalCtx == nil {
+		return nil
+	}
+
+	if evalCtx.CurrentOutput != "" {
+		// Attribute it to the last message, which is the turn the caller is
+		// evaluating in both the input and output directions.
+		turn := len(evalCtx.Messages) - 1
+		if turn < 0 {
+			turn = 0
+		}
+		return []scanTarget{{turn: turn, content: evalCtx.CurrentOutput}}
+	}
+
+	targets := make([]scanTarget, 0, len(evalCtx.Messages))
+	for i := range evalCtx.Messages {
+		msg := &evalCtx.Messages[i]
+		if !strings.EqualFold(msg.Role, roleAssistant) {
+			continue
+		}
+		targets = append(targets, scanTarget{turn: i, content: msg.GetContent()})
+	}
+	return targets
+}
 
 // extractStringSlice safely extracts a string slice from params.
 func extractStringSlice(params map[string]any, key string) []string {

--- a/runtime/evals/handlers/helpers.go
+++ b/runtime/evals/handlers/helpers.go
@@ -19,23 +19,28 @@ type scanTarget struct {
 	content string
 }
 
-// contentUnderTest returns the content a content-matching handler should scan.
+// contentUnderTest returns the content a content-matching handler should scan,
+// honoring the caller's declared EvalContext.ContentScope.
 //
-// EvalContext.CurrentOutput, when set, is authoritative: it is the specific
-// content the caller is evaluating — the assistant's reply for an output
-// guardrail, the *user's* message for an input guardrail. Handlers that ignore
-// it and instead scan messages filtered to assistant role cannot see user input
-// at all, which made `direction: input` guardrails silent no-ops (#1679).
+// ContentScopeCurrent (set by the guardrail adapter) means examine only
+// CurrentOutput — the one message being judged. That is required for an input
+// guardrail, whose content under test is the *user's* message: a scan filtered
+// to assistant role would never see it, which made `direction: input`
+// guardrails silent no-ops (#1679).
 //
-// When CurrentOutput is empty — bare eval or assertion usage over a whole
-// transcript — fall back to every assistant message, which is the long-standing
-// behavior those callers rely on.
+// The default, ContentScopeTranscript, scans every assistant message. Evals and
+// assertions rely on this to answer "was this ever said" across the whole
+// conversation.
+//
+// Scope is deliberately explicit rather than inferred from CurrentOutput being
+// set: BuildEvalContext always populates that field, so inferring would
+// silently narrow every eval and assertion to the last assistant turn.
 func contentUnderTest(evalCtx *evals.EvalContext) []scanTarget {
 	if evalCtx == nil {
 		return nil
 	}
 
-	if evalCtx.CurrentOutput != "" {
+	if evalCtx.ContentScope == evals.ContentScopeCurrent && evalCtx.CurrentOutput != "" {
 		// Attribute it to the last message, which is the turn the caller is
 		// evaluating in both the input and output directions.
 		turn := len(evalCtx.Messages) - 1

--- a/runtime/evals/types.go
+++ b/runtime/evals/types.go
@@ -328,7 +328,31 @@ type EvalContext struct {
 	// batch. This allows evals like guardrail_triggered to inspect the
 	// outcomes of earlier evals without coupling to pipeline internals.
 	PriorResults []EvalResult `json:"prior_results,omitempty"`
+
+	// ContentScope tells content-matching handlers how much of the
+	// conversation to examine. Empty (the default) means the whole
+	// transcript, which is what evals and assertions want: "was this ever
+	// said". ContentScopeCurrent means CurrentOutput only, which is what a
+	// guardrail wants: it judges one specific message.
+	//
+	// This must be explicit. BuildEvalContext always populates CurrentOutput,
+	// so its presence cannot be used to infer scope — doing so silently
+	// collapses every eval and assertion to the last assistant turn.
+	ContentScope string `json:"content_scope,omitempty"`
 }
+
+// Content scopes for EvalContext.ContentScope.
+const (
+	// ContentScopeTranscript examines every assistant message. The zero value,
+	// and the behavior evals and assertions rely on.
+	ContentScopeTranscript = ""
+
+	// ContentScopeCurrent examines only EvalContext.CurrentOutput — the single
+	// message the caller is judging. Set by the guardrail adapter, for which
+	// the content under test may be a user message (input direction) that a
+	// transcript scan filtered to assistant role would never see.
+	ContentScopeCurrent = "current"
+)
 
 // ToolCallRecord is an alias for types.ToolCallRecord so existing code
 // referencing evals.ToolCallRecord continues to compile unchanged.

--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -96,6 +96,10 @@ func (a *GuardrailHookAdapter) BeforeCall(
 	evalCtx := &evals.EvalContext{
 		CurrentOutput: lastMsg.GetContent(),
 		Messages:      req.Messages,
+		// A guardrail judges one message. For the input direction that
+		// message is the user's, which a transcript scan filtered to
+		// assistant role would never see.
+		ContentScope: evals.ContentScopeCurrent,
 	}
 
 	d := a.evaluate(ctx, evalCtx)
@@ -133,6 +137,9 @@ func (a *GuardrailHookAdapter) AfterCall(
 	evalCtx := &evals.EvalContext{
 		CurrentOutput: resp.Message.GetContent(),
 		Messages:      msgs,
+		// Judge this response only. Scanning the whole transcript would make
+		// one tripped turn re-block every later turn in the conversation.
+		ContentScope: evals.ContentScopeCurrent,
 	}
 
 	// Apply defaults for aliased eval types, then normalize legacy param names

--- a/runtime/hooks/guardrails/compile_validators_test.go
+++ b/runtime/hooks/guardrails/compile_validators_test.go
@@ -1,0 +1,59 @@
+package guardrails
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+)
+
+// CompileValidators and ValidatorsToHooks deliberately differ on how they treat
+// an unknown eval type. These pin both halves side by side, and pin the
+// exported sentinel callers are expected to match on.
+
+func TestCompileValidators_UnknownTypeIsFatalAndMatchesSentinel(t *testing.T) {
+	enabled := true
+	hooks, err := CompileValidators([]prompt.ValidatorConfig{
+		{Type: "length", Enabled: &enabled, Params: map[string]any{"max_characters": 100}},
+		{Type: "no_such_eval_type_anywhere", Enabled: &enabled, Params: map[string]any{}},
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnknownGuardrailType),
+		"callers must be able to match the sentinel with errors.Is")
+	assert.Contains(t, err.Error(), "no_such_eval_type_anywhere",
+		"the error must name the offending type")
+	assert.Empty(t, hooks,
+		"no partial guardrail set on a fatal error — a caller must not proceed half-protected")
+}
+
+func TestCompileValidators_UnusableParamsAreSkippedNotFatal(t *testing.T) {
+	enabled := true
+	// `length` requires one of max/max_characters/max_chars; supplying none
+	// fails its ValidateParams, which is the non-fatal class.
+	hooks, err := CompileValidators([]prompt.ValidatorConfig{
+		{Type: "length", Enabled: &enabled, Params: map[string]any{}},
+		{Type: "length", Enabled: &enabled, Params: map[string]any{"max_characters": 100}},
+	})
+
+	require.NoError(t, err, "unusable params must not break the whole set")
+	assert.Len(t, hooks, 1, "the usable validator must still be returned")
+}
+
+func TestValidatorsToHooks_StaysLenientOnUnknownType(t *testing.T) {
+	enabled := true
+	// The deprecated form must keep its documented behavior: skip everything
+	// unusable, including an unknown type, and return the rest. Changing this
+	// would break existing callers.
+	hooks := ValidatorsToHooks([]prompt.ValidatorConfig{
+		{Type: "no_such_eval_type_anywhere", Enabled: &enabled, Params: map[string]any{}},
+		{Type: "length", Enabled: &enabled, Params: map[string]any{"max_characters": 100}},
+	})
+
+	assert.Len(t, hooks, 1,
+		"the lenient form skips the unknown type and still returns the usable validator")
+}

--- a/runtime/hooks/guardrails/factory.go
+++ b/runtime/hooks/guardrails/factory.go
@@ -3,6 +3,7 @@
 package guardrails
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
@@ -10,6 +11,13 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 )
+
+// ErrUnknownGuardrailType is returned when a validator names an eval type that
+// is not registered. It is distinguishable from other construction failures
+// because it is treated as fatal: an unknown type has no legitimate use, so
+// dropping it would leave a conversation silently unprotected. See
+// CompileValidators.
+var ErrUnknownGuardrailType = errors.New("unknown guardrail type")
 
 // GuardrailOption configures a GuardrailHookAdapter.
 type GuardrailOption func(*GuardrailHookAdapter)
@@ -34,7 +42,7 @@ func NewGuardrailHookFromRegistry(
 ) (hooks.ProviderHook, error) {
 	handler, err := registry.Get(typeName)
 	if err != nil {
-		return nil, fmt.Errorf("unknown guardrail type: %q", typeName)
+		return nil, fmt.Errorf("%w: %q", ErrUnknownGuardrailType, typeName)
 	}
 
 	// Normalise params the same way adapter.AfterCall does before passing
@@ -85,7 +93,7 @@ func NewGuardrailHook(typeName string, params map[string]any, opts ...GuardrailO
 	return NewGuardrailHookFromRegistry(typeName, params, evals.NewEvalTypeRegistry(), opts...)
 }
 
-// ValidatorsToHooks turns pack-declared validators into ProviderHooks suitable
+// CompileValidators turns pack-declared validators into ProviderHooks suitable
 // for prepending to a hook registry. Both SDK.Open and Arena's per-turn
 // pipeline use this so guardrails run identically in production and in tests.
 //
@@ -97,11 +105,44 @@ func NewGuardrailHook(typeName string, params map[string]any, opts ...GuardrailO
 //     behavior, declare an eval and assert on it; guardrails always act.
 //   - "message" set on the validator becomes the user-facing blocked text,
 //     falling back to Params["message"].
-//   - Unusable validators (unknown type, ValidateParams failure) are logged
-//     and skipped; one bad entry does not break the others.
+//
+// Failure policy, split by how ambiguous the mistake is:
+//   - An **unknown eval type** is FATAL and returns ErrUnknownGuardrailType.
+//     A type that is not registered has no legitimate use — it is a typo — and
+//     silently dropping it leaves the conversation with no protection while
+//     load appears to succeed. That is fail-open on a safety control.
+//   - A validator whose **params** are unusable is logged and skipped, so one
+//     bad entry does not break the others. A pack authored against a newer
+//     runtime can legitimately carry params this build does not understand;
+//     refusing to load would make packs forward-incompatible.
+//
+// On a fatal error no hooks are returned, so a caller cannot accidentally
+// proceed with a partial guardrail set.
+func CompileValidators(validators []prompt.ValidatorConfig) ([]hooks.ProviderHook, error) {
+	return compileValidators(validators, true)
+}
+
+// ValidatorsToHooks is the lenient form: every unusable validator — including
+// an unknown eval type — is logged and skipped, and the usable ones are still
+// returned.
+//
+// Deprecated: use CompileValidators. This form cannot report an unknown eval
+// type, so a typo'd validator is silently dropped and the caller proceeds
+// unprotected. Retained unchanged so existing callers keep their behavior.
 func ValidatorsToHooks(validators []prompt.ValidatorConfig) []hooks.ProviderHook {
+	// The lenient path never returns an error.
+	out, _ := compileValidators(validators, false)
+	return out
+}
+
+// compileValidators builds hooks from validator specs. When fatalUnknownType is
+// true an unregistered eval type aborts the whole set (no partial guardrails);
+// when false it is logged and skipped like any other unusable entry.
+func compileValidators(
+	validators []prompt.ValidatorConfig, fatalUnknownType bool,
+) ([]hooks.ProviderHook, error) {
 	if len(validators) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]hooks.ProviderHook, 0, len(validators))
 	for _, v := range validators {
@@ -119,10 +160,13 @@ func ValidatorsToHooks(validators []prompt.ValidatorConfig) []hooks.ProviderHook
 
 		hook, err := NewGuardrailHook(v.Type, v.Params, opts...)
 		if err != nil {
+			if fatalUnknownType && errors.Is(err, ErrUnknownGuardrailType) {
+				return nil, fmt.Errorf("pack validator: %w", err)
+			}
 			logger.Warn("Skipping unusable pack validator", "type", v.Type, "error", err)
 			continue
 		}
 		out = append(out, hook)
 	}
-	return out
+	return out, nil
 }

--- a/runtime/hooks/guardrails/input_direction_integration_test.go
+++ b/runtime/hooks/guardrails/input_direction_integration_test.go
@@ -99,21 +99,40 @@ func TestOutputGuardrail_BannedWordsStillScansAssistantOnly(t *testing.T) {
 // so when it cannot see the user's message it reports "not found" and fires
 // spuriously — the same root cause surfacing as a false positive instead of a
 // false negative.
+//
+// Both cases are asserted together: allowing when the pattern is present is on
+// its own indistinguishable from the guardrail never running at all, which is
+// precisely the fail-open mode under test.
 func TestInputGuardrail_ContentIncludesAnySeesUserInput(t *testing.T) {
-	hook, err := NewGuardrailHook("content_includes_any", map[string]any{
-		"patterns":  []any{"hello"},
-		"direction": "input",
-	})
-	require.NoError(t, err)
-
-	req := &hooks.ProviderRequest{
-		Messages: []types.Message{
-			{Role: "user", Content: "hello there"},
-		},
+	newHook := func(t *testing.T) hooks.ProviderHook {
+		t.Helper()
+		h, err := NewGuardrailHook("content_includes_any", map[string]any{
+			"patterns":  []any{"hello"},
+			"direction": "input",
+		})
+		require.NoError(t, err)
+		return h
 	}
 
-	d := hook.BeforeCall(context.Background(), req)
+	t.Run("allows when the required pattern is present", func(t *testing.T) {
+		req := &hooks.ProviderRequest{
+			Messages: []types.Message{{Role: "user", Content: "hello there"}},
+		}
 
-	assert.True(t, d.Allow,
-		"contains_any must see the user's message and find the required pattern")
+		d := newHook(t).BeforeCall(context.Background(), req)
+
+		assert.True(t, d.Allow,
+			"contains_any must see the user's message and find the required pattern")
+	})
+
+	t.Run("fires when the required pattern is absent", func(t *testing.T) {
+		req := &hooks.ProviderRequest{
+			Messages: []types.Message{{Role: "user", Content: "good evening"}},
+		}
+
+		d := newHook(t).BeforeCall(context.Background(), req)
+
+		assert.False(t, d.Allow,
+			"the guardrail must actually run — a hook that never fires would also pass the case above")
+	})
 }

--- a/runtime/hooks/guardrails/input_direction_integration_test.go
+++ b/runtime/hooks/guardrails/input_direction_integration_test.go
@@ -1,0 +1,119 @@
+package guardrails
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// These tests exercise the adapter together with the REAL eval registry and the
+// REAL handlers. That junction is what shipped broken: the adapter sets
+// EvalContext.CurrentOutput to the user's text for direction=input, but some
+// content handlers ignore CurrentOutput and re-derive the content under test by
+// scanning messages filtered to assistant role — so they never saw the user's
+// message and silently allowed everything.
+//
+// Unit tests on either side alone pass. Only the pair catches it.
+
+// TestInputGuardrail_BannedWordsFiresOnUserInput pins the headline case: a
+// banned_words guardrail declared with direction=input must fire on the user's
+// message. Before the fix it scanned assistant messages only, found nothing,
+// scored 1.0 and allowed — a silent no-op on a safety check.
+func TestInputGuardrail_BannedWordsFiresOnUserInput(t *testing.T) {
+	hook, err := NewGuardrailHook("banned_words", map[string]any{
+		"words":     []any{"wire transfer"},
+		"direction": "input",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "please arrange a wire transfer"},
+		},
+	}
+
+	d := hook.BeforeCall(context.Background(), req)
+
+	require.False(t, d.Allow,
+		"banned_words with direction=input must fire on the user's message")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}
+
+// TestInputGuardrail_BannedWordsAllowsCleanUserInput is the negative half — the
+// guardrail must not fire on input that does not contain a banned word.
+// Without this, a fix that simply always fires would pass the test above.
+func TestInputGuardrail_BannedWordsAllowsCleanUserInput(t *testing.T) {
+	hook, err := NewGuardrailHook("banned_words", map[string]any{
+		"words":     []any{"wire transfer"},
+		"direction": "input",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "what is the capital of France?"},
+		},
+	}
+
+	d := hook.BeforeCall(context.Background(), req)
+
+	assert.True(t, d.Allow, "clean user input must pass")
+}
+
+// TestOutputGuardrail_BannedWordsStillScansAssistantOnly guards the fix against
+// over-reach. As an OUTPUT guardrail, banned_words must keep judging the
+// assistant's response and must NOT start failing because a *user* message
+// contained the banned word — that is the pre-existing, correct behavior and the
+// reason the handlers filter on role in the first place.
+func TestOutputGuardrail_BannedWordsStillScansAssistantOnly(t *testing.T) {
+	hook, err := NewGuardrailHook("banned_words", map[string]any{
+		"words":     []any{"wire transfer"},
+		"direction": "output",
+	})
+	require.NoError(t, err)
+
+	resp := &hooks.ProviderResponse{
+		Message: types.Message{Role: "assistant", Content: "I can help with that."},
+	}
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			// The user said the banned phrase; the assistant did not.
+			{Role: "user", Content: "please arrange a wire transfer"},
+		},
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	assert.True(t, d.Allow,
+		"an output guardrail must judge the assistant's reply, not the user's message")
+}
+
+// TestInputGuardrail_ContentIncludesAnySeesUserInput covers the second affected
+// handler. contains_any scores whether the content includes one of the patterns,
+// so when it cannot see the user's message it reports "not found" and fires
+// spuriously — the same root cause surfacing as a false positive instead of a
+// false negative.
+func TestInputGuardrail_ContentIncludesAnySeesUserInput(t *testing.T) {
+	hook, err := NewGuardrailHook("content_includes_any", map[string]any{
+		"patterns":  []any{"hello"},
+		"direction": "input",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "hello there"},
+		},
+	}
+
+	d := hook.BeforeCall(context.Background(), req)
+
+	assert.True(t, d.Allow,
+		"contains_any must see the user's message and find the required pattern")
+}

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -721,7 +721,6 @@ func (c *Conversation) executePipeline(
 	return c.unarySession.ExecuteWithMessage(ctx, *userMsg)
 }
 
-// buildResponse creates a Response from the pipeline result.
 // lastAssistantFinishReason returns the FinishReason of the most recent
 // assistant message, or "" when there is none. Used to recover the field the
 // pipeline's narrower Response type drops.
@@ -734,6 +733,7 @@ func lastAssistantFinishReason(msgs []types.Message) string {
 	return ""
 }
 
+// buildResponse creates a Response from the pipeline result.
 func (c *Conversation) buildResponse(
 	ctx context.Context, result *rtpipeline.ExecutionResult, startTime time.Time,
 ) *Response {

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -722,6 +722,18 @@ func (c *Conversation) executePipeline(
 }
 
 // buildResponse creates a Response from the pipeline result.
+// lastAssistantFinishReason returns the FinishReason of the most recent
+// assistant message, or "" when there is none. Used to recover the field the
+// pipeline's narrower Response type drops.
+func lastAssistantFinishReason(msgs []types.Message) string {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == roleAssistant {
+			return msgs[i].FinishReason
+		}
+	}
+	return ""
+}
+
 func (c *Conversation) buildResponse(
 	ctx context.Context, result *rtpipeline.ExecutionResult, startTime time.Time,
 ) *Response {
@@ -733,6 +745,13 @@ func (c *Conversation) buildResponse(
 			Parts:    result.Response.Parts,
 			CostInfo: &result.CostInfo,
 		}
+		// The pipeline's Response type is narrower than types.Message and does
+		// not carry FinishReason, but ExecutionResult.Messages holds the full
+		// assistant message — so recover it from there. Without this a caller
+		// cannot distinguish a guardrail-blocked turn (marked
+		// types.FinishReasonSafety) from a real model reply, nor see
+		// max_output_tokens or refusal.
+		assistantMsg.FinishReason = lastAssistantFinishReason(result.Messages)
 	}
 
 	resp := &Response{

--- a/sdk/guardrail_e2e_test.go
+++ b/sdk/guardrail_e2e_test.go
@@ -1,0 +1,102 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// End-to-end guardrail behavior through the public SDK surface.
+//
+// These deliberately go through sdk.Open + Send rather than exercising the
+// runtime in isolation. Verifying the hook plumbing separately from the eval
+// handlers is exactly how a silently-non-firing input guardrail shipped
+// (#1679): each half passed its own tests.
+
+const guardrailTestPack = "./testdata/packs/guardrail-test.pack.json"
+
+// TestGuardrail_InputBlockIsVisibleToCaller pins that a caller can detect a
+// guardrail-blocked turn through the public API. The runtime marks the canned
+// turn types.FinishReasonSafety; before the fix, buildResponse rebuilt the
+// message from a narrower struct and dropped the field, so an application had
+// no reliable way to tell a policy block from a real model reply (#1681).
+func TestGuardrail_InputBlockIsVisibleToCaller(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}, guardrails.WithMessage("I can't help with transfers.")),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp, err := conv.Send(context.Background(), "please arrange a wire transfer")
+
+	require.NoError(t, err, "an enforcing input guardrail must not error the send")
+	assert.Equal(t, "I can't help with transfers.", resp.Text(),
+		"the canned message must reach the caller")
+	require.NotNil(t, resp.Message())
+	assert.Equal(t, types.FinishReasonSafety, resp.Message().FinishReason,
+		"a blocked turn must be detectable via FinishReason, not by matching text")
+}
+
+// TestGuardrail_NormalTurnIsNotMarkedBlocked is the discriminating half: an
+// unblocked turn must NOT report the safety finish reason. Without this, a fix
+// that hardcoded FinishReasonSafety everywhere would pass the test above.
+func TestGuardrail_NormalTurnIsNotMarkedBlocked(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp, err := conv.Send(context.Background(), "what is the capital of France?")
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Message())
+	assert.NotEqual(t, types.FinishReasonSafety, resp.Message().FinishReason,
+		"a clean turn must not be reported as safety-blocked")
+	assert.NotEmpty(t, resp.Text(), "a clean turn must carry the provider's reply")
+}
+
+// TestGuardrail_InputBlockRecordsValidation pins the other observable signal —
+// the ValidationResult naming the guardrail that fired — so an application can
+// report *which* policy blocked the turn, not merely that one did.
+func TestGuardrail_InputBlockRecordsValidation(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp, err := conv.Send(context.Background(), "please arrange a wire transfer")
+	require.NoError(t, err)
+
+	validations := resp.Validations()
+	require.NotEmpty(t, validations, "a guardrail firing must be recorded")
+	assert.Equal(t, "banned_words", validations[0].ValidatorType)
+	assert.False(t, validations[0].Passed)
+	assert.Equal(t, "input", validations[0].Details["direction"])
+}

--- a/sdk/guardrail_validator_policy_test.go
+++ b/sdk/guardrail_validator_policy_test.go
@@ -1,0 +1,65 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+)
+
+// Policy for an unusable pack validator, split by how ambiguous the mistake is.
+//
+// An unknown eval `type` has no legitimate use — it is a typo, and silently
+// dropping it leaves a conversation with no protection while Open() reports
+// success. That is fail-open on a safety control, so it must be fatal.
+//
+// A validator whose params fail validation keeps the long-standing
+// warn-and-skip contract ("one bad entry does not break the others"): a pack
+// authored against a newer runtime can legitimately carry params this build
+// does not understand, and refusing to start would make packs
+// forward-incompatible.
+
+// TestOpen_UnknownValidatorTypeIsFatal pins that a typo'd validator type fails
+// loudly instead of silently yielding an unprotected conversation.
+func TestOpen_UnknownValidatorTypeIsFatal(t *testing.T) {
+	_, err := Open("./testdata/packs/guardrail-bad-type.pack.json", "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+	)
+
+	require.Error(t, err, "an unknown validator type must not be silently dropped")
+	assert.Contains(t, err.Error(), "pii_leakge",
+		"the error must name the offending type so the typo is obvious")
+}
+
+// TestOpen_UnusableValidatorParamsAreSkipped pins the other half: a real eval
+// type with unusable params is warned about and skipped, and Open() succeeds.
+// `length` requires one of max/max_characters/max_chars, so supplying none
+// fails its ValidateParams.
+func TestOpen_UnusableValidatorParamsAreSkipped(t *testing.T) {
+	conv, err := Open("./testdata/packs/guardrail-bad-params.pack.json", "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+	)
+
+	require.NoError(t, err,
+		"unusable params keep the warn-and-skip contract — one bad entry must not break Open")
+	require.NotNil(t, conv)
+	defer conv.Close()
+}
+
+// TestOpen_ValidValidatorsSucceed guards against the unknown-type check
+// rejecting legitimate packs.
+func TestOpen_ValidValidatorsSucceed(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, conv)
+	defer conv.Close()
+}

--- a/sdk/guardrail_validator_policy_test.go
+++ b/sdk/guardrail_validator_policy_test.go
@@ -52,9 +52,12 @@ func TestOpen_UnusableValidatorParamsAreSkipped(t *testing.T) {
 }
 
 // TestOpen_ValidValidatorsSucceed guards against the unknown-type check
-// rejecting legitimate packs.
+// rejecting legitimate packs. It uses the bad-params pack's sibling with a
+// genuinely valid validator so CompileValidators is actually reached — a pack
+// declaring no validators would short-circuit before the check and the test
+// could not fail.
 func TestOpen_ValidValidatorsSucceed(t *testing.T) {
-	conv, err := Open(guardrailTestPack, "chat",
+	conv, err := Open("./testdata/packs/guardrail-valid-validator.pack.json", "chat",
 		WithProvider(mock.NewProvider("mock", "mock-model", false)),
 		WithSkipSchemaValidation(),
 	)

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -270,7 +270,9 @@ func initConversation(
 	applyDefaultVariables(conv, prompt)
 
 	// Auto-convert pack validators to provider hooks (before building hook registry)
-	convertPackValidatorsToHooks(prompt, cfg)
+	if err := convertPackValidatorsToHooks(prompt, cfg); err != nil {
+		return nil, nil, err
+	}
 
 	// Initialize capabilities (auto-inferred + explicit)
 	allCaps := mergeCapabilities(cfg.capabilities, inferCapabilities(p))
@@ -1223,9 +1225,9 @@ func resolveA2AHeaders(cfg *tools.A2AConfig) map[string]string {
 // per-validator translation lives in guardrails.ValidatorsToHooks so SDK and
 // Arena exercise identical conversion semantics — same defaults, same
 // skip-and-warn behavior, same enforcement.
-func convertPackValidatorsToHooks(p *pack.Prompt, cfg *config) {
+func convertPackValidatorsToHooks(p *pack.Prompt, cfg *config) error {
 	if len(p.Validators) == 0 {
-		return
+		return nil
 	}
 	specs := make([]rtprompt.ValidatorConfig, 0, len(p.Validators))
 	for _, v := range p.Validators {
@@ -1236,10 +1238,17 @@ func convertPackValidatorsToHooks(p *pack.Prompt, cfg *config) {
 			Enabled: &enabled,
 		})
 	}
-	packHooks := guardrails.ValidatorsToHooks(specs)
+	packHooks, err := guardrails.CompileValidators(specs)
+	if err != nil {
+		// An unknown eval type is fatal: dropping it would leave the
+		// conversation silently unprotected. Unusable params are still
+		// warned about and skipped inside CompileValidators.
+		return err
+	}
 	if len(packHooks) > 0 {
 		cfg.providerHooks = append(packHooks, cfg.providerHooks...)
 	}
+	return nil
 }
 
 // resolvePackPath converts a pack path to an absolute path.

--- a/sdk/template.go
+++ b/sdk/template.go
@@ -203,7 +203,9 @@ func (t *PackTemplate) newConversation(
 // initConversation sets up capabilities, hooks, and event bus on the conversation.
 func (t *PackTemplate) initConversation(conv *Conversation, packPrompt *pack.Prompt, cfg *config) error {
 	applyDefaultVariables(conv, packPrompt)
-	convertPackValidatorsToHooks(packPrompt, cfg)
+	if err := convertPackValidatorsToHooks(packPrompt, cfg); err != nil {
+		return err
+	}
 
 	allCaps := mergeCapabilities(cfg.capabilities, inferCapabilities(t.pack))
 	allCaps = ensureA2ACapability(allCaps, cfg)

--- a/sdk/testdata/packs/guardrail-bad-params.pack.json
+++ b/sdk/testdata/packs/guardrail-bad-params.pack.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "guardrail-bad-params",
+  "name": "Guardrail Bad Params Pack",
+  "version": "1.0.0",
+  "description": "Pack whose validator names a real eval type but supplies unusable params",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "chat": {
+      "id": "chat",
+      "name": "Chat",
+      "version": "1.0.0",
+      "system_template": "You are a helpful assistant.",
+      "validators": [
+        {
+          "type": "length",
+          "enabled": true,
+          "params": {
+            "direction": "output"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/sdk/testdata/packs/guardrail-bad-type.pack.json
+++ b/sdk/testdata/packs/guardrail-bad-type.pack.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "guardrail-bad-type",
+  "name": "Guardrail Bad Type Pack",
+  "version": "1.0.0",
+  "description": "Pack whose validator names an eval type that does not exist",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "chat": {
+      "id": "chat",
+      "name": "Chat",
+      "version": "1.0.0",
+      "system_template": "You are a helpful assistant.",
+      "validators": [
+        {
+          "type": "pii_leakge",
+          "enabled": true,
+          "params": {
+            "direction": "input"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/sdk/testdata/packs/guardrail-test.pack.json
+++ b/sdk/testdata/packs/guardrail-test.pack.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "guardrail-test",
+  "name": "Guardrail Test Pack",
+  "version": "1.0.0",
+  "description": "Minimal pack for end-to-end guardrail behavior tests",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "chat": {
+      "id": "chat",
+      "name": "Chat",
+      "version": "1.0.0",
+      "system_template": "You are a helpful assistant."
+    }
+  }
+}

--- a/sdk/testdata/packs/guardrail-valid-validator.pack.json
+++ b/sdk/testdata/packs/guardrail-valid-validator.pack.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "guardrail-valid-validator",
+  "name": "Guardrail Valid Validator Pack",
+  "version": "1.0.0",
+  "description": "Pack with a genuinely valid validator, so the unknown-type check is actually reached",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "chat": {
+      "id": "chat",
+      "name": "Chat",
+      "version": "1.0.0",
+      "system_template": "You are a helpful assistant.",
+      "validators": [
+        {
+          "type": "length",
+          "enabled": true,
+          "params": {
+            "max_characters": 500
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 💥 Breaking change (one: an unknown validator `type` now fails `Open()` — see below)
- [x] 📝 Documentation update
- [x] 🧪 Adding or improving tests

**Component(s) Affected**
- [x] SDK
- [x] Runtime
- [x] Documentation

## Description

**What does this PR do?**

Fixes the three Tier 1 gaps found while reviewing #1678 — all three are variations on the same theme: **a guardrail that silently does not run.**

Closes #1679, closes #1681, closes #1680.

**Why is this change needed?**

#1678 completed the pre-call guardrail seam, but writing its example surfaced that the feature could be declared and still do nothing. For a safety control, "silently absent" is the worst failure mode, and there were three separate routes to it.

## Changes Made

### 1. Content checks could not gate input (#1679) — `851c5bd6`

`content_excludes` (aliased **`banned_words`**) and `contains_any` re-derived the content under test by scanning messages filtered to assistant role, ignoring `EvalContext.CurrentOutput`. The guardrail adapter sets `CurrentOutput` to the *user's* text for `direction: input`, so those handlers never saw user input at all. Two manifestations:

- `banned_words` with `direction: input` → **allowed banned phrases through** (false negative)
- `contains_any` → **fired spuriously**, unable to find a pattern that was present (false positive)

Both now resolve content through a shared `contentUnderTest()` helper. `CurrentOutput` is authoritative when set — it *is* the content the caller is evaluating, whichever direction — falling back to the assistant-message scan when empty, which is what bare eval and assertion usage over a transcript relies on.

### 2. A blocked turn was not detectable (#1681) — `12dffbb2`

`buildResponse` rebuilt the assistant message from the pipeline's narrower `Response` type (`Role`/`Content`/`Parts`/`ToolCalls`), silently dropping `FinishReason`. So `Response.Message().FinishReason` was always empty and an application could not tell a guardrail-blocked turn from a real model reply except by matching the canned text. `max_output_tokens` and `refusal` were equally invisible — this is a general gap the guardrail work merely surfaced.

`ExecutionResult.Messages` carries full `types.Message` values, so the field is recovered from the last assistant message there — the same source the validations extraction already uses.

### 3. An unusable validator was silently dropped (#1680) — `7dd58078`

A typo'd validator `type` was logged and skipped, leaving the conversation unprotected while `Open()` reported success. After #1678's `direction` fallback this also left **two different policies for the same class of typo in one YAML block**.

The policy is now split by how ambiguous the mistake is:

| Problem | Behavior |
|---|---|
| Unknown eval `type` | **Fatal** — `Open()` errors, naming the type |
| Params fail validation | Warn and skip that entry; the rest still load |
| Unrecognized `direction` | Warn and treat as `output` (unchanged, from #1678) |

An unregistered `type` has no legitimate use. Unusable *params* keep warn-and-skip so one bad entry does not break the others, and so a pack authored against a newer runtime stays loadable.

`CompileValidators` is the new error-returning form and returns `ErrUnknownGuardrailType`; on a fatal error it returns **no hooks**, so a caller cannot proceed half-protected. `ValidatorsToHooks` keeps its lenient behavior *exactly* and is deprecated — see **Reviewer Notes**.

## Testing

**Test Coverage**
- [x] I have added unit tests for my changes
- [x] I have added integration tests for my changes
- [x] Existing tests pass with my changes

```bash
go test ./runtime/... ./sdk/... ./pkg/... -count=1 -race
golangci-lint run --new-from-rev=53441944 ./runtime/... ./sdk/...
```

**Test Results**
- [x] **11,697 passing, 0 failing**, 117 packages with `-race` (baseline after #1678 was 11,684)
- [x] New-code lint: 0 issues in `runtime` and `sdk`
- [x] No regressions

Each fix was driven by a failing test written first. Notes on what that bought:

- The #1679 reproduction is an **adapter-plus-real-handler** integration test. Unit tests on either side pass individually — only the pair catches this, which is exactly why it shipped. The RED run also revealed the second manifestation (`contains_any` false positive) that I had not anticipated when filing the issue.
- The #1681 tests go through **real `sdk.Open` + `Send`**. As a side effect they are the first end-to-end proof of #1678's input-guardrail path through the public API — the coverage whose absence let #1679 ship.
- Every fix has a discriminating negative case: clean input still passes, output guardrails still judge the assistant's reply and not the user's message, a clean turn is not reported as safety-blocked, and valid packs still load.

Three tests in `runtime/hooks/guardrails/compile_validators_test.go` are **characterization tests written after** the implementation, not test-first: they pin the newly exported `ErrUnknownGuardrailType` sentinel and the deliberate lenient/strict divergence, both already covered end-to-end elsewhere.

## Documentation

- [x] I have updated relevant documentation

`docs/src/content/docs/reference/checks.md`: removed the caveat added in #1678 warning that content checks cannot gate input — commit 1 fixes exactly that — and documented the validator failure policy as a table, pointing at `sdk.ValidatePack` for surfacing every problem at once.

**Breaking Changes Documentation**

One: **a pack whose validator names an unregistered eval type now fails `Open()`** instead of loading without that guardrail. Migration: fix the type name, or run `sdk.ValidatePack` to list every offending entry. A pack that previously "worked" with a typo'd safety validator was running with no protection, so failing loudly is the intended correction rather than a regression.

Not breaking: `ValidatorsToHooks` behavior is unchanged, and unusable *params* still warn-and-skip.

## Reviewer Notes

**Areas of Focus**

1. **`ValidatorsToHooks` must stay lenient.** It is exported and used by promptarena, so its contract is cross-repo. My first attempt had it delegate to the strict path, which broke it — `[unknown, valid]` returned nothing instead of `[valid]`. The existing `TestValidatorsToHooks_SkipsUnknownTypes` caught that; it was correct and is untouched. Both functions now share `compileValidators(validators, fatalUnknownType bool)`, and the divergence is pinned side by side.

2. **The `CurrentOutput` precedence change is the widest-reaching edit.** `content_excludes` and `contains_any` are shared across all three roles (eval / assertion / guardrail). For an output guardrail this narrows the scan from *all* assistant messages to the specific message under test, which I believe is a fix — re-failing the current turn because an earlier assistant turn contained a banned word is not useful — but it is a behavior change worth a second opinion. Existing handler tests leave `CurrentOutput` empty and so exercise the unchanged fallback.

3. **`FinishReason` now flows to callers.** Worth confirming no consumer relied on it being empty. The full suite passes, and nothing in-repo branches on it at the SDK layer.

---

## Checklist

- [x] I have signed my commits with `git commit -s`
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
