### PR TITLE
fix(guardrails): correct guardrail observability and drop a stage coupling

### DIFF
--- a/docs/src/content/docs/runtime/reference/hooks.md
+++ b/docs/src/content/docs/runtime/reference/hooks.md
@@ -84,6 +84,21 @@ const (
 )
 ```
 
+<a name="DirectionInput"></a>Guardrail directions: which side of a provider call a check gates, and the vocabulary a firing is tagged with.
+
+These live here rather than in hooks/guardrails because both the guardrail adapter and the pipeline stage need them, and the stage's use is about its own two call phases — it should not have to depend on a concrete hook implementation for a set of string labels.
+
+```go
+const (
+    // DirectionInput gates the user's input, in BeforeCall.
+    DirectionInput = "input"
+    // DirectionOutput gates the assistant's response, in AfterCall.
+    DirectionOutput = "output"
+    // DirectionBoth gates input and output.
+    DirectionBoth = "both"
+)
+```
+
 ## Variables
 
 <a name="Allow"></a>Allow is the zero\-cost approval decision.

--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -11,19 +11,14 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
-// Direction values for guardrail hook evaluation, as accepted in a validator's
-// params["direction"].
-//
-// Aliases of the canonical constants in runtime/hooks, which is where the
-// vocabulary lives so the pipeline stage does not have to import a concrete
-// hook implementation to tag a firing. Kept here for existing callers.
+// Aliases of the canonical direction constants, retained for existing callers.
+// See runtime/hooks for what each value means; the vocabulary lives there so
+// the pipeline stage need not import a concrete hook implementation to tag a
+// firing.
 const (
-	// DirectionInput gates the user's input in BeforeCall.
-	DirectionInput = hooks.DirectionInput
-	// DirectionOutput gates the assistant's response in AfterCall.
+	DirectionInput  = hooks.DirectionInput
 	DirectionOutput = hooks.DirectionOutput
-	// DirectionBoth gates input and output.
-	DirectionBoth = hooks.DirectionBoth
+	DirectionBoth   = hooks.DirectionBoth
 )
 
 // roleUser is the message role an input guardrail gates on.

--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -12,16 +12,18 @@ import (
 )
 
 // Direction values for guardrail hook evaluation, as accepted in a validator's
-// params["direction"]. Exported so the pipeline can tag a firing with the same
-// vocabulary the adapter gates on — a second, private copy in another package
-// could diverge without breaking the build.
+// params["direction"].
+//
+// Aliases of the canonical constants in runtime/hooks, which is where the
+// vocabulary lives so the pipeline stage does not have to import a concrete
+// hook implementation to tag a firing. Kept here for existing callers.
 const (
 	// DirectionInput gates the user's input in BeforeCall.
-	DirectionInput = "input"
+	DirectionInput = hooks.DirectionInput
 	// DirectionOutput gates the assistant's response in AfterCall.
-	DirectionOutput = "output"
+	DirectionOutput = hooks.DirectionOutput
 	// DirectionBoth gates input and output.
-	DirectionBoth = "both"
+	DirectionBoth = hooks.DirectionBoth
 )
 
 // roleUser is the message role an input guardrail gates on.

--- a/runtime/hooks/types.go
+++ b/runtime/hooks/types.go
@@ -37,6 +37,22 @@ func Enforced(reason string, metadata map[string]any) Decision {
 	return Decision{Allow: false, Reason: reason, Metadata: metadata, Enforced: true}
 }
 
+// Guardrail directions: which side of a provider call a check gates, and the
+// vocabulary a firing is tagged with.
+//
+// These live here rather than in hooks/guardrails because both the guardrail
+// adapter and the pipeline stage need them, and the stage's use is about its
+// own two call phases — it should not have to depend on a concrete hook
+// implementation for a set of string labels.
+const (
+	// DirectionInput gates the user's input, in BeforeCall.
+	DirectionInput = "input"
+	// DirectionOutput gates the assistant's response, in AfterCall.
+	DirectionOutput = "output"
+	// DirectionBoth gates input and output.
+	DirectionBoth = "both"
+)
+
 // ProviderRequest describes an LLM call about to be made.
 type ProviderRequest struct {
 	ProviderID   string

--- a/runtime/pipeline/stage/guardrail_event_score_test.go
+++ b/runtime/pipeline/stage/guardrail_event_score_test.go
@@ -1,0 +1,52 @@
+package stage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+)
+
+// TestGuardrailEvent_CarriesTheEvalScore pins that the score reaching observers
+// is the eval's real score.
+//
+// recordGuardrailFiring reads Metadata["score"] with a float64 type assertion,
+// but the guardrail adapter stores evals.EvalResult.Score, which is a
+// *float64 — so the assertion always failed and every guardrail event reported
+// Score: 0 while runtime-events.md advertises "evaluation score (0.0-1.0)".
+//
+// This must drive the REAL adapter: a test hook putting a plain float64 in the
+// decision metadata would not reproduce a pointer-type mismatch.
+func TestGuardrailEvent_CarriesTheEvalScore(t *testing.T) {
+	provider := mock.NewProvider("p", "m", false)
+
+	// max_characters far below the mock's reply length, so the guardrail fires
+	// with a fractional score rather than a pass.
+	guard, err := guardrails.NewGuardrailHook("length", map[string]any{
+		"max_characters": 5,
+	})
+	require.NoError(t, err)
+
+	bus := events.NewEventBus()
+	getEvents := collectValidationFailures(t, bus)
+	emitter := events.NewEmitter(bus, "run1", "sess1", "conv1")
+
+	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, emitter, hooks.NewRegistry(hooks.WithProviderHook(guard)))
+
+	_, runErr := runProviderStage(t, stage, "hello")
+	require.NoError(t, runErr)
+
+	got := getEvents()
+	require.Len(t, got, 1, "the guardrail should have fired once")
+	assert.Greater(t, got[0].Score, 0.0,
+		"the event must carry the eval's real score, not the zero value from a failed type assertion")
+	assert.LessOrEqual(t, got[0].Score, 1.0, "score is a 0..1 ratio")
+}

--- a/runtime/pipeline/stage/guardrail_event_score_test.go
+++ b/runtime/pipeline/stage/guardrail_event_score_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
-	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
@@ -24,8 +23,6 @@ import (
 // This must drive the REAL adapter: a test hook putting a plain float64 in the
 // decision metadata would not reproduce a pointer-type mismatch.
 func TestGuardrailEvent_CarriesTheEvalScore(t *testing.T) {
-	provider := mock.NewProvider("p", "m", false)
-
 	// max_characters far below the mock's reply length, so the guardrail fires
 	// with a fractional score rather than a pass.
 	guard, err := guardrails.NewGuardrailHook("length", map[string]any{
@@ -33,16 +30,11 @@ func TestGuardrailEvent_CarriesTheEvalScore(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	bus := events.NewEventBus()
-	getEvents := collectValidationFailures(t, bus)
-	emitter := events.NewEmitter(bus, "run1", "sess1", "conv1")
-
-	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
-		MaxTokens: 100,
-	}, emitter, hooks.NewRegistry(hooks.WithProviderHook(guard)))
-
-	_, runErr := runProviderStage(t, stage, "hello")
-	require.NoError(t, runErr)
+	_, getEvents := runStageCollectingValidations(t,
+		mock.NewProvider("p", "m", false),
+		hooks.NewRegistry(hooks.WithProviderHook(guard)),
+		"hello",
+	)
 
 	got := getEvents()
 	require.Len(t, got, 1, "the guardrail should have fired once")

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1148,35 +1148,16 @@ func (s *ProviderStage) executeRound(
 	}
 
 	// Run AfterCall hooks
-	if s.hookRegistry != nil {
-		hookReq := &hooks.ProviderRequest{
-			ProviderID:   s.provider.ID(),
-			Model:        s.provider.Model(),
-			Messages:     messages,
-			SystemPrompt: systemPrompt,
-			Round:        round,
-			Metadata:     metadata,
-		}
-		hookResp := &hooks.ProviderResponse{
-			ProviderID: s.provider.ID(),
-			Model:      s.provider.Model(),
-			Message:    responseMsg,
-			Round:      round,
-			LatencyMs:  duration.Milliseconds(),
-		}
-		hookStart := time.Now()
-		if d := s.hookRegistry.RunAfterProviderCall(ctx, hookReq, hookResp); !d.Allow {
-			s.recordGuardrailFiring(&responseMsg, d, hooks.DirectionOutput, time.Since(hookStart))
-			if !d.Enforced {
-				return responseMsg, false, &hooks.HookDeniedError{
-					HookName: providerHookName,
-					HookType: providerHookTypeAfter,
-					Reason:   d.Reason,
-					Metadata: d.Metadata,
-				}
-			}
-			applyEnforcedResponse(&responseMsg, &toolCalls, hookResp, d)
-		}
+	if err := s.runAfterCallHooks(ctx, &afterCallParams{
+		messages:     messages,
+		systemPrompt: systemPrompt,
+		round:        round,
+		metadata:     metadata,
+		duration:     duration,
+		responseMsg:  &responseMsg,
+		toolCalls:    &toolCalls,
+	}); err != nil {
+		return responseMsg, false, err
 	}
 
 	logger.Debug("Provider round completed",
@@ -1336,35 +1317,16 @@ func (s *ProviderStage) executeStreamingRound(
 	}
 
 	// Run AfterCall hooks
-	if s.hookRegistry != nil {
-		hookReq := &hooks.ProviderRequest{
-			ProviderID:   s.provider.ID(),
-			Model:        s.provider.Model(),
-			Messages:     params.messages,
-			SystemPrompt: params.systemPrompt,
-			Round:        params.round,
-			Metadata:     params.metadata,
-		}
-		hookResp := &hooks.ProviderResponse{
-			ProviderID: s.provider.ID(),
-			Model:      s.provider.Model(),
-			Message:    responseMsg,
-			Round:      params.round,
-			LatencyMs:  duration.Milliseconds(),
-		}
-		hookStart := time.Now()
-		if d := s.hookRegistry.RunAfterProviderCall(ctx, hookReq, hookResp); !d.Allow {
-			s.recordGuardrailFiring(&responseMsg, d, hooks.DirectionOutput, time.Since(hookStart))
-			if !d.Enforced {
-				return responseMsg, false, &hooks.HookDeniedError{
-					HookName: providerHookName,
-					HookType: providerHookTypeAfter,
-					Reason:   d.Reason,
-					Metadata: d.Metadata,
-				}
-			}
-			applyEnforcedResponse(&responseMsg, &toolCalls, hookResp, d)
-		}
+	if err := s.runAfterCallHooks(ctx, &afterCallParams{
+		messages:     params.messages,
+		systemPrompt: params.systemPrompt,
+		round:        params.round,
+		metadata:     params.metadata,
+		duration:     duration,
+		responseMsg:  &responseMsg,
+		toolCalls:    &toolCalls,
+	}); err != nil {
+		return responseMsg, false, err
 	}
 
 	logger.Debug("Provider streaming round completed",
@@ -1800,6 +1762,66 @@ func (s *ProviderStage) emitToolStarted(toolCall types.MessageToolCall, labels m
 		_ = json.Unmarshal(toolCall.Args, &argsMap)
 	}
 	s.emitter.ToolCallStarted(toolCall.Name, toolCall.ID, argsMap, labels)
+}
+
+// afterCallParams carries what the AfterCall hook chain needs from either
+// round function. responseMsg and toolCalls are pointers because an enforcing
+// guardrail rewrites the response and drops its tool calls in place.
+type afterCallParams struct {
+	messages     []types.Message
+	systemPrompt string
+	round        int
+	metadata     map[string]interface{}
+	duration     time.Duration
+	responseMsg  *types.Message
+	toolCalls    *[]types.MessageToolCall
+}
+
+// runAfterCallHooks runs the AfterCall hook chain, shared by the unary and
+// streaming rounds so the two cannot drift.
+//
+// A non-nil error is a hook denial, which aborts the pipeline. An enforcing
+// guardrail returns nil: it rewrites the response and clears its tool calls via
+// applyEnforcedResponse, so the caller reports hasToolCalls=false and the round
+// loop stops while the pipeline continues.
+func (s *ProviderStage) runAfterCallHooks(ctx context.Context, p *afterCallParams) error {
+	if s.hookRegistry == nil {
+		return nil
+	}
+
+	hookReq := &hooks.ProviderRequest{
+		ProviderID:   s.provider.ID(),
+		Model:        s.provider.Model(),
+		Messages:     p.messages,
+		SystemPrompt: p.systemPrompt,
+		Round:        p.round,
+		Metadata:     p.metadata,
+	}
+	hookResp := &hooks.ProviderResponse{
+		ProviderID: s.provider.ID(),
+		Model:      s.provider.Model(),
+		Message:    *p.responseMsg,
+		Round:      p.round,
+		LatencyMs:  p.duration.Milliseconds(),
+	}
+
+	hookStart := time.Now()
+	d := s.hookRegistry.RunAfterProviderCall(ctx, hookReq, hookResp)
+	if d.Allow {
+		return nil
+	}
+
+	s.recordGuardrailFiring(p.responseMsg, d, hooks.DirectionOutput, time.Since(hookStart))
+	if !d.Enforced {
+		return &hooks.HookDeniedError{
+			HookName: providerHookName,
+			HookType: providerHookTypeAfter,
+			Reason:   d.Reason,
+			Metadata: d.Metadata,
+		}
+	}
+	applyEnforcedResponse(p.responseMsg, p.toolCalls, hookResp, d)
+	return nil
 }
 
 // runBeforeCallHooks runs the BeforeCall hook chain. It is called BEFORE the

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
-	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/pipeline"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
@@ -1167,7 +1166,7 @@ func (s *ProviderStage) executeRound(
 		}
 		hookStart := time.Now()
 		if d := s.hookRegistry.RunAfterProviderCall(ctx, hookReq, hookResp); !d.Allow {
-			s.recordGuardrailFiring(&responseMsg, d, guardrails.DirectionOutput, time.Since(hookStart))
+			s.recordGuardrailFiring(&responseMsg, d, hooks.DirectionOutput, time.Since(hookStart))
 			if !d.Enforced {
 				return responseMsg, false, &hooks.HookDeniedError{
 					HookName: providerHookName,
@@ -1320,14 +1319,20 @@ func (s *ProviderStage) executeStreamingRound(
 	// firings — without this, a guardrail that aborts mid-stream produces
 	// no observable validation record.
 	responseMsg := types.Message{
-		Role:        "assistant",
-		Content:     content,
-		ToolCalls:   toolCalls,
-		Reasoning:   reasoning,
-		Timestamp:   timeNow(),
-		LatencyMs:   duration.Milliseconds(),
-		CostInfo:    costInfo,
-		Validations: chunkValidations,
+		Role:      roleAssistant,
+		Content:   content,
+		ToolCalls: toolCalls,
+		Reasoning: reasoning,
+		Timestamp: timeNow(),
+		LatencyMs: duration.Milliseconds(),
+		CostInfo:  costInfo,
+		// Stamp the provider's own reason, mirroring the non-streaming path.
+		// Enforcement below overwrites this with FinishReasonSafety when a
+		// guardrail fires. Without it a streaming turn reports no finish
+		// reason at all, so max_output_tokens and refusal are indistinguishable
+		// from a normal completion once the SDK surfaces the field.
+		FinishReason: finishReason,
+		Validations:  chunkValidations,
 	}
 
 	// Run AfterCall hooks
@@ -1349,7 +1354,7 @@ func (s *ProviderStage) executeStreamingRound(
 		}
 		hookStart := time.Now()
 		if d := s.hookRegistry.RunAfterProviderCall(ctx, hookReq, hookResp); !d.Allow {
-			s.recordGuardrailFiring(&responseMsg, d, guardrails.DirectionOutput, time.Since(hookStart))
+			s.recordGuardrailFiring(&responseMsg, d, hooks.DirectionOutput, time.Since(hookStart))
 			if !d.Enforced {
 				return responseMsg, false, &hooks.HookDeniedError{
 					HookName: providerHookName,
@@ -1462,7 +1467,7 @@ func (s *ProviderStage) processStreamChunks(
 		// Run chunk interceptor hooks
 		if s.hookRegistry != nil && s.hookRegistry.HasChunkInterceptors() {
 			if d := s.hookRegistry.RunOnChunk(ctx, &chunk); !d.Allow {
-				s.recordGuardrailFiring(nil, d, guardrails.DirectionOutput, 0)
+				s.recordGuardrailFiring(nil, d, hooks.DirectionOutput, 0)
 				// Stamp the firing on a sentinel pending-validation slot so
 				// the AfterCall path below can fold it into responseMsg.
 				// Without this, streaming-only guardrails produce no
@@ -1842,7 +1847,7 @@ func (s *ProviderStage) runBeforeCallHooks(
 	}
 	// Guardrail skipped the provider call: no request, no tokens.
 	blocked := s.blockedMessage(hookReq, d)
-	s.recordGuardrailFiring(&blocked, d, guardrails.DirectionInput, time.Since(hookStart))
+	s.recordGuardrailFiring(&blocked, d, hooks.DirectionInput, time.Since(hookStart))
 	return blocked, true, nil
 }
 
@@ -1906,19 +1911,36 @@ func (s *ProviderStage) recordGuardrailFiring(
 	if s.emitter == nil {
 		return
 	}
-	score, _ := d.Metadata["score"].(float64)
 	data := &events.ValidationEventData{
 		ValidatorName: vType,
 		ValidatorType: vType,
 		Direction:     direction,
 		Duration:      duration,
 		Enforced:      d.Enforced,
-		Score:         score,
+		Score:         metadataScore(d.Metadata),
 	}
 	if !d.Allow {
 		data.Violations = []string{d.Reason}
 	}
 	s.emitter.GuardrailResult(data)
+}
+
+// metadataScore extracts a guardrail's eval score from decision metadata.
+//
+// The guardrail adapter stores evals.EvalResult.Score, which is a *float64, so
+// a plain float64 type assertion silently yields 0 and every event under-reports
+// the score. Accept both shapes: a hand-written hook may reasonably put a plain
+// float64 there.
+func metadataScore(metadata map[string]any) float64 {
+	switch v := metadata["score"].(type) {
+	case *float64:
+		if v != nil {
+			return *v
+		}
+	case float64:
+		return v
+	}
+	return 0
 }
 
 // blockedMessage builds the assistant turn substituted for a provider call that

--- a/runtime/pipeline/stage/stages_provider_hooks_test.go
+++ b/runtime/pipeline/stage/stages_provider_hooks_test.go
@@ -1198,22 +1198,13 @@ func collectValidationFailures(
 func TestProviderStage_BeforeCallHook_EnforcedRecordsFiring(t *testing.T) {
 	provider := &redactionRecordingProvider{Provider: mock.NewProvider("p", "m", false)}
 
-	bus := events.NewEventBus()
-	getEvents := collectValidationFailures(t, bus)
-	emitter := events.NewEmitter(bus, "run1", "sess1", "conv1")
-
 	reg := hooks.NewRegistry(hooks.WithProviderHook(&enforceBeforeCallHook{
 		reason:      "pii detected",
 		replacement: "I can't help with that.",
 		metadata:    map[string]any{"validator_type": "pii_leakage"},
 	}))
 
-	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
-		MaxTokens: 100,
-	}, emitter, reg)
-
-	elems, err := runProviderStage(t, stage, "my SSN is 123-45-6789")
-	require.NoError(t, err)
+	elems, getEvents := runStageCollectingValidations(t, provider, reg, "my SSN is 123-45-6789")
 	assert.Equal(t, 0, provider.callCount())
 
 	// Validation record lands on the canned assistant message.
@@ -1238,24 +1229,37 @@ func TestProviderStage_BeforeCallHook_EnforcedRecordsFiring(t *testing.T) {
 func TestProviderStage_AfterCallHook_EnforcedTaggedOutput(t *testing.T) {
 	provider := &redactionRecordingProvider{Provider: mock.NewProvider("p", "m", false)}
 
-	bus := events.NewEventBus()
-	getEvents := collectValidationFailures(t, bus)
-	emitter := events.NewEmitter(bus, "run1", "sess1", "conv1")
-
 	reg := hooks.NewRegistry(hooks.WithProviderHook(
 		&enforceAfterCallHook{replacement: "I can't help with that."},
 	))
+
+	_, getEvents := runStageCollectingValidations(t, provider, reg, "hi")
+
+	got := getEvents()
+	require.Len(t, got, 1)
+	assert.Equal(t, "output", got[0].Direction)
+}
+
+// runStageCollectingValidations runs one turn through a ProviderStage wired to
+// reg, and returns the emitted elements plus a getter for the validation.failed
+// events. The getter closes the bus to flush async delivery, so call it after
+// asserting on the elements.
+func runStageCollectingValidations(
+	t *testing.T, provider providers.Provider, reg *hooks.Registry, userText string,
+) ([]StreamElement, func() []*events.ValidationEventData) {
+	t.Helper()
+
+	bus := events.NewEventBus()
+	getEvents := collectValidationFailures(t, bus)
+	emitter := events.NewEmitter(bus, "run1", "sess1", "conv1")
 
 	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
 		MaxTokens: 100,
 	}, emitter, reg)
 
-	_, err := runProviderStage(t, stage, "hi")
+	elems, err := runProviderStage(t, stage, userText)
 	require.NoError(t, err)
-
-	got := getEvents()
-	require.Len(t, got, 1)
-	assert.Equal(t, "output", got[0].Direction)
+	return elems, getEvents
 }
 
 // TestProviderStage_InputGuardrail_EvaluatesOncePerToolLoop proves the real

--- a/runtime/pipeline/stage/streaming_finish_reason_test.go
+++ b/runtime/pipeline/stage/streaming_finish_reason_test.go
@@ -11,55 +11,56 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
-// TestStreamingRound_StampsProviderFinishReason pins that a streaming turn
-// carries the provider's finish reason on the assistant message.
+// TestStreamingRound_FinishReason pins what a streaming turn reports as its
+// finish reason.
 //
-// processStreamChunks already returns it — the value is used for the
+// processStreamChunks already returns the provider's reason — it feeds the
 // provider.call.completed event — but it was never stamped on responseMsg, so
-// the streaming path reported an empty FinishReason where the non-streaming
-// path reported the real one. That divergence became caller-visible once the
-// SDK started surfacing FinishReason (#1681): a streaming turn ending for
-// max_output_tokens or refusal looked identical to a normal completion.
-func TestStreamingRound_StampsProviderFinishReason(t *testing.T) {
-	// mock.NewProvider streams and emits FinishReason "stop" on its final chunk.
-	provider := mock.NewProvider("p", "m", false)
+// the streaming path reported nothing where the non-streaming path reported the
+// real value. That became caller-visible once the SDK started surfacing
+// FinishReason (#1681): a streaming turn ending for max_output_tokens or
+// refusal looked identical to a normal completion.
+//
+// The enforced case is the guard: stamping the provider's reason must not
+// overwrite the safety marker a firing guardrail sets afterwards.
+func TestStreamingRound_FinishReason(t *testing.T) {
+	tests := []struct {
+		name string
+		// registry is nil for the plain case; mock.NewProvider streams and
+		// emits FinishReason "stop" on its final chunk.
+		registry *hooks.Registry
+		want     string
+		reason   string
+	}{
+		{
+			name:   "stamps the provider's reason",
+			want:   "stop",
+			reason: "the streaming path must stamp the provider's finish reason, not drop it",
+		},
+		{
+			name: "enforcement wins over the provider's reason",
+			registry: hooks.NewRegistry(hooks.WithProviderHook(
+				&enforceAfterCallHook{replacement: "I can't help with that."},
+			)),
+			want:   types.FinishReasonSafety,
+			reason: "a firing guardrail must override the provider's finish reason",
+		},
+	}
 
-	stage := NewProviderStageWithEmitter(provider, nil, nil, &ProviderConfig{
-		MaxTokens: 100,
-	}, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stage := NewProviderStageWithHooks(
+				mock.NewProvider("p", "m", false), nil, nil,
+				&ProviderConfig{MaxTokens: 100}, nil, tt.registry,
+			)
 
-	elems, err := runProviderStage(t, stage, "hello")
-	require.NoError(t, err)
+			elems, err := runProviderStage(t, stage, "hello")
+			require.NoError(t, err)
 
-	msgs := assistantMessages(elems)
-	require.NotEmpty(t, msgs, "the streaming turn must emit an assistant message")
+			msgs := assistantMessages(elems)
+			require.NotEmpty(t, msgs, "the streaming turn must emit an assistant message")
 
-	last := msgs[len(msgs)-1]
-	assert.Equal(t, "stop", last.FinishReason,
-		"the streaming path must stamp the provider's finish reason, not drop it")
-}
-
-// TestStreamingRound_EnforcedFinishReasonWins guards the interaction with
-// guardrail enforcement: when an output guardrail enforces, the turn is marked
-// safety rather than the provider's own reason, and stamping the provider value
-// must not overwrite that.
-func TestStreamingRound_EnforcedFinishReasonWins(t *testing.T) {
-	provider := mock.NewProvider("p", "m", false)
-
-	reg := hooks.NewRegistry(hooks.WithProviderHook(
-		&enforceAfterCallHook{replacement: "I can't help with that."},
-	))
-	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
-		MaxTokens: 100,
-	}, nil, reg)
-
-	elems, err := runProviderStage(t, stage, "hello")
-	require.NoError(t, err)
-
-	msgs := assistantMessages(elems)
-	require.NotEmpty(t, msgs)
-
-	last := msgs[len(msgs)-1]
-	assert.Equal(t, types.FinishReasonSafety, last.FinishReason,
-		"enforcement must win over the provider's finish reason")
+			assert.Equal(t, tt.want, msgs[len(msgs)-1].FinishReason, tt.reason)
+		})
+	}
 }

--- a/runtime/pipeline/stage/streaming_finish_reason_test.go
+++ b/runtime/pipeline/stage/streaming_finish_reason_test.go
@@ -1,0 +1,65 @@
+package stage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestStreamingRound_StampsProviderFinishReason pins that a streaming turn
+// carries the provider's finish reason on the assistant message.
+//
+// processStreamChunks already returns it — the value is used for the
+// provider.call.completed event — but it was never stamped on responseMsg, so
+// the streaming path reported an empty FinishReason where the non-streaming
+// path reported the real one. That divergence became caller-visible once the
+// SDK started surfacing FinishReason (#1681): a streaming turn ending for
+// max_output_tokens or refusal looked identical to a normal completion.
+func TestStreamingRound_StampsProviderFinishReason(t *testing.T) {
+	// mock.NewProvider streams and emits FinishReason "stop" on its final chunk.
+	provider := mock.NewProvider("p", "m", false)
+
+	stage := NewProviderStageWithEmitter(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil)
+
+	elems, err := runProviderStage(t, stage, "hello")
+	require.NoError(t, err)
+
+	msgs := assistantMessages(elems)
+	require.NotEmpty(t, msgs, "the streaming turn must emit an assistant message")
+
+	last := msgs[len(msgs)-1]
+	assert.Equal(t, "stop", last.FinishReason,
+		"the streaming path must stamp the provider's finish reason, not drop it")
+}
+
+// TestStreamingRound_EnforcedFinishReasonWins guards the interaction with
+// guardrail enforcement: when an output guardrail enforces, the turn is marked
+// safety rather than the provider's own reason, and stamping the provider value
+// must not overwrite that.
+func TestStreamingRound_EnforcedFinishReasonWins(t *testing.T) {
+	provider := mock.NewProvider("p", "m", false)
+
+	reg := hooks.NewRegistry(hooks.WithProviderHook(
+		&enforceAfterCallHook{replacement: "I can't help with that."},
+	))
+	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, reg)
+
+	elems, err := runProviderStage(t, stage, "hello")
+	require.NoError(t, err)
+
+	msgs := assistantMessages(elems)
+	require.NotEmpty(t, msgs)
+
+	last := msgs[len(msgs)-1]
+	assert.Equal(t, types.FinishReasonSafety, last.FinishReason,
+		"enforcement must win over the provider's finish reason")
+}


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Code refactoring (no functional changes)
- [x] 🧪 Adding or improving tests

**Component(s) Affected**
- [x] Runtime
- [x] Documentation (generated reference only)

## Description

**What does this PR do?**

Three related gaps in how guardrail activity is reported, all found reviewing #1678 and #1683. Two are real bugs that made observability lie; the third removes a dependency edge two reviewers flagged.

**Why is this change needed?**

#1678 and #1683 made guardrails work correctly. This makes them *reportable* correctly — a guardrail that fires but misreports what it did is only marginally better than one that does not fire.

## Changes Made

### 1. The guardrail event's `Score` was always zero

`recordGuardrailFiring` read `Metadata["score"]` with a `float64` type assertion, but the adapter stores `evals.EvalResult.Score`, which is a **`*float64`**. The assertion always failed, so every validation event reported `Score: 0` — while `runtime-events.md` advertises "evaluation score (0.0–1.0)".

Nothing asserted `Score` anywhere in the suite, which is exactly why it survived: the same untested-therefore-broken shape as the input-guardrail gap in #1679.

`metadataScore` now accepts both the pointer the adapter stores and a plain `float64`, because a hand-written `ProviderHook` would naturally put the latter in its decision metadata — reporting 0 for those would relocate the bug rather than fix it.

### 2. The streaming path dropped the provider's `FinishReason`

`processStreamChunks` already returns it (it feeds `provider.call.completed`), but it was never stamped on `responseMsg`. So a streaming turn reported **no** finish reason where the non-streaming path reported the real one.

That became caller-visible the moment #1681 started surfacing `FinishReason` through `sdk.Response`: on the streaming path, `max_output_tokens` and `refusal` were indistinguishable from a normal completion. Guardrail enforcement still overwrites it with `FinishReasonSafety`, pinned by its own test.

### 3. The pipeline stage depended on a concrete hook implementation

`stage` imported `runtime/hooks/guardrails` **solely** for the `Direction*` string constants, while its own use of them is about which of its two call phases fired — not about guardrails. The constants move to `runtime/hooks`, which both the adapter and the stage already import; `hooks/guardrails` keeps aliases so existing callers (including cross-repo ones) are unaffected.

The `stage → hooks/guardrails` import edge is now gone entirely.

## Testing

```bash
go test ./runtime/... ./sdk/... ./pkg/... -count=1 -race
golangci-lint run --new-from-rev=9ee0c80a ./runtime/...
```

- [x] **11,710 passing, 0 failing**, 117 packages with `-race`
- [x] New-code lint: 0 issues
- [x] No regressions

Each fix was driven by a failing test first, with the RED output verified:

- Score: `"0" is not greater than "0"` — and the test drives the **real guardrail adapter**, because a test hook putting a plain `float64` in metadata could not reproduce a pointer-type mismatch.
- FinishReason: expected `"stop"`, got `""`. The companion test asserting that enforcement still wins passed before and after, so the fix is confined to the non-enforced path.

## Documentation

Only the generated `runtime/reference/hooks.md`, regenerated for the newly exported constants. No prose changes were needed — `runtime-events.md` already documented `Score` as "0.0–1.0", which was a false claim before this PR and is now accurate.

## Reviewer Notes

**Areas of Focus**

1. **`metadataScore` accepting two shapes.** Deliberate, for the reason above. If you would rather force a single canonical shape, the alternative is changing the adapter to store a plain `float64` — but that would silently break any external hook already storing a pointer.
2. **The `Direction*` move.** `hooks/guardrails` retains aliases, so this should be invisible to callers. Worth confirming the aliases are genuinely equivalent and that no import cycle was introduced (`guardrails → hooks` already existed; nothing new points the other way).
3. **`FinishReason` on streaming.** Confirm no consumer relied on it being empty there. Nothing in-repo does, and the full suite passes.

---

## Checklist

- [x] I have signed my commits with `git commit -s`
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
