### PR TITLE
docs(examples): use banned_words for the input guardrail now that it works

### DIFF
--- a/sdk/examples/hooks/README.md
+++ b/sdk/examples/hooks/README.md
@@ -45,9 +45,8 @@ never called:
 ```go
 conv, err := sdk.Open("./hooks.pack.json", "chat",
     sdk.WithGuardrail(
-        guardrails.Input("regex", map[string]any{
-            "pattern":      `(?i)\bwire transfer\b`,
-            "expect_match": false,
+        guardrails.Input("banned_words", map[string]any{
+            "words": []any{"wire transfer"},
         }, guardrails.WithMessage("I can't help with transfers.")),
     ),
 )
@@ -75,14 +74,12 @@ There's a matching `guardrails.OutputFunc` for the response side, working
 against `hooks.OutputRequest` (`Content`, `Message` — mutate it in place to
 rewrite, `Round`).
 
-**A gotcha worth knowing:** not every built-in eval type works as an input
-guardrail. `banned_words` (aliased to `content_excludes`) and `contains_any`
-only scan assistant-role messages — as an input guardrail they compile,
-register, and silently never fire, because the trailing message they'd need
-to check is the user's. That's why this example uses `regex` (with
-`expect_match: false`) instead of `banned_words` for its input guardrail.
-Content-agnostic eval types — `regex`, `length`, `pii_leakage`, `contains`,
-`json_valid` — all read the input correctly.
+**Direction is the only thing that changes.** A content check evaluates
+whichever side `direction` selects, so the same type works either way —
+`guardrails.Input("banned_words", …)` gates the user's message and
+`guardrails.Output("banned_words", …)` gates the reply. As an output
+guardrail a check judges that response alone; an earlier turn does not
+affect the verdict.
 
 ### Pack-declared validators — the same gating, zero Go code
 

--- a/sdk/examples/hooks/main_interactive.go
+++ b/sdk/examples/hooks/main_interactive.go
@@ -175,18 +175,14 @@ func main() {
 		sdk.WithGuardrail(
 			// --- Input guardrails: gate the user's message, before any LLM call ---
 
-			// Eval-backed: "regex" with expect_match:false fails (blocks) when
-			// the pattern IS found — a "banned phrase" check. This example
-			// deliberately does NOT use "banned_words" here: that eval type
-			// (content_excludes) and "contains_any" only ever scan
-			// assistant-role messages, so as an input guardrail they'd compile
-			// and register but silently never fire against the user's
-			// message. Content-agnostic eval types — regex, length,
-			// pii_leakage, contains, json_valid — all read the input
-			// correctly instead.
-			guardrails.Input("regex", map[string]any{
-				"pattern":      `(?i)\bwire transfer\b`,
-				"expect_match": false,
+			// Eval-backed, gating the user's message: a hit means the provider
+			// is never called at all, so a blocked turn costs nothing. Send
+			// returns normally with WithMessage's text — see Example 2.
+			//
+			// The same check type works in either direction; `direction` (set
+			// here by the Input constructor) decides which side is examined.
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
 			}, guardrails.WithMessage("I can't help with transfers.")),
 
 			// --- Output guardrails: gate the assistant's response, after the LLM call ---

--- a/sdk/examples/hooks/smoke_test.go
+++ b/sdk/examples/hooks/smoke_test.go
@@ -37,9 +37,8 @@ func TestInputGuardrailBlocksGracefully(t *testing.T) {
 		sdk.WithProvider(provider),
 		sdk.WithSkipSchemaValidation(),
 		sdk.WithGuardrail(
-			guardrails.Input("regex", map[string]any{
-				"pattern":      `(?i)\bwire transfer\b`,
-				"expect_match": false,
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
 			}, guardrails.WithMessage("I can't help with transfers.")),
 		),
 	)
@@ -53,13 +52,36 @@ func TestInputGuardrailBlocksGracefully(t *testing.T) {
 	require.NotEmpty(t, resp.Validations(), "blocked turn must carry a validation record")
 	found := false
 	for _, v := range resp.Validations() {
-		if v.ValidatorType == "regex" {
+		if v.ValidatorType == "banned_words" {
 			require.False(t, v.Passed)
 			require.Equal(t, "input", v.Details["direction"])
 			found = true
 		}
 	}
-	require.True(t, found, "expected a regex validation result")
+	require.True(t, found, "expected a banned_words validation result")
+}
+
+// TestInputGuardrailAllowsCleanInput is the discriminating half: the same
+// guardrail must let an unrelated message through to the provider. Without it,
+// a guardrail that blocked everything would satisfy the test above.
+func TestInputGuardrailAllowsCleanInput(t *testing.T) {
+	provider := mock.NewProvider("mock", "mock-model", false)
+	conv, err := sdk.Open("hooks.pack.json", "chat",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+		sdk.WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}, guardrails.WithMessage("I can't help with transfers.")),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp, err := conv.Send(context.Background(), "What is the capital of France?")
+	require.NoError(t, err)
+	require.NotEqual(t, "I can't help with transfers.", resp.Text(),
+		"a clean message must reach the provider")
 }
 
 // TestPackDeclaredInputValidatorBlocksGracefully pins the pack-declared path:


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [x] 📝 Documentation update
- [x] 🧪 Adding or improving tests

**Component(s) Affected**
- [x] Examples
- [x] Documentation

## Description

The hooks example warned that `banned_words` and `contains_any` "compile, register, and silently never fire" as input guardrails, and used `regex` with `expect_match: false` as a workaround.

That was accurate when written. **#1679 fixed it** — content checks now evaluate whichever side `direction` selects. So the flagship guardrail example was documenting a bug we had already closed, and steering readers away from the type they would naturally reach for.

## Changes Made

- The Go example and the matching README snippet now use `guardrails.Input("banned_words", ...)`, which is both the natural demonstration and a live exercise of the #1679 fix.
- The "gotcha" paragraph is replaced with what actually governs behavior: `direction` selects the side, the same check type works either way, and an output guardrail judges only that response.
- The pack-declared validator keeps `regex` — it is demonstrating the pack path with a routing-number pattern, where a regex is genuinely the right tool.

## Testing

```bash
go test ./sdk/... -count=1     # 0 failures
go vet ./sdk/examples/hooks
go run .                        # exits cleanly: no API key configured
```

The smoke test moves to `banned_words` and gains the discriminating case — a clean message must still reach the provider — so a guardrail that blocked everything would fail it. 5/5 example tests pass, which is what empirically confirms the old comment was false.

The example was also executed directly: without `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/`GOOGLE_API_KEY` it exits with a clear provider-detection message rather than crashing. A full end-to-end run against a live model still needs a key and has not been done here.

## Reviewer Notes

Worth confirming the README no longer contradicts itself: the prose now says direction is the only difference, and both code snippets agree with that.
