### PR TITLE
fix(guardrails): stop the streaming path leaking banned content

### DIFF
--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -198,10 +198,15 @@ func (a *GuardrailHookAdapter) OnChunk(
 	}
 
 	if result.Score == nil || *result.Score < 1.0 {
-		// Truncate chunk content for length validators
-		if maxLen := extractMaxLen(params); maxLen > 0 && len(chunk.Content) > maxLen {
-			chunk.Content = chunk.Content[:maxLen]
-		}
+		// Substitute the enforced content, exactly as the non-streaming path
+		// does. Previously this only truncated for length validators, so a
+		// content blocker left the offending text in place and the caller
+		// received the very pattern it was configured to block (#1697).
+		//
+		// Deltas already emitted to a consumer cannot be recalled — that is
+		// inherent to streaming — but the accumulated content the stage keeps,
+		// which becomes the assistant message, is corrected here.
+		chunk.Content = a.enforcedContent(chunk.Content, params)
 		return a.enforced(result)
 	}
 
@@ -210,20 +215,34 @@ func (a *GuardrailHookAdapter) OnChunk(
 
 // enforce modifies the message content based on the validator type.
 func (a *GuardrailHookAdapter) enforce(msg *types.Message, params map[string]any) {
-	if maxLen := extractMaxLen(params); maxLen > 0 && len(msg.Content) > maxLen {
+	msg.Content = a.enforcedContent(msg.Content, params)
+}
+
+// enforcedContent returns the content that should replace the offending text.
+//
+// Single-sourced so the streaming and non-streaming paths cannot disagree about
+// what enforcement means. They legitimately disagree about *detection* — the
+// streaming check matches substrings so a pattern split across chunks is not
+// missed, while the final check honors match_mode — but once either has fired,
+// the substituted content must be the same.
+//
+// Getting that wrong leaked the banned text: a chunk check fired on a substring,
+// the stream stopped, and the final check then judged the same content clean
+// under word_boundary mode and left it in place (#1697).
+func (a *GuardrailHookAdapter) enforcedContent(content string, params map[string]any) string {
+	if maxLen := extractMaxLen(params); maxLen > 0 && len(content) > maxLen {
 		logger.Info("Guardrail enforced: truncating content",
-			"type", a.evalType, "original_length", len(msg.Content), "max_length", maxLen)
-		msg.Content = msg.Content[:maxLen]
-		return
+			"type", a.evalType, "original_length", len(content), "max_length", maxLen)
+		return content[:maxLen]
 	}
 
-	// Content blocker — replace with user-facing message
+	// Content blocker — replace with the user-facing message.
 	blockedMsg := a.message
 	if blockedMsg == "" {
 		blockedMsg = prompt.DefaultBlockedMessage
 	}
 	logger.Info("Guardrail enforced: content blocked", "type", a.evalType)
-	msg.Content = blockedMsg
+	return blockedMsg
 }
 
 // enforced builds an Enforced decision from an EvalResult.

--- a/sdk/guardrail_e2e_test.go
+++ b/sdk/guardrail_e2e_test.go
@@ -100,3 +100,71 @@ func TestGuardrail_InputBlockRecordsValidation(t *testing.T) {
 	assert.False(t, validations[0].Passed)
 	assert.Equal(t, "input", validations[0].Details["direction"])
 }
+
+// TestGuardrail_StreamingOutputBlockDoesNotLeakBannedContent pins that an
+// output guardrail replaces the response on the STREAMING path, not just the
+// unary one.
+//
+// GuardrailHookAdapter.OnChunk only rewrote content for length validators; a
+// content blocker modified nothing yet still returned Enforced, and the stage
+// took that text verbatim. The caller therefore received the model's words —
+// including the very pattern the guardrail was configured to block — and
+// WithMessage was silently ignored (#1697).
+//
+// mock.NewProvider advertises streaming, so Send takes the streaming path here,
+// which is what most real providers do too. Asserting on the absence of the
+// banned word is the point: a fix that returned some other placeholder while
+// still leaking the pattern would not satisfy this.
+func TestGuardrail_StreamingOutputBlockDoesNotLeakBannedContent(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			// "respons" matches the mock's canned reply ("Mock response from
+			// mock model mock-model") under the STREAMING check, which uses
+			// substring mode deliberately to avoid false negatives on partial
+			// words — but not under the final check, which uses banned_words'
+			// default word_boundary mode. That divergence is what let the
+			// content survive: the chunk check aborted the stream, then the
+			// final check judged the same text clean and never replaced it.
+			guardrails.Output("banned_words", map[string]any{
+				"words": []any{"respons"},
+			}, guardrails.WithMessage("I can't share that.")),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp, err := conv.Send(context.Background(), "hello")
+	require.NoError(t, err, "an Enforced output guardrail must not surface as an error")
+
+	assert.NotContains(t, resp.Text(), "respons",
+		"the banned pattern must not reach the caller")
+	assert.Equal(t, "I can't share that.", resp.Text(),
+		"the configured guardrail message must replace the model text")
+}
+
+// TestGuardrail_StreamingOutputAllowsCleanResponse is the discriminating half:
+// a guardrail whose pattern does not appear must leave the model's reply alone,
+// so a fix that always substituted the message would fail here.
+func TestGuardrail_StreamingOutputAllowsCleanResponse(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Output("banned_words", map[string]any{
+				"words": []any{"nonexistent-phrase-xyzzy"},
+			}, guardrails.WithMessage("I can't share that.")),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp, err := conv.Send(context.Background(), "hello")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, "I can't share that.", resp.Text(),
+		"a clean response must not be replaced")
+	assert.Contains(t, resp.Text(), "Mock response",
+		"the model's reply must pass through untouched")
+}


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Adding or improving tests

**Component(s) Affected**
- [x] Runtime

## Description

An output guardrail on the **streaming** path returned the model text — including the pattern it was configured to block — instead of its configured message. Fail-open on a safety control, on the path most providers take.

Found by running `sdk/examples/hooks` against a real provider. A `banned_words` guardrail on `"password"` returned:

```
Response text: Its important to avoid using default passwords
```

Closes #1697.

## Root cause

Two checks disagreed about the same text:

- `ContentExcludesHandler.EvalPartial` matches **substrings**, deliberately — a pattern can span two chunks, so substring matching avoids false negatives mid-stream.
- The final `Eval` honors `match_mode`, and `banned_words` defaults to **`word_boundary`** (`runtime/evals/normalize.go`).

`\bpassword\b` does not match `passwords`. So the chunk check fired on the substring and stopped the stream; `AfterCall` then judged the identical content clean and left it in place. Compounding it, `OnChunk` only rewrote content for length validators, so a content blocker modified nothing while still returning `Enforced`.

My original issue text blamed only the second half. That was incomplete, and a fix based on it alone would have looked right and done nothing — corrected in a comment on the issue.

## The fix

Single-source the substitution in `enforcedContent`, used by both `enforce` (non-streaming) and `OnChunk` (streaming).

The two paths may legitimately disagree about **detection** — that is a deliberate design choice and stays. What they must not disagree about is the **content substituted** once either has fired.

Deltas already emitted to a consumer cannot be recalled; that is inherent to streaming and is noted in the code. The accumulated content that becomes the assistant message is now corrected.

## Testing

```bash
go test ./runtime/... ./sdk/... ./pkg/... -count=1 -race   # 0 failures
golangci-lint run --new-from-rev=8d374a85 ./runtime/... ./sdk/...   # 0 issues
```

Pinned end to end through `sdk.Open` + `Send`, per the issues own acceptance criteria — the adapter and the stage each behaved correctly in isolation, which is precisely why this survived four reviews and ~11,700 tests.

**A note on the reproduction, because it is easy to get wrong:** the test uses a pattern matching under substring but *not* word_boundary, which is the actual divergence. My first attempt used a word matching under both modes and went **green against the unfixed code**. The discriminating negative case — a clean response must pass through untouched — is included so a fix that always substituted would fail.

Verified live against a real provider with the same example that exposed it:

```
before: Response text: Its important to avoid using default passwords
after:  Response text: I cant share credentials like that.
```

## Reviewer Notes

1. **Detection divergence is intentional and retained.** If you would rather align the match modes too, that is a separate call with its own tradeoff: word_boundary mid-stream risks missing a pattern split across chunks.
2. `enforcedContent` is shared by both callers — worth confirming the length-validator branch still truncates identically for the non-streaming path.
